### PR TITLE
Issue 1010

### DIFF
--- a/docs/super-sirius/issue-1010-dynamic-filter-sip-design.md
+++ b/docs/super-sirius/issue-1010-dynamic-filter-sip-design.md
@@ -1,0 +1,1181 @@
+# General Dynamic Filters: Sideways Information Passing at Hash-Join Probe Inputs
+
+**Status:** finalized proposal — converged after cross-review (Claude ↔ Codex); ready for
+implementation planning
+
+**Baseline:** Phase 1 dynamic table-filter pushdown, merged by
+[#794](https://github.com/sirius-db/sirius/pull/794); all `file:line` references below are at
+`dev` commit `506a1d9f` unless a pinned DuckDB file is named.
+
+**Targets:** [#1010](https://github.com/sirius-db/sirius/issues/1010) (extend dynamic filtering to
+non-scan probe inputs) and [#1014](https://github.com/sirius-db/sirius/issues/1014) (remove the
+unbounded global build-task preference after measurement). v1 intentionally covers only
+DuckDB-admitted producer/key candidates; it does not claim every theoretically valid SIP shape.
+
+**Related:** [dynamic-filters.md](dynamic-filters.md),
+[dynamic-filters-multi-gpu.md](dynamic-filters-multi-gpu.md).
+
+---
+
+## Decision summary
+
+1. **The new consumer is an intermediate hash join's probe checkpoint.** For a producing join `P`
+   and a different hash join `C` in `P`'s probe subtree, membership filters are applied after
+   `C`'s probe `CONCAT`/repository pop and immediately before `C` prepares keys and hashes the
+   probe batch. This is the Phase 2 consumer described by `dynamic-filters.md`; it is not a unary
+   operator inserted in the pre-partition feeder.
+
+2. **Scan and join-probe consumption are layered.** DuckDB-provided scan consumers remain wired.
+   Sirius additionally installs a dedicated consumer at every eligible intermediate hash-join
+   probe on the admitted branch. The scan is the earliest pruning opportunity; each join-probe
+   checkpoint catches batches that passed an earlier checkpoint before publication. Filter
+   construction and device replication happen once; immutable filter objects fan out to separate
+   consumer channels.
+
+3. **DuckDB is authoritative for candidate admission, not GPU representation.** v1 creates a
+   producer/key candidate only when the pinned DuckDB `JOIN_FILTER_PUSHDOWN` pass emitted
+   `JoinFilterPushdownInfo` with non-empty `probe_info`, and only for condition indexes named by
+   DuckDB. Sirius may narrow that set. Sirius deliberately retains its own GPU materialization
+   policy (exact-set/Bloom/none membership plus an independently optional zone map); it does not
+   claim to reproduce DuckDB's CPU runtime choice of min/max, optional IN, or optional Bloom.
+
+4. **Discovery, physical resolution, and topology freeze are explicit.** After binding resolution
+   but before recursive planning moves logical conditions, a pure pass creates pending target
+   values, channels, and logical-node tokens. `create_plan` resolves both endpoints despite the
+   child-before-parent order. After pipeline conversion proves branch/runtime identity, one
+   finalizer freezes producer and consumer plans together. Runtime sees no DuckDB pointers or
+   mutable pending route state.
+
+5. **v1 is opportunistic, without predicting coverage.** Every probe batch applies whatever
+   complete filters are visible. No existing hint or scheduler behavior is treated as an ordering
+   contract: an intervening join's sibling-build hint drives that join's build, not the outer
+   filter producer. C3 measures whether opportunistic join-probe checkpoints see enough filters.
+   If not, a narrowly admitted, exactly-once ordered activation protocol lands before default-on.
+
+6. **#1014 is measure → disable → delete, not an asserted memory win.** The existing pass only
+   reorders already-created feeder tasks; it is not a bound on live hash tables. Instrument first,
+   run the legacy/off comparison, default it off only if coverage, wall time, and resident memory
+   pass, retain a rollback release, and then delete it. If the gate fails, land route-local
+   ordering and repeat; do not replace it with another global join-aware scheduler policy.
+
+7. **Phase 0 is deferred by decision (2026-07-08): no fork, no backport.** The pinned DuckDB
+   v1.5.4 target walk crosses `LIMIT`/`TOP_N`, an upstream wrong-results bug fixed by
+   duckdb/duckdb#22963. The exposure is latent at default settings (masked by
+   `late_materialization`, `compressed_materialization`, and scheduling races) and already exists
+   in merged Phase 1; Sirius's own SIP crossing rules stop at row selectors, so this work does not
+   widen it. We accept the latent risk and pick up the fix at the next pin bump to a released
+   DuckDB containing it (tracked in sirius-db/sirius#1123). Two rules survive the deferral: an
+   unpatched CPU run is never an oracle for LIMIT/TOP-N-shaped tests, and the pin-bump ships the
+   sentinel regressions (§ "Phase 0").
+
+---
+
+## Scope and non-goals
+
+### v1 scope
+
+- Producer: a Sirius `BUILD_PROBE` hash join whose DuckDB metadata contains a non-empty dynamic
+  filter target and whose producing semantics pass the Sirius gates below.
+- Filter kinds: existing Phase 1 membership filters; scan targets may also retain existing zone
+  maps. No new filter representation.
+- Consumers: existing scan reader/post-decode endpoints plus branch-local probe checkpoints in
+  intermediate Sirius equality hash joins running in BUILD_PROBE or STANDARD mode.
+- Candidate source: pinned DuckDB metadata only. Sirius traces placement but does not invent a
+  producer/key absent from DuckDB's candidate set.
+- Runtime: opportunistic per-batch consumption behind a default-off SIP flag, followed by measured
+  default-on or a route-local ordered phase.
+
+### Explicit non-goals
+
+- Producing filters from STANDARD/partitioned joins.
+- Candidate discovery for keys for which DuckDB found no scan target.
+- Mixed-provenance composite keys rejected by DuckDB's all-or-nothing target walk.
+- Aggregate, window, set-operation, CTE/materialization, or shared-source crossing.
+- Applying a producer's filter at its own authoritative probe.
+- Moving filtering into the global scheduler, blocking a worker, or waiting with wall-clock
+  timeouts.
+- Exact parity with DuckDB's CPU filter representation and cost heuristics.
+
+---
+
+## Verified execution-model facts
+
+These facts determine the design; they are not assumptions delegated to implementation.
+
+**The required point is after the consumer join's probe repository.** Sirius splits every
+intermediate join with `PARTITION` + `CONCAT` (`src/pipeline/sirius_pipeline_converter.cpp:459-575`).
+A unary operator placed before a join in the pre-split chain becomes part of the feeder before
+that pair. It cannot revisit a batch that already passed the unary operator and is queued in the
+partition/concat repositories. The Phase 2 catch-up point is instead inside the consuming hash
+join, after it obtains its branch-specific probe batch and before the first
+`prepare_join_keys(..., is_left_side=true)`/hash operation
+(`src/op/sirius_physical_hash_join.cpp:910-1315` — BUILD_PROBE probe keys at `:975`, the STANDARD
+probe path from `:1057`; the checkpoint must cover both since STANDARD joins are eligible
+consumers, and the original probe batch is re-read at many later sites — `:983,:990,:1021,:1057,
+:1094,:1238,:1289` — which is exactly why the `probe_batch_handle` discipline below is mandatory).
+
+**There is no happens-before edge from an outer producer to an intermediate consumer.**
+`setup_pipeline_parents` rebuilds dependencies from repository wiring
+(`sirius_pipeline_converter.cpp:1140-1173`). The producer build subtree and a lower join's probe
+pipeline are normally unordered. Publication may precede a probe batch, land between batches, or
+arrive after the consumer drains. Opportunistic consumption is correctness-safe in all three
+cases; only its benefit changes.
+
+**The intervening join's build hint is not the filter producer's hint.** A probe `PARTITION` can
+delegate to its own build sibling until partition count is known
+(`src/op/sirius_physical_partition.cpp:264-312`). In a SIP route, that drives consumer `C`'s build,
+not outer producer `P`'s build. The design makes no early-publication prediction from this fact.
+
+**Hints are stateful.** `sirius_physical_hash_join::get_next_task_hint` transitions
+`NOT_BUILT → SCHEDULING` while returning `READY`; task-input creation performs
+`SCHEDULING → SCHEDULED` (`sirius_physical_hash_join.cpp:486-547`). Any ordered gate must run
+before hint resolution, not between the hint and input pop.
+
+**The priority pass only reorders queued feeder tasks.**
+`collect_filter_build_pipelines` finds pipelines feeding plan-wired producer build ports, and the
+management loop prefers compatible queued tasks from that set
+(`src/pipeline/task_scheduler.cpp:164-214,404-416`). It does not create tasks, preempt work, limit
+live producers, or directly prioritize the join task that pins the build batch and constructs the
+hash table. Its downstream memory effect is empirical.
+
+**Publication is conditional.** Only runtime `BUILD_PROBE` publishes
+(`sirius_physical_hash_join.cpp:1319-1428`). STANDARD/MIXED resolution, empty build, downgraded or
+unavailable build data, policy suppression, a drained target, failure, and cancellation can all
+produce no usable filter. Opportunistic consumers simply pass through; ordered consumers require
+a terminal completion outcome for every path.
+
+**The existing channel is N-producer/one-consumer.** A Phase 1 scan's
+`DynamicTableFilterSet` may be referenced by several producing joins. Its Sirius channel is closed
+by one logical scan consumer and accepts filters from multiple producers
+(`src/include/op/sirius_dynamic_filter.hpp:389-417`). A SIP endpoint is different: it gets a
+dedicated one-producer/one-consumer channel so its close, gate, telemetry, and possible activation
+state cannot affect the scan or another join.
+
+**`BUILD_PROBE` state is a resident floor only after the join task runs.** The build batch is pinned
+and the persistent hash table is constructed in `sirius_physical_hash_join::execute`
+(`:927-969`), then held until finalize (`:1420-1427`). Filter replicas are likewise query-lived.
+Repository batches before that point remain subject to normal downgrade behavior. Telemetry must
+measure these lifecycle stages separately.
+
+**Two current planner signals are dead post-resolver.** `build_key_domain_cardinalities` and
+`trace_binding_to_get` expect `BOUND_COLUMN_REF`, while `ColumnBindingResolver` has already
+rewritten join conditions to `BoundReferenceExpression`. Domain coverage is therefore unknown and
+the current publisher gate is inert. Candidate extraction after the resolver is still useful:
+`cond.left.index` identifies the producing join's left-child output position, from which the
+corresponding `ColumnBinding` can be recovered via the child's bindings.
+
+---
+
+## Issue #1014: measure, disable, then delete the priority pass
+
+The target end state is a filter-agnostic scheduler. The current global pass is a layering
+violation—the scheduler `dynamic_cast`s to a hash join and reads dynamic-filter policy—but
+correctness-safe deletion does not by itself prove a memory reduction or impose a numerical
+concurrency bound.
+
+### Sequence
+
+1. **A1 — instrumentation only.** Add query-level resident high-water, task/build lifecycle
+   counts, and channel coverage telemetry without changing dispatch.
+2. **A2 — controlled opt-out.** Add
+   `dynamic_filter_build_priority={legacy,off}`, default `legacy`, retaining the implementation.
+3. **A3 — default-off cutover.** If the acceptance gate passes, default to `off` while preserving
+   the rollback switch for one release.
+4. **A4 — deletion.** After the default-off release confirms the result, delete
+   `collect_filter_build_pipelines`, `_filter_build_pipelines`, and the priority `pop_if` branch.
+
+### Acceptance gate
+
+Run three configurations—dynamic filters disabled, enabled with legacy priority, and enabled with
+priority off—on nested/star TPC-H shapes plus a synthetic many-join chain. Record:
+
+- relational/bag-equivalent results (exact row order only for order-guaranteed queries) and wall
+  time;
+- rows/batches reaching scan and SIP channels before/after publication;
+- per-memory-space resident high-water;
+- queued/running prioritized feeder tasks;
+- build batches delivered to joins;
+- live pinned `BUILD_PROBE` batches and live persistent hash tables; and
+- resident filter-replica bytes.
+
+The distinction is load-bearing: the pass directly controls only queued-task selection. It may
+affect later residency indirectly, but the design does not assume the sign or size of that effect.
+
+Coverage is diagnostic rather than an independent veto: the gate passes only when priority-off has
+no material wall-time or resident-peak regression outside measured run variance, while coverage
+explains any movement. A lower peak is a hypothesis, not a premise.
+
+If lost join-probe coverage causes a regression, keep the rollback path, land measured route-local
+ordering, and repeat. Ordered join-probe activation cannot recover lost Parquet pruning or decode
+avoidance. A material scan-I/O regression retains the rollback unless a separately reviewed,
+bounded scan-split deferral exists. Track C is not presumed to recover A2 losses.
+
+### Why not CAP or STAGGER by default
+
+CAP and STAGGER retain join/filter topology in the global scheduler and need producer grouping,
+in-flight counts, and consumer-liveness state that do not exist today. A hardware-tuned cap has no
+principled default, and a consumer-liveness heuristic can still activate many bushy branches.
+Own-consumer staggering also fails its stated goal for the case that matters most: a transitive
+producer's own consumer sits high in the plan and becomes live late, so staggering delays that
+build further and its filter reaches the fact scan later, not earlier.
+Route-local ordered activation, if measurement requires it, expresses the actual dependency and
+admits at most one ordered producer per runtime consumer pipeline. It is the preferred recovery.
+
+Resolving #1014 means removing the unbounded global preference after this gate. It does not mean
+that priority deletion alone bounds the total number of hash tables a query may legitimately use.
+
+---
+
+## Phase 0: repair the pinned DuckDB candidate source
+
+> **Status: deferred (2026-07-08).** No Sirius-owned fork or backport. The fix is picked up at the
+> next pin bump to a released DuckDB containing duckdb/duckdb#22963; the sentinel regressions
+> below land with that bump. Until then the latent Phase 1 exposure is accepted, Phase 0 blocks
+> nothing (C1c/C1e/C3 enablement proceeds), and the only standing obligations are: never use an
+> unpatched CPU run as an oracle for LIMIT/TOP-N-shaped tests, and keep Sirius's own crossing
+> rules stopping at row selectors (which also lets C3's lineage pass drop a traced target whose
+> branch crosses a selector, when SIP is on). Tracked in sirius-db/sirius#1123; the B cluster doc
+> is the pin-bump playbook.
+
+Pinned DuckDB v1.5.4 treats `LOGICAL_LIMIT` and `LOGICAL_TOP_N` as transparent while walking a
+probe subtree (`duckdb/src/optimizer/join_filter_pushdown_optimizer.cpp:58-72`). Applying a
+build-derived predicate below either row-selection operator can change the selected relation.
+Upstream duckdb/duckdb#22963 (`4c8c90db44`) makes both terminal.
+
+This exposure already affects merged Phase 1; it is not introduced by SIP. At the pin bump:
+
+1. Backport `4c8c90db44` onto a clean-clone-reachable Sirius-owned DuckDB branch, updating
+   `.gitmodules` and the gitlink, or advance to a verified release containing it.
+2. Keep the upstream SQL tests and add Sirius variants whose LIMIT/TOP-N input is produced by
+   another join.
+3. Use explicit expected rows, or join-filter-pushdown-disabled execution, as the oracle. An
+   affected unpatched DuckDB CPU run is not a correctness oracle.
+4. On the patched pin, verify CPU, GPU filters-off, Phase 1 on, and SIP on against that oracle.
+   Keyed by publication-plan/target ID, assert that the outer producer does not cross LIMIT/TOP-N; a join
+   wholly inside the selector input may still produce a legal local route.
+
+Do not reimplement this target walk merely to route around the bug. The adapter consumes the
+corrected DuckDB contract; the Sirius placement walk only chooses additional consumers for an
+already-admitted candidate.
+
+---
+
+## DuckDB candidate contract
+
+### Candidate parity, not materialization parity
+
+The normative invariant is:
+
+```text
+Sirius producer/key candidates ⊆ pinned DuckDB optimizer candidates
+
+Sirius runtime filter kinds need not equal DuckDB runtime filter kinds
+```
+
+A producing join enters the v1 candidate set iff:
+
+```text
+filter_pushdown != nullptr
+&& !filter_pushdown->probe_info.empty()
+&& at least one filter_pushdown->join_condition entry passes Sirius's gates
+```
+
+A non-null object with empty `probe_info` is statistics-only: DuckDB retained aggregates for
+perfect-hash planning but found no dynamic-filter target. Sirius creates neither a scan route nor a
+SIP route for it.
+
+Conversely, non-empty `probe_info` means DuckDB planned a dynamic table-filter path for the named
+key/target (normally at least min/max, subject to empty/NULL runtime outcomes). Sirius therefore
+never materializes for a producer/key that DuckDB would not attempt; only the GPU representation
+and cost decision may differ.
+
+DuckDB's physical hash join selects min/max, optional IN, and optional Bloom using DuckDB settings,
+hash-table state, cardinality estimates, perfect-hash state, and CPU cost assumptions
+(`duckdb/src/execution/operator/join/physical_hash_join.cpp:714-905`). Sirius does not execute that
+physical path. For an admitted key it independently chooses its GPU representation or suppresses
+materialization. Telemetry records candidate admission and the two independently materializable
+capabilities:
+
+```text
+duckdb_candidate = absent | statistics_only | admitted
+membership_materialization = exact_set | bloom | none(reason)
+zone_map_materialization = emitted | none(reason)
+```
+
+`build_side_has_filter` is snapshotted as `duckdb_build_subtree_has_filter_hint`. It is one input to
+DuckDB's Bloom heuristic, not route admission, not proof that the join key was reduced, and not
+evidence that DuckDB would actually materialize a Bloom.
+
+### Version-pinned adapter
+
+One `duckdb_join_filter_candidate_adapter` owns every version-sensitive read through two entry
+points:
+
+1. **Preservation**, called while the optimized DuckDB logical plan is copied.
+2. **Extraction**, called after `ColumnBindingResolver` and before recursive planning moves
+   `op.conditions` or children.
+
+Preservation retains exact shared `DynamicTableFilterSet` identity:
+
+```text
+copied_join.probe_info[t].dynamic_filters.get()
+    == copied_target_get.dynamic_filters.get()
+```
+
+This is a Phase 1 pairing invariant. Several producing joins may reference the same scan set; the
+adapter must not deep-copy or replace either endpoint independently.
+
+Extraction validates and fails closed on structural invariants it can prove locally:
+
+- out-of-range or duplicate `join_condition` indexes;
+- null target channel identities;
+- `probe_info[t].columns.size() != join_condition.size()`; and
+- a copied logical shape inconsistent with the pinned layout.
+
+The lineage pass later validates that target column ordinal `j` actually corresponds to resolved
+condition `join_condition[j]` along the selected branch. A base-table binding cannot be proven
+equivalent to a resolved positional condition inside the adapter alone. Failure drops that target
+rather than guessing the correspondence.
+
+It then emits Sirius-owned immutable values and preserves three distinct index spaces:
+
+```cpp
+struct admitted_dynamic_filter_key {
+  std::size_t duckdb_filter_ordinal;  // j in join_condition and probe_info[t].columns
+  std::size_t condition_index;        // reordered logical join condition
+  std::size_t sirius_key_ordinal;     // compact ordinal after Sirius narrowing
+};
+```
+
+`join_stats` is not correlated with these values; it uses a different/original condition order.
+Runtime publication never dereferences `JoinFilterPushdownInfo`.
+
+### Sirius narrowing gates
+
+Producer eligibility is release-mode fail-closed:
+
+- producing join type is INNER or SEMI;
+- producing execution mode is `BUILD_PROBE` at the publication claim;
+- routed comparison is `COMPARE_EQUAL`;
+- both keys are direct bound references after resolver indexing;
+- no key cast;
+- GPU membership type is supported; and
+- the route contains at least one live target.
+
+`COMPARE_NOT_DISTINCT_FROM` is excluded: NULL probe keys are matchable under null equality, while
+current membership masks null-propagate and would drop them. ANTI/MARK/outer-producing joins are
+excluded even if runtime mode selection can place some of them in `BUILD_PROBE`.
+
+Implement the join-type predicate as a fresh pure function of `join_type`. Do not derive it from
+`prove_unique_columns`' preservation switch (`sirius_plan_comparison_join.cpp:205-222`): that
+switch computes data-dependent uniqueness preservation (`left_preserved = right_keys_unique`, even
+for INNER), which is a different property from row retention and would mis-gate eligibility.
+
+### Deliberate v1 coverage limit
+
+DuckDB v1.5.4 walks the full candidate column vector as one unit. At a `LogicalGet`, one key whose
+binding belongs elsewhere rejects the whole target. Thus a composite key split across different
+sides of an intermediate join normally yields empty `probe_info`; Sirius never reaches per-key
+fan-out for that shape.
+
+Per-key fan-out remains useful for independently suppressing unsupported components of an already
+admitted target. It does not recover mixed-provenance candidates. Those require either an upstream
+per-key DuckDB descriptor or a separately reviewed Sirius discovery pass and belong to Track E.
+
+---
+
+## SIP topology and placement
+
+### Normative physical point
+
+For producing join `P` and a different intermediate hash join `C` in `P`'s probe subtree:
+
+```text
+C probe feeder
+  → PARTITION
+  → CONCAT
+  → C.default repository
+  → [SIP probe checkpoint]
+  → prepare_join_keys
+  → C hash probe
+```
+
+The checkpoint runs after `C` obtains its branch-specific probe batch and before any probe key
+cast, hash lookup, or join output allocation. It is a composed part of `C`'s probe execution, not a
+new physical source/sink in the converter.
+
+Consequences:
+
+- a batch decoded, partitioned, or queued before publication can still be filtered before `C`'s
+  hash probe;
+- shared upstream data is not mutated—the checkpoint owns or forwards `C`'s popped batch only;
+- partition-count selection, CONCAT folding, and positional sibling wiring remain untouched; and
+- the filter cannot save work already paid below `C`, including `C`'s input partition, but it can
+  save `C`'s probe and all work above it.
+
+`P` is never its own SIP consumer. Applying its build membership immediately before its own exact
+probe would save only a failed lookup while duplicating the same test.
+
+### Layered target model
+
+For each DuckDB-admitted producer/scan branch, retain:
+
+1. the existing scan reader and post-decode endpoint; and
+2. one dedicated SIP endpoint at every eligible intermediate hash-join probe on that branch.
+
+For a chain `scan → C1 → C2 → P`, the same filter may therefore be checked at the scan, `C1`'s
+probe, and `C2`'s probe. This is intentional:
+
+- the scan has the greatest possible savings when publication is early;
+- `C1` catches batches that missed the scan;
+- `C2` catches batches that missed both earlier checkpoints; and
+- independent gates disable redundant downstream masks after observing that they keep nearly all
+  already-filtered rows.
+
+Reaching the base scan suppresses only a duplicate checkpoint in that same scan pipeline. It never
+removes join-probe checkpoints already collected above intervening joins.
+If the admitted branch contains no intermediate join, Phase 1 remains the only consumer; v1 does
+not add a low-value checkpoint at `P`'s own probe.
+
+### Planner lineage pass
+
+Route discovery runs once on the resolved copied logical plan, before physical `create_plan`.
+For each admitted key and each `probe_info` target:
+
+1. Recover the starting `ColumnBinding` from the producing join's left-child bindings and the
+   resolved `cond.left.index`.
+2. Locate the target `LogicalGet` by its preserved `DynamicTableFilterSet` identity. Exactly one
+   matching GET is required per `probe_info` target; zero or multiple matches drop that target.
+3. Trace the exact branch toward that target, remapping the binding at each supported operator,
+   and require the final binding to equal `probe_info[target].columns[duckdb_filter_ordinal]`.
+4. Whenever the binding originates in an eligible intermediate join's left/probe child, record
+   that join as a consumer before continuing toward the target. The binding must resolve to
+   exactly one ordinal in that consumer's probe schema.
+5. Group independently traced keys by `(producer logical node, consumer logical node)`, compact
+   the supported subset, and deduplicate paths reaching the same pair.
+
+The pure result contains values, not physical pointers. Scan and join-probe ordinals are distinct
+strong types because they name different spaces: Phase 1 initially publishes in DuckDB
+`column_ids` space and lets the scan channel remap it, while SIP indexes `C`'s runtime probe
+schema.
+
+```cpp
+struct scan_target_key {
+  std::size_t sirius_key_ordinal;
+  duckdb_column_ids_index consumer_column;
+  std::optional<cudf::data_type> storage_type;
+};
+
+struct join_probe_target_key {
+  std::size_t sirius_key_ordinal;
+  probe_schema_ordinal consumer_column;
+};
+
+struct pending_join_probe_target {
+  dynamic_filter_publication_plan_id publication_plan_id;
+  dynamic_filter_target_id target_id;
+  logical_plan_node_id producer;
+  logical_plan_node_id consumer;
+  std::vector<join_probe_target_key> keys;
+  std::shared_ptr<sirius_dynamic_filter_set> channel;
+};
+```
+
+A query-local registry assigns `logical_plan_node_id` values and owns pending descriptors. During
+recursive planning:
+
+- building consumer `C` resolves every pending endpoint registered for `C`;
+- building producer `P` resolves the matching producer/key plan; and
+- neither side is frozen yet.
+
+The registry survives pipeline conversion. After runtime topology and branch contexts are known, a
+finalization pass validates branch uniqueness, the expected probe port/schema ordinal, and the
+producer's publication driver. It then freezes the producer publish plan and consumer endpoint
+plan together through single-assignment plan slots. Runtime reads only `shared_ptr<const ...>`
+snapshots. A rejected target is removed from both sides and its channel is closed as
+`PLANNING_REJECTED`; a consumer resolved before its producer later fails does not retain a dangling
+endpoint. The converter subsequently asserts this frozen invariant rather than mutating a const
+plan.
+
+Only after topology finalization are the temporary logical-node maps and pending builders
+destroyed.
+
+This intentionally uses planner lookups and a single freeze boundary. It is simpler and more
+testable than threading mutable pending state through every `create_plan` overload, rewriting an
+already-built deep physical subtree, or mutating an immutable producer plan during conversion.
+
+### Crossing rules
+
+Producer eligibility and path crossing are separate predicates.
+
+| Logical operator | DuckDB candidate behavior at the fixed pin | Sirius v1 placement behavior |
+|---|---|---|
+| Filter, ORDER BY without limit, DISTINCT | crosses | cross; binding unchanged |
+| Projection | crosses refs and supported integral casts | cross direct pass-through ref only; remap binding |
+| Intermediate comparison join | follows left child | for an equality INNER/SEMI join that is not MIXED, record its hash-probe consumer and continue left only when the binding comes from the left child; otherwise stop |
+| Aggregate | crosses plain group keys | stop conservatively |
+| LIMIT / TOP-N | terminal after Phase 0 | no v1 route below the row selector when it blocks the target |
+| WINDOW | unsupported/default terminal | stop |
+| UNNEST | conditionally crosses | stop conservatively |
+| UNION / INTERSECT / EXCEPT | remaps into selected children | stop at branching/fan-out boundary |
+| CTE, recursive, materialization, reusable source | varies | stop |
+| Computed expression or cast | candidate-dependent | stop |
+
+For every intermediate comparison join, a right/build-origin binding, an unproved join type, or a
+non-hash physical implementation stops descent. An endpoint collected for a logical comparison
+join is also dropped if physical planning does not produce the expected Sirius hash join.
+
+The extra Sirius stops are deliberate narrowing, not "mirroring #22963." If DuckDB itself stops
+and emits no target, v1 creates no route. If DuckDB admitted a scan target but Sirius stops while
+tracing placement, the already-collected lower join-probe endpoints remain valid and the scan
+route remains untouched.
+
+### Safety proof
+
+For ordinary equality, each published membership filter is a no-false-negative superset of `P`'s
+build keys. At a routed consumer `C`, the filtered column is an unchanged value from `C`'s probe
+input to `P`'s probe input. A row rejected at `C` cannot produce a descendant row whose key matches
+`P`; `P` would reject that lineage. `P` still rechecks every survivor authoritatively.
+
+v1 restricts intermediate consumers to INNER/SEMI joins and direct left-derived keys. This is
+conservative: broader predicate-commutation cases may exist, but they need independent proofs and
+do not expand the first production surface.
+
+### Branch and shared-source safety
+
+Discovery stops at logical CTE/materialization/reusable-source fan-out. The checkpoint itself is
+also branch-local because it runs after `C` pops from its own probe repository and produces a new
+filtered table; it never edits a shared upstream batch. Topology finalization uses the converted
+pipelines to require one branch-specific default probe context before either plan slot is frozen.
+Failure elides both target ends; subsequent converter/runtime checks only assert the frozen
+invariant. Valid Phase 1 scan targets remain.
+
+---
+
+## Publication, target, channel, and filter identity
+
+Identity is explicit and query-relative:
+
+- **`publication_plan_id`:** one producing join plus its admitted key plan; filter construction is
+  attempted once per publication plan.
+- **`target_id`:** one scan or SIP consumer endpoint receiving that publication.
+- **`channel_id`:** one append-only delivery object owned by one logical consumer endpoint. A scan
+  channel can serve target edges from multiple publication plans.
+- **`filter_id`:** one constructed immutable filter. It is assigned before fan-out and remains the
+  same in every target channel receiving that object.
+
+The channel stores `published_filter_entry{filter_id, shared_ptr<const filter>}` rather than
+requiring telemetry to reconstruct identity from an address. Mask helpers use the filter payload;
+events and offline correlation use the stable ID.
+
+### Scan channels
+
+The existing scan map remains keyed by preserved `DynamicTableFilterSet*`. One scan channel may
+have N producing joins and one logical scan consumer. The scan closes it once; producer
+publications AND-conjoin in that channel. This preserves Phase 1 exactly.
+
+### SIP channels
+
+Each `(producer P, consumer C)` SIP target gets a dedicated channel with exactly one producer and
+one consumer. If the same filter also targets a scan or another join, those endpoints receive
+separate channels containing entries with the same `filter_id` and
+`shared_ptr<const sirius_dynamic_filter>`.
+
+This is the correct close invariant: **one logical consumer per channel**, not universally one
+producer per channel. Gate state, close state, telemetry, and any future activation token are
+never shared across consumers.
+
+All four IDs are query-relative monotonic values used for planning, telemetry, and tests. They are
+never cached across replans.
+
+---
+
+## Hash-join probe consumer
+
+### Component boundary
+
+`sirius_physical_hash_join` owns zero or more immutable SIP endpoint descriptions. Mutable gate
+state lives in a narrow composed `hash_join_probe_filter_consumer`; planner metadata and DuckDB
+objects do not enter execution.
+
+For each probe task:
+
+1. Identify the probe batch through the join's port-aware input path.
+2. In an initial `BUILD_PROBE` task, construct `C`'s own build hash table as today.
+3. Before `prepare_join_keys` for the probe, snapshot each SIP endpoint.
+4. Apply available membership filters through the shared gated-mask helper.
+5. Produce one `probe_batch_handle` containing stable source/batch identity, the original or owned
+   gathered table, its table view, and its memory space.
+6. Use that handle for every later probe-side access: key preparation, `left_full`, payload gather,
+   distinct/mark/semi helpers, output memory-space selection, and telemetry.
+
+Mixing indices computed against a filtered table with payload rows from the original
+`input_batches[0]` would be wrong. After the checkpoint, direct probe-side reads from that original
+slot are forbidden; focused tests remove non-prefix rows and project payload columns so index/view
+misalignment cannot hide.
+
+The same checkpoint is used for BUILD_PROBE and STANDARD consumers. MIXED consumers are rejected
+in v1 rather than adding another predicate/key preparation path. A STANDARD consumer still pays
+its already-completed partition/shuffle; SIP saves its hash probe and work above it. This design
+makes no claim that post-CONCAT filtering shrinks the shuffle.
+
+STANDARD input creation may pair one probe batch with several build batches. Give the handle a
+stable probe-batch ID and record repeated applications. C3 may initially reapply safely, but
+STANDARD routes cannot default on unless that duplicated cost is measured acceptable or a
+device/generation-qualified filtered-probe cache is added with an explicit memory lifetime.
+
+### Fast paths and semantics
+
+- No channel, no visible filter, unavailable local replica, or a disabled gate forwards the
+  original probe batch zero-copy.
+- Filtering never mutates the input batch.
+- A zero-row filtered probe remains a schema-correct zero-row input and follows ordinary join/task
+  completion.
+- Replica-unavailable pass-through does not train the gate.
+- Each SIP endpoint owns independent combined and per-filter gate statistics.
+- A scan and later join probe may apply the same filter; downstream marginal keep-rate disables
+  redundant work after its first measurement.
+
+Only membership-capable filters are consumed at a join probe. Zone maps remain scan-reader
+capabilities; no empty/sentinel `cudf::data_type` is used to encode that distinction.
+
+### Multi-GPU
+
+- Resolve device identity from the probe batch's memory space, never ambient CUDA context.
+- Apply a filter only when `is_available_on_device(device_id)` succeeds.
+- Publication constructs and synchronizes each usable replica before pushing the immutable filter
+  into any channel.
+- Adding SIP targets adds channel fan-out, not another replica-construction pass.
+- A target records replica-unavailable pass-through separately from late publication.
+
+---
+
+## Ordering and contingent activation
+
+### C3: opportunistic experiment
+
+Every join-probe batch snapshots its channel and applies the complete filters currently visible.
+No task waits. There is deliberately no claim that the producer "usually" runs first: the relevant
+outer producer is not driven by the intervening consumer's build hint, and removal of the global
+priority pass may change coverage.
+
+Opportunistic C3 is liveness-safe and correctness-safe. Its performance value is an empirical
+question answered before default-on:
+
+- how many rows/batches reach each checkpoint before publication;
+- how many missed a scan but were caught at C1/C2;
+- hash-probe rows and bytes avoided;
+- filter/gather overhead and gate disable rate; and
+- end-to-end time and resident peak with legacy/off priority.
+
+If a valuable route class sees adequate coverage, it can remain opportunistic. If systematic
+misses erase the value, ordered activation for that class is a prerequisite to default-on—not an
+assumed future optimization.
+
+### Track D: exactly-once ordered activation
+
+Track D is admitted only after runtime pipelines are finalized.
+
+#### Admission
+
+- At most one ORDERED target per runtime consumer pipeline. Other targets remain opportunistic.
+- The selected SIP channel has exactly one registered producer.
+- Validate acyclicity over repository/data edges, activation edges, and the synthetic hint path
+  used to drive the producer—not activation edges alone.
+- Every task-driving node in the consumer-to-producer activation closure is runtime-unique. A
+  shared node demotes the target to opportunistic.
+- Choose among competing targets deterministically by measured/estimated avoided hash-probe work.
+- The activation descriptor stores the resolved producer build-side publication driver/milestone
+  pipeline (the build PARTITION/CONCAT path), not merely producing join `P`. Asking `P` for a hint
+  can follow its probe back through `C` and manufacture a cycle.
+
+These rules prevent a consumer from waiting for several outer builds and recreating #1014.
+
+#### Publication completion
+
+Each ordered channel has one atomic completion state:
+
+```text
+OPEN → PUBLISHING → PUBLISHED | SEALED_EMPTY
+OPEN -------------------------> SEALED_EMPTY
+PUBLISHING -------------------> SEALED_EMPTY(CONSUMER_CLOSED)
+OPEN | PUBLISHING ------------> FAILED
+OPEN -------------------------> CANCELLED   // quiescent teardown only
+```
+
+`SEALED_EMPTY` records `EMPTY_BUILD`, `UNSUPPORTED_MODE`, `POLICY_SKIPPED`, or
+`SOURCE_UNAVAILABLE`, plus `CONSUMER_CLOSED` when this target stops accepting filters. Channel
+close and completion are one atomic/locked operation, so a detached target is never later reported
+as `PUBLISHED`. All terminal transitions go through one compare/exchange
+`complete_once(...)` API. Mode/build-finish fallbacks may seal only `OPEN`; they never overwrite
+`PUBLISHING`. Success reaches `PUBLISHED` only after construction, all usable replicas, and all
+channel pushes complete.
+
+#### Exactly-once waiter
+
+Each `(channel, consumer runtime pipeline)` has one query-owned activation token:
+
+```text
+IDLE → ARMED → QUEUED → CLAIMED
+  \       \       \----> DETACHED
+   \-------\------------> DETACHED
+```
+
+Before resolving any operator hint:
+
+1. A completed `PUBLISHED`/`SEALED_EMPTY` target channel proceeds normally.
+2. `FAILED`/`CANCELLED` creates no work.
+3. Otherwise CAS `IDLE → ARMED`, register the token, and re-read completion.
+4. Terminal success/empty calls `release_once`; only `ARMED → QUEUED` enqueues the consumer.
+5. Repeated scheduling requests observing `ARMED` wait without registering another token.
+6. The task creator must CAS `QUEUED → CLAIMED` before dereferencing the request's pipeline. A
+   zero-input close or teardown may win `IDLE/ARMED/QUEUED → DETACHED`; a queued request carries
+   the shared token and becomes a no-op if detached. A claimed request is quiesced before query
+   destruction.
+
+The activation check precedes hint resolution, repository pop, GPU memory reservation, and task
+accounting. Synthetic `WAITING_FOR_INPUT_DATA{publication_driver}` drives the exact producing
+build/milestone path through existing recursion. That edge is included in cycle validation.
+Wakeups are queued only after channel, join, partition, and pipeline-status locks are released;
+completion callbacks never synchronously recurse into hints. If bounded-pool slot acquisition
+remains before hint resolution, an armed waiter may occupy only that control-plane slot—never a GPU
+memory reservation or worker executing query data.
+
+#### Milestones and teardown
+
+- STANDARD/MIXED decision seals `UNSUPPORTED_MODE` outside join/partition locks.
+- Build-CONCAT completion performs `complete_if_open(SEALED_EMPTY(...))`, covering empty and
+  no-batch paths without waiting for a probe. Join finalize is never the seal point.
+- Every downgraded/unavailable/policy early return completes the publication attempt and each
+  affected target channel.
+- A consumer finishing through zero input or early close detaches its token before destruction.
+
+Error teardown order is:
+
+1. stop task creation and reject new activation requests;
+2. detach `IDLE`/`ARMED`/`QUEUED` tokens without enqueueing and invalidate queued activation
+   requests;
+3. drain the task-creation queue/claimed requests, scan/GPU executors, and in-flight publishers;
+4. cancel still-open channels;
+5. remove activation edges/tokens;
+6. destroy query pipelines/operators; and
+7. restart task creation for the next query only after both normal and activation request queues
+   are empty.
+
+Activation requests retain pipeline-qualified query-owned identity; they do not add another raw
+operator pointer whose lifetime exceeds the query.
+
+Rejected alternatives remain: blocking inside `execute`, gating the deepest scan, a FULL data
+barrier, wall-clock timeout, or coordinated fan-in.
+
+---
+
+## Producer and materialization changes
+
+### Waiter-free publication lifecycle (A1/C1)
+
+Coverage telemetry cannot wait for Track D. Every `publication_plan_id` therefore gets a
+waiter-free attempt state in A1/C1:
+
+```text
+OPEN → PUBLISHING → PUBLISHED | NO_MATERIALIZATION(reason) | FAILED
+OPEN -------------> NO_MATERIALIZATION(reason) | FAILED
+OPEN | PUBLISHING -> CANCELLED   // query teardown, no wake
+```
+
+Reasons include `EMPTY_BUILD`, `UNSUPPORTED_MODE`, `POLICY_SKIPPED`, and `SOURCE_UNAVAILABLE`.
+Every transition records one monotonic timestamp and is exactly once, but it has no waiter and
+schedules no task. Each target edge separately records whether its channel accepted the filters,
+was already `CONSUMER_CLOSED`, or was rejected during planning. Thus STANDARD, empty, unavailable,
+policy-skip, and closed-consumer paths are observable even when ordered activation is disabled.
+
+Track D reuses these outcomes to complete per-channel activation; it does not introduce the first
+notion of producer completion.
+
+### Immutable Sirius plan
+
+Publication claim and execution move entirely to an immutable Sirius value:
+
+```cpp
+struct dynamic_filter_key_plan {
+  std::size_t condition_index;
+  cudf::size_type build_column_index;
+  cudf::data_type build_type;
+  std::optional<std::size_t> build_key_domain_cardinality;
+};
+
+struct scan_publish_target {
+  dynamic_filter_target_id target_id;
+  std::shared_ptr<sirius_dynamic_filter_set> channel;
+  std::vector<scan_target_key> keys;
+};
+
+struct join_probe_publish_target {
+  dynamic_filter_target_id target_id;
+  std::shared_ptr<sirius_dynamic_filter_set> channel;
+  std::vector<join_probe_target_key> keys;
+};
+
+using dynamic_filter_publish_target =
+  std::variant<scan_publish_target, join_probe_publish_target>;
+
+struct dynamic_filter_publication_plan {
+  dynamic_filter_publication_plan_id id;
+  std::vector<dynamic_filter_key_plan> keys;
+  std::vector<dynamic_filter_publish_target> targets;
+};
+```
+
+Runtime claim checks `_dynamic_filter_plan.enabled()` and release-mode producer eligibility; it
+does not re-read `filter_pushdown`, `join_condition`, `key_casts`, or DuckDB target columns.
+
+### Per-key fan-out
+
+Replace the current target-arity all-or-nothing push with independent target-key entries. Each
+published equality component is a necessary condition, so independently admitted subsets are
+safe. This hardening applies only after DuckDB admission; it does not create mixed-provenance
+candidates DuckDB rejected.
+
+### Materialization policy
+
+For an admitted equality key, Sirius chooses `exact_set`, `bloom`, or `none` using explicit GPU
+policy. `duckdb_build_subtree_has_filter_hint` may be recorded or used as a cost hint, but it is
+not a correctness gate. Keep the policy change separate from the adapter refactor:
+
+- first preserve Phase 1's observable route/materialization behavior under fixed configuration;
+- revive or replace the dead domain/selectivity signal in shadow mode;
+- instrument membership exact/Bloom/none, independent zone-map emission, and usefulness; and
+- separately A/B-enable the repaired selectivity gate and remove the current blanket
+  `build_side_has_filter` gate.
+
+This avoids describing a broader producer policy as "no behavior change."
+
+### Selectivity signal
+
+Repair the dead domain signal either with a pre-resolver snapshot keyed to logical bindings or a
+post-resolver source whose semantics are proved. The first PR records the would-suppress decision
+only; feeding a formerly dead value into the existing publisher gate would itself change behavior.
+A later policy PR enables enforcement behind A/B. Until a value is proved, unknown remains
+`std::nullopt`—not sentinel zero—and the runtime consumer gate is the only selectivity backstop.
+The default-on gate must include build cost, resident bytes, first-mask cost, and keep-rate, not
+just result correctness.
+
+### Publication streams and target liveness
+
+Keep durable pooled publication streams and the existing per-stream replica reservation. Build
+each filter once on the producer, replicate once per active device, synchronize, then fan the same
+immutable objects into accepting targets. A closed target can be skipped; closure of one SIP
+channel never closes the scan or another SIP target.
+
+---
+
+## Memory model
+
+### Resident floors
+
+The query has two non-spillable dynamic-filter-related floors:
+
+- pinned `BUILD_PROBE` build batches plus persistent hash tables; and
+- device-local dynamic-filter replicas retained for query/channel lifetime.
+
+The count of simultaneously resident joins, not only the 500 MB per-build admission cap, controls
+the first. Filter bytes scale with admitted keys × devices, while channels share filter objects and
+do not duplicate replicas.
+
+Add a per-query aggregate filter-replica budget before any Track E candidate expansion. Its
+downgrade order is exact set → Bloom → none, and every choice is recorded. v1 publication-plan
+count remains bounded by DuckDB-admitted joins; adding targets does not duplicate replicas, but
+telemetry still measures aggregate resident bytes.
+
+### Transient reservation
+
+Remove the scan operator's current optimistic `stats.bytes` override. Do not replace it with a
+fixed `2.1 × input`: during a multi-filter cascade the caller can retain the original batch while
+the previous gathered table, the next gathered table, the BOOL8 mask, optional gather map, and
+cuDF scratch overlap (`src/op/scan/dynamic_filter_merge.cpp:81-87`). Narrow schemas make the mask
+and gather map proportionally large, and a hash-join consumer may retain the filtered probe while
+allocating keys and join output.
+
+Extend `input_stats` with an optional row count and use a shared, saturating estimate of
+simultaneous **new allocations**:
+
+- previous cascade result retained while another filter is applied;
+- next output, bounded by the input data footprint plus table metadata;
+- `rows × sizeof(bool)` mask;
+- any `rows × sizeof(cudf::size_type)` gather map used by the cuDF path; and
+- measured backend scratch allowance.
+
+Existing resident input ownership is recorded in query-level peak telemetry, not charged again as
+new operator allocation; nonresident input materialization remains the separate
+`bytes_to_materialize_input` term. If exact decoded rows are unavailable, use a conservative
+schema/byte-derived row bound. Hash-join tasks use probe-batch rows/bytes, not aggregate
+probe+build statistics, for mask sizing.
+
+The no-history estimate is never below the generic fallback. `sirius_physical_hash_join` currently
+has no mode-aware override, so C2 adds one rather than referring to a nonexistent existing
+key/hash estimate. It models allocations that overlap inside the composed checkpoint and join:
+
+- the first BUILD_PROBE task includes persistent hash-table/build-key allocation plus filtering,
+  probe-key, index, output, and scratch peaks;
+- later BUILD_PROBE probe tasks exclude the already-resident hash table from **new** reservation
+  demand while resident high-water still observes it; and
+- STANDARD tasks estimate their probe/build pair, repeated probe filtering, local hash/index
+  allocations, output, and scratch.
+
+The pipeline-level `max()` cannot combine allocations inside this composed join path, so the join
+override performs that overlap calculation itself. Execution history may tighten the estimate
+only after successful runs.
+
+Focused tests cover one-column INT32/nullable inputs, wide rows, unknown row counts, multiple
+filters, keep ratios near 0/0.5/1, repeated STANDARD probe IDs, multi-batch tasks, and OOM
+rescheduling.
+
+---
+
+## C++ structure and design guidance
+
+The structure follows the guidance in Iglberger, *C++ Software Design*:
+
+| Decision | Guideline / consequence |
+|---|---|
+| One adapter owns every pinned DuckDB metadata read and copy invariant | G24 Adapter; third-party layout does not leak into runtime |
+| Candidate extraction, lineage tracing, eligibility, and grouping are pure functions over values | G4 testability; G19/G23 value-based strategies |
+| Key, publication, target, and endpoint descriptors use value semantics, strong index types, and `std::optional` for absence | G22; invalid/cross-space sentinel states are avoided |
+| `std::variant<scan_publish_target, join_probe_publish_target>` closes the two target-specific index spaces without a target hierarchy | G17; exhaustive cold-path dispatch |
+| `hash_join_probe_filter_consumer` is composed into the join rather than adding planner/routing responsibilities to the join class | G2 SRP; G3 interface segregation |
+| Scan and join consumers reuse a free mask-application operation over `sirius_mask_applicable`; no filter-kind switch | G5 OCP; G15 operation axis over a closed type set |
+| Capability discovery remains outside the per-row path | G18; dynamic dispatch cost is per filter/batch |
+| Query-local registry owns temporary logical pairing; runtime owns only Sirius values/channels | G9 dependency inversion and explicit lifetime |
+| Scheduler loses join/filter knowledge after A4 | G2/G9; policy dependency is removed at the correct layer |
+| Activation uses one DAG edge and an exactly-once token, not an Observer callback graph | G25; teardown and duplicate notification are explicit |
+| Sirius-side admission, shared activation, STANDARD producers, and aggregate producers wait for a measured payer | G2/G5 YAGNI |
+
+No type erasure is added to the filter zoo: several named capabilities make its tradeoff worse than
+the existing small polymorphic hierarchy (G32).
+
+---
+
+## Phasing
+
+Per-PR implementation plans (adversarially reviewed against the baseline commit) live in
+[issue-1010-implementation-plan.md](issue-1010-implementation-plan.md) and
+[issue-1010-plans/](issue-1010-plans/).
+
+Phase 0 is deferred (see § "Phase 0") and blocks nothing; the B1 row becomes the pin-bump
+playbook. While on the unpatched pin, LIMIT/TOP-N-shaped tests must use explicit expected rows or
+a filters-disabled reference run, never an unpatched CPU run.
+
+Within Track C, C1a-C1e and C2 are reviewable steps and are prerequisites to C3's complete
+candidate contract; behavior-changing C1c-C1e remain independently flaggable/revertible until
+their gates pass.
+
+| PR | Track | Content | Gate |
+|---|---|---|---|
+| A1 | #1014 | Stable publication/target/channel/filter IDs, waiter-free outcomes, resident high-water, lifecycle counts, channel-level scan coverage (SIP targets reuse this later) | instrumentation only |
+| A2 | #1014 | `dynamic_filter_build_priority={legacy,off}` comparison switch | legacy default; no deletion |
+| A3 | #1014 | Default priority off if measured gate passes | one-release rollback |
+| A4 | #1014 | Delete pass and scheduler filter knowledge | after default-off release |
+| B1 | Phase 0 | **Deferred** — executes at the next pin bump to a released DuckDB containing #22963; ships the explicit-oracle sentinel regressions then | pin-bump playbook; blocks nothing (sirius-db/sirius#1123) |
+| C1a | foundation | Version-pinned adapter, pointer-identity preservation, Sirius value snapshots, publisher claim decoupling | same admitted producers/keys, scan targets, materialization choices, channel lifecycle, and results under fixed config |
+| C1b | producer | Strong target-key types, materialization telemetry, shadow selectivity signal | compatibility behavior; policy observable |
+| C1c | producer | Enable per-key fan-out behind A/B | explicit target behavior change |
+| C1d | producer | Enforce repaired selectivity signal behind A/B | explicit suppression policy change |
+| C1e | producer | Remove blanket `build_side_has_filter` gate behind default-off A/B | explicit candidate expansion; widens the accepted latent LIMIT/TOP-N exposure marginally (#1123) |
+| C2 | consumer | Extract reusable mask operation; add hash-join probe endpoint component and memory model with unit tests | no planned routes yet |
+| C3 | SIP | Discovery/resolution/topology-freeze registry, layered scan + opportunistic join-probe targets behind `enable_dynamic_filter_sip=false`, telemetry | first value experiment |
+| C4 | SIP | Default-on only if coverage/value gates pass; otherwise depends on D | results + wall time + memory |
+| D | conditional | Exactly-once ordered activation for selected non-shared, acyclic, one-producer pipelines | required only for route classes that miss |
+| E | vNext | Sirius-side/no-scan admission, mixed provenance, broader crossing, STANDARD producers, aggregate producers, replica narrowing | aggregate filter budget first |
+
+A and C are evaluated as a matrix where relevant; neither track is assumed to repair the other's
+regressions. C1a/C1b preserve observable publication policy; C1c-C1e are intentionally separate so
+fan-out, selectivity enforcement, and candidate expansion can each be attributed and reverted.
+
+---
+
+## Testing and observability
+
+### Unit and adapter contracts
+
+- Copied join/get `DynamicTableFilterSet` pointer identity, including two producers sharing one
+  scan channel.
+- Zero and duplicate logical GET matches for one target identity fail that target closed.
+- Null/statistics-only/admitted metadata; malformed condition indexes and target arity; exact
+  DuckDB ordinal → reordered condition → compact Sirius key alignment.
+- Producing join-type, equality/INDF, cast, NULL, GPU type, and runtime-mode gates. INDF/cast
+  rejection is per condition: an eligible ordinary-equality sibling remains routable.
+- Lineage remapping through pass-through projection/filter/order/distinct; stop cases for every
+  unsupported operator and fan-out boundary.
+- Composite admitted-key compaction; mixed-provenance composite rejected as
+  `duckdb_not_admitted`.
+- Deterministic grouping/deduplication into `(producer, consumer)` targets.
+- Per-key publisher fan-out and independent consumer gate state.
+
+### Planner and topology
+
+- `scan → C1 → P` retains the scan channel and installs a distinct endpoint in `C1`.
+- `scan → C1 → C2 → P` installs endpoints in both intermediate joins without inserting a unary
+  feeder operator.
+- The checkpoint runs after the consumer's probe repository pop and before
+  `prepare_join_keys`/hash probe.
+- PARTITION/CONCAT shapes, partition negotiation, and sibling positional contracts are unchanged.
+- CTE/shared-source branches either stop discovery or prove branch-local post-pop filtering; an
+  unrelated branch observes unfiltered input.
+- Topology finalization freezes producer/consumer plan slots exactly once.
+- Failure to resolve one SIP consumer drops both target ends, closes its pending channel, and does
+  not disconnect valid scan targets.
+
+### Correctness end to end
+
+- ON/OFF relational/bag equivalence for nested INNER/SEMI chains, multiple intermediate joins,
+  composite admitted keys, NULL keys, empty build, downgraded build, STANDARD consumers, and
+  multi-GPU consumers on non-producer devices. Compare exact order only where SQL guarantees it.
+- No producing publication for LEFT/ANTI/MARK/FULL joins; INDF/cast conditions are rejected per
+  key while an eligible equality sibling remains routable.
+- LIMIT/TOP-N explicit expected results on the patched pin, including join-sourced inputs; keyed by
+  publication-plan/target ID, assert that the outer producer does not cross the selector.
+  Independent joins wholly inside the selector input may still have legal routes.
+- Zero-row filtered probes complete normally.
+- Shared-source isolation and query teardown under failure.
+
+### Race and coverage
+
+- Publication before scan, between scan and C1, between C1 and C2, and after all consumers.
+- A batch already queued behind `PARTITION`/`CONCAT` before publication is still caught at the join
+  probe checkpoint; a filtered non-prefix payload proves every later probe access uses the handle.
+- Stable probe-batch IDs expose repeated STANDARD applications across build-batch pairings.
+- Partial multi-key fan-out, consumer closure racing publication, unavailable device replica, and
+  gate re-arm after new filters.
+- TSan over publish/snapshot/close; opportunistic mode has no waiter and cannot hang.
+
+### Memory and scheduling
+
+- A1/A2/A3 three-configuration #1014 protocol and priority × SIP matrix.
+- Separate counts for feeder tasks, delivered build batches, pinned build batches, hash tables,
+  and filter replicas.
+- Component reservation tests for narrow/wide/multi-filter inputs and OOM re-entry.
+- Query aggregate replica budget/downgrade tests before Track E.
+
+### Track D fault injection
+
+- simultaneous register/seal, duplicate schedule notifications, completion during re-read;
+- STANDARD, empty, policy skip, unavailable source, CONSUMER_CLOSED, FAILED, and CANCELLED
+  outcomes;
+- cancellation during publication and zero-input consumer detachment;
+- several candidate targets on one runtime pipeline (only one ordered);
+- the synthetic wait drives the resolved build publication driver, never the producing join's
+  probe hint;
+- cycles visible only in the union of data, activation, and synthetic wait edges; and
+- no wake while holding pipeline/join/channel locks.
+
+### Telemetry
+
+Object addresses are never event identity. Use a query-relative monotonic clock and emit:
+
+```text
+publication_plan_created(publication_plan_id, producer, admitted_keys)
+candidate_rejected(reason)
+target_planned(target_id, publication_plan_id, channel_id, kind, consumer, mode)
+publication_started(publication_plan_id)
+publication_completed(publication_plan_id, outcome, filter_ids, replica_bytes, devices)
+channel_filter_visible(channel_id, target_id, generation, filter_ids, accepted_at)
+target_publication_terminal(target_id, channel_id, outcome)
+consume_batch(channel_id, rows_in, rows_out,
+              visible_filter_ids, masks_applied, masks_skipped,
+              replica_unavailable)
+channel_closed(channel_id, reason)
+activation_armed/released/cancelled(target_id, runtime_pipeline_id)  // Track D
+```
+
+Scan coverage is channel-level in A1 because one scan channel may have several producers. Planned
+publication/target IDs, per-target terminal events, channel generations, and stable filter IDs are
+correlated offline to distinguish pre-publication batches and sequential fan-out. The consumer does
+not pretend to attribute a combined scan mask's row reduction to one producer. Dedicated SIP
+channels support direct per-target coverage.
+
+Aggregate into:
+
+- no DuckDB candidate vs Sirius rejection vs runtime no-materialization;
+- rows before publication, with an applicable filter, and after terminal empty outcome;
+- late miss vs replica unavailable vs gate skip vs closed consumer;
+- scan-caught, C1-caught, C2-caught, and redundant downstream keep-rate;
+- hash-probe rows/bytes avoided and mask/gather cost; and
+- resident filter bytes plus live join-state counts.
+
+---
+
+## Risks and retiring evidence
+
+1. **Opportunistic coverage is too late or zero.** C3 per-layer timing and avoided-probe telemetry;
+   ordered activation is the recovery before default-on.
+2. **#1014 priority removal regresses transitive coverage.** A1-A3 paired comparison; retain
+   rollback, add route-local ordering, and repeat rather than guessing a global cap.
+3. **DuckDB pin/layout drift.** Adapter contract tests and Phase 0 sentinels on every pin bump.
+4. **GPU materialization diverges unprofitably from DuckDB's policy.** Record candidate,
+   membership exact/Bloom/none, and independent zone-map decisions with build/apply time and
+   keep-rate.
+5. **Layered consumers add redundant masks.** Independent marginal gates plus per-layer overhead;
+   reduce target depth only with measured evidence.
+6. **Filter replica bytes grow with admitted producer/key count.** Shared filter objects,
+   resident-byte telemetry, and aggregate budget before candidate expansion.
+7. **Lineage/projection mistakes cause wrong-column filtering.** Pure binding-based tests,
+   branch-anchor validation, and release-mode fail-closed endpoint installation.
+8. **Track D introduces wake/lifetime races.** Exactly-once token, combined-edge cycle validation,
+   lock-free wake boundary, and fault-injection suite before it can ship.
+
+---
+
+## Expected file changes
+
+| Concern | Files |
+|---|---|
+| #1014 instrumentation/switch/removal | `src/{include/,}pipeline/task_scheduler.*`, memory/executor telemetry |
+| DuckDB correctness pin | `duckdb/src/optimizer/join_filter_pushdown_optimizer.cpp`, upstream regression SQL, `.gitmodules`, gitlink |
+| Adapter preservation/extraction | new `src/{include/,}planner/duckdb_join_filter_candidate_adapter.*`, `src/transparent/sirius_optimizer_extension.cpp` |
+| Route registry, lineage, topology freeze | new planner values/registry; `sirius_physical_plan_generator.*`, `sirius_plan_comparison_join.cpp`, `sirius_plan_get.cpp`, converter/query finalization invariant |
+| Sirius producer plan/materialization/lifecycle | `sirius_dynamic_filter.*`, `dynamic_filter_publish_plan.*`, `dynamic_filter_publisher.*`, `sirius_physical_hash_join.*` |
+| Reusable mask operation and probe consumer | move/generalize `dynamic_filter_merge.*` and gate interfaces under `src/{include/,}op/`; new hash-join probe consumer component; retain scan operator |
+| Reservation inputs/estimator | `src/include/op/sirius_physical_operator.hpp`, `src/pipeline/gpu_pipeline_task.cpp`, focused memory tests |
+| Documentation | this file and `dynamic-filters.md` Phase 2/ordering sections |
+| Tests | adapter, planner lineage, publisher, hash-join probe, pipeline topology, race, memory, multi-GPU suites |
+
+Track D additionally touches `task_creator.*`, `sirius_pipeline.*`, query-owned activation
+registry/tokens, join mode/build completion hooks, and teardown ordering. It does not add a
+pre-partition unary consumer.
+
+---
+
+## Open questions resolved by measurement
+
+1. Whether every eligible intermediate join probe pays for its first mask, or target depth should
+   be capped after C3 telemetry.
+2. Whether a join-probe gate needs a different keep threshold because it saves hash work but not
+   scan/partition work.
+3. Which route class, if any, merits ordered activation and which single route wins when several
+   target the same runtime pipeline.
+4. Whether the current Sirius materialization policy should incorporate DuckDB's build-filter and
+   probe/build-ratio hints after their independent predictive value is measured.
+
+Questions intentionally deferred to Track E—no-scan candidate discovery, mixed provenance,
+aggregate crossing, STANDARD producers, shared activation, and device-narrowed replica sets—are
+not v1 implementation choices.
+
+---
+
+## References
+
+- `docs/super-sirius/dynamic-filters.md`, `dynamic-filters-multi-gpu.md` — Phase 1 architecture,
+  N-producer/one-consumer scan channels, replica model, and Phase 2 hash-join-probe goal.
+- `src/pipeline/task_scheduler.cpp:164-214,404-416` — global queued-task preference addressed by
+  #1014.
+- `src/op/sirius_physical_hash_join.cpp:486-547,910-1315,1319-1428` — stateful hints, probe
+  execution (BUILD_PROBE and STANDARD paths), and publication lifecycle.
+- `src/include/op/sirius_dynamic_filter.hpp`, `src/op/dynamic_filter_publisher.cpp` — append-only
+  channel and GPU materialization policy.
+- `src/op/scan/dynamic_filter_merge.cpp`, `dynamic_filter_gate.hpp` — mask operation and adaptive
+  gate reused at the hash-join probe.
+- `duckdb/src/optimizer/join_filter_pushdown_optimizer.cpp` and
+  `duckdb/src/execution/operator/join/physical_hash_join.cpp` — pinned candidate and runtime
+  materialization contracts.
+- duckdb/duckdb#22963 (`4c8c90db44`) — LIMIT/TOP-N correctness fix.
+- Klaus Iglberger, *C++ Software Design* — guidelines cited in the structure table.

--- a/docs/super-sirius/issue-1010-github-delivery-plan.md
+++ b/docs/super-sirius/issue-1010-github-delivery-plan.md
@@ -1,0 +1,215 @@
+# Issue #1010 GitHub Delivery Plan
+
+**Scope:** Delivery structure for the implementation described in
+[General Dynamic Filters: Sideways Information Passing at Hash-Join Probe Inputs](issue-1010-dynamic-filter-sip-design.md).
+
+**Parent issues:** [#1010](https://github.com/sirius-db/sirius/issues/1010) for general dynamic
+filters and [#1014](https://github.com/sirius-db/sirius/issues/1014) for build-task priority
+removal.
+
+This document defines how to divide the design into GitHub issues and pull requests. The design
+document remains authoritative for architecture, correctness, gates, and acceptance criteria.
+
+## Decision
+
+Use GitHub parent issues and native sub-issues as the umbrella. Do not create an umbrella pull
+request.
+
+- `#1010` owns the Phase 0 and Track C delivery needed for dynamic-filter SIP v1.
+- `#1014` separately owns Track A because scheduler cleanup is independently measurable,
+  releasable, and reversible.
+- Create one sub-issue for each independently reviewable and mergeable unit below.
+- Normally create one pull request per sub-issue.
+- Express real ordering constraints with GitHub's `blocked by`/`blocking` relationships, rather
+  than relying on list order or prose alone.
+- Use a milestone or GitHub Project for release planning and visualization, not as a replacement
+  for the parent issues.
+
+GitHub's native
+[sub-issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/adding-sub-issues)
+provide hierarchy and rolled-up progress. Native
+[issue dependencies](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-issue-dependencies)
+represent merge and enablement constraints.
+
+## Proposed issue hierarchy
+
+### #1010 — General dynamic filters: join-probe SIP
+
+Create these as native sub-issues of `#1010`:
+
+| ID | Suggested sub-issue title | Delivery boundary |
+|---|---|---|
+| B1 | Phase 0: repair the pinned DuckDB join-filter candidate walk | Backport or advance past duckdb/duckdb#22963 and add explicit-oracle regressions. |
+| C1a | Dynamic filters: add a version-pinned DuckDB candidate adapter | Preserve target identity, extract Sirius value snapshots, and decouple publisher claims without behavior changes. |
+| C1b | Dynamic filters: introduce typed target keys and decision telemetry | Add strong key/index types, materialization telemetry, and the shadow selectivity signal without changing policy. |
+| C1c | Dynamic filters: enable per-key target fan-out | Ship behind an independently reversible A/B control. |
+| C1d | Dynamic filters: enforce the repaired selectivity decision | Ship the suppression-policy change behind an independently reversible A/B control. |
+| C1e | Dynamic filters: remove the blanket build-filter exclusion | Expand candidates behind a default-off, independently reversible A/B control. |
+| C2 | Dynamic filters: add the reusable mask operation and join-probe consumer | Add the composed probe checkpoint, endpoint component, reservation model, and focused tests without planning routes to it. |
+| C3 | Dynamic filters: plan and run opportunistic join-probe SIP | Add discovery, resolution, topology freeze, layered scan/probe targets, telemetry, and a default-off SIP experiment. |
+| C4 | Dynamic filters: make the SIP rollout decision | Turn SIP on by default only if correctness, coverage, wall-time, and memory gates pass. |
+| D | Dynamic filters: add route-local ordered activation if required | Conditional recovery for route classes whose opportunistic coverage misses the C3 gate. |
+
+Track E is vNext scope. Give it a separate follow-up parent issue instead of making it part of the
+v1 completion percentage.
+
+### #1014 — Remove dynamic-filter build-task prioritization
+
+Treat `#1014` as a separate parent and create these native sub-issues:
+
+| ID | Suggested sub-issue title | Delivery boundary |
+|---|---|---|
+| A1 | Instrument dynamic-filter publication, coverage, and join residency | Instrumentation only; establish the comparison baseline. |
+| A2 | Add a legacy/off switch for dynamic-filter build priority | Keep `legacy` as the default and retain the implementation. |
+| A3 | Default dynamic-filter build priority to off | Merge only if the measured acceptance gate passes; preserve one-release rollback. |
+| A4 | Delete scheduler-level dynamic-filter prioritization | Remove the pass and scheduler knowledge after the default-off release is validated. |
+
+Link `#1010` and `#1014` as related issues. Do not make either entire parent issue block the other:
+Tracks A and C are an experimental matrix, and neither is assumed to repair the other's
+regressions.
+
+## Dependency graph
+
+Represent the following edges with native `blocked by` relationships:
+
+```text
+C1a ──► C1b ──► C1c
+              ├─► C1d
+              └─► C1e
+
+B1 ───────────► C1c enablement
+ ├────────────► C1e enablement
+ └────────────► C3
+
+C1a + C1b + C1c + C1d + C1e + C2 ──► C3 ──► C4
+                                               ▲
+                                               │
+                                      D, only if C3
+                                      misses its gate
+
+A1 ──► A2 ──► A3 ──► A4
+```
+
+The B1 constraint is specifically an enablement constraint. Structural work may proceed in
+parallel, but vulnerable behavior must not be enabled against the unpatched DuckDB pin.
+
+Do not create D merely to complete the issue tree. Create it when C3 telemetry identifies a
+specific route class that requires ordering, then mark C4 as blocked by D. If C3 passes without
+ordered activation, close C4 without creating D or close a pre-created D issue as not required.
+
+## Pull-request policy
+
+Each pull request should:
+
+1. Target `dev`, the repository's default branch.
+2. Close exactly one delivery sub-issue whenever practical.
+3. Reference, but not close, its parent issue.
+4. Identify blocking issues or pull requests explicitly.
+5. State its behavior boundary: instrumentation-only, behavior-preserving, default-off,
+   A/B-controlled, default change, or code removal.
+6. Include validation, rollout, and rollback conditions from the design.
+
+Use this header in pull-request descriptions:
+
+```markdown
+Parent: #1010
+Closes: #<sub-issue>
+Design section: <B1 | C1a | C1b | C1c | C1d | C1e | C2 | C3 | C4 | D>
+Depends on: #<issue-or-PR>, or none
+Behavior: <instrumentation-only | preserving | default-off | A/B | default change | removal>
+Rollback: <flag, revert boundary, or not applicable>
+```
+
+For Track A, use `Parent: #1014` instead.
+
+Do not put `Closes #1010` or `Closes #1014` on implementation pull requests. GitHub applies
+[closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue)
+when a pull request merges into the default branch; using one on a parent would close the umbrella
+before all acceptance criteria are met. Use `Refs #1010` or the `Parent:` line and close the parent
+manually after its exit criteria pass.
+
+## Branching and stacking
+
+Prefer sibling pull requests that all target `dev` and merge in dependency order. Structural
+foundations and default-off behavior are intentionally separated so that most reviews can remain
+independent.
+
+Use a stacked pull request only when a later unit cannot be reviewed or tested without unmerged
+prerequisite code:
+
+- base the dependent pull request temporarily on its immediate prerequisite branch;
+- open it as a draft and state `Depends on #<PR>` prominently;
+- describe which commits belong only to the dependent unit; and
+- after the prerequisite merges, rebase or retarget the dependent pull request to `dev` and
+  verify its resulting diff.
+
+Avoid a single deep stack spanning B1 through C4. It obscures rollback boundaries, makes reviews
+depend on unrelated unfinished work, and prevents independent experiments from merging or being
+reverted cleanly.
+
+## Labels, milestone, and project view
+
+Suggested shared labels:
+
+- `area: dynamic-filters`
+- `track: scheduler` for A1–A4
+- `track: duckdb-contract` for B1 and C1a
+- `track: producer` for C1b–C1e
+- `track: consumer` for C2
+- `track: sip` for C3, C4, and D
+- `behavior-change`
+- `default-off`
+- `conditional`
+
+Use a milestone such as `Dynamic Filters SIP v1` for B1 and C1a–C4. Track A may use the same
+milestone if it shares a release target, but it remains owned by `#1014`.
+
+If a GitHub Project is useful, add both parent issues, all active sub-issues, and their pull
+requests. Useful fields are `Track`, `Design ID`, `Behavior`, `Status`, and `Target release`.
+GitHub Projects can expose the
+[linked pull-request field](https://docs.github.com/en/issues/planning-and-tracking-with-projects/understanding-fields/about-pull-request-fields),
+so the project should derive PR status instead of maintaining a second manual checklist.
+
+## Parent-issue content
+
+Keep each parent issue short and operational:
+
+```markdown
+## Design
+
+<link to the design document at a stable GitHub revision>
+
+## Scope
+
+<one-paragraph v1 scope>
+
+## Sub-issues
+
+<native GitHub sub-issue list>
+
+## Dependency and rollout rules
+
+<short link to this delivery plan and any currently active blockers>
+
+## Exit criteria
+
+- [ ] Required sub-issues are complete.
+- [ ] Correctness tests pass against explicit oracles.
+- [ ] Performance and memory gates pass.
+- [ ] Default and rollback decisions are recorded.
+- [ ] Architecture and operator documentation is updated.
+```
+
+The native sub-issue list is the progress record. Avoid duplicating it with a second hand-edited
+checkbox list in the issue body; retain only exit criteria and information that GitHub cannot
+derive.
+
+## Completion rules
+
+Close a delivery sub-issue when its pull request has merged into `dev` and its stated acceptance
+criteria pass. Closing a code pull request without merging does not complete the sub-issue unless
+the issue is explicitly resolved as unnecessary.
+
+Close `#1010` only after C4 records the v1 default-on or explicit no-ship decision and the required
+documentation is current. Close `#1014` only after A4 removes the scheduler policy, or after a
+recorded decision changes the issue's target outcome based on the measured gate.

--- a/docs/super-sirius/issue-1010-implementation-plan.md
+++ b/docs/super-sirius/issue-1010-implementation-plan.md
@@ -10,7 +10,7 @@ reviewed against the code at the baseline commit, and corrected (each cluster do
 
 | Cluster doc | PRs | One line |
 |---|---|---|
-| [A-1014-priority-pass.md](issue-1010-plans/A-1014-priority-pass.md) | A1–A4 | Instrumentation (IDs, waiter-free publication outcomes, resident high-water, lifecycle counters, coverage), then measure → disable → delete the build-priority pass |
+| [A-1014-priority-pass.md](issue-1010-plans/A-1014-priority-pass.md) | A1–A4 | Instrumentation (IDs, waiter-free publication outcomes, resident high-water, lifecycle counters, coverage), then measure → disable → delete the build-priority pass. Packaging: A1+A2 = one PR (stage-per-commit); A3/A4 separate (decision- and release-gated) |
 | [B-phase0-duckdb-backport.md](issue-1010-plans/B-phase0-duckdb-backport.md) | B1 | **Deferred** (decision 2026-07-08): no fork/backport; executes as the pin-bump playbook when a released DuckDB contains duckdb#22963 (sirius-db/sirius#1123) |
 | [C1ab-adapter-foundation.md](issue-1010-plans/C1ab-adapter-foundation.md) | C1a, C1b | Version-pinned DuckDB candidate adapter, Sirius value snapshots, publisher + claim decoupling; strong target-key types, materialization telemetry, shadow selectivity signal |
 | [C1cde-producer-flags.md](issue-1010-plans/C1cde-producer-flags.md) | C1c–C1e | Target-key entry restructure (fail-closed arity retained), selectivity-gate enforcement A/B, blanket `build_side_has_filter` gate removal A/B |

--- a/docs/super-sirius/issue-1010-implementation-plan.md
+++ b/docs/super-sirius/issue-1010-implementation-plan.md
@@ -1,0 +1,131 @@
+# Implementation Plan: General Dynamic Filters (SIP) + #1014
+
+Companion to [issue-1010-dynamic-filter-sip-design.md](issue-1010-dynamic-filter-sip-design.md);
+baseline `dev` commit `506a1d9f`.
+
+This is the program-level overview. Each PR cluster has a self-contained implementation plan under
+[issue-1010-plans/](issue-1010-plans/), produced against the finalized design, adversarially
+reviewed against the code at the baseline commit, and corrected (each cluster doc ends with a
+"Review resolution" appendix mapping every review finding to its fix).
+
+| Cluster doc | PRs | One line |
+|---|---|---|
+| [A-1014-priority-pass.md](issue-1010-plans/A-1014-priority-pass.md) | A1–A4 | Instrumentation (IDs, waiter-free publication outcomes, resident high-water, lifecycle counters, coverage), then measure → disable → delete the build-priority pass |
+| [B-phase0-duckdb-backport.md](issue-1010-plans/B-phase0-duckdb-backport.md) | B1 | **Deferred** (decision 2026-07-08): no fork/backport; executes as the pin-bump playbook when a released DuckDB contains duckdb#22963 (sirius-db/sirius#1123) |
+| [C1ab-adapter-foundation.md](issue-1010-plans/C1ab-adapter-foundation.md) | C1a, C1b | Version-pinned DuckDB candidate adapter, Sirius value snapshots, publisher + claim decoupling; strong target-key types, materialization telemetry, shadow selectivity signal |
+| [C1cde-producer-flags.md](issue-1010-plans/C1cde-producer-flags.md) | C1c–C1e | Target-key entry restructure (fail-closed arity retained), selectivity-gate enforcement A/B, blanket `build_side_has_filter` gate removal A/B |
+| [C2-probe-consumer.md](issue-1010-plans/C2-probe-consumer.md) | C2 | `probe_batch_handle` refactor, `hash_join_probe_filter_consumer` component, shared gated-mask extraction, mode-aware memory estimator |
+| [C3-routes-and-freeze.md](issue-1010-plans/C3-routes-and-freeze.md) | C3, C4 (+ Track D sketch) | Discovery/lineage/topology-freeze registry, SIP channels + layered targets behind `enable_dynamic_filter_sip`, C3 experiment, C4 default-on gate |
+
+## Dependency graph and starting order
+
+```text
+A1 ──► A2 ──► A3 ──► A4                      (#1014: instrument → switch → default-off → delete)
+B1: deferred — runs at the next DuckDB pin bump; blocks nothing (#1123)
+C1a ──► C1b ──► C1d(enforce)                 (adapter → strong types + shadow signal → enforce)
+  │        │
+  │        └──► C1c (restructure; compat-gated)
+  ├──► C3 ◄── C2                             (registry needs C1a's values; consumer needs C2)
+  │      │
+  │      └──► C4 (default-on; gate also consumes A3's measured state)
+  └── A1 IDs feed C1a telemetry fields (soft: land A1 first)
+
+D (ordered activation) — contingent on C3 telemetry.  E (vNext) — after C4 + aggregate filter budget.
+```
+
+**Start immediately, in parallel:** A1, C1a-groundwork, C2-groundwork. (B1 is deferred to the next pin bump.)
+
+**One sequencing trap:** A1, C1a, and C2 all modify `src/op/sirius_physical_hash_join.cpp`
+(A1: publication outcome instrumentation; C1a: claim-condition rewrite at `:1333`/`:1364` +
+publisher decoupling; C2: the probe-path `probe_batch_handle` refactor, atomics, estimator).
+Land them in that order — A1 → C1a → C2 — to avoid rebase churn.
+
+## Program-wide conventions
+
+Every cluster doc follows these; deviations are bugs.
+
+- **Identity.** `dynamic_filter_publication_plan_id` / `target_id` / `channel_id` / `filter_id`
+  are query-relative monotonic values minted at plan time (design § "Publication, target, channel,
+  and filter identity"). Object addresses are never event identity. A1 introduces the IDs; C1a
+  extends events with the fields A1 defers (`target_id` on `channel_filter_visible`,
+  `replica_bytes`/`devices` on `publication_completed`). **Open coordination item:** the
+  `[dynf_summary]` field vocabulary (plan/target IDs, `keys_admitted` split across planner and
+  ctor lines) must be reconciled between the A1 and C1b PRs before C1b merges — both cluster docs
+  flag it.
+- **Logging/telemetry.** New log lines keep the bracketed component prefix already used by their
+  file (e.g. `[sirius_physical_hash_join]`). Machine-parsed per-query summaries use
+  `[dynf_summary]` at INFO. Per-batch/per-split coverage lines are DEBUG/TRACE. **Every
+  measurement runbook states the log level per pass**: wall-time passes run at INFO (coverage
+  taken from INFO-level summary aggregates); DEBUG/TRACE passes are separate and excluded from
+  timing statistics. Structured (quent) telemetry additions are optional follow-ups — new quent
+  event kinds require Rust model + codegen changes, so v1 telemetry is log-based and
+  `tools/log_analyzer/` grows the matching patterns.
+- **Resident high-water.** Per-query peak requires calling
+  `reset_peak_allocated_bytes` at QueryBegin (the currently logged `peak=` is process-lifetime);
+  the A-cluster doc owns that change and its interaction with the existing pool-stats lines.
+- **Flags** (all config-file + `SET`-registered per the existing `sirius_config` pattern):
+  `dynamic_filter_build_priority={legacy,off}` (A2; gates only the dispatch preference — the
+  feeder-pipeline set is always collected so telemetry stays live in all configs),
+  `dynamic_filter_selectivity_gate_mode={off,shadow,enforce}` (C1b records, C1d enforces),
+  the C1e candidate-expansion flag (default off), and `enable_dynamic_filter_sip` (C3, default
+  off). Flags are read at plan/prepare time — the A/B unit is the query, and runbooks toggle via
+  `SET` between iterations.
+- **Oracles.** An unpatched DuckDB CPU run is never a correctness oracle for
+  LIMIT/TOP-N-shaped tests (it shares the pinned bug); use explicit expected rows or a
+  filters-disabled reference run.
+- **Fail-closed.** A runtime `probe_info`-arity mismatch means structural corruption: the
+  whole-target skip stays, in every flag mode. Per-key suppression applies only to
+  independently-gated components of a structurally valid target.
+
+## Empirical findings that shaped the plans
+
+These came out of executing the review protocol against the baseline (details and transcripts in
+the cluster docs):
+
+1. **The pinned LIMIT/TOP-N bug is masked at default settings** by `late_materialization`
+   (rewrites LIMIT/TOP-N-over-scan into a rowid semi-join whose scan target is legal),
+   `compressed_materialization` (its internal compress projections kill the pushdown — partly a
+   small-integer test artifact), and pipeline-timing races. Runtime wrong results were reproduced
+   only in a dependency-ordered shape with both optimizers disabled. Consequently B1's
+   deterministic red→green gate is **metadata-level** (`probe_info` empty vs non-empty with
+   `late_materialization` disabled in the harness), runtime rows are patched-pin regressions, and
+   the Phase 1 bug issue is framed as latent-but-real, not actively-wrong-at-defaults. This
+   grounded the decision (2026-07-08) to defer the backport entirely and wait for a released fix
+   (#1123); the oracle rule below still applies while on the unpatched pin.
+2. **DuckDB pushes range comparisons into `join_condition`**, not just equalities — the adapter
+   keeps full candidate arity and marks non-equality ordinals per-key not-admitted, mirroring
+   today's runtime skip. Treating them as malformed would silently change plan shape for
+   eq+range joins.
+3. **Today's publisher fan-out is already per-key** except the fail-closed arity guard — so C1c
+   is a restructure with a compatibility gate, not a behavior-changing A/B.
+4. **`sirius_engine::initialize` resets engine state before `initialize_internal`** — the C3
+   registry must be released after topology finalization inside `initialize_internal`, never in
+   `reset()`, and a flag-on test must assert the `topology_frozen` event exists (the failure mode
+   is a silent no-op that green tests would not catch).
+5. **Delim joins route through `plan_comparison_join`** — SIP discovery must explicitly reject
+   `DELIM_JOIN`/`ASOF` producers (`PRODUCER_SHAPE` rejection reason).
+6. **BUILD_PROBE probe-only tasks carry one input batch and predate memory history** — the C2
+   estimator snapshots build rows/bytes into atomics when the build completes rather than reading
+   a second input batch that isn't there.
+
+## Measurement runbooks (shared shape)
+
+Both gates use the same three-configuration protocol on nested/star TPC-H (Q2, Q5, Q8, Q9, Q17,
+Q18, Q21) plus a synthetic many-join chain, with per-pass log levels stated, results compared as
+bags (exact order only where SQL guarantees it), and thresholds from measured run variance:
+
+- **#1014 gate (A2→A3):** filters disabled / legacy priority / priority off. Read: wall time,
+  per-memory-space resident high-water, live pinned build batches + hash tables, feeder-task
+  counts (collected in *all* configs), channel coverage before/after publication. Pass = no
+  material wall-time or peak regression outside variance, with coverage explaining any movement.
+- **SIP gate (C3→C4):** SIP off / SIP on (× priority legacy/off where relevant). Read: per-layer
+  coverage (scan-caught / C1-caught / C2-caught), hash-probe rows and bytes avoided, mask/gather
+  overhead and gate-disable rate, publication outcomes, resident filter bytes, wall time.
+  Default-on requires bit-equivalent results and value the telemetry can attribute; route classes
+  with systematic misses go to Track D consideration instead of default-on.
+
+## Status tracking
+
+Suggested issue structure: one umbrella issue per track (A, B, C) referencing the cluster docs,
+plus the standalone Phase 1 LIMIT/TOP-N bug issue (text in the B cluster doc). Each PR links its
+cluster doc section and states its gate outcome in the PR description.

--- a/docs/super-sirius/issue-1010-plans/A-1014-priority-pass.md
+++ b/docs/super-sirius/issue-1010-plans/A-1014-priority-pass.md
@@ -1,0 +1,360 @@
+# Track A implementation plan — A1 (instrumentation), A2 (`dynamic_filter_build_priority`), A3 (default flip), A4 (pass deletion)
+
+Companion to [issue-1010-dynamic-filter-sip-design.md](../issue-1010-dynamic-filter-sip-design.md); baseline dev 506a1d9f.
+PR IDs covered: **A1** (optionally split A1a/A1b), **A2**, **A3**, **A4**.
+
+## Cluster goal + non-goals
+
+Deliver the design's #1014 sequence (design doc `docs/super-sirius/issue-1010-dynamic-filter-sip-design.md:171-180`): A1 adds query-relative stable IDs (publication/target/channel/filter, design :542-576), waiter-free publication outcome observability (design :762-780), per-memory-space resident high-water, lifecycle counts, and channel-level scan coverage — **with zero dispatch/behavior change** (phasing row A1, design :957). A2 adds the `dynamic_filter_build_priority={legacy,off}` switch gating **only the priority `pop_if` dispatch preference** (task_scheduler.cpp:404-416) — the collect pass (task_scheduler.cpp:241) and the feeder telemetry set stay live in both modes so the acceptance-gate metrics exist under config-3 (see PR A2 step 6); default `legacy` (design :958). A3 flips the default after the acceptance gate (design :182-206) passes; A4 deletes the pass and the scheduler's filter knowledge (design :166-168, :179-180). Non-goals: no Track C/D structural refactor (no `dynamic_filter_publication_plan` value type migration — that is C1a, design :782-817), no quent/Rust model changes (log lines are the A1 mechanism; quent `DynamicFilterChannel` resource deferred to C3 per recon R1 §4), no CAP/STAGGER (design :208-217), no change to what/when filters publish, no per-key fan-out.
+
+## Logging conventions (cluster-wide)
+
+- Every new event line keeps the existing bracketed component prefix of the file it lives in (e.g. `[apply_dynamic_filters]` in dynamic_filter_merge.cpp:158; files whose lines are currently unprefixed, e.g. sirius_physical_hash_join.cpp, gain a bracketed component prefix such as `[sirius_physical_hash_join]` on the new lines only), followed by the machine anchor: `[<component>] [dynf] <event> k=v ...`. The analyzer anchors on the `"[dynf] "` substring; strict regexes never pin the component prefix or filename (recon R1 §5).
+- Machine-parsed per-query summary lines use the `[dynf_summary]` prefix at **INFO**, emitted from `dynamic_filter_query_stats::end_query()`.
+- Per-batch / per-split events (`consume_batch`, `consume_passthrough`, `channel_filter_visible`, `reader_pushdown`, per-key publisher summaries) are **DEBUG or TRACE** and are excluded from timing runs. One-shot per-query events (`publication_plan_created/started/completed`, `target_*`, `channel_closed`) are INFO/DEBUG, mirroring dynamic_filter_publisher.cpp:330.
+- Every measurement runbook in this plan states the log level per pass: **timing passes run at INFO** (default level, `Config::LOG_LEVEL = "info"`, src/config.cpp:49) with coverage derived from INFO-level `[dynf_summary]` aggregates; per-batch coverage forensics come from separate, non-timed DEBUG passes.
+- IDs (`dynamic_filter_publication_plan_id` / `target_id` / `channel_id` / `filter_id`) are query-relative monotonic values (design "Publication, target, channel, and filter identity", :542-576).
+
+---
+
+## PR A1 — instrumentation
+
+### Goal
+
+IDs, outcome observability, lifecycle/feeder counters, resident high-water, channel coverage, and the analyzer contract — instrumentation only, no dispatch or publication behavior change.
+
+### Deliverables (public types/APIs)
+
+**New header `src/include/op/dynamic_filter_ids.hpp`** (op-layer, no deps beyond `<cstdint>`; reused by C1a/C3 for the design's identity model, design :575):
+```cpp
+namespace sirius::op {
+enum class dynamic_filter_publication_outcome : std::uint8_t {
+  PUBLISHED, NO_MATERIALIZATION, FAILED, CANCELLED };
+enum class dynamic_filter_no_materialization_reason : std::uint8_t {
+  NONE, EMPTY_BUILD, NO_BUILD_DELIVERY, UNSUPPORTED_MODE, POLICY_SKIPPED,
+  SOURCE_UNAVAILABLE, CONSUMER_CLOSED };
+using dynamic_filter_publication_plan_id = std::uint32_t;   // query-relative monotonic
+using dynamic_filter_target_id           = std::uint32_t;
+using dynamic_filter_channel_id          = std::uint32_t;
+using dynamic_filter_filter_id           = std::uint32_t;
+const char* to_string(dynamic_filter_publication_outcome);
+const char* to_string(dynamic_filter_no_materialization_reason);
+}
+```
+(Plain aliases in A1; C1a may strengthen to single-member structs — IDs are never compared across kinds in A1 log lines. `NO_BUILD_DELIVERY` = eligible window closed on the normal completion path with zero build batches delivered; `CANCELLED` is reserved for query teardown per design :762-771 and is **not emitted in A1** — see step A1-4.)
+
+**New module `src/include/telemetry/dynamic_filter_telemetry.hpp` + `src/telemetry/dynamic_filter_telemetry.cpp`** — process-global, query-scoped stats/ID singleton (precedent: `sirius_physical_operator::next_operator_id` reset in QueryBegin, src/sirius_context.cpp:179):
+```cpp
+namespace sirius::telemetry {
+class dynamic_filter_query_stats {
+ public:
+  static dynamic_filter_query_stats& instance();
+
+  // --- lifecycle (called from SiriusContext) ---
+  void begin_query(sirius::memory::sirius_memory_reservation_manager* mm);  // reset counters,
+      // cache reservation_aware_resource_adaptor*/fixed_size_host_memory_resource* per space,
+      // record per-space A0 = get_total_allocated_bytes(), P0 = get_peak_total_allocated_bytes()
+  void end_query();          // emits [dynf_summary] INFO lines (step A1-9)
+  void reset_for_testing();
+
+  // --- ID minting (query-relative monotonic, design :575) ---
+  op::dynamic_filter_publication_plan_id next_publication_plan_id();
+  op::dynamic_filter_target_id           next_target_id();
+  op::dynamic_filter_channel_id          next_channel_id();
+  op::dynamic_filter_filter_id           next_filter_id();
+
+  // --- lifecycle counters (all std::atomic, relaxed) ---
+  void count_build_batch_delivered();
+  void on_build_batch_pinned();      void on_build_state_released(std::size_t pinned,
+                                                                  std::size_t tables);
+  void on_hash_table_built();
+  void add_replica_bytes(std::size_t);  void sub_replica_bytes(std::size_t);
+  void count_publication_outcome(op::dynamic_filter_publication_outcome,
+                                 op::dynamic_filter_no_materialization_reason);
+
+  // --- feeder-task tracking (#1014 gate, design :191) ---
+  void set_feeder_pipelines(std::unordered_set<const void*> p);  // task_scheduler::prepare_for_query
+  bool is_feeder(const void* pipeline) const noexcept;
+  void count_feeder_queued();  void count_feeder_dispatch(bool prioritized);
+  void feeder_running_inc();   void feeder_running_dec();
+
+  // --- per-channel consume coverage (INFO-run aggregates; feeds [dynf_summary] channel_coverage) ---
+  void record_channel_batch(op::dynamic_filter_channel_id ch, std::int64_t rows_in,
+                            std::int64_t rows_out, bool post_publication,
+                            std::uint32_t masks_applied, std::uint32_t masks_skipped,
+                            std::uint32_t replica_unavailable);
+  void record_channel_passthrough(op::dynamic_filter_channel_id ch, std::size_t batches,
+                                  std::int64_t rows);
+
+  // --- resident high-water sampler (recon R2 §2) ---
+  void sample_gpu_allocated(int device_id, std::size_t total_allocated_bytes);  // atomic max
+};
+}
+```
+The per-channel coverage aggregates are a small mutex-protected flat map keyed by channel id (channel count per query is tiny); one short mutexed update per consumed batch — far cheaper than the synchronous DEBUG file write it replaces in timed runs, and the reason coverage is available at INFO (see the runbook in PR A2).
+
+**Changed existing APIs:**
+```cpp
+// src/include/op/dynamic_filter_publish_plan.hpp — identity carried on the immutable plan
+struct probe_target {                                   // :44-48, target_id appended LAST:
+  /* existing: filter_set, probe_col_idx, probe_col_type */
+  dynamic_filter_target_id target_id{0}; };
+// (Appended last because the planner constructs it positionally:
+//  `probe_target target{std::move(channel), {}};`, sirius_plan_comparison_join.cpp:447 —
+//  a leading target_id would fail to compile; no other construction sites exist.)
+class dynamic_filter_publish_plan {                     // add:
+  dynamic_filter_publication_plan_id id() const noexcept;   // 0 when !enabled()
+};
+
+// src/include/op/sirius_dynamic_filter.hpp
+class sirius_dynamic_filter {                           // :70-84, add:
+ protected: sirius_dynamic_filter();                    // mints _filter_id
+ public:  [[nodiscard]] dynamic_filter_filter_id filter_id() const noexcept;
+};
+class sirius_dynamic_filter_set {                       // :419-532, add:
+ public:  sirius_dynamic_filter_set();                  // mints _channel_id
+  [[nodiscard]] dynamic_filter_channel_id channel_id() const noexcept;
+};
+
+// src/include/op/dynamic_filter_publisher.hpp — publish() reports its outcome (:55 today: void)
+struct dynamic_filter_publish_result {
+  op::dynamic_filter_publication_outcome outcome;
+  op::dynamic_filter_no_materialization_reason reason;
+  std::size_t filters_built, filters_pushed, active_targets;
+  std::vector<op::dynamic_filter_filter_id> filter_ids;
+};
+[[nodiscard]] dynamic_filter_publish_result publish(cudf::table_view const&, rmm::cuda_stream_view) const;
+
+// src/include/op/sirius_physical_operator.hpp — cheap fast-path probe (new, 3 lines)
+class pipelineable_operator_data {                      // :186-255, add:
+  [[nodiscard]] bool has_read_only_locks() const noexcept { return _read_only_data_batches.has_value(); }
+};
+```
+
+### Step-by-step changes
+
+**A1-1. IDs + stats module (new files).** `src/include/op/dynamic_filter_ids.hpp`, `src/include/telemetry/dynamic_filter_telemetry.hpp`, `src/telemetry/dynamic_filter_telemetry.cpp` as above. Adaptor access per recon R2: GPU `space->get_memory_resource_as<cucascade::memory::reservation_aware_resource_adaptor>()`, HOST `fixed_size_host_memory_resource` — the in-tree precedent is `SiriusContext::log_pool_stats` (sirius_context.cpp:138-141 for the host resource, :152-155 for the GPU adaptor). `memory_space`/adaptor pointers are process-stable (non-copyable/movable, `cucascade/include/cucascade/memory/memory_space.hpp:84-88`) — cache once in `begin_query`. All reads are atomic loads (recon R2 §1). Register the new `.cpp` in the extension source list in `CMakeLists.txt` (wherever `src/telemetry/telemetry_context.cpp` is listed).
+
+**A1-2. Query lifecycle hooks — `src/sirius_context.cpp`.**
+- `QueryBegin` (:165-209): after `log_pool_stats("QueryBegin")` (:173) and next to the operator-ID reset (:179), call `dynamic_filter_query_stats::instance().begin_query(memory_manager_.get())`. **Do not** call any peak reset — `reset_peak_allocated_bytes` is per-stream only (recon R2 §1.4/§4); high-water uses the baseline/delta scheme below, leaving the leak-check semantics of `log_pool_stats` (:128-163) untouched.
+- `QueryEnd` (:211-265): after `query_.reset()` (:220, so filter/replica destructors have already decremented) and immediately before `log_pool_stats("QueryEnd")` (:250), call `.end_query()`. It emits the `[dynf_summary]` INFO lines (step A1-9). High-water closure: per GPU space report `max(sampled_max, P_end > P0 ? P_end : 0) - 0` as absolute bytes plus `A0` baseline, where `P_end = get_peak_total_allocated_bytes()` — exact whenever the query sets a new process peak, tight lower bound otherwise (recon R2 §2.3).
+
+**A1-3. Plan-time identity + planner events — `src/planner/sirius_plan_comparison_join.cpp` (:417-516).**
+- Channel ID: minted automatically by the new `sirius_dynamic_filter_set` ctor at `sirius_physical_plan_generator.cpp:63`.
+- In the target loop (:443-461): after `channel->register_producer()` (:446), set `target.target_id = stats.next_target_id()` (the positional init at :447 is untouched — `target_id` is the last member with a default initializer) and emit `SIRIUS_LOG_INFO("... [dynf] target_planned target={} channel={} cols={} ...")` per target.
+- In the `!filter_targets.empty()` block (:462-493): mint `pub_plan_id = stats.next_publication_plan_id()`, pass it into the `dynamic_filter_publish_plan` ctor (:497-502; extend ctor signature in `dynamic_filter_publish_plan.hpp:54-59` + `.cpp`), and extend the existing INFO (:488-492) into `publication_plan_created`: `[dynf] publication_plan_created pub_plan={} targets={} keys={} build_est={}` listing `target=/channel=` pairs.
+- `candidate_rejected(reason)` (design :1060): append `reason=build_unfiltered` to :427-430 and `reason=no_replica_spaces` to :438-440 as `k=v` fields on the existing lines.
+
+**A1-4. Waiter-free outcomes — producer.**
+- `src/include/op/sirius_physical_hash_join.hpp`: keep the 5-state claim enum (:245-251) unchanged (A1 is observability only; design :762-771's state names map onto it: FINISHED→PUBLISHED/NO_MATERIALIZATION, CLOSED→terminal-without-claim). Add `std::atomic<op::dynamic_filter_no_materialization_reason> _dynamic_filter_skip_reason{NONE};` next to :256-257.
+- `src/op/sirius_physical_hash_join.cpp::publish_dynamic_filters` (:1319-1345): after the successful CAS (:1324-1330) emit `[dynf] publication_started pub_plan={}` (DEBUG). Capture `publish()`'s new result; at the FINISHED store (:1338) emit `[dynf] publication_completed pub_plan={} outcome={} reason={} filters_built={} filters_pushed={} active_targets={} filter_ids=[..]` (INFO); in the catch (:1340-1343) emit `outcome=FAILED` before rethrow.
+- `push_data_batch_partitioned` (:1348-1405): at the non-GPU-residency skip (:1377-1380) store `_dynamic_filter_skip_reason = SOURCE_UNAVAILABLE` and emit `[dynf] publication_skipped pub_plan={} reason=source_unavailable` (DEBUG) — the window stays OPEN and finalize closes it. Increment `count_build_batch_delivered()` for every `port_id == "build" && batch` (:1358), independent of the claim (:1359-1367) — this is gate metric "build batches delivered to joins" (design :192).
+- `on_finalize_operator` (:1407-1428): **compute under the lock, emit after the scope** — the whole body today runs under `op_state_mutex` (:1409) and the lock-discipline rule (Risk 3) forbids logging under it. Restructure: wrap the existing body in an inner `{ std::scoped_lock lg(op_state_mutex); ... }` scope; inside it capture into locals `bool closed_now` (the OPEN→CLOSED CAS at :1413-1418 succeeded) and, when `closed_now && _dynamic_filter_plan.enabled()`, the reason: `UNSUPPORTED_MODE` if `_join_mode != BUILD_PROBE`, else `_dynamic_filter_skip_reason` if set, else `NO_BUILD_DELIVERY` (window closed with zero build delivery on the normal completion path — an OPEN window with reason unset implies no build batch ever arrived GPU-resident, since a delivered resident batch claims via the CAS in `publish_dynamic_filters` :1323-1330 and a non-resident one sets SOURCE_UNAVAILABLE). After the scope emit the terminal `[dynf] publication_completed pub_plan={} outcome=NO_MATERIALIZATION reason={}` (INFO). **`CANCELLED` is not emitted in A1**: query-teardown vs. normal completion is not distinguishable at this call site; the analyzer note documents that teardown closures also report NO_MATERIALIZATION(NO_BUILD_DELIVERY) until C1a's completion-handler wiring can separate them (design :762-771). This makes STANDARD/unavailable/zero-delivery paths observable per design :776-777. In the existing BUILD_PROBE release block (:1420-1426), before setting `DESTROYED` (:1426): if `_hash_table_build_state == BUILT`, call `on_build_state_released(1, tables_built)` (atomic counter update, safe under the lock; idempotent via the state guard, recon R2 §3(c)).
+- BUILD_PROBE build in `execute` (:926-970): inside the locked block, after `_build_table = build_batch_ro` (:946) call `on_build_batch_pinned()`; after each table construction (`filtered_join` :952, `distinct_hash_join` :958-959, `hash_join` :964-965) call `on_hash_table_built()` — gate metric "live pinned BUILD_PROBE batches and live persistent hash tables" (design :193). Instances only; bytes come from the sampler (cudf exposes no table size, recon R2 §3(c)). These are atomic increments, not log lines — safe under `op_state_mutex`.
+
+**A1-5. Publisher outcome + per-target terminals — `src/op/dynamic_filter_publisher.cpp`.**
+- Return `dynamic_filter_publish_result`: early return :77-81 → `{NO_MATERIALIZATION, EMPTY_BUILD}`; early return :87-91 → `{NO_MATERIALIZATION, CONSUMER_CLOSED}`; loop completes with zero filters built (all keys skipped via cast :163-171, bounds :172, domain gate :177-190, zone-map gate :219-231, no supported membership type) → `{NO_MATERIALIZATION, POLICY_SKIPPED}`; otherwise `{PUBLISHED, NONE, ...}` with `filter_ids` collected from the constructed filters (:234-236, :253-254, :258-259 — IDs now minted in the `sirius_dynamic_filter` base ctor).
+- Per-key DEBUG summary (:262-271): append `filter_id_zm={} filter_id_mem={}`.
+- Fan-out loop (:303-329): per target emit `[dynf] target_publication_terminal target={} channel={} outcome={accepted|consumer_closed|arity_mismatch} pushed={}` — `consumer_closed` for `!target_accepts_filters(tgt)` (:307), `arity_mismatch` for the WARN branch (:310-317). Terminal INFO (:330-337): append `pub_plan={}`.
+
+**A1-6. Channel events — `src/op/sirius_dynamic_filter.cpp`.**
+- `push_filter` (:454-473): after the `fetch_add` (:471), **outside `_mu`**, emit `[dynf] channel_filter_visible channel={} filter={} col={} generation={}` (DEBUG; generation = returned count). Rejected pushes (closed :460, remap-drop :463-467, ignored :468) return through a single exit that logs at TRACE with `accepted=0 reason=...` (cheap; only reachable when producers race a closed/remapped channel).
+- `close_for_new_filters` (:492-496): perform `_accepting_filters.exchange(false, std::memory_order_release)` **inside the existing `_mu` scope** — the mutex is what guarantees no `push_filter` (which checks the flag under the same `_mu`, :458-470) lands after close returns; a bare exchange would weaken that barrier and smuggle a semantic change into an instrumentation PR. Capture the exchange result under the lock; **after** lock release, on the true→false edge, emit `[dynf] channel_closed channel={} reason=consumer_drained filters_seen={}` (INFO). Caller today: `sirius_physical_dynamic_filter::on_finalize_operator` (src/op/scan/sirius_physical_dynamic_filter.cpp:43-46) — no change there.
+- Replica-bytes accounting: `sirius_dynamic_in_list_filter` — add bytes at source-set construction (source replica registered, `src/cuda/sirius_dynamic_in_list_filter.cu:195-204`, bytes = `capacity * sizeof(key_type)` as computed for remote replicas at :264) and at each remote replica commit after sync (`_set->replicas.push_back`, :319 region); accumulate into a member `_resident_bytes` and call `add_replica_bytes`. Same for bloom (`src/cuda/sirius_dynamic_bloom_filter.cu:230-239` source, :285-286 bytes, :336 commit). Destructors (`~sirius_dynamic_in_list_filter` sirius_dynamic_in_list_filter.cu:213, `~sirius_dynamic_bloom_filter` :242) call `sub_replica_bytes(_resident_bytes)` — cannot be defaulted anymore. Zone-map: count instances only (scalar bytes negligible; its replication at src/op/sirius_dynamic_filter.cpp:353-411 has no reservation scope). Replica-unavailable WARNs already exist (in_list/bloom/zone-map, e.g. src/op/sirius_dynamic_filter.cpp:403-408) — add `filter_id={}` to each so the analyzer can correlate `replica_unavailable` (design :1068).
+
+**A1-7. Consumer coverage — scan channel (design :1073-1077).**
+- `src/op/scan/dynamic_filter_merge.cpp::apply_dynamic_filters_to_view` (:64-164): count locally (plain ints, no atomics) `masks_applied` (each `cascade_step` with a non-null mask, :147-152 and AST apply :115-119), `masks_skipped_gate` (:139 `continue`), `replica_unavailable` (`is_available_on_device` failures :102, :135). Move the DEBUG line (:158-163) so it also fires when `owned == nullptr` (today silent, :154) with `rows_out = rows_in, masks_applied=0` — this is the "late miss / replica unavailable" signal. Final shape: `[apply_dynamic_filters] [dynf] consume_batch channel={} device={} mode={} rows_in={} rows_out={} visible={} masks_applied={} masks_skipped={} replica_unavailable={}` (`visible` = `filters.filter_count()` snapshot; channel via new `filters.channel_id()`). **In addition**, feed the same locals into the INFO-visible aggregates: one call to `record_channel_batch(channel, rows_in, rows_out, /*post_publication=*/visible > 0, masks_applied, masks_skipped, replica_unavailable)` per batch — this is what makes per-channel pre/post-publication coverage available in the timed INFO runs (`[dynf_summary] channel_coverage`, step A1-9), with the per-batch DEBUG line reserved for non-timed forensic passes.
+- Gate lines: append `channel={}` to the per-filter gate DEBUG (:180-184) and the selectivity-gate DEBUG (:216-219) — `record_keep_ratio`/`record_filter_keep_ratio` don't see the set, so pass the id through from `apply_dynamic_filters_gated_view` (:222-243): add a `dynamic_filter_channel_id` param to the two `dynamic_filter_gate` methods (`src/include/op/scan/dynamic_filter_gate.hpp`).
+- Pre-publication/passthrough coverage — `src/op/scan/sirius_physical_dynamic_filter.cpp::execute` (:48-87): on the fast path (:58-60) emit TRACE `[dynf] consume_passthrough channel={} batches={} rows={} reason={no_filters|gate_disabled}` and call `record_channel_passthrough(channel, batches, rows)`; `rows` computed from cudf views only if `input.has_read_only_locks()` is already true (new accessor, Deliverables), else `rows=-1` — never acquire RO locks on this path (RO locks pin the GPU representation; hot-path rule). `batches` = `input.get_data_batches().size()` (idle vector, no lock). `reason` distinguished by `_filters->has_filters()`. Batch counts satisfy the gate's "rows/batches reaching scan … before/after publication" (design :189).
+- Reader path — `src/op/scan/parquet_gpu_ingestible.cpp` (:727-744): after the merge attempt, emit one per-split DEBUG `[dynf] reader_pushdown channel={} dyn_merged={0|1} static_ast={0|1} visible={}` (dyn_merged = root changed / `dynamic_ast_expression` engaged). One line per split, off the decode path.
+
+**A1-8. Scheduler/executor counters + high-water sampler (no dispatch change).**
+- `src/pipeline/task_scheduler.cpp::prepare_for_query` (:218-242): after `_filter_build_pipelines = collect_filter_build_pipelines(*_query)` (:241), install the set into the singleton: `set_feeder_pipelines({begin,end as const void*})` (safe: `drain_leftover_tasks` at :221-223 precedes, set is read-only thereafter per task_scheduler.hpp:224-228). This install is unconditional — it does not depend on A2's mode (see PR A2 step 6).
+- `task_scheduler::schedule` (:101-115): membership test `gpu_task->get_pipeline()` (accessor `src/include/pipeline/gpu_pipeline_task.hpp:177`) → `count_feeder_queued()`. OOM re-entries bypass this (they go through `itask_executor::schedule`, `src/include/parallel/task_executor.hpp:67`, via `this->schedule` at gpu_pipeline_executor.cpp:405) — documented undercount, not a gauge.
+- Dispatch (`management_eventloop`): a hit on the priority `pop_if` (:404-416, non-null `task`) → `count_feeder_dispatch(true)`; carry a local `bool prioritized` to the dispatch point and, for non-priority pops whose pipeline is a feeder, `count_feeder_dispatch(false)`. Append `feeder={0|1} prioritized={0|1}` **after** `task_id` on the dispatch INFO (:464-465) — its `[mgpu-audit] pipeline_task dispatched to GPU` prefix is grep-load-bearing (comment :462-463); appending preserves it. **Never count inside the `pop_if` predicate** (it runs per queued element per pass, recon R3).
+- `src/pipeline/gpu_pipeline_executor.cpp` running-gauge: **RAII scope guard, not manual paired calls.** The worker lambda (:290-455) has **seven** exit paths, not four: the completion-handler-already-errored return (:301), the cast-failure return (:310), the MAX_OOM_RETRIES-exceeded return (:349 — reachable in real runs, see the SF100 retry-exhaustion comment at :325-333), the reschedule return (:406), the `std::exception` catch return (:411), the unknown-catch return (:416), and the fall-through end (:455). Manual decrements at a subset of these would leak the gauge and spuriously fire the `running_end != 0` WARN. Instead define a tiny guard in gpu_pipeline_executor.cpp:
+  ```cpp
+  struct feeder_running_scope {
+    bool active;
+    explicit feeder_running_scope(bool is_feeder) : active(is_feeder) {
+      if (active) { telemetry::dynamic_filter_query_stats::instance().feeder_running_inc(); } }
+    ~feeder_running_scope() {
+      if (active) { telemetry::dynamic_filter_query_stats::instance().feeder_running_dec(); } }
+  };
+  ```
+  Construct it at lambda entry (:294-296 region, membership via `is_feeder(pipeline)` — `pipeline` captured :285,:294), before `task->execute`. The destructor balances every exit including exceptions; reservation-failure `break`s in `manager_loop` (:174-182) never reach the lambda so never increment; an OOM-rescheduled task re-increments on its next lambda entry after this guard's decrement — balanced.
+- High-water sampler: executor caches `auto* _ra = _memory_space->get_memory_resource_as<reservation_aware_resource_adaptor>()` at construction; call `sample_gpu_allocated(device_id, _ra->get_total_allocated_bytes())` at (a) post-`make_reservation` (:173, beside the existing TRACE :163-172), (b) success point before `task.reset()` (:426), (c) OOM catch after `exc_stream->synchronize()` (:314). Each sample = one relaxed load + one atomic-max (recon R2 §2).
+
+**A1-9. Analyzer contract — `tools/log_analyzer`.**
+- New `tools/log_analyzer/metrics/dynamic_filters.py` exposing `COLUMNS` + `parse(lines, warnings)` (module pattern: `metrics/memory_reservation.py:22-50`), producing per-query rows for: publication outcomes, per-channel coverage (from the INFO `[dynf_summary] channel_coverage` lines; the per-batch DEBUG split at the `publication_completed` timestamp is parsed only when DEBUG lines are present, i.e. in non-timed forensic passes), feeder counts, summary gauges.
+- `tools/log_analyzer/patterns.py`: add `DYNF_*_ANCHOR` static substrings (`"[dynf] "` / `"[dynf_summary] "` + event name) + strict named-group regexes; **keep the emitting filename and component prefix out of the strict regexes** (events span multiple files — recon R1 §5 warns regexes that pin `file.cpp` break on refactor); bump `SHAPE_VERSION` `"1.6"` → `"1.7"` (patterns.py:17). Wire the module in `parse_logs.py::process_query` (:142). QueryBegin/QueryEnd segmentation attributes all `[dynf]` lines automatically (patterns.py:46-51); IDs are for intra-query correlation only.
+- `[dynf_summary]` QueryEnd INFO lines (one per metric family, `k=v`): `publications total= published= no_mat_empty= no_mat_no_delivery= no_mat_mode= no_mat_policy= no_mat_source= no_mat_closed= failed= cancelled=` (`cancelled` always 0 in A1, reserved); `feeder queued= dispatched= prioritized= running_hwm= running_end=` (WARN if `running_end != 0`); `builds delivered= pinned_hwm= pinned_end= tables_hwm= tables_end=`; `replicas bytes_hwm= bytes_end= unavailable=`; per space `high_water space=GPU:{} bytes= baseline_allocated= exact={0|1}`; per channel `channel_coverage channel={} batches_pre= rows_in_pre= rows_out_pre= batches_post= rows_in_post= rows_out_post= passthrough_batches= passthrough_rows= masks_applied= masks_skipped= replica_unavailable=` (pre/post = the `visible` snapshot at consume time: `visible == 0` → pre-publication).
+- **Declared deviations from the design's event list** (design :1060-1071), deferred to C1a: (a) `channel_filter_visible` omits the design's `target_id` field — a producer's `push_filter` cannot know the consuming target pre-C1a; C1a adds it via `published_filter_entry` (design :555-557). (b) `publication_completed` omits `replica_bytes`/`devices` — in A1 they live only in the summary gauges; C1a attaches them to the event. Both are consistent with A1's channel-level-coverage caveat (design :1073-1077).
+
+**Level discipline** (recon R1 §5 + cluster conventions above): per-batch events (`consume_batch`, `consume_passthrough`, `channel_filter_visible`, `reader_pushdown`) at DEBUG/TRACE — excluded from timed runs; one-shot per-query events (`publication_plan_created/started/completed`, `target_*`, `channel_closed`, `[dynf_summary]`) at INFO/DEBUG, mirroring dynamic_filter_publisher.cpp:330. Coverage in timed runs comes exclusively from the INFO `[dynf_summary]` aggregates.
+
+### Tests
+
+Register every new file in `TEST_SOURCES` (CMakeLists.txt:562; enforced by `scripts/check_orphan_tests.py` pre-commit). Run: `pixi run build/release/extension/sirius/test/cpp/sirius_unittest "[dynf_telemetry]"` etc.
+
+**`test/cpp/operator/test_dynamic_filter_telemetry.cpp`** (tag `[dynamic_filter][dynf_telemetry]`; CPU-only cases isolated from GPU cases):
+- `dynf ids: monotonic per query and reset` — `reset_for_testing()`, mint each kind, assert monotonic + independence; CPU-only.
+- `dynf channel: id minted and close idempotent` — construct two `sirius_dynamic_filter_set`s, distinct channel ids; double `close_for_new_filters()` logs once (assert via `_accepting_filters` + a counter, not log scraping); CPU-only.
+- `dynf publisher: empty build → NO_MATERIALIZATION(EMPTY_BUILD)` — plan with one open target, `publish(empty table_view)`; assert result. CPU-only (early return at dynamic_filter_publisher.cpp:77-81 precedes CUDA).
+- `dynf publisher: all targets drained → NO_MATERIALIZATION(CONSUMER_CLOSED)` — close the set first; early return :87-91 precedes `cudaGetDevice` :95. CPU-only.
+- `dynf publisher: filter ids stable across fan-out` — one filter pushed into two channels carries one `filter_id` (design :551-552). **GPU** (in-list construction), pattern `test/cpp/operator/test_sirius_dynamic_filter.cpp:42-58`.
+- `dynf stats: replica bytes balance to zero` — build in-list/bloom, destroy, assert gauge 0 and hwm > 0. **GPU**; multi-GPU replica variant extends `test/cpp/operator/test_sirius_dynamic_filter_mgpu.cpp` (self-skips <2 GPUs, mgpu_test_utils.hpp) and cross-checks against `get_total_allocated_bytes()` deltas as `test_sirius_dynamic_filter_mgpu.cpp:202-220` already does.
+- `dynf gate: keep-ratio lines carry channel id` — exercise `apply_dynamic_filters_gated_view` (extend `test/cpp/scan/test_dynamic_filter_merge.cpp`); assert new counters via return/introspection. **GPU**.
+- `dynf coverage: channel aggregates split pre/post` — drive `apply_dynamic_filters_to_view` with an empty then non-empty set; assert `record_channel_batch` buckets via singleton introspection. **GPU**.
+
+**Hash-join lifecycle** (extend or add `test/cpp/operator/` case, tag `[dynamic_filter][dynf_telemetry]`, **GPU**): drive a BUILD_PROBE join to BUILT then `on_finalize_operator()`; assert pinned/table gauges rise then return to 0; finalize-without-build leaves gauges untouched (idempotence guard on `BUILD_HASH_TABLE_STATE`); finalize-without-delivery reports `NO_MATERIALIZATION(NO_BUILD_DELIVERY)` via `count_publication_outcome` introspection.
+
+**End-to-end summary** (tag `[integration]`, **GPU**): via `GpuExecutionFixture`-style connection (test/cpp/utils/gpu_execution_fixture.hpp:144-186) run a two-join query and assert `dynamic_filter_query_stats` end-state (publications counted, running gauges zero) — asserts state, not log text. **Constraint**: the singleton is process-global and `query_lifecycle_mutex_` serializes queries only per SiriusContext (sirius_context.cpp:894-903), while the unittest binary can hold multiple DuckDB instances (private fixture DBs alongside paused shared envs, gpu_execution_fixture.hpp:82-95, unittest.cpp:115-127) — a concurrent instance's QueryBegin would cross-reset the counters. The test must run with exactly one active instance (the listener pauses shared envs, which already mostly guarantees this); document the constraint in the test file. If it ever flakes, key `begin_query` to the calling SiriusContext and ignore non-owner QueryBegin/QueryEnd.
+
+### Gate & rollback
+
+**Merge gate**: instrumentation only — no dispatch/publication behavior change (the finding-6/finding-7 lock restructurings preserve today's synchronization exactly: close still flips under `_mu`; finalize still transitions under `op_state_mutex`). Proof: full `pixi run make test` green; A/B of a TPC-H run with A1 vs base shows identical `Pushed {} dynamic filter(s)` lines (dynamic_filter_publisher.cpp:330) and identical results; `[dynf_summary] feeder running_end=0` on every query; log_analyzer `_summary.json` has no `FormatWarnings` for the new patterns — **this check requires one untimed DEBUG-level run** so the per-batch patterns (`consume_batch`, `reader_pushdown`, `channel_filter_visible`) are actually present in the log; INFO-only logs exercise only the INFO patterns.
+
+**Rollback**: plain revert (no behavior surface; analyzer `SHAPE_VERSION` reverts with it).
+
+### Dependencies
+
+- A1's `dynamic_filter_ids.hpp` and outcome enums are the identity/outcome vocabulary Track C consumes (C1a value types, design :809-813; C3 telemetry reuse, phasing A1 row "SIP targets reuse this later", design :957). Coordinate the header name/location with the Track C planner **before** A1 merges; C1a may later strengthen aliases to strong types — no A1 consumer compares IDs across kinds.
+- The publisher `publish()` signature change (A1-5) touches the same file C1a will refactor ("publisher claim decoupling", design :962) — keep A1's change minimal (return value only) and land A1 first to avoid rebase churn.
+- `tools/log_analyzer` `SHAPE_VERSION` bump must ship in the same PR as the emitting C++ (freshness contract, patterns.py:11-17).
+- No dependency on B1/Phase 0: A-track changes no candidate admission or filter behavior (B1 gates C1c/C1e/C3, design :961-966).
+
+### Size
+
+Prod ~700-850 LOC C++ (new module ~280 incl. channel-coverage map; ids header ~60; publisher/hash-join/channel/merge/scan/scheduler/executor edits ~310; context hooks ~50) + ~220 LOC Python (analyzer module + patterns) + ~500 LOC tests. **Split recommendation**: A1a = IDs + outcome/channel/coverage events + analyzer; A1b = high-water sampler + feeder/lifecycle counters + summary. Each independently revertible and reviewable (~450-550 LOC).
+
+### Risks
+
+1. **Log-format drift breaking the analyzer** — mitigate: `"[dynf] "` anchor substring on every event, filenames/component prefixes excluded from strict regexes, `SHAPE_VERSION` bump in-PR, `FormatWarnings` check (DEBUG pass) part of the merge gate.
+2. **Hot-path perturbation at the scan fast path** — mitigate: never acquire RO locks in `sirius_physical_dynamic_filter::execute` fast path (:58-60); rows only when `has_read_only_locks()`; per-batch counters are function-local ints; atomics/one short mutexed map update touched once per batch at most; per-batch log lines are DEBUG/TRACE and absent at the INFO timing level.
+3. **Logging under locks** — `push_filter` holds `_mu` (sirius_dynamic_filter.cpp:458-470), `close_for_new_filters` holds `_mu` (:492-496), and hash-join sites hold `op_state_mutex` (:944, :1409): compute under the lock, emit all new lines after lock release (spdlog sink is a synchronous file write). A1-4 and A1-6 spell out the restructuring at the two sites where today's body is entirely under the lock.
+4. **Feeder running-gauge imbalance** — the worker lambda has **seven** exit paths (gpu_pipeline_executor.cpp:301, :310, :349, :406, :411, :416, fall-through :455); the RAII `feeder_running_scope` guard (A1-8) balances all of them including exceptional unwinds; reservation-failure `break`s (:174-182, :280-283) never reach the lambda so never increment; `running_end != 0` WARN in the summary is the runtime tripwire; OOM re-entries re-increment on next lambda entry.
+5. **Singleton vs. tests/error paths** — IDs/counters are process-global reset at QueryBegin; tests use `reset_for_testing()` and never assert absolute IDs; QueryEnd runs on error paths too (sirius_context.cpp:211-265) so the summary always flushes; filter destructors run at `query_.reset()` (:220), before the summary (:250). Multi-instance test processes: see the end-to-end summary test constraint above.
+6. **High-water is a lower bound when the query doesn't set a process peak** — mitigation: report `exact={0|1}` (P_end > P0) per space; the #1014-interesting case (peak-setting queries) is exact (recon R2 §2.3); avoids touching cucascade (no public total-peak reset, recon R2 §4).
+7. **`[mgpu-audit]` grep contract** — dispatch-line fields are appended after `task_id` only; prefix and existing fields unchanged (task_scheduler.cpp:462-465); the existing regexes use unanchored `task_id=(\S+)` and tolerate appended fields (mgpu_test_utils.hpp:273, test_gpu_execution_tpch_mgpu_audit.cpp:80).
+8. **Destructor accounting on device-teardown failure** — bloom/in-list destructors currently `= default`; new decrement bodies must be `noexcept`-safe (decrement first, then member teardown), mirroring the zone-map destructor's catch-all discipline (src/op/sirius_dynamic_filter.cpp:323-342).
+
+---
+
+## PR A2 — `dynamic_filter_build_priority` switch
+
+### Goal
+
+A per-query switch that disables **only the priority dispatch preference** (the `pop_if` branch), leaving the collect pass and all A1 feeder telemetry live in both modes — so the A2→A3 acceptance gate can compare configs with full metrics on both sides. Default `legacy` (design :958).
+
+### Deliverables (public types/APIs)
+
+```cpp
+// src/include/sirius_config.hpp (namespace sirius), next to operator_params :118
+enum class dynamic_filter_build_priority_mode : std::uint8_t { LEGACY, OFF };
+inline bool string_to_enum(std::string_view sv, dynamic_filter_build_priority_mode& out); // "legacy"/"off"
+inline bool enum_to_string(dynamic_filter_build_priority_mode m, std::string& s);
+// operator_params field:
+dynamic_filter_build_priority_mode dynamic_filter_build_priority =
+    dynamic_filter_build_priority_mode::LEGACY;
+
+// src/include/pipeline/task_scheduler.hpp — ctor gains live-params pointer (pattern:
+// downgrade_executors pointer param, :81-82):
+explicit task_scheduler(..., const std::vector<...>* downgrade_executors = nullptr,
+                        const sirius::operator_params* op_params = nullptr);
+// unit-testable gate (free function, declared in task_scheduler.hpp):
+[[nodiscard]] bool filter_build_priority_enabled(const sirius::operator_params* p) noexcept;
+// per-query snapshot member (avoids torn reads on the dispatch loop):
+bool _priority_dispatch_enabled = true;
+// test seams (pattern: set_no_pref_rr_counter_for_testing, :213-216):
+[[nodiscard]] std::size_t filter_build_pipeline_count_for_testing() const noexcept;
+[[nodiscard]] bool priority_dispatch_enabled_for_testing() const noexcept;
+```
+
+### Step-by-step changes
+
+1. **`src/include/sirius_config.hpp`**: enum + ADL `string_to_enum`/`enum_to_string` (pattern: `exec::queue_ordering`, src/include/exec/inspectable_mpsc.hpp:41-58); field in `operator_params` after `dynamic_filter_keep_threshold` (:115-118).
+2. **`src/sirius_config.cpp`**: `r.optional("dynamic_filter_build_priority", opt.dynamic_filter_build_priority);` in `from_yaml(..., operator_params&)` (:160-181, before `r.reject_unknown()` :180) — the yaml reader resolves the enum via ADL as for `task_queue_ordering`.
+3. **`src/sirius_extension.cpp`**: `SetDynamicFilterBuildPriority(ClientContext&, SetScope, Value&)` after `SetDynamicFilterKeepThreshold` (:1638-1651): `get_operator_params(context)` (helper :1480-1488, silently no-ops pre-LOAD — recon R3 gotcha 1), parse via `string_to_enum`, `InvalidInputException` on bad value (enum-as-VARCHAR precedent: `expression_evaluator_strategy`). Register in `InitialGPUConfigs` after the `dynamic_filter_keep_threshold` block (:1867-1874): `LogicalType::VARCHAR`, default `Value("legacy")` derived from a fresh `sirius::operator_params{}` via `enum_to_string` (default-Value convention, :1847).
+4. **`src/include/pipeline/task_scheduler.hpp`**: ctor param `const sirius::operator_params* op_params = nullptr` appended (:76-82); member `const sirius::operator_params* _op_params = nullptr;`; member `bool _priority_dispatch_enabled = true;`; declare `filter_build_priority_enabled` + the two test seams (Deliverables).
+5. **`src/sirius_context.cpp:490-496`**: pass `&config_.get_operator_params()` as the new argument (lifetime safe: `config_` and `task_scheduler_` are SiriusContext members; `config_` assigned in `initialize` before scheduler construction and `task_scheduler_.reset()` at :530 precedes SiriusContext member teardown).
+6. **`src/pipeline/task_scheduler.cpp` — gate the dispatch preference only.**
+   - `prepare_for_query` (:218-242): the collect call at :241 is **unchanged** — `_filter_build_pipelines = collect_filter_build_pipelines(*_query);` runs in both modes, and A1's `set_feeder_pipelines` install stays unconditional. This keeps feeder queued/dispatched/running metrics live under `off` (config-3), which the acceptance gate needs to explain any movement (design :186-201). Add the per-query snapshot: `_priority_dispatch_enabled = filter_build_priority_enabled(_op_params);` — read once per query at prepare so a mid-query `SET` can't tear the dispatch loop's decision.
+   - `management_eventloop` (:404): change the priority-branch guard from `if (!_filter_build_pipelines.empty())` to `if (_priority_dispatch_enabled && !_filter_build_pipelines.empty())`. The `pop_if` body is untouched.
+   - `filter_build_priority_enabled` = `!p || p->dynamic_filter_build_priority == LEGACY`. Live-read per query makes `SET` effective at the next query — required by measure→disable→delete (recon R3 §3a.5).
+   - Under `off`, feeder counters keep counting and the dispatch INFO carries `feeder=1 prioritized=0` — `prioritized=0` is the correct config-3 signal (not zeroed counters). **Honest cost note**: `off` retains the per-query `collect_filter_build_pipelines` plan walk and the scheduler's filter knowledge (`publishes_dynamic_filters()` at :190) — the layering violation is removed by A4, not A2; `off` differs from `legacy` only in dispatch order.
+7. **Docs**: one paragraph in `docs/super-sirius/dynamic-filters.md` documenting the switch (dispatch-preference-only scope included) and its #1014 purpose.
+
+### Tests
+
+- **`test/cpp/config/test_config.cpp` additions** (CPU-only): YAML `dynamic_filter_build_priority: off` parses to `OFF` (the yaml reader's StringEnum path takes the string "off", not a YAML-1.1 boolean — verified, yaml_reader.hpp:214-220); default is `LEGACY`; unknown value fails; `string_to_enum/enum_to_string` round-trip.
+- **`test/cpp/planner/test_dynamic_filter_build_priority.cpp`** (CPU-only): unit-test `filter_build_priority_enabled` (nullptr → true; LEGACY → true; OFF → false).
+- **SQL setter** (extend the router-fixture pattern, test/cpp/planner/test_dynamic_filter_router.cpp:43-61): registered `SiriusContext`, `SET dynamic_filter_build_priority='off'` via connection, assert the live `operator_params` field flipped; invalid value throws `InvalidInputException`.
+- **Scheduler behavior** (**GPU**, `[integration]`): with a wired dynamic-filter query prepared, `filter_build_pipeline_count_for_testing()` > 0 under **both** modes (the collect pass always runs), and `priority_dispatch_enabled_for_testing()` is true under `legacy`, false under `off` (uses the shared integration env's SiriusContext).
+
+### Gate & rollback (incl. A2→A3 measurement protocol runbook)
+
+**A2 merge gate**: default `legacy` produces byte-identical scheduling behavior (the collect call and the `pop_if` run exactly as today; the added guard reads a bool that is true); `off` verified by the unit/integration tests. No measurement needed to merge (design :958 "legacy default; no deletion").
+
+**A2→A3 measurement protocol (the #1014 acceptance gate, design :182-206)** — run on the GB10 box (datasets per memory note; `SIRIUS_CONFIG_FILE` override):
+
+- Three configs, serialized in one process each (SET is per-DB-instance global — never interleave connections, recon R3 §4), `LOAD` before `SET` (gotcha: pre-LOAD SET silently dropped, sirius_extension.cpp:1480-1488):
+  1. `SET enable_dynamic_filter_pushdown=false`
+  2. `... =true; SET dynamic_filter_build_priority='legacy'`
+  3. `... =true; SET dynamic_filter_build_priority='off'`
+- Queries: nested/star TPC-H shapes (Q5, Q7, Q8, Q9, Q21) at SF≥10, plus a synthetic many-join chain (≥6 chained joins over one fact table) added to the benchmark script.
+- **Timing passes — log level INFO** (the default, `Config::LOG_LEVEL = "info"`, src/config.cpp:49): ≥7 iterations per query per config, first discarded. All gate metrics come from these passes: wall time (QueryBegin/QueryEnd segments); per-memory-space high-water (`[dynf_summary] high_water`, `exact=` flag noted); feeder queued/dispatched/prioritized/running-hwm (live in **all three** configs; under config-3 `prioritized=0` by construction); build batches delivered; pinned-build/hash-table hwm; replica bytes hwm; **per-channel coverage from the INFO `[dynf_summary] channel_coverage` aggregates** (batches/rows split pre/post publication via the `visible` snapshot). No DEBUG/TRACE events fire at this level, so the timed numbers are unperturbed by per-batch logging.
+- **Coverage-forensics passes — log level DEBUG, excluded from all wall-time statistics**: 1 iteration per (query, config), run separately after the timing passes. These produce the per-batch `consume_batch` / per-split `reader_pushdown` / `channel_filter_visible` detail (including the analyzer's timestamp-split at `publication_completed`) used only to diagnose any coverage delta the INFO aggregates flag. The runbook records the level of every pass in the run manifest.
+- Results: config-2 vs config-3 outputs bag-compared (exact order only for ORDER BY queries); config-1 is the no-filter oracle for both.
+- **Pass** (design :199-201): config-3 has no material wall-time or resident-peak regression vs config-2 outside run variance (median deltas within the config-2 run-to-run spread), results equivalent, and coverage deltas explain any movement. Coverage is diagnostic, not a veto. **Fail with scan-I/O regression** → retain rollback; route-local ordering (Track D) is the recovery, never CAP/STAGGER (design :203-217).
+
+**Rollback**: revert or leave dormant (`legacy` default = status quo).
+
+### Dependencies
+
+A1 → A2: A2's gate evidence uses A1 counters and the `[dynf_summary]` channel-coverage aggregates; A2's `prioritized=0`-under-off signal uses A1's dispatch counters.
+
+### Size
+
+Prod ~130 LOC, tests ~160 LOC. Single PR.
+
+### Risks
+
+1. **Pointer-param lifetime / stale reads** — `config_` outlives `task_scheduler_` (SiriusContext members; scheduler reset at sirius_context.cpp:530); the mode is snapshotted once per query into `_priority_dispatch_enabled` at prepare (:218-242) so a mid-query SET can't tear the dispatch decision; ctor-snapshot of the whole params explicitly rejected (would freeze the flag, recon R3 gotcha 3).
+2. **Silent scope confusion** — `off` is dispatch-preference-only; the doc paragraph and PR description must say so, or users will expect the collect-pass cost and the scheduler's filter knowledge to disappear (that is A4).
+
+---
+
+## PR A3 — default flip (after gate passes)
+
+- Flip the in-struct default to `OFF` (sirius_config.hpp field from A2-1). SQL-option default follows automatically (fresh `operator_params{}` convention, sirius_extension.cpp:1847-style). Update the doc paragraph + release note: rollback = `SET dynamic_filter_build_priority='legacy'` or YAML, kept exactly one release (design :177-178).
+- **Gate**: the A2→A3 measurement protocol above has passed. **Rollback**: `SET`/YAML, no rebuild; revert = one-line default flip. **Size**: ~10 LOC + docs.
+
+## PR A4 — pass deletion (after one default-off release)
+
+- Delete: `collect_filter_build_pipelines` + namespace block (task_scheduler.cpp:154-216), the assignment (:241), the `_priority_dispatch_enabled` snapshot + `filter_build_priority_enabled` gate function, `_filter_build_pipelines` member (task_scheduler.hpp:224-228), the priority `pop_if` branch incl. the A2 guard (task_scheduler.cpp:400-416), the now-unused `#include "op/sirius_physical_hash_join.hpp"` (task_scheduler.cpp:24) — this removes the scheduler's filter knowledge (`publishes_dynamic_filters()` use at :190), resolving the layering violation (design :166-168). (Deletion inventory verified complete: the only uses of `sirius_physical_hash_join` in task_scheduler.cpp are the include at :24 and the `dynamic_cast`/`publishes_dynamic_filters()` at :189-190.)
+- Delete the A2 flag end-to-end (enum, field, yaml line, setter, registration, ctor param, test seams) and A1's feeder counters/`set_feeder_pipelines`/`feeder_running_scope` (their source set is gone); keep all other A1 telemetry. Note in the PR: YAML files carrying the key now fail at startup via `reject_unknown` (sirius_config.cpp:180) — intended, loud.
+- **Tests**: delete A2 tests; optionally keep an assertion that dispatch order for feeder pipelines is now unpreferenced (primarily covered by the full suite passing). **Rollback**: revert restores flag + pass; only after a full default-off release confirms (design :179-180). **Size**: net ≈ −220 LOC.
+
+## Cluster dependencies & ordering
+
+- A1 → A2 (A2's gate evidence uses A1 counters + summary aggregates) → protocol run → A3 → one release → A4.
+- The three-config protocol is valid on the current pin because configs 2 and 3 share identical Phase 1 publication behavior.
+- Track C coordination and the analyzer freshness contract as stated in PR A1 Dependencies.
+
+---
+
+## Review resolution appendix
+
+| # | Finding | Resolution |
+|---|---------|-----------|
+| 1 | MAJOR — worker lambda has seven exits, not four; manual gauge decrements leak | Applied as proposed: RAII `feeder_running_scope` guard at lambda entry (A1-8); Risk 4 rewritten to enumerate all seven exits (verified in gpu_pipeline_executor.cpp:290-455, incl. the reachable MAX_OOM_RETRIES return); `running_end != 0` WARN kept as tripwire. |
+| 2 | MAJOR — A2 ternary zeroed config-3 feeder telemetry the gate needs | Applied as proposed: collect call at :241 and `set_feeder_pipelines` install stay unconditional; the flag gates only the `pop_if` branch guard at :404 (via a per-query `_priority_dispatch_enabled` snapshot rather than a raw per-pass read, preserving the plan's no-torn-reads property); `prioritized=0` under `off` replaces the deleted "zero-counter cross-check" claim; A2 test updated (count > 0 in both modes, new `priority_dispatch_enabled_for_testing()` seam); A4 inventory updated; honest note added that `off` keeps the collect cost and layering violation until A4. |
+| 3 | MAJOR — coverage metrics required DEBUG logging, contaminating or emptying timed runs | Applied per the summary-aggregation variant: per-channel pre/post-publication batch/row aggregates added to the INFO `[dynf_summary]` (`channel_coverage`, fed by `record_channel_batch`/`record_channel_passthrough` in A1-7); runbook rewritten to state the log level per pass — timing at INFO with coverage from INFO aggregates, separate untimed DEBUG forensics passes; A1 merge-gate FormatWarnings check now explicitly requires one untimed DEBUG run. |
+| 4 | MINOR — `target_id` first in `probe_target` breaks positional init at sirius_plan_comparison_join.cpp:447 | Applied: `target_id` appended as the **last** member with a default initializer; :447 untouched; rationale noted inline in Deliverables. |
+| 5 | MINOR — wrong citation for adaptor-access pattern | Applied: A1-1 now cites `SiriusContext::log_pool_stats` (sirius_context.cpp:138-141 host / :152-155 GPU adaptor); the dynamic_filter_replica_reservation.hpp:76 citation removed (it is `get_memory_resource_of<Tier::GPU>` on a reservation — different API). |
+| 6 | MINOR — bare `exchange` in `close_for_new_filters` weakens the `_mu` close barrier | Applied: A1-6 specifies `exchange` **inside** the existing `_mu` scope (push_filter checks the flag under the same mutex, :458-470), INFO line emitted after lock release; zero behavior change preserved and stated in the A1 gate. |
+| 7 | MINOR — finalize terminal event would log under `op_state_mutex`, violating the plan's own Risk 3 | Applied: A1-4 now states the compute-under-lock / emit-after-scope split explicitly (inner scoped_lock block, locals for CAS result + outcome/reason, log after the scope); Risk 3 updated to reference both restructured sites. |
+| 8 | MINOR — CANCELLED overloaded for normal zero-delivery completion, diverging from design :762-771 | Applied: new `NO_BUILD_DELIVERY` value in `dynamic_filter_no_materialization_reason`; finalize reports `NO_MATERIALIZATION(NO_BUILD_DELIVERY)` when the window closes with no delivery and no skip reason; `CANCELLED` reserved for teardown and **not emitted in A1** (teardown vs. normal completion is indistinguishable at this call site — documented for the analyzer; C1a's completion-handler wiring can separate them). Summary gains `no_mat_no_delivery=`; `cancelled=` reads 0 in A1. |
+| 9 | MINOR — silent deviations from the design's event signatures | Applied: A1-9 now declares both deferred fields — `channel_filter_visible` omits `target_id` (unknowable pre-C1a; C1a adds via `published_filter_entry`, design :555-557) and `publication_completed` omits `replica_bytes`/`devices` (gauges only in A1; C1a attaches them). |
+| 10 | MINOR — process-global singleton vs. multiple DB instances in one test process | Applied via the note variant: the end-to-end summary test documents the one-active-instance constraint (shared envs paused by the listener, gpu_execution_fixture.hpp:82-95, unittest.cpp:115-127) with the owner-keyed `begin_query` fallback named if it flakes; Risk 5 cross-references it. |

--- a/docs/super-sirius/issue-1010-plans/A-1014-priority-pass.md
+++ b/docs/super-sirius/issue-1010-plans/A-1014-priority-pass.md
@@ -1,7 +1,10 @@
 # Track A implementation plan — A1 (instrumentation), A2 (`dynamic_filter_build_priority`), A3 (default flip), A4 (pass deletion)
 
 Companion to [issue-1010-dynamic-filter-sip-design.md](../issue-1010-dynamic-filter-sip-design.md); baseline dev 506a1d9f.
-PR IDs covered: **A1** (optionally split A1a/A1b), **A2**, **A3**, **A4**.
+Work items: **A1** (commits A1a/A1b) and **A2** ship together as **one PR** with stage-per-commit
+history (each commit independently revertible; both are zero-behavior-change at defaults, so no
+review or timing boundary separates them). **A3** and **A4** are separate PRs because they are
+gated on the measurement outcome and on a release cycle respectively, not on code volume.
 
 ## Cluster goal + non-goals
 
@@ -17,7 +20,7 @@ Deliver the design's #1014 sequence (design doc `docs/super-sirius/issue-1010-dy
 
 ---
 
-## PR A1 — instrumentation
+## A1 — instrumentation (commits A1a/A1b of the Track A PR)
 
 ### Goal
 
@@ -226,7 +229,7 @@ Register every new file in `TEST_SOURCES` (CMakeLists.txt:562; enforced by `scri
 
 ### Size
 
-Prod ~700-850 LOC C++ (new module ~280 incl. channel-coverage map; ids header ~60; publisher/hash-join/channel/merge/scan/scheduler/executor edits ~310; context hooks ~50) + ~220 LOC Python (analyzer module + patterns) + ~500 LOC tests. **Split recommendation**: A1a = IDs + outcome/channel/coverage events + analyzer; A1b = high-water sampler + feeder/lifecycle counters + summary. Each independently revertible and reviewable (~450-550 LOC).
+Prod ~700-850 LOC C++ (new module ~280 incl. channel-coverage map; ids header ~60; publisher/hash-join/channel/merge/scan/scheduler/executor edits ~310; context hooks ~50) + ~220 LOC Python (analyzer module + patterns) + ~500 LOC tests. **Commit split**: A1a = IDs + outcome/channel/coverage events + analyzer; A1b = high-water sampler + feeder/lifecycle counters + summary. Each an independently revertible commit (~450-550 LOC).
 
 ### Risks
 
@@ -241,7 +244,7 @@ Prod ~700-850 LOC C++ (new module ~280 incl. channel-coverage map; ids header ~6
 
 ---
 
-## PR A2 — `dynamic_filter_build_priority` switch
+## A2 — `dynamic_filter_build_priority` switch (final commit of the Track A PR)
 
 ### Goal
 
@@ -316,7 +319,7 @@ A1 → A2: A2's gate evidence uses A1 counters and the `[dynf_summary]` channel-
 
 ### Size
 
-Prod ~130 LOC, tests ~160 LOC. Single PR.
+Prod ~130 LOC, tests ~160 LOC. Final commit of the Track A PR.
 
 ### Risks
 
@@ -325,12 +328,12 @@ Prod ~130 LOC, tests ~160 LOC. Single PR.
 
 ---
 
-## PR A3 — default flip (after gate passes)
+## A3 — default flip (separate PR, after gate passes)
 
 - Flip the in-struct default to `OFF` (sirius_config.hpp field from A2-1). SQL-option default follows automatically (fresh `operator_params{}` convention, sirius_extension.cpp:1847-style). Update the doc paragraph + release note: rollback = `SET dynamic_filter_build_priority='legacy'` or YAML, kept exactly one release (design :177-178).
 - **Gate**: the A2→A3 measurement protocol above has passed. **Rollback**: `SET`/YAML, no rebuild; revert = one-line default flip. **Size**: ~10 LOC + docs.
 
-## PR A4 — pass deletion (after one default-off release)
+## A4 — pass deletion (separate PR, after one default-off release)
 
 - Delete: `collect_filter_build_pipelines` + namespace block (task_scheduler.cpp:154-216), the assignment (:241), the `_priority_dispatch_enabled` snapshot + `filter_build_priority_enabled` gate function, `_filter_build_pipelines` member (task_scheduler.hpp:224-228), the priority `pop_if` branch incl. the A2 guard (task_scheduler.cpp:400-416), the now-unused `#include "op/sirius_physical_hash_join.hpp"` (task_scheduler.cpp:24) — this removes the scheduler's filter knowledge (`publishes_dynamic_filters()` use at :190), resolving the layering violation (design :166-168). (Deletion inventory verified complete: the only uses of `sirius_physical_hash_join` in task_scheduler.cpp are the include at :24 and the `dynamic_cast`/`publishes_dynamic_filters()` at :189-190.)
 - Delete the A2 flag end-to-end (enum, field, yaml line, setter, registration, ctor param, test seams) and A1's feeder counters/`set_feeder_pipelines`/`feeder_running_scope` (their source set is gone); keep all other A1 telemetry. Note in the PR: YAML files carrying the key now fail at startup via `reject_unknown` (sirius_config.cpp:180) — intended, loud.
@@ -338,7 +341,7 @@ Prod ~130 LOC, tests ~160 LOC. Single PR.
 
 ## Cluster dependencies & ordering
 
-- A1 → A2 (A2's gate evidence uses A1 counters + summary aggregates) → protocol run → A3 → one release → A4.
+- Commit order A1a → A1b → A2 within the Track A PR (A2's gate evidence uses A1 counters + summary aggregates) → merge → protocol run → A3 PR → one release → A4 PR.
 - The three-config protocol is valid on the current pin because configs 2 and 3 share identical Phase 1 publication behavior.
 - Track C coordination and the analyzer freshness contract as stated in PR A1 Dependencies.
 

--- a/docs/super-sirius/issue-1010-plans/A-track-agent-handoff.md
+++ b/docs/super-sirius/issue-1010-plans/A-track-agent-handoff.md
@@ -18,17 +18,21 @@ stop and ask for them):
 
 ## Definition of done
 
-1. PR A1 merged (instrumentation, split as A1a/A1b if review size demands).
-2. PR A2 merged (`dynamic_filter_build_priority={legacy,off}`, default `legacy`).
-3. The three-config measurement executed per the runbook, results posted as a comment on #1124
+1. **One Track A PR merged**, containing A1 (instrumentation) and A2 (the
+   `dynamic_filter_build_priority={legacy,off}` switch, default `legacy`) as clean, separately
+   revertible commits: A1a, A1b, A2. Both stages are zero-behavior-change at defaults; the PR
+   body carries each stage's gate evidence.
+2. The three-config measurement executed per the runbook, results posted as a comment on #1124
    with the raw data attached.
-4. **Stop for human sign-off.** If the human approves and the gate passed: PR A3 (default flip,
-   ~10 LOC). A4 is out of scope regardless.
+3. **Stop for human sign-off.** If the human approves and the gate passed: PR A3 (default flip,
+   ~10 LOC — separate because it is decision-gated on the measurement). A4 is out of scope
+   regardless (release-gated).
 
 ## Ground rules
 
-- Branch off `dev`; PRs against `sirius-db/sirius` `dev` via `gh`. One PR per stage. Reference
-  #1124 in each PR body and check off its task list as you go.
+- Branch off `dev`; PRs against `sirius-db/sirius` `dev` via `gh`. A1+A2 ship as one PR with
+  stage-per-commit history; A3 is its own small PR after sign-off. Reference #1124 in each PR
+  body and check off its task list as you go.
 - Baseline for all file:line citations in the plan is commit `506a1d9f`. `dev` may have moved —
   verify each cited site before editing it; if a site has materially changed, stop and report
   rather than guessing.
@@ -69,9 +73,9 @@ Machine notes (apply if this is the GB10 box `pdx02-zeno-01`; otherwise adapt):
 - Log analysis: run with `SIRIUS_LOG_LEVEL=trace` + `SIRIUS_LOG_DIR`, then
   `python3 tools/log_analyzer/parse_logs.py <log>`.
 
-## Stage 1 — PR A1 (instrumentation)
+## Stage 1 — commits A1a/A1b (instrumentation)
 
-Implement exactly per `A-1014-priority-pass.md` § "PR A1". Recommended split: **A1a** (IDs +
+Implement exactly per `A-1014-priority-pass.md` § "A1", as two clean commits: **A1a** (IDs +
 outcome/channel/coverage events + analyzer) then **A1b** (high-water sampler + feeder/lifecycle
 counters + summary) — each ~450–550 LOC and independently revertible.
 
@@ -92,15 +96,15 @@ them:
   line carries the `[dynf] ` anchor. The analyzer (`tools/log_analyzer`) gets its module +
   `SHAPE_VERSION` bump **in the same PR**.
 
-**Merge gate (prove all of it, put the evidence in the PR body):** full `pixi run make test`
+**Stage gate (prove all of it, put the evidence in the PR body):** full `pixi run make test`
 green; one TPC-H A/B run (A1 vs base) with identical results and identical
 `Pushed {} dynamic filter(s)` line multisets; `[dynf_summary] feeder running_end=0` on every
 query; log_analyzer reports no `FormatWarnings` for the new patterns — this last check requires
 **one untimed DEBUG-level run** so the per-batch patterns actually appear in the log.
 
-## Stage 2 — PR A2 (the switch)
+## Stage 2 — commit A2 (the switch), then open the PR
 
-Implement per `A-1014-priority-pass.md` § "PR A2". The one thing that matters most:
+Implement per `A-1014-priority-pass.md` § "A2" as the final commit, then open the single Track A PR. The one thing that matters most:
 
 - The flag gates **only** the priority `pop_if` dispatch branch. `collect_filter_build_pipelines`
   and the feeder-telemetry install run unconditionally in both modes — the measurement needs
@@ -108,7 +112,7 @@ Implement per `A-1014-priority-pass.md` § "PR A2". The one thing that matters m
 - Mode is snapshotted once per query at `prepare_for_query` (`_priority_dispatch_enabled`), so a
   mid-query `SET` cannot tear the dispatch loop.
 
-**Merge gate:** default `legacy` is behaviorally identical; the CPU unit tests + the GPU
+**Stage gate (also in the PR body):** default `legacy` is behaviorally identical; the CPU unit tests + the GPU
 integration test from the plan pass (`filter_build_pipeline_count_for_testing() > 0` in both
 modes; `priority_dispatch_enabled_for_testing()` flips).
 

--- a/docs/super-sirius/issue-1010-plans/A-track-agent-handoff.md
+++ b/docs/super-sirius/issue-1010-plans/A-track-agent-handoff.md
@@ -1,0 +1,167 @@
+# Agent handoff: implement and evaluate Track A (issue #1014) end to end
+
+You are an agent on a performance machine. Your job is to implement, measure, and (conditionally)
+land the Track A sequence for [sirius-db/sirius#1124](https://github.com/sirius-db/sirius/issues/1124)
+(which resolves [#1014](https://github.com/sirius-db/sirius/issues/1014)): instrument the dynamic-filter
+pipeline, add a switch for the build-priority pass, run the acceptance measurement, and flip the
+default if the gate passes. Deleting the pass (A4) is **not** in this engagement — it happens a
+release later.
+
+**Read these two files before writing any code** (they should sit next to this file; if missing,
+stop and ask for them):
+
+1. `A-1014-priority-pass.md` — the authoritative implementation plan. It has exact file:line
+   targets, C++ signatures, test lists, and a review-resolution appendix. Follow it. This handoff
+   only sequences your work and adds machine/process guidance; where they disagree, the plan wins.
+2. `../issue-1010-dynamic-filter-sip-design.md` — the design. Read § "Issue #1014" and
+   § "Verified execution-model facts" for why the work is shaped this way.
+
+## Definition of done
+
+1. PR A1 merged (instrumentation, split as A1a/A1b if review size demands).
+2. PR A2 merged (`dynamic_filter_build_priority={legacy,off}`, default `legacy`).
+3. The three-config measurement executed per the runbook, results posted as a comment on #1124
+   with the raw data attached.
+4. **Stop for human sign-off.** If the human approves and the gate passed: PR A3 (default flip,
+   ~10 LOC). A4 is out of scope regardless.
+
+## Ground rules
+
+- Branch off `dev`; PRs against `sirius-db/sirius` `dev` via `gh`. One PR per stage. Reference
+  #1124 in each PR body and check off its task list as you go.
+- Baseline for all file:line citations in the plan is commit `506a1d9f`. `dev` may have moved —
+  verify each cited site before editing it; if a site has materially changed, stop and report
+  rather than guessing.
+- **A1 and A2 must not change behavior** (A1: no dispatch/publication change; A2: `legacy`
+  default is byte-identical scheduling). The merge gates in the plan define the proof. Treat any
+  behavioral diff you introduce as a bug in your change.
+- Do not start Track C work (no `dynamic_filter_publication_plan` value-type migration, no
+  adapter, no consumer changes). Another machine owns that. The one file both tracks edit is
+  `src/op/sirius_physical_hash_join.cpp` — A1 lands first by agreement, so you are not blocked,
+  but keep your edits there minimal (the plan already scopes them).
+- **Cross-machine coordination item:** A1 introduces `src/include/op/dynamic_filter_ids.hpp` and
+  the `[dynf_summary]` field vocabulary. After A1 merges, post a short comment on #1124 listing
+  the header path, the enum/ID names, and the exact summary field names — the C-track implementer
+  consumes them.
+- Run `pixi run pre-commit run -a` before each push. New test files must be registered in
+  `TEST_SOURCES` (enforced by the orphan-test hook).
+
+## Setup checklist
+
+```bash
+git clone --recursive git@github.com:sirius-db/sirius.git && cd sirius   # or update existing
+git checkout dev && git pull && git submodule update --init --recursive
+pixi run make            # full build
+pixi run make test       # sanity: suite green before you change anything
+```
+
+Machine notes (apply if this is the GB10 box `pdx02-zeno-01`; otherwise adapt):
+
+- Single NVIDIA GB10, unified memory (~119 GB), arm64. Single-GPU only.
+- TPC-H datasets in `~/Code/sirius_1/test_datasets/` (`tpch_parquet_sf30/`, `tpch_sf30.duckdb`,
+  `tpch_sf50.duckdb`). Query files in `scripts/` (`tpch-queries-run.sql`, `run-tpch.sh` — read the
+  script before using it).
+- `~/.sirius/sirius.yaml` may be stale (unknown-key startup error) — always set
+  `SIRIUS_CONFIG_FILE` explicitly. Default `usage_limit_fraction` (0.95) fails allocation on
+  GB10; use ~0.3–0.55.
+- Do not put trivial marker queries (`select 42`) in benchmark scripts — CPU_SOURCE→DUMMY_SCAN
+  pipelines have hung under GPU interception on this box.
+- Log analysis: run with `SIRIUS_LOG_LEVEL=trace` + `SIRIUS_LOG_DIR`, then
+  `python3 tools/log_analyzer/parse_logs.py <log>`.
+
+## Stage 1 — PR A1 (instrumentation)
+
+Implement exactly per `A-1014-priority-pass.md` § "PR A1". Recommended split: **A1a** (IDs +
+outcome/channel/coverage events + analyzer) then **A1b** (high-water sampler + feeder/lifecycle
+counters + summary) — each ~450–550 LOC and independently revertible.
+
+The plan is detailed; these are the mistakes it specifically armors against — do not reintroduce
+them:
+
+- The feeder running gauge uses the RAII `feeder_running_scope` at worker-lambda entry. The
+  lambda has **seven** exit paths; manual decrements leak.
+- `close_for_new_filters`: the `exchange` stays **inside** the existing `_mu` scope; log after
+  unlock. Same compute-under-lock / emit-after-scope split in `on_finalize_operator`
+  (`op_state_mutex`). Never log under a lock.
+- `probe_target::target_id` is appended **last** (positional init at
+  `sirius_plan_comparison_join.cpp:447` must keep compiling).
+- Normal zero-delivery completion reports `NO_MATERIALIZATION(NO_BUILD_DELIVERY)`; `CANCELLED`
+  is never emitted in A1.
+- No peak-reset calls on memory resources — high-water uses the baseline/delta scheme in the plan.
+- Per-batch events are DEBUG/TRACE; per-query summaries are INFO `[dynf_summary]`; every event
+  line carries the `[dynf] ` anchor. The analyzer (`tools/log_analyzer`) gets its module +
+  `SHAPE_VERSION` bump **in the same PR**.
+
+**Merge gate (prove all of it, put the evidence in the PR body):** full `pixi run make test`
+green; one TPC-H A/B run (A1 vs base) with identical results and identical
+`Pushed {} dynamic filter(s)` line multisets; `[dynf_summary] feeder running_end=0` on every
+query; log_analyzer reports no `FormatWarnings` for the new patterns — this last check requires
+**one untimed DEBUG-level run** so the per-batch patterns actually appear in the log.
+
+## Stage 2 — PR A2 (the switch)
+
+Implement per `A-1014-priority-pass.md` § "PR A2". The one thing that matters most:
+
+- The flag gates **only** the priority `pop_if` dispatch branch. `collect_filter_build_pipelines`
+  and the feeder-telemetry install run unconditionally in both modes — the measurement needs
+  feeder metrics under `off`. Under `off`, dispatch lines show `feeder=1 prioritized=0`.
+- Mode is snapshotted once per query at `prepare_for_query` (`_priority_dispatch_enabled`), so a
+  mid-query `SET` cannot tear the dispatch loop.
+
+**Merge gate:** default `legacy` is behaviorally identical; the CPU unit tests + the GPU
+integration test from the plan pass (`filter_build_pipeline_count_for_testing() > 0` in both
+modes; `priority_dispatch_enabled_for_testing()` flips).
+
+## Stage 3 — the measurement (the actual point of this engagement)
+
+This is the #1014 acceptance gate. Follow `A-1014-priority-pass.md` § "A2→A3 measurement protocol"
+exactly. Summary of the protocol — the plan is authoritative on details:
+
+**Configs** (each in its own process; `LOAD` the extension before any `SET` — a pre-LOAD `SET` is
+silently dropped; never interleave connections):
+
+1. `SET enable_dynamic_filter_pushdown=false`
+2. `SET enable_dynamic_filter_pushdown=true; SET dynamic_filter_build_priority='legacy'`
+3. `SET enable_dynamic_filter_pushdown=true; SET dynamic_filter_build_priority='off'`
+
+**Workload:** TPC-H Q5, Q7, Q8, Q9, Q21 at SF≥10 (SF30 on the GB10 box), plus a synthetic
+many-join chain (≥6 chained joins over one fact table — write it, check it into the benchmark
+script, no trivial marker queries).
+
+**Passes:**
+
+- **Timing passes at INFO** (the default log level): ≥7 iterations per query per config, first
+  discarded. All gate metrics come from these: wall time (QueryBegin/QueryEnd segments),
+  per-space resident high-water (note the `exact=` flag), feeder queued/dispatched/prioritized/
+  running-hwm, build batches delivered, pinned-build/hash-table hwm, replica-bytes hwm, and
+  per-channel pre/post-publication coverage from the INFO `[dynf_summary] channel_coverage`
+  aggregates.
+- **Forensics passes at DEBUG**, 1 iteration per (query, config), run after the timing passes,
+  **excluded from all wall-time statistics**. Only for diagnosing coverage deltas.
+- Record the log level of every pass in a run manifest. Keep all raw logs.
+
+**Results comparison:** config-2 vs config-3 outputs bag-compared (exact order only for ORDER BY
+queries); config-1 is the no-filter result oracle for both.
+
+**Pass criterion:** config-3 shows no material wall-time or resident-peak regression vs config-2
+outside config-2's own run-to-run spread, results equivalent, and the coverage numbers explain
+any movement. Coverage is diagnostic, not a veto.
+
+**Report:** post a comment on #1124 with: the verdict (pass/fail per criterion), a per-query
+table (median wall time, peak bytes, coverage pre/post-publication) for all three configs, the
+run-variance you measured, machine + SF + commit SHAs, and attach the analyzer outputs. Then
+**stop and wait for human sign-off**.
+
+## Stage 4 — PR A3 (only after human approval of the Stage 3 report)
+
+One-line default flip to `OFF` + doc/release note per the plan. Rollback stays available via
+`SET dynamic_filter_build_priority='legacy'` for one release. Do **not** proceed to A4.
+
+## When to stop and ask a human
+
+- Any plan-cited call site that no longer matches the code in a way that changes the approach.
+- Any A1/A2 gate check that fails and isn't clearly your bug.
+- Measurement results that are ambiguous against the pass criterion (e.g., regression inside
+  variance on some queries but not others) — post the data, propose a reading, wait.
+- Anything that tempts you to change publication behavior, dispatch order (beyond the flag), or
+  Track C files. That temptation means scope creep; stop.

--- a/docs/super-sirius/issue-1010-plans/B-phase0-duckdb-backport.md
+++ b/docs/super-sirius/issue-1010-plans/B-phase0-duckdb-backport.md
@@ -1,0 +1,540 @@
+# PR B1 Implementation Plan — Phase 0: DuckDB #22963 backport + explicit-oracle regressions
+
+Companion to [issue-1010-dynamic-filter-sip-design.md](../issue-1010-dynamic-filter-sip-design.md); baseline dev 506a1d9f.
+PR IDs covered: **B1**.
+
+> **STATUS: DEFERRED (decision 2026-07-08).** No Sirius-owned fork or backport will be created.
+> The latent exposure is accepted; the fix arrives at the next pin bump to a released DuckDB
+> containing duckdb/duckdb#22963, at which point this document is the playbook: skip the fork
+> sections (§ fork/gitlink mechanics become a plain pin advance) and ship the sentinel
+> regressions and metadata assertions as specified. Until then, nothing here blocks Track A or C;
+> the standing rule that survives deferral: LIMIT/TOP-N-shaped tests use explicit expected rows
+> or a filters-disabled reference run — never an unpatched CPU run. Tracked in
+> sirius-db/sirius#1123.
+
+> **Empirical status (adversarial review, executed on the unpatched pin):** at default optimizer
+> settings the pinned DuckDB returns **correct** results for all five query shapes below — the bug
+> is *latent*, masked by `late_materialization`, `compressed_materialization`, and pipeline-timing
+> races. The deterministic red→green evidence for this backport is the **logical-metadata
+> assertion** (`probe_info` non-empty on the unpatched pin, empty on the patched pin) with
+> `late_materialization` disabled; the only *runtime* CPU red sentinel is Q-S3 with
+> `late_materialization,compressed_materialization` disabled, and even that is schedule-dependent.
+> Every section below is structured around that reality. This plan involves no timing/perf
+> measurement passes; the one CI perf-adjacent check (TPC-H snapshot) runs at the CI default INFO
+> log level with no new DEBUG/TRACE logging introduced.
+
+## 1. GOAL + NON-GOALS
+
+Make the pinned DuckDB candidate source correct before any SIP behavior change: cherry-pick
+upstream `444f473a12` ("Avoid join filter pushdown below limits", the single-parent change commit
+behind merge `4c8c90db44`) onto a clean-clone-reachable Sirius-owned DuckDB branch, repoint
+`.gitmodules` + the gitlink, and land regressions with explicit oracles — upstream's two SQL cases
+kept as pin-upgrade sentinels, Sirius variants with join-sourced LIMIT/TOP-N inputs, and per-plan
+assertions that no outer producer crosses a row selector while a join wholly inside the selector
+input keeps its route (design `docs/super-sirius/issue-1010-dynamic-filter-sip-design.md:224-246`,
+phasing row B1 `:961`). This is the gate that unblocks C1c, C1e, and C3 enablement (`:961-966`).
+
+Non-goals: no changes to the Sirius placement walk or any `src/` production code ("Do not
+reimplement this target walk", design `:244-246`); no new config flags; no A1 telemetry IDs (plan
+assertions are keyed by plan position now, re-keyed by `dynamic_filter_publication_plan_id` when A1
+lands — query-relative monotonic per the design's "Publication, target, channel, and filter
+identity" section); no SIP-on test config yet (C3 appends it); no pin advance to v1.5.5+/v1.6. On
+the "no released tag contains the fix" claim: `git tag --contains 4c8c90db44` is empty in the
+submodule store, but that store tops out at `v1.5.4` while the fix merged upstream 2026-06-04 — the
+claim is plausible but **must be re-verified against fresh upstream refs before it is written into
+the PR** (`git -C duckdb fetch https://github.com/duckdb/duckdb --tags && git -C duckdb tag
+--contains 444f473a12`). If a released tag does contain it, evaluate a pin advance instead of the
+fork before proceeding.
+
+## 2. DELIVERABLES
+
+**Repo/infra (no Sirius C++ API changes; zero `src/` diff):**
+- Public fork `sirius-db/duckdb` (does not exist today; verified `gh repo view sirius-db/duckdb` →
+  resolution error), branch `sirius/v1.5.4-backports` =
+  `08e34c447bae34eaee3723cac61f2878b6bdf787` (== tag `v1.5.4` == current gitlink) +
+  `git cherry-pick -x 444f473a12` (verified clean via `merge-tree`, +33/−2, 2 files). Tag the head
+  `v1.5.4-sirius.1` for reachability independent of the branch ref.
+- `.gitmodules` duckdb entry repointed; gitlink bumped to the new SHA.
+- GitHub issue documenting the merged-Phase-1 **latent** exposure (filed before the PR; PR closes
+  it) — honest text in §3.8.
+- Small follow-up issue (or in-PR code comment) for the pre-existing uninitialized-read hazard in
+  §3.9.
+
+**Test-only C++ (anonymous namespaces in the two new test files):**
+```cpp
+// test/cpp/planner/test_join_filter_pushdown_limit_plan.cpp
+//
+// Transaction ownership: the CALLER opens one transaction (con.Query("BEGIN TRANSACTION"))
+// before build_optimized_logical_plan, keeps it open across the logical-plan walk and
+// to_sirius_plan, and commits/rolls back itself. Helpers never BEGIN/COMMIT/ROLLBACK —
+// Parser→Optimizer→create_plan and every interleaved inspection must share one open
+// transaction (same discipline as generate_sirius_plan,
+// test/cpp/planner/test_distinct_hash_join_detection.cpp:53-92).
+duckdb::unique_ptr<duckdb::LogicalOperator> build_optimized_logical_plan(
+  duckdb::Connection& con, const std::string& query);                 // Parser→Planner→Optimizer→ResolveOperatorTypes→ColumnBindingResolver
+void collect_logical_comparison_joins(duckdb::LogicalOperator& root,
+  std::vector<duckdb::LogicalComparisonJoin*>& out);                   // pre-order
+bool join_build_side_is_table(duckdb::LogicalComparisonJoin& join,
+  const std::string& table_name);                                      // RHS-binding check: every condition's right expression resolves
+                                                                       // into a binding produced by children[1], and children[1]'s subtree
+                                                                       // contains a LogicalGet on `table_name` owning that table_index
+duckdb::unique_ptr<sirius::op::sirius_physical_operator> to_sirius_plan(
+  sirius::planner::sirius_physical_plan_generator& gen,
+  duckdb::unique_ptr<duckdb::LogicalOperator> plan);                   // gen passed in so gen.dynamic_filter_channels stays inspectable
+void collect_hash_joins(sirius::op::sirius_physical_operator* root,
+  std::vector<sirius::op::sirius_physical_hash_join*>& out);           // pre-order (outer join first)
+bool subtree_contains(sirius::op::sirius_physical_operator const& op,
+  sirius::op::SiriusPhysicalOperatorType type);                        // identify the join above the LIMIT/TOP_N (shape guard only —
+                                                                       // NOT sufficient alone, see Risk 4; pair with join_build_side_is_table)
+
+// test/cpp/integration/test_gpu_execution_join_filter_limit.cpp
+struct pushdown_setting_guard {                                        // RAII: capture current enable_dynamic_filter_pushdown from the
+  explicit pushdown_setting_guard(duckdb::Connection& con);            // shared process-global SiriusContext operator_params, restore the
+  ~pushdown_setting_guard();                                           // CAPTURED value (not hardcoded true) in the destructor
+private:
+  duckdb::Connection& con_;
+  bool prior_value_;
+};
+struct disabled_optimizers_guard {                                     // RAII: capture disabled_optimizers, SET the requested list,
+  disabled_optimizers_guard(duckdb::Connection& con, const std::string& list);
+  ~disabled_optimizers_guard();                                        // restore captured prior set
+};
+void require_rows(sirius::test::GpuExecutionFixture& fx, const std::string& query,
+  std::vector<std::vector<std::string>> expected_sorted);              // uses GpuExecutionFixture::collect_rows
+```
+No guard for `gpu_execution`: `SetEnableGpuExecution` is a log-only no-op on shared state
+(`src/sirius_extension.cpp:1599-1602`); the option value itself is per-session DuckDB option state
+that dies with the fixture connection.
+
+**New test assets:** `test/sql/join_filter_pushdown_limit.test` (manual sqllogic sentinel), the two
+Catch2 files above, two `TEST_SOURCES` lines.
+
+## 3. STEP-BY-STEP CHANGES
+
+### 3.1 Fork + backport branch (outside the superproject; do FIRST — push order is fork-then-superproject)
+```bash
+gh repo fork duckdb/duckdb --org sirius-db --clone=false      # must be PUBLIC (CI checkout uses default token)
+git -C duckdb worktree add --detach /tmp/ddb-b1 08e34c447bae34eaee3723cac61f2878b6bdf787
+cd /tmp/ddb-b1
+git switch -c sirius/v1.5.4-backports
+git cherry-pick -x 444f473a12                                  # clean; -x records the upstream SHA
+git tag v1.5.4-sirius.1
+git remote add sirius https://github.com/sirius-db/duckdb.git
+git push sirius sirius/v1.5.4-backports v1.5.4-sirius.1
+NEW_SHA=$(git rev-parse HEAD)
+cd - && git -C duckdb worktree remove --force /tmp/ddb-b1
+```
+If `gh repo fork --org` lacks permission, fallback: create empty repo `sirius-db/duckdb`,
+`git -C duckdb push <url> 08e34c447b:refs/heads/sirius/v1.5.4-backports`, then push the cherry-pick
+commit. Protect the branch (no force-push/delete). The cherry-pick touches only
+`src/optimizer/join_filter_pushdown_optimizer.cpp` (splits `LOGICAL_LIMIT`/`LOGICAL_TOP_N` out of
+the transparent fall-through group at pinned lines 63-69 into a terminal `break`) and
+`test/sql/join/inner/test_inner_join_filter_pushdown.test` (+30). No headers, no ABI, no
+serialization.
+
+### 3.2 `.gitmodules` (repo root, entry at `.gitmodules:1-5`: currently `url = https://github.com/duckdb/duckdb`, `branch = main`)
+```
+[submodule "duckdb"]
+	path = duckdb
+	url = https://github.com/sirius-db/duckdb
+	branch = sirius/v1.5.4-backports
+	ignore = dirty
+```
+Then `git submodule sync duckdb`. Precedent for org-fork submodules: `substrait` →
+`sirius-db/duckdb-substrait-extension` (`.gitmodules:6-9`).
+
+### 3.3 Gitlink bump
+```bash
+git -C duckdb fetch https://github.com/sirius-db/duckdb sirius/v1.5.4-backports
+git -C duckdb checkout $NEW_SHA
+git add .gitmodules duckdb
+```
+Consumers that follow the gitlink automatically (verified, no edits needed): `Makefile:16`
+(`DUCKDB_DIR ?= duckdb`; `set_duckdb_version` stubbed at `Makefile:90-91`), CI checkouts with
+`submodules: recursive` at `test.yml:57-58`, `check.yml:32-33`, `check.yml:107-109`, Python API via
+`-DDUCKDB_SOURCE_PATH` (`pixi.toml:115`). **Leave unchanged:** `distribution.yml:33` and `:57`
+`duckdb_version: v1.5.4` (label into extension-ci-tools only; extension ABI still v1.5.4).
+`experimental.yml` inits only starrocks submodules (`experimental.yml:42-46`) — unaffected. sccache
+is content-hash keyed (`test.yml:66-76`, `check.yml:124-137`) — one TU recompile.
+
+### 3.4 `test/sql/join_filter_pushdown_limit.test` (new; manual-only — CI runs no sqllogic, grep of `.github/workflows/` for `test/sql` is empty)
+Header per repo convention (`test/sql/bugfix.test:15-20`): `# name:` / `# description:` /
+`# group: [sirius]` / `require sirius`. Add a header comment block documenting **runner environment
+sensitivity**: the sirius-linked binary reads `SIRIUS_CONFIG_FILE` / `~/.sirius/sirius.yaml` at
+startup and a stale user yaml aborts the process before any SQL runs (observed:
+`unknown config key: 'duckdb_scan'` from a stale `~/.sirius/sirius.yaml`); document the required
+invocation (`SIRIUS_CONFIG_FILE=test/cpp/config/data/minimal.yaml`) and **smoke-run the file once
+before landing** — there is no existing transparent-plain-SQL sqllogic precedent (existing files
+use `call gpu_buffer_init` + legacy `call gpu_processing`, `test/sql/tpch-sirius.test:151,155`,
+`test/sql/bugfix.test:24`), so the "no `gpu_buffer_init` needed" assumption must be validated by
+that smoke run. Use transparent plain SQL; `SET` via plain `statement ok` (options registered at
+`src/sirius_extension.cpp:1834-1848`; `require sirius` loads the extension first so the "SET before
+context" gotcha does not bite).
+
+Sections, each running the full query set against **hardcoded expected rows** (the oracle — design
+`:238-239`). Every bug-exercising section wraps its queries in
+`SET disabled_optimizers = 'late_materialization,compressed_materialization';` … restore with
+`SET disabled_optimizers = '';` afterwards — at defaults those two optimizers mask the bug
+(late materialization rewrites LIMIT/TOP-N-over-scan into `TOP_N(rowid) → SEMI join → full scan`,
+making the filter target the rowid-preserving base scan, a legal route; compressed materialization
+inserts `__internal_compress_integral_*` projections that fail `PushdownJoinFilterExpression` for
+these small-int columns):
+1. `SET gpu_execution = false;` — **patched-pin CPU regression at defaults.** Documented in-file:
+   this section does NOT fail on the unpatched pin (masking above); it guards the patched pin.
+2. `SET gpu_execution = false; SET disabled_optimizers = 'late_materialization,compressed_materialization';`
+   — the bug-exercising CPU leg. **Q-S3 here is the single runtime CPU red sentinel** (on the
+   unpatched pin it returned 2 rows incl. spurious `0,5,50,0`; its fact-probe pipeline depends on
+   the inner `side` build, so the dim filter is populated before the scan — but this is
+   schedule-dependent, not guaranteed; documented as such in-file). Q-up1/Q-up2/Q-S1/Q-S2 in this
+   section are patched-pin regressions: on the unpatched pin they still returned correct rows due
+   to the pipeline-timing race (the `fact→TOP_N` pipeline has no dependency on the dim build and
+   scans before the min/max filter finalizes). Restore `disabled_optimizers` after.
+3. `SET gpu_execution = false; SET disabled_optimizers = 'join_filter_pushdown';` — the design's
+   "join-filter-pushdown-disabled execution" oracle cross-check (optimizer name at pinned
+   `duckdb/src/common/enums/optimizer_type.cpp:40`); restore after.
+4. `SET gpu_execution = true; SET enable_dynamic_filter_pushdown = false;` with the two masking
+   optimizers disabled — GPU filters-off; restore after.
+5. `SET gpu_execution = true; SET enable_dynamic_filter_pushdown = true;` with the two masking
+   optimizers disabled — Phase 1 on; restore after.
+6. Trailing comment block reserving a SIP-on section for C3 (`SET enable_dynamic_filter_sip = true`
+   once it exists).
+
+**Query set** (all `ORDER BY` on a unique key so explicit rows are deterministic):
+
+Upstream sentinels, verbatim from `444f473a12` (kept as pin-upgrade sentinels; note their `WITH`
+form is fine here because they are upstream-verbatim — Sirius variants use plain subqueries, §risk 3):
+```sql
+CREATE TABLE ordered_probe(flag BOOLEAN, ord INTEGER);
+INSERT INTO ordered_probe VALUES (true, 1), (true, 2), (false, 3);
+CREATE TABLE boolean_keys(flag_key BOOLEAN);
+INSERT INTO boolean_keys VALUES (false);
+-- Q-up1: WITH c AS (SELECT flag FROM ordered_probe ORDER BY ord OFFSET 2)
+--        SELECT * FROM c INNER JOIN boolean_keys ON flag = flag_key;   → false, false
+-- Q-up2: same with ORDER BY ord LIMIT 1                                 → empty
+```
+
+Sirius variants. Build sides carry a WHERE so `build_side_has_filter` is true and the Sirius wiring
+gate at `src/planner/sirius_plan_comparison_join.cpp:426` passes. Sizing: **do not rely on the
+"probe ≫ build" idiom** — `LIMIT 4` caps the selector-side cardinality estimate at ~4 rows, which
+is comparable to a filtered 5-row dim, so the borrowed idiom from
+`test/cpp/planner/test_distinct_hash_join_detection.cpp:141-153` does not apply here. Instead
+shrink `dim` to 3 rows so the filtered build (~2 rows) is decisively smaller than the ~4-row
+selector estimate, and assert build-side identity explicitly via `join_build_side_is_table(join,
+"dim")` (RHS-binding check), not just subtree containment:
+```sql
+CREATE TABLE fact(k INTEGER, ord INTEGER);   -- 20 rows: ord = 1..20 unique, k = ord % 5
+CREATE TABLE dim(dk INTEGER, tag VARCHAR);   -- 3 rows: (0,'keep'),(1,'drop'),(2,'keep')
+CREATE TABLE side(ord INTEGER, s INTEGER);   -- 20 rows: ord = 1..20, s = ord * 10
+```
+- **Q-S1 (TOP-N over probe spine, LOGICAL_TOP_N):**
+  `SELECT c.k, c.ord, d.dk FROM (SELECT k, ord FROM fact ORDER BY ord LIMIT 4) c JOIN dim d ON c.k = d.dk WHERE d.tag = 'keep' ORDER BY c.ord;`
+  → expected exactly `2 2 2` (1 row). **Unpatched-pin behavior (measured):** correct at defaults
+  AND with the two masking optimizers disabled (timing race) — a patched-pin regression, not a red
+  sentinel.
+- **Q-S2 (LIMIT/OFFSET, LOGICAL_LIMIT):**
+  same shape with `(SELECT k, ord FROM fact ORDER BY ord OFFSET 16) c` → expected `2 17 2` and
+  `0 20 0`. **Unpatched-pin behavior (measured):** correct, same masking — patched-pin regression.
+- **Q-S3 (join-sourced selector input; inner join wholly inside the selector legitimately keeps its route):**
+  ```sql
+  SELECT c.k, c.ord, c.s, d.dk
+  FROM (SELECT f.k, f.ord, s.s FROM fact f JOIN side s ON f.ord = s.ord
+        WHERE s.s <= 60 ORDER BY f.ord LIMIT 4) c
+  JOIN dim d ON c.k = d.dk WHERE d.tag = 'keep' ORDER BY c.ord;
+  ```
+  → expected exactly `2 2 20 2`. The inner `fact⋈side` (build = `side` filtered to 6 rows) is a
+  legal Phase 1 producer to the `fact` scan (no selector between them); the outer join must not
+  route below the TOP-N. **Unpatched-pin behavior (measured, optimizers-disabled leg):** 2 rows —
+  spurious `0 5 50 0` from `k IN (0, 2) AND k>=0 AND k<=2` populated on the fact scan below the
+  TOP_N (EXPLAIN ANALYZE-verified); the dependency on the inner build makes the wrongness
+  observable, though still schedule-dependent.
+  Use plain subqueries, not `WITH`, to avoid CTE-materialization ambiguity (materialized CTEs stop
+  the walk and would mask the bug; design `:508`).
+
+**Mandatory pre-landing step:** re-derive every expected-row prediction in this file (and §3.6)
+**empirically** on the patched pin, per leg (CPU and GPU), before landing — the review demonstrated
+that unexecuted predictions in this area are unreliable. The shrunken 3-row dim is expected to
+leave all correct-result oracles unchanged (`2 2 2`; `2 17 2`+`0 20 0`; `2 2 20 2` — the removed
+dk 3/4 rows were all `tag='drop'`), but this must be confirmed by execution, not derivation.
+
+### 3.5 `test/cpp/planner/test_join_filter_pushdown_limit_plan.cpp` (new — the CI-enforced pin sentinel; THE deterministic red→green gate)
+Fixture: clone of `distinct_hash_join_fixture`
+(`test/cpp/planner/test_distinct_hash_join_detection.cpp:110-160`):
+`SIRIUS_CONFIG_FILE=test/cpp/config/data/minimal.yaml` before `DuckDB db(nullptr)`,
+`SIRIUS_DISABLE=1` after, tables from §3.4 created up front. Helpers split from
+`generate_sirius_plan` (`:42-94`) into `build_optimized_logical_plan` + `to_sirius_plan`, with the
+transaction owned by the caller as specified in §2. The harness disables **three** optimizers
+(vs. the donor's two at `:50-51`):
+```cpp
+disabled.insert(OptimizerType::IN_CLAUSE);
+disabled.insert(OptimizerType::COMPRESSED_MATERIALIZATION);
+disabled.insert(OptimizerType::LATE_MATERIALIZATION);   // REQUIRED: without this the patched pin
+    // rewrites Q-S1/Q-S2 into TOP_N(rowid) → SEMI join → full scan; the (patched) walk then
+    // legitimately reaches the rowid-side LOGICAL_GET, probe_info is non-empty, and the
+    // metadata assertion FAILS GREEN. Verified: with late-mat + compressed-mat disabled the
+    // intended shape appears (TOP_N as probe child, dim as build); unpatched → probe_info
+    // non-empty (red), patched → empty (green).
+```
+Do NOT disable `join_filter_pushdown`. Assertions run at **two levels**:
+
+**(a) Logical-level DuckDB-metadata absence — never skipped, and the red→green gate proper**
+(immune to the plan-gen `InternalException` WARN-skip precedent at `:168-171,80-84`): walk the
+optimized logical plan; for each `duckdb::LogicalComparisonJoin` inspect `filter_pushdown` (pinned
+member `duckdb/src/include/duckdb/planner/operator/logical_comparison_join.hpp:40`; `probe_info` at
+`duckdb/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp:66`):
+- Shape guards first, so drift fails loudly: `REQUIRE` on join count, `REQUIRE(join_build_side_is_table(outer, "dim"))`
+  (RHS-binding check), and `subtree_contains(probe, TOP_N/LIMIT)` as a secondary check.
+- Q-S1/Q-S2 outer join: `REQUIRE(!fp || fp->probe_info.empty());` — **fails on an unpatched pin,
+  passes on the patched pin** (verified by execution with the three-optimizer disable set). The
+  `!fp || empty()` form deliberately tolerates the patched pin's `compute_aggregates_anyway` path,
+  which keeps `filter_pushdown` alive with empty `probe_info`.
+- Q-S3: `REQUIRE(joins.size() == 2);` outer `probe_info` empty; inner
+  `fp && !fp->probe_info.empty()`.
+
+**(b) Sirius plan level** (skip-tolerant, same WARN pattern): construct
+`sirius::planner::sirius_physical_plan_generator gen(*con->context)` in the test (router style,
+`test/cpp/planner/test_dynamic_filter_router.cpp:69-78`), call `to_sirius_plan` inside the same
+open transaction, then:
+- outer join (identified as the pre-order hash join whose probe subtree contains
+  `SiriusPhysicalOperatorType::TOP_N`/`LIMIT` via `subtree_contains`, with the logical-level
+  build-side identity already asserted in (a); tree-walk modeled on `find_hash_join`,
+  `test_distinct_hash_join_detection.cpp:97-108`):
+  `REQUIRE_FALSE(hj->publishes_dynamic_filters())` (`src/include/op/sirius_physical_hash_join.hpp:166-170`)
+  and `REQUIRE(!hj->filter_pushdown || hj->filter_pushdown->probe_info.empty())`
+  (`src/include/op/sirius_physical_hash_join.hpp:100`).
+- Q-S1/Q-S2: `REQUIRE(gen.dynamic_filter_channels.empty())`
+  (`src/include/planner/sirius_physical_plan_generator.hpp:82-85`).
+- Q-S3: inner join `REQUIRE(hj_inner->publishes_dynamic_filters())`;
+  `REQUIRE(gen.dynamic_filter_channels.size() == 1)`. Wiring preconditions all hold:
+  `build_side_has_filter` true (WHERE on `side`; gate at
+  `src/planner/sirius_plan_comparison_join.cpp:426`), GPU+HOST spaces exist under minimal.yaml
+  (gate at `:432-441`; targets built from `probe_info` at `:442-461`).
+- Comment each assertion block: "keyed by plan position pending A1
+  dynamic_filter_publication_plan_id" (design `:1018-1019`).
+
+Named cases (tag `[dynamic_filter][limit_selector][isolated_context]`):
+`"limit_selector - TOP-N blocks outer producer target (duckdb metadata)"`,
+`"... (sirius wiring + channels)"`,
+`"limit_selector - LIMIT/OFFSET blocks outer producer target (duckdb metadata)"`,
+`"... (sirius wiring + channels)"`,
+`"limit_selector - join inside selector input keeps its route"`,
+`"limit_selector - upstream #22963 shapes produce no probe_info"` (Q-up1/Q-up2, logical level only;
+these also need the late-mat disable — the rewrite masks upstream's own reproducers).
+
+### 3.6 `test/cpp/integration/test_gpu_execution_join_filter_limit.cpp` (new — end-to-end explicit-rows regression, GPU)
+Uses `GpuExecutionFixture` (`test/cpp/utils/gpu_execution_fixture.hpp:66-99`; on-disk ATTACH for
+the native scan, `CHECKPOINT` after loading per header comment `:25-29`). Tag
+`[integration][gpu_execution][dynamic_filter][limit_selector]` — `[integration]` binds the shared
+env via the listener (`test/cpp/unittest.cpp:52-101`). **Every leg is bug-exercising and therefore
+runs under a `disabled_optimizers_guard(con, "late_materialization,compressed_materialization")`**
+— without it, late materialization rewrites Q-up/Q-S1/Q-S2 before Sirius sees them, so (a) the
+Phase-1-on leg never exercises the filter-below-selector interaction (target becomes the rowid
+scan, a legal route), and (b) the transparent path must plan a rowid-projecting scan + SEMI join,
+which — if Sirius plan-gen rejects it — trips the zero-fallback delta assertion even on the patched
+pin. The guard captures and restores the prior `disabled_optimizers` set (destructor-safe on
+REQUIRE failure).
+
+Per query shape (Q-up1, Q-up2, Q-S1, Q-S2, Q-S3), run the design's `:240` matrix against
+**hardcoded expected rows** via `require_rows` (sorted-stringified compare reusing `collect_rows`,
+`gpu_execution_fixture.hpp:129-142`):
+1. `SET gpu_execution = false;` — patched CPU (regression, not a red sentinel — see §3.4).
+2. `SET gpu_execution = true;` + `SET enable_dynamic_filter_pushdown = false;` — GPU filters-off,
+   with `require_transparent_execution_delta(before, after, 1, 0, 1)` proving GPU ran with zero
+   fallback (`test/cpp/utils/transparent_execution_test_utils.hpp:40-51`).
+3. `SET enable_dynamic_filter_pushdown = true;` — Phase 1 on, same delta assertion.
+4. SIP-on leg left as a comment for C3.
+
+These legs are **patched-pin regressions**: on the unpatched pin, GPU runtime wrongness is racy —
+transitive scan targets (a scan below TOP_N is transitive) "may observe no filter, a subset … or
+the full set" (`docs/super-sirius/dynamic-filters.md:238`); only the immediate probe scan is
+synchronized (`dynamic-filters.md:162,283`). Do not claim they fire on the unpatched pin.
+
+**Mandatory pre-landing step:** empirically confirm zero-fallback (`1, 0, 1` deltas) for every
+shape × leg on the patched pin before landing; if a leg falls back, restructure the query rather
+than weakening the delta.
+
+`pushdown_setting_guard` captures the current `enable_dynamic_filter_pushdown` value and restores
+**the captured value** in its destructor — the setting mutates the process-global SiriusContext's
+`operator_params` shared by every connection (verified: `src/sirius_extension.cpp:1604-1611` via
+`get_operator_params` → registered `"sirius_state"`, `src/sirius_extension.cpp:1480-1488`; default
+true at `src/include/sirius_config.hpp:102`), so leakage would poison later `[integration]` tests.
+Never call `compare_gpu_vs_cpu` as the oracle (redundant with leg 1 on the patched pin, and an
+unpatched CPU is not an oracle).
+
+### 3.7 `CMakeLists.txt`
+Add to `TEST_SOURCES` (`CMakeLists.txt:562` block, alphabetical-by-directory):
+`test/cpp/integration/test_gpu_execution_join_filter_limit.cpp` next to the existing
+`test/cpp/integration/test_gpu_execution_tpch.cpp` entry, and
+`test/cpp/planner/test_join_filter_pushdown_limit_plan.cpp` next to
+`test/cpp/planner/test_dynamic_filter_router.cpp`. Omission is a hard pre-commit failure
+(`scripts/check_orphan_tests.py` hook, `.pre-commit-config.yaml:81-86`).
+
+### 3.8 GitHub issue (file before the PR; PR body: "Fixes #NNN")
+Title: *"Latent wrong-results bug: Phase 1 dynamic table-filter pushdown can apply build-derived
+filters below LIMIT/TOP-N (upstream duckdb#22963)"*. Body — **honest exposure statement**:
+- Root cause: pinned v1.5.4 `GetPushdownFilterTargets` treats `LOGICAL_LIMIT`/`LOGICAL_TOP_N` as
+  transparent (pinned `duckdb/src/optimizer/join_filter_pushdown_optimizer.cpp:63-69`); Sirius
+  consumes `probe_info` verbatim into producer targets
+  (`src/planner/sirius_plan_comparison_join.cpp:442-461`) and applies filters post-decode at the
+  scan (`src/op/scan/dynamic_filter_merge.cpp`), changing the row selector's input. Affects merged
+  PR #794 independently of SIP (design `:231`).
+- **Exposure is latent, not default-reproducible**: at default settings the bug is masked by
+  (1) `late_materialization`, which rewrites LIMIT/TOP-N-over-scan so the filter target is the
+  rowid-preserving base scan (a legal route); (2) `compressed_materialization`, whose compress
+  projections defeat `PushdownJoinFilterExpression` — partly an artifact of small-int test columns,
+  so NOT a safety guarantee for wide/real schemas; and (3) pipeline-timing races that let
+  independent probe pipelines scan before the filter finalizes. It is reproducible
+  **deterministically at the logical-metadata level** (non-empty `probe_info` on a join whose probe
+  subtree contains a selector, with late materialization disabled) and **at runtime** in
+  dependency-ordered shapes (Q-S3) with `late_materialization,compressed_materialization` disabled
+  (schedule-dependent, EXPLAIN ANALYZE shows `k IN (0, 2) AND k>=0 AND k<=2` on the scan below the
+  TOP_N; observed spurious row `0,5,50,0`).
+- Still a correctness bug worth the backport: the masking mechanisms are optimizer heuristics and
+  scheduling accidents, none of which Sirius controls or the design permits relying on.
+- Reproducers: Q-S1..Q-S3 with per-leg optimizer settings and measured unpatched behavior as in
+  §3.4 (expected-vs-actual only where actually wrong). Fix = pin backport of `444f473a12`. Labels:
+  bug, correctness.
+
+### 3.9 Follow-up note (small issue or in-PR comment; no code change in B1)
+Pre-existing UB the new tests will tickle on the patched pin: for Q-S1/Q-S2 the
+`compute_aggregates_anyway` path leaves `JoinFilterPushdownInfo::build_side_has_filter`
+uninitialized (pinned `join_filter_pushdown.hpp:71` — no default initializer; only assigned when
+`probe_info` is non-empty in the optimizer's `GenerateJoinFilters` tail), and Sirius reads it at
+`src/planner/sirius_plan_comparison_join.cpp:426`. The B1 assertions stay robust either way (empty
+`probe_info` → zero targets regardless of the read value), but record it: candidate fixes are a
+`= false` default in a future backport branch commit or a defensive
+`filter_pushdown->probe_info.empty()` short-circuit on the Sirius side (out of B1 scope).
+
+## 4. TESTS (summary)
+
+| File | Cases | GPU needed |
+|---|---|---|
+| `test/sql/join_filter_pushdown_limit.test` (new) | Q-up1/2 + Q-S1/2/3 × {CPU defaults (regression), CPU optimizers-disabled (Q-S3 = runtime red sentinel, schedule-dependent), CPU jfp-disabled oracle, GPU filters-off, Phase 1 on — the last two with masking optimizers disabled} | manual only; runs anywhere (GPU legs silently degrade to fallback if unsupported — acceptable, CI coverage is the Catch2 files). Smoke-run before landing with `SIRIUS_CONFIG_FILE` set and no stale `~/.sirius/sirius.yaml`. |
+| `test/cpp/planner/test_join_filter_pushdown_limit_plan.cpp` | 6 cases in §3.5; the logical-metadata cases are the deterministic red→green gate | yes (SiriusContext bring-up + minimal.yaml spaces; all Catch2 CI is GPU — `test.yml:115,133-136`; no CPU job *runs* `sirius_unittest`, `check.yml:139,167` build only) |
+| `test/cpp/integration/test_gpu_execution_join_filter_limit.cpp` | 5 shapes × 3 config legs (each under `disabled_optimizers_guard`), explicit rows + transparent-delta proof; patched-pin regressions | yes |
+| Fork branch carries upstream `test/sql/join/inner/test_inner_join_filter_pushdown.test` | upstream regression, runnable manually: `(cd duckdb && cmake --build --preset release --target unittest)` then `build/release/test/unittest test/sql/join/inner/test_inner_join_filter_pushdown.test` from `duckdb/` | no |
+
+## 5. GATE & ROLLBACK
+
+**Merge gate (all required):**
+1. **Red→green demonstration** (attach transcripts to PR), two tiers:
+   - **Deterministic (the gate proper):** with the old gitlink (`08e34c447b`), the §3.5
+     logical-metadata cases FAIL (outer-join `probe_info` non-empty for Q-S1/Q-S2 under the
+     three-optimizer disable set); with `$NEW_SHA` they pass. This is what makes the sentinels
+     real. (Empirically validated direction by the review: unpatched → non-empty, patched → empty.)
+   - **Runtime (evidence, not a determinism requirement):** Q-S3 on the old gitlink, CPU, with
+     `disabled_optimizers='late_materialization,compressed_materialization'`, observed wrong
+     (spurious `0,5,50,0`); record the transcript and note the schedule dependence. Do NOT gate on
+     Q-S1/Q-S2/Q-up runtime failures — measured correct on the unpatched pin at all settings tried.
+2. **Mandatory pre-landing empirical steps:** (a) re-derive every expected-row prediction on the
+   patched pin, per leg (§3.4/§3.6); (b) confirm zero-fallback `1,0,1` deltas for all integration
+   legs; (c) smoke-run the sqllogic file (env note §3.4); (d) re-fetch upstream tags and re-verify
+   `git tag --contains 444f473a12` is still empty of released tags (§1).
+3. Verification checklist:
+   - `git clone --recurse-submodules` of the PR branch into a scratch dir resolves `$NEW_SHA` via
+     the fork URL (fork public, branch+tag pushed first).
+   - `git -C duckdb log -1` shows the `-x` line `(cherry picked from commit 444f473a12...)`;
+     `git -C duckdb merge-base --is-ancestor 08e34c447b HEAD` succeeds.
+   - `pixi run make clean && pixi run make test` green (whole `sirius_unittest`);
+     `pixi run pre-commit run -a` green (orphan hook, formatting).
+   - Metadata-absence assertions green: outer `probe_info` empty, `gen.dynamic_filter_channels`
+     empty for Q-S1/Q-S2, inner join of Q-S3 still wired.
+   - CI `test-run` TPC-H snapshot (`test.yml:133-176`) unchanged — TPC-H LIMITs sit at plan roots
+     above all joins, so the optimizer change is expected not to alter any TPC-H plan (note:
+     late-materialization rewrites make this an expectation, not a proof); treat any
+     perf/validation delta as a stop. This check runs at CI default INFO logging; no DEBUG/TRACE
+     passes are involved in B1.
+   - Optional smoke: `pixi run -e duckdb-python build-duckdb-python` (consumes the patched tree via
+     `pixi.toml:115`).
+4. **Flag defaults:** none added or changed (`enable_dynamic_filter_pushdown` stays default-true,
+   `src/include/sirius_config.hpp:102`). This is a correctness fix, not an A/B.
+
+**Rollback:** single `git revert` of the superproject commit restores the upstream URL and old
+gitlink (`08e34c447b` remains fetchable from `duckdb/duckdb` as `v1.5.4`) and removes the tests
+atomically — necessary, since the §3.5 metadata sentinels fail by design on the unpatched pin. Keep
+the fork branch/tag immutable regardless. **Pin-advance retirement:** when a future release
+contains `444f473a12`, bump the pin, restore `.gitmodules` to upstream, delete nothing from
+Sirius's test tree — the sentinels re-verify every pin bump (design `:1096`).
+
+**Post-merge developer note (PR description):** existing clones/worktrees must run
+`git submodule sync duckdb && git submodule update --init --recursive`, or fetches of the new
+gitlink fail against the old URL.
+
+## 6. DEPENDENCIES & ORDERING
+
+- **Within B1:** (1) fork creation (may need org-admin; the only external dependency) → (2)
+  branch+tag push → (3) superproject PR (`.gitmodules` + gitlink + tests + issue). Never push the
+  superproject before the fork branch is public.
+- **Cross-track:** B1 depends on nothing else; A1-A4 and C1a/C1b/C2 may proceed in parallel. B1
+  **blocks enablement** (not development) of C1c, C1e, C3 (design `:961-966`). C3 later appends the
+  SIP-on leg to both the sqllogic file and the integration test; A1 later re-keys the plan
+  assertions by `dynamic_filter_publication_plan_id`/`target_id` (design `:1018-1019`).
+
+## 7. SIZE ESTIMATE
+
+Superproject prod diff: ~5 lines (`.gitmodules` 2, gitlink 1, `CMakeLists.txt` 2). Fork diff: the
++33/−2 cherry-pick. Tests: sqllogic ~200 lines (extra optimizer-settings legs); planner Catch2
+~330; integration Catch2 ~300; total ~830-880 test LOC. **One PR, do not split** — the gitlink bump
+and its sentinels must land atomically (a gitlink-only PR would be an unverified pin move; a
+tests-only PR fails on the unpatched pin).
+
+## 8. RISKS (implementation-level) + MITIGATIONS
+
+1. **Fork reachability breakage** (private fork, deleted branch, gitlink pushed first) breaks every
+   `submodules: recursive` checkout (`test.yml:57-58`, `check.yml:32-33,107-109`) and all
+   contributor clones. Mitigate: push order, branch protection, the `v1.5.4-sirius.1` tag, and the
+   clean-clone simulation in the gate.
+2. **`gh repo fork --org` permission** may be unavailable to the implementer. Mitigate: documented
+   empty-repo + push fallback (§3.1); flag to the org owner early.
+3. **Optimizer rewrites mask the bug** — this is not hypothetical: `late_materialization` and
+   `compressed_materialization` mask ALL five shapes at defaults (review-measured), and a
+   materialized CTE would stop DuckDB's walk regardless of the fix. Mitigate: three-optimizer
+   disable set in the Catch2 harness, explicit `SET disabled_optimizers` legs in sqllogic and
+   integration tests (with restore), plain subqueries in Q-S1..Q-S3 (upstream `WITH` queries kept
+   only as verbatim sentinels). Residual: a future pin adding a new masking rewrite would surface
+   as a green-side sentinel failure (shape guards fire), which is the intended loud failure mode.
+4. **Join-order / plan-shape drift** silently changes which join carries `filter_pushdown`, and
+   `subtree_contains(probe, LIMIT/TOP_N)` alone is NOT a sufficient guard — under the
+   late-materialization rewrite the TOP_N sits inside the semi-join branch and the containment
+   check still passes while the assertion target is wrong. Mitigate: `LIMIT 4` caps the selector
+   estimate at ~4 rows, so shrink `dim` to 3 rows (filtered build ~2 rows ≪ 4) instead of relying
+   on the 20-row-probe idiom; `REQUIRE` on join count; `join_build_side_is_table(outer, "dim")`
+   RHS-binding assertion before any pushdown assertion, so drift fails loudly rather than asserting
+   the wrong operator.
+5. **Sirius plan-gen `InternalException` on internal table scans** would WARN-skip physical-level
+   assertions (precedent `test_distinct_hash_join_detection.cpp:168-171`), leaving a sentinel hole.
+   Mitigate: the logical-level `probe_info` assertions (§3.5a) never touch plan-gen and are the
+   primary sentinel; physical-level checks are additive.
+6. **Integration transparent-path fallback** (delta assertion `1,0,1` fails if any shape falls
+   back). With the masking optimizers disabled per leg, the planned shapes use only GPU-supported
+   operators (`LOGICAL_LIMIT`/`LOGICAL_TOP_N` handled at
+   `src/planner/sirius_physical_plan_generator.cpp:182,192`; offset supported —
+   `src/include/op/sirius_physical_limit.hpp:41,55`, `src/include/op/sirius_physical_top_n.hpp:43,50`).
+   Note the defaults-path late-mat plan (rowid scan + SEMI join) was a real fallback risk — that is
+   one reason the legs disable it. Mitigate: mandatory pre-landing empirical zero-fallback
+   confirmation; if a leg still falls back, restructure the query rather than weakening the delta.
+7. **Shared-state leakage from `SET enable_dynamic_filter_pushdown` / `SET disabled_optimizers`**
+   into other `[integration]` tests (one process-global SiriusContext,
+   `src/sirius_extension.cpp:1480-1488`; optimizer set is connection config mutated per leg).
+   Mitigate: `pushdown_setting_guard` (capture-and-restore) and `disabled_optimizers_guard` RAII in
+   every case, including failure paths.
+8. **Schedule-dependence of the runtime red evidence:** Q-S3's unpatched wrongness relies on the
+   probe pipeline depending on the inner build; a scheduler change could make even Q-S3 pass on an
+   unpatched pin. Mitigate: the gate's deterministic tier is the metadata assertion; the runtime
+   transcript is recorded evidence, not a repeatable gate condition.
+9. **Wheel/version cosmetics:** duckdb-python and the extension report v1.5.4 while embedding the
+   patched optimizer (dev SHA suffix may differ). Cosmetic; note in PR, keep `distribution.yml`
+   labels at v1.5.4.
+
+## Review resolution
+
+- **Finding 1 (BLOCKER — red gate empirically false at defaults):** applied. §3.4 restructured: CPU-defaults section demoted to patched-pin regression with an in-file note; new optimizers-disabled section is the bug-exercising leg; Q-S3 there is the sole runtime CPU red sentinel, documented as schedule-dependent; all "Unpatched: N rows" predictions replaced with the review's measured behavior; gate item 1 rewritten with the deterministic burden on §3.5 metadata assertions; §3.8 issue text rewritten (see finding-10-adjacent honesty directive).
+- **Finding 2 (BLOCKER — §3.5 sentinel fails green on patched pin without late-mat disable):** applied. Harness disables `OptimizerType::LATE_MATERIALIZATION` in addition to the donor's two, with an explanatory comment; noted the `!fp || empty()` form's tolerance of `compute_aggregates_anyway`; Risk 4 updated to say `subtree_contains` alone is insufficient.
+- **Finding 3 (MAJOR — integration test at defaults never exercises the bug / risks patched-pin fallback):** applied. Every integration leg runs under a new `disabled_optimizers_guard('late_materialization,compressed_materialization')` with capture-and-restore; mandatory pre-landing empirical zero-fallback confirmation added (§3.6, gate item 2b).
+- **Finding 4 (MAJOR — runtime wrongness racy on CPU and GPU):** applied. "Fires on CPU and GPU" claims removed; explicit-row legs labeled patched-pin regressions with the `dynamic-filters.md:238/:162/:283` transitive-target citations; Risk 8 added for Q-S3's schedule dependence.
+- **Finding 5 (MAJOR — sizing rationale wrong, LIMIT caps probe estimate):** applied. `dim` shrunk to 3 rows (correct-result oracles verified unchanged by derivation — dropped dk 3/4 were both `tag='drop'` — with empirical re-derivation still mandated); new `join_build_side_is_table` RHS-binding assertion replaces reliance on subtree containment; the 20-row-probe idiom claim deleted.
+- **Finding 6 (MINOR — no transparent-SQL sqllogic precedent; env-sensitive runner):** applied. §3.4 header documents `SIRIUS_CONFIG_FILE` / stale `~/.sirius/sirius.yaml` abort and mandates a pre-landing smoke run; "no gpu_buffer_init needed" downgraded to an assumption the smoke run must validate.
+- **Finding 7 (MINOR — transaction ownership unspecified):** applied. §2 states caller owns one transaction spanning Parser→Optimizer→create_plan and the interleaved walk; helpers never BEGIN/COMMIT/ROLLBACK (mirrors `test_distinct_hash_join_detection.cpp:53-92`).
+- **Finding 8 (MINOR — guard semantics):** applied. `pushdown_setting_guard` now captures and restores the prior value (not hardcoded true); no guard for `gpu_execution` (log-only callback `sirius_extension.cpp:1599-1602`, per-session option state — verified in code).
+- **Finding 9 (MINOR — stale tag store):** applied. §1 and gate item 2d require re-fetching upstream tags and re-verifying `git tag --contains 444f473a12` before the claim enters the PR, with a stop condition if a released tag contains it.
+- **Finding 10 (OBSERVATION — uninitialized `build_side_has_filter` on the compute_aggregates_anyway path):** applied as §3.9 follow-up note (verified: pinned `join_filter_pushdown.hpp:71` has no default initializer; Sirius reads it at `sirius_plan_comparison_join.cpp:426`); no B1 code change.
+- **Review's corrected citations adopted:** `test.yml:57-58`, `check.yml:32-33,107-109` (+ build-only note `:139,:167`), `distribution.yml:33,:57`, `sirius_extension.cpp:1834-1848`, `publishes_dynamic_filters` `:166-170`, `sirius_physical_plan_generator.hpp:82-85`, `unittest.cpp:52-101`, `.pre-commit-config.yaml:81-86`, fixture `:110-160`.

--- a/docs/super-sirius/issue-1010-plans/C1ab-adapter-foundation.md
+++ b/docs/super-sirius/issue-1010-plans/C1ab-adapter-foundation.md
@@ -1,0 +1,419 @@
+# Track C foundation: PR C1a (version-pinned adapter + immutable publish plan) and PR C1b (strong target types, telemetry, shadow selectivity)
+
+Companion to [issue-1010-dynamic-filter-sip-design.md](../issue-1010-dynamic-filter-sip-design.md); baseline dev 506a1d9f.
+
+PR IDs covered: **C1a**, **C1b**.
+
+---
+
+## 0. Grep-verified enumeration: every non-legacy read of `JoinFilterPushdownInfo` / join `filter_pushdown` / `DynamicTableFilterSet` in `src/`
+
+**A. `JoinFilterPushdownInfo` (producer metadata)**
+
+| # | Site | What it does today |
+|---|---|---|
+| 1 | `src/include/transparent/sirius_optimizer_extension.hpp:43-68` (doc refs continue to :79) | declares `detail::preserved_counts` (:46-50), `clone_filter_pushdown_info` (:56-57), `preserve_dynamic_filter_metadata` (:64-66) |
+| 2 | `src/transparent/sirius_optimizer_extension.cpp:45-61` | clone impl: copies `join_condition`, `build_side_has_filter`, `probe_info` sharing `dynamic_filters` shared_ptr (:54), drops `min_max_aggregates` (:58-59) |
+| 3 | `src/transparent/sirius_optimizer_extension.cpp:63-90` | `preserve_dynamic_filter_metadata` parallel walk: GET `dynamic_filters` share (:74-75), join clone (:81-82) |
+| 4 | `copy_logical_plan` callers: `sirius_optimizer_extension.cpp:158` (optimizer hook), `src/transparent/physical_sirius_execution.cpp:124` (re-execute), `src/sirius_context.cpp:851` (prepare-time validation copy) | invoke the preservation walk |
+| 5 | `src/planner/sirius_plan_comparison_join.cpp:332` | dead `build_key_domain_cardinalities` reads `filter_pushdown->join_condition` |
+| 6 | `sirius_plan_comparison_join.cpp:368` | `op.filter_pushdown ? build_key_domain_cardinalities(...)` gate |
+| 7 | `sirius_plan_comparison_join.cpp:422,426` | wiring gate: non-null + `build_side_has_filter` |
+| 8 | `sirius_plan_comparison_join.cpp:442-443,444,450-458` | iterates `probe_info`, uses `pi.dynamic_filters.get()` as channel key, copies `pi.columns[*].probe_column_index.column_index` / `.storage_type` |
+| 9 | `sirius_plan_comparison_join.cpp:514` | `std::move(op.filter_pushdown)` into the physical join (commented-out relics :587,:595) |
+| 10 | `src/include/op/sirius_physical_hash_join.hpp:85` (ctor param), `:100` (member) | ownership |
+| 11 | `src/op/sirius_physical_hash_join.cpp:33` (include), `:214,228` (store), `:229-233` (ctor invariant enabled-plan⇒pushdown), `:1333` (claim `filter_pushdown && _dynamic_filter_plan.enabled()`), `:1335` (publisher ctor arg), `:1364` (claim inside `push_data_batch_partitioned`) | the runtime deref C1a removes |
+| 12 | `src/include/op/dynamic_filter_publisher.hpp:19` (include), `:43,47,58` (`_filter_pushdown` ref member) | publisher holds a live DuckDB ref |
+| 13 | `src/op/dynamic_filter_publisher.cpp:121,123,124` (per-key vectors sized by `join_condition.size()`), `:159-172` (key loop: `cond_idx` indexes `_key_casts`; cast skip :163-171; index skip `cond_idx >= _right_key_col_indices.size()` :172 — this is what drops range-comparison ordinals today), `:337` (summary log key count) | runtime iteration over DuckDB metadata |
+| 14 | `src/include/op/sirius_physical_nested_loop_join.hpp:59,101`; `src/op/sirius_physical_nested_loop_join.cpp:126,146` | **dead**: the only NLJ constructions (`sirius_plan_comparison_join.cpp:600-607`, `test/cpp/operator/test_physical_mark_join.cpp:151`) use the projection-map overload; pushdown is never passed |
+
+**B. `DynamicTableFilterSet` (channel identity)**
+
+| # | Site | What it does today |
+|---|---|---|
+| 15 | `src/include/planner/sirius_physical_plan_generator.hpp:32,80-91` + `src/planner/sirius_physical_plan_generator.cpp:54-65` | router: pointer-keyed channel map, central enable gate (:61) via `dynamic_filter_pushdown_enabled` (:39-44) |
+| 16 | `src/planner/sirius_plan_get.cpp:264-268` | scan side: copies `op.dynamic_filters`, creates channel by pointer key, logs raw address |
+| 17 | `src/include/op/sirius_physical_table_scan.hpp:100-103` (member, assigned only at #16) | identity/lifetime anchor |
+| 18 | `src/include/op/sirius_physical_parquet_scan.hpp:84-87` + `src/op/sirius_physical_parquet_scan.cpp:65` | copies the anchor from the table scan |
+| 19 | `src/include/op/sirius_physical_duckdb_scan.hpp:79` | **dead**: never assigned nor read anywhere in non-legacy `src/` |
+
+**Excluded name collisions** (not part of this contract): `src/sirius_extension.cpp:1321` (`TableFunction::filter_pushdown` static-filter capability flag); `src/op/scan/parquet_gpu_ingestible.cpp` `disable_filter_pushdown` (:116-124,193-207,479-497,559,637,704-727 + `.hpp:125,202`) — reader-side static-filter flag; everything under `src/legacy/` and `src/include/legacy/`.
+
+**Verified index-space fact underpinning the adapter.** Pinned DuckDB calls `PhysicalComparisonJoin::ReorderConditions(join.conditions)` *before* recording `join_condition` (`duckdb/src/optimizer/join_filter_pushdown_optimizer.cpp:224,249-250`); that reorder is equality-first stable with equality = `COMPARE_EQUAL|COMPARE_NOT_DISTINCT_FROM` (`duckdb/src/execution/operator/join/physical_comparison_join.cpp:34-73`), semantically identical to Sirius's `reorder_join_conditions` (`sirius_physical_hash_join.cpp:171-202`, `is_equality` :79-83). **DuckDB pushes both equality and range comparisons** into `join_condition` — `COMPARE_EQUAL` plus `COMPARE_LESSTHAN/LESSTHANOREQUALTO/GREATERTHAN/GREATERTHANOREQUALTO` are admitted (`join_filter_pushdown_optimizer.cpp:230-236`); only `COMPARE_NOT_DISTINCT_FROM` is skipped (:237-239). Consequences: (a) every recorded `cond_idx` is a valid index into Sirius's post-reorder `conditions`; (b) equality conditions form a prefix, so `key_casts`/`right_key_col_indices` (populated per equality condition, ctor :284-340) are validly indexed by `cond_idx` **iff** `cond_idx < right_key_col_indices.size()` — range ordinals land past the equality prefix and are exactly the ones today's runtime skip at `dynamic_filter_publisher.cpp:172` drops, while their targets are still wired at plan time (site #8). Producer join types: DuckDB admits INNER/RIGHT/SEMI (`join_filter_pushdown_optimizer.cpp:207-219`); RIGHT/RIGHT_SEMI/RIGHT_ANTI and MIXED_JOIN never enter `BUILD_PROBE` (`sirius_physical_hash_join.cpp:445-448`, `update_join_exec_mode`), and eq+range joins run as MIXED_JOIN (:344-346) — so today's *claiming* producers are exactly {INNER, SEMI} pure-equality BUILD_PROBE joins. The design's INNER-or-SEMI claim assertion is behavior-preserving; the plan-time wiring set (which includes RIGHT and eq+range producers) must not narrow.
+
+**Verified dead-signal fact.** `build_key_domain_cardinalities` (`sirius_plan_comparison_join.cpp:329-352`) requires `BOUND_COLUMN_REF` keys (:338), but it runs after `ColumnBindingResolver` (`sirius_physical_plan_generator.cpp:126-132` always precedes dispatch; every entry path funnels through it — `sirius_context.cpp:856,861`, `physical_sirius_execution.cpp:148-149`, `sirius_extension.cpp:536`, `sirius_ffi.cpp:171`), where keys are `BoundReferenceExpression` (the join ctor asserts BOUND_REF/BOUND_CAST, :304-337). So domains are always 0 and the publisher gates at `dynamic_filter_publisher.cpp:177` and `:214` never fire. Replacing them with `std::optional` + shadow logging is a no-behavior-change.
+
+---
+
+# PR C1a — version-pinned adapter + immutable publish plan
+
+## Goal
+
+Concentrate every pinned-DuckDB metadata read behind one version-pinned `duckdb_join_filter_candidate_adapter` (preservation + extraction entry points), snapshot the producer's routing/key decisions into immutable Sirius values at plan/construction time, and rewrite the publication claim and publisher so runtime never dereferences `JoinFilterPushdownInfo` (design "Version-pinned adapter" :296-338, "Immutable Sirius plan" :782-817).
+
+**Gate promise** (design phasing row :962): same admitted producers/keys, scan targets, materialization choices, channel lifecycle, and results under fixed config.
+
+**Non-goals**: per-key fan-out that changes target behavior (C1c), enforcing the repaired selectivity gate (C1d — enforcement-only, lives in the C1cde cluster and depends on C1b), removing the `build_side_has_filter` wiring gate (C1e), SIP targets/lineage/registry (C3), consumer/mask work (C2), scheduler changes (A-track), the DuckDB pin bump (B1). No new config flags — observationally idempotent.
+
+## Deliverables
+
+**New `src/include/op/dynamic_filter_identity.hpp`** (shared with A1 — see Dependencies):
+
+```cpp
+namespace sirius::op {
+// Query-relative monotonic IDs (design "Publication, target, channel, and filter identity").
+// Assigned from per-plan-generator counters; exactly one constructed plan executes per query,
+// so log consumers may treat them as query-relative.
+struct dynamic_filter_publication_plan_id { std::uint32_t value = 0; };
+struct dynamic_filter_target_id           { std::uint32_t value = 0; };
+// channel_id / filter_id slots reserved for A1; add here, not elsewhere.
+struct admitted_dynamic_filter_key {          // design :330-335, three index spaces
+  std::size_t duckdb_filter_ordinal;  // j in join_condition and probe_info[t].columns
+  std::size_t condition_index;        // DuckDB-reordered == Sirius-reordered condition index
+  std::size_t sirius_key_ordinal;     // compact ordinal after Sirius narrowing
+};
+}
+```
+
+**New `src/include/planner/duckdb_join_filter_candidate_adapter.hpp` / `src/planner/duckdb_join_filter_candidate_adapter.cpp`:**
+
+```cpp
+namespace sirius::planner {
+
+enum class duckdb_candidate_kind : std::uint8_t { absent, statistics_only, admitted, malformed };
+
+struct duckdb_probe_target_candidate {
+  duckdb::DynamicTableFilterSet const* channel_key;   // opaque identity; never dereferenced
+  struct probe_column { std::size_t column_index; duckdb::LogicalType storage_type; };
+  std::vector<probe_column> columns;                   // validated: size == condition_indexes.size()
+};
+
+struct duckdb_join_filter_candidate {
+  duckdb_candidate_kind kind = duckdb_candidate_kind::absent;
+  bool build_subtree_has_filter_hint = false;          // snapshot of build_side_has_filter (design :292)
+  // FULL DuckDB arity: every join_condition ordinal is kept, equality or not. DuckDB pushes
+  // range comparisons too (join_filter_pushdown_optimizer.cpp:230-236); non-equality ordinals
+  // are narrowed per key at finalization (the mirror of dynamic_filter_publisher.cpp:172),
+  // never rejected structurally. Validated in-range and unique.
+  std::vector<std::size_t> condition_indexes;
+  // Per-ordinal comparison snapshot aligned with condition_indexes (telemetry/debug-assert use
+  // only; lets C1b label "not admitted: non_equality" vs "not admitted: cast").
+  std::vector<duckdb::ExpressionType> condition_comparisons;
+  std::vector<duckdb_probe_target_candidate> targets;  // null-channel targets dropped individually
+};
+
+struct preserved_counts { std::size_t joins = 0; std::size_t gets = 0; };  // moved from transparent::detail
+
+class duckdb_join_filter_candidate_adapter {
+public:
+  // Entry point 1: preservation while the optimized logical plan is copied (design :301,305-313).
+  static void preserve_dynamic_filter_metadata(duckdb::LogicalOperator& original,
+                                               duckdb::LogicalOperator& copy,
+                                               preserved_counts& counts);
+  [[nodiscard]] static duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo>
+    clone_filter_pushdown_info(duckdb::JoinFilterPushdownInfo const& src);
+
+  // Entry point 2: extraction post-resolver, before create_plan(children)/condition wrap (design :302-303,315-325).
+  [[nodiscard]] static duckdb_join_filter_candidate extract(duckdb::LogicalComparisonJoin const& op);
+
+  // Scan-side identity read (completes "one adapter owns every read").
+  [[nodiscard]] static duckdb::shared_ptr<duckdb::DynamicTableFilterSet>
+    scan_channel_identity(duckdb::LogicalGet const& get);
+};
+}
+```
+
+**Changed `src/include/op/dynamic_filter_publish_plan.hpp` (+ .cpp):**
+
+```cpp
+struct dynamic_filter_key_plan {                       // design :787-792, embedded key superset
+  admitted_dynamic_filter_key key;
+  cudf::size_type build_column_index;                  // resolved right_key_col_indices[condition_index]
+  cudf::data_type build_type;                          // EMPTY == resolve from runtime column (fallback)
+  std::optional<std::size_t> build_key_domain_cardinality;  // always nullopt in C1a; shadow value in C1b
+};
+
+class dynamic_filter_publish_plan final {
+public:
+  struct probe_target {                                // unchanged shape in C1a + id
+    dynamic_filter_target_id target_id;
+    std::shared_ptr<sirius_dynamic_filter_set> filter_set;
+    std::vector<std::size_t> probe_col_idx;            // full DuckDB arity, indexed by duckdb_filter_ordinal
+    std::vector<cudf::data_type> probe_col_type;
+  };
+  dynamic_filter_publish_plan() = default;
+  dynamic_filter_publish_plan(dynamic_filter_publication_plan_id id,
+                              std::vector<probe_target> probe_targets,
+                              bool emit_zone_map_filters,
+                              std::size_t duckdb_key_count,                    // join_condition.size() snapshot (log parity)
+                              std::vector<dynamic_filter_replica_space> replica_spaces,
+                              double domain_coverage_threshold = k_default_domain_coverage_threshold);
+  // Exactly-once finalization by the owning join's ctor after condition reorder/key extraction:
+  void finalize_keys(std::vector<dynamic_filter_key_plan> keys);              // throws if called twice
+  [[nodiscard]] bool enabled() const noexcept;                                // unchanged: !_probe_targets.empty()
+  [[nodiscard]] std::span<dynamic_filter_key_plan const> keys() const noexcept;
+  [[nodiscard]] std::size_t duckdb_key_count() const noexcept;
+  [[nodiscard]] dynamic_filter_publication_plan_id id() const noexcept;
+  // Producer eligibility used by the claim's release-mode fail-closed check (design :342-354,816).
+  // Join-type predicate ONLY — zero admitted keys is a legitimate state (all keys cast-skipped or
+  // non-equality) in which the publisher still runs and emits its terminal summary line.
+  [[nodiscard]] bool validate_producer_eligibility(duckdb::JoinType join_type) const noexcept;
+  // existing accessors kept: probe_targets(), emit_zone_map_filters(), replica_spaces(), domain_coverage_threshold()
+  // REMOVED: build_key_domain_cardinalities()
+};
+
+// Fresh pure predicate, NOT derived from prove_unique_columns' switch (design :356-359):
+[[nodiscard]] constexpr bool is_dynamic_filter_producing_join_type(duckdb::JoinType t) noexcept
+{ return t == duckdb::JoinType::INNER || t == duckdb::JoinType::SEMI; }
+```
+
+**Changed `src/include/op/dynamic_filter_publisher.hpp`:**
+
+```cpp
+class dynamic_filter_publisher final {
+public:
+  explicit dynamic_filter_publisher(dynamic_filter_publish_plan const& plan) : _plan(plan) {}
+  void publish(cudf::table_view const& build_view, rmm::cuda_stream_view stream) const;
+private:
+  dynamic_filter_publish_plan const& _plan;   // ONLY member; JoinFilterPushdownInfo/key_casts/right_key_col_indices gone
+};
+```
+
+**Changed `sirius_physical_hash_join`** (`src/include/op/sirius_physical_hash_join.hpp`): drop the `duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> pushdown_info` ctor parameter (:85) and the `filter_pushdown` member (:100); `_dynamic_filter_plan` loses `const` qualification (:254) but is finalized exactly once in the ctor and never mutated afterward (documented invariant). Add a public const accessor (test/introspection surface — `_dynamic_filter_plan` is `protected`, and today only `publishes_dynamic_filters()` at :167-170 is public):
+
+```cpp
+[[nodiscard]] dynamic_filter_publish_plan const& dynamic_filter_plan() const noexcept
+{ return _dynamic_filter_plan; }
+```
+
+## Step-by-step changes
+
+**Step 1 — adapter module (new files + move preservation).**
+- Create `src/include/planner/duckdb_join_filter_candidate_adapter.hpp` and `src/planner/duckdb_join_filter_candidate_adapter.cpp` (add the .cpp to the library sources next to `src/op/dynamic_filter_publish_plan.cpp` at `CMakeLists.txt:282`).
+- Move the bodies of `clone_filter_pushdown_info` (`src/transparent/sirius_optimizer_extension.cpp:45-61`) and `preserve_dynamic_filter_metadata` (`:63-90`) into the adapter verbatim (pointer-identity share at :54 and :75 is the load-bearing invariant, design :305-313). `src/transparent/sirius_optimizer_extension.cpp` keeps `copy_logical_plan` (:94-103) delegating to the adapter; delete the entire `detail` namespace block from `src/include/transparent/sirius_optimizer_extension.hpp:43-68` (`preserved_counts` :46-50 moves to the adapter header, clone decl :56-57, preserve decl :64-66) and update the doc comments through :79. Callers `sirius_optimizer_extension.cpp:158`, `physical_sirius_execution.cpp:124`, `sirius_context.cpp:851` are signature-stable — no edits beyond includes.
+- Implement `extract(duckdb::LogicalComparisonJoin const&)`:
+  - null `filter_pushdown` → `absent`; non-null with empty `probe_info` → `statistics_only` (design :270-272);
+  - **whole-candidate `malformed` is reserved for structural corruption only**: an out-of-range `condition_indexes` entry (`>= op.conditions.size()`), a duplicate entry, or a probe target whose `pi.columns.size() != join_condition.size()` (arity corruption breaks the ordinal alignment for every consumer; unreachable under the pinned DuckDB, which pushes `pushdown_columns` and `join_condition` in lockstep, `join_filter_pushdown_optimizer.cpp:243-250` — see Risks for the honest consequence if it ever fired);
+  - **non-equality pushed conditions are NOT malformed**: all `join_condition` ordinals are kept at full arity with their `condition_comparisons` snapshot; range ordinals are narrowed per key at finalization (Step 3), reproducing today's runtime skip at `dynamic_filter_publisher.cpp:172`. This preserves plan shape for eq+range joins (targets wired, channels registered, scan operators inserted) exactly as today;
+  - per-target validation dropping only that target: null `pi.dynamic_filters` (design :317);
+  - copies out values only: `column_index` = `col.probe_column_index.column_index`, `storage_type` as `duckdb::LogicalType` value (the cudf conversion with the EMPTY fallback stays in the planner, mirroring `sirius_plan_comparison_join.cpp:452-457`).
+- Implement `scan_channel_identity(LogicalGet const&)` returning `get.dynamic_filters` (trivial; centralizes read #16).
+
+**Step 2 — planner rewiring, `src/planner/sirius_plan_comparison_join.cpp`.**
+- Delete the dead `build_key_domain_cardinalities` (:325-352) and its call/gate (:367-368). Keep `trace_binding_to_get` (:280-323) — move it to the adapter .cpp now as a file-static kept for C1b's preservation-time domain walk.
+- Replace the direct `op.filter_pushdown` block (:420-496): call `auto candidate = duckdb_join_filter_candidate_adapter::extract(op);` **before** `create_plan(*op.children[...])` (:372-373, same constraint as today's :365-368 comment). Wiring predicate stays byte-equivalent: `candidate.kind == admitted && candidate.build_subtree_has_filter_hint` plus the GPU/HOST-space check (:432-440). **Log-emission equivalence**: the "build side is unfiltered" INFO (:426-430) today fires for *any* non-null `filter_pushdown` with `build_side_has_filter == false`, including probe_info-empty candidates — key it on `candidate.kind != absent && !candidate.build_subtree_has_filter_hint` (NOT on `kind == admitted`) so `statistics_only` candidates keep their line. Keep the GPU/HOST INFO (:438-440) and the wired-targets INFO (:488-492) as-is. Channel creation loop (:442-461) now iterates `candidate.targets`, calling `get_or_create_dynamic_filter_channel(tgt.channel_key)` (:444 unchanged router) and `channel->register_producer()` (:446) — **unchanged for all DuckDB-admitted producers incl. RIGHT joins and eq+range MIXED_JOIN joins**, because `register_producer()` feeds `has_producers()` which controls scan-operator insertion (`src/pipeline/sirius_pipeline_converter.cpp:277-279,294-304`).
+- Assign `dynamic_filter_target_id`s from a per-generator monotonic counter (new `std::uint32_t next_dynamic_filter_target_id_ = 0;` + `next_dynamic_filter_publication_plan_id_` members beside the channel map, `src/include/planner/sirius_physical_plan_generator.hpp:80-91`; a generator instance is per-plan-construction — `sirius_context.cpp:843`, `physical_sirius_execution.cpp:148` — and exactly one constructed plan executes per query, making the IDs query-relative for log consumers).
+- Construct the plan with the new ctor: `{plan_id, targets, op_params.enable_dynamic_zone_map_filter, candidate.condition_indexes.size(), replica_spaces, op_params.dynamic_filter_domain_coverage_threshold}` (replaces :497-502; `build_key_domains` argument gone; `duckdb_key_count` = full `join_condition.size()` always, including non-equality ordinals).
+- Hash-join construction (:504-516): remove the `std::move(op.filter_pushdown)` argument (:514). Pass `candidate.condition_indexes` (+ `condition_comparisons`) into the plan draft as a private "pending key candidates" field `std::vector<std::size_t> _pending_condition_indexes` cleared by finalization.
+
+**Step 3 — hash-join ctor finalization, `src/op/sirius_physical_hash_join.cpp`.**
+- Ctor (:204-233): drop `pushdown_info_p` param, delete `:228` and the invariant `:229-233`. After key extraction completes (:284-340), call a new private static
+  `resolve_dynamic_filter_keys(std::span<std::size_t const> condition_indexes, std::span<key_cast_info const> key_casts, std::span<cudf::size_type const> right_key_col_indices, duckdb::vector<sirius::logical_type> const& rhs_types) -> std::vector<dynamic_filter_key_plan>`
+  which, per DuckDB ordinal `j` with `cond_idx = condition_indexes[j]`, reproduces today's runtime skips exactly: skip (not-admitted) if `cond_idx >= right_key_col_indices.size()` (mirror of `dynamic_filter_publisher.cpp:172`; this is the branch that drops range-comparison ordinals — they sit past the equality prefix); skip if `key_casts[cond_idx].cast_left || .cast_right` (mirror of :163-171, keep the DEBUG log text incl. `k`/`cond_idx`); otherwise emit `{ {j, cond_idx, compact_ordinal++}, right_key_col_indices[cond_idx], build_type, std::nullopt }` where `build_type = get_cudf_type(rhs_types[right_key_col_indices[cond_idx]])` wrapped in try/catch → `EMPTY` (runtime resolves from `col.type()`). Debug-assert (never fires under the pinned DuckDB): any `cond_idx < right_key_col_indices.size()` refers to an equality condition. Then `_dynamic_filter_plan.finalize_keys(std::move(keys))`.
+- Claim rewrite (:1358-1367): condition becomes
+  ```cpp
+  claim = _dynamic_filter_publication_state.load(...) == OPEN &&
+          _join_mode == HASH_JOIN_MODE::BUILD_PROBE &&
+          _dynamic_filter_plan.enabled();
+  ```
+  (the removed `filter_pushdown &&` is redundant today given the ctor invariant at :229-233 — provably equivalent). Inside `publish_dynamic_filters` (:1332-1337): release-mode fail-closed eligibility check **scoped strictly to the join-type predicate** —
+  ```cpp
+  if (_dynamic_filter_plan.enabled()) {
+    if (!_dynamic_filter_plan.validate_producer_eligibility(join_type)) {
+      SIRIUS_LOG_ERROR("[sirius_physical_hash_join] dynamic-filter eligibility violated at claim "
+                       "(join_type={}); skipping publication.", ...);
+    } else {
+      dynamic_filter_publisher{_dynamic_filter_plan}.publish(build_view, stream);
+    }
+  }
+  ```
+  `validate_producer_eligibility(join_type)` = `is_dynamic_filter_producing_join_type(join_type)` — genuinely unreachable today (only INNER/SEMI reach a claimed BUILD_PROBE publish, §0). **The publisher runs even when `keys()` is empty** (all keys cast-skipped or non-equality): the key loop no-ops and the terminal INFO line is still emitted with its `duckdb_key_count`, preserving the log-diff gate's multiset identity — today the publisher runs and prints "Pushed 0 dynamic filter(s) …" in that state (`dynamic_filter_publisher.cpp:330-337`). The FINISHED/FAILED state transitions (:1338-1344) are unchanged. Also update :1333 (`if (filter_pushdown && ...)` → `if (_dynamic_filter_plan.enabled())`). Remove include :33 if now unused.
+- Header (`src/include/op/sirius_physical_hash_join.hpp`): delete member :100, ctor param :85; `_dynamic_filter_plan` (:254) drops `const`; add the public `dynamic_filter_plan()` accessor next to `publishes_dynamic_filters()` (:167-170); doc-comment (:230-243) unchanged.
+
+**Step 4 — publisher rewrite, `src/op/dynamic_filter_publisher.{hpp,cpp}`.**
+- hpp: remove includes :19 and :21 (`join_filter_pushdown.hpp`, `sirius_physical_hash_join.hpp`), members `_filter_pushdown`, `_key_casts`, `_right_key_col_indices` (:43-61) → single-arg ctor.
+- cpp: keep :74-114 unchanged (empty-build skip :77-81, drained-targets skip :83-91, source-space resolution :95-111, L2 probe :114). Key loop :159-272 iterates `_plan.keys()` (admitted only; may be empty — loop no-ops, function still reaches the terminal INFO): the cast skip (:163-171) and index skip (:172) are gone (resolved at finalization); the domain gates (:176-190 membership, :210-231 zone-map) now read `key.build_key_domain_cardinality` — `nullopt` in C1a ⇒ never fire ⇒ identical to today's always-zero behavior. Column access: `build_view.column(key.build_column_index)`. **Effective build type is always the runtime `col.type()`** (today's behavior, :194); the plan-time `key.build_type` is used only as a drift *detector*: if `key.build_type != EMPTY && key.build_type != col.type()`, `SIRIUS_LOG_WARN` (existing `[sirius_physical_hash_join]` prefix of this file) **and continue with `col.type()`** — never skip the key (skipping would change behavior in a direction the plan cannot prove impossible; see Risks item 5). Per-key vectors sized `_plan.keys().size()`, indexed by `sirius_key_ordinal`.
+- Fan-out :303-329: iterate targets; the arity-mismatch guard (:310-317) **stays WARN + skip-target in release** (a throw would propagate through `publish_dynamic_filters`' catch → FAILED + rethrow, `sirius_physical_hash_join.cpp:1340-1344`, aborting the query — "fail closed" means skip, not crash), comparing `tgt.probe_col_idx.size() == _plan.duckdb_key_count()`; add a debug-only assert (adapter guarantees it; same never-fires observable in release). Push loop iterates `_plan.keys()` and indexes target vectors by `key.key.duckdb_filter_ordinal`; zone-map type check `tgt.probe_col_type[key.key.duckdb_filter_ordinal] == effective_build_type` (:319-321 semantics preserved).
+- Summary INFO (:330-337): keep format and **keep the keys count = `_plan.duckdb_key_count()`** (not admitted count) so fixed-config log-diff is byte-stable. This is the machine-diffed terminal line of the gate protocol; it keeps its existing `[sirius_physical_hash_join]` prefix and INFO level.
+
+**Step 5 — scan side + cleanups.**
+- `src/planner/sirius_plan_get.cpp:264-268`: replace direct reads with `auto identity = duckdb_join_filter_candidate_adapter::scan_channel_identity(op); node->dynamic_filters = identity; if (identity) { node->sirius_dynamic_filters = get_or_create_dynamic_filter_channel(identity.get()); ... }` (log line unchanged). Router `get_or_create_dynamic_filter_channel` (`sirius_physical_plan_generator.cpp:54-65`) and its map (`hpp:80-91`) unchanged — scan channels stay keyed by preserved `DynamicTableFilterSet*` (design :558-562).
+- Dead-code deletions (no behavior change): NLJ pushdown ctor overload + member (`sirius_physical_nested_loop_join.hpp:59,:101`; `.cpp:126,:146` — never populated, §0 #14); `sirius_physical_duckdb_scan.hpp:79` member (never assigned). Optional; if deferred, note in PR.
+- Test call-site mechanical fixes for the ctor signature: `test/cpp/operator/test_no_history_peak_memory_estimate.cpp:67-77`, `test/cpp/operator/test_physical_mark_join.cpp:90-101`, `test/cpp/operator/test_physical_concat.cpp:95-106` (each currently passes a trailing `nullptr` pushdown arg — delete it).
+- Update `test/cpp/transparent/test_preserve_dynamic_filter_metadata.cpp` includes/namespaces to the adapter (**7** existing TEST_CASEs at :72,:83,:97,:113,:127,:146,:174 must pass unmodified in assertion content — they are the pointer-identity contract tests the design names).
+
+## Tests
+
+All new files must be added to `TEST_SOURCES` (`CMakeLists.txt:562` list, `add_executable` :693) or the `check-orphan-tests` pre-commit hook fails (`.pre-commit-config.yaml:81-85`).
+
+1. `test/cpp/planner/test_duckdb_join_filter_candidate_adapter.cpp` — tag `[dynamic_filter][adapter]`, no-DB logical-op construction (pattern of `test/cpp/transparent/test_preserve_dynamic_filter_metadata.cpp:116-183`), CPU-only:
+   - `extract classifies null / statistics_only / admitted` (design :986);
+   - `extract keeps range-comparison ordinals at full arity` (eq+range join → `admitted`, `condition_indexes.size()` == full join_condition arity, `condition_comparisons[j]` records the range type — NOT malformed);
+   - `extract rejects out-of-range join_condition index` and `...duplicate index` → `malformed`; `target arity corruption -> malformed` (hand-corrupted `pi.columns`);
+   - `extract drops null-channel-identity target, keeps sibling target`;
+   - `ordinal alignment: duckdb ordinal -> condition index -> compact sirius ordinal` incl. an eq+range mixed-condition join (range ordinal present in candidate, absent from finalized keys) and an eq+INDF join (INDF never recorded by DuckDB, design :987);
+   - `preservation keeps DynamicTableFilterSet pointer identity join<->get` and `two producing joins share one scan set` (design :983-984) — adapter-namespace versions extending the 7 existing cases in `test_preserve_dynamic_filter_metadata.cpp` (those move/update to the adapter API, assertions unchanged).
+2. `test/cpp/planner/test_dynamic_filter_plan_snapshot.cpp` — tag `[dynamic_filter][planner]`, SQL-through-planner harness copied from `test/cpp/planner/test_distinct_hash_join_detection.cpp:41-158` (Parser→CreatePlan→Optimize→create_plan under `SIRIUS_CONFIG_FILE=test/cpp/config/data/minimal.yaml`, `SIRIUS_DISABLE=1` after DB creation; needs GPU-capable binary but no kernel launches). Assertions read the join's plan via the new `dynamic_filter_plan()` accessor:
+   - `filtered build inner join wires 1 target with admitted key` (asserts `publishes_dynamic_filters()`, `keys()`/target arity, `duckdb_key_count`);
+   - `unfiltered build side wires nothing` (mirror of `sirius_plan_comparison_join.cpp:426-430`);
+   - `cast build key: target wired, key not admitted, plan enabled` (arity preservation, `keys().empty()`);
+   - `eq+range join: target wired at full arity, range ordinal not admitted, plan enabled` (guards F1 plan-shape parity; the join runs as MIXED_JOIN and never claims, but channels/scan operators must exist exactly as today);
+   - `statistics_only probe_info wires nothing` (and still emits the "unfiltered" INFO when the hint is false);
+   - `RIGHT join still registers channel producer` (guards converter elision behavior at `sirius_pipeline_converter.cpp:278`);
+   - `pushdown disabled via config wires no channels` (fixture flip per `test_dynamic_filter_router.cpp:53-57`).
+3. `test/cpp/operator/test_dynamic_filter_publisher_plan.cpp` — tag `[dynamic_filter][publisher]`, **needs a CUDA device** (style of `test/cpp/operator/test_sirius_dynamic_filter.cpp:42-58`): construct `sirius_dynamic_filter_set` channels + a hand-built finalized plan + small cudf build tables; assert:
+   - `admitted int32 key publishes in_list under L2, bloom above` (mirrors :244-261 policy);
+   - `no admitted keys -> publisher runs, pushes nothing, terminal summary reflects duckdb_key_count` (empty `keys()`, publication state ends FINISHED);
+   - `drained target skipped, sibling target receives filters` (:83-91,:307);
+   - `zone-map pushed only on matching probe/build type` (:319-321);
+   - `plan/runtime build-type drift: WARN + publish with runtime type` (hand-built plan with a wrong `build_type`; push counts unchanged vs EMPTY-typed control);
+   - `claim eligibility: MARK join_type fails closed` (via `validate_producer_eligibility`; join-type predicate only).
+4. Existing suites as regression oracle (must pass unmodified except the three ctor call-site arg deletions): `test_dynamic_filter_router.cpp` (7 cases), `test_sirius_dynamic_filter.cpp`, `test_sirius_dynamic_filter_mgpu.cpp` (2-GPU, self-skipping), `test/cpp/integration/test_gpu_execution_tpch.cpp` (GPU, `[integration]`).
+
+## Gate & rollback
+
+**Fixed-config compatibility protocol** (gate evidence; log level stated per pass, per program conventions):
+- (a) `pixi run make test` green on the `gpu-2xl4` runner (whole Catch2 binary, `test.yml:133-136`).
+- (b) TPC-H SF1 `test/tpch_performance/benchmark_and_validate.sh` result validation + timing, run at **INFO** log level (timing passes are always INFO; DEBUG lines are excluded from timing runs).
+- (c) paired-run log diff, base vs PR, fixed config, two legs:
+  - **Leg 1 (INFO, may reuse the timing pass)**: per query, identical multisets of the publisher terminal line (`dynamic_filter_publisher.cpp:330-337`, INFO — counts preserved by `duckdb_key_count`).
+  - **Leg 2 (DEBUG, separate non-timed pass)**: identical multisets of the scan apply line and selectivity-gate line (`src/op/scan/dynamic_filter_merge.cpp:158,:216` — both `SIRIUS_LOG_DEBUG`; invisible at INFO, so this leg requires a dedicated DEBUG run whose timings are discarded).
+  - Both legs segmented by the QueryBegin/QueryEnd anchors the log analyzer already parses (`tools/log_analyzer/patterns.py:46-51`). Script lives in the PR description / scratch, not the repo.
+
+**Merge gate C1a** (design row :962): (a)-(c) show identical wired-target counts, pushed-filter counts, apply-row trajectories, and query results across TPC-H SF1 + clickbench sample under fixed config (dynamic filters ON and OFF); all listed suites green; adapter tests green. No new flags — `enable_dynamic_filter_pushdown` / `enable_dynamic_zone_map_filter` / thresholds keep their exact consumption points (`sirius_physical_plan_generator.cpp:38-45`, `sirius_plan_comparison_join.cpp:415,499,502`, `sirius_pipeline_converter.cpp:299`).
+
+**Rollback**: flag-free refactor — revert story is `git revert` of the single PR commit; no config, YAML schema, or on-disk state involved.
+
+## Dependencies
+
+1. **C1a → C1b** strictly ordered (C1b reshapes C1a's plan/target types and reuses the adapter entry points).
+2. **A1 (Track A)**: independent files except `dynamic_filter_identity.hpp` — whichever PR lands first creates it; the other consumes. Log-analyzer pattern registration + `SHAPE_VERSION` bump is A1's scope.
+3. **A2** (`dynamic_filter_build_priority` flag) touches `task_scheduler.*` only — its `collect_filter_build_pipelines` reads `publishes_dynamic_filters()` (`src/pipeline/task_scheduler.cpp:190`), whose semantics (`_dynamic_filter_plan.enabled()`, `sirius_physical_hash_join.hpp:167-170`) C1a preserves; no ordering constraint.
+4. **B1**: no code dependency; C1a changes no admitted candidates, so the vulnerable pin does not block it (design :947-949).
+
+## Size
+
+~600–750 prod LOC touched (adapter ~330 new; plan value ~150; publisher ~120 diff; hash join ~120 diff; planner ~140 diff; transparent −60/+20; identity header ~40; NLJ/duckdb-scan dead-code −55) + ~800–950 test LOC (3 new files, 1 updated, 3 mechanical fixes). **Recommend splitting** into C1a-1 (adapter module + preservation move + adapter/preserve tests; zero runtime change) and C1a-2 (value snapshot + publisher/claim rewrite + planner rewiring + parity tests) — each reviewable in one pass.
+
+## Risks & mitigations
+
+1. **Index-space misalignment** (DuckDB ordinal vs reordered condition vs equality ordinal). The scheme rests on DuckDB recording `join_condition` post-`ReorderConditions` (`join_filter_pushdown_optimizer.cpp:224,249-250`) and Sirius's reorder being a stable no-op on already-ordered input (`sirius_physical_hash_join.cpp:173-185`). *Mitigation*: extraction fails closed (malformed) on out-of-range/duplicate indexes; finalization's `cond_idx >= right_key_col_indices.size()` skip fences every non-equality/non-prefix ordinal out of the `key_casts`/`right_key_col_indices` index space (identical to today's runtime fence at `dynamic_filter_publisher.cpp:172`), plus a debug assert that admitted `cond_idx` refer to equality conditions; adapter tests cover eq+range and eq+INDF layouts.
+2. **Wiring side-effect drift**: channel `register_producer()` (`sirius_plan_comparison_join.cpp:446`) drives scan-operator insertion (`sirius_pipeline_converter.cpp:277-279,294-304`); narrowing wiring (e.g., excluding RIGHT joins or eq+range joins at plan time) would silently change plans. *Mitigation*: keep the wiring predicate byte-equivalent and the candidate at full DuckDB arity; INNER/SEMI narrowing exists only at the claim (proven unreachable difference); RIGHT-join and eq+range plan-shape tests.
+3. **Log-diff instability breaking the gate itself**: the summary line's key count currently equals `join_condition.size()` (`dynamic_filter_publisher.cpp:337`); a rewrite keyed on admitted count — or skipping the publisher on empty `keys()` — would change/remove the line. *Mitigation*: `duckdb_key_count` snapshot preserved for that line; publisher runs even with zero admitted keys (Step 3/4).
+4. **`DynamicTableFilterSet` lifetime after removing the join's ownership**: sets remain owned by scans (`sirius_plan_get.cpp:264`, `sirius_physical_parquet_scan.cpp:65`) and by the logical plan during planning; runtime never dereferences the pointer (map keys only, planning-scoped). *Mitigation*: comment the invariant on the router map (`sirius_physical_plan_generator.hpp:80-84`); if any GET path is found that plans without a table-scan node retaining the set, fall back to keeping an opaque ownership-only `unique_ptr` member on the join (no accessor).
+5. **Plan-time `build_type` vs runtime `col.type()` divergence** (decimal/timestamp conversions). Today's behavior uses the runtime type unconditionally; the plan snapshot cannot be proven drift-free for every type mapping. *Mitigation*: runtime `col.type()` remains authoritative; `key.build_type` is EMPTY-fallback + WARN-only drift detector (never skips a key); publisher parity test over INT32/INT64/DECIMAL/VARCHAR keys plus an injected-drift test.
+6. **`_dynamic_filter_plan` losing `const`**: mutation-after-finalize would break the immutability contract (design :782-817). *Mitigation*: `finalize_keys` throws on second call; the new public accessor is const-ref only; comment on the member (`sirius_physical_hash_join.hpp:253-254`).
+7. **Defensive `malformed` on target-arity corruption is a (theoretical) plan-shape change**: today an arity-corrupt target would still wire and be WARN-skipped at fan-out (`dynamic_filter_publisher.cpp:310-317`); under C1a the whole candidate is rejected and no channel is registered. This is unreachable under the pinned DuckDB (columns and `join_condition` pushed in lockstep, `join_filter_pushdown_optimizer.cpp:243-250`) and is the design's intended structural fail-closed (design :315-320); stated here honestly rather than claimed "no behavior change". The runtime WARN+skip guard is retained as a second fence regardless.
+
+---
+
+# PR C1b — strong target-key value types, materialization telemetry, shadow selectivity signal
+
+## Goal
+
+Strong target-key value types (`scan_target_key`, target variant, strong IDs), materialization telemetry (`duckdb_candidate` / `membership_materialization` / `zone_map_materialization` / `duckdb_build_subtree_has_filter_hint`, design :283-294), and a live-but-shadow selectivity signal replacing the dead domain path with a pre-resolver snapshot and `std::nullopt` unknown semantics (design :840-848).
+
+**Ownership (cross-cluster resolution): C1b OWNS the shadow selectivity signal end to end** — the preservation-time snapshot pass, the registry, the flow into `dynamic_filter_key_plan.build_key_domain_cardinality`, and the would-suppress *recording* (log-only). The C1cde cluster's **C1d is enforcement-only** (flipping shadow suppression to actual skips) and **depends on C1b landing**; it adds no signal plumbing of its own.
+
+**Gate** (design row :963): C1a criteria repeated; C1b additionally makes policy observable with behavior unchanged.
+
+## Deliverables
+
+```cpp
+// dynamic_filter_publish_plan.hpp
+struct scan_target_key {                                  // strong per-target key (design :794-798)
+  admitted_dynamic_filter_key key;
+  cudf::size_type probe_column_index;
+  cudf::data_type probe_column_type;
+};
+struct scan_publish_target {
+  dynamic_filter_target_id target_id;
+  std::shared_ptr<sirius_dynamic_filter_set> channel;
+  std::vector<scan_target_key> keys;                      // aligned to admitted keys (sirius_key_ordinal)
+};
+struct join_probe_target_key { admitted_dynamic_filter_key key;
+                               cudf::size_type probe_column_index; cudf::data_type probe_column_type; };
+struct join_probe_publish_target { dynamic_filter_target_id target_id;
+                                   std::shared_ptr<sirius_dynamic_filter_set> channel;
+                                   std::vector<join_probe_target_key> keys; };   // declared; unconstructed until C3
+using dynamic_filter_publish_target = std::variant<scan_publish_target, join_probe_publish_target>;  // design :806-807
+```
+
+```cpp
+// new src/include/planner/dynamic_filter_candidate_snapshot_registry.hpp (+ .cpp)
+// Query-local logical pairing (design G9 row, :935); owned by SiriusContext, cleared in QueryBegin/QueryEnd.
+class dynamic_filter_candidate_snapshot_registry {
+public:
+  void record(duckdb::JoinFilterPushdownInfo const* cloned_info,
+              std::vector<std::optional<std::size_t>> per_key_domains);   // 0/untraceable stored as nullopt
+  [[nodiscard]] std::optional<std::vector<std::optional<std::size_t>>>
+    take(duckdb::JoinFilterPushdownInfo const* info);
+  void clear();
+};
+```
+
+Materialization-telemetry value enums (in `dynamic_filter_publish_plan.hpp` or a small `dynamic_filter_telemetry.hpp`): `membership_materialization {exact_set, bloom, none_unsupported_type}`, `zone_map_materialization {emitted, none_disabled, none_invalid_minmax, none_shadow_would_suppress}` — used only to format log lines in C1b.
+
+## Step-by-step changes
+
+**Step 1 — target restructure (`dynamic_filter_publish_plan.{hpp,cpp}`, `sirius_plan_comparison_join.cpp`, `dynamic_filter_publisher.cpp`).**
+- Replace `probe_target` with the `dynamic_filter_publish_target` variant. Planner builds full-arity *draft* scan targets (probe column index/type per DuckDB ordinal, from `candidate.targets[t].columns`); `finalize_keys` (hash-join ctor) compacts each scan target's per-ordinal columns into `std::vector<scan_target_key>` aligned to admitted keys. Publisher fan-out becomes a `std::visit` (exhaustive; `join_probe_publish_target` branch `throw std::logic_error` until C3) iterating `tgt.keys` by `sirius_key_ordinal`. Push set is provably identical (non-admitted ordinals never have built filters today — non-equality and cast ordinals are skipped before any filter is materialized, C1a Step 3). The C1a arity WARN+skip guard translates to the compacted form (keys-vector length vs plan `keys().size()`).
+- The converter/scan/channel code is untouched; `filter_set`→`channel` rename confined to the plan/publisher/planner.
+
+**Step 2 — shadow selectivity signal (owned here, enforced in C1d).**
+- New `dynamic_filter_candidate_snapshot_registry` (files above; register the .cpp in CMake). Owner: `SiriusContext` member; `clear()` called in `QueryBegin` (`src/sirius_context.cpp:165-209`) and `QueryEnd` (:211-265). SiriusContext serializes query lifecycles (`sirius_context.hpp:267-277`), so the query-local registry is race-safe.
+- Preservation-time walk: extend `duckdb_join_filter_candidate_adapter::preserve_dynamic_filter_metadata` with an optional `(duckdb::ClientContext&, dynamic_filter_candidate_snapshot_registry*)`; in the join branch (old :78-84), after cloning, run the resurrected domain walk **on the original join** (pre-resolver: conditions are `BOUND_COLUMN_REF`, exactly what the dead code at `sirius_plan_comparison_join.cpp:329-352` required) reusing `trace_binding_to_get` (moved to the adapter in C1a) and the pre-filter cardinality read (:343-349); store per-DuckDB-ordinal `optional<size_t>` (0/untraceable → `nullopt`, design :845-846) keyed by the **clone's** `JoinFilterPushdownInfo*` (stable from clone through `extract`, since the copy's `unique_ptr` moves don't change the pointee). All three `copy_logical_plan` callers get the registry from the `SiriusContext` already in hand (`sirius_optimizer_extension.cpp:111,146`, `physical_sirius_execution.cpp:132`, `sirius_context.cpp` member scope).
+- Extraction attaches: `extract` gains an optional registry param; on hit, per-ordinal domains flow into `dynamic_filter_key_plan.build_key_domain_cardinality` at finalization. **Registry misses (all stay `nullopt`, harmless)** occur on every path where no preservation copy runs: the explicit non-transparent paths `sirius_extension.cpp:295,387,686` and `sirius_ffi.cpp:164`, **and the transparent replan fallback** `physical_sirius_execution.cpp:132-147` (re-parse/re-optimize when `logical_plan_` proved non-copyable — `extract` then sees native, non-clone `JoinFilterPushdownInfo` pointers).
+- Publisher gates become shadow: at :176-190 and :214-231 sites compute `would_suppress` from the optional and threshold, **log only** (`shadow_suppress_membership=`/`shadow_suppress_zone_map=` k=v fields), never skip. Enforcement is C1d (C1cde cluster), which consumes this signal as-is.
+
+**Step 3 — materialization telemetry.**
+- Plan-time, one machine-parsed line per producing join at INFO: `[dynf_summary] candidate: plan_id={} kind={absent|statistics_only|admitted|malformed} build_hint={} keys_total={} keys_admitted={} targets={}` (emitted from `sirius_plan_comparison_join.cpp`; uses the `[dynf_summary]` prefix because it is a machine-parsed summary line, per program logging conventions — human-oriented lines in that file keep `[sirius_plan_comparison_join]`). `keys_total` = `duckdb_key_count`; `keys_admitted` = finalized `keys().size()` is only known post-ctor, so the planner logs `keys_total`/`targets` and the hash-join ctor logs a companion `[dynf_summary] finalized: plan_id={} keys_admitted={}` line — both INFO, both per-join, both stable-count (safe for timing passes).
+- Publish-time: extend the per-key DEBUG (`dynamic_filter_publisher.cpp:262-271`) to k=v: `plan_id= key= cond_idx= build_rows= membership={exact_set|bloom|none(unsupported_type)} zone_map={emitted|none(disabled)|none(invalid_minmax)} domain={n|unknown} shadow_suppress_membership={0|1} shadow_suppress_zone_map={0|1} set_bytes= bloom_bytes= l2_bytes=`. **DEBUG level — excluded from timing runs**; coverage claims about these fields come from a separate non-timed DEBUG pass. Keep the terminal INFO (:330) format-stable. New/changed lines follow the log_analyzer contract style (`tools/log_analyzer/patterns.py` anchors, `k=v` numeric fields); pattern/`SHAPE_VERSION` updates are A1's deliverable — coordinate field names (`plan_id`, `target_id`) with A1's event vocabulary (design :1059-1069) so A1 doesn't re-churn.
+
+## Tests
+
+5. Extend `test_duckdb_join_filter_candidate_adapter.cpp`: `registry: preservation records per-ordinal domains keyed by clone pointer; extract attaches; miss -> all nullopt; zero cardinality -> nullopt` (design :845-846). Miss matrix covers all three no-preservation paths: explicit non-transparent planning, FFI, **and the transparent replan fallback** (simulate by extracting from a native, never-preserved `JoinFilterPushdownInfo` — the `physical_sirius_execution.cpp:132-147` shape).
+6. Extend `test_dynamic_filter_plan_snapshot.cpp`: `shadow domains flow from preservation through finalized key plans` (uses `copy_logical_plan` + registry, then plans the copy; asserted via `dynamic_filter_plan()`).
+7. Extend `test_dynamic_filter_publisher_plan.cpp` (GPU): `high domain coverage logs would-suppress but still publishes` — push counts identical with domain nullopt vs domain small vs domain huge (shadow proof, design :843-844).
+8. Variant dispatch: `join_probe_publish_target present -> publish throws logic_error` (until C2/C3).
+
+## Gate & rollback
+
+- **Merge gate C1b** (design row :963): C1a's fixed-config protocol repeated (same log levels per leg: INFO timing/terminal-line legs; separate non-timed DEBUG leg for per-key shadow fields and scan-apply lines), plus: shadow `k=v` fields present in the DEBUG pass for every admitted key on a TPC-H run; at least one query demonstrates a non-`unknown` domain with `would_suppress=1` while push counts remain unchanged vs C1a base (policy observable, behavior unchanged); `[dynf_summary]` lines present per producing join in the INFO pass.
+- **Proceed gate**: C1c/C1e may only build on the merged C1b types; **C1d additionally consumes C1b's shadow signal (enforcement-only)**; B1 is deferred (decision 2026-07-08, sirius-db/sirius#1123) and blocks nothing; while on the unpatched pin, LIMIT/TOP-N-shaped tests use explicit expected rows or a filters-disabled reference, never an unpatched CPU run.
+- **Rollback**: flag-free; `git revert` of the single PR commit. The registry is query-local and self-clearing; reverting C1b leaves C1a intact (C1b is strictly additive over C1a's types except the target restructure, which is why C1b must not be squashed into C1a).
+
+## Dependencies
+
+1. **C1a → C1b** strictly ordered.
+2. **A1**: k=v field names (`plan_id`, `target_id`) and the `[dynf_summary]` vocabulary must match A1's event vocabulary; log_analyzer pattern registration + `SHAPE_VERSION` bump is A1's scope. Coordinate before C1b merges.
+3. **C1d (C1cde cluster)**: enforcement-only consumer of C1b's shadow signal; blocked on C1b. C2/C3 consume C1b's `join_probe_publish_target`/variant and the adapter; blocked on C1b.
+
+## Size
+
+~450–550 prod (variant/target restructure ~180; registry ~150; preservation walk ~80; telemetry ~60) + ~380–480 test. Single PR.
+
+## Risks & mitigations
+
+1. **Registry key aliasing across copies**: three `copy_logical_plan` sites can register multiple snapshots per query (prepare-validation + execute copies). *Mitigation*: key by the clone pointer actually consumed by `extract` (`take()` removes the entry), `clear()` at QueryBegin/QueryEnd (`sirius_context.cpp:165-265`); registry test covers double-copy and the replan-fallback miss.
+2. **Preservation-time domain walk cost/exceptions**: `get->function.cardinality` (old :343-347) can allocate/throw inside the optimizer hook. *Mitigation*: wrap per-key in try/catch → `nullopt`; walk only joins that already have `filter_pushdown`; it replaces an identical-shape walk that previously ran per plan anyway (:367-368).
+3. **Telemetry perturbing the timing gate**: per-key lines are DEBUG and excluded from timing runs; the two new per-join `[dynf_summary]` INFO lines are constant-count per plan (no per-batch fan-out) and are diffed, not timed, in leg 1.
+
+---
+
+# Review resolution appendix
+
+One line per adversarial-review finding → how it was applied.
+
+1. **BLOCKER — non-equality pushed conditions made the whole candidate `malformed`** → Fixed as directed: `extract()` keeps ALL `join_condition` ordinals at full arity (DuckDB pushes range comparisons, `join_filter_pushdown_optimizer.cpp:230-236`); non-equality ordinals are narrowed per key at finalization via the `cond_idx >= right_key_col_indices.size()` mirror of today's runtime skip (`dynamic_filter_publisher.cpp:172`); `malformed` reserved for out-of-range/duplicate indexes and target-arity corruption; `duckdb_key_count = join_condition.size()` always; §0 index-space paragraph corrected; eq+range plan-shape test added. Note: per-target arity corruption moved from "drop target" to `malformed` per the directive and design :315-320 — a theoretical plan-shape change vs today's runtime WARN+skip, unreachable under the pinned DuckDB and stated honestly as C1a Risk 7 (the runtime WARN+skip fence is retained regardless).
+2. **MAJOR — `!keys().empty()` eligibility clause broke log parity and emitted spurious ERROR** → Fixed as directed: the publisher runs even with zero admitted keys (loop no-ops; terminal INFO keeps its multiset identity via `duckdb_key_count`); `validate_producer_eligibility` and the release-mode ERROR are scoped strictly to the join-type predicate (genuinely unreachable); publisher test 3 updated to assert the terminal line + FINISHED state on empty keys.
+3. **MINOR — fan-out arity assertion would abort the query** → Fixed: WARN + skip-target in release (unchanged failure semantics vs today's :310-317), debug-only assert.
+4. **MINOR — build-type drift "WARN + skip-key" inverted today's fallback** → Fixed: runtime `col.type()` stays authoritative; plan-time `build_type` is a WARN-only drift detector, never skips; injected-drift publisher test added.
+5. **MINOR — "8 existing cases at :72-190"** → Fixed: 7 TEST_CASEs (:72,:83,:97,:113,:127,:146,:174; file is 191 lines) — verified against the file.
+6. **MINOR — snapshot tests needed an accessor** → Fixed: public `[[nodiscard]] dynamic_filter_publish_plan const& dynamic_filter_plan() const noexcept` added to C1a deliverables on `sirius_physical_hash_join` (member is `protected` at `hpp:254`; only `publishes_dynamic_filters()` was public).
+7. **MINOR — registry-miss enumeration omitted the transparent replan fallback** → Fixed: `physical_sirius_execution.cpp:132-147` added to the C1b miss enumeration and to the registry test matrix (test 5).
+8. **MINOR — `detail` decl citation ":52-57"** → Fixed: the block spans `sirius_optimizer_extension.hpp:43-68` (`preserved_counts` :46-50, clone :56-57, preserve :64-66) — verified; Step 1 now deletes the whole block including `preserved_counts`.
+9. **MINOR — "build side is unfiltered" INFO would vanish for statistics_only candidates** → Fixed: the log is keyed on `candidate.kind != absent && !build_subtree_has_filter_hint` (not `kind == admitted`), preserving today's emission set; snapshot test 2's statistics_only case asserts the line.
+10. **MINOR — gate protocol (c) silent about log level** → Fixed: protocol now states levels per pass — leg 1 (publisher terminal line) at INFO and reusable for timing; leg 2 (scan-apply `dynamic_filter_merge.cpp:158` and selectivity-gate `:216`, both `SIRIUS_LOG_DEBUG`) in a separate non-timed DEBUG pass; timing numbers only ever from INFO passes.
+
+Directive-level additions beyond the numbered findings: (a) cross-cluster ownership stated — C1b owns the shadow selectivity signal (snapshot pass + would-suppress recording); C1cde's C1d is enforcement-only and depends on C1b landing; (b) program logging conventions applied — machine-parsed per-join summary lines use `[dynf_summary]` at INFO, other new lines keep their file's component prefix, per-key lines are DEBUG and excluded from timing runs; (c) doc restructured into per-PR sections (Goal / Deliverables / Step-by-step / Tests / Gate & rollback / Dependencies / Size / Risks) with the standard header, content preserved.

--- a/docs/super-sirius/issue-1010-plans/C1cde-producer-flags.md
+++ b/docs/super-sirius/issue-1010-plans/C1cde-producer-flags.md
@@ -1,0 +1,572 @@
+# Planner P4 — Track C producer policy flags: C1c / C1d / C1e implementation plan
+
+Companion to [issue-1010-dynamic-filter-sip-design.md](../issue-1010-dynamic-filter-sip-design.md); baseline dev 506a1d9f.
+
+PR IDs covered: **C1c** (per-target-key fan-out restructure), **C1d** (selectivity-gate enforcement), **C1e** (unfiltered-build candidate expansion).
+
+## Cluster overview
+
+### Goal + non-goals
+
+Land the three flagged producer-policy PRs of Track C, each independently flaggable/revertible
+(design `docs/super-sirius/issue-1010-dynamic-filter-sip-design.md:951-953,964-966,974-975`).
+Honest behavior classification:
+
+- **C1c** restructures the publisher fan-out loop into per-target-key admission entries with
+  reasoned telemetry (design :819-824, read in its C1a/C1b strong-type context) — **no runtime
+  behavior change is claimed or permitted**. Today's loop is already per-key everywhere except the
+  fail-closed arity guard, and that guard stays fail-closed in both flag modes (see C1c §Goal).
+- **C1d** turns the (C1b-recorded) domain/selectivity shadow signal into an enforceable
+  publish-time gate behind `dynamic_filter_selectivity_gate = off|shadow|enforce`
+  (design :155-158, :840-848). **Enforcement-only**: the pre-resolver domain snapshot pass and the
+  shadow would-suppress recording are owned by **C1b** in the C1ab-adapter cluster (design :963,
+  :842-844); C1d consumes that recorded signal and adds the OFF/ENFORCE modes. Behavior change is
+  suppression-only, and only in `enforce` mode.
+- **C1e** removes the blanket `!build_side_has_filter → no-producer` planner gate
+  (design :826-836) behind default-off `enable_dynamic_filter_unfiltered_build`. This is the one
+  genuinely surface-expanding change in the cluster.
+
+Non-goals: no C1a adapter / C1b strong-type-and-snapshot work (owned by the foundation planner —
+C1c and C1d are specified **against the post-C1a/C1b tree** and list their interface contracts
+below), no SIP targets or `enable_dynamic_filter_sip` (C3), no consumer/memory-estimate work (C2),
+no aggregate replica budget (Track E, design :872-875), no telemetry-ID infrastructure (A1 —
+consumed if present, not built here).
+
+**B1 (patched DuckDB pin)**: B1 is deferred by decision (2026-07-08, sirius-db/sirius#1123) and
+blocks nothing, including C1e enablement. C1e's candidate expansion marginally widens the accepted
+latent LIMIT/TOP-N exposure — noted in its gate, not a blocker. While on the unpatched pin,
+LIMIT/TOP-N-shaped tests use explicit expected rows or a filters-disabled reference run, never an
+unpatched CPU run. C1d has no dependency either way (suppression-only, design :961, :964-966).
+C1c's original design-table B1 precondition (:964) was predicated on fan-out admitting *more*
+filters; the rescoped C1c admits
+none, so the precondition is vacuous — the flag nevertheless stays default-off until its parity
+soak completes, which costs nothing.
+
+### Shared deliverable: config plumbing (identical mechanics, one commit per PR)
+
+The C1d enum and its ADL conversion functions live at **namespace scope in `sirius`, above
+`struct operator_params` (src/include/sirius_config.hpp:64)** — they cannot be member declarations
+or the ADL pattern (`src/include/exec/inspectable_mpsc.hpp:38-50`, `exec::queue_ordering`) does not
+work:
+
+```cpp
+// src/include/sirius_config.hpp — namespace scope, above operator_params (:64)
+enum class dynamic_filter_selectivity_gate_mode { OFF, SHADOW, ENFORCE };          // C1d
+inline bool string_to_enum(std::string_view sv, dynamic_filter_selectivity_gate_mode& out);
+inline bool enum_to_string(dynamic_filter_selectivity_gate_mode m, std::string& s);
+```
+
+```cpp
+// src/include/sirius_config.hpp — fields appended inside struct operator_params (fields end :118)
+bool enable_dynamic_filter_per_key_fanout = false;                       // C1c (parity chicken-bit)
+dynamic_filter_selectivity_gate_mode dynamic_filter_selectivity_gate =
+  dynamic_filter_selectivity_gate_mode::SHADOW;                          // C1d
+bool enable_dynamic_filter_unfiltered_build = false;                     // C1e
+```
+
+Plumbing per Recon R3:
+
+1. `src/sirius_config.cpp` — `from_yaml(…, operator_params&)`: add `r.optional("<key>", opt.<field>);`
+   inside :160-180 (existing dynamic-filter keys at :174-178), before `r.reject_unknown()` (:179).
+   The yaml reader resolves the C1d enum via ADL as it does `task_queue_ordering`
+   (src/sirius_config.cpp:420).
+2. `src/sirius_extension.cpp` — setter next to `SetEnableDynamicFilterPushdown` (:1604-1611);
+   registration in `InitialGPUConfigs` (:1653) next to the existing dynamic-filter options
+   (:1841-1875), default `Value` from a fresh `sirius::operator_params{}` (convention :1847). Bool
+   setters clone :1604-1611; the enum setter `SetDynamicFilterSelectivityGate` clones the
+   `expression_evaluator_strategy` parse/throw pattern (`InvalidInputException` on bad value,
+   :1389-1392; registration :1675-1681). SQL options: `enable_dynamic_filter_per_key_fanout`
+   (BOOLEAN), `dynamic_filter_selectivity_gate` (VARCHAR `off|shadow|enforce`),
+   `enable_dynamic_filter_unfiltered_build` (BOOLEAN).
+3. Consumption is plan-time only via the `op_params` ref already in hand at
+   src/planner/sirius_plan_comparison_join.cpp:415, copied into the immutable publish plan at
+   :497-502 — runtime reads only the plan copy, so a mid-query `SET` cannot tear (R3 gotcha 2) and
+   A/B boundaries are query boundaries.
+
+### Shared deliverable: publish-plan policy struct (lands in C1d, the first PR of this cluster)
+
+```cpp
+// src/include/op/dynamic_filter_publish_plan.hpp
+struct dynamic_filter_publish_policy {          // groups the new knobs; one ctor param, not three
+  bool per_key_fanout = false;                                              // C1c
+  sirius::dynamic_filter_selectivity_gate_mode selectivity_gate =
+    sirius::dynamic_filter_selectivity_gate_mode::SHADOW;                   // C1d
+  bool duckdb_build_subtree_has_filter_hint = false;                        // C1e (design :292-294)
+};
+dynamic_filter_publish_plan(std::vector<probe_target> probe_targets,
+                            bool emit_zone_map_filters,
+                            std::vector<std::optional<std::size_t>> build_key_domain_cardinalities, // C1b type
+                            std::vector<dynamic_filter_replica_space> replica_spaces,
+                            double domain_coverage_threshold = k_default_domain_coverage_threshold,
+                            dynamic_filter_publish_policy policy = {});
+[[nodiscard]] dynamic_filter_publish_policy const& policy() const noexcept;
+```
+
+C1d lands the struct (filling `selectivity_gate`); C1c and C1e fill their fields in their own PRs,
+keeping the ctor signature stable across the cluster. On the C1a `dynamic_filter_publication_plan`
+these are fields of that value (design :787-813). The `optional<size_t>` domain element type is
+C1b's change (design :791, nullopt-not-zero :845) — C1d consumes it, it does not introduce it.
+
+Test accessor (lands in **C1d**, the first PR whose planner tests need it — C1c/C1e reuse it):
+
+```cpp
+// src/include/op/sirius_physical_hash_join.hpp — next to publishes_dynamic_filters() (:167-170)
+[[nodiscard]] dynamic_filter_publish_plan const& dynamic_filter_plan() const noexcept;
+```
+
+(`_dynamic_filter_plan` is private const at :254; the only existing exposure is the bool
+`publishes_dynamic_filters()`.)
+
+### Shared conventions: logging, IDs, measurement passes
+
+- **Prefixes**: every per-event line in `src/op/dynamic_filter_publisher.cpp` keeps that file's
+  uniform `[sirius_physical_hash_join]` prefix (existing events at :78, :88, :165, :181, :220,
+  :262, :311, :330); consumer-side lines in `src/op/scan/dynamic_filter_merge.cpp` keep
+  `[apply_dynamic_filters]`. No new ad-hoc prefixes.
+- **Machine-parsed per-query summary**: one new INFO line per producing-join publish, prefix
+  `[dynf_summary]`, emitted from `dynamic_filter_publisher.cpp` immediately after the existing
+  terminal INFO line (:330-337, which stays untouched for humans). k=v fields, grown per PR:
+  `pushed= active_targets= wired_targets= build_rows= keys=` (base), `fanout={target|per_key}
+  skipped_target_keys=` (C1c), `gate_mode={off|shadow|enforce} policy_suppressed_keys=
+  shadow_would_skip_keys=` (C1d), `build_has_filter_hint=` (C1e). Mirrored into
+  `tools/log_analyzer/patterns.py` with a `SHAPE_VERSION` bump (R1 §5); the emitting filename is
+  part of the parsing contract — keep publisher events in `dynamic_filter_publisher.cpp` only.
+- **Per-key / per-split lines are DEBUG** (shadow would-suppress decisions, per-filter consumer
+  keep ratios) and are EXCLUDED from timing runs. Every measurement runbook below states the log
+  level per pass: **timing passes run at INFO** (only `[dynf_summary]` and existing INFO lines
+  fire; coverage/suppression totals come from the INFO-level aggregates), and **audit/coverage
+  passes are separate non-timed DEBUG runs**.
+- **IDs**: when A1 has landed, `[dynf_summary]`, the shadow line, and the consumer per-filter line
+  carry `dynamic_filter_publication_plan_id` / `target_id` / `channel_id` / `filter_id` —
+  query-relative monotonic values (design "Publication, target, channel, and filter identity").
+  Until then, the **correlation key is `(probe_col_idx, filter_kind)`** per scan (see C1d).
+
+### Shared A/B protocol (all flags, per R3 §4)
+
+One process, `LOAD` extension before any `SET` (R3 gotcha 1), serialized
+`SET x; run suite; SET y; run suite` — never concurrent connections with different values (shared
+`SiriusContext`, src/sirius_context.cpp:919); the clean boundary is the query (flags copied into
+the plan at plan time). Offline analysis via log-analyzer per-query CSVs.
+
+### Dependencies & land order
+
+- **C1a/C1b (foundation cluster)**: **C1c is blocked on C1a** (it restructures on C1a's strong
+  target-key value types with plan-time `zone_map_admitted`, design :787-792, :627, :930).
+  **C1d is blocked on C1b** (snapshot pass + shadow recording + `optional<size_t>` domain type are
+  C1b deliverables; interface contract in C1d §Dependencies). C1e depends on neither for merge.
+- **B1**: blocks *enablement* (not merge) of C1e; vacuous for the rescoped C1c; none for C1d.
+  CI enforcement: defaults stay off/shadow until B1's gitlink lands.
+- **A1**: soft — event IDs and `NO_MATERIALIZATION(POLICY_SKIPPED)` outcomes (design :768-777) are
+  emitted only if A1 landed; k=v log fields carry the A/B otherwise.
+- **Within cluster**: land order **C1d → C1c → C1e**. C1d (first post-C1b PR) carries the shared
+  `dynamic_filter_publish_policy` struct and the test accessor; C1e's profitable operation depends
+  on C1d ENFORCE as the publish-time backstop for domain-covering unfiltered builds.
+
+---
+
+## PR C1d — selectivity-gate enforcement (`dynamic_filter_selectivity_gate`, default `shadow`)
+
+### Goal
+
+Make the repaired domain/selectivity signal *enforceable*. Context (verified against 506a1d9f):
+today the signal is dead — `build_key_domain_cardinalities()`
+(src/planner/sirius_plan_comparison_join.cpp:329-352) requires `BOUND_COLUMN_REF` (:338) but runs
+from `plan_comparison_join` (:365-368) **after** `ColumnBindingResolver` has rewritten conditions
+to `BoundReferenceExpression` in `create_plan(unique_ptr)`
+(src/planner/sirius_physical_plan_generator.cpp:126-127) — so every domain is the 0 sentinel and
+the publisher gates at src/op/dynamic_filter_publisher.cpp:176-190 (rows gate) and :214-231
+(zone-map range gate) never fire (design :155-158). **Repairing this — the pre-resolver snapshot
+pass and shadow would-suppress recording — is C1b's deliverable** (design :842-844, :963). C1d adds
+the mode flag and the ENFORCE/OFF behaviors on top of C1b's recorded signal (design :965).
+
+### Deliverables
+
+- Config enum + ADL conversions + `dynamic_filter_selectivity_gate` field + SQL option/setter
+  (shared plumbing above).
+- `dynamic_filter_publish_policy` struct with `selectivity_gate` (shared deliverable above; this PR
+  lands the struct).
+- Three-way gate treatment in the publisher (OFF / SHADOW / ENFORCE) at both publish gates.
+- Correlation-key fields on the shadow would-suppress line and the consumer per-filter line.
+- `sirius_physical_hash_join::dynamic_filter_plan()` const test accessor (shared deliverable).
+
+### Step-by-step changes
+
+1. **Interface contract consumed from C1b** (verify at rebase; if C1b landed differently, adjust
+   here, not in C1b): (a) a pre-resolver snapshot pass
+   (`src/planner/dynamic_filter_domain_snapshot.{hpp,cpp}` or equivalent) hooked in
+   `sirius_physical_plan_generator::create_plan(duckdb::unique_ptr<…>)`
+   (src/planner/sirius_physical_plan_generator.cpp:114-138) after `ResolveOperatorTypes()` (:121)
+   and before `resolver.VisitOperator(*op)` (:126-127), keyed by `JoinFilterPushdownInfo const*`
+   (stable through the `std::move(op.filter_pushdown)` at sirius_plan_comparison_join.cpp:514;
+   fresh generator per plan at src/sirius_context.cpp:843,
+   src/transparent/physical_sirius_execution.cpp:148, src/sirius_extension.cpp:533-536,
+   src/sirius_ffi.cpp:171), skipped when `!dynamic_filter_pushdown_enabled(context)`
+   (generator :39-45); (b) per-key domains as `std::vector<std::optional<std::size_t>>` on the
+   publish plan, nullopt (never sentinel 0) for untraceable keys — non-`BOUND_COLUMN_REF`,
+   untraceable get, zero estimates — padded/truncated to `join_condition.size()`; the dead
+   post-resolver call at :365-368 deleted; (c) shadow would-suppress recording at both publisher
+   gates that logs and does **not** skip. Entry-path taxonomy (verified): transparent production
+   paths pass unresolved optimized plans (src/transparent/physical_sirius_execution.cpp:124/146→149,
+   validation pass src/sirius_context.cpp:851-861) so capture is genuinely pre-resolver there;
+   explicit paths pre-resolve before calling in (`ExtractPlan` src/sirius_extension.cpp:295-298→:536,
+   Substrait FFI src/sirius_ffi.cpp:164-171) so domains are all nullopt and both gates stay off
+   there — identical to today's behavior, fail-safe.
+2. **Planner** — `plan_comparison_join` (:497-502): pass
+   `policy.selectivity_gate = op_params.dynamic_filter_selectivity_gate` in the
+   `dynamic_filter_publish_policy` ctor argument (this is the only `dynamic_filter_publish_plan`
+   value-ctor call site — grep-verified; the default-constructed member default at
+   src/include/op/sirius_physical_hash_join.hpp:87 / member :254, forwarded through the join ctor
+   at src/op/sirius_physical_hash_join.cpp:216, needs no change).
+3. **Publisher rows gate** (src/op/dynamic_filter_publisher.cpp:176-190):
+   `auto const key_domain = k < key_domains.size() ? key_domains[k] : std::nullopt;` then
+   `if (key_domain) { covered = build_rows / double(*key_domain); would_skip = covered >= threshold; }`.
+   `ENFORCE`: `continue` as the code already intends (:188) — the key's membership and zone-map are
+   never built. `SHADOW`: keep C1b's recording — log at **DEBUG**
+   `[sirius_physical_hash_join] selectivity_shadow key={} probe_col_idx={} filter_kind={membership|zone_map} build_rows={} domain={} coverage={:.3f} decision={skip|keep}`
+   and do **not** skip (adding the `probe_col_idx`/`filter_kind` fields here if C1b's line lacks
+   them). `OFF`: don't evaluate, don't log. nullopt domain: never gates in any mode.
+4. **Publisher zone-map range gate** (:214-231): same three-way treatment of the
+   `publish_zone_map = false` decision (:228).
+5. **Consumer correlation key** — `src/op/scan/dynamic_filter_merge.cpp`: the per-filter marginal
+   keep-ratio DEBUG line (:179-184, in `record_filter_keep_ratio`) currently logs only the kept
+   ratio; the combined gate line (:216-219) only kept + filter count. Extend the per-filter line
+   with `probe_col_idx={} filter_kind={}` — both already in hand at the call site (:147-152:
+   `e.col_idx`, `e.filter`); pass them into `record_filter_keep_ratio` (or log at the call site).
+   Keeps the `[apply_dynamic_filters]` prefix.
+6. **Telemetry**: `[dynf_summary]` gains `gate_mode={off|shadow|enforce} policy_suppressed_keys={n}
+   shadow_would_skip_keys={n}`. When ENFORCE suppresses **all** keys, record the A1 waiter-free
+   outcome `NO_MATERIALIZATION(POLICY_SKIPPED)` if A1 has landed (design :768-777).
+7. **Test accessor** on `sirius_physical_hash_join` (shared deliverable above).
+8. Interplay note: shadow-mode would-skip decisions are validated offline against the consumer
+   gate's measured keep ratios (:216-219) before anyone flips ENFORCE — that runtime gate remains
+   the only selectivity backstop until then (design :844-846).
+
+### Tests
+
+All new files added to `TEST_SOURCES` (CMakeLists.txt:562, dynamic-filter entries at
+:637-638,:641,:656; orphan hook `scripts/check_orphan_tests.py`). Everything runs in CI's single
+GPU-runner Catch2 binary (R4 §3).
+
+- **Planner** — in C1b's snapshot test file or new `test/cpp/planner/test_dynamic_filter_selectivity_gate.cpp`
+  (tag `[dynamic_filter][selectivity]`; SQL-through-planner pattern of
+  test/cpp/planner/test_distinct_hash_join_detection.cpp:41-95 **minus** its own resolver
+  invocation at :74-76 — the helper must let `create_plan(unique_ptr)` run the resolver, otherwise
+  the snapshot legitimately records nullopt; extension bring-up needs a GPU device even though
+  assertions are plan-shape only): `"plan carries selectivity gate mode from operator_params"` via
+  the new `dynamic_filter_plan()` accessor and a `find_hash_join()` walk (pattern
+  test_distinct_hash_join_detection.cpp:97-108).
+- **Publisher-side** (GPU; pattern test/cpp/operator/test_sirius_dynamic_filter.cpp):
+  `"nullopt domain never gates"`, `"shadow: covering domain logs would-skip but still publishes"`,
+  `"enforce: covering domain suppresses membership and zone-map for that key only"`,
+  `"enforce: non-covering domain publishes"`.
+- **Config**: extend `test/cpp/config/test_config.cpp` with YAML round-trip of
+  `dynamic_filter_selectivity_gate` (reject_unknown protects typos, src/sirius_config.cpp:179) and
+  enum parse errors (SQL setter and yaml).
+
+### Gate & rollback
+
+| Stage | Gate |
+|---|---|
+| Merge | `off` and `shadow` produce identical publications to pre-C1d C1b behavior (shadow adds ≤ noise wall-time cost vs `off`, measured in an INFO-level timing pass); enforce unit coverage above |
+| Before `enforce` in any run | **Shadow false-suppression audit**: every would-skip key cross-checked against the measured consumer keep ratio, joined on the **correlation key `(probe_col_idx, filter_kind)`** (A1 IDs when available) between the publisher `selectivity_shadow` line and the consumer per-filter line (:179-184). Log levels: this audit is a separate **non-timed DEBUG pass**; timing numbers come only from INFO passes. |
+| Enforce A/B (`shadow` vs `enforce`) | identical results, wall time not worse, publish/replica bytes reduced or flat (from `[dynf_summary]` aggregates at INFO) |
+
+**Rollback**: `SET dynamic_filter_selectivity_gate='shadow'` (or `'off'`) reverts behavior at the
+next query, no restart — this is the primary rollback story. A later `git revert` of C1d is
+possible but not clean once C1c has landed: both PRs touch the publish-plan ctor and adjacent
+publisher gate/summary lines, so expect conflict resolution confined to
+`dynamic_filter_publish_plan` ctor plumbing and the publisher gates.
+
+### Dependencies
+
+**Blocked on C1b** (snapshot pass, optional domain type, shadow recording — contract in step 1).
+No B1 dependency. A1 soft. Lands first in this cluster, carrying the shared policy struct and the
+test accessor.
+
+### Size
+
+~150 prod LOC (config enum + setter ~70, gate three-way ~40, accessor + consumer/summary logs
+~40); ~250 test LOC. No split.
+
+### Risks
+
+1. **C1b interface drift**: C1b may land the signal in a different shape (e.g. domains on
+   `dynamic_filter_key_plan::build_key_domain_cardinality`, design :791). Mitigation: step 1 is an
+   explicit contract; C1d adapts at rebase, C1b is not reworked.
+2. **Cardinality-estimate falsity → false suppression under ENFORCE**
+   (`function.cardinality`/`estimated_cardinality`, sirius_plan_comparison_join.cpp:343-350;
+   gating *benefit* on stats is tolerable only because correctness never depends on it): mitigated
+   by shadow-first audit, the runtime consumer gate remaining active, and the tunable threshold
+   (`dynamic_filter_domain_coverage_threshold`, sirius_config.hpp:111-113).
+3. **Pre-resolved entry paths keep ENFORCE inert** (explicit `ExtractPlan`/FFI paths, and
+   pre-resolving test helpers at test_distinct_hash_join_detection.cpp:74-76,
+   test/cpp/integration/test_tpcds_plan_translation.cpp:112-116,
+   test/cpp/pipeline/test_plan_printer.cpp:383-386, test/cpp/pipeline/test_modified_pipeline.cpp:392-398):
+   domains all nullopt → gates off there. This is C1b's documented degrade (one DEBUG line, no WARN
+   spam); C1d adds an explicit test that ENFORCE is a no-op on a pre-resolved plan.
+
+---
+
+## PR C1c — per-target-key fan-out restructure (`enable_dynamic_filter_per_key_fanout`, default false)
+
+### Goal
+
+Restructure the publisher's target fan-out into explicit per-(target,key) admission entries with
+reasoned telemetry, on C1a's strong target-key value types (design :819-824, :368-370: fan-out
+means "independently suppressing unsupported components of an **already admitted** target").
+**No runtime behavior change**: today's inner loop is already per-key — cast keys are suppressed
+per-key at build time (src/op/dynamic_filter_publisher.cpp:163-171), domain-gated keys per-key
+(:176-190), the zone-map type-gate per-key (:319-323), and null `per_key_membership[k]` /
+`per_key_zone_map[k]` slots are skipped per-key (:318-328). The only whole-target behavior is the
+**arity fail-closed guard (:310-317), and it stays fail-closed in BOTH flag modes**: DuckDB v1.5.4
+guarantees `probe_info[t].columns.size() == join_condition.size()` (one `JoinFilterPushdownColumn`
+per pushed condition; targets whose bindings don't all resolve to one `LogicalGet` are rejected
+whole — duckdb/src/optimizer/join_filter_pushdown_optimizer.cpp:249-270; design :360-365), so a
+runtime mismatch can only mean structural corruption, in which case the positional pairing
+`tgt.probe_col_idx[k] ↔ join_condition[k]` is exactly what is no longer trustworthy — a membership
+filter pushed to the wrong probe column silently drops correct rows (design's necessary-condition
+safety :821-823 holds only for correctly paired components; the design mandates fail-closed on this
+invariant, :315-319). There is **no** min()-prefix partial push. This PR does not recover
+mixed-provenance candidates either (design :363-370).
+
+The flag is therefore a **transition chicken-bit**: OFF keeps the legacy loop verbatim; ON selects
+the restructured per-(target,key) admission iteration, with bit-identical publications required.
+It is removed after a parity soak (follow-up cleanup PR).
+
+### Deliverables
+
+- `enable_dynamic_filter_per_key_fanout` config field + SQL option/setter (shared plumbing).
+- `dynamic_filter_publish_policy::per_key_fanout` filled at the planner call site (struct itself
+  landed by C1d).
+- Restructured fan-out loop (flag ON) emitting per-(target,key) admission records with reason
+  codes; `[dynf_summary]` fields `fanout={target|per_key} skipped_target_keys={n}`.
+
+### Step-by-step changes
+
+1. *`src/planner/sirius_plan_comparison_join.cpp`* — in the `filter_plan` construction (:497-502),
+   set `policy.per_key_fanout = op_params.enable_dynamic_filter_per_key_fanout` (only value-ctor
+   call site, as established in C1d).
+2. *`src/op/dynamic_filter_publisher.cpp` — fan-out loop :303-329:*
+   - **Flag OFF (legacy, bit-exact)**: keep :310-317 (arity WARN + `continue`) and the inner loop
+     :318-328 unchanged in code shape — do not re-derive them.
+   - **Flag ON**: same admission *outcomes*, restructured *iteration*: keep the whole-target
+     fail-closed arity skip verbatim (WARN text extended with `fail_closed=true`); for admitted
+     targets iterate per-(target,key) producing an explicit admission record
+     `{target, key, pushed_membership, pushed_zone_map, reason}` with
+     `reason ∈ {ok, type_mismatch, no_filter_built, drained_target}` (target-level
+     `arity_out_of_range` recorded once per skipped target), then push exactly what the legacy loop
+     pushes. Counters feed `skipped_target_keys` in `[dynf_summary]`; if A1 has landed, also emit
+     its per-target accept/reject edge events with the same reasons.
+   - **Zone-map type-gate (:319-323)**: the per-key predicate
+     `per_key_zone_map[k] && k < tgt.probe_col_type.size() && tgt.probe_col_type[k] == per_key_build_type[k]`
+     is already per-key and its outcome is preserved verbatim in both modes. Post-C1a:
+     `per_key_build_type[k]` (captured at runtime from `build_view.column(...)`, :192-194) is
+     replaced by the plan-time `dynamic_filter_key_plan.build_type` (design :787-792), and the
+     EMPTY-sentinel probe type produced at plan time (src/planner/sirius_plan_comparison_join.cpp:452-457)
+     becomes `std::optional<cudf::data_type>` (design :627, :930); the gate becomes a
+     plan-time-evaluable `zone_map_admitted` boolean per target-key. Keep a debug-assert that
+     runtime `col.type() == key_plan.build_type`, falling back to suppress+WARN on mismatch.
+   - Membership push (:324-327) is unchanged — cast keys are already suppressed per-key at build
+     time (:163-171) and the type-equivalence invariant comes from the no-cast gate.
+3. All new/extended log lines keep the `[sirius_physical_hash_join]` prefix; the machine-parsed
+   fields go on the `[dynf_summary]` line (shared conventions).
+
+### Tests
+
+**New `test/cpp/operator/test_dynamic_filter_publisher_fanout.cpp`** (tag
+`[dynamic_filter][fanout]`, needs GPU — builds cudf columns and in-list/Bloom filters; pattern
+test/cpp/operator/test_sirius_dynamic_filter.cpp): construct a `duckdb::JoinFilterPushdownInfo`
+(constructible in tests, test/cpp/transparent/test_preserve_dynamic_filter_metadata.cpp:53),
+`dynamic_filter_publish_plan` with hand-built `probe_target`s, invoke
+`dynamic_filter_publisher{…}.publish(...)`, assert per-channel contents via
+`filters_for_column`/`filtered_columns`/`empty` (src/include/op/sirius_dynamic_filter.hpp:440-463;
+`close_for_new_filters` :484, `accepting_filters` :487). Cases:
+
+- `"arity mismatch skips whole target in BOTH flag modes"` — the fail-closed invariant, asserted
+  for OFF and ON.
+- `"fanout on/off identical publications for well-formed targets"` — the core parity gate.
+- `"zone-map type mismatch suppresses zone-map only, membership still pushed"` — identical in both
+  modes (parity coverage of existing per-key behavior, not new behavior).
+- `"drained target skipped, sibling target still served"`.
+- Multi-producer channel case (`register_producer()` concurrency; see C1e risk 2).
+
+### Gate & rollback
+
+| Stage | Gate |
+|---|---|
+| Merge | OFF path bit-exact (code-shape preserved + parity tests); ON-mode unit coverage above |
+| Flag flip (compatibility gate — replaces the former TPC-H off↔on wall-time A/B, which would measure nothing since there is no behavior change) | **Identical publications under fixed config**: run TPC-H SF10 + nested/star shapes off then on (shared A/B protocol) and diff the `[dynf_summary]` aggregates (pushed counts, skipped_target_keys) and per-channel filter multisets — must be identical; any nonzero `skipped_target_keys` delta is a bug. Both passes at INFO. No wall-time claim is made. |
+
+**Rollback**: `SET enable_dynamic_filter_per_key_fanout=false` at the next query (primary).
+`git revert` after C1d/C1e is mechanical-but-not-clean (adjacent publisher lines and the shared
+`[dynf_summary]` fields); conflicts confined to the publisher loop and summary line.
+
+### Dependencies
+
+**Blocked on C1a** (strong target-key value types, plan-time `zone_map_admitted`). B1 vacuous
+(no filter-surface change). A1 soft. Lands after C1d (policy struct, accessor).
+
+### Size
+
+~140 prod LOC (config ~40, planner ~10, publisher loop restructure + telemetry ~90); ~250 test
+LOC. No split.
+
+### Risks
+
+1. **Legacy-parity drift** (the central risk): the OFF path must remain bit-exact through the loop
+   rewrite — enforce with the parity tests and by keeping the :310-317/:318-328 code shape under
+   the OFF branch rather than re-deriving it; the flag-flip compatibility gate catches residue.
+2. **Plan-time vs runtime build-type divergence (zone-map gate post-C1a)**: `get_cudf_type` of the
+   condition type may disagree with the runtime cudf column type on exotic mappings; keep the
+   runtime assert+suppress fallback (step 2).
+3. **Log-format drift**: `fanout=`/`skipped_target_keys=` must be mirrored in
+   `tools/log_analyzer/patterns.py` with a `SHAPE_VERSION` bump (R1 §5).
+
+---
+
+## PR C1e — remove blanket `build_side_has_filter` gate (`enable_dynamic_filter_unfiltered_build`, default false)
+
+### Goal
+
+Stop refusing to wire a dynamic-filter producer purely because DuckDB's
+`build_side_has_filter` bit is false (design :826-836). DuckDB creates
+`filter_pushdown`/`probe_info` regardless of build filtering and itself uses the bit only as a
+Bloom cost input (duckdb/src/optimizer/join_filter_pushdown_optimizer.cpp:250-311,
+duckdb/src/execution/operator/join/physical_hash_join.cpp:784) — it is a cost hint, not a
+correctness signal (design :292-294, :828-830). Behind a default-off flag because this genuinely
+expands applied-filter surface.
+
+### Deliverables
+
+- `enable_dynamic_filter_unfiltered_build` config field + SQL option/setter (shared plumbing).
+- Guard change + `dynamic_filter_publish_policy::duckdb_build_subtree_has_filter_hint` recorded.
+
+### Step-by-step changes
+
+1. *`src/planner/sirius_plan_comparison_join.cpp:426-431`* — the only Sirius decision site (grep:
+   other `build_side_has_filter` uses are the metadata copy
+   src/transparent/sirius_optimizer_extension.cpp:50 and its test
+   test/cpp/transparent/test_preserve_dynamic_filter_metadata.cpp:53,79 — untouched). Change the
+   guard to:
+   ```cpp
+   if (!op.filter_pushdown->build_side_has_filter &&
+       !op_params.enable_dynamic_filter_unfiltered_build) { /* existing :427-430 INFO log */ }
+   ```
+   and extend the INFO text with `(enable_dynamic_filter_unfiltered_build=false)`. In the wired
+   branch, set `policy.duckdb_build_subtree_has_filter_hint = op.filter_pushdown->build_side_has_filter`
+   — a cost hint / telemetry field, never a correctness gate. Extend the wired INFO at :488-492
+   and `[dynf_summary]` with `build_has_filter_hint={}`.
+2. No publisher code change: expanded candidates flow through the existing pipeline — channel
+   creation/`register_producer` (:444-446; the N-producer/1-consumer channel supports extra
+   producers, design :142-147, `push_filter` contract src/include/op/sirius_dynamic_filter.hpp:440),
+   replica-space wiring (:432-487), and all publish gates.
+3. **What expansion costs (must be measured, gate below)**: each newly wired producer pays per
+   admitted key — min/max reduce when zone-maps are on (src/op/dynamic_filter_publisher.cpp:198-209),
+   membership build (in-list vs Bloom by L2 fit, :244-261), replication bytes × devices (in-list
+   `capacity*sizeof(key)` src/cuda/sirius_dynamic_in_list_filter.cu:264, Bloom
+   src/cuda/sirius_dynamic_bloom_filter.cu:285-286 — Recon R2 §3d), a query-lived resident-replica
+   floor (design :861-870), plus consumer-side first-mask cost per scan split
+   (src/op/scan/dynamic_filter_merge.cpp:147-152,158) before the keep-rate gate can disable an
+   unselective filter (:216-219). Unfiltered FK-shaped builds are exactly the domain-covering case
+   — with C1d ENFORCE they are re-suppressed at publish (:176-190), leaving the profitable case:
+   builds reduced by upstream joins rather than table filters.
+
+### Tests
+
+- **Planner — new `test/cpp/planner/test_dynamic_filter_candidate_expansion.cpp`** (tag
+  `[dynamic_filter][expansion]`, same planner harness as C1d): unfiltered-build join
+  (`SELECT … FROM fact JOIN dim ON …` with no dim predicate) → `find_hash_join()` walk (pattern
+  test_distinct_hash_join_detection.cpp:97-108) asserting `dynamic_filter_plan().enabled()` false
+  with flag off / true with flag on (accessor landed by C1d), and
+  `policy().duckdb_build_subtree_has_filter_hint` recorded.
+- **Integration** (`[integration]`, flag SET on):
+  - Plain unfiltered-build join: `GpuExecutionFixture::compare_gpu_vs_cpu()`
+    (test/cpp/utils/gpu_execution_fixture.hpp:144-186) is a valid oracle here.
+  - **LIMIT-shaped probe query (the B1 regression shape, design :236-242): `compare_gpu_vs_cpu` is
+    FORBIDDEN as the oracle** — it compares against the same in-process DuckDB with
+    `SET gpu_execution=false`, and on the unpatched pin CPU and GPU consume the same buggy
+    `filter_pushdown` metadata and can be wrong identically (design :239-240: "An affected
+    unpatched DuckDB CPU run is not a correctness oracle"). Instead assert **explicit expected
+    rows** on a small hand-computed fixture, or diff against a same-process reference run with
+    `SET enable_dynamic_filter_pushdown=false`.
+- **Config**: YAML round-trip of the key in test/cpp/config/test_config.cpp.
+
+### Gate & rollback
+
+| Stage | Gate |
+|---|---|
+| Merge | off-mode is a no-op diff (guard short-circuit); tests above |
+| Enablement (flip in benchmarks/default) | **B1 merged** (design :966), then 2×2 A/B (`unfiltered_build` × `selectivity_gate ∈ {shadow, enforce}`) — the design's default-on gate: build cost (nvtx `dynfilter::build_*`, publisher :250-260), resident replica bytes, first-mask cost, keep-rate distribution, per-memory-space high-water (A1), **and** results/wall time (design :846-848). Log levels: timing passes at INFO ([dynf_summary] aggregates); keep-rate distributions from a separate non-timed DEBUG pass. |
+
+**Rollback**: `SET enable_dynamic_filter_unfiltered_build=false` at the next query (primary).
+`git revert` is nearly clean (C1e's diff is a guard + one policy field) with possible trivial
+conflicts on the shared `[dynf_summary]`/wired-INFO lines.
+
+### Dependencies
+
+None for merge. **B1 blocks enablement**. C1d ENFORCE is the publish-time backstop that makes
+enablement profitable (soft dependency, reflected in the 2×2 gate). Lands last.
+
+### Size
+
+~70 prod LOC (config ~50, guard + hint ~20); ~220 test LOC. No split.
+
+### Risks
+
+1. **Cost without benefit on FK-shaped unfiltered builds** if enabled without C1d ENFORCE: the
+   consumer keep-rate gate disables the filter only after paying first-mask cost per scan split
+   (step 3). Mitigation: the 2×2 enablement gate; keep default off.
+2. **Channel-lifecycle load**: extra producers call `register_producer()` (:446) and fan into
+   shared scan channels concurrently; the channel is documented thread-safe append-only
+   (sirius_dynamic_filter.hpp:389-417) — covered by the multi-producer case in the C1c fanout test
+   rather than assumed.
+3. **Log-format drift**: `build_has_filter_hint=` mirrored in `tools/log_analyzer/patterns.py`
+   with a `SHAPE_VERSION` bump.
+
+---
+
+## Review resolution
+
+How each finding of the adversarial review (C1cde-flags) was applied:
+
+1. **BLOCKER — min()-prefix push unsound**: applied. The `usable_keys = min(...)` branch is
+   deleted; the whole-target arity skip at publisher :310-317 is fail-closed in BOTH flag modes
+   (C1c §Goal, tests assert it in both modes). Rationale recorded: a runtime arity mismatch means
+   structural corruption, so the positional pairing is untrustworthy.
+2. **MAJOR — C1c mischaracterized as behavior-changing**: applied. C1c re-scoped as the
+   target-key entry/telemetry restructure on C1a's value types with NO runtime behavior change;
+   the flag is an explicit parity chicken-bit; the TPC-H off↔on wall-time A/B gate is replaced by
+   a compatibility gate (identical publications under fixed config); cluster overview no longer
+   calls C1c behavior-changing, and its B1 precondition is noted as vacuous.
+3. **MAJOR — forbidden CPU oracle in the C1e LIMIT-shape test**: applied. That case now uses
+   explicit expected rows or a same-process `SET enable_dynamic_filter_pushdown=false` reference
+   run; `compare_gpu_vs_cpu` is kept only for the plain unfiltered-build case, and the prohibition
+   is stated inline with design :239-240.
+4. **MAJOR — C1d duplicated C1b's snapshot/shadow work**: applied via the directive's option:
+   C1d is enforcement-only, blocked on C1b; the snapshot pass, optional domain type, and shadow
+   recording are restated as a consumed interface contract (C1d step 1, with the verified
+   diagnosis/entry-path/lifetime facts preserved as contract documentation), and the
+   "build it in C1d if C1b hasn't landed" branch is removed.
+5. **MINOR — no correlation key for the shadow audit**: applied. `(probe_col_idx, filter_kind)`
+   added to both the publisher `selectivity_shadow` line and the consumer per-filter line
+   (dynamic_filter_merge.cpp:147-152/:179-184), named as the correlation key in C1d's gate
+   protocol; A1 IDs supersede it when available.
+6. **MINOR — independent `git revert` overstated**: applied. Flag-level `SET` rollback is stated
+   as the primary story in all three PRs; git-revert claims softened to "conflict resolution
+   confined to the publish-plan ctor / publisher gates and shared summary lines".
+7. **MINOR — enum/ADL placement inconsistency in §2**: applied. The config deliverable now shows
+   two blocks: enum + ADL free functions at namespace scope above `operator_params` (:64), fields
+   inside the struct — consistent with the step-by-step text.
+8. **MINOR — new `[dynfilter_publish]` prefix**: applied. All per-event publisher lines keep
+   `[sirius_physical_hash_join]`; the ad-hoc prefix is gone. The one intentional new prefix is the
+   program-mandated `[dynf_summary]` machine-parsed per-query INFO summary line, registered in
+   patterns.py (deviation from a literal "one prefix per file" reading, required by the program's
+   logging conventions; the existing human INFO line at :330-337 is left untouched).
+9. **MINOR — missing test accessor until C1e**: applied. The const
+   `dynamic_filter_plan()` accessor (exposing plan + `policy()`) lands in C1d, the first PR of the
+   cluster; C1e's tests reuse it.
+10. **MINOR — line drift**: applied. Corrected to resolver :74-76 and `find_hash_join` :97-108 in
+    test_distinct_hash_join_detection.cpp; test_modified_pipeline.cpp resolver :392-394 /
+    create_plan :398; test/cpp/pipeline/test_plan_printer.cpp resolver :383 / create_plan :386;
+    test/cpp/integration/test_tpcds_plan_translation.cpp resolver :112 / create_plan :116 (paths
+    fixed too). Re-verified against 506a1d9f.

--- a/docs/super-sirius/issue-1010-plans/C2-probe-consumer.md
+++ b/docs/super-sirius/issue-1010-plans/C2-probe-consumer.md
@@ -1,0 +1,300 @@
+# PR C2 implementation plan — reusable mask op, `hash_join_probe_filter_consumer`, `probe_batch_handle` discipline, memory-estimate model
+
+Companion to [issue-1010-dynamic-filter-sip-design.md](../issue-1010-dynamic-filter-sip-design.md); baseline dev 506a1d9f.
+
+PRs covered: **C2** (recommended landing split, §7: **C2a** = Steps 1–5, behavior-identical consumer/handle cluster; **C2b** = Step 6, reservation-sizing change).
+
+## 1. GOAL + NON-GOALS
+
+Land the consumer half of the SIP design as a fully unit-tested component with **zero planned routes** (design `docs/super-sirius/issue-1010-dynamic-filter-sip-design.md:967` — "no planned routes yet"): (a) extract the scan's gated mask operation into `src/{include/,}op/` so scan and join consumers share one mask-application path over `sirius_mask_applicable` (design :933, :1120); (b) refactor `sirius_physical_hash_join::execute` so every probe-side access after the checkpoint goes through a `probe_batch_handle` (design :594-602 — the mandatory discipline; this is the riskiest refactor and is executed as compile-fenced mechanical steps); (c) compose a `hash_join_probe_filter_consumer` into the join with independent per-endpoint gates, stable STANDARD probe-batch IDs, repeated-application recording, and zero-copy fast paths (design :580-627); (d) the memory model: optional row counts in `input_stats`, a shared saturating simultaneous-new-allocations estimator, a new mode-aware `no_history_peak_memory_estimate` override on the join (none exists today — verified: `src/include/op/sirius_physical_hash_join.hpp` declares no override; design :901-903), and removal of the scan op's optimistic `stats.bytes` override (`src/include/op/scan/sirius_physical_dynamic_filter.hpp:57-62`; design :879). **Non-goals:** no planner/lineage/topology work, no route installation, no channels created (all C3); no telemetry events (A1); no new config flags (`enable_dynamic_filter_sip` is C3, design :968); no producer changes (C1a-e); no Track D. C2 does not violate Phase 0 because it enables no route (design :947-949).
+
+**Honest behavior-change statement:** Steps 1–5 are result-identical. Step 6 (C2b) is a deliberate reservation-sizing change: first-split (no-history) reservations grow for dynamic-filtered scan pipelines by roughly **3×** and for join pipelines by the new mode-aware model (see §8 risks 5–6 for magnitudes and containment). It is not "no behavior change".
+
+## 2. DELIVERABLES — public types and APIs
+
+### 2a. Moved/shared mask operation (namespace `sirius::op`, new files `src/include/op/dynamic_filter_mask.hpp`, `src/op/dynamic_filter_mask.cpp`, `src/include/op/dynamic_filter_gate.hpp`)
+
+Moved verbatim from `sirius::op::scan` (currently `src/include/op/scan/dynamic_filter_merge.hpp:37-98`, impls `src/op/scan/dynamic_filter_merge.cpp:64-243`, gate `src/include/op/scan/dynamic_filter_gate.hpp:46-121`):
+
+```cpp
+namespace sirius::op {
+enum class dynamic_filter_apply_mode { membership_masks_only, include_ast_row_masks };
+
+class dynamic_filter_gate { /* unchanged body, moved from op/scan */ };
+
+[[nodiscard]] std::unique_ptr<cudf::table> apply_dynamic_filters_to_view(
+  cudf::table_view const& input, sirius_dynamic_filter_set const& filters,
+  rmm::cuda_stream_view stream,
+  dynamic_filter_apply_mode mode = dynamic_filter_apply_mode::include_ast_row_masks,
+  dynamic_filter_gate* gate = nullptr, int device_id = -1);
+
+[[nodiscard]] std::unique_ptr<cudf::table> apply_dynamic_filters_gated_view(
+  cudf::table_view const& input, sirius_dynamic_filter_set const& filters,
+  dynamic_filter_gate& gate, rmm::cuda_stream_view stream,
+  dynamic_filter_apply_mode mode, int device_id = -1);
+}
+```
+
+**Stays in `sirius::op::scan`** (`op/scan/dynamic_filter_merge.{hpp,cpp}` shrink): `merge_dynamic_filters_into_ast` (`dynamic_filter_merge.hpp:54-59`, `.cpp:35-62`) — it depends on `scan_plan` (parquet column names, hive skipping) and zone-map/AST lowering remains a scan-reader capability (design :626-627). The scan operator (`sirius_physical_dynamic_filter`) keeps working, calling the moved functions.
+
+### 2b. `probe_batch_handle` (new `src/include/op/probe_batch_handle.hpp`, header-only)
+
+```cpp
+namespace sirius::op {
+/// Result of the SIP probe checkpoint. All probe-side access inside one
+/// sirius_physical_hash_join::execute call after the checkpoint goes through this handle
+/// (design :594-602). Scope-bound: must not outlive the execute-local read-only batch vector.
+class probe_batch_handle {
+ public:
+  static probe_batch_handle passthrough(::cucascade::read_only_data_batch const& original);
+  static probe_batch_handle filtered(::cucascade::read_only_data_batch const& original,
+                                     std::unique_ptr<cudf::table> owned);
+
+  probe_batch_handle(probe_batch_handle&&) = default;            // move-only,
+  probe_batch_handle(probe_batch_handle const&) = delete;        // scope discipline
+
+  [[nodiscard]] cudf::table_view view() const noexcept;          // filtered or original view
+  [[nodiscard]] ::cucascade::memory::memory_space& memory_space() const noexcept;
+  [[nodiscard]] uint64_t probe_batch_id() const noexcept;        // read_only_data_batch::get_batch_id()
+  [[nodiscard]] bool is_filtered() const noexcept;
+  [[nodiscard]] cudf::size_type num_rows() const noexcept;
+ private:
+  ::cucascade::read_only_data_batch const* _original;            // non-owning, execute-scoped
+  std::unique_ptr<cudf::table> _owned;                           // set iff filtered
+  cudf::table_view _view;                                        // cached at construction
+};
+}
+```
+
+Identity source verified: `read_only_data_batch::get_batch_id()` exists (`cucascade/include/cucascade/data/data_batch.hpp:282`; the class begins at `:277` — the similar accessor at `:389` belongs to `mutable_data_batch`); batch IDs are process-unique (`data_repository_manager` atomic counter, `data_repository_manager.hpp:171,:245`). Memory space via `get_memory_space()` (`data_batch.hpp:291`). Stability across STANDARD re-pairings: the same left batch object is re-delivered per pairing (`src/op/sirius_physical_hash_join.cpp:626-637`, `get_data_batch_by_id` until the last pairing pops), so its batch ID is the stable probe-batch ID.
+
+### 2c. `hash_join_probe_filter_consumer` (new `src/include/op/hash_join_probe_filter_consumer.hpp`, `src/op/hash_join_probe_filter_consumer.cpp`)
+
+```cpp
+namespace sirius::op {
+/// Immutable endpoint description. C3's topology freeze populates these; C2 only unit tests do.
+struct sip_endpoint_desc {
+  std::size_t target_id = 0;   // query-relative monotonic (design "Publication, target, channel,
+                               // and filter identity"); becomes the A1 strong
+                               // dynamic_filter_target_id when A1 lands
+  std::shared_ptr<sirius_dynamic_filter_set> channel;  // dedicated 1-producer/1-consumer (design :566-573)
+  double gate_keep_threshold = dynamic_filter_gate::k_default_keep_threshold;  // C3 may set per-endpoint (design open q.2)
+};
+
+/// Composed, thread-safe (concurrent BUILD_PROBE probe tasks share it: READY hints per queued
+/// probe batch, sirius_physical_hash_join.cpp:504-512). Owns all mutable gate state (design :584-586).
+class hash_join_probe_filter_consumer {
+ public:
+  hash_join_probe_filter_consumer() = default;
+  void install_endpoints(std::vector<sip_endpoint_desc> endpoints);   // once, before first execute
+  [[nodiscard]] bool has_endpoints() const noexcept;
+
+  /// The SIP probe checkpoint (design :385-392): snapshot each endpoint, apply visible
+  /// membership filters via apply_dynamic_filters_gated_view (membership_masks_only,
+  /// device from probe batch's memory space), cascading across endpoints. Zero-copy passthrough
+  /// when nothing applies. Never mutates the input batch. Records repeated applications per
+  /// (endpoint, probe_batch_id).
+  [[nodiscard]] probe_batch_handle checkpoint(::cucascade::read_only_data_batch const& probe,
+                                              rmm::cuda_stream_view stream);
+
+  // test/telemetry accessors (A1/C3 consume later)
+  [[nodiscard]] std::size_t repeated_application_count(std::size_t endpoint_idx) const;
+  [[nodiscard]] std::size_t applications_for_probe_batch(std::size_t endpoint_idx, uint64_t batch_id) const;
+ private:
+  struct endpoint_state {
+    sip_endpoint_desc desc;
+    dynamic_filter_gate gate;                                   // independent per endpoint (design :623)
+    mutable std::mutex mu;
+    std::unordered_map<uint64_t, std::size_t> applications_by_probe_batch_id;
+    std::size_t repeated_applications = 0;
+  };
+  std::vector<std::unique_ptr<endpoint_state>> _endpoints;      // immutable after install
+};
+}
+```
+
+The consumer is join-mode-agnostic; MIXED-mode rejection is enforced at the join's installation point (`install_sip_endpoints`, Step 5) **and** at the execute dispatch — install-time fail-closed per design risk 7 (:1104-1106).
+
+Fast paths (design :617-624): empty `_endpoints` → passthrough with no atomic work; per-endpoint `channel->has_filters()` lock-free skip (`src/include/op/sirius_dynamic_filter.hpp:498-501`); `gate.applicable()` skip (`src/op/scan/dynamic_filter_merge.cpp:187-195`); a null apply result (no device-local replica) passes through **without training the gate** — already the helper's contract (`dynamic_filter_merge.cpp:237-239`). Zero-row filtered output stays a valid schema-correct handle (design :619-620). Device identity from `probe.get_memory_space()->get_device_id()`, matching the scan op (`src/op/scan/sirius_physical_dynamic_filter.cpp:78`).
+
+### 2d. Memory model
+
+```cpp
+// src/include/op/sirius_physical_operator.hpp — extend input_stats (currently :295-303)
+struct batch_input_stats {
+  std::size_t bytes = 0;                 // uncompressed logical footprint of one input batch
+                                         // (get_uncompressed_data_size_in_bytes)
+  std::optional<std::size_t> rows;       // exact rows when cheaply known (GPU-resident), else nullopt
+};
+struct input_stats {
+  std::size_t num_batches = 0;
+  std::size_t bytes       = 0;           // aggregate CONSUMPTION BASIS (unchanged semantics)
+  operator_data_type type = operator_data_type::BASE;
+  bool resident = false;
+  std::optional<std::size_t> rows;              // NEW: total, set iff every batch's rows known
+  std::vector<batch_input_stats> batches;       // NEW: per-batch; [0]=probe for join tasks; empty if not built
+};
+```
+
+**`batches[]` vs aggregate semantics (documented invariant):** `batches[i].bytes` is the **uncompressed logical footprint** of batch *i* (`get_uncompressed_data_size_in_bytes()`, `cucascade/include/cucascade/data/common.hpp:102`), while the aggregate `stats.bytes` remains the task **consumption basis** (`get_task_consumption_basis()`, `gpu_pipeline_task.cpp:511`) and `get_input_size` uses yet another basis (`get_size_in_bytes()`, `:502`). `Σ batches[i].bytes` need not equal `stats.bytes`; overrides model allocation demand from `batches[]` and the **floor intentionally uses the aggregate** (`stats.bytes * 2`), matching the generic fallback's basis. This is stated in the header doc comment so no future override "reconciles" the two.
+
+```cpp
+// src/include/op/dynamic_filter_mask.hpp — shared saturating estimator (design :886-899)
+struct mask_apply_estimate_input {
+  std::size_t table_bytes = 0;                  // footprint of the table being filtered
+  std::optional<std::size_t> table_rows;
+  std::size_t min_row_bytes = 1;                // schema-derived bound when rows unknown
+  bool charge_input = false;                    // true when the filtered table is itself a new allocation of this task
+};
+[[nodiscard]] std::size_t mask_apply_peak_new_allocation_estimate(
+  mask_apply_estimate_input const& in) noexcept;
+// = sat_add( charge_input? bytes : 0,          // input retained by caller, when task-new
+//            bytes,                            // previous cascade result retained…
+//            bytes,                            // …while next gathered output is built
+//            rows * 1,                         // BOOL8 mask
+//            rows * sizeof(cudf::size_type),   // gather map (cudf apply_boolean_mask path)
+//            k_mask_backend_scratch(rows) )    // measured backend allowance (named constant)
+// rows = table_rows.value_or(table_bytes / max(1, min_row_bytes)). Saturating arithmetic
+// throughout; extra filters do NOT grow the estimate — the cascade frees each prior step
+// (dynamic_filter_merge.cpp:81-89), so simultaneous new allocations are bounded regardless of count.
+// NOTE: both full-size copy terms are kept even when only one filter is visible at estimate time,
+// because the channel can grow between estimate and execute (a 2-filter cascade at execute time
+// would then under-reserve). Considered and rejected: a max_simultaneous_filters hint (see §8.6).
+
+// src/include/op/sirius_physical_hash_join.hpp — NEW mode-aware override (design :901-914)
+[[nodiscard]] std::size_t no_history_peak_memory_estimate(const input_stats& stats) const override;
+```
+
+**Join override semantics** (implements design :903-914; floor per :901): read `_join_mode`/`_hash_table_build_state` (made `std::atomic<>`, see §3.7) with lone relaxed loads, never taking `op_state_mutex`.
+
+*Build-stat sourcing (probe-only tasks carry only one batch):* BUILD_PROBE probe-only tasks contain exactly the popped probe batch (`sirius_physical_hash_join.cpp:564-577`), so `stats.batches` has size 1 for them, and they arise **before** memory history exists: they are created the moment `_hash_table_build_state == BUILT` (`:504-512`), which is set inside the first task's execute (`:969`) — before that task completes and records history (`gpu_pipeline_task.cpp:455-473`). `stats.batches[1]` therefore must never be read unconditionally. Instead, when the SCHEDULED block finishes the build (under `op_state_mutex`, `:944-970`, just before `_hash_table_build_state = BUILT` at `:969`), the join snapshots the build side into two new members `std::atomic<std::size_t> _build_snapshot_bytes{0}, _build_snapshot_rows{0}` (bytes from `build_batch_ro.get_data()->get_uncompressed_data_size_in_bytes()`, rows from the `gpu_table_representation` view). The estimator's rule: build stats come from `stats.batches[1]` when `stats.batches.size() >= 2`, else from the snapshot; **if neither is available (snapshot bytes == 0), all build-derived terms are dropped** (hash-table term, build row term in the index vectors, `build.bytes` gather bound) and the floor still applies.
+
+*Per mode* (probe stats from `stats.batches[0]`, falling back to aggregates when `batches` is empty; never aggregate probe+build for mask sizing — design :898-899):
+- `BUILD_PROBE` state ≤ `SCHEDULED`: `sat(build_keys(≤build.bytes) + k_hash_table_bytes_per_row × rows_bound(build) + probe_terms)`.
+- `BUILD_PROBE` state `BUILT`: `sat(probe_terms)` — the resident hash table/pinned build (`sirius_physical_hash_join.cpp:946,:952-965`, held until finalize `:1420-1426`) is not **new** reservation demand; `probe_terms`' build-derived inputs come from the snapshot per the rule above.
+- `STANDARD`: `sat(build.bytes + hash_table_term + probe_terms)` (per-task transient build; two batches present, so `batches[1]` is available).
+- `MIXED`: `return stats.bytes * 2;` — **not 0**. The pipeline-wide fallback applies only when *every* operator returns 0 (`gpu_pipeline_task.cpp:538-539`); the join pipeline also contains the sink pushed by `finalize_pipeline_structure` (`sirius_pipeline_converter.cpp:1149-1162`) and operators with sub-2× overrides (e.g. partition returning 0 for one partition, `test_no_history_peak_memory_estimate.cpp:152-161`), so a literal 0 here could leave the pipeline max below the design floor (:901).
+
+`probe_terms = filter_term + probe.bytes /*key-cast bound*/ + 2 × (rows_bound(probe)+rows_bound(build)) × 4 /*index vectors*/ + probe.bytes + build.bytes /*gather output bound*/` (build terms dropped when build stats unavailable), `filter_term = _sip_consumer.has_endpoints() ? mask_apply_peak_new_allocation_estimate({probe.bytes, probe.rows, min_row_bytes(children types), false}) : 0`. Final `return std::max(model, stats.bytes * 2);` in **every** mode — never below the generic fallback (`sirius_physical_operator.hpp:380-383`).
+
+Scan op replacement (removes `sirius_physical_dynamic_filter.hpp:57-62`):
+```cpp
+std::size_t sirius_physical_dynamic_filter::no_history_peak_memory_estimate(const input_stats& s) const override {
+  const std::size_t decoded = s.resident ? s.bytes : s.bytes * scan::k_scan_decode_expansion; // =8, extracted from sirius_gpu_scan_operator.cpp:125-135
+  return std::max(mask_apply_peak_new_allocation_estimate({decoded, s.rows, min_row_bytes(types), /*charge_input=*/true}),
+                  s.bytes * 2);
+}
+```
+`charge_input=true` because the decoded table the cascade retains is itself a new allocation of the scan task; the join checkpoint's input is materialized input (charged in `bytes_to_materialize_input`, `gpu_pipeline_task.cpp:512,:517,:542`), hence `false` — exactly the design's resident/materialize split (:895-898). Pipeline aggregation stays the `max()` at `gpu_pipeline_task.cpp:532-539`; the join override performs the intra-task overlap sum itself (design :912-913). **Magnitude:** the new scan-filter model (≈ `3×decoded + row terms`, `decoded = 8×bytes` on fresh reads ⇒ ~24×+ compressed bytes) strictly dominates the scan's own 8× in the pipeline `max()` — first-split reservations for dynamic-filtered scan pipelines roughly **triple** until history corrects them (§8.6).
+
+## 3. STEP-BY-STEP CHANGES (each step compiles + tests green)
+
+### Step 1 — mask-operation move (mechanical, behavior-neutral)
+- **New** `src/include/op/dynamic_filter_gate.hpp`: move class from `src/include/op/scan/dynamic_filter_gate.hpp` (whole file, :46-121), namespace `sirius::op`. Delete old file.
+- **New** `src/include/op/dynamic_filter_mask.hpp` / `src/op/dynamic_filter_mask.cpp`: move `dynamic_filter_apply_mode` (`op/scan/dynamic_filter_merge.hpp:37`), `apply_dynamic_filters_to_view` (decl :78-84, impl `.cpp:64-164`), `apply_dynamic_filters_gated_view` (decl :92-98, impl `.cpp:222-243`), and the gate member impls (`.cpp:166-220`). Also add `mask_apply_peak_new_allocation_estimate` + `min_row_bytes(duckdb::vector<sirius::logical_type> const&)` here (Step 6).
+- **Shrink** `src/include/op/scan/dynamic_filter_merge.hpp` / `.cpp` to `merge_dynamic_filters_into_ast` only; it includes the new op/ headers.
+- **Update every referencing file** (grep-verified complete list): `src/op/scan/sirius_physical_dynamic_filter.cpp:19,:73` (include + call, now `sirius::op::apply_dynamic_filters_gated_view` and `op::dynamic_filter_apply_mode`); `src/include/op/scan/sirius_physical_dynamic_filter.hpp:19,:50,:68` (include, default-arg constant, `_gate` member type → `sirius::op::dynamic_filter_gate`); `src/op/scan/parquet_gpu_ingestible.cpp:27,:730,:737` (AST merge stays in scan — include path only); `test/cpp/scan/test_dynamic_filter_merge.cpp` (using-decls :54-56 area); `src/include/op/sirius_dynamic_filter.hpp:504` — doc-comment `@ref dynamic_filter_gate` updated for the moved namespace (comment-only, no compile impact). `src/pipeline/sirius_pipeline_converter.cpp:294-299` (scan-op construction) needs no change. CMake: add `src/op/dynamic_filter_mask.cpp` to the extension source list.
+
+### Step 2 — helper signature prep (`resolve_mark_join_result`)
+Change its 4th param from `::cucascade::read_only_data_batch const& left_batch` (`src/op/sirius_physical_hash_join.cpp:863-868`; only use is `*left_batch.get_memory_space()` at `:907`) to `::cucascade::memory::memory_space& memory_space` (same shape as `gather_join_output` `:755`). Update all 4 call sites: `:989-990`, `:1093-1094`, `:1288-1289`, `:1293-1294` (pass `*input_batches[0].get_memory_space()` for now). Add a `cudf::table_view` overload of `prepare_join_keys` (current batch version `:682-739`; its first act is `get_cudf_table_view(input_batch)` at `:692` — the batch overload delegates to the view overload).
+
+### Step 3 — `probe_batch_handle` (new header, §2b) + unit tests. No join changes yet.
+
+### Step 4 — execute() extraction with compile fence (the riskiest step, mechanical)
+**Complete grep-verified enumeration of probe-side `input_batches[0]` reads after the checkpoint locations** (all uses of `input_batches` in the file confirmed; build-side `[1]` reads at `:935,:1058,:1067,:1204,:1211` are unaffected). Note a correction to the task brief: `:1057`/`:1094`/`:1061` are in the **MIXED_JOIN** branch (branch opens `:1052`), not STANDARD; STANDARD additionally reads at `:1203`/`:1205`, which the brief omitted:
+
+| Mode | Line | Read |
+|---|---|---|
+| BUILD_PROBE (BUILT block `:972`) | `:975` | `prepare_join_keys(input_batches[0], left_key_col_indices, …)` |
+| BUILD_PROBE | `:983` | `left_full = get_cudf_table_view(input_batches[0])` |
+| BUILD_PROBE MARK | `:990` | `resolve_mark_join_result(…, input_batches[0], stream)` |
+| BUILD_PROBE distinct LEFT | `:1021` | `*input_batches[0].get_memory_space()` (gather output space) |
+| MIXED | `:1057` | `left_full = get_cudf_table_view(input_batches[0])` |
+| MIXED | `:1061` | `prepare_join_keys(input_batches[0], …)` |
+| MIXED MARK | `:1094` | `resolve_mark_join_result(…, input_batches[0], stream)` |
+| STANDARD | `:1203` | `left_full = get_cudf_table_view(input_batches[0])` |
+| STANDARD | `:1205` | `prepare_join_keys(input_batches[0], …)` |
+| STANDARD distinct LEFT | `:1238` | `*input_batches[0].get_memory_space()` |
+| STANDARD MARK (adaptive `mark_join`) | `:1289` | `resolve_mark_join_result(…, input_batches[0], …)` |
+| STANDARD MARK (filtered_join) | `:1294` | `resolve_mark_join_result(…, input_batches[0], …)` |
+| shared tail (all index-producing paths) | `:1312` | `*input_batches[0].get_memory_space()` in `gather_join_output` |
+
+**MIXED separability — confirmed:** the MIXED branch `:1052-1197` is a self-contained `else if`; its only coupling to other modes is the four shared locals (`left_full/right_full/left_indices/right_indices`, `:923-924`) and the shared gather tail `:1305-1313`. It can be extracted independently; per design `:604-605` MIXED consumers are rejected in v1, so its handle is always a passthrough and `checkpoint()` is never invoked for it.
+
+**Refactor mechanics (compile fence = scope removal, stronger than rename):** extract three private member functions declared in `sirius_physical_hash_join.hpp`, each taking the handle and **not** `input_batches`, so any missed direct read is a compile error:
+
+```cpp
+std::unique_ptr<operator_data> execute_build_probe_probe(probe_batch_handle const& probe,
+                                                         rmm::cuda_stream_view stream);   // old :972-1043
+std::unique_ptr<operator_data> execute_mixed_join(probe_batch_handle const& probe,
+    ::cucascade::read_only_data_batch const& build_batch, rmm::cuda_stream_view stream);  // old :1052-1197
+std::unique_ptr<operator_data> execute_standard_join(probe_batch_handle const& probe,
+    ::cucascade::read_only_data_batch const& build_batch, rmm::cuda_stream_view stream);  // old :1198-1303
+```
+
+The shared tail `:1305-1313` moves into a private `finish_gather(join_type, probe, right_full, left_indices, right_indices, stream)` calling `gather_join_output(…, probe.memory_space(), stream)`. Inside the extracted bodies, substitutions are exactly: `prepare_join_keys(input_batches[0],…)` → `prepare_join_keys(probe.view(),…)`; `get_cudf_table_view(input_batches[0])` → `probe.view()`; `*input_batches[0].get_memory_space()` → `probe.memory_space()`; `resolve_mark_join_result(…, input_batches[0]|memory-space, …)` → `…, probe.memory_space(), …`. `execute()` (`:910`) retains: the dynamic_cast/`get_read_only_batches` (`:914-915`), the inequality guard (`:917-921`), the SCHEDULED build block (`:927-971`, all `[1]`/build reads unchanged), batch-count checks, and mode dispatch. Extract order: STANDARD → BUILD_PROBE → MIXED, one commit each, with a passthrough handle constructed at each dispatch site (behavior-identical).
+
+### Step 5 — compose the consumer
+- `sirius_physical_hash_join.hpp`: add `hash_join_probe_filter_consumer _sip_consumer;` and `void install_sip_endpoints(std::vector<sip_endpoint_desc>);` (asserts before first execute; **called by unit tests only in C2** — the converter/planner never calls it, so no route exists).
+- **Install-time fail-closed for MIXED (design risk 7, :1104-1106):** `install_sip_endpoints` **rejects installation** when `_join_mode == MIXED_JOIN` — debug builds throw `std::logic_error`; release builds log `SIRIUS_LOG_WARN("[sirius_physical_hash_join] ...")` and drop the endpoints (fail-closed: `has_endpoints()` stays false, passthrough guaranteed). The consumer itself stays mode-agnostic; the check lives at the join's single installation point.
+- `execute()` dispatch sites: BUILD_PROBE after the build completes (`:971`) and STANDARD after the 2-batch check → `auto probe = _sip_consumer.checkpoint(input_batches[0], stream);` — i.e., after the branch-specific probe batch is obtained and before any probe key cast/hash/output allocation (normative point, design :376-401, :1002-1003). MIXED → `probe_batch_handle::passthrough(input_batches[0])` plus a second, execute-time fail-closed guard: warn (`[sirius_physical_hash_join]` prefix) if endpoints are somehow present (design :604, :1105). No `[dynf_summary]` lines are emitted by C2 — those arrive with routes (C3) per the program logging conventions.
+
+### Step 6 — memory model
+- `src/include/op/sirius_physical_operator.hpp:295-303`: extend `input_stats` per §2d (trailing defaulted members keep the only prod aggregate-init site and all test literals valid — grep-verified sole construction: `gpu_pipeline_task.cpp:530`). Document the `batches[]`-vs-aggregate byte-basis invariant (§2d) in the header comment.
+- `src/pipeline/gpu_pipeline_task.cpp:523-530`: in the no-history branch, walk `pd->get_read_only_batches(false)` (precedent: `get_input_size` `:501-503`); per batch, **guard `ro.get_data()` for null** (existing precedent: `sirius_physical_operator.hpp:245-249`, `sirius_physical_hash_join.cpp:1377`) — a null-data batch contributes `bytes = 0, rows = nullopt`; otherwise `bytes = get_data()->get_uncompressed_data_size_in_bytes()` (`cucascade/include/cucascade/data/common.hpp:102`), `rows =` `dynamic_cast<cucascade::gpu_table_representation const*>(get_data())` ? `->get_table_view().num_rows()` (`cucascade/include/cucascade/cudf/gpu_data_representation.hpp:136`) : `nullopt` (no row API exists on `idata_representation` — verified). Fill `stats.batches`/`stats.rows`.
+- `src/include/op/sirius_physical_hash_join.hpp:195-196`: change `_join_mode` and `_hash_table_build_state` to `std::atomic<HASH_JOIN_MODE>` / `std::atomic<BUILD_HASH_TABLE_STATE>`. **Corrected audit: 26 referencing lines** (24 in `sirius_physical_hash_join.cpp`, 2 in the header). Not all reads are mutex-guarded today: `execute()` already reads both members lock-free at `:926-927`, `:972`, and `:1044-1052` (`_join_mode` at `:926,:1052`; `_hash_table_build_state` at `:927,:972,:1044-1048`) — the atomic conversion **legalizes these pre-existing unlocked reads** in addition to the new estimator reads. All RMW transitions stay under `op_state_mutex` exactly as today; the const estimator does lone relaxed loads and must **not** take `op_state_mutex`, which is held across a `stream.synchronize()` during build `:944-970`.
+- Same file/block: add `std::atomic<std::size_t> _build_snapshot_bytes{0}, _build_snapshot_rows{0}`; write them inside the SCHEDULED block (under the existing `op_state_mutex` lock, `:944-970`, before the `BUILT` transition at `:969`) from `build_batch_ro` (`:935`). The estimator's build-stat sourcing rule is §2d.
+- Add the join override (§2d, including the MIXED `stats.bytes * 2` return and the build-stat fallback chain).
+- `sirius_physical_dynamic_filter.{hpp,cpp}`: delete the inline override `hpp:57-62`; add the declaration + `.cpp` impl (§2d). Extract `k_scan_decode_expansion = 8` shared with `sirius_gpu_scan_operator.cpp:125-135`.
+- CMake `CMakeLists.txt:562` `TEST_SOURCES`: add the new test files (operator section near `:634-638`); enforced by the `check-orphan-tests` pre-commit hook.
+
+## 4. TESTS (Catch2, single `sirius_unittest` binary; add each file to `TEST_SOURCES`)
+
+Existing mask/gate tests move with the code: `test/cpp/scan/test_dynamic_filter_merge.cpp` keeps its 30+ cases (apply/cascade/gate `:319-905`), namespace updates only.
+
+1. **`test/cpp/operator/test_probe_batch_handle.cpp`** `[dynamic_filter][probe_handle]` (GPU — cudf tables via `operator_test_utils` `initialize_memory_manager`/`make_numeric_batch`, pattern `test_physical_mark_join.cpp:105-120`): "passthrough aliases original view (pointer-equal column data)", "filtered handle owns table and reports memory space of original", "probe_batch_id equals read_only_data_batch::get_batch_id", "zero-row filtered handle is schema-correct".
+2. **`test/cpp/operator/test_hash_join_probe_filter_consumer.cpp`** `[dynamic_filter][sip_consumer]` (GPU; filters built as in `test_dynamic_filter_merge.cpp:60-85` and in-list filters as `test_sirius_dynamic_filter.cpp`): "no endpoints returns zero-copy passthrough", "empty channel passthrough", "one-column INT32 in-list filter drops non-prefix rows", "nullable key column", "wide-row payload survives mask (many columns)", "multiple filters across two endpoints cascade", "keep≈0 stays active / keep≈0.5 vs threshold / keep≈1.0 disables gate (per-endpoint independence)", "replica-unavailable passthrough does not train gate" (single-GPU device-mismatch trick as `test_dynamic_filter_merge.cpp:748`), "repeated STANDARD probe-batch ID records repeated application and still applies", "zero-row input passthrough", "gate re-arms when channel grows after disable", "two-thread concurrent checkpoint is serialized correctly" (mirrors `test_dynamic_filter_merge.cpp:830`).
+3. **`test/cpp/operator/test_hash_join_probe_consumer_join.cpp`** `[dynamic_filter][sip_consumer][physical_hash_join]` (GPU; direct-execute pattern of `test_physical_mark_join.cpp:65-174`; a file-local `struct test_hash_join : sirius_physical_hash_join` uses protected access to force `_join_mode=BUILD_PROBE`, `_hash_table_build_state=SCHEDULED` for BUILD_PROBE paths): "STANDARD INNER with filtered non-prefix probe rows and non-prefix payload projection (`lhs_output_columns.col_idxs` selecting a non-zero column) produces exact expected rows" (the design's misalignment-cannot-hide test :601-602, :1028), "STANDARD MARK: mark column length equals filtered row count", "BUILD_PROBE INNER first task (2 batches) filters probe after build", "BUILD_PROBE probe-only task (1 batch) filters", "BUILD_PROBE distinct LEFT output lands in probe memory space", "probe filtered to zero rows completes with schema-correct empty output", "multi-batch: same probe batch across repeated STANDARD pairings applies via stable ID and is recorded", "MIXED join executes unchanged with passthrough handle", "install_sip_endpoints on MIXED_JOIN is rejected fail-closed (throws in debug; has_endpoints() stays false)".
+4. **Extend `test/cpp/operator/test_no_history_peak_memory_estimate.cpp`** `[no_history_peak_memory_estimate]` (CPU-only construction, pattern `:40-80`): estimator free-function cases "known rows INT32 one column", "unknown rows uses byte-derived bound", "wide rows shrink row term", "saturates at SIZE_MAX", "filter count does not grow estimate"; join override "STANDARD ≥ 2× floor", "BUILD_PROBE NOT_BUILT includes hash-table term", "BUILD_PROBE BUILT excludes it (strictly smaller, still ≥ floor)" (state forced via test subclass — models OOM re-entry: a rescheduled task re-estimates after `BUILT`), "BUILT probe-only single-batch task uses build snapshot for build-derived terms (never reads batches[1])", "BUILT with zero build snapshot drops build-derived terms and still returns ≥ floor", "uses batches[0] probe stats not aggregate", "MIXED returns exactly stats.bytes × 2 (never 0)"; scan filter op "override ≥ 2× bytes (old 1× override removed)", "resident vs non-resident decode expansion".
+5. **CI**: all run on the `gpu-2xl4` runner via `test.yml:133-136`; no `[mgpu]`/env tags needed (direct construction, no Sirius context); estimator cases are device-free like the existing file.
+
+## 5. GATE & ROLLBACK
+
+- **Gate (per design row C2 :967 "no planned routes yet"):** grep-provable no-route invariant — `install_sip_endpoints` has zero callers outside `test/`; full `sirius_unittest --abort` green; TPC-H SF1 performance+validation snapshot (`test.yml:141-176`) shows no validation failure and wall time within run variance (the join execute refactor must be result-identical; existing join coverage: `test_physical_mark_join.cpp`, `test_physical_hash_join_mgpu.cpp`, `test_gpu_execution_tpch.cpp` BUILD_PROBE suites at `:1643-1891`); estimator floor property (`≥ 2× bytes`) proven by unit test; no new OOM/downgrade churn in the snapshot logs (log-analyzer `memory_reservation` metrics, `tools/log_analyzer/metrics/memory_reservation.py`).
+- **Log levels for the snapshot runs (per program logging conventions):** both the baseline and post-change TPC-H timing passes run at **INFO**; C2 adds no `[dynf_summary]` lines (no route exists) and no per-batch DEBUG/TRACE coverage lines, so nothing new is excluded from — or perturbs — the timed passes. Downgrade/OOM comparison is derived from INFO-level `memory_reservation` aggregates.
+- **Flags:** none added or changed. `enable_dynamic_filter_sip=false` arrives in C3; C2 has nothing to flag because no route exists.
+- **Rollback:** plain `git revert` — no config, schema, or persisted state. Keep the estimator/input_stats work in its own commit (or own PR, §7) so a reservation-sizing regression can be reverted without losing the consumer/handle refactor.
+
+## 6. DEPENDENCIES & ORDERING
+
+- **Internal order:** Step 1 (mask move) → Steps 2-3 (helper prep + handle) → Step 4 (extraction, one mode per commit) → Step 5 (consumer) → Step 6 (memory model). Steps 1 and 6a (input_stats) are independently landable.
+- **On other tracks:** C2 is a prerequisite of C3 (complete consumer contract, design :951-953) and requires neither B1 nor A1-A4 (it enables no route; Phase 0 gate binds C1c/C1e/C3 only, :961-968). Soft dependency on A1: `sip_endpoint_desc.target_id` uses `std::size_t` until A1's strong ID types land, then a one-line type swap (the value stays query-relative monotonic per the design's identity section). **Merge-conflict coordination with C1a/C1b:** they refactor the publication region of the same file (`sirius_physical_hash_join.cpp:1319-1428` + header dynamic-filter block `hpp:227-257`); C2 touches `:910-1315` + different header regions — disjoint but same files, so rebase-order these PRs explicitly.
+- The scan operator keeps working throughout (converter construction site `sirius_pipeline_converter.cpp:294-303` untouched except the estimator override's behavior).
+
+## 7. SIZE ESTIMATE
+
+Prod: mask move ~300 (mostly relocation) + handle ~130 + join refactor ~250 diff + consumer ~250 + memory model ~230 ≈ **1,100-1,200 diff lines prod**. Tests ≈ **1,100-1,400** new lines plus relocated merge tests. **Recommend splitting into two PRs:** C2a = Steps 1-5 (behavior-identical consumer cluster; gate = identical results), C2b = Step 6 (reservation-sizing change; gate = no OOM/downgrade regression). If one PR, keep the 6 steps as separate reviewable commits — Step 4 must remain 3 mode-scoped commits.
+
+## 8. RISKS (implementation-level) & MITIGATIONS
+
+1. **Handle dangling past `input_batches`** (`get_read_only_batches()` returns by value; execute binds a lifetime-extended const ref `:915`). Mitigation: handle is move-only/non-copyable, created and consumed inside `execute` scope; extracted functions take `const&`; doc comment states the scope contract.
+2. **Missed probe read surviving the refactor.** Mitigation: the fence is scope removal (extracted functions cannot name `input_batches`), plus the non-prefix-row/non-prefix-payload tests that make misalignment produce wrong values, not just wrong counts.
+3. **Atomic conversion of `_join_mode`/`_hash_table_build_state`** could mask an ordering bug. Mitigation: all RMW transitions stay under `op_state_mutex` exactly as today (`:466-468,:472,:592,:944-969,:1409-1426`); the atomics legalize the **pre-existing** lock-free reads at `:926-927,:972,:1044-1052` plus the new estimator reads (26 referencing lines total across the two files — audit in §3 Step 6); comment the invariant at the member declarations. Never lock `op_state_mutex` in the estimator — it is held across `stream.synchronize()` (`:967`).
+4. **Concurrent probe tasks share the consumer** (multiple READY hints while `BUILT`, `:504-512`). Mitigation: gate is already thread-safe (`dynamic_filter_gate.hpp:106-120`); the repeated-ID map gets its own mutex; endpoints vector immutable after install; two-thread checkpoint test (§4.2) mirroring `test_dynamic_filter_merge.cpp:830`.
+5. **Reservation growth from the new join override** on memory-tight configs (first BUILD_PROBE tasks now charge hash-table + overlap terms) could increase downgrades. Mitigation: floor-only-growth (`max(model, 2×)`), constants named and commented as measured allowances, C2b separately revertible, watch TPC-H snapshot downgrade counts via log-analyzer. The probe-only path never reads out-of-bounds build stats (snapshot mechanism, §2d) and degrades to probe-terms-only when the snapshot is unavailable.
+6. **Scan filter estimate jump — stated honestly:** the new model is not "bounded by the pipeline `max()`" — it *dominates* it. `3×decoded + row terms` with `decoded = 8×bytes` on fresh reads ⇒ ~24×+ compressed bytes vs the scan's own 8× (`sirius_gpu_scan_operator.cpp:125-135`), so first-split reservations for dynamic-filtered scan pipelines roughly **triple** until memory history replaces the no-history estimate after the first successful task (`gpu_pipeline_task.cpp:513,:520-521`). Real mitigations: history correction is fast (one task); C2b is separately revertible; the TPC-H snapshot gate watches OOM/downgrade churn. **Reconsidered and rejected** (over-conservatism relief): a `max_simultaneous_filters` hint that drops the mid-cascade copy term when ≤1 filter is visible at estimate time (peak would be `2×decoded`) — rejected because the channel can grow between estimate and execute, turning a 1-filter estimate into a 2-filter cascade and under-reserving; the one-task history correction makes the first-split over-charge cheaper than that risk. Revisit with A1 telemetry if snapshot data shows first-split downgrades.
+7. **Namespace move fallout** breaking an unlisted include. Mitigation: caller list is grep-verified closed (§3 Step 1, including the `sirius_dynamic_filter.hpp:504` doc-comment ref); pre-commit + full CI build matrix (`check.yml`) compiles all TUs.
+8. **`resolve_mark_join_result`/`prepare_join_keys` signature edits** touching MARK/cast paths. Mitigation: 4 call sites enumerated (`:989,:1093,:1288,:1293`); existing MARK tests (`test_physical_mark_join.cpp:182-300+`) plus new BUILD_PROBE MARK filtered test cover both filtered and passthrough shapes.
+
+## Review resolution appendix
+
+| # | Finding | Resolution |
+|---|---|---|
+| 1 | MAJOR — BUILT-mode estimator read `stats.batches[1]`, which does not exist for probe-only (single-batch) tasks that routinely predate memory history | Adopted the snapshot fix: `_build_snapshot_bytes/_build_snapshot_rows` (`std::atomic<std::size_t>`) written in the SCHEDULED block under `op_state_mutex` (`:944-970`) before the `BUILT` transition; estimator uses `batches[1]` only when `batches.size() >= 2`, else the snapshot, and drops all build-derived terms when the snapshot is zero (§2d, §3 Step 6, new tests §4.4). |
+| 2 | MINOR — MIXED returning 0 violated the design floor because the pipeline fallback (`gpu_pipeline_task.cpp:538-539`) fires only when every operator returns 0 | Adopted: MIXED returns `stats.bytes * 2`; floor applies in every mode (§2d, test "MIXED returns exactly 2×" §4.4). |
+| 3 | MINOR — atomics audit wrong ("24 uses, all under mutex"): 26 referencing lines and `:926-927,:972,:1044-1052` are already lock-free reads | Adopted: audit corrected in §3 Step 6 and Risk 3; the already-lock-free reads are enumerated as what the atomics legalize (verified: 24 cpp + 2 hpp lines; unlocked reads at `:926,:927,:972,:1044-1048,:1052`). |
+| 4 | MINOR — `get_batch_id` citation was `data_batch.hpp:389` (`mutable_data_batch`) | Adopted: corrected to `:282` (`read_only_data_batch`, class begins `:277`); verified against the header (§2b). |
+| 5 | MINOR — risk 6's "bounded by pipeline max()" argument was inverted; magnitude understated | Adopted: §8.6 and §2d now state the honest magnitude (~3× first-split reservation for dynamic-filtered scan pipelines, model dominates the 8× in the `max()`). `charge_input` over-conservatism was reconsidered as directed but the filter-count-hint relief was **rejected** (deviation from "consider adopting"): the channel can grow between estimate and execute, so dropping the mid-cascade term risks under-reservation; rationale recorded in §8.6 with a revisit trigger (A1 telemetry). |
+| 6 | MINOR — `batches[i].bytes` (uncompressed footprint) vs `stats.bytes` (consumption basis) inconsistency undocumented; null `get_data()` unguarded | Adopted: invariant documented in §2d (floor intentionally uses the aggregate basis) and in the header comment (Step 6); null-`get_data()` guard added to the fill loop with existing-precedent citations (`sirius_physical_operator.hpp:245-249`, `sirius_physical_hash_join.cpp:1377`). |
+| 7 | MINOR — Step 1 caller list omitted the `@ref dynamic_filter_gate` doc comment at `sirius_dynamic_filter.hpp:504` | Adopted: added to the Step 1 referencing list (comment-only, no compile impact); verified the ref exists at `:504`. |
+| 8 | MINOR — design risk 7 asks for install-time fail-closed on MIXED, plan only guarded execute | Adopted: `install_sip_endpoints` rejects installation for `MIXED_JOIN` (debug throw; release WARN with `[sirius_physical_hash_join]` prefix + drop, fail-closed), in addition to the execute-time passthrough guard (§2c, Step 5, test §4.3). |

--- a/docs/super-sirius/issue-1010-plans/C3-routes-and-freeze.md
+++ b/docs/super-sirius/issue-1010-plans/C3-routes-and-freeze.md
@@ -1,0 +1,419 @@
+# PR C3 implementation plan — SIP discovery/resolution/topology-freeze registry, layered targets, SIP channels, experiment telemetry
+
+Companion to [issue-1010-dynamic-filter-sip-design.md](../issue-1010-dynamic-filter-sip-design.md); baseline dev 506a1d9f.
+
+PR IDs covered: **C3** (recommended split **C3a**: planner/registry/freeze/flag/telemetry, **C3b**: publisher fan-out + consumer wiring + experiment tooling), plus the **C4 gate definition** (deliverable of the C3 experiment) and the contingent **Track D sketch**. All `file:line` at `dev` 506a1d9f. Design = the companion doc (cited as `design:N`).
+
+## 1. Goal + non-goals
+
+C3 delivers the design's "first value experiment" row (design:968): a query-local route registry that (a) discovers SIP routes on the resolved logical plan before physical planning (design:42-47, 427-447), (b) resolves both physical endpoints during `create_plan` despite child-before-parent order, (c) freezes producer publish targets and consumer endpoint plans together after pipeline conversion proves branch/runtime identity (design:479-492), and (d) fans membership filters into dedicated one-producer/one-consumer SIP channels consumed opportunistically at the C2 hash-join probe checkpoint — all behind `enable_dynamic_filter_sip=false`, with the telemetry needed to answer the C3 coverage questions (design:642-660) and gate C4. With the flag off, planner/publisher/runtime behavior is byte-identical to Phase 1. Non-goals: ordered activation (Track D — sketch only, §"Track D"), any producer-policy change (C1b-C1e), STANDARD-route default-on (design:608-612), mixed-provenance/no-scan candidates (Track E, design:361-371), MIXED-mode consumers (design:604-606), pre-partition unary consumers (design:100-110), scheduler changes (Track A).
+
+## 2. Deliverables — public types and APIs
+
+**`src/include/op/dynamic_filter_ids.hpp`** (A1-owned per design:957; C3 lands it if A1 has not — coordinate, see §6). All four IDs are query-relative monotonic values (design "Publication, target, channel, and filter identity"):
+
+```cpp
+namespace sirius::op {
+template <class Tag> struct df_strong_id {
+  std::uint32_t value{0};
+  friend bool operator==(df_strong_id, df_strong_id) = default;
+};
+using dynamic_filter_publication_plan_id = df_strong_id<struct publication_plan_tag>;
+using dynamic_filter_target_id           = df_strong_id<struct target_tag>;
+using dynamic_filter_channel_id          = df_strong_id<struct channel_tag>;
+using dynamic_filter_filter_id           = df_strong_id<struct filter_tag>;
+}  // + fmt formatters
+```
+
+**`src/include/op/dynamic_filter_sip_plan.hpp`** — runtime-facing immutable values (design:449-469, 794-814; SIP variant leg only):
+
+```cpp
+namespace sirius::op {
+struct probe_schema_ordinal { cudf::size_type value; };  // consumer C's runtime probe schema space
+
+struct join_probe_target_key {
+  std::size_t duckdb_filter_ordinal;      // k in filter_pushdown.join_condition — indexes the
+                                          // publisher's per-key arrays (dynamic_filter_publisher.cpp:120-125)
+  std::size_t sirius_key_ordinal;         // compact post-narrowing ordinal (aligns with C1b's
+                                          // admitted_dynamic_filter_key, design:330-335)
+  probe_schema_ordinal consumer_column;
+  cudf::data_type key_type;               // producer build key type, CAPTURED AT DISCOVERY from
+                                          // C1a's extraction value (dynamic_filter_key_plan
+                                          // .build_type, design:784-791) — never read back from
+                                          // the physical join at freeze (its right_key_col_indices
+                                          // / key_casts are protected, sirius_physical_hash_join
+                                          // .hpp:212/:225, and equality-ordinal-compacted so
+                                          // duckdb_filter_ordinal cannot index them; §3.4 step 5)
+};
+
+struct join_probe_publish_target {        // producer side, frozen; same shape as C1a's variant
+  dynamic_filter_target_id  target_id;    // alternative in dynamic_filter_publication_plan
+  dynamic_filter_channel_id channel_id;   // (design:800-814)
+  std::shared_ptr<sirius_dynamic_filter_set> channel;   // dedicated 1-producer/1-consumer (design:564-573)
+  std::vector<join_probe_target_key> keys;
+};
+
+struct sip_consumer_endpoint {            // consumer side, frozen
+  dynamic_filter_publication_plan_id publication_plan_id;
+  dynamic_filter_target_id  target_id;
+  dynamic_filter_channel_id channel_id;
+  std::shared_ptr<sirius_dynamic_filter_set> channel;
+  std::vector<join_probe_target_key> keys;
+};
+struct sip_consumer_plan { std::vector<sip_consumer_endpoint> endpoints; };
+}
+```
+
+**`src/include/utils/single_assignment.hpp`**:
+
+```cpp
+namespace sirius {
+template <class T> class single_assignment {   // assign exactly once before runtime; lock-free reads
+ public:
+  void assign(T v);                             // throws internal_exception on second assign
+  [[nodiscard]] T const* get() const noexcept;  // nullptr while unassigned
+  [[nodiscard]] bool assigned() const noexcept;
+};
+}
+```
+
+**`src/include/planner/dynamic_filter_lineage.hpp` / `src/planner/dynamic_filter_lineage.cpp`** — the pure pass (design:427-447, 494-518; G4 testability, design:929):
+
+```cpp
+namespace sirius::planner {
+struct logical_plan_node_id { std::uint32_t value; };
+
+enum class sip_crossing {
+  CROSS,               // Filter / ORDER BY (no limit) / DISTINCT — binding unchanged (design:501)
+  CROSS_REMAP,         // Projection: direct BoundReferenceExpression pass-through only (design:502)
+  CONSUMER_THEN_LEFT,  // eligible intermediate comparison join (design:503)
+  STOP                 // everything else: aggregate, LIMIT/TOP-N, WINDOW, UNNEST, set ops,
+                       // CTE/materialization/CTE_REF, DELIM joins, computed expr (design:504-510)
+};
+[[nodiscard]] sip_crossing classify_sip_crossing(duckdb::LogicalOperator const& node);
+
+// Fresh pure predicate of join_type — deliberately NOT derived from prove_unique_columns'
+// preservation switch (sirius_plan_comparison_join.cpp:205-222), per design:355-359.
+[[nodiscard]] bool sip_consumer_join_type_eligible(duckdb::JoinType t);        // INNER || SEMI
+[[nodiscard]] bool sip_consumer_join_shape_eligible(duckdb::LogicalComparisonJoin const& j);
+  // = type eligible && has COMPARE_EQUAL condition && !(equality+inequality mix that becomes
+  //   MIXED_JOIN — mirrors the plan-time-constant ctor decision at sirius_physical_hash_join.cpp:342-347)
+
+// Producer-shape predicate: the producing node itself must be a plain comparison join.
+// LOGICAL_DELIM_JOIN / LOGICAL_ASOF_JOIN are LogicalComparisonJoin subclasses that Phase 1 DOES
+// wire as producers today (delim routes through plan_comparison_join via
+// sirius_plan_delim_join.cpp:73-76; the build_side_has_filter comment at
+// sirius_plan_comparison_join.cpp:425 explicitly covers the delim case), but their probe subtrees
+// contain DuckDB delim machinery and their pipeline shapes hit the RIGHT_DELIM_JOIN build-wrapping
+// special case (sirius_pipeline_converter.cpp:1182-1197) — excluded from SIP in C3.
+[[nodiscard]] bool sip_producer_shape_eligible(duckdb::LogicalOperator const& node);
+  // = node.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN (exactly; not DELIM/ASOF)
+
+// Remap a binding downward through one crossed node; nullopt == cannot remap (→ STOP).
+[[nodiscard]] std::optional<duckdb::ColumnBinding>
+remap_binding_through(duckdb::LogicalOperator const& node, duckdb::ColumnBinding b);
+
+enum class sip_reject_reason : std::uint8_t {
+  FLAG_DISABLED, PRODUCER_SHAPE, CROSSING_STOP, RIGHT_ORIGIN_BINDING, NO_GET_MATCH,
+  DUPLICATE_GET_MATCH, FINAL_BINDING_MISMATCH, CONSUMER_INELIGIBLE, PRODUCER_NOT_WIRED,
+  CONSUMER_NOT_PLANNED, CONSUMER_MIXED_MODE, NOT_HASH_JOIN_PHYSICAL, BRANCH_AMBIGUOUS,
+  ORDINAL_OUT_OF_RANGE, TYPE_MISMATCH, NO_INTERMEDIATE_JOIN
+};
+
+struct pending_join_probe_target {          // design:461-469
+  op::dynamic_filter_publication_plan_id publication_plan_id;
+  op::dynamic_filter_target_id           target_id;
+  logical_plan_node_id producer, consumer;
+  std::vector<op::join_probe_target_key> keys;       // key_type populated here (discovery)
+  std::vector<cudf::data_type> consumer_probe_types; // per key: consumer probe-column type,
+                                                     // captured at discovery from the consumer's
+                                                     // left-child logical types (§3.4 step 5)
+  op::dynamic_filter_channel_id channel_id;
+  std::shared_ptr<op::sirius_dynamic_filter_set> channel;
+};
+struct sip_candidate_rejection { logical_plan_node_id producer; std::size_t duckdb_filter_ordinal;
+                                 sip_reject_reason reason; };
+struct sip_discovery_result { std::vector<pending_join_probe_target> targets;
+                              std::vector<sip_candidate_rejection> rejections; };
+
+// One producing join with non-empty probe_info (candidates via the C1a adapter, design:296-338).
+// Pure over the resolved logical tree; registry only mints ids/channels.
+sip_discovery_result trace_sip_routes(duckdb::LogicalOperator& resolved_root,
+                                      duckdb::LogicalComparisonJoin& producer,
+                                      /* C1a extraction value: admitted keys (condition_index,
+                                         build_column_index, build_type) + probe_info identities */,
+                                      dynamic_filter_route_registry& registry);
+}
+```
+
+**`src/include/planner/dynamic_filter_route_registry.hpp` / `src/planner/dynamic_filter_route_registry.cpp`** — the query-local registry (design:471-492):
+
+```cpp
+namespace sirius::planner {
+class dynamic_filter_route_registry {
+ public:
+  // --- discovery (pre-create_plan) ---
+  logical_plan_node_id node_id_for(duckdb::LogicalOperator const& node);      // assign-on-first-use
+  op::dynamic_filter_publication_plan_id mint_publication_plan_id();
+  op::dynamic_filter_target_id mint_target_id();
+  std::pair<op::dynamic_filter_channel_id, std::shared_ptr<op::sirius_dynamic_filter_set>>
+      mint_sip_channel();                                                     // dedicated, no remap
+  void add_discovery(sip_discovery_result r);
+
+  // --- endpoint resolution (during create_plan; both roles resolved here, design:471-475) ---
+  void bind_physical_join(duckdb::LogicalOperator const& logical_node,
+                          op::sirius_physical_hash_join& physical,
+                          bool phase1_producer_wired);
+
+  // --- freeze (after conversion; single-assignment of slots) ---
+  // First call freezes; LATER CALLS ARE DEFINED NO-OPS that return the first call's stats and
+  // re-emit topology_frozen with reused=true — required because the extension prepared path
+  // caches the physical plan and re-executes it (§3.4 "Prepared-plan re-execution").
+  struct finalize_stats { std::size_t frozen_targets, rejected_targets; };
+  finalize_stats finalize(
+      duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>> const& scheduled);
+  [[nodiscard]] bool finalized() const noexcept;
+
+ private:
+  // pending state: node-id map (LogicalOperator const* -> id), pending targets,
+  // logical-node -> physical-join binds, rejections buffer; ALL cleared inside the first
+  // finalize() so runtime never sees DuckDB pointers or mutable route state (design:46-47,
+  // 487-489). Only finalize_stats + the spent flag survive for the no-op re-call.
+};
+}
+```
+
+**`sirius_physical_hash_join` additions** (`src/include/op/sirius_physical_hash_join.hpp`):
+
+```cpp
+// Frozen SIP slots — assigned at most once by dynamic_filter_route_registry::finalize, strictly
+// before create_query/start_query; runtime reads snapshots only (design:483-485).
+// install_sip_consumer_plan also constructs the C2 checkpoint's per-endpoint gate state here,
+// single-threaded (§3.6) — probe tasks never construct gates.
+void install_sip_publish_targets(std::shared_ptr<std::vector<op::join_probe_publish_target> const>);
+void install_sip_consumer_plan(std::shared_ptr<op::sip_consumer_plan const>);
+[[nodiscard]] std::shared_ptr<std::vector<op::join_probe_publish_target> const>
+    sip_publish_targets() const noexcept;      // nullptr == none
+[[nodiscard]] std::shared_ptr<op::sip_consumer_plan const> sip_consumer_plan() const noexcept;
+[[nodiscard]] bool is_mixed_join() const noexcept;   // _join_mode==MIXED_JOIN; plan-time constant (cpp:342-347)
+```
+
+**Config**: `bool enable_dynamic_filter_sip = false;` in `operator_params` + YAML + `SET enable_dynamic_filter_sip` (recipe in §3.9).
+
+**Free function** `finalize_sip_topology` is `registry.finalize(...)` invoked from the engine (§3.4).
+
+## 3. Step-by-step changes
+
+### 3.1 `src/planner/sirius_physical_plan_generator.{hpp,cpp}` — discovery hook + registry ownership
+
+- Header: next to the scan-channel map (`sirius_physical_plan_generator.hpp:80-85`), add
+  `std::shared_ptr<dynamic_filter_route_registry> sip_registry; // null unless SIP enabled and routes pending`.
+- Cpp: add helper `dynamic_filter_sip_enabled(duckdb::ClientContext&)` cloning `dynamic_filter_pushdown_enabled` (`sirius_physical_plan_generator.cpp:38-45`), returning false with no `SiriusContext`.
+- In `create_plan(duckdb::unique_ptr<duckdb::LogicalOperator>)`: after `resolver.VisitOperator(*op)` (`sirius_physical_plan_generator.cpp:126-128`) and before the recursion `create_plan(*op)` (`:132`), run discovery when `dynamic_filter_sip_enabled(context) && dynamic_filter_pushdown_enabled(context)`:
+  walk the logical tree; for each node with **`node.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN` exactly** (`sip_producer_shape_eligible`; `LOGICAL_DELIM_JOIN`/`LOGICAL_ASOF_JOIN` are rejected with `PRODUCER_SHAPE` — Phase 1 wires delim producers today via `sirius_plan_delim_join.cpp:73-76` → `plan_comparison_join`, so without this check delim producers would mint SIP routes over DuckDB's delim machinery and perturb the freeze step-4 pipeline-shape assumptions via `sirius_pipeline_converter.cpp:1182-1197`) whose C1a extraction reports non-empty admitted `probe_info` candidates (design:262-268), call `trace_sip_routes(...)` and `sip_registry->add_discovery(...)` (create `sip_registry` lazily on first admitted producer). This is exactly the required window: post-resolver, pre-condition-drain (design:302-304, 429) — `plan_comparison_join` later drains `op.conditions` at `sirius_plan_comparison_join.cpp:408-409` and `filter_pushdown` at `:514`.
+- Note `fold_adjacent_projections` (`:135`) runs on the physical plan and does not touch joins — physical pointers recorded by `bind_physical_join` stay valid.
+
+**Lineage-pass internals** (`dynamic_filter_lineage.cpp`), per admitted key `k` and `probe_info` target `t` (design:430-443):
+1. Starting binding = `producer.children[0]->GetColumnBindings()[cond_left_index]` — post-resolver left keys are `BoundReferenceExpression` positions into the left child's flattened output (design:155-160; the existing extraction precedent for right keys is `sirius_physical_hash_join.cpp:300-338`).
+2. Locate the target `LogicalGet` by preserved `DynamicTableFilterSet` identity — walk `resolved_root` for `LogicalGet` with `get.dynamic_filters.get() == pi.dynamic_filters.get()` (same pairing key used today at `sirius_plan_get.cpp:264-266` and `sirius_plan_comparison_join.cpp:444`); zero or ≥2 matches → reject `NO_GET_MATCH`/`DUPLICATE_GET_MATCH` (design:433-435).
+3. Descend from the producer's left child toward that GET, applying `classify_sip_crossing`/`remap_binding_through` (the projection remap mirrors the value-preserving pass-through logic used in `trace_binding_to_get`, `sirius_plan_comparison_join.cpp:288-300`, but over `BOUND_REF` post-resolver expressions and failing closed on anything computed). At each `CONSUMER_THEN_LEFT` join: if the binding originates in its left child (check via child `GetColumnBindings()` ownership), record `(consumer node, probe ordinal = position in left-child bindings, consumer probe-column logical type → cudf::data_type)` and continue left; right/build-origin → `RIGHT_ORIGIN_BINDING` stop (design:438-443, 512-513). The producer itself is never recorded (trace starts below it — design:402-404).
+4. Require the final remapped binding to equal `pi.columns[duckdb_filter_ordinal].probe_column_index` (the field consumed today at `sirius_plan_comparison_join.cpp:451`); mismatch → `FINAL_BINDING_MISMATCH` (design:321-325, 437).
+5. Group per `(producer node, consumer node)`, compact keys, dedup paths, mint `publication_plan_id`/`target_id`/`channel_id` + channel per group (design:441-445, 461-469). Each key carries `key_type` = the producer build-key `build_type` from C1a's extraction value (`dynamic_filter_key_plan`, design:784-791) plus the captured consumer probe-column type from step 3 — freeze validates types purely from these captured values (§3.4 step 5). A route with no intermediate join yields no target — Phase 1 stays the only consumer (design:424-425).
+
+### 3.2 `src/planner/sirius_plan_comparison_join.cpp` — endpoint resolution
+
+In `plan_comparison_join`, after the join is constructed and configured (`sirius_plan_comparison_join.cpp:504-519`), add:
+
+```cpp
+if (sip_registry) {
+  sip_registry->bind_physical_join(op, hj, /*phase1_producer_wired=*/phase1_wired);
+}
+```
+
+where `bool phase1_wired = !filter_targets.empty();` is snapshotted just before `filter_targets` is moved into `filter_plan` (`:497-502`). `bind_physical_join` resolves **both roles** for this logical node (design:471-475): records `&hj` as physical consumer for every pending target whose `consumer` node-id maps to `&op`, and as physical producer for pending targets whose `producer` maps to `&op` — remembering `phase1_producer_wired`. This deliberately reuses the Phase 1 producer gates as the single source of truth: if the join was not wired (unfiltered build `:426-431`, missing GPU/HOST spaces `:437-440`, no channel from the central gate `:444-445`), the pending SIP targets are later rejected `PRODUCER_NOT_WIRED` — preserving the invariant SIP producers ⊆ Phase 1 producers. That invariant is an inference from keeping the blanket `build_side_has_filter` gate until C1e removes it (design:964-966), not a design bullet. Children are planned at `:372-373` before this point, so consumer joins in the probe subtree are always bound before their producer — no post-hoc patching. `plan_delim_join` needs no change: it delegates to `plan_comparison_join` (`sirius_plan_delim_join.cpp:73-76`), so `bind_physical_join` **does** execute for delim-join logical nodes — but discovery excludes delim producers (`PRODUCER_SHAPE`, §3.1) and crossing STOPs at delim consumers, so no pending target can name them; `bind_physical_join` is lookup-miss-tolerant and the bind is a no-op there.
+
+Timing note: because the SIP flag is read once here (plan time) and never at runtime, `SET enable_dynamic_filter_sip` is effective at the next query (recon R3 §4; same contract as `enable_dynamic_filter_pushdown`).
+
+### 3.3 Registry lifetime — plan-generator → engine handoff
+
+The generator is stack-local at all four instantiation sites and dies immediately after `create_plan` returns: `src/sirius_extension.cpp:534-536` (inside `SiriusGeneratePhysicalPlan` `:531-538`), `src/sirius_ffi.cpp:171`, `src/transparent/physical_sirius_execution.cpp:148-149`, and the validation-only path `src/sirius_context.cpp:843-863`. The registry must survive until conversion. Carrier: `sirius_prepared_statement_data` (keeps ops free of planner types — G9, design:935):
+
+- `src/include/sirius_interface.hpp:26-38`: add public member `std::shared_ptr<planner::dynamic_filter_route_registry> sip_registry;` (forward-declared; default null).
+- Assign it at the three construction sites (all grep-verified):
+  - `src/sirius_extension.cpp:601-605` — change `SiriusGeneratePhysicalPlan` (`:531-538`) to also out-return `physical_planner.sip_registry`, assign onto `gpu_prepared`.
+  - `src/sirius_ffi.cpp:170-173` — hoist the generator into a named local; assign `gpu_prepared->sip_registry`.
+  - `src/transparent/physical_sirius_execution.cpp:148-152` — same.
+- `src/include/sirius_engine.hpp` (class at `:54`): add `std::shared_ptr<planner::dynamic_filter_route_registry> sip_registry;` in the **public** member section (the engine's data members are public and its only friends are pipeline classes, `sirius_engine.hpp:55-58` — a private trailing-underscore member would not be assignable from `sirius_interface`). Set it in `sirius_interface::sirius_pending_statement_internal` (`src/sirius_interface.cpp:150-177`) — the engine is created at `:160-163` and initialized at `:177` (the only `engine.initialize` call site, grep-verified; `sirius_execute_query` at `:214-240` only delegates via `sirius_pending_statement_or_prepared_statement`): `engine.sip_registry = statement_p->sip_registry;` before `engine.initialize(std::move(sirius_collector))`.
+- **Do NOT clear the registry in `sirius_engine::reset()`.** `sirius_engine::initialize` calls `reset()` at `src/sirius_engine.cpp:141` *before* `initialize_internal` at `:149` — clearing there would null the registry before the freeze ever runs, making SIP a silent no-op on every path with the flag on (no `register_producer`, no slot installs, no telemetry) while all correctness tests stay green. Instead the engine releases it inside `initialize_internal` immediately after `finalize` (§3.4), where it is spent.
+- The validation-only path (`sirius_context.cpp:843-863`) discards plan+generator+registry together — pending state and channels are all plan-local shared_ptrs, so nothing leaks or dangles. The transparent replan path builds a fresh generator/registry per execute (`physical_sirius_execution.cpp:110-149`) — IDs are query-relative and never cached across replans (design:575-577).
+
+### 3.4 Topology freeze — `src/sirius_engine.cpp` + `dynamic_filter_route_registry::finalize`
+
+In `initialize_internal`, after `auto result = converter.convert(*root_pipeline);` (`src/sirius_engine.cpp:353-355`) and before `materialize_repository_wiring` (`:358-359`):
+
+```cpp
+if (sip_registry) {
+  sip_registry->finalize(result.scheduled_pipelines);  // emits [dynf_summary] topology_frozen (§3.8)
+  sip_registry.reset();  // spent; MUST NOT be cleared earlier (reset() runs pre-initialize_internal,
+                         // sirius_engine.cpp:141 — see §3.3)
+}
+```
+
+`finalize` logs its own `topology_frozen` line from `dynamic_filter_route_registry.cpp` (component prefix `[dynf_summary]`, §3.8), so the engine call site adds no logging. Per pending target:
+1. **Physical existence**: both producer and consumer were bound and are `sirius_physical_hash_join` (a logical comparison join that planned to NLJ at `sirius_plan_comparison_join.cpp:597-608` was never bound → `NOT_HASH_JOIN_PHYSICAL`, design:513-514).
+2. **Producer viability**: `phase1_producer_wired` recorded at bind, and `producer.publishes_dynamic_filters()` (`sirius_physical_hash_join.hpp:167-170`) → else `PRODUCER_NOT_WIRED`.
+3. **Consumer mode**: `!consumer.is_mixed_join()` (plan-time constant, `sirius_physical_hash_join.cpp:342-347`) → else `CONSUMER_MIXED_MODE` (design:604-606). BUILD_PROBE vs STANDARD is runtime-decided (`sirius_physical_hash_join.cpp:434-461`) and both are eligible — no check.
+4. **Branch uniqueness** (design:483, 536-539): exactly one pipeline in `scheduled` whose `source == &consumer` and exactly one whose `source == &producer`. The converter guarantees join pipelines have `dependencies[0]=build concat, dependencies[1]=probe concat` (`sirius_pipeline_converter.cpp:1164-1204`, probe at `:1172-1173`); require `dependencies.size() >= 2` on the consumer pipeline (the branch-specific default probe context). CTE-duplicated or missing → `BRANCH_AMBIGUOUS`. (Delim producers, whose build wrapping at `:1182-1197` would perturb this shape, never reach freeze — excluded at discovery, §3.1.)
+5. **Key validation** — purely over values captured at discovery/bind; freeze reads **no** join key metadata (`right_key_col_indices`/`key_casts` are `protected`, `sirius_physical_hash_join.hpp:212/:225`, and equality-ordinal-compacted — the ctor loop skips inequality conditions, `sirius_physical_hash_join.cpp:290-341` — so `duckdb_filter_ordinal` cannot index them even with an accessor): every `consumer_column.value < consumer probe schema width` (consumer's `children[0]` output arity captured at bind time) → else `ORDINAL_OUT_OF_RANGE`; `key_type` (producer `build_type` from C1a's extraction value, captured at discovery — §3.1 step 5) equals the captured consumer probe-column type (both sides no-cast by the narrowing gates, design:349-351) → else `TYPE_MISMATCH`.
+6. **Survivor**: `channel->register_producer()` (`sirius_dynamic_filter.hpp:475`); append `join_probe_publish_target` to the producer's batch and `sip_consumer_endpoint` to the consumer's batch. **Rejected**: `channel->close_for_new_filters()` (`:484`), emit `channel_closed reason=PLANNING_REJECTED`, drop both ends; scan targets are untouched (design:485-486, 516-518, 1007-1009). A consumer resolved before its producer failed retains no dangling endpoint because endpoints are only installed here, never at bind.
+7. Assign each participating join's slots exactly once via `install_sip_publish_targets` / `install_sip_consumer_plan` (skip empty; the consumer install also constructs gate state, §3.6), emit `target_planned` per frozen target and buffered `candidate_rejected` lines, then **destroy all pending state** — node-id map, logical pointers, bind records (design:487-489); only `finalize_stats` and the spent flag survive. Freeze precedes `execute()` → `create_query` → `start_query` (`src/sirius_engine.cpp:151-167`), so runtime only ever observes assigned-or-null slots; no converter change is needed (the converter never reads SIP state; its scan elision at `sirius_pipeline_converter.cpp:277-278` concerns scan channels only, whose `register_producer` happened at plan time `sirius_plan_comparison_join.cpp:446`).
+
+**Prepared-plan re-execution.** The extension path caches `gpu_prepared` on the bind result (`sirius_extension.cpp:601-605`) and `sirius_interface` supports prepared statements (`sirius_pending_statement_or_prepared_statement`, `sirius_interface.cpp:132-142, 221-222`), so the same physical plan — and therefore the same registry held by `statement_p->sip_registry` — can be initialized more than once. **The second and later `finalize` calls are defined per-plan-instance no-ops**: the registry keeps a spent flag + the first call's `finalize_stats`, returns them, re-emits `topology_frozen ... reused=true`, and installs nothing (so `single_assignment` never double-throws). Channel-content reuse across executions of the same prepared plan matches Phase 1's existing exposure exactly — scan channels are likewise minted at plan time and live in the physical plan (`sirius_plan_comparison_join.cpp:444-446`) — so C3 adds no new hazard class; an e2e test executes the same prepared statement twice with the flag on (§4 test 4). The transparent path re-plans per execute (`physical_sirius_execution.cpp:110-152`) and never hits this.
+
+### 3.5 Producer fan-out — C1a publication-plan seam, `src/op/sirius_physical_hash_join.cpp`
+
+C3's hard dependency C1a replaces the current publisher internals with an immutable `dynamic_filter_publication_plan` whose `targets` are `std::vector<dynamic_filter_publish_target>` = `variant<scan_publish_target, join_probe_publish_target>`, and whose claim path "does not re-read `filter_pushdown`, `join_condition`, `key_casts`" (design:794-830, 962). C3 integrates **against that seam**, not against the dev-line publisher (`dynamic_filter_publisher.hpp:43-53` ctor taking `JoinFilterPushdownInfo`/`key_casts`/`right_key_col_indices`, per-key arrays sized from `_filter_pushdown.join_condition` at `dynamic_filter_publisher.cpp:120-125`, scan loop `:305-329`, drained early-out `:83-91` — those cites document the code C1a rewrites and will not survive it):
+
+- `install_sip_publish_targets` is the freeze→producer hand-off: before `create_query`, the join folds the frozen `join_probe_publish_target` entries into its `dynamic_filter_publication_plan.targets` as the variant's join-probe alternative (design:800-814); the plan is immutable from then on. The publisher's target loop, per-target accepting check, arity handling, and all-targets-drained early-out then cover SIP targets **for free** — a drained-scans-but-live-SIP plan still publishes because the early-out iterates the unified vector.
+- The claim gate is unchanged: C3 keeps SIP producers ⊆ Phase 1 wired producers (§3.2), so the existing `_dynamic_filter_plan.enabled()` claim condition (dev-line `sirius_physical_hash_join.cpp:1364`; C1a's equivalent) needs no edit.
+- The variant visitor pushes **membership filters only** into `join_probe_publish_target` channels — one `per_key_membership`-equivalent filter per `join_probe_target_key`, at `key.consumer_column.value`; **never zone maps** (design:626-627; zone maps stay scan-reader capabilities and remain `scan_publish_target`-only). The same `shared_ptr<sirius_dynamic_filter const>` object fans out — channels co-own filters, no replica duplication (design:565-569, 633-634; channel contract `sirius_dynamic_filter.hpp:437-440`). Key alignment is by construction: SIP keys were built at freeze from the same C1a-admitted key set (`duckdb_filter_ordinal` ↔ key-plan index), enforce with `assert`.
+- Emit `channel_filter_visible` per push and `target_publication_terminal` per SIP target after fan-out (§3.8); extend the existing per-publication summary line with `sip_targets={}` count.
+- **Coordination requirement (merge-blocking for C3b):** if C1a lands with a different variant/plan shape, C3b rebases the fold-in on it; if C1a is delayed, C3b either amends C1a's structs in the same stack or is blocked — C3b must not re-implement fan-out against the pre-C1a publisher internals.
+
+### 3.6 Consumer wiring — `src/include/op/sirius_physical_hash_join.hpp`, `src/op/sirius_physical_hash_join.cpp`
+
+- Add the two `single_assignment` slot members + accessors + `is_mixed_join()` (§2). Include only `dynamic_filter_sip_plan.hpp` (op-layer header; no planner include — the registry is forward-declared nowhere in op headers).
+- Connect the frozen `sip_consumer_plan` to the **C2** checkpoint component (`hash_join_probe_filter_consumer`, design:582-612). **Gate state is constructed inside `install_sip_consumer_plan` at freeze** — one `dynamic_filter_gate` per endpoint (independent combined + per-filter stats, design:622-624; gate type at `src/include/op/scan/dynamic_filter_gate.hpp:46-121`, which C2 relocates under `src/include/op/`). Freeze is single-threaded and strictly precedes `create_query`, so no synchronization is needed for construction; probe tasks only *mutate per-batch stats* under the gate's own accounting. Lazy construction on first probe task is explicitly ruled out: probe tasks for one join run concurrently (STANDARD per-partition tasks; BUILD_PROBE probe tasks after `BUILT`, `sirius_physical_hash_join.cpp:510-517`), so first-task construction is a data race.
+- Fast paths per design:615-620: null plan / `!channel->has_filters()` (`sirius_dynamic_filter.hpp:498-501`) / replica unavailable / disabled gate → zero-copy forward; replica-unavailable pass-through does not train the gate.
+- `on_finalize_operator` (`sirius_physical_hash_join.cpp:1407-1428`): after the existing publication-window close (`:1412-1418`), close each consumer endpoint channel via `close_for_new_filters()` + emit `channel_closed reason=CONSUMER_FINALIZED` — mirroring the scan consumer's close (`src/op/scan/sirius_physical_dynamic_filter.cpp:43-46`). One logical consumer per SIP channel makes this the unique closer (design:571-573).
+
+### 3.7 STANDARD-route probe-batch identity
+
+Give the C2 `probe_batch_handle` its stable probe-batch ID from the batch's repository identity so repeated STANDARD applications (one probe × several build batches) are visible in `consume_batch` telemetry (design:608-612, 1029). C3 reapplies safely and only measures; no cache.
+
+### 3.8 Telemetry — log lines + analyzer (recon R1 recommendation: log lines primary; quent later)
+
+Events (subset of design:1058-1070 that is C3's to emit; A1 owns `publication_plan_created/started/completed`, the waiter-free outcomes design:762-780, the query-relative clock, and resident high-water). Prefix rules: machine-parsed per-query summary lines use the `[dynf_summary]` prefix at INFO; other new lines keep the existing bracketed component prefix of the file they live in (`dynamic_filter_publisher.cpp` emits under `[sirius_physical_hash_join]` today — e.g. `:83-91` — so its new lines do too); new files get their own prefix.
+
+| line (k=v style per `MEM_HISTORY_RE` precedent) | level | emitting file |
+|---|---|---|
+| `[dynf_summary] topology_frozen targets= rejected= reused=` | INFO | `dynamic_filter_route_registry.cpp` (inside `finalize`) |
+| `[dynf_summary] target_planned publication_plan_id= target_id= channel_id= kind=join_probe producer_op= consumer_op= keys=` | INFO | same |
+| `[dynf_summary] sip_consume_summary channel_id= batches= rows_in= rows_out= masks_applied= masks_skipped= replica_unavailable= apply_us= batches_before_first_filter= rows_before_first_filter=` (per endpoint, at consumer finalize — makes coverage (b),(d),(e) INFO-derivable) | INFO | hash join .cpp |
+| `[sip_registry] candidate_rejected publication_plan_id= ordinal= reason=` (discovery rejections buffered, logged at freeze so one file emits) | DEBUG | `dynamic_filter_route_registry.cpp` |
+| `[sip_registry] channel_closed channel_id= reason=PLANNING_REJECTED` | DEBUG | same |
+| `[sirius_physical_hash_join] channel_filter_visible channel_id= target_id= filter_id= generation=` | DEBUG | `dynamic_filter_publisher.cpp` |
+| `[sirius_physical_hash_join] target_publication_terminal target_id= channel_id= outcome=` | DEBUG | same |
+| `[sip_consume] consume_batch channel_id= probe_batch_id= rows_in= rows_out= filters_visible= masks_applied= masks_skipped= replica_unavailable= apply_us=` | TRACE | C2 consumer component .cpp |
+| `[sirius_physical_hash_join] channel_closed channel_id= reason=CONSUMER_FINALIZED` | DEBUG | hash join .cpp |
+
+Rules: IDs in-line (never addresses, design:1055-1056); `channel_closed` has two emitters with different prefixes, so its strict regex must pin neither filename nor prefix (log-analyzer contract; `tools/log_analyzer/patterns.py:102` precedent pins filenames — deliberately omit here). Per-batch events TRACE, one-shot events INFO/DEBUG (matches existing split, `patterns.py:184-195` / the publisher summary line).
+
+Analyzer: new `tools/log_analyzer/metrics/dynamic_filter_sip.py` exposing `COLUMNS` + `parse(lines, warnings)` (pattern: `metrics/memory_reservation.py:22-50`), wired in `parse_logs.py` `process_query` (`:142`); anchors + strict regexes in `patterns.py` and `SHAPE_VERSION` bump `"1.6"` → `"1.7"` (`patterns.py:11-17`). Segmentation is automatic via existing QueryBegin/QueryEnd anchors (`patterns.py:46-51`). The module warns "flag-on run but zero `consume_batch`/`sip_consume_summary` lines seen" so a mis-leveled coverage pass cannot silently produce empty CSVs.
+
+**Coverage report** (computed by the analyzer module + a small aggregation notebook/script in `tools/log_analyzer/`): per query × config, (a) routes planned/rejected by reason (INFO); (b) per SIP channel: rows/batches consumed before first filter visible vs after (pre-publication miss rate — INFO via `sip_consume_summary.{batches,rows}_before_first_filter`); (c) layer attribution scan-caught vs C1-caught vs C2-caught via distinct channel_ids sharing filter_ids (design:1074-1077, 1083-1084 — needs the DEBUG `channel_filter_visible` legs); (d) hash-probe rows avoided = Σ(rows_in − rows_out) and estimated bytes (INFO); (e) mask overhead Σapply_us and gate disable/skip rates (INFO); (f) joined with A1's wall-time + per-space resident high-water lines (design:644-649, 1079-1086).
+
+**Runbook** (ships as a section in the dynamic-filters.md update, §3.10) — **log level is stated per pass and is part of the protocol**:
+- **Timing passes: `SIRIUS_LOG_LEVEL=info`.** N≥5 paired runs; all wall-time numbers come only from these passes. Coverage items (a),(b),(d),(e),(f) are derived from the INFO `[dynf_summary]` aggregates of the same timed runs — no TRACE required.
+- **Coverage-detail passes: `SIRIUS_LOG_LEVEL=trace`, separate and non-timed.** Needed only for item (c) filter-level attribution and per-batch `consume_batch` drill-down; their timings are excluded from every statistic. (CI already exports `SIRIUS_LOG_LEVEL: trace`, `test.yml:116` — fine for tests, never for timing.)
+- Serialize configs in one process (`SET` is process-global per DB instance — `src/sirius_context.cpp:919`; LOAD before SET — recon R3 gotcha 1); 2×2 matrix + reference: {pushdown off} ∪ {pushdown on} × {sip off,on} × {`dynamic_filter_build_priority` legacy,off (A2 flag)} (priority×SIP matrix, design:1036); all 22 TPC-H queries at SF10 on the dev box (SF1 sanity in CI) plus the synthetic many-join chain from the A-track gate (design:184-185); expected route-bearing shapes to inspect first: Q2, Q5, Q7, Q8, Q9, Q10, Q17, Q18, Q20, Q21 (Q21's orders self-join is the documented Phase-2 case, `docs/super-sirius/dynamic-filters.md:348`) — but the report's first table is "which queries actually admitted routes", since DuckDB owns candidate admission (design:35-41). Bag-equivalence checks per design:1013-1015.
+
+### 3.9 Config flag — exactly the R3 recipe
+
+- `src/include/sirius_config.hpp`: `bool enable_dynamic_filter_sip = false;` in `operator_params` (fields block `:102-118`).
+- `src/sirius_config.cpp`: `r.optional("enable_dynamic_filter_sip", opt.enable_dynamic_filter_sip);` in `from_yaml(..., operator_params&)` (`:160-180`, before `reject_unknown` `:179`).
+- `src/sirius_extension.cpp`: `SetEnableDynamicFilterSip` cloning `SetEnableDynamicFilterPushdown` (`:1604-1611`); registration next to `:1841-1848` with default from a fresh `sirius::operator_params{}` (leak-rationale convention at `:1734-1736`).
+- Consumption: only `dynamic_filter_sip_enabled` in the plan generator (§3.1). No runtime read.
+
+### 3.10 `docs/super-sirius/dynamic-filters.md` — Phase 2 section update (ships with C3; design:1122)
+
+Rewrite `:389-408`:
+- Consumer is the **in-join probe checkpoint** after the consumer's CONCAT/repository pop, before `prepare_join_keys` — supersede the current text's implicit shape and state explicitly it is not a pre-partition unary operator (design:100-110, 376-404).
+- **Supersede** `:395` ("Routing (new): Sirius-owned `sirius_sip_route` route key") and `:405` ("`dynamic_filter_channels` becomes keyed by a variant"): the finalized design keeps the scan map keyed by `DynamicTableFilterSet*` unchanged and gives each `(P,C)` SIP target a dedicated one-producer/one-consumer channel minted by the query-local route registry (design:558-577). Update `:128` ("route key generalizes to a variant") with a pointer to the superseding design.
+- **Supersede** `:396` coordination sentence: v1 is opportunistic (C3); ordered activation is contingent Track D, not "implicit upstream meta-pipeline" ordering (design:49-53, 642-660).
+- Add: flag `enable_dynamic_filter_sip` (default false), layered target model summary (design:406-425), identity model (four IDs), telemetry event names, the C3 runbook (incl. per-pass log levels), and a link to `issue-1010-dynamic-filter-sip-design.md`. Extend References (`:438-446`) with the new registry/lineage/sip-plan files.
+
+### 3.11 Build wiring
+
+New prod files added to the extension source list in `CMakeLists.txt`; new test files appended to `TEST_SOURCES` (`CMakeLists.txt:562`, executable at `:693`) — mandatory, enforced by the orphan-test hook (`.pre-commit-config.yaml:81-83`, `scripts/check_orphan_tests.py`).
+
+## 4. Tests
+
+All Catch2 in the single `sirius_unittest` binary; CI runs everything on `gpu-2xl4` (`.github/workflows/test.yml:115,133-136`). SQLLogic is not CI-run (recon R4 §4) — e2e coverage is Catch2.
+
+1. **`test/cpp/planner/test_dynamic_filter_lineage.cpp`** — tag `[dynamic_filter][sip][lineage]`. Pure/no-GPU-execution. Two styles: no-DB logical construction (pattern of `test/cpp/transparent/test_preserve_dynamic_filter_metadata.cpp:116-183`) for `classify_sip_crossing`/`remap_binding_through`/`sip_consumer_join_type_eligible`/`sip_producer_shape_eligible` truth tables (every row of the crossing table design:498-510, incl. DELIM_JOIN and UNION stops; **producer-shape table pins `LOGICAL_DELIM_JOIN` and `LOGICAL_ASOF_JOIN` → `PRODUCER_SHAPE` rejection** — reachable today because delim routes through `plan_comparison_join`, `sirius_plan_delim_join.cpp:73-76`); SQL-through-planner (`generate_sirius_plan`, `test/cpp/planner/test_distinct_hash_join_detection.cpp:41-95`, fixture with `SIRIUS_CONFIG_FILE`+`SIRIUS_DISABLE` `:112-158`) for: consumer recorded on left-derived binding / stop on right-origin; zero+duplicate GET match fail-closed; final-binding-mismatch drop; grouping/dedup into `(producer, consumer)`; per-key INDF/cast rejection keeps the equality sibling routable (design:988-994); no target when no intermediate join exists; a correlated-subquery plan whose delim join admits Phase 1 filters mints **zero** SIP targets.
+2. **`test/cpp/planner/test_sip_topology_freeze.cpp`** — tag `[dynamic_filter][sip][topology]`. Registry-level: hand-built `sirius_pipeline` objects with stub hash joins as sources (stub-child pattern of `test/cpp/operator/test_no_history_peak_memory_estimate.cpp:40-80`; hand-built `sirius_pipeline(pipeline_build_context{})` proven feasible by `test/cpp/pipeline/test_get_next_ports_after_sink.cpp:61`, `dependencies` public at `sirius_pipeline.hpp:157`); cases: freeze assigns slots exactly once; **second `finalize` is a defined no-op returning first-call stats (and emits `reused=true`), not an error**; `PRODUCER_NOT_WIRED` and `CONSUMER_MIXED_MODE` rejection closes channel (`accepting_filters()==false`) and installs nothing on either side while a sibling scan target survives; `BRANCH_AMBIGUOUS` (two pipelines, same source op); `ORDINAL_OUT_OF_RANGE`/`TYPE_MISMATCH` (validated against captured discovery values — no join internals); consumer-resolved-before-producer-failure leaves no endpoint (design:997-1009). Plus one plan-through case asserting `scan → C1 → P` yields scan channel + one C1 endpoint, and `scan → C1 → C2 → P` yields endpoints in both (design:999-1003).
+3. **`test/cpp/operator/test_dynamic_filter_sip_publish.cpp`** — tag `[dynamic_filter][sip]`, needs a CUDA device (constructs filters like `test/cpp/operator/test_sirius_dynamic_filter.cpp:42-58`). Publisher fan-out through the unified publication-plan variant vector (§3.5): membership-only into SIP channels (zone map never pushed); identical `shared_ptr` filter object (same `filter_id`) lands in scan and SIP channels; closed SIP target skipped without affecting the scan target; drained-scan/live-SIP still publishes (unified early-out); channel close racing push loses no correctness (push after close is a no-op, `sirius_dynamic_filter.hpp:440`).
+4. **`test/cpp/integration/test_dynamic_filter_sip_e2e.cpp`** — tag `[integration][dynamic_filter][sip]`, GPU. `GpuExecutionFixture::compare_gpu_vs_cpu` (`test/cpp/utils/gpu_execution_fixture.hpp:144-186`) with `SET enable_dynamic_filter_sip=true` via the registered `SiriusContext` (router-test style, `test/cpp/planner/test_dynamic_filter_router.cpp:46-57`): nested INNER/SEMI chains (2- and 3-deep), composite admitted keys, NULL probe keys, empty build, zero-row filtered probe completes normally, STANDARD consumer shape, non-prefix-payload query that would expose index/view misalignment if any post-checkpoint access bypassed the handle (design:598-603, 1027-1029). **Liveness assertion (the silent-no-op trap, §3.3):** one flag-on route-bearing case registers a temporary log-capture sink and `REQUIRE`s the `[dynf_summary] topology_frozen` line with `targets >= 1` (correct results alone would pass even if the registry were dropped before freeze). **Prepared re-execution:** execute the same prepared statement twice with the flag on — both runs correct, second run's `topology_frozen` has `reused=true`, no throw (§3.4). LIMIT/TOP-N explicit-oracle variants gated on B1 (design:1018-1020).
+5. **Multi-GPU**: extend `test/cpp/operator/test_sirius_dynamic_filter_mgpu.cpp` (skip helper `require_two_gpus`, `mgpu_test_utils.hpp:144`; env params `mgpu_env_params`, `:62`) — SIP endpoint on non-producer device applies the local replica; a device without a replica passes through and increments `replica_unavailable` without training the gate (design:629-637).
+6. **Flag-off invariance**: one case in file 2 asserting `sip_registry == nullptr` and zero SIP lines with the flag off; plus the existing TPC-H CI snapshot (`test.yml:171-176`) serving as the no-change regression under default config.
+
+## 5. Gate & rollback
+
+**Merge gate for C3 (the PR itself):** default `enable_dynamic_filter_sip=false`; with flag off, zero planner/publisher behavior change (existing `[dynamic_filter]` suites + TPC-H snapshot green, no new log anchors emitted); with flag on, e2e suite green **including the `topology_frozen` liveness assertion** (test 4 — result-correctness alone cannot catch a registry lifecycle regression, §3.3), TSan-clean publish/snapshot/close (design:1032), analyzer parses all new lines with zero format warnings; B1 **not** required to merge (flag stays off) but **required before running the C3 experiment or enabling the flag anywhere shared** (design:947-949, 961).
+
+**C4 gate definition (the deliverable — measured after the C3 experiment, decides default-on; design:969, 642-660, 199-201):**
+1. **Correctness:** ON/OFF bag-equivalence across the full e2e matrix incl. multi-GPU and STANDARD consumers; exact order only where SQL guarantees it (design:1013-1015). Zero diffs. Hard veto.
+2. **Prerequisites:** B1 merged and Phase-0 sentinels green on the pin (design:961); A2 flag available so the priority×SIP matrix is measurable (design:1036).
+3. **Value:** on route-admitting queries, wall-time improvement outside measured run variance attributable (via consume-summary/rows-avoided) to SIP checkpoints; full-suite geomean not regressed beyond variance. All timing from INFO-level passes (§3.8 runbook).
+4. **Coverage explains value:** for every route class kept opportunistic, pre-publication miss rate low enough that measured value persists; a class with systematic misses that erases its value makes C4 **depend on Track D** for that class rather than defaulting on (design:53, 657-660, 1092-1093).
+5. **Memory:** per-space resident high-water and filter-replica bytes unchanged beyond variance (fan-out adds channels, not replicas — design:633-634, 875).
+6. **Overhead bound:** on non-benefiting queries, first-mask cost is bounded by gate disable behavior; redundant-downstream keep-rate shows layered masks disabling as designed (design:417-421, 1100-1101).
+7. **STANDARD routes:** default-on only if repeated-application cost measured acceptable; otherwise STANDARD consumers stay flag-gated (design:608-612).
+8. **Priority independence:** SIP value must not require `build_priority=legacy` (A/C matrix independence, design:973-975).
+
+**Rollback:** runtime — `SET enable_dynamic_filter_sip=false` (next query) or YAML; code — C3 is a single revertible PR (plus C3b if split, §7): no persistent state, no schema, all channels/registry/IDs query-local; analyzer `SHAPE_VERSION` reverts with it. Retain the flag for one release after any C4 default-on (mirrors A3, design:177-178).
+
+## 6. Dependencies & ordering
+
+- **Hard, before C3 merges:** C1a (version-pinned adapter + extraction values + **the unified `dynamic_filter_publication_plan` variant target vector that §3.5's fan-out folds into** — discovery consumes its extraction output including per-key `build_type`; design:296-338, 784-814, 962) and C2 (probe checkpoint component + `probe_batch_handle` + relocated mask/gate helpers + join memory-model override; design:967 "no planned routes yet" — C3 supplies the routes). C1b's strong key types shared with `join_probe_target_key` — coordinate the `sirius_key_ordinal` field.
+- **Soft/coordination:** A1 (ID header, waiter-free publication outcomes, query-relative clock, high-water lines) — C3 reuses; if A1 is unlanded, C3 lands `dynamic_filter_ids.hpp` and the clock helper itself and A1 adopts them. A2's `dynamic_filter_build_priority` needed only to *run* the experiment matrix, not to merge.
+- **B1:** required before flag-on experiments and before C4 (design:947-949, 961); not a merge blocker for flag-off C3.
+- **C1c/C1d/C1e:** orthogonal producer-policy A/Bs; the C3 experiment runs against whatever producer policy is current — record config in every run (candidate-parity invariant, design:254-259).
+- **Internal order if split (§7):** C3a (planner: lineage+registry+freeze+flag+`target_planned`/`topology_frozen` telemetry; publisher/consumer untouched → planned routes visible, zero runtime effect) → C3b (publisher fan-out via C1a's publication plan + consumer wiring + `consume_batch`/`sip_consume_summary` telemetry + e2e/mgpu tests + runbook + doc update).
+- **C4** is a measurement/config PR (default flip + doc), not new machinery. **Track D** only if C4 criterion 4 fails for a valuable class.
+
+## 7. Size estimate
+
+Prod: lineage ~360 (incl. producer-shape predicate); registry+freeze ~420 (incl. spent/no-op re-finalize); sip-plan/ids/single_assignment ~180; generator/join-planner/engine/interface/ffi/extension wiring ~140; hash-join slots + gate construction at install + finalize-close + consumer hookup ~160; publisher fold-in ~70 (thinner than a parallel loop — rides C1a's variant vector); config/flag ~60; telemetry lines ~90; analyzer (py) ~180; docs ~180. **≈ 1.65k prod + 180 py + 180 doc.** Tests: lineage ~480; topology ~420; publish ~250; e2e ~450; mgpu ~120. **≈ 1.7k test.** Recommendation: **split into C3a/C3b as in §6** — C3a is mergeable with provably zero runtime effect (strongest reviewability), C3b carries all runtime risk; both stay behind the one flag.
+
+## 8. Risks (implementation-level) & mitigations
+
+1. **Registry lifecycle vs `sirius_engine::initialize`'s internal `reset()`** (`sirius_engine.cpp:141` runs *before* `initialize_internal` `:149`). If the registry were cleared in `reset()` — the natural-looking place — SIP becomes a **silent no-op on every path** with correct results, and a correctness-only gate never notices. Mitigation: `reset()` never touches `sip_registry`; release happens in `initialize_internal` immediately after `finalize` (§3.4); the e2e liveness test asserts the `topology_frozen` line (test 4); the merge gate names that assertion explicitly (§5).
+2. **Dangling operator pointers in the registry** (validation-only plans `sirius_context.cpp:843-863`, transparent replans, conversion failure). Mitigation: registry never dereferences physical pointers outside `finalize`; the first `finalize` clears all pending maps; the engine releases the registry right after freeze; plan-local ownership means discarded plans discard everything.
+3. **Logical-node address instability.** `plan_comparison_join` moves `op.conditions`/`filter_pushdown` (`sirius_plan_comparison_join.cpp:408-409,514`) but node objects stay alive through `create_plan`; the node-id map is used only during discovery+bind and destroyed at freeze. Guard: discovery captures everything it needs (bindings, types, ordinals) as values before recursion.
+4. **Ordinal-space confusion** (`duckdb_filter_ordinal` vs `condition_index` vs `sirius_key_ordinal` vs `probe_schema_ordinal`; `join_stats` is original-order — design:336-338 and MEMORY note; `right_key_col_indices` is additionally equality-ordinal-compacted, `sirius_physical_hash_join.cpp:290-341`, which is why freeze never indexes join internals at all — §3.4 step 5). Mitigation: strong types, all key metadata captured as values at discovery from C1a's extraction, and the exact alignment test (design:986-987).
+5. **Freeze/converter ordering drift** (someone moves the finalize call after `create_query`). Mitigation: `install_*` slots throw on assignment after the join has executed a task (cheap `finalized`/first-task flag assert), and `sip_consumer_plan()`/`sip_publish_targets()` are snapshot reads.
+6. **Publisher pushing zone maps into SIP channels** (would violate design:626-627 and the consumer's mask-only contract). Mitigation: the variant visitor pushes membership filters only for the join-probe alternative; test 3 asserts.
+7. **`register_producer` double-count / scan-elision interference.** SIP channels are registered only at freeze and never consulted by the converter's scan elision (`sirius_pipeline_converter.cpp:277-278`); scan channels untouched. Test 2 covers.
+8. **Delim/ASOF producers minting SIP routes.** Phase 1 *does* wire delim producers today (`sirius_plan_delim_join.cpp:73-76` delegates to `plan_comparison_join`; the `build_side_has_filter` comment at `sirius_plan_comparison_join.cpp:425` covers the delim case), so this is reachable, not "impossible by construction": without the §3.1 producer-shape check, routes would trace through DuckDB's delim machinery and freeze step 4 would meet the `RIGHT_DELIM_JOIN` build-wrapping pipeline shape (`sirius_pipeline_converter.cpp:1182-1197`). Mitigation: `sip_producer_shape_eligible` rejects `PRODUCER_SHAPE` at discovery; crossing STOP covers the consumer side; `bind_physical_join` stays lookup-miss-tolerant; lineage test pins both (test 1).
+9. **C1a seam drift.** §3.5 integrates with C1a's publication-plan variant vector; if C1a's landed shape differs, C3b rebases (coordination requirement in §3.5/§6) — C3b never re-targets the pre-C1a publisher internals, whose cited lines will not survive C1a.
+10. **Log-format drift breaking the experiment tooling.** Anchors + strict regexes land in the same PR as the emitters, `SHAPE_VERSION` bumped, format-warning counters (validators) surface drift in `_summary.json` (patterns contract, `tools/log_analyzer/patterns.py:1-17`); the analyzer's "flag-on but zero consume lines" warning catches mis-leveled runs (§3.8).
+11. **Flag-on plan-time cost** (extra full-tree walks per admitted producer). Bounded: discovery only runs with the flag on and only for joins with non-empty `probe_info`; walks are O(plan size × admitted producers); acceptable for an experiment flag — measure in C3 runs, memoize the GET-identity index per query if it shows up.
+
+---
+
+## Track D sketch (contingent — NOT planned in detail; design:662-757)
+
+**Admission** (post-freeze pass in the same registry, new `select_ordered_targets(...)`): among frozen SIP targets, admit at most one ORDERED target per runtime consumer pipeline; require the channel's single registered producer; validate acyclicity over the union of repository/data edges (`repository_wirings_`/`setup_pipeline_parents`, `sirius_pipeline_converter.cpp:1133-1147`), activation edges, and the synthetic hint path used to drive the producer; require every task-driving node in the consumer→producer activation closure runtime-unique, else demote to opportunistic; tie-break deterministically by estimated avoided probe work. The activation descriptor stores the producer's **build-side publication driver pipeline** (build PARTITION/CONCAT path — `dependencies[0]` chain, `sirius_pipeline_converter.cpp:1170-1171`), never producing join `P` itself, because `P`'s hint recursion can re-enter through `C` and manufacture a cycle (design:666-679).
+
+**Token**: one query-owned `sip_activation_token` per `(channel, consumer runtime pipeline)` with CAS FSM `IDLE→ARMED→QUEUED→CLAIMED | →DETACHED`; the check runs in the task creator **before hint resolution** (hints are stateful: `NOT_BUILT→SCHEDULING` on read, `sirius_physical_hash_join.cpp:486-547`), i.e., ahead of `get_next_task_hint`/input pop/reservation in `src/creator/task_creator.cpp`. Channel completion (`complete_once`: `OPEN→PUBLISHING→PUBLISHED|SEALED_EMPTY(reason)|FAILED|CANCELLED`, sealed at STANDARD/MIXED decision and at build-CONCAT completion — never join finalize) calls `release_once`; only `ARMED→QUEUED` enqueues; task creator CAS `QUEUED→CLAIMED` before dereferencing; wakeups queued only after channel/join/partition/pipeline locks are released (design:681-729).
+
+**Teardown** (error path, order fixed by design:740-750): stop task creation & reject activations → detach `IDLE/ARMED/QUEUED` tokens and invalidate queued requests → drain creator queue/claimed requests/executors/publishers → cancel open channels → remove edges/tokens → destroy pipelines/operators → restart creation only when both queues are empty. Files touched: `src/creator/task_creator.*`, `src/pipeline/sirius_pipeline.*`, query-owned activation registry, join mode/build-completion hooks; fault-injection suite per design:1042-1052 is a ship blocker for D.
+
+---
+
+## Review resolution
+
+| # | Finding | Resolution |
+|---|---|---|
+| 1 | BLOCKER — clearing the registry in `reset()` makes SIP a silent no-op (`reset()` at `sirius_engine.cpp:141` runs before `initialize_internal` `:149`) | Applied: `reset()` never touches `sip_registry`; the engine releases it in `initialize_internal` immediately after `finalize` (§3.3, §3.4); e2e liveness test asserts the `topology_frozen` line and the merge gate names it (§4 test 4, §5, risk 1). |
+| 2 | MAJOR — "DELIM plans reaching bind is impossible" false; delim producers are Phase-1-wired and reach `bind_physical_join` via `sirius_plan_delim_join.cpp:73-76` | Applied: new `sip_producer_shape_eligible` requires `node.type == LOGICAL_COMPARISON_JOIN` exactly; `DELIM_JOIN`/`ASOF_JOIN` rejected with new reason `PRODUCER_SHAPE` at discovery (§2, §3.1); lineage test pins both types (§4 test 1); risk claim rewritten honestly (risk 8). |
+| 3 | MAJOR — freeze TYPE_MISMATCH read protected, equality-ordinal-compacted join members | Applied: `key_type` (producer `build_type`) is captured at discovery from C1a's `dynamic_filter_key_plan` extraction value, and the consumer probe-column type is captured during the lineage trace; freeze validates types purely from captured values, no join accessor added (§2, §3.1 steps 3/5, §3.4 step 5, risk 4). The review's alternative (public `build_key_type` accessor) rejected as unnecessary given value capture. |
+| 4 | MAJOR — §3.5 wired fan-out into the pre-C1a publisher C1a replaces | Applied: §3.5 restated against C1a's unified `dynamic_filter_publication_plan` variant target vector (design:794-814) — freeze's `install_sip_publish_targets` entries are folded in as `join_probe_publish_target` variant alternatives before `create_query`; early-out/arity/per-target push come from the unified loop; dev-line ctor-span recipe and `:83-91`/`:121-126`/`:305-337` line surgery dropped (kept only as "code C1a rewrites" documentation); explicit C3b↔C1a coordination requirement added (§3.5, §6, risk 9). |
+| 5 | MINOR — lazy gate construction on first probe task is a data race (concurrent probe tasks, `sirius_physical_hash_join.cpp:510-517`) | Applied: gate state constructed inside `install_sip_consumer_plan` at freeze, single-threaded, pre-`create_query`; runtime only mutates per-batch stats (§2, §3.6). |
+| 6 | MINOR — §3.3 misattributed the assignment site; member visibility | Applied: function corrected to `sirius_interface::sirius_pending_statement_internal` (`sirius_interface.cpp:150-177`; `:177` engine.initialize; `sirius_execute_query` `:214-240` delegates); `sip_registry` declared public without trailing underscore to match the engine's public-member style (friends are pipeline classes only, `sirius_engine.hpp:55-58`) (§3.3). |
+| 7 | MINOR — `require_two_gpus` citation | Applied: `mgpu_test_utils.hpp:144` (`mgpu_env_params` at `:62`) (§4 test 5). |
+| 8 | MINOR — prepared/cached plan re-execution vs finalize-once | Applied: chose **defined per-plan-instance no-op** (not single-use verification): registry keeps spent flag + first-call stats, re-emits `topology_frozen reused=true`, installs nothing; rationale: `gpu_prepared` is cached (`sirius_extension.cpp:601-605`) and re-executable, and channel-content reuse matches Phase 1's plan-time scan-channel lifetime, so no new hazard class; topology test covers no-op re-finalize and e2e executes a prepared statement twice (§2, §3.4, §4 tests 2/4). |
+| 9 | MINOR — two loose citations | Applied: producer-subset invariant now cited as an inference from design:964-966 (C1e), not design:72-79 (§3.2); `key_casts`/`right_key_col_indices` cited at `hpp:212`/`:225` (§2, §3.4). |
+| 10 | MINOR — runbook omitted the log level coverage depends on | Applied: per-pass log levels are protocol (timing passes `SIRIUS_LOG_LEVEL=info`, coverage-detail passes `trace`, separate and non-timed); added an INFO `[dynf_summary] sip_consume_summary` per-endpoint aggregate (with before-first-filter counters) so coverage (b),(d),(e) derive from INFO timing runs; analyzer warns on flag-on runs with zero consume lines (§3.8). Prefixes also aligned to conventions: `[dynf_summary]` for machine-parsed per-query INFO lines, file-native `[sirius_physical_hash_join]` for publisher/consumer lines. |


### PR DESCRIPTION
This PR removes the build-task prioritization that was integrated into the scheduler by #794. The code was predicated on an assumption which is false: that probe scan tasks can be scheduled before their corresponding build concat operator completes. Moreover, the code introduces performance regression, as documented in #1124.

Fixes #1014