### PR TITLE
ci: use slim runner for experimental check job

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -69,7 +69,7 @@ jobs:
 
   experimental:
     name: experimental
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     needs: [starrocks]
     if: always()
     steps:


### PR DESCRIPTION
We can use slim runners for this check (like we do in the other workflows).