### PR TITLE
fix: match constructor init-list order to declaration order

### DIFF
--- a/src/include/scan_manager/load_balancing_scan_batch_coalescer.hpp
+++ b/src/include/scan_manager/load_balancing_scan_batch_coalescer.hpp
@@ -81,8 +81,8 @@ class load_balancing_scan_batch_coalescer {
       : op_id(op_id),
         pipeline_id(pipeline_id),
         coalescer(std::move(coalescer)),
-        connector(std::move(connector)),
-        balancer(std::move(balancer))
+        balancer(std::move(balancer)),
+        connector(std::move(connector))
     {
       assert(this->coalescer);
       assert(this->connector);

--- a/src/include/sirius_interface.hpp
+++ b/src/include/sirius_interface.hpp
@@ -28,7 +28,7 @@ class sirius_prepared_statement_data {
   sirius_prepared_statement_data(
     duckdb::shared_ptr<duckdb::PreparedStatementData> _prepared,
     duckdb::unique_ptr<op::sirius_physical_operator> _sirius_physical_plan)
-    : prepared(_prepared), sirius_physical_plan(std::move(_sirius_physical_plan))
+    : sirius_physical_plan(std::move(_sirius_physical_plan)), prepared(_prepared)
   {
   }
   //! The sirius physical plan

--- a/src/op/dynamic_filter_publish_plan.cpp
+++ b/src/op/dynamic_filter_publish_plan.cpp
@@ -33,8 +33,8 @@ dynamic_filter_publish_plan::dynamic_filter_publish_plan(
   : _probe_targets(std::move(probe_targets)),
     _emit_zone_map_filters(emit_zone_map_filters),
     _build_key_domain_cardinalities(std::move(build_key_domain_cardinalities)),
-    _replica_spaces(std::move(replica_spaces)),
-    _domain_coverage_threshold(domain_coverage_threshold)
+    _domain_coverage_threshold(domain_coverage_threshold),
+    _replica_spaces(std::move(replica_spaces))
 {
   if (!_probe_targets.empty() && _replica_spaces.empty()) {
     throw std::invalid_argument(

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -97,8 +97,8 @@ sirius_physical_nested_loop_join::sirius_physical_nested_loop_join(
   : sirius_physical_partition_consumer_operator(SiriusPhysicalOperatorType::NESTED_LOOP_JOIN,
                                                 sirius::from_duckdb_vec(op.types),
                                                 estimated_cardinality),
-    join_type(join_type),
-    conditions(std::move(cond))
+    conditions(std::move(cond)),
+    join_type(join_type)
 {
   reorder_conditions(conditions);
 
@@ -127,8 +127,8 @@ sirius_physical_nested_loop_join::sirius_physical_nested_loop_join(
   : sirius_physical_partition_consumer_operator(SiriusPhysicalOperatorType::NESTED_LOOP_JOIN,
                                                 sirius::from_duckdb_vec(op.types),
                                                 estimated_cardinality),
-    join_type(join_type),
-    conditions(std::move(cond))
+    conditions(std::move(cond)),
+    join_type(join_type)
 {
   reorder_conditions(conditions);
   children.push_back(std::move(left));
@@ -158,8 +158,8 @@ sirius_physical_nested_loop_join::sirius_physical_nested_loop_join(
   : sirius_physical_partition_consumer_operator(SiriusPhysicalOperatorType::NESTED_LOOP_JOIN,
                                                 sirius::from_duckdb_vec(op.types),
                                                 estimated_cardinality),
-    join_type(join_type),
-    conditions(std::move(cond))
+    conditions(std::move(cond)),
+    join_type(join_type)
 {
   reorder_conditions(conditions);
   children.push_back(std::move(left));

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -91,9 +91,9 @@ void sirius_physical_result_collector::build_pipelines(
 sirius_physical_materialized_collector::sirius_physical_materialized_collector(
   ::sirius::sirius_prepared_statement_data& data, duckdb::ClientContext& client_ctx)
   : sirius_physical_result_collector(data),
-    _client_ctx(client_ctx),
     result_collection(
-      duckdb::make_uniq<duckdb::ColumnDataCollection>(client_ctx, sirius::to_duckdb_vec(types)))
+      duckdb::make_uniq<duckdb::ColumnDataCollection>(client_ctx, sirius::to_duckdb_vec(types))),
+    _client_ctx(client_ctx)
 {
 }
 

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -38,7 +38,7 @@ namespace sirius {
 namespace pipeline {
 
 sirius_pipeline::sirius_pipeline(const pipeline_build_context& ctx)
-  : build_ctx_(ctx), ready(false), initialized(false), source(nullptr), sink(nullptr)
+  : ready(false), initialized(false), source(nullptr), sink(nullptr), build_ctx_(ctx)
 {
 }
 


### PR DESCRIPTION
Silences clang's `-Wreorder-ctor`. Pure reordering of independent member initializers; no behavior change.

Part of the clang-debug warning cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)