### PR TITLE
fix: silence build warnings

### DIFF
--- a/src/cuda/scan/gpu_decode_bitpacking.cu
+++ b/src/cuda/scan/gpu_decode_bitpacking.cu
@@ -81,7 +81,6 @@ __global__ void kernel_decode_bitpacking(detail::cta_block_desc const* __restric
                                          int num_groups)
 {
   using vec_t               = int4;
-  auto constexpr VEC_BYTES  = sizeof(vec_t);
   auto constexpr WORD_BYTES = sizeof(uint32_t);
   auto constexpr WORD_BITS  = ::cuda::std::numeric_limits<uint32_t>::digits;
 

--- a/src/include/util/error_utils.hpp
+++ b/src/include/util/error_utils.hpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <spdlog/spdlog.h>
+#include <log/logging.hpp>
 
 #include <exception>
 #include <source_location>

--- a/src/memory/sirius_memory_reservation_manager.cpp
+++ b/src/memory/sirius_memory_reservation_manager.cpp
@@ -42,7 +42,8 @@ sirius_memory_reservation_manager::sirius_memory_reservation_manager(
     auto const device_mr = space->get_default_allocator();
     rmm::cuda_set_device_raii set_device{rmm::cuda_device_id{space->get_device_id()}};
     // Capture the old resource by value (not by ref) — see comment in header for why.
-    prev_device_mrs_.push_back(cudf::set_current_device_resource_ref(device_mr));
+    prev_device_mrs_.push_back(cudf::set_current_device_resource(
+      ::cuda::mr::any_resource<::cuda::mr::device_accessible>{device_mr}));
   }
 }
 

--- a/test/cpp/data/test_convertible_gpu_pipeline_task.cpp
+++ b/test/cpp/data/test_convertible_gpu_pipeline_task.cpp
@@ -114,7 +114,7 @@ TEST_CASE("RAII returns task to queue on destruction", "[convertible_gpu_pipelin
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{1, 2, 3}, cudf::type_id::INT32);
   auto task = make_test_gpu_task(1, {batch});
-  queue.push(std::move(task));
+  REQUIRE(queue.push(std::move(task)));
   REQUIRE(queue.size() == 1);
 
   {
@@ -136,7 +136,7 @@ TEST_CASE("RAII returns task after successful convert", "[convertible_gpu_pipeli
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{10, 20, 30}, cudf::type_id::INT32);
   auto task = make_test_gpu_task(1, {batch});
-  queue.push(std::move(task));
+  REQUIRE(queue.push(std::move(task)));
 
   {
     sirius::convertible_gpu_pipeline_task_provider provider(queue);
@@ -171,7 +171,7 @@ TEST_CASE("RAII returns task on exception", "[convertible_gpu_pipeline_task]")
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{4, 5, 6}, cudf::type_id::INT32);
   auto task = make_test_gpu_task(1, {batch});
-  queue.push(std::move(task));
+  REQUIRE(queue.push(std::move(task)));
 
   {
     sirius::convertible_gpu_pipeline_task_provider provider(queue);
@@ -195,7 +195,7 @@ TEST_CASE("non-gpu_pipeline_task skipped by predicate", "[convertible_gpu_pipeli
   auto& e = env();
 
   sirius::exec::inspectable_mpsc<sirius::parallel::itask> queue;
-  queue.push(std::make_unique<dummy_task>());
+  REQUIRE(queue.push(std::make_unique<dummy_task>()));
   REQUIRE(queue.size() == 1);
 
   sirius::convertible_gpu_pipeline_task_provider provider(queue);
@@ -213,7 +213,7 @@ TEST_CASE("wrong memory_space skipped by predicate", "[convertible_gpu_pipeline_
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{1, 2, 3}, cudf::type_id::INT32);
   auto task = make_test_gpu_task(1, {batch});
-  queue.push(std::move(task));
+  REQUIRE(queue.push(std::move(task)));
 
   sirius::convertible_gpu_pipeline_task_provider provider(queue);
   // Search for tasks in host_space — should find nothing (batch is in gpu_space)
@@ -231,7 +231,7 @@ TEST_CASE("non-idle batch skipped by predicate", "[convertible_gpu_pipeline_task
     *e.gpu_space, std::vector<int32_t>{7, 8, 9}, cudf::type_id::INT32);
 
   auto task = make_test_gpu_task(1, {batch});
-  queue.push(std::move(task));
+  REQUIRE(queue.push(std::move(task)));
 
   // Hold an exclusive lock so batch is not idle — provider should skip it
   auto exclusive_lock = batch->to_mutable();
@@ -255,7 +255,7 @@ TEST_CASE("matching task selected by predicate", "[convertible_gpu_pipeline_task
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{1, 2, 3}, cudf::type_id::INT32);
   auto task = make_test_gpu_task(1, {batch});  // batch is idle
-  queue.push(std::move(task));
+  REQUIRE(queue.push(std::move(task)));
 
   sirius::convertible_gpu_pipeline_task_provider provider(queue);
   auto cd = provider.get_next_convertible(e.gpu_space, false);
@@ -271,7 +271,7 @@ TEST_CASE("convert GPU task to HOST", "[convertible_gpu_pipeline_task]")
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{100, 200, 300}, cudf::type_id::INT32);
   auto task = make_test_gpu_task(1, {batch});
-  queue.push(std::move(task));
+  REQUIRE(queue.push(std::move(task)));
 
   sirius::convertible_gpu_pipeline_task_provider provider(queue);
   auto cd = provider.get_next_convertible(e.gpu_space, false);
@@ -297,7 +297,7 @@ TEST_CASE("bytes_in_space returns correct size", "[convertible_gpu_pipeline_task
   auto batch2_size = get_batch_size(*batch2);
 
   auto task = make_test_gpu_task(1, {batch1, batch2});
-  queue.push(std::move(task));
+  REQUIRE(queue.push(std::move(task)));
 
   sirius::convertible_gpu_pipeline_task_provider provider(queue);
   auto cd = provider.get_next_convertible(e.gpu_space, false);
@@ -317,7 +317,7 @@ TEST_CASE("get_all_convertible extracts all matching tasks", "[convertible_gpu_p
     auto batch = sirius::test::operator_utils::make_numeric_batch(
       *e.gpu_space, std::vector<int32_t>{1, 2, 3}, cudf::type_id::INT32);
     auto task = make_test_gpu_task(i + 1, {batch});
-    queue.push(std::move(task));
+    REQUIRE(queue.push(std::move(task)));
   }
   REQUIRE(queue.size() == 3);
 
@@ -339,7 +339,7 @@ TEST_CASE("RAII on interrupted queue does not crash", "[convertible_gpu_pipeline
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{1, 2, 3}, cudf::type_id::INT32);
   auto task = make_test_gpu_task(1, {batch});
-  queue.push(std::move(task));
+  REQUIRE(queue.push(std::move(task)));
 
   {
     sirius::convertible_gpu_pipeline_task_provider provider(queue);


### PR DESCRIPTION
Fixes four build warnings originating from this tree:

- **`gpu_decode_bitpacking.cu`** — remove dead `VEC_BYTES` constant (nvcc `#177-D`).
- **`test_convertible_gpu_pipeline_task.cpp`** — wrap `inspectable_mpsc::push` in `REQUIRE` (`-Wunused-result` on the `[[nodiscard]]` return).
- **`error_utils.hpp`** — include `log/logging.hpp` instead of `<spdlog/spdlog.h>` so it stops leaking spdlog before `SPDLOG_ACTIVE_LEVEL` is set, tripping logging.hpp's guard `#warning`.
- **`sirius_memory_reservation_manager.cpp`** — use non-deprecated `cudf::set_current_device_resource` (`-Wdeprecated-declarations`).

Not addressed here: the `operator` reserved-keyword `cargo:warning` comes from quent's codegen, so it needs an upstream change + pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)