### PR TITLE
feat(starrocks): translate arithmetic, date, IN, CASE, and scalar calls

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
@@ -9,7 +9,9 @@ use substrait::proto::{Expression, FunctionArgument, Type, function_argument};
 use crate::descriptor_table::DescriptorTable;
 use crate::error::{Result, TranslateError};
 use crate::type_mapper;
-use crate::{ExtensionRegistry, URN_BOOLEAN, URN_COMPARISON};
+use crate::{
+    ExtensionRegistry, URN_ARITHMETIC, URN_BOOLEAN, URN_COMPARISON, URN_DATETIME, URN_STRING,
+};
 
 /// Mutable state needed while translating one StarRocks expression tree.
 pub(crate) struct ExprContext<'a> {
@@ -118,10 +120,15 @@ fn translate_expr_node(
         TExprNodeType::STRING_LITERAL => translate_string_literal(node, children),
         TExprNodeType::NULL_LITERAL => translate_null_literal(node, children),
         TExprNodeType::DECIMAL_LITERAL => translate_decimal_literal(node, children),
+        TExprNodeType::DATE_LITERAL => translate_date_literal(node, children),
         TExprNodeType::BINARY_PRED => translate_binary_pred(node, children, ctx),
         TExprNodeType::COMPOUND_PRED => translate_compound_pred(node, children, ctx),
         TExprNodeType::CAST_EXPR => translate_cast(node, children),
         TExprNodeType::IS_NULL_PRED => translate_is_null(node, children, ctx),
+        TExprNodeType::ARITHMETIC_EXPR => translate_arithmetic(node, children, ctx),
+        TExprNodeType::IN_PRED => translate_in_pred(node, children, ctx),
+        TExprNodeType::CASE_EXPR => translate_case(node, children),
+        TExprNodeType::FUNCTION_CALL => translate_function_call(node, children, ctx),
         _ => Err(TranslateError::UnsupportedExpression {
             node_type: node.node_type,
             reason: "expression node is outside the v1 StarRocks slice",
@@ -261,6 +268,327 @@ fn translate_decimal_literal(node: &TExprNode, children: Vec<Expression>) -> Res
             scale: decimal.scale,
         },
     )))
+}
+
+/// Converts a StarRocks `DATE_LITERAL` into a Substrait date literal.
+///
+/// StarRocks carries the literal as a `YYYY-MM-DD[ HH:MM:SS]` string; Substrait dates are days
+/// since the UNIX epoch. Only DATE-typed literals are supported — DATETIME literals would need a
+/// precision-timestamp literal the consumer side has not been exercised with.
+fn translate_date_literal(node: &TExprNode, children: Vec<Expression>) -> Result<Expression> {
+    expect_child_count(node, &children, 0)?;
+    let lit = node
+        .date_literal
+        .as_ref()
+        .ok_or(TranslateError::MissingField {
+            context: "DATE_LITERAL",
+            field: "date_literal",
+        })?;
+    match type_mapper::scalar_primitive(&node.type_)? {
+        TPrimitiveType::DATE => Ok(literal(expression::literal::LiteralType::Date(
+            epoch_days_from_date_str(&lit.value)?,
+        ))),
+        primitive => Err(TranslateError::UnsupportedType {
+            primitive: Some(primitive),
+            node_type: Some(starrocks_thrift::types::TTypeNodeType::SCALAR),
+            reason: "only DATE-typed date literals are supported",
+        }),
+    }
+}
+
+/// Parses `YYYY-MM-DD` (ignoring any time suffix) into days since the UNIX epoch.
+fn epoch_days_from_date_str(value: &str) -> Result<i32> {
+    let invalid = || TranslateError::malformed(format!("invalid date literal {value:?}"));
+    let date_part = value.split_whitespace().next().ok_or_else(invalid)?;
+    let mut parts = date_part.split('-');
+    let mut next = || -> Result<i64> {
+        parts
+            .next()
+            .and_then(|part| part.parse::<i64>().ok())
+            .ok_or_else(invalid)
+    };
+    let (year, month, day) = (next()?, next()?, next()?);
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return Err(invalid());
+    }
+    // Howard Hinnant's civil-days algorithm; no chrono dependency needed for whole dates.
+    let year_adjusted = if month <= 2 { year - 1 } else { year };
+    let era = year_adjusted.div_euclid(400);
+    let year_of_era = year_adjusted - era * 400;
+    let month_shifted = if month > 2 { month - 3 } else { month + 9 };
+    let day_of_year = (153 * month_shifted + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    let days = era * 146097 + day_of_era - 719468;
+    i32::try_from(days).map_err(|_| invalid())
+}
+
+/// Converts a StarRocks `ARITHMETIC_EXPR` into a Substrait arithmetic function.
+fn translate_arithmetic(
+    node: &TExprNode,
+    children: Vec<Expression>,
+    ctx: &mut ExprContext<'_>,
+) -> Result<Expression> {
+    let opcode = node.opcode.ok_or(TranslateError::MissingField {
+        context: "ARITHMETIC_EXPR",
+        field: "opcode",
+    })?;
+    let name = match opcode {
+        TExprOpcode::ADD => "add",
+        TExprOpcode::SUBTRACT => "subtract",
+        TExprOpcode::MULTIPLY => "multiply",
+        TExprOpcode::DIVIDE => "divide",
+        TExprOpcode::MOD => "modulus",
+        _ => {
+            return Err(TranslateError::UnsupportedExpression {
+                node_type: node.node_type,
+                reason: "arithmetic opcode is unsupported",
+            });
+        }
+    };
+    expect_child_count(node, &children, 2)?;
+    // Decimal-typed arithmetic is rejected for now: the StarRocks-shaped cast/width combination
+    // reliably segfaults the engine's GPU projection (see the starrocks tpch crash repro);
+    // fail with a structured error instead of taking down the compute node.
+    if is_decimal(&node.type_)? {
+        return Err(TranslateError::UnsupportedExpression {
+            node_type: node.node_type,
+            reason: "decimal arithmetic is not supported yet (crashes the engine projection)",
+        });
+    }
+    let output_type = type_mapper::map_type_desc(&node.type_, node.is_nullable.unwrap_or(true))?;
+    let anchor = ctx.registry.register_function(URN_ARITHMETIC, name);
+    Ok(scalar_function(anchor, children, output_type))
+}
+
+/// Returns whether a StarRocks type descriptor is any decimal flavour.
+fn is_decimal(type_desc: &starrocks_thrift::types::TTypeDesc) -> Result<bool> {
+    Ok(matches!(
+        type_mapper::scalar_primitive(type_desc)?,
+        TPrimitiveType::DECIMAL
+            | TPrimitiveType::DECIMALV2
+            | TPrimitiveType::DECIMAL32
+            | TPrimitiveType::DECIMAL64
+            | TPrimitiveType::DECIMAL128
+            | TPrimitiveType::DECIMAL256
+    ))
+}
+
+/// Converts a StarRocks `IN_PRED` into a Substrait singular-or-list expression.
+fn translate_in_pred(
+    node: &TExprNode,
+    children: Vec<Expression>,
+    ctx: &mut ExprContext<'_>,
+) -> Result<Expression> {
+    let in_pred = node
+        .in_predicate
+        .as_ref()
+        .ok_or(TranslateError::MissingField {
+            context: "IN_PRED",
+            field: "in_predicate",
+        })?;
+    if children.len() < 2 {
+        return Err(TranslateError::malformed(
+            "IN_PRED expected a value and at least one list entry",
+        ));
+    }
+    let mut children = children.into_iter();
+    let value = children.next().unwrap();
+    let in_list = Expression {
+        rex_type: Some(expression::RexType::SingularOrList(Box::new(
+            expression::SingularOrList {
+                value: Some(Box::new(value)),
+                options: children.collect(),
+            },
+        ))),
+    };
+    if in_pred.is_not_in {
+        let anchor = ctx.registry.register_function(URN_BOOLEAN, "not");
+        Ok(scalar_function(
+            anchor,
+            vec![in_list],
+            type_mapper::bool_type(),
+        ))
+    } else {
+        Ok(in_list)
+    }
+}
+
+/// Converts a StarRocks `CASE_EXPR` into a Substrait if-then expression chain.
+///
+/// StarRocks children are `[case?] (when then)* [else?]`, flagged by
+/// `TCaseExpr::has_case_expr`/`has_else_expr`. A leading case operand is not supported yet — the
+/// frontend normally rewrites `CASE x WHEN ...` into comparisons already.
+fn translate_case(node: &TExprNode, children: Vec<Expression>) -> Result<Expression> {
+    let case = node
+        .case_expr
+        .as_ref()
+        .ok_or(TranslateError::MissingField {
+            context: "CASE_EXPR",
+            field: "case_expr",
+        })?;
+    if case.has_case_expr {
+        return Err(TranslateError::UnsupportedExpression {
+            node_type: node.node_type,
+            reason: "CASE with a leading case operand is not supported",
+        });
+    }
+    let mut children = children.into_iter();
+    let mut r#else = if case.has_else_expr {
+        Some(Box::new(children.next_back().ok_or_else(|| {
+            TranslateError::malformed("CASE_EXPR missing else child")
+        })?))
+    } else {
+        None
+    };
+    let mut ifs = Vec::new();
+    loop {
+        let Some(condition) = children.next() else {
+            break;
+        };
+        let then = children
+            .next()
+            .ok_or_else(|| TranslateError::malformed("CASE_EXPR when without then"))?;
+        ifs.push(expression::if_then::IfClause {
+            r#if: Some(condition),
+            then: Some(then),
+        });
+    }
+    if ifs.is_empty() {
+        return Err(TranslateError::malformed("CASE_EXPR has no when/then arms"));
+    }
+    if r#else.is_none() {
+        // Substrait if-then requires an else branch; SQL CASE defaults to NULL.
+        r#else = Some(Box::new(literal(expression::literal::LiteralType::Null(
+            type_mapper::map_type_desc(&node.type_, true)?,
+        ))));
+    }
+    Ok(Expression {
+        rex_type: Some(expression::RexType::IfThen(Box::new(expression::IfThen {
+            ifs,
+            r#else,
+        }))),
+    })
+}
+
+/// Converts a StarRocks `FUNCTION_CALL` into a Substrait expression.
+///
+/// Functions are allowlisted so an unknown StarRocks builtin fails loudly instead of silently
+/// binding to a DuckDB function with different semantics.
+fn translate_function_call(
+    node: &TExprNode,
+    children: Vec<Expression>,
+    ctx: &mut ExprContext<'_>,
+) -> Result<Expression> {
+    let function = node.fn_.as_ref().ok_or(TranslateError::MissingField {
+        context: "FUNCTION_CALL",
+        field: "fn",
+    })?;
+    let name = function.name.function_name.as_str();
+    let output_type = type_mapper::map_type_desc(&node.type_, node.is_nullable.unwrap_or(true))?;
+
+    // Null checks the frontend planned as builtin calls rather than IS_NULL_PRED nodes.
+    let (urn, mapped) = match name {
+        "is_null_pred" => {
+            expect_child_count(node, &children, 1)?;
+            (URN_COMPARISON, "is_null")
+        }
+        "is_not_null_pred" => {
+            expect_child_count(node, &children, 1)?;
+            (URN_COMPARISON, "is_not_null")
+        }
+        "if" => {
+            expect_child_count(node, &children, 3)?;
+            let mut children = children.into_iter();
+            let condition = children.next().unwrap();
+            let then = children.next().unwrap();
+            let otherwise = children.next().unwrap();
+            return Ok(Expression {
+                rex_type: Some(expression::RexType::IfThen(Box::new(expression::IfThen {
+                    ifs: vec![expression::if_then::IfClause {
+                        r#if: Some(condition),
+                        then: Some(then),
+                    }],
+                    r#else: Some(Box::new(otherwise)),
+                }))),
+            });
+        }
+        "like" => {
+            // The GPU evaluator needs a constant pattern and applies no escape character,
+            // while StarRocks treats backslash as the default escape.
+            expect_child_count(node, &children, 2)?;
+            match string_literal_value(&children[1]) {
+                Some(pattern) if !pattern.contains('\\') => {}
+                _ => {
+                    return Err(TranslateError::UnsupportedExpression {
+                        node_type: node.node_type,
+                        reason: "LIKE requires a constant pattern without escapes",
+                    });
+                }
+            }
+            (URN_STRING, "like")
+        }
+        "substring" | "substr" => {
+            // The GPU evaluator supports exactly `substring(col, start, length)` with constant,
+            // positive bounds; two-argument or from-the-end forms would misexecute.
+            expect_child_count(node, &children, 3)?;
+            let constant_positive = |expr: &Expression| {
+                matches!(
+                    integer_literal_value(expr),
+                    Some(value) if value > 0
+                )
+            };
+            if !constant_positive(&children[1]) || !constant_positive(&children[2]) {
+                return Err(TranslateError::UnsupportedExpression {
+                    node_type: node.node_type,
+                    reason: "substring requires constant positive start and length",
+                });
+            }
+            (URN_STRING, "substring")
+        }
+        // StarRocks `length` counts bytes; `octet_length` remaps to DuckDB's byte-length
+        // (`strlen`), while `char_length` keeps codepoint semantics on both sides.
+        "length" => (URN_STRING, "octet_length"),
+        "char_length" => (URN_STRING, "char_length"),
+        // `concat` is intentionally absent: StarRocks concat is NULL-strict while DuckDB's
+        // ignores NULL arguments, so a name-level mapping would change results. Other string
+        // and math builtins (upper/lower/trim/abs/floor/...) are absent because the GPU
+        // expression evaluator has no implementations for them yet.
+        "year" | "month" | "day" => (URN_DATETIME, name),
+        _ => {
+            return Err(TranslateError::malformed(format!(
+                "unsupported StarRocks function call {name:?}"
+            )));
+        }
+    };
+    let anchor = ctx.registry.register_function(urn, mapped);
+    Ok(scalar_function(anchor, children, output_type))
+}
+
+/// Returns a Substrait expression's string-literal payload, if it is one.
+fn string_literal_value(expr: &Expression) -> Option<&str> {
+    match expr.rex_type.as_ref()? {
+        expression::RexType::Literal(literal) => match literal.literal_type.as_ref()? {
+            expression::literal::LiteralType::String(value) => Some(value),
+            expression::literal::LiteralType::FixedChar(value) => Some(value),
+            expression::literal::LiteralType::VarChar(varchar) => Some(&varchar.value),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Returns a Substrait expression's integer-literal payload, if it is one.
+fn integer_literal_value(expr: &Expression) -> Option<i64> {
+    match expr.rex_type.as_ref()? {
+        expression::RexType::Literal(literal) => match literal.literal_type.as_ref()? {
+            expression::literal::LiteralType::I8(value) => Some(i64::from(*value)),
+            expression::literal::LiteralType::I16(value) => Some(i64::from(*value)),
+            expression::literal::LiteralType::I32(value) => Some(i64::from(*value)),
+            expression::literal::LiteralType::I64(value) => Some(*value),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 /// Converts supported comparison opcodes into Substrait comparison functions.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -3,10 +3,12 @@
 //! This crate converts a StarRocks `TExecPlanFragmentParams` (the Thrift plan a
 //! StarRocks frontend ships to a backend) into a `substrait` `Plan`. It is meant
 //! as a foundation more operators are built on, so it favours explicit, checked
-//! invariants over breadth: v1 supports scan, filter, and projection, and
-//! everything outside that surface returns a structured [`TranslateError`] that
+//! invariants over breadth: it translates one fragment at a time, and everything
+//! outside the supported surface returns a structured [`TranslateError`] that
 //! names the offending node/type — so the next contributor knows exactly what to
-//! implement next.
+//! implement next. In particular `EXCHANGE_NODE` is rejected: a fragment is
+//! translated in isolation, and multi-fragment plans (every exchange is a
+//! fragment boundary) are a later milestone.
 //!
 //! # Wire format: flat preorder
 //!
@@ -21,23 +23,27 @@
 //! instead of silently producing a truncated tree. **Any new node translator
 //! must preserve this invariant.**
 //!
-//! # Supported surface (v1)
+//! # Supported surface
 //!
-//! | Plan node        | Substrait relation     |
-//! |------------------|------------------------|
-//! | `FILE_SCAN_NODE` | `ReadRel` (local files) |
-//! | `HDFS_SCAN_NODE` | `ReadRel` (named table) |
-//! | `SELECT_NODE`    | `FilterRel`            |
-//! | `PROJECT_NODE`   | `ProjectRel`           |
+//! | Plan node            | Substrait relation |
+//! |----------------------|--------------------|
+//! | `FILE_SCAN_NODE`     | `ReadRel` (local files) |
+//! | `HDFS_SCAN_NODE`     | `ReadRel` (named table) |
+//! | `SELECT_NODE`        | `FilterRel`        |
+//! | `PROJECT_NODE`       | `ProjectRel`       |
 //!
-//! | Expression node | Substrait expression |
-//! |-----------------|----------------------|
-//! | `SLOT_REF`      | field reference (resolved by `DescriptorTable::slot_global_index`) |
-//! | `*_LITERAL`     | width-matched typed literal |
-//! | `BINARY_PRED`   | comparison function (`equal`, `not_equal`, `lt`, `lte`, `gt`, `gte`) |
-//! | `COMPOUND_PRED` | boolean function (`and`, `or`, `not`) |
-//! | `CAST_EXPR`     | cast (throwing failure behavior) |
-//! | `IS_NULL_PRED`  | `is_null` / `is_not_null` |
+//! | Expression node   | Substrait expression |
+//! |-------------------|----------------------|
+//! | `SLOT_REF`        | field reference (resolved by `DescriptorTable::slot_global_index`) |
+//! | `*_LITERAL`       | width-matched typed literal (incl. `DATE_LITERAL` as epoch days) |
+//! | `BINARY_PRED`     | comparison function (`equal`, `not_equal`, `lt`, `lte`, `gt`, `gte`) |
+//! | `COMPOUND_PRED`   | boolean function (`and`, `or`, `not`) |
+//! | `CAST_EXPR`       | cast (throwing failure behavior) |
+//! | `IS_NULL_PRED`    | `is_null` / `is_not_null` |
+//! | `ARITHMETIC_EXPR` | `add`/`subtract`/`multiply`/`divide`/`modulus` |
+//! | `IN_PRED`         | singular-or-list (wrapped in `not` for `NOT IN`) |
+//! | `CASE_EXPR`       | if-then chain (no leading case operand) |
+//! | `FUNCTION_CALL`   | allowlisted scalar functions (`like`, `if`, `substring`, `year`, ...) |
 //!
 //! Type mapping lives in `type_mapper`. Intentional v1 omissions return
 //! [`TranslateError::UnsupportedType`]: `LARGEINT` (128-bit), `DECIMAL256` and
@@ -87,6 +93,12 @@ use scan_paths::ScanFilePaths;
 pub const URN_COMPARISON: &str = "extension:io.substrait:functions_comparison";
 /// Substrait boolean function extension URN used for compound predicates.
 pub const URN_BOOLEAN: &str = "extension:io.substrait:functions_boolean";
+/// Substrait arithmetic function extension URN.
+pub const URN_ARITHMETIC: &str = "extension:io.substrait:functions_arithmetic";
+/// Substrait string function extension URN.
+pub const URN_STRING: &str = "extension:io.substrait:functions_string";
+/// Substrait datetime function extension URN.
+pub const URN_DATETIME: &str = "extension:io.substrait:functions_datetime";
 
 /// Result of translating one StarRocks plan fragment.
 pub struct TranslatedPlan {

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -8,8 +8,8 @@ use starrocks_thrift::descriptors::{
     TDescriptorTable, TSlotDescriptor, TTableDescriptor, TTupleDescriptor,
 };
 use starrocks_thrift::exprs::{
-    TBoolLiteral, TDecimalLiteral, TExpr, TExprNode, TExprNodeType, TFloatLiteral, TIntLiteral,
-    TIsNullPredicate, TSlotRef, TStringLiteral,
+    TBoolLiteral, TCaseExpr, TDateLiteral, TDecimalLiteral, TExpr, TExprNode, TExprNodeType,
+    TFloatLiteral, TInPredicate, TIntLiteral, TIsNullPredicate, TSlotRef, TStringLiteral,
 };
 use starrocks_thrift::internal_service::{
     InternalServiceVersion, TExecPlanFragmentParams, TPlanFragmentExecParams, TScanRangeParams,
@@ -22,8 +22,8 @@ use starrocks_thrift::plan_nodes::{
 };
 use starrocks_thrift::planner::TPlanFragment;
 use starrocks_thrift::types::{
-    TFileType, TPrimitiveType, TScalarType, TTableType, TTypeDesc, TTypeNode, TTypeNodeType,
-    TUniqueId,
+    TFileType, TFunction, TFunctionBinaryType, TFunctionName, TPrimitiveType, TScalarType,
+    TTableType, TTypeDesc, TTypeNode, TTypeNodeType, TUniqueId,
 };
 use substrait::proto::{expression, plan_rel, read_rel, rel};
 
@@ -1160,7 +1160,7 @@ fn unsupported_expression_is_structured_error() {
     let mut select = base_plan_node(1, TPlanNodeType::SELECT_NODE, 1, vec![0]);
     select.select_node = Some(TSelectNode::new(None));
     select.conjuncts = Some(vec![TExpr::new(vec![base_expr_node(
-        TExprNodeType::FUNCTION_CALL,
+        TExprNodeType::LAMBDA_FUNCTION_EXPR,
         scalar_type(TPrimitiveType::BOOLEAN),
         0,
     )])]);
@@ -1176,7 +1176,7 @@ fn unsupported_expression_is_structured_error() {
         TranslateError::UnsupportedExpression {
             node_type,
             ..
-        } if node_type == TExprNodeType::FUNCTION_CALL
+        } if node_type == TExprNodeType::LAMBDA_FUNCTION_EXPR
     ));
 }
 
@@ -1966,4 +1966,321 @@ fn expression_missing_child_node_is_error() {
     ))
     .unwrap_err();
     assert!(matches!(err, TranslateError::MalformedPlan(_)));
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation, sort, join, and expression coverage for the TPC-H slice.
+// ---------------------------------------------------------------------------
+
+/// Builds a builtin StarRocks function payload with the given name and return type.
+fn builtin_function(name: &str, ret_type: TTypeDesc) -> TFunction {
+    TFunction::new(
+        TFunctionName::new(None, name.to_string()),
+        TFunctionBinaryType::BUILTIN,
+        Vec::new(),
+        ret_type,
+        false,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+}
+
+/// Verifies an exchange node is still rejected: fragments are translated in isolation and
+/// multi-fragment plans are a later milestone.
+#[test]
+fn exchange_node_is_rejected() {
+    let exchange = base_plan_node(1, TPlanNodeType::EXCHANGE_NODE, 0, vec![0]);
+    let err = translate_fragment(&params(
+        Some(TPlan::new(vec![exchange])),
+        Some(base_desc()),
+        None,
+    ))
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        TranslateError::UnsupportedPlanNode {
+            node_type: TPlanNodeType::EXCHANGE_NODE,
+            ..
+        }
+    ));
+}
+
+/// Returns every extension function name declared by the plan.
+fn extension_function_names(plan: &substrait::proto::Plan) -> Vec<String> {
+    use substrait::proto::extensions::simple_extension_declaration::MappingType;
+    plan.extensions
+        .iter()
+        .filter_map(|declaration| match declaration.mapping_type.as_ref() {
+            Some(MappingType::ExtensionFunction(function)) => Some(function.name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Builds a select node filtering the scan with `conjunct`.
+fn filtered_scan(conjunct: TExpr) -> TPlan {
+    let mut select = base_plan_node(1, TPlanNodeType::SELECT_NODE, 1, vec![0]);
+    select.select_node = Some(TSelectNode::new(None));
+    select.conjuncts = Some(vec![conjunct]);
+    TPlan::new(vec![select, scan_node(0, 0)])
+}
+
+/// Verifies arithmetic expressions become Substrait arithmetic functions.
+#[test]
+fn arithmetic_expression_translates() {
+    let mut arith = base_expr_node(
+        TExprNodeType::ARITHMETIC_EXPR,
+        scalar_type(TPrimitiveType::BIGINT),
+        2,
+    );
+    arith.opcode = Some(TExprOpcode::MULTIPLY);
+    let mut nodes = vec![arith];
+    nodes.extend(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)).nodes);
+    nodes.extend(int_literal(2).nodes);
+    let product = TExpr::new(nodes);
+
+    let mut pred = base_expr_node(
+        TExprNodeType::BINARY_PRED,
+        scalar_type(TPrimitiveType::BOOLEAN),
+        2,
+    );
+    pred.opcode = Some(TExprOpcode::GT);
+    let mut nodes = vec![pred];
+    nodes.extend(product.nodes);
+    nodes.extend(int_literal(10).nodes);
+
+    let translated = translate_fragment(&params(
+        Some(filtered_scan(TExpr::new(nodes))),
+        Some(base_desc()),
+        None,
+    ))
+    .unwrap();
+    let names = extension_function_names(&translated.plan);
+    assert!(names.contains(&"multiply".to_string()), "{names:?}");
+}
+
+/// Verifies a DATE literal becomes a Substrait date literal in days since the epoch.
+#[test]
+fn date_literal_translates_to_epoch_days() {
+    let mut date = base_expr_node(
+        TExprNodeType::DATE_LITERAL,
+        scalar_type(TPrimitiveType::DATE),
+        0,
+    );
+    date.date_literal = Some(TDateLiteral::new("1998-09-02".to_string()));
+
+    let mut pred = base_expr_node(
+        TExprNodeType::BINARY_PRED,
+        scalar_type(TPrimitiveType::BOOLEAN),
+        2,
+    );
+    pred.opcode = Some(TExprOpcode::LE);
+    let mut nodes = vec![pred];
+    nodes.extend(slot_ref(1, 0, scalar_type(TPrimitiveType::DATE)).nodes);
+    nodes.push(date);
+
+    let translated = translate_fragment(&params(
+        Some(filtered_scan(TExpr::new(nodes))),
+        Some(desc_table(
+            vec![(0, Some(100))],
+            vec![slot(1, 0, 0, "d", scalar_type(TPrimitiveType::DATE))],
+        )),
+        None,
+    ))
+    .unwrap();
+    let condition = filter_condition(&translated.plan);
+    let literal = literal_type(scalar_arg(condition, 1));
+    assert_eq!(literal, &expression::literal::LiteralType::Date(10471));
+}
+
+/// Verifies `IN` predicates become singular-or-list expressions.
+#[test]
+fn in_predicate_translates_to_singular_or_list() {
+    let mut in_pred = base_expr_node(
+        TExprNodeType::IN_PRED,
+        scalar_type(TPrimitiveType::BOOLEAN),
+        3,
+    );
+    in_pred.in_predicate = Some(TInPredicate::new(false));
+    let mut nodes = vec![in_pred];
+    nodes.extend(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)).nodes);
+    nodes.extend(int_literal(1).nodes);
+    nodes.extend(int_literal(2).nodes);
+
+    let translated = translate_fragment(&params(
+        Some(filtered_scan(TExpr::new(nodes))),
+        Some(base_desc()),
+        None,
+    ))
+    .unwrap();
+    let condition = filter_condition(&translated.plan);
+    let expression::RexType::SingularOrList(list) = condition.rex_type.as_ref().unwrap() else {
+        panic!("expected singular-or-list");
+    };
+    assert_eq!(list.options.len(), 2);
+}
+
+/// Verifies allowlisted function calls translate and unknown builtins are rejected.
+#[test]
+fn function_calls_use_allowlist() {
+    let build = |name: &str| {
+        let mut call = base_expr_node(
+            TExprNodeType::FUNCTION_CALL,
+            scalar_type(TPrimitiveType::BOOLEAN),
+            2,
+        );
+        call.fn_ = Some(builtin_function(name, scalar_type(TPrimitiveType::BOOLEAN)));
+        let mut nodes = vec![call];
+        nodes.extend(slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR)).nodes);
+        nodes.extend(string_literal("%x%").nodes);
+        TExpr::new(nodes)
+    };
+
+    let translated = translate_fragment(&params(
+        Some(filtered_scan(build("like"))),
+        Some(base_desc()),
+        None,
+    ))
+    .unwrap();
+    let names = extension_function_names(&translated.plan);
+    assert!(names.contains(&"like".to_string()), "{names:?}");
+
+    let err = translate_fragment(&params(
+        Some(filtered_scan(build("hll_cardinality"))),
+        Some(base_desc()),
+        None,
+    ))
+    .unwrap_err();
+    assert!(matches!(err, TranslateError::MalformedPlan(_)));
+}
+
+/// Verifies CASE WHEN chains become Substrait if-then expressions with a null default.
+#[test]
+fn case_expression_translates_to_if_then() {
+    let mut case = base_expr_node(
+        TExprNodeType::CASE_EXPR,
+        scalar_type(TPrimitiveType::BIGINT),
+        2,
+    );
+    case.case_expr = Some(TCaseExpr::new(false, false));
+    let mut nodes = vec![case];
+    nodes.extend(bool_literal(true).nodes);
+    nodes.extend(int_literal(1).nodes);
+
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![scan_node(0, 0)])),
+        Some(base_desc()),
+        Some(vec![TExpr::new(nodes)]),
+    ))
+    .unwrap();
+    let root = root(&translated.plan);
+    let rel::RelType::Project(project) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected projection");
+    };
+    let expression::RexType::IfThen(if_then) = project.expressions[0].rex_type.as_ref().unwrap()
+    else {
+        panic!("expected if-then expression");
+    };
+    assert_eq!(if_then.ifs.len(), 1);
+    assert!(
+        if_then.r#else.is_some(),
+        "CASE without else defaults to null"
+    );
+}
+
+/// Verifies decimal-typed arithmetic is rejected (it crashes the engine's GPU projection).
+#[test]
+fn decimal_arithmetic_is_rejected() {
+    let decimal = scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(31), Some(4));
+    let mut arith = base_expr_node(TExprNodeType::ARITHMETIC_EXPR, decimal.clone(), 2);
+    arith.opcode = Some(TExprOpcode::MULTIPLY);
+    let mut nodes = vec![arith];
+    nodes.extend(slot_ref(1, 0, decimal.clone()).nodes);
+    nodes.extend(slot_ref(1, 0, decimal).nodes);
+
+    let err = translate_fragment(&params(
+        Some(TPlan::new(vec![scan_node(0, 0)])),
+        Some(base_desc()),
+        Some(vec![TExpr::new(nodes)]),
+    ))
+    .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            TranslateError::UnsupportedExpression {
+                node_type: TExprNodeType::ARITHMETIC_EXPR,
+                ..
+            }
+        ),
+        "{err:?}"
+    );
+}
+
+/// Verifies GPU-executor guards: non-constant LIKE patterns and non-constant substring
+/// bounds are rejected.
+#[test]
+fn gpu_unsupported_shapes_are_rejected() {
+    // LIKE with a column pattern (not a literal).
+    let mut like = base_expr_node(
+        TExprNodeType::FUNCTION_CALL,
+        scalar_type(TPrimitiveType::BOOLEAN),
+        2,
+    );
+    like.fn_ = Some(builtin_function(
+        "like",
+        scalar_type(TPrimitiveType::BOOLEAN),
+    ));
+    let mut nodes = vec![like];
+    nodes.extend(slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR)).nodes);
+    nodes.extend(slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR)).nodes);
+    let err = translate_fragment(&params(
+        Some(filtered_scan(TExpr::new(nodes))),
+        Some(base_desc()),
+        None,
+    ))
+    .unwrap_err();
+    assert!(
+        matches!(err, TranslateError::UnsupportedExpression { .. }),
+        "{err:?}"
+    );
+
+    // substring with a non-constant start.
+    let mut substr = base_expr_node(
+        TExprNodeType::FUNCTION_CALL,
+        scalar_type(TPrimitiveType::VARCHAR),
+        3,
+    );
+    substr.fn_ = Some(builtin_function(
+        "substring",
+        scalar_type(TPrimitiveType::VARCHAR),
+    ));
+    let mut nodes = vec![substr];
+    nodes.extend(slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR)).nodes);
+    nodes.extend(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)).nodes);
+    nodes.extend(int_literal(2).nodes);
+    let err = translate_fragment(&params(
+        Some(TPlan::new(vec![scan_node(0, 0)])),
+        Some(base_desc()),
+        Some(vec![TExpr::new(nodes)]),
+    ))
+    .unwrap_err();
+    assert!(
+        matches!(err, TranslateError::UnsupportedExpression { .. }),
+        "{err:?}"
+    );
 }


### PR DESCRIPTION
Translate `ARITHMETIC_EXPR`, `DATE_LITERAL`, `IN_PRED`, `CASE_EXPR`, and an allowlist of scalar `FUNCTION_CALL`s (`like`, `if`, `substring`, `year`/`month`/`day`, byte/codepoint length) chosen so name-level mapping preserves StarRocks semantics on the DuckDB side.

Rejected with structured errors instead of failing downstream: decimal-typed arithmetic (currently segfaults the GPU projection kernel), non-constant LIKE patterns or patterns with escapes, and non-constant/non-positive substring bounds.



## Stack

All based on `dev`, so each diff includes the levels below it until they merge (review commits, or the last commit, for the per-level change):

1. #1106
2. #1107
3. #1108
4. #1109 ⬅️ this PR
5. #1110
6. #1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
