### PR TITLE
fix: drop redundant std::move that pessimizes copy elision

### DIFF
--- a/src/expression_evaluator/specializations/case.cpp
+++ b/src/expression_evaluator/specializations/case.cpp
@@ -119,7 +119,7 @@ evaluate_result expression_evaluator::evaluate(sirius::ast::case_expr const& alt
         "[expression_evaluator:case]: Expected an owned column after executing CASE "
         "expression.");
     }
-    return materialize_as_ast_column(std::move(current_result.release_column()));
+    return materialize_as_ast_column(current_result.release_column());
   }
   return current_result;
 }

--- a/src/expression_evaluator/specializations/function.cpp
+++ b/src/expression_evaluator/specializations/function.cpp
@@ -117,7 +117,7 @@ evaluate_result expression_evaluator::evaluate(sirius::ast::function_call const&
         "[expression_evaluator:function]: Expected an owned column after executing function "
         "expression.");
     }
-    return materialize_as_ast_column(std::move(result.release_column()));
+    return materialize_as_ast_column(result.release_column());
   }
   auto const output_type = sirius::get_cudf_type(alt.return_type());
 

--- a/src/io/cache/prefetching_cache.cpp
+++ b/src/io/cache/prefetching_cache.cpp
@@ -366,7 +366,7 @@ prefetching_handle prefetching_cache::insert(const sirius_io_object& obj,
     work, _eviction_queue, _prefetch_queue));
   _preparation_queue.enqueue(std::move(work));
 
-  return std::move(handle);
+  return handle;
 }
 
 bool prefetching_cache::host_read_from_cache_only(const sirius_io_object& obj,

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -71,7 +71,7 @@ std::vector<::cucascade::read_only_data_batch> pipelineable_operator_data::get_r
     if (leave_locked) {
       _read_only_data_batches = std::move(ro_batches);
     } else {
-      return std::move(ro_batches);
+      return ro_batches;
     }
   }
   return *_read_only_data_batches;

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -210,7 +210,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
         // in that case we just return the node
         if (filter) {
           filter->children.push_back(std::move(node));
-          return std::move(filter);
+          return filter;
         }
         return std::move(node);
       }
@@ -269,7 +269,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   }
   if (filter) {
     filter->children.push_back(std::move(node));
-    return std::move(filter);
+    return filter;
   }
   return std::move(node);
 }

--- a/test/cpp/utils/utils.cpp
+++ b/test/cpp/utils/utils.cpp
@@ -387,13 +387,13 @@ std::unique_ptr<cudf::table> create_cudf_table_with_random_data(
     const auto& dtype = column_types[c];
     switch (dtype.id()) {
       case cudf::type_id::INT32: {
-        cols.push_back(std::move(
-          create_numeric_column_with_random_data<int32_t>(num_rows, dtype, ranges[c], stream, mr)));
+        cols.push_back(
+          create_numeric_column_with_random_data<int32_t>(num_rows, dtype, ranges[c], stream, mr));
         break;
       }
       case cudf::type_id::INT64: {
-        cols.push_back(std::move(
-          create_numeric_column_with_random_data<int64_t>(num_rows, dtype, ranges[c], stream, mr)));
+        cols.push_back(
+          create_numeric_column_with_random_data<int64_t>(num_rows, dtype, ranges[c], stream, mr));
         break;
       }
       case cudf::type_id::STRING: {


### PR DESCRIPTION
Removes `std::move` on function-return temporaries and locals in return statements, silencing `-Wpessimizing-move`. Implicit move / copy elision applies without it.

Part of the clang-debug warning cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)