### PR TITLE
feat(log): DuckDB logging sink + sirius_log_backend selector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,7 @@ set(EXTENSION_SOURCES
     src/io/s3/sirius_sigv4_authorizer.cpp
     src/io/uring/uring_ioctx.cpp
     src/io/uring/uring_reactor.cpp
+    src/log/duckdb_sink.cpp
     src/log/level.cpp
     src/log/logging.cpp
     src/log/noop_sink.cpp
@@ -610,6 +611,7 @@ set(TEST_SOURCES
     test/cpp/io/test_uri_parser.cpp
     test/cpp/io/uring/test_uring_readv.cpp
     test/cpp/io/rest/test_rest_reactor.cpp
+    test/cpp/log/test_duckdb_sink.cpp
     test/cpp/log/test_logging.cpp
     test/cpp/scan_manager/test_s3_routing_cutover.cpp
     test/cpp/scan_manager/test_pin_table_multi_gpu.cpp

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -356,9 +356,26 @@ Registered in `src/sirius_extension.cpp`. These can be changed at runtime:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `sirius_log_level` | `info` | Log level: trace, debug, info, warn, error |
-| `sirius_log_dir` | `log` | Log output directory |
-| `sirius_log_flush_seconds` | 5 | Log flush interval |
+| `sirius_log_backend` | `duckdb` | Log sink: `duckdb`, `spdlog`, or `noop` |
+| `sirius_log_level` | `info` | Log level: trace, debug, info, warn, error (`spdlog` backend only) |
+| `sirius_log_dir` | `log` | Log output directory (`spdlog` backend only) |
+| `sirius_log_flush_seconds` | 5 | Log flush interval (`spdlog` backend only) |
+
+The **`duckdb`** backend (default) routes Sirius logs into DuckDB's own logging under the
+`Sirius` log type. Nothing is emitted until DuckDB logging is enabled, and level/enable are
+governed by DuckDB (not `sirius_log_level`):
+
+```sql
+PRAGMA enable_logging;
+SELECT * FROM duckdb_logs WHERE type = 'Sirius';
+```
+
+The **`spdlog`** backend writes the daily-rotated `<sirius_log_dir>/sirius.log` and honours
+`sirius_log_level` / `sirius_log_flush_seconds` (this is what `tools/log_analyzer` parses). Switch
+to it with `SET sirius_log_backend='spdlog';`. **`noop`** discards all logs.
+
+The backend / dir / level also read the `SIRIUS_LOG_BACKEND` / `SIRIUS_LOG_DIR` /
+`SIRIUS_LOG_LEVEL` environment variables at load.
 
 ### Memory
 

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -356,26 +356,20 @@ Registered in `src/sirius_extension.cpp`. These can be changed at runtime:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `sirius_log_backend` | `duckdb` | Log sink: `duckdb`, `spdlog`, or `noop` |
-| `sirius_log_level` | `info` | Log level: trace, debug, info, warn, error (`spdlog` backend only) |
-| `sirius_log_dir` | `log` | Log output directory (`spdlog` backend only) |
-| `sirius_log_flush_seconds` | 5 | Log flush interval (`spdlog` backend only) |
+| `sirius_log_backend` | `spdlog` | Log sink: `spdlog`, `duckdb`, or `noop` |
+| `sirius_log_level` | `info` | Log level: trace, debug, info, warn, error (`spdlog` only) |
+| `sirius_log_dir` | `log` | Log output directory (`spdlog` only) |
+| `sirius_log_flush_seconds` | 3 | Log flush interval in seconds (`spdlog` only) |
 
-The **`duckdb`** backend (default) routes Sirius logs into DuckDB's own logging under the
-`Sirius` log type. Nothing is emitted until DuckDB logging is enabled, and level/enable are
-governed by DuckDB (not `sirius_log_level`):
+- **`spdlog`** (default): writes the daily-rotated `<sirius_log_dir>/sirius.log`, honouring
+  `sirius_log_level` and `sirius_log_flush_seconds`.
+- **`duckdb`**: routes logs into DuckDB's own logging under the `Sirius` log type; enable and
+  read them with `CALL enable_logging(); SELECT * FROM duckdb_logs WHERE type = 'Sirius';`.
+  Level and enable are governed by DuckDB, not `sirius_log_level`.
+- **`noop`**: discards all logs.
 
-```sql
-PRAGMA enable_logging;
-SELECT * FROM duckdb_logs WHERE type = 'Sirius';
-```
-
-The **`spdlog`** backend writes the daily-rotated `<sirius_log_dir>/sirius.log` and honours
-`sirius_log_level` / `sirius_log_flush_seconds` (this is what `tools/log_analyzer` parses). Switch
-to it with `SET sirius_log_backend='spdlog';`. **`noop`** discards all logs.
-
-The backend / dir / level also read the `SIRIUS_LOG_BACKEND` / `SIRIUS_LOG_DIR` /
-`SIRIUS_LOG_LEVEL` environment variables at load.
+These can also be set at load via the `SIRIUS_LOG_BACKEND`, `SIRIUS_LOG_DIR`, and
+`SIRIUS_LOG_LEVEL` environment variables.
 
 ### Memory
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -46,7 +46,7 @@ uint64_t Config::DEFAULT_SCAN_TASK_VARCHAR_SIZE = 256ULL;
 
 uint64_t Config::MAX_SORT_PARTITION_BYTES = 0;  ///< 0 = auto (33% of available GPU memory)
 
-std::string Config::LOG_BACKEND = "duckdb";
+std::string Config::LOG_BACKEND = "spdlog";
 std::string Config::LOG_LEVEL   = "info";
 std::string Config::LOG_DIR     = "log";
 int Config::LOG_FLUSH_SECONDS   = 3;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -46,8 +46,9 @@ uint64_t Config::DEFAULT_SCAN_TASK_VARCHAR_SIZE = 256ULL;
 
 uint64_t Config::MAX_SORT_PARTITION_BYTES = 0;  ///< 0 = auto (33% of available GPU memory)
 
-std::string Config::LOG_LEVEL = "info";
-std::string Config::LOG_DIR   = "log";
-int Config::LOG_FLUSH_SECONDS = 3;
+std::string Config::LOG_BACKEND = "duckdb";
+std::string Config::LOG_LEVEL   = "info";
+std::string Config::LOG_DIR     = "log";
+int Config::LOG_FLUSH_SECONDS   = 3;
 
 }  // namespace duckdb

--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -72,6 +72,7 @@ struct Config {
   static uint64_t MAX_SORT_PARTITION_BYTES;
 
   // Logging configuration
+  static std::string LOG_BACKEND;
   static std::string LOG_LEVEL;
   static std::string LOG_DIR;
   static int LOG_FLUSH_SECONDS;

--- a/src/include/log/duckdb_sink.hpp
+++ b/src/include/log/duckdb_sink.hpp
@@ -20,11 +20,8 @@
 
 #include <memory>
 
-// A sink that forwards into DuckDB's own logging, so that when Sirius runs as a
-// loaded DuckDB extension its messages surface through DuckDB's logger (queryable
-// via `PRAGMA enable_logging; SELECT * FROM duckdb_logs`). Filtering is deferred
-// to DuckDB: `should_log` consults DuckDB's logger and `set_level` is a no-op, so
-// the messages that pass are governed by DuckDB's own enable/level configuration.
+// A sink that forwards into DuckDB's own logging, so a loaded Sirius extension's
+// messages surface via `PRAGMA enable_logging; SELECT * FROM duckdb_logs`.
 
 // Forward-declared so this header does not pull in DuckDB headers.
 namespace duckdb {
@@ -36,10 +33,8 @@ namespace sirius::log {
 /// Creates a sink that forwards messages to `db`'s global logger under the
 /// "Sirius" log type.
 ///
-/// The sink retains only a weak reference to `db`, so it safely discards messages
-/// once the database instance is destroyed. `db` must be owned by a shared_ptr
-/// (true for any live DuckDB database), as it is when a `DatabaseInstance&` is
-/// handed to an extension at load time.
+/// Retains only a weak reference to `db`, so it discards messages once `db` is
+/// destroyed.
 std::shared_ptr<sink> make_duckdb_sink(duckdb::DatabaseInstance& db);
 
 }  // namespace sirius::log

--- a/src/include/log/duckdb_sink.hpp
+++ b/src/include/log/duckdb_sink.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "log/sink.hpp"
+
+#include <memory>
+
+// A sink that forwards into DuckDB's own logging, so that when Sirius runs as a
+// loaded DuckDB extension its messages surface through DuckDB's logger (queryable
+// via `PRAGMA enable_logging; SELECT * FROM duckdb_logs`). Filtering is deferred
+// to DuckDB: `should_log` consults DuckDB's logger and `set_level` is a no-op, so
+// the messages that pass are governed by DuckDB's own enable/level configuration.
+
+// Forward-declared so this header does not pull in DuckDB headers.
+namespace duckdb {
+class DatabaseInstance;
+}
+
+namespace sirius::log {
+
+/// Creates a sink that forwards messages to `db`'s global logger under the
+/// "Sirius" log type.
+///
+/// The sink retains only a weak reference to `db`, so it safely discards messages
+/// once the database instance is destroyed. `db` must be owned by a shared_ptr
+/// (true for any live DuckDB database), as it is when a `DatabaseInstance&` is
+/// handed to an extension at load time.
+std::shared_ptr<sink> make_duckdb_sink(duckdb::DatabaseInstance& db);
+
+}  // namespace sirius::log

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -381,6 +381,18 @@ class SiriusContext : public ClientContextState {
   std::atomic<uint64_t> transparent_runtime_fallback_count_{0};
 };
 
+/// Installs the log sink selected by `Config::LOG_BACKEND`, reading the level/dir
+/// from `Config::LOG_*`.
+///
+/// `db` backs the `duckdb` backend: when it is null (the callback ctor calls it
+/// this way, before a DatabaseInstance exists) the `duckdb` backend is left
+/// deferred — the facade keeps its no-op default until `LoadInternal` calls this
+/// again with the real `db`. The db-independent backends (`spdlog`, `noop`) are
+/// installed regardless, so startup diagnostics emitted during construction are
+/// captured. An unknown backend throws only when `db` is non-null, so the error
+/// surfaces from extension load / SET rather than from the ctor.
+void install_configured_log_sink(DatabaseInstance* db);
+
 /// todo(amin): when duckdb is updated, we need to enable OnExtensionLoaded to support sirius
 /// extensions
 class SiriusContextExtensionCallback : public ExtensionCallback {

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -381,16 +381,12 @@ class SiriusContext : public ClientContextState {
   std::atomic<uint64_t> transparent_runtime_fallback_count_{0};
 };
 
-/// Installs the log sink selected by `Config::LOG_BACKEND`, reading the level/dir
-/// from `Config::LOG_*`.
+/// Installs the sink selected by `Config::LOG_BACKEND` (with `Config::LOG_*`).
 ///
-/// `db` backs the `duckdb` backend: when it is null (the callback ctor calls it
-/// this way, before a DatabaseInstance exists) the `duckdb` backend is left
-/// deferred — the facade keeps its no-op default until `LoadInternal` calls this
-/// again with the real `db`. The db-independent backends (`spdlog`, `noop`) are
-/// installed regardless, so startup diagnostics emitted during construction are
-/// captured. An unknown backend throws only when `db` is non-null, so the error
-/// surfaces from extension load / SET rather than from the ctor.
+/// `spdlog` and `noop` install unconditionally; `duckdb` needs `db` and, given a
+/// null `db`, defers (leaves the current sink) so a caller without one yet can
+/// still select it. An unknown backend throws only when `db` is non-null, so the
+/// null (best-effort) path never throws.
 void install_configured_log_sink(DatabaseInstance* db);
 
 /// todo(amin): when duckdb is updated, we need to enable OnExtensionLoaded to support sirius

--- a/src/log/duckdb_sink.cpp
+++ b/src/log/duckdb_sink.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "log/duckdb_sink.hpp"
+
+#include "duckdb/logging/log_manager.hpp"
+#include "duckdb/logging/logger.hpp"
+#include "duckdb/main/database.hpp"
+
+#include <format>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace sirius::log {
+
+namespace {
+
+constexpr const char* log_type = "Sirius";
+
+duckdb::LogLevel to_duckdb_level(level lvl)
+{
+  using enum level;
+  switch (lvl) {
+    case trace: return duckdb::LogLevel::LOG_TRACE;
+    case debug: return duckdb::LogLevel::LOG_DEBUG;
+    case info: return duckdb::LogLevel::LOG_INFO;
+    case warn: return duckdb::LogLevel::LOG_WARNING;
+    case error: return duckdb::LogLevel::LOG_ERROR;
+    case critical: return duckdb::LogLevel::LOG_FATAL;
+    // `off` is only ever a threshold, never an emitted level; map it to the
+    // highest severity so a stray emission is not silently reclassified lower.
+    case off: return duckdb::LogLevel::LOG_FATAL;
+  }
+  return duckdb::LogLevel::LOG_INFO;
+}
+
+std::string_view basename(std::string_view path)
+{
+  auto slash = path.find_last_of("/\\");
+  return slash == std::string_view::npos ? path : path.substr(slash + 1);
+}
+
+/// Forwards to DuckDB's global logger. Holds a weak reference to the database so
+/// it becomes a safe no-op after the DatabaseInstance (and its LogManager) is
+/// destroyed, since DuckDB offers no extension-teardown hook to unregister on.
+class duckdb_sink final : public sink {
+ public:
+  explicit duckdb_sink(duckdb::weak_ptr<duckdb::DatabaseInstance> db) : _db(std::move(db)) {}
+
+  // DuckDB owns the level: its enable/level configuration decides what passes.
+  void set_level(level) override {}
+
+  [[nodiscard]] bool should_log(level lvl) const override
+  {
+    auto db = _db.lock();
+    if (!db) { return false; }
+    return duckdb::Logger::Get(*db).ShouldLog(log_type, to_duckdb_level(lvl));
+  }
+
+  void log(level lvl, const std::source_location& loc, std::string_view message) override
+  {
+    auto db = _db.lock();
+    if (!db) { return; }
+    // DuckDB's WriteLog carries no source location, so fold it into the message
+    // for parity with the spdlog sink's `[file:line]` attribution.
+    auto formatted = std::format("[{}:{}] {}", basename(loc.file_name()), loc.line(), message);
+    // WriteLog can throw when `warnings_as_errors` promotes a warning; a log call
+    // must never propagate into the caller's control flow.
+    try {
+      duckdb::Logger::Get(*db).WriteLog(log_type, to_duckdb_level(lvl), formatted);
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
+    }
+  }
+
+  bool flush() override
+  {
+    auto db = _db.lock();
+    if (!db) { return true; }
+    try {
+      db->GetLogManager().Flush();
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
+    }
+    // Delivered to DuckDB's log storage; further durability is DuckDB's concern.
+    return true;
+  }
+
+ private:
+  duckdb::weak_ptr<duckdb::DatabaseInstance> _db;
+};
+
+}  // namespace
+
+std::shared_ptr<sink> make_duckdb_sink(duckdb::DatabaseInstance& db)
+{
+  return std::make_shared<duckdb_sink>(db.shared_from_this());
+}
+
+}  // namespace sirius::log

--- a/src/log/duckdb_sink.cpp
+++ b/src/log/duckdb_sink.cpp
@@ -41,8 +41,7 @@ duckdb::LogLevel to_duckdb_level(level lvl)
     case warn: return duckdb::LogLevel::LOG_WARNING;
     case error: return duckdb::LogLevel::LOG_ERROR;
     case critical: return duckdb::LogLevel::LOG_FATAL;
-    // `off` is only ever a threshold, never an emitted level; map it to the
-    // highest severity so a stray emission is not silently reclassified lower.
+    // `off` is a threshold, never an emitted level; map it high just in case.
     case off: return duckdb::LogLevel::LOG_FATAL;
   }
   return duckdb::LogLevel::LOG_INFO;
@@ -54,18 +53,19 @@ std::string_view basename(std::string_view path)
   return slash == std::string_view::npos ? path : path.substr(slash + 1);
 }
 
-/// Forwards to DuckDB's global logger. Holds a weak reference to the database so
-/// it becomes a safe no-op after the DatabaseInstance (and its LogManager) is
-/// destroyed, since DuckDB offers no extension-teardown hook to unregister on.
+/// Forwards to DuckDB's global logger under the "Sirius" log type.
 class duckdb_sink final : public sink {
  public:
   explicit duckdb_sink(duckdb::weak_ptr<duckdb::DatabaseInstance> db) : _db(std::move(db)) {}
 
-  // DuckDB owns the level: its enable/level configuration decides what passes.
+  // DuckDB owns the level; nothing to set here.
   void set_level(level) override {}
 
   [[nodiscard]] bool should_log(level lvl) const override
   {
+    // The sink can outlive the db (process-wide, no teardown hook), so it holds a
+    // weak ref and re-locks each call: lock() is a cheap refcount bump, not a db
+    // lock, and yields null once the db is gone — making the call a safe no-op.
     auto db = _db.lock();
     if (!db) { return false; }
     return duckdb::Logger::Get(*db).ShouldLog(log_type, to_duckdb_level(lvl));
@@ -75,11 +75,9 @@ class duckdb_sink final : public sink {
   {
     auto db = _db.lock();
     if (!db) { return; }
-    // DuckDB's WriteLog carries no source location, so fold it into the message
-    // for parity with the spdlog sink's `[file:line]` attribution.
+    // WriteLog takes no source location, so fold file:line into the message.
     auto formatted = std::format("[{}:{}] {}", basename(loc.file_name()), loc.line(), message);
-    // WriteLog can throw when `warnings_as_errors` promotes a warning; a log call
-    // must never propagate into the caller's control flow.
+    // WriteLog can throw (warnings_as_errors promotes a warning); never propagate.
     try {
       duckdb::Logger::Get(*db).WriteLog(log_type, to_duckdb_level(lvl), formatted);
     } catch (...) {  // NOLINT(bugprone-empty-catch)

--- a/src/log/duckdb_sink.cpp
+++ b/src/log/duckdb_sink.cpp
@@ -22,7 +22,6 @@
 
 #include <format>
 #include <memory>
-#include <string>
 #include <string_view>
 
 namespace sirius::log {

--- a/src/log/duckdb_sink.cpp
+++ b/src/log/duckdb_sink.cpp
@@ -86,13 +86,14 @@ class duckdb_sink final : public sink {
   bool flush() override
   {
     auto db = _db.lock();
-    if (!db) { return true; }
+    if (!db) { return false; }
     try {
       db->GetLogManager().Flush();
     } catch (...) {  // NOLINT(bugprone-empty-catch)
     }
-    // Delivered to DuckDB's log storage; further durability is DuckDB's concern.
-    return true;
+    // Best-effort only: Flush() gives no delivery confirmation and the storage may
+    // be non-durable, so we cannot promise the messages reached a final destination.
+    return false;
   }
 
  private:

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -1090,14 +1090,11 @@ void install_configured_log_sink(DatabaseInstance* db)
   } else if (backend == "noop") {
     sirius::log::set_sink(sirius::log::make_noop_sink());
   } else if (backend == "duckdb") {
-    // The duckdb sink needs the DatabaseInstance and defers its level to DuckDB.
-    // When called from the ctor (db == nullptr) it stays deferred: the facade's
-    // no-op default remains until LoadInternal reinstalls with the real db, which
-    // matches DuckDB logging being off until `enable_logging`.
+    // Needs a DatabaseInstance; with none, defer and leave the current sink.
     if (db) { sirius::log::set_sink(sirius::log::make_duckdb_sink(*db)); }
   } else if (db) {
-    // Surface a bad backend only where a throw is handled (extension load / SET),
-    // never from the callback ctor (db == nullptr) where it would terminate.
+    // Only report a bad backend on the db path; the db-less call is best-effort
+    // and must not throw.
     throw InvalidInputException("Unknown sirius_log_backend '%s' (expected: duckdb, spdlog, noop)",
                                 backend);
   }
@@ -1108,10 +1105,9 @@ SiriusContextExtensionCallback::SiriusContextExtensionCallback()
   if (auto* env = std::getenv("SIRIUS_LOG_BACKEND")) { Config::LOG_BACKEND = env; }
   if (auto* env = std::getenv("SIRIUS_LOG_DIR")) { Config::LOG_DIR = env; }
   if (auto* env = std::getenv("SIRIUS_LOG_LEVEL")) { Config::LOG_LEVEL = env; }
-  // Install the db-independent sink now so the startup diagnostics emitted by
-  // read_config_file_if_exists() -> SiriusContext::initialize() are captured for
-  // the spdlog/noop backends. The duckdb backend is installed later from
-  // LoadInternal, where the DatabaseInstance it needs is available.
+  // Install now (no db yet) so spdlog/noop capture the logs emitted by
+  // read_config_file_if_exists() below; the duckdb backend needs a db (installed
+  // later).
   install_configured_log_sink(nullptr);
   read_config_file_if_exists();
 }

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -25,7 +25,9 @@
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/planner.hpp"
+#include "log/duckdb_sink.hpp"
 #include "log/logging.hpp"
+#include "log/noop_sink.hpp"
 #include "log/spdlog_owning_sink.hpp"
 #include "memory/numa_small_pinned_mr.hpp"
 #include "memory/resource_ref_utils.hpp"
@@ -1067,22 +1069,50 @@ void SiriusContext::release_query_lifecycle_slot()
 
 // ================= Free Functions ================= //
 
+void install_configured_log_sink(DatabaseInstance* db)
+{
+  auto parsed_level = sirius::log::string_to_enum(Config::LOG_LEVEL);
+  auto lvl          = parsed_level.value_or(sirius::log::level::info);
+
+  const std::string& backend = Config::LOG_BACKEND;
+  if (backend == "spdlog") {
+    auto flush =
+      Config::LOG_FLUSH_SECONDS <= 0
+        ? std::nullopt
+        : std::optional<std::chrono::milliseconds>{std::chrono::seconds{Config::LOG_FLUSH_SECONDS}};
+    auto sink = sirius::log::make_spdlog_owning_sink({Config::LOG_DIR, flush});
+    sink->set_level(lvl);
+    sirius::log::set_sink(std::move(sink));
+    // Warn only once the sink is installed, so the message actually reaches it.
+    if (!parsed_level) {
+      SIRIUS_LOG_WARN("Unknown log level '{}', defaulting to info", Config::LOG_LEVEL);
+    }
+  } else if (backend == "noop") {
+    sirius::log::set_sink(sirius::log::make_noop_sink());
+  } else if (backend == "duckdb") {
+    // The duckdb sink needs the DatabaseInstance and defers its level to DuckDB.
+    // When called from the ctor (db == nullptr) it stays deferred: the facade's
+    // no-op default remains until LoadInternal reinstalls with the real db, which
+    // matches DuckDB logging being off until `enable_logging`.
+    if (db) { sirius::log::set_sink(sirius::log::make_duckdb_sink(*db)); }
+  } else if (db) {
+    // Surface a bad backend only where a throw is handled (extension load / SET),
+    // never from the callback ctor (db == nullptr) where it would terminate.
+    throw InvalidInputException("Unknown sirius_log_backend '%s' (expected: duckdb, spdlog, noop)",
+                                backend);
+  }
+}
+
 SiriusContextExtensionCallback::SiriusContextExtensionCallback()
 {
+  if (auto* env = std::getenv("SIRIUS_LOG_BACKEND")) { Config::LOG_BACKEND = env; }
   if (auto* env = std::getenv("SIRIUS_LOG_DIR")) { Config::LOG_DIR = env; }
   if (auto* env = std::getenv("SIRIUS_LOG_LEVEL")) { Config::LOG_LEVEL = env; }
-  auto parsed_level = sirius::log::string_to_enum(Config::LOG_LEVEL);
-  auto flush =
-    Config::LOG_FLUSH_SECONDS <= 0
-      ? std::nullopt
-      : std::optional<std::chrono::milliseconds>{std::chrono::seconds{Config::LOG_FLUSH_SECONDS}};
-  auto sink = sirius::log::make_spdlog_owning_sink({Config::LOG_DIR, flush});
-  sink->set_level(parsed_level.value_or(sirius::log::level::info));
-  sirius::log::set_sink(std::move(sink));
-  // Warn only once the sink is installed, so the message actually reaches it.
-  if (!parsed_level) {
-    SIRIUS_LOG_WARN("Unknown log level '{}', defaulting to info", Config::LOG_LEVEL);
-  }
+  // Install the db-independent sink now so the startup diagnostics emitted by
+  // read_config_file_if_exists() -> SiriusContext::initialize() are captured for
+  // the spdlog/noop backends. The duckdb backend is installed later from
+  // LoadInternal, where the DatabaseInstance it needs is available.
+  install_configured_log_sink(nullptr);
   read_config_file_if_exists();
 }
 

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -76,7 +76,6 @@ extern "C" int cudaProfilerStop();
 #include "duckdb/main/connection_manager.hpp"
 #include "helper/type_conversions.hpp"
 #include "log/logging.hpp"
-#include "log/spdlog_owning_sink.hpp"
 #include "op/scan/duckdb_native_gpu_ingestible.hpp"
 #include "op/scan/gpu_ingestible.hpp"
 #include "op/scan/parquet_gpu_ingestible.hpp"
@@ -1609,23 +1608,23 @@ static void SetSortSampleBytes(ClientContext& context, SetScope scope, Value& pa
   SIRIUS_LOG_DEBUG("Updated config SORT_SAMPLE_BYTES to {}", params->sort_sample_bytes);
 }
 
-// Rebuilds the global sink from the current logging config.
-static void ReinstallLogSink()
+static void SetLogBackend(ClientContext& context, SetScope scope, Value& parameter)
 {
-  auto lvl = sirius::log::string_to_enum(Config::LOG_LEVEL).value_or(sirius::log::level::info);
-  auto flush =
-    Config::LOG_FLUSH_SECONDS <= 0
-      ? std::nullopt
-      : std::optional<std::chrono::milliseconds>{std::chrono::seconds{Config::LOG_FLUSH_SECONDS}};
-  auto sink = sirius::log::make_spdlog_owning_sink({Config::LOG_DIR, flush});
-  sink->set_level(lvl);
-  sirius::log::set_sink(std::move(sink));
+  auto backend = StringValue::Get(parameter);
+  if (backend != "duckdb" && backend != "spdlog" && backend != "noop") {
+    throw InvalidInputException("Unknown sirius_log_backend '%s' (expected: duckdb, spdlog, noop)",
+                                backend);
+  }
+  Config::LOG_BACKEND = std::move(backend);
+  install_configured_log_sink(context.db.get());
+  SIRIUS_LOG_DEBUG("Updated config LOG_BACKEND to {}", Config::LOG_BACKEND);
 }
 
 static void SetLogLevel(ClientContext& context, SetScope scope, Value& parameter)
 {
   Config::LOG_LEVEL = StringValue::Get(parameter);
-  // A level change only re-targets the current sink; no need to rebuild it.
+  // A level change only re-targets the current sink; no need to rebuild it. The
+  // duckdb backend defers to DuckDB's own level, so its set_level is a no-op.
   auto parsed_level = sirius::log::string_to_enum(Config::LOG_LEVEL);
   sirius::log::get_sink()->set_level(parsed_level.value_or(sirius::log::level::info));
   if (!parsed_level) {
@@ -1637,15 +1636,17 @@ static void SetLogLevel(ClientContext& context, SetScope scope, Value& parameter
 static void SetLogDir(ClientContext& context, SetScope scope, Value& parameter)
 {
   Config::LOG_DIR = StringValue::Get(parameter);
-  ReinstallLogSink();
+  // log_dir only affects the spdlog backend; rebuild it when that one is active.
+  if (Config::LOG_BACKEND == "spdlog") { install_configured_log_sink(context.db.get()); }
   SIRIUS_LOG_DEBUG("Updated config LOG_DIR to {}", Config::LOG_DIR);
 }
 
 static void SetLogFlushSeconds(ClientContext& context, SetScope scope, Value& parameter)
 {
   Config::LOG_FLUSH_SECONDS = IntegerValue::Get(parameter);
-  // The flush interval is fixed at sink construction, so rebuild the sink.
-  ReinstallLogSink();
+  // The flush interval is fixed at spdlog-sink construction, so rebuild it when
+  // that backend is active; other backends do not use it.
+  if (Config::LOG_BACKEND == "spdlog") { install_configured_log_sink(context.db.get()); }
   SIRIUS_LOG_DEBUG("Updated config LOG_FLUSH_SECONDS to {}", Config::LOG_FLUSH_SECONDS);
 }
 
@@ -1874,6 +1875,11 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
     SetMaxSortPartitionMemoryFraction);
 
   // Logging configuration
+  config.AddExtensionOption("sirius_log_backend",
+                            "Logging backend for Sirius (duckdb, spdlog, noop)",
+                            LogicalType::VARCHAR,
+                            Value(Config::LOG_BACKEND),
+                            SetLogBackend);
   config.AddExtensionOption("sirius_log_level",
                             "Log level for Sirius (trace, debug, info, warn, error, critical, off)",
                             LogicalType::VARCHAR,
@@ -1985,6 +1991,13 @@ static void LoadInternal(ExtensionLoader& loader)
   auto callback      = make_shared_ptr<duckdb::SiriusContextExtensionCallback>();
   auto* callback_ptr = callback.get();
   config.GetCallbackManager().Register(std::move(callback));
+
+  // Install the duckdb-backed sink now that the DatabaseInstance is available (it
+  // is the default backend and the callback ctor could not build it without db).
+  // The ctor already installed the db-independent backends, so this is a no-op
+  // reinstall for spdlog/noop.
+  install_configured_log_sink(&db);
+
   sirius::converter_registry::initialize();
   SiriusExtension::InitialGPUConfigs(config);
   SiriusExtension::RegisterGPUFunctions(db);

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1623,8 +1623,7 @@ static void SetLogBackend(ClientContext& context, SetScope scope, Value& paramet
 static void SetLogLevel(ClientContext& context, SetScope scope, Value& parameter)
 {
   Config::LOG_LEVEL = StringValue::Get(parameter);
-  // A level change only re-targets the current sink; no need to rebuild it. The
-  // duckdb backend defers to DuckDB's own level, so its set_level is a no-op.
+  // Only re-targets the current sink; no rebuild (a no-op for the duckdb backend).
   auto parsed_level = sirius::log::string_to_enum(Config::LOG_LEVEL);
   sirius::log::get_sink()->set_level(parsed_level.value_or(sirius::log::level::info));
   if (!parsed_level) {
@@ -1644,8 +1643,8 @@ static void SetLogDir(ClientContext& context, SetScope scope, Value& parameter)
 static void SetLogFlushSeconds(ClientContext& context, SetScope scope, Value& parameter)
 {
   Config::LOG_FLUSH_SECONDS = IntegerValue::Get(parameter);
-  // The flush interval is fixed at spdlog-sink construction, so rebuild it when
-  // that backend is active; other backends do not use it.
+  // The flush interval is fixed at spdlog-sink construction, so rebuild it (only
+  // the spdlog backend uses it).
   if (Config::LOG_BACKEND == "spdlog") { install_configured_log_sink(context.db.get()); }
   SIRIUS_LOG_DEBUG("Updated config LOG_FLUSH_SECONDS to {}", Config::LOG_FLUSH_SECONDS);
 }
@@ -1992,10 +1991,8 @@ static void LoadInternal(ExtensionLoader& loader)
   auto* callback_ptr = callback.get();
   config.GetCallbackManager().Register(std::move(callback));
 
-  // Install the duckdb-backed sink now that the DatabaseInstance is available (it
-  // is the default backend and the callback ctor could not build it without db).
-  // The ctor already installed the db-independent backends, so this is a no-op
-  // reinstall for spdlog/noop.
+  // Now that the DatabaseInstance exists, install the configured sink; the
+  // default duckdb backend needs it.
   install_configured_log_sink(&db);
 
   sirius::converter_registry::initialize();

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1991,8 +1991,9 @@ static void LoadInternal(ExtensionLoader& loader)
   auto* callback_ptr = callback.get();
   config.GetCallbackManager().Register(std::move(callback));
 
-  // Now that the DatabaseInstance exists, install the configured sink; the
-  // default duckdb backend needs it.
+  // The ctor already installed the db-independent backend; reinstall now that the
+  // DatabaseInstance exists so the duckdb backend (which needs it) is built and an
+  // unknown backend name is reported here rather than swallowed by the ctor.
   install_configured_log_sink(&db);
 
   sirius::converter_registry::initialize();

--- a/test/cpp/log/test_duckdb_sink.cpp
+++ b/test/cpp/log/test_duckdb_sink.cpp
@@ -46,7 +46,7 @@ TEST_CASE("duckdb sink forwards Sirius logs into duckdb_logs", "[log]")
   // DuckDB logging is off by default: the sink defers and drops everything.
   CHECK_FALSE(sink->should_log(level::error));
 
-  REQUIRE_FALSE(con.Query("PRAGMA enable_logging")->HasError());
+  REQUIRE_FALSE(con.Query("CALL enable_logging()")->HasError());
 
   // With logging enabled (default INFO threshold), error-and-above passes.
   CHECK(sink->should_log(level::error));
@@ -54,7 +54,8 @@ TEST_CASE("duckdb sink forwards Sirius logs into duckdb_logs", "[log]")
   sink_restorer restore;
   sirius::log::set_sink(sink);
   SIRIUS_LOG_ERROR("duckdb sink marker {}", 4242);
-  CHECK(sink->flush());
+  // flush() forwards to storage but reports false — best-effort, no delivery guarantee.
+  CHECK_FALSE(sink->flush());
 
   auto result = con.Query("SELECT message FROM duckdb_logs WHERE type = 'Sirius'");
   REQUIRE_FALSE(result->HasError());
@@ -75,12 +76,12 @@ TEST_CASE("duckdb sink is a safe no-op after the database is destroyed", "[log]"
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE_FALSE(con.Query("PRAGMA enable_logging")->HasError());
+    REQUIRE_FALSE(con.Query("CALL enable_logging()")->HasError());
     sink = sirius::log::make_duckdb_sink(*db.instance);
     CHECK(sink->should_log(level::error));
   }
   // The DatabaseInstance is gone; the sink's weak reference has expired.
   CHECK_FALSE(sink->should_log(level::error));
   sink->log(level::error, std::source_location::current(), "after destroy");  // must not crash
-  CHECK(sink->flush());
+  CHECK_FALSE(sink->flush());  // safe no-op, reports false once the db is gone
 }

--- a/test/cpp/log/test_duckdb_sink.cpp
+++ b/test/cpp/log/test_duckdb_sink.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "log/duckdb_sink.hpp"
+#include "log/logging.hpp"
+
+#include <duckdb.hpp>
+
+#include <memory>
+#include <source_location>
+#include <string>
+
+using sirius::log::level;
+
+namespace {
+
+// Restores whatever sink the test suite installed (unittest.cpp's main sets one).
+struct sink_restorer {
+  std::shared_ptr<sirius::log::sink> prev = sirius::log::get_sink();
+  ~sink_restorer() { sirius::log::set_sink(prev); }
+};
+
+}  // namespace
+
+TEST_CASE("duckdb sink forwards Sirius logs into duckdb_logs", "[log]")
+{
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto sink = sirius::log::make_duckdb_sink(*db.instance);
+
+  // DuckDB logging is off by default: the sink defers and drops everything.
+  CHECK_FALSE(sink->should_log(level::error));
+
+  REQUIRE_FALSE(con.Query("PRAGMA enable_logging")->HasError());
+
+  // With logging enabled (default INFO threshold), error-and-above passes.
+  CHECK(sink->should_log(level::error));
+
+  sink_restorer restore;
+  sirius::log::set_sink(sink);
+  SIRIUS_LOG_ERROR("duckdb sink marker {}", 4242);
+  CHECK(sink->flush());
+
+  auto result = con.Query("SELECT message FROM duckdb_logs WHERE type = 'Sirius'");
+  REQUIRE_FALSE(result->HasError());
+  REQUIRE(result->RowCount() >= 1);
+
+  bool found = false;
+  for (duckdb::idx_t i = 0; i < result->RowCount(); ++i) {
+    if (result->GetValue(0, i).ToString().find("duckdb sink marker 4242") != std::string::npos) {
+      found = true;
+    }
+  }
+  CHECK(found);
+}
+
+TEST_CASE("duckdb sink is a safe no-op after the database is destroyed", "[log]")
+{
+  std::shared_ptr<sirius::log::sink> sink;
+  {
+    duckdb::DuckDB db(nullptr);
+    duckdb::Connection con(db);
+    REQUIRE_FALSE(con.Query("PRAGMA enable_logging")->HasError());
+    sink = sirius::log::make_duckdb_sink(*db.instance);
+    CHECK(sink->should_log(level::error));
+  }
+  // The DatabaseInstance is gone; the sink's weak reference has expired.
+  CHECK_FALSE(sink->should_log(level::error));
+  sink->log(level::error, std::source_location::current(), "after destroy");  // must not crash
+  CHECK(sink->flush());
+}


### PR DESCRIPTION
Adds a DuckDB-backed log sink and a `sirius_log_backend` setting to select among `spdlog` | `duckdb` | `noop` (also via the `SIRIUS_LOG_BACKEND` env var).

The default stays `spdlog`.

- **`spdlog`** (default): the existing daily-rotated `<sirius_log_dir>/sirius.log` file backend.
- **`duckdb`**: routes Sirius logs into DuckDB's own logging (see example below).
- **`noop`**: discards all logs.

The duckdb sink keeps a `weak_ptr<DatabaseInstance>` and resolves the logger per call, so it becomes a safe no-op once the database is destroyed (the process-wide sink outlives the db, and DuckDB has no extension-teardown hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Example:

Run this in your terminal after building:
```
SIRIUS_CONFIG_FILE=test/cpp/integration/integration.yaml ./build/release/duckdb -c "CALL enable_logging(); SELECT count(*) FROM range(1000);"
```

Results in Sirius logs showing up in DuckDB:
```
WARNING:The logging settings have been changed so you may lose warnings printed in the CLI.
To continue printing warnings to the console, set storage='shell_log_storage'.
For more info see https://duckdb.org/docs/stable/operations_manual/logging/overview.

INFO:
[sirius_context.cpp:225] QueryEnd

INFO:
[sirius_context.cpp:149] [host_pool] HOST:0 QueryEnd allocated=67108864 bytes peak=67108864 bytes free_blocks=5056

INFO:
[sirius_context.cpp:164] [gpu_pool] GPU:0 QueryEnd allocated=0 bytes peak=0 bytes reserved=0 bytes

┌─────────┐
│ Success │
│ boolean │
└─────────┘
  0 rows
INFO:
[sirius_context.cpp:149] [host_pool] HOST:0 QueryBegin allocated=67108864 bytes peak=67108864 bytes free_blocks=5056

INFO:
[sirius_context.cpp:164] [gpu_pool] GPU:0 QueryBegin allocated=0 bytes peak=0 bytes reserved=0 bytes

INFO:
[sirius_context.cpp:209] QueryBegin: SQL: SELECT count(*) FROM range(1000);

INFO:
 SELECT count(*) FROM range(1000);

INFO:
[sirius_context.cpp:1020] Transparent execution fallback (unsupported): {"exception_type":"Not implemented","exception_message":"Table function '{}' is not supported in Sirius"}

┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│         1000 │
└──────────────┘
INFO:
[sirius_context.cpp:1123] Connection closed.
```