### PR TITLE
dynamic filters: adapter layer (c1a1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,7 @@ set(EXTENSION_SOURCES
     src/pipeline/repository_wiring_materializer.cpp
     src/pipeline/sirius_plan_printer.cpp
     src/pipeline/task_request.cpp
+    src/planner/duckdb_join_filter_candidate_adapter.cpp
     src/planner/query.cpp
     src/planner/sirius_physical_plan_generator.cpp
     src/planner/sirius_plan_aggregate.cpp
@@ -641,6 +642,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_sirius_dynamic_filter_mgpu.cpp
     test/cpp/parallel/test_task_executor.cpp
     test/cpp/planner/test_distinct_hash_join_detection.cpp
+    test/cpp/planner/test_duckdb_join_filter_candidate_adapter.cpp
     test/cpp/planner/test_dynamic_filter_router.cpp
     test/cpp/planner/test_join_expression_key.cpp
     test/cpp/planner/test_plan_tree_shape.cpp

--- a/src/include/planner/duckdb_join_filter_candidate_adapter.hpp
+++ b/src/include/planner/duckdb_join_filter_candidate_adapter.hpp
@@ -107,11 +107,11 @@ class duckdb_probe_target_candidate final {
     duckdb::LogicalType storage_type{};
   };
 
-  ~duckdb_probe_target_candidate() = default;
-  duckdb_probe_target_candidate(duckdb_probe_target_candidate const&) = default;
+  ~duckdb_probe_target_candidate()                                               = default;
+  duckdb_probe_target_candidate(duckdb_probe_target_candidate const&)            = default;
   duckdb_probe_target_candidate& operator=(duckdb_probe_target_candidate const&) = default;
-  duckdb_probe_target_candidate(duckdb_probe_target_candidate&&)            = delete;
-  duckdb_probe_target_candidate& operator=(duckdb_probe_target_candidate&&) = delete;
+  duckdb_probe_target_candidate(duckdb_probe_target_candidate&&)                 = delete;
+  duckdb_probe_target_candidate& operator=(duckdb_probe_target_candidate&&)      = delete;
 
   [[nodiscard]] duckdb_dynamic_filter_channel const& channel_identity() const& noexcept;
   [[nodiscard]] duckdb_dynamic_filter_channel const& channel_identity() const&& = delete;
@@ -147,7 +147,7 @@ class duckdb_probe_target_candidate final {
  */
 class duckdb_join_filter_candidate final {
  public:
-  ~duckdb_join_filter_candidate() = default;
+  ~duckdb_join_filter_candidate()                                   = default;
   duckdb_join_filter_candidate(duckdb_join_filter_candidate const&) = default;
   duckdb_join_filter_candidate& operator=(duckdb_join_filter_candidate const& other);
   duckdb_join_filter_candidate(duckdb_join_filter_candidate&& other) noexcept;
@@ -157,8 +157,7 @@ class duckdb_join_filter_candidate final {
   [[nodiscard]] bool build_subtree_has_filter_hint() const noexcept;
   [[nodiscard]] std::vector<std::size_t> const& condition_indexes() const& noexcept;
   [[nodiscard]] std::vector<std::size_t> const& condition_indexes() const&& = delete;
-  [[nodiscard]] std::vector<duckdb::ExpressionType> const& condition_comparisons()
-    const& noexcept;
+  [[nodiscard]] std::vector<duckdb::ExpressionType> const& condition_comparisons() const& noexcept;
   [[nodiscard]] std::vector<duckdb::ExpressionType> const& condition_comparisons() const&& = delete;
   [[nodiscard]] std::vector<duckdb_probe_target_candidate> const& targets() const& noexcept;
   [[nodiscard]] std::vector<duckdb_probe_target_candidate> const& targets() const&& = delete;

--- a/src/include/planner/duckdb_join_filter_candidate_adapter.hpp
+++ b/src/include/planner/duckdb_join_filter_candidate_adapter.hpp
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+/**
+ * @file
+ * @brief The encapsulation boundary between DuckDB's internal dynamic-filter representation and
+ * Sirius.
+ *
+ * The normal data flow is:
+ *
+ *   DuckDB logical join                         Sirius-owned planning data
+ *   +---------------------------+               +-----------------------------+
+ *   | filter_pushdown           |   extract()   | kind                        |
+ *   |   join_condition[]        | ------------> | condition indexes/types     |
+ *   |   probe_info[]            |               | probe columns               |
+ *   |   DynamicTableFilterSet * |               | opaque shared channel key   |
+ *   +---------------------------+               +-----------------------------+
+ *                                                          |
+ *                                                          v
+ *                                              downstream Sirius planning
+ *
+ * DuckDB's JoinFilterPushdownInfo (join_filter_pushdown.hpp) is the DuckDB planner's internal
+ * representation of dynamic-filter metadata. 2 of its member vectors are:
+ *  - join_condition[]:     the indexes of the join conditions for which DuckDB will build filters,
+ *  - probe_info[]:         the probe targets (one per LogicalGet) and the columns in each target
+ *                          that correspond to the join_condition[] entries.
+ *
+ * A `DuckDB filter ordinal` is the index position into the aligned join_condition[] and
+ * probe_info[t].columns[] vectors for each JoinFilterPushdownFilter target t.
+ *
+ * For a join
+ *   ON f.a = d.a AND f.ts < d.ts AND f.b = d.b     -- conditions[0], [1], [2]
+ * where DuckDB recorded join_condition = [2, 0]:
+ *   DuckDB filter ordinal j     0                     1
+ *   join_condition[j]           2  (f.b = d.b)        0  (f.a = d.a)
+ *   target t's columns          columns[0] -> b       columns[1] -> a
+ *                               (each an index into this scan's column_ids vector)
+ */
+
+#include <duckdb/common/enums/expression_type.hpp>
+#include <duckdb/common/shared_ptr.hpp>
+#include <duckdb/common/types.hpp>
+#include <duckdb/execution/operator/join/join_filter_pushdown.hpp>
+#include <duckdb/planner/logical_operator.hpp>
+
+#include <cstddef>
+#include <vector>
+
+namespace duckdb {
+class LogicalComparisonJoin;
+class LogicalGet;
+}  // namespace duckdb
+
+namespace sirius::planner {
+
+namespace duckdb_join_filter_candidate_adapter::detail {
+class candidate_builder;
+}  // namespace duckdb_join_filter_candidate_adapter::detail
+
+using duckdb_dynamic_filter_channel = duckdb::shared_ptr<duckdb::DynamicTableFilterSet const>;
+
+/**
+ * @brief Structural classification of one comparison join's DuckDB dynamic-filter metadata.
+ */
+enum class duckdb_candidate_kind {
+  absent,           ///< No JoinFilterPushdownInfo was attached to the join.
+  statistics_only,  ///< DuckDB deliberately recorded no probe target; the build hint is false.
+  admitted,         ///< The recorded indexes, target arity, and channel identities are usable.
+  malformed,        ///< The adapter can prove that the recorded structure is inconsistent.
+};
+
+/**
+ * @brief One probe target named by the producing join, copied into Sirius-owned values.
+ *
+ * A target is one base-table scan (`LogicalGet`) on the join's probe subtree that DuckDB's
+ * pushdown walk selected to receive the build-side filters — one entry per `probe_info` element.
+ * A join can name several scans (e.g., a probe side built from a UNION reaches one per branch),
+ * and every target carries the full key arity: `columns[j]` names where filter ordinal `j`'s
+ * key lives in THIS scan's output.
+ *
+ * `channel_identity` keeps the exact shared DuckDB object alive and exposes it as a read-only,
+ * opaque map key during planning. DuckDB owns mutation of the underlying runtime filter set.
+ * Targets have no disengaged state, so they are copyable but deliberately not movable.
+ */
+class duckdb_probe_target_candidate final {
+ public:
+  struct probe_column {
+    /// Index INTO the target scan's `column_ids` vector (its projection position, i.e.,
+    /// probe_info[t].columns[j]), NOT the base-table column index stored at that position
+    /// (`column_ids[i].GetPrimaryIndex()`).
+    std::size_t column_index = 0;
+    duckdb::LogicalType storage_type{};
+  };
+
+  ~duckdb_probe_target_candidate() = default;
+  duckdb_probe_target_candidate(duckdb_probe_target_candidate const&) = default;
+  duckdb_probe_target_candidate& operator=(duckdb_probe_target_candidate const&) = default;
+  duckdb_probe_target_candidate(duckdb_probe_target_candidate&&)            = delete;
+  duckdb_probe_target_candidate& operator=(duckdb_probe_target_candidate&&) = delete;
+
+  [[nodiscard]] duckdb_dynamic_filter_channel const& channel_identity() const& noexcept;
+  [[nodiscard]] duckdb_dynamic_filter_channel const& channel_identity() const&& = delete;
+  [[nodiscard]] std::vector<probe_column> const& columns() const& noexcept;
+  [[nodiscard]] std::vector<probe_column> const& columns() const&& = delete;
+
+ private:
+  friend class duckdb_join_filter_candidate_adapter::detail::candidate_builder;
+
+  duckdb_probe_target_candidate(duckdb_dynamic_filter_channel channel_identity,
+                                std::vector<probe_column> columns);
+
+  duckdb_dynamic_filter_channel _channel_identity;
+  std::vector<probe_column> _columns;
+};
+
+/**
+ * @brief Immutable Sirius-owned snapshot of one comparison join's dynamic-filter metadata.
+ *
+ * The filter-key set is decided once per producing join and is SHARED by every target; a target
+ * records only where each shared key lands in its own scan. The vectors form a keys-by-targets
+ * grid indexed by DuckDB filter ordinal `j` (the position in the aligned vectors — a different
+ * ordinal space from the join-condition index stored at that position):
+ *
+ *   shared across targets    condition_indexes[j]       index into the join's condition vector
+ *                            condition_comparisons[j]   comparison at that condition index
+ *   per target t             targets[t].columns[j]      where key j lands in scan t's output
+ *
+ * (Runtime mirrors this: one filter is built per ordinal j and pushed to every target.)
+ *
+ * Later planning wraps these raw adapter values in strong ordinal types and may compact admitted
+ * equality keys into a third space, the Sirius key ordinal.
+ */
+class duckdb_join_filter_candidate final {
+ public:
+  ~duckdb_join_filter_candidate() = default;
+  duckdb_join_filter_candidate(duckdb_join_filter_candidate const&) = default;
+  duckdb_join_filter_candidate& operator=(duckdb_join_filter_candidate const& other);
+  duckdb_join_filter_candidate(duckdb_join_filter_candidate&& other) noexcept;
+  duckdb_join_filter_candidate& operator=(duckdb_join_filter_candidate&& other) noexcept;
+
+  [[nodiscard]] duckdb_candidate_kind kind() const noexcept;
+  [[nodiscard]] bool build_subtree_has_filter_hint() const noexcept;
+  [[nodiscard]] std::vector<std::size_t> const& condition_indexes() const& noexcept;
+  [[nodiscard]] std::vector<std::size_t> const& condition_indexes() const&& = delete;
+  [[nodiscard]] std::vector<duckdb::ExpressionType> const& condition_comparisons()
+    const& noexcept;
+  [[nodiscard]] std::vector<duckdb::ExpressionType> const& condition_comparisons() const&& = delete;
+  [[nodiscard]] std::vector<duckdb_probe_target_candidate> const& targets() const& noexcept;
+  [[nodiscard]] std::vector<duckdb_probe_target_candidate> const& targets() const&& = delete;
+
+ private:
+  friend class duckdb_join_filter_candidate_adapter::detail::candidate_builder;
+
+  [[nodiscard]] static duckdb_join_filter_candidate absent();
+  [[nodiscard]] static duckdb_join_filter_candidate statistics_only();
+  [[nodiscard]] static duckdb_join_filter_candidate malformed();
+  [[nodiscard]] static duckdb_join_filter_candidate admitted(
+    bool build_subtree_has_filter_hint,
+    std::vector<std::size_t> condition_indexes,
+    std::vector<duckdb::ExpressionType> condition_comparisons,
+    std::vector<duckdb_probe_target_candidate> targets);
+
+  duckdb_join_filter_candidate(duckdb_candidate_kind kind,
+                               bool build_subtree_has_filter_hint,
+                               std::vector<std::size_t> condition_indexes,
+                               std::vector<duckdb::ExpressionType> condition_comparisons,
+                               std::vector<duckdb_probe_target_candidate> targets);
+
+  void reset_to_absent() noexcept;
+
+  duckdb_candidate_kind _kind;
+  bool _build_subtree_has_filter_hint;
+  std::vector<std::size_t> _condition_indexes;
+  std::vector<duckdb::ExpressionType> _condition_comparisons;
+  std::vector<duckdb_probe_target_candidate> _targets;
+};
+
+/**
+ * @brief The semantic owner of reads from DuckDB's dynamic-filter metadata layout.
+ *
+ * Consumers receive Sirius-owned structural values and do not retain or dereference DuckDB's
+ * `JoinFilterPushdownInfo`. The opaque channel handle is the deliberate exception: it keeps the
+ * shared route identity alive without exposing mutation. Planner code that still reads
+ * `filter_pushdown` / `dynamic_filters` directly predates the adapter; follow-up units route those
+ * reads through it.
+ */
+namespace duckdb_join_filter_candidate_adapter {
+
+namespace detail {
+
+/**
+ * @brief Clone the subset of metadata consumed by Sirius, exposed only for unit tests.
+ *
+ * Shares each `DynamicTableFilterSet` to preserve route identity and intentionally omits
+ * `min_max_aggregates`. The result is only for Sirius planning and must not be handed to DuckDB's
+ * physical join execution; the untouched original retains the complete CPU-fallback metadata.
+ */
+[[nodiscard]] duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> clone_sirius_filter_pushdown_info(
+  duckdb::JoinFilterPushdownInfo const& src);
+
+}  // namespace detail
+
+/**
+ * @brief Re-attach dynamic-filter metadata from @p original onto @p copy while a logical plan is
+ * deep-copied for Sirius's transparent execution path.
+ *
+ * `LogicalOperator::Copy` round-trips through serialize/deserialize, and neither
+ * `LogicalComparisonJoin::filter_pushdown` nor `LogicalGet::dynamic_filters` is in DuckDB's
+ * serialization schema, so a plain `Copy` strips them. The copy is expected to have the same tree
+ * shape; a whole-tree preflight leaves a mismatched copy unchanged in every build.
+ *
+ * @param original  Read-only source plan. Its `filter_pushdown` / `dynamic_filters` stay put so
+ *                  DuckDB's CPU fallback still sees them; only shared_ptrs are copied out.
+ * @param copy      The freshly-`Copy`-produced plan that receives the metadata.
+ */
+void preserve_dynamic_filter_metadata(duckdb::LogicalOperator const& original,
+                                      duckdb::LogicalOperator& copy);
+
+/**
+ * @brief Classify and snapshot one comparison join's dynamic-filter metadata into Sirius values.
+ *
+ * Fails closed (@c malformed) on structural corruption it can prove locally:
+ *  - an out-of-range or duplicate condition index,
+ *  - a target whose column count disagrees with the recorded ordinal count,
+ *  - recorded targets with an empty ordinal list, or
+ *  - targetless metadata carrying a build-side filter hint, or
+ *  - a non-empty `probe_info` whose every channel identity is null.
+ *
+ * A malformed result carries only `kind == malformed`; callers must not rely on partially copied
+ * fields from the rejected metadata.
+ */
+[[nodiscard]] duckdb_join_filter_candidate extract(duckdb::LogicalComparisonJoin const& op);
+
+/**
+ * @brief Return the opaque channel identity at the scan end of the join-scan pairing.
+ *
+ * The PRODUCER obtains the same shared object through @ref extract. Pointer equality pairs the two
+ * producer/consumer objects during planning. The returned handle keeps the channel alive but
+ * exposes only a const pointee; DuckDB owns runtime mutation. Exposed for the CONSUMER.
+ */
+[[nodiscard]] duckdb_dynamic_filter_channel scan_channel_identity(duckdb::LogicalGet const& get);
+
+}  // namespace duckdb_join_filter_candidate_adapter
+
+}  // namespace sirius::planner

--- a/src/include/transparent/sirius_optimizer_extension.hpp
+++ b/src/include/transparent/sirius_optimizer_extension.hpp
@@ -16,11 +16,8 @@
 
 #pragma once
 
-#include <duckdb/execution/operator/join/join_filter_pushdown.hpp>
 #include <duckdb/optimizer/optimizer_extension.hpp>
 #include <duckdb/planner/logical_operator.hpp>
-
-#include <cstddef>
 
 namespace sirius::transparent {
 
@@ -40,49 +37,19 @@ void sirius_pre_optimizer_hook(duckdb::OptimizerExtensionInput& input,
 void sirius_optimizer_hook(duckdb::OptimizerExtensionInput& input,
                            duckdb::unique_ptr<duckdb::LogicalOperator>& plan);
 
-namespace detail {
-
-/// @brief Count of nodes that received metadata during preserve_dynamic_filter_metadata.
-/// Surfaced for diagnostic logging and unit-test assertions.
-struct preserved_counts {
-  std::size_t joins{0};
-  std::size_t gets{0};
-};
-
-/// @brief Deep-copy a @c JoinFilterPushdownInfo, sharing the @c DynamicTableFilterSet shared_ptrs
-/// (preserving the route-key pointer identity that pairs joins with their downstream scans).
-/// Omits @c min_max_aggregates — Sirius does not consume them and cloning @c Expression trees
-/// is non-trivial.
-[[nodiscard]] duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> clone_filter_pushdown_info(
-  duckdb::JoinFilterPushdownInfo const& src);
-
-/// @brief Walk @p original and @p copy in parallel and re-attach
-/// @c LogicalComparisonJoin::filter_pushdown / @c LogicalGet::dynamic_filters from original onto
-/// copy. @c LogicalOperator::Copy round-trips through serialize/deserialize, and these fields
-/// are absent from both operators' serialization schemas — without this fixup the copy has them
-/// null. Bails defensively at any structural mismatch.
-void preserve_dynamic_filter_metadata(duckdb::LogicalOperator& original,
-                                      duckdb::LogicalOperator& copy,
-                                      preserved_counts& counts);
-
-}  // namespace detail
-
-/// @brief Copy a logical plan for Sirius's transparent execution path. Wraps
-/// @c duckdb::LogicalOperator::Copy and additionally preserves the dynamic-filter metadata from
-/// the source plan onto the copy: @c LogicalComparisonJoin::filter_pushdown and
-/// @c LogicalGet::dynamic_filters. Neither field is in DuckDB's serialization schema, so a plain
-/// @c Copy (serialize → deserialize) strips them, and the downstream Sirius wiring would never
-/// see the optimizer's pushdown work. Use this at every site that copies a captured logical plan
-/// for GPU execution; see @ref detail::preserve_dynamic_filter_metadata for the parallel-walk
-/// mechanics.
+/// \brief Copy a logical plan for Sirius's transparent execution path.
 ///
-/// @param plan      The plan to copy. Not consumed; @c filter_pushdown / @c dynamic_filters are
-///                  left on the original so DuckDB's CPU fallback path can still see them.
-/// @param context   DuckDB client context for @c LogicalOperator::Copy.
-/// @param counts    Optional out-param recording how many joins/gets received metadata.
+/// Wraps \c duckdb::LogicalOperator::Copy and additionally preserves the dynamic-filter metadata
+/// from the source plan onto the copy: \c LogicalComparisonJoin::filter_pushdown and \c
+/// LogicalGet::dynamic_filters. Neither field is in DuckDB's serialization schema, so a plain \c
+/// Copy (serialize → deserialize) strips them, and the downstream Sirius wiring would never see the
+/// optimizer's pushdown work. Use this at every site that copies a captured logical plan for GPU
+/// execution.
+///
+/// \param plan     The plan to copy. Not consumed; \c filter_pushdown / \c dynamic_filters are left
+///                 on the original so DuckDB's CPU fallback path can still see them.
+/// \param context  DuckDB client context for \c LogicalOperator::Copy.
 [[nodiscard]] duckdb::unique_ptr<duckdb::LogicalOperator> copy_logical_plan(
-  duckdb::LogicalOperator& plan,
-  duckdb::ClientContext& context,
-  detail::preserved_counts* counts = nullptr);
+  duckdb::LogicalOperator const& plan, duckdb::ClientContext& context);
 
 }  // namespace sirius::transparent

--- a/src/planner/duckdb_join_filter_candidate_adapter.cpp
+++ b/src/planner/duckdb_join_filter_candidate_adapter.cpp
@@ -48,11 +48,15 @@ duckdb_probe_target_candidate::duckdb_probe_target_candidate(
 
 duckdb_dynamic_filter_channel const& duckdb_probe_target_candidate::channel_identity()
   const& noexcept
-{ return _channel_identity; }
+{
+  return _channel_identity;
+}
 
 std::vector<duckdb_probe_target_candidate::probe_column> const&
 duckdb_probe_target_candidate::columns() const& noexcept
-{ return _columns; }
+{
+  return _columns;
+}
 
 duckdb_join_filter_candidate::duckdb_join_filter_candidate(
   duckdb_candidate_kind kind,
@@ -75,7 +79,9 @@ duckdb_join_filter_candidate::duckdb_join_filter_candidate(
     _condition_indexes(std::move(other._condition_indexes)),
     _condition_comparisons(std::move(other._condition_comparisons)),
     _targets(std::move(other._targets))
-{ other.reset_to_absent(); }
+{
+  other.reset_to_absent();
+}
 
 duckdb_join_filter_candidate& duckdb_join_filter_candidate::operator=(
   duckdb_join_filter_candidate const& other)
@@ -99,13 +105,19 @@ duckdb_join_filter_candidate& duckdb_join_filter_candidate::operator=(
 }
 
 duckdb_join_filter_candidate duckdb_join_filter_candidate::absent()
-{ return duckdb_join_filter_candidate{duckdb_candidate_kind::absent, false, {}, {}, {}}; }
+{
+  return duckdb_join_filter_candidate{duckdb_candidate_kind::absent, false, {}, {}, {}};
+}
 
 duckdb_join_filter_candidate duckdb_join_filter_candidate::statistics_only()
-{ return duckdb_join_filter_candidate{duckdb_candidate_kind::statistics_only, false, {}, {}, {}}; }
+{
+  return duckdb_join_filter_candidate{duckdb_candidate_kind::statistics_only, false, {}, {}, {}};
+}
 
 duckdb_join_filter_candidate duckdb_join_filter_candidate::malformed()
-{ return duckdb_join_filter_candidate{duckdb_candidate_kind::malformed, false, {}, {}, {}}; }
+{
+  return duckdb_join_filter_candidate{duckdb_candidate_kind::malformed, false, {}, {}, {}};
+}
 
 duckdb_join_filter_candidate duckdb_join_filter_candidate::admitted(
   bool build_subtree_has_filter_hint,
@@ -152,18 +164,26 @@ duckdb_join_filter_candidate duckdb_join_filter_candidate::admitted(
 duckdb_candidate_kind duckdb_join_filter_candidate::kind() const noexcept { return _kind; }
 
 bool duckdb_join_filter_candidate::build_subtree_has_filter_hint() const noexcept
-{ return _build_subtree_has_filter_hint; }
+{
+  return _build_subtree_has_filter_hint;
+}
 
 std::vector<std::size_t> const& duckdb_join_filter_candidate::condition_indexes() const& noexcept
-{ return _condition_indexes; }
+{
+  return _condition_indexes;
+}
 
 std::vector<duckdb::ExpressionType> const& duckdb_join_filter_candidate::condition_comparisons()
   const& noexcept
-{ return _condition_comparisons; }
+{
+  return _condition_comparisons;
+}
 
 std::vector<duckdb_probe_target_candidate> const& duckdb_join_filter_candidate::targets()
   const& noexcept
-{ return _targets; }
+{
+  return _targets;
+}
 
 void duckdb_join_filter_candidate::reset_to_absent() noexcept
 {
@@ -189,13 +209,19 @@ class candidate_builder final {
   }
 
   [[nodiscard]] static duckdb_join_filter_candidate absent()
-  { return duckdb_join_filter_candidate::absent(); }
+  {
+    return duckdb_join_filter_candidate::absent();
+  }
 
   [[nodiscard]] static duckdb_join_filter_candidate statistics_only()
-  { return duckdb_join_filter_candidate::statistics_only(); }
+  {
+    return duckdb_join_filter_candidate::statistics_only();
+  }
 
   [[nodiscard]] static duckdb_join_filter_candidate malformed()
-  { return duckdb_join_filter_candidate::malformed(); }
+  {
+    return duckdb_join_filter_candidate::malformed();
+  }
 
   [[nodiscard]] static duckdb_join_filter_candidate admitted(
     bool build_subtree_has_filter_hint,
@@ -325,7 +351,9 @@ duckdb_join_filter_candidate extract(duckdb::LogicalComparisonJoin const& op)
 }
 
 duckdb_dynamic_filter_channel scan_channel_identity(duckdb::LogicalGet const& get)
-{ return get.dynamic_filters; }
+{
+  return get.dynamic_filters;
+}
 
 }  // namespace duckdb_join_filter_candidate_adapter
 

--- a/src/planner/duckdb_join_filter_candidate_adapter.cpp
+++ b/src/planner/duckdb_join_filter_candidate_adapter.cpp
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "planner/duckdb_join_filter_candidate_adapter.hpp"
+
+#include <duckdb/common/helper.hpp>
+#include <duckdb/common/typedefs.hpp>
+#include <duckdb/planner/operator/logical_comparison_join.hpp>
+#include <duckdb/planner/operator/logical_get.hpp>
+#include <duckdb/planner/table_filter.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace sirius::planner {
+
+duckdb_probe_target_candidate::duckdb_probe_target_candidate(
+  duckdb_dynamic_filter_channel channel_identity, std::vector<probe_column> columns)
+  : _channel_identity(std::move(channel_identity)), _columns(std::move(columns))
+{
+  if (!_channel_identity) {
+    throw std::invalid_argument(
+      "[duckdb_probe_target_candidate] A DuckDB dynamic-filter target requires a channel identity");
+  }
+  if (_columns.empty()) {
+    throw std::invalid_argument(
+      "[duckdb_probe_target_candidate] A DuckDB dynamic-filter target requires at least one "
+      "column");
+  }
+}
+
+duckdb_dynamic_filter_channel const& duckdb_probe_target_candidate::channel_identity()
+  const& noexcept
+{ return _channel_identity; }
+
+std::vector<duckdb_probe_target_candidate::probe_column> const&
+duckdb_probe_target_candidate::columns() const& noexcept
+{ return _columns; }
+
+duckdb_join_filter_candidate::duckdb_join_filter_candidate(
+  duckdb_candidate_kind kind,
+  bool build_subtree_has_filter_hint,
+  std::vector<std::size_t> condition_indexes,
+  std::vector<duckdb::ExpressionType> condition_comparisons,
+  std::vector<duckdb_probe_target_candidate> targets)
+  : _kind(kind),
+    _build_subtree_has_filter_hint(build_subtree_has_filter_hint),
+    _condition_indexes(std::move(condition_indexes)),
+    _condition_comparisons(std::move(condition_comparisons)),
+    _targets(std::move(targets))
+{
+}
+
+duckdb_join_filter_candidate::duckdb_join_filter_candidate(
+  duckdb_join_filter_candidate&& other) noexcept
+  : _kind(other._kind),
+    _build_subtree_has_filter_hint(other._build_subtree_has_filter_hint),
+    _condition_indexes(std::move(other._condition_indexes)),
+    _condition_comparisons(std::move(other._condition_comparisons)),
+    _targets(std::move(other._targets))
+{ other.reset_to_absent(); }
+
+duckdb_join_filter_candidate& duckdb_join_filter_candidate::operator=(
+  duckdb_join_filter_candidate const& other)
+{
+  if (this == &other) { return *this; }
+  auto copy    = other;
+  return *this = std::move(copy);
+}
+
+duckdb_join_filter_candidate& duckdb_join_filter_candidate::operator=(
+  duckdb_join_filter_candidate&& other) noexcept
+{
+  if (this == &other) { return *this; }
+  _kind                          = other._kind;
+  _build_subtree_has_filter_hint = other._build_subtree_has_filter_hint;
+  _condition_indexes             = std::move(other._condition_indexes);
+  _condition_comparisons         = std::move(other._condition_comparisons);
+  _targets                       = std::move(other._targets);
+  other.reset_to_absent();
+  return *this;
+}
+
+duckdb_join_filter_candidate duckdb_join_filter_candidate::absent()
+{ return duckdb_join_filter_candidate{duckdb_candidate_kind::absent, false, {}, {}, {}}; }
+
+duckdb_join_filter_candidate duckdb_join_filter_candidate::statistics_only()
+{ return duckdb_join_filter_candidate{duckdb_candidate_kind::statistics_only, false, {}, {}, {}}; }
+
+duckdb_join_filter_candidate duckdb_join_filter_candidate::malformed()
+{ return duckdb_join_filter_candidate{duckdb_candidate_kind::malformed, false, {}, {}, {}}; }
+
+duckdb_join_filter_candidate duckdb_join_filter_candidate::admitted(
+  bool build_subtree_has_filter_hint,
+  std::vector<std::size_t> condition_indexes,
+  std::vector<duckdb::ExpressionType> condition_comparisons,
+  std::vector<duckdb_probe_target_candidate> targets)
+{
+  if (condition_indexes.empty()) {
+    throw std::invalid_argument(
+      "[duckdb_join_filter_candidate::admitted] An admitted DuckDB dynamic-filter candidate "
+      "requires a key");
+  }
+  if (condition_indexes.size() != condition_comparisons.size()) {
+    throw std::invalid_argument(
+      "[duckdb_join_filter_candidate::admitted] DuckDB dynamic-filter condition vectors must have "
+      "equal arity");
+  }
+  for (auto it = condition_indexes.begin(); it != condition_indexes.end(); ++it) {
+    if (std::find(condition_indexes.begin(), it, *it) != it) {
+      throw std::invalid_argument(
+        "[duckdb_join_filter_candidate::admitted] DuckDB dynamic-filter condition indexes must be "
+        "unique");
+    }
+  }
+  if (targets.empty()) {
+    throw std::invalid_argument(
+      "[duckdb_join_filter_candidate::admitted] An admitted DuckDB dynamic-filter candidate "
+      "requires a target");
+  }
+  for (auto const& target : targets) {
+    if (target.columns().size() != condition_indexes.size()) {
+      throw std::invalid_argument(
+        "[duckdb_join_filter_candidate::admitted] DuckDB dynamic-filter target and key arity must "
+        "match");
+    }
+  }
+  return duckdb_join_filter_candidate{duckdb_candidate_kind::admitted,
+                                      build_subtree_has_filter_hint,
+                                      std::move(condition_indexes),
+                                      std::move(condition_comparisons),
+                                      std::move(targets)};
+}
+
+duckdb_candidate_kind duckdb_join_filter_candidate::kind() const noexcept { return _kind; }
+
+bool duckdb_join_filter_candidate::build_subtree_has_filter_hint() const noexcept
+{ return _build_subtree_has_filter_hint; }
+
+std::vector<std::size_t> const& duckdb_join_filter_candidate::condition_indexes() const& noexcept
+{ return _condition_indexes; }
+
+std::vector<duckdb::ExpressionType> const& duckdb_join_filter_candidate::condition_comparisons()
+  const& noexcept
+{ return _condition_comparisons; }
+
+std::vector<duckdb_probe_target_candidate> const& duckdb_join_filter_candidate::targets()
+  const& noexcept
+{ return _targets; }
+
+void duckdb_join_filter_candidate::reset_to_absent() noexcept
+{
+  _kind                          = duckdb_candidate_kind::absent;
+  _build_subtree_has_filter_hint = false;
+  _condition_indexes.clear();
+  _condition_comparisons.clear();
+  _targets.clear();
+}
+
+namespace duckdb_join_filter_candidate_adapter {
+
+namespace detail {
+
+class candidate_builder final {
+ public:
+  static void append_probe_target(std::vector<duckdb_probe_target_candidate>& targets,
+                                  duckdb_dynamic_filter_channel channel_identity,
+                                  std::vector<duckdb_probe_target_candidate::probe_column> columns)
+  {
+    duckdb_probe_target_candidate target{std::move(channel_identity), std::move(columns)};
+    targets.push_back(target);
+  }
+
+  [[nodiscard]] static duckdb_join_filter_candidate absent()
+  { return duckdb_join_filter_candidate::absent(); }
+
+  [[nodiscard]] static duckdb_join_filter_candidate statistics_only()
+  { return duckdb_join_filter_candidate::statistics_only(); }
+
+  [[nodiscard]] static duckdb_join_filter_candidate malformed()
+  { return duckdb_join_filter_candidate::malformed(); }
+
+  [[nodiscard]] static duckdb_join_filter_candidate admitted(
+    bool build_subtree_has_filter_hint,
+    std::vector<std::size_t> condition_indexes,
+    std::vector<duckdb::ExpressionType> condition_comparisons,
+    std::vector<duckdb_probe_target_candidate> targets)
+  {
+    return duckdb_join_filter_candidate::admitted(build_subtree_has_filter_hint,
+                                                  std::move(condition_indexes),
+                                                  std::move(condition_comparisons),
+                                                  std::move(targets));
+  }
+};
+
+}  // namespace detail
+
+static_assert(std::numeric_limits<std::size_t>::max() >= std::numeric_limits<duckdb::idx_t>::max(),
+              "DuckDB idx_t ordinals must fit in std::size_t without narrowing");
+
+duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> detail::clone_sirius_filter_pushdown_info(
+  duckdb::JoinFilterPushdownInfo const& src)
+{
+  // Clone the Sirius-consumed fields but share every DynamicTableFilterSet. min_max_aggregates is
+  // deliberately omitted: this partial clone must never enter DuckDB physical join execution.
+  auto dst                   = duckdb::make_uniq<duckdb::JoinFilterPushdownInfo>();
+  dst->join_condition        = src.join_condition;
+  dst->build_side_has_filter = src.build_side_has_filter;
+  dst->probe_info.reserve(src.probe_info.size());
+  for (auto const& pi : src.probe_info) {
+    duckdb::JoinFilterPushdownFilter copy_pi;
+    copy_pi.dynamic_filters = pi.dynamic_filters;
+    copy_pi.columns         = pi.columns;
+    dst->probe_info.push_back(std::move(copy_pi));
+  }
+  return dst;
+}
+
+namespace {
+
+bool structurally_aligned(duckdb::LogicalOperator const& a, duckdb::LogicalOperator const& b)
+{
+  if (a.type != b.type || a.children.size() != b.children.size()) { return false; }
+  for (std::size_t i = 0; i < a.children.size(); ++i) {
+    if (!structurally_aligned(*a.children[i], *b.children[i])) { return false; }
+  }
+  return true;
+}
+
+void preserve_aligned(duckdb::LogicalOperator const& original, duckdb::LogicalOperator& copy)
+{
+  if (original.type == duckdb::LogicalOperatorType::LOGICAL_GET) {
+    auto const& o = original.Cast<duckdb::LogicalGet>();
+    auto& c       = copy.Cast<duckdb::LogicalGet>();
+    if (o.dynamic_filters) { c.dynamic_filters = o.dynamic_filters; }
+  } else if (original.type == duckdb::LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+    auto const& o = original.Cast<duckdb::LogicalComparisonJoin>();
+    auto& c       = copy.Cast<duckdb::LogicalComparisonJoin>();
+    if (o.filter_pushdown) {
+      c.filter_pushdown = detail::clone_sirius_filter_pushdown_info(*o.filter_pushdown);
+    }
+  }
+  for (std::size_t i = 0; i < original.children.size(); ++i) {
+    preserve_aligned(*original.children[i], *copy.children[i]);
+  }
+}
+
+}  // namespace
+
+void preserve_dynamic_filter_metadata(duckdb::LogicalOperator const& original,
+                                      duckdb::LogicalOperator& copy)
+{
+  // Check the complete pair before copying anything so preservation is all-or-nothing.
+  if (!structurally_aligned(original, copy)) { return; }
+  preserve_aligned(original, copy);
+}
+
+duckdb_join_filter_candidate extract(duckdb::LogicalComparisonJoin const& op)
+{
+  if (!op.filter_pushdown) { return detail::candidate_builder::absent(); }
+  auto const& info = *op.filter_pushdown;
+
+  auto const malformed = []() { return detail::candidate_builder::malformed(); };
+
+  if (info.join_condition.empty()) { return malformed(); }
+
+  std::vector<std::size_t> condition_indexes;
+  std::vector<duckdb::ExpressionType> condition_comparisons;
+  condition_indexes.reserve(info.join_condition.size());
+  condition_comparisons.reserve(info.join_condition.size());
+  for (auto const cond_idx : info.join_condition) {
+    if (cond_idx >= op.conditions.size()) { return malformed(); }
+    auto const condition_index = static_cast<std::size_t>(cond_idx);
+    if (std::find(condition_indexes.begin(), condition_indexes.end(), condition_index) !=
+        condition_indexes.end()) {
+      return malformed();
+    }
+    condition_indexes.push_back(condition_index);
+    condition_comparisons.push_back(op.conditions[condition_index].comparison);
+  }
+
+  if (info.probe_info.empty()) {
+    if (info.build_side_has_filter) { return malformed(); }
+    return detail::candidate_builder::statistics_only();
+  }
+
+  std::vector<duckdb_probe_target_candidate> targets;
+  targets.reserve(info.probe_info.size());
+  for (auto const& pi : info.probe_info) {
+    if (pi.columns.size() != info.join_condition.size()) { return malformed(); }
+    if (!pi.dynamic_filters) { continue; }
+
+    std::vector<duckdb_probe_target_candidate::probe_column> columns;
+    columns.reserve(pi.columns.size());
+    for (auto const& col : pi.columns) {
+      columns.push_back(duckdb_probe_target_candidate::probe_column{
+        static_cast<std::size_t>(col.probe_column_index.column_index), col.storage_type});
+    }
+    detail::candidate_builder::append_probe_target(targets, pi.dynamic_filters, std::move(columns));
+  }
+
+  if (targets.empty()) { return malformed(); }
+
+  return detail::candidate_builder::admitted(info.build_side_has_filter,
+                                             std::move(condition_indexes),
+                                             std::move(condition_comparisons),
+                                             std::move(targets));
+}
+
+duckdb_dynamic_filter_channel scan_channel_identity(duckdb::LogicalGet const& get)
+{ return get.dynamic_filters; }
+
+}  // namespace duckdb_join_filter_candidate_adapter
+
+}  // namespace sirius::planner

--- a/src/transparent/physical_sirius_execution.cpp
+++ b/src/transparent/physical_sirius_execution.cpp
@@ -117,10 +117,6 @@ duckdb::SourceResultType PhysicalSiriusExecution::GetDataInternal(
     duckdb::unique_ptr<duckdb::LogicalOperator> fresh_plan;
     if (logical_plan_) {
       try {
-        // Use the dynamic-filter-aware copy so LogicalComparisonJoin::filter_pushdown and
-        // LogicalGet::dynamic_filters survive the serialize/deserialize round-trip — they are
-        // not in DuckDB's serialization schema and would otherwise be null on the fresh plan,
-        // making downstream Sirius wiring silently miss runtime-computed dynamic filters.
         fresh_plan = sirius::transparent::copy_logical_plan(*logical_plan_, context.client);
       } catch (duckdb::NotImplementedException&) {
         // Drop logical_plan_ — we know it can't be copied, so future executes

--- a/src/transparent/sirius_optimizer_extension.cpp
+++ b/src/transparent/sirius_optimizer_extension.cpp
@@ -16,16 +16,17 @@
 
 #include "transparent/sirius_optimizer_extension.hpp"
 
+#include "planner/duckdb_join_filter_candidate_adapter.hpp"
 #include "sirius_context.hpp"
 
 #include <duckdb/common/enums/optimizer_type.hpp>
 #include <duckdb/common/types/value.hpp>
 #include <duckdb/main/client_context.hpp>
 #include <duckdb/main/config.hpp>
-#include <duckdb/planner/operator/logical_comparison_join.hpp>
-#include <duckdb/planner/operator/logical_get.hpp>
-#include <duckdb/planner/table_filter.hpp>
 #include <log/logging.hpp>
+
+#include <exception>
+#include <utility>
 
 namespace sirius::transparent {
 
@@ -40,65 +41,11 @@ bool gpu_execution_enabled(const duckdb::ClientContext& context)
 
 }  // namespace
 
-namespace detail {
-
-duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> clone_filter_pushdown_info(
-  duckdb::JoinFilterPushdownInfo const& src)
-{
-  auto dst                   = duckdb::make_uniq<duckdb::JoinFilterPushdownInfo>();
-  dst->join_condition        = src.join_condition;
-  dst->build_side_has_filter = src.build_side_has_filter;
-  dst->probe_info.reserve(src.probe_info.size());
-  for (auto const& pi : src.probe_info) {
-    duckdb::JoinFilterPushdownFilter copy_pi;
-    copy_pi.dynamic_filters = pi.dynamic_filters;  // share — preserves route-key identity
-    copy_pi.columns         = pi.columns;
-    dst->probe_info.push_back(std::move(copy_pi));
-  }
-  // min_max_aggregates intentionally omitted: Sirius does not read them, and cloning
-  // unique_ptr<Expression> trees requires deep-copying every node type.
-  return dst;
-}
-
-void preserve_dynamic_filter_metadata(duckdb::LogicalOperator& original,
-                                      duckdb::LogicalOperator& copy,
-                                      preserved_counts& counts)
-{
-  // Parallel walk requires structural alignment. If Copy ever rearranges children, bail rather
-  // than risk attaching mismatched metadata (safe failure: copy stays in its post-Copy state).
-  if (original.type != copy.type || original.children.size() != copy.children.size()) { return; }
-
-  if (original.type == duckdb::LogicalOperatorType::LOGICAL_GET) {
-    auto& o = original.Cast<duckdb::LogicalGet>();
-    auto& c = copy.Cast<duckdb::LogicalGet>();
-    if (o.dynamic_filters) {
-      c.dynamic_filters = o.dynamic_filters;  // share the same DynamicTableFilterSet
-      ++counts.gets;
-    }
-  } else if (original.type == duckdb::LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
-    auto& o = original.Cast<duckdb::LogicalComparisonJoin>();
-    auto& c = copy.Cast<duckdb::LogicalComparisonJoin>();
-    if (o.filter_pushdown) {
-      c.filter_pushdown = clone_filter_pushdown_info(*o.filter_pushdown);
-      ++counts.joins;
-    }
-  }
-
-  for (std::size_t i = 0; i < original.children.size(); ++i) {
-    preserve_dynamic_filter_metadata(*original.children[i], *copy.children[i], counts);
-  }
-}
-
-}  // namespace detail
-
-duckdb::unique_ptr<duckdb::LogicalOperator> copy_logical_plan(duckdb::LogicalOperator& plan,
-                                                              duckdb::ClientContext& context,
-                                                              detail::preserved_counts* counts)
+duckdb::unique_ptr<duckdb::LogicalOperator> copy_logical_plan(duckdb::LogicalOperator const& plan,
+                                                              duckdb::ClientContext& context)
 {
   auto copy = plan.Copy(context);
-  detail::preserved_counts local_counts;
-  detail::preserved_counts& target_counts = counts ? *counts : local_counts;
-  detail::preserve_dynamic_filter_metadata(plan, *copy, target_counts);
+  planner::duckdb_join_filter_candidate_adapter::preserve_dynamic_filter_metadata(plan, *copy);
   return copy;
 }
 
@@ -153,15 +100,7 @@ void sirius_optimizer_hook(duckdb::OptimizerExtensionInput& input,
   // copy — that's the single source of truth for GPU support. If the plan contains
   // unsupported operators, create_plan() throws and we fall back to CPU.
   try {
-    detail::preserved_counts counts;
-    auto plan_copy = copy_logical_plan(*plan, context, &counts);
-    if (counts.joins > 0 || counts.gets > 0) {
-      SIRIUS_LOG_DEBUG(
-        "Transparent execution: preserved dynamic-filter metadata on {} join(s), {} get(s)",
-        counts.joins,
-        counts.gets);
-    }
-    ctx->set_captured_logical_plan(std::move(plan_copy));
+    ctx->set_captured_logical_plan(copy_logical_plan(*plan, context));
   } catch (duckdb::NotImplementedException&) {
     // Plan not serializable — skip GPU.
   } catch (std::exception& e) {

--- a/test/cpp/planner/test_duckdb_join_filter_candidate_adapter.cpp
+++ b/test/cpp/planner/test_duckdb_join_filter_candidate_adapter.cpp
@@ -152,29 +152,33 @@ TEST_CASE("extract classifies statistics_only when probe_info is empty",
 
 TEST_CASE("extract rejects anomalous targetless metadata", "[dynamic_filter][adapter]")
 {
-  SECTION("empty condition ordinals") {
+  SECTION("empty condition ordinals")
+  {
     auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
     join->filter_pushdown = make_pushdown_info({}, false);
 
     require_malformed_carries_only_kind(extract(*join));
   }
 
-  SECTION("out-of-range condition ordinal") {
+  SECTION("out-of-range condition ordinal")
+  {
     auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
     join->filter_pushdown = make_pushdown_info({1}, false);
 
     require_malformed_carries_only_kind(extract(*join));
   }
 
-  SECTION("duplicate condition ordinals") {
-    auto join = make_join(
-      {duckdb::ExpressionType::COMPARE_EQUAL, duckdb::ExpressionType::COMPARE_EQUAL});
+  SECTION("duplicate condition ordinals")
+  {
+    auto join =
+      make_join({duckdb::ExpressionType::COMPARE_EQUAL, duckdb::ExpressionType::COMPARE_EQUAL});
     join->filter_pushdown = make_pushdown_info({0, 0}, false);
 
     require_malformed_carries_only_kind(extract(*join));
   }
 
-  SECTION("build-side filter hint without a probe target") {
+  SECTION("build-side filter hint without a probe target")
+  {
     auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
     join->filter_pushdown = make_pushdown_info({0}, true);
 

--- a/test/cpp/planner/test_duckdb_join_filter_candidate_adapter.cpp
+++ b/test/cpp/planner/test_duckdb_join_filter_candidate_adapter.cpp
@@ -1,0 +1,550 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_duckdb_join_filter_candidate_adapter.cpp
+ * @brief Contract tests for the version-pinned adapter's extraction/classification surface
+ *        (sirius::planner::duckdb_join_filter_candidate_adapter::extract / scan_channel_identity)
+ *        and the join-to-GET channel-identity topology the preservation walk must keep intact.
+ *
+ * These are the pin-bump sentinels. Every `malformed` case below is unreachable under the pinned
+ * DuckDB: it exists to fail loudly if a future submodule bump breaks a structural invariant that
+ * the positional key-to-column pairing depends on.
+ */
+
+#include "planner/duckdb_join_filter_candidate_adapter.hpp"
+
+#include <catch.hpp>
+#include <duckdb/common/typedefs.hpp>
+#include <duckdb/execution/operator/join/join_filter_pushdown.hpp>
+#include <duckdb/function/table_function.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <duckdb/planner/operator/logical_comparison_join.hpp>
+#include <duckdb/planner/operator/logical_get.hpp>
+#include <duckdb/planner/table_filter.hpp>
+
+#include <cstddef>
+#include <initializer_list>
+#include <utility>
+#include <vector>
+
+using sirius::planner::duckdb_candidate_kind;
+using sirius::planner::duckdb_join_filter_candidate;
+using sirius::planner::duckdb_join_filter_candidate_adapter::extract;
+using sirius::planner::duckdb_join_filter_candidate_adapter::preserve_dynamic_filter_metadata;
+using sirius::planner::duckdb_join_filter_candidate_adapter::scan_channel_identity;
+
+namespace {
+
+duckdb::JoinCondition make_condition(duckdb::ExpressionType comparison)
+{
+  duckdb::JoinCondition cond;
+  cond.left =
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0ULL);
+  cond.right =
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0ULL);
+  cond.comparison = comparison;
+  return cond;
+}
+
+duckdb::unique_ptr<duckdb::LogicalComparisonJoin> make_join(
+  std::initializer_list<duckdb::ExpressionType> comparisons)
+{
+  auto join = duckdb::make_uniq<duckdb::LogicalComparisonJoin>(duckdb::JoinType::INNER);
+  for (auto comparison : comparisons) {
+    join->conditions.push_back(make_condition(comparison));
+  }
+  return join;
+}
+
+/// One probe target: @p column_count columns, INTEGER storage, channel @p dyn (may be null).
+duckdb::JoinFilterPushdownFilter make_target(duckdb::shared_ptr<duckdb::DynamicTableFilterSet> dyn,
+                                             duckdb::idx_t column_count)
+{
+  duckdb::JoinFilterPushdownFilter pi;
+  pi.dynamic_filters = std::move(dyn);
+  for (duckdb::idx_t i = 0; i < column_count; ++i) {
+    duckdb::JoinFilterPushdownColumn col;
+    col.probe_column_index = duckdb::ColumnBinding{0, i};
+    col.storage_type       = duckdb::LogicalType::INTEGER;
+    pi.columns.push_back(col);
+  }
+  return pi;
+}
+
+duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> make_pushdown_info(
+  duckdb::vector<duckdb::idx_t> join_condition, bool build_side_has_filter = true)
+{
+  auto info                   = duckdb::make_uniq<duckdb::JoinFilterPushdownInfo>();
+  info->join_condition        = std::move(join_condition);
+  info->build_side_has_filter = build_side_has_filter;
+  return info;
+}
+
+/// A minimal constructible LogicalGet (the default ctor is private; TableFunction() is enough for
+/// a structural test — the walk and the adapter never invoke the function).
+duckdb::unique_ptr<duckdb::LogicalGet> make_get()
+{
+  return duckdb::make_uniq<duckdb::LogicalGet>(
+    /*table_index=*/0,
+    duckdb::TableFunction(),
+    /*bind_data=*/nullptr,
+    duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER},
+    duckdb::vector<duckdb::string>{"a"});
+}
+
+/// The malformed contract: only `kind` is meaningful; every other field is default/empty.
+void require_malformed_carries_only_kind(duckdb_join_filter_candidate const& c)
+{
+  REQUIRE(c.kind() == duckdb_candidate_kind::malformed);
+  REQUIRE_FALSE(c.build_subtree_has_filter_hint());
+  REQUIRE(c.condition_indexes().empty());
+  REQUIRE(c.condition_comparisons().empty());
+  REQUIRE(c.targets().empty());
+}
+
+}  // namespace
+
+//===-----------------------------------------------------------------------------------------===//
+// Classification
+//===-----------------------------------------------------------------------------------------===//
+
+TEST_CASE("extract classifies absent when the join has no pushdown metadata",
+          "[dynamic_filter][adapter]")
+{
+  auto join      = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
+  auto candidate = extract(*join);
+
+  REQUIRE(candidate.kind() == duckdb_candidate_kind::absent);
+  REQUIRE_FALSE(candidate.build_subtree_has_filter_hint());
+  REQUIRE(candidate.condition_indexes().empty());
+  REQUIRE(candidate.condition_comparisons().empty());
+  REQUIRE(candidate.targets().empty());
+}
+
+TEST_CASE("extract classifies statistics_only when probe_info is empty",
+          "[dynamic_filter][adapter]")
+{
+  auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
+  join->filter_pushdown = make_pushdown_info({0}, false);
+
+  auto candidate = extract(*join);
+
+  REQUIRE(candidate.kind() == duckdb_candidate_kind::statistics_only);
+  REQUIRE_FALSE(candidate.build_subtree_has_filter_hint());
+  REQUIRE(candidate.condition_indexes().empty());
+  REQUIRE(candidate.targets().empty());
+  REQUIRE(candidate.condition_comparisons().empty());
+}
+
+TEST_CASE("extract rejects anomalous targetless metadata", "[dynamic_filter][adapter]")
+{
+  SECTION("empty condition ordinals") {
+    auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
+    join->filter_pushdown = make_pushdown_info({}, false);
+
+    require_malformed_carries_only_kind(extract(*join));
+  }
+
+  SECTION("out-of-range condition ordinal") {
+    auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
+    join->filter_pushdown = make_pushdown_info({1}, false);
+
+    require_malformed_carries_only_kind(extract(*join));
+  }
+
+  SECTION("duplicate condition ordinals") {
+    auto join = make_join(
+      {duckdb::ExpressionType::COMPARE_EQUAL, duckdb::ExpressionType::COMPARE_EQUAL});
+    join->filter_pushdown = make_pushdown_info({0, 0}, false);
+
+    require_malformed_carries_only_kind(extract(*join));
+  }
+
+  SECTION("build-side filter hint without a probe target") {
+    auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
+    join->filter_pushdown = make_pushdown_info({0}, true);
+
+    require_malformed_carries_only_kind(extract(*join));
+  }
+}
+
+TEST_CASE("extract admits a candidate and snapshots ordinals, comparisons, and target columns",
+          "[dynamic_filter][adapter]")
+{
+  auto dyn = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto join =
+    make_join({duckdb::ExpressionType::COMPARE_EQUAL, duckdb::ExpressionType::COMPARE_EQUAL});
+  join->filter_pushdown = make_pushdown_info({0, 1});
+  join->filter_pushdown->probe_info.push_back(make_target(dyn, 2));
+
+  auto candidate = extract(*join);
+
+  REQUIRE(candidate.kind() == duckdb_candidate_kind::admitted);
+  REQUIRE(candidate.build_subtree_has_filter_hint());
+  REQUIRE(candidate.condition_indexes() == std::vector<std::size_t>{0, 1});
+  REQUIRE(candidate.condition_comparisons() ==
+          std::vector<duckdb::ExpressionType>{duckdb::ExpressionType::COMPARE_EQUAL,
+                                              duckdb::ExpressionType::COMPARE_EQUAL});
+  REQUIRE(candidate.targets().size() == 1);
+  REQUIRE(candidate.targets()[0].columns().size() == 2);
+  REQUIRE(candidate.targets()[0].columns()[0].column_index == 0);
+  REQUIRE(candidate.targets()[0].columns()[1].column_index == 1);
+  REQUIRE(candidate.targets()[0].columns()[0].storage_type == duckdb::LogicalType::INTEGER);
+}
+
+TEST_CASE("extract preserves the filter-ordinal to condition-index mapping",
+          "[dynamic_filter][adapter]")
+{
+  auto dyn  = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto join = make_join({duckdb::ExpressionType::COMPARE_EQUAL,
+                         duckdb::ExpressionType::COMPARE_GREATERTHAN,
+                         duckdb::ExpressionType::COMPARE_EQUAL});
+  // DuckDB selected conditions 2 and 0, in that order: filter ordinal j is the POSITION here, and
+  // the value at that position is the condition index it names. The two must never be swapped.
+  join->filter_pushdown = make_pushdown_info({2, 0});
+  join->filter_pushdown->probe_info.push_back(make_target(dyn, 2));
+
+  auto candidate = extract(*join);
+
+  REQUIRE(candidate.kind() == duckdb_candidate_kind::admitted);
+  REQUIRE(candidate.condition_indexes() == std::vector<std::size_t>{2, 0});
+  // Comparisons are looked up THROUGH the condition index, not by ordinal position.
+  REQUIRE(candidate.condition_comparisons() ==
+          std::vector<duckdb::ExpressionType>{duckdb::ExpressionType::COMPARE_EQUAL,
+                                              duckdb::ExpressionType::COMPARE_EQUAL});
+  // Target columns stay in filter-ordinal space, parallel to condition_indexes.
+  REQUIRE(candidate.targets()[0].columns().size() == 2);
+  REQUIRE(candidate.targets()[0].columns()[0].column_index == 0);
+  REQUIRE(candidate.targets()[0].columns()[1].column_index == 1);
+}
+
+TEST_CASE("extract keeps range comparisons at full arity", "[dynamic_filter][adapter]")
+{
+  auto dyn = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto join =
+    make_join({duckdb::ExpressionType::COMPARE_EQUAL, duckdb::ExpressionType::COMPARE_GREATERTHAN});
+  join->filter_pushdown = make_pushdown_info({0, 1});
+  join->filter_pushdown->probe_info.push_back(make_target(dyn, 2));
+
+  auto candidate = extract(*join);
+
+  // Range ordinals are valid candidates (narrowed per key later, C1a-2), never malformed.
+  REQUIRE(candidate.kind() == duckdb_candidate_kind::admitted);
+  REQUIRE(candidate.condition_indexes() == std::vector<std::size_t>{0, 1});
+  REQUIRE(candidate.condition_comparisons()[1] == duckdb::ExpressionType::COMPARE_GREATERTHAN);
+}
+
+TEST_CASE("extract shares one key set across every target", "[dynamic_filter][adapter]")
+{
+  auto dyn_a = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto dyn_b = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto join =
+    make_join({duckdb::ExpressionType::COMPARE_EQUAL, duckdb::ExpressionType::COMPARE_EQUAL});
+  join->filter_pushdown = make_pushdown_info({0, 1});
+  // Two scans (e.g. a UNION-ed probe side): the key set is a property of the JOIN, and each target
+  // records only where those same keys land in its own scan.
+  join->filter_pushdown->probe_info.push_back(make_target(dyn_a, 2));
+  join->filter_pushdown->probe_info.push_back(make_target(dyn_b, 2));
+
+  auto candidate = extract(*join);
+
+  REQUIRE(candidate.kind() == duckdb_candidate_kind::admitted);
+  REQUIRE(candidate.condition_indexes().size() == 2);  // one shared key set, not one per target
+  REQUIRE(candidate.targets().size() == 2);
+  REQUIRE(candidate.targets()[0].channel_identity().get() == dyn_a.get());
+  REQUIRE(candidate.targets()[1].channel_identity().get() == dyn_b.get());
+  // Every target carries the full key arity.
+  REQUIRE(candidate.targets()[0].columns().size() == candidate.condition_indexes().size());
+  REQUIRE(candidate.targets()[1].columns().size() == candidate.condition_indexes().size());
+}
+
+//===-----------------------------------------------------------------------------------------===//
+// Fail-closed fences (malformed cases are unreachable at the pin) and null-channel handling
+//===-----------------------------------------------------------------------------------------===//
+
+TEST_CASE("extract fails closed on an out-of-range condition index", "[dynamic_filter][adapter]")
+{
+  auto dyn              = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
+  join->filter_pushdown = make_pushdown_info({5});  // join has 1 condition
+  join->filter_pushdown->probe_info.push_back(make_target(dyn, 1));
+
+  require_malformed_carries_only_kind(extract(*join));
+}
+
+TEST_CASE("extract fails closed on a duplicate condition index", "[dynamic_filter][adapter]")
+{
+  auto dyn = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto join =
+    make_join({duckdb::ExpressionType::COMPARE_EQUAL, duckdb::ExpressionType::COMPARE_EQUAL});
+  join->filter_pushdown = make_pushdown_info({0, 0});
+  join->filter_pushdown->probe_info.push_back(make_target(dyn, 2));
+
+  require_malformed_carries_only_kind(extract(*join));
+}
+
+TEST_CASE("extract fails closed on recorded targets with no condition ordinals",
+          "[dynamic_filter][adapter]")
+{
+  auto dyn              = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
+  join->filter_pushdown = make_pushdown_info({});                    // empty join_condition…
+  join->filter_pushdown->probe_info.push_back(make_target(dyn, 0));  // …with a recorded target
+
+  require_malformed_carries_only_kind(extract(*join));
+}
+
+TEST_CASE("extract fails closed on target column-arity mismatch", "[dynamic_filter][adapter]")
+{
+  auto dyn = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto join =
+    make_join({duckdb::ExpressionType::COMPARE_EQUAL, duckdb::ExpressionType::COMPARE_EQUAL});
+  join->filter_pushdown = make_pushdown_info({0, 1});
+  join->filter_pushdown->probe_info.push_back(make_target(dyn, 1));  // 1 column, 2 ordinals
+
+  require_malformed_carries_only_kind(extract(*join));
+}
+
+TEST_CASE("extract drops a null-channel target and keeps its live sibling",
+          "[dynamic_filter][adapter]")
+{
+  auto dyn              = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
+  join->filter_pushdown = make_pushdown_info({0});
+  join->filter_pushdown->probe_info.push_back(make_target(nullptr, 1));  // null channel: dropped
+  join->filter_pushdown->probe_info.push_back(make_target(dyn, 1));      // live sibling: kept
+
+  auto candidate = extract(*join);
+
+  REQUIRE(candidate.kind() == duckdb_candidate_kind::admitted);
+  REQUIRE(candidate.targets().size() == 1);
+  REQUIRE(candidate.targets()[0].channel_identity().get() == dyn.get());
+}
+
+TEST_CASE("extract fails closed when every recorded target has a null channel",
+          "[dynamic_filter][adapter]")
+{
+  auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
+  join->filter_pushdown = make_pushdown_info({0});
+  join->filter_pushdown->probe_info.push_back(make_target(nullptr, 1));
+  join->filter_pushdown->probe_info.push_back(make_target(nullptr, 1));
+
+  // NOT statistics_only: that kind is reserved for DuckDB's deliberate zero-target state (its
+  // telemetry count sizes the Track E opportunity); an anomaly must not inflate it.
+  require_malformed_carries_only_kind(extract(*join));
+}
+
+TEST_CASE("extract checks target arity before the null-channel drop", "[dynamic_filter][adapter]")
+{
+  auto dyn              = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
+  join->filter_pushdown = make_pushdown_info({0});
+  join->filter_pushdown->probe_info.push_back(make_target(nullptr, 2));  // null AND corrupt arity
+  join->filter_pushdown->probe_info.push_back(make_target(dyn, 1));      // live sibling
+
+  // Arity corruption impeaches the candidate even on a null-channel target: the whole candidate
+  // fails closed rather than the corrupt entry being silently dropped.
+  require_malformed_carries_only_kind(extract(*join));
+}
+
+//===-----------------------------------------------------------------------------------------===//
+// Channel identity: ownership and the join-to-GET pairing
+//===-----------------------------------------------------------------------------------------===//
+
+TEST_CASE("extracted candidate co-owns the channel identity", "[dynamic_filter][adapter]")
+{
+  auto dyn              = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
+  join->filter_pushdown = make_pushdown_info({0});
+  join->filter_pushdown->probe_info.push_back(make_target(dyn, 1));
+
+  auto* raw      = dyn.get();
+  auto candidate = extract(*join);
+  join.reset();  // destroy the plan the candidate was extracted from
+
+  REQUIRE(candidate.targets()[0].channel_identity().get() == raw);
+  // Exactly two owners remain: the candidate and `dyn`.
+  REQUIRE(candidate.targets()[0].channel_identity().use_count() == 2);
+
+  // The candidate's shared ownership keeps the identity alive on its own: release the last other
+  // holder and the candidate remains the sole owner of a live object.
+  dyn.reset();
+  REQUIRE(candidate.targets()[0].channel_identity().use_count() == 1);
+}
+
+TEST_CASE("adapter values preserve their invariants after assignment and candidate moves",
+          "[dynamic_filter][adapter]")
+{
+  auto dyn              = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto join             = make_join({duckdb::ExpressionType::COMPARE_EQUAL});
+  join->filter_pushdown = make_pushdown_info({0});
+  join->filter_pushdown->probe_info.push_back(make_target(dyn, 1));
+
+  auto candidate       = extract(*join);
+  auto assigned_target = candidate.targets().front();
+  assigned_target      = candidate.targets().front();
+  REQUIRE(assigned_target.channel_identity().get() == dyn.get());
+  REQUIRE_FALSE(assigned_target.columns().empty());
+
+  auto copy_assigned_candidate = extract(*join);
+  copy_assigned_candidate      = candidate;
+  REQUIRE(copy_assigned_candidate.kind() == duckdb_candidate_kind::admitted);
+  REQUIRE_FALSE(copy_assigned_candidate.targets().empty());
+
+  auto moved_candidate = std::move(candidate);
+  REQUIRE(moved_candidate.kind() == duckdb_candidate_kind::admitted);
+  REQUIRE_FALSE(moved_candidate.targets().empty());
+  REQUIRE(candidate.kind() == duckdb_candidate_kind::absent);
+  REQUIRE_FALSE(candidate.build_subtree_has_filter_hint());
+  REQUIRE(candidate.condition_indexes().empty());
+  REQUIRE(candidate.condition_comparisons().empty());
+  REQUIRE(candidate.targets().empty());
+
+  auto move_assigned_candidate = extract(*join);
+  move_assigned_candidate      = std::move(moved_candidate);
+  REQUIRE(move_assigned_candidate.kind() == duckdb_candidate_kind::admitted);
+  REQUIRE_FALSE(move_assigned_candidate.targets().empty());
+  REQUIRE(moved_candidate.kind() == duckdb_candidate_kind::absent);
+  REQUIRE_FALSE(moved_candidate.build_subtree_has_filter_hint());
+  REQUIRE(moved_candidate.condition_indexes().empty());
+  REQUIRE(moved_candidate.condition_comparisons().empty());
+  REQUIRE(moved_candidate.targets().empty());
+}
+
+TEST_CASE("scan_channel_identity returns the gets channel or null", "[dynamic_filter][adapter]")
+{
+  auto get = make_get();
+  REQUIRE(scan_channel_identity(*get) == nullptr);
+
+  auto dyn             = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  get->dynamic_filters = dyn;
+  REQUIRE(scan_channel_identity(*get).get() == dyn.get());
+}
+
+TEST_CASE("preservation keeps a producing join and its GET paired to one channel",
+          "[dynamic_filter][adapter]")
+{
+  auto dyn = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+
+  // Original: join → [get(with channel), get(plain)]; the join's target names the same channel.
+  duckdb::LogicalComparisonJoin original(duckdb::JoinType::INNER);
+  {
+    auto probe_get             = make_get();
+    probe_get->dynamic_filters = dyn;
+    original.children.push_back(std::move(probe_get));
+    original.children.push_back(make_get());
+    original.conditions.push_back(make_condition(duckdb::ExpressionType::COMPARE_EQUAL));
+    original.filter_pushdown = make_pushdown_info({0});
+    original.filter_pushdown->probe_info.push_back(make_target(dyn, 1));
+  }
+
+  // Structurally aligned copy, metadata stripped (the post-Copy state).
+  duckdb::LogicalComparisonJoin copy(duckdb::JoinType::INNER);
+  copy.children.push_back(make_get());
+  copy.children.push_back(make_get());
+  copy.conditions.push_back(make_condition(duckdb::ExpressionType::COMPARE_EQUAL));
+
+  preserve_dynamic_filter_metadata(original, copy);
+
+  // The pairing invariant: the copied join's target and the copied GET reference the SAME set —
+  // and extraction on the copy surfaces that same identity.
+  auto& copy_get = copy.children[0]->Cast<duckdb::LogicalGet>();
+  REQUIRE(copy.filter_pushdown);
+  REQUIRE(copy.filter_pushdown->probe_info[0].dynamic_filters.get() == dyn.get());
+  REQUIRE(copy_get.dynamic_filters.get() == dyn.get());
+  auto reextracted = extract(copy);
+  REQUIRE(reextracted.kind() == duckdb_candidate_kind::admitted);
+  REQUIRE(reextracted.targets()[0].channel_identity().get() ==
+          scan_channel_identity(copy_get).get());
+}
+
+TEST_CASE("preservation is all-or-nothing on a descendant structural mismatch",
+          "[dynamic_filter][adapter]")
+{
+  auto dyn = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+
+  // Original: join(pushdown) → [get(with channel), get].
+  duckdb::LogicalComparisonJoin original(duckdb::JoinType::INNER);
+  {
+    auto probe_get             = make_get();
+    probe_get->dynamic_filters = dyn;
+    original.children.push_back(std::move(probe_get));
+    original.children.push_back(make_get());
+    original.conditions.push_back(make_condition(duckdb::ExpressionType::COMPARE_EQUAL));
+    original.filter_pushdown = make_pushdown_info({0});
+    original.filter_pushdown->probe_info.push_back(make_target(dyn, 1));
+  }
+
+  // Copy: aligned AT the join, but child 0 is a join instead of a get — descendant mismatch.
+  duckdb::LogicalComparisonJoin copy(duckdb::JoinType::INNER);
+  copy.children.push_back(
+    duckdb::make_uniq<duckdb::LogicalComparisonJoin>(duckdb::JoinType::INNER));
+  copy.children.push_back(make_get());
+  copy.conditions.push_back(make_condition(duckdb::ExpressionType::COMPARE_EQUAL));
+
+  preserve_dynamic_filter_metadata(original, copy);
+
+  // The locally-aligned ancestor must receive NOTHING: attaching its metadata while the scan
+  // below cannot be restored would half-build the join-to-GET pairing.
+  REQUIRE_FALSE(copy.filter_pushdown);
+}
+
+TEST_CASE("preservation keeps two producing joins sharing one GET channel",
+          "[dynamic_filter][adapter]")
+{
+  auto dyn = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+
+  // Original: P2 → [P1 → [get(with channel), get], get]; both joins target the same channel.
+  duckdb::LogicalComparisonJoin original_p2(duckdb::JoinType::INNER);
+  {
+    auto p1        = duckdb::make_uniq<duckdb::LogicalComparisonJoin>(duckdb::JoinType::INNER);
+    auto probe_get = make_get();
+    probe_get->dynamic_filters = dyn;
+    p1->children.push_back(std::move(probe_get));
+    p1->children.push_back(make_get());
+    p1->conditions.push_back(make_condition(duckdb::ExpressionType::COMPARE_EQUAL));
+    p1->filter_pushdown = make_pushdown_info({0});
+    p1->filter_pushdown->probe_info.push_back(make_target(dyn, 1));
+
+    original_p2.children.push_back(std::move(p1));
+    original_p2.children.push_back(make_get());
+    original_p2.conditions.push_back(make_condition(duckdb::ExpressionType::COMPARE_EQUAL));
+    original_p2.filter_pushdown = make_pushdown_info({0});
+    original_p2.filter_pushdown->probe_info.push_back(make_target(dyn, 1));
+  }
+
+  // Structurally aligned copy.
+  duckdb::LogicalComparisonJoin copy_p2(duckdb::JoinType::INNER);
+  {
+    auto p1 = duckdb::make_uniq<duckdb::LogicalComparisonJoin>(duckdb::JoinType::INNER);
+    p1->children.push_back(make_get());
+    p1->children.push_back(make_get());
+    copy_p2.children.push_back(std::move(p1));
+    copy_p2.children.push_back(make_get());
+  }
+
+  preserve_dynamic_filter_metadata(original_p2, copy_p2);
+
+  // N-producer/one-consumer: both copied joins and the copied GET share ONE set.
+  auto& copy_p1  = copy_p2.children[0]->Cast<duckdb::LogicalComparisonJoin>();
+  auto& copy_get = copy_p1.children[0]->Cast<duckdb::LogicalGet>();
+  REQUIRE(copy_p2.filter_pushdown);
+  REQUIRE(copy_p1.filter_pushdown);
+  REQUIRE(copy_p2.filter_pushdown->probe_info[0].dynamic_filters.get() == dyn.get());
+  REQUIRE(copy_p1.filter_pushdown->probe_info[0].dynamic_filters.get() == dyn.get());
+  REQUIRE(copy_get.dynamic_filters.get() == dyn.get());
+}

--- a/test/cpp/transparent/test_preserve_dynamic_filter_metadata.cpp
+++ b/test/cpp/transparent/test_preserve_dynamic_filter_metadata.cpp
@@ -16,9 +16,10 @@
 
 /**
  * @file test_preserve_dynamic_filter_metadata.cpp
- * @brief Tests for the transparent-optimizer post-Copy fixup helpers
- *        (sirius::transparent::detail::clone_filter_pushdown_info,
- *         sirius::transparent::detail::preserve_dynamic_filter_metadata).
+ * @brief Tests for the version-pinned adapter's post-Copy fixup helpers
+ *        (sirius::planner::duckdb_join_filter_candidate_adapter::preserve_dynamic_filter_metadata
+ *         and its detail::clone_sirius_filter_pushdown_info helper), which the transparent
+ *         execution path's copy_logical_plan drives.
  *
  * LogicalOperator::Copy round-trips through serialize/deserialize. LogicalComparisonJoin's
  * filter_pushdown and LogicalGet's dynamic_filters are not in the serialization schemas, so the
@@ -27,20 +28,52 @@
  * identity that downstream wiring (Phase 1.1 of dynamic filter pushdown) relies on.
  */
 
+#include "planner/duckdb_join_filter_candidate_adapter.hpp"
 #include "transparent/sirius_optimizer_extension.hpp"
 
 #include <catch.hpp>
+#include <duckdb.hpp>
 #include <duckdb/execution/operator/join/join_filter_pushdown.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
 #include <duckdb/planner/operator/logical_comparison_join.hpp>
+#include <duckdb/planner/operator/logical_get.hpp>
 #include <duckdb/planner/table_filter.hpp>
 
+#include <cstddef>
+#include <string>
 #include <utility>
+#include <vector>
 
-using sirius::transparent::detail::clone_filter_pushdown_info;
-using sirius::transparent::detail::preserve_dynamic_filter_metadata;
-using sirius::transparent::detail::preserved_counts;
+using sirius::planner::duckdb_join_filter_candidate_adapter::preserve_dynamic_filter_metadata;
+using sirius::planner::duckdb_join_filter_candidate_adapter::detail::
+  clone_sirius_filter_pushdown_info;
 
 namespace {
+
+class transaction_rollback_guard final {
+ public:
+  explicit transaction_rollback_guard(duckdb::Connection& connection) : _connection(connection)
+  {
+    _connection.BeginTransaction();
+  }
+
+  ~transaction_rollback_guard() noexcept
+  {
+    try {
+      _connection.Rollback();
+    } catch (...) {
+      // Cleanup must not mask the original Catch failure; Connection destruction is the fallback.
+    }
+  }
+
+  transaction_rollback_guard(transaction_rollback_guard const&)            = delete;
+  transaction_rollback_guard& operator=(transaction_rollback_guard const&) = delete;
+  transaction_rollback_guard(transaction_rollback_guard&&)                 = delete;
+  transaction_rollback_guard& operator=(transaction_rollback_guard&&)      = delete;
+
+ private:
+  duckdb::Connection& _connection;
+};
 
 /// Construct a representative JoinFilterPushdownInfo: two join-condition indices, one probe
 /// target with two columns, and a caller-provided DynamicTableFilterSet (so the test can assert
@@ -67,25 +100,72 @@ duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> make_pushdown_info(
   return info;
 }
 
+void require_query_ok(duckdb::Connection& connection, std::string const& sql)
+{
+  auto result = connection.Query(sql);
+  REQUIRE(result);
+  INFO((result->HasError() ? result->GetError() : ""));
+  REQUIRE_FALSE(result->HasError());
+}
+
+duckdb::LogicalComparisonJoin const* find_dynamic_filter_join(duckdb::LogicalOperator const& op)
+{
+  if (op.type == duckdb::LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+    auto const& join = op.Cast<duckdb::LogicalComparisonJoin>();
+    if (join.filter_pushdown && !join.filter_pushdown->probe_info.empty()) { return &join; }
+  }
+  for (auto const& child : op.children) {
+    if (auto const* join = find_dynamic_filter_join(*child)) { return join; }
+  }
+  return nullptr;
+}
+
+duckdb::LogicalGet const* find_get_with_channel(duckdb::LogicalOperator const& op,
+                                                duckdb::DynamicTableFilterSet const* channel)
+{
+  if (op.type == duckdb::LogicalOperatorType::LOGICAL_GET) {
+    auto const& get = op.Cast<duckdb::LogicalGet>();
+    if (get.dynamic_filters.get() == channel) { return &get; }
+  }
+  for (auto const& child : op.children) {
+    if (auto const* get = find_get_with_channel(*child, channel)) { return get; }
+  }
+  return nullptr;
+}
 }  // namespace
 
-TEST_CASE("clone_filter_pushdown_info copies scalar fields", "[transparent][preserve]")
+TEST_CASE("clone_sirius_filter_pushdown_info copies scalar fields", "[transparent][preserve]")
 {
   auto dyn = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
   auto src = make_pushdown_info(dyn);
-  auto dst = clone_filter_pushdown_info(*src);
+  auto dst = clone_sirius_filter_pushdown_info(*src);
 
   REQUIRE(dst->join_condition == src->join_condition);
   REQUIRE(dst->build_side_has_filter == src->build_side_has_filter);
   REQUIRE(dst->probe_info.size() == src->probe_info.size());
 }
 
-TEST_CASE("clone_filter_pushdown_info shares DynamicTableFilterSet pointer identity",
+TEST_CASE("clone_sirius_filter_pushdown_info intentionally omits DuckDB min-max aggregates",
           "[transparent][preserve]")
 {
   auto dyn = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
   auto src = make_pushdown_info(dyn);
-  auto dst = clone_filter_pushdown_info(*src);
+  // The expression is an opaque non-null sentinel; this test covers the container-level policy.
+  src->min_max_aggregates.push_back(
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0ULL));
+
+  auto dst = clone_sirius_filter_pushdown_info(*src);
+
+  REQUIRE(src->min_max_aggregates.size() == 1);
+  REQUIRE(dst->min_max_aggregates.empty());
+}
+
+TEST_CASE("clone_sirius_filter_pushdown_info shares DynamicTableFilterSet pointer identity",
+          "[transparent][preserve]")
+{
+  auto dyn = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
+  auto src = make_pushdown_info(dyn);
+  auto dst = clone_sirius_filter_pushdown_info(*src);
 
   // Critical: the DynamicTableFilterSet pointer is the route key paired between the join's
   // filter_pushdown and the consumer scan's dynamic_filters. Deep-copying would break that
@@ -94,12 +174,12 @@ TEST_CASE("clone_filter_pushdown_info shares DynamicTableFilterSet pointer ident
   REQUIRE(dst->probe_info[0].dynamic_filters.get() == src->probe_info[0].dynamic_filters.get());
 }
 
-TEST_CASE("clone_filter_pushdown_info copies column bindings and storage types",
+TEST_CASE("clone_sirius_filter_pushdown_info copies column bindings and storage types",
           "[transparent][preserve]")
 {
   auto dyn = duckdb::make_shared_ptr<duckdb::DynamicTableFilterSet>();
   auto src = make_pushdown_info(dyn);
-  auto dst = clone_filter_pushdown_info(*src);
+  auto dst = clone_sirius_filter_pushdown_info(*src);
 
   auto const& src_cols = src->probe_info[0].columns;
   auto const& dst_cols = dst->probe_info[0].columns;
@@ -116,11 +196,8 @@ TEST_CASE("preserve_dynamic_filter_metadata is a no-op when original has no meta
   duckdb::LogicalComparisonJoin original(duckdb::JoinType::INNER);
   duckdb::LogicalComparisonJoin copy(duckdb::JoinType::INNER);
 
-  preserved_counts counts;
-  preserve_dynamic_filter_metadata(original, copy, counts);
+  preserve_dynamic_filter_metadata(original, copy);
 
-  REQUIRE(counts.joins == 0);
-  REQUIRE(counts.gets == 0);
   REQUIRE_FALSE(copy.filter_pushdown);
 }
 
@@ -133,10 +210,8 @@ TEST_CASE("preserve_dynamic_filter_metadata copies filter_pushdown onto the copy
 
   duckdb::LogicalComparisonJoin copy(duckdb::JoinType::INNER);
 
-  preserved_counts counts;
-  preserve_dynamic_filter_metadata(original, copy, counts);
+  preserve_dynamic_filter_metadata(original, copy);
 
-  REQUIRE(counts.joins == 1);
   REQUIRE(copy.filter_pushdown);
   REQUIRE(copy.filter_pushdown->probe_info[0].dynamic_filters.get() == dyn.get());
   // Original is untouched — DuckDB's CPU fallback path still consumes it.
@@ -162,10 +237,8 @@ TEST_CASE("preserve_dynamic_filter_metadata recurses into children", "[transpare
   copy_outer.children.push_back(
     duckdb::make_uniq<duckdb::LogicalComparisonJoin>(duckdb::JoinType::INNER));
 
-  preserved_counts counts;
-  preserve_dynamic_filter_metadata(original_outer, copy_outer, counts);
+  preserve_dynamic_filter_metadata(original_outer, copy_outer);
 
-  REQUIRE(counts.joins == 1);
   REQUIRE(copy_outer.children[0]->Cast<duckdb::LogicalComparisonJoin>().filter_pushdown);
   REQUIRE_FALSE(copy_outer.children[1]->Cast<duckdb::LogicalComparisonJoin>().filter_pushdown);
   REQUIRE_FALSE(copy_outer.filter_pushdown);
@@ -181,11 +254,63 @@ TEST_CASE("preserve_dynamic_filter_metadata bails on top-level structural mismat
     duckdb::make_uniq<duckdb::LogicalComparisonJoin>(duckdb::JoinType::INNER));
 
   duckdb::LogicalComparisonJoin copy(duckdb::JoinType::INNER);
-  // No children — child-count mismatch triggers the defensive bail.
+  // No children — child-count mismatch fails the whole-tree preflight, so nothing is preserved.
 
-  preserved_counts counts;
-  preserve_dynamic_filter_metadata(original, copy, counts);
+  preserve_dynamic_filter_metadata(original, copy);
 
-  REQUIRE(counts.joins == 0);
   REQUIRE_FALSE(copy.filter_pushdown);
+}
+
+TEST_CASE("copy_logical_plan preserves real DuckDB join-to-GET channel identity",
+          "[transparent][preserve]")
+{
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection connection(db);
+
+  // LogicalOperator::Copy deserializes table-scan bindings through the catalog, so use real
+  // catalog-backed tables and keep their in-memory database/context alive through the copy.
+  require_query_ok(connection,
+                   "CREATE TABLE probe AS "
+                   "SELECT i::INTEGER AS k, i::BIGINT AS payload FROM range(32) AS r(i)");
+  require_query_ok(connection,
+                   "CREATE TABLE build AS SELECT i::INTEGER AS k FROM range(8) AS r(i)");
+
+  // Deserialization resolves catalog entries through ActiveTransaction(), matching the optimizer
+  // hook's production prepare-time context. The guard rolls back even if a REQUIRE aborts the test.
+  transaction_rollback_guard transaction{connection};
+
+  auto original =
+    connection.ExtractPlan("SELECT p.payload FROM probe AS p JOIN build AS b ON p.k = b.k");
+  REQUIRE(original);
+
+  auto const* original_join = find_dynamic_filter_join(*original);
+  REQUIRE(original_join != nullptr);
+  REQUIRE(original_join->filter_pushdown);
+  REQUIRE(original_join->filter_pushdown->probe_info.size() == 1);
+
+  auto const original_channel = original_join->filter_pushdown->probe_info.front().dynamic_filters;
+  REQUIRE(original_channel);
+  auto const* original_get = find_get_with_channel(*original, original_channel.get());
+  REQUIRE(original_get != nullptr);
+
+  auto copy = sirius::transparent::copy_logical_plan(*original, *connection.context);
+  REQUIRE(copy);
+  REQUIRE(copy.get() != original.get());
+
+  auto const* copied_join = find_dynamic_filter_join(*copy);
+  REQUIRE(copied_join != nullptr);
+  REQUIRE(copied_join != original_join);
+  REQUIRE(copied_join->filter_pushdown.get() != original_join->filter_pushdown.get());
+  REQUIRE(copied_join->filter_pushdown->probe_info.size() == 1);
+
+  auto const copied_channel = copied_join->filter_pushdown->probe_info.front().dynamic_filters;
+  REQUIRE(copied_channel.get() == original_channel.get());
+  auto const* copied_get = find_get_with_channel(*copy, copied_channel.get());
+  REQUIRE(copied_get != nullptr);
+  REQUIRE(copied_get != original_get);
+  REQUIRE(copied_get->dynamic_filters.get() == copied_channel.get());
+
+  // The source remains intact for DuckDB's CPU fallback path.
+  REQUIRE(original_join->filter_pushdown);
+  REQUIRE(original_get->dynamic_filters.get() == original_channel.get());
 }


### PR DESCRIPTION
This PR implements phase c1a1 of the rollout plan documented in #1179. Please see the docs in that PR for more information, but this code defines the seam between duckdb planner structures and corresponding Sirius structures for dynamic filters. Zero functional/performance change. Just scaffolding.