### PR TITLE
Use caller reservations in HOST representation conversions

### DIFF
--- a/src/include/data/convertible_data_batch.hpp
+++ b/src/include/data/convertible_data_batch.hpp
@@ -126,15 +126,15 @@ class convertible_data_batch : public convertible_data {
       switch (space->get_tier()) {
         case cucascade::memory::Tier::GPU:
           mut.convert_to<cucascade::gpu_table_representation>(
-            converter_registry, mem_space, stream);
+            converter_registry, *reservation, stream);
           break;
         case cucascade::memory::Tier::HOST:
           mut.convert_to<cucascade::host_data_representation>(
-            converter_registry, mem_space, stream);
+            converter_registry, *reservation, stream);
           break;
         case cucascade::memory::Tier::DISK:
           mut.convert_to<cucascade::disk_data_representation>(
-            converter_registry, mem_space, stream);
+            converter_registry, *reservation, stream);
           break;
         default: continue;
       }

--- a/src/include/pipeline/batch_lock_utils.hpp
+++ b/src/include/pipeline/batch_lock_utils.hpp
@@ -158,6 +158,11 @@ inline std::optional<cucascade::read_only_data_batch> lock_or_prepare_batch(
           mut_accessor.convert_to<cucascade::host_data_representation>(
             registry, *host_reservation, stream);
         } else {
+          SIRIUS_LOG_WARN(
+            "lock_or_prepare_batch: host reservation failed for batch {} ({} bytes) — "
+            "proceeding without reservation, converter may OOM",
+            mut_accessor.get_batch_id(),
+            mut_accessor.get_data()->get_size_in_bytes());
           mut_accessor.convert_to<cucascade::host_data_representation>(
             registry, target_space, stream);
         }

--- a/src/include/pipeline/batch_lock_utils.hpp
+++ b/src/include/pipeline/batch_lock_utils.hpp
@@ -151,8 +151,16 @@ inline std::optional<cucascade::read_only_data_batch> lock_or_prepare_batch(
       // Same non-atomic-upgrade race as the GPU arm: skip if already in the target space.
       if (mut_accessor.get_memory_space() == nullptr ||
           mut_accessor.get_memory_space()->get_id() != target_space->get_id()) {
-        mut_accessor.convert_to<cucascade::host_data_representation>(
-          registry, target_space, stream);
+        auto host_reservation =
+          const_cast<cucascade::memory::memory_space*>(target_space)
+            ->make_reservation_or_null(mut_accessor.get_data()->get_size_in_bytes());
+        if (host_reservation != nullptr) {
+          mut_accessor.convert_to<cucascade::host_data_representation>(
+            registry, *host_reservation, stream);
+        } else {
+          mut_accessor.convert_to<cucascade::host_data_representation>(
+            registry, target_space, stream);
+        }
       }
       return cucascade::data_batch::mutable_to_readonly(std::move(mut_accessor));
     }

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -168,6 +168,13 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
           data->get_size_in_bytes());
 
       // clone_to: creates new batch with data converted to host_data_representation
+      if (host_reservation == nullptr) {
+        SIRIUS_LOG_WARN(
+          "sirius_physical_materialized_collector: host reservation failed for batch {} ({} "
+          "bytes) — proceeding without reservation, converter may OOM",
+          ro.get_batch_id(),
+          data->get_size_in_bytes());
+      }
       auto result_batch =
         host_reservation != nullptr
           ? ro.clone_to<cucascade::host_data_representation>(

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -163,13 +163,25 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
       auto& data_repo_mgr = sirius_ctx->get_data_repository_manager();
       auto next_batch_id  = data_repo_mgr.get_next_data_batch_id();
 
+      auto host_reservation =
+        const_cast<cucascade::memory::memory_space*>(mem_space)->make_reservation_or_null(
+          data->get_size_in_bytes());
+
       // clone_to: creates new batch with data converted to host_data_representation
-      auto result_batch = ro.clone_to<cucascade::host_data_representation>(
-        registry,
-        next_batch_id,
-        mem_space,
-        stream,
-        telemetry::quent_data_batch_probe::create(batch_telemetry(), next_batch_id));
+      auto result_batch =
+        host_reservation != nullptr
+          ? ro.clone_to<cucascade::host_data_representation>(
+              registry,
+              next_batch_id,
+              *host_reservation,
+              stream,
+              telemetry::quent_data_batch_probe::create(batch_telemetry(), next_batch_id))
+          : ro.clone_to<cucascade::host_data_representation>(
+              registry,
+              next_batch_id,
+              mem_space,
+              stream,
+              telemetry::quent_data_batch_probe::create(batch_telemetry(), next_batch_id));
 
       // Access the result batch's data. Declared outside the if-block so result_ro outlives
       // the branch — data points into it and must not dangle when we reach the assert below.

--- a/src/pin_table.cpp
+++ b/src/pin_table.cpp
@@ -308,6 +308,12 @@ materialized_host_pin materialize_pin_to_host(
       cucascade::gpu_table_representation gpu_repr(std::move(tbl), *src_space, stream);
       auto host_reservation =
         target_host_space->make_reservation_or_null(gpu_repr.get_size_in_bytes());
+      if (host_reservation == nullptr) {
+        SIRIUS_LOG_WARN(
+          "materialize_pin_to_host: host reservation failed ({} bytes) — proceeding without "
+          "reservation, converter may OOM",
+          gpu_repr.get_size_in_bytes());
+      }
       auto host_repr = host_reservation != nullptr
                          ? registry.convert<cucascade::host_data_representation>(
                              gpu_repr, *host_reservation, stream)

--- a/src/pin_table.cpp
+++ b/src/pin_table.cpp
@@ -306,8 +306,13 @@ materialized_host_pin materialize_pin_to_host(
       out.base_row_count_per_chunk.push_back(static_cast<std::size_t>(tbl->num_rows()));
       if (!chunk_stats.empty()) { out.chunk_stats.emplace_back(std::move(chunk_stats)); }
       cucascade::gpu_table_representation gpu_repr(std::move(tbl), *src_space, stream);
-      auto host_repr =
-        registry.convert<cucascade::host_data_representation>(gpu_repr, target_host_space, stream);
+      auto host_reservation =
+        target_host_space->make_reservation_or_null(gpu_repr.get_size_in_bytes());
+      auto host_repr = host_reservation != nullptr
+                         ? registry.convert<cucascade::host_data_representation>(
+                             gpu_repr, *host_reservation, stream)
+                         : registry.convert<cucascade::host_data_representation>(
+                             gpu_repr, target_host_space, stream);
       stream.synchronize();
       out.host_chunks.emplace_back(std::move(host_repr));
     });


### PR DESCRIPTION
## Summary
- Adopt cuCascade’s reservation-aware converter API (`convert` / `convert_to` / `clone_to` overloads that take `memory::reservation&`) so HOST allocations draw down a caller-owned reservation instead of committing a second copy of the same capacity.
- Update Sirius call sites that convert/clone into HOST (downgrade, host materialization in `lock_or_prepare_batch`, result collector, pin-table) and Sirius-registered parquet converters to accept and forward the reservation.
- Keep the `memory_space*` overloads as the no-reservation path (GPU/DISK today, probes, and fallback when `make_reservation_or_null` fails).
## Depends on
~cuCascade PR https://github.com/NVIDIA/cuCascade/pull/152. Once that is merged I'll bump up cuCascade in this PR.~
The PR is merged in cuCascade, this PR bumps up cuCascade

Closes https://github.com/sirius-db/sirius/issues/566