### PR TITLE
feat(starrocks): translate hash and nested-loop joins

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -33,9 +33,11 @@
 //! | `PROJECT_NODE`       | `ProjectRel`       |
 //! | `AGGREGATION_NODE`   | `AggregateRel` (finalized one-phase only, `new_planner_agg_stage=1`) |
 //! | `SORT_NODE`          | `ProjectRel` (sort tuple) + `SortRel` (global row-number top-N only) |
+//! | `HASH_JOIN_NODE`     | `JoinRel` (inner/outer/left-semi; anti joins are rejected) |
+//! | `NESTLOOP_JOIN_NODE` | `CrossRel` (+ `FilterRel`), inner/cross only |
 //!
-//! Node-level `conjuncts` (scan/filter predicates, HAVING) become a `FilterRel` over the
-//! node's output on every supported node.
+//! Node-level `conjuncts` (scan/filter predicates, HAVING, post-join filters) become a
+//! `FilterRel` over the node's output on every supported node.
 //!
 //! Any node's non-negative `limit` (plus a sort offset) becomes a `FetchRel` on top of its
 //! relation.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -1,4 +1,4 @@
-use starrocks_thrift::exprs::TExpr;
+use starrocks_thrift::exprs::{TExpr, TExprNodeType};
 use starrocks_thrift::opcodes::TExprOpcode;
 use starrocks_thrift::plan_nodes::{TJoinOp, TPlan, TPlanNode, TPlanNodeType, TSortInfo};
 use substrait::proto::read_rel::local_files::FileOrFiles;
@@ -752,8 +752,9 @@ fn translate_nestloop_join(
     let row_tuples = [left.row_tuples.as_slice(), right.row_tuples.as_slice()].concat();
     let output_width = left.output_width + right.output_width;
 
-    let mut conditions = Vec::new();
-    for expr in join.join_conjuncts.as_deref().unwrap_or_default() {
+    let conjuncts = join.join_conjuncts.as_deref().unwrap_or_default();
+    let mut conditions = Vec::with_capacity(conjuncts.len());
+    for expr in conjuncts {
         let mut expr_ctx = ctx.expr_context(&row_tuples);
         conditions.push(expr.translate(&mut expr_ctx)?);
     }
@@ -764,6 +765,16 @@ fn translate_nestloop_join(
         node_type: node.node_type,
         reason: "cross joins without join conjuncts are not supported",
     })?;
+    if !conjuncts
+        .iter()
+        .any(|conjunct| becomes_join_condition(conjunct, &left.row_tuples, &right.row_tuples))
+    {
+        return Err(TranslateError::UnsupportedPlanNode {
+            node_id: node.node_id,
+            node_type: node.node_type,
+            reason: "nested-loop joins need a comparison between the two inputs",
+        });
+    }
 
     let cross = Rel {
         rel_type: Some(rel::RelType::Cross(Box::new(CrossRel {
@@ -785,6 +796,36 @@ fn translate_nestloop_join(
     };
     // Node conjuncts are post-join predicates over the join's output row.
     apply_conjuncts(filtered, node, ctx)
+}
+
+/// Returns whether DuckDB will lift `conjunct` out of the filter above the cross product and into
+/// a join condition.
+///
+/// `FilterPushdown::PushdownCrossProduct` splits that filter by side: a predicate reading only one
+/// input is pushed into that input, and only predicates reading both become join conditions —
+/// which `ExtractJoinConditions` then keeps as conditions when the predicate is a comparison, and
+/// demotes to an any-join otherwise. With no such predicate the plan lowers to a bare cross
+/// product or an any-join, and the GPU planner implements neither
+/// (`sirius_physical_plan_generator.cpp`), so it would fail at execution instead of here.
+///
+/// This approximates the rule from the one side that matters: a comparison whose own operands each
+/// read both inputs (`a.x + b.y < 10`) also becomes an any-join, and is accepted here.
+fn becomes_join_condition(conjunct: &TExpr, left_tuples: &[i32], right_tuples: &[i32]) -> bool {
+    conjunct
+        .nodes
+        .first()
+        .is_some_and(|root| root.node_type == TExprNodeType::BINARY_PRED)
+        && reads_tuples(conjunct, left_tuples)
+        && reads_tuples(conjunct, right_tuples)
+}
+
+/// Returns whether any slot reference in `expr` belongs to one of `tuples`.
+fn reads_tuples(expr: &TExpr, tuples: &[i32]) -> bool {
+    expr.nodes.iter().any(|node| {
+        node.slot_ref
+            .as_ref()
+            .is_some_and(|slot_ref| tuples.contains(&slot_ref.tuple_id))
+    })
 }
 
 /// Combines boolean conditions with `and`.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -17,9 +17,7 @@ use crate::error::{Result, TranslateError};
 use crate::expr_translator::{self, ExprContext, TranslateExpr};
 use crate::scan_paths::ScanFilePaths;
 use crate::type_mapper;
-use crate::{
-    ExtensionRegistry, URN_AGGREGATE, URN_ARITHMETIC, URN_BOOLEAN, URN_COMPARISON,
-};
+use crate::{ExtensionRegistry, URN_AGGREGATE, URN_ARITHMETIC, URN_BOOLEAN, URN_COMPARISON};
 
 /// Partially translated relation plus the StarRocks row layout it emits.
 pub(crate) struct TranslatedRel {

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -671,14 +671,11 @@ fn translate_hash_join(
         let mut expr_ctx = ctx.expr_context(&combined_tuples);
         conditions.push(expr.translate(&mut expr_ctx)?);
     }
-    if conditions.is_empty() {
-        return Err(TranslateError::UnsupportedPlanNode {
-            node_id: node.node_id,
-            node_type: node.node_type,
-            reason: "hash join without join conjuncts",
-        });
-    }
-    let condition = and_conditions(conditions, ctx);
+    let condition = and_conditions(conditions, ctx).ok_or(TranslateError::UnsupportedPlanNode {
+        node_id: node.node_id,
+        node_type: node.node_type,
+        reason: "hash join without join conjuncts",
+    })?;
 
     // Anti joins (from NOT IN / NOT EXISTS rewrites) are not translated: DuckDB's Substrait
     // consumer has no left-anti conversion, so an emitted plan would fail downstream anyway.
@@ -721,8 +718,8 @@ fn translate_hash_join(
     apply_conjuncts(joined, node, ctx)
 }
 
-/// Translates a `NESTLOOP_JOIN_NODE` into a Substrait cross product (plus a filter when the
-/// join carries conjuncts). Only inner/cross nested-loop joins are supported.
+/// Translates a `NESTLOOP_JOIN_NODE` into a Substrait cross product with the join conjuncts as a
+/// filter on top. Only inner/cross nested-loop joins are supported.
 fn translate_nestloop_join(
     node: &TPlanNode,
     children: Vec<TranslatedRel>,
@@ -752,72 +749,61 @@ fn translate_nestloop_join(
     let row_tuples = [left.row_tuples.as_slice(), right.row_tuples.as_slice()].concat();
     let output_width = left.output_width + right.output_width;
 
-    let cross = TranslatedRel {
+    let mut conditions = Vec::new();
+    for expr in join.join_conjuncts.as_deref().unwrap_or_default() {
+        let mut expr_ctx = ctx.expr_context(&row_tuples);
+        conditions.push(expr.translate(&mut expr_ctx)?);
+    }
+    // A conjunct-free cross product is rejected: the GPU physical planner has no cross-product
+    // operator, so the plan would translate and then fail at execution.
+    let condition = and_conditions(conditions, ctx).ok_or(TranslateError::UnsupportedPlanNode {
+        node_id: node.node_id,
+        node_type: node.node_type,
+        reason: "cross joins without join conjuncts are not supported",
+    })?;
+
+    let cross = Rel {
+        rel_type: Some(rel::RelType::Cross(Box::new(CrossRel {
+            left: Some(Box::new(left.rel)),
+            right: Some(Box::new(right.rel)),
+            ..Default::default()
+        }))),
+    };
+    let filtered = TranslatedRel {
         rel: Rel {
-            rel_type: Some(rel::RelType::Cross(Box::new(CrossRel {
-                left: Some(Box::new(left.rel)),
-                right: Some(Box::new(right.rel)),
+            rel_type: Some(rel::RelType::Filter(Box::new(FilterRel {
+                input: Some(Box::new(cross)),
+                condition: Some(Box::new(condition)),
                 ..Default::default()
             }))),
         },
         row_tuples,
         output_width,
     };
-
-    // A conjunct-free cross product is rejected: the GPU physical planner has no cross-product
-    // operator, so the plan would translate and then fail at execution.
-    if join
-        .join_conjuncts
-        .as_ref()
-        .is_none_or(|conjuncts| conjuncts.is_empty())
-    {
-        return Err(TranslateError::UnsupportedPlanNode {
-            node_id: node.node_id,
-            node_type: node.node_type,
-            reason: "cross joins without join conjuncts are not supported",
-        });
-    }
-    let filtered = if let Some(conjuncts) = join
-        .join_conjuncts
-        .as_ref()
-        .filter(|conjuncts| !conjuncts.is_empty())
-    {
-        let mut conditions = Vec::with_capacity(conjuncts.len());
-        for expr in conjuncts {
-            let mut expr_ctx = ctx.expr_context(&cross.row_tuples);
-            conditions.push(expr.translate(&mut expr_ctx)?);
-        }
-        let condition = and_conditions(conditions, ctx);
-        let TranslatedRel {
-            rel,
-            row_tuples,
-            output_width,
-        } = cross;
-        TranslatedRel {
-            rel: Rel {
-                rel_type: Some(rel::RelType::Filter(Box::new(FilterRel {
-                    input: Some(Box::new(rel)),
-                    condition: Some(Box::new(condition)),
-                    ..Default::default()
-                }))),
-            },
-            row_tuples,
-            output_width,
-        }
-    } else {
-        cross
-    };
     // Node conjuncts are post-join predicates over the join's output row.
     apply_conjuncts(filtered, node, ctx)
 }
 
-/// Combines one or more boolean conditions with `and`.
-fn and_conditions(mut conditions: Vec<Expression>, ctx: &mut PlanContext<'_>) -> Expression {
-    if conditions.len() == 1 {
-        return conditions.pop().unwrap();
+/// Combines boolean conditions with `and`.
+///
+/// `None` for an empty list: a zero-argument `and()` is not a valid Substrait expression, so what
+/// an absent condition means is the caller's decision.
+fn and_conditions(
+    mut conditions: Vec<Expression>,
+    ctx: &mut PlanContext<'_>,
+) -> Option<Expression> {
+    match conditions.len() {
+        0 => None,
+        1 => conditions.pop(),
+        _ => {
+            let anchor = ctx.registry.register_function(URN_BOOLEAN, "and");
+            Some(expr_translator::scalar_function(
+                anchor,
+                conditions,
+                crate::type_mapper::bool_type(),
+            ))
+        }
     }
-    let anchor = ctx.registry.register_function(URN_BOOLEAN, "and");
-    expr_translator::scalar_function(anchor, conditions, crate::type_mapper::bool_type())
 }
 
 /// Builds a Substrait read for a StarRocks scan tuple.
@@ -971,24 +957,14 @@ fn apply_conjuncts(
     node: &TPlanNode,
     ctx: &mut PlanContext<'_>,
 ) -> Result<TranslatedRel> {
-    let Some(conjuncts) = node.conjuncts.as_ref().filter(|_| has_conjuncts(node)) else {
-        return Ok(input);
-    };
+    let conjuncts = node.conjuncts.as_deref().unwrap_or_default();
     let mut conditions = Vec::with_capacity(conjuncts.len());
     for expr in conjuncts {
         let mut expr_ctx = ctx.expr_context(&input.row_tuples);
         conditions.push(expr.translate(&mut expr_ctx)?);
     }
-    let condition = match conditions.len() {
-        1 => conditions.pop().unwrap(),
-        _ => {
-            let and_anchor = ctx.registry.register_function(URN_BOOLEAN, "and");
-            expr_translator::scalar_function(
-                and_anchor,
-                conditions,
-                crate::type_mapper::bool_type(),
-            )
-        }
+    let Some(condition) = and_conditions(conditions, ctx) else {
+        return Ok(input);
     };
 
     // A filter does not change the column layout, so the width passes through.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -640,6 +640,26 @@ fn translate_hash_join(
             context: "HASH_JOIN_NODE",
             field: "hash_join_node",
         })?;
+    // Validated before the conjuncts so an unsupported op is reported as such, rather than as the
+    // missing conjuncts an anti join arrives with once the FE has folded its predicate away.
+    //
+    // Anti joins (from NOT IN / NOT EXISTS rewrites) are not translated: DuckDB's Substrait
+    // consumer has no left-anti conversion, so an emitted plan would fail downstream anyway.
+    let (join_type, semi) = match join.join_op {
+        TJoinOp::INNER_JOIN => (join_rel::JoinType::Inner, false),
+        TJoinOp::LEFT_OUTER_JOIN => (join_rel::JoinType::Left, false),
+        TJoinOp::RIGHT_OUTER_JOIN => (join_rel::JoinType::Right, false),
+        TJoinOp::FULL_OUTER_JOIN => (join_rel::JoinType::Outer, false),
+        TJoinOp::LEFT_SEMI_JOIN => (join_rel::JoinType::LeftSemi, true),
+        _ => {
+            return Err(TranslateError::UnsupportedPlanNode {
+                node_id: node.node_id,
+                node_type: node.node_type,
+                reason: "hash join type is unsupported",
+            });
+        }
+    };
+
     let mut children = children.into_iter();
     let left = children.next().unwrap();
     let right = children.next().unwrap();
@@ -676,23 +696,6 @@ fn translate_hash_join(
         node_type: node.node_type,
         reason: "hash join without join conjuncts",
     })?;
-
-    // Anti joins (from NOT IN / NOT EXISTS rewrites) are not translated: DuckDB's Substrait
-    // consumer has no left-anti conversion, so an emitted plan would fail downstream anyway.
-    let (join_type, semi) = match join.join_op {
-        TJoinOp::INNER_JOIN => (join_rel::JoinType::Inner, false),
-        TJoinOp::LEFT_OUTER_JOIN => (join_rel::JoinType::Left, false),
-        TJoinOp::RIGHT_OUTER_JOIN => (join_rel::JoinType::Right, false),
-        TJoinOp::FULL_OUTER_JOIN => (join_rel::JoinType::Outer, false),
-        TJoinOp::LEFT_SEMI_JOIN => (join_rel::JoinType::LeftSemi, true),
-        _ => {
-            return Err(TranslateError::UnsupportedPlanNode {
-                node_id: node.node_id,
-                node_type: node.node_type,
-                reason: "hash join type is unsupported",
-            });
-        }
-    };
 
     // Semi joins emit only the probe-side row; other joins emit probe then build columns.
     let (row_tuples, output_width) = if semi {

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -1,14 +1,15 @@
 use starrocks_thrift::exprs::TExpr;
-use starrocks_thrift::plan_nodes::{TPlan, TPlanNode, TPlanNodeType, TSortInfo};
+use starrocks_thrift::opcodes::TExprOpcode;
+use starrocks_thrift::plan_nodes::{TJoinOp, TPlan, TPlanNode, TPlanNodeType, TSortInfo};
 use substrait::proto::read_rel::local_files::FileOrFiles;
 use substrait::proto::read_rel::local_files::file_or_files::{
     FileFormat, ParquetReadOptions, PathType,
 };
 use substrait::proto::read_rel::{LocalFiles, NamedTable, ReadType};
 use substrait::proto::{
-    AggregateFunction, AggregateRel, Expression, FetchRel, FilterRel, ProjectRel, ReadRel, Rel,
-    RelCommon, SortField, SortRel, aggregate_rel, fetch_rel, function_argument, rel, rel_common,
-    sort_field,
+    AggregateFunction, AggregateRel, CrossRel, Expression, FetchRel, FilterRel, JoinRel,
+    ProjectRel, ReadRel, Rel, RelCommon, SortField, SortRel, aggregate_rel, fetch_rel,
+    function_argument, join_rel, rel, rel_common, sort_field,
 };
 
 use crate::descriptor_table::DescriptorTable;
@@ -16,7 +17,9 @@ use crate::error::{Result, TranslateError};
 use crate::expr_translator::{self, ExprContext, TranslateExpr};
 use crate::scan_paths::ScanFilePaths;
 use crate::type_mapper;
-use crate::{ExtensionRegistry, URN_AGGREGATE, URN_ARITHMETIC, URN_BOOLEAN};
+use crate::{
+    ExtensionRegistry, URN_AGGREGATE, URN_ARITHMETIC, URN_BOOLEAN, URN_COMPARISON,
+};
 
 /// Partially translated relation plus the StarRocks row layout it emits.
 pub(crate) struct TranslatedRel {
@@ -152,6 +155,8 @@ fn translate_plan_node(
         TPlanNodeType::PROJECT_NODE => translate_project(node, children, ctx),
         TPlanNodeType::AGGREGATION_NODE => translate_aggregation(node, children, ctx),
         TPlanNodeType::SORT_NODE => translate_sort(node, children, ctx),
+        TPlanNodeType::HASH_JOIN_NODE => translate_hash_join(node, children, ctx),
+        TPlanNodeType::NESTLOOP_JOIN_NODE => translate_nestloop_join(node, children, ctx),
         _ => Err(TranslateError::UnsupportedPlanNode {
             node_id: node.node_id,
             node_type: node.node_type,
@@ -615,6 +620,204 @@ fn sort_fields(
             })
         })
         .collect()
+}
+
+/// Translates a `HASH_JOIN_NODE` into a Substrait join relation.
+///
+/// StarRocks children are `[probe (left), build (right)]`; the Substrait join condition is
+/// evaluated over the concatenated left-then-right row, which is exactly how
+/// `slot_global_index` resolves slots against the combined layout.
+fn translate_hash_join(
+    node: &TPlanNode,
+    children: Vec<TranslatedRel>,
+    ctx: &mut PlanContext<'_>,
+) -> Result<TranslatedRel> {
+    expect_children(node, &children, 2)?;
+    let join = node
+        .hash_join_node
+        .as_ref()
+        .ok_or(TranslateError::MissingField {
+            context: "HASH_JOIN_NODE",
+            field: "hash_join_node",
+        })?;
+    let mut children = children.into_iter();
+    let left = children.next().unwrap();
+    let right = children.next().unwrap();
+
+    let combined_tuples = [left.row_tuples.as_slice(), right.row_tuples.as_slice()].concat();
+    let mut conditions = Vec::new();
+    for eq in &join.eq_join_conjuncts {
+        if let Some(opcode) = eq.opcode
+            && opcode != TExprOpcode::EQ
+        {
+            return Err(TranslateError::UnsupportedPlanNode {
+                node_id: node.node_id,
+                node_type: node.node_type,
+                reason: "only plain equality join conjuncts are supported",
+            });
+        }
+        let mut expr_ctx = ctx.expr_context(&combined_tuples);
+        let left_expr = eq.left.translate(&mut expr_ctx)?;
+        let mut expr_ctx = ctx.expr_context(&combined_tuples);
+        let right_expr = eq.right.translate(&mut expr_ctx)?;
+        let anchor = ctx.registry.register_function(URN_COMPARISON, "equal");
+        conditions.push(expr_translator::scalar_function(
+            anchor,
+            vec![left_expr, right_expr],
+            crate::type_mapper::bool_type(),
+        ));
+    }
+    for expr in join.other_join_conjuncts.as_deref().unwrap_or_default() {
+        let mut expr_ctx = ctx.expr_context(&combined_tuples);
+        conditions.push(expr.translate(&mut expr_ctx)?);
+    }
+    if conditions.is_empty() {
+        return Err(TranslateError::UnsupportedPlanNode {
+            node_id: node.node_id,
+            node_type: node.node_type,
+            reason: "hash join without join conjuncts",
+        });
+    }
+    let condition = and_conditions(conditions, ctx);
+
+    // Anti joins (from NOT IN / NOT EXISTS rewrites) are not translated: DuckDB's Substrait
+    // consumer has no left-anti conversion, so an emitted plan would fail downstream anyway.
+    let (join_type, semi) = match join.join_op {
+        TJoinOp::INNER_JOIN => (join_rel::JoinType::Inner, false),
+        TJoinOp::LEFT_OUTER_JOIN => (join_rel::JoinType::Left, false),
+        TJoinOp::RIGHT_OUTER_JOIN => (join_rel::JoinType::Right, false),
+        TJoinOp::FULL_OUTER_JOIN => (join_rel::JoinType::Outer, false),
+        TJoinOp::LEFT_SEMI_JOIN => (join_rel::JoinType::LeftSemi, true),
+        _ => {
+            return Err(TranslateError::UnsupportedPlanNode {
+                node_id: node.node_id,
+                node_type: node.node_type,
+                reason: "hash join type is unsupported",
+            });
+        }
+    };
+
+    // Semi joins emit only the probe-side row; other joins emit probe then build columns.
+    let (row_tuples, output_width) = if semi {
+        (left.row_tuples.clone(), left.output_width)
+    } else {
+        (combined_tuples, left.output_width + right.output_width)
+    };
+
+    let joined = TranslatedRel {
+        rel: Rel {
+            rel_type: Some(rel::RelType::Join(Box::new(JoinRel {
+                left: Some(Box::new(left.rel)),
+                right: Some(Box::new(right.rel)),
+                expression: Some(Box::new(condition)),
+                r#type: join_type as i32,
+                ..Default::default()
+            }))),
+        },
+        row_tuples,
+        output_width,
+    };
+    // Node conjuncts are post-join predicates over the join's output row.
+    apply_conjuncts(joined, node, ctx)
+}
+
+/// Translates a `NESTLOOP_JOIN_NODE` into a Substrait cross product (plus a filter when the
+/// join carries conjuncts). Only inner/cross nested-loop joins are supported.
+fn translate_nestloop_join(
+    node: &TPlanNode,
+    children: Vec<TranslatedRel>,
+    ctx: &mut PlanContext<'_>,
+) -> Result<TranslatedRel> {
+    expect_children(node, &children, 2)?;
+    let join = node
+        .nestloop_join_node
+        .as_ref()
+        .ok_or(TranslateError::MissingField {
+            context: "NESTLOOP_JOIN_NODE",
+            field: "nestloop_join_node",
+        })?;
+    match join.join_op {
+        None | Some(TJoinOp::CROSS_JOIN) | Some(TJoinOp::INNER_JOIN) => {}
+        Some(_) => {
+            return Err(TranslateError::UnsupportedPlanNode {
+                node_id: node.node_id,
+                node_type: node.node_type,
+                reason: "only inner/cross nested-loop joins are supported",
+            });
+        }
+    }
+    let mut children = children.into_iter();
+    let left = children.next().unwrap();
+    let right = children.next().unwrap();
+    let row_tuples = [left.row_tuples.as_slice(), right.row_tuples.as_slice()].concat();
+    let output_width = left.output_width + right.output_width;
+
+    let cross = TranslatedRel {
+        rel: Rel {
+            rel_type: Some(rel::RelType::Cross(Box::new(CrossRel {
+                left: Some(Box::new(left.rel)),
+                right: Some(Box::new(right.rel)),
+                ..Default::default()
+            }))),
+        },
+        row_tuples,
+        output_width,
+    };
+
+    // A conjunct-free cross product is rejected: the GPU physical planner has no cross-product
+    // operator, so the plan would translate and then fail at execution.
+    if join
+        .join_conjuncts
+        .as_ref()
+        .is_none_or(|conjuncts| conjuncts.is_empty())
+    {
+        return Err(TranslateError::UnsupportedPlanNode {
+            node_id: node.node_id,
+            node_type: node.node_type,
+            reason: "cross joins without join conjuncts are not supported",
+        });
+    }
+    let filtered = if let Some(conjuncts) = join
+        .join_conjuncts
+        .as_ref()
+        .filter(|conjuncts| !conjuncts.is_empty())
+    {
+        let mut conditions = Vec::with_capacity(conjuncts.len());
+        for expr in conjuncts {
+            let mut expr_ctx = ctx.expr_context(&cross.row_tuples);
+            conditions.push(expr.translate(&mut expr_ctx)?);
+        }
+        let condition = and_conditions(conditions, ctx);
+        let TranslatedRel {
+            rel,
+            row_tuples,
+            output_width,
+        } = cross;
+        TranslatedRel {
+            rel: Rel {
+                rel_type: Some(rel::RelType::Filter(Box::new(FilterRel {
+                    input: Some(Box::new(rel)),
+                    condition: Some(Box::new(condition)),
+                    ..Default::default()
+                }))),
+            },
+            row_tuples,
+            output_width,
+        }
+    } else {
+        cross
+    };
+    // Node conjuncts are post-join predicates over the join's output row.
+    apply_conjuncts(filtered, node, ctx)
+}
+
+/// Combines one or more boolean conditions with `and`.
+fn and_conditions(mut conditions: Vec<Expression>, ctx: &mut PlanContext<'_>) -> Expression {
+    if conditions.len() == 1 {
+        return conditions.pop().unwrap();
+    }
+    let anchor = ctx.registry.register_function(URN_BOOLEAN, "and");
+    expr_translator::scalar_function(anchor, conditions, crate::type_mapper::bool_type())
 }
 
 /// Builds a Substrait read for a StarRocks scan tuple.

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -2258,6 +2258,20 @@ fn join_desc() -> TDescriptorTable {
     )
 }
 
+/// Two-table descriptor whose sides differ in width: tuple 0 = users(`a`, `b`), tuple 1 =
+/// orders(`c`). A build-side slot lands at field 2, so an index into the concatenated
+/// probe-then-build row cannot be confused with a literal `1`.
+fn wide_join_desc() -> TDescriptorTable {
+    desc_table(
+        vec![(0, Some(100)), (1, Some(100))],
+        vec![
+            slot(1, 0, 0, "a", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, 1, "b", scalar_type(TPrimitiveType::BIGINT)),
+            slot(1, 1, 0, "c", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    )
+}
+
 /// Builds a hash-join plan node with one `left = right` equality conjunct.
 fn hash_join_node(join_op: TJoinOp) -> TPlanNode {
     let mut join = base_plan_node(2, TPlanNodeType::HASH_JOIN_NODE, 2, vec![0, 1]);
@@ -2287,6 +2301,18 @@ fn hash_join_node(join_op: TJoinOp) -> TPlanNode {
         None,
     ));
     join
+}
+
+/// Field indices referenced by a scalar function's arguments, in order.
+fn argument_field_indices(scalar: &expression::ScalarFunction) -> Vec<i32> {
+    scalar
+        .arguments
+        .iter()
+        .map(|argument| match argument.arg_type.as_ref().unwrap() {
+            substrait::proto::function_argument::ArgType::Value(value) => field_index(value),
+            other => panic!("unexpected argument {other:?}"),
+        })
+        .collect()
 }
 
 /// Extracts the field index from a direct struct-field reference.
@@ -2332,15 +2358,86 @@ fn inner_hash_join_translates_to_join_rel() {
     else {
         panic!("expected scalar function join condition");
     };
-    let args: Vec<_> = equal
+    assert_eq!(argument_field_indices(equal), vec![0, 1]);
+}
+
+/// Verifies an ON-clause predicate beyond the equality is ANDed into the join condition, and that
+/// both operands resolve against the concatenated probe-then-build row.
+///
+/// Run over the asymmetric descriptor: with a two-column probe side a build-side reference lands
+/// at field 2, which a wrong offset (a literal 1, or the build width) cannot reproduce.
+#[test]
+fn other_join_conjuncts_are_anded_into_the_join_condition() {
+    let bigint = || scalar_type(TPrimitiveType::BIGINT);
+    let mut join = hash_join_node(TJoinOp::INNER_JOIN);
+    join.hash_join_node.as_mut().unwrap().other_join_conjuncts = Some(vec![binary_pred(
+        TExprOpcode::LT,
+        slot_ref(2, 0, bigint()),
+        slot_ref(1, 1, bigint()),
+    )]);
+    let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
+    let translated = translate_fragment(&params(Some(plan), Some(wide_join_desc()), None)).unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["a", "b", "c"]);
+    let rel::RelType::Join(join) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected join relation");
+    };
+    let conjunction = scalar_fn(join.expression.as_ref().unwrap());
+    let (urn, name) = resolved_function(&translated.plan, conjunction.function_reference);
+    assert_eq!((urn.as_str(), name.as_str()), (URN_BOOLEAN, "and"));
+
+    let operands: Vec<_> = conjunction
         .arguments
         .iter()
         .map(|argument| match argument.arg_type.as_ref().unwrap() {
-            substrait::proto::function_argument::ArgType::Value(value) => field_index(value),
+            substrait::proto::function_argument::ArgType::Value(value) => scalar_fn(value),
             other => panic!("unexpected argument {other:?}"),
         })
         .collect();
-    assert_eq!(args, vec![0, 1]);
+    let names: Vec<_> = operands
+        .iter()
+        .map(|operand| resolved_function(&translated.plan, operand.function_reference).1)
+        .collect();
+    assert_eq!(names, vec!["equal", "lt"]);
+    // `a = c` then `b < c`: fields 0 and 1 are the probe side, field 2 is the build side.
+    assert_eq!(argument_field_indices(operands[0]), vec![0, 2]);
+    assert_eq!(argument_field_indices(operands[1]), vec![1, 2]);
+}
+
+/// Verifies a join's own conjuncts become a filter over the join, resolved against the
+/// concatenated row rather than the probe side alone.
+#[test]
+fn join_node_conjuncts_become_a_post_join_filter() {
+    let mut join = hash_join_node(TJoinOp::INNER_JOIN);
+    join.conjuncts = Some(vec![binary_pred(
+        TExprOpcode::GT,
+        slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+        int_literal(10),
+    )]);
+    let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
+    let translated = translate_fragment(&params(Some(plan), Some(wide_join_desc()), None)).unwrap();
+
+    let rel::RelType::Filter(filter) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected a filter over the join");
+    };
+    let rel::RelType::Join(_) = filter.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected the join under the filter");
+    };
+    let greater = scalar_fn(filter.condition.as_deref().unwrap());
+    let substrait::proto::function_argument::ArgType::Value(probed) =
+        greater.arguments[0].arg_type.as_ref().unwrap()
+    else {
+        panic!("expected a value argument");
+    };
+    assert_eq!(field_index(probed), 2);
 }
 
 /// Verifies a left semi join keeps only the probe-side row layout.
@@ -2415,6 +2512,31 @@ fn nestloop_join_translates_to_filtered_cross_rel() {
     let rel::RelType::Cross(_) = filter.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
         panic!("expected cross product under filter");
     };
+}
+
+/// Verifies a nested-loop join that is not inner or cross is rejected: the translation emits a
+/// cross product, which keeps no unmatched rows.
+#[test]
+fn non_inner_nestloop_join_is_rejected() {
+    for join_op in [TJoinOp::LEFT_OUTER_JOIN, TJoinOp::LEFT_SEMI_JOIN] {
+        let plan = TPlan::new(vec![
+            nestloop_join_node(
+                join_op,
+                vec![binary_pred(
+                    TExprOpcode::LT,
+                    slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+                    slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+                )],
+            ),
+            scan_node(0, 0),
+            scan_node(1, 1),
+        ]);
+        let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
+        let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
+            panic!("{join_op:?}: expected an unsupported plan node, got {err:?}");
+        };
+        assert_eq!(reason, "only inner/cross nested-loop joins are supported");
+    }
 }
 
 /// Verifies a nested-loop join is rejected unless a conjunct survives as a join condition.

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -2652,6 +2652,21 @@ fn anti_hash_join_is_rejected() {
     }
 }
 
+/// Verifies an unsupported join op is named as the reason even when the plan also carries no join
+/// conjuncts, which is the shape an anti join arrives in once the FE has folded its predicate away.
+#[test]
+fn unsupported_join_type_is_reported_before_missing_conjuncts() {
+    let mut join = hash_join_node(TJoinOp::LEFT_ANTI_JOIN);
+    join.hash_join_node.as_mut().unwrap().eq_join_conjuncts = vec![];
+    let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
+
+    let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
+    let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
+        panic!("expected an unsupported plan node, got {err:?}");
+    };
+    assert_eq!(reason, "hash join type is unsupported");
+}
+
 /// Verifies decimal-typed arithmetic is rejected (it crashes the engine's GPU projection).
 #[test]
 fn decimal_arithmetic_is_rejected() {

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -2252,8 +2252,8 @@ fn join_desc() -> TDescriptorTable {
     desc_table(
         vec![(0, Some(100)), (1, Some(100))],
         vec![
-            slot(1, 0, 0, "a", scalar_type(TPrimitiveType::BIGINT)),
-            slot(1, 1, 0, "b", scalar_type(TPrimitiveType::BIGINT)),
+            slot(1, 0, "a", scalar_type(TPrimitiveType::BIGINT)),
+            slot(1, 1, "b", scalar_type(TPrimitiveType::BIGINT)),
         ],
     )
 }
@@ -2265,9 +2265,9 @@ fn wide_join_desc() -> TDescriptorTable {
     desc_table(
         vec![(0, Some(100)), (1, Some(100))],
         vec![
-            slot(1, 0, 0, "a", scalar_type(TPrimitiveType::BIGINT)),
-            slot(2, 0, 1, "b", scalar_type(TPrimitiveType::BIGINT)),
-            slot(1, 1, 0, "c", scalar_type(TPrimitiveType::BIGINT)),
+            slot(1, 0, "a", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, "b", scalar_type(TPrimitiveType::BIGINT)),
+            slot(1, 1, "c", scalar_type(TPrimitiveType::BIGINT)),
         ],
     )
 }
@@ -2313,24 +2313,6 @@ fn argument_field_indices(scalar: &expression::ScalarFunction) -> Vec<i32> {
             other => panic!("unexpected argument {other:?}"),
         })
         .collect()
-}
-
-/// Extracts the field index from a direct struct-field reference.
-fn field_index(expr: &substrait::proto::Expression) -> i32 {
-    let expression::RexType::Selection(selection) = expr.rex_type.as_ref().unwrap() else {
-        panic!("expected field reference");
-    };
-    let expression::field_reference::ReferenceType::DirectReference(segment) =
-        selection.reference_type.as_ref().unwrap()
-    else {
-        panic!("expected direct reference");
-    };
-    let expression::reference_segment::ReferenceType::StructField(field) =
-        segment.reference_type.as_ref().unwrap()
-    else {
-        panic!("expected struct field");
-    };
-    field.field
 }
 
 /// Verifies an inner hash join becomes a Substrait join whose equality condition references the

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -18,9 +18,9 @@ use starrocks_thrift::internal_service::{
 use starrocks_thrift::opcodes::TExprOpcode;
 use starrocks_thrift::partitions::{TDataPartition, TPartitionType};
 use starrocks_thrift::plan_nodes::{
-    TAggregationNode, TBrokerRangeDesc, TBrokerScanRange, TBrokerScanRangeParams, TFileFormatType,
-    TFileScanNode, TFileScanType, TPlan, TPlanNode, TPlanNodeType, TProjectNode, TScanRange,
-    TSelectNode, TSortInfo, TSortNode,
+    TAggregationNode, TBrokerRangeDesc, TBrokerScanRange, TBrokerScanRangeParams, TEqJoinCondition,
+    TFileFormatType, TFileScanNode, TFileScanType, THashJoinNode, TJoinOp, TNestLoopJoinNode,
+    TPlan, TPlanNode, TPlanNodeType, TProjectNode, TScanRange, TSelectNode, TSortInfo, TSortNode,
 };
 use starrocks_thrift::planner::TPlanFragment;
 use starrocks_thrift::types::{
@@ -1139,10 +1139,10 @@ fn fragment_output_exprs_add_root_projection() {
     }
 }
 
-/// Verifies unsupported joins return a structured unsupported-plan-node error.
+/// Verifies unsupported plan nodes return a structured unsupported-plan-node error.
 #[test]
-fn unsupported_hash_join_is_structured_error() {
-    let join = base_plan_node(9, TPlanNodeType::HASH_JOIN_NODE, 0, vec![0]);
+fn unsupported_merge_join_is_structured_error() {
+    let join = base_plan_node(9, TPlanNodeType::MERGE_JOIN_NODE, 0, vec![0]);
     let err = translate_fragment(&params(
         Some(TPlan::new(vec![join])),
         Some(base_desc()),
@@ -1155,7 +1155,7 @@ fn unsupported_hash_join_is_structured_error() {
             node_id: 9,
             node_type,
             ..
-        } if node_type == TPlanNodeType::HASH_JOIN_NODE
+        } if node_type == TPlanNodeType::MERGE_JOIN_NODE
     ));
 }
 
@@ -2247,6 +2247,153 @@ fn sort_with_limit_becomes_project_sort_fetch() {
     };
 }
 
+/// Two-table descriptor for join tests: tuple 0 = users(`a`), tuple 1 = orders(`b`).
+fn join_desc() -> TDescriptorTable {
+    desc_table(
+        vec![(0, Some(100)), (1, Some(100))],
+        vec![
+            slot(1, 0, 0, "a", scalar_type(TPrimitiveType::BIGINT)),
+            slot(1, 1, 0, "b", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    )
+}
+
+/// Builds a hash-join plan node with one `left = right` equality conjunct.
+fn hash_join_node(join_op: TJoinOp) -> TPlanNode {
+    let mut join = base_plan_node(2, TPlanNodeType::HASH_JOIN_NODE, 2, vec![0, 1]);
+    join.hash_join_node = Some(THashJoinNode::new(
+        join_op,
+        vec![TEqJoinCondition::new(
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+            Some(TExprOpcode::EQ),
+        )],
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    ));
+    join
+}
+
+/// Extracts the field index from a direct struct-field reference.
+fn field_index(expr: &substrait::proto::Expression) -> i32 {
+    let expression::RexType::Selection(selection) = expr.rex_type.as_ref().unwrap() else {
+        panic!("expected field reference");
+    };
+    let expression::field_reference::ReferenceType::DirectReference(segment) =
+        selection.reference_type.as_ref().unwrap()
+    else {
+        panic!("expected direct reference");
+    };
+    let expression::reference_segment::ReferenceType::StructField(field) =
+        segment.reference_type.as_ref().unwrap()
+    else {
+        panic!("expected struct field");
+    };
+    field.field
+}
+
+/// Verifies an inner hash join becomes a Substrait join whose equality condition references the
+/// concatenated left-then-right row (right side offset by the left width).
+#[test]
+fn inner_hash_join_translates_to_join_rel() {
+    let plan = TPlan::new(vec![
+        hash_join_node(TJoinOp::INNER_JOIN),
+        scan_node(0, 0),
+        scan_node(1, 1),
+    ]);
+    let translated = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["a", "b"]);
+    let rel::RelType::Join(join) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected join relation");
+    };
+    assert_eq!(
+        join.r#type,
+        substrait::proto::join_rel::JoinType::Inner as i32
+    );
+    let expression::RexType::ScalarFunction(equal) =
+        join.expression.as_ref().unwrap().rex_type.as_ref().unwrap()
+    else {
+        panic!("expected scalar function join condition");
+    };
+    let args: Vec<_> = equal
+        .arguments
+        .iter()
+        .map(|argument| match argument.arg_type.as_ref().unwrap() {
+            substrait::proto::function_argument::ArgType::Value(value) => field_index(value),
+            other => panic!("unexpected argument {other:?}"),
+        })
+        .collect();
+    assert_eq!(args, vec![0, 1]);
+}
+
+/// Verifies a left semi join keeps only the probe-side row layout.
+#[test]
+fn left_semi_join_keeps_probe_layout() {
+    let plan = TPlan::new(vec![
+        hash_join_node(TJoinOp::LEFT_SEMI_JOIN),
+        scan_node(0, 0),
+        scan_node(1, 1),
+    ]);
+    let translated = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["a"]);
+    let rel::RelType::Join(join) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected join relation");
+    };
+    assert_eq!(
+        join.r#type,
+        substrait::proto::join_rel::JoinType::LeftSemi as i32
+    );
+}
+
+/// Verifies a cross nested-loop join with a conjunct becomes filter-over-cross-product.
+#[test]
+fn nestloop_join_translates_to_filtered_cross_rel() {
+    let mut join = base_plan_node(2, TPlanNodeType::NESTLOOP_JOIN_NODE, 2, vec![0, 1]);
+    join.nestloop_join_node = Some(TNestLoopJoinNode::new(
+        Some(TJoinOp::CROSS_JOIN),
+        None,
+        Some(vec![binary_pred(
+            TExprOpcode::LT,
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+        )]),
+        None,
+        None,
+        None,
+    ));
+    let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
+    let translated = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["a", "b"]);
+    let rel::RelType::Filter(filter) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected filter over cross product");
+    };
+    let rel::RelType::Cross(_) = filter.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected cross product under filter");
+    };
+}
+
 /// Verifies an exchange node is still rejected: fragments are translated in isolation and
 /// multi-fragment plans are a later milestone.
 #[test]
@@ -2488,6 +2635,23 @@ fn aggregation_conjuncts_become_having_filter() {
     };
 }
 
+/// Verifies anti joins are rejected: the Substrait consumer has no left-anti conversion.
+#[test]
+fn anti_hash_join_is_rejected() {
+    for join_op in [TJoinOp::LEFT_ANTI_JOIN, TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN] {
+        let plan = TPlan::new(vec![
+            hash_join_node(join_op),
+            scan_node(0, 0),
+            scan_node(1, 1),
+        ]);
+        let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
+        assert!(
+            matches!(err, TranslateError::UnsupportedPlanNode { .. }),
+            "{join_op:?}: {err:?}"
+        );
+    }
+}
+
 /// Verifies decimal-typed arithmetic is rejected (it crashes the engine's GPU projection).
 #[test]
 fn decimal_arithmetic_is_rejected() {
@@ -2624,7 +2788,7 @@ fn sort_tuple_exprs_come_from_sort_info() {
 }
 
 /// Verifies GPU-executor guards: non-constant LIKE patterns, non-constant substring bounds,
-/// and ungrouped DISTINCT aggregates are rejected.
+/// bare cross joins, and ungrouped DISTINCT aggregates are rejected.
 #[test]
 fn gpu_unsupported_shapes_are_rejected() {
     // LIKE with a column pattern (not a literal).
@@ -2673,6 +2837,23 @@ fn gpu_unsupported_shapes_are_rejected() {
     .unwrap_err();
     assert!(
         matches!(err, TranslateError::UnsupportedExpression { .. }),
+        "{err:?}"
+    );
+
+    // Nested-loop join without conjuncts (bare cross product).
+    let mut join = base_plan_node(2, TPlanNodeType::NESTLOOP_JOIN_NODE, 2, vec![0, 1]);
+    join.nestloop_join_node = Some(TNestLoopJoinNode::new(
+        Some(TJoinOp::CROSS_JOIN),
+        None,
+        None,
+        None,
+        None,
+        None,
+    ));
+    let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
+    let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
+    assert!(
+        matches!(err, TranslateError::UnsupportedPlanNode { .. }),
         "{err:?}"
     );
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -2364,22 +2364,45 @@ fn left_semi_join_keeps_probe_layout() {
     );
 }
 
-/// Verifies a cross nested-loop join with a conjunct becomes filter-over-cross-product.
-#[test]
-fn nestloop_join_translates_to_filtered_cross_rel() {
+/// Builds a nested-loop join plan node carrying `conjuncts` as its join predicate.
+fn nestloop_join_node(join_op: TJoinOp, conjuncts: Vec<TExpr>) -> TPlanNode {
     let mut join = base_plan_node(2, TPlanNodeType::NESTLOOP_JOIN_NODE, 2, vec![0, 1]);
     join.nestloop_join_node = Some(TNestLoopJoinNode::new(
-        Some(TJoinOp::CROSS_JOIN),
+        Some(join_op),
         None,
-        Some(vec![binary_pred(
-            TExprOpcode::LT,
-            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
-            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
-        )]),
+        Some(conjuncts),
         None,
         None,
         None,
     ));
+    join
+}
+
+/// Builds `left OR right`.
+fn or_pred(left: TExpr, right: TExpr) -> TExpr {
+    let mut node = base_expr_node(
+        TExprNodeType::COMPOUND_PRED,
+        scalar_type(TPrimitiveType::BOOLEAN),
+        2,
+    );
+    node.opcode = Some(TExprOpcode::COMPOUND_OR);
+    let mut nodes = vec![node];
+    nodes.extend(left.nodes);
+    nodes.extend(right.nodes);
+    TExpr::new(nodes)
+}
+
+/// Verifies a cross nested-loop join with a conjunct becomes filter-over-cross-product.
+#[test]
+fn nestloop_join_translates_to_filtered_cross_rel() {
+    let join = nestloop_join_node(
+        TJoinOp::CROSS_JOIN,
+        vec![binary_pred(
+            TExprOpcode::LT,
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+        )],
+    );
     let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
     let translated = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap();
 
@@ -2392,6 +2415,45 @@ fn nestloop_join_translates_to_filtered_cross_rel() {
     let rel::RelType::Cross(_) = filter.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
         panic!("expected cross product under filter");
     };
+}
+
+/// Verifies a nested-loop join is rejected unless a conjunct survives as a join condition.
+///
+/// A predicate reading one input is pushed into that input and leaves a bare cross product; a
+/// disjunction reading both is demoted to an any-join. The GPU planner has neither operator, so
+/// either shape would translate here and then fail at execution.
+#[test]
+fn nestloop_join_without_a_liftable_comparison_is_rejected() {
+    let bigint = || scalar_type(TPrimitiveType::BIGINT);
+    let probe_side_only = binary_pred(TExprOpcode::LT, slot_ref(1, 0, bigint()), int_literal(10));
+    let disjunction = or_pred(
+        binary_pred(
+            TExprOpcode::LT,
+            slot_ref(1, 0, bigint()),
+            slot_ref(1, 1, bigint()),
+        ),
+        binary_pred(
+            TExprOpcode::GT,
+            slot_ref(1, 0, bigint()),
+            slot_ref(1, 1, bigint()),
+        ),
+    );
+
+    for conjunct in [probe_side_only, disjunction] {
+        let plan = TPlan::new(vec![
+            nestloop_join_node(TJoinOp::CROSS_JOIN, vec![conjunct]),
+            scan_node(0, 0),
+            scan_node(1, 1),
+        ]);
+        let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
+        let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
+            panic!("expected an unsupported plan node, got {err:?}");
+        };
+        assert_eq!(
+            reason,
+            "nested-loop joins need a comparison between the two inputs"
+        );
+    }
 }
 
 /// Verifies an exchange node is still rejected: fragments are translated in isolation and


### PR DESCRIPTION
Translate `HASH_JOIN_NODE` (inner/outer/left-semi; conditions evaluated over the concatenated probe-then-build row) and `NESTLOOP_JOIN_NODE` (cross product + filter, inner/cross only). Node conjuncts become post-join filters; semi joins keep the probe-side layout.

Rejected: anti joins (DuckDB's Substrait consumer has no left-anti conversion), null-safe equality conjuncts, and conjunct-free cross products (no GPU cross-product operator).

With the full stack, single-fragment plans (scan/filter/project/aggregate/sort/join) translate and execute on the GPU. Every TPC-H query still splits at a gather exchange, so TPC-H proper waits for multi-fragment execution.



## Stack

All based on `dev`, so each diff includes the levels below it until they merge (review commits, or the last commit, for the per-level change):

1. #1106
2. #1107
3. #1108
4. #1109
5. #1110
6. #1111 ⬅️ this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
