### PR TITLE
Read globbed `read_parquet('s3://…/*.parquet')` on GPU via S3 LIST

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ set(EXTENSION_SOURCES
     src/io/rest/curl_handle.cpp
     src/io/rest/rest_ioctx.cpp
     src/io/rest/rest_reactor.cpp
+    src/io/s3/s3_list_parser.cpp
     src/io/s3/sigv4.cpp
     src/io/s3/sirius_httpfs.cpp
     src/io/s3/sirius_sigv4_authorizer.cpp

--- a/Makefile
+++ b/Makefile
@@ -166,12 +166,12 @@ s3-test-large:
 	@# group. Catch2 OR-combines specs within one argument via commas (multiple
 	@# positional args are AND-concatenated instead), so each group runs in a
 	@# single process where same-config cases share one SiriusContext lifecycle.
-	@# SIRIUS_TEST_S3_TPCH is scoped to the first group only: it gates both the
-	@# SF1 TPC-H fixture upload at bring-up and the [tpch][large] case, so the
-	@# second group's bring-up must not see it (it would re-generate/upload).
+	@# SIRIUS_TEST_S3_TPCH gates the SF1 TPC-H fixture + [tpch][large]; SIRIUS_TEST_S3_GLOB_SCALE
+	@# gates the 1001-object fixture + [glob-scale]. Both are scoped to the first group only, so
+	@# the second group's bring-up must not see them (it would re-generate / re-upload).
 	@set -e; \
 	export SIRIUS_TEST_S3_AUTO=1 SIRIUS_TEST_S3_LARGE=1 SIRIUS_TEST_S3_STRICT=1; \
-	SIRIUS_TEST_S3_TPCH=1 $(S3_TEST_BIN) "[s3][sql][large][large-count],[s3][sql][large][large-q1],[s3][sql][large][large-join],[s3][integration][sql][tpch][large]"; \
+	SIRIUS_TEST_S3_TPCH=1 SIRIUS_TEST_S3_GLOB_SCALE=1 $(S3_TEST_BIN) "[s3][sql][large][large-count],[s3][sql][large][large-q1],[s3][sql][large][large-join],[s3][integration][sql][tpch][large],[s3][large][glob-scale]"; \
 	$(S3_TEST_BIN) "[s3][sql][large][large-count-no-prewarm],[s3][sql][large][large-q1-no-prewarm],[s3][sql][large][large-join-no-prewarm]"
 
 # TPC-H-over-S3 correctness tier (Q1-Q22 == local CPU oracle, GPU-only). Uploads

--- a/src/include/io/io_context.hpp
+++ b/src/include/io/io_context.hpp
@@ -25,6 +25,7 @@
 #include <rmm/cuda_stream_view.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -109,6 +110,12 @@ class sirius_ioctx : public std::enable_shared_from_this<sirius_ioctx> {
   /// can, e.g., prefetch a parquet footer in the same round-trip as the size.
   [[nodiscard]] std::unique_ptr<sirius_datasource> open_datasource(std::string path,
                                                                    open_hint hint);
+
+  /// As above, with the object's size already known (e.g. from an S3
+  /// ListObjectsV2 response), so a backend that can act on it skips its size
+  /// discovery entirely (no HEAD for object stores).
+  [[nodiscard]] std::unique_ptr<sirius_datasource> open_datasource(std::string path,
+                                                                   std::uint64_t known_size);
 
   /// Whether this backend can serve reads for @p path.  Backends should
   /// validate scheme/protocol support and any backend-specific
@@ -248,6 +255,14 @@ class sirius_ioctx : public std::enable_shared_from_this<sirius_ioctx> {
   /// distinct virtual — not a defaulted argument on the pure virtual above — so
   /// the hint dispatches on the dynamic type instead of binding statically.
   virtual std::shared_ptr<sirius_io_object> create_io_object(std::string path, open_hint hint);
+
+  /// Known-size variant.  The base implementation ignores @p known_size and
+  /// delegates to the required @c create_io_object(path) (local backends learn
+  /// the size for free from the fd); a backend whose size discovery costs a
+  /// round-trip (rest_ioctx's HEAD) overrides this to build the io_object with
+  /// zero network.  Same distinct-virtual rationale as the hint variant above.
+  virtual std::shared_ptr<sirius_io_object> create_io_object(std::string path,
+                                                             std::uint64_t known_size);
 
   /// Owned by this ioctx.  Built by @ref initialize_cache, destroyed
   /// by @ref shutdown_cache (or the ioctx destructor as a safety net,

--- a/src/include/io/io_context.hpp
+++ b/src/include/io/io_context.hpp
@@ -257,10 +257,10 @@ class sirius_ioctx : public std::enable_shared_from_this<sirius_ioctx> {
   virtual std::shared_ptr<sirius_io_object> create_io_object(std::string path, open_hint hint);
 
   /// Known-size variant.  The base implementation ignores @p known_size and
-  /// delegates to the required @c create_io_object(path) (local backends learn
-  /// the size for free from the fd); a backend whose size discovery costs a
-  /// round-trip (rest_ioctx's HEAD) overrides this to build the io_object with
-  /// zero network.  Same distinct-virtual rationale as the hint variant above.
+  /// delegates to the required @c create_io_object(path); a backend whose size
+  /// discovery would otherwise cost a round-trip overrides this to build the
+  /// io_object without one.  Same distinct-virtual rationale as the hint
+  /// variant above.
   virtual std::shared_ptr<sirius_io_object> create_io_object(std::string path,
                                                              std::uint64_t known_size);
 

--- a/src/include/io/rest/config.hpp
+++ b/src/include/io/rest/config.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "io/s3/s3_list_parser.hpp"
+
 #include <chrono>
 #include <cstddef>
 
@@ -101,6 +103,14 @@ struct config {
   /// for multi-GB single files, lower it for many-tiny-file / low-bandwidth
   /// workloads.
   std::size_t footer_probe_bytes{512UL << 10};  // 512 KiB
+
+  /// S3 LIST / glob safety caps (both throw "narrow the glob prefix", never
+  /// truncate).  @c list_max_matches bounds the files a glob keeps / a
+  /// whole-listing accumulates (result memory); @c list_max_scanned bounds the
+  /// objects a LIST sweep looks at across pages (time / LIST round-trips).  The
+  /// two axes diverge when a prefix is huge but few keys match, so both exist.
+  std::size_t list_max_matches{s3::default_max_list_objects};     // 100'000
+  std::size_t list_max_scanned{s3::default_max_scanned_objects};  // 1'000'000
 };
 
 }  // namespace sirius::io::rest

--- a/src/include/io/rest/rest_ioctx.hpp
+++ b/src/include/io/rest/rest_ioctx.hpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -71,7 +72,7 @@ class rest_ioctx : public templated_ioctx<rest_reactor> {
                           std::string_view prefix,
                           std::size_t page_size,
                           std::function<bool(s3::list_objects_v2_page const&)> const& sink,
-                          std::size_t max_scanned = s3::default_max_scanned_objects);
+                          std::optional<std::size_t> max_scanned = std::nullopt);
 
   /// Whole-listing convenience over @c list_objects_paged: every object under
   /// @p prefix, in document order, with sizes.  Throws (never truncates) when
@@ -80,8 +81,14 @@ class rest_ioctx : public templated_ioctx<rest_reactor> {
   [[nodiscard]] std::vector<s3::list_entry> list_objects(
     std::string_view bucket,
     std::string_view prefix,
-    std::size_t page_size = 1000,
-    std::size_t max_keys  = s3::default_max_list_objects);
+    std::size_t page_size               = 1000,
+    std::optional<std::size_t> max_keys = std::nullopt);
+
+  /// The configured matched cap (@c config.list_max_matches) — exposed so the
+  /// glob layer (@c sirius_httpfs::expand_glob, one level up) can bound its
+  /// match set without a reactor handle.  Falls back to the built-in default
+  /// when the pool is empty (never in practice).
+  [[nodiscard]] std::size_t list_max_matches() const;
 
  protected:
   /// Backend hook invoked by @c sirius_ioctx::open_datasource: parse @p path

--- a/src/include/io/rest/rest_ioctx.hpp
+++ b/src/include/io/rest/rest_ioctx.hpp
@@ -17,11 +17,16 @@
 #pragma once
 
 #include "io/rest/rest_reactor.hpp"
+#include "io/s3/s3_list_parser.hpp"
 #include "io/templated_ioctx.hpp"
 
 #include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace sirius::io::rest {
 
@@ -54,6 +59,30 @@ class rest_ioctx : public templated_ioctx<rest_reactor> {
   /// non-zero reactor value.  Lock-free; drives the s3-bench JSON baseline.
   [[nodiscard]] rest_perf_snapshot perf_snapshot() const noexcept;
 
+  /// Stream a bucket's ListObjectsV2 pages under @p prefix to @p sink, one call
+  /// per page (a page holds at most 1000 entries, so peak memory is one page
+  /// regardless of bucket population).  @p sink returns false to stop early —
+  /// no further LIST requests are issued.  @p page_size is clamped to [1,1000]
+  /// (0 and >1000 mean 1000).  Throws (never truncates) on a truncated page
+  /// without a continuation token, and once more than @p max_scanned entries
+  /// have been scanned across pages (bounds time / request count on a prefix
+  /// whose population dwarfs the caller's matches).
+  void list_objects_paged(std::string_view bucket,
+                          std::string_view prefix,
+                          std::size_t page_size,
+                          std::function<bool(s3::list_objects_v2_page const&)> const& sink,
+                          std::size_t max_scanned = s3::default_max_scanned_objects);
+
+  /// Whole-listing convenience over @c list_objects_paged: every object under
+  /// @p prefix, in document order, with sizes.  Throws (never truncates) when
+  /// the accumulated entries would exceed @p max_keys — a partial key set would
+  /// resolve a glob to a silently incomplete table.
+  [[nodiscard]] std::vector<s3::list_entry> list_objects(
+    std::string_view bucket,
+    std::string_view prefix,
+    std::size_t page_size = 1000,
+    std::size_t max_keys  = s3::default_max_list_objects);
+
  protected:
   /// Backend hook invoked by @c sirius_ioctx::open_datasource: parse @p path
   /// (s3://bucket/key), HEAD it for the size, and build a @c rest_io_object.
@@ -64,6 +93,12 @@ class rest_ioctx : public templated_ioctx<rest_reactor> {
   /// parquet footer together via a single suffix-range GET, carried on the
   /// returned io_object; every other hint falls back to the plain HEAD path above.
   std::shared_ptr<sirius_io_object> create_io_object(std::string path, open_hint hint) override;
+
+  /// Known-size open: the caller already learned the object's size (e.g. from a
+  /// ListObjectsV2 response), so the io_object is built with ZERO network — no
+  /// HEAD, no probe.
+  std::shared_ptr<sirius_io_object> create_io_object(std::string path,
+                                                     std::uint64_t known_size) override;
 
  private:
   /// Resolve @p path with a single suffix-range GET: it discovers the size and

--- a/src/include/io/rest/rest_reactor.hpp
+++ b/src/include/io/rest/rest_reactor.hpp
@@ -151,14 +151,9 @@ struct rest_perf_snapshot {
   // over every completed curl attempt incl. retries / partial / failed bodies.
   // Not TLS/header/TCP-frame bytes — this is the S3-scan payload byte budget.
   std::uint64_t payload_bytes_read_total{0};
-  // perf_instrumentation-gated: an ADDITIONAL view of every blocking host_read
-  // GET that hits the network (the native parquet binder reads footers this
-  // way, but so does any other synchronous read — e.g. CPU-fallback data reads;
-  // column data goes through the async chunk path).  These GETs are ALSO
-  // counted in chunk_get_count above — blocking_host_get_* does not remove
-  // them, it isolates the blocking-read phase.  Stash-served host_reads issue
-  // no GET and are counted by neither; the one-shot footer-probe suffix GET at
-  // open counts only as a chunk GET.
+  // perf_instrumentation-gated. Blocking host GETs remain part of chunk_get_*
+  // and are also attributed to blocking_host_get_*. Stash hits issue no GET and
+  // increment neither.
   std::uint64_t blocking_host_get_count{0};
   std::uint64_t blocking_host_get_wall_ns_total{0};
   std::uint64_t blocking_host_get_wall_ns_max{0};

--- a/src/include/io/rest/rest_reactor.hpp
+++ b/src/include/io/rest/rest_reactor.hpp
@@ -276,6 +276,17 @@ class rest_reactor {
   /// falls back to a HEAD.  @p bucket / @p key identify the object.
   footer_probe fetch_footer_suffix(std::string_view bucket, std::string_view key, std::size_t n);
 
+  /// Blocking bucket-level ListObjectsV2 GET for one page: returns the raw XML
+  /// body on HTTP 200.  @p canonical_query is the pre-encoded, key-sorted
+  /// request query (no auth params — authorization is added via
+  /// @c authorize_list).  @p prefix is only for retry-log / error text.
+  /// Control-plane op: retries/terminals are counted (and retries WARN-logged)
+  /// like every retry loop here, but the XML body never touches the
+  /// chunk-GET / payload byte counters.
+  std::string list_page(std::string_view bucket,
+                        std::string_view prefix,
+                        std::string_view canonical_query);
+
   /// Snapshot of this reactor's perf counters.  Lock-free (relaxed atomic
   /// loads); safe to call while the reactor is running.
   [[nodiscard]] rest_perf_snapshot perf_snapshot() const noexcept;

--- a/src/include/io/rest/rest_reactor.hpp
+++ b/src/include/io/rest/rest_reactor.hpp
@@ -151,6 +151,15 @@ struct rest_perf_snapshot {
   // over every completed curl attempt incl. retries / partial / failed bodies.
   // Not TLS/header/TCP-frame bytes — this is the S3-scan payload byte budget.
   std::uint64_t payload_bytes_read_total{0};
+  // perf_instrumentation-gated: an ADDITIONAL, footer-isolated view of blocking
+  // host_read GETs that hit the network (the native parquet binder reads footers
+  // this way; column data goes through the async chunk path).  These GETs are
+  // ALSO counted in chunk_get_count above — native_footer_* does not remove them,
+  // it isolates the footer phase for A0.  Stash-served host_reads issue no GET
+  // and are counted by neither.
+  std::uint64_t native_footer_get_count{0};
+  std::uint64_t native_footer_wall_ns_total{0};
+  std::uint64_t native_footer_wall_ns_max{0};
 };
 
 // ---------------------------------------------------------------------------
@@ -225,7 +234,8 @@ class rest_reactor {
 
   static request_type_ptr prep_host_rx_request(const reactor_config_type& cfg,
                                                const io_object_type& file,
-                                               const io_object_segment& segment);
+                                               const io_object_segment& segment,
+                                               bool perf_footer_read = false);
 
   static request_type_ptr prep_host_rxv_request(const reactor_config_type& cfg,
                                                 const io_object_type& file,
@@ -358,6 +368,9 @@ class rest_reactor {
     std::atomic<std::uint64_t> terminal_failures_total{0};
     std::atomic<std::uint64_t> device_stream_sync_total{0};
     std::atomic<std::uint64_t> payload_bytes_read_total{0};
+    std::atomic<std::uint64_t> native_footer_get_count{0};
+    std::atomic<std::uint64_t> native_footer_wall_ns_total{0};
+    std::atomic<std::uint64_t> native_footer_wall_ns_max{0};
   };
   perf_counters _perf;
 

--- a/src/include/io/rest/rest_reactor.hpp
+++ b/src/include/io/rest/rest_reactor.hpp
@@ -151,15 +151,17 @@ struct rest_perf_snapshot {
   // over every completed curl attempt incl. retries / partial / failed bodies.
   // Not TLS/header/TCP-frame bytes — this is the S3-scan payload byte budget.
   std::uint64_t payload_bytes_read_total{0};
-  // perf_instrumentation-gated: an ADDITIONAL, footer-isolated view of blocking
-  // host_read GETs that hit the network (the native parquet binder reads footers
-  // this way; column data goes through the async chunk path).  These GETs are
-  // ALSO counted in chunk_get_count above — native_footer_* does not remove them,
-  // it isolates the footer phase for A0.  Stash-served host_reads issue no GET
-  // and are counted by neither.
-  std::uint64_t native_footer_get_count{0};
-  std::uint64_t native_footer_wall_ns_total{0};
-  std::uint64_t native_footer_wall_ns_max{0};
+  // perf_instrumentation-gated: an ADDITIONAL view of every blocking host_read
+  // GET that hits the network (the native parquet binder reads footers this
+  // way, but so does any other synchronous read — e.g. CPU-fallback data reads;
+  // column data goes through the async chunk path).  These GETs are ALSO
+  // counted in chunk_get_count above — blocking_host_get_* does not remove
+  // them, it isolates the blocking-read phase.  Stash-served host_reads issue
+  // no GET and are counted by neither; the one-shot footer-probe suffix GET at
+  // open counts only as a chunk GET.
+  std::uint64_t blocking_host_get_count{0};
+  std::uint64_t blocking_host_get_wall_ns_total{0};
+  std::uint64_t blocking_host_get_wall_ns_max{0};
 };
 
 // ---------------------------------------------------------------------------
@@ -235,7 +237,7 @@ class rest_reactor {
   static request_type_ptr prep_host_rx_request(const reactor_config_type& cfg,
                                                const io_object_type& file,
                                                const io_object_segment& segment,
-                                               bool perf_footer_read = false);
+                                               bool perf_blocking_host_get = false);
 
   static request_type_ptr prep_host_rxv_request(const reactor_config_type& cfg,
                                                 const io_object_type& file,
@@ -368,9 +370,9 @@ class rest_reactor {
     std::atomic<std::uint64_t> terminal_failures_total{0};
     std::atomic<std::uint64_t> device_stream_sync_total{0};
     std::atomic<std::uint64_t> payload_bytes_read_total{0};
-    std::atomic<std::uint64_t> native_footer_get_count{0};
-    std::atomic<std::uint64_t> native_footer_wall_ns_total{0};
-    std::atomic<std::uint64_t> native_footer_wall_ns_max{0};
+    std::atomic<std::uint64_t> blocking_host_get_count{0};
+    std::atomic<std::uint64_t> blocking_host_get_wall_ns_total{0};
+    std::atomic<std::uint64_t> blocking_host_get_wall_ns_max{0};
   };
   perf_counters _perf;
 

--- a/src/include/io/rest/types.hpp
+++ b/src/include/io/rest/types.hpp
@@ -97,10 +97,12 @@ struct rest_chunked_rx_request {
   bool staged_through_bounce{false};
 
   // perf_instrumentation attribution: set on the blocking single host_read path
-  // (rest_reactor::host_read → prep_host_rx_request), the way DuckDB's native
-  // parquet binder reads footers.  finish() then counts this GET as a native
-  // footer read instead of an async scan chunk, keeping the two disjoint.
-  bool perf_footer_read{false};
+  // (rest_reactor::host_read → prep_host_rx_request) — every synchronous host
+  // GET that reaches the network, e.g. DuckDB's native parquet binder footer
+  // reads, but equally any other blocking read.  finish() then bumps
+  // blocking_host_get_* IN ADDITION to the chunk_get_* counters (additive, not
+  // disjoint).  Stash-served reads issue no GET and count in neither.
+  bool perf_blocking_host_get{false};
 
   // perf (set only when the reactor's perf_instrumentation is on): t_enqueue at
   // queue insertion, t_submit at dequeue onto a connection; their delta is the

--- a/src/include/io/rest/types.hpp
+++ b/src/include/io/rest/types.hpp
@@ -96,6 +96,12 @@ struct rest_chunked_rx_request {
   // take the event-synchronized recycle path (see needs_event_for_synchronization).
   bool staged_through_bounce{false};
 
+  // perf_instrumentation attribution: set on the blocking single host_read path
+  // (rest_reactor::host_read → prep_host_rx_request), the way DuckDB's native
+  // parquet binder reads footers.  finish() then counts this GET as a native
+  // footer read instead of an async scan chunk, keeping the two disjoint.
+  bool perf_footer_read{false};
+
   // perf (set only when the reactor's perf_instrumentation is on): t_enqueue at
   // queue insertion, t_submit at dequeue onto a connection; their delta is the
   // queue_wait sample (attempt 0 only), and t_submit anchors the chunk_get span.

--- a/src/include/io/rest/types.hpp
+++ b/src/include/io/rest/types.hpp
@@ -96,12 +96,7 @@ struct rest_chunked_rx_request {
   // take the event-synchronized recycle path (see needs_event_for_synchronization).
   bool staged_through_bounce{false};
 
-  // perf_instrumentation attribution: set on the blocking single host_read path
-  // (rest_reactor::host_read → prep_host_rx_request) — every synchronous host
-  // GET that reaches the network, e.g. DuckDB's native parquet binder footer
-  // reads, but equally any other blocking read.  finish() then bumps
-  // blocking_host_get_* IN ADDITION to the chunk_get_* counters (additive, not
-  // disjoint).  Stash-served reads issue no GET and count in neither.
+  // Marks synchronous network reads for blocking_host_get_* attribution.
   bool perf_blocking_host_get{false};
 
   // perf (set only when the reactor's perf_instrumentation is on): t_enqueue at

--- a/src/include/io/s3/s3_list_parser.hpp
+++ b/src/include/io/s3/s3_list_parser.hpp
@@ -30,8 +30,8 @@ namespace sirius::io::s3 {
 inline constexpr std::size_t default_max_list_objects = 100'000;
 
 /// Default cap on the total number of entries a paged listing will scan across
-/// all pages (≤ 1000 LIST round-trips at the maximum page size). Bounds time
-/// and request count on a prefix whose population dwarfs the matches.
+/// all pages. Bounds the scanned-object count and request cost on a prefix
+/// whose population dwarfs the matches.
 inline constexpr std::size_t default_max_scanned_objects = 1'000'000;
 
 /// One object from a ListObjectsV2 page: full key + object size in bytes.
@@ -54,35 +54,14 @@ struct list_objects_v2_page {
 };
 
 /**
- * @brief Parse one ListObjectsV2 XML response body.
+ * @brief Parse one complete ListObjectsV2 response.
  *
- * Hand-rolled (no XML dependency): the S3 ListObjectsV2 schema is small and
- * fixed. Tolerant of the `xmlns` attribute on `<ListBucketResult>` and leading /
- * trailing whitespace. XML entities (`&amp; &lt; &gt; &quot; &apos;`) in key /
- * token text are unescaped.
+ * Hand-rolled (no XML dependency). Accepts an optional XML declaration and root
+ * attributes, and unescapes the five predefined XML entities. Fails closed so a
+ * malformed body never parses as a silently-incomplete listing.
  *
- * The body must be a COMPLETE, well-formed response — a truncated / partial
- * (but transport-complete) body must not parse as a silently-incomplete
- * listing, so the root close tag and every `<Contents>` block are required to
- * close, and the fields AWS documents as always present are mandatory: a
- * malformed body fails closed instead of silently dropping entries or ending
- * the paged sweep early.
- *
- * @throw std::runtime_error when @p xml is not a recognizable, complete
- *        ListObjectsV2 response: no `<ListBucketResult>` open tag (e.g. an S3
- *        `<Error>` body or an empty string), a missing `</ListBucketResult>`
- *        close tag, or a `<Contents>` opened without a `</Contents>` close (both
- *        signal a truncated body); a `<Contents>` whose `<Key>` is missing /
- *        unclosed / empty (a silently-skipped entry would make a glob drop the
- *        object with no error); a `<Contents>` whose `<Size>` is missing /
- *        non-numeric / overflows `uint64_t` (a silently-zeroed or wrapped size
- *        would defeat the no-HEAD open path downstream — `<Size>0</Size>` is
- *        legal, S3 allows zero-byte objects); a missing / unclosed
- *        `<IsTruncated>` or a value other than exactly `true` / `false` after
- *        trimming (defaulting would end the paged loop on a partial listing);
- *        or `<IsTruncated>true</IsTruncated>` without a `<NextContinuationToken>`
- *        element (the listing could not be completed). An empty-but-present
- *        token element is accepted here and rejected by the paged caller.
+ * @throws std::runtime_error for malformed roots, entries, sizes, or paging
+ *         fields.
  */
 list_objects_v2_page parse_list_objects_v2(std::string_view xml);
 

--- a/src/include/io/s3/s3_list_parser.hpp
+++ b/src/include/io/s3/s3_list_parser.hpp
@@ -57,16 +57,22 @@ struct list_objects_v2_page {
  * @brief Parse one ListObjectsV2 XML response body.
  *
  * Hand-rolled (no XML dependency): the S3 ListObjectsV2 schema is small and
- * fixed. Tolerant of the `xmlns` attribute on `<ListBucketResult>`, leading /
- * trailing whitespace, and a self-closing `<ListBucketResult/>`. XML entities
- * (`&amp; &lt; &gt; &quot; &apos;`) in key / token text are unescaped.
+ * fixed. Tolerant of the `xmlns` attribute on `<ListBucketResult>` and leading /
+ * trailing whitespace. XML entities (`&amp; &lt; &gt; &quot; &apos;`) in key /
+ * token text are unescaped.
  *
- * @throw std::runtime_error when @p xml is not a recognizable ListObjectsV2
- *        response (no `<ListBucketResult>` — e.g. an S3 `<Error>` body or an
- *        empty string), or when a `<Contents>` block lacks a parseable
- *        non-negative `<Size>` (a silently-zeroed size would defeat the
- *        no-HEAD open path downstream). `<Size>0</Size>` is legal — S3 allows
- *        zero-byte objects.
+ * The body must be a COMPLETE response — a truncated / partial (but
+ * transport-complete) body must not parse as a silently-incomplete listing, so
+ * both the root close tag and every `<Contents>` block are required to close.
+ *
+ * @throw std::runtime_error when @p xml is not a recognizable, complete
+ *        ListObjectsV2 response: no `<ListBucketResult>` open tag (e.g. an S3
+ *        `<Error>` body or an empty string), a missing `</ListBucketResult>`
+ *        close tag, or a `<Contents>` opened without a `</Contents>` close (both
+ *        signal a truncated body); or a `<Contents>` whose `<Size>` is missing /
+ *        non-numeric / overflows `uint64_t` (a silently-zeroed or wrapped size
+ *        would defeat the no-HEAD open path downstream). `<Size>0</Size>` is
+ *        legal — S3 allows zero-byte objects.
  */
 list_objects_v2_page parse_list_objects_v2(std::string_view xml);
 

--- a/src/include/io/s3/s3_list_parser.hpp
+++ b/src/include/io/s3/s3_list_parser.hpp
@@ -61,18 +61,28 @@ struct list_objects_v2_page {
  * trailing whitespace. XML entities (`&amp; &lt; &gt; &quot; &apos;`) in key /
  * token text are unescaped.
  *
- * The body must be a COMPLETE response — a truncated / partial (but
- * transport-complete) body must not parse as a silently-incomplete listing, so
- * both the root close tag and every `<Contents>` block are required to close.
+ * The body must be a COMPLETE, well-formed response — a truncated / partial
+ * (but transport-complete) body must not parse as a silently-incomplete
+ * listing, so the root close tag and every `<Contents>` block are required to
+ * close, and the fields AWS documents as always present are mandatory: a
+ * malformed body fails closed instead of silently dropping entries or ending
+ * the paged sweep early.
  *
  * @throw std::runtime_error when @p xml is not a recognizable, complete
  *        ListObjectsV2 response: no `<ListBucketResult>` open tag (e.g. an S3
  *        `<Error>` body or an empty string), a missing `</ListBucketResult>`
  *        close tag, or a `<Contents>` opened without a `</Contents>` close (both
- *        signal a truncated body); or a `<Contents>` whose `<Size>` is missing /
+ *        signal a truncated body); a `<Contents>` whose `<Key>` is missing /
+ *        unclosed / empty (a silently-skipped entry would make a glob drop the
+ *        object with no error); a `<Contents>` whose `<Size>` is missing /
  *        non-numeric / overflows `uint64_t` (a silently-zeroed or wrapped size
- *        would defeat the no-HEAD open path downstream). `<Size>0</Size>` is
- *        legal — S3 allows zero-byte objects.
+ *        would defeat the no-HEAD open path downstream — `<Size>0</Size>` is
+ *        legal, S3 allows zero-byte objects); a missing / unclosed
+ *        `<IsTruncated>` or a value other than exactly `true` / `false` after
+ *        trimming (defaulting would end the paged loop on a partial listing);
+ *        or `<IsTruncated>true</IsTruncated>` without a `<NextContinuationToken>`
+ *        element (the listing could not be completed). An empty-but-present
+ *        token element is accepted here and rejected by the paged caller.
  */
 list_objects_v2_page parse_list_objects_v2(std::string_view xml);
 

--- a/src/include/io/s3/s3_list_parser.hpp
+++ b/src/include/io/s3/s3_list_parser.hpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace sirius::io::s3 {
+
+/// Default cap on the number of entries a whole-listing call will accumulate.
+/// Exceeding it throws (never truncates) — a partial key set would resolve a
+/// glob to a silently incomplete table.
+inline constexpr std::size_t default_max_list_objects = 100'000;
+
+/// Default cap on the total number of entries a paged listing will scan across
+/// all pages (≤ 1000 LIST round-trips at the maximum page size). Bounds time
+/// and request count on a prefix whose population dwarfs the matches.
+inline constexpr std::size_t default_max_scanned_objects = 1'000'000;
+
+/// One object from a ListObjectsV2 page: full key + object size in bytes.
+/// The size rides the LIST response for free, so downstream opens need no
+/// size-discovery round-trip.
+struct list_entry {
+  std::string key;
+  std::uint64_t size = 0;
+};
+
+/// One parsed page of an S3 ListObjectsV2 response.
+struct list_objects_v2_page {
+  /// Every `<Contents>` object in document order, XML-entity-unescaped.
+  /// Excludes `<CommonPrefixes><Prefix>` entries (directory rollups, not keys).
+  std::vector<list_entry> entries;
+  /// `<IsTruncated>` — true when another page follows.
+  bool is_truncated = false;
+  /// `<NextContinuationToken>` — the cursor for the next page; empty when absent.
+  std::string next_continuation_token;
+};
+
+/**
+ * @brief Parse one ListObjectsV2 XML response body.
+ *
+ * Hand-rolled (no XML dependency): the S3 ListObjectsV2 schema is small and
+ * fixed. Tolerant of the `xmlns` attribute on `<ListBucketResult>`, leading /
+ * trailing whitespace, and a self-closing `<ListBucketResult/>`. XML entities
+ * (`&amp; &lt; &gt; &quot; &apos;`) in key / token text are unescaped.
+ *
+ * @throw std::runtime_error when @p xml is not a recognizable ListObjectsV2
+ *        response (no `<ListBucketResult>` — e.g. an S3 `<Error>` body or an
+ *        empty string), or when a `<Contents>` block lacks a parseable
+ *        non-negative `<Size>` (a silently-zeroed size would defeat the
+ *        no-HEAD open path downstream). `<Size>0</Size>` is legal — S3 allows
+ *        zero-byte objects.
+ */
+list_objects_v2_page parse_list_objects_v2(std::string_view xml);
+
+}  // namespace sirius::io::s3

--- a/src/include/io/s3/s3_request_authorizer.hpp
+++ b/src/include/io/s3/s3_request_authorizer.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "io/io_errors.hpp"
 #include "io/s3/s3_object_ref.hpp"
 
 #include <chrono>
@@ -100,6 +101,38 @@ class s3_request_authorizer {
   [[nodiscard]] virtual s3_authorized_request authorize(s3_object_ref const& obj,
                                                         s3_request_method method,
                                                         std::chrono::seconds timeout) = 0;
+
+  /**
+   * @brief Authorize a bucket-level ListObjectsV2 GET.
+   *
+   * @param bucket           Bucket name (no scheme / slashes).
+   * @param canonical_query  The request query string, already percent-encoded,
+   *                          `&`-joined, and **sorted by encoded key** (SigV4
+   *                          canonical order), WITHOUT any auth params — e.g.
+   *                          @c "list-type=2&max-keys=1000&prefix=a%2Fb" (with
+   *                          @c "continuation-token=..." sorted in first). The
+   *                          header-signing path signs this string verbatim, so
+   *                          an unsorted query would be signed but rejected by
+   *                          S3; the presigned path re-sorts when merging the
+   *                          @c X-Amz-* params, but callers should pass sorted
+   *                          regardless. Must not contain any @c X-Amz-* key —
+   *                          implementations reject those so callers cannot
+   *                          smuggle / override signing parameters.
+   * @param timeout          Per-call URL lifetime (presigned @c X-Amz-Expires);
+   *                          ignored by header-signing authorizers.
+   *
+   * Default: throws — LIST is opt-in, so a pluggable authorizer that only knows
+   * how to sign object GET/HEAD need not implement it.
+   *
+   * @throw sirius::io::credential_error when unsupported, or on signing failure.
+   */
+  [[nodiscard]] virtual s3_authorized_request authorize_list(std::string_view /*bucket*/,
+                                                             std::string_view /*canonical_query*/,
+                                                             std::chrono::seconds /*timeout*/)
+  {
+    throw sirius::io::credential_error(
+      "s3_request_authorizer: ListObjectsV2 is not supported by this authorizer");
+  }
 };
 
 }  // namespace sirius::io::s3

--- a/src/include/io/s3/sigv4.hpp
+++ b/src/include/io/s3/sigv4.hpp
@@ -105,6 +105,15 @@ sigv4_signed_request sign_request(
  *                      Passed explicitly so tests are deterministic.
  * @param ttl           Validity window. Becomes the @c X-Amz-Expires query
  *                      parameter (in seconds).
+ * @param extra_canonical_query  Additional request query parameters, already
+ *                      RFC3986-encoded and `&`-joined (e.g.
+ *                      @c "list-type=2&prefix=p%2F&max-keys=1000" for a
+ *                      ListObjectsV2 request). Empty for plain object GET/HEAD.
+ *                      These are merged with the @c X-Amz-* parameters and the
+ *                      whole set is re-sorted before signing, so they
+ *                      participate in the signature (required for S3 to accept
+ *                      a presigned LIST). Each element is taken verbatim — pass
+ *                      it pre-encoded, not raw.
  *
  * @throw std::invalid_argument on empty credentials / region / service /
  *                              method / scheme / host, or non-positive @p ttl.
@@ -115,7 +124,8 @@ std::string presign_url(std::string_view method,
                         std::string_view canonical_uri,
                         sigv4_signer_config const& creds,
                         std::time_t timestamp_utc,
-                        std::chrono::seconds ttl);
+                        std::chrono::seconds ttl,
+                        std::string_view extra_canonical_query = {});
 
 /// Hex-encoded SHA256 digest of @p data. Thin wrapper around OpenSSL SHA256.
 std::string sha256_hex(std::string_view data);

--- a/src/include/io/s3/sigv4.hpp
+++ b/src/include/io/s3/sigv4.hpp
@@ -106,8 +106,9 @@ sigv4_signed_request sign_request(
  * @param ttl           Validity window. Becomes the @c X-Amz-Expires query
  *                      parameter (in seconds).
  * @param extra_canonical_query  Additional request query parameters, already
- *                      RFC3986-encoded and `&`-joined (e.g.
- *                      @c "list-type=2&prefix=p%2F&max-keys=1000" for a
+ *                      RFC3986-encoded, `&`-joined, and in SigV4 canonical
+ *                      (byte-sorted) order (e.g.
+ *                      @c "list-type=2&max-keys=1000&prefix=p%2F" for a
  *                      ListObjectsV2 request). Empty for plain object GET/HEAD.
  *                      These are merged with the @c X-Amz-* parameters and the
  *                      whole set is re-sorted before signing, so they

--- a/src/include/io/s3/sirius_httpfs.hpp
+++ b/src/include/io/s3/sirius_httpfs.hpp
@@ -16,11 +16,18 @@
 
 #pragma once
 
+#include "io/s3/s3_list_parser.hpp"
+
 #include <duckdb/common/file_system.hpp>
 #include <duckdb/common/open_file_info.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
+
+namespace sirius::scan_manager {
+class sirius_scan_manager;
+}  // namespace sirius::scan_manager
 
 namespace sirius::io::s3 {
 
@@ -62,6 +69,17 @@ class sirius_httpfs : public duckdb::FileSystem {
     duckdb::FileOpenFlags flags,
     duckdb::optional_ptr<duckdb::FileOpener> opener = nullptr) override;
 
+  /// Extended open: when @p file carries a @c "file_size" option (a
+  /// non-negative BIGINT — the LIST-provided size @ref Glob attaches), the
+  /// datasource is opened through the known-size seam with ZERO network (no
+  /// HEAD). A missing / wrong-typed / negative option silently falls back to
+  /// the plain open path — third-party-populated @c OpenFileInfo must not
+  /// break the open.
+  duckdb::unique_ptr<duckdb::FileHandle> OpenFileExtended(
+    const duckdb::OpenFileInfo& file,
+    duckdb::FileOpenFlags flags,
+    duckdb::optional_ptr<duckdb::FileOpener> opener) override;
+
   void Read(duckdb::FileHandle& handle,
             void* buffer,
             int64_t nr_bytes,
@@ -71,8 +89,14 @@ class sirius_httpfs : public duckdb::FileSystem {
   int64_t GetFileSize(duckdb::FileHandle& handle) override;
   duckdb::timestamp_t GetLastModifiedTime(duckdb::FileHandle& handle) override;
 
-  /// Concrete-object only: returns @c {path} when @ref CanHandleFile, else empty.
-  /// Rejects glob/wildcard patterns (no S3 LIST) with a clear error.
+  /// Exact key: returns @c {path} when @ref CanHandleFile, else empty. A
+  /// glob/wildcard pattern expands via one paginated S3 LIST (through the
+  /// connection's scan_manager — see @ref expand_glob), gated like @ref
+  /// OpenFile: requires a resolvable @c ClientContext, @c gpu_execution
+  /// enabled, and no active CPU-fallback replay. Each match carries its
+  /// LIST-provided size in the extended info so the subsequent open needs no
+  /// HEAD. Zero matches yield an empty vector (DuckDB raises its standard
+  /// no-files error).
   duckdb::vector<duckdb::OpenFileInfo> Glob(const std::string& path,
                                             duckdb::FileOpener* opener = nullptr) override;
 
@@ -82,6 +106,23 @@ class sirius_httpfs : public duckdb::FileSystem {
   bool OnDiskFile(duckdb::FileHandle& /*handle*/) override { return false; }
 
   std::string GetName() const override { return "SiriusHttpFS"; }
+
+ protected:
+  bool SupportsOpenFileExtended() const override { return true; }
 };
+
+/// Expand an @c s3:// glob @p pattern into concrete object URIs via one
+/// paginated ListObjectsV2 sweep, streamed page-by-page (peak memory = one
+/// page + the matches). The LIST prefix is everything up to the last '/'
+/// before the first wildcard, so the sweep is server-side-narrowed to the
+/// table's prefix. Matching follows DuckDB's glob semantics per '/'-segment
+/// (@c *, @c ?, @c […] never cross a segment; @c ** crosses). Matches carry
+/// their LIST size in @c extended_info->options["file_size"]. Throws (never
+/// truncates) once more than @p max_matches keys match — "narrow the glob
+/// prefix"; wildcards in the bucket segment are rejected.
+duckdb::vector<duckdb::OpenFileInfo> expand_glob(
+  std::string const& pattern,
+  sirius::scan_manager::sirius_scan_manager& scan_manager,
+  std::size_t max_matches = default_max_list_objects);
 
 }  // namespace sirius::io::s3

--- a/src/include/io/s3/sirius_httpfs.hpp
+++ b/src/include/io/s3/sirius_httpfs.hpp
@@ -23,6 +23,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
 
 namespace sirius::scan_manager {
@@ -119,10 +120,11 @@ class sirius_httpfs : public duckdb::FileSystem {
 /// (@c *, @c ?, @c […] never cross a segment; @c ** crosses). Matches carry
 /// their LIST size in @c extended_info->options["file_size"]. Throws (never
 /// truncates) once more than @p max_matches keys match — "narrow the glob
-/// prefix"; wildcards in the bucket segment are rejected.
+/// prefix"; wildcards in the bucket segment are rejected. @p max_matches unset
+/// → the backend's configured cap (@c rest.list_max_matches).
 duckdb::vector<duckdb::OpenFileInfo> expand_glob(
   std::string const& pattern,
   sirius::scan_manager::sirius_scan_manager& scan_manager,
-  std::size_t max_matches = default_max_list_objects);
+  std::optional<std::size_t> max_matches = std::nullopt);
 
 }  // namespace sirius::io::s3

--- a/src/include/io/s3/sirius_httpfs.hpp
+++ b/src/include/io/s3/sirius_httpfs.hpp
@@ -72,10 +72,15 @@ class sirius_httpfs : public duckdb::FileSystem {
 
   /// Extended open: when @p file carries a @c "file_size" option (a
   /// non-negative BIGINT — the LIST-provided size @ref Glob attaches), the
-  /// datasource is opened through the known-size seam with ZERO network (no
-  /// HEAD). A missing / wrong-typed / negative option silently falls back to
-  /// the plain open path — third-party-populated @c OpenFileInfo must not
-  /// break the open.
+  /// datasource is opened through the parquet-footer-probe seam: ONE
+  /// suffix-range GET resolves the size from Content-Range (no HEAD) and
+  /// stashes the trailing bytes for the binder's footer reads. The size value
+  /// itself only discriminates this extended open from the plain fallback —
+  /// the probe re-derives the authoritative size from the response. A missing /
+  /// wrong-typed / negative option silently falls back to the plain open path
+  /// (HEAD, then ranged GETs) — third-party-populated @c OpenFileInfo must not
+  /// break the open. Non-parquet files opened this way still read correctly;
+  /// they just pay for a stashed tail that no footer read consumes.
   duckdb::unique_ptr<duckdb::FileHandle> OpenFileExtended(
     const duckdb::OpenFileInfo& file,
     duckdb::FileOpenFlags flags,
@@ -96,8 +101,16 @@ class sirius_httpfs : public duckdb::FileSystem {
   /// OpenFile: requires a resolvable @c ClientContext, @c gpu_execution
   /// enabled, and no active CPU-fallback replay. Each match carries its
   /// LIST-provided size in the extended info so the subsequent open needs no
-  /// HEAD. Zero matches yield an empty vector (DuckDB raises its standard
-  /// no-files error).
+  /// HEAD (one suffix-range GET instead — see @ref OpenFileExtended). Match
+  /// paths embed the literal LIST key via @ref escape_s3_key_for_uri: keys
+  /// containing @c #, @c ? or a bare @c % show the escaped form in the path
+  /// text (and in the @c filename virtual column) but open the exact object.
+  /// A matched key containing a percent-encoded sequence (@c % followed by
+  /// two hex digits) throws instead — DuckDB URL-decodes hive partition
+  /// values from the path once, so no single path text can serve both the
+  /// open and hive semantics for such keys; full support is a tracked
+  /// follow-up. Zero matches yield an empty vector (DuckDB raises its
+  /// standard no-files error).
   duckdb::vector<duckdb::OpenFileInfo> Glob(const std::string& path,
                                             duckdb::FileOpener* opener = nullptr) override;
 
@@ -111,6 +124,17 @@ class sirius_httpfs : public duckdb::FileSystem {
  protected:
   bool SupportsOpenFileExtended() const override { return true; }
 };
+
+/// Escape a literal S3 object key for embedding into an @c s3:// URI so the
+/// later @c sirius::io::parse() of that URI restores the exact key bytes.
+/// LIST returns keys as literal bytes, but the open path treats the produced
+/// string as a URI — @c '#' starts a fragment, @c '?' starts a query, and
+/// @c %xx percent-decodes — so exactly those three bytes are escaped
+/// (@c '%'→"%25" first, then @c '#'→"%23", @c '?'→"%3F"). Every other byte,
+/// including @c '/', @c '=' and space, stays literal: hive-partition path
+/// text (@c col=a b/) must survive unchanged. Identity for keys without
+/// @c %/#/?, i.e. every plain key round-trips byte-identically.
+std::string escape_s3_key_for_uri(std::string_view key);
 
 /// Expand an @c s3:// glob @p pattern into concrete object URIs via one
 /// paginated ListObjectsV2 sweep, streamed page-by-page (peak memory = one

--- a/src/include/io/s3/sirius_httpfs.hpp
+++ b/src/include/io/s3/sirius_httpfs.hpp
@@ -70,17 +70,10 @@ class sirius_httpfs : public duckdb::FileSystem {
     duckdb::FileOpenFlags flags,
     duckdb::optional_ptr<duckdb::FileOpener> opener = nullptr) override;
 
-  /// Extended open: when @p file carries a @c "file_size" option (a
-  /// non-negative BIGINT — the LIST-provided size @ref Glob attaches), the
-  /// datasource is opened through the parquet-footer-probe seam: ONE
-  /// suffix-range GET resolves the size from Content-Range (no HEAD) and
-  /// stashes the trailing bytes for the binder's footer reads. The size value
-  /// itself only discriminates this extended open from the plain fallback —
-  /// the probe re-derives the authoritative size from the response. A missing /
-  /// wrong-typed / negative option silently falls back to the plain open path
-  /// (HEAD, then ranged GETs) — third-party-populated @c OpenFileInfo must not
-  /// break the open. Non-parquet files opened this way still read correctly;
-  /// they just pay for a stashed tail that no footer read consumes.
+  /// A valid LIST-provided @c "file_size" option (the non-negative BIGINT
+  /// @ref Glob attaches) selects the parquet footer probe, which resolves size
+  /// and stashes the suffix in one GET. Invalid metadata falls back to the
+  /// regular HEAD-based open.
   duckdb::unique_ptr<duckdb::FileHandle> OpenFileExtended(
     const duckdb::OpenFileInfo& file,
     duckdb::FileOpenFlags flags,
@@ -95,22 +88,13 @@ class sirius_httpfs : public duckdb::FileSystem {
   int64_t GetFileSize(duckdb::FileHandle& handle) override;
   duckdb::timestamp_t GetLastModifiedTime(duckdb::FileHandle& handle) override;
 
-  /// Exact key: returns @c {path} when @ref CanHandleFile, else empty. A
-  /// glob/wildcard pattern expands via one paginated S3 LIST (through the
-  /// connection's scan_manager — see @ref expand_glob), gated like @ref
-  /// OpenFile: requires a resolvable @c ClientContext, @c gpu_execution
-  /// enabled, and no active CPU-fallback replay. Each match carries its
-  /// LIST-provided size in the extended info so the subsequent open needs no
-  /// HEAD (one suffix-range GET instead — see @ref OpenFileExtended). Match
-  /// paths embed the literal LIST key via @ref escape_s3_key_for_uri: keys
-  /// containing @c #, @c ? or a bare @c % show the escaped form in the path
-  /// text (and in the @c filename virtual column) but open the exact object.
-  /// A matched key containing a percent-encoded sequence (@c % followed by
-  /// two hex digits) throws instead — DuckDB URL-decodes hive partition
-  /// values from the path once, so no single path text can serve both the
-  /// open and hive semantics for such keys; full support is a tracked
-  /// follow-up. Zero matches yield an empty vector (DuckDB raises its
-  /// standard no-files error).
+  /// Exact key: returns @c {path} when @ref CanHandleFile. A glob pattern
+  /// expands via one paginated S3 LIST (see @ref expand_glob) under four
+  /// contracts: it is gated like @ref OpenFile (resolvable @c ClientContext,
+  /// @c gpu_execution on, no CPU-fallback replay); each match carries its
+  /// LIST-provided size so the open needs no HEAD; a matched key containing a
+  /// percent-encoded sequence (@c % + two hex digits) throws; and zero matches
+  /// yield an empty vector.
   duckdb::vector<duckdb::OpenFileInfo> Glob(const std::string& path,
                                             duckdb::FileOpener* opener = nullptr) override;
 

--- a/src/include/io/s3/sirius_sigv4_authorizer.hpp
+++ b/src/include/io/s3/sirius_sigv4_authorizer.hpp
@@ -76,6 +76,15 @@ class sirius_sigv4_presigned_authorizer final : public sirius_sigv4_authorizer_b
                                   s3_request_method method,
                                   std::chrono::seconds timeout) override;
 
+  /// Presigned bucket-level ListObjectsV2: the request params are merged into
+  /// the signed query, so the returned URL carries both the list params and the
+  /// X-Amz-* auth params; headers are empty.
+  /// @throw sirius::io::credential_error on empty bucket, an X-Amz-* key inside
+  ///        @p canonical_query (signing-param smuggling), or SigV4 failure.
+  s3_authorized_request authorize_list(std::string_view bucket,
+                                       std::string_view canonical_query,
+                                       std::chrono::seconds timeout) override;
+
  private:
   std::chrono::seconds _ttl;
 };
@@ -105,6 +114,16 @@ class sirius_sigv4_header_authorizer final : public sirius_sigv4_authorizer_base
   s3_authorized_request authorize(s3_object_ref const& obj,
                                   s3_request_method method,
                                   std::chrono::seconds timeout) override;
+
+  /// Header-signed bucket-level ListObjectsV2: returns a plain
+  /// @c "{scheme}://{host}/{bucket}?{canonical_query}" URL plus the signed
+  /// Authorization / x-amz-* headers. @c timeout is unused (header auth carries
+  /// no explicit expiry).
+  /// @throw sirius::io::credential_error on empty bucket, an X-Amz-* key inside
+  ///        @p canonical_query (signing-param smuggling), or SigV4 failure.
+  s3_authorized_request authorize_list(std::string_view bucket,
+                                       std::string_view canonical_query,
+                                       std::chrono::seconds timeout) override;
 };
 
 }  // namespace sirius::io::s3

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -20,6 +20,7 @@
 #include "exec/scoped_dispatcher.hpp"
 #include "exec/thread_pool.hpp"
 #include "io/datasource_factory.hpp"
+#include "io/s3/s3_list_parser.hpp"
 #include "io/sirius_datasource.hpp"
 #include "op/scan/gpu_ingestible_types.hpp"
 #include "scan_manager/config.hpp"
@@ -45,6 +46,8 @@ namespace cucascade::memory {
 class fixed_size_host_memory_resource;
 }  // namespace cucascade::memory
 
+#include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <span>
@@ -377,6 +380,24 @@ class sirius_scan_manager {
 
   [[nodiscard]] std::shared_ptr<sirius::io::sirius_datasource> create_datasource(
     std::string_view path, sirius::io::open_hint hint = sirius::io::open_hint::generic);
+
+  /// \brief Known-size open: the object's size is already known (e.g. from an
+  ///        S3 ListObjectsV2 response), so a backend whose size discovery costs
+  ///        a round-trip builds the datasource with zero network.
+  [[nodiscard]] std::shared_ptr<sirius::io::sirius_datasource> create_datasource(
+    std::string_view path, std::uint64_t known_size);
+
+  /// \brief Stream ListObjectsV2 pages for @p s3_prefix_uri ("s3://bucket/prefix")
+  ///        to @p sink, one call per page; @p sink returns false to stop early.
+  ///        Routes via @ref ioctx_for_path to the object-store backend (throws a
+  ///        clear error when the path does not resolve to one). page_size /
+  ///        early-stop / @p max_scanned semantics are the backend's
+  ///        (@c rest_ioctx::list_objects_paged).
+  void list_objects_paged(
+    std::string const& s3_prefix_uri,
+    std::size_t page_size,
+    std::function<bool(sirius::io::s3::list_objects_v2_page const&)> const& sink,
+    std::size_t max_scanned = sirius::io::s3::default_max_scanned_objects);
 
  private:
   /// \brief Run providers sequentially: start each, wait on its future, advance.

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -384,7 +384,10 @@ class sirius_scan_manager {
 
   /// \brief Known-size open: the object's size is already known (e.g. from an
   ///        S3 ListObjectsV2 response), so a backend whose size discovery costs
-  ///        a round-trip builds the datasource with zero network.
+  ///        a round-trip builds the datasource with zero network. No production
+  ///        caller today — parquet opens prefer the footer-probe hint (one
+  ///        suffix GET replaces HEAD + footer reads); reserved for the
+  ///        exact-range known-size open of non-footer consumers.
   [[nodiscard]] std::shared_ptr<sirius::io::sirius_datasource> create_datasource(
     std::string_view path, std::uint64_t known_size);
 

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -382,15 +382,6 @@ class sirius_scan_manager {
   [[nodiscard]] std::shared_ptr<sirius::io::sirius_datasource> create_datasource(
     std::string_view path, sirius::io::open_hint hint = sirius::io::open_hint::generic);
 
-  /// \brief Known-size open: the object's size is already known (e.g. from an
-  ///        S3 ListObjectsV2 response), so a backend whose size discovery costs
-  ///        a round-trip builds the datasource with zero network. No production
-  ///        caller today — parquet opens prefer the footer-probe hint (one
-  ///        suffix GET replaces HEAD + footer reads); reserved for the
-  ///        exact-range known-size open of non-footer consumers.
-  [[nodiscard]] std::shared_ptr<sirius::io::sirius_datasource> create_datasource(
-    std::string_view path, std::uint64_t known_size);
-
   /// \brief Stream ListObjectsV2 pages for @p s3_prefix_uri ("s3://bucket/prefix")
   ///        to @p sink, one call per page; @p sink returns false to stop early.
   ///        Routes via @ref ioctx_for_path to the object-store backend (throws a

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -50,6 +50,7 @@ class fixed_size_host_memory_resource;
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -391,13 +392,19 @@ class sirius_scan_manager {
   ///        to @p sink, one call per page; @p sink returns false to stop early.
   ///        Routes via @ref ioctx_for_path to the object-store backend (throws a
   ///        clear error when the path does not resolve to one). page_size /
-  ///        early-stop / @p max_scanned semantics are the backend's
-  ///        (@c rest_ioctx::list_objects_paged).
+  ///        early-stop semantics are the backend's (@c rest_ioctx::list_objects_paged).
+  ///        @p max_scanned unset → the backend's configured cap
+  ///        (@c rest.list_max_scanned); a value overrides it.
   void list_objects_paged(
     std::string const& s3_prefix_uri,
     std::size_t page_size,
     std::function<bool(sirius::io::s3::list_objects_v2_page const&)> const& sink,
-    std::size_t max_scanned = sirius::io::s3::default_max_scanned_objects);
+    std::optional<std::size_t> max_scanned = std::nullopt);
+
+  /// \brief The configured glob-match cap (@c rest.list_max_matches) for the
+  ///        backend @p s3_uri routes to — the glob layer bounds its match set
+  ///        with it. Throws a clear error for a non-object-store path.
+  [[nodiscard]] std::size_t s3_list_max_matches(std::string const& s3_uri);
 
  private:
   /// \brief Run providers sequentially: start each, wait on its future, advance.

--- a/src/io/io_context.cpp
+++ b/src/io/io_context.cpp
@@ -78,8 +78,21 @@ std::unique_ptr<sirius_datasource> sirius_ioctx::open_datasource(std::string pat
                                              create_io_object(std::move(path), hint));
 }
 
+std::unique_ptr<sirius_datasource> sirius_ioctx::open_datasource(std::string path,
+                                                                 std::uint64_t known_size)
+{
+  return std::make_unique<sirius_datasource>(shared_from_this(),
+                                             create_io_object(std::move(path), known_size));
+}
+
 std::shared_ptr<sirius_io_object> sirius_ioctx::create_io_object(std::string path,
                                                                  open_hint /*hint*/)
+{
+  return create_io_object(std::move(path));
+}
+
+std::shared_ptr<sirius_io_object> sirius_ioctx::create_io_object(std::string path,
+                                                                 std::uint64_t /*known_size*/)
 {
   return create_io_object(std::move(path));
 }

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -16,6 +16,7 @@
 
 #include "io/rest/rest_ioctx.hpp"
 
+#include "io/s3/sigv4.hpp"
 #include "io/uri_parser.hpp"
 
 #include <algorithm>
@@ -58,6 +59,73 @@ rest_perf_snapshot rest_ioctx::perf_snapshot() const noexcept
   return agg;
 }
 
+void rest_ioctx::list_objects_paged(
+  std::string_view bucket,
+  std::string_view prefix,
+  std::size_t page_size,
+  std::function<bool(s3::list_objects_v2_page const&)> const& sink,
+  std::size_t max_scanned)
+{
+  if (_reactors.empty()) { throw std::runtime_error("rest_ioctx::list_objects: no reactors"); }
+  std::size_t const clamped = (page_size == 0 || page_size > 1000) ? 1000 : page_size;
+
+  std::size_t scanned = 0;
+  std::string token;
+  bool truncated = false;
+  do {
+    // SigV4 canonical order = byte order of the encoded keys; for these params
+    // that is continuation-token < list-type < max-keys < prefix.
+    std::string query;
+    if (!token.empty()) {
+      query += "continuation-token=";
+      query += s3::uri_encode(token, /*encode_slash=*/true);
+      query += '&';
+    }
+    query += "list-type=2&max-keys=";
+    query += std::to_string(clamped);
+    query += "&prefix=";
+    query += s3::uri_encode(prefix, /*encode_slash=*/true);
+
+    auto const page =
+      s3::parse_list_objects_v2(_reactors.front()->list_page(bucket, prefix, query));
+
+    scanned += page.entries.size();
+    if (scanned > max_scanned) {
+      throw std::runtime_error("rest_ioctx::list_objects: scanned more than " +
+                               std::to_string(max_scanned) + " objects under s3://" +
+                               std::string(bucket) + "/" + std::string(prefix) +
+                               " — narrow the glob prefix");
+    }
+    if (page.is_truncated && page.next_continuation_token.empty()) {
+      throw std::runtime_error(
+        "rest_ioctx::list_objects: truncated ListObjectsV2 page without a continuation token for "
+        "s3://" +
+        std::string(bucket) + "/" + std::string(prefix));
+    }
+    truncated = page.is_truncated;
+    token     = page.next_continuation_token;
+    if (!sink(page)) { return; }
+  } while (truncated);
+}
+
+std::vector<s3::list_entry> rest_ioctx::list_objects(std::string_view bucket,
+                                                     std::string_view prefix,
+                                                     std::size_t page_size,
+                                                     std::size_t max_keys)
+{
+  std::vector<s3::list_entry> out;
+  list_objects_paged(bucket, prefix, page_size, [&](s3::list_objects_v2_page const& page) {
+    if (out.size() + page.entries.size() > max_keys) {
+      throw std::runtime_error("rest_ioctx::list_objects: more than " + std::to_string(max_keys) +
+                               " objects under s3://" + std::string(bucket) + "/" +
+                               std::string(prefix) + " — narrow the glob prefix");
+    }
+    out.insert(out.end(), page.entries.begin(), page.entries.end());
+    return true;
+  });
+  return out;
+}
+
 std::shared_ptr<sirius_io_object> rest_ioctx::create_io_object(std::string path)
 {
   auto parsed = sirius::io::parse(path);
@@ -81,6 +149,22 @@ std::shared_ptr<sirius_io_object> rest_ioctx::create_io_object(std::string path,
     return create_footer_probe_object(std::move(path));
   }
   return create_io_object(std::move(path));
+}
+
+std::shared_ptr<sirius_io_object> rest_ioctx::create_io_object(std::string path,
+                                                               std::uint64_t known_size)
+{
+  auto parsed = sirius::io::parse(path);
+  if (parsed.scheme != "s3") {
+    throw std::invalid_argument("rest_ioctx::create_io_object: unsupported scheme '" +
+                                parsed.scheme + "'");
+  }
+  // The size came from a ListObjectsV2 response: build the io_object with zero
+  // network — no HEAD, no probe.
+  return std::make_shared<rest_io_object>(std::move(path),
+                                          std::move(parsed.host),
+                                          std::move(parsed.path),
+                                          static_cast<size_t>(known_size));
 }
 
 std::shared_ptr<sirius_io_object> rest_ioctx::create_footer_probe_object(std::string path)

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -64,10 +64,12 @@ void rest_ioctx::list_objects_paged(
   std::string_view prefix,
   std::size_t page_size,
   std::function<bool(s3::list_objects_v2_page const&)> const& sink,
-  std::size_t max_scanned)
+  std::optional<std::size_t> max_scanned)
 {
   if (_reactors.empty()) { throw std::runtime_error("rest_ioctx::list_objects: no reactors"); }
   std::size_t const clamped = (page_size == 0 || page_size > 1000) ? 1000 : page_size;
+  std::size_t const scanned_cap =
+    max_scanned.value_or(_reactors.front()->get_config().list_max_scanned);
 
   std::size_t scanned = 0;
   std::string token;
@@ -90,9 +92,9 @@ void rest_ioctx::list_objects_paged(
       s3::parse_list_objects_v2(_reactors.front()->list_page(bucket, prefix, query));
 
     scanned += page.entries.size();
-    if (scanned > max_scanned) {
+    if (scanned > scanned_cap) {
       throw std::runtime_error("rest_ioctx::list_objects: scanned more than " +
-                               std::to_string(max_scanned) + " objects under s3://" +
+                               std::to_string(scanned_cap) + " objects under s3://" +
                                std::string(bucket) + "/" + std::string(prefix) +
                                " — narrow the glob prefix");
     }
@@ -111,12 +113,13 @@ void rest_ioctx::list_objects_paged(
 std::vector<s3::list_entry> rest_ioctx::list_objects(std::string_view bucket,
                                                      std::string_view prefix,
                                                      std::size_t page_size,
-                                                     std::size_t max_keys)
+                                                     std::optional<std::size_t> max_keys)
 {
+  std::size_t const keys_cap = max_keys.value_or(list_max_matches());
   std::vector<s3::list_entry> out;
   list_objects_paged(bucket, prefix, page_size, [&](s3::list_objects_v2_page const& page) {
-    if (out.size() + page.entries.size() > max_keys) {
-      throw std::runtime_error("rest_ioctx::list_objects: more than " + std::to_string(max_keys) +
+    if (out.size() + page.entries.size() > keys_cap) {
+      throw std::runtime_error("rest_ioctx::list_objects: more than " + std::to_string(keys_cap) +
                                " objects under s3://" + std::string(bucket) + "/" +
                                std::string(prefix) + " — narrow the glob prefix");
     }
@@ -124,6 +127,12 @@ std::vector<s3::list_entry> rest_ioctx::list_objects(std::string_view bucket,
     return true;
   });
   return out;
+}
+
+std::size_t rest_ioctx::list_max_matches() const
+{
+  return _reactors.empty() ? s3::default_max_list_objects
+                           : _reactors.front()->get_config().list_max_matches;
 }
 
 std::shared_ptr<sirius_io_object> rest_ioctx::create_io_object(std::string path)

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -55,6 +55,10 @@ rest_perf_snapshot rest_ioctx::perf_snapshot() const noexcept
     agg.terminal_failures_total += s.terminal_failures_total;
     agg.device_stream_sync_total += s.device_stream_sync_total;
     agg.payload_bytes_read_total += s.payload_bytes_read_total;
+    agg.native_footer_get_count += s.native_footer_get_count;
+    agg.native_footer_wall_ns_total += s.native_footer_wall_ns_total;
+    agg.native_footer_wall_ns_max =
+      std::max(agg.native_footer_wall_ns_max, s.native_footer_wall_ns_max);
   }
   return agg;
 }

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -108,14 +108,9 @@ void rest_ioctx::list_objects_paged(
         "s3://" +
         std::string(bucket) + "/" + std::string(prefix));
     }
-    // Loop-termination guards: the scanned cap above only advances with the
-    // entry count, so a non-conformant backend that keeps answering truncated
-    // pages that add no entries (same token, alternating tokens, or empty
-    // pages) would otherwise spin this loop forever. We never send a
-    // delimiter, so a conformant non-final page always carries entries; and a
-    // token that does not advance can only refetch the same page. Every
-    // accepted page therefore advances `scanned` by at least one, keeping the
-    // total page count bounded by the scanned cap.
+    // A truncated page must contain entries and advance the token. Together
+    // with scanned_cap these bound pagination for non-conforming backends that
+    // would otherwise loop on empty or non-advancing pages.
     if (page.is_truncated && page.entries.empty()) {
       throw std::runtime_error(
         "rest_ioctx::list_objects: truncated ListObjectsV2 page with no entries for s3://" +

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -55,10 +55,10 @@ rest_perf_snapshot rest_ioctx::perf_snapshot() const noexcept
     agg.terminal_failures_total += s.terminal_failures_total;
     agg.device_stream_sync_total += s.device_stream_sync_total;
     agg.payload_bytes_read_total += s.payload_bytes_read_total;
-    agg.native_footer_get_count += s.native_footer_get_count;
-    agg.native_footer_wall_ns_total += s.native_footer_wall_ns_total;
-    agg.native_footer_wall_ns_max =
-      std::max(agg.native_footer_wall_ns_max, s.native_footer_wall_ns_max);
+    agg.blocking_host_get_count += s.blocking_host_get_count;
+    agg.blocking_host_get_wall_ns_total += s.blocking_host_get_wall_ns_total;
+    agg.blocking_host_get_wall_ns_max =
+      std::max(agg.blocking_host_get_wall_ns_max, s.blocking_host_get_wall_ns_max);
   }
   return agg;
 }

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -108,6 +108,24 @@ void rest_ioctx::list_objects_paged(
         "s3://" +
         std::string(bucket) + "/" + std::string(prefix));
     }
+    // Loop-termination guards: the scanned cap above only advances with the
+    // entry count, so a non-conformant backend that keeps answering truncated
+    // pages that add no entries (same token, alternating tokens, or empty
+    // pages) would otherwise spin this loop forever. We never send a
+    // delimiter, so a conformant non-final page always carries entries; and a
+    // token that does not advance can only refetch the same page. Every
+    // accepted page therefore advances `scanned` by at least one, keeping the
+    // total page count bounded by the scanned cap.
+    if (page.is_truncated && page.entries.empty()) {
+      throw std::runtime_error(
+        "rest_ioctx::list_objects: truncated ListObjectsV2 page with no entries for s3://" +
+        std::string(bucket) + "/" + std::string(prefix));
+    }
+    if (page.is_truncated && page.next_continuation_token == token) {
+      throw std::runtime_error(
+        "rest_ioctx::list_objects: ListObjectsV2 continuation token did not advance for s3://" +
+        std::string(bucket) + "/" + std::string(prefix));
+    }
     truncated = page.is_truncated;
     token     = page.next_continuation_token;
     if (!sink(page)) { return; }

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -1544,14 +1544,9 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
             static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
                                          std::chrono::steady_clock::now() - req.t_submit)
                                          .count());
-          // chunk_get_count keeps its established meaning — every completed
-          // ranged GET, blocking host_reads included (the #1087 s3-bench
-          // bind_chunk_get and the routing-perf tests depend on that).  The
-          // blocking_host_get_* counters are an ADDITIONAL view: a blocking
-          // single host_read (e.g. the native parquet binder's footer /
-          // metadata fetch, or any other synchronous read) bumps both, so the
-          // blocking-read phase stays readable without changing chunk_get's
-          // semantics.
+          // Every completed ranged GET bumps chunk_get_*, blocking host_reads
+          // included. A blocking single host_read additionally bumps
+          // blocking_host_get_* — the two are additive, not disjoint.
           _perf.chunk_get_ns_total.fetch_add(get_ns, std::memory_order_relaxed);
           _perf.chunk_get_count.fetch_add(1, std::memory_order_relaxed);
           atomic_max_relaxed(_perf.chunk_get_ns_max, get_ns);

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -519,7 +519,8 @@ void rest_reactor::enqueue_chunks(std::span<std::unique_ptr<rest_chunked_rx_requ
 
 rest_reactor::request_type_ptr rest_reactor::prep_host_rx_request(const reactor_config_type& cfg,
                                                                   const io_object_type& file,
-                                                                  const io_object_segment& segment)
+                                                                  const io_object_segment& segment,
+                                                                  bool perf_footer_read)
 {
   if (segment.size == 0) { return rest_rx_request::create({}); }
 
@@ -556,12 +557,13 @@ rest_reactor::request_type_ptr rest_reactor::prep_host_rx_request(const reactor_
   chunks.reserve(n_chunks);
   size_t pos = 0;  // byte offset within the segment
   for (size_t c = 0; c < n_chunks; ++c) {
-    size_t const piece = base + (c < rem ? 1 : 0);
-    auto req           = std::make_unique<rest_chunked_rx_request>();
-    req->object        = obj;
-    req->chunk         = io_object_segment{segment.offset + pos, piece, dst + pos};
-    req->file_size     = fsize;
-    req->manager       = manager;
+    size_t const piece    = base + (c < rem ? 1 : 0);
+    auto req              = std::make_unique<rest_chunked_rx_request>();
+    req->object           = obj;
+    req->chunk            = io_object_segment{segment.offset + pos, piece, dst + pos};
+    req->file_size        = fsize;
+    req->manager          = manager;
+    req->perf_footer_read = perf_footer_read;
     chunks.push_back(std::move(req));
     pos += piece;
   }
@@ -785,7 +787,8 @@ size_t rest_reactor::host_read(const io_object_type& file, size_t offset, size_t
   // full TCP+TLS handshake per call and duplicates the retry logic.  Build the
   // request, grab its future BEFORE enqueue (which moves the chunks out), then
   // block: get() rethrows the first reported error or returns the byte count.
-  auto req = prep_host_rx_request(_config, file, io_object_segment{offset, size, dst});
+  auto req = prep_host_rx_request(
+    _config, file, io_object_segment{offset, size, dst}, /*perf_footer_read=*/true);
   auto fut = req->get_future();
   enqueue(std::move(req));
   return std::move(fut).get();
@@ -794,19 +797,22 @@ size_t rest_reactor::host_read(const io_object_type& file, size_t offset, size_t
 rest_perf_snapshot rest_reactor::perf_snapshot() const noexcept
 {
   rest_perf_snapshot s;
-  s.chunk_get_ns_total       = _perf.chunk_get_ns_total.load(std::memory_order_relaxed);
-  s.chunk_get_count          = _perf.chunk_get_count.load(std::memory_order_relaxed);
-  s.chunk_get_ns_max         = _perf.chunk_get_ns_max.load(std::memory_order_relaxed);
-  s.queue_wait_ns_total      = _perf.queue_wait_ns_total.load(std::memory_order_relaxed);
-  s.queue_wait_count         = _perf.queue_wait_count.load(std::memory_order_relaxed);
-  s.ttfb_ns                  = _perf.ttfb_ns.load(std::memory_order_relaxed);
-  s.h2d_observed_ns_total    = _perf.h2d_observed_ns_total.load(std::memory_order_relaxed);
-  s.h2d_observed_count       = _perf.h2d_observed_count.load(std::memory_order_relaxed);
-  s.h2d_observed_ns_max      = _perf.h2d_observed_ns_max.load(std::memory_order_relaxed);
-  s.retries_total            = _perf.retries_total.load(std::memory_order_relaxed);
-  s.terminal_failures_total  = _perf.terminal_failures_total.load(std::memory_order_relaxed);
-  s.device_stream_sync_total = _perf.device_stream_sync_total.load(std::memory_order_relaxed);
-  s.payload_bytes_read_total = _perf.payload_bytes_read_total.load(std::memory_order_relaxed);
+  s.chunk_get_ns_total          = _perf.chunk_get_ns_total.load(std::memory_order_relaxed);
+  s.chunk_get_count             = _perf.chunk_get_count.load(std::memory_order_relaxed);
+  s.chunk_get_ns_max            = _perf.chunk_get_ns_max.load(std::memory_order_relaxed);
+  s.queue_wait_ns_total         = _perf.queue_wait_ns_total.load(std::memory_order_relaxed);
+  s.queue_wait_count            = _perf.queue_wait_count.load(std::memory_order_relaxed);
+  s.ttfb_ns                     = _perf.ttfb_ns.load(std::memory_order_relaxed);
+  s.h2d_observed_ns_total       = _perf.h2d_observed_ns_total.load(std::memory_order_relaxed);
+  s.h2d_observed_count          = _perf.h2d_observed_count.load(std::memory_order_relaxed);
+  s.h2d_observed_ns_max         = _perf.h2d_observed_ns_max.load(std::memory_order_relaxed);
+  s.retries_total               = _perf.retries_total.load(std::memory_order_relaxed);
+  s.terminal_failures_total     = _perf.terminal_failures_total.load(std::memory_order_relaxed);
+  s.device_stream_sync_total    = _perf.device_stream_sync_total.load(std::memory_order_relaxed);
+  s.payload_bytes_read_total    = _perf.payload_bytes_read_total.load(std::memory_order_relaxed);
+  s.native_footer_get_count     = _perf.native_footer_get_count.load(std::memory_order_relaxed);
+  s.native_footer_wall_ns_total = _perf.native_footer_wall_ns_total.load(std::memory_order_relaxed);
+  s.native_footer_wall_ns_max   = _perf.native_footer_wall_ns_max.load(std::memory_order_relaxed);
   return s;
 }
 
@@ -1536,11 +1542,23 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
             static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
                                          std::chrono::steady_clock::now() - req.t_submit)
                                          .count());
+          // chunk_get_count keeps its established meaning — every completed
+          // ranged GET, footer host_reads included (the #1087 s3-bench
+          // bind_chunk_get and the routing-perf tests depend on that).  The
+          // native_footer_* counters are an ADDITIONAL, footer-isolated view: a
+          // blocking single host_read (the native parquet binder's footer /
+          // metadata fetch) bumps both, so A0 can read the footer phase without
+          // changing chunk_get's semantics.
           _perf.chunk_get_ns_total.fetch_add(get_ns, std::memory_order_relaxed);
           _perf.chunk_get_count.fetch_add(1, std::memory_order_relaxed);
           atomic_max_relaxed(_perf.chunk_get_ns_max, get_ns);
           std::uint64_t expected = 0;
           _perf.ttfb_ns.compare_exchange_strong(expected, get_ns, std::memory_order_relaxed);
+          if (req.perf_footer_read) {
+            _perf.native_footer_get_count.fetch_add(1, std::memory_order_relaxed);
+            _perf.native_footer_wall_ns_total.fetch_add(get_ns, std::memory_order_relaxed);
+            atomic_max_relaxed(_perf.native_footer_wall_ns_max, get_ns);
+          }
         }
         if (req.is_device()) {
           // Issue the async H2D copy.  Bounce-staged reads need a CUDA event so

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -520,7 +520,7 @@ void rest_reactor::enqueue_chunks(std::span<std::unique_ptr<rest_chunked_rx_requ
 rest_reactor::request_type_ptr rest_reactor::prep_host_rx_request(const reactor_config_type& cfg,
                                                                   const io_object_type& file,
                                                                   const io_object_segment& segment,
-                                                                  bool perf_footer_read)
+                                                                  bool perf_blocking_host_get)
 {
   if (segment.size == 0) { return rest_rx_request::create({}); }
 
@@ -557,13 +557,13 @@ rest_reactor::request_type_ptr rest_reactor::prep_host_rx_request(const reactor_
   chunks.reserve(n_chunks);
   size_t pos = 0;  // byte offset within the segment
   for (size_t c = 0; c < n_chunks; ++c) {
-    size_t const piece    = base + (c < rem ? 1 : 0);
-    auto req              = std::make_unique<rest_chunked_rx_request>();
-    req->object           = obj;
-    req->chunk            = io_object_segment{segment.offset + pos, piece, dst + pos};
-    req->file_size        = fsize;
-    req->manager          = manager;
-    req->perf_footer_read = perf_footer_read;
+    size_t const piece          = base + (c < rem ? 1 : 0);
+    auto req                    = std::make_unique<rest_chunked_rx_request>();
+    req->object                 = obj;
+    req->chunk                  = io_object_segment{segment.offset + pos, piece, dst + pos};
+    req->file_size              = fsize;
+    req->manager                = manager;
+    req->perf_blocking_host_get = perf_blocking_host_get;
     chunks.push_back(std::move(req));
     pos += piece;
   }
@@ -788,7 +788,7 @@ size_t rest_reactor::host_read(const io_object_type& file, size_t offset, size_t
   // request, grab its future BEFORE enqueue (which moves the chunks out), then
   // block: get() rethrows the first reported error or returns the byte count.
   auto req = prep_host_rx_request(
-    _config, file, io_object_segment{offset, size, dst}, /*perf_footer_read=*/true);
+    _config, file, io_object_segment{offset, size, dst}, /*perf_blocking_host_get=*/true);
   auto fut = req->get_future();
   enqueue(std::move(req));
   return std::move(fut).get();
@@ -797,22 +797,24 @@ size_t rest_reactor::host_read(const io_object_type& file, size_t offset, size_t
 rest_perf_snapshot rest_reactor::perf_snapshot() const noexcept
 {
   rest_perf_snapshot s;
-  s.chunk_get_ns_total          = _perf.chunk_get_ns_total.load(std::memory_order_relaxed);
-  s.chunk_get_count             = _perf.chunk_get_count.load(std::memory_order_relaxed);
-  s.chunk_get_ns_max            = _perf.chunk_get_ns_max.load(std::memory_order_relaxed);
-  s.queue_wait_ns_total         = _perf.queue_wait_ns_total.load(std::memory_order_relaxed);
-  s.queue_wait_count            = _perf.queue_wait_count.load(std::memory_order_relaxed);
-  s.ttfb_ns                     = _perf.ttfb_ns.load(std::memory_order_relaxed);
-  s.h2d_observed_ns_total       = _perf.h2d_observed_ns_total.load(std::memory_order_relaxed);
-  s.h2d_observed_count          = _perf.h2d_observed_count.load(std::memory_order_relaxed);
-  s.h2d_observed_ns_max         = _perf.h2d_observed_ns_max.load(std::memory_order_relaxed);
-  s.retries_total               = _perf.retries_total.load(std::memory_order_relaxed);
-  s.terminal_failures_total     = _perf.terminal_failures_total.load(std::memory_order_relaxed);
-  s.device_stream_sync_total    = _perf.device_stream_sync_total.load(std::memory_order_relaxed);
-  s.payload_bytes_read_total    = _perf.payload_bytes_read_total.load(std::memory_order_relaxed);
-  s.native_footer_get_count     = _perf.native_footer_get_count.load(std::memory_order_relaxed);
-  s.native_footer_wall_ns_total = _perf.native_footer_wall_ns_total.load(std::memory_order_relaxed);
-  s.native_footer_wall_ns_max   = _perf.native_footer_wall_ns_max.load(std::memory_order_relaxed);
+  s.chunk_get_ns_total       = _perf.chunk_get_ns_total.load(std::memory_order_relaxed);
+  s.chunk_get_count          = _perf.chunk_get_count.load(std::memory_order_relaxed);
+  s.chunk_get_ns_max         = _perf.chunk_get_ns_max.load(std::memory_order_relaxed);
+  s.queue_wait_ns_total      = _perf.queue_wait_ns_total.load(std::memory_order_relaxed);
+  s.queue_wait_count         = _perf.queue_wait_count.load(std::memory_order_relaxed);
+  s.ttfb_ns                  = _perf.ttfb_ns.load(std::memory_order_relaxed);
+  s.h2d_observed_ns_total    = _perf.h2d_observed_ns_total.load(std::memory_order_relaxed);
+  s.h2d_observed_count       = _perf.h2d_observed_count.load(std::memory_order_relaxed);
+  s.h2d_observed_ns_max      = _perf.h2d_observed_ns_max.load(std::memory_order_relaxed);
+  s.retries_total            = _perf.retries_total.load(std::memory_order_relaxed);
+  s.terminal_failures_total  = _perf.terminal_failures_total.load(std::memory_order_relaxed);
+  s.device_stream_sync_total = _perf.device_stream_sync_total.load(std::memory_order_relaxed);
+  s.payload_bytes_read_total = _perf.payload_bytes_read_total.load(std::memory_order_relaxed);
+  s.blocking_host_get_count  = _perf.blocking_host_get_count.load(std::memory_order_relaxed);
+  s.blocking_host_get_wall_ns_total =
+    _perf.blocking_host_get_wall_ns_total.load(std::memory_order_relaxed);
+  s.blocking_host_get_wall_ns_max =
+    _perf.blocking_host_get_wall_ns_max.load(std::memory_order_relaxed);
   return s;
 }
 
@@ -1543,21 +1545,22 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
                                          std::chrono::steady_clock::now() - req.t_submit)
                                          .count());
           // chunk_get_count keeps its established meaning — every completed
-          // ranged GET, footer host_reads included (the #1087 s3-bench
+          // ranged GET, blocking host_reads included (the #1087 s3-bench
           // bind_chunk_get and the routing-perf tests depend on that).  The
-          // native_footer_* counters are an ADDITIONAL, footer-isolated view: a
-          // blocking single host_read (the native parquet binder's footer /
-          // metadata fetch) bumps both, so A0 can read the footer phase without
-          // changing chunk_get's semantics.
+          // blocking_host_get_* counters are an ADDITIONAL view: a blocking
+          // single host_read (e.g. the native parquet binder's footer /
+          // metadata fetch, or any other synchronous read) bumps both, so the
+          // blocking-read phase stays readable without changing chunk_get's
+          // semantics.
           _perf.chunk_get_ns_total.fetch_add(get_ns, std::memory_order_relaxed);
           _perf.chunk_get_count.fetch_add(1, std::memory_order_relaxed);
           atomic_max_relaxed(_perf.chunk_get_ns_max, get_ns);
           std::uint64_t expected = 0;
           _perf.ttfb_ns.compare_exchange_strong(expected, get_ns, std::memory_order_relaxed);
-          if (req.perf_footer_read) {
-            _perf.native_footer_get_count.fetch_add(1, std::memory_order_relaxed);
-            _perf.native_footer_wall_ns_total.fetch_add(get_ns, std::memory_order_relaxed);
-            atomic_max_relaxed(_perf.native_footer_wall_ns_max, get_ns);
+          if (req.perf_blocking_host_get) {
+            _perf.blocking_host_get_count.fetch_add(1, std::memory_order_relaxed);
+            _perf.blocking_host_get_wall_ns_total.fetch_add(get_ns, std::memory_order_relaxed);
+            atomic_max_relaxed(_perf.blocking_host_get_wall_ns_max, get_ns);
           }
         }
         if (req.is_device()) {

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -97,6 +97,15 @@ size_t write_discard(char* /*ptr*/, size_t size, size_t nmemb, void* /*userdata*
   return size * nmemb;
 }
 
+/// Accumulate the whole response body into a std::string (small control-plane
+/// responses only — e.g. one ListObjectsV2 XML page).
+size_t write_string(char* ptr, size_t size, size_t nmemb, void* userdata)
+{
+  auto* out = static_cast<std::string*>(userdata);
+  out->append(ptr, size * nmemb);
+  return size * nmemb;
+}
+
 /// Lowercase a byte.
 char ascii_lower(char c) { return static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
 
@@ -861,6 +870,66 @@ size_t rest_reactor::head_object_size(std::string_view bucket, std::string_view 
   _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
   throw std::runtime_error("rest_reactor::head_object_size: exhausted retries (" + last_error +
                            ") for " + obj.bucket + "/" + obj.key);
+}
+
+std::string rest_reactor::list_page(std::string_view bucket,
+                                    std::string_view prefix,
+                                    std::string_view canonical_query)
+{
+  std::string const bucket_s{bucket};
+  std::string const prefix_s{prefix};
+  std::string last_error;
+  for (std::size_t attempt = 0; attempt < _config.max_retry_attempts; ++attempt) {
+    header_capture hc;
+    auto const authd = _ctx->authorizer()->authorize_list(
+      bucket_s, std::string{canonical_query}, presign_ttl(_config));
+
+    curl_easy_ptr h{curl_easy_init()};
+    if (!h) { throw std::runtime_error("rest_reactor::list_page: curl_easy_init failed"); }
+    configure_easy_handle(h.get(), global_curl_context::instance().share_handle());
+    apply_request_opts(h.get(), _config);
+
+    std::string body;
+    curl_slist_ptr hdrs = build_header_list(authd.headers, nullptr);
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_URL, authd.url.c_str()));
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HTTPGET, 1L));
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HTTPHEADER, hdrs.get()));
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_WRITEFUNCTION, &write_string));
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_WRITEDATA, &body));
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HEADERFUNCTION, &capture_header));
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HEADERDATA, &hc));
+
+    CURLcode const rc = curl_easy_perform(h.get());
+    long status       = 0;
+    curl_easy_getinfo(h.get(), CURLINFO_RESPONSE_CODE, &status);
+
+    // Control-plane response: the XML body is deliberately NOT credited to
+    // chunk_get_count / payload_bytes_read_total — those budget object reads.
+    if (rc == CURLE_OK && status == 200) { return body; }
+
+    last_error =
+      rc != CURLE_OK ? std::string(curl_easy_strerror(rc)) : ("HTTP " + std::to_string(status));
+    bool const retriable =
+      (rc != CURLE_OK && is_retriable_curl(rc)) || (rc == CURLE_OK && is_retriable_status(status));
+    if (!retriable) {
+      _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
+      throw std::runtime_error("rest_reactor::list_page: " + last_error + " for " + bucket_s + "/" +
+                               prefix_s);
+    }
+    if (attempt + 1 < _config.max_retry_attempts) {
+      _perf.retries_total.fetch_add(1, std::memory_order_relaxed);
+      SIRIUS_LOG_WARN("rest_reactor::list_page: retrying {}/{} after {} (attempt {}/{})",
+                      bucket_s,
+                      prefix_s,
+                      last_error,
+                      attempt + 1,
+                      _config.max_retry_attempts);
+      std::this_thread::sleep_for(compute_backoff(attempt, hc.retry_after, _config));
+    }
+  }
+  _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
+  throw std::runtime_error("rest_reactor::list_page: exhausted retries (" + last_error + ") for " +
+                           bucket_s + "/" + prefix_s);
 }
 
 footer_probe rest_reactor::fetch_footer_suffix(std::string_view bucket,

--- a/src/io/s3/s3_list_parser.cpp
+++ b/src/io/s3/s3_list_parser.cpp
@@ -17,6 +17,7 @@
 #include "io/s3/s3_list_parser.hpp"
 
 #include <cctype>
+#include <limits>
 #include <optional>
 #include <stdexcept>
 
@@ -106,7 +107,14 @@ std::uint64_t parse_size(std::string_view raw)
       throw std::runtime_error("parse_list_objects_v2: non-numeric <Size> '" + std::string{text} +
                                "' in <Contents>");
     }
-    value = value * 10 + static_cast<std::uint64_t>(c - '0');
+    auto const digit = static_cast<std::uint64_t>(c - '0');
+    // Guard the accumulation: a wrapped-small size is later trusted to skip the
+    // HEAD in the known-size open, so an overflow would silently truncate reads.
+    if (value > (std::numeric_limits<std::uint64_t>::max() - digit) / 10) {
+      throw std::runtime_error("parse_list_objects_v2: <Size> '" + std::string{text} +
+                               "' overflows uint64 in <Contents>");
+    }
+    value = value * 10 + digit;
   }
   return value;
 }
@@ -118,6 +126,15 @@ list_objects_v2_page parse_list_objects_v2(std::string_view xml)
   if (xml.find("<ListBucketResult") == std::string_view::npos) {
     throw std::runtime_error(
       "parse_list_objects_v2: not a ListObjectsV2 response (no <ListBucketResult>)");
+  }
+  // Require the root close tag: a body truncated before it (a malformed /
+  // partial 200 from an S3-compatible gateway) would otherwise parse as a
+  // "valid" page with is_truncated defaulting to false — the paged loop would
+  // believe the listing is complete and a glob would silently drop every object
+  // past the cut. Real S3/MinIO always close the root.
+  if (xml.find("</ListBucketResult>") == std::string_view::npos) {
+    throw std::runtime_error(
+      "parse_list_objects_v2: truncated ListObjectsV2 response (missing </ListBucketResult>)");
   }
 
   list_objects_v2_page page;
@@ -133,10 +150,15 @@ list_objects_v2_page parse_list_objects_v2(std::string_view xml)
   constexpr std::string_view k_contents_close = "</Contents>";
   for (std::size_t pos = 0;;) {
     auto const co = xml.find(k_contents_open, pos);
-    if (co == std::string_view::npos) { break; }
+    if (co == std::string_view::npos) { break; }  // no more objects — clean end
     auto const block_begin = co + k_contents_open.size();
     auto const ce          = xml.find(k_contents_close, block_begin);
-    if (ce == std::string_view::npos) { break; }
+    if (ce == std::string_view::npos) {
+      // An opened <Contents> with no close is a mid-block truncation — throw
+      // rather than silently returning the objects parsed so far.
+      throw std::runtime_error(
+        "parse_list_objects_v2: truncated ListObjectsV2 page (unclosed <Contents>)");
+    }
     auto const block = xml.substr(block_begin, ce - block_begin);
     if (auto const key = element_text(block, "Key"); key.has_value()) {
       auto const size = element_text(block, "Size");

--- a/src/io/s3/s3_list_parser.cpp
+++ b/src/io/s3/s3_list_parser.cpp
@@ -123,12 +123,12 @@ std::uint64_t parse_size(std::string_view raw)
 
 list_objects_v2_page parse_list_objects_v2(std::string_view xml)
 {
+  // Fail closed: a malformed body must never parse as a silently-incomplete
+  // listing (dropped objects), nor let elements outside the root steer paging.
   constexpr std::string_view k_root_open  = "<ListBucketResult";
   constexpr std::string_view k_root_close = "</ListBucketResult>";
-  // The root open tag must be exactly <ListBucketResult, terminated by '>' or
-  // XML whitespace (attributes follow) — a prefix match alone would accept a
-  // bogus root like <ListBucketResultBogus> and parse its content as a real
-  // listing.
+  // Reject root-name prefix matches: <ListBucketResult must end at '>' or XML
+  // whitespace, else <ListBucketResultBogus> would parse as a real listing.
   auto const is_xml_space = [](char c) { return c == ' ' || c == '\t' || c == '\r' || c == '\n'; };
   std::size_t root_open   = std::string_view::npos;
   for (auto cand = xml.find(k_root_open); cand != std::string_view::npos;
@@ -143,10 +143,7 @@ list_objects_v2_page parse_list_objects_v2(std::string_view xml)
     throw std::runtime_error(
       "parse_list_objects_v2: not a ListObjectsV2 response (no <ListBucketResult>)");
   }
-  // Only whitespace and one optional <?xml ...?> prologue may precede the
-  // root: any other leading content (a wrapper element, a comment, a second
-  // document) marks a body this parser does not understand — fail closed
-  // rather than silently skipping it.
+  // Only an optional XML declaration may precede the root.
   auto const pre = trim(xml.substr(0, root_open));
   if (!pre.empty()) {
     bool prologue_only = false;
@@ -159,24 +156,15 @@ list_objects_v2_page parse_list_objects_v2(std::string_view xml)
         "parse_list_objects_v2: unexpected content before <ListBucketResult>");
     }
   }
-  // Window every scan below to the root element's CONTENT. Elements placed
-  // outside the root (a <Contents>, <IsTruncated> or continuation token after
-  // the close tag) must never be honored as results — an injected token could
-  // even steer the pagination loop. The window starts after the open tag's '>'
-  // (tolerating the xmlns attribute and any prologue before the root), and the
-  // close is searched AFTER the open, so a close-before-open body is rejected
-  // as truncated for free.
+  // Restrict all field lookup below to the root element's content. The window
+  // starts after the open tag's '>'; the close is searched after the open, so a
+  // close-before-open (or absent close) body is rejected as truncated.
   auto const root_open_end = xml.find('>', root_open + k_root_open.size());
   if (root_open_end == std::string_view::npos) {
     throw std::runtime_error(
       "parse_list_objects_v2: truncated ListObjectsV2 response (unterminated <ListBucketResult> "
       "open tag)");
   }
-  // Require the root close tag: a body truncated before it (a malformed /
-  // partial 200 from an S3-compatible gateway) would otherwise parse as a
-  // "valid" page with is_truncated defaulting to false — the paged loop would
-  // believe the listing is complete and a glob would silently drop every object
-  // past the cut. Real S3/MinIO always close the root.
   auto const root_close = xml.find(k_root_close, root_open_end + 1);
   if (root_close == std::string_view::npos) {
     throw std::runtime_error(
@@ -186,16 +174,10 @@ list_objects_v2_page parse_list_objects_v2(std::string_view xml)
 
   list_objects_v2_page page;
 
-  // Object entries: the <Key>/<Size> inside each <Contents> block. Scoping to
-  // <Contents> (rather than scanning every <Key> in the document) keeps a stray
-  // <Key> that an S3-compatible service might place elsewhere — or a future
-  // response extension — from being mistaken for an object key. <CommonPrefixes>
-  // rollups use <Prefix>, so they are excluded for free. A <Contents> without a
-  // present, closed, non-empty <Key> or without a parseable <Size> throws: AWS
-  // documents both as always present, so their absence means a mangled body —
-  // silently skipping the entry would make a glob drop the object with no
-  // error, and downstream opens rely on the LIST-provided size to skip their
-  // size-discovery round-trip, so a silent zero would corrupt reads.
+  // Parse Key and Size only from complete <Contents> elements; scoping to the
+  // block excludes stray <Key>s and <CommonPrefixes> rollups. A missing Key or
+  // Size means a mangled body (both are always present), so throw rather than
+  // drop the entry or open with a zero size.
   constexpr std::string_view k_contents_open  = "<Contents>";
   constexpr std::string_view k_contents_close = "</Contents>";
   for (std::size_t pos = 0;;) {
@@ -229,10 +211,8 @@ list_objects_v2_page parse_list_objects_v2(std::string_view xml)
     pos = ce + k_contents_close.size();
   }
 
-  // <IsTruncated> is mandatory and strictly boolean. AWS documents it as always
-  // present; a page missing it (or carrying anything but true/false) is a
-  // mangled body, and defaulting to "not truncated" would end the paged loop
-  // early — a glob would silently treat a partial listing as complete.
+  // IsTruncated is required and strictly boolean; defaulting a missing/garbage
+  // value to "not truncated" would end the paged loop on a partial listing.
   auto const truncated = element_text(body, "IsTruncated");
   if (!truncated.has_value()) {
     throw std::runtime_error(
@@ -251,19 +231,15 @@ list_objects_v2_page parse_list_objects_v2(std::string_view xml)
   if (auto const token = element_text(body, "NextContinuationToken"); token.has_value()) {
     page.next_continuation_token = xml_unescape(trim(*token));
   } else if (page.is_truncated) {
-    // A truncated page must carry the token that fetches the next page; without
-    // it the listing cannot be completed and must not be treated as complete.
-    // (An empty <NextContinuationToken></NextContinuationToken> passes here and
-    // is rejected by the paged caller — the parser validates body shape only.)
+    // A truncated page must carry the token for the next page. (An empty token
+    // element passes here and is rejected by the paged caller.)
     throw std::runtime_error(
       "parse_list_objects_v2: truncated ListObjectsV2 page without a continuation token "
       "(<NextContinuationToken> missing)");
   }
 
-  // Reject non-whitespace content after the root close. Checked LAST so a
-  // malformed window (missing <IsTruncated>, token-less truncated page) reports
-  // its own, more specific error first; nothing here was honored either way —
-  // every scan above is window-scoped.
+  // Reject non-whitespace content after the root close. Checked last so a
+  // malformed window reports its own, more specific error first.
   if (!trim(xml.substr(root_close + k_root_close.size())).empty()) {
     throw std::runtime_error("parse_list_objects_v2: unexpected content after </ListBucketResult>");
   }

--- a/src/io/s3/s3_list_parser.cpp
+++ b/src/io/s3/s3_list_parser.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "io/s3/s3_list_parser.hpp"
+
+#include <cctype>
+#include <optional>
+#include <stdexcept>
+
+namespace sirius::io::s3 {
+
+namespace {
+
+// Single-pass unescape of the five predefined XML entities. Unknown sequences
+// (e.g. numeric character references, which S3 does not emit for keys) pass
+// through verbatim.
+std::string xml_unescape(std::string_view s)
+{
+  std::string out;
+  out.reserve(s.size());
+  for (std::size_t i = 0; i < s.size();) {
+    if (s[i] == '&') {
+      if (s.compare(i, 5, "&amp;") == 0) {
+        out += '&';
+        i += 5;
+        continue;
+      }
+      if (s.compare(i, 4, "&lt;") == 0) {
+        out += '<';
+        i += 4;
+        continue;
+      }
+      if (s.compare(i, 4, "&gt;") == 0) {
+        out += '>';
+        i += 4;
+        continue;
+      }
+      if (s.compare(i, 6, "&quot;") == 0) {
+        out += '"';
+        i += 6;
+        continue;
+      }
+      if (s.compare(i, 6, "&apos;") == 0) {
+        out += '\'';
+        i += 6;
+        continue;
+      }
+    }
+    out += s[i];
+    ++i;
+  }
+  return out;
+}
+
+std::string_view trim(std::string_view s)
+{
+  std::size_t b = 0;
+  std::size_t e = s.size();
+  while (b < e && std::isspace(static_cast<unsigned char>(s[b])) != 0) {
+    ++b;
+  }
+  while (e > b && std::isspace(static_cast<unsigned char>(s[e - 1])) != 0) {
+    --e;
+  }
+  return s.substr(b, e - b);
+}
+
+// Raw text between the first `<tag>` and its `</tag>` (these S3 elements carry
+// no attributes), searching from @p from. nullopt when the element is absent.
+std::optional<std::string_view> element_text(std::string_view xml,
+                                             std::string_view tag,
+                                             std::size_t from = 0)
+{
+  std::string const open  = "<" + std::string{tag} + ">";
+  std::string const close = "</" + std::string{tag} + ">";
+  auto const o            = xml.find(open, from);
+  if (o == std::string_view::npos) { return std::nullopt; }
+  auto const s = o + open.size();
+  auto const c = xml.find(close, s);
+  if (c == std::string_view::npos) { return std::nullopt; }
+  return xml.substr(s, c - s);
+}
+
+std::uint64_t parse_size(std::string_view raw)
+{
+  auto const text = trim(raw);
+  if (text.empty()) {
+    throw std::runtime_error("parse_list_objects_v2: empty <Size> in <Contents>");
+  }
+  std::uint64_t value = 0;
+  for (char const c : text) {
+    if (c < '0' || c > '9') {
+      throw std::runtime_error("parse_list_objects_v2: non-numeric <Size> '" + std::string{text} +
+                               "' in <Contents>");
+    }
+    value = value * 10 + static_cast<std::uint64_t>(c - '0');
+  }
+  return value;
+}
+
+}  // namespace
+
+list_objects_v2_page parse_list_objects_v2(std::string_view xml)
+{
+  if (xml.find("<ListBucketResult") == std::string_view::npos) {
+    throw std::runtime_error(
+      "parse_list_objects_v2: not a ListObjectsV2 response (no <ListBucketResult>)");
+  }
+
+  list_objects_v2_page page;
+
+  // Object entries: the <Key>/<Size> inside each <Contents> block. Scoping to
+  // <Contents> (rather than scanning every <Key> in the document) keeps a stray
+  // <Key> that an S3-compatible service might place elsewhere — or a future
+  // response extension — from being mistaken for an object key. <CommonPrefixes>
+  // rollups use <Prefix>, so they are excluded for free. A <Contents> without a
+  // parseable <Size> throws: downstream opens rely on the LIST-provided size to
+  // skip their size-discovery round-trip, so a silent zero would corrupt reads.
+  constexpr std::string_view k_contents_open  = "<Contents>";
+  constexpr std::string_view k_contents_close = "</Contents>";
+  for (std::size_t pos = 0;;) {
+    auto const co = xml.find(k_contents_open, pos);
+    if (co == std::string_view::npos) { break; }
+    auto const block_begin = co + k_contents_open.size();
+    auto const ce          = xml.find(k_contents_close, block_begin);
+    if (ce == std::string_view::npos) { break; }
+    auto const block = xml.substr(block_begin, ce - block_begin);
+    if (auto const key = element_text(block, "Key"); key.has_value()) {
+      auto const size = element_text(block, "Size");
+      if (!size.has_value()) {
+        throw std::runtime_error("parse_list_objects_v2: <Contents> without <Size> for key '" +
+                                 xml_unescape(*key) + "'");
+      }
+      page.entries.push_back({xml_unescape(*key), parse_size(*size)});
+    }
+    pos = ce + k_contents_close.size();
+  }
+
+  if (auto const truncated = element_text(xml, "IsTruncated"); truncated.has_value()) {
+    page.is_truncated = trim(*truncated) == "true";
+  }
+  if (auto const token = element_text(xml, "NextContinuationToken"); token.has_value()) {
+    page.next_continuation_token = xml_unescape(trim(*token));
+  }
+
+  return page;
+}
+
+}  // namespace sirius::io::s3

--- a/src/io/s3/s3_list_parser.cpp
+++ b/src/io/s3/s3_list_parser.cpp
@@ -123,19 +123,66 @@ std::uint64_t parse_size(std::string_view raw)
 
 list_objects_v2_page parse_list_objects_v2(std::string_view xml)
 {
-  if (xml.find("<ListBucketResult") == std::string_view::npos) {
+  constexpr std::string_view k_root_open  = "<ListBucketResult";
+  constexpr std::string_view k_root_close = "</ListBucketResult>";
+  // The root open tag must be exactly <ListBucketResult, terminated by '>' or
+  // XML whitespace (attributes follow) — a prefix match alone would accept a
+  // bogus root like <ListBucketResultBogus> and parse its content as a real
+  // listing.
+  auto const is_xml_space = [](char c) { return c == ' ' || c == '\t' || c == '\r' || c == '\n'; };
+  std::size_t root_open   = std::string_view::npos;
+  for (auto cand = xml.find(k_root_open); cand != std::string_view::npos;
+       cand      = xml.find(k_root_open, cand + 1)) {
+    auto const after = cand + k_root_open.size();
+    if (after < xml.size() && (xml[after] == '>' || is_xml_space(xml[after]))) {
+      root_open = cand;
+      break;
+    }
+  }
+  if (root_open == std::string_view::npos) {
     throw std::runtime_error(
       "parse_list_objects_v2: not a ListObjectsV2 response (no <ListBucketResult>)");
+  }
+  // Only whitespace and one optional <?xml ...?> prologue may precede the
+  // root: any other leading content (a wrapper element, a comment, a second
+  // document) marks a body this parser does not understand — fail closed
+  // rather than silently skipping it.
+  auto const pre = trim(xml.substr(0, root_open));
+  if (!pre.empty()) {
+    bool prologue_only = false;
+    if (pre.substr(0, 5) == "<?xml") {
+      auto const end = pre.find("?>");
+      prologue_only  = end != std::string_view::npos && trim(pre.substr(end + 2)).empty();
+    }
+    if (!prologue_only) {
+      throw std::runtime_error(
+        "parse_list_objects_v2: unexpected content before <ListBucketResult>");
+    }
+  }
+  // Window every scan below to the root element's CONTENT. Elements placed
+  // outside the root (a <Contents>, <IsTruncated> or continuation token after
+  // the close tag) must never be honored as results — an injected token could
+  // even steer the pagination loop. The window starts after the open tag's '>'
+  // (tolerating the xmlns attribute and any prologue before the root), and the
+  // close is searched AFTER the open, so a close-before-open body is rejected
+  // as truncated for free.
+  auto const root_open_end = xml.find('>', root_open + k_root_open.size());
+  if (root_open_end == std::string_view::npos) {
+    throw std::runtime_error(
+      "parse_list_objects_v2: truncated ListObjectsV2 response (unterminated <ListBucketResult> "
+      "open tag)");
   }
   // Require the root close tag: a body truncated before it (a malformed /
   // partial 200 from an S3-compatible gateway) would otherwise parse as a
   // "valid" page with is_truncated defaulting to false — the paged loop would
   // believe the listing is complete and a glob would silently drop every object
   // past the cut. Real S3/MinIO always close the root.
-  if (xml.find("</ListBucketResult>") == std::string_view::npos) {
+  auto const root_close = xml.find(k_root_close, root_open_end + 1);
+  if (root_close == std::string_view::npos) {
     throw std::runtime_error(
       "parse_list_objects_v2: truncated ListObjectsV2 response (missing </ListBucketResult>)");
   }
+  auto const body = xml.substr(root_open_end + 1, root_close - root_open_end - 1);
 
   list_objects_v2_page page;
 
@@ -144,38 +191,81 @@ list_objects_v2_page parse_list_objects_v2(std::string_view xml)
   // <Key> that an S3-compatible service might place elsewhere — or a future
   // response extension — from being mistaken for an object key. <CommonPrefixes>
   // rollups use <Prefix>, so they are excluded for free. A <Contents> without a
-  // parseable <Size> throws: downstream opens rely on the LIST-provided size to
-  // skip their size-discovery round-trip, so a silent zero would corrupt reads.
+  // present, closed, non-empty <Key> or without a parseable <Size> throws: AWS
+  // documents both as always present, so their absence means a mangled body —
+  // silently skipping the entry would make a glob drop the object with no
+  // error, and downstream opens rely on the LIST-provided size to skip their
+  // size-discovery round-trip, so a silent zero would corrupt reads.
   constexpr std::string_view k_contents_open  = "<Contents>";
   constexpr std::string_view k_contents_close = "</Contents>";
   for (std::size_t pos = 0;;) {
-    auto const co = xml.find(k_contents_open, pos);
+    auto const co = body.find(k_contents_open, pos);
     if (co == std::string_view::npos) { break; }  // no more objects — clean end
     auto const block_begin = co + k_contents_open.size();
-    auto const ce          = xml.find(k_contents_close, block_begin);
+    auto const ce          = body.find(k_contents_close, block_begin);
     if (ce == std::string_view::npos) {
       // An opened <Contents> with no close is a mid-block truncation — throw
       // rather than silently returning the objects parsed so far.
       throw std::runtime_error(
         "parse_list_objects_v2: truncated ListObjectsV2 page (unclosed <Contents>)");
     }
-    auto const block = xml.substr(block_begin, ce - block_begin);
-    if (auto const key = element_text(block, "Key"); key.has_value()) {
-      auto const size = element_text(block, "Size");
-      if (!size.has_value()) {
-        throw std::runtime_error("parse_list_objects_v2: <Contents> without <Size> for key '" +
-                                 xml_unescape(*key) + "'");
-      }
-      page.entries.push_back({xml_unescape(*key), parse_size(*size)});
+    auto const block = body.substr(block_begin, ce - block_begin);
+    auto const key   = element_text(block, "Key");
+    if (!key.has_value()) {
+      throw std::runtime_error(
+        "parse_list_objects_v2: malformed ListObjectsV2 page (<Contents> without <Key>)");
     }
+    auto object_key = xml_unescape(*key);
+    if (object_key.empty()) {
+      throw std::runtime_error(
+        "parse_list_objects_v2: malformed ListObjectsV2 page (empty <Key> in <Contents>)");
+    }
+    auto const size = element_text(block, "Size");
+    if (!size.has_value()) {
+      throw std::runtime_error("parse_list_objects_v2: <Contents> without <Size> for key '" +
+                               object_key + "'");
+    }
+    page.entries.push_back({std::move(object_key), parse_size(*size)});
     pos = ce + k_contents_close.size();
   }
 
-  if (auto const truncated = element_text(xml, "IsTruncated"); truncated.has_value()) {
-    page.is_truncated = trim(*truncated) == "true";
+  // <IsTruncated> is mandatory and strictly boolean. AWS documents it as always
+  // present; a page missing it (or carrying anything but true/false) is a
+  // mangled body, and defaulting to "not truncated" would end the paged loop
+  // early — a glob would silently treat a partial listing as complete.
+  auto const truncated = element_text(body, "IsTruncated");
+  if (!truncated.has_value()) {
+    throw std::runtime_error(
+      "parse_list_objects_v2: malformed ListObjectsV2 page (missing <IsTruncated>)");
   }
-  if (auto const token = element_text(xml, "NextContinuationToken"); token.has_value()) {
+  auto const truncated_text = trim(*truncated);
+  if (truncated_text == "true") {
+    page.is_truncated = true;
+  } else if (truncated_text == "false") {
+    page.is_truncated = false;
+  } else {
+    throw std::runtime_error("parse_list_objects_v2: invalid <IsTruncated> value '" +
+                             std::string{truncated_text} + "'");
+  }
+
+  if (auto const token = element_text(body, "NextContinuationToken"); token.has_value()) {
     page.next_continuation_token = xml_unescape(trim(*token));
+  } else if (page.is_truncated) {
+    // A truncated page must carry the token that fetches the next page; without
+    // it the listing cannot be completed and must not be treated as complete.
+    // (An empty <NextContinuationToken></NextContinuationToken> passes here and
+    // is rejected by the paged caller — the parser validates body shape only.)
+    throw std::runtime_error(
+      "parse_list_objects_v2: truncated ListObjectsV2 page without a continuation token "
+      "(<NextContinuationToken> missing)");
+  }
+
+  // Reject non-whitespace content after the root close. Checked LAST so a
+  // malformed window (missing <IsTruncated>, token-less truncated page) reports
+  // its own, more specific error first; nothing here was honored either way —
+  // every scan above is window-scoped.
+  if (!trim(xml.substr(root_close + k_root_close.size())).empty()) {
+    throw std::runtime_error("parse_list_objects_v2: unexpected content after </ListBucketResult>");
   }
 
   return page;

--- a/src/io/s3/sigv4.cpp
+++ b/src/io/s3/sigv4.cpp
@@ -267,7 +267,8 @@ std::string presign_url(std::string_view method,
                         std::string_view canonical_uri,
                         sigv4_signer_config const& creds,
                         std::time_t timestamp_utc,
-                        std::chrono::seconds ttl)
+                        std::chrono::seconds ttl,
+                        std::string_view extra_canonical_query)
 {
   if (creds.access_key.empty() || creds.secret_key.empty() || creds.region.empty() ||
       creds.service.empty()) {
@@ -306,16 +307,39 @@ std::string presign_url(std::string_view method,
   //         encode_slash=true (per AWS query-encoding rules). The
   //         X-Amz-Signature itself is appended *after* signing — it is not
   //         part of the canonical request. ----
+  //         Stored already-encoded so the X-Amz-* parameters and any
+  //         caller-supplied request parameters (@p extra_canonical_query, which
+  //         arrives pre-encoded) can be merged and sorted together by encoded
+  //         key — AWS signs the combined, sorted set.
   std::vector<std::pair<std::string, std::string>> qparams;
-  qparams.reserve(6);
-  qparams.emplace_back("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
-  qparams.emplace_back("X-Amz-Credential", credential_qparam);
-  qparams.emplace_back("X-Amz-Date", amz_date);
-  qparams.emplace_back("X-Amz-Expires", std::to_string(ttl.count()));
-  if (!creds.session_token.empty()) {
-    qparams.emplace_back("X-Amz-Security-Token", creds.session_token);
+  auto add_amz = [&qparams](std::string_view k, std::string_view v) {
+    qparams.emplace_back(uri_encode(k, /*encode_slash=*/true),
+                         uri_encode(v, /*encode_slash=*/true));
+  };
+  add_amz("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
+  add_amz("X-Amz-Credential", credential_qparam);
+  add_amz("X-Amz-Date", amz_date);
+  add_amz("X-Amz-Expires", std::to_string(ttl.count()));
+  if (!creds.session_token.empty()) { add_amz("X-Amz-Security-Token", creds.session_token); }
+  add_amz("X-Amz-SignedHeaders", "host");
+
+  // Merge the caller's pre-encoded request params (e.g. ListObjectsV2's
+  // list-type / prefix / max-keys / continuation-token), taken verbatim.
+  for (std::size_t b = 0; b < extra_canonical_query.size();) {
+    auto const amp  = extra_canonical_query.find('&', b);
+    auto const pair = extra_canonical_query.substr(
+      b, amp == std::string_view::npos ? std::string_view::npos : amp - b);
+    if (!pair.empty()) {
+      auto const eq = pair.find('=');
+      if (eq == std::string_view::npos) {
+        qparams.emplace_back(std::string{pair}, std::string{});
+      } else {
+        qparams.emplace_back(std::string{pair.substr(0, eq)}, std::string{pair.substr(eq + 1)});
+      }
+    }
+    if (amp == std::string_view::npos) { break; }
+    b = amp + 1;
   }
-  qparams.emplace_back("X-Amz-SignedHeaders", "host");
 
   std::sort(
     qparams.begin(), qparams.end(), [](auto const& a, auto const& b) { return a.first < b.first; });
@@ -323,9 +347,9 @@ std::string presign_url(std::string_view method,
   std::string canonical_query;
   for (std::size_t i = 0; i < qparams.size(); ++i) {
     if (i != 0) canonical_query += '&';
-    canonical_query += uri_encode(qparams[i].first, /*encode_slash=*/true);
+    canonical_query += qparams[i].first;
     canonical_query += '=';
-    canonical_query += uri_encode(qparams[i].second, /*encode_slash=*/true);
+    canonical_query += qparams[i].second;
   }
 
   // ---- 4. Canonical headers (host only) and signed headers list. ----
@@ -376,19 +400,42 @@ std::string presign_url(std::string_view method,
 
   std::string signature_hex = hex_encode(sig.data(), sig.size());
 
-  // ---- 8. Assemble the final URL:
-  //         scheme://host<canonical_uri>?<canonical_query>&X-Amz-Signature=<sig>. ----
+  // ---- 8. Assemble the final URL.  S3 accepts the query params in any order
+  //         (only the canonical query fed into the signature must be sorted,
+  //         and X-Amz-Signature is never part of it), so the placement of the
+  //         signature is presentation-only.  Two shapes:
+  //         - pure X-Amz query (no extra params): append the signature LAST —
+  //           byte-for-byte the layout of AWS's published query-auth vector,
+  //           which a golden test pins.
+  //         - merged query (extra request params present): insert the
+  //           signature in sorted position, so the final URL mirrors the
+  //           canonical order end to end. ----
+  std::string final_query;
+  if (extra_canonical_query.empty()) {
+    final_query = canonical_query;
+    final_query += "&X-Amz-Signature=";
+    final_query += signature_hex;
+  } else {
+    qparams.emplace_back("X-Amz-Signature", std::move(signature_hex));
+    std::sort(qparams.begin(), qparams.end(), [](auto const& a, auto const& b) {
+      return a.first < b.first;
+    });
+    for (std::size_t i = 0; i < qparams.size(); ++i) {
+      if (i != 0) final_query += '&';
+      final_query += qparams[i].first;
+      final_query += '=';
+      final_query += qparams[i].second;
+    }
+  }
+
   std::string out;
-  out.reserve(scheme.size() + 3 + host.size() + canonical_uri.size() + 1 + canonical_query.size() +
-              /* &X-Amz-Signature= */ 18 + signature_hex.size());
+  out.reserve(scheme.size() + 3 + host.size() + canonical_uri.size() + 1 + final_query.size());
   out.append(scheme.data(), scheme.size());
   out += "://";
   out.append(host.data(), host.size());
   out.append(canonical_uri.data(), canonical_uri.size());
   out += '?';
-  out += canonical_query;
-  out += "&X-Amz-Signature=";
-  out += signature_hex;
+  out += final_query;
   return out;
 }
 

--- a/src/io/s3/sigv4.cpp
+++ b/src/io/s3/sigv4.cpp
@@ -402,14 +402,10 @@ std::string presign_url(std::string_view method,
 
   // ---- 8. Assemble the final URL.  S3 accepts the query params in any order
   //         (only the canonical query fed into the signature must be sorted,
-  //         and X-Amz-Signature is never part of it), so the placement of the
-  //         signature is presentation-only.  Two shapes:
-  //         - pure X-Amz query (no extra params): append the signature LAST —
-  //           byte-for-byte the layout of AWS's published query-auth vector,
-  //           which a golden test pins.
-  //         - merged query (extra request params present): insert the
-  //           signature in sorted position, so the final URL mirrors the
-  //           canonical order end to end. ----
+  //         and X-Amz-Signature is never part of it), so signature placement is
+  //         presentation-only.  Preserve the existing object-request layout —
+  //         a pure X-Amz query appends the signature last; merged LIST queries
+  //         insert it in sorted position for a fully canonical-ordered URL. ----
   std::string final_query;
   if (extra_canonical_query.empty()) {
     final_query = canonical_query;

--- a/src/io/s3/sirius_httpfs.cpp
+++ b/src/io/s3/sirius_httpfs.cpp
@@ -332,6 +332,44 @@ duckdb::vector<duckdb::OpenFileInfo> sirius_httpfs::Glob(const std::string& path
   return expand_glob(path, sirius_ctx->get_scan_manager());
 }
 
+namespace {
+
+// True when @p key contains '%' followed by two hex digits. Such keys cannot
+// be represented faithfully today: DuckDB URL-decodes hive partition values
+// (and only those) from the path exactly once, so the escaped path text this
+// file emits would make bind-time pruning, the GPU-projected value, and the
+// local-FS oracle all disagree — silent wrong results. expand_glob fails
+// loudly on them instead; '#', '?' and bare-'%' keys round-trip exactly and
+// stay supported. Full support is a tracked follow-up (a path/URI contract
+// change), at which point this guard is removed.
+bool key_has_percent_encoded_sequence(std::string_view key)
+{
+  auto const is_hex = [](char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+  };
+  for (std::size_t i = 0; i + 2 < key.size(); ++i) {
+    if (key[i] == '%' && is_hex(key[i + 1]) && is_hex(key[i + 2])) { return true; }
+  }
+  return false;
+}
+
+}  // namespace
+
+std::string escape_s3_key_for_uri(std::string_view key)
+{
+  std::string out;
+  out.reserve(key.size());
+  for (char const c : key) {
+    switch (c) {
+      case '%': out += "%25"; break;
+      case '#': out += "%23"; break;
+      case '?': out += "%3F"; break;
+      default: out += c;
+    }
+  }
+  return out;
+}
+
 duckdb::vector<duckdb::OpenFileInfo> expand_glob(
   std::string const& pattern,
   sirius::scan_manager::sirius_scan_manager& scan_manager,
@@ -389,12 +427,24 @@ duckdb::vector<duckdb::OpenFileInfo> expand_glob(
           matched = match_glob_no_crawl(key_segments, pattern_segments);
         }
         if (!matched) { continue; }
+        // Match-scoped fail-loud guard (see key_has_percent_encoded_sequence):
+        // unmatched keys under the same prefix stay harmless.
+        if (key_has_percent_encoded_sequence(entry.key)) {
+          throw duckdb::IOException(
+            "[sirius_httpfs] glob '" + pattern + "' matched S3 key '" + entry.key +
+            "' containing a percent-encoded sequence; hive/filename semantics for such keys are "
+            "not preserved over s3:// yet — rename the object or exclude it from the glob");
+        }
         if (matches.size() >= match_cap) {
           throw duckdb::IOException("[sirius_httpfs] glob '" + pattern + "' matched more than " +
                                     std::to_string(match_cap) +
                                     " objects — narrow the glob prefix");
         }
-        duckdb::OpenFileInfo info("s3://" + std::string{bucket} + "/" + entry.key);
+        // Matching runs on the literal key bytes above; only the URI embedding
+        // escapes them, so the later parse() of this path restores the exact
+        // key (see escape_s3_key_for_uri).
+        duckdb::OpenFileInfo info("s3://" + std::string{bucket} + "/" +
+                                  escape_s3_key_for_uri(entry.key));
         if (entry.size <= static_cast<std::uint64_t>(std::numeric_limits<int64_t>::max())) {
           info.extended_info = duckdb::make_shared_ptr<duckdb::ExtendedOpenFileInfo>();
           info.extended_info->options["file_size"] =

--- a/src/io/s3/sirius_httpfs.cpp
+++ b/src/io/s3/sirius_httpfs.cpp
@@ -258,9 +258,11 @@ duckdb::unique_ptr<duckdb::FileHandle> sirius_httpfs::OpenFileExtended(
                               "' is read-only; S3 writes (COPY TO) are not supported");
   }
   auto sirius_ctx = resolve_gated_sirius_context(opener, file.path, "reading");
-  // The size rode the ListObjectsV2 response that expanded the glob, so this
-  // open costs zero network (no HEAD).
-  auto datasource = sirius_ctx->get_scan_manager().create_datasource(file.path, *known_size);
+  // A parquet_footer_probe open: one suffix-range GET resolves the size (== the
+  // LIST size that rode the glob expansion) and stashes the footer, so the
+  // binder's footer reads are served locally (no HEAD, no separate footer GETs).
+  auto datasource = sirius_ctx->get_scan_manager().create_datasource(
+    file.path, sirius::io::open_hint::parquet_footer_probe);
   if (!datasource) {
     throw std::runtime_error("[sirius_httpfs] no S3 backend supports '" + file.path + "'");
   }

--- a/src/io/s3/sirius_httpfs.cpp
+++ b/src/io/s3/sirius_httpfs.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -135,16 +136,17 @@ std::optional<std::uint64_t> extract_known_size(duckdb::OpenFileInfo const& file
   return static_cast<std::uint64_t>(size);
 }
 
-/// Split @p s into its '/'-separated segments (S3 keys are flat strings; the
-/// segment view only exists for glob matching).
-std::vector<std::string_view> split_segments(std::string_view s)
+/// Split @p s into its '/'-separated segments into @p out (cleared first). The
+/// segment views alias @p s and exist only for glob matching. @p out is a
+/// reused scratch buffer so a broad listing does not heap-allocate per key.
+void split_segments(std::string_view s, std::vector<std::string_view>& out)
 {
-  std::vector<std::string_view> out;
+  out.clear();
   for (std::size_t b = 0;;) {
     auto const slash = s.find('/', b);
     if (slash == std::string_view::npos) {
       out.push_back(s.substr(b));
-      return out;
+      return;
     }
     out.push_back(s.substr(b, slash - b));
     b = slash + 1;
@@ -154,21 +156,35 @@ std::vector<std::string_view> split_segments(std::string_view s)
 /// DuckDB glob semantics over a flat key: `*` / `?` / `[…]` match within one
 /// '/'-segment (duckdb::Glob, the same matcher LocalFileSystem applies per
 /// directory entry); `**` matches zero or more whole segments (the crawl).
+/// Memoized on `(ki, pi)` — plain backtracking is exponential in the number of
+/// `**` segments, and the pattern is user-supplied on an external SQL surface.
+/// @p memo is a reused scratch buffer sized `(keys.size()+1)*(pats.size()+1)`,
+/// values -1 (unknown) / 0 (false) / 1 (true).
 bool match_glob_segments(std::vector<std::string_view> const& keys,
                          std::size_t ki,
                          std::vector<std::string_view> const& pats,
-                         std::size_t pi)
+                         std::size_t pi,
+                         std::vector<std::int8_t>& memo)
 {
-  if (pi == pats.size()) { return ki == keys.size(); }
-  if (pats[pi] == "**") {
+  auto const idx = ki * (pats.size() + 1) + pi;
+  if (memo[idx] != -1) { return memo[idx] != 0; }
+  bool result = false;
+  if (pi == pats.size()) {
+    result = ki == keys.size();
+  } else if (pats[pi] == "**") {
     for (std::size_t skip = ki; skip <= keys.size(); ++skip) {
-      if (match_glob_segments(keys, skip, pats, pi + 1)) { return true; }
+      if (match_glob_segments(keys, skip, pats, pi + 1, memo)) {
+        result = true;
+        break;
+      }
     }
-    return false;
+  } else {
+    result = ki < keys.size() &&
+             duckdb::Glob(keys[ki].data(), keys[ki].size(), pats[pi].data(), pats[pi].size()) &&
+             match_glob_segments(keys, ki + 1, pats, pi + 1, memo);
   }
-  return ki < keys.size() &&
-         duckdb::Glob(keys[ki].data(), keys[ki].size(), pats[pi].data(), pats[pi].size()) &&
-         match_glob_segments(keys, ki + 1, pats, pi + 1);
+  memo[idx] = static_cast<std::int8_t>(result ? 1 : 0);
+  return result;
 }
 
 }  // namespace
@@ -326,19 +342,24 @@ duckdb::vector<duckdb::OpenFileInfo> expand_glob(
   auto const prefix     = last_slash == std::string_view::npos ? std::string_view{}
                                                                : key_pattern.substr(0, last_slash + 1);
 
-  auto const pattern_segments = split_segments(key_pattern);
-  std::string const list_uri  = "s3://" + std::string{bucket} + "/" + std::string{prefix};
+  std::vector<std::string_view> pattern_segments;
+  split_segments(key_pattern, pattern_segments);
+  std::string const list_uri = "s3://" + std::string{bucket} + "/" + std::string{prefix};
 
   // Stream the pages, keeping only matches: peak memory = one page (≤1000
   // entries) + the matched set, regardless of the prefix's population. The
   // match cap throws rather than truncating — a shortened file list would
-  // silently change query results.
+  // silently change query results. `key_segments` / `memo` are reused across
+  // keys so a broad listing does not heap-allocate per key.
   duckdb::vector<duckdb::OpenFileInfo> matches;
+  std::vector<std::string_view> key_segments;
+  std::vector<std::int8_t> memo;
   scan_manager.list_objects_paged(
     list_uri, /*page_size=*/1000, [&](sirius::io::s3::list_objects_v2_page const& page) {
       for (auto const& entry : page.entries) {
-        auto const key_segments = split_segments(entry.key);
-        if (!match_glob_segments(key_segments, 0, pattern_segments, 0)) { continue; }
+        split_segments(entry.key, key_segments);
+        memo.assign((key_segments.size() + 1) * (pattern_segments.size() + 1), -1);
+        if (!match_glob_segments(key_segments, 0, pattern_segments, 0, memo)) { continue; }
         if (matches.size() >= max_matches) {
           throw duckdb::IOException("[sirius_httpfs] glob '" + pattern + "' matched more than " +
                                     std::to_string(max_matches) +

--- a/src/io/s3/sirius_httpfs.cpp
+++ b/src/io/s3/sirius_httpfs.cpp
@@ -187,6 +187,23 @@ bool match_glob_segments(std::vector<std::string_view> const& keys,
   return result;
 }
 
+/// Fast path for a pattern with NO `**`: every pattern segment matches exactly
+/// one key segment (`*`/`?`/`[…]` never cross a '/'), so the match reduces to a
+/// length check plus a per-segment duckdb::Glob — no recursion, no memo. This is
+/// the common glob (`root_*.parquet`, `nation_[ab].parquet`), so keeping it off
+/// the memoized path avoids a per-listed-key memo write on a broad listing.
+bool match_glob_no_crawl(std::vector<std::string_view> const& keys,
+                         std::vector<std::string_view> const& pats)
+{
+  if (keys.size() != pats.size()) { return false; }
+  for (std::size_t i = 0; i < keys.size(); ++i) {
+    if (!duckdb::Glob(keys[i].data(), keys[i].size(), pats[i].data(), pats[i].size())) {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace
 
 bool sirius_httpfs::CanHandleFile(const std::string& fpath)
@@ -344,13 +361,16 @@ duckdb::vector<duckdb::OpenFileInfo> expand_glob(
 
   std::vector<std::string_view> pattern_segments;
   split_segments(key_pattern, pattern_segments);
+  bool const has_crawl =
+    std::find(pattern_segments.begin(), pattern_segments.end(), "**") != pattern_segments.end();
   std::string const list_uri = "s3://" + std::string{bucket} + "/" + std::string{prefix};
 
   // Stream the pages, keeping only matches: peak memory = one page (≤1000
   // entries) + the matched set, regardless of the prefix's population. The
   // match cap throws rather than truncating — a shortened file list would
   // silently change query results. `key_segments` / `memo` are reused across
-  // keys so a broad listing does not heap-allocate per key.
+  // keys so a broad listing does not heap-allocate per key; the `**` memo is
+  // only touched when the pattern actually has a crawl segment.
   duckdb::vector<duckdb::OpenFileInfo> matches;
   std::vector<std::string_view> key_segments;
   std::vector<std::int8_t> memo;
@@ -358,8 +378,14 @@ duckdb::vector<duckdb::OpenFileInfo> expand_glob(
     list_uri, /*page_size=*/1000, [&](sirius::io::s3::list_objects_v2_page const& page) {
       for (auto const& entry : page.entries) {
         split_segments(entry.key, key_segments);
-        memo.assign((key_segments.size() + 1) * (pattern_segments.size() + 1), -1);
-        if (!match_glob_segments(key_segments, 0, pattern_segments, 0, memo)) { continue; }
+        bool matched;
+        if (has_crawl) {
+          memo.assign((key_segments.size() + 1) * (pattern_segments.size() + 1), -1);
+          matched = match_glob_segments(key_segments, 0, pattern_segments, 0, memo);
+        } else {
+          matched = match_glob_no_crawl(key_segments, pattern_segments);
+        }
+        if (!matched) { continue; }
         if (matches.size() >= max_matches) {
           throw duckdb::IOException("[sirius_httpfs] glob '" + pattern + "' matched more than " +
                                     std::to_string(max_matches) +

--- a/src/io/s3/sirius_httpfs.cpp
+++ b/src/io/s3/sirius_httpfs.cpp
@@ -157,8 +157,7 @@ void split_segments(std::string_view s, std::vector<std::string_view>& out)
 /// '/'-segment (duckdb::Glob, the same matcher LocalFileSystem applies per
 /// directory entry); `**` matches zero or more whole segments (the crawl).
 /// Memoized on `(ki, pi)` — plain backtracking is exponential in the number of
-/// `**` segments, and the pattern is user-supplied on an external SQL surface.
-/// @p memo is a reused scratch buffer sized `(keys.size()+1)*(pats.size()+1)`,
+/// `**` segments. @p memo is a reused scratch buffer sized `(keys.size()+1)*(pats.size()+1)`,
 /// values -1 (unknown) / 0 (false) / 1 (true).
 bool match_glob_segments(std::vector<std::string_view> const& keys,
                          std::size_t ki,
@@ -334,14 +333,10 @@ duckdb::vector<duckdb::OpenFileInfo> sirius_httpfs::Glob(const std::string& path
 
 namespace {
 
-// True when @p key contains '%' followed by two hex digits. Such keys cannot
-// be represented faithfully today: DuckDB URL-decodes hive partition values
-// (and only those) from the path exactly once, so the escaped path text this
-// file emits would make bind-time pruning, the GPU-projected value, and the
-// local-FS oracle all disagree — silent wrong results. expand_glob fails
-// loudly on them instead; '#', '?' and bare-'%' keys round-trip exactly and
-// stay supported. Full support is a tracked follow-up (a path/URI contract
-// change), at which point this guard is removed.
+// True when @p key contains '%' followed by two hex digits. DuckDB decodes hive
+// partition values from the path, so a literal %HH key cannot currently preserve
+// both object identity and partition values; expand_glob rejects it. ('#', '?'
+// and bare-'%' keys round-trip exactly and stay supported.)
 bool key_has_percent_encoded_sequence(std::string_view key)
 {
   auto const is_hex = [](char c) {

--- a/src/io/s3/sirius_httpfs.cpp
+++ b/src/io/s3/sirius_httpfs.cpp
@@ -333,7 +333,7 @@ duckdb::vector<duckdb::OpenFileInfo> sirius_httpfs::Glob(const std::string& path
 duckdb::vector<duckdb::OpenFileInfo> expand_glob(
   std::string const& pattern,
   sirius::scan_manager::sirius_scan_manager& scan_manager,
-  std::size_t max_matches)
+  std::optional<std::size_t> max_matches)
 {
   constexpr std::string_view k_scheme = "s3://";
   if (pattern.size() <= k_scheme.size()) {
@@ -363,7 +363,8 @@ duckdb::vector<duckdb::OpenFileInfo> expand_glob(
   split_segments(key_pattern, pattern_segments);
   bool const has_crawl =
     std::find(pattern_segments.begin(), pattern_segments.end(), "**") != pattern_segments.end();
-  std::string const list_uri = "s3://" + std::string{bucket} + "/" + std::string{prefix};
+  std::string const list_uri  = "s3://" + std::string{bucket} + "/" + std::string{prefix};
+  std::size_t const match_cap = max_matches.value_or(scan_manager.s3_list_max_matches(list_uri));
 
   // Stream the pages, keeping only matches: peak memory = one page (≤1000
   // entries) + the matched set, regardless of the prefix's population. The
@@ -386,9 +387,9 @@ duckdb::vector<duckdb::OpenFileInfo> expand_glob(
           matched = match_glob_no_crawl(key_segments, pattern_segments);
         }
         if (!matched) { continue; }
-        if (matches.size() >= max_matches) {
+        if (matches.size() >= match_cap) {
           throw duckdb::IOException("[sirius_httpfs] glob '" + pattern + "' matched more than " +
-                                    std::to_string(max_matches) +
+                                    std::to_string(match_cap) +
                                     " objects — narrow the glob prefix");
         }
         duckdb::OpenFileInfo info("s3://" + std::string{bucket} + "/" + entry.key);

--- a/src/io/s3/sirius_httpfs.cpp
+++ b/src/io/s3/sirius_httpfs.cpp
@@ -24,14 +24,19 @@
 #include <duckdb/common/exception.hpp>
 #include <duckdb/common/file_opener.hpp>
 #include <duckdb/common/types/value.hpp>
+#include <duckdb/function/scalar/string_common.hpp>
 #include <duckdb/main/client_context.hpp>
 
+#include <algorithm>
 #include <cctype>
 #include <cstddef>
+#include <limits>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 namespace sirius::io::s3 {
 
@@ -66,6 +71,106 @@ sirius_httpfs_file_handle& as_httpfs_handle(duckdb::FileHandle& handle)
   return static_cast<sirius_httpfs_file_handle&>(handle);
 }
 
+/// Shared gate for every s3:// access through this FileSystem (open AND glob
+/// expansion): resolve the connection's SiriusContext and enforce the GPU-only
+/// contract — reject when gpu_execution is off or a CPU-fallback replay is
+/// active. @p verb only shapes the error text.
+duckdb::shared_ptr<duckdb::SiriusContext> resolve_gated_sirius_context(
+  duckdb::optional_ptr<duckdb::FileOpener> opener, std::string const& path, char const* verb)
+{
+  // The ClientFileSystem (OpenerFileSystem) layer injects the connection's
+  // FileOpener even though the parquet reader passes none.
+  auto client = duckdb::FileOpener::TryGetClientContext(opener);
+  if (!client) {
+    throw std::runtime_error(std::string("[sirius_httpfs] no ClientContext while ") + verb + " '" +
+                             path + "'; S3 reads require a Sirius-enabled connection");
+  }
+  // Transparent S3 is GPU-only. If gpu_execution is off there is no GPU
+  // consumer, so serving here would be a CPU read of s3:// — which Sirius does
+  // not support. Refuse with a clear message instead of silently serving a CPU
+  // fallback. Applies to glob expansion too: an expanded file list is only ever
+  // consumed by a scan that would hit this same wall at open.
+  {
+    duckdb::Value gpu_exec;
+    auto have         = client->TryGetCurrentSetting("gpu_execution", gpu_exec);
+    bool const gpu_on = have && !gpu_exec.IsNull() && gpu_exec.GetValue<bool>();
+    if (!gpu_on) {
+      throw duckdb::IOException(std::string("[sirius_httpfs] ") + verb + " '" + path +
+                                "' over S3 requires GPU execution: S3 is GPU-only and has no CPU "
+                                "fallback; SET gpu_execution=true");
+    }
+  }
+  auto sirius_ctx = client->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  if (!sirius_ctx) {
+    throw std::runtime_error(std::string("[sirius_httpfs] Sirius is not initialized on this "
+                                         "connection while ") +
+                             verb + " '" + path + "'");
+  }
+  // No S3 CPU fallback. A CPU-fallback replay active here means the GPU plan
+  // failed and we are replaying on CPU (run_internal_cpu_fallback_query wraps
+  // the replay in a CpuFallbackGuard). Refuse so s3:// data is never served to
+  // a CPU plan, even when reached indirectly through a view. Uses the narrow
+  // CpuFallbackGuard flag (not the broad is_internal_query_active), so a
+  // legitimate internal s3:// read is not blocked.
+  if (sirius_ctx->is_cpu_fallback_active()) {
+    throw duckdb::IOException(std::string("[sirius_httpfs] ") + verb + " '" + path +
+                              "' on a CPU execution path: S3 CPU fallback is not supported (S3 is "
+                              "GPU-only); Sirius has no CPU fallback for S3 data sources");
+  }
+  return sirius_ctx;
+}
+
+/// The LIST-provided size Glob attaches ("file_size", duckdb-httpfs convention).
+/// Wrong type / null / negative → nullopt: a third-party-populated OpenFileInfo
+/// must degrade to the plain (HEAD) open path, never break the open.
+std::optional<std::uint64_t> extract_known_size(duckdb::OpenFileInfo const& file)
+{
+  if (!file.extended_info) { return std::nullopt; }
+  auto const it = file.extended_info->options.find("file_size");
+  if (it == file.extended_info->options.end()) { return std::nullopt; }
+  auto const& value = it->second;
+  if (value.IsNull() || value.type().id() != duckdb::LogicalTypeId::BIGINT) { return std::nullopt; }
+  auto const size = value.GetValue<int64_t>();
+  if (size < 0) { return std::nullopt; }
+  return static_cast<std::uint64_t>(size);
+}
+
+/// Split @p s into its '/'-separated segments (S3 keys are flat strings; the
+/// segment view only exists for glob matching).
+std::vector<std::string_view> split_segments(std::string_view s)
+{
+  std::vector<std::string_view> out;
+  for (std::size_t b = 0;;) {
+    auto const slash = s.find('/', b);
+    if (slash == std::string_view::npos) {
+      out.push_back(s.substr(b));
+      return out;
+    }
+    out.push_back(s.substr(b, slash - b));
+    b = slash + 1;
+  }
+}
+
+/// DuckDB glob semantics over a flat key: `*` / `?` / `[…]` match within one
+/// '/'-segment (duckdb::Glob, the same matcher LocalFileSystem applies per
+/// directory entry); `**` matches zero or more whole segments (the crawl).
+bool match_glob_segments(std::vector<std::string_view> const& keys,
+                         std::size_t ki,
+                         std::vector<std::string_view> const& pats,
+                         std::size_t pi)
+{
+  if (pi == pats.size()) { return ki == keys.size(); }
+  if (pats[pi] == "**") {
+    for (std::size_t skip = ki; skip <= keys.size(); ++skip) {
+      if (match_glob_segments(keys, skip, pats, pi + 1)) { return true; }
+    }
+    return false;
+  }
+  return ki < keys.size() &&
+         duckdb::Glob(keys[ki].data(), keys[ki].size(), pats[pi].data(), pats[pi].size()) &&
+         match_glob_segments(keys, ki + 1, pats, pi + 1);
+}
+
 }  // namespace
 
 bool sirius_httpfs::CanHandleFile(const std::string& fpath)
@@ -96,49 +201,7 @@ duckdb::unique_ptr<duckdb::FileHandle> sirius_httpfs::OpenFile(
     throw duckdb::IOException("[sirius_httpfs] '" + path +
                               "' is read-only; S3 writes (COPY TO) are not supported");
   }
-  // The ClientFileSystem (OpenerFileSystem) layer injects the connection's
-  // FileOpener even though the parquet reader passes none.
-  auto client = duckdb::FileOpener::TryGetClientContext(opener);
-  if (!client) {
-    throw std::runtime_error("[sirius_httpfs] no ClientContext while opening '" + path +
-                             "'; S3 reads require a Sirius-enabled connection");
-  }
-  // Transparent S3 is GPU-only. The GPU scan reads column data through the routed
-  // ioctx, so this FileSystem only ever serves the bind-time footer read for the
-  // GPU path. If gpu_execution is off there is no GPU consumer, so opening here
-  // would be a CPU read of s3:// — which Sirius does not support. Refuse with a
-  // clear message instead of silently serving a CPU fallback.
-  {
-    duckdb::Value gpu_exec;
-    auto have         = client->TryGetCurrentSetting("gpu_execution", gpu_exec);
-    bool const gpu_on = have && !gpu_exec.IsNull() && gpu_exec.GetValue<bool>();
-    if (!gpu_on) {
-      throw duckdb::IOException("[sirius_httpfs] reading '" + path +
-                                "' over S3 requires GPU execution: S3 is GPU-only and has no CPU "
-                                "fallback; SET gpu_execution=true");
-    }
-  }
-  auto sirius_ctx = client->registered_state->Get<duckdb::SiriusContext>("sirius_state");
-  if (!sirius_ctx) {
-    throw std::runtime_error(
-      "[sirius_httpfs] Sirius is not initialized on this connection while opening '" + path + "'");
-  }
-  // No S3 CPU fallback. This FileSystem is only meant to serve the bind-time
-  // footer read for the transparent GPU path (the GPU scan then reads via the
-  // routed ioctx, not here). A CPU-fallback replay active here means the GPU
-  // plan failed and we are replaying on CPU (run_internal_cpu_fallback_query
-  // wraps the replay in a CpuFallbackGuard) — e.g. gpu_execution('SELECT ...
-  // FROM v_s3') whose view body reads s3:// and whose GPU plan failed. Refuse
-  // the read so s3:// data is never served to a CPU plan, even when reached
-  // indirectly through a view. Uses the narrow CpuFallbackGuard flag (not the
-  // broad is_internal_query_active), so a legitimate internal s3:// read is not
-  // blocked.
-  if (sirius_ctx->is_cpu_fallback_active()) {
-    throw duckdb::IOException(
-      "[sirius_httpfs] reading '" + path +
-      "' on a CPU execution path: S3 CPU fallback is not supported (S3 is GPU-only); "
-      "Sirius has no CPU fallback for S3 data sources");
-  }
+  auto sirius_ctx = resolve_gated_sirius_context(opener, path, "reading");
   // Resolve through the scan_manager's datasource factory (the routed seam):
   // the returned sirius_datasource performs the HEAD and carries the backend;
   // HEAD failures (missing key / auth / network) propagate as exceptions for
@@ -148,6 +211,28 @@ duckdb::unique_ptr<duckdb::FileHandle> sirius_httpfs::OpenFile(
     throw std::runtime_error("[sirius_httpfs] no S3 backend supports '" + path + "'");
   }
   return duckdb::make_uniq<sirius_httpfs_file_handle>(*this, path, flags, std::move(datasource));
+}
+
+duckdb::unique_ptr<duckdb::FileHandle> sirius_httpfs::OpenFileExtended(
+  const duckdb::OpenFileInfo& file,
+  duckdb::FileOpenFlags flags,
+  duckdb::optional_ptr<duckdb::FileOpener> opener)
+{
+  auto const known_size = extract_known_size(file);
+  if (!known_size) { return OpenFile(file.path, flags, opener); }
+  if (flags.OpenForWriting()) {
+    throw duckdb::IOException("[sirius_httpfs] '" + file.path +
+                              "' is read-only; S3 writes (COPY TO) are not supported");
+  }
+  auto sirius_ctx = resolve_gated_sirius_context(opener, file.path, "reading");
+  // The size rode the ListObjectsV2 response that expanded the glob, so this
+  // open costs zero network (no HEAD).
+  auto datasource = sirius_ctx->get_scan_manager().create_datasource(file.path, *known_size);
+  if (!datasource) {
+    throw std::runtime_error("[sirius_httpfs] no S3 backend supports '" + file.path + "'");
+  }
+  return duckdb::make_uniq<sirius_httpfs_file_handle>(
+    *this, file.path, flags, std::move(datasource));
 }
 
 void sirius_httpfs::Read(duckdb::FileHandle& handle,
@@ -197,19 +282,82 @@ duckdb::timestamp_t sirius_httpfs::GetLastModifiedTime(duckdb::FileHandle& /*han
 }
 
 duckdb::vector<duckdb::OpenFileInfo> sirius_httpfs::Glob(const std::string& path,
-                                                         duckdb::FileOpener* /*opener*/)
+                                                         duckdb::FileOpener* opener)
 {
-  // No S3 LIST: reject glob/wildcard patterns with a clear error instead of
-  // treating '*' as a literal key and failing later on object open.
-  if (duckdb::FileSystem::HasGlob(path)) {
-    throw duckdb::IOException(
-      "[sirius_httpfs] glob/wildcard patterns are not supported for s3:// "
-      "(no S3 LIST); specify an exact object key: '" +
-      path + "'");
+  if (!duckdb::FileSystem::HasGlob(path)) {
+    duckdb::vector<duckdb::OpenFileInfo> result;
+    if (CanHandleFile(path)) { result.emplace_back(path); }
+    return result;
   }
-  duckdb::vector<duckdb::OpenFileInfo> result;
-  if (CanHandleFile(path)) { result.emplace_back(path); }
-  return result;
+  // Wildcard expansion needs the connection's backend (one paginated LIST) and
+  // is gated exactly like OpenFile: expansion is metadata-only, but its file
+  // list is only ever consumed by a GPU-only scan, so failing here gives the
+  // clear error at the earliest point.
+  auto sirius_ctx = resolve_gated_sirius_context(opener, path, "glob-expanding");
+  return expand_glob(path, sirius_ctx->get_scan_manager());
+}
+
+duckdb::vector<duckdb::OpenFileInfo> expand_glob(
+  std::string const& pattern,
+  sirius::scan_manager::sirius_scan_manager& scan_manager,
+  std::size_t max_matches)
+{
+  constexpr std::string_view k_scheme = "s3://";
+  if (pattern.size() <= k_scheme.size()) {
+    throw duckdb::IOException("[sirius_httpfs] malformed s3:// glob pattern: '" + pattern + "'");
+  }
+  auto const rest         = std::string_view{pattern}.substr(k_scheme.size());
+  auto const bucket_slash = rest.find('/');
+  auto const bucket       = rest.substr(0, bucket_slash);
+  if (bucket.find_first_of("*?[") != std::string_view::npos) {
+    throw duckdb::IOException(
+      "[sirius_httpfs] wildcards in the bucket segment are not supported: '" + pattern + "'");
+  }
+  if (bucket.empty() || bucket_slash == std::string_view::npos) {
+    throw duckdb::IOException("[sirius_httpfs] malformed s3:// glob pattern: '" + pattern + "'");
+  }
+  auto const key_pattern = rest.substr(bucket_slash + 1);
+
+  // LIST prefix = everything up to the last '/' before the first wildcard —
+  // ListObjectsV2 is prefix-indexed, so the sweep is server-side-narrowed to
+  // the table's prefix before any keys flow.
+  auto const first_wild = key_pattern.find_first_of("*?[");
+  auto const last_slash = key_pattern.rfind('/', first_wild);
+  auto const prefix     = last_slash == std::string_view::npos ? std::string_view{}
+                                                               : key_pattern.substr(0, last_slash + 1);
+
+  auto const pattern_segments = split_segments(key_pattern);
+  std::string const list_uri  = "s3://" + std::string{bucket} + "/" + std::string{prefix};
+
+  // Stream the pages, keeping only matches: peak memory = one page (≤1000
+  // entries) + the matched set, regardless of the prefix's population. The
+  // match cap throws rather than truncating — a shortened file list would
+  // silently change query results.
+  duckdb::vector<duckdb::OpenFileInfo> matches;
+  scan_manager.list_objects_paged(
+    list_uri, /*page_size=*/1000, [&](sirius::io::s3::list_objects_v2_page const& page) {
+      for (auto const& entry : page.entries) {
+        auto const key_segments = split_segments(entry.key);
+        if (!match_glob_segments(key_segments, 0, pattern_segments, 0)) { continue; }
+        if (matches.size() >= max_matches) {
+          throw duckdb::IOException("[sirius_httpfs] glob '" + pattern + "' matched more than " +
+                                    std::to_string(max_matches) +
+                                    " objects — narrow the glob prefix");
+        }
+        duckdb::OpenFileInfo info("s3://" + std::string{bucket} + "/" + entry.key);
+        if (entry.size <= static_cast<std::uint64_t>(std::numeric_limits<int64_t>::max())) {
+          info.extended_info = duckdb::make_shared_ptr<duckdb::ExtendedOpenFileInfo>();
+          info.extended_info->options["file_size"] =
+            duckdb::Value::BIGINT(static_cast<int64_t>(entry.size));
+        }
+        matches.push_back(std::move(info));
+      }
+      return true;
+    });
+
+  std::sort(
+    matches.begin(), matches.end(), [](auto const& a, auto const& b) { return a.path < b.path; });
+  return matches;
 }
 
 void sirius_httpfs::Seek(duckdb::FileHandle& handle, duckdb::idx_t location)

--- a/src/io/s3/sirius_sigv4_authorizer.cpp
+++ b/src/io/s3/sirius_sigv4_authorizer.cpp
@@ -19,6 +19,7 @@
 #include "io/io_errors.hpp"
 #include "io/s3/sigv4.hpp"
 
+#include <algorithm>
 #include <cctype>
 #include <ctime>
 #include <stdexcept>
@@ -108,6 +109,38 @@ std::string_view method_to_str(s3_request_method method)
   return "GET";  // unreachable; all enumerators handled
 }
 
+// A LIST canonical query must never carry auth params: a caller-supplied
+// X-Amz-* key would be merged into the signed set (presigned mode) or signed
+// verbatim (header mode), silently duplicating or overriding the authorizer's
+// own signing parameters. Case-insensitive — S3 treats query keys as sent, but
+// rejecting both spellings closes the smuggling door entirely.
+void reject_amz_query_params(std::string_view canonical_query)
+{
+  constexpr std::string_view k_amz = "x-amz-";
+  for (std::size_t b = 0; b < canonical_query.size();) {
+    auto const amp     = canonical_query.find('&', b);
+    auto const len     = (amp == std::string::npos ? canonical_query.size() : amp) - b;
+    auto const key_end = std::min(std::string_view{canonical_query}.substr(b, len).find('='), len);
+    auto const key     = std::string_view{canonical_query}.substr(b, key_end);
+    if (key.size() >= k_amz.size()) {
+      bool amz = true;
+      for (std::size_t i = 0; i < k_amz.size(); ++i) {
+        if (std::tolower(static_cast<unsigned char>(key[i])) != k_amz[i]) {
+          amz = false;
+          break;
+        }
+      }
+      if (amz) {
+        throw credential_error(
+          "sirius_sigv4_authorizer: X-Amz-* keys are not allowed in a LIST canonical query (got '" +
+          std::string{key} + "')");
+      }
+    }
+    if (amp == std::string::npos) { break; }
+    b = amp + 1;
+  }
+}
+
 }  // namespace
 
 sirius_sigv4_authorizer_base::sirius_sigv4_authorizer_base(static_credentials creds,
@@ -170,6 +203,34 @@ s3_authorized_request sirius_sigv4_presigned_authorizer::authorize(s3_object_ref
   }
 }
 
+s3_authorized_request sirius_sigv4_presigned_authorizer::authorize_list(
+  std::string_view bucket, std::string_view canonical_query, std::chrono::seconds timeout)
+{
+  if (bucket.empty()) { throw credential_error("sirius_sigv4_authorizer: empty bucket"); }
+  reject_amz_query_params(canonical_query);
+  std::string const canonical_uri = "/" + uri_encode(bucket, /*encode_slash=*/true);
+  auto const signer               = make_signer(_creds, _region);
+  auto const effective_ttl        = timeout.count() > 0 ? timeout : _ttl;
+
+  try {
+    // The list params are merged into the signed canonical query by presign_url,
+    // so the URL carries both them and the X-Amz-* auth params; headers empty.
+    return s3_authorized_request{presign_url(/*method=*/"GET",
+                                             _scheme,
+                                             _host,
+                                             canonical_uri,
+                                             signer,
+                                             std::time(nullptr),
+                                             effective_ttl,
+                                             canonical_query),
+                                 {}};
+  } catch (credential_error const&) {
+    throw;
+  } catch (std::exception const& e) {
+    throw credential_error(std::string("sirius_sigv4_presigned_authorizer: ") + e.what());
+  }
+}
+
 sirius_sigv4_header_authorizer::sirius_sigv4_header_authorizer(static_credentials creds,
                                                                std::string region,
                                                                std::string endpoint)
@@ -197,6 +258,38 @@ s3_authorized_request sirius_sigv4_header_authorizer::authorize(s3_object_ref co
                                    signer,
                                    std::time(nullptr));
     std::string url = _scheme + "://" + _host + canonical_uri;
+    return s3_authorized_request{std::move(url), std::move(signed_req.headers)};
+  } catch (credential_error const&) {
+    throw;
+  } catch (std::exception const& e) {
+    throw credential_error(std::string("sirius_sigv4_header_authorizer: ") + e.what());
+  }
+}
+
+s3_authorized_request sirius_sigv4_header_authorizer::authorize_list(
+  std::string_view bucket, std::string_view canonical_query, std::chrono::seconds /*timeout*/)
+{
+  if (bucket.empty()) { throw credential_error("sirius_sigv4_authorizer: empty bucket"); }
+  reject_amz_query_params(canonical_query);
+  std::string const canonical_uri = "/" + uri_encode(bucket, /*encode_slash=*/true);
+  auto const signer               = make_signer(_creds, _region);
+
+  try {
+    // sign_request already signs an arbitrary pre-sorted canonical query; the
+    // URL carries the same query verbatim, auth rides in the returned headers.
+    auto signed_req = sign_request(/*method=*/"GET",
+                                   _host,
+                                   canonical_uri,
+                                   canonical_query,
+                                   sha256_hex(""),
+                                   /*extra_headers=*/{},
+                                   signer,
+                                   std::time(nullptr));
+    std::string url = _scheme + "://" + _host + canonical_uri;
+    if (!canonical_query.empty()) {
+      url += '?';
+      url += canonical_query;
+    }
     return s3_authorized_request{std::move(url), std::move(signed_req.headers)};
   } catch (credential_error const&) {
     throw;

--- a/src/io/s3/sirius_sigv4_authorizer.cpp
+++ b/src/io/s3/sirius_sigv4_authorizer.cpp
@@ -109,11 +109,10 @@ std::string_view method_to_str(s3_request_method method)
   return "GET";  // unreachable; all enumerators handled
 }
 
-// A LIST canonical query must never carry auth params: a caller-supplied
-// X-Amz-* key would be merged into the signed set (presigned mode) or signed
-// verbatim (header mode), silently duplicating or overriding the authorizer's
-// own signing parameters. Case-insensitive — S3 treats query keys as sent, but
-// rejecting both spellings closes the smuggling door entirely.
+// Reject X-Amz-* parameters case-insensitively to prevent signing-parameter
+// injection: a caller-supplied X-Amz-* key would otherwise be merged into the
+// signed set (presigned mode) or signed verbatim (header mode), duplicating or
+// overriding the authorizer's own signing parameters.
 void reject_amz_query_params(std::string_view canonical_query)
 {
   constexpr std::string_view k_amz = "x-amz-";

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -441,9 +441,13 @@ std::unique_ptr<scan_info> parquet_gpu_ingestible::build_file_scan_info(
   auto stream = cudf::get_default_stream();
 
   // Resolve the file to a sirius_datasource (own io backend, prefetch cache and
-  // cached metadata). Fall back to a plain cudf datasource only for local paths
-  // no sirius backend claims.
-  std::shared_ptr<io::sirius_datasource> sirius_ds = io_ctx->open_datasource(file_path);
+  // cached metadata). The parquet_footer_probe hint collapses the S3 footer read
+  // to one suffix-range GET that resolves the size and stashes the footer, so
+  // cuDF's footer reads are served locally (no HEAD, no separate trailer/body
+  // GETs). Fall back to a plain cudf datasource only for local paths no sirius
+  // backend claims.
+  std::shared_ptr<io::sirius_datasource> sirius_ds =
+    io_ctx->open_datasource(file_path, io::open_hint::parquet_footer_probe);
   if (!sirius_ds && has_uri_scheme(file_path)) {
     throw std::runtime_error("[parquet_gpu_ingestible] no backend supports path: " + file_path);
   }

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -21,6 +21,7 @@
 #include "io/cache/prefetching_cache.hpp"
 #include "io/io_context.hpp"
 #include "io/parquet_helpers.hpp"
+#include "io/rest/rest_ioctx.hpp"
 #include "io/sirius_datasource.hpp"
 #include "log/logging.hpp"
 #include "memory/topology_index.hpp"
@@ -403,6 +404,53 @@ std::shared_ptr<sirius::io::sirius_datasource> sirius_scan_manager::create_datas
   // Real I/O / HEAD / auth / missing-object errors propagate as exceptions;
   // only "no backend" is reported as nullptr (callers map it to that message).
   return io_ctx->open_datasource(file_path, hint);
+}
+
+std::shared_ptr<sirius::io::sirius_datasource> sirius_scan_manager::create_datasource(
+  std::string_view path, std::uint64_t known_size)
+{
+  auto file_path = normalize_path(std::string(path));
+  auto io_ctx    = ioctx_for_path(file_path);
+  if (!io_ctx) { return nullptr; }
+  return io_ctx->open_datasource(file_path, known_size);
+}
+
+void sirius_scan_manager::list_objects_paged(
+  std::string const& s3_prefix_uri,
+  std::size_t page_size,
+  std::function<bool(sirius::io::s3::list_objects_v2_page const&)> const& sink,
+  std::size_t max_scanned)
+{
+  // Hand-split rather than uri_parser::parse — a LIST prefix URI legitimately
+  // has an EMPTY key part (bucket-root glob: "s3://bucket/"), which parse()
+  // rejects as an object URI.
+  constexpr std::string_view k_scheme = "s3://";
+  if (s3_prefix_uri.size() <= k_scheme.size() ||
+      s3_prefix_uri.compare(0, k_scheme.size(), k_scheme) != 0) {
+    throw std::runtime_error("sirius_scan_manager::list_objects_paged: malformed prefix URI '" +
+                             s3_prefix_uri + "'");
+  }
+  auto const rest_uri     = std::string_view{s3_prefix_uri}.substr(k_scheme.size());
+  auto const bucket_slash = rest_uri.find('/');
+  auto const bucket       = rest_uri.substr(0, bucket_slash);
+  auto const prefix =
+    bucket_slash == std::string_view::npos ? std::string_view{} : rest_uri.substr(bucket_slash + 1);
+  if (bucket.empty()) {
+    throw std::runtime_error("sirius_scan_manager::list_objects_paged: malformed prefix URI '" +
+                             s3_prefix_uri + "'");
+  }
+  // Routing probe only (scheme dispatch, never touches the network): the
+  // backend checkers parse() their input and reject an empty object key, so a
+  // bucket-root prefix routes via a placeholder key.
+  auto const route_probe =
+    "s3://" + std::string(bucket) + "/" + (prefix.empty() ? "_" : std::string(prefix));
+  auto io_ctx = ioctx_for_path(route_probe);
+  auto* rest  = dynamic_cast<sirius::io::rest::rest_ioctx*>(io_ctx.get());
+  if (rest == nullptr) {
+    throw std::runtime_error("sirius_scan_manager::list_objects_paged: '" + s3_prefix_uri +
+                             "' does not route to an object-store backend that supports LIST");
+  }
+  rest->list_objects_paged(bucket, prefix, page_size, sink, max_scanned);
 }
 
 std::shared_ptr<sirius::io::sirius_ioctx> sirius_scan_manager::ioctx_for_path(std::string_view path)

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -406,15 +406,6 @@ std::shared_ptr<sirius::io::sirius_datasource> sirius_scan_manager::create_datas
   return io_ctx->open_datasource(file_path, hint);
 }
 
-std::shared_ptr<sirius::io::sirius_datasource> sirius_scan_manager::create_datasource(
-  std::string_view path, std::uint64_t known_size)
-{
-  auto file_path = normalize_path(std::string(path));
-  auto io_ctx    = ioctx_for_path(file_path);
-  if (!io_ctx) { return nullptr; }
-  return io_ctx->open_datasource(file_path, known_size);
-}
-
 void sirius_scan_manager::list_objects_paged(
   std::string const& s3_prefix_uri,
   std::size_t page_size,

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -419,7 +419,7 @@ void sirius_scan_manager::list_objects_paged(
   std::string const& s3_prefix_uri,
   std::size_t page_size,
   std::function<bool(sirius::io::s3::list_objects_v2_page const&)> const& sink,
-  std::size_t max_scanned)
+  std::optional<std::size_t> max_scanned)
 {
   // Hand-split rather than uri_parser::parse — a LIST prefix URI legitimately
   // has an EMPTY key part (bucket-root glob: "s3://bucket/"), which parse()
@@ -451,6 +451,31 @@ void sirius_scan_manager::list_objects_paged(
                              "' does not route to an object-store backend that supports LIST");
   }
   rest->list_objects_paged(bucket, prefix, page_size, sink, max_scanned);
+}
+
+std::size_t sirius_scan_manager::s3_list_max_matches(std::string const& s3_uri)
+{
+  // Route by scheme only (no LIST call) to read the backend's configured cap.
+  // Same bucket-root-safe placeholder-key probe as list_objects_paged.
+  constexpr std::string_view k_scheme = "s3://";
+  if (s3_uri.size() <= k_scheme.size() || s3_uri.compare(0, k_scheme.size(), k_scheme) != 0) {
+    throw std::runtime_error("sirius_scan_manager::s3_list_max_matches: malformed URI '" + s3_uri +
+                             "'");
+  }
+  auto const rest_uri     = std::string_view{s3_uri}.substr(k_scheme.size());
+  auto const bucket_slash = rest_uri.find('/');
+  auto const bucket       = rest_uri.substr(0, bucket_slash);
+  auto const prefix =
+    bucket_slash == std::string_view::npos ? std::string_view{} : rest_uri.substr(bucket_slash + 1);
+  auto const route_probe =
+    "s3://" + std::string(bucket) + "/" + (prefix.empty() ? "_" : std::string(prefix));
+  auto io_ctx = ioctx_for_path(route_probe);
+  auto* rest  = dynamic_cast<sirius::io::rest::rest_ioctx*>(io_ctx.get());
+  if (rest == nullptr) {
+    throw std::runtime_error("sirius_scan_manager::s3_list_max_matches: '" + s3_uri +
+                             "' does not route to an object-store backend that supports LIST");
+  }
+  return rest->list_max_matches();
 }
 
 std::shared_ptr<sirius::io::sirius_ioctx> sirius_scan_manager::ioctx_for_path(std::string_view path)

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -116,6 +116,8 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
   r.optional("honor_retry_after", opt.honor_retry_after);
   r.optional("perf_instrumentation", opt.perf_instrumentation);
   r.optional("footer_probe_bytes", yaml::bytes(opt.footer_probe_bytes));
+  r.optional("list_max_matches", opt.list_max_matches);
+  r.optional("list_max_scanned", opt.list_max_scanned);
   r.reject_unknown();
 }
 

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -255,6 +255,8 @@ TEST_CASE("sirius_config parses rest perf instrumentation flag",
 {
   CHECK_FALSE(sirius::io::rest::config{}.perf_instrumentation);
   CHECK(sirius::io::rest::config{}.footer_probe_bytes == 512UL * 1024);
+  CHECK(sirius::io::rest::config{}.list_max_matches == 100'000);
+  CHECK(sirius::io::rest::config{}.list_max_scanned == 1'000'000);
 
   auto const path =
     std::filesystem::temp_directory_path() / "sirius_rest_perf_instrumentation.yaml";
@@ -264,12 +266,16 @@ TEST_CASE("sirius_config parses rest perf instrumentation flag",
              "    scan_manager:\n"
              "      rest:\n"
              "        perf_instrumentation: true\n"
-             "        footer_probe_bytes: 256KiB\n");
+             "        footer_probe_bytes: 256KiB\n"
+             "        list_max_matches: 5\n"
+             "        list_max_scanned: 50\n");
 
   sirius::sirius_config cfg;
   REQUIRE_NOTHROW(cfg.load_from_file(path));
   CHECK(cfg.get_scan_manager_config().rest.perf_instrumentation);
   CHECK(cfg.get_scan_manager_config().rest.footer_probe_bytes == 256UL * 1024);
+  CHECK(cfg.get_scan_manager_config().rest.list_max_matches == 5);
+  CHECK(cfg.get_scan_manager_config().rest.list_max_scanned == 50);
 
   std::error_code ec;
   std::filesystem::remove(path, ec);

--- a/test/cpp/integration/s3/generate_fixtures.py
+++ b/test/cpp/integration/s3/generate_fixtures.py
@@ -75,6 +75,33 @@ def copy_parquet_fixtures(source_dir: Path, out_dir: Path) -> list[Path]:
     return paths
 
 
+def copy_glob_parquet_fixtures(source_dir: Path, out_dir: Path) -> list[Path]:
+    """Create deterministic multi-file and hive-style parquet layouts for S3 glob tests."""
+    nation = source_dir / "nation.parquet"
+    region = source_dir / "region.parquet"
+    if not nation.is_file() or not region.is_file():
+        raise FileNotFoundError(
+            "nation.parquet and region.parquet are required for glob fixtures"
+        )
+
+    layout = [
+        (nation, out_dir / "glob" / "multi" / "nation_a.parquet"),
+        (nation, out_dir / "glob" / "multi" / "nation_b.parquet"),
+        (region, out_dir / "glob" / "multi" / "region.parquet"),
+        (nation, out_dir / "glob" / "hive" / "year=2024" / "nation.parquet"),
+        (nation, out_dir / "glob" / "hive" / "year=2025" / "nation.parquet"),
+        (nation, out_dir / "root_a.parquet"),
+        (nation, out_dir / "root_b.parquet"),
+    ]
+
+    paths: list[Path] = []
+    for src, dst in layout:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+        paths.append(dst)
+    return paths
+
+
 def sha256_of(path: Path) -> str:
     h = hashlib.sha256()
     with path.open("rb") as f:
@@ -113,10 +140,16 @@ def main() -> int:
         "medium.bin",
         "small.parquet",
         "MANIFEST.sha256",
+        "root_glob.parquet",
+        "root_a.parquet",
+        "root_b.parquet",
     ):
         stale_path = out_dir / stale
         if stale_path.exists():
             stale_path.unlink()
+    stale_glob_dir = out_dir / "glob"
+    if stale_glob_dir.exists():
+        shutil.rmtree(stale_glob_dir)
 
     paths = [
         write_hello(out_dir),
@@ -124,6 +157,7 @@ def main() -> int:
         write_deterministic_bytes(out_dir / "medium.bin", MEDIUM_SIZE, MEDIUM_SEED),
     ]
     paths.extend(copy_parquet_fixtures(args.parquet_source, out_dir))
+    paths.extend(copy_glob_parquet_fixtures(args.parquet_source, out_dir))
 
     manifest_path = args.manifest or (out_dir / "MANIFEST.sha256")
     with manifest_path.open("w") as f:

--- a/test/cpp/integration/s3/run_b1_bench.sh
+++ b/test/cpp/integration/s3/run_b1_bench.sh
@@ -4,15 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 S3_TEST_BIN="${S3_TEST_BIN:-${PROJECT_ROOT}/build/release/extension/sirius/test/cpp/sirius_unittest}"
-DOC_OUTPUT="/Users/tengyu/code/doc/s3support/pr6-b1-bench-results.md"
-
-if [[ -z "${SIRIUS_BENCH_OUTPUT_PATH:-}" ]]; then
-  if [[ -d "$(dirname "${DOC_OUTPUT}")" ]]; then
-    export SIRIUS_BENCH_OUTPUT_PATH="${DOC_OUTPUT}"
-  else
-    export SIRIUS_BENCH_OUTPUT_PATH="${SCRIPT_DIR}/pr6-b1-bench-results.md"
-  fi
-fi
+: "${SIRIUS_BENCH_OUTPUT_PATH:=${SCRIPT_DIR}/pr6-b1-bench-results.md}"
+export SIRIUS_BENCH_OUTPUT_PATH
 
 if [[ ! -x "${S3_TEST_BIN}" ]]; then
   echo "run_b1_bench: ${S3_TEST_BIN} not found; run make release first" >&2

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -28,13 +28,17 @@
 #include <duckdb/parser/expression/constant_expression.hpp>
 #include <duckdb/parser/expression/function_expression.hpp>
 #include <duckdb/parser/tableref/table_function_ref.hpp>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cerrno>
 #include <chrono>
 #include <cmath>
 #include <condition_variable>
+#include <csignal>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -637,10 +641,25 @@ std::string local_parquet_file_scan(fs::path const& path)
   return "read_parquet(" + sql_quote(path.string()) + ")";
 }
 
+std::string local_parquet_glob_scan(s3_test_env const& env,
+                                    std::string_view pattern,
+                                    std::string_view options = {})
+{
+  return "read_parquet(" + sql_quote((env.local_dir / std::string{pattern}).string()) +
+         std::string{options} + ")";
+}
+
 std::string s3_parquet_scan(s3_test_env const& env, std::string_view table)
 {
   auto const key = "parquet/" + std::string{table} + ".parquet";
   return "read_parquet(" + sql_quote(s3_uri(env.bucket, key)) + ")";
+}
+
+std::string s3_parquet_glob_scan(s3_test_env const& env,
+                                 std::string_view pattern,
+                                 std::string_view options = {})
+{
+  return "read_parquet(" + sql_quote(s3_uri(env.bucket, pattern)) + std::string{options} + ")";
 }
 
 std::string s3_sirius_parquet_scan(s3_test_env const& env, std::string_view table)
@@ -697,6 +716,20 @@ std::uint64_t rest_chunk_get_count(s3_sql_fixture& fixture, std::string const& u
 std::uint64_t rest_terminal_failures(s3_sql_fixture& fixture, std::string const& uri)
 {
   return require_rest_ioctx(fixture, uri).perf_snapshot().terminal_failures_total;
+}
+
+bool wait_for_child(pid_t pid, std::chrono::milliseconds timeout, int& status)
+{
+  auto const deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    auto const result = ::waitpid(pid, &status, WNOHANG);
+    if (result == pid) { return true; }
+    if (result < 0 && errno != EINTR) {
+      throw std::runtime_error("waitpid failed while watching known issue repro");
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+  }
+  return false;
 }
 
 struct large_lineitem_fixture {
@@ -2433,6 +2466,154 @@ TEST_CASE("transparent read_parquet over S3 keeps REST routing when local Sirius
     require_query_ok(fixture.con, "SELECT count(*) FROM read_parquet(" + sql_quote(uri) + ")");
   REQUIRE(result->RowCount() == 1);
   CHECK(result->GetValue(0, 0).GetValue<int64_t>() == 25);
+}
+
+TEST_CASE("transparent S3 read_parquet expands globbed parquet files",
+          "[s3][integration][sql][gpu_execution][transparent][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+
+  auto const s3_scan    = s3_parquet_glob_scan(*env, "glob/multi/nation_*.parquet");
+  auto const local_scan = local_parquet_glob_scan(*env, "glob/multi/nation_*.parquet");
+  auto const s3_query   = "SELECT n_nationkey, n_name, n_regionkey FROM " + s3_scan +
+                        " ORDER BY n_nationkey, n_name, n_regionkey";
+  auto const local_query = "SELECT n_nationkey, n_name, n_regionkey FROM " + local_scan +
+                           " ORDER BY n_nationkey, n_name, n_regionkey";
+
+  compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+}
+
+TEST_CASE("transparent S3 glob preserves hive partition columns",
+          "[s3][integration][sql][gpu_execution][transparent][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+
+  auto const options    = ", hive_partitioning=true";
+  auto const s3_scan    = s3_parquet_glob_scan(*env, "glob/hive/year=*/nation.parquet", options);
+  auto const local_scan = local_parquet_glob_scan(*env, "glob/hive/year=*/nation.parquet", options);
+  auto const s3_query   = "SELECT year, count(*), min(n_nationkey), max(n_nationkey) FROM " +
+                        s3_scan + " GROUP BY year ORDER BY year";
+  auto const local_query = "SELECT year, count(*), min(n_nationkey), max(n_nationkey) FROM " +
+                           local_scan + " GROUP BY year ORDER BY year";
+
+  compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+}
+
+TEST_CASE("transparent S3 glob matcher semantics match DuckDB segment globs",
+          "[s3][integration][sql][gpu_execution][transparent][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+
+  auto check_count =
+    [&](std::string_view s3_pattern, std::string_view local_pattern, std::int64_t expected) {
+      auto const s3_query =
+        "SELECT count(n_nationkey) FROM " + s3_parquet_glob_scan(*env, s3_pattern);
+      auto const local_query =
+        "SELECT count(n_nationkey) FROM " + local_parquet_glob_scan(*env, local_pattern);
+      compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+      auto result = require_query_ok(fixture.con, s3_query);
+      REQUIRE(result->RowCount() == 1);
+      CHECK(result->GetValue(0, 0).GetValue<int64_t>() == expected);
+    };
+
+  check_count("glob/multi/nation_?.parquet", "glob/multi/nation_?.parquet", 50);
+  check_count("glob/multi/nation_[ab].parquet", "glob/multi/nation_[ab].parquet", 50);
+  check_count("glob/hive/**/nation.parquet", "glob/hive/**/nation.parquet", 50);
+  check_count("root_*.parquet", "root_*.parquet", 50);
+
+  auto wildcard_bucket =
+    fixture.con.Query("SELECT count(*) FROM read_parquet('s3://*/glob/multi/nation_*.parquet')");
+  REQUIRE(wildcard_bucket);
+  REQUIRE(wildcard_bucket->HasError());
+  INFO(wildcard_bucket->GetError());
+  CHECK(wildcard_bucket->GetError().find("bucket") != std::string::npos);
+}
+
+TEST_CASE("known issue: transparent hive-layout glob count star hangs",
+          "[.][s3][integration][known-issue][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  INFO("Known issue: /Users/tengyu/code/doc/s3support/issue-hive-glob-count-star-hang.md");
+
+  auto const pid = ::fork();
+  REQUIRE(pid >= 0);
+  if (pid == 0) {
+    try {
+      s3_sql_fixture fixture(*env);
+      set_gpu_execution(fixture.con, true);
+      auto result = fixture.con.Query("SELECT count(*) FROM " +
+                                      s3_parquet_glob_scan(*env, "glob/hive/**/*.parquet"));
+      if (result && !result->HasError()) { ::_exit(0); }
+      ::_exit(2);
+    } catch (...) {
+      ::_exit(3);
+    }
+  }
+
+  int status = 0;
+  if (!wait_for_child(pid, std::chrono::seconds{10}, status)) {
+    (void)::kill(pid, SIGKILL);
+    (void)::waitpid(pid, &status, 0);
+    SUCCEED("Known issue reproduced: hive-layout glob count(*) did not return before watchdog");
+    return;
+  }
+
+  INFO("child status=" << status);
+  FAIL("Known issue no longer reproduces; remove or update this tracker");
+}
+
+TEST_CASE("transparent S3 glob reports no-files and GPU-only errors clearly",
+          "[s3][integration][sql][gpu_execution][transparent][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  SECTION("zero-match glob reports a no-files class error")
+  {
+    s3_sql_fixture fixture(*env);
+    set_gpu_execution(fixture.con, true);
+
+    auto result = fixture.con.Query("SELECT count(*) FROM " +
+                                    s3_parquet_glob_scan(*env, "glob/multi/no-match-*.parquet"));
+    REQUIRE(result);
+    REQUIRE(result->HasError());
+    auto const error = result->GetError();
+    INFO(error);
+    CHECK(
+      (error.find("No files") != std::string::npos || error.find("no files") != std::string::npos));
+    CHECK(error.find("glob/wildcard patterns are not supported") == std::string::npos);
+    CHECK(error.find("No filesystem") == std::string::npos);
+    CHECK(error.find("no filesystem") == std::string::npos);
+  }
+
+  SECTION("gpu_execution=false rejects globbed S3 at the filesystem gate")
+  {
+    s3_sql_fixture fixture(*env);
+    set_gpu_execution(fixture.con, false);
+
+    auto result = fixture.con.Query("SELECT count(*) FROM " +
+                                    s3_parquet_glob_scan(*env, "glob/multi/nation_*.parquet"));
+    REQUIRE(result);
+    REQUIRE(result->HasError());
+    auto const error = result->GetError();
+    INFO(error);
+    CHECK(error.find("S3 is GPU-only") != std::string::npos);
+    CHECK(error.find("SET gpu_execution=true") != std::string::npos);
+  }
 }
 
 TEST_CASE("gpu_execution S3 SQL surface returns empty result sets cleanly",

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -846,6 +846,11 @@ sirius::io::rest::rest_perf_snapshot delta_snapshot(
     sat_sub(after.device_stream_sync_total, before.device_stream_sync_total);
   out.payload_bytes_read_total =
     sat_sub(after.payload_bytes_read_total, before.payload_bytes_read_total);
+  out.native_footer_get_count =
+    sat_sub(after.native_footer_get_count, before.native_footer_get_count);
+  out.native_footer_wall_ns_total =
+    sat_sub(after.native_footer_wall_ns_total, before.native_footer_wall_ns_total);
+  out.native_footer_wall_ns_max = after.native_footer_wall_ns_max;
   return out;
 }
 
@@ -2485,14 +2490,17 @@ TEST_CASE("transparent S3 read_parquet expands globbed parquet files",
   s3_sql_fixture fixture(*env);
   set_gpu_execution(fixture.con, true);
 
-  auto const s3_scan    = s3_parquet_glob_scan(*env, "glob/multi/nation_*.parquet");
-  auto const local_scan = local_parquet_glob_scan(*env, "glob/multi/nation_*.parquet");
-  auto const s3_query   = "SELECT n_nationkey, n_name, n_regionkey FROM " + s3_scan +
+  auto const before_stats = sirius::test::get_transparent_execution_stats(fixture.con);
+  auto const s3_scan      = s3_parquet_glob_scan(*env, "glob/multi/nation_*.parquet");
+  auto const local_scan   = local_parquet_glob_scan(*env, "glob/multi/nation_*.parquet");
+  auto const s3_query     = "SELECT n_nationkey, n_name, n_regionkey FROM " + s3_scan +
                         " ORDER BY n_nationkey, n_name, n_regionkey";
   auto const local_query = "SELECT n_nationkey, n_name, n_regionkey FROM " + local_scan +
                            " ORDER BY n_nationkey, n_name, n_regionkey";
 
   compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+  auto const after_stats = sirius::test::get_transparent_execution_stats(fixture.con);
+  sirius::test::require_transparent_execution_delta(before_stats, after_stats, 1, 0, 1);
 }
 
 TEST_CASE("transparent S3 glob preserves hive partition columns",
@@ -2504,8 +2512,9 @@ TEST_CASE("transparent S3 glob preserves hive partition columns",
   s3_sql_fixture fixture(*env);
   set_gpu_execution(fixture.con, true);
 
-  auto const options    = ", hive_partitioning=true";
-  auto const s3_scan    = s3_parquet_glob_scan(*env, "glob/hive/year=*/nation.parquet", options);
+  auto const before_stats = sirius::test::get_transparent_execution_stats(fixture.con);
+  auto const options      = ", hive_partitioning=true";
+  auto const s3_scan      = s3_parquet_glob_scan(*env, "glob/hive/year=*/nation.parquet", options);
   auto const local_scan = local_parquet_glob_scan(*env, "glob/hive/year=*/nation.parquet", options);
   auto const s3_query   = "SELECT year, count(*), min(n_nationkey), max(n_nationkey) FROM " +
                         s3_scan + " GROUP BY year ORDER BY year";
@@ -2513,6 +2522,76 @@ TEST_CASE("transparent S3 glob preserves hive partition columns",
                            local_scan + " GROUP BY year ORDER BY year";
 
   compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+  auto const after_stats = sirius::test::get_transparent_execution_stats(fixture.con);
+  sirius::test::require_transparent_execution_delta(before_stats, after_stats, 1, 0, 1);
+}
+
+TEST_CASE("transparent S3 glob scans use parquet footer probes",
+          "[s3][integration][sql][gpu_execution][transparent][glob][footerbind]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  sirius_memory_limits limits;
+  limits.rest_perf_instrumentation = true;
+  s3_sql_fixture fixture(*env, limits);
+  set_gpu_execution(fixture.con, true);
+
+  auto& rest = require_rest_ioctx(fixture, s3_uri(env->bucket, "glob/multi/nation_a.parquet"));
+  auto const s3_scan     = s3_parquet_glob_scan(*env, "glob/multi/nation_*.parquet");
+  auto const local_scan  = local_parquet_glob_scan(*env, "glob/multi/nation_*.parquet");
+  auto const s3_query    = "SELECT count(n_nationkey), min(n_name), max(n_name) FROM " + s3_scan;
+  auto const local_query = "SELECT count(n_nationkey), min(n_name), max(n_name) FROM " + local_scan;
+
+  auto const before = rest.perf_snapshot();
+  compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+  auto const delta = delta_snapshot(rest.perf_snapshot(), before);
+
+  CHECK(delta.native_footer_get_count == 0);
+}
+
+TEST_CASE("transparent S3 glob remains correct with a straddled footer-probe window",
+          "[s3][integration][sql][gpu_execution][transparent][glob][footerbind]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  sirius_memory_limits limits;
+  limits.rest_footer_probe_bytes = "512 B";
+  s3_sql_fixture fixture(*env, limits);
+  set_gpu_execution(fixture.con, true);
+
+  auto const s3_scan     = s3_parquet_glob_scan(*env, "glob/multi/nation_*.parquet");
+  auto const local_scan  = local_parquet_glob_scan(*env, "glob/multi/nation_*.parquet");
+  auto const s3_query    = "SELECT count(n_nationkey), min(n_name), max(n_name) FROM " + s3_scan;
+  auto const local_query = "SELECT count(n_nationkey), min(n_name), max(n_name) FROM " + local_scan;
+
+  compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+}
+
+TEST_CASE("transparent S3 glob warm scan skips native footer reads",
+          "[s3][integration][sql][gpu_execution][transparent][glob][footerbind]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  sirius_memory_limits limits;
+  limits.rest_perf_instrumentation = true;
+  s3_sql_fixture fixture(*env, limits);
+  set_gpu_execution(fixture.con, true);
+
+  auto& rest = require_rest_ioctx(fixture, s3_uri(env->bucket, "glob/multi/nation_a.parquet"));
+  auto const s3_scan     = s3_parquet_glob_scan(*env, "glob/multi/nation_*.parquet");
+  auto const local_scan  = local_parquet_glob_scan(*env, "glob/multi/nation_*.parquet");
+  auto const s3_query    = "SELECT count(n_nationkey), min(n_name), max(n_name) FROM " + s3_scan;
+  auto const local_query = "SELECT count(n_nationkey), min(n_name), max(n_name) FROM " + local_scan;
+
+  compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+  auto const before_warm = rest.perf_snapshot();
+  compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+  auto const warm_delta = delta_snapshot(rest.perf_snapshot(), before_warm);
+
+  CHECK(warm_delta.native_footer_get_count == 0);
 }
 
 TEST_CASE("transparent S3 glob matcher semantics match DuckDB segment globs",

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -849,11 +849,11 @@ sirius::io::rest::rest_perf_snapshot delta_snapshot(
     sat_sub(after.device_stream_sync_total, before.device_stream_sync_total);
   out.payload_bytes_read_total =
     sat_sub(after.payload_bytes_read_total, before.payload_bytes_read_total);
-  out.native_footer_get_count =
-    sat_sub(after.native_footer_get_count, before.native_footer_get_count);
-  out.native_footer_wall_ns_total =
-    sat_sub(after.native_footer_wall_ns_total, before.native_footer_wall_ns_total);
-  out.native_footer_wall_ns_max = after.native_footer_wall_ns_max;
+  out.blocking_host_get_count =
+    sat_sub(after.blocking_host_get_count, before.blocking_host_get_count);
+  out.blocking_host_get_wall_ns_total =
+    sat_sub(after.blocking_host_get_wall_ns_total, before.blocking_host_get_wall_ns_total);
+  out.blocking_host_get_wall_ns_max = after.blocking_host_get_wall_ns_max;
   return out;
 }
 
@@ -2637,7 +2637,7 @@ TEST_CASE("transparent S3 glob scans use parquet footer probes",
   compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
   auto const delta = delta_snapshot(rest.perf_snapshot(), before);
 
-  CHECK(delta.native_footer_get_count == 0);
+  CHECK(delta.blocking_host_get_count == 0);
 }
 
 TEST_CASE("transparent S3 glob remains correct with a straddled footer-probe window",
@@ -2681,7 +2681,7 @@ TEST_CASE("transparent S3 glob warm scan skips blocking host reads",
   compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
   auto const warm_delta = delta_snapshot(rest.perf_snapshot(), before_warm);
 
-  CHECK(warm_delta.native_footer_get_count == 0);
+  CHECK(warm_delta.blocking_host_get_count == 0);
 }
 
 TEST_CASE("transparent S3 glob matcher semantics match DuckDB segment globs",

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -3660,9 +3660,8 @@ TEST_CASE("gpu_execution large S3 lineitem join uses planner cardinality and mat
     large_lineitem_orders_join_query(local_parquet_file_scan(large->local_path),
                                      local_parquet_scan(*env, "orders")));
 
-  // The filtered query above guards correctness. With #1065 filter pushdown, its EXPLAIN reports
-  // DuckDB's post-filter orders estimate, so exact base cardinality requires this unfiltered plan;
-  // reusing large_lineitem_orders_join_query here would silently break this assertion again.
+  // Keep this plan unfiltered. The filtered query above checks correctness;
+  // filter pushdown makes EXPLAIN report a post-filter estimate.
   auto const explain_sql = "SELECT count(*) FROM " + s3_sirius_large_lineitem_scan(*env) +
                            " l JOIN " + s3_sirius_parquet_scan(*env, "orders") +
                            " o ON l.l_orderkey = o.o_orderkey";

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -500,6 +500,13 @@ std::unique_ptr<duckdb::MaterializedQueryResult> require_query_ok(duckdb::Connec
     static_cast<duckdb::MaterializedQueryResult*>(result.release()));
 }
 
+void query_or_throw_on_error(duckdb::Connection& con, std::string const& sql)
+{
+  auto result = con.Query(sql);
+  if (!result) { throw std::runtime_error("DuckDB returned a null query result"); }
+  if (result->HasError()) { result->ThrowError(); }
+}
+
 std::string gpu_execution_sql(std::string const& inner_sql)
 {
   std::string escaped;
@@ -711,6 +718,19 @@ sirius::io::rest::rest_ioctx& require_rest_ioctx(s3_sql_fixture& fixture, std::s
   auto* rest_ctx = dynamic_cast<sirius::io::rest::rest_ioctx*>(datasource->io_ctx().get());
   REQUIRE(rest_ctx != nullptr);
   return *rest_ctx;
+}
+
+void require_s3_keys_listed(s3_sql_fixture& fixture,
+                            s3_test_env const& env,
+                            std::vector<std::string_view> const& expected_keys)
+{
+  auto& rest  = require_rest_ioctx(fixture, s3_uri(env.bucket, "parquet/nation.parquet"));
+  auto listed = rest.list_objects(env.bucket, "glob-enc/");
+  for (auto const expected : expected_keys) {
+    INFO("expected LIST key=" << expected);
+    REQUIRE(std::any_of(
+      listed.begin(), listed.end(), [&](auto const& entry) { return entry.key == expected; }));
+  }
 }
 
 std::uint64_t rest_chunk_get_count(s3_sql_fixture& fixture, std::string const& uri)
@@ -2486,6 +2506,93 @@ TEST_CASE("transparent S3 read_parquet expands globbed parquet files",
   sirius::test::require_transparent_execution_delta(before_stats, after_stats, 1, 0, 1);
 }
 
+TEST_CASE("transparent S3 glob rejects a matched percent-encoded key instead of opening its decoy",
+          "[s3][integration][sql][gpu_execution][transparent][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+  require_s3_keys_listed(fixture, *env, {"glob-enc/a%2Fb.parquet", "glob-enc/a/b.parquet"});
+
+  auto const s3_query = "SELECT count(*) FROM " + s3_parquet_glob_scan(*env, "glob-enc/a*.parquet");
+
+  CHECK_THROWS_WITH(query_or_throw_on_error(fixture.con, s3_query),
+                    Catch::Contains("percent-encoded"));
+}
+
+TEST_CASE("transparent S3 glob opens keys containing URI fragment and query delimiters",
+          "[s3][integration][sql][gpu_execution][transparent][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+  require_s3_keys_listed(fixture, *env, {"glob-enc/x#1.parquet", "glob-enc/y?v.parquet"});
+
+  for (auto const pattern :
+       {std::string_view{"glob-enc/x*.parquet"}, std::string_view{"glob-enc/y*.parquet"}}) {
+    DYNAMIC_SECTION("pattern=" << pattern)
+    {
+      auto const s3_query    = "SELECT count(*) FROM " + s3_parquet_glob_scan(*env, pattern);
+      auto const local_query = "SELECT count(*) FROM " + local_parquet_glob_scan(*env, pattern);
+      compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+    }
+  }
+}
+
+TEST_CASE("transparent S3 glob opens a key containing a literal percent byte",
+          "[s3][integration][sql][gpu_execution][transparent][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+  require_s3_keys_listed(fixture, *env, {"glob-enc/100%.parquet"});
+
+  auto const s3_query =
+    "SELECT count(*) FROM " + s3_parquet_glob_scan(*env, "glob-enc/100*.parquet");
+  auto const local_query =
+    "SELECT count(*) FROM " + local_parquet_glob_scan(*env, "glob-enc/100*.parquet");
+  compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+}
+
+TEST_CASE("transparent S3 glob rejects a matched Hive-style percent-encoded key",
+          "[s3][integration][sql][gpu_execution][transparent][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+  require_s3_keys_listed(fixture, *env, {"glob-enc/t/col=a%20b/p0.parquet"});
+
+  auto const s3_query =
+    "SELECT count(*) FROM " + s3_parquet_glob_scan(*env, "glob-enc/t/*/*.parquet");
+
+  CHECK_THROWS_WITH(query_or_throw_on_error(fixture.con, s3_query),
+                    Catch::Contains("percent-encoded"));
+}
+
+TEST_CASE("transparent S3 glob ignores percent-encoded keys outside the match",
+          "[s3][integration][sql][gpu_execution][transparent][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+  require_s3_keys_listed(fixture, *env, {"glob-enc/a%2Fb.parquet", "glob-enc/y?v.parquet"});
+
+  auto const pattern     = std::string_view{"glob-enc/y*.parquet"};
+  auto const s3_query    = "SELECT count(*) FROM " + s3_parquet_glob_scan(*env, pattern);
+  auto const local_query = "SELECT count(*) FROM " + local_parquet_glob_scan(*env, pattern);
+  compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+}
+
 TEST_CASE("transparent S3 glob preserves hive partition columns",
           "[s3][integration][sql][gpu_execution][transparent][glob]")
 {
@@ -2552,7 +2659,7 @@ TEST_CASE("transparent S3 glob remains correct with a straddled footer-probe win
   compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
 }
 
-TEST_CASE("transparent S3 glob warm scan skips native footer reads",
+TEST_CASE("transparent S3 glob warm scan skips blocking host reads",
           "[s3][integration][sql][gpu_execution][transparent][glob][footerbind]")
 {
   auto env = load_s3_test_env();

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -307,6 +307,8 @@ struct sirius_memory_limits {
   std::optional<std::size_t> rest_max_connections;
   std::optional<bool> use_sirius_datasource;
   std::optional<std::string> rest_footer_probe_bytes;
+  std::optional<std::size_t> rest_list_max_matches;
+  std::optional<std::size_t> rest_list_max_scanned;
   bool rest_perf_instrumentation{false};
 };
 
@@ -421,6 +423,12 @@ class sirius_config_env_guard {
            "        request_timeout_s: 30\n";
     if (limits.rest_footer_probe_bytes.has_value()) {
       out << "        footer_probe_bytes: " << yaml_quote(*limits.rest_footer_probe_bytes) << "\n";
+    }
+    if (limits.rest_list_max_matches.has_value()) {
+      out << "        list_max_matches: " << *limits.rest_list_max_matches << "\n";
+    }
+    if (limits.rest_list_max_scanned.has_value()) {
+      out << "        list_max_scanned: " << *limits.rest_list_max_scanned << "\n";
     }
     if (limits.rest_perf_instrumentation) { out << "        perf_instrumentation: true\n"; }
     out.close();
@@ -2624,6 +2632,22 @@ TEST_CASE("transparent S3 glob reports no-files and GPU-only errors clearly",
     INFO(error);
     CHECK(error.find("S3 is GPU-only") != std::string::npos);
     CHECK(error.find("SET gpu_execution=true") != std::string::npos);
+  }
+
+  SECTION("configured glob match cap rejects overly broad matches")
+  {
+    sirius_memory_limits limits;
+    limits.rest_list_max_matches = 1;
+    s3_sql_fixture fixture(*env, limits);
+    set_gpu_execution(fixture.con, true);
+
+    auto result = fixture.con.Query("SELECT count(n_nationkey) FROM " +
+                                    s3_parquet_glob_scan(*env, "glob/multi/nation_*.parquet"));
+    REQUIRE(result);
+    REQUIRE(result->HasError());
+    auto const error = result->GetError();
+    INFO(error);
+    CHECK(error.find("narrow the glob prefix") != std::string::npos);
   }
 }
 

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -28,8 +28,6 @@
 #include <duckdb/parser/expression/constant_expression.hpp>
 #include <duckdb/parser/expression/function_expression.hpp>
 #include <duckdb/parser/tableref/table_function_ref.hpp>
-#include <sys/wait.h>
-#include <unistd.h>
 
 #include <algorithm>
 #include <array>
@@ -38,7 +36,6 @@
 #include <chrono>
 #include <cmath>
 #include <condition_variable>
-#include <csignal>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -724,20 +721,6 @@ std::uint64_t rest_chunk_get_count(s3_sql_fixture& fixture, std::string const& u
 std::uint64_t rest_terminal_failures(s3_sql_fixture& fixture, std::string const& uri)
 {
   return require_rest_ioctx(fixture, uri).perf_snapshot().terminal_failures_total;
-}
-
-bool wait_for_child(pid_t pid, std::chrono::milliseconds timeout, int& status)
-{
-  auto const deadline = std::chrono::steady_clock::now() + timeout;
-  while (std::chrono::steady_clock::now() < deadline) {
-    auto const result = ::waitpid(pid, &status, WNOHANG);
-    if (result == pid) { return true; }
-    if (result < 0 && errno != EINTR) {
-      throw std::runtime_error("waitpid failed while watching known issue repro");
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds{100});
-  }
-  return false;
 }
 
 struct large_lineitem_fixture {
@@ -2603,17 +2586,16 @@ TEST_CASE("transparent S3 glob matcher semantics match DuckDB segment globs",
   s3_sql_fixture fixture(*env);
   set_gpu_execution(fixture.con, true);
 
-  auto check_count =
-    [&](std::string_view s3_pattern, std::string_view local_pattern, std::int64_t expected) {
-      auto const s3_query =
-        "SELECT count(n_nationkey) FROM " + s3_parquet_glob_scan(*env, s3_pattern);
-      auto const local_query =
-        "SELECT count(n_nationkey) FROM " + local_parquet_glob_scan(*env, local_pattern);
-      compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
-      auto result = require_query_ok(fixture.con, s3_query);
-      REQUIRE(result->RowCount() == 1);
-      CHECK(result->GetValue(0, 0).GetValue<int64_t>() == expected);
-    };
+  auto check_count = [&](std::string_view s3_pattern,
+                         std::string_view local_pattern,
+                         std::int64_t expected) {
+    auto const s3_query    = "SELECT count(*) FROM " + s3_parquet_glob_scan(*env, s3_pattern);
+    auto const local_query = "SELECT count(*) FROM " + local_parquet_glob_scan(*env, local_pattern);
+    compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+    auto result = require_query_ok(fixture.con, s3_query);
+    REQUIRE(result->RowCount() == 1);
+    CHECK(result->GetValue(0, 0).GetValue<int64_t>() == expected);
+  };
 
   check_count("glob/multi/nation_?.parquet", "glob/multi/nation_?.parquet", 50);
   check_count("glob/multi/nation_[ab].parquet", "glob/multi/nation_[ab].parquet", 50);
@@ -2637,41 +2619,6 @@ TEST_CASE("transparent S3 glob matcher semantics match DuckDB segment globs",
   REQUIRE(wildcard_bucket->HasError());
   INFO(wildcard_bucket->GetError());
   CHECK(wildcard_bucket->GetError().find("bucket") != std::string::npos);
-}
-
-TEST_CASE("known issue: transparent hive-layout glob count star hangs",
-          "[.][s3][integration][known-issue][glob]")
-{
-  auto env = load_s3_test_env();
-  if (should_skip_s3_env(env)) { return; }
-
-  INFO("Known issue: /Users/tengyu/code/doc/s3support/issue-hive-glob-count-star-hang.md");
-
-  auto const pid = ::fork();
-  REQUIRE(pid >= 0);
-  if (pid == 0) {
-    try {
-      s3_sql_fixture fixture(*env);
-      set_gpu_execution(fixture.con, true);
-      auto result = fixture.con.Query("SELECT count(*) FROM " +
-                                      s3_parquet_glob_scan(*env, "glob/hive/**/*.parquet"));
-      if (result && !result->HasError()) { ::_exit(0); }
-      ::_exit(2);
-    } catch (...) {
-      ::_exit(3);
-    }
-  }
-
-  int status = 0;
-  if (!wait_for_child(pid, std::chrono::seconds{10}, status)) {
-    (void)::kill(pid, SIGKILL);
-    (void)::waitpid(pid, &status, 0);
-    SUCCEED("Known issue reproduced: hive-layout glob count(*) did not return before watchdog");
-    return;
-  }
-
-  INFO("child status=" << status);
-  FAIL("Known issue no longer reproduces; remove or update this tracker");
 }
 
 TEST_CASE("transparent S3 glob reports no-files and GPU-only errors clearly",

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -2533,6 +2533,17 @@ TEST_CASE("transparent S3 glob matcher semantics match DuckDB segment globs",
   check_count("glob/hive/**/nation.parquet", "glob/hive/**/nation.parquet", 50);
   check_count("root_*.parquet", "root_*.parquet", 50);
 
+  auto uppercase_root_uri = s3_uri(env->bucket, "root_*.parquet");
+  uppercase_root_uri.replace(0, 2, "S3");
+  auto const uppercase_root_query =
+    "SELECT count(n_nationkey) FROM read_parquet(" + sql_quote(uppercase_root_uri) + ")";
+  auto const local_root_query =
+    "SELECT count(n_nationkey) FROM " + local_parquet_glob_scan(*env, "root_*.parquet");
+  compare_transparent_s3_gpu_to_local_cpu(fixture, uppercase_root_query, local_root_query);
+  auto uppercase_root = require_query_ok(fixture.con, uppercase_root_query);
+  REQUIRE(uppercase_root->RowCount() == 1);
+  CHECK(uppercase_root->GetValue(0, 0).GetValue<int64_t>() == 50);
+
   auto wildcard_bucket =
     fixture.con.Query("SELECT count(*) FROM read_parquet('s3://*/glob/multi/nation_*.parquet')");
   REQUIRE(wildcard_bucket);

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -3527,9 +3527,13 @@ TEST_CASE("gpu_execution large S3 lineitem join uses planner cardinality and mat
     large_lineitem_orders_join_query(local_parquet_file_scan(large->local_path),
                                      local_parquet_scan(*env, "orders")));
 
-  auto const explain_sql = large_lineitem_orders_join_query(s3_sirius_large_lineitem_scan(*env),
-                                                            s3_sirius_parquet_scan(*env, "orders"));
-  auto const plan        = explain_text(fixture.con, explain_sql);
+  // The filtered query above guards correctness. With #1065 filter pushdown, its EXPLAIN reports
+  // DuckDB's post-filter orders estimate, so exact base cardinality requires this unfiltered plan;
+  // reusing large_lineitem_orders_join_query here would silently break this assertion again.
+  auto const explain_sql = "SELECT count(*) FROM " + s3_sirius_large_lineitem_scan(*env) +
+                           " l JOIN " + s3_sirius_parquet_scan(*env, "orders") +
+                           " o ON l.l_orderkey = o.o_orderkey";
+  auto const plan = explain_text(fixture.con, explain_sql);
   INFO(plan);
   CHECK(plan_mentions_cardinality(plan, expected_lineitem_rows));
   CHECK(plan_mentions_cardinality(plan, expected_orders_rows));

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -2621,6 +2621,32 @@ TEST_CASE("transparent S3 glob matcher semantics match DuckDB segment globs",
   CHECK(wildcard_bucket->GetError().find("bucket") != std::string::npos);
 }
 
+TEST_CASE("transparent S3 glob scans 1001 parquet objects across LIST pages",
+          "[.][s3][integration][sql][gpu_execution][transparent][glob][large][glob-scale]")
+{
+  if (!truthy_env("SIRIUS_TEST_S3_GLOB_SCALE")) {
+    SUCCEED("SIRIUS_TEST_S3_GLOB_SCALE is not enabled");
+    return;
+  }
+
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+
+  auto const query =
+    "SELECT count(n_nationkey), sum(n_nationkey), min(n_nationkey), max(n_nationkey) FROM " +
+    s3_parquet_glob_scan(*env, "glob-scale/part_*.parquet");
+  auto result = require_query_ok(fixture.con, query);
+
+  REQUIRE(result->RowCount() == 1);
+  CHECK(result->GetValue(0, 0).GetValue<int64_t>() == 25'025);
+  CHECK(result->GetValue(1, 0).GetValue<int64_t>() == 300'300);
+  CHECK(result->GetValue(2, 0).GetValue<int64_t>() == 0);
+  CHECK(result->GetValue(3, 0).GetValue<int64_t>() == 24);
+}
+
 TEST_CASE("transparent S3 glob reports no-files and GPU-only errors clearly",
           "[s3][integration][sql][gpu_execution][transparent][glob]")
 {

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -24,6 +24,7 @@
 #include "scan/test_utils.hpp"
 #include "scan_manager/sirius_scan_manager.hpp"
 #include "utils/s3_container.hpp"
+#include "utils/sirius_test_env.hpp"
 
 #include <rmm/cuda_stream.hpp>
 #include <rmm/device_buffer.hpp>
@@ -37,6 +38,7 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/time.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #include <utils/log_test_utils.hpp>
 
@@ -46,6 +48,7 @@
 #include <cctype>
 #include <cerrno>
 #include <chrono>
+#include <csignal>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -264,6 +267,13 @@ struct generated_listing {
   std::size_t total{0};
 };
 
+enum class scripted_list_mode {
+  normal,
+  repeated_empty_token,
+  alternating_empty_tokens,
+  truncated_empty_without_token
+};
+
 class fixed_url_authorizer final : public sirius::io::s3::s3_request_authorizer {
  public:
   explicit fixed_url_authorizer(std::string endpoint) : _endpoint(std::move(endpoint)) {}
@@ -290,8 +300,9 @@ class range_http_server {
  public:
   explicit range_http_server(std::vector<std::uint8_t> object,
                              range_fault_policy fault          = {},
-                             std::vector<listed_object> listed = {})
-    : _object(std::move(object)), _fault(fault), _listed(std::move(listed))
+                             std::vector<listed_object> listed = {},
+                             scripted_list_mode list_mode      = scripted_list_mode::normal)
+    : _object(std::move(object)), _fault(fault), _listed(std::move(listed)), _list_mode(list_mode)
   {
     REQUIRE_FALSE(_object.empty());
 
@@ -570,6 +581,33 @@ class range_http_server {
       send_all(fd, response);
       return;
     }
+    if (_fault.response_delay.count() > 0) { std::this_thread::sleep_for(_fault.response_delay); }
+
+    if (_list_mode != scripted_list_mode::normal) {
+      std::string token_out;
+      if (_list_mode == scripted_list_mode::repeated_empty_token) {
+        token_out = "repeat-token";
+      } else if (_list_mode == scripted_list_mode::alternating_empty_tokens) {
+        token_out = list_idx % 2 == 0 ? "token-A" : "token-B";
+      }
+
+      std::ostringstream xml;
+      xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+             "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
+             "<IsTruncated>true</IsTruncated>";
+      if (!token_out.empty()) {
+        xml << "<NextContinuationToken>" << xml_escape(token_out) << "</NextContinuationToken>";
+      }
+      xml << "</ListBucketResult>";
+
+      auto body = xml.str();
+      std::string response =
+        "HTTP/1.1 200 OK\r\nContent-Type: application/xml\r\nContent-Length: " +
+        std::to_string(body.size()) + "\r\nConnection: close\r\n\r\n";
+      send_all(fd, response);
+      send_all(fd, body);
+      return;
+    }
 
     auto prefix          = query_value(target, "prefix");
     auto token           = query_value(target, "continuation-token");
@@ -703,6 +741,7 @@ class range_http_server {
   std::vector<std::uint8_t> _object;
   range_fault_policy _fault;
   std::vector<listed_object> _listed;
+  scripted_list_mode _list_mode;
   std::optional<generated_listing> _generated_listing;
   std::atomic<bool> _stop{false};
   std::atomic<std::size_t> _head_count{0};
@@ -747,6 +786,67 @@ std::shared_ptr<rest_ioctx> make_direct_rest_ioctx(std::string endpoint)
 
 using capture_sink       = sirius::test::recording_log_sink;
 using scoped_log_capture = sirius::test::scoped_recording_log_sink;
+
+struct list_watchdog_result {
+  bool timed_out{false};
+  bool exited_normally{false};
+  int exit_code{-1};
+};
+
+list_watchdog_result run_list_watchdog(range_http_server const& server,
+                                       std::chrono::milliseconds startup_timeout,
+                                       std::chrono::milliseconds operation_timeout)
+{
+  if (sirius::test::g_integration_env != nullptr && sirius::test::g_integration_env->is_active()) {
+    sirius::test::g_integration_env->pause();
+  }
+
+  constexpr char k_endpoint_env[] = "SIRIUS_TEST_REST_LIST_WATCHDOG_ENDPOINT";
+  std::optional<std::string> old_endpoint;
+  if (auto const* current = std::getenv(k_endpoint_env); current != nullptr) {
+    old_endpoint = current;
+  }
+  auto const endpoint = server.endpoint();
+  REQUIRE(::setenv(k_endpoint_env, endpoint.c_str(), 1) == 0);
+
+  auto const pid = ::fork();
+  REQUIRE(pid >= 0);
+  if (pid == 0) {
+    ::execl("/proc/self/exe",
+            "sirius_unittest",
+            "rest LIST loop watchdog child runner",
+            static_cast<char*>(nullptr));
+    ::_exit(127);
+  }
+
+  if (old_endpoint.has_value()) {
+    REQUIRE(::setenv(k_endpoint_env, old_endpoint->c_str(), 1) == 0);
+  } else {
+    REQUIRE(::unsetenv(k_endpoint_env) == 0);
+  }
+
+  int status        = 0;
+  bool request_seen = false;
+  auto stop         = std::chrono::steady_clock::now() + startup_timeout;
+  while (std::chrono::steady_clock::now() < stop) {
+    if (!request_seen && server.list_count() > 0) {
+      request_seen = true;
+      stop         = std::chrono::steady_clock::now() + operation_timeout;
+    }
+    auto const waited = ::waitpid(pid, &status, WNOHANG);
+    if (waited == pid) {
+      return {.timed_out       = false,
+              .exited_normally = WIFEXITED(status),
+              .exit_code       = WIFEXITED(status) ? WEXITSTATUS(status) : -1};
+    }
+    if (waited < 0) { return {}; }
+    std::this_thread::sleep_for(20ms);
+  }
+
+  (void)::kill(pid, SIGKILL);
+  (void)::waitpid(pid, &status, 0);
+  return {.timed_out = true, .exited_normally = false, .exit_code = -1};
+}
 
 }  // namespace
 
@@ -1181,7 +1281,7 @@ TEST_CASE("rest LIST retries are observable and isolated from object-read byte c
     range_http_server server(deterministic_payload(16), fault, objects);
     auto ctx    = make_direct_rest_ioctx(server.endpoint(), cfg);
     auto before = ctx->perf_snapshot();
-    scoped_spdlog_capture logs;
+    scoped_log_capture logs;
 
     auto listed = ctx->list_objects("bucket", "data/", /*page_size=*/1000);
     auto after  = ctx->perf_snapshot();
@@ -1195,9 +1295,9 @@ TEST_CASE("rest LIST retries are observable and isolated from object-read byte c
 
     auto records = logs.records();
     CHECK(std::any_of(records.begin(), records.end(), [](capture_sink::record const& record) {
-      return record.level == spdlog::level::warn &&
-             record.payload.find("bucket") != std::string::npos &&
-             record.payload.find("data/") != std::string::npos;
+      return record.level == sirius::log::level::warn &&
+             record.message.find("bucket") != std::string::npos &&
+             record.message.find("data/") != std::string::npos;
     }));
   }
 
@@ -1206,7 +1306,7 @@ TEST_CASE("rest LIST retries are observable and isolated from object-read byte c
     range_http_server server(deterministic_payload(16), {}, objects);
     auto ctx    = make_direct_rest_ioctx(server.endpoint(), cfg);
     auto before = ctx->perf_snapshot();
-    scoped_spdlog_capture logs;
+    scoped_log_capture logs;
 
     auto listed = ctx->list_objects("bucket", "data/", /*page_size=*/1000);
     auto after  = ctx->perf_snapshot();
@@ -1219,7 +1319,7 @@ TEST_CASE("rest LIST retries are observable and isolated from object-read byte c
 
     auto records = logs.records();
     CHECK(std::none_of(records.begin(), records.end(), [](capture_sink::record const& record) {
-      return record.level >= spdlog::level::warn;
+      return record.level >= sirius::log::level::warn;
     }));
   }
 }

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -700,12 +700,13 @@ sirius::io::rest::config direct_rest_test_config()
 }
 
 std::shared_ptr<rest_ioctx> make_direct_rest_ioctx(std::string endpoint,
-                                                   sirius::io::rest::config cfg)
+                                                   sirius::io::rest::config cfg,
+                                                   std::size_t n_reactors = 1)
 {
   auto authorizer = std::make_shared<fixed_url_authorizer>(std::move(endpoint));
   auto ctx        = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
     cfg, std::move(authorizer), nullptr);
-  auto ioctx = std::make_shared<rest_ioctx>(1, std::move(ctx));
+  auto ioctx = std::make_shared<rest_ioctx>(n_reactors, std::move(ctx));
   ioctx->start();
   return ioctx;
 }
@@ -742,6 +743,133 @@ TEST_CASE("rest_ioctx lists S3 objects with sizes and follows encoded continuati
   CHECK(server.list_count() == 3);
   CHECK(server.get_count() == 0);
   CHECK(server.head_count() == 0);
+}
+
+TEST_CASE("rest perf snapshot attributes native footer reads separately from chunk reads",
+          "[s3][integration][rest][perf]")
+{
+  SECTION("native footer counters exist and default to zero")
+  {
+    sirius::io::rest::rest_perf_snapshot snapshot{};
+    CHECK(snapshot.native_footer_get_count == 0);
+    CHECK(snapshot.native_footer_wall_ns_total == 0);
+    CHECK(snapshot.native_footer_wall_ns_max == 0);
+  }
+
+  SECTION("blocking host_read network GETs are counted and pool-aggregated")
+  {
+    auto payload = deterministic_payload(16 * 1024);
+    range_http_server server(payload);
+    auto cfg                  = direct_rest_test_config();
+    cfg.perf_instrumentation  = true;
+    cfg.max_connections       = 1;
+    std::size_t const readers = 2;
+    auto ioctx                = make_direct_rest_ioctx(server.endpoint(), cfg, readers);
+    auto datasource           = ioctx->open_datasource("s3://footer-bucket/native-footer.bin",
+                                             static_cast<std::uint64_t>(payload.size()));
+
+    auto const before = ioctx->perf_snapshot();
+
+    std::array<std::uint8_t, 64> first{};
+    REQUIRE(datasource->host_read(17, first.size(), first.data()) == first.size());
+    require_bytes_equal(first, std::span<std::uint8_t const>(payload.data() + 17, first.size()));
+
+    std::array<std::uint8_t, 32> second{};
+    REQUIRE(datasource->host_read(4096, second.size(), second.data()) == second.size());
+    require_bytes_equal(second,
+                        std::span<std::uint8_t const>(payload.data() + 4096, second.size()));
+
+    auto const after = ioctx->perf_snapshot();
+    CHECK(after.native_footer_get_count == before.native_footer_get_count + readers);
+    CHECK(after.native_footer_wall_ns_total > before.native_footer_wall_ns_total);
+    CHECK(after.native_footer_wall_ns_max > 0);
+    CHECK(after.chunk_get_count == before.chunk_get_count + readers);
+    CHECK(server.get_count() == readers);
+  }
+
+  SECTION("stash-served parquet footer reads are not counted as native network footer reads")
+  {
+    auto const parquet    = read_binary_file(committed_parquet_fixture("nation.parquet"));
+    auto const footer_len = static_cast<std::size_t>(parquet_footer_len(parquet));
+    auto const footer_off = parquet.size() - 8 - footer_len;
+    range_http_server server(parquet);
+    auto cfg                 = direct_rest_test_config();
+    cfg.perf_instrumentation = true;
+    auto ioctx               = make_direct_rest_ioctx(server.endpoint(), cfg);
+    auto datasource          = ioctx->open_datasource("s3://footer-bucket/nation.parquet",
+                                             sirius::io::open_hint::parquet_footer_probe);
+    REQUIRE(datasource != nullptr);
+
+    auto const before = ioctx->perf_snapshot();
+
+    std::array<std::uint8_t, 8> trailer{};
+    REQUIRE(datasource->host_read(
+              parquet.size() - trailer.size(), trailer.size(), trailer.data()) == trailer.size());
+    require_bytes_equal(trailer,
+                        std::span<std::uint8_t const>(parquet.data() + parquet.size() - 8, 8));
+
+    std::vector<std::uint8_t> footer(footer_len);
+    REQUIRE(datasource->host_read(footer_off, footer.size(), footer.data()) == footer.size());
+    require_bytes_equal(footer,
+                        std::span<std::uint8_t const>(parquet.data() + footer_off, footer_len));
+
+    auto const after = ioctx->perf_snapshot();
+    CHECK(after.native_footer_get_count == before.native_footer_get_count);
+    CHECK(after.native_footer_wall_ns_total == before.native_footer_wall_ns_total);
+    CHECK(after.native_footer_wall_ns_max == before.native_footer_wall_ns_max);
+    CHECK(server.get_count() == 1);
+  }
+
+  SECTION("async chunk reads bump chunk counters without touching native footer counters")
+  {
+    auto payload = deterministic_payload(64 * 1024);
+    range_http_server server(payload);
+    auto cfg                 = direct_rest_test_config();
+    cfg.perf_instrumentation = true;
+    auto ioctx               = make_direct_rest_ioctx(server.endpoint(), cfg);
+    auto datasource          = ioctx->open_datasource("s3://footer-bucket/chunk-data.bin",
+                                             static_cast<std::uint64_t>(payload.size()));
+
+    std::vector<std::uint8_t> a(257);
+    std::vector<std::uint8_t> b(1024);
+    std::array<sirius::io::io_object_segment, 2> segments{
+      sirius::io::io_object_segment{17, a.size(), a.data()},
+      sirius::io::io_object_segment{4096, b.size(), b.data()}};
+
+    auto const before = ioctx->perf_snapshot();
+    auto got =
+      std::move(ioctx->host_read_ranges_async_io(datasource->io_object(), segments)).get(5s);
+    auto const after = ioctx->perf_snapshot();
+
+    REQUIRE(got == a.size() + b.size());
+    require_bytes_equal(a, std::span<std::uint8_t const>(payload.data() + 17, a.size()));
+    require_bytes_equal(b, std::span<std::uint8_t const>(payload.data() + 4096, b.size()));
+    CHECK(after.chunk_get_count > before.chunk_get_count);
+    CHECK(after.native_footer_get_count == before.native_footer_get_count);
+    CHECK(after.native_footer_wall_ns_total == before.native_footer_wall_ns_total);
+    CHECK(after.native_footer_wall_ns_max == before.native_footer_wall_ns_max);
+  }
+
+  SECTION("native footer counters are gated off when perf instrumentation is disabled")
+  {
+    auto payload = deterministic_payload(4096);
+    range_http_server server(payload);
+    auto cfg                 = direct_rest_test_config();
+    cfg.perf_instrumentation = false;
+    auto ioctx               = make_direct_rest_ioctx(server.endpoint(), cfg);
+    auto datasource          = ioctx->open_datasource("s3://footer-bucket/perf-off.bin",
+                                             static_cast<std::uint64_t>(payload.size()));
+
+    std::array<std::uint8_t, 128> out{};
+    REQUIRE(datasource->host_read(99, out.size(), out.data()) == out.size());
+    require_bytes_equal(out, std::span<std::uint8_t const>(payload.data() + 99, out.size()));
+
+    auto const after = ioctx->perf_snapshot();
+    CHECK(after.native_footer_get_count == 0);
+    CHECK(after.native_footer_wall_ns_total == 0);
+    CHECK(after.native_footer_wall_ns_max == 0);
+    CHECK(server.get_count() == 1);
+  }
 }
 
 TEST_CASE("rest_ioctx paged LIST supports early stop and explicit safety caps",

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -259,6 +259,11 @@ struct listed_object {
   std::uint64_t size{0};
 };
 
+struct generated_listing {
+  std::string prefix;
+  std::size_t total{0};
+};
+
 class fixed_url_authorizer final : public sirius::io::s3::s3_request_authorizer {
  public:
   explicit fixed_url_authorizer(std::string endpoint) : _endpoint(std::move(endpoint)) {}
@@ -339,6 +344,11 @@ class range_http_server {
   [[nodiscard]] std::size_t list_count() const noexcept { return _list_count.load(); }
   [[nodiscard]] std::size_t body_bytes_sent() const noexcept { return _body_bytes_sent.load(); }
   [[nodiscard]] int peak_active_gets() const noexcept { return _peak_active_gets.load(); }
+
+  void set_generated_listing(std::string prefix, std::size_t total)
+  {
+    _generated_listing = generated_listing{std::move(prefix), total};
+  }
 
  private:
   struct active_get_guard {
@@ -571,24 +581,42 @@ class range_http_server {
     }
     auto start = page_start_from_token(token);
 
-    std::vector<listed_object> matching;
-    for (auto const& object : _listed) {
-      if (object.key.rfind(prefix, 0) == 0) { matching.push_back(object); }
-    }
-
-    if (start > matching.size()) { start = matching.size(); }
-    auto end              = std::min(start + max_keys, matching.size());
-    bool truncated        = end < matching.size();
-    std::string token_out = truncated ? continuation_token_for(end) : std::string{};
-
     std::ostringstream xml;
     xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
            "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
-           "<IsTruncated>"
-        << (truncated ? "true" : "false") << "</IsTruncated>";
-    for (auto i = start; i < end; ++i) {
-      xml << "<Contents><Key>" << xml_escape(matching[i].key) << "</Key><Size>" << matching[i].size
-          << "</Size></Contents>";
+           "<IsTruncated>";
+
+    auto const emit_contents = [&](std::string_view key, std::uint64_t size) {
+      xml << "<Contents><Key>" << xml_escape(key) << "</Key><Size>" << size << "</Size></Contents>";
+    };
+
+    bool truncated        = false;
+    std::string token_out = {};
+    if (_generated_listing.has_value() && prefix == _generated_listing->prefix) {
+      auto const total = _generated_listing->total;
+      if (start > total) { start = total; }
+      auto const end = std::min(start + max_keys, total);
+      truncated      = end < total;
+      token_out      = truncated ? continuation_token_for(end) : std::string{};
+      xml << (truncated ? "true" : "false") << "</IsTruncated>";
+      for (std::size_t i = start; i < end; ++i) {
+        emit_contents(_generated_listing->prefix + std::to_string(i),
+                      static_cast<std::uint64_t>(i % 4096U));
+      }
+    } else {
+      std::vector<listed_object> matching;
+      for (auto const& object : _listed) {
+        if (object.key.rfind(prefix, 0) == 0) { matching.push_back(object); }
+      }
+
+      if (start > matching.size()) { start = matching.size(); }
+      auto const end = std::min(start + max_keys, matching.size());
+      truncated      = end < matching.size();
+      token_out      = truncated ? continuation_token_for(end) : std::string{};
+      xml << (truncated ? "true" : "false") << "</IsTruncated>";
+      for (auto i = start; i < end; ++i) {
+        emit_contents(matching[i].key, matching[i].size);
+      }
     }
     if (truncated) {
       xml << "<NextContinuationToken>" << xml_escape(token_out) << "</NextContinuationToken>";
@@ -675,6 +703,7 @@ class range_http_server {
   std::vector<std::uint8_t> _object;
   range_fault_policy _fault;
   std::vector<listed_object> _listed;
+  std::optional<generated_listing> _generated_listing;
   std::atomic<bool> _stop{false};
   std::atomic<std::size_t> _head_count{0};
   std::atomic<std::size_t> _get_count{0};
@@ -984,6 +1013,156 @@ TEST_CASE("rest_ioctx paged LIST supports early stop and explicit safety caps",
     auto none = ctx->list_objects("bucket", "missing/", /*page_size=*/1);
     CHECK(none.empty());
     CHECK(server.list_count() == 1);
+  }
+}
+
+TEST_CASE("rest_ioctx generated LIST scale obeys configured caps without accumulating pages",
+          "[s3][integration][rest][list]")
+{
+  SECTION("scanned cap triggers page-by-page with one page held at a time")
+  {
+    range_http_server server(deterministic_payload(16));
+    server.set_generated_listing("big/", 6000);
+    auto cfg               = direct_rest_test_config();
+    cfg.list_max_scanned   = 5000;
+    auto ctx               = make_direct_rest_ioctx(server.endpoint(), cfg);
+    std::size_t max_seen   = 0;
+    std::size_t sink_calls = 0;
+
+    bool threw = false;
+    try {
+      ctx->list_objects_paged("bucket",
+                              "big/",
+                              /*page_size=*/1000,
+                              [&](sirius::io::s3::list_objects_v2_page const& page) {
+                                max_seen = std::max(max_seen, page.entries.size());
+                                ++sink_calls;
+                                return true;
+                              });
+    } catch (std::exception const& e) {
+      threw            = true;
+      auto const error = std::string{e.what()};
+      CHECK(error.find("scanned more than 5000") != std::string::npos);
+      CHECK(error.find("narrow the glob prefix") != std::string::npos);
+    }
+
+    CHECK(threw);
+    CHECK(max_seen <= 1000);
+    CHECK(sink_calls == 5);
+    CHECK(server.list_count() == 6);
+  }
+
+  SECTION("matched cap stops the accumulating wrapper")
+  {
+    range_http_server server(deterministic_payload(16));
+    server.set_generated_listing("big/", 600);
+    auto cfg             = direct_rest_test_config();
+    cfg.list_max_matches = 500;
+    auto ctx             = make_direct_rest_ioctx(server.endpoint(), cfg);
+
+    bool threw = false;
+    try {
+      (void)ctx->list_objects("bucket", "big/", /*page_size=*/1000);
+    } catch (std::exception const& e) {
+      threw            = true;
+      auto const error = std::string{e.what()};
+      CHECK(error.find("more than 500") != std::string::npos);
+      CHECK(error.find("narrow the glob prefix") != std::string::npos);
+    }
+    CHECK(threw);
+    CHECK(server.list_count() == 1);
+  }
+
+  SECTION("under the default caps succeeds and preserves generated key order")
+  {
+    range_http_server server(deterministic_payload(16));
+    server.set_generated_listing("big/", 500);
+    auto ctx = make_direct_rest_ioctx(server.endpoint());
+
+    auto listed = ctx->list_objects("bucket", "big/", /*page_size=*/1000);
+
+    REQUIRE(listed.size() == 500);
+    CHECK(listed.front().key == "big/0");
+    CHECK(listed.front().size == 0);
+    CHECK(listed.back().key == "big/499");
+    CHECK(listed.back().size == 499);
+    CHECK(server.list_count() == 1);
+  }
+
+  SECTION("early stop returns after the first generated page even for a large prefix")
+  {
+    range_http_server server(deterministic_payload(16));
+    server.set_generated_listing("big/", 100000);
+    auto ctx               = make_direct_rest_ioctx(server.endpoint());
+    std::size_t max_seen   = 0;
+    std::size_t sink_calls = 0;
+
+    ctx->list_objects_paged("bucket",
+                            "big/",
+                            /*page_size=*/1000,
+                            [&](sirius::io::s3::list_objects_v2_page const& page) {
+                              max_seen = std::max(max_seen, page.entries.size());
+                              ++sink_calls;
+                              return false;
+                            });
+
+    CHECK(max_seen <= 1000);
+    CHECK(sink_calls == 1);
+    CHECK(server.list_count() == 1);
+  }
+}
+
+TEST_CASE("rest_ioctx generated LIST scale obeys the default safety caps",
+          "[.][s3][integration][rest][list][stress]")
+{
+  SECTION("default scanned cap trips at one million entries without retaining pages")
+  {
+    range_http_server server(deterministic_payload(16));
+    server.set_generated_listing("big/", 1000001);
+    auto ctx               = make_direct_rest_ioctx(server.endpoint());
+    std::size_t max_seen   = 0;
+    std::size_t sink_calls = 0;
+
+    bool threw = false;
+    try {
+      ctx->list_objects_paged("bucket",
+                              "big/",
+                              /*page_size=*/1000,
+                              [&](sirius::io::s3::list_objects_v2_page const& page) {
+                                max_seen = std::max(max_seen, page.entries.size());
+                                ++sink_calls;
+                                return true;
+                              });
+    } catch (std::exception const& e) {
+      threw            = true;
+      auto const error = std::string{e.what()};
+      CHECK(error.find("scanned more than 1000000") != std::string::npos);
+      CHECK(error.find("narrow the glob prefix") != std::string::npos);
+    }
+
+    CHECK(threw);
+    CHECK(max_seen <= 1000);
+    CHECK(sink_calls == 1000);
+    CHECK(server.list_count() == 1001);
+  }
+
+  SECTION("default matched cap trips at one hundred thousand accumulated entries")
+  {
+    range_http_server server(deterministic_payload(16));
+    server.set_generated_listing("big/", 100001);
+    auto ctx = make_direct_rest_ioctx(server.endpoint());
+
+    bool threw = false;
+    try {
+      (void)ctx->list_objects("bucket", "big/", /*page_size=*/1000);
+    } catch (std::exception const& e) {
+      threw            = true;
+      auto const error = std::string{e.what()};
+      CHECK(error.find("more than 100000") != std::string::npos);
+      CHECK(error.find("narrow the glob prefix") != std::string::npos);
+    }
+    CHECK(threw);
+    CHECK(server.list_count() == 101);
   }
 }
 

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -796,6 +796,58 @@ TEST_CASE("rest_ioctx paged LIST supports early stop and explicit safety caps",
                       Catch::Contains("narrow the glob prefix"));
   }
 
+  SECTION("primitive uses configured scanned cap unless an explicit override is passed")
+  {
+    auto cfg             = direct_rest_test_config();
+    cfg.list_max_scanned = 2;
+
+    range_http_server capped_server(deterministic_payload(16), {}, objects);
+    auto capped_ctx = make_direct_rest_ioctx(capped_server.endpoint(), cfg);
+
+    CHECK_THROWS_WITH(capped_ctx->list_objects_paged(
+                        "bucket",
+                        "data/",
+                        /*page_size=*/1,
+                        [](sirius::io::s3::list_objects_v2_page const&) { return true; }),
+                      Catch::Contains("narrow the glob prefix"));
+
+    range_http_server override_server(deterministic_payload(16), {}, objects);
+    auto override_ctx = make_direct_rest_ioctx(override_server.endpoint(), cfg);
+
+    std::size_t pages = 0;
+    override_ctx->list_objects_paged(
+      "bucket",
+      "data/",
+      /*page_size=*/1,
+      [&](sirius::io::s3::list_objects_v2_page const& page) {
+        ++pages;
+        REQUIRE(page.entries.size() == 1);
+        return true;
+      },
+      /*max_scanned=*/3);
+    CHECK(pages == 3);
+    CHECK(override_server.list_count() == 3);
+  }
+
+  SECTION("wrapper uses configured matched cap unless an explicit override is passed")
+  {
+    auto cfg             = direct_rest_test_config();
+    cfg.list_max_matches = 2;
+
+    range_http_server capped_server(deterministic_payload(16), {}, objects);
+    auto capped_ctx = make_direct_rest_ioctx(capped_server.endpoint(), cfg);
+
+    CHECK_THROWS_WITH(capped_ctx->list_objects("bucket", "data/", /*page_size=*/1000),
+                      Catch::Contains("narrow the glob prefix"));
+
+    range_http_server override_server(deterministic_payload(16), {}, objects);
+    auto override_ctx = make_direct_rest_ioctx(override_server.endpoint(), cfg);
+
+    auto all = override_ctx->list_objects("bucket", "data/", /*page_size=*/1000, /*max_keys=*/3);
+    CHECK(all.size() == 3);
+    CHECK(override_server.list_count() == 1);
+  }
+
   SECTION("empty prefix returns an empty vector")
   {
     range_http_server server(deterministic_payload(16), {}, objects);

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -874,15 +874,90 @@ TEST_CASE("rest_ioctx lists S3 objects with sizes and follows encoded continuati
   CHECK(server.head_count() == 0);
 }
 
-TEST_CASE("rest perf snapshot attributes native footer reads separately from chunk reads",
+TEST_CASE("rest LIST loop watchdog child runner", "[.][rest][list][watchdog_child]")
+{
+  auto const* endpoint = std::getenv("SIRIUS_TEST_REST_LIST_WATCHDOG_ENDPOINT");
+  if (endpoint == nullptr) { return; }
+
+  auto ctx = make_direct_rest_ioctx(endpoint);
+  std::string error;
+  try {
+    (void)ctx->list_objects("bucket", "loop/", /*page_size=*/1);
+  } catch (std::exception const& e) {
+    error = e.what();
+  }
+
+  INFO(error);
+  CHECK((error.find("continuation token did not advance") != std::string::npos ||
+         (error.find("truncated") != std::string::npos &&
+          error.find("no entries") != std::string::npos)));
+}
+
+TEST_CASE("rest_ioctx terminates a repeated-token empty LIST loop", "[s3][integration][rest][list]")
+{
+  range_fault_policy fault;
+  fault.response_delay = 100ms;
+  range_http_server server(
+    deterministic_payload(16), fault, {}, scripted_list_mode::repeated_empty_token);
+
+  auto const result = run_list_watchdog(server, 10s, 1s);
+  INFO("LIST requests=" << server.list_count());
+  CHECK_FALSE(result.timed_out);
+  CHECK(result.exited_normally);
+  CHECK(result.exit_code == 0);
+  CHECK(server.list_count() <= 3);
+}
+
+TEST_CASE("rest_ioctx terminates an alternating-token empty LIST loop",
+          "[s3][integration][rest][list]")
+{
+  range_fault_policy fault;
+  fault.response_delay = 100ms;
+  range_http_server server(
+    deterministic_payload(16), fault, {}, scripted_list_mode::alternating_empty_tokens);
+
+  auto const result = run_list_watchdog(server, 10s, 1s);
+  INFO("LIST requests=" << server.list_count());
+  CHECK_FALSE(result.timed_out);
+  CHECK(result.exited_normally);
+  CHECK(result.exit_code == 0);
+  CHECK(server.list_count() <= 3);
+}
+
+TEST_CASE("rest_ioctx accepts an empty final LIST page and rejects an empty continuation token",
+          "[s3][integration][rest][list]")
+{
+  SECTION("empty final page")
+  {
+    range_http_server server(deterministic_payload(16));
+    auto ctx    = make_direct_rest_ioctx(server.endpoint());
+    auto listed = ctx->list_objects("bucket", "empty/", /*page_size=*/1);
+
+    CHECK(listed.empty());
+    CHECK(server.list_count() == 1);
+  }
+
+  SECTION("truncated page without a continuation token")
+  {
+    range_http_server server(
+      deterministic_payload(16), {}, {}, scripted_list_mode::truncated_empty_without_token);
+    auto ctx = make_direct_rest_ioctx(server.endpoint());
+
+    CHECK_THROWS_WITH(ctx->list_objects("bucket", "empty/", /*page_size=*/1),
+                      Catch::Contains("without") && Catch::Contains("continuation token"));
+    CHECK(server.list_count() == 1);
+  }
+}
+
+TEST_CASE("rest perf snapshot attributes blocking host reads separately from chunk reads",
           "[s3][integration][rest][perf]")
 {
-  SECTION("native footer counters exist and default to zero")
+  SECTION("blocking host counters exist and default to zero")
   {
     sirius::io::rest::rest_perf_snapshot snapshot{};
-    CHECK(snapshot.native_footer_get_count == 0);
-    CHECK(snapshot.native_footer_wall_ns_total == 0);
-    CHECK(snapshot.native_footer_wall_ns_max == 0);
+    CHECK(snapshot.blocking_host_get_count == 0);
+    CHECK(snapshot.blocking_host_get_wall_ns_total == 0);
+    CHECK(snapshot.blocking_host_get_wall_ns_max == 0);
   }
 
   SECTION("blocking host_read network GETs are counted and pool-aggregated")
@@ -909,14 +984,14 @@ TEST_CASE("rest perf snapshot attributes native footer reads separately from chu
                         std::span<std::uint8_t const>(payload.data() + 4096, second.size()));
 
     auto const after = ioctx->perf_snapshot();
-    CHECK(after.native_footer_get_count == before.native_footer_get_count + readers);
-    CHECK(after.native_footer_wall_ns_total > before.native_footer_wall_ns_total);
-    CHECK(after.native_footer_wall_ns_max > 0);
+    CHECK(after.blocking_host_get_count == before.blocking_host_get_count + readers);
+    CHECK(after.blocking_host_get_wall_ns_total > before.blocking_host_get_wall_ns_total);
+    CHECK(after.blocking_host_get_wall_ns_max > 0);
     CHECK(after.chunk_get_count == before.chunk_get_count + readers);
     CHECK(server.get_count() == readers);
   }
 
-  SECTION("stash-served parquet footer reads are not counted as native network footer reads")
+  SECTION("stash-served parquet footer reads are not counted as blocking host reads")
   {
     auto const parquet    = read_binary_file(committed_parquet_fixture("nation.parquet"));
     auto const footer_len = static_cast<std::size_t>(parquet_footer_len(parquet));
@@ -943,13 +1018,56 @@ TEST_CASE("rest perf snapshot attributes native footer reads separately from chu
                         std::span<std::uint8_t const>(parquet.data() + footer_off, footer_len));
 
     auto const after = ioctx->perf_snapshot();
-    CHECK(after.native_footer_get_count == before.native_footer_get_count);
-    CHECK(after.native_footer_wall_ns_total == before.native_footer_wall_ns_total);
-    CHECK(after.native_footer_wall_ns_max == before.native_footer_wall_ns_max);
+    CHECK(after.blocking_host_get_count == before.blocking_host_get_count);
+    CHECK(after.blocking_host_get_wall_ns_total == before.blocking_host_get_wall_ns_total);
+    CHECK(after.blocking_host_get_wall_ns_max == before.blocking_host_get_wall_ns_max);
     CHECK(server.get_count() == 1);
   }
 
-  SECTION("async chunk reads bump chunk counters without touching native footer counters")
+  SECTION("a blocking read outside the footer stash is counted as a blocking network read")
+  {
+    auto payload = deterministic_payload(16 * 1024);
+    range_http_server server(payload);
+    auto cfg                 = direct_rest_test_config();
+    cfg.perf_instrumentation = true;
+    cfg.footer_probe_bytes   = 8;
+    auto ioctx               = make_direct_rest_ioctx(server.endpoint(), cfg);
+    auto datasource          = ioctx->open_datasource("s3://footer-bucket/outside-stash.bin",
+                                             sirius::io::open_hint::parquet_footer_probe);
+    auto const before        = ioctx->perf_snapshot();
+
+    std::array<std::uint8_t, 32> out{};
+    REQUIRE(datasource->host_read(0, out.size(), out.data()) == out.size());
+    require_bytes_equal(out, std::span<std::uint8_t const>(payload.data(), out.size()));
+
+    auto const after = ioctx->perf_snapshot();
+    CHECK(after.blocking_host_get_count == before.blocking_host_get_count + 1);
+    CHECK(after.chunk_get_count == before.chunk_get_count + 1);
+    CHECK(server.get_count() == 2);
+  }
+
+  SECTION("the one-shot footer probe GET bypasses native counters but remains a chunk GET")
+  {
+    auto payload = deterministic_payload(16 * 1024);
+    range_http_server server(payload);
+    auto cfg                 = direct_rest_test_config();
+    cfg.perf_instrumentation = true;
+    auto ioctx               = make_direct_rest_ioctx(server.endpoint(), cfg);
+    auto const before        = ioctx->perf_snapshot();
+
+    auto datasource = ioctx->open_datasource("s3://footer-bucket/probe-only.bin",
+                                             sirius::io::open_hint::parquet_footer_probe);
+    REQUIRE(datasource != nullptr);
+
+    auto const after = ioctx->perf_snapshot();
+    CHECK(after.blocking_host_get_count == before.blocking_host_get_count);
+    CHECK(after.blocking_host_get_wall_ns_total == before.blocking_host_get_wall_ns_total);
+    CHECK(after.blocking_host_get_wall_ns_max == before.blocking_host_get_wall_ns_max);
+    CHECK(after.chunk_get_count == before.chunk_get_count + 1);
+    CHECK(server.get_count() == 1);
+  }
+
+  SECTION("async chunk reads bump chunk counters without touching blocking host counters")
   {
     auto payload = deterministic_payload(64 * 1024);
     range_http_server server(payload);
@@ -974,12 +1092,12 @@ TEST_CASE("rest perf snapshot attributes native footer reads separately from chu
     require_bytes_equal(a, std::span<std::uint8_t const>(payload.data() + 17, a.size()));
     require_bytes_equal(b, std::span<std::uint8_t const>(payload.data() + 4096, b.size()));
     CHECK(after.chunk_get_count > before.chunk_get_count);
-    CHECK(after.native_footer_get_count == before.native_footer_get_count);
-    CHECK(after.native_footer_wall_ns_total == before.native_footer_wall_ns_total);
-    CHECK(after.native_footer_wall_ns_max == before.native_footer_wall_ns_max);
+    CHECK(after.blocking_host_get_count == before.blocking_host_get_count);
+    CHECK(after.blocking_host_get_wall_ns_total == before.blocking_host_get_wall_ns_total);
+    CHECK(after.blocking_host_get_wall_ns_max == before.blocking_host_get_wall_ns_max);
   }
 
-  SECTION("native footer counters are gated off when perf instrumentation is disabled")
+  SECTION("blocking host counters are gated off when perf instrumentation is disabled")
   {
     auto payload = deterministic_payload(4096);
     range_http_server server(payload);
@@ -994,9 +1112,9 @@ TEST_CASE("rest perf snapshot attributes native footer reads separately from chu
     require_bytes_equal(out, std::span<std::uint8_t const>(payload.data() + 99, out.size()));
 
     auto const after = ioctx->perf_snapshot();
-    CHECK(after.native_footer_get_count == 0);
-    CHECK(after.native_footer_wall_ns_total == 0);
-    CHECK(after.native_footer_wall_ns_max == 0);
+    CHECK(after.blocking_host_get_count == 0);
+    CHECK(after.blocking_host_get_wall_ns_total == 0);
+    CHECK(after.blocking_host_get_wall_ns_max == 0);
     CHECK(server.get_count() == 1);
   }
 }

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -1351,6 +1351,36 @@ TEST_CASE("footer suffix probe falls back safely on unusable suffix responses",
     CHECK(server.head_count() == 1);
     CHECK(server.get_count() == 1);
   }
+
+  SECTION("missing object fails the footer-probe open after HEAD fallback")
+  {
+    range_fault_policy fault{};
+    fault.fail_all_gets    = true;
+    fault.fail_all_heads   = true;
+    fault.fail_status      = 404;
+    fault.fail_head_status = 404;
+    range_http_server server(parquet, fault);
+    auto ioctx = make_direct_rest_ioctx(server.endpoint());
+
+    CHECK_THROWS_WITH(ioctx->open_datasource("s3://footer-bucket/missing.parquet",
+                                             sirius::io::open_hint::parquet_footer_probe),
+                      Catch::Matchers::Contains("HTTP 404"));
+  }
+
+  SECTION("forbidden object fails the footer-probe open after HEAD fallback")
+  {
+    range_fault_policy fault{};
+    fault.fail_all_gets    = true;
+    fault.fail_all_heads   = true;
+    fault.fail_status      = 403;
+    fault.fail_head_status = 403;
+    range_http_server server(parquet, fault);
+    auto ioctx = make_direct_rest_ioctx(server.endpoint());
+
+    CHECK_THROWS_WITH(ioctx->open_datasource("s3://footer-bucket/forbidden.parquet",
+                                             sirius::io::open_hint::parquet_footer_probe),
+                      Catch::Matchers::Contains("HTTP 403"));
+  }
 }
 
 TEST_CASE("footer suffix probe retries transient GET failures",

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -16,6 +16,7 @@
 
 #include "catch.hpp"
 #include "io/rest/rest_ioctx.hpp"
+#include "io/s3/s3_list_parser.hpp"
 #include "io/s3/s3_request_authorizer.hpp"
 #include "io/sirius_datasource.hpp"
 #include "io/types.hpp"
@@ -57,6 +58,7 @@
 #include <mutex>
 #include <optional>
 #include <span>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -240,13 +242,21 @@ struct range_fault_policy {
   bool fail_all_gets{false};
   std::size_t fail_first_heads{0};
   bool fail_all_heads{false};
+  std::size_t fail_first_lists{0};
+  bool fail_all_lists{false};
   int fail_status{503};
   int fail_head_status{503};
+  int fail_list_status{503};
   std::chrono::milliseconds response_delay{0};
   bool omit_content_range{false};
   bool unknown_content_range_total{false};
   bool ignore_range_with_200{false};
   bool fail_suffix_with_416{false};
+};
+
+struct listed_object {
+  std::string key;
+  std::uint64_t size{0};
 };
 
 class fixed_url_authorizer final : public sirius::io::s3::s3_request_authorizer {
@@ -260,14 +270,23 @@ class fixed_url_authorizer final : public sirius::io::s3::s3_request_authorizer 
     return {_endpoint + "/" + obj.bucket + "/" + obj.key, {}};
   }
 
+  sirius::io::s3::s3_authorized_request authorize_list(std::string_view bucket,
+                                                       std::string_view canonical_query,
+                                                       std::chrono::seconds /*timeout*/) override
+  {
+    return {_endpoint + "/" + std::string{bucket} + "?" + std::string{canonical_query}, {}};
+  }
+
  private:
   std::string _endpoint;
 };
 
 class range_http_server {
  public:
-  explicit range_http_server(std::vector<std::uint8_t> object, range_fault_policy fault = {})
-    : _object(std::move(object)), _fault(fault)
+  explicit range_http_server(std::vector<std::uint8_t> object,
+                             range_fault_policy fault          = {},
+                             std::vector<listed_object> listed = {})
+    : _object(std::move(object)), _fault(fault), _listed(std::move(listed))
   {
     REQUIRE_FALSE(_object.empty());
 
@@ -317,6 +336,7 @@ class range_http_server {
   [[nodiscard]] std::string endpoint() const { return "http://127.0.0.1:" + std::to_string(_port); }
   [[nodiscard]] std::size_t head_count() const noexcept { return _head_count.load(); }
   [[nodiscard]] std::size_t get_count() const noexcept { return _get_count.load(); }
+  [[nodiscard]] std::size_t list_count() const noexcept { return _list_count.load(); }
   [[nodiscard]] std::size_t body_bytes_sent() const noexcept { return _body_bytes_sent.load(); }
   [[nodiscard]] int peak_active_gets() const noexcept { return _peak_active_gets.load(); }
 
@@ -334,6 +354,97 @@ class range_http_server {
   };
 
   static std::string errno_message() { return std::strerror(errno); }
+
+  static std::string request_target(std::string const& request)
+  {
+    auto first_space = request.find(' ');
+    if (first_space == std::string::npos) { return {}; }
+    auto second_space = request.find(' ', first_space + 1);
+    if (second_space == std::string::npos) { return {}; }
+    return request.substr(first_space + 1, second_space - first_space - 1);
+  }
+
+  static std::string xml_escape(std::string_view value)
+  {
+    std::string out;
+    out.reserve(value.size());
+    for (char c : value) {
+      switch (c) {
+        case '&': out += "&amp;"; break;
+        case '<': out += "&lt;"; break;
+        case '>': out += "&gt;"; break;
+        case '"': out += "&quot;"; break;
+        case '\'': out += "&apos;"; break;
+        default: out.push_back(c); break;
+      }
+    }
+    return out;
+  }
+
+  static int from_hex(char c)
+  {
+    if (c >= '0' && c <= '9') { return c - '0'; }
+    if (c >= 'a' && c <= 'f') { return c - 'a' + 10; }
+    if (c >= 'A' && c <= 'F') { return c - 'A' + 10; }
+    return -1;
+  }
+
+  static std::string percent_decode(std::string_view value)
+  {
+    std::string out;
+    out.reserve(value.size());
+    for (std::size_t i = 0; i < value.size(); ++i) {
+      if (value[i] == '%' && i + 2 < value.size()) {
+        auto hi = from_hex(value[i + 1]);
+        auto lo = from_hex(value[i + 2]);
+        if (hi >= 0 && lo >= 0) {
+          out.push_back(static_cast<char>((hi << 4) | lo));
+          i += 2;
+          continue;
+        }
+      }
+      out.push_back(value[i]);
+    }
+    return out;
+  }
+
+  static std::string query_value(std::string const& target, std::string_view key)
+  {
+    auto qpos = target.find('?');
+    if (qpos == std::string::npos) { return {}; }
+    auto query      = std::string_view{target}.substr(qpos + 1);
+    auto needle     = std::string{key} + "=";
+    std::size_t pos = 0;
+    while (pos < query.size()) {
+      auto amp = query.find('&', pos);
+      if (amp == std::string_view::npos) { amp = query.size(); }
+      auto part        = query.substr(pos, amp - pos);
+      auto needle_view = std::string_view{needle};
+      if (part.size() >= needle_view.size() && part.substr(0, needle_view.size()) == needle_view) {
+        return percent_decode(part.substr(needle.size()));
+      }
+      pos = amp + 1;
+    }
+    return {};
+  }
+
+  static std::size_t page_start_from_token(std::string const& token)
+  {
+    if (token.empty()) { return 0; }
+    std::string const prefix = "page/";
+    std::string const suffix = "+=";
+    if (token.rfind(prefix, 0) != 0 || token.size() <= prefix.size() + suffix.size() ||
+        token.substr(token.size() - suffix.size()) != suffix) {
+      throw std::runtime_error("unexpected continuation-token: " + token);
+    }
+    return static_cast<std::size_t>(
+      std::stoull(token.substr(prefix.size(), token.size() - prefix.size() - suffix.size())));
+  }
+
+  static std::string continuation_token_for(std::size_t index)
+  {
+    return "page/" + std::to_string(index) + "+=";
+  }
 
   void accept_loop()
   {
@@ -365,6 +476,7 @@ class range_http_server {
 
     bool const is_head = request.rfind("HEAD ", 0) == 0;
     bool const is_get  = request.rfind("GET ", 0) == 0;
+    auto const target  = request_target(request);
     if (is_head) {
       auto const head_idx = _head_count.fetch_add(1, std::memory_order_relaxed);
       if (_fault.fail_all_heads || head_idx < _fault.fail_first_heads) {
@@ -378,6 +490,10 @@ class range_http_server {
         "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size()) +
         "\r\nConnection: close\r\n\r\n";
       send_all(fd, response);
+      return;
+    }
+    if (is_get && target.find("list-type=2") != std::string::npos) {
+      handle_list_request(fd, target);
       return;
     }
     if (!is_get) {
@@ -432,6 +548,58 @@ class range_http_server {
                            "\r\nConnection: close\r\n\r\n";
     send_all(fd, response);
     send_body(fd, _object.data(), _object.size());
+  }
+
+  void handle_list_request(int fd, std::string const& target)
+  {
+    auto const list_idx = _list_count.fetch_add(1, std::memory_order_relaxed);
+    if (_fault.fail_all_lists || list_idx < _fault.fail_first_lists) {
+      std::string response =
+        "HTTP/1.1 " + std::to_string(_fault.fail_list_status) +
+        " Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+      send_all(fd, response);
+      return;
+    }
+
+    auto prefix          = query_value(target, "prefix");
+    auto token           = query_value(target, "continuation-token");
+    std::size_t max_keys = 1000;
+    auto max_keys_text   = query_value(target, "max-keys");
+    if (!max_keys_text.empty()) {
+      max_keys = std::max<std::size_t>(
+        1, std::min<std::size_t>(1000, static_cast<std::size_t>(std::stoull(max_keys_text))));
+    }
+    auto start = page_start_from_token(token);
+
+    std::vector<listed_object> matching;
+    for (auto const& object : _listed) {
+      if (object.key.rfind(prefix, 0) == 0) { matching.push_back(object); }
+    }
+
+    if (start > matching.size()) { start = matching.size(); }
+    auto end              = std::min(start + max_keys, matching.size());
+    bool truncated        = end < matching.size();
+    std::string token_out = truncated ? continuation_token_for(end) : std::string{};
+
+    std::ostringstream xml;
+    xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+           "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
+           "<IsTruncated>"
+        << (truncated ? "true" : "false") << "</IsTruncated>";
+    for (auto i = start; i < end; ++i) {
+      xml << "<Contents><Key>" << xml_escape(matching[i].key) << "</Key><Size>" << matching[i].size
+          << "</Size></Contents>";
+    }
+    if (truncated) {
+      xml << "<NextContinuationToken>" << xml_escape(token_out) << "</NextContinuationToken>";
+    }
+    xml << "</ListBucketResult>";
+
+    auto body            = xml.str();
+    std::string response = "HTTP/1.1 200 OK\r\nContent-Type: application/xml\r\nContent-Length: " +
+                           std::to_string(body.size()) + "\r\nConnection: close\r\n\r\n";
+    send_all(fd, response);
+    send_all(fd, body);
   }
 
   [[nodiscard]] static bool is_suffix_range(std::string const& request)
@@ -506,9 +674,11 @@ class range_http_server {
   std::uint16_t _port{0};
   std::vector<std::uint8_t> _object;
   range_fault_policy _fault;
+  std::vector<listed_object> _listed;
   std::atomic<bool> _stop{false};
   std::atomic<std::size_t> _head_count{0};
   std::atomic<std::size_t> _get_count{0};
+  std::atomic<std::size_t> _list_count{0};
   std::atomic<std::size_t> _body_bytes_sent{0};
   std::atomic<int> _active_gets{0};
   std::atomic<int> _peak_active_gets{0};
@@ -549,6 +719,171 @@ using capture_sink       = sirius::test::recording_log_sink;
 using scoped_log_capture = sirius::test::scoped_recording_log_sink;
 
 }  // namespace
+
+TEST_CASE("rest_ioctx lists S3 objects with sizes and follows encoded continuation tokens",
+          "[s3][integration][rest][list]")
+{
+  std::vector<listed_object> objects = {{"data/part-000.parquet", 11},
+                                        {"data/year=2024/part-001.parquet", 22},
+                                        {"data/year=2025/part-002.parquet", 0},
+                                        {"other/ignored.parquet", 99}};
+  range_http_server server(deterministic_payload(16), {}, objects);
+  auto ctx = make_direct_rest_ioctx(server.endpoint());
+
+  auto listed = ctx->list_objects("bucket", "data/", /*page_size=*/1);
+
+  REQUIRE(listed.size() == 3);
+  CHECK(listed[0].key == "data/part-000.parquet");
+  CHECK(listed[0].size == 11);
+  CHECK(listed[1].key == "data/year=2024/part-001.parquet");
+  CHECK(listed[1].size == 22);
+  CHECK(listed[2].key == "data/year=2025/part-002.parquet");
+  CHECK(listed[2].size == 0);
+  CHECK(server.list_count() == 3);
+  CHECK(server.get_count() == 0);
+  CHECK(server.head_count() == 0);
+}
+
+TEST_CASE("rest_ioctx paged LIST supports early stop and explicit safety caps",
+          "[s3][integration][rest][list]")
+{
+  std::vector<listed_object> objects = {
+    {"data/a.parquet", 1}, {"data/b.parquet", 2}, {"data/c.parquet", 3}};
+
+  SECTION("sink false stops after one page")
+  {
+    range_http_server server(deterministic_payload(16), {}, objects);
+    auto ctx = make_direct_rest_ioctx(server.endpoint());
+
+    std::size_t pages = 0;
+    ctx->list_objects_paged("bucket",
+                            "data/",
+                            /*page_size=*/1,
+                            [&](sirius::io::s3::list_objects_v2_page const& page) {
+                              ++pages;
+                              REQUIRE(page.entries.size() == 1);
+                              CHECK(page.entries[0].key == "data/a.parquet");
+                              return false;
+                            });
+
+    CHECK(pages == 1);
+    CHECK(server.list_count() == 1);
+  }
+
+  SECTION("wrapper throws instead of truncating past max_keys")
+  {
+    range_http_server server(deterministic_payload(16), {}, objects);
+    auto ctx = make_direct_rest_ioctx(server.endpoint());
+
+    CHECK_THROWS_WITH(ctx->list_objects("bucket", "data/", /*page_size=*/1000, /*max_keys=*/2),
+                      Catch::Contains("narrow the glob prefix"));
+
+    auto all = ctx->list_objects("bucket", "data/", /*page_size=*/1000, /*max_keys=*/3);
+    CHECK(all.size() == 3);
+  }
+
+  SECTION("primitive throws instead of scanning unbounded pages")
+  {
+    range_http_server server(deterministic_payload(16), {}, objects);
+    auto ctx = make_direct_rest_ioctx(server.endpoint());
+
+    CHECK_THROWS_WITH(ctx->list_objects_paged(
+                        "bucket",
+                        "data/",
+                        /*page_size=*/1,
+                        [](sirius::io::s3::list_objects_v2_page const&) { return true; },
+                        /*max_scanned=*/2),
+                      Catch::Contains("narrow the glob prefix"));
+  }
+
+  SECTION("empty prefix returns an empty vector")
+  {
+    range_http_server server(deterministic_payload(16), {}, objects);
+    auto ctx = make_direct_rest_ioctx(server.endpoint());
+
+    auto none = ctx->list_objects("bucket", "missing/", /*page_size=*/1);
+    CHECK(none.empty());
+    CHECK(server.list_count() == 1);
+  }
+}
+
+TEST_CASE("rest LIST retries are observable and isolated from object-read byte counters",
+          "[s3][integration][rest][list][telemetry]")
+{
+  std::vector<listed_object> objects = {{"data/a.parquet", 1}};
+  auto cfg                           = direct_rest_test_config();
+  cfg.perf_instrumentation           = true;
+
+  SECTION("transient LIST failure retries and logs bucket/prefix")
+  {
+    range_fault_policy fault{};
+    fault.fail_first_lists = 1;
+    fault.fail_list_status = 503;
+    range_http_server server(deterministic_payload(16), fault, objects);
+    auto ctx    = make_direct_rest_ioctx(server.endpoint(), cfg);
+    auto before = ctx->perf_snapshot();
+    scoped_spdlog_capture logs;
+
+    auto listed = ctx->list_objects("bucket", "data/", /*page_size=*/1000);
+    auto after  = ctx->perf_snapshot();
+
+    REQUIRE(listed.size() == 1);
+    CHECK(after.retries_total - before.retries_total == 1);
+    CHECK(after.terminal_failures_total == before.terminal_failures_total);
+    CHECK(after.chunk_get_count == before.chunk_get_count);
+    CHECK(after.payload_bytes_read_total == before.payload_bytes_read_total);
+    CHECK(server.list_count() == 2);
+
+    auto records = logs.records();
+    CHECK(std::any_of(records.begin(), records.end(), [](capture_sink::record const& record) {
+      return record.level == spdlog::level::warn &&
+             record.payload.find("bucket") != std::string::npos &&
+             record.payload.find("data/") != std::string::npos;
+    }));
+  }
+
+  SECTION("clean LIST is telemetry-quiet")
+  {
+    range_http_server server(deterministic_payload(16), {}, objects);
+    auto ctx    = make_direct_rest_ioctx(server.endpoint(), cfg);
+    auto before = ctx->perf_snapshot();
+    scoped_spdlog_capture logs;
+
+    auto listed = ctx->list_objects("bucket", "data/", /*page_size=*/1000);
+    auto after  = ctx->perf_snapshot();
+
+    REQUIRE(listed.size() == 1);
+    CHECK(after.retries_total == before.retries_total);
+    CHECK(after.terminal_failures_total == before.terminal_failures_total);
+    CHECK(after.chunk_get_count == before.chunk_get_count);
+    CHECK(after.payload_bytes_read_total == before.payload_bytes_read_total);
+
+    auto records = logs.records();
+    CHECK(std::none_of(records.begin(), records.end(), [](capture_sink::record const& record) {
+      return record.level >= spdlog::level::warn;
+    }));
+  }
+}
+
+TEST_CASE("rest_ioctx opens LIST-sized objects without a HEAD round trip",
+          "[s3][integration][rest][list][filesystem]")
+{
+  auto payload = deterministic_payload(4096);
+  range_http_server server(payload);
+  auto ctx = make_direct_rest_ioctx(server.endpoint());
+
+  auto datasource =
+    ctx->open_datasource("s3://bucket/list-sized.bin", static_cast<std::uint64_t>(payload.size()));
+  REQUIRE(datasource != nullptr);
+  CHECK(datasource->io_object().size() == payload.size());
+  CHECK(server.head_count() == 0);
+
+  std::vector<std::uint8_t> out(payload.size());
+  auto const got = datasource->host_read(0, out.size(), out.data());
+  CHECK(got == out.size());
+  CHECK(out == payload);
+  CHECK(server.get_count() == 1);
+}
 
 TEST_CASE("rest footer suffix parses Content-Range totals", "[s3][integration][rest][footerbind]")
 {

--- a/test/cpp/io/s3/test_sirius_httpfs.cpp
+++ b/test/cpp/io/s3/test_sirius_httpfs.cpp
@@ -9,6 +9,7 @@
 #include "io/rest/rest_ioctx.hpp"
 #include "io/s3/sirius_httpfs.hpp"
 #include "io/sirius_datasource.hpp"
+#include "io/uri_parser.hpp"
 #include "sirius_context.hpp"
 #include "sirius_extension.hpp"
 #include "utils/s3_container.hpp"
@@ -288,6 +289,34 @@ class exposed_sirius_httpfs final : public sirius::io::s3::sirius_httpfs {
 };
 
 }  // namespace
+
+TEST_CASE("S3 LIST keys survive the URI embedding escape seam", "[s3][filesystem][glob]")
+{
+  for (auto const key : {std::string_view{"a%2Fb.p"},
+                         std::string_view{"x#1.p"},
+                         std::string_view{"y?v.p"},
+                         std::string_view{"100%.p"},
+                         std::string_view{"col=a%20b/p0.p"}}) {
+    DYNAMIC_SECTION("key=" << key)
+    {
+      auto const escaped = sirius::io::s3::escape_s3_key_for_uri(key);
+      auto const parsed  = sirius::io::parse("s3://bkt/" + escaped);
+
+      CHECK(parsed.host == "bkt");
+      CHECK(parsed.path == key);
+    }
+  }
+}
+
+TEST_CASE("S3 LIST key URI escaping preserves ordinary keys byte for byte",
+          "[s3][filesystem][glob]")
+{
+  for (auto const key : {std::string_view{"plain.parquet"},
+                         std::string_view{"year=2026/part 0.parquet"},
+                         std::string_view{"nested/path/file.parquet"}}) {
+    DYNAMIC_SECTION("key=" << key) { CHECK(sirius::io::s3::escape_s3_key_for_uri(key) == key); }
+  }
+}
 
 TEST_CASE("sirius_httpfs claims only valid S3 object paths", "[s3][filesystem]")
 {

--- a/test/cpp/io/s3/test_sirius_httpfs.cpp
+++ b/test/cpp/io/s3/test_sirius_httpfs.cpp
@@ -274,6 +274,19 @@ std::shared_ptr<sirius::io::sirius_datasource> require_rest_datasource(
   return datasource;
 }
 
+duckdb::SiriusContext& require_sirius_context(sirius_httpfs_fixture& fixture)
+{
+  auto sirius_ctx =
+    fixture.con.context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx);
+  return *sirius_ctx;
+}
+
+class exposed_sirius_httpfs final : public sirius::io::s3::sirius_httpfs {
+ public:
+  using sirius::io::s3::sirius_httpfs::SupportsOpenFileExtended;
+};
+
 }  // namespace
 
 TEST_CASE("sirius_httpfs claims only valid S3 object paths", "[s3][filesystem]")
@@ -288,19 +301,37 @@ TEST_CASE("sirius_httpfs claims only valid S3 object paths", "[s3][filesystem]")
   CHECK(fs.CanSeek());
 }
 
-TEST_CASE("sirius_httpfs rejects glob patterns but accepts exact keys", "[s3][filesystem]")
+TEST_CASE("sirius_httpfs accepts exact keys and gates wildcard expansion on a Sirius opener",
+          "[s3][filesystem]")
 {
-  sirius::io::s3::sirius_httpfs fs;
+  exposed_sirius_httpfs fs;
+  CHECK(fs.SupportsOpenFileExtended());
 
-  CHECK_THROWS_AS(fs.Glob("s3://bucket/prefix/*.parquet"), duckdb::IOException);
-  CHECK_THROWS_AS(fs.Glob("s3://bucket/a?.parquet"), duckdb::IOException);
-  CHECK_THROWS_AS(fs.Glob("s3://bucket/[ab].parquet"), duckdb::IOException);
+  auto wildcard_message = thrown_message([&] { (void)fs.Glob("s3://bucket/prefix/*.parquet"); });
+  REQUIRE_FALSE(wildcard_message.empty());
+  CHECK(wildcard_message.find("no ClientContext") != std::string::npos);
+  CHECK(wildcard_message.find("glob/wildcard patterns are not supported") == std::string::npos);
 
   auto exact = fs.Glob("s3://bucket/key.parquet");
   REQUIRE(exact.size() == 1);
   CHECK(exact[0].path == "s3://bucket/key.parquet");
 
   CHECK(fs.Glob("s3://bucket").empty());
+}
+
+TEST_CASE("sirius_httpfs glob helper throws instead of silently truncating matched files",
+          "[.][s3][integration][filesystem][glob]")
+{
+  auto env = read_s3_test_env();
+  if (skip_if_no_s3_env(env)) { return; }
+
+  sirius_httpfs_fixture fixture(*env);
+  auto& manager = require_sirius_context(fixture).get_scan_manager();
+
+  CHECK_THROWS_WITH(sirius::io::s3::expand_glob(s3_uri(env->bucket, "glob/multi/nation_*.parquet"),
+                                                manager,
+                                                /*max_matches=*/1),
+                    Catch::Contains("narrow the glob prefix"));
 }
 
 TEST_CASE("sirius_httpfs rejects write opens before opener resolution", "[s3][filesystem]")

--- a/test/cpp/io/s3/test_sirius_sigv4_authorizer.cpp
+++ b/test/cpp/io/s3/test_sirius_sigv4_authorizer.cpp
@@ -26,6 +26,8 @@
 #include <atomic>
 #include <cctype>
 #include <chrono>
+#include <cstdint>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -201,6 +203,22 @@ TEST_CASE("ListObjectsV2 parser rejects non-list bodies and malformed sizes", "[
     parse_list_objects_v2(
       R"(<ListBucketResult><Contents><Key>a</Key><Size>not-a-size</Size></Contents></ListBucketResult>)"),
     std::runtime_error);
+  CHECK_THROWS_AS(
+    parse_list_objects_v2(R"(<ListBucketResult><Contents><Key>a</Key><Size>1</Size></Contents>)"),
+    std::runtime_error);
+  CHECK_THROWS_AS(
+    parse_list_objects_v2(
+      R"(<ListBucketResult><Contents><Key>a</Key><Size>1</Size></Contents><Contents><Key>b</Key>)"),
+    std::runtime_error);
+  CHECK_THROWS_AS(
+    parse_list_objects_v2(
+      R"(<ListBucketResult><Contents><Key>a</Key><Size>99999999999999999999999999</Size></Contents></ListBucketResult>)"),
+    std::runtime_error);
+
+  auto max_size = parse_list_objects_v2(
+    R"(<ListBucketResult><Contents><Key>a</Key><Size>18446744073709551615</Size></Contents></ListBucketResult>)");
+  REQUIRE(max_size.entries.size() == 1);
+  CHECK(max_size.entries[0].size == std::numeric_limits<std::uint64_t>::max());
 }
 
 TEST_CASE("s3_request_authorizer base rejects LIST until implementations opt in",

--- a/test/cpp/io/s3/test_sirius_sigv4_authorizer.cpp
+++ b/test/cpp/io/s3/test_sirius_sigv4_authorizer.cpp
@@ -18,6 +18,7 @@
 #include "io/io_errors.hpp"
 #include "io/object_store_config.hpp"
 #include "io/s3/mock_request_authorizer.hpp"
+#include "io/s3/s3_list_parser.hpp"
 #include "io/s3/sirius_sigv4_authorizer.hpp"
 #include "io/s3/static_credentials.hpp"
 
@@ -107,7 +108,166 @@ bool is_lower_hex_64(std::string_view value)
          });
 }
 
+std::vector<std::string> query_keys(std::string_view url)
+{
+  auto query = query_string(url);
+  std::vector<std::string> keys;
+  std::size_t pos = 0;
+  while (pos < query.size()) {
+    auto amp = query.find('&', pos);
+    if (amp == std::string::npos) { amp = query.size(); }
+    auto eq = query.find('=', pos);
+    REQUIRE(eq != std::string::npos);
+    REQUIRE(eq <= amp);
+    keys.push_back(query.substr(pos, eq - pos));
+    pos = amp + 1;
+  }
+  return keys;
+}
+
+class object_only_authorizer final : public sirius::io::s3::s3_request_authorizer {
+ public:
+  s3_authorized_request authorize(s3_object_ref const& /*obj*/,
+                                  s3_request_method /*method*/,
+                                  std::chrono::seconds /*timeout*/) override
+  {
+    return {"https://example.invalid/object", {}};
+  }
+};
+
 }  // namespace
+
+TEST_CASE("ListObjectsV2 parser extracts ordered keys, sizes, and pagination", "[s3][list_parser]")
+{
+  using sirius::io::s3::parse_list_objects_v2;
+
+  auto page = parse_list_objects_v2(
+    R"(<?xml version="1.0" encoding="UTF-8"?>)"
+    R"(<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">)"
+    R"(<Name>bucket</Name><Prefix>lake/</Prefix>)"
+    R"(<Contents><Key>lake/a&amp;b.parquet</Key><Size>12</Size></Contents>)"
+    R"(<Contents><Key>lake/year=2024/file.parquet</Key><Size>0</Size></Contents>)"
+    R"(<IsTruncated>true</IsTruncated>)"
+    R"(<NextContinuationToken>token/with+chars=</NextContinuationToken>)"
+    R"(</ListBucketResult>)");
+
+  REQUIRE(page.entries.size() == 2);
+  CHECK(page.entries[0].key == "lake/a&b.parquet");
+  CHECK(page.entries[0].size == 12);
+  CHECK(page.entries[1].key == "lake/year=2024/file.parquet");
+  CHECK(page.entries[1].size == 0);
+  CHECK(page.is_truncated);
+  CHECK(page.next_continuation_token == "token/with+chars=");
+}
+
+TEST_CASE("ListObjectsV2 parser ignores non-object keys and preserves flat-key order",
+          "[s3][list_parser]")
+{
+  using sirius::io::s3::parse_list_objects_v2;
+
+  auto page = parse_list_objects_v2(
+    R"(<ListBucketResult>)"
+    R"(<Key>not-an-object.parquet</Key>)"
+    R"(<CommonPrefixes><Prefix>lake/year=2024/</Prefix><Key>also-not-object</Key></CommonPrefixes>)"
+    R"(<Contents><Key>lake/part-000.parquet</Key><Size>7</Size></Contents>)"
+    R"(<Contents><Key>lake/nested/year=2025/part-001.parquet</Key><Size>8</Size></Contents>)"
+    R"(<IsTruncated>false</IsTruncated>)"
+    R"(</ListBucketResult>)");
+
+  REQUIRE(page.entries.size() == 2);
+  CHECK(page.entries[0].key == "lake/part-000.parquet");
+  CHECK(page.entries[0].size == 7);
+  CHECK(page.entries[1].key == "lake/nested/year=2025/part-001.parquet");
+  CHECK(page.entries[1].size == 8);
+  CHECK_FALSE(page.is_truncated);
+  CHECK(page.next_continuation_token.empty());
+}
+
+TEST_CASE("ListObjectsV2 parser rejects non-list bodies and malformed sizes", "[s3][list_parser]")
+{
+  using sirius::io::s3::parse_list_objects_v2;
+
+  auto empty = parse_list_objects_v2(
+    R"(<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>)");
+  CHECK(empty.entries.empty());
+
+  CHECK_THROWS_AS(parse_list_objects_v2(
+                    R"(<Error><Code>NoSuchBucket</Code><Message>no bucket</Message></Error>)"),
+                  std::runtime_error);
+  CHECK_THROWS_AS(parse_list_objects_v2(
+                    R"(<ListBucketResult><Contents><Key>a</Key></Contents></ListBucketResult>)"),
+                  std::runtime_error);
+  CHECK_THROWS_AS(
+    parse_list_objects_v2(
+      R"(<ListBucketResult><Contents><Key>a</Key><Size>not-a-size</Size></Contents></ListBucketResult>)"),
+    std::runtime_error);
+}
+
+TEST_CASE("s3_request_authorizer base rejects LIST until implementations opt in",
+          "[s3][authorizer]")
+{
+  object_only_authorizer provider;
+
+  CHECK_THROWS_AS(
+    provider.authorize_list("bucket", "list-type=2&max-keys=1000&prefix=p%2F", k_presign_timeout),
+    credential_error);
+}
+
+TEST_CASE("sirius_sigv4_presigned_authorizer signs sorted ListObjectsV2 query params",
+          "[s3][authorizer]")
+{
+  auto creds          = example_static_credentials();
+  creds.session_token = "temporary/session+token=";
+  sirius_sigv4_presigned_authorizer provider(
+    creds, "us-east-1", "https://s3.us-east-1.amazonaws.com");
+
+  auto request =
+    provider.authorize_list("bucket", "list-type=2&max-keys=1000&prefix=p%2F", k_presign_timeout);
+
+  REQUIRE(request.headers.empty());
+  CHECK(starts_with(request.url, "https://s3.us-east-1.amazonaws.com/bucket?"));
+  CHECK(contains(request.url, "list-type=2"));
+  CHECK(contains(request.url, "max-keys=1000"));
+  CHECK(contains(request.url, "prefix=p%2F"));
+  CHECK(contains(request.url, "X-Amz-Security-Token=temporary%2Fsession%2Btoken%3D"));
+  CHECK(is_lower_hex_64(query_value(request.url, "X-Amz-Signature")));
+
+  auto keys = query_keys(request.url);
+  CHECK(std::is_sorted(keys.begin(), keys.end()));
+}
+
+TEST_CASE("sirius_sigv4_header_authorizer signs ListObjectsV2 canonical queries",
+          "[s3][authorizer]")
+{
+  sirius_sigv4_header_authorizer provider(
+    example_static_credentials(), "us-east-1", "http://minio.local:9000");
+
+  auto request =
+    provider.authorize_list("bucket",
+                            "continuation-token=page%2F1%2B%3D&list-type=2&max-keys=1&prefix=p%2F",
+                            k_presign_timeout);
+
+  CHECK(request.url ==
+        "http://minio.local:9000/bucket?continuation-token=page%2F1%2B%3D&list-type=2&max-keys=1&"
+        "prefix=p%2F");
+  CHECK_FALSE(contains(request.url, "X-Amz-Signature"));
+  CHECK(starts_with(header_value(request.headers, "Authorization"), "AWS4-HMAC-SHA256 "));
+  CHECK_FALSE(header_value(request.headers, "x-amz-date").empty());
+  CHECK_FALSE(header_value(request.headers, "x-amz-content-sha256").empty());
+}
+
+TEST_CASE("SigV4 LIST rejects X-Amz query smuggling", "[s3][authorizer]")
+{
+  sirius_sigv4_presigned_authorizer presigned(
+    example_static_credentials(), "us-east-1", "https://s3.us-east-1.amazonaws.com");
+  sirius_sigv4_header_authorizer header(
+    example_static_credentials(), "us-east-1", "https://s3.us-east-1.amazonaws.com");
+
+  CHECK_THROWS(presigned.authorize_list(
+    "bucket", "list-type=2&X-Amz-Signature=evil&prefix=p%2F", k_presign_timeout));
+  CHECK_THROWS(header.authorize_list(
+    "bucket", "list-type=2&x-amz-credential=evil&prefix=p%2F", k_presign_timeout));
+}
 
 TEST_CASE("sirius_sigv4_presigned_authorizer normalizes HTTPS endpoint", "[s3][authorizer]")
 {

--- a/test/cpp/io/s3/test_sirius_sigv4_authorizer.cpp
+++ b/test/cpp/io/s3/test_sirius_sigv4_authorizer.cpp
@@ -216,9 +216,156 @@ TEST_CASE("ListObjectsV2 parser rejects non-list bodies and malformed sizes", "[
     std::runtime_error);
 
   auto max_size = parse_list_objects_v2(
-    R"(<ListBucketResult><Contents><Key>a</Key><Size>18446744073709551615</Size></Contents></ListBucketResult>)");
+    R"(<ListBucketResult><Contents><Key>a</Key><Size>18446744073709551615</Size></Contents><IsTruncated>false</IsTruncated></ListBucketResult>)");
   REQUIRE(max_size.entries.size() == 1);
   CHECK(max_size.entries[0].size == std::numeric_limits<std::uint64_t>::max());
+}
+
+TEST_CASE("ListObjectsV2 parser rejects Contents without a Key", "[s3][list_parser]")
+{
+  CHECK_THROWS_WITH(
+    sirius::io::s3::parse_list_objects_v2(
+      R"(<ListBucketResult><Contents><Size>5</Size></Contents><IsTruncated>false</IsTruncated></ListBucketResult>)"),
+    Catch::Contains("<Contents> without <Key>"));
+}
+
+TEST_CASE("ListObjectsV2 parser rejects an unclosed Key", "[s3][list_parser]")
+{
+  CHECK_THROWS_WITH(
+    sirius::io::s3::parse_list_objects_v2(
+      R"(<ListBucketResult><Contents><Key>a<Size>5</Size></Contents><IsTruncated>false</IsTruncated></ListBucketResult>)"),
+    Catch::Contains("<Contents> without <Key>"));
+}
+
+TEST_CASE("ListObjectsV2 parser rejects an empty Key", "[s3][list_parser]")
+{
+  CHECK_THROWS_WITH(
+    sirius::io::s3::parse_list_objects_v2(
+      R"(<ListBucketResult><Contents><Key></Key><Size>5</Size></Contents><IsTruncated>false</IsTruncated></ListBucketResult>)"),
+    Catch::Contains("empty <Key>"));
+}
+
+TEST_CASE("ListObjectsV2 parser requires IsTruncated", "[s3][list_parser]")
+{
+  CHECK_THROWS_WITH(
+    sirius::io::s3::parse_list_objects_v2(
+      R"(<ListBucketResult><Contents><Key>a</Key><Size>5</Size></Contents></ListBucketResult>)"),
+    Catch::Contains("missing <IsTruncated>"));
+}
+
+TEST_CASE("ListObjectsV2 parser rejects invalid IsTruncated values", "[s3][list_parser]")
+{
+  for (auto const value : {"TRUE", "1", "garbage"}) {
+    DYNAMIC_SECTION("value=" << value)
+    {
+      auto const xml =
+        std::string{
+          "<ListBucketResult><Contents><Key>a</Key><Size>5</Size>"
+          "</Contents><IsTruncated>"} +
+        value + "</IsTruncated></ListBucketResult>";
+      CHECK_THROWS_WITH(sirius::io::s3::parse_list_objects_v2(xml),
+                        Catch::Contains("invalid <IsTruncated>"));
+    }
+  }
+
+  SECTION("unclosed element")
+  {
+    CHECK_THROWS_WITH(
+      sirius::io::s3::parse_list_objects_v2(
+        R"(<ListBucketResult><Contents><Key>a</Key><Size>5</Size></Contents><IsTruncated>true</ListBucketResult>)"),
+      Catch::Contains("missing <IsTruncated>"));
+  }
+}
+
+TEST_CASE("ListObjectsV2 parser requires a token for a truncated page", "[s3][list_parser]")
+{
+  CHECK_THROWS_WITH(
+    sirius::io::s3::parse_list_objects_v2(
+      R"(<ListBucketResult><Contents><Key>a</Key><Size>5</Size></Contents><IsTruncated>true</IsTruncated></ListBucketResult>)"),
+    Catch::Contains("without") && Catch::Contains("ContinuationToken"));
+}
+
+TEST_CASE("ListObjectsV2 parser trims a valid IsTruncated value", "[s3][list_parser]")
+{
+  auto const page = sirius::io::s3::parse_list_objects_v2(
+    R"(<ListBucketResult><Contents><Key>a</Key><Size>5</Size></Contents><IsTruncated> true </IsTruncated><NextContinuationToken>next</NextContinuationToken></ListBucketResult>)");
+
+  CHECK(page.is_truncated);
+  CHECK(page.next_continuation_token == "next");
+}
+
+TEST_CASE("ListObjectsV2 parser rejects object entries after the root element", "[s3][list_parser]")
+{
+  CHECK_THROWS_WITH(
+    sirius::io::s3::parse_list_objects_v2(
+      R"(<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult><Contents><Key>outside</Key><Size>1</Size></Contents>)"),
+    Catch::Contains("after </ListBucketResult>"));
+}
+
+TEST_CASE("ListObjectsV2 parser does not read IsTruncated outside the root", "[s3][list_parser]")
+{
+  CHECK_THROWS_WITH(sirius::io::s3::parse_list_objects_v2(
+                      R"(<ListBucketResult></ListBucketResult><IsTruncated>false</IsTruncated>)"),
+                    Catch::Contains("missing <IsTruncated>"));
+}
+
+TEST_CASE("ListObjectsV2 parser does not read a continuation token outside the root",
+          "[s3][list_parser]")
+{
+  CHECK_THROWS_WITH(
+    sirius::io::s3::parse_list_objects_v2(
+      R"(<ListBucketResult><Contents><Key>a</Key><Size>1</Size></Contents><IsTruncated>true</IsTruncated></ListBucketResult><NextContinuationToken>outside</NextContinuationToken>)"),
+    Catch::Contains("without") && Catch::Contains("ContinuationToken"));
+}
+
+TEST_CASE("ListObjectsV2 parser rejects a root close before the root open", "[s3][list_parser]")
+{
+  CHECK_THROWS_AS(sirius::io::s3::parse_list_objects_v2(
+                    R"(</ListBucketResult><ListBucketResult><IsTruncated>false</IsTruncated>)"),
+                  std::runtime_error);
+}
+
+TEST_CASE("ListObjectsV2 parser accepts a prologue, root namespace, and trailing whitespace",
+          "[s3][list_parser]")
+{
+  auto const page = sirius::io::s3::parse_list_objects_v2(
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
+    "<Contents><Key>a</Key><Size>1</Size></Contents>"
+    "<IsTruncated>false</IsTruncated>"
+    "</ListBucketResult> \n\t");
+
+  REQUIRE(page.entries.size() == 1);
+  CHECK(page.entries[0].key == "a");
+  CHECK(page.entries[0].size == 1);
+  CHECK_FALSE(page.is_truncated);
+}
+
+TEST_CASE("ListObjectsV2 parser rejects a root-name prefix collision", "[s3][list_parser]")
+{
+  CHECK_THROWS_WITH(
+    sirius::io::s3::parse_list_objects_v2(
+      R"(<ListBucketResultBogus><IsTruncated>false</IsTruncated></ListBucketResult>)"),
+    Catch::Contains("not a ListObjectsV2 response"));
+}
+
+TEST_CASE("ListObjectsV2 parser rejects content before the root element", "[s3][list_parser]")
+{
+  CHECK_THROWS_WITH(
+    sirius::io::s3::parse_list_objects_v2(
+      R"(<Foo/><ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>)"),
+    Catch::Contains("before <ListBucketResult>"));
+}
+
+TEST_CASE("ListObjectsV2 parser accepts a prologue and newline before the root",
+          "[s3][list_parser]")
+{
+  auto const page = sirius::io::s3::parse_list_objects_v2(
+    "<?xml version=\"1.0\"?>\n "
+    "<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>");
+
+  CHECK(page.entries.empty());
+  CHECK_FALSE(page.is_truncated);
 }
 
 TEST_CASE("s3_request_authorizer base rejects LIST until implementations opt in",

--- a/test/cpp/utils/s3_container.cpp
+++ b/test/cpp/utils/s3_container.cpp
@@ -65,6 +65,7 @@ extern "C" {
 #include <optional>
 #include <stdexcept>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace sirius::test {
@@ -214,6 +215,30 @@ fs::path generate_fixtures(fs::path const& out_dir)
     {"python3", script.string(), "--out", out_dir.string(), "--parquet-source", parquet_src});
   if (rc != 0) throw std::runtime_error("generate_fixtures.py failed");
   return out_dir;
+}
+
+void create_special_key_fixtures(fs::path const& fixture_dir)
+{
+  auto const nation = fixture_dir / "parquet" / "nation.parquet";
+  auto const region = fixture_dir / "parquet" / "region.parquet";
+  if (!fs::is_regular_file(nation) || !fs::is_regular_file(region)) {
+    throw std::runtime_error("special-key glob fixtures require nation.parquet and region.parquet");
+  }
+
+  auto const root = fixture_dir / "glob-enc";
+  fs::remove_all(root);
+  std::array<std::pair<fs::path, fs::path>, 6> const fixtures{{
+    {nation, root / "a%2Fb.parquet"},
+    {region, root / "a" / "b.parquet"},
+    {nation, root / "x#1.parquet"},
+    {nation, root / "y?v.parquet"},
+    {nation, root / "100%.parquet"},
+    {nation, root / "t" / "col=a%20b" / "p0.parquet"},
+  }};
+  for (auto const& [source, destination] : fixtures) {
+    fs::create_directories(destination.parent_path());
+    fs::copy_file(source, destination, fs::copy_options::overwrite_existing);
+  }
 }
 
 // ---- host-side SigV4 + libcurl upload --------------------------------------
@@ -555,6 +580,7 @@ bool bring_up()
 
   fs::path ca_bundle = generate_self_signed_cert(certs_dir);
   generate_fixtures(fixture_dir);
+  create_special_key_fixtures(fixture_dir);
 
   // HTTP instance: testcontainers' HTTP wait makes it ready before run returns.
   int http_req = make_minio_request();

--- a/test/cpp/utils/s3_container.cpp
+++ b/test/cpp/utils/s3_container.cpp
@@ -515,6 +515,31 @@ void maybe_upload_tpch_sf1_fixture(minio_instance const& http,
             << http.endpoint << " and " << tls.endpoint << std::endl;
 }
 
+void maybe_upload_glob_scale_fixture(minio_instance const& http, fs::path const& fixture_dir)
+{
+  if (!env_truthy("SIRIUS_TEST_S3_GLOB_SCALE")) return;
+
+  constexpr std::size_t object_count = 1001;
+  auto const parquet                 = fixture_dir / "parquet" / "nation.parquet";
+  auto const parquet_size            = static_cast<std::int64_t>(fs::file_size(parquet));
+
+  for (std::size_t index = 0; index < object_count; ++index) {
+    auto const key = "glob-scale/part_" + std::to_string(index) + ".parquet";
+    std::FILE* f   = std::fopen(parquet.c_str(), "rb");
+    if (f == nullptr) throw std::runtime_error("cannot open glob-scale parquet fixture");
+    auto const code =
+      s3_put(http, "http", uri_path_for(kBucket, key), f, parquet_size, std::nullopt);
+    std::fclose(f);
+    if (!(code == 200 || code == 204)) {
+      throw std::runtime_error("glob-scale upload failed for '" + key + "' (HTTP " +
+                               std::to_string(code) + ")");
+    }
+  }
+
+  std::cout << "[s3] uploaded " << object_count << " parquet objects under " << http.endpoint << "/"
+            << kBucket << "/glob-scale/" << std::endl;
+}
+
 // ---- orchestration ---------------------------------------------------------
 
 void setenv_kv(char const* k, std::string const& v) { ::setenv(k, v.c_str(), /*overwrite=*/1); }
@@ -560,6 +585,7 @@ bool bring_up()
   upload_fixtures(tls, "https", fixture_dir, ca);
   maybe_upload_large_fixture(http, tls, ca, work);
   maybe_upload_tpch_sf1_fixture(http, tls, ca, work);
+  maybe_upload_glob_scale_fixture(http, fixture_dir);
 
   // Publish the env contract the [s3] tests consume (mirrors the old env.sh).
   setenv_kv("SIRIUS_TEST_S3_ENDPOINT", http.endpoint);


### PR DESCRIPTION
Address https://github.com/sirius-db/sirius/issues/1116


## Summary

Adds S3 `ListObjectsV2` + glob expansion so a transparent GPU `read_parquet('s3://bucket/pfx/*.parquet')` scans every matching object (multi-file, hive-partitioned) instead of a single key — and reads each globbed file's footer in one suffix-range GET.

## What changed

**LIST (read path)**
- `s3_list_parser` — hand-rolled `ListObjectsV2` XML → `{key, size}` + pagination; rejects `<Error>` bodies, truncated bodies (missing root / `<Contents>` close), and `<Size>` values that overflow uint64.
- `authorize_list` seam on the SigV4 authorizer (`presign_url` gains an extra-canonical-query arg; header + presigned modes).
- `rest_reactor::list_page` (one blocking, retried LIST request) + `rest_ioctx::list_objects_paged` (streaming, one page per sink call) and an accumulating `list_objects` wrapper.

**Glob**
- `sirius_httpfs::Glob` now expands wildcards: LIST the prefix up to the wildcard-bearing segment, glob-match each page's keys (DuckDB `*` `**` `?` `[…]` semantics), return a sorted `OpenFileInfo` list with sizes attached. Feeds the **existing** native multi-file `read_parquet` path (converter + `parquet_gpu_ingestible`); hive partition columns come from DuckDB's `MultiFileReader` as before — no new engine machinery, this just gives it a file list.

**Footer read**
- Each globbed file opens with the `parquet_footer_probe` hint (both the ingestible scan-side open and the transparent bind of the first file), so its footer arrives in **one suffix-range GET, no HEAD** (reusing #1087's probe/stash).

**Config**
- `scan_manager.rest.list_max_matches` (default 100 000) and `list_max_scanned` (default 1 000 000).
-   Two bounds, both throw — max_scanned bounds requests/time on a hot-mess prefix (≤1M entries ≈ ≤1000 round-trips); max_matches bounds result memory + scan fan-out (≤100k kept files ≈ tens of MB accumulated + 100k footer reads). They diverge when a prefix is huge but few keys match. No silent truncation.
- Tuning: treat both as fail-fast rails, not knobs to raise — if you hit one, narrow the glob prefix (a well-organized table sits well under both defaults). Tighten in dev (e.g. list_max_matches: 5000, list_max_scanned: 50000) to catch fat-fingered globs early; only raise list_max_matches for a genuine >100k-file table, and prefer repartitioning into fewer, larger files first.

## Behavior / limits

**Supported**: `*` `**` `?` `[…]` key globs · hive-partitioned globs (`year=*/…`, partition columns injected + filterable) · bucket-root globs (`root_*.parquet`) · object sizes ride the LIST response.

**Not supported** (out of scope): bucket-name wildcards · delimiter/`CommonPrefixes` listing · S3 writes. Zero-match glob → DuckDB's standard "no files found". `gpu_execution=false` on an `s3://` glob → the GPU-only error, at Glob.

**Caps throw, never truncate**: exceeding `max_matches` or `max_scanned` raises "…narrow the glob prefix" rather than silently returning a partial list.

## Perf / safety

- **Streaming LIST** — the paged primitive holds **O(one page ≈ ≤1000 entries)** regardless of bucket population; the sink can stop early and no further LIST is issued.
- **Safety caps** — `list_max_scanned` / `list_max_matches` both throw (see Config); no page is silently truncated.
- **Footer cost** — sizes ride the LIST (no N HEADs for size discovery); each file's footer is one suffix-range GET with the trailing bytes stashed and served locally (no HEAD, no separate trailer/body GETs) for files that fit the probe window.
- SigV4 `authorize_list` rejects smuggled `X-Amz-*` query params.

## Tests

New / extended, all green on the S3 CI gate:
- **parser** `[s3][list_parser]` — document order, pagination, entity unescape, `<Size>`, xmlns, truncation/overflow rejection.
- **authorizer** `[s3][authorizer]` — merged+sorted presigned LIST query, header-mode signing, base default throws (added to the existing `test_sirius_sigv4_authorizer.cpp` object-authorizer suite).
- **REST** `[s3][integration][rest]` — LIST with sizes + encoded continuation tokens, paged early-stop, `max_keys`/`max_scanned` throw, footer-probe open (incl. 404/403), **generated-listing scale tests** (config-override caps + one-page-at-a-time streaming) with a hidden `[…][stress]` tier pinning the default 1M-scanned / 100k-matches thresholds.
- **SQL** `[s3][integration][sql][…][transparent][glob]` — glob + hive-glob == local-CPU oracle, `fallback=0`; cold glob issues 0 blocking-`host_read` footer GETs; zero-match / GPU-only errors; glob-matcher `* ** ? […]` semantics vs DuckDB's local `read_parquet` oracle.
- **glob pagination (real MinIO)** `[…][transparent][glob][large][glob-scale]` — a real 1001-object `glob-scale/part_*.parquet` fixture (1001 copies of `nation.parquet`) crosses the 1000-key `ListObjectsV2` page boundary on the live MinIO path; the GPU glob scan pins `count/sum/min/max(n_nationkey)` = 25025 / 300300 / 0 / 24, proving every page's objects are opened and read. Gated on `SIRIUS_TEST_S3_GLOB_SCALE` (which also drives the fixture upload) and wired into `make s3-test-large` (first group).
- **httpfs** `[s3][filesystem]` — CanHandleFile path validation, opener-gated wildcard expansion (`Glob('…/*.parquet')` throws without a Sirius opener; an exact key returns the single key), and read-only write-open rejection.
- **config** — the two caps parse from YAML with defaults.

## Known follow-ups
- **Large-file footer** — for files bigger than the probe window the footer is stashed but cuDF's offset-0 header-magic read still costs one GET (a tail-suffix probe can't cover offset 0). An exact-range / size-scaled window refinement is deferred behind an over-read bench.
