### PR TITLE
fix(hash-join): emit NULL mark for MARK joins with NULL keys

### DIFF
--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -194,6 +194,8 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
     _distinct_hash_table;  // used instead of _hash_table when build keys are proven unique
   std::unique_ptr<cudf::filtered_join>
     _filtered_table;  // reusable build-on-right semi-join object for MARK joins in BUILD_PROBE mode
+  bool _build_has_null = false;  // whether the build/right side has a NULL in any join key column;
+                                 // needed for MARK three-valued logic in BUILD_PROBE mode
   std::optional<::cucascade::read_only_data_batch>
     _build_table;  // owned build table for BUILD_PROBE mode, to materialize build side results
   std::vector<std::unique_ptr<cudf::column>>

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "op/sirius_physical_hash_join.hpp"
+
 #include "cudf/aggregation.hpp"
 #include "cudf/copying.hpp"
 #include "cudf/join/distinct_hash_join.hpp"
@@ -40,7 +42,6 @@
 #include "log/logging.hpp"
 #include "op/dynamic_filter_publisher.hpp"
 #include "op/sirius_dynamic_filter.hpp"
-#include "op/sirius_physical_hash_join.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 #include "sirius/exception.hpp"

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -852,10 +852,7 @@ static std::unique_ptr<operator_data> gather_distinct_left_join_output(
 /// @brief Whether any column of @p keys carries at least one NULL value.
 static bool table_has_any_null(cudf::table_view const& keys)
 {
-  for (auto const& col : keys) {
-    if (col.null_count() > 0) { return true; }
-  }
-  return false;
+  return std::ranges::any_of(keys, [](auto const& col) { return col.null_count() > 0; });
 }
 
 /// @brief the MARK join output from the semi_join matching row indices.

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "op/sirius_physical_hash_join.hpp"
-
 #include "cudf/aggregation.hpp"
 #include "cudf/copying.hpp"
 #include "cudf/join/distinct_hash_join.hpp"
@@ -23,8 +21,10 @@
 #include "cudf/join/join.hpp"
 #include "cudf/join/mark_join.hpp"
 #include "cudf/join/mixed_join.hpp"
+#include "cudf/null_mask.hpp"
 #include "cudf/reduction.hpp"
 #include "cudf/table/table_view.hpp"
+#include "cudf/transform.hpp"
 #include "cudf/types.hpp"
 #include "cudf/unary.hpp"
 #include "cudf/utilities/memory_resource.hpp"
@@ -40,6 +40,7 @@
 #include "log/logging.hpp"
 #include "op/dynamic_filter_publisher.hpp"
 #include "op/sirius_dynamic_filter.hpp"
+#include "op/sirius_physical_hash_join.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 #include "sirius/exception.hpp"
@@ -848,10 +849,30 @@ static std::unique_ptr<operator_data> gather_distinct_left_join_output(
       make_data_batch(std::move(output_cudf_table), memory_space, stream, telemetry_info)});
 }
 
+/// @brief Whether any column of @p keys carries at least one NULL value.
+static bool table_has_any_null(cudf::table_view const& keys)
+{
+  for (auto const& col : keys) {
+    if (col.null_count() > 0) { return true; }
+  }
+  return false;
+}
+
 /// @brief the MARK join output from the semi_join matching row indices.
 ///
 /// Copies all left output columns (all rows pass through, no gather), then creates a BOOL8 mark
-/// column initialized to false and scatters true at every position in semi_indices.
+/// column initialized to false and scatters true at every position in semi_indices. Finally applies
+/// SQL three-valued logic: an unmatched left row is NULL (not false) when its probe key is NULL, or
+/// when the build/right side contains a NULL join key.
+///
+/// The scattered values are already correct (true at matched rows, false elsewhere), so only a null
+/// mask is added. Because a NULL key never matches under null_equality::UNEQUAL, a matched row
+/// always has a valid probe key, so the desired validity reduces to two cases:
+///   - build_has_null == true : every unmatched row is NULL, so valid == matched. The mask is the
+///                              mark values themselves (cudf::bools_to_mask).
+///   - build_has_null == false: valid == probe row validity (all probe key columns valid). The mask
+///                              is cudf::bitmask_and over the probe keys (empty when none
+///                              nullable).
 ///
 /// @param semi_indices  Device vector of left-side row indices that matched the join condition,
 ///                      as returned by cuDF's semi-join. Used as the scatter map for the mark
@@ -859,6 +880,9 @@ static std::unique_ptr<operator_data> gather_distinct_left_join_output(
 /// @param left_full     Full left-side table view (all columns, all rows) before output projection.
 /// @param lhs_output_col_idxs  Column indices within @p left_full to include in the output.
 ///                             Drives the projection of the left side.
+/// @param probe_keys    Probe/left join key columns (post-cast); their per-row validity drives the
+///                      NULL mark when the build side has no NULL key.
+/// @param build_has_null  Whether the build/right side contains a NULL in any join key column.
 /// @param left_batch    The original left-side data batch; used to propagate memory space metadata
 ///                      to the returned operator_data.
 /// @param stream        CUDA stream on which all device operations are launched.
@@ -866,6 +890,8 @@ static std::unique_ptr<operator_data> resolve_mark_join_result(
   rmm::device_uvector<cudf::size_type> const& semi_indices,
   cudf::table_view const& left_full,
   std::vector<cudf::size_type> const& lhs_output_col_idxs,
+  cudf::table_view const& probe_keys,
+  bool build_has_null,
   ::cucascade::read_only_data_batch const& left_batch,
   rmm::cuda_stream_view stream,
   const telemetry::batch_telemetry_info& telemetry_info = {})
@@ -902,6 +928,22 @@ static std::unique_ptr<operator_data> resolve_mark_join_result(
                                    stream);
     mark_column    = std::move(scattered->release()[0]);
   }
+
+  // Apply SQL three-valued logic by attaching a null mask: unmatched rows become NULL when the
+  // build side has a NULL key (valid == matched) or when the probe key is NULL (valid == probe key
+  // validity). See the function doc comment for the derivation.
+  rmm::device_buffer null_mask;
+  cudf::size_type null_count = 0;
+  if (build_has_null) {
+    auto [mask, count] = cudf::bools_to_mask(mark_column->view(), stream);
+    null_mask          = std::move(*mask);
+    null_count         = count;
+  } else {
+    auto [mask, count] = cudf::bitmask_and(probe_keys, stream);
+    null_mask          = std::move(mask);
+    null_count         = count;
+  }
+  if (null_count > 0) { mark_column->set_null_mask(std::move(null_mask), null_count); }
 
   mark_out_cols.push_back(std::move(mark_column));
   auto output_cudf_table = std::make_unique<cudf::table>(std::move(mark_out_cols), stream);
@@ -953,6 +995,9 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
           // batch's semi_join/anti_join returns left-row match indices (scattered into a BOOL8 mark
           // for MARK, gathered as the output rows for SEMI/ANTI).
           _filtered_table = make_right_filtered_join_ptr(build_keys, stream);
+          // Record whether the build keys contain a NULL; MARK three-valued logic needs it at probe
+          // time, but the build keys are not retained beyond this scope.
+          _build_has_null = table_has_any_null(build_keys);
           SIRIUS_LOG_DEBUG("sirius_physical_hash_join id {}: using filtered_join (BUILD_PROBE {})",
                            this->get_operator_id(),
                            duckdb::JoinTypeToString(join_type));
@@ -992,6 +1037,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         return resolve_mark_join_result(*semi_indices,
                                         left_full,
                                         lhs_output_columns.col_idxs,
+                                        probe_keys,
+                                        _build_has_null,
                                         input_batches[0],
                                         stream,
                                         batch_telemetry());
@@ -1101,6 +1148,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       return resolve_mark_join_result(*semi_indices,
                                       left_full,
                                       lhs_output_columns.col_idxs,
+                                      left_eq,
+                                      table_has_any_null(right_eq),
                                       input_batches[0],
                                       stream,
                                       batch_telemetry());
@@ -1301,6 +1350,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         return resolve_mark_join_result(*semi_indices,
                                         left_full,
                                         lhs_output_columns.col_idxs,
+                                        left_keys,
+                                        table_has_any_null(right_keys),
                                         input_batches[0],
                                         stream,
                                         batch_telemetry());
@@ -1310,6 +1361,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       return resolve_mark_join_result(*semi_indices,
                                       left_full,
                                       lhs_output_columns.col_idxs,
+                                      left_keys,
+                                      table_has_any_null(right_keys),
                                       input_batches[0],
                                       stream,
                                       batch_telemetry());

--- a/test/cpp/operator/operator_test_utils.hpp
+++ b/test/cpp/operator/operator_test_utils.hpp
@@ -175,6 +175,23 @@ inline std::vector<T> copy_column_to_host(const cudf::column_view& col)
   }
 }
 
+/// @brief Copy a column's per-row validity to host (true == valid). All-true if no null mask.
+inline std::vector<bool> copy_validity_to_host(const cudf::column_view& col)
+{
+  std::vector<bool> host(col.size(), true);
+  if (col.size() == 0 || col.null_mask() == nullptr) { return host; }
+  auto const total_bits = col.offset() + col.size();
+  auto const num_words  = static_cast<std::size_t>((total_bits + 31) / 32);
+  std::vector<cudf::bitmask_type> words(num_words);
+  cudaMemcpy(
+    words.data(), col.null_mask(), num_words * sizeof(cudf::bitmask_type), cudaMemcpyDeviceToHost);
+  for (cudf::size_type i = 0; i < col.size(); ++i) {
+    auto const bit = i + col.offset();
+    host[i]        = (words[bit / 32] >> (bit % 32)) & 1u;
+  }
+  return host;
+}
+
 template <typename T>
 inline std::shared_ptr<cucascade::data_batch> make_numeric_batch(
   cucascade::memory::memory_space& space, const std::vector<T>& values, cudf::type_id type_id)
@@ -195,6 +212,47 @@ inline std::shared_ptr<cucascade::data_batch> make_numeric_batch(
                sizeof(int8_t) * tmp.size(),
                cudaMemcpyHostToDevice);
   } else {
+    cudaMemcpy(col->mutable_view().data<T>(),
+               values.data(),
+               sizeof(T) * values.size(),
+               cudaMemcpyHostToDevice);
+  }
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col));
+  auto table = std::make_unique<cudf::table>(std::move(cols));
+
+  auto gpu_repr =
+    std::make_unique<cucascade::gpu_table_representation>(std::move(table), space, stream);
+  auto batch_id = ::sirius::get_next_batch_id();
+  return cucascade::data_batch::make(batch_id, std::move(gpu_repr));
+}
+
+/// @brief Single numeric column batch where @p valids[i]==false makes row i NULL.
+template <typename T>
+inline std::shared_ptr<cucascade::data_batch> make_numeric_batch_with_nulls(
+  cucascade::memory::memory_space& space,
+  const std::vector<T>& values,
+  const std::vector<bool>& valids,
+  cudf::type_id type_id)
+{
+  auto mr     = get_resource_ref(space);
+  auto stream = default_stream();
+  auto size   = static_cast<cudf::size_type>(values.size());
+
+  auto null_mask = cudf::create_null_mask(size, cudf::mask_state::ALL_VALID, stream, mr);
+  auto* mask_ptr = static_cast<cudf::bitmask_type*>(null_mask.data());
+  cudf::size_type null_count = 0;
+  for (cudf::size_type i = 0; i < size; ++i) {
+    if (!valids[i]) {
+      cudf::set_null_mask(mask_ptr, i, i + 1, false, stream);
+      ++null_count;
+    }
+  }
+
+  auto col = cudf::make_numeric_column(
+    cudf::data_type{type_id}, size, std::move(null_mask), null_count, stream, mr);
+  if (size > 0) {
     cudaMemcpy(col->mutable_view().data<T>(),
                values.data(),
                sizeof(T) * values.size(),

--- a/test/cpp/operator/test_physical_mark_join.cpp
+++ b/test/cpp/operator/test_physical_mark_join.cpp
@@ -364,6 +364,105 @@ TEST_CASE("sirius_physical_hash_join mark join - build-on-left (cudf::mark_join)
           std::vector<bool>{false, true, false, true});
 }
 
+// Issue #1076: MARK joins must emit a NULL mark (not false) for an unmatched left row when the
+// build/right side contains a NULL join key. left {1,2,3} vs right {2, NULL} -> [NULL, true, NULL].
+TEST_CASE("sirius_physical_hash_join mark join - right side has NULL key", "[physical_mark_join]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+
+  std::vector<int32_t> left_ids     = {1, 2, 3};
+  std::vector<int32_t> left_payload = {10, 20, 30};
+  auto left_batch                   = make_two_column_batch<int32_t, int32_t>(
+    *space, left_ids, left_payload, cudf::type_id::INT32, std::nullopt, cudf::type_id::INT32);
+
+  // Right key column = {2, NULL}: only 2 is a real key; the NULL taints every non-match to NULL.
+  auto right_batch =
+    make_numeric_batch_with_nulls<int32_t>(*space, {2, 0}, {true, false}, cudf::type_id::INT32);
+
+  auto f = create_mark_join();
+  std::vector<std::shared_ptr<cucascade::data_batch>> inputs{left_batch, right_batch};
+  auto outputs =
+    f.hash_join->execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+
+  auto out_view = sirius::get_cudf_table_view(
+    *dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()[0]);
+  REQUIRE(out_view.num_rows() == 3);
+
+  auto mark = out_view.column(2);
+  REQUIRE(mark.null_count() == 2);
+  REQUIRE(copy_validity_to_host(mark) == std::vector<bool>{false, true, false});
+  REQUIRE(copy_column_to_host<bool>(mark)[1] == true);  // the one matched row
+}
+
+// Issue #1076: an unmatched left row with a NULL probe key is NULL, not false, even when the build
+// side has no NULL key. left {1, NULL, 2} vs right {2} -> [false, NULL, true].
+TEST_CASE("sirius_physical_hash_join mark join - probe side has NULL key", "[physical_mark_join]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+
+  // Left key column carries a NULL at row 1; payload is a plain column.
+  auto left_key = make_numeric_batch_with_nulls<int32_t>(
+    *space, {1, 0, 2}, {true, false, true}, cudf::type_id::INT32);
+  auto left_payload = make_numeric_batch<int32_t>(*space, {10, 20, 30}, cudf::type_id::INT32);
+  auto left_batch   = concatenate_batches_horizontal({left_key, left_payload}, *space);
+
+  auto right_batch = make_numeric_batch<int32_t>(*space, {2}, cudf::type_id::INT32);
+
+  auto f = create_mark_join();
+  std::vector<std::shared_ptr<cucascade::data_batch>> inputs{left_batch, right_batch};
+  auto outputs =
+    f.hash_join->execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+
+  auto out_view = sirius::get_cudf_table_view(
+    *dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()[0]);
+  REQUIRE(out_view.num_rows() == 3);
+
+  auto mark = out_view.column(2);
+  REQUIRE(mark.null_count() == 1);
+  REQUIRE(copy_validity_to_host(mark) == std::vector<bool>{true, false, true});
+  auto values = copy_column_to_host<bool>(mark);
+  REQUIRE(values[0] == false);  // 1 has no match, probe valid, right clean -> false
+  REQUIRE(values[2] == true);   // 2 matches -> true
+}
+
+// Issue #1076: the same NULL semantics must hold on the build-on-left (cudf::mark_join) path.
+TEST_CASE("sirius_physical_hash_join mark join - right NULL key on build-on-left path",
+          "[physical_mark_join]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+
+  std::vector<int32_t> left_ids     = {10, 20, 30, 40};
+  std::vector<int32_t> left_payload = {1, 2, 3, 4};
+  auto left_batch                   = make_two_column_batch<int32_t, int32_t>(
+    *space, left_ids, left_payload, cudf::type_id::INT32, std::nullopt, cudf::type_id::INT32);
+
+  // Right (probe) side larger than left to trigger the switch; {20, 40} match and a NULL is
+  // present.
+  auto right_batch =
+    make_numeric_batch_with_nulls<int32_t>(*space,
+                                           {20, 40, 0, 11, 12, 13, 14},
+                                           {true, true, false, true, true, true, true},
+                                           cudf::type_id::INT32);
+
+  auto f                                    = create_mark_join();
+  f.hash_join->mark_join_build_switch_ratio = 1.0;
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> inputs{left_batch, right_batch};
+  auto outputs =
+    f.hash_join->execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+
+  auto out_view = sirius::get_cudf_table_view(
+    *dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()[0]);
+  REQUIRE(out_view.num_rows() == 4);
+
+  auto mark = out_view.column(2);
+  REQUIRE(mark.null_count() == 2);
+  REQUIRE(copy_validity_to_host(mark) == std::vector<bool>{false, true, false, true});
+}
+
 //===----------------------------------------------------------------------===//
 // Nested-loop join projection-map regression tests
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Fixes #1118 (sub-issue of #1076).

## Problem

MARK joins built the BOOL8 mark column all-`false` and only ever scattered `true` at matched left rows, so an unmatched row always came back `false` — there was no path that emitted a `NULL`. By SQL three-valued logic an unmatched row is `NULL`, not `false`, when the probe key is NULL **or** the build/right side contains a NULL join key. Because Sirius always emitted `false`, `IN` / `= ANY` / `NOT IN` / correlated equality subqueries returned wrong answers once NULLs were involved — most sharply `x NOT IN (subquery containing NULL)`, which must return no rows but returned them (`false → NOT → true → kept`).

## Fix

The scattered mark **values** already equal the matched indicator, so this only attaches a **null mask** — no new kernel. Since a NULL key never matches under `null_equality::UNEQUAL`, a matched row always has a valid probe key, so the desired validity reduces to two cases:

- `build_has_null` → every unmatched row is NULL, `valid == matched` (`cudf::bools_to_mask` over the mark values).
- otherwise → `valid == probe row validity` (`cudf::bitmask_and` over the probe keys; empty when no probe key is nullable).

`resolve_mark_join_result` gains `probe_keys` + `build_has_null` params, threaded through all four hash-join MARK call sites (BUILD_PROBE, mixed, single-shot build-on-left, single-shot standard). BUILD_PROBE records build-key nullness at build time in a new `_build_has_null` member since the build keys are not retained to probe time.

## Correct semantics

| case | mark |
|---|---|
| `x` matches an element of `S` | `true` |
| no match, `x` non-NULL, `S` has no NULL key | `false` |
| no match, and (`x` is NULL **or** `S` has a NULL key) | **`NULL`** |

## Tests

Adds `[physical_mark_join]` regressions for a NULL right key (`{1,2,3}` vs `{2, NULL}` → `[NULL, true, NULL]`), a NULL probe key (`{1, NULL, 2}` vs `{2}` → `[false, NULL, true]`), and a NULL right key on the build-on-left (`cudf::mark_join`) path, plus shared `make_numeric_batch_with_nulls` / `copy_validity_to_host` test helpers. Full C++ suite: 1618/1618 pass.

## Scope

Hash-join (equality) path only — covers all `IN` / `NOT IN` cases. The nested-loop (conditional) MARK path is tracked separately as #1119.