### PR TITLE
telemetry: render threads as a collapsible GPU → type tree in Quent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -614,6 +614,7 @@ set(TEST_SOURCES
     test/cpp/scan/test_parquet_schema_mapping.cpp
     test/cpp/sirius_extension/test_sirius_read_parquet_cardinality.cpp
     test/cpp/sql/test_sirius_sql_rewrite.cpp
+    test/cpp/telemetry/test_telemetry_context.cpp
     test/cpp/unittest.cpp
     test/cpp/utils/sirius_test_env.cpp
     test/cpp/utils/utils.cpp)

--- a/docs/super-sirius/quent-telemetry.md
+++ b/docs/super-sirius/quent-telemetry.md
@@ -108,6 +108,16 @@ timeline.
 **Default view** — the query plan on the left and the per-resource execution timeline
 (executor threads, task-manager loops, task queues) on the right.
 
+Resources are grouped into a collapsible tree by GPU device: each `gpu-N` group (declared once per
+GPU at engine startup) contains per-thread-type buckets (`executor_thread`,
+`task_manager_loop_thread`) plus that executor's task queue, and a `shared` group under the engine
+holds threads with no single GPU (e.g. the task-scheduler thread). The tree shape is entirely
+data-driven via each resource's `parent_group_id`; to inspect it offline run:
+
+```bash
+pixi run bash -c "cd rust && cargo run -p sirius-telemetry-analyzer --example print_resource_tree -- <output_dir>/<session_uuid>"
+```
+
 ![Quent standard view](quent-screenshots/standard.png)
 
 **Operator timeline** — selecting an operator or pipeline highlights it in both the plan and the

--- a/rust/crates/telemetry/analyzer/examples/print_resource_tree.rs
+++ b/rust/crates/telemetry/analyzer/examples/print_resource_tree.rs
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Print the resource-group tree of a Sirius telemetry session directory —
+//! the same tree the Quent viewer renders as collapsible rows.
+//!
+//! Usage:
+//!   cargo run -p sirius-telemetry-analyzer --example print_resource_tree -- \
+//!       <telemetry_output_dir>/<session_uuid>
+
+use instrumentation_model::Sirius;
+use quent_analyzer::resource::collection::ResourceCollection;
+use quent_analyzer::resource::tree::ResourceTreeNode;
+use quent_analyzer::{Entity, Model};
+use quent_query_engine_analyzer::ui::UiAnalyzer;
+use sirius_telemetry_analyzer::SiriusUiAnalyzer;
+use uuid::Uuid;
+
+fn print_node(
+    model: &sirius_telemetry_analyzer::model::SiriusModel,
+    node: &ResourceTreeNode,
+    depth: usize,
+) {
+    let indent = "  ".repeat(depth);
+    match node {
+        ResourceTreeNode::ResourceGroup(id, children) => {
+            let group = model.resource_group(*id).expect("group in tree");
+            println!(
+                "{indent}[{}] {} ({id})",
+                group.type_name(),
+                group.instance_name()
+            );
+            for child in children {
+                print_node(model, child, depth + 1);
+            }
+        }
+        ResourceTreeNode::Resource(id) => {
+            let resource = model.resource(*id).expect("resource in tree");
+            println!(
+                "{indent}<{}> {} ({id})",
+                resource.type_name(),
+                resource.instance_name()
+            );
+        }
+    }
+}
+
+fn main() {
+    let dir = std::path::PathBuf::from(
+        std::env::args()
+            .nth(1)
+            .expect("usage: print_resource_tree <session_dir>"),
+    );
+
+    // The engine id is the `id` of the first engine event in the session.
+    let engine_file = std::fs::read_dir(dir.join("engine"))
+        .expect("session dir has an engine/ subdirectory")
+        .next()
+        .expect("engine/ contains an event file")
+        .expect("readable dir entry")
+        .path();
+    let first_line = std::fs::read_to_string(&engine_file)
+        .expect("readable engine event file")
+        .lines()
+        .next()
+        .expect("non-empty engine event file")
+        .to_owned();
+    let id_start = first_line.find("\"id\":\"").expect("engine event has id") + 6;
+    let engine_id: Uuid = first_line[id_start..id_start + 36]
+        .parse()
+        .expect("valid engine uuid");
+
+    let events = Sirius::import_events(&dir).expect("importable session dir");
+    let analyzer = SiriusUiAnalyzer::try_new(engine_id, events).expect("analyzable events");
+    let model = &analyzer.model;
+
+    let root_id = model.root().expect("model has a root group").id();
+    let tree = ResourceTreeNode::try_new(model, root_id).expect("resource tree");
+    print_node(model, &tree, 0);
+}

--- a/rust/crates/telemetry/analyzer/src/model.rs
+++ b/rust/crates/telemetry/analyzer/src/model.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use instrumentation_model::{SiriusEvent, task};
+use instrumentation_model::{SiriusEvent, gpu_device, task, thread_group};
 use quent_time::TimeUnixNanoSec;
 use rustc_hash::FxHashMap as HashMap;
 
@@ -39,6 +39,8 @@ use crate::{
     view::SiriusModelQueryView,
 };
 
+const GPU_DEVICE_GROUP_TYPE_NAME: &str = "gpu_device";
+const THREAD_GROUP_TYPE_NAME: &str = "thread_group";
 const TASK_QUEUE_TYPE_NAME: &str = "task_queue";
 const TASK_MANAGER_LOOP_THREAD_TYPE_NAME: &str = "task_manager_loop_thread";
 const EXECUTOR_THREAD_TYPE_NAME: &str = "executor_thread";
@@ -314,6 +316,26 @@ impl SiriusModelBuilder {
             SiriusEvent::Port(e) => {
                 self.query_engine
                     .try_push(Event::new(id, timestamp, QueryEngineEvent::Port(e)))
+            }
+            SiriusEvent::GpuDevice(e) => {
+                let gpu_device::GpuDeviceEvent::Declaration(d) = e;
+                self.arbitrary_resources.push_group_raw(
+                    id,
+                    GPU_DEVICE_GROUP_TYPE_NAME,
+                    &d.instance_name,
+                    Some(d.parent_group_id),
+                );
+                Ok(())
+            }
+            SiriusEvent::ThreadGroup(e) => {
+                let thread_group::ThreadGroupEvent::Declaration(d) = e;
+                self.arbitrary_resources.push_group_raw(
+                    id,
+                    THREAD_GROUP_TYPE_NAME,
+                    &d.instance_name,
+                    Some(d.parent_group_id),
+                );
+                Ok(())
             }
             SiriusEvent::TaskQueue(e) => self.push_task_queue(id, timestamp, e),
             SiriusEvent::TaskManagerLoopThread(e) => {

--- a/rust/crates/telemetry/model/src/gpu_device.rs
+++ b/rust/crates/telemetry/model/src/gpu_device.rs
@@ -1,0 +1,30 @@
+//! GpuDevice entity: a per-GPU resource group nested under the engine.
+//!
+//! One instance is declared per GPU at engine startup (instance names
+//! `gpu-0`, `gpu-1`, ...). Per-thread-type [`crate::thread_group`] buckets and
+//! device-scoped resources (task queues) are parented under it so the viewer
+//! renders an `engine -> gpu-N -> thread type -> threads` collapsible tree.
+
+use quent_model::serde::{Deserialize, Serialize};
+use quent_model::{Attributes, entity};
+use uuid::Uuid;
+
+#[derive(Debug, Attributes, Serialize, Deserialize)]
+#[serde(crate = "quent_model::serde")]
+pub struct Declaration {
+    /// Human-readable group label shown in the viewer, e.g. "gpu-0".
+    pub instance_name: String,
+    /// The id of the resource group this device belongs to (the engine).
+    pub parent_group_id: Uuid,
+    /// CUDA device ordinal of this GPU.
+    pub ordinal: u32,
+}
+
+entity! {
+    GpuDevice: ResourceGroup {
+        declaration: declaration,
+        events: {
+            declaration: Declaration,
+        },
+    }
+}

--- a/rust/crates/telemetry/model/src/lib.rs
+++ b/rust/crates/telemetry/model/src/lib.rs
@@ -1,6 +1,8 @@
 use quent_model::{instrumentation, model};
 
+pub mod gpu_device;
 pub mod task;
+pub mod thread_group;
 
 model! {
     name: Sirius,
@@ -12,6 +14,8 @@ model! {
         quent_query_engine_model::plan::Plan,
         quent_query_engine_model::operator::Operator,
         quent_query_engine_model::port::Port,
+        gpu_device::GpuDevice,
+        thread_group::ThreadGroup,
         task::Task,
         task::TaskQueue,
         task::TaskManagerLoopThread,

--- a/rust/crates/telemetry/model/src/thread_group.rs
+++ b/rust/crates/telemetry/model/src/thread_group.rs
@@ -1,0 +1,29 @@
+//! ThreadGroup entity: a generic resource group for bucketing threads.
+//!
+//! Used for the per-(device, thread type) buckets under each
+//! [`crate::gpu_device`] group (instance names `executor_thread`,
+//! `task_manager_loop_thread`) and for the engine-level `shared` group that
+//! holds threads with no single GPU (e.g. the task scheduler thread).
+
+use quent_model::serde::{Deserialize, Serialize};
+use quent_model::{Attributes, entity};
+use uuid::Uuid;
+
+#[derive(Debug, Attributes, Serialize, Deserialize)]
+#[serde(crate = "quent_model::serde")]
+pub struct Declaration {
+    /// Human-readable group label shown in the viewer, e.g. "executor_thread".
+    pub instance_name: String,
+    /// The id of the resource group this bucket is nested under
+    /// (a gpu_device group or the engine).
+    pub parent_group_id: Uuid,
+}
+
+entity! {
+    ThreadGroup: ResourceGroup {
+        declaration: declaration,
+        events: {
+            declaration: Declaration,
+        },
+    }
+}

--- a/src/include/parallel/task_executor.hpp
+++ b/src/include/parallel/task_executor.hpp
@@ -25,6 +25,7 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
 #include <thread>
 
 namespace sirius {
@@ -50,8 +51,13 @@ namespace parallel {
  */
 class itask_executor {
  public:
+  /**
+   * @param device_id GPU this executor is bound to, if any. Used to parent the
+   * task-queue telemetry under that GPU's device group instead of the engine.
+   */
   explicit itask_executor(exec::thread_pool_config config,
-                          std::shared_ptr<const telemetry::telemetry_context> telemetry_context);
+                          std::shared_ptr<const telemetry::telemetry_context> telemetry_context,
+                          std::optional<int> device_id = std::nullopt);
 
   virtual ~itask_executor();
 

--- a/src/include/telemetry/telemetry_context.hpp
+++ b/src/include/telemetry/telemetry_context.hpp
@@ -21,17 +21,21 @@
 #include "telemetry-bridge/gen/context.rs.h"
 #include "telemetry-bridge/gen/engine.rs.h"
 #include "telemetry-bridge/gen/executor_thread.rs.h"
+#include "telemetry-bridge/gen/gpu_device.rs.h"
 #include "telemetry-bridge/gen/query_group.rs.h"
 #include "telemetry-bridge/gen/task_manager_loop_thread.rs.h"
 #include "telemetry-bridge/gen/task_queue.rs.h"
+#include "telemetry-bridge/gen/thread_group.rs.h"
 #include "telemetry-bridge/gen/uuid.rs.h"
 #include "telemetry-bridge/gen/worker.rs.h"
 
 #include <cstdint>
 #include <limits>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace sirius::pipeline {
 class sirius_pipeline;
@@ -46,8 +50,10 @@ namespace sirius::telemetry {
 /// Owns the top-level telemetry states for a single SiriusContext.
 class telemetry_context {
  public:
+  /// `gpu_device_ids` declares one per-GPU resource group (plus per-thread-type
+  /// child buckets) under the engine, so thread telemetry can nest per device.
   [[nodiscard]] static std::shared_ptr<const telemetry_context> create(
-    const sirius::telemetry_config& config);
+    const sirius::telemetry_config& config, const std::vector<int>& gpu_device_ids = {});
 
   ~telemetry_context();
 
@@ -61,14 +67,33 @@ class telemetry_context {
   [[nodiscard]] const uuid::UUID& worker_id() const { return worker_uuid_; }
   /// The single, session-scoped query group that every query in this context is reported under.
   [[nodiscard]] const uuid::UUID& query_group_id() const { return query_group_uuid_; }
+  /// The `gpu-N` device group for `device_id`; falls back to the engine group
+  /// (with a warning) when the device was not declared at creation time.
+  [[nodiscard]] const uuid::UUID& gpu_device_group_id(int device_id) const;
+  /// The `executor_thread` bucket group under `gpu-N` (engine fallback as above).
+  [[nodiscard]] const uuid::UUID& executor_thread_group_id(int device_id) const;
+  /// The `task_manager_loop_thread` bucket group under `gpu-N` (engine fallback as above).
+  [[nodiscard]] const uuid::UUID& manager_thread_group_id(int device_id) const;
+  /// The `shared` group under the engine, for threads with no single GPU.
+  [[nodiscard]] const uuid::UUID& shared_group_id() const { return shared_group_uuid_; }
   [[nodiscard]] const quent::Context& context() const { return *context_; }
 
  private:
-  explicit telemetry_context(const sirius::telemetry_config& config);
+  telemetry_context(const sirius::telemetry_config& config, const std::vector<int>& gpu_device_ids);
+
+  /// Telemetry group ids for one GPU: the `gpu-N` group and its per-thread-type
+  /// child buckets.
+  struct gpu_device_group_ids {
+    uuid::UUID device;
+    uuid::UUID executor_threads;
+    uuid::UUID manager_threads;
+  };
 
   uuid::UUID engine_uuid_;
   uuid::UUID worker_uuid_;
   uuid::UUID query_group_uuid_;
+  uuid::UUID shared_group_uuid_;
+  std::map<int, gpu_device_group_ids> gpu_group_ids_;
   rust::Box<quent::Context> context_;
   rust::Box<quent::engine::EngineObserver> engine_observer_;
   rust::Box<quent::worker::WorkerObserver> worker_observer_;
@@ -90,11 +115,13 @@ void emit_plan_telemetry(
   query_telemetry_info telemetry_info);
 
 struct ExecutorThreadHandleWrapper {
-  ExecutorThreadHandleWrapper(const telemetry_context& context, const std::string& thread_name)
+  ExecutorThreadHandleWrapper(const telemetry_context& context,
+                              const std::string& thread_name,
+                              const uuid::UUID& parent_group_id)
     : handle(quent::executor_thread::create(context.context(),
                                             {
                                               .instance_name   = thread_name,
-                                              .parent_group_id = context.engine_id(),
+                                              .parent_group_id = parent_group_id,
                                             }))
   {
     handle->operating();
@@ -116,11 +143,12 @@ struct ExecutorThreadHandleWrapper {
 
 struct TaskManagerLoopThreadHandleWrapper {
   TaskManagerLoopThreadHandleWrapper(const telemetry_context& context,
-                                     const std::string& thread_name)
+                                     const std::string& thread_name,
+                                     const uuid::UUID& parent_group_id)
     : handle(quent::task_manager_loop_thread::create(context.context(),
                                                      {
                                                        .instance_name   = thread_name,
-                                                       .parent_group_id = context.engine_id(),
+                                                       .parent_group_id = parent_group_id,
                                                      }))
   {
     handle->operating();
@@ -141,11 +169,13 @@ struct TaskManagerLoopThreadHandleWrapper {
 };
 
 struct TaskQueueHandleWrapper {
-  TaskQueueHandleWrapper(const telemetry_context& context, const std::string& queue_name)
+  TaskQueueHandleWrapper(const telemetry_context& context,
+                         const std::string& queue_name,
+                         const uuid::UUID& parent_group_id)
     : handle(quent::task_queue::create(context.context(),
                                        {
                                          .instance_name   = queue_name,
-                                         .parent_group_id = context.engine_id(),
+                                         .parent_group_id = parent_group_id,
                                        }))
   {
     handle->operating({
@@ -173,12 +203,13 @@ inline thread_local std::optional<ExecutorThreadHandleWrapper> executor_thread_t
 
 // Initialize the thread local ExecutorThreadHandleWrapper for this worker thread.
 inline void thread_local_executor_thread_telemtry_init(const telemetry_context& context,
-                                                       const std::string& thread_name)
+                                                       const std::string& thread_name,
+                                                       const uuid::UUID& parent_group_id)
 {
   if (executor_thread_telemetry_handle.has_value()) {
     SIRIUS_LOG_WARN("ExecutorThreadHandleWrapper was already initialized; overriding.");
   }
-  executor_thread_telemetry_handle.emplace(context, thread_name);
+  executor_thread_telemetry_handle.emplace(context, thread_name, parent_group_id);
 }
 
 }  // namespace sirius::telemetry

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -30,11 +30,15 @@ namespace parallel {
 
 itask_executor::itask_executor(
   exec::thread_pool_config config,
-  std::shared_ptr<const telemetry::telemetry_context> telemetry_context)
+  std::shared_ptr<const telemetry::telemetry_context> telemetry_context,
+  std::optional<int> device_id)
   : _config(std::move(config)),
     _telemetry_context(std::move(telemetry_context)),
     _task_queue_telemetry(std::make_unique<telemetry::TaskQueueHandleWrapper>(
-      *_telemetry_context, _config.thread_name_prefix + "-task-queue"))
+      *_telemetry_context,
+      _config.thread_name_prefix + "-task-queue",
+      device_id.has_value() ? _telemetry_context->gpu_device_group_id(*device_id)
+                            : _telemetry_context->engine_id()))
 {
 }
 

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -49,7 +49,8 @@ gpu_pipeline_executor::gpu_pipeline_executor(
   exec::publisher<std::unique_ptr<task_request>> task_request_publisher,
   sirius::parallel::downgrade_executor* downgrade_executor,
   std::shared_ptr<const telemetry::telemetry_context> telemetry_context)
-  : sirius::parallel::itask_executor(config, std::move(telemetry_context)),
+  : sirius::parallel::itask_executor(
+      config, std::move(telemetry_context), mem_space->get_device_id()),
     _stream_pool(rmm::cuda_device_id{mem_space->get_device_id()}, config.num_threads),
     _task_request_publisher(std::move(task_request_publisher)),
     _memory_space(mem_space),
@@ -70,7 +71,9 @@ absl::AnyInvocable<void() noexcept> gpu_pipeline_executor::get_per_thread_init()
           thread_id_counter]() mutable noexcept {
     const int32_t thread_id = thread_id_counter->fetch_add(1, std::memory_order_relaxed);
     telemetry::thread_local_executor_thread_telemtry_init(
-      *telemetry_context, fmt::format("{}-gpu_exec-{}", thread_prefix, thread_id));
+      *telemetry_context,
+      fmt::format("{}-gpu{}-exec-{}", thread_prefix, device_id, thread_id),
+      telemetry_context->executor_thread_group_id(device_id));
 
     // Per-thread init runs on a worker thread just spawned by the
     // bounded_pool. cudaSetDevice pins this thread to the executor's GPU
@@ -91,7 +94,9 @@ absl::AnyInvocable<void() noexcept> gpu_pipeline_executor::get_per_thread_init()
 void gpu_pipeline_executor::manager_loop()
 {
   telemetry::TaskManagerLoopThreadHandleWrapper manager_thread_telemetry{
-    *_telemetry_context, fmt::format("gpu-{}-exec-manager", _memory_space->get_device_id())};
+    *_telemetry_context,
+    fmt::format("gpu-{}-exec-manager", _memory_space->get_device_id()),
+    _telemetry_context->manager_thread_group_id(_memory_space->get_device_id())};
 
   rmm::cuda_set_device_raii set_device_guard(rmm::cuda_device_id{_memory_space->get_device_id()});
   sirius::util::enable_log_on_default_stream();

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -265,7 +265,7 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
     auto& op = operators[i].get();
     try {
       this->telemetry_handle().computing({
-        .instance_name       = "",
+        .instance_name       = fmt::format("{}({})", op.get_name(), op.get_operator_id()),
         .current_operator_id = static_cast<uint32_t>(
           op.get_operator_id()),  // TODO(dhruv9vats): look into possible overflow
         .input_bytes                 = operator_input_output_data->get_estimated_size_in_bytes(),

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -47,7 +47,7 @@ task_scheduler::task_scheduler(
   : _task_queue(task_queue_ordering), _telemetry_context(std::move(telemetry_context))
 {
   _task_queue_telemetry = std::make_unique<telemetry::TaskQueueHandleWrapper>(
-    *_telemetry_context, "task-scheduler-gpu-queue");
+    *_telemetry_context, "task-scheduler-gpu-queue", _telemetry_context->shared_group_id());
 
   // Self-publisher: schedule() uses this to wake management_eventloop when a
   // new task is pushed, so the loop can re-run the matcher against any device
@@ -281,8 +281,8 @@ void task_scheduler::wait_for_completion()
 
 void task_scheduler::management_eventloop()
 {
-  telemetry::TaskManagerLoopThreadHandleWrapper manager_thread_telemetry{*_telemetry_context,
-                                                                         "task-scheduler-thread"};
+  telemetry::TaskManagerLoopThreadHandleWrapper manager_thread_telemetry{
+    *_telemetry_context, "task-scheduler-thread", _telemetry_context->shared_group_id()};
 
   // Pull-signal scheduler. The loop blocks on _task_request_channel for two
   // event kinds:

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -58,6 +58,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 
 namespace duckdb {
 
@@ -281,10 +282,15 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
 
   config_ = config;
   // Declare one telemetry device group per GPU so thread/queue telemetry can
-  // nest under its device instead of piling up flat under the engine.
+  // nest under its device instead of piling up flat under the engine. The GPU
+  // memory space configs already reflect the configured topology.num_gpus /
+  // topology.gpu_ids selection, unlike the raw hardware topology.
   std::vector<int> telemetry_gpu_ids;
-  for (auto const& gpu : config_.get_hw_topology().gpus) {
-    telemetry_gpu_ids.push_back(gpu.id);
+  for (auto const& space_config : config_.get_memory_space_configs()) {
+    if (auto const* gpu_config =
+          std::get_if<cucascade::memory::gpu_memory_space_config>(&space_config)) {
+      telemetry_gpu_ids.push_back(gpu_config->device_id);
+    }
   }
   telemetry_context_ =
     sirius::telemetry::telemetry_context::create(config_.get_telemetry_config(), telemetry_gpu_ids);

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -279,8 +279,15 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
 {
   if (is_initialized_) { throw std::runtime_error("Sirius context is already initialized."); }
 
-  config_            = config;
-  telemetry_context_ = sirius::telemetry::telemetry_context::create(config_.get_telemetry_config());
+  config_ = config;
+  // Declare one telemetry device group per GPU so thread/queue telemetry can
+  // nest under its device instead of piling up flat under the engine.
+  std::vector<int> telemetry_gpu_ids;
+  for (auto const& gpu : config_.get_hw_topology().gpus) {
+    telemetry_gpu_ids.push_back(gpu.id);
+  }
+  telemetry_context_ =
+    sirius::telemetry::telemetry_context::create(config_.get_telemetry_config(), telemetry_gpu_ids);
 
   // Validate the cached topology before any downstream construction so a stub
   // topology fails loudly rather than producing zero-GPU executors silently.

--- a/src/telemetry/telemetry_context.cpp
+++ b/src/telemetry/telemetry_context.cpp
@@ -34,15 +34,17 @@
 namespace sirius::telemetry {
 
 std::shared_ptr<const telemetry_context> telemetry_context::create(
-  const sirius::telemetry_config& config)
+  const sirius::telemetry_config& config, const std::vector<int>& gpu_device_ids)
 {
-  return std::shared_ptr<telemetry_context>(new telemetry_context(config));
+  return std::shared_ptr<telemetry_context>(new telemetry_context(config, gpu_device_ids));
 }
 
-telemetry_context::telemetry_context(const sirius::telemetry_config& config)
+telemetry_context::telemetry_context(const sirius::telemetry_config& config,
+                                     const std::vector<int>& gpu_device_ids)
   : engine_uuid_(uuid::now_v7()),
     worker_uuid_(uuid::now_v7()),
     query_group_uuid_(uuid::now_v7()),
+    shared_group_uuid_(uuid::now_v7()),
     context_(
       quent::create_context(config.enable_quent ? "ndjson" : "noop", config.output_directory)),
     engine_observer_(quent::engine::create_observer(*context_)),
@@ -75,7 +77,76 @@ telemetry_context::telemetry_context(const sirius::telemetry_config& config)
       .engine_id     = engine_uuid_,
     });
 
-  SIRIUS_LOG_INFO("Telemetry context initialized (engine={})", config.engine_name);
+  // Per-GPU device groups plus per-thread-type buckets underneath, so the
+  // viewer renders threads as an engine -> gpu-N -> thread-type tree instead
+  // of a flat sibling list. Threads with no single GPU go under `shared`.
+  auto gpu_device_observer   = quent::gpu_device::create_observer(*context_);
+  auto thread_group_observer = quent::thread_group::create_observer(*context_);
+
+  thread_group_observer->declaration(shared_group_uuid_,
+                                     quent::thread_group::Declaration{
+                                       .instance_name   = "shared",
+                                       .parent_group_id = engine_uuid_,
+                                     });
+
+  for (const int device_id : gpu_device_ids) {
+    const gpu_device_group_ids ids{
+      .device           = uuid::now_v7(),
+      .executor_threads = uuid::now_v7(),
+      .manager_threads  = uuid::now_v7(),
+    };
+    gpu_device_observer->declaration(ids.device,
+                                     quent::gpu_device::Declaration{
+                                       .instance_name   = fmt::format("gpu-{}", device_id),
+                                       .parent_group_id = engine_uuid_,
+                                       .ordinal         = static_cast<uint32_t>(device_id),
+                                     });
+    thread_group_observer->declaration(ids.executor_threads,
+                                       quent::thread_group::Declaration{
+                                         .instance_name   = "executor_thread",
+                                         .parent_group_id = ids.device,
+                                       });
+    thread_group_observer->declaration(ids.manager_threads,
+                                       quent::thread_group::Declaration{
+                                         .instance_name   = "task_manager_loop_thread",
+                                         .parent_group_id = ids.device,
+                                       });
+    gpu_group_ids_.emplace(device_id, ids);
+  }
+
+  SIRIUS_LOG_INFO("Telemetry context initialized (engine={}, {} GPU device group(s))",
+                  config.engine_name,
+                  gpu_group_ids_.size());
+}
+
+const uuid::UUID& telemetry_context::gpu_device_group_id(int device_id) const
+{
+  if (const auto it = gpu_group_ids_.find(device_id); it != gpu_group_ids_.end()) {
+    return it->second.device;
+  }
+  SIRIUS_LOG_WARN("Telemetry: no device group declared for GPU {}; falling back to engine group",
+                  device_id);
+  return engine_uuid_;
+}
+
+const uuid::UUID& telemetry_context::executor_thread_group_id(int device_id) const
+{
+  if (const auto it = gpu_group_ids_.find(device_id); it != gpu_group_ids_.end()) {
+    return it->second.executor_threads;
+  }
+  SIRIUS_LOG_WARN("Telemetry: no device group declared for GPU {}; falling back to engine group",
+                  device_id);
+  return engine_uuid_;
+}
+
+const uuid::UUID& telemetry_context::manager_thread_group_id(int device_id) const
+{
+  if (const auto it = gpu_group_ids_.find(device_id); it != gpu_group_ids_.end()) {
+    return it->second.manager_threads;
+  }
+  SIRIUS_LOG_WARN("Telemetry: no device group declared for GPU {}; falling back to engine group",
+                  device_id);
+  return engine_uuid_;
 }
 
 telemetry_context::~telemetry_context()

--- a/test/cpp/telemetry/test_telemetry_context.cpp
+++ b/test/cpp/telemetry/test_telemetry_context.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "sirius_config.hpp"
+#include "telemetry/telemetry_context.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace sirius;
+using namespace sirius::telemetry;
+
+namespace {
+
+std::string uuid_str(const uuid::UUID& id) { return std::string(uuid::to_string(id)); }
+
+/// Read every line of every ndjson file that the quent context wrote.
+std::vector<std::string> read_all_telemetry_lines(const std::filesystem::path& dir)
+{
+  std::vector<std::string> lines;
+  for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
+    if (!entry.is_regular_file()) { continue; }
+    std::ifstream in(entry.path());
+    std::string line;
+    while (std::getline(in, line)) {
+      if (!line.empty()) { lines.push_back(line); }
+    }
+  }
+  return lines;
+}
+
+bool any_line_with_all(const std::vector<std::string>& lines,
+                       const std::vector<std::string>& needles)
+{
+  for (const auto& line : lines) {
+    bool all = true;
+    for (const auto& needle : needles) {
+      if (line.find(needle) == std::string::npos) {
+        all = false;
+        break;
+      }
+    }
+    if (all) { return true; }
+  }
+  return false;
+}
+
+}  // namespace
+
+TEST_CASE("telemetry_context nests threads under per-GPU device groups", "[telemetry_context]")
+{
+  const auto out_dir = std::filesystem::temp_directory_path() /
+                       ("sirius_telemetry_test_" + std::to_string(::getpid()));
+  std::filesystem::remove_all(out_dir);
+
+  telemetry_config config;
+  config.enable_quent     = true;
+  config.output_directory = out_dir.string();
+  config.engine_name      = "test-engine";
+
+  std::string engine_id;
+  std::string gpu0_id, gpu1_id, gpu0_exec_id, gpu0_mgr_id, shared_id;
+  {
+    auto context = telemetry_context::create(config, {0, 1});
+    engine_id    = uuid_str(context->engine_id());
+    gpu0_id      = uuid_str(context->gpu_device_group_id(0));
+    gpu1_id      = uuid_str(context->gpu_device_group_id(1));
+    gpu0_exec_id = uuid_str(context->executor_thread_group_id(0));
+    gpu0_mgr_id  = uuid_str(context->manager_thread_group_id(0));
+    shared_id    = uuid_str(context->shared_group_id());
+
+    // Every id is distinct and none collapses onto the engine.
+    const std::vector<std::string> ids{
+      engine_id, gpu0_id, gpu1_id, gpu0_exec_id, gpu0_mgr_id, shared_id};
+    for (size_t i = 0; i < ids.size(); i++) {
+      for (size_t j = i + 1; j < ids.size(); j++) {
+        REQUIRE(ids[i] != ids[j]);
+      }
+    }
+
+    // Unknown devices fall back to the engine group instead of orphaning.
+    REQUIRE(context->gpu_device_group_id(99) == context->engine_id());
+    REQUIRE(context->executor_thread_group_id(99) == context->engine_id());
+    REQUIRE(context->manager_thread_group_id(99) == context->engine_id());
+
+    // Emit one thread of each kind the way the executors do.
+    ExecutorThreadHandleWrapper exec_thread{
+      *context, "test-gpu0-exec-0", context->executor_thread_group_id(0)};
+    TaskManagerLoopThreadHandleWrapper manager_thread{
+      *context, "gpu-0-exec-manager", context->manager_thread_group_id(0)};
+    TaskManagerLoopThreadHandleWrapper scheduler_thread{
+      *context, "task-scheduler-thread", context->shared_group_id()};
+    TaskQueueHandleWrapper task_queue{
+      *context, "gpu_pipeline-task-queue", context->gpu_device_group_id(0)};
+  }  // wrappers exit, then the context drops and flushes the ndjson files
+
+  const auto lines = read_all_telemetry_lines(out_dir);
+  REQUIRE(!lines.empty());
+
+  // Device groups are declared under the engine, with matching ids.
+  REQUIRE(any_line_with_all(lines, {"\"gpu-0\"", engine_id, gpu0_id}));
+  REQUIRE(any_line_with_all(lines, {"\"gpu-1\"", engine_id, gpu1_id}));
+  // Per-thread-type buckets are declared under the gpu-0 device group.
+  REQUIRE(any_line_with_all(lines, {"\"executor_thread\"", gpu0_id, gpu0_exec_id}));
+  REQUIRE(any_line_with_all(lines, {"\"task_manager_loop_thread\"", gpu0_id, gpu0_mgr_id}));
+  // The shared group hangs off the engine.
+  REQUIRE(any_line_with_all(lines, {"\"shared\"", engine_id, shared_id}));
+
+  // Threads and queues point at their group, not at the engine.
+  REQUIRE(any_line_with_all(lines, {"test-gpu0-exec-0", gpu0_exec_id}));
+  REQUIRE(!any_line_with_all(lines, {"test-gpu0-exec-0", engine_id}));
+  REQUIRE(any_line_with_all(lines, {"gpu-0-exec-manager", gpu0_mgr_id}));
+  REQUIRE(any_line_with_all(lines, {"task-scheduler-thread", shared_id}));
+  REQUIRE(any_line_with_all(lines, {"gpu_pipeline-task-queue", gpu0_id}));
+
+  std::filesystem::remove_all(out_dir);
+}


### PR DESCRIPTION
## What

Quent currently shows every execution thread as a flat sibling list under the engine, because all thread telemetry declares the engine as its `parent_group_id`. This PR emits the nesting as data instead — no Quent-side changes needed:

```
engine (siriusDB)
├─ gpu-0
│  ├─ executor_thread            → gpu_pipeline-gpu0-exec-0..3
│  ├─ task_manager_loop_thread   → gpu-0-exec-manager
│  └─ gpu_pipeline-task-queue
├─ gpu-1                          (same shape)
└─ shared
   ├─ task-scheduler-thread
   └─ task-scheduler-gpu-queue
```

## How

- **Model** (`rust/crates/telemetry/model`): new `GpuDevice` and `ThreadGroup` resource-group entities (declaration = `instance_name` + `parent_group_id`, plus GPU `ordinal` on `GpuDevice`).
- **Runtime** (`telemetry_context`): `create()` takes the topology's GPU device ids and declares one `gpu-N` group per GPU under the engine, with per-thread-type bucket groups underneath, plus a `shared` group. Unknown device ids fall back to the engine group with a warning.
- **Spawn sites**: the telemetry wrappers take an explicit `parent_group_id`. `gpu_pipeline_executor` parents its executor threads, manager thread, and task queue under its GPU's groups, sourcing the device ordinal from `_memory_space->get_device_id()` (not from name strings). `task_scheduler`'s thread and queue go under `shared`. Executor thread names now include the GPU ordinal (`gpu_pipeline-gpu0-exec-N`), so the two GPUs' threads no longer share identical names.
- **Analyzer**: ingests the new declarations as resource groups; the existing tree machinery does the rest. Also adds a `print_resource_tree` example for inspecting a session's group tree offline.

## Verification

- New `[telemetry_context]` unit test asserts the declared groups, thread parenting, and engine fallback against the emitted ndjson (29 assertions).
- Real 2-GPU TPC-H q1 (SF100) run: `gpu-0`/`gpu-1` declared under the engine, all 8 executor threads point at per-GPU bucket uuids (4+4, none at the engine), and the analyzer builds the full tree with no orphans. Confirmed the collapsible tree renders in the Quent UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)