### PR TITLE
feat(pipeline): make cross-GPU copies read-only clones instead of in-place moves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -641,6 +641,7 @@ set(TEST_SOURCES
     test/cpp/planner/test_dynamic_filter_router.cpp
     test/cpp/planner/test_join_expression_key.cpp
     test/cpp/planner/test_projection_fold.cpp
+    test/cpp/pipeline/test_batch_lock_utils.cpp
     test/cpp/pipeline/test_gpu_pipeline_executor.cpp
     test/cpp/pipeline/test_oom_reschedule.cpp
     test/cpp/pipeline/test_pipeline_memory_history.cpp

--- a/docs/super-sirius/memory-management.md
+++ b/docs/super-sirius/memory-management.md
@@ -142,7 +142,7 @@ Each GPU pipeline maintains a `pipeline_memory_history` — a thread-safe ring b
 
 ### Integration
 
-`gpu_pipeline_task::get_estimated_reservation_size()` uses `estimate_peak_memory()` for the reservation, adding `_bytes_to_materialize_input` (bytes to pull from HOST/disk to GPU) and subtracting it from recorded peak to keep operator history clean of I/O materialization overhead.
+`gpu_pipeline_task::get_estimated_reservation_size_info(target_space)` uses `estimate_peak_memory()` for the reservation, adding `_bytes_to_materialize_input` — the bytes needed to materialize inputs into the task's target memory space (HOST/disk upgrades plus cross-GPU clones) — and subtracting it from recorded peak to keep operator history clean of materialization overhead. Materialization allocations are charged to the task's reservation through the default per-thread allocation tracking; with the non-default `track_per_stream_reservation: true`, converter allocations made on internal pool streams bypass the task's reservation and are only checked against space capacity.
 
 ## Memory Pool Defragmentation
 

--- a/docs/super-sirius/multi-gpu-architecture.md
+++ b/docs/super-sirius/multi-gpu-architecture.md
@@ -170,9 +170,11 @@ The pin also survives OOM reschedule. When a partitioned task OOMs and is rebuil
 
 ## Cross-GPU Data Movement
 
-When an operator must consume data on GPU A that lives on GPU B (e.g., a hash join's probe side has chunks scattered across all GPUs), the engine performs a **GPU↔GPU transfer** via `cucascade::convert_gpu_to_gpu` (in `cucascade/src/data/representation_converter.cpp`).
+When an operator must consume data on GPU A that lives on GPU B (e.g., a hash join's probe side has chunks scattered across all GPUs), `lock_or_prepare_batch` (`src/include/pipeline/batch_lock_utils.hpp`) **clones the batch into the consumer's memory space under a shared (read) lock** via `read_only_data_batch::clone_to`. The source batch is never exclusively locked and never mutated: it stays resident on GPU B for consumers local to that device, concurrent readers proceed during the transfer, and the source drops back to the idle state as soon as the prepare completes — making it immediately downgrade-eligible. Source lifetime is ownership-driven: repositories and other tasks holding the batch keep it alive, and the consuming task releases its own pin on the original right after prepare, so a single-consumer source is freed as soon as its clone exists. The clone's allocation is charged to the consuming task's memory reservation, and the reservation estimator counts GPU inputs residing in a different memory space in `bytes_to_materialize_input`.
 
-The transfer chooses one of two paths empirically:
+Host- and disk-resident inputs intentionally keep **move semantics**: `lock_or_prepare_batch` upgrades them to the GPU in place, freeing the spilled copy — the common case is a single consumer re-materializing a downgraded batch.
+
+The underlying byte transfer is `cucascade::convert_gpu_to_gpu` (in `cucascade/src/data/representation_converter.cpp`), which waits on the source's writer event and synchronizes its copy stream before returning, so the clone is complete when `clone_to` returns. The transfer chooses one of two paths empirically:
 
 1. **Direct peer DMA** (`cudaMemcpyPeerAsync`) — fastest, used when `probe_peer_dma_works(src, dst)` returns true. Real peer access requires both GPUs to have driver-level P2P enabled AND the hardware to actually honor it.
 2. **Host-staging** (`cudaMemcpyAsync(DtoH)` → host buffer → `cudaMemcpyAsync(HtoD)`) — fallback for hardware where peer DMA is empirically broken (e.g., the consumer-grade RTX 6000 Ada we use for development, which advertises P2P but silently fails DMA in both directions).

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -209,7 +209,8 @@ void downgrade_executor::processing_loop()
       if (req->satisfied.load()) break;
 
       convertible_data_batch_provider provider(repo);
-      auto candidates = provider.get_all_convertible(source_space, /*front_to_back=*/false);
+      auto candidates = provider.get_all_convertible(
+        source_space, /*front_to_back=*/false, /*ignore_subscribed=*/true);
       for (auto& candidate : candidates) {
         if (req->satisfied.load()) break;
 

--- a/src/include/data/convertible_data.hpp
+++ b/src/include/data/convertible_data.hpp
@@ -111,12 +111,14 @@ class convertible_data_provider {
   /**
    * @brief Get all convertible data units matching the given memory space.
    *
-   * @param space           The memory space to filter by.
-   * @param front_to_back   Iteration direction: true = front-to-back, false = back-to-front.
+   * @param space             The memory space to filter by.
+   * @param front_to_back     Iteration direction: true = front-to-back, false = back-to-front.
+   * @param ignore_subscribed When true (default), skip batches that have been subscribed to by a
+   * task.
    * @return A vector of convertible_data instances (may be empty).
    */
   virtual std::vector<std::unique_ptr<convertible_data>> get_all_convertible(
-    cucascade::memory::memory_space* space, bool front_to_back) = 0;
+    cucascade::memory::memory_space* space, bool front_to_back, bool ignore_subscribed = true) = 0;
 };
 
 }  // namespace sirius

--- a/src/include/data/convertible_data_batch.hpp
+++ b/src/include/data/convertible_data_batch.hpp
@@ -230,12 +230,16 @@ class convertible_data_batch_provider : public convertible_data_provider {
    *
    * Same iteration order as get_next_convertible but collects all matching batches.
    *
-   * @param space           The memory space to filter by.
-   * @param front_to_back   Iteration direction.
+   * @param space             The memory space to filter by.
+   * @param front_to_back     Iteration direction.
+   * @param ignore_subscribed When true (default), skip batches that have been subscribed to by a
+   * task
    * @return A vector of convertible_data_batch instances (may be empty).
    */
   std::vector<std::unique_ptr<convertible_data>> get_all_convertible(
-    cucascade::memory::memory_space* space, bool front_to_back) override
+    cucascade::memory::memory_space* space,
+    bool front_to_back,
+    bool ignore_subscribed = true) override
   {
     std::vector<std::unique_ptr<convertible_data>> results;
     auto num_parts = _repo->num_partitions();
@@ -245,7 +249,7 @@ class convertible_data_batch_provider : public convertible_data_provider {
       for (std::size_t p = 0; p < num_parts; ++p) {
         auto batch_ids = _repo->get_batch_ids(p);
         for (std::size_t i = 0; i < batch_ids.size(); ++i) {
-          auto result = try_get_batch(batch_ids[i], p, space);
+          auto result = try_get_batch(batch_ids[i], p, space, ignore_subscribed);
           if (result) { results.push_back(std::move(result)); }
         }
       }
@@ -253,7 +257,7 @@ class convertible_data_batch_provider : public convertible_data_provider {
       for (std::size_t p = num_parts; p > 0; --p) {
         auto batch_ids = _repo->get_batch_ids(p - 1);
         for (std::size_t i = batch_ids.size(); i > 0; --i) {
-          auto result = try_get_batch(batch_ids[i - 1], p - 1, space);
+          auto result = try_get_batch(batch_ids[i - 1], p - 1, space, ignore_subscribed);
           if (result) { results.push_back(std::move(result)); }
         }
       }
@@ -298,17 +302,24 @@ class convertible_data_batch_provider : public convertible_data_provider {
    * to_read_only() as required by the new cucascade API (get_memory_space() is
    * private on idle data_batch).
    *
-   * @param batch_id       The batch ID to retrieve.
-   * @param partition_idx  The partition containing the batch.
-   * @param space          The target memory space to match.
+   * @param batch_id          The batch ID to retrieve.
+   * @param partition_idx     The partition containing the batch.
+   * @param space             The target memory space to match.
+   * @param ignore_subscribed When true (default), skip batches that have been subscribed to by a
+   * task.
    * @return A convertible_data_batch if the batch matches, nullptr otherwise.
    */
   std::unique_ptr<convertible_data> try_get_batch(uint64_t batch_id,
                                                   std::size_t partition_idx,
-                                                  cucascade::memory::memory_space* space) const
+                                                  cucascade::memory::memory_space* space,
+                                                  bool ignore_subscribed = true) const
   {
     auto batch = _repo->get_data_batch_by_id(batch_id, partition_idx);
     if (!batch) { return nullptr; }
+
+    // A subscribed batch is being held by a task (queued or preparing); skip it so we don't
+    // downgrade data a task is about to use.
+    if (ignore_subscribed && batch->get_subscriber_count() > 0) { return nullptr; }
 
     if (batch->get_state() != cucascade::batch_state::idle) { return nullptr; }
 

--- a/src/include/data/convertible_gpu_pipeline_task.hpp
+++ b/src/include/data/convertible_gpu_pipeline_task.hpp
@@ -265,10 +265,16 @@ class convertible_gpu_pipeline_task_provider : public convertible_data_provider 
    *
    * @param space           The memory space to filter by.
    * @param front_to_back   Iteration direction.
+   * @param ignore_subscribed  Unused here: a queued task always subscribes to its own input
+   *                           batches, so honoring this filter would disable task-queue downgrade
+   *                           entirely. The subscriber filter applies to repository batches (see
+   *                           convertible_data_batch_provider), not a task's own held batches.
    * @return A vector of convertible_gpu_pipeline_task wrappers (may be empty).
    */
   std::vector<std::unique_ptr<convertible_data>> get_all_convertible(
-    cucascade::memory::memory_space* space, bool front_to_back) override
+    cucascade::memory::memory_space* space,
+    bool front_to_back,
+    [[maybe_unused]] bool ignore_subscribed = true) override
   {
     std::vector<std::unique_ptr<convertible_data>> results;
     while (true) {

--- a/src/include/op/scan/cpu_source_task.hpp
+++ b/src/include/op/scan/cpu_source_task.hpp
@@ -87,8 +87,8 @@ class cpu_source_task : public pipeline::sirius_pipeline_itask {
 
   void publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream) override;
 
-  [[nodiscard]] pipeline::reservation_size_info get_estimated_reservation_size_info()
-    const override;
+  [[nodiscard]] pipeline::reservation_size_info get_estimated_reservation_size_info(
+    const cucascade::memory::memory_space* target_space) const override;
 
   std::vector<op::sirius_physical_operator*> get_output_consumers() override;
 

--- a/src/include/pipeline/batch_lock_utils.hpp
+++ b/src/include/pipeline/batch_lock_utils.hpp
@@ -25,6 +25,7 @@
 #include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/memory/memory_space.hpp>
+#include <data/data_batch_utils.hpp>
 #include <data/sirius_converter_registry.hpp>
 
 #include <memory>
@@ -36,16 +37,32 @@ namespace pipeline {
 /**
  * @brief Lock or prepare a single data batch for processing in the requested memory space.
  *
- * Acquires a read-only (shared) lock on the batch. If the batch resides in a different memory
- * space than requested, it is first upgraded to a mutable (exclusive) lock, converted in-place
- * to the target representation, then downgraded back to a read-only lock.
+ * Acquires a read-only (shared) lock on the batch. On a memory-space mismatch the behavior
+ * depends on where the data currently lives:
+ *
+ * - GPU -> GPU (cross-device): the batch is cloned into the target space via
+ *   read_only_data_batch::clone_to while only the shared lock is held. The source is never
+ *   exclusively locked or mutated — concurrent readers (e.g. probe tasks on another GPU sharing
+ *   a build batch) proceed during the transfer — and it stays resident in its original space for
+ *   consumers local to that device. The returned accessor references the NEW (cloned) batch.
+ *   Source lifetime is ownership-driven: whoever still needs the original (repositories, other
+ *   tasks) holds a reference to it; once the last reference drops it is freed. The source is
+ *   back in the idle state as soon as this function returns, so it is downgrade-eligible.
+ *
+ * - HOST/DISK -> GPU (upgrade/readback): the batch is upgraded to a mutable (exclusive) lock and
+ *   converted in-place, freeing the spilled copy — intentional move semantics for the common
+ *   single-consumer case. The returned accessor references the same batch. If a concurrent
+ *   consumer converted the batch during the (non-atomic) lock upgrade, the state observed under
+ *   the exclusive lock is re-dispatched: same space -> no-op; a different GPU -> clone (a
+ *   GPU-resident batch is never moved cross-device); still host/disk -> move as planned.
  *
  * @param batch                   The batch to lock/prepare.
  * @param requested_memory_space  Target memory space; may be nullptr to use the batch's current
  *                                space.
  * @param stream                  CUDA stream used for any data-movement kernels.
- * @return A read_only_data_batch holding the shared lock, or std::nullopt on failure.
- * @throws rmm::out_of_memory  If a GPU memory allocation fails during the conversion.
+ * @return A read_only_data_batch holding the shared lock (on the clone for cross-GPU inputs),
+ *         or std::nullopt on failure.
+ * @throws rmm::out_of_memory  If a GPU memory allocation fails during the conversion or clone.
  */
 inline std::optional<cucascade::read_only_data_batch> lock_or_prepare_batch(
   const std::shared_ptr<cucascade::data_batch>& batch,
@@ -88,26 +105,62 @@ inline std::optional<cucascade::read_only_data_batch> lock_or_prepare_batch(
     return std::move(read_accessor);
   }
 
-  // Memory space mismatch — go to mutable, convert in-place, go back to read-only
-  auto& registry    = sirius::converter_registry::get();
-  auto mut_accessor = cucascade::data_batch::readonly_to_mutable(std::move(read_accessor));
+  // Memory space mismatch — clone or move depending on where the data lives.
+  auto& registry = sirius::converter_registry::get();
 
   switch (target_space->get_tier()) {
-    case cucascade::memory::Tier::GPU:
+    case cucascade::memory::Tier::GPU: {
+      if (read_accessor.get_current_tier() == cucascade::memory::Tier::GPU) {
+        // Cross-GPU: clone into the target space under the shared lock. The source is never
+        // exclusively locked or mutated. clone_to routes through convert_gpu_to_gpu, which waits
+        // on the source's writer event and synchronizes its copy stream before returning, so
+        // holding read_accessor across the call is sufficient ordering and the copy is complete
+        // when it returns. No normalize_gpu_list_offsets here: that fixup only reverses the
+        // INT64 offsets promotion of host->GPU reconstruction, and a GPU->GPU copy preserves the
+        // source's column types (a GPU-resident source is already normalized — the same-space
+        // fast path above depends on that invariant).
+        auto clone = read_accessor.clone_to<cucascade::gpu_table_representation>(
+          registry, sirius::get_next_batch_id(), target_space, stream);
+        return clone->to_read_only();
+      }
+      // HOST/DISK -> GPU upgrade/readback: convert in place (move), freeing the spilled copy.
+      auto mut_accessor = cucascade::data_batch::readonly_to_mutable(std::move(read_accessor));
+      // readonly_to_mutable is not atomic (shared released, then exclusive acquired): a
+      // concurrent consumer of a shared spilled batch may have converted it in the gap.
+      // Re-dispatch on the state observed under the exclusive lock:
+      const auto* current_space = mut_accessor.get_memory_space();
+      if (current_space != nullptr && current_space->get_id() == target_space->get_id()) {
+        // Already in the target space — skip the wasteful same-space deep copy.
+        return cucascade::data_batch::mutable_to_readonly(std::move(mut_accessor));
+      }
+      if (mut_accessor.get_current_tier() == cucascade::memory::Tier::GPU) {
+        // Upgraded to a DIFFERENT GPU in the gap: never move a GPU-resident batch cross-device
+        // (that would steal it from the device that just materialized it) — clone instead. The
+        // clone happens under the exclusive lock we already hold; pinning the state here avoids
+        // yet another non-atomic lock transition.
+        auto clone = mut_accessor.clone_to<cucascade::gpu_table_representation>(
+          registry, sirius::get_next_batch_id(), target_space, stream);
+        return clone->to_read_only();
+      }
       mut_accessor.convert_to<cucascade::gpu_table_representation>(registry, target_space, stream);
       normalize_gpu_list_offsets(mut_accessor, target_space, stream);
-      break;
-    case cucascade::memory::Tier::HOST:
-      mut_accessor.convert_to<cucascade::host_data_representation>(registry, target_space, stream);
-      break;
+      return cucascade::data_batch::mutable_to_readonly(std::move(mut_accessor));
+    }
+    case cucascade::memory::Tier::HOST: {
+      auto mut_accessor = cucascade::data_batch::readonly_to_mutable(std::move(read_accessor));
+      // Same non-atomic-upgrade race as the GPU arm: skip if already in the target space.
+      if (mut_accessor.get_memory_space() == nullptr ||
+          mut_accessor.get_memory_space()->get_id() != target_space->get_id()) {
+        mut_accessor.convert_to<cucascade::host_data_representation>(
+          registry, target_space, stream);
+      }
+      return cucascade::data_batch::mutable_to_readonly(std::move(mut_accessor));
+    }
     default:
       SIRIUS_LOG_ERROR("lock_or_prepare_batch: unsupported target tier for batch {}",
-                       mut_accessor.get_batch_id());
+                       read_accessor.get_batch_id());
       return std::nullopt;
   }
-
-  // Downgrade the exclusive lock back to a shared read-only lock
-  return cucascade::data_batch::mutable_to_readonly(std::move(mut_accessor));
 }
 
 }  // namespace pipeline

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -255,22 +255,13 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
     uint64_t task_id, std::unique_ptr<sirius_pipeline_task_local_state> local_state);
 
  private:
-  /**
-   * @brief Unsubscribe from and release the pinned input data_batches.
-   *
-   * Called once prepare_for_processing has materialized this task's inputs in the target memory
-   * space: from then on the pin is redundant (the operator_data owns the prepared batches), and
-   * releasing it lets a single-consumer original that was cloned cross-GPU free its source-GPU
-   * memory immediately instead of at task destruction. Batches other consumers still need stay
-   * alive via their own owners (repositories, other tasks). Also called by the destructor for
-   * tasks that never executed.
-   */
-  void release_input_batches();
-
   std::vector<cucascade::shared_data_repository*> _data_repos;
   cucascade::memory::reservation_aware_resource_adaptor* _allocator = nullptr;
-  /// Input data_batches held for subscribe/unsubscribe lifecycle until prepare completes
-  std::vector<std::shared_ptr<cucascade::data_batch>> _input_batches;
+  /// Non-owning subscription ledger: the input data_batches this task subscribed to in its
+  /// constructor so that the downgrade_executor can know that the data_baches are in a task.
+  /// weak_ptr so that memory can be released as soon as the last owner drops.
+  /// This is used in the destructor to unsubscribe.
+  std::vector<std::weak_ptr<cucascade::data_batch>> _subscribed_batches;
 };
 
 }  // namespace pipeline

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -98,14 +98,26 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
     return _input_data ? _input_data->get_estimated_size_in_bytes() : 0;
   }
 
-  [[nodiscard]] std::size_t get_estimated_bytes_to_materialize_input() const
+  /**
+   * @brief Estimate the bytes prepare_for_processing will allocate in the target space.
+   *
+   * Counts inputs that are not GPU-resident (host/disk upgrades) and, when @p target_space is
+   * given, GPU-resident inputs living in a different memory space — those are cloned into the
+   * target space by lock_or_prepare_batch, so their bytes are part of the task's footprint.
+   */
+  [[nodiscard]] std::size_t get_estimated_bytes_to_materialize_input(
+    const cucascade::memory::memory_space* target_space) const
   {
     std::size_t input_size = 0;
     auto* pipelineable_input =
       dynamic_cast<const op::pipelineable_operator_data*>(_input_data.get());
     if (pipelineable_input) {
       for (const auto& ro : pipelineable_input->get_read_only_batches(false)) {
-        if (ro.get_data() && ro.get_current_tier() != cucascade::memory::Tier::GPU) {
+        if (!ro.get_data()) { continue; }
+        const bool non_gpu     = ro.get_current_tier() != cucascade::memory::Tier::GPU;
+        const bool cross_space = target_space != nullptr && ro.get_memory_space() != nullptr &&
+                                 ro.get_memory_space()->get_id() != target_space->get_id();
+        if (non_gpu || cross_space) {
           input_size += ro.get_data()->get_uncompressed_data_size_in_bytes();
         }
       }
@@ -202,8 +214,8 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
    */
   std::size_t get_input_size() const;
 
-  [[nodiscard]] pipeline::reservation_size_info get_estimated_reservation_size_info()
-    const override;
+  [[nodiscard]] pipeline::reservation_size_info get_estimated_reservation_size_info(
+    const cucascade::memory::memory_space* target_space) const override;
 
   /// @brief Get the output consumer operators for this task.
   std::vector<op::sirius_physical_operator*> get_output_consumers() override;
@@ -243,9 +255,21 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
     uint64_t task_id, std::unique_ptr<sirius_pipeline_task_local_state> local_state);
 
  private:
+  /**
+   * @brief Unsubscribe from and release the pinned input data_batches.
+   *
+   * Called once prepare_for_processing has materialized this task's inputs in the target memory
+   * space: from then on the pin is redundant (the operator_data owns the prepared batches), and
+   * releasing it lets a single-consumer original that was cloned cross-GPU free its source-GPU
+   * memory immediately instead of at task destruction. Batches other consumers still need stay
+   * alive via their own owners (repositories, other tasks). Also called by the destructor for
+   * tasks that never executed.
+   */
+  void release_input_batches();
+
   std::vector<cucascade::shared_data_repository*> _data_repos;
   cucascade::memory::reservation_aware_resource_adaptor* _allocator = nullptr;
-  /// Input data_batches held for subscribe/unsubscribe lifecycle
+  /// Input data_batches held for subscribe/unsubscribe lifecycle until prepare completes
   std::vector<std::shared_ptr<cucascade::data_batch>> _input_batches;
 };
 

--- a/src/include/pipeline/sirius_pipeline_itask.hpp
+++ b/src/include/pipeline/sirius_pipeline_itask.hpp
@@ -82,11 +82,15 @@ class sirius_pipeline_itask : public parallel::itask {
    * reservation, then passes the struct to set_reservation() so execute() can read
    * the components without re-computing them.
    *
+   * @param target_space The memory space the task will execute in, so inputs residing outside it
+   *                     (host/disk tiers, or GPU data on a different device that prepare will
+   *                     clone) are counted in bytes_to_materialize_input. nullptr means no single
+   *                     target space is known; only non-GPU-tier inputs are counted.
    * @return reservation_size_info with input_basis, bytes_to_materialize_input,
    *         peak_memory_estimate, reservation_size, and had_history populated.
    */
-  [[nodiscard]] virtual pipeline::reservation_size_info get_estimated_reservation_size_info()
-    const = 0;
+  [[nodiscard]] virtual pipeline::reservation_size_info get_estimated_reservation_size_info(
+    const cucascade::memory::memory_space* target_space) const = 0;
 
   /// @brief Get the output consumer operators for this task.
   virtual std::vector<op::sirius_physical_operator*> get_output_consumers() = 0;

--- a/src/include/pipeline/sirius_pipeline_task_states.hpp
+++ b/src/include/pipeline/sirius_pipeline_task_states.hpp
@@ -40,8 +40,10 @@ namespace pipeline {
  * set_reservation() so that execute() can access all components without re-computing.
  */
 struct reservation_size_info {
-  std::size_t input_basis                = 0;  ///< Estimation basis (e.g. input data size)
-  std::size_t bytes_to_materialize_input = 0;  ///< Cost to bring non-GPU input to GPU; 0 for scans
+  std::size_t input_basis = 0;  ///< Estimation basis (e.g. input data size)
+  std::size_t bytes_to_materialize_input =
+    0;  ///< Cost to materialize input into the task's target space (host/disk upgrades plus
+        ///< cross-GPU clones); 0 for scans
   std::size_t peak_memory_estimate = 0;  ///< Predicted operator peak; 2*input_basis if no history
   std::size_t reservation_size     = 0;  ///< peak_memory_estimate + bytes_to_materialize_input
   bool had_history                 = false;  ///< True if estimate came from pipeline_memory_history

--- a/src/op/scan/cpu_source_task.cpp
+++ b/src/op/scan/cpu_source_task.cpp
@@ -278,7 +278,8 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
     telemetry::quent_data_batch_probe::create(telemetry_info, batch_id));
 }
 
-pipeline::reservation_size_info cpu_source_task::get_estimated_reservation_size_info() const
+pipeline::reservation_size_info cpu_source_task::get_estimated_reservation_size_info(
+  const cucascade::memory::memory_space* /*target_space*/) const
 {
   constexpr std::size_t kMinBytes = 64ULL * 1024;
   auto& g_state                   = _global_state->cast<cpu_source_task_global_state>();

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -119,6 +119,13 @@ void pipelineable_operator_data::prepare_for_processing(
   }
 
   _read_only_data_batches = std::move(ro_batches);
+  // lock_or_prepare_batch may have returned an accessor to a clone (cross-GPU inputs), so
+  // accessor i can reference a different batch than _data_batches[i]. Reset the idle vector so
+  // get_data_batches() lazily rebuilds it from the accessors, restoring the invariant that
+  // _data_batches[i] is the batch underlying accessor i. Downstream forwarding (dynamic_filter,
+  // sink) and OOM reschedule (remove_read_only_lock materializes from the accessors) then all
+  // see the prepared batch, not a stale original.
+  _data_batches = std::nullopt;
 }
 
 std::string sirius_physical_operator::get_name() const

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -127,7 +127,9 @@ void gpu_pipeline_executor::manager_loop()
       }
       break;
     }
-    auto reservation_info = gpu_task->get_estimated_reservation_size_info();
+    // Pass this executor's memory space so cross-space inputs (host/disk tiers and GPU data on
+    // another device, which prepare clones into this space) are counted in the reservation.
+    auto reservation_info = gpu_task->get_estimated_reservation_size_info(_memory_space);
     auto bytes_needs      = reservation_info.reservation_size;
     gpu_task->telemetry_handle().reserving({
       .instance_name              = "",

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -209,20 +209,29 @@ gpu_pipeline_task::gpu_pipeline_task(
   }
 }
 
-gpu_pipeline_task::~gpu_pipeline_task()
+void gpu_pipeline_task::release_input_batches()
 {
-  // Unsubscribe from all input data_batches
+  // Unsubscribe from all input data_batches and drop this task's references to them. Any batch
+  // whose last owner this was (e.g. a popped single-consumer original that prepare replaced with
+  // a cross-GPU clone) is destroyed here, freeing its memory in its source space.
   for (const auto& batch : _input_batches) {
     if (batch) {
       try {
         batch->unsubscribe();
       } catch (...) {
-        // Destructor must not throw; log if possible
+        // Also runs from the destructor, which must not throw; log if possible
         SIRIUS_LOG_WARN("gpu_pipeline_task: unsubscribe failed for batch {}",
                         batch->get_batch_id());
       }
     }
   }
+  _input_batches.clear();
+}
+
+gpu_pipeline_task::~gpu_pipeline_task()
+{
+  // Covers tasks destroyed without executing; a no-op after execute() released the pin.
+  release_input_batches();
 
   if (_global_state == nullptr ||
       _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline() == nullptr) {
@@ -414,9 +423,16 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
     // is accurate.
     stream.synchronize();
   } catch (const rmm::out_of_memory& oom) {
-    auto peak_bytes  = allocator->get_peak_allocated_bytes(stream);
-    auto input_basis = local_state.get_reservation_size_info()->input_basis;
-    auto& global     = _global_state->cast<gpu_pipeline_task_global_state>();
+    auto peak_bytes           = allocator->get_peak_allocated_bytes(stream);
+    const auto& res_info      = local_state.get_reservation_size_info();
+    auto bytes_to_materialize = res_info->bytes_to_materialize_input;
+    auto input_basis          = res_info->input_basis;
+    // Keep the recorded peak clean of materialization overhead (host/disk upgrades and
+    // cross-GPU clones — prepare's allocations are almost entirely those), consistent with
+    // the success and compute-OOM record paths; the estimator re-adds
+    // bytes_to_materialize_input on top of the history-based estimate.
+    peak_bytes   = peak_bytes > bytes_to_materialize ? peak_bytes - bytes_to_materialize : 0;
+    auto& global = _global_state->cast<gpu_pipeline_task_global_state>();
     global.get_memory_history().record_on_failure(input_basis, peak_bytes);
 
     SIRIUS_LOG_ERROR("Pipeline {}: OOM preparing batches for processing",
@@ -440,6 +456,12 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
                    first_op.get_name(),
                    first_op.get_operator_id(),
                    prepare_duration.count() / 1000.0);
+
+  // Inputs are materialized in this task's memory space (cross-GPU inputs as clones owned by
+  // local_state._input_data), so drop the redundant pin on the original batches: a popped
+  // single-consumer original freed of all other owners releases its source-GPU memory now
+  // rather than at task destruction, while shared batches stay alive via their other owners.
+  release_input_batches();
 
   // All input batches are now locked for reading via _read_only_data_batches inside
   // local_state._input_data. The locks are released when the pipelineable_operator_data
@@ -504,12 +526,13 @@ std::size_t gpu_pipeline_task::get_input_size() const
   return input_size;
 }
 
-pipeline::reservation_size_info gpu_pipeline_task::get_estimated_reservation_size_info() const
+pipeline::reservation_size_info gpu_pipeline_task::get_estimated_reservation_size_info(
+  const cucascade::memory::memory_space* target_space) const
 {
   auto& ls                         = _local_state->cast<gpu_pipeline_task_local_state>();
   auto& gs                         = _global_state->cast<gpu_pipeline_task_global_state>();
   std::size_t input_basis          = ls.get_task_consumption_basis();
-  std::size_t bytes_to_materialize = ls.get_estimated_bytes_to_materialize_input();
+  std::size_t bytes_to_materialize = ls.get_estimated_bytes_to_materialize_input(target_space);
   auto peak_opt                    = gs.get_memory_history().estimate_peak_memory(input_basis);
   const auto input_type =
     ls._input_data ? ls._input_data->get_type() : op::operator_data_type::BASE;

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -199,7 +199,7 @@ gpu_pipeline_task::gpu_pipeline_task(
       for (const auto& batch : pipelineable_input->get_data_batches()) {
         if (batch) {
           batch->subscribe();
-          _input_batches.push_back(batch);
+          _subscribed_batches.push_back(batch);
         }
       }
     }
@@ -209,29 +209,19 @@ gpu_pipeline_task::gpu_pipeline_task(
   }
 }
 
-void gpu_pipeline_task::release_input_batches()
-{
-  // Unsubscribe from all input data_batches and drop this task's references to them. Any batch
-  // whose last owner this was (e.g. a popped single-consumer original that prepare replaced with
-  // a cross-GPU clone) is destroyed here, freeing its memory in its source space.
-  for (const auto& batch : _input_batches) {
-    if (batch) {
-      try {
-        batch->unsubscribe();
-      } catch (...) {
-        // Also runs from the destructor, which must not throw; log if possible
-        SIRIUS_LOG_WARN("gpu_pipeline_task: unsubscribe failed for batch {}",
-                        batch->get_batch_id());
-      }
-    }
-  }
-  _input_batches.clear();
-}
-
 gpu_pipeline_task::~gpu_pipeline_task()
 {
-  // Covers tasks destroyed without executing; a no-op after execute() released the pin.
-  release_input_batches();
+  for (const auto& weak_batch : _subscribed_batches) {
+    auto batch = weak_batch.lock();
+    if (!batch) { continue; }
+    try {
+      batch->unsubscribe();
+    } catch (...) {
+      // The destructor must not throw; log if possible.
+      SIRIUS_LOG_WARN("gpu_pipeline_task: unsubscribe failed for batch {}", batch->get_batch_id());
+    }
+  }
+  _subscribed_batches.clear();
 
   if (_global_state == nullptr ||
       _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline() == nullptr) {
@@ -456,12 +446,6 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
                    first_op.get_name(),
                    first_op.get_operator_id(),
                    prepare_duration.count() / 1000.0);
-
-  // Inputs are materialized in this task's memory space (cross-GPU inputs as clones owned by
-  // local_state._input_data), so drop the redundant pin on the original batches: a popped
-  // single-consumer original freed of all other owners releases its source-GPU memory now
-  // rather than at task destruction, while shared batches stay alive via their other owners.
-  release_input_batches();
 
   // All input batches are now locked for reading via _read_only_data_batches inside
   // local_state._input_data. The locks are released when the pipelineable_operator_data

--- a/test/cpp/data/test_convertible_data_batch.cpp
+++ b/test/cpp/data/test_convertible_data_batch.cpp
@@ -181,6 +181,46 @@ TEST_CASE("convertible_data_batch_provider get_all_convertible returns all idle 
   REQUIRE(all.size() == 2);
 }
 
+TEST_CASE("convertible_data_batch_provider get_all_convertible skips subscribed batches",
+          "[convertible_data_batch]")
+{
+  auto& e = env();
+
+  cucascade::shared_data_repository repo;
+
+  auto batch1 = sirius::test::operator_utils::make_numeric_batch(
+    *e.gpu_space, std::vector<int32_t>{1, 2}, cudf::type_id::INT32);
+  auto batch2 = sirius::test::operator_utils::make_numeric_batch(
+    *e.gpu_space, std::vector<int32_t>{3, 4, 5}, cudf::type_id::INT32);
+  auto batch3 = sirius::test::operator_utils::make_numeric_batch(
+    *e.gpu_space, std::vector<int32_t>{6, 7, 8, 9}, cudf::type_id::INT32);
+
+  // batch2 is subscribed: a task has declared interest in it and it must not be downgraded.
+  batch2->subscribe();
+
+  repo.add_data_batch(batch1);
+  repo.add_data_batch(batch2);
+  repo.add_data_batch(batch3);
+
+  sirius::convertible_data_batch_provider provider(&repo);
+
+  SECTION("ignore_subscribed=true (default) skips the subscribed batch")
+  {
+    auto all = provider.get_all_convertible(e.gpu_space, false, /*ignore_subscribed=*/true);
+    // batch2 is subscribed -> excluded; batch1 and batch3 remain.
+    REQUIRE(all.size() == 2);
+  }
+
+  SECTION("ignore_subscribed=false includes the subscribed batch")
+  {
+    auto all = provider.get_all_convertible(e.gpu_space, false, /*ignore_subscribed=*/false);
+    // Subscription is ignored -> all three idle batches are returned.
+    REQUIRE(all.size() == 3);
+  }
+
+  batch2->unsubscribe();
+}
+
 TEST_CASE("convertible_data_batch_provider iterates multi-partition last-to-first",
           "[convertible_data_batch]")
 {

--- a/test/cpp/pipeline/test_batch_lock_utils.cpp
+++ b/test/cpp/pipeline/test_batch_lock_utils.cpp
@@ -61,9 +61,10 @@ namespace {
 // Enable CUDA driver-level peer access for every GPU pair, idempotently, with sticky-error
 // consumption. Adapted from test/cpp/config/test_context.cpp (anonymous namespace, not
 // reachable from this TU) — these tests build a bare memory manager and bypass the enable
-// loop in SiriusContext::initialize(). Returns true only when EVERY ordered pair enabled
-// peer access (i.e. all pairs are bidirectionally P2P-capable), since the tests transfer in
-// both directions.
+// loop in SiriusContext::initialize(). Best-effort, mirroring that init loop: pairs that
+// cannot enable peer access are left to cucascade's host-staged copy fallback, which is the
+// production transfer path on such hardware. Returns true only when EVERY ordered pair
+// enabled peer access, so callers can log which flavor a run exercised.
 bool enable_p2p_for_test(int num_gpus)
 {
   bool all_enabled = true;
@@ -90,7 +91,10 @@ bool enable_p2p_for_test(int num_gpus)
 }
 
 /// Skip idiom for multi-GPU tests (Catch2 v2): WARN + return true when fewer than two GPUs
-/// are present or the pair is not P2P-capable.
+/// are present. These tests validate lock/clone semantics, which hold on both cross-GPU
+/// transfer flavors, so P2P is enabled best-effort rather than required: with it the clone
+/// peer-DMAs, without it cucascade host-stages — exactly as production would on the same
+/// hardware. The WARN records which flavor a run exercised.
 bool skip_if_not_mgpu()
 {
   int device_count = 0;
@@ -100,8 +104,7 @@ bool skip_if_not_mgpu()
     return true;
   }
   if (!enable_p2p_for_test(2)) {
-    WARN("skipping: GPUs 0 and 1 are not P2P-capable");
-    return true;
+    WARN("GPUs 0 and 1 are not P2P-capable — cross-GPU copies will host-stage");
   }
   return false;
 }
@@ -182,14 +185,26 @@ struct batch_lock_utils_fixture {
   }
 };
 
-/// Copy a fixed-width column's payload to host for value comparison (works across devices).
+/// Copy a fixed-width column's payload to host for value comparison. The copy is issued with
+/// the payload's owning device current: without P2P, a cudaMemcpyAsync of another device's
+/// pool memory fails with cudaErrorInvalidValue, and an unchecked failure would silently
+/// return the zero-initialized vector.
 template <typename T>
 std::vector<T> column_values_to_host(const cudf::column_view& col, rmm::cuda_stream_view stream)
 {
   std::vector<T> out(static_cast<std::size_t>(col.size()));
-  cudaMemcpyAsync(
-    out.data(), col.data<T>(), out.size() * sizeof(T), cudaMemcpyDeviceToHost, stream.value());
+  if (out.empty()) { return out; }
   stream.synchronize();
+  cudaPointerAttributes attrs{};
+  REQUIRE(cudaPointerGetAttributes(&attrs, col.data<T>()) == cudaSuccess);
+  int prev = -1;
+  REQUIRE(cudaGetDevice(&prev) == cudaSuccess);
+  const bool switch_device = attrs.type == cudaMemoryTypeDevice && attrs.device != prev;
+  if (switch_device) { REQUIRE(cudaSetDevice(attrs.device) == cudaSuccess); }
+  const cudaError_t copy_err =
+    cudaMemcpy(out.data(), col.data<T>(), out.size() * sizeof(T), cudaMemcpyDeviceToHost);
+  if (switch_device) { REQUIRE(cudaSetDevice(prev) == cudaSuccess); }
+  REQUIRE(copy_err == cudaSuccess);
   return out;
 }
 

--- a/test/cpp/pipeline/test_batch_lock_utils.cpp
+++ b/test/cpp/pipeline/test_batch_lock_utils.cpp
@@ -1,0 +1,593 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for lock_or_prepare_batch (pipeline/batch_lock_utils.hpp) clone-vs-move semantics:
+// cross-GPU inputs are cloned into the consumer's memory space under a shared lock (the source
+// is never exclusively locked, never mutated, and stays resident on its device), while
+// host/disk -> GPU upgrades keep in-place move semantics. Also covers the
+// pipelineable_operator_data invariant that prepare_for_processing rebinds the idle batch
+// vector to the (possibly cloned) batches underlying the read-only accessors, and the
+// target-space-aware bytes_to_materialize_input estimator.
+
+#include "catch.hpp"
+#include "data/data_batch_utils.hpp"
+#include "data/sirius_converter_registry.hpp"
+#include "memory/sirius_memory_reservation_manager.hpp"
+#include "op/sirius_physical_operator.hpp"
+#include "pipeline/batch_lock_utils.hpp"
+#include "pipeline/gpu_pipeline_task.hpp"
+#include "utils/utils.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/table/table.hpp>
+
+#include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/memory/common.hpp>
+#include <cucascade/memory/memory_space.hpp>
+#include <cucascade/memory/reservation_manager_configurator.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace {
+
+// Enable CUDA driver-level peer access for every GPU pair, idempotently, with sticky-error
+// consumption. Adapted from test/cpp/config/test_context.cpp (anonymous namespace, not
+// reachable from this TU) — these tests build a bare memory manager and bypass the enable
+// loop in SiriusContext::initialize(). Returns true only when EVERY ordered pair enabled
+// peer access (i.e. all pairs are bidirectionally P2P-capable), since the tests transfer in
+// both directions.
+bool enable_p2p_for_test(int num_gpus)
+{
+  bool all_enabled = true;
+  for (int i = 0; i < num_gpus; ++i) {
+    for (int j = 0; j < num_gpus; ++j) {
+      if (i == j) { continue; }
+      int can_access = 0;
+      if (cudaDeviceCanAccessPeer(&can_access, i, j) != cudaSuccess || !can_access) {
+        (void)cudaGetLastError();
+        all_enabled = false;
+        continue;
+      }
+      (void)cudaSetDevice(i);
+      cudaError_t enable_err = cudaDeviceEnablePeerAccess(j, 0);
+      (void)cudaGetLastError();  // consume sticky state
+      if (enable_err != cudaSuccess && enable_err != cudaErrorPeerAccessAlreadyEnabled) {
+        all_enabled = false;
+      }
+    }
+  }
+  cudaSetDevice(0);
+  (void)cudaGetLastError();
+  return all_enabled;
+}
+
+/// Skip idiom for multi-GPU tests (Catch2 v2): WARN + return true when fewer than two GPUs
+/// are present or the pair is not P2P-capable.
+bool skip_if_not_mgpu()
+{
+  int device_count = 0;
+  cudaGetDeviceCount(&device_count);
+  if (device_count < 2) {
+    WARN("skipping: requires >=2 GPUs");
+    return true;
+  }
+  if (!enable_p2p_for_test(2)) {
+    WARN("skipping: GPUs 0 and 1 are not P2P-capable");
+    return true;
+  }
+  return false;
+}
+
+/// Memory manager fixture over `num_gpus` GPU spaces plus NUMA host spaces.
+struct batch_lock_utils_fixture {
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> manager;
+  cucascade::memory::memory_space* gpu0  = nullptr;
+  cucascade::memory::memory_space* gpu1  = nullptr;  // null on single-GPU fixtures
+  cucascade::memory::memory_space* host0 = nullptr;
+
+  bool setup(int num_gpus)
+  {
+    sirius::converter_registry::reset_for_testing();
+    try {
+      cucascade::memory::reservation_manager_configurator builder;
+      builder.set_number_of_gpus(num_gpus)
+        .set_gpu_usage_limit(256ULL << 20)
+        .set_reservation_fraction_per_gpu(0.75)
+        .set_per_host_capacity(1ULL << 30)
+        .use_host_per_numa()
+        .track_reservation_per_stream(false)
+        .set_reservation_fraction_per_host(0.75);
+      auto space_configs = builder.build();
+      manager            = std::make_unique<sirius::memory::sirius_memory_reservation_manager>(
+        std::move(space_configs));
+    } catch (const std::exception&) {
+      return false;
+    }
+    sirius::converter_registry::initialize();
+
+    auto gpu_spaces = manager->get_memory_spaces_for_tier(cucascade::memory::Tier::GPU);
+    if (gpu_spaces.size() < static_cast<std::size_t>(num_gpus)) { return false; }
+    gpu0 = const_cast<cucascade::memory::memory_space*>(gpu_spaces[0]);
+    if (num_gpus > 1) { gpu1 = const_cast<cucascade::memory::memory_space*>(gpu_spaces[1]); }
+    auto host_spaces = manager->get_memory_spaces_for_tier(cucascade::memory::Tier::HOST);
+    if (host_spaces.empty()) { return false; }
+    host0 = const_cast<cucascade::memory::memory_space*>(host_spaces[0]);
+    return true;
+  }
+
+  ~batch_lock_utils_fixture()
+  {
+    // The registry is initialized right after the manager is built, so both exist or neither.
+    if (manager) {
+      manager->shutdown();
+      sirius::converter_registry::shutdown();
+    }
+  }
+
+  /// Single INT64 column of random data, resident on `space`.
+  std::shared_ptr<cucascade::data_batch> make_gpu_batch(std::size_t num_rows,
+                                                        cucascade::memory::memory_space& space,
+                                                        rmm::cuda_stream_view stream)
+  {
+    auto table = sirius::create_cudf_table_with_random_data(num_rows,
+                                                            {cudf::data_type{cudf::type_id::INT64}},
+                                                            {std::make_pair(0, 1000000)},
+                                                            stream,
+                                                            space.get_default_allocator());
+    stream.synchronize();
+    return sirius::make_data_batch(
+      std::move(table), space, stream, sirius::telemetry::batch_telemetry_info{});
+  }
+
+  /// GPU batch converted in place to the host representation (spilled-batch shape).
+  std::shared_ptr<cucascade::data_batch> make_host_batch(std::size_t num_rows,
+                                                         rmm::cuda_stream_view stream)
+  {
+    auto batch     = make_gpu_batch(num_rows, *gpu0, stream);
+    auto& registry = sirius::converter_registry::get();
+    {
+      auto mut = batch->to_mutable();
+      mut.convert_to<cucascade::host_data_representation>(registry, host0, stream);
+    }
+    stream.synchronize();
+    return batch;
+  }
+};
+
+/// Copy a fixed-width column's payload to host for value comparison (works across devices).
+template <typename T>
+std::vector<T> column_values_to_host(const cudf::column_view& col, rmm::cuda_stream_view stream)
+{
+  std::vector<T> out(static_cast<std::size_t>(col.size()));
+  cudaMemcpyAsync(
+    out.data(), col.data<T>(), out.size() * sizeof(T), cudaMemcpyDeviceToHost, stream.value());
+  stream.synchronize();
+  return out;
+}
+
+/// One LIST<INT32> column with `num_lists` two-element lists [2i, 2i+1], on `space`.
+std::unique_ptr<cudf::table> make_list_table(std::size_t num_lists,
+                                             cucascade::memory::memory_space& space,
+                                             rmm::cuda_stream_view stream)
+{
+  auto mr = space.get_default_allocator();
+
+  std::vector<int32_t> offsets_host(num_lists + 1);
+  for (std::size_t i = 0; i <= num_lists; ++i) {
+    offsets_host[i] = static_cast<int32_t>(2 * i);
+  }
+  std::vector<int32_t> values_host(2 * num_lists);
+  std::iota(values_host.begin(), values_host.end(), 0);
+
+  auto offsets = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                           static_cast<cudf::size_type>(num_lists + 1),
+                                           cudf::mask_state::UNALLOCATED,
+                                           stream,
+                                           mr);
+  cudaMemcpyAsync(offsets->mutable_view().data<int32_t>(),
+                  offsets_host.data(),
+                  offsets_host.size() * sizeof(int32_t),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  auto values = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                          static_cast<cudf::size_type>(values_host.size()),
+                                          cudf::mask_state::UNALLOCATED,
+                                          stream,
+                                          mr);
+  cudaMemcpyAsync(values->mutable_view().data<int32_t>(),
+                  values_host.data(),
+                  values_host.size() * sizeof(int32_t),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  stream.synchronize();
+
+  auto list_col = cudf::make_lists_column(static_cast<cudf::size_type>(num_lists),
+                                          std::move(offsets),
+                                          std::move(values),
+                                          0,
+                                          rmm::device_buffer{});
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(list_col));
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
+constexpr std::size_t kNumRows = 4096;
+
+}  // namespace
+
+TEST_CASE("lock_or_prepare_batch cross-GPU returns a clone and leaves the source in place",
+          "[batch_lock_utils][mgpu]")
+{
+  if (skip_if_not_mgpu()) { return; }
+  batch_lock_utils_fixture f;
+  REQUIRE(f.setup(2));
+
+  rmm::cuda_stream stream;
+  auto batch = f.make_gpu_batch(kNumRows, *f.gpu0, stream.view());
+  REQUIRE(batch != nullptr);
+  const auto source_id = batch->get_batch_id();
+  std::size_t source_bytes;
+  std::vector<int64_t> source_values;
+  {
+    auto ro      = batch->to_read_only();
+    source_bytes = ro.get_data()->get_size_in_bytes();
+    source_values =
+      column_values_to_host<int64_t>(sirius::get_cudf_table_view(ro).column(0), stream.view());
+  }
+
+  auto prepared = sirius::pipeline::lock_or_prepare_batch(batch, f.gpu1, stream.view());
+  REQUIRE(prepared.has_value());
+
+  // The returned accessor references a NEW batch in the target space.
+  REQUIRE(prepared->get_batch_id() != source_id);
+  REQUIRE(prepared->get_memory_space() != nullptr);
+  REQUIRE(prepared->get_memory_space()->get_id() == f.gpu1->get_id());
+  REQUIRE(prepared->get_data()->get_size_in_bytes() == source_bytes);
+  auto clone_values =
+    column_values_to_host<int64_t>(sirius::get_cudf_table_view(*prepared).column(0), stream.view());
+  REQUIRE(clone_values == source_values);
+
+  // The source was never moved or mutated: still on gpu0, and back to idle (readable /
+  // downgrade-eligible) even while the clone accessor is still held.
+  REQUIRE(batch->get_state() == cucascade::batch_state::idle);
+  {
+    auto ro = batch->to_read_only();
+    REQUIRE(ro.get_memory_space()->get_id() == f.gpu0->get_id());
+    REQUIRE(ro.get_data()->get_size_in_bytes() == source_bytes);
+  }
+}
+
+TEST_CASE("lock_or_prepare_batch cross-GPU does not block on concurrent readers",
+          "[batch_lock_utils][mgpu]")
+{
+  if (skip_if_not_mgpu()) { return; }
+  batch_lock_utils_fixture f;
+  REQUIRE(f.setup(2));
+
+  rmm::cuda_stream stream;
+  auto batch = f.make_gpu_batch(kNumRows, *f.gpu0, stream.view());
+
+  // Hold a shared lock on the source for the entire duration of the cross-GPU prepare —
+  // modelling a probe task on another GPU sharing a build batch. The in-place convert_to
+  // design deadlocked here (readonly_to_mutable waits for exclusive access); the clone
+  // design only ever takes shared locks on the source.
+  auto reader = std::make_optional(batch->to_read_only());
+
+  auto fut                               = std::async(std::launch::async, [&]() {
+    return sirius::pipeline::lock_or_prepare_batch(batch, f.gpu1, stream.view());
+  });
+  const auto status                      = fut.wait_for(std::chrono::seconds(120));
+  const bool completed_while_reader_held = (status == std::future_status::ready);
+
+  // Release the reader before asserting so a regressed (blocking) implementation unwinds
+  // instead of hanging the whole suite on the future's destructor.
+  reader.reset();
+  REQUIRE(completed_while_reader_held);
+
+  auto prepared = fut.get();
+  REQUIRE(prepared.has_value());
+  REQUIRE(prepared->get_memory_space()->get_id() == f.gpu1->get_id());
+  REQUIRE(prepared->get_batch_id() != batch->get_batch_id());
+}
+
+TEST_CASE("lock_or_prepare_batch host to GPU keeps move semantics", "[batch_lock_utils]")
+{
+  batch_lock_utils_fixture f;
+  REQUIRE(f.setup(1));
+
+  rmm::cuda_stream stream;
+  auto batch           = f.make_gpu_batch(kNumRows, *f.gpu0, stream.view());
+  const auto source_id = batch->get_batch_id();
+  std::vector<int64_t> source_values;
+  {
+    auto ro = batch->to_read_only();
+    source_values =
+      column_values_to_host<int64_t>(sirius::get_cudf_table_view(ro).column(0), stream.view());
+  }
+  auto& registry = sirius::converter_registry::get();
+  {
+    auto mut = batch->to_mutable();
+    mut.convert_to<cucascade::host_data_representation>(registry, f.host0, stream.view());
+  }
+  stream.synchronize();
+
+  auto prepared = sirius::pipeline::lock_or_prepare_batch(batch, f.gpu0, stream.view());
+  REQUIRE(prepared.has_value());
+
+  // Same batch object, converted in place: identical id, source object now GPU-resident and
+  // read-locked by the returned accessor (no clone was made).
+  REQUIRE(prepared->get_batch_id() == source_id);
+  REQUIRE(prepared->get_current_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(prepared->get_memory_space()->get_id() == f.gpu0->get_id());
+  REQUIRE(batch->get_state() == cucascade::batch_state::read_only);
+
+  // Data integrity across the spill + upgrade round trip.
+  auto upgraded_values =
+    column_values_to_host<int64_t>(sirius::get_cudf_table_view(*prepared).column(0), stream.view());
+  REQUIRE(upgraded_values == source_values);
+}
+
+TEST_CASE("concurrent same-GPU upgrades of a shared spilled batch race safely",
+          "[batch_lock_utils]")
+{
+  batch_lock_utils_fixture f;
+  REQUIRE(f.setup(1));
+
+  rmm::cuda_stream stream1;
+  rmm::cuda_stream stream2;
+  auto batch = f.make_host_batch(kNumRows, stream1.view());
+
+  // Two consumers of the same spilled batch racing to the same GPU space exercise the
+  // post-readonly_to_mutable re-dispatch: the exclusive-lock winner converts in place, the
+  // loser observes the batch already in the target space and skips the redundant copy.
+  auto worker = [&](rmm::cuda_stream_view sv) {
+    return sirius::pipeline::lock_or_prepare_batch(batch, f.gpu0, sv);
+  };
+  auto fut1 = std::async(std::launch::async, worker, stream1.view());
+  auto fut2 = std::async(std::launch::async, worker, stream2.view());
+
+  auto consume = [&](std::future<std::optional<cucascade::read_only_data_batch>>& fut) {
+    auto prepared = fut.get();
+    REQUIRE(prepared.has_value());
+    REQUIRE(prepared->get_batch_id() == batch->get_batch_id());  // same object, no clone
+    REQUIRE(prepared->get_current_tier() == cucascade::memory::Tier::GPU);
+    REQUIRE(prepared->get_memory_space()->get_id() == f.gpu0->get_id());
+    // prepared's accessor (a shared lock on the batch) is released at scope exit.
+  };
+
+  // Consume whichever worker finishes first and RELEASE its accessor before waiting on the
+  // other: the race loser blocks inside readonly_to_mutable until every shared lock is gone,
+  // including the winner's returned accessor. Waiting on the loser while holding the
+  // winner's accessor would deadlock the test (in production the winner's task releases its
+  // locks independently).
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(120);
+  std::future<std::optional<cucascade::read_only_data_batch>>* first  = nullptr;
+  std::future<std::optional<cucascade::read_only_data_batch>>* second = nullptr;
+  while (first == nullptr && std::chrono::steady_clock::now() < deadline) {
+    if (fut1.wait_for(std::chrono::milliseconds(10)) == std::future_status::ready) {
+      first  = &fut1;
+      second = &fut2;
+    } else if (fut2.wait_for(std::chrono::milliseconds(10)) == std::future_status::ready) {
+      first  = &fut2;
+      second = &fut1;
+    }
+  }
+  REQUIRE(first != nullptr);
+  consume(*first);
+  REQUIRE(second->wait_for(std::chrono::seconds(120)) == std::future_status::ready);
+  consume(*second);
+
+  REQUIRE(batch->get_state() == cucascade::batch_state::idle);
+}
+
+namespace {
+
+/// Expected payload of make_list_table: offsets [0, 2, 4, ...] and iota values.
+std::vector<int32_t> expected_list_offsets(std::size_t num_lists)
+{
+  std::vector<int32_t> offsets(num_lists + 1);
+  for (std::size_t i = 0; i <= num_lists; ++i) {
+    offsets[i] = static_cast<int32_t>(2 * i);
+  }
+  return offsets;
+}
+
+std::vector<int32_t> expected_list_values(std::size_t num_lists)
+{
+  std::vector<int32_t> values(2 * num_lists);
+  std::iota(values.begin(), values.end(), 0);
+  return values;
+}
+
+/// LIST<INT32> batch built on gpu0, spilled to host, then upgraded back to gpu0 through
+/// lock_or_prepare_batch — i.e. a GPU-resident batch that went through the H2D
+/// reconstruction (which promotes LIST offsets to INT64) and the move path's
+/// normalize_gpu_list_offsets fixup. Returned idle.
+std::shared_ptr<cucascade::data_batch> make_normalized_gpu_list_batch(batch_lock_utils_fixture& f,
+                                                                      std::size_t num_lists,
+                                                                      rmm::cuda_stream_view stream)
+{
+  auto table = make_list_table(num_lists, *f.gpu0, stream);
+  auto batch = sirius::make_data_batch(
+    std::move(table), *f.gpu0, stream, sirius::telemetry::batch_telemetry_info{});
+  auto& registry = sirius::converter_registry::get();
+  {
+    auto mut = batch->to_mutable();
+    mut.convert_to<cucascade::host_data_representation>(registry, f.host0, stream);
+  }
+  stream.synchronize();
+  {
+    auto upgraded = sirius::pipeline::lock_or_prepare_batch(batch, f.gpu0, stream);
+    REQUIRE(upgraded.has_value());
+  }
+  return batch;
+}
+
+}  // namespace
+
+TEST_CASE("host to GPU upgrade normalizes LIST offsets to INT32", "[batch_lock_utils]")
+{
+  batch_lock_utils_fixture f;
+  REQUIRE(f.setup(1));
+
+  rmm::cuda_stream stream;
+  constexpr std::size_t kNumLists = 512;
+
+  auto batch = make_normalized_gpu_list_batch(f, kNumLists, stream.view());
+
+  auto ro = batch->to_read_only();
+  cudf::lists_column_view lcv(sirius::get_cudf_table_view(ro).column(0));
+  REQUIRE(lcv.offsets().type().id() == cudf::type_id::INT32);
+  REQUIRE(column_values_to_host<int32_t>(lcv.offsets(), stream.view()) ==
+          expected_list_offsets(kNumLists));
+  REQUIRE(column_values_to_host<int32_t>(lcv.child(), stream.view()) ==
+          expected_list_values(kNumLists));
+}
+
+TEST_CASE("LIST columns survive a cross-GPU clone with INT32 offsets", "[batch_lock_utils][mgpu]")
+{
+  if (skip_if_not_mgpu()) { return; }
+  batch_lock_utils_fixture f;
+  REQUIRE(f.setup(2));
+
+  rmm::cuda_stream stream;
+  constexpr std::size_t kNumLists = 512;
+
+  auto batch = make_normalized_gpu_list_batch(f, kNumLists, stream.view());
+
+  // Cross-GPU clone of the (normalized) GPU-resident source: the peer copy preserves the
+  // source's column types exactly, so the clone's LIST offsets stay INT32 with no fixup on
+  // the clone path.
+  auto prepared = sirius::pipeline::lock_or_prepare_batch(batch, f.gpu1, stream.view());
+  REQUIRE(prepared.has_value());
+  REQUIRE(prepared->get_memory_space()->get_id() == f.gpu1->get_id());
+  cudf::lists_column_view clone_lcv(sirius::get_cudf_table_view(*prepared).column(0));
+  REQUIRE(clone_lcv.offsets().type().id() == cudf::type_id::INT32);
+  REQUIRE(column_values_to_host<int32_t>(clone_lcv.offsets(), stream.view()) ==
+          expected_list_offsets(kNumLists));
+  REQUIRE(column_values_to_host<int32_t>(clone_lcv.child(), stream.view()) ==
+          expected_list_values(kNumLists));
+}
+
+TEST_CASE("prepare_for_processing rebinds idle batches to the prepared clones",
+          "[batch_lock_utils][mgpu]")
+{
+  if (skip_if_not_mgpu()) { return; }
+  batch_lock_utils_fixture f;
+  REQUIRE(f.setup(2));
+
+  rmm::cuda_stream stream;
+  auto batch = f.make_gpu_batch(kNumRows, *f.gpu0, stream.view());
+
+  sirius::op::pipelineable_operator_data op_data(
+    std::vector<std::shared_ptr<cucascade::data_batch>>{batch});
+  op_data.prepare_for_processing(f.gpu1, stream.view());
+
+  // get_data_batches() must return the clone underlying the read-only accessor, not the
+  // stale original — downstream forwarding (dynamic_filter, sink) relies on this.
+  auto clone_sp = op_data.get_data_batches().at(0);
+  REQUIRE(clone_sp != nullptr);
+  REQUIRE(clone_sp != batch);
+  REQUIRE(clone_sp->get_batch_id() != batch->get_batch_id());
+
+  // The source is idle again (no lock held on it), while the clone is read-locked by the
+  // stored accessor.
+  REQUIRE(batch->get_state() == cucascade::batch_state::idle);
+  REQUIRE(clone_sp->get_state() == cucascade::batch_state::read_only);
+
+  // OOM-reschedule survival: remove_read_only_lock materializes the idle vector from the
+  // accessors before dropping them, so the clone (and its transfer work) outlives the locks.
+  op_data.remove_read_only_lock();
+  REQUIRE(op_data.get_data_batches().at(0) == clone_sp);
+  REQUIRE(clone_sp->get_state() == cucascade::batch_state::idle);
+  {
+    auto ro = clone_sp->to_read_only();
+    REQUIRE(ro.get_memory_space()->get_id() == f.gpu1->get_id());
+  }
+}
+
+TEST_CASE("bytes_to_materialize_input counts cross-GPU inputs for the target space",
+          "[batch_lock_utils][mgpu]")
+{
+  if (skip_if_not_mgpu()) { return; }
+  batch_lock_utils_fixture f;
+  REQUIRE(f.setup(2));
+
+  rmm::cuda_stream stream;
+  auto batch = f.make_gpu_batch(kNumRows, *f.gpu0, stream.view());
+  std::size_t uncompressed_bytes;
+  {
+    auto ro            = batch->to_read_only();
+    uncompressed_bytes = ro.get_data()->get_uncompressed_data_size_in_bytes();
+  }
+  REQUIRE(uncompressed_bytes > 0);
+
+  auto op_data = std::make_unique<sirius::op::pipelineable_operator_data>(
+    std::vector<std::shared_ptr<cucascade::data_batch>>{batch});
+  sirius::pipeline::gpu_pipeline_task_local_state ls(std::move(op_data));
+
+  // A gpu0-resident input is a cross-space clone cost for a gpu1 task, free for a gpu0 task,
+  // and (legacy semantics) not counted when no target space is known.
+  REQUIRE(ls.get_estimated_bytes_to_materialize_input(f.gpu1) == uncompressed_bytes);
+  REQUIRE(ls.get_estimated_bytes_to_materialize_input(f.gpu0) == 0);
+  REQUIRE(ls.get_estimated_bytes_to_materialize_input(nullptr) == 0);
+}
+
+TEST_CASE("single-consumer source is freed promptly after a cross-GPU prepare",
+          "[batch_lock_utils][mgpu]")
+{
+  if (skip_if_not_mgpu()) { return; }
+  batch_lock_utils_fixture f;
+  REQUIRE(f.setup(2));
+
+  rmm::cuda_stream stream;
+  std::weak_ptr<cucascade::data_batch> source_weak;
+  auto op_data = [&]() {
+    auto batch  = f.make_gpu_batch(kNumRows, *f.gpu0, stream.view());
+    source_weak = batch;
+    return std::make_unique<sirius::op::pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(batch)});
+  }();
+  REQUIRE(!source_weak.expired());
+
+  op_data->prepare_for_processing(f.gpu1, stream.view());
+
+  // Ownership-driven lifetime: with no other owners, the original loses its last reference
+  // during prepare (the idle vector is rebound to the clone) and its gpu0 memory is freed —
+  // while the clone stays alive through the stored accessor.
+  REQUIRE(source_weak.expired());
+  auto clone_sp = op_data->get_data_batches().at(0);
+  REQUIRE(clone_sp != nullptr);
+  {
+    auto ro = clone_sp->to_read_only();
+    REQUIRE(ro.get_memory_space()->get_id() == f.gpu1->get_id());
+  }
+}

--- a/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
@@ -132,7 +132,8 @@ class sirius_pipeline_task : public sirius::pipeline::gpu_pipeline_task {
     global.executed_count.fetch_add(1, std::memory_order_relaxed);
   }
 
-  sirius::pipeline::reservation_size_info get_estimated_reservation_size_info() const override
+  sirius::pipeline::reservation_size_info get_estimated_reservation_size_info(
+    const cucascade::memory::memory_space* /*target_space*/) const override
   {
     sirius::pipeline::reservation_size_info info;
     info.reservation_size = kReservationBytes;

--- a/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
@@ -267,7 +267,7 @@ std::unique_ptr<sirius::pipeline::gpu_pipeline_task> create_pipeline_task(
     std::move(global_state));
 
   if (reservation_size > 0) {
-    auto info        = task->get_estimated_reservation_size_info();
+    auto info        = task->get_estimated_reservation_size_info(f.gpu_space);
     auto reservation = f.manager->request_reservation(
       cucascade::memory::any_memory_space_in_tier{cucascade::memory::Tier::GPU}, reservation_size);
     REQUIRE(reservation != nullptr);
@@ -296,7 +296,9 @@ TEST_CASE("scan working set is a lower bound for history-based reservations",
       std::make_unique<scan_sizing_input>()),
     std::move(global_state));
 
-  auto const estimate = task->get_estimated_reservation_size_info();
+  // nullptr target space: scan inputs are not pipelineable, so no materialization is counted
+  // regardless; this test sizes from history + scan working set only.
+  auto const estimate = task->get_estimated_reservation_size_info(nullptr);
   CHECK(estimate.had_history);
   CHECK(estimate.peak_memory_estimate == 500);
   CHECK(estimate.reservation_size == 500);
@@ -315,7 +317,12 @@ TEST_CASE("scan working set is a lower bound for history-based reservations",
 // When execute() tries to convert the host data to GPU via lock_or_prepare_batch,
 // the 300 MB allocation exceeds the remaining ~100 MB -> rmm::out_of_memory.
 //
-// In the OOM catch handler, peak_bytes ~= 300 MB (requested) should be recorded to memory history.
+// The OOM catch handler records to memory history with bytes_to_materialize_input subtracted
+// from the observed peak (consistent with the success and compute-OOM record paths, so
+// materialization overhead never inflates operator peaks). Prepare's allocations here are
+// entirely input materialization (~300 MB == bytes_to_materialize_input), so the recorded
+// operator peak is 0 — a record still exists, and the estimator re-adds materialization cost
+// separately on top of the history-based estimate.
 // ---------------------------------------------------------------------------
 
 TEST_CASE(
@@ -366,11 +373,13 @@ TEST_CASE(
 
   REQUIRE_THROWS_AS(task->execute(stream), sirius::pipeline::oom_reschedule_exception);
 
-  // Verify: memory history should have one record with the OOM peak_bytes
+  // Verify: one record exists, and its peak excludes materialization bytes. Prepare's
+  // allocations were entirely input materialization, so the recorded operator peak is 0
+  // (the estimator adds bytes_to_materialize_input back on top of the history estimate).
   REQUIRE(global_state->get_memory_history().size() == 1);
   auto estimate = global_state->get_memory_history().estimate_peak_memory(kInputDataSize);
   REQUIRE(estimate.has_value());
-  REQUIRE(*estimate == kInputDataSize);
+  REQUIRE(*estimate == 0);
 
   // Cleanup: release the pressure allocation
   pressure_allocator->deallocate(
@@ -486,7 +495,7 @@ TEST_CASE("gpu_pipeline_task execute successfully records to pipeline memory his
 
   auto task2 = create_pipeline_task(f, global_state, input_batch2, 0, /*task_id=*/2);
 
-  auto info2       = task2->get_estimated_reservation_size_info();
+  auto info2       = task2->get_estimated_reservation_size_info(f.gpu_space);
   auto estimation2 = info2.reservation_size;
   REQUIRE(estimation2 ==
           ((float)kInputDataSize2 / (float)kInputDataSize1) * (kExecuteConsumptionSize1));

--- a/test/cpp/pipeline/test_oom_reschedule.cpp
+++ b/test/cpp/pipeline/test_oom_reschedule.cpp
@@ -143,7 +143,8 @@ class oom_test_task_base : public sirius::pipeline::gpu_pipeline_task {
 
   void publish_output(sirius::op::operator_data&, rmm::cuda_stream_view) override {}
 
-  sirius::pipeline::reservation_size_info get_estimated_reservation_size_info() const override
+  sirius::pipeline::reservation_size_info get_estimated_reservation_size_info(
+    const cucascade::memory::memory_space* /*target_space*/) const override
   {
     sirius::pipeline::reservation_size_info info;
     info.reservation_size = kReservationSize;


### PR DESCRIPTION
Closes #1059

## Problem

When a task consumes a batch resident on another GPU, `lock_or_prepare_batch` took an exclusive lock and `convert_to`'d the batch **in place**: concurrent readers blocked for the duration of the transfer (the documented cause of the OOM retry budget going 10→100), the source device lost its copy — ping-pong for shared inputs (MIXED_JOIN pairings, sink fan-out, warm table_gpu cache) — and a semantic read was modeled as a mutation.

## Change

- **Cross-GPU (GPU→GPU) mismatches now clone** via `read_only_data_batch::clone_to` under the shared lock. The source is never exclusively locked or mutated, stays resident for consumers local to its device, and returns to `idle` (downgrade-eligible) as soon as prepare completes. Stream ordering is inherited from `convert_gpu_to_gpu` (waits the source's writer event, synchronizes its copy stream before returning).
- **Host/disk→GPU upgrades keep move semantics** (freeing the spilled copy). The non-atomic `readonly_to_mutable` upgrade is now hardened by re-dispatching on the state observed under the exclusive lock: already in the target space → skip; concurrently upgraded to a *different* GPU → clone (a GPU-resident batch is never moved cross-device); still host/disk → move as planned.
- **`prepare_for_processing` resets `_data_batches`** so the idle view lazily rebuilds from the accessors, restoring the invariant `_data_batches[i]` ≡ batch under accessor `i`. Clones flow correctly to downstream forwarding (`dynamic_filter`, sink), survive OOM reschedule, and are downgrade-visible while requeued.
- **`gpu_pipeline_task` releases its `_input_batches` pin right after prepare** (the pin's only uses were ctor subscribe / dtor unsubscribe). Source lifetime is ownership-driven: batches other consumers still need survive via their owners; a popped single-consumer original is freed as soon as its clone exists — net memory equal to the old move, without the exclusive lock.
- **Reservation estimator is target-space-aware**: `get_estimated_reservation_size_info(target_space)` counts GPU inputs residing in a different memory space in `bytes_to_materialize_input`, so the reservation covers the clone and recorded operator memory history stays clean (the prepare-phase OOM record path now subtracts materialization bytes, consistent with the success and compute-OOM paths).

## Trade-offs

- N remote tasks over one shared batch ⇒ N transfers/transient copies instead of alternating moves (net win expected: no exclusive-lock contention). A per-space clone cache is a plausible follow-up.
- Aggregate footprint rises by the clone size only while the source is genuinely shared; reservation sizing covers the clone.
- With the non-default `track_per_stream_reservation: true`, converter pool-stream allocations bypass task reservations — pre-existing converter-wide behavior, now noted in `memory-management.md`.

## Testing

- New `test/cpp/pipeline/test_batch_lock_utils.cpp` (9 cases): cross-GPU clone semantics, **no blocking of concurrent readers** (deadlocks under the old design), host→GPU move preserved with data-integrity check, LIST-offset normalization (H2D upgrade) and type preservation across the clone, `prepare_for_processing` rebind + OOM-reschedule survival, target-space-aware estimator, prompt single-consumer free, same-GPU upgrade race.
- Full `sirius_unittest` suite: **1624/1624 test cases pass** (~32M assertions), plus pre-commit clean.
- ⚠️ Verified on a **single-GPU** box (GB10): the six `[mgpu]` cases skip there and still need a run on a 2-GPU machine (`"[batch_lock_utils]"`, `"[mgpu][followup-17][gpu_execution]"` warm-cache, and the mgpu hash-join suites) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)