### PR TITLE
fix: address stray clang warnings (switch, tags, dead comparison)

### DIFF
--- a/src/include/helper/helper.hpp
+++ b/src/include/helper/helper.hpp
@@ -18,6 +18,8 @@
 
 #include <nvtx3/nvtx3.hpp>
 
+#include <cassert>
+
 namespace sirius {
 
 template <class T, class SRC>
@@ -25,7 +27,7 @@ void DynamicCastCheck(const SRC* source)
 {
 #ifndef __APPLE__
   // Actual check is on the fact that dynamic_cast and reinterpret_cast are equivalent
-  reinterpret_cast<const T*>(source) == dynamic_cast<const T*>(source);
+  assert(reinterpret_cast<const T*>(source) == dynamic_cast<const T*>(source));
 #endif
 }
 

--- a/src/include/io/cache/prefetching_cache.hpp
+++ b/src/include/io/cache/prefetching_cache.hpp
@@ -107,7 +107,7 @@ class prefetching_handle {
 
  private:
   friend class prefetching_cache;
-  struct prefetch_lifecycle_manager;
+  class prefetch_lifecycle_manager;
 
   prefetching_handle(std::unique_ptr<prefetch_lifecycle_manager> mgr) noexcept;
 

--- a/src/op/sirius_physical_operator_type.cpp
+++ b/src/op/sirius_physical_operator_type.cpp
@@ -23,6 +23,7 @@ std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type)
 {
   switch (type) {
     case SiriusPhysicalOperatorType::TABLE_SCAN: return "TABLE_SCAN";
+    case SiriusPhysicalOperatorType::PARQUET_SCAN: return "PARQUET_SCAN";
     case SiriusPhysicalOperatorType::DUMMY_SCAN: return "DUMMY_SCAN";
     case SiriusPhysicalOperatorType::CHUNK_SCAN: return "CHUNK_SCAN";
     case SiriusPhysicalOperatorType::COLUMN_DATA_SCAN: return "COLUMN_DATA_SCAN";


### PR DESCRIPTION
- Restore the dropped `DynamicCastCheck` assert so the cast equivalence is actually validated (`-Wunused-comparison`).
- Handle `PARQUET_SCAN` in `SiriusPhysicalOperatorToString` (`-Wswitch`).
- Declare `prefetch_lifecycle_manager` with a class tag to match its definition (`-Wmismatched-tags`).

Part of the clang-debug warning cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)