### PR TITLE
feat(scheduler): priority-ordered pipeline task queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ set(EXTENSION_SOURCES
     src/pipeline/sirius_plan_printer.cpp
     src/pipeline/task_request.cpp
     src/planner/query.cpp
+    src/planner/query_index.cpp
     src/planner/sirius_physical_plan_generator.cpp
     src/planner/sirius_plan_aggregate.cpp
     src/planner/sirius_plan_column_data_get.cpp
@@ -524,6 +525,7 @@ set(TEST_SOURCES
     test/cpp/downgrade/test_downgrade_lifecycle.cpp
     test/cpp/exec/test_bounded_thread_pool.cpp
     test/cpp/exec/test_inspectable_mpsc.cpp
+    test/cpp/exec/test_inspectable_priority_queue.cpp
     test/cpp/exec/test_interruptible_mpmc.cpp
     test/cpp/exec/test_semi_future.cpp
     test/cpp/expression/test_ast_aggregate.cpp
@@ -592,6 +594,7 @@ set(TEST_SOURCES
     test/cpp/parallel/test_task_executor.cpp
     test/cpp/planner/test_distinct_hash_join_detection.cpp
     test/cpp/planner/test_projection_fold.cpp
+    test/cpp/planner/test_query_index.cpp
     test/cpp/pipeline/test_gpu_pipeline_executor.cpp
     test/cpp/pipeline/test_oom_reschedule.cpp
     test/cpp/pipeline/test_pipeline_memory_history.cpp

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -24,6 +24,7 @@
 #include "pipeline/gpu_pipeline_task.hpp"
 #include "pipeline/task_scheduler.hpp"
 #include "planner/query.hpp"
+#include "planner/query_index.hpp"
 #include "sirius_context.hpp"
 
 #include <cucascade/cudf/gpu_data_representation.hpp>
@@ -104,6 +105,8 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
   std::shared_ptr<const telemetry::telemetry_context> telemetry_context =
     sirius_ctx->get_telemetry_context();
 
+  auto pipeline_priorities = compute_pipeline_priorities(query);
+
   for (const auto& pipeline : pipelines) {
     pipeline->set_task_creator(this);
     auto source_operator = pipeline->get_source();
@@ -114,8 +117,55 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
     size_t operator_id = source_operator->get_operator_id();
     auto gs =
       std::make_shared<pipeline::gpu_pipeline_task_global_state>(pipeline, telemetry_context);
+    if (auto it = pipeline_priorities.find(pipeline.get()); it != pipeline_priorities.end()) {
+      gs->set_priority(it->second);
+    }
     _gpu_operator_global_state_map.emplace(operator_id, std::move(gs));
   }
+}
+
+std::unordered_map<const pipeline::sirius_pipeline*, exec::queue_priority>
+task_creator::compute_pipeline_priorities(const sirius::planner::query& query) const
+{
+  // Partition the pipeline DAG into branches (linear chains between branch points) and give each
+  // pipeline a scheduling priority. Higher priority is dispatched first by the pipeline-level
+  // priority queue. The rules (see query_index for the branch definition):
+  //   - Branches are ordered by plan order; an earlier branch is ALWAYS strictly higher priority
+  //     than a later one (guaranteed by a per-branch stride larger than any branch length).
+  //   - Within a branch, FIFO ranks the head (closest to the scan) highest; LIFO reverses it.
+  //   - A pipeline shared by several branches (a join/merge endpoint) takes the MAX priority of
+  //     the branches that reach it, so it runs as soon as its earliest-needed branch wants it.
+  std::unordered_map<const pipeline::sirius_pipeline*, exec::queue_priority> priorities;
+
+  auto index    = planner::query_index::build_index(query);
+  auto branches = index->get_branches();
+  if (branches.empty()) { return priorities; }
+
+  const bool lifo = _task_scheduler != nullptr &&
+                    _task_scheduler->get_task_queue_ordering() == exec::queue_ordering::LIFO;
+
+  // Stride larger than any branch length keeps cross-branch ordering strictly dominant over the
+  // within-branch offset.
+  std::size_t max_branch_len = 0;
+  for (const auto& chain : branches) {
+    max_branch_len = std::max(max_branch_len, chain.size());
+  }
+  const exec::queue_priority stride = static_cast<exec::queue_priority>(max_branch_len) + 1;
+
+  const std::size_t num_branches = branches.size();
+  for (std::size_t b = 0; b < num_branches; ++b) {
+    const auto& chain               = branches[b];
+    const auto len                  = chain.size();
+    const exec::queue_priority base = static_cast<exec::queue_priority>(num_branches - b) * stride;
+    for (std::size_t pos = 0; pos < len; ++pos) {
+      const exec::queue_priority within   = lifo ? static_cast<exec::queue_priority>(pos + 1)
+                                                 : static_cast<exec::queue_priority>(len - pos);
+      const exec::queue_priority priority = base + within;
+      auto [it, inserted]                 = priorities.try_emplace(chain[pos], priority);
+      if (!inserted) { it->second = std::max(it->second, priority); }
+    }
+  }
+  return priorities;
 }
 
 void task_creator::signal_query_complete()

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -45,7 +45,7 @@ downgrade_executor::downgrade_executor(
   cucascade::memory::memory_space_id space_id,
   cucascade::memory::memory_space* memory_space,
   sirius::memory::sirius_memory_reservation_manager& reservation_manager,
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask>* pipeline_task_queue)
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask>* pipeline_task_queue)
   : _config(std::move(config)),
     _data_repo_mgr(data_repo_mgr),
     _space_id(space_id),
@@ -484,7 +484,7 @@ void downgrade_executor::cancel_pending_requests()
 }
 
 void downgrade_executor::set_pipeline_task_queue(
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask>* pipeline_task_queue)
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask>* pipeline_task_queue)
 {
   _pipeline_task_queue = pipeline_task_queue;
 }

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -19,6 +19,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "exec/bounded_thread_pool.hpp"
 #include "exec/config.hpp"
+#include "exec/inspectable_priority_queue.hpp"
 #include "exec/interruptible_mpmc.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "op/sirius_physical_operator.hpp"
@@ -154,6 +155,20 @@ class task_creator {
    * @return uint64_t The next task id.
    */
   uint64_t get_next_task_id();
+
+  /**
+   * @brief Compute a scheduling priority for every pipeline in the query.
+   *
+   * Partitions the pipeline DAG into branches (via query_index) and assigns each pipeline a
+   * priority so that earlier (closer-to-scan) branches outrank later ones, honoring the
+   * configured FIFO/LIFO ordering within each branch. Exposed for unit testing.
+   *
+   * @param query The query whose pipelines are prioritized.
+   * @return Map from pipeline to its scheduling priority (pipelines absent from the map keep the
+   *         default priority of 0).
+   */
+  [[nodiscard]] std::unordered_map<const pipeline::sirius_pipeline*, exec::queue_priority>
+  compute_pipeline_priorities(const sirius::planner::query& query) const;
 
  protected:
   /**

--- a/src/include/data/convertible_gpu_pipeline_task.hpp
+++ b/src/include/data/convertible_gpu_pipeline_task.hpp
@@ -19,7 +19,7 @@
 #include "data/convertible_data.hpp"
 #include "data/convertible_data_batch.hpp"
 #include "data/sirius_converter_registry.hpp"
-#include "exec/inspectable_mpsc.hpp"
+#include "exec/inspectable_priority_queue.hpp"
 #include "log/logging.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "parallel/task.hpp"
@@ -63,8 +63,9 @@ class convertible_gpu_pipeline_task : public convertible_data {
    * @param task The task to wrap (exclusive ownership taken).
    * @param queue The originating task queue (task is returned here on destruction).
    */
-  convertible_gpu_pipeline_task(std::unique_ptr<sirius::parallel::itask> task,
-                                sirius::exec::inspectable_mpsc<sirius::parallel::itask>& queue)
+  convertible_gpu_pipeline_task(
+    std::unique_ptr<sirius::parallel::itask> task,
+    sirius::exec::inspectable_priority_queue<sirius::parallel::itask>& queue)
     : _task(std::move(task)), _queue(queue)
   {
   }
@@ -208,7 +209,7 @@ class convertible_gpu_pipeline_task : public convertible_data {
   }
 
   std::unique_ptr<sirius::parallel::itask> _task;
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask>& _queue;
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask>& _queue;
 };
 
 /**
@@ -227,7 +228,7 @@ class convertible_gpu_pipeline_task_provider : public convertible_data_provider 
    * @param queue The task queue to search (non-owning reference).
    */
   explicit convertible_gpu_pipeline_task_provider(
-    sirius::exec::inspectable_mpsc<sirius::parallel::itask>& queue)
+    sirius::exec::inspectable_priority_queue<sirius::parallel::itask>& queue)
     : _queue(queue)
   {
   }
@@ -310,7 +311,7 @@ class convertible_gpu_pipeline_task_provider : public convertible_data_provider 
     return false;
   }
 
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask>& _queue;
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask>& _queue;
 };
 
 }  // namespace sirius

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -18,7 +18,7 @@
 
 #include "exec/bounded_thread_pool.hpp"
 #include "exec/config.hpp"
-#include "exec/inspectable_mpsc.hpp"
+#include "exec/inspectable_priority_queue.hpp"
 #include "exec/interruptible_mpmc.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "parallel/task.hpp"
@@ -88,7 +88,8 @@ class downgrade_executor {
     cucascade::memory::memory_space_id space_id,
     cucascade::memory::memory_space* memory_space,
     sirius::memory::sirius_memory_reservation_manager& reservation_manager,
-    sirius::exec::inspectable_mpsc<sirius::parallel::itask>* pipeline_task_queue = nullptr);
+    sirius::exec::inspectable_priority_queue<sirius::parallel::itask>* pipeline_task_queue =
+      nullptr);
 
   ~downgrade_executor();
 
@@ -137,7 +138,7 @@ class downgrade_executor {
    * @param pipeline_task_queue Pointer to the task_scheduler's task queue
    */
   void set_pipeline_task_queue(
-    sirius::exec::inspectable_mpsc<sirius::parallel::itask>* pipeline_task_queue);
+    sirius::exec::inspectable_priority_queue<sirius::parallel::itask>* pipeline_task_queue);
 
   /**
    * @brief Asynchronously request a predicate-driven downgrade.
@@ -203,7 +204,7 @@ class downgrade_executor {
   cucascade::memory::memory_space* _memory_space;
   std::string _source_label;
   sirius::memory::sirius_memory_reservation_manager& _reservation_manager;
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask>* _pipeline_task_queue{nullptr};
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask>* _pipeline_task_queue{nullptr};
 };
 
 }  // namespace parallel

--- a/src/include/exec/inspectable_priority_queue.hpp
+++ b/src/include/exec/inspectable_priority_queue.hpp
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace sirius::exec {
+
+/// The priority type used to order items in inspectable_priority_queue. Larger values are
+/// higher priority (popped from the front first). Signed so callers can express "lower than
+/// default" priorities without underflow tricks.
+using queue_priority = std::int64_t;
+
+/**
+ * @brief A thread-safe, inspectable priority queue backed by a contiguous vector.
+ *
+ * Drop-in replacement for inspectable_mpsc that orders items by an explicit priority rather
+ * than by insertion order. The backing storage is a std::vector kept sorted by priority in
+ * descending order (highest priority at the front), so:
+ *   - pop() / try_pop() / pop_front() return the highest-priority item,
+ *   - pop_back() returns the lowest-priority item.
+ * Ties (equal priority) preserve insertion order (FIFO among equals), matching the legacy
+ * queue's behavior when every item shares the default priority.
+ *
+ * The priority of an item is obtained through a caller-supplied extractor at construction
+ * time. When no extractor is provided every item gets priority 0, which reduces to a plain
+ * FIFO queue. Priority is captured once at push time and never re-read, so mutating an item's
+ * priority after it is enqueued has no effect on its position.
+ *
+ * A vector backing (rather than a heap) is deliberate: pop_if() / mutable_pop_if() and the
+ * downgrade inspector scan the whole queue, and callers benefit from cheap in-order iteration.
+ */
+template <typename T>
+class inspectable_priority_queue {
+ public:
+  /// Extracts the priority of an item. Returning a larger value ranks the item closer to the
+  /// front (popped sooner).
+  using priority_fn = std::function<queue_priority(const T&)>;
+
+ private:
+  struct entry {
+    queue_priority priority;
+    std::unique_ptr<T> item;
+  };
+
+  std::vector<entry> _queue;  ///< Sorted by priority descending; ties keep insertion order.
+  mutable std::mutex _mutex;
+  std::condition_variable _cv;
+  bool _active{true};
+  priority_fn _priority_fn;
+
+ public:
+  inspectable_priority_queue() : _priority_fn([](const T&) -> queue_priority { return 0; }) {}
+  explicit inspectable_priority_queue(priority_fn fn) : _priority_fn(std::move(fn))
+  {
+    if (!_priority_fn) {
+      _priority_fn = [](const T&) -> queue_priority { return 0; };
+    }
+  }
+  ~inspectable_priority_queue() = default;
+
+  inspectable_priority_queue(const inspectable_priority_queue&)            = delete;
+  inspectable_priority_queue& operator=(const inspectable_priority_queue&) = delete;
+  inspectable_priority_queue(inspectable_priority_queue&&)                 = delete;
+  inspectable_priority_queue& operator=(inspectable_priority_queue&&)      = delete;
+
+  /**
+   * \brief Pushes an item into the queue at its priority-sorted position.
+   * \return Returns false if the queue has been interrupted.
+   */
+  [[nodiscard]] bool push(std::unique_ptr<T> item)
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    if (!_active) { return false; }
+    // Compute priority before the move: argument evaluation order is unspecified, so passing
+    // _priority_fn(*item) and std::move(item) to one call risks reading a moved-from pointer.
+    const queue_priority priority = _priority_fn(*item);
+    insert_unlocked(priority, std::move(item));
+    lock.unlock();
+    _cv.notify_one();
+    return true;
+  }
+
+  /**
+   * \brief Constructs an item in-place and enqueues it at its priority-sorted position.
+   * \return Returns false if the queue has been interrupted.
+   */
+  template <typename... Args>
+  [[nodiscard]] bool emplace(Args&&... args)
+  {
+    auto item = std::make_unique<T>(std::forward<Args>(args)...);
+    std::unique_lock<std::mutex> lock(_mutex);
+    if (!_active) { return false; }
+    const queue_priority priority = _priority_fn(*item);
+    insert_unlocked(priority, std::move(item));
+    lock.unlock();
+    _cv.notify_one();
+    return true;
+  }
+
+  /**
+   * \brief Blocks waiting for the highest-priority item.
+   * \return Returns nullptr if the queue is interrupted and empty.
+   *
+   * If the queue is interrupted but still has items, those items are returned (highest
+   * priority first) before nullptr. Uses condition_variable::wait for true blocking.
+   */
+  std::unique_ptr<T> pop()
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    _cv.wait(lock, [this] { return !_queue.empty() || !_active; });
+    if (_queue.empty()) { return nullptr; }
+    return pop_front_unlocked();
+  }
+
+  /**
+   * \brief Attempts to pop the highest-priority item without blocking.
+   * \return Returns nullptr if the queue is empty.
+   */
+  std::unique_ptr<T> try_pop()
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    if (_queue.empty()) { return nullptr; }
+    return pop_front_unlocked();
+  }
+
+  /**
+   * \brief Removes and returns the highest-priority item, or nullptr if empty. Non-blocking.
+   */
+  std::unique_ptr<T> pop_front() { return try_pop(); }
+
+  /**
+   * \brief Removes and returns the lowest-priority item, or nullptr if empty. Non-blocking.
+   */
+  std::unique_ptr<T> pop_back()
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    if (_queue.empty()) { return nullptr; }
+    auto item = std::move(_queue.back().item);
+    _queue.pop_back();
+    return item;
+  }
+
+  /**
+   * \brief Interrupts the queue, causing blocked pop() calls to return nullptr.
+   */
+  void interrupt()
+  {
+    {
+      std::unique_lock<std::mutex> lock(_mutex);
+      _active = false;
+    }
+    _cv.notify_all();
+  }
+
+  /**
+   * \brief Reactivates the queue after an interrupt, restoring normal operation.
+   */
+  void reactivate()
+  {
+    {
+      std::unique_lock<std::mutex> lock(_mutex);
+      _active = true;
+    }
+    _cv.notify_all();
+  }
+
+  /**
+   * \brief Removes all queued items.
+   */
+  void drain()
+  {
+    {
+      std::unique_lock<std::mutex> lock(_mutex);
+      _queue.clear();
+    }
+    _cv.notify_all();
+  }
+
+  /**
+   * \brief Returns true if the queue is active (not interrupted).
+   */
+  [[nodiscard]] bool is_open() const
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    return _active;
+  }
+
+  /**
+   * \brief Returns true if the queue contains no items.
+   */
+  [[nodiscard]] bool is_empty() const
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    return _queue.empty();
+  }
+
+  /**
+   * \brief Returns the number of items currently in the queue.
+   */
+  [[nodiscard]] std::size_t size() const
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    return _queue.size();
+  }
+
+  /**
+   * \brief Removes and returns the first element matching the predicate.
+   * \param predicate Callable receiving const T& and returning bool.
+   * \param front_to_back If true, searches highest-to-lowest priority; if false,
+   *        lowest-to-highest.
+   * \return The matching element, or nullptr if no match found.
+   *
+   * Holds the mutex for the entire scan. Predicate should be lightweight.
+   */
+  std::unique_ptr<T> pop_if(std::function<bool(const T&)> predicate, bool front_to_back)
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    return pop_if_unlocked([&](T& t) { return predicate(t); }, front_to_back);
+  }
+
+  /**
+   * \brief Removes and returns the first element matching the mutable predicate.
+   * \param predicate Callable receiving T& (mutable) and returning bool.
+   * \param front_to_back If true, searches highest-to-lowest priority; if false,
+   *        lowest-to-highest.
+   * \return The matching element, or nullptr if no match found.
+   */
+  std::unique_ptr<T> mutable_pop_if(std::function<bool(T&)> predicate, bool front_to_back)
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    return pop_if_unlocked([&](T& t) { return predicate(t); }, front_to_back);
+  }
+
+ private:
+  /// Insert item keeping the vector sorted by priority descending, with FIFO order among
+  /// equal priorities. Caller must hold _mutex.
+  void insert_unlocked(queue_priority priority, std::unique_ptr<T> item)
+  {
+    // Find the first entry with strictly lower priority; insert before it so all
+    // equal-priority entries pushed earlier stay ahead (FIFO among equals).
+    auto pos = std::find_if(
+      _queue.begin(), _queue.end(), [priority](const entry& e) { return e.priority < priority; });
+    _queue.insert(pos, entry{priority, std::move(item)});
+  }
+
+  /// Pop the front (highest-priority) element. Caller must hold _mutex and ensure non-empty.
+  std::unique_ptr<T> pop_front_unlocked()
+  {
+    auto item = std::move(_queue.front().item);
+    _queue.erase(_queue.begin());
+    return item;
+  }
+
+  template <typename Pred>
+  std::unique_ptr<T> pop_if_unlocked(Pred predicate, bool front_to_back)
+  {
+    if (front_to_back) {
+      for (auto it = _queue.begin(); it != _queue.end(); ++it) {
+        if (predicate(*it->item)) {
+          auto item = std::move(it->item);
+          _queue.erase(it);
+          return item;
+        }
+      }
+    } else {
+      for (auto rit = _queue.rbegin(); rit != _queue.rend(); ++rit) {
+        if (predicate(*rit->item)) {
+          auto item = std::move(rit->item);
+          _queue.erase(std::next(rit).base());
+          return item;
+        }
+      }
+    }
+    return nullptr;
+  }
+};
+
+}  // namespace sirius::exec

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -170,6 +170,23 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
   }
 
   /**
+   * @brief Get the scheduling priority for this task.
+   *
+   * Priority is a pipeline-level property carried on the shared global state, so every task of a
+   * pipeline reports the same value. Higher priorities are dispatched first by the pipeline-level
+   * priority queue. Defaults to 0 when no global state is attached.
+   *
+   * @return The scheduling priority for this task.
+   */
+  [[nodiscard]] exec::queue_priority get_priority() const
+  {
+    if (auto gs = std::dynamic_pointer_cast<const gpu_pipeline_task_global_state>(_global_state)) {
+      return gs->get_priority();
+    }
+    return 0;
+  }
+
+  /**
    * @brief Get the GPU pipeline associated with this task
    *
    * @return const duckdb::sirius_pipeline* Pointer to the GPU pipeline

--- a/src/include/pipeline/sirius_pipeline_task_states.hpp
+++ b/src/include/pipeline/sirius_pipeline_task_states.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "exec/inspectable_priority_queue.hpp"
 #include "parallel/task.hpp"
 #include "pipeline/pipeline_memory_history.hpp"
 #include "pipeline/sirius_pipeline.hpp"
@@ -115,10 +116,24 @@ class sirius_pipeline_task_global_state : public sirius::parallel::itask_global_
    */
   [[nodiscard]] std::optional<int> get_preferred_device_id() const { return _preferred_device_id; }
 
+  /**
+   * @brief Set the scheduling priority shared by all tasks of this pipeline.
+   *
+   * Higher values are scheduled first by the pipeline-level priority queue. Assigned once per
+   * query by task_creator::prepare_for_query() based on the pipeline's position in the plan.
+   */
+  void set_priority(exec::queue_priority priority) { _priority = priority; }
+
+  /**
+   * @brief Get the scheduling priority for this pipeline's tasks (default 0).
+   */
+  [[nodiscard]] exec::queue_priority get_priority() const { return _priority; }
+
  private:
   duckdb::shared_ptr<sirius_pipeline> _pipeline;  ///< Shared pointer to the GPU pipeline to execute
   pipeline_memory_history _memory_history;        ///< Historical memory metrics for estimation
   std::optional<int> _preferred_device_id;        ///< Pipeline-level preferred GPU device
+  exec::queue_priority _priority{0};              ///< Pipeline-level scheduling priority
   std::shared_ptr<const telemetry::telemetry_context>
     _telemetry_context;  ///< SiriusContext telemetry
 };

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -19,6 +19,7 @@
 #include "exec/channel.hpp"
 #include "exec/config.hpp"
 #include "exec/inspectable_mpsc.hpp"
+#include "exec/inspectable_priority_queue.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "parallel/task.hpp"
 #include "pipeline/completion_handler.hpp"
@@ -129,9 +130,22 @@ class task_scheduler {
   /**
    * @brief Get a pointer to the pipeline-level task queue.
    */
-  [[nodiscard]] exec::inspectable_mpsc<sirius::parallel::itask>* get_pipeline_task_queue() noexcept
+  [[nodiscard]] exec::inspectable_priority_queue<sirius::parallel::itask>*
+  get_pipeline_task_queue() noexcept
   {
     return &_task_queue;
+  }
+
+  /**
+   * @brief Get the configured task-queue ordering (FIFO/LIFO).
+   *
+   * The pipeline-level queue is now ordered strictly by task priority; this setting no longer
+   * controls the queue itself. It is consumed by task_creator when assigning per-pipeline
+   * priorities: FIFO keeps plan order within a branch, LIFO reverses it.
+   */
+  [[nodiscard]] exec::queue_ordering get_task_queue_ordering() const noexcept
+  {
+    return _task_queue_ordering;
   }
 
   /**
@@ -220,7 +234,11 @@ class task_scheduler {
   std::mutex _query_mutex;
   duckdb::shared_ptr<planner::query> _query;
 
-  exec::inspectable_mpsc<sirius::parallel::itask> _task_queue;  ///< Queue for GPU pipeline tasks
+  /// Pipeline-level task queue, ordered by task priority (highest dispatched first).
+  exec::inspectable_priority_queue<sirius::parallel::itask> _task_queue;
+  /// Configured FIFO/LIFO ordering. No longer applied to the queue (which is priority-ordered);
+  /// read by task_creator to decide within-branch priority direction. See get_task_queue_ordering.
+  exec::queue_ordering _task_queue_ordering;
   exec::channel<std::unique_ptr<task_request>> _task_request_channel;
   /// Publisher used by schedule() to wake the management event loop when a new
   /// task is pushed into _task_queue. The event loop blocks on _task_request_channel

--- a/src/include/planner/query_index.hpp
+++ b/src/include/planner/query_index.hpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "op/sirius_physical_operator.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+namespace sirius::planner {
+
+class query;
+
+/// Options for query_index::build_index. Reserved for future tuning; empty for now.
+struct build_index_options {};
+
+/**
+ * @brief Precomputed structural index over a query's pipeline DAG.
+ *
+ * The index partitions the pipeline DAG into linear "branches". A branch is a maximal chain of
+ * pipelines that runs from one branch point to the next, following consumer (downstream) edges.
+ * A pipeline is a branch point when it is not a simple 1-producer / 1-consumer pass-through:
+ * scans (0 producers), joins / merges (>1 producer, "fan-in"), forks (>1 consumer, "fan-out"),
+ * and terminal result pipelines (0 consumers) are all branch points. Both endpoints of a branch
+ * are branch points, so adjacent branches share their boundary pipeline.
+ *
+ * Example (numbers are pipelines; 3, 7, 10 are joins/forks):
+ *   1 -> 2 -> 3        4 -> 5 -> 3       3 -> 6 -> 7      8 -> 9 -> 10 -> 7
+ *   11 -> 10           3 -> 12
+ * yields the branches [1,2,3], [4,5,3], [3,6,7], [3,12], [8,9,10,7], [11,10], ... with pipeline 3
+ * appearing (as a shared endpoint) in several branches.
+ *
+ * Branches are stored in plan order (by the head pipeline's position in the query's execution
+ * order), so earlier branches sit closer to the scans. Callers use this order to assign
+ * scheduling priority: earlier branch => higher priority.
+ */
+class query_index {
+ public:
+  using pipeline_ptr = pipeline::sirius_pipeline*;
+  /// A branch: a chain of pipelines from one branch point to the next (both endpoints included),
+  /// head first (closest to the scans).
+  using branch = std::span<pipeline_ptr const>;
+
+  /**
+   * @brief Build the structural index for a query.
+   *
+   * @param q The query whose pipeline DAG is indexed.
+   * @param options Reserved for future tuning.
+   * @return A shared, immutable index valid for as long as the query's pipelines live.
+   */
+  static std::shared_ptr<const query_index> build_index(const query& q,
+                                                        build_index_options options = {});
+
+  /**
+   * @brief Build the structural index directly from a pipeline list (in execution order).
+   *
+   * Same as build_index(query) but bypasses the query wrapper; used by build_index(query) and by
+   * unit tests that construct pipeline DAGs without a full query.
+   */
+  static std::shared_ptr<const query_index> build_index(
+    const duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>>& pipelines,
+    build_index_options options = {});
+
+  /**
+   * @brief All branches, in plan order (earlier = closer to the scans).
+   */
+  [[nodiscard]] std::span<const branch> get_branches() const { return _branch_views; }
+
+  /**
+   * @brief The consumer-pipeline chain of the branch that starts at @p op's pipeline.
+   *
+   * Given a branch-point operator (typically a scan's source), returns the branch it heads:
+   * the pipelines from @p op's pipeline down to the next branch point, in plan order. When
+   * @p op heads several branches (a fan-out), the first one in plan order is returned. Returns an
+   * empty span if @p op does not head a branch.
+   *
+   * @param op The operator whose pipeline heads the branch (its source operator).
+   */
+  [[nodiscard]] branch get_consumer_pipelines_till_next_branch(
+    const op::sirius_physical_operator* op) const;
+
+ private:
+  query_index() = default;
+
+  //! Owning storage for every branch's pipeline chain. Stable addresses back the spans below.
+  std::vector<std::vector<pipeline_ptr>> _branches;
+  //! Non-owning views over _branches, in the same (plan) order.
+  std::vector<branch> _branch_views;
+  //! Head operator id -> index of the first branch that operator heads.
+  std::unordered_map<std::size_t, std::size_t> _head_op_to_branch;
+};
+
+}  // namespace sirius::planner

--- a/src/include/planner/query_index.hpp
+++ b/src/include/planner/query_index.hpp
@@ -39,10 +39,16 @@ struct pipeline_order {};
 /// pipeline. Only FULL-barrier edges cut a branch, so pipelinable work stays in one branch.
 struct barrier_order {};
 
+/// Branch-formation strategy: exactly like barrier_order, except that an edge feeding the probe
+/// side of a HASH_JOIN consumer is always treated as a PIPELINE barrier (regardless of its actual
+/// barrier). This keeps the probe pipeline flowing through the join into the downstream branch,
+/// while the build side still cuts on its own (typically FULL) barrier.
+struct build_probe {};
+
 /// Options for query_index::build_index.
 struct build_index_options {
   /// How branches are formed from the pipeline DAG. Defaults to pipeline_order.
-  std::variant<pipeline_order, barrier_order> branch_order{pipeline_order{}};
+  std::variant<pipeline_order, barrier_order, build_probe> branch_order{pipeline_order{}};
 };
 
 /**

--- a/src/include/planner/query_index.hpp
+++ b/src/include/planner/query_index.hpp
@@ -23,30 +23,42 @@
 #include <memory>
 #include <span>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 namespace sirius::planner {
 
 class query;
 
-/// Options for query_index::build_index. Reserved for future tuning; empty for now.
-struct build_index_options {};
+/// Branch-formation strategy: cut a branch at every multiport (fan-in) consumer operator. The
+/// multiport pipeline starts the next branch; branches are disjoint. This is the default.
+struct pipeline_order {};
+
+/// Branch-formation strategy: like pipeline_order, but a branch that reaches a multiport consumer
+/// through a PIPELINE- or PARTIAL-barrier port extends past that operator into the downstream
+/// pipeline. Only FULL-barrier edges cut a branch, so pipelinable work stays in one branch.
+struct barrier_order {};
+
+/// Options for query_index::build_index.
+struct build_index_options {
+  /// How branches are formed from the pipeline DAG. Defaults to pipeline_order.
+  std::variant<pipeline_order, barrier_order> branch_order{pipeline_order{}};
+};
 
 /**
  * @brief Precomputed structural index over a query's pipeline DAG.
  *
- * The index partitions the pipeline DAG into linear "branches". A branch is a maximal chain of
- * pipelines that runs from one branch point to the next, following consumer (downstream) edges.
- * A pipeline is a branch point when it is not a simple 1-producer / 1-consumer pass-through:
- * scans (0 producers), joins / merges (>1 producer, "fan-in"), forks (>1 consumer, "fan-out"),
- * and terminal result pipelines (0 consumers) are all branch points. Both endpoints of a branch
- * are branch points, so adjacent branches share their boundary pipeline.
+ * The index partitions the pipeline DAG into linear "branches" following consumer (downstream)
+ * edges. A branch is cut at a multiport consumer operator (fan-in, e.g. a join/merge whose source
+ * operator has more than one input port); the multiport pipeline starts a *new* branch, so
+ * pipeline_order branches are disjoint. barrier_order relaxes this: a branch reaching a multiport
+ * consumer through a PIPELINE/PARTIAL-barrier port is extended past the operator into the
+ * downstream pipeline (only FULL barriers cut). The chosen strategy is set via build_index_options.
  *
- * Example (numbers are pipelines; 3, 7, 10 are joins/forks):
- *   1 -> 2 -> 3        4 -> 5 -> 3       3 -> 6 -> 7      8 -> 9 -> 10 -> 7
- *   11 -> 10           3 -> 12
- * yields the branches [1,2,3], [4,5,3], [3,6,7], [3,12], [8,9,10,7], [11,10], ... with pipeline 3
- * appearing (as a shared endpoint) in several branches.
+ * Example (numbers are pipelines; the operator merging into 4 is multiport):
+ *   1 -> 2 -> 3 --[FULL]-->  4        5 -> 6 --[PIPELINE]--> 4        4 -> 7 -> 8
+ * pipeline_order branches: [1,2,3], [5,6], [4,7,8].
+ * barrier_order  branches: [1,2,3], [5,6,4,7,8]   (the PIPELINE edge extends 5,6 through 4,7,8).
  *
  * Branches are stored in plan order (by the head pipeline's position in the query's execution
  * order), so earlier branches sit closer to the scans. Callers use this order to assign
@@ -55,8 +67,7 @@ struct build_index_options {};
 class query_index {
  public:
   using pipeline_ptr = pipeline::sirius_pipeline*;
-  /// A branch: a chain of pipelines from one branch point to the next (both endpoints included),
-  /// head first (closest to the scans).
+  /// A branch: the chain of pipelines forming one branch, head first (closest to the scans).
   using branch = std::span<pipeline_ptr const>;
 
   /**

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -44,7 +44,16 @@ task_scheduler::task_scheduler(
   exec::queue_ordering task_queue_ordering,
   const cucascade::memory::system_topology_info* sys_topology,
   const std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>>* downgrade_executors)
-  : _task_queue(task_queue_ordering), _telemetry_context(std::move(telemetry_context))
+  : _task_queue([](const sirius::parallel::itask& task) -> exec::queue_priority {
+      // Order the pipeline-level queue by per-task priority. Non-pipeline tasks (and tasks
+      // whose priority was never assigned) fall back to 0, preserving FIFO among equals.
+      if (const auto* gpu_task = dynamic_cast<const pipeline::gpu_pipeline_task*>(&task)) {
+        return gpu_task->get_priority();
+      }
+      return 0;
+    }),
+    _task_queue_ordering(task_queue_ordering),
+    _telemetry_context(std::move(telemetry_context))
 {
   _task_queue_telemetry = std::make_unique<telemetry::TaskQueueHandleWrapper>(
     *_telemetry_context, "task-scheduler-gpu-queue");

--- a/src/planner/query_index.cpp
+++ b/src/planner/query_index.cpp
@@ -18,6 +18,7 @@
 
 #include "planner/query.hpp"
 
+#include <string_view>
 #include <unordered_set>
 
 namespace sirius::planner {
@@ -63,11 +64,19 @@ struct pipeline_dag {
   }
 };
 
+/// The build side of a HASH_JOIN feeds its "build" port; every other input port is a probe side.
+constexpr std::string_view kHashJoinBuildPort = "build";
+
 /// Build the pipeline DAG from the sink operators' next-ports. Each next-port names the downstream
 /// consumer operator and the port it pushes into; that port carries the barrier and identifies the
 /// consumer pipeline via the operator's owning pipeline.
+///
+/// @param probe_as_pipeline When true (build_probe strategy), an edge feeding the probe side of a
+///        HASH_JOIN consumer is recorded as a PIPELINE barrier regardless of the port's real
+///        barrier, so the probe pipeline extends through the join.
 pipeline_dag build_dag(
-  const duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>>& pipelines)
+  const duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>>& pipelines,
+  bool probe_as_pipeline)
 {
   pipeline_dag dag;
   for (const auto& producer_sp : pipelines) {
@@ -81,6 +90,10 @@ pipeline_dag build_dag(
       auto barrier = op::MemoryBarrierType::FULL;
       if (auto* port = consumer_op->get_port(next.next_operator_port_name)) {
         barrier = port->type;
+      }
+      if (probe_as_pipeline && consumer_op->type == op::SiriusPhysicalOperatorType::HASH_JOIN &&
+          next.next_operator_port_name != kHashJoinBuildPort) {
+        barrier = op::MemoryBarrierType::PIPELINE;  // probe side always pipelines through the join
       }
       dag.outgoing[producer].push_back({consumer, barrier});
       dag.incoming[consumer].push_back({producer, barrier});
@@ -136,8 +149,11 @@ std::shared_ptr<const query_index> query_index::build_index(
   const duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>>& pipelines,
   build_index_options options)
 {
-  const bool barrier_aware = std::holds_alternative<barrier_order>(options.branch_order);
-  const pipeline_dag dag   = build_dag(pipelines);
+  // barrier_order and build_probe both honor barriers when cutting; only pipeline_order ignores
+  // them. build_probe additionally rewrites hash-join probe edges to PIPELINE (see build_dag).
+  const bool barrier_aware     = !std::holds_alternative<pipeline_order>(options.branch_order);
+  const bool probe_as_pipeline = std::holds_alternative<build_probe>(options.branch_order);
+  const pipeline_dag dag       = build_dag(pipelines, probe_as_pipeline);
 
   // Not std::make_shared: the constructor is private.
   std::shared_ptr<query_index> index(new query_index());

--- a/src/planner/query_index.cpp
+++ b/src/planner/query_index.cpp
@@ -18,22 +18,111 @@
 
 #include "planner/query.hpp"
 
+#include <unordered_set>
+
 namespace sirius::planner {
 
 namespace {
 
 using pipeline_ptr = query_index::pipeline_ptr;
 
-/// Downstream consumer pipelines (pipelines this one feeds).
-std::vector<pipeline_ptr> consumers_of(pipeline_ptr p) { return p->get_parents(); }
+/// A directed data-flow edge between two pipelines, tagged with the memory barrier of the port
+/// through which the producer feeds the consumer.
+struct dag_edge {
+  pipeline_ptr other;  ///< producer (for an incoming edge) or consumer (for an outgoing edge)
+  op::MemoryBarrierType barrier;
+};
 
-/// Number of upstream producer pipelines (pipelines that feed this one).
-std::size_t producer_count(pipeline_ptr p) { return p->dependencies.size(); }
+/// Pipeline-level data-flow graph derived from the operator ports. `outgoing[P]` lists the
+/// pipelines P feeds; `incoming[C]` lists the pipelines that feed C, with the connecting barrier.
+struct pipeline_dag {
+  std::unordered_map<pipeline_ptr, std::vector<dag_edge>> outgoing;
+  std::unordered_map<pipeline_ptr, std::vector<dag_edge>> incoming;
 
-/// A pipeline is "internal" (mid-branch) only when it is a simple pass-through: exactly one
-/// producer and exactly one consumer. Everything else -- scans (0 producers), joins/merges
-/// (>1 producer), forks (>1 consumer), and terminal results (0 consumers) -- is a branch point.
-bool is_internal(pipeline_ptr p) { return producer_count(p) == 1 && p->get_parents().size() == 1; }
+  const std::vector<dag_edge>& out(pipeline_ptr p) const { return lookup(outgoing, p); }
+  const std::vector<dag_edge>& in(pipeline_ptr p) const { return lookup(incoming, p); }
+
+  /// A consumer is "multiport" (a fan-in branch point) when more than one pipeline feeds it.
+  bool is_multiport(pipeline_ptr c) const { return in(c).size() > 1; }
+
+  /// An edge into `consumer` (carrying `barrier`) cuts the branch when the consumer is multiport,
+  /// and -- in barrier_order -- only when that edge is a FULL barrier.
+  bool cuts(pipeline_ptr consumer, op::MemoryBarrierType barrier, bool barrier_aware) const
+  {
+    if (!is_multiport(consumer)) { return false; }
+    return !barrier_aware || barrier == op::MemoryBarrierType::FULL;
+  }
+
+ private:
+  static const std::vector<dag_edge>& lookup(
+    const std::unordered_map<pipeline_ptr, std::vector<dag_edge>>& m, pipeline_ptr p)
+  {
+    static const std::vector<dag_edge> empty;
+    auto it = m.find(p);
+    return it == m.end() ? empty : it->second;
+  }
+};
+
+/// Build the pipeline DAG from the sink operators' next-ports. Each next-port names the downstream
+/// consumer operator and the port it pushes into; that port carries the barrier and identifies the
+/// consumer pipeline via the operator's owning pipeline.
+pipeline_dag build_dag(
+  const duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>>& pipelines)
+{
+  pipeline_dag dag;
+  for (const auto& producer_sp : pipelines) {
+    pipeline_ptr producer = producer_sp.get();
+    if (producer == nullptr) { continue; }
+    for (const auto& next : producer->get_next_ports_after_sink()) {
+      auto* consumer_op = next.next_operator;
+      if (consumer_op == nullptr) { continue; }
+      pipeline_ptr consumer = consumer_op->get_pipeline().get();
+      if (consumer == nullptr || consumer == producer) { continue; }
+      auto barrier = op::MemoryBarrierType::FULL;
+      if (auto* port = consumer_op->get_port(next.next_operator_port_name)) {
+        barrier = port->type;
+      }
+      dag.outgoing[producer].push_back({consumer, barrier});
+      dag.incoming[consumer].push_back({producer, barrier});
+    }
+  }
+  return dag;
+}
+
+/// A pipeline heads a branch unless it is absorbed into a producer's branch -- i.e. unless some
+/// producer edge into it is not a cut AND that producer feeds only this pipeline (so the producer's
+/// forward walk continues into it).
+bool is_branch_head(const pipeline_dag& dag, pipeline_ptr p, bool barrier_aware)
+{
+  const auto& producers = dag.in(p);
+  if (producers.empty()) { return true; }  // a scan (no producers) always heads a branch
+  for (const auto& edge : producers) {
+    const bool cut = dag.cuts(p, edge.barrier, barrier_aware);
+    if (!cut && dag.out(edge.other).size() == 1) { return false; }
+  }
+  return true;
+}
+
+/// Walk consumer edges from a branch head, absorbing pipelines until the chain forks, ends, or
+/// hits a cut edge.
+std::vector<pipeline_ptr> walk_branch(const pipeline_dag& dag,
+                                      pipeline_ptr head,
+                                      bool barrier_aware)
+{
+  std::vector<pipeline_ptr> chain{head};
+  std::unordered_set<pipeline_ptr> visited{head};
+  pipeline_ptr cur = head;
+  while (true) {
+    const auto& consumers = dag.out(cur);
+    if (consumers.size() != 1) { break; }  // fork or dead end ends the branch
+    const dag_edge& edge = consumers.front();
+    if (dag.cuts(edge.other, edge.barrier, barrier_aware)) { break; }
+    if (!visited.insert(edge.other).second) { break; }  // defensive cycle guard
+    chain.push_back(edge.other);
+    cur = edge.other;
+  }
+  return chain;
+}
 
 }  // namespace
 
@@ -45,28 +134,20 @@ std::shared_ptr<const query_index> query_index::build_index(const query& q,
 
 std::shared_ptr<const query_index> query_index::build_index(
   const duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>>& pipelines,
-  build_index_options /*options*/)
+  build_index_options options)
 {
+  const bool barrier_aware = std::holds_alternative<barrier_order>(options.branch_order);
+  const pipeline_dag dag   = build_dag(pipelines);
+
   // Not std::make_shared: the constructor is private.
   std::shared_ptr<query_index> index(new query_index());
 
-  // Enumerate branches by walking, from each branch-point pipeline, along every consumer edge
-  // through internal pass-through pipelines until the next branch point. Iterating the query's
-  // pipelines in execution order makes the emitted branch order plan order (scans first).
+  // Emit one branch per branch head, iterating pipelines in execution order so branches come out
+  // in plan order (scans first).
   for (const auto& head_sp : pipelines) {
     pipeline_ptr head = head_sp.get();
-    if (head == nullptr || is_internal(head)) { continue; }  // only start at branch points
-
-    for (pipeline_ptr next : consumers_of(head)) {
-      std::vector<pipeline_ptr> chain{head};
-      pipeline_ptr cur = next;
-      while (cur != nullptr && is_internal(cur)) {
-        chain.push_back(cur);
-        cur = cur->get_parents().front();  // internal => exactly one consumer
-      }
-      if (cur != nullptr) { chain.push_back(cur); }  // the next branch point (branch tail)
-      index->_branches.push_back(std::move(chain));
-    }
+    if (head == nullptr || !is_branch_head(dag, head, barrier_aware)) { continue; }
+    index->_branches.push_back(walk_branch(dag, head, barrier_aware));
   }
 
   // Second pass (after _branches is fully populated so the inner-vector buffers are stable):

--- a/src/planner/query_index.cpp
+++ b/src/planner/query_index.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "planner/query_index.hpp"
+
+#include "planner/query.hpp"
+
+namespace sirius::planner {
+
+namespace {
+
+using pipeline_ptr = query_index::pipeline_ptr;
+
+/// Downstream consumer pipelines (pipelines this one feeds).
+std::vector<pipeline_ptr> consumers_of(pipeline_ptr p) { return p->get_parents(); }
+
+/// Number of upstream producer pipelines (pipelines that feed this one).
+std::size_t producer_count(pipeline_ptr p) { return p->dependencies.size(); }
+
+/// A pipeline is "internal" (mid-branch) only when it is a simple pass-through: exactly one
+/// producer and exactly one consumer. Everything else -- scans (0 producers), joins/merges
+/// (>1 producer), forks (>1 consumer), and terminal results (0 consumers) -- is a branch point.
+bool is_internal(pipeline_ptr p) { return producer_count(p) == 1 && p->get_parents().size() == 1; }
+
+}  // namespace
+
+std::shared_ptr<const query_index> query_index::build_index(const query& q,
+                                                            build_index_options options)
+{
+  return build_index(q.get_pipelines(), options);
+}
+
+std::shared_ptr<const query_index> query_index::build_index(
+  const duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>>& pipelines,
+  build_index_options /*options*/)
+{
+  // Not std::make_shared: the constructor is private.
+  std::shared_ptr<query_index> index(new query_index());
+
+  // Enumerate branches by walking, from each branch-point pipeline, along every consumer edge
+  // through internal pass-through pipelines until the next branch point. Iterating the query's
+  // pipelines in execution order makes the emitted branch order plan order (scans first).
+  for (const auto& head_sp : pipelines) {
+    pipeline_ptr head = head_sp.get();
+    if (head == nullptr || is_internal(head)) { continue; }  // only start at branch points
+
+    for (pipeline_ptr next : consumers_of(head)) {
+      std::vector<pipeline_ptr> chain{head};
+      pipeline_ptr cur = next;
+      while (cur != nullptr && is_internal(cur)) {
+        chain.push_back(cur);
+        cur = cur->get_parents().front();  // internal => exactly one consumer
+      }
+      if (cur != nullptr) { chain.push_back(cur); }  // the next branch point (branch tail)
+      index->_branches.push_back(std::move(chain));
+    }
+  }
+
+  // Second pass (after _branches is fully populated so the inner-vector buffers are stable):
+  // build the span views and the head-operator lookup.
+  index->_branch_views.reserve(index->_branches.size());
+  for (std::size_t i = 0; i < index->_branches.size(); ++i) {
+    const auto& chain = index->_branches[i];
+    index->_branch_views.emplace_back(chain.data(), chain.size());
+    if (const auto source = chain.front()->get_source()) {
+      // First branch headed by this operator wins (a fan-out head owns several branches).
+      index->_head_op_to_branch.try_emplace(source->get_operator_id(), i);
+    }
+  }
+
+  return index;
+}
+
+query_index::branch query_index::get_consumer_pipelines_till_next_branch(
+  const op::sirius_physical_operator* op) const
+{
+  if (op == nullptr) { return {}; }
+  auto it = _head_op_to_branch.find(op->get_operator_id());
+  if (it == _head_op_to_branch.end()) { return {}; }
+  return _branch_views[it->second];
+}
+
+}  // namespace sirius::planner

--- a/test/cpp/data/test_convertible_gpu_pipeline_task.cpp
+++ b/test/cpp/data/test_convertible_gpu_pipeline_task.cpp
@@ -23,7 +23,7 @@
 #include <cucascade/memory/common.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <data/convertible_gpu_pipeline_task.hpp>
-#include <exec/inspectable_mpsc.hpp>
+#include <exec/inspectable_priority_queue.hpp>
 #include <op/sirius_physical_operator.hpp>
 #include <parallel/task.hpp>
 #include <pipeline/gpu_pipeline_task.hpp>
@@ -110,7 +110,7 @@ TEST_CASE("RAII returns task to queue on destruction", "[convertible_gpu_pipelin
 {
   auto& e = env();
 
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask> queue;
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask> queue;
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{1, 2, 3}, cudf::type_id::INT32);
   auto task = make_test_gpu_task(1, {batch});
@@ -132,7 +132,7 @@ TEST_CASE("RAII returns task after successful convert", "[convertible_gpu_pipeli
 {
   auto& e = env();
 
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask> queue;
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask> queue;
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{10, 20, 30}, cudf::type_id::INT32);
   auto task = make_test_gpu_task(1, {batch});
@@ -167,7 +167,7 @@ TEST_CASE("RAII returns task on exception", "[convertible_gpu_pipeline_task]")
 {
   auto& e = env();
 
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask> queue;
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask> queue;
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{4, 5, 6}, cudf::type_id::INT32);
   auto task = make_test_gpu_task(1, {batch});
@@ -194,7 +194,7 @@ TEST_CASE("non-gpu_pipeline_task skipped by predicate", "[convertible_gpu_pipeli
 {
   auto& e = env();
 
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask> queue;
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask> queue;
   queue.push(std::make_unique<dummy_task>());
   REQUIRE(queue.size() == 1);
 
@@ -208,7 +208,7 @@ TEST_CASE("wrong memory_space skipped by predicate", "[convertible_gpu_pipeline_
 {
   auto& e = env();
 
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask> queue;
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask> queue;
   // Create GPU task with batch in gpu_space
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{1, 2, 3}, cudf::type_id::INT32);
@@ -226,7 +226,7 @@ TEST_CASE("non-idle batch skipped by predicate", "[convertible_gpu_pipeline_task
 {
   auto& e = env();
 
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask> queue;
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask> queue;
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{7, 8, 9}, cudf::type_id::INT32);
 
@@ -251,7 +251,7 @@ TEST_CASE("matching task selected by predicate", "[convertible_gpu_pipeline_task
 {
   auto& e = env();
 
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask> queue;
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask> queue;
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{1, 2, 3}, cudf::type_id::INT32);
   auto task = make_test_gpu_task(1, {batch});  // batch is idle
@@ -267,7 +267,7 @@ TEST_CASE("convert GPU task to HOST", "[convertible_gpu_pipeline_task]")
 {
   auto& e = env();
 
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask> queue;
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask> queue;
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{100, 200, 300}, cudf::type_id::INT32);
   auto task = make_test_gpu_task(1, {batch});
@@ -287,7 +287,7 @@ TEST_CASE("bytes_in_space returns correct size", "[convertible_gpu_pipeline_task
 {
   auto& e = env();
 
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask> queue;
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask> queue;
   auto batch1 = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{1, 2, 3}, cudf::type_id::INT32);
   auto batch2 = sirius::test::operator_utils::make_numeric_batch(
@@ -311,7 +311,7 @@ TEST_CASE("get_all_convertible extracts all matching tasks", "[convertible_gpu_p
 {
   auto& e = env();
 
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask> queue;
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask> queue;
 
   for (uint64_t i = 0; i < 3; ++i) {
     auto batch = sirius::test::operator_utils::make_numeric_batch(
@@ -335,7 +335,7 @@ TEST_CASE("RAII on interrupted queue does not crash", "[convertible_gpu_pipeline
 {
   auto& e = env();
 
-  sirius::exec::inspectable_mpsc<sirius::parallel::itask> queue;
+  sirius::exec::inspectable_priority_queue<sirius::parallel::itask> queue;
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{1, 2, 3}, cudf::type_id::INT32);
   auto task = make_test_gpu_task(1, {batch});

--- a/test/cpp/exec/test_inspectable_priority_queue.cpp
+++ b/test/cpp/exec/test_inspectable_priority_queue.cpp
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "exec/inspectable_priority_queue.hpp"
+
+#include <string>
+#include <vector>
+
+using namespace sirius::exec;
+
+namespace {
+
+struct prio_payload {
+  int id;
+  queue_priority priority;
+  prio_payload(int i, queue_priority p) : id(i), priority(p) {}
+};
+
+// Extractor used by most tests: the item's own priority field.
+inspectable_priority_queue<prio_payload>::priority_fn by_field()
+{
+  return [](const prio_payload& p) { return p.priority; };
+}
+
+// Drains the queue and returns the popped ids in pop order (highest priority first).
+std::vector<int> drain_ids(inspectable_priority_queue<prio_payload>& q)
+{
+  std::vector<int> out;
+  while (auto item = q.try_pop()) {
+    out.push_back(item->id);
+  }
+  return out;
+}
+
+}  // namespace
+
+// =============================================================================
+// Default extractor reduces to FIFO
+// =============================================================================
+
+TEST_CASE("priority_queue default extractor pops in FIFO order", "[inspectable_priority_queue]")
+{
+  inspectable_priority_queue<int> queue;
+  for (int i = 0; i < 5; ++i) {
+    REQUIRE(queue.push(std::make_unique<int>(i)));
+  }
+  for (int i = 0; i < 5; ++i) {
+    auto item = queue.try_pop();
+    REQUIRE(item != nullptr);
+    REQUIRE(*item == i);
+  }
+  REQUIRE(queue.try_pop() == nullptr);
+}
+
+// =============================================================================
+// Priority ordering
+// =============================================================================
+
+TEST_CASE("priority_queue pops highest priority first", "[inspectable_priority_queue]")
+{
+  inspectable_priority_queue<prio_payload> queue(by_field());
+  // Pushed in arbitrary order; priorities: 10=>1, 11=>5, 12=>3, 13=>5, 14=>0
+  queue.push(std::make_unique<prio_payload>(10, 1));
+  queue.push(std::make_unique<prio_payload>(11, 5));
+  queue.push(std::make_unique<prio_payload>(12, 3));
+  queue.push(std::make_unique<prio_payload>(13, 5));
+  queue.push(std::make_unique<prio_payload>(14, 0));
+
+  // Highest priority first; equal priorities (11,13 both =5) keep insertion order.
+  REQUIRE(drain_ids(queue) == std::vector<int>{11, 13, 12, 10, 14});
+}
+
+TEST_CASE("priority_queue equal priorities preserve FIFO order", "[inspectable_priority_queue]")
+{
+  inspectable_priority_queue<prio_payload> queue(by_field());
+  for (int i = 0; i < 6; ++i) {
+    queue.push(std::make_unique<prio_payload>(i, 7));
+  }
+  REQUIRE(drain_ids(queue) == std::vector<int>{0, 1, 2, 3, 4, 5});
+}
+
+TEST_CASE("priority_queue pop_back returns lowest priority", "[inspectable_priority_queue]")
+{
+  inspectable_priority_queue<prio_payload> queue(by_field());
+  queue.push(std::make_unique<prio_payload>(10, 1));
+  queue.push(std::make_unique<prio_payload>(11, 5));
+  queue.push(std::make_unique<prio_payload>(12, 3));
+
+  auto lowest = queue.pop_back();
+  REQUIRE(lowest != nullptr);
+  REQUIRE(lowest->id == 10);  // priority 1 is lowest
+
+  auto highest = queue.pop_front();
+  REQUIRE(highest != nullptr);
+  REQUIRE(highest->id == 11);  // priority 5 is highest
+}
+
+TEST_CASE("priority_queue supports negative priorities", "[inspectable_priority_queue]")
+{
+  inspectable_priority_queue<prio_payload> queue(by_field());
+  queue.push(std::make_unique<prio_payload>(10, -5));
+  queue.push(std::make_unique<prio_payload>(11, 0));
+  queue.push(std::make_unique<prio_payload>(12, -1));
+  REQUIRE(drain_ids(queue) == std::vector<int>{11, 12, 10});
+}
+
+TEST_CASE("priority_queue blocking pop returns highest priority", "[inspectable_priority_queue]")
+{
+  inspectable_priority_queue<prio_payload> queue(by_field());
+  queue.push(std::make_unique<prio_payload>(10, 1));
+  queue.push(std::make_unique<prio_payload>(11, 9));
+  queue.push(std::make_unique<prio_payload>(12, 4));
+
+  auto a = queue.pop();
+  REQUIRE(a != nullptr);
+  REQUIRE(a->id == 11);
+  auto b = queue.pop();
+  REQUIRE(b != nullptr);
+  REQUIRE(b->id == 12);
+}
+
+// =============================================================================
+// pop_if / mutable_pop_if honor priority-sorted iteration
+// =============================================================================
+
+TEST_CASE("priority_queue pop_if front_to_back scans highest priority first",
+          "[inspectable_priority_queue]")
+{
+  inspectable_priority_queue<prio_payload> queue(by_field());
+  queue.push(std::make_unique<prio_payload>(10, 1));
+  queue.push(std::make_unique<prio_payload>(11, 5));
+  queue.push(std::make_unique<prio_payload>(12, 5));
+
+  // Both id 11 and 12 have priority 5; front_to_back returns the higher-ranked one first (11).
+  auto match = queue.pop_if([](const prio_payload& p) { return p.priority == 5; }, true);
+  REQUIRE(match != nullptr);
+  REQUIRE(match->id == 11);
+  REQUIRE(queue.size() == 2);
+}
+
+TEST_CASE("priority_queue pop_if back_to_front scans lowest priority first",
+          "[inspectable_priority_queue]")
+{
+  inspectable_priority_queue<prio_payload> queue(by_field());
+  queue.push(std::make_unique<prio_payload>(10, 5));
+  queue.push(std::make_unique<prio_payload>(11, 5));
+  queue.push(std::make_unique<prio_payload>(12, 1));
+
+  // back_to_front finds the last (lowest-ranked) matching priority-5 entry: id 11.
+  auto match = queue.pop_if([](const prio_payload& p) { return p.priority == 5; }, false);
+  REQUIRE(match != nullptr);
+  REQUIRE(match->id == 11);
+}
+
+TEST_CASE("priority_queue mutable_pop_if removes matching element", "[inspectable_priority_queue]")
+{
+  inspectable_priority_queue<prio_payload> queue(by_field());
+  for (int i = 0; i < 5; ++i) {
+    queue.push(std::make_unique<prio_payload>(i, i));
+  }
+  auto match = queue.mutable_pop_if([](prio_payload& p) { return p.id == 3; }, true);
+  REQUIRE(match != nullptr);
+  REQUIRE(match->id == 3);
+  REQUIRE(queue.size() == 4);
+}
+
+// =============================================================================
+// Lifecycle: interrupt / reactivate / drain / size / emplace
+// =============================================================================
+
+TEST_CASE("priority_queue push fails after interrupt", "[inspectable_priority_queue]")
+{
+  inspectable_priority_queue<prio_payload> queue(by_field());
+  queue.interrupt();
+  REQUIRE_FALSE(queue.is_open());
+  REQUIRE_FALSE(queue.push(std::make_unique<prio_payload>(1, 1)));
+  queue.reactivate();
+  REQUIRE(queue.is_open());
+  REQUIRE(queue.push(std::make_unique<prio_payload>(2, 1)));
+}
+
+TEST_CASE("priority_queue emplace inserts by priority", "[inspectable_priority_queue]")
+{
+  inspectable_priority_queue<prio_payload> queue(by_field());
+  REQUIRE(queue.emplace(10, 1));
+  REQUIRE(queue.emplace(11, 9));
+  REQUIRE(queue.emplace(12, 4));
+  REQUIRE(queue.size() == 3);
+  REQUIRE(drain_ids(queue) == std::vector<int>{11, 12, 10});
+}
+
+TEST_CASE("priority_queue drain removes all items", "[inspectable_priority_queue]")
+{
+  inspectable_priority_queue<prio_payload> queue(by_field());
+  for (int i = 0; i < 4; ++i) {
+    queue.push(std::make_unique<prio_payload>(i, i));
+  }
+  REQUIRE(queue.size() == 4);
+  queue.drain();
+  REQUIRE(queue.is_empty());
+}

--- a/test/cpp/planner/test_query_index.cpp
+++ b/test/cpp/planner/test_query_index.cpp
@@ -20,101 +20,182 @@
 #include "planner/query_index.hpp"
 
 #include <algorithm>
+#include <deque>
+#include <memory>
+#include <span>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
+using sirius::op::MemoryBarrierType;
+using sirius::op::sirius_physical_operator;
+using sirius::op::SiriusPhysicalOperatorType;
 using sirius::pipeline::pipeline_build_context;
 using sirius::pipeline::sirius_pipeline;
+using sirius::pipeline::sirius_pipeline_build_state;
+using sirius::planner::barrier_order;
+using sirius::planner::build_index_options;
+using sirius::planner::pipeline_order;
 using sirius::planner::query_index;
 
 namespace {
 
-// Wire a producer -> consumer data-flow edge. add_dependency(producer) records `producer` as an
-// upstream dependency of `consumer` and `consumer` as a downstream parent of `producer`.
-void connect(duckdb::shared_ptr<sirius_pipeline>& producer,
-             duckdb::shared_ptr<sirius_pipeline>& consumer)
+// Minimal concrete operator: a pass-through node used purely to carry ports/next-ports so that
+// query_index can read the pipeline DAG. Uses PROJECTION so get_next_ports_after_sink() takes the
+// plain (non-delim-join) path.
+struct test_operator : sirius_physical_operator {
+  test_operator() : sirius_physical_operator(SiriusPhysicalOperatorType::PROJECTION, {}, 0) {}
+};
+
+// Builds a pipeline DAG out of one operator per pipeline (acting as both source and sink) wired
+// together through barrier-tagged ports, mirroring how the planner wires real pipelines.
+class dag_builder {
+ public:
+  // Add a pipeline labelled `id`; each pipeline gets a single source+sink operator.
+  duckdb::shared_ptr<sirius_pipeline> add(int id)
+  {
+    auto pipeline = duckdb::make_shared_ptr<sirius_pipeline>(_ctx);
+    auto op       = std::make_unique<test_operator>();
+    op->set_pipeline(pipeline);
+    _bs.set_pipeline_source(*pipeline, *op);
+    _bs.set_pipeline_sink(*pipeline, sirius::optional_ptr<sirius_physical_operator>(op.get()), 0);
+    _ids[pipeline.get()] = id;
+    _ops.push_back(std::move(op));
+    _pipelines.push_back(pipeline);
+    return pipeline;
+  }
+
+  // Wire a data-flow edge from -> to carrying `barrier`.
+  void connect(const duckdb::shared_ptr<sirius_pipeline>& from,
+               const duckdb::shared_ptr<sirius_pipeline>& to,
+               MemoryBarrierType barrier)
+  {
+    auto* consumer_op = to->get_source().get();
+    auto* producer_op = from->get_sink().get();
+
+    _names.push_back("e" + std::to_string(_names.size()));
+    std::string_view name = _names.back();
+
+    auto port           = std::make_unique<sirius_physical_operator::port>();
+    port->type          = barrier;
+    port->repo          = nullptr;
+    port->src_pipeline  = from;
+    port->dest_pipeline = to;
+    consumer_op->add_port(name, std::move(port));
+
+    producer_op->add_next_port_after_sink(
+      sirius_physical_operator::next_port_info{consumer_op, name, uuid::now_v7()});
+  }
+
+  const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines() const
+  {
+    return _pipelines;
+  }
+
+  // Convert branch spans to id vectors for readable assertions.
+  std::vector<std::vector<int>> label(std::span<const query_index::branch> branches) const
+  {
+    std::vector<std::vector<int>> out;
+    for (const auto& br : branches) {
+      std::vector<int> ids;
+      for (auto* p : br) {
+        ids.push_back(_ids.at(p));
+      }
+      out.push_back(std::move(ids));
+    }
+    return out;
+  }
+
+ private:
+  pipeline_build_context _ctx{true};
+  sirius_pipeline_build_state _bs;
+  std::vector<std::unique_ptr<test_operator>> _ops;
+  std::deque<std::string> _names;  // stable storage backing the port-name string_views
+  std::unordered_map<sirius_pipeline*, int> _ids;
+  duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> _pipelines;
+};
+
+bool contains(const std::vector<std::vector<int>>& all, const std::vector<int>& one)
 {
-  consumer->add_dependency(producer);
+  return std::find(all.begin(), all.end(), one) != all.end();
 }
 
-std::vector<sirius_pipeline*> branch_to_vec(query_index::branch b)
+// The example DAG from the spec:
+//   1 -> 2 -> 3 --[FULL]--> 4 ;  5 -> 6 --[PIPELINE]--> 4 ;  4 -> 7 -> 8
+// Pipeline 4 is the multiport (fan-in) consumer.
+dag_builder make_example()
 {
-  return std::vector<sirius_pipeline*>(b.begin(), b.end());
+  dag_builder b;
+  auto p1 = b.add(1);
+  auto p2 = b.add(2);
+  auto p3 = b.add(3);
+  auto p4 = b.add(4);
+  auto p5 = b.add(5);
+  auto p6 = b.add(6);
+  auto p7 = b.add(7);
+  auto p8 = b.add(8);
+
+  b.connect(p1, p2, MemoryBarrierType::PIPELINE);
+  b.connect(p2, p3, MemoryBarrierType::PIPELINE);
+  b.connect(p3, p4, MemoryBarrierType::FULL);
+  b.connect(p5, p6, MemoryBarrierType::PIPELINE);
+  b.connect(p6, p4, MemoryBarrierType::PIPELINE);
+  b.connect(p4, p7, MemoryBarrierType::PIPELINE);
+  b.connect(p7, p8, MemoryBarrierType::PIPELINE);
+  return b;
 }
 
 }  // namespace
 
-TEST_CASE("query_index partitions a DAG into boundary-inclusive branches", "[query_index]")
+TEST_CASE("query_index pipeline_order cuts every branch at the multiport consumer", "[query_index]")
 {
-  pipeline_build_context ctx{true};
-  auto make = [&] { return duckdb::make_shared_ptr<sirius_pipeline>(ctx); };
+  auto b     = make_example();
+  auto index = query_index::build_index(b.pipelines(), build_index_options{pipeline_order{}});
+  auto got   = b.label(index->get_branches());
 
-  // Data flow:
-  //   scanA -> mid1 -> joinX
-  //   scanB --------> joinX
-  //   joinX -> mid2 -> result
-  // joinX is a fan-in branch point (2 producers); mid1/mid2 are pass-through; result is terminal.
-  auto scanA  = make();
-  auto scanB  = make();
-  auto mid1   = make();
-  auto mid2   = make();
-  auto joinX  = make();
-  auto result = make();
-
-  connect(scanA, mid1);
-  connect(mid1, joinX);
-  connect(scanB, joinX);
-  connect(joinX, mid2);
-  connect(mid2, result);
-
-  // Execution order (scans first) determines branch/plan order.
-  duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> pipelines{
-    scanA, scanB, mid1, mid2, joinX, result};
-
-  auto index    = query_index::build_index(pipelines);
-  auto branches = index->get_branches();
-
-  REQUIRE(branches.size() == 3);
-  // Branch order follows the head pipeline's plan position: scanA, then scanB, then joinX.
-  REQUIRE(branch_to_vec(branches[0]) ==
-          std::vector<sirius_pipeline*>{scanA.get(), mid1.get(), joinX.get()});
-  REQUIRE(branch_to_vec(branches[1]) == std::vector<sirius_pipeline*>{scanB.get(), joinX.get()});
-  REQUIRE(branch_to_vec(branches[2]) ==
-          std::vector<sirius_pipeline*>{joinX.get(), mid2.get(), result.get()});
-
-  // joinX is a shared endpoint appearing in all three branches.
-  auto appears_in = [&](sirius_pipeline* p) {
-    int count = 0;
-    for (auto& br : branches) {
-      if (std::find(br.begin(), br.end(), p) != br.end()) { ++count; }
-    }
-    return count;
-  };
-  REQUIRE(appears_in(joinX.get()) == 3);
-  REQUIRE(appears_in(mid1.get()) == 1);
+  REQUIRE(got.size() == 3);
+  REQUIRE(contains(got, {1, 2, 3}));
+  REQUIRE(contains(got, {5, 6}));
+  REQUIRE(contains(got, {4, 7, 8}));
+  // The first-added scan heads the highest-priority (first) branch.
+  REQUIRE(got.front() == std::vector<int>{1, 2, 3});
 }
 
-TEST_CASE("query_index splits at a fan-out branch point", "[query_index]")
+TEST_CASE("query_index barrier_order extends through pipeline/partial barriers", "[query_index]")
 {
-  pipeline_build_context ctx{true};
-  auto make = [&] { return duckdb::make_shared_ptr<sirius_pipeline>(ctx); };
+  auto b     = make_example();
+  auto index = query_index::build_index(b.pipelines(), build_index_options{barrier_order{}});
+  auto got   = b.label(index->get_branches());
 
-  // scan -> fork ; fork -> a ; fork -> b   (fork feeds two consumers => fan-out branch point)
-  auto scan = make();
-  auto fork = make();
-  auto a    = make();
-  auto b    = make();
+  // The FULL edge (3->4) still cuts, but the PIPELINE edge (6->4) extends 5,6 through 4,7,8.
+  REQUIRE(got.size() == 2);
+  REQUIRE(contains(got, {1, 2, 3}));
+  REQUIRE(contains(got, {5, 6, 4, 7, 8}));
+}
 
-  connect(scan, fork);
-  connect(fork, a);
-  connect(fork, b);
+TEST_CASE("query_index default options use pipeline_order", "[query_index]")
+{
+  auto b     = make_example();
+  auto index = query_index::build_index(b.pipelines());  // default options
+  REQUIRE(index->get_branches().size() == 3);
+}
 
-  duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> pipelines{scan, fork, a, b};
-  auto index    = query_index::build_index(pipelines);
-  auto branches = index->get_branches();
+TEST_CASE("query_index barrier_order with a partial barrier also extends", "[query_index]")
+{
+  dag_builder b;
+  auto scan = b.add(1);
+  auto mid  = b.add(2);
+  auto join = b.add(3);  // multiport
+  auto tail = b.add(4);
 
-  // scan -> [scan, fork]; fork fans out into two single-pipeline branches [fork,a] and [fork,b].
-  REQUIRE(branches.size() == 3);
-  REQUIRE(branch_to_vec(branches[0]) == std::vector<sirius_pipeline*>{scan.get(), fork.get()});
-  REQUIRE(branch_to_vec(branches[1]) == std::vector<sirius_pipeline*>{fork.get(), a.get()});
-  REQUIRE(branch_to_vec(branches[2]) == std::vector<sirius_pipeline*>{fork.get(), b.get()});
+  b.connect(scan, join, MemoryBarrierType::FULL);    // full edge into the multiport join
+  b.connect(mid, join, MemoryBarrierType::PARTIAL);  // partial edge extends
+  b.connect(join, tail, MemoryBarrierType::PIPELINE);
+
+  auto index = query_index::build_index(b.pipelines(), build_index_options{barrier_order{}});
+  auto got   = b.label(index->get_branches());
+
+  REQUIRE(got.size() == 2);
+  REQUIRE(contains(got, {1}));        // scan branch cut by its FULL edge
+  REQUIRE(contains(got, {2, 3, 4}));  // partial edge extends mid through join, tail
 }

--- a/test/cpp/planner/test_query_index.cpp
+++ b/test/cpp/planner/test_query_index.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "pipeline/pipeline_build_context.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "planner/query_index.hpp"
+
+#include <algorithm>
+#include <vector>
+
+using sirius::pipeline::pipeline_build_context;
+using sirius::pipeline::sirius_pipeline;
+using sirius::planner::query_index;
+
+namespace {
+
+// Wire a producer -> consumer data-flow edge. add_dependency(producer) records `producer` as an
+// upstream dependency of `consumer` and `consumer` as a downstream parent of `producer`.
+void connect(duckdb::shared_ptr<sirius_pipeline>& producer,
+             duckdb::shared_ptr<sirius_pipeline>& consumer)
+{
+  consumer->add_dependency(producer);
+}
+
+std::vector<sirius_pipeline*> branch_to_vec(query_index::branch b)
+{
+  return std::vector<sirius_pipeline*>(b.begin(), b.end());
+}
+
+}  // namespace
+
+TEST_CASE("query_index partitions a DAG into boundary-inclusive branches", "[query_index]")
+{
+  pipeline_build_context ctx{true};
+  auto make = [&] { return duckdb::make_shared_ptr<sirius_pipeline>(ctx); };
+
+  // Data flow:
+  //   scanA -> mid1 -> joinX
+  //   scanB --------> joinX
+  //   joinX -> mid2 -> result
+  // joinX is a fan-in branch point (2 producers); mid1/mid2 are pass-through; result is terminal.
+  auto scanA  = make();
+  auto scanB  = make();
+  auto mid1   = make();
+  auto mid2   = make();
+  auto joinX  = make();
+  auto result = make();
+
+  connect(scanA, mid1);
+  connect(mid1, joinX);
+  connect(scanB, joinX);
+  connect(joinX, mid2);
+  connect(mid2, result);
+
+  // Execution order (scans first) determines branch/plan order.
+  duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> pipelines{
+    scanA, scanB, mid1, mid2, joinX, result};
+
+  auto index    = query_index::build_index(pipelines);
+  auto branches = index->get_branches();
+
+  REQUIRE(branches.size() == 3);
+  // Branch order follows the head pipeline's plan position: scanA, then scanB, then joinX.
+  REQUIRE(branch_to_vec(branches[0]) ==
+          std::vector<sirius_pipeline*>{scanA.get(), mid1.get(), joinX.get()});
+  REQUIRE(branch_to_vec(branches[1]) == std::vector<sirius_pipeline*>{scanB.get(), joinX.get()});
+  REQUIRE(branch_to_vec(branches[2]) ==
+          std::vector<sirius_pipeline*>{joinX.get(), mid2.get(), result.get()});
+
+  // joinX is a shared endpoint appearing in all three branches.
+  auto appears_in = [&](sirius_pipeline* p) {
+    int count = 0;
+    for (auto& br : branches) {
+      if (std::find(br.begin(), br.end(), p) != br.end()) { ++count; }
+    }
+    return count;
+  };
+  REQUIRE(appears_in(joinX.get()) == 3);
+  REQUIRE(appears_in(mid1.get()) == 1);
+}
+
+TEST_CASE("query_index splits at a fan-out branch point", "[query_index]")
+{
+  pipeline_build_context ctx{true};
+  auto make = [&] { return duckdb::make_shared_ptr<sirius_pipeline>(ctx); };
+
+  // scan -> fork ; fork -> a ; fork -> b   (fork feeds two consumers => fan-out branch point)
+  auto scan = make();
+  auto fork = make();
+  auto a    = make();
+  auto b    = make();
+
+  connect(scan, fork);
+  connect(fork, a);
+  connect(fork, b);
+
+  duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> pipelines{scan, fork, a, b};
+  auto index    = query_index::build_index(pipelines);
+  auto branches = index->get_branches();
+
+  // scan -> [scan, fork]; fork fans out into two single-pipeline branches [fork,a] and [fork,b].
+  REQUIRE(branches.size() == 3);
+  REQUIRE(branch_to_vec(branches[0]) == std::vector<sirius_pipeline*>{scan.get(), fork.get()});
+  REQUIRE(branch_to_vec(branches[1]) == std::vector<sirius_pipeline*>{fork.get(), a.get()});
+  REQUIRE(branch_to_vec(branches[2]) == std::vector<sirius_pipeline*>{fork.get(), b.get()});
+}

--- a/test/cpp/planner/test_query_index.cpp
+++ b/test/cpp/planner/test_query_index.cpp
@@ -35,27 +35,32 @@ using sirius::pipeline::sirius_pipeline;
 using sirius::pipeline::sirius_pipeline_build_state;
 using sirius::planner::barrier_order;
 using sirius::planner::build_index_options;
+using sirius::planner::build_probe;
 using sirius::planner::pipeline_order;
 using sirius::planner::query_index;
 
 namespace {
 
 // Minimal concrete operator: a pass-through node used purely to carry ports/next-ports so that
-// query_index can read the pipeline DAG. Uses PROJECTION so get_next_ports_after_sink() takes the
-// plain (non-delim-join) path.
+// query_index can read the pipeline DAG. Defaults to PROJECTION so get_next_ports_after_sink()
+// takes the plain (non-delim-join) path; a type can be supplied to model e.g. a HASH_JOIN consumer.
 struct test_operator : sirius_physical_operator {
-  test_operator() : sirius_physical_operator(SiriusPhysicalOperatorType::PROJECTION, {}, 0) {}
+  explicit test_operator(SiriusPhysicalOperatorType type = SiriusPhysicalOperatorType::PROJECTION)
+    : sirius_physical_operator(type, {}, 0)
+  {
+  }
 };
 
 // Builds a pipeline DAG out of one operator per pipeline (acting as both source and sink) wired
 // together through barrier-tagged ports, mirroring how the planner wires real pipelines.
 class dag_builder {
  public:
-  // Add a pipeline labelled `id`; each pipeline gets a single source+sink operator.
-  duckdb::shared_ptr<sirius_pipeline> add(int id)
+  // Add a pipeline labelled `id`; each pipeline gets a single source+sink operator of `type`.
+  duckdb::shared_ptr<sirius_pipeline> add(
+    int id, SiriusPhysicalOperatorType type = SiriusPhysicalOperatorType::PROJECTION)
   {
     auto pipeline = duckdb::make_shared_ptr<sirius_pipeline>(_ctx);
-    auto op       = std::make_unique<test_operator>();
+    auto op       = std::make_unique<test_operator>(type);
     op->set_pipeline(pipeline);
     _bs.set_pipeline_source(*pipeline, *op);
     _bs.set_pipeline_sink(*pipeline, sirius::optional_ptr<sirius_physical_operator>(op.get()), 0);
@@ -65,15 +70,17 @@ class dag_builder {
     return pipeline;
   }
 
-  // Wire a data-flow edge from -> to carrying `barrier`.
+  // Wire a data-flow edge from -> to carrying `barrier`, pushed into port `port_name` on the
+  // consumer (auto-generated when empty; use "build"/"default" to model hash-join sides).
   void connect(const duckdb::shared_ptr<sirius_pipeline>& from,
                const duckdb::shared_ptr<sirius_pipeline>& to,
-               MemoryBarrierType barrier)
+               MemoryBarrierType barrier,
+               const std::string& port_name = "")
   {
     auto* consumer_op = to->get_source().get();
     auto* producer_op = from->get_sink().get();
 
-    _names.push_back("e" + std::to_string(_names.size()));
+    _names.push_back(port_name.empty() ? "e" + std::to_string(_names.size()) : port_name);
     std::string_view name = _names.back();
 
     auto port           = std::make_unique<sirius_physical_operator::port>();
@@ -198,4 +205,49 @@ TEST_CASE("query_index barrier_order with a partial barrier also extends", "[que
   REQUIRE(got.size() == 2);
   REQUIRE(contains(got, {1}));        // scan branch cut by its FULL edge
   REQUIRE(contains(got, {2, 3, 4}));  // partial edge extends mid through join, tail
+}
+
+// A hash join fed by a FULL-barrier probe side and a FULL-barrier build side:
+//   probe(1) --[FULL,"default"]--> join(2) ;  build(3) --[FULL,"build"]--> join(2) ;  join -> 4
+namespace {
+struct join_dag {
+  dag_builder b;
+  duckdb::shared_ptr<sirius_pipeline> probe, build, join, tail;
+  join_dag()
+  {
+    probe = b.add(1);
+    build = b.add(3);
+    join  = b.add(2, SiriusPhysicalOperatorType::HASH_JOIN);
+    tail  = b.add(4);
+    b.connect(probe, join, MemoryBarrierType::FULL, "default");  // probe side
+    b.connect(build, join, MemoryBarrierType::FULL, "build");    // build side
+    b.connect(join, tail, MemoryBarrierType::PIPELINE);
+  }
+};
+}  // namespace
+
+TEST_CASE("query_index build_probe pipelines the hash-join probe side through the join",
+          "[query_index]")
+{
+  join_dag d;
+  auto index = query_index::build_index(d.b.pipelines(), build_index_options{build_probe{}});
+  auto got   = d.b.label(index->get_branches());
+
+  // Probe (1) extends through the join (2) and its downstream (4); build side (3) still cuts.
+  REQUIRE(got.size() == 2);
+  REQUIRE(contains(got, {1, 2, 4}));
+  REQUIRE(contains(got, {3}));
+}
+
+TEST_CASE("query_index barrier_order does not pipeline the hash-join probe side", "[query_index]")
+{
+  join_dag d;
+  // Same DAG under barrier_order: both FULL edges cut, so the join heads its own branch.
+  auto index = query_index::build_index(d.b.pipelines(), build_index_options{barrier_order{}});
+  auto got   = d.b.label(index->get_branches());
+
+  REQUIRE(got.size() == 3);
+  REQUIRE(contains(got, {1}));
+  REQUIRE(contains(got, {3}));
+  REQUIRE(contains(got, {2, 4}));
 }


### PR DESCRIPTION
## Summary

Turns the pipeline-level task queue into a **priority queue** and assigns per-pipeline scheduling priorities derived from the query's pipeline DAG.

### 1. `inspectable_priority_queue`
New vector-backed, thread-safe priority queue (`src/include/exec/inspectable_priority_queue.hpp`) replacing `inspectable_mpsc` for the scheduler's top-level queue:
- Sorted by priority (descending), highest at front. `pop()`/`pop_front()` → highest, `pop_back()` → lowest; ties keep FIFO order.
- Priority via a construction-time extractor that reads `gpu_pipeline_task::get_priority()`.
- Full inspectable API preserved (`pop_if`/`mutable_pop_if`/`interrupt`/`drain`/…), so the downgrade executor and convertible-task provider swap over unchanged.

### 2. Per-task priority
`sirius_pipeline_task_global_state` carries a `priority`; `gpu_pipeline_task::get_priority()` reads it. All tasks of a pipeline share it.

### 3. `query_index` (branch analysis)
`build_index(query, options)` + `get_consumer_pipelines_till_next_branch(op)` (`src/include/planner/query_index.hpp`). Reads the pipeline DAG from the operator ports (`get_next_ports_after_sink`), which carry the per-edge `MemoryBarrierType`. Partitions the DAG into **branches** — a branch is cut at a **multiport** (fan-in) consumer; the multiport pipeline starts the next branch, so branches are disjoint.

`build_index_options.branch_order` is a `std::variant<pipeline_order, barrier_order>`:
- **`pipeline_order`** (default): cut every edge into a multiport consumer.
- **`barrier_order`**: only `FULL`-barrier edges cut; `PIPELINE`/`PARTIAL` edges extend the branch **past** the multiport operator into the downstream pipeline.

```
1->2->3 --[FULL]--> 4 ;  5->6 --[PIPELINE]--> 4 ;  4->7->8
pipeline_order : [1,2,3]  [5,6]  [4,7,8]
barrier_order  : [1,2,3]  [5,6,4,7,8]
```

### 4. Priority assignment (`task_creator::prepare_for_query`)
Each pipeline's global-state priority is computed so that:
- an **earlier** (closer-to-scan) branch is always strictly higher priority (per-branch stride > any branch length),
- `task_queue_ordering` selects **within-branch** direction — `fifo` = head-first, `lifo` = reversed — instead of ordering the queue,
- a pipeline **shared** by several branches takes the **max** priority.

With no priorities assigned, every task is priority 0 ⇒ behavior identical to the previous FIFO queue. `task_creator` currently builds the index with the default (`pipeline_order`).

## Tests
- `[inspectable_priority_queue]` — 12 cases (priority ordering, FIFO ties, `pop_back`, negatives, blocking pop, `pop_if`/`mutable_pop_if` direction, lifecycle).
- `[query_index]` — 4 cases: `pipeline_order` and `barrier_order` on the spec example, default-options, and a `PARTIAL`-barrier extension.
- Regression: `[inspectable_mpsc]`, `[convertible_gpu_pipeline_task]`, `[downgrade_executor]` pass. Full build green.

## Notes
- `task_queue_ordering` is now consumed by `task_creator` (via `task_scheduler::get_task_queue_ordering()`) and no longer orders the queue.
- `query_index::build_index` has a pipeline-vector overload used by the unit test (avoids constructing a full `query`).
- `task_creator` uses `pipeline_order` by default; switching to `barrier_order` (or wiring it to config) is a one-line change — happy to do either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
