### PR TITLE
telemetry: surface per-transition task attributes for the quent timeline tooltip

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "serde",
  "thiserror",
@@ -1771,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "serde",
  "serde_json",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "quent-collector-client",
  "quent-collector-proto",
@@ -1807,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "ciborium",
  "http",
@@ -1826,7 +1826,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "prost",
  "tonic",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "quent-attributes",
  "quent-time",
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "http",
  "quent-events",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "async-trait",
  "http",
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-postcard"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "async-trait",
  "postcard",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-types"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "quent-attributes",
  "quent-build-info",
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "ciborium",
  "quent-attributes",
@@ -1969,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "quent-attributes",
  "quent-model",
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "axum",
  "mime_guess",
@@ -2040,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -2055,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -2066,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "quent-model",
  "serde",
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "serde",
  "thiserror",
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1758,7 +1758,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "serde",
  "thiserror",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "serde",
  "serde_json",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1807,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "quent-collector-client",
  "quent-collector-proto",
@@ -1821,7 +1821,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "bitcode",
  "http",
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "prost",
  "tonic",
@@ -1851,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "quent-time",
  "serde",
@@ -1861,7 +1861,7 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "quent-attributes",
  "quent-build-info",
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "quent-io"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "async-trait",
  "http",
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "quent-io-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "async-trait",
  "http",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "quent-io-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "quent-io-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1938,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "quent-io-postcard"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "async-trait",
  "postcard",
@@ -1953,7 +1953,7 @@ dependencies = [
 [[package]]
 name = "quent-io-types"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "quent-attributes",
  "quent-build-info",
@@ -1983,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1994,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "quent-model",
  "serde",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "axum",
  "mime_guess",
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -2067,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "quent-model",
  "uuid",
@@ -2087,7 +2087,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "serde",
  "thiserror",
@@ -2097,7 +2097,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+source = "git+https://github.com/rapidsai/quent.git?rev=5ec56ccb4163810ad42aa0a57559f4d20ddc3aee#5ec56ccb4163810ad42aa0a57559f4d20ddc3aee"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "serde",
  "thiserror",
@@ -1771,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "serde",
  "serde_json",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "quent-collector-client",
  "quent-collector-proto",
@@ -1807,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "ciborium",
  "http",
@@ -1826,7 +1826,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "prost",
  "tonic",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "quent-attributes",
  "quent-time",
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "http",
  "quent-events",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "async-trait",
  "http",
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-postcard"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "async-trait",
  "postcard",
@@ -1923,18 +1923,17 @@ dependencies = [
 [[package]]
 name = "quent-exporter-types"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "async-trait",
  "quent-events",
- "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "quent-attributes",
  "quent-build-info",
@@ -1951,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "ciborium",
  "quent-attributes",
@@ -1970,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1981,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1998,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "quent-attributes",
  "quent-model",
@@ -2009,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "axum",
  "mime_guess",
@@ -2041,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -2056,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -2067,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "quent-model",
  "serde",
@@ -2077,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "serde",
  "thiserror",
@@ -2087,9 +2086,10 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=1e82188c7af631bb334cca6b0c31bbc3a4faef7e#1e82188c7af631bb334cca6b0c31bbc3a4faef7e"
+source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
 dependencies = [
  "quent-analyzer",
+ "quent-attributes",
  "quent-time",
  "serde",
  "ts-rs",
@@ -2849,13 +2849,14 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.11"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "bitflags",
  "bytes",
  "http",
+ "percent-encoding",
  "pin-project-lite",
  "tower-layer",
  "tower-service",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "serde",
  "thiserror",
@@ -1771,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "serde",
  "serde_json",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "quent-collector-client",
  "quent-collector-proto",
@@ -1807,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "ciborium",
  "http",
@@ -1826,7 +1826,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "prost",
  "tonic",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "quent-attributes",
  "quent-time",
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "http",
  "quent-events",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "async-trait",
  "http",
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-postcard"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "async-trait",
  "postcard",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-types"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "quent-attributes",
  "quent-build-info",
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "ciborium",
  "quent-attributes",
@@ -1969,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "quent-attributes",
  "quent-model",
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "axum",
  "mime_guess",
@@ -2040,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -2055,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -2066,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "quent-model",
  "serde",
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "serde",
  "thiserror",
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -2488,6 +2488,7 @@ version = "0.1.0"
 dependencies = [
  "instrumentation-model",
  "quent-analyzer",
+ "quent-attributes",
  "quent-events",
  "quent-model",
  "quent-query-engine-analyzer",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "serde",
  "thiserror",
@@ -1771,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "serde",
  "serde_json",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "quent-collector-client",
  "quent-collector-proto",
@@ -1807,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "ciborium",
  "http",
@@ -1826,7 +1826,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "prost",
  "tonic",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "quent-attributes",
  "quent-time",
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "http",
  "quent-events",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "async-trait",
  "http",
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-postcard"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "async-trait",
  "postcard",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-types"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "quent-attributes",
  "quent-build-info",
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "ciborium",
  "quent-attributes",
@@ -1969,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "quent-attributes",
  "quent-model",
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "axum",
  "mime_guess",
@@ -2040,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -2055,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -2066,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "quent-model",
  "serde",
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "serde",
  "thiserror",
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=a92ef60dd63dc6ee8beaec8be116aab423d729ff#a92ef60dd63dc6ee8beaec8be116aab423d729ff"
+source = "git+https://github.com/felipeblazing/quent.git?rev=8025e4a8d1fa738e59d7646f53c73803366c418f#8025e4a8d1fa738e59d7646f53c73803366c418f"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "serde",
  "thiserror",
@@ -1771,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "serde",
  "serde_json",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "quent-collector-client",
  "quent-collector-proto",
@@ -1807,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "ciborium",
  "http",
@@ -1826,7 +1826,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "prost",
  "tonic",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "quent-attributes",
  "quent-time",
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "http",
  "quent-events",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "async-trait",
  "http",
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-postcard"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "async-trait",
  "postcard",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-types"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "quent-attributes",
  "quent-build-info",
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "ciborium",
  "quent-attributes",
@@ -1969,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "quent-attributes",
  "quent-model",
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "axum",
  "mime_guess",
@@ -2040,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -2055,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -2066,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "quent-model",
  "serde",
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "serde",
  "thiserror",
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=0469a5b1b9eba30d53672cba7b55b5a0086e0130#0469a5b1b9eba30d53672cba7b55b5a0086e0130"
+source = "git+https://github.com/felipeblazing/quent.git?rev=1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05#1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "serde",
  "thiserror",
@@ -1771,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "serde",
  "serde_json",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "quent-collector-client",
  "quent-collector-proto",
@@ -1807,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "ciborium",
  "http",
@@ -1826,7 +1826,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "prost",
  "tonic",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "quent-attributes",
  "quent-time",
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "http",
  "quent-events",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "async-trait",
  "http",
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-postcard"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "async-trait",
  "postcard",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-types"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "quent-attributes",
  "quent-build-info",
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "ciborium",
  "quent-attributes",
@@ -1969,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "quent-attributes",
  "quent-model",
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "axum",
  "mime_guess",
@@ -2040,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -2055,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -2066,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "quent-model",
  "serde",
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "serde",
  "thiserror",
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=1ec1c1418d324d3587f948374abf9435033ec65f#1ec1c1418d324d3587f948374abf9435033ec65f"
+source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -127,6 +127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "arrow-array"
 version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +314,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitcode"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6ed1b54d8dc333e7be604d00fa9262f4635485ffea923647b6521a5fff045d"
+dependencies = [
+ "arrayvec",
+ "bitcode_derive",
+ "bytemuck",
+ "glam",
+ "serde",
+]
+
+[[package]]
+name = "bitcode_derive"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238b90427dfad9da4a9abd60f3ec1cdee6b80454bde49ed37f1781dd8e9dc7f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +380,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,33 +424,6 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
 ]
 
 [[package]]
@@ -514,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -907,6 +916,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glam"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
 
 [[package]]
 name = "h2"
@@ -1743,11 +1758,10 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "quent-attributes",
  "quent-events",
- "quent-exporter-types",
  "quent-model",
  "quent-time",
  "rustc-hash",
@@ -1761,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "serde",
  "thiserror",
@@ -1771,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "serde",
  "serde_json",
@@ -1780,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1793,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "quent-collector-client",
  "quent-collector-proto",
@@ -1807,9 +1821,9 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
- "ciborium",
+ "bitcode",
  "http",
  "quent-collector-proto",
  "quent-events",
@@ -1826,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "prost",
  "tonic",
@@ -1837,52 +1851,68 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
- "quent-attributes",
  "quent-time",
  "serde",
  "uuid",
 ]
 
 [[package]]
-name = "quent-exporter"
+name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
+ "quent-attributes",
+ "quent-build-info",
+ "quent-events",
+ "quent-io",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "quent-io"
+version = "0.1.0"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
+dependencies = [
+ "async-trait",
  "http",
  "quent-events",
- "quent-exporter-collector",
- "quent-exporter-msgpack",
- "quent-exporter-ndjson",
- "quent-exporter-postcard",
- "quent-exporter-types",
+ "quent-io-collector",
+ "quent-io-msgpack",
+ "quent-io-ndjson",
+ "quent-io-postcard",
+ "quent-io-types",
  "serde",
  "uuid",
 ]
 
 [[package]]
-name = "quent-exporter-collector"
+name = "quent-io-collector"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "async-trait",
  "http",
  "quent-collector-client",
  "quent-events",
- "quent-exporter-types",
+ "quent-io-types",
  "serde",
  "uuid",
 ]
 
 [[package]]
-name = "quent-exporter-msgpack"
+name = "quent-io-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "async-trait",
  "quent-events",
- "quent-exporter-types",
+ "quent-io-types",
  "rmp-serde",
  "serde",
  "tokio",
@@ -1891,13 +1921,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "quent-exporter-ndjson"
+name = "quent-io-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "async-trait",
  "quent-events",
- "quent-exporter-types",
+ "quent-io-types",
  "serde",
  "serde_json",
  "tokio",
@@ -1906,14 +1936,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "quent-exporter-postcard"
+name = "quent-io-postcard"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "async-trait",
  "postcard",
  "quent-events",
- "quent-exporter-types",
+ "quent-io-types",
  "serde",
  "tokio",
  "tracing",
@@ -1921,28 +1951,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "quent-exporter-types"
+name = "quent-io-types"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "async-trait",
  "quent-events",
  "thiserror",
-]
-
-[[package]]
-name = "quent-instrumentation"
-version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
-dependencies = [
- "quent-attributes",
- "quent-build-info",
- "quent-events",
- "quent-exporter",
- "quent-exporter-types",
- "serde",
- "tokio",
- "tokio-util",
  "tracing",
  "uuid",
 ]
@@ -1950,15 +1965,14 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
- "ciborium",
  "quent-attributes",
  "quent-build-info",
  "quent-collector-client",
  "quent-events",
- "quent-exporter",
  "quent-instrumentation",
+ "quent-io",
  "quent-model-macros",
  "quent-time",
  "serde",
@@ -1969,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1980,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1997,9 +2011,8 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
- "quent-attributes",
  "quent-model",
  "serde",
  "uuid",
@@ -2008,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "axum",
  "mime_guess",
@@ -2017,8 +2030,7 @@ dependencies = [
  "quent-collector",
  "quent-collector-proto",
  "quent-events",
- "quent-exporter",
- "quent-exporter-types",
+ "quent-io",
  "quent-query-engine-analyzer",
  "quent-query-engine-model",
  "quent-query-engine-ui",
@@ -2040,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -2055,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -2066,17 +2078,16 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "quent-model",
- "serde",
  "uuid",
 ]
 
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "serde",
  "thiserror",
@@ -2086,7 +2097,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/felipeblazing/quent.git?rev=246b92f86f946a404fb091b831c746c7a41e8a0b#246b92f86f946a404fb091b831c746c7a41e8a0b"
+source = "git+https://github.com/felipeblazing/quent.git?rev=f2ab99748eb3e6995b0882c525a78a43d10b5dab#f2ab99748eb3e6995b0882c525a78a43d10b5dab"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -2510,7 +2521,7 @@ dependencies = [
  "clap",
  "instrumentation-model",
  "quent-collector",
- "quent-exporter",
+ "quent-io",
  "quent-query-engine-server",
  "quent-query-engine-ui",
  "quent-simulator-ui",

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -7,16 +7,16 @@ edition.workspace = true
 instrumentation-model = { path = "../model" }
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -7,15 +7,15 @@ edition.workspace = true
 instrumentation-model = { path = "../model" }
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -7,16 +7,16 @@ edition.workspace = true
 instrumentation-model = { path = "../model" }
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -5,18 +5,16 @@ edition.workspace = true
 
 [dependencies]
 instrumentation-model = { path = "../model" }
-# TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
-# tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -7,15 +7,16 @@ edition.workspace = true
 instrumentation-model = { path = "../model" }
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -5,16 +5,17 @@ edition.workspace = true
 
 [dependencies]
 instrumentation-model = { path = "../model" }
-# Tracks a pinned commit from quent's main branch.
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
+# TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
+# tracks the PR branch on the felipeblazing fork (per-transition attributes).
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -7,16 +7,16 @@ edition.workspace = true
 instrumentation-model = { path = "../model" }
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -7,16 +7,16 @@ edition.workspace = true
 instrumentation-model = { path = "../model" }
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-events = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-query-engine-analyzer = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-time = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/src/data_batch.rs
+++ b/rust/crates/telemetry/analyzer/src/data_batch.rs
@@ -68,6 +68,8 @@ impl DataBatchExt for DataBatch {
                         })
                         .collect(),
                     timestamp: to_secs_relative(transition.timestamp(), epoch),
+                    attributes: transition.attributes(),
+                    derived_attributes: vec![],
                 })
             })
             .collect::<AnalyzerResult<Vec<_>>>()?;

--- a/rust/crates/telemetry/analyzer/src/lib.rs
+++ b/rust/crates/telemetry/analyzer/src/lib.rs
@@ -992,7 +992,11 @@ impl SiriusUiAnalyzer {
             .iter()
             .filter_map(|&id| {
                 if let Some(task) = self.model.tasks.get(&id) {
-                    Some(task.try_to_ui_fsm(epoch))
+                    let pipeline_name = task
+                        .pipeline_uuid()
+                        .and_then(|id| self.model.query_engine.operators.get(&id))
+                        .map(|operator| operator.instance_name());
+                    Some(task.try_to_ui_fsm(epoch, pipeline_name))
                 } else {
                     self.model
                         .data_batches

--- a/rust/crates/telemetry/analyzer/src/lib.rs
+++ b/rust/crates/telemetry/analyzer/src/lib.rs
@@ -1,6 +1,7 @@
 use instrumentation_model::{Sirius, SiriusEvent};
 use quent_events::Event;
 pub use quent_query_engine_analyzer::QueryEngineModel;
+use quent_query_engine_analyzer::entities;
 use quent_query_engine_analyzer::ui::{QuentViewer, UiAnalyzer, ViewerEventStream};
 use quent_query_engine_ui::{OperatorFilter, QueryBundle, QueryEntities, QueryFilter};
 use quent_ui::{
@@ -62,7 +63,7 @@ impl QuentViewer for Viewer {
 
     fn import_events(
         dir: &std::path::Path,
-    ) -> quent_model::exporter::ImporterResult<ViewerEventStream<Self::Analyzer>> {
+    ) -> quent_model::io::ImporterResult<ViewerEventStream<Self::Analyzer>> {
         Sirius::import_events(dir)
     }
 }
@@ -262,6 +263,51 @@ impl UiAnalyzer for SiriusUiAnalyzer {
 
     fn query_engine_model(&self) -> &impl QueryEngineModel {
         &self.model
+    }
+
+    fn list_entities(
+        &self,
+        request: quent_ui::entities::request::EntityListRequest<QueryFilter, OperatorFilter>,
+    ) -> AnalyzerResult<quent_ui::entities::response::EntityListResponse> {
+        let query_id = request.app_params.query_id;
+        let epoch = self.query_engine_model().query_epoch(query_id)?;
+        let entry = request.entry;
+        let window = entry.window.try_into_span(epoch)?;
+        let scope = entry
+            .filter
+            .scope
+            .as_ref()
+            .map(|s| s.resolve(&self.model))
+            .transpose()?;
+        let operator_filter = entry.application;
+
+        // Restrict candidates to the requested query: a task belongs to a query
+        // iff its operator is one of that query's operators. Without this, tasks
+        // from a different query sharing a resource and overlapping the window
+        // would leak in.
+        let query_operators: HashSet<Uuid> = self
+            .model
+            .query_view(query_id)?
+            .operators()
+            .map(|op| op.id())
+            .collect();
+
+        entities::list_entities(
+            &self.model,
+            |task| {
+                task.pipeline_uuid()
+                    .is_some_and(|op| query_operators.contains(&op))
+                    && task.matches_filter(&operator_filter)
+            },
+            entities::ListQuery {
+                scope: scope.as_ref(),
+                window,
+                filter: &entry.filter,
+                sort: entry.sort,
+                page: entry.page,
+                epoch,
+            },
+        )
     }
 
     // TODO(johanpel): consider reusing the bulk request API with a single entry for requests like this.

--- a/rust/crates/telemetry/analyzer/src/lib.rs
+++ b/rust/crates/telemetry/analyzer/src/lib.rs
@@ -26,7 +26,7 @@ use tracing::debug;
 
 use quent_analyzer::{
     AnalyzerError, AnalyzerResult, Entity, Model, Span,
-    fsm::{FsmTypeDeclaration, FsmUsages},
+    fsm::{FsmTypeDeclaration, FsmUsages, collection::FsmCollection},
     resource::{
         ResourceGroup, ResourceTypeDecl, Usage, Using, collection::ResourceCollection,
         tree::ResourceTreeNode,
@@ -87,6 +87,30 @@ struct PerStateBuilderSlot<'a> {
     resource_id_filter: Arc<HashSet<Uuid>>,
     op_filter: OperatorFilter,
     entity_type_name: String,
+}
+
+/// Adapts the model's task map to the [`FsmCollection`] contract that
+/// [`entities::list_entities`] ranks and pages over.
+struct TaskCollection<'a>(&'a HashMap<Uuid, Task>);
+
+impl FsmCollection for TaskCollection<'_> {
+    type Fsm = Task;
+
+    fn fsms(&self) -> impl Iterator<Item = &Task> {
+        self.0.values()
+    }
+}
+
+/// Adapts the model's data-batch map to the [`FsmCollection`] contract that
+/// [`entities::list_entities`] ranks and pages over.
+struct DataBatchCollection<'a>(&'a HashMap<Uuid, DataBatch>);
+
+impl FsmCollection for DataBatchCollection<'_> {
+    type Fsm = DataBatch;
+
+    fn fsms(&self) -> impl Iterator<Item = &DataBatch> {
+        self.0.values()
+    }
 }
 
 impl UiAnalyzer for SiriusUiAnalyzer {
@@ -281,10 +305,10 @@ impl UiAnalyzer for SiriusUiAnalyzer {
             .transpose()?;
         let operator_filter = entry.application;
 
-        // Restrict candidates to the requested query: a task belongs to a query
-        // iff its operator is one of that query's operators. Without this, tasks
-        // from a different query sharing a resource and overlapping the window
-        // would leak in.
+        // Restrict candidates to the requested query: an entity belongs to a
+        // query iff its (producer) pipeline is one of that query's operators.
+        // Without this, entities from a different query sharing a resource and
+        // overlapping the window would leak in.
         let query_operators: HashSet<Uuid> = self
             .model
             .query_view(query_id)?
@@ -292,22 +316,39 @@ impl UiAnalyzer for SiriusUiAnalyzer {
             .map(|op| op.id())
             .collect();
 
-        entities::list_entities(
-            &self.model,
-            |task| {
-                task.pipeline_uuid()
-                    .is_some_and(|op| query_operators.contains(&op))
-                    && task.matches_filter(&operator_filter)
-            },
-            entities::ListQuery {
-                scope: scope.as_ref(),
-                window,
-                filter: &entry.filter,
-                sort: entry.sort,
-                page: entry.page,
-                epoch,
-            },
-        )
+        let query = entities::ListQuery {
+            scope: scope.as_ref(),
+            window,
+            filter: &entry.filter,
+            sort: entry.sort,
+            page: entry.page,
+            epoch,
+        };
+
+        // The model holds two distinct FSM types (tasks and data batches), so
+        // dispatch on the requested entity type rather than a single collection.
+        // Absent an explicit type, default to tasks.
+        match entry.filter.entity_type_name.as_deref() {
+            Some(DATA_BATCH_TYPE_NAME) => entities::list_entities(
+                &DataBatchCollection(&self.model.data_batches),
+                |data_batch| {
+                    data_batch
+                        .producer_pipeline_uuid()
+                        .is_some_and(|op| query_operators.contains(&op))
+                        && data_batch.matches_filter(&operator_filter)
+                },
+                query,
+            ),
+            _ => entities::list_entities(
+                &TaskCollection(&self.model.tasks),
+                |task| {
+                    task.pipeline_uuid()
+                        .is_some_and(|op| query_operators.contains(&op))
+                        && task.matches_filter(&operator_filter)
+                },
+                query,
+            ),
+        }
     }
 
     // TODO(johanpel): consider reusing the bulk request API with a single entry for requests like this.

--- a/rust/crates/telemetry/analyzer/src/task.rs
+++ b/rust/crates/telemetry/analyzer/src/task.rs
@@ -16,9 +16,9 @@ use quent_analyzer::{
     },
 };
 use quent_attributes::Attribute;
+use quent_query_engine_ui::OperatorFilter;
 use quent_time::{TimeUnixNanoSec, Timestamp, span::SpanUnixNanoSec, to_secs_relative};
 use quent_ui::{FiniteStateMachine, FsmTransition, FsmUsage};
-use quent_query_engine_ui::OperatorFilter;
 use uuid::Uuid;
 
 /// The reconstructed Task FSM.
@@ -85,8 +85,7 @@ impl TaskExt for Task {
                 if let ModelTaskTransition::Computing(data) = &transition.data
                     && let Some(next) = raw.get(i + 1)
                 {
-                    let span_secs =
-                        (next.timestamp() - transition.timestamp()) as f64 / 1e9;
+                    let span_secs = (next.timestamp() - transition.timestamp()) as f64 / 1e9;
                     if span_secs > 0.0 {
                         derived_attributes.push(Attribute::f64(
                             "bytes_per_sec",

--- a/rust/crates/telemetry/analyzer/src/task.rs
+++ b/rust/crates/telemetry/analyzer/src/task.rs
@@ -85,6 +85,7 @@ impl TaskExt for Task {
                         })
                         .collect(),
                     timestamp: to_secs_relative(transition.timestamp(), epoch),
+                    attributes: transition.attributes.clone(),
                 })
             })
             .collect::<AnalyzerResult<Vec<_>>>()?;

--- a/rust/crates/telemetry/analyzer/src/task.rs
+++ b/rust/crates/telemetry/analyzer/src/task.rs
@@ -15,6 +15,7 @@ use quent_analyzer::{
         events::{FsmEvents, FsmEventsBuilder},
     },
 };
+use quent_attributes::Attribute;
 use quent_time::{TimeUnixNanoSec, Timestamp, span::SpanUnixNanoSec, to_secs_relative};
 use quent_ui::{FiniteStateMachine, FsmTransition, FsmUsage};
 use quent_query_engine_ui::OperatorFilter;
@@ -32,7 +33,11 @@ pub trait TaskExt {
     fn executes_physical_operation(&self, physical_operator_id: u32) -> bool;
     fn matches_filter(&self, filter: &OperatorFilter) -> bool;
     fn active_span(&self) -> Option<SpanUnixNanoSec>;
-    fn try_to_ui_fsm(&self, epoch: TimeUnixNanoSec) -> AnalyzerResult<FiniteStateMachine>;
+    fn try_to_ui_fsm(
+        &self,
+        epoch: TimeUnixNanoSec,
+        pipeline_name: Option<&str>,
+    ) -> AnalyzerResult<FiniteStateMachine>;
 }
 
 impl TaskExt for Task {
@@ -65,18 +70,39 @@ impl TaskExt for Task {
         SpanUnixNanoSec::try_new(start, end).ok()
     }
 
-    fn try_to_ui_fsm(&self, epoch: TimeUnixNanoSec) -> AnalyzerResult<FiniteStateMachine> {
-        let transitions = self
-            .transitions()
+    fn try_to_ui_fsm(
+        &self,
+        epoch: TimeUnixNanoSec,
+        pipeline_name: Option<&str>,
+    ) -> AnalyzerResult<FiniteStateMachine> {
+        let raw = self.transitions();
+        let transitions = raw
             .iter()
-            .map(|transition| {
-                // Task-specific semantics live here: a Computing state's
-                // input_bytes is the quantity processed over the span, which
-                // lets the UI display a processing rate generically.
-                let processed_bytes = match &transition.data {
-                    ModelTaskTransition::Computing(data) => Some(data.input_bytes),
-                    _ => None,
-                };
+            .enumerate()
+            .map(|(i, transition)| {
+                let mut attributes = transition.attributes.clone();
+                // Task-specific semantics live here, emitted as plain
+                // attributes for the UI to render verbatim: a Computing
+                // state's input_bytes is the quantity processed over the
+                // span, so the processing rate can be derived from it.
+                if let ModelTaskTransition::Computing(data) = &transition.data
+                    && let Some(next) = raw.get(i + 1)
+                {
+                    let span_secs =
+                        (next.timestamp() - transition.timestamp()) as f64 / 1e9;
+                    if span_secs > 0.0 {
+                        attributes.push(Attribute::f64(
+                            "bytes_per_sec",
+                            data.input_bytes as f64 / span_secs,
+                        ));
+                    }
+                }
+                // The resolved pipeline chain rides along on every state so
+                // it shows on whichever span is hovered (created, which
+                // carries pipeline_uuid, is filtered off resource lanes).
+                if let Some(name) = pipeline_name {
+                    attributes.push(Attribute::string("pipeline", name));
+                }
                 Ok(FsmTransition {
                     name: transition.name().to_string(),
                     usages: transition
@@ -92,8 +118,7 @@ impl TaskExt for Task {
                         })
                         .collect(),
                     timestamp: to_secs_relative(transition.timestamp(), epoch),
-                    attributes: transition.attributes.clone(),
-                    processed_bytes,
+                    attributes,
                 })
             })
             .collect::<AnalyzerResult<Vec<_>>>()?;
@@ -102,9 +127,6 @@ impl TaskExt for Task {
             id: self.id(),
             type_name: self.type_name().to_string(),
             instance_name: self.instance_name().to_string(),
-            // The pipeline the task executes is an Operator entity; linking it
-            // here lets the UI resolve and render the fused chain generically.
-            operator_id: self.pipeline_uuid(),
             transitions,
         })
     }

--- a/rust/crates/telemetry/analyzer/src/task.rs
+++ b/rust/crates/telemetry/analyzer/src/task.rs
@@ -80,18 +80,18 @@ impl TaskExt for Task {
             .iter()
             .enumerate()
             .map(|(i, transition)| {
-                let mut attributes = transition.attributes.clone();
-                // Task-specific semantics live here, emitted as plain
+                // Task-specific semantics live here, emitted as derived
                 // attributes for the UI to render verbatim: a Computing
                 // state's input_bytes is the quantity processed over the
                 // span, so the processing rate can be derived from it.
+                let mut derived_attributes = vec![];
                 if let ModelTaskTransition::Computing(data) = &transition.data
                     && let Some(next) = raw.get(i + 1)
                 {
                     let span_secs =
                         (next.timestamp() - transition.timestamp()) as f64 / 1e9;
                     if span_secs > 0.0 {
-                        attributes.push(Attribute::f64(
+                        derived_attributes.push(Attribute::f64(
                             "bytes_per_sec",
                             data.input_bytes as f64 / span_secs,
                         ));
@@ -101,7 +101,7 @@ impl TaskExt for Task {
                 // it shows on whichever span is hovered (created, which
                 // carries pipeline_uuid, is filtered off resource lanes).
                 if let Some(name) = pipeline_name {
-                    attributes.push(Attribute::string("pipeline", name));
+                    derived_attributes.push(Attribute::string("pipeline", name));
                 }
                 Ok(FsmTransition {
                     name: transition.name().to_string(),
@@ -118,7 +118,11 @@ impl TaskExt for Task {
                         })
                         .collect(),
                     timestamp: to_secs_relative(transition.timestamp(), epoch),
-                    attributes,
+                    // The statically typed -> dynamically typed attribute
+                    // conversion happens only here, after long-entity
+                    // filtering — never for FSMs that won't be displayed.
+                    attributes: transition.attributes(),
+                    derived_attributes,
                 })
             })
             .collect::<AnalyzerResult<Vec<_>>>()?;

--- a/rust/crates/telemetry/analyzer/src/task.rs
+++ b/rust/crates/telemetry/analyzer/src/task.rs
@@ -80,10 +80,7 @@ impl TaskExt for Task {
             .iter()
             .enumerate()
             .map(|(i, transition)| {
-                // Task-specific semantics live here, emitted as derived
-                // attributes for the UI to render verbatim: a Computing
-                // state's input_bytes is the quantity processed over the
-                // span, so the processing rate can be derived from it.
+                // Derive the processing rate from input_bytes over the span.
                 let mut derived_attributes = vec![];
                 if let ModelTaskTransition::Computing(data) = &transition.data
                     && let Some(next) = raw.get(i + 1)
@@ -97,9 +94,8 @@ impl TaskExt for Task {
                         ));
                     }
                 }
-                // The resolved pipeline chain rides along on every state so
-                // it shows on whichever span is hovered (created, which
-                // carries pipeline_uuid, is filtered off resource lanes).
+                // Stamped on every transition — created, which carries
+                // pipeline_uuid, is filtered off resource lanes.
                 if let Some(name) = pipeline_name {
                     derived_attributes.push(Attribute::string("pipeline", name));
                 }
@@ -118,9 +114,6 @@ impl TaskExt for Task {
                         })
                         .collect(),
                     timestamp: to_secs_relative(transition.timestamp(), epoch),
-                    // The statically typed -> dynamically typed attribute
-                    // conversion happens only here, after long-entity
-                    // filtering — never for FSMs that won't be displayed.
                     attributes: transition.attributes(),
                     derived_attributes,
                 })

--- a/rust/crates/telemetry/analyzer/src/task.rs
+++ b/rust/crates/telemetry/analyzer/src/task.rs
@@ -70,6 +70,13 @@ impl TaskExt for Task {
             .transitions()
             .iter()
             .map(|transition| {
+                // Task-specific semantics live here: a Computing state's
+                // input_bytes is the quantity processed over the span, which
+                // lets the UI display a processing rate generically.
+                let processed_bytes = match &transition.data {
+                    ModelTaskTransition::Computing(data) => Some(data.input_bytes),
+                    _ => None,
+                };
                 Ok(FsmTransition {
                     name: transition.name().to_string(),
                     usages: transition
@@ -86,6 +93,7 @@ impl TaskExt for Task {
                         .collect(),
                     timestamp: to_secs_relative(transition.timestamp(), epoch),
                     attributes: transition.attributes.clone(),
+                    processed_bytes,
                 })
             })
             .collect::<AnalyzerResult<Vec<_>>>()?;
@@ -94,6 +102,9 @@ impl TaskExt for Task {
             id: self.id(),
             type_name: self.type_name().to_string(),
             instance_name: self.instance_name().to_string(),
+            // The pipeline the task executes is an Operator entity; linking it
+            // here lets the UI resolve and render the fused chain generically.
+            operator_id: self.pipeline_uuid(),
             transitions,
         })
     }

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -16,4 +16,4 @@ cxx-build = "1"
 instrumentation-model = { path = "../model" }
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -14,6 +14,4 @@ instrumentation-model = { path = "../model" }
 [build-dependencies]
 cxx-build = "1"
 instrumentation-model = { path = "../model" }
-# TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
-# tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -14,5 +14,6 @@ instrumentation-model = { path = "../model" }
 [build-dependencies]
 cxx-build = "1"
 instrumentation-model = { path = "../model" }
-# Tracks a pinned commit from quent's main branch.
-quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
+# TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
+# tracks the PR branch on the felipeblazing fork (per-transition attributes).
+quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -16,4 +16,4 @@ cxx-build = "1"
 instrumentation-model = { path = "../model" }
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -16,4 +16,4 @@ cxx-build = "1"
 instrumentation-model = { path = "../model" }
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -16,4 +16,4 @@ cxx-build = "1"
 instrumentation-model = { path = "../model" }
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -16,4 +16,4 @@ cxx-build = "1"
 instrumentation-model = { path = "../model" }
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -16,4 +16,4 @@ cxx-build = "1"
 instrumentation-model = { path = "../model" }
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-codegen = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -9,13 +9,13 @@ collector = ["quent-model/collector"]
 [dependencies]
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -9,13 +9,13 @@ collector = ["quent-model/collector"]
 [dependencies]
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -7,15 +7,13 @@ edition.workspace = true
 collector = ["quent-model/collector"]
 
 [dependencies]
-# TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
-# tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -9,13 +9,13 @@ collector = ["quent-model/collector"]
 [dependencies]
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -9,13 +9,13 @@ collector = ["quent-model/collector"]
 [dependencies]
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -9,13 +9,13 @@ collector = ["quent-model/collector"]
 [dependencies]
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -9,13 +9,13 @@ collector = ["quent-model/collector"]
 [dependencies]
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -7,14 +7,15 @@ edition.workspace = true
 collector = ["quent-model/collector"]
 
 [dependencies]
-# Tracks a pinned commit from quent's main branch.
-quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
+# TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
+# tracks the PR branch on the felipeblazing fork (per-transition attributes).
+quent-attributes = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-model = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-query-engine-model = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-stdlib = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
+quent-build-info = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,9 +12,9 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model", features = ["collector"] }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-exporter = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-io = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
@@ -22,7 +22,7 @@ uuid = "1"
 [build-dependencies]
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
 ts-rs = { version = "12", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,16 +12,17 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model", features = ["collector"] }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-exporter = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
+quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-exporter = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
 
 [build-dependencies]
-# Tracks a pinned commit from quent's main branch.
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "1e82188c7af631bb334cca6b0c31bbc3a4faef7e" }
+# TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
+# tracks the PR branch on the felipeblazing fork (per-transition attributes).
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
 ts-rs = { version = "12", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,9 +12,9 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model", features = ["collector"] }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-exporter = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-exporter = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
@@ -22,7 +22,7 @@ uuid = "1"
 [build-dependencies]
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
 ts-rs = { version = "12", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,17 +12,15 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model", features = ["collector"] }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-io = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-io = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
 
 [build-dependencies]
-# TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
-# tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "f2ab99748eb3e6995b0882c525a78a43d10b5dab" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "5ec56ccb4163810ad42aa0a57559f4d20ddc3aee" }
 ts-rs = { version = "12", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,9 +12,9 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model", features = ["collector"] }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-exporter = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-exporter = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
@@ -22,7 +22,7 @@ uuid = "1"
 [build-dependencies]
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1ec1c1418d324d3587f948374abf9435033ec65f" }
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "246b92f86f946a404fb091b831c746c7a41e8a0b" }
 ts-rs = { version = "12", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,9 +12,9 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model", features = ["collector"] }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-exporter = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-exporter = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
@@ -22,7 +22,7 @@ uuid = "1"
 [build-dependencies]
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "1b43e55d56ee886ba13a4290f44d6b1f5ec3aa05" }
 ts-rs = { version = "12", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,9 +12,9 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model", features = ["collector"] }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-exporter = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-exporter = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
@@ -22,7 +22,7 @@ uuid = "1"
 [build-dependencies]
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "0469a5b1b9eba30d53672cba7b55b5a0086e0130" }
 ts-rs = { version = "12", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,9 +12,9 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model", features = ["collector"] }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-exporter = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-collector = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-exporter = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-query-engine-server = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
@@ -22,7 +22,7 @@ uuid = "1"
 [build-dependencies]
 # TODO: flip back to rapidsai/quent once rapidsai/quent#323 merges — temporarily
 # tracks the PR branch on the felipeblazing fork (per-transition attributes).
-quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
-quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "a92ef60dd63dc6ee8beaec8be116aab423d729ff" }
+quent-simulator-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-query-engine-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
+quent-ui = { git = "https://github.com/felipeblazing/quent.git", rev = "8025e4a8d1fa738e59d7646f53c73803366c418f" }
 ts-rs = { version = "12", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/build.rs
+++ b/rust/crates/telemetry/server/build.rs
@@ -1,10 +1,10 @@
 use quent_query_engine_ui::QueryBundle;
+use quent_query_engine_ui::{OperatorFilter, QueryFilter};
+use quent_simulator_ui::EntityRef;
 use quent_ui::timeline::{
     request::{BulkTimelineRequest, SingleTimelineRequest},
     response::{BulkTimelinesResponse, SingleTimelineResponse},
 };
-use quent_query_engine_ui::{OperatorFilter, QueryFilter};
-use quent_simulator_ui::EntityRef;
 use ts_rs::{Config, TS};
 
 const TS_OUT_DIR: &str = "./ts-bindings/";

--- a/rust/crates/telemetry/server/src/main.rs
+++ b/rust/crates/telemetry/server/src/main.rs
@@ -2,7 +2,7 @@ use std::{net::ToSocketAddrs, path::PathBuf};
 
 use clap::Parser;
 use instrumentation_model::{Sirius, SiriusContext};
-use quent_exporter::{ExporterOptions, FileSystemExporterOptions, FileSystemFormat};
+use quent_io::{ExporterOptions, FileSystemExporterOptions, FileSystemFormat};
 use quent_query_engine_server::{
     analyzer_cache::index_query_engines, analyzer_service_router, collector_service,
     initialize_tracing,
@@ -77,10 +77,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     // Each context exports under `output_dir/<context-id>/<entity>/`, so the
     // collector writes per-entity streams beneath output_dir.
-    let exporter_kind = ExporterOptions::FileSystem(FileSystemExporterOptions {
-        format,
-        root: output_dir,
-    });
+    let exporter_kind =
+        ExporterOptions::FileSystem(FileSystemExporterOptions::new(format, output_dir));
 
     // The collector builds a fresh sink per incoming context, replaying each
     // remote source's events under that source's own context id.


### PR DESCRIPTION
## What

Companion to rapidsai/quent#323. Quent surfaces typed FSM state payloads as per-transition attributes and renders them **verbatim** — no task-specific conventions or semantic fields on the quent side. All task knowledge lives in this analyzer, which synthesizes derived values as plain attributes in `try_to_ui_fsm`:

- **`analyzer/src/task.rs`**:
  - `attributes: transition.attributes()` — the state's recorded attributes (`input_bytes`, `requested_bytes`, `target_tier`, `current_operator_id`, …), converted from the typed state **lazily, only here** — after long-entity filtering, so filtered-out tasks never pay for the conversion.
  - `derived_attributes` — values computed by this analyzer, rendered by quent under a "derived" subsection:
    - `bytes_per_sec` — on `Computing` spans, `input_bytes` over the span duration; quent's generic unit formatter renders it as e.g. `3.54 GB/s`.
    - `pipeline` — the fused operator chain (`GPU_SCAN(11) -> PROJECTION(6) -> …`), resolved from the task's `pipeline_uuid` at the call site (`lib.rs::task_entities_to_ui_fsm`) and stamped on every transition so it shows on whichever span is hovered.
- **`crates/telemetry/*/Cargo.toml` + `Cargo.lock`** — bump the pinned quent rev (and add `quent-attributes` for the `Attribute` constructors).

**No instrumentation, bridge, or emission changes** — the C++ side already emits everything. Existing telemetry dumps (verified with the TPC-H SF300 2-GPU dataset, both grouped and ungrouped) work as-is; only the read path changes.

## Status: draft — blocked on rapidsai/quent#323

The quent git deps temporarily point at the PR branch on the `felipeblazing/quent` fork so this is buildable and reviewable now. Before landing, flip the URLs back to `rapidsai/quent` with the merged rev (one `sed` across the four telemetry Cargo.tomls + `cargo update`).

## Testing

`cargo check -p sirius-telemetry-server -p sirius-telemetry-analyzer` clean against the new quent. Ran the telemetry server on the SF300 2-GPU dataset end-to-end: a computing span carries recorded `[current_operator_id, input_bytes]` and derived `[bytes_per_sec, pipeline]`, rendered with the split in the tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
