### PR TITLE
fix(nlj): emit NULL mark for conditional MARK joins with NULL keys

### DIFF
--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -361,10 +361,7 @@ cudf::ast::ast_operator to_ast_operator(sirius::comparison_type comparison)
     case sirius::comparison_type::equal: return cudf::ast::ast_operator::EQUAL;
     case sirius::comparison_type::not_distinct_from: return cudf::ast::ast_operator::NULL_EQUAL;
     case sirius::comparison_type::not_equal: return cudf::ast::ast_operator::NOT_EQUAL;
-    case sirius::comparison_type::distinct_from:
-      // No single null-safe cuDF operator; the condition loop builds NOT(NULL_EQUAL) instead
-      // (NOT_EQUAL would be null-propagating and wrong for NULL operands).
-      break;
+    case sirius::comparison_type::distinct_from: break;  // built as NOT(NULL_EQUAL) by the caller
     case sirius::comparison_type::lt: return cudf::ast::ast_operator::LESS;
     case sirius::comparison_type::gt: return cudf::ast::ast_operator::GREATER;
     case sirius::comparison_type::le: return cudf::ast::ast_operator::LESS_EQUAL;
@@ -373,9 +370,8 @@ cudf::ast::ast_operator to_ast_operator(sirius::comparison_type comparison)
   throw std::runtime_error("sirius_physical_nested_loop_join: unsupported comparison type");
 }
 
-/// @brief Left-associative LOGICAL_AND over @p terms, appending the (terms.size()-1) AND nodes to
-/// @p chain, which must be reserved to at least that size — cudf::ast::operation stores operands by
-/// reference, so a reallocation would dangle them. Returns the root expression.
+/// @brief Left-associative LOGICAL_AND over @p terms; @p chain owns the AND nodes and must be
+/// pre-reserved to terms.size()-1.
 const cudf::ast::expression& fold_logical_and(
   const std::vector<std::reference_wrapper<const cudf::ast::expression>>& terms,
   std::vector<cudf::ast::operation>& chain)
@@ -425,7 +421,6 @@ cudf::table_view sirius_physical_nested_loop_join::select_left_output(
   return left.select(sel);
 }
 
-/// @brief Scatter a single BOOL8 @p value into @p column at every position in @p indices.
 static std::unique_ptr<cudf::column> scatter_bool(
   std::unique_ptr<cudf::column> column,
   const rmm::device_uvector<cudf::size_type>& indices,
@@ -448,21 +443,13 @@ static std::unique_ptr<cudf::column> scatter_bool(
   return std::move(scattered->release()[0]);
 }
 
-/// @brief MARK join output implementing SQL three-valued logic.
+/// @brief MARK join output with SQL three-valued logic: every row of @p left_view passes through,
+/// plus a BOOL8 mark that is true at @p true_indices, NULL at rows in @p maybe_indices (the
+/// "predicate IS NOT FALSE" semi-join) but not in @p true_indices, and false elsewhere.
 ///
-/// Every row of @p left_view passes through unchanged, plus a BOOL8 mark column. The mark VALUE is
-/// true at rows in @p true_indices (the predicate evaluated TRUE against some right row) and false
-/// elsewhere. The mark VALIDITY encodes NULL: an unmatched row is NULL when the predicate was never
-/// TRUE but was UNKNOWN (NULL) for some right row — i.e. it is in @p maybe_indices (the "predicate
-/// IS NOT FALSE" semi-join) but not in @p true_indices. Since true_indices is a subset of
-/// maybe_indices, validity == matched OR NOT maybe, built by scattering false at the maybe rows
-/// then true back at the matched rows.
-///
-/// Callers pass the projection-selected left view; both index sets index rows of the original left
-/// table, which stay valid because selection drops columns only.
-///
-/// @p telemetry_info is threaded through to the emitted batch so it stays linked into the query's
-/// telemetry lineage (callers pass the operator's batch_telemetry()).
+/// Callers pass the projection-selected left view; the index sets index original left rows, which
+/// stay valid because selection drops columns only. @p telemetry_info links the emitted batch into
+/// the query's telemetry lineage.
 static std::unique_ptr<operator_data> resolve_mark_join_result(
   const rmm::device_uvector<cudf::size_type>& true_indices,
   const rmm::device_uvector<cudf::size_type>& maybe_indices,
@@ -479,13 +466,11 @@ static std::unique_ptr<operator_data> resolve_mark_join_result(
 
   auto num_rows = left_view.num_rows();
 
-  // Mark values: all-false, scatter true at matched rows.
   cudf::numeric_scalar<bool> false_scalar(false, true, stream);
   auto mark_column = cudf::make_column_from_scalar(false_scalar, num_rows, stream);
   mark_column      = scatter_bool(std::move(mark_column), true_indices, true, stream);
 
-  // Validity: all-valid, scatter invalid(false) at the maybe rows, then valid(true) back at the
-  // matched rows. A false cell in validity_col marks that mark row as NULL.
+  // validity == matched OR NOT maybe; false cells become NULL via bools_to_mask.
   cudf::numeric_scalar<bool> true_scalar(true, true, stream);
   auto validity_col = cudf::make_column_from_scalar(true_scalar, num_rows, stream);
   validity_col      = scatter_bool(std::move(validity_col), maybe_indices, false, stream);
@@ -513,10 +498,8 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::emit_one_side_e
   auto const num_surviving_rows = left_side_empty ? right.num_rows() : left.num_rows();
 
   if (join_type == duckdb::JoinType::MARK) {
-    // Both empty-side MARK cases are "no matches": an empty left side emits 0 rows with the
-    // mark column still in the schema; an empty right side marks every left row false. An empty
-    // right side is definitively false (the OR over an empty set of right rows is FALSE, never
-    // NULL), so both the matched and maybe index sets are empty and no row is NULL.
+    // Empty left emits 0 rows (schema kept); empty right marks every left row false — the OR over
+    // an empty set of right rows is FALSE, never NULL, so both index sets stay empty.
     rmm::device_uvector<cudf::size_type> no_matches(0, stream);
     rmm::device_uvector<cudf::size_type> no_maybe(0, stream);
     return resolve_mark_join_result(
@@ -835,23 +818,14 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
             make_data_batch(std::move(gathered), *space, stream, batch_telemetry())});
       }
       case duckdb::JoinType::MARK: {
-        // Matched rows: predicate evaluated TRUE against some right row.
         auto true_indices = cudf::conditional_left_semi_join(
           left_effective, right_effective, predicate, std::nullopt, stream, mr);
 
-        // SQL three-valued MARK: an unmatched left row is NULL (not false) only when the predicate
-        // was UNKNOWN (never TRUE) for some right row. We find those rows with a second semi-join
-        // on "predicate IS NOT FALSE". Since a conjunction is FALSE iff some conjunct is FALSE,
-        // (AND ci) IS NOT FALSE == AND_i (ci IS NOT FALSE), built per comparison as:
-        //   - null-propagating (=, <, >, <=, >=, !=): a NULL operand makes ci UNKNOWN, so
-        //     "ci IS NOT FALSE" == ci OR IS_NULL(left) OR IS_NULL(right) (NULL_LOGICAL_OR keeps it
-        //     a clean boolean).
-        //   - null-safe (IS [NOT] DISTINCT FROM): a NULL operand yields a definite TRUE/FALSE,
-        //     never UNKNOWN, so "ci IS NOT FALSE" is just ci — tainting it would wrongly emit NULL
-        //     for a definite FALSE (#1119 review).
-        // notfalse_terms holds the per-comparison term (a fresh OR node, or cond_ops[i] for the
-        // null-safe case). The owning vectors are reserved to an upper bound because
-        // cudf::ast::operation stores operands by reference, so a reallocation would dangle them.
+        // Three-valued MARK: an unmatched row is NULL only when the predicate was UNKNOWN (never
+        // TRUE) for some right row; a second semi-join on "predicate IS NOT FALSE" finds those.
+        // (AND ci) IS NOT FALSE == AND_i (ci IS NOT FALSE), where a null-propagating ci becomes
+        // ci OR IS_NULL(left) OR IS_NULL(right) (Kleene NULL_LOGICAL_OR) and a null-safe ci is
+        // never UNKNOWN, so it stays ci itself.
         std::vector<cudf::ast::operation> isnull_left_ops;
         std::vector<cudf::ast::operation> isnull_right_ops;
         std::vector<cudf::ast::operation> notfalse_inner_ops;

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -39,6 +39,7 @@
 #include <cudf/join/join.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/transform.hpp>
 
 #include <rmm/resource_ref.hpp>
 
@@ -399,17 +400,47 @@ cudf::table_view sirius_physical_nested_loop_join::select_left_output(
   return left.select(sel);
 }
 
-/// @brief MARK join output from semi-join matching row indices.
+/// @brief Scatter a single BOOL8 @p value into @p column at every position in @p indices.
+static std::unique_ptr<cudf::column> scatter_bool(
+  std::unique_ptr<cudf::column> column,
+  const rmm::device_uvector<cudf::size_type>& indices,
+  bool value,
+  rmm::cuda_stream_view stream)
+{
+  if (indices.size() == 0) { return column; }
+  cudf::numeric_scalar<bool> scalar(value, true, stream);
+  cudf::column_view scatter_map(cudf::data_type(cudf::type_id::INT32),
+                                static_cast<cudf::size_type>(indices.size()),
+                                indices.data(),
+                                nullptr,
+                                0,
+                                0,
+                                {});
+  auto scattered = cudf::scatter({std::ref(static_cast<const cudf::scalar&>(scalar))},
+                                 scatter_map,
+                                 cudf::table_view({column->view()}),
+                                 stream);
+  return std::move(scattered->release()[0]);
+}
+
+/// @brief MARK join output implementing SQL three-valued logic.
 ///
-/// Every row of @p left_view passes through unchanged, plus a BOOL8 mark column that starts
-/// all-false and gets true scattered at every position in @p semi_indices. Callers pass the
-/// projection-selected left view; @p semi_indices index rows of the original left table, which
-/// stay valid because selection drops columns only.
+/// Every row of @p left_view passes through unchanged, plus a BOOL8 mark column. The mark VALUE is
+/// true at rows in @p true_indices (the predicate evaluated TRUE against some right row) and false
+/// elsewhere. The mark VALIDITY encodes NULL: an unmatched row is NULL when the predicate was never
+/// TRUE but was UNKNOWN (NULL) for some right row — i.e. it is in @p maybe_indices (the "predicate
+/// IS NOT FALSE" semi-join) but not in @p true_indices. Since true_indices is a subset of
+/// maybe_indices, validity == matched OR NOT maybe, built by scattering false at the maybe rows
+/// then true back at the matched rows.
+///
+/// Callers pass the projection-selected left view; both index sets index rows of the original left
+/// table, which stay valid because selection drops columns only.
 ///
 /// @p telemetry_info is threaded through to the emitted batch so it stays linked into the query's
 /// telemetry lineage (callers pass the operator's batch_telemetry()).
 static std::unique_ptr<operator_data> resolve_mark_join_result(
-  const rmm::device_uvector<cudf::size_type>& semi_indices,
+  const rmm::device_uvector<cudf::size_type>& true_indices,
+  const rmm::device_uvector<cudf::size_type>& maybe_indices,
   const cudf::table_view& left_view,
   cucascade::memory::memory_space& space,
   rmm::cuda_stream_view stream,
@@ -421,23 +452,23 @@ static std::unique_ptr<operator_data> resolve_mark_join_result(
     out_cols.push_back(std::make_unique<cudf::column>(left_view.column(i), stream));
   }
 
+  auto num_rows = left_view.num_rows();
+
+  // Mark values: all-false, scatter true at matched rows.
   cudf::numeric_scalar<bool> false_scalar(false, true, stream);
-  auto mark_column = cudf::make_column_from_scalar(false_scalar, left_view.num_rows(), stream);
-  if (semi_indices.size() > 0) {
-    cudf::numeric_scalar<bool> true_scalar(true, true, stream);
-    cudf::column_view scatter_map(cudf::data_type(cudf::type_id::INT32),
-                                  static_cast<cudf::size_type>(semi_indices.size()),
-                                  semi_indices.data(),
-                                  nullptr,
-                                  0,
-                                  0,
-                                  {});
-    auto scattered = cudf::scatter({std::ref(static_cast<const cudf::scalar&>(true_scalar))},
-                                   scatter_map,
-                                   cudf::table_view({mark_column->view()}),
-                                   stream);
-    mark_column    = std::move(scattered->release()[0]);
-  }
+  auto mark_column = cudf::make_column_from_scalar(false_scalar, num_rows, stream);
+  mark_column      = scatter_bool(std::move(mark_column), true_indices, true, stream);
+
+  // Validity: all-valid, scatter invalid(false) at the maybe rows, then valid(true) back at the
+  // matched rows. A false cell in validity_col marks that mark row as NULL.
+  cudf::numeric_scalar<bool> true_scalar(true, true, stream);
+  auto validity_col = cudf::make_column_from_scalar(true_scalar, num_rows, stream);
+  validity_col      = scatter_bool(std::move(validity_col), maybe_indices, false, stream);
+  validity_col      = scatter_bool(std::move(validity_col), true_indices, true, stream);
+
+  auto [null_mask, null_count] = cudf::bools_to_mask(validity_col->view(), stream);
+  if (null_count > 0) { mark_column->set_null_mask(std::move(*null_mask), null_count); }
+
   out_cols.push_back(std::move(mark_column));
 
   auto output_table = std::make_unique<cudf::table>(std::move(out_cols), stream);
@@ -458,10 +489,13 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::emit_one_side_e
 
   if (join_type == duckdb::JoinType::MARK) {
     // Both empty-side MARK cases are "no matches": an empty left side emits 0 rows with the
-    // mark column still in the schema; an empty right side marks every left row false.
+    // mark column still in the schema; an empty right side marks every left row false. An empty
+    // right side is definitively false (the OR over an empty set of right rows is FALSE, never
+    // NULL), so both the matched and maybe index sets are empty and no row is NULL.
     rmm::device_uvector<cudf::size_type> no_matches(0, stream);
+    rmm::device_uvector<cudf::size_type> no_maybe(0, stream);
     return resolve_mark_join_result(
-      no_matches, select_left_output(left), space, stream, batch_telemetry());
+      no_matches, no_maybe, select_left_output(left), space, stream, batch_telemetry());
   }
 
   // Gather maps per the §3 semantics table, filled on the task stream (cudf::sequence /
@@ -775,11 +809,60 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
             make_data_batch(std::move(gathered), *space, stream, batch_telemetry())});
       }
       case duckdb::JoinType::MARK: {
-        auto left_indices = cudf::conditional_left_semi_join(
+        // Matched rows: predicate evaluated TRUE against some right row.
+        auto true_indices = cudf::conditional_left_semi_join(
           left_effective, right_effective, predicate, std::nullopt, stream, mr);
+
+        // SQL three-valued MARK: an unmatched left row is NULL (not false) when the predicate was
+        // never TRUE but was UNKNOWN (NULL) for some right row. To find those rows we run a second
+        // semi-join with "predicate IS NOT FALSE". A conjunction c1 AND ... AND cn is FALSE iff
+        // some ci is FALSE, so (AND ci) IS NOT FALSE == AND_i (ci IS NOT FALSE), and each
+        // comparison "ci IS NOT FALSE" == ci OR IS_NULL(left_i) OR IS_NULL(right_i) (true when ci
+        // is TRUE or NULL, false only when both operands are non-null and ci is FALSE).
+        // NULL_LOGICAL_OR gives Kleene OR so the result is a clean boolean with no NULLs. The
+        // vectors below own the AST nodes and are reserved to exact size — cudf::ast::operation
+        // stores operands by reference, so any reallocation would invalidate them.
+        std::vector<cudf::ast::operation> isnull_left_ops;
+        std::vector<cudf::ast::operation> isnull_right_ops;
+        std::vector<cudf::ast::operation> notfalse_inner_ops;
+        std::vector<cudf::ast::operation> notfalse_ops;
+        std::vector<cudf::ast::operation> notfalse_and_chain;
+        isnull_left_ops.reserve(cond_ops.size());
+        isnull_right_ops.reserve(cond_ops.size());
+        notfalse_inner_ops.reserve(cond_ops.size());
+        notfalse_ops.reserve(cond_ops.size());
+        notfalse_and_chain.reserve(cond_ops.size() > 1 ? cond_ops.size() - 1 : 0);
+        for (size_t i = 0; i < cond_ops.size(); i++) {
+          isnull_left_ops.emplace_back(cudf::ast::ast_operator::IS_NULL, left_refs[i]);
+          isnull_right_ops.emplace_back(cudf::ast::ast_operator::IS_NULL, right_refs[i]);
+          notfalse_inner_ops.emplace_back(
+            cudf::ast::ast_operator::NULL_LOGICAL_OR, cond_ops[i], isnull_left_ops.back());
+          notfalse_ops.emplace_back(cudf::ast::ast_operator::NULL_LOGICAL_OR,
+                                    notfalse_inner_ops.back(),
+                                    isnull_right_ops.back());
+        }
+        for (size_t i = 1; i < notfalse_ops.size(); i++) {
+          const cudf::ast::expression& lhs =
+            (i == 1) ? static_cast<const cudf::ast::expression&>(notfalse_ops[0])
+                     : notfalse_and_chain.back();
+          notfalse_and_chain.emplace_back(
+            cudf::ast::ast_operator::LOGICAL_AND,
+            lhs,
+            static_cast<const cudf::ast::expression&>(notfalse_ops[i]));
+        }
+        const cudf::ast::expression& not_false_predicate =
+          notfalse_and_chain.empty() ? static_cast<const cudf::ast::expression&>(notfalse_ops[0])
+                                     : notfalse_and_chain.back();
+        auto maybe_indices = cudf::conditional_left_semi_join(
+          left_effective, right_effective, not_false_predicate, std::nullopt, stream, mr);
+
         SIRIUS_LOG_DEBUG("Pipeline {}: nested loop join, 1 output batches", pipeline_id);
-        return resolve_mark_join_result(
-          *left_indices, select_left_output(left), *space, stream, batch_telemetry());
+        return resolve_mark_join_result(*true_indices,
+                                        *maybe_indices,
+                                        select_left_output(left),
+                                        *space,
+                                        stream,
+                                        batch_telemetry());
       }
       case duckdb::JoinType::OUTER:
         join_result =

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -55,6 +55,14 @@ static bool nlj_is_equality(sirius::comparison_type c)
   return c == sirius::comparison_type::equal || c == sirius::comparison_type::not_distinct_from;
 }
 
+// Null-safe comparisons treat NULL as an ordinary value: a NULL operand yields a definite
+// TRUE/FALSE, never UNKNOWN.
+static bool nlj_is_null_safe(sirius::comparison_type c)
+{
+  return c == sirius::comparison_type::distinct_from ||
+         c == sirius::comparison_type::not_distinct_from;
+}
+
 void reorder_conditions(duckdb::vector<sirius::join_condition>& conditions)
 {
   bool is_ordered     = true;
@@ -352,14 +360,31 @@ cudf::ast::ast_operator to_ast_operator(sirius::comparison_type comparison)
   switch (comparison) {
     case sirius::comparison_type::equal: return cudf::ast::ast_operator::EQUAL;
     case sirius::comparison_type::not_distinct_from: return cudf::ast::ast_operator::NULL_EQUAL;
-    case sirius::comparison_type::not_equal:
-    case sirius::comparison_type::distinct_from: return cudf::ast::ast_operator::NOT_EQUAL;
+    case sirius::comparison_type::not_equal: return cudf::ast::ast_operator::NOT_EQUAL;
+    case sirius::comparison_type::distinct_from:
+      // No single null-safe cuDF operator; the condition loop builds NOT(NULL_EQUAL) instead
+      // (NOT_EQUAL would be null-propagating and wrong for NULL operands).
+      break;
     case sirius::comparison_type::lt: return cudf::ast::ast_operator::LESS;
     case sirius::comparison_type::gt: return cudf::ast::ast_operator::GREATER;
     case sirius::comparison_type::le: return cudf::ast::ast_operator::LESS_EQUAL;
     case sirius::comparison_type::ge: return cudf::ast::ast_operator::GREATER_EQUAL;
   }
   throw std::runtime_error("sirius_physical_nested_loop_join: unsupported comparison type");
+}
+
+/// @brief Left-associative LOGICAL_AND over @p terms, appending the (terms.size()-1) AND nodes to
+/// @p chain, which must be reserved to at least that size — cudf::ast::operation stores operands by
+/// reference, so a reallocation would dangle them. Returns the root expression.
+const cudf::ast::expression& fold_logical_and(
+  const std::vector<std::reference_wrapper<const cudf::ast::expression>>& terms,
+  std::vector<cudf::ast::operation>& chain)
+{
+  for (size_t i = 1; i < terms.size(); i++) {
+    const cudf::ast::expression& lhs = (i == 1) ? terms[0].get() : chain.back();
+    chain.emplace_back(cudf::ast::ast_operator::LOGICAL_AND, lhs, terms[i].get());
+  }
+  return chain.empty() ? terms[0].get() : chain.back();
 }
 
 // Resolve table column index: BOUND_REF, BOUND_CAST(BOUND_REF), or BOUND_SUBQUERY (scalar
@@ -655,10 +680,12 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
     std::vector<cudf::ast::column_reference> left_refs;
     std::vector<cudf::ast::column_reference> right_refs;
     std::vector<cudf::ast::operation> cond_ops;
+    std::vector<cudf::ast::operation> distinct_inner_ops;  // NULL_EQUAL nodes under distinct_from
     std::vector<cudf::ast::operation> and_chain;
     left_refs.reserve(conditions.size());
     right_refs.reserve(conditions.size());
     cond_ops.reserve(conditions.size());
+    distinct_inner_ops.reserve(conditions.size());
     and_chain.reserve(conditions.size() > 1 ? conditions.size() - 1 : 0);
     std::vector<cudf::column_view> left_col_views, right_col_views;
     std::vector<std::unique_ptr<cudf::column>> intermediates_scope_holder;
@@ -736,25 +763,24 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
 
       left_refs.emplace_back(left_join_input_index, cudf::ast::table_reference::LEFT);
       right_refs.emplace_back(right_join_input_index, cudf::ast::table_reference::RIGHT);
-      cond_ops.emplace_back(to_ast_operator(cond.comparison), left_refs.back(), right_refs.back());
+      if (cond.comparison == sirius::comparison_type::distinct_from) {
+        // IS DISTINCT FROM is null-safe (NULL vs 5 is TRUE, NULL vs NULL is FALSE) but cuDF's
+        // NOT_EQUAL is null-propagating, so build NOT(NULL_EQUAL(l, r)) instead.
+        distinct_inner_ops.emplace_back(
+          cudf::ast::ast_operator::NULL_EQUAL, left_refs.back(), right_refs.back());
+        cond_ops.emplace_back(cudf::ast::ast_operator::NOT, distinct_inner_ops.back());
+      } else {
+        cond_ops.emplace_back(
+          to_ast_operator(cond.comparison), left_refs.back(), right_refs.back());
+      }
     }
 
     cudf::table_view left_effective(left_col_views);
     cudf::table_view right_effective(right_col_views);
 
-    // Build a left-associative AND chain referencing cond_ops elements directly — never copying
-    // operations, matching the cuDF test pattern. and_chain holds exactly (N-1) LOGICAL_AND nodes
-    // for N conditions; cond_ops[0] is the left leaf of the first AND node, not copied into
-    // and_chain.
-    for (size_t i = 1; i < cond_ops.size(); i++) {
-      const cudf::ast::expression& lhs =
-        (i == 1) ? static_cast<const cudf::ast::expression&>(cond_ops[0]) : and_chain.back();
-      and_chain.emplace_back(cudf::ast::ast_operator::LOGICAL_AND,
-                             lhs,
-                             static_cast<const cudf::ast::expression&>(cond_ops[i]));
-    }
-    const cudf::ast::expression& predicate =
-      and_chain.empty() ? static_cast<const cudf::ast::expression&>(cond_ops[0]) : and_chain.back();
+    const std::vector<std::reference_wrapper<const cudf::ast::expression>> cond_terms(
+      cond_ops.begin(), cond_ops.end());
+    const cudf::ast::expression& predicate = fold_logical_and(cond_terms, and_chain);
 
     std::pair<std::unique_ptr<rmm::device_uvector<cudf::size_type>>,
               std::unique_ptr<rmm::device_uvector<cudf::size_type>>>
@@ -813,46 +839,47 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
         auto true_indices = cudf::conditional_left_semi_join(
           left_effective, right_effective, predicate, std::nullopt, stream, mr);
 
-        // SQL three-valued MARK: an unmatched left row is NULL (not false) when the predicate was
-        // never TRUE but was UNKNOWN (NULL) for some right row. To find those rows we run a second
-        // semi-join with "predicate IS NOT FALSE". A conjunction c1 AND ... AND cn is FALSE iff
-        // some ci is FALSE, so (AND ci) IS NOT FALSE == AND_i (ci IS NOT FALSE), and each
-        // comparison "ci IS NOT FALSE" == ci OR IS_NULL(left_i) OR IS_NULL(right_i) (true when ci
-        // is TRUE or NULL, false only when both operands are non-null and ci is FALSE).
-        // NULL_LOGICAL_OR gives Kleene OR so the result is a clean boolean with no NULLs. The
-        // vectors below own the AST nodes and are reserved to exact size — cudf::ast::operation
-        // stores operands by reference, so any reallocation would invalidate them.
+        // SQL three-valued MARK: an unmatched left row is NULL (not false) only when the predicate
+        // was UNKNOWN (never TRUE) for some right row. We find those rows with a second semi-join
+        // on "predicate IS NOT FALSE". Since a conjunction is FALSE iff some conjunct is FALSE,
+        // (AND ci) IS NOT FALSE == AND_i (ci IS NOT FALSE), built per comparison as:
+        //   - null-propagating (=, <, >, <=, >=, !=): a NULL operand makes ci UNKNOWN, so
+        //     "ci IS NOT FALSE" == ci OR IS_NULL(left) OR IS_NULL(right) (NULL_LOGICAL_OR keeps it
+        //     a clean boolean).
+        //   - null-safe (IS [NOT] DISTINCT FROM): a NULL operand yields a definite TRUE/FALSE,
+        //     never UNKNOWN, so "ci IS NOT FALSE" is just ci — tainting it would wrongly emit NULL
+        //     for a definite FALSE (#1119 review).
+        // notfalse_terms holds the per-comparison term (a fresh OR node, or cond_ops[i] for the
+        // null-safe case). The owning vectors are reserved to an upper bound because
+        // cudf::ast::operation stores operands by reference, so a reallocation would dangle them.
         std::vector<cudf::ast::operation> isnull_left_ops;
         std::vector<cudf::ast::operation> isnull_right_ops;
         std::vector<cudf::ast::operation> notfalse_inner_ops;
-        std::vector<cudf::ast::operation> notfalse_ops;
+        std::vector<cudf::ast::operation> notfalse_or_ops;
         std::vector<cudf::ast::operation> notfalse_and_chain;
+        std::vector<std::reference_wrapper<const cudf::ast::expression>> notfalse_terms;
         isnull_left_ops.reserve(cond_ops.size());
         isnull_right_ops.reserve(cond_ops.size());
         notfalse_inner_ops.reserve(cond_ops.size());
-        notfalse_ops.reserve(cond_ops.size());
+        notfalse_or_ops.reserve(cond_ops.size());
         notfalse_and_chain.reserve(cond_ops.size() > 1 ? cond_ops.size() - 1 : 0);
+        notfalse_terms.reserve(cond_ops.size());
         for (size_t i = 0; i < cond_ops.size(); i++) {
+          if (nlj_is_null_safe(conditions[i].comparison)) {
+            notfalse_terms.emplace_back(cond_ops[i]);
+            continue;
+          }
           isnull_left_ops.emplace_back(cudf::ast::ast_operator::IS_NULL, left_refs[i]);
           isnull_right_ops.emplace_back(cudf::ast::ast_operator::IS_NULL, right_refs[i]);
           notfalse_inner_ops.emplace_back(
             cudf::ast::ast_operator::NULL_LOGICAL_OR, cond_ops[i], isnull_left_ops.back());
-          notfalse_ops.emplace_back(cudf::ast::ast_operator::NULL_LOGICAL_OR,
-                                    notfalse_inner_ops.back(),
-                                    isnull_right_ops.back());
-        }
-        for (size_t i = 1; i < notfalse_ops.size(); i++) {
-          const cudf::ast::expression& lhs =
-            (i == 1) ? static_cast<const cudf::ast::expression&>(notfalse_ops[0])
-                     : notfalse_and_chain.back();
-          notfalse_and_chain.emplace_back(
-            cudf::ast::ast_operator::LOGICAL_AND,
-            lhs,
-            static_cast<const cudf::ast::expression&>(notfalse_ops[i]));
+          notfalse_or_ops.emplace_back(cudf::ast::ast_operator::NULL_LOGICAL_OR,
+                                       notfalse_inner_ops.back(),
+                                       isnull_right_ops.back());
+          notfalse_terms.emplace_back(notfalse_or_ops.back());
         }
         const cudf::ast::expression& not_false_predicate =
-          notfalse_and_chain.empty() ? static_cast<const cudf::ast::expression&>(notfalse_ops[0])
-                                     : notfalse_and_chain.back();
+          fold_logical_and(notfalse_terms, notfalse_and_chain);
         auto maybe_indices = cudf::conditional_left_semi_join(
           left_effective, right_effective, not_false_predicate, std::nullopt, stream, mr);
 

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -46,6 +46,7 @@
 #include <nvtx3/nvtx3.hpp>
 
 #include <cstdio>
+#include <span>
 
 namespace sirius {
 namespace op {
@@ -358,14 +359,16 @@ namespace {
 cudf::ast::ast_operator to_ast_operator(sirius::comparison_type comparison)
 {
   switch (comparison) {
-    case sirius::comparison_type::equal: return cudf::ast::ast_operator::EQUAL;
-    case sirius::comparison_type::not_distinct_from: return cudf::ast::ast_operator::NULL_EQUAL;
-    case sirius::comparison_type::not_equal: return cudf::ast::ast_operator::NOT_EQUAL;
-    case sirius::comparison_type::distinct_from: break;  // built as NOT(NULL_EQUAL) by the caller
-    case sirius::comparison_type::lt: return cudf::ast::ast_operator::LESS;
-    case sirius::comparison_type::gt: return cudf::ast::ast_operator::GREATER;
-    case sirius::comparison_type::le: return cudf::ast::ast_operator::LESS_EQUAL;
-    case sirius::comparison_type::ge: return cudf::ast::ast_operator::GREATER_EQUAL;
+    using enum sirius::comparison_type;
+    using enum cudf::ast::ast_operator;
+    case equal: return EQUAL;
+    case not_distinct_from: return NULL_EQUAL;
+    case not_equal: return NOT_EQUAL;
+    case distinct_from: break;  // built as NOT(NULL_EQUAL) by the caller
+    case lt: return LESS;
+    case gt: return GREATER;
+    case le: return LESS_EQUAL;
+    case ge: return GREATER_EQUAL;
   }
   throw std::runtime_error("sirius_physical_nested_loop_join: unsupported comparison type");
 }
@@ -373,7 +376,7 @@ cudf::ast::ast_operator to_ast_operator(sirius::comparison_type comparison)
 /// @brief Left-associative LOGICAL_AND over @p terms; @p chain owns the AND nodes and must be
 /// pre-reserved to terms.size()-1.
 const cudf::ast::expression& fold_logical_and(
-  const std::vector<std::reference_wrapper<const cudf::ast::expression>>& terms,
+  std::span<const std::reference_wrapper<const cudf::ast::expression>> terms,
   std::vector<cudf::ast::operation>& chain)
 {
   for (size_t i = 1; i < terms.size(); i++) {

--- a/test/cpp/operator/test_physical_mark_join.cpp
+++ b/test/cpp/operator/test_physical_mark_join.cpp
@@ -161,10 +161,12 @@ nlj_projection_fixture create_projected_nlj(duckdb::JoinType join_type,
   return f;
 }
 
-// Two-condition NLJ MARK fixture: (left.col0 OP right.col0) AND (left.col2 OP right.col1).
+// Two-condition NLJ MARK fixture: (left.col0 <cmp0> right.col0) AND (left.col2 <cmp1> right.col1).
 // Left child {INT,INT,INT} (col0, payload col1, col2), right child {INT,INT}. Outputs the payload
-// column plus the mark. Used to exercise three-valued conjunction semantics (NULL AND FALSE=FALSE).
-nlj_projection_fixture create_projected_nlj_two_cond(duckdb::ExpressionType comparison)
+// column plus the mark. Used to exercise three-valued conjunction semantics (NULL AND FALSE=FALSE)
+// and mixed null-safe/null-propagating conjunctions.
+nlj_projection_fixture create_projected_nlj_two_cond(duckdb::ExpressionType comparison0,
+                                                     duckdb::ExpressionType comparison1)
 {
   nlj_projection_fixture f;
 
@@ -186,12 +188,12 @@ nlj_projection_fixture create_projected_nlj_two_cond(duckdb::ExpressionType comp
   duckdb::JoinCondition cond0;
   cond0.left       = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
   cond0.right      = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  cond0.comparison = comparison;
+  cond0.comparison = comparison0;
   conditions.push_back(std::move(cond0));
   duckdb::JoinCondition cond1;
   cond1.left       = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 2);
   cond1.right      = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 1);
-  cond1.comparison = comparison;
+  cond1.comparison = comparison1;
   conditions.push_back(std::move(cond1));
 
   f.nlj = duckdb::make_uniq<sirius_physical_nested_loop_join>(
@@ -675,7 +677,8 @@ TEST_CASE("sirius_physical_nested_loop_join MARK conjunction absorbs NULL with F
     // r1=(b=10,d=NULL): (100<10)=FALSE AND (100<NULL)=NULL -> FALSE
     auto right = make_right({0, 10}, {false, true}, {5, 0}, {true, false});
 
-    auto f        = create_projected_nlj_two_cond(duckdb::ExpressionType::COMPARE_LESSTHAN);
+    auto f        = create_projected_nlj_two_cond(duckdb::ExpressionType::COMPARE_LESSTHAN,
+                                           duckdb::ExpressionType::COMPARE_LESSTHAN);
     auto result   = execute_projected_nlj(*f.nlj, left, right);
     auto out_view = result.view;
 
@@ -690,7 +693,130 @@ TEST_CASE("sirius_physical_nested_loop_join MARK conjunction absorbs NULL with F
     // r0=(b=NULL,d=5): (100<NULL)=NULL AND (1<5)=TRUE -> NULL, and there is no TRUE match anywhere.
     auto right = make_right({0}, {false}, {5}, {true});
 
-    auto f        = create_projected_nlj_two_cond(duckdb::ExpressionType::COMPARE_LESSTHAN);
+    auto f        = create_projected_nlj_two_cond(duckdb::ExpressionType::COMPARE_LESSTHAN,
+                                           duckdb::ExpressionType::COMPARE_LESSTHAN);
+    auto result   = execute_projected_nlj(*f.nlj, left, right);
+    auto out_view = result.view;
+
+    auto mark = out_view.column(1);
+    REQUIRE(mark.null_count() == 1);
+    REQUIRE(copy_validity_to_host(mark) == std::vector<bool>{false});
+  }
+}
+
+// Issue #1119 (review): a null-safe comparison (IS NOT DISTINCT FROM) is never UNKNOWN, so a NULL
+// operand yields a definite TRUE/FALSE. Such rows must NOT be tainted into NULL marks.
+TEST_CASE("sirius_physical_nested_loop_join MARK null-safe comparisons yield definite marks",
+          "[physical_nested_loop_join][projection][mark]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+
+  // Left col0 (the key) = {NULL, 5}, payload = {10, 20}; predicate col0 <cmp> right.col0 where
+  // <cmp> is a null-safe comparison (IS [NOT] DISTINCT FROM): a NULL operand yields a definite
+  // TRUE/FALSE, never UNKNOWN, so the mark column must have no NULLs.
+  auto make_left = [&](const std::vector<int32_t>& a,
+                       const std::vector<bool>& a_valid,
+                       const std::vector<int32_t>& payload) {
+    auto col0 = make_numeric_batch_with_nulls<int32_t>(*space, a, a_valid, cudf::type_id::INT32);
+    auto col1 = make_numeric_batch<int32_t>(*space, payload, cudf::type_id::INT32);
+    auto col2 =
+      make_numeric_batch<int32_t>(*space, std::vector<int32_t>(a.size(), 0), cudf::type_id::INT32);
+    return concatenate_batches_horizontal({col0, col1, col2}, *space);
+  };
+  auto run = [&](duckdb::ExpressionType cmp, std::shared_ptr<cucascade::data_batch> right) {
+    auto left = make_left({0, 5}, {false, true}, {10, 20});  // col0 = {NULL, 5}
+    auto f    = create_projected_nlj(duckdb::JoinType::MARK, cmp);
+    return execute_projected_nlj(*f.nlj, std::move(left), std::move(right));
+  };
+
+  SECTION("IS NOT DISTINCT FROM, right {5}: NULL vs 5 FALSE, 5 vs 5 TRUE")
+  {
+    auto result = run(duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM,
+                      make_numeric_batch<int32_t>(*space, {5}, cudf::type_id::INT32));
+    auto mark   = result.view.column(1);
+    REQUIRE(mark.null_count() == 0);
+    REQUIRE(copy_column_to_host<bool>(mark) == std::vector<bool>{false, true});
+  }
+
+  SECTION("IS NOT DISTINCT FROM, right {NULL}: NULL vs NULL TRUE, 5 vs NULL FALSE")
+  {
+    auto result =
+      run(duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM,
+          make_numeric_batch_with_nulls<int32_t>(*space, {0}, {false}, cudf::type_id::INT32));
+    auto mark = result.view.column(1);
+    REQUIRE(mark.null_count() == 0);
+    REQUIRE(copy_column_to_host<bool>(mark) == std::vector<bool>{true, false});
+  }
+
+  SECTION("IS DISTINCT FROM, right {5}: NULL vs 5 TRUE, 5 vs 5 FALSE")
+  {
+    auto result = run(duckdb::ExpressionType::COMPARE_DISTINCT_FROM,
+                      make_numeric_batch<int32_t>(*space, {5}, cudf::type_id::INT32));
+    auto mark   = result.view.column(1);
+    REQUIRE(mark.null_count() == 0);
+    REQUIRE(copy_column_to_host<bool>(mark) == std::vector<bool>{true, false});
+  }
+
+  SECTION("IS DISTINCT FROM, right {NULL}: NULL vs NULL FALSE, 5 vs NULL TRUE")
+  {
+    auto result =
+      run(duckdb::ExpressionType::COMPARE_DISTINCT_FROM,
+          make_numeric_batch_with_nulls<int32_t>(*space, {0}, {false}, cudf::type_id::INT32));
+    auto mark = result.view.column(1);
+    REQUIRE(mark.null_count() == 0);
+    REQUIRE(copy_column_to_host<bool>(mark) == std::vector<bool>{false, true});
+  }
+}
+
+// Issue #1119 (review): the realistic reachable path — a mixed conjunction that pairs a null-safe
+// comparison (IS NOT DISTINCT FROM) with a null-propagating one (<). Only the propagating conjunct
+// may be null-tainted; the null-safe conjunct must keep its definite TRUE/FALSE.
+TEST_CASE("sirius_physical_nested_loop_join MARK mixed null-safe + null-propagating conjunction",
+          "[physical_nested_loop_join][projection][mark]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+
+  // Predicate: (left.col0 IS NOT DISTINCT FROM right.col0) AND (left.col2 < right.col1).
+  auto make_left = [&](int32_t a, bool a_valid, int32_t payload, int32_t c, bool c_valid) {
+    auto col0 =
+      make_numeric_batch_with_nulls<int32_t>(*space, {a}, {a_valid}, cudf::type_id::INT32);
+    auto col1 = make_numeric_batch<int32_t>(*space, {payload}, cudf::type_id::INT32);
+    auto col2 =
+      make_numeric_batch_with_nulls<int32_t>(*space, {c}, {c_valid}, cudf::type_id::INT32);
+    return concatenate_batches_horizontal({col0, col1, col2}, *space);
+  };
+  auto make_right = [&](int32_t b, int32_t d) {
+    auto col0 = make_numeric_batch<int32_t>(*space, {b}, cudf::type_id::INT32);
+    auto col1 = make_numeric_batch<int32_t>(*space, {d}, cudf::type_id::INT32);
+    return concatenate_batches_horizontal({col0, col1}, *space);
+  };
+
+  SECTION("null-safe conjunct is a definite FALSE -> whole predicate FALSE, mark FALSE")
+  {
+    // (NULL IS NOT DISTINCT FROM 5) = FALSE, (1 < 100) = TRUE -> FALSE AND TRUE = FALSE.
+    auto left  = make_left(/*a*/ 0, /*a_valid*/ false, /*payload*/ 10, /*c*/ 1, /*c_valid*/ true);
+    auto right = make_right(/*b*/ 5, /*d*/ 100);
+
+    auto f        = create_projected_nlj_two_cond(duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM,
+                                           duckdb::ExpressionType::COMPARE_LESSTHAN);
+    auto result   = execute_projected_nlj(*f.nlj, left, right);
+    auto out_view = result.view;
+
+    auto mark = out_view.column(1);
+    REQUIRE(mark.null_count() == 0);
+    REQUIRE(copy_column_to_host<bool>(mark) == std::vector<bool>{false});
+  }
+
+  SECTION("null-safe conjunct TRUE but propagating conjunct UNKNOWN -> mark NULL")
+  {
+    // (5 IS NOT DISTINCT FROM 5) = TRUE, (NULL < 100) = UNKNOWN -> TRUE AND UNKNOWN = UNKNOWN.
+    auto left  = make_left(/*a*/ 5, /*a_valid*/ true, /*payload*/ 10, /*c*/ 0, /*c_valid*/ false);
+    auto right = make_right(/*b*/ 5, /*d*/ 100);
+
+    auto f        = create_projected_nlj_two_cond(duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM,
+                                           duckdb::ExpressionType::COMPARE_LESSTHAN);
     auto result   = execute_projected_nlj(*f.nlj, left, right);
     auto out_view = result.view;
 

--- a/test/cpp/operator/test_physical_mark_join.cpp
+++ b/test/cpp/operator/test_physical_mark_join.cpp
@@ -581,7 +581,8 @@ TEST_CASE("sirius_physical_nested_loop_join MARK emits NULL under three-valued l
   auto* space = get_shared_mem_space();
   REQUIRE(space);
 
-  // Predicate is left.col0 < right.col0 (routes to NLJ since it is a pure inequality).
+  // Predicate is left.col0 < right.col0 — a pure inequality, the shape that reaches the NLJ in
+  // production plans.
   auto make_left = [&](const std::vector<int32_t>& a,
                        const std::vector<bool>& a_valid,
                        const std::vector<int32_t>& payload) {
@@ -704,17 +705,16 @@ TEST_CASE("sirius_physical_nested_loop_join MARK conjunction absorbs NULL with F
   }
 }
 
-// Issue #1119 (review): a null-safe comparison (IS NOT DISTINCT FROM) is never UNKNOWN, so a NULL
-// operand yields a definite TRUE/FALSE. Such rows must NOT be tainted into NULL marks.
+// Issue #1119 (review): the null-safe comparisons IS [NOT] DISTINCT FROM yield a definite
+// TRUE/FALSE for NULL operands, never UNKNOWN — their rows must not be tainted into NULL marks.
 TEST_CASE("sirius_physical_nested_loop_join MARK null-safe comparisons yield definite marks",
           "[physical_nested_loop_join][projection][mark]")
 {
   auto* space = get_shared_mem_space();
   REQUIRE(space);
 
-  // Left col0 (the key) = {NULL, 5}, payload = {10, 20}; predicate col0 <cmp> right.col0 where
-  // <cmp> is a null-safe comparison (IS [NOT] DISTINCT FROM): a NULL operand yields a definite
-  // TRUE/FALSE, never UNKNOWN, so the mark column must have no NULLs.
+  // Left col0 (the key) = {NULL, 5}, payload = {10, 20}; predicate col0 <cmp> right.col0.
+  // Every section expects a mark column with no NULLs.
   auto make_left = [&](const std::vector<int32_t>& a,
                        const std::vector<bool>& a_valid,
                        const std::vector<int32_t>& payload) {

--- a/test/cpp/operator/test_physical_mark_join.cpp
+++ b/test/cpp/operator/test_physical_mark_join.cpp
@@ -161,6 +161,52 @@ nlj_projection_fixture create_projected_nlj(duckdb::JoinType join_type,
   return f;
 }
 
+// Two-condition NLJ MARK fixture: (left.col0 OP right.col0) AND (left.col2 OP right.col1).
+// Left child {INT,INT,INT} (col0, payload col1, col2), right child {INT,INT}. Outputs the payload
+// column plus the mark. Used to exercise three-valued conjunction semantics (NULL AND FALSE=FALSE).
+nlj_projection_fixture create_projected_nlj_two_cond(duckdb::ExpressionType comparison)
+{
+  nlj_projection_fixture f;
+
+  f.logical_join        = duckdb::make_uniq<duckdb::LogicalComparisonJoin>(duckdb::JoinType::MARK);
+  f.logical_join->types = {duckdb::LogicalType::INTEGER, duckdb::LogicalType::BOOLEAN};
+
+  auto left_child = duckdb::make_uniq<sirius_physical_operator>(
+    SiriusPhysicalOperatorType::PROJECTION,
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{
+      duckdb::LogicalType::INTEGER, duckdb::LogicalType::INTEGER, duckdb::LogicalType::INTEGER}),
+    0);
+  auto right_child = duckdb::make_uniq<sirius_physical_operator>(
+    SiriusPhysicalOperatorType::PROJECTION,
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER,
+                                                                duckdb::LogicalType::INTEGER}),
+    0);
+
+  duckdb::vector<duckdb::JoinCondition> conditions;
+  duckdb::JoinCondition cond0;
+  cond0.left       = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
+  cond0.right      = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
+  cond0.comparison = comparison;
+  conditions.push_back(std::move(cond0));
+  duckdb::JoinCondition cond1;
+  cond1.left       = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 2);
+  cond1.right      = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 1);
+  cond1.comparison = comparison;
+  conditions.push_back(std::move(cond1));
+
+  f.nlj = duckdb::make_uniq<sirius_physical_nested_loop_join>(
+    *f.logical_join,
+    std::move(left_child),
+    std::move(right_child),
+    sirius::wrap_join_conditions(std::move(conditions)),
+    duckdb::JoinType::MARK,
+    1000,
+    duckdb::vector<std::size_t>{1},  // left_projection_map: output only payload column
+    duckdb::vector<std::size_t>{});
+
+  return f;
+}
+
 projected_nlj_result execute_projected_nlj(sirius_physical_nested_loop_join& nlj,
                                            std::shared_ptr<cucascade::data_batch> left,
                                            std::shared_ptr<cucascade::data_batch> right)
@@ -522,6 +568,135 @@ TEST_CASE("sirius_physical_nested_loop_join MARK empty side honors the left proj
 
     REQUIRE(out_view.num_columns() == 2);
     REQUIRE(out_view.num_rows() == 0);
+  }
+}
+
+// Issue #1119: the NLJ (conditional) MARK path must emit a NULL mark for an unmatched left row
+// when the predicate was never TRUE but was UNKNOWN (NULL) for some right row.
+TEST_CASE("sirius_physical_nested_loop_join MARK emits NULL under three-valued logic",
+          "[physical_nested_loop_join][projection][mark]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+
+  // Predicate is left.col0 < right.col0 (routes to NLJ since it is a pure inequality).
+  auto make_left = [&](const std::vector<int32_t>& a,
+                       const std::vector<bool>& a_valid,
+                       const std::vector<int32_t>& payload) {
+    auto col0 = a_valid.empty() ? make_numeric_batch<int32_t>(*space, a, cudf::type_id::INT32)
+                                : make_numeric_batch_with_nulls<int32_t>(
+                                    *space, a, a_valid, cudf::type_id::INT32);
+    auto col1 = make_numeric_batch<int32_t>(*space, payload, cudf::type_id::INT32);
+    auto col2 =
+      make_numeric_batch<int32_t>(*space, std::vector<int32_t>(a.size(), 0), cudf::type_id::INT32);
+    return concatenate_batches_horizontal({col0, col1, col2}, *space);
+  };
+
+  SECTION("right NULL taints an otherwise-false row to NULL")
+  {
+    auto left = make_left({1, 5, 10}, {}, {10, 20, 30});
+    auto right =
+      make_numeric_batch_with_nulls<int32_t>(*space, {8, 0}, {true, false}, cudf::type_id::INT32);
+
+    auto f = create_projected_nlj(duckdb::JoinType::MARK, duckdb::ExpressionType::COMPARE_LESSTHAN);
+    auto result   = execute_projected_nlj(*f.nlj, left, right);
+    auto out_view = result.view;
+
+    REQUIRE(out_view.num_rows() == 3);
+    auto mark = out_view.column(1);
+    REQUIRE(mark.null_count() == 1);
+    REQUIRE(copy_validity_to_host(mark) == std::vector<bool>{true, true, false});
+    auto values = copy_column_to_host<bool>(mark);
+    REQUIRE(values[0] == true);
+    REQUIRE(values[1] == true);
+  }
+
+  SECTION("NULL probe key is NULL, not false")
+  {
+    auto left  = make_left({1, 0, 20}, {true, false, true}, {10, 20, 30});
+    auto right = make_numeric_batch<int32_t>(*space, {10}, cudf::type_id::INT32);
+
+    auto f = create_projected_nlj(duckdb::JoinType::MARK, duckdb::ExpressionType::COMPARE_LESSTHAN);
+    auto result   = execute_projected_nlj(*f.nlj, left, right);
+    auto out_view = result.view;
+
+    REQUIRE(out_view.num_rows() == 3);
+    auto mark = out_view.column(1);
+    REQUIRE(mark.null_count() == 1);
+    REQUIRE(copy_validity_to_host(mark) == std::vector<bool>{true, false, true});
+    auto values = copy_column_to_host<bool>(mark);
+    REQUIRE(values[0] == true);   // 1 < 10
+    REQUIRE(values[2] == false);  // 20 < 10 is definitively false
+  }
+
+  SECTION("definitely-false rows with no nulls stay false")
+  {
+    auto left  = make_left({20, 30}, {}, {10, 20});
+    auto right = make_numeric_batch<int32_t>(*space, {10}, cudf::type_id::INT32);
+
+    auto f = create_projected_nlj(duckdb::JoinType::MARK, duckdb::ExpressionType::COMPARE_LESSTHAN);
+    auto result   = execute_projected_nlj(*f.nlj, left, right);
+    auto out_view = result.view;
+
+    auto mark = out_view.column(1);
+    REQUIRE(mark.null_count() == 0);
+    REQUIRE(copy_column_to_host<bool>(mark) == std::vector<bool>{false, false});
+  }
+}
+
+// Issue #1119: with a conjunction, a NULL in one comparison must be absorbed by a FALSE in another
+// (NULL AND FALSE == FALSE) — a naive "any referenced null -> NULL" would be wrong here.
+TEST_CASE("sirius_physical_nested_loop_join MARK conjunction absorbs NULL with FALSE",
+          "[physical_nested_loop_join][projection][mark]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+
+  // Predicate: (left.col0 < right.col0) AND (left.col2 < right.col1).
+  auto make_left = [&](int32_t a, int32_t payload, int32_t c) {
+    auto col0 = make_numeric_batch<int32_t>(*space, {a}, cudf::type_id::INT32);
+    auto col1 = make_numeric_batch<int32_t>(*space, {payload}, cudf::type_id::INT32);
+    auto col2 = make_numeric_batch<int32_t>(*space, {c}, cudf::type_id::INT32);
+    return concatenate_batches_horizontal({col0, col1, col2}, *space);
+  };
+  auto make_right = [&](const std::vector<int32_t>& b,
+                        const std::vector<bool>& b_valid,
+                        const std::vector<int32_t>& d,
+                        const std::vector<bool>& d_valid) {
+    auto col0 = make_numeric_batch_with_nulls<int32_t>(*space, b, b_valid, cudf::type_id::INT32);
+    auto col1 = make_numeric_batch_with_nulls<int32_t>(*space, d, d_valid, cudf::type_id::INT32);
+    return concatenate_batches_horizontal({col0, col1}, *space);
+  };
+
+  SECTION("every right row has a FALSE conjunct -> mark FALSE despite the NULLs")
+  {
+    auto left = make_left(/*a*/ 100, /*payload*/ 10, /*c*/ 100);
+    // r0=(b=NULL,d=5): (100<NULL)=NULL AND (100<5)=FALSE -> FALSE
+    // r1=(b=10,d=NULL): (100<10)=FALSE AND (100<NULL)=NULL -> FALSE
+    auto right = make_right({0, 10}, {false, true}, {5, 0}, {true, false});
+
+    auto f        = create_projected_nlj_two_cond(duckdb::ExpressionType::COMPARE_LESSTHAN);
+    auto result   = execute_projected_nlj(*f.nlj, left, right);
+    auto out_view = result.view;
+
+    auto mark = out_view.column(1);
+    REQUIRE(mark.null_count() == 0);
+    REQUIRE(copy_column_to_host<bool>(mark) == std::vector<bool>{false});
+  }
+
+  SECTION("a right row that is TRUE-then-NULL (no FALSE conjunct) yields NULL")
+  {
+    auto left = make_left(/*a*/ 100, /*payload*/ 10, /*c*/ 1);
+    // r0=(b=NULL,d=5): (100<NULL)=NULL AND (1<5)=TRUE -> NULL, and there is no TRUE match anywhere.
+    auto right = make_right({0}, {false}, {5}, {true});
+
+    auto f        = create_projected_nlj_two_cond(duckdb::ExpressionType::COMPARE_LESSTHAN);
+    auto result   = execute_projected_nlj(*f.nlj, left, right);
+    auto out_view = result.view;
+
+    auto mark = out_view.column(1);
+    REQUIRE(mark.null_count() == 1);
+    REQUIRE(copy_validity_to_host(mark) == std::vector<bool>{false});
   }
 }
 


### PR DESCRIPTION
Fixes #1119 (sub-issue of #1076; pairs with the merged #1118 hash-join fix).

## Problem

The NLJ MARK path marked every unmatched left row `false`. `cudf::conditional_left_semi_join` only returns TRUE matches, dropping NULL/UNKNOWN pairs — but by SQL three-valued logic an unmatched row is `NULL` when the predicate was UNKNOWN (never TRUE) for some right row.

## Fix

**Three-valued mark (commit 1):** a second semi-join on `predicate IS NOT FALSE` separates definite-false rows from unknown ones. Since a conjunction is FALSE iff some conjunct is FALSE, the predicate is built per comparison as `ci OR IS_NULL(left) OR IS_NULL(right)` (Kleene `NULL_LOGICAL_OR`). A row is `NULL` iff it's in this "maybe" set but not the matched set; the null mask comes from `bools_to_mask` over `validity == matched OR NOT maybe`.

**Null-safe comparisons (commit 2):** `IS [NOT] DISTINCT FROM` yield a definite TRUE/FALSE for NULL operands, never UNKNOWN, so:
- their conjuncts skip the `IS_NULL` tainting (else `NULL IS NOT DISTINCT FROM 5` would wrongly mark NULL instead of FALSE), and
- `distinct_from` is now lowered as `NOT(NULL_EQUAL(l, r))` instead of null-propagating `NOT_EQUAL` — a pre-existing bug where `NULL IS DISTINCT FROM 5` evaluated UNKNOWN instead of TRUE on every NLJ join type.

Also dedups the two AND-chain builders into one `fold_logical_and` helper.

## Tests

`[physical_nested_loop_join][mark]` regressions: right/probe-side NULLs, definite-false stays false, `NULL AND FALSE` conjunction absorption, mixed null-safe + propagating conjunction, and the full `IS [NOT] DISTINCT FROM` truth table. Full C++ suite: 1649/1649.
