### PR TITLE
test: refectory TPC-H-over-S3 correctness test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -693,7 +693,8 @@ if(SIRIUS_BUILD_S3_TESTS)
     test/cpp/io/s3/test_sirius_httpfs.cpp
     test/cpp/io/rest/test_rest_ioctx_integration.cpp
     test/cpp/scan_manager/test_describe_parquet_s3.cpp
-    test/cpp/integration/test_s3_sql_surface.cpp)
+    test/cpp/integration/test_s3_sql_surface.cpp
+    test/cpp/integration/test_s3_tpch.cpp)
 endif()
 
 # Orphaned test files (present in the tree but missing from TEST_SOURCES) are

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BUILD_TARGETS := $(MAIN_BUILD_TARGETS) $(TEST_BUILD_TARGET)
 	clang-release clang-debug clang-relwithdebinfo clang-asan clang-tsan \
 	ci-release configure_ci set_duckdb_version \
 	test test_release test_debug test_reldebug test_ci-release clean list-presets \
-	s3-test s3-test-large \
+	s3-test s3-test-large s3-tpch \
 	s3-test-aws s3-test-aws-sigv4 s3-test-aws-broker s3-bench
 
 PRESETS_LINK := $(DUCKDB_DIR)/CMakePresets.json
@@ -166,10 +166,25 @@ s3-test-large:
 	@# group. Catch2 OR-combines specs within one argument via commas (multiple
 	@# positional args are AND-concatenated instead), so each group runs in a
 	@# single process where same-config cases share one SiriusContext lifecycle.
+	@# SIRIUS_TEST_S3_TPCH is scoped to the first group only: it gates both the
+	@# SF1 TPC-H fixture upload at bring-up and the [tpch][large] case, so the
+	@# second group's bring-up must not see it (it would re-generate/upload).
 	@set -e; \
 	export SIRIUS_TEST_S3_AUTO=1 SIRIUS_TEST_S3_LARGE=1 SIRIUS_TEST_S3_STRICT=1; \
-	$(S3_TEST_BIN) "[s3][sql][large][large-count],[s3][sql][large][large-q1],[s3][sql][large][large-join]"; \
+	SIRIUS_TEST_S3_TPCH=1 $(S3_TEST_BIN) "[s3][sql][large][large-count],[s3][sql][large][large-q1],[s3][sql][large][large-join],[s3][integration][sql][tpch][large]"; \
 	$(S3_TEST_BIN) "[s3][sql][large][large-count-no-prewarm],[s3][sql][large][large-q1-no-prewarm],[s3][sql][large][large-join-no-prewarm]"
+
+# TPC-H-over-S3 correctness tier (Q1-Q22 == local CPU oracle, GPU-only). Uploads
+# the SF1 TPC-H fixture (SIRIUS_TEST_S3_TPCH=1) and runs both the tiny and SF1
+# correctness cases; excludes the [bench] perf arm. MinIO auto-managed.
+s3-tpch:
+	@if [ ! -x $(S3_TEST_BIN) ]; then \
+	  echo "s3-tpch: $(S3_TEST_BIN) not found - run \`make release\` first" >&2; \
+	  exit 1; \
+	fi
+	@set -e; \
+	export SIRIUS_TEST_S3_AUTO=1 SIRIUS_TEST_S3_STRICT=1 SIRIUS_TEST_S3_TPCH=1; \
+	$(S3_TEST_BIN) "[s3][integration][sql][tpch]~[bench]"
 
 # Manual real-AWS gates. These never start MinIO/Docker and are excluded from
 # CI. Export the AWS environment yourself before invoking (regional S3 endpoint,
@@ -225,12 +240,17 @@ s3-bench:
 	  echo "s3-bench: $(S3_TEST_BIN) not found - run \`make release\` first" >&2; \
 	  exit 1; \
 	fi
+	@# The TPC-H query benchmark ([s3][bench][tpch]) is excluded from the routine
+	@# run and its SF1 fixture (SIRIUS_TEST_S3_TPCH) is not uploaded, unless the
+	@# caller opts in with SIRIUS_BENCH_S3_TPCH=1.
 	@set -e; \
+	tpch_excl="~[tpch]"; \
+	if [ -n "$${SIRIUS_BENCH_S3_TPCH:-}" ]; then tpch_excl=""; fi; \
 	if [ "$${SIRIUS_BENCH_BACKEND:-minio}" = "minio" ]; then \
 	  export SIRIUS_TEST_S3_AUTO=1 SIRIUS_TEST_S3_LARGE=1 SIRIUS_TEST_S3_STRICT=1; \
-	  selector="[s3][bench]~[aws]"; \
+	  selector="[s3][bench]~[aws]$$tpch_excl"; \
 	else \
-	  selector="[s3][bench][aws]"; \
+	  selector="[s3][bench][aws]$$tpch_excl"; \
 	fi; \
 	export SIRIUS_BENCH_GIT_SHA="$$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"; \
 	export HOSTNAME="$${HOSTNAME:-$$(hostname)}"; \

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -23,6 +23,7 @@
 #include <catch.hpp>
 #include <duckdb.hpp>
 #include <utils/sirius_test_env.hpp>
+#include <utils/tpch_queries.hpp>
 #include <utils/transparent_execution_test_utils.hpp>
 
 #include <algorithm>
@@ -4070,118 +4071,42 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 1",
                  "[integration][gpu_execution][TPC-H][Q1]")
 {
-  RUN_TPCH_MGPU(
-    "select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, "
-    "sum(l_extendedprice) as sum_base_price, "
-    "sum(l_extendedprice * (1 - l_discount)) as sum_disc_price, "
-    "sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge, "
-    "avg(l_quantity) as avg_qty, avg(l_extendedprice) as avg_price, "
-    "avg(l_discount) as avg_disc, count(*) as count_order "
-    "from lineitem "
-    "where l_shipdate <= date '1995-08-19' "
-    "group by l_returnflag, l_linestatus "
-    "order by l_returnflag, l_linestatus;",
-    0.00001f);
+  RUN_TPCH_MGPU(sirius::test::kTpchQ1, sirius::test::kTpchQueries[0].float_tolerance);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 1 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q1]")
 {
-  RUN_TPCH_MGPU(
-    "select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, "
-    "sum(l_extendedprice) as sum_base_price, "
-    "sum(l_extendedprice * (1 - l_discount)) as sum_disc_price, "
-    "sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge, "
-    "avg(l_quantity) as avg_qty, avg(l_extendedprice) as avg_price, "
-    "avg(l_discount) as avg_disc, count(*) as count_order "
-    "from lineitem "
-    "where l_shipdate <= date '1995-08-19' "
-    "group by l_returnflag, l_linestatus "
-    "order by l_returnflag, l_linestatus;",
-    0.00001f);
+  RUN_TPCH_MGPU(sirius::test::kTpchQ1, sirius::test::kTpchQueries[0].float_tolerance);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 2",
                  "[integration][gpu_execution][TPC-H][Q2]")
 {
-  RUN_TPCH_MGPU(
-    "select s.s_acctbal, s.s_name, n.n_name, p.p_partkey, p.p_mfgr, "
-    "s.s_address, s.s_phone, s.s_comment "
-    "from part p, supplier s, partsupp ps, nation n, region r "
-    "where p.p_partkey = ps.ps_partkey and s.s_suppkey = ps.ps_suppkey "
-    "and p.p_size = 41 and p.p_type like '%NICKEL' "
-    "and s.s_nationkey = n.n_nationkey and n.n_regionkey = r.r_regionkey "
-    "and r.r_name = 'EUROPE' "
-    "and ps.ps_supplycost = ("
-    "  select min(ps.ps_supplycost) "
-    "  from partsupp ps, supplier s, nation n, region r "
-    "  where p.p_partkey = ps.ps_partkey and s.s_suppkey = ps.ps_suppkey "
-    "  and s.s_nationkey = n.n_nationkey and n.n_regionkey = r.r_regionkey "
-    "  and r.r_name = 'EUROPE'"
-    ") "
-    "order by s.s_acctbal desc, n.n_name, s.s_name, p.p_partkey "
-    "limit 100;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ2);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 2 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q2]")
 {
-  RUN_TPCH_MGPU(
-    "select s.s_acctbal, s.s_name, n.n_name, p.p_partkey, p.p_mfgr, "
-    "s.s_address, s.s_phone, s.s_comment "
-    "from part p, supplier s, partsupp ps, nation n, region r "
-    "where p.p_partkey = ps.ps_partkey and s.s_suppkey = ps.ps_suppkey "
-    "and p.p_size = 41 and p.p_type like '%NICKEL' "
-    "and s.s_nationkey = n.n_nationkey and n.n_regionkey = r.r_regionkey "
-    "and r.r_name = 'EUROPE' "
-    "and ps.ps_supplycost = ("
-    "  select min(ps.ps_supplycost) "
-    "  from partsupp ps, supplier s, nation n, region r "
-    "  where p.p_partkey = ps.ps_partkey and s.s_suppkey = ps.ps_suppkey "
-    "  and s.s_nationkey = n.n_nationkey and n.n_regionkey = r.r_regionkey "
-    "  and r.r_name = 'EUROPE'"
-    ") "
-    "order by s.s_acctbal desc, n.n_name, s.s_name, p.p_partkey "
-    "limit 100;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ2);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 3",
                  "[integration][gpu_execution][TPC-H][Q3]")
 {
-  RUN_TPCH_MGPU(
-    "select l.l_orderkey, "
-    "sum(l.l_extendedprice * (1 - l.l_discount)) as revenue, "
-    "o.o_orderdate, o.o_shippriority "
-    "from customer c, orders o, lineitem l "
-    "where c.c_mktsegment = 'HOUSEHOLD' and c.c_custkey = o.o_custkey "
-    "and l.l_orderkey = o.o_orderkey "
-    "and o.o_orderdate < date '1995-03-25' "
-    "and l.l_shipdate > date '1995-03-25' "
-    "group by l.l_orderkey, o.o_orderdate, o.o_shippriority "
-    "order by revenue desc, o.o_orderdate "
-    "limit 10;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ3);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 3 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q3]")
 {
-  RUN_TPCH_MGPU(
-    "select l.l_orderkey, "
-    "sum(l.l_extendedprice * (1 - l.l_discount)) as revenue, "
-    "o.o_orderdate, o.o_shippriority "
-    "from customer c, orders o, lineitem l "
-    "where c.c_mktsegment = 'HOUSEHOLD' and c.c_custkey = o.o_custkey "
-    "and l.l_orderkey = o.o_orderkey "
-    "and o.o_orderdate < date '1995-03-25' "
-    "and l.l_shipdate > date '1995-03-25' "
-    "group by l.l_orderkey, o.o_orderdate, o.o_shippriority "
-    "order by revenue desc, o.o_orderdate "
-    "limit 10;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ3);
 }
 
 // TPC-H Q4 parquet has a pre-existing intermittent flake (see ROADMAP Phase 8
@@ -4190,19 +4115,6 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
 // on other queries must fail loudly. We wrap the SAME body shape as RUN_TPCH_MGPU
 // but handle any std::exception from compare_gpu_vs_cpu by retrying once with
 // a fresh bind_env.
-static constexpr auto kTpchQ4Body =
-  "select o.o_orderpriority, count(*) as order_count "
-  "from orders o "
-  "where o.o_orderdate >= date '1996-10-01' "
-  "and o.o_orderdate < date '1997-01-01' "
-  "and exists ("
-  "  select * from lineitem l "
-  "  where l.l_orderkey = o.o_orderkey "
-  "  and l.l_commitdate < l.l_receiptdate"
-  ") "
-  "group by o.o_orderpriority "
-  "order by o.o_orderpriority;";
-
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 4",
                  "[integration][gpu_execution][TPC-H][Q4]")
@@ -4210,13 +4122,13 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
   auto const num_gpus = GENERATE(1, 2);
   CAPTURE(num_gpus);
   try {
-    if (!compare_gpu_vs_cpu_for(num_gpus, kTpchQ4Body)) { return; }
+    if (!compare_gpu_vs_cpu_for(num_gpus, sirius::test::kTpchQ4)) { return; }
   } catch (std::exception const& first_err) {
     WARN(
       "tpch_q4 first attempt failed (pre-existing flake per ROADMAP Phase 8 "
       "Success Criterion 2); retrying once: "
       << first_err.what());
-    if (!compare_gpu_vs_cpu_for(num_gpus, kTpchQ4Body)) { return; }
+    if (!compare_gpu_vs_cpu_for(num_gpus, sirius::test::kTpchQ4)) { return; }
   }
 }
 
@@ -4227,13 +4139,13 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
   auto const num_gpus = GENERATE(1, 2);
   CAPTURE(num_gpus);
   try {
-    if (!compare_gpu_vs_cpu_for(num_gpus, kTpchQ4Body)) { return; }
+    if (!compare_gpu_vs_cpu_for(num_gpus, sirius::test::kTpchQ4)) { return; }
   } catch (std::exception const& first_err) {
     WARN(
       "tpch_q4 parquet first attempt failed (pre-existing flake per ROADMAP "
       "Phase 8 Success Criterion 2); retrying once: "
       << first_err.what());
-    if (!compare_gpu_vs_cpu_for(num_gpus, kTpchQ4Body)) { return; }
+    if (!compare_gpu_vs_cpu_for(num_gpus, sirius::test::kTpchQ4)) { return; }
   }
 }
 
@@ -4241,768 +4153,252 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 5",
                  "[integration][gpu_execution][TPC-H][Q5]")
 {
-  RUN_TPCH_MGPU(
-    "select n.n_name, "
-    "sum(l.l_extendedprice * (1 - l.l_discount)) as revenue "
-    "from orders o, lineitem l, supplier s, nation n, region r, customer c "
-    "where c.c_custkey = o.o_custkey and l.l_orderkey = o.o_orderkey "
-    "and l.l_suppkey = s.s_suppkey and c.c_nationkey = s.s_nationkey "
-    "and s.s_nationkey = n.n_nationkey and n.n_regionkey = r.r_regionkey "
-    "and r.r_name = 'EUROPE' "
-    "and o.o_orderdate >= date '1997-01-01' "
-    "and o.o_orderdate < date '1998-01-01' "
-    "group by n.n_name "
-    "order by revenue desc;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ5);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 5 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q5]")
 {
-  RUN_TPCH_MGPU(
-    "select n.n_name, "
-    "sum(l.l_extendedprice * (1 - l.l_discount)) as revenue "
-    "from orders o, lineitem l, supplier s, nation n, region r, customer c "
-    "where c.c_custkey = o.o_custkey and l.l_orderkey = o.o_orderkey "
-    "and l.l_suppkey = s.s_suppkey and c.c_nationkey = s.s_nationkey "
-    "and s.s_nationkey = n.n_nationkey and n.n_regionkey = r.r_regionkey "
-    "and r.r_name = 'EUROPE' "
-    "and o.o_orderdate >= date '1997-01-01' "
-    "and o.o_orderdate < date '1998-01-01' "
-    "group by n.n_name "
-    "order by revenue desc;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ5);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 6",
                  "[integration][gpu_execution][TPC-H][Q6]")
 {
-  RUN_TPCH_MGPU(
-    "select sum(l_extendedprice * l_discount) as revenue "
-    "from lineitem "
-    "where l_shipdate >= date '1997-01-01' "
-    "and l_shipdate < date '1998-01-01' "
-    "and l_discount between 0.03 - 0.01 and 0.03 + 0.01 "
-    "and l_quantity < 24;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ6);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 6 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q6]")
 {
-  RUN_TPCH_MGPU(
-    "select sum(l_extendedprice * l_discount) as revenue "
-    "from lineitem "
-    "where l_shipdate >= date '1997-01-01' "
-    "and l_shipdate < date '1998-01-01' "
-    "and l_discount between 0.03 - 0.01 and 0.03 + 0.01 "
-    "and l_quantity < 24;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ6);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 7",
                  "[integration][gpu_execution][TPC-H][Q7]")
 {
-  RUN_TPCH_MGPU(
-    "select supp_nation, cust_nation, l_year, sum(volume) as revenue "
-    "from ("
-    "  select n1.n_name as supp_nation, n2.n_name as cust_nation, "
-    "  extract(year from l.l_shipdate) as l_year, "
-    "  l.l_extendedprice * (1 - l.l_discount) as volume "
-    "  from supplier s, lineitem l, orders o, customer c, nation n1, nation n2 "
-    "  where s.s_suppkey = l.l_suppkey and o.o_orderkey = l.l_orderkey "
-    "  and c.c_custkey = o.o_custkey and s.s_nationkey = n1.n_nationkey "
-    "  and c.c_nationkey = n2.n_nationkey "
-    "  and ((n1.n_name = 'EGYPT' and n2.n_name = 'UNITED STATES') "
-    "    or (n1.n_name = 'UNITED STATES' and n2.n_name = 'EGYPT')) "
-    "  and l.l_shipdate between date '1995-01-01' and date '1996-12-31'"
-    ") as shipping "
-    "group by supp_nation, cust_nation, l_year "
-    "order by supp_nation, cust_nation, l_year;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ7);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 7 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q7]")
 {
-  RUN_TPCH_MGPU(
-    "select supp_nation, cust_nation, l_year, sum(volume) as revenue "
-    "from ("
-    "  select n1.n_name as supp_nation, n2.n_name as cust_nation, "
-    "  extract(year from l.l_shipdate) as l_year, "
-    "  l.l_extendedprice * (1 - l.l_discount) as volume "
-    "  from supplier s, lineitem l, orders o, customer c, nation n1, nation n2 "
-    "  where s.s_suppkey = l.l_suppkey and o.o_orderkey = l.l_orderkey "
-    "  and c.c_custkey = o.o_custkey and s.s_nationkey = n1.n_nationkey "
-    "  and c.c_nationkey = n2.n_nationkey "
-    "  and ((n1.n_name = 'EGYPT' and n2.n_name = 'UNITED STATES') "
-    "    or (n1.n_name = 'UNITED STATES' and n2.n_name = 'EGYPT')) "
-    "  and l.l_shipdate between date '1995-01-01' and date '1996-12-31'"
-    ") as shipping "
-    "group by supp_nation, cust_nation, l_year "
-    "order by supp_nation, cust_nation, l_year;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ7);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 8",
                  "[integration][gpu_execution][TPC-H][Q8]")
 {
-  RUN_TPCH_MGPU(
-    "select o_year, "
-    "sum(case when nation = 'EGYPT' then volume else 0 end) / sum(volume) as mkt_share "
-    "from ("
-    "  select extract(year from o.o_orderdate) as o_year, "
-    "  l.l_extendedprice * (1 - l.l_discount) as volume, "
-    "  n2.n_name as nation "
-    "  from lineitem l, part p, supplier s, orders o, customer c, "
-    "  nation n1, nation n2, region r "
-    "  where p.p_partkey = l.l_partkey and s.s_suppkey = l.l_suppkey "
-    "  and l.l_orderkey = o.o_orderkey and o.o_custkey = c.c_custkey "
-    "  and c.c_nationkey = n1.n_nationkey and n1.n_regionkey = r.r_regionkey "
-    "  and r.r_name = 'MIDDLE EAST' and s.s_nationkey = n2.n_nationkey "
-    "  and o.o_orderdate between date '1995-01-01' and date '1996-12-31' "
-    "  and p.p_type = 'PROMO BRUSHED COPPER'"
-    ") as all_nations "
-    "group by o_year "
-    "order by o_year;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ8);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 8 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q8]")
 {
-  RUN_TPCH_MGPU(
-    "select o_year, "
-    "sum(case when nation = 'EGYPT' then volume else 0 end) / sum(volume) as mkt_share "
-    "from ("
-    "  select extract(year from o.o_orderdate) as o_year, "
-    "  l.l_extendedprice * (1 - l.l_discount) as volume, "
-    "  n2.n_name as nation "
-    "  from lineitem l, part p, supplier s, orders o, customer c, "
-    "  nation n1, nation n2, region r "
-    "  where p.p_partkey = l.l_partkey and s.s_suppkey = l.l_suppkey "
-    "  and l.l_orderkey = o.o_orderkey and o.o_custkey = c.c_custkey "
-    "  and c.c_nationkey = n1.n_nationkey and n1.n_regionkey = r.r_regionkey "
-    "  and r.r_name = 'MIDDLE EAST' and s.s_nationkey = n2.n_nationkey "
-    "  and o.o_orderdate between date '1995-01-01' and date '1996-12-31' "
-    "  and p.p_type = 'PROMO BRUSHED COPPER'"
-    ") as all_nations "
-    "group by o_year "
-    "order by o_year;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ8);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 9",
                  "[integration][gpu_execution][TPC-H][Q9]")
 {
-  RUN_TPCH_MGPU(
-    "select nation, o_year, sum(amount) as sum_profit "
-    "from ("
-    "  select n.n_name as nation, "
-    "  extract(year from o.o_orderdate) as o_year, "
-    "  l.l_extendedprice * (1 - l.l_discount) - ps.ps_supplycost * l.l_quantity as amount "
-    "  from part p, supplier s, lineitem l, partsupp ps, orders o, nation n "
-    "  where s.s_suppkey = l.l_suppkey and ps.ps_suppkey = l.l_suppkey "
-    "  and ps.ps_partkey = l.l_partkey and p.p_partkey = l.l_partkey "
-    "  and o.o_orderkey = l.l_orderkey and s.s_nationkey = n.n_nationkey "
-    "  and p.p_name like '%yellow%'"
-    ") as profit "
-    "group by nation, o_year "
-    "order by nation, o_year desc;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ9);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 9 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q9]")
 {
-  RUN_TPCH_MGPU(
-    "select nation, o_year, sum(amount) as sum_profit "
-    "from ("
-    "  select n.n_name as nation, "
-    "  extract(year from o.o_orderdate) as o_year, "
-    "  l.l_extendedprice * (1 - l.l_discount) - ps.ps_supplycost * l.l_quantity as amount "
-    "  from part p, supplier s, lineitem l, partsupp ps, orders o, nation n "
-    "  where s.s_suppkey = l.l_suppkey and ps.ps_suppkey = l.l_suppkey "
-    "  and ps.ps_partkey = l.l_partkey and p.p_partkey = l.l_partkey "
-    "  and o.o_orderkey = l.l_orderkey and s.s_nationkey = n.n_nationkey "
-    "  and p.p_name like '%yellow%'"
-    ") as profit "
-    "group by nation, o_year "
-    "order by nation, o_year desc;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ9);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 10",
                  "[integration][gpu_execution][TPC-H][Q10]")
 {
-  RUN_TPCH_MGPU(
-    "select c.c_custkey, c.c_name, "
-    "sum(l.l_extendedprice * (1 - l.l_discount)) as revenue, "
-    "c.c_acctbal, n.n_name, c.c_address, c.c_phone, c.c_comment "
-    "from customer c, orders o, lineitem l, nation n "
-    "where c.c_custkey = o.o_custkey and l.l_orderkey = o.o_orderkey "
-    "and o.o_orderdate >= date '1994-03-01' "
-    "and o.o_orderdate < date '1994-06-01' "
-    "and l.l_returnflag = 'R' "
-    "and c.c_nationkey = n.n_nationkey "
-    "group by c.c_custkey, c.c_name, c.c_acctbal, c.c_phone, "
-    "n.n_name, c.c_address, c.c_comment "
-    "order by revenue desc "
-    "limit 20;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ10);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 10 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q10]")
 {
-  RUN_TPCH_MGPU(
-    "select c.c_custkey, c.c_name, "
-    "sum(l.l_extendedprice * (1 - l.l_discount)) as revenue, "
-    "c.c_acctbal, n.n_name, c.c_address, c.c_phone, c.c_comment "
-    "from customer c, orders o, lineitem l, nation n "
-    "where c.c_custkey = o.o_custkey and l.l_orderkey = o.o_orderkey "
-    "and o.o_orderdate >= date '1994-03-01' "
-    "and o.o_orderdate < date '1994-06-01' "
-    "and l.l_returnflag = 'R' "
-    "and c.c_nationkey = n.n_nationkey "
-    "group by c.c_custkey, c.c_name, c.c_acctbal, c.c_phone, "
-    "n.n_name, c.c_address, c.c_comment "
-    "order by revenue desc "
-    "limit 20;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ10);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 11",
                  "[integration][gpu_execution][TPC-H][Q11]")
 {
-  RUN_TPCH_MGPU(
-    "select ps.ps_partkey, "
-    "sum(ps.ps_supplycost * ps.ps_availqty) as value "
-    "from partsupp ps, supplier s, nation n "
-    "where ps.ps_suppkey = s.s_suppkey "
-    "and s.s_nationkey = n.n_nationkey "
-    "and n.n_name = 'JAPAN' "
-    "group by ps.ps_partkey "
-    "having sum(ps.ps_supplycost * ps.ps_availqty) > ("
-    "  select sum(ps.ps_supplycost * ps.ps_availqty) * 0.0001000000 "
-    "  from partsupp ps, supplier s, nation n "
-    "  where ps.ps_suppkey = s.s_suppkey "
-    "  and s.s_nationkey = n.n_nationkey "
-    "  and n.n_name = 'JAPAN'"
-    ") "
-    "order by value desc;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ11);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 11 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q11]")
 {
-  RUN_TPCH_MGPU(
-    "select ps.ps_partkey, "
-    "sum(ps.ps_supplycost * ps.ps_availqty) as value "
-    "from partsupp ps, supplier s, nation n "
-    "where ps.ps_suppkey = s.s_suppkey "
-    "and s.s_nationkey = n.n_nationkey "
-    "and n.n_name = 'JAPAN' "
-    "group by ps.ps_partkey "
-    "having sum(ps.ps_supplycost * ps.ps_availqty) > ("
-    "  select sum(ps.ps_supplycost * ps.ps_availqty) * 0.0001000000 "
-    "  from partsupp ps, supplier s, nation n "
-    "  where ps.ps_suppkey = s.s_suppkey "
-    "  and s.s_nationkey = n.n_nationkey "
-    "  and n.n_name = 'JAPAN'"
-    ") "
-    "order by value desc;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ11);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 12",
                  "[integration][gpu_execution][TPC-H][Q12]")
 {
-  RUN_TPCH_MGPU(
-    "select l.l_shipmode, "
-    "sum(case when o.o_orderpriority = '1-URGENT' "
-    "  or o.o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, "
-    "sum(case when o.o_orderpriority <> '1-URGENT' "
-    "  and o.o_orderpriority <> '2-HIGH' then 1 else 0 end) as low_line_count "
-    "from orders o, lineitem l "
-    "where o.o_orderkey = l.l_orderkey "
-    "and l.l_shipmode in ('TRUCK', 'REG AIR') "
-    "and l.l_commitdate < l.l_receiptdate "
-    "and l.l_shipdate < l.l_commitdate "
-    "and l.l_receiptdate >= date '1994-01-01' "
-    "and l.l_receiptdate < date '1995-01-01' "
-    "group by l.l_shipmode "
-    "order by l.l_shipmode;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ12);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 12 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q12]")
 {
-  RUN_TPCH_MGPU(
-    "select l.l_shipmode, "
-    "sum(case when o.o_orderpriority = '1-URGENT' "
-    "  or o.o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, "
-    "sum(case when o.o_orderpriority <> '1-URGENT' "
-    "  and o.o_orderpriority <> '2-HIGH' then 1 else 0 end) as low_line_count "
-    "from orders o, lineitem l "
-    "where o.o_orderkey = l.l_orderkey "
-    "and l.l_shipmode in ('TRUCK', 'REG AIR') "
-    "and l.l_commitdate < l.l_receiptdate "
-    "and l.l_shipdate < l.l_commitdate "
-    "and l.l_receiptdate >= date '1994-01-01' "
-    "and l.l_receiptdate < date '1995-01-01' "
-    "group by l.l_shipmode "
-    "order by l.l_shipmode;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ12);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 13",
                  "[integration][gpu_execution][TPC-H][Q13]")
 {
-  RUN_TPCH_MGPU(
-    "select c_count, count(*) as custdist "
-    "from ("
-    "  select c.c_custkey, count(o.o_orderkey) "
-    "  from customer c "
-    "  left outer join orders o "
-    "    on c.c_custkey = o.o_custkey "
-    "    and o.o_comment not like '%special%requests%' "
-    "  group by c.c_custkey"
-    ") as orders (c_custkey, c_count) "
-    "group by c_count "
-    "order by custdist desc, c_count desc;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ13);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 13 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q13]")
 {
-  RUN_TPCH_MGPU(
-    "select c_count, count(*) as custdist "
-    "from ("
-    "  select c.c_custkey, count(o.o_orderkey) "
-    "  from customer c "
-    "  left outer join orders o "
-    "    on c.c_custkey = o.o_custkey "
-    "    and o.o_comment not like '%special%requests%' "
-    "  group by c.c_custkey"
-    ") as orders (c_custkey, c_count) "
-    "group by c_count "
-    "order by custdist desc, c_count desc;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ13);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 14",
                  "[integration][gpu_execution][TPC-H][Q14]")
 {
-  RUN_TPCH_MGPU(
-    "select 100.00 * sum(case when p.p_type like 'PROMO%' "
-    "  then l.l_extendedprice * (1 - l.l_discount) else 0 end) "
-    "  / sum(l.l_extendedprice * (1 - l.l_discount)) as promo_revenue "
-    "from lineitem l, part p "
-    "where l.l_partkey = p.p_partkey "
-    "and l.l_shipdate >= date '1994-08-01' "
-    "and l.l_shipdate < date '1994-09-01';");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ14);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 14 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q14]")
 {
-  RUN_TPCH_MGPU(
-    "select 100.00 * sum(case when p.p_type like 'PROMO%' "
-    "  then l.l_extendedprice * (1 - l.l_discount) else 0 end) "
-    "  / sum(l.l_extendedprice * (1 - l.l_discount)) as promo_revenue "
-    "from lineitem l, part p "
-    "where l.l_partkey = p.p_partkey "
-    "and l.l_shipdate >= date '1994-08-01' "
-    "and l.l_shipdate < date '1994-09-01';");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ14);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 15",
                  "[integration][gpu_execution][TPC-H][Q15]")
 {
-  RUN_TPCH_MGPU(
-    "with revenue_view as ("
-    "  select l_suppkey as supplier_no, "
-    "  sum(l_extendedprice * (1 - l_discount)) as total_revenue "
-    "  from lineitem "
-    "  where l_shipdate >= date '1993-05-01' "
-    "  and l_shipdate < date '1993-08-01' "
-    "  group by l_suppkey"
-    ") "
-    "select s.s_suppkey, s.s_name, s.s_address, s.s_phone, r.total_revenue "
-    "from supplier s, revenue_view r "
-    "where s.s_suppkey = r.supplier_no "
-    "and r.total_revenue = ("
-    "  select max(total_revenue) from revenue_view"
-    ") "
-    "order by s.s_suppkey;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ15);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 15 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q15]")
 {
-  RUN_TPCH_MGPU(
-    "with revenue_view as ("
-    "  select l_suppkey as supplier_no, "
-    "  sum(l_extendedprice * (1 - l_discount)) as total_revenue "
-    "  from lineitem "
-    "  where l_shipdate >= date '1993-05-01' "
-    "  and l_shipdate < date '1993-08-01' "
-    "  group by l_suppkey"
-    ") "
-    "select s.s_suppkey, s.s_name, s.s_address, s.s_phone, r.total_revenue "
-    "from supplier s, revenue_view r "
-    "where s.s_suppkey = r.supplier_no "
-    "and r.total_revenue = ("
-    "  select max(total_revenue) from revenue_view"
-    ") "
-    "order by s.s_suppkey;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ15);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 16",
                  "[integration][gpu_execution][TPC-H][Q16]")
 {
-  RUN_TPCH_MGPU(
-    "select p.p_brand, p.p_type, p.p_size, "
-    "count(distinct ps.ps_suppkey) as supplier_cnt "
-    "from partsupp ps, part p "
-    "where p.p_partkey = ps.ps_partkey "
-    "and p.p_brand <> 'Brand#21' "
-    "and p.p_type not like 'MEDIUM PLATED%' "
-    "and p.p_size in (38, 2, 8, 31, 44, 5, 14, 24) "
-    "and ps.ps_suppkey not in ("
-    "  select s.s_suppkey from supplier s "
-    "  where s.s_comment like '%Customer%Complaints%'"
-    ") "
-    "group by p.p_brand, p.p_type, p.p_size "
-    "order by supplier_cnt desc, p.p_brand, p.p_type, p.p_size;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ16);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 16 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q16]")
 {
-  RUN_TPCH_MGPU(
-    "select p.p_brand, p.p_type, p.p_size, "
-    "count(distinct ps.ps_suppkey) as supplier_cnt "
-    "from partsupp ps, part p "
-    "where p.p_partkey = ps.ps_partkey "
-    "and p.p_brand <> 'Brand#21' "
-    "and p.p_type not like 'MEDIUM PLATED%' "
-    "and p.p_size in (38, 2, 8, 31, 44, 5, 14, 24) "
-    "and ps.ps_suppkey not in ("
-    "  select s.s_suppkey from supplier s "
-    "  where s.s_comment like '%Customer%Complaints%'"
-    ") "
-    "group by p.p_brand, p.p_type, p.p_size "
-    "order by supplier_cnt desc, p.p_brand, p.p_type, p.p_size;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ16);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 17",
                  "[integration][gpu_execution][TPC-H][Q17]")
 {
-  RUN_TPCH_MGPU(
-    "select sum(l.l_extendedprice) / 7.0 as avg_yearly "
-    "from lineitem l, part p "
-    "where p.p_partkey = l.l_partkey "
-    "and p.p_brand = 'Brand#13' "
-    "and p.p_container = 'JUMBO CAN' "
-    "and l.l_quantity < ("
-    "  select 0.2 * avg(l2.l_quantity) "
-    "  from lineitem l2 "
-    "  where l2.l_partkey = p.p_partkey"
-    ");");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ17);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 17 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q17]")
 {
-  RUN_TPCH_MGPU(
-    "select sum(l.l_extendedprice) / 7.0 as avg_yearly "
-    "from lineitem l, part p "
-    "where p.p_partkey = l.l_partkey "
-    "and p.p_brand = 'Brand#13' "
-    "and p.p_container = 'JUMBO CAN' "
-    "and l.l_quantity < ("
-    "  select 0.2 * avg(l2.l_quantity) "
-    "  from lineitem l2 "
-    "  where l2.l_partkey = p.p_partkey"
-    ");");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ17);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 18",
                  "[integration][gpu_execution][TPC-H][Q18]")
 {
-  RUN_TPCH_MGPU(
-    "select c.c_name, c.c_custkey, o.o_orderkey, o.o_orderdate, "
-    "o.o_totalprice, sum(l.l_quantity) "
-    "from customer c, orders o, lineitem l "
-    "where o.o_orderkey in ("
-    "  select l_orderkey from lineitem "
-    "  group by l_orderkey having sum(l_quantity) > 300"
-    ") "
-    "and c.c_custkey = o.o_custkey "
-    "and o.o_orderkey = l.l_orderkey "
-    "group by c.c_name, c.c_custkey, o.o_orderkey, o.o_orderdate, o.o_totalprice "
-    "order by o.o_totalprice desc, o.o_orderdate "
-    "limit 100;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ18);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 18 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q18]")
 {
-  RUN_TPCH_MGPU(
-    "select c.c_name, c.c_custkey, o.o_orderkey, o.o_orderdate, "
-    "o.o_totalprice, sum(l.l_quantity) "
-    "from customer c, orders o, lineitem l "
-    "where o.o_orderkey in ("
-    "  select l_orderkey from lineitem "
-    "  group by l_orderkey having sum(l_quantity) > 300"
-    ") "
-    "and c.c_custkey = o.o_custkey "
-    "and o.o_orderkey = l.l_orderkey "
-    "group by c.c_name, c.c_custkey, o.o_orderkey, o.o_orderdate, o.o_totalprice "
-    "order by o.o_totalprice desc, o.o_orderdate "
-    "limit 100;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ18);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 19",
                  "[integration][gpu_execution][TPC-H][Q19]")
 {
-  RUN_TPCH_MGPU(
-    "select sum(l.l_extendedprice* (1 - l.l_discount)) as revenue "
-    "from lineitem l, part p "
-    "where ("
-    "  p.p_partkey = l.l_partkey "
-    "  and p.p_brand = 'Brand#41' "
-    "  and p.p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') "
-    "  and l.l_quantity >= 2 and l.l_quantity <= 2 + 10 "
-    "  and p.p_size between 1 and 5 "
-    "  and l.l_shipmode in ('AIR', 'AIR REG') "
-    "  and l.l_shipinstruct = 'DELIVER IN PERSON'"
-    ") or ("
-    "  p.p_partkey = l.l_partkey "
-    "  and p.p_brand = 'Brand#13' "
-    "  and p.p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') "
-    "  and l.l_quantity >= 14 and l.l_quantity <= 14 + 10 "
-    "  and p.p_size between 1 and 10 "
-    "  and l.l_shipmode in ('AIR', 'AIR REG') "
-    "  and l.l_shipinstruct = 'DELIVER IN PERSON'"
-    ") or ("
-    "  p.p_partkey = l.l_partkey "
-    "  and p.p_brand = 'Brand#55' "
-    "  and p.p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') "
-    "  and l.l_quantity >= 23 and l.l_quantity <= 23 + 10 "
-    "  and p.p_size between 1 and 15 "
-    "  and l.l_shipmode in ('AIR', 'AIR REG') "
-    "  and l.l_shipinstruct = 'DELIVER IN PERSON'"
-    ");");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ19);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 19 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q19]")
 {
-  RUN_TPCH_MGPU(
-    "select sum(l.l_extendedprice* (1 - l.l_discount)) as revenue "
-    "from lineitem l, part p "
-    "where ("
-    "  p.p_partkey = l.l_partkey "
-    "  and p.p_brand = 'Brand#41' "
-    "  and p.p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') "
-    "  and l.l_quantity >= 2 and l.l_quantity <= 2 + 10 "
-    "  and p.p_size between 1 and 5 "
-    "  and l.l_shipmode in ('AIR', 'AIR REG') "
-    "  and l.l_shipinstruct = 'DELIVER IN PERSON'"
-    ") or ("
-    "  p.p_partkey = l.l_partkey "
-    "  and p.p_brand = 'Brand#13' "
-    "  and p.p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') "
-    "  and l.l_quantity >= 14 and l.l_quantity <= 14 + 10 "
-    "  and p.p_size between 1 and 10 "
-    "  and l.l_shipmode in ('AIR', 'AIR REG') "
-    "  and l.l_shipinstruct = 'DELIVER IN PERSON'"
-    ") or ("
-    "  p.p_partkey = l.l_partkey "
-    "  and p.p_brand = 'Brand#55' "
-    "  and p.p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') "
-    "  and l.l_quantity >= 23 and l.l_quantity <= 23 + 10 "
-    "  and p.p_size between 1 and 15 "
-    "  and l.l_shipmode in ('AIR', 'AIR REG') "
-    "  and l.l_shipinstruct = 'DELIVER IN PERSON'"
-    ");");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ19);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 20",
                  "[integration][gpu_execution][TPC-H][Q20]")
 {
-  RUN_TPCH_MGPU(
-    "select s.s_name, s.s_address "
-    "from supplier s, nation n "
-    "where s.s_suppkey in ("
-    "  select ps.ps_suppkey from partsupp ps "
-    "  where ps.ps_partkey in ("
-    "    select p.p_partkey from part p where p.p_name like 'antique%'"
-    "  ) "
-    "  and ps.ps_availqty > ("
-    "    select 0.5 * sum(l.l_quantity) "
-    "    from lineitem l "
-    "    where l.l_partkey = ps.ps_partkey "
-    "    and l.l_suppkey = ps.ps_suppkey "
-    "    and l.l_shipdate >= date '1993-01-01' "
-    "    and l.l_shipdate < date '1994-01-01'"
-    "  )"
-    ") "
-    "and s.s_nationkey = n.n_nationkey "
-    "and n.n_name = 'KENYA' "
-    "order by s.s_name;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ20);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 20 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q20]")
 {
-  RUN_TPCH_MGPU(
-    "select s.s_name, s.s_address "
-    "from supplier s, nation n "
-    "where s.s_suppkey in ("
-    "  select ps.ps_suppkey from partsupp ps "
-    "  where ps.ps_partkey in ("
-    "    select p.p_partkey from part p where p.p_name like 'antique%'"
-    "  ) "
-    "  and ps.ps_availqty > ("
-    "    select 0.5 * sum(l.l_quantity) "
-    "    from lineitem l "
-    "    where l.l_partkey = ps.ps_partkey "
-    "    and l.l_suppkey = ps.ps_suppkey "
-    "    and l.l_shipdate >= date '1993-01-01' "
-    "    and l.l_shipdate < date '1994-01-01'"
-    "  )"
-    ") "
-    "and s.s_nationkey = n.n_nationkey "
-    "and n.n_name = 'KENYA' "
-    "order by s.s_name;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ20);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 21",
                  "[integration][gpu_execution][TPC-H][Q21]")
 {
-  RUN_TPCH_MGPU(
-    "select s.s_name, count(*) as numwait "
-    "from supplier s, lineitem l1, orders o, nation n "
-    "where s.s_suppkey = l1.l_suppkey "
-    "and o.o_orderkey = l1.l_orderkey "
-    "and o.o_orderstatus = 'F' "
-    "and l1.l_receiptdate > l1.l_commitdate "
-    "and exists ("
-    "  select * from lineitem l2 "
-    "  where l2.l_orderkey = l1.l_orderkey "
-    "  and l2.l_suppkey <> l1.l_suppkey"
-    ") "
-    "and not exists ("
-    "  select * from lineitem l3 "
-    "  where l3.l_orderkey = l1.l_orderkey "
-    "  and l3.l_suppkey <> l1.l_suppkey "
-    "  and l3.l_receiptdate > l3.l_commitdate"
-    ") "
-    "and s.s_nationkey = n.n_nationkey "
-    "and n.n_name = 'BRAZIL' "
-    "group by s.s_name "
-    "order by numwait desc, s.s_name "
-    "limit 100;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ21);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 21 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q21]")
 {
-  RUN_TPCH_MGPU(
-    "select s.s_name, count(*) as numwait "
-    "from supplier s, lineitem l1, orders o, nation n "
-    "where s.s_suppkey = l1.l_suppkey "
-    "and o.o_orderkey = l1.l_orderkey "
-    "and o.o_orderstatus = 'F' "
-    "and l1.l_receiptdate > l1.l_commitdate "
-    "and exists ("
-    "  select * from lineitem l2 "
-    "  where l2.l_orderkey = l1.l_orderkey "
-    "  and l2.l_suppkey <> l1.l_suppkey"
-    ") "
-    "and not exists ("
-    "  select * from lineitem l3 "
-    "  where l3.l_orderkey = l1.l_orderkey "
-    "  and l3.l_suppkey <> l1.l_suppkey "
-    "  and l3.l_receiptdate > l3.l_commitdate"
-    ") "
-    "and s.s_nationkey = n.n_nationkey "
-    "and n.n_name = 'BRAZIL' "
-    "group by s.s_name "
-    "order by numwait desc, s.s_name "
-    "limit 100;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ21);
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - TPC-H Query 22",
                  "[integration][gpu_execution][TPC-H][Q22]")
 {
-  RUN_TPCH_MGPU(
-    "select cntrycode, count(*) as numcust, sum(c_acctbal) as totacctbal "
-    "from ("
-    "  select substring(c_phone from 1 for 2) as cntrycode, c_acctbal "
-    "  from customer c "
-    "  where substring(c_phone from 1 for 2) in "
-    "    ('24', '31', '11', '16', '21', '20', '34') "
-    "  and c_acctbal > ("
-    "    select avg(c_acctbal) from customer "
-    "    where c_acctbal > 0.00 "
-    "    and substring(c_phone from 1 for 2) in "
-    "      ('24', '31', '11', '16', '21', '20', '34')"
-    "  ) "
-    "  and not exists ("
-    "    select * from orders o where o.o_custkey = c.c_custkey"
-    "  )"
-    ") as custsale "
-    "group by cntrycode "
-    "order by cntrycode;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ22);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 22 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q22]")
 {
-  RUN_TPCH_MGPU(
-    "select cntrycode, count(*) as numcust, sum(c_acctbal) as totacctbal "
-    "from ("
-    "  select substring(c_phone from 1 for 2) as cntrycode, c_acctbal "
-    "  from customer c "
-    "  where substring(c_phone from 1 for 2) in "
-    "    ('24', '31', '11', '16', '21', '20', '34') "
-    "  and c_acctbal > ("
-    "    select avg(c_acctbal) from customer "
-    "    where c_acctbal > 0.00 "
-    "    and substring(c_phone from 1 for 2) in "
-    "      ('24', '31', '11', '16', '21', '20', '34')"
-    "  ) "
-    "  and not exists ("
-    "    select * from orders o where o.o_custkey = c.c_custkey"
-    "  )"
-    ") as custsale "
-    "group by cntrycode "
-    "order by cntrycode;");
+  RUN_TPCH_MGPU(sirius::test::kTpchQ22);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -13,6 +13,7 @@
 #include "sirius_context.hpp"
 #include "sirius_extension.hpp"
 #include "utils/s3_container.hpp"
+#include "utils/tpch_queries.hpp"
 #include "utils/transparent_execution_test_utils.hpp"
 
 #include <cudf/io/experimental/hybrid_scan.hpp>
@@ -951,6 +952,14 @@ struct bench_record {
   std::vector<metric_delta> comparisons;
 };
 
+struct tpch_bench_record {
+  std::string scenario;
+  std::string arm;
+  std::size_t query_number{0};
+  double wall_clock_ms{0.0};
+  duckdb::idx_t row_count{0};
+};
+
 bench_record make_record(std::string scenario,
                          std::string transport,
                          std::string projection,
@@ -1305,6 +1314,38 @@ void write_perf_json(fs::path const& path,
     }
     out << "}";
     out << (i + 1 == records.size() ? "\n" : ",\n");
+  }
+  out << "  ]\n";
+  out << "}\n";
+}
+
+void write_perf_json(fs::path const& path,
+                     s3_test_env const& env,
+                     std::string_view backend,
+                     std::string_view object_key,
+                     std::uint64_t dataset_bytes,
+                     std::vector<tpch_bench_record> const& records)
+{
+  fs::create_directories(path.parent_path());
+  std::ofstream out(path);
+  REQUIRE(out);
+
+  out << "{\n";
+  out << "  \"git_sha\": \"" << json_escape(env_or("SIRIUS_BENCH_GIT_SHA", "unknown")) << "\",\n";
+  out << "  \"host\": \"" << json_escape(env_or("HOSTNAME", "unknown")) << "\",\n";
+  out << "  \"backend\": \"" << json_escape(backend) << "\",\n";
+  out << "  \"dataset_bytes\": " << dataset_bytes << ",\n";
+  out << "  \"config\": {\"bucket\": \"" << json_escape(env.bucket) << "\", \"key\": \""
+      << json_escape(object_key) << "\"},\n";
+  out << "  \"results\": [\n";
+  for (std::size_t index = 0; index < records.size(); ++index) {
+    auto const& record = records[index];
+    out << "    {\"scenario\": \"" << json_escape(record.scenario) << "\", "
+        << "\"arm\": \"" << json_escape(record.arm) << "\", "
+        << "\"query_number\": " << record.query_number << ", "
+        << "\"wall_clock_ms\": " << std::fixed << std::setprecision(3) << record.wall_clock_ms
+        << ", \"row_count\": " << record.row_count << "}";
+    out << (index + 1 == records.size() ? "\n" : ",\n");
   }
   out << "  ]\n";
   out << "}\n";
@@ -1732,6 +1773,56 @@ void compare_s3_gpu_to_local_cpu_with_watchdog(std::shared_ptr<s3_sql_fixture> c
   CHECK(s3_result.rows == local_rows);
 }
 
+constexpr std::array<std::string_view, 8> kBenchTpchTables = {
+  "nation", "region", "customer", "orders", "part", "partsupp", "supplier", "lineitem"};
+
+sirius_memory_limits tpch_sf1_bench_memory_limits()
+{
+  sirius_memory_limits limits;
+  limits.gpu_usage     = "2 GiB";
+  limits.host_capacity = "4 GiB";
+  limits.disk_capacity = "16 GiB";
+  return limits;
+}
+
+void create_tpch_bench_views(duckdb::Connection& connection, std::string const& root, bool s3)
+{
+  for (auto const table : kBenchTpchTables) {
+    auto const path = s3 ? root + "/" + std::string{table} + ".parquet"
+                         : (fs::path{root} / (std::string{table} + ".parquet")).string();
+    require_query_ok(connection,
+                     "CREATE OR REPLACE VIEW " + std::string{table} +
+                       " AS SELECT * FROM read_parquet(" + sql_quote(path) + ");");
+  }
+}
+
+tpch_bench_record run_tpch_bench_query(duckdb::Connection& connection,
+                                       sirius::test::tpch_query_spec const& query,
+                                       std::string arm)
+{
+  auto const start = bench_clock::now();
+  auto result      = connection.Query(std::string{query.sql});
+  auto const stop  = bench_clock::now();
+  if (!result)
+    throw std::runtime_error("TPC-H Q" + std::to_string(query.number) + " returned no result");
+  if (result->HasError()) throw std::runtime_error(result->GetError());
+
+  return tpch_bench_record{"tpch_q" + std::to_string(query.number) + "_" + arm,
+                           std::move(arm),
+                           query.number,
+                           elapsed_ms(start, stop),
+                           result->RowCount()};
+}
+
+std::uint64_t tpch_dataset_bytes(fs::path const& root)
+{
+  std::uint64_t bytes = 0;
+  for (auto const table : kBenchTpchTables) {
+    bytes += static_cast<std::uint64_t>(fs::file_size(root / (std::string{table} + ".parquet")));
+  }
+  return bytes;
+}
+
 }  // namespace
 
 TEST_CASE("internal sirius_read_parquet is registered as a one-argument table function",
@@ -2086,6 +2177,66 @@ TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][
                             "rest_reactor_compat_http",
                             "rest_reactor_compat_https"});
   WARN("Wrote S3 REST perf JSON baseline to " << path.string());
+}
+
+TEST_CASE("S3 TPC-H benchmark records SF1 S3 and local wall-clock arms", "[.][s3][bench][tpch]")
+{
+  if (!truthy_env("SIRIUS_BENCH_S3_TPCH")) {
+    SUCCEED("SIRIUS_BENCH_S3_TPCH is not enabled");
+    return;
+  }
+
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) return;
+
+  auto const local_dir_text = env_or("SIRIUS_TEST_S3_TPCH_LOCAL_DIR");
+  REQUIRE_FALSE(local_dir_text.empty());
+  fs::path const local_dir{local_dir_text};
+  for (auto const table : kBenchTpchTables) {
+    REQUIRE(fs::exists(local_dir / (std::string{table} + ".parquet")));
+  }
+
+  s3_sql_fixture fixture(*env, tpch_sf1_bench_memory_limits());
+  set_gpu_execution(fixture.con, true);
+  create_tpch_bench_views(fixture.con, s3_uri(env->bucket, "tpch/sf1"), true);
+
+  duckdb::DuckDB local_db(nullptr);
+  duckdb::Connection local_connection(local_db);
+  create_tpch_bench_views(local_connection, local_dir.string(), false);
+
+  std::vector<tpch_bench_record> records;
+  records.reserve(sirius::test::kTpchQueries.size() * 2);
+  for (auto const& query : sirius::test::kTpchQueries) {
+    tpch_bench_record s3_record;
+    try {
+      s3_record = run_tpch_bench_query(fixture.con, query, "s3");
+    } catch (std::exception const& first_error) {
+      if (!query.retry_once) throw;
+      WARN("TPC-H Q" << query.number << " S3 benchmark first attempt failed; retrying once: "
+                     << first_error.what());
+      s3_record = run_tpch_bench_query(fixture.con, query, "s3");
+    }
+    auto local_record = run_tpch_bench_query(local_connection, query, "local");
+
+    CHECK(s3_record.row_count == local_record.row_count);
+    WARN("TPC-H Q" << query.number << " S3=" << s3_record.wall_clock_ms << "ms local="
+                   << local_record.wall_clock_ms << "ms rows=" << s3_record.row_count);
+    records.push_back(std::move(s3_record));
+    records.push_back(std::move(local_record));
+  }
+  REQUIRE(records.size() == 44);
+
+  auto const path = perf_json_path();
+  write_perf_json(
+    path, *env, "rest_minio_tpch", "tpch/sf1", tpch_dataset_bytes(local_dir), records);
+  auto const json = read_text_file(path);
+  for (auto const& query : sirius::test::kTpchQueries) {
+    CHECK(json.find("\"scenario\": \"tpch_q" + std::to_string(query.number) + "_s3\"") !=
+          std::string::npos);
+    CHECK(json.find("\"scenario\": \"tpch_q" + std::to_string(query.number) + "_local\"") !=
+          std::string::npos);
+  }
+  WARN("Wrote S3 TPC-H perf JSON to " << path.string());
 }
 
 TEST_CASE("S3 REST AWS perf benchmark records projected and full scans",

--- a/test/cpp/integration/test_s3_tpch.cpp
+++ b/test/cpp/integration/test_s3_tpch.cpp
@@ -1,0 +1,408 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * See the LICENSE file at the repo root for the full text.
+ */
+
+#include "catch.hpp"
+#include "sirius_extension.hpp"
+#include "utils/s3_container.hpp"
+#include "utils/tpch_queries.hpp"
+#include "utils/transparent_execution_test_utils.hpp"
+
+#include <duckdb.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr std::array<std::string_view, 8> kS3TpchTables = {
+  "nation", "region", "customer", "orders", "part", "partsupp", "supplier", "lineitem"};
+
+std::string tpch_env_or(std::string_view name, std::string fallback = {})
+{
+  auto const* value = std::getenv(std::string{name}.c_str());
+  return value != nullptr ? std::string{value} : std::move(fallback);
+}
+
+bool tpch_truthy_env(std::string_view name)
+{
+  auto const value = tpch_env_or(name);
+  return value == "1" || value == "true" || value == "TRUE" || value == "yes" || value == "YES";
+}
+
+std::string tpch_sql_quote(std::string_view value)
+{
+  std::string out{"'"};
+  for (auto const c : value) {
+    if (c == '\'') out.push_back('\'');
+    out.push_back(c);
+  }
+  out.push_back('\'');
+  return out;
+}
+
+struct s3_tpch_env {
+  std::string endpoint;
+  std::string region;
+  std::string access_key;
+  std::string secret_key;
+  std::string bucket;
+  std::string session_token;
+  fs::path tiny_local_dir;
+  fs::path sf1_local_dir;
+};
+
+std::optional<s3_tpch_env> load_s3_tpch_env()
+{
+  if (!sirius::test::ensure_s3_container_env()) return std::nullopt;
+
+  auto endpoint   = tpch_env_or("SIRIUS_TEST_S3_ENDPOINT");
+  auto access_key = tpch_env_or("SIRIUS_TEST_S3_ACCESS_KEY");
+  auto secret_key = tpch_env_or("SIRIUS_TEST_S3_SECRET_KEY");
+  auto bucket     = tpch_env_or("SIRIUS_TEST_S3_BUCKET");
+  auto local_dir  = tpch_env_or("SIRIUS_TEST_S3_LOCAL_DIR");
+  if (endpoint.empty() || access_key.empty() || secret_key.empty() || bucket.empty() ||
+      local_dir.empty()) {
+    return std::nullopt;
+  }
+
+  return s3_tpch_env{std::move(endpoint),
+                     tpch_env_or("SIRIUS_TEST_S3_REGION", "us-east-1"),
+                     std::move(access_key),
+                     std::move(secret_key),
+                     std::move(bucket),
+                     tpch_env_or("SIRIUS_TEST_S3_SESSION_TOKEN"),
+                     fs::path{std::move(local_dir)} / "parquet",
+                     fs::path{tpch_env_or("SIRIUS_TEST_S3_TPCH_LOCAL_DIR")}};
+}
+
+bool should_skip_s3_tpch_env(std::optional<s3_tpch_env> const& env)
+{
+  if (env.has_value()) return false;
+  if (tpch_truthy_env("SIRIUS_TEST_S3_STRICT")) {
+    FAIL("SIRIUS_TEST_S3_* environment is required in strict mode");
+  }
+  SUCCEED("SIRIUS_TEST_S3_* not set; skipping S3 TPC-H test");
+  return true;
+}
+
+class s3_tpch_config_guard {
+ public:
+  s3_tpch_config_guard(s3_tpch_env const& env, bool sf1)
+  {
+    if (auto const* current = std::getenv("SIRIUS_CONFIG_FILE"); current != nullptr) {
+      original_config_ = current;
+    }
+    if (auto const* current = std::getenv("SIRIUS_DISABLE"); current != nullptr) {
+      original_disable_ = current;
+    }
+
+    auto const unique = std::to_string(reinterpret_cast<std::uintptr_t>(this));
+    dir_              = fs::temp_directory_path() / ("sirius_s3_tpch_" + unique);
+    config_path_      = dir_ / "sirius.yaml";
+    fs::create_directories(dir_);
+
+    auto const gpu_capacity  = sf1 ? "2 GiB" : "512 MiB";
+    auto const host_capacity = sf1 ? "4 GiB" : "1 GiB";
+    auto const disk_capacity = sf1 ? "16 GiB" : "2 GiB";
+    std::ofstream out(config_path_);
+    out << "sirius:\n"
+           "  space:\n"
+           "    gpu:\n"
+           "      - device_id: 0\n"
+           "        per_stream_reservation: false\n"
+           "        reservation_limit_fraction: 0.4\n"
+           "        downgrade_trigger_fraction: 0.8\n"
+           "        downgrade_stop_fraction: 0.6\n"
+           "        memory_capacity: "
+        << gpu_capacity
+        << "\n"
+           "    host:\n"
+           "      - numa_id: -1\n"
+           "        reservation_limit_fraction: 0.9\n"
+           "        downgrade_trigger_fraction: 0.8\n"
+           "        downgrade_stop_fraction: 0.6\n"
+           "        memory_capacity: "
+        << host_capacity
+        << "\n"
+           "        block_size: 1 MiB\n"
+           "    disk:\n"
+           "      - disk_id: 0\n"
+           "        mount_path: "
+        << tpch_sql_quote((dir_ / "disk_memory").string())
+        << "\n"
+           "        memory_capacity: "
+        << disk_capacity
+        << "\n"
+           "  executor:\n"
+           "    scan_manager:\n"
+           "      object_store:\n"
+           "        endpoint: "
+        << tpch_sql_quote(env.endpoint)
+        << "\n"
+           "        region: "
+        << tpch_sql_quote(env.region)
+        << "\n"
+           "        access_key: "
+        << tpch_sql_quote(env.access_key)
+        << "\n"
+           "        secret_key: "
+        << tpch_sql_quote(env.secret_key) << "\n";
+    if (!env.session_token.empty()) {
+      out << "        session_token: " << tpch_sql_quote(env.session_token) << "\n";
+    }
+    out << "        tls_verify: false\n"
+           "      rest:\n"
+           "        max_connections: 8\n"
+           "        request_timeout_s: 30\n";
+    out.close();
+    REQUIRE(out);
+
+    setenv("SIRIUS_CONFIG_FILE", config_path_.c_str(), /*overwrite=*/1);
+    unsetenv("SIRIUS_DISABLE");
+  }
+
+  ~s3_tpch_config_guard()
+  {
+    if (original_config_.has_value()) {
+      setenv("SIRIUS_CONFIG_FILE", original_config_->c_str(), /*overwrite=*/1);
+    } else {
+      unsetenv("SIRIUS_CONFIG_FILE");
+    }
+    if (original_disable_.has_value()) {
+      setenv("SIRIUS_DISABLE", original_disable_->c_str(), /*overwrite=*/1);
+    } else {
+      unsetenv("SIRIUS_DISABLE");
+    }
+    std::error_code ec;
+    fs::remove_all(dir_, ec);
+  }
+
+ private:
+  fs::path dir_;
+  fs::path config_path_;
+  std::optional<std::string> original_config_;
+  std::optional<std::string> original_disable_;
+};
+
+void tpch_require_query_ok(duckdb::Connection& connection, std::string const& sql)
+{
+  auto result = connection.Query(sql);
+  REQUIRE(result);
+  if (result->HasError()) UNSCOPED_INFO(result->GetError());
+  REQUIRE_FALSE(result->HasError());
+}
+
+void tpch_load_sirius_extension(duckdb::DuckDB& db)
+{
+  try {
+    db.LoadStaticExtension<duckdb::SiriusExtension>();
+  } catch (std::exception const& error) {
+    auto const message = std::string{error.what()};
+    if (message.find("already exists") == std::string::npos &&
+        message.find("already loaded") == std::string::npos) {
+      throw;
+    }
+  }
+}
+
+std::vector<std::vector<std::string>> tpch_collect_rows(duckdb::MaterializedQueryResult& result)
+{
+  std::vector<std::vector<std::string>> rows;
+  rows.reserve(result.RowCount());
+  for (duckdb::idx_t row_index = 0; row_index < result.RowCount(); ++row_index) {
+    std::vector<std::string> row;
+    row.reserve(result.ColumnCount());
+    for (duckdb::idx_t column_index = 0; column_index < result.ColumnCount(); ++column_index) {
+      row.push_back(result.GetValue(column_index, row_index).ToString());
+    }
+    rows.push_back(std::move(row));
+  }
+  std::sort(rows.begin(), rows.end());
+  return rows;
+}
+
+bool tpch_is_floating_point(duckdb::LogicalTypeId type)
+{
+  return type == duckdb::LogicalTypeId::FLOAT || type == duckdb::LogicalTypeId::DOUBLE;
+}
+
+class s3_tpch_suite {
+ public:
+  s3_tpch_suite(s3_tpch_env const& env, std::string object_prefix, fs::path local_dir, bool sf1)
+    : env_(env),
+      object_prefix_(std::move(object_prefix)),
+      local_dir_(std::move(local_dir)),
+      config_guard_(env, sf1),
+      cpu_db_(nullptr),
+      cpu_connection_(cpu_db_)
+  {
+    REQUIRE_FALSE(local_dir_.empty());
+    create_local_views();
+    reset_gpu_catalog();
+  }
+
+  void run_all_queries()
+  {
+    for (auto const& query : sirius::test::kTpchQueries) {
+      INFO("TPC-H Q" << query.number);
+      if (!query.retry_once) {
+        compare_query(query);
+        continue;
+      }
+
+      try {
+        compare_query(query);
+      } catch (std::exception const& first_error) {
+        WARN("TPC-H Q" << query.number
+                       << " first attempt failed; retrying once: " << first_error.what());
+        reset_gpu_catalog();
+        compare_query(query);
+      }
+    }
+  }
+
+  void require_gpu_off_rejected()
+  {
+    tpch_require_query_ok(*gpu_connection_, "SET gpu_execution = false;");
+    auto result = gpu_connection_->Query("SELECT count(*) FROM nation");
+    REQUIRE(result);
+    REQUIRE(result->HasError());
+    INFO(result->GetError());
+    CHECK(result->GetError().find("S3 is GPU-only") != std::string::npos);
+    tpch_require_query_ok(*gpu_connection_, "SET gpu_execution = true;");
+  }
+
+ private:
+  void create_views(duckdb::Connection& connection, std::string const& root, bool s3)
+  {
+    for (auto const table : kS3TpchTables) {
+      auto const path = s3 ? root + "/" + std::string{table} + ".parquet"
+                           : (fs::path{root} / (std::string{table} + ".parquet")).string();
+      tpch_require_query_ok(connection,
+                            "CREATE OR REPLACE VIEW " + std::string{table} +
+                              " AS SELECT * FROM read_parquet(" + tpch_sql_quote(path) + ");");
+    }
+  }
+
+  void create_local_views()
+  {
+    for (auto const table : kS3TpchTables) {
+      auto const parquet = local_dir_ / (std::string{table} + ".parquet");
+      REQUIRE(fs::exists(parquet));
+    }
+    create_views(cpu_connection_, local_dir_.string(), false);
+  }
+
+  void reset_gpu_catalog()
+  {
+    gpu_connection_.reset();
+    gpu_db_.reset();
+    gpu_db_ = std::make_unique<duckdb::DuckDB>(nullptr);
+    tpch_load_sirius_extension(*gpu_db_);
+    gpu_connection_ = std::make_unique<duckdb::Connection>(*gpu_db_);
+    auto const root = "s3://" + env_.bucket + "/" + object_prefix_;
+    create_views(*gpu_connection_, root, true);
+    tpch_require_query_ok(*gpu_connection_, "SET gpu_execution = true;");
+  }
+
+  std::unique_ptr<duckdb::MaterializedQueryResult> run_gpu_query(std::string const& sql)
+  {
+    auto result = gpu_connection_->Query(sql);
+    if (!result) throw std::runtime_error("GPU query returned no result");
+    if (result->HasError()) throw std::runtime_error(result->GetError());
+    return result;
+  }
+
+  void compare_query(sirius::test::tpch_query_spec const& query)
+  {
+    auto const before = sirius::test::get_transparent_execution_stats(*gpu_connection_);
+    auto gpu_result   = run_gpu_query(std::string{query.sql});
+    auto const after  = sirius::test::get_transparent_execution_stats(*gpu_connection_);
+    sirius::test::require_transparent_execution_delta(before, after, 1, 0, 1);
+
+    auto cpu_result = cpu_connection_.Query(std::string{query.sql});
+    REQUIRE(cpu_result);
+    if (cpu_result->HasError()) UNSCOPED_INFO(cpu_result->GetError());
+    REQUIRE_FALSE(cpu_result->HasError());
+    REQUIRE(gpu_result->ColumnCount() == cpu_result->ColumnCount());
+    REQUIRE(gpu_result->RowCount() == cpu_result->RowCount());
+
+    std::vector<bool> floating_columns(gpu_result->ColumnCount());
+    for (duckdb::idx_t column = 0; column < gpu_result->ColumnCount(); ++column) {
+      floating_columns[column] = tpch_is_floating_point(gpu_result->types[column].id());
+    }
+
+    auto gpu_rows = tpch_collect_rows(*gpu_result);
+    auto cpu_rows = tpch_collect_rows(cpu_result->Cast<duckdb::MaterializedQueryResult>());
+    REQUIRE(gpu_rows.size() == cpu_rows.size());
+    for (std::size_t row = 0; row < gpu_rows.size(); ++row) {
+      REQUIRE(gpu_rows[row].size() == cpu_rows[row].size());
+      for (std::size_t column = 0; column < gpu_rows[row].size(); ++column) {
+        if (query.float_tolerance.has_value() && floating_columns[column]) {
+          auto const gpu_value = std::stod(gpu_rows[row][column]);
+          auto const cpu_value = std::stod(cpu_rows[row][column]);
+          CHECK(std::fabs(gpu_value - cpu_value) <= *query.float_tolerance);
+        } else {
+          CHECK(gpu_rows[row][column] == cpu_rows[row][column]);
+        }
+      }
+    }
+  }
+
+  s3_tpch_env const& env_;
+  std::string object_prefix_;
+  fs::path local_dir_;
+  s3_tpch_config_guard config_guard_;
+  std::unique_ptr<duckdb::DuckDB> gpu_db_;
+  std::unique_ptr<duckdb::Connection> gpu_connection_;
+  duckdb::DuckDB cpu_db_;
+  duckdb::Connection cpu_connection_;
+};
+
+}  // namespace
+
+TEST_CASE("transparent S3 TPC-H Q1-Q22 match the tiny local CPU oracle",
+          "[.][s3][integration][sql][tpch]")
+{
+  auto env = load_s3_tpch_env();
+  if (should_skip_s3_tpch_env(env)) return;
+
+  s3_tpch_suite suite(*env, "parquet", env->tiny_local_dir, false);
+  suite.run_all_queries();
+  suite.require_gpu_off_rejected();
+}
+
+TEST_CASE("transparent S3 TPC-H Q1-Q22 match the SF1 local CPU oracle",
+          "[.][s3][integration][sql][tpch][large]")
+{
+  if (!tpch_truthy_env("SIRIUS_TEST_S3_TPCH")) {
+    SUCCEED("SIRIUS_TEST_S3_TPCH is not enabled");
+    return;
+  }
+
+  auto env = load_s3_tpch_env();
+  if (should_skip_s3_tpch_env(env)) return;
+  REQUIRE_FALSE(env->sf1_local_dir.empty());
+
+  s3_tpch_suite suite(*env, "tpch/sf1", env->sf1_local_dir, true);
+  suite.run_all_queries();
+}

--- a/test/cpp/utils/s3_container.cpp
+++ b/test/cpp/utils/s3_container.cpp
@@ -54,6 +54,7 @@ extern "C" {
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
@@ -426,6 +427,94 @@ void maybe_upload_large_fixture(minio_instance const& http,
   }
 }
 
+void maybe_upload_tpch_sf1_fixture(minio_instance const& http,
+                                   minio_instance const& tls,
+                                   std::optional<fs::path> const& ca,
+                                   fs::path const& work)
+{
+  if (!env_truthy("SIRIUS_TEST_S3_TPCH") && !env_truthy("SIRIUS_BENCH_S3_TPCH")) return;
+
+  constexpr std::array<std::string_view, 8> tables = {
+    "nation", "region", "customer", "orders", "part", "partsupp", "supplier", "lineitem"};
+  fs::path fixture_dir = work / "tpch_sf1";
+
+  auto fixture_complete = [&] {
+    std::error_code ec;
+    for (auto const table : tables) {
+      auto const parquet = fixture_dir / (std::string{table} + ".parquet");
+      if (!fs::exists(parquet, ec) || fs::file_size(parquet, ec) == 0 || ec) return false;
+    }
+    return true;
+  };
+
+  if (!fixture_complete()) {
+    fs::path duckdb_bin =
+      env_or("SIRIUS_TEST_DUCKDB",
+             (fs::path{SIRIUS_PROJECT_ROOT} / "build" / "release" / "duckdb").string());
+    fs::path db          = work / "tpch_sf1.duckdb";
+    fs::path fixture_tmp = work / "tpch_sf1.tmp";
+    std::error_code ec;
+    fs::remove(db, ec);
+    fs::remove_all(fixture_tmp, ec);
+    fs::create_directories(fixture_tmp);
+
+    std::string sql = "INSTALL tpch; LOAD tpch; CALL dbgen(sf=1); ";
+    for (auto const table : tables) {
+      auto const parquet = fixture_tmp / (std::string{table} + ".parquet");
+      sql += "COPY (SELECT * FROM " + std::string{table} + ") TO '" + parquet.string() +
+             "' (FORMAT PARQUET); ";
+    }
+
+    int rc = run_process({duckdb_bin.string(), db.string(), "-c", sql});
+    fs::remove(db, ec);
+    if (rc != 0) {
+      fs::remove_all(fixture_tmp, ec);
+      throw std::runtime_error("failed to generate SF1 TPC-H parquet fixtures via DuckDB CLI (" +
+                               duckdb_bin.string() + ")");
+    }
+
+    fs::remove_all(fixture_dir, ec);
+    fs::rename(fixture_tmp, fixture_dir, ec);
+    if (ec) throw std::runtime_error("failed to finalize SF1 TPC-H fixture cache: " + ec.message());
+    if (!fixture_complete()) {
+      throw std::runtime_error("SF1 TPC-H fixture generation left an incomplete cache");
+    }
+  } else {
+    std::cout << "[s3] reusing cached SF1 TPC-H fixtures at " << fixture_dir << std::endl;
+  }
+
+  std::uintmax_t total_bytes = 0;
+  for (auto const table : tables) {
+    auto const parquet = fixture_dir / (std::string{table} + ".parquet");
+    auto const key     = "tpch/sf1/" + std::string{table} + ".parquet";
+    auto const bytes   = static_cast<std::int64_t>(fs::file_size(parquet));
+    total_bytes += static_cast<std::uintmax_t>(bytes);
+
+    auto upload = [&](minio_instance const& instance,
+                      std::string const& scheme,
+                      std::optional<fs::path> const& ca_bundle) {
+      std::FILE* file = std::fopen(parquet.c_str(), "rb");
+      if (file == nullptr) {
+        throw std::runtime_error("cannot open SF1 TPC-H fixture: " + parquet.string());
+      }
+      auto const code =
+        s3_put(instance, scheme, uri_path_for(kBucket, key), file, bytes, ca_bundle);
+      std::fclose(file);
+      if (!(code == 200 || code == 204)) {
+        throw std::runtime_error("SF1 TPC-H upload failed for '" + key + "' (HTTP " +
+                                 std::to_string(code) + ") at " + instance.endpoint);
+      }
+    };
+
+    upload(http, "http", std::nullopt);
+    upload(tls, "https", ca);
+  }
+
+  setenv("SIRIUS_TEST_S3_TPCH_LOCAL_DIR", fixture_dir.c_str(), /*overwrite=*/1);
+  std::cout << "[s3] uploaded 8 SF1 TPC-H parquet fixtures (" << total_bytes << " bytes) to "
+            << http.endpoint << " and " << tls.endpoint << std::endl;
+}
+
 // ---- orchestration ---------------------------------------------------------
 
 void setenv_kv(char const* k, std::string const& v) { ::setenv(k, v.c_str(), /*overwrite=*/1); }
@@ -470,6 +559,7 @@ bool bring_up()
   upload_fixtures(http, "http", fixture_dir, std::nullopt);
   upload_fixtures(tls, "https", fixture_dir, ca);
   maybe_upload_large_fixture(http, tls, ca, work);
+  maybe_upload_tpch_sf1_fixture(http, tls, ca, work);
 
   // Publish the env contract the [s3] tests consume (mirrors the old env.sh).
   setenv_kv("SIRIUS_TEST_S3_ENDPOINT", http.endpoint);

--- a/test/cpp/utils/tpch_queries.hpp
+++ b/test/cpp/utils/tpch_queries.hpp
@@ -1,0 +1,399 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * See the LICENSE file at the repo root for the full text.
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <string_view>
+
+namespace sirius::test {
+
+struct tpch_query_spec {
+  std::size_t number;
+  std::string_view sql;
+  std::optional<float> float_tolerance;
+  bool retry_once;
+};
+
+inline constexpr char kTpchQ1[] =
+  "select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, "
+  "sum(l_extendedprice) as sum_base_price, "
+  "sum(l_extendedprice * (1 - l_discount)) as sum_disc_price, "
+  "sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge, "
+  "avg(l_quantity) as avg_qty, avg(l_extendedprice) as avg_price, "
+  "avg(l_discount) as avg_disc, count(*) as count_order "
+  "from lineitem "
+  "where l_shipdate <= date '1995-08-19' "
+  "group by l_returnflag, l_linestatus "
+  "order by l_returnflag, l_linestatus;";
+
+inline constexpr char kTpchQ2[] =
+  "select s.s_acctbal, s.s_name, n.n_name, p.p_partkey, p.p_mfgr, "
+  "s.s_address, s.s_phone, s.s_comment "
+  "from part p, supplier s, partsupp ps, nation n, region r "
+  "where p.p_partkey = ps.ps_partkey and s.s_suppkey = ps.ps_suppkey "
+  "and p.p_size = 41 and p.p_type like '%NICKEL' "
+  "and s.s_nationkey = n.n_nationkey and n.n_regionkey = r.r_regionkey "
+  "and r.r_name = 'EUROPE' "
+  "and ps.ps_supplycost = ("
+  "  select min(ps.ps_supplycost) "
+  "  from partsupp ps, supplier s, nation n, region r "
+  "  where p.p_partkey = ps.ps_partkey and s.s_suppkey = ps.ps_suppkey "
+  "  and s.s_nationkey = n.n_nationkey and n.n_regionkey = r.r_regionkey "
+  "  and r.r_name = 'EUROPE'"
+  ") "
+  "order by s.s_acctbal desc, n.n_name, s.s_name, p.p_partkey "
+  "limit 100;";
+
+inline constexpr char kTpchQ3[] =
+  "select l.l_orderkey, "
+  "sum(l.l_extendedprice * (1 - l.l_discount)) as revenue, "
+  "o.o_orderdate, o.o_shippriority "
+  "from customer c, orders o, lineitem l "
+  "where c.c_mktsegment = 'HOUSEHOLD' and c.c_custkey = o.o_custkey "
+  "and l.l_orderkey = o.o_orderkey "
+  "and o.o_orderdate < date '1995-03-25' "
+  "and l.l_shipdate > date '1995-03-25' "
+  "group by l.l_orderkey, o.o_orderdate, o.o_shippriority "
+  "order by revenue desc, o.o_orderdate "
+  "limit 10;";
+
+inline constexpr char kTpchQ4[] =
+  "select o.o_orderpriority, count(*) as order_count "
+  "from orders o "
+  "where o.o_orderdate >= date '1996-10-01' "
+  "and o.o_orderdate < date '1997-01-01' "
+  "and exists ("
+  "  select * from lineitem l "
+  "  where l.l_orderkey = o.o_orderkey "
+  "  and l.l_commitdate < l.l_receiptdate"
+  ") "
+  "group by o.o_orderpriority "
+  "order by o.o_orderpriority;";
+
+inline constexpr char kTpchQ5[] =
+  "select n.n_name, "
+  "sum(l.l_extendedprice * (1 - l.l_discount)) as revenue "
+  "from orders o, lineitem l, supplier s, nation n, region r, customer c "
+  "where c.c_custkey = o.o_custkey and l.l_orderkey = o.o_orderkey "
+  "and l.l_suppkey = s.s_suppkey and c.c_nationkey = s.s_nationkey "
+  "and s.s_nationkey = n.n_nationkey and n.n_regionkey = r.r_regionkey "
+  "and r.r_name = 'EUROPE' "
+  "and o.o_orderdate >= date '1997-01-01' "
+  "and o.o_orderdate < date '1998-01-01' "
+  "group by n.n_name "
+  "order by revenue desc;";
+
+inline constexpr char kTpchQ6[] =
+  "select sum(l_extendedprice * l_discount) as revenue "
+  "from lineitem "
+  "where l_shipdate >= date '1997-01-01' "
+  "and l_shipdate < date '1998-01-01' "
+  "and l_discount between 0.03 - 0.01 and 0.03 + 0.01 "
+  "and l_quantity < 24;";
+
+inline constexpr char kTpchQ7[] =
+  "select supp_nation, cust_nation, l_year, sum(volume) as revenue "
+  "from ("
+  "  select n1.n_name as supp_nation, n2.n_name as cust_nation, "
+  "  extract(year from l.l_shipdate) as l_year, "
+  "  l.l_extendedprice * (1 - l.l_discount) as volume "
+  "  from supplier s, lineitem l, orders o, customer c, nation n1, nation n2 "
+  "  where s.s_suppkey = l.l_suppkey and o.o_orderkey = l.l_orderkey "
+  "  and c.c_custkey = o.o_custkey and s.s_nationkey = n1.n_nationkey "
+  "  and c.c_nationkey = n2.n_nationkey "
+  "  and ((n1.n_name = 'EGYPT' and n2.n_name = 'UNITED STATES') "
+  "    or (n1.n_name = 'UNITED STATES' and n2.n_name = 'EGYPT')) "
+  "  and l.l_shipdate between date '1995-01-01' and date '1996-12-31'"
+  ") as shipping "
+  "group by supp_nation, cust_nation, l_year "
+  "order by supp_nation, cust_nation, l_year;";
+
+inline constexpr char kTpchQ8[] =
+  "select o_year, "
+  "sum(case when nation = 'EGYPT' then volume else 0 end) / sum(volume) as mkt_share "
+  "from ("
+  "  select extract(year from o.o_orderdate) as o_year, "
+  "  l.l_extendedprice * (1 - l.l_discount) as volume, "
+  "  n2.n_name as nation "
+  "  from lineitem l, part p, supplier s, orders o, customer c, "
+  "  nation n1, nation n2, region r "
+  "  where p.p_partkey = l.l_partkey and s.s_suppkey = l.l_suppkey "
+  "  and l.l_orderkey = o.o_orderkey and o.o_custkey = c.c_custkey "
+  "  and c.c_nationkey = n1.n_nationkey and n1.n_regionkey = r.r_regionkey "
+  "  and r.r_name = 'MIDDLE EAST' and s.s_nationkey = n2.n_nationkey "
+  "  and o.o_orderdate between date '1995-01-01' and date '1996-12-31' "
+  "  and p.p_type = 'PROMO BRUSHED COPPER'"
+  ") as all_nations "
+  "group by o_year "
+  "order by o_year;";
+
+inline constexpr char kTpchQ9[] =
+  "select nation, o_year, sum(amount) as sum_profit "
+  "from ("
+  "  select n.n_name as nation, "
+  "  extract(year from o.o_orderdate) as o_year, "
+  "  l.l_extendedprice * (1 - l.l_discount) - ps.ps_supplycost * l.l_quantity as amount "
+  "  from part p, supplier s, lineitem l, partsupp ps, orders o, nation n "
+  "  where s.s_suppkey = l.l_suppkey and ps.ps_suppkey = l.l_suppkey "
+  "  and ps.ps_partkey = l.l_partkey and p.p_partkey = l.l_partkey "
+  "  and o.o_orderkey = l.l_orderkey and s.s_nationkey = n.n_nationkey "
+  "  and p.p_name like '%yellow%'"
+  ") as profit "
+  "group by nation, o_year "
+  "order by nation, o_year desc;";
+
+inline constexpr char kTpchQ10[] =
+  "select c.c_custkey, c.c_name, "
+  "sum(l.l_extendedprice * (1 - l.l_discount)) as revenue, "
+  "c.c_acctbal, n.n_name, c.c_address, c.c_phone, c.c_comment "
+  "from customer c, orders o, lineitem l, nation n "
+  "where c.c_custkey = o.o_custkey and l.l_orderkey = o.o_orderkey "
+  "and o.o_orderdate >= date '1994-03-01' "
+  "and o.o_orderdate < date '1994-06-01' "
+  "and l.l_returnflag = 'R' "
+  "and c.c_nationkey = n.n_nationkey "
+  "group by c.c_custkey, c.c_name, c.c_acctbal, c.c_phone, "
+  "n.n_name, c.c_address, c.c_comment "
+  "order by revenue desc "
+  "limit 20;";
+
+inline constexpr char kTpchQ11[] =
+  "select ps.ps_partkey, "
+  "sum(ps.ps_supplycost * ps.ps_availqty) as value "
+  "from partsupp ps, supplier s, nation n "
+  "where ps.ps_suppkey = s.s_suppkey "
+  "and s.s_nationkey = n.n_nationkey "
+  "and n.n_name = 'JAPAN' "
+  "group by ps.ps_partkey "
+  "having sum(ps.ps_supplycost * ps.ps_availqty) > ("
+  "  select sum(ps.ps_supplycost * ps.ps_availqty) * 0.0001000000 "
+  "  from partsupp ps, supplier s, nation n "
+  "  where ps.ps_suppkey = s.s_suppkey "
+  "  and s.s_nationkey = n.n_nationkey "
+  "  and n.n_name = 'JAPAN'"
+  ") "
+  "order by value desc;";
+
+inline constexpr char kTpchQ12[] =
+  "select l.l_shipmode, "
+  "sum(case when o.o_orderpriority = '1-URGENT' "
+  "  or o.o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, "
+  "sum(case when o.o_orderpriority <> '1-URGENT' "
+  "  and o.o_orderpriority <> '2-HIGH' then 1 else 0 end) as low_line_count "
+  "from orders o, lineitem l "
+  "where o.o_orderkey = l.l_orderkey "
+  "and l.l_shipmode in ('TRUCK', 'REG AIR') "
+  "and l.l_commitdate < l.l_receiptdate "
+  "and l.l_shipdate < l.l_commitdate "
+  "and l.l_receiptdate >= date '1994-01-01' "
+  "and l.l_receiptdate < date '1995-01-01' "
+  "group by l.l_shipmode "
+  "order by l.l_shipmode;";
+
+inline constexpr char kTpchQ13[] =
+  "select c_count, count(*) as custdist "
+  "from ("
+  "  select c.c_custkey, count(o.o_orderkey) "
+  "  from customer c "
+  "  left outer join orders o "
+  "    on c.c_custkey = o.o_custkey "
+  "    and o.o_comment not like '%special%requests%' "
+  "  group by c.c_custkey"
+  ") as orders (c_custkey, c_count) "
+  "group by c_count "
+  "order by custdist desc, c_count desc;";
+
+inline constexpr char kTpchQ14[] =
+  "select 100.00 * sum(case when p.p_type like 'PROMO%' "
+  "  then l.l_extendedprice * (1 - l.l_discount) else 0 end) "
+  "  / sum(l.l_extendedprice * (1 - l.l_discount)) as promo_revenue "
+  "from lineitem l, part p "
+  "where l.l_partkey = p.p_partkey "
+  "and l.l_shipdate >= date '1994-08-01' "
+  "and l.l_shipdate < date '1994-09-01';";
+
+inline constexpr char kTpchQ15[] =
+  "with revenue_view as ("
+  "  select l_suppkey as supplier_no, "
+  "  sum(l_extendedprice * (1 - l_discount)) as total_revenue "
+  "  from lineitem "
+  "  where l_shipdate >= date '1993-05-01' "
+  "  and l_shipdate < date '1993-08-01' "
+  "  group by l_suppkey"
+  ") "
+  "select s.s_suppkey, s.s_name, s.s_address, s.s_phone, r.total_revenue "
+  "from supplier s, revenue_view r "
+  "where s.s_suppkey = r.supplier_no "
+  "and r.total_revenue = ("
+  "  select max(total_revenue) from revenue_view"
+  ") "
+  "order by s.s_suppkey;";
+
+inline constexpr char kTpchQ16[] =
+  "select p.p_brand, p.p_type, p.p_size, "
+  "count(distinct ps.ps_suppkey) as supplier_cnt "
+  "from partsupp ps, part p "
+  "where p.p_partkey = ps.ps_partkey "
+  "and p.p_brand <> 'Brand#21' "
+  "and p.p_type not like 'MEDIUM PLATED%' "
+  "and p.p_size in (38, 2, 8, 31, 44, 5, 14, 24) "
+  "and ps.ps_suppkey not in ("
+  "  select s.s_suppkey from supplier s "
+  "  where s.s_comment like '%Customer%Complaints%'"
+  ") "
+  "group by p.p_brand, p.p_type, p.p_size "
+  "order by supplier_cnt desc, p.p_brand, p.p_type, p.p_size;";
+
+inline constexpr char kTpchQ17[] =
+  "select sum(l.l_extendedprice) / 7.0 as avg_yearly "
+  "from lineitem l, part p "
+  "where p.p_partkey = l.l_partkey "
+  "and p.p_brand = 'Brand#13' "
+  "and p.p_container = 'JUMBO CAN' "
+  "and l.l_quantity < ("
+  "  select 0.2 * avg(l2.l_quantity) "
+  "  from lineitem l2 "
+  "  where l2.l_partkey = p.p_partkey"
+  ");";
+
+inline constexpr char kTpchQ18[] =
+  "select c.c_name, c.c_custkey, o.o_orderkey, o.o_orderdate, "
+  "o.o_totalprice, sum(l.l_quantity) "
+  "from customer c, orders o, lineitem l "
+  "where o.o_orderkey in ("
+  "  select l_orderkey from lineitem "
+  "  group by l_orderkey having sum(l_quantity) > 300"
+  ") "
+  "and c.c_custkey = o.o_custkey "
+  "and o.o_orderkey = l.l_orderkey "
+  "group by c.c_name, c.c_custkey, o.o_orderkey, o.o_orderdate, o.o_totalprice "
+  "order by o.o_totalprice desc, o.o_orderdate "
+  "limit 100;";
+
+inline constexpr char kTpchQ19[] =
+  "select sum(l.l_extendedprice* (1 - l.l_discount)) as revenue "
+  "from lineitem l, part p "
+  "where ("
+  "  p.p_partkey = l.l_partkey "
+  "  and p.p_brand = 'Brand#41' "
+  "  and p.p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') "
+  "  and l.l_quantity >= 2 and l.l_quantity <= 2 + 10 "
+  "  and p.p_size between 1 and 5 "
+  "  and l.l_shipmode in ('AIR', 'AIR REG') "
+  "  and l.l_shipinstruct = 'DELIVER IN PERSON'"
+  ") or ("
+  "  p.p_partkey = l.l_partkey "
+  "  and p.p_brand = 'Brand#13' "
+  "  and p.p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') "
+  "  and l.l_quantity >= 14 and l.l_quantity <= 14 + 10 "
+  "  and p.p_size between 1 and 10 "
+  "  and l.l_shipmode in ('AIR', 'AIR REG') "
+  "  and l.l_shipinstruct = 'DELIVER IN PERSON'"
+  ") or ("
+  "  p.p_partkey = l.l_partkey "
+  "  and p.p_brand = 'Brand#55' "
+  "  and p.p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') "
+  "  and l.l_quantity >= 23 and l.l_quantity <= 23 + 10 "
+  "  and p.p_size between 1 and 15 "
+  "  and l.l_shipmode in ('AIR', 'AIR REG') "
+  "  and l.l_shipinstruct = 'DELIVER IN PERSON'"
+  ");";
+
+inline constexpr char kTpchQ20[] =
+  "select s.s_name, s.s_address "
+  "from supplier s, nation n "
+  "where s.s_suppkey in ("
+  "  select ps.ps_suppkey from partsupp ps "
+  "  where ps.ps_partkey in ("
+  "    select p.p_partkey from part p where p.p_name like 'antique%'"
+  "  ) "
+  "  and ps.ps_availqty > ("
+  "    select 0.5 * sum(l.l_quantity) "
+  "    from lineitem l "
+  "    where l.l_partkey = ps.ps_partkey "
+  "    and l.l_suppkey = ps.ps_suppkey "
+  "    and l.l_shipdate >= date '1993-01-01' "
+  "    and l.l_shipdate < date '1994-01-01'"
+  "  )"
+  ") "
+  "and s.s_nationkey = n.n_nationkey "
+  "and n.n_name = 'KENYA' "
+  "order by s.s_name;";
+
+inline constexpr char kTpchQ21[] =
+  "select s.s_name, count(*) as numwait "
+  "from supplier s, lineitem l1, orders o, nation n "
+  "where s.s_suppkey = l1.l_suppkey "
+  "and o.o_orderkey = l1.l_orderkey "
+  "and o.o_orderstatus = 'F' "
+  "and l1.l_receiptdate > l1.l_commitdate "
+  "and exists ("
+  "  select * from lineitem l2 "
+  "  where l2.l_orderkey = l1.l_orderkey "
+  "  and l2.l_suppkey <> l1.l_suppkey"
+  ") "
+  "and not exists ("
+  "  select * from lineitem l3 "
+  "  where l3.l_orderkey = l1.l_orderkey "
+  "  and l3.l_suppkey <> l1.l_suppkey "
+  "  and l3.l_receiptdate > l3.l_commitdate"
+  ") "
+  "and s.s_nationkey = n.n_nationkey "
+  "and n.n_name = 'BRAZIL' "
+  "group by s.s_name "
+  "order by numwait desc, s.s_name "
+  "limit 100;";
+
+inline constexpr char kTpchQ22[] =
+  "select cntrycode, count(*) as numcust, sum(c_acctbal) as totacctbal "
+  "from ("
+  "  select substring(c_phone from 1 for 2) as cntrycode, c_acctbal "
+  "  from customer c "
+  "  where substring(c_phone from 1 for 2) in "
+  "    ('24', '31', '11', '16', '21', '20', '34') "
+  "  and c_acctbal > ("
+  "    select avg(c_acctbal) from customer "
+  "    where c_acctbal > 0.00 "
+  "    and substring(c_phone from 1 for 2) in "
+  "      ('24', '31', '11', '16', '21', '20', '34')"
+  "  ) "
+  "  and not exists ("
+  "    select * from orders o where o.o_custkey = c.c_custkey"
+  "  )"
+  ") as custsale "
+  "group by cntrycode "
+  "order by cntrycode;";
+
+inline constexpr std::array<tpch_query_spec, 22> kTpchQueries{{
+  tpch_query_spec{1, kTpchQ1, 0.00001f, false},
+  tpch_query_spec{2, kTpchQ2, std::nullopt, false},
+  tpch_query_spec{3, kTpchQ3, std::nullopt, false},
+  tpch_query_spec{4, kTpchQ4, std::nullopt, true},
+  tpch_query_spec{5, kTpchQ5, std::nullopt, false},
+  tpch_query_spec{6, kTpchQ6, std::nullopt, false},
+  tpch_query_spec{7, kTpchQ7, std::nullopt, false},
+  tpch_query_spec{8, kTpchQ8, std::nullopt, false},
+  tpch_query_spec{9, kTpchQ9, std::nullopt, false},
+  tpch_query_spec{10, kTpchQ10, std::nullopt, false},
+  tpch_query_spec{11, kTpchQ11, std::nullopt, false},
+  tpch_query_spec{12, kTpchQ12, std::nullopt, false},
+  tpch_query_spec{13, kTpchQ13, std::nullopt, false},
+  tpch_query_spec{14, kTpchQ14, std::nullopt, false},
+  tpch_query_spec{15, kTpchQ15, std::nullopt, false},
+  tpch_query_spec{16, kTpchQ16, std::nullopt, false},
+  tpch_query_spec{17, kTpchQ17, std::nullopt, false},
+  tpch_query_spec{18, kTpchQ18, std::nullopt, false},
+  tpch_query_spec{19, kTpchQ19, std::nullopt, false},
+  tpch_query_spec{20, kTpchQ20, std::nullopt, false},
+  tpch_query_spec{21, kTpchQ21, std::nullopt, false},
+  tpch_query_spec{22, kTpchQ22, std::nullopt, false},
+}};
+
+}  // namespace sirius::test


### PR DESCRIPTION
Run the canonical TPC-H Q1-Q22 over transparent s3:// parquet views and assert each result equals a separate local DuckDB-CPU oracle, executed GPU-only with zero fallback (verified per query). 

Two scales: a tiny variant over the 8 already-uploaded fixtures runs in `make s3-test`, and an SF1 variant generates and uploads an 8-table SF1 fixture (gated SIRIUS_TEST_S3_TPCH) and runs in a new `make s3-tpch` target and the large gate. A per-query wall-clock benchmark records an S3 arm against a local SF1 arm (gated SIRIUS_BENCH_S3_TPCH), excluded from the routine bench.

The Q1-Q22 texts move into a shared test/cpp/utils/tpch_queries.hpp so the local suite and the S3 tier query from one source; the local suite is unchanged (22 cases, 18491 assertions).

make s3-test 49->50; make s3-tpch runs both scales; routine make s3-bench stays at 2 cases.