### PR TITLE
fix(starrocks): serialize result batches into a growable buffer

### DIFF
--- a/experimental/starrocks/src/result_encoder.rs
+++ b/experimental/starrocks/src/result_encoder.rs
@@ -10,10 +10,7 @@ use arrow_array::{
 };
 use arrow_schema::DataType;
 use starrocks_thrift::data::TResultBatch;
-use thrift::{
-    protocol::{TBinaryOutputProtocol, TSerializable},
-    transport::{TBufferChannel, TIoChannel},
-};
+use thrift::protocol::{TBinaryOutputProtocol, TSerializable};
 
 /// Encodes Arrow result batches into a StarRocks `TResultBatch` of MySQL text rows.
 #[derive(Default)]
@@ -150,15 +147,13 @@ pub(crate) trait ThriftBinary {
 
 impl<T: TSerializable> ThriftBinary for T {
     fn to_binary(&self) -> Result<Vec<u8>, String> {
-        let channel = TBufferChannel::with_capacity(0, 64 * 1024);
-        let (_, write) = channel
-            .clone()
-            .split()
-            .map_err(|err| format!("failed to split thrift channel: {err}"))?;
-        let mut protocol = TBinaryOutputProtocol::new(write, true);
+        // A plain growable buffer: result batches can be arbitrarily large, so a fixed-capacity
+        // channel would truncate (surface as a transport error) on big results.
+        let mut buffer = Vec::new();
+        let mut protocol = TBinaryOutputProtocol::new(&mut buffer, true);
         self.write_to_out_protocol(&mut protocol)
             .map_err(|err| format!("failed to serialize thrift value: {err}"))?;
-        Ok(channel.write_bytes())
+        Ok(buffer)
     }
 }
 


### PR DESCRIPTION
Result batches can be arbitrarily large; the fixed 64 KiB thrift channel truncated them, surfacing as a transport error at `fetch_data`. Serialize into a plain growable buffer instead.



## Stack

All based on `dev`, so each diff includes the levels below it until they merge (review commits, or the last commit, for the per-level change):

1. #1106 ⬅️ this PR
2. #1107
3. #1108
4. #1109
5. #1110
6. #1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
