### PR TITLE
ci: speed up submodule checkout

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,8 +29,6 @@ jobs:
       CONDA_OVERRIDE_CUDA: "13"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          submodules: recursive
 
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
@@ -105,12 +103,17 @@ jobs:
     continue-on-error: ${{ matrix.build.cudf-channel == 'nightly' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          submodules: recursive
 
-      - name: Unshallow vcpkg for version overrides
+      - name: Init build submodules
+        run: git submodule update --init --depth=1 --jobs 3 duckdb substrait cucascade
+
+      - name: Init vcpkg with full history for version overrides
         if: matrix.build.environment == 'vcpkg'
-        run: git -C vcpkg rev-parse --is-shallow-repository | grep -q true && git -C vcpkg fetch --unshallow || true
+        run: |
+          git submodule update --init vcpkg
+          if [[ "$(git -C vcpkg rev-parse --is-shallow-repository)" == "true" ]]; then
+            git -C vcpkg fetch --unshallow
+          fi
 
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Init starrocks submodules
         working-directory: ${{ github.workspace }}
-        run: git submodule update --init --depth=1 experimental/starrocks/starrocks experimental/starrocks/brpc
+        run: git submodule update --init --depth=1 --jobs 2 experimental/starrocks/starrocks experimental/starrocks/brpc
 
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,9 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          submodules: recursive
+
+      - name: Init build submodules
+        run: git submodule update --init --depth=1 --jobs 3 duckdb substrait cucascade
 
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,9 @@ repos:
       - id: check-json
       - id: check-merge-conflict
       - id: check-symlinks
+        # These tracked links target the optional .claude/claude-tools submodule,
+        # which lint CI intentionally leaves uninitialized.
+        exclude: '^\.claude/(commands/(commit-push-pr|review)\.md|skills/skill-creator)$'
       - id: check-toml
       - id: check-yaml
       - id: debug-statements


### PR DESCRIPTION
## Summary

- Skip submodules for lint and ignore its optional Claude-tool symlinks.
- Shallow-fetch only `duckdb`, `substrait`, and `cucascade`, in parallel.
- Fetch full vcpkg history only for the vcpkg build.

## Checkout timings

Measured from step timestamps against `dev` SHA `506a1d9f` (checkout + explicit init):

| Job | dev | PR | Change |
|---|---:|---:|---:|
| Lint | 84s | 4s | -95% |
| Check / GCC | 96s | 21s | -78% |
| Check / Clang | 90s | 22s | -76% |
| Test build | 71s | 14s | -80% |
| StarRocks | 27s | 33s | no gain |

All PR checks pass.