### PR TITLE
feat(telemetry): report input size and rate on the task preparing transition

### DIFF
--- a/rust/crates/telemetry/analyzer/src/task.rs
+++ b/rust/crates/telemetry/analyzer/src/task.rs
@@ -82,14 +82,19 @@ impl TaskExt for Task {
             .map(|(i, transition)| {
                 // Derive the processing rate from input_bytes over the span.
                 let mut derived_attributes = vec![];
-                if let ModelTaskTransition::Computing(data) = &transition.data
+                let input_bytes = match &transition.data {
+                    ModelTaskTransition::Preparing(data) => Some(data.input_bytes),
+                    ModelTaskTransition::Computing(data) => Some(data.input_bytes),
+                    _ => None,
+                };
+                if let Some(input_bytes) = input_bytes
                     && let Some(next) = raw.get(i + 1)
                 {
                     let span_secs = (next.timestamp() - transition.timestamp()) as f64 / 1e9;
                     if span_secs > 0.0 {
                         derived_attributes.push(Attribute::f64(
                             "bytes_per_sec",
-                            data.input_bytes as f64 / span_secs,
+                            input_bytes as f64 / span_secs,
                         ));
                     }
                 }

--- a/rust/crates/telemetry/model/src/task.rs
+++ b/rust/crates/telemetry/model/src/task.rs
@@ -75,6 +75,7 @@ state! {
 state! {
     Preparing {
         attributes: {
+            origin_tier: String,
             target_tier: String,
             input_bytes: u64,
         },

--- a/rust/crates/telemetry/model/src/task.rs
+++ b/rust/crates/telemetry/model/src/task.rs
@@ -76,6 +76,7 @@ state! {
     Preparing {
         attributes: {
             target_tier: String,
+            input_bytes: u64,
         },
         usages: {
             executor_thread: ExecutorThread,

--- a/src/include/op/scan/sirius_gpu_scan_operator_data.hpp
+++ b/src/include/op/scan/sirius_gpu_scan_operator_data.hpp
@@ -110,6 +110,17 @@ class scan_operator_input : public op::operator_data {
     return *std::get<std::unique_ptr<scan_info>>(materialization_info);
   }
 
+  [[nodiscard]] std::string get_origin_tiers() const override
+  {
+    if (!is_resident()) { return "SOURCE"; }
+    // The batch's tier is only readable through a lock accessor; take the non-blocking
+    // one and fall back to UNKNOWN if the batch is exclusively locked right now.
+    if (auto ro = get_cached_batch()->try_to_read_only()) {
+      return tier_display_name(ro->get_current_tier());
+    }
+    return "UNKNOWN";
+  }
+
   [[nodiscard]] std::shared_ptr<::cucascade::data_batch> get_cached_batch() const
   {
     if (!is_resident()) {

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -27,10 +27,12 @@
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
 
+#include <array>
 #include <atomic>
 #include <list>
 #include <memory>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -56,6 +58,19 @@ class sirius_physical_plan_generator;
 namespace op {
 
 enum class TaskCreationHint { WAITING_FOR_INPUT_DATA, READY };
+
+/**
+ * @brief Display name of a memory tier for telemetry attributes.
+ */
+[[nodiscard]] constexpr const char* tier_display_name(::cucascade::memory::Tier tier)
+{
+  switch (tier) {
+    case ::cucascade::memory::Tier::GPU: return "GPU";
+    case ::cucascade::memory::Tier::HOST: return "HOST";
+    case ::cucascade::memory::Tier::DISK: return "DISK";
+    default: return "UNKNOWN";
+  }
+}
 
 enum class MemoryBarrierType { PIPELINE, PARTIAL, FULL };
 
@@ -157,6 +172,15 @@ class operator_data {
    * represent GPU-resident data should override to return a meaningful estimate.
    */
   [[nodiscard]] virtual std::size_t get_estimated_size_in_bytes() const { return 0; }
+
+  /**
+   * @brief Summarize where this data currently lives, for telemetry.
+   *
+   * Returns a '+'-joined set of memory tiers in tier order (e.g. "GPU+HOST"),
+   * "SOURCE" for fresh reads from a datasource, or "UNKNOWN" when the subclass
+   * cannot tell (the default).
+   */
+  [[nodiscard]] virtual std::string get_origin_tiers() const { return "UNKNOWN"; }
 
   /**
    * @brief Estimate the transient working set needed to materialize this data.
@@ -268,6 +292,23 @@ class pipelineable_operator_data : public operator_data {
       if (ro.get_data()) { total += ro.get_data()->get_uncompressed_data_size_in_bytes(); }
     }
     return total;
+  }
+
+  [[nodiscard]] std::string get_origin_tiers() const override
+  {
+    std::array<bool, static_cast<std::size_t>(::cucascade::memory::Tier::SIZE)> present{};
+    for (auto const& ro : get_read_only_batches(false)) {
+      if (!ro.get_data()) { continue; }
+      auto tier = static_cast<std::size_t>(ro.get_current_tier());
+      if (tier < present.size()) { present[tier] = true; }
+    }
+    std::string result;
+    for (std::size_t i = 0; i < present.size(); ++i) {
+      if (!present[i]) { continue; }
+      if (!result.empty()) { result += '+'; }
+      result += tier_display_name(static_cast<::cucascade::memory::Tier>(i));
+    }
+    return result.empty() ? "UNKNOWN" : result;
   }
 
  private:

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -28,8 +28,10 @@
 #include <cucascade/memory/memory_reservation.hpp>
 #include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 
+#include <array>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace sirius {
@@ -123,6 +125,33 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
       }
     }
     return input_size;
+  }
+
+  /**
+   * @brief Summarize the memory tiers the input batches currently live on.
+   *
+   * Returns a '+'-joined set in tier order (e.g. "GPU+HOST"), or "UNKNOWN" when the
+   * input is not batch-backed.
+   */
+  [[nodiscard]] std::string get_input_origin_tiers() const
+  {
+    auto* pipelineable_input =
+      dynamic_cast<const op::pipelineable_operator_data*>(_input_data.get());
+    if (!pipelineable_input) { return "UNKNOWN"; }
+    std::array<bool, static_cast<std::size_t>(cucascade::memory::Tier::SIZE)> present{};
+    for (const auto& ro : pipelineable_input->get_read_only_batches(false)) {
+      if (!ro.get_data()) { continue; }
+      auto tier = static_cast<std::size_t>(ro.get_current_tier());
+      if (tier < present.size()) { present[tier] = true; }
+    }
+    static constexpr std::array<const char*, 3> tier_names{"GPU", "HOST", "DISK"};
+    std::string result;
+    for (std::size_t i = 0; i < tier_names.size(); ++i) {
+      if (!present[i]) { continue; }
+      if (!result.empty()) { result += '+'; }
+      result += tier_names[i];
+    }
+    return result.empty() ? "UNKNOWN" : result;
   }
 
  private:

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -28,10 +28,8 @@
 #include <cucascade/memory/memory_reservation.hpp>
 #include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 
-#include <array>
 #include <cstdint>
 #include <memory>
-#include <string>
 #include <vector>
 
 namespace sirius {
@@ -125,33 +123,6 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
       }
     }
     return input_size;
-  }
-
-  /**
-   * @brief Summarize the memory tiers the input batches currently live on.
-   *
-   * Returns a '+'-joined set in tier order (e.g. "GPU+HOST"), or "UNKNOWN" when the
-   * input is not batch-backed.
-   */
-  [[nodiscard]] std::string get_input_origin_tiers() const
-  {
-    auto* pipelineable_input =
-      dynamic_cast<const op::pipelineable_operator_data*>(_input_data.get());
-    if (!pipelineable_input) { return "UNKNOWN"; }
-    std::array<bool, static_cast<std::size_t>(cucascade::memory::Tier::SIZE)> present{};
-    for (const auto& ro : pipelineable_input->get_read_only_batches(false)) {
-      if (!ro.get_data()) { continue; }
-      auto tier = static_cast<std::size_t>(ro.get_current_tier());
-      if (tier < present.size()) { present[tier] = true; }
-    }
-    static constexpr std::array<const char*, 3> tier_names{"GPU", "HOST", "DISK"};
-    std::string result;
-    for (std::size_t i = 0; i < tier_names.size(); ++i) {
-      if (!present[i]) { continue; }
-      if (!result.empty()) { result += '+'; }
-      result += tier_names[i];
-    }
-    return result.empty() ? "UNKNOWN" : result;
   }
 
  private:

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -404,7 +404,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
   }
   telemetry_handle().preparing({
     .instance_name               = "",
-    .origin_tier                 = local_state.get_input_origin_tiers(),
+    .origin_tier                 = local_state._input_data->get_origin_tiers(),
     .target_tier                 = "GPU",
     .input_bytes                 = local_state._input_data->get_estimated_size_in_bytes(),
     .executor_thread_resource_id = executor_thread_resource_id,

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -404,6 +404,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
   }
   telemetry_handle().preparing({
     .instance_name               = "",
+    .origin_tier                 = local_state.get_input_origin_tiers(),
     .target_tier                 = "GPU",
     .input_bytes                 = local_state._input_data->get_estimated_size_in_bytes(),
     .executor_thread_resource_id = executor_thread_resource_id,

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -405,6 +405,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
   telemetry_handle().preparing({
     .instance_name               = "",
     .target_tier                 = "GPU",
+    .input_bytes                 = local_state._input_data->get_estimated_size_in_bytes(),
     .executor_thread_resource_id = executor_thread_resource_id,
   });
   try {


### PR DESCRIPTION
## Summary

In the quent UI, task computing sections show `input_bytes` and a derived `bytes_per_sec` rate, but the preparing section that precedes them showed neither. This PR adds both — plus an `origin_tier` attribute — so the preparation phase (staging/upgrading input onto the GPU) is visible in the UI:

- **Model** (`rust/crates/telemetry/model/src/task.rs`): add `origin_tier: String` and `input_bytes: u64` attributes to the task FSM's `Preparing` state. The C++ bridge API is code-generated from the model, so the fields flow through automatically.
- **Emitter** (`src/pipeline/gpu_pipeline_task.cpp`): the preparing transition now reports the input's `get_estimated_size_in_bytes()` — the same size the first computing transition reports — and its origin tiers.
- **Origin reporting** (`src/include/op/sirius_physical_operator.hpp`, `src/include/op/scan/sirius_gpu_scan_operator_data.hpp`): a new `operator_data::get_origin_tiers()` virtual. `pipelineable_operator_data` returns the '+'-joined set of its batches' tiers in tier order (e.g. `GPU+HOST`); `scan_operator_input` returns `SOURCE` for a fresh datasource read or the cached batch's tier when resident (via the non-blocking lock accessor, since `data_batch` keeps its tier private); the base default is `UNKNOWN`. `tier_display_name()` is a shared tier-to-string helper.
- **Analyzer** (`rust/crates/telemetry/analyzer/src/task.rs`): the `bytes_per_sec` derivation that previously only ran for `Computing` transitions now also covers `Preparing`, dividing `input_bytes` by the span to the next transition.

No UI changes needed — the quent UI infers formatting from attribute names (`*_bytes` → IEC size, `bytes_per_sec` → SI B/s rate), so the preparing section picks up the same display treatment the computing sections already have.

## Compatibility note

This changes the `Preparing` state schema: telemetry captured before this change cannot be loaded by the newer analyzer (and vice versa) — recapture instead.

## Testing

- `cargo check`/`cargo test` on `instrumentation-model`, `sirius-telemetry-analyzer`, and `telemetry-bridge` (bridge codegen verified: generated C++ struct field order matches the emitter's designated initializer).
- Full `pixi run make test` — all 1802 test cases pass.
- Verified live on an SF100 TPC-H capture (Q1/Q5/Q9): all 557 tasks report a real origin (`GPU` for pipeline tasks, `SOURCE` for fresh scans, zero `UNKNOWN`), and the quent UI renders size/rate/origin on preparing sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
