### PR TITLE
refactor(log): route all direct spdlog call sites through SIRIUS_LOG_* macros

### DIFF
--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -87,9 +87,9 @@ void downgrade_executor::start()
       // across contexts. Lambda is noexcept, so check inline.
       cudaError_t err = cudaSetDevice(device_id);
       if (err != cudaSuccess) {
-        spdlog::error("downgrade_executor per-thread init: cudaSetDevice({}) failed: {}",
-                      device_id,
-                      cudaGetErrorString(err));
+        SIRIUS_LOG_ERROR("downgrade_executor per-thread init: cudaSetDevice({}) failed: {}",
+                         device_id,
+                         cudaGetErrorString(err));
       }
     };
   }

--- a/src/include/log/logging.hpp
+++ b/src/include/log/logging.hpp
@@ -88,6 +88,11 @@ inline void InitGlobalLogger(const std::string& log_level_str,
   spdlog::flush_every(std::chrono::seconds(flush_seconds));
 }
 
+inline void FlushGlobalLogger()
+{
+  if (auto* logger = spdlog::default_logger_raw()) { logger->flush(); }
+}
+
 inline void SetGlobalLogFlush(int flush_seconds)
 {
   spdlog::flush_every(std::chrono::seconds(flush_seconds));

--- a/src/io/cache/prefetching_cache.cpp
+++ b/src/io/cache/prefetching_cache.cpp
@@ -22,6 +22,7 @@
 #include "io/cache/types.hpp"
 #include "io/io_context.hpp"
 #include "io/types.hpp"
+#include "log/logging.hpp"
 #include "memory/topology_index.hpp"
 #include "util/error_utils.hpp"
 
@@ -31,7 +32,6 @@
 #include <cuda_runtime.h>
 
 #include <spdlog/fmt/fmt.h>
-#include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <array>
@@ -674,7 +674,7 @@ void prefetching_cache::prepare_for_query(const sirius::planner::query& query) n
 void prefetching_cache::prepare_loop(const std::stop_token& st)
 {
   std::stop_callback cb(st, [this]() {
-    spdlog::trace("prefetching_cache: prepare_loop received stop request, unblocking queue");
+    SIRIUS_LOG_TRACE("prefetching_cache: prepare_loop received stop request, unblocking queue");
     _preparation_queue.enqueue(nullptr);  // unblock the worker if it's waiting on an empty queueue
   });
 
@@ -716,7 +716,7 @@ void prefetching_cache::prepare_loop(const std::stop_token& st)
         c->numa_node = numa_allocated;
         if (!c->state.mark_allocated()) {
           buffers.push_back(buffer);  // return the buffer to the pool
-          spdlog::error(
+          SIRIUS_LOG_ERROR(
             "prefetching_cache: chunk at offset {} was marked queued but failed to mark "
             "allocated",
             c->offset);
@@ -744,7 +744,7 @@ void prefetching_cache::prepare_loop(const std::stop_token& st)
 void prefetching_cache::prefetch_loop(const std::stop_token& st)
 {
   std::stop_callback cb(st, [this]() {
-    spdlog::trace("prefetching_cache: prefetch_loop received stop request, unblocking queue");
+    SIRIUS_LOG_TRACE("prefetching_cache: prefetch_loop received stop request, unblocking queue");
     _prefetch_queue.enqueue(nullptr);  // unblock the worker if it's waiting on an empty queueue
   });
   while (!_shutting_down && !st.stop_requested()) {
@@ -795,7 +795,7 @@ void prefetching_cache::prefetch_loop(const std::stop_token& st)
 void prefetching_cache::evict_loop(const std::stop_token& st)
 {
   std::stop_callback cb(st, [this]() {
-    spdlog::trace("prefetching_cache: evict_loop received stop request, unblocking queue");
+    SIRIUS_LOG_TRACE("prefetching_cache: evict_loop received stop request, unblocking queue");
     _eviction_queue.enqueue(nullptr);  // unblock the worker if it's waiting on an empty queueue
   });
 

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -24,7 +24,7 @@
 
 #include <rmm/cuda_device.hpp>
 
-#include <spdlog/spdlog.h>
+#include <spdlog/fmt/fmt.h>
 #include <sys/epoll.h>
 #include <unistd.h>
 
@@ -1640,7 +1640,7 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
         pc.event->synchronize();
         pc.manager->chunk_complete(pc.bytes);
       } catch (const std::exception& e) {
-        spdlog::error("rest_reactor: copy-event synchronize on shutdown failed: {}", e.what());
+        SIRIUS_LOG_ERROR("rest_reactor: copy-event synchronize on shutdown failed: {}", e.what());
         pc.manager->report_error(std::make_exception_ptr(std::runtime_error(
           std::string("rest_reactor: device H2D copy failed on shutdown: ") + e.what())));
       }
@@ -1667,7 +1667,7 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
     }
     ready.clear();
   } catch (const std::exception& e) {
-    spdlog::error("rest_reactor worker_loop: {}", e.what());
+    SIRIUS_LOG_ERROR("rest_reactor worker_loop: {}", e.what());
   }
 
   std::unique_ptr<rest_chunked_rx_request> dr;

--- a/src/io/sirius_datasource.cpp
+++ b/src/io/sirius_datasource.cpp
@@ -199,7 +199,7 @@ void sirius_datasource::fadvise(std::span<const cudf::io::text::byte_range_info>
   // worker drops the old request and we don't leak both into the cache.
   if (_prefetch_handle) {
     if (_prefetch_handle.is_active()) {
-      spdlog::warn(
+      SIRIUS_LOG_WARN(
         "sirius_datasource::fadvise: a prefetching_handle was already stored on "
         "this datasource (path={}); cancelling the stale request.  Each scan "
         "should own a unique datasource.",

--- a/src/io/uring/uring_reactor.cpp
+++ b/src/io/uring/uring_reactor.cpp
@@ -399,11 +399,11 @@ unique_ring_ptr make_ring(unsigned depth)
   p.flags |= IORING_SETUP_COOP_TASKRUN | IORING_SETUP_DEFER_TASKRUN;
   int rc = io_uring_queue_init_params(depth, r.get(), &p);
   if (rc == 0) {
-    spdlog::trace("uring_device_reactor: ring using SINGLE_ISSUER|DEFER_TASKRUN, entries={}",
-                  depth);
+    SIRIUS_LOG_TRACE("uring_device_reactor: ring using SINGLE_ISSUER|DEFER_TASKRUN, entries={}",
+                     depth);
     return unique_ring_ptr{r.release()};
   }
-  spdlog::trace(
+  SIRIUS_LOG_TRACE(
     "uring_device_reactor: SINGLE_ISSUER|DEFER_TASKRUN unsupported "
     "({}), falling back to plain flags",
     strerror(-rc));
@@ -411,7 +411,7 @@ unique_ring_ptr make_ring(unsigned depth)
   auto r2 = std::make_unique<io_uring>();
   int rc2 = io_uring_queue_init(depth, r2.get(), 0);
   if (rc2 < 0) throw std::runtime_error("uring_reactor: ring init: " + std::string(strerror(-rc2)));
-  spdlog::trace("uring_reactor: ring using plain flags, entries={}", depth);
+  SIRIUS_LOG_TRACE("uring_reactor: ring using plain flags, entries={}", depth);
   return unique_ring_ptr{r2.release()};
 }
 
@@ -427,8 +427,9 @@ struct unique_ring {
   [[nodiscard]] bool register_buffers(std::span<iovec> iovecs)
   {
     if (int rc = io_uring_register_buffers(ring.get(), iovecs.data(), iovecs.size()); rc < 0) {
-      spdlog::warn("uring_reactor: io_uring_register_buffers failed ({}); fixed buffers disabled",
-                   strerror(-rc));
+      SIRIUS_LOG_WARN(
+        "uring_reactor: io_uring_register_buffers failed ({}); fixed buffers disabled",
+        strerror(-rc));
       return false;
     }
     return true;
@@ -851,7 +852,7 @@ void uring_reactor::worker_loop(const std::stop_token& stop_token)
   static constexpr std::chrono::milliseconds SHUTDOWN_POLL_MS{100};
 
   std::stop_callback cb(stop_token, [this] {
-    spdlog::trace("uring_reactor worker_loop: stop requested");
+    SIRIUS_LOG_TRACE("uring_reactor worker_loop: stop requested");
     _requests.enqueue(nullptr);  // unblock the worker if it's waiting on an empty queue
   });
 
@@ -979,7 +980,7 @@ void uring_reactor::worker_loop(const std::stop_token& stop_token)
         // resubmit — register_bound_buffer re-preps it as a plain read.  No
         // bytes landed, so the resubmit reads the whole range from scratch.
         if (s.used_fixed_buffer && is_fixed_buffer_error(errc)) {
-          spdlog::warn(
+          SIRIUS_LOG_WARN(
             "uring_reactor: fixed-buffer read failed on slot {} ({}); "
             "falling back to plain read",
             si,
@@ -1040,7 +1041,8 @@ void uring_reactor::worker_loop(const std::stop_token& stop_token)
     while (inflight > 0) {
       auto s = ring.wait_for(SHUTDOWN_POLL_MS);
       if (s) {
-        spdlog::error("uring_reactor: io_uring_wait_cqe failed during shutdown: {}", strerror(s));
+        SIRIUS_LOG_ERROR("uring_reactor: io_uring_wait_cqe failed during shutdown: {}",
+                         strerror(s));
         break;
       }
       reap_cqes();
@@ -1082,7 +1084,7 @@ void uring_reactor::worker_loop(const std::stop_token& stop_token)
         if (inflight > 0) {
           auto s = ring.wait_for(SHUTDOWN_POLL_MS);
           if (s) {
-            spdlog::error("uring_reactor: io_uring_wait_cqe_timeout failed: {}", strerror(s));
+            SIRIUS_LOG_ERROR("uring_reactor: io_uring_wait_cqe_timeout failed: {}", strerror(s));
             break;
           }
           reap_cqes();
@@ -1093,7 +1095,7 @@ void uring_reactor::worker_loop(const std::stop_token& stop_token)
         poll_copy_completions();
       }
     } catch (const std::exception& e) {
-      spdlog::error("uring_reactor: exception: {}", e.what());
+      SIRIUS_LOG_ERROR("uring_reactor: exception: {}", e.what());
     }
   }
 }

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -83,9 +83,9 @@ absl::AnyInvocable<void() noexcept> gpu_pipeline_executor::get_per_thread_init()
     // check instead.
     cudaError_t err = cudaSetDevice(device_id);
     if (err != cudaSuccess) {
-      spdlog::error("gpu_pipeline_executor per-thread init: cudaSetDevice({}) failed: {}",
-                    device_id,
-                    cudaGetErrorString(err));
+      SIRIUS_LOG_ERROR("gpu_pipeline_executor per-thread init: cudaSetDevice({}) failed: {}",
+                       device_id,
+                       cudaGetErrorString(err));
     }
     sirius::util::enable_log_on_default_stream();
   };

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -361,7 +361,8 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query)
   }
 
   if (_scan_op_order.empty()) {
-    spdlog::warn("[sirius_scan_manager::prepare_for_query] no GPU scan operators found in query");
+    SIRIUS_LOG_WARN(
+      "[sirius_scan_manager::prepare_for_query] no GPU scan operators found in query");
     return;
   }
 
@@ -828,19 +829,19 @@ bool sirius_scan_manager::try_assign_cached_entries(op::scan::sirius_gpu_scan_op
       validate_pinned_entry_for_serving(entry, cols);
       auto provider = make_provider_for_pinned_entry(entry, cols, op->batch_telemetry());
       _metadata_processor->use_cached_entries_for_pipeline(op, std::move(provider));
-      spdlog::info("[sirius_scan_manager] assigned pinned entry '{}' to operator '{}'",
-                   pinned_name,
-                   op->get_operator_id());
+      SIRIUS_LOG_INFO("[sirius_scan_manager] assigned pinned entry '{}' to operator '{}'",
+                      pinned_name,
+                      op->get_operator_id());
       return true;
     }
   } catch (std::exception const& e) {
-    spdlog::error(
+    SIRIUS_LOG_ERROR(
       "[sirius_scan_manager] error while trying to assign cached entries to "
       "operator '{}': {}",
       op->get_operator_id(),
       e.what());
   } catch (...) {
-    spdlog::error(
+    SIRIUS_LOG_ERROR(
       "[sirius_scan_manager] error while trying to assign cached entries to "
       "operator '{}'",
       op->get_operator_id());

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -49,8 +49,6 @@
 #include <duckdb/execution/physical_plan_generator.hpp>
 #include <io/types.hpp>
 #include <io/uring/uring_ioctx.hpp>
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/spdlog.h>
 #include <sys/resource.h>
 
 #include <cctype>
@@ -143,12 +141,12 @@ void SiriusContext::log_pool_stats(std::string_view tag) const
     auto* fs_mr =
       space->get_memory_resource_as<cucascade::memory::fixed_size_host_memory_resource>();
     if (fs_mr) {
-      spdlog::info("[host_pool] HOST:{} {} allocated={} bytes peak={} bytes free_blocks={}",
-                   space->get_id().device_id,
-                   tag,
-                   fs_mr->get_total_allocated_bytes(),
-                   fs_mr->get_peak_total_allocated_bytes(),
-                   fs_mr->get_free_blocks());
+      SIRIUS_LOG_INFO("[host_pool] HOST:{} {} allocated={} bytes peak={} bytes free_blocks={}",
+                      space->get_id().device_id,
+                      tag,
+                      fs_mr->get_total_allocated_bytes(),
+                      fs_mr->get_peak_total_allocated_bytes(),
+                      fs_mr->get_free_blocks());
     }
   }
 
@@ -158,12 +156,12 @@ void SiriusContext::log_pool_stats(std::string_view tag) const
     auto* ra_mr =
       space->get_memory_resource_as<cucascade::memory::reservation_aware_resource_adaptor>();
     if (!ra_mr) { continue; }
-    spdlog::info("[gpu_pool] GPU:{} {} allocated={} bytes peak={} bytes reserved={} bytes",
-                 space->get_device_id(),
-                 tag,
-                 ra_mr->get_total_allocated_bytes(),
-                 ra_mr->get_peak_total_allocated_bytes(),
-                 ra_mr->get_total_reserved_bytes());
+    SIRIUS_LOG_INFO("[gpu_pool] GPU:{} {} allocated={} bytes peak={} bytes reserved={} bytes",
+                    space->get_device_id(),
+                    tag,
+                    ra_mr->get_total_allocated_bytes(),
+                    ra_mr->get_peak_total_allocated_bytes(),
+                    ra_mr->get_total_reserved_bytes());
   }
 }
 

--- a/src/util/segfault_backtrace_handler.cpp
+++ b/src/util/segfault_backtrace_handler.cpp
@@ -77,8 +77,8 @@ static void write_backtrace_line(int fd, int frame_no, const char* raw_line)
   write(fd, "\n", 1);
 }
 
-// Best-effort flush of the spdlog logger so the most recent log lines reach
-// disk before we terminate. This is NOT async-signal-safe: the _mt sink takes
+// Best-effort flush of the global logger so the most recent log lines reach
+// disk before we terminate. This is NOT async-signal-safe: the sink takes
 // a mutex and may allocate, so if the crash happened while a thread held the
 // logging mutex (or inside the allocator) the flush could deadlock. We bound
 // that risk with alarm(): SIGALRM's default disposition terminates the
@@ -88,10 +88,8 @@ static void flush_logs_best_effort()
 {
   signal(SIGALRM, SIG_DFL);  // ensure default (terminate) disposition
   alarm(3);                  // hard deadline for the log + flush below
-  if (auto* logger = spdlog::default_logger_raw()) {
-    SPDLOG_LOGGER_WARN(logger, "SIRIUS signal handler triggered, flushing logs");
-    logger->flush();
-  }
+  SIRIUS_LOG_WARN("SIRIUS signal handler triggered, flushing logs");
+  duckdb::FlushGlobalLogger();
   alarm(0);  // flush returned in time; cancel the deadline
 }
 
@@ -206,7 +204,7 @@ void install_segfault_backtrace_handler()
   // writing a core dump; leaving it uninstalled lets the default disposition
   // produce a core (with `ulimit -c unlimited`). See docs/super-sirius/debugging.md.
   if (env_flag_enabled("DISABLE_SIRIUS_SIGNAL_HANDLER")) {
-    spdlog::warn(
+    SIRIUS_LOG_WARN(
       "Sirius crash backtrace handler DISABLED via DISABLE_SIRIUS_SIGNAL_HANDLER — "
       "the OS default disposition is in effect (core dumps enabled if `ulimit -c` allows)");
     return;


### PR DESCRIPTION
Convert the remaining direct spdlog::<level> calls in non-legacy code to the SIRIUS_LOG_* macros, add FlushGlobalLogger() so the segfault handler no longer touches spdlog directly, and drop now-unneeded spdlog includes.

Part of #1145.