### PR TITLE
refactor(log): make the logging API spdlog-free

### DIFF
--- a/src/debug_utils.cpp
+++ b/src/debug_utils.cpp
@@ -23,10 +23,10 @@
 #include <cuda_runtime.h>
 
 #include <cucascade/data/data_batch.hpp>
-#include <spdlog/fmt/fmt.h>
 
 #include <algorithm>
 #include <cstdlib>
+#include <format>
 #include <random>
 #include <type_traits>
 
@@ -131,43 +131,43 @@ std::string scalar_to_string(cudf::scalar const& s,
   switch (dt.id()) {
     case cudf::type_id::INT8: {
       auto val = static_cast<cudf::numeric_scalar<int8_t> const&>(s).value(stream);
-      return fmt::format("{}", static_cast<int>(val));
+      return std::format("{}", static_cast<int>(val));
     }
     case cudf::type_id::INT16: {
       auto val = static_cast<cudf::numeric_scalar<int16_t> const&>(s).value(stream);
-      return fmt::format("{}", val);
+      return std::format("{}", val);
     }
     case cudf::type_id::INT32: {
       auto val = static_cast<cudf::numeric_scalar<int32_t> const&>(s).value(stream);
-      return fmt::format("{}", val);
+      return std::format("{}", val);
     }
     case cudf::type_id::INT64: {
       auto val = static_cast<cudf::numeric_scalar<int64_t> const&>(s).value(stream);
-      return fmt::format("{}", val);
+      return std::format("{}", val);
     }
     case cudf::type_id::UINT8: {
       auto val = static_cast<cudf::numeric_scalar<uint8_t> const&>(s).value(stream);
-      return fmt::format("{}", val);
+      return std::format("{}", val);
     }
     case cudf::type_id::UINT16: {
       auto val = static_cast<cudf::numeric_scalar<uint16_t> const&>(s).value(stream);
-      return fmt::format("{}", val);
+      return std::format("{}", val);
     }
     case cudf::type_id::UINT32: {
       auto val = static_cast<cudf::numeric_scalar<uint32_t> const&>(s).value(stream);
-      return fmt::format("{}", val);
+      return std::format("{}", val);
     }
     case cudf::type_id::UINT64: {
       auto val = static_cast<cudf::numeric_scalar<uint64_t> const&>(s).value(stream);
-      return fmt::format("{}", val);
+      return std::format("{}", val);
     }
     case cudf::type_id::FLOAT32: {
       auto val = static_cast<cudf::numeric_scalar<float> const&>(s).value(stream);
-      return fmt::format("{:g}", val);
+      return std::format("{:g}", val);
     }
     case cudf::type_id::FLOAT64: {
       auto val = static_cast<cudf::numeric_scalar<double> const&>(s).value(stream);
-      return fmt::format("{:g}", val);
+      return std::format("{:g}", val);
     }
     default: return "?";
   }
@@ -182,12 +182,12 @@ std::string scalar_to_string(cudf::scalar const& s,
 template <typename T>
 std::string format_decimal_value(T raw, int abs_scale)
 {
-  if (abs_scale == 0) { return fmt::format("{}", raw); }
+  if (abs_scale == 0) { return std::format("{}", raw); }
   bool negative = raw < 0;
   // Cast to unsigned BEFORE negation to avoid UB on MIN values
   using U            = std::make_unsigned_t<T>;
   U magnitude        = negative ? static_cast<U>(0) - static_cast<U>(raw) : static_cast<U>(raw);
-  std::string digits = fmt::format("{}", magnitude);
+  std::string digits = std::format("{}", magnitude);
   // Pad with leading zeros if digit count <= abs_scale (e.g. 5 with scale=2 -> "0.05")
   while (digits.size() <= static_cast<std::size_t>(abs_scale)) {
     digits.insert(digits.begin(), '0');
@@ -269,7 +269,7 @@ std::string format_timestamp_s(int64_t raw_s)
   int hh             = seconds_in_day / 3600;
   int mm             = (seconds_in_day % 3600) / 60;
   int ss             = seconds_in_day % 60;
-  return fmt::format("{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}", y, m, d, hh, mm, ss);
+  return std::format("{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}", y, m, d, hh, mm, ss);
 }
 
 // Format TIMESTAMP_MILLISECONDS (int64_t milliseconds since epoch)
@@ -287,9 +287,9 @@ std::string format_timestamp_ms(int64_t raw_ms)
   int ss             = seconds_in_day % 60;
 
   std::string result =
-    fmt::format("{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}", y, m, d, hh, mm_t, ss);
+    std::format("{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}", y, m, d, hh, mm_t, ss);
   if (frac_ms != 0) {
-    std::string frac = fmt::format(".{:03d}", frac_ms);
+    std::string frac = std::format(".{:03d}", frac_ms);
     // Trim trailing zeros from fractional part
     while (frac.back() == '0') {
       frac.pop_back();
@@ -314,9 +314,9 @@ std::string format_timestamp_us(int64_t raw_us)
   int ss             = seconds_in_day % 60;
 
   std::string result =
-    fmt::format("{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}", y, m, d, hh, mm, ss);
+    std::format("{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}", y, m, d, hh, mm, ss);
   if (frac_us != 0) {
-    std::string frac = fmt::format(".{:06d}", frac_us);
+    std::string frac = std::format(".{:06d}", frac_us);
     // Trim trailing zeros from fractional part
     while (frac.back() == '0') {
       frac.pop_back();
@@ -342,9 +342,9 @@ std::string format_timestamp_ns(int64_t raw_ns)
   int ss             = seconds_in_day % 60;
 
   std::string result =
-    fmt::format("{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}", y, m, d, hh, mm, ss);
+    std::format("{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}", y, m, d, hh, mm, ss);
   if (frac_ns != 0) {
-    std::string frac = fmt::format(".{:09d}", frac_ns);
+    std::string frac = std::format(".{:09d}", frac_ns);
     // Trim trailing zeros from fractional part
     while (frac.back() == '0') {
       frac.pop_back();
@@ -358,7 +358,7 @@ std::string format_timestamp_ns(int64_t raw_ns)
 std::string format_date_days(int32_t raw_days)
 {
   auto [y, m, d] = civil_from_days(raw_days);
-  return fmt::format("{:04d}-{:02d}-{:02d}", y, m, d);
+  return std::format("{:04d}-{:02d}-{:02d}", y, m, d);
 }
 
 // ---------------------------------------------------------------------------
@@ -398,11 +398,11 @@ void format_rows_to_output(std::string& output,
           cells[c][r] = "NULL";
         } else {
           if constexpr (std::is_floating_point_v<T>) {
-            cells[c][r] = fmt::format("{:g}", host_vals[r]);
+            cells[c][r] = std::format("{:g}", host_vals[r]);
           } else if constexpr (std::is_same_v<T, int8_t>) {
-            cells[c][r] = fmt::format("{}", static_cast<int>(host_vals[r]));
+            cells[c][r] = std::format("{}", static_cast<int>(host_vals[r]));
           } else {
-            cells[c][r] = fmt::format("{}", host_vals[r]);
+            cells[c][r] = std::format("{}", host_vals[r]);
           }
         }
       }
@@ -661,7 +661,7 @@ void format_rows_to_output(std::string& output,
     // Header row
     output += "[SIRIUS_DIAG]   ";
     for (cudf::size_type c = 0; c < num_cols; ++c) {
-      output += fmt::format("{:<{}s}", names[c], widths[c]);
+      output += std::format("{:<{}s}", names[c], widths[c]);
     }
     output += "\n";
 
@@ -676,7 +676,7 @@ void format_rows_to_output(std::string& output,
     for (cudf::size_type r = 0; r < num_rows; ++r) {
       output += "[SIRIUS_DIAG]   ";
       for (cudf::size_type c = 0; c < num_cols; ++c) {
-        output += fmt::format("{:<{}s}", cells[c][r], widths[c]);
+        output += std::format("{:<{}s}", cells[c][r], widths[c]);
       }
       output += "\n";
     }
@@ -700,28 +700,28 @@ void debug_schema(cucascade::data_batch& batch,
     stream.synchronize();
 
     std::string output;
-    output += fmt::format("[SIRIUS_DIAG] schema: batch_id={} rows={} cols={}\n",
+    output += std::format("[SIRIUS_DIAG] schema: batch_id={} rows={} cols={}\n",
                           batch.get_batch_id(),
                           tv.num_rows(),
                           tv.num_columns());
-    output += fmt::format("[SIRIUS_DIAG]   {:<6s} {:<20s} {:<15s} {:>8s} {:>8s}\n",
+    output += std::format("[SIRIUS_DIAG]   {:<6s} {:<20s} {:<15s} {:>8s} {:>8s}\n",
                           "idx",
                           "name",
                           "type",
                           "nulls",
                           "null%");
-    output += fmt::format(
+    output += std::format(
       "[SIRIUS_DIAG]   {:-<6s} {:-<20s} {:-<15s} {:->8s} {:->8s}\n", "", "", "", "", "");
 
     for (cudf::size_type c = 0; c < tv.num_columns(); ++c) {
       auto const& col  = tv.column(c);
       std::string name = (static_cast<std::size_t>(c) < col_names.size())
                            ? col_names[static_cast<std::size_t>(c)]
-                           : fmt::format("col[{}]", c);
+                           : std::format("col[{}]", c);
       auto nc          = col.null_count();
       if (nc < 0) { nc = 0; }
       double pct = (col.size() > 0) ? 100.0 * nc / col.size() : 0.0;
-      output += fmt::format("[SIRIUS_DIAG]   {:<6d} {:<20s} {:<15s} {:>8d} {:>7.1f}%\n",
+      output += std::format("[SIRIUS_DIAG]   {:<6d} {:<20s} {:<15s} {:>8d} {:>7.1f}%\n",
                             static_cast<int>(c),
                             name,
                             cudf::type_to_name(col.type()),
@@ -753,23 +753,23 @@ void debug_nulls(cucascade::data_batch& batch,
     stream.synchronize();
 
     std::string output;
-    output += fmt::format("[SIRIUS_DIAG] nulls: batch_id={} rows={} cols={}\n",
+    output += std::format("[SIRIUS_DIAG] nulls: batch_id={} rows={} cols={}\n",
                           batch.get_batch_id(),
                           tv.num_rows(),
                           tv.num_columns());
-    output += fmt::format(
+    output += std::format(
       "[SIRIUS_DIAG]   {:<6s} {:<20s} {:>8s} {:>8s}\n", "idx", "name", "nulls", "null%");
-    output += fmt::format("[SIRIUS_DIAG]   {:-<6s} {:-<20s} {:->8s} {:->8s}\n", "", "", "", "");
+    output += std::format("[SIRIUS_DIAG]   {:-<6s} {:-<20s} {:->8s} {:->8s}\n", "", "", "", "");
 
     for (cudf::size_type c = 0; c < tv.num_columns(); ++c) {
       auto const& col  = tv.column(c);
       std::string name = (static_cast<std::size_t>(c) < col_names.size())
                            ? col_names[static_cast<std::size_t>(c)]
-                           : fmt::format("col[{}]", c);
+                           : std::format("col[{}]", c);
       auto nc          = col.null_count();
       if (nc < 0) { nc = 0; }
       double pct = (col.size() > 0) ? 100.0 * nc / col.size() : 0.0;
-      output += fmt::format("[SIRIUS_DIAG]   {:<6d} {:<20s} {:>8d} {:>7.1f}%\n",
+      output += std::format("[SIRIUS_DIAG]   {:<6d} {:<20s} {:>8d} {:>7.1f}%\n",
                             static_cast<int>(c),
                             name,
                             static_cast<int>(nc),
@@ -806,7 +806,7 @@ void debug_head(cucascade::data_batch& batch,
     // Empty batch handling
     if (tv.num_rows() == 0) {
       std::string output;
-      output += fmt::format(
+      output += std::format(
         "[SIRIUS_DIAG] head: batch_id={} rows=0 cols={}\n", batch.get_batch_id(), num_cols);
       output += "[SIRIUS_DIAG]   (empty batch)\n";
       SIRIUS_LOG_DEBUG("{}", output);
@@ -828,12 +828,12 @@ void debug_head(cucascade::data_batch& batch,
     for (cudf::size_type c = 0; c < num_cols; ++c) {
       names[c] = (static_cast<std::size_t>(c) < col_names.size())
                    ? col_names[static_cast<std::size_t>(c)]
-                   : fmt::format("col[{}]", c);
+                   : std::format("col[{}]", c);
     }
 
     // Build output via shared formatting helper
     std::string output;
-    output += fmt::format("[SIRIUS_DIAG] head: batch_id={} rows={} cols={} showing={}\n",
+    output += std::format("[SIRIUS_DIAG] head: batch_id={} rows={} cols={} showing={}\n",
                           batch.get_batch_id(),
                           tv.num_rows(),
                           num_cols,
@@ -865,7 +865,7 @@ void debug_stats(cucascade::data_batch& batch,
     auto num_cols = tv.num_columns();
 
     std::string output;
-    output += fmt::format("[SIRIUS_DIAG] stats: batch_id={} rows={} cols={}\n",
+    output += std::format("[SIRIUS_DIAG] stats: batch_id={} rows={} cols={}\n",
                           batch.get_batch_id(),
                           tv.num_rows(),
                           num_cols);
@@ -878,14 +878,14 @@ void debug_stats(cucascade::data_batch& batch,
     }
 
     // Summary table format consistent with debug_schema
-    output += fmt::format("[SIRIUS_DIAG]   {:<6s} {:<20s} {:<15s} {:>15s} {:>15s} {:>15s}\n",
+    output += std::format("[SIRIUS_DIAG]   {:<6s} {:<20s} {:<15s} {:>15s} {:>15s} {:>15s}\n",
                           "idx",
                           "name",
                           "type",
                           "min",
                           "max",
                           "sum");
-    output += fmt::format("[SIRIUS_DIAG]   {:-<6s} {:-<20s} {:-<15s} {:->15s} {:->15s} {:->15s}\n",
+    output += std::format("[SIRIUS_DIAG]   {:-<6s} {:-<20s} {:-<15s} {:->15s} {:->15s} {:->15s}\n",
                           "",
                           "",
                           "",
@@ -897,12 +897,12 @@ void debug_stats(cucascade::data_batch& batch,
       auto const& col  = tv.column(c);
       std::string name = (static_cast<std::size_t>(c) < col_names.size())
                            ? col_names[static_cast<std::size_t>(c)]
-                           : fmt::format("col[{}]", c);
+                           : std::format("col[{}]", c);
       auto type_name   = cudf::type_to_name(col.type());
 
       if (!is_stats_numeric(col.type().id())) {
         // Non-numeric columns skipped
-        output += fmt::format("[SIRIUS_DIAG]   {:<6d} {:<20s} {:<15s} {:>15s} {:>15s} {:>15s}\n",
+        output += std::format("[SIRIUS_DIAG]   {:<6d} {:<20s} {:<15s} {:>15s} {:>15s} {:>15s}\n",
                               static_cast<int>(c),
                               name,
                               type_name,
@@ -925,7 +925,7 @@ void debug_stats(cucascade::data_batch& batch,
       std::string max_str = scalar_to_string(*max_scalar, col.type(), stream);
       std::string sum_str = scalar_to_string(*sum_scalar, sum_type, stream);
 
-      output += fmt::format("[SIRIUS_DIAG]   {:<6d} {:<20s} {:<15s} {:>15s} {:>15s} {:>15s}\n",
+      output += std::format("[SIRIUS_DIAG]   {:<6d} {:<20s} {:<15s} {:>15s} {:>15s} {:>15s}\n",
                             static_cast<int>(c),
                             name,
                             type_name,
@@ -960,7 +960,7 @@ void debug_checksum(cucascade::data_batch& batch,
     auto num_cols = tv.num_columns();
 
     std::string output;
-    output += fmt::format("[SIRIUS_DIAG] checksum: batch_id={} rows={} cols={}\n",
+    output += std::format("[SIRIUS_DIAG] checksum: batch_id={} rows={} cols={}\n",
                           batch.get_batch_id(),
                           tv.num_rows(),
                           num_cols);
@@ -976,14 +976,14 @@ void debug_checksum(cucascade::data_batch& batch,
       auto const& col  = tv.column(c);
       std::string name = (static_cast<std::size_t>(c) < col_names.size())
                            ? col_names[static_cast<std::size_t>(c)]
-                           : fmt::format("col[{}]", c);
+                           : std::format("col[{}]", c);
 
       auto nc = col.null_count();
       if (nc < 0) { nc = 0; }
 
       // Empty or all-NULL column
       if (col.size() == 0 || nc == col.size()) {
-        output += fmt::format("[SIRIUS_DIAG]   {} checksum: 0x{:016X} nulls={}\n",
+        output += std::format("[SIRIUS_DIAG]   {} checksum: 0x{:016X} nulls={}\n",
                               name,
                               uint64_t{0},
                               static_cast<int>(nc));
@@ -1004,7 +1004,7 @@ void debug_checksum(cucascade::data_batch& batch,
       uint64_t checksum = scalar.is_valid(stream) ? scalar.value(stream) : 0;
 
       // D-11: Output format with null count
-      output += fmt::format(
+      output += std::format(
         "[SIRIUS_DIAG]   {} checksum: 0x{:016X} nulls={}\n", name, checksum, static_cast<int>(nc));
     }
 
@@ -1037,7 +1037,7 @@ void debug_diff(cucascade::data_batch& batch_a,
     stream.synchronize();
 
     std::string output;
-    output += fmt::format(
+    output += std::format(
       "[SIRIUS_DIAG] diff: batch_a_id={} batch_b_id={} cols_a={} cols_b={} rows_a={} rows_b={}\n",
       batch_a.get_batch_id(),
       batch_b.get_batch_id(),
@@ -1049,7 +1049,7 @@ void debug_diff(cucascade::data_batch& batch_a,
     // Schema mismatch check — column count
     if (tv_a.num_columns() != tv_b.num_columns()) {
       output +=
-        fmt::format("[SIRIUS_DIAG]   schema mismatch: batch_a has {} cols, batch_b has {} cols\n",
+        std::format("[SIRIUS_DIAG]   schema mismatch: batch_a has {} cols, batch_b has {} cols\n",
                     tv_a.num_columns(),
                     tv_b.num_columns());
       SIRIUS_LOG_DEBUG("{}", output);
@@ -1064,8 +1064,8 @@ void debug_diff(cucascade::data_batch& batch_a,
       if (tv_a.column(c).type() != tv_b.column(c).type()) {
         std::string name = (static_cast<std::size_t>(c) < col_names.size())
                              ? col_names[static_cast<std::size_t>(c)]
-                             : fmt::format("col[{}]", c);
-        output += fmt::format("[SIRIUS_DIAG]   schema mismatch: {} type {} vs {}\n",
+                             : std::format("col[{}]", c);
+        output += std::format("[SIRIUS_DIAG]   schema mismatch: {} type {} vs {}\n",
                               name,
                               cudf::type_to_name(tv_a.column(c).type()),
                               cudf::type_to_name(tv_b.column(c).type()));
@@ -1079,7 +1079,7 @@ void debug_diff(cucascade::data_batch& batch_a,
 
     // Row count mismatch
     if (tv_a.num_rows() != tv_b.num_rows()) {
-      output += fmt::format(
+      output += std::format(
         "[SIRIUS_DIAG]   row count mismatch: batch_a has {} rows, batch_b has {} rows\n",
         tv_a.num_rows(),
         tv_b.num_rows());
@@ -1092,7 +1092,7 @@ void debug_diff(cucascade::data_batch& batch_a,
     // Row limit guard to prevent OOM
     if (num_rows > max_rows) {
       output +=
-        fmt::format("[SIRIUS_DIAG]   row count {} exceeds limit {}, skipping value comparison\n",
+        std::format("[SIRIUS_DIAG]   row count {} exceeds limit {}, skipping value comparison\n",
                     num_rows,
                     max_rows);
       SIRIUS_LOG_DEBUG("{}", output);
@@ -1109,7 +1109,7 @@ void debug_diff(cucascade::data_batch& batch_a,
 
       std::string name = (static_cast<std::size_t>(c) < col_names.size())
                            ? col_names[static_cast<std::size_t>(c)]
-                           : fmt::format("col[{}]", c);
+                           : std::format("col[{}]", c);
 
       cudf::size_type diff_count = 0;
       std::vector<cudf::size_type> diff_indices;
@@ -1243,7 +1243,7 @@ void debug_diff(cucascade::data_batch& batch_a,
 
         default:
           // Unsupported type — skip comparison for this column
-          output += fmt::format("[SIRIUS_DIAG]   {} (unsupported type, skipped)\n", name);
+          output += std::format("[SIRIUS_DIAG]   {} (unsupported type, skipped)\n", name);
           continue;
       }
 
@@ -1253,9 +1253,9 @@ void debug_diff(cucascade::data_batch& batch_a,
         std::string idx_list;
         for (std::size_t i = 0; i < diff_indices.size(); ++i) {
           if (i > 0) { idx_list += ", "; }
-          idx_list += fmt::format("{}", diff_indices[i]);
+          idx_list += std::format("{}", diff_indices[i]);
         }
-        output += fmt::format(
+        output += std::format(
           "[SIRIUS_DIAG]   {} diffs: {}/{} rows [idx: {}]\n", name, diff_count, num_rows, idx_list);
       }
     }
@@ -1293,7 +1293,7 @@ void debug_sample(cucascade::data_batch& batch,
     // Empty batch handling
     if (tv.num_rows() == 0) {
       std::string output;
-      output += fmt::format(
+      output += std::format(
         "[SIRIUS_DIAG] sample: batch_id={} rows=0 cols={}\n", batch.get_batch_id(), num_cols);
       output += "[SIRIUS_DIAG]   (empty batch)\n";
       SIRIUS_LOG_DEBUG("{}", output);
@@ -1309,11 +1309,11 @@ void debug_sample(cucascade::data_batch& batch,
     for (cudf::size_type c = 0; c < num_cols; ++c) {
       names[c] = (static_cast<std::size_t>(c) < col_names.size())
                    ? col_names[static_cast<std::size_t>(c)]
-                   : fmt::format("col[{}]", c);
+                   : std::format("col[{}]", c);
     }
 
     std::string output;
-    output += fmt::format("[SIRIUS_DIAG] sample: batch_id={} rows={} cols={} sampled={}\n",
+    output += std::format("[SIRIUS_DIAG] sample: batch_id={} rows={} cols={} sampled={}\n",
                           batch.get_batch_id(),
                           tv.num_rows(),
                           num_cols,

--- a/src/include/log/logging.hpp
+++ b/src/include/log/logging.hpp
@@ -16,52 +16,41 @@
 
 #pragma once
 
-#ifdef __CUDACC__
-// nvcc cannot compile spdlog/fmt chrono headers — provide no-op macros
-#define SIRIUS_LOG_TRACE(...)
-#define SIRIUS_LOG_DEBUG(...)
-#define SIRIUS_LOG_INFO(...)
-#define SIRIUS_LOG_WARN(...)
-#define SIRIUS_LOG_ERROR(...)
-#define SIRIUS_LOG_FATAL(...)
-#else  // !__CUDACC__
+// Numeric log levels for the compile-time threshold below. Must mirror the
+// order of sirius::log_level (static_asserted after the enum definition).
+#define SIRIUS_LOG_LEVEL_TRACE    0
+#define SIRIUS_LOG_LEVEL_DEBUG    1
+#define SIRIUS_LOG_LEVEL_INFO     2
+#define SIRIUS_LOG_LEVEL_WARN     3
+#define SIRIUS_LOG_LEVEL_ERROR    4
+#define SIRIUS_LOG_LEVEL_CRITICAL 5
+#define SIRIUS_LOG_LEVEL_OFF      6
 
-// Compile in every log level by default. This must be set before spdlog is
-// first included in a translation unit, so this header is the single entry
-// point for spdlog: include <log/logging.hpp> rather than <spdlog/...> so the
-// level is set here first. If spdlog is pulled in earlier, it defaults the
-// level to INFO and silently drops TRACE/DEBUG statements — the post-include
-// check below catches that case.
-#ifndef SPDLOG_ACTIVE_LEVEL
-#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
+// SIRIUS_LOG_* statements below this level expand to ((void)0): the format
+// string and arguments are compiled out entirely. Defaults to TRACE so every
+// level is compiled in; override with -DSIRIUS_ACTIVE_LOG_LEVEL=<level>.
+#ifndef SIRIUS_ACTIVE_LOG_LEVEL
+#define SIRIUS_ACTIVE_LOG_LEVEL SIRIUS_LOG_LEVEL_TRACE
 #endif
 
-#include <spdlog/spdlog.h>
-
-// Warn only if the level was actually raised above TRACE, which compiles out
-// lower-level log statements (e.g. because spdlog was included before this
-// header). SPDLOG_LEVEL_* is defined by the headers above.
-#if SPDLOG_ACTIVE_LEVEL > SPDLOG_LEVEL_TRACE
-#warning "SPDLOG_ACTIVE_LEVEL is above TRACE; lower-level log output is compiled out"
-#endif
-
-#define SIRIUS_LOG_TRACE(...) SPDLOG_LOGGER_TRACE(spdlog::default_logger_raw(), __VA_ARGS__)
-#define SIRIUS_LOG_DEBUG(...) SPDLOG_LOGGER_DEBUG(spdlog::default_logger_raw(), __VA_ARGS__)
-#define SIRIUS_LOG_INFO(...)  SPDLOG_LOGGER_INFO(spdlog::default_logger_raw(), __VA_ARGS__)
-#define SIRIUS_LOG_WARN(...)  SPDLOG_LOGGER_WARN(spdlog::default_logger_raw(), __VA_ARGS__)
-#define SIRIUS_LOG_ERROR(...) SPDLOG_LOGGER_ERROR(spdlog::default_logger_raw(), __VA_ARGS__)
-#define SIRIUS_LOG_FATAL(...) SPDLOG_LOGGER_CRITICAL(spdlog::default_logger_raw(), __VA_ARGS__)
-
-#endif  // __CUDACC__
-#ifndef __CUDACC__
-
+#include <format>
 #include <source_location>
 #include <string_view>
+#include <utility>
 
 namespace sirius {
 
 /// Log severity levels of the Sirius logging facade.
 enum class log_level { trace, debug, info, warn, error, critical, off };
+
+static_assert(static_cast<int>(log_level::trace) == SIRIUS_LOG_LEVEL_TRACE &&
+                static_cast<int>(log_level::debug) == SIRIUS_LOG_LEVEL_DEBUG &&
+                static_cast<int>(log_level::info) == SIRIUS_LOG_LEVEL_INFO &&
+                static_cast<int>(log_level::warn) == SIRIUS_LOG_LEVEL_WARN &&
+                static_cast<int>(log_level::error) == SIRIUS_LOG_LEVEL_ERROR &&
+                static_cast<int>(log_level::critical) == SIRIUS_LOG_LEVEL_CRITICAL &&
+                static_cast<int>(log_level::off) == SIRIUS_LOG_LEVEL_OFF,
+              "log_level enum and SIRIUS_LOG_LEVEL_* macros must stay in sync");
 
 /// Initializes the global logger with a daily file sink at `<log_dir>/sirius.log`.
 void InitGlobalLogger(std::string_view log_level_str, std::string_view log_dir, int flush_seconds);
@@ -75,11 +64,65 @@ void SetGlobalLogFlush(int flush_seconds);
 /// Sets the level of the global logger from a level name.
 void SetGlobalLogLevel(std::string_view log_level_str);
 
+/// Returns whether the global logger currently emits `level`.
+bool ShouldLog(log_level level);
+
 /// Logs `message` attributed to a caller-supplied source location.
 ///
 /// For log statements at the current location, use the SIRIUS_LOG_* macros.
 void LogAt(log_level level, const std::source_location& loc, std::string_view message);
 
+namespace detail {
+
+/// Formats and logs a message; arguments are only formatted when `level` is
+/// enabled at runtime. Use through the SIRIUS_LOG_* macros.
+template <typename... Args>
+void LogFormatted(log_level level,
+                  const std::source_location& loc,
+                  std::format_string<Args...> fmt,
+                  Args&&... args)
+{
+  if (ShouldLog(level)) { LogAt(level, loc, std::format(fmt, std::forward<Args>(args)...)); }
+}
+
+}  // namespace detail
 }  // namespace sirius
 
-#endif  // !__CUDACC__
+#define SIRIUS_LOG_IMPL(level, ...) \
+  ::sirius::detail::LogFormatted(level, std::source_location::current(), __VA_ARGS__)
+
+#if SIRIUS_ACTIVE_LOG_LEVEL <= SIRIUS_LOG_LEVEL_TRACE
+#define SIRIUS_LOG_TRACE(...) SIRIUS_LOG_IMPL(::sirius::log_level::trace, __VA_ARGS__)
+#else
+#define SIRIUS_LOG_TRACE(...) ((void)0)
+#endif
+
+#if SIRIUS_ACTIVE_LOG_LEVEL <= SIRIUS_LOG_LEVEL_DEBUG
+#define SIRIUS_LOG_DEBUG(...) SIRIUS_LOG_IMPL(::sirius::log_level::debug, __VA_ARGS__)
+#else
+#define SIRIUS_LOG_DEBUG(...) ((void)0)
+#endif
+
+#if SIRIUS_ACTIVE_LOG_LEVEL <= SIRIUS_LOG_LEVEL_INFO
+#define SIRIUS_LOG_INFO(...) SIRIUS_LOG_IMPL(::sirius::log_level::info, __VA_ARGS__)
+#else
+#define SIRIUS_LOG_INFO(...) ((void)0)
+#endif
+
+#if SIRIUS_ACTIVE_LOG_LEVEL <= SIRIUS_LOG_LEVEL_WARN
+#define SIRIUS_LOG_WARN(...) SIRIUS_LOG_IMPL(::sirius::log_level::warn, __VA_ARGS__)
+#else
+#define SIRIUS_LOG_WARN(...) ((void)0)
+#endif
+
+#if SIRIUS_ACTIVE_LOG_LEVEL <= SIRIUS_LOG_LEVEL_ERROR
+#define SIRIUS_LOG_ERROR(...) SIRIUS_LOG_IMPL(::sirius::log_level::error, __VA_ARGS__)
+#else
+#define SIRIUS_LOG_ERROR(...) ((void)0)
+#endif
+
+#if SIRIUS_ACTIVE_LOG_LEVEL <= SIRIUS_LOG_LEVEL_CRITICAL
+#define SIRIUS_LOG_FATAL(...) SIRIUS_LOG_IMPL(::sirius::log_level::critical, __VA_ARGS__)
+#else
+#define SIRIUS_LOG_FATAL(...) ((void)0)
+#endif

--- a/src/io/cache/prefetching_cache.cpp
+++ b/src/io/cache/prefetching_cache.cpp
@@ -31,14 +31,13 @@
 
 #include <cuda_runtime.h>
 
-#include <spdlog/fmt/fmt.h>
-
 #include <algorithm>
 #include <array>
 #include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <exception>
+#include <format>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -637,7 +636,7 @@ std::string prefetching_cache::summary() const
   uint64_t const miss  = _counters.misses.load(std::memory_order_relaxed);
   uint64_t const evict = _counters.evictions.load(std::memory_order_relaxed);
 
-  return fmt::format(
+  return std::format(
     "prefetching_cache: "
     "global[reads={} hits={} h2d={} miss={} evictions={}] "
     "last_cycle[reads={} hits={} h2d={} miss={} evictions={}]",

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -18,10 +18,9 @@
 
 #include "io/uri_parser.hpp"
 
-#include <fmt/format.h>
-
 #include <algorithm>
 #include <cstddef>
+#include <format>
 #include <memory>
 #include <stdexcept>
 #include <utility>
@@ -30,7 +29,7 @@ namespace sirius::io::rest {
 
 rest_ioctx::rest_ioctx(std::size_t n_reactors, std::shared_ptr<rest_reactor::reactor_context> ctx)
   : templated_ioctx<rest_reactor>(n_reactors, [ctx = std::move(ctx), i = 0]() mutable {
-      return std::make_unique<rest_reactor>(ctx, fmt::format("rest-{}", i++));
+      return std::make_unique<rest_reactor>(ctx, std::format("rest-{}", i++));
     })
 {
 }

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -24,7 +24,6 @@
 
 #include <rmm/cuda_device.hpp>
 
-#include <spdlog/fmt/fmt.h>
 #include <sys/epoll.h>
 #include <unistd.h>
 
@@ -36,6 +35,7 @@
 #include <cstdint>
 #include <cstring>
 #include <deque>
+#include <format>
 #include <optional>
 #include <random>
 #include <stdexcept>
@@ -261,12 +261,12 @@ curl_slist_ptr build_header_list(std::vector<std::pair<std::string, std::string>
 /// "Range: bytes=<lo>-<hi>" (inclusive end) for [offset, offset+size).
 std::string range_header(size_t offset, size_t size)
 {
-  return fmt::format("Range: bytes={}-{}", offset, offset + size - 1);
+  return std::format("Range: bytes={}-{}", offset, offset + size - 1);
 }
 
 /// "Range: bytes=-<n>" — the last @p n bytes of an object (a suffix range).
 /// Unlike range_header this needs no prior knowledge of the object's size.
-std::string suffix_range_header(size_t n) { return fmt::format("Range: bytes=-{}", n); }
+std::string suffix_range_header(size_t n) { return std::format("Range: bytes=-{}", n); }
 
 /// Parse the first-byte position out of a Content-Range value of the form
 /// "bytes <first>-<last>/<total>" (the trimmed value captured by the header

--- a/src/io/uring/uring_ioctx.cpp
+++ b/src/io/uring/uring_ioctx.cpp
@@ -18,13 +18,14 @@
 
 #include "io/uring/uring_reactor.hpp"
 
+#include <format>
 #include <memory>
 
 namespace sirius::io::uring {
 
 uring_ioctx::uring_ioctx(size_t n_reactors, std::shared_ptr<uring_reactor::reactor_context> ctx)
   : templated_ioctx<uring_reactor>(n_reactors, [ctx = std::move(ctx), i = 0]() mutable {
-      return std::make_unique<uring_reactor>(ctx, fmt::format("reactor-{}", i++));
+      return std::make_unique<uring_reactor>(ctx, std::format("reactor-{}", i++));
     })
 {
 }

--- a/src/log/logging.cpp
+++ b/src/log/logging.cpp
@@ -17,6 +17,7 @@
 #include "log/logging.hpp"
 
 #include <spdlog/sinks/daily_file_sink.h>
+#include <spdlog/spdlog.h>
 
 #include <chrono>
 #include <format>
@@ -28,14 +29,15 @@ namespace {
 
 spdlog::level::level_enum to_spdlog_level(log_level level)
 {
+  using enum log_level;
   switch (level) {
-    case log_level::trace: return spdlog::level::trace;
-    case log_level::debug: return spdlog::level::debug;
-    case log_level::info: return spdlog::level::info;
-    case log_level::warn: return spdlog::level::warn;
-    case log_level::error: return spdlog::level::err;
-    case log_level::critical: return spdlog::level::critical;
-    case log_level::off: return spdlog::level::off;
+    case trace: return spdlog::level::trace;
+    case debug: return spdlog::level::debug;
+    case info: return spdlog::level::info;
+    case warn: return spdlog::level::warn;
+    case error: return spdlog::level::err;
+    case critical: return spdlog::level::critical;
+    case off: return spdlog::level::off;
   }
   return spdlog::level::info;
 }
@@ -43,14 +45,15 @@ spdlog::level::level_enum to_spdlog_level(log_level level)
 // Parses a level name ("trace" .. "critical", "off"), defaulting to `info`.
 log_level ParseLogLevel(std::string_view level_str)
 {
-  if (level_str == "trace") return log_level::trace;
-  if (level_str == "debug") return log_level::debug;
-  if (level_str == "info") return log_level::info;
-  if (level_str == "warn") return log_level::warn;
-  if (level_str == "error") return log_level::error;
-  if (level_str == "critical") return log_level::critical;
-  if (level_str == "off") return log_level::off;
-  return log_level::info;
+  using enum log_level;
+  if (level_str == "trace") return trace;
+  if (level_str == "debug") return debug;
+  if (level_str == "info") return info;
+  if (level_str == "warn") return warn;
+  if (level_str == "error") return error;
+  if (level_str == "critical") return critical;
+  if (level_str == "off") return off;
+  return info;
 }
 
 }  // namespace
@@ -84,6 +87,12 @@ void SetGlobalLogLevel(std::string_view log_level_str)
   auto log_level = to_spdlog_level(ParseLogLevel(log_level_str));
   spdlog::set_level(log_level);
   if (auto logger = spdlog::default_logger()) { logger->set_level(log_level); }
+}
+
+bool ShouldLog(log_level level)
+{
+  auto* logger = spdlog::default_logger_raw();
+  return logger != nullptr && logger->should_log(to_spdlog_level(level));
 }
 
 void LogAt(log_level level, const std::source_location& loc, std::string_view message)

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -205,7 +205,8 @@ duckdb_native_gpu_ingestible::duckdb_native_gpu_ingestible(
                                      bind.table_filters.get(),
                                      &bind.column_ids);
   if (!_plan.viable) {
-    SPDLOG_DEBUG("[duckdb_native_gpu_ingestible] non-viable: {}", _plan.viability_failure_reason);
+    SIRIUS_LOG_DEBUG("[duckdb_native_gpu_ingestible] non-viable: {}",
+                     _plan.viability_failure_reason);
     throw std::runtime_error("duckdb-native scan rejected query: " +
                              _plan.viability_failure_reason);
   }

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -59,6 +59,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
+#include <format>
 #include <limits>
 #include <optional>
 #include <stdexcept>
@@ -585,19 +586,19 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
     } else {
       SIRIUS_LOG_WARN(
         "In sirius_physical_hash_join:get_next_task_input_data_for_build_probe: expected to pop a "
-        "batch from the default port but got none in operator " +
-        std::to_string(this->get_operator_id()));
+        "batch from the default port but got none in operator {}",
+        this->get_operator_id());
     }
     // Subsequent probe-only tasks share the hash table built under the initial
     // SCHEDULING task. They MUST run on the same GPU — tag with operator_id.
     return std::make_unique<partitioned_operator_data>(std::move(input_batch),
                                                        this->get_operator_id());
   } else {
-    SIRIUS_LOG_WARN(fmt::format(
+    SIRIUS_LOG_WARN(
       "In sirius_physical_hash_join:get_next_task_input_data_for_build_probe: invalid hash table "
       "build state {} in operator {}",
       static_cast<int>(_hash_table_build_state),
-      this->get_operator_id()));
+      this->get_operator_id());
     return nullptr;
   }
 }
@@ -1110,7 +1111,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       }
 
     } else {
-      throw std::runtime_error(fmt::format(
+      throw std::runtime_error(std::format(
         "In sirius_physical_hash_join::execute: invalid hash table build state {} in BUILD_PROBE "
         "mode for operator id {}",
         static_cast<int>(_hash_table_build_state),

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -36,6 +36,7 @@
 #include <atomic>
 #include <cstdint>
 #include <exception>
+#include <format>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -72,7 +73,7 @@ absl::AnyInvocable<void() noexcept> gpu_pipeline_executor::get_per_thread_init()
     const int32_t thread_id = thread_id_counter->fetch_add(1, std::memory_order_relaxed);
     telemetry::thread_local_executor_thread_telemtry_init(
       *telemetry_context,
-      fmt::format("{}-gpu{}-exec-{}", thread_prefix, device_id, thread_id),
+      std::format("{}-gpu{}-exec-{}", thread_prefix, device_id, thread_id),
       telemetry_context->executor_thread_group_id(device_id));
 
     // Per-thread init runs on a worker thread just spawned by the
@@ -95,7 +96,7 @@ void gpu_pipeline_executor::manager_loop()
 {
   telemetry::TaskManagerLoopThreadHandleWrapper manager_thread_telemetry{
     *_telemetry_context,
-    fmt::format("gpu-{}-exec-manager", _memory_space->get_device_id()),
+    std::format("gpu-{}-exec-manager", _memory_space->get_device_id()),
     _telemetry_context->manager_thread_group_id(_memory_space->get_device_id())};
 
   rmm::cuda_set_device_raii set_device_guard(rmm::cuda_device_id{_memory_space->get_device_id()});

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -168,7 +168,7 @@ std::unique_ptr<op::operator_data> run_one_operator(
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
 
   auto peak_bytes        = allocator ? allocator->get_peak_allocated_bytes(stream) : 0;
-  std::string extra_info = fmt::format(
+  std::string extra_info = std::format(
     "execution time: {:.2f} ms, "
     "peak allocated: {} bytes ({:.2f} MB)",
     duration.count() / 1000.0,
@@ -264,7 +264,7 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
     auto& op = operators[i].get();
     try {
       this->telemetry_handle().computing({
-        .instance_name       = fmt::format("{}({})", op.get_name(), op.get_operator_id()),
+        .instance_name       = std::format("{}({})", op.get_name(), op.get_operator_id()),
         .current_operator_id = static_cast<uint32_t>(
           op.get_operator_id()),  // TODO(dhruv9vats): look into possible overflow
         .input_bytes                 = operator_input_output_data->get_estimated_size_in_bytes(),

--- a/src/pipeline/sirius_pipeline_itask.cpp
+++ b/src/pipeline/sirius_pipeline_itask.cpp
@@ -19,8 +19,7 @@
 #include "telemetry-bridge/gen/uuid.rs.h"
 #include "telemetry/telemetry_context.hpp"
 
-#include <spdlog/fmt/fmt.h>
-
+#include <format>
 #include <memory>
 #include <utility>
 
@@ -34,7 +33,7 @@ sirius_pipeline_itask::sirius_pipeline_itask(
     _telemetry_task_handle(
       quent::task::create(global_state->get_telemetry_context().context(),
                           {
-                            .instance_name = fmt::format("task-{}", task_id),
+                            .instance_name = std::format("task-{}", task_id),
                             .pipeline_uuid = global_state->get_pipeline()
                                                ? global_state->get_pipeline()->pipeline_uuid()
                                                : uuid::new_nil(),

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -96,7 +96,7 @@ extern "C" int cudaProfilerStop();
 // Ordering rule: include uring_reactor LAST among sirius headers — liburing.h
 // transitively pulled by uring_reactor.hpp defines a BLOCK_SIZE preprocessor
 // macro that collides with the BLOCK_SIZE static member in
-// <blockingconcurrentqueue.h> (used by spdlog / pipeline / duckdb
+// <blockingconcurrentqueue.h> (used by pipeline / duckdb
 // connection_manager). All consumers of blockingconcurrentqueue.h must
 // precede this include.
 #include "io/s3/sirius_httpfs.hpp"     // sirius::io::s3::sirius_httpfs

--- a/src/telemetry/telemetry_context.cpp
+++ b/src/telemetry/telemetry_context.cpp
@@ -27,6 +27,7 @@
 
 #include <unistd.h>
 
+#include <format>
 #include <memory>
 #include <ranges>
 #include <string>
@@ -68,7 +69,7 @@ telemetry_context::telemetry_context(const sirius::telemetry_config& config,
   worker_observer_->init(worker_uuid_,
                          quent::worker::Init{
                            .parent_engine_id = engine_uuid_,
-                           .instance_name    = fmt::format("worker-{}", getpid()),
+                           .instance_name    = std::format("worker-{}", getpid()),
                          });
 
   memory_context_ = std::make_shared<memory_context>(engine_uuid_, *context_, manager);
@@ -78,7 +79,7 @@ telemetry_context::telemetry_context(const sirius::telemetry_config& config,
   query_group_observer_->declaration(
     query_group_uuid_,
     quent::query_group::Declaration{
-      .instance_name = fmt::format("{}-session-{}", config.engine_name, getpid()),
+      .instance_name = std::format("{}-session-{}", config.engine_name, getpid()),
       .engine_id     = engine_uuid_,
     });
 
@@ -102,7 +103,7 @@ telemetry_context::telemetry_context(const sirius::telemetry_config& config,
     };
     gpu_device_observer->declaration(ids.device,
                                      quent::gpu_device::Declaration{
-                                       .instance_name   = fmt::format("gpu-{}", device_id),
+                                       .instance_name   = std::format("gpu-{}", device_id),
                                        .parent_group_id = engine_uuid_,
                                        .ordinal         = static_cast<uint32_t>(device_id),
                                      });
@@ -180,14 +181,14 @@ void emit_plan_telemetry(
     const std::string operator_chain = [&operators]() {
       std::string chain{};
       for (const auto& name : operators | std::views::transform([](const auto& op) {
-                                return fmt::format(
+                                return std::format(
                                   "{}({})", op.get().get_name(), op.get().operator_id);
                               })) {
         if (chain.empty()) {
           chain = name;
           continue;
         }
-        chain = fmt::format("{} -> {}", chain, name);
+        chain = std::format("{} -> {}", chain, name);
       }
       return chain;
     }();
@@ -198,7 +199,7 @@ void emit_plan_telemetry(
         .plan_id             = plan_id,
         .parent_operator_ids = {},
         .instance_name       = operator_chain,
-        .type_name           = fmt::format("Pipeline Id {}", pipeline->get_pipeline_id()),
+        .type_name           = std::format("Pipeline Id {}", pipeline->get_pipeline_id()),
         .custom_attributes   = {},
       });
 
@@ -209,7 +210,7 @@ void emit_plan_telemetry(
           port_obs->declaration(port->source_port_uuid,
                                 quent::port::Declaration{
                                   .operator_id   = pipeline_uuid,
-                                  .instance_name = fmt::format("{}_receiver", port_id),
+                                  .instance_name = std::format("{}_receiver", port_id),
                                 });
         }
       }
@@ -222,7 +223,7 @@ void emit_plan_telemetry(
       port_obs->declaration(pseudo_sink_port_uuid,
                             quent::port::Declaration{
                               .operator_id   = pipeline_uuid,
-                              .instance_name = fmt::format("{}_sender", next_operator_port_name),
+                              .instance_name = std::format("{}_sender", next_operator_port_name),
                             });
 
       // Find the target port on the downstream operator


### PR DESCRIPTION
Rewrite the SIRIUS_LOG_* macros over std::format and the compiled logging facade, so log/logging.hpp no longer includes any spdlog or fmt header. spdlog is now an implementation detail of src/log/logging.cpp (it remains a link dependency there; CMake is unchanged). This replaces the last spdlog seam in the public API left open by #1164. Part of #1145.

- The macros format with std::format and dispatch to LogAt(); a new ShouldLog() gates formatting, so arguments are only formatted when the level is enabled at runtime (matching spdlog's should_log() behavior).
- A sirius-owned SIRIUS_ACTIVE_LOG_LEVEL (default TRACE, everything compiled in) replaces SPDLOG_ACTIVE_LEVEL: statements below the threshold expand to ((void)0), compiling out their format strings and arguments entirely.
- The __CUDACC__ no-op path is gone: it existed because nvcc couldn't compile spdlog/fmt's chrono headers, but nvcc 13 compiles <format>/<source_location> fine. .cu files now share the real macros — activating the SIRIUS_LOG_WARN/DEBUG statements in the dynamic-filter kernels that were silently compiled out until now.
- std::format_string checks format strings at compile time; two hash-join call sites that pre-formatted their message pass format arguments directly instead, and one raw SPDLOG_DEBUG becomes SIRIUS_LOG_DEBUG.
- Ten files that used fmt::format via the transitive <spdlog/fmt/fmt.h> include switch to std::format, and the direct fmt includes are dropped.

Verified: full C++ unit suite passes; log lines keep the same layout and source locations (now via std::source_location); a probe TU built with -DSIRIUS_ACTIVE_LOG_LEVEL=SIRIUS_LOG_LEVEL_ERROR confirms sub-error statements leave no trace in the binary.

🤖 Generated with Claude Code (https://claude.com/claude-code)