### PR TITLE
feat(streaming): streaming source operator + exchange channel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,7 @@ set(EXTENSION_SOURCES
     src/op/sirius_dynamic_filter.cpp
     src/op/sirius_physical_column_data_scan.cpp
     src/op/sirius_physical_cpu_source.cpp
+    src/op/sirius_physical_streaming_source.cpp
     src/op/sirius_physical_concat.cpp
     src/op/sirius_physical_cte.cpp
     src/op/sirius_physical_delim_join.cpp
@@ -570,6 +571,7 @@ set(TEST_SOURCES
     test/cpp/downgrade/test_downgrade_executor.cpp
     test/cpp/downgrade/test_downgrade_lifecycle.cpp
     test/cpp/exec/test_bounded_thread_pool.cpp
+    test/cpp/exec/test_exchange_channel.cpp
     test/cpp/exec/test_inspectable_mpsc.cpp
     test/cpp/exec/test_interruptible_mpmc.cpp
     test/cpp/exec/test_semi_future.cpp
@@ -634,6 +636,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_physical_partition.cpp
     test/cpp/operator/test_physical_projection.cpp
     test/cpp/operator/test_physical_result_collector.cpp
+    test/cpp/operator/test_physical_streaming_source.cpp
     test/cpp/operator/test_physical_table_scan.cpp
     test/cpp/operator/test_no_history_peak_memory_estimate.cpp
     test/cpp/operator/test_physical_top_n.cpp

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -71,7 +71,7 @@ each handle via a `cucascade::shared_data_repository`, and publishes the batch i
 as a `pipelineable_operator_data`. Used only when a fragment's input arrives from another node
 over exchange; a leaf fragment keeps its normal `GPU_SCAN` source.
 
-Key design invariants (design §3/§7):
+Key design invariants:
 - The channel carries **handles**, not `shared_ptr`s — the repository owns the batch so queued
   items remain spill-visible to the downgrade executor.
 - Engine workers use `try_pop` only (non-blocking); `push`/`pop` are provided for the wrapper/test side.
@@ -91,9 +91,20 @@ Hint table:
 `all_ports_empty()` is overridden to `_input_channel->drained()`, driving both the task-creation
 loop guard and the port-less source pipeline-finish predicate.
 
+Channel close notifies the pipeline (`update_pipeline_status(false)`, via a weak pipeline
+reference wired in `set_pipeline`), so an empty or late-closed stream still finishes its
+pipeline — and re-arms downstream consumers — even when no task is left in flight.
+
 **Producer contract**: register the incoming batch in the input repository (`add_data_batch`) *first*,
 then push the handle. The session (#839) owns edge-triggered re-scheduling; the plan generator (#838)
 owns channel wiring.
+
+**Backpressure (open integration requirement for #839)**: `try_pop()` frees channel item/byte
+capacity at task-creation time, but the popped batches move into the unbounded task-scheduler
+queue — the channel bound therefore does not bound total outstanding data. When #839 wires the
+session, task creation must be gated on in-flight work (e.g. counting via the channel's `on_pop`
+hook and the task-completion path) so a fast producer cannot accumulate an arbitrarily large GPU
+backlog behind a nominally bounded channel.
 
 ### `sirius_physical_dummy_scan` — `DUMMY_SCAN`
 **File:** `src/include/op/sirius_physical_dummy_scan.hpp`

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -62,6 +62,39 @@ The pipeline converter rewrites a DuckDB parquet or DuckDB-native table scan int
 
 See [Scan](scan.md) for the full scan subsystem (scan manager, `gpu_ingestible`, pinned-table caching, and the IO layer).
 
+### `sirius_physical_streaming_source` — `STREAMING_SOURCE`
+**File:** `src/include/op/sirius_physical_streaming_source.hpp`
+
+Source operator that marks the bottom boundary of an intermediate pipeline fragment. It pulls
+`exchange_batch_handle` records (batch-id + size) from a bounded `exec::exchange_channel`, resolves
+each handle via a `cucascade::shared_data_repository`, and publishes the batch into the pipeline
+as a `pipelineable_operator_data`. Used only when a fragment's input arrives from another node
+over exchange; a leaf fragment keeps its normal `GPU_SCAN` source.
+
+Key design invariants (design §3/§7):
+- The channel carries **handles**, not `shared_ptr`s — the repository owns the batch so queued
+  items remain spill-visible to the downgrade executor.
+- Engine workers use `try_pop` only (non-blocking); `push`/`pop` are provided for the wrapper/test side.
+- EOS is **close-then-drain**: `close()` forbids new pushes; queued handles stay poppable;
+  `drained()` (= `closed() && empty()`) is the terminal predicate.
+- `execute()` is a pure pass-through (COLUMN_DATA_SCAN shape — no GPU work).
+- `no_history_peak_memory_estimate()` returns `stats.bytes` (no extra allocation).
+
+Hint table:
+
+| Channel state | `get_next_task_hint()` |
+|---|---|
+| non-empty (open or closed) | `READY{this}` |
+| open, empty | `WAITING{nullptr}` — re-armable by the session on push (#839) |
+| closed && drained | `std::nullopt` — EOS |
+
+`all_ports_empty()` is overridden to `_input_channel->drained()`, driving both the task-creation
+loop guard and the port-less source pipeline-finish predicate.
+
+**Producer contract**: register the incoming batch in the input repository (`add_data_batch`) *first*,
+then push the handle. The session (#839) owns edge-triggered re-scheduling; the plan generator (#838)
+owns channel wiring.
+
 ### `sirius_physical_dummy_scan` — `DUMMY_SCAN`
 **File:** `src/include/op/sirius_physical_dummy_scan.hpp`
 
@@ -312,6 +345,7 @@ After pipeline finalization, `source` and `sink` are just aliases for the first 
 | DUCKDB_SCAN | Scan | DuckDB table function (CPU / DuckDB-source path) |
 | PARQUET_SCAN | Scan | Parquet reading (CPU / DuckDB-source path) |
 | GPU_SCAN | Scan | Unified GPU scan source served by `sirius_scan_manager` via a per-format `gpu_ingestible` |
+| STREAMING_SOURCE | Scan | Exchange-input source; pulls batch handles from `exchange_channel`, resolves via `shared_data_repository` |
 | DUMMY_SCAN | Scan | Generates 1 row |
 | COLUMN_DATA_SCAN | Scan | Reads ColumnDataCollection |
 | FILTER | Relational | `expression_evaluator::select()` |

--- a/src/include/exec/exchange_channel.hpp
+++ b/src/include/exec/exchange_channel.hpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+
+namespace sirius::exec {
+
+/// Lightweight handle pushed through the channel. The shared_data_repository is the owner of
+/// record; queued batches therefore sit idle where the downgrade sweep can see and spill them
+/// (design §3/§7). A channel that owned batches would make them spill-invisible.
+struct exchange_batch_handle {
+  uint64_t batch_id;       // repository batch id — repo is the owner of record
+  std::size_t size_bytes;  // size estimate captured at registration (byte accounting)
+};
+
+/// Bounded MPMC queue of batch handles with close-then-drain end-of-stream.
+///
+/// Semantics (design §3/§7):
+///   - full()    ≡  items == capacity_items  OR  (byte_bound set AND bytes ≥ bound AND non-empty)
+///   - Oversized-batch rule: a handle whose size_bytes > capacity_bytes is admitted into an
+///     *empty* channel so the stream never wedges.
+///   - close()   forbids further pushes; already-queued items remain poppable.
+///   - drained() ≡  closed() && empty()  — terminal EOS predicate.
+///   - Engine workers use try_push / try_pop only (non-blocking). Blocking push / pop are
+///     provided for the wrapper / test side.
+///   - Callbacks (on_push / on_pop) fire outside the lock; single-slot — last setter wins.
+class exchange_channel {
+ public:
+  struct config {
+    std::size_t capacity_items;      // required, > 0
+    std::size_t capacity_bytes = 0;  // 0 = no byte bound
+  };
+
+  explicit exchange_channel(config cfg) : _cfg(std::move(cfg))
+  {
+    if (_cfg.capacity_items == 0) {
+      throw std::invalid_argument("exchange_channel: capacity_items must be > 0");
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Producer side
+  // -----------------------------------------------------------------------
+
+  /// Non-blocking push. Returns false when full or closed; never blocks.
+  [[nodiscard]] bool try_push(exchange_batch_handle h)
+  {
+    std::function<void()> cb;
+    {
+      std::unique_lock<std::mutex> lock(_mutex);
+      if (_closed || full_unlocked()) return false;
+      _queue.push_back(h);
+      _total_bytes += h.size_bytes;
+      cb = _on_push;
+    }
+    _cv.notify_all();
+    if (cb) cb();
+    return true;
+  }
+
+  /// Blocking push. Blocks while full; returns false once closed (and stays false).
+  bool push(exchange_batch_handle h)
+  {
+    std::function<void()> cb;
+    {
+      std::unique_lock<std::mutex> lock(_mutex);
+      _cv.wait(lock, [&] { return !full_unlocked() || _closed; });
+      if (_closed) return false;
+      _queue.push_back(h);
+      _total_bytes += h.size_bytes;
+      cb = _on_push;
+    }
+    _cv.notify_all();
+    if (cb) cb();
+    return true;
+  }
+
+  /// Idempotent close. Queued items remain poppable after close.
+  void close()
+  {
+    {
+      std::unique_lock<std::mutex> lock(_mutex);
+      if (_closed) return;
+      _closed = true;
+    }
+    _cv.notify_all();
+  }
+
+  // -----------------------------------------------------------------------
+  // Consumer side
+  // -----------------------------------------------------------------------
+
+  /// Non-blocking pop. Returns nullopt when empty (including when closed+drained); never blocks.
+  std::optional<exchange_batch_handle> try_pop()
+  {
+    std::function<void()> cb;
+    std::optional<exchange_batch_handle> result;
+    {
+      std::unique_lock<std::mutex> lock(_mutex);
+      if (_queue.empty()) return std::nullopt;
+      result = _queue.front();
+      _queue.pop_front();
+      _total_bytes -= result->size_bytes;
+      cb = _on_pop;
+    }
+    _cv.notify_all();
+    if (cb) cb();
+    return result;
+  }
+
+  /// Blocking pop. Blocks until an item is available or the channel is drained.
+  /// Returns nullopt only when closed && empty (EOS reached).
+  std::optional<exchange_batch_handle> pop()
+  {
+    std::function<void()> cb;
+    std::optional<exchange_batch_handle> result;
+    {
+      std::unique_lock<std::mutex> lock(_mutex);
+      _cv.wait(lock, [&] { return !_queue.empty() || _closed; });
+      if (_queue.empty()) return std::nullopt;  // closed && drained
+      result = _queue.front();
+      _queue.pop_front();
+      _total_bytes -= result->size_bytes;
+      cb = _on_pop;
+    }
+    _cv.notify_all();
+    if (cb) cb();
+    return result;
+  }
+
+  // -----------------------------------------------------------------------
+  // State queries (mutex-guarded — safe for task-admission decisions)
+  // -----------------------------------------------------------------------
+
+  [[nodiscard]] bool full() const
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    return full_unlocked();
+  }
+
+  [[nodiscard]] bool empty() const
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    return _queue.empty();
+  }
+
+  [[nodiscard]] std::size_t size() const
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    return _queue.size();
+  }
+
+  [[nodiscard]] std::size_t size_bytes() const
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    return _total_bytes;
+  }
+
+  [[nodiscard]] bool closed() const
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    return _closed;
+  }
+
+  /// Terminal EOS predicate: closed() && empty().
+  [[nodiscard]] bool drained() const
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    return _closed && _queue.empty();
+  }
+
+  // -----------------------------------------------------------------------
+  // Re-arm hooks (single-slot; fired outside the lock).
+  // Wired by the stream session in #839; tests poll instead.
+  // The owner must clear callbacks before the callee dies.
+  // -----------------------------------------------------------------------
+
+  void set_on_push(std::function<void()> cb)
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    _on_push = std::move(cb);
+  }
+
+  void set_on_pop(std::function<void()> cb)
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    _on_pop = std::move(cb);
+  }
+
+ private:
+  /// full() without taking the lock. Caller must hold _mutex.
+  [[nodiscard]] bool full_unlocked() const
+  {
+    if (_queue.size() >= _cfg.capacity_items) return true;
+    if (_cfg.capacity_bytes > 0 && !_queue.empty() && _total_bytes >= _cfg.capacity_bytes)
+      return true;
+    return false;
+  }
+
+  config _cfg;
+  mutable std::mutex _mutex;
+  std::condition_variable _cv;
+  std::deque<exchange_batch_handle> _queue;
+  std::size_t _total_bytes{0};
+  bool _closed{false};
+  std::function<void()> _on_push;
+  std::function<void()> _on_pop;
+};
+
+}  // namespace sirius::exec

--- a/src/include/exec/exchange_channel.hpp
+++ b/src/include/exec/exchange_channel.hpp
@@ -50,7 +50,8 @@ struct exchange_batch_handle {
 ///   - drained() ≡  closed() && empty()  — terminal EOS predicate.
 ///   - Engine workers use try_push / try_pop only (non-blocking). Blocking push / pop are
 ///     provided for the wrapper / test side.
-///   - Callbacks (on_push / on_pop) fire outside the lock; single-slot — last setter wins.
+///   - Callbacks (on_push / on_pop / on_close) fire outside the lock; each is single-slot —
+///     last setter wins. on_close fires exactly once, on the first successful close().
 class exchange_channel {
  public:
   struct config {
@@ -104,15 +105,19 @@ class exchange_channel {
     return true;
   }
 
-  /// Idempotent close. Queued items remain poppable after close.
+  /// Idempotent close. Queued items remain poppable after close. Fires the on-close callback
+  /// exactly once, on the first successful call, outside the lock.
   void close()
   {
+    std::function<void()> cb;
     {
       std::unique_lock<std::mutex> lock(_mutex);
       if (_closed) return;
       _closed = true;
+      cb      = _on_close;
     }
     _cv.notify_all();
+    if (cb) cb();
   }
 
   // -----------------------------------------------------------------------
@@ -216,6 +221,16 @@ class exchange_channel {
     _on_pop = std::move(cb);
   }
 
+  /// Fired exactly once, after the first successful close() (repeated close() calls are a
+  /// no-op and do not re-fire it), outside the lock. Distinct from on_push/on_pop: "the stream
+  /// ended" is a different event than "data is available", with a different intended consumer
+  /// (pipeline-completion re-evaluation vs. task-creation re-scheduling).
+  void set_on_close(std::function<void()> cb)
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    _on_close = std::move(cb);
+  }
+
  private:
   /// full() without taking the lock. Caller must hold _mutex.
   [[nodiscard]] bool full_unlocked() const
@@ -250,6 +265,7 @@ class exchange_channel {
   bool _closed{false};
   std::function<void()> _on_push;
   std::function<void()> _on_pop;
+  std::function<void()> _on_close;
 };
 
 }  // namespace sirius::exec

--- a/src/include/exec/exchange_channel.hpp
+++ b/src/include/exec/exchange_channel.hpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <deque>
 #include <functional>
+#include <limits>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
@@ -28,30 +29,20 @@
 namespace sirius::exec {
 
 /// Lightweight handle pushed through the channel. The shared_data_repository is the owner of
-/// record; queued batches therefore sit idle where the downgrade sweep can see and spill them
-/// (design §3/§7). A channel that owned batches would make them spill-invisible.
+/// record; queued batches therefore sit idle where the downgrade sweep can see and spill them.
 struct exchange_batch_handle {
   uint64_t batch_id;       // repository batch id — repo is the owner of record
   std::size_t size_bytes;  // size estimate captured at registration (byte accounting)
 };
 
-/// Bounded MPMC queue of batch handles with close-then-drain end-of-stream.
+/// Bounded MPMC queue of batch handles with close-then-drain end-of-stream:
+/// close() forbids further pushes, already-queued items remain poppable, and
+/// drained() (= closed() && empty()) is the terminal EOS predicate.
 ///
-/// Semantics (design §3/§7):
-///   - full()    ≡  items == capacity_items  OR  (byte_bound set AND bytes ≥ bound AND non-empty)
-///     — a state-only query with no candidate handle. Push admission is decided separately (see
-///     can_push_unlocked()) because a specific incoming handle can cross the byte bound even
-///     while full() would still report false (e.g. 40 queued + a 40-byte handle against a
-///     50-byte bound).
-///   - Oversized-batch rule: a handle whose size_bytes > capacity_bytes is admitted into an
-///     *empty* channel so the stream never wedges. A non-empty channel never admits a handle
-///     that would push the cumulative total past capacity_bytes.
-///   - close()   forbids further pushes; already-queued items remain poppable.
-///   - drained() ≡  closed() && empty()  — terminal EOS predicate.
-///   - Engine workers use try_push / try_pop only (non-blocking). Blocking push / pop are
-///     provided for the wrapper / test side.
-///   - Callbacks (on_push / on_pop / on_close) fire outside the lock; each is single-slot —
-///     last setter wins. on_close fires exactly once, on the first successful close().
+/// Capacity is bounded by item count and optionally by cumulative bytes. Engine workers use
+/// the non-blocking try_push / try_pop; blocking push / pop serve the wrapper / test side.
+/// Callbacks (on_push / on_pop / on_close) fire outside the lock and must not capture raw
+/// pointers to objects the channel can outlive.
 class exchange_channel {
  public:
   struct config {
@@ -78,9 +69,7 @@ class exchange_channel {
     {
       std::unique_lock<std::mutex> lock(_mutex);
       if (_closed || !can_push_unlocked(h)) return false;
-      _queue.push_back(h);
-      _total_bytes += h.size_bytes;
-      cb = _on_push;
+      cb = enqueue_unlocked(h);
     }
     _cv.notify_all();
     if (cb) cb();
@@ -96,9 +85,7 @@ class exchange_channel {
       std::unique_lock<std::mutex> lock(_mutex);
       _cv.wait(lock, [&] { return can_push_unlocked(h) || _closed; });
       if (_closed) return false;
-      _queue.push_back(h);
-      _total_bytes += h.size_bytes;
-      cb = _on_push;
+      cb = enqueue_unlocked(h);
     }
     _cv.notify_all();
     if (cb) cb();
@@ -132,10 +119,7 @@ class exchange_channel {
     {
       std::unique_lock<std::mutex> lock(_mutex);
       if (_queue.empty()) return std::nullopt;
-      result = _queue.front();
-      _queue.pop_front();
-      _total_bytes -= result->size_bytes;
-      cb = _on_pop;
+      result = dequeue_unlocked(cb);
     }
     _cv.notify_all();
     if (cb) cb();
@@ -152,10 +136,7 @@ class exchange_channel {
       std::unique_lock<std::mutex> lock(_mutex);
       _cv.wait(lock, [&] { return !_queue.empty() || _closed; });
       if (_queue.empty()) return std::nullopt;  // closed && drained
-      result = _queue.front();
-      _queue.pop_front();
-      _total_bytes -= result->size_bytes;
-      cb = _on_pop;
+      result = dequeue_unlocked(cb);
     }
     _cv.notify_all();
     if (cb) cb();
@@ -204,9 +185,12 @@ class exchange_channel {
   }
 
   // -----------------------------------------------------------------------
-  // Re-arm hooks (single-slot; fired outside the lock).
+  // Re-arm hooks (single-slot — last setter wins; fired outside the lock).
   // Wired by the stream session in #839; tests poll instead.
-  // The owner must clear callbacks before the callee dies.
+  // A firing operation snapshots the callback under the lock and invokes the copy after
+  // unlocking, so replacing a callback does not synchronize with an in-flight invocation:
+  // callbacks must not capture raw pointers to objects the channel can outlive (capture a
+  // weak reference instead).
   // -----------------------------------------------------------------------
 
   void set_on_push(std::function<void()> cb)
@@ -232,6 +216,26 @@ class exchange_channel {
   }
 
  private:
+  /// Shared tail of try_push/push: admit `h` and snapshot the push callback for the caller to
+  /// fire outside the lock. Caller must hold _mutex and have checked can_push_unlocked().
+  std::function<void()> enqueue_unlocked(const exchange_batch_handle& h)
+  {
+    _queue.push_back(h);
+    _total_bytes += h.size_bytes;
+    return _on_push;
+  }
+
+  /// Shared tail of try_pop/pop: dequeue the front handle and snapshot the pop callback into
+  /// `cb` for the caller to fire outside the lock. Caller must hold _mutex; queue non-empty.
+  exchange_batch_handle dequeue_unlocked(std::function<void()>& cb)
+  {
+    exchange_batch_handle result = _queue.front();
+    _queue.pop_front();
+    _total_bytes -= result.size_bytes;
+    cb = _on_pop;
+    return result;
+  }
+
   /// full() without taking the lock. Caller must hold _mutex.
   [[nodiscard]] bool full_unlocked() const
   {
@@ -248,6 +252,11 @@ class exchange_channel {
   [[nodiscard]] bool can_push_unlocked(const exchange_batch_handle& h) const
   {
     if (_queue.size() >= _cfg.capacity_items) return false;
+    // Reject a handle whose size would overflow the byte accounting; without this a wrapped
+    // _total_bytes makes size_bytes()/full() wrong. Only reachable on a byte-unbounded
+    // channel — a bounded non-empty channel already rejects below, and an empty channel has
+    // _total_bytes == 0.
+    if (h.size_bytes > std::numeric_limits<std::size_t>::max() - _total_bytes) return false;
     if (_cfg.capacity_bytes == 0) return true;
     // Oversized-batch rule: always admit into an empty channel so the stream never wedges.
     if (_queue.empty()) return true;

--- a/src/include/exec/exchange_channel.hpp
+++ b/src/include/exec/exchange_channel.hpp
@@ -39,8 +39,13 @@ struct exchange_batch_handle {
 ///
 /// Semantics (design §3/§7):
 ///   - full()    ≡  items == capacity_items  OR  (byte_bound set AND bytes ≥ bound AND non-empty)
+///     — a state-only query with no candidate handle. Push admission is decided separately (see
+///     can_push_unlocked()) because a specific incoming handle can cross the byte bound even
+///     while full() would still report false (e.g. 40 queued + a 40-byte handle against a
+///     50-byte bound).
 ///   - Oversized-batch rule: a handle whose size_bytes > capacity_bytes is admitted into an
-///     *empty* channel so the stream never wedges.
+///     *empty* channel so the stream never wedges. A non-empty channel never admits a handle
+///     that would push the cumulative total past capacity_bytes.
 ///   - close()   forbids further pushes; already-queued items remain poppable.
 ///   - drained() ≡  closed() && empty()  — terminal EOS predicate.
 ///   - Engine workers use try_push / try_pop only (non-blocking). Blocking push / pop are
@@ -64,13 +69,14 @@ class exchange_channel {
   // Producer side
   // -----------------------------------------------------------------------
 
-  /// Non-blocking push. Returns false when full or closed; never blocks.
+  /// Non-blocking push. Returns false when the handle can't be admitted (item/byte bound would
+  /// be crossed) or the channel is closed; never blocks.
   [[nodiscard]] bool try_push(exchange_batch_handle h)
   {
     std::function<void()> cb;
     {
       std::unique_lock<std::mutex> lock(_mutex);
-      if (_closed || full_unlocked()) return false;
+      if (_closed || !can_push_unlocked(h)) return false;
       _queue.push_back(h);
       _total_bytes += h.size_bytes;
       cb = _on_push;
@@ -80,13 +86,14 @@ class exchange_channel {
     return true;
   }
 
-  /// Blocking push. Blocks while full; returns false once closed (and stays false).
+  /// Blocking push. Blocks while the handle can't be admitted; returns false once closed (and
+  /// stays false).
   bool push(exchange_batch_handle h)
   {
     std::function<void()> cb;
     {
       std::unique_lock<std::mutex> lock(_mutex);
-      _cv.wait(lock, [&] { return !full_unlocked() || _closed; });
+      _cv.wait(lock, [&] { return can_push_unlocked(h) || _closed; });
       if (_closed) return false;
       _queue.push_back(h);
       _total_bytes += h.size_bytes;
@@ -217,6 +224,22 @@ class exchange_channel {
     if (_cfg.capacity_bytes > 0 && !_queue.empty() && _total_bytes >= _cfg.capacity_bytes)
       return true;
     return false;
+  }
+
+  /// True when the specific candidate handle `h` may be admitted right now. Caller must hold
+  /// _mutex. Unlike full_unlocked() (a state-only query), this inspects the incoming handle so
+  /// a push that would cross capacity_bytes is rejected even when the queue isn't yet at/over
+  /// the bound (e.g. 40 queued + a 40-byte handle against a 50-byte bound).
+  [[nodiscard]] bool can_push_unlocked(const exchange_batch_handle& h) const
+  {
+    if (_queue.size() >= _cfg.capacity_items) return false;
+    if (_cfg.capacity_bytes == 0) return true;
+    // Oversized-batch rule: always admit into an empty channel so the stream never wedges.
+    if (_queue.empty()) return true;
+    if (_total_bytes >= _cfg.capacity_bytes) return false;
+    // Subtraction (rather than _total_bytes + h.size_bytes) avoids overflow when the incoming
+    // handle reports an implausibly large size.
+    return h.size_bytes <= _cfg.capacity_bytes - _total_bytes;
   }
 
   config _cfg;

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -594,7 +594,7 @@ class sirius_physical_operator {
   //! Get pipeline
   duckdb::shared_ptr<pipeline::sirius_pipeline> get_pipeline() const noexcept;
 
-  void set_pipeline(duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline);
+  virtual void set_pipeline(duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline);
 
  protected:
   duckdb::shared_ptr<pipeline::sirius_pipeline> _pipeline;

--- a/src/include/op/sirius_physical_operator_type.hpp
+++ b/src/include/op/sirius_physical_operator_type.hpp
@@ -150,7 +150,8 @@ enum class SiriusPhysicalOperatorType : uint8_t {
   ICEBERG_SCAN,
   CPU_SOURCE,
   GPU_SCAN,
-  DYNAMIC_FILTER
+  DYNAMIC_FILTER,
+  STREAMING_SOURCE
 };
 
 std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type);

--- a/src/include/op/sirius_physical_streaming_source.hpp
+++ b/src/include/op/sirius_physical_streaming_source.hpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "exec/exchange_channel.hpp"
+#include "op/sirius_physical_operator.hpp"
+
+#include <cucascade/data/data_repository.hpp>
+
+#include <memory>
+#include <optional>
+
+namespace sirius::op {
+
+/// Source operator that pulls data_batch handles from an exchange_channel, resolves each
+/// handle via the input repository, and publishes the batch into the pipeline.
+///
+/// Lifecycle / engine contracts (discoveries §1/§2, plan §4):
+///   - get_next_task_hint(): READY{this} when channel non-empty; WAITING{nullptr} when
+///     open+empty (re-armable by the session pushing to the channel); nullopt when drained.
+///   - all_ports_empty(): delegates to _input_channel->drained(), drives both the task
+///     creation loop and the pipeline-finish predicate (port-less source variant).
+///   - get_next_task_input_data(): non-blocking try_pop + repo resolve; one batch per task.
+///   - execute(): pure pass-through (COLUMN_DATA_SCAN shape — no GPU work).
+///   - no_history_peak_memory_estimate(): returns stats.bytes (pass-through allocates nothing).
+class sirius_physical_streaming_source : public sirius_physical_operator {
+ public:
+  static constexpr SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::STREAMING_SOURCE;
+
+  sirius_physical_streaming_source(
+    duckdb::vector<sirius::logical_type> types,
+    std::size_t estimated_cardinality,
+    std::shared_ptr<exec::exchange_channel> input_channel,
+    std::shared_ptr<cucascade::shared_data_repository> input_repository);
+
+  // -----------------------------------------------------------------------
+  // Source interface
+  // -----------------------------------------------------------------------
+
+  bool is_source() const override { return true; }
+
+  /// READY{this} when channel non-empty (open or closed); WAITING{nullptr} when open+empty;
+  /// nullopt when closed && drained (EOS).
+  std::optional<task_creation_hint> get_next_task_hint() override;
+
+  /// True only when the channel is closed AND empty (EOS). Drives both the task-creation
+  /// guard and the port-less source pipeline-finish predicate.
+  [[nodiscard]] bool all_ports_empty() override;
+
+  /// Non-blocking: try_pop a handle, resolve via repo, wrap in pipelineable_operator_data.
+  /// Returns nullptr when the channel is empty. Throws on a handle missing from the repo.
+  std::unique_ptr<operator_data> get_next_task_input_data() override;
+
+  // -----------------------------------------------------------------------
+  // Execution
+  // -----------------------------------------------------------------------
+
+  /// Pass-through: returns the input batches unchanged.
+  std::unique_ptr<operator_data> execute(const operator_data& input,
+                                         rmm::cuda_stream_view stream) override;
+
+  /// Pass-through allocates nothing new; return input bytes so the reservation system
+  /// does not over-reserve with the default 2× heuristic.
+  [[nodiscard]] std::size_t no_history_peak_memory_estimate(
+    const input_stats& stats) const override;
+
+ private:
+  std::shared_ptr<exec::exchange_channel> _input_channel;
+  std::shared_ptr<cucascade::shared_data_repository> _input_repository;
+};
+
+}  // namespace sirius::op

--- a/src/include/op/sirius_physical_streaming_source.hpp
+++ b/src/include/op/sirius_physical_streaming_source.hpp
@@ -37,6 +37,11 @@ namespace sirius::op {
 ///   - get_next_task_input_data(): non-blocking try_pop + repo resolve; one batch per task.
 ///   - execute(): pure pass-through (COLUMN_DATA_SCAN shape — no GPU work).
 ///   - no_history_peak_memory_estimate(): returns stats.bytes (pass-through allocates nothing).
+///   - Completion: wires the channel's on-close callback (constructor) to
+///     pipeline->update_pipeline_status(), so an empty or already-drained-by-the-last-task
+///     stream still finishes its pipeline even though no task is left in flight to trigger
+///     re-evaluation via mark_task_completed(). See streaming-source-p1-fix-plan-v2-no-task-
+///     creator.md, Finding 1.
 class sirius_physical_streaming_source : public sirius_physical_operator {
  public:
   static constexpr SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::STREAMING_SOURCE;
@@ -46,6 +51,10 @@ class sirius_physical_streaming_source : public sirius_physical_operator {
     std::size_t estimated_cardinality,
     std::shared_ptr<exec::exchange_channel> input_channel,
     std::shared_ptr<cucascade::shared_data_repository> input_repository);
+
+  /// Clears the channel's on-close callback before this operator is destroyed, since the
+  /// channel (owned jointly with the producer side) may outlive it.
+  ~sirius_physical_streaming_source() override;
 
   // -----------------------------------------------------------------------
   // Source interface

--- a/src/include/op/sirius_physical_streaming_source.hpp
+++ b/src/include/op/sirius_physical_streaming_source.hpp
@@ -28,33 +28,22 @@ namespace sirius::op {
 
 /// Source operator that pulls data_batch handles from an exchange_channel, resolves each
 /// handle via the input repository, and publishes the batch into the pipeline.
-///
-/// Lifecycle / engine contracts (discoveries §1/§2, plan §4):
-///   - get_next_task_hint(): READY{this} when channel non-empty; WAITING{nullptr} when
-///     open+empty (re-armable by the session pushing to the channel); nullopt when drained.
-///   - all_ports_empty(): delegates to _input_channel->drained(), drives both the task
-///     creation loop and the pipeline-finish predicate (port-less source variant).
-///   - get_next_task_input_data(): non-blocking try_pop + repo resolve; one batch per task.
-///   - execute(): pure pass-through (COLUMN_DATA_SCAN shape — no GPU work).
-///   - no_history_peak_memory_estimate(): returns stats.bytes (pass-through allocates nothing).
-///   - Completion: wires the channel's on-close callback (constructor) to
-///     pipeline->update_pipeline_status(), so an empty or already-drained-by-the-last-task
-///     stream still finishes its pipeline even though no task is left in flight to trigger
-///     re-evaluation via mark_task_completed(). See streaming-source-p1-fix-plan-v2-no-task-
-///     creator.md, Finding 1.
 class sirius_physical_streaming_source : public sirius_physical_operator {
  public:
   static constexpr SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::STREAMING_SOURCE;
 
+  /// Throws invalid_input_exception when input_channel or input_repository is null.
   sirius_physical_streaming_source(
     duckdb::vector<sirius::logical_type> types,
     std::size_t estimated_cardinality,
     std::shared_ptr<exec::exchange_channel> input_channel,
     std::shared_ptr<cucascade::shared_data_repository> input_repository);
 
-  /// Clears the channel's on-close callback before this operator is destroyed, since the
-  /// channel (owned jointly with the producer side) may outlive it.
-  ~sirius_physical_streaming_source() override;
+  /// Wires the channel's on-close callback to the pipeline so an empty or late-closed
+  /// stream still finishes even when no task is in flight to re-evaluate completion.
+  /// The callback captures a weak reference to the pipeline (never `this`), so a close()
+  /// racing with operator destruction cannot dereference a destroyed operator.
+  void set_pipeline(duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline) override;
 
   // -----------------------------------------------------------------------
   // Source interface

--- a/src/op/sirius_physical_operator_type.cpp
+++ b/src/op/sirius_physical_operator_type.cpp
@@ -117,6 +117,7 @@ std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type)
     case SiriusPhysicalOperatorType::CPU_SOURCE: return "CPU_SOURCE";
     case SiriusPhysicalOperatorType::GPU_SCAN: return "GPU_SCAN";
     case SiriusPhysicalOperatorType::DYNAMIC_FILTER: return "DYNAMIC_FILTER";
+    case SiriusPhysicalOperatorType::STREAMING_SOURCE: return "STREAMING_SOURCE";
     case SiriusPhysicalOperatorType::INVALID: break;
   }
   return "INVALID";

--- a/src/op/sirius_physical_streaming_source.cpp
+++ b/src/op/sirius_physical_streaming_source.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_physical_streaming_source.hpp"
+
+#include "sirius/exception.hpp"
+
+#include <cucascade/data/data_batch.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace sirius::op {
+
+sirius_physical_streaming_source::sirius_physical_streaming_source(
+  duckdb::vector<sirius::logical_type> types,
+  std::size_t estimated_cardinality,
+  std::shared_ptr<exec::exchange_channel> input_channel,
+  std::shared_ptr<cucascade::shared_data_repository> input_repository)
+  : sirius_physical_operator(
+      SiriusPhysicalOperatorType::STREAMING_SOURCE, std::move(types), estimated_cardinality),
+    _input_channel(std::move(input_channel)),
+    _input_repository(std::move(input_repository))
+{
+}
+
+std::optional<task_creation_hint> sirius_physical_streaming_source::get_next_task_hint()
+{
+  // Terminal EOS: channel closed and fully drained.
+  if (_input_channel->drained()) return std::nullopt;
+
+  // Data available (open or closed-but-non-empty): schedule a task.
+  if (!_input_channel->empty()) { return task_creation_hint{TaskCreationHint::READY, this}; }
+
+  // Open but empty: drop the request. A future push must re-schedule via the session (#839).
+  return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, nullptr};
+}
+
+bool sirius_physical_streaming_source::all_ports_empty() { return _input_channel->drained(); }
+
+std::unique_ptr<operator_data> sirius_physical_streaming_source::get_next_task_input_data()
+{
+  auto maybe_handle = _input_channel->try_pop();
+  if (!maybe_handle) return nullptr;
+
+  auto batch = _input_repository->pop_data_batch_by_id(maybe_handle->batch_id);
+  if (!batch) {
+    throw sirius::internal_exception(
+      "sirius_physical_streaming_source: batch_id " + std::to_string(maybe_handle->batch_id) +
+      " not found in input repository — producer must register before pushing handle");
+  }
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> batches{std::move(batch)};
+  return std::make_unique<pipelineable_operator_data>(std::move(batches));
+}
+
+std::unique_ptr<operator_data> sirius_physical_streaming_source::execute(
+  const operator_data& input, rmm::cuda_stream_view /*stream*/)
+{
+  const auto& pod = static_cast<const pipelineable_operator_data&>(input);
+  return std::make_unique<pipelineable_operator_data>(pod.get_data_batches());
+}
+
+std::size_t sirius_physical_streaming_source::no_history_peak_memory_estimate(
+  const input_stats& stats) const
+{
+  // Pass-through: the input is already resident; no additional GPU allocation happens.
+  // Return stats.bytes instead of the default 2× to avoid over-reserving under memory pressure.
+  return stats.bytes;
+}
+
+}  // namespace sirius::op

--- a/src/op/sirius_physical_streaming_source.cpp
+++ b/src/op/sirius_physical_streaming_source.cpp
@@ -36,28 +36,40 @@ sirius_physical_streaming_source::sirius_physical_streaming_source(
     _input_channel(std::move(input_channel)),
     _input_repository(std::move(input_repository))
 {
+  if (!_input_channel) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_source: input_channel must not be null");
+  }
+  if (!_input_repository) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_source: input_repository must not be null");
+  }
+}
+
+void sirius_physical_streaming_source::set_pipeline(
+  duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline)
+{
+  sirius_physical_operator::set_pipeline(pipeline);
+
   // Close is the only event that can make this pipeline finish without a task in flight to
   // call mark_task_completed() -> update_pipeline_status() for it (empty stream, or the last
   // task already completed while the channel was still open). Wire close directly to a
-  // re-evaluation instead of relying on task_creator to notice a dropped nullopt hint — see
-  // docs/super-sirius/streaming-source-p1-fix-plan-v2-no-task-creator.md, Finding 1.
+  // status re-evaluation. `original_pipeline=false` so notify_downstream_pipelines() also
+  // schedules this pipeline's output consumers — with the default (true) an empty or
+  // late-closed stream would finish this pipeline but never re-arm its downstream.
   //
-  // get_pipeline() is resolved lazily (at callback-fire time, not here at construction time):
-  // set_pipeline() runs once per operator during query::build_indices(), which happens after
-  // every operator is constructed but before any channel activity starts in production, so by
-  // the time close() is actually called the pipeline is always set. The null check makes this
-  // safe even if that ordering assumption is ever violated (e.g. in tests that never wire a
-  // pipeline at all).
-  _input_channel->set_on_close([this] {
-    if (auto pipeline = get_pipeline()) { pipeline->update_pipeline_status(); }
+  // The callback captures a weak pipeline reference, never `this`: exchange_channel::close()
+  // snapshots the callback under its mutex and invokes it after unlocking, so a callback
+  // holding `this` could fire after this operator was destroyed (the channel is shared with
+  // the producer side and may outlive the operator).
+  duckdb::weak_ptr<pipeline::sirius_pipeline> weak_pipeline = pipeline;
+  _input_channel->set_on_close([weak_pipeline] {
+    if (auto p = weak_pipeline.lock()) { p->update_pipeline_status(false); }
   });
-}
 
-sirius_physical_streaming_source::~sirius_physical_streaming_source()
-{
-  // The channel may outlive this operator (e.g. held by a producer on another thread); clear
-  // the callback before `this` becomes dangling, per exchange_channel's documented contract.
-  _input_channel->set_on_close(nullptr);
+  // If close() ran before the callback was wired, on_close will never fire; re-evaluate now
+  // so an already-closed empty stream still finishes.
+  if (_input_channel->closed()) { pipeline->update_pipeline_status(false); }
 }
 
 std::optional<task_creation_hint> sirius_physical_streaming_source::get_next_task_hint()

--- a/src/op/sirius_physical_streaming_source.cpp
+++ b/src/op/sirius_physical_streaming_source.cpp
@@ -16,6 +16,7 @@
 
 #include "op/sirius_physical_streaming_source.hpp"
 
+#include "pipeline/sirius_pipeline.hpp"
 #include "sirius/exception.hpp"
 
 #include <cucascade/data/data_batch.hpp>
@@ -35,6 +36,28 @@ sirius_physical_streaming_source::sirius_physical_streaming_source(
     _input_channel(std::move(input_channel)),
     _input_repository(std::move(input_repository))
 {
+  // Close is the only event that can make this pipeline finish without a task in flight to
+  // call mark_task_completed() -> update_pipeline_status() for it (empty stream, or the last
+  // task already completed while the channel was still open). Wire close directly to a
+  // re-evaluation instead of relying on task_creator to notice a dropped nullopt hint — see
+  // docs/super-sirius/streaming-source-p1-fix-plan-v2-no-task-creator.md, Finding 1.
+  //
+  // get_pipeline() is resolved lazily (at callback-fire time, not here at construction time):
+  // set_pipeline() runs once per operator during query::build_indices(), which happens after
+  // every operator is constructed but before any channel activity starts in production, so by
+  // the time close() is actually called the pipeline is always set. The null check makes this
+  // safe even if that ordering assumption is ever violated (e.g. in tests that never wire a
+  // pipeline at all).
+  _input_channel->set_on_close([this] {
+    if (auto pipeline = get_pipeline()) { pipeline->update_pipeline_status(); }
+  });
+}
+
+sirius_physical_streaming_source::~sirius_physical_streaming_source()
+{
+  // The channel may outlive this operator (e.g. held by a producer on another thread); clear
+  // the callback before `this` becomes dangling, per exchange_channel's documented contract.
+  _input_channel->set_on_close(nullptr);
 }
 
 std::optional<task_creation_hint> sirius_physical_streaming_source::get_next_task_hint()

--- a/test/cpp/exec/test_exchange_channel.cpp
+++ b/test/cpp/exec/test_exchange_channel.cpp
@@ -335,3 +335,111 @@ TEST_CASE("exchange_channel: hooks fire outside the lock", "[exchange_channel]")
   REQUIRE(pop_count.load() == 1);
   REQUIRE(size_in_pop_cb.load() == 1);
 }
+
+// ============================================================================
+// CH-12 (Finding 3a, reproduction): a push that would push the cumulative total
+// past capacity_bytes must be rejected. full_unlocked() only inspects bytes
+// already queued, not the incoming candidate, so a 40-byte handle is wrongly
+// admitted on top of 40 already-queued bytes in a 50-byte-bound channel.
+// See docs/super-sirius/streaming-source-p1-p3-fix-plan.md, Finding 3.
+// ============================================================================
+
+TEST_CASE("exchange_channel: cumulative push crossing byte bound is rejected (Finding 3a)",
+          "[exchange_channel][byte_admission]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 10, .capacity_bytes = 50});
+
+  REQUIRE(ch.try_push(make_handle(0, 40)));
+  REQUIRE_FALSE(ch.full());  // 40 < 50 — current full() correctly reports not-full here.
+
+  // BUG: the incoming 40-byte handle would bring the total to 80 (> 50), but
+  // full_unlocked() only compares the *already-queued* 40 bytes against the bound,
+  // so this push is wrongly admitted today.
+  REQUIRE_FALSE(ch.try_push(make_handle(1, 40)));
+  REQUIRE(ch.size_bytes() == 40);
+}
+
+// ============================================================================
+// CH-13 (Finding 3b, reproduction): the oversized-batch rule is documented to
+// admit an oversized handle only into an *empty* channel. A non-empty channel
+// must reject an oversized handle instead of wedging past its byte bound.
+// ============================================================================
+
+TEST_CASE("exchange_channel: oversized handle rejected while queue is non-empty (Finding 3b)",
+          "[exchange_channel][byte_admission]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 10, .capacity_bytes = 50});
+
+  REQUIRE(ch.try_push(make_handle(0, 1)));  // 1 byte queued — far under the bound.
+
+  // BUG: full_unlocked() only compares the queued total (1) against the bound (50),
+  // so this 200-byte handle is wrongly admitted even though the queue is non-empty.
+  REQUIRE_FALSE(ch.try_push(make_handle(1, 200)));
+  REQUIRE(ch.size_bytes() == 1);
+}
+
+// ============================================================================
+// CH-14 (Finding 3c, must-not-regress): the same oversized handle IS accepted
+// once the queue drains back to empty — the oversized-batch rule must keep
+// working for a channel that becomes empty again, not just a freshly-built one.
+// ============================================================================
+
+TEST_CASE("exchange_channel: oversized handle accepted once queue becomes empty (Finding 3c)",
+          "[exchange_channel][byte_admission]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 10, .capacity_bytes = 50});
+
+  REQUIRE(ch.try_push(make_handle(0, 1)));
+  auto h = ch.try_pop();
+  REQUIRE(h.has_value());
+  REQUIRE(ch.empty());
+
+  REQUIRE(ch.try_push(make_handle(1, 200)));
+  REQUIRE(ch.size_bytes() == 200);
+}
+
+// ============================================================================
+// CH-15 (Finding 3, blocking push): a blocking push() whose candidate would
+// cross the byte bound must wait rather than being admitted immediately, and
+// must succeed once popping frees enough byte capacity.
+// ============================================================================
+
+TEST_CASE("exchange_channel: blocking push waits for byte headroom (Finding 3, blocking path)",
+          "[exchange_channel][byte_admission]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 10, .capacity_bytes = 50});
+
+  REQUIRE(ch.try_push(make_handle(0, 40)));  // 40 queued, 10 bytes of headroom left.
+
+  std::atomic<bool> unblocked{false};
+  std::atomic<bool> push_ok{false};
+  std::thread producer([&] {
+    // A 40-byte handle would cross the 50-byte bound on top of the 40 already
+    // queued; with a correct admission check this call must block instead of
+    // returning immediately. Today's buggy full_unlocked()-only check admits it
+    // right away, so this thread will observe `unblocked` flip to true before the
+    // pop below ever runs.
+    //
+    // Assertions here use CHECK (non-throwing) rather than REQUIRE: a throwing
+    // assertion on this thread would propagate as an unhandled exception across
+    // the thread boundary and crash the whole test binary via std::terminate.
+    bool ok = ch.push(make_handle(1, 40));
+    push_ok.store(ok, std::memory_order_release);
+    unblocked.store(true, std::memory_order_release);
+  });
+
+  // CHECK (not REQUIRE): if this fails, `producer` must still be joined below —
+  // a REQUIRE failure here would throw and unwind past producer.join(), and a
+  // still-joinable std::thread's destructor calls std::terminate().
+  std::this_thread::sleep_for(10ms);
+  CHECK_FALSE(unblocked.load());
+
+  // Popping the first handle frees all 40 bytes, leaving 50 bytes of headroom —
+  // enough for the pending 40-byte push to proceed.
+  auto h = ch.pop();
+  CHECK(h.has_value());
+
+  producer.join();
+  REQUIRE(unblocked.load());
+  REQUIRE(push_ok.load());
+}

--- a/test/cpp/exec/test_exchange_channel.cpp
+++ b/test/cpp/exec/test_exchange_channel.cpp
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Pure CPU tests — no GPU required.
+
+#include "catch.hpp"
+#include "exec/exchange_channel.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <set>
+#include <thread>
+#include <vector>
+
+using namespace sirius::exec;
+using namespace std::chrono_literals;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+static exchange_batch_handle make_handle(uint64_t id, std::size_t bytes = 0)
+{
+  return exchange_batch_handle{id, bytes};
+}
+
+// ============================================================================
+// CH-1: fresh channel state
+// ============================================================================
+
+TEST_CASE("exchange_channel: fresh channel", "[exchange_channel]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 4});
+  REQUIRE(ch.empty());
+  REQUIRE_FALSE(ch.full());
+  REQUIRE(ch.size() == 0);
+  REQUIRE(ch.size_bytes() == 0);
+  REQUIRE_FALSE(ch.closed());
+  REQUIRE_FALSE(ch.drained());
+}
+
+// ============================================================================
+// CH-2: fill to capacity_items
+// ============================================================================
+
+TEST_CASE("exchange_channel: fill to capacity_items", "[exchange_channel]")
+{
+  const std::size_t N = 4;
+  exchange_channel ch(exchange_channel::config{.capacity_items = N});
+
+  for (std::size_t i = 0; i < N; ++i) {
+    REQUIRE(ch.try_push(make_handle(i)));
+  }
+  REQUIRE(ch.size() == N);
+  REQUIRE(ch.full());
+  REQUIRE_FALSE(ch.empty());
+
+  // One more item must be rejected.
+  REQUIRE_FALSE(ch.try_push(make_handle(N)));
+}
+
+// ============================================================================
+// CH-3: byte bound
+// ============================================================================
+
+TEST_CASE("exchange_channel: byte bound blocks push when non-empty", "[exchange_channel]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 10, .capacity_bytes = 100});
+
+  // Push an item that brings total bytes to exactly the bound.
+  REQUIRE(ch.try_push(make_handle(0, 100)));
+  REQUIRE(ch.size_bytes() == 100);
+  REQUIRE(ch.full());
+
+  // Next push must be rejected (bytes >= bound AND non-empty).
+  REQUIRE_FALSE(ch.try_push(make_handle(1, 1)));
+}
+
+// ============================================================================
+// CH-4: oversized-batch rule
+// ============================================================================
+
+TEST_CASE("exchange_channel: oversized batch admitted into empty channel", "[exchange_channel]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 4, .capacity_bytes = 50});
+
+  // A batch larger than capacity_bytes must be admitted when the channel is empty.
+  REQUIRE_FALSE(ch.full());
+  REQUIRE(ch.try_push(make_handle(0, 200)));
+  REQUIRE(ch.size() == 1);
+  REQUIRE(ch.size_bytes() == 200);
+  // After admission the channel is "full" by bytes.
+  REQUIRE(ch.full());
+}
+
+// ============================================================================
+// CH-5: FIFO ordering and size_bytes tracking
+// ============================================================================
+
+TEST_CASE("exchange_channel: FIFO ordering and size_bytes tracking", "[exchange_channel]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 8});
+
+  REQUIRE(ch.try_push(make_handle(10, 100)));
+  REQUIRE(ch.try_push(make_handle(20, 200)));
+  REQUIRE(ch.try_push(make_handle(30, 300)));
+  REQUIRE(ch.size_bytes() == 600);
+
+  auto h0 = ch.try_pop();
+  REQUIRE(h0.has_value());
+  REQUIRE(h0->batch_id == 10);
+  REQUIRE(ch.size_bytes() == 500);
+
+  auto h1 = ch.try_pop();
+  REQUIRE(h1.has_value());
+  REQUIRE(h1->batch_id == 20);
+  REQUIRE(ch.size_bytes() == 300);
+
+  auto h2 = ch.try_pop();
+  REQUIRE(h2.has_value());
+  REQUIRE(h2->batch_id == 30);
+  REQUIRE(ch.size_bytes() == 0);
+  REQUIRE(ch.empty());
+}
+
+// ============================================================================
+// CH-6: blocking push unblocks when consumer pops
+// ============================================================================
+
+TEST_CASE("exchange_channel: blocking push unblocks on pop", "[exchange_channel]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 1});
+
+  REQUIRE(ch.try_push(make_handle(0)));  // fills the channel
+  REQUIRE(ch.full());
+
+  std::atomic<bool> unblocked{false};
+  std::thread producer([&] {
+    bool ok = ch.push(make_handle(1));  // blocks until consumer pops
+    REQUIRE(ok);
+    unblocked.store(true, std::memory_order_release);
+  });
+
+  std::this_thread::sleep_for(10ms);
+  REQUIRE_FALSE(unblocked.load());
+
+  // Consumer pops — producer should unblock.
+  auto h = ch.pop();
+  REQUIRE(h.has_value());
+
+  producer.join();
+  REQUIRE(unblocked.load());
+}
+
+// ============================================================================
+// CH-7: close-then-drain semantics
+// ============================================================================
+
+TEST_CASE("exchange_channel: close-then-drain", "[exchange_channel]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 4});
+
+  REQUIRE(ch.try_push(make_handle(1)));
+  REQUIRE(ch.try_push(make_handle(2)));
+
+  ch.close();
+  REQUIRE(ch.closed());
+  REQUIRE_FALSE(ch.drained());  // items still queued
+
+  // Pushes after close are rejected.
+  REQUIRE_FALSE(ch.try_push(make_handle(3)));
+  REQUIRE_FALSE(ch.push(make_handle(4)));
+
+  // Queued items still pop in FIFO order.
+  auto h1 = ch.pop();
+  REQUIRE(h1.has_value());
+  REQUIRE(h1->batch_id == 1);
+  REQUIRE_FALSE(ch.drained());
+
+  auto h2 = ch.pop();
+  REQUIRE(h2.has_value());
+  REQUIRE(h2->batch_id == 2);
+
+  // Now drained.
+  REQUIRE(ch.empty());
+  REQUIRE(ch.drained());
+
+  // pop on a drained channel returns nullopt immediately.
+  auto h3 = ch.pop();
+  REQUIRE_FALSE(h3.has_value());
+}
+
+// ============================================================================
+// CH-8: blocked pop wakes on close
+// ============================================================================
+
+TEST_CASE("exchange_channel: blocked pop wakes on close", "[exchange_channel]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 4});
+
+  std::atomic<bool> returned_nullopt{false};
+  std::thread consumer([&] {
+    auto h = ch.pop();  // blocks on empty open channel
+    REQUIRE_FALSE(h.has_value());
+    returned_nullopt.store(true, std::memory_order_release);
+  });
+
+  std::this_thread::sleep_for(10ms);
+  REQUIRE_FALSE(returned_nullopt.load());
+
+  ch.close();
+  consumer.join();
+  REQUIRE(returned_nullopt.load());
+}
+
+// ============================================================================
+// CH-9: close is idempotent
+// ============================================================================
+
+TEST_CASE("exchange_channel: close is idempotent", "[exchange_channel]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 4});
+
+  ch.close();
+  ch.close();  // second call must not throw or deadlock
+  REQUIRE(ch.closed());
+  REQUIRE_FALSE(ch.try_push(make_handle(0)));
+  REQUIRE_FALSE(ch.push(make_handle(0)));
+}
+
+// ============================================================================
+// CH-10: MPMC stress — each handle delivered exactly once
+// ============================================================================
+
+TEST_CASE("exchange_channel: MPMC stress — each handle delivered exactly once",
+          "[exchange_channel]")
+{
+  constexpr int N_PRODUCERS          = 4;
+  constexpr int N_CONSUMERS          = 3;
+  constexpr int HANDLES_PER_PRODUCER = 200;
+  constexpr int TOTAL                = N_PRODUCERS * HANDLES_PER_PRODUCER;
+
+  exchange_channel ch(exchange_channel::config{.capacity_items = 16});
+
+  std::atomic<int> consumed{0};
+  std::set<uint64_t> seen;
+  std::mutex seen_mutex;
+
+  // Consumers: drain until they have seen TOTAL items.
+  std::vector<std::thread> consumers;
+  for (int c = 0; c < N_CONSUMERS; ++c) {
+    consumers.emplace_back([&] {
+      while (true) {
+        auto h = ch.pop();
+        if (!h.has_value()) break;  // drained
+        {
+          std::lock_guard<std::mutex> lk(seen_mutex);
+          seen.insert(h->batch_id);
+        }
+        consumed.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+  }
+
+  // Producers: push handles, then close once last producer is done.
+  std::vector<std::thread> producers;
+  std::atomic<int> done_producers{0};
+  for (int p = 0; p < N_PRODUCERS; ++p) {
+    producers.emplace_back([&, p] {
+      for (int i = 0; i < HANDLES_PER_PRODUCER; ++i) {
+        uint64_t id = static_cast<uint64_t>(p * HANDLES_PER_PRODUCER + i);
+        while (!ch.push(make_handle(id))) {
+          // push returns false only if closed — shouldn't happen here
+          break;
+        }
+      }
+      if (done_producers.fetch_add(1, std::memory_order_acq_rel) + 1 == N_PRODUCERS) { ch.close(); }
+    });
+  }
+
+  for (auto& t : producers)
+    t.join();
+  for (auto& t : consumers)
+    t.join();
+
+  REQUIRE(consumed.load() == TOTAL);
+  REQUIRE(static_cast<int>(seen.size()) == TOTAL);
+}
+
+// ============================================================================
+// CH-11: hooks fire once per op and are called outside the lock
+// ============================================================================
+
+TEST_CASE("exchange_channel: hooks fire outside the lock", "[exchange_channel]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 4});
+
+  std::atomic<int> push_count{0};
+  std::atomic<int> pop_count{0};
+  std::atomic<std::size_t> size_in_push_cb{0};
+  std::atomic<std::size_t> size_in_pop_cb{0};
+
+  ch.set_on_push([&] {
+    push_count.fetch_add(1, std::memory_order_relaxed);
+    // size() acquires the mutex; if the callback were fired inside the lock this would deadlock.
+    size_in_push_cb.store(ch.size(), std::memory_order_relaxed);
+  });
+  ch.set_on_pop([&] {
+    pop_count.fetch_add(1, std::memory_order_relaxed);
+    size_in_pop_cb.store(ch.size(), std::memory_order_relaxed);
+  });
+
+  REQUIRE(ch.try_push(make_handle(1)));
+  REQUIRE(push_count.load() == 1);
+  REQUIRE(size_in_push_cb.load() == 1);
+
+  REQUIRE(ch.try_push(make_handle(2)));
+  REQUIRE(push_count.load() == 2);
+
+  auto h = ch.try_pop();
+  REQUIRE(h.has_value());
+  REQUIRE(pop_count.load() == 1);
+  REQUIRE(size_in_pop_cb.load() == 1);
+}

--- a/test/cpp/exec/test_exchange_channel.cpp
+++ b/test/cpp/exec/test_exchange_channel.cpp
@@ -21,6 +21,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <limits>
 #include <set>
 #include <thread>
 #include <vector>
@@ -150,7 +151,8 @@ TEST_CASE("exchange_channel: blocking push unblocks on pop", "[exchange_channel]
   std::atomic<bool> unblocked{false};
   std::thread producer([&] {
     bool ok = ch.push(make_handle(1));  // blocks until consumer pops
-    REQUIRE(ok);
+    // CHECK (not REQUIRE): a throwing assertion in a std::thread terminates the process.
+    CHECK(ok);
     unblocked.store(true, std::memory_order_release);
   });
 
@@ -214,7 +216,8 @@ TEST_CASE("exchange_channel: blocked pop wakes on close", "[exchange_channel]")
   std::atomic<bool> returned_nullopt{false};
   std::thread consumer([&] {
     auto h = ch.pop();  // blocks on empty open channel
-    REQUIRE_FALSE(h.has_value());
+    // CHECK (not REQUIRE): a throwing assertion in a std::thread terminates the process.
+    CHECK_FALSE(h.has_value());
     returned_nullopt.store(true, std::memory_order_release);
   });
 
@@ -337,11 +340,11 @@ TEST_CASE("exchange_channel: hooks fire outside the lock", "[exchange_channel]")
 }
 
 // ============================================================================
-// CH-16 (Finding 1): on_close fires exactly once, outside the lock, only on the
+// CH-16: on_close fires exactly once, outside the lock, only on the
 // first successful close().
 // ============================================================================
 
-TEST_CASE("exchange_channel: on_close fires exactly once outside the lock (Finding 1)",
+TEST_CASE("exchange_channel: on_close fires exactly once outside the lock",
           "[exchange_channel][pipeline_completion]")
 {
   exchange_channel ch(exchange_channel::config{.capacity_items = 4});
@@ -367,12 +370,12 @@ TEST_CASE("exchange_channel: on_close fires exactly once outside the lock (Findi
 }
 
 // ============================================================================
-// CH-17 (Finding 1): on_close fires even for a channel that closes with items
+// CH-17: on_close fires even for a channel that closes with items
 // still queued (close-then-drain — the callback signals "no more pushes will
 // ever happen", not "the queue is empty").
 // ============================================================================
 
-TEST_CASE("exchange_channel: on_close fires even when items remain queued (Finding 1)",
+TEST_CASE("exchange_channel: on_close fires even when items remain queued",
           "[exchange_channel][pipeline_completion]")
 {
   exchange_channel ch(exchange_channel::config{.capacity_items = 4});
@@ -388,14 +391,13 @@ TEST_CASE("exchange_channel: on_close fires even when items remain queued (Findi
 }
 
 // ============================================================================
-// CH-12 (Finding 3a, reproduction): a push that would push the cumulative total
+// CH-12 (reproduction): a push that would push the cumulative total
 // past capacity_bytes must be rejected. full_unlocked() only inspects bytes
 // already queued, not the incoming candidate, so a 40-byte handle is wrongly
 // admitted on top of 40 already-queued bytes in a 50-byte-bound channel.
-// See docs/super-sirius/streaming-source-p1-p3-fix-plan.md, Finding 3.
 // ============================================================================
 
-TEST_CASE("exchange_channel: cumulative push crossing byte bound is rejected (Finding 3a)",
+TEST_CASE("exchange_channel: cumulative push crossing byte bound is rejected",
           "[exchange_channel][byte_admission]")
 {
   exchange_channel ch(exchange_channel::config{.capacity_items = 10, .capacity_bytes = 50});
@@ -411,12 +413,12 @@ TEST_CASE("exchange_channel: cumulative push crossing byte bound is rejected (Fi
 }
 
 // ============================================================================
-// CH-13 (Finding 3b, reproduction): the oversized-batch rule is documented to
+// CH-13 (reproduction): the oversized-batch rule is documented to
 // admit an oversized handle only into an *empty* channel. A non-empty channel
 // must reject an oversized handle instead of wedging past its byte bound.
 // ============================================================================
 
-TEST_CASE("exchange_channel: oversized handle rejected while queue is non-empty (Finding 3b)",
+TEST_CASE("exchange_channel: oversized handle rejected while queue is non-empty",
           "[exchange_channel][byte_admission]")
 {
   exchange_channel ch(exchange_channel::config{.capacity_items = 10, .capacity_bytes = 50});
@@ -430,12 +432,12 @@ TEST_CASE("exchange_channel: oversized handle rejected while queue is non-empty 
 }
 
 // ============================================================================
-// CH-14 (Finding 3c, must-not-regress): the same oversized handle IS accepted
+// CH-14 (must-not-regress): the same oversized handle IS accepted
 // once the queue drains back to empty — the oversized-batch rule must keep
 // working for a channel that becomes empty again, not just a freshly-built one.
 // ============================================================================
 
-TEST_CASE("exchange_channel: oversized handle accepted once queue becomes empty (Finding 3c)",
+TEST_CASE("exchange_channel: oversized handle accepted once queue becomes empty",
           "[exchange_channel][byte_admission]")
 {
   exchange_channel ch(exchange_channel::config{.capacity_items = 10, .capacity_bytes = 50});
@@ -450,12 +452,12 @@ TEST_CASE("exchange_channel: oversized handle accepted once queue becomes empty 
 }
 
 // ============================================================================
-// CH-15 (Finding 3, blocking push): a blocking push() whose candidate would
+// CH-15 (blocking push): a blocking push() whose candidate would
 // cross the byte bound must wait rather than being admitted immediately, and
 // must succeed once popping frees enough byte capacity.
 // ============================================================================
 
-TEST_CASE("exchange_channel: blocking push waits for byte headroom (Finding 3, blocking path)",
+TEST_CASE("exchange_channel: blocking push waits for byte headroom (blocking path)",
           "[exchange_channel][byte_admission]")
 {
   exchange_channel ch(exchange_channel::config{.capacity_items = 10, .capacity_bytes = 50});
@@ -493,4 +495,34 @@ TEST_CASE("exchange_channel: blocking push waits for byte headroom (Finding 3, b
   producer.join();
   REQUIRE(unblocked.load());
   REQUIRE(push_ok.load());
+}
+
+// ============================================================================
+// CH-18: byte accounting never overflows
+// ============================================================================
+
+TEST_CASE("exchange_channel: rejects a push that would overflow byte accounting",
+          "[exchange_channel]")
+{
+  constexpr auto max_bytes = std::numeric_limits<std::size_t>::max();
+
+  // Byte-unbounded channel: this is the only configuration where the cumulative
+  // total is not already capped by capacity_bytes at admission time.
+  exchange_channel ch(exchange_channel::config{.capacity_items = 4});
+
+  REQUIRE(ch.try_push(make_handle(1, max_bytes)));
+  REQUIRE(ch.size_bytes() == max_bytes);
+
+  // Admitting even one more byte would wrap _total_bytes.
+  REQUIRE_FALSE(ch.try_push(make_handle(2, 1)));
+  // A zero-sized handle still fits exactly.
+  REQUIRE(ch.try_push(make_handle(3, 0)));
+  REQUIRE(ch.size_bytes() == max_bytes);
+
+  // Popping the oversized handle restores headroom.
+  auto h = ch.try_pop();
+  REQUIRE(h.has_value());
+  REQUIRE(h->batch_id == 1);
+  REQUIRE(ch.size_bytes() == 0);
+  REQUIRE(ch.try_push(make_handle(4, 1)));
 }

--- a/test/cpp/exec/test_exchange_channel.cpp
+++ b/test/cpp/exec/test_exchange_channel.cpp
@@ -337,6 +337,57 @@ TEST_CASE("exchange_channel: hooks fire outside the lock", "[exchange_channel]")
 }
 
 // ============================================================================
+// CH-16 (Finding 1): on_close fires exactly once, outside the lock, only on the
+// first successful close().
+// ============================================================================
+
+TEST_CASE("exchange_channel: on_close fires exactly once outside the lock (Finding 1)",
+          "[exchange_channel][pipeline_completion]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 4});
+
+  std::atomic<int> close_count{0};
+  std::atomic<bool> was_closed_in_cb{false};
+  ch.set_on_close([&] {
+    close_count.fetch_add(1, std::memory_order_relaxed);
+    // closed() acquires the mutex; if the callback fired inside the lock this would deadlock.
+    was_closed_in_cb.store(ch.closed(), std::memory_order_relaxed);
+  });
+
+  REQUIRE(close_count.load() == 0);  // not fired before close() is ever called
+
+  ch.close();
+  REQUIRE(close_count.load() == 1);
+  REQUIRE(was_closed_in_cb.load());
+
+  // Repeated close() calls must not re-fire the callback.
+  ch.close();
+  ch.close();
+  REQUIRE(close_count.load() == 1);
+}
+
+// ============================================================================
+// CH-17 (Finding 1): on_close fires even for a channel that closes with items
+// still queued (close-then-drain — the callback signals "no more pushes will
+// ever happen", not "the queue is empty").
+// ============================================================================
+
+TEST_CASE("exchange_channel: on_close fires even when items remain queued (Finding 1)",
+          "[exchange_channel][pipeline_completion]")
+{
+  exchange_channel ch(exchange_channel::config{.capacity_items = 4});
+
+  std::atomic<int> close_count{0};
+  ch.set_on_close([&] { close_count.fetch_add(1, std::memory_order_relaxed); });
+
+  REQUIRE(ch.try_push(make_handle(0)));
+  ch.close();
+
+  REQUIRE(close_count.load() == 1);
+  REQUIRE_FALSE(ch.drained());  // item still queued — on_close still fired
+}
+
+// ============================================================================
 // CH-12 (Finding 3a, reproduction): a push that would push the cumulative total
 // past capacity_bytes must be rejected. full_unlocked() only inspects bytes
 // already queued, not the incoming candidate, so a 40-byte handle is wrongly

--- a/test/cpp/operator/test_physical_streaming_source.cpp
+++ b/test/cpp/operator/test_physical_streaming_source.cpp
@@ -31,6 +31,7 @@
 #include <helper/type_conversions.hpp>
 #include <op/sirius_physical_filter.hpp>
 #include <op/sirius_physical_streaming_source.hpp>
+#include <pipeline/sirius_pipeline.hpp>
 
 #include <atomic>
 #include <memory>
@@ -72,6 +73,24 @@ static auto make_source(std::size_t channel_capacity = 16)
     ch,
     repo);
   return std::make_tuple(std::move(op), ch, repo);
+}
+
+/// Wire a trivial single-operator pipeline (source == sink, no intermediate
+/// operators) around an already-constructed streaming source, so tests can drive
+/// the *real* sirius_pipeline completion predicate (update_pipeline_status() /
+/// is_pipeline_finished()) instead of only inspecting the operator in isolation.
+/// Mirrors the minimal wiring pattern used by
+/// test/cpp/pipeline/test_gpu_pipeline_task_history.cpp's create_pipeline_context().
+static duckdb::shared_ptr<sirius::pipeline::sirius_pipeline> make_single_op_pipeline(
+  sirius_physical_streaming_source& op)
+{
+  sirius::pipeline::pipeline_build_context build_ctx{nullptr, true};
+  auto pipeline = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(build_ctx);
+  sirius::pipeline::sirius_pipeline_build_state build_state;
+  build_state.set_pipeline_source(*pipeline, op);
+  build_state.set_pipeline_sink(*pipeline, &op, 1);
+  op.set_pipeline(pipeline);
+  return pipeline;
 }
 
 }  // namespace
@@ -350,7 +369,6 @@ TEST_CASE("streaming_source SRC-13: task owns batch; repo no longer holds it", "
 
   auto [op, ch, repo] = make_source();
   auto batch          = make_numeric_batch<int32_t>(*gpu_space, {1, 2}, cudf::type_id::INT32);
-  auto batch_id       = batch->get_batch_id();
   push_batch(repo, *ch, batch);
 
   REQUIRE(repo->total_size() == 1);
@@ -700,4 +718,88 @@ TEST_CASE("streaming_source SRC-21: concurrent input-data pulls deliver each bat
 
   REQUIRE(received.load() == K);
   REQUIRE(static_cast<int>(ids.size()) == K);
+}
+
+// ============================================================================
+// BUG-1 (Finding 1a, reproduction): closing an empty stream must finish a
+// zero-task pipeline. See docs/super-sirius/streaming-source-p1-p3-fix-plan.md,
+// Finding 1, "Empty stream" failure mode.
+//
+// These BUG-* tests exercise the real sirius_pipeline completion predicate
+// (update_pipeline_status() / is_pipeline_finished()), not just the operator's
+// own hint/all_ports_empty() methods, because the bug is in what *calls*
+// update_pipeline_status() (or rather, what fails to), not in the predicate
+// itself.
+// ============================================================================
+
+TEST_CASE(
+  "streaming_source BUG-1 (Finding 1a): closing an empty stream finishes a zero-task pipeline",
+  "[streaming_source][pipeline_completion]")
+{
+  auto [op, ch, repo] = make_source();
+  auto pipeline       = make_single_op_pipeline(*op);
+
+  REQUIRE_FALSE(pipeline->is_pipeline_finished());
+
+  // Stream closes with zero batches ever pushed: tasks_created == tasks_completed
+  // == 0 forever, and the source is now exhausted (closed + drained).
+  ch->close();
+  REQUIRE(op->all_ports_empty());
+  REQUIRE(pipeline->get_tasks_created() == 0);
+  REQUIRE(pipeline->get_tasks_completed() == 0);
+
+  // BUG: nothing in the current architecture re-evaluates pipeline status when a
+  // source's stream closes without ever needing a task — task_creator's
+  // manager_loop silently drops the request when get_operator_for_next_task()
+  // resolves to nullptr, so update_pipeline_status() is never called here. The
+  // finish predicate is already satisfiable (0 == 0 tasks, source exhausted) but
+  // nobody asks it to check.
+  REQUIRE(pipeline->is_pipeline_finished());
+}
+
+// ============================================================================
+// BUG-2 (Finding 1b, reproduction): closing the stream after the last task has
+// already completed must finish the pipeline. See streaming-source-p1-p3-fix-
+// plan.md, Finding 1, "Late close" failure mode.
+// ============================================================================
+
+TEST_CASE(
+  "streaming_source BUG-2 (Finding 1b): late close after last task completed finishes "
+  "the pipeline",
+  "[streaming_source][pipeline_completion]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, ch, repo] = make_source();
+  auto pipeline       = make_single_op_pipeline(*op);
+
+  auto batch = make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32);
+  push_batch(repo, *ch, batch);
+
+  // Simulate the one real task the task-creator would have made for this batch:
+  // mark_task_created()/mark_task_completed() are the same production calls made
+  // by gpu_pipeline_task's constructor/destructor.
+  pipeline->mark_task_created();
+  auto pod = op->get_next_task_input_data();
+  REQUIRE(pod != nullptr);
+
+  // Task completes while the channel is still OPEN (more data could still
+  // arrive): correctly not finished yet.
+  pipeline->mark_task_completed();
+  REQUIRE_FALSE(op->all_ports_empty());
+  REQUIRE_FALSE(pipeline->is_pipeline_finished());
+
+  // Later: the producer closes the stream. No more tasks will ever run, and the
+  // last one already completed (tasks_created == tasks_completed == 1).
+  ch->close();
+  REQUIRE(op->all_ports_empty());
+  REQUIRE(pipeline->get_tasks_created() == pipeline->get_tasks_completed());
+
+  // BUG: the close happens with no task in flight, so nothing calls
+  // mark_task_completed() -> update_pipeline_status() to notice the pipeline can
+  // now finish. The pipeline is stuck even though its finish predicate is
+  // satisfied.
+  REQUIRE(pipeline->is_pipeline_finished());
 }

--- a/test/cpp/operator/test_physical_streaming_source.cpp
+++ b/test/cpp/operator/test_physical_streaming_source.cpp
@@ -17,6 +17,7 @@
 #include "operator_test_utils.hpp"
 
 #include <catch.hpp>
+#include <creator/task_creator.hpp>
 #include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
@@ -32,9 +33,12 @@
 #include <op/sirius_physical_filter.hpp>
 #include <op/sirius_physical_streaming_source.hpp>
 #include <pipeline/sirius_pipeline.hpp>
+#include <sirius/exception.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <thread>
 #include <vector>
@@ -721,9 +725,8 @@ TEST_CASE("streaming_source SRC-21: concurrent input-data pulls deliver each bat
 }
 
 // ============================================================================
-// BUG-1 (Finding 1a, reproduction): closing an empty stream must finish a
-// zero-task pipeline. See docs/super-sirius/streaming-source-p1-p3-fix-plan.md,
-// Finding 1, "Empty stream" failure mode.
+// BUG-1 (reproduction): closing an empty stream must finish a zero-task
+// pipeline.
 //
 // These BUG-* tests exercise the real sirius_pipeline completion predicate
 // (update_pipeline_status() / is_pipeline_finished()), not just the operator's
@@ -732,9 +735,8 @@ TEST_CASE("streaming_source SRC-21: concurrent input-data pulls deliver each bat
 // itself.
 // ============================================================================
 
-TEST_CASE(
-  "streaming_source BUG-1 (Finding 1a): closing an empty stream finishes a zero-task pipeline",
-  "[streaming_source][pipeline_completion]")
+TEST_CASE("streaming_source BUG-1: closing an empty stream finishes a zero-task pipeline",
+          "[streaming_source][pipeline_completion]")
 {
   auto [op, ch, repo] = make_source();
   auto pipeline       = make_single_op_pipeline(*op);
@@ -758,15 +760,12 @@ TEST_CASE(
 }
 
 // ============================================================================
-// BUG-2 (Finding 1b, reproduction): closing the stream after the last task has
-// already completed must finish the pipeline. See streaming-source-p1-p3-fix-
-// plan.md, Finding 1, "Late close" failure mode.
+// BUG-2 (reproduction): closing the stream after the last task has already
+// completed must finish the pipeline.
 // ============================================================================
 
-TEST_CASE(
-  "streaming_source BUG-2 (Finding 1b): late close after last task completed finishes "
-  "the pipeline",
-  "[streaming_source][pipeline_completion]")
+TEST_CASE("streaming_source BUG-2: late close after last task completed finishes the pipeline",
+          "[streaming_source][pipeline_completion]")
 {
   auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
   auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
@@ -802,4 +801,135 @@ TEST_CASE(
   // now finish. The pipeline is stuck even though its finish predicate is
   // satisfied.
   REQUIRE(pipeline->is_pipeline_finished());
+}
+
+// ============================================================================
+// SRC-22: constructor input validation
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-22: null channel or repository is rejected", "[streaming_source]")
+{
+  auto types =
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER});
+  auto ch   = std::make_shared<exchange_channel>(exchange_channel::config{16});
+  auto repo = std::make_shared<cucascade::shared_data_repository>();
+
+  REQUIRE_THROWS_AS(sirius_physical_streaming_source(types, 0, nullptr, repo),
+                    sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(sirius_physical_streaming_source(types, 0, ch, nullptr),
+                    sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// SRC-23: close after the consumer side is destroyed must not touch freed
+// memory. The on-close callback holds only a weak pipeline reference, so a
+// producer closing a channel that outlived its operator/pipeline is a no-op.
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-23: close after operator and pipeline destruction is safe",
+          "[streaming_source][pipeline_completion]")
+{
+  auto [op, ch, repo] = make_source();
+  {
+    auto pipeline = make_single_op_pipeline(*op);
+  }
+  op.reset();  // channel (producer side) outlives the whole consumer side
+
+  ch->close();  // fires on_close; the weak pipeline reference is expired
+  REQUIRE(ch->drained());
+}
+
+// ============================================================================
+// BUG-3 / BUG-4: pipeline completion must also re-arm downstream pipelines.
+// update_pipeline_status(false) makes notify_downstream_pipelines() schedule
+// this pipeline's output consumers via the task_creator; with the default
+// (true) an empty or late-closed stream finishes this pipeline but its
+// downstream pipeline never gets a task scheduled.
+// ============================================================================
+
+namespace {
+
+/// task_creator that only records what would have been scheduled.
+class recording_task_creator : public sirius::creator::task_creator {
+ public:
+  explicit recording_task_creator(sirius::memory::sirius_memory_reservation_manager& mem_mgr)
+    : task_creator(sirius::exec::thread_pool_config{.num_threads        = 1,
+                                                    .thread_name_prefix = "test_task_creator"},
+                   mem_mgr)
+  {
+  }
+
+  void schedule(sirius_physical_operator* request) override
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _scheduled.push_back(request);
+  }
+
+  bool scheduled(const sirius_physical_operator* op)
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return std::find(_scheduled.begin(), _scheduled.end(), op) != _scheduled.end();
+  }
+
+ private:
+  std::mutex _mutex;
+  std::vector<sirius_physical_operator*> _scheduled;
+};
+
+}  // namespace
+
+TEST_CASE("streaming_source BUG-3: closing an empty stream schedules downstream consumers",
+          "[streaming_source][pipeline_completion]")
+{
+  auto mem_mgr = sirius::test::operator_utils::initialize_memory_manager();
+  recording_task_creator creator(*mem_mgr);
+
+  auto [op, ch, repo] = make_source();
+  auto pipeline       = make_single_op_pipeline(*op);
+  pipeline->set_task_creator(&creator);
+
+  // Downstream pipeline consuming this one's output: its source operator is what
+  // notify_downstream_pipelines() must hand to the task_creator on finish.
+  auto [downstream_op, downstream_ch, downstream_repo] = make_source();
+  auto downstream                                      = make_single_op_pipeline(*downstream_op);
+  downstream->add_dependency(pipeline);
+
+  ch->close();
+
+  REQUIRE(pipeline->is_pipeline_finished());
+  REQUIRE(creator.scheduled(downstream_op.get()));
+}
+
+TEST_CASE("streaming_source BUG-4: late close after last task schedules downstream consumers",
+          "[streaming_source][pipeline_completion]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+  recording_task_creator creator(*mem_mgr);
+
+  auto [op, ch, repo] = make_source();
+  auto pipeline       = make_single_op_pipeline(*op);
+  pipeline->set_task_creator(&creator);
+
+  auto [downstream_op, downstream_ch, downstream_repo] = make_source();
+  auto downstream                                      = make_single_op_pipeline(*downstream_op);
+  downstream->add_dependency(pipeline);
+
+  // Run the stream's one real task to completion while the channel is still open.
+  auto batch = make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32);
+  push_batch(repo, *ch, batch);
+  pipeline->mark_task_created();
+  auto pod = op->get_next_task_input_data();
+  REQUIRE(pod != nullptr);
+  pipeline->mark_task_completed();
+  REQUIRE_FALSE(pipeline->is_pipeline_finished());
+  REQUIRE_FALSE(creator.scheduled(downstream_op.get()));
+
+  // Late close with no task in flight: the pipeline must finish AND its
+  // downstream consumer must still get scheduled.
+  ch->close();
+
+  REQUIRE(pipeline->is_pipeline_finished());
+  REQUIRE(creator.scheduled(downstream_op.get()));
 }

--- a/test/cpp/operator/test_physical_streaming_source.cpp
+++ b/test/cpp/operator/test_physical_streaming_source.cpp
@@ -1,0 +1,703 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator_test_utils.hpp"
+
+#include <catch.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <data/data_batch_utils.hpp>
+#include <data/sirius_converter_registry.hpp>
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <exec/exchange_channel.hpp>
+#include <expression/ast/from_duckdb.hpp>
+#include <helper/type_conversions.hpp>
+#include <op/sirius_physical_filter.hpp>
+#include <op/sirius_physical_streaming_source.hpp>
+
+#include <atomic>
+#include <memory>
+#include <set>
+#include <thread>
+#include <vector>
+
+using namespace sirius::exec;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+
+namespace {
+
+using namespace sirius::test::operator_utils;
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+/// Producer contract helper: register batch in repo, then push handle to channel.
+static void push_batch(std::shared_ptr<cucascade::shared_data_repository> repo,
+                       exchange_channel& ch,
+                       std::shared_ptr<cucascade::data_batch> batch)
+{
+  uint64_t id = batch->get_batch_id();
+  repo->add_data_batch(batch);
+  REQUIRE(ch.try_push(exchange_batch_handle{id, 0}));
+}
+
+/// Create a streaming source with a fresh channel and repo.
+static auto make_source(std::size_t channel_capacity = 16)
+{
+  auto ch   = std::make_shared<exchange_channel>(exchange_channel::config{channel_capacity});
+  auto repo = std::make_shared<cucascade::shared_data_repository>();
+  auto op   = std::make_unique<sirius_physical_streaming_source>(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    ch,
+    repo);
+  return std::make_tuple(std::move(op), ch, repo);
+}
+
+}  // namespace
+
+// ============================================================================
+// SRC-1: open + empty → WAITING{nullptr}
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-1: open+empty hint is WAITING{nullptr}", "[streaming_source]")
+{
+  auto [op, ch, repo] = make_source();
+  auto hint           = op->get_next_task_hint();
+  REQUIRE(hint.has_value());
+  REQUIRE(hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+  REQUIRE(hint->producer == nullptr);
+}
+
+// ============================================================================
+// SRC-2: non-empty → READY{this}
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-2: non-empty hint is READY{this}", "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, ch, repo] = make_source();
+  auto batch          = make_numeric_batch<int32_t>(*gpu_space, {1, 2, 3}, cudf::type_id::INT32);
+  push_batch(repo, *ch, batch);
+
+  auto hint = op->get_next_task_hint();
+  REQUIRE(hint.has_value());
+  REQUIRE(hint->hint == TaskCreationHint::READY);
+  REQUIRE(hint->producer == op.get());
+}
+
+// ============================================================================
+// SRC-3: closed && drained → nullopt
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-3: closed+drained hint is nullopt", "[streaming_source]")
+{
+  auto [op, ch, repo] = make_source();
+  ch->close();
+  REQUIRE(ch->drained());
+  auto hint = op->get_next_task_hint();
+  REQUIRE_FALSE(hint.has_value());
+}
+
+// ============================================================================
+// SRC-4: closed but not drained → READY{this}
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-4: closed+non-empty hint is READY{this}", "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, ch, repo] = make_source();
+  auto batch          = make_numeric_batch<int32_t>(*gpu_space, {10}, cudf::type_id::INT32);
+  push_batch(repo, *ch, batch);
+
+  ch->close();
+  REQUIRE_FALSE(ch->drained());
+
+  auto hint = op->get_next_task_hint();
+  REQUIRE(hint.has_value());
+  REQUIRE(hint->hint == TaskCreationHint::READY);
+  REQUIRE(hint->producer == op.get());
+}
+
+// ============================================================================
+// SRC-5: all_ports_empty() tracks drained state
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-5: all_ports_empty reflects channel drained state",
+          "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, ch, repo] = make_source();
+
+  // Open + empty: NOT done (must not finish pipeline early).
+  REQUIRE_FALSE(op->all_ports_empty());
+
+  // Push a batch, then close.
+  auto batch = make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32);
+  push_batch(repo, *ch, batch);
+  ch->close();
+
+  // Closed but not drained.
+  REQUIRE_FALSE(op->all_ports_empty());
+
+  // Drain the channel.
+  auto pod = op->get_next_task_input_data();
+  REQUIRE(pod != nullptr);
+
+  // Now drained.
+  REQUIRE(op->all_ports_empty());
+}
+
+// ============================================================================
+// SRC-6: input-data happy path — pointer identity proves zero-copy
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-6: input-data happy path preserves batch identity",
+          "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, ch, repo] = make_source();
+  auto batch          = make_numeric_batch<int32_t>(*gpu_space, {1, 2, 3}, cudf::type_id::INT32);
+  auto expected_id    = batch->get_batch_id();
+  push_batch(repo, *ch, batch);
+
+  auto data = op->get_next_task_input_data();
+  REQUIRE(data != nullptr);
+
+  auto& pod     = dynamic_cast<pipelineable_operator_data&>(*data);
+  auto& batches = pod.get_data_batches();
+  REQUIRE(batches.size() == 1);
+  REQUIRE(batches[0]->get_batch_id() == expected_id);
+}
+
+// ============================================================================
+// SRC-7: empty channel → nullptr, no throw
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-7: empty channel returns nullptr non-blocking",
+          "[streaming_source]")
+{
+  auto [op, ch, repo] = make_source();
+  auto data           = op->get_next_task_input_data();
+  REQUIRE(data == nullptr);
+}
+
+// ============================================================================
+// SRC-8: dangling handle (id not in repo) → throws
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-8: dangling handle throws", "[streaming_source]")
+{
+  auto [op, ch, repo] = make_source();
+
+  // Push a handle without registering the batch in the repo.
+  REQUIRE(ch->try_push(exchange_batch_handle{9999, 0}));
+
+  REQUIRE_THROWS(op->get_next_task_input_data());
+}
+
+// ============================================================================
+// SRC-9: one-batch-per-task
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-9: one handle per call to get_next_task_input_data",
+          "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr int K     = 5;
+  auto [op, ch, repo] = make_source();
+
+  for (int i = 0; i < K; ++i) {
+    auto batch = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    push_batch(repo, *ch, batch);
+  }
+
+  int pulls = 0;
+  while (true) {
+    auto data = op->get_next_task_input_data();
+    if (!data) break;
+    auto& pod = dynamic_cast<pipelineable_operator_data&>(*data);
+    REQUIRE(pod.get_data_batches().size() == 1);
+    ++pulls;
+  }
+  REQUIRE(pulls == K);
+}
+
+// ============================================================================
+// SRC-10: no_history_peak_memory_estimate returns stats.bytes
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-10: memory estimate is stats.bytes (pass-through)",
+          "[streaming_source]")
+{
+  auto [op, ch, repo] = make_source();
+
+  input_stats stats;
+  stats.bytes       = 12345;
+  stats.num_batches = 1;
+
+  REQUIRE(op->no_history_peak_memory_estimate(stats) == stats.bytes);
+}
+
+// ============================================================================
+// SRC-11: execute identity — numeric round-trip
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-11: execute round-trips numeric batch bit-exact",
+          "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream         = default_stream();
+  auto [op, ch, repo] = make_source();
+
+  std::vector<int32_t> values{10, 20, 30, 40, 50};
+  auto batch = make_numeric_batch<int32_t>(*gpu_space, values, cudf::type_id::INT32);
+  push_batch(repo, *ch, batch);
+
+  auto input  = op->get_next_task_input_data();
+  auto output = op->execute(*input, stream);
+
+  auto& out_pod     = dynamic_cast<pipelineable_operator_data&>(*output);
+  auto& out_batches = out_pod.get_data_batches();
+  REQUIRE(out_batches.size() == 1);
+
+  auto view   = sirius::get_cudf_table_view(*out_batches[0]);
+  auto result = copy_column_to_host<int32_t>(view.column(0));
+  REQUIRE(result == values);
+}
+
+// ============================================================================
+// SRC-12: execute identity — multi-column and strings
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-12: execute round-trips two-column and string batches",
+          "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream         = default_stream();
+  auto [op, ch, repo] = make_source();
+
+  std::vector<int64_t> col0{1, 2, 3};
+  std::vector<int32_t> col1{10, 20, 30};
+  auto batch =
+    make_two_column_batch<int64_t, int32_t>(*gpu_space, col0, col1, cudf::type_id::INT32);
+  push_batch(repo, *ch, batch);
+
+  auto input  = op->get_next_task_input_data();
+  auto output = op->execute(*input, stream);
+
+  auto& out_pod     = dynamic_cast<pipelineable_operator_data&>(*output);
+  auto& out_batches = out_pod.get_data_batches();
+  REQUIRE(out_batches.size() == 1);
+
+  auto view   = sirius::get_cudf_table_view(*out_batches[0]);
+  auto res_c0 = copy_column_to_host<int64_t>(view.column(0));
+  auto res_c1 = copy_column_to_host<int32_t>(view.column(1));
+  REQUIRE(res_c0 == col0);
+  REQUIRE(res_c1 == col1);
+}
+
+// ============================================================================
+// SRC-13: ownership — batch removed from repo after input-data pull
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-13: task owns batch; repo no longer holds it", "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, ch, repo] = make_source();
+  auto batch          = make_numeric_batch<int32_t>(*gpu_space, {1, 2}, cudf::type_id::INT32);
+  auto batch_id       = batch->get_batch_id();
+  push_batch(repo, *ch, batch);
+
+  REQUIRE(repo->total_size() == 1);
+
+  auto pod = op->get_next_task_input_data();
+  REQUIRE(pod != nullptr);
+
+  // Batch is now owned by the task's pipelineable_operator_data; repo should be empty.
+  REQUIRE(repo->total_size() == 0);
+}
+
+// ============================================================================
+// SRC-14: spill self-heal — downgrade queued batch to HOST, then pull and
+//         prepare_for_processing restores it to GPU, execute returns intact data.
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-14: spill self-heal via prepare_for_processing",
+          "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  // Find host space.
+  auto* host_space =
+    const_cast<cucascade::memory::memory_space*>(mem_mgr->get_memory_space(Tier::HOST, 0));
+  if (!host_space) {
+    auto host_spaces = mem_mgr->get_memory_spaces_for_tier(Tier::HOST);
+    REQUIRE_FALSE(host_spaces.empty());
+    host_space = const_cast<cucascade::memory::memory_space*>(host_spaces.front());
+  }
+  REQUIRE(host_space != nullptr);
+
+  rmm::cuda_stream conv_stream;
+  auto& registry = sirius::converter_registry::get();
+
+  auto [op, ch, repo] = make_source();
+
+  std::vector<int32_t> values{7, 8, 9};
+  auto batch = make_numeric_batch<int32_t>(*gpu_space, values, cudf::type_id::INT32);
+  push_batch(repo, *ch, batch);
+
+  // Downgrade the queued batch to HOST while it waits in the repo.
+  {
+    auto mut = batch->to_mutable();
+    mut.convert_to<cucascade::host_data_representation>(registry, host_space, conv_stream);
+  }
+  {
+    auto ro = batch->to_read_only();
+    REQUIRE(ro.get_data()->get_current_tier() == Tier::HOST);
+  }
+
+  // Pull via get_next_task_input_data.
+  auto pod_data = op->get_next_task_input_data();
+  REQUIRE(pod_data != nullptr);
+
+  // Simulate what the pipeline executor does: prepare_for_processing restores to GPU.
+  auto& pod = dynamic_cast<pipelineable_operator_data&>(*pod_data);
+  pod.prepare_for_processing(gpu_space, conv_stream);
+
+  // Execute should return intact data.
+  auto output       = op->execute(*pod_data, conv_stream);
+  auto& out_pod     = dynamic_cast<pipelineable_operator_data&>(*output);
+  auto& out_batches = out_pod.get_data_batches();
+  REQUIRE(out_batches.size() == 1);
+
+  auto view   = sirius::get_cudf_table_view(*out_batches[0]);
+  auto result = copy_column_to_host<int32_t>(view.column(0));
+  REQUIRE(result == values);
+}
+
+// ============================================================================
+// SRC-15: lifecycle end-to-end — push k, close, drain all, then EOS
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-15: lifecycle end-to-end: k batches out then EOS",
+          "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr int K     = 4;
+  auto stream         = default_stream();
+  auto [op, ch, repo] = make_source();
+
+  for (int i = 0; i < K; ++i) {
+    auto batch = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    push_batch(repo, *ch, batch);
+  }
+  ch->close();
+
+  int received = 0;
+  while (true) {
+    auto hint = op->get_next_task_hint();
+    if (!hint.has_value()) break;                                       // EOS
+    if (hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA) break;  // shouldn't happen
+
+    auto pod = op->get_next_task_input_data();
+    if (!pod) break;
+    auto output = op->execute(*pod, stream);
+    ++received;
+  }
+
+  REQUIRE(received == K);
+  REQUIRE(op->all_ports_empty());
+}
+
+// ============================================================================
+// SRC-16: empty stream — close with zero batches → immediately EOS
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-16: empty stream → immediate EOS", "[streaming_source]")
+{
+  auto [op, ch, repo] = make_source();
+  ch->close();
+
+  auto hint = op->get_next_task_hint();
+  REQUIRE_FALSE(hint.has_value());
+  REQUIRE(op->all_ports_empty());
+}
+
+// ============================================================================
+// SRC-17: source → FILTER chain (run_one_operator style chaining)
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-17: execute output feeds into real sirius_physical_filter",
+          "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream         = default_stream();
+  auto [op, ch, repo] = make_source();
+
+  // Two-column batch: col0 = filter key (int64), col1 = int32 data.
+  std::vector<int64_t> filter_col{1, 5, 2, 8, 3};
+  std::vector<int32_t> data_col{10, 50, 20, 80, 30};
+  auto batch =
+    make_two_column_batch<int64_t, int32_t>(*gpu_space, filter_col, data_col, cudf::type_id::INT32);
+  push_batch(repo, *ch, batch);
+
+  // Execute source: pass-through.
+  auto source_input = op->get_next_task_input_data();
+  auto source_out   = op->execute(*source_input, stream);
+
+  // Build filter: col0 > 3 (BIGINT).
+  auto filter_expr_duck = duckdb::make_uniq<duckdb::BoundComparisonExpression>(
+    duckdb::ExpressionType::COMPARE_GREATERTHAN,
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(
+      duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), 0),
+    duckdb::make_uniq<duckdb::BoundConstantExpression>(duckdb::Value::BIGINT(3)));
+  auto filter_ast = sirius::ast::from_duckdb(*filter_expr_duck);
+
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  sirius_physical_filter filter_op(sirius::from_duckdb_vec(types), std::move(filter_ast), 0);
+
+  // Chain: feed source output into filter.
+  auto filter_out = filter_op.execute(*source_out, stream);
+
+  auto& out_pod     = dynamic_cast<pipelineable_operator_data&>(*filter_out);
+  auto& out_batches = out_pod.get_data_batches();
+  REQUIRE(out_batches.size() == 1);
+
+  auto view       = sirius::get_cudf_table_view(*out_batches[0]);
+  auto res_filter = copy_column_to_host<int64_t>(view.column(0));
+  auto res_data   = copy_column_to_host<int32_t>(view.column(1));
+
+  // Expect rows where col0 > 3: values {5, 8}.
+  REQUIRE(res_filter == std::vector<int64_t>{5, 8});
+  REQUIRE(res_data == std::vector<int32_t>{50, 80});
+}
+
+// ============================================================================
+// SRC-18: source pipeline → boundary port via base-class sink()
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-18: sink pushes batch to downstream boundary port",
+          "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream         = default_stream();
+  auto [op, ch, repo] = make_source();
+
+  auto batch    = make_numeric_batch<int32_t>(*gpu_space, {1, 2, 3}, cudf::type_id::INT32);
+  auto batch_id = batch->get_batch_id();
+  push_batch(repo, *ch, batch);
+
+  // Execute source to produce output.
+  auto input  = op->get_next_task_input_data();
+  auto output = op->execute(*input, stream);
+
+  // Create a downstream operator and wire up a port+repo.
+  sirius_physical_operator downstream_op;
+  auto downstream_repo           = std::make_unique<cucascade::shared_data_repository>();
+  auto downstream_port           = std::make_unique<sirius_physical_operator::port>();
+  downstream_port->type          = MemoryBarrierType::FULL;
+  downstream_port->repo          = downstream_repo.get();
+  downstream_port->src_pipeline  = nullptr;
+  downstream_port->dest_pipeline = nullptr;
+  downstream_op.add_port("input", std::move(downstream_port));
+
+  // Register downstream as next sink target.
+  op->add_next_port_after_sink({&downstream_op, "input"});
+
+  // Sink the source output → batch should land in downstream repo.
+  op->sink(*output, stream);
+
+  auto batch_ids = downstream_repo->get_batch_ids();
+  REQUIRE(batch_ids.size() == 1);
+  REQUIRE(batch_ids[0] == batch_id);
+}
+
+// ============================================================================
+// SRC-19: hint chaining — WAITING{&source} recurses to source's hint
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-19: hint chaining reaches source via WAITING producer",
+          "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, ch, repo] = make_source();
+
+  // When channel is empty: source returns WAITING{nullptr}. Chaining ends.
+  {
+    task_creation_hint downstream_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, op.get()};
+    auto chained = downstream_hint.producer->get_next_task_hint();
+    REQUIRE(chained.has_value());
+    REQUIRE(chained->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+    REQUIRE(chained->producer == nullptr);
+  }
+
+  // Push a batch: source should now return READY.
+  auto batch = make_numeric_batch<int32_t>(*gpu_space, {42}, cudf::type_id::INT32);
+  push_batch(repo, *ch, batch);
+
+  {
+    task_creation_hint downstream_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, op.get()};
+    auto chained = downstream_hint.producer->get_next_task_hint();
+    REQUIRE(chained.has_value());
+    REQUIRE(chained->hint == TaskCreationHint::READY);
+    REQUIRE(chained->producer == op.get());
+  }
+}
+
+// ============================================================================
+// SRC-20: producer thread + consumer loop — k batches, no deadlock
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-20: producer thread and consumer loop", "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr int K     = 20;
+  auto stream         = default_stream();
+  auto [op, ch, repo] = make_source(8 /*capacity*/);
+
+  std::atomic<int> pushed{0};
+  std::thread producer([&] {
+    for (int i = 0; i < K; ++i) {
+      auto batch = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+      // Serialize repo registration + channel push.
+      uint64_t id = batch->get_batch_id();
+      repo->add_data_batch(batch);
+      while (!ch->push(exchange_batch_handle{id, 0})) {
+        // push returns false only on close — shouldn't happen during producer run.
+        break;
+      }
+      pushed.fetch_add(1, std::memory_order_release);
+    }
+    ch->close();
+  });
+
+  int received = 0;
+  while (true) {
+    auto hint = op->get_next_task_hint();
+    if (!hint.has_value()) break;  // EOS
+    if (hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA) {
+      std::this_thread::yield();
+      continue;
+    }
+    auto pod = op->get_next_task_input_data();
+    if (!pod) {
+      std::this_thread::yield();
+      continue;
+    }
+    auto out = op->execute(*pod, stream);
+    ++received;
+  }
+  producer.join();
+
+  REQUIRE(received == K);
+  REQUIRE(op->all_ports_empty());
+}
+
+// ============================================================================
+// SRC-21: concurrent input-data pulls — each batch delivered exactly once
+// ============================================================================
+
+TEST_CASE("streaming_source SRC-21: concurrent input-data pulls deliver each batch once",
+          "[streaming_source]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr int K     = 40;
+  auto [op, ch, repo] = make_source(K);
+
+  for (int i = 0; i < K; ++i) {
+    auto batch = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    push_batch(repo, *ch, batch);
+  }
+
+  std::atomic<int> received{0};
+  std::set<uint64_t> ids;
+  std::mutex ids_mutex;
+
+  auto worker = [&] {
+    while (true) {
+      auto pod = op->get_next_task_input_data();
+      if (!pod) break;
+      auto& p       = dynamic_cast<pipelineable_operator_data&>(*pod);
+      auto& batches = p.get_data_batches();
+      std::lock_guard<std::mutex> lk(ids_mutex);
+      for (auto& b : batches) {
+        ids.insert(b->get_batch_id());
+      }
+      received.fetch_add(static_cast<int>(batches.size()), std::memory_order_relaxed);
+    }
+  };
+
+  std::thread t1(worker);
+  std::thread t2(worker);
+  t1.join();
+  t2.join();
+
+  REQUIRE(received.load() == K);
+  REQUIRE(static_cast<int>(ids.size()) == K);
+}


### PR DESCRIPTION
PR 1 of 2 for #836 (sink: #837). Adds the exchange building blocks for streaming
execution. Deliberately unwired — nothing constructs the operator outside tests;
wiring lands with the stream session (#839).

## What

- `sirius::exec::exchange_channel` — bounded MPMC queue of `{batch_id, size_bytes}`
  handles (item + byte capacity, close-then-drain EOS, push/pop/close hooks fired
  outside the lock).
- `sirius::op::sirius_physical_streaming_source` — multi-shot source: pops one handle
  per task, resolves the batch via `shared_data_repository`, passes it through
  unchanged.

## Design notes

- The channel carries handles, not `shared_ptr`s: the repository stays owner of record,
  so queued batches remain visible to the downgrade/spill sweep and self-heal on resolve.
- Source hint contract: `READY` when non-empty, `WAITING` when open+empty (re-armed by
  the session in #839), done when closed and drained.
- Channel close notifies the pipeline via a weak reference and re-arms downstream
  consumers, so empty or late-closed streams still finish.
- Known gap, deferred to #839: the channel bound does not bound the task-scheduler
  backlog; the session must gate task creation on in-flight work (documented in
  `operators.md`).

## Testing

- `[exchange_channel]` (CPU): capacity/byte admission, overflow guard, FIFO, close
  semantics, MPMC stress, callback contracts.
- `[streaming_source]` (GPU): hint/lifecycle, pass-through identity, spill self-heal,
  input validation, callback lifetime after operator destruction, and pipeline
  completion for empty/late-closed streams including downstream re-arming.