### PR TITLE
refactor(log): remove spdlog and fmt types from public headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ AGENTS.override.md
 CLAUDE.local.md
 newplan.md
 telemetry_data/
-log/
+/log/
 .ai-helper/
 
 .planning/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ set(EXTENSION_SOURCES
     src/io/s3/sirius_sigv4_authorizer.cpp
     src/io/uring/uring_ioctx.cpp
     src/io/uring/uring_reactor.cpp
+    src/log/logging.cpp
     src/memory/defragmenter_oom_policy.cpp
     src/memory/sirius_memory_reservation_manager.cpp
     src/op/aggregate/aggregate_op_util.cpp

--- a/src/include/log/logging.hpp
+++ b/src/include/log/logging.hpp
@@ -64,14 +64,15 @@ namespace sirius {
 enum class log_level { trace, debug, info, warn, error, critical, off };
 
 /// Initializes the global logger with a daily file sink at `<log_dir>/sirius.log`.
-void InitGlobalLogger(std::string_view log_level_str, std::string_view log_dir,
-                      int flush_seconds);
+void InitGlobalLogger(std::string_view log_level_str, std::string_view log_dir, int flush_seconds);
 
 /// Flushes buffered log lines of the global logger to its sink.
 void FlushGlobalLogger();
 
+/// Sets the periodic flush interval of the global logger.
 void SetGlobalLogFlush(int flush_seconds);
 
+/// Sets the level of the global logger from a level name.
 void SetGlobalLogLevel(std::string_view log_level_str);
 
 /// Logs `message` attributed to a caller-supplied source location.

--- a/src/include/log/logging.hpp
+++ b/src/include/log/logging.hpp
@@ -36,7 +36,6 @@
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 #endif
 
-#include <spdlog/sinks/daily_file_sink.h>
 #include <spdlog/spdlog.h>
 
 // Warn only if the level was actually raised above TRACE, which compiles out
@@ -45,8 +44,6 @@
 #if SPDLOG_ACTIVE_LEVEL > SPDLOG_LEVEL_TRACE
 #warning "SPDLOG_ACTIVE_LEVEL is above TRACE; lower-level log output is compiled out"
 #endif
-
-#include <string>
 
 #define SIRIUS_LOG_TRACE(...) SPDLOG_LOGGER_TRACE(spdlog::default_logger_raw(), __VA_ARGS__)
 #define SIRIUS_LOG_DEBUG(...) SPDLOG_LOGGER_DEBUG(spdlog::default_logger_raw(), __VA_ARGS__)
@@ -58,53 +55,30 @@
 #endif  // __CUDACC__
 #ifndef __CUDACC__
 
-namespace duckdb {
+#include <source_location>
+#include <string_view>
 
-inline spdlog::level::level_enum ParseLogLevel(const std::string& level_str)
-{
-  if (level_str == "trace") return spdlog::level::trace;
-  if (level_str == "debug") return spdlog::level::debug;
-  if (level_str == "info") return spdlog::level::info;
-  if (level_str == "warn") return spdlog::level::warn;
-  if (level_str == "error") return spdlog::level::err;
-  if (level_str == "critical") return spdlog::level::critical;
-  if (level_str == "off") return spdlog::level::off;
-  return spdlog::level::info;
-}
+namespace sirius {
 
-inline void InitGlobalLogger(const std::string& log_level_str,
-                             const std::string& log_dir,
-                             int flush_seconds)
-{
-  auto log_file  = log_dir + "/sirius.log";
-  auto file_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>(log_file, 0, 0, false);
-  file_sink->set_pattern("[%Y-%m-%d %T.%e] [%l] [%s:%#] %v");
+/// Log severity levels of the Sirius logging facade.
+enum class log_level { trace, debug, info, warn, error, critical, off };
 
-  auto log_level = ParseLogLevel(log_level_str);
-  auto logger    = std::make_shared<spdlog::logger>("", spdlog::sinks_init_list{file_sink});
-  logger->set_level(log_level);
-  spdlog::set_default_logger(logger);
-  spdlog::set_level(log_level);
-  spdlog::flush_every(std::chrono::seconds(flush_seconds));
-}
+/// Initializes the global logger with a daily file sink at `<log_dir>/sirius.log`.
+void InitGlobalLogger(std::string_view log_level_str, std::string_view log_dir,
+                      int flush_seconds);
 
-inline void FlushGlobalLogger()
-{
-  if (auto* logger = spdlog::default_logger_raw()) { logger->flush(); }
-}
+/// Flushes buffered log lines of the global logger to its sink.
+void FlushGlobalLogger();
 
-inline void SetGlobalLogFlush(int flush_seconds)
-{
-  spdlog::flush_every(std::chrono::seconds(flush_seconds));
-}
+void SetGlobalLogFlush(int flush_seconds);
 
-inline void SetGlobalLogLevel(const std::string& log_level_str)
-{
-  auto log_level = ParseLogLevel(log_level_str);
-  spdlog::set_level(log_level);
-  if (auto logger = spdlog::default_logger()) { logger->set_level(log_level); }
-}
+void SetGlobalLogLevel(std::string_view log_level_str);
 
-}  // namespace duckdb
+/// Logs `message` attributed to a caller-supplied source location.
+///
+/// For log statements at the current location, use the SIRIUS_LOG_* macros.
+void LogAt(log_level level, const std::source_location& loc, std::string_view message);
+
+}  // namespace sirius
 
 #endif  // !__CUDACC__

--- a/src/include/telemetry/data_batch_probe.hpp
+++ b/src/include/telemetry/data_batch_probe.hpp
@@ -24,7 +24,6 @@
 #include "telemetry/telemetry_context.hpp"
 
 #include <cucascade/data/data_batch.hpp>
-#include <spdlog/fmt/fmt.h>
 
 #include <functional>
 #include <memory>
@@ -93,8 +92,8 @@ class quent_data_batch_probe : public cucascade::idata_batch_probe {
       auto maybe_memory_handle =
         memory_context_->get_memory_handle(data.get_memory_space().get_id());
       if (not maybe_memory_handle) {
-        SIRIUS_LOG_WARN(
-          fmt::format("No quent memory handle found for {}", data.get_memory_space().to_string()));
+        SIRIUS_LOG_WARN("No quent memory handle found for {}",
+                        data.get_memory_space().to_string());
         return;
       }
 
@@ -116,26 +115,24 @@ class quent_data_batch_probe : public cucascade::idata_batch_probe {
       auto maybe_source_memory_handle =
         memory_context_->get_memory_handle(current_data.get_memory_space().get_id());
       if (not maybe_source_memory_handle) {
-        SIRIUS_LOG_WARN(fmt::format("No quent memory handle found for {}",
-                                    current_data.get_memory_space().to_string()));
+        SIRIUS_LOG_WARN("No quent memory handle found for {}",
+                        current_data.get_memory_space().to_string());
         return;
       }
 
       auto maybe_dest_memory_handle =
         memory_context_->get_memory_handle(target_memory_space->get_id());
       if (not maybe_dest_memory_handle) {
-        SIRIUS_LOG_WARN(
-          fmt::format("No quent memory handle found for {}", target_memory_space->to_string()));
+        SIRIUS_LOG_WARN("No quent memory handle found for {}", target_memory_space->to_string());
         return;
       }
 
       auto maybe_channel_handle = memory_context_->get_channel_handle(
         current_data.get_memory_space().get_id(), target_memory_space->get_id());
       if (not maybe_channel_handle) {
-        SIRIUS_LOG_WARN(
-          fmt::format("No quent channel handle found for the channel between {} and {}",
-                      current_data.get_memory_space().to_string(),
-                      target_memory_space->to_string()));
+        SIRIUS_LOG_WARN("No quent channel handle found for the channel between {} and {}",
+                        current_data.get_memory_space().to_string(),
+                        target_memory_space->to_string());
         return;
       }
 
@@ -158,8 +155,8 @@ class quent_data_batch_probe : public cucascade::idata_batch_probe {
       auto maybe_memory_handle =
         memory_context_->get_memory_handle(data.get_memory_space().get_id());
       if (not maybe_memory_handle) {
-        SIRIUS_LOG_WARN(
-          fmt::format("No quent memory handle found for {}", data.get_memory_space().to_string()));
+        SIRIUS_LOG_WARN("No quent memory handle found for {}",
+                        data.get_memory_space().to_string());
         return;
       }
 
@@ -178,8 +175,8 @@ class quent_data_batch_probe : public cucascade::idata_batch_probe {
       auto maybe_memory_handle =
         memory_context_->get_memory_handle(new_data.get_memory_space().get_id());
       if (not maybe_memory_handle) {
-        SIRIUS_LOG_WARN(fmt::format("No quent memory handle found for {}",
-                                    new_data.get_memory_space().to_string()));
+        SIRIUS_LOG_WARN("No quent memory handle found for {}",
+                        new_data.get_memory_space().to_string());
         return;
       }
       handle_->stationary({

--- a/src/include/telemetry/data_batch_probe.hpp
+++ b/src/include/telemetry/data_batch_probe.hpp
@@ -92,8 +92,7 @@ class quent_data_batch_probe : public cucascade::idata_batch_probe {
       auto maybe_memory_handle =
         memory_context_->get_memory_handle(data.get_memory_space().get_id());
       if (not maybe_memory_handle) {
-        SIRIUS_LOG_WARN("No quent memory handle found for {}",
-                        data.get_memory_space().to_string());
+        SIRIUS_LOG_WARN("No quent memory handle found for {}", data.get_memory_space().to_string());
         return;
       }
 
@@ -155,8 +154,7 @@ class quent_data_batch_probe : public cucascade::idata_batch_probe {
       auto maybe_memory_handle =
         memory_context_->get_memory_handle(data.get_memory_space().get_id());
       if (not maybe_memory_handle) {
-        SIRIUS_LOG_WARN("No quent memory handle found for {}",
-                        data.get_memory_space().to_string());
+        SIRIUS_LOG_WARN("No quent memory handle found for {}", data.get_memory_space().to_string());
         return;
       }
 

--- a/src/include/telemetry/memory_context.hpp
+++ b/src/include/telemetry/memory_context.hpp
@@ -21,8 +21,6 @@
 #include "telemetry-bridge/gen/channel.rs.h"
 #include "telemetry-bridge/gen/memory.rs.h"
 
-#include <spdlog/fmt/fmt.h>
-
 #include <functional>
 #include <unordered_map>
 

--- a/src/include/util/error_utils.hpp
+++ b/src/include/util/error_utils.hpp
@@ -27,8 +27,7 @@ inline void log_exception_helper(const std::source_location& loc)
   try {
     throw;
   } catch (const std::exception& e) {
-    sirius::LogAt(
-      sirius::log_level::error, loc, std::format("Exception caught: {}", e.what()));
+    sirius::LogAt(sirius::log_level::error, loc, std::format("Exception caught: {}", e.what()));
   } catch (...) {
     sirius::LogAt(sirius::log_level::error, loc, "UNKNOWN exception caught");
   }

--- a/src/include/util/error_utils.hpp
+++ b/src/include/util/error_utils.hpp
@@ -17,36 +17,34 @@
 #include <log/logging.hpp>
 
 #include <exception>
+#include <format>
 #include <source_location>
 #include <string>
 #include <string_view>
 
 inline void log_exception_helper(const std::source_location& loc)
 {
-  spdlog::source_loc spd_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()};
   try {
     throw;
   } catch (const std::exception& e) {
-    spdlog::log(spd_loc, spdlog::level::err, "Exception caught: {}", e.what());
+    sirius::LogAt(
+      sirius::log_level::error, loc, std::format("Exception caught: {}", e.what()));
   } catch (...) {
-    spdlog::log(spd_loc, spdlog::level::err, "UNKNOWN exception caught");
+    sirius::LogAt(sirius::log_level::error, loc, "UNKNOWN exception caught");
   }
 }
 
 template <typename... Args>
 void log_exception_helper(const std::source_location& loc, std::string_view fmt_str, Args&&... args)
 {
-  spdlog::source_loc spd_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()};
-
-  // Formats your string cleanly using v1.8.5 syntax
-  std::string user_msg = fmt::vformat(fmt_str, fmt::make_format_args(args...));
+  std::string user_msg = std::vformat(fmt_str, std::make_format_args(args...));
 
   try {
     throw;
   } catch (const std::exception& e) {
-    spdlog::log(spd_loc, spdlog::level::err, "{}: {}", user_msg, e.what());
+    sirius::LogAt(sirius::log_level::error, loc, std::format("{}: {}", user_msg, e.what()));
   } catch (...) {
-    spdlog::log(spd_loc, spdlog::level::err, "{}: UNKNOWN exception", user_msg);
+    sirius::LogAt(sirius::log_level::error, loc, std::format("{}: UNKNOWN exception", user_msg));
   }
 }
 

--- a/src/log/logging.cpp
+++ b/src/log/logging.cpp
@@ -55,8 +55,7 @@ log_level ParseLogLevel(std::string_view level_str)
 
 }  // namespace
 
-void InitGlobalLogger(std::string_view log_level_str, std::string_view log_dir,
-                      int flush_seconds)
+void InitGlobalLogger(std::string_view log_level_str, std::string_view log_dir, int flush_seconds)
 {
   auto log_file  = std::format("{}/sirius.log", log_dir);
   auto file_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>(log_file, 0, 0, false);

--- a/src/log/logging.cpp
+++ b/src/log/logging.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "log/logging.hpp"
+
+#include <spdlog/sinks/daily_file_sink.h>
+
+#include <chrono>
+#include <format>
+#include <memory>
+
+namespace sirius {
+
+namespace {
+
+spdlog::level::level_enum to_spdlog_level(log_level level)
+{
+  switch (level) {
+    case log_level::trace: return spdlog::level::trace;
+    case log_level::debug: return spdlog::level::debug;
+    case log_level::info: return spdlog::level::info;
+    case log_level::warn: return spdlog::level::warn;
+    case log_level::error: return spdlog::level::err;
+    case log_level::critical: return spdlog::level::critical;
+    case log_level::off: return spdlog::level::off;
+  }
+  return spdlog::level::info;
+}
+
+// Parses a level name ("trace" .. "critical", "off"), defaulting to `info`.
+log_level ParseLogLevel(std::string_view level_str)
+{
+  if (level_str == "trace") return log_level::trace;
+  if (level_str == "debug") return log_level::debug;
+  if (level_str == "info") return log_level::info;
+  if (level_str == "warn") return log_level::warn;
+  if (level_str == "error") return log_level::error;
+  if (level_str == "critical") return log_level::critical;
+  if (level_str == "off") return log_level::off;
+  return log_level::info;
+}
+
+}  // namespace
+
+void InitGlobalLogger(std::string_view log_level_str, std::string_view log_dir,
+                      int flush_seconds)
+{
+  auto log_file  = std::format("{}/sirius.log", log_dir);
+  auto file_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>(log_file, 0, 0, false);
+  file_sink->set_pattern("[%Y-%m-%d %T.%e] [%l] [%s:%#] %v");
+
+  auto log_level = to_spdlog_level(ParseLogLevel(log_level_str));
+  auto logger    = std::make_shared<spdlog::logger>("", spdlog::sinks_init_list{file_sink});
+  logger->set_level(log_level);
+  spdlog::set_default_logger(logger);
+  spdlog::set_level(log_level);
+  spdlog::flush_every(std::chrono::seconds(flush_seconds));
+}
+
+void FlushGlobalLogger()
+{
+  if (auto* logger = spdlog::default_logger_raw()) { logger->flush(); }
+}
+
+void SetGlobalLogFlush(int flush_seconds)
+{
+  spdlog::flush_every(std::chrono::seconds(flush_seconds));
+}
+
+void SetGlobalLogLevel(std::string_view log_level_str)
+{
+  auto log_level = to_spdlog_level(ParseLogLevel(log_level_str));
+  spdlog::set_level(log_level);
+  if (auto logger = spdlog::default_logger()) { logger->set_level(log_level); }
+}
+
+void LogAt(log_level level, const std::source_location& loc, std::string_view message)
+{
+  spdlog::source_loc spd_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()};
+  spdlog::default_logger_raw()->log(spd_loc, to_spdlog_level(level), "{}", message);
+}
+
+}  // namespace sirius

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -998,7 +998,7 @@ SiriusContextExtensionCallback::SiriusContextExtensionCallback()
 {
   if (auto* env = std::getenv("SIRIUS_LOG_DIR")) { Config::LOG_DIR = env; }
   if (auto* env = std::getenv("SIRIUS_LOG_LEVEL")) { Config::LOG_LEVEL = env; }
-  InitGlobalLogger(Config::LOG_LEVEL, Config::LOG_DIR, Config::LOG_FLUSH_SECONDS);
+  sirius::InitGlobalLogger(Config::LOG_LEVEL, Config::LOG_DIR, Config::LOG_FLUSH_SECONDS);
   read_config_file_if_exists();
 }
 

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1609,21 +1609,21 @@ static void SetSortSampleBytes(ClientContext& context, SetScope scope, Value& pa
 static void SetLogLevel(ClientContext& context, SetScope scope, Value& parameter)
 {
   Config::LOG_LEVEL = StringValue::Get(parameter);
-  SetGlobalLogLevel(Config::LOG_LEVEL);
+  sirius::SetGlobalLogLevel(Config::LOG_LEVEL);
   SIRIUS_LOG_DEBUG("Updated config LOG_LEVEL to {}", Config::LOG_LEVEL);
 }
 
 static void SetLogDir(ClientContext& context, SetScope scope, Value& parameter)
 {
   Config::LOG_DIR = StringValue::Get(parameter);
-  InitGlobalLogger(Config::LOG_LEVEL, Config::LOG_DIR, Config::LOG_FLUSH_SECONDS);
+  sirius::InitGlobalLogger(Config::LOG_LEVEL, Config::LOG_DIR, Config::LOG_FLUSH_SECONDS);
   SIRIUS_LOG_DEBUG("Updated config LOG_DIR to {}", Config::LOG_DIR);
 }
 
 static void SetLogFlushSeconds(ClientContext& context, SetScope scope, Value& parameter)
 {
   Config::LOG_FLUSH_SECONDS = IntegerValue::Get(parameter);
-  SetGlobalLogFlush(Config::LOG_FLUSH_SECONDS);
+  sirius::SetGlobalLogFlush(Config::LOG_FLUSH_SECONDS);
   SIRIUS_LOG_DEBUG("Updated config LOG_FLUSH_SECONDS to {}", Config::LOG_FLUSH_SECONDS);
 }
 

--- a/src/telemetry/memory_context.cpp
+++ b/src/telemetry/memory_context.cpp
@@ -17,6 +17,7 @@
 #include "telemetry/memory_context.hpp"
 
 #include <cstdint>
+#include <format>
 #include <optional>
 
 namespace {
@@ -63,7 +64,7 @@ memory_context::memory_context(uuid::UUID engine_uuid,
         channel_key{.source = space_id_1, .destination = space_id_2},
         quent::channel::create(context,
                                {
-                                 .instance_name   = fmt::format("{}-{}->{}-{}",
+                                 .instance_name   = std::format("{}-{}->{}-{}",
                                                               tier_to_string(space_id_1.tier),
                                                               space_id_1.device_id,
                                                               tier_to_string(space_id_2.tier),

--- a/src/util/segfault_backtrace_handler.cpp
+++ b/src/util/segfault_backtrace_handler.cpp
@@ -89,7 +89,7 @@ static void flush_logs_best_effort()
   signal(SIGALRM, SIG_DFL);  // ensure default (terminate) disposition
   alarm(3);                  // hard deadline for the log + flush below
   SIRIUS_LOG_WARN("SIRIUS signal handler triggered, flushing logs");
-  duckdb::FlushGlobalLogger();
+  sirius::FlushGlobalLogger();
   alarm(0);  // flush returned in time; cancel the deadline
 }
 

--- a/test/cpp/unittest.cpp
+++ b/test/cpp/unittest.cpp
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
   // Initialize the logger
   std::string log_dir = SIRIUS_UNITTEST_LOG_DIR;
   Config::LOG_DIR     = log_dir;
-  InitGlobalLogger(Config::LOG_LEVEL, Config::LOG_DIR, Config::LOG_FLUSH_SECONDS);
+  sirius::InitGlobalLogger(Config::LOG_LEVEL, Config::LOG_DIR, Config::LOG_FLUSH_SECONDS);
 
   // Create shared test environments. Both start PAUSED and are only activated
   // by the listener for tests with the matching tag. This avoids GPU memory


### PR DESCRIPTION
Make log/logging.hpp the only header that names spdlog, and remove all header-level use of spdlog's bundled fmt. Part of #1145.

- Add a sirius-owned sirius::log_level enum, replacing spdlog::level::level_enum in the public API.
- Move the global-logger helpers out of the header into a new src/log/logging.cpp; the header keeps declarations only. ParseLogLevel had no external callers and became internal.
- Add LogAt(log_level, source_location, message) and rewrite error_utils.hpp over it with std::format instead of spdlog::log/fmt::vformat.
- Drop <spdlog/fmt/fmt.h> from the telemetry headers; telemetry/memory_context.cpp and the redundant fmt::format-inside-macro calls in data_batch_probe.hpp now use std::format / plain macro arguments.
- Helpers move from namespace duckdb to sirius and take string_view.
- Anchor the .gitignore log/ pattern to the repo root; it was unintentionally ignoring the new src/log/.

The SIRIUS_LOG_* macros still expand to spdlog macros; replacing that seam with the runtime-selectable facade is a next step in #1145.

🤖 Generated with Claude Code (https://claude.com/claude-code)