### PR TITLE
Fix hash-join partition sizing

### DIFF
--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -217,8 +217,8 @@ Repartitions data into N buckets based on partition keys.
 
 - **Modes:** `HASH` (most common), `RANGE`, `EVENLY`, `CUSTOM`, `NONE`
 - **Adaptive count:** `determine_num_partitions()` computes N from actual input data size and `hash_partition_bytes` config
-- **Sibling coordination:** Build-side partition determines count; probe-side waits for the result
-- **Key members:** `_partition_keys`, `_partition_type`, `_num_partitions`, `_is_build`, `_sibling_partition_op`
+- **Sibling coordination:** Build-side partition normally determines the shared count. For RIGHT-family hash joins other than `RIGHT_DELIM_JOIN`, the retained probe side determines it instead.
+- **Key members:** `_partition_keys`, `_partition_type`, `_num_partitions`, `_is_build`, `_drives_partition_count`, `_sibling_partition_op`
 
 ### `sirius_physical_concat` — `CONCAT`
 **File:** `src/include/op/sirius_physical_concat.hpp`

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -11,7 +11,7 @@ This document catalogs Super Sirius performance optimizations by category. Each 
 **Mechanism:** `determine_num_partitions()` computes partition count from actual input data size:
 ```
 total_bytes = sum of all batch sizes from input repository
-num_partitions = max(1, total_bytes / hash_partition_bytes)
+num_partitions = max(1, ceil(total_bytes / hash_partition_bytes))
 ```
 
 **Code path:** `src/op/sirius_physical_partition.cpp` — `determine_num_partitions()`

--- a/docs/super-sirius/task-creator.md
+++ b/docs/super-sirius/task-creator.md
@@ -143,9 +143,9 @@ Uses base class for both `get_next_task_hint()` and `get_next_task_input_data()`
 
 | Method | Behavior |
 |--------|----------|
-| `get_next_task_hint()` | If probe-side with no `_num_partitions` and has sibling: delegates to build sibling's hint. Otherwise: base class. |
-| `get_next_task_input_data()` | Mutex-locked with sibling to atomically determine partition count on first call via `determine_num_partitions()`. Notifies hash join of partition count. Then delegates to base class. |
-| Why custom | Sibling pair coordination: probe must wait for build to determine partition count |
+| `get_next_task_hint()` | If the non-driving side has no `_num_partitions`, delegates to the sizing sibling's hint. Otherwise: base class. |
+| `get_next_task_input_data()` | Mutex-locked with sibling to atomically determine partition count from the designated sizing side on first call. Notifies the hash join when build-side sizing can select an execution mode. Then delegates to base class. |
+| Why custom | Sibling pair coordination: build normally sizes both sides; RIGHT-family joins other than `RIGHT_DELIM_JOIN` size both from the retained probe side. |
 
 Deadlock prevention: both this and sibling partition locks are acquired in a fixed order using `std::scoped_lock`.
 
@@ -196,7 +196,7 @@ Same pattern as MERGE_SORT: drains all batches from one partition per call.
 | PARQUET_SCAN | READY if partitions remain | N/A (task creator handles) | Source, no ports |
 | HASH_JOIN (BUILD_PROBE) | Build state machine | Build+probe or probe only | Build/probe asymmetry |
 | HASH_JOIN (STANDARD) | Base class | Cartesian product walk | Multi-partition iteration |
-| PARTITION | Delegates to build sibling | Mutex-locked count determination | Sibling coordination |
+| PARTITION | Delegates to sizing sibling | Mutex-locked count determination | Sibling coordination |
 | CONCAT | Byte-threshold check | Accumulate until threshold | Batching + blocking mode |
 | SORT_SAMPLE | Wait for N batches | Base class | Two-phase sampling |
 | MERGE_SORT | Base class | Drain all from one partition | Per-partition merge |

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -125,6 +125,13 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
    * conditional table columns.
    */
   static bool are_conditions_supported(duckdb::vector<sirius::join_condition>& conditions);
+
+  [[nodiscard]] bool is_right_family() const
+  {
+    return join_type == duckdb::JoinType::RIGHT || join_type == duckdb::JoinType::RIGHT_SEMI ||
+           join_type == duckdb::JoinType::RIGHT_ANTI;
+  }
+
   void build_pipelines(pipeline::sirius_pipeline& current,
                        pipeline::sirius_meta_pipeline& meta_pipeline) override;
 

--- a/src/include/op/sirius_physical_partition.hpp
+++ b/src/include/op/sirius_physical_partition.hpp
@@ -62,6 +62,8 @@ class sirius_physical_partition : public sirius_physical_operator {
 
   bool is_build_partition();
 
+  void set_drives_partition_count(bool drives) { _drives_partition_count = drives; }
+
   //! Get the parent operator (e.g., HASH_JOIN for build partition)
   [[nodiscard]] sirius_physical_operator* get_parent_op() const { return _parent_op; }
 
@@ -120,6 +122,7 @@ class sirius_physical_partition : public sirius_physical_operator {
   std::vector<cudf::data_type> _partition_key_cast_types;
   std::optional<int> _num_partitions;
   bool _is_build;
+  bool _drives_partition_count{false};
   bool _has_sibling_partition_op;
   PartitionType _partition_type;
   uint64_t s_partition_size;

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -46,9 +46,7 @@ sirius_physical_concat::sirius_physical_concat(duckdb::vector<sirius::logical_ty
       // if the join type is left or anti, then we need to concat all the batches into one batch for
       // the build side
       _concat_all = is_build;
-    } else if (hash_join->join_type == duckdb::JoinType::RIGHT ||
-               hash_join->join_type == duckdb::JoinType::RIGHT_ANTI ||
-               hash_join->join_type == duckdb::JoinType::RIGHT_SEMI) {
+    } else if (hash_join->is_right_family()) {
       // if the join type is right or right anti, then we need to concat all the batches into one
       // batch for the probe side
       _concat_all = !is_build;

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -418,8 +418,7 @@ void sirius_physical_hash_join::update_join_exec_mode(int num_partitions,
   // require the persistent table on the left plus cross-batch accumulation, incompatible with the
   // build-on-right / stream-left model.
   if (num_partitions == 1 && build_side_bytes < _max_build_hash_table_bytes &&
-      build_foldable_to_single_batch && join_type != duckdb::JoinType::RIGHT_SEMI &&
-      join_type != duckdb::JoinType::RIGHT_ANTI && join_type != duckdb::JoinType::RIGHT &&
+      build_foldable_to_single_batch && !is_right_family() &&
       _join_mode != HASH_JOIN_MODE::MIXED_JOIN) {
     // Switch to a more efficient join strategy for small datasets. The
     // build_foldable_to_single_batch gate matches the runtime invariant in

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -64,6 +64,7 @@ sirius_physical_partition::sirius_physical_partition(duckdb::vector<sirius::logi
   _parent_op       = parent_op;
   _is_build        = is_build;
   get_partition_keys_and_type(parent_op, is_build);
+  _drives_partition_count = _is_build;
 }
 
 std::string sirius_physical_partition::get_name() const { return "PARTITION"; }
@@ -243,7 +244,9 @@ std::pair<int, uint64_t> sirius_physical_partition::determine_num_partitions()
       if (ro.get_data()) { total_bytes += ro.get_data()->get_size_in_bytes(); }
     }
   }
-  int num_partitions = static_cast<int>(std::max(uint64_t{1}, total_bytes / s_partition_size));
+  int num_partitions = static_cast<int>(std::max(
+    uint64_t{1},
+    total_bytes / s_partition_size + static_cast<uint64_t>(total_bytes % s_partition_size != 0)));
   // Multi-GPU floor: if the input is big enough to justify using the second
   // GPU, force at least num_gpus partitions so partition-based operators
   // (hash_join, merge_group_by) get work on every GPU. Below the small-table
@@ -264,12 +267,13 @@ void sirius_physical_partition::set_num_partitions(int num_partitions)
 std::optional<task_creation_hint> sirius_physical_partition::get_next_task_hint()
 {
   std::lock_guard<std::mutex> guard(lock);
-  if (!_num_partitions.has_value() && !_is_build && _sibling_partition_op != nullptr) {
-    // If this is a probe partition and we haven't determined the number of partitions yet, we
-    // should wait for the build sibling to determine it. This is because the build side will drive
-    // the partitioning and the probe side needs to know the number of partitions to create the
-    // correct number of tasks.
-    return _sibling_partition_op->get_next_task_hint();
+  if (!_num_partitions.has_value() && !_drives_partition_count &&
+      _sibling_partition_op != nullptr) {
+    // Prefer scheduling the side that sizes the sibling pair. If that side is complete but empty,
+    // schedule this side so it can elect one partition from the empty sizing input.
+    auto driver_hint = _sibling_partition_op->get_next_task_hint();
+    if (driver_hint.has_value()) { return driver_hint; }
+    return sirius_physical_operator::get_next_task_hint();
   } else if (_num_partitions.has_value() && !_is_build && _sibling_partition_op != nullptr) {
     // If this is part of a join and its on the probe side, and we have determined the number of
     // partitions, we have this behave as a pipeline operator and just schedule tasks
@@ -300,7 +304,8 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
     auto& sibling = _sibling_partition_op->Cast<sirius_physical_partition>();
     std::scoped_lock guard(lock, sibling.lock);
     if (!_num_partitions.has_value()) {
-      auto [num_parts, total_bytes] = determine_num_partitions();
+      auto& sizing_partition        = _drives_partition_count ? *this : sibling;
+      auto [num_parts, total_bytes] = sizing_partition.determine_num_partitions();
       auto& hash_join               = _hash_join_op->Cast<sirius_physical_hash_join>();
       // BUILD_PROBE mode requires the build side to deliver exactly one
       // batch at runtime. The only mechanism that guarantees that is the
@@ -319,7 +324,9 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
         return false;
       };
       bool const build_foldable = has_build_concat(*this) || has_build_concat(sibling);
-      hash_join.update_join_exec_mode(num_parts, total_bytes, build_foldable);
+      if (sizing_partition._is_build) {
+        hash_join.update_join_exec_mode(num_parts, total_bytes, build_foldable);
+      }
       if (_hash_join_op->type == SiriusPhysicalOperatorType::HASH_JOIN &&
           hash_join.is_build_probe_mode()) {
         // Either sibling may run this block first; configure the build-side CONCAT only.
@@ -336,14 +343,14 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
       _num_partitions         = num_parts;
       sibling._num_partitions = num_parts;
       SIRIUS_LOG_DEBUG(
-        "sirius_physical_partition id {} determined {} partitions from {} bytes on sibling id {} "
-        "and {} build "
-        "side",
+        "sirius_physical_partition id {} determined {} partitions from {} bytes on sizing id {} "
+        "({} side), sibling id {}",
         this->get_operator_id(),
         _num_partitions.value(),
         total_bytes,
-        _sibling_partition_op->get_operator_id(),
-        (_is_build ? "is" : "is not"));
+        sizing_partition.get_operator_id(),
+        (sizing_partition._is_build ? "build" : "probe"),
+        _sibling_partition_op->get_operator_id());
     }
   } else {
     std::lock_guard<std::mutex> guard(lock);

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -1147,21 +1147,26 @@ void sirius_pipeline_converter::link_join_partition_siblings()
     // for each hash join as a source, get the dependencies (concat) and get the dependencies of
     // concat (partition)
     if (pipeline->source->type == op::SiriusPhysicalOperatorType::HASH_JOIN) {
+      auto& hash_join               = pipeline->source->Cast<op::sirius_physical_hash_join>();
       auto build_concat_pipeline    = pipeline->dependencies[0];
       auto build_partition_pipeline = build_concat_pipeline->dependencies[0];
       auto probe_concat_pipeline    = pipeline->dependencies[1];
       auto probe_partition_pipeline = probe_concat_pipeline->dependencies[0];
-      // Change probe partition barrier to partial. The corresponding port doesn't exist
-      // yet (materialisation happens after `convert()` returns); mutate the descriptor
-      // so the materialiser creates the port with the correct barrier type.
+      bool const is_right_delim     = build_partition_pipeline->get_sink()->type ==
+                                  op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN;
+      // RIGHT_DELIM_JOIN must bootstrap its probe subtree from build-side distinct data.
+      bool const probe_drives_partition_count = hash_join.is_right_family() && !is_right_delim;
+
+      // Probe partitions normally stream through a partial barrier. A RIGHT-family join must
+      // size from the complete probe input because CONCAT retains the whole probe partition.
       auto wiring_it = std::find_if(
         repository_wirings_.begin(), repository_wirings_.end(), [&](const repository_wiring& w) {
           return w.dest_pipeline == probe_partition_pipeline && w.port_id == "default";
         });
       D_ASSERT(wiring_it != repository_wirings_.end());
-      wiring_it->barrier_type = op::MemoryBarrierType::PARTIAL;
-      if (build_partition_pipeline->get_sink()->type ==
-          op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
+      wiring_it->barrier_type =
+        probe_drives_partition_count ? op::MemoryBarrierType::FULL : op::MemoryBarrierType::PARTIAL;
+      if (is_right_delim) {
         // partition pipeline only has one operator
         auto& right_delim_join_op =
           build_partition_pipeline->get_sink()->Cast<op::sirius_physical_right_delim_join>();
@@ -1178,6 +1183,10 @@ void sirius_pipeline_converter::link_join_partition_siblings()
           probe_partition_pipeline->get_sink()->Cast<op::sirius_physical_partition>();
         build_partition_op.set_sibling_partition_op(&probe_partition_op);
         probe_partition_op.set_sibling_partition_op(&build_partition_op);
+        if (probe_drives_partition_count) {
+          build_partition_op.set_drives_partition_count(false);
+          probe_partition_op.set_drives_partition_count(true);
+        }
       }
     }
   }

--- a/test/cpp/operator/test_physical_concat.cpp
+++ b/test/cpp/operator/test_physical_concat.cpp
@@ -24,6 +24,7 @@
 #include <duckdb/planner/operator/logical_comparison_join.hpp>
 #include <op/sirius_physical_concat.hpp>
 #include <op/sirius_physical_hash_join.hpp>
+#include <op/sirius_physical_partition.hpp>
 
 #include <atomic>
 #include <mutex>
@@ -614,6 +615,86 @@ TEST_CASE("sirius_physical_concat constructor sets concat_all for different join
         false),
       std::runtime_error);
   }
+}
+
+TEST_CASE("sirius_physical_hash_join identifies right-family joins", "[physical_concat]")
+{
+  for (auto join_type :
+       {duckdb::JoinType::RIGHT, duckdb::JoinType::RIGHT_ANTI, duckdb::JoinType::RIGHT_SEMI}) {
+    INFO("join_type=" << duckdb::JoinTypeToString(join_type));
+    auto fixture = create_test_hash_join(join_type, {duckdb::LogicalType::INTEGER});
+    REQUIRE(fixture.hash_join->is_right_family());
+  }
+
+  for (auto join_type : {duckdb::JoinType::INNER,
+                         duckdb::JoinType::LEFT,
+                         duckdb::JoinType::SEMI,
+                         duckdb::JoinType::ANTI,
+                         duckdb::JoinType::MARK,
+                         duckdb::JoinType::OUTER}) {
+    INFO("join_type=" << duckdb::JoinTypeToString(join_type));
+    auto fixture = create_test_hash_join(join_type, {duckdb::LogicalType::INTEGER});
+    REQUIRE_FALSE(fixture.hash_join->is_right_family());
+  }
+}
+
+TEST_CASE("right-family sibling partitions round up from the probe input", "[physical_partition]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space != nullptr);
+
+  auto build_batch =
+    make_numeric_batch<int32_t>(*space, std::vector<int32_t>(4, 1), cudf::type_id::INT32);
+  auto probe_batch =
+    make_numeric_batch<int32_t>(*space, std::vector<int32_t>(9, 1), cudf::type_id::INT32);
+  auto const build_bytes = build_batch->to_read_only().get_data()->get_size_in_bytes();
+  auto const probe_bytes = probe_batch->to_read_only().get_data()->get_size_in_bytes();
+  REQUIRE(probe_bytes > build_bytes);
+  auto const partition_size = probe_bytes - 1;
+
+  auto fixture    = create_test_hash_join(duckdb::JoinType::RIGHT, {duckdb::LogicalType::INTEGER});
+  auto make_types = [] {
+    return sirius::from_duckdb_vec(
+      duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER});
+  };
+  sirius_physical_partition build_partition(
+    make_types(), 4, fixture.hash_join.get(), true, partition_size);
+  sirius_physical_partition probe_partition(
+    make_types(), 9, fixture.hash_join.get(), false, partition_size);
+  build_partition.set_sibling_partition_op(&probe_partition);
+  probe_partition.set_sibling_partition_op(&build_partition);
+  build_partition.set_drives_partition_count(false);
+  probe_partition.set_drives_partition_count(true);
+
+  auto build_repo = std::make_unique<cucascade::shared_data_repository>();
+  auto probe_repo = std::make_unique<cucascade::shared_data_repository>();
+  build_repo->add_data_batch(std::move(build_batch), 0);
+  probe_repo->add_data_batch(std::move(probe_batch), 0);
+
+  auto attach_port = [](sirius_physical_partition& partition,
+                        cucascade::shared_data_repository& repo) {
+    auto port           = std::make_unique<sirius_physical_operator::port>();
+    port->type          = MemoryBarrierType::FULL;
+    port->repo          = &repo;
+    port->src_pipeline  = nullptr;
+    port->dest_pipeline = nullptr;
+    partition.add_port("default", std::move(port));
+  };
+  attach_port(build_partition, *build_repo);
+  attach_port(probe_partition, *probe_repo);
+
+  // Enter through the non-driving build side first. It must still size both siblings from probe.
+  auto build_input = build_partition.get_next_task_input_data();
+  REQUIRE(build_input != nullptr);
+  auto build_output = build_partition.execute(*build_input, default_stream());
+  REQUIRE(
+    dynamic_cast<const pipelineable_operator_data&>(*build_output).get_data_batches().size() == 2);
+
+  auto probe_input = probe_partition.get_next_task_input_data();
+  REQUIRE(probe_input != nullptr);
+  auto probe_output = probe_partition.execute(*probe_input, default_stream());
+  REQUIRE(
+    dynamic_cast<const pipelineable_operator_data&>(*probe_output).get_data_batches().size() == 2);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary

Fix two independent ways Sirius can underestimate the number of hash partitions:

1. Byte-based partition counts use floor division, so an input just over a partition boundary remains at the lower partition count.
2. Join siblings are always sized from the build input, even when a `RIGHT`, `RIGHT_SEMI`, or `RIGHT_ANTI` join retains and concatenates the probe input.

This change uses ceiling division for byte-based partition counts and lets the retained probe input drive the shared count for right-family joins.

## Why this is needed

Both sides of a hash join must use the same partition count. Previously, the count was effectively based on:

```text
max(1, floor(build_bytes / partition_target))
```

### Q13: the wrong input drives sizing

DuckDB plans Q13's SQL `LEFT OUTER JOIN` as a physical `RIGHT` hash join.

At SF1000:

- Customer build input: approximately 0.62 GB
- Filtered orders probe input: 18,176,930,656 bytes
- Configured partition target: 5 GiB

The old build-driven calculation selects one partition from the small customer input, even though Sirius retains the much larger orders probe input.

The new calculation uses the complete probe input:

```text
ceil(18,176,930,656 / 5,368,709,120) = 4 partitions
```

This gives Q13 four balanced join tasks instead of one large retained probe task. The expected benefit is improved memory and task shape, not lower Q13 latency.

### Q21: floor division independently under-partitions

Q21 contains a build-driven stage with approximately 5.94 GB of input:

```text
old: floor(5,937,804,664 / 5,368,709,120) = 1 partition
new:  ceil(5,937,804,664 / 5,368,709,120) = 2 partitions
```

This decision remains build-driven. Its change from one partition to two comes solely from ceiling division, not the right-family logic.

The sampled logs show the following stage starting roughly 1.2 seconds earlier, consistent with the additional parallelism and observed Q21 runtime improvement.

## Implementation

- Round byte-based partition counts up.
- Size `RIGHT`, `RIGHT_SEMI`, and `RIGHT_ANTI` sibling partitions from the complete probe input.
- Assign the resulting shared count to both join sides.
- Use a `FULL` probe barrier only when the probe drives sizing. Other probe pipelines remain `PARTIAL` and streaming.
- Keep `RIGHT_DELIM_JOIN` build-driven because its probe subtree depends on build-side distinct data.
- Only use build-side byte counts when selecting the `BUILD_PROBE` execution mode.
- Preserve a one-partition fallback when the designated sizing input is empty.
- Centralize right-family classification across concat behavior, execution-mode selection, and pipeline wiring.
- Update the partitioning and task-creation documentation.

`hash_partition_bytes` remains a sizing target rather than a strict per-partition upper bound because hash skew and operator output expansion can still affect individual partition sizes.

## SF1000 evidence

All runs used the same GB300 machine with per-query host pinning after iteration 2.

| Run | Q13 cold / warm-best | Q21 cold / warm-best | Q1-Q22 total cold / warm-best |
|---|---:|---:|---:|
| `dev`, 3 iterations | 3.21 s / 1.35 s | 9.69 s / 4.99 s | 75.10 s / 31.04 s |
| Patch, 3 iterations | 3.18 s / 1.42 s | 8.44 s / 3.80 s | 73.90 s / 29.59 s |
| Patch, 6 iterations | 3.24 s / 1.40 s | 8.37 s / 3.79 s | 73.70 s / 27.84 s |

The three-iteration runs provide the closest direct comparison. The six-iteration run has more warm samples, so its `warm-best` values should not be treated as an identical A/B comparison.

The deterministic evidence is the partition selection:

- Q13: build-driven 1 partition -> probe-driven 4 partitions
- Q21: floor-divided 1 partition -> ceiling-divided 2 partitions

Q13 latency remains effectively unchanged, as expected. Q21 warm-best improves by approximately 24% in the matched three-iteration runs, but the partition-count correction—not a guaranteed timing improvement—is the basis for the patch.

## Validation

- Added classification coverage for right-family and unaffected join types.
- Added a regression test that enters through the non-driving build side and only produces two sibling partitions when both probe-driven sizing and ceiling division work.
- Full pre-commit suite passes.
- Full SF1000 TPC-H Q1-Q22 host-pinned benchmarks completed successfully.

## Review notes

The main behavioral tradeoffs are:

- Ceiling division may add one partition near each configured boundary, increasing task overhead for those inputs.
- Right-family probe sizing waits for the complete probe input before partitioning.
- `OUTER` and all other join families retain their existing build-driven behavior.
- `RIGHT_DELIM_JOIN` is deliberately excluded to avoid introducing a dependency cycle.
