### PR TITLE
perf improvement - Collapse S3 parquet footer bind to one suffix-range GET

### DIFF
--- a/src/include/io/cache/metadata_store.hpp
+++ b/src/include/io/cache/metadata_store.hpp
@@ -58,6 +58,11 @@ class metadata_store {
   [[nodiscard]] std::shared_ptr<sirius_io_object_metadata> get_metadata(
     sirius_io_object const& obj) const;
 
+  /// As above but keyed directly by @c raw_file_cache_id() — for callers that
+  /// know the path but have not built an io_object yet.  Returns nullptr on miss.
+  [[nodiscard]] std::shared_ptr<sirius_io_object_metadata> get_metadata(
+    std::string const& cache_key) const;
+
  private:
   mutable std::shared_mutex _mtx;
   std::unordered_map<std::string, std::shared_ptr<sirius_io_object_metadata>> _by_key;

--- a/src/include/io/io_context.hpp
+++ b/src/include/io/io_context.hpp
@@ -37,6 +37,14 @@ namespace sirius::io {
 
 enum class io_context_type { uring, restful, kvikio };
 
+/// Hint passed to @c open_datasource so a backend can tailor how it resolves an
+/// object's metadata.  @c generic resolves the size however is cheapest for the
+/// scheme (a HEAD for object stores).  @c parquet_footer_probe asks the backend
+/// to resolve the size *and* stash the object's trailing bytes in one
+/// round-trip (a suffix-range GET), so the parquet footer reads that follow are
+/// served locally instead of costing extra round-trips.
+enum class open_hint { generic, parquet_footer_probe };
+
 namespace cache {
 class prefetching_cache;
 }
@@ -96,6 +104,11 @@ class sirius_ioctx : public std::enable_shared_from_this<sirius_ioctx> {
   /// unreachable paths (callers that want a check-without-open should use
   /// @c supports()).
   [[nodiscard]] std::unique_ptr<sirius_datasource> open_datasource(std::string path);
+
+  /// As above, forwarding @p hint to the backend's io_object resolution so it
+  /// can, e.g., prefetch a parquet footer in the same round-trip as the size.
+  [[nodiscard]] std::unique_ptr<sirius_datasource> open_datasource(std::string path,
+                                                                   open_hint hint);
 
   /// Whether this backend can serve reads for @p path.  Backends should
   /// validate scheme/protocol support and any backend-specific
@@ -228,6 +241,13 @@ class sirius_ioctx : public std::enable_shared_from_this<sirius_ioctx> {
   /// the public surface (callers receive a ready @c sirius_datasource).  Throws
   /// on unsupported / unreachable paths.
   virtual std::shared_ptr<sirius_io_object> create_io_object(std::string path) = 0;
+
+  /// Hinted variant.  The base implementation ignores @p hint and delegates to
+  /// the required @c create_io_object(path); a backend that can act on the hint
+  /// (e.g. rest_ioctx's suffix-range footer probe) overrides this.  Kept a
+  /// distinct virtual — not a defaulted argument on the pure virtual above — so
+  /// the hint dispatches on the dynamic type instead of binding statically.
+  virtual std::shared_ptr<sirius_io_object> create_io_object(std::string path, open_hint hint);
 
   /// Owned by this ioctx.  Built by @ref initialize_cache, destroyed
   /// by @ref shutdown_cache (or the ioctx destructor as a safety net,

--- a/src/include/io/rest/config.hpp
+++ b/src/include/io/rest/config.hpp
@@ -88,6 +88,19 @@ struct config {
   /// terminal-failure and device-stream-sync counters are always recorded,
   /// independent of this flag.
   bool perf_instrumentation{false};
+
+  /// Suffix-range window (bytes) for the parquet footer probe
+  /// (@c open_hint::parquet_footer_probe): one `Range: bytes=-N` GET resolves the
+  /// object size and stashes its last N bytes, so cuDF's trailer/footer reads are
+  /// served locally.  Tradeoff — a parquet footer is ~0.037% of the file (SF1
+  /// lineitem 207 MB -> 78 KiB, SF10 2.2 GB -> 771 KiB): N must cover the footer,
+  /// else the probe wastes the suffix and re-GETs the footer body (worse than a
+  /// plain HEAD), so err large; the over-read when N exceeds the footer is a
+  /// one-time bind transfer (~10 ms on a high-bandwidth link).  The 512 KiB
+  /// default covers files up to ~1.4 GB in one GET (the common range); raise it
+  /// for multi-GB single files, lower it for many-tiny-file / low-bandwidth
+  /// workloads.
+  std::size_t footer_probe_bytes{512UL << 10};  // 512 KiB
 };
 
 }  // namespace sirius::io::rest

--- a/src/include/io/rest/rest_ioctx.hpp
+++ b/src/include/io/rest/rest_ioctx.hpp
@@ -59,6 +59,19 @@ class rest_ioctx : public templated_ioctx<rest_reactor> {
   /// (s3://bucket/key), HEAD it for the size, and build a @c rest_io_object.
   /// Throws on a non-s3 scheme or a failed HEAD.
   std::shared_ptr<sirius_io_object> create_io_object(std::string path) override;
+
+  /// @c open_hint::parquet_footer_probe resolves the size and stashes the
+  /// parquet footer together via a single suffix-range GET, carried on the
+  /// returned io_object; every other hint falls back to the plain HEAD path above.
+  std::shared_ptr<sirius_io_object> create_io_object(std::string path, open_hint hint) override;
+
+ private:
+  /// Resolve @p path with a single suffix-range GET: it discovers the size and
+  /// stashes the object's trailing bytes on the returned io_object so cuDF's
+  /// footer reads are served locally by @c rest_reactor::host_read.  Falls back
+  /// to a HEAD when the suffix response is unusable.  The stash lives only as
+  /// long as the returned io_object — a per-open transport shortcut, not a cache.
+  std::shared_ptr<sirius_io_object> create_footer_probe_object(std::string path);
 };
 
 }  // namespace sirius::io::rest

--- a/src/include/io/rest/rest_reactor.hpp
+++ b/src/include/io/rest/rest_reactor.hpp
@@ -43,6 +43,27 @@
 
 namespace sirius::io::rest {
 
+/// Parse the total object length out of a Content-Range value of the form
+/// "bytes <first>-<last>/<total>".  Returns nullopt when the unit is not
+/// "bytes", the range is unsatisfied ("bytes */..."), or the total is unknown
+/// ("*") — i.e. any response the footer probe cannot trust.
+[[nodiscard]] std::optional<std::size_t> content_range_total(std::string const& content_range);
+
+// ---------------------------------------------------------------------------
+// footer_probe
+// ---------------------------------------------------------------------------
+
+/// Result of a suffix-range footer probe: the object's total size plus the
+/// trailing window [window_lo, object_size) captured in @c bytes.  @c bytes is
+/// null when the probe could not be satisfied (the caller then falls back to a
+/// HEAD).  Held by shared_ptr so the trailing bytes are shared, not copied, with
+/// the io_object that carries them for this open.
+struct footer_probe {
+  std::size_t object_size{0};
+  std::size_t window_lo{0};
+  std::shared_ptr<const std::vector<std::uint8_t>> bytes;
+};
+
 // ---------------------------------------------------------------------------
 // rest_io_object
 // ---------------------------------------------------------------------------
@@ -61,6 +82,24 @@ class rest_io_object : public sirius_io_object {
   {
   }
 
+  /// As above, but carrying a suffix-range footer stash: @p stash holds the
+  /// object's bytes over [window_lo, object_size), so @c rest_reactor::host_read
+  /// serves any read fully inside that window from memory instead of a GET.
+  rest_io_object(std::string path,
+                 std::string bucket,
+                 std::string key,
+                 size_t object_size,
+                 size_t window_lo,
+                 std::shared_ptr<const std::vector<std::uint8_t>> stash)
+    : _path(std::move(path)),
+      _bucket(std::move(bucket)),
+      _key(std::move(key)),
+      _file_size(object_size),
+      _window_lo(window_lo),
+      _stash(std::move(stash))
+  {
+  }
+
   [[nodiscard]] const std::string& raw_file_cache_id() const noexcept override { return _path; }
   [[nodiscard]] const std::string& object_path() const noexcept override { return _path; }
   [[nodiscard]] size_t size() const noexcept override { return _file_size; }
@@ -69,11 +108,22 @@ class rest_io_object : public sirius_io_object {
   [[nodiscard]] const std::string& key() const noexcept { return _key; }
   [[nodiscard]] s3::s3_object_ref object_ref() const { return s3::s3_object_ref{_bucket, _key}; }
 
+  /// Trailing bytes prefetched at open (a suffix-range footer probe), or null
+  /// when the object was opened without one.  A read fully inside
+  /// [stash_window_lo, size) is served from here by @c host_read.
+  [[nodiscard]] const std::shared_ptr<const std::vector<std::uint8_t>>& stash() const noexcept
+  {
+    return _stash;
+  }
+  [[nodiscard]] size_t stash_window_lo() const noexcept { return _window_lo; }
+
  private:
   std::string _path;
   std::string _bucket;
   std::string _key;
   size_t _file_size{0};
+  size_t _window_lo{0};
+  std::shared_ptr<const std::vector<std::uint8_t>> _stash;
 };
 
 // ---------------------------------------------------------------------------
@@ -217,6 +267,14 @@ class rest_reactor {
   /// Blocking HEAD to discover an object's size.  Used by the ioctx to build
   /// an @c rest_io_object.  @p bucket / @p key identify the object.
   size_t head_object_size(std::string_view bucket, std::string_view key);
+
+  /// Blocking suffix-range GET of the last @p n bytes of an object, resolving
+  /// the size and stashing the parquet footer in a single round-trip.  On a
+  /// well-formed 206 the returned @c footer_probe carries the object size, the
+  /// window origin, and the trailing bytes; on any unusable response (200 full
+  /// body, missing / unsatisfied Content-Range) @c bytes is null so the caller
+  /// falls back to a HEAD.  @p bucket / @p key identify the object.
+  footer_probe fetch_footer_suffix(std::string_view bucket, std::string_view key, std::size_t n);
 
   /// Snapshot of this reactor's perf counters.  Lock-free (relaxed atomic
   /// loads); safe to call while the reactor is running.

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -296,7 +296,7 @@ class sirius_scan_manager {
   [[nodiscard]] sirius::io::sirius_ioctx* io_ctx() const noexcept { return _io_ctx.get(); }
 
   [[nodiscard]] std::shared_ptr<sirius::io::sirius_datasource> create_datasource(
-    std::string_view path);
+    std::string_view path, sirius::io::open_hint hint = sirius::io::open_hint::generic);
 
  private:
   /// \brief Run providers sequentially: start each, wait on its future, advance.

--- a/src/io/cache/metadata_store.cpp
+++ b/src/io/cache/metadata_store.cpp
@@ -32,9 +32,14 @@ void metadata_store::register_metadata(sirius_io_object const& obj,
 std::shared_ptr<sirius_io_object_metadata> metadata_store::get_metadata(
   sirius_io_object const& obj) const
 {
-  auto const& key = obj.raw_file_cache_id();
+  return get_metadata(obj.raw_file_cache_id());
+}
+
+std::shared_ptr<sirius_io_object_metadata> metadata_store::get_metadata(
+  std::string const& cache_key) const
+{
   std::shared_lock lk(_mtx);
-  auto it = _by_key.find(key);
+  auto it = _by_key.find(cache_key);
   if (it == _by_key.end()) return nullptr;
   return it->second;
 }

--- a/src/io/io_context.cpp
+++ b/src/io/io_context.cpp
@@ -72,4 +72,16 @@ std::unique_ptr<sirius_datasource> sirius_ioctx::open_datasource(std::string pat
   return std::make_unique<sirius_datasource>(shared_from_this(), create_io_object(std::move(path)));
 }
 
+std::unique_ptr<sirius_datasource> sirius_ioctx::open_datasource(std::string path, open_hint hint)
+{
+  return std::make_unique<sirius_datasource>(shared_from_this(),
+                                             create_io_object(std::move(path), hint));
+}
+
+std::shared_ptr<sirius_io_object> sirius_ioctx::create_io_object(std::string path,
+                                                                 open_hint /*hint*/)
+{
+  return create_io_object(std::move(path));
+}
+
 }  // namespace sirius::io

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -76,13 +76,6 @@ std::shared_ptr<sirius_io_object> rest_ioctx::create_io_object(std::string path)
     std::move(path), std::move(parsed.host), std::move(parsed.path), size);
 }
 
-namespace {
-// Suffix length requested by a parquet footer probe.  Generous enough to cover
-// typical parquet footers (KB-scale) plus the 8-byte trailer in one GET; a
-// footer larger than this simply falls through to a ranged GET at read time.
-constexpr std::size_t kFooterProbeBytes = std::size_t{1} << 20;  // 1 MiB
-}  // namespace
-
 std::shared_ptr<sirius_io_object> rest_ioctx::create_io_object(std::string path, open_hint hint)
 {
   if (hint == open_hint::parquet_footer_probe) {
@@ -102,8 +95,8 @@ std::shared_ptr<sirius_io_object> rest_ioctx::create_footer_probe_object(std::st
 
   // One suffix-range GET resolves the size and stashes the footer; cuDF's
   // trailer/footer reads are then served from the stash by host_read.
-  footer_probe probe =
-    _reactors.front()->fetch_footer_suffix(parsed.host, parsed.path, kFooterProbeBytes);
+  footer_probe probe = _reactors.front()->fetch_footer_suffix(
+    parsed.host, parsed.path, _reactors.front()->get_config().footer_probe_bytes);
   if (!probe.bytes) {
     // Unusable suffix response (200 full body, 416, missing / "*" Content-Range):
     // fall back to a plain HEAD for the size, with no stash.

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -21,6 +21,8 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <memory>
 #include <stdexcept>
 #include <utility>
 
@@ -72,6 +74,49 @@ std::shared_ptr<sirius_io_object> rest_ioctx::create_io_object(std::string path)
   size_t const size = _reactors.front()->head_object_size(parsed.host, parsed.path);
   return std::make_shared<rest_io_object>(
     std::move(path), std::move(parsed.host), std::move(parsed.path), size);
+}
+
+namespace {
+// Suffix length requested by a parquet footer probe.  Generous enough to cover
+// typical parquet footers (KB-scale) plus the 8-byte trailer in one GET; a
+// footer larger than this simply falls through to a ranged GET at read time.
+constexpr std::size_t kFooterProbeBytes = std::size_t{1} << 20;  // 1 MiB
+}  // namespace
+
+std::shared_ptr<sirius_io_object> rest_ioctx::create_io_object(std::string path, open_hint hint)
+{
+  if (hint == open_hint::parquet_footer_probe) {
+    return create_footer_probe_object(std::move(path));
+  }
+  return create_io_object(std::move(path));
+}
+
+std::shared_ptr<sirius_io_object> rest_ioctx::create_footer_probe_object(std::string path)
+{
+  auto parsed = sirius::io::parse(path);
+  if (parsed.scheme != "s3") {
+    throw std::invalid_argument("rest_ioctx::create_io_object: unsupported scheme '" +
+                                parsed.scheme + "'");
+  }
+  if (_reactors.empty()) { throw std::runtime_error("rest_ioctx::create_io_object: no reactors"); }
+
+  // One suffix-range GET resolves the size and stashes the footer; cuDF's
+  // trailer/footer reads are then served from the stash by host_read.
+  footer_probe probe =
+    _reactors.front()->fetch_footer_suffix(parsed.host, parsed.path, kFooterProbeBytes);
+  if (!probe.bytes) {
+    // Unusable suffix response (200 full body, 416, missing / "*" Content-Range):
+    // fall back to a plain HEAD for the size, with no stash.
+    size_t const size = _reactors.front()->head_object_size(parsed.host, parsed.path);
+    return std::make_shared<rest_io_object>(
+      std::move(path), std::move(parsed.host), std::move(parsed.path), size);
+  }
+  return std::make_shared<rest_io_object>(std::move(path),
+                                          std::move(parsed.host),
+                                          std::move(parsed.path),
+                                          probe.object_size,
+                                          probe.window_lo,
+                                          probe.bytes);
 }
 
 }  // namespace sirius::io::rest

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -140,6 +140,7 @@ size_t capture_header(char* buffer, size_t size, size_t nitems, void* userdata)
 struct suffix_sink {
   std::vector<std::uint8_t> data;
   std::size_t cap{0};
+  std::size_t total_received{0};  // wire bytes, incl. those dropped by cap/abort
   long status{0};
   std::string content_range;
   std::string retry_after;
@@ -176,6 +177,7 @@ size_t suffix_write_cb(char* ptr, size_t size, size_t nmemb, void* userdata)
 {
   auto* s            = static_cast<suffix_sink*>(userdata);
   size_t const bytes = size * nmemb;
+  s->total_received += bytes;
   if (s->status != 206) { return 0; }
   if (s->data.size() < s->cap) {
     size_t const take = std::min(s->cap - s->data.size(), bytes);
@@ -886,6 +888,11 @@ footer_probe rest_reactor::fetch_footer_suffix(std::string_view bucket,
     long status       = 0;
     curl_easy_getinfo(h.get(), CURLINFO_RESPONSE_CODE, &status);
 
+    // payload_bytes_read_total is always-on and per-attempt (see the async
+    // worker's finish()), so credit every attempt's wire bytes outside the
+    // perf_instrumentation gate.
+    _perf.payload_bytes_read_total.fetch_add(sink.total_received, std::memory_order_relaxed);
+
     // suffix_write_cb aborts any non-206 body, so a CURLE_WRITE_ERROR here is our
     // own doing and the HTTP status is still valid; only a different curl error
     // (no HTTP status) is a genuine transport failure.
@@ -915,7 +922,6 @@ footer_probe rest_reactor::fetch_footer_suffix(std::string_view bucket,
           atomic_max_relaxed(_perf.chunk_get_ns_max, get_ns);
           std::uint64_t expected = 0;
           _perf.ttfb_ns.compare_exchange_strong(expected, get_ns, std::memory_order_relaxed);
-          _perf.payload_bytes_read_total.fetch_add(sink.data.size(), std::memory_order_relaxed);
         }
         probe.object_size = *total;
         probe.window_lo   = *start;

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -133,6 +133,58 @@ size_t capture_header(char* buffer, size_t size, size_t nitems, void* userdata)
   return bytes;
 }
 
+/// Shared sink for a suffix-range footer probe: the header callback records the
+/// HTTP status (from the status line) plus Content-Range / Retry-After; the body
+/// callback consults @c status to abort a non-206 response before it streams a
+/// whole object into us.  @c HEADERDATA and @c WRITEDATA point at the same one.
+struct suffix_sink {
+  std::vector<std::uint8_t> data;
+  std::size_t cap{0};
+  long status{0};
+  std::string content_range;
+  std::string retry_after;
+};
+
+/// Header callback for a suffix probe: parse the status code out of the status
+/// line so the body callback can abort a non-206 early, and capture the headers
+/// the caller needs (Content-Range to verify the 206, Retry-After for backoff).
+size_t suffix_header_cb(char* buffer, size_t size, size_t nitems, void* userdata)
+{
+  auto* s            = static_cast<suffix_sink*>(userdata);
+  size_t const bytes = size * nitems;
+  std::string_view const line(buffer, bytes);
+  if (line.size() >= 5 && ascii_lower(line[0]) == 'h' && ascii_lower(line[1]) == 't' &&
+      ascii_lower(line[2]) == 't' && ascii_lower(line[3]) == 'p' && line[4] == '/') {
+    if (auto const sp = line.find(' '); sp != std::string_view::npos) {
+      long code = 0;
+      for (size_t i = sp + 1; i < line.size() && line[i] >= '0' && line[i] <= '9'; ++i) {
+        code = code * 10 + (line[i] - '0');
+      }
+      if (code != 0) { s->status = code; }
+    }
+  }
+  if (auto v = match_header(line, "content-range"); !v.empty()) { s->content_range = std::move(v); }
+  if (auto v = match_header(line, "retry-after"); !v.empty()) { s->retry_after = std::move(v); }
+  return bytes;
+}
+
+/// Body callback for a suffix probe: abort a non-206 response (a deliberate
+/// short write, surfacing as CURLE_WRITE_ERROR) so a server that ignores the
+/// Range or answers 416/4xx never streams a whole object into us; otherwise
+/// append up to @c cap bytes and report the full incoming size to curl.
+size_t suffix_write_cb(char* ptr, size_t size, size_t nmemb, void* userdata)
+{
+  auto* s            = static_cast<suffix_sink*>(userdata);
+  size_t const bytes = size * nmemb;
+  if (s->status != 206) { return 0; }
+  if (s->data.size() < s->cap) {
+    size_t const take = std::min(s->cap - s->data.size(), bytes);
+    auto const* src   = reinterpret_cast<std::uint8_t const*>(ptr);
+    s->data.insert(s->data.end(), src, src + take);
+  }
+  return bytes;
+}
+
 // ---- retry classification --------------------------------------------------
 
 /// HTTP status codes worth retrying (transient server / throttling).  Only the
@@ -208,6 +260,10 @@ std::string range_header(size_t offset, size_t size)
 {
   return fmt::format("Range: bytes={}-{}", offset, offset + size - 1);
 }
+
+/// "Range: bytes=-<n>" — the last @p n bytes of an object (a suffix range).
+/// Unlike range_header this needs no prior knowledge of the object's size.
+std::string suffix_range_header(size_t n) { return fmt::format("Range: bytes=-{}", n); }
 
 /// Parse the first-byte position out of a Content-Range value of the form
 /// "bytes <first>-<last>/<total>" (the trimmed value captured by the header
@@ -326,6 +382,33 @@ std::vector<io_object_segment> chunk_host_segments(std::span<const io_object_seg
 }
 
 }  // namespace
+
+std::optional<size_t> content_range_total(std::string const& cr)
+{
+  constexpr std::string_view kUnit = "bytes";
+  std::string_view sv{cr};
+  if (sv.size() < kUnit.size()) { return std::nullopt; }
+  for (size_t i = 0; i < kUnit.size(); ++i) {
+    if (ascii_lower(sv[i]) != kUnit[i]) { return std::nullopt; }
+  }
+  sv.remove_prefix(kUnit.size());
+  while (!sv.empty() && (sv.front() == ' ' || sv.front() == '\t')) {
+    sv.remove_prefix(1);
+  }
+  // The range part must be a satisfied "<first>-<last>", never "*": a leading
+  // digit both rejects "bytes */..." and confirms a total follows the '/'.
+  if (sv.empty() || sv.front() < '0' || sv.front() > '9') { return std::nullopt; }
+  auto const slash = sv.find('/');
+  if (slash == std::string_view::npos) { return std::nullopt; }
+  std::string_view const total = sv.substr(slash + 1);
+  if (total.empty() || total.front() < '0' || total.front() > '9') { return std::nullopt; }
+  size_t value = 0;
+  for (char const c : total) {
+    if (c < '0' || c > '9') { break; }
+    value = value * 10 + static_cast<size_t>(c - '0');
+  }
+  return value;
+}
 
 // ---------------------------------------------------------------------------
 // construction / lifecycle
@@ -673,6 +756,17 @@ size_t rest_reactor::host_read(const io_object_type& file, size_t offset, size_t
   size = std::min(size, file.size() > offset ? file.size() - offset : size_t{0});
   if (size == 0) { return 0; }
 
+  // Serve reads fully inside the suffix-range footer stash locally (the parquet
+  // trailer/footer reads after a probe); a straddling read falls through to a GET.
+  if (auto const& stash = file.stash(); stash) {
+    size_t const lo = file.stash_window_lo();
+    size_t const hi = lo + stash->size();
+    if (offset >= lo && offset + size <= hi) {
+      std::memcpy(dst, stash->data() + (offset - lo), size);
+      return size;
+    }
+  }
+
   // Drive the blocking read through the worker's async pipeline (pooled
   // connections, parallel ranged GETs, the shared retry/backoff policy) and
   // synchronize on its future — rather than a one-shot easy handle that pays a
@@ -753,6 +847,97 @@ size_t rest_reactor::head_object_size(std::string_view bucket, std::string_view 
     }
   }
   throw std::runtime_error("rest_reactor::head_object_size: exhausted retries (" + last_error +
+                           ") for " + obj.bucket + "/" + obj.key);
+}
+
+footer_probe rest_reactor::fetch_footer_suffix(std::string_view bucket,
+                                               std::string_view key,
+                                               std::size_t n)
+{
+  footer_probe probe;
+  if (n == 0) { return probe; }
+
+  s3::s3_object_ref const obj{std::string(bucket), std::string(key)};
+  std::string last_error;
+  for (std::size_t attempt = 0; attempt < _config.max_retry_attempts; ++attempt) {
+    suffix_sink sink;
+    sink.cap = n;
+    auto const authd =
+      _ctx->authorizer()->authorize(obj, s3::s3_request_method::GET, presign_ttl(_config));
+
+    curl_easy_ptr h{curl_easy_init()};
+    if (!h) {
+      throw std::runtime_error("rest_reactor::fetch_footer_suffix: curl_easy_init failed");
+    }
+    configure_easy_handle(h.get(), global_curl_context::instance().share_handle());
+    apply_request_opts(h.get(), _config);
+
+    std::string const range = suffix_range_header(n);
+    curl_slist_ptr hdrs     = build_header_list(authd.headers, &range);
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_URL, authd.url.c_str()));
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HTTPHEADER, hdrs.get()));
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_WRITEFUNCTION, &suffix_write_cb));
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_WRITEDATA, &sink));
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HEADERFUNCTION, &suffix_header_cb));
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HEADERDATA, &sink));
+
+    auto const t0     = std::chrono::steady_clock::now();
+    CURLcode const rc = curl_easy_perform(h.get());
+    long status       = 0;
+    curl_easy_getinfo(h.get(), CURLINFO_RESPONSE_CODE, &status);
+
+    // suffix_write_cb aborts any non-206 body, so a CURLE_WRITE_ERROR here is our
+    // own doing and the HTTP status is still valid; only a different curl error
+    // (no HTTP status) is a genuine transport failure.
+    if (rc != CURLE_OK && rc != CURLE_WRITE_ERROR) {
+      last_error = std::string(curl_easy_strerror(rc));
+      if (!is_retriable_curl(rc)) {
+        throw std::runtime_error("rest_reactor::fetch_footer_suffix: " + last_error + " for " +
+                                 obj.bucket + "/" + obj.key);
+      }
+    } else if (status == 206) {
+      // Trust the 206 only when the window origin and total both parse and the
+      // delivered byte count matches exactly; an unverifiable 206 (missing /
+      // "*" Content-Range) reports an empty probe so the caller HEADs instead.
+      auto const total = content_range_total(sink.content_range);
+      auto const start = content_range_start(sink.content_range);
+      if (total && start && *start <= *total && sink.data.size() == *total - *start) {
+        // Account the footer suffix GET the same way the async chunk path does
+        // (it replaces the tail+body GETs that used to run through the pipeline),
+        // so bind-time footer reads stay visible in the perf snapshot.
+        if (_config.perf_instrumentation) {
+          auto const get_ns =
+            static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                         std::chrono::steady_clock::now() - t0)
+                                         .count());
+          _perf.chunk_get_ns_total.fetch_add(get_ns, std::memory_order_relaxed);
+          _perf.chunk_get_count.fetch_add(1, std::memory_order_relaxed);
+          atomic_max_relaxed(_perf.chunk_get_ns_max, get_ns);
+          std::uint64_t expected = 0;
+          _perf.ttfb_ns.compare_exchange_strong(expected, get_ns, std::memory_order_relaxed);
+          _perf.payload_bytes_read_total.fetch_add(sink.data.size(), std::memory_order_relaxed);
+        }
+        probe.object_size = *total;
+        probe.window_lo   = *start;
+        probe.bytes       = std::make_shared<const std::vector<std::uint8_t>>(std::move(sink.data));
+      }
+      return probe;
+    } else if (status == 200 || status == 416) {
+      // Range ignored (full body) or unsatisfiable (416): probe unusable but the
+      // object exists — report empty so the caller falls back to a HEAD.
+      return probe;
+    } else if (is_retriable_status(status)) {
+      last_error = "HTTP " + std::to_string(status);
+    } else {
+      // 404 / 403 / 401 / ... — an error a HEAD would not recover from either.
+      throw std::runtime_error("rest_reactor::fetch_footer_suffix: HTTP " + std::to_string(status) +
+                               " for " + obj.bucket + "/" + obj.key);
+    }
+    if (attempt + 1 < _config.max_retry_attempts) {
+      std::this_thread::sleep_for(compute_backoff(attempt, sink.retry_after, _config));
+    }
+  }
+  throw std::runtime_error("rest_reactor::fetch_footer_suffix: exhausted retries (" + last_error +
                            ") for " + obj.bucket + "/" + obj.key);
 }
 

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -899,6 +899,7 @@ footer_probe rest_reactor::fetch_footer_suffix(std::string_view bucket,
     if (rc != CURLE_OK && rc != CURLE_WRITE_ERROR) {
       last_error = std::string(curl_easy_strerror(rc));
       if (!is_retriable_curl(rc)) {
+        _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
         throw std::runtime_error("rest_reactor::fetch_footer_suffix: " + last_error + " for " +
                                  obj.bucket + "/" + obj.key);
       }
@@ -936,13 +937,16 @@ footer_probe rest_reactor::fetch_footer_suffix(std::string_view bucket,
       last_error = "HTTP " + std::to_string(status);
     } else {
       // 404 / 403 / 401 / ... — an error a HEAD would not recover from either.
+      _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
       throw std::runtime_error("rest_reactor::fetch_footer_suffix: HTTP " + std::to_string(status) +
                                " for " + obj.bucket + "/" + obj.key);
     }
     if (attempt + 1 < _config.max_retry_attempts) {
+      _perf.retries_total.fetch_add(1, std::memory_order_relaxed);
       std::this_thread::sleep_for(compute_backoff(attempt, sink.retry_after, _config));
     }
   }
+  _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
   throw std::runtime_error("rest_reactor::fetch_footer_suffix: exhausted retries (" + last_error +
                            ") for " + obj.bucket + "/" + obj.key);
 }

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -20,6 +20,7 @@
 #include "io/details/slot_pool.hpp"
 #include "io/rest/curl_handle.hpp"
 #include "io/uri_parser.hpp"
+#include "log/logging.hpp"
 
 #include <rmm/cuda_device.hpp>
 
@@ -830,6 +831,7 @@ size_t rest_reactor::head_object_size(std::string_view bucket, std::string_view 
       curl_off_t cl = -1;
       curl_easy_getinfo(h.get(), CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &cl);
       if (cl < 0) {
+        _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
         throw std::runtime_error("rest_reactor::head_object_size: missing Content-Length for " +
                                  obj.bucket + "/" + obj.key);
       }
@@ -841,13 +843,22 @@ size_t rest_reactor::head_object_size(std::string_view bucket, std::string_view 
     bool const retriable =
       (rc != CURLE_OK && is_retriable_curl(rc)) || (rc == CURLE_OK && is_retriable_status(status));
     if (!retriable) {
+      _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
       throw std::runtime_error("rest_reactor::head_object_size: " + last_error + " for " +
                                obj.bucket + "/" + obj.key);
     }
     if (attempt + 1 < _config.max_retry_attempts) {
+      _perf.retries_total.fetch_add(1, std::memory_order_relaxed);
+      SIRIUS_LOG_WARN("rest_reactor::head_object_size: retrying {}/{} after {} (attempt {}/{})",
+                      obj.bucket,
+                      obj.key,
+                      last_error,
+                      attempt + 1,
+                      _config.max_retry_attempts);
       std::this_thread::sleep_for(compute_backoff(attempt, hc.retry_after, _config));
     }
   }
+  _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
   throw std::runtime_error("rest_reactor::head_object_size: exhausted retries (" + last_error +
                            ") for " + obj.bucket + "/" + obj.key);
 }
@@ -943,6 +954,12 @@ footer_probe rest_reactor::fetch_footer_suffix(std::string_view bucket,
     }
     if (attempt + 1 < _config.max_retry_attempts) {
       _perf.retries_total.fetch_add(1, std::memory_order_relaxed);
+      SIRIUS_LOG_WARN("rest_reactor::fetch_footer_suffix: retrying {}/{} after {} (attempt {}/{})",
+                      obj.bucket,
+                      obj.key,
+                      last_error,
+                      attempt + 1,
+                      _config.max_retry_attempts);
       std::this_thread::sleep_for(compute_backoff(attempt, sink.retry_after, _config));
     }
   }
@@ -1299,7 +1316,8 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
     // a genuine AccessDenied still fails fast.
     auto schedule_retry = [&](std::unique_ptr<rest_chunked_rx_request> req,
                               std::string const& retry_after,
-                              bool is_auth) {
+                              bool is_auth,
+                              std::string const& reason) {
       std::size_t& counter = is_auth ? req->auth_attempt : req->attempt;
       std::size_t const max_attempts =
         is_auth ? _config.max_auth_retry_attempts : _config.max_retry_attempts;
@@ -1313,6 +1331,12 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
       // and reuses the current step without inflating it.
       auto const delay = compute_backoff(req->attempt, retry_after, _config);
       _perf.retries_total.fetch_add(1, std::memory_order_relaxed);
+      SIRIUS_LOG_WARN("rest_reactor: retrying {}/{} after {} (attempt {}/{})",
+                      req->object.bucket,
+                      req->object.key,
+                      reason,
+                      counter + 1,
+                      max_attempts);
       counter += 1;
       retry_heap.push_back(retry_entry{std::chrono::steady_clock::now() + delay, std::move(req)});
       std::push_heap(retry_heap.begin(), retry_heap.end(), retry_cmp);
@@ -1517,8 +1541,13 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
       // with a fresh signature a bounded number of times before giving up.
       bool const auth_retriable = rc == CURLE_OK && status == 403;
       if (retriable || auth_retriable) {
-        schedule_retry(
-          std::move(s.req), s.hc.retry_after, /*is_auth=*/auth_retriable && !retriable);
+        std::string const reason =
+          rc != CURLE_OK ? std::string(curl_easy_strerror(rc))
+                         : (short_read ? "short read" : "HTTP " + std::to_string(status));
+        schedule_retry(std::move(s.req),
+                       s.hc.retry_after,
+                       /*is_auth=*/auth_retriable && !retriable,
+                       reason);
         return false;
       }
       std::string const msg = rc != CURLE_OK

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -259,7 +259,16 @@ sirius_scan_manager::~sirius_scan_manager()
 
 parquet_bind_result sirius_scan_manager::describe_parquet(std::string const& uri)
 {
-  auto datasource = create_datasource(uri);
+  // Footer-probe only when we will actually read + parse the footer.  On a warm
+  // re-bind the metadata_store already holds the parsed footer, so a suffix GET
+  // would download footer bytes we won't reuse — a plain HEAD resolves the size.
+  auto const cache_key     = normalize_path(uri);
+  auto const io_ctx        = ioctx_for_path(uri);
+  bool const footer_cached = io_ctx && io_ctx->metadata_store().get_metadata(cache_key) != nullptr;
+  auto const hint =
+    footer_cached ? sirius::io::open_hint::generic : sirius::io::open_hint::parquet_footer_probe;
+
+  auto datasource = create_datasource(uri, hint);
   if (!datasource) {
     throw std::runtime_error("[sirius_scan_manager::describe_parquet] no backend supports URI: " +
                              uri);
@@ -370,14 +379,14 @@ void sirius_scan_manager::start_metadata_processing()
 }
 
 std::shared_ptr<sirius::io::sirius_datasource> sirius_scan_manager::create_datasource(
-  std::string_view path)
+  std::string_view path, sirius::io::open_hint hint)
 {
   auto file_path = normalize_path(std::string(path));
   auto io_ctx    = ioctx_for_path(file_path);
   if (!io_ctx) { return nullptr; }  // no backend supports the path
   // Real I/O / HEAD / auth / missing-object errors propagate as exceptions;
   // only "no backend" is reported as nullptr (callers map it to that message).
-  return io_ctx->open_datasource(file_path);
+  return io_ctx->open_datasource(file_path, hint);
 }
 
 std::shared_ptr<sirius::io::sirius_ioctx> sirius_scan_manager::ioctx_for_path(std::string_view path)

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -115,6 +115,7 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
   r.optional("max_auth_retry_attempts", opt.max_auth_retry_attempts);
   r.optional("honor_retry_after", opt.honor_retry_after);
   r.optional("perf_instrumentation", opt.perf_instrumentation);
+  r.optional("footer_probe_bytes", yaml::bytes(opt.footer_probe_bytes));
   r.reject_unknown();
 }
 

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -254,6 +254,7 @@ TEST_CASE("sirius_config parses rest perf instrumentation flag",
           "[scan_manager][config][s3][rest][perf]")
 {
   CHECK_FALSE(sirius::io::rest::config{}.perf_instrumentation);
+  CHECK(sirius::io::rest::config{}.footer_probe_bytes == 512UL * 1024);
 
   auto const path =
     std::filesystem::temp_directory_path() / "sirius_rest_perf_instrumentation.yaml";
@@ -262,11 +263,13 @@ TEST_CASE("sirius_config parses rest perf instrumentation flag",
              "  executor:\n"
              "    scan_manager:\n"
              "      rest:\n"
-             "        perf_instrumentation: true\n");
+             "        perf_instrumentation: true\n"
+             "        footer_probe_bytes: 256KiB\n");
 
   sirius::sirius_config cfg;
   REQUIRE_NOTHROW(cfg.load_from_file(path));
   CHECK(cfg.get_scan_manager_config().rest.perf_instrumentation);
+  CHECK(cfg.get_scan_manager_config().rest.footer_probe_bytes == 256UL * 1024);
 
   std::error_code ec;
   std::filesystem::remove(path, ec);

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -301,6 +301,7 @@ struct sirius_memory_limits {
   std::optional<std::size_t> rest_n_reactors;
   std::optional<std::size_t> rest_max_connections;
   std::optional<bool> use_sirius_datasource;
+  std::optional<std::string> rest_footer_probe_bytes;
   bool rest_perf_instrumentation{false};
 };
 
@@ -413,6 +414,9 @@ class sirius_config_env_guard {
         << limits.rest_max_connections.value_or(std::size_t{8})
         << "\n"
            "        request_timeout_s: 30\n";
+    if (limits.rest_footer_probe_bytes.has_value()) {
+      out << "        footer_probe_bytes: " << yaml_quote(*limits.rest_footer_probe_bytes) << "\n";
+    }
     if (limits.rest_perf_instrumentation) { out << "        perf_instrumentation: true\n"; }
     out.close();
     REQUIRE(out);
@@ -843,7 +847,11 @@ rest_bench_measurement run_rest_parquet_scan(s3_sql_fixture& fixture,
                                              bool use_footer_probe = false)
 {
   auto& manager = require_sirius_context(fixture).get_scan_manager();
-  auto& rest    = ensure_rest_ioctx_for_bench(manager, uri);
+  // Snapshotting the routed REST ioctx before the measured open requires one
+  // unmeasured datasource lookup.  That may warm the backend's connection path,
+  // so the absolute open_ms is a warm-open measurement; the generic/probe A/B
+  // still uses the same pre-open and remains comparable within this benchmark.
+  auto& rest = ensure_rest_ioctx_for_bench(manager, uri);
 
   auto const wall_start = bench_clock::now();
   auto const before     = rest.perf_snapshot();
@@ -913,6 +921,7 @@ struct bench_record {
   double wall_clock_ms{0.0};
   double open_ms{0.0};
   double footer_fetch_ms{0.0};
+  double bind_ms{0.0};
   double metadata_parse_ms{0.0};
   double scan_ms{0.0};
   std::uint64_t payload_bytes_read{0};
@@ -959,6 +968,7 @@ bench_record make_record(std::string scenario,
                       measurement.wall_clock_ms,
                       measurement.open_ms,
                       measurement.footer_fetch_ms,
+                      measurement.open_ms + measurement.footer_fetch_ms,
                       measurement.metadata_parse_ms,
                       measurement.scan_ms,
                       measurement.payload_bytes_read,
@@ -987,15 +997,13 @@ void warn_footer_probe_ab(std::string_view label,
                           bench_record const& generic,
                           bench_record const& probe)
 {
-  double const generic_bind = generic.open_ms + generic.footer_fetch_ms;
-  double const probe_bind   = probe.open_ms + probe.footer_fetch_ms;
-  WARN("[footerbind A/B] " << label << " bind(open+footer) generic=" << generic_bind << "ms"
+  WARN("[footerbind A/B] " << label << " bind(open+footer) generic=" << generic.bind_ms << "ms"
                            << " (bind_chunk_get=" << generic.bind_chunk_get_count
                            << ", total_chunk_get=" << generic.chunk_get_count
-                           << ") probe=" << probe_bind << "ms"
+                           << ") probe=" << probe.bind_ms << "ms"
                            << " (bind_chunk_get=" << probe.bind_chunk_get_count
                            << ", total_chunk_get=" << probe.chunk_get_count << ") collapse="
-                           << (probe_bind > 0.0 ? generic_bind / probe_bind : 0.0) << "x");
+                           << (probe.bind_ms > 0.0 ? generic.bind_ms / probe.bind_ms : 0.0) << "x");
 }
 
 std::string json_escape(std::string_view value)
@@ -1257,6 +1265,7 @@ void write_perf_json(fs::path const& path,
         << "\"wall_clock_ms\": " << std::fixed << std::setprecision(3) << r.wall_clock_ms << ", "
         << "\"open_ms\": " << r.open_ms << ", "
         << "\"footer_fetch_ms\": " << r.footer_fetch_ms << ", "
+        << "\"bind_ms\": " << r.bind_ms << ", "
         << "\"metadata_parse_ms\": " << r.metadata_parse_ms << ", "
         << "\"scan_ms\": " << r.scan_ms << ", "
         << "\"payload_bytes_read\": " << r.payload_bytes_read << ", "
@@ -1324,6 +1333,7 @@ void append_perf_history_jsonl(fs::path const& path,
         << ",\"payload_bytes_read\":" << r.payload_bytes_read << ",\"row_count\":" << r.row_count
         << ",\"bind_chunk_get_count\":" << r.bind_chunk_get_count
         << ",\"wall_clock_ms\":" << std::fixed << std::setprecision(3) << r.wall_clock_ms
+        << ",\"bind_ms\":" << r.bind_ms
         << ",\"effective_bytes_per_sec\":" << r.effective_bytes_per_sec
         << ",\"retries_total\":" << r.retries_total
         << ",\"terminal_failures_total\":" << r.terminal_failures_total
@@ -1349,6 +1359,7 @@ void require_perf_json_schema(fs::path const& path, std::vector<std::string> exp
                    "\"wall_clock_ms\"",
                    "\"open_ms\"",
                    "\"footer_fetch_ms\"",
+                   "\"bind_ms\"",
                    "\"metadata_parse_ms\"",
                    "\"scan_ms\"",
                    "\"payload_bytes_read\"",
@@ -1465,6 +1476,13 @@ bench_record run_rest_minio_bench_scenario(
   limits.rest_perf_instrumentation = perf_instrumentation;
   limits.rest_max_connections      = rest_max_connections;
   limits.rest_n_reactors           = rest_n_reactors;
+  if (use_footer_probe) {
+    // The default footer-probe window is intentionally 512 KiB.  SF10
+    // lineitem's footer is larger than that, so the benchmark's probe variant
+    // pins a 1 MiB window to keep this scenario focused on the single-suffix-GET
+    // A/B rather than the out-of-window fallback (covered by REST unit tests).
+    limits.rest_footer_probe_bytes = "1 MiB";
+  }
   if (columns.size() > 1) {
     // The compatibility run mirrors the old #982 seven-column async-S3 baseline.
     // SF10 materializes a much wider cuDF table than the single-column CI
@@ -1532,7 +1550,11 @@ bench_record run_rest_aws_bench_scenario(s3_test_env const& env,
   CHECK(measurement.rows > 0);
   if (expected_rows.has_value()) { CHECK(measurement.rows == *expected_rows); }
   CHECK(measurement.payload_bytes_read > 0);
-  CHECK(measurement.bind_micro.chunk_get_count >= (use_footer_probe ? 1 : 2));
+  if (use_footer_probe) {
+    CHECK(measurement.bind_micro.chunk_get_count == 1);
+  } else {
+    CHECK(measurement.bind_micro.chunk_get_count >= 2);
+  }
   CHECK(measurement.micro.device_stream_sync_total == 0);
   CHECK(measurement.micro.terminal_failures_total == 0);
   return make_record(footer_probe_scenario_name(std::move(scenario), use_footer_probe),
@@ -2115,7 +2137,7 @@ TEST_CASE("S3 REST AWS perf benchmark records projected and full scans",
     CHECK(projected_probe.payload_bytes_read == *projected_probe_payload_bytes);
     CHECK(projected_probe.terminal_failures_total == 0);
     CHECK(projected_probe.device_stream_sync_total == 0);
-    CHECK(projected_probe.bind_chunk_get_count >= 1);
+    CHECK(projected_probe.bind_chunk_get_count == 1);
     WARN("AWS REST projected_probe mc="
          << max_connections << " throughput=" << projected_probe.effective_bytes_per_sec
          << " B/s footer_fetch_ms=" << projected_probe.footer_fetch_ms
@@ -2153,7 +2175,7 @@ TEST_CASE("S3 REST AWS perf benchmark records projected and full scans",
     CHECK(full_probe.payload_bytes_read == *full_probe_payload_bytes);
     CHECK(full_probe.terminal_failures_total == 0);
     CHECK(full_probe.device_stream_sync_total == 0);
-    CHECK(full_probe.bind_chunk_get_count >= 1);
+    CHECK(full_probe.bind_chunk_get_count == 1);
     WARN("AWS REST full_probe mc="
          << max_connections << " throughput=" << full_probe.effective_bytes_per_sec
          << " B/s footer_fetch_ms=" << full_probe.footer_fetch_ms

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -773,6 +773,11 @@ double mean_ns_as_ms(std::uint64_t total_ns, std::uint64_t count)
   return static_cast<double>(total_ns) / static_cast<double>(count) / 1'000'000.0;
 }
 
+double bytes_per_sec_to_mib_per_sec(double bytes_per_sec)
+{
+  return bytes_per_sec / static_cast<double>(1024U * 1024U);
+}
+
 std::uint64_t sat_sub(std::uint64_t after, std::uint64_t before)
 {
   return after >= before ? after - before : 0;
@@ -926,7 +931,7 @@ struct bench_record {
   double scan_ms{0.0};
   std::uint64_t payload_bytes_read{0};
   duckdb::idx_t row_count{0};
-  double effective_bytes_per_sec{0.0};
+  double effective_mib_per_sec{0.0};
   std::uint64_t bind_chunk_get_count{0};
   std::uint64_t chunk_get_ns_total{0};
   std::uint64_t chunk_get_count{0};
@@ -956,9 +961,10 @@ bench_record make_record(std::string scenario,
                          std::uint64_t dataset_bytes)
 {
   auto seconds = measurement.wall_clock_ms / 1000.0;
-  auto effective =
+  auto const raw_bytes_per_sec =
     seconds > 0.0 ? static_cast<double>(dataset_bytes) / seconds : static_cast<double>(0);
-  auto const& micro = measurement.micro;
+  auto const effective_mib_per_sec = bytes_per_sec_to_mib_per_sec(raw_bytes_per_sec);
+  auto const& micro                = measurement.micro;
   return bench_record{std::move(scenario),
                       std::move(transport),
                       std::move(projection),
@@ -973,7 +979,7 @@ bench_record make_record(std::string scenario,
                       measurement.scan_ms,
                       measurement.payload_bytes_read,
                       measurement.rows,
-                      effective,
+                      effective_mib_per_sec,
                       measurement.bind_micro.chunk_get_count,
                       micro.chunk_get_ns_total,
                       micro.chunk_get_count,
@@ -1270,7 +1276,7 @@ void write_perf_json(fs::path const& path,
         << "\"scan_ms\": " << r.scan_ms << ", "
         << "\"payload_bytes_read\": " << r.payload_bytes_read << ", "
         << "\"row_count\": " << r.row_count << ", "
-        << "\"effective_bytes_per_sec\": " << r.effective_bytes_per_sec << ", "
+        << "\"effective_mib_per_sec\": " << r.effective_mib_per_sec << ", "
         << "\"bind_chunk_get_count\": " << r.bind_chunk_get_count << ", "
         << "\"chunk_get_ns_total\": " << r.chunk_get_ns_total << ", "
         << "\"chunk_get_count\": " << r.chunk_get_count << ", "
@@ -1333,8 +1339,7 @@ void append_perf_history_jsonl(fs::path const& path,
         << ",\"payload_bytes_read\":" << r.payload_bytes_read << ",\"row_count\":" << r.row_count
         << ",\"bind_chunk_get_count\":" << r.bind_chunk_get_count
         << ",\"wall_clock_ms\":" << std::fixed << std::setprecision(3) << r.wall_clock_ms
-        << ",\"bind_ms\":" << r.bind_ms
-        << ",\"effective_bytes_per_sec\":" << r.effective_bytes_per_sec
+        << ",\"bind_ms\":" << r.bind_ms << ",\"effective_mib_per_sec\":" << r.effective_mib_per_sec
         << ",\"retries_total\":" << r.retries_total
         << ",\"terminal_failures_total\":" << r.terminal_failures_total
         << ",\"device_stream_sync_total\":" << r.device_stream_sync_total << "}";
@@ -1364,7 +1369,7 @@ void require_perf_json_schema(fs::path const& path, std::vector<std::string> exp
                    "\"scan_ms\"",
                    "\"payload_bytes_read\"",
                    "\"row_count\"",
-                   "\"effective_bytes_per_sec\"",
+                   "\"effective_mib_per_sec\"",
                    "\"bind_chunk_get_count\"",
                    "\"chunk_get_ns_total\"",
                    "\"chunk_get_count\"",
@@ -1879,7 +1884,7 @@ TEST_CASE("S3 REST bench perf instrumentation gate keeps micro counters zero", "
 
   auto record = run_rest_minio_bench_scenario(*env,
                                               *large,
-                                              "async_http_gate_off",
+                                              "rest_reactor_http_gate_off",
                                               env->endpoint,
                                               std::nullopt,
                                               false,
@@ -1922,41 +1927,42 @@ TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][
   std::vector<bench_record> records;
   records.reserve(6);
 
-  // compat_* mirrors the old async-S3 benchmark shape: seven projected columns,
-  // mc=32, and no scan-manager prefetch cache mixed into the raw S3 read path.
-  auto compat_http  = run_rest_minio_bench_scenario(*env,
-                                                   *large,
-                                                   "compat_http",
-                                                   env->endpoint,
-                                                   std::nullopt,
-                                                   false,
-                                                   /*perf_instrumentation=*/true,
-                                                   bench_compat_projection(),
-                                                   std::size_t{32},
-                                                   std::size_t{1},
-                                                   /*enable_prefetch_cache=*/false);
-  auto compat_https = run_rest_minio_bench_scenario(*env,
-                                                    *large,
-                                                    "compat_https",
-                                                    env->https_endpoint,
-                                                    env->ca_bundle_path,
-                                                    true,
-                                                    /*perf_instrumentation=*/true,
-                                                    bench_compat_projection(),
-                                                    std::size_t{32},
-                                                    std::size_t{1},
-                                                    /*enable_prefetch_cache=*/false);
-  auto http         = run_rest_minio_bench_scenario(*env,
+  // rest_reactor_compat_* mirrors the old async-S3 benchmark shape: seven
+  // projected columns, mc=32, and no scan-manager prefetch cache mixed into the
+  // raw S3 read path.
+  auto rest_reactor_compat_http  = run_rest_minio_bench_scenario(*env,
+                                                                *large,
+                                                                "rest_reactor_compat_http",
+                                                                env->endpoint,
+                                                                std::nullopt,
+                                                                false,
+                                                                /*perf_instrumentation=*/true,
+                                                                bench_compat_projection(),
+                                                                std::size_t{32},
+                                                                std::size_t{1},
+                                                                /*enable_prefetch_cache=*/false);
+  auto rest_reactor_compat_https = run_rest_minio_bench_scenario(*env,
+                                                                 *large,
+                                                                 "rest_reactor_compat_https",
+                                                                 env->https_endpoint,
+                                                                 env->ca_bundle_path,
+                                                                 true,
+                                                                 /*perf_instrumentation=*/true,
+                                                                 bench_compat_projection(),
+                                                                 std::size_t{32},
+                                                                 std::size_t{1},
+                                                                 /*enable_prefetch_cache=*/false);
+  auto http                      = run_rest_minio_bench_scenario(*env,
                                             *large,
-                                            "async_http",
+                                            "rest_reactor_http",
                                             env->endpoint,
                                             std::nullopt,
                                             false,
                                             /*perf_instrumentation=*/true,
                                             bench_single_column_projection());
-  auto http_probe   = run_rest_minio_bench_scenario(*env,
+  auto http_probe                = run_rest_minio_bench_scenario(*env,
                                                   *large,
-                                                  "async_http",
+                                                  "rest_reactor_http",
                                                   env->endpoint,
                                                   std::nullopt,
                                                   false,
@@ -1966,17 +1972,17 @@ TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][
                                                   std::nullopt,
                                                   /*enable_prefetch_cache=*/true,
                                                   /*use_footer_probe=*/true);
-  auto https        = run_rest_minio_bench_scenario(*env,
+  auto https                     = run_rest_minio_bench_scenario(*env,
                                              *large,
-                                             "async_https",
+                                             "rest_reactor_https",
                                              env->https_endpoint,
                                              env->ca_bundle_path,
                                              true,
                                              /*perf_instrumentation=*/true,
                                              bench_single_column_projection());
-  auto https_probe  = run_rest_minio_bench_scenario(*env,
+  auto https_probe               = run_rest_minio_bench_scenario(*env,
                                                    *large,
-                                                   "async_https",
+                                                   "rest_reactor_https",
                                                    env->https_endpoint,
                                                    env->ca_bundle_path,
                                                    true,
@@ -1991,8 +1997,8 @@ TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][
                         std::cref(http_probe),
                         std::cref(https),
                         std::cref(https_probe),
-                        std::cref(compat_http),
-                        std::cref(compat_https)}) {
+                        std::cref(rest_reactor_compat_http),
+                        std::cref(rest_reactor_compat_https)}) {
     auto const& record = r.get();
     CHECK(record.row_count == large->total_num_rows);
     CHECK(record.payload_bytes_read > 0);
@@ -2020,45 +2026,49 @@ TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][
   CHECK(http_probe.bind_chunk_get_count == 1);
   CHECK(https.bind_chunk_get_count == 2);
   CHECK(https_probe.bind_chunk_get_count == 1);
-  CHECK(compat_http.row_count == compat_https.row_count);
-  CHECK(compat_http.payload_bytes_read == compat_https.payload_bytes_read);
+  CHECK(rest_reactor_compat_http.row_count == rest_reactor_compat_https.row_count);
+  CHECK(rest_reactor_compat_http.payload_bytes_read ==
+        rest_reactor_compat_https.payload_bytes_read);
   if (https.footer_fetch_ms > http.footer_fetch_ms * 3.0) {
     WARN("HTTPS footer_fetch_ms is more than 3x HTTP on this MinIO run: http="
          << http.footer_fetch_ms << "ms https=" << https.footer_fetch_ms << "ms");
   }
-  if (compat_https.footer_fetch_ms > compat_http.footer_fetch_ms * 3.0) {
+  if (rest_reactor_compat_https.footer_fetch_ms > rest_reactor_compat_http.footer_fetch_ms * 3.0) {
     WARN("HTTPS compat footer_fetch_ms is more than 3x HTTP on this MinIO run: http="
-         << compat_http.footer_fetch_ms << "ms https=" << compat_https.footer_fetch_ms << "ms");
+         << rest_reactor_compat_http.footer_fetch_ms
+         << "ms https=" << rest_reactor_compat_https.footer_fetch_ms << "ms");
   }
-  WARN("S3 REST perf async_http throughput=" << http.effective_bytes_per_sec
-                                             << " B/s footer_fetch_ms=" << http.footer_fetch_ms
-                                             << " chunk_get_ms_mean=" << http.chunk_get_ms_mean);
-  WARN("S3 REST perf async_https throughput=" << https.effective_bytes_per_sec
-                                              << " B/s footer_fetch_ms=" << https.footer_fetch_ms
-                                              << " chunk_get_ms_mean=" << https.chunk_get_ms_mean);
-  warn_footer_probe_ab("async_http", http, http_probe);
-  warn_footer_probe_ab("async_https", https, https_probe);
-  WARN("S3 REST perf compat_http throughput="
-       << compat_http.effective_bytes_per_sec << " B/s footer_fetch_ms="
-       << compat_http.footer_fetch_ms << " chunk_get_ms_mean=" << compat_http.chunk_get_ms_mean
-       << " chunk_get_count=" << compat_http.chunk_get_count);
-  WARN("S3 REST perf compat_https throughput="
-       << compat_https.effective_bytes_per_sec << " B/s footer_fetch_ms="
-       << compat_https.footer_fetch_ms << " chunk_get_ms_mean=" << compat_https.chunk_get_ms_mean
-       << " chunk_get_count=" << compat_https.chunk_get_count);
+  WARN("S3 REST perf rest_reactor_http throughput="
+       << http.effective_mib_per_sec << " MiB/s footer_fetch_ms=" << http.footer_fetch_ms
+       << " chunk_get_ms_mean=" << http.chunk_get_ms_mean);
+  WARN("S3 REST perf rest_reactor_https throughput="
+       << https.effective_mib_per_sec << " MiB/s footer_fetch_ms=" << https.footer_fetch_ms
+       << " chunk_get_ms_mean=" << https.chunk_get_ms_mean);
+  warn_footer_probe_ab("rest_reactor_http", http, http_probe);
+  warn_footer_probe_ab("rest_reactor_https", https, https_probe);
+  WARN("S3 REST perf rest_reactor_compat_http throughput="
+       << rest_reactor_compat_http.effective_mib_per_sec
+       << " MiB/s footer_fetch_ms=" << rest_reactor_compat_http.footer_fetch_ms
+       << " chunk_get_ms_mean=" << rest_reactor_compat_http.chunk_get_ms_mean
+       << " chunk_get_count=" << rest_reactor_compat_http.chunk_get_count);
+  WARN("S3 REST perf rest_reactor_compat_https throughput="
+       << rest_reactor_compat_https.effective_mib_per_sec
+       << " MiB/s footer_fetch_ms=" << rest_reactor_compat_https.footer_fetch_ms
+       << " chunk_get_ms_mean=" << rest_reactor_compat_https.chunk_get_ms_mean
+       << " chunk_get_count=" << rest_reactor_compat_https.chunk_get_count);
 
   attach_baseline_comparison(http, baseline_json, backend);
   attach_baseline_comparison(http_probe, baseline_json, backend);
   attach_baseline_comparison(https, baseline_json, backend);
   attach_baseline_comparison(https_probe, baseline_json, backend);
-  attach_baseline_comparison(compat_http, baseline_json, backend);
-  attach_baseline_comparison(compat_https, baseline_json, backend);
+  attach_baseline_comparison(rest_reactor_compat_http, baseline_json, backend);
+  attach_baseline_comparison(rest_reactor_compat_https, baseline_json, backend);
   records.push_back(std::move(http));
   records.push_back(std::move(http_probe));
   records.push_back(std::move(https));
   records.push_back(std::move(https_probe));
-  records.push_back(std::move(compat_http));
-  records.push_back(std::move(compat_https));
+  records.push_back(std::move(rest_reactor_compat_http));
+  records.push_back(std::move(rest_reactor_compat_https));
   REQUIRE(records.size() >= 6);
 
   auto const path = perf_json_path();
@@ -2069,12 +2079,12 @@ TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][
                   static_cast<std::uint64_t>(fs::file_size(large->local_path)),
                   records);
   require_perf_json_schema(path,
-                           {"async_http",
-                            "async_http_probe",
-                            "async_https",
-                            "async_https_probe",
-                            "compat_http",
-                            "compat_https"});
+                           {"rest_reactor_http",
+                            "rest_reactor_http_probe",
+                            "rest_reactor_https",
+                            "rest_reactor_https_probe",
+                            "rest_reactor_compat_http",
+                            "rest_reactor_compat_https"});
   WARN("Wrote S3 REST perf JSON baseline to " << path.string());
 }
 
@@ -2116,8 +2126,8 @@ TEST_CASE("S3 REST AWS perf benchmark records projected and full scans",
     CHECK(projected.device_stream_sync_total == 0);
     CHECK(projected.bind_chunk_get_count >= 2);
     WARN("AWS REST projected mc=" << max_connections
-                                  << " throughput=" << projected.effective_bytes_per_sec
-                                  << " B/s footer_fetch_ms=" << projected.footer_fetch_ms
+                                  << " throughput=" << projected.effective_mib_per_sec
+                                  << " MiB/s footer_fetch_ms=" << projected.footer_fetch_ms
                                   << " ttfb_ns=" << projected.ttfb_ns
                                   << " retries=" << projected.retries_total);
     attach_baseline_comparison(projected, baseline_json, backend);
@@ -2139,8 +2149,8 @@ TEST_CASE("S3 REST AWS perf benchmark records projected and full scans",
     CHECK(projected_probe.device_stream_sync_total == 0);
     CHECK(projected_probe.bind_chunk_get_count == 1);
     WARN("AWS REST projected_probe mc="
-         << max_connections << " throughput=" << projected_probe.effective_bytes_per_sec
-         << " B/s footer_fetch_ms=" << projected_probe.footer_fetch_ms
+         << max_connections << " throughput=" << projected_probe.effective_mib_per_sec
+         << " MiB/s footer_fetch_ms=" << projected_probe.footer_fetch_ms
          << " ttfb_ns=" << projected_probe.ttfb_ns << " retries=" << projected_probe.retries_total);
     warn_footer_probe_ab("aws_https_projected", records.back(), projected_probe);
     attach_baseline_comparison(projected_probe, baseline_json, backend);
@@ -2155,8 +2165,8 @@ TEST_CASE("S3 REST AWS perf benchmark records projected and full scans",
     CHECK(full.terminal_failures_total == 0);
     CHECK(full.device_stream_sync_total == 0);
     CHECK(full.bind_chunk_get_count >= 2);
-    WARN("AWS REST full mc=" << max_connections << " throughput=" << full.effective_bytes_per_sec
-                             << " B/s footer_fetch_ms=" << full.footer_fetch_ms
+    WARN("AWS REST full mc=" << max_connections << " throughput=" << full.effective_mib_per_sec
+                             << " MiB/s footer_fetch_ms=" << full.footer_fetch_ms
                              << " ttfb_ns=" << full.ttfb_ns << " retries=" << full.retries_total);
     attach_baseline_comparison(full, baseline_json, backend);
     records.push_back(std::move(full));
@@ -2177,8 +2187,8 @@ TEST_CASE("S3 REST AWS perf benchmark records projected and full scans",
     CHECK(full_probe.device_stream_sync_total == 0);
     CHECK(full_probe.bind_chunk_get_count == 1);
     WARN("AWS REST full_probe mc="
-         << max_connections << " throughput=" << full_probe.effective_bytes_per_sec
-         << " B/s footer_fetch_ms=" << full_probe.footer_fetch_ms
+         << max_connections << " throughput=" << full_probe.effective_mib_per_sec
+         << " MiB/s footer_fetch_ms=" << full_probe.footer_fetch_ms
          << " ttfb_ns=" << full_probe.ttfb_ns << " retries=" << full_probe.retries_total);
     warn_footer_probe_ab("aws_https_full", records.back(), full_probe);
     attach_baseline_comparison(full_probe, baseline_json, backend);

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "catch.hpp"
+#include "io/io_context.hpp"
 #include "io/rest/rest_ioctx.hpp"
 #include "io/s3/s3_object_ref.hpp"
 #include "io/s3/sirius_sigv4_authorizer.hpp"
@@ -805,6 +806,7 @@ struct rest_bench_measurement {
   double scan_ms{0.0};
   std::uint64_t payload_bytes_read{0};
   duckdb::idx_t rows{0};
+  sirius::io::rest::rest_perf_snapshot bind_micro;
   sirius::io::rest::rest_perf_snapshot micro;
 };
 
@@ -824,27 +826,43 @@ std::unique_ptr<cudf::io::datasource::buffer> read_parquet_footer_for_bench(
   return source.host_read(file_size - footer_tail_size - footer_size, footer_size);
 }
 
+sirius::io::rest::rest_ioctx& ensure_rest_ioctx_for_bench(
+  sirius::scan_manager::sirius_scan_manager& manager, std::string const& uri)
+{
+  auto datasource = manager.create_datasource(uri);
+  REQUIRE(datasource != nullptr);
+  REQUIRE(datasource->io_ctx() != nullptr);
+  auto* rest = dynamic_cast<sirius::io::rest::rest_ioctx*>(datasource->io_ctx().get());
+  REQUIRE(rest != nullptr);
+  return *rest;
+}
+
 rest_bench_measurement run_rest_parquet_scan(s3_sql_fixture& fixture,
                                              std::string const& uri,
-                                             std::vector<std::string> const& columns)
+                                             std::vector<std::string> const& columns,
+                                             bool use_footer_probe = false)
 {
   auto& manager = require_sirius_context(fixture).get_scan_manager();
+  auto& rest    = ensure_rest_ioctx_for_bench(manager, uri);
 
   auto const wall_start = bench_clock::now();
+  auto const before     = rest.perf_snapshot();
 
   auto const open_start = bench_clock::now();
-  auto datasource       = manager.create_datasource(uri);
-  auto const open_stop  = bench_clock::now();
+  auto datasource =
+    manager.create_datasource(uri,
+                              use_footer_probe ? sirius::io::open_hint::parquet_footer_probe
+                                               : sirius::io::open_hint::generic);
+  auto const open_stop = bench_clock::now();
   REQUIRE(datasource != nullptr);
   REQUIRE(datasource->io_ctx() != nullptr);
   auto io_ctx = datasource->io_ctx();
-  auto* rest  = dynamic_cast<sirius::io::rest::rest_ioctx*>(io_ctx.get());
-  REQUIRE(rest != nullptr);
-  auto const before = rest->perf_snapshot();
+  REQUIRE(io_ctx.get() == &rest);
 
   auto const footer_start = bench_clock::now();
   auto footer_buffer      = read_parquet_footer_for_bench(*datasource);
   auto const footer_stop  = bench_clock::now();
+  auto const after_footer = rest.perf_snapshot();
 
   auto opts = cudf::io::parquet_reader_options::builder().column_names(columns).build();
 
@@ -861,10 +879,11 @@ rest_bench_measurement run_rest_parquet_scan(s3_sql_fixture& fixture,
   auto const scan_start  = bench_clock::now();
   auto [table, metadata] = cudf::io::read_parquet(std::move(sources), std::move(metadatas), opts);
   (void)metadata;
-  auto const scan_stop = bench_clock::now();
-  auto const wall_stop = bench_clock::now();
-  auto const after     = rest->perf_snapshot();
-  auto const micro     = delta_snapshot(after, before);
+  auto const scan_stop  = bench_clock::now();
+  auto const wall_stop  = bench_clock::now();
+  auto const after      = rest.perf_snapshot();
+  auto const bind_micro = delta_snapshot(after_footer, before);
+  auto const micro      = delta_snapshot(after, before);
 
   return rest_bench_measurement{elapsed_ms(wall_start, wall_stop),
                                 elapsed_ms(open_start, open_stop),
@@ -873,6 +892,7 @@ rest_bench_measurement run_rest_parquet_scan(s3_sql_fixture& fixture,
                                 elapsed_ms(scan_start, scan_stop),
                                 micro.payload_bytes_read_total,
                                 static_cast<duckdb::idx_t>(table->num_rows()),
+                                bind_micro,
                                 micro};
 }
 
@@ -898,6 +918,7 @@ struct bench_record {
   std::uint64_t payload_bytes_read{0};
   duckdb::idx_t row_count{0};
   double effective_bytes_per_sec{0.0};
+  std::uint64_t bind_chunk_get_count{0};
   std::uint64_t chunk_get_ns_total{0};
   std::uint64_t chunk_get_count{0};
   std::uint64_t chunk_get_ns_max{0};
@@ -943,6 +964,7 @@ bench_record make_record(std::string scenario,
                       measurement.payload_bytes_read,
                       measurement.rows,
                       effective,
+                      measurement.bind_micro.chunk_get_count,
                       micro.chunk_get_ns_total,
                       micro.chunk_get_count,
                       micro.chunk_get_ns_max,
@@ -959,6 +981,21 @@ bench_record make_record(std::string scenario,
                       micro.terminal_failures_total,
                       micro.device_stream_sync_total,
                       {}};
+}
+
+void warn_footer_probe_ab(std::string_view label,
+                          bench_record const& generic,
+                          bench_record const& probe)
+{
+  double const generic_bind = generic.open_ms + generic.footer_fetch_ms;
+  double const probe_bind   = probe.open_ms + probe.footer_fetch_ms;
+  WARN("[footerbind A/B] " << label << " bind(open+footer) generic=" << generic_bind << "ms"
+                           << " (bind_chunk_get=" << generic.bind_chunk_get_count
+                           << ", total_chunk_get=" << generic.chunk_get_count
+                           << ") probe=" << probe_bind << "ms"
+                           << " (bind_chunk_get=" << probe.bind_chunk_get_count
+                           << ", total_chunk_get=" << probe.chunk_get_count << ") collapse="
+                           << (probe_bind > 0.0 ? generic_bind / probe_bind : 0.0) << "x");
 }
 
 std::string json_escape(std::string_view value)
@@ -994,6 +1031,12 @@ std::string transport_signature(std::string const& endpoint)
 std::string prefetch_cache_signature(bool enable_prefetch_cache)
 {
   return enable_prefetch_cache ? "on" : "off";
+}
+
+std::string footer_probe_scenario_name(std::string scenario, bool use_footer_probe)
+{
+  if (use_footer_probe) { scenario += "_probe"; }
+  return scenario;
 }
 
 fs::path unittest_log_dir()
@@ -1219,6 +1262,7 @@ void write_perf_json(fs::path const& path,
         << "\"payload_bytes_read\": " << r.payload_bytes_read << ", "
         << "\"row_count\": " << r.row_count << ", "
         << "\"effective_bytes_per_sec\": " << r.effective_bytes_per_sec << ", "
+        << "\"bind_chunk_get_count\": " << r.bind_chunk_get_count << ", "
         << "\"chunk_get_ns_total\": " << r.chunk_get_ns_total << ", "
         << "\"chunk_get_count\": " << r.chunk_get_count << ", "
         << "\"chunk_get_ns_max\": " << r.chunk_get_ns_max << ", "
@@ -1278,6 +1322,7 @@ void append_perf_history_jsonl(fs::path const& path,
         << "\",\"max_connections\":" << r.max_connections
         << ",\"rest_n_reactors\":" << r.rest_n_reactors
         << ",\"payload_bytes_read\":" << r.payload_bytes_read << ",\"row_count\":" << r.row_count
+        << ",\"bind_chunk_get_count\":" << r.bind_chunk_get_count
         << ",\"wall_clock_ms\":" << std::fixed << std::setprecision(3) << r.wall_clock_ms
         << ",\"effective_bytes_per_sec\":" << r.effective_bytes_per_sec
         << ",\"retries_total\":" << r.retries_total
@@ -1309,6 +1354,7 @@ void require_perf_json_schema(fs::path const& path, std::vector<std::string> exp
                    "\"payload_bytes_read\"",
                    "\"row_count\"",
                    "\"effective_bytes_per_sec\"",
+                   "\"bind_chunk_get_count\"",
                    "\"chunk_get_ns_total\"",
                    "\"chunk_get_count\"",
                    "\"chunk_get_ns_max\"",
@@ -1407,12 +1453,14 @@ bench_record run_rest_minio_bench_scenario(
   std::vector<std::string> columns,
   std::optional<std::size_t> rest_max_connections = std::nullopt,
   std::optional<std::size_t> rest_n_reactors      = std::nullopt,
-  bool enable_prefetch_cache                      = true)
+  bool enable_prefetch_cache                      = true,
+  bool use_footer_probe                           = false)
 {
   INFO("scenario=" << scenario << " columns=" << columns.size()
                    << " max_connections=" << rest_max_connections.value_or(std::size_t{8})
                    << " rest_n_reactors=" << rest_n_reactors.value_or(std::size_t{2})
-                   << " enable_prefetch_cache=" << enable_prefetch_cache);
+                   << " enable_prefetch_cache=" << enable_prefetch_cache
+                   << " use_footer_probe=" << use_footer_probe);
   auto limits                      = large_sirius_memory_limits(enable_prefetch_cache);
   limits.rest_perf_instrumentation = perf_instrumentation;
   limits.rest_max_connections      = rest_max_connections;
@@ -1431,7 +1479,7 @@ bench_record run_rest_minio_bench_scenario(
     limits.host_capacity = "12 GiB";
   }
   s3_sql_fixture fixture(env, limits, std::nullopt, endpoint, std::move(ca_bundle), tls_verify);
-  auto measurement = run_rest_parquet_scan(fixture, large.uri, columns);
+  auto measurement = run_rest_parquet_scan(fixture, large.uri, columns, use_footer_probe);
   CHECK(measurement.rows == large.total_num_rows);
   CHECK(measurement.payload_bytes_read > 0);
   CHECK(measurement.open_ms > 0.0);
@@ -1440,9 +1488,12 @@ bench_record run_rest_minio_bench_scenario(
   CHECK(measurement.scan_ms > 0.0);
   CHECK(measurement.wall_clock_ms + 0.001 >=
         measurement.open_ms + measurement.footer_fetch_ms + measurement.scan_ms);
+  if (perf_instrumentation) {
+    CHECK(measurement.bind_micro.chunk_get_count == (use_footer_probe ? 1 : 2));
+  }
   CHECK(measurement.micro.device_stream_sync_total == 0);
   CHECK(measurement.micro.terminal_failures_total == 0);
-  return make_record(std::move(scenario),
+  return make_record(footer_probe_scenario_name(std::move(scenario), use_footer_probe),
                      transport_signature(endpoint),
                      projection_signature(columns),
                      rest_max_connections.value_or(std::size_t{8}),
@@ -1457,10 +1508,12 @@ bench_record run_rest_aws_bench_scenario(s3_test_env const& env,
                                          std::string scenario,
                                          std::vector<std::string> columns,
                                          std::size_t rest_max_connections,
-                                         std::optional<duckdb::idx_t> expected_rows)
+                                         std::optional<duckdb::idx_t> expected_rows,
+                                         bool use_footer_probe = false)
 {
   INFO("scenario=" << scenario << " key=" << aws_bench_lineitem_key()
-                   << " columns=" << columns.size() << " max_connections=" << rest_max_connections);
+                   << " columns=" << columns.size() << " max_connections=" << rest_max_connections
+                   << " use_footer_probe=" << use_footer_probe);
   auto limits                      = large_sirius_memory_limits(/*enable_prefetch_cache=*/true);
   limits.rest_perf_instrumentation = true;
   limits.rest_max_connections      = rest_max_connections;
@@ -1475,13 +1528,14 @@ bench_record run_rest_aws_bench_scenario(s3_test_env const& env,
                          env.endpoint,
                          std::nullopt,
                          /*tls_verify=*/true);
-  auto measurement = run_rest_parquet_scan(fixture, uri, columns);
+  auto measurement = run_rest_parquet_scan(fixture, uri, columns, use_footer_probe);
   CHECK(measurement.rows > 0);
   if (expected_rows.has_value()) { CHECK(measurement.rows == *expected_rows); }
   CHECK(measurement.payload_bytes_read > 0);
+  CHECK(measurement.bind_micro.chunk_get_count >= (use_footer_probe ? 1 : 2));
   CHECK(measurement.micro.device_stream_sync_total == 0);
   CHECK(measurement.micro.terminal_failures_total == 0);
-  return make_record(std::move(scenario),
+  return make_record(footer_probe_scenario_name(std::move(scenario), use_footer_probe),
                      "https",
                      projection_signature(columns),
                      rest_max_connections,
@@ -1844,7 +1898,7 @@ TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][
   auto constexpr backend = std::string_view{"rest_minio"};
   auto baseline_json     = read_optional_text_file(perf_baseline_path(backend));
   std::vector<bench_record> records;
-  records.reserve(4);
+  records.reserve(6);
 
   // compat_* mirrors the old async-S3 benchmark shape: seven projected columns,
   // mc=32, and no scan-manager prefetch cache mixed into the raw S3 read path.
@@ -1878,6 +1932,18 @@ TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][
                                             false,
                                             /*perf_instrumentation=*/true,
                                             bench_single_column_projection());
+  auto http_probe   = run_rest_minio_bench_scenario(*env,
+                                                  *large,
+                                                  "async_http",
+                                                  env->endpoint,
+                                                  std::nullopt,
+                                                  false,
+                                                  /*perf_instrumentation=*/true,
+                                                  bench_single_column_projection(),
+                                                  std::nullopt,
+                                                  std::nullopt,
+                                                  /*enable_prefetch_cache=*/true,
+                                                  /*use_footer_probe=*/true);
   auto https        = run_rest_minio_bench_scenario(*env,
                                              *large,
                                              "async_https",
@@ -1886,9 +1952,25 @@ TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][
                                              true,
                                              /*perf_instrumentation=*/true,
                                              bench_single_column_projection());
+  auto https_probe  = run_rest_minio_bench_scenario(*env,
+                                                   *large,
+                                                   "async_https",
+                                                   env->https_endpoint,
+                                                   env->ca_bundle_path,
+                                                   true,
+                                                   /*perf_instrumentation=*/true,
+                                                   bench_single_column_projection(),
+                                                   std::nullopt,
+                                                   std::nullopt,
+                                                   /*enable_prefetch_cache=*/true,
+                                                   /*use_footer_probe=*/true);
 
-  for (auto const& r :
-       {std::cref(http), std::cref(https), std::cref(compat_http), std::cref(compat_https)}) {
+  for (auto const& r : {std::cref(http),
+                        std::cref(http_probe),
+                        std::cref(https),
+                        std::cref(https_probe),
+                        std::cref(compat_http),
+                        std::cref(compat_https)}) {
     auto const& record = r.get();
     CHECK(record.row_count == large->total_num_rows);
     CHECK(record.payload_bytes_read > 0);
@@ -1909,6 +1991,13 @@ TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][
 
   CHECK(http.row_count == https.row_count);
   CHECK(http.payload_bytes_read == https.payload_bytes_read);
+  CHECK(http.row_count == http_probe.row_count);
+  CHECK(https.row_count == https_probe.row_count);
+  CHECK(http_probe.payload_bytes_read == https_probe.payload_bytes_read);
+  CHECK(http.bind_chunk_get_count == 2);
+  CHECK(http_probe.bind_chunk_get_count == 1);
+  CHECK(https.bind_chunk_get_count == 2);
+  CHECK(https_probe.bind_chunk_get_count == 1);
   CHECK(compat_http.row_count == compat_https.row_count);
   CHECK(compat_http.payload_bytes_read == compat_https.payload_bytes_read);
   if (https.footer_fetch_ms > http.footer_fetch_ms * 3.0) {
@@ -1925,6 +2014,8 @@ TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][
   WARN("S3 REST perf async_https throughput=" << https.effective_bytes_per_sec
                                               << " B/s footer_fetch_ms=" << https.footer_fetch_ms
                                               << " chunk_get_ms_mean=" << https.chunk_get_ms_mean);
+  warn_footer_probe_ab("async_http", http, http_probe);
+  warn_footer_probe_ab("async_https", https, https_probe);
   WARN("S3 REST perf compat_http throughput="
        << compat_http.effective_bytes_per_sec << " B/s footer_fetch_ms="
        << compat_http.footer_fetch_ms << " chunk_get_ms_mean=" << compat_http.chunk_get_ms_mean
@@ -1935,14 +2026,18 @@ TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][
        << " chunk_get_count=" << compat_https.chunk_get_count);
 
   attach_baseline_comparison(http, baseline_json, backend);
+  attach_baseline_comparison(http_probe, baseline_json, backend);
   attach_baseline_comparison(https, baseline_json, backend);
+  attach_baseline_comparison(https_probe, baseline_json, backend);
   attach_baseline_comparison(compat_http, baseline_json, backend);
   attach_baseline_comparison(compat_https, baseline_json, backend);
   records.push_back(std::move(http));
+  records.push_back(std::move(http_probe));
   records.push_back(std::move(https));
+  records.push_back(std::move(https_probe));
   records.push_back(std::move(compat_http));
   records.push_back(std::move(compat_https));
-  REQUIRE(records.size() >= 4);
+  REQUIRE(records.size() >= 6);
 
   auto const path = perf_json_path();
   write_perf_json(path,
@@ -1951,7 +2046,13 @@ TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][
                   sf10_lineitem_key(),
                   static_cast<std::uint64_t>(fs::file_size(large->local_path)),
                   records);
-  require_perf_json_schema(path, {"async_http", "async_https", "compat_http", "compat_https"});
+  require_perf_json_schema(path,
+                           {"async_http",
+                            "async_http_probe",
+                            "async_https",
+                            "async_https_probe",
+                            "compat_http",
+                            "compat_https"});
   WARN("Wrote S3 REST perf JSON baseline to " << path.string());
 }
 
@@ -1967,12 +2068,14 @@ TEST_CASE("S3 REST AWS perf benchmark records projected and full scans",
   auto baseline_json     = read_optional_text_file(perf_baseline_path(backend));
 
   std::vector<bench_record> records;
-  records.reserve(4);
+  records.reserve(8);
 
   std::optional<duckdb::idx_t> projected_rows;
   std::optional<duckdb::idx_t> full_rows;
   std::optional<std::uint64_t> projected_payload_bytes;
+  std::optional<std::uint64_t> projected_probe_payload_bytes;
   std::optional<std::uint64_t> full_payload_bytes;
+  std::optional<std::uint64_t> full_probe_payload_bytes;
 
   for (auto max_connections : {std::size_t{1}, std::size_t{32}}) {
     auto projected = run_rest_aws_bench_scenario(*env,
@@ -1989,6 +2092,7 @@ TEST_CASE("S3 REST AWS perf benchmark records projected and full scans",
     CHECK(projected.payload_bytes_read == *projected_payload_bytes);
     CHECK(projected.terminal_failures_total == 0);
     CHECK(projected.device_stream_sync_total == 0);
+    CHECK(projected.bind_chunk_get_count >= 2);
     WARN("AWS REST projected mc=" << max_connections
                                   << " throughput=" << projected.effective_bytes_per_sec
                                   << " B/s footer_fetch_ms=" << projected.footer_fetch_ms
@@ -1996,6 +2100,29 @@ TEST_CASE("S3 REST AWS perf benchmark records projected and full scans",
                                   << " retries=" << projected.retries_total);
     attach_baseline_comparison(projected, baseline_json, backend);
     records.push_back(std::move(projected));
+
+    auto projected_probe = run_rest_aws_bench_scenario(*env,
+                                                       uri,
+                                                       "aws_https_projected",
+                                                       bench_single_column_projection(),
+                                                       max_connections,
+                                                       projected_rows,
+                                                       /*use_footer_probe=*/true);
+    if (!projected_probe_payload_bytes.has_value()) {
+      projected_probe_payload_bytes = projected_probe.payload_bytes_read;
+    }
+    CHECK(projected_probe.row_count == *projected_rows);
+    CHECK(projected_probe.payload_bytes_read == *projected_probe_payload_bytes);
+    CHECK(projected_probe.terminal_failures_total == 0);
+    CHECK(projected_probe.device_stream_sync_total == 0);
+    CHECK(projected_probe.bind_chunk_get_count >= 1);
+    WARN("AWS REST projected_probe mc="
+         << max_connections << " throughput=" << projected_probe.effective_bytes_per_sec
+         << " B/s footer_fetch_ms=" << projected_probe.footer_fetch_ms
+         << " ttfb_ns=" << projected_probe.ttfb_ns << " retries=" << projected_probe.retries_total);
+    warn_footer_probe_ab("aws_https_projected", records.back(), projected_probe);
+    attach_baseline_comparison(projected_probe, baseline_json, backend);
+    records.push_back(std::move(projected_probe));
 
     auto full = run_rest_aws_bench_scenario(
       *env, uri, "aws_https_full", bench_full_lineitem_projection(), max_connections, full_rows);
@@ -2005,13 +2132,37 @@ TEST_CASE("S3 REST AWS perf benchmark records projected and full scans",
     CHECK(full.payload_bytes_read == *full_payload_bytes);
     CHECK(full.terminal_failures_total == 0);
     CHECK(full.device_stream_sync_total == 0);
+    CHECK(full.bind_chunk_get_count >= 2);
     WARN("AWS REST full mc=" << max_connections << " throughput=" << full.effective_bytes_per_sec
                              << " B/s footer_fetch_ms=" << full.footer_fetch_ms
                              << " ttfb_ns=" << full.ttfb_ns << " retries=" << full.retries_total);
     attach_baseline_comparison(full, baseline_json, backend);
     records.push_back(std::move(full));
+
+    auto full_probe = run_rest_aws_bench_scenario(*env,
+                                                  uri,
+                                                  "aws_https_full",
+                                                  bench_full_lineitem_projection(),
+                                                  max_connections,
+                                                  full_rows,
+                                                  /*use_footer_probe=*/true);
+    if (!full_probe_payload_bytes.has_value()) {
+      full_probe_payload_bytes = full_probe.payload_bytes_read;
+    }
+    CHECK(full_probe.row_count == *full_rows);
+    CHECK(full_probe.payload_bytes_read == *full_probe_payload_bytes);
+    CHECK(full_probe.terminal_failures_total == 0);
+    CHECK(full_probe.device_stream_sync_total == 0);
+    CHECK(full_probe.bind_chunk_get_count >= 1);
+    WARN("AWS REST full_probe mc="
+         << max_connections << " throughput=" << full_probe.effective_bytes_per_sec
+         << " B/s footer_fetch_ms=" << full_probe.footer_fetch_ms
+         << " ttfb_ns=" << full_probe.ttfb_ns << " retries=" << full_probe.retries_total);
+    warn_footer_probe_ab("aws_https_full", records.back(), full_probe);
+    attach_baseline_comparison(full_probe, baseline_json, backend);
+    records.push_back(std::move(full_probe));
   }
-  REQUIRE(records.size() == 4);
+  REQUIRE(records.size() == 8);
 
   auto dataset_bytes = std::uint64_t{0};
   for (auto const& record : records) {
@@ -2021,7 +2172,9 @@ TEST_CASE("S3 REST AWS perf benchmark records projected and full scans",
 
   auto const path = perf_json_path();
   write_perf_json(path, *env, backend, object_key, dataset_bytes, records);
-  require_perf_json_schema(path, {"aws_https_projected", "aws_https_full"});
+  require_perf_json_schema(
+    path,
+    {"aws_https_projected", "aws_https_projected_probe", "aws_https_full", "aws_https_full_probe"});
   append_perf_history_jsonl(
     perf_history_path(backend), *env, backend, object_key, dataset_bytes, records);
   WARN("Wrote AWS S3 REST perf JSON to " << path.string());

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -502,7 +502,7 @@ class range_http_server {
   std::vector<std::thread> _workers;
 };
 
-std::shared_ptr<rest_ioctx> make_direct_rest_ioctx(std::string endpoint)
+sirius::io::rest::config direct_rest_test_config()
 {
   sirius::io::rest::config cfg{};
   cfg.request_timeout_s       = 5;
@@ -512,12 +512,23 @@ std::shared_ptr<rest_ioctx> make_direct_rest_ioctx(std::string endpoint)
   cfg.retry_backoff_base      = std::chrono::milliseconds{1};
   cfg.retry_jitter            = std::chrono::milliseconds{0};
   cfg.honor_retry_after       = false;
-  auto authorizer             = std::make_shared<fixed_url_authorizer>(std::move(endpoint));
-  auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+  return cfg;
+}
+
+std::shared_ptr<rest_ioctx> make_direct_rest_ioctx(std::string endpoint,
+                                                   sirius::io::rest::config cfg)
+{
+  auto authorizer = std::make_shared<fixed_url_authorizer>(std::move(endpoint));
+  auto ctx        = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
     cfg, std::move(authorizer), nullptr);
   auto ioctx = std::make_shared<rest_ioctx>(1, std::move(ctx));
   ioctx->start();
   return ioctx;
+}
+
+std::shared_ptr<rest_ioctx> make_direct_rest_ioctx(std::string endpoint)
+{
+  return make_direct_rest_ioctx(std::move(endpoint), direct_rest_test_config());
 }
 
 }  // namespace
@@ -587,6 +598,76 @@ TEST_CASE("parquet footer bind is served by one suffix GET and then the stash",
 
   CHECK(server.head_count() == 0);
   CHECK(server.get_count() == 1);
+}
+
+TEST_CASE("footer probe open uses the configured suffix window",
+          "[s3][integration][rest][footerbind]")
+{
+  auto const parquet    = read_binary_file(committed_parquet_fixture("nation.parquet"));
+  auto const footer_len = static_cast<std::size_t>(parquet_footer_len(parquet));
+  auto const footer_off = parquet.size() - 8 - footer_len;
+
+  SECTION("tiny configured window misses the footer body and re-GETs it")
+  {
+    std::size_t constexpr suffix_bytes = 8;
+    REQUIRE(footer_len + 8 > suffix_bytes);
+    range_http_server server(parquet);
+    auto cfg               = direct_rest_test_config();
+    cfg.footer_probe_bytes = suffix_bytes;
+    auto ioctx             = make_direct_rest_ioctx(server.endpoint(), cfg);
+    auto datasource        = ioctx->open_datasource("s3://footer-bucket/nation.parquet",
+                                             sirius::io::open_hint::parquet_footer_probe);
+    auto const* rest_object =
+      dynamic_cast<sirius::io::rest::rest_io_object const*>(&datasource->io_object());
+
+    REQUIRE(rest_object != nullptr);
+    CHECK(rest_object->stash_window_lo() == parquet.size() - suffix_bytes);
+    REQUIRE(rest_object->stash() != nullptr);
+    CHECK(rest_object->stash()->size() == suffix_bytes);
+    CHECK(server.head_count() == 0);
+    CHECK(server.get_count() == 1);
+
+    std::vector<std::uint8_t> footer(footer_len);
+    REQUIRE(datasource->host_read(footer_off, footer.size(), footer.data()) == footer.size());
+    require_bytes_equal(footer,
+                        std::span<std::uint8_t const>(parquet.data() + footer_off, footer_len));
+    CHECK(server.head_count() == 0);
+    CHECK(server.get_count() == 2);
+  }
+
+  SECTION("configured window covering the footer serves both cudf footer reads from stash")
+  {
+    auto const suffix_bytes = footer_len + 8;
+    REQUIRE(suffix_bytes <= parquet.size());
+    range_http_server server(parquet);
+    auto cfg               = direct_rest_test_config();
+    cfg.footer_probe_bytes = suffix_bytes;
+    auto ioctx             = make_direct_rest_ioctx(server.endpoint(), cfg);
+    auto datasource        = ioctx->open_datasource("s3://footer-bucket/nation.parquet",
+                                             sirius::io::open_hint::parquet_footer_probe);
+    auto const* rest_object =
+      dynamic_cast<sirius::io::rest::rest_io_object const*>(&datasource->io_object());
+
+    REQUIRE(rest_object != nullptr);
+    CHECK(rest_object->stash_window_lo() == parquet.size() - suffix_bytes);
+    REQUIRE(rest_object->stash() != nullptr);
+    CHECK(rest_object->stash()->size() == suffix_bytes);
+    CHECK(server.head_count() == 0);
+    CHECK(server.get_count() == 1);
+
+    std::array<std::uint8_t, 8> trailer{};
+    REQUIRE(datasource->host_read(
+              parquet.size() - trailer.size(), trailer.size(), trailer.data()) == trailer.size());
+    require_bytes_equal(trailer,
+                        std::span<std::uint8_t const>(parquet.data() + parquet.size() - 8, 8));
+
+    std::vector<std::uint8_t> footer(footer_len);
+    REQUIRE(datasource->host_read(footer_off, footer.size(), footer.data()) == footer.size());
+    require_bytes_equal(footer,
+                        std::span<std::uint8_t const>(parquet.data() + footer_off, footer_len));
+    CHECK(server.head_count() == 0);
+    CHECK(server.get_count() == 1);
+  }
 }
 
 TEST_CASE("footer outside the suffix window falls back to one body GET",
@@ -674,7 +755,7 @@ TEST_CASE("footer suffix probe falls back safely on unusable suffix responses",
     REQUIRE(datasource != nullptr);
     CHECK(datasource->size() == parquet.size());
     CHECK(server.head_count() == 1);
-    CHECK(server.get_count() >= 1);
+    CHECK(server.get_count() == 1);
   }
 
   SECTION("unknown Content-Range total")
@@ -688,7 +769,7 @@ TEST_CASE("footer suffix probe falls back safely on unusable suffix responses",
     REQUIRE(datasource != nullptr);
     CHECK(datasource->size() == parquet.size());
     CHECK(server.head_count() == 1);
-    CHECK(server.get_count() >= 1);
+    CHECK(server.get_count() == 1);
   }
 
   SECTION("server ignores Range with 200 full-body")
@@ -702,7 +783,7 @@ TEST_CASE("footer suffix probe falls back safely on unusable suffix responses",
     REQUIRE(datasource != nullptr);
     CHECK(datasource->size() == parquet.size());
     CHECK(server.head_count() == 1);
-    CHECK(server.get_count() >= 1);
+    CHECK(server.get_count() == 1);
   }
 
   SECTION("server ignores Range with 200 full-body on a large object")
@@ -737,6 +818,62 @@ TEST_CASE("footer suffix probe falls back safely on unusable suffix responses",
     CHECK(datasource->size() == parquet.size());
     CHECK(server.head_count() == 1);
     CHECK(server.get_count() == 1);
+  }
+}
+
+TEST_CASE("footer suffix probe retries transient GET failures",
+          "[s3][integration][rest][footerbind]")
+{
+  auto const parquet = read_binary_file(committed_parquet_fixture("nation.parquet"));
+
+  SECTION("transient 503s are retried and the final 206 produces a probe")
+  {
+    range_fault_policy fault{};
+    fault.fail_first_gets = 2;
+    fault.fail_status     = 503;
+    range_http_server server(parquet, fault);
+    auto authorizer             = std::make_shared<fixed_url_authorizer>(server.endpoint());
+    auto cfg                    = direct_rest_test_config();
+    cfg.max_retry_attempts      = 3;
+    cfg.max_auth_retry_attempts = 1;
+    auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+      cfg, std::move(authorizer), nullptr);
+    sirius::io::rest::rest_reactor reactor(ctx, "footer-suffix-retry-success");
+
+    auto probe = reactor.fetch_footer_suffix("footer-bucket", "nation.parquet", 1UL << 20);
+
+    CHECK(probe.object_size == parquet.size());
+    CHECK(probe.window_lo == 0);
+    REQUIRE(probe.bytes != nullptr);
+    CHECK(probe.bytes->size() == parquet.size());
+    CHECK(server.head_count() == 0);
+    CHECK(server.get_count() == 3);
+  }
+
+  SECTION("exhausted transient 503s throw after the retry budget")
+  {
+    range_fault_policy fault{};
+    fault.fail_all_gets = true;
+    fault.fail_status   = 503;
+    range_http_server server(parquet, fault);
+    auto authorizer             = std::make_shared<fixed_url_authorizer>(server.endpoint());
+    auto cfg                    = direct_rest_test_config();
+    cfg.max_retry_attempts      = 2;
+    cfg.max_auth_retry_attempts = 1;
+    auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+      cfg, std::move(authorizer), nullptr);
+    sirius::io::rest::rest_reactor reactor(ctx, "footer-suffix-retry-exhausted");
+
+    try {
+      (void)reactor.fetch_footer_suffix("footer-bucket", "nation.parquet", 1UL << 20);
+      FAIL("fetch_footer_suffix should throw after exhausting transient retries");
+    } catch (std::runtime_error const& e) {
+      auto const message = std::string{e.what()};
+      CHECK(message.find("exhausted retries") != std::string::npos);
+      CHECK(message.find("HTTP 503") != std::string::npos);
+    }
+    CHECK(server.head_count() == 0);
+    CHECK(server.get_count() == 2);
   }
 }
 

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -16,6 +16,7 @@
 
 #include "catch.hpp"
 #include "io/rest/rest_ioctx.hpp"
+#include "io/s3/s3_request_authorizer.hpp"
 #include "io/sirius_datasource.hpp"
 #include "io/types.hpp"
 #include "memory/topology_index.hpp"
@@ -148,9 +149,23 @@ scan_manager_config make_fake_rest_config(std::string endpoint)
   return cfg;
 }
 
+std::filesystem::path project_root()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return std::filesystem::path{SIRIUS_PROJECT_ROOT};
+#else
+  return std::filesystem::current_path();
+#endif
+}
+
 std::filesystem::path local_fixture_path(std::string const& key)
 {
   return std::filesystem::path{require_env("SIRIUS_TEST_S3_LOCAL_DIR")} / key;
+}
+
+std::filesystem::path committed_parquet_fixture(std::string const& name)
+{
+  return project_root() / "test" / "cpp" / "integration" / "data" / "parquet" / name;
 }
 
 std::vector<std::uint8_t> read_binary_file(std::filesystem::path const& path)
@@ -198,11 +213,48 @@ rest_ioctx* require_rest_ioctx(std::shared_ptr<sirius::io::sirius_datasource> co
   return rest_ctx;
 }
 
+std::uint32_t read_le32(std::span<std::uint8_t const> bytes)
+{
+  REQUIRE(bytes.size() >= 4);
+  return static_cast<std::uint32_t>(bytes[0]) | (static_cast<std::uint32_t>(bytes[1]) << 8U) |
+         (static_cast<std::uint32_t>(bytes[2]) << 16U) |
+         (static_cast<std::uint32_t>(bytes[3]) << 24U);
+}
+
+std::uint32_t parquet_footer_len(std::span<std::uint8_t const> parquet)
+{
+  REQUIRE(parquet.size() >= 8);
+  CHECK(parquet[parquet.size() - 4] == static_cast<std::uint8_t>('P'));
+  CHECK(parquet[parquet.size() - 3] == static_cast<std::uint8_t>('A'));
+  CHECK(parquet[parquet.size() - 2] == static_cast<std::uint8_t>('R'));
+  CHECK(parquet[parquet.size() - 1] == static_cast<std::uint8_t>('1'));
+  return read_le32(parquet.subspan(parquet.size() - 8, 4));
+}
+
 struct range_fault_policy {
   std::size_t fail_first_gets{0};
   bool fail_all_gets{false};
   int fail_status{503};
   std::chrono::milliseconds response_delay{0};
+  bool omit_content_range{false};
+  bool unknown_content_range_total{false};
+  bool ignore_range_with_200{false};
+  bool fail_suffix_with_416{false};
+};
+
+class fixed_url_authorizer final : public sirius::io::s3::s3_request_authorizer {
+ public:
+  explicit fixed_url_authorizer(std::string endpoint) : _endpoint(std::move(endpoint)) {}
+
+  sirius::io::s3::s3_authorized_request authorize(sirius::io::s3::s3_object_ref const& obj,
+                                                  sirius::io::s3::s3_request_method /*method*/,
+                                                  std::chrono::seconds /*timeout*/) override
+  {
+    return {_endpoint + "/" + obj.bucket + "/" + obj.key, {}};
+  }
+
+ private:
+  std::string _endpoint;
 };
 
 class range_http_server {
@@ -256,7 +308,9 @@ class range_http_server {
   range_http_server& operator=(range_http_server const&) = delete;
 
   [[nodiscard]] std::string endpoint() const { return "http://127.0.0.1:" + std::to_string(_port); }
+  [[nodiscard]] std::size_t head_count() const noexcept { return _head_count.load(); }
   [[nodiscard]] std::size_t get_count() const noexcept { return _get_count.load(); }
+  [[nodiscard]] std::size_t body_bytes_sent() const noexcept { return _body_bytes_sent.load(); }
   [[nodiscard]] int peak_active_gets() const noexcept { return _peak_active_gets.load(); }
 
  private:
@@ -305,6 +359,7 @@ class range_http_server {
     bool const is_head = request.rfind("HEAD ", 0) == 0;
     bool const is_get  = request.rfind("GET ", 0) == 0;
     if (is_head) {
+      _head_count.fetch_add(1, std::memory_order_relaxed);
       std::string response =
         "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size()) +
         "\r\nConnection: close\r\n\r\n";
@@ -331,35 +386,68 @@ class range_http_server {
 
     if (auto range = parse_range(request)) {
       auto const [start, end] = *range;
-      auto const len          = end - start + 1;
+      if (_fault.fail_suffix_with_416 && is_suffix_range(request)) {
+        send_all(fd,
+                 "HTTP/1.1 416 Range Not Satisfiable\r\nContent-Length: 0\r\nConnection: "
+                 "close\r\n\r\n");
+        return;
+      }
+      if (_fault.ignore_range_with_200 && is_suffix_range(request)) {
+        std::string response =
+          "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size()) +
+          "\r\nConnection: close\r\n\r\n";
+        send_all(fd, response);
+        send_body(fd, _object.data(), _object.size());
+        return;
+      }
+      auto const len = end - start + 1;
       std::string response =
-        "HTTP/1.1 206 Partial Content\r\nContent-Length: " + std::to_string(len) +
-        "\r\nContent-Range: bytes " + std::to_string(start) + "-" + std::to_string(end) + "/" +
-        std::to_string(_object.size()) + "\r\nConnection: close\r\n\r\n";
+        "HTTP/1.1 206 Partial Content\r\nContent-Length: " + std::to_string(len);
+      if (!_fault.omit_content_range) {
+        response +=
+          "\r\nContent-Range: bytes " + std::to_string(start) + "-" + std::to_string(end) + "/" +
+          (_fault.unknown_content_range_total ? std::string{"*"} : std::to_string(_object.size()));
+      }
+      response += "\r\nConnection: close\r\n\r\n";
       send_all(fd, response);
-      send_all(fd, _object.data() + start, len);
+      send_body(fd, _object.data() + start, len);
       return;
     }
 
     std::string response = "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size()) +
                            "\r\nConnection: close\r\n\r\n";
     send_all(fd, response);
-    send_all(fd, _object.data(), _object.size());
+    send_body(fd, _object.data(), _object.size());
+  }
+
+  [[nodiscard]] static bool is_suffix_range(std::string const& request)
+  {
+    std::string lower = request;
+    std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
+    return lower.find("range: bytes=-") != std::string::npos;
+  }
+
+  void send_body(int fd, std::uint8_t const* bytes, std::size_t size)
+  {
+    _body_bytes_sent.fetch_add(send_all(fd, bytes, size), std::memory_order_relaxed);
   }
 
   static void send_all(int fd, std::string_view bytes)
   {
-    send_all(fd, reinterpret_cast<std::uint8_t const*>(bytes.data()), bytes.size());
+    (void)send_all(fd, reinterpret_cast<std::uint8_t const*>(bytes.data()), bytes.size());
   }
 
-  static void send_all(int fd, std::uint8_t const* bytes, std::size_t size)
+  static std::size_t send_all(int fd, std::uint8_t const* bytes, std::size_t size)
   {
     std::size_t sent = 0;
     while (sent < size) {
       ssize_t n = ::send(fd, bytes + sent, size - sent, MSG_NOSIGNAL);
-      if (n <= 0) { return; }
+      if (n <= 0) { return sent; }
       sent += static_cast<std::size_t>(n);
     }
+    return sent;
   }
 
   [[nodiscard]] std::optional<std::pair<std::size_t, std::size_t>> parse_range(
@@ -379,9 +467,16 @@ class range_http_server {
     auto const dash    = spec.find('-');
     if (dash == std::string::npos) { return std::nullopt; }
     try {
-      std::size_t start = static_cast<std::size_t>(std::stoull(spec.substr(0, dash)));
+      std::size_t start = 0;
       std::size_t end   = _object.size() - 1;
-      if (dash + 1 < spec.size()) {
+      if (dash == 0) {
+        auto const suffix = static_cast<std::size_t>(std::stoull(spec.substr(1)));
+        if (suffix == 0) { return std::nullopt; }
+        start = suffix >= _object.size() ? 0 : _object.size() - suffix;
+      } else {
+        start = static_cast<std::size_t>(std::stoull(spec.substr(0, dash)));
+      }
+      if (dash != 0 && dash + 1 < spec.size()) {
         end = static_cast<std::size_t>(std::stoull(spec.substr(dash + 1)));
       }
       if (start >= _object.size()) { return std::nullopt; }
@@ -398,14 +493,299 @@ class range_http_server {
   std::vector<std::uint8_t> _object;
   range_fault_policy _fault;
   std::atomic<bool> _stop{false};
+  std::atomic<std::size_t> _head_count{0};
   std::atomic<std::size_t> _get_count{0};
+  std::atomic<std::size_t> _body_bytes_sent{0};
   std::atomic<int> _active_gets{0};
   std::atomic<int> _peak_active_gets{0};
   std::thread _thread;
   std::vector<std::thread> _workers;
 };
 
+std::shared_ptr<rest_ioctx> make_direct_rest_ioctx(std::string endpoint)
+{
+  sirius::io::rest::config cfg{};
+  cfg.request_timeout_s       = 5;
+  cfg.max_connections         = 4;
+  cfg.max_retry_attempts      = 2;
+  cfg.max_auth_retry_attempts = 1;
+  cfg.retry_backoff_base      = std::chrono::milliseconds{1};
+  cfg.retry_jitter            = std::chrono::milliseconds{0};
+  cfg.honor_retry_after       = false;
+  auto authorizer             = std::make_shared<fixed_url_authorizer>(std::move(endpoint));
+  auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+    cfg, std::move(authorizer), nullptr);
+  auto ioctx = std::make_shared<rest_ioctx>(1, std::move(ctx));
+  ioctx->start();
+  return ioctx;
+}
+
 }  // namespace
+
+TEST_CASE("rest footer suffix parses Content-Range totals", "[s3][integration][rest][footerbind]")
+{
+  using sirius::io::rest::content_range_total;
+
+  CHECK(content_range_total("bytes 42-99/12345") == std::optional<std::size_t>{12345});
+  CHECK(content_range_total("Bytes 0-7/8") == std::optional<std::size_t>{8});
+  CHECK_FALSE(content_range_total("bytes 42-99/*").has_value());
+  CHECK_FALSE(content_range_total("bytes */12345").has_value());
+  CHECK_FALSE(content_range_total("not-a-content-range").has_value());
+}
+
+TEST_CASE("rest footer suffix probe discovers size without HEAD",
+          "[s3][integration][rest][footerbind]")
+{
+  auto const parquet = read_binary_file(committed_parquet_fixture("nation.parquet"));
+  range_http_server server(parquet);
+  auto authorizer = std::make_shared<fixed_url_authorizer>(server.endpoint());
+  sirius::io::rest::config cfg{};
+  cfg.request_timeout_s       = 5;
+  cfg.max_retry_attempts      = 1;
+  cfg.max_auth_retry_attempts = 1;
+  auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+    cfg, std::move(authorizer), nullptr);
+  sirius::io::rest::rest_reactor reactor(ctx, "footer-suffix-test");
+
+  auto probe = reactor.fetch_footer_suffix("footer-bucket", "nation.parquet", 1UL << 20);
+
+  CHECK(probe.object_size == parquet.size());
+  CHECK(probe.window_lo == 0);
+  REQUIRE(probe.bytes != nullptr);
+  CHECK(probe.bytes->size() == parquet.size());
+  CHECK(server.head_count() == 0);
+  CHECK(server.get_count() == 1);
+}
+
+TEST_CASE("parquet footer bind is served by one suffix GET and then the stash",
+          "[s3][integration][rest][footerbind]")
+{
+  auto const parquet    = read_binary_file(committed_parquet_fixture("nation.parquet"));
+  auto const footer_len = static_cast<std::size_t>(parquet_footer_len(parquet));
+  auto const footer_off = parquet.size() - 8 - footer_len;
+  range_http_server server(parquet);
+  auto ioctx = make_direct_rest_ioctx(server.endpoint());
+
+  auto datasource = ioctx->open_datasource("s3://footer-bucket/nation.parquet",
+                                           sirius::io::open_hint::parquet_footer_probe);
+
+  REQUIRE(datasource != nullptr);
+  CHECK(datasource->size() == parquet.size());
+  CHECK(server.head_count() == 0);
+  CHECK(server.get_count() == 1);
+
+  std::array<std::uint8_t, 8> trailer{};
+  REQUIRE(datasource->host_read(parquet.size() - trailer.size(), trailer.size(), trailer.data()) ==
+          trailer.size());
+  require_bytes_equal(trailer,
+                      std::span<std::uint8_t const>(parquet.data() + parquet.size() - 8, 8));
+
+  std::vector<std::uint8_t> footer(footer_len);
+  REQUIRE(datasource->host_read(footer_off, footer.size(), footer.data()) == footer.size());
+  require_bytes_equal(footer,
+                      std::span<std::uint8_t const>(parquet.data() + footer_off, footer_len));
+
+  CHECK(server.head_count() == 0);
+  CHECK(server.get_count() == 1);
+}
+
+TEST_CASE("footer outside the suffix window falls back to one body GET",
+          "[s3][integration][rest][footerbind]")
+{
+  auto const parquet             = read_binary_file(committed_parquet_fixture("nation.parquet"));
+  auto const footer_len          = static_cast<std::size_t>(parquet_footer_len(parquet));
+  auto const footer_off          = parquet.size() - 8 - footer_len;
+  std::size_t const suffix_bytes = 8;
+  REQUIRE(footer_len + 8 > suffix_bytes);
+  range_http_server server(parquet);
+  auto authorizer = std::make_shared<fixed_url_authorizer>(server.endpoint());
+  sirius::io::rest::config cfg{};
+  cfg.request_timeout_s       = 5;
+  cfg.max_retry_attempts      = 1;
+  cfg.max_auth_retry_attempts = 1;
+  auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+    cfg, std::move(authorizer), nullptr);
+  sirius::io::rest::rest_reactor reactor(ctx, "footer-window-test");
+  reactor.start();
+
+  auto probe = reactor.fetch_footer_suffix("footer-bucket", "nation.parquet", suffix_bytes);
+  CHECK(probe.object_size == parquet.size());
+  CHECK(probe.window_lo == parquet.size() - suffix_bytes);
+  REQUIRE(probe.bytes != nullptr);
+
+  sirius::io::rest::rest_io_object object("s3://footer-bucket/nation.parquet",
+                                          "footer-bucket",
+                                          "nation.parquet",
+                                          probe.object_size,
+                                          probe.window_lo,
+                                          probe.bytes);
+  CHECK(server.get_count() == 1);
+
+  std::vector<std::uint8_t> footer(footer_len);
+  REQUIRE(reactor.host_read(object, footer_off, footer.size(), footer.data()) == footer.size());
+  require_bytes_equal(footer,
+                      std::span<std::uint8_t const>(parquet.data() + footer_off, footer_len));
+  CHECK(server.head_count() == 0);
+  CHECK(server.get_count() == 2);
+}
+
+TEST_CASE("describe_parquet over S3 uses footer probe and preserves schema",
+          "[s3][integration][rest][footerbind]")
+{
+  auto const parquet = read_binary_file(committed_parquet_fixture("nation.parquet"));
+  range_http_server server(parquet);
+  scan_manager_fixture fixture;
+  sirius_scan_manager manager{
+    make_fake_rest_config(server.endpoint()), *fixture.memory, fixture.topology};
+
+  auto result = manager.describe_parquet("s3://footer-bucket/nation.parquet");
+
+  CHECK(result.object_size == parquet.size());
+  CHECK(result.total_num_rows == 25);
+  REQUIRE(result.names.size() == 4);
+  CHECK(result.names[0] == "n_nationkey");
+  CHECK(result.names[1] == "n_name");
+  CHECK(result.names[2] == "n_regionkey");
+  CHECK(result.names[3] == "n_comment");
+  CHECK(server.head_count() == 0);
+  CHECK(server.get_count() == 1);
+
+  auto second = manager.describe_parquet("s3://footer-bucket/nation.parquet");
+  CHECK(second.object_size == result.object_size);
+  CHECK(second.total_num_rows == result.total_num_rows);
+  CHECK(second.names == result.names);
+  CHECK(server.head_count() == 1);
+  CHECK(server.get_count() == 1);
+}
+
+TEST_CASE("footer suffix probe falls back safely on unusable suffix responses",
+          "[s3][integration][rest][footerbind]")
+{
+  auto const parquet = read_binary_file(committed_parquet_fixture("nation.parquet"));
+
+  SECTION("missing Content-Range")
+  {
+    range_fault_policy fault{};
+    fault.omit_content_range = true;
+    range_http_server server(parquet, fault);
+    auto ioctx      = make_direct_rest_ioctx(server.endpoint());
+    auto datasource = ioctx->open_datasource("s3://footer-bucket/nation.parquet",
+                                             sirius::io::open_hint::parquet_footer_probe);
+    REQUIRE(datasource != nullptr);
+    CHECK(datasource->size() == parquet.size());
+    CHECK(server.head_count() == 1);
+    CHECK(server.get_count() >= 1);
+  }
+
+  SECTION("unknown Content-Range total")
+  {
+    range_fault_policy fault{};
+    fault.unknown_content_range_total = true;
+    range_http_server server(parquet, fault);
+    auto ioctx      = make_direct_rest_ioctx(server.endpoint());
+    auto datasource = ioctx->open_datasource("s3://footer-bucket/nation.parquet",
+                                             sirius::io::open_hint::parquet_footer_probe);
+    REQUIRE(datasource != nullptr);
+    CHECK(datasource->size() == parquet.size());
+    CHECK(server.head_count() == 1);
+    CHECK(server.get_count() >= 1);
+  }
+
+  SECTION("server ignores Range with 200 full-body")
+  {
+    range_fault_policy fault{};
+    fault.ignore_range_with_200 = true;
+    range_http_server server(parquet, fault);
+    auto ioctx      = make_direct_rest_ioctx(server.endpoint());
+    auto datasource = ioctx->open_datasource("s3://footer-bucket/nation.parquet",
+                                             sirius::io::open_hint::parquet_footer_probe);
+    REQUIRE(datasource != nullptr);
+    CHECK(datasource->size() == parquet.size());
+    CHECK(server.head_count() == 1);
+    CHECK(server.get_count() >= 1);
+  }
+
+  SECTION("server ignores Range with 200 full-body on a large object")
+  {
+    auto payload = deterministic_payload(8 * 1024 * 1024);
+    range_fault_policy fault{};
+    fault.ignore_range_with_200 = true;
+    range_http_server server(payload, fault);
+    auto ioctx = make_direct_rest_ioctx(server.endpoint());
+
+    auto datasource = ioctx->open_datasource("s3://footer-bucket/large.bin",
+                                             sirius::io::open_hint::parquet_footer_probe);
+
+    REQUIRE(datasource != nullptr);
+    CHECK(datasource->size() == payload.size());
+    CHECK(server.head_count() == 1);
+    CHECK(server.get_count() == 1);
+    CHECK(server.body_bytes_sent() < payload.size());
+  }
+
+  SECTION("suffix 416 falls back to HEAD")
+  {
+    range_fault_policy fault{};
+    fault.fail_suffix_with_416 = true;
+    range_http_server server(parquet, fault);
+    auto ioctx = make_direct_rest_ioctx(server.endpoint());
+
+    auto datasource = ioctx->open_datasource("s3://footer-bucket/nation.parquet",
+                                             sirius::io::open_hint::parquet_footer_probe);
+
+    REQUIRE(datasource != nullptr);
+    CHECK(datasource->size() == parquet.size());
+    CHECK(server.head_count() == 1);
+    CHECK(server.get_count() == 1);
+  }
+}
+
+TEST_CASE("small objects can be resolved by one suffix probe",
+          "[s3][integration][rest][footerbind]")
+{
+  auto payload = deterministic_payload(512);
+  range_http_server server(payload);
+  auto authorizer = std::make_shared<fixed_url_authorizer>(server.endpoint());
+  sirius::io::rest::config cfg{};
+  cfg.request_timeout_s       = 5;
+  cfg.max_retry_attempts      = 1;
+  cfg.max_auth_retry_attempts = 1;
+  auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+    cfg, std::move(authorizer), nullptr);
+  sirius::io::rest::rest_reactor reactor(ctx, "small-footer-suffix-test");
+
+  auto probe = reactor.fetch_footer_suffix("footer-bucket", "small.bin", 1UL << 20);
+
+  CHECK(probe.object_size == payload.size());
+  CHECK(probe.window_lo == 0);
+  REQUIRE(probe.bytes != nullptr);
+  CHECK(probe.bytes->size() == payload.size());
+  CHECK(server.head_count() == 0);
+  CHECK(server.get_count() == 1);
+}
+
+TEST_CASE("concurrent footer probes each get an object-local suffix stash",
+          "[s3][integration][rest][footerbind]")
+{
+  auto const parquet = read_binary_file(committed_parquet_fixture("nation.parquet"));
+  range_http_server server(parquet);
+  auto ioctx            = make_direct_rest_ioctx(server.endpoint());
+  std::string const uri = "s3://footer-bucket/nation.parquet";
+
+  std::vector<std::future<std::size_t>> futures;
+  for (int i = 0; i < 8; ++i) {
+    futures.push_back(std::async(std::launch::async, [ioctx, uri] {
+      auto datasource = ioctx->open_datasource(uri, sirius::io::open_hint::parquet_footer_probe);
+      return datasource->size();
+    }));
+  }
+
+  for (auto& f : futures) {
+    CHECK(f.get() == parquet.size());
+  }
+  CHECK(server.head_count() == 0);
+  CHECK(server.get_count() == futures.size());
+}
 
 TEST_CASE("rest_ioctx reads the MinIO hello fixture through scan_manager create_datasource",
           "[s3][integration][rest]")

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -848,6 +848,9 @@ TEST_CASE("footer suffix probe retries transient GET failures",
     CHECK(probe.bytes->size() == parquet.size());
     CHECK(server.head_count() == 0);
     CHECK(server.get_count() == 3);
+    auto const perf = reactor.perf_snapshot();
+    CHECK(perf.retries_total == 2);
+    CHECK(perf.terminal_failures_total == 0);
   }
 
   SECTION("exhausted transient 503s throw after the retry budget")
@@ -874,6 +877,61 @@ TEST_CASE("footer suffix probe retries transient GET failures",
     }
     CHECK(server.head_count() == 0);
     CHECK(server.get_count() == 2);
+    auto const perf = reactor.perf_snapshot();
+    CHECK(perf.retries_total == cfg.max_retry_attempts - 1);
+    CHECK(perf.terminal_failures_total == 1);
+  }
+
+  SECTION("hard non-retriable errors fail without retrying")
+  {
+    range_fault_policy fault{};
+    fault.fail_all_gets = true;
+    fault.fail_status   = 403;
+    range_http_server server(parquet, fault);
+    auto authorizer             = std::make_shared<fixed_url_authorizer>(server.endpoint());
+    auto cfg                    = direct_rest_test_config();
+    cfg.max_retry_attempts      = 3;
+    cfg.max_auth_retry_attempts = 1;
+    auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+      cfg, std::move(authorizer), nullptr);
+    sirius::io::rest::rest_reactor reactor(ctx, "footer-suffix-hard-failure");
+
+    try {
+      (void)reactor.fetch_footer_suffix("footer-bucket", "nation.parquet", 1UL << 20);
+      FAIL("fetch_footer_suffix should throw on a hard non-retriable HTTP error");
+    } catch (std::runtime_error const& e) {
+      auto const message = std::string{e.what()};
+      CHECK(message.find("HTTP 403") != std::string::npos);
+    }
+    CHECK(server.head_count() == 0);
+    CHECK(server.get_count() == 1);
+    auto const perf = reactor.perf_snapshot();
+    CHECK(perf.retries_total == 0);
+    CHECK(perf.terminal_failures_total == 1);
+  }
+
+  SECTION("clean 206 has no retry or terminal-failure telemetry")
+  {
+    range_http_server server(parquet);
+    auto authorizer             = std::make_shared<fixed_url_authorizer>(server.endpoint());
+    auto cfg                    = direct_rest_test_config();
+    cfg.max_retry_attempts      = 3;
+    cfg.max_auth_retry_attempts = 1;
+    auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+      cfg, std::move(authorizer), nullptr);
+    sirius::io::rest::rest_reactor reactor(ctx, "footer-suffix-clean");
+
+    auto probe = reactor.fetch_footer_suffix("footer-bucket", "nation.parquet", 1UL << 20);
+
+    CHECK(probe.object_size == parquet.size());
+    CHECK(probe.window_lo == 0);
+    REQUIRE(probe.bytes != nullptr);
+    CHECK(probe.bytes->size() == parquet.size());
+    CHECK(server.head_count() == 0);
+    CHECK(server.get_count() == 1);
+    auto const perf = reactor.perf_snapshot();
+    CHECK(perf.retries_total == 0);
+    CHECK(perf.terminal_failures_total == 0);
   }
 }
 

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -32,6 +32,8 @@
 #include <arpa/inet.h>
 #include <cucascade/memory/topology_discovery.hpp>
 #include <netinet/in.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/spdlog.h>
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -51,6 +53,7 @@
 #include <future>
 #include <iterator>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <span>
 #include <stdexcept>
@@ -234,7 +237,10 @@ std::uint32_t parquet_footer_len(std::span<std::uint8_t const> parquet)
 struct range_fault_policy {
   std::size_t fail_first_gets{0};
   bool fail_all_gets{false};
+  std::size_t fail_first_heads{0};
+  bool fail_all_heads{false};
   int fail_status{503};
+  int fail_head_status{503};
   std::chrono::milliseconds response_delay{0};
   bool omit_content_range{false};
   bool unknown_content_range_total{false};
@@ -359,7 +365,14 @@ class range_http_server {
     bool const is_head = request.rfind("HEAD ", 0) == 0;
     bool const is_get  = request.rfind("GET ", 0) == 0;
     if (is_head) {
-      _head_count.fetch_add(1, std::memory_order_relaxed);
+      auto const head_idx = _head_count.fetch_add(1, std::memory_order_relaxed);
+      if (_fault.fail_all_heads || head_idx < _fault.fail_first_heads) {
+        std::string response =
+          "HTTP/1.1 " + std::to_string(_fault.fail_head_status) +
+          " Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+        send_all(fd, response);
+        return;
+      }
       std::string response =
         "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size()) +
         "\r\nConnection: close\r\n\r\n";
@@ -530,6 +543,62 @@ std::shared_ptr<rest_ioctx> make_direct_rest_ioctx(std::string endpoint)
 {
   return make_direct_rest_ioctx(std::move(endpoint), direct_rest_test_config());
 }
+
+class capture_sink final : public spdlog::sinks::base_sink<std::mutex> {
+ public:
+  struct record {
+    spdlog::level::level_enum level;
+    std::string payload;
+  };
+
+  [[nodiscard]] std::vector<record> records() const
+  {
+    std::lock_guard<std::mutex> lock(_records_mutex);
+    return _records;
+  }
+
+ protected:
+  void sink_it_(spdlog::details::log_msg const& msg) override
+  {
+    std::lock_guard<std::mutex> lock(_records_mutex);
+    _records.push_back({msg.level, std::string(msg.payload.data(), msg.payload.size())});
+  }
+
+  void flush_() override {}
+
+ private:
+  mutable std::mutex _records_mutex;
+  std::vector<record> _records;
+};
+
+class scoped_spdlog_capture {
+ public:
+  scoped_spdlog_capture()
+    : _logger(spdlog::default_logger()),
+      _sink(std::make_shared<capture_sink>()),
+      _old_level(_logger->level())
+  {
+    _logger->sinks().push_back(_sink);
+    _logger->set_level(spdlog::level::trace);
+  }
+
+  ~scoped_spdlog_capture()
+  {
+    auto& sinks = _logger->sinks();
+    sinks.erase(std::remove(sinks.begin(), sinks.end(), _sink), sinks.end());
+    _logger->set_level(_old_level);
+  }
+
+  scoped_spdlog_capture(scoped_spdlog_capture const&)            = delete;
+  scoped_spdlog_capture& operator=(scoped_spdlog_capture const&) = delete;
+
+  [[nodiscard]] std::vector<capture_sink::record> records() const { return _sink->records(); }
+
+ private:
+  std::shared_ptr<spdlog::logger> _logger;
+  std::shared_ptr<capture_sink> _sink;
+  spdlog::level::level_enum _old_level;
+};
 
 }  // namespace
 
@@ -932,6 +1001,164 @@ TEST_CASE("footer suffix probe retries transient GET failures",
     auto const perf = reactor.perf_snapshot();
     CHECK(perf.retries_total == 0);
     CHECK(perf.terminal_failures_total == 0);
+  }
+}
+
+TEST_CASE("HEAD object-size retries update REST perf counters",
+          "[s3][integration][rest][footerbind]")
+{
+  auto const payload = deterministic_payload(4096);
+
+  SECTION("transient 503s are retried and the final HEAD returns the size")
+  {
+    range_fault_policy fault{};
+    fault.fail_first_heads = 2;
+    fault.fail_head_status = 503;
+    range_http_server server(payload, fault);
+    auto authorizer             = std::make_shared<fixed_url_authorizer>(server.endpoint());
+    auto cfg                    = direct_rest_test_config();
+    cfg.max_retry_attempts      = 3;
+    cfg.max_auth_retry_attempts = 1;
+    auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+      cfg, std::move(authorizer), nullptr);
+    sirius::io::rest::rest_reactor reactor(ctx, "head-retry-success");
+
+    CHECK(reactor.head_object_size("head-bucket", "head-success.bin") == payload.size());
+    CHECK(server.head_count() == 3);
+    CHECK(server.get_count() == 0);
+    auto const perf = reactor.perf_snapshot();
+    CHECK(perf.retries_total == 2);
+    CHECK(perf.terminal_failures_total == 0);
+  }
+
+  SECTION("exhausted transient 503s are reported as one terminal failure")
+  {
+    range_fault_policy fault{};
+    fault.fail_all_heads   = true;
+    fault.fail_head_status = 503;
+    range_http_server server(payload, fault);
+    auto authorizer             = std::make_shared<fixed_url_authorizer>(server.endpoint());
+    auto cfg                    = direct_rest_test_config();
+    cfg.max_retry_attempts      = 2;
+    cfg.max_auth_retry_attempts = 1;
+    auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+      cfg, std::move(authorizer), nullptr);
+    sirius::io::rest::rest_reactor reactor(ctx, "head-retry-exhausted");
+
+    try {
+      (void)reactor.head_object_size("head-bucket", "head-exhausted.bin");
+      FAIL("head_object_size should throw after exhausting transient retries");
+    } catch (std::runtime_error const& e) {
+      auto const message = std::string{e.what()};
+      CHECK(message.find("exhausted retries") != std::string::npos);
+      CHECK(message.find("HTTP 503") != std::string::npos);
+    }
+    CHECK(server.head_count() == 2);
+    CHECK(server.get_count() == 0);
+    auto const perf = reactor.perf_snapshot();
+    CHECK(perf.retries_total == cfg.max_retry_attempts - 1);
+    CHECK(perf.terminal_failures_total == 1);
+  }
+
+  SECTION("hard non-retriable HEAD errors fail without retrying")
+  {
+    range_fault_policy fault{};
+    fault.fail_all_heads   = true;
+    fault.fail_head_status = 403;
+    range_http_server server(payload, fault);
+    auto authorizer             = std::make_shared<fixed_url_authorizer>(server.endpoint());
+    auto cfg                    = direct_rest_test_config();
+    cfg.max_retry_attempts      = 3;
+    cfg.max_auth_retry_attempts = 1;
+    auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+      cfg, std::move(authorizer), nullptr);
+    sirius::io::rest::rest_reactor reactor(ctx, "head-hard-failure");
+
+    try {
+      (void)reactor.head_object_size("head-bucket", "head-forbidden.bin");
+      FAIL("head_object_size should throw on a hard non-retriable HTTP error");
+    } catch (std::runtime_error const& e) {
+      auto const message = std::string{e.what()};
+      CHECK(message.find("HTTP 403") != std::string::npos);
+    }
+    CHECK(server.head_count() == 1);
+    CHECK(server.get_count() == 0);
+    auto const perf = reactor.perf_snapshot();
+    CHECK(perf.retries_total == 0);
+    CHECK(perf.terminal_failures_total == 1);
+  }
+
+  SECTION("clean HEAD has no retry or terminal-failure telemetry")
+  {
+    range_http_server server(payload);
+    auto authorizer             = std::make_shared<fixed_url_authorizer>(server.endpoint());
+    auto cfg                    = direct_rest_test_config();
+    cfg.max_retry_attempts      = 3;
+    cfg.max_auth_retry_attempts = 1;
+    auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+      cfg, std::move(authorizer), nullptr);
+    sirius::io::rest::rest_reactor reactor(ctx, "head-clean");
+
+    CHECK(reactor.head_object_size("head-bucket", "head-clean.bin") == payload.size());
+    CHECK(server.head_count() == 1);
+    CHECK(server.get_count() == 0);
+    auto const perf = reactor.perf_snapshot();
+    CHECK(perf.retries_total == 0);
+    CHECK(perf.terminal_failures_total == 0);
+  }
+}
+
+TEST_CASE("REST retry logging includes object keys and stays quiet on clean requests",
+          "[s3][integration][rest][footerbind]")
+{
+  auto const payload = deterministic_payload(4096);
+
+  SECTION("a retried request emits a warning with the object key")
+  {
+    range_fault_policy fault{};
+    fault.fail_first_gets = 1;
+    fault.fail_status     = 503;
+    range_http_server server(payload, fault);
+    auto authorizer             = std::make_shared<fixed_url_authorizer>(server.endpoint());
+    auto cfg                    = direct_rest_test_config();
+    cfg.max_retry_attempts      = 2;
+    cfg.max_auth_retry_attempts = 1;
+    auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+      cfg, std::move(authorizer), nullptr);
+    sirius::io::rest::rest_reactor reactor(ctx, "retry-log-warning");
+
+    scoped_spdlog_capture logs;
+    auto probe = reactor.fetch_footer_suffix("log-bucket", "warn-retry.parquet", 1024);
+    REQUIRE(probe.bytes != nullptr);
+
+    auto const records = logs.records();
+    auto const found   = std::any_of(records.begin(), records.end(), [](auto const& r) {
+      return r.level == spdlog::level::warn &&
+             r.payload.find("warn-retry.parquet") != std::string::npos;
+    });
+    CHECK(found);
+  }
+
+  SECTION("clean first-try suffix GET and HEAD do not emit warnings or errors")
+  {
+    range_http_server server(payload);
+    auto authorizer             = std::make_shared<fixed_url_authorizer>(server.endpoint());
+    auto cfg                    = direct_rest_test_config();
+    cfg.max_retry_attempts      = 2;
+    cfg.max_auth_retry_attempts = 1;
+    auto ctx                    = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+      cfg, std::move(authorizer), nullptr);
+    sirius::io::rest::rest_reactor reactor(ctx, "retry-log-clean");
+
+    scoped_spdlog_capture logs;
+    auto probe = reactor.fetch_footer_suffix("log-bucket", "clean.parquet", 1024);
+    REQUIRE(probe.bytes != nullptr);
+    CHECK(reactor.head_object_size("log-bucket", "clean.parquet") == payload.size());
+
+    auto const records        = logs.records();
+    auto const warning_or_bad = std::any_of(
+      records.begin(), records.end(), [](auto const& r) { return r.level >= spdlog::level::warn; });
+    CHECK_FALSE(warning_or_bad);
   }
 }
 


### PR DESCRIPTION
## Collapse S3 parquet footer bind to one suffix-range GET

Closes #<1086>.

### What changed
- **One suffix-range GET replaces the HEAD.** `open_hint::parquet_footer_probe` makes `rest_ioctx` issue a single `Range: bytes=-N` GET that returns the size (from `Content-Range`) and stashes the object's trailing N bytes on the `rest_io_object`; `rest_reactor::host_read` then serves cuDF's trailer/footer reads from that stash — no extra GET. The stash is per-open, not a cache.
- **Metadata-aware `describe_parquet`.** Cold bind (metadata_store miss) probes; a warm re-bind opens `generic` (one HEAD) and reuses the parsed footer — dev-parity, no footer re-download.
- **Configurable window.** `scan_manager.rest.footer_probe_bytes` (yaml, byte-valued), default **512 KiB** (footer ≈ 0.037 % of file: SF1 207 MB → 78 KiB, SF10 2.2 GB → 771 KiB; N must cover the footer or it falls back to a body re-GET, so err large — over-read is a cheap one-time bind cost).
- **Fallback.** An unusable suffix response (200 full body / 416 / missing-or-`*` `Content-Range`) aborts the body mid-stream and falls back to a plain HEAD.
- **Bench A/B.** `make s3-bench` runs generic vs probe on MinIO + AWS and reports `bind_ms = open_ms + footer_fetch_ms` + `bind_chunk_get_count`.

### Results (footer-probe A/B)
- **Requests 3 → 1**, deterministic: `bind_chunk_get_count 2 → 1` on 24/24 AWS + MinIO samples.
- **MinIO HTTPS (clean link): footer bind 11 ms → 4 ms (2.75×)**, `footer_fetch` 9 ms → 0.
- AWS (via socks5 proxy) confirms 2 → 1; absolute latency is proxy-masked (the 434 KiB over-read ≈ one throttled-proxy RTT) — a clean magnitude needs in-region EC2.


### Test plan
All green on the CI GPU host: `make s3-test` 40/40, `[…rest…footerbind]` 10/10, `make s3-bench` 2/2,
`make s3-test-large` (SF10), full Catch2 1548/1548. Coverage: cold bind = 1 suffix GET / 0 HEAD; size
from `Content-Range`; trailer/footer from stash; footer beyond window → one body re-GET; unusable
suffix → HEAD; transient-5xx retry + exhaustion; small object; concurrent binds; warm re-bind; config.
