### PR TITLE
feat(transparent): execution-time fallback to DuckDB CPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,6 +592,7 @@ set(TEST_SOURCES
     test/cpp/integration/test_pin_table_column_order.cpp
     test/cpp/integration/test_pin_table_mvcc_foundation.cpp
     test/cpp/integration/test_table_gpu_cache_warm_mgpu.cpp
+    test/cpp/integration/test_transparent_runtime_fallback.cpp
     test/cpp/io/s3/test_sigv4.cpp
     test/cpp/io/s3/test_s3_default_visibility_guard.cpp
     test/cpp/io/s3/test_sirius_sigv4_authorizer.cpp

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -429,7 +429,7 @@ SET enable_dynamic_zone_map_filter = false;
 |----------|---------|-------------|
 | `print_gpu_table_max_rows` | - | Max rows to print in debug output |
 | `enable_fallback_check` | - | Enable fallback validation |
-| `enable_duckdb_fallback` | true | Fall back to DuckDB CPU on Sirius errors. Matches the legacy `gpu_processing` path. Set to `false` to surface Sirius errors instead of silently falling back. |
+| `enable_duckdb_fallback` | true | Fall back to DuckDB CPU execution on Sirius errors. Gates both plan-time fallback (unsupported operator/type) and runtime fallback (GPU execution failure) on the transparent path, plus the legacy `CALL gpu_execution(...)` path. Set to `false` to surface Sirius errors instead of falling back. The default is seeded from the `sirius.enable_duckdb_fallback` YAML key; a per-session `SET` overrides it. |
 | `enable_regex_jit_impl` | - | Use JIT regex implementation |
 
 ## Legacy Config Flags

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -429,7 +429,7 @@ SET enable_dynamic_zone_map_filter = false;
 |----------|---------|-------------|
 | `print_gpu_table_max_rows` | - | Max rows to print in debug output |
 | `enable_fallback_check` | - | Enable fallback validation |
-| `enable_duckdb_fallback` | true | Fall back to DuckDB CPU execution on Sirius errors. Gates both plan-time fallback (unsupported operator/type) and runtime fallback (GPU execution failure) on the transparent path, plus the legacy `CALL gpu_execution(...)` path. Set to `false` to surface Sirius errors instead of falling back. The default is seeded from the `sirius.enable_duckdb_fallback` YAML key; a per-session `SET` overrides it. |
+| `enable_duckdb_fallback` | true | Fall back to DuckDB CPU execution on Sirius errors. Gates both plan-time fallback (unsupported operator/type) and runtime fallback (GPU execution failure) on the transparent path, plus the legacy `CALL gpu_execution(...)` path. Set to `false` to surface Sirius errors instead of falling back. |
 | `enable_regex_jit_impl` | - | Use JIT regex implementation |
 
 ## Legacy Config Flags

--- a/docs/super-sirius/execution-flow.md
+++ b/docs/super-sirius/execution-flow.md
@@ -25,8 +25,8 @@ DuckDB's optimizer calls two Sirius hooks registered via `OptimizerExtension`:
 3. **OnFinalizePrepare** (`SiriusContext::OnFinalizePrepare`): After DuckDB generates its CPU physical plan, this hook:
    - Retrieves the stored logical plan copy
    - Calls `sirius_physical_plan_generator::create_plan()` — the single source of truth for GPU support
-   - If successful, creates a `PhysicalSiriusExecution` operator (a DuckDB `PhysicalOperator` subclass) and replaces `prepared.physical_plan`
-   - If `create_plan()` throws (unsupported operator/type), the CPU plan remains — silent fallback
+   - If successful, stashes DuckDB's CPU physical plan (kept for runtime fallback) and replaces `prepared.physical_plan` with a `PhysicalSiriusExecution` operator (a DuckDB `PhysicalOperator` subclass)
+   - If `create_plan()` throws (unsupported operator/type), the CPU plan is left in place — plan-time fallback. When `enable_duckdb_fallback` is false the error is surfaced instead of silently running on CPU.
 
 4. DuckDB's executor runs `PhysicalSiriusExecution::GetData()`, which delegates to the Sirius GPU engine (Step 3 below).
 
@@ -47,6 +47,8 @@ This path is still supported but is no longer the primary way to use Sirius.
 **File:** `src/transparent/physical_sirius_execution.cpp`
 
 For transparent execution, DuckDB's executor calls `PhysicalSiriusExecution::GetData()` which lazily triggers the Sirius GPU engine on the first call. It creates a `sirius_interface`, wraps the Sirius physical plan in a `sirius_prepared_statement_data`, and calls `sirius_execute_query()`.
+
+If GPU execution fails at runtime (and `enable_duckdb_fallback` is true), the operator runs the stashed DuckDB CPU plan on a private `duckdb::Executor` bound to the same `ClientContext` — so the fallback executes under the same transaction and MVCC snapshot as the failed attempt, including that transaction's own uncommitted writes. The GPU result is fully materialized before any row is emitted, so the fallback cannot duplicate rows. S3-reading queries have no CPU path and surface a clear error instead of falling back. A `runtime_fallbacks` counter and a WARN log record each occurrence.
 
 ## Step 3: Query Lifecycle Setup
 
@@ -189,7 +191,9 @@ If any task throws an exception during execution:
    - Drains the task queue
    - Calls `drain_and_wait()` on the GPU executors
    - Restarts the task creator for the next query
-3. The error propagates through the future to the main thread
+3. The error propagates through the future to the main thread, surfacing as an error-carrying result at `PhysicalSiriusExecution::GetData()`
+
+On the transparent path, that error triggers the runtime CPU fallback described in Step 2 (unless `enable_duckdb_fallback` is false, the error is a user interrupt, or the query reads S3). The fallback runs the stashed DuckDB CPU plan in the same transaction, so a runtime GPU failure completes on CPU rather than failing the query.
 
 ## Sequence Diagram
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -35,8 +35,6 @@ uint64_t Config::PRINT_GPU_TABLE_MAX_ROWS = 1000;
 
 bool Config::ENABLE_FALLBACK_CHECK = false;
 
-bool Config::ENABLE_DUCKDB_FALLBACK = true;
-
 bool Config::ENABLE_REGEX_JIT_IMPL = true;
 
 bool Config::MODIFIED_PIPELINE = false;

--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -60,9 +60,6 @@ struct Config {
   // Whether to use modified pipeline for the new execution model
   static bool MODIFIED_PIPELINE;
 
-  // Whether to fall back to duckdb execution after an error is detected
-  static bool ENABLE_DUCKDB_FALLBACK;
-
   // For duckdb scan task:
   //  - the default batch size
   //  - the default varchar size for estimating rows per batch

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -67,6 +67,10 @@ class SiriusContext : public ClientContextState {
     uint64_t successful_rebinds = 0;
     uint64_t fallbacks          = 0;
     uint64_t executions         = 0;
+    // GPU execution was attempted and failed at runtime, and the query completed
+    // via DuckDB CPU fallback (same transaction). Distinct from `fallbacks`, which
+    // counts plan-time (create_plan) fallbacks that never reached the GPU.
+    uint64_t runtime_fallbacks = 0;
   };
 
   SiriusContext();
@@ -301,6 +305,10 @@ class SiriusContext : public ClientContextState {
   /// \brief Record that a transparently rebound query actually executed through Sirius.
   void record_transparent_execution() noexcept;
 
+  /// \brief Record that a GPU execution failed at runtime and the query completed
+  /// via DuckDB CPU fallback (same transaction).
+  void record_transparent_runtime_fallback() noexcept;
+
  private:
   void throw_if_not_initialized() const;
   void acquire_query_lifecycle_slot();
@@ -370,6 +378,7 @@ class SiriusContext : public ClientContextState {
   std::atomic<uint64_t> transparent_rebind_success_count_{0};
   std::atomic<uint64_t> transparent_fallback_count_{0};
   std::atomic<uint64_t> transparent_execution_count_{0};
+  std::atomic<uint64_t> transparent_runtime_fallback_count_{0};
 };
 
 /// todo(amin): when duckdb is updated, we need to enable OnExtensionLoaded to support sirius
@@ -402,5 +411,18 @@ class SiriusContextExtensionCallback : public ExtensionCallback {
   sirius::sirius_config config_;
   duckdb::shared_ptr<SiriusContext> context_;
 };
+
+/// \brief Read the per-session `enable_duckdb_fallback` setting (default true).
+///
+/// Gates both plan-time and runtime fallback from GPU to DuckDB CPU. Set per
+/// connection via `SET enable_duckdb_fallback = ...`.
+bool duckdb_fallback_enabled(ClientContext& context);
+
+/// \brief Print the "GPU execution failed, falling back to DuckDB" banner.
+///
+/// Written to stdout in red (ANSI) when stdout is a TTY, plain text otherwise so
+/// piped/redirected output is not corrupted. Shared by the transparent runtime
+/// fallback and the legacy gpu_execution() CALL path so the message stays in sync.
+void print_cpu_fallback_banner();
 
 }  // namespace duckdb

--- a/src/include/transparent/physical_sirius_execution.hpp
+++ b/src/include/transparent/physical_sirius_execution.hpp
@@ -22,6 +22,10 @@
 #include <duckdb/execution/physical_operator.hpp>
 #include <duckdb/planner/logical_operator.hpp>
 
+namespace duckdb {
+class PreparedStatementData;
+}  // namespace duckdb
+
 namespace sirius::transparent {
 
 /// \brief A DuckDB PhysicalOperator that transparently wraps Sirius GPU execution.
@@ -41,6 +45,8 @@ class PhysicalSiriusExecution : public duckdb::PhysicalOperator {
                           std::string query_sql,
                           duckdb::vector<duckdb::LogicalType> types,
                           duckdb::vector<std::string> names,
+                          duckdb::shared_ptr<duckdb::PreparedStatementData> cpu_fallback_prepared,
+                          bool cpu_plan_reads_s3,
                           duckdb::idx_t estimated_cardinality);
 
   // Source operator interface
@@ -76,6 +82,18 @@ class PhysicalSiriusExecution : public duckdb::PhysicalOperator {
 
   /// Output column names (needed for result construction).
   duckdb::vector<std::string> result_names_;
+
+  /// DuckDB's CPU physical plan, wrapped in a minimal PreparedStatementData and
+  /// stashed at OnFinalizePrepare before this operator replaced it. On a GPU
+  /// execution failure, GetDataInternal runs it on a private duckdb::Executor bound
+  /// to the same ClientContext (same transaction/MVCC snapshot). shared_ptr so the
+  /// const source state can keep it alive across the nested run.
+  duckdb::shared_ptr<duckdb::PreparedStatementData> cpu_fallback_prepared_;
+
+  /// Whether the CPU fallback plan reads s3:// data. S3 is GPU-only (DuckDB's CPU
+  /// read_parquet cannot serve Sirius-owned s3://), so a runtime GPU failure on an
+  /// s3 query surfaces a clear error instead of falling back to CPU.
+  bool cpu_plan_reads_s3_ = false;
 };
 
 }  // namespace sirius::transparent

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -52,9 +52,11 @@
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/spdlog.h>
 #include <sys/resource.h>
+#include <unistd.h>  // for isatty/fileno
 
 #include <cctype>
 #include <cstddef>
+#include <cstdio>   // for fprintf/fileno (fallback banner)
 #include <cstdlib>  // for std::getenv
 #include <filesystem>
 #include <memory>
@@ -759,6 +761,7 @@ SiriusContext::transparent_execution_stats SiriusContext::get_transparent_execut
     .successful_rebinds = transparent_rebind_success_count_.load(std::memory_order_relaxed),
     .fallbacks          = transparent_fallback_count_.load(std::memory_order_relaxed),
     .executions         = transparent_execution_count_.load(std::memory_order_relaxed),
+    .runtime_fallbacks  = transparent_runtime_fallback_count_.load(std::memory_order_relaxed),
   };
 }
 
@@ -775,6 +778,11 @@ void SiriusContext::record_transparent_fallback() noexcept
 void SiriusContext::record_transparent_execution() noexcept
 {
   transparent_execution_count_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void SiriusContext::record_transparent_runtime_fallback() noexcept
+{
+  transparent_runtime_fallback_count_.fetch_add(1, std::memory_order_relaxed);
 }
 
 namespace {
@@ -821,7 +829,42 @@ void throw_if_s3_no_cpu_fallback(bool plan_reads_s3,
   }
 }
 
+// With enable_duckdb_fallback off, surface a GPU plan-generation failure as a
+// normal query error. Sanitize INTERNAL/FATAL (which would invalidate the whole
+// database) to ExecutorException; keep other exception types as-is.
+[[noreturn]] void rethrow_gpu_error_no_fallback(std::exception& e, const std::string& prefix)
+{
+  duckdb::ErrorData err(e);
+  if (err.Type() == duckdb::ExceptionType::INTERNAL || err.Type() == duckdb::ExceptionType::FATAL) {
+    throw duckdb::ExecutorException(prefix + err.RawMessage());
+  }
+  err.Throw(prefix);
+}
+
 }  // namespace
+
+bool duckdb_fallback_enabled(ClientContext& context)
+{
+  Value setting;
+  if (context.TryGetCurrentSetting("enable_duckdb_fallback", setting) && !setting.IsNull()) {
+    return setting.GetValue<bool>();
+  }
+  return true;
+}
+
+void print_cpu_fallback_banner()
+{
+  const bool tty  = ::isatty(::fileno(stdout)) != 0;
+  const char* red = tty ? "\033[1;31m" : "";
+  const char* off = tty ? "\033[0m" : "";
+  std::fprintf(stdout,
+               "%s=============================================\n"
+               "Error in Sirius GPU execution, fallback to DuckDB\n"
+               "=============================================%s\n",
+               red,
+               off);
+  std::fflush(stdout);
+}
 
 RebindQueryInfo SiriusContext::OnFinalizePrepare(ClientContext& context,
                                                  PreparedStatementData& prepared,
@@ -883,11 +926,17 @@ RebindQueryInfo SiriusContext::OnFinalizePrepare(ClientContext& context,
       // No captured plan to inspect on the replan path; guard on the SQL text so
       // a direct read_parquet('s3://') that fails to re-plan does not CPU-fall-back.
       throw_if_s3_no_cpu_fallback(false, current_query_sql, e.what());
+      if (!duckdb_fallback_enabled(context)) {
+        rethrow_gpu_error_no_fallback(e, "GPU plan generation failed: ");
+      }
       record_transparent_fallback();
       SIRIUS_LOG_INFO("Transparent execution fallback (replan unsupported): {}", e.what());
       return RebindQueryInfo::DO_NOT_REBIND;
     } catch (std::exception& e) {
       throw_if_s3_no_cpu_fallback(false, current_query_sql, e.what());
+      if (!duckdb_fallback_enabled(context)) {
+        rethrow_gpu_error_no_fallback(e, "GPU plan generation failed: ");
+      }
       record_transparent_fallback();
       SIRIUS_LOG_INFO("Transparent execution fallback (replan failed): {}", e.what());
       return RebindQueryInfo::DO_NOT_REBIND;
@@ -933,10 +982,26 @@ RebindQueryInfo SiriusContext::OnFinalizePrepare(ClientContext& context,
 
     SIRIUS_LOG_INFO("Transparent execution: Sirius physical plan generated successfully");
 
+    // Stash DuckDB's CPU plan before overwriting it, wrapped in a minimal
+    // PreparedStatementData. On a runtime GPU failure PhysicalSiriusExecution runs
+    // it on a private Executor in the same transaction. It's collector-free here —
+    // exactly what GetResultCollector expects at execute time.
+    auto cpu_fallback   = make_shared_ptr<PreparedStatementData>(StatementType::SELECT_STATEMENT);
+    cpu_fallback->types = prepared.types;
+    cpu_fallback->names = prepared.names;
+    cpu_fallback->properties    = prepared.properties;
+    cpu_fallback->physical_plan = std::move(prepared.physical_plan);
+
     // Create a new DuckDB PhysicalPlan containing our custom operator.
     auto new_physical_plan = make_uniq<PhysicalPlan>(Allocator::Get(context));
-    auto& sirius_op        = new_physical_plan->Make<sirius::transparent::PhysicalSiriusExecution>(
-      std::move(logical_plan), current_query_sql, prepared.types, prepared.names, 0);
+    auto& sirius_op =
+      new_physical_plan->Make<sirius::transparent::PhysicalSiriusExecution>(std::move(logical_plan),
+                                                                            current_query_sql,
+                                                                            prepared.types,
+                                                                            prepared.names,
+                                                                            std::move(cpu_fallback),
+                                                                            plan_reads_s3,
+                                                                            0);
     new_physical_plan->SetRoot(sirius_op);
 
     // Replace the DuckDB CPU physical plan.
@@ -946,10 +1011,16 @@ RebindQueryInfo SiriusContext::OnFinalizePrepare(ClientContext& context,
     SIRIUS_LOG_INFO("Transparent execution: physical plan replaced with GPU operator");
   } catch (NotImplementedException& e) {
     throw_if_s3_no_cpu_fallback(plan_reads_s3, current_query_sql, e.what());
+    if (!duckdb_fallback_enabled(context)) {
+      rethrow_gpu_error_no_fallback(e, "GPU plan generation failed: ");
+    }
     record_transparent_fallback();
     SIRIUS_LOG_INFO("Transparent execution fallback (unsupported): {}", e.what());
   } catch (std::exception& e) {
     throw_if_s3_no_cpu_fallback(plan_reads_s3, current_query_sql, e.what());
+    if (!duckdb_fallback_enabled(context)) {
+      rethrow_gpu_error_no_fallback(e, "GPU plan generation failed: ");
+    }
     record_transparent_fallback();
     SIRIUS_LOG_INFO("Transparent execution fallback: {}", e.what());
   }

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -117,22 +117,6 @@ constexpr std::string QUERY_LABEL_PARAM_KEY = "query_label";
 
 namespace {
 
-// Read the per-session `enable_duckdb_fallback` setting (default true).  Mirrors
-// how `gpu_execution` is read via ClientContext::TryGetCurrentSetting, so a
-// `SET enable_duckdb_fallback = false` stays scoped to the connection that
-// issued it instead of leaking through a process-global to every other
-// connection (and, across a test binary, to every later test case).  The
-// AddExtensionOption registration already stores the value per-context; only the
-// read had been going through the global static.
-bool duckdb_fallback_enabled(ClientContext& context)
-{
-  Value setting;
-  if (context.TryGetCurrentSetting("enable_duckdb_fallback", setting) && !setting.IsNull()) {
-    return setting.GetValue<bool>();
-  }
-  return true;
-}
-
 unique_ptr<QueryResult> run_internal_cpu_fallback_query(ClientContext& context,
                                                         Connection& connection,
                                                         const string& query,
@@ -643,9 +627,7 @@ void SiriusExtension::GPUExecutionFunction(ClientContext& context,
   if (!data.res) {
     auto start = std::chrono::high_resolution_clock::now();
     if (data.plan_error) {
-      printf(
-        "=============================================\nError in SiriusExecuteQuery, fallback to "
-        "DuckDB\n=============================================\n");
+      print_cpu_fallback_banner();
       data.res = run_internal_cpu_fallback_query(
         context, *data.conn, data.cpu_fallback_query, data.plan_error_message);
     } else {
@@ -654,9 +636,7 @@ void SiriusExtension::GPUExecutionFunction(ClientContext& context,
       if (data.res->HasError()) {
         if (duckdb_fallback_enabled(context)) {
           SIRIUS_LOG_ERROR("SiriusExecuteQuery error: {}", data.res->GetError());
-          printf(
-            "=============================================\nError in SiriusExecuteQuery, fallback "
-            "to DuckDB\n=============================================\n");
+          print_cpu_fallback_banner();
           data.res = run_internal_cpu_fallback_query(
             context, *data.conn, data.cpu_fallback_query, data.res->GetError());
         } else {
@@ -1788,6 +1768,15 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
                            // prior connection's SET may have mutated (that leaked the
                            // fallback policy into every freshly-created database).
     SetEnableDuckdbFallback);
+
+  // TEST ONLY: when non-empty, transparent GPU execution fails at runtime with that
+  // message after plan generation succeeds, to exercise the CPU fallback path. No
+  // setter — the value is read via TryGetCurrentSetting in PhysicalSiriusExecution.
+  config.AddExtensionOption(
+    "sirius_test_inject_transparent_gpu_error",
+    "TEST ONLY: force transparent GPU execution to fail at runtime with this message",
+    LogicalType::VARCHAR,
+    Value(""));
 
   // Add in config options for special JIT implementation for regex
   config.AddExtensionOption(

--- a/src/transparent/physical_sirius_execution.cpp
+++ b/src/transparent/physical_sirius_execution.cpp
@@ -20,10 +20,15 @@
 #include "planner/sirius_physical_plan_generator.hpp"
 #include "sirius_context.hpp"
 #include "sirius_interface.hpp"
+#include "sirius_sql_rewrite.hpp"
 #include "transparent/sirius_optimizer_extension.hpp"
 
 #include <duckdb/common/enums/statement_type.hpp>
+#include <duckdb/execution/executor.hpp>
+#include <duckdb/execution/operator/helper/physical_result_collector.hpp>
+#include <duckdb/main/client_config.hpp>
 #include <duckdb/main/client_context.hpp>
+#include <duckdb/main/pending_query_result.hpp>
 #include <duckdb/main/prepared_statement_data.hpp>
 #include <duckdb/main/query_result.hpp>
 #include <duckdb/optimizer/optimizer.hpp>
@@ -41,9 +46,57 @@ struct SiriusGlobalSourceState : public duckdb::GlobalSourceState {
   duckdb::unique_ptr<duckdb::DataChunk> current_chunk;
   duckdb::SiriusContext* sirius_context = nullptr;
   bool finished                         = false;
+  // Private executor for the CPU fallback plan (see run_cpu_fallback_plan). Kept
+  // alive here so the materialized result's backing pipelines outlive GetData.
+  duckdb::unique_ptr<duckdb::Executor> cpu_executor;
 
   duckdb::idx_t MaxThreads() override { return 1; }
 };
+
+// Run a stored DuckDB CPU plan on a private Executor. Reusing the outer query's
+// ClientContext (not a fresh Connection) keeps it on the same transaction and MVCC
+// snapshot, including this transaction's uncommitted writes. Returns a materialized
+// result; throws if the CPU plan itself fails.
+duckdb::unique_ptr<duckdb::QueryResult> run_cpu_fallback_plan(
+  duckdb::ClientContext& client,
+  duckdb::PreparedStatementData& cpu_prepared,
+  duckdb::unique_ptr<duckdb::Executor>& out_executor)
+{
+  // Force a materialized (non-streaming) result so the whole plan runs before any
+  // row is streamed out of the operator.
+  cpu_prepared.output_type = duckdb::QueryResultOutputType::FORCE_MATERIALIZED;
+  cpu_prepared.memory_type = duckdb::QueryResultMemoryType::IN_MEMORY;
+
+  auto collector = duckdb::PhysicalResultCollector::GetResultCollector(client, cpu_prepared);
+  D_ASSERT(collector->type == duckdb::PhysicalOperatorType::RESULT_COLLECTOR);
+
+  // Suppress profiling for the nested run: it shares the context's single
+  // QueryProfiler with the outer query, so letting it re-initialize would corrupt
+  // the outer profile. No-op when profiling is already off. Restored on every path.
+  auto& client_config              = duckdb::ClientConfig::GetConfig(client);
+  const bool saved_enable_profiler = client_config.enable_profiler;
+  client_config.enable_profiler    = false;
+
+  out_executor   = duckdb::make_uniq<duckdb::Executor>(client);
+  auto& executor = *out_executor;
+  try {
+    executor.Initialize(std::move(collector));
+    duckdb::PendingExecutionResult exec_result;
+    while (!duckdb::PendingQueryResult::IsResultReady(exec_result = executor.ExecuteTask())) {
+      if (exec_result == duckdb::PendingExecutionResult::BLOCKED) { executor.WaitForTask(); }
+    }
+    if (executor.HasError()) { executor.ThrowException(); }
+    auto result                   = executor.GetResult();
+    client_config.enable_profiler = saved_enable_profiler;
+    return result;
+  } catch (...) {
+    // Drain any still-registered tasks before the executor is destroyed
+    // (~Executor asserts executor_tasks == 0), then restore profiling.
+    executor.CancelTasks();
+    client_config.enable_profiler = saved_enable_profiler;
+    throw;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Construction
@@ -54,12 +107,16 @@ PhysicalSiriusExecution::PhysicalSiriusExecution(
   std::string query_sql,
   duckdb::vector<duckdb::LogicalType> types,
   duckdb::vector<std::string> names,
+  duckdb::shared_ptr<duckdb::PreparedStatementData> cpu_fallback_prepared,
+  bool cpu_plan_reads_s3,
   duckdb::idx_t estimated_cardinality)
   : duckdb::PhysicalOperator(
       physical_plan, PhysicalSiriusExecution::TYPE, std::move(types), estimated_cardinality),
     logical_plan_(std::move(logical_plan)),
     query_sql_(std::move(query_sql)),
-    result_names_(std::move(names))
+    result_names_(std::move(names)),
+    cpu_fallback_prepared_(std::move(cpu_fallback_prepared)),
+    cpu_plan_reads_s3_(cpu_plan_reads_s3)
 {
 }
 
@@ -96,70 +153,138 @@ duckdb::SourceResultType PhysicalSiriusExecution::GetDataInternal(
   if (!state.result) {
     SIRIUS_LOG_INFO("Transparent GPU execution: executing query");
     if (state.sirius_context) { state.sirius_context->record_transparent_execution(); }
-    if (!logical_plan_ && query_sql_.empty()) {
-      throw duckdb::InternalException(
-        "Transparent GPU execution is missing the logical plan template");
+
+    // Attempt GPU execution. Any failure — a thrown exception or an error-carrying
+    // result — is captured in gpu_error and routed to the CPU fallback below. The
+    // result is fully materialized before the first Fetch, so falling back here
+    // cannot duplicate rows.
+    duckdb::ErrorData gpu_error;
+    bool gpu_failed = false;
+    try {
+      if (!logical_plan_ && query_sql_.empty()) {
+        throw duckdb::ExecutorException(
+          "Transparent GPU execution is missing the logical plan template");
+      }
+
+      // Build a minimal PreparedStatementData with the output schema.
+      auto prepared = duckdb::make_shared_ptr<duckdb::PreparedStatementData>(
+        duckdb::StatementType::SELECT_STATEMENT);
+      prepared->types = types;
+      prepared->names = result_names_;
+
+      // Rebuild a fresh Sirius physical plan for this execution. DuckDB may reuse
+      // the same prepared physical operator across multiple EXECUTE calls.
+      //
+      // Prefer LogicalOperator::Copy when the plan supports it (cheap deep clone
+      // via serialization). When the plan contains a non-serializable LogicalGet,
+      // fall back to re-parsing + re-binding the unbound SQL statement, which
+      // exercises the same bind path the very first run did.
+      duckdb::unique_ptr<duckdb::LogicalOperator> fresh_plan;
+      if (logical_plan_) {
+        try {
+          // Use the dynamic-filter-aware copy so LogicalComparisonJoin::filter_pushdown and
+          // LogicalGet::dynamic_filters survive the serialize/deserialize round-trip — they are
+          // not in DuckDB's serialization schema and would otherwise be null on the fresh plan,
+          // making downstream Sirius wiring silently miss runtime-computed dynamic filters.
+          fresh_plan = sirius::transparent::copy_logical_plan(*logical_plan_, context.client);
+        } catch (duckdb::NotImplementedException&) {
+          // Drop logical_plan_ — we know it can't be copied, so future executes
+          // will skip straight to the replan path.
+          logical_plan_.reset();
+        }
+      }
+      if (!fresh_plan) {
+        auto sirius_ctx =
+          context.client.registered_state->Get<duckdb::SiriusContext>("sirius_state");
+        duckdb::unique_ptr<duckdb::SiriusContext::InternalQueryGuard> guard;
+        if (sirius_ctx) {
+          guard = duckdb::make_uniq<duckdb::SiriusContext::InternalQueryGuard>(*sirius_ctx);
+        }
+        duckdb::Parser parser(context.client.GetParserOptions());
+        parser.ParseQuery(query_sql_);
+        if (parser.statements.size() != 1) {
+          throw duckdb::ExecutorException(
+            "Transparent GPU execution: replan expected exactly one statement");
+        }
+        duckdb::Planner duckdb_planner(context.client);
+        duckdb_planner.CreatePlan(std::move(parser.statements[0]));
+        duckdb::Optimizer optimizer(*duckdb_planner.binder, context.client);
+        fresh_plan = optimizer.Optimize(std::move(duckdb_planner.plan));
+      }
+      sirius::planner::sirius_physical_plan_generator planner(context.client);
+      auto sirius_plan = planner.create_plan(std::move(fresh_plan));
+
+      auto gpu_prepared = duckdb::make_shared_ptr<sirius::sirius_prepared_statement_data>(
+        std::move(prepared), std::move(sirius_plan));
+
+      // TEST-ONLY fault injection: plan generation has already succeeded, so failing
+      // here exercises the runtime CPU fallback path (not the plan-time path).
+      {
+        duckdb::Value inject;
+        if (context.client.TryGetCurrentSetting("sirius_test_inject_transparent_gpu_error",
+                                                inject) &&
+            !inject.IsNull() && !inject.ToString().empty()) {
+          throw duckdb::ExecutorException("injected transparent GPU failure: " + inject.ToString());
+        }
+      }
+
+      // Execute via the standard sirius_interface path.
+      duckdb::PendingQueryParameters parameters;
+      state.result = state.iface->sirius_execute_query(
+        context.client, "transparent_execution", gpu_prepared, parameters);
+
+      if (state.result->HasError()) {
+        gpu_error = state.result->GetErrorObject();
+        state.result.reset();
+        gpu_failed = true;
+      }
+    } catch (std::exception& e) {
+      gpu_error  = duckdb::ErrorData(e);
+      gpu_failed = true;
     }
 
-    // Build a minimal PreparedStatementData with the output schema.
-    auto prepared = duckdb::make_shared_ptr<duckdb::PreparedStatementData>(
-      duckdb::StatementType::SELECT_STATEMENT);
-    prepared->types = types;
-    prepared->names = result_names_;
+    if (gpu_failed) {
+      const std::string gpu_msg = gpu_error.RawMessage();
+      SIRIUS_LOG_ERROR("Transparent GPU execution error: {}", gpu_msg);
 
-    // Rebuild a fresh Sirius physical plan for this execution. DuckDB may reuse
-    // the same prepared physical operator across multiple EXECUTE calls.
-    //
-    // Prefer LogicalOperator::Copy when the plan supports it (cheap deep clone
-    // via serialization). When the plan contains a non-serializable LogicalGet,
-    // fall back to re-parsing + re-binding the unbound SQL statement, which
-    // exercises the same bind path the very first run did.
-    duckdb::unique_ptr<duckdb::LogicalOperator> fresh_plan;
-    if (logical_plan_) {
-      try {
-        // Use the dynamic-filter-aware copy so LogicalComparisonJoin::filter_pushdown and
-        // LogicalGet::dynamic_filters survive the serialize/deserialize round-trip — they are
-        // not in DuckDB's serialization schema and would otherwise be null on the fresh plan,
-        // making downstream Sirius wiring silently miss runtime-computed dynamic filters.
-        fresh_plan = sirius::transparent::copy_logical_plan(*logical_plan_, context.client);
-      } catch (duckdb::NotImplementedException&) {
-        // Drop logical_plan_ — we know it can't be copied, so future executes
-        // will skip straight to the replan path.
-        logical_plan_.reset();
+      // A user interrupt is never a fallback candidate — propagate it as-is.
+      if (gpu_error.Type() == duckdb::ExceptionType::INTERRUPT) { gpu_error.Throw(); }
+
+      // S3 is GPU-only: DuckDB's CPU read_parquet cannot serve Sirius-owned s3://,
+      // so surface a clear error instead of a fallback that would fail anyway.
+      if (cpu_plan_reads_s3_ || sirius::references_sirius_owned_s3_parquet(query_sql_)) {
+        throw duckdb::ExecutorException(
+          "S3 CPU fallback is not supported: this query reads s3:// data, GPU execution failed, "
+          "and Sirius has no CPU fallback for S3 data sources. Underlying GPU error: " +
+          gpu_msg);
       }
-    }
-    if (!fresh_plan) {
-      auto sirius_ctx = context.client.registered_state->Get<duckdb::SiriusContext>("sirius_state");
-      duckdb::unique_ptr<duckdb::SiriusContext::InternalQueryGuard> guard;
-      if (sirius_ctx) {
-        guard = duckdb::make_uniq<duckdb::SiriusContext::InternalQueryGuard>(*sirius_ctx);
+
+      // Fallback disabled, or no CPU plan stashed: surface the GPU error. Sanitize
+      // INTERNAL/FATAL types (which would invalidate the whole database/session)
+      // down to a plain ExecutorException; preserve other types.
+      if (!cpu_fallback_prepared_ || !duckdb::duckdb_fallback_enabled(context.client)) {
+        if (gpu_error.Type() == duckdb::ExceptionType::INTERNAL ||
+            gpu_error.Type() == duckdb::ExceptionType::FATAL) {
+          throw duckdb::ExecutorException("Sirius GPU execution failed: " + gpu_msg);
+        }
+        gpu_error.Throw("Sirius GPU execution failed: ");
       }
-      duckdb::Parser parser(context.client.GetParserOptions());
-      parser.ParseQuery(query_sql_);
-      if (parser.statements.size() != 1) {
-        throw duckdb::InternalException(
-          "Transparent GPU execution: replan expected exactly one statement");
-      }
-      duckdb::Planner duckdb_planner(context.client);
-      duckdb_planner.CreatePlan(std::move(parser.statements[0]));
-      duckdb::Optimizer optimizer(*duckdb_planner.binder, context.client);
-      fresh_plan = optimizer.Optimize(std::move(duckdb_planner.plan));
-    }
-    sirius::planner::sirius_physical_plan_generator planner(context.client);
-    auto sirius_plan = planner.create_plan(std::move(fresh_plan));
 
-    auto gpu_prepared = duckdb::make_shared_ptr<sirius::sirius_prepared_statement_data>(
-      std::move(prepared), std::move(sirius_plan));
+      // Fall back: run the stored CPU plan on a private executor bound to the same
+      // ClientContext (same transaction / MVCC snapshot).
+      duckdb::print_cpu_fallback_banner();
+      SIRIUS_LOG_WARN(
+        "Transparent execution: GPU execution failed at runtime; falling back to DuckDB CPU "
+        "within the same transaction. GPU error: {}",
+        gpu_msg);
+      if (state.sirius_context) { state.sirius_context->record_transparent_runtime_fallback(); }
 
-    // Execute via the standard sirius_interface path.
-    duckdb::PendingQueryParameters parameters;
-    state.result = state.iface->sirius_execute_query(
-      context.client, "transparent_execution", gpu_prepared, parameters);
-
-    if (state.result->HasError()) {
-      auto error_msg = state.result->GetError();
-      SIRIUS_LOG_ERROR("Transparent GPU execution error: {}", error_msg);
-      throw duckdb::InternalException("Sirius GPU execution failed: " + error_msg);
+      // CpuFallbackGuard marks the replay so sirius_httpfs refuses to serve s3://
+      // reached indirectly (e.g. through a view) to the CPU plan.
+      std::optional<duckdb::SiriusContext::CpuFallbackGuard> fallback_guard;
+      if (state.sirius_context) { fallback_guard.emplace(*state.sirius_context); }
+      state.result =
+        run_cpu_fallback_plan(context.client, *cpu_fallback_prepared_, state.cpu_executor);
     }
 
     SIRIUS_LOG_INFO("Transparent GPU execution: query completed");

--- a/test/cpp/integration/test_transparent_runtime_fallback.cpp
+++ b/test/cpp/integration/test_transparent_runtime_fallback.cpp
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for execution-time (runtime) fallback from GPU to DuckDB CPU on the
+// transparent interception path. GPU failures are forced deterministically via the
+// test-only `sirius_test_inject_transparent_gpu_error` setting, which makes
+// PhysicalSiriusExecution fail *after* plan generation succeeds — i.e. a runtime
+// failure, distinct from a plan-time (create_plan) fallback.
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/main/client_context.hpp>
+#include <unistd.h>  // getpid
+#include <utils/sirius_test_env.hpp>
+#include <utils/transparent_execution_test_utils.hpp>
+
+#include <atomic>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <system_error>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+/// Guard that sets SIRIUS_CONFIG_FILE for the duration of the test.
+struct config_env_guard {
+  explicit config_env_guard(const std::string& path)
+  {
+    if (const char* current = std::getenv("SIRIUS_CONFIG_FILE")) {
+      had_original_value = true;
+      original_value     = current;
+    }
+    setenv("SIRIUS_CONFIG_FILE", path.c_str(), 1);
+  }
+
+  ~config_env_guard()
+  {
+    if (had_original_value) {
+      setenv("SIRIUS_CONFIG_FILE", original_value.c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_CONFIG_FILE");
+    }
+  }
+
+  std::string original_value;
+  bool had_original_value = false;
+};
+
+/// Fixture: a DuckDB connection with Sirius transparent execution enabled. Reuses
+/// the shared integration environment when active, otherwise spins up its own
+/// DuckDB against integration.yaml (same pattern as the transparent-execution
+/// integration suite).
+class RuntimeFallbackFixture {
+ public:
+  RuntimeFallbackFixture()
+  {
+    if (sirius::test::g_integration_env && sirius::test::g_integration_env->is_active()) {
+      con =
+        std::make_unique<duckdb::Connection>(sirius::test::g_integration_env->make_connection());
+    } else {
+      auto cfg_path = fs::path(__FILE__).parent_path() / "integration.yaml";
+      REQUIRE(fs::exists(cfg_path));
+      config_guard = std::make_unique<config_env_guard>(cfg_path.string());
+      db           = std::make_unique<duckdb::DuckDB>(nullptr);
+      con          = std::make_unique<duckdb::Connection>(*db);
+    }
+    con->Query("SET gpu_execution = true;");
+    con->Query("SET enable_duckdb_fallback = true;");
+    clear_injection();
+
+    // Sirius's duckdb-native GPU scan requires a single-file block manager, which
+    // the in-memory catalog does not have. Create tables in a file-backed attached
+    // database (unique per fixture) so queries actually reach GPU execution — a
+    // prerequisite for exercising the *runtime* fallback path.
+    static std::atomic<unsigned> seq{0};
+    alias_   = "rfdb_" + std::to_string(seq.fetch_add(1));
+    db_file_ = fs::temp_directory_path() / (alias_ + "_" + std::to_string(::getpid()) + ".db");
+    std::error_code ec;
+    fs::remove(db_file_, ec);
+    fs::remove(fs::path(db_file_.string() + ".wal"), ec);
+    auto attach = con->Query("ATTACH '" + db_file_.string() + "' AS " + alias_ + ";");
+    REQUIRE_FALSE(attach->HasError());
+    con->Query("USE " + alias_ + ";");
+  }
+
+  ~RuntimeFallbackFixture()
+  {
+    // Reset session state and detach so later tests are unaffected, then remove the
+    // temp database files.
+    if (con) {
+      clear_injection();
+      con->Query("ROLLBACK;");  // no-op if no transaction is open
+      con->Query("USE memory;");
+      con->Query("DETACH " + alias_ + ";");
+    }
+    std::error_code ec;
+    fs::remove(db_file_, ec);
+    fs::remove(fs::path(db_file_.string() + ".wal"), ec);
+  }
+
+  std::unique_ptr<duckdb::Connection> make_connection()
+  {
+    if (sirius::test::g_integration_env && sirius::test::g_integration_env->is_active()) {
+      return std::make_unique<duckdb::Connection>(
+        sirius::test::g_integration_env->make_connection());
+    }
+    REQUIRE(db);
+    return std::make_unique<duckdb::Connection>(*db);
+  }
+
+  // Create a table and CHECKPOINT it so its data lands in on-disk blocks. Sirius's
+  // duckdb-native GPU scan reads committed blocks from the single-file block
+  // manager; freshly created (WAL-resident) rows decode as empty segments on GPU.
+  void create_table(const std::string& create_sql)
+  {
+    auto r = con->Query(create_sql);
+    REQUIRE_FALSE(r->HasError());
+    con->Query("CHECKPOINT;");
+  }
+
+  void inject(duckdb::Connection& c, const std::string& msg = "injected boom")
+  {
+    auto r = c.Query("SET sirius_test_inject_transparent_gpu_error = '" + msg + "';");
+    REQUIRE_FALSE(r->HasError());
+  }
+  void inject(const std::string& msg = "injected boom") { inject(*con, msg); }
+
+  void clear_injection(duckdb::Connection& c)
+  {
+    c.Query("SET sirius_test_inject_transparent_gpu_error = '';");
+  }
+  void clear_injection() { clear_injection(*con); }
+
+  static std::string scalar(duckdb::Connection& c, const std::string& sql)
+  {
+    auto r = c.Query(sql);
+    REQUIRE(r);
+    if (r->HasError()) { UNSCOPED_INFO("query error: " << r->GetError()); }
+    REQUIRE_FALSE(r->HasError());
+    REQUIRE(r->RowCount() == 1);
+    return r->GetValue(0, 0).ToString();
+  }
+
+ protected:
+  std::unique_ptr<config_env_guard> config_guard;
+  std::unique_ptr<duckdb::DuckDB> db;
+  std::unique_ptr<duckdb::Connection> con;
+  std::string alias_;
+  fs::path db_file_;
+};
+
+}  // namespace
+
+// A GPU failure at runtime completes the query on CPU and is counted as a runtime
+// fallback. Without injection the same query runs on the GPU.
+TEST_CASE_METHOD(RuntimeFallbackFixture,
+                 "runtime fallback: basic",
+                 "[transparent][fallback][integration]")
+{
+  create_table("CREATE TABLE rf_basic AS SELECT i AS id, i * 2 AS val FROM range(1000) t(i);");
+  const std::string q = "SELECT count(*) AS n, sum(val) AS s FROM rf_basic WHERE val > 100;";
+
+  // With injection: GPU is attempted (rebind + execution), fails, falls back to CPU.
+  inject();
+  auto before = sirius::test::get_transparent_execution_stats(*con);
+  auto gpu    = con->Query(q);
+  REQUIRE(gpu);
+  REQUIRE_FALSE(gpu->HasError());
+  auto after = sirius::test::get_transparent_execution_stats(*con);
+  sirius::test::require_transparent_execution_delta(before, after, 1, 0, 1, 1);
+
+  // Same query with no injection runs fully on the GPU (no runtime fallback).
+  clear_injection();
+  before    = sirius::test::get_transparent_execution_stats(*con);
+  auto gpu2 = con->Query(q);
+  REQUIRE(gpu2);
+  REQUIRE_FALSE(gpu2->HasError());
+  after = sirius::test::get_transparent_execution_stats(*con);
+  sirius::test::require_transparent_execution_delta(before, after, 1, 0, 1, 0);
+
+  // The fallback result matches the GPU result.
+  REQUIRE(gpu->Cast<duckdb::MaterializedQueryResult>().GetValue(0, 0).ToString() ==
+          gpu2->Cast<duckdb::MaterializedQueryResult>().GetValue(0, 0).ToString());
+}
+
+// The CPU fallback runs in the SAME transaction as the failed GPU attempt, so it
+// sees this transaction's own uncommitted writes. A fresh-connection replay could
+// not (it would start its own transaction) — this is the core MVCC requirement.
+TEST_CASE_METHOD(RuntimeFallbackFixture,
+                 "runtime fallback: sees own uncommitted writes",
+                 "[transparent][fallback][mvcc][integration]")
+{
+  create_table("CREATE TABLE rf_mvcc AS SELECT i AS id FROM range(100) t(i);");
+  inject();
+
+  con->Query("BEGIN TRANSACTION;");
+  con->Query("INSERT INTO rf_mvcc VALUES (100);");  // uncommitted, this transaction
+  // The SELECT falls back to CPU, but under the same transaction — must see 101.
+  REQUIRE(scalar(*con, "SELECT count(*) FROM rf_mvcc;") == "101");
+  con->Query("ROLLBACK;");
+
+  // After rollback the uncommitted row is gone.
+  REQUIRE(scalar(*con, "SELECT count(*) FROM rf_mvcc;") == "100");
+}
+
+// The CPU fallback runs under the failed attempt's snapshot: a concurrent commit
+// made after this transaction pinned its snapshot must stay invisible.
+TEST_CASE_METHOD(RuntimeFallbackFixture,
+                 "runtime fallback: snapshot is stable across a concurrent commit",
+                 "[transparent][fallback][mvcc][integration]")
+{
+  create_table("CREATE TABLE rf_snap AS SELECT i AS id FROM range(100) t(i);");
+  auto other = make_connection();
+
+  inject(*con);
+  con->Query("BEGIN TRANSACTION;");
+  // First read pins this transaction's snapshot at 100 rows (falls back to CPU).
+  REQUIRE(scalar(*con, "SELECT count(*) FROM rf_snap;") == "100");
+
+  // A different connection inserts and commits (qualified: it has not USE'd alias_).
+  auto ins = other->Query("INSERT INTO " + alias_ + ".rf_snap VALUES (1000);");
+  REQUIRE_FALSE(ins->HasError());
+
+  // The in-transaction read still sees the pinned snapshot, not the new commit.
+  REQUIRE(scalar(*con, "SELECT count(*) FROM rf_snap;") == "100");
+  con->Query("COMMIT;");
+
+  // A fresh statement sees the committed row.
+  REQUIRE(scalar(*con, "SELECT count(*) FROM rf_snap;") == "101");
+}
+
+// With enable_duckdb_fallback = false, a runtime GPU failure surfaces as a query
+// error instead of falling back — and, critically, does NOT invalidate the
+// database/session (a bare InternalException would have).
+TEST_CASE_METHOD(RuntimeFallbackFixture,
+                 "runtime fallback: disabled surfaces error without invalidating session",
+                 "[transparent][fallback][integration]")
+{
+  create_table("CREATE TABLE rf_off AS SELECT i AS id FROM range(10) t(i);");
+  con->Query("SET enable_duckdb_fallback = false;");
+  inject("boom-off");
+
+  auto before = sirius::test::get_transparent_execution_stats(*con);
+  auto err    = con->Query("SELECT count(*) FROM rf_off;");
+  REQUIRE(err);
+  REQUIRE(err->HasError());
+  REQUIRE(err->GetError().find("boom-off") != std::string::npos);
+  auto after = sirius::test::get_transparent_execution_stats(*con);
+  // GPU was attempted (rebind + execution) but did not fall back.
+  sirius::test::require_transparent_execution_delta(before, after, 1, 0, 1, 0);
+
+  // The session is still usable: a subsequent query succeeds.
+  clear_injection();
+  con->Query("SET enable_duckdb_fallback = true;");
+  REQUIRE(scalar(*con, "SELECT count(*) FROM rf_off;") == "10");
+}
+
+// enable_duckdb_fallback also gates plan-time fallback: an unsupported operator
+// (window function) errors when fallback is off, and silently runs on CPU when on.
+TEST_CASE_METHOD(RuntimeFallbackFixture,
+                 "runtime fallback: plan-time fallback is gated by the setting",
+                 "[transparent][fallback][integration]")
+{
+  create_table("CREATE TABLE rf_plan AS SELECT i AS id, i % 5 AS grp FROM range(100) t(i);");
+  const std::string window =
+    "SELECT id, grp, ROW_NUMBER() OVER (PARTITION BY grp ORDER BY id) AS rn FROM rf_plan;";
+
+  // Off: unsupported operator surfaces an error instead of silently using CPU.
+  con->Query("SET enable_duckdb_fallback = false;");
+  auto err = con->Query(window);
+  REQUIRE(err);
+  REQUIRE(err->HasError());
+  // Session stays usable.
+  REQUIRE(scalar(*con, "SELECT count(*) FROM rf_plan;") == "100");
+
+  // On: the same query silently falls back at plan time (plan-time fallback + 1).
+  con->Query("SET enable_duckdb_fallback = true;");
+  auto before = sirius::test::get_transparent_execution_stats(*con);
+  auto ok     = con->Query(window);
+  REQUIRE(ok);
+  REQUIRE_FALSE(ok->HasError());
+  REQUIRE(ok->RowCount() == 100);
+  auto after = sirius::test::get_transparent_execution_stats(*con);
+  sirius::test::require_transparent_execution_delta(before, after, 0, 1, 0, 0);
+}
+
+// Note: SQL-level `PREPARE ... AS SELECT` / `EXECUTE` is not intercepted by Sirius
+// (transparent interception gates on statement_type == SELECT_STATEMENT, and those
+// carry PREPARE/EXECUTE statement types), so it runs on DuckDB CPU and the runtime
+// fallback path does not apply. Extending interception to prepared statements is a
+// separate concern, out of scope for runtime fallback.
+
+// The enable_duckdb_fallback setting defaults to true and is overridable per session.
+TEST_CASE_METHOD(RuntimeFallbackFixture,
+                 "runtime fallback: setting defaults true and is session-overridable",
+                 "[transparent][fallback][integration]")
+{
+  duckdb::Value v;
+  auto lr = con->context->TryGetCurrentSetting("enable_duckdb_fallback", v);
+  REQUIRE(lr.GetScope() != duckdb::SettingScope::INVALID);
+  REQUIRE_FALSE(v.IsNull());
+  REQUIRE(v.GetValue<bool>() == true);
+
+  con->Query("SET enable_duckdb_fallback = false;");
+  con->context->TryGetCurrentSetting("enable_duckdb_fallback", v);
+  REQUIRE(v.GetValue<bool>() == false);
+
+  con->Query("SET enable_duckdb_fallback = true;");
+  con->context->TryGetCurrentSetting("enable_duckdb_fallback", v);
+  REQUIRE(v.GetValue<bool>() == true);
+}

--- a/test/cpp/utils/transparent_execution_test_utils.hpp
+++ b/test/cpp/utils/transparent_execution_test_utils.hpp
@@ -42,11 +42,13 @@ inline void require_transparent_execution_delta(
   const duckdb::SiriusContext::transparent_execution_stats& after,
   uint64_t expected_rebind_delta,
   uint64_t expected_fallback_delta,
-  uint64_t expected_execution_delta)
+  uint64_t expected_execution_delta,
+  uint64_t expected_runtime_fallback_delta = 0)
 {
   REQUIRE(after.successful_rebinds == before.successful_rebinds + expected_rebind_delta);
   REQUIRE(after.fallbacks == before.fallbacks + expected_fallback_delta);
   REQUIRE(after.executions == before.executions + expected_execution_delta);
+  REQUIRE(after.runtime_fallbacks == before.runtime_fallbacks + expected_runtime_fallback_delta);
 }
 
 }  // namespace sirius::test


### PR DESCRIPTION
## What

When a transparently-intercepted `SELECT` fails **during GPU execution** (not just at plan time), it now completes on DuckDB CPU instead of erroring — under the **same transaction and MVCC snapshot** as the failed GPU attempt.

## How

`OnFinalizePrepare` stashes DuckDB's CPU physical plan (previously discarded) inside `PhysicalSiriusExecution`. On a GPU execution failure, the operator runs that plan itself, from inside `GetData`, on a private `duckdb::Executor` bound to the same `ClientContext`. Reusing the same context (not a fresh connection) keeps the fallback on the same transaction, so it sees the transaction's own uncommitted writes and none of the commits made after it started. The GPU result is fully materialized before any row is emitted, so the fallback can't duplicate rows. No DuckDB submodule changes.

## Behavior

- Both plan-time and runtime fallback are gated by the `enable_duckdb_fallback` session setting (default true, `SET` per connection). When off, failures surface as errors instead of running on CPU.
- Runtime GPU failures no longer throw `InternalException`, which was invalidating the whole database. Errors are sanitized to `ExecutorException`.
- S3-reading queries have no CPU path and surface a clear error. User interrupts propagate.
- A `runtime_fallbacks` counter and a red console banner (shared with the legacy `CALL gpu_execution` path) record each fallback.

## Testing

`test_transparent_runtime_fallback.cpp` drives the runtime path via a test-only injection setting: basic fallback, MVCC same-snapshot (sees own uncommitted writes; ignores a concurrent commit), `enable_duckdb_fallback` gating for both runtime and plan-time, and the setting default/override. The shared `require_transparent_execution_delta` helper now also asserts `runtime_fallbacks`, so existing GPU tests confirm it stays zero.

## Notes

- SQL-level `PREPARE ... AS SELECT` / `EXECUTE` isn't intercepted (the SELECT-only statement-type gate), so runtime fallback doesn't apply there — a separate concern.
- Under query profiling, the nested CPU executor's profile is suppressed so it doesn't corrupt the outer query's profile.
