### PR TITLE
feat(scan): serve pinned entries through the split_provider machinery via a pinned-serving mode on the format ingestibles (#819 PR2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,7 @@ set(EXTENSION_SOURCES
     src/op/scan/gpu_ingestible.cpp
     src/op/scan/parquet_gpu_ingestible.cpp
     src/op/scan/duckdb_native_gpu_ingestible.cpp
+    src/op/scan/pinned_chunk_source.cpp
     src/op/dynamic_filter_publish_plan.cpp
     src/op/dynamic_filter_publisher.cpp
     src/op/sirius_dynamic_filter.cpp
@@ -607,6 +608,7 @@ set(TEST_SOURCES
     test/cpp/io/rest/test_rest_reactor.cpp
     test/cpp/scan_manager/test_s3_routing_cutover.cpp
     test/cpp/scan_manager/test_pin_table_multi_gpu.cpp
+    test/cpp/scan/test_pinned_chunk_source.cpp
     test/cpp/operator/test_physical_grouped_aggregate_merge_mgpu.cpp
     test/cpp/operator/test_physical_hash_join_mgpu.cpp
     test/cpp/operator/test_physical_order_mgpu.cpp

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -359,8 +359,8 @@ void task_creator::manager_loop()
             // scheduler and triggers a peer DMA or host staging when the
             // consumer GPU differs from the chunk's home GPU. The pinned
             // chunk's GPU residency is preserved on the batch
-            // (cached_parquet_gpu_ingestible pins each chunk_memory_space
-            // into the gpu_table_representation), so we just read it here.
+            // (pinned_chunk_source stamps each chunk's memory_space into
+            // the gpu_table_representation), so we just read it here.
             if (!preferred_device_id.has_value()) {
               if (auto* cached =
                     dynamic_cast<op::scan::scan_operator_input*>(local_state->_input_data.get())) {

--- a/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
+++ b/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
@@ -145,6 +145,13 @@ class duckdb_native_gpu_ingestible : public op::scan::gpu_ingestible {
 
   metadata_scan_task_t next_split_provider(io::ioctx_resolver resolve) override;
 
+  /// Pinned-cache serving mode: the three serving methods above deliver the
+  /// source's resident chunks instead of walking the row-group metadata (no
+  /// disk read). MVCC serving (issue #819) extends THIS class's pinned mode —
+  /// visibility work items, mask join, delta staging — since it needs the
+  /// DuckDB table handles this class already owns.
+  bool serve_from_pinned_chunks(std::unique_ptr<pinned_chunk_source> source) override;
+
   op::scan::filtered_table materialize_metadata_to_table(
     scan_info const& info,
     ::cucascade::memory::memory_space const& mem_space,
@@ -170,6 +177,10 @@ class duckdb_native_gpu_ingestible : public op::scan::gpu_ingestible {
     1;  ///< The number of row groups to chunk together for each metadata scan task.
   std::size_t _num_ranges = 0;
   std::atomic<std::size_t> _next_range_idx{0};
+
+  /// Pinned-cache serving mode (null = normal disk walk). Set once by
+  /// @ref serve_from_pinned_chunks before the split_provider runs.
+  std::unique_ptr<pinned_chunk_source> _pinned;
 };
 
 std::shared_ptr<duckdb_native_gpu_ingestible> make_ingestible(

--- a/src/include/op/scan/gpu_ingestible.hpp
+++ b/src/include/op/scan/gpu_ingestible.hpp
@@ -54,6 +54,9 @@ class gpu_ingestible;
 // Forward-declared to break the gpu_ingestible.hpp <-> sirius_gpu_scan_operator_data.hpp
 // include cycle; only used by const-reference below. Full definition pulled in by .cpp.
 class scan_operator_input;
+// Forward-declared to keep this header light; implementations that accept
+// pinned serving include op/scan/pinned_chunk_source.hpp in their .cpp.
+class pinned_chunk_source;
 
 //===----------------------------------------------------------------------===//
 // gpu_ingestible
@@ -68,7 +71,11 @@ class scan_operator_input;
  * on each split it pulls off its connector.
  *
  * Implementations today: @c parquet_gpu_ingestible,
- * @c duckdb_native_gpu_ingestible, @c cached_parquet_gpu_ingestible.
+ * @c duckdb_native_gpu_ingestible. Both also accept pinned-cache serving
+ * (@ref serve_from_pinned_chunks): on a pin hit the scan manager switches the
+ * operator's ingestible into pinned mode, and the three serving methods
+ * deliver the already-resident chunks as work items instead of walking
+ * metadata — same machinery, no disk read.
  */
 class gpu_ingestible : public std::enable_shared_from_this<gpu_ingestible> {
  public:
@@ -85,6 +92,23 @@ class gpu_ingestible : public std::enable_shared_from_this<gpu_ingestible> {
                                    rmm::cuda_stream_view stream);
 
   virtual std::unique_ptr<batch_coalescer> create_batch_coalescer() const = 0;
+
+  /**
+   * @brief Switch this ingestible into pinned-cache serving mode.
+   *
+   * Called by the scan manager (before the pipeline slot and split_provider
+   * are built) when a pinned entry can serve the scan. In pinned mode the
+   * SERVING surface — @ref has_processed_all_metadata,
+   * @ref next_split_provider, @ref create_batch_coalescer — delivers the
+   * source's already-resident chunks as work items instead of walking
+   * metadata; the OPERATOR surface (@ref post_filter_and_project,
+   * @ref materialized_column_order, @ref table_info) is unaffected, so a
+   * cached batch is filtered/assembled exactly like a fresh read.
+   *
+   * Default: this format does not support pinned serving — the source is
+   * discarded and false is returned (the caller falls back to the disk read).
+   */
+  virtual bool serve_from_pinned_chunks(std::unique_ptr<pinned_chunk_source> source);
 
   /**
    * @brief Snapshot check for remaining work. Thread-safe.

--- a/src/include/op/scan/parquet_gpu_ingestible.hpp
+++ b/src/include/op/scan/parquet_gpu_ingestible.hpp
@@ -271,6 +271,11 @@ class parquet_gpu_ingestible : public gpu_ingestible {
 
   metadata_scan_task_t next_split_provider(io::ioctx_resolver resolve) override;
 
+  /// Pinned-cache serving mode: the three serving methods above deliver the
+  /// source's resident chunks instead of reading footers (no disk read).
+  /// Stays trivial permanently — MVCC serving is duckdb-only.
+  bool serve_from_pinned_chunks(std::unique_ptr<pinned_chunk_source> source) override;
+
   filtered_table materialize_metadata_to_table(scan_info const& info,
                                                const cucascade::memory::memory_space& mem_space,
                                                rmm::cuda_stream_view stream) override;
@@ -314,6 +319,10 @@ class parquet_gpu_ingestible : public gpu_ingestible {
   // AST-capable filters are ANDed into the parquet reader filter; membership filtering happens in
   // the downstream dynamic-filter operator.
   std::shared_ptr<sirius::op::sirius_dynamic_filter_set> _sirius_dynamic_filters;
+
+  /// Pinned-cache serving mode (null = normal footer walk). Set once by
+  /// @ref serve_from_pinned_chunks before the split_provider runs.
+  std::unique_ptr<pinned_chunk_source> _pinned;
 };
 
 std::shared_ptr<parquet_gpu_ingestible> make_ingestible(

--- a/src/include/op/scan/pinned_chunk_source.hpp
+++ b/src/include/op/scan/pinned_chunk_source.hpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <op/scan/batch_coalescer.hpp>
+#include <op/scan/gpu_ingestible_types.hpp>
+#include <telemetry/data_batch_probe.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace cucascade {
+class data_batch;
+class host_data_representation;
+}  // namespace cucascade
+
+namespace cucascade::memory {
+class memory_space;
+}  // namespace cucascade::memory
+
+namespace cudf {
+class column;
+}  // namespace cudf
+
+namespace sirius::op::scan {
+
+/**
+ * @brief Per-chunk split descriptor for a pinned (cached) table.
+ *
+ * Carries the already-resident data_batch a pinned-mode work item assembled.
+ * The sequencer's emit path unwraps it (via @ref take_batch) into a resident
+ * scan_operator_input, skipping balancer stamping and fadvise/prefetch —
+ * task_creator routes the task off the batch's memory_space instead.
+ * @c estimated_bytes / @c fadvise_entries keep the base defaults: the split is
+ * resident (no IO to advise), and the resident scan_operator_input computes
+ * its size from the batch itself.
+ *
+ * Format-neutral by design: parquet and duckdb pins serve identical resident
+ * chunks. MVCC serving (issue #819, duckdb-only) subclasses this in
+ * duckdb-native land to add visibility state; the emit path dynamic_casts to
+ * THIS base, so derived splits flow through it unchanged.
+ */
+class cached_scan_info : public scan_info {
+ public:
+  cached_scan_info(std::shared_ptr<cucascade::data_batch> batch, std::size_t chunk_index);
+  ~cached_scan_info() override;
+
+  /// Surrender the resident batch to the emit path. Call once.
+  [[nodiscard]] std::shared_ptr<cucascade::data_batch> take_batch() noexcept;
+
+  [[nodiscard]] std::size_t chunk_index() const noexcept { return _chunk_index; }
+
+ private:
+  std::shared_ptr<cucascade::data_batch> _batch;
+  std::size_t _chunk_index{0};
+};
+
+/**
+ * @brief Pass-through coalescer for pinned (cached) pipeline slots.
+ *
+ * Pinned chunks were already coalesced to batch size at pin time, so there is
+ * nothing to bundle: @c push emits each cached split as-is (foreign split
+ * types are dropped, mirroring the disk-format coalescers) and @c flush never
+ * emits — unlike the disk coalescers there is no template-split fallback, so
+ * a zero-chunk pin closes its connector with zero splits, exactly as the
+ * direct cached serving path did. MVCC serving (duckdb-only) replaces this
+ * with its own join-coalescer variant; parquet keeps this one forever.
+ */
+class cached_batch_coalescer final : public batch_coalescer {
+ public:
+  std::vector<std::unique_ptr<scan_info>> push(std::unique_ptr<scan_info> split) override;
+
+  std::vector<std::unique_ptr<scan_info>> flush() override;
+};
+
+/**
+ * @brief The pinned chunks of one cache-hit scan, served as claimable work
+ *        items.
+ *
+ * Built by the scan manager from a matched pinned entry (gathered down to the
+ * scan's requested columns, in materialized order) and handed to the
+ * operator's format ingestible via gpu_ingestible::serve_from_pinned_chunks.
+ * The ingestible's pinned-mode serving methods delegate here: work items
+ * claim chunk indices lock-free and assemble each chunk's resident
+ * data_batch on a scan-manager dispatcher thread.
+ *
+ * Self-contained: holds shared_ptr copies of the pinned chunk data (columns /
+ * host representations), not a reference into the scan manager's
+ * pinned-entries map — the data stays alive for the query even if the entry
+ * is unpinned concurrently, and nothing scan_manager-shaped leaks into the
+ * op layer.
+ */
+class pinned_chunk_source {
+ public:
+  /// One GPU-tier chunk: the selected columns (serve order) + the chunk's
+  /// pinned memory space (its home GPU — the placement signal task_creator
+  /// routes by).
+  struct gpu_chunk {
+    std::vector<std::shared_ptr<cudf::column>> columns;
+    cucascade::memory::memory_space* memory_space{nullptr};
+  };
+
+  /// One HOST-tier chunk: the pinned host representation holding every pinned
+  /// column; the serve-time column subset is applied by slice().
+  struct host_chunk {
+    std::shared_ptr<cucascade::host_data_representation> data;
+  };
+
+  /// GPU-tier source. Every chunk must carry a non-null memory_space.
+  /// @p telemetry_info attributes the assembled batches to the producing
+  /// pipeline (a null context yields no-op probes, e.g. in unit tests).
+  explicit pinned_chunk_source(std::vector<gpu_chunk> chunks,
+                               telemetry::batch_telemetry_info telemetry_info = {});
+
+  /// HOST-tier source. @p column_indices selects the served columns (in serve
+  /// order) out of each chunk's representation. Every chunk must be non-null.
+  pinned_chunk_source(std::vector<host_chunk> chunks,
+                      std::vector<std::size_t> column_indices,
+                      telemetry::batch_telemetry_info telemetry_info = {});
+
+  [[nodiscard]] bool has_more() const noexcept
+  {
+    return _next_chunk.load(std::memory_order_relaxed) < _n_chunks;
+  }
+
+  [[nodiscard]] std::size_t num_chunks() const noexcept { return _n_chunks; }
+
+  /// Claim the next chunk and return a callable that assembles its resident
+  /// batch wrapped in a cached_scan_info. Null when all chunks are claimed
+  /// (lost the race). Thread-safe; the callable runs on a dispatcher thread.
+  [[nodiscard]] std::function<std::unique_ptr<scan_info>()> next_work_item();
+
+ private:
+  [[nodiscard]] std::shared_ptr<cucascade::data_batch> make_batch(std::size_t index) const;
+
+  std::vector<gpu_chunk> _gpu_chunks;
+  std::vector<host_chunk> _host_chunks;
+  std::vector<std::size_t> _host_column_indices;
+  telemetry::batch_telemetry_info _telemetry_info{};
+  std::size_t _n_chunks{0};
+  std::atomic<std::size_t> _next_chunk{0};
+};
+
+}  // namespace sirius::op::scan

--- a/src/include/scan_manager/load_balancing_scan_batch_coalescer.hpp
+++ b/src/include/scan_manager/load_balancing_scan_batch_coalescer.hpp
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "blockingconcurrentqueue.h"
-#include "cucascade/data/data_batch.hpp"
 #include "exec/try.hpp"
 #include "op/scan/batch_coalescer.hpp"
 #include "op/scan/gpu_ingestible_types.hpp"
@@ -34,11 +33,6 @@
 #include <stop_token>
 
 namespace sirius::scan_manager {
-
-struct databatch_provider {
-  virtual ~databatch_provider()                                   = default;
-  virtual std::shared_ptr<cucascade::data_batch> get_next_batch() = 0;
-};
 
 /**
  * @brief Pipeline-ordered sequencer for @c fadvise(opportunistic) calls.
@@ -58,10 +52,12 @@ struct databatch_provider {
  *
  * Usage:
  *   - scan_manager calls @c register_pipeline(scan_op, balancer) once per
- *     pipeline that needs opportunistic prefetching; the returned slot pointer
- *     drives that pipeline's splits.  Its split provider is wired up via
- *     @c get_split_provider_bridge (live metadata scan) or
- *     @c use_cached_entries_for_pipeline (cached-batch replay).
+ *     pipeline; the returned slot pointer drives that pipeline's splits.  Its
+ *     split provider is wired up via @c get_split_provider_bridge — the same
+ *     plain provider whether the ingestible walks disk metadata or serves
+ *     pinned chunks; a pinned-mode ingestible supplies the pass-through
+ *     cached coalescer so its resident splits bypass the disk-format
+ *     coalescing.
  *   - scan_manager calls @c spawn_workers(dispatcher) once, after all slots
  *     have been registered, to launch the sequencer task.  The task processes
  *     slots in registration order until either all slots are drained or the
@@ -89,11 +85,6 @@ class load_balancing_scan_batch_coalescer {
       assert(this->balancer);
     }
 
-    void attach_batch_provider(std::unique_ptr<databatch_provider> provider)
-    {
-      batch_provider = std::move(provider);
-    }
-
     std::size_t op_id{0};
     std::size_t pipeline_id{0};
     using provider_value_t = exec::try_t<std::unique_ptr<op::scan::scan_info>>;
@@ -101,7 +92,6 @@ class load_balancing_scan_batch_coalescer {
     std::shared_ptr<op::scan::batch_coalescer> coalescer;
     std::shared_ptr<balancing_strategy> balancer;
     std::shared_ptr<split_connector> connector;
-    std::unique_ptr<databatch_provider> batch_provider;
   };
 
   load_balancing_scan_batch_coalescer()                                           = default;
@@ -113,11 +103,11 @@ class load_balancing_scan_batch_coalescer {
   /// sequencer task in the order they were added — typically scan_manager
   /// adds them in pipeline-id order so the head-of-line pipeline drains
   /// first.  The returned pointer is valid for the manager's lifetime.
+  /// The slot's batch coalescer comes from the operator ingestible's
+  /// create_batch_coalescer() — a pinned-mode ingestible supplies the
+  /// pass-through cached coalescer, a disk one its format coalescer.
   metadata_processing_state* register_pipeline(op::scan::sirius_gpu_scan_operator* scan_op,
                                                std::shared_ptr<balancing_strategy> balancer);
-
-  void use_cached_entries_for_pipeline(op::scan::sirius_gpu_scan_operator* scan_op,
-                                       std::unique_ptr<databatch_provider> provider);
 
   std::function<void(exec::try_t<std::unique_ptr<op::scan::scan_info>>&&)>
   get_split_provider_bridge(op::scan::sirius_gpu_scan_operator* scan_op);
@@ -138,8 +128,6 @@ class load_balancing_scan_batch_coalescer {
   void worker_loop(std::stop_token const& stop);
 
   void process_provider_inputs(metadata_processing_state& state, std::stop_token const& stop);
-
-  void process_cached_entries(metadata_processing_state& state, std::stop_token const& stop);
 
   /// unique_ptr storage: the slot contains a semaphore and a moodycamel
   /// queue, both of which are non-movable, so we need stable addresses

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -24,9 +24,10 @@
 #include "scan_manager/config.hpp"
 #include "scan_manager/load_balancing_scan_batch_coalescer.hpp"
 #include "scan_manager/split_provider.hpp"
+#include "telemetry/data_batch_probe.hpp"
 
 // Forward-declare sirius_ioctx via <io/types.hpp> for the gpu_ioctxs map type
-// used by prepare_for_query / create_provider_for.
+// used by prepare_for_query.
 #include <cudf/column/column.hpp>
 #include <cudf/table/table.hpp>
 
@@ -67,6 +68,7 @@ class buffer_pool;
 namespace sirius::op::scan {
 class sirius_gpu_scan_operator;
 class gpu_ingestible;
+class pinned_chunk_source;
 }  // namespace sirius::op::scan
 
 namespace sirius::scan_manager {
@@ -84,7 +86,7 @@ namespace sirius::scan_manager {
 /// Captures only what serving needs — the table's identity (parquet file set OR
 /// duckdb catalog/schema/table name), the cached columns (by primary/storage
 /// index), and their names (aligned with @c column_ids) for the GPU gather — and
-/// owns the match logic that @ref sirius_scan_manager::try_assign_cached_entries consults.
+/// owns the match logic that @ref sirius_scan_manager::try_enter_pinned_serving consults.
 class cache_entry_info {
  public:
   std::vector<std::string> resolved_file_paths;    ///< parquet identity (file set)
@@ -135,20 +137,34 @@ struct pinned_entry {
   /// chunked_parquet_reader::read_chunk() call.
   std::vector<cucascade::memory::memory_space*> chunk_memory_spaces;
   /// HOST-tier storage: one host_data_representation per chunk, each holding all
-  /// pinned columns. The cached_split_provider slices these by column index when
+  /// pinned columns. The pinned_chunk_source slices these by column index when
   /// serving a particular scan. Populated by @ref insert_pinned_entry_host.
   std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks;
   /// Tier the pinned data resides in. Drives which storage member above is used
-  /// and which cached_split_provider variant @ref create_provider_for builds.
+  /// and which per-chunk assembly path the pinned_chunk_source takes.
   cucascade::memory::Tier tier{cucascade::memory::Tier::GPU};
-  /// Memory space the pinned data resides in. Captured at pin time so the
-  /// cached_split_provider can wrap copied tables as data_batch instances.
+  /// Memory space the pinned data resides in. Captured at pin time so pinned
+  /// serving can wrap the cached chunks as data_batch instances.
   cucascade::memory::memory_space* memory_space{nullptr};
   /// Total number of rows across all pinned chunks. Used by insert_pinned_entry
   /// to decide whether a re-insert merges into the existing entry (same row
   /// count → add unique columns) or replaces it (different row count).
   std::size_t num_rows{0};
 };
+
+/// Extract @p entry's chunks — gathered down to @p selected_columns (positions
+/// into the entry's column layout), in that order — into a self-contained
+/// pinned_chunk_source ready to hand to
+/// gpu_ingestible::serve_from_pinned_chunks. @p telemetry_info attributes the
+/// served batches to the scanning pipeline (default: no-op probes, e.g. unit
+/// tests). Throws on a malformed entry (per-column chunk counts that disagree,
+/// short chunk_memory_spaces, a null host chunk, or an unsupported tier); @ref
+/// sirius_scan_manager::try_enter_pinned_serving treats that as a cache miss
+/// and falls back to the disk read.
+[[nodiscard]] std::unique_ptr<op::scan::pinned_chunk_source> build_pinned_chunk_source(
+  pinned_entry const& entry,
+  std::span<std::size_t const> selected_columns,
+  telemetry::batch_telemetry_info telemetry_info = {});
 
 /**
  * @brief Bind-time result of @ref sirius_scan_manager::describe_parquet.
@@ -199,15 +215,16 @@ class sirius_scan_manager {
 
   /// \brief Prepare per-scan state for the given query.
   ///
-  /// Walks @p query 's pipelines in scan-operator order. For each GPU parquet
-  /// scan source, the factory builds a split_provider from the operator's
-  /// scan_info, installs a fresh split_connector on the operator, and stores
-  /// the provider in a map keyed by the operator. A driver thread then runs
-  /// the providers SEQUENTIALLY in registration order: provider[0] starts,
-  /// when its future completes provider[1] starts, and so on. Consumers (the
-  /// gpu scan operators) block in split_connector::get_next_split until splits
-  /// arrive or the connector is closed, so no separate wake-up channel is
-  /// needed.
+  /// Walks @p query 's pipelines in scan-operator order. Each GPU scan gets a
+  /// slot in the metadata sequencer and a plain split_provider over its
+  /// ingestible in @c _providers_by_op. When a pinned entry can serve the scan
+  /// (probed first), the ingestible is switched into pinned-serving mode so
+  /// the same provider delivers the resident chunks and no disk read is
+  /// issued. All providers then run on the metadata dispatcher, while the
+  /// sequencer drains their slots in registration order. Consumers (the gpu
+  /// scan operators) block in
+  /// split_connector::get_next_split until splits arrive or the connector is
+  /// closed, so no separate wake-up channel is needed.
   ///
   /// @param query        The query whose scan operators must be prepared.
   void prepare_for_query(const sirius::planner::query& query);
@@ -262,7 +279,7 @@ class sirius_scan_manager {
   ///
   /// Each entry in @p host_chunks describes one batch's worth of pinned data
   /// (covering all pinned columns) as a host_data_representation. The
-  /// cached_split_provider built from this entry slices each chunk by column
+  /// pinned_chunk_source built from this entry slices each chunk by column
   /// index at scan time. This path always REPLACES any existing entry for @p name
   /// — there is no per-column merge analog to the GPU path because the
   /// chunk-vs-column dimensions are flipped (each chunk already holds every column).
@@ -302,10 +319,13 @@ class sirius_scan_manager {
   /// \brief Run providers sequentially: start each, wait on its future, advance.
   void start_metadata_processing();
 
-  /// \brief Attach a cached batch_provider to @p op if a pinned entry can serve
-  ///        it. Returns true when a cache hit was assigned (the caller then skips
-  ///        the disk-reading split_provider for this operator).
-  bool try_assign_cached_entries(op::scan::sirius_gpu_scan_operator* op);
+  /// \brief Switch @p op 's ingestible into pinned-serving mode if a pinned
+  ///        entry can serve it (via gpu_ingestible::serve_from_pinned_chunks).
+  ///        Returns false on a cache miss — the ingestible keeps its normal
+  ///        disk walk. Any matching/extraction error is swallowed and treated
+  ///        as a miss, so a malformed entry falls back to the disk read
+  ///        instead of failing the query.
+  bool try_enter_pinned_serving(op::scan::sirius_gpu_scan_operator* op);
 
   /// Resolve the ioctx that should serve @p path (normalized internally, so callers
   /// — including the scan resolver — may pass a raw `file://` / `s3://` URI),
@@ -338,9 +358,10 @@ class sirius_scan_manager {
   std::unordered_map<std::string, pinned_entry> _pinned_entries;
 
   /// Per-query sequencer for opportunistic fadvise calls.  Built fresh
-  /// in @ref prepare_for_query, gets one @c pipeline_slot per non-cached
-  /// parquet scan (allocated by @ref create_provider_for when it builds
-  /// a parquet_split_provider).  The sequencer task is enqueued on the
+  /// in @ref prepare_for_query, gets one slot per GPU scan (the slot
+  /// coalescer comes from the ingestible: pass-through cached coalescer
+  /// in pinned mode, format coalescer otherwise).  The sequencer task is
+  /// enqueued on the
   /// per-query @c _dispatcher, which injects its own stop_token; the
   /// dispatcher's @c request_stop() in @ref reset() therefore tears the
   /// sequencer down without an extra side-channel.

--- a/src/include/scan_manager/split_provider.hpp
+++ b/src/include/scan_manager/split_provider.hpp
@@ -49,13 +49,13 @@ namespace sirius::scan_manager {
  * (first-writer-wins via atomic CAS) is forwarded so consumers see the
  * failure through @ref split_connector::get_next_split.
  *
- * Historical note: this class was abstract pre-gpu_ingestible refactor.
- * Legacy subclasses (parquet_split_provider, duckdb_native_split_provider,
- * cached_split_provider) override @ref has_more_splits and
- * @ref next_split_provider; they are scheduled for deletion in step 10 of
- * the refactor. The default (concrete) construction path takes a
- * @c shared_ptr<io::gpu_ingestible> and uses the base's default
- * implementations to delegate to it.
+ * Concrete class — per-format (and pinned-cache) behavior lives in the
+ * composed @c gpu_ingestible, not in provider subclasses: the construction
+ * path takes the operator's ingestible and @ref has_more_splits /
+ * @ref next_split_provider delegate to it. A pinned-cache hit switches the
+ * ingestible into pinned-serving mode (see
+ * @c gpu_ingestible::serve_from_pinned_chunks); the provider is none the
+ * wiser.
  */
 class split_provider {
  public:

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -25,6 +25,7 @@
 #include <log/logging.hpp>
 #include <op/scan/duckdb_native_decoder.hpp>
 #include <op/scan/duckdb_native_gpu_ingestible.hpp>
+#include <op/scan/pinned_chunk_source.hpp>
 #include <op/scan/scan_utils.hpp>
 #include <op/scan/sirius_gpu_scan_operator_data.hpp>
 
@@ -256,14 +257,25 @@ duckdb_native_gpu_ingestible::~duckdb_native_gpu_ingestible() = default;
 //===----------------------------------------------------------------------===//
 // split-provider interface
 //===----------------------------------------------------------------------===//
+bool duckdb_native_gpu_ingestible::serve_from_pinned_chunks(
+  std::unique_ptr<pinned_chunk_source> source)
+{
+  _pinned = std::move(source);
+  return true;
+}
+
 bool duckdb_native_gpu_ingestible::has_processed_all_metadata() const
 {
+  if (_pinned) { return !_pinned->has_more(); }
   return _next_range_idx.load(std::memory_order_relaxed) >= _num_ranges;
 }
 
 duckdb_native_gpu_ingestible::metadata_scan_task_t
 duckdb_native_gpu_ingestible::next_split_provider(io::ioctx_resolver resolve)
 {
+  // Pinned mode: serve resident chunks; no ioctx, no metadata walk.
+  if (_pinned) { return _pinned->next_work_item(); }
+
   auto const idx = _next_range_idx.fetch_add(1, std::memory_order_relaxed);
   if (idx >= _num_ranges) { return nullptr; }  // lost the race for the final range
 
@@ -321,6 +333,11 @@ filtered_table duckdb_native_gpu_ingestible::materialize_metadata_to_table(
 //===----------------------------------------------------------------------===//
 std::unique_ptr<batch_coalescer> duckdb_native_gpu_ingestible::create_batch_coalescer() const
 {
+  // Pinned mode: resident chunks were already coalesced to batch size at pin
+  // time — the slot gets the pass-through coalescer instead of the row-group
+  // byte-budget one (which would drop cached_scan_info splits).
+  if (_pinned) { return std::make_unique<cached_batch_coalescer>(); }
+
   std::vector<bool> is_varchar;
   is_varchar.reserve(_info->projected_types.size());
   for (auto const& t : _info->projected_types) {

--- a/src/op/scan/gpu_ingestible.cpp
+++ b/src/op/scan/gpu_ingestible.cpp
@@ -18,9 +18,15 @@
 
 #include <data/data_batch_utils.hpp>
 #include <op/scan/gpu_ingestible.hpp>
+#include <op/scan/pinned_chunk_source.hpp>
 #include <op/scan/sirius_gpu_scan_operator_data.hpp>
 
 namespace sirius::op::scan {
+
+bool gpu_ingestible::serve_from_pinned_chunks(std::unique_ptr<pinned_chunk_source> /*source*/)
+{
+  return false;  // this format has no pinned-serving mode; caller falls back to the disk read
+}
 
 filtered_table gpu_ingestible::materialize_table(const op::scan::scan_operator_input& split,
                                                  rmm::cuda_stream_view stream)

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -28,6 +28,7 @@
 #include <op/scan/parquet_gpu_ingestible.hpp>
 #include <op/scan/parquet_metadata.hpp>
 #include <op/scan/parquet_schema_mapping.hpp>
+#include <op/scan/pinned_chunk_source.hpp>
 #include <op/scan/scan_utils.hpp>
 #include <op/scan/sirius_gpu_scan_operator_data.hpp>
 #include <op/sirius_dynamic_filter.hpp>
@@ -397,6 +398,11 @@ parquet_gpu_ingestible::~parquet_gpu_ingestible() = default;
 //===----------------------------------------------------------------------===//
 std::unique_ptr<batch_coalescer> parquet_gpu_ingestible::create_batch_coalescer() const
 {
+  // Pinned mode: resident chunks were already coalesced to batch size at pin
+  // time — the slot gets the pass-through coalescer instead of the file
+  // byte-budget one (which would drop cached_scan_info splits).
+  if (_pinned) { return std::make_unique<cached_batch_coalescer>(); }
+
   return std::make_unique<parquet_batch_coalescer>(
     _info->approximate_batch_size, _reader_options, _plan);
 }
@@ -404,14 +410,24 @@ std::unique_ptr<batch_coalescer> parquet_gpu_ingestible::create_batch_coalescer(
 //===----------------------------------------------------------------------===//
 // split-provider interface
 //===----------------------------------------------------------------------===//
+bool parquet_gpu_ingestible::serve_from_pinned_chunks(std::unique_ptr<pinned_chunk_source> source)
+{
+  _pinned = std::move(source);
+  return true;
+}
+
 bool parquet_gpu_ingestible::has_processed_all_metadata() const
 {
+  if (_pinned) { return !_pinned->has_more(); }
   return _next_file_idx.load(std::memory_order_relaxed) >= _file_paths.size();
 }
 
 std::function<std::unique_ptr<op::scan::scan_info>()> parquet_gpu_ingestible::next_split_provider(
   io::ioctx_resolver resolve)
 {
+  // Pinned mode: serve resident chunks; no ioctx, no footer read.
+  if (_pinned) { return _pinned->next_work_item(); }
+
   if (!resolve) { throw std::runtime_error("parquet_gpu_ingestible: no scan_manager is wired."); }
   auto const idx = _next_file_idx.fetch_add(1, std::memory_order_relaxed);
   if (idx >= _file_paths.size()) { return nullptr; }  // lost the race for the final file

--- a/src/op/scan/pinned_chunk_source.cpp
+++ b/src/op/scan/pinned_chunk_source.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/scan/pinned_chunk_source.hpp"
+
+#include "data/data_batch_utils.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/table/table_view.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/memory/memory_space.hpp>
+
+#include <stdexcept>
+#include <utility>
+
+namespace sirius::op::scan {
+
+//===----------------------------------------------------------------------===//
+// cached_scan_info
+//===----------------------------------------------------------------------===//
+
+cached_scan_info::cached_scan_info(std::shared_ptr<cucascade::data_batch> batch,
+                                   std::size_t chunk_index)
+  : _batch(std::move(batch)), _chunk_index(chunk_index)
+{
+}
+
+cached_scan_info::~cached_scan_info() = default;
+
+std::shared_ptr<cucascade::data_batch> cached_scan_info::take_batch() noexcept
+{
+  return std::move(_batch);
+}
+
+//===----------------------------------------------------------------------===//
+// cached_batch_coalescer
+//===----------------------------------------------------------------------===//
+
+std::vector<std::unique_ptr<scan_info>> cached_batch_coalescer::push(
+  std::unique_ptr<scan_info> split)
+{
+  std::vector<std::unique_ptr<scan_info>> out;
+  if (dynamic_cast<cached_scan_info*>(split.get()) != nullptr) { out.push_back(std::move(split)); }
+  // Foreign split types are dropped, mirroring the disk-format coalescers.
+  return out;
+}
+
+std::vector<std::unique_ptr<scan_info>> cached_batch_coalescer::flush()
+{
+  // No template-split fallback: a zero-chunk pin closes with zero splits.
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
+// pinned_chunk_source
+//===----------------------------------------------------------------------===//
+
+pinned_chunk_source::pinned_chunk_source(std::vector<gpu_chunk> chunks,
+                                         telemetry::batch_telemetry_info telemetry_info)
+  : _gpu_chunks(std::move(chunks)), _telemetry_info(telemetry_info), _n_chunks(_gpu_chunks.size())
+{
+  for (auto const& chunk : _gpu_chunks) {
+    if (chunk.memory_space == nullptr) {
+      throw std::runtime_error("pinned_chunk_source: GPU chunk without a memory_space");
+    }
+  }
+}
+
+pinned_chunk_source::pinned_chunk_source(std::vector<host_chunk> chunks,
+                                         std::vector<std::size_t> column_indices,
+                                         telemetry::batch_telemetry_info telemetry_info)
+  : _host_chunks(std::move(chunks)),
+    _host_column_indices(std::move(column_indices)),
+    _telemetry_info(telemetry_info),
+    _n_chunks(_host_chunks.size())
+{
+  for (auto const& chunk : _host_chunks) {
+    if (!chunk.data) { throw std::runtime_error("pinned_chunk_source: null pinned host chunk"); }
+  }
+}
+
+std::function<std::unique_ptr<scan_info>()> pinned_chunk_source::next_work_item()
+{
+  auto const chunk = _next_chunk.fetch_add(1, std::memory_order_relaxed);
+  if (chunk >= _n_chunks) { return nullptr; }  // lost the race to the last chunk
+  return [this, chunk]() -> std::unique_ptr<scan_info> {
+    return std::make_unique<cached_scan_info>(make_batch(chunk), chunk);
+  };
+}
+
+std::shared_ptr<cucascade::data_batch> pinned_chunk_source::make_batch(std::size_t index) const
+{
+  auto const batch_id = ::sirius::get_next_batch_id();
+  if (!_gpu_chunks.empty()) {
+    auto const& chunk                                  = _gpu_chunks.at(index);
+    std::vector<std::shared_ptr<cudf::column>> columns = chunk.columns;
+    std::vector<cudf::column_view> column_views;
+    column_views.reserve(columns.size());
+    std::size_t alloc_size = 0;
+    for (auto const& column : columns) {
+      column_views.emplace_back(column->view());
+      alloc_size += column->alloc_size();
+    }
+    cudf::table_view view(column_views);
+    auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(
+      view, std::move(columns), alloc_size, *chunk.memory_space, rmm::cuda_stream_view{});
+    return cucascade::data_batch::make(
+      batch_id,
+      std::move(gpu_repr),
+      telemetry::quent_data_batch_probe::create(_telemetry_info, batch_id));
+  }
+  auto const& chunk = _host_chunks.at(index);
+  auto data_rep     = chunk.data->slice(_host_column_indices);
+  return cucascade::data_batch::make(
+    batch_id,
+    std::move(data_rep),
+    telemetry::quent_data_batch_probe::create(_telemetry_info, batch_id));
+}
+
+}  // namespace sirius::op::scan

--- a/src/scan_manager/load_balancing_scan_batch_coalescer.cpp
+++ b/src/scan_manager/load_balancing_scan_batch_coalescer.cpp
@@ -18,6 +18,7 @@
 
 #include "exec/try.hpp"
 #include "log/logging.hpp"
+#include "op/scan/pinned_chunk_source.hpp"
 #include "op/scan/sirius_gpu_scan_operator_data.hpp"
 
 #include <stop_token>
@@ -44,17 +45,6 @@ load_balancing_scan_batch_coalescer::register_pipeline(op::scan::sirius_gpu_scan
   return state_ptr;
 }
 
-void load_balancing_scan_batch_coalescer::use_cached_entries_for_pipeline(
-  op::scan::sirius_gpu_scan_operator* scan_op, std::unique_ptr<databatch_provider> provider)
-{
-  if (!scan_op) return;
-  auto uid = scan_op->get_operator_id();
-  auto it  = _slots.find(uid);
-  if (it == _slots.end()) { return; }
-  auto& state = *it->second;
-  state.attach_batch_provider(std::move(provider));
-}
-
 std::function<void(exec::try_t<std::unique_ptr<op::scan::scan_info>>&&)>
 load_balancing_scan_batch_coalescer::get_split_provider_bridge(
   op::scan::sirius_gpu_scan_operator* scan_op)
@@ -72,12 +62,7 @@ void load_balancing_scan_batch_coalescer::worker_loop([[maybe_unused]] std::stop
 {
   for (auto pipeline_id : _pipeline_order) {
     if (stop.stop_requested()) { break; }
-    auto& state = *_slots.at(pipeline_id);
-    if (state.batch_provider) {
-      process_cached_entries(state, stop);
-    } else {
-      process_provider_inputs(state, stop);
-    }
+    process_provider_inputs(*_slots.at(pipeline_id), stop);
   }
 }
 
@@ -91,6 +76,17 @@ void load_balancing_scan_batch_coalescer::process_provider_inputs(metadata_proce
 
   // Balance one coalesced batch onto a GPU and hand it to the connector.
   auto emit = [&state](std::unique_ptr<op::scan::scan_info> batch) {
+    if (auto* cached = dynamic_cast<op::scan::cached_scan_info*>(batch.get())) {
+      // Pinned-cache chunk: already resident, so no fadvise/prefetch, and no
+      // balancer stamping — task_creator routes cached scans off the batch's
+      // memory_space (its cached-scan locality branch), which a
+      // preferred_device_id stamped here would override. Skipping the
+      // get_next_gpu call also keeps the shared round-robin cursor untouched
+      // for the disk pipelines of a mixed cached+disk query.
+      state.connector->push_split(
+        std::make_unique<op::scan::scan_operator_input>(cached->take_batch()));
+      return;
+    }
     auto op_data = std::make_unique<op::scan::scan_operator_input>(std::move(batch));
     auto dev_id  = state.balancer->get_next_gpu(state.pipeline_id, op_data.get());
     SIRIUS_LOG_INFO("[coalesce-debug] load_balancer emit pipeline={} -> preferred GPU {}",
@@ -158,21 +154,6 @@ void load_balancing_scan_batch_coalescer::process_provider_inputs(metadata_proce
   }
 
   // Stop requested between iterations — close so downstream consumers unblock.
-  state.connector->close();
-}
-
-void load_balancing_scan_batch_coalescer::process_cached_entries(
-  metadata_processing_state& state, [[maybe_unused]] std::stop_token const& stop)
-{
-  bool is_closed = false;
-  while (!is_closed) {
-    auto databatch = state.batch_provider->get_next_batch();
-    is_closed      = databatch == nullptr;
-    if (!is_closed) {
-      auto op_data = std::make_unique<op::scan::scan_operator_input>(std::move(databatch));
-      state.connector->push_split(std::move(op_data));
-    }
-  }
   state.connector->close();
 }
 

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -16,7 +16,6 @@
 
 #include "scan_manager/sirius_scan_manager.hpp"
 
-#include "data/data_batch_utils.hpp"
 #include "exec/thread_pool.hpp"
 #include "io/cache/prefetching_cache.hpp"
 #include "io/io_context.hpp"
@@ -28,13 +27,13 @@
 #include "op/scan/gpu_ingestible.hpp"
 #include "op/scan/parquet_gpu_ingestible.hpp"
 #include "op/scan/parquet_metadata.hpp"
+#include "op/scan/pinned_chunk_source.hpp"
 #include "op/scan/sirius_gpu_scan_operator.hpp"
 #include "op/scan/sirius_gpu_scan_operator_data.hpp"
 #include "op/sirius_physical_operator_type.hpp"
 #include "planner/query.hpp"
 #include "scan_manager/round_robin_strategy.hpp"
 
-#include <cudf/column/column_view.hpp>
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/experimental/hybrid_scan.hpp>
 #include <cudf/io/parquet.hpp>
@@ -47,7 +46,6 @@
 
 #include <rmm/cuda_device.hpp>
 
-#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 #include <cucascade/memory/memory_reservation_manager.hpp>
 #include <cucascade/memory/memory_space.hpp>
@@ -63,96 +61,6 @@
 namespace sirius::scan_manager {
 
 namespace {
-
-struct cached_databatch_provider : public databatch_provider {
-  cached_databatch_provider(pinned_entry const& entry,
-                            std::span<size_t> selected_columns,
-                            const telemetry::batch_telemetry_info& telemetry_info)
-    : _entry(entry), _telemetry_info(telemetry_info)
-  {
-    auto const& entry_column_names = _entry.cache_info.column_names();
-    std::ranges::for_each(selected_columns, [this, &entry_column_names](size_t idx) {
-      _column_names.emplace_back(entry_column_names[idx]);
-      _column_indices.push_back(idx);
-    });
-
-    if (_entry.tier == cucascade::memory::Tier::GPU) {
-      if (_entry.data_batches_by_column.empty()) {
-        _n_chunks = 0;
-      } else {
-        _n_chunks = _entry.data_batches_by_column.begin()->second.size();
-      }
-    } else if (_entry.tier == cucascade::memory::Tier::HOST) {
-      _n_chunks = _entry.host_chunks.size();
-    }
-  }
-
-  std::shared_ptr<cucascade::data_batch> get_next_batch() override
-  {
-    auto index = _index.fetch_add(1);
-    if (index >= _n_chunks) { return nullptr; }
-    if (_entry.tier == cucascade::memory::Tier::GPU) {
-      return get_device_databatch(index);
-    } else if (_entry.tier == cucascade::memory::Tier::HOST) {
-      return get_host_databatch(index);
-    }
-    return nullptr;
-  }
-
- private:
-  std::shared_ptr<cucascade::data_batch> get_host_databatch(std::size_t index)
-  {
-    if (index >= _entry.host_chunks.size()) { return nullptr; }
-    const auto& chunk = _entry.host_chunks.at(index);
-    if (!chunk) { return nullptr; }
-    auto data_rep       = chunk->slice(_column_indices);
-    const auto batch_id = get_next_batch_id();
-    return cucascade::data_batch::make(
-      batch_id,
-      std::move(data_rep),
-      telemetry::quent_data_batch_probe::create(_telemetry_info, batch_id));
-  }
-
-  std::shared_ptr<cucascade::data_batch> get_device_databatch(std::size_t index)
-  {
-    if (index >= _entry.chunk_memory_spaces.size()) { return nullptr; }
-    std::vector<std::shared_ptr<cudf::column>> columns;
-    std::vector<cudf::column_view> column_views;
-    std::size_t alloc_size = 0;
-    for (const auto& col_idx : _column_names) {
-      const auto& col_chunks = _entry.data_batches_by_column.at(col_idx);
-      if (index >= col_chunks.size()) { return nullptr; }
-      columns.push_back(col_chunks.at(index));
-      column_views.emplace_back(columns.back()->view());
-      alloc_size += columns.back()->alloc_size();
-    }
-    cudf::table_view view(column_views);
-    auto* chunk_space = !_entry.chunk_memory_spaces.empty() ? _entry.chunk_memory_spaces.at(index)
-                                                            : _entry.memory_space;
-    auto gpu_repr     = std::make_unique<::cucascade::gpu_table_representation>(
-      view, std::move(columns), alloc_size, *chunk_space, rmm::cuda_stream_view{});
-    const auto batch_id = ::sirius::get_next_batch_id();
-    return ::cucascade::data_batch::make(
-      batch_id,
-      std::move(gpu_repr),
-      telemetry::quent_data_batch_probe::create(_telemetry_info, batch_id));
-  }
-
-  std::size_t _n_chunks;
-  std::vector<std::string> _column_names;
-  std::vector<size_t> _column_indices;
-  const pinned_entry& _entry;
-  telemetry::batch_telemetry_info _telemetry_info;
-  std::atomic<std::size_t> _index{0};
-};
-
-std::unique_ptr<databatch_provider> make_provider_for_pinned_entry(
-  pinned_entry const& entry,
-  std::span<size_t> selected_columns,
-  const telemetry::batch_telemetry_info& telemetry_info)
-{
-  return std::make_unique<cached_databatch_provider>(entry, selected_columns, telemetry_info);
-}
 
 /// Strip a leading "file://" scheme (case-insensitive) so the path can be
 /// resolved by a local-file backend.
@@ -329,14 +237,13 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query)
     if (scan_op->type != ::sirius::op::SiriusPhysicalOperatorType::GPU_SCAN) { continue; }
     auto* op = &scan_op->Cast<op::scan::sirius_gpu_scan_operator>();
     if (_providers_by_op.find(op) != _providers_by_op.end()) { continue; }
+    // Probe the pinned cache first: on a hit the operator's format ingestible
+    // enters pinned-serving mode (resident-chunk work items + the pass-through
+    // cached coalescer), so the plain split_provider below serves the cache
+    // and no disk read is issued. On a miss the ingestible keeps its normal
+    // metadata walk — the serving tail is identical either way.
+    try_enter_pinned_serving(op);
     _metadata_processor->register_pipeline(op, round_robin);
-    // On a pinned-cache hit the coalescer serves this operator from the cached
-    // batch_provider (process_cached_entries); skip the disk-reading
-    // split_provider entirely so no read is issued for the cached scan.
-    if (try_assign_cached_entries(op)) {
-      _scan_op_order.push_back(op);
-      continue;
-    }
     auto provider = std::make_unique<split_provider>(
       op->get_ingestible(),
       [this](std::string_view file_path) -> std::shared_ptr<io::sirius_ioctx> {
@@ -615,8 +522,8 @@ void sirius_scan_manager::insert_pinned_entry(
       // Decide which column INDICES are new BEFORE iterating chunks. Doing
       // the contains() check per-chunk would let chunk 0 install a new
       // column and then chunks 1..N-1 see contains()==true and skip — leaving
-      // the new column with only chunk 0 and tripping cached_split_provider's
-      // "mismatched chunk count across requested columns" invariant.
+      // the new column with only chunk 0 and tripping build_pinned_chunk_source's
+      // "column does not cover every chunk" validation.
       std::vector<bool> is_new_col(column_names.size(), false);
       for (std::size_t i = 0; i < column_names.size(); ++i) {
         is_new_col[i] = !entry.data_batches_by_column.contains(column_names[i]);
@@ -721,7 +628,68 @@ void sirius_scan_manager::visit_pinned_entries(
   }
 }
 
-bool sirius_scan_manager::try_assign_cached_entries(op::scan::sirius_gpu_scan_operator* op)
+std::unique_ptr<op::scan::pinned_chunk_source> build_pinned_chunk_source(
+  pinned_entry const& entry,
+  std::span<std::size_t const> selected_columns,
+  telemetry::batch_telemetry_info telemetry_info)
+{
+  auto const& entry_column_names = entry.cache_info.column_names();
+
+  if (entry.tier == cucascade::memory::Tier::GPU) {
+    std::vector<op::scan::pinned_chunk_source::gpu_chunk> chunks;
+    if (entry.data_batches_by_column.empty()) {
+      // Legitimate zero-chunk entry: nothing to serve, nothing to validate.
+      return std::make_unique<op::scan::pinned_chunk_source>(std::move(chunks), telemetry_info);
+    }
+    auto const n_chunks = entry.data_batches_by_column.begin()->second.size();
+    if (!entry.chunk_memory_spaces.empty() && entry.chunk_memory_spaces.size() != n_chunks) {
+      throw std::runtime_error(
+        "pinned entry's chunk_memory_spaces does not cover every chunk of the entry");
+    }
+    // Resolve the selected columns' chunk vectors once, validating coverage —
+    // a malformed entry throws here (the caller falls back to the disk read)
+    // instead of silently truncating the scan mid-stream.
+    std::vector<std::vector<std::shared_ptr<cudf::column>> const*> selected;
+    selected.reserve(selected_columns.size());
+    for (auto idx : selected_columns) {
+      auto const& name = entry_column_names.at(idx);
+      auto it          = entry.data_batches_by_column.find(name);
+      if (it == entry.data_batches_by_column.end() || it->second.size() != n_chunks) {
+        throw std::runtime_error("pinned column '" + name +
+                                 "' does not cover every chunk of the entry");
+      }
+      selected.push_back(&it->second);
+    }
+    chunks.reserve(n_chunks);
+    for (std::size_t c = 0; c < n_chunks; ++c) {
+      op::scan::pinned_chunk_source::gpu_chunk chunk;
+      chunk.columns.reserve(selected.size());
+      for (auto const* col_chunks : selected) {
+        chunk.columns.push_back(col_chunks->at(c));
+      }
+      chunk.memory_space =
+        !entry.chunk_memory_spaces.empty() ? entry.chunk_memory_spaces.at(c) : entry.memory_space;
+      chunks.push_back(std::move(chunk));
+    }
+    return std::make_unique<op::scan::pinned_chunk_source>(std::move(chunks), telemetry_info);
+  }
+
+  if (entry.tier == cucascade::memory::Tier::HOST) {
+    std::vector<op::scan::pinned_chunk_source::host_chunk> chunks;
+    chunks.reserve(entry.host_chunks.size());
+    for (auto const& chunk : entry.host_chunks) {
+      chunks.push_back({chunk});  // null chunks are rejected by the source ctor
+    }
+    return std::make_unique<op::scan::pinned_chunk_source>(
+      std::move(chunks),
+      std::vector<std::size_t>(selected_columns.begin(), selected_columns.end()),
+      telemetry_info);
+  }
+
+  throw std::runtime_error("pinned entry has an unsupported tier");
+}
+
+bool sirius_scan_manager::try_enter_pinned_serving(op::scan::sirius_gpu_scan_operator* op)
 {
   const auto& table_info = op->get_ingestible().table_info();
 
@@ -736,11 +704,25 @@ bool sirius_scan_manager::try_assign_cached_entries(op::scan::sirius_gpu_scan_op
       auto cols = gather_by_primary_index(entry.cache_info.column_ids,
                                           op->get_ingestible().materialized_column_order());
       if (cols.empty()) { continue; }  // defensive: materialized set must be a cache subset
-      auto provider = make_provider_for_pinned_entry(entry, cols, op->batch_telemetry());
-      _metadata_processor->use_cached_entries_for_pipeline(op, std::move(provider));
+      auto source         = build_pinned_chunk_source(entry, cols, op->batch_telemetry());
+      auto const n_chunks = source->num_chunks();
+      if (!op->get_ingestible().serve_from_pinned_chunks(std::move(source))) {
+        // This format's ingestible has no pinned-serving mode; keep the disk read.
+        spdlog::warn(
+          "[sirius_scan_manager] pinned entry '{}' matched operator '{}' but its "
+          "ingestible does not support pinned serving; using the disk read",
+          pinned_name,
+          op->get_operator_id());
+        return false;
+      }
       spdlog::info("[sirius_scan_manager] assigned pinned entry '{}' to operator '{}'",
                    pinned_name,
                    op->get_operator_id());
+      spdlog::info(
+        "[sirius_scan_manager] pinned entry '{}' served via pinned chunks "
+        "({} chunks) on the metadata dispatcher",
+        pinned_name,
+        n_chunks);
       return true;
     }
   } catch (...) {

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -240,10 +240,12 @@ void SiriusContext::QueryEnd()
       }
     }
 
-    // Drop scan-manager providers for this query. Each cached_split_provider
-    // holds shared_ptr copies of the pinned entry's host_chunks; if kept past
-    // the query, those refs prevent fixed_size_host_memory_resource blocks from
-    // returning to the pool even after unpin_table runs. Repositories are
+    // Drop scan-manager providers for this query. A pinned-mode ingestible's
+    // pinned_chunk_source holds shared_ptr copies of the pinned chunks, and
+    // batches it emitted hold host-chunk slices while in flight; resetting
+    // here (and tearing down the per-query operators) keeps per-query serving
+    // state from outliving the query, so fixed_size_host_memory_resource
+    // blocks return to the pool once unpin_table runs. Repositories are
     // already cleared above, so downstream data_batches that referenced
     // sliced host_data_representation are gone before we drop the providers.
     if (scan_manager_) { scan_manager_->reset(); }

--- a/test/cpp/integration/test_pin_table_column_order.cpp
+++ b/test/cpp/integration/test_pin_table_column_order.cpp
@@ -171,8 +171,8 @@ TEST_CASE("pin_table - cached scan serves columns in materialized order (column-
     REQUIRE(fb);
     REQUIRE_FALSE(fb->HasError());
 
-    // The cached-scan column ordering is tier-agnostic (both tiers share
-    // cached_databatch_provider), so exercise both. 'host' matches the originally reported
+    // The cached-scan column ordering is tier-agnostic (both tiers share the
+    // pinned-chunk serving path), so exercise both. 'host' matches the originally reported
     // configuration; 'gpu' is the tier the other pin tests use.
     for (auto const* tier : {"host", "gpu"}) {
       DYNAMIC_SECTION("pin tier = " << tier)

--- a/test/cpp/scan/test_can_serve_with_columns.cpp
+++ b/test/cpp/scan/test_can_serve_with_columns.cpp
@@ -15,7 +15,7 @@
  */
 
 // Unit tests for cache_entry_info::can_serve_with_columns — the pinned-cache match
-// used by sirius_scan_manager::try_assign_cached_entries. A pinned entry can serve
+// used by sirius_scan_manager::try_enter_pinned_serving. A pinned entry can serve
 // an incoming scan iff it has the same identity (parquet file set OR duckdb
 // catalog.schema.table) AND reads a superset of the requested columns; the result
 // is the gather projection (positions into the pinned entry's column layout) that

--- a/test/cpp/scan/test_pinned_chunk_source.cpp
+++ b/test/cpp/scan/test_pinned_chunk_source.cpp
@@ -1,0 +1,580 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// #819 PR2: pinned-entry serving rides the split_provider / metadata-task
+// machinery as a pinned-serving MODE of the format ingestibles, powered by
+// pinned_chunk_source.
+//
+// Unit gates cover the pieces bottom-up: build_pinned_chunk_source extraction
+// + validation (malformed entries throw -> disk fallback, replacing the old
+// silent truncation), pinned_chunk_source chunk claim + resident-batch
+// assembly (column subset/permutation, per-chunk memory_space, HOST slice),
+// the pass-through cached_batch_coalescer, and — through a minimal
+// pinned-only gpu_ingestible — the UNMODIFIED split_provider::run driving
+// pinned work items on real pool threads with the end-of-stream sentinel.
+//
+// The integration gate pins a parquet surface and SELECTs through it on a
+// single-GPU env, asserting the scan-manager log marker that only the
+// pinned serving path emits.
+
+#include "operator/mgpu_test_utils.hpp"
+#include "operator/operator_test_utils.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/table/table.hpp>
+
+#include <rmm/cuda_stream.hpp>
+
+#include <cuda_runtime.h>
+
+#include <catch.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/memory/memory_space.hpp>
+#include <data/sirius_converter_registry.hpp>
+#include <duckdb.hpp>
+#include <exec/scoped_dispatcher.hpp>
+#include <exec/thread_pool.hpp>
+#include <op/scan/gpu_ingestible.hpp>
+#include <op/scan/pinned_chunk_source.hpp>
+#include <scan_manager/sirius_scan_manager.hpp>
+#include <scan_manager/split_provider.hpp>
+#include <spdlog/spdlog.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+using sirius::op::scan::cached_batch_coalescer;
+using sirius::op::scan::cached_scan_info;
+using sirius::op::scan::pinned_chunk_source;
+using sirius::scan_manager::build_pinned_chunk_source;
+using sirius::scan_manager::pinned_entry;
+
+namespace {
+
+// Shared test environment: memory manager (+ converter registry) initialized
+// once for every unit gate in this file. The converter needs a non-default
+// stream (same constraint test_convertible_data_batch documents).
+struct test_env {
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> mgr;
+  cucascade::memory::memory_space* gpu_space;
+  cucascade::memory::memory_space* host_space;
+  rmm::cuda_stream conv_stream;
+
+  test_env()
+    : mgr(sirius::test::operator_utils::initialize_memory_manager()),
+      gpu_space(mgr->get_memory_space(cucascade::memory::Tier::GPU, 0)),
+      host_space(mgr->get_memory_space(cucascade::memory::Tier::HOST, 0)),
+      conv_stream()
+  {
+  }
+
+  rmm::cuda_stream_view stream() { return conv_stream.view(); }
+};
+
+test_env& env()
+{
+  static test_env e;
+  return e;
+}
+
+/// Deterministic per-cell value so a chunk/column/row mixup fails loudly.
+int32_t cell(std::size_t chunk, std::size_t col, std::size_t row)
+{
+  return static_cast<int32_t>(1000 * chunk + 100 * col + row);
+}
+
+std::shared_ptr<cudf::column> make_gpu_column(cucascade::memory::memory_space& space,
+                                              std::vector<int32_t> const& values)
+{
+  auto mr     = sirius::test::operator_utils::get_resource_ref(space);
+  auto stream = sirius::test::operator_utils::default_stream();
+  auto col    = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                       static_cast<cudf::size_type>(values.size()),
+                                       cudf::mask_state::UNALLOCATED,
+                                       stream,
+                                       mr);
+  cudaMemcpy(col->mutable_view().data<int32_t>(),
+             values.data(),
+             sizeof(int32_t) * values.size(),
+             cudaMemcpyHostToDevice);
+  return std::shared_ptr<cudf::column>(std::move(col));
+}
+
+/// GPU-tier pinned entry with columns {k, v, w} x @p n_chunks chunks of
+/// @p rows rows, every chunk placed in @p space.
+pinned_entry make_gpu_entry(cucascade::memory::memory_space& space,
+                            std::size_t n_chunks,
+                            std::size_t rows)
+{
+  pinned_entry entry;
+  entry.cache_info.names = {"k", "v", "w"};
+  entry.tier             = cucascade::memory::Tier::GPU;
+  entry.memory_space     = &space;
+  for (std::size_t c = 0; c < n_chunks; ++c) {
+    entry.chunk_memory_spaces.push_back(&space);
+    for (std::size_t col = 0; col < entry.cache_info.names.size(); ++col) {
+      std::vector<int32_t> values(rows);
+      for (std::size_t r = 0; r < rows; ++r) {
+        values[r] = cell(c, col, r);
+      }
+      entry.data_batches_by_column[entry.cache_info.names[col]].push_back(
+        make_gpu_column(space, values));
+    }
+  }
+  entry.num_rows = n_chunks * rows;
+  return entry;
+}
+
+/// HOST-tier pinned entry with columns {k, v} x @p n_chunks chunks, built the
+/// way the pin path builds them (GPU table -> converter -> host chunk).
+pinned_entry make_host_entry(test_env& e, std::size_t n_chunks, std::size_t rows)
+{
+  pinned_entry entry;
+  entry.cache_info.names = {"k", "v"};
+  entry.tier             = cucascade::memory::Tier::HOST;
+  entry.memory_space     = e.host_space;
+
+  auto& registry = sirius::converter_registry::get();
+  for (std::size_t c = 0; c < n_chunks; ++c) {
+    std::vector<std::unique_ptr<cudf::column>> cols;
+    for (std::size_t col = 0; col < entry.cache_info.names.size(); ++col) {
+      std::vector<int32_t> values(rows);
+      for (std::size_t r = 0; r < rows; ++r) {
+        values[r] = cell(c, col, r);
+      }
+      auto shared = make_gpu_column(*e.gpu_space, values);
+      cols.push_back(std::make_unique<cudf::column>(
+        shared->view(), e.stream(), e.gpu_space->get_default_allocator()));
+    }
+    cucascade::gpu_table_representation gpu_repr(
+      std::make_unique<cudf::table>(std::move(cols)), *e.gpu_space, e.stream());
+    auto host_repr =
+      registry.convert<cucascade::host_data_representation>(gpu_repr, e.host_space, e.stream());
+    e.stream().synchronize();
+    entry.host_chunks.emplace_back(std::move(host_repr));
+  }
+  entry.num_rows = n_chunks * rows;
+  return entry;
+}
+
+/// Run every remaining work item of @p source on the calling thread and
+/// return the produced cached_scan_infos.
+std::vector<std::unique_ptr<sirius::op::scan::scan_info>> drain(pinned_chunk_source& source)
+{
+  std::vector<std::unique_ptr<sirius::op::scan::scan_info>> infos;
+  while (auto work = source.next_work_item()) {
+    infos.push_back(work());
+  }
+  return infos;
+}
+
+/// Sort emitted infos by chunk index so assertions are order-independent.
+std::vector<cached_scan_info*> as_cached_sorted(
+  std::vector<std::unique_ptr<sirius::op::scan::scan_info>>& infos)
+{
+  std::vector<cached_scan_info*> cached;
+  for (auto& info : infos) {
+    auto* c = dynamic_cast<cached_scan_info*>(info.get());
+    REQUIRE(c != nullptr);
+    cached.push_back(c);
+  }
+  std::sort(cached.begin(), cached.end(), [](auto* a, auto* b) {
+    return a->chunk_index() < b->chunk_index();
+  });
+  return cached;
+}
+
+struct dummy_scan_info final : sirius::op::scan::scan_info {};
+
+struct dummy_table_info final : sirius::op::scan::ingestible_table_info {
+  [[nodiscard]] std::span<std::string const> column_names() const override { return {}; }
+  [[nodiscard]] std::span<std::string const> file_paths() const override { return {}; }
+};
+
+/// Minimal ingestible that ONLY serves pinned chunks — the shape every format
+/// ingestible takes in pinned mode. Lets the composition gate drive the
+/// UNMODIFIED split_provider over pinned work items without a real
+/// parquet/duckdb bind.
+struct pinned_only_ingestible final : sirius::op::scan::gpu_ingestible {
+  bool serve_from_pinned_chunks(std::unique_ptr<pinned_chunk_source> source) override
+  {
+    _pinned = std::move(source);
+    return true;
+  }
+
+  [[nodiscard]] bool has_processed_all_metadata() const override
+  {
+    return !_pinned || !_pinned->has_more();
+  }
+
+  metadata_scan_task_t next_split_provider(sirius::io::ioctx_resolver /*resolve*/) override
+  {
+    return _pinned ? _pinned->next_work_item() : nullptr;
+  }
+
+  std::unique_ptr<sirius::op::scan::batch_coalescer> create_batch_coalescer() const override
+  {
+    return std::make_unique<cached_batch_coalescer>();
+  }
+
+  sirius::op::scan::filtered_table materialize_metadata_to_table(
+    sirius::op::scan::scan_info const&,
+    cucascade::memory::memory_space const&,
+    rmm::cuda_stream_view) override
+  {
+    throw std::logic_error("unreachable: resident batches never materialize metadata");
+  }
+
+  std::unique_ptr<cudf::table> post_filter_and_project(sirius::op::scan::filtered_table&&,
+                                                       cucascade::memory::memory_space const&,
+                                                       rmm::cuda_stream_view) override
+  {
+    throw std::logic_error("unreachable in this test");
+  }
+
+  [[nodiscard]] sirius::op::scan::ingestible_table_info const& table_info() const noexcept override
+  {
+    return _tinfo;
+  }
+
+  [[nodiscard]] std::vector<std::size_t> materialized_column_order() const override { return {}; }
+
+ private:
+  dummy_table_info _tinfo;
+  std::unique_ptr<pinned_chunk_source> _pinned;
+};
+
+/// Drive provider.run() on a real pool the way start_metadata_processing
+/// does, collecting everything the provider pushes plus the pushing threads.
+struct run_result {
+  std::vector<std::unique_ptr<sirius::op::scan::scan_info>> infos;
+  int empties    = 0;
+  int exceptions = 0;
+  std::set<std::thread::id> value_threads;
+};
+
+run_result drive(sirius::scan_manager::split_provider& provider)
+{
+  sirius::exec::static_thread_pool pool(4, "pinned_chunk_test");
+  run_result out;
+  {
+    sirius::exec::scoped_dispatcher dispatcher(pool, 4);
+    std::mutex mtx;
+    provider.run(dispatcher, [&](sirius::scan_manager::split_provider::value_type&& entry) {
+      std::lock_guard lk(mtx);
+      if (entry.has_exception()) {
+        ++out.exceptions;
+      } else if (entry.is_empty()) {
+        ++out.empties;
+      } else {
+        out.value_threads.insert(std::this_thread::get_id());
+        out.infos.push_back(std::move(entry).value());
+      }
+    });
+    dispatcher.wait_for_all();
+    // The end-of-stream sentinel fires when the last work item drops its
+    // completion token, which can trail wait_for_all by an instant.
+    for (int spin = 0; spin < 5000; ++spin) {
+      {
+        std::lock_guard lk(mtx);
+        if (out.empties + out.exceptions > 0) { break; }
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+  return out;
+}
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// build_pinned_chunk_source + pinned_chunk_source unit gates
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("pinned_chunk_source serves GPU chunks with a permuted column subset",
+          "[pinned_chunk_source][scan_manager]")
+{
+  auto& e                       = env();
+  constexpr std::size_t kChunks = 3;
+  constexpr std::size_t kRows   = 8;
+  auto entry                    = make_gpu_entry(*e.gpu_space, kChunks, kRows);
+
+  // Permuted subset: serve {w, k} out of {k, v, w}.
+  std::vector<std::size_t> selection{2, 0};
+  auto source = build_pinned_chunk_source(entry, selection);
+  REQUIRE(source->num_chunks() == kChunks);
+  REQUIRE(source->has_more());
+
+  auto infos = drain(*source);
+  REQUIRE_FALSE(source->has_more());
+  REQUIRE(source->next_work_item() == nullptr);  // exhausted claims stay null
+  REQUIRE(infos.size() == kChunks);
+
+  auto cached = as_cached_sorted(infos);
+  for (std::size_t c = 0; c < kChunks; ++c) {
+    REQUIRE(cached[c]->chunk_index() == c);
+    auto batch = cached[c]->take_batch();
+    REQUIRE(batch != nullptr);
+    {
+      auto ro = batch->to_read_only();
+      REQUIRE(ro.get_memory_space() == entry.chunk_memory_spaces.at(c));
+    }
+    auto view = sirius::get_cudf_table_view(*batch);
+    REQUIRE(view.num_columns() == static_cast<cudf::size_type>(selection.size()));
+    REQUIRE(view.num_rows() == static_cast<cudf::size_type>(kRows));
+    auto w = sirius::test::operator_utils::copy_column_to_host<int32_t>(view.column(0));
+    auto k = sirius::test::operator_utils::copy_column_to_host<int32_t>(view.column(1));
+    for (std::size_t r = 0; r < kRows; ++r) {
+      REQUIRE(w[r] == cell(c, 2, r));
+      REQUIRE(k[r] == cell(c, 0, r));
+    }
+  }
+}
+
+TEST_CASE("pinned_chunk_source serves HOST chunks as sliced resident batches",
+          "[pinned_chunk_source][scan_manager]")
+{
+  auto& e                       = env();
+  constexpr std::size_t kChunks = 2;
+  constexpr std::size_t kRows   = 16;
+  auto entry                    = make_host_entry(e, kChunks, kRows);
+
+  std::vector<std::size_t> selection{1};  // just {v}
+  auto source = build_pinned_chunk_source(entry, selection);
+  REQUIRE(source->num_chunks() == kChunks);
+
+  auto infos = drain(*source);
+  REQUIRE(infos.size() == kChunks);
+
+  auto cached = as_cached_sorted(infos);
+  for (std::size_t c = 0; c < kChunks; ++c) {
+    REQUIRE(cached[c]->chunk_index() == c);
+    auto batch = cached[c]->take_batch();
+    REQUIRE(batch != nullptr);
+    auto ro = batch->to_read_only();
+    REQUIRE(ro.get_memory_space()->get_tier() == cucascade::memory::Tier::HOST);
+    REQUIRE(ro.get_data()->get_size_in_bytes() > 0);
+  }
+}
+
+TEST_CASE("build_pinned_chunk_source: zero-chunk entry yields an empty source",
+          "[pinned_chunk_source][scan_manager]")
+{
+  auto& e = env();
+  pinned_entry entry;
+  entry.cache_info.names = {"k"};
+  entry.tier             = cucascade::memory::Tier::GPU;
+  entry.memory_space     = e.gpu_space;
+
+  auto source = build_pinned_chunk_source(entry, std::vector<std::size_t>{0});
+  REQUIRE(source->num_chunks() == 0);
+  REQUIRE_FALSE(source->has_more());
+  REQUIRE(source->next_work_item() == nullptr);
+}
+
+TEST_CASE("build_pinned_chunk_source refuses malformed entries",
+          "[pinned_chunk_source][scan_manager]")
+{
+  auto& e = env();
+
+  SECTION("per-column chunk counts disagree")
+  {
+    auto entry = make_gpu_entry(*e.gpu_space, 3, 4);
+    entry.data_batches_by_column["v"].pop_back();  // v now has 2 chunks, k/w have 3
+    REQUIRE_THROWS_AS(build_pinned_chunk_source(entry, std::vector<std::size_t>{0, 1, 2}),
+                      std::runtime_error);
+  }
+
+  SECTION("chunk_memory_spaces does not cover every chunk")
+  {
+    auto entry = make_gpu_entry(*e.gpu_space, 3, 4);
+    entry.chunk_memory_spaces.resize(1);
+    REQUIRE_THROWS_AS(build_pinned_chunk_source(entry, std::vector<std::size_t>{0}),
+                      std::runtime_error);
+  }
+
+  SECTION("null host chunk")
+  {
+    auto entry           = make_host_entry(e, 2, 4);
+    entry.host_chunks[1] = nullptr;
+    REQUIRE_THROWS_AS(build_pinned_chunk_source(entry, std::vector<std::size_t>{0}),
+                      std::runtime_error);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// cached_batch_coalescer unit gates
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("cached_batch_coalescer passes cached splits through unchanged",
+          "[pinned_chunk_source][scan_manager]")
+{
+  cached_batch_coalescer c;
+  auto out = c.push(std::make_unique<cached_scan_info>(nullptr, /*chunk_index=*/5));
+  REQUIRE(out.size() == 1);
+  auto* cached = dynamic_cast<cached_scan_info*>(out[0].get());
+  REQUIRE(cached != nullptr);
+  REQUIRE(cached->chunk_index() == 5);
+  REQUIRE(c.flush().empty());
+}
+
+TEST_CASE("cached_batch_coalescer drops foreign splits and never emits on flush",
+          "[pinned_chunk_source][scan_manager]")
+{
+  cached_batch_coalescer c;
+  REQUIRE(c.push(std::make_unique<dummy_scan_info>()).empty());
+  // flush must emit nothing at all — a zero-chunk pin relies on closing with
+  // zero splits (no template-split fallback like the disk coalescers).
+  REQUIRE(c.flush().empty());
+}
+
+//===----------------------------------------------------------------------===//
+// Plain-provider composition gate: the UNMODIFIED split_provider drives a
+// pinned-mode ingestible's work items on dispatcher threads.
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("split_provider drives pinned-mode work items on pool threads",
+          "[pinned_chunk_source][scan_manager]")
+{
+  auto& e                       = env();
+  constexpr std::size_t kChunks = 3;
+  auto entry                    = make_gpu_entry(*e.gpu_space, kChunks, /*rows=*/4);
+
+  pinned_only_ingestible ingestible;
+  REQUIRE(ingestible.serve_from_pinned_chunks(
+    build_pinned_chunk_source(entry, std::vector<std::size_t>{0, 1, 2})));
+  REQUIRE_FALSE(ingestible.has_processed_all_metadata());
+
+  sirius::scan_manager::split_provider provider(ingestible, /*resolve=*/{});
+  auto out = drive(provider);
+
+  REQUIRE(out.exceptions == 0);
+  REQUIRE(out.empties >= 1);  // end-of-stream sentinel
+  REQUIRE(out.infos.size() == kChunks);
+  REQUIRE(ingestible.has_processed_all_metadata());
+  // Work items ran on pool threads, not the driving thread.
+  REQUIRE_FALSE(out.value_threads.empty());
+  REQUIRE(out.value_threads.find(std::this_thread::get_id()) == out.value_threads.end());
+
+  auto cached = as_cached_sorted(out.infos);
+  for (std::size_t c = 0; c < kChunks; ++c) {
+    REQUIRE(cached[c]->chunk_index() == c);
+    REQUIRE(cached[c]->take_batch() != nullptr);
+  }
+}
+
+TEST_CASE("split_provider emits only the sentinel for a zero-chunk pinned source",
+          "[pinned_chunk_source][scan_manager]")
+{
+  auto& e = env();
+  pinned_entry entry;
+  entry.cache_info.names = {"k"};
+  entry.tier             = cucascade::memory::Tier::GPU;
+  entry.memory_space     = e.gpu_space;
+
+  pinned_only_ingestible ingestible;
+  REQUIRE(ingestible.serve_from_pinned_chunks(
+    build_pinned_chunk_source(entry, std::vector<std::size_t>{0})));
+
+  sirius::scan_manager::split_provider provider(ingestible, /*resolve=*/{});
+  auto out = drive(provider);
+
+  REQUIRE(out.infos.empty());
+  REQUIRE(out.exceptions == 0);
+  REQUIRE(out.empties >= 1);  // the connector still gets closed downstream
+}
+
+//===----------------------------------------------------------------------===//
+// Integration gate: a pinned scan is served through the pinned-mode
+// ingestible + plain provider (the log marker below is only emitted on that
+// path in prepare_for_query).
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("pinned serving handles pin_table scans end to end",
+          "[pinned_chunk_source][scan_manager][pin_table]")
+{
+  namespace mgpu = sirius::test::mgpu;
+
+  auto tmp = fs::temp_directory_path() / ("sirius-pinned-source-" + std::to_string(::getpid()));
+  std::error_code ec;
+  fs::remove_all(tmp, ec);
+  fs::create_directories(tmp);
+
+  mgpu::generate_parquet_surface(
+    tmp, "SELECT range AS k, range * 2 AS v FROM range(100000)", /*num_files=*/2);
+
+  mgpu::mgpu_env_params params;
+  params.num_gpus = 1;
+  auto yaml_path  = tmp / "pinned_source.yaml";
+  mgpu::write_mgpu_yaml(yaml_path, params);
+
+  mgpu::scoped_log_dir logs(tmp / "logs");
+  mgpu::scoped_mgpu_env env(yaml_path);
+  auto con = env.make_connection();
+
+  auto glob = mgpu::parquet_glob(tmp);
+  auto pin  = con.Query("CALL pin_table('" + glob + "', tier='gpu', name='pinned_source_gate');");
+  REQUIRE(pin);
+  if (pin->HasError()) { UNSCOPED_INFO("pin_table error: " << pin->GetError()); }
+  REQUIRE_FALSE(pin->HasError());
+
+  auto res =
+    con.Query("CALL gpu_execution(\"SELECT MAX(k), SUM(v) FROM read_parquet('" + glob + "')\");");
+  REQUIRE(res);
+  if (res->HasError()) { UNSCOPED_INFO("gpu_execution error: " << res->GetError()); }
+  REQUIRE_FALSE(res->HasError());
+  REQUIRE(res->GetValue(0, 0).GetValue<int64_t>() == 99999);
+
+  auto unpin = con.Query("CALL unpin_table('pinned_source_gate');");
+  REQUIRE(unpin);
+  REQUIRE_FALSE(unpin->HasError());
+
+  // Flush spdlog's file sink before reading the log dir (default flush cadence
+  // is seconds; the query completes well under it).
+  if (auto logger = spdlog::default_logger()) { logger->flush(); }
+
+  bool marker_found = false;
+  for (auto const& file : fs::directory_iterator(logs.path())) {
+    std::ifstream in(file.path());
+    std::string line;
+    while (std::getline(in, line)) {
+      if (line.find("served via pinned chunks") != std::string::npos) {
+        marker_found = true;
+        break;
+      }
+    }
+    if (marker_found) { break; }
+  }
+  INFO("expected the prepare_for_query pinned-serving marker in " << logs.path());
+  REQUIRE(marker_found);
+
+  fs::remove_all(tmp, ec);
+}

--- a/test/cpp/scan_manager/test_pin_table_multi_gpu.cpp
+++ b/test/cpp/scan_manager/test_pin_table_multi_gpu.cpp
@@ -244,14 +244,12 @@ TEST_CASE("pin_table - PIN-MGPU-01 routing via [mgpu-audit]",
     if (pin->HasError()) { UNSCOPED_INFO("pin_table error: " << pin->GetError()); }
     REQUIRE_FALSE(pin->HasError());
 
-    // Run a SELECT through the cached split provider. The scan_manager
-    // matches incoming parquet_scan_info::file_paths against the pinned
-    // entry's file_paths (sirius_scan_manager.cpp matches_scan_info
-    // lambda), so we reuse the same glob in read_parquet. Sirius's
-    // task_creator + cached_split_provider then emit one
-    // scan_cached_operator_data per chunk tagged with that chunk's
-    // memory_space, which the [mgpu-audit] hook in pipeline_executor.cpp
-    // and duckdb_scan_executor.cpp records.
+    // Run a SELECT through the pinned-chunk serving path. The scan_manager
+    // matches the incoming scan's file_paths against the pinned entry's
+    // file_paths, so we reuse the same glob in read_parquet. The pinned-mode
+    // ingestible then emits one resident scan_operator_input per chunk tagged
+    // with that chunk's memory_space, which the [mgpu-audit] hook in
+    // pipeline_executor.cpp and duckdb_scan_executor.cpp records.
     auto select_sql = "CALL gpu_execution(\"SELECT k, count(*) FROM read_parquet('" + glob +
                       "') WHERE k % 2 = 0 GROUP BY k LIMIT 10\");";
     auto select = con.Query(select_sql);
@@ -296,8 +294,8 @@ TEST_CASE("pin_table - PIN-MGPU-01 routing via [mgpu-audit]",
   // [mgpu-audit] has two emission sites in the codebase:
   //   - task_scheduler.cpp:275 emits "pipeline_task dispatched to GPU N
   //     task_id=K" — fires for EVERY pipeline_task dispatched. The
-  //     scan_cached_operator_data emitted per chunk by cached_split_provider
-  //     drives a pipeline_task on the chunk's home GPU, so this is the
+  //     resident scan_operator_input emitted per chunk by the pinned serving
+  //     path drives a pipeline_task on the chunk's home GPU, so this is the
   //     correct emission for the cached-pin routing gate.
   //   - duckdb_scan_executor.cpp:264 emits "scan_batch assigned to GPU N
   //     batch_id=K" — fires ONLY for the DuckDB-attach scan path
@@ -579,7 +577,7 @@ TEST_CASE("pin_table - host-tier cached path serves MAX(k) after overwrite (mult
 
   // Sanity check: query BEFORE overwriting to confirm pin → cached SELECT works
   // in this scenario. Use MAX(k) instead of count(*) — count(*) has a separate
-  // metadata-only optimization that bypasses the cached_split_provider's
+  // metadata-only optimization that bypasses the pinned serving's
   // column-selection path; MAX(k) requires the cached chunks to actually
   // surface the k column's values, which is exactly what host-tier caching
   // must serve.
@@ -784,8 +782,8 @@ TEST_CASE("pin_table - host-tier cached path serves SUM(v) after overwrite (mult
 // checked `entry.data_batches_by_column.contains(col_name)` per chunk —
 // after chunk 0 installed C, contains() returned true and chunks 1..N were
 // dropped. The pinned entry then had uneven chunk counts across columns,
-// which trips the cached_split_provider invariant and silently falls back
-// to uncached reads.
+// which trips build_pinned_chunk_source's coverage validation and silently
+// falls back to uncached reads.
 //
 // This gate generates a multi-chunk surface (large enough that the cudf
 // chunked_parquet_reader emits >=2 chunks per file at the default 100 MB


### PR DESCRIPTION
Part of #819 (query-time MVCC delta merge for pinned caches) — the serving reorg that PR3 (DELETE masks) and PR4 (INSERT delta) build on. **Behavior-identical: no MVCC logic in this PR.**

## What

Pinned/cached-entry serving moves off its dedicated coalescer-direct path and onto the same `split_provider` / metadata-task machinery disk scans use. On a pin hit, `prepare_for_query` switches the operator's format ingestible into **pinned-serving mode** (`gpu_ingestible::serve_from_pinned_chunks`, default-false virtual) and the plain, unmodified `split_provider` fans the resident chunks out as work items on the scan manager's dispatcher threads. The serving tail is now uniform — cached and disk scans both live in `_providers_by_op` and are driven by `start_metadata_processing`; the entire `databatch_provider` / `use_cached_entries_for_pipeline` / `process_cached_entries` bypass is deleted.

## Pieces

- **`pinned_chunk_source`** (op/scan): self-contained chunk inventory built by the scan manager from a matched pinned entry (`shared_ptr` copies, no reference into the pinned-entries map); lock-free chunk claim + per-chunk resident batch assembly (GPU column wrap stamped with the chunk's `memory_space` / HOST slice), with per-batch telemetry attribution (#1068's `quent_data_batch_probe`) preserved.
- **`cached_scan_info`**: the format-neutral resident-split carrier. The sequencer's emit path unwraps it into a resident `scan_operator_input` and skips the balancer call, so `task_creator` keeps routing pinned scans by the batch's `memory_space` (home-GPU / NUMA locality) and the shared round-robin cursor stays untouched for disk pipelines in mixed queries.
- **`cached_batch_coalescer`**: pass-through slot coalescer — pinned chunks were already batch-sized at pin time. `flush()` emits nothing, so a zero-chunk pin still closes its connector with zero splits.
- **Format ingestibles**: `duckdb_native_gpu_ingestible` and `parquet_gpu_ingestible` each gain the override plus three one-line pinned-mode forks in `has_processed_all_metadata` / `next_split_provider` / `create_batch_coalescer`.
- **`build_pinned_chunk_source`** validates the entry shape and throws (caught → disk fallback) where the old path silently truncated the scan mid-stream; work-item exceptions now surface as clean query errors (`try_t` → `connector->close(exception)`) instead of an unclosed-connector hang.

## Why this shape (for #819)

MVCC is DuckDB-specific, so the serving seam is deliberately placed such that **all MVCC work lands in `duckdb_native_gpu_ingestible`'s pinned mode** in PR3/PR4 — visibility work items on dispatcher threads, a mask-join coalescer variant, and delta splits decoded by its own `materialize_metadata_to_table` — next to the DuckDB table handles, serial-prep discipline, and decode machinery it needs. The shared pieces (`pinned_chunk_source`, `cached_scan_info`, the pass-through coalescer) stay format-neutral and MVCC-free permanently; parquet's pinned mode is trivial forever. This also follows the IO-framework refactor's direction: `split_provider` stays a concrete class composing `gpu_ingestible` (no provider subclasses).

## Intentional divergences (all edge-case, all strictly better)

- A work-item exception used to be swallowed (connector never closed → query hang, later pipelines starved); it now propagates as a query error.
- A malformed pinned entry (uneven per-column chunk counts, short `chunk_memory_spaces`, null host chunk) used to truncate the scan silently; it now throws in the builder and falls back to the disk read.
- Chunk emission order within one scan is completion-order instead of index-order (splits are independent tasks; cross-pipeline order is still sequencer-enforced).
- Cached serving is now stop-token-aware during teardown.

## Verification

- New `[pinned_chunk_source]` gates (9 cases, 130 assertions): source claim/assembly with a permuted column subset, per-chunk `memory_space` preservation, HOST slice, zero-chunk close, builder validation throws, coalescer pass-through/foreign-drop/empty-flush, the unmodified `split_provider::run` driving pinned work items on pool threads with the end-of-stream sentinel, and an end-to-end pin → SELECT gate asserting the pinned-serving log marker.
- Behavior-identical suites pass unchanged: `[pin_table]`, `[pin_table_host]`, `[pin_table_duckdb]`, `[pin_table_duckdb_host]`, `[pin_table_cols_subset]`, `[pin_table_host_streaming]` (GPU high-water preserved), `[host_serve]` (served-from-pin-not-disk proof), merge and column-order regressions, `[can_serve]`.
- Disk-path regressions: `[duckdb_native]`, `[overflow_string]`, `[parquet_schema_mapping]`, `[scan][batch_coalescer]`.

Draft until the multi-GPU gates (`[pin_mgpu]`) run on a 2-GPU box (this branch was validated on a single-GPU GB10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
