### PR TITLE
harden the coalescer-direct cached serving path (#819 PR2-lite)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,6 +607,7 @@ set(TEST_SOURCES
     test/cpp/io/rest/test_rest_reactor.cpp
     test/cpp/scan_manager/test_s3_routing_cutover.cpp
     test/cpp/scan_manager/test_pin_table_multi_gpu.cpp
+    test/cpp/scan_manager/test_cached_serving_hardening.cpp
     test/cpp/operator/test_physical_grouped_aggregate_merge_mgpu.cpp
     test/cpp/operator/test_physical_hash_join_mgpu.cpp
     test/cpp/operator/test_physical_order_mgpu.cpp

--- a/src/include/scan_manager/load_balancing_scan_batch_coalescer.hpp
+++ b/src/include/scan_manager/load_balancing_scan_batch_coalescer.hpp
@@ -122,6 +122,19 @@ class load_balancing_scan_batch_coalescer {
   std::function<void(exec::try_t<std::unique_ptr<op::scan::scan_info>>&&)>
   get_split_provider_bridge(op::scan::sirius_gpu_scan_operator* scan_op);
 
+  /// Drain @p provider into @p connector: pull batches until the provider is
+  /// exhausted (or @p stop fires), wrapping each as a resident
+  /// scan_operator_input. Always closes the connector on exit — with the
+  /// pending exception when the provider throws, so the consumer's
+  /// get_next_split() rethrows a clean query error instead of blocking
+  /// forever (the dispatcher swallows task exceptions, so an unclosed
+  /// connector is a silent query hang). Static and public so the drain
+  /// behavior is unit-testable against a fake provider; production use is
+  /// the sequencer's cached-slot path.
+  static void drain_cached_provider(databatch_provider& provider,
+                                    split_connector& connector,
+                                    std::stop_token const& stop);
+
   /// Spawn the sequencer task on @p dispatcher.  The dispatcher must
   /// expose @c enqueue(callable) and inject a @c std::stop_token when
   /// the callable asks for one (e.g. @c scoped_dispatcher).  Call once
@@ -141,9 +154,9 @@ class load_balancing_scan_batch_coalescer {
 
   void process_cached_entries(metadata_processing_state& state, std::stop_token const& stop);
 
-  /// unique_ptr storage: the slot contains a semaphore and a moodycamel
-  /// queue, both of which are non-movable, so we need stable addresses
-  /// in the vector.
+  /// shared_ptr storage: the slot contains a semaphore and a moodycamel
+  /// queue, both of which are non-movable, so slots need stable addresses —
+  /// and the split-provider bridge lambda shares ownership of its slot.
   std::vector<std::size_t> _pipeline_order;
   std::unordered_map<std::size_t, std::shared_ptr<metadata_processing_state>> _slots;
 };

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -150,6 +150,22 @@ struct pinned_entry {
   std::size_t num_rows{0};
 };
 
+/// Validate that @p entry can serve @p selected_columns (positions into
+/// @c entry.cache_info.column_ids) without truncation. GPU tier: every
+/// selected column must be present in @c data_batches_by_column with exactly
+/// n_chunks non-null chunks, and @c chunk_memory_spaces must cover every chunk
+/// with non-null spaces. HOST tier: every host chunk must be non-null.
+/// Zero-chunk entries are legitimate and pass. Throws std::runtime_error
+/// naming the offending column/condition.
+///
+/// Serve-time defense against malformed entries: the cached serving loop reads
+/// a nullptr batch as end-of-stream, so a column with fewer chunks (or a null
+/// chunk) would silently end the scan early — fewer rows than requested, no
+/// error. @ref sirius_scan_manager::try_assign_cached_entries calls this before
+/// attaching the provider and converts a throw into a disk-read fallback.
+void validate_pinned_entry_for_serving(pinned_entry const& entry,
+                                       std::span<std::size_t const> selected_columns);
+
 /**
  * @brief Bind-time result of @ref sirius_scan_manager::describe_parquet.
  *

--- a/src/scan_manager/load_balancing_scan_batch_coalescer.cpp
+++ b/src/scan_manager/load_balancing_scan_batch_coalescer.cpp
@@ -161,19 +161,29 @@ void load_balancing_scan_batch_coalescer::process_provider_inputs(metadata_proce
   state.connector->close();
 }
 
-void load_balancing_scan_batch_coalescer::process_cached_entries(
-  metadata_processing_state& state, [[maybe_unused]] std::stop_token const& stop)
+void load_balancing_scan_batch_coalescer::process_cached_entries(metadata_processing_state& state,
+                                                                 std::stop_token const& stop)
 {
-  bool is_closed = false;
-  while (!is_closed) {
-    auto databatch = state.batch_provider->get_next_batch();
-    is_closed      = databatch == nullptr;
-    if (!is_closed) {
-      auto op_data = std::make_unique<op::scan::scan_operator_input>(std::move(databatch));
-      state.connector->push_split(std::move(op_data));
+  drain_cached_provider(*state.batch_provider, *state.connector, stop);
+}
+
+void load_balancing_scan_batch_coalescer::drain_cached_provider(databatch_provider& provider,
+                                                                split_connector& connector,
+                                                                std::stop_token const& stop)
+{
+  try {
+    while (!stop.stop_requested()) {
+      auto databatch = provider.get_next_batch();
+      if (!databatch) { break; }
+      connector.push_split(std::make_unique<op::scan::scan_operator_input>(std::move(databatch)));
     }
+    connector.close();
+  } catch (...) {
+    // Surface the provider failure to the consumer: get_next_split() rethrows
+    // once the queue drains. Without this close the connector never closes —
+    // the dispatcher swallows task exceptions — and the query hangs silently.
+    connector.close(std::current_exception());
   }
-  state.connector->close();
 }
 
 }  // namespace sirius::scan_manager

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -721,6 +721,45 @@ void sirius_scan_manager::visit_pinned_entries(
   }
 }
 
+void validate_pinned_entry_for_serving(pinned_entry const& entry,
+                                       std::span<std::size_t const> selected_columns)
+{
+  auto const& entry_column_names = entry.cache_info.column_names();
+
+  if (entry.tier == cucascade::memory::Tier::GPU) {
+    if (entry.data_batches_by_column.empty()) { return; }  // legitimate zero-chunk entry
+    auto const n_chunks = entry.data_batches_by_column.begin()->second.size();
+    if (entry.chunk_memory_spaces.size() != n_chunks) {
+      throw std::runtime_error(
+        "pinned entry's chunk_memory_spaces does not cover every chunk of the entry");
+    }
+    for (auto const* space : entry.chunk_memory_spaces) {
+      if (!space) { throw std::runtime_error("pinned entry has a null chunk memory_space"); }
+    }
+    for (auto idx : selected_columns) {
+      auto const& name = entry_column_names.at(idx);
+      auto it          = entry.data_batches_by_column.find(name);
+      if (it == entry.data_batches_by_column.end() || it->second.size() != n_chunks) {
+        throw std::runtime_error("pinned column '" + name +
+                                 "' does not cover every chunk of the entry");
+      }
+      for (auto const& chunk : it->second) {
+        if (!chunk) { throw std::runtime_error("pinned column '" + name + "' has a null chunk"); }
+      }
+    }
+    return;
+  }
+
+  if (entry.tier == cucascade::memory::Tier::HOST) {
+    for (auto const& chunk : entry.host_chunks) {
+      if (!chunk) { throw std::runtime_error("pinned entry has a null host chunk"); }
+    }
+    return;
+  }
+
+  throw std::runtime_error("pinned entry has an unsupported tier");
+}
+
 bool sirius_scan_manager::try_assign_cached_entries(op::scan::sirius_gpu_scan_operator* op)
 {
   const auto& table_info = op->get_ingestible().table_info();
@@ -736,6 +775,11 @@ bool sirius_scan_manager::try_assign_cached_entries(op::scan::sirius_gpu_scan_op
       auto cols = gather_by_primary_index(entry.cache_info.column_ids,
                                           op->get_ingestible().materialized_column_order());
       if (cols.empty()) { continue; }  // defensive: materialized set must be a cache subset
+      // Serve-time defense: a malformed entry would end the cached batch stream
+      // early (nullptr mid-stream reads as end-of-stream) and silently truncate
+      // the scan; validate up front so it throws here and the catch below falls
+      // back to the disk read instead.
+      validate_pinned_entry_for_serving(entry, cols);
       auto provider = make_provider_for_pinned_entry(entry, cols, op->batch_telemetry());
       _metadata_processor->use_cached_entries_for_pipeline(op, std::move(provider));
       spdlog::info("[sirius_scan_manager] assigned pinned entry '{}' to operator '{}'",
@@ -743,6 +787,12 @@ bool sirius_scan_manager::try_assign_cached_entries(op::scan::sirius_gpu_scan_op
                    op->get_operator_id());
       return true;
     }
+  } catch (std::exception const& e) {
+    spdlog::error(
+      "[sirius_scan_manager] error while trying to assign cached entries to "
+      "operator '{}': {}",
+      op->get_operator_id(),
+      e.what());
   } catch (...) {
     spdlog::error(
       "[sirius_scan_manager] error while trying to assign cached entries to "

--- a/test/cpp/scan_manager/test_cached_serving_hardening.cpp
+++ b/test/cpp/scan_manager/test_cached_serving_hardening.cpp
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// #819 PR2-lite: hardening gates for the coalescer-direct cached serving path.
+//
+// Two failure modes on this path used to be silent:
+//   - a throwing databatch_provider escaped into the dispatcher (which
+//     swallows task exceptions), leaving the operator's split_connector never
+//     closed — the consumer blocked in get_next_split() forever (silent query
+//     hang);
+//   - a malformed pinned entry (per-column chunk counts disagreeing, short
+//     chunk_memory_spaces, null chunks) made the cached provider return
+//     nullptr mid-stream, which the drain loop reads as end-of-stream — the
+//     query completed on FEWER rows than requested (silent truncation).
+//
+// Gates: load_balancing_scan_batch_coalescer::drain_cached_provider
+// (forward-then-close; provider throw -> close(exception) -> consumer
+// rethrows; pre-stopped token -> close without draining) and
+// validate_pinned_entry_for_serving (malformed entries throw so
+// try_assign_cached_entries falls back to the disk read; well-formed and
+// zero-chunk entries pass).
+
+#include "operator/operator_test_utils.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
+
+#include <rmm/cuda_stream.hpp>
+
+#include <cuda_runtime.h>
+
+#include <catch.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/memory/memory_space.hpp>
+#include <data/data_batch_utils.hpp>
+#include <data/sirius_converter_registry.hpp>
+#include <op/scan/sirius_gpu_scan_operator_data.hpp>
+#include <scan_manager/load_balancing_scan_batch_coalescer.hpp>
+#include <scan_manager/sirius_scan_manager.hpp>
+#include <scan_manager/split_connector.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <stop_token>
+#include <string>
+#include <vector>
+
+using sirius::scan_manager::databatch_provider;
+using sirius::scan_manager::load_balancing_scan_batch_coalescer;
+using sirius::scan_manager::pinned_entry;
+using sirius::scan_manager::split_connector;
+using sirius::scan_manager::validate_pinned_entry_for_serving;
+
+namespace {
+
+// Shared test environment: memory manager (+ converter registry) initialized
+// once for every gate in this file. The converter needs a non-default stream
+// (same constraint test_convertible_data_batch documents).
+struct test_env {
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> mgr;
+  cucascade::memory::memory_space* gpu_space;
+  cucascade::memory::memory_space* host_space;
+  rmm::cuda_stream conv_stream;
+
+  test_env()
+    : mgr(sirius::test::operator_utils::initialize_memory_manager()),
+      gpu_space(mgr->get_memory_space(cucascade::memory::Tier::GPU, 0)),
+      host_space(mgr->get_memory_space(cucascade::memory::Tier::HOST, 0)),
+      conv_stream()
+  {
+  }
+
+  rmm::cuda_stream_view stream() { return conv_stream.view(); }
+};
+
+test_env& env()
+{
+  static test_env e;
+  return e;
+}
+
+/// Deterministic per-cell value so a chunk/column/row mixup fails loudly.
+int32_t cell(std::size_t chunk, std::size_t col, std::size_t row)
+{
+  return static_cast<int32_t>(1000 * chunk + 100 * col + row);
+}
+
+std::shared_ptr<cudf::column> make_gpu_column(cucascade::memory::memory_space& space,
+                                              std::vector<int32_t> const& values)
+{
+  auto mr     = sirius::test::operator_utils::get_resource_ref(space);
+  auto stream = sirius::test::operator_utils::default_stream();
+  auto col    = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                       static_cast<cudf::size_type>(values.size()),
+                                       cudf::mask_state::UNALLOCATED,
+                                       stream,
+                                       mr);
+  cudaMemcpy(col->mutable_view().data<int32_t>(),
+             values.data(),
+             sizeof(int32_t) * values.size(),
+             cudaMemcpyHostToDevice);
+  return std::shared_ptr<cudf::column>(std::move(col));
+}
+
+/// GPU-tier pinned entry with columns {k, v, w} x @p n_chunks chunks of
+/// @p rows rows, every chunk placed in @p space.
+pinned_entry make_gpu_entry(cucascade::memory::memory_space& space,
+                            std::size_t n_chunks,
+                            std::size_t rows)
+{
+  pinned_entry entry;
+  entry.cache_info.names = {"k", "v", "w"};
+  entry.tier             = cucascade::memory::Tier::GPU;
+  entry.memory_space     = &space;
+  for (std::size_t c = 0; c < n_chunks; ++c) {
+    entry.chunk_memory_spaces.push_back(&space);
+    for (std::size_t col = 0; col < entry.cache_info.names.size(); ++col) {
+      std::vector<int32_t> values(rows);
+      for (std::size_t r = 0; r < rows; ++r) {
+        values[r] = cell(c, col, r);
+      }
+      entry.data_batches_by_column[entry.cache_info.names[col]].push_back(
+        make_gpu_column(space, values));
+    }
+  }
+  entry.num_rows = n_chunks * rows;
+  return entry;
+}
+
+/// HOST-tier pinned entry with columns {k, v} x @p n_chunks chunks, built the
+/// way the pin path builds them (GPU table -> converter -> host chunk).
+pinned_entry make_host_entry(test_env& e, std::size_t n_chunks, std::size_t rows)
+{
+  pinned_entry entry;
+  entry.cache_info.names = {"k", "v"};
+  entry.tier             = cucascade::memory::Tier::HOST;
+  entry.memory_space     = e.host_space;
+
+  auto& registry = sirius::converter_registry::get();
+  for (std::size_t c = 0; c < n_chunks; ++c) {
+    std::vector<std::unique_ptr<cudf::column>> cols;
+    for (std::size_t col = 0; col < entry.cache_info.names.size(); ++col) {
+      std::vector<int32_t> values(rows);
+      for (std::size_t r = 0; r < rows; ++r) {
+        values[r] = cell(c, col, r);
+      }
+      auto shared = make_gpu_column(*e.gpu_space, values);
+      cols.push_back(std::make_unique<cudf::column>(
+        shared->view(), e.stream(), e.gpu_space->get_default_allocator()));
+    }
+    cucascade::gpu_table_representation gpu_repr(
+      std::make_unique<cudf::table>(std::move(cols)), *e.gpu_space, e.stream());
+    auto host_repr =
+      registry.convert<cucascade::host_data_representation>(gpu_repr, e.host_space, e.stream());
+    e.stream().synchronize();
+    entry.host_chunks.emplace_back(std::move(host_repr));
+  }
+  entry.num_rows = n_chunks * rows;
+  return entry;
+}
+
+/// One-column resident GPU batch — payload for the fake providers below.
+std::shared_ptr<cucascade::data_batch> make_test_batch(test_env& e, std::size_t rows)
+{
+  auto col = make_gpu_column(*e.gpu_space, std::vector<int32_t>(rows, 7));
+  std::vector<std::shared_ptr<cudf::column>> columns{col};
+  std::vector<cudf::column_view> views{col->view()};
+  auto const alloc_size = col->alloc_size();
+  auto repr             = std::make_unique<cucascade::gpu_table_representation>(
+    cudf::table_view(views), std::move(columns), alloc_size, *e.gpu_space, rmm::cuda_stream_view{});
+  return cucascade::data_batch::make(sirius::get_next_batch_id(), std::move(repr));
+}
+
+/// Serves its scripted batches in order, then either ends the stream
+/// (nullptr) or throws — the two provider behaviors the drain must handle.
+struct scripted_provider final : databatch_provider {
+  std::vector<std::shared_ptr<cucascade::data_batch>> batches;
+  std::size_t served{0};
+  bool throw_when_exhausted{false};
+
+  std::shared_ptr<cucascade::data_batch> get_next_batch() override
+  {
+    if (served < batches.size()) { return batches[served++]; }
+    if (throw_when_exhausted) { throw std::runtime_error("provider blew up mid-stream"); }
+    return nullptr;
+  }
+};
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// drain_cached_provider gates
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("drain_cached_provider forwards every batch then closes",
+          "[cached_serving][scan_manager]")
+{
+  auto& e = env();
+  scripted_provider provider;
+  provider.batches = {make_test_batch(e, 4), make_test_batch(e, 4), make_test_batch(e, 4)};
+
+  split_connector connector;
+  std::stop_source stop;
+  load_balancing_scan_batch_coalescer::drain_cached_provider(provider, connector, stop.get_token());
+
+  for (int i = 0; i < 3; ++i) {
+    auto split = connector.get_next_split();
+    REQUIRE(split.has_value());
+    auto* input = dynamic_cast<sirius::op::scan::scan_operator_input*>(split->get());
+    REQUIRE(input != nullptr);
+    REQUIRE(input->is_resident());
+  }
+  REQUIRE_FALSE(connector.get_next_split().has_value());  // closed and drained
+}
+
+TEST_CASE("drain_cached_provider surfaces a provider exception instead of hanging",
+          "[cached_serving][scan_manager]")
+{
+  auto& e = env();
+  scripted_provider provider;
+  provider.batches              = {make_test_batch(e, 4)};
+  provider.throw_when_exhausted = true;
+
+  split_connector connector;
+  std::stop_source stop;
+  // Must not propagate: the dispatcher would swallow it and leave the
+  // connector open forever (the old silent-hang bug).
+  REQUIRE_NOTHROW(load_balancing_scan_batch_coalescer::drain_cached_provider(
+    provider, connector, stop.get_token()));
+
+  // The stored error takes precedence over queued splits: every consumer
+  // pull now rethrows the producer failure (instead of a partial stream
+  // followed by an eternal block — the old silent-hang bug).
+  REQUIRE_THROWS_AS(connector.get_next_split(), std::runtime_error);
+  REQUIRE_THROWS_AS(connector.get_next_split(), std::runtime_error);
+}
+
+TEST_CASE("drain_cached_provider honors a pre-stopped token", "[cached_serving][scan_manager]")
+{
+  auto& e = env();
+  scripted_provider provider;
+  provider.batches = {make_test_batch(e, 4), make_test_batch(e, 4)};
+
+  split_connector connector;
+  std::stop_source stop;
+  stop.request_stop();
+  load_balancing_scan_batch_coalescer::drain_cached_provider(provider, connector, stop.get_token());
+
+  REQUIRE(provider.served == 0);                          // nothing pulled after stop
+  REQUIRE_FALSE(connector.get_next_split().has_value());  // still closed: consumer unblocked
+}
+
+//===----------------------------------------------------------------------===//
+// validate_pinned_entry_for_serving gates
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("validate_pinned_entry_for_serving accepts well-formed and zero-chunk entries",
+          "[cached_serving][scan_manager]")
+{
+  auto& e = env();
+
+  SECTION("well-formed GPU entry")
+  {
+    auto entry = make_gpu_entry(*e.gpu_space, 3, 4);
+    REQUIRE_NOTHROW(validate_pinned_entry_for_serving(entry, std::vector<std::size_t>{0, 1, 2}));
+  }
+
+  SECTION("zero-chunk GPU entry")
+  {
+    pinned_entry entry;
+    entry.cache_info.names = {"k"};
+    entry.tier             = cucascade::memory::Tier::GPU;
+    entry.memory_space     = e.gpu_space;
+    REQUIRE_NOTHROW(validate_pinned_entry_for_serving(entry, std::vector<std::size_t>{0}));
+  }
+
+  SECTION("well-formed HOST entry")
+  {
+    auto entry = make_host_entry(e, 2, 4);
+    REQUIRE_NOTHROW(validate_pinned_entry_for_serving(entry, std::vector<std::size_t>{0, 1}));
+  }
+}
+
+TEST_CASE("validate_pinned_entry_for_serving refuses malformed entries",
+          "[cached_serving][scan_manager]")
+{
+  auto& e = env();
+
+  SECTION("per-column chunk counts disagree")
+  {
+    auto entry = make_gpu_entry(*e.gpu_space, 3, 4);
+    entry.data_batches_by_column["v"].pop_back();  // v now has 2 chunks, k/w have 3
+    REQUIRE_THROWS_AS(validate_pinned_entry_for_serving(entry, std::vector<std::size_t>{0, 1, 2}),
+                      std::runtime_error);
+  }
+
+  SECTION("selected column missing from the entry's storage")
+  {
+    auto entry = make_gpu_entry(*e.gpu_space, 2, 4);
+    entry.data_batches_by_column.erase("w");
+    REQUIRE_THROWS_AS(validate_pinned_entry_for_serving(entry, std::vector<std::size_t>{2}),
+                      std::runtime_error);
+  }
+
+  SECTION("chunk_memory_spaces does not cover every chunk")
+  {
+    auto entry = make_gpu_entry(*e.gpu_space, 3, 4);
+    entry.chunk_memory_spaces.resize(1);
+    REQUIRE_THROWS_AS(validate_pinned_entry_for_serving(entry, std::vector<std::size_t>{0}),
+                      std::runtime_error);
+  }
+
+  SECTION("null chunk memory_space")
+  {
+    auto entry                   = make_gpu_entry(*e.gpu_space, 2, 4);
+    entry.chunk_memory_spaces[1] = nullptr;
+    REQUIRE_THROWS_AS(validate_pinned_entry_for_serving(entry, std::vector<std::size_t>{0}),
+                      std::runtime_error);
+  }
+
+  SECTION("null GPU chunk")
+  {
+    auto entry                           = make_gpu_entry(*e.gpu_space, 2, 4);
+    entry.data_batches_by_column["k"][1] = nullptr;
+    REQUIRE_THROWS_AS(validate_pinned_entry_for_serving(entry, std::vector<std::size_t>{0}),
+                      std::runtime_error);
+  }
+
+  SECTION("null host chunk")
+  {
+    auto entry           = make_host_entry(e, 2, 4);
+    entry.host_chunks[1] = nullptr;
+    REQUIRE_THROWS_AS(validate_pinned_entry_for_serving(entry, std::vector<std::size_t>{0}),
+                      std::runtime_error);
+  }
+}


### PR DESCRIPTION
Part of #819 (**PR2-lite** — replaces the serving reorg previously drafted in #1126, closed unmerged: the MVCC CPU work moves to prepare-time dispatcher jobs and the serving path stays coalescer-direct; see #1126's closure comment and #819's updated design).

## Summary

Three pre-existing bugs in the pinned-table cached serving path — they affect **all** pinned serving today (parquet + duckdb, GPU + host tiers), independent of MVCC:

- **Silent query hang on provider failure.** `process_cached_entries` had no try/catch: a throwing `databatch_provider` escaped into the dispatcher (which swallows task exceptions), the operator's `split_connector` never closed, and the consumer blocked in `get_next_split()` forever. The drain is restructured into a testable public static `load_balancing_scan_batch_coalescer::drain_cached_provider(provider, connector, stop)` whose `catch(...)` does `connector.close(current_exception())` — the consumer now rethrows a clean query error, mirroring `process_provider_inputs`' hardening on the disk path.
- **Silent truncation on malformed entries.** The cached provider returns `nullptr` mid-stream when a selected column has fewer chunks than the others, `chunk_memory_spaces` is short/null, or a chunk is null — indistinguishable from end-of-stream, so the query completed on fewer rows than requested with no error. New `validate_pinned_entry_for_serving` runs in `try_assign_cached_entries` before the provider attaches: a malformed entry throws, the existing catch logs the reason (`e.what()` was previously dropped) and falls back to the disk read.
- **Ignored stop token.** The cached drain took its stop token `[[maybe_unused]]`; it now stops between batches and still closes the connector so consumers unblock during teardown.

Drive-by: the coalescer header's stale slot-storage comment (`unique_ptr` → actual `shared_ptr`, which the bridge lambda relies on).

**Deliberately not fixed** (documented in #819 → Known hazards): the unpin-mid-query dangling reference (`cached_databatch_provider` holds `const pinned_entry&`; `_pinned_entries` is mutated by `unpin_table` without the query-lifecycle mutex) — a separate follow-up.

## Test plan

- [x] New `[cached_serving]` suite (5 cases, 24 assertions): drain forwards-then-closes; provider throw → consumer rethrows (no hang); pre-stopped token → closed without draining; validator accepts well-formed + zero-chunk entries and refuses six malformed shapes (chunk-count mismatch, missing selected column, short/null memory spaces, null GPU/host chunks).
- [x] Pin regression suites pass unchanged: `[pin_table]` (394 assertions incl. the column-order regression), `[pin_table_host]`, `[pin_table_duckdb]`, `[pin_table_duckdb_host]`, `[pin_table_cols_subset]`, `[pin_table_host_streaming]`.
- [x] `pre-commit` clean on touched files.
- [ ] `[pin_mgpu]` on a 2-GPU box (kept as the undraft gate per convention; note this change touches no placement logic — balancer stamping and memory_space routing are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)