### PR TITLE
feat: perf improvement - configurable REST bounce grain

### DIFF
--- a/src/include/io/rest/config.hpp
+++ b/src/include/io/rest/config.hpp
@@ -53,37 +53,28 @@ struct config {
   std::size_t max_read_split{16};
 
   /// Bounce-slot size (bytes) for the reactor-staged device path — also the
-  /// window grain @c prep_device_rx_request splits device reads by (the static
-  /// prep needs this size without access to the live staging resource, which
-  /// lives on the @c reactor_context).  Nonzero is authoritative and must be a
-  /// whole multiple of (and at least) the host staging block size — validated
-  /// at datasource construction and in the reactor constructor.  Zero means
-  /// auto: the factory substitutes the staging resource's block size, or
-  /// keeps 0 (device reads disabled) when no staging resource exists.  Values
-  /// above @c max_bounce_block_size are rejected outright.  A grain larger
-  /// than one staging block switches the bounce pool to one contiguous pinned
-  /// span BOOKED against the host staging budget (FSMR reservation, stricter
-  /// reservation-limit admission than the block path's capacity admission).
+  /// window grain @c prep_device_rx_request splits device reads by (the
+  /// static prep cannot reach the live staging resource).  Nonzero is
+  /// authoritative (whole multiple of the host block size,
+  /// <= @c max_bounce_block_size); a larger-than-block grain stages through
+  /// one budget-booked contiguous span instead of per-slot staging blocks.
+  /// 0 = auto: the host block size, or disabled when no staging resource
+  /// exists.
   std::size_t bounce_block_size{0};
 
-  /// RESOLVED host reservation limit (bytes), stamped by sirius_config after
+  /// RESOLVED host reservation limit, stamped by sirius_config after
   /// memory-space resolution so runtime budget failures can report exact
   /// needed/limit/shortfall (the staging pool exposes no limit getter).
-  /// Internal carrier — NOT a YAML key; 0 = unknown (direct construction),
-  /// in which case errors fall back to the capacity-headroom upper bound.
+  /// Internal carrier — NOT a YAML key; 0 = unknown, errors then fall back to
+  /// the capacity-headroom upper bound.
   std::size_t resolved_host_reservation_limit{0};
 
-  /// Hard ceiling for @c bounce_block_size (1 GiB).  This is a per-SLOT grain
-  /// bound for arithmetic hygiene (the reactor additionally guards
-  /// max_connections * grain against size_t overflow); the pool-level bound is
-  /// @c max_bounce_pool_bytes below.
+  /// Per-slot ceiling for @c bounce_block_size; the pool-level bound is
+  /// @c max_bounce_pool_bytes.
   static constexpr std::size_t max_bounce_block_size{1UL << 30};
 
-  /// Hard ceiling for the whole bounce pool (2 GiB):
-  /// reactors * max_connections * bounce_block_size must not exceed this,
-  /// whichever knob produced the product.  Calibrated so the largest
-  /// known-legal geometry (8 reactors * 256 connections * 1 MiB) sits exactly
-  /// at the cap.
+  /// Ceiling for the whole bounce pool: reactors * max_connections *
+  /// bounce_block_size, whichever knob produced the product.
   static constexpr std::size_t max_bounce_pool_bytes{2UL << 30};
 
   /// Idle-connection keepalive.  While the reactor is idle, every
@@ -132,10 +123,9 @@ struct config {
   std::size_t footer_probe_bytes{512UL << 10};  // 512 KiB
 };
 
-/// Overflow-safe reactors * connections * grain — THE bounce-pool sizing
-/// formula, shared verbatim by the YAML preflight, the datasource factory and
-/// the reactor context so the three admission sites cannot drift.  nullopt on
-/// size_t overflow (two-stage checked multiply).
+/// Overflow-safe reactors * connections * grain: the single bounce-pool
+/// sizing formula for every admission site (YAML preflight, factory, reactor
+/// context).  nullopt on size_t overflow.
 [[nodiscard]] inline std::optional<std::size_t> checked_bounce_pool_bytes(
   std::size_t n_reactors, std::size_t max_connections, std::size_t grain) noexcept
 {

--- a/src/include/io/rest/config.hpp
+++ b/src/include/io/rest/config.hpp
@@ -18,6 +18,8 @@
 
 #include <chrono>
 #include <cstddef>
+#include <limits>
+#include <optional>
 
 namespace sirius::io::rest {
 
@@ -50,12 +52,39 @@ struct config {
   /// than 2 MiB stays a single GET.
   std::size_t max_read_split{16};
 
-  /// Bounce-slot size (bytes) for the reactor-staged device path, cached from
-  /// the staging resource's block size by @c rest_ioctx.  Zero disables the
-  /// reactor-staged device read (the static @c prep_device_rx_request needs
-  /// this size without access to the live resource, which lives on the
-  /// @c reactor_context).
+  /// Bounce-slot size (bytes) for the reactor-staged device path — also the
+  /// window grain @c prep_device_rx_request splits device reads by (the static
+  /// prep needs this size without access to the live staging resource, which
+  /// lives on the @c reactor_context).  Nonzero is authoritative and must be a
+  /// whole multiple of (and at least) the host staging block size — validated
+  /// at datasource construction and in the reactor constructor.  Zero means
+  /// auto: the factory substitutes the staging resource's block size, or
+  /// keeps 0 (device reads disabled) when no staging resource exists.  Values
+  /// above @c max_bounce_block_size are rejected outright.  A grain larger
+  /// than one staging block switches the bounce pool to one contiguous pinned
+  /// span BOOKED against the host staging budget (FSMR reservation, stricter
+  /// reservation-limit admission than the block path's capacity admission).
   std::size_t bounce_block_size{0};
+
+  /// RESOLVED host reservation limit (bytes), stamped by sirius_config after
+  /// memory-space resolution so runtime budget failures can report exact
+  /// needed/limit/shortfall (the staging pool exposes no limit getter).
+  /// Internal carrier — NOT a YAML key; 0 = unknown (direct construction),
+  /// in which case errors fall back to the capacity-headroom upper bound.
+  std::size_t resolved_host_reservation_limit{0};
+
+  /// Hard ceiling for @c bounce_block_size (1 GiB).  This is a per-SLOT grain
+  /// bound for arithmetic hygiene (the reactor additionally guards
+  /// max_connections * grain against size_t overflow); the pool-level bound is
+  /// @c max_bounce_pool_bytes below.
+  static constexpr std::size_t max_bounce_block_size{1UL << 30};
+
+  /// Hard ceiling for the whole bounce pool (2 GiB):
+  /// reactors * max_connections * bounce_block_size must not exceed this,
+  /// whichever knob produced the product.  Calibrated so the largest
+  /// known-legal geometry (8 reactors * 256 connections * 1 MiB) sits exactly
+  /// at the cap.
+  static constexpr std::size_t max_bounce_pool_bytes{2UL << 30};
 
   /// Idle-connection keepalive.  While the reactor is idle, every
   /// @c upkeep_interval the worker calls @c curl_easy_upkeep on its pooled
@@ -102,5 +131,22 @@ struct config {
   /// workloads.
   std::size_t footer_probe_bytes{512UL << 10};  // 512 KiB
 };
+
+/// Overflow-safe reactors * connections * grain — THE bounce-pool sizing
+/// formula, shared verbatim by the YAML preflight, the datasource factory and
+/// the reactor context so the three admission sites cannot drift.  nullopt on
+/// size_t overflow (two-stage checked multiply).
+[[nodiscard]] inline std::optional<std::size_t> checked_bounce_pool_bytes(
+  std::size_t n_reactors, std::size_t max_connections, std::size_t grain) noexcept
+{
+  if (n_reactors != 0 && max_connections > std::numeric_limits<std::size_t>::max() / n_reactors) {
+    return std::nullopt;
+  }
+  std::size_t const slots = n_reactors * max_connections;
+  if (slots != 0 && grain > std::numeric_limits<std::size_t>::max() / slots) {
+    return std::nullopt;
+  }
+  return slots * grain;
+}
 
 }  // namespace sirius::io::rest

--- a/src/include/io/rest/rest_ioctx.hpp
+++ b/src/include/io/rest/rest_ioctx.hpp
@@ -47,12 +47,25 @@ class rest_ioctx : public templated_ioctx<rest_reactor> {
   /// @c templated_ioctx.
   rest_ioctx(std::size_t n_reactors, std::shared_ptr<rest_reactor::reactor_context> ctx);
 
+  /// Prepares the context's shared bounce span (large-grain staging: one
+  /// accounted contiguous allocation for the whole pool) BEFORE the base class
+  /// starts any reactor worker — budget failures surface here, with no thread
+  /// or GET in flight.  Then delegates to the base start (idempotent).
+  void start() override;
+
   [[nodiscard]] io_context_type type() const noexcept override { return io_context_type::restful; }
 
   /// Pool-aggregated perf counters: every reactor's snapshot summed (ns totals,
   /// counts, retries, terminal, device-sync), maxes maxed, and ttfb the first
   /// non-zero reactor value.  Lock-free; drives the s3-bench JSON baseline.
   [[nodiscard]] rest_perf_snapshot perf_snapshot() const noexcept;
+
+  /// One entry per reactor whose staging is backed by the dedicated
+  /// large-grain bounce pool (empty on the default block-carve path), with
+  /// @c reactor_index assigned by pool position.  Exists so the shared-span
+  /// slice invariants (one allocation, r * conns * grain offsets, no overlap)
+  /// are externally verifiable — see rest_bounce_slice_snapshot.
+  [[nodiscard]] std::vector<rest_bounce_slice_snapshot> bounce_slice_snapshots() const;
 
  protected:
   /// Backend hook invoked by @c sirius_ioctx::open_datasource: parse @p path
@@ -66,6 +79,10 @@ class rest_ioctx : public templated_ioctx<rest_reactor> {
   std::shared_ptr<sirius_io_object> create_io_object(std::string path, open_hint hint) override;
 
  private:
+  /// The pool's shared context (also captured by every reactor); kept here so
+  /// start() can prepare the bounce span before the reactors run.
+  std::shared_ptr<rest_reactor::reactor_context> _pool_ctx;
+
   /// Resolve @p path with a single suffix-range GET: it discovers the size and
   /// stashes the object's trailing bytes on the returned io_object so cuDF's
   /// footer reads are served locally by @c rest_reactor::host_read.  Falls back

--- a/src/include/io/rest/rest_ioctx.hpp
+++ b/src/include/io/rest/rest_ioctx.hpp
@@ -47,10 +47,9 @@ class rest_ioctx : public templated_ioctx<rest_reactor> {
   /// @c templated_ioctx.
   rest_ioctx(std::size_t n_reactors, std::shared_ptr<rest_reactor::reactor_context> ctx);
 
-  /// Prepares the context's shared bounce span (large-grain staging: one
-  /// accounted contiguous allocation for the whole pool) BEFORE the base class
-  /// starts any reactor worker — budget failures surface here, with no thread
-  /// or GET in flight.  Then delegates to the base start (idempotent).
+  /// Prepares the context's shared bounce span BEFORE the base class starts
+  /// any reactor worker — budget failures surface with no thread or GET in
+  /// flight.
   void start() override;
 
   [[nodiscard]] io_context_type type() const noexcept override { return io_context_type::restful; }
@@ -60,11 +59,9 @@ class rest_ioctx : public templated_ioctx<rest_reactor> {
   /// non-zero reactor value.  Lock-free; drives the s3-bench JSON baseline.
   [[nodiscard]] rest_perf_snapshot perf_snapshot() const noexcept;
 
-  /// One entry per reactor whose staging is backed by the dedicated
-  /// large-grain bounce pool (empty on the default block-carve path), with
-  /// @c reactor_index assigned by pool position.  Exists so the shared-span
-  /// slice invariants (one allocation, r * conns * grain offsets, no overlap)
-  /// are externally verifiable — see rest_bounce_slice_snapshot.
+  /// One entry per reactor backed by the shared bounce span (empty on the
+  /// default block-carve path), @c reactor_index assigned by pool position —
+  /// see rest_bounce_slice_snapshot.
   [[nodiscard]] std::vector<rest_bounce_slice_snapshot> bounce_slice_snapshots() const;
 
  protected:
@@ -79,8 +76,7 @@ class rest_ioctx : public templated_ioctx<rest_reactor> {
   std::shared_ptr<sirius_io_object> create_io_object(std::string path, open_hint hint) override;
 
  private:
-  /// The pool's shared context (also captured by every reactor); kept here so
-  /// start() can prepare the bounce span before the reactors run.
+  /// The pool's shared context, kept so start() can prepare the bounce span.
   std::shared_ptr<rest_reactor::reactor_context> _pool_ctx;
 
   /// Resolve @p path with a single suffix-range GET: it discovers the size and

--- a/src/include/io/rest/rest_reactor.hpp
+++ b/src/include/io/rest/rest_reactor.hpp
@@ -157,14 +157,9 @@ struct rest_perf_snapshot {
 // rest_bounce_slice_snapshot
 // ---------------------------------------------------------------------------
 
-/// Test-observation view of one reactor's bounce staging slice, exposed so the
-/// slice invariants of the shared-span design are verifiable from outside:
-/// every entry of a pool shares one allocation (same @c allocation_id and
-/// @c span_bytes), reactor r's slice starts at r * conns * grain
-/// (@c offset_bytes) and covers conns * grain bytes (@c slice_bytes), with no
-/// overlap and full span coverage.  @c allocation_id is an opaque identity —
-/// never dereference it.  Populated only for the dedicated large-grain path
-/// after start(); the default block-carve path reports nothing.
+/// Test-observation view of one reactor's slice of the shared bounce span
+/// (large-grain staging only; the default block-carve path reports nothing).
+/// @c allocation_id is an opaque identity — never dereference it.
 struct rest_bounce_slice_snapshot {
   std::size_t reactor_index{0};
   std::uintptr_t allocation_id{0};
@@ -224,14 +219,12 @@ class rest_reactor {
       return _host_mr;
     }
 
-    /// One-shot: book (FSMR reserve, same host ledger with the stricter
-    /// reservation-limit admission) and allocate (one contiguous NUMA-bound
-    /// upstream region) the shared bounce span for @p n_reactors.  Called by
-    /// rest_ioctx::start() BEFORE any reactor worker starts.  No-op when
-    /// staging is absent, the grain equals the staging block size (default
-    /// block-carve path), or the span is already prepared.  Budget failures
-    /// throw with needed/limit/shortfall BEFORE any upstream allocation; an
-    /// upstream failure after a successful booking unwinds the booking.
+    /// One-shot: book (FSMR reserve) and allocate (one contiguous pinned
+    /// region from the selected HOST resource's upstream) the shared bounce
+    /// span for @p n_reactors.  No-op when staging is absent, the grain
+    /// equals the staging block size, or the span is already prepared.
+    /// Budget failures throw BEFORE any upstream allocation; an upstream
+    /// failure after a successful booking unwinds it.
     void prepare_bounce_span(std::size_t n_reactors);
 
     struct bounce_slice {
@@ -239,9 +232,8 @@ class rest_reactor {
       std::size_t index{0};
     };
 
-    /// Claim the next reactor slice of the prepared span (called from
-    /// rest_reactor::start(), sequential pool order under the base start
-    /// loop).  nullopt when no span exists (default path).  Throws if more
+    /// Claim the next reactor slice of the prepared span (start()-time, pool
+    /// order).  nullopt when no span exists (default path); throws if more
     /// reactors claim than the span was prepared for.
     [[nodiscard]] std::optional<bounce_slice> claim_bounce_slice();
 
@@ -256,9 +248,9 @@ class rest_reactor {
     std::shared_ptr<s3::s3_request_authorizer> _authorizer;
     cucascade::memory::fixed_size_host_memory_resource* _host_mr{nullptr};
 
-    // Shared bounce span (large-grain staging): the booking keeps the bytes
-    // visible in the host budget while the physical region lives outside the
-    // pool's block inventory (one contiguous slab-equivalent).
+    // Shared bounce span: the booking keeps the bytes visible in the host
+    // budget while the physical region lives outside the pool's block
+    // inventory.
     std::unique_ptr<cucascade::memory::reserved_arena> _bounce_booking;
     void* _bounce_span{nullptr};
     std::size_t _bounce_span_bytes{0};
@@ -345,10 +337,8 @@ class rest_reactor {
   /// loads); safe to call while the reactor is running.
   [[nodiscard]] rest_perf_snapshot perf_snapshot() const noexcept;
 
-  /// This reactor's bounce slice, when the dedicated large-grain pool backs
-  /// staging (nullopt on the default block-carve path or before start()).
-  /// @c reactor_index is left 0 — rest_ioctx assigns it by pool position.
-  /// Immutable once start() ran, so safe to call while the reactor is running.
+  /// This reactor's bounce slice (nullopt on the default block-carve path or
+  /// before start()); @c reactor_index is assigned by rest_ioctx.
   [[nodiscard]] std::optional<rest_bounce_slice_snapshot> bounce_slice_snapshot() const noexcept;
 
   // -- capabilities / factory ----------------------------------------------
@@ -393,10 +383,8 @@ class rest_reactor {
   // reactor is destroyed.  Null when no host_memory_resource is set.
   cucascade::memory::fixed_multiple_blocks_allocation _bounce_storage;
 
-  // This reactor's slice of the context's shared bounce span (large-grain
-  // staging): base of max_connections * _bounce_slot_size contiguous bytes,
-  // claimed from the context in start().  Null on the default block-carve
-  // path.  Exactly one of _bounce_storage / _bounce_slice_base is set when
+  // This reactor's slice of the context's shared bounce span, claimed in
+  // start().  Exactly one of _bounce_storage / _bounce_slice_base is set when
   // staging is enabled.
   uint8_t* _bounce_slice_base{nullptr};
   std::size_t _reactor_index{0};

--- a/src/include/io/rest/rest_reactor.hpp
+++ b/src/include/io/rest/rest_reactor.hpp
@@ -154,6 +154,26 @@ struct rest_perf_snapshot {
 };
 
 // ---------------------------------------------------------------------------
+// rest_bounce_slice_snapshot
+// ---------------------------------------------------------------------------
+
+/// Test-observation view of one reactor's bounce staging slice, exposed so the
+/// slice invariants of the shared-span design are verifiable from outside:
+/// every entry of a pool shares one allocation (same @c allocation_id and
+/// @c span_bytes), reactor r's slice starts at r * conns * grain
+/// (@c offset_bytes) and covers conns * grain bytes (@c slice_bytes), with no
+/// overlap and full span coverage.  @c allocation_id is an opaque identity —
+/// never dereference it.  Populated only for the dedicated large-grain path
+/// after start(); the default block-carve path reports nothing.
+struct rest_bounce_slice_snapshot {
+  std::size_t reactor_index{0};
+  std::uintptr_t allocation_id{0};
+  std::size_t span_bytes{0};
+  std::size_t offset_bytes{0};
+  std::size_t slice_bytes{0};
+};
+
+// ---------------------------------------------------------------------------
 // rest_reactor
 // ---------------------------------------------------------------------------
 
@@ -185,6 +205,14 @@ class rest_reactor {
     {
     }
 
+    /// Teardown order is load-bearing: the physical span returns to the
+    /// upstream BEFORE its FSMR booking is released, so the budget never
+    /// under-reports live pinned memory.
+    ~reactor_context();
+
+    reactor_context(reactor_context const&)            = delete;
+    reactor_context& operator=(reactor_context const&) = delete;
+
     [[nodiscard]] const config& cfg() const noexcept { return _config; }
     [[nodiscard]] const std::shared_ptr<s3::s3_request_authorizer>& authorizer() const noexcept
     {
@@ -196,10 +224,47 @@ class rest_reactor {
       return _host_mr;
     }
 
+    /// One-shot: book (FSMR reserve, same host ledger with the stricter
+    /// reservation-limit admission) and allocate (one contiguous NUMA-bound
+    /// upstream region) the shared bounce span for @p n_reactors.  Called by
+    /// rest_ioctx::start() BEFORE any reactor worker starts.  No-op when
+    /// staging is absent, the grain equals the staging block size (default
+    /// block-carve path), or the span is already prepared.  Budget failures
+    /// throw with needed/limit/shortfall BEFORE any upstream allocation; an
+    /// upstream failure after a successful booking unwinds the booking.
+    void prepare_bounce_span(std::size_t n_reactors);
+
+    struct bounce_slice {
+      uint8_t* base{nullptr};
+      std::size_t index{0};
+    };
+
+    /// Claim the next reactor slice of the prepared span (called from
+    /// rest_reactor::start(), sequential pool order under the base start
+    /// loop).  nullopt when no span exists (default path).  Throws if more
+    /// reactors claim than the span was prepared for.
+    [[nodiscard]] std::optional<bounce_slice> claim_bounce_slice();
+
+    [[nodiscard]] const uint8_t* bounce_span_base() const noexcept
+    {
+      return static_cast<const uint8_t*>(_bounce_span);
+    }
+    [[nodiscard]] std::size_t bounce_span_bytes() const noexcept { return _bounce_span_bytes; }
+
    private:
     config _config;
     std::shared_ptr<s3::s3_request_authorizer> _authorizer;
     cucascade::memory::fixed_size_host_memory_resource* _host_mr{nullptr};
+
+    // Shared bounce span (large-grain staging): the booking keeps the bytes
+    // visible in the host budget while the physical region lives outside the
+    // pool's block inventory (one contiguous slab-equivalent).
+    std::unique_ptr<cucascade::memory::reserved_arena> _bounce_booking;
+    void* _bounce_span{nullptr};
+    std::size_t _bounce_span_bytes{0};
+    std::size_t _bounce_slice_bytes{0};
+    std::size_t _bounce_n_reactors{0};
+    std::atomic<std::size_t> _bounce_claims{0};
   };
 
   using io_object_type       = rest_io_object;
@@ -280,6 +345,12 @@ class rest_reactor {
   /// loads); safe to call while the reactor is running.
   [[nodiscard]] rest_perf_snapshot perf_snapshot() const noexcept;
 
+  /// This reactor's bounce slice, when the dedicated large-grain pool backs
+  /// staging (nullopt on the default block-carve path or before start()).
+  /// @c reactor_index is left 0 — rest_ioctx assigns it by pool position.
+  /// Immutable once start() ran, so safe to call while the reactor is running.
+  [[nodiscard]] std::optional<rest_bounce_slice_snapshot> bounce_slice_snapshot() const noexcept;
+
   // -- capabilities / factory ----------------------------------------------
 
   /// True iff @p path is an s3:// URL this reactor can serve.
@@ -321,6 +392,14 @@ class rest_reactor {
   // allocation handle returns the blocks to the upstream resource when the
   // reactor is destroyed.  Null when no host_memory_resource is set.
   cucascade::memory::fixed_multiple_blocks_allocation _bounce_storage;
+
+  // This reactor's slice of the context's shared bounce span (large-grain
+  // staging): base of max_connections * _bounce_slot_size contiguous bytes,
+  // claimed from the context in start().  Null on the default block-carve
+  // path.  Exactly one of _bounce_storage / _bounce_slice_base is set when
+  // staging is enabled.
+  uint8_t* _bounce_slice_base{nullptr};
+  std::size_t _reactor_index{0};
 
   // Cross-thread wakeup: written by enqueue()/interrupt() and the CUDA
   // copy-completion callback to break the worker out of epoll_wait.

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -179,6 +179,14 @@ struct sirius_config {
   /// the override takes effect. Called from the end of @ref load_from_file.
   void enforce_sirius_datasource_for_multi_gpu();
 
+  /// When an explicit @c scan_manager.rest.bounce_block_size is configured,
+  /// validate the whole bounce-pool footprint against the RESOLVED host memory
+  /// space (the first HOST entry of @c _memory_space_configs — the one the
+  /// REST backend will select at runtime) and the pool ceiling.  Throws with a
+  /// needed/limit/shortfall message so misconfiguration fails at startup, not
+  /// at the first s3:// query.  Called from the end of @ref load_from_file.
+  void preflight_rest_bounce_span() const;
+
   cucascade::memory::system_topology_info _hw_topology{.num_gpus = 1};
   std::vector<cucascade::memory::memory_space_config> _memory_space_configs;
   exec::thread_pool_config _task_creator_config{.num_threads        = 2,

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -180,11 +180,9 @@ struct sirius_config {
   void enforce_sirius_datasource_for_multi_gpu();
 
   /// When an explicit @c scan_manager.rest.bounce_block_size is configured,
-  /// validate the whole bounce-pool footprint against the RESOLVED host memory
-  /// space (the first HOST entry of @c _memory_space_configs — the one the
-  /// REST backend will select at runtime) and the pool ceiling.  Throws with a
-  /// needed/limit/shortfall message so misconfiguration fails at startup, not
-  /// at the first s3:// query.  Called from the end of @ref load_from_file.
+  /// validate the bounce-pool footprint against the RESOLVED host memory
+  /// space and the pool ceiling, so misconfiguration fails at startup instead
+  /// of at the first s3:// query.  Called from the end of @ref load_from_file.
   void preflight_rest_bounce_span() const;
 
   cucascade::memory::system_topology_info _hw_topology{.num_gpus = 1};

--- a/src/io/datasource_factory.cpp
+++ b/src/io/datasource_factory.cpp
@@ -34,10 +34,12 @@
 
 #include <cctype>
 #include <exception>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 namespace sirius::io {
@@ -146,10 +148,48 @@ factory_type make_rest_ioctx_factory(
         return nullptr;
       }
       // Host staging is optional for REST — when absent, reactor-staged device
-      // reads are disabled (bounce_block_size 0), host reads still work.
-      auto* host_mr              = first_host_resource(reservation_manager);
-      auto rest_cfg              = config.rest;
-      rest_cfg.bounce_block_size = host_mr != nullptr ? host_mr->get_block_size() : 0;
+      // reads are disabled (bounce_block_size 0), host reads still work.  A
+      // configured rest.bounce_block_size is authoritative when nonzero (it
+      // must be a whole multiple of the staging block size, since the default
+      // grain carves bounce slots from staging blocks); zero falls back to the
+      // staging resource's block size.
+      auto* host_mr = first_host_resource(reservation_manager);
+      auto rest_cfg = config.rest;
+      if (host_mr == nullptr) {
+        if (rest_cfg.bounce_block_size != 0) {
+          SIRIUS_LOG_WARN(
+            "make_rest_ioctx_factory: rest.bounce_block_size is configured but no host staging "
+            "resource is available; reactor-staged device reads stay disabled");
+        }
+        rest_cfg.bounce_block_size = 0;
+      } else if (rest_cfg.bounce_block_size == 0) {
+        rest_cfg.bounce_block_size = host_mr->get_block_size();
+      } else if (rest_cfg.bounce_block_size < host_mr->get_block_size() ||
+                 rest_cfg.bounce_block_size % host_mr->get_block_size() != 0 ||
+                 rest_cfg.bounce_block_size > rest::config::max_bounce_block_size) {
+        throw std::invalid_argument(
+          "make_rest_ioctx_factory: rest.bounce_block_size (" +
+          std::to_string(rest_cfg.bounce_block_size) +
+          " bytes) must be a whole multiple of the host staging block size (" +
+          std::to_string(host_mr->get_block_size()) + " bytes) and at most " +
+          std::to_string(rest::config::max_bounce_block_size) + " bytes");
+      }
+      if (host_mr != nullptr && rest_cfg.bounce_block_size != 0) {
+        // Pool-level ceiling on the RESOLVED grain — both axes (connections
+        // and grain) obey the same bound; the shared formula keeps this site,
+        // the YAML preflight, and the reactor context from drifting.
+        auto const pool = rest::checked_bounce_pool_bytes(
+          config.rest_n_reactors, rest_cfg.max_connections, rest_cfg.bounce_block_size);
+        if (!pool || *pool > rest::config::max_bounce_pool_bytes) {
+          auto const needed = pool ? *pool : std::numeric_limits<std::size_t>::max();
+          auto const cap    = rest::config::max_bounce_pool_bytes;
+          throw std::invalid_argument(
+            "make_rest_ioctx_factory: rest bounce pool (rest_n_reactors x max_connections x "
+            "bounce_block_size) needed " +
+            std::to_string(needed) + " bytes, admissible limit " + std::to_string(cap) +
+            " bytes, shortfall " + std::to_string(needed - cap) + " bytes");
+        }
+      }
       // The object store owns the endpoint and its TLS trust; the reactor's
       // curl GETs must verify against the same CA bundle / policy the authorizer
       // presigns for, so source these from object_store rather than rest config.

--- a/src/io/datasource_factory.cpp
+++ b/src/io/datasource_factory.cpp
@@ -148,19 +148,13 @@ factory_type make_rest_ioctx_factory(
         return nullptr;
       }
       // Host staging is optional for REST — when absent, reactor-staged device
-      // reads are disabled (bounce_block_size 0), host reads still work.  A
-      // configured rest.bounce_block_size is authoritative when nonzero (it
-      // must be a whole multiple of the staging block size, since the default
-      // grain carves bounce slots from staging blocks); zero falls back to the
-      // staging resource's block size.
+      // reads are disabled (bounce_block_size 0), host reads still work.
       auto* host_mr = first_host_resource(reservation_manager);
       auto rest_cfg = config.rest;
       if (host_mr == nullptr) {
         if (rest_cfg.bounce_block_size != 0) {
-          // An explicitly configured grain must take effect or fail — never
-          // silently degrade to host-read-only staging.  (The YAML path is
-          // already rejected by the config preflight; this covers programmatic
-          // configs.)
+          // An explicit grain must take effect or fail — never silently
+          // degrade to host-read-only staging.
           throw std::invalid_argument(
             "make_rest_ioctx_factory: rest.bounce_block_size is configured but no host staging "
             "resource is available for reactor-staged device reads");
@@ -179,9 +173,8 @@ factory_type make_rest_ioctx_factory(
           std::to_string(rest::config::max_bounce_block_size) + " bytes");
       }
       if (host_mr != nullptr && rest_cfg.bounce_block_size != 0) {
-        // Pool-level ceiling on the RESOLVED grain — both axes (connections
-        // and grain) obey the same bound; the shared formula keeps this site,
-        // the YAML preflight, and the reactor context from drifting.
+        // Apply the same resolved pool formula and ceiling used by the config
+        // preflight and reactor-context preparation.
         auto const pool = rest::checked_bounce_pool_bytes(
           config.rest_n_reactors, rest_cfg.max_connections, rest_cfg.bounce_block_size);
         if (!pool || *pool > rest::config::max_bounce_pool_bytes) {

--- a/src/io/datasource_factory.cpp
+++ b/src/io/datasource_factory.cpp
@@ -157,9 +157,13 @@ factory_type make_rest_ioctx_factory(
       auto rest_cfg = config.rest;
       if (host_mr == nullptr) {
         if (rest_cfg.bounce_block_size != 0) {
-          SIRIUS_LOG_WARN(
+          // An explicitly configured grain must take effect or fail — never
+          // silently degrade to host-read-only staging.  (The YAML path is
+          // already rejected by the config preflight; this covers programmatic
+          // configs.)
+          throw std::invalid_argument(
             "make_rest_ioctx_factory: rest.bounce_block_size is configured but no host staging "
-            "resource is available; reactor-staged device reads stay disabled");
+            "resource is available for reactor-staged device reads");
         }
         rest_cfg.bounce_block_size = 0;
       } else if (rest_cfg.bounce_block_size == 0) {

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -29,10 +29,19 @@
 namespace sirius::io::rest {
 
 rest_ioctx::rest_ioctx(std::size_t n_reactors, std::shared_ptr<rest_reactor::reactor_context> ctx)
-  : templated_ioctx<rest_reactor>(n_reactors, [ctx = std::move(ctx), i = 0]() mutable {
-      return std::make_unique<rest_reactor>(ctx, fmt::format("rest-{}", i++));
-    })
+  : templated_ioctx<rest_reactor>(n_reactors,
+                                  [ctx, i = 0]() mutable {
+                                    return std::make_unique<rest_reactor>(
+                                      ctx, fmt::format("rest-{}", i++));
+                                  }),
+    _pool_ctx(std::move(ctx))
 {
+}
+
+void rest_ioctx::start()
+{
+  _pool_ctx->prepare_bounce_span(_reactors.size());
+  templated_ioctx<rest_reactor>::start();
 }
 
 rest_perf_snapshot rest_ioctx::perf_snapshot() const noexcept
@@ -57,6 +66,19 @@ rest_perf_snapshot rest_ioctx::perf_snapshot() const noexcept
     agg.payload_bytes_read_total += s.payload_bytes_read_total;
   }
   return agg;
+}
+
+std::vector<rest_bounce_slice_snapshot> rest_ioctx::bounce_slice_snapshots() const
+{
+  std::vector<rest_bounce_slice_snapshot> out;
+  out.reserve(_reactors.size());
+  for (std::size_t i = 0; i < _reactors.size(); ++i) {
+    if (auto s = _reactors[i]->bounce_slice_snapshot()) {
+      s->reactor_index = i;
+      out.push_back(*s);
+    }
+  }
+  return out;
 }
 
 std::shared_ptr<sirius_io_object> rest_ioctx::create_io_object(std::string path)

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -36,6 +36,7 @@
 #include <cstdint>
 #include <cstring>
 #include <deque>
+#include <limits>
 #include <optional>
 #include <random>
 #include <stdexcept>
@@ -414,6 +415,101 @@ std::optional<size_t> content_range_total(std::string const& cr)
 }
 
 // ---------------------------------------------------------------------------
+// reactor_context — shared bounce span
+// ---------------------------------------------------------------------------
+
+void rest_reactor::reactor_context::prepare_bounce_span(std::size_t n_reactors)
+{
+  if (_bounce_span != nullptr || _host_mr == nullptr || n_reactors == 0) { return; }
+  auto const block = _host_mr->get_block_size();
+  auto const grain = _config.bounce_block_size != 0 ? _config.bounce_block_size : block;
+
+  auto const fail = [](std::string const& reason, std::size_t needed, std::size_t admissible) {
+    auto const shortfall = needed > admissible ? needed - admissible : std::size_t{0};
+    throw std::runtime_error("rest_reactor: bounce span " + reason + " — needed " +
+                             std::to_string(needed) + " bytes, admissible limit " +
+                             std::to_string(admissible) + " bytes, shortfall " +
+                             std::to_string(shortfall) + " bytes");
+  };
+
+  auto const needed_opt = checked_bounce_pool_bytes(n_reactors, _config.max_connections, grain);
+  if (!needed_opt) {
+    fail("size (reactors x connections x grain) overflows size_t",
+         std::numeric_limits<std::size_t>::max(),
+         config::max_bounce_pool_bytes);
+  }
+  auto const needed = *needed_opt;
+  if (needed > config::max_bounce_pool_bytes) {
+    fail("exceeds the bounce pool ceiling", needed, config::max_bounce_pool_bytes);
+  }
+
+  // The uniform pool ceiling above binds BOTH grains — direct construction
+  // reaches no other checkpoint.  Only past it may the default carve path
+  // return to per-reactor block allocation, mechanism unchanged.
+  if (grain == block) { return; }
+
+  // Book first (same _allocated_bytes ledger as the block path, stricter
+  // reservation-limit admission); nothing physical exists yet, so a booking
+  // failure allocates nothing.
+  std::unique_ptr<cucascade::memory::reserved_arena> booking;
+  try {
+    booking = _host_mr->reserve(needed);
+  } catch (const std::exception&) {
+    booking.reset();
+  }
+  if (!booking) {
+    // Exact admissible headroom when sirius_config stamped the resolved
+    // reservation limit; otherwise get_available_memory() (capacity −
+    // allocated) is an upper bound on what the stricter limit could admit.
+    std::size_t admissible = 0;
+    if (_config.resolved_host_reservation_limit != 0) {
+      auto const allocated = _host_mr->get_total_allocated_bytes();
+      admissible           = _config.resolved_host_reservation_limit > allocated
+                               ? _config.resolved_host_reservation_limit - allocated
+                               : 0;
+    } else {
+      admissible = _host_mr->get_available_memory();
+    }
+    fail("does not fit the resolved host budget", needed, admissible);
+  }
+
+  // Physical span: one contiguous, pinned, NUMA-bound region from the SAME
+  // upstream expand_pool() uses.  If this throws, `booking` unwinds and the
+  // ledger returns to baseline (rollback observed by the accounting tests).
+  void* span = _host_mr->get_upstream_resource().allocate(
+    rmm::cuda_stream_view{}, needed, alignof(std::max_align_t));
+
+  _bounce_booking     = std::move(booking);
+  _bounce_span        = span;
+  _bounce_span_bytes  = needed;
+  _bounce_slice_bytes = _config.max_connections * grain;
+  _bounce_n_reactors  = n_reactors;
+}
+
+std::optional<rest_reactor::reactor_context::bounce_slice>
+rest_reactor::reactor_context::claim_bounce_slice()
+{
+  if (_bounce_span == nullptr) { return std::nullopt; }
+  auto const idx = _bounce_claims.fetch_add(1, std::memory_order_relaxed);
+  if (idx >= _bounce_n_reactors) {
+    throw std::logic_error(
+      "rest_reactor: more reactors claimed bounce slices than the span was prepared for");
+  }
+  return bounce_slice{static_cast<uint8_t*>(_bounce_span) + idx * _bounce_slice_bytes, idx};
+}
+
+rest_reactor::reactor_context::~reactor_context()
+{
+  if (_bounce_span != nullptr && _host_mr != nullptr) {
+    // Physical region back to the upstream FIRST, then the booking — the
+    // budget must never under-report live pinned memory.
+    _host_mr->get_upstream_resource().deallocate(
+      rmm::cuda_stream_view{}, _bounce_span, _bounce_span_bytes, alignof(std::max_align_t));
+  }
+  _bounce_booking.reset();
+}
+
+// ---------------------------------------------------------------------------
 // construction / lifecycle
 // ---------------------------------------------------------------------------
 
@@ -437,7 +533,33 @@ rest_reactor::rest_reactor(std::shared_ptr<reactor_context> ctx, std::string_vie
   (void)global_curl_context::instance();
 
   if (_ctx->host_memory_resource() != nullptr) {
-    _bounce_slot_size = _ctx->host_memory_resource()->get_block_size();
+    // The bounce slot size doubles as the device-read window grain: the static
+    // prep_device_rx_request splits by cfg.bounce_block_size, and every window
+    // must fit the slot that stages it.  There is NO runtime capacity check
+    // anywhere downstream (sink bound, set_data, H2D all trust chunk.size), so
+    // this resolution + validation is the only enforcement point.  A nonzero
+    // configured value is authoritative; zero resolves to the staging
+    // resource's block size — written back into _config so get_config() (the
+    // ioctx's dispatch config) windows by the same value the slots are sized
+    // to, with or without the datasource factory in front.
+    auto const staging_block = _ctx->host_memory_resource()->get_block_size();
+    if (_config.bounce_block_size == 0) {
+      _config.bounce_block_size = staging_block;
+    } else if (_config.bounce_block_size < staging_block ||
+               _config.bounce_block_size % staging_block != 0 ||
+               _config.bounce_block_size > config::max_bounce_block_size) {
+      throw std::invalid_argument(
+        "rest_reactor: bounce_block_size (" + std::to_string(_config.bounce_block_size) +
+        " bytes) must be a whole multiple of the host staging block size (" +
+        std::to_string(staging_block) + " bytes) and at most " +
+        std::to_string(config::max_bounce_block_size) + " bytes");
+    }
+    _bounce_slot_size = _config.bounce_block_size;
+    if (_config.max_connections != 0 &&
+        _bounce_slot_size > std::numeric_limits<std::size_t>::max() / _config.max_connections) {
+      throw std::invalid_argument(
+        "rest_reactor: bounce pool size (max_connections * bounce_block_size) overflows size_t");
+    }
   }
 
   // The wakeup fd is cheap and the worker (started in start()) registers it with
@@ -450,11 +572,31 @@ void rest_reactor::start()
 {
   if (_worker.joinable()) { return; }  // already started
 
-  if (_ctx->host_memory_resource() != nullptr) {
+  if (_ctx->host_memory_resource() != nullptr && _bounce_slice_base == nullptr &&
+      !_bounce_storage) {
     // One pinned bounce buffer per slot (1:1 with the easy-handle pool), since a
-    // slot stages at most one device read at a time.
-    _bounce_storage = _ctx->host_memory_resource()->allocate_multiple_blocks(
-      _config.max_connections * _bounce_slot_size);
+    // slot stages at most one device read at a time.  The already-acquired
+    // guard keeps a retried start() (e.g. after a failed thread creation) from
+    // claiming a second slice or re-carving blocks.
+    if (auto slice = _ctx->claim_bounce_slice()) {
+      // Shared-span path (grain > staging block): this reactor's contiguous
+      // slice of the context's accounted span, claimed in pool order under the
+      // ioctx's sequential start loop.
+      _bounce_slice_base = slice->base;
+      _reactor_index     = slice->index;
+    } else if (_bounce_slot_size == _ctx->host_memory_resource()->get_block_size()) {
+      // Default grain: carve one staging block per slot (accounted against the
+      // host staging budget, as always).
+      _bounce_storage = _ctx->host_memory_resource()->allocate_multiple_blocks(
+        _config.max_connections * _bounce_slot_size);
+    } else {
+      // A large grain with no prepared span means rest_ioctx::start() (which
+      // runs prepare_bounce_span first) was bypassed — carving this slot size
+      // from per-block staging would overflow slots, so refuse loudly.
+      throw std::logic_error(
+        "rest_reactor: bounce span not prepared for a large grain — start the reactor pool "
+        "through rest_ioctx::start()");
+    }
   }
 
   _worker =
@@ -626,14 +768,18 @@ rest_reactor::request_type_ptr rest_reactor::prep_device_rx_request(const reacto
   if (offset >= end) { return rest_rx_request::create({}); }
   size_t const wanted = end - offset;
   size_t const bounce = cfg.bounce_block_size;
-  size_t const n_win  = (wanted + bounce - 1) / bounce;
+  // Overflow-safe ceil(wanted / bounce): the additive form can wrap for a
+  // huge configured grain.
+  size_t const n_win = wanted / bounce + (wanted % bounce != 0 ? 1 : 0);
 
   auto manager   = std::make_shared<request_manager>(wanted, n_win);
   auto const obj = file.object_ref();
 
   std::vector<std::unique_ptr<rest_chunked_rx_request>> chunks;
   chunks.reserve(n_win);
-  for (size_t w = offset; w < end; w += bounce) {
+  // Advance by the clamped window size (never past `end`), not by `bounce` —
+  // `w += bounce` could wrap for a huge configured grain.
+  for (size_t w = offset; w < end;) {
     size_t const rs = std::min(bounce, end - w);
     auto req        = std::make_unique<rest_chunked_rx_request>();
     req->object     = obj;
@@ -649,6 +795,7 @@ rest_reactor::request_type_ptr rest_reactor::prep_device_rx_request(const reacto
     req->cpy_req = std::move(cpy);
     req->manager = manager;
     chunks.push_back(std::move(req));
+    w += rs;
   }
   return rest_rx_request::create(std::move(chunks));
 }
@@ -798,6 +945,17 @@ rest_perf_snapshot rest_reactor::perf_snapshot() const noexcept
   s.terminal_failures_total  = _perf.terminal_failures_total.load(std::memory_order_relaxed);
   s.device_stream_sync_total = _perf.device_stream_sync_total.load(std::memory_order_relaxed);
   s.payload_bytes_read_total = _perf.payload_bytes_read_total.load(std::memory_order_relaxed);
+  return s;
+}
+
+std::optional<rest_bounce_slice_snapshot> rest_reactor::bounce_slice_snapshot() const noexcept
+{
+  if (_bounce_slice_base == nullptr) { return std::nullopt; }
+  rest_bounce_slice_snapshot s;
+  s.allocation_id = reinterpret_cast<std::uintptr_t>(_ctx->bounce_span_base());
+  s.span_bytes    = _ctx->bounce_span_bytes();
+  s.offset_bytes  = static_cast<std::size_t>(_bounce_slice_base - _ctx->bounce_span_base());
+  s.slice_bytes   = _config.max_connections * _bounce_slot_size;
   return s;
 }
 
@@ -1209,6 +1367,13 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
       for (auto* b : blocks) {
         bounce_bufs.push_back(reinterpret_cast<uint8_t*>(b));
       }
+    } else if (_bounce_slice_base != nullptr) {
+      // Shared-span slice (configured grain > staging block): slot i owns the
+      // i-th _bounce_slot_size-sized stride of this reactor's slice.
+      bounce_bufs.reserve(_config.max_connections);
+      for (std::size_t i = 0; i < _config.max_connections; ++i) {
+        bounce_bufs.push_back(_bounce_slice_base + i * _bounce_slot_size);
+      }
     }
 
     for (std::size_t i = 0; i < _config.max_connections; ++i) {
@@ -1259,7 +1424,7 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
     };
     std::unordered_map<int, std::vector<cucascade::cuda::cuda_event>> copy_events;
     std::vector<parked_copy> copying;
-    if (_bounce_storage) {
+    if (!bounce_bufs.empty()) {  // device staging enabled, whichever pool backs it
       int const n_dev = rmm::get_num_cuda_devices();
       for (int d = 0; d < n_dev; ++d) {
         rmm::cuda_set_device_raii const guard{rmm::cuda_device_id{d}};

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -443,14 +443,12 @@ void rest_reactor::reactor_context::prepare_bounce_span(std::size_t n_reactors)
     fail("exceeds the bounce pool ceiling", needed, config::max_bounce_pool_bytes);
   }
 
-  // The uniform pool ceiling above binds BOTH grains — direct construction
-  // reaches no other checkpoint.  Only past it may the default carve path
-  // return to per-reactor block allocation, mechanism unchanged.
+  // The pool ceiling applies to both the default block-carve path and the
+  // explicit large-grain span path — direct construction reaches no other
+  // checkpoint before the default path returns.
   if (grain == block) { return; }
 
-  // Book first (same _allocated_bytes ledger as the block path, stricter
-  // reservation-limit admission); nothing physical exists yet, so a booking
-  // failure allocates nothing.
+  // Book first: a booking failure must allocate nothing.
   std::unique_ptr<cucascade::memory::reserved_arena> booking;
   try {
     booking = _host_mr->reserve(needed);
@@ -458,9 +456,9 @@ void rest_reactor::reactor_context::prepare_bounce_span(std::size_t n_reactors)
     booking.reset();
   }
   if (!booking) {
-    // Exact admissible headroom when sirius_config stamped the resolved
-    // reservation limit; otherwise get_available_memory() (capacity −
-    // allocated) is an upper bound on what the stricter limit could admit.
+    // Exact headroom when the resolved reservation limit was stamped;
+    // otherwise capacity − allocated is an upper bound on what the stricter
+    // limit could admit.
     std::size_t admissible = 0;
     if (_config.resolved_host_reservation_limit != 0) {
       auto const allocated = _host_mr->get_total_allocated_bytes();
@@ -473,9 +471,8 @@ void rest_reactor::reactor_context::prepare_bounce_span(std::size_t n_reactors)
     fail("does not fit the resolved host budget", needed, admissible);
   }
 
-  // Physical span: one contiguous, pinned, NUMA-bound region from the SAME
-  // upstream expand_pool() uses.  If this throws, `booking` unwinds and the
-  // ledger returns to baseline (rollback observed by the accounting tests).
+  // Physical span: one contiguous pinned region from the same upstream
+  // expand_pool() uses.  If this throws, `booking` unwinds.
   void* span = _host_mr->get_upstream_resource().allocate(
     rmm::cuda_stream_view{}, needed, alignof(std::max_align_t));
 
@@ -501,8 +498,6 @@ rest_reactor::reactor_context::claim_bounce_slice()
 rest_reactor::reactor_context::~reactor_context()
 {
   if (_bounce_span != nullptr && _host_mr != nullptr) {
-    // Physical region back to the upstream FIRST, then the booking — the
-    // budget must never under-report live pinned memory.
     _host_mr->get_upstream_resource().deallocate(
       rmm::cuda_stream_view{}, _bounce_span, _bounce_span_bytes, alignof(std::max_align_t));
   }
@@ -533,15 +528,12 @@ rest_reactor::rest_reactor(std::shared_ptr<reactor_context> ctx, std::string_vie
   (void)global_curl_context::instance();
 
   if (_ctx->host_memory_resource() != nullptr) {
-    // The bounce slot size doubles as the device-read window grain: the static
-    // prep_device_rx_request splits by cfg.bounce_block_size, and every window
-    // must fit the slot that stages it.  There is NO runtime capacity check
-    // anywhere downstream (sink bound, set_data, H2D all trust chunk.size), so
-    // this resolution + validation is the only enforcement point.  A nonzero
-    // configured value is authoritative; zero resolves to the staging
-    // resource's block size — written back into _config so get_config() (the
-    // ioctx's dispatch config) windows by the same value the slots are sized
-    // to, with or without the datasource factory in front.
+    // The bounce slot size doubles as the device-read window grain, and no
+    // downstream path re-checks capacity (sink, set_data, H2D all trust
+    // chunk.size) — this resolution + validation is the only enforcement
+    // point.  The zero fallback is written back into _config so get_config()
+    // (the ioctx's dispatch config) windows by the same value the slots are
+    // sized to.
     auto const staging_block = _ctx->host_memory_resource()->get_block_size();
     if (_config.bounce_block_size == 0) {
       _config.bounce_block_size = staging_block;
@@ -574,25 +566,20 @@ void rest_reactor::start()
 
   if (_ctx->host_memory_resource() != nullptr && _bounce_slice_base == nullptr &&
       !_bounce_storage) {
-    // One pinned bounce buffer per slot (1:1 with the easy-handle pool), since a
-    // slot stages at most one device read at a time.  The already-acquired
-    // guard keeps a retried start() (e.g. after a failed thread creation) from
-    // claiming a second slice or re-carving blocks.
+    // One pinned bounce buffer per slot (1:1 with the easy-handle pool), since
+    // a slot stages at most one device read at a time.  The already-acquired
+    // guard keeps a retried start() from claiming a second slice.
     if (auto slice = _ctx->claim_bounce_slice()) {
-      // Shared-span path (grain > staging block): this reactor's contiguous
-      // slice of the context's accounted span, claimed in pool order under the
-      // ioctx's sequential start loop.
+      // Shared-span path (grain > staging block).
       _bounce_slice_base = slice->base;
       _reactor_index     = slice->index;
     } else if (_bounce_slot_size == _ctx->host_memory_resource()->get_block_size()) {
-      // Default grain: carve one staging block per slot (accounted against the
-      // host staging budget, as always).
+      // Default grain: carve one staging block per slot.
       _bounce_storage = _ctx->host_memory_resource()->allocate_multiple_blocks(
         _config.max_connections * _bounce_slot_size);
     } else {
-      // A large grain with no prepared span means rest_ioctx::start() (which
-      // runs prepare_bounce_span first) was bypassed — carving this slot size
-      // from per-block staging would overflow slots, so refuse loudly.
+      // Large grain but no prepared span: rest_ioctx::start() was bypassed —
+      // per-block staging cannot back this slot size, refuse loudly.
       throw std::logic_error(
         "rest_reactor: bounce span not prepared for a large grain — start the reactor pool "
         "through rest_ioctx::start()");
@@ -768,8 +755,7 @@ rest_reactor::request_type_ptr rest_reactor::prep_device_rx_request(const reacto
   if (offset >= end) { return rest_rx_request::create({}); }
   size_t const wanted = end - offset;
   size_t const bounce = cfg.bounce_block_size;
-  // Overflow-safe ceil(wanted / bounce): the additive form can wrap for a
-  // huge configured grain.
+  // Overflow-safe ceil: the additive form can wrap for a huge grain.
   size_t const n_win = wanted / bounce + (wanted % bounce != 0 ? 1 : 0);
 
   auto manager   = std::make_shared<request_manager>(wanted, n_win);
@@ -777,8 +763,7 @@ rest_reactor::request_type_ptr rest_reactor::prep_device_rx_request(const reacto
 
   std::vector<std::unique_ptr<rest_chunked_rx_request>> chunks;
   chunks.reserve(n_win);
-  // Advance by the clamped window size (never past `end`), not by `bounce` —
-  // `w += bounce` could wrap for a huge configured grain.
+  // Advance by the clamped window size — `w += bounce` could wrap.
   for (size_t w = offset; w < end;) {
     size_t const rs = std::min(bounce, end - w);
     auto req        = std::make_unique<rest_chunked_rx_request>();
@@ -1368,8 +1353,7 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
         bounce_bufs.push_back(reinterpret_cast<uint8_t*>(b));
       }
     } else if (_bounce_slice_base != nullptr) {
-      // Shared-span slice (configured grain > staging block): slot i owns the
-      // i-th _bounce_slot_size-sized stride of this reactor's slice.
+      // Shared-span slice: slot i owns the i-th _bounce_slot_size stride.
       bounce_bufs.reserve(_config.max_connections);
       for (std::size_t i = 0; i < _config.max_connections; ++i) {
         bounce_bufs.push_back(_bounce_slice_base + i * _bounce_slot_size);

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -479,9 +479,8 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
     }
 
     enforce_sirius_datasource_for_multi_gpu();
-    // Carry the resolved host reservation limit into the REST config so
-    // runtime budget failures can report exact needed/limit/shortfall (the
-    // FSMR exposes no limit getter).  Internal resolved field, not a YAML key.
+    // Stamp the resolved host reservation limit into the REST config — see
+    // rest::config::resolved_host_reservation_limit.
     for (auto const& space : _memory_space_configs) {
       if (auto const* h = std::get_if<cucascade::memory::host_memory_space_config>(&space)) {
         _scan_manager_config.rest.resolved_host_reservation_limit = static_cast<std::size_t>(
@@ -514,9 +513,8 @@ void sirius_config::preflight_rest_bounce_span() const
     fail("rest.max_connections must be > 0 when bounce_block_size is set", 0, 0);
   }
 
-  // The host space REST will actually select at runtime: the FIRST resolved
-  // HOST entry (explicit sirius.space.host configs bypass memory.host, so the
-  // check must run on the resolved list, not the high-level knobs).
+  // REST selects the FIRST resolved HOST entry at runtime — explicit
+  // sirius.space.host bypasses memory.host, so check the resolved list.
   const cucascade::memory::host_memory_space_config* host = nullptr;
   for (auto const& space : _memory_space_configs) {
     if (auto const* h = std::get_if<cucascade::memory::host_memory_space_config>(&space)) {
@@ -531,8 +529,7 @@ void sirius_config::preflight_rest_bounce_span() const
   }
 
   // Mirror the FSMR constructor's block-size alignment so the multiple-of
-  // check agrees with what the pool will actually report at runtime.  The
-  // from_yaml validators reject block_size == 0; guard anyway (division below).
+  // check matches the runtime pool; guard zero anyway (division below).
   if (host->block_size == 0) {
     fail("resolved host block_size is 0 — a HOST space must have a positive block size",
          rest.bounce_block_size,
@@ -568,9 +565,8 @@ void sirius_config::preflight_rest_bounce_span() const
       fail("bounce pool does not fit the resolved host reservation limit", *needed, resolved_limit);
     }
   } else {
-    // grain == block: runtime stays on the block-carve path, which admits
-    // against capacity — checking the stricter reservation limit here would
-    // reject configs that are legal today.
+    // grain == block stays on the block-carve path, which admits against
+    // capacity — the stricter reservation limit would reject legal configs.
     if (*needed > host->memory_capacity) {
       fail("bounce pool does not fit the resolved host capacity", *needed, host->memory_capacity);
     }

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -20,11 +20,14 @@
 #include "log/logging.hpp"
 #include "yaml_reader.hpp"
 
+#include <rmm/aligned.hpp>
+
 #include <cucascade/memory/config.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 #include <yaml-cpp/yaml.h>
 
 #include <exception>
+#include <limits>
 #include <variant>
 #include <vector>
 
@@ -61,6 +64,9 @@ static void from_yaml(const YAML::Node& node, cucascade::memory::host_memory_spa
   r.optional("pool_size", opt.pool_size);
   r.optional("initial_number_pools", opt.initial_number_pools);
   r.reject_unknown();
+  if (opt.block_size == 0) {
+    throw std::runtime_error("host_memory_space: block_size must be > 0");
+  }
 }
 
 static void from_yaml(const YAML::Node& node, cucascade::memory::disk_memory_space_config& opt)
@@ -102,7 +108,7 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
   r.optional("request_timeout_s", opt.request_timeout_s);
   r.optional("ca_bundle_path", opt.ca_bundle_path);
   r.optional("tls_verify", opt.tls_verify);
-  r.optional("max_connections", opt.max_connections);
+  r.optional("max_connections", opt.max_connections, yaml::greater_than<std::size_t>{0});
   r.optional("chunk_size", yaml::bytes(opt.chunk_size));
   r.optional("max_n_chunks", opt.max_n_chunks);
   r.optional("max_read_split", opt.max_read_split);
@@ -296,6 +302,7 @@ struct host_mem_config {
     r.optional("pool_size", opt.pool_size);
     r.optional("initial_number_pools", opt.initial_number_pools);
     r.reject_unknown();
+    if (opt.block_size == 0) { throw std::runtime_error("memory.host: block_size must be > 0"); }
   }
 
   void setup_configurator(cucascade::memory::reservation_manager_configurator& builder) const
@@ -472,10 +479,101 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
     }
 
     enforce_sirius_datasource_for_multi_gpu();
+    // Carry the resolved host reservation limit into the REST config so
+    // runtime budget failures can report exact needed/limit/shortfall (the
+    // FSMR exposes no limit getter).  Internal resolved field, not a YAML key.
+    for (auto const& space : _memory_space_configs) {
+      if (auto const* h = std::get_if<cucascade::memory::host_memory_space_config>(&space)) {
+        _scan_manager_config.rest.resolved_host_reservation_limit = static_cast<std::size_t>(
+          static_cast<double>(h->memory_capacity) * h->reservation_limit_fraction);
+        break;
+      }
+    }
+    preflight_rest_bounce_span();
 
   } catch (const std::exception& e) {
     throw std::runtime_error("Failed to load config from " + config_path.string() + ": " +
                              e.what());
+  }
+}
+
+void sirius_config::preflight_rest_bounce_span() const
+{
+  auto const& rest = _scan_manager_config.rest;
+  if (rest.bounce_block_size == 0) { return; }  // auto: today's block path, nothing to preflight
+
+  auto const fail = [](std::string const& reason, std::size_t needed, std::size_t admissible) {
+    auto const shortfall = needed > admissible ? needed - admissible : std::size_t{0};
+    throw std::invalid_argument("scan_manager.rest bounce preflight: " + reason + " — needed " +
+                                std::to_string(needed) + " bytes, admissible limit " +
+                                std::to_string(admissible) + " bytes, shortfall " +
+                                std::to_string(shortfall) + " bytes");
+  };
+
+  if (rest.max_connections == 0) {
+    fail("rest.max_connections must be > 0 when bounce_block_size is set", 0, 0);
+  }
+
+  // The host space REST will actually select at runtime: the FIRST resolved
+  // HOST entry (explicit sirius.space.host configs bypass memory.host, so the
+  // check must run on the resolved list, not the high-level knobs).
+  const cucascade::memory::host_memory_space_config* host = nullptr;
+  for (auto const& space : _memory_space_configs) {
+    if (auto const* h = std::get_if<cucascade::memory::host_memory_space_config>(&space)) {
+      host = h;
+      break;
+    }
+  }
+  if (host == nullptr) {
+    fail("bounce_block_size is set but no HOST memory space is configured for staging",
+         rest.bounce_block_size,
+         0);
+  }
+
+  // Mirror the FSMR constructor's block-size alignment so the multiple-of
+  // check agrees with what the pool will actually report at runtime.  The
+  // from_yaml validators reject block_size == 0; guard anyway (division below).
+  if (host->block_size == 0) {
+    fail("resolved host block_size is 0 — a HOST space must have a positive block size",
+         rest.bounce_block_size,
+         0);
+  }
+  auto const block = rmm::align_up(host->block_size, alignof(std::max_align_t));
+  if (rest.bounce_block_size < block || rest.bounce_block_size % block != 0 ||
+      rest.bounce_block_size > io::rest::config::max_bounce_block_size) {
+    fail("bounce_block_size must be a whole multiple of the host block size (" +
+           std::to_string(block) + " bytes) and at most " +
+           std::to_string(io::rest::config::max_bounce_block_size) + " bytes",
+         rest.bounce_block_size,
+         io::rest::config::max_bounce_block_size);
+  }
+
+  auto const needed = io::rest::checked_bounce_pool_bytes(
+    _scan_manager_config.rest_n_reactors, rest.max_connections, rest.bounce_block_size);
+  if (!needed) {
+    fail("rest_n_reactors x max_connections x bounce_block_size overflows size_t",
+         std::numeric_limits<std::size_t>::max(),
+         io::rest::config::max_bounce_pool_bytes);
+  }
+  if (*needed > io::rest::config::max_bounce_pool_bytes) {
+    fail("bounce pool exceeds the ceiling", *needed, io::rest::config::max_bounce_pool_bytes);
+  }
+
+  if (rest.bounce_block_size > block) {
+    // Span path (grain > block): admitted at runtime via the stricter
+    // reservation limit.
+    auto const resolved_limit = static_cast<std::size_t>(
+      static_cast<double>(host->memory_capacity) * host->reservation_limit_fraction);
+    if (*needed > resolved_limit) {
+      fail("bounce pool does not fit the resolved host reservation limit", *needed, resolved_limit);
+    }
+  } else {
+    // grain == block: runtime stays on the block-carve path, which admits
+    // against capacity — checking the stricter reservation limit here would
+    // reject configs that are legal today.
+    if (*needed > host->memory_capacity) {
+      fail("bounce pool does not fit the resolved host capacity", *needed, host->memory_capacity);
+    }
   }
 }
 

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -19,8 +19,11 @@
 #include "io/rest/config.hpp"
 #include "sirius_config.hpp"
 
+#include <cstdint>
+#include <exception>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <string>
 
 using sirius::io::enum_to_string;
@@ -34,6 +37,21 @@ void write_yaml(std::filesystem::path const& path, std::string const& text)
   std::ofstream out(path);
   out << text;
   REQUIRE(out);
+}
+
+std::string load_config_error(std::filesystem::path const& path, std::string const& text)
+{
+  write_yaml(path, text);
+  std::string error;
+  try {
+    sirius::sirius_config cfg;
+    cfg.load_from_file(path);
+  } catch (std::exception const& e) {
+    error = e.what();
+  }
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+  return error;
 }
 
 }  // namespace
@@ -273,6 +291,163 @@ TEST_CASE("sirius_config parses rest perf instrumentation flag",
 
   std::error_code ec;
   std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("sirius_config preserves an explicit REST bounce block size",
+          "[scan_manager][config][s3][rest][bounce_grain]")
+{
+  auto const path = std::filesystem::temp_directory_path() / "sirius_rest_bounce_block_size.yaml";
+  write_yaml(path,
+             "sirius:\n"
+             "  executor:\n"
+             "    scan_manager:\n"
+             "      rest:\n"
+             "        bounce_block_size: '8 MiB'\n");
+
+  sirius::sirius_config cfg;
+  REQUIRE_NOTHROW(cfg.load_from_file(path));
+  CHECK(cfg.get_scan_manager_config().rest.bounce_block_size == 8UL * 1024 * 1024);
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("sirius_config preflights the resolved REST bounce-span footprint",
+          "[scan_manager][config][s3][rest][bounce_accounting]")
+{
+  auto const path =
+    std::filesystem::temp_directory_path() / "sirius_rest_bounce_span_preflight.yaml";
+
+  auto const expect_failure = [&](std::string const& yaml) {
+    auto const error = load_config_error(path, yaml);
+    INFO(error);
+    REQUIRE_FALSE(error.empty());
+    CHECK(error.find("needed") != std::string::npos);
+    CHECK(error.find("limit") != std::string::npos);
+    CHECK(error.find("shortfall") != std::string::npos);
+  };
+
+  SECTION("the exact 2 GiB pool boundary is legal")
+  {
+    auto const error = load_config_error(path,
+                                         "sirius:\n"
+                                         "  memory:\n"
+                                         "    host:\n"
+                                         "      capacity_bytes: 3GiB\n"
+                                         "      reservation_limit_fraction: 0.5\n"
+                                         "  executor:\n"
+                                         "    scan_manager:\n"
+                                         "      rest_n_reactors: 8\n"
+                                         "      rest:\n"
+                                         "        max_connections: 256\n"
+                                         "        bounce_block_size: 1MiB\n");
+    CHECK(error.empty());
+  }
+
+  SECTION("a pool larger than 2 GiB is rejected before runtime allocation")
+  {
+    expect_failure(
+      "sirius:\n"
+      "  memory:\n"
+      "    host:\n"
+      "      capacity_bytes: 16GiB\n"
+      "  executor:\n"
+      "    scan_manager:\n"
+      "      rest_n_reactors: 8\n"
+      "      rest:\n"
+      "        max_connections: 256\n"
+      "        bounce_block_size: 4MiB\n");
+  }
+
+  SECTION("reactor-count multiplication overflow is rejected")
+  {
+    auto const max_size = std::to_string(std::numeric_limits<std::int64_t>::max());
+    expect_failure(
+      "sirius:\n"
+      "  memory:\n"
+      "    host:\n"
+      "      capacity_bytes: 16GiB\n"
+      "  executor:\n"
+      "    scan_manager:\n"
+      "      rest_n_reactors: " +
+      max_size +
+      "\n"
+      "      rest:\n"
+      "        max_connections: 2\n"
+      "        bounce_block_size: 1MiB\n");
+  }
+
+  SECTION("zero REST connections are rejected by the YAML validator")
+  {
+    auto const error = load_config_error(path,
+                                         "sirius:\n"
+                                         "  memory:\n"
+                                         "    host:\n"
+                                         "      capacity_bytes: 16MiB\n"
+                                         "  executor:\n"
+                                         "    scan_manager:\n"
+                                         "      rest:\n"
+                                         "        max_connections: 0\n"
+                                         "        bounce_block_size: 1MiB\n");
+    INFO(error);
+    REQUIRE_FALSE(error.empty());
+    CHECK(error.find("max_connections") != std::string::npos);
+  }
+
+  SECTION("an explicit space configuration without a HOST space is rejected")
+  {
+    expect_failure(
+      "sirius:\n"
+      "  space:\n"
+      "    gpu:\n"
+      "      - device_id: 0\n"
+      "        memory_capacity: 4GiB\n"
+      "  executor:\n"
+      "    scan_manager:\n"
+      "      rest:\n"
+      "        max_connections: 2\n"
+      "        bounce_block_size: 4MiB\n");
+  }
+
+  SECTION("the first resolved explicit HOST space, not a later larger one, controls admission")
+  {
+    expect_failure(
+      "sirius:\n"
+      "  space:\n"
+      "    host:\n"
+      "      - numa_id: 0\n"
+      "        memory_capacity: 4MiB\n"
+      "        reservation_limit_fraction: 1.0\n"
+      "        initial_number_pools: 0\n"
+      "      - numa_id: 1\n"
+      "        memory_capacity: 64MiB\n"
+      "        reservation_limit_fraction: 1.0\n"
+      "        initial_number_pools: 0\n"
+      "  executor:\n"
+      "    scan_manager:\n"
+      "      rest_n_reactors: 2\n"
+      "      rest:\n"
+      "        max_connections: 2\n"
+      "        bounce_block_size: 4MiB\n");
+  }
+
+  SECTION("a resolved custom host block size still validates the configured grain")
+  {
+    expect_failure(
+      "sirius:\n"
+      "  space:\n"
+      "    host:\n"
+      "      - numa_id: 0\n"
+      "        memory_capacity: 64MiB\n"
+      "        reservation_limit_fraction: 1.0\n"
+      "        block_size: 2MiB\n"
+      "        initial_number_pools: 0\n"
+      "  executor:\n"
+      "    scan_manager:\n"
+      "      rest:\n"
+      "        max_connections: 1\n"
+      "        bounce_block_size: 3MiB\n");
+  }
 }
 
 TEST_CASE("sirius_config rejects unknown rest config keys", "[scan_manager][config][rest]")

--- a/test/cpp/integration/s3/run_read_consumers_bench.sh
+++ b/test/cpp/integration/s3/run_read_consumers_bench.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+S3_TEST_BIN="${S3_TEST_BIN:-${PROJECT_ROOT}/build/release/extension/sirius/test/cpp/sirius_unittest}"
+TEST_NAME="S3 REST read consumers benchmark partitions SF10 by whole row groups"
+SAMPLES="${SIRIUS_BENCH_READ_SAMPLES:-5}"
+OUTPUT_DIR="${SIRIUS_BENCH_READ_OUTPUT_DIR:-${PROJECT_ROOT}/build/release/extension/sirius/test/cpp/log/read_consumers_$(date +%s)}"
+MANIFEST="${OUTPUT_DIR}/samples.tsv"
+REUSE_MINIO="${SIRIUS_BENCH_READ_REUSE_MINIO:-1}"
+MINIO_IMAGE="${SIRIUS_BENCH_READ_MINIO_IMAGE:-minio/minio:RELEASE.2025-09-07T16-13-09Z-cpuv1}"
+OBJECT_KEY="${SIRIUS_BENCH_S3_KEY:-tpch/lineitem_sf10.parquet}"
+LOCAL_PARQUET="${SIRIUS_BENCH_READ_LOCAL_PARQUET:-/tmp/sirius-s3-testcontainers/lineitem_sf10.parquet}"
+SAMPLE_TIMEOUT_SECONDS="${SIRIUS_BENCH_READ_SAMPLE_TIMEOUT_SECONDS:-180}"
+UPLOAD_TIMEOUT_SECONDS="${SIRIUS_BENCH_READ_UPLOAD_TIMEOUT_SECONDS:-300}"
+GRAINS="${SIRIUS_BENCH_READ_GRAINS:-1048576 4194304}"
+
+MINIO_ACCESS_KEY="minioadmin"
+MINIO_SECRET_KEY="minioadmin"
+MINIO_REGION="us-east-1"
+MINIO_BUCKET="sirius-test"
+SHARED_CONTAINER=""
+SHARED_ENDPOINT=""
+SHARED_WORK_DIR=""
+ACTIVE_BENCH_PID=""
+ACTIVE_PIDSTAT_PID=""
+ACTIVE_WATCHDOG_PID=""
+EXECUTION_INDEX=0
+BASELINE_PAYLOAD=""
+
+if [[ "${REUSE_MINIO}" == "1" ]]; then
+  BACKEND_LIFECYCLE="shared_warm"
+else
+  BACKEND_LIFECYCLE="per_sample_testcontainers"
+fi
+
+if [[ ! -x "${S3_TEST_BIN}" ]]; then
+  echo "run_read_consumers_bench: ${S3_TEST_BIN} not found; run make release first" >&2
+  exit 1
+fi
+if ((BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 1))); then
+  echo "run_read_consumers_bench: Bash 5.1+ is required for the sample watchdog" >&2
+  exit 1
+fi
+for tool in jq pidstat; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    echo "run_read_consumers_bench: ${tool} is required" >&2
+    exit 1
+  }
+done
+if [[ "${REUSE_MINIO}" == "1" ]]; then
+  for tool in curl docker; do
+    command -v "${tool}" >/dev/null 2>&1 || {
+      echo "run_read_consumers_bench: ${tool} is required for shared MinIO mode" >&2
+      exit 1
+    }
+  done
+fi
+if ! [[ "${SAMPLES}" =~ ^[1-9][0-9]*$ ]] || ! [[ "${SAMPLE_TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "run_read_consumers_bench: samples and timeout must be positive integers" >&2
+  exit 1
+fi
+
+terminate_process() {
+  local pid="$1"
+  if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+    kill -TERM "${pid}" 2>/dev/null || true
+    sleep 0.2
+    kill -KILL "${pid}" 2>/dev/null || true
+  fi
+  [[ -z "${pid}" ]] || wait "${pid}" 2>/dev/null || true
+}
+
+cleanup() {
+  terminate_process "${ACTIVE_WATCHDOG_PID}"
+  terminate_process "${ACTIVE_BENCH_PID}"
+  terminate_process "${ACTIVE_PIDSTAT_PID}"
+  if [[ -n "${SHARED_CONTAINER}" ]]; then
+    docker rm --force "${SHARED_CONTAINER}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${SHARED_WORK_DIR}" ]]; then
+    rm -rf "${SHARED_WORK_DIR}"
+  fi
+}
+trap cleanup EXIT
+
+ensure_local_parquet() {
+  [[ -s "${LOCAL_PARQUET}" ]] && return
+
+  local duckdb_bin="${SIRIUS_TEST_DUCKDB:-${PROJECT_ROOT}/build/release/duckdb}"
+  if [[ ! -x "${duckdb_bin}" ]]; then
+    echo "run_read_consumers_bench: ${LOCAL_PARQUET} is absent and ${duckdb_bin} is unavailable" >&2
+    exit 1
+  fi
+  mkdir -p "$(dirname "${LOCAL_PARQUET}")"
+  local db="${SHARED_WORK_DIR}/tpch_sf10.duckdb"
+  local tmp="${LOCAL_PARQUET}.tmp.$$"
+  "${duckdb_bin}" "${db}" -c \
+    "INSTALL tpch; LOAD tpch; CALL dbgen(sf=10); COPY (SELECT * FROM lineitem) TO '${tmp}' (FORMAT PARQUET);"
+  mv "${tmp}" "${LOCAL_PARQUET}"
+}
+
+container_port() {
+  local mapping=""
+  for _ in $(seq 1 50); do
+    mapping="$(docker port "${SHARED_CONTAINER}" 9000/tcp 2>/dev/null | head -n 1)"
+    if [[ -n "${mapping}" ]]; then
+      printf '%s\n' "${mapping##*:}"
+      return
+    fi
+    sleep 0.1
+  done
+  echo "run_read_consumers_bench: no mapped MinIO port" >&2
+  exit 1
+}
+
+wait_for_minio() {
+  for _ in $(seq 1 100); do
+    if curl --fail --silent --show-error --noproxy '*' --connect-timeout 1 --max-time 2 \
+      "${SHARED_ENDPOINT}/minio/health/ready" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 0.1
+  done
+  echo "run_read_consumers_bench: MinIO did not become ready at ${SHARED_ENDPOINT}" >&2
+  exit 1
+}
+
+start_shared_minio() {
+  SHARED_WORK_DIR="$(mktemp -d /tmp/sirius-read-consumers.XXXXXX)"
+  ensure_local_parquet
+  SHARED_CONTAINER="sirius-read-consumers-$$"
+  docker run --detach --rm --name "${SHARED_CONTAINER}" \
+    --env "MINIO_ROOT_USER=${MINIO_ACCESS_KEY}" \
+    --env "MINIO_ROOT_PASSWORD=${MINIO_SECRET_KEY}" \
+    --env "MINIO_REGION=${MINIO_REGION}" \
+    --publish 127.0.0.1::9000 \
+    "${MINIO_IMAGE}" server /data --console-address :9001 >/dev/null
+  SHARED_ENDPOINT="http://127.0.0.1:$(container_port)"
+  wait_for_minio
+
+  local auth=(--aws-sigv4 "aws:amz:${MINIO_REGION}:s3" --user "${MINIO_ACCESS_KEY}:${MINIO_SECRET_KEY}")
+  curl --fail --silent --show-error --noproxy '*' --connect-timeout 5 \
+    --max-time "${UPLOAD_TIMEOUT_SECONDS}" "${auth[@]}" --request PUT \
+    "${SHARED_ENDPOINT}/${MINIO_BUCKET}"
+  curl --fail --silent --show-error --noproxy '*' --connect-timeout 5 \
+    --max-time "${UPLOAD_TIMEOUT_SECONDS}" "${auth[@]}" --upload-file "${LOCAL_PARQUET}" \
+    "${SHARED_ENDPOINT}/${MINIO_BUCKET}/${OBJECT_KEY}"
+  echo "[read-consumers] shared MinIO ready at ${SHARED_ENDPOINT}"
+}
+
+mkdir -p "${OUTPUT_DIR}"
+printf 'arm\treactors\tconnections\tconsumers\tbounce_block_size\tsample\texecution_index\tbackend_lifecycle\tpayload_bytes\twall_ms\tprocess_wall_ms\tharness_overhead_ms\twall_gb_per_sec\tjson\tpidstat\tlog\n' >"${MANIFEST}"
+
+if [[ "${REUSE_MINIO}" == "1" ]]; then
+  start_shared_minio
+fi
+
+GIT_SHA="$(git -C "${PROJECT_ROOT}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+HOST_NAME="${HOSTNAME:-$(hostname)}"
+
+run_sample() {
+  local reactors="$1"
+  local connections="$2"
+  local consumers="$3"
+  local grain="$4"
+  local sample="$5"
+  local stem="m1_r${reactors}_c${connections}_n${consumers}_grain${grain}_s${sample}"
+  local json="${OUTPUT_DIR}/${stem}.json"
+  local pidstat_log="${OUTPUT_DIR}/${stem}.pidstat.txt"
+  local test_log="${OUTPUT_DIR}/${stem}.test.log"
+  local timeout_marker="${OUTPUT_DIR}/${stem}.timeout"
+  local -a s3_env=(
+    SIRIUS_TEST_S3_AUTO=1
+    SIRIUS_TEST_S3_LARGE=1
+    SIRIUS_TEST_S3_STRICT=1
+  )
+  if [[ "${REUSE_MINIO}" == "1" ]]; then
+    s3_env=(
+      SIRIUS_TEST_S3_AUTO=0
+      SIRIUS_TEST_S3_LARGE=1
+      SIRIUS_TEST_S3_STRICT=1
+      SIRIUS_TEST_S3_ENDPOINT="${SHARED_ENDPOINT}"
+      SIRIUS_TEST_S3_REGION="${MINIO_REGION}"
+      SIRIUS_TEST_S3_ACCESS_KEY="${MINIO_ACCESS_KEY}"
+      SIRIUS_TEST_S3_SECRET_KEY="${MINIO_SECRET_KEY}"
+      SIRIUS_TEST_S3_SESSION_TOKEN=
+      SIRIUS_TEST_S3_BUCKET="${MINIO_BUCKET}"
+      SIRIUS_TEST_S3_KEY=hello.txt
+      SIRIUS_TEST_S3_LOCAL_DIR="$(dirname "${LOCAL_PARQUET}")"
+      SIRIUS_PR6_LARGE_LOCAL_PARQUET="${LOCAL_PARQUET}"
+      SIRIUS_PR6_LARGE_S3_KEY="${OBJECT_KEY}"
+      SIRIUS_BENCH_S3_KEY="${OBJECT_KEY}"
+    )
+  fi
+
+  rm -f "${json}" "${timeout_marker}"
+  EXECUTION_INDEX=$((EXECUTION_INDEX + 1))
+  local process_start_ns
+  process_start_ns="$(date +%s%N)"
+  env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy \
+    NO_PROXY="localhost,127.0.0.1,::1,host.docker.internal" \
+    no_proxy="localhost,127.0.0.1,::1,host.docker.internal" \
+    "${s3_env[@]}" \
+    SIRIUS_BENCH_GIT_SHA="${GIT_SHA}" \
+    HOSTNAME="${HOST_NAME}" \
+    SIRIUS_BENCH_READ_CONSUMERS="${consumers}" \
+    SIRIUS_BENCH_READ_REACTORS="${reactors}" \
+    SIRIUS_BENCH_READ_MAX_CONNECTIONS="${connections}" \
+    SIRIUS_BENCH_READ_BOUNCE_BLOCK_SIZE="${grain}" \
+    SIRIUS_BENCH_READ_TRANSPORT=http \
+    SIRIUS_BENCH_READ_SAMPLE="${sample}" \
+    SIRIUS_BENCH_READ_ARM=M1 \
+    SIRIUS_BENCH_READ_BACKEND_LIFECYCLE="${BACKEND_LIFECYCLE}" \
+    SIRIUS_BENCH_READ_BASELINE_BYTES="${BASELINE_PAYLOAD}" \
+    SIRIUS_BENCH_READ_CONSUMERS_OUTPUT="${json}" \
+    "${S3_TEST_BIN}" "${TEST_NAME}" >"${test_log}" 2>&1 &
+  ACTIVE_BENCH_PID=$!
+  pidstat -t -p "${ACTIVE_BENCH_PID}" 1 >"${pidstat_log}" 2>&1 &
+  ACTIVE_PIDSTAT_PID=$!
+  sleep "${SAMPLE_TIMEOUT_SECONDS}" &
+  ACTIVE_WATCHDOG_PID=$!
+
+  local completed_pid=""
+  local completed_rc=0
+  wait -n -p completed_pid "${ACTIVE_BENCH_PID}" "${ACTIVE_WATCHDOG_PID}" || completed_rc=$?
+  if [[ "${completed_pid}" == "${ACTIVE_WATCHDOG_PID}" ]]; then
+    printf 'sample exceeded %s seconds\n' "${SAMPLE_TIMEOUT_SECONDS}" >"${timeout_marker}"
+    terminate_process "${ACTIVE_BENCH_PID}"
+    completed_rc=124
+  else
+    terminate_process "${ACTIVE_WATCHDOG_PID}"
+  fi
+  ACTIVE_BENCH_PID=""
+  ACTIVE_WATCHDOG_PID=""
+  kill -INT "${ACTIVE_PIDSTAT_PID}" 2>/dev/null || true
+  wait "${ACTIVE_PIDSTAT_PID}" 2>/dev/null || true
+  ACTIVE_PIDSTAT_PID=""
+  local process_wall_ms=$((($(date +%s%N) - process_start_ns) / 1000000))
+
+  if [[ "${completed_rc}" -ne 0 || -s "${timeout_marker}" || ! -s "${json}" ]]; then
+    echo "[read-consumers] ${stem} failed" >&2
+    tail -80 "${test_log}" >&2 || true
+    exit "${completed_rc:-1}"
+  fi
+
+  local pinned_bytes=$((reactors * connections * grain))
+  jq -e \
+    --argjson reactors "${reactors}" \
+    --argjson connections "${connections}" \
+    --argjson consumers "${consumers}" \
+    --argjson grain "${grain}" \
+    --argjson pinned "${pinned_bytes}" \
+    --argjson sample "${sample}" \
+    '.scenario == "s3_read_consumers" and .arm == "M1" and .transport == "http" and
+     .rest_n_reactors == $reactors and .max_connections == $connections and
+     .read_consumers == $consumers and .bounce_block_size == $grain and
+     .pinned_bytes == $pinned and .sample == $sample and
+     .rows == 59986052 and .orderkey_sum == 1799465265420123 and
+     (.wall_clock_ms | type == "number") and (.aggregate.chunk_get_count > 0) and
+     (.aggregate.payload_bytes_read_total | type == "number") and
+     .aggregate.terminal_failures_total == 0 and .aggregate.device_stream_sync_total == 0' \
+    "${json}" >/dev/null || {
+      echo "[read-consumers] ${stem} produced invalid JSON" >&2
+      exit 1
+    }
+
+  local thread_index
+  for ((thread_index = 0; thread_index < reactors; ++thread_index)); do
+    grep -Fq "rest-${thread_index}_worker" "${pidstat_log}" || {
+      echo "[read-consumers] ${stem} pidstat missed rest-${thread_index}_worker" >&2
+      exit 1
+    }
+  done
+  for ((thread_index = 0; thread_index < consumers; ++thread_index)); do
+    grep -Fq "read_cons_${thread_index}" "${pidstat_log}" || {
+      echo "[read-consumers] ${stem} pidstat missed read_cons_${thread_index}" >&2
+      exit 1
+    }
+  done
+
+  local payload wall_ms wall_gbps overhead_ms
+  payload="$(jq -r '.aggregate.payload_bytes_read_total' "${json}")"
+  wall_ms="$(jq -r '.wall_clock_ms' "${json}")"
+  wall_gbps="$(jq -r '.effective_wall_gb_per_sec' "${json}")"
+  overhead_ms="$(awk -v process="${process_wall_ms}" -v measured="${wall_ms}" 'BEGIN { printf "%.3f", process - measured }')"
+  if [[ -n "${BASELINE_PAYLOAD}" ]]; then
+    awk -v payload="${payload}" -v baseline="${BASELINE_PAYLOAD}" 'BEGIN {
+      ratio = payload / baseline
+      if (ratio < 0.98 || ratio > 1.02) exit 1
+    }' || {
+      echo "[read-consumers] payload guardrail failed: ${payload} vs ${BASELINE_PAYLOAD}" >&2
+      exit 1
+    }
+  else
+    BASELINE_PAYLOAD="${payload}"
+  fi
+  printf 'M1\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "${reactors}" "${connections}" "${consumers}" "${grain}" "${sample}" "${EXECUTION_INDEX}" \
+    "${BACKEND_LIFECYCLE}" "${payload}" "${wall_ms}" "${process_wall_ms}" "${overhead_ms}" \
+    "${wall_gbps}" "${json}" "${pidstat_log}" "${test_log}" >>"${MANIFEST}"
+}
+
+run_point() {
+  local reactors="$1" connections="$2" consumers="$3" grain="$4"
+  local sample
+  for sample in $(seq 1 "${SAMPLES}"); do
+    run_sample "${reactors}" "${connections}" "${consumers}" "${grain}" "${sample}"
+  done
+}
+
+for grain in ${GRAINS}; do
+  [[ "${grain}" =~ ^[1-9][0-9]*$ ]] || {
+    echo "run_read_consumers_bench: SIRIUS_BENCH_READ_GRAINS must contain byte counts" >&2
+    exit 1
+  }
+  run_point 4 8 1 "${grain}"
+  run_point 4 8 2 "${grain}"
+  run_point 4 8 4 "${grain}"
+  run_point 1 32 1 "${grain}"
+done
+
+echo "[read-consumers] samples: ${MANIFEST}"
+echo "[read-consumers] raw JSON, pidstat, and test logs: ${OUTPUT_DIR}"

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -15,10 +15,17 @@
 #include "utils/s3_container.hpp"
 #include "utils/transparent_execution_test_utils.hpp"
 
+#include <cudf/aggregation.hpp>
 #include <cudf/io/experimental/hybrid_scan.hpp>
 #include <cudf/io/parquet.hpp>
 #include <cudf/io/parquet_io_utils.hpp>
+#include <cudf/reduction.hpp>
+#include <cudf/scalar/scalar.hpp>
 #include <cudf/utilities/span.hpp>
+
+#include <rmm/cuda_stream.hpp>
+
+#include <cuda_runtime_api.h>
 
 #include <duckdb.hpp>
 #include <duckdb/catalog/catalog.hpp>
@@ -37,6 +44,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -45,11 +53,16 @@
 #include <mutex>
 #include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <thread>
 #include <utility>
 #include <vector>
+
+#if defined(__linux__)
+#include <pthread.h>
+#endif
 
 namespace {
 
@@ -300,6 +313,7 @@ struct sirius_memory_limits {
   std::optional<bool> enable_prefetch_cache;
   std::optional<std::size_t> rest_n_reactors;
   std::optional<std::size_t> rest_max_connections;
+  std::optional<std::string> rest_bounce_block_size;
   std::optional<bool> use_sirius_datasource;
   std::optional<std::string> rest_footer_probe_bytes;
   bool rest_perf_instrumentation{false};
@@ -416,6 +430,9 @@ class sirius_config_env_guard {
            "        request_timeout_s: 30\n";
     if (limits.rest_footer_probe_bytes.has_value()) {
       out << "        footer_probe_bytes: " << yaml_quote(*limits.rest_footer_probe_bytes) << "\n";
+    }
+    if (limits.rest_bounce_block_size.has_value()) {
+      out << "        bounce_block_size: " << yaml_quote(*limits.rest_bounce_block_size) << "\n";
     }
     if (limits.rest_perf_instrumentation) { out << "        perf_instrumentation: true\n"; }
     out.close();
@@ -907,6 +924,348 @@ rest_bench_measurement run_rest_parquet_scan(s3_sql_fixture& fixture,
                                 static_cast<duckdb::idx_t>(table->num_rows()),
                                 bind_micro,
                                 micro};
+}
+
+std::string json_escape(std::string_view value);
+fs::path unittest_log_dir();
+
+struct read_consumer_partition {
+  std::size_t row_group_begin{0};
+  std::size_t row_group_end{0};
+  std::int64_t expected_rows{0};
+  std::vector<cudf::size_type> row_groups;
+};
+
+struct read_consumer_result {
+  std::string thread_name;
+  bench_clock::time_point thread_start;
+  bench_clock::time_point read_start;
+  bench_clock::time_point read_stop;
+  bench_clock::time_point reduce_stop;
+  bench_clock::time_point thread_stop;
+  std::int64_t rows{0};
+  std::int64_t orderkey_sum{0};
+};
+
+struct read_consumers_measurement {
+  bench_clock::time_point wall_start;
+  bench_clock::time_point open_start;
+  bench_clock::time_point open_stop;
+  bench_clock::time_point footer_start;
+  bench_clock::time_point footer_stop;
+  bench_clock::time_point metadata_start;
+  bench_clock::time_point metadata_stop;
+  bench_clock::time_point prepare_start;
+  bench_clock::time_point prepare_stop;
+  bench_clock::time_point scan_start;
+  bench_clock::time_point scan_stop;
+  bench_clock::time_point wall_stop;
+  std::vector<read_consumer_partition> partitions;
+  std::vector<read_consumer_result> consumers;
+  sirius::io::rest::rest_perf_snapshot aggregate;
+  std::int64_t rows{0};
+  std::int64_t orderkey_sum{0};
+};
+
+std::size_t positive_size_env(std::string_view name)
+{
+  auto const value = env_or(name);
+  if (value.empty()) { throw std::invalid_argument(std::string{name} + " is required"); }
+  auto const parsed = std::stoull(value);
+  if (parsed == 0) { throw std::invalid_argument(std::string{name} + " must be > 0"); }
+  return static_cast<std::size_t>(parsed);
+}
+
+std::string bounce_grain_yaml(std::size_t bytes)
+{
+  std::size_t constexpr kMiB = 1024UL * 1024UL;
+  if (bytes < kMiB || bytes % kMiB != 0) {
+    throw std::invalid_argument("SIRIUS_BENCH_READ_BOUNCE_BLOCK_SIZE must be a whole MiB");
+  }
+  return std::to_string(bytes / kMiB) + " MiB";
+}
+
+std::vector<read_consumer_partition> partition_whole_row_groups(
+  cudf::io::parquet::FileMetaData const& metadata, std::size_t read_consumers)
+{
+  if (read_consumers == 0 || metadata.row_groups.size() < read_consumers) {
+    throw std::invalid_argument("read_consumers exceeds the available row groups");
+  }
+
+  std::vector<read_consumer_partition> partitions;
+  partitions.reserve(read_consumers);
+  auto const base      = metadata.row_groups.size() / read_consumers;
+  auto const remainder = metadata.row_groups.size() % read_consumers;
+  std::size_t begin    = 0;
+  for (std::size_t consumer = 0; consumer < read_consumers; ++consumer) {
+    auto const count = base + (consumer < remainder ? 1 : 0);
+    read_consumer_partition partition;
+    partition.row_group_begin = begin;
+    partition.row_group_end   = begin + count;
+    partition.row_groups.reserve(count);
+    for (std::size_t rg = partition.row_group_begin; rg < partition.row_group_end; ++rg) {
+      partition.row_groups.push_back(static_cast<cudf::size_type>(rg));
+      partition.expected_rows += metadata.row_groups[rg].num_rows;
+    }
+    partitions.push_back(std::move(partition));
+    begin += count;
+  }
+  return partitions;
+}
+
+std::int64_t sum_orderkeys(cudf::column_view const& column, rmm::cuda_stream_view stream)
+{
+  if (column.type().id() != cudf::type_id::INT64) {
+    throw std::runtime_error("l_orderkey did not decode as INT64");
+  }
+  auto aggregation = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+  auto scalar =
+    cudf::reduce(column, *aggregation, cudf::data_type{cudf::type_id::INT64}, std::nullopt, stream);
+  return static_cast<cudf::numeric_scalar<std::int64_t> const&>(*scalar).value(stream);
+}
+
+read_consumers_measurement run_rest_parquet_read_consumers(s3_sql_fixture& fixture,
+                                                           std::string const& uri,
+                                                           std::vector<std::string> const& columns,
+                                                           std::size_t read_consumers)
+{
+  auto& manager = require_sirius_context(fixture).get_scan_manager();
+  auto& rest    = ensure_rest_ioctx_for_bench(manager, uri);
+
+  read_consumers_measurement measurement;
+  measurement.wall_start = bench_clock::now();
+  auto const before      = rest.perf_snapshot();
+
+  measurement.open_start = bench_clock::now();
+  auto datasource        = manager.create_datasource(uri);
+  measurement.open_stop  = bench_clock::now();
+  if (!datasource || !datasource->io_ctx() || datasource->io_ctx().get() != &rest) {
+    throw std::runtime_error(
+      "read-consumers benchmark did not route through the expected REST ioctx");
+  }
+
+  measurement.footer_start = bench_clock::now();
+  auto footer_buffer       = read_parquet_footer_for_bench(*datasource);
+  measurement.footer_stop  = bench_clock::now();
+
+  auto opts = cudf::io::parquet_reader_options::builder().column_names(columns).build();
+  measurement.metadata_start = bench_clock::now();
+  cudf::io::parquet::experimental::hybrid_scan_reader reader{
+    cudf::host_span<std::uint8_t const>(footer_buffer->data(), footer_buffer->size()), opts};
+  auto metadata             = reader.parquet_metadata();
+  measurement.metadata_stop = bench_clock::now();
+  measurement.partitions    = partition_whole_row_groups(metadata, read_consumers);
+
+  measurement.prepare_start = bench_clock::now();
+  std::vector<std::vector<std::unique_ptr<cudf::io::datasource>>> consumer_sources(read_consumers);
+  std::vector<std::vector<cudf::io::parquet::FileMetaData>> consumer_metadata(read_consumers);
+  std::vector<rmm::cuda_stream> streams;
+  streams.reserve(read_consumers);
+  for (std::size_t consumer = 0; consumer < read_consumers; ++consumer) {
+    streams.emplace_back();
+    consumer_metadata[consumer].push_back(metadata);
+    consumer_sources[consumer].push_back(datasource->duplicate());
+  }
+  measurement.prepare_stop = bench_clock::now();
+
+  int device_id                = 0;
+  auto const get_device_status = cudaGetDevice(&device_id);
+  if (get_device_status != cudaSuccess) {
+    throw std::runtime_error(std::string{"cudaGetDevice failed: "} +
+                             cudaGetErrorString(get_device_status));
+  }
+
+  measurement.consumers.resize(read_consumers);
+  std::vector<std::exception_ptr> errors(read_consumers);
+  std::mutex start_mutex;
+  std::condition_variable start_cv;
+  std::size_t ready = 0;
+  bool start        = false;
+  std::vector<std::thread> workers;
+  workers.reserve(read_consumers);
+  for (std::size_t consumer = 0; consumer < read_consumers; ++consumer) {
+    workers.emplace_back([&, consumer] {
+      auto& result       = measurement.consumers[consumer];
+      result.thread_name = "read_cons_" + std::to_string(consumer);
+#if defined(__linux__)
+      (void)pthread_setname_np(pthread_self(), result.thread_name.c_str());
+#endif
+      result.thread_start = bench_clock::now();
+      {
+        std::unique_lock lock(start_mutex);
+        ++ready;
+        start_cv.notify_all();
+        start_cv.wait(lock, [&] { return start; });
+      }
+
+      try {
+        auto const set_device_status = cudaSetDevice(device_id);
+        if (set_device_status != cudaSuccess) {
+          throw std::runtime_error(std::string{"cudaSetDevice failed: "} +
+                                   cudaGetErrorString(set_device_status));
+        }
+        auto consumer_opts =
+          cudf::io::parquet_reader_options::builder().column_names(columns).build();
+        consumer_opts.set_row_groups({measurement.partitions[consumer].row_groups});
+
+        result.read_start = bench_clock::now();
+        auto [table, table_metadata] =
+          cudf::io::read_parquet(std::move(consumer_sources[consumer]),
+                                 std::move(consumer_metadata[consumer]),
+                                 consumer_opts,
+                                 streams[consumer].view());
+        (void)table_metadata;
+        result.read_stop = bench_clock::now();
+        if (!table || table->num_columns() != static_cast<cudf::size_type>(columns.size())) {
+          throw std::runtime_error("read-consumers benchmark returned an unexpected table shape");
+        }
+        result.rows         = table->num_rows();
+        result.orderkey_sum = sum_orderkeys(table->view().column(0), streams[consumer].view());
+        result.reduce_stop  = bench_clock::now();
+      } catch (...) {
+        errors[consumer] = std::current_exception();
+      }
+      result.thread_stop = bench_clock::now();
+    });
+  }
+
+  {
+    std::unique_lock lock(start_mutex);
+    start_cv.wait(lock, [&] { return ready == read_consumers; });
+    measurement.scan_start = bench_clock::now();
+    start                  = true;
+  }
+  start_cv.notify_all();
+  for (auto& worker : workers) {
+    worker.join();
+  }
+  measurement.scan_stop = bench_clock::now();
+
+  for (auto const& error : errors) {
+    if (error) { std::rethrow_exception(error); }
+  }
+  for (std::size_t consumer = 0; consumer < read_consumers; ++consumer) {
+    if (measurement.consumers[consumer].rows != measurement.partitions[consumer].expected_rows) {
+      throw std::runtime_error("whole-row-group partition returned an unexpected row count");
+    }
+    measurement.rows += measurement.consumers[consumer].rows;
+    measurement.orderkey_sum += measurement.consumers[consumer].orderkey_sum;
+  }
+
+  measurement.wall_stop = bench_clock::now();
+  measurement.aggregate = delta_snapshot(rest.perf_snapshot(), before);
+  return measurement;
+}
+
+fs::path read_consumers_json_path()
+{
+  auto const configured = env_or("SIRIUS_BENCH_READ_CONSUMERS_OUTPUT");
+  if (!configured.empty()) { return configured; }
+  auto const stamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::system_clock::now().time_since_epoch())
+                       .count();
+  return unittest_log_dir() / ("s3_read_consumers_" + std::to_string(stamp) + ".json");
+}
+
+void write_read_consumers_json(fs::path const& path,
+                               s3_test_env const& env,
+                               std::string_view object_key,
+                               std::uint64_t dataset_bytes,
+                               std::string const& transport,
+                               std::size_t sample,
+                               std::size_t read_consumers,
+                               std::size_t rest_n_reactors,
+                               std::size_t max_connections,
+                               std::size_t bounce_block_size,
+                               read_consumers_measurement const& measurement)
+{
+  fs::create_directories(path.parent_path());
+  std::ofstream out(path);
+  if (!out) { throw std::runtime_error("could not create read-consumers JSON: " + path.string()); }
+
+  auto const offset_ms = [&](bench_clock::time_point point) {
+    return elapsed_ms(measurement.wall_start, point);
+  };
+  auto const wall_ms   = elapsed_ms(measurement.wall_start, measurement.wall_stop);
+  auto const scan_ms   = elapsed_ms(measurement.scan_start, measurement.scan_stop);
+  auto const payload   = measurement.aggregate.payload_bytes_read_total;
+  auto const wall_gbps = wall_ms > 0.0 ? static_cast<double>(payload) / wall_ms / 1'000'000.0 : 0.0;
+  auto const scan_gbps = scan_ms > 0.0 ? static_cast<double>(payload) / scan_ms / 1'000'000.0 : 0.0;
+  auto const pinned_bytes = rest_n_reactors * max_connections * bounce_block_size;
+  auto const signature    = "rest" + std::to_string(rest_n_reactors) + "_conn" +
+                         std::to_string(max_connections) + "_cons" +
+                         std::to_string(read_consumers) + "_grain" +
+                         std::to_string(bounce_block_size) + "_" + transport + "_compat7_cacheoff";
+
+  out << "{\n"
+      << "  \"git_sha\": \"" << json_escape(env_or("SIRIUS_BENCH_GIT_SHA", "unknown")) << "\",\n"
+      << "  \"host\": \"" << json_escape(env_or("HOSTNAME", "unknown")) << "\",\n"
+      << "  \"scenario\": \"s3_read_consumers\",\n"
+      << "  \"arm\": \"" << json_escape(env_or("SIRIUS_BENCH_READ_ARM", "M1")) << "\",\n"
+      << "  \"backend_lifecycle\": \""
+      << json_escape(env_or("SIRIUS_BENCH_READ_BACKEND_LIFECYCLE", "unknown")) << "\",\n"
+      << "  \"config_signature\": \"" << signature << "\",\n"
+      << "  \"transport\": \"" << transport << "\",\n"
+      << "  \"sample\": " << sample << ",\n"
+      << "  \"dataset_bytes\": " << dataset_bytes << ",\n"
+      << "  \"object\": {\"bucket\": \"" << json_escape(env.bucket) << "\", \"key\": \""
+      << json_escape(object_key) << "\"},\n"
+      << "  \"projection\": \"columns_7\",\n"
+      << "  \"prefetch_cache_mode\": \"off\",\n"
+      << "  \"read_consumers\": " << read_consumers << ",\n"
+      << "  \"rest_n_reactors\": " << rest_n_reactors << ",\n"
+      << "  \"max_connections\": " << max_connections << ",\n"
+      << "  \"slot_budget\": " << rest_n_reactors * max_connections << ",\n"
+      << "  \"bounce_block_size\": " << bounce_block_size << ",\n"
+      << "  \"pinned_bytes\": " << pinned_bytes << ",\n"
+      << "  \"wall_clock_ms\": " << std::fixed << std::setprecision(3) << wall_ms << ",\n"
+      << "  \"scan_wall_ms\": " << scan_ms << ",\n"
+      << "  \"effective_wall_gb_per_sec\": " << wall_gbps << ",\n"
+      << "  \"effective_scan_gb_per_sec\": " << scan_gbps << ",\n"
+      << "  \"rows\": " << measurement.rows << ",\n"
+      << "  \"orderkey_sum\": " << measurement.orderkey_sum << ",\n"
+      << "  \"stage_boundaries_ms\": {"
+      << "\"open_start\":" << offset_ms(measurement.open_start)
+      << ",\"open_stop\":" << offset_ms(measurement.open_stop)
+      << ",\"footer_start\":" << offset_ms(measurement.footer_start)
+      << ",\"footer_stop\":" << offset_ms(measurement.footer_stop)
+      << ",\"metadata_start\":" << offset_ms(measurement.metadata_start)
+      << ",\"metadata_stop\":" << offset_ms(measurement.metadata_stop)
+      << ",\"prepare_start\":" << offset_ms(measurement.prepare_start)
+      << ",\"prepare_stop\":" << offset_ms(measurement.prepare_stop)
+      << ",\"scan_start\":" << offset_ms(measurement.scan_start)
+      << ",\"scan_stop\":" << offset_ms(measurement.scan_stop)
+      << ",\"wall_stop\":" << offset_ms(measurement.wall_stop) << "},\n"
+      << "  \"consumers\": [\n";
+  for (std::size_t consumer = 0; consumer < measurement.consumers.size(); ++consumer) {
+    auto const& result    = measurement.consumers[consumer];
+    auto const& partition = measurement.partitions[consumer];
+    out << "    {\"consumer\":" << consumer << ",\"thread_name\":\""
+        << json_escape(result.thread_name) << "\",\"row_group_begin\":" << partition.row_group_begin
+        << ",\"row_group_end\":" << partition.row_group_end
+        << ",\"expected_rows\":" << partition.expected_rows << ",\"rows\":" << result.rows
+        << ",\"orderkey_sum\":" << result.orderkey_sum
+        << ",\"read_ms\":" << elapsed_ms(result.read_start, result.read_stop)
+        << ",\"reduce_ms\":" << elapsed_ms(result.read_stop, result.reduce_stop)
+        << ",\"wall_ms\":" << elapsed_ms(result.thread_start, result.thread_stop) << "}"
+        << (consumer + 1 == measurement.consumers.size() ? "\n" : ",\n");
+  }
+  auto const& aggregate = measurement.aggregate;
+  out << "  ],\n"
+      << "  \"aggregate\": {"
+      << "\"chunk_get_count\":" << aggregate.chunk_get_count
+      << ",\"payload_bytes_read_total\":" << aggregate.payload_bytes_read_total
+      << ",\"queue_wait_ns_total\":" << aggregate.queue_wait_ns_total
+      << ",\"queue_wait_count\":" << aggregate.queue_wait_count
+      << ",\"chunk_get_ns_total\":" << aggregate.chunk_get_ns_total
+      << ",\"ttfb_ns\":" << aggregate.ttfb_ns
+      << ",\"h2d_observed_ns_total\":" << aggregate.h2d_observed_ns_total
+      << ",\"h2d_observed_count\":" << aggregate.h2d_observed_count
+      << ",\"h2d_observed_ns_max\":" << aggregate.h2d_observed_ns_max
+      << ",\"retries_total\":" << aggregate.retries_total
+      << ",\"terminal_failures_total\":" << aggregate.terminal_failures_total
+      << ",\"device_stream_sync_total\":" << aggregate.device_stream_sync_total << "}\n"
+      << "}\n";
 }
 
 struct metric_delta {
@@ -1904,6 +2263,102 @@ TEST_CASE("S3 REST bench perf instrumentation gate keeps micro counters zero", "
   CHECK(record.retries_total == 0);
   CHECK(record.terminal_failures_total == 0);
   CHECK(record.device_stream_sync_total == 0);
+}
+
+TEST_CASE("S3 REST read consumers benchmark partitions SF10 by whole row groups",
+          "[.][s3][read-consumers]")
+{
+  if (env_or("SIRIUS_BENCH_READ_CONSUMERS").empty()) {
+    SUCCEED("SIRIUS_BENCH_READ_CONSUMERS not set; skipping read-consumers measurement");
+    return;
+  }
+
+  auto const read_consumers  = positive_size_env("SIRIUS_BENCH_READ_CONSUMERS");
+  auto const rest_n_reactors = positive_size_env("SIRIUS_BENCH_READ_REACTORS");
+  auto const max_connections = positive_size_env("SIRIUS_BENCH_READ_MAX_CONNECTIONS");
+  auto const bounce_grain    = positive_size_env("SIRIUS_BENCH_READ_BOUNCE_BLOCK_SIZE");
+  auto const sample          = positive_size_env("SIRIUS_BENCH_READ_SAMPLE");
+  auto const transport       = env_or("SIRIUS_BENCH_READ_TRANSPORT", "http");
+
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+  auto large = read_large_lineitem_bench_fixture(*env);
+  if (!large) { return; }
+
+  std::string endpoint;
+  std::optional<std::string> ca_bundle;
+  bool tls_verify = false;
+  if (transport == "http") {
+    endpoint = env->endpoint;
+  } else if (transport == "https") {
+    if (env->https_endpoint.empty() || env->ca_bundle_path.empty()) {
+      FAIL("HTTPS read-consumers measurement requires SIRIUS_TEST_S3_HTTPS_ENDPOINT and CA bundle");
+    }
+    endpoint   = env->https_endpoint;
+    ca_bundle  = env->ca_bundle_path;
+    tls_verify = true;
+  } else {
+    FAIL("SIRIUS_BENCH_READ_TRANSPORT must be http or https");
+  }
+
+  auto limits                      = large_sirius_memory_limits(/*enable_prefetch_cache=*/false);
+  limits.gpu_usage                 = "8 GiB";
+  limits.gpu_reservation           = "3 GiB";
+  limits.host_capacity             = "12 GiB";
+  limits.rest_perf_instrumentation = true;
+  limits.rest_n_reactors           = rest_n_reactors;
+  limits.rest_max_connections      = max_connections;
+  limits.rest_bounce_block_size    = bounce_grain_yaml(bounce_grain);
+  s3_sql_fixture fixture(*env, limits, std::nullopt, endpoint, std::move(ca_bundle), tls_verify);
+
+  auto measurement =
+    run_rest_parquet_read_consumers(fixture, large->uri, bench_compat_projection(), read_consumers);
+
+  constexpr std::int64_t expected_rows         = 59'986'052;
+  constexpr std::int64_t expected_orderkey_sum = 1'799'465'265'420'123;
+  REQUIRE(static_cast<std::int64_t>(large->total_num_rows) == expected_rows);
+  CHECK(measurement.rows == expected_rows);
+  CHECK(measurement.orderkey_sum == expected_orderkey_sum);
+  CHECK(measurement.aggregate.chunk_get_count > 0);
+  CHECK(measurement.aggregate.payload_bytes_read_total > 0);
+  CHECK(measurement.aggregate.terminal_failures_total == 0);
+  CHECK(measurement.aggregate.device_stream_sync_total == 0);
+  CHECK(elapsed_ms(measurement.scan_start, measurement.scan_stop) > 0.0);
+  CHECK(elapsed_ms(measurement.wall_start, measurement.wall_stop) >=
+        elapsed_ms(measurement.scan_start, measurement.scan_stop));
+
+  auto const baseline_bytes = env_or("SIRIUS_BENCH_READ_BASELINE_BYTES");
+  if (!baseline_bytes.empty()) {
+    auto const ratio = static_cast<double>(measurement.aggregate.payload_bytes_read_total) /
+                       static_cast<double>(std::stoull(baseline_bytes));
+    CHECK(ratio >= 0.98);
+    CHECK(ratio <= 1.02);
+  }
+
+  auto const path = read_consumers_json_path();
+  write_read_consumers_json(path,
+                            *env,
+                            sf10_lineitem_key(),
+                            static_cast<std::uint64_t>(fs::file_size(large->local_path)),
+                            transport,
+                            sample,
+                            read_consumers,
+                            rest_n_reactors,
+                            max_connections,
+                            bounce_grain,
+                            measurement);
+  auto const json = read_text_file(path);
+  for (auto const key : {"\"config_signature\"",
+                         "\"stage_boundaries_ms\"",
+                         "\"consumers\"",
+                         "\"aggregate\"",
+                         "\"orderkey_sum\""}) {
+    CHECK(json.find(key) != std::string::npos);
+  }
+  WARN("S3 read-consumers sample wall="
+       << elapsed_ms(measurement.wall_start, measurement.wall_stop)
+       << "ms payload=" << measurement.aggregate.payload_bytes_read_total
+       << " bytes GETs=" << measurement.aggregate.chunk_get_count << " output=" << path.string());
 }
 
 TEST_CASE("S3 REST perf benchmark emits HTTP and HTTPS JSON baseline", "[.][s3][bench]")

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -27,9 +27,11 @@
 #include <rmm/cuda_stream.hpp>
 #include <rmm/device_buffer.hpp>
 
+#include <cuda/memory_resource>
 #include <cuda_runtime.h>
 
 #include <arpa/inet.h>
+#include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 #include <cucascade/memory/topology_discovery.hpp>
 #include <netinet/in.h>
 #include <spdlog/sinks/base_sink.h>
@@ -52,8 +54,10 @@
 #include <fstream>
 #include <future>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <mutex>
+#include <new>
 #include <optional>
 #include <span>
 #include <stdexcept>
@@ -70,6 +74,8 @@ using sirius::io::rest::rest_ioctx;
 using sirius::scan_manager::scan_manager_config;
 using sirius::scan_manager::sirius_scan_manager;
 using namespace std::chrono_literals;
+
+using fixed_host_mr = cucascade::memory::fixed_size_host_memory_resource;
 
 std::string env_or(std::string const& name, std::string fallback = {})
 {
@@ -599,6 +605,99 @@ class scoped_spdlog_capture {
   std::shared_ptr<capture_sink> _sink;
   spdlog::level::level_enum _old_level;
 };
+
+void require_invalid_bounce_grain_rejected(std::size_t bounce_block_size)
+{
+  scan_manager_fixture fixture;
+  auto cfg                   = make_fake_rest_config("http://127.0.0.1:9");
+  cfg.rest.bounce_block_size = bounce_block_size;
+
+  scoped_spdlog_capture capture;
+  sirius_scan_manager manager{cfg, *fixture.memory, fixture.topology};
+  auto datasource = manager.create_datasource("s3://bounce-grain-bucket/object.bin");
+
+  REQUIRE(datasource == nullptr);
+  auto const records = capture.records();
+  CHECK(std::any_of(records.begin(), records.end(), [](capture_sink::record const& record) {
+    return record.payload.find("bounce_block_size") != std::string::npos;
+  }));
+}
+
+struct recording_upstream_state {
+  std::atomic<std::size_t> allocations{0};
+  std::atomic<std::size_t> deallocations{0};
+  std::atomic<bool> throw_on_allocate{false};
+  std::atomic<bool> workers_stopped{false};
+  std::atomic<bool> deallocated_after_workers_stopped{false};
+  std::atomic<bool> deallocated_while_reservation_active{false};
+  fixed_host_mr* host{nullptr};
+};
+
+/// Test-only upstream used through the public FSMR constructor.  It lets the
+/// test force the allocation after reserve() to fail, and records the only
+/// externally observable destruction order: workers are stopped, the upstream
+/// span is returned, then the FSMR reservation is released.
+class recording_upstream {
+ public:
+  explicit recording_upstream(std::shared_ptr<recording_upstream_state> state)
+    : state_(std::move(state))
+  {
+  }
+
+  void* allocate(cuda::stream_ref, std::size_t bytes, std::size_t = alignof(std::max_align_t))
+  {
+    state_->allocations.fetch_add(1, std::memory_order_relaxed);
+    if (state_->throw_on_allocate.load(std::memory_order_relaxed)) {
+      throw std::runtime_error("injected shared-bounce upstream allocation failure");
+    }
+    auto* ptr = std::malloc(bytes);
+    if (ptr == nullptr) { throw std::bad_alloc{}; }
+    return ptr;
+  }
+
+  void deallocate(cuda::stream_ref,
+                  void* ptr,
+                  std::size_t,
+                  std::size_t = alignof(std::max_align_t)) noexcept
+  {
+    state_->deallocated_after_workers_stopped.store(
+      state_->workers_stopped.load(std::memory_order_relaxed), std::memory_order_relaxed);
+    auto* const host = state_->host;
+    state_->deallocated_while_reservation_active.store(
+      host != nullptr && host->get_active_reservation_count() != 0, std::memory_order_relaxed);
+    state_->deallocations.fetch_add(1, std::memory_order_relaxed);
+    std::free(ptr);
+  }
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
+  {
+    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  }
+
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = alignof(std::max_align_t)) noexcept
+  {
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+  }
+
+  bool operator==(recording_upstream const& other) const noexcept { return state_ == other.state_; }
+
+  friend void get_property(recording_upstream const&, cuda::mr::device_accessible) noexcept {}
+
+ private:
+  std::shared_ptr<recording_upstream_state> state_;
+};
+
+std::shared_ptr<rest_ioctx> make_host_backed_rest_ioctx(fixed_host_mr* host_mr,
+                                                        sirius::io::rest::config cfg,
+                                                        std::size_t n_reactors)
+{
+  auto authorizer = std::make_shared<fixed_url_authorizer>("http://127.0.0.1:9");
+  auto ctx        = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+    std::move(cfg), std::move(authorizer), host_mr);
+  return std::make_shared<rest_ioctx>(n_reactors, std::move(ctx));
+}
 
 }  // namespace
 
@@ -1364,6 +1463,378 @@ TEST_CASE("rest_ioctx stages device reads through FSMR for single and multi chun
     auto got = copy_device_to_host(dst, size, stream);
     require_bytes_equal(got, std::span<std::uint8_t const>(medium.data() + offset, size));
   }
+}
+
+TEST_CASE("REST rejects bounce grains incompatible with the host block size",
+          "[s3][rest][bounce_grain]")
+{
+  SECTION("smaller than one host block") { require_invalid_bounce_grain_rejected(512UL * 1024); }
+
+  SECTION("not a whole number of host blocks")
+  {
+    require_invalid_bounce_grain_rejected((3UL * 1024 * 1024) / 2);
+  }
+
+  SECTION("valid multiple above the hard grain ceiling")
+  {
+    require_invalid_bounce_grain_rejected(2UL * 1024 * 1024 * 1024);
+  }
+
+  SECTION("valid multiple near size_t max")
+  {
+    std::size_t constexpr host_block_size = 1UL * 1024 * 1024;
+    auto const size_max                   = std::numeric_limits<std::size_t>::max();
+    auto const near_size_max              = size_max - (size_max % host_block_size);
+    REQUIRE(near_size_max > sirius::io::rest::config::max_bounce_block_size);
+    require_invalid_bounce_grain_rejected(near_size_max);
+  }
+}
+
+TEST_CASE("REST direct context resolves a zero bounce grain to the host block size",
+          "[s3][rest][bounce_grain]")
+{
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    WARN("Skipping REST direct-context bounce fallback test: no CUDA device");
+    return;
+  }
+
+  scan_manager_fixture fixture;
+  auto const host_spaces =
+    fixture.memory->get_memory_spaces_for_tier(cucascade::memory::Tier::HOST);
+  REQUIRE_FALSE(host_spaces.empty());
+  auto* host_mr = host_spaces.front()->get_memory_resource_of<cucascade::memory::Tier::HOST>();
+  REQUIRE(host_mr != nullptr);
+  auto const host_block_size = host_mr->get_block_size();
+
+  auto const payload = deterministic_payload((2 * host_block_size) + 17);
+  range_http_server server(payload);
+  auto cfg                 = direct_rest_test_config();
+  cfg.max_connections      = 2;
+  cfg.bounce_block_size    = 0;
+  cfg.perf_instrumentation = true;
+  auto authorizer          = std::make_shared<fixed_url_authorizer>(server.endpoint());
+  auto reactor_ctx         = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+    cfg, std::move(authorizer), host_mr);
+  auto ioctx = std::make_shared<rest_ioctx>(1, std::move(reactor_ctx));
+  ioctx->start();
+  CHECK(ioctx->bounce_slice_snapshots().empty());
+  auto datasource = ioctx->open_datasource("s3://bounce-grain-bucket/zero-fallback.bin");
+  REQUIRE(datasource != nullptr);
+
+  rmm::cuda_stream stream;
+  rmm::device_buffer dst(payload.size(), stream);
+  auto const before = ioctx->perf_snapshot();
+  REQUIRE(datasource->device_read(
+            0, payload.size(), static_cast<std::uint8_t*>(dst.data()), stream) == payload.size());
+  auto const got   = copy_device_to_host(dst, payload.size(), stream);
+  auto const after = ioctx->perf_snapshot();
+
+  require_bytes_equal(got, payload);
+  auto const expected_windows =
+    payload.size() / host_block_size + (payload.size() % host_block_size != 0 ? 1 : 0);
+  CHECK(after.chunk_get_count - before.chunk_get_count == expected_windows);
+  CHECK(after.payload_bytes_read_total - before.payload_bytes_read_total == payload.size());
+  CHECK(server.get_count() == expected_windows);
+}
+
+TEST_CASE("REST device reads use the configured bounce grain for ranged GET windows",
+          "[s3][rest][bounce_grain]")
+{
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    WARN("Skipping REST bounce-grain device-read test: no CUDA device");
+    return;
+  }
+
+  std::size_t constexpr bounce_block_size = 4UL * 1024 * 1024;
+  auto const payload                      = deterministic_payload((9UL * 1024 * 1024) + 17);
+  range_http_server server(payload);
+  scan_manager_fixture fixture;
+  auto cfg                      = make_fake_rest_config(server.endpoint());
+  cfg.rest.max_connections      = 4;
+  cfg.rest.bounce_block_size    = bounce_block_size;
+  cfg.rest.perf_instrumentation = true;
+  sirius_scan_manager manager{cfg, *fixture.memory, fixture.topology};
+
+  auto datasource = manager.create_datasource("s3://bounce-grain-bucket/object.bin");
+  auto* ioctx     = require_rest_ioctx(datasource);
+
+  rmm::cuda_stream stream;
+  rmm::device_buffer dst(payload.size(), stream);
+  auto const before = ioctx->perf_snapshot();
+  REQUIRE(datasource->device_read(
+            0, payload.size(), static_cast<std::uint8_t*>(dst.data()), stream) == payload.size());
+  auto const got   = copy_device_to_host(dst, payload.size(), stream);
+  auto const after = ioctx->perf_snapshot();
+
+  require_bytes_equal(got, payload);
+  std::uint64_t const expected_windows =
+    (payload.size() + bounce_block_size - 1) / bounce_block_size;
+  CHECK(after.chunk_get_count - before.chunk_get_count == expected_windows);
+  CHECK(after.payload_bytes_read_total - before.payload_bytes_read_total == payload.size());
+  CHECK(server.get_count() == expected_windows);
+}
+
+TEST_CASE("REST large-grain staging is one accounted span with deterministic reactor slices",
+          "[s3][integration][rest][bounce_accounting]")
+{
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    WARN("Skipping REST shared-bounce accounting test: no CUDA device");
+    return;
+  }
+
+  std::size_t constexpr kMiB        = 1UL << 20;
+  std::size_t constexpr reactors    = 2;
+  std::size_t constexpr connections = 2;
+  std::size_t constexpr grain       = 4 * kMiB;
+  std::size_t constexpr span_bytes  = reactors * connections * grain;
+
+  scan_manager_fixture fixture;
+  auto const host_spaces =
+    fixture.memory->get_memory_spaces_for_tier(cucascade::memory::Tier::HOST);
+  REQUIRE_FALSE(host_spaces.empty());
+  auto* const host_mr =
+    host_spaces.front()->get_memory_resource_of<cucascade::memory::Tier::HOST>();
+  REQUIRE(host_mr != nullptr);
+  REQUIRE(host_mr->get_block_size() < grain);
+
+  auto const reserved_before     = host_mr->get_total_reserved_bytes();
+  auto const allocated_before    = host_mr->get_total_allocated_bytes();
+  auto const blocks_before       = host_mr->get_total_blocks();
+  auto const reservations_before = host_mr->get_active_reservation_count();
+
+  auto cfg              = direct_rest_test_config();
+  cfg.max_connections   = connections;
+  cfg.bounce_block_size = grain;
+  auto ioctx            = make_host_backed_rest_ioctx(host_mr, cfg, reactors);
+  REQUIRE_NOTHROW(ioctx->start());
+
+  CHECK(host_mr->get_total_reserved_bytes() == reserved_before + span_bytes);
+  CHECK(host_mr->get_total_allocated_bytes() == allocated_before + span_bytes);
+  CHECK(host_mr->get_total_blocks() == blocks_before);
+  CHECK(host_mr->get_active_reservation_count() == reservations_before + 1);
+
+  auto const slices = ioctx->bounce_slice_snapshots();
+  REQUIRE(slices.size() == reactors);
+  for (std::size_t r = 0; r < slices.size(); ++r) {
+    CHECK(slices[r].reactor_index == r);
+    CHECK(slices[r].allocation_id == slices.front().allocation_id);
+    CHECK(slices[r].span_bytes == span_bytes);
+    CHECK(slices[r].offset_bytes == r * connections * grain);
+    CHECK(slices[r].slice_bytes == connections * grain);
+  }
+
+  ioctx->shutdown();
+  ioctx.reset();
+
+  CHECK(host_mr->get_total_reserved_bytes() == reserved_before);
+  CHECK(host_mr->get_total_allocated_bytes() == allocated_before);
+  CHECK(host_mr->get_total_blocks() == blocks_before);
+  CHECK(host_mr->get_active_reservation_count() == reservations_before);
+}
+
+TEST_CASE("REST shared bounce span rolls back a successful FSMR reservation when upstream throws",
+          "[s3][integration][rest][bounce_accounting]")
+{
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    WARN("Skipping REST shared-bounce rollback test: no CUDA device");
+    return;
+  }
+
+  std::size_t constexpr kMiB       = 1UL << 20;
+  std::size_t constexpr grain      = 4 * kMiB;
+  std::size_t constexpr span_bytes = 2 * grain;
+  auto state                       = std::make_shared<recording_upstream_state>();
+  recording_upstream upstream{state};
+  fixed_host_mr host{0,
+                     rmm::device_async_resource_ref{upstream},
+                     /*memory_limit=*/16 * kMiB,
+                     /*memory_capacity=*/16 * kMiB,
+                     /*block_size=*/kMiB,
+                     /*pool_size=*/1,
+                     /*initial_pools=*/0};
+  state->host = &host;
+  state->throw_on_allocate.store(true, std::memory_order_relaxed);
+
+  auto const reserved_before     = host.get_total_reserved_bytes();
+  auto const allocated_before    = host.get_total_allocated_bytes();
+  auto const reservations_before = host.get_active_reservation_count();
+
+  auto cfg              = direct_rest_test_config();
+  cfg.max_connections   = 2;
+  cfg.bounce_block_size = grain;
+  auto ioctx            = make_host_backed_rest_ioctx(&host, cfg, /*n_reactors=*/1);
+
+  CHECK_THROWS_WITH(ioctx->start(), Catch::Contains("injected shared-bounce upstream"));
+  CHECK(state->allocations.load(std::memory_order_relaxed) == 1);
+  CHECK(state->deallocations.load(std::memory_order_relaxed) == 0);
+  CHECK(host.get_total_reserved_bytes() == reserved_before);
+  CHECK(host.get_total_allocated_bytes() == allocated_before);
+  CHECK(host.get_active_reservation_count() == reservations_before);
+
+  ioctx->shutdown();
+}
+
+TEST_CASE("REST shared bounce span releases upstream before its FSMR booking",
+          "[s3][integration][rest][bounce_accounting]")
+{
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    WARN("Skipping REST shared-bounce teardown-order test: no CUDA device");
+    return;
+  }
+
+  std::size_t constexpr kMiB       = 1UL << 20;
+  std::size_t constexpr grain      = 4 * kMiB;
+  std::size_t constexpr span_bytes = 2 * grain;
+  auto state                       = std::make_shared<recording_upstream_state>();
+  recording_upstream upstream{state};
+  fixed_host_mr host{0,
+                     rmm::device_async_resource_ref{upstream},
+                     /*memory_limit=*/16 * kMiB,
+                     /*memory_capacity=*/16 * kMiB,
+                     /*block_size=*/kMiB,
+                     /*pool_size=*/1,
+                     /*initial_pools=*/0};
+  state->host = &host;
+
+  auto cfg              = direct_rest_test_config();
+  cfg.max_connections   = 2;
+  cfg.bounce_block_size = grain;
+  auto ioctx            = make_host_backed_rest_ioctx(&host, cfg, /*n_reactors=*/1);
+  REQUIRE_NOTHROW(ioctx->start());
+  CHECK(state->allocations.load(std::memory_order_relaxed) == 1);
+  CHECK(host.get_total_reserved_bytes() == span_bytes);
+  CHECK(host.get_total_allocated_bytes() == span_bytes);
+  CHECK(host.get_active_reservation_count() == 1);
+
+  ioctx->shutdown();
+  state->workers_stopped.store(true, std::memory_order_relaxed);
+  ioctx.reset();
+
+  CHECK(state->deallocations.load(std::memory_order_relaxed) == 1);
+  CHECK(state->deallocated_after_workers_stopped.load(std::memory_order_relaxed));
+  CHECK(state->deallocated_while_reservation_active.load(std::memory_order_relaxed));
+  CHECK(host.get_total_reserved_bytes() == 0);
+  CHECK(host.get_total_allocated_bytes() == 0);
+  CHECK(host.get_active_reservation_count() == 0);
+}
+
+TEST_CASE("REST shared bounce span fails loudly when the resolved host budget is too small",
+          "[s3][integration][rest][bounce_accounting]")
+{
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    WARN("Skipping REST shared-bounce host-budget test: no CUDA device");
+    return;
+  }
+
+  std::size_t constexpr kMiB  = 1UL << 20;
+  std::size_t constexpr grain = 4 * kMiB;
+  auto state                  = std::make_shared<recording_upstream_state>();
+  recording_upstream upstream{state};
+  fixed_host_mr host{0,
+                     rmm::device_async_resource_ref{upstream},
+                     /*memory_limit=*/4 * kMiB,
+                     /*memory_capacity=*/16 * kMiB,
+                     /*block_size=*/kMiB,
+                     /*pool_size=*/1,
+                     /*initial_pools=*/0};
+  state->host = &host;
+
+  auto cfg                            = direct_rest_test_config();
+  cfg.max_connections                 = 2;
+  cfg.bounce_block_size               = grain;
+  cfg.resolved_host_reservation_limit = 4 * kMiB;
+  auto ioctx                          = make_host_backed_rest_ioctx(&host, cfg, /*n_reactors=*/1);
+
+  std::string error;
+  try {
+    ioctx->start();
+  } catch (std::exception const& e) {
+    error = e.what();
+  }
+  REQUIRE_FALSE(error.empty());
+  CHECK(error.find("needed 8388608 bytes") != std::string::npos);
+  CHECK(error.find("admissible limit 4194304 bytes") != std::string::npos);
+  CHECK(error.find("shortfall 4194304 bytes") != std::string::npos);
+  CHECK(state->allocations.load(std::memory_order_relaxed) == 0);
+  CHECK(host.get_total_reserved_bytes() == 0);
+  CHECK(host.get_total_allocated_bytes() == 0);
+  CHECK(host.get_active_reservation_count() == 0);
+}
+
+TEST_CASE("REST shared bounce slices are disjoint under concurrent device reads",
+          "[s3][integration][rest][bounce_accounting]")
+{
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    WARN("Skipping REST shared-bounce slice test: no CUDA device");
+    return;
+  }
+
+  std::size_t constexpr kMiB        = 1UL << 20;
+  std::size_t constexpr reactors    = 2;
+  std::size_t constexpr connections = 2;
+  std::size_t constexpr grain       = 4 * kMiB;
+  std::size_t constexpr span_bytes  = reactors * connections * grain;
+  if (!sirius::test::ensure_s3_container_env()) { return; }
+
+  auto const bucket  = require_env("SIRIUS_TEST_S3_BUCKET");
+  auto const payload = read_binary_file(local_fixture_path("small.bin"));
+  scan_manager_fixture fixture;
+  auto cfg                   = make_minio_rest_config();
+  cfg.rest_n_reactors        = reactors;
+  cfg.rest.max_connections   = connections;
+  cfg.rest.bounce_block_size = grain;
+  cfg.enable_prefetch_cache  = false;
+  sirius_scan_manager manager{cfg, *fixture.memory, fixture.topology};
+  auto first        = manager.create_datasource("s3://" + bucket + "/small.bin");
+  auto* const ioctx = require_rest_ioctx(first);
+  auto second       = manager.create_datasource("s3://" + bucket + "/small.bin");
+  REQUIRE(first != nullptr);
+  REQUIRE(second != nullptr);
+  REQUIRE(second->io_ctx().get() == first->io_ctx().get());
+
+  auto const slices = ioctx->bounce_slice_snapshots();
+  REQUIRE(slices.size() == reactors);
+  for (std::size_t r = 0; r < slices.size(); ++r) {
+    CHECK(slices[r].reactor_index == r);
+    CHECK(slices[r].allocation_id == slices.front().allocation_id);
+    CHECK(slices[r].span_bytes == span_bytes);
+    CHECK(slices[r].offset_bytes == r * connections * grain);
+    CHECK(slices[r].slice_bytes == connections * grain);
+    if (r != 0) {
+      CHECK(slices[r - 1].offset_bytes + slices[r - 1].slice_bytes <= slices[r].offset_bytes);
+    }
+  }
+  CHECK(slices.back().offset_bytes + slices.back().slice_bytes == span_bytes);
+
+  auto read_all = [&](sirius::io::sirius_datasource& datasource) {
+    rmm::cuda_stream stream;
+    rmm::device_buffer dst(payload.size(), stream);
+    auto const read =
+      datasource.device_read(0, payload.size(), static_cast<std::uint8_t*>(dst.data()), stream);
+    if (read != payload.size()) {
+      throw std::runtime_error("concurrent REST device read returned a short result");
+    }
+    std::vector<std::uint8_t> out(payload.size());
+    auto const copy = cudaMemcpyAsync(
+      out.data(), dst.data(), payload.size(), cudaMemcpyDeviceToHost, stream.value());
+    if (copy != cudaSuccess) {
+      throw std::runtime_error(std::string("concurrent REST D2H copy failed: ") +
+                               cudaGetErrorString(copy));
+    }
+    stream.synchronize();
+    return out;
+  };
+  auto first_read  = std::async(std::launch::async, [&] { return read_all(*first); });
+  auto second_read = std::async(std::launch::async, [&] { return read_all(*second); });
+  require_bytes_equal(first_read.get(), payload);
+  require_bytes_equal(second_read.get(), payload);
 }
 
 TEST_CASE("rest_ioctx retries transient fake-server failures and reports terminal failures",

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -1490,6 +1490,38 @@ TEST_CASE("REST rejects bounce grains incompatible with the host block size",
   }
 }
 
+TEST_CASE("REST rejects a programmatic bounce grain without HOST staging",
+          "[s3][rest][bounce_accounting]")
+{
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    WARN("Skipping REST GPU-only staging test: no CUDA device");
+    return;
+  }
+
+  cucascade::memory::gpu_memory_space_config gpu_space{};
+  gpu_space.device_id       = 0;
+  gpu_space.memory_capacity = 256UL * 1024 * 1024;
+  std::vector<cucascade::memory::memory_space_config> spaces;
+  spaces.emplace_back(std::move(gpu_space));
+  sirius::memory::sirius_memory_reservation_manager memory{spaces};
+  REQUIRE(memory.get_memory_spaces_for_tier(cucascade::memory::Tier::HOST).empty());
+
+  auto cfg                   = make_fake_rest_config("http://127.0.0.1:9");
+  cfg.use_sirius_datasource  = false;
+  cfg.rest.bounce_block_size = 4UL * 1024 * 1024;
+
+  scoped_spdlog_capture capture;
+  sirius_scan_manager manager{cfg, memory, single_gpu_index()};
+  auto datasource = manager.create_datasource("s3://bounce-grain-bucket/object.bin");
+
+  REQUIRE(datasource == nullptr);
+  auto const records = capture.records();
+  CHECK(std::any_of(records.begin(), records.end(), [](capture_sink::record const& record) {
+    return record.payload.find("bounce_block_size") != std::string::npos;
+  }));
+}
+
 TEST_CASE("REST direct context resolves a zero bounce grain to the host block size",
           "[s3][rest][bounce_grain]")
 {


### PR DESCRIPTION
On large scans (SF10–SF100 parquet over S3), the REST device-read path splits everyread into windows of `bounce_block_size`, and each window costs one Range GET + one H2D copy + one slot lifecycle (SigV4 signing, curl setup, enqueue/completion/recycle, CUDA event). The grain was hard-wired to the host block size (1 MiB) — the config key
parsed but was silently overwritten — so a ~1 GB scan became **1467 GETs**, and per-request fixed cost dominated. Raising concurrency does not help: fixed cost × request count is unchanged, connections only hide latency (measured flat from 32 to 2048 slots).

## What

**1. `rest.bounce_block_size` is now honored** (whole multiple of the host block size, ≤ 1 GiB per slot). Default stays `0 → host block size` (1 MiB) — behavior and memory byte-identical for every existing config; larger grains are explicit opt-in.

**2. Bounce staging memory: before and after**

**Before**
Each REST reactor allocated one fixed-size host-pool block per curl slot:

```text
staging bytes = reactors × max_connections × host block size
```
With the default 1 MiB host block, every device read was split into 1 MiB windows. Although `rest.bounce_block_size` was parsed, it was overwritten by the host block size. A larger slot could not reuse multiple slab blocks: `allocate_multiple_blocks()` returns independent, potentially non-contiguous blocks, while curl requires each slot to be one contiguous buffer.
**After**
The default path remains unchanged:

```text
grain == host block size
→ one existing FSMR slab block per slot
```
An explicitly larger grain uses a budget-accounted contiguous span:

```text
total = reactors × max_connections × grain
FSMR reserve(total)
upstream.allocate(total)      # one contiguous pinned region
reactor r → fixed slice
slot i    → slice + i × grain
```

The span is allocated once when the REST ioctx starts and reused by all requests; there is no per-GET staging allocation. A slot remains occupied until its asynchronous H2D copy completes, then returns to the slot pool. Retrying requests release their slot during backoff and rebind to an available slot on the next attempt. Memory remains bounded by the selected HOST resource budget, a 1 GiB per-slot limit, and a 2 GiB whole-pool ceiling. The physical span is released before its FSMR reservation during teardown.

The existing default footprint remains 32 MiB:
```text
2 reactors × 16 connections × 1 MiB = 32 MiB
```
Opting into a 4 MiB grain with the same geometry uses 128 MiB:
```text
2 reactors × 16 connections × 4 MiB = 128 MiB
```

## Results

SF10 lineitem, local MinIO, 5 fresh-process samples/point, payload fixed at
1,062,080,163 B. Constant 32 MiB of bounce memory in every row — trading connections
for grain:

| Layout | Grain | GETs | Median | vs baseline |
|---|---:|---:|---:|---:|
| 1r × 32 conn | 1 MiB | 1467 | 0.907 GB/s (CV 3.7%) | — |
| 4r × 2 conn | 4 MiB | 491 | 1.271 GB/s (CV 1.2%) | **+40%** |
| 1r × 4 conn | 8 MiB | 491 | **1.447 GB/s** (CV 0.9%) | **+60%** |


Real EC2-FS3 validation is still pending. Higher per-request latency makes request-count reduction promising, but the magnitude and optimal connection/grain geometry must be measured on EC2.

Not a universal win: small objects or low-parallelism reads may not fill large slots — which is why the default is unchanged and the knob is opt-in.
