### PR TITLE
feat(op): streaming sink operator (#837)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,7 @@ set(EXTENSION_SOURCES
     src/op/sirius_dynamic_filter.cpp
     src/op/sirius_physical_column_data_scan.cpp
     src/op/sirius_physical_streaming_source.cpp
+    src/op/sirius_physical_streaming_sink.cpp
     src/op/sirius_physical_concat.cpp
     src/op/sirius_physical_cte.cpp
     src/op/sirius_physical_delim_join.cpp
@@ -641,6 +642,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_physical_projection.cpp
     test/cpp/operator/test_physical_result_collector.cpp
     test/cpp/operator/test_physical_streaming_source.cpp
+    test/cpp/operator/test_physical_streaming_sink.cpp
     test/cpp/operator/test_physical_table_scan.cpp
     test/cpp/operator/test_no_history_peak_memory_estimate.cpp
     test/cpp/operator/test_physical_top_n.cpp

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -96,6 +96,47 @@ session, task creation must be gated on in-flight work (e.g. counting via the ch
 hook and the task-completion path) so a fast producer cannot accumulate an arbitrarily large GPU
 backlog behind a nominally bounded channel.
 
+### `sirius_physical_streaming_sink` — `STREAMING_SINK`
+**File:** `src/include/op/sirius_physical_streaming_sink.hpp`
+
+Sink operator that marks the top boundary of an intermediate pipeline fragment. It registers each
+incoming `cucascade::data_batch` in a `cucascade::shared_data_repository` (making it spill-visible
+to the downgrade executor) and then pushes an `exec::exchange_batch_handle` (batch-id + size) to a
+bounded `exec::exchange_channel`. Used only when a fragment's output must be forwarded to another
+node over exchange; a leaf fragment keeps its normal `RESULT_COLLECTOR` sink.
+
+Key design invariants:
+- **Zero-copy emission**: the batch is registered in the output repository first, then only a
+  lightweight handle (batch-id + size) is pushed to the channel — no host clone, no
+  `ColumnDataCollection` materialization.
+- **CONCAT shape**: `is_source() && is_sink()` are both `true`. The operator heads its own
+  single-operator pipeline fed via an `"input"` port; the upstream pipeline pushes batches into
+  that port's repository via the base-class `sink()` → `push_data_batch()` path.
+- **Backpressure as admission control**: if the channel is full or `_pending` is non-empty,
+  `get_next_task_hint()` and `get_next_task_input_data()` return `WAITING{nullptr}` / `nullptr`
+  respectively, preventing new tasks from being created. Worker threads never block.
+- **FIFO `_pending` queue**: when `try_push` fails (channel full), the handle is appended to
+  `_pending`. Subsequent calls to `get_next_task_hint()` or `sink()` call `try_flush_pending()`
+  first, draining `_pending` in order before any new handles are attempted.
+- **Flush-then-close EOS**: `on_finalize_operator()` flushes what fits; if `_pending` is empty
+  it closes the channel immediately; otherwise it sets `_close_when_flushed` and defers the
+  close to the `try_flush_pending()` call triggered by the next consumer pop.
+- **Locking discipline**: whenever `_pending_lock` and the channel's internal mutex are both
+  needed, `_pending_lock` is always acquired first (consistent ordering prevents deadlock);
+  the base-class `lock` guards `ports` and is never held simultaneously with `_pending_lock`.
+- `no_history_peak_memory_estimate()` returns `stats.bytes` (no extra allocation).
+
+Hint table:
+
+| State | `get_next_task_hint()` |
+|---|---|
+| `_pending` non-empty or channel full | `WAITING{nullptr}` — stalled on consumer |
+| input port repo non-empty, channel has room | `READY{this}` |
+| port empty, upstream pipeline finished | `std::nullopt` — EOS |
+| port empty, upstream still running | `WAITING{upstream_op}` — propagate hint up the chain |
+
+**Consumer contract**: pop a handle from the channel, then call `output_repository->pop_data_batch_by_id(handle.batch_id)` to take ownership of the batch. The `try_flush_pending()` flush is triggered by `get_next_task_hint()` (called by the task-creation loop on every iteration), so consumer pops indirectly drive the pending drain.
+
 ### `sirius_physical_dummy_scan` — `DUMMY_SCAN`
 **File:** `src/include/op/sirius_physical_dummy_scan.hpp`
 
@@ -345,6 +386,7 @@ After pipeline finalization, `source` and `sink` are just aliases for the first 
 |----------|----------|-----------|
 | GPU_SCAN | Scan | Unified GPU scan source served by `sirius_scan_manager` via a per-format `gpu_ingestible` |
 | STREAMING_SOURCE | Scan | Exchange-input source; pulls batch handles from `exchange_channel`, resolves via `shared_data_repository` |
+| STREAMING_SINK | Pipeline | Exchange-output sink (CONCAT shape); registers batches in `shared_data_repository`, pushes handles to `exchange_channel` with backpressure |
 | DUMMY_SCAN | Scan | Generates 1 row |
 | COLUMN_DATA_SCAN | Scan | Reads ColumnDataCollection |
 | FILTER | Relational | `expression_evaluator::select()` |

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -115,18 +115,20 @@ Key design invariants:
 - **Backpressure as admission control**: if the channel is full or `_pending` is non-empty,
   `get_next_task_hint()` and `get_next_task_input_data()` return `WAITING{nullptr}` / `nullptr`
   respectively, preventing new tasks from being created. Worker threads never block.
-- **FIFO `_pending` overflow buffer (bounded)**: when `try_push` fails (channel full), the handle
-  is appended to `_pending`. Subsequent calls to `get_next_task_hint()` or `sink()` call
+- **FIFO `_pending` overflow buffer**: when `try_push` fails (channel full), the handle is
+  appended to `_pending`. Subsequent calls to `get_next_task_hint()` or `sink()` call
   `try_flush_pending()` first, draining `_pending` in order before any new handles are attempted.
-  `_pending` is not a second unbounded queue: because admission control refuses new sink tasks
-  while `_pending` is non-empty, its depth is bounded by the operator's in-flight task concurrency,
-  never by the input size.
+  Admission control stops new pulls while `_pending` is non-empty or the channel is full, but the
+  task creator can pull an entire port before any created task executes, so `_pending` depth is
+  bounded only once task creation is paced against completion — the session wiring's job (#839),
+  the same caveat as the streaming source above. Parked batches remain registered, idle, and
+  spill-visible (accounted, spillable state).
 - **Flush-then-close EOS**: `on_finalize_operator()` flushes what fits; if `_pending` is empty
-  it closes the channel immediately; otherwise it sets `_close_when_flushed` and defers the
-  close to the `try_flush_pending()` call triggered by the next consumer pop. Finalize sets a
-  `_closing` flag under `_pending_lock`; a `sink()` that observes it (a batch arriving after
-  finalize — which the pipeline never does) throws rather than stranding the handle behind the
-  closed channel.
+  it closes the channel immediately; otherwise it sets `_close_when_flushed` and the close
+  happens on a later `try_flush_pending()` call. Nothing polls that after finalize — the
+  consumer/session must call `try_flush_pending()` after pops (or wire `on_pop` to it, #839) or
+  deferred EOS stalls. Finalize also sets `_closing` under `_pending_lock`; a `sink()` that
+  observes it throws rather than stranding the handle behind the closed channel.
 - **Locking discipline**: whenever `_pending_lock` and the channel's internal mutex are both
   needed, `_pending_lock` is always acquired first (consistent ordering prevents deadlock);
   the base-class `lock` guards `ports` and is never held simultaneously with `_pending_lock`.
@@ -141,7 +143,7 @@ Hint table:
 | port empty, upstream pipeline finished | `std::nullopt` — EOS |
 | port empty, upstream still running | `WAITING{upstream_op}` — propagate hint up the chain |
 
-**Consumer contract**: pop a handle from the channel, then call `output_repository->pop_data_batch_by_id(handle.batch_id)` to take ownership of the batch. The `try_flush_pending()` flush is triggered by `get_next_task_hint()` (called by the task-creation loop on every iteration), so consumer pops indirectly drive the pending drain.
+**Consumer contract**: pop a handle from the channel, then call `output_repository->pop_data_batch_by_id(handle.batch_id)` to take ownership of the batch. Hint polling drives the pending drain only while the sink's pipeline is still running; after finalize the consumer/session must call `try_flush_pending()` after pops (or wire `exchange_channel::on_pop` to it) so `_pending` drains and the deferred close completes. Channel callbacks run synchronously on the calling thread — they must post/schedule work, never re-enter an operator or take pipeline locks.
 
 ### `sirius_physical_dummy_scan` — `DUMMY_SCAN`
 **File:** `src/include/op/sirius_physical_dummy_scan.hpp`

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -111,7 +111,9 @@ Key design invariants:
   `ColumnDataCollection` materialization.
 - **CONCAT shape**: `is_source() && is_sink()` are both `true`. The operator heads its own
   single-operator pipeline fed via an `"input"` port; the upstream pipeline pushes batches into
-  that port's repository via the base-class `sink()` → `push_data_batch()` path.
+  that port's repository via the base-class `sink()` → `push_data_batch()` path. Being the head,
+  it is simultaneously the *final* operator of that pipeline (`publish_output()` calls its
+  `sink()`) — the same head-and-terminal shape as `RESULT_COLLECTOR` and `MERGE_GROUP_BY`.
 - **Backpressure as admission control**: if the channel is full or `_pending` is non-empty,
   `get_next_task_hint()` and `get_next_task_input_data()` return `WAITING{nullptr}` / `nullptr`
   respectively, preventing new tasks from being created. Worker threads never block.
@@ -126,8 +128,8 @@ Key design invariants:
 - **Flush-then-close EOS**: `on_finalize_operator()` flushes what fits; if `_pending` is empty
   it closes the channel immediately; otherwise it sets `_close_when_flushed` and the close
   happens on a later `try_flush_pending()` call. Nothing polls that after finalize — the
-  consumer/session must call `try_flush_pending()` after pops (or wire `on_pop` to it, #839) or
-  deferred EOS stalls. Finalize also sets `_closing` under `_pending_lock`; a `sink()` that
+  consumer/session must call `try_flush_pending()` after pops (or have `on_pop` schedule a
+  deferred call — #839) or deferred EOS stalls. Finalize also sets `_closing` under `_pending_lock`; a `sink()` that
   observes it throws rather than stranding the handle behind the closed channel.
 - **Locking discipline**: whenever `_pending_lock` and the channel's internal mutex are both
   needed, `_pending_lock` is always acquired first (consistent ordering prevents deadlock);
@@ -143,7 +145,7 @@ Hint table:
 | port empty, upstream pipeline finished | `std::nullopt` — EOS |
 | port empty, upstream still running | `WAITING{upstream_op}` — propagate hint up the chain |
 
-**Consumer contract**: pop a handle from the channel, then call `output_repository->pop_data_batch_by_id(handle.batch_id)` to take ownership of the batch. Hint polling drives the pending drain only while the sink's pipeline is still running; after finalize the consumer/session must call `try_flush_pending()` after pops (or wire `exchange_channel::on_pop` to it) so `_pending` drains and the deferred close completes. Channel callbacks run synchronously on the calling thread — they must post/schedule work, never re-enter an operator or take pipeline locks.
+**Consumer contract**: pop a handle from the channel, then call `output_repository->pop_data_batch_by_id(handle.batch_id)` to take ownership of the batch. Hint polling drives the pending drain only while the sink's pipeline is still running; after finalize the consumer/session must call `try_flush_pending()` after pops (or have `exchange_channel::on_pop` post/schedule a deferred `try_flush_pending()` call — never invoke it directly from the callback) so `_pending` drains and the deferred close completes. Channel callbacks run synchronously on the calling thread — they must post/schedule work, never re-enter an operator or take pipeline locks.
 
 ### `sirius_physical_dummy_scan` — `DUMMY_SCAN`
 **File:** `src/include/op/sirius_physical_dummy_scan.hpp`
@@ -394,7 +396,7 @@ After pipeline finalization, `source` and `sink` are just aliases for the first 
 |----------|----------|-----------|
 | GPU_SCAN | Scan | Unified GPU scan source served by `sirius_scan_manager` via a per-format `gpu_ingestible` |
 | STREAMING_SOURCE | Scan | Exchange-input source; pulls batch handles from `exchange_channel`, resolves via `shared_data_repository` |
-| STREAMING_SINK | Pipeline | Exchange-output sink (CONCAT shape); registers batches in `shared_data_repository`, pushes handles to `exchange_channel` with backpressure |
+| STREAMING_SINK | Result | Exchange-output sink (CONCAT shape); registers batches in `shared_data_repository`, pushes handles to `exchange_channel` with backpressure |
 | DUMMY_SCAN | Scan | Generates 1 row |
 | COLUMN_DATA_SCAN | Scan | Reads ColumnDataCollection |
 | FILTER | Relational | `expression_evaluator::select()` |

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -109,11 +109,13 @@ Key design invariants:
 - **Zero-copy emission**: the batch is registered in the output repository first, then only a
   lightweight handle (batch-id + size) is pushed to the channel — no host clone, no
   `ColumnDataCollection` materialization.
-- **CONCAT shape**: `is_source() && is_sink()` are both `true`. The operator heads its own
-  single-operator pipeline fed via an `"input"` port; the upstream pipeline pushes batches into
-  that port's repository via the base-class `sink()` → `push_data_batch()` path. Being the head,
-  it is simultaneously the *final* operator of that pipeline (`publish_output()` calls its
-  `sink()`) — the same head-and-terminal shape as `RESULT_COLLECTOR` and `MERGE_GROUP_BY`.
+- **Head-and-terminal shape**: `is_sink()` is `true`, `is_source()` is `false` — head placement
+  is structural (`operators[0]`), not flag-driven, and no runtime code reads the flag. The
+  operator heads its own single-operator pipeline fed via an `"input"` port; the upstream
+  pipeline pushes batches into that port's repository via the base-class `sink()` →
+  `push_data_batch()` path. Being the head, it is simultaneously the *final* operator of that
+  pipeline (`publish_output()` calls its `sink()`) — the same head-and-terminal shape as
+  `RESULT_COLLECTOR` and `MERGE_GROUP_BY` (which still report `is_source() == true`).
 - **Backpressure as admission control**: if the channel is full or `_pending` is non-empty,
   `get_next_task_hint()` and `get_next_task_input_data()` return `WAITING{nullptr}` / `nullptr`
   respectively, preventing new tasks from being created. Worker threads never block.
@@ -396,7 +398,7 @@ After pipeline finalization, `source` and `sink` are just aliases for the first 
 |----------|----------|-----------|
 | GPU_SCAN | Scan | Unified GPU scan source served by `sirius_scan_manager` via a per-format `gpu_ingestible` |
 | STREAMING_SOURCE | Scan | Exchange-input source; pulls batch handles from `exchange_channel`, resolves via `shared_data_repository` |
-| STREAMING_SINK | Result | Exchange-output sink (CONCAT shape); registers batches in `shared_data_repository`, pushes handles to `exchange_channel` with backpressure |
+| STREAMING_SINK | Result | Exchange-output sink heading its own single-operator pipeline; registers batches in `shared_data_repository`, pushes handles to `exchange_channel` with backpressure |
 | DUMMY_SCAN | Scan | Generates 1 row |
 | COLUMN_DATA_SCAN | Scan | Reads ColumnDataCollection |
 | FILTER | Relational | `expression_evaluator::select()` |

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -115,12 +115,18 @@ Key design invariants:
 - **Backpressure as admission control**: if the channel is full or `_pending` is non-empty,
   `get_next_task_hint()` and `get_next_task_input_data()` return `WAITING{nullptr}` / `nullptr`
   respectively, preventing new tasks from being created. Worker threads never block.
-- **FIFO `_pending` queue**: when `try_push` fails (channel full), the handle is appended to
-  `_pending`. Subsequent calls to `get_next_task_hint()` or `sink()` call `try_flush_pending()`
-  first, draining `_pending` in order before any new handles are attempted.
+- **FIFO `_pending` overflow buffer (bounded)**: when `try_push` fails (channel full), the handle
+  is appended to `_pending`. Subsequent calls to `get_next_task_hint()` or `sink()` call
+  `try_flush_pending()` first, draining `_pending` in order before any new handles are attempted.
+  `_pending` is not a second unbounded queue: because admission control refuses new sink tasks
+  while `_pending` is non-empty, its depth is bounded by the operator's in-flight task concurrency,
+  never by the input size.
 - **Flush-then-close EOS**: `on_finalize_operator()` flushes what fits; if `_pending` is empty
   it closes the channel immediately; otherwise it sets `_close_when_flushed` and defers the
-  close to the `try_flush_pending()` call triggered by the next consumer pop.
+  close to the `try_flush_pending()` call triggered by the next consumer pop. Finalize sets a
+  `_closing` flag under `_pending_lock`; a `sink()` that observes it (a batch arriving after
+  finalize — which the pipeline never does) throws rather than stranding the handle behind the
+  closed channel.
 - **Locking discipline**: whenever `_pending_lock` and the channel's internal mutex are both
   needed, `_pending_lock` is always acquired first (consistent ordering prevents deadlock);
   the base-class `lock` guards `ports` and is never held simultaneously with `_pending_lock`.

--- a/src/include/exec/exchange_channel.hpp
+++ b/src/include/exec/exchange_channel.hpp
@@ -190,7 +190,9 @@ class exchange_channel {
   // A firing operation snapshots the callback under the lock and invokes the copy after
   // unlocking, so replacing a callback does not synchronize with an in-flight invocation:
   // callbacks must not capture raw pointers to objects the channel can outlive (capture a
-  // weak reference instead).
+  // weak reference instead). Callbacks run synchronously on the pushing/popping/closing
+  // thread — post/schedule work from them; do not re-enter a producer/consumer operator or
+  // take pipeline locks (the caller may already hold operator or pipeline mutexes).
   // -----------------------------------------------------------------------
 
   void set_on_push(std::function<void()> cb)

--- a/src/include/op/sirius_physical_operator_type.hpp
+++ b/src/include/op/sirius_physical_operator_type.hpp
@@ -148,7 +148,8 @@ enum class SiriusPhysicalOperatorType : uint8_t {
   GPU_VALUES,
   GPU_SCAN,
   DYNAMIC_FILTER,
-  STREAMING_SOURCE
+  STREAMING_SOURCE,
+  STREAMING_SINK
 };
 
 std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type);

--- a/src/include/op/sirius_physical_streaming_sink.hpp
+++ b/src/include/op/sirius_physical_streaming_sink.hpp
@@ -33,7 +33,9 @@ namespace sirius::op {
 /// and pushes a lightweight handle into the exchange channel.
 ///
 /// Key design invariants:
-/// - sink() never blocks a worker: a full channel parks the handle in _pending and returns.
+/// - sink() never blocks a worker: a full channel parks the handle in _pending and returns
+///   (exchange_channel::push() is wrapper/test-side only — a blocked worker can deadlock the
+///   pool and cannot be cancelled; see the park-site comment in sink()).
 /// - _pending is flushed FIFO before any newer handle is pushed, preserving order.
 /// - EOS: on_finalize_operator() flushes what fits and closes immediately, or sets
 ///   _close_when_flushed so the last try_flush_pending() call closes the channel.
@@ -55,6 +57,9 @@ class sirius_physical_streaming_sink : public sirius_physical_operator {
     std::shared_ptr<exec::exchange_channel> output_channel,
     std::shared_ptr<cucascade::shared_data_repository> output_repository);
 
+  // Port-fed terminal operator (RESULT_COLLECTOR-style): heads the single-operator pipeline it
+  // also terminates. Head placement is what lets get_next_task_hint() gate task creation on
+  // channel capacity; a pipeline head must report is_source() (see sirius_pipeline::reset_source).
   bool is_source() const override { return true; }
   bool is_sink() const override { return true; }
   bool sink_order_dependent() const override { return false; }

--- a/src/include/op/sirius_physical_streaming_sink.hpp
+++ b/src/include/op/sirius_physical_streaming_sink.hpp
@@ -28,7 +28,7 @@
 
 namespace sirius::op {
 
-/// Boundary operator (source + sink) that marks the top of a pipeline fragment. Pops batches
+/// Port-fed terminal sink that marks the top of a pipeline fragment. Pops batches
 /// from its input port, registers each in the output repository (making it idle and spillable),
 /// and pushes a lightweight handle into the exchange channel.
 ///
@@ -57,10 +57,11 @@ class sirius_physical_streaming_sink : public sirius_physical_operator {
     std::shared_ptr<exec::exchange_channel> output_channel,
     std::shared_ptr<cucascade::shared_data_repository> output_repository);
 
-  // Port-fed terminal operator (RESULT_COLLECTOR-style): heads the single-operator pipeline it
-  // also terminates. Head placement is what lets get_next_task_hint() gate task creation on
-  // channel capacity; a pipeline head must report is_source() (see sirius_pipeline::reset_source).
-  bool is_source() const override { return true; }
+  // Heads the single-operator pipeline it also terminates; head placement is structural
+  // (pipeline operators[0], not this flag) and is what lets get_next_task_hint() gate task
+  // creation on channel capacity. No runtime code reads is_source() — the dormant head check
+  // (sirius_pipeline::reset_source) and the #839 session wiring must key on structure instead.
+  bool is_source() const override { return false; }
   bool is_sink() const override { return true; }
   bool sink_order_dependent() const override { return false; }
 

--- a/src/include/op/sirius_physical_streaming_sink.hpp
+++ b/src/include/op/sirius_physical_streaming_sink.hpp
@@ -39,8 +39,10 @@ namespace sirius::op {
 ///   _close_when_flushed so the last try_flush_pending() call closes the channel.
 /// - Backpressure is admission control: a full channel or non-empty _pending makes
 ///   get_next_task_hint() report WAITING, so no new sink tasks are created.
-/// - _pending is bounded: admission control refuses new sink tasks while it is non-empty,
-///   so its depth is bounded by in-flight task concurrency, not by input size.
+/// - _pending holds one handle per sink task created ahead of the consumer; admission control
+///   stops new pulls while it is non-empty or the channel is full. Its depth is bounded only
+///   once task creation is paced against completion — the session wiring's job (#839). Parked
+///   batches stay registered and spill-visible.
 class sirius_physical_streaming_sink : public sirius_physical_operator {
  public:
   static constexpr SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::STREAMING_SINK;

--- a/src/include/op/sirius_physical_streaming_sink.hpp
+++ b/src/include/op/sirius_physical_streaming_sink.hpp
@@ -40,6 +40,8 @@ namespace sirius::op {
 ///   _close_when_flushed so the last try_flush_pending() call closes the channel.
 /// - Backpressure is admission control: a full channel or non-empty _pending makes
 ///   get_next_task_hint() report WAITING, so no new sink tasks are created.
+/// - _pending is bounded: admission control refuses new sink tasks while it is non-empty,
+///   so its depth is bounded by in-flight task concurrency, not by input size.
 class sirius_physical_streaming_sink : public sirius_physical_operator {
  public:
   static constexpr SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::STREAMING_SINK;
@@ -94,6 +96,9 @@ class sirius_physical_streaming_sink : public sirius_physical_operator {
   std::mutex _pending_lock;
   std::deque<exec::exchange_batch_handle> _pending;
   std::atomic<bool> _close_when_flushed{false};
+  // Set by on_finalize_operator() under _pending_lock; sink() checks it under the same lock and
+  // throws, so a late batch cannot strand behind the closed channel.
+  bool _closing{false};
 };
 
 }  // namespace sirius::op

--- a/src/include/op/sirius_physical_streaming_sink.hpp
+++ b/src/include/op/sirius_physical_streaming_sink.hpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "exec/exchange_channel.hpp"
+#include "op/sirius_physical_operator.hpp"
+
+#include <cucascade/data/data_repository.hpp>
+
+#include <atomic>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <optional>
+
+namespace sirius::op {
+
+/// Boundary operator (source + sink) that marks the top of a pipeline fragment. Pops batches
+/// from its input port, registers each in the output repository (making it idle and spillable),
+/// and pushes a lightweight handle into the exchange channel.
+///
+/// Key design invariants:
+/// - sink() never blocks a worker: a full channel parks the handle in _pending and returns.
+/// - _pending is flushed FIFO before any newer handle is pushed, preserving order.
+/// - EOS: on_finalize_operator() flushes what fits and closes immediately, or sets
+///   _close_when_flushed so the last try_flush_pending() call closes the channel.
+/// - Backpressure is admission control: a full channel or non-empty _pending makes
+///   get_next_task_hint() report WAITING, so no new sink tasks are created.
+class sirius_physical_streaming_sink : public sirius_physical_operator {
+ public:
+  static constexpr SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::STREAMING_SINK;
+  static constexpr std::string_view INPUT_PORT     = "input";
+
+  /// Throws invalid_input_exception when output_channel or output_repository is null.
+  sirius_physical_streaming_sink(
+    duckdb::vector<sirius::logical_type> types,
+    std::size_t estimated_cardinality,
+    std::shared_ptr<exec::exchange_channel> output_channel,
+    std::shared_ptr<cucascade::shared_data_repository> output_repository);
+
+  bool is_source() const override { return true; }
+  bool is_sink() const override { return true; }
+  bool sink_order_dependent() const override { return false; }
+
+  /// Flushes pending handles first; returns WAITING{nullptr} when the channel is full or
+  /// handles remain pending, READY{this} when the input port has data, nullopt when the
+  /// upstream pipeline is done and the port is empty, or WAITING{upstream source} otherwise.
+  std::optional<task_creation_hint> get_next_task_hint() override;
+
+  /// Per-pull admission check: returns nullptr when the channel has no free slot (races
+  /// absorbed by _pending); otherwise pops one batch FIFO from the input port.
+  std::unique_ptr<operator_data> get_next_task_input_data() override;
+
+  /// Pass-through: returns the input batches unchanged.
+  std::unique_ptr<operator_data> execute(const operator_data& input,
+                                         rmm::cuda_stream_view stream) override;
+
+  /// Zero-copy emit: registers each batch in the output repository, then pushes its handle
+  /// to the channel. Handles that cannot be admitted are appended to _pending (never blocks).
+  void sink(const operator_data& output, rmm::cuda_stream_view stream) override;
+
+  /// Pass-through allocates nothing new; return input bytes to avoid over-reserving.
+  [[nodiscard]] std::size_t no_history_peak_memory_estimate(
+    const input_stats& stats) const override;
+
+  /// Flush pending handles into the channel. Closes the channel once _pending empties and
+  /// _close_when_flushed is set. Handle-only; callable from any thread.
+  void try_flush_pending();
+
+ protected:
+  void on_finalize_operator() override;
+
+ private:
+  /// Push queued handles into the channel in FIFO order until it rejects one (full).
+  /// Caller must hold _pending_lock. Does not close the channel — callers decide that.
+  void flush_pending_locked();
+
+  std::shared_ptr<exec::exchange_channel> _output_channel;
+  std::shared_ptr<cucascade::shared_data_repository> _output_repository;
+  std::mutex _pending_lock;
+  std::deque<exec::exchange_batch_handle> _pending;
+  std::atomic<bool> _close_when_flushed{false};
+};
+
+}  // namespace sirius::op

--- a/src/include/op/sirius_physical_streaming_sink.hpp
+++ b/src/include/op/sirius_physical_streaming_sink.hpp
@@ -21,7 +21,6 @@
 
 #include <cucascade/data/data_repository.hpp>
 
-#include <atomic>
 #include <deque>
 #include <memory>
 #include <mutex>
@@ -95,7 +94,7 @@ class sirius_physical_streaming_sink : public sirius_physical_operator {
   std::shared_ptr<cucascade::shared_data_repository> _output_repository;
   std::mutex _pending_lock;
   std::deque<exec::exchange_batch_handle> _pending;
-  std::atomic<bool> _close_when_flushed{false};
+  bool _close_when_flushed{false};  // guarded by _pending_lock
   // Set by on_finalize_operator() under _pending_lock; sink() checks it under the same lock and
   // throws, so a late batch cannot strand behind the closed channel.
   bool _closing{false};

--- a/src/op/sirius_physical_operator_type.cpp
+++ b/src/op/sirius_physical_operator_type.cpp
@@ -115,6 +115,7 @@ std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type)
     case SiriusPhysicalOperatorType::GPU_SCAN: return "GPU_SCAN";
     case SiriusPhysicalOperatorType::DYNAMIC_FILTER: return "DYNAMIC_FILTER";
     case SiriusPhysicalOperatorType::STREAMING_SOURCE: return "STREAMING_SOURCE";
+    case SiriusPhysicalOperatorType::STREAMING_SINK: return "STREAMING_SINK";
     case SiriusPhysicalOperatorType::INVALID: break;
   }
   return "INVALID";

--- a/src/op/sirius_physical_streaming_sink.cpp
+++ b/src/op/sirius_physical_streaming_sink.cpp
@@ -56,11 +56,15 @@ void sirius_physical_streaming_sink::flush_pending_locked()
 
 void sirius_physical_streaming_sink::try_flush_pending()
 {
-  std::lock_guard<std::mutex> lk(_pending_lock);
-  flush_pending_locked();
-  if (_pending.empty() && _close_when_flushed.load(std::memory_order_acquire)) {
-    _output_channel->close();
+  bool should_close = false;
+  {
+    std::lock_guard<std::mutex> lk(_pending_lock);
+    flush_pending_locked();
+    should_close = _pending.empty() && _close_when_flushed;
   }
+  // close() runs the on_close callback synchronously; call it outside _pending_lock so a
+  // re-entrant callback cannot deadlock. Safe: post-finalize sink() throws, close() is idempotent.
+  if (should_close) { _output_channel->close(); }
 }
 
 std::optional<task_creation_hint> sirius_physical_streaming_sink::get_next_task_hint()
@@ -188,14 +192,19 @@ void sirius_physical_streaming_sink::on_finalize_operator()
   // drained, otherwise defer the close to whichever try_flush_pending() delivers the last handle.
   // _closing is set under the same lock: a concurrent sink() either completes before the close
   // decision or rejects its batch.
-  std::lock_guard<std::mutex> lk(_pending_lock);
-  _closing = true;
-  flush_pending_locked();
-  if (_pending.empty()) {
-    _output_channel->close();
-  } else {
-    _close_when_flushed.store(true, std::memory_order_release);
+  bool should_close = false;
+  {
+    std::lock_guard<std::mutex> lk(_pending_lock);
+    _closing = true;
+    flush_pending_locked();
+    if (_pending.empty()) {
+      should_close = true;
+    } else {
+      _close_when_flushed = true;
+    }
   }
+  // close() outside _pending_lock (see try_flush_pending).
+  if (should_close) { _output_channel->close(); }
 }
 
 }  // namespace sirius::op

--- a/src/op/sirius_physical_streaming_sink.cpp
+++ b/src/op/sirius_physical_streaming_sink.cpp
@@ -142,12 +142,24 @@ void sirius_physical_streaming_sink::sink(const operator_data& output_data,
   const auto& batches = pod.get_data_batches();
 
   for (const auto& batch : batches) {
-    // Read size via a shared (read-only) lock — pure metadata access, no data copy or GPU work.
-    // The lock is released before add_data_batch so the repo receives the batch in idle state.
+    // Registration-time size snapshot, read under the batch's shared lock (excludes concurrent
+    // spill). The channel adds and subtracts this same stored value, so a later spill only makes
+    // the byte bound conservative, never unbalanced.
     std::size_t size_bytes = 0;
     {
       auto ro = batch->to_read_only();
       if (const auto* d = ro.get_data()) { size_bytes = d->get_size_in_bytes(); }
+    }
+
+    // One lock hold per batch keeps the _closing check, registration, and push atomic and FIFO.
+    std::lock_guard<std::mutex> lk(_pending_lock);
+
+    // A sink() after finalize is a pipeline-contract violation; fail before add_data_batch so
+    // the batch is neither orphaned in the repo nor stranded behind the closed channel.
+    if (_closing) {
+      throw sirius::internal_exception(
+        "sirius_physical_streaming_sink::sink() called after finalize — a task was still in "
+        "flight when the pipeline was declared finished");
     }
 
     // Register first: the repo becomes the owner of record and the batch is spill-visible
@@ -157,8 +169,7 @@ void sirius_physical_streaming_sink::sink(const operator_data& output_data,
     exec::exchange_batch_handle handle{batch->get_batch_id(), size_bytes};
 
     // Drain the backlog first, then push the new handle — or park it if anything is still
-    // queued or the channel is full. One lock hold keeps FIFO order intact and never blocks.
-    std::lock_guard<std::mutex> lk(_pending_lock);
+    // queued or the channel is full. Never blocks a worker.
     flush_pending_locked();
     if (!_pending.empty() || !_output_channel->try_push(handle)) { _pending.push_back(handle); }
   }
@@ -175,7 +186,10 @@ void sirius_physical_streaming_sink::on_finalize_operator()
 {
   // Hold the lock across flush + close decision so they are atomic: close now if the backlog
   // drained, otherwise defer the close to whichever try_flush_pending() delivers the last handle.
+  // _closing is set under the same lock: a concurrent sink() either completes before the close
+  // decision or rejects its batch.
   std::lock_guard<std::mutex> lk(_pending_lock);
+  _closing = true;
   flush_pending_locked();
   if (_pending.empty()) {
     _output_channel->close();

--- a/src/op/sirius_physical_streaming_sink.cpp
+++ b/src/op/sirius_physical_streaming_sink.cpp
@@ -172,8 +172,9 @@ void sirius_physical_streaming_sink::sink(const operator_data& output_data,
 
     exec::exchange_batch_handle handle{batch->get_batch_id(), size_bytes};
 
-    // Drain the backlog first, then push the new handle — or park it if anything is still
-    // queued or the channel is full. Never blocks a worker.
+    // Flush backlog first, then try_push — or park if still queued/full. Never block: sink()
+    // runs on a scheduler worker, and push() can deadlock the pool or strand on a stalled
+    // consumer (no cancellation; only pop/close wakes it). Closed channels still refuse.
     flush_pending_locked();
     if (!_pending.empty() || !_output_channel->try_push(handle)) { _pending.push_back(handle); }
   }

--- a/src/op/sirius_physical_streaming_sink.cpp
+++ b/src/op/sirius_physical_streaming_sink.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_physical_streaming_sink.hpp"
+
+#include "pipeline/sirius_pipeline.hpp"
+#include "sirius/exception.hpp"
+
+#include <cucascade/data/data_batch.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace sirius::op {
+
+sirius_physical_streaming_sink::sirius_physical_streaming_sink(
+  duckdb::vector<sirius::logical_type> types,
+  std::size_t estimated_cardinality,
+  std::shared_ptr<exec::exchange_channel> output_channel,
+  std::shared_ptr<cucascade::shared_data_repository> output_repository)
+  : sirius_physical_operator(
+      SiriusPhysicalOperatorType::STREAMING_SINK, std::move(types), estimated_cardinality),
+    _output_channel(std::move(output_channel)),
+    _output_repository(std::move(output_repository))
+{
+  if (!_output_channel) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_sink: output_channel must not be null");
+  }
+  if (!_output_repository) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_sink: output_repository must not be null");
+  }
+}
+
+void sirius_physical_streaming_sink::flush_pending_locked()
+{
+  while (!_pending.empty()) {
+    if (!_output_channel->try_push(_pending.front())) break;
+    _pending.pop_front();
+  }
+}
+
+void sirius_physical_streaming_sink::try_flush_pending()
+{
+  std::lock_guard<std::mutex> lk(_pending_lock);
+  flush_pending_locked();
+  if (_pending.empty() && _close_when_flushed.load(std::memory_order_acquire)) {
+    _output_channel->close();
+  }
+}
+
+std::optional<task_creation_hint> sirius_physical_streaming_sink::get_next_task_hint()
+{
+  // Flush any backed-up handles first — cheap, handle-only, no GPU work.
+  try_flush_pending();
+
+  // Backpressure: if pending handles remain or the channel is full, no new sink tasks.
+  {
+    std::lock_guard<std::mutex> lk(_pending_lock);
+    if (!_pending.empty()) {
+      return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, nullptr};
+    }
+  }
+  if (_output_channel->full()) {
+    return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, nullptr};
+  }
+
+  std::lock_guard<std::mutex> lg(lock);
+  auto it = ports.find(std::string(INPUT_PORT));
+  if (it == ports.end() || !it->second || !it->second->repo) {
+    return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, nullptr};
+  }
+  auto* port_ptr = it->second;
+
+  if (port_ptr->repo->total_size() > 0) {
+    return task_creation_hint{TaskCreationHint::READY, this};
+  }
+
+  bool upstream_finished = port_ptr->src_pipeline && port_ptr->src_pipeline->is_pipeline_finished();
+  if (upstream_finished) { return std::nullopt; }
+
+  // Upstream still running; propagate the hint up the chain.
+  // Null-check src_pipeline: hand-wired test ports carry nullptr.
+  if (port_ptr->src_pipeline) {
+    return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA,
+                              &(port_ptr->src_pipeline->get_operators()[0].get())};
+  }
+  return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, nullptr};
+}
+
+std::unique_ptr<operator_data> sirius_physical_streaming_sink::get_next_task_input_data()
+{
+  // Per-pull admission: the task-creation loop pulls without re-polling the hint, so we must
+  // re-check here. Approximate admission is fine; races are absorbed by _pending.
+  {
+    std::lock_guard<std::mutex> lk(_pending_lock);
+    if (!_pending.empty()) return nullptr;
+  }
+  if (_output_channel->full()) return nullptr;
+
+  std::lock_guard<std::mutex> lg(lock);
+  auto it = ports.find(std::string(INPUT_PORT));
+  if (it == ports.end() || !it->second || !it->second->repo) return nullptr;
+  auto* port_ptr = it->second;
+
+  auto batch_ids = port_ptr->repo->get_batch_ids(0);
+  if (batch_ids.empty()) return nullptr;
+
+  auto batch = port_ptr->repo->pop_data_batch_by_id(batch_ids[0], 0);
+  if (!batch) return nullptr;
+
+  return std::make_unique<pipelineable_operator_data>(
+    std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(batch)});
+}
+
+std::unique_ptr<operator_data> sirius_physical_streaming_sink::execute(
+  const operator_data& input, rmm::cuda_stream_view /*stream*/)
+{
+  // Pass-through: the sink holds no intermediate state; coalescing/splitting is deferred.
+  const auto& pod = static_cast<const pipelineable_operator_data&>(input);
+  return std::make_unique<pipelineable_operator_data>(pod.get_data_batches());
+}
+
+void sirius_physical_streaming_sink::sink(const operator_data& output_data,
+                                          rmm::cuda_stream_view /*stream*/)
+{
+  const auto& pod     = static_cast<const pipelineable_operator_data&>(output_data);
+  const auto& batches = pod.get_data_batches();
+
+  for (const auto& batch : batches) {
+    // Read size via a shared (read-only) lock — pure metadata access, no data copy or GPU work.
+    // The lock is released before add_data_batch so the repo receives the batch in idle state.
+    std::size_t size_bytes = 0;
+    {
+      auto ro = batch->to_read_only();
+      if (const auto* d = ro.get_data()) { size_bytes = d->get_size_in_bytes(); }
+    }
+
+    // Register first: the repo becomes the owner of record and the batch is spill-visible
+    // before any channel push, so _pending handles always point at accountable batches.
+    _output_repository->add_data_batch(batch);
+
+    exec::exchange_batch_handle handle{batch->get_batch_id(), size_bytes};
+
+    // Drain the backlog first, then push the new handle — or park it if anything is still
+    // queued or the channel is full. One lock hold keeps FIFO order intact and never blocks.
+    std::lock_guard<std::mutex> lk(_pending_lock);
+    flush_pending_locked();
+    if (!_pending.empty() || !_output_channel->try_push(handle)) { _pending.push_back(handle); }
+  }
+}
+
+std::size_t sirius_physical_streaming_sink::no_history_peak_memory_estimate(
+  const input_stats& stats) const
+{
+  // Pass-through: no additional GPU allocation; return stats.bytes to avoid 2x over-reserving.
+  return stats.bytes;
+}
+
+void sirius_physical_streaming_sink::on_finalize_operator()
+{
+  // Hold the lock across flush + close decision so they are atomic: close now if the backlog
+  // drained, otherwise defer the close to whichever try_flush_pending() delivers the last handle.
+  std::lock_guard<std::mutex> lk(_pending_lock);
+  flush_pending_locked();
+  if (_pending.empty()) {
+    _output_channel->close();
+  } else {
+    _close_when_flushed.store(true, std::memory_order_release);
+  }
+}
+
+}  // namespace sirius::op

--- a/test/cpp/operator/test_physical_streaming_sink.cpp
+++ b/test/cpp/operator/test_physical_streaming_sink.cpp
@@ -1,0 +1,990 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator_test_utils.hpp"
+
+#include <catch.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <data/data_batch_utils.hpp>
+#include <data/sirius_converter_registry.hpp>
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <exec/exchange_channel.hpp>
+#include <expression/ast/from_duckdb.hpp>
+#include <helper/type_conversions.hpp>
+#include <op/sirius_physical_filter.hpp>
+#include <op/sirius_physical_streaming_sink.hpp>
+#include <op/sirius_physical_streaming_source.hpp>
+#include <pipeline/sirius_pipeline.hpp>
+#include <sirius/exception.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <vector>
+
+using namespace sirius::exec;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+
+namespace {
+
+using namespace sirius::test::operator_utils;
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+/// Create a streaming sink with its own output channel and output repository.
+static auto make_sink(std::size_t channel_capacity = 16)
+{
+  auto out_ch   = std::make_shared<exchange_channel>(exchange_channel::config{channel_capacity});
+  auto out_repo = std::make_shared<cucascade::shared_data_repository>();
+  auto op       = std::make_unique<sirius_physical_streaming_sink>(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    out_ch,
+    out_repo);
+  return std::make_tuple(std::move(op), out_ch, out_repo);
+}
+
+/// Wire a fresh input-port repository to the sink and return it.
+static std::unique_ptr<cucascade::shared_data_repository> wire_input_port(
+  sirius_physical_streaming_sink& op,
+  duckdb::shared_ptr<sirius::pipeline::sirius_pipeline> src_pipeline = nullptr)
+{
+  auto in_repo     = std::make_unique<cucascade::shared_data_repository>();
+  auto p           = std::make_unique<sirius_physical_operator::port>();
+  p->type          = MemoryBarrierType::FULL;
+  p->repo          = in_repo.get();
+  p->src_pipeline  = src_pipeline;
+  p->dest_pipeline = nullptr;
+  op.add_port(std::string(sirius_physical_streaming_sink::INPUT_PORT), std::move(p));
+  return in_repo;
+}
+
+/// Create a minimal pipeline around a streaming source that finishes immediately
+/// (zero batches ever pushed, channel closed on return).
+struct finished_upstream {
+  std::shared_ptr<exchange_channel> ch;
+  std::shared_ptr<cucascade::shared_data_repository> repo;
+  std::unique_ptr<sirius_physical_streaming_source> op;
+  duckdb::shared_ptr<sirius::pipeline::sirius_pipeline> pipeline;
+};
+
+static finished_upstream make_finished_upstream()
+{
+  finished_upstream f;
+  f.ch   = std::make_shared<exchange_channel>(exchange_channel::config{1});
+  f.repo = std::make_shared<cucascade::shared_data_repository>();
+  f.op   = std::make_unique<sirius_physical_streaming_source>(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    f.ch,
+    f.repo);
+
+  sirius::pipeline::pipeline_build_context build_ctx{nullptr, true};
+  f.pipeline = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(build_ctx);
+  sirius::pipeline::sirius_pipeline_build_state build_state;
+  build_state.set_pipeline_source(*f.pipeline, *f.op);
+  build_state.set_pipeline_sink(*f.pipeline, f.op.get(), 1);
+  f.op->set_pipeline(f.pipeline);
+
+  // Close channel: 0 tasks created, source is drained → pipeline is finished.
+  f.ch->close();
+  return f;
+}
+
+/// Pop all handles from the channel and resolve each via the output repo.
+/// Simulates the consumer side (wrapper / session).
+static std::vector<std::shared_ptr<cucascade::data_batch>> drain_channel(
+  exchange_channel& ch, cucascade::shared_data_repository& repo)
+{
+  std::vector<std::shared_ptr<cucascade::data_batch>> result;
+  while (true) {
+    auto maybe = ch.try_pop();
+    if (!maybe) break;
+    auto batch = repo.pop_data_batch_by_id(maybe->batch_id);
+    REQUIRE(batch != nullptr);
+    result.push_back(std::move(batch));
+  }
+  return result;
+}
+
+/// Sink a single batch directly, bypassing the port and per-pull admission check.
+/// Used to force a batch into _pending when the channel is full.
+static void sink_batch(sirius_physical_streaming_sink& op,
+                       std::shared_ptr<cucascade::data_batch> b,
+                       rmm::cuda_stream_view stream)
+{
+  pipelineable_operator_data pod{std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(b)}};
+  op.sink(pod, stream);
+}
+
+/// Advance one batch through the operator: get_next_task_input_data → execute → sink.
+/// Requires the admission check to pass (the port has data and the channel has room).
+static void run_cycle(sirius_physical_streaming_sink& op, rmm::cuda_stream_view stream)
+{
+  auto input_data = op.get_next_task_input_data();
+  REQUIRE(input_data != nullptr);
+  auto output_data = op.execute(*input_data, stream);
+  op.sink(*output_data, stream);
+}
+
+}  // namespace
+
+// ============================================================================
+// 7.1  Hint & admission
+// ============================================================================
+
+TEST_CASE("streaming_sink hint: port non-empty with free channel is READY", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, out_ch, out_repo] = make_sink();
+  auto in_repo                = wire_input_port(*op);
+
+  auto batch = make_numeric_batch<int32_t>(*gpu_space, {1, 2, 3}, cudf::type_id::INT32);
+  in_repo->add_data_batch(batch);
+
+  auto hint = op->get_next_task_hint();
+  REQUIRE(hint.has_value());
+  REQUIRE(hint->hint == TaskCreationHint::READY);
+  REQUIRE(hint->producer == op.get());
+}
+
+TEST_CASE("streaming_sink hint: full channel is WAITING{nullptr}", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, out_ch, out_repo] = make_sink(/*capacity=*/1);
+  auto in_repo                = wire_input_port(*op);
+
+  // Fill the channel.
+  auto batch = make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32);
+  in_repo->add_data_batch(batch);
+  out_repo->add_data_batch(batch);
+  REQUIRE(out_ch->try_push({batch->get_batch_id(), 0}));
+  REQUIRE(out_ch->full());
+
+  auto hint = op->get_next_task_hint();
+  REQUIRE(hint.has_value());
+  REQUIRE(hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+  REQUIRE(hint->producer == nullptr);
+}
+
+TEST_CASE("streaming_sink hint: pending non-empty causes flush-first then re-check",
+          "[streaming_sink]")
+{
+  // Verify the flush-first discipline: after a consumer pop frees a slot and
+  // try_flush_pending() succeeds inside get_next_task_hint(), the hint proceeds to READY
+  // rather than returning WAITING due to stale pending state.
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink(/*capacity=*/1);
+  auto in_repo                = wire_input_port(*op);
+
+  // b1 flows through the normal admission path and fills the channel. b2 is sinked directly:
+  // once the channel is full, get_next_task_input_data() returns nullptr by design, so the
+  // normal cycle cannot push b2 — sinking it directly is the only way to reach _pending.
+  auto b1 = make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32);
+  auto b2 = make_numeric_batch<int32_t>(*gpu_space, {2}, cudf::type_id::INT32);
+  in_repo->add_data_batch(b1);
+
+  run_cycle(*op, stream);  // b1 → channel
+  REQUIRE(out_ch->full());
+  sink_batch(*op, b2, stream);  // b2 → _pending (channel full, try_push fails)
+
+  // Consume b1 from the channel → frees a slot.
+  auto h = out_ch->try_pop();
+  REQUIRE(h.has_value());
+  out_repo->pop_data_batch_by_id(h->batch_id);
+
+  // The hint's leading try_flush_pending() must now deliver b2 into the freed slot.
+  op->get_next_task_hint();
+  REQUIRE_FALSE(out_ch->empty());
+}
+
+TEST_CASE("streaming_sink hint: port empty, src_pipeline null is WAITING{nullptr}",
+          "[streaming_sink]")
+{
+  auto [op, out_ch, out_repo] = make_sink();
+  auto in_repo                = wire_input_port(*op, /*src_pipeline=*/nullptr);
+
+  // Port empty, src_pipeline null → must not crash, must be WAITING{nullptr}.
+  auto hint = op->get_next_task_hint();
+  REQUIRE(hint.has_value());
+  REQUIRE(hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+  REQUIRE(hint->producer == nullptr);
+}
+
+TEST_CASE("streaming_sink hint: upstream finished, port empty, no pending is nullopt",
+          "[streaming_sink]")
+{
+  auto [op, out_ch, out_repo] = make_sink();
+  auto upstream               = make_finished_upstream();
+  REQUIRE(upstream.pipeline->is_pipeline_finished());
+
+  auto in_repo = wire_input_port(*op, upstream.pipeline);
+  // Port empty, upstream finished → EOS.
+  auto hint = op->get_next_task_hint();
+  REQUIRE_FALSE(hint.has_value());
+}
+
+TEST_CASE("streaming_sink hint: upstream finished but port non-empty is READY", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, out_ch, out_repo] = make_sink();
+  auto upstream               = make_finished_upstream();
+  REQUIRE(upstream.pipeline->is_pipeline_finished());
+
+  auto in_repo = wire_input_port(*op, upstream.pipeline);
+
+  auto batch = make_numeric_batch<int32_t>(*gpu_space, {7}, cudf::type_id::INT32);
+  in_repo->add_data_batch(batch);
+
+  auto hint = op->get_next_task_hint();
+  REQUIRE(hint.has_value());
+  REQUIRE(hint->hint == TaskCreationHint::READY);
+}
+
+TEST_CASE("streaming_sink admission: full channel blocks get_next_task_input_data",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, out_ch, out_repo] = make_sink(/*capacity=*/1);
+  auto in_repo                = wire_input_port(*op);
+
+  // Put two batches in the port.
+  auto b1 = make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32);
+  auto b2 = make_numeric_batch<int32_t>(*gpu_space, {2}, cudf::type_id::INT32);
+  in_repo->add_data_batch(b1);
+  in_repo->add_data_batch(b2);
+
+  // Fill the output channel with a synthetic handle.
+  REQUIRE(out_ch->try_push({9999, 0}));
+  REQUIRE(out_ch->full());
+
+  // Port has data but channel is full → admission check must return nullptr.
+  auto pod = op->get_next_task_input_data();
+  REQUIRE(pod == nullptr);
+}
+
+TEST_CASE("streaming_sink admission: happy path pops one batch FIFO", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, out_ch, out_repo] = make_sink();
+  auto in_repo                = wire_input_port(*op);
+
+  auto b1      = make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32);
+  auto b2      = make_numeric_batch<int32_t>(*gpu_space, {2}, cudf::type_id::INT32);
+  uint64_t id1 = b1->get_batch_id();
+  in_repo->add_data_batch(b1);
+  in_repo->add_data_batch(b2);
+
+  auto pod = op->get_next_task_input_data();
+  REQUIRE(pod != nullptr);
+
+  auto& batches = static_cast<pipelineable_operator_data&>(*pod).get_data_batches();
+  REQUIRE(batches.size() == 1);
+  REQUIRE(batches[0]->get_batch_id() == id1);
+}
+
+// ============================================================================
+// 7.2  sink() data path
+// ============================================================================
+
+TEST_CASE("streaming_sink data path: n batches appear in channel and output repo",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr int N             = 4;
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink(N);
+  auto in_repo                = wire_input_port(*op);
+
+  std::vector<uint64_t> expected_ids;
+  for (int i = 0; i < N; ++i) {
+    auto b = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    expected_ids.push_back(b->get_batch_id());
+    in_repo->add_data_batch(b);
+  }
+
+  for (int i = 0; i < N; ++i)
+    run_cycle(*op, stream);
+
+  // All N handles must be on the channel, and all N batches must be in the output repo.
+  REQUIRE(out_ch->size() == static_cast<std::size_t>(N));
+  std::vector<uint64_t> got_ids;
+  while (true) {
+    auto h = out_ch->try_pop();
+    if (!h) break;
+    got_ids.push_back(h->batch_id);
+  }
+  REQUIRE(got_ids == expected_ids);
+}
+
+TEST_CASE("streaming_sink data path: emitted batches remain GPU-tier (no materialization)",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink();
+  auto in_repo                = wire_input_port(*op);
+
+  std::vector<int32_t> values{10, 20, 30};
+  auto batch = make_numeric_batch<int32_t>(*gpu_space, values, cudf::type_id::INT32);
+  in_repo->add_data_batch(batch);
+
+  run_cycle(*op, stream);
+
+  auto h = out_ch->try_pop();
+  REQUIRE(h.has_value());
+
+  auto resolved = out_repo->pop_data_batch_by_id(h->batch_id);
+  REQUIRE(resolved != nullptr);
+
+  // Batch must still be GPU-resident (no host clone occurred).
+  auto ro = resolved->to_read_only();
+  REQUIRE(ro.get_data()->get_current_tier() == Tier::GPU);
+
+  auto view   = sirius::get_cudf_table_view(*resolved);
+  auto result = copy_column_to_host<int32_t>(view.column(0));
+  REQUIRE(result == values);
+}
+
+TEST_CASE("streaming_sink data path: after task drops, repo is sole owner and batch is idle",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink();
+  auto in_repo                = wire_input_port(*op);
+
+  auto batch   = make_numeric_batch<int32_t>(*gpu_space, {1, 2}, cudf::type_id::INT32);
+  uint64_t bid = batch->get_batch_id();
+  in_repo->add_data_batch(batch);
+
+  run_cycle(*op, stream);  // its pod_in/pod_out drop on return, releasing shared references
+
+  // The batch should now be exclusively in the output repo.
+  auto h = out_ch->try_pop();
+  REQUIRE(h.has_value());
+  REQUIRE(h->batch_id == bid);
+
+  auto resolved = out_repo->pop_data_batch_by_id(bid);
+  REQUIRE(resolved != nullptr);
+
+  // After popping from repo, only 'resolved' and 'batch' (original in-test ref) hold it.
+  // State must be idle (not processing).
+  REQUIRE(resolved->get_state() == cucascade::batch_state::idle);
+}
+
+TEST_CASE("streaming_sink data path: handle size_bytes is consistent with repo accounting",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink();
+  auto in_repo                = wire_input_port(*op);
+
+  auto batch = make_numeric_batch<int32_t>(*gpu_space, {1, 2, 3, 4, 5}, cudf::type_id::INT32);
+  std::size_t expected_size = 0;
+  {
+    auto ro = batch->to_read_only();
+    REQUIRE(ro.get_data() != nullptr);
+    expected_size = ro.get_data()->get_size_in_bytes();
+  }
+  in_repo->add_data_batch(batch);
+
+  run_cycle(*op, stream);
+
+  auto h = out_ch->try_pop();
+  REQUIRE(h.has_value());
+  REQUIRE(h->size_bytes == expected_size);
+}
+
+TEST_CASE("streaming_sink data path: full-channel fallback parks handle in pending (non-blocking)",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink(/*capacity=*/1);
+  auto in_repo                = wire_input_port(*op);
+
+  auto b1 = make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32);
+  auto b2 = make_numeric_batch<int32_t>(*gpu_space, {2}, cudf::type_id::INT32);
+  in_repo->add_data_batch(b1);
+
+  run_cycle(*op, stream);  // b1 → channel (fits)
+  REQUIRE(out_ch->full());
+
+  // b2 → _pending (channel full). sink() must return promptly without blocking; b2 is sinked
+  // directly since per-pull admission would refuse to pull it while the channel is full.
+  sink_batch(*op, b2, stream);
+
+  // b2's handle is in _pending; b2 is idle in the output repo (spill-visible).
+  REQUIRE(out_ch->size() == 1u);          // only b1
+  REQUIRE(out_repo->total_size() == 2u);  // b1 + b2 both registered
+
+  // Drain b1 → frees a slot; try_flush_pending on next hint call pushes b2.
+  auto h1 = out_ch->try_pop();
+  REQUIRE(h1.has_value());
+  out_repo->pop_data_batch_by_id(h1->batch_id);
+
+  op->get_next_task_hint();       // triggers try_flush_pending → b2 pushed to channel
+  REQUIRE(out_ch->size() == 1u);  // now b2
+}
+
+TEST_CASE("streaming_sink data path: pending handles delivered FIFO before newer ones",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink(/*capacity=*/1);
+  auto in_repo                = wire_input_port(*op);
+
+  // Sink two batches: b1 → channel, b2 → _pending.
+  auto b1      = make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32);
+  auto b2      = make_numeric_batch<int32_t>(*gpu_space, {2}, cudf::type_id::INT32);
+  uint64_t id1 = b1->get_batch_id();
+  uint64_t id2 = b2->get_batch_id();
+
+  sink_batch(*op, b1, stream);
+  sink_batch(*op, b2, stream);  // b2 goes to _pending
+
+  // Consumer pops b1, freeing a slot.
+  auto h1 = out_ch->try_pop();
+  REQUIRE(h1.has_value());
+  REQUIRE(h1->batch_id == id1);
+
+  // try_flush_pending delivers b2; then sink a fresh b3.
+  auto b3 = make_numeric_batch<int32_t>(*gpu_space, {3}, cudf::type_id::INT32);
+  op->try_flush_pending();
+  sink_batch(*op, b3, stream);  // after flush: channel has b2; b3 may go to pending
+
+  // The next pop must be b2 (FIFO), not b3.
+  auto h2 = out_ch->try_pop();
+  REQUIRE(h2.has_value());
+  REQUIRE(h2->batch_id == id2);
+}
+
+// ============================================================================
+// 7.3  Lifecycle & EOS
+// ============================================================================
+
+TEST_CASE("streaming_sink lifecycle: finalize with nothing pending closes channel immediately",
+          "[streaming_sink]")
+{
+  auto [op, out_ch, out_repo] = make_sink();
+  auto in_repo                = wire_input_port(*op);
+
+  REQUIRE_FALSE(out_ch->closed());
+  op->finalize_operator();
+  REQUIRE(out_ch->closed());
+}
+
+TEST_CASE("streaming_sink lifecycle: finalize with pending defers close until last flush",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink(/*capacity=*/1);
+  auto in_repo                = wire_input_port(*op);
+
+  auto b1 = make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32);
+  auto b2 = make_numeric_batch<int32_t>(*gpu_space, {2}, cudf::type_id::INT32);
+
+  sink_batch(*op, b1, stream);
+  sink_batch(*op, b2, stream);  // b2 → _pending
+
+  // Finalize: channel not yet closed because b2 is still pending.
+  op->finalize_operator();
+  REQUIRE_FALSE(out_ch->closed());
+
+  // Consumer pops b1 → frees slot.
+  auto h1 = out_ch->try_pop();
+  REQUIRE(h1.has_value());
+  out_repo->pop_data_batch_by_id(h1->batch_id);
+
+  // try_flush_pending delivers b2 into the channel and closes it. The channel is now
+  // closed but not yet drained — b2 still sits in the queue awaiting the consumer.
+  op->try_flush_pending();
+  REQUIRE(out_ch->closed());
+  REQUIRE_FALSE(out_ch->drained());
+
+  // Consumer pops the last handle (b2) → channel is now drained (closed && empty).
+  auto h2 = out_ch->try_pop();
+  REQUIRE(h2.has_value());
+  REQUIRE(h2->batch_id == b2->get_batch_id());
+  out_repo->pop_data_batch_by_id(h2->batch_id);
+  REQUIRE(out_ch->drained());
+}
+
+TEST_CASE("streaming_sink lifecycle: empty stream finalized closes channel with zero items",
+          "[streaming_sink]")
+{
+  auto [op, out_ch, out_repo] = make_sink();
+  auto in_repo                = wire_input_port(*op);
+
+  op->finalize_operator();
+  REQUIRE(out_ch->closed());
+  REQUIRE(out_ch->drained());
+
+  // Consumer sees EOS immediately.
+  auto h = out_ch->try_pop();
+  REQUIRE_FALSE(h.has_value());
+}
+
+TEST_CASE("streaming_sink lifecycle: conservation across randomized run", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr int N             = 20;
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink(N);
+  auto in_repo                = wire_input_port(*op);
+
+  std::set<uint64_t> pushed_ids;
+  for (int i = 0; i < N; ++i) {
+    auto b = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    pushed_ids.insert(b->get_batch_id());
+    in_repo->add_data_batch(b);
+  }
+
+  for (int i = 0; i < N; ++i)
+    run_cycle(*op, stream);
+  op->finalize_operator();
+
+  std::set<uint64_t> got_ids;
+  while (true) {
+    auto h = out_ch->try_pop();
+    if (!h) break;
+    REQUIRE(pushed_ids.count(h->batch_id) == 1u);
+    REQUIRE(got_ids.insert(h->batch_id).second);  // no duplicates
+  }
+  REQUIRE(got_ids == pushed_ids);
+}
+
+TEST_CASE("streaming_sink lifecycle: spill-while-queued — content intact after re-upgrade",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto* host_space =
+    const_cast<cucascade::memory::memory_space*>(mem_mgr->get_memory_space(Tier::HOST, 0));
+  if (!host_space) {
+    auto hs = mem_mgr->get_memory_spaces_for_tier(Tier::HOST);
+    REQUIRE_FALSE(hs.empty());
+    host_space = const_cast<cucascade::memory::memory_space*>(hs.front());
+  }
+  REQUIRE(host_space != nullptr);
+
+  rmm::cuda_stream conv_stream;
+  auto& registry = sirius::converter_registry::get();
+
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink();
+  auto in_repo                = wire_input_port(*op);
+
+  std::vector<int32_t> values{7, 8, 9};
+  auto batch = make_numeric_batch<int32_t>(*gpu_space, values, cudf::type_id::INT32);
+  in_repo->add_data_batch(batch);
+
+  run_cycle(*op, stream);
+
+  // Downgrade the batch in the output repo while its handle waits in the channel.
+  {
+    auto mut = batch->to_mutable();
+    mut.convert_to<cucascade::host_data_representation>(registry, host_space, conv_stream);
+  }
+  {
+    auto ro = batch->to_read_only();
+    REQUIRE(ro.get_data()->get_current_tier() == Tier::HOST);
+  }
+
+  // Consumer resolves the handle from the channel.
+  auto h = out_ch->try_pop();
+  REQUIRE(h.has_value());
+  auto resolved = out_repo->pop_data_batch_by_id(h->batch_id);
+  REQUIRE(resolved != nullptr);
+
+  // Restore to GPU and verify content.
+  {
+    auto pod2 =
+      pipelineable_operator_data{std::vector<std::shared_ptr<cucascade::data_batch>>{resolved}};
+    pod2.prepare_for_processing(gpu_space, conv_stream);
+    auto out2 = op->execute(pod2, conv_stream);
+
+    auto& out_batches = static_cast<pipelineable_operator_data&>(*out2).get_data_batches();
+    REQUIRE(out_batches.size() == 1u);
+    auto view   = sirius::get_cudf_table_view(*out_batches[0]);
+    auto result = copy_column_to_host<int32_t>(view.column(0));
+    REQUIRE(result == values);
+  }
+}
+
+TEST_CASE("streaming_sink lifecycle: null constructor inputs are rejected", "[streaming_sink]")
+{
+  auto types =
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER});
+  auto out_ch   = std::make_shared<exchange_channel>(exchange_channel::config{16});
+  auto out_repo = std::make_shared<cucascade::shared_data_repository>();
+
+  REQUIRE_THROWS_AS(sirius_physical_streaming_sink(types, 0, nullptr, out_repo),
+                    sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(sirius_physical_streaming_sink(types, 0, out_ch, nullptr),
+                    sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// 7.4  Integration with neighbor operators
+// ============================================================================
+
+TEST_CASE("streaming_sink integration: push_data_batch wires into input port repo",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, out_ch, out_repo] = make_sink();
+  auto in_repo                = wire_input_port(*op);
+
+  // Push a batch directly into the sink's input port (mirrors what the upstream
+  // pipeline does via the base-class push_data_batch path).
+  auto batch   = make_numeric_batch<int32_t>(*gpu_space, {42}, cudf::type_id::INT32);
+  uint64_t bid = batch->get_batch_id();
+  op->push_data_batch(sirius_physical_streaming_sink::INPUT_PORT, batch);
+
+  // The batch should now be in the sink's input port repo.
+  auto ids = in_repo->get_batch_ids(0);
+  REQUIRE(ids.size() == 1u);
+  REQUIRE(ids[0] == bid);
+
+  // Hint should flip to READY.
+  auto hint = op->get_next_task_hint();
+  REQUIRE(hint.has_value());
+  REQUIRE(hint->hint == TaskCreationHint::READY);
+}
+
+TEST_CASE("streaming_sink integration: full boundary cycle preserves pointer identity",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink();
+  auto in_repo                = wire_input_port(*op);
+
+  auto batch       = make_numeric_batch<int32_t>(*gpu_space, {1, 2, 3}, cudf::type_id::INT32);
+  uint64_t orig_id = batch->get_batch_id();
+  op->push_data_batch(sirius_physical_streaming_sink::INPUT_PORT, batch);
+
+  run_cycle(*op, stream);  // input-data → execute → sink
+
+  // The handle on the channel must carry the same batch_id.
+  auto h = out_ch->try_pop();
+  REQUIRE(h.has_value());
+  REQUIRE(h->batch_id == orig_id);
+}
+
+TEST_CASE("streaming_sink integration: filter output flows through sink to channel",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink();
+
+  // Build a two-column input: col0 = filter key (int64), col1 = int32 payload.
+  std::vector<int64_t> filter_col{1, 5, 2, 8, 3};
+  std::vector<int32_t> data_col{10, 50, 20, 80, 30};
+  auto batch =
+    make_two_column_batch<int64_t, int32_t>(*gpu_space, filter_col, data_col, cudf::type_id::INT32);
+
+  // Build filter: col0 > 3 (BIGINT). Expected output: {5,8} → {50,80}.
+  auto filter_expr = duckdb::make_uniq<duckdb::BoundComparisonExpression>(
+    duckdb::ExpressionType::COMPARE_GREATERTHAN,
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(
+      duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), 0),
+    duckdb::make_uniq<duckdb::BoundConstantExpression>(duckdb::Value::BIGINT(3)));
+  auto filter_ast = sirius::ast::from_duckdb(*filter_expr);
+
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  sirius_physical_filter filter_op(sirius::from_duckdb_vec(types), std::move(filter_ast), 0);
+
+  // Re-wire the sink's input port to accept two-column batches.
+  auto in_repo     = std::make_unique<cucascade::shared_data_repository>();
+  auto p           = std::make_unique<sirius_physical_operator::port>();
+  p->type          = MemoryBarrierType::FULL;
+  p->repo          = in_repo.get();
+  p->src_pipeline  = nullptr;
+  p->dest_pipeline = nullptr;
+  op->add_port(std::string(sirius_physical_streaming_sink::INPUT_PORT), std::move(p));
+
+  // Run filter, feed output into sink.
+  pipelineable_operator_data filter_input{
+    std::vector<std::shared_ptr<cucascade::data_batch>>{batch}};
+  auto filter_output = filter_op.execute(filter_input, stream);
+  REQUIRE(filter_output != nullptr);
+
+  // Manually put the filter output into the sink's input port.
+  auto& filter_batches =
+    static_cast<pipelineable_operator_data&>(*filter_output).get_data_batches();
+  REQUIRE(filter_batches.size() == 1u);
+  in_repo->add_data_batch(filter_batches[0]);
+
+  run_cycle(*op, stream);
+
+  auto h = out_ch->try_pop();
+  REQUIRE(h.has_value());
+  auto resolved = out_repo->pop_data_batch_by_id(h->batch_id);
+  REQUIRE(resolved != nullptr);
+
+  auto view       = sirius::get_cudf_table_view(*resolved);
+  auto res_filter = copy_column_to_host<int64_t>(view.column(0));
+  auto res_data   = copy_column_to_host<int32_t>(view.column(1));
+  REQUIRE(res_filter == std::vector<int64_t>{5, 8});
+  REQUIRE(res_data == std::vector<int32_t>{50, 80});
+}
+
+TEST_CASE("streaming_sink integration: mid-stream backpressure stalls and resumes",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream = default_stream();
+  // capacity=3: sink 3 → fill, drain all 3, resume with 2 remaining (both fit).
+  auto [op, out_ch, out_repo] = make_sink(/*capacity=*/3);
+  auto in_repo                = wire_input_port(*op);
+
+  constexpr int STALL_AT = 3;
+  constexpr int TOTAL    = 5;
+  std::vector<uint64_t> ids;
+  for (int i = 0; i < TOTAL; ++i) {
+    auto b = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    ids.push_back(b->get_batch_id());
+    in_repo->add_data_batch(b);
+  }
+
+  // Sink STALL_AT batches → fills the channel.
+  for (int i = 0; i < STALL_AT; ++i)
+    run_cycle(*op, stream);
+  REQUIRE(out_ch->full());
+
+  // Hint must be WAITING (stalled); get_next_task_input_data must return nullptr.
+  {
+    auto hint = op->get_next_task_hint();
+    REQUIRE(hint.has_value());
+    REQUIRE(hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+    REQUIRE(hint->producer == nullptr);
+  }
+  REQUIRE(op->get_next_task_input_data() == nullptr);
+
+  // Drain all → frees all slots.
+  auto drained = drain_channel(*out_ch, *out_repo);
+  REQUIRE(drained.size() == static_cast<std::size_t>(STALL_AT));
+
+  // Resume: sink remaining 2 batches (TOTAL - STALL_AT = 2 < capacity, so no stall).
+  for (int i = 0; i < TOTAL - STALL_AT; ++i)
+    run_cycle(*op, stream);
+
+  op->finalize_operator();
+  auto rest = drain_channel(*out_ch, *out_repo);
+  REQUIRE(rest.size() == static_cast<std::size_t>(TOTAL - STALL_AT));
+}
+
+// ============================================================================
+// 7.5  Concurrency
+// ============================================================================
+
+TEST_CASE("streaming_sink concurrency: concurrent sink calls preserve conservation",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr int K             = 40;
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink(K);
+  auto in_repo                = wire_input_port(*op);
+
+  // Prepare K batches.
+  std::vector<std::shared_ptr<cucascade::data_batch>> batches;
+  batches.reserve(K);
+  for (int i = 0; i < K; ++i) {
+    auto b = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    batches.push_back(b);
+  }
+
+  // Two threads, each calling sink() on K/2 batches concurrently.
+  std::atomic<int> thread_idx{0};
+  auto worker = [&] {
+    int start = thread_idx.fetch_add(K / 2, std::memory_order_relaxed);
+    for (int i = start; i < start + K / 2; ++i)
+      CHECK_NOTHROW(sink_batch(*op, batches[i], stream));
+  };
+
+  std::thread t1(worker);
+  std::thread t2(worker);
+  t1.join();
+  t2.join();
+
+  // Flush any remaining pending handles.
+  op->try_flush_pending();
+  op->finalize_operator();
+
+  // Conservation: all K batches must appear in the output, none duplicated.
+  std::set<uint64_t> expected_ids;
+  for (auto& b : batches)
+    expected_ids.insert(b->get_batch_id());
+
+  std::set<uint64_t> got_ids;
+  while (true) {
+    auto h = out_ch->try_pop();
+    if (!h) break;
+    CHECK(got_ids.insert(h->batch_id).second);  // no duplicates
+  }
+  CHECK(got_ids == expected_ids);
+}
+
+TEST_CASE("streaming_sink concurrency: producer/consumer/flush race terminates and conserves",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr int K             = 30;
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink(/*capacity=*/4);
+  auto in_repo                = wire_input_port(*op);
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> batches;
+  batches.reserve(K);
+  for (int i = 0; i < K; ++i) {
+    auto b = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    batches.push_back(b);
+  }
+
+  std::atomic<int> sunk{0};
+
+  // Producer: sink all K batches.
+  std::thread producer([&] {
+    for (int i = 0; i < K; ++i) {
+      CHECK_NOTHROW(sink_batch(*op, batches[i], stream));
+      sunk.fetch_add(1, std::memory_order_release);
+    }
+  });
+
+  // Consumer: drain channel continuously until finalized and drained.
+  // Also calls try_flush_pending() when the channel is empty — once finalize_operator()
+  // sets _close_when_flushed, the next try_flush_pending() call will close the channel.
+  std::set<uint64_t> consumed_ids;
+  std::mutex consume_mutex;
+  std::thread consumer([&] {
+    while (!out_ch->drained()) {
+      auto h = out_ch->try_pop();
+      if (!h) {
+        op->try_flush_pending();  // help deliver any pending handles and close when done
+        std::this_thread::yield();
+        continue;
+      }
+      std::lock_guard<std::mutex> lk(consume_mutex);
+      CHECK(consumed_ids.insert(h->batch_id).second);
+    }
+  });
+
+  // Flusher: periodically call try_flush_pending.
+  std::thread flusher([&] {
+    while (sunk.load(std::memory_order_acquire) < K) {
+      op->try_flush_pending();
+      std::this_thread::yield();
+    }
+    op->try_flush_pending();
+  });
+
+  producer.join();
+  flusher.join();
+
+  op->finalize_operator();
+  consumer.join();
+
+  // All K handles must be consumed, no duplicates.
+  std::set<uint64_t> expected_ids;
+  for (auto& b : batches)
+    expected_ids.insert(b->get_batch_id());
+  CHECK(consumed_ids == expected_ids);
+  CHECK(out_ch->drained());
+}

--- a/test/cpp/operator/test_physical_streaming_sink.cpp
+++ b/test/cpp/operator/test_physical_streaming_sink.cpp
@@ -617,6 +617,92 @@ TEST_CASE("streaming_sink lifecycle: sink() after finalize throws and leaves no 
   REQUIRE(out_ch->drained());
 }
 
+TEST_CASE("streaming_sink lifecycle: on_close re-entering the sink does not deadlock (finalize)",
+          "[streaming_sink]")
+{
+  auto [op, out_ch, out_repo] = make_sink();
+  auto in_repo                = wire_input_port(*op);
+
+  // finalize_operator() closes the channel; close() fires this callback synchronously, so it
+  // must run outside _pending_lock or the re-entrant try_flush_pending() self-deadlocks.
+  bool reentered = false;
+  out_ch->set_on_close([&] {
+    reentered = true;
+    op->try_flush_pending();
+  });
+
+  op->finalize_operator();
+  REQUIRE(reentered);
+  REQUIRE(out_ch->closed());
+}
+
+TEST_CASE(
+  "streaming_sink lifecycle: on_close re-entering the sink does not deadlock (deferred close)",
+  "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink(/*capacity=*/1);
+  auto in_repo                = wire_input_port(*op);
+
+  auto b1 = make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32);
+  auto b2 = make_numeric_batch<int32_t>(*gpu_space, {2}, cudf::type_id::INT32);
+  sink_batch(*op, b1, stream);
+  sink_batch(*op, b2, stream);  // b2 → _pending
+  op->finalize_operator();      // close deferred: b2 still pending
+
+  // The deferred close fires from inside try_flush_pending(); the callback re-enters it.
+  out_ch->set_on_close([&] { op->try_flush_pending(); });
+
+  REQUIRE(out_ch->try_pop().has_value());  // free the slot
+  op->try_flush_pending();                 // delivers b2, closes, callback re-enters
+  REQUIRE(out_ch->closed());
+}
+
+TEST_CASE("streaming_sink lifecycle: stalled consumer — _pending grows with the burst size",
+          "[streaming_sink]")
+{
+  // Characterizes the documented caveat: sink tasks created ahead of execution can park
+  // input-many handles while the consumer stalls; every batch stays registered and
+  // spill-visible, and all are delivered once the consumer resumes. Pacing task creation
+  // against completion (the structural bound) is the session wiring's job (#839).
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr int N             = 12;
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink(/*capacity=*/2);
+  auto in_repo                = wire_input_port(*op);
+
+  std::set<uint64_t> expected_ids;
+  for (int i = 0; i < N; ++i) {
+    auto b = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    expected_ids.insert(b->get_batch_id());
+    sink_batch(*op, b, stream);  // models an already-created task executing against the stall
+  }
+
+  REQUIRE(out_ch->size() == 2u);         // channel holds capacity
+  REQUIRE(out_repo->total_size() == N);  // all N registered; N-2 parked in _pending
+
+  op->finalize_operator();  // close deferred behind the backlog
+
+  std::set<uint64_t> got_ids;
+  while (!out_ch->drained()) {
+    auto h = out_ch->try_pop();
+    if (!h) {
+      op->try_flush_pending();
+      continue;
+    }
+    got_ids.insert(h->batch_id);
+    out_repo->pop_data_batch_by_id(h->batch_id);
+  }
+  REQUIRE(got_ids == expected_ids);
+}
+
 TEST_CASE("streaming_sink lifecycle: conservation across randomized run", "[streaming_sink]")
 {
   auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();

--- a/test/cpp/operator/test_physical_streaming_sink.cpp
+++ b/test/cpp/operator/test_physical_streaming_sink.cpp
@@ -41,6 +41,7 @@
 #include <mutex>
 #include <set>
 #include <thread>
+#include <tuple>
 #include <vector>
 
 using namespace sirius::exec;

--- a/test/cpp/operator/test_physical_streaming_sink.cpp
+++ b/test/cpp/operator/test_physical_streaming_sink.cpp
@@ -594,6 +594,29 @@ TEST_CASE("streaming_sink lifecycle: empty stream finalized closes channel with 
   REQUIRE_FALSE(h.has_value());
 }
 
+TEST_CASE("streaming_sink lifecycle: sink() after finalize throws and leaves no orphan",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream                 = default_stream();
+  auto [op, out_ch, out_repo] = make_sink();
+  auto in_repo                = wire_input_port(*op);
+
+  op->finalize_operator();  // nothing pending → sets _closing and closes the channel
+  REQUIRE(out_ch->closed());
+
+  // A late sink() must throw instead of stranding the handle behind the closed channel.
+  auto late = make_numeric_batch<int32_t>(*gpu_space, {42}, cudf::type_id::INT32);
+  REQUIRE_THROWS_AS(sink_batch(*op, late, stream), sirius::internal_exception);
+
+  // The rejected batch is not orphaned in the repo and nothing entered the channel.
+  REQUIRE(out_repo->total_size() == 0);
+  REQUIRE(out_ch->drained());
+}
+
 TEST_CASE("streaming_sink lifecycle: conservation across randomized run", "[streaming_sink]")
 {
   auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();


### PR DESCRIPTION
PR 2 of 2 for #836 (source: #1094). Adds the streaming sink operator. 

## What

- `sirius::op::sirius_physical_streaming_sink` — boundary operator (source+sink) heading its own pipeline: pops batches from its input port, registers them in the output repository, pushes `{batch_id, size_bytes}` handles to the exchange channel; closes the channel at pipeline finish.

## Design notes

- Zero-copy: the repository stays owner of record; no host clone, no `ColumnDataCollection` — queued batches remain idle and spillable.
- Backpressure is a task-creation condition: a full channel makes the hint report not-ready; `sink()` on a full channel parks the handle in a pending queue and never blocks a worker.
- EOS: finalize flushes what fits and closes immediately, or defers the close until consumer pops drain the pending queue.
- Known gap, deferred to #839: sink re-arm on consumer pop is owned by the session wiring, not the operator.

## Testing

- `[streaming_sink]` (GPU): hint/admission gating, zero-copy identity, full-channel fallback, flush-then-close EOS (immediate/deferred/empty), spill-while-queued, upstream-operator integration, mid-stream backpressure, concurrency conservation, input validation.