### PR TITLE
fix: silence -Wunused-function on retained helpers

### DIFF
--- a/src/io/datasource_factory.cpp
+++ b/src/io/datasource_factory.cpp
@@ -49,7 +49,7 @@ namespace {
 // the write side so callers don't need to remember which side does it. Used
 // by both register_ioctx and lookup so a register("S3", ...) is found by a
 // lookup("s3"), and vice versa.
-std::string to_lower_scheme(std::string_view s)
+[[maybe_unused]] std::string to_lower_scheme(std::string_view s)
 {
   std::string out;
   out.reserve(s.size());

--- a/src/io/uring/uring_reactor.cpp
+++ b/src/io/uring/uring_reactor.cpp
@@ -55,7 +55,7 @@ static constexpr size_t NUM_CHUNKS = 64;  // max concurrent device reads, i.e. r
 namespace {
 
 /// True iff @p v is a multiple of IO_BLOCK_SIZE (O_DIRECT page size).
-[[nodiscard]] constexpr bool is_block_aligned(size_t v) noexcept
+[[maybe_unused]] [[nodiscard]] constexpr bool is_block_aligned(size_t v) noexcept
 {
   return (v & (static_cast<size_t>(IO_BLOCK_SIZE) - 1)) == 0;
 }

--- a/src/op/scan/iceberg_avro_reader.cpp
+++ b/src/op/scan/iceberg_avro_reader.cpp
@@ -419,7 +419,6 @@ struct JsonParser {
 
 // Forward declarations
 static void skip_avro_value(const AvroType& t, const uint8_t*& p, const uint8_t* end);
-static int64_t skip_avro_block_items(const uint8_t*& p, const uint8_t* end);
 
 static void skip_avro_value(const AvroType& t, const uint8_t*& p, const uint8_t* end)
 {

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -36,8 +36,8 @@ namespace op {
 // callers in Super Sirius and have been removed.
 
 // Helper to convert vector<vector<idx_t>> to vector<unsafe_vector<idx_t>>
-[[maybe_unused]] static duckdb::vector<duckdb::unsafe_vector<std::size_t>> convert_grouping_functions(
-  const duckdb::vector<duckdb::vector<std::size_t>>& src)
+[[maybe_unused]] static duckdb::vector<duckdb::unsafe_vector<std::size_t>>
+convert_grouping_functions(const duckdb::vector<duckdb::vector<std::size_t>>& src)
 {
   duckdb::vector<duckdb::unsafe_vector<std::size_t>> result;
   result.reserve(src.size());

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -36,7 +36,7 @@ namespace op {
 // callers in Super Sirius and have been removed.
 
 // Helper to convert vector<vector<idx_t>> to vector<unsafe_vector<idx_t>>
-static duckdb::vector<duckdb::unsafe_vector<std::size_t>> convert_grouping_functions(
+[[maybe_unused]] static duckdb::vector<duckdb::unsafe_vector<std::size_t>> convert_grouping_functions(
   const duckdb::vector<duckdb::vector<std::size_t>>& src)
 {
   duckdb::vector<duckdb::unsafe_vector<std::size_t>> result;

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -672,9 +672,9 @@ void SiriusExtension::GPUExecutionFunction(ClientContext& context,
   return;
 }
 
-static unique_ptr<LogicalOperator> OptimizePlan(ClientContext& context,
-                                                Planner& planner,
-                                                Connection& new_conn)
+[[maybe_unused]] static unique_ptr<LogicalOperator> OptimizePlan(ClientContext& context,
+                                                                Planner& planner,
+                                                                Connection& new_conn)
 {
   unique_ptr<LogicalOperator> plan;
   plan = std::move(planner.plan);

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -673,8 +673,8 @@ void SiriusExtension::GPUExecutionFunction(ClientContext& context,
 }
 
 [[maybe_unused]] static unique_ptr<LogicalOperator> OptimizePlan(ClientContext& context,
-                                                                Planner& planner,
-                                                                Connection& new_conn)
+                                                                 Planner& planner,
+                                                                 Connection& new_conn)
 {
   unique_ptr<LogicalOperator> plan;
   plan = std::move(planner.plan);

--- a/test/cpp/scan_manager/test_s3_routing_cutover.cpp
+++ b/test/cpp/scan_manager/test_s3_routing_cutover.cpp
@@ -214,8 +214,8 @@ std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info> make_nation_tab
   return info;
 }
 
-std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info> make_nation_table_info(
-  std::string uri)
+[[maybe_unused]] std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info>
+make_nation_table_info(std::string uri)
 {
   std::vector<std::string> uris;
   uris.push_back(std::move(uri));


### PR DESCRIPTION
Marks currently-uncalled file-local helpers `[[maybe_unused]]` rather than deleting them, and drops a dead forward declaration with no definition or callers.

Part of the clang-debug warning cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)