### PR TITLE
feat(vss): ANN Index (IVF-Flat) Creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,6 +439,7 @@ set(EXTENSION_SOURCES
     src/transparent/sirius_optimizer_extension.cpp
     src/util/stream_check_wrapper.cpp
     src/util/segfault_backtrace_handler.cpp
+    src/vss/cuvs_index_cache.cpp
     src/vss/distance_metric.cpp
     src/vss/enn_top_k.cpp
     src/vss/pinned_column.cpp
@@ -466,7 +467,8 @@ set(CUDA_SOURCES
     src/cuda/scan/strings/fsst.cu
     src/cuda/scan/strings/uncompressed.cu
     src/cuda/vss/cudf_raft_interop.cu
-    src/cuda/vss/brute_force_search.cu)
+    src/cuda/vss/brute_force_search.cu
+    src/cuda/vss/ivf_flat_index.cu)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/legacy/CMakeLists.txt")
   add_subdirectory(src/legacy)
   list(APPEND EXTENSION_SOURCES ${SIRIUS_LEGACY_SOURCES}
@@ -875,8 +877,10 @@ set(TEST_SOURCES
     test/cpp/telemetry/test_telemetry_context.cpp
     test/cpp/vss/test_brute_force_search.cpp
     test/cpp/vss/test_cudf_raft_interop.cpp
+    test/cpp/vss/test_cuvs_index_cache.cpp
     test/cpp/vss/test_distance_metric.cpp
     test/cpp/vss/test_enn_top_k.cpp
+    test/cpp/vss/test_ivf_flat_index.cpp
     test/cpp/vss/test_pinned_column.cpp
     test/cpp/vss/test_vector_search.cpp
     test/cpp/unittest.cpp

--- a/src/cuda/vss/ivf_flat_index.cu
+++ b/src/cuda/vss/ivf_flat_index.cu
@@ -65,15 +65,16 @@ struct scoped_current_device_resource {
 
 }  // namespace
 
-std::unique_ptr<any_cuvs_index> build_ivf_flat_index_from_chunks(
-  std::vector<cudf::column_view> const& chunks,
+std::unique_ptr<any_cuvs_index> build_ivf_flat_index_from_batches(
+  std::vector<cudf::column_view> const& batches,
   std::int64_t dim,
   std::uint32_t n_lists,
   cuvs::distance::DistanceType metric,
-  rmm::device_async_resource_ref index_mr)
+  rmm::device_async_resource_ref index_mr,
+  rmm::cuda_stream_view stream)
 {
-  if (chunks.empty()) {
-    throw std::invalid_argument("build_ivf_flat_index_from_chunks: no chunks to index");
+  if (batches.empty()) {
+    throw std::invalid_argument("build_ivf_flat_index_from_batches: no batches to index");
   }
 
   cuvs::neighbors::ivf_flat::index_params index_params;
@@ -95,49 +96,50 @@ std::unique_ptr<any_cuvs_index> build_ivf_flat_index_from_chunks(
   // the build, restoring the prior current device resource.
   auto index = [&] {
     scoped_current_device_resource route{index_mr};
-    raft::device_resources res;
-    auto const stream = raft::resource::get_cuda_stream(res);
+    // Build on the caller's stream so the index's device buffers are bound to it
+    // and so allocations charge the reservation attached to it.
+    raft::device_resources res{stream};
 
     // Train centroids on the first batch that has at least n_lists rows.
-    // NOTE: could improve recall if we do a cross-chunk training sample
-    cudf::column_view const* train_chunk = nullptr;
+    // NOTE: could improve recall if we do a cross-batch training sample
+    cudf::column_view const* train_batch = nullptr;
     bool any_non_empty                   = false;
-    for (auto const& chunk : chunks) {
-      auto const rows = static_cast<std::int64_t>(chunk.size());
+    for (auto const& batch : batches) {
+      auto const rows = static_cast<std::int64_t>(batch.size());
       if (rows == 0) { continue; }
       any_non_empty = true;
       if (rows >= static_cast<std::int64_t>(n_lists)) {
-        train_chunk = &chunk;
+        train_batch = &batch;
         break;
       }
     }
-    if (train_chunk == nullptr) {
+    if (train_batch == nullptr) {
       if (!any_non_empty) {
-        throw std::invalid_argument("build_ivf_flat_index_from_chunks: all chunks are empty");
+        throw std::invalid_argument("build_ivf_flat_index_from_batches: all batches are empty");
       }
       throw std::invalid_argument(
-        "build_ivf_flat_index_from_chunks: no batch has at least n_lists=" +
+        "build_ivf_flat_index_from_batches: no batch has at least n_lists=" +
         std::to_string(n_lists) + " rows to train IVF-Flat centroids; lower n_lists");
     }
-    auto const train_view = list_column_as_dataset_view(*train_chunk, dim);
+    auto const train_view = list_column_as_dataset_view(*train_batch, dim);
     auto idx              = cuvs::neighbors::ivf_flat::build(res, index_params, train_view);
 
-    // Populate the index chunk by chunk, tagging each vector with its global row id
+    // Populate the index batch by batch, tagging each vector with its global row id
     // (offset by the rows already added) so search returns dataset-global indices.
     std::int64_t base = 0;
-    for (auto const& chunk : chunks) {
-      auto const chunk_view = list_column_as_dataset_view(chunk, dim);
-      auto const rows       = chunk_view.extent(0);
+    for (auto const& batch : batches) {
+      auto const batch_view = list_column_as_dataset_view(batch, dim);
+      auto const rows       = batch_view.extent(0);
       if (rows == 0) { continue; }
       if (base == 0) {
         // Index is still empty: nullopt implies the contiguous range [0, rows).
-        cuvs::neighbors::ivf_flat::extend(res, chunk_view, std::nullopt, &idx);
+        cuvs::neighbors::ivf_flat::extend(res, batch_view, std::nullopt, &idx);
       } else {
         rmm::device_uvector<std::int64_t> ids(static_cast<std::size_t>(rows), stream, index_mr);
         thrust::sequence(rmm::exec_policy(stream), ids.begin(), ids.end(), base);
         auto const ids_view =
           raft::make_device_vector_view<const std::int64_t, std::int64_t>(ids.data(), rows);
-        cuvs::neighbors::ivf_flat::extend(res, chunk_view, std::optional{ids_view}, &idx);
+        cuvs::neighbors::ivf_flat::extend(res, batch_view, std::optional{ids_view}, &idx);
         // ids is freed async on `stream` at scope exit, ordered after this extend.
       }
       base += rows;

--- a/src/cuda/vss/ivf_flat_index.cu
+++ b/src/cuda/vss/ivf_flat_index.cu
@@ -98,17 +98,26 @@ std::unique_ptr<any_cuvs_index> build_ivf_flat_index_from_chunks(
     raft::device_resources res;
     auto const stream = raft::resource::get_cuda_stream(res);
 
-    // Centroids are trained on the first non-empty chunk.
+    // Train centroids on the first batch that has at least n_lists rows.
     // NOTE: could improve recall if we do a cross-chunk training sample
     cudf::column_view const* train_chunk = nullptr;
+    bool any_non_empty                   = false;
     for (auto const& chunk : chunks) {
-      if (chunk.size() > 0) {
+      auto const rows = static_cast<std::int64_t>(chunk.size());
+      if (rows == 0) { continue; }
+      any_non_empty = true;
+      if (rows >= static_cast<std::int64_t>(n_lists)) {
         train_chunk = &chunk;
         break;
       }
     }
     if (train_chunk == nullptr) {
-      throw std::invalid_argument("build_ivf_flat_index_from_chunks: all chunks are empty");
+      if (!any_non_empty) {
+        throw std::invalid_argument("build_ivf_flat_index_from_chunks: all chunks are empty");
+      }
+      throw std::invalid_argument(
+        "build_ivf_flat_index_from_chunks: no batch has at least n_lists=" +
+        std::to_string(n_lists) + " rows to train IVF-Flat centroids; lower n_lists");
     }
     auto const train_view = list_column_as_dataset_view(*train_chunk, dim);
     auto idx              = cuvs::neighbors::ivf_flat::build(res, index_params, train_view);

--- a/src/cuda/vss/ivf_flat_index.cu
+++ b/src/cuda/vss/ivf_flat_index.cu
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vss/cudf_raft_interop.hpp"
+#include "vss/ivf_flat_index.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <raft/core/device_mdspan.hpp>
+#include <raft/core/device_resources.hpp>
+#include <raft/core/resource/cuda_stream.hpp>
+
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <cuda/memory_resource>
+#include <thrust/sequence.h>
+
+#include <cuvs/neighbors/ivf_flat.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace sirius::vss {
+
+namespace {
+
+/// RAII: route allocations on the current device through @p mr for the guard's
+/// lifetime, restoring the previous resource on exit. The evicted resource is
+/// captured by value (an owning any_resource) per the rmm 26.06 behavior
+/// documented in sirius_memory_reservation_manager, capturing a non-owning ref
+/// would dangle once the per-device map entry is moved out.
+struct scoped_current_device_resource {
+  ::cuda::mr::any_resource<::cuda::mr::device_accessible> prev;
+
+  explicit scoped_current_device_resource(rmm::device_async_resource_ref mr)
+    : prev(cudf::set_current_device_resource(mr))
+  {
+  }
+  scoped_current_device_resource(const scoped_current_device_resource&)            = delete;
+  scoped_current_device_resource& operator=(const scoped_current_device_resource&) = delete;
+  scoped_current_device_resource(scoped_current_device_resource&&)                 = delete;
+  scoped_current_device_resource& operator=(scoped_current_device_resource&&)      = delete;
+  ~scoped_current_device_resource() { cudf::set_current_device_resource(std::move(prev)); }
+};
+
+}  // namespace
+
+std::unique_ptr<any_cuvs_index> build_ivf_flat_index_from_chunks(
+  std::vector<cudf::column_view> const& chunks,
+  std::int64_t dim,
+  std::uint32_t n_lists,
+  cuvs::distance::DistanceType metric,
+  rmm::device_async_resource_ref index_mr)
+{
+  if (chunks.empty()) {
+    throw std::invalid_argument("build_ivf_flat_index_from_chunks: no chunks to index");
+  }
+
+  cuvs::neighbors::ivf_flat::index_params index_params;
+  index_params.n_lists = n_lists;
+  index_params.metric  = metric;
+  // Train the kmeans centroids only; the dataset is added chunk by chunk.
+  index_params.add_data_on_build = false;
+
+  // Allocate the index (and its build-time scratch) through the reservation's
+  // resource so the whole thing lives in Sirius-reserved GPU memory. The handle
+  // is constructed inside the guard so RAFT's workspace resource is the
+  // reservation's too, not just the per-allocation default. The scope ends after
+  // the build, restoring the prior current device resource.
+  auto index = [&] {
+    scoped_current_device_resource route{index_mr};
+    raft::device_resources res;
+    auto const stream = raft::resource::get_cuda_stream(res);
+
+    // Centroids are trained on the first non-empty chunk.
+    // NOTE: could improve recall if we do a cross-chunk training sample
+    cudf::column_view const* train_chunk = nullptr;
+    for (auto const& chunk : chunks) {
+      if (chunk.size() > 0) {
+        train_chunk = &chunk;
+        break;
+      }
+    }
+    if (train_chunk == nullptr) {
+      throw std::invalid_argument("build_ivf_flat_index_from_chunks: all chunks are empty");
+    }
+    auto const train_view = list_column_as_dataset_view(*train_chunk, dim);
+    auto idx              = cuvs::neighbors::ivf_flat::build(res, index_params, train_view);
+
+    // Populate the index chunk by chunk, tagging each vector with its global row id
+    // (offset by the rows already added) so search returns dataset-global indices.
+    std::int64_t base = 0;
+    for (auto const& chunk : chunks) {
+      auto const chunk_view = list_column_as_dataset_view(chunk, dim);
+      auto const rows       = chunk_view.extent(0);
+      if (rows == 0) { continue; }
+      if (base == 0) {
+        // Index is still empty: nullopt implies the contiguous range [0, rows).
+        cuvs::neighbors::ivf_flat::extend(res, chunk_view, std::nullopt, &idx);
+      } else {
+        rmm::device_uvector<std::int64_t> ids(static_cast<std::size_t>(rows), stream, index_mr);
+        thrust::sequence(rmm::exec_policy(stream), ids.begin(), ids.end(), base);
+        auto const ids_view =
+          raft::make_device_vector_view<const std::int64_t, std::int64_t>(ids.data(), rows);
+        cuvs::neighbors::ivf_flat::extend(res, chunk_view, std::optional{ids_view}, &idx);
+        // ids is freed async on `stream` at scope exit, ordered after this extend.
+      }
+      base += rows;
+    }
+    // Synchronous contract: the index is fully resident before we restore the
+    // resource and return (the dataset view borrows caller memory only for here).
+    raft::resource::sync_stream(res);
+    return idx;
+  }();
+
+  return make_cuvs_index(std::move(index));
+}
+
+namespace {
+using ivf_flat_index_t = cuvs::neighbors::ivf_flat::index<float, int64_t>;
+}  // namespace
+
+ann_result search_ivf_flat_index(any_cuvs_index const& index,
+                                 const float* query_device,
+                                 std::int64_t dim,
+                                 std::int64_t k,
+                                 std::uint32_t n_probes,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::device_async_resource_ref mr)
+{
+  auto const* holder = dynamic_cast<cuvs_index_holder<ivf_flat_index_t> const*>(&index);
+  if (holder == nullptr) {
+    throw std::invalid_argument("search_ivf_flat_index: pinned index is not an IVF-Flat index");
+  }
+  auto const& idx = holder->index;
+
+  auto const query_view = raft::make_device_matrix_view<const float, int64_t, raft::row_major>(
+    query_device, int64_t{1}, dim);
+
+  // Allocate flattened [1 * k] outputs through `mr` so the reservation system tracks them
+  auto const out_size = static_cast<cudf::size_type>(k);
+  auto neighbors_col  = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT64}, out_size, cudf::mask_state::UNALLOCATED, stream, mr);
+  auto distances_col = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::FLOAT32}, out_size, cudf::mask_state::UNALLOCATED, stream, mr);
+
+  auto neighbors_view = raft::make_device_matrix_view<int64_t, int64_t, raft::row_major>(
+    neighbors_col->mutable_view().data<int64_t>(), int64_t{1}, k);
+  auto distances_view = raft::make_device_matrix_view<float, int64_t, raft::row_major>(
+    distances_col->mutable_view().data<float>(), int64_t{1}, k);
+
+  raft::device_resources res{stream};
+  cuvs::neighbors::ivf_flat::search_params search_params;
+  search_params.n_probes = n_probes;
+  cuvs::neighbors::ivf_flat::search(
+    res, search_params, idx, query_view, neighbors_view, distances_view);
+  raft::resource::sync_stream(res);
+
+  return ann_result{std::move(neighbors_col), std::move(distances_col)};
+}
+
+}  // namespace sirius::vss

--- a/src/cuda/vss/ivf_flat_index.cu
+++ b/src/cuda/vss/ivf_flat_index.cu
@@ -79,8 +79,14 @@ std::unique_ptr<any_cuvs_index> build_ivf_flat_index_from_chunks(
   cuvs::neighbors::ivf_flat::index_params index_params;
   index_params.n_lists = n_lists;
   index_params.metric  = metric;
-  // Train the kmeans centroids only; the dataset is added chunk by chunk.
+  // Train the kmeans centroids only; the dataset is added batch by batch.
   index_params.add_data_on_build = false;
+  // Size each list to what it holds instead of the default padded growth.
+  // We extend batch by batch, so the default policy over-allocates every list and
+  // re-grows it on each batch, inflating the build-time peak well past the final
+  // index size. Exact sizing keeps the peak close to the real footprint so the
+  // build fits inside the reservation alongside the still-pinned source table.
+  index_params.conservative_memory_allocation = true;
 
   // Allocate the index (and its build-time scratch) through the reservation's
   // resource so the whole thing lives in Sirius-reserved GPU memory. The handle

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -53,6 +53,10 @@ namespace cucascade::memory {
 class small_pinned_host_memory_resource;
 }  // namespace cucascade::memory
 
+namespace sirius::vss {
+class cuvs_index_cache;
+}  // namespace sirius::vss
+
 namespace sirius::memory {
 class numa_small_pinned_mr;
 class topology_index;
@@ -513,6 +517,10 @@ class SiriusContext : public ClientContextState {
   [[nodiscard]] sirius::scan_manager::sirius_scan_manager& get_scan_manager();
   [[nodiscard]] const sirius::scan_manager::sirius_scan_manager& get_scan_manager() const;
 
+  /// \brief Get the session's cuVS ANN index cache (GPU-resident, pinned indexes).
+  [[nodiscard]] sirius::vss::cuvs_index_cache& get_cuvs_index_cache();
+  [[nodiscard]] const sirius::vss::cuvs_index_cache& get_cuvs_index_cache() const;
+
   /// Coordinate update execution with pin-registry mutations.
   std::shared_lock<std::shared_mutex> lock_pinned_table_updates();
   std::unique_lock<std::shared_mutex> lock_pinned_table_registry();
@@ -650,6 +658,11 @@ class SiriusContext : public ClientContextState {
   bool is_initialized_ = false;
   sirius::sirius_config config_;
   std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory_manager_;
+  // Session-lifetime cache of GPU-resident, pinned cuVS ANN indexes. Declared
+  // after memory_manager_ so it is destroyed before it: each entry holds a
+  // reservation into the manager's GPU spaces, so the manager must outlive the
+  // cache. Also reset explicitly in terminate() before the manager is torn down.
+  std::unique_ptr<sirius::vss::cuvs_index_cache> cuvs_index_cache_;
   // Single source of truth for the GPU<->NUMA hardware topology, scoped to the
   // memory manager's reserved GPU/HOST spaces. Shared by shared_ptr copy with
   // the small-pinned allocator, downgrade executors, task_creator, and

--- a/src/include/vss/cuvs_index_cache.hpp
+++ b/src/include/vss/cuvs_index_cache.hpp
@@ -98,19 +98,16 @@ template <class Index>
 /// index's device buffers were allocated through
 /// @c reservation->get_memory_resource(), so Sirius owns every byte and
 /// releasing the reservation frees the index. Move-only (owns unique resources).
+///
+/// The cache stores entries as @c shared_ptr, and lookups hand back a shared
+/// handle, so a caller that is mid-search keeps the whole entry (index +
+/// reservation) alive even if it is dropped or replaced concurrently.
 struct pinned_index_entry {
   // The index's device buffers were allocated through reservation,
   // so the index must be freed before the reservation.
   index_metadata meta;
   std::unique_ptr<cucascade::memory::reservation> reservation;
   std::unique_ptr<any_cuvs_index> index;
-
-  pinned_index_entry()                     = default; // default constructor
-  pinned_index_entry(pinned_index_entry&&) = default; // default move constructor
-
-  // The move assignment op (frees the old payload and installs the new one) needs to release the
-  // old payload in the same order as the destructor (i.e., index before reservation, see .cpp).
-  pinned_index_entry& operator=(pinned_index_entry&& other) noexcept;
 
   /// Recover the concrete cuVS index, or nullptr if the held index is not of
   /// type @c Index. The returned pointer is owned by this entry.
@@ -137,10 +134,14 @@ struct pinned_index_entry {
 /// allocates outside Sirius's cucascade reservation manager.
 ///
 /// Lifetime: entries live until @ref erase / @ref clear or session teardown.
-/// There is no eviction or spilling yet (future work), so a pointer returned by
-/// @ref find stays valid until the named entry is explicitly removed.
+/// There is no eviction or spilling yet (future work). Lookups return a shared
+/// handle to the entry, so the entry (and its reservation) stays alive for as
+/// long as any caller holds the handle, even if the named entry is erased or
+/// replaced in the meantime.
 ///
-/// Thread-safety: all members are guarded by an internal mutex.
+/// Thread-safety: all members are guarded by an internal mutex. The mutex only
+/// guards the map itself; the shared handle returned by a lookup is what keeps
+/// the entry alive after the lock is released.
 class cuvs_index_cache {
  public:
   explicit cuvs_index_cache(cucascade::memory::memory_reservation_manager& reservation_manager);
@@ -167,16 +168,18 @@ class cuvs_index_cache {
     std::size_t bytes, int preferred_gpu = -1);
 
   /// Pin a built index under @p name, replacing any existing entry with that
-  /// name (its old index + reservation are freed). Takes ownership of both the
-  /// index payload and its reservation.
+  /// name. The old entry is unlinked here; its index and reservation are freed
+  /// once no outstanding lookup handle still refers to it. Takes ownership of
+  /// both the index payload and its reservation.
   void insert(std::string name,
               index_metadata meta,
               std::unique_ptr<any_cuvs_index> index,
               std::unique_ptr<cucascade::memory::reservation> reservation);
 
   /// Look up a pinned index by its management name, or nullptr if absent. The
-  /// pointer is stable until the entry is erased (no eviction).
-  [[nodiscard]] const pinned_index_entry* find(std::string_view name) const;
+  /// returned handle keeps the entry alive for as long as it is held, even if the
+  /// entry is erased or replaced afterward (no eviction).
+  [[nodiscard]] std::shared_ptr<const pinned_index_entry> find(std::string_view name) const;
 
   /// Find a pinned index by its auto-routing identity, i.e., the first entry whose
   /// metadata matches (@p table, @p column, @p metric). This is the lookup a
@@ -184,14 +187,18 @@ class cuvs_index_cache {
   /// nullptr if no pinned index covers that column under that metric. Metrics
   /// are compared up to canonicalization: L2SqrtExpanded/L2SqrtUnexpanded fold
   /// together, so a query's unexpanded metric still matches an index built expanded.
-  [[nodiscard]] const pinned_index_entry* find_by_column(std::string_view table,
-                                                         std::string_view column,
-                                                         cuvs::distance::DistanceType metric) const;
+  ///
+  /// Like @ref find, the returned handle keeps the entry alive while held.
+  [[nodiscard]] std::shared_ptr<const pinned_index_entry> find_by_column(
+    std::string_view table,
+    std::string_view column,
+    cuvs::distance::DistanceType metric) const;
 
   [[nodiscard]] bool contains(std::string_view name) const;
 
-  /// Remove the entry for @p name, freeing its index and releasing its
-  /// reservation. Returns true iff an entry was removed.
+  /// Remove the entry for @p name. Its index and reservation are freed once no
+  /// outstanding lookup handle still refers to it. Returns true iff an entry was
+  /// removed.
   bool erase(std::string_view name);
 
   /// Drop all pinned indexes.
@@ -202,7 +209,7 @@ class cuvs_index_cache {
  private:
   cucascade::memory::memory_reservation_manager& _reservation_manager;
   mutable std::mutex _mutex;
-  std::unordered_map<std::string, pinned_index_entry> _entries;
+  std::unordered_map<std::string, std::shared_ptr<pinned_index_entry>> _entries;
 };
 
 }  // namespace sirius::vss

--- a/src/include/vss/cuvs_index_cache.hpp
+++ b/src/include/vss/cuvs_index_cache.hpp
@@ -47,13 +47,12 @@ enum class index_kind : std::uint8_t {
 /// (type-erased) index payload so the cache can be inspected, logged, and
 /// matched without instantiating any cuVS index type.
 ///
-/// The (@c table_name, @c column_name, @c metric) triple is the index's
-/// auto-routing identity: a search recognizer resolves a query's vector column
-/// to its base (table, column) and matches it against pinned indexes here. The
-/// cache map key (i.e., the CREATE INDEX name) is separate and only used for
-/// management (i.e., drop/replace).
+/// The (@c catalog_name, @c schema_name, @c table_name, @c column_name, @c metric) tuple is
+/// the index's auto-routing identity.
 struct index_metadata {
   index_kind kind{index_kind::ivf_flat};
+  std::string catalog_name;  ///< Resolved catalog the table lives in
+  std::string schema_name;   ///< Resolved schema the table lives in
   std::string table_name;    ///< Base table the index was built on
   std::string column_name;   ///< Vector column the index was built on
   std::int64_t dim{0};       ///< Vector dimensionality
@@ -182,14 +181,16 @@ class cuvs_index_cache {
   [[nodiscard]] std::shared_ptr<const pinned_index_entry> find(std::string_view name) const;
 
   /// Find a pinned index by its auto-routing identity, i.e., the first entry whose
-  /// metadata matches (@p table, @p column, @p metric). This is the lookup a
-  /// search recognizer uses to decide whether a query can use ANN. Returns
-  /// nullptr if no pinned index covers that column under that metric. Metrics
-  /// are compared up to canonicalization: L2SqrtExpanded/L2SqrtUnexpanded fold
-  /// together, so a query's unexpanded metric still matches an index built expanded.
+  /// metadata matches (@p catalog, @p schema, @p table, @p column, @p metric).
+  /// This is the lookup a search recognizer uses to decide whether a query can use
+  /// ANN. Returns nullptr if no pinned index covers that column under that metric.
+  /// Metrics are compared up to canonicalization: L2SqrtExpanded/L2SqrtUnexpanded fold together,
+  /// so a query's unexpanded metric still matches an index built expanded.
   ///
   /// Like @ref find, the returned handle keeps the entry alive while held.
   [[nodiscard]] std::shared_ptr<const pinned_index_entry> find_by_column(
+    std::string_view catalog,
+    std::string_view schema,
     std::string_view table,
     std::string_view column,
     cuvs::distance::DistanceType metric) const;

--- a/src/include/vss/cuvs_index_cache.hpp
+++ b/src/include/vss/cuvs_index_cache.hpp
@@ -23,11 +23,13 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace cucascade::memory {
 class memory_reservation_manager;
@@ -64,6 +66,22 @@ struct index_metadata {
   std::size_t resident_bytes{
     0};  ///< Resident GPU bytes the finished index occupies (capacity-accounted)
 };
+
+/// Build the cache key for an index from its routing identity.
+[[nodiscard]] inline std::string build_ann_index_cache_key(std::string_view catalog,
+                                                           std::string_view schema,
+                                                           std::string_view table,
+                                                           std::string_view column,
+                                                           std::string_view metric)
+{
+  std::string key;
+  for (auto part : {catalog, schema, table, column, metric}) {
+    key += std::to_string(part.size());
+    key += ':';
+    key += part;
+  }
+  return key;
+}
 
 /// Type-erased owner of a cuVS index. The cache stores indexes through
 /// this base so it never has to template over the concrete cuVS index type
@@ -159,7 +177,7 @@ class cuvs_index_cache {
   /// this reservation to the build stream so cuVS's allocations are charged and
   /// bounded by it, then releases it once the index is built.
   ///
-  /// Non-blocking, and pinned to @p preferred_gpu: the index must be reserved on
+  /// Non-blocking and pinned to @p preferred_gpu: the index must be reserved on
   /// the same GPU that holds the table's pinned data. Returns null instead of
   /// waiting, so the caller can fail cleanly rather than blocking indefinitely
   /// when the device cannot fit the index.
@@ -187,12 +205,8 @@ class cuvs_index_cache {
 
   /// Find a pinned index by its auto-routing identity, i.e., the first entry whose
   /// metadata matches (@p catalog, @p schema, @p table, @p column, @p metric).
-  /// This is the lookup a search recognizer uses to decide whether a query can use
-  /// ANN. Returns nullptr if no pinned index covers that column under that metric.
-  /// Metrics are compared up to canonicalization: L2SqrtExpanded/L2SqrtUnexpanded fold together,
-  /// so a query's unexpanded metric still matches an index built expanded.
-  ///
-  /// Like @ref find, the returned handle keeps the entry alive while held.
+  /// Returns nullptr if no pinned index covers that column under that metric.
+  /// Metrics are compared up to canonicalization.
   [[nodiscard]] std::shared_ptr<const pinned_index_entry> find_by_column(
     std::string_view catalog,
     std::string_view schema,
@@ -200,14 +214,11 @@ class cuvs_index_cache {
     std::string_view column,
     cuvs::distance::DistanceType metric) const;
 
-  /// Remove every entry whose auto-routing identity matches
-  /// (@p catalog, @p schema, @p table, @p column, @p metric). Metrics are compared
-  /// up to canonicalization. Returns the number of entries removed.
-  std::size_t erase_by_column(std::string_view catalog,
-                              std::string_view schema,
-                              std::string_view table,
-                              std::string_view column,
-                              cuvs::distance::DistanceType metric);
+  /// List all pinned indexes (across metrics) on this column.
+  [[nodiscard]] std::vector<index_metadata> indexes_on_column(std::string_view catalog,
+                                                              std::string_view schema,
+                                                              std::string_view table,
+                                                              std::string_view column) const;
 
   [[nodiscard]] bool contains(std::string_view name) const;
 
@@ -215,6 +226,16 @@ class cuvs_index_cache {
   /// outstanding lookup handle still refers to it. Returns true iff an entry was
   /// removed.
   bool erase(std::string_view name);
+
+  /// Remove entries on (@p catalog, @p schema, @p table, @p column). With a
+  /// @p metric, only the entry for that metric is removed (compared up to
+  /// canonicalization); with no metric, every index on the column is removed
+  /// regardless of metric. Returns the number of entries removed.
+  std::size_t erase_by_column(std::string_view catalog,
+                              std::string_view schema,
+                              std::string_view table,
+                              std::string_view column,
+                              std::optional<cuvs::distance::DistanceType> metric = std::nullopt);
 
   /// Drop all pinned indexes.
   void clear();

--- a/src/include/vss/cuvs_index_cache.hpp
+++ b/src/include/vss/cuvs_index_cache.hpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuvs/distance/distance.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+namespace cucascade::memory {
+class memory_reservation_manager;
+class reservation;
+}  // namespace cucascade::memory
+
+namespace sirius::vss {
+
+/// Which cuVS index algorithm a pinned entry holds. Drives how a search
+/// operator down-casts the type-erased index back to its concrete cuVS type.
+/// Only @c ivf_flat is built today; the rest are placeholders.
+enum class index_kind : std::uint8_t {
+  ivf_flat,
+  // ivf_pq,  // not supported yet
+  // cagra,  // not supported yet
+};
+
+/// Small, copyable description of a pinned cuVS index. Kept separate from the
+/// (type-erased) index payload so the cache can be inspected, logged, and
+/// matched without instantiating any cuVS index type.
+///
+/// The (@c table_name, @c column_name, @c metric) triple is the index's
+/// auto-routing identity: a search recognizer resolves a query's vector column
+/// to its base (table, column) and matches it against pinned indexes here. The
+/// cache map key (i.e., the CREATE INDEX name) is separate and only used for
+/// management (i.e., drop/replace).
+struct index_metadata {
+  index_kind kind{index_kind::ivf_flat};
+  std::string table_name;    ///< Base table the index was built on
+  std::string column_name;   ///< Vector column the index was built on
+  std::int64_t dim{0};       ///< Vector dimensionality
+  std::int64_t num_rows{0};  ///< Number of indexed vectors
+  std::int64_t n_lists{0};   ///< IVF-Flat inverted-list count (0 if not applicable).
+  cuvs::distance::DistanceType metric{cuvs::distance::DistanceType::L2Expanded};
+  std::size_t reserved_bytes{
+    0};  ///< GPU bytes reserved from the reservation manager to hold this index
+};
+
+/// Type-erased owner of a cuVS index. The cache stores indexes through
+/// this base so it never has to template over the concrete cuVS index type
+/// (@c cuvs::neighbors::ivf_flat::index, ...). The concrete index lives in
+/// @ref cuvs_index_holder; a search operator recovers it with
+/// @ref pinned_index_entry::index_as.
+struct any_cuvs_index {
+  any_cuvs_index()                                 = default;
+  any_cuvs_index(const any_cuvs_index&)            = delete;  // copy not allowed
+  any_cuvs_index& operator=(const any_cuvs_index&) = delete;  // assign not allowed
+  virtual ~any_cuvs_index()                        = default;
+};
+
+/// Concrete holder owning one cuVS index of type @c Index.
+template <class Index>
+struct cuvs_index_holder final : any_cuvs_index {
+  explicit cuvs_index_holder(Index&& idx) : index(std::move(idx)) {}
+  Index index;
+};
+
+/// Wrap a freshly-built cuVS index in a type-erased holder ready for the cache.
+template <class Index>
+[[nodiscard]] std::unique_ptr<any_cuvs_index> make_cuvs_index(Index&& idx)
+{
+  return std::make_unique<cuvs_index_holder<std::decay_t<Index>>>(std::forward<Index>(idx));
+}
+
+/// One pinned cuVS index: its metadata, the type-erased index payload, and the
+/// GPU reservation that pins the index's memory.
+///
+/// The reservation keeps the index's footprint reserved and accounted in the
+/// reservation manager until the entry is dropped (unpin or session end). The
+/// index's device buffers were allocated through
+/// @c reservation->get_memory_resource(), so Sirius owns every byte and
+/// releasing the reservation frees the index. Move-only (owns unique resources).
+struct pinned_index_entry {
+  index_metadata meta;
+  std::unique_ptr<any_cuvs_index> index;
+  std::unique_ptr<cucascade::memory::reservation> reservation;
+
+  /// Recover the concrete cuVS index, or nullptr if the held index is not of
+  /// type @c Index. The returned pointer is owned by this entry.
+  template <class Index>
+  [[nodiscard]] Index* index_as() const noexcept
+  {
+    auto* holder = dynamic_cast<cuvs_index_holder<Index>*>(index.get());
+    return holder ? &holder->index : nullptr;
+  }
+};
+
+/// Session-lifetime registry of GPU-resident cuVS indexes, keyed by name.
+///
+/// This is the ANN analogue of the scan manager's pin-table cache: a named entry
+/// pins a built cuVS index on the GPU so later searches reuse it instead of
+/// rebuilding. It is deliberately a standalone cache (not an extension of the
+/// pin-table cache) so each future index type can add its own search operator
+/// without touching shared scan code.
+///
+/// Memory ownership: GPU memory for an index is taken as an explicit reservation
+/// from the reservation manager via @ref reserve_index_memory; the caller builds
+/// the cuVS index through that reservation's memory resource and hands the
+/// reservation to @ref insert, which stores it on the entry. Nothing here ever
+/// allocates outside Sirius's cucascade reservation manager.
+///
+/// Lifetime: entries live until @ref erase / @ref clear or session teardown.
+/// There is no eviction or spilling yet (future work), so a pointer returned by
+/// @ref find stays valid until the named entry is explicitly removed.
+///
+/// Thread-safety: all members are guarded by an internal mutex.
+class cuvs_index_cache {
+ public:
+  explicit cuvs_index_cache(cucascade::memory::memory_reservation_manager& reservation_manager);
+  ~cuvs_index_cache();
+
+  cuvs_index_cache(const cuvs_index_cache&)            = delete;  // copy ctor not allowed
+  cuvs_index_cache& operator=(const cuvs_index_cache&) = delete;  // copy assignment not allowed
+  cuvs_index_cache(cuvs_index_cache&&)                 = delete;  // move ctor not allowed
+  cuvs_index_cache& operator=(cuvs_index_cache&&)      = delete;  // move assignment not allowed
+
+  /// Reserve @p bytes of GPU memory for building an index, so cuVS allocates the
+  /// index through Sirius's reservation manager: build the index with
+  /// @c reservation->get_memory_resource() set as the current device resource,
+  /// then move the same reservation into @ref insert to pin it.
+  ///
+  /// Delegates to @c memory_reservation_manager::request_reservation, which
+  /// blocks until the GPU tier can satisfy the request (it does not return null);
+  /// the returned reservation is therefore always valid.
+  ///
+  /// \param bytes         Estimated GPU footprint of the index to build
+  /// \param preferred_gpu Device id to prefer (>= 0), or -1 for any GPU in the tier
+  /// \returns The non-null GPU reservation
+  [[nodiscard]] std::unique_ptr<cucascade::memory::reservation> reserve_index_memory(
+    std::size_t bytes, int preferred_gpu = -1);
+
+  /// Pin a built index under @p name, replacing any existing entry with that
+  /// name (its old index + reservation are freed). Takes ownership of both the
+  /// index payload and its reservation.
+  void insert(std::string name,
+              index_metadata meta,
+              std::unique_ptr<any_cuvs_index> index,
+              std::unique_ptr<cucascade::memory::reservation> reservation);
+
+  /// Look up a pinned index by its management name, or nullptr if absent. The
+  /// pointer is stable until the entry is erased (no eviction).
+  [[nodiscard]] const pinned_index_entry* find(std::string_view name) const;
+
+  /// Find a pinned index by its auto-routing identity, i.e., the first entry whose
+  /// metadata matches (@p table, @p column, @p metric). This is the lookup a
+  /// search recognizer uses to decide whether a query can use ANN. Returns
+  /// nullptr if no pinned index covers that column under that metric. Metrics
+  /// are compared up to canonicalization: L2SqrtExpanded/L2SqrtUnexpanded fold
+  /// together, so a query's unexpanded metric still matches an index built expanded.
+  [[nodiscard]] const pinned_index_entry* find_by_column(std::string_view table,
+                                                         std::string_view column,
+                                                         cuvs::distance::DistanceType metric) const;
+
+  [[nodiscard]] bool contains(std::string_view name) const;
+
+  /// Remove the entry for @p name, freeing its index and releasing its
+  /// reservation. Returns true iff an entry was removed.
+  bool erase(std::string_view name);
+
+  /// Drop all pinned indexes.
+  void clear();
+
+  [[nodiscard]] std::size_t size() const;
+
+ private:
+  cucascade::memory::memory_reservation_manager& _reservation_manager;
+  mutable std::mutex _mutex;
+  std::unordered_map<std::string, pinned_index_entry> _entries;
+};
+
+}  // namespace sirius::vss

--- a/src/include/vss/cuvs_index_cache.hpp
+++ b/src/include/vss/cuvs_index_cache.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <rmm/cuda_stream.hpp>
+
 #include <cuvs/distance/distance.hpp>
 
 #include <cstdint>
@@ -59,8 +61,8 @@ struct index_metadata {
   std::int64_t num_rows{0};  ///< Number of indexed vectors
   std::int64_t n_lists{0};   ///< IVF-Flat inverted-list count (0 if not applicable).
   cuvs::distance::DistanceType metric{cuvs::distance::DistanceType::L2Expanded};
-  std::size_t reserved_bytes{
-    0};  ///< GPU bytes reserved from the reservation manager to hold this index
+  std::size_t resident_bytes{
+    0};  ///< Resident GPU bytes the finished index occupies (capacity-accounted)
 };
 
 /// Type-erased owner of a cuVS index. The cache stores indexes through
@@ -90,22 +92,22 @@ template <class Index>
 }
 
 /// One pinned cuVS index: its metadata, the type-erased index payload, and the
-/// GPU reservation that pins the index's memory.
+/// stream the index was built on.
 ///
-/// The reservation keeps the index's footprint reserved and accounted in the
-/// reservation manager until the entry is dropped (unpin or session end). The
-/// index's device buffers were allocated through
-/// @c reservation->get_memory_resource(), so Sirius owns every byte and
-/// releasing the reservation frees the index. Move-only (owns unique resources).
+/// The index's device memory is ordinary capacity-accounted GPU memory: it was
+/// charged to a reservation only during the build, which was released once the
+/// build finished. The entry keeps the build stream so the index can be freed on
+/// it when the entry is dropped (unpin or session end). Move-only.
 ///
 /// The cache stores entries as @c shared_ptr, and lookups hand back a shared
-/// handle, so a caller that is mid-search keeps the whole entry (index +
-/// reservation) alive even if it is dropped or replaced concurrently.
+/// handle, so a caller that is mid-search keeps the whole entry alive even if it
+/// is dropped or replaced concurrently.
 struct pinned_index_entry {
-  // The index's device buffers were allocated through reservation,
-  // so the index must be freed before the reservation.
   index_metadata meta;
-  std::unique_ptr<cucascade::memory::reservation> reservation;
+  // The index's device buffers were built on this stream and are freed on it
+  // when the index is destroyed. It is declared before the index because members
+  // are destroyed in reverse order, and the index needs to be freed first.
+  rmm::cuda_stream build_stream;
   std::unique_ptr<any_cuvs_index> index;
 
   /// Recover the concrete cuVS index, or nullptr if the held index is not of
@@ -126,17 +128,19 @@ struct pinned_index_entry {
 /// pin-table cache) so each future index type can add its own search operator
 /// without touching shared scan code.
 ///
-/// Memory ownership: GPU memory for an index is taken as an explicit reservation
-/// from the reservation manager via @ref reserve_index_memory; the caller builds
-/// the cuVS index through that reservation's memory resource and hands the
-/// reservation to @ref insert, which stores it on the entry. Nothing here ever
-/// allocates outside Sirius's cucascade reservation manager.
+/// Memory ownership: @ref reserve_index_memory reserves the build's footprint so
+/// the caller can admit it against the GPU budget. The caller attaches that
+/// reservation to the build stream for the build only, so cuVS's allocations are
+/// charged and bounded by it, then releases the reservation. The finished index's
+/// device memory stays as ordinary capacity-accounted GPU memory, and the entry
+/// keeps only the build stream so the index can be freed on it later. Nothing here
+/// ever allocates outside the GPU memory space's allocator.
 ///
 /// Lifetime: entries live until @ref erase / @ref clear or session teardown.
 /// There is no eviction or spilling yet (future work). Lookups return a shared
-/// handle to the entry, so the entry (and its reservation) stays alive for as
-/// long as any caller holds the handle, even if the named entry is erased or
-/// replaced in the meantime.
+/// handle to the entry, so the entry (and its index) stays alive for as long as
+/// any caller holds the handle, even if the named entry is erased or replaced in
+/// the meantime.
 ///
 /// Thread-safety: all members are guarded by an internal mutex. The mutex only
 /// guards the map itself; the shared handle returned by a lookup is what keeps
@@ -151,10 +155,9 @@ class cuvs_index_cache {
   cuvs_index_cache(cuvs_index_cache&&)                 = delete;  // move ctor not allowed
   cuvs_index_cache& operator=(cuvs_index_cache&&)      = delete;  // move assignment not allowed
 
-  /// Reserve @p bytes of GPU memory for building an index, so cuVS allocates the
-  /// index through Sirius's reservation manager: build the index with
-  /// @c reservation->get_memory_resource() set as the current device resource,
-  /// then move the same reservation into @ref insert to pin it.
+  /// Reserve @p bytes of GPU memory for building an index. The caller attaches
+  /// this reservation to the build stream so cuVS's allocations are charged and
+  /// bounded by it, then releases it once the index is built.
   ///
   /// Non-blocking, and pinned to @p preferred_gpu: the index must be reserved on
   /// the same GPU that holds the table's pinned data. Returns null instead of
@@ -169,13 +172,13 @@ class cuvs_index_cache {
     std::size_t bytes, int preferred_gpu = -1);
 
   /// Pin a built index under @p name, replacing any existing entry with that
-  /// name. The old entry is unlinked here; its index and reservation are freed
-  /// once no outstanding lookup handle still refers to it. Takes ownership of
-  /// both the index payload and its reservation.
+  /// name. The old entry is unlinked here; its index is freed once no outstanding
+  /// lookup handle still refers to it. Takes ownership of the index payload and
+  /// the stream it was built on (the index is freed on that stream).
   void insert(std::string name,
               index_metadata meta,
               std::unique_ptr<any_cuvs_index> index,
-              std::unique_ptr<cucascade::memory::reservation> reservation);
+              rmm::cuda_stream build_stream);
 
   /// Look up a pinned index by its management name, or nullptr if absent. The
   /// returned handle keeps the entry alive for as long as it is held, even if the

--- a/src/include/vss/cuvs_index_cache.hpp
+++ b/src/include/vss/cuvs_index_cache.hpp
@@ -156,13 +156,15 @@ class cuvs_index_cache {
   /// @c reservation->get_memory_resource() set as the current device resource,
   /// then move the same reservation into @ref insert to pin it.
   ///
-  /// Delegates to @c memory_reservation_manager::request_reservation, which
-  /// blocks until the GPU tier can satisfy the request (it does not return null);
-  /// the returned reservation is therefore always valid.
+  /// Non-blocking, and pinned to @p preferred_gpu: the index must be reserved on
+  /// the same GPU that holds the table's pinned data. Returns null instead of
+  /// waiting, so the caller can fail cleanly rather than blocking indefinitely
+  /// when the device cannot fit the index.
   ///
   /// \param bytes         Estimated GPU footprint of the index to build
-  /// \param preferred_gpu Device id to prefer (>= 0), or -1 for any GPU in the tier
-  /// \returns The non-null GPU reservation
+  /// \param preferred_gpu Device id that holds the table's data (>= 0); null is
+  ///                      returned for a negative id or an unknown device
+  /// \returns The GPU reservation on @p preferred_gpu, or null if it cannot satisfy @p bytes
   [[nodiscard]] std::unique_ptr<cucascade::memory::reservation> reserve_index_memory(
     std::size_t bytes, int preferred_gpu = -1);
 
@@ -194,6 +196,15 @@ class cuvs_index_cache {
     std::string_view table,
     std::string_view column,
     cuvs::distance::DistanceType metric) const;
+
+  /// Remove every entry whose auto-routing identity matches
+  /// (@p catalog, @p schema, @p table, @p column, @p metric). Metrics are compared
+  /// up to canonicalization. Returns the number of entries removed.
+  std::size_t erase_by_column(std::string_view catalog,
+                              std::string_view schema,
+                              std::string_view table,
+                              std::string_view column,
+                              cuvs::distance::DistanceType metric);
 
   [[nodiscard]] bool contains(std::string_view name) const;
 

--- a/src/include/vss/cuvs_index_cache.hpp
+++ b/src/include/vss/cuvs_index_cache.hpp
@@ -99,9 +99,18 @@ template <class Index>
 /// @c reservation->get_memory_resource(), so Sirius owns every byte and
 /// releasing the reservation frees the index. Move-only (owns unique resources).
 struct pinned_index_entry {
+  // The index's device buffers were allocated through reservation,
+  // so the index must be freed before the reservation.
   index_metadata meta;
-  std::unique_ptr<any_cuvs_index> index;
   std::unique_ptr<cucascade::memory::reservation> reservation;
+  std::unique_ptr<any_cuvs_index> index;
+
+  pinned_index_entry()                     = default; // default constructor
+  pinned_index_entry(pinned_index_entry&&) = default; // default move constructor
+
+  // The move assignment op (frees the old payload and installs the new one) needs to release the
+  // old payload in the same order as the destructor (i.e., index before reservation, see .cpp).
+  pinned_index_entry& operator=(pinned_index_entry&& other) noexcept;
 
   /// Recover the concrete cuVS index, or nullptr if the held index is not of
   /// type @c Index. The returned pointer is owned by this entry.

--- a/src/include/vss/distance_metric.hpp
+++ b/src/include/vss/distance_metric.hpp
@@ -33,4 +33,9 @@ cuvs::distance::DistanceType enn_distance_type_from_metric(std::string_view metr
  */
 cuvs::distance::DistanceType ann_distance_type_from_metric(std::string_view metric);
 
+/**
+ * @brief Name the metric family of a cuVS DistanceType for user-facing messages.
+ */
+std::string_view ann_metric_name(cuvs::distance::DistanceType metric);
+
 }  // namespace sirius::vss

--- a/src/include/vss/distance_metric.hpp
+++ b/src/include/vss/distance_metric.hpp
@@ -28,4 +28,9 @@ namespace sirius::vss {
  */
 cuvs::distance::DistanceType enn_distance_type_from_metric(std::string_view metric);
 
+/**
+ * @brief Map a user metric string to the cuVS DistanceType for ann.
+ */
+cuvs::distance::DistanceType ann_distance_type_from_metric(std::string_view metric);
+
 }  // namespace sirius::vss

--- a/src/include/vss/ivf_flat_index.hpp
+++ b/src/include/vss/ivf_flat_index.hpp
@@ -26,12 +26,27 @@
 
 #include <cuvs/distance/distance.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string_view>
 #include <vector>
 
 namespace sirius::vss {
+
+/// GPU bytes to reserve for building an IVF-Flat index.
+[[nodiscard]] inline std::size_t ivf_flat_reservation_bytes(std::int64_t n_rows,
+                                                            std::int64_t dim,
+                                                            std::uint32_t n_lists)
+{
+  std::size_t const row_bytes =
+    static_cast<std::size_t>(dim) * sizeof(float) + sizeof(std::int64_t);
+  std::size_t const vec_bytes      = static_cast<std::size_t>(n_rows) * row_bytes;
+  std::size_t const rounding_bytes = static_cast<std::size_t>(n_lists) * 32 * row_bytes;
+  std::size_t const centroid_bytes =
+    static_cast<std::size_t>(n_lists) * static_cast<std::size_t>(dim) * sizeof(float);
+  return vec_bytes * 2 + rounding_bytes + centroid_bytes * 2 + (std::size_t{1} << 20);
+}
 
 /// Build an IVF-Flat index from the dataset held as many separate FLOAT32 LIST
 /// @p batches (each unsliced, gap-free, fixed width @p dim), without concatenating

--- a/src/include/vss/ivf_flat_index.hpp
+++ b/src/include/vss/ivf_flat_index.hpp
@@ -34,36 +34,43 @@
 namespace sirius::vss {
 
 /// Build an IVF-Flat index from the dataset held as many separate FLOAT32 LIST
-/// @p chunks (each unsliced, gap-free, fixed width @p dim), without concatenating
+/// @p batches (each unsliced, gap-free, fixed width @p dim), without concatenating
 /// them into one column. This sidesteps cudf's 2^31-element per-column limit,
 /// which a full coalesce of a large dataset overflows in the LIST child.
 ///
 /// Centroids are trained on the first chunk (cuVS subsamples it internally per
 /// `kmeans_trainset_fraction`); the index is then populated chunk by chunk via
 /// `ivf_flat::extend`, assigning each vector its global row id so search returns
-/// indices into the whole dataset (in @p chunks order). Same ownership contract
+/// indices into the whole dataset (in @p batches order). Same ownership contract
 /// as @ref build_ivf_flat_index: everything allocates through @p index_mr and the
-/// index is fully resident on return. @p chunks are only read during the build.
+/// index is fully resident on return. @p batches are only read during the build.
 ///
 /// Ownership: the index and its build-time scratch allocates through @p index_mr,
 /// i.e., the GPU reservation's memory resource, so the whole index lives in
 /// Sirius-reserved GPU memory. The current CUDA device must already be the
 /// reservation's device. The build is synchronous, so the index is fully resident
-/// on return and @p chunks are only read during it (the index keeps its own copy).
-/// Returned type-erased so callers need not name the cuVS index type; recover the
-/// concrete `ivf_flat::index<float, int64_t>` with `pinned_index_entry::index_as<...>()`.
+/// on return and @p batches are only read during it (the index keeps its own copy).
+/// Returned type-erased so callers need not name the cuVS index type.
 ///
-/// \param chunks    Fixed-width FLOAT32 LIST column, each holding part of the dataset vectors.
+/// The build runs on @p stream, so the index's device buffers are bound to it and
+/// are freed on it when the index is destroyed. The caller must keep @p stream
+/// alive at least as long as the returned index. Binding the reservation to this
+/// same stream (attach it before calling) is what routes the build's allocations
+/// through the reservation.
+///
+/// \param batches    Fixed-width FLOAT32 LIST column, each holding part of the dataset vectors.
 /// \param dim       Vector dimensionality.
 /// \param n_lists   IVF-Flat inverted-list count (1 <= n_lists <= n_rows).
 /// \param metric    Distance metric (must be IVF-Flat-supported, e.g. L2SqrtExpanded).
 /// \param index_mr  Reservation-backed device resource the index allocates through.
-std::unique_ptr<any_cuvs_index> build_ivf_flat_index_from_chunks(
-  std::vector<cudf::column_view> const& chunks,
+/// \param stream    Stream the build runs on; the index's buffers are bound to it.
+std::unique_ptr<any_cuvs_index> build_ivf_flat_index_from_batches(
+  std::vector<cudf::column_view> const& batches,
   std::int64_t dim,
   std::uint32_t n_lists,
   cuvs::distance::DistanceType metric,
-  rmm::device_async_resource_ref index_mr);
+  rmm::device_async_resource_ref index_mr,
+  rmm::cuda_stream_view stream);
 
 /// Flattened k-NN result from an ANN search: both columns have length @c k.
 struct ann_result {

--- a/src/include/vss/ivf_flat_index.hpp
+++ b/src/include/vss/ivf_flat_index.hpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "vss/cuvs_index_cache.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuvs/distance/distance.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+namespace sirius::vss {
+
+/// Build an IVF-Flat index from the dataset held as many separate FLOAT32 LIST
+/// @p chunks (each unsliced, gap-free, fixed width @p dim), without concatenating
+/// them into one column. This sidesteps cudf's 2^31-element per-column limit,
+/// which a full coalesce of a large dataset overflows in the LIST child.
+///
+/// Centroids are trained on the first chunk (cuVS subsamples it internally per
+/// `kmeans_trainset_fraction`); the index is then populated chunk by chunk via
+/// `ivf_flat::extend`, assigning each vector its global row id so search returns
+/// indices into the whole dataset (in @p chunks order). Same ownership contract
+/// as @ref build_ivf_flat_index: everything allocates through @p index_mr and the
+/// index is fully resident on return. @p chunks are only read during the build.
+///
+/// Ownership: the index and its build-time scratch allocates through @p index_mr,
+/// i.e., the GPU reservation's memory resource, so the whole index lives in
+/// Sirius-reserved GPU memory. The current CUDA device must already be the
+/// reservation's device. The build is synchronous, so the index is fully resident
+/// on return and @p chunks are only read during it (the index keeps its own copy).
+/// Returned type-erased so callers need not name the cuVS index type; recover the
+/// concrete `ivf_flat::index<float, int64_t>` with `pinned_index_entry::index_as<...>()`.
+///
+/// \param chunks    Fixed-width FLOAT32 LIST column, each holding part of the dataset vectors.
+/// \param dim       Vector dimensionality.
+/// \param n_lists   IVF-Flat inverted-list count (1 <= n_lists <= n_rows).
+/// \param metric    Distance metric (must be IVF-Flat-supported, e.g. L2SqrtExpanded).
+/// \param index_mr  Reservation-backed device resource the index allocates through.
+std::unique_ptr<any_cuvs_index> build_ivf_flat_index_from_chunks(
+  std::vector<cudf::column_view> const& chunks,
+  std::int64_t dim,
+  std::uint32_t n_lists,
+  cuvs::distance::DistanceType metric,
+  rmm::device_async_resource_ref index_mr);
+
+/// Flattened k-NN result from an ANN search: both columns have length @c k.
+struct ann_result {
+  std::unique_ptr<cudf::column> neighbors;  ///< INT64 row indices into the indexed dataset.
+  std::unique_ptr<cudf::column> distances;  ///< FLOAT32 distances to those rows.
+};
+
+/// Search a pinned IVF-Flat index (held type-erased in @p index) for the @p k
+/// nearest neighbors of a single query vector.
+///
+/// @p query_device points to a @p dim-length FLOAT32 vector ALREADY ON THE
+/// DEVICE (caller uploads it). Outputs are allocated through @p mr. The call is
+/// synchronous (the work stream is synchronized before returning).
+///
+/// \param index        Type-erased IVF-Flat index (throws if it is not one).
+/// \param query_device Device pointer to the [dim] FLOAT32 query vector.
+/// \param dim          Vector dimensionality (must equal the index's).
+/// \param k            Neighbors to return (1 <= k <= n_rows).
+/// \param n_probes     IVF lists to probe (accuracy/speed knob; <= n_lists).
+ann_result search_ivf_flat_index(any_cuvs_index const& index,
+                                 const float* query_device,
+                                 std::int64_t dim,
+                                 std::int64_t k,
+                                 std::uint32_t n_probes,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::device_async_resource_ref mr);
+
+}  // namespace sirius::vss

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -40,6 +40,7 @@
 #include "transparent/physical_sirius_execution.hpp"
 #include "transparent/sirius_optimizer_extension.hpp"
 #include "util/duckdb_error_message.hpp"
+#include "vss/cuvs_index_cache.hpp"
 
 #include <cudf/utilities/pinned_memory.hpp>
 
@@ -659,6 +660,10 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
   memory_manager_ = std::make_unique<sirius::memory::sirius_memory_reservation_manager>(
     config_.get_memory_space_configs());
 
+  // Session cache for pinned GPU-resident cuVS ANN indexes. Takes the memory
+  // manager so an index build can reserve its GPU footprint through Sirius.
+  cuvs_index_cache_ = std::make_unique<sirius::vss::cuvs_index_cache>(*memory_manager_);
+
   // Declare one telemetry device group per GPU so thread/queue telemetry can
   // nest under its device instead of piling up flat under the engine. The GPU
   // memory manager already reflects the configured topology.num_gpus / topology.gpu_ids
@@ -920,6 +925,11 @@ void SiriusContext::terminate()
 
   scan_manager_.reset();
 
+  // Free pinned cuVS indexes and release their GPU reservations while the
+  // memory manager is still alive. The device was synchronized just above, so
+  // no kernels are still reading the index buffers being freed here.
+  cuvs_index_cache_.reset();
+
   // Drop any remaining per-query repositories while the memory manager is still alive. The
   // downgrade executors (the only other holders of a manager reference) were stopped above, so
   // no borrower can outlive this.
@@ -1041,6 +1051,18 @@ const sirius::scan_manager::sirius_scan_manager& SiriusContext::get_scan_manager
 {
   throw_if_not_initialized();
   return *scan_manager_;
+}
+
+sirius::vss::cuvs_index_cache& SiriusContext::get_cuvs_index_cache()
+{
+  throw_if_not_initialized();
+  return *cuvs_index_cache_;
+}
+
+const sirius::vss::cuvs_index_cache& SiriusContext::get_cuvs_index_cache() const
+{
+  throw_if_not_initialized();
+  return *cuvs_index_cache_;
 }
 
 std::shared_lock<std::shared_mutex> SiriusContext::lock_pinned_table_updates()

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1784,6 +1784,10 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
       "sirius_create_ann_index requires the Sirius context to be initialized");
   }
 
+  // Required to hold the query-lifecycle slot for the whole build since the pinned entry is
+  // non-owning. The slot also serializes the current-device-resource swap the build does.
+  duckdb::SiriusContext::SlotGuard slot(*sirius_ctx, context);
+
   // --- Resolve the vector column's fixed dimensionality from the catalog. ---
   auto const qname          = QualifiedName::Parse(data.table_name);
   std::string const catalog = qname.catalog;  // empty => search path

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -110,6 +110,9 @@ extern "C" int cudaProfilerStop();
 #include "sirius_interface.hpp"
 #include "sirius_sql_rewrite.hpp"
 #include "util/segfault_backtrace.hpp"
+#include "vss/cuvs_index_cache.hpp"
+#include "vss/distance_metric.hpp"
+#include "vss/ivf_flat_index.hpp"
 #include "vss/pinned_column.hpp"
 #include "vss/vector_search.hpp"
 
@@ -1688,6 +1691,199 @@ static void SiriusSetQueryLabelFunction(ClientContext& context,
   data.finished = true;
 }
 
+struct CreateAnnIndexData : public TableFunctionData {
+  std::string table_name;
+  std::string column_name;
+  std::string index_name;                ///< management name (for a future drop_ann_index)
+  std::string index_type  = "ivf_flat";  ///< lowercased; only "ivf_flat" supported today
+  std::string metric      = "l2sq";      ///< lowercased; one of l2sq / cosine
+  std::string schema_name = "main";
+  int64_t n_lists         = 0;  ///< IVF-Flat list count; 0 = choose a default at build time
+  bool finished           = false;
+};
+
+static unique_ptr<FunctionData> SiriusCreateAnnIndexBind(ClientContext& context,
+                                                         TableFunctionBindInput& input,
+                                                         vector<LogicalType>& return_types,
+                                                         vector<string>& names)
+{
+  auto result = make_uniq<CreateAnnIndexData>();
+
+  if (input.inputs.size() < 2 || input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
+    throw BinderException(
+      "sirius_create_ann_index requires two non-NULL positional arguments: table and column");
+  }
+  result->table_name  = input.inputs[0].ToString();
+  result->column_name = input.inputs[1].ToString();
+
+  for (auto& kv : input.named_parameters) {
+    auto const key = StringUtil::Lower(kv.first);
+    if (kv.second.IsNull()) {
+      throw BinderException("sirius_create_ann_index: named parameter '" + kv.first +
+                            "' cannot be NULL");
+    }
+    if (key == "name") {
+      result->index_name = kv.second.ToString();
+    } else if (key == "metric") {
+      result->metric = StringUtil::Lower(kv.second.ToString());
+    } else if (key == "index_type") {
+      result->index_type = StringUtil::Lower(kv.second.ToString());
+    } else if (key == "n_lists") {
+      result->n_lists = kv.second.GetValue<int64_t>();
+    } else if (key == "schema_name") {
+      result->schema_name = kv.second.ToString();
+    }
+  }
+
+  if (result->index_type != "ivf_flat") {
+    throw BinderException("sirius_create_ann_index: unsupported index_type '" + result->index_type +
+                          "'; only 'ivf_flat' is supported");
+  }
+  if (result->metric != "l2sq" && result->metric != "cosine") {
+    throw BinderException("sirius_create_ann_index: metric must be one of 'l2sq', 'cosine', got '" +
+                          result->metric + "'");
+  }
+  if (result->n_lists < 0) {
+    throw BinderException("sirius_create_ann_index: n_lists must be >= 0");
+  }
+
+  // Default the management name from the index identity when not given.
+  if (result->index_name.empty()) {
+    result->index_name =
+      result->table_name + "_" + result->column_name + "_" + result->metric + "_ann";
+  }
+
+  return_types.emplace_back(LogicalType::BOOLEAN);
+  names.emplace_back("Success");
+  return std::move(result);
+}
+
+// Map the (already-validated) index_type string to its cache index_kind.
+static sirius::vss::index_kind ann_index_kind_from_type(const std::string& index_type)
+{
+  if (index_type == "ivf_flat") { return sirius::vss::index_kind::ivf_flat; }
+  throw InvalidInputException("sirius_create_ann_index: unsupported index_type '" + index_type +
+                              "'");
+}
+
+// Default IVF-Flat list count
+static std::uint32_t default_ivf_n_lists(int64_t n_rows)
+{
+  auto const approx = static_cast<std::uint32_t>(std::sqrt(static_cast<double>(n_rows)));
+  std::uint32_t n   = approx == 0 ? 1u : approx;
+  return n > 1024u ? 1024u : n;
+}
+
+static void SiriusCreateAnnIndexFunction(ClientContext& context,
+                                         TableFunctionInput& data_p,
+                                         DataChunk& output)
+{
+  auto& data = data_p.bind_data->CastNoConst<CreateAnnIndexData>();
+  if (data.finished) { return; }
+
+  nvtx3::scoped_range nvtx_range{"SiriusCreateAnnIndexFunction"};
+
+  auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  if (!sirius_ctx) {
+    throw InvalidInputException(
+      "sirius_create_ann_index requires the Sirius context to be initialized");
+  }
+
+  // --- Resolve the vector column's fixed dimensionality from the catalog. ---
+  auto const qname          = QualifiedName::Parse(data.table_name);
+  std::string const catalog = qname.catalog;  // empty => search path
+  std::string const schema  = !qname.schema.empty() ? qname.schema : data.schema_name;
+  std::string const& table  = qname.name;
+  auto& entry_base = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, catalog, schema, table);
+  auto& entry      = entry_base.Cast<DuckTableEntry>();
+  auto const& columns     = entry.GetColumns();
+  auto const schema_names = columns.GetColumnNames();
+  auto const schema_types = columns.GetColumnTypes();
+
+  std::size_t col_idx = schema_names.size();
+  for (std::size_t i = 0; i < schema_names.size(); ++i) {
+    if (schema_names[i] == data.column_name) {
+      col_idx = i;
+      break;
+    }
+  }
+  if (col_idx == schema_names.size()) {
+    throw InvalidInputException("sirius_create_ann_index: column '" + data.column_name +
+                                "' not found in table '" + data.table_name + "'");
+  }
+  auto const& col_type = schema_types[col_idx];
+  if (col_type.id() != LogicalTypeId::ARRAY ||
+      ArrayType::GetChildType(col_type).id() != LogicalTypeId::FLOAT) {
+    throw InvalidInputException("sirius_create_ann_index: column '" + data.column_name +
+                                "' must be a FLOAT[N] array column");
+  }
+  auto const dim    = static_cast<int64_t>(ArrayType::GetSize(col_type));
+  auto const metric = sirius::vss::ann_distance_type_from_metric(data.metric);
+
+  // Get the vector column onto a single GPU as one contiguous column for one cuVS index
+  auto& memory_manager = sirius_ctx->get_memory_manager();
+  auto gpu_spaces      = memory_manager.get_memory_spaces_for_tier(cucascade::memory::Tier::GPU);
+  if (gpu_spaces.empty()) {
+    throw InvalidInputException("sirius_create_ann_index: no GPU memory space available");
+  }
+  auto* target_space   = const_cast<cucascade::memory::memory_space*>(gpu_spaces[0]);
+  int const target_gpu = target_space->get_device_id();
+  rmm::cuda_set_device_raii device_guard{rmm::cuda_device_id{target_gpu}};
+
+  auto& scan_mgr  = sirius_ctx->get_scan_manager();
+  const auto* pin = scan_mgr.find_pinned_entry(entry.name);
+  if (pin == nullptr || pin->tier != cucascade::memory::Tier::GPU) {
+    throw InvalidInputException("sirius_create_ann_index: table '" + data.table_name +
+                                "' must be pinned on the GPU tier before building an index");
+  }
+
+  // Collect the vector column's GPU chunks as views:
+  // a full coalesce of a large dataset overflows cudf's 2^31-element per-column limit
+  // in the LIST child. The chunked builder feeds cuVS one chunk at a time via ivf_flat::extend.
+  auto chunk_views = sirius::vss::pinned_column_chunk_views(*pin, data.column_name, *target_space);
+
+  int64_t n_rows = 0;
+  for (auto const& v : chunk_views) {
+    n_rows += static_cast<int64_t>(v.size());
+  }
+  if (n_rows <= 0) { throw InvalidInputException("sirius_create_ann_index: empty vector column"); }
+
+  std::uint32_t n_lists =
+    data.n_lists > 0 ? static_cast<std::uint32_t>(data.n_lists) : default_ivf_n_lists(n_rows);
+  if (static_cast<int64_t>(n_lists) > n_rows) { n_lists = static_cast<std::uint32_t>(n_rows); }
+
+  // Reserve the index footprint (heuristic, over-estimated to cover build-time
+  // scratch): ~2x the stored vectors + 2x centroids + 1 MiB slack
+  std::size_t const vec_bytes =
+    static_cast<std::size_t>(n_rows) * static_cast<std::size_t>(dim) * sizeof(float);
+  std::size_t const centroid_bytes =
+    static_cast<std::size_t>(n_lists) * static_cast<std::size_t>(dim) * sizeof(float);
+  std::size_t const footprint = vec_bytes * 2 + centroid_bytes * 2 + (std::size_t{1} << 20);
+
+  auto& index_cache = sirius_ctx->get_cuvs_index_cache();
+  auto reservation  = index_cache.reserve_index_memory(footprint, target_gpu);
+
+  // Build IVF-Flat through the reservation's resource, then pin it
+  auto handle = sirius::vss::build_ivf_flat_index_from_chunks(
+    chunk_views, dim, n_lists, metric, reservation->get_memory_resource());
+  reservation->shrink_to_fit();
+
+  sirius::vss::index_metadata meta;
+  meta.kind           = ann_index_kind_from_type(data.index_type);
+  meta.table_name     = entry.name;  // catalog-resolved name (matches query-side derivation)
+  meta.column_name    = data.column_name;
+  meta.dim            = dim;
+  meta.num_rows       = n_rows;
+  meta.n_lists        = static_cast<int64_t>(n_lists);
+  meta.metric         = metric;
+  meta.reserved_bytes = reservation->size();
+  index_cache.insert(data.index_name, std::move(meta), std::move(handle), std::move(reservation));
+
+  output.SetCardinality(1);
+  output.SetValue(0, 0, Value::BOOLEAN(true));
+  data.finished = true;
+}
+
 struct SiriusVectorSearchBindData : public TableFunctionData {
   sirius::vss::vector_search_request req;
   // Output column types + trailing distance, for the host_table_chunk_reader.
@@ -1976,6 +2172,20 @@ void SiriusExtension::RegisterGPUFunctions(DatabaseInstance& instance)
     "unpin_table", {LogicalType::VARCHAR}, UnpinTableFunction, UnpinTableBind);
   CreateTableFunctionInfo unpin_table_info(unpin_table);
   catalog.CreateTableFunction(transaction, unpin_table_info);
+
+  // sirius_create_ann_index(table, column, name=>, metric=>, index_type=>, n_lists=>,
+  // schema_name=>)
+  TableFunction create_ann_index("sirius_create_ann_index",
+                                 {LogicalType::VARCHAR, LogicalType::VARCHAR},
+                                 SiriusCreateAnnIndexFunction,
+                                 SiriusCreateAnnIndexBind);
+  create_ann_index.named_parameters["name"]        = LogicalType::VARCHAR;
+  create_ann_index.named_parameters["metric"]      = LogicalType::VARCHAR;
+  create_ann_index.named_parameters["index_type"]  = LogicalType::VARCHAR;
+  create_ann_index.named_parameters["n_lists"]     = LogicalType::BIGINT;
+  create_ann_index.named_parameters["schema_name"] = LogicalType::VARCHAR;
+  CreateTableFunctionInfo create_ann_index_info(create_ann_index);
+  catalog.CreateTableFunction(transaction, create_ann_index_info);
 
   // sirius_knn_search(table, column, query, k =>, output_columns =>, metric =>,
   // schema_name =>)

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1747,12 +1747,6 @@ static unique_ptr<FunctionData> SiriusCreateAnnIndexBind(ClientContext& context,
     throw BinderException("sirius_create_ann_index: n_lists must be >= 0");
   }
 
-  // Default the management name from the index identity when not given.
-  if (result->index_name.empty()) {
-    result->index_name =
-      result->table_name + "_" + result->column_name + "_" + result->metric + "_ann";
-  }
-
   return_types.emplace_back(LogicalType::BOOLEAN);
   names.emplace_back("Success");
   return std::move(result);
@@ -1873,6 +1867,8 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
 
   sirius::vss::index_metadata meta;
   meta.kind           = ann_index_kind_from_type(data.index_type);
+  meta.catalog_name   = entry_catalog;  // resolved identity, matches the pin cache + query side
+  meta.schema_name    = entry_schema;
   meta.table_name     = entry.name;  // catalog-resolved name (matches query-side derivation)
   meta.column_name    = data.column_name;
   meta.dim            = dim;
@@ -1880,7 +1876,15 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
   meta.n_lists        = static_cast<int64_t>(n_lists);
   meta.metric         = metric;
   meta.reserved_bytes = reservation->size();
-  index_cache.insert(data.index_name, std::move(meta), std::move(handle), std::move(reservation));
+
+  // Default the management name from its identity when not given.
+  std::string index_name = data.index_name;
+  if (index_name.empty()) {
+    index_name = entry_catalog + "_" + entry_schema + "_" + entry.name + "_" + data.column_name +
+                 "_" + data.metric + "_ann";
+  }
+  index_cache.insert(
+    std::move(index_name), std::move(meta), std::move(handle), std::move(reservation));
 
   output.SetCardinality(1);
   output.SetValue(0, 0, Value::BOOLEAN(true));

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2029,6 +2029,9 @@ static unique_ptr<FunctionData> SiriusVectorSearchBind(ClientContext& context,
   if (!sirius_ctx) {
     throw InvalidInputException("sirius_knn_search requires the Sirius context to be initialized");
   }
+  // Required to hold the query-lifecycle slot for the whole build since the pinned entry is
+  // non-owning. The slot also serializes the current-device-resource swap the build does.
+  duckdb::SiriusContext::SlotGuard slot(*sirius_ctx, context);
   const auto* pin = sirius_ctx->get_scan_manager().find_pinned_entry_for_duckdb_table(
     req.catalog, req.schema, req.table_name);
   if (pin == nullptr) {

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1849,8 +1849,8 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
   // Cap n_lists in 64-bit before narrowing to uint32
   int64_t n_lists64 =
     data.n_lists > 0 ? data.n_lists : static_cast<int64_t>(default_ivf_n_lists(n_rows));
-  n_lists64 = std::min(n_lists64, n_rows);
-  n_lists64 = std::min<int64_t>(n_lists64, std::numeric_limits<std::uint32_t>::max());
+  n_lists64          = std::min(n_lists64, n_rows);
+  n_lists64          = std::min<int64_t>(n_lists64, std::numeric_limits<std::uint32_t>::max());
   auto const n_lists = static_cast<std::uint32_t>(n_lists64);
 
   // Reserve the index footprint (heuristic, over-estimated to cover build-time

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1697,7 +1697,6 @@ static void SiriusSetQueryLabelFunction(ClientContext& context,
 struct CreateAnnIndexData : public TableFunctionData {
   std::string table_name;
   std::string column_name;
-  std::string index_name;                ///< management name (for a future drop_ann_index)
   std::string index_type  = "ivf_flat";  ///< lowercased; only "ivf_flat" supported today
   std::string metric      = "l2";        ///< lowercased; one of l2 / cosine
   std::string schema_name = "main";
@@ -1735,9 +1734,7 @@ static unique_ptr<FunctionData> SiriusCreateAnnIndexBind(ClientContext& context,
       throw BinderException("sirius_create_ann_index: named parameter '" + kv.first +
                             "' cannot be NULL");
     }
-    if (key == "name") {
-      result->index_name = kv.second.ToString();
-    } else if (key == "metric") {
+    if (key == "metric") {
       result->metric = StringUtil::Lower(kv.second.ToString());
     } else if (key == "index_type") {
       result->index_type = StringUtil::Lower(kv.second.ToString());
@@ -1900,24 +1897,22 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
     dim,
     n_lists);
 
-  auto& index_cache = sirius_ctx->get_cuvs_index_cache();
-
-  // The index's management name contains the index identity and then a suffix (index's name)
-  std::string index_name = entry_catalog + "_" + entry_schema + "_" + entry.name + "_" +
-                           data.column_name + "_" + data.metric + "_ann_" +
-                           (data.index_name.empty() ? "default" : data.index_name);
+  auto& index_cache      = sirius_ctx->get_cuvs_index_cache();
+  std::string index_name = sirius::vss::build_ann_index_cache_key(
+    entry_catalog, entry_schema, entry.name, data.column_name, data.metric);
 
   // Check if there's enough memory to build the index before releasing the current one
   auto reservation      = index_cache.reserve_index_memory(footprint, target_gpu);
   bool released_first   = false;
   bool removed_existing = false;
-  // Destructive path: not enough memory to hold both indexes at once so release the current one
+  // Destructive path: not enough memory to hold all indexes so release the current one first
   if (!reservation) {
     removed_existing = index_cache.erase_by_column(
                          entry_catalog, entry_schema, entry.name, data.column_name, metric) > 0;
     released_first = true;
     reservation    = index_cache.reserve_index_memory(footprint, target_gpu);
     if (!reservation) {
+      // Still not enough memory
       auto const avail = target_space->get_available_memory();
       std::string msg =
         "sirius_create_ann_index: not enough free GPU memory to build the index for '" +
@@ -1926,6 +1921,23 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
         std::to_string(target_gpu) + ".";
       if (removed_existing) {
         msg += " The previous index for this column and metric was removed to make room.";
+      }
+      // Look for indexes on this same column under other metrics to inform users
+      auto const others =
+        index_cache.indexes_on_column(entry_catalog, entry_schema, entry.name, data.column_name);
+      if (!others.empty()) {
+        std::size_t held_bytes = 0;
+        std::string listed;
+        for (auto const& o : others) {
+          held_bytes += o.resident_bytes;
+          if (!listed.empty()) { listed += ", "; }
+          listed += std::string(sirius::vss::ann_metric_name(o.metric)) + " (~" +
+                    std::to_string(o.resident_bytes >> 20) + " MiB)";
+        }
+        msg += " Other indexes on this column are still holding ~" +
+               std::to_string(held_bytes >> 20) + " MiB of GPU memory [" + listed +
+               "]; drop one with sirius_drop_ann_index('" + data.table_name + "', '" +
+               data.column_name + "', metric => ...) to free it.";
       }
       throw InvalidInputException(msg);
     }
@@ -2003,6 +2015,102 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
 
   output.SetCardinality(1);
   output.SetValue(0, 0, Value::BOOLEAN(true));
+  gstate.finished = true;
+}
+
+struct DropAnnIndexData : public TableFunctionData {
+  std::string table_name;
+  std::string column_name;
+  std::string schema_name = "main";
+  std::string metric;       ///< lowercased l2 / cosine; only read when has_metric
+  bool has_metric = false;  ///< true if a metric was given (drop just that one)
+};
+
+// Per-execution state
+struct DropAnnIndexGlobalState : public GlobalTableFunctionState {
+  bool finished = false;
+};
+
+static unique_ptr<GlobalTableFunctionState> SiriusDropAnnIndexInit(ClientContext& context,
+                                                                   TableFunctionInitInput& input)
+{
+  return make_uniq<DropAnnIndexGlobalState>();
+}
+
+static unique_ptr<FunctionData> SiriusDropAnnIndexBind(ClientContext& context,
+                                                       TableFunctionBindInput& input,
+                                                       vector<LogicalType>& return_types,
+                                                       vector<string>& names)
+{
+  auto result = make_uniq<DropAnnIndexData>();
+
+  if (input.inputs.size() < 2 || input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
+    throw BinderException(
+      "sirius_drop_ann_index requires two non-NULL positional arguments: table and column");
+  }
+  result->table_name  = input.inputs[0].ToString();
+  result->column_name = input.inputs[1].ToString();
+
+  for (auto& kv : input.named_parameters) {
+    auto const key = StringUtil::Lower(kv.first);
+    if (kv.second.IsNull()) {
+      throw BinderException("sirius_drop_ann_index: named parameter '" + kv.first +
+                            "' cannot be NULL");
+    }
+    if (key == "metric") {
+      result->has_metric = true;
+      result->metric     = StringUtil::Lower(kv.second.ToString());
+    } else if (key == "schema_name") {
+      result->schema_name = kv.second.ToString();
+    }
+  }
+
+  // A given metric drops just that index; omitting it drops every metric on the column.
+  if (result->has_metric && result->metric != "l2" && result->metric != "cosine") {
+    throw BinderException("sirius_drop_ann_index: metric must be one of 'l2', 'cosine', got '" +
+                          result->metric + "'");
+  }
+
+  return_types.emplace_back(LogicalType::BOOLEAN);
+  names.emplace_back("Dropped");
+  return std::move(result);
+}
+
+static void SiriusDropAnnIndexFunction(ClientContext& context,
+                                       TableFunctionInput& data_p,
+                                       DataChunk& output)
+{
+  auto& data   = data_p.bind_data->CastNoConst<DropAnnIndexData>();
+  auto& gstate = data_p.global_state->Cast<DropAnnIndexGlobalState>();
+  if (gstate.finished) { return; }
+
+  auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  if (!sirius_ctx) {
+    throw InvalidInputException(
+      "sirius_drop_ann_index requires the Sirius context to be initialized");
+  }
+
+  // Hold the query-lifecycle slot while the registry is read and mutated
+  duckdb::SiriusContext::SlotGuard slot(*sirius_ctx, context);
+
+  auto const qname          = QualifiedName::Parse(data.table_name);
+  std::string const catalog = qname.catalog;  // empty => search path
+  std::string const schema  = !qname.schema.empty() ? qname.schema : data.schema_name;
+  std::string const& table  = qname.name;
+  auto& entry_base = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, catalog, schema, table);
+  auto& entry      = entry_base.Cast<DuckTableEntry>();
+  auto& entry_catalog = entry.ParentCatalog().GetName();
+  auto& entry_schema  = entry.ParentSchema().name;
+
+  std::optional<cuvs::distance::DistanceType> metric;
+  if (data.has_metric) { metric = sirius::vss::ann_distance_type_from_metric(data.metric); }
+
+  auto& index_cache = sirius_ctx->get_cuvs_index_cache();
+  std::size_t const removed =
+    index_cache.erase_by_column(entry_catalog, entry_schema, entry.name, data.column_name, metric);
+
+  output.SetCardinality(1);
+  output.SetValue(0, 0, Value::BOOLEAN(removed > 0));
   gstate.finished = true;
 }
 
@@ -2302,20 +2410,29 @@ void SiriusExtension::RegisterGPUFunctions(DatabaseInstance& instance)
   CreateTableFunctionInfo unpin_table_info(unpin_table);
   catalog.CreateTableFunction(transaction, unpin_table_info);
 
-  // sirius_create_ann_index(table, column, name=>, metric=>, index_type=>, n_lists=>,
-  // schema_name=>)
+  // sirius_create_ann_index(table, column, metric=>, index_type=>, n_lists=>, schema_name=>)
   TableFunction create_ann_index("sirius_create_ann_index",
                                  {LogicalType::VARCHAR, LogicalType::VARCHAR},
                                  SiriusCreateAnnIndexFunction,
                                  SiriusCreateAnnIndexBind,
                                  SiriusCreateAnnIndexInit);
-  create_ann_index.named_parameters["name"]        = LogicalType::VARCHAR;
   create_ann_index.named_parameters["metric"]      = LogicalType::VARCHAR;
   create_ann_index.named_parameters["index_type"]  = LogicalType::VARCHAR;
   create_ann_index.named_parameters["n_lists"]     = LogicalType::BIGINT;
   create_ann_index.named_parameters["schema_name"] = LogicalType::VARCHAR;
   CreateTableFunctionInfo create_ann_index_info(create_ann_index);
   catalog.CreateTableFunction(transaction, create_ann_index_info);
+
+  // sirius_drop_ann_index(table, column, metric =>, schema_name =>)
+  TableFunction drop_ann_index("sirius_drop_ann_index",
+                               {LogicalType::VARCHAR, LogicalType::VARCHAR},
+                               SiriusDropAnnIndexFunction,
+                               SiriusDropAnnIndexBind,
+                               SiriusDropAnnIndexInit);
+  drop_ann_index.named_parameters["metric"]      = LogicalType::VARCHAR;
+  drop_ann_index.named_parameters["schema_name"] = LogicalType::VARCHAR;
+  CreateTableFunctionInfo drop_ann_index_info(drop_ann_index);
+  catalog.CreateTableFunction(transaction, drop_ann_index_info);
 
   // sirius_knn_search(table, column, query, k =>, output_columns =>, metric =>,
   // schema_name =>)

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1850,7 +1850,7 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
                                 "' must be pinned on the GPU tier before building an index");
   }
 
-  // Collect the vector column's GPU chunks as views:
+  // Collect the vector column's batches as views:
   // a full coalesce of a large dataset overflows cudf's 2^31-element per-column limit
   // in the LIST child. The chunked builder feeds cuVS one chunk at a time via ivf_flat::extend.
   auto chunk_views = sirius::vss::pinned_column_chunk_views(*pin, data.column_name, *target_space);
@@ -1868,6 +1868,20 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
   n_lists64          = std::min<int64_t>(n_lists64, std::numeric_limits<std::uint32_t>::max());
   auto const n_lists = static_cast<std::uint32_t>(n_lists64);
 
+  // Reject when the largest batch is smaller than n_lists here so a bad n_lists never
+  // removes the existing index.
+  int64_t max_chunk_rows = 0;
+  for (auto const& v : chunk_views) {
+    max_chunk_rows = std::max(max_chunk_rows, static_cast<int64_t>(v.size()));
+  }
+  if (std::cmp_greater(n_lists, max_chunk_rows)) {
+    throw InvalidInputException(
+      "sirius_create_ann_index: n_lists=" + std::to_string(n_lists) +
+      " exceeds the largest batch size (" + std::to_string(max_chunk_rows) +
+      " rows) available to train IVF-Flat centroids; lower n_lists. The existing "
+      "index for this column, if any, was left in place.");
+  }
+
   // Reserve the index footprint (heuristic, over-estimated to cover build-time
   // scratch): ~2x the stored vectors + 2x centroids + 1 MiB slack
   std::size_t const vec_bytes =
@@ -1878,27 +1892,58 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
 
   auto& index_cache = sirius_ctx->get_cuvs_index_cache();
 
-  // Drop any existing index before reserving the new one
-  index_cache.erase_by_column(entry_catalog, entry_schema, entry.name, data.column_name, metric);
-  auto reservation = index_cache.reserve_index_memory(footprint, target_gpu);
+  // The index's management name contains the index identity and then a suffix (index's name)
+  std::string index_name = entry_catalog + "_" + entry_schema + "_" + entry.name + "_" +
+                           data.column_name + "_" + data.metric + "_ann_" +
+                           (data.index_name.empty() ? "default" : data.index_name);
+
+  // Check if there's enough memory to build the index before releasing the current one
+  auto reservation      = index_cache.reserve_index_memory(footprint, target_gpu);
+  bool released_first   = false;
+  bool removed_existing = false;
+  // Destructive path: not enough memory to hold both indexes at once so release the current one
   if (!reservation) {
-    auto const avail = target_space->get_available_memory();
-    throw InvalidInputException(
-      "sirius_create_ann_index: not enough free GPU memory to build the index for '" + entry.name +
-      "." + data.column_name + "': need ~" + std::to_string(footprint >> 20) + " MiB, only ~" +
-      std::to_string(avail >> 20) + " MiB free on GPU " + std::to_string(target_gpu));
+    removed_existing = index_cache.erase_by_column(
+                         entry_catalog, entry_schema, entry.name, data.column_name, metric) > 0;
+    released_first = true;
+    reservation    = index_cache.reserve_index_memory(footprint, target_gpu);
+    if (!reservation) {
+      auto const avail = target_space->get_available_memory();
+      std::string msg =
+        "sirius_create_ann_index: not enough free GPU memory to build the index for '" +
+        entry.name + "." + data.column_name + "': need ~" + std::to_string(footprint >> 20) +
+        " MiB, only ~" + std::to_string(avail >> 20) + " MiB free on GPU " +
+        std::to_string(target_gpu) + ".";
+      if (removed_existing) {
+        msg += " The previous index for this column and metric was removed to make room.";
+      }
+      throw InvalidInputException(msg);
+    }
   }
 
-  // Build IVF-Flat through the reservation's resource, then pin it
-  auto handle = sirius::vss::build_ivf_flat_index_from_chunks(
-    chunk_views, dim, n_lists, metric, reservation->get_memory_resource());
+  // Build IVF-Flat through the reservation's resource
+  std::unique_ptr<sirius::vss::any_cuvs_index> handle;
+  try {
+    handle = sirius::vss::build_ivf_flat_index_from_chunks(
+      chunk_views, dim, n_lists, metric, reservation->get_memory_resource());
+  } catch (std::exception const& e) {
+    if (removed_existing) {
+      throw InvalidInputException(
+        std::string("sirius_create_ann_index: failed to build the index for '") + entry.name + "." +
+        data.column_name +
+        "' after the previous index was removed to make room, so this column and metric now has "
+        "no index. Underlying error: " +
+        e.what());
+    }
+    throw;
+  }
   reservation->shrink_to_fit();
 
   sirius::vss::index_metadata meta;
   meta.kind           = ann_index_kind_from_type(data.index_type);
-  meta.catalog_name   = entry_catalog;  // resolved identity, matches the pin cache + query side
+  meta.catalog_name   = entry_catalog;
   meta.schema_name    = entry_schema;
-  meta.table_name     = entry.name;  // catalog-resolved name (matches query-side derivation)
+  meta.table_name     = entry.name;
   meta.column_name    = data.column_name;
   meta.dim            = dim;
   meta.num_rows       = n_rows;
@@ -1906,11 +1951,9 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
   meta.metric         = metric;
   meta.reserved_bytes = reservation->size();
 
-  // Default the management name from its identity when not given.
-  std::string index_name = data.index_name;
-  if (index_name.empty()) {
-    index_name = entry_catalog + "_" + entry_schema + "_" + entry.name + "_" + data.column_name +
-                 "_" + data.metric + "_ann";
+  // Non-destructive path: remove the old one now that the new one is built
+  if (!released_first) {
+    index_cache.erase_by_column(entry_catalog, entry_schema, entry.name, data.column_name, metric);
   }
   index_cache.insert(
     std::move(index_name), std::move(meta), std::move(handle), std::move(reservation));

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1884,13 +1884,8 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
       "index for this column, if any, was left in place.");
   }
 
-  // Reserve the index footprint: ~2x the stored vectors + 2x centroids + 1 MiB slack
-  // NOTE: this is very conservative and can be tightened
-  std::size_t const vec_bytes =
-    static_cast<std::size_t>(n_rows) * static_cast<std::size_t>(dim) * sizeof(float);
-  std::size_t const centroid_bytes =
-    static_cast<std::size_t>(n_lists) * static_cast<std::size_t>(dim) * sizeof(float);
-  std::size_t const footprint = vec_bytes * 2 + centroid_bytes * 2 + (std::size_t{1} << 20);
+  // Index building footprint reservation
+  std::size_t const footprint = sirius::vss::ivf_flat_reservation_bytes(n_rows, dim, n_lists);
 
   [[maybe_unused]] auto* pool = target_space->get_memory_resource_of<cucascade::memory::Tier::GPU>();
   SIRIUS_LOG_DEBUG(

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1696,7 +1696,7 @@ struct CreateAnnIndexData : public TableFunctionData {
   std::string column_name;
   std::string index_name;                ///< management name (for a future drop_ann_index)
   std::string index_type  = "ivf_flat";  ///< lowercased; only "ivf_flat" supported today
-  std::string metric      = "l2sq";      ///< lowercased; one of l2sq / cosine
+  std::string metric      = "l2";        ///< lowercased; one of l2 / cosine
   std::string schema_name = "main";
   int64_t n_lists         = 0;  ///< IVF-Flat list count; 0 = choose a default at build time
   bool finished           = false;
@@ -1739,8 +1739,8 @@ static unique_ptr<FunctionData> SiriusCreateAnnIndexBind(ClientContext& context,
     throw BinderException("sirius_create_ann_index: unsupported index_type '" + result->index_type +
                           "'; only 'ivf_flat' is supported");
   }
-  if (result->metric != "l2sq" && result->metric != "cosine") {
-    throw BinderException("sirius_create_ann_index: metric must be one of 'l2sq', 'cosine', got '" +
+  if (result->metric != "l2" && result->metric != "cosine") {
+    throw BinderException("sirius_create_ann_index: metric must be one of 'l2', 'cosine', got '" +
                           result->metric + "'");
   }
   if (result->n_lists < 0) {
@@ -1796,6 +1796,8 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
   std::string const& table  = qname.name;
   auto& entry_base = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, catalog, schema, table);
   auto& entry      = entry_base.Cast<DuckTableEntry>();
+  auto& entry_catalog     = entry.ParentCatalog().GetName();
+  auto& entry_schema      = entry.ParentSchema().name;
   auto const& columns     = entry.GetColumns();
   auto const schema_names = columns.GetColumnNames();
   auto const schema_types = columns.GetColumnTypes();
@@ -1830,8 +1832,9 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
   int const target_gpu = target_space->get_device_id();
   rmm::cuda_set_device_raii device_guard{rmm::cuda_device_id{target_gpu}};
 
-  auto& scan_mgr  = sirius_ctx->get_scan_manager();
-  const auto* pin = scan_mgr.find_pinned_entry(entry.name);
+  auto& scan_mgr = sirius_ctx->get_scan_manager();
+  const auto* pin =
+    scan_mgr.find_pinned_entry_for_duckdb_table(entry_catalog, entry_schema, entry.name);
   if (pin == nullptr || pin->tier != cucascade::memory::Tier::GPU) {
     throw InvalidInputException("sirius_create_ann_index: table '" + data.table_name +
                                 "' must be pinned on the GPU tier before building an index");

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1887,7 +1887,8 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
   // Index building footprint reservation
   std::size_t const footprint = sirius::vss::ivf_flat_reservation_bytes(n_rows, dim, n_lists);
 
-  [[maybe_unused]] auto* pool = target_space->get_memory_resource_of<cucascade::memory::Tier::GPU>();
+  [[maybe_unused]] auto* pool =
+    target_space->get_memory_resource_of<cucascade::memory::Tier::GPU>();
   SIRIUS_LOG_DEBUG(
     "[ann_index] build begin, GPU:{} allocated={} bytes reserved={} bytes footprint={} bytes "
     "(rows={} dim={} n_lists={})",
@@ -1977,7 +1978,7 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
   meta.n_lists      = static_cast<int64_t>(n_lists);
   meta.metric       = metric;
   // Resident index footprint, read while the reservation still tracks the arena.
-  meta.resident_bytes                = allocator->get_allocated_bytes(build_stream.view());
+  meta.resident_bytes = allocator->get_allocated_bytes(build_stream.view());
   [[maybe_unused]] std::size_t const build_peak_bytes =
     allocator->get_peak_allocated_bytes(build_stream.view());
 

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -31,12 +31,14 @@
 
 #include <nvtx3/nvtx3.hpp>
 
+#include <absl/cleanup/cleanup.h>
 #include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/memory/common.hpp>
 #include <cucascade/memory/memory_reservation.hpp>
 #include <cucascade/memory/memory_space.hpp>
+#include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 
 // Forward-declare CUDA profiler API functions (linked via libcudart).
 extern "C" int cudaProfilerStart();
@@ -1882,13 +1884,25 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
       "index for this column, if any, was left in place.");
   }
 
-  // Reserve the index footprint (heuristic, over-estimated to cover build-time
-  // scratch): ~2x the stored vectors + 2x centroids + 1 MiB slack
+  // Reserve the index footprint: ~2x the stored vectors + 2x centroids + 1 MiB slack
+  // NOTE: this is very conservative and can be tightened
   std::size_t const vec_bytes =
     static_cast<std::size_t>(n_rows) * static_cast<std::size_t>(dim) * sizeof(float);
   std::size_t const centroid_bytes =
     static_cast<std::size_t>(n_lists) * static_cast<std::size_t>(dim) * sizeof(float);
   std::size_t const footprint = vec_bytes * 2 + centroid_bytes * 2 + (std::size_t{1} << 20);
+
+  [[maybe_unused]] auto* pool = target_space->get_memory_resource_of<cucascade::memory::Tier::GPU>();
+  SIRIUS_LOG_DEBUG(
+    "[ann_index] build begin, GPU:{} allocated={} bytes reserved={} bytes footprint={} bytes "
+    "(rows={} dim={} n_lists={})",
+    target_gpu,
+    pool ? pool->get_total_allocated_bytes() : 0,
+    pool ? pool->get_total_reserved_bytes() : 0,
+    footprint,
+    n_rows,
+    dim,
+    n_lists);
 
   auto& index_cache = sirius_ctx->get_cuvs_index_cache();
 
@@ -1921,11 +1935,30 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
     }
   }
 
-  // Build IVF-Flat through the reservation's resource
+  // Bind the reservation to the build stream for the build only. The reservation
+  // is released after the build, so the index is just ordinary allocated GPU memory.
+  rmm::cuda_stream build_stream;
+  auto* allocator = reservation->get_memory_resource_of<cucascade::memory::Tier::GPU>();
+  if (allocator == nullptr ||
+      !allocator->attach_reservation_to_tracker(build_stream.view(), std::move(reservation))) {
+    throw InvalidInputException(
+      "sirius_create_ann_index: failed to bind the index build to its GPU reservation");
+  }
+  // Release the reservation whether the build succeeds or throws. On release the
+  // arena hands back its unused slack and keeps the resident index accounted.
+  absl::Cleanup reset_reservation = [allocator, &build_stream] {
+    allocator->reset_stream_reservation(build_stream.view());
+  };
+
+  // Build IVF-Flat on the build stream
   std::unique_ptr<sirius::vss::any_cuvs_index> handle;
   try {
-    handle = sirius::vss::build_ivf_flat_index_from_chunks(
-      chunk_views, dim, n_lists, metric, reservation->get_memory_resource());
+    handle = sirius::vss::build_ivf_flat_index_from_batches(chunk_views,
+                                                            dim,
+                                                            n_lists,
+                                                            metric,
+                                                            target_space->get_default_allocator(),
+                                                            build_stream.view());
   } catch (std::exception const& e) {
     if (removed_existing) {
       throw InvalidInputException(
@@ -1937,26 +1970,40 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
     }
     throw;
   }
-  reservation->shrink_to_fit();
 
   sirius::vss::index_metadata meta;
-  meta.kind           = ann_index_kind_from_type(data.index_type);
-  meta.catalog_name   = entry_catalog;
-  meta.schema_name    = entry_schema;
-  meta.table_name     = entry.name;
-  meta.column_name    = data.column_name;
-  meta.dim            = dim;
-  meta.num_rows       = n_rows;
-  meta.n_lists        = static_cast<int64_t>(n_lists);
-  meta.metric         = metric;
-  meta.reserved_bytes = reservation->size();
+  meta.kind         = ann_index_kind_from_type(data.index_type);
+  meta.catalog_name = entry_catalog;
+  meta.schema_name  = entry_schema;
+  meta.table_name   = entry.name;
+  meta.column_name  = data.column_name;
+  meta.dim          = dim;
+  meta.num_rows     = n_rows;
+  meta.n_lists      = static_cast<int64_t>(n_lists);
+  meta.metric       = metric;
+  // Resident index footprint, read while the reservation still tracks the arena.
+  meta.resident_bytes                = allocator->get_allocated_bytes(build_stream.view());
+  [[maybe_unused]] std::size_t const build_peak_bytes =
+    allocator->get_peak_allocated_bytes(build_stream.view());
+
+  // Release the reservation before the build stream moves into the cache.
+  std::move(reset_reservation).Invoke();
+
+  SIRIUS_LOG_DEBUG(
+    "[ann_index] build end, GPU:{} allocated={} bytes reserved={} bytes index_footprint={} bytes "
+    "build_peak={} bytes",
+    target_gpu,
+    allocator->get_total_allocated_bytes(),
+    allocator->get_total_reserved_bytes(),
+    meta.resident_bytes,
+    build_peak_bytes);
 
   // Non-destructive path: remove the old one now that the new one is built
   if (!released_first) {
     index_cache.erase_by_column(entry_catalog, entry_schema, entry.name, data.column_name, metric);
   }
   index_cache.insert(
-    std::move(index_name), std::move(meta), std::move(handle), std::move(reservation));
+    std::move(index_name), std::move(meta), std::move(handle), std::move(build_stream));
 
   output.SetCardinality(1);
   output.SetValue(0, 0, Value::BOOLEAN(true));

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -140,6 +140,7 @@ extern "C" int cudaProfilerStop();
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
 #include <span>
 #include <string_view>
 #include <unordered_map>
@@ -1845,9 +1846,12 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
   }
   if (n_rows <= 0) { throw InvalidInputException("sirius_create_ann_index: empty vector column"); }
 
-  std::uint32_t n_lists =
-    data.n_lists > 0 ? static_cast<std::uint32_t>(data.n_lists) : default_ivf_n_lists(n_rows);
-  if (static_cast<int64_t>(n_lists) > n_rows) { n_lists = static_cast<std::uint32_t>(n_rows); }
+  // Cap n_lists in 64-bit before narrowing to uint32
+  int64_t n_lists64 =
+    data.n_lists > 0 ? data.n_lists : static_cast<int64_t>(default_ivf_n_lists(n_rows));
+  n_lists64 = std::min(n_lists64, n_rows);
+  n_lists64 = std::min<int64_t>(n_lists64, std::numeric_limits<std::uint32_t>::max());
+  auto const n_lists = static_cast<std::uint32_t>(n_lists64);
 
   // Reserve the index footprint (heuristic, over-estimated to cover build-time
   // scratch): ~2x the stored vectors + 2x centroids + 1 MiB slack

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1700,8 +1700,18 @@ struct CreateAnnIndexData : public TableFunctionData {
   std::string metric      = "l2";        ///< lowercased; one of l2 / cosine
   std::string schema_name = "main";
   int64_t n_lists         = 0;  ///< IVF-Flat list count; 0 = choose a default at build time
-  bool finished           = false;
 };
+
+// Per-execution state
+struct CreateAnnIndexGlobalState : public GlobalTableFunctionState {
+  bool finished = false;
+};
+
+static unique_ptr<GlobalTableFunctionState> SiriusCreateAnnIndexInit(ClientContext& context,
+                                                                     TableFunctionInitInput& input)
+{
+  return make_uniq<CreateAnnIndexGlobalState>();
+}
 
 static unique_ptr<FunctionData> SiriusCreateAnnIndexBind(ClientContext& context,
                                                          TableFunctionBindInput& input,
@@ -1773,8 +1783,9 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
                                          TableFunctionInput& data_p,
                                          DataChunk& output)
 {
-  auto& data = data_p.bind_data->CastNoConst<CreateAnnIndexData>();
-  if (data.finished) { return; }
+  auto& data   = data_p.bind_data->CastNoConst<CreateAnnIndexData>();
+  auto& gstate = data_p.global_state->Cast<CreateAnnIndexGlobalState>();
+  if (gstate.finished) { return; }
 
   nvtx3::scoped_range nvtx_range{"SiriusCreateAnnIndexFunction"};
 
@@ -1906,7 +1917,7 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
 
   output.SetCardinality(1);
   output.SetValue(0, 0, Value::BOOLEAN(true));
-  data.finished = true;
+  gstate.finished = true;
 }
 
 struct SiriusVectorSearchBindData : public TableFunctionData {
@@ -2203,7 +2214,8 @@ void SiriusExtension::RegisterGPUFunctions(DatabaseInstance& instance)
   TableFunction create_ann_index("sirius_create_ann_index",
                                  {LogicalType::VARCHAR, LogicalType::VARCHAR},
                                  SiriusCreateAnnIndexFunction,
-                                 SiriusCreateAnnIndexBind);
+                                 SiriusCreateAnnIndexBind,
+                                 SiriusCreateAnnIndexInit);
   create_ann_index.named_parameters["name"]        = LogicalType::VARCHAR;
   create_ann_index.named_parameters["metric"]      = LogicalType::VARCHAR;
   create_ann_index.named_parameters["index_type"]  = LogicalType::VARCHAR;

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2105,6 +2105,10 @@ static unique_ptr<GlobalTableFunctionState> SiriusVectorSearchInit(ClientContext
     throw InvalidInputException("sirius_knn_search requires the Sirius context to be initialized");
   }
 
+  // Required to hold the query-lifecycle slot for the whole build since the pinned entry is
+  // non-owning. The slot also serializes the current-device-resource swap the build does.
+  duckdb::SiriusContext::SlotGuard slot(*sirius_ctx, context);
+
   auto state       = make_uniq<SiriusVectorSearchGlobalState>();
   state->host_repr = sirius::vss::run_vector_search(*sirius_ctx, bind_data.req);
   state->reader    = std::make_unique<sirius::op::result::host_table_chunk_reader>(

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1858,7 +1858,17 @@ static void SiriusCreateAnnIndexFunction(ClientContext& context,
   std::size_t const footprint = vec_bytes * 2 + centroid_bytes * 2 + (std::size_t{1} << 20);
 
   auto& index_cache = sirius_ctx->get_cuvs_index_cache();
-  auto reservation  = index_cache.reserve_index_memory(footprint, target_gpu);
+
+  // Drop any existing index before reserving the new one
+  index_cache.erase_by_column(entry_catalog, entry_schema, entry.name, data.column_name, metric);
+  auto reservation = index_cache.reserve_index_memory(footprint, target_gpu);
+  if (!reservation) {
+    auto const avail = target_space->get_available_memory();
+    throw InvalidInputException(
+      "sirius_create_ann_index: not enough free GPU memory to build the index for '" + entry.name +
+      "." + data.column_name + "': need ~" + std::to_string(footprint >> 20) + " MiB, only ~" +
+      std::to_string(avail >> 20) + " MiB free on GPU " + std::to_string(target_gpu));
+  }
 
   // Build IVF-Flat through the reservation's resource, then pin it
   auto handle = sirius::vss::build_ivf_flat_index_from_chunks(

--- a/src/vss/cuvs_index_cache.cpp
+++ b/src/vss/cuvs_index_cache.cpp
@@ -20,6 +20,7 @@
 #include <cucascade/memory/memory_reservation.hpp>
 #include <cucascade/memory/memory_reservation_manager.hpp>
 
+#include <optional>
 #include <utility>
 
 namespace sirius::vss {
@@ -106,6 +107,23 @@ std::shared_ptr<const pinned_index_entry> cuvs_index_cache::find_by_column(
   return nullptr;
 }
 
+std::vector<index_metadata> cuvs_index_cache::indexes_on_column(std::string_view catalog,
+                                                                std::string_view schema,
+                                                                std::string_view table,
+                                                                std::string_view column) const
+{
+  std::scoped_lock lock(_mutex);
+  std::vector<index_metadata> out;
+  for (auto const& kv : _entries) {
+    auto const& meta = kv.second->meta;
+    if (meta.catalog_name == catalog && meta.schema_name == schema && meta.table_name == table &&
+        meta.column_name == column) {
+      out.push_back(meta);
+    }
+  }
+  return out;
+}
+
 bool cuvs_index_cache::contains(std::string_view name) const
 {
   std::scoped_lock lock(_mutex);
@@ -122,15 +140,17 @@ std::size_t cuvs_index_cache::erase_by_column(std::string_view catalog,
                                               std::string_view schema,
                                               std::string_view table,
                                               std::string_view column,
-                                              cuvs::distance::DistanceType metric)
+                                              std::optional<cuvs::distance::DistanceType> metric)
 {
   std::scoped_lock lock(_mutex);
-  auto const wanted   = canonical_metric(metric);
+  // With a metric, match that one canonically; with none, match every metric.
+  std::optional<cuvs::distance::DistanceType> const wanted =
+    metric ? std::optional{canonical_metric(*metric)} : std::nullopt;
   std::size_t removed = 0;
   for (auto it = _entries.begin(); it != _entries.end();) {
     auto const& meta = it->second->meta;
     if (meta.catalog_name == catalog && meta.schema_name == schema && meta.table_name == table &&
-        meta.column_name == column && canonical_metric(meta.metric) == wanted) {
+        meta.column_name == column && (!wanted || canonical_metric(meta.metric) == *wanted)) {
       it = _entries.erase(it);
       ++removed;
     } else {

--- a/src/vss/cuvs_index_cache.cpp
+++ b/src/vss/cuvs_index_cache.cpp
@@ -55,6 +55,19 @@ cuvs_index_cache::cuvs_index_cache(
 // the header) is destroyed here, where cucascade::memory::reservation is complete.
 cuvs_index_cache::~cuvs_index_cache() = default;
 
+// Explicit move assignment op
+pinned_index_entry& pinned_index_entry::operator=(pinned_index_entry&& other) noexcept
+{
+  if (this != &other) {
+    index.reset();
+    reservation.reset();
+    meta        = std::move(other.meta);
+    reservation = std::move(other.reservation);
+    index       = std::move(other.index);
+  }
+  return *this;
+}
+
 std::unique_ptr<cucascade::memory::reservation> cuvs_index_cache::reserve_index_memory(
   std::size_t bytes, int preferred_gpu)
 {

--- a/src/vss/cuvs_index_cache.cpp
+++ b/src/vss/cuvs_index_cache.cpp
@@ -90,13 +90,18 @@ std::shared_ptr<const pinned_index_entry> cuvs_index_cache::find(std::string_vie
 }
 
 std::shared_ptr<const pinned_index_entry> cuvs_index_cache::find_by_column(
-  std::string_view table, std::string_view column, cuvs::distance::DistanceType metric) const
+  std::string_view catalog,
+  std::string_view schema,
+  std::string_view table,
+  std::string_view column,
+  cuvs::distance::DistanceType metric) const
 {
   std::lock_guard<std::mutex> lock(_mutex);
   auto const wanted = canonical_metric(metric);
   for (auto const& kv : _entries) {
     auto const& entry = kv.second;
-    if (entry->meta.table_name == table && entry->meta.column_name == column &&
+    if (entry->meta.catalog_name == catalog && entry->meta.schema_name == schema &&
+        entry->meta.table_name == table && entry->meta.column_name == column &&
         canonical_metric(entry->meta.metric) == wanted) {
       return entry;
     }

--- a/src/vss/cuvs_index_cache.cpp
+++ b/src/vss/cuvs_index_cache.cpp
@@ -51,8 +51,6 @@ cuvs_index_cache::cuvs_index_cache(
 {
 }
 
-// Out-of-line so pinned_index_entry's reservation (a forward-declared type in
-// the header) is destroyed here, where cucascade::memory::reservation is complete.
 cuvs_index_cache::~cuvs_index_cache() = default;
 
 std::unique_ptr<cucascade::memory::reservation> cuvs_index_cache::reserve_index_memory(
@@ -70,12 +68,12 @@ std::unique_ptr<cucascade::memory::reservation> cuvs_index_cache::reserve_index_
 void cuvs_index_cache::insert(std::string name,
                               index_metadata meta,
                               std::unique_ptr<any_cuvs_index> index,
-                              std::unique_ptr<cucascade::memory::reservation> reservation)
+                              rmm::cuda_stream build_stream)
 {
-  auto entry         = std::make_shared<pinned_index_entry>();
-  entry->meta        = std::move(meta);
-  entry->index       = std::move(index);
-  entry->reservation = std::move(reservation);
+  auto entry          = std::make_shared<pinned_index_entry>();
+  entry->meta         = std::move(meta);
+  entry->build_stream = std::move(build_stream);
+  entry->index        = std::move(index);
 
   std::scoped_lock lock(_mutex);
   _entries[std::move(name)] = std::move(entry);

--- a/src/vss/cuvs_index_cache.cpp
+++ b/src/vss/cuvs_index_cache.cpp
@@ -77,13 +77,13 @@ void cuvs_index_cache::insert(std::string name,
   entry->index       = std::move(index);
   entry->reservation = std::move(reservation);
 
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::scoped_lock lock(_mutex);
   _entries[std::move(name)] = std::move(entry);
 }
 
 std::shared_ptr<const pinned_index_entry> cuvs_index_cache::find(std::string_view name) const
 {
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::scoped_lock lock(_mutex);
   auto it = _entries.find(std::string(name));
   return it == _entries.end() ? nullptr : it->second;
 }
@@ -95,7 +95,7 @@ std::shared_ptr<const pinned_index_entry> cuvs_index_cache::find_by_column(
   std::string_view column,
   cuvs::distance::DistanceType metric) const
 {
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::scoped_lock lock(_mutex);
   auto const wanted = canonical_metric(metric);
   for (auto const& kv : _entries) {
     auto const& entry = kv.second;
@@ -110,13 +110,13 @@ std::shared_ptr<const pinned_index_entry> cuvs_index_cache::find_by_column(
 
 bool cuvs_index_cache::contains(std::string_view name) const
 {
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::scoped_lock lock(_mutex);
   return _entries.contains(std::string(name));
 }
 
 bool cuvs_index_cache::erase(std::string_view name)
 {
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::scoped_lock lock(_mutex);
   return _entries.erase(std::string(name)) > 0;
 }
 
@@ -126,7 +126,7 @@ std::size_t cuvs_index_cache::erase_by_column(std::string_view catalog,
                                               std::string_view column,
                                               cuvs::distance::DistanceType metric)
 {
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::scoped_lock lock(_mutex);
   auto const wanted   = canonical_metric(metric);
   std::size_t removed = 0;
   for (auto it = _entries.begin(); it != _entries.end();) {
@@ -144,13 +144,13 @@ std::size_t cuvs_index_cache::erase_by_column(std::string_view catalog,
 
 void cuvs_index_cache::clear()
 {
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::scoped_lock lock(_mutex);
   _entries.clear();
 }
 
 std::size_t cuvs_index_cache::size() const
 {
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::scoped_lock lock(_mutex);
   return _entries.size();
 }
 

--- a/src/vss/cuvs_index_cache.cpp
+++ b/src/vss/cuvs_index_cache.cpp
@@ -60,12 +60,11 @@ std::unique_ptr<cucascade::memory::reservation> cuvs_index_cache::reserve_index_
 {
   using namespace cucascade::memory;
   if (preferred_gpu >= 0) {
-    any_memory_space_in_tier_with_preference strategy(Tier::GPU,
-                                                      static_cast<std::size_t>(preferred_gpu));
-    return _reservation_manager.request_reservation(strategy, bytes);
+    if (auto* space = _reservation_manager.get_memory_space(Tier::GPU, preferred_gpu)) {
+      return space->make_reservation_or_null(bytes);
+    }
   }
-  any_memory_space_in_tier strategy(Tier::GPU);
-  return _reservation_manager.request_reservation(strategy, bytes);
+  return nullptr;
 }
 
 void cuvs_index_cache::insert(std::string name,
@@ -119,6 +118,28 @@ bool cuvs_index_cache::erase(std::string_view name)
 {
   std::lock_guard<std::mutex> lock(_mutex);
   return _entries.erase(std::string(name)) > 0;
+}
+
+std::size_t cuvs_index_cache::erase_by_column(std::string_view catalog,
+                                              std::string_view schema,
+                                              std::string_view table,
+                                              std::string_view column,
+                                              cuvs::distance::DistanceType metric)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  auto const wanted   = canonical_metric(metric);
+  std::size_t removed = 0;
+  for (auto it = _entries.begin(); it != _entries.end();) {
+    auto const& meta = it->second->meta;
+    if (meta.catalog_name == catalog && meta.schema_name == schema && meta.table_name == table &&
+        meta.column_name == column && canonical_metric(meta.metric) == wanted) {
+      it = _entries.erase(it);
+      ++removed;
+        } else {
+          ++it;
+        }
+  }
+  return removed;
 }
 
 void cuvs_index_cache::clear()

--- a/src/vss/cuvs_index_cache.cpp
+++ b/src/vss/cuvs_index_cache.cpp
@@ -55,19 +55,6 @@ cuvs_index_cache::cuvs_index_cache(
 // the header) is destroyed here, where cucascade::memory::reservation is complete.
 cuvs_index_cache::~cuvs_index_cache() = default;
 
-// Explicit move assignment op
-pinned_index_entry& pinned_index_entry::operator=(pinned_index_entry&& other) noexcept
-{
-  if (this != &other) {
-    index.reset();
-    reservation.reset();
-    meta        = std::move(other.meta);
-    reservation = std::move(other.reservation);
-    index       = std::move(other.index);
-  }
-  return *this;
-}
-
 std::unique_ptr<cucascade::memory::reservation> cuvs_index_cache::reserve_index_memory(
   std::size_t bytes, int preferred_gpu)
 {
@@ -86,32 +73,32 @@ void cuvs_index_cache::insert(std::string name,
                               std::unique_ptr<any_cuvs_index> index,
                               std::unique_ptr<cucascade::memory::reservation> reservation)
 {
-  pinned_index_entry entry;
-  entry.meta        = std::move(meta);
-  entry.index       = std::move(index);
-  entry.reservation = std::move(reservation);
+  auto entry         = std::make_shared<pinned_index_entry>();
+  entry->meta        = std::move(meta);
+  entry->index       = std::move(index);
+  entry->reservation = std::move(reservation);
 
   std::lock_guard<std::mutex> lock(_mutex);
   _entries[std::move(name)] = std::move(entry);
 }
 
-const pinned_index_entry* cuvs_index_cache::find(std::string_view name) const
+std::shared_ptr<const pinned_index_entry> cuvs_index_cache::find(std::string_view name) const
 {
   std::lock_guard<std::mutex> lock(_mutex);
   auto it = _entries.find(std::string(name));
-  return it == _entries.end() ? nullptr : &it->second;
+  return it == _entries.end() ? nullptr : it->second;
 }
 
-const pinned_index_entry* cuvs_index_cache::find_by_column(
+std::shared_ptr<const pinned_index_entry> cuvs_index_cache::find_by_column(
   std::string_view table, std::string_view column, cuvs::distance::DistanceType metric) const
 {
   std::lock_guard<std::mutex> lock(_mutex);
   auto const wanted = canonical_metric(metric);
   for (auto const& kv : _entries) {
     auto const& entry = kv.second;
-    if (entry.meta.table_name == table && entry.meta.column_name == column &&
-        canonical_metric(entry.meta.metric) == wanted) {
-      return &entry;
+    if (entry->meta.table_name == table && entry->meta.column_name == column &&
+        canonical_metric(entry->meta.metric) == wanted) {
+      return entry;
     }
   }
   return nullptr;

--- a/src/vss/cuvs_index_cache.cpp
+++ b/src/vss/cuvs_index_cache.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vss/cuvs_index_cache.hpp"
+
+#include <cucascade/memory/common.hpp>
+#include <cucascade/memory/memory_reservation.hpp>
+#include <cucascade/memory/memory_reservation_manager.hpp>
+
+#include <utility>
+
+namespace sirius::vss {
+
+namespace {
+
+/// Fold metrics that produce the same reported distance in an IVF-Flat search
+/// into one canonical value, so the auto-route match is on distance semantics
+/// rather than the exact enum. The recognizer derives L2SqrtUnexpanded for
+/// array_distance (avoids catastrophic cancellation on the brute-force path),
+/// while an index is built L2SqrtExpanded for correct coarse cluster selection.
+/// IVF-Flat's fine scan is unexpanded for both, so they return identical
+/// distances and must match here.
+cuvs::distance::DistanceType canonical_metric(cuvs::distance::DistanceType metric)
+{
+  switch (metric) {
+    case cuvs::distance::DistanceType::L2SqrtExpanded:
+    case cuvs::distance::DistanceType::L2SqrtUnexpanded:
+      return cuvs::distance::DistanceType::L2SqrtExpanded;
+    default: return metric;
+  }
+}
+
+}  // namespace
+
+cuvs_index_cache::cuvs_index_cache(
+  cucascade::memory::memory_reservation_manager& reservation_manager)
+  : _reservation_manager(reservation_manager)
+{
+}
+
+// Out-of-line so pinned_index_entry's reservation (a forward-declared type in
+// the header) is destroyed here, where cucascade::memory::reservation is complete.
+cuvs_index_cache::~cuvs_index_cache() = default;
+
+std::unique_ptr<cucascade::memory::reservation> cuvs_index_cache::reserve_index_memory(
+  std::size_t bytes, int preferred_gpu)
+{
+  using namespace cucascade::memory;
+  if (preferred_gpu >= 0) {
+    any_memory_space_in_tier_with_preference strategy(Tier::GPU,
+                                                      static_cast<std::size_t>(preferred_gpu));
+    return _reservation_manager.request_reservation(strategy, bytes);
+  }
+  any_memory_space_in_tier strategy(Tier::GPU);
+  return _reservation_manager.request_reservation(strategy, bytes);
+}
+
+void cuvs_index_cache::insert(std::string name,
+                              index_metadata meta,
+                              std::unique_ptr<any_cuvs_index> index,
+                              std::unique_ptr<cucascade::memory::reservation> reservation)
+{
+  pinned_index_entry entry;
+  entry.meta        = std::move(meta);
+  entry.index       = std::move(index);
+  entry.reservation = std::move(reservation);
+
+  std::lock_guard<std::mutex> lock(_mutex);
+  _entries[std::move(name)] = std::move(entry);
+}
+
+const pinned_index_entry* cuvs_index_cache::find(std::string_view name) const
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  auto it = _entries.find(std::string(name));
+  return it == _entries.end() ? nullptr : &it->second;
+}
+
+const pinned_index_entry* cuvs_index_cache::find_by_column(
+  std::string_view table, std::string_view column, cuvs::distance::DistanceType metric) const
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  auto const wanted = canonical_metric(metric);
+  for (auto const& kv : _entries) {
+    auto const& entry = kv.second;
+    if (entry.meta.table_name == table && entry.meta.column_name == column &&
+        canonical_metric(entry.meta.metric) == wanted) {
+      return &entry;
+    }
+  }
+  return nullptr;
+}
+
+bool cuvs_index_cache::contains(std::string_view name) const
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  return _entries.contains(std::string(name));
+}
+
+bool cuvs_index_cache::erase(std::string_view name)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  return _entries.erase(std::string(name)) > 0;
+}
+
+void cuvs_index_cache::clear()
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _entries.clear();
+}
+
+std::size_t cuvs_index_cache::size() const
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  return _entries.size();
+}
+
+}  // namespace sirius::vss

--- a/src/vss/cuvs_index_cache.cpp
+++ b/src/vss/cuvs_index_cache.cpp
@@ -135,9 +135,9 @@ std::size_t cuvs_index_cache::erase_by_column(std::string_view catalog,
         meta.column_name == column && canonical_metric(meta.metric) == wanted) {
       it = _entries.erase(it);
       ++removed;
-        } else {
-          ++it;
-        }
+    } else {
+      ++it;
+    }
   }
   return removed;
 }

--- a/src/vss/distance_metric.cpp
+++ b/src/vss/distance_metric.cpp
@@ -31,7 +31,7 @@ cuvs::distance::DistanceType enn_distance_type_from_metric(std::string_view metr
 
 cuvs::distance::DistanceType ann_distance_type_from_metric(std::string_view metric)
 {
-  if (metric == "l2sq") { return cuvs::distance::DistanceType::L2SqrtExpanded; }
+  if (metric == "l2") { return cuvs::distance::DistanceType::L2SqrtExpanded; }
   if (metric == "cosine") { return cuvs::distance::DistanceType::CosineExpanded; }
   throw std::invalid_argument("ann_distance_type_from_metric: unsupported metric '" +
                               std::string(metric) + "'");

--- a/src/vss/distance_metric.cpp
+++ b/src/vss/distance_metric.cpp
@@ -37,4 +37,13 @@ cuvs::distance::DistanceType ann_distance_type_from_metric(std::string_view metr
                               std::string(metric) + "'");
 }
 
+std::string_view ann_metric_name(cuvs::distance::DistanceType metric)
+{
+  switch (metric) {
+    case cuvs::distance::DistanceType::L2SqrtExpanded: return "l2";
+    case cuvs::distance::DistanceType::CosineExpanded: return "cosine";
+    default: return "unknown";
+  }
+}
+
 }  // namespace sirius::vss

--- a/src/vss/distance_metric.cpp
+++ b/src/vss/distance_metric.cpp
@@ -29,4 +29,12 @@ cuvs::distance::DistanceType enn_distance_type_from_metric(std::string_view metr
                               std::string(metric) + "'");
 }
 
+cuvs::distance::DistanceType ann_distance_type_from_metric(std::string_view metric)
+{
+  if (metric == "l2sq") { return cuvs::distance::DistanceType::L2SqrtExpanded; }
+  if (metric == "cosine") { return cuvs::distance::DistanceType::CosineExpanded; }
+  throw std::invalid_argument("ann_distance_type_from_metric: unsupported metric '" +
+                              std::string(metric) + "'");
+}
+
 }  // namespace sirius::vss

--- a/test/cpp/integration/test_gpu_execution_vector_search.cpp
+++ b/test/cpp/integration/test_gpu_execution_vector_search.cpp
@@ -314,13 +314,12 @@ TEST_CASE_METHOD(VectorSearchFixture,
   run_ok("SET scan_task_batch_size = 1048576;");
 }
 
-// A created index must resolve two ways: by its management name (the key always
-// embeds the routing identity, then the user's name or "default"), and by its
-// routing identity via find_by_column. Rebuilding under a different name moves
-// the management key but keeps exactly one entry for the identity, so identity
-// lookup still resolves.
+// A created index resolves two ways to the same entry: by its cache key (the
+// routing identity, built by build_ann_index_cache_key) and by find_by_column.
+// Rebuilding the same identity replaces the one entry on that key rather than
+// appending a second.
 TEST_CASE_METHOD(VectorSearchFixture,
-                 "sirius_create_ann_index - findable by identity and management name",
+                 "sirius_create_ann_index - findable by identity key",
                  "[integration][gpu_execution][array][vss][vector_search]")
 {
   run_ok(
@@ -338,44 +337,135 @@ TEST_CASE_METHOD(VectorSearchFixture,
   REQUIRE(sirius_ctx);
   auto& index_cache = sirius_ctx->get_cuvs_index_cache();
 
-  auto const identity_prefix = catalog + "_main_vs_lookup_vec_l2_ann_";
+  // The cache key is the routing identity.
+  auto const key =
+    sirius::vss::build_ann_index_cache_key(catalog, "main", "vs_lookup", "vec", "l2");
 
   // The cache is shared across test cases in this process, so assert on the net
   // change this test makes rather than an absolute count.
   auto const baseline = index_cache.size();
 
-  // Explicit name => the management key ends with that name; identity lookup
-  // resolves to the same entry.
   run_ok(
-    "SELECT * FROM sirius_create_ann_index('vs_lookup', 'vec', name => 'my_idx', "
-    "metric => 'l2', n_lists => 16);");
+    "SELECT * FROM sirius_create_ann_index('vs_lookup', 'vec', metric => 'l2', n_lists => 16);");
   {
-    auto by_name = index_cache.find(identity_prefix + "my_idx");
+    auto by_key = index_cache.find(key);
     auto by_identity =
       index_cache.find_by_column(catalog, "main", "vs_lookup", "vec", Metric::L2SqrtExpanded);
-    REQUIRE(by_name != nullptr);
+    REQUIRE(by_key != nullptr);
     REQUIRE(by_identity != nullptr);
-    REQUIRE(by_name == by_identity);              // same entry, reached two ways
+    REQUIRE(by_key == by_identity);               // same entry, reached two ways
     REQUIRE(index_cache.size() == baseline + 1);  // one entry added
   }
 
-  // No name => the suffix defaults to "default". Rebuilding the same identity
-  // replaces the old entry, so the old "my_idx" key is gone but identity lookup
-  // still resolves (to the new "default" entry).
+  // Rebuilding the same identity replaces the entry on the same key (not appended).
   run_ok(
-    "SELECT * FROM sirius_create_ann_index('vs_lookup', 'vec', "
-    "metric => 'l2', n_lists => 16);");
+    "SELECT * FROM sirius_create_ann_index('vs_lookup', 'vec', metric => 'l2', n_lists => 16);");
   {
-    // The old name is gone (replaced, not appended) and identity still resolves.
-    REQUIRE(index_cache.find(identity_prefix + "my_idx") == nullptr);
-    auto by_name = index_cache.find(identity_prefix + "default");
+    auto by_key = index_cache.find(key);
     auto by_identity =
       index_cache.find_by_column(catalog, "main", "vs_lookup", "vec", Metric::L2SqrtExpanded);
-    REQUIRE(by_name != nullptr);
+    REQUIRE(by_key != nullptr);
     REQUIRE(by_identity != nullptr);
-    REQUIRE(by_name == by_identity);
+    REQUIRE(by_key == by_identity);
     REQUIRE(index_cache.size() == baseline + 1);  // replaced, not appended
   }
 
   run_ok("SELECT * FROM unpin_table('vs_lookup');");
+}
+
+// sirius_drop_ann_index removes a built index by its (table, column, metric)
+// identity: after the drop, routing can no longer find it, and a second drop is a
+// no-op that reports nothing was dropped.
+TEST_CASE_METHOD(VectorSearchFixture,
+                 "sirius_drop_ann_index - drops a built index by metric",
+                 "[integration][gpu_execution][array][vss][vector_search]")
+{
+  run_ok(
+    "CREATE TABLE vs_drop AS SELECT i AS id, [i, i, i]::FLOAT[3] AS vec FROM range(1000) t(i);");
+  run_ok("CHECKPOINT;");
+  run_ok("SELECT * FROM pin_table(name => 'vs_drop', tier => 'gpu', format => 'duckdb');");
+
+  auto catq = con->Query("SELECT current_database();");
+  REQUIRE(catq);
+  REQUIRE_FALSE(catq->HasError());
+  auto const catalog = catq->GetValue(0, 0).ToString();
+  using Metric       = cuvs::distance::DistanceType;
+
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx);
+  auto& index_cache = sirius_ctx->get_cuvs_index_cache();
+
+  run_ok("SELECT * FROM sirius_create_ann_index('vs_drop', 'vec', metric => 'l2', n_lists => 16);");
+  REQUIRE(index_cache.find_by_column(catalog, "main", "vs_drop", "vec", Metric::L2SqrtExpanded) !=
+          nullptr);
+
+  // Drop reports it removed one, and routing can no longer find it.
+  {
+    auto r = con->Query("SELECT * FROM sirius_drop_ann_index('vs_drop', 'vec', metric => 'l2');");
+    REQUIRE(r);
+    if (r->HasError()) { UNSCOPED_INFO("drop error: " << r->GetError()); }
+    REQUIRE_FALSE(r->HasError());
+    REQUIRE(r->GetValue(0, 0).GetValue<bool>());
+  }
+  REQUIRE(index_cache.find_by_column(catalog, "main", "vs_drop", "vec", Metric::L2SqrtExpanded) ==
+          nullptr);
+
+  // Dropping again is a no-op: nothing matched, so Dropped is false.
+  {
+    auto r = con->Query("SELECT * FROM sirius_drop_ann_index('vs_drop', 'vec', metric => 'l2');");
+    REQUIRE(r);
+    REQUIRE_FALSE(r->HasError());
+    REQUIRE_FALSE(r->GetValue(0, 0).GetValue<bool>());
+  }
+
+  run_ok("SELECT * FROM unpin_table('vs_drop');");
+}
+
+// sirius_drop_ann_index with no metric removes every index on the column. Build an
+// l2 and a cosine index on the same column, then a single metric-less drop clears
+// both.
+TEST_CASE_METHOD(VectorSearchFixture,
+                 "sirius_drop_ann_index - no metric drops every index on the column",
+                 "[integration][gpu_execution][array][vss][vector_search]")
+{
+  run_ok(
+    "CREATE TABLE vs_drop_all AS SELECT i AS id, [i, i, i]::FLOAT[3] AS vec FROM range(1000) "
+    "t(i);");
+  run_ok("CHECKPOINT;");
+  run_ok("SELECT * FROM pin_table(name => 'vs_drop_all', tier => 'gpu', format => 'duckdb');");
+
+  auto catq = con->Query("SELECT current_database();");
+  REQUIRE(catq);
+  REQUIRE_FALSE(catq->HasError());
+  auto const catalog = catq->GetValue(0, 0).ToString();
+  using Metric       = cuvs::distance::DistanceType;
+
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx);
+  auto& index_cache = sirius_ctx->get_cuvs_index_cache();
+
+  run_ok(
+    "SELECT * FROM sirius_create_ann_index('vs_drop_all', 'vec', metric => 'l2', n_lists => 16);");
+  run_ok(
+    "SELECT * FROM sirius_create_ann_index('vs_drop_all', 'vec', metric => 'cosine', "
+    "n_lists => 16);");
+  REQUIRE(index_cache.find_by_column(
+            catalog, "main", "vs_drop_all", "vec", Metric::L2SqrtExpanded) != nullptr);
+  REQUIRE(index_cache.find_by_column(
+            catalog, "main", "vs_drop_all", "vec", Metric::CosineExpanded) != nullptr);
+
+  // One metric-less drop clears both indexes on the column.
+  {
+    auto r = con->Query("SELECT * FROM sirius_drop_ann_index('vs_drop_all', 'vec');");
+    REQUIRE(r);
+    if (r->HasError()) { UNSCOPED_INFO("drop-all error: " << r->GetError()); }
+    REQUIRE_FALSE(r->HasError());
+    REQUIRE(r->GetValue(0, 0).GetValue<bool>());
+  }
+  REQUIRE(index_cache.find_by_column(
+            catalog, "main", "vs_drop_all", "vec", Metric::L2SqrtExpanded) == nullptr);
+  REQUIRE(index_cache.find_by_column(
+            catalog, "main", "vs_drop_all", "vec", Metric::CosineExpanded) == nullptr);
+
+  run_ok("SELECT * FROM unpin_table('vs_drop_all');");
 }

--- a/test/cpp/integration/test_gpu_execution_vector_search.cpp
+++ b/test/cpp/integration/test_gpu_execution_vector_search.cpp
@@ -20,10 +20,12 @@
  */
 
 #include <catch.hpp>
+#include <cuvs/distance/distance.hpp>
 #include <duckdb.hpp>
 #include <scan_manager/sirius_scan_manager.hpp>
 #include <sirius_context.hpp>
 #include <utils/gpu_execution_fixture.hpp>
+#include <vss/cuvs_index_cache.hpp>
 
 #include <cstdlib>
 #include <numbers>
@@ -245,4 +247,135 @@ TEST_CASE_METHOD(VectorSearchFixture,
   }
 
   run_ok("SELECT * FROM unpin_table('vs_reexec');");
+}
+
+// A deterministic (non-OOM) failed rebuild must not destroy the existing index.
+// The builder trains centroids on a single batch, so n_lists that exceeds the
+// largest batch can never build even though it is within the total row count.
+// We force a two-batch pin (one batch per storage row group) so the largest
+// batch (122880 rows) sits strictly below a chosen n_lists that is still under
+// the total, then assert the rejected rebuild left the prior index in place.
+TEST_CASE_METHOD(VectorSearchFixture,
+                 "sirius_create_ann_index - failed rebuild leaves the existing index in place",
+                 "[integration][gpu_execution][array][vss][vector_search]")
+{
+  // One storage row group is 122880 rows; 200000 rows spans two. A tiny scan
+  // batch target puts each row group in its own batch, so the largest batch is
+  // 122880 < 150000 <= 200000 total. (scan_task_batch_size is a test-only option,
+  // enabled for the C++ test binary.)
+  run_ok("SET scan_task_batch_size = 1;");
+  run_ok(
+    "CREATE TABLE vs_badrebuild AS "
+    "SELECT i AS id, [i, i, i]::FLOAT[3] AS vec FROM range(200000) t(i);");
+  run_ok("CHECKPOINT;");
+  run_ok("SELECT * FROM pin_table(name => 'vs_badrebuild', tier => 'gpu', format => 'duckdb');");
+
+  // Build a valid index. Routing looks it up by identity, so we assert on that.
+  run_ok(
+    "SELECT * FROM sirius_create_ann_index('vs_badrebuild', 'vec', "
+    "metric => 'l2', n_lists => 64);");
+
+  // The identity's catalog is the attached database this fixture routed DDL into.
+  auto catq = con->Query("SELECT current_database();");
+  REQUIRE(catq);
+  REQUIRE_FALSE(catq->HasError());
+  auto const catalog = catq->GetValue(0, 0).ToString();
+  using Metric       = cuvs::distance::DistanceType;
+
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx);
+  auto& index_cache = sirius_ctx->get_cuvs_index_cache();
+  {
+    auto entry =
+      index_cache.find_by_column(catalog, "main", "vs_badrebuild", "vec", Metric::L2SqrtExpanded);
+    REQUIRE(entry != nullptr);
+    REQUIRE(entry->meta.n_lists == 64);
+  }
+
+  // Rebuild with n_lists above the largest batch but within the total row count.
+  // This is deterministic: it cannot build regardless of free memory.
+  auto bad = con->Query(
+    "SELECT * FROM sirius_create_ann_index('vs_badrebuild', 'vec', "
+    "metric => 'l2', n_lists => 150000);");
+  REQUIRE(bad);
+  REQUIRE(bad->HasError());
+  INFO("rebuild error: " << bad->GetError());
+  REQUIRE(bad->GetError().find("largest batch size") != std::string::npos);
+  REQUIRE(bad->GetError().find("left in place") != std::string::npos);
+
+  // The failure contract: the rebuild was rejected before any erase, so the
+  // original index is unchanged, not removed.
+  auto entry =
+    index_cache.find_by_column(catalog, "main", "vs_badrebuild", "vec", Metric::L2SqrtExpanded);
+  REQUIRE(entry != nullptr);
+  REQUIRE(entry->meta.n_lists == 64);
+
+  run_ok("SELECT * FROM unpin_table('vs_badrebuild');");
+  run_ok("SET scan_task_batch_size = 1048576;");
+}
+
+// A created index must resolve two ways: by its management name (the key always
+// embeds the routing identity, then the user's name or "default"), and by its
+// routing identity via find_by_column. Rebuilding under a different name moves
+// the management key but keeps exactly one entry for the identity, so identity
+// lookup still resolves.
+TEST_CASE_METHOD(VectorSearchFixture,
+                 "sirius_create_ann_index - findable by identity and management name",
+                 "[integration][gpu_execution][array][vss][vector_search]")
+{
+  run_ok(
+    "CREATE TABLE vs_lookup AS SELECT i AS id, [i, i, i]::FLOAT[3] AS vec FROM range(1000) t(i);");
+  run_ok("CHECKPOINT;");
+  run_ok("SELECT * FROM pin_table(name => 'vs_lookup', tier => 'gpu', format => 'duckdb');");
+
+  auto catq = con->Query("SELECT current_database();");
+  REQUIRE(catq);
+  REQUIRE_FALSE(catq->HasError());
+  auto const catalog = catq->GetValue(0, 0).ToString();
+  using Metric       = cuvs::distance::DistanceType;
+
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx);
+  auto& index_cache = sirius_ctx->get_cuvs_index_cache();
+
+  auto const identity_prefix = catalog + "_main_vs_lookup_vec_l2_ann_";
+
+  // The cache is shared across test cases in this process, so assert on the net
+  // change this test makes rather than an absolute count.
+  auto const baseline = index_cache.size();
+
+  // Explicit name => the management key ends with that name; identity lookup
+  // resolves to the same entry.
+  run_ok(
+    "SELECT * FROM sirius_create_ann_index('vs_lookup', 'vec', name => 'my_idx', "
+    "metric => 'l2', n_lists => 16);");
+  {
+    auto by_name = index_cache.find(identity_prefix + "my_idx");
+    auto by_identity =
+      index_cache.find_by_column(catalog, "main", "vs_lookup", "vec", Metric::L2SqrtExpanded);
+    REQUIRE(by_name != nullptr);
+    REQUIRE(by_identity != nullptr);
+    REQUIRE(by_name == by_identity);              // same entry, reached two ways
+    REQUIRE(index_cache.size() == baseline + 1);  // one entry added
+  }
+
+  // No name => the suffix defaults to "default". Rebuilding the same identity
+  // replaces the old entry, so the old "my_idx" key is gone but identity lookup
+  // still resolves (to the new "default" entry).
+  run_ok(
+    "SELECT * FROM sirius_create_ann_index('vs_lookup', 'vec', "
+    "metric => 'l2', n_lists => 16);");
+  {
+    // The old name is gone (replaced, not appended) and identity still resolves.
+    REQUIRE(index_cache.find(identity_prefix + "my_idx") == nullptr);
+    auto by_name = index_cache.find(identity_prefix + "default");
+    auto by_identity =
+      index_cache.find_by_column(catalog, "main", "vs_lookup", "vec", Metric::L2SqrtExpanded);
+    REQUIRE(by_name != nullptr);
+    REQUIRE(by_identity != nullptr);
+    REQUIRE(by_name == by_identity);
+    REQUIRE(index_cache.size() == baseline + 1);  // replaced, not appended
+  }
+
+  run_ok("SELECT * FROM unpin_table('vs_lookup');");
 }

--- a/test/cpp/integration/test_gpu_execution_vector_search.cpp
+++ b/test/cpp/integration/test_gpu_execution_vector_search.cpp
@@ -234,7 +234,9 @@ TEST_CASE_METHOD(VectorSearchFixture,
 
   for (int exec = 1; exec <= 2; ++exec) {
     INFO("execution #" << exec);
-    auto res = prep->Execute();
+    // allow_stream_result = false so we get a materialized result to count rows.
+    duckdb::vector<duckdb::Value> params;
+    auto res = prep->Execute(params, /*allow_stream_result=*/false);
     REQUIRE(res);
     if (res->HasError()) { UNSCOPED_INFO("execute error: " << res->GetError()); }
     REQUIRE_FALSE(res->HasError());

--- a/test/cpp/integration/test_gpu_execution_vector_search.cpp
+++ b/test/cpp/integration/test_gpu_execution_vector_search.cpp
@@ -212,3 +212,35 @@ TEST_CASE_METHOD(VectorSearchFixture,
 
   run_ok("SELECT * FROM unpin_table('vs_enn_cos');");
 }
+
+TEST_CASE_METHOD(VectorSearchFixture,
+                 "sirius_create_ann_index - prepared statement rebuilds on every execution",
+                 "[integration][gpu_execution][array][vss][vector_search]")
+{
+  run_ok(
+    "CREATE TABLE vs_reexec AS SELECT i AS id, [i, i, i]::FLOAT[3] AS vec FROM range(1000) t(i);");
+  run_ok("CHECKPOINT;");
+  run_ok("SELECT * FROM pin_table(name => 'vs_reexec', tier => 'gpu', format => 'duckdb');");
+
+  // Prepare once, execute twice. finished now lives in per-execution state, so each
+  // execution rebuilds and returns its one success row. When the flag lived in bind
+  // data (reused across executions of a prepared plan) the second execution returned
+  // zero rows and skipped the rebuild.
+  auto prep = con->Prepare(
+    "SELECT * FROM sirius_create_ann_index('vs_reexec', 'vec', metric => 'l2', n_lists => 16);");
+  REQUIRE(prep);
+  if (prep->HasError()) { UNSCOPED_INFO("prepare error: " << prep->GetError()); }
+  REQUIRE_FALSE(prep->HasError());
+
+  for (int exec = 1; exec <= 2; ++exec) {
+    INFO("execution #" << exec);
+    auto res = prep->Execute();
+    REQUIRE(res);
+    if (res->HasError()) { UNSCOPED_INFO("execute error: " << res->GetError()); }
+    REQUIRE_FALSE(res->HasError());
+    auto& mat = res->Cast<duckdb::MaterializedQueryResult>();
+    REQUIRE(mat.RowCount() == 1);  // rebuilt and returned its success row
+  }
+
+  run_ok("SELECT * FROM unpin_table('vs_reexec');");
+}

--- a/test/cpp/vss/test_cuvs_index_cache.cpp
+++ b/test/cpp/vss/test_cuvs_index_cache.cpp
@@ -268,6 +268,41 @@ TEST_CASE("cuvs_index_cache keeps same-named tables in different schemas distinc
   REQUIRE(e1 != e2);  // each schema routes to its own index
 }
 
+// Regression for the key-collision bug: the old key glued the identity parts with
+// underscores, so table "orders_data" column "vec" and table "orders" column
+// "data_vec" both flattened to the same "..._orders_data_vec_l2..." string, and the
+// second build silently replaced the first table's index. build_ann_index_cache_key
+// length-prefixes each part so their contents can never run together.
+TEST_CASE("cuvs_index_cache keeps colliding-name identities distinct", "[vss]")
+{
+  using sirius::vss::build_ann_index_cache_key;
+
+  // The two identities the old glued key could not tell apart.
+  auto const k1 = build_ann_index_cache_key("mem", "main", "orders_data", "vec", "l2");
+  auto const k2 = build_ann_index_cache_key("mem", "main", "orders", "data_vec", "l2");
+
+  SECTION("the key itself is distinct for the two identities") { REQUIRE(k1 != k2); }
+
+  SECTION("both survive in the cache instead of one overwriting the other")
+  {
+    auto manager = sirius::test::operator_utils::initialize_memory_manager();
+    cuvs_index_cache cache(*manager);
+
+    insert_dummy(cache, k1, make_meta("orders_data", "vec", Metric::L2SqrtExpanded));
+    insert_dummy(cache, k2, make_meta("orders", "data_vec", Metric::L2SqrtExpanded));
+
+    REQUIRE(cache.size() == 2);  // distinct keys, not a silent overwrite
+
+    auto e1 = cache.find_by_column("mem", "main", "orders_data", "vec", Metric::L2SqrtExpanded);
+    auto e2 = cache.find_by_column("mem", "main", "orders", "data_vec", Metric::L2SqrtExpanded);
+    REQUIRE(e1 != nullptr);
+    REQUIRE(e2 != nullptr);
+    REQUIRE(e1->meta.table_name == "orders_data");
+    REQUIRE(e2->meta.table_name == "orders");
+    REQUIRE(e1 != e2);  // each identity routes to its own index
+  }
+}
+
 TEST_CASE("cuvs_index_cache reserve_index_memory is non-blocking", "[vss]")
 {
   auto manager = sirius::test::operator_utils::initialize_memory_manager();
@@ -517,6 +552,124 @@ TEST_CASE("cuvs_index_cache erase_by_column drops the matching index before a re
     REQUIRE(cache.erase_by_column("mem", "main", "docs", "other", Metric::L2SqrtExpanded) == 0);
     REQUIRE(cache.size() == 1);
   }
+  SECTION("no metric drops every index on the column, leaving other columns")
+  {
+    // sirius_drop_ann_index without a metric: both l2 and cosine on docs.vec go,
+    // docs.title_vec stays.
+    insert_dummy(cache, "vec_l2", make_meta("docs", "vec", Metric::L2SqrtExpanded));
+    insert_dummy(cache, "vec_cos", make_meta("docs", "vec", Metric::CosineExpanded));
+    insert_dummy(cache, "title", make_meta("docs", "title_vec", Metric::L2SqrtExpanded));
+
+    REQUIRE(cache.erase_by_column("mem", "main", "docs", "vec") == 2);  // no metric = all metrics
+    REQUIRE(cache.find("vec_l2") == nullptr);
+    REQUIRE(cache.find("vec_cos") == nullptr);
+    REQUIRE(cache.find("title") != nullptr);  // different column untouched
+  }
+  SECTION("a metric drops only that index, leaving the other metric on the column")
+  {
+    insert_dummy(cache, "vec_l2", make_meta("docs", "vec", Metric::L2SqrtExpanded));
+    insert_dummy(cache, "vec_cos", make_meta("docs", "vec", Metric::CosineExpanded));
+
+    REQUIRE(cache.erase_by_column("mem", "main", "docs", "vec", Metric::CosineExpanded) == 1);
+    REQUIRE(cache.find("vec_cos") == nullptr);
+    REQUIRE(cache.find("vec_l2") != nullptr);  // the l2 index survives
+  }
+}
+
+// indexes_on_column feeds the "not enough GPU memory" error so it can name the
+// other-metric indexes that are still holding memory on the same column.
+TEST_CASE("cuvs_index_cache indexes_on_column lists all metrics on a column", "[vss]")
+{
+  using sirius::vss::build_ann_index_cache_key;
+  auto manager = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  // Two indexes on docs.vec (l2 and cosine) plus one on a different column.
+  auto l2           = make_meta("docs", "vec", Metric::L2SqrtExpanded);
+  l2.resident_bytes = 4ull << 20;  // 4 MiB
+  insert_dummy(cache, build_ann_index_cache_key("mem", "main", "docs", "vec", "l2"), l2);
+
+  auto cos           = make_meta("docs", "vec", Metric::CosineExpanded);
+  cos.resident_bytes = 6ull << 20;  // 6 MiB
+  insert_dummy(cache, build_ann_index_cache_key("mem", "main", "docs", "vec", "cosine"), cos);
+
+  insert_dummy(cache,
+               build_ann_index_cache_key("mem", "main", "docs", "title_vec", "l2"),
+               make_meta("docs", "title_vec", Metric::L2SqrtExpanded));
+
+  auto const on_vec = cache.indexes_on_column("mem", "main", "docs", "vec");
+  REQUIRE(on_vec.size() == 2);  // both metrics on this column, not the other column
+
+  std::size_t total = 0;
+  bool saw_l2 = false, saw_cos = false;
+  for (auto const& e : on_vec) {
+    total += e.resident_bytes;
+    if (e.metric == Metric::L2SqrtExpanded) { saw_l2 = true; }
+    if (e.metric == Metric::CosineExpanded) { saw_cos = true; }
+  }
+  REQUIRE(saw_l2);
+  REQUIRE(saw_cos);
+  REQUIRE(total == (10ull << 20));
+
+  // A column with no index reports nothing.
+  REQUIRE(cache.indexes_on_column("mem", "main", "docs", "missing").empty());
+}
+
+// Creating a second index (a different metric) on a column
+// that already has one, when the GPU cannot hold both. The second build's
+// reservation must be refused cleanly, the existing index must survive untouched,
+// and it must remain discoverable as the memory holder the error names. The exact
+// fits-one-but-not-two capacity is verified manually (GPU size varies); here the
+// oversized request stands in for "the second build cannot be admitted".
+TEST_CASE("cuvs_index_cache refused second build leaves the first index holding memory", "[vss]")
+{
+  namespace mem = cucascade::memory;
+  auto manager  = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  auto* gpu_space = const_cast<mem::memory_space*>(manager->get_memory_space(mem::Tier::GPU, 0));
+  REQUIRE(gpu_space != nullptr);
+  auto* adaptor = gpu_space->get_memory_resource_of<mem::Tier::GPU>();
+  REQUIRE(adaptor != nullptr);
+
+  // Build and pin a small l2 index on docs.vec (the first index).
+  constexpr cudf::size_type dim = 2;
+  auto col                      = make_float_list(
+    {0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 10.0f, 10.0f, 11.0f, 10.0f, 10.0f, 11.0f}, 6, dim);
+
+  auto reservation = cache.reserve_index_memory(2ull << 20, /*preferred_gpu=*/0);
+  REQUIRE(reservation != nullptr);
+  rmm::cuda_stream build_stream;
+  auto* alloc = reservation->get_memory_resource_of<mem::Tier::GPU>();
+  REQUIRE(alloc->attach_reservation_to_tracker(build_stream.view(), std::move(reservation)));
+  auto handle         = sirius::vss::build_ivf_flat_index_from_batches({col->view()},
+                                                               dim,
+                                                               /*n_lists=*/2,
+                                                               Metric::L2SqrtExpanded,
+                                                               gpu_space->get_default_allocator(),
+                                                               build_stream.view());
+  auto const l2_bytes = adaptor->get_allocated_bytes(build_stream.view());
+  adaptor->reset_stream_reservation(build_stream.view());
+
+  index_metadata l2 = make_meta("docs", "vec", Metric::L2SqrtExpanded);
+  l2.resident_bytes = l2_bytes;
+  cache.insert(sirius::vss::build_ann_index_cache_key("mem", "main", "docs", "vec", "l2"),
+               std::move(l2),
+               std::move(handle),
+               std::move(build_stream));
+
+  // The second build (cosine on the same column) needs more than the GPU can hold.
+  // reserve_index_memory returns null instead of blocking, so the create path can
+  // fail cleanly before it touches the l2 index.
+  REQUIRE(cache.reserve_index_memory(8ull << 30, /*preferred_gpu=*/0) == nullptr);
+
+  // The l2 index survives untouched and is discoverable as the holder the error names.
+  REQUIRE(cache.find_by_column("mem", "main", "docs", "vec", Metric::L2SqrtExpanded) != nullptr);
+  auto const others = cache.indexes_on_column("mem", "main", "docs", "vec");
+  REQUIRE(others.size() == 1);
+  REQUIRE(others[0].metric == Metric::L2SqrtExpanded);
+  REQUIRE(others[0].resident_bytes == l2_bytes);
+  REQUIRE(l2_bytes > 0);
 }
 
 TEST_CASE("cuvs_index_cache lookup handle outlives an erase", "[vss]")

--- a/test/cpp/vss/test_cuvs_index_cache.cpp
+++ b/test/cpp/vss/test_cuvs_index_cache.cpp
@@ -101,7 +101,8 @@ TEST_CASE("cuvs_index_cache find_by_column matches the auto-routing identity", "
   }
   SECTION("wrong column misses")
   {
-    REQUIRE(cache.find_by_column("mem", "main", "docs", "other", Metric::L2SqrtExpanded) == nullptr);
+    REQUIRE(cache.find_by_column("mem", "main", "docs", "other", Metric::L2SqrtExpanded) ==
+            nullptr);
   }
   SECTION("wrong table misses")
   {
@@ -113,7 +114,8 @@ TEST_CASE("cuvs_index_cache find_by_column matches the auto-routing identity", "
   }
   SECTION("wrong catalog misses")
   {
-    REQUIRE(cache.find_by_column("other", "main", "docs", "vec", Metric::L2SqrtExpanded) == nullptr);
+    REQUIRE(cache.find_by_column("other", "main", "docs", "vec", Metric::L2SqrtExpanded) ==
+            nullptr);
   }
   SECTION("right column but wrong metric misses (an l2 index can't serve a cosine query)")
   {
@@ -129,7 +131,8 @@ TEST_CASE("cuvs_index_cache find_by_column folds L2 expanded/unexpanded", "[vss]
   SECTION("index built L2SqrtExpanded matches an L2SqrtUnexpanded query")
   {
     insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtExpanded));
-    REQUIRE(cache.find_by_column("mem", "main", "docs", "vec", Metric::L2SqrtUnexpanded) != nullptr);
+    REQUIRE(cache.find_by_column("mem", "main", "docs", "vec", Metric::L2SqrtUnexpanded) !=
+            nullptr);
   }
   SECTION("index built L2SqrtUnexpanded matches an L2SqrtExpanded query")
   {
@@ -139,7 +142,8 @@ TEST_CASE("cuvs_index_cache find_by_column folds L2 expanded/unexpanded", "[vss]
   SECTION("the fold stays within the metric family (an L2 query misses a cosine index)")
   {
     insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::CosineExpanded));
-    REQUIRE(cache.find_by_column("mem", "main", "docs", "vec", Metric::L2SqrtUnexpanded) == nullptr);
+    REQUIRE(cache.find_by_column("mem", "main", "docs", "vec", Metric::L2SqrtUnexpanded) ==
+            nullptr);
   }
 }
 

--- a/test/cpp/vss/test_cuvs_index_cache.cpp
+++ b/test/cpp/vss/test_cuvs_index_cache.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// test
+#include "operator/operator_test_utils.hpp"
+
+#include <catch.hpp>
+
+// sirius
+#include <cuvs/distance/distance.hpp>
+#include <vss/cuvs_index_cache.hpp>
+
+#include <string>
+
+namespace {
+
+using sirius::vss::cuvs_index_cache;
+using sirius::vss::index_kind;
+using sirius::vss::index_metadata;
+using Metric = cuvs::distance::DistanceType;
+
+index_metadata make_meta(std::string table, std::string column, Metric metric)
+{
+  index_metadata meta;
+  meta.kind           = index_kind::ivf_flat;
+  meta.table_name     = std::move(table);
+  meta.column_name    = std::move(column);
+  meta.dim            = 3;
+  meta.num_rows       = 100;
+  meta.n_lists        = 4;
+  meta.metric         = metric;
+  meta.reserved_bytes = 1024;
+  return meta;
+}
+
+// Pin a dummy (type-erased) index under `name`. The cache is index-type agnostic,
+// so an int holder stands in for a real cuVS index, only the metadata and the
+// reservation lifetime are under test here.
+void insert_dummy(cuvs_index_cache& cache, std::string name, index_metadata meta)
+{
+  auto reservation = cache.reserve_index_memory(/*bytes=*/1024, /*preferred_gpu=*/0);
+  cache.insert(
+    std::move(name), std::move(meta), sirius::vss::make_cuvs_index(int{0}), std::move(reservation));
+}
+
+}  // namespace
+
+TEST_CASE("cuvs_index_cache inserts and looks up by management name", "[vss]")
+{
+  auto manager = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  REQUIRE(cache.size() == 0);
+  REQUIRE(cache.find("idx") == nullptr);
+  REQUIRE_FALSE(cache.contains("idx"));
+
+  insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtExpanded));
+
+  REQUIRE(cache.size() == 1);
+  REQUIRE(cache.contains("idx"));
+  const auto* entry = cache.find("idx");
+  REQUIRE(entry != nullptr);
+  REQUIRE(entry->meta.table_name == "docs");
+  REQUIRE(entry->meta.column_name == "vec");
+  REQUIRE(entry->meta.metric == Metric::L2SqrtExpanded);
+  REQUIRE(entry->index != nullptr);
+  REQUIRE(entry->reservation != nullptr);
+}
+
+TEST_CASE("cuvs_index_cache find_by_column matches the auto-routing identity", "[vss]")
+{
+  auto manager = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtExpanded));
+
+  SECTION("exact (table, column, metric) match hits")
+  {
+    const auto* e = cache.find_by_column("docs", "vec", Metric::L2SqrtExpanded);
+    REQUIRE(e != nullptr);
+    REQUIRE(e->meta.table_name == "docs");
+  }
+  SECTION("wrong column misses")
+  {
+    REQUIRE(cache.find_by_column("docs", "other", Metric::L2SqrtExpanded) == nullptr);
+  }
+  SECTION("wrong table misses")
+  {
+    REQUIRE(cache.find_by_column("other", "vec", Metric::L2SqrtExpanded) == nullptr);
+  }
+  SECTION("right column but wrong metric misses (an l2 index can't serve a cosine query)")
+  {
+    REQUIRE(cache.find_by_column("docs", "vec", Metric::CosineExpanded) == nullptr);
+  }
+}
+
+TEST_CASE("cuvs_index_cache find_by_column folds L2 expanded/unexpanded", "[vss]")
+{
+  auto manager = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  SECTION("index built L2SqrtExpanded matches an L2SqrtUnexpanded query")
+  {
+    insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtExpanded));
+    REQUIRE(cache.find_by_column("docs", "vec", Metric::L2SqrtUnexpanded) != nullptr);
+  }
+  SECTION("index built L2SqrtUnexpanded matches an L2SqrtExpanded query")
+  {
+    insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtUnexpanded));
+    REQUIRE(cache.find_by_column("docs", "vec", Metric::L2SqrtExpanded) != nullptr);
+  }
+  SECTION("the fold stays within the metric family (an L2 query misses a cosine index)")
+  {
+    insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::CosineExpanded));
+    REQUIRE(cache.find_by_column("docs", "vec", Metric::L2SqrtUnexpanded) == nullptr);
+  }
+}
+
+TEST_CASE("cuvs_index_cache insert replaces an existing name in place", "[vss]")
+{
+  auto manager = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtExpanded));
+  insert_dummy(cache, "idx", make_meta("docs", "embedding", Metric::CosineExpanded));
+
+  REQUIRE(cache.size() == 1);  // replaced, not appended
+  const auto* entry = cache.find("idx");
+  REQUIRE(entry != nullptr);
+  REQUIRE(entry->meta.column_name == "embedding");
+  REQUIRE(entry->meta.metric == Metric::CosineExpanded);
+}
+
+TEST_CASE("cuvs_index_cache erase and clear release entries", "[vss]")
+{
+  auto manager = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  insert_dummy(cache, "a", make_meta("t", "v", Metric::L2SqrtExpanded));
+  insert_dummy(cache, "b", make_meta("t", "w", Metric::L2SqrtExpanded));
+  REQUIRE(cache.size() == 2);
+
+  SECTION("erase removes exactly the named entry")
+  {
+    REQUIRE(cache.erase("a"));
+    REQUIRE(cache.size() == 1);
+    REQUIRE(cache.find("a") == nullptr);
+    REQUIRE(cache.find("b") != nullptr);
+    REQUIRE_FALSE(cache.erase("a"));  // already gone
+  }
+  SECTION("clear drops everything")
+  {
+    cache.clear();
+    REQUIRE(cache.size() == 0);
+    REQUIRE(cache.find("a") == nullptr);
+    REQUIRE(cache.find("b") == nullptr);
+  }
+}
+
+TEST_CASE("cuvs_index_cache find_by_column returns a match among several entries", "[vss]")
+{
+  auto manager = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  insert_dummy(cache, "idx_a", make_meta("images", "clip", Metric::CosineExpanded));
+  insert_dummy(cache, "idx_b", make_meta("docs", "vec", Metric::L2SqrtExpanded));
+  insert_dummy(cache, "idx_c", make_meta("docs", "title_vec", Metric::L2SqrtExpanded));
+
+  const auto* e = cache.find_by_column("docs", "title_vec", Metric::L2SqrtExpanded);
+  REQUIRE(e != nullptr);
+  REQUIRE(e->meta.table_name == "docs");
+  REQUIRE(e->meta.column_name == "title_vec");
+}

--- a/test/cpp/vss/test_cuvs_index_cache.cpp
+++ b/test/cpp/vss/test_cuvs_index_cache.cpp
@@ -71,7 +71,7 @@ TEST_CASE("cuvs_index_cache inserts and looks up by management name", "[vss]")
 
   REQUIRE(cache.size() == 1);
   REQUIRE(cache.contains("idx"));
-  const auto* entry = cache.find("idx");
+  auto entry = cache.find("idx");
   REQUIRE(entry != nullptr);
   REQUIRE(entry->meta.table_name == "docs");
   REQUIRE(entry->meta.column_name == "vec");
@@ -89,7 +89,7 @@ TEST_CASE("cuvs_index_cache find_by_column matches the auto-routing identity", "
 
   SECTION("exact (table, column, metric) match hits")
   {
-    const auto* e = cache.find_by_column("docs", "vec", Metric::L2SqrtExpanded);
+    auto e = cache.find_by_column("docs", "vec", Metric::L2SqrtExpanded);
     REQUIRE(e != nullptr);
     REQUIRE(e->meta.table_name == "docs");
   }
@@ -138,7 +138,7 @@ TEST_CASE("cuvs_index_cache insert replaces an existing name in place", "[vss]")
   insert_dummy(cache, "idx", make_meta("docs", "embedding", Metric::CosineExpanded));
 
   REQUIRE(cache.size() == 1);  // replaced, not appended
-  const auto* entry = cache.find("idx");
+  auto entry = cache.find("idx");
   REQUIRE(entry != nullptr);
   REQUIRE(entry->meta.column_name == "embedding");
   REQUIRE(entry->meta.metric == Metric::CosineExpanded);
@@ -179,8 +179,47 @@ TEST_CASE("cuvs_index_cache find_by_column returns a match among several entries
   insert_dummy(cache, "idx_b", make_meta("docs", "vec", Metric::L2SqrtExpanded));
   insert_dummy(cache, "idx_c", make_meta("docs", "title_vec", Metric::L2SqrtExpanded));
 
-  const auto* e = cache.find_by_column("docs", "title_vec", Metric::L2SqrtExpanded);
+  auto e = cache.find_by_column("docs", "title_vec", Metric::L2SqrtExpanded);
   REQUIRE(e != nullptr);
   REQUIRE(e->meta.table_name == "docs");
   REQUIRE(e->meta.column_name == "title_vec");
+}
+
+TEST_CASE("cuvs_index_cache lookup handle outlives an erase", "[vss]")
+{
+  auto manager = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtExpanded));
+
+  // A caller mid-search holds the handle. Erasing (a concurrent DROP) unlinks the
+  // map entry but must not destroy the entry or its reservation under the caller.
+  auto handle = cache.find("idx");
+  REQUIRE(handle != nullptr);
+
+  REQUIRE(cache.erase("idx"));
+  REQUIRE(cache.size() == 0);
+  REQUIRE(cache.find("idx") == nullptr);
+
+  // The held handle is still valid: entry, index, and reservation are all alive.
+  REQUIRE(handle->meta.column_name == "vec");
+  REQUIRE(handle->index != nullptr);
+  REQUIRE(handle->reservation != nullptr);
+}
+
+TEST_CASE("cuvs_index_cache lookup handle outlives a replace", "[vss]")
+{
+  auto manager = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtExpanded));
+  auto old_handle = cache.find("idx");
+  REQUIRE(old_handle != nullptr);
+
+  // Replacing the name installs a new entry; the old handle keeps pointing at the
+  // old one, which stays alive and unchanged for as long as the handle is held.
+  insert_dummy(cache, "idx", make_meta("docs", "embedding", Metric::CosineExpanded));
+
+  REQUIRE(old_handle->meta.column_name == "vec");
+  REQUIRE(cache.find("idx")->meta.column_name == "embedding");
 }

--- a/test/cpp/vss/test_cuvs_index_cache.cpp
+++ b/test/cpp/vss/test_cuvs_index_cache.cpp
@@ -32,10 +32,16 @@ using sirius::vss::index_kind;
 using sirius::vss::index_metadata;
 using Metric = cuvs::distance::DistanceType;
 
-index_metadata make_meta(std::string table, std::string column, Metric metric)
+index_metadata make_meta(std::string table,
+                         std::string column,
+                         Metric metric,
+                         std::string catalog = "mem",
+                         std::string schema  = "main")
 {
   index_metadata meta;
   meta.kind           = index_kind::ivf_flat;
+  meta.catalog_name   = std::move(catalog);
+  meta.schema_name    = std::move(schema);
   meta.table_name     = std::move(table);
   meta.column_name    = std::move(column);
   meta.dim            = 3;
@@ -87,23 +93,31 @@ TEST_CASE("cuvs_index_cache find_by_column matches the auto-routing identity", "
 
   insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtExpanded));
 
-  SECTION("exact (table, column, metric) match hits")
+  SECTION("exact (catalog, schema, table, column, metric) match hits")
   {
-    auto e = cache.find_by_column("docs", "vec", Metric::L2SqrtExpanded);
+    auto e = cache.find_by_column("mem", "main", "docs", "vec", Metric::L2SqrtExpanded);
     REQUIRE(e != nullptr);
     REQUIRE(e->meta.table_name == "docs");
   }
   SECTION("wrong column misses")
   {
-    REQUIRE(cache.find_by_column("docs", "other", Metric::L2SqrtExpanded) == nullptr);
+    REQUIRE(cache.find_by_column("mem", "main", "docs", "other", Metric::L2SqrtExpanded) == nullptr);
   }
   SECTION("wrong table misses")
   {
-    REQUIRE(cache.find_by_column("other", "vec", Metric::L2SqrtExpanded) == nullptr);
+    REQUIRE(cache.find_by_column("mem", "main", "other", "vec", Metric::L2SqrtExpanded) == nullptr);
+  }
+  SECTION("wrong schema misses (a same-named table in another schema does not route here)")
+  {
+    REQUIRE(cache.find_by_column("mem", "other", "docs", "vec", Metric::L2SqrtExpanded) == nullptr);
+  }
+  SECTION("wrong catalog misses")
+  {
+    REQUIRE(cache.find_by_column("other", "main", "docs", "vec", Metric::L2SqrtExpanded) == nullptr);
   }
   SECTION("right column but wrong metric misses (an l2 index can't serve a cosine query)")
   {
-    REQUIRE(cache.find_by_column("docs", "vec", Metric::CosineExpanded) == nullptr);
+    REQUIRE(cache.find_by_column("mem", "main", "docs", "vec", Metric::CosineExpanded) == nullptr);
   }
 }
 
@@ -115,17 +129,17 @@ TEST_CASE("cuvs_index_cache find_by_column folds L2 expanded/unexpanded", "[vss]
   SECTION("index built L2SqrtExpanded matches an L2SqrtUnexpanded query")
   {
     insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtExpanded));
-    REQUIRE(cache.find_by_column("docs", "vec", Metric::L2SqrtUnexpanded) != nullptr);
+    REQUIRE(cache.find_by_column("mem", "main", "docs", "vec", Metric::L2SqrtUnexpanded) != nullptr);
   }
   SECTION("index built L2SqrtUnexpanded matches an L2SqrtExpanded query")
   {
     insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtUnexpanded));
-    REQUIRE(cache.find_by_column("docs", "vec", Metric::L2SqrtExpanded) != nullptr);
+    REQUIRE(cache.find_by_column("mem", "main", "docs", "vec", Metric::L2SqrtExpanded) != nullptr);
   }
   SECTION("the fold stays within the metric family (an L2 query misses a cosine index)")
   {
     insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::CosineExpanded));
-    REQUIRE(cache.find_by_column("docs", "vec", Metric::L2SqrtUnexpanded) == nullptr);
+    REQUIRE(cache.find_by_column("mem", "main", "docs", "vec", Metric::L2SqrtUnexpanded) == nullptr);
   }
 }
 
@@ -179,10 +193,30 @@ TEST_CASE("cuvs_index_cache find_by_column returns a match among several entries
   insert_dummy(cache, "idx_b", make_meta("docs", "vec", Metric::L2SqrtExpanded));
   insert_dummy(cache, "idx_c", make_meta("docs", "title_vec", Metric::L2SqrtExpanded));
 
-  auto e = cache.find_by_column("docs", "title_vec", Metric::L2SqrtExpanded);
+  auto e = cache.find_by_column("mem", "main", "docs", "title_vec", Metric::L2SqrtExpanded);
   REQUIRE(e != nullptr);
   REQUIRE(e->meta.table_name == "docs");
   REQUIRE(e->meta.column_name == "title_vec");
+}
+
+TEST_CASE("cuvs_index_cache keeps same-named tables in different schemas distinct", "[vss]")
+{
+  auto manager = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  // s1.docs.vec and s2.docs.vec share table/column/metric and differ only by schema.
+  insert_dummy(cache, "s1_idx", make_meta("docs", "vec", Metric::L2SqrtExpanded, "mem", "s1"));
+  insert_dummy(cache, "s2_idx", make_meta("docs", "vec", Metric::L2SqrtExpanded, "mem", "s2"));
+
+  REQUIRE(cache.size() == 2);  // distinct identities, not a replace
+
+  auto e1 = cache.find_by_column("mem", "s1", "docs", "vec", Metric::L2SqrtExpanded);
+  auto e2 = cache.find_by_column("mem", "s2", "docs", "vec", Metric::L2SqrtExpanded);
+  REQUIRE(e1 != nullptr);
+  REQUIRE(e2 != nullptr);
+  REQUIRE(e1->meta.schema_name == "s1");
+  REQUIRE(e2->meta.schema_name == "s2");
+  REQUIRE(e1 != e2);  // each schema routes to its own index
 }
 
 TEST_CASE("cuvs_index_cache lookup handle outlives an erase", "[vss]")

--- a/test/cpp/vss/test_cuvs_index_cache.cpp
+++ b/test/cpp/vss/test_cuvs_index_cache.cpp
@@ -437,7 +437,7 @@ TEST_CASE("cuvs_index_cache reservation covers the build peak for a large low-di
   auto* adaptor = gpu_space->get_memory_resource_of<mem::Tier::GPU>();
   REQUIRE(adaptor != nullptr);
 
-  constexpr cudf::size_type dim = 3;
+  constexpr cudf::size_type dim   = 3;
   constexpr std::uint32_t n_lists = 1;
   constexpr cudf::size_type per   = 100000;
   constexpr int n_batches         = 10;

--- a/test/cpp/vss/test_cuvs_index_cache.cpp
+++ b/test/cpp/vss/test_cuvs_index_cache.cpp
@@ -219,6 +219,69 @@ TEST_CASE("cuvs_index_cache keeps same-named tables in different schemas distinc
   REQUIRE(e1 != e2);  // each schema routes to its own index
 }
 
+TEST_CASE("cuvs_index_cache reserve_index_memory is non-blocking", "[vss]")
+{
+  auto manager = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  SECTION("a request that fits returns a reservation")
+  {
+    auto r = cache.reserve_index_memory(/*bytes=*/1024, /*preferred_gpu=*/0);
+    REQUIRE(r != nullptr);
+  }
+  SECTION("a request larger than the GPU can hold returns null instead of blocking")
+  {
+    // The test GPU space is 512 MiB; ask for far more. A blocking reserve would
+    // hang here, so returning null is what lets CREATE INDEX fail cleanly (the
+    // "not enough free GPU memory" error in SiriusCreateAnnIndexFunction).
+    auto r = cache.reserve_index_memory(/*bytes=*/8ull << 30, /*preferred_gpu=*/0);
+    REQUIRE(r == nullptr);
+  }
+  SECTION("a negative device id returns null")
+  {
+    auto r = cache.reserve_index_memory(/*bytes=*/1024, /*preferred_gpu=*/-1);
+    REQUIRE(r == nullptr);
+  }
+}
+
+TEST_CASE("cuvs_index_cache erase_by_column drops the matching index before a rebuild", "[vss]")
+{
+  auto manager = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  SECTION("removes the identity match regardless of its management name, leaving others")
+  {
+    insert_dummy(cache, "custom_name", make_meta("docs", "vec", Metric::L2SqrtExpanded));
+    insert_dummy(cache, "other", make_meta("docs", "title_vec", Metric::L2SqrtExpanded));
+
+    REQUIRE(cache.erase_by_column("mem", "main", "docs", "vec", Metric::L2SqrtExpanded) == 1);
+    REQUIRE(cache.find("custom_name") == nullptr);
+    REQUIRE(cache.find("other") != nullptr);  // different column untouched
+  }
+  SECTION("matches up to metric canonicalization (unexpanded query drops an expanded index)")
+  {
+    insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtExpanded));
+    REQUIRE(cache.erase_by_column("mem", "main", "docs", "vec", Metric::L2SqrtUnexpanded) == 1);
+    REQUIRE(cache.size() == 0);
+  }
+  SECTION("scoped to the schema (rebuilding s1's index leaves s2's alone)")
+  {
+    insert_dummy(cache, "s1_idx", make_meta("docs", "vec", Metric::L2SqrtExpanded, "mem", "s1"));
+    insert_dummy(cache, "s2_idx", make_meta("docs", "vec", Metric::L2SqrtExpanded, "mem", "s2"));
+
+    REQUIRE(cache.erase_by_column("mem", "s1", "docs", "vec", Metric::L2SqrtExpanded) == 1);
+    REQUIRE(cache.find("s1_idx") == nullptr);
+    REQUIRE(cache.find("s2_idx") != nullptr);
+  }
+  SECTION("no match removes nothing")
+  {
+    insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtExpanded));
+    REQUIRE(cache.erase_by_column("mem", "main", "docs", "vec", Metric::CosineExpanded) == 0);
+    REQUIRE(cache.erase_by_column("mem", "main", "docs", "other", Metric::L2SqrtExpanded) == 0);
+    REQUIRE(cache.size() == 1);
+  }
+}
+
 TEST_CASE("cuvs_index_cache lookup handle outlives an erase", "[vss]")
 {
   auto manager = sirius::test::operator_utils::initialize_memory_manager();

--- a/test/cpp/vss/test_cuvs_index_cache.cpp
+++ b/test/cpp/vss/test_cuvs_index_cache.cpp
@@ -363,6 +363,124 @@ TEST_CASE("cuvs_index_cache create binds the build to its reservation and leaks 
   REQUIRE(adaptor->get_total_allocated_bytes() == alloc_before);
 }
 
+// Exercises the list-growth path the current tests miss: one list, two batches of
+// 32 then 1 row. IVF-Flat sizes each list in 32-row units, so the 33rd row forces
+// the single list to grow past its initial 32-row capacity. resize_list allocates
+// the larger buffer and copies while the old one is still owned, which is the
+// transient the footprint estimate has to cover. This prints footprint vs the
+// measured resident/peak so the estimate can be checked against reality.
+TEST_CASE("cuvs_index_cache build peak when a list outgrows its 32-row capacity", "[vss]")
+{
+  namespace mem = cucascade::memory;
+  auto manager  = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  auto* gpu_space = const_cast<mem::memory_space*>(manager->get_memory_space(mem::Tier::GPU, 0));
+  REQUIRE(gpu_space != nullptr);
+  auto* adaptor = gpu_space->get_memory_resource_of<mem::Tier::GPU>();
+  REQUIRE(adaptor != nullptr);
+
+  constexpr cudf::size_type dim   = 3;
+  constexpr std::uint32_t n_lists = 1;
+
+  std::vector<float> a(32 * dim);
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    a[i] = static_cast<float>(i);
+  }
+  std::vector<float> const b(1 * dim, 1.0f);
+  auto batch_a = make_float_list(a, 32, dim);  // fills the list to its 32-row capacity
+  auto batch_b = make_float_list(b, 1, dim);   // the 33rd row forces resize_list to grow it
+
+  std::int64_t const n_rows   = 33;
+  std::size_t const footprint = sirius::vss::ivf_flat_reservation_bytes(n_rows, dim, n_lists);
+
+  auto reservation = cache.reserve_index_memory(footprint, /*preferred_gpu=*/0);
+  REQUIRE(reservation != nullptr);
+  rmm::cuda_stream build_stream;
+  auto* alloc = reservation->get_memory_resource_of<mem::Tier::GPU>();
+  REQUIRE(alloc->attach_reservation_to_tracker(build_stream.view(), std::move(reservation)));
+
+  auto handle = sirius::vss::build_ivf_flat_index_from_batches({batch_a->view(), batch_b->view()},
+                                                               dim,
+                                                               n_lists,
+                                                               Metric::L2SqrtExpanded,
+                                                               gpu_space->get_default_allocator(),
+                                                               build_stream.view());
+
+  std::size_t const resident = adaptor->get_allocated_bytes(build_stream.view());
+  std::size_t const peak     = adaptor->get_peak_allocated_bytes(build_stream.view());
+  adaptor->reset_stream_reservation(build_stream.view());
+
+  REQUIRE(handle != nullptr);
+  WARN("footprint=" << footprint << " resident=" << resident << " peak=" << peak);
+  CHECK(peak >= resident);
+  // The growth path is exercised (a list reallocated past its 32-row capacity) and
+  // the reservation covers the build peak.
+  CHECK(footprint >= peak);
+}
+
+// The low-dim / many-rows-per-list case that a naive 2x-vectors estimate misses:
+// one list, 1,000,000 rows at dim 3, fed as ten equal 100k batches. The final extend
+// keeps the 900k-row old list buffer while allocating the 1M-row replacement, so the
+// list buffers alone peak near (900k + 1M) * (4*dim + 8) = 38,000,000 bytes. The
+// row-id and clone-and-replace terms in ivf_flat_reservation_bytes are what keep the
+// reservation above that peak here; a formula that only doubled the vector floats
+// would fall below it.
+TEST_CASE("cuvs_index_cache reservation covers the build peak for a large low-dim list", "[vss]")
+{
+  namespace mem = cucascade::memory;
+  auto manager  = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  auto* gpu_space = const_cast<mem::memory_space*>(manager->get_memory_space(mem::Tier::GPU, 0));
+  REQUIRE(gpu_space != nullptr);
+  auto* adaptor = gpu_space->get_memory_resource_of<mem::Tier::GPU>();
+  REQUIRE(adaptor != nullptr);
+
+  constexpr cudf::size_type dim = 3;
+  constexpr std::uint32_t n_lists = 1;
+  constexpr cudf::size_type per   = 100000;
+  constexpr int n_batches         = 10;
+
+  // Build the ten source batches; keep the columns alive for the whole build.
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  std::vector<cudf::column_view> batches;
+  cols.reserve(n_batches);
+  batches.reserve(n_batches);
+  for (int c = 0; c < n_batches; ++c) {
+    std::vector<float> vals(static_cast<std::size_t>(per) * dim);
+    for (std::size_t i = 0; i < vals.size(); ++i) {
+      vals[i] = static_cast<float>(static_cast<std::size_t>(c) * per + i / dim);
+    }
+    cols.push_back(make_float_list(vals, per, dim));
+    batches.push_back(cols.back()->view());
+  }
+
+  std::int64_t const n_rows   = static_cast<std::int64_t>(per) * n_batches;  // 1,000,000
+  std::size_t const footprint = sirius::vss::ivf_flat_reservation_bytes(n_rows, dim, n_lists);
+
+  auto reservation = cache.reserve_index_memory(footprint, /*preferred_gpu=*/0);
+  REQUIRE(reservation != nullptr);
+  rmm::cuda_stream build_stream;
+  auto* alloc = reservation->get_memory_resource_of<mem::Tier::GPU>();
+  REQUIRE(alloc->attach_reservation_to_tracker(build_stream.view(), std::move(reservation)));
+
+  auto handle = sirius::vss::build_ivf_flat_index_from_batches(batches,
+                                                               dim,
+                                                               n_lists,
+                                                               Metric::L2SqrtExpanded,
+                                                               gpu_space->get_default_allocator(),
+                                                               build_stream.view());
+
+  std::size_t const resident = adaptor->get_allocated_bytes(build_stream.view());
+  std::size_t const peak     = adaptor->get_peak_allocated_bytes(build_stream.view());
+  adaptor->reset_stream_reservation(build_stream.view());
+
+  REQUIRE(handle != nullptr);
+  WARN("footprint=" << footprint << " resident=" << resident << " peak=" << peak);
+  CHECK(footprint >= peak);
+}
+
 TEST_CASE("cuvs_index_cache erase_by_column drops the matching index before a rebuild", "[vss]")
 {
   auto manager = sirius::test::operator_utils::initialize_memory_manager();

--- a/test/cpp/vss/test_cuvs_index_cache.cpp
+++ b/test/cpp/vss/test_cuvs_index_cache.cpp
@@ -20,10 +20,28 @@
 #include <catch.hpp>
 
 // sirius
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream.hpp>
+#include <rmm/device_buffer.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <cucascade/memory/common.hpp>
+#include <cucascade/memory/memory_reservation.hpp>
+#include <cucascade/memory/memory_reservation_manager.hpp>
+#include <cucascade/memory/memory_space.hpp>
+#include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 #include <cuvs/distance/distance.hpp>
 #include <vss/cuvs_index_cache.hpp>
+#include <vss/ivf_flat_index.hpp>
 
+#include <cstdint>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -31,6 +49,34 @@ using sirius::vss::cuvs_index_cache;
 using sirius::vss::index_kind;
 using sirius::vss::index_metadata;
 using Metric = cuvs::distance::DistanceType;
+
+// Build a Sirius-style FLOAT[dim] column (a cudf LIST with a contiguous FLOAT32
+// values child), the per-batch shape build_ivf_flat_index_from_batches expects.
+std::unique_ptr<cudf::column> make_float_list(std::vector<float> const& values,
+                                              cudf::size_type n_rows,
+                                              cudf::size_type dim)
+{
+  auto child = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::FLOAT32}, n_rows * dim, cudf::mask_state::UNALLOCATED);
+  cudaMemcpy(child->mutable_view().data<float>(),
+             values.data(),
+             sizeof(float) * values.size(),
+             cudaMemcpyHostToDevice);
+
+  std::vector<int32_t> offsets(static_cast<std::size_t>(n_rows) + 1);
+  for (cudf::size_type i = 0; i <= n_rows; ++i) {
+    offsets[static_cast<std::size_t>(i)] = i * dim;
+  }
+  auto offsets_col = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT32}, n_rows + 1, cudf::mask_state::UNALLOCATED);
+  cudaMemcpy(offsets_col->mutable_view().data<int32_t>(),
+             offsets.data(),
+             sizeof(int32_t) * offsets.size(),
+             cudaMemcpyHostToDevice);
+
+  return cudf::make_lists_column(
+    n_rows, std::move(offsets_col), std::move(child), 0, rmm::device_buffer{});
+}
 
 index_metadata make_meta(std::string table,
                          std::string column,
@@ -48,18 +94,17 @@ index_metadata make_meta(std::string table,
   meta.num_rows       = 100;
   meta.n_lists        = 4;
   meta.metric         = metric;
-  meta.reserved_bytes = 1024;
+  meta.resident_bytes = 1024;
   return meta;
 }
 
 // Pin a dummy (type-erased) index under `name`. The cache is index-type agnostic,
-// so an int holder stands in for a real cuVS index, only the metadata and the
-// reservation lifetime are under test here.
+// so an int holder stands in for a real cuVS index; only the metadata and the
+// entry lifetime are under test here.
 void insert_dummy(cuvs_index_cache& cache, std::string name, index_metadata meta)
 {
-  auto reservation = cache.reserve_index_memory(/*bytes=*/1024, /*preferred_gpu=*/0);
   cache.insert(
-    std::move(name), std::move(meta), sirius::vss::make_cuvs_index(int{0}), std::move(reservation));
+    std::move(name), std::move(meta), sirius::vss::make_cuvs_index(int{0}), rmm::cuda_stream{});
 }
 
 }  // namespace
@@ -83,7 +128,7 @@ TEST_CASE("cuvs_index_cache inserts and looks up by management name", "[vss]")
   REQUIRE(entry->meta.column_name == "vec");
   REQUIRE(entry->meta.metric == Metric::L2SqrtExpanded);
   REQUIRE(entry->index != nullptr);
-  REQUIRE(entry->reservation != nullptr);
+  REQUIRE(entry->meta.resident_bytes == 1024);
 }
 
 TEST_CASE("cuvs_index_cache find_by_column matches the auto-routing identity", "[vss]")
@@ -248,6 +293,76 @@ TEST_CASE("cuvs_index_cache reserve_index_memory is non-blocking", "[vss]")
   }
 }
 
+// Regression for the reservation-accounting bug: a build must be charged to its
+// reservation, the reservation released afterward (no reserved-memory leak), and
+// the index left as ordinary capacity-accounted memory that returns to baseline
+// once the entry is dropped. See the reserve -> attach -> build -> reset -> insert
+// sequence in SiriusCreateAnnIndexFunction.
+TEST_CASE("cuvs_index_cache create binds the build to its reservation and leaks nothing", "[vss]")
+{
+  namespace mem = cucascade::memory;
+  auto manager  = sirius::test::operator_utils::initialize_memory_manager();
+  cuvs_index_cache cache(*manager);
+
+  auto* gpu_space = const_cast<mem::memory_space*>(manager->get_memory_space(mem::Tier::GPU, 0));
+  REQUIRE(gpu_space != nullptr);
+  auto* adaptor = gpu_space->get_memory_resource_of<mem::Tier::GPU>();
+  REQUIRE(adaptor != nullptr);
+
+  // Two well-separated clusters, six rows. The baseline counters are read after the
+  // source column is built and the column is kept alive through every assertion, so
+  // whatever it costs is already in the baseline and cancels out of the deltas.
+  constexpr cudf::size_type dim = 2;
+  auto col                      = make_float_list(
+    {0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 10.0f, 10.0f, 11.0f, 10.0f, 10.0f, 11.0f}, 6, dim);
+
+  auto const reserved_before = adaptor->get_total_reserved_bytes();
+  auto const alloc_before    = adaptor->get_total_allocated_bytes();
+
+  // Reserve, bind the reservation to the build stream, build on it, measure the
+  // resident footprint, then release: the same sequence the create path runs.
+  std::size_t const footprint = 2ull << 20;  // 2 MiB, ample for this tiny index
+  auto reservation            = cache.reserve_index_memory(footprint, /*preferred_gpu=*/0);
+  REQUIRE(reservation != nullptr);
+
+  rmm::cuda_stream build_stream;
+  auto* alloc = reservation->get_memory_resource_of<mem::Tier::GPU>();
+  REQUIRE(alloc == adaptor);
+  REQUIRE(alloc->attach_reservation_to_tracker(build_stream.view(), std::move(reservation)));
+
+  auto handle = sirius::vss::build_ivf_flat_index_from_batches({col->view()},
+                                                               dim,
+                                                               /*n_lists=*/2,
+                                                               Metric::L2SqrtExpanded,
+                                                               gpu_space->get_default_allocator(),
+                                                               build_stream.view());
+
+  auto const index_bytes = adaptor->get_allocated_bytes(build_stream.view());
+  adaptor->reset_stream_reservation(build_stream.view());
+
+  index_metadata meta = make_meta("docs", "vec", Metric::L2SqrtExpanded);
+  meta.resident_bytes = index_bytes;
+  cache.insert("idx", std::move(meta), std::move(handle), std::move(build_stream));
+
+  // After create: the reservation is fully released (no reserved leak), and the
+  // index's resident bytes are accounted as ordinary capacity.
+  REQUIRE(index_bytes > 0);
+  REQUIRE(adaptor->get_total_reserved_bytes() == reserved_before);
+  REQUIRE(adaptor->get_total_allocated_bytes() - alloc_before == index_bytes);
+
+  // A caller mid-search holds a lookup handle. Erasing unlinks the map entry but
+  // the index (and its accounting) stays until that handle is released.
+  auto held = cache.find("idx");
+  REQUIRE(held != nullptr);
+  REQUIRE(cache.erase("idx"));
+  REQUIRE(adaptor->get_total_allocated_bytes() - alloc_before == index_bytes);
+
+  // Releasing the last handle frees the index; both counters return to baseline.
+  held.reset();
+  REQUIRE(adaptor->get_total_reserved_bytes() == reserved_before);
+  REQUIRE(adaptor->get_total_allocated_bytes() == alloc_before);
+}
+
 TEST_CASE("cuvs_index_cache erase_by_column drops the matching index before a rebuild", "[vss]")
 {
   auto manager = sirius::test::operator_utils::initialize_memory_manager();
@@ -294,7 +409,7 @@ TEST_CASE("cuvs_index_cache lookup handle outlives an erase", "[vss]")
   insert_dummy(cache, "idx", make_meta("docs", "vec", Metric::L2SqrtExpanded));
 
   // A caller mid-search holds the handle. Erasing (a concurrent DROP) unlinks the
-  // map entry but must not destroy the entry or its reservation under the caller.
+  // map entry but must not destroy the entry or its index under the caller.
   auto handle = cache.find("idx");
   REQUIRE(handle != nullptr);
 
@@ -302,10 +417,9 @@ TEST_CASE("cuvs_index_cache lookup handle outlives an erase", "[vss]")
   REQUIRE(cache.size() == 0);
   REQUIRE(cache.find("idx") == nullptr);
 
-  // The held handle is still valid: entry, index, and reservation are all alive.
+  // The held handle is still valid: entry and index are all alive.
   REQUIRE(handle->meta.column_name == "vec");
   REQUIRE(handle->index != nullptr);
-  REQUIRE(handle->reservation != nullptr);
 }
 
 TEST_CASE("cuvs_index_cache lookup handle outlives a replace", "[vss]")

--- a/test/cpp/vss/test_distance_metric.cpp
+++ b/test/cpp/vss/test_distance_metric.cpp
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-// test
 #include <catch.hpp>
-
-// sirius
 #include <vss/distance_metric.hpp>
 
 #include <stdexcept>
@@ -30,4 +27,12 @@ TEST_CASE("enn_distance_type_from_metric maps l2 to the unexpanded form", "[vss]
   REQUIRE(sirius::vss::enn_distance_type_from_metric("cosine") == Metric::CosineExpanded);
   REQUIRE_THROWS_AS(sirius::vss::enn_distance_type_from_metric("dot"), std::invalid_argument);
   REQUIRE_THROWS_AS(sirius::vss::enn_distance_type_from_metric(""), std::invalid_argument);
+}
+
+TEST_CASE("ann_distance_type_from_metric maps the supported metrics", "[vss]")
+{
+  REQUIRE(sirius::vss::ann_distance_type_from_metric("l2sq") == Metric::L2SqrtExpanded);
+  REQUIRE(sirius::vss::ann_distance_type_from_metric("cosine") == Metric::CosineExpanded);
+  REQUIRE_THROWS_AS(sirius::vss::ann_distance_type_from_metric("dot"), std::invalid_argument);
+  REQUIRE_THROWS_AS(sirius::vss::ann_distance_type_from_metric(""), std::invalid_argument);
 }

--- a/test/cpp/vss/test_distance_metric.cpp
+++ b/test/cpp/vss/test_distance_metric.cpp
@@ -31,7 +31,7 @@ TEST_CASE("enn_distance_type_from_metric maps l2 to the unexpanded form", "[vss]
 
 TEST_CASE("ann_distance_type_from_metric maps the supported metrics", "[vss]")
 {
-  REQUIRE(sirius::vss::ann_distance_type_from_metric("l2sq") == Metric::L2SqrtExpanded);
+  REQUIRE(sirius::vss::ann_distance_type_from_metric("l2") == Metric::L2SqrtExpanded);
   REQUIRE(sirius::vss::ann_distance_type_from_metric("cosine") == Metric::CosineExpanded);
   REQUIRE_THROWS_AS(sirius::vss::ann_distance_type_from_metric("dot"), std::invalid_argument);
   REQUIRE_THROWS_AS(sirius::vss::ann_distance_type_from_metric(""), std::invalid_argument);

--- a/test/cpp/vss/test_ivf_flat_index.cpp
+++ b/test/cpp/vss/test_ivf_flat_index.cpp
@@ -39,12 +39,12 @@
 
 namespace {
 
-using sirius::vss::build_ivf_flat_index_from_chunks;
+using sirius::vss::build_ivf_flat_index_from_batches;
 using sirius::vss::search_ivf_flat_index;
 using Metric = cuvs::distance::DistanceType;
 
 // Build a Sirius-style ARRAY<FLOAT>[dim] column (cudf LIST with a contiguous,
-// uniform FLOAT32 values child); i.e., the shape the builder wraps per chunk.
+// uniform FLOAT32 values child); i.e., the shape the builder wraps per batch.
 std::unique_ptr<cudf::column> make_fixed_size_float_list(std::vector<float> const& values,
                                                          cudf::size_type n_rows,
                                                          cudf::size_type dim)
@@ -97,7 +97,7 @@ std::vector<float> to_host_f(cudf::column_view const& col)
 
 }  // namespace
 
-TEST_CASE("build_ivf_flat_index_from_chunks + search finds exact nearest neighbours", "[vss]")
+TEST_CASE("build_ivf_flat_index_from_batches + search finds exact nearest neighbours", "[vss]")
 {
   constexpr cudf::size_type dim = 2;
   auto const stream             = cudf::get_default_stream();
@@ -124,8 +124,8 @@ TEST_CASE("build_ivf_flat_index_from_chunks + search finds exact nearest neighbo
   // is exact; the ANN approximation only kicks in when fewer lists are probed.
   constexpr std::uint32_t n_lists  = 2;
   constexpr std::uint32_t n_probes = n_lists;
-  auto index                       = build_ivf_flat_index_from_chunks(
-    {dataset_col->view()}, dim, n_lists, Metric::L2SqrtExpanded, mr);
+  auto index                       = build_ivf_flat_index_from_batches(
+    {dataset_col->view()}, dim, n_lists, Metric::L2SqrtExpanded, mr, stream);
 
   SECTION("query in the origin cluster returns row 0")
   {
@@ -163,27 +163,27 @@ TEST_CASE("build_ivf_flat_index_from_chunks + search finds exact nearest neighbo
   }
 }
 
-// The chunked builder populates the index chunk by chunk via ivf_flat::extend,
+// The batched builder populates the index batch by batch via ivf_flat::extend,
 // tagging each vector with its GLOBAL row id (offset by the rows already added)
-// so search returns dataset-global indices in chunk order. A per-chunk-local id
-// regression would return 0-based ids from the far chunk and this test would catch it.
-TEST_CASE("build_ivf_flat_index_from_chunks tags global ids across chunks", "[vss]")
+// so search returns dataset-global indices in batch order. A per-batch-local id
+// regression would return 0-based ids from the far batch and this test would catch it.
+TEST_CASE("build_ivf_flat_index_from_batches tags global ids across batches", "[vss]")
 {
   constexpr cudf::size_type dim = 2;
   auto const stream             = cudf::get_default_stream();
   auto const mr                 = cudf::get_current_device_resource_ref();
 
-  // Chunk A -> global rows 0,1,2 near the origin.
-  auto chunk_a = make_fixed_size_float_list({0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f}, 3, dim);
-  // Chunk B -> global rows 3,4,5 near (10,10).
-  auto chunk_b = make_fixed_size_float_list({10.0f, 10.0f, 11.0f, 10.0f, 10.0f, 11.0f}, 3, dim);
+  // batch A -> global rows 0,1,2 near the origin.
+  auto batch_a = make_fixed_size_float_list({0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f}, 3, dim);
+  // batch B -> global rows 3,4,5 near (10,10).
+  auto batch_b = make_fixed_size_float_list({10.0f, 10.0f, 11.0f, 10.0f, 10.0f, 11.0f}, 3, dim);
 
   constexpr std::uint32_t n_lists  = 2;
   constexpr std::uint32_t n_probes = n_lists;  // exact
-  auto index                       = build_ivf_flat_index_from_chunks(
-    {chunk_a->view(), chunk_b->view()}, dim, n_lists, Metric::L2SqrtExpanded, mr);
+  auto index                       = build_ivf_flat_index_from_batches(
+    {batch_a->view(), batch_b->view()}, dim, n_lists, Metric::L2SqrtExpanded, mr, stream);
 
-  SECTION("a query in chunk B returns its global id 3, not a chunk-local 0")
+  SECTION("a query in batch B returns its global id 3, not a batch-local 0")
   {
     auto q      = upload({10.1f, 10.1f}, stream);
     auto result = search_ivf_flat_index(
@@ -191,11 +191,11 @@ TEST_CASE("build_ivf_flat_index_from_chunks tags global ids across chunks", "[vs
     auto neighbors = to_host_i64(result.neighbors->view());
     REQUIRE(neighbors[0] == 3);
     for (auto id : neighbors) {
-      REQUIRE(id >= 3);  // every near neighbour lives in the far chunk
+      REQUIRE(id >= 3);  // every near neighbor lives in the far batch
     }
   }
 
-  SECTION("a query in chunk A still returns global id 0")
+  SECTION("a query in batch A still returns global id 0")
   {
     auto q      = upload({0.1f, 0.1f}, stream);
     auto result = search_ivf_flat_index(
@@ -203,68 +203,75 @@ TEST_CASE("build_ivf_flat_index_from_chunks tags global ids across chunks", "[vs
     auto neighbors = to_host_i64(result.neighbors->view());
     REQUIRE(neighbors[0] == 0);
     for (auto id : neighbors) {
-      REQUIRE(id < 3);  // every near neighbour lives in the origin chunk
+      REQUIRE(id < 3);  // every near neighbor lives in the origin batch
     }
   }
 }
 
-// An empty leading chunk must be skipped without shifting the global ids: the
-// first non-empty chunk still occupies [0, rows), so a subsequent chunk's ids are
+// An empty leading batch must be skipped without shifting the global ids: the
+// first non-empty batch still occupies [0, rows), so a subsequent batch's ids are
 // offset only by real rows.
-TEST_CASE("build_ivf_flat_index_from_chunks skips empty chunks without shifting ids", "[vss]")
+TEST_CASE("build_ivf_flat_index_from_batches skips empty batches without shifting ids", "[vss]")
 {
   constexpr cudf::size_type dim = 2;
   auto const stream             = cudf::get_default_stream();
   auto const mr                 = cudf::get_current_device_resource_ref();
 
   auto empty   = make_fixed_size_float_list({}, 0, dim);
-  auto chunk_a = make_fixed_size_float_list({0.0f, 0.0f, 1.0f, 0.0f}, 2, dim);      // ids 0,1
-  auto chunk_b = make_fixed_size_float_list({10.0f, 10.0f, 11.0f, 10.0f}, 2, dim);  // ids 2,3
+  auto batch_a = make_fixed_size_float_list({0.0f, 0.0f, 1.0f, 0.0f}, 2, dim);      // ids 0,1
+  auto batch_b = make_fixed_size_float_list({10.0f, 10.0f, 11.0f, 10.0f}, 2, dim);  // ids 2,3
 
-  auto index = build_ivf_flat_index_from_chunks(
-    {empty->view(), chunk_a->view(), empty->view(), chunk_b->view()},
+  auto index = build_ivf_flat_index_from_batches(
+    {empty->view(), batch_a->view(), empty->view(), batch_b->view()},
     dim,
     /*n_lists=*/2,
     Metric::L2SqrtExpanded,
-    mr);
+    mr,
+    stream);
 
   auto q      = upload({10.1f, 10.1f}, stream);
   auto result = search_ivf_flat_index(
     *index, static_cast<const float*>(q.data()), dim, /*k=*/1, /*n_probes=*/2, stream, mr);
-  // Chunk B follows exactly 2 real rows, so its first vector is global id 2.
+  // batch B follows exactly 2 real rows, so its first vector is global id 2.
   REQUIRE(to_host_i64(result.neighbors->view())[0] == 2);
 }
 
-TEST_CASE("build_ivf_flat_index_from_chunks rejects n_lists larger than every batch", "[vss]")
+TEST_CASE("build_ivf_flat_index_from_batches rejects n_lists larger than every batch", "[vss]")
 {
   constexpr cudf::size_type dim = 2;
   auto const mr                 = cudf::get_current_device_resource_ref();
 
   // Two non-empty batches of 2 rows each: 4 rows total, but no single batch reaches
   // n_lists=4, so kmeans cannot train the requested clusters.
-  auto chunk_a = make_fixed_size_float_list({0.0f, 0.0f, 1.0f, 0.0f}, 2, dim);
-  auto chunk_b = make_fixed_size_float_list({10.0f, 10.0f, 11.0f, 10.0f}, 2, dim);
+  auto batch_a = make_fixed_size_float_list({0.0f, 0.0f, 1.0f, 0.0f}, 2, dim);
+  auto batch_b = make_fixed_size_float_list({10.0f, 10.0f, 11.0f, 10.0f}, 2, dim);
 
-  REQUIRE_THROWS_WITH(
-    build_ivf_flat_index_from_chunks(
-      {chunk_a->view(), chunk_b->view()}, dim, /*n_lists=*/4, Metric::L2SqrtExpanded, mr),
-    Catch::Contains("no batch has at least n_lists=4"));
+  REQUIRE_THROWS_WITH(build_ivf_flat_index_from_batches({batch_a->view(), batch_b->view()},
+                                                        dim,
+                                                        /*n_lists=*/4,
+                                                        Metric::L2SqrtExpanded,
+                                                        mr,
+                                                        cudf::get_default_stream()),
+                      Catch::Contains("no batch has at least n_lists=4"));
 }
 
-TEST_CASE("build_ivf_flat_index_from_chunks rejects all-empty input", "[vss]")
+TEST_CASE("build_ivf_flat_index_from_batches rejects all-empty input", "[vss]")
 {
   constexpr cudf::size_type dim = 2;
   auto const mr                 = cudf::get_current_device_resource_ref();
 
   auto empty = make_fixed_size_float_list({}, 0, dim);
 
-  REQUIRE_THROWS_WITH(
-    build_ivf_flat_index_from_chunks(
-      {empty->view(), empty->view()}, dim, /*n_lists=*/1, Metric::L2SqrtExpanded, mr),
-    Catch::Contains("all chunks are empty"));
+  REQUIRE_THROWS_WITH(build_ivf_flat_index_from_batches({empty->view(), empty->view()},
+                                                        dim,
+                                                        /*n_lists=*/1,
+                                                        Metric::L2SqrtExpanded,
+                                                        mr,
+                                                        cudf::get_default_stream()),
+                      Catch::Contains("all batches are empty"));
 }
 
-TEST_CASE("build_ivf_flat_index_from_chunks trains on a later batch when the first is too small",
+TEST_CASE("build_ivf_flat_index_from_batches trains on a later batch when the first is too small",
           "[vss]")
 {
   constexpr cudf::size_type dim = 2;
@@ -277,8 +284,8 @@ TEST_CASE("build_ivf_flat_index_from_chunks trains on a later batch when the fir
   auto big   = make_fixed_size_float_list(
     {10.0f, 10.0f, 11.0f, 10.0f, 12.0f, 10.0f, 13.0f, 10.0f}, 4, dim);  // ids 1..4
 
-  auto index = build_ivf_flat_index_from_chunks(
-    {small->view(), big->view()}, dim, /*n_lists=*/2, Metric::L2SqrtExpanded, mr);
+  auto index = build_ivf_flat_index_from_batches(
+    {small->view(), big->view()}, dim, /*n_lists=*/2, Metric::L2SqrtExpanded, mr, stream);
 
   // Query at the first batch's only vector: it is present and returned as id 0.
   auto q      = upload({0.0f, 0.0f}, stream);
@@ -310,8 +317,8 @@ TEST_CASE("search_ivf_flat_index returns Euclidean distances for L2SqrtExpanded"
   auto dataset_col = make_fixed_size_float_list(dataset_vals, 4, dim);
 
   // Single list so every point is in it; probing it is a full (exact) scan.
-  auto index = build_ivf_flat_index_from_chunks(
-    {dataset_col->view()}, dim, /*n_lists=*/1, Metric::L2SqrtExpanded, mr);
+  auto index = build_ivf_flat_index_from_batches(
+    {dataset_col->view()}, dim, /*n_lists=*/1, Metric::L2SqrtExpanded, mr, stream);
 
   auto q      = upload({0.0f, 0.0f}, stream);
   auto result = search_ivf_flat_index(
@@ -334,8 +341,8 @@ TEST_CASE("search_ivf_flat_index handles k == n_rows", "[vss]")
 
   std::vector<float> dataset_vals = {1.0f, 5.0f, 2.0f};  // distances to 0: 1, 5, 2
   auto dataset_col                = make_fixed_size_float_list(dataset_vals, 3, dim);
-  auto index                      = build_ivf_flat_index_from_chunks(
-    {dataset_col->view()}, dim, /*n_lists=*/1, Metric::L2SqrtExpanded, mr);
+  auto index                      = build_ivf_flat_index_from_batches(
+    {dataset_col->view()}, dim, /*n_lists=*/1, Metric::L2SqrtExpanded, mr, stream);
 
   auto q      = upload({0.0f}, stream);
   auto result = search_ivf_flat_index(
@@ -371,8 +378,8 @@ TEST_CASE("build/search IVF-Flat ranks by direction for CosineExpanded", "[vss]"
     1.0f,  // row 3 -> 135 deg
   };
   auto dataset_col = make_fixed_size_float_list(dataset_vals, 4, dim);
-  auto index       = build_ivf_flat_index_from_chunks(
-    {dataset_col->view()}, dim, /*n_lists=*/1, Metric::CosineExpanded, mr);
+  auto index       = build_ivf_flat_index_from_batches(
+    {dataset_col->view()}, dim, /*n_lists=*/1, Metric::CosineExpanded, mr, stream);
 
   auto q      = upload({1.0f, 0.0f}, stream);
   auto result = search_ivf_flat_index(
@@ -386,7 +393,7 @@ TEST_CASE("build/search IVF-Flat ranks by direction for CosineExpanded", "[vss]"
   REQUIRE(distances[2] <= distances[3]);
 }
 
-TEST_CASE("build_ivf_flat_index_from_chunks rejects a dim that mismatches the column width",
+TEST_CASE("build_ivf_flat_index_from_batches rejects a dim that mismatches the column width",
           "[vss]")
 {
   constexpr cudf::size_type dim = 2;
@@ -396,28 +403,37 @@ TEST_CASE("build_ivf_flat_index_from_chunks rejects a dim that mismatches the co
 
   // Column rows are width 2; asking the builder to read them as width 3 must be
   // rejected by the dataset-view validation, not silently misinterpreted.
-  REQUIRE_THROWS(build_ivf_flat_index_from_chunks(
-    {col->view()}, /*dim=*/3, /*n_lists=*/1, Metric::L2SqrtExpanded, mr));
+  REQUIRE_THROWS(build_ivf_flat_index_from_batches({col->view()},
+                                                   /*dim=*/3,
+                                                   /*n_lists=*/1,
+                                                   Metric::L2SqrtExpanded,
+                                                   mr,
+                                                   cudf::get_default_stream()));
 }
 
-TEST_CASE("build_ivf_flat_index_from_chunks rejects empty chunk sets", "[vss]")
+TEST_CASE("build_ivf_flat_index_from_batches rejects empty batch sets", "[vss]")
 {
   constexpr cudf::size_type dim = 2;
   auto const mr                 = cudf::get_current_device_resource_ref();
 
-  SECTION("no chunks at all throws")
+  SECTION("no batches at all throws")
   {
     std::vector<cudf::column_view> none;
     REQUIRE_THROWS_AS(
-      build_ivf_flat_index_from_chunks(none, dim, /*n_lists=*/1, Metric::L2SqrtExpanded, mr),
+      build_ivf_flat_index_from_batches(
+        none, dim, /*n_lists=*/1, Metric::L2SqrtExpanded, mr, cudf::get_default_stream()),
       std::invalid_argument);
   }
 
-  SECTION("all-empty chunks throw")
+  SECTION("all-empty batches throw")
   {
     auto empty = make_fixed_size_float_list({}, 0, dim);
-    REQUIRE_THROWS_AS(build_ivf_flat_index_from_chunks(
-                        {empty->view()}, dim, /*n_lists=*/1, Metric::L2SqrtExpanded, mr),
+    REQUIRE_THROWS_AS(build_ivf_flat_index_from_batches({empty->view()},
+                                                        dim,
+                                                        /*n_lists=*/1,
+                                                        Metric::L2SqrtExpanded,
+                                                        mr,
+                                                        cudf::get_default_stream()),
                       std::invalid_argument);
   }
 }

--- a/test/cpp/vss/test_ivf_flat_index.cpp
+++ b/test/cpp/vss/test_ivf_flat_index.cpp
@@ -235,6 +235,58 @@ TEST_CASE("build_ivf_flat_index_from_chunks skips empty chunks without shifting 
   REQUIRE(to_host_i64(result.neighbors->view())[0] == 2);
 }
 
+TEST_CASE("build_ivf_flat_index_from_chunks rejects n_lists larger than every batch", "[vss]")
+{
+  constexpr cudf::size_type dim = 2;
+  auto const mr                 = cudf::get_current_device_resource_ref();
+
+  // Two non-empty batches of 2 rows each: 4 rows total, but no single batch reaches
+  // n_lists=4, so kmeans cannot train the requested clusters.
+  auto chunk_a = make_fixed_size_float_list({0.0f, 0.0f, 1.0f, 0.0f}, 2, dim);
+  auto chunk_b = make_fixed_size_float_list({10.0f, 10.0f, 11.0f, 10.0f}, 2, dim);
+
+  REQUIRE_THROWS_WITH(
+    build_ivf_flat_index_from_chunks(
+      {chunk_a->view(), chunk_b->view()}, dim, /*n_lists=*/4, Metric::L2SqrtExpanded, mr),
+    Catch::Contains("no batch has at least n_lists=4"));
+}
+
+TEST_CASE("build_ivf_flat_index_from_chunks rejects all-empty input", "[vss]")
+{
+  constexpr cudf::size_type dim = 2;
+  auto const mr                 = cudf::get_current_device_resource_ref();
+
+  auto empty = make_fixed_size_float_list({}, 0, dim);
+
+  REQUIRE_THROWS_WITH(
+    build_ivf_flat_index_from_chunks(
+      {empty->view(), empty->view()}, dim, /*n_lists=*/1, Metric::L2SqrtExpanded, mr),
+    Catch::Contains("all chunks are empty"));
+}
+
+TEST_CASE("build_ivf_flat_index_from_chunks trains on a later batch when the first is too small",
+          "[vss]")
+{
+  constexpr cudf::size_type dim = 2;
+  auto const stream             = cudf::get_default_stream();
+  auto const mr                 = cudf::get_current_device_resource_ref();
+
+  // First batch has 1 row (< n_lists), so it can't train, but the second can. The
+  // small first batch must still be indexed as data (global id 0), not dropped.
+  auto small = make_fixed_size_float_list({0.0f, 0.0f}, 1, dim);  // id 0
+  auto big   = make_fixed_size_float_list(
+    {10.0f, 10.0f, 11.0f, 10.0f, 12.0f, 10.0f, 13.0f, 10.0f}, 4, dim);  // ids 1..4
+
+  auto index = build_ivf_flat_index_from_chunks(
+    {small->view(), big->view()}, dim, /*n_lists=*/2, Metric::L2SqrtExpanded, mr);
+
+  // Query at the first batch's only vector: it is present and returned as id 0.
+  auto q      = upload({0.0f, 0.0f}, stream);
+  auto result = search_ivf_flat_index(
+    *index, static_cast<const float*>(q.data()), dim, /*k=*/1, /*n_probes=*/2, stream, mr);
+  REQUIRE(to_host_i64(result.neighbors->view())[0] == 0);
+}
+
 // Pin the distance magnitude: L2SqrtExpanded must yield Euclidean (rooted)
 // distances, which is the array_distance contract the ANN operator relies on.
 // Ordering-only checks would let a squared-L2 regression pass silently.

--- a/test/cpp/vss/test_ivf_flat_index.cpp
+++ b/test/cpp/vss/test_ivf_flat_index.cpp
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// test
+#include <catch.hpp>
+
+// sirius
+#include <vss/ivf_flat_index.hpp>
+
+// cudf
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+// rmm
+#include <rmm/device_buffer.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+using sirius::vss::build_ivf_flat_index_from_chunks;
+using sirius::vss::search_ivf_flat_index;
+using Metric = cuvs::distance::DistanceType;
+
+// Build a Sirius-style ARRAY<FLOAT>[dim] column (cudf LIST with a contiguous,
+// uniform FLOAT32 values child); i.e., the shape the builder wraps per chunk.
+std::unique_ptr<cudf::column> make_fixed_size_float_list(std::vector<float> const& values,
+                                                         cudf::size_type n_rows,
+                                                         cudf::size_type dim)
+{
+  auto child = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::FLOAT32}, n_rows * dim, cudf::mask_state::UNALLOCATED);
+  cudaMemcpy(child->mutable_view().data<float>(),
+             values.data(),
+             sizeof(float) * values.size(),
+             cudaMemcpyHostToDevice);
+
+  std::vector<int32_t> offsets(n_rows + 1);
+  for (cudf::size_type i = 0; i <= n_rows; ++i) {
+    offsets[i] = i * dim;
+  }
+  auto offsets_col = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT32}, n_rows + 1, cudf::mask_state::UNALLOCATED);
+  cudaMemcpy(offsets_col->mutable_view().data<int32_t>(),
+             offsets.data(),
+             sizeof(int32_t) * offsets.size(),
+             cudaMemcpyHostToDevice);
+
+  return cudf::make_lists_column(
+    n_rows, std::move(offsets_col), std::move(child), 0, rmm::device_buffer{});
+}
+
+// Upload a host query vector to the device (search requires a device pointer)
+rmm::device_buffer upload(std::vector<float> const& v, rmm::cuda_stream_view stream)
+{
+  rmm::device_buffer buf(v.size() * sizeof(float), stream);
+  cudaMemcpyAsync(buf.data(), v.data(), buf.size(), cudaMemcpyHostToDevice, stream.value());
+  stream.synchronize();
+  return buf;
+}
+
+std::vector<int64_t> to_host_i64(cudf::column_view const& col)
+{
+  std::vector<int64_t> host(col.size());
+  cudaMemcpy(
+    host.data(), col.data<int64_t>(), sizeof(int64_t) * host.size(), cudaMemcpyDeviceToHost);
+  return host;
+}
+
+std::vector<float> to_host_f(cudf::column_view const& col)
+{
+  std::vector<float> host(col.size());
+  cudaMemcpy(host.data(), col.data<float>(), sizeof(float) * host.size(), cudaMemcpyDeviceToHost);
+  return host;
+}
+
+}  // namespace
+
+TEST_CASE("build_ivf_flat_index_from_chunks + search finds exact nearest neighbours", "[vss]")
+{
+  constexpr cudf::size_type dim = 2;
+  auto const stream             = cudf::get_default_stream();
+  auto const mr                 = cudf::get_current_device_resource_ref();
+
+  // Two well-separated clusters: rows 0-2 near the origin, rows 3-5 near (10,10).
+  std::vector<float> dataset_vals = {
+    0.0f,
+    0.0f,  // row 0
+    1.0f,
+    0.0f,  // row 1
+    0.0f,
+    1.0f,  // row 2
+    10.0f,
+    10.0f,  // row 3
+    11.0f,
+    10.0f,  // row 4
+    10.0f,
+    11.0f,  // row 5
+  };
+  auto dataset_col = make_fixed_size_float_list(dataset_vals, 6, dim);
+
+  // n_probes == n_lists probes every list, so the search considers all points and
+  // is exact; the ANN approximation only kicks in when fewer lists are probed.
+  constexpr std::uint32_t n_lists  = 2;
+  constexpr std::uint32_t n_probes = n_lists;
+  auto index                       = build_ivf_flat_index_from_chunks(
+    {dataset_col->view()}, dim, n_lists, Metric::L2SqrtExpanded, mr);
+
+  SECTION("query in the origin cluster returns row 0")
+  {
+    auto q      = upload({0.1f, 0.1f}, stream);
+    auto result = search_ivf_flat_index(
+      *index, static_cast<const float*>(q.data()), dim, /*k=*/1, n_probes, stream, mr);
+
+    REQUIRE(result.neighbors->size() == 1);
+    REQUIRE(result.distances->size() == 1);
+    REQUIRE(to_host_i64(result.neighbors->view())[0] == 0);
+  }
+
+  SECTION("query in the far cluster returns row 3")
+  {
+    auto q      = upload({10.1f, 10.1f}, stream);
+    auto result = search_ivf_flat_index(
+      *index, static_cast<const float*>(q.data()), dim, /*k=*/1, n_probes, stream, mr);
+
+    REQUIRE(to_host_i64(result.neighbors->view())[0] == 3);
+  }
+
+  SECTION("k = 3 for an origin query stays within the origin cluster, ordered")
+  {
+    auto q      = upload({0.1f, 0.1f}, stream);
+    auto result = search_ivf_flat_index(
+      *index, static_cast<const float*>(q.data()), dim, /*k=*/3, n_probes, stream, mr);
+
+    auto neighbors = to_host_i64(result.neighbors->view());
+    auto distances = to_host_f(result.distances->view());
+    REQUIRE(neighbors[0] == 0);
+    REQUIRE(neighbors[1] < 3);
+    REQUIRE(neighbors[2] < 3);
+    REQUIRE(distances[0] <= distances[1]);
+    REQUIRE(distances[1] <= distances[2]);
+  }
+}
+
+// The chunked builder populates the index chunk by chunk via ivf_flat::extend,
+// tagging each vector with its GLOBAL row id (offset by the rows already added)
+// so search returns dataset-global indices in chunk order. A per-chunk-local id
+// regression would return 0-based ids from the far chunk and this test would catch it.
+TEST_CASE("build_ivf_flat_index_from_chunks tags global ids across chunks", "[vss]")
+{
+  constexpr cudf::size_type dim = 2;
+  auto const stream             = cudf::get_default_stream();
+  auto const mr                 = cudf::get_current_device_resource_ref();
+
+  // Chunk A -> global rows 0,1,2 near the origin.
+  auto chunk_a = make_fixed_size_float_list({0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f}, 3, dim);
+  // Chunk B -> global rows 3,4,5 near (10,10).
+  auto chunk_b = make_fixed_size_float_list({10.0f, 10.0f, 11.0f, 10.0f, 10.0f, 11.0f}, 3, dim);
+
+  constexpr std::uint32_t n_lists  = 2;
+  constexpr std::uint32_t n_probes = n_lists;  // exact
+  auto index                       = build_ivf_flat_index_from_chunks(
+    {chunk_a->view(), chunk_b->view()}, dim, n_lists, Metric::L2SqrtExpanded, mr);
+
+  SECTION("a query in chunk B returns its global id 3, not a chunk-local 0")
+  {
+    auto q      = upload({10.1f, 10.1f}, stream);
+    auto result = search_ivf_flat_index(
+      *index, static_cast<const float*>(q.data()), dim, /*k=*/3, n_probes, stream, mr);
+    auto neighbors = to_host_i64(result.neighbors->view());
+    REQUIRE(neighbors[0] == 3);
+    for (auto id : neighbors) {
+      REQUIRE(id >= 3);  // every near neighbour lives in the far chunk
+    }
+  }
+
+  SECTION("a query in chunk A still returns global id 0")
+  {
+    auto q      = upload({0.1f, 0.1f}, stream);
+    auto result = search_ivf_flat_index(
+      *index, static_cast<const float*>(q.data()), dim, /*k=*/3, n_probes, stream, mr);
+    auto neighbors = to_host_i64(result.neighbors->view());
+    REQUIRE(neighbors[0] == 0);
+    for (auto id : neighbors) {
+      REQUIRE(id < 3);  // every near neighbour lives in the origin chunk
+    }
+  }
+}
+
+// An empty leading chunk must be skipped without shifting the global ids: the
+// first non-empty chunk still occupies [0, rows), so a subsequent chunk's ids are
+// offset only by real rows.
+TEST_CASE("build_ivf_flat_index_from_chunks skips empty chunks without shifting ids", "[vss]")
+{
+  constexpr cudf::size_type dim = 2;
+  auto const stream             = cudf::get_default_stream();
+  auto const mr                 = cudf::get_current_device_resource_ref();
+
+  auto empty   = make_fixed_size_float_list({}, 0, dim);
+  auto chunk_a = make_fixed_size_float_list({0.0f, 0.0f, 1.0f, 0.0f}, 2, dim);      // ids 0,1
+  auto chunk_b = make_fixed_size_float_list({10.0f, 10.0f, 11.0f, 10.0f}, 2, dim);  // ids 2,3
+
+  auto index = build_ivf_flat_index_from_chunks(
+    {empty->view(), chunk_a->view(), empty->view(), chunk_b->view()},
+    dim,
+    /*n_lists=*/2,
+    Metric::L2SqrtExpanded,
+    mr);
+
+  auto q      = upload({10.1f, 10.1f}, stream);
+  auto result = search_ivf_flat_index(
+    *index, static_cast<const float*>(q.data()), dim, /*k=*/1, /*n_probes=*/2, stream, mr);
+  // Chunk B follows exactly 2 real rows, so its first vector is global id 2.
+  REQUIRE(to_host_i64(result.neighbors->view())[0] == 2);
+}
+
+// Pin the distance magnitude: L2SqrtExpanded must yield Euclidean (rooted)
+// distances, which is the array_distance contract the ANN operator relies on.
+// Ordering-only checks would let a squared-L2 regression pass silently.
+TEST_CASE("search_ivf_flat_index returns Euclidean distances for L2SqrtExpanded", "[vss]")
+{
+  constexpr cudf::size_type dim = 2;
+  auto const stream             = cudf::get_default_stream();
+  auto const mr                 = cudf::get_current_device_resource_ref();
+
+  // Pythagorean rows so the distances to the origin are exact: 0, 5, 10, 13.
+  std::vector<float> dataset_vals = {
+    0.0f,
+    0.0f,  // row 0 -> 0
+    3.0f,
+    4.0f,  // row 1 -> 5
+    8.0f,
+    6.0f,  // row 2 -> 10
+    5.0f,
+    12.0f,  // row 3 -> 13
+  };
+  auto dataset_col = make_fixed_size_float_list(dataset_vals, 4, dim);
+
+  // Single list so every point is in it; probing it is a full (exact) scan.
+  auto index = build_ivf_flat_index_from_chunks(
+    {dataset_col->view()}, dim, /*n_lists=*/1, Metric::L2SqrtExpanded, mr);
+
+  auto q      = upload({0.0f, 0.0f}, stream);
+  auto result = search_ivf_flat_index(
+    *index, static_cast<const float*>(q.data()), dim, /*k=*/4, /*n_probes=*/1, stream, mr);
+
+  auto neighbors = to_host_i64(result.neighbors->view());
+  auto distances = to_host_f(result.distances->view());
+  REQUIRE(neighbors == std::vector<int64_t>{0, 1, 2, 3});
+  REQUIRE(distances[0] == Approx(0.0f));
+  REQUIRE(distances[1] == Approx(5.0f));
+  REQUIRE(distances[2] == Approx(10.0f));
+  REQUIRE(distances[3] == Approx(13.0f));
+}
+
+TEST_CASE("search_ivf_flat_index handles k == n_rows", "[vss]")
+{
+  constexpr cudf::size_type dim = 1;
+  auto const stream             = cudf::get_default_stream();
+  auto const mr                 = cudf::get_current_device_resource_ref();
+
+  std::vector<float> dataset_vals = {1.0f, 5.0f, 2.0f};  // distances to 0: 1, 5, 2
+  auto dataset_col                = make_fixed_size_float_list(dataset_vals, 3, dim);
+  auto index                      = build_ivf_flat_index_from_chunks(
+    {dataset_col->view()}, dim, /*n_lists=*/1, Metric::L2SqrtExpanded, mr);
+
+  auto q      = upload({0.0f}, stream);
+  auto result = search_ivf_flat_index(
+    *index, static_cast<const float*>(q.data()), dim, /*k=*/3, /*n_probes=*/1, stream, mr);
+
+  auto neighbors = to_host_i64(result.neighbors->view());
+  auto distances = to_host_f(result.distances->view());
+  REQUIRE(neighbors == std::vector<int64_t>{0, 2, 1});  // 1 < 2 < 5
+  REQUIRE(distances[0] == Approx(1.0f));
+  REQUIRE(distances[1] == Approx(2.0f));
+  REQUIRE(distances[2] == Approx(5.0f));
+}
+
+// cuVS IVF-Flat supports CosineExpanded; verify it ranks by direction (nearest =
+// smallest angle) so the operator's ascending-by-distance sort is correct for
+// cosine too. Magnitudes are left unpinned (cuVS owns the cosine-distance scale),
+// but the strictly-separated angles make the neighbour ORDER unambiguous.
+TEST_CASE("build/search IVF-Flat ranks by direction for CosineExpanded", "[vss]")
+{
+  constexpr cudf::size_type dim = 2;
+  auto const stream             = cudf::get_default_stream();
+  auto const mr                 = cudf::get_current_device_resource_ref();
+
+  // Directions at 0, 45, 90, 135 degrees from the query [1,0].
+  std::vector<float> dataset_vals = {
+    1.0f,
+    0.0f,  // row 0 -> 0 deg (identical direction)
+    1.0f,
+    1.0f,  // row 1 -> 45 deg
+    0.0f,
+    1.0f,  // row 2 -> 90 deg
+    -1.0f,
+    1.0f,  // row 3 -> 135 deg
+  };
+  auto dataset_col = make_fixed_size_float_list(dataset_vals, 4, dim);
+  auto index       = build_ivf_flat_index_from_chunks(
+    {dataset_col->view()}, dim, /*n_lists=*/1, Metric::CosineExpanded, mr);
+
+  auto q      = upload({1.0f, 0.0f}, stream);
+  auto result = search_ivf_flat_index(
+    *index, static_cast<const float*>(q.data()), dim, /*k=*/4, /*n_probes=*/1, stream, mr);
+
+  auto neighbors = to_host_i64(result.neighbors->view());
+  auto distances = to_host_f(result.distances->view());
+  REQUIRE(neighbors == std::vector<int64_t>{0, 1, 2, 3});  // increasing angle
+  REQUIRE(distances[0] <= distances[1]);
+  REQUIRE(distances[1] <= distances[2]);
+  REQUIRE(distances[2] <= distances[3]);
+}
+
+TEST_CASE("build_ivf_flat_index_from_chunks rejects a dim that mismatches the column width",
+          "[vss]")
+{
+  constexpr cudf::size_type dim = 2;
+  auto const mr                 = cudf::get_current_device_resource_ref();
+  std::vector<float> vals       = {0.0f, 0.0f, 1.0f, 1.0f};
+  auto col                      = make_fixed_size_float_list(vals, 2, dim);
+
+  // Column rows are width 2; asking the builder to read them as width 3 must be
+  // rejected by the dataset-view validation, not silently misinterpreted.
+  REQUIRE_THROWS(build_ivf_flat_index_from_chunks(
+    {col->view()}, /*dim=*/3, /*n_lists=*/1, Metric::L2SqrtExpanded, mr));
+}
+
+TEST_CASE("build_ivf_flat_index_from_chunks rejects empty chunk sets", "[vss]")
+{
+  constexpr cudf::size_type dim = 2;
+  auto const mr                 = cudf::get_current_device_resource_ref();
+
+  SECTION("no chunks at all throws")
+  {
+    std::vector<cudf::column_view> none;
+    REQUIRE_THROWS_AS(
+      build_ivf_flat_index_from_chunks(none, dim, /*n_lists=*/1, Metric::L2SqrtExpanded, mr),
+      std::invalid_argument);
+  }
+
+  SECTION("all-empty chunks throw")
+  {
+    auto empty = make_fixed_size_float_list({}, 0, dim);
+    REQUIRE_THROWS_AS(build_ivf_flat_index_from_chunks(
+                        {empty->view()}, dim, /*n_lists=*/1, Metric::L2SqrtExpanded, mr),
+                      std::invalid_argument);
+  }
+}
+
+TEST_CASE("search_ivf_flat_index rejects an index that is not IVF-Flat", "[vss]")
+{
+  auto const stream = cudf::get_default_stream();
+  auto const mr     = cudf::get_current_device_resource_ref();
+
+  // A type-erased holder of the wrong concrete type: the search's dynamic_cast
+  // back to the IVF-Flat index must fail loudly rather than reinterpret memory.
+  auto not_ivf_flat = sirius::vss::make_cuvs_index(int{7});
+  auto q            = upload({0.0f}, stream);
+  REQUIRE_THROWS_AS(search_ivf_flat_index(*not_ivf_flat,
+                                          static_cast<const float*>(q.data()),
+                                          /*dim=*/1,
+                                          /*k=*/1,
+                                          /*n_probes=*/1,
+                                          stream,
+                                          mr),
+                    std::invalid_argument);
+}


### PR DESCRIPTION
## Description

### Summary

- **New Table Functions**: `sirius_create_ann_index` builds an IVF-Flat index and `sirius_drop_ann_index` removes one. Both **require** the table to be pinned on GPU.
- **New cache interface**: for ANN index and the cache is keyed on the index's routing identity (catalog, schema, table, column, metric) with length prefixed.
- **Memory**: The index footprint is reserved upfront to admit the build against the GPU budget. The reservation is bound to the build stream so the build's allocations are charged and bounded by it, then released once the index is built. The finished index is ordinary capacity-accounted GPU memory, freed when the cache entry is erased or the session ends.
- **Impl**: Collect the column's GPU batches as views (zero-copy) and build the IVF-Flat index incrementally (one batch at a time). This avoids materializing the whole dataset but the tradeoff is that recall degrades at low `n_probes`.
- **Scope**: prototype. The index is a point-in-time snapshot of the pinned table at build time; it does not track updates, so any post-build INSERT/DELETE or unpin/re-pin needs an explicit rebuild.


### Sample queries

<details>
    <summary><strong>Expand to see sample queries</strong></summary>

```bash
# start Sirius with a persistent file
SIRIUS_LOG_LEVEL=debug ./build/release/duckdb test.duckdb
```

```sql
-- creating dataset
CREATE TABLE test_arrays (id INTEGER, vec FLOAT[3]);
INSERT INTO test_arrays SELECT i, [i::float, (i+1)::float, (i+2)::float] FROM range(5000) t(i);
CHECKPOINT; -- checkpoint is needed

-- cache the table
SELECT * FROM pin_table(name => 'test_arrays', tier => 'gpu', format => 'duckdb');

-- create ann index
SELECT * FROM sirius_create_ann_index(
    'test_arrays',                    -- table   (positional; must be GPU-pinned)
    'vec',                            -- column  (positional)
    metric      => 'l2',              -- default 'l2'  (one of 'l2', 'cosine')
    index_type  => 'ivf_flat',        -- default 'ivf_flat' (only 'ivf_flat' supported today)
    n_lists     => 1024,              -- default 0 (0 = choose a default at build time)
    schema_name => 'main'             -- default 'main'
);

-- or using all defaults
SELECT * FROM sirius_create_ann_index('test_arrays', 'vec');

-- drop an index
-- a given metric drops just that one
SELECT * FROM sirius_drop_ann_index('test_arrays', 'vec', metric => 'l2');

-- or drops every metric on the column
SELECT * FROM sirius_drop_ann_index('test_arrays', 'vec');
```

</details>

### Changes

**Table Functions**
- **`src/sirius_extension.cpp`**: Register `sirius_create_ann_index` and `sirius_drop_ann_index` with bind & execute logic.
- **`src/include/vss/distance_metric.hpp`, `src/vss/distance_metric.cpp`**: Helper functions routing the metric to the corresponding distance function.

**ANN Index Cache Interface**
- **`src/include/vss/ivf_flat_index.hpp`, `src/cuda/vss/ivf_flat_index.cu`**: Build IVF-Flat index and approximate search kernel, plus the metric → cuVS `DistanceType` mapping helpers.
- **`src/include/vss/cuvs_index_cache.hpp`, `src/vss/cuvs_index_cache.cpp`**: New session cache for pinned cuVS indexes which reserves GPU memory via the reservation manager, stores the type-erased index + metadata, and looks up by the length-prefixed identity key (`build_ann_index_cache_key`), plus erase/clear.

**Caches**
- **`src/include/sirius_context.hpp`, `src/sirius_context.cpp`**: Own the `cuvs_index_cache` on the Sirius context (constructed with the memory manager, exposed via accessor, torn down before the manager).

**Build**
- **`CMakeLists.txt`**: add the VSS sources and test files to the build.

**Tests**

- **`test/cpp/vss/test_cuvs_index_cache.cpp`**: insert/lookup (by identity key), in-place replace, erase/clear, and a reservation-accounting regression that verifies a build binds to its reservation and leaks no reserved memory.
- **`test/cpp/vss/test_distance_metric.cpp`**: routing metrics helper validation.
- **`test/cpp/vss/test_ivf_flat_index.cpp`**: incremental batched build (global-id tagging, empty-batch skipping) + approximate search (L2/cosine, k == n_rows) + metric mapping/rejections.
- **`test/cpp/integration/test_gpu_execution_vector_search.cpp`**: end-to-end `sirius_create_ann_index`, including a prepared statement re-execution case that verifies each execution rebuilds and returns its success row.

## Checklist
- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
Refs #1204 (stacked on the ENN branch)