### PR TITLE
Skip unused prefetch ranges when the datasource has no prefetch cache

### DIFF
--- a/src/include/io/sirius_datasource.hpp
+++ b/src/include/io/sirius_datasource.hpp
@@ -136,9 +136,9 @@ class sirius_datasource : public cudf::io::datasource {
 
   void prefetch(cache::prefetching_stage site);
 
- private:
-  [[nodiscard]] bool uses_prefetching_cache();
+  [[nodiscard]] bool uses_prefetching_cache() const noexcept;
 
+ private:
   std::shared_ptr<sirius_ioctx> _io_ctx;
   std::shared_ptr<sirius_io_object> _io_object;
   /// Handle of the most recent speculative/immediate insert into the

--- a/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
+++ b/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
@@ -118,16 +118,17 @@ class duckdb_native_scan_info : public op::scan::scan_info {
   /// groups currently held. The scan sequencer fadvises these to prefetch.
   [[nodiscard]] std::vector<fadvise_entry> fadvise_entries() const override
   {
-    if (!datasource || !datasource->uses_prefetching_cache() || block_manager == nullptr) {
-      return {};
-    }
-    fadvise_entry entry;
-    entry.datasource = datasource;
-    for (auto const& rg : row_groups) {
-      auto ranges = row_group_file_ranges(*block_manager, rg);
-      entry.ranges.insert(entry.ranges.end(), ranges.begin(), ranges.end());
-    }
-    return {std::move(entry)};
+    if (block_manager == nullptr) { return {}; }
+    std::vector<fadvise_entry> entries;
+    append_fadvise_entry(entries, datasource, [this] {
+      std::vector<cudf::io::text::byte_range_info> ranges;
+      for (auto const& rg : row_groups) {
+        auto rg_ranges = row_group_file_ranges(*block_manager, rg);
+        ranges.insert(ranges.end(), rg_ranges.begin(), rg_ranges.end());
+      }
+      return ranges;
+    });
+    return entries;
   }
 
   /// Decoded (GPU) byte budget for this unit; drives memory reservation.

--- a/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
+++ b/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
@@ -118,7 +118,9 @@ class duckdb_native_scan_info : public op::scan::scan_info {
   /// groups currently held. The scan sequencer fadvises these to prefetch.
   [[nodiscard]] std::vector<fadvise_entry> fadvise_entries() const override
   {
-    if (!datasource || block_manager == nullptr) { return {}; }
+    if (!datasource || !datasource->uses_prefetching_cache() || block_manager == nullptr) {
+      return {};
+    }
     fadvise_entry entry;
     entry.datasource = datasource;
     for (auto const& rg : row_groups) {

--- a/src/include/op/scan/gpu_ingestible_types.hpp
+++ b/src/include/op/scan/gpu_ingestible_types.hpp
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <span>
+#include <utility>
 #include <vector>
 
 #pragma once
@@ -106,6 +107,18 @@ class scan_info : public std::enable_shared_from_this<scan_info> {
   [[nodiscard]] virtual std::size_t estimated_working_set_bytes() const noexcept
   {
     return estimated_bytes();
+  }
+
+ protected:
+  template <typename RangeFactory>
+  static void append_fadvise_entry(std::vector<fadvise_entry>& entries,
+                                   std::shared_ptr<sirius::io::sirius_datasource> const& datasource,
+                                   RangeFactory&& make_ranges)
+  {
+    if (!datasource || !datasource->uses_prefetching_cache()) { return; }
+    auto ranges = std::forward<RangeFactory>(make_ranges)();
+    if (ranges.empty()) { return; }
+    entries.push_back(fadvise_entry{datasource, std::move(ranges)});
   }
 };
 

--- a/src/io/sirius_datasource.cpp
+++ b/src/io/sirius_datasource.cpp
@@ -229,10 +229,9 @@ void sirius_datasource::prefetch(cache::prefetching_stage site)
   }
 }
 
-bool sirius_datasource::uses_prefetching_cache()
+bool sirius_datasource::uses_prefetching_cache() const noexcept
 {
-  auto* cache = _io_ctx->cache();
-  return cache != nullptr && _io_ctx->can_use_prefetching_cache();
+  return _io_ctx->uses_prefetching_cache();
 }
 
 }  // namespace sirius::io

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -265,22 +265,17 @@ std::vector<cudf::io::text::byte_range_info> column_chunk_ranges(
 //===----------------------------------------------------------------------===//
 std::vector<scan_info::fadvise_entry> parquet_file_scan_info::fadvise_entries() const
 {
-  if (!datasource || !datasource->uses_prefetching_cache() || !file_metadata || !reader_options) {
-    return {};
-  }
-  std::vector<cudf::size_type> rg_indices;
-  rg_indices.reserve(row_groups.size());
-  for (auto const& rg : row_groups) {
-    rg_indices.push_back(rg.index);
-  }
-  auto ranges = column_chunk_ranges(*file_metadata, *reader_options, rg_indices);
-  if (ranges.empty()) { return {}; }
-  fadvise_entry entry;
-  entry.datasource = datasource;
-  entry.ranges     = std::move(ranges);
-  std::vector<fadvise_entry> out;
-  out.push_back(std::move(entry));
-  return out;
+  if (!file_metadata || !reader_options) { return {}; }
+  std::vector<fadvise_entry> entries;
+  append_fadvise_entry(entries, datasource, [this] {
+    std::vector<cudf::size_type> rg_indices;
+    rg_indices.reserve(row_groups.size());
+    for (auto const& rg : row_groups) {
+      rg_indices.push_back(rg.index);
+    }
+    return column_chunk_ranges(*file_metadata, *reader_options, rg_indices);
+  });
+  return entries;
 }
 
 std::vector<scan_info::fadvise_entry> parquet_split_info::fadvise_entries() const
@@ -289,16 +284,10 @@ std::vector<scan_info::fadvise_entry> parquet_split_info::fadvise_entries() cons
   std::vector<fadvise_entry> entries;
   entries.reserve(rg_slices.size());
   for (auto const& slice : rg_slices) {
-    if (!slice.datasource || !slice.datasource->uses_prefetching_cache() || !slice.file_metadata) {
-      continue;
-    }
-    auto ranges =
-      column_chunk_ranges(*slice.file_metadata, *reader_options, slice.row_group_indices);
-    if (ranges.empty()) { continue; }
-    fadvise_entry entry;
-    entry.datasource = slice.datasource;
-    entry.ranges     = std::move(ranges);
-    entries.push_back(std::move(entry));
+    if (!slice.file_metadata) { continue; }
+    append_fadvise_entry(entries, slice.datasource, [&slice, this] {
+      return column_chunk_ranges(*slice.file_metadata, *reader_options, slice.row_group_indices);
+    });
   }
   return entries;
 }

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -265,7 +265,9 @@ std::vector<cudf::io::text::byte_range_info> column_chunk_ranges(
 //===----------------------------------------------------------------------===//
 std::vector<scan_info::fadvise_entry> parquet_file_scan_info::fadvise_entries() const
 {
-  if (!datasource || !file_metadata || !reader_options) { return {}; }
+  if (!datasource || !datasource->uses_prefetching_cache() || !file_metadata || !reader_options) {
+    return {};
+  }
   std::vector<cudf::size_type> rg_indices;
   rg_indices.reserve(row_groups.size());
   for (auto const& rg : row_groups) {
@@ -287,7 +289,9 @@ std::vector<scan_info::fadvise_entry> parquet_split_info::fadvise_entries() cons
   std::vector<fadvise_entry> entries;
   entries.reserve(rg_slices.size());
   for (auto const& slice : rg_slices) {
-    if (!slice.datasource || !slice.file_metadata) { continue; }
+    if (!slice.datasource || !slice.datasource->uses_prefetching_cache() || !slice.file_metadata) {
+      continue;
+    }
     auto ranges =
       column_chunk_ranges(*slice.file_metadata, *reader_options, slice.row_group_indices);
     if (ranges.empty()) { continue; }

--- a/test/cpp/scan/test_parquet_scan_sizing.cpp
+++ b/test/cpp/scan/test_parquet_scan_sizing.cpp
@@ -153,7 +153,8 @@ TEST_CASE("parquet scans without a prefetch cache skip advisory ranges",
 {
   auto ingestible = scan::make_ingestible(make_nation_info(false));
   auto ioctx      = std::make_shared<sirius::io::kvikio_context>();
-  auto task       = ingestible->next_split_provider(
+  REQUIRE_FALSE(ioctx->uses_prefetching_cache());
+  auto task = ingestible->next_split_provider(
     [ioctx](std::string_view) -> std::shared_ptr<sirius::io::sirius_ioctx> { return ioctx; });
   REQUIRE(task);
 

--- a/test/cpp/scan/test_parquet_scan_sizing.cpp
+++ b/test/cpp/scan/test_parquet_scan_sizing.cpp
@@ -148,6 +148,28 @@ duckdb::vector<duckdb::HivePartitioningIndex> year_partition()
 
 }  // namespace
 
+TEST_CASE("parquet scans without a prefetch cache skip advisory ranges",
+          "[scan][parquet][prefetch]")
+{
+  auto ingestible = scan::make_ingestible(make_nation_info(false));
+  auto ioctx      = std::make_shared<sirius::io::kvikio_context>();
+  auto task       = ingestible->next_split_provider(
+    [ioctx](std::string_view) -> std::shared_ptr<sirius::io::sirius_ioctx> { return ioctx; });
+  REQUIRE(task);
+
+  auto coalescer = ingestible->create_batch_coalescer();
+  auto batches   = coalescer->push(task());
+  auto tail      = coalescer->flush();
+  for (auto& batch : tail) {
+    batches.push_back(std::move(batch));
+  }
+  REQUIRE(batches.size() == 1);
+
+  auto* batch = dynamic_cast<scan::parquet_split_info*>(batches.front().get());
+  REQUIRE(batch);
+  CHECK(batch->fadvise_entries().empty());
+}
+
 TEST_CASE("parquet batches are capped by decode working set", "[scan][parquet][sizing]")
 {
   auto info                    = std::make_unique<scan::parquet_ingestible_table_info>();


### PR DESCRIPTION
Avoid computing Parquet and DuckDB-native prefetch ranges when the datasource has no prefetch cache. In that configuration, `fadvise()` is already a no-op.

For SF100 TPC-H Q1, this reduced scan task creation from 16–21 seconds to approximately 0.1 ms, and total buffered execution from 20–23 seconds to approximately 2 seconds.