### PR TITLE
feat(pin_table): MVCC snapshot foundation for duckdb-native pins (#819 PR1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,6 +596,7 @@ set(TEST_SOURCES
     test/cpp/integration/test_pin_table_host_streaming.cpp
     test/cpp/integration/test_pin_table_merge_columns.cpp
     test/cpp/integration/test_pin_table_column_order.cpp
+    test/cpp/integration/test_pin_table_mvcc_foundation.cpp
     test/cpp/integration/test_table_gpu_cache_warm_mgpu.cpp
     test/cpp/io/s3/test_sigv4.cpp
     test/cpp/io/s3/test_s3_default_visibility_guard.cpp

--- a/src/include/pin_table.hpp
+++ b/src/include/pin_table.hpp
@@ -72,6 +72,7 @@ namespace sirius {
 
 namespace op::scan {
 class gpu_ingestible;
+class scan_info;
 }  // namespace op::scan
 namespace io {
 class sirius_ioctx;
@@ -85,7 +86,32 @@ class sirius_ioctx;
 struct materialized_pin {
   std::vector<std::unique_ptr<cudf::table>> tables;
   std::vector<cucascade::memory::memory_space*> chunk_memory_spaces;
+  /// Row count of each materialized chunk (parallel to @c tables). For duckdb-native
+  /// pins these become @c duckdb_mvcc_metadata::base_row_count_per_chunk — the
+  /// positional chunk→rowid-range map query-time MVCC merge relies on.
+  std::vector<std::size_t> base_row_count_per_chunk;
 };
+
+/// Host-pinned chunks produced by @ref materialize_pin_to_host — one
+/// host_data_representation per emitted batch, with the batch row counts captured
+/// alongside (parallel to @c host_chunks), mirroring @ref materialized_pin.
+struct materialized_host_pin {
+  std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks;
+  std::vector<std::size_t> base_row_count_per_chunk;
+};
+
+/// Pin-time validation of the coalescer invariant the MVCC delta merge relies on
+/// (#819): every duckdb-native batch must be a contiguous run of WHOLE row groups
+/// starting at @p rows_before_chunk, and its row-group metadata must cover exactly
+/// @p chunk_rows (the decoded cudf row count) — so the pinned chunks partition the
+/// decoded rowid prefix [0, N_cache) at row-group boundaries and per-chunk
+/// visibility masks can be assembled at row-group granularity. Throws
+/// std::runtime_error on violation; batches that are not duckdb_native_scan_info
+/// (parquet) are skipped. Called by the pin materialization driver on every
+/// emitted batch; exposed here so its failure paths are unit-testable.
+void validate_duckdb_pin_chunk(const op::scan::scan_info& batch,
+                               std::size_t chunk_rows,
+                               std::size_t rows_before_chunk);
 
 /// Drive @p ingestible 's metadata walk + batch coalescer to completion on @p io_ctx,
 /// materializing every emitted batch into a GPU-resident cudf::table and round-robining
@@ -116,8 +142,9 @@ materialized_pin materialize_all_batches(
 ///                          be pinned on (NUMA-local). Must contain an entry for every device id
 ///                          in @p gpu_spaces.
 /// \param io_ctx            IO context the metadata reads run on (owned by the scan manager).
-/// \return The pinned host chunks in materialization (round-robin) order — one per emitted batch.
-std::vector<std::shared_ptr<cucascade::host_data_representation>> materialize_pin_to_host(
+/// \return The pinned host chunks in materialization (round-robin) order — one per emitted
+///         batch — plus their per-chunk row counts.
+materialized_host_pin materialize_pin_to_host(
   op::scan::gpu_ingestible& ingestible,
   std::span<cucascade::memory::memory_space* const> gpu_spaces,
   const std::unordered_map<int, cucascade::memory::memory_space*>& host_space_by_gpu,

--- a/src/include/scan_manager/duckdb_mvcc_metadata.hpp
+++ b/src/include/scan_manager/duckdb_mvcc_metadata.hpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <duckdb/common/typedefs.hpp>
+
+#include <cstddef>
+#include <numeric>
+#include <vector>
+
+namespace sirius::scan_manager {
+
+/// MVCC snapshot metadata captured when a duckdb-native table is pinned, composed
+/// onto @ref pinned_entry (absent for parquet pins, whose sources are immutable).
+///
+/// A duckdb-native pin decodes the table's last-checkpointed disk image MVCC-blind:
+/// the cached data is the positionally-stable rowid prefix [0, n_cache()), including
+/// rows already tombstoned in memory and excluding rows that live only in
+/// uncheckpointed transient segments. Query-time delta merge reconciles that
+/// snapshot against DuckDB's live MVCC state; these fields are the pin-side facts
+/// it needs. Auto-checkpoint is suppressed while the pin exists so the disk image
+/// (and therefore the positional base) cannot change underneath the cache; a
+/// manual CHECKPOINT while pinned is outside the supported contract.
+struct duckdb_mvcc_metadata {
+  /// The pin transaction's DuckTransaction::start_time on the pinned table's own
+  /// AttachedDatabase (not the default database — each attached database has its
+  /// own MVCC counter domain). Serves as the snapshot fence: a query whose
+  /// start_time is >= v_base sees every commit the pin saw, so the cached base
+  /// filtered through query-time visibility is exact; an older query may still
+  /// see rows the last checkpoint compacted out of the disk image, so it cannot
+  /// be served from this cache.
+  duckdb::transaction_t v_base{0};
+
+  /// Physical row count of each pinned chunk, in materialization order — parallel
+  /// to pinned_entry::chunk_memory_spaces (GPU tier) / host_chunks (HOST tier).
+  /// Prefix sums map each chunk to its absolute rowid range [start, start + count).
+  /// Each chunk is a contiguous run of whole row groups (validated at pin time),
+  /// so per-chunk visibility masks can be assembled at row-group granularity.
+  std::vector<std::size_t> base_row_count_per_chunk;
+
+  /// Number of cached base rows: the pin covers rowids [0, n_cache()). Rows at
+  /// [n_cache(), live table rows) exist only in DuckDB's in-memory transient
+  /// segments — the insert delta.
+  [[nodiscard]] std::size_t n_cache() const
+  {
+    return std::accumulate(
+      base_row_count_per_chunk.begin(), base_row_count_per_chunk.end(), std::size_t{0});
+  }
+};
+
+}  // namespace sirius::scan_manager

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -22,6 +22,7 @@
 #include "io/sirius_datasource.hpp"
 #include "op/scan/gpu_ingestible_types.hpp"
 #include "scan_manager/config.hpp"
+#include "scan_manager/duckdb_mvcc_metadata.hpp"
 #include "scan_manager/load_balancing_scan_batch_coalescer.hpp"
 #include "scan_manager/split_provider.hpp"
 
@@ -148,6 +149,10 @@ struct pinned_entry {
   /// to decide whether a re-insert merges into the existing entry (same row
   /// count → add unique columns) or replaces it (different row count).
   std::size_t num_rows{0};
+  /// MVCC snapshot metadata for duckdb-native pins, attached by
+  /// @ref sirius_scan_manager::attach_mvcc_metadata right after insert. nullptr
+  /// for parquet pins (immutable sources need no visibility reconciliation).
+  std::unique_ptr<duckdb_mvcc_metadata> mvcc;
 };
 
 /**
@@ -281,6 +286,17 @@ class sirius_scan_manager {
     cache_entry_info cache_info,
     std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks,
     cucascade::memory::memory_space& memory_space);
+
+  /// \brief Attach MVCC snapshot metadata to the pinned entry for @p name.
+  ///
+  /// Called by the duckdb-format pin path immediately after insert_pinned_entry /
+  /// insert_pinned_entry_host. Overwrites any previous metadata: on a re-pin that
+  /// merged into an existing entry, the refreshed (newer) v_base is the more
+  /// conservative snapshot fence for every cached column, and the refreshed
+  /// per-chunk counts stay valid for every column because the merge path rejects
+  /// materializations whose per-chunk row counts differ from the existing
+  /// chunks'. Throws std::invalid_argument when no entry exists for @p name.
+  void attach_mvcc_metadata(const std::string& name, duckdb_mvcc_metadata metadata);
 
   /// \brief Remove the pinned entry for @p name. No-op if absent.
   void remove_pinned_entry(const std::string& name);

--- a/src/pin_table.cpp
+++ b/src/pin_table.cpp
@@ -18,6 +18,7 @@
 
 #include "data/sirius_converter_registry.hpp"
 #include "io/io_context.hpp"
+#include "op/scan/duckdb_native_gpu_ingestible.hpp"
 #include "op/scan/gpu_ingestible.hpp"
 #include "scan_manager/round_robin_strategy.hpp"
 
@@ -99,6 +100,35 @@ void clear_recorded_unpin_calls()
 
 namespace sirius {
 
+// A coalescer change that splits a row group across batches or reorders batches
+// must fail the pin loudly here instead of silently misaligning the per-chunk
+// visibility masks built over these boundaries (full contract in pin_table.hpp).
+void validate_duckdb_pin_chunk(const op::scan::scan_info& batch,
+                               std::size_t chunk_rows,
+                               std::size_t rows_before_chunk)
+{
+  auto const* native = dynamic_cast<const op::scan::duckdb_native_scan_info*>(&batch);
+  if (native == nullptr) { return; }
+
+  std::size_t next_row = rows_before_chunk;
+  for (auto const& rg : native->row_groups) {
+    if (static_cast<std::size_t>(rg.row_group_start) != next_row) {
+      throw std::runtime_error(
+        "[pin_table] duckdb-native batch breaks the whole-row-group contiguity invariant: row "
+        "group " +
+        std::to_string(rg.row_group_index) + " starts at row " +
+        std::to_string(rg.row_group_start) + " but the pin has materialized rows [0, " +
+        std::to_string(next_row) + ")");
+    }
+    next_row += rg.row_count;
+  }
+  if (next_row - rows_before_chunk != chunk_rows) {
+    throw std::runtime_error(
+      "[pin_table] duckdb-native chunk decoded " + std::to_string(chunk_rows) +
+      " rows but its row-group metadata covers " + std::to_string(next_row - rows_before_chunk));
+  }
+}
+
 namespace {
 
 /// Per-materialized-batch sink: receives one GPU-resident table, its GPU placement, and the
@@ -145,6 +175,10 @@ void materialize_pin_batches(op::scan::gpu_ingestible& ingestible,
 
   auto coalescer = ingestible.create_batch_coalescer();
 
+  // Rows materialized so far, in emission order — feeds the chunk-contiguity
+  // validation (duckdb-native pins only).
+  std::size_t rows_materialized = 0;
+
   // Materialize one coalesced batch into a GPU-resident cudf::table and hand it to on_batch
   // together with its GPU placement + the decode stream. Mirrors
   // load_balancing_scan_batch_coalescer::process_provider_inputs, minus the connector/balancer
@@ -174,8 +208,11 @@ void materialize_pin_batches(op::scan::gpu_ingestible& ingestible,
     // post_filter_and_project (which would only apply a row filter or re-project to a
     // query's output layout, neither of which a pin needs). `batch` is borrowed by const
     // ref and outlives the call.
-    auto materialized = ingestible.materialize_metadata_to_table(*batch, *target, stream);
-    auto tbl          = materialized.table.release(stream, target->get_default_allocator());
+    auto materialized     = ingestible.materialize_metadata_to_table(*batch, *target, stream);
+    auto tbl              = materialized.table.release(stream, target->get_default_allocator());
+    auto const chunk_rows = static_cast<std::size_t>(tbl->num_rows());
+    validate_duckdb_pin_chunk(*batch, chunk_rows, rows_materialized);
+    rows_materialized += chunk_rows;
     on_batch(std::move(tbl), target, stream);
   };
 
@@ -202,29 +239,31 @@ materialized_pin materialize_all_batches(
   io::sirius_ioctx& io_ctx)
 {
   materialized_pin out;
-  materialize_pin_batches(ingestible,
-                          gpu_spaces,
-                          io_ctx,
-                          [&](std::unique_ptr<cudf::table> tbl,
-                              cucascade::memory::memory_space* target,
-                              rmm::cuda_stream_view stream) {
-                            // Cached GPU batches are stored with a null writer stream, so the data
-                            // must be fully resident before it can be served or host-converted.
-                            stream.synchronize();
-                            out.tables.emplace_back(std::move(tbl));
-                            out.chunk_memory_spaces.push_back(target);
-                          });
+  materialize_pin_batches(
+    ingestible,
+    gpu_spaces,
+    io_ctx,
+    [&](std::unique_ptr<cudf::table> tbl,
+        cucascade::memory::memory_space* target,
+        rmm::cuda_stream_view stream) {
+      // Cached GPU batches are stored with a null writer stream, so the data
+      // must be fully resident before it can be served or host-converted.
+      stream.synchronize();
+      out.base_row_count_per_chunk.push_back(static_cast<std::size_t>(tbl->num_rows()));
+      out.tables.emplace_back(std::move(tbl));
+      out.chunk_memory_spaces.push_back(target);
+    });
   return out;
 }
 
-std::vector<std::shared_ptr<cucascade::host_data_representation>> materialize_pin_to_host(
+materialized_host_pin materialize_pin_to_host(
   op::scan::gpu_ingestible& ingestible,
   std::span<cucascade::memory::memory_space* const> gpu_spaces,
   const std::unordered_map<int, cucascade::memory::memory_space*>& host_space_by_gpu,
   io::sirius_ioctx& io_ctx)
 {
   auto& registry = converter_registry::get();
-  std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks;
+  materialized_host_pin out;
 
   materialize_pin_batches(
     ingestible,
@@ -242,14 +281,15 @@ std::vector<std::shared_ptr<cucascade::host_data_representation>> materialize_pi
       // so the host copy is complete once convert() returns. The explicit sync below is
       // belt-and-suspenders before gpu_repr (which owns the GPU table's buffers) leaves scope.
       auto* target_host_space = host_space_by_gpu.at(src_space->get_device_id());
+      out.base_row_count_per_chunk.push_back(static_cast<std::size_t>(tbl->num_rows()));
       cucascade::gpu_table_representation gpu_repr(std::move(tbl), *src_space, stream);
       auto host_repr =
         registry.convert<cucascade::host_data_representation>(gpu_repr, target_host_space, stream);
       stream.synchronize();
-      host_chunks.emplace_back(std::move(host_repr));
+      out.host_chunks.emplace_back(std::move(host_repr));
     });
 
-  return host_chunks;
+  return out;
 }
 
 }  // namespace sirius

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -598,6 +598,33 @@ void sirius_scan_manager::insert_pinned_entry(
             std::to_string(i) + "] differs between existing and new entry");
         }
       }
+      // Per-chunk ROW counts must match too: the byte-budget coalescer can slice
+      // the same table at different row-group boundaries for a different column
+      // set (varchar byte budgets are data-dependent), which still yields equal
+      // chunk counts and — because round-robin placement is a function of chunk
+      // index alone — identical memory_spaces. Merging such chunks would corrupt
+      // the entry positionally (columns disagreeing on chunk boundaries) and
+      // silently invalidate the per-chunk MVCC row-count map a duckdb pin stamps
+      // via attach_mvcc_metadata. Reject loudly instead.
+      if (!entry.data_batches_by_column.empty()) {
+        auto const& existing_chunks = entry.data_batches_by_column.begin()->second;
+        if (existing_chunks.size() != data_tables.size()) {
+          throw std::runtime_error(
+            "[sirius_scan_manager::insert_pinned_entry] merge mismatch — existing entry has " +
+            std::to_string(existing_chunks.size()) + " chunks but the new materialization has " +
+            std::to_string(data_tables.size()));
+        }
+        for (std::size_t i = 0; i < data_tables.size(); ++i) {
+          if (!data_tables[i]) { continue; }
+          if (existing_chunks[i]->size() != data_tables[i]->num_rows()) {
+            throw std::runtime_error(
+              "[sirius_scan_manager::insert_pinned_entry] merge mismatch — chunk " +
+              std::to_string(i) + " has " + std::to_string(existing_chunks[i]->size()) +
+              " rows in the existing entry but " + std::to_string(data_tables[i]->num_rows()) +
+              " in the new materialization (same total, different chunk boundaries)");
+          }
+        }
+      }
       // Same row count → merge unique columns into the existing entry.
       // Decide which column INDICES are new BEFORE iterating chunks. Doing
       // the contains() check per-chunk would let chunk 0 install a new
@@ -693,6 +720,16 @@ void sirius_scan_manager::insert_pinned_entry_host(
   entry.host_chunks  = std::move(host_chunks);
 
   _pinned_entries[name] = std::move(entry);
+}
+
+void sirius_scan_manager::attach_mvcc_metadata(const std::string& name,
+                                               duckdb_mvcc_metadata metadata)
+{
+  auto it = _pinned_entries.find(name);
+  if (it == _pinned_entries.end()) {
+    throw std::invalid_argument("[attach_mvcc_metadata] no pinned entry named '" + name + "'");
+  }
+  it->second.mvcc = std::make_unique<duckdb_mvcc_metadata>(std::move(metadata));
 }
 
 void sirius_scan_manager::remove_pinned_entry(const std::string& name)

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -44,6 +44,7 @@ extern "C" int cudaProfilerStop();
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/assert.hpp"
+#include "duckdb/common/limits.hpp"
 #include "duckdb/execution/column_binding_resolver.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/function/table_function.hpp"
@@ -63,6 +64,7 @@ extern "C" int cudaProfilerStop();
 #include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/planner/planner.hpp"
 #include "duckdb/storage/storage_manager.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 #include "transparent/sirius_optimizer_extension.hpp"
 // #include "from_substrait.hpp"
@@ -888,6 +890,24 @@ std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info> build_parquet_p
   return info;
 }
 
+// A duckdb-native pin is a positional snapshot of the table's last-checkpointed
+// disk image: a later checkpoint would compact tombstoned rows and flush transient
+// appends, silently shifting rowids out from under the cache (and compressing the
+// in-memory transient segments the query-time insert delta reads). Suppress both
+// WAL auto-checkpoint triggers — the size threshold and the entry count — before
+// the pin's metadata walk snapshots the on-disk row groups. The DBConfig is shared
+// by every attached database, so this covers them all. Idempotent, and deliberately
+// not restored on unpin (or when a later pin step fails): a restore would need pin
+// refcounting to be safe against other pins taken meanwhile. Manual CHECKPOINT —
+// and DETACH of the pinned database, whose close runs a shutdown checkpoint —
+// while pinned are outside the supported contract.
+void suppress_auto_checkpoint_for_pin(ClientContext& context)
+{
+  auto& config                       = DBConfig::GetConfig(context);
+  config.options.checkpoint_wal_size = NumericLimits<idx_t>::Maximum();
+  config.SetOptionByName("wal_autocheckpoint_entries", Value::UBIGINT(0));
+}
+
 // Resolve an attached duckdb table from the catalog and build its table_info for a
 // pin. The .db must be ATTACHed. The pin captures the table's (catalog, schema,
 // table) name from the resolved DuckTableEntry; that name tuple must match what a
@@ -1116,11 +1136,23 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
   // duckdb-native has no standalone reader, so both formats go through their
   // gpu_ingestible — one read path.
   std::shared_ptr<sirius::op::scan::gpu_ingestible> ingestible;
+  // The pin transaction's MVCC fence on the pinned table's own AttachedDatabase;
+  // meaningful only for format == "duckdb" (see duckdb_mvcc_metadata::v_base).
+  transaction_t duckdb_pin_v_base = 0;
 
   if (data.args.format == "duckdb") {
     auto info =
       build_duckdb_pin_info(context, data.args.name, data.args.schema, data.args.cols, batch_size);
-    ingestible = sirius::op::scan::make_ingestible(std::move(info));
+    // After the catalog resolution (so a bad table name fails without side
+    // effects) but before make_ingestible snapshots the on-disk row groups.
+    suppress_auto_checkpoint_for_pin(context);
+    // Not the default database's counter: each AttachedDatabase has its own MVCC
+    // start_time domain, and pins usually target an ATTACHed .db (the catalog
+    // resolved by build_duckdb_pin_info), so read the fence off that catalog's
+    // DuckTransaction.
+    auto& pinned_catalog = Catalog::GetCatalog(context, info->catalog_name);
+    duckdb_pin_v_base    = DuckTransaction::Get(context, pinned_catalog).start_time;
+    ingestible           = sirius::op::scan::make_ingestible(std::move(info));
   } else {  // parquet
     auto& fs   = FileSystem::GetFileSystem(context);
     auto files = fs.GlobFiles(data.args.path);
@@ -1147,22 +1179,37 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
     // GPU table before materializing the next. Peak GPU residency stays at ~one batch, so the
     // whole table never needs to fit in GPU memory. On multi-GPU the chunks land round-robin
     // across NUMA nodes; the cached-serve path then reads each chunk back on a NUMA-local GPU.
-    auto host_chunks = sirius::materialize_pin_to_host(
+    auto mat = sirius::materialize_pin_to_host(
       *ingestible, gpu_spaces_mut, host_space_by_gpu, *scan_mgr.io_ctx());
     // entry.memory_space is metadata only; each host_chunk carries its own per-GPU
     // NUMA-local memory_space. Pass a representative (the first GPU's host space).
     int const first_gpu_id          = gpu_spaces_mut[0]->get_device_id();
     auto* representative_host_space = host_space_by_gpu.at(first_gpu_id);
-    scan_mgr.insert_pinned_entry_host(
-      data.args.name, std::move(cache_info), std::move(host_chunks), *representative_host_space);
+    scan_mgr.insert_pinned_entry_host(data.args.name,
+                                      std::move(cache_info),
+                                      std::move(mat.host_chunks),
+                                      *representative_host_space);
+    if (data.args.format == "duckdb") {
+      sirius::scan_manager::duckdb_mvcc_metadata mvcc;
+      mvcc.v_base                   = duckdb_pin_v_base;
+      mvcc.base_row_count_per_chunk = std::move(mat.base_row_count_per_chunk);
+      scan_mgr.attach_mvcc_metadata(data.args.name, std::move(mvcc));
+    }
   } else {
     // GPU tier: materialize every batch as a GPU-resident cudf::table (with its GPU
     // placement) and pin them in place.
     auto mat = sirius::materialize_all_batches(*ingestible, gpu_spaces_mut, *scan_mgr.io_ctx());
+    auto base_row_count_per_chunk = std::move(mat.base_row_count_per_chunk);
     scan_mgr.insert_pinned_entry(data.args.name,
                                  std::move(cache_info),
                                  std::move(mat.tables),
                                  std::move(mat.chunk_memory_spaces));
+    if (data.args.format == "duckdb") {
+      sirius::scan_manager::duckdb_mvcc_metadata mvcc;
+      mvcc.v_base                   = duckdb_pin_v_base;
+      mvcc.base_row_count_per_chunk = std::move(base_row_count_per_chunk);
+      scan_mgr.attach_mvcc_metadata(data.args.name, std::move(mvcc));
+    }
   }
 
   output.SetCardinality(1);

--- a/test/cpp/integration/test_pin_table_mvcc_foundation.cpp
+++ b/test/cpp/integration/test_pin_table_mvcc_foundation.cpp
@@ -1,0 +1,392 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_pin_table_mvcc_foundation.cpp
+ * @brief Foundation tests for query-time MVCC delta merge over the duckdb-native
+ *        pinned cache (#819): a duckdb-format pin captures MVCC snapshot metadata
+ *        (v_base + per-chunk row counts) on its pinned_entry, suppresses WAL
+ *        auto-checkpoint so the pinned disk image cannot shift underneath the
+ *        cache, and the table keeps taking INSERT/DELETE traffic while pinned.
+ *        The serve path is intentionally unchanged at this stage — nothing here
+ *        asserts query-time visibility.
+ */
+
+#include "op/scan/duckdb_native_gpu_ingestible.hpp"
+#include "pin_table.hpp"
+#include "scan_manager/sirius_scan_manager.hpp"
+#include "sirius_context.hpp"
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/catalog/catalog.hpp>
+#include <duckdb/common/limits.hpp>
+#include <duckdb/main/config.hpp>
+#include <duckdb/transaction/duck_transaction.hpp>
+#include <utils/gpu_execution_fixture.hpp>
+#include <utils/transparent_execution_test_utils.hpp>
+
+#include <cstddef>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using PinMvccFixture = sirius::test::GpuExecutionFixture;
+
+namespace {
+
+/// PR1-relevant state of a pinned entry, copied out inside visit_pinned_entries
+/// so no reference to the entry escapes the visitor.
+struct entry_probe {
+  bool found                   = false;
+  bool has_mvcc                = false;
+  duckdb::transaction_t v_base = 0;
+  std::vector<std::size_t> counts;
+  std::size_t n_cache     = 0;
+  std::size_t num_rows    = 0;
+  std::size_t gpu_chunks  = 0;
+  std::size_t host_chunks = 0;
+  /// The entry's REAL per-chunk row counts, read back from the cached data
+  /// itself (GPU tier: any column's chunk sizes; HOST tier: each host chunk's
+  /// rows) — what the recorded counts must match elementwise.
+  std::vector<std::size_t> actual_chunk_rows;
+};
+
+entry_probe probe_entry(duckdb::Connection& con, const std::string& name)
+{
+  auto sirius_ctx = sirius::test::get_registered_sirius_context(con);
+  REQUIRE(sirius_ctx != nullptr);
+  entry_probe out;
+  sirius_ctx->get_scan_manager().visit_pinned_entries(
+    [&](std::string_view entry_name, const sirius::scan_manager::pinned_entry& entry) {
+      if (entry_name != name) { return true; }  // keep scanning
+      out.found    = true;
+      out.has_mvcc = entry.mvcc != nullptr;
+      if (entry.mvcc) {
+        out.v_base  = entry.mvcc->v_base;
+        out.counts  = entry.mvcc->base_row_count_per_chunk;
+        out.n_cache = entry.mvcc->n_cache();
+      }
+      out.num_rows    = entry.num_rows;
+      out.gpu_chunks  = entry.chunk_memory_spaces.size();
+      out.host_chunks = entry.host_chunks.size();
+      if (!entry.data_batches_by_column.empty()) {
+        for (auto const& chunk : entry.data_batches_by_column.begin()->second) {
+          out.actual_chunk_rows.push_back(static_cast<std::size_t>(chunk->size()));
+        }
+      } else {
+        for (auto const& chunk : entry.host_chunks) {
+          auto const& host_table = chunk->get_host_table();
+          out.actual_chunk_rows.push_back(
+            host_table && !host_table->columns.empty()
+              ? static_cast<std::size_t>(host_table->columns.front().num_rows)
+              : 0);
+        }
+      }
+      return false;  // stop
+    });
+  return out;
+}
+
+}  // namespace
+
+TEST_CASE_METHOD(PinMvccFixture,
+                 "pin_table mvcc - duckdb GPU pin captures v_base and per-chunk counts",
+                 "[integration][gpu_execution][pin_table_mvcc]")
+{
+  // ~2.5 row groups worth of rows so the pin spans several row groups and the
+  // whole-row-group chunk validation in materialize_pin_batches gets real work.
+  run_ok("CREATE TABLE mvcc_gpu_t AS SELECT range AS a, range * 2 AS b FROM range(300000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='mvcc_gpu_t', tier='gpu');");
+
+  auto probe = probe_entry(*con, "mvcc_gpu_t");
+  REQUIRE(probe.found);
+  REQUIRE(probe.has_mvcc);
+  REQUIRE(probe.v_base > 0);
+  REQUIRE_FALSE(probe.counts.empty());
+  // Counts are per materialized chunk, parallel to the entry's chunk placement,
+  // and must equal the cached chunks' real row counts elementwise.
+  REQUIRE(probe.counts.size() == probe.gpu_chunks);
+  REQUIRE(probe.counts == probe.actual_chunk_rows);
+  // The pin covers the checkpointed rowid prefix exactly: N_cache == cached rows.
+  REQUIRE(probe.n_cache == 300000);
+  REQUIRE(probe.n_cache == probe.num_rows);
+
+  // The pin still serves queries (serve path untouched by the foundation).
+  compare_gpu_vs_cpu("SELECT count(*), sum(a), sum(b) FROM mvcc_gpu_t;");
+
+  run_ok("CALL unpin_table('mvcc_gpu_t');");
+  REQUIRE_FALSE(probe_entry(*con, "mvcc_gpu_t").found);
+}
+
+TEST_CASE_METHOD(PinMvccFixture,
+                 "pin_table mvcc - duckdb HOST pin captures v_base and per-chunk counts",
+                 "[integration][gpu_execution][pin_table_mvcc]")
+{
+  run_ok("CREATE TABLE mvcc_host_t AS SELECT range AS a FROM range(200000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='mvcc_host_t', tier='host');");
+
+  auto probe = probe_entry(*con, "mvcc_host_t");
+  REQUIRE(probe.found);
+  REQUIRE(probe.has_mvcc);
+  REQUIRE(probe.v_base > 0);
+  REQUIRE_FALSE(probe.counts.empty());
+  // Host tier: counts are parallel to the pinned host chunks (one per batch)
+  // and must equal each chunk's real row count.
+  REQUIRE(probe.counts.size() == probe.host_chunks);
+  REQUIRE(probe.counts == probe.actual_chunk_rows);
+  REQUIRE(probe.n_cache == 200000);
+  REQUIRE(probe.n_cache == probe.num_rows);
+
+  run_ok("CALL unpin_table('mvcc_host_t');");
+}
+
+TEST_CASE_METHOD(PinMvccFixture,
+                 "pin_table mvcc - v_base equals the pin transaction's start_time on the pinned "
+                 "catalog",
+                 "[integration][gpu_execution][pin_table_mvcc]")
+{
+  run_ok("CREATE TABLE mvcc_vbase_t AS SELECT range AS a FROM range(10000);");
+  run_ok("CHECKPOINT;");
+
+  // Pin inside an explicit transaction and read the SAME transaction's
+  // start_time on the pinned table's own catalog: the captured fence must equal
+  // it exactly. This pins down both the timing (the pin transaction, not some
+  // later one) and the MVCC domain (the attached database's counter, not the
+  // default in-memory catalog's — each AttachedDatabase counts independently).
+  run_ok("BEGIN TRANSACTION;");
+  run_ok("CALL pin_table(format='duckdb', name='mvcc_vbase_t', tier='gpu');");
+  auto& pinned_catalog = duckdb::Catalog::GetCatalog(*con->context, attach_alias);
+  auto const expected  = duckdb::DuckTransaction::Get(*con->context, pinned_catalog).start_time;
+  run_ok("COMMIT;");
+
+  auto probe = probe_entry(*con, "mvcc_vbase_t");
+  REQUIRE(probe.has_mvcc);
+  REQUIRE(probe.v_base == expected);
+
+  run_ok("CALL unpin_table('mvcc_vbase_t');");
+}
+
+TEST_CASE_METHOD(PinMvccFixture,
+                 "pin_table mvcc - multi-chunk pin records the per-chunk rowid partition",
+                 "[integration][gpu_execution][pin_table_mvcc]")
+{
+  // integration.yaml caps scan_task_batch_size at 100 MB; 13M BIGINTs decode to
+  // ~104 MB, so the coalescer must emit at least two chunks — exercising the
+  // per-chunk map beyond the single-chunk tautology.
+  run_ok("CREATE TABLE mvcc_multi_t AS SELECT range AS a FROM range(13000000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='mvcc_multi_t', tier='gpu');");
+
+  auto probe = probe_entry(*con, "mvcc_multi_t");
+  REQUIRE(probe.has_mvcc);
+  REQUIRE(probe.counts.size() >= 2);
+  REQUIRE(probe.counts == probe.actual_chunk_rows);
+  REQUIRE(probe.n_cache == 13000000);
+  // Chunks are whole row groups, so every chunk but the table's last (which owns
+  // the one partial row group) covers a multiple of ROW_GROUP_SIZE rows.
+  for (std::size_t i = 0; i + 1 < probe.counts.size(); ++i) {
+    REQUIRE(probe.counts[i] % 122880 == 0);
+  }
+
+  run_ok("CALL unpin_table('mvcc_multi_t');");
+}
+
+TEST_CASE_METHOD(PinMvccFixture,
+                 "pin_table mvcc - parquet pin carries no MVCC metadata",
+                 "[integration][gpu_execution][pin_table_mvcc]")
+{
+  auto parquet_path = temp_db_path + "_mvcc.parquet";
+  run_ok("COPY (SELECT range AS a FROM range(1000)) TO '" + parquet_path + "' (FORMAT parquet);");
+  run_ok("CALL pin_table('" + parquet_path + "', name='mvcc_pq', tier='gpu');");
+
+  auto probe = probe_entry(*con, "mvcc_pq");
+  REQUIRE(probe.found);
+  REQUIRE_FALSE(probe.has_mvcc);
+
+  run_ok("CALL unpin_table('mvcc_pq');");
+  std::filesystem::remove(parquet_path);
+}
+
+TEST_CASE_METHOD(PinMvccFixture,
+                 "pin_table mvcc - re-pin refreshes v_base through the merge path",
+                 "[integration][gpu_execution][pin_table_mvcc]")
+{
+  run_ok("CREATE TABLE mvcc_repin_t AS SELECT range AS a FROM range(50000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='mvcc_repin_t', tier='gpu');");
+  auto const first = probe_entry(*con, "mvcc_repin_t");
+  REQUIRE(first.has_mvcc);
+
+  // Committed write transactions on the attached database advance its MVCC
+  // counter, so the second pin's transaction has a strictly newer start_time.
+  run_ok("CREATE TABLE mvcc_repin_bump AS SELECT 1 AS x;");
+  run_ok("DROP TABLE mvcc_repin_bump;");
+
+  // No checkpoint ran in between, so the decoded row count is unchanged and this
+  // re-pin takes insert_pinned_entry's MERGE path — the metadata must still be
+  // refreshed (attach overwrites) with the newer, more conservative fence.
+  run_ok("CALL pin_table(format='duckdb', name='mvcc_repin_t', tier='gpu');");
+  auto const second = probe_entry(*con, "mvcc_repin_t");
+  REQUIRE(second.has_mvcc);
+  REQUIRE(second.v_base > first.v_base);
+  REQUIRE(second.n_cache == first.n_cache);
+
+  run_ok("CALL unpin_table('mvcc_repin_t');");
+}
+
+TEST_CASE_METHOD(PinMvccFixture,
+                 "pin_table mvcc - duckdb pin suppresses WAL auto-checkpoint",
+                 "[integration][gpu_execution][pin_table_mvcc]")
+{
+  run_ok("CREATE TABLE mvcc_wal_t (a BIGINT);");
+  run_ok("INSERT INTO mvcc_wal_t SELECT range FROM range(100000);");
+  run_ok("CHECKPOINT;");
+  // Arm the SECOND auto-checkpoint trigger (entry count) before pinning: the pin
+  // must disarm it too, or the 40 commits below would checkpoint and truncate
+  // the WAL regardless of the size threshold.
+  run_ok("SET GLOBAL wal_autocheckpoint_entries = 5;");
+  run_ok("CALL pin_table(format='duckdb', name='mvcc_wal_t', tier='gpu');");
+
+  // The pin disables the size-based trigger outright (the DBConfig is shared by
+  // every attached database) and zeroes the entry-count trigger.
+  auto& config = duckdb::DBConfig::GetConfig(*con->context);
+  REQUIRE(config.options.checkpoint_wal_size == duckdb::NumericLimits<duckdb::idx_t>::Maximum());
+  auto entries_setting = con->Query("SELECT current_setting('wal_autocheckpoint_entries');");
+  REQUIRE_FALSE(entries_setting->HasError());
+  REQUIRE(entries_setting->GetValue(0, 0).GetValue<int64_t>() == 0);
+
+  // Write well past the 16 MiB default threshold across many commits. Under the
+  // default config the commit crossing it would auto-checkpoint and truncate the
+  // WAL; with the pin's suppression the WAL just keeps growing. The commits stay
+  // below a row group (122,880 rows) each: DuckDB writes larger appends
+  // optimistically — data blocks straight to the db file, only references in the
+  // WAL — so bulk inserts would barely grow the WAL at all.
+  for (int i = 0; i < 40; ++i) {
+    run_ok("INSERT INTO mvcc_wal_t SELECT range FROM range(60000);");
+  }
+  auto const wal_path = temp_db_path + ".wal";
+  REQUIRE(std::filesystem::exists(wal_path));
+  REQUIRE(std::filesystem::file_size(wal_path) > (16ULL << 20));
+
+  run_ok("CALL unpin_table('mvcc_wal_t');");
+}
+
+TEST_CASE_METHOD(PinMvccFixture,
+                 "pin_table mvcc - INSERT and DELETE run while the table is pinned",
+                 "[integration][gpu_execution][pin_table_mvcc]")
+{
+  run_ok("CREATE TABLE mvcc_dml_t AS SELECT range AS a FROM range(100000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='mvcc_dml_t', tier='gpu');");
+  auto const before = probe_entry(*con, "mvcc_dml_t");
+  REQUIRE(before.has_mvcc);
+
+  // The pin takes no table lock: normal DML must proceed while the cache exists.
+  run_ok("INSERT INTO mvcc_dml_t SELECT range FROM range(1000);");
+  run_ok("DELETE FROM mvcc_dml_t WHERE a < 500;");
+
+  // The entry (and its snapshot metadata) is untouched by the concurrent writes.
+  auto const after = probe_entry(*con, "mvcc_dml_t");
+  REQUIRE(after.found);
+  REQUIRE(after.has_mvcc);
+  REQUIRE(after.v_base == before.v_base);
+  REQUIRE(after.n_cache == before.n_cache);
+
+  run_ok("CALL unpin_table('mvcc_dml_t');");
+}
+
+TEST_CASE_METHOD(PinMvccFixture,
+                 "pin_table mvcc - attach_mvcc_metadata without an entry throws",
+                 "[integration][pin_table_mvcc]")
+{
+  auto sirius_ctx = sirius::test::get_registered_sirius_context(*con);
+  REQUIRE(sirius_ctx != nullptr);
+  REQUIRE_THROWS_AS(sirius_ctx->get_scan_manager().attach_mvcc_metadata("mvcc_no_such_entry", {}),
+                    std::invalid_argument);
+}
+
+//===----------------------------------------------------------------------===//
+// validate_duckdb_pin_chunk failure paths (pure unit tests, no GPU / fixture)
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+sirius::op::scan::duckdb_row_group_metadata make_rg(duckdb::idx_t index,
+                                                    duckdb::idx_t start,
+                                                    duckdb::idx_t count)
+{
+  sirius::op::scan::duckdb_row_group_metadata rg;
+  rg.row_group_index = index;
+  rg.row_group_start = start;
+  rg.row_count       = count;
+  return rg;
+}
+
+}  // namespace
+
+TEST_CASE("pin_table mvcc - chunk validator accepts contiguous whole row groups",
+          "[pin_table_mvcc]")
+{
+  sirius::op::scan::duckdb_native_scan_info first;
+  first.row_groups.push_back(make_rg(0, 0, 122880));
+  first.row_groups.push_back(make_rg(1, 122880, 122880));
+  REQUIRE_NOTHROW(sirius::validate_duckdb_pin_chunk(first, 245760, 0));
+
+  // A later chunk continues exactly where the previous one ended.
+  sirius::op::scan::duckdb_native_scan_info second;
+  second.row_groups.push_back(make_rg(2, 245760, 1000));
+  REQUIRE_NOTHROW(sirius::validate_duckdb_pin_chunk(second, 1000, 245760));
+}
+
+TEST_CASE("pin_table mvcc - chunk validator rejects a rowid gap between chunks", "[pin_table_mvcc]")
+{
+  // The chunk starts one row group in while the pin has materialized nothing:
+  // a skipped/reordered row group must fail the pin.
+  sirius::op::scan::duckdb_native_scan_info batch;
+  batch.row_groups.push_back(make_rg(1, 122880, 122880));
+  REQUIRE_THROWS_AS(sirius::validate_duckdb_pin_chunk(batch, 122880, 0), std::runtime_error);
+}
+
+TEST_CASE("pin_table mvcc - chunk validator rejects out-of-order row groups within a chunk",
+          "[pin_table_mvcc]")
+{
+  sirius::op::scan::duckdb_native_scan_info batch;
+  batch.row_groups.push_back(make_rg(1, 122880, 122880));
+  batch.row_groups.push_back(make_rg(0, 0, 122880));
+  REQUIRE_THROWS_AS(sirius::validate_duckdb_pin_chunk(batch, 245760, 0), std::runtime_error);
+}
+
+TEST_CASE("pin_table mvcc - chunk validator rejects a decoded/metadata row-count mismatch",
+          "[pin_table_mvcc]")
+{
+  // The decoder produced fewer rows than the row-group metadata covers (e.g. a
+  // future coalescer slicing a row group across batches).
+  sirius::op::scan::duckdb_native_scan_info batch;
+  batch.row_groups.push_back(make_rg(0, 0, 122880));
+  REQUIRE_THROWS_AS(sirius::validate_duckdb_pin_chunk(batch, 100000, 0), std::runtime_error);
+}
+
+TEST_CASE("pin_table mvcc - chunk validator skips non-duckdb batches", "[pin_table_mvcc]")
+{
+  // Parquet (or any other format's) batches carry no duckdb row-group metadata;
+  // the validator must not constrain them.
+  sirius::op::scan::scan_info parquet_like;
+  REQUIRE_NOTHROW(sirius::validate_duckdb_pin_chunk(parquet_like, 12345, 0));
+}

--- a/test/cpp/integration/test_pin_table_mvcc_foundation.cpp
+++ b/test/cpp/integration/test_pin_table_mvcc_foundation.cpp
@@ -35,6 +35,7 @@
 #include <duckdb/catalog/catalog.hpp>
 #include <duckdb/common/limits.hpp>
 #include <duckdb/main/config.hpp>
+#include <duckdb/main/settings.hpp>
 #include <duckdb/transaction/duck_transaction.hpp>
 #include <utils/gpu_execution_fixture.hpp>
 #include <utils/transparent_execution_test_utils.hpp>
@@ -255,6 +256,12 @@ TEST_CASE_METHOD(PinMvccFixture,
                  "pin_table mvcc - duckdb pin suppresses WAL auto-checkpoint",
                  "[integration][gpu_execution][pin_table_mvcc]")
 {
+  // This test is about WAL/checkpoint mechanics, not GPU serving — keep its
+  // statements off the transparent-interception path (the pin CALL is
+  // unaffected). A trivial intercepted SELECT here previously tripped a latent
+  // state-dependent engine hang ~960 tests into the CI suite.
+  run_ok("SET gpu_execution = false;");
+
   run_ok("CREATE TABLE mvcc_wal_t (a BIGINT);");
   run_ok("INSERT INTO mvcc_wal_t SELECT range FROM range(100000);");
   run_ok("CHECKPOINT;");
@@ -265,12 +272,11 @@ TEST_CASE_METHOD(PinMvccFixture,
   run_ok("CALL pin_table(format='duckdb', name='mvcc_wal_t', tier='gpu');");
 
   // The pin disables the size-based trigger outright (the DBConfig is shared by
-  // every attached database) and zeroes the entry-count trigger.
+  // every attached database) and zeroes the entry-count trigger. Read both back
+  // exactly the way SingleFileStorageManager::AutomaticCheckpoint reads them.
   auto& config = duckdb::DBConfig::GetConfig(*con->context);
   REQUIRE(config.options.checkpoint_wal_size == duckdb::NumericLimits<duckdb::idx_t>::Maximum());
-  auto entries_setting = con->Query("SELECT current_setting('wal_autocheckpoint_entries');");
-  REQUIRE_FALSE(entries_setting->HasError());
-  REQUIRE(entries_setting->GetValue(0, 0).GetValue<int64_t>() == 0);
+  REQUIRE(duckdb::Settings::Get<duckdb::WalAutocheckpointEntriesSetting>(config) == 0);
 
   // Write well past the 16 MiB default threshold across many commits. Under the
   // default config the commit crossing it would auto-checkpoint and truncate the


### PR DESCRIPTION
Part of #819 (PR1 of the ladder — foundation only, serve path unchanged). Foundation for query-time MVCC delta merge over the duckdb-native pinned cache: everything a pin must remember at pin time so later stages can reconcile the cached snapshot with DuckDB's live MVCC state (DELETE visibility masks, then the INSERT delta).

## Summary

- **New `duckdb_mvcc_metadata`**, composed onto `pinned_entry` (`nullptr` for parquet pins): `v_base` (the pin transaction's `DuckTransaction::start_time` on the pinned table's **own** catalog — each AttachedDatabase has its own MVCC counter domain) and `base_row_count_per_chunk` (parallel to the entry's chunk storage; prefix sums map each chunk to its absolute rowid range; `n_cache()` = the base/delta boundary).
- **`sirius_scan_manager::attach_mvcc_metadata(name, metadata)`** — called by the duckdb pin path right after insert; overwrites on re-pin (fresher fence); throws if the entry is absent.
- **Auto-checkpoint suppressed at duckdb pin time** — a checkpoint would compact tombstones/flush transient appends and silently shift rowids under the positional cache. Both triggers are disarmed: `checkpoint_wal_size` (set to max) **and** the entry-count trigger `wal_autocheckpoint_entries` (zeroed). Deliberately not restored on unpin (needs pin refcounting; PR5 candidate). Manual `CHECKPOINT` — and `DETACH`, whose close runs a shutdown checkpoint — while pinned are documented out of contract.
- **Per-chunk row counts captured on both tiers**: `materialized_pin` gains `base_row_count_per_chunk`; the host path returns a new `materialized_host_pin` mirroring it.
- **Whole-row-group chunk invariant enforced at pin time** (`validate_duckdb_pin_chunk`): every duckdb-native batch must be a contiguous run of whole row groups continuing exactly where the previous batch ended, and its metadata row total must equal the decoded row count. A future coalescer change that splits/reorders row groups fails the pin loudly instead of silently misaligning the downstream visibility masks.
- **Merge-path guard in `insert_pinned_entry`** (pre-existing hazard, surfaced by review): byte-budget coalescing is column-set-dependent, so a re-pin with different columns can produce equal chunk *counts* with different row-group boundaries — passing the existing memory-space checks while corrupting the merged entry positionally. The merge now rejects per-chunk row-count mismatches loudly.

## Notes / observed behavior

- A pin taken while committed-but-uncheckpointed rows exist **fails loudly today** (transient segments stage zero bytes; the decoder's pre-validation throws) — no silent garbage is possible. PR4 will make that case work by excluding transient tails from the pin walk and serving them as the insert delta.
- Same-name same-row-count re-pins across formats remain a pre-existing `insert_pinned_entry` quirk (cache identity is preserved from the first pin); unchanged here.

## Test plan

- [x] New `[pin_table_mvcc]` suite (14 cases, 279 assertions): GPU + host duckdb pins capture `v_base`/counts with counts matching the cached chunks' real row counts elementwise; multi-chunk pin (13M rows > the 100MB batch cap) records the per-chunk rowid partition at row-group multiples; `v_base` equals the pin transaction's `start_time` on the pinned catalog exactly (pinned inside an explicit transaction); parquet pin carries no metadata; re-pin refreshes `v_base` through the merge path; WAL grows past the 16MiB default across 40 commits with both triggers disarmed (entry trigger armed at 5 before the pin); INSERT/DELETE run while pinned; `attach_mvcc_metadata` without an entry throws; `validate_duckdb_pin_chunk` failure paths unit-tested (gap, out-of-order, row-total mismatch, non-duckdb skip).
- [x] Existing pin regression suites pass unchanged: `[pin_table]`, `[pin_table_host]`, `[pin_table_duckdb]`, `[pin_table_duckdb_host]`, `[pin_table_cols_subset]`, `[pin_table_host_streaming]`, `[pin_mgpu]` (17 cases, 887 assertions).
- [x] `pixi run pre-commit run -a` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)