### PR TITLE
feat(io)+ Quent : backend-neutral IO telemetry seam with REST-only activation

### DIFF
--- a/src/include/io/io_context.hpp
+++ b/src/include/io/io_context.hpp
@@ -20,6 +20,7 @@
 #include "io/cache/config.hpp"
 #include "io/cache/metadata_store.hpp"
 #include "io/cache/types.hpp"
+#include "io/io_telemetry.hpp"
 #include "io/types.hpp"
 
 #include <rmm/cuda_stream_view.hpp>
@@ -180,6 +181,14 @@ class sirius_ioctx : public std::enable_shared_from_this<sirius_ioctx> {
 
   [[nodiscard]] cache::prefetching_cache* cache() noexcept { return _cache.get(); }
 
+  /// Optional telemetry sink; null (the default) keeps every emission point
+  /// structurally inert.
+  [[nodiscard]] io_telemetry_sink* io_telemetry() const noexcept { return _io_telemetry.get(); }
+  [[nodiscard]] const std::shared_ptr<io_telemetry_sink>& io_telemetry_shared() const noexcept
+  {
+    return _io_telemetry;
+  }
+
   /// True iff @c host_read / @c device_read should consult the cache
   /// before falling through to the backend.  Computed live so it tracks
   /// @ref initialize_cache / @ref shutdown_cache transitions.
@@ -237,6 +246,64 @@ class sirius_ioctx : public std::enable_shared_from_this<sirius_ioctx> {
   virtual exec::semi_future<size_t> host_read_ranges_async_io(
     const sirius_io_object& obj, std::span<io_object_segment> segments) noexcept = 0;
 
+  // -- Telemetry-carrying read overloads ---------------------------------------
+  //
+  // Default: drop the context and forward to the plain read, so a backend that
+  // has not adopted telemetry keeps its original five methods and cannot
+  // half-attach (its sink stays null, which keeps the datasource layer inert).
+  // Adopting backends (REST) override these to thread the read identity into
+  // their request layer.
+
+  virtual size_t host_read_io(const sirius_io_object& obj,
+                              size_t offset,
+                              size_t size,
+                              uint8_t* dst,
+                              const io_read_context* /*telemetry_ctx*/)
+  {
+    return host_read_io(obj, offset, size, dst);
+  }
+
+  virtual exec::semi_future<size_t> host_read_async_io(
+    const sirius_io_object& obj,
+    size_t offset,
+    size_t size,
+    uint8_t* dst,
+    const io_read_context* /*telemetry_ctx*/) noexcept
+  {
+    return host_read_async_io(obj, offset, size, dst);
+  }
+
+  virtual exec::semi_future<size_t> device_read_async_io(
+    const sirius_io_object& obj,
+    size_t offset,
+    size_t size,
+    uint8_t* dst,
+    rmm::cuda_stream_view stream,
+    const io_read_context* /*telemetry_ctx*/) noexcept
+  {
+    return device_read_async_io(obj, offset, size, dst, stream);
+  }
+
+  virtual exec::semi_future<size_t> host_to_device_read_async_io(
+    const sirius_io_object& obj,
+    std::span<io_object_segment> slices,
+    size_t offset,
+    size_t size,
+    uint8_t* device_dst,
+    rmm::cuda_stream_view stream,
+    const io_read_context* /*telemetry_ctx*/) noexcept
+  {
+    return host_to_device_read_async_io(obj, slices, offset, size, device_dst, stream);
+  }
+
+  virtual exec::semi_future<size_t> host_read_ranges_async_io(
+    const sirius_io_object& obj,
+    std::span<io_object_segment> segments,
+    const io_read_context* /*telemetry_ctx*/) noexcept
+  {
+    return host_read_ranges_async_io(obj, segments);
+  }
+
   bool can_use_prefetching_cache() const noexcept
   {
     return supports_vector_host_read() || supports_host_to_device_read();
@@ -264,11 +331,19 @@ class sirius_ioctx : public std::enable_shared_from_this<sirius_ioctx> {
   virtual std::shared_ptr<sirius_io_object> create_io_object(std::string path,
                                                              std::uint64_t known_size);
 
+  /// Set once at construction; never mutated afterwards.
+  void set_io_telemetry(std::shared_ptr<io_telemetry_sink> sink) noexcept
+  {
+    _io_telemetry = std::move(sink);
+  }
+
   /// Owned by this ioctx.  Built by @ref initialize_cache, destroyed
   /// by @ref shutdown_cache (or the ioctx destructor as a safety net,
   /// though callers are expected to drive the lifecycle explicitly so
   /// reactors stay alive while workers drain).
   std::unique_ptr<cache::prefetching_cache> _cache;
+
+  std::shared_ptr<io_telemetry_sink> _io_telemetry;
 
   /// Independent of the prefetching machinery — exposed via @c metadata_store().
   cache::metadata_store _metadata_store;

--- a/src/include/io/io_request.hpp
+++ b/src/include/io/io_request.hpp
@@ -25,6 +25,7 @@
 // dispatch layer splits across the reactor pool.
 
 #include "exec/semi_future.hpp"
+#include "io/io_telemetry.hpp"
 
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream_view.hpp>
@@ -67,6 +68,7 @@ class request_manager {
 
   ~request_manager()
   {
+    emit_backend_record();
     if (has_error()) {
       promise.set_exception(first_exception);
     } else {
@@ -78,16 +80,33 @@ class request_manager {
     }
   }
 
+  /// Must be called before the request's chunks are enqueued; the backend
+  /// record is emitted exactly once from the destructor, before the future
+  /// settles. An untracked request pays exactly one null pointer.
+  void install_telemetry(std::shared_ptr<io_telemetry_sink> sink, const io_read_context& ctx)
+  {
+    telemetry = std::make_unique<telemetry_state>(std::move(sink), ctx, io_now_ns());
+  }
+
   void chunk_complete(std::size_t n_bytes)
   {
     bytes_read.fetch_add(n_bytes, std::memory_order_acq_rel);
     chunks_completed.fetch_add(1, std::memory_order_acq_rel);
   }
 
-  void report_error(const error_type& e, std::source_location loc = std::source_location::current())
+  /// Counted at schedule time so failed requests report their retries too.
+  void note_retry() noexcept
+  {
+    if (telemetry) { telemetry->retries.fetch_add(1, std::memory_order_relaxed); }
+  }
+
+  void report_error(const error_type& e,
+                    std::source_location loc   = std::source_location::current(),
+                    io_terminal_class terminal = io_terminal_class::transport_error)
   {
     if (!error_reported.exchange(true, std::memory_order_acq_rel)) {
       first_exception = to_exception_ptr(e, loc);
+      if (telemetry) { telemetry->terminal = terminal; }
     }
   }
 
@@ -123,11 +142,43 @@ class request_manager {
     return nullptr;  // Should never reach here
   }
 
+  struct telemetry_state {
+    telemetry_state(std::shared_ptr<io_telemetry_sink> s, const io_read_context& c, uint64_t t)
+      : sink(std::move(s)), ctx(c), t_create_ns(t)
+    {
+    }
+    std::shared_ptr<io_telemetry_sink> sink;
+    io_read_context ctx;
+    uint64_t t_create_ns{0};
+    std::atomic<uint32_t> retries{0};
+    io_terminal_class terminal{io_terminal_class::transport_error};
+  };
+
+  void emit_backend_record() noexcept
+  {
+    if (!telemetry) { return; }
+    backend_io_record record{
+      .read_id          = telemetry->ctx.read_id,
+      .attribution      = telemetry->ctx.attribution,
+      .object_id        = telemetry->ctx.object_id,
+      .bytes_requested  = bytes_requested,
+      .bytes_delivered  = bytes_read.load(std::memory_order_acquire),
+      .chunks_total     = static_cast<uint32_t>(total_chunks),
+      .chunks_completed = static_cast<uint32_t>(chunks_completed.load(std::memory_order_acquire)),
+      .retries          = telemetry->retries.load(std::memory_order_relaxed),
+      .terminal         = has_error() ? telemetry->terminal : io_terminal_class::ok,
+      .t_create_ns      = telemetry->t_create_ns,
+      .t_complete_ns    = io_now_ns(),
+    };
+    telemetry->sink->on_backend_read(record);
+  }
+
   std::atomic<std::size_t> bytes_read{0};
   std::atomic<std::size_t> chunks_completed{0};
   std::atomic<bool> error_reported{false};
   std::exception_ptr first_exception{nullptr};
   exec::promise<size_t> promise;
+  std::unique_ptr<telemetry_state> telemetry;
 };
 
 struct device_cpy_request {
@@ -230,6 +281,14 @@ struct rx_request_t {
   }
 
   std::vector<std::unique_ptr<Chunk>> get_all_chunks() noexcept { return std::move(requests); }
+
+  /// Attach sink + read identity to the shared manager; no-op for empty
+  /// requests.
+  void install_telemetry(std::shared_ptr<io_telemetry_sink> sink, const io_read_context& ctx)
+  {
+    if (requests.empty() || !sink) { return; }
+    requests.front()->manager->install_telemetry(std::move(sink), ctx);
+  }
 
   exec::semi_future<size_t> get_future() noexcept
   {

--- a/src/include/io/io_telemetry.hpp
+++ b/src/include/io/io_telemetry.hpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <random>
+
+namespace sirius::io {
+
+/**
+ * Backend-neutral IO telemetry seam. Must stay free of telemetry-backend
+ * dependencies (no generated bridge headers, no Rust types). With no sink
+ * registered (the default) every emission point is a single untaken branch.
+ */
+
+/// 128-bit id, layout-compatible with the engine's UUID type (which lives in
+/// a generated header this seam must not include). Nil (all zero) = unknown.
+struct io_uuid {
+  uint64_t high_bits{0};
+  uint64_t low_bits{0};
+
+  [[nodiscard]] constexpr bool is_nil() const noexcept { return high_bits == 0 && low_bits == 0; }
+  constexpr bool operator==(const io_uuid&) const noexcept = default;
+};
+
+enum class io_phase : uint8_t { unknown, scan, prefetch, bind, open, list, head, footer };
+
+/// Which code path served a leaf datasource read. Cache/stash HIT truth is a
+/// join, not a field: a served-from-memory read has no backend_io_record with
+/// its read_id.
+enum class io_route : uint8_t { direct, cache };
+
+enum class io_outcome : uint8_t { ok, error, cancelled };
+
+/// Captured structurally at report time — never parsed from message strings.
+enum class io_terminal_class : uint8_t {
+  ok,
+  http_error,
+  transport_error,
+  cuda_error,
+  cancelled,
+  shutdown,
+};
+
+/// Flows BY VALUE with each read; never shared by pointer into asynchronous
+/// paths (the prefetch cache outlives the datasource that armed it).
+struct io_attribution {
+  io_uuid query_uuid{};
+  io_uuid pipeline_uuid{};
+  int32_t device_id{-1};
+  io_phase phase{io_phase::unknown};
+};
+
+/// Exactly one per caller-visible datasource read, emitted at the leaf
+/// implementations only (overload delegation must not double-count).
+struct logical_io_record {
+  io_uuid read_id{};
+  io_attribution attribution{};
+  io_route route{io_route::direct};
+  uint64_t object_id{0};
+  uint64_t offset{0};
+  uint64_t bytes{0};
+  uint64_t t_begin_ns{0};
+  uint64_t t_end_ns{0};
+  io_outcome outcome{io_outcome::ok};
+};
+
+/// Exactly one per request_manager, i.e. per actual backend access.
+struct backend_io_record {
+  io_uuid read_id{};
+  io_attribution attribution{};
+  uint64_t object_id{0};
+  uint64_t bytes_requested{0};
+  uint64_t bytes_delivered{0};
+  uint32_t chunks_total{0};
+  uint32_t chunks_completed{0};
+  uint32_t retries{0};
+  io_terminal_class terminal{io_terminal_class::ok};
+  uint64_t t_create_ns{0};
+  uint64_t t_complete_ns{0};
+};
+
+/// Consumer seam. Implementations must be thread-safe (calls arrive from
+/// caller, reactor, and prefetch-cache threads) and may not block or throw.
+class io_telemetry_sink {
+ public:
+  virtual ~io_telemetry_sink() = default;
+
+  virtual void on_logical_read(const logical_io_record& record) noexcept = 0;
+  virtual void on_backend_read(const backend_io_record& record) noexcept = 0;
+};
+
+/// Joins a backend record to its logical read. Built only when a sink is
+/// active; pointer arguments are valid only for the duration of the call.
+struct io_read_context {
+  io_attribution attribution{};
+  io_uuid read_id{};
+  uint64_t object_id{0};
+};
+
+/// Process-unique read id (random high half, counter low half) — deliberately
+/// not the engine's generated UUID type; joins are process-local.
+namespace detail {
+/// std::random_device may throw; fall back to clock/address entropy rather
+/// than terminating from a noexcept context.
+[[nodiscard]] inline uint64_t io_telemetry_entropy() noexcept
+{
+  try {
+    std::random_device rd;
+    return (static_cast<uint64_t>(rd()) << 32) ^ rd();
+  } catch (...) {
+    static const int anchor = 0;
+    return static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count()) ^
+           reinterpret_cast<uintptr_t>(&anchor);
+  }
+}
+}  // namespace detail
+
+[[nodiscard]] inline io_uuid make_io_read_id() noexcept
+{
+  static const uint64_t hi = detail::io_telemetry_entropy() ^ 0x5152'4553'544c'4f47ULL;
+  static std::atomic<uint64_t> counter{1};
+  return {hi, counter.fetch_add(1, std::memory_order_relaxed)};
+}
+
+/// Session-salted 64-bit object identity; the salt is minted once per process
+/// and never recorded. Centralized so every emitter derives it identically.
+[[nodiscard]] inline uint64_t make_io_object_identity(const char* data, size_t len) noexcept
+{
+  static const uint64_t salt = detail::io_telemetry_entropy() ^ 0x4f42'4a49'4453'414cULL;
+  uint64_t h                 = 0xcbf29ce484222325ULL ^ salt;
+  for (size_t i = 0; i < len; ++i) {
+    h ^= static_cast<unsigned char>(data[i]);
+    h *= 0x100000001b3ULL;
+  }
+  return h ^ (salt << 1);
+}
+
+[[nodiscard]] inline uint64_t io_now_ns() noexcept
+{
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                 std::chrono::steady_clock::now().time_since_epoch())
+                                 .count());
+}
+
+}  // namespace sirius::io

--- a/src/include/io/rest/rest_reactor.hpp
+++ b/src/include/io/rest/rest_reactor.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "io/cache/types.hpp"
+#include "io/io_telemetry.hpp"
 #include "io/rest/config.hpp"
 #include "io/rest/types.hpp"
 #include "io/s3/s3_object_ref.hpp"
@@ -186,8 +187,12 @@ class rest_reactor {
    public:
     reactor_context(config cfg,
                     std::shared_ptr<s3::s3_request_authorizer> authorizer,
-                    cucascade::memory::fixed_size_host_memory_resource* host_mr = nullptr)
-      : _config(std::move(cfg)), _authorizer(std::move(authorizer)), _host_mr(host_mr)
+                    cucascade::memory::fixed_size_host_memory_resource* host_mr = nullptr,
+                    std::shared_ptr<io_telemetry_sink> io_telemetry             = nullptr)
+      : _config(std::move(cfg)),
+        _authorizer(std::move(authorizer)),
+        _host_mr(host_mr),
+        _io_telemetry(std::move(io_telemetry))
     {
     }
 
@@ -201,11 +206,16 @@ class rest_reactor {
     {
       return _host_mr;
     }
+    [[nodiscard]] const std::shared_ptr<io_telemetry_sink>& io_telemetry() const noexcept
+    {
+      return _io_telemetry;
+    }
 
    private:
     config _config;
     std::shared_ptr<s3::s3_request_authorizer> _authorizer;
     cucascade::memory::fixed_size_host_memory_resource* _host_mr{nullptr};
+    std::shared_ptr<io_telemetry_sink> _io_telemetry;
   };
 
   using io_object_type       = rest_io_object;
@@ -269,7 +279,11 @@ class rest_reactor {
   void shutdown();
 
   /// Synchronous buffered host read (blocking ranged GET).  Blocks the caller.
-  size_t host_read(const io_object_type& file, size_t offset, size_t size, uint8_t* dst);
+  size_t host_read(const io_object_type& file,
+                   size_t offset,
+                   size_t size,
+                   uint8_t* dst,
+                   const io_read_context* telemetry_ctx = nullptr);
 
   /// Blocking HEAD to discover an object's size.  Used by the ioctx to build
   /// an @c rest_io_object.  @p bucket / @p key identify the object.

--- a/src/include/io/sirius_datasource.hpp
+++ b/src/include/io/sirius_datasource.hpp
@@ -136,11 +136,21 @@ class sirius_datasource : public cudf::io::datasource {
 
   void prefetch(cache::prefetching_stage site);
 
+  /// Attribution carried into every record this datasource emits; must be set
+  /// before reads are issued. Copied by @c duplicate().
+  void set_io_attribution(const io_attribution& attribution) noexcept
+  {
+    _attribution = attribution;
+  }
+  void set_io_device(int device_id) noexcept { _attribution.device_id = device_id; }
+  [[nodiscard]] const io_attribution& get_io_attribution() const noexcept { return _attribution; }
+
  private:
   [[nodiscard]] bool uses_prefetching_cache();
 
   std::shared_ptr<sirius_ioctx> _io_ctx;
   std::shared_ptr<sirius_io_object> _io_object;
+  io_attribution _attribution{};
   /// Handle of the most recent speculative/immediate insert into the
   /// prefetching cache, or empty if none was made.  fadvise(disposable)
   /// uses this to cancel still-pending work.

--- a/src/include/io/templated_ioctx.hpp
+++ b/src/include/io/templated_ioctx.hpp
@@ -299,6 +299,16 @@ class templated_ioctx : public sirius_ioctx {
     }
   }
 
+  /// No-op when either the context or the sink is absent — the off path stays
+  /// a single branch.
+  void install_request_telemetry(request_type& req, const io_read_context* telemetry_ctx)
+  {
+    if (telemetry_ctx == nullptr) { return; }
+    if (auto sink = this->io_telemetry_shared()) {
+      req.install_telemetry(std::move(sink), *telemetry_ctx);
+    }
+  }
+
   virtual std::vector<Reactor*> next_reactor([[maybe_unused]] const io_object_type& obj,
                                              [[maybe_unused]] size_t n_chunks,
                                              [[maybe_unused]] io_op_type type,
@@ -317,16 +327,37 @@ class templated_ioctx : public sirius_ioctx {
                       size_t size,
                       uint8_t* dst) override
   {
+    return host_read_io(obj, offset, size, dst, nullptr);
+  }
+
+  size_t host_read_io(const sirius_io_object& obj,
+                      size_t offset,
+                      size_t size,
+                      uint8_t* dst,
+                      const io_read_context* telemetry_ctx) override
+  {
     auto& tobj = as_typed(obj);
     size       = std::min(size, tobj.size() > offset ? tobj.size() - offset : size_t{0});
     if (size == 0) return 0;
-    return next_reactor(tobj, 1, io_op_type::host).at(0)->host_read(tobj, offset, size, dst);
+    return next_reactor(tobj, 1, io_op_type::host)
+      .at(0)
+      ->host_read(tobj, offset, size, dst, telemetry_ctx);
   }
 
   exec::semi_future<size_t> host_read_async_io(const sirius_io_object& obj,
                                                size_t offset,
                                                size_t size,
                                                uint8_t* dst) noexcept override
+  {
+    return host_read_async_io(obj, offset, size, dst, nullptr);
+  }
+
+  exec::semi_future<size_t> host_read_async_io(
+    const sirius_io_object& obj,
+    size_t offset,
+    size_t size,
+    uint8_t* dst,
+    const io_read_context* telemetry_ctx) noexcept override
   {
     if (size == 0) return exec::make_semi_future<size_t>(0);
     try {
@@ -340,6 +371,7 @@ class templated_ioctx : public sirius_ioctx {
       }
 
       auto req = Reactor::prep_host_rx_request(_config, tobj, io_object_segment{offset, size, dst});
+      install_request_telemetry(*req, telemetry_ctx);
       auto semi = req->get_future();
       auto reqs = request_type::splits(std::move(req), reactors.size());
       assert(reqs.size() <= reactors.size());
@@ -360,6 +392,17 @@ class templated_ioctx : public sirius_ioctx {
                                                  uint8_t* dst,
                                                  rmm::cuda_stream_view stream) noexcept override
   {
+    return device_read_async_io(obj, offset, size, dst, stream, nullptr);
+  }
+
+  exec::semi_future<size_t> device_read_async_io(
+    const sirius_io_object& obj,
+    size_t offset,
+    size_t size,
+    uint8_t* dst,
+    rmm::cuda_stream_view stream,
+    const io_read_context* telemetry_ctx) noexcept override
+  {
     if constexpr (reactor_traits_t::supports_device_read) {
       try {
         auto& tobj    = as_typed(obj);
@@ -371,6 +414,7 @@ class templated_ioctx : public sirius_ioctx {
         }
         request_type_ptr req =
           Reactor::prep_device_rx_request(_config, tobj, dst, offset, size, stream, device_id);
+        install_request_telemetry(*req, telemetry_ctx);
         auto semi = req->get_future();
         auto reqs = request_type::splits(std::move(req), reactors.size());
         assert(reqs.size() <= reactors.size());
@@ -396,6 +440,18 @@ class templated_ioctx : public sirius_ioctx {
     uint8_t* dst,
     rmm::cuda_stream_view stream) noexcept override
   {
+    return host_to_device_read_async_io(obj, slices, offset, size, dst, stream, nullptr);
+  }
+
+  exec::semi_future<size_t> host_to_device_read_async_io(
+    const sirius_io_object& obj,
+    std::span<io_object_segment> slices,
+    size_t offset,
+    size_t size,
+    uint8_t* dst,
+    rmm::cuda_stream_view stream,
+    const io_read_context* telemetry_ctx) noexcept override
+  {
     if constexpr (reactor_traits_t::supports_host_to_device_read) {
       try {
         auto& tobj    = as_typed(obj);
@@ -407,6 +463,7 @@ class templated_ioctx : public sirius_ioctx {
         }
         request_type_ptr req = Reactor::prep_host_to_device_rx_request(
           _config, tobj, slices, dst, offset, size, stream, device_id);
+        install_request_telemetry(*req, telemetry_ctx);
         auto semi = req->get_future();
         auto reqs = request_type::splits(std::move(req), reactors.size());
         assert(reqs.size() <= reactors.size());
@@ -428,6 +485,14 @@ class templated_ioctx : public sirius_ioctx {
   exec::semi_future<size_t> host_read_ranges_async_io(
     const sirius_io_object& obj, std::span<io_object_segment> segments) noexcept override
   {
+    return host_read_ranges_async_io(obj, segments, nullptr);
+  }
+
+  exec::semi_future<size_t> host_read_ranges_async_io(
+    const sirius_io_object& obj,
+    std::span<io_object_segment> segments,
+    const io_read_context* telemetry_ctx) noexcept override
+  {
     if constexpr (reactor_traits_t::supports_vector_host_read) {
       try {
         auto& tobj = as_typed(obj);
@@ -438,7 +503,8 @@ class templated_ioctx : public sirius_ioctx {
             std::runtime_error("host_read_ranges_async_io: no available reactors")));
         }
 
-        auto req  = Reactor::prep_host_rxv_request(_config, tobj, segments);
+        auto req = Reactor::prep_host_rxv_request(_config, tobj, segments);
+        install_request_telemetry(*req, telemetry_ctx);
         auto semi = req->get_future();
         auto reqs = request_type::splits(std::move(req), reactors.size());
         assert(reqs.size() <= reactors.size());

--- a/src/include/io/types.hpp
+++ b/src/include/io/types.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "io/io_telemetry.hpp"
+
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/text/byte_range_info.hpp>
 
@@ -92,6 +94,23 @@ class sirius_io_object : public std::enable_shared_from_this<sirius_io_object> {
   /// Total size of the underlying object, populated by the reactor at
   /// construction time and stored on the io_object thereafter.
   [[nodiscard]] virtual size_t size() const noexcept = 0;
+
+  /// Session-salted telemetry identity, computed lazily from @c object_path()
+  /// and cached. Never the plaintext key.
+  [[nodiscard]] uint64_t telemetry_object_id() const noexcept
+  {
+    uint64_t v = _telemetry_object_id.load(std::memory_order_relaxed);
+    if (v == 0) {
+      const auto& path = object_path();
+      v                = make_io_object_identity(path.data(), path.size());
+      if (v == 0) { v = 1; }
+      _telemetry_object_id.store(v, std::memory_order_relaxed);
+    }
+    return v;
+  }
+
+ private:
+  mutable std::atomic<uint64_t> _telemetry_object_id{0};
 };
 
 class sirius_io_object_metadata {

--- a/src/include/io/uring/uring_reactor.hpp
+++ b/src/include/io/uring/uring_reactor.hpp
@@ -19,6 +19,7 @@
 #include "exec/semi_future.hpp"
 #include "io/cache/types.hpp"
 #include "io/details/slot_pool.hpp"
+#include "io/io_telemetry.hpp"
 #include "io/types.hpp"
 #include "io/uring/config.hpp"
 #include "io/uring/types.hpp"
@@ -225,8 +226,11 @@ class uring_reactor {
   void shutdown();
 
   /// Synchronous buffered host read (pread on @p fd).  Blocks the caller.
-  size_t host_read(const io_object_type& file, size_t offset, size_t size, uint8_t* dst);
-
+  size_t host_read(const io_object_type& file,
+                   size_t offset,
+                   size_t size,
+                   uint8_t* dst,
+                   const io_read_context* telemetry_ctx = nullptr);
   void enqueue(request_type_ptr req);
 
   /// Whether @p path can be served by this reactor.  Local-disk only:

--- a/src/include/scan_manager/config.hpp
+++ b/src/include/scan_manager/config.hpp
@@ -23,6 +23,12 @@
 #include "io/rest/config.hpp"
 #include "io/uring/config.hpp"
 
+#include <memory>
+
+namespace sirius::io {
+class io_telemetry_sink;
+}
+
 namespace sirius::scan_manager {
 
 /**
@@ -69,6 +75,11 @@ struct scan_manager_config {
   /// Object-store credentials and endpoint consumed by the REST reactor.
   /// Empty fields disable the S3/REST backend.
   io::object_store_config object_store{};
+
+  /// Optional IO telemetry sink (io/io_telemetry.hpp), runtime-injected — not
+  /// file-settable. Null (the default) keeps the IO layer's emission points
+  /// structurally inert.
+  std::shared_ptr<io::io_telemetry_sink> io_telemetry{};
 };
 
 }  // namespace sirius::scan_manager

--- a/src/io/datasource_factory.cpp
+++ b/src/io/datasource_factory.cpp
@@ -156,7 +156,7 @@ factory_type make_rest_ioctx_factory(
       rest_cfg.ca_bundle_path = config.object_store.ca_bundle_path;
       rest_cfg.tls_verify     = config.object_store.tls_verify;
       auto ctx                = std::make_shared<rest::rest_reactor::reactor_context>(
-        std::move(rest_cfg), std::move(authorizer), host_mr);
+        std::move(rest_cfg), std::move(authorizer), host_mr, config.io_telemetry);
       return std::make_shared<rest::rest_ioctx>(config.rest_n_reactors, std::move(ctx));
     } catch (const std::exception& e) {
       SIRIUS_LOG_ERROR("make_rest_ioctx_factory: construction failed: {}", e.what());

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -29,10 +29,11 @@
 namespace sirius::io::rest {
 
 rest_ioctx::rest_ioctx(std::size_t n_reactors, std::shared_ptr<rest_reactor::reactor_context> ctx)
-  : templated_ioctx<rest_reactor>(n_reactors, [ctx = std::move(ctx), i = 0]() mutable {
+  : templated_ioctx<rest_reactor>(n_reactors, [ctx, i = 0]() mutable {
       return std::make_unique<rest_reactor>(ctx, std::format("rest-{}", i++));
     })
 {
+  set_io_telemetry(ctx->io_telemetry());
 }
 
 rest_perf_snapshot rest_ioctx::perf_snapshot() const noexcept

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -764,7 +764,11 @@ rest_reactor::request_type_ptr rest_reactor::prep_host_to_device_rx_request(
 // synchronous paths
 // ---------------------------------------------------------------------------
 
-size_t rest_reactor::host_read(const io_object_type& file, size_t offset, size_t size, uint8_t* dst)
+size_t rest_reactor::host_read(const io_object_type& file,
+                               size_t offset,
+                               size_t size,
+                               uint8_t* dst,
+                               const io_read_context* telemetry_ctx)
 {
   if (size == 0) { return 0; }
   size = std::min(size, file.size() > offset ? file.size() - offset : size_t{0});
@@ -789,6 +793,7 @@ size_t rest_reactor::host_read(const io_object_type& file, size_t offset, size_t
   // block: get() rethrows the first reported error or returns the byte count.
   auto req = prep_host_rx_request(
     _config, file, io_object_segment{offset, size, dst}, /*perf_blocking_host_get=*/true);
+  if (telemetry_ctx != nullptr) { req->install_telemetry(_ctx->io_telemetry(), *telemetry_ctx); }
   auto fut = req->get_future();
   enqueue(std::move(req));
   return std::move(fut).get();
@@ -1366,7 +1371,9 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
         } else {
           _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
           it->manager->report_error(
-            std::make_exception_ptr(std::runtime_error("rest_reactor: device H2D copy failed")));
+            std::make_exception_ptr(std::runtime_error("rest_reactor: device H2D copy failed")),
+            std::source_location::current(),
+            io_terminal_class::cuda_error);
         }
         it = copying.erase(it);
       }
@@ -1394,16 +1401,21 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
     auto schedule_retry = [&](std::unique_ptr<rest_chunked_rx_request> req,
                               std::string const& retry_after,
                               bool is_auth,
-                              std::string const& reason) {
+                              std::string const& reason,
+                              io_terminal_class reason_class) {
       std::size_t& counter = is_auth ? req->auth_attempt : req->attempt;
       std::size_t const max_attempts =
         is_auth ? _config.max_auth_retry_attempts : _config.max_retry_attempts;
       if (counter + 1 >= max_attempts) {
         _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
-        req->manager->report_error(std::make_exception_ptr(std::runtime_error(
-          "rest_reactor: exhausted retries for " + req->object.bucket + "/" + req->object.key)));
+        req->manager->report_error(
+          std::make_exception_ptr(std::runtime_error("rest_reactor: exhausted retries for " +
+                                                     req->object.bucket + "/" + req->object.key)),
+          std::source_location::current(),
+          reason_class);
         return;
       }
+      req->manager->note_retry();
       // Backoff tracks the transient-attempt count; an auth retry re-presigns
       // and reuses the current step without inflating it.
       auto const delay = compute_backoff(req->attempt, retry_after, _config);
@@ -1531,10 +1543,13 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
         auto const start = content_range_start(s.hc.content_range);
         if (!start || *start != req.chunk.offset) {
           _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
-          req.manager->report_error(std::make_exception_ptr(std::runtime_error(
-            "rest_reactor: 206 Content-Range mismatch (got '" + s.hc.content_range +
-            "', requested offset " + std::to_string(req.chunk.offset) + ") for " +
-            req.object.bucket + "/" + req.object.key)));
+          req.manager->report_error(
+            std::make_exception_ptr(std::runtime_error(
+              "rest_reactor: 206 Content-Range mismatch (got '" + s.hc.content_range +
+              "', requested offset " + std::to_string(req.chunk.offset) + ") for " +
+              req.object.bucket + "/" + req.object.key)),
+            std::source_location::current(),
+            io_terminal_class::http_error);
           return false;
         }
       }
@@ -1575,7 +1590,8 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
           cudaError_t const err = req.copy_h2d_async(cev);
           if (err != cudaSuccess) {
             _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
-            req.manager->report_error(err);
+            req.manager->report_error(
+              err, std::source_location::current(), io_terminal_class::cuda_error);
             return false;
           }
           if (_config.perf_instrumentation) {
@@ -1610,9 +1626,11 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
         // Server ignored Range and returned the whole object: the bytes start
         // at offset 0, not req.offset — non-retriable, would loop forever.
         _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
-        req.manager->report_error(std::make_exception_ptr(
-          std::runtime_error("rest_reactor: server ignored Range (HTTP 200) for " +
-                             req.object.bucket + "/" + req.object.key)));
+        req.manager->report_error(std::make_exception_ptr(std::runtime_error(
+                                    "rest_reactor: server ignored Range (HTTP 200) for " +
+                                    req.object.bucket + "/" + req.object.key)),
+                                  std::source_location::current(),
+                                  io_terminal_class::http_error);
         return false;
       }
       // Error or truncated transfer.  A short read or a transient HTTP / curl
@@ -1632,15 +1650,21 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
         schedule_retry(std::move(s.req),
                        s.hc.retry_after,
                        /*is_auth=*/auth_retriable && !retriable,
-                       reason);
+                       reason,
+                       (rc != CURLE_OK || short_read) ? io_terminal_class::transport_error
+                                                      : io_terminal_class::http_error);
         return false;
       }
       std::string const msg = rc != CURLE_OK
                                 ? std::string(curl_easy_strerror(rc))
                                 : (ok_range ? "short read" : "HTTP " + std::to_string(status));
       _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
-      req.manager->report_error(std::make_exception_ptr(std::runtime_error(
-        "rest_reactor: " + msg + " for " + req.object.bucket + "/" + req.object.key)));
+      req.manager->report_error(
+        std::make_exception_ptr(std::runtime_error("rest_reactor: " + msg + " for " +
+                                                   req.object.bucket + "/" + req.object.key)),
+        std::source_location::current(),
+        (rc != CURLE_OK || ok_range) ? io_terminal_class::transport_error
+                                     : io_terminal_class::http_error);
       return false;
     };
 
@@ -1737,18 +1761,26 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
     for (auto& s : slots) {
       if (s.req) {
         curl_multi_remove_handle(multi.get(), s.easy.get());
-        s.req->manager->report_error(std::make_error_code(std::errc::operation_canceled));
+        s.req->manager->report_error(std::make_error_code(std::errc::operation_canceled),
+                                     std::source_location::current(),
+                                     io_terminal_class::shutdown);
         s.reset();
       }
     }
     for (auto& e : retry_heap) {
       if (e.req) {
-        e.req->manager->report_error(std::make_error_code(std::errc::operation_canceled));
+        e.req->manager->report_error(std::make_error_code(std::errc::operation_canceled),
+                                     std::source_location::current(),
+                                     io_terminal_class::shutdown);
       }
     }
     retry_heap.clear();
     for (auto& r : ready) {
-      if (r) { r->manager->report_error(std::make_error_code(std::errc::operation_canceled)); }
+      if (r) {
+        r->manager->report_error(std::make_error_code(std::errc::operation_canceled),
+                                 std::source_location::current(),
+                                 io_terminal_class::shutdown);
+      }
     }
     ready.clear();
   } catch (const std::exception& e) {
@@ -1757,7 +1789,11 @@ void rest_reactor::worker_loop(const std::stop_token& stop_token)
 
   std::unique_ptr<rest_chunked_rx_request> dr;
   while (_requests.try_dequeue(dr)) {
-    if (dr) { dr->manager->report_error(std::make_error_code(std::errc::operation_canceled)); }
+    if (dr) {
+      dr->manager->report_error(std::make_error_code(std::errc::operation_canceled),
+                                std::source_location::current(),
+                                io_terminal_class::shutdown);
+    }
     dr.reset();
   }
 }

--- a/src/io/sirius_datasource.cpp
+++ b/src/io/sirius_datasource.cpp
@@ -58,6 +58,38 @@ std::future<size_t> bridge_semi_to_std(exec::semi_future<size_t>&& sf)
   return fut;
 }
 
+/// Telemetry-carrying variant: the callback owns the sink (emission never
+/// depends on another object's lifetime) and classifies cancellation
+/// structurally from the settled exception.
+std::future<size_t> bridge_semi_to_std(exec::semi_future<size_t>&& sf,
+                                       std::shared_ptr<io_telemetry_sink> sink,
+                                       logical_io_record record)
+{
+  auto p   = std::make_shared<std::promise<size_t>>();
+  auto fut = p->get_future();
+  std::move(sf).install_callback(
+    [p = std::move(p), sink = std::move(sink), record](exec::try_t<size_t>&& t) mutable {
+      record.t_end_ns = io_now_ns();
+      record.outcome  = io_outcome::ok;
+      if (t.has_exception()) {
+        record.outcome = io_outcome::error;
+        try {
+          std::rethrow_exception(t.exception());
+        } catch (const std::system_error& e) {
+          if (e.code() == std::errc::operation_canceled) { record.outcome = io_outcome::cancelled; }
+        } catch (...) {
+        }
+      }
+      sink->on_logical_read(record);
+      if (t.has_exception()) {
+        p->set_exception(std::move(t).exception());
+      } else {
+        p->set_value(std::move(t).value());
+      }
+    });
+  return fut;
+}
+
 }  // namespace
 
 sirius_datasource::sirius_datasource(std::shared_ptr<sirius_ioctx> io_ctx,
@@ -100,11 +132,35 @@ bool sirius_datasource::is_device_read_preferred(size_t) const
 
 size_t sirius_datasource::host_read(size_t offset, size_t size, uint8_t* dst)
 {
+  // The cache route stays silent until hit/miss join semantics land, so a
+  // backend-served miss can never masquerade as a cache hit.
   if (uses_prefetching_cache()) {
-    auto* cache = _io_ctx->cache();
-    return cache->host_read(*_io_object, offset, size, dst, &_prefetch_handle);
+    return _io_ctx->cache()->host_read(*_io_object, offset, size, dst, &_prefetch_handle);
   }
-  return _io_ctx->host_read_io(*_io_object, offset, size, dst);
+  auto* sink = _io_ctx->io_telemetry();
+  if (sink == nullptr) { return _io_ctx->host_read_io(*_io_object, offset, size, dst); }
+  const io_read_context rctx{_attribution, make_io_read_id(), _io_object->telemetry_object_id()};
+  logical_io_record record{
+    .read_id     = rctx.read_id,
+    .attribution = _attribution,
+    .route       = io_route::direct,
+    .object_id   = rctx.object_id,
+    .offset      = offset,
+    .bytes       = size,
+    .t_begin_ns  = io_now_ns(),
+  };
+  try {
+    size_t n        = _io_ctx->host_read_io(*_io_object, offset, size, dst, &rctx);
+    record.t_end_ns = io_now_ns();
+    record.outcome  = io_outcome::ok;
+    sink->on_logical_read(record);
+    return n;
+  } catch (...) {
+    record.t_end_ns = io_now_ns();
+    record.outcome  = io_outcome::error;
+    sink->on_logical_read(record);
+    throw;
+  }
 }
 
 std::unique_ptr<cudf::io::datasource::buffer> sirius_datasource::host_read(size_t offset,
@@ -118,14 +174,26 @@ std::unique_ptr<cudf::io::datasource::buffer> sirius_datasource::host_read(size_
 
 std::future<size_t> sirius_datasource::host_read_async(size_t offset, size_t size, uint8_t* dst)
 {
-  exec::semi_future<size_t> semi;
   if (uses_prefetching_cache()) {
-    auto* cache = _io_ctx->cache();
-    semi        = cache->host_read_async(*_io_object, offset, size, dst, &_prefetch_handle);
-  } else {
-    semi = _io_ctx->host_read_async_io(*_io_object, offset, size, dst);
+    return bridge_semi_to_std(
+      _io_ctx->cache()->host_read_async(*_io_object, offset, size, dst, &_prefetch_handle));
   }
-  return bridge_semi_to_std(std::move(semi));
+  if (_io_ctx->io_telemetry() == nullptr) {
+    return bridge_semi_to_std(_io_ctx->host_read_async_io(*_io_object, offset, size, dst));
+  }
+  const io_read_context rctx{_attribution, make_io_read_id(), _io_object->telemetry_object_id()};
+  logical_io_record record{
+    .read_id     = rctx.read_id,
+    .attribution = _attribution,
+    .route       = io_route::direct,
+    .object_id   = rctx.object_id,
+    .offset      = offset,
+    .bytes       = size,
+    .t_begin_ns  = io_now_ns(),
+  };
+  return bridge_semi_to_std(_io_ctx->host_read_async_io(*_io_object, offset, size, dst, &rctx),
+                            _io_ctx->io_telemetry_shared(),
+                            record);
 }
 
 std::future<std::unique_ptr<cudf::io::datasource::buffer>> sirius_datasource::host_read_async(
@@ -168,14 +236,28 @@ std::future<size_t> sirius_datasource::device_read_async(size_t offset,
                                                          uint8_t* dst,
                                                          rmm::cuda_stream_view stream)
 {
-  exec::semi_future<size_t> semi;
   if (uses_prefetching_cache()) {
-    auto* cache = _io_ctx->cache();
-    semi = cache->device_read_async(*_io_object, offset, size, dst, stream, &_prefetch_handle);
-  } else {
-    semi = _io_ctx->device_read_async_io(*_io_object, offset, size, dst, stream);
+    return bridge_semi_to_std(_io_ctx->cache()->device_read_async(
+      *_io_object, offset, size, dst, stream, &_prefetch_handle));
   }
-  return bridge_semi_to_std(std::move(semi));
+  if (_io_ctx->io_telemetry() == nullptr) {
+    return bridge_semi_to_std(
+      _io_ctx->device_read_async_io(*_io_object, offset, size, dst, stream));
+  }
+  const io_read_context rctx{_attribution, make_io_read_id(), _io_object->telemetry_object_id()};
+  logical_io_record record{
+    .read_id     = rctx.read_id,
+    .attribution = _attribution,
+    .route       = io_route::direct,
+    .object_id   = rctx.object_id,
+    .offset      = offset,
+    .bytes       = size,
+    .t_begin_ns  = io_now_ns(),
+  };
+  return bridge_semi_to_std(
+    _io_ctx->device_read_async_io(*_io_object, offset, size, dst, stream, &rctx),
+    _io_ctx->io_telemetry_shared(),
+    record);
 }
 
 std::unique_ptr<sirius_datasource> sirius_datasource::duplicate() const

--- a/src/io/uring/uring_reactor.cpp
+++ b/src/io/uring/uring_reactor.cpp
@@ -805,8 +805,11 @@ bool uring_reactor::supports(std::string_view path)
 size_t uring_reactor::host_read(const io_object_type& file,
                                 size_t offset,
                                 size_t size,
-                                uint8_t* dst)
+                                uint8_t* dst,
+                                const io_read_context* /*telemetry_ctx*/)
 {
+  // Telemetry is deferred for uring (its sink is never wired); the parameter
+  // only satisfies the shared templated_ioctx dispatch shape.
   if (size == 0) return 0;
   // Loop until either the full requested size is read, EOF (n == 0), or a
   // real error. pread on a regular file should only return short on EOF, but
@@ -1066,7 +1069,9 @@ void uring_reactor::worker_loop(const std::stop_token& stop_token)
     chunk_io_request_type_ptr dr = nullptr;
     while (_requests.try_dequeue(dr)) {
       if (dr) {
-        dr->manager->report_error(std::make_error_code(std::errc::operation_canceled));
+        dr->manager->report_error(std::make_error_code(std::errc::operation_canceled),
+                                  std::source_location::current(),
+                                  io_terminal_class::shutdown);
         dr.reset(nullptr);
       } else {
         break;  // queue empty

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "catch.hpp"
+#include "io/io_telemetry.hpp"
 #include "io/rest/rest_ioctx.hpp"
 #include "io/s3/s3_list_parser.hpp"
 #include "io/s3/s3_request_authorizer.hpp"
@@ -125,6 +126,14 @@ scan_manager_config make_minio_rest_config()
   cfg.rest.request_timeout_s  = 30;
   cfg.rest.max_connections    = 8;
   cfg.rest_n_reactors         = 1;
+  return cfg;
+}
+
+scan_manager_config make_minio_rest_config(
+  std::shared_ptr<sirius::io::io_telemetry_sink> io_telemetry)
+{
+  auto cfg         = make_minio_rest_config();
+  cfg.io_telemetry = std::move(io_telemetry);
   return cfg;
 }
 
@@ -338,9 +347,9 @@ class range_http_server {
     if (_listen_fd >= 0) {
       ::shutdown(_listen_fd, SHUT_RDWR);
       ::close(_listen_fd);
-      _listen_fd = -1;
     }
     if (_thread.joinable()) { _thread.join(); }
+    _listen_fd = -1;
     for (auto& w : _workers) {
       if (w.joinable()) { w.join(); }
     }
@@ -767,13 +776,15 @@ sirius::io::rest::config direct_rest_test_config()
   return cfg;
 }
 
-std::shared_ptr<rest_ioctx> make_direct_rest_ioctx(std::string endpoint,
-                                                   sirius::io::rest::config cfg,
-                                                   std::size_t n_reactors = 1)
+std::shared_ptr<rest_ioctx> make_direct_rest_ioctx(
+  std::string endpoint,
+  sirius::io::rest::config cfg,
+  std::shared_ptr<sirius::io::io_telemetry_sink> io_telemetry = nullptr,
+  std::size_t n_reactors                                      = 1)
 {
   auto authorizer = std::make_shared<fixed_url_authorizer>(std::move(endpoint));
   auto ctx        = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
-    cfg, std::move(authorizer), nullptr);
+    cfg, std::move(authorizer), nullptr, std::move(io_telemetry));
   auto ioctx = std::make_shared<rest_ioctx>(n_reactors, std::move(ctx));
   ioctx->start();
   return ioctx;
@@ -786,6 +797,123 @@ std::shared_ptr<rest_ioctx> make_direct_rest_ioctx(std::string endpoint)
 
 using capture_sink       = sirius::test::recording_log_sink;
 using scoped_log_capture = sirius::test::scoped_recording_log_sink;
+struct io_telemetry_records {
+  std::vector<sirius::io::logical_io_record> logical;
+  std::vector<sirius::io::backend_io_record> backend;
+  std::size_t dropped{0};
+  std::size_t calls_after_seal{0};
+};
+
+struct io_telemetry_cursor {
+  std::size_t logical{0};
+  std::size_t backend{0};
+};
+
+class recording_io_telemetry_sink final : public sirius::io::io_telemetry_sink {
+ public:
+  void on_logical_read(sirius::io::logical_io_record const& record) noexcept override
+  {
+    try {
+      std::lock_guard<std::mutex> lock(_mutex);
+      if (_sealed) {
+        ++_calls_after_seal;
+      } else {
+        _logical.push_back(record);
+      }
+    } catch (...) {
+      _dropped.fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+
+  void on_backend_read(sirius::io::backend_io_record const& record) noexcept override
+  {
+    try {
+      std::lock_guard<std::mutex> lock(_mutex);
+      if (_sealed) {
+        ++_calls_after_seal;
+      } else {
+        _backend.push_back(record);
+      }
+    } catch (...) {
+      _dropped.fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+
+  [[nodiscard]] io_telemetry_cursor cursor() const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return {_logical.size(), _backend.size()};
+  }
+
+  [[nodiscard]] io_telemetry_records records_since(io_telemetry_cursor cursor) const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    REQUIRE(cursor.logical <= _logical.size());
+    REQUIRE(cursor.backend <= _backend.size());
+    return {{_logical.begin() + static_cast<std::ptrdiff_t>(cursor.logical), _logical.end()},
+            {_backend.begin() + static_cast<std::ptrdiff_t>(cursor.backend), _backend.end()},
+            _dropped.load(std::memory_order_relaxed),
+            _calls_after_seal};
+  }
+
+  [[nodiscard]] io_telemetry_records records() const { return records_since({}); }
+
+  void seal()
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _sealed = true;
+  }
+
+ private:
+  mutable std::mutex _mutex;
+  std::vector<sirius::io::logical_io_record> _logical;
+  std::vector<sirius::io::backend_io_record> _backend;
+  std::atomic<std::size_t> _dropped{0};
+  std::size_t _calls_after_seal{0};
+  bool _sealed{false};
+};
+
+bool has_backend_record(io_telemetry_records const& records, sirius::io::io_uuid read_id)
+{
+  return std::any_of(records.backend.begin(), records.backend.end(), [&](auto const& record) {
+    return record.read_id == read_id;
+  });
+}
+
+void require_source_neutral_success(io_telemetry_records const& records,
+                                    std::size_t requested_bytes)
+{
+  REQUIRE(records.dropped == 0);
+  REQUIRE(records.logical.size() == 1);
+  REQUIRE(records.backend.size() == 1);
+
+  auto const& logical = records.logical.front();
+  auto const& backend = records.backend.front();
+  CHECK_FALSE(logical.read_id.is_nil());
+  CHECK(logical.read_id == backend.read_id);
+  CHECK(logical.object_id != 0);
+  CHECK(logical.object_id == backend.object_id);
+  CHECK(logical.bytes == requested_bytes);
+  CHECK(logical.outcome == sirius::io::io_outcome::ok);
+  CHECK(logical.t_begin_ns <= logical.t_end_ns);
+  CHECK(backend.bytes_requested == requested_bytes);
+  CHECK(backend.bytes_delivered == requested_bytes);
+  CHECK(backend.chunks_total >= 1);
+  CHECK(backend.chunks_completed == backend.chunks_total);
+  CHECK(backend.terminal == sirius::io::io_terminal_class::ok);
+  CHECK(backend.t_create_ns <= backend.t_complete_ns);
+}
+
+bool read_ids_are_unique(std::vector<sirius::io::logical_io_record> const& records)
+{
+  for (std::size_t i = 0; i < records.size(); ++i) {
+    if (records[i].read_id.is_nil()) { return false; }
+    for (std::size_t j = i + 1; j < records.size(); ++j) {
+      if (records[i].read_id == records[j].read_id) { return false; }
+    }
+  }
+  return true;
+}
 
 struct list_watchdog_result {
   bool timed_out{false};
@@ -968,7 +1096,7 @@ TEST_CASE("rest perf snapshot attributes blocking host reads separately from chu
     cfg.perf_instrumentation  = true;
     cfg.max_connections       = 1;
     std::size_t const readers = 2;
-    auto ioctx                = make_direct_rest_ioctx(server.endpoint(), cfg, readers);
+    auto ioctx                = make_direct_rest_ioctx(server.endpoint(), cfg, nullptr, readers);
     auto datasource           = ioctx->open_datasource("s3://footer-bucket/native-footer.bin",
                                              static_cast<std::uint64_t>(payload.size()));
 
@@ -2389,4 +2517,426 @@ TEST_CASE("rest_ioctx teardown resolves an in-flight async read without hanging"
     INFO("teardown completed in-flight request with exception: " << e.what());
     SUCCEED("future resolved with an exception during teardown");
   }
+}
+
+TEST_CASE("IO telemetry records the REST exactly-once outcome matrix",
+          "[.][s3][integration][io_telemetry][rest]")
+{
+  SECTION("direct success emits one joined logical and backend record")
+  {
+    auto payload  = deterministic_payload(16 * 1024);
+    auto recorder = std::make_shared<recording_io_telemetry_sink>();
+    range_http_server server(payload);
+    auto ioctx = make_direct_rest_ioctx(server.endpoint(), direct_rest_test_config(), recorder);
+    auto datasource   = ioctx->open_datasource("s3://telemetry-bucket/direct.bin");
+    auto const before = recorder->cursor();
+
+    std::array<std::uint8_t, 128> got{};
+    REQUIRE(datasource->host_read(37, got.size(), got.data()) == got.size());
+    require_bytes_equal(got, std::span<std::uint8_t const>(payload.data() + 37, got.size()));
+
+    require_source_neutral_success(recorder->records_since(before), got.size());
+  }
+
+  SECTION("footer-stash success emits one logical record and no backend record")
+  {
+    auto payload  = read_binary_file(committed_parquet_fixture("nation.parquet"));
+    auto recorder = std::make_shared<recording_io_telemetry_sink>();
+    range_http_server server(payload);
+    auto ioctx = make_direct_rest_ioctx(server.endpoint(), direct_rest_test_config(), recorder);
+    auto datasource   = ioctx->open_datasource("s3://telemetry-bucket/nation.parquet",
+                                             sirius::io::open_hint::parquet_footer_probe);
+    auto const before = recorder->cursor();
+
+    std::array<std::uint8_t, 8> got{};
+    REQUIRE(datasource->host_read(payload.size() - got.size(), got.size(), got.data()) ==
+            got.size());
+    require_bytes_equal(
+      got, std::span<std::uint8_t const>(payload.data() + payload.size() - got.size(), got.size()));
+
+    auto const records = recorder->records_since(before);
+    REQUIRE(records.logical.size() == 1);
+    CHECK(records.backend.empty());
+    CHECK_FALSE(records.logical.front().read_id.is_nil());
+    CHECK(records.logical.front().route == sirius::io::io_route::direct);
+    CHECK(records.logical.front().bytes == got.size());
+    CHECK(records.logical.front().outcome == sirius::io::io_outcome::ok);
+  }
+
+  SECTION("terminal HTTP error emits one matching error pair without retry duplicates")
+  {
+    auto payload  = deterministic_payload(16 * 1024);
+    auto recorder = std::make_shared<recording_io_telemetry_sink>();
+    range_fault_policy fault{};
+    fault.fail_all_gets = true;
+    fault.fail_status   = 404;
+    range_http_server server(payload, fault);
+    auto ioctx = make_direct_rest_ioctx(server.endpoint(), direct_rest_test_config(), recorder);
+    auto datasource   = ioctx->open_datasource("s3://telemetry-bucket/missing.bin");
+    auto const before = recorder->cursor();
+
+    std::array<std::uint8_t, 128> got{};
+    CHECK_THROWS(datasource->host_read(0, got.size(), got.data()));
+
+    auto const records = recorder->records_since(before);
+    REQUIRE(records.logical.size() == 1);
+    REQUIRE(records.backend.size() == 1);
+    CHECK(records.logical.front().read_id == records.backend.front().read_id);
+    CHECK(records.logical.front().outcome == sirius::io::io_outcome::error);
+    CHECK(records.backend.front().terminal == sirius::io::io_terminal_class::http_error);
+  }
+
+  SECTION("empty request emits one zero-byte logical success and no backend record")
+  {
+    auto payload  = deterministic_payload(4096);
+    auto recorder = std::make_shared<recording_io_telemetry_sink>();
+    range_http_server server(payload);
+    auto ioctx = make_direct_rest_ioctx(server.endpoint(), direct_rest_test_config(), recorder);
+    auto datasource   = ioctx->open_datasource("s3://telemetry-bucket/empty.bin");
+    auto const before = recorder->cursor();
+
+    std::array<std::uint8_t, 1> unused{};
+    auto future = datasource->host_read_async(0, 0, unused.data());
+    REQUIRE(future.get() == 0);
+
+    auto const records = recorder->records_since(before);
+    REQUIRE(records.logical.size() == 1);
+    CHECK(records.backend.empty());
+    CHECK(records.logical.front().bytes == 0);
+    CHECK(records.logical.front().outcome == sirius::io::io_outcome::ok);
+  }
+
+  SECTION("zero-read path emits no records")
+  {
+    auto payload  = deterministic_payload(4096);
+    auto recorder = std::make_shared<recording_io_telemetry_sink>();
+    range_http_server server(payload);
+    auto ioctx = make_direct_rest_ioctx(server.endpoint(), direct_rest_test_config(), recorder);
+    auto const before = recorder->cursor();
+
+    auto datasource = ioctx->open_datasource("s3://telemetry-bucket/not-read.bin");
+    REQUIRE(datasource != nullptr);
+
+    auto const records = recorder->records_since(before);
+    CHECK(records.logical.empty());
+    CHECK(records.backend.empty());
+  }
+}
+
+TEST_CASE("IO telemetry reports REST retry outcomes without losing attempts",
+          "[.][s3][integration][io_telemetry][rest][retry]")
+{
+  auto payload = deterministic_payload(16 * 1024);
+
+  SECTION("transient HTTP failures retain retry count on success")
+  {
+    auto recorder = std::make_shared<recording_io_telemetry_sink>();
+    range_fault_policy fault{};
+    fault.fail_first_gets = 2;
+    fault.fail_status     = 503;
+    range_http_server server(payload, fault);
+    auto cfg               = direct_rest_test_config();
+    cfg.max_retry_attempts = 4;
+    auto ioctx             = make_direct_rest_ioctx(server.endpoint(), cfg, recorder);
+    auto datasource        = ioctx->open_datasource("s3://telemetry-bucket/retry-success.bin");
+    auto const before      = recorder->cursor();
+
+    std::array<std::uint8_t, 128> got{};
+    REQUIRE(datasource->host_read(0, got.size(), got.data()) == got.size());
+
+    auto const records = recorder->records_since(before);
+    require_source_neutral_success(records, got.size());
+    CHECK(records.backend.front().retries == 2);
+    CHECK(server.get_count() == 3);
+  }
+
+  SECTION("exhausted HTTP retries retain attempts and terminal class")
+  {
+    auto recorder = std::make_shared<recording_io_telemetry_sink>();
+    range_fault_policy fault{};
+    fault.fail_all_gets = true;
+    fault.fail_status   = 503;
+    range_http_server server(payload, fault);
+    auto cfg               = direct_rest_test_config();
+    cfg.max_retry_attempts = 3;
+    auto ioctx             = make_direct_rest_ioctx(server.endpoint(), cfg, recorder);
+    auto datasource        = ioctx->open_datasource("s3://telemetry-bucket/retry-exhausted.bin");
+    auto const before      = recorder->cursor();
+
+    std::array<std::uint8_t, 128> got{};
+    CHECK_THROWS(datasource->host_read(0, got.size(), got.data()));
+
+    auto const records = recorder->records_since(before);
+    REQUIRE(records.logical.size() == 1);
+    REQUIRE(records.backend.size() == 1);
+    CHECK(records.logical.front().read_id == records.backend.front().read_id);
+    CHECK(records.logical.front().outcome == sirius::io::io_outcome::error);
+    CHECK(records.backend.front().retries == cfg.max_retry_attempts - 1);
+    CHECK(records.backend.front().terminal == sirius::io::io_terminal_class::http_error);
+    CHECK(server.get_count() == cfg.max_retry_attempts);
+  }
+
+  SECTION("hard HTTP failures do not retry")
+  {
+    auto recorder = std::make_shared<recording_io_telemetry_sink>();
+    range_fault_policy fault{};
+    fault.fail_all_gets = true;
+    fault.fail_status   = 404;
+    range_http_server server(payload, fault);
+    auto cfg               = direct_rest_test_config();
+    cfg.max_retry_attempts = 4;
+    auto ioctx             = make_direct_rest_ioctx(server.endpoint(), cfg, recorder);
+    auto datasource        = ioctx->open_datasource("s3://telemetry-bucket/retry-hard.bin");
+    auto const before      = recorder->cursor();
+
+    std::array<std::uint8_t, 128> got{};
+    CHECK_THROWS(datasource->host_read(0, got.size(), got.data()));
+
+    auto const records = recorder->records_since(before);
+    REQUIRE(records.logical.size() == 1);
+    REQUIRE(records.backend.size() == 1);
+    CHECK(records.logical.front().read_id == records.backend.front().read_id);
+    CHECK(records.logical.front().outcome == sirius::io::io_outcome::error);
+    CHECK(records.backend.front().retries == 0);
+    CHECK(records.backend.front().terminal == sirius::io::io_terminal_class::http_error);
+    CHECK(server.get_count() == 1);
+  }
+}
+
+TEST_CASE("IO telemetry logical latency brackets REST backend work",
+          "[.][s3][integration][io_telemetry][rest][latency]")
+{
+  auto payload  = deterministic_payload(16 * 1024);
+  auto recorder = std::make_shared<recording_io_telemetry_sink>();
+  range_fault_policy fault{};
+  fault.response_delay = 20ms;
+  range_http_server server(payload, fault);
+  auto ioctx      = make_direct_rest_ioctx(server.endpoint(), direct_rest_test_config(), recorder);
+  auto datasource = ioctx->open_datasource("s3://telemetry-bucket/latency.bin");
+  auto const before = recorder->cursor();
+
+  std::array<std::uint8_t, 128> got{};
+  REQUIRE(datasource->host_read_async(37, got.size(), got.data()).get() == got.size());
+
+  auto const records = recorder->records_since(before);
+  require_source_neutral_success(records, got.size());
+  auto const& logical = records.logical.front();
+  auto const& backend = records.backend.front();
+  CHECK(logical.t_begin_ns <= backend.t_create_ns);
+  CHECK(backend.t_create_ns <= backend.t_complete_ns);
+  CHECK(backend.t_complete_ns <= logical.t_end_ns);
+}
+
+TEST_CASE("IO telemetry counts each public datasource overload once",
+          "[.][s3][integration][io_telemetry][rest][overloads]")
+{
+  if (!sirius::test::ensure_s3_container_env()) { return; }
+
+  auto const bucket  = require_env("SIRIUS_TEST_S3_BUCKET");
+  auto const payload = read_binary_file(local_fixture_path("small.bin"));
+  auto recorder      = std::make_shared<recording_io_telemetry_sink>();
+  scan_manager_fixture fixture;
+  sirius_scan_manager manager{make_minio_rest_config(recorder), *fixture.memory, fixture.topology};
+  auto datasource = manager.create_datasource("s3://" + bucket + "/small.bin");
+  require_rest_ioctx(datasource);
+  std::size_t constexpr offset = 37;
+  std::size_t constexpr bytes  = 128;
+  auto const before            = recorder->cursor();
+
+  SECTION("host pointer sync")
+  {
+    std::array<std::uint8_t, bytes> got{};
+    REQUIRE(datasource->host_read(offset, bytes, got.data()) == bytes);
+    require_bytes_equal(got, std::span<std::uint8_t const>(payload.data() + offset, bytes));
+  }
+
+  SECTION("host owning-buffer sync")
+  {
+    auto got = datasource->host_read(offset, bytes);
+    REQUIRE(got != nullptr);
+    CHECK(got->size() == bytes);
+  }
+
+  SECTION("host pointer async")
+  {
+    std::array<std::uint8_t, bytes> got{};
+    REQUIRE(datasource->host_read_async(offset, bytes, got.data()).get() == bytes);
+    require_bytes_equal(got, std::span<std::uint8_t const>(payload.data() + offset, bytes));
+  }
+
+  SECTION("host owning-buffer async")
+  {
+    auto got = datasource->host_read_async(offset, bytes).get();
+    REQUIRE(got != nullptr);
+    CHECK(got->size() == bytes);
+  }
+
+  SECTION("device owning-buffer sync")
+  {
+    rmm::cuda_stream stream;
+    auto got = datasource->device_read(offset, bytes, stream);
+    REQUIRE(got != nullptr);
+    CHECK(got->size() == bytes);
+  }
+
+  SECTION("device pointer sync")
+  {
+    rmm::cuda_stream stream;
+    rmm::device_buffer got(bytes, stream);
+    REQUIRE(datasource->device_read(
+              offset, bytes, static_cast<std::uint8_t*>(got.data()), stream) == bytes);
+    require_bytes_equal(copy_device_to_host(got, bytes, stream),
+                        std::span<std::uint8_t const>(payload.data() + offset, bytes));
+  }
+
+  SECTION("device pointer async")
+  {
+    rmm::cuda_stream stream;
+    rmm::device_buffer got(bytes, stream);
+    REQUIRE(
+      datasource->device_read_async(offset, bytes, static_cast<std::uint8_t*>(got.data()), stream)
+        .get() == bytes);
+    require_bytes_equal(copy_device_to_host(got, bytes, stream),
+                        std::span<std::uint8_t const>(payload.data() + offset, bytes));
+  }
+
+  require_source_neutral_success(recorder->records_since(before), bytes);
+}
+
+TEST_CASE("IO telemetry off mode leaves a REST ioctx inert",
+          "[.][s3][integration][io_telemetry][off]")
+{
+  auto payload = deterministic_payload(4096);
+  range_http_server server(payload);
+  auto ioctx = make_direct_rest_ioctx(server.endpoint());
+  REQUIRE(ioctx->io_telemetry() == nullptr);
+  auto datasource = ioctx->open_datasource("s3://telemetry-bucket/off.bin");
+
+  std::array<std::uint8_t, 128> got{};
+  REQUIRE(datasource->host_read(0, got.size(), got.data()) == got.size());
+  require_bytes_equal(got, std::span<std::uint8_t const>(payload.data(), got.size()));
+  CHECK(ioctx->io_telemetry() == nullptr);
+}
+
+TEST_CASE("IO telemetry recorder adds up concurrent REST reads without races",
+          "[.][s3][integration][io_telemetry][concurrency][tsan]")
+{
+  auto payload  = deterministic_payload(256 * 1024);
+  auto recorder = std::make_shared<recording_io_telemetry_sink>();
+  range_fault_policy fault{};
+  fault.response_delay = 10ms;
+  range_http_server server(payload, fault);
+  auto cfg            = direct_rest_test_config();
+  cfg.max_connections = 4;
+  cfg.chunk_size      = 1024;
+  cfg.max_n_chunks    = 1;
+  auto ioctx          = make_direct_rest_ioctx(server.endpoint(), cfg, recorder);
+  auto datasource     = ioctx->open_datasource("s3://telemetry-bucket/concurrent.bin");
+  auto const before   = recorder->cursor();
+
+  std::size_t constexpr readers = 16;
+  std::atomic<std::size_t> ready{0};
+  std::atomic<bool> go{false};
+  std::vector<std::exception_ptr> errors(readers);
+  std::vector<std::thread> threads;
+  threads.reserve(readers);
+  for (std::size_t i = 0; i < readers; ++i) {
+    threads.emplace_back([&, i, local = datasource->duplicate()]() mutable {
+      try {
+        ready.fetch_add(1, std::memory_order_release);
+        while (!go.load(std::memory_order_acquire)) {
+          std::this_thread::yield();
+        }
+        std::array<std::uint8_t, 256> got{};
+        auto const offset = i * 1024 + 13;
+        auto const n      = local->host_read(offset, got.size(), got.data());
+        if (n != got.size() ||
+            !std::equal(
+              got.begin(), got.end(), payload.begin() + static_cast<std::ptrdiff_t>(offset))) {
+          throw std::runtime_error("concurrent REST read returned incorrect bytes");
+        }
+      } catch (...) {
+        errors[i] = std::current_exception();
+      }
+    });
+  }
+  while (ready.load(std::memory_order_acquire) != readers) {
+    std::this_thread::yield();
+  }
+  go.store(true, std::memory_order_release);
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  for (auto const& error : errors) {
+    if (error) { std::rethrow_exception(error); }
+  }
+
+  auto const records = recorder->records_since(before);
+  CHECK(records.dropped == 0);
+  REQUIRE(records.logical.size() == readers);
+  REQUIRE(records.backend.size() == readers);
+  CHECK(read_ids_are_unique(records.logical));
+  for (auto const& logical : records.logical) {
+    CHECK(logical.outcome == sirius::io::io_outcome::ok);
+    CHECK(has_backend_record(records, logical.read_id));
+  }
+}
+
+TEST_CASE("IO telemetry finalizes queued REST reads once during teardown",
+          "[.][s3][integration][io_telemetry][lifecycle]")
+{
+  auto payload  = deterministic_payload(128 * 1024);
+  auto recorder = std::make_shared<recording_io_telemetry_sink>();
+  range_fault_policy fault{};
+  fault.response_delay = 250ms;
+  range_http_server server(payload, fault);
+  auto cfg            = direct_rest_test_config();
+  cfg.max_connections = 1;
+  auto ioctx          = make_direct_rest_ioctx(server.endpoint(), cfg, recorder);
+  auto first          = ioctx->open_datasource("s3://telemetry-bucket/teardown.bin");
+  auto second         = first->duplicate();
+  auto const before   = recorder->cursor();
+
+  std::array<std::uint8_t, 4096> first_bytes{};
+  std::array<std::uint8_t, 4096> second_bytes{};
+  auto first_future = first->host_read_async(0, first_bytes.size(), first_bytes.data());
+  auto second_future =
+    second->host_read_async(first_bytes.size(), second_bytes.size(), second_bytes.data());
+  std::this_thread::sleep_for(20ms);
+  first.reset();
+  second.reset();
+  ioctx.reset();
+
+  REQUIRE(first_future.wait_for(5s) == std::future_status::ready);
+  REQUIRE(second_future.wait_for(5s) == std::future_status::ready);
+  for (auto* future : {&first_future, &second_future}) {
+    try {
+      (void)future->get();
+    } catch (...) {
+    }
+  }
+
+  auto const records = recorder->records_since(before);
+  REQUIRE(records.logical.size() == 2);
+  REQUIRE(records.backend.size() == 2);
+  CHECK(read_ids_are_unique(records.logical));
+  bool saw_cancelled = false;
+  for (auto const& backend : records.backend) {
+    auto const terminal = backend.terminal;
+    if (terminal == sirius::io::io_terminal_class::cancelled ||
+        terminal == sirius::io::io_terminal_class::shutdown) {
+      saw_cancelled = true;
+      auto const matching =
+        std::find_if(records.logical.begin(), records.logical.end(), [&](auto const& logical) {
+          return logical.read_id == backend.read_id;
+        });
+      REQUIRE(matching != records.logical.end());
+      CHECK(matching->outcome == sirius::io::io_outcome::cancelled);
+    }
+  }
+  CHECK(saw_cancelled);
+
+  recorder->seal();
+  std::this_thread::sleep_for(50ms);
+  CHECK(recorder->records().calls_after_seal == 0);
 }


### PR DESCRIPTION
Part of #1165 (query-attributed IO telemetry). **First PR of a three-PR stack**: it lands the backend-neutral telemetry seam the IO layer will use to feed Quent, and wires it end-to-end for the **REST/S3 backend only** — no uring, no KvikIO (they keep their original read APIs and stay fully inert).
Follow-ups: `T1b` query/pipeline/device attribution, `T1c` cache/prefetch join semantics.

## Design

Three plain-C++ types and one interface, no Quent/Rust dependency (`src/include/io/io_telemetry.hpp`):

- `logical_io_record` — exactly one per caller-visible datasource read, emitted at the three leaf read implementations 

- `backend_io_record` — exactly one per request_manager, aggregating all chunks and retries for one backend read. Per-GET/per-attempt detail belongs to the later Rest Transfer layer.

- `io_attribution` — `{query, pipeline, device, phase}`, carried by value; stamped in the next PR.

- `io_telemetry_sink` — consumer interface: thread-safe, `noexcept`   non-blocking; registered through `scan_manager_config`, propagated at construction to the REST reactor context and ioctx.


## Cost

- **Off (default, no sink)**: per read, 2-3 predictable branches + one pointer load + one extra virtual hop; no atomics, clocks, or allocations; zero per-chunk work in the reactor loop. Verified by an interleaved A/B against the base (5 runs × 6 scenarios, SF10 lineitem on MinIO): deltas −0.58%…+2.05%, all within 2×CV — no measurable drift.
- **On (sink registered)**: the seam adds ~50–130 ns per logical record and ~150–250 ns per backend record (two clock reads, one 64-byte state allocation, POD construction, one virtual call) — ~0.3–0.4 µs per S3 read pair, <0.01% of a wire GET.  On S3 it should be fine.

## Read-path overview

```text
registration:
  scan_manager_config.io_telemetry ─→ rest reactor_context ─→ rest_ioctx (sink)

per read:
  caller ─→ sirius_datasource leaf ──── direct ───→ read API ─→ request_manager
               │                                                     │
               │ logical_io_record                     backend_io_record (dtor)
               │   exactly 1 / read                        exactly 1 / request
               │        └────────── shared read_id ──────────┘
               └─ cache route: silent in this PR (join lands in T1c)
  sink == nullptr  ⇒  none of the above is built (branch-only off path)
```

