### PR TITLE
fix: remove or annotate unused variables

### DIFF
--- a/src/io/cache/prefetching_cache.cpp
+++ b/src/io/cache/prefetching_cache.cpp
@@ -329,8 +329,7 @@ prefetching_handle prefetching_cache::insert(const sirius_io_object& obj,
 {
   if (!_armed) { return prefetching_handle(nullptr); }
 
-  const auto& key = obj.raw_file_cache_id();
-  auto& file      = get_or_create_file_entry(obj);
+  auto& file = get_or_create_file_entry(obj);
 
   const size_t chunk_bytes = _chunk_size;
   auto coalesced_ranges    = _io_ctx->align_and_coalesce(ranges, chunk_bytes);

--- a/src/op/scan/iceberg_avro_reader.cpp
+++ b/src/op/scan/iceberg_avro_reader.cpp
@@ -658,7 +658,6 @@ std::vector<std::pair<std::string, int>> read_iceberg_manifest_list(const std::s
   bool mp_first  = (mp_idx < ct_idx);
 
   std::vector<std::pair<std::string, int>> result;
-  std::array<uint8_t, 16> block_sync{};
 
   // Data blocks
   // OCF data blocks: count (zigzag long), byte_count (zigzag long, ALWAYS present),

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -380,9 +380,9 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
     // return Make<PhysicalCrossProduct>(op.types, left, right, op.estimated_cardinality);
   }
 
-  std::size_t has_range = 0;
-  bool has_equality     = op.HasEquality(has_range);
-  bool can_merge        = has_range > 0;
+  std::size_t has_range              = 0;
+  [[maybe_unused]] bool has_equality = op.HasEquality(has_range);
+  bool can_merge                     = has_range > 0;
   bool can_iejoin       = has_range >= 2 && recursive_cte_tables.empty();
   switch (op.join_type) {
     case duckdb::JoinType::SEMI:

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -383,7 +383,7 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
   std::size_t has_range              = 0;
   [[maybe_unused]] bool has_equality = op.HasEquality(has_range);
   bool can_merge                     = has_range > 0;
-  bool can_iejoin       = has_range >= 2 && recursive_cte_tables.empty();
+  bool can_iejoin                    = has_range >= 2 && recursive_cte_tables.empty();
   switch (op.join_type) {
     case duckdb::JoinType::SEMI:
     case duckdb::JoinType::ANTI:

--- a/src/planner/sirius_plan_recursive_cte.cpp
+++ b/src/planner/sirius_plan_recursive_cte.cpp
@@ -75,10 +75,6 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalCTERef& op)
     }
   }
 
-  auto& types     = cte->second.get()->Types();
-  auto op_type    = op.is_recurring
-                      ? sirius::op::SiriusPhysicalOperatorType::RECURSIVE_RECURRING_CTE_SCAN
-                      : sirius::op::SiriusPhysicalOperatorType::RECURSIVE_CTE_SCAN;
   auto chunk_scan = duckdb::make_uniq<sirius::op::sirius_physical_column_data_scan>(
     sirius::from_duckdb_vec(cte->second.get()->Types()),
     sirius::op::SiriusPhysicalOperatorType::RECURSIVE_CTE_SCAN,

--- a/src/scan_manager/load_balancing_scan_batch_coalescer.cpp
+++ b/src/scan_manager/load_balancing_scan_batch_coalescer.cpp
@@ -164,8 +164,7 @@ void load_balancing_scan_batch_coalescer::process_provider_inputs(metadata_proce
 void load_balancing_scan_batch_coalescer::process_cached_entries(
   metadata_processing_state& state, [[maybe_unused]] std::stop_token const& stop)
 {
-  auto& batch_queue = state.queue;
-  bool is_closed    = false;
+  bool is_closed = false;
   while (!is_closed) {
     auto databatch = state.batch_provider->get_next_batch();
     is_closed      = databatch == nullptr;

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -393,12 +393,9 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
   // Configure cuDF to use our pinned slab allocator for small internal host buffers
   // (e.g. column_device_view metadata arrays in cudf::concatenate).  This eliminates
   // the pageable H2D transfers that cuDF issues by default.
-  cucascade::memory::fixed_size_host_memory_resource* host_fsmr = nullptr;
   {
     auto host_spaces = memory_manager_->get_memory_spaces_for_tier(cucascade::memory::Tier::HOST);
     if (!host_spaces.empty()) {
-      host_fsmr = host_spaces[0]
-                    ->get_memory_resource_as<cucascade::memory::fixed_size_host_memory_resource>();
       std::unordered_map<int, std::unique_ptr<cucascade::memory::small_pinned_host_memory_resource>>
         per_node_pools;
       int fallback_node = -1;

--- a/src/sirius_interface.cpp
+++ b/src/sirius_interface.cpp
@@ -94,8 +94,7 @@ duckdb::unique_ptr<duckdb::QueryResult> sirius_interface::fetch_result_internal(
   D_ASSERT(sirius_active_query);
   D_ASSERT(sirius_active_query->is_open_result(pending));
   D_ASSERT(sirius_active_query->sirius_prepared->prepared);
-  auto& engine   = get_sirius_engine();
-  auto& prepared = *sirius_active_query->sirius_prepared->prepared;
+  auto& engine = get_sirius_engine();
   duckdb::unique_ptr<duckdb::QueryResult> result;
   D_ASSERT(engine.has_result_collector());
   SIRIUS_LOG_DEBUG("Fetching result from GPU executor");
@@ -137,7 +136,6 @@ sirius_interface::sirius_pending_statement_or_prepared_statement(
 {
   begin_query_internal(query);
 
-  bool invalidate_query = true;
   duckdb::unique_ptr<duckdb::PendingQueryResult> pending =
     sirius_pending_statement_internal(context, statement_p, parameters);
 

--- a/test/cpp/operator/aggregate/aggregate_test_utils.hpp
+++ b/test/cpp/operator/aggregate/aggregate_test_utils.hpp
@@ -86,7 +86,7 @@ AggregateExpressionResult create_aggregate_expressions(
   AggregateExpressionResult result;
 
   // Create output types: first the group by column types, then the aggregate result types
-  for (std::size_t group_idx : group_indexes) {
+  for ([[maybe_unused]] std::size_t group_idx : group_indexes) {
     result.output_types.push_back(sirius::from_duckdb(Traits::logical_type()));
   }
   for (std::size_t i = 0; i < aggregations.size(); ++i) {

--- a/test/cpp/pipeline/test_get_next_ports_after_sink.cpp
+++ b/test/cpp/pipeline/test_get_next_ports_after_sink.cpp
@@ -61,7 +61,7 @@ TEST_CASE("yields nothing when no sink is set", "[pipeline][get_next_ports_after
   sirius_pipeline pipeline(sirius::pipeline::pipeline_build_context{});
   REQUIRE(not pipeline.get_sink());
 
-  for (const auto& port : pipeline.get_next_ports_after_sink()) {
+  for ([[maybe_unused]] const auto& port : pipeline.get_next_ports_after_sink()) {
     FAIL("port found");
   }
 }
@@ -99,7 +99,7 @@ TEST_CASE("yields nothing for standard sink with no ports", "[pipeline][get_next
   sirius_pipeline_build_state build_state;
   build_state.set_pipeline_sink(pipeline, &sink_op, 0);
 
-  for (const auto& port : pipeline.get_next_ports_after_sink()) {
+  for ([[maybe_unused]] const auto& port : pipeline.get_next_ports_after_sink()) {
     FAIL("port found");
   }
 }

--- a/test/cpp/scan/test_gpu_decode_rle.cpp
+++ b/test/cpp/scan/test_gpu_decode_rle.cpp
@@ -50,7 +50,6 @@ using sirius::test::decode::rle::make_rle_block;
 
 namespace {
 
-auto const I8  = cudf::data_type{cudf::type_id::INT8};
 auto const I16 = cudf::data_type{cudf::type_id::INT16};
 auto const I32 = cudf::data_type{cudf::type_id::INT32};
 auto const I64 = cudf::data_type{cudf::type_id::INT64};


### PR DESCRIPTION
Removes dead locals and a dead getter assignment; marks loop vars and a bool kept only for a side-effecting call `[[maybe_unused]]`. Silences `-Wunused-variable` / `-Wunused-const-variable` / `-Wunused-but-set-variable`. No behavior change.

Part of the clang-debug warning cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)