### PR TITLE
feat: query-time INSERT deltas for the duckdb-native pinned cache (#819 PR4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,7 @@ set(EXTENSION_SOURCES
     src/op/partition/gpu_partition_impl.cpp
     src/op/result/host_table_chunk_reader.cpp
     src/op/scan/cached_ranges.cpp
+    src/op/scan/duckdb_insert_delta.cpp
     src/op/scan/duckdb_mvcc_visibility.cpp
     src/op/scan/duckdb_native_metadata.cpp
     src/op/scan/duckdb_native_decoder.cpp
@@ -686,6 +687,7 @@ set(TEST_SOURCES
     test/cpp/scan/bench_decode_codecs.cpp
     test/cpp/scan/test_can_serve_with_columns.cpp
     test/cpp/scan/test_duckdb_block_layout.cpp
+    test/cpp/scan/test_duckdb_insert_delta.cpp
     test/cpp/scan/test_duckdb_mvcc_visibility.cpp
     test/cpp/scan/test_duckdb_native_batch_coalescer.cpp
     test/cpp/scan/test_duckdb_native_dynamic_filter_remap.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -613,6 +613,7 @@ set(TEST_SOURCES
     test/cpp/integration/test_pin_table_column_order.cpp
     test/cpp/integration/test_pin_table_mvcc_delete.cpp
     test/cpp/integration/test_pin_table_mvcc_foundation.cpp
+    test/cpp/integration/test_pin_table_mvcc_insert.cpp
     test/cpp/integration/test_pin_table_zone_map_pruning.cpp
     test/cpp/integration/test_table_gpu_cache_warm_mgpu.cpp
     test/cpp/integration/test_transparent_runtime_fallback.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,6 +689,7 @@ set(TEST_SOURCES
     test/cpp/scan/test_duckdb_mvcc_visibility.cpp
     test/cpp/scan/test_duckdb_native_batch_coalescer.cpp
     test/cpp/scan/test_duckdb_native_dynamic_filter_remap.cpp
+    test/cpp/scan/test_duckdb_native_host_backed_decode.cpp
     test/cpp/scan/test_duckdb_native_walker.cpp
     test/cpp/scan/test_dynamic_filter_merge.cpp
     test/cpp/scan/test_gpu_decode_alp.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,6 +346,7 @@ set(EXTENSION_SOURCES
     src/planner/sirius_plan_top_n.cpp
     src/pin_table.cpp
     src/scan_manager/load_balancing_scan_batch_coalescer.cpp
+    src/scan_manager/insert_delta_job.cpp
     src/scan_manager/mvcc_mask_job.cpp
     src/scan_manager/pinned_chunk_stats.cpp
     src/scan_manager/round_robin_strategy.cpp
@@ -628,6 +629,7 @@ set(TEST_SOURCES
     test/cpp/scan_manager/test_s3_routing_cutover.cpp
     test/cpp/scan_manager/test_pin_table_multi_gpu.cpp
     test/cpp/scan_manager/test_cached_serving_hardening.cpp
+    test/cpp/scan_manager/test_insert_delta_job.cpp
     test/cpp/scan_manager/test_mvcc_mask_job.cpp
     test/cpp/scan_manager/test_pinned_chunk_stats.cpp
     test/cpp/operator/test_physical_grouped_aggregate_merge_mgpu.cpp

--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -183,7 +183,7 @@ A lock-protected queue of pre-built splits. The producer (sequencer) enqueues vi
 
 ## Pinned Tables
 
-**Files:** `src/include/pin_table.hpp`, `src/pin_table.cpp`; pinned-entry storage + cache matching in `src/include/scan_manager/sirius_scan_manager.hpp` and `src/scan_manager/sirius_scan_manager.cpp`; zone-map capture and pruning in `src/include/scan_manager/pinned_chunk_stats.hpp` and `src/scan_manager/pinned_chunk_stats.cpp`.
+**Files:** `src/include/pin_table.hpp`, `src/pin_table.cpp`; pinned-entry storage + cache matching in `src/include/scan_manager/sirius_scan_manager.hpp` and `src/scan_manager/sirius_scan_manager.cpp`; zone-map capture and pruning in `src/include/scan_manager/pinned_chunk_stats.hpp` and `src/scan_manager/pinned_chunk_stats.cpp`; MVCC reconciliation in `src/op/scan/duckdb_mvcc_visibility.cpp`, `src/scan_manager/mvcc_mask_job.cpp`, `src/op/scan/duckdb_insert_delta.cpp`, and `src/scan_manager/insert_delta_job.cpp` (with their headers).
 
 The `pin_table` table function pre-loads a table's columns into memory so subsequent scans of the same source bypass file I/O entirely. It supports both source formats and two memory tiers.
 
@@ -223,6 +223,15 @@ During `prepare_for_query`, `try_assign_cached_entries` matches each `GPU_SCAN` 
 ### Re-pin semantics
 
 For the GPU tier, `insert_pinned_entry` merges into an existing entry when the row count matches (adding only columns not already cached; per-chunk memory-space placement must match) and replaces it otherwise. The HOST tier always replaces, since each host chunk already holds every column.
+
+### MVCC under concurrent DML (duckdb pins)
+
+A duckdb-format pin caches the table's **checkpointed prefix**: physical rows `[0, n_cache)` in on-disk order. `pin_table` refuses tables where that prefix is not stable — rows with in-flight update chains, or committed-but-uncheckpointed appends ("run CHECKPOINT before pinning"). After the pin the table stays fully writable; each query reconciles the cached prefix with the table's current state during `prepare_for_query`, against that query's own transaction snapshot:
+
+- **Deletes** — a per-entry mask job walks the row groups covering the prefix with the query's transaction and builds a bit-packed keep-mask (cuDF validity convention) in pinned host memory, fanned out across scan-manager threads. Chunks with no invisible rows skip masking entirely; masked chunks apply the bitmask on device right after the resident batch materializes. A checkpoint that reshapes the row groups under a live pin makes the capture throw rather than serve drifted positions.
+- **Inserts** — physical rows `[n_cache, N_total)` form the query's **insert delta**. Membership is positional; reading branches per segment: `TRANSIENT` segments (small appends, always `UNCOMPRESSED`) are copied into cuda-pinned staging at prepare time, releasing the DuckDB block pins before serving starts, while `PERSISTENT` segments (bulk appends flushed by `MergeStorage`, compressed like a checkpoint) keep their block references and decode through the normal file-read lane. Row groups the snapshot proves all-invisible are skipped whole; partially visible ones stage fully and carry a keep-mask like deleted base chunks. The delta is bundled to roughly the scan batch size, captured once per entry per query (a self-join stages one copy), and served as ordinary duckdb-native scan splits after the resident chunks — decoded on the GPU even for host-tier entries.
+
+States the delta cannot represent decline at plan time into the transparent CPU fallback: the querying transaction's own uncommitted rows (`LocalStorage`), rowid-only projections, `ARRAY` projections while a delta exists, and string columns whose statistics no longer fit the GPU string-decode limits. In-place `UPDATE`s after the pin (DuckDB update chains) are not yet detected — affected rows serve their pre-update values, for base and delta rows alike. The delta is re-captured and re-staged on every query, so a pinned table under sustained insert churn pays that cost until the next `CHECKPOINT` + re-pin; delta splits also carry no zone maps, so filter pruning never drops them.
 
 ### Zone maps
 
@@ -490,6 +499,10 @@ The converter builds a `gpu_ingestible` and parks it on the `GPU_SCAN` operator.
 | `src/include/scan_manager/round_robin_strategy.hpp` / `.cpp` | Round-robin GPU placement |
 | `src/include/scan_manager/config.hpp` | `scan_manager_config` |
 | `src/include/scan_manager/pinned_chunk_stats.hpp` / `.cpp` | Pin-time per-chunk min/max capture, filter-safety check + prune probe |
+| `src/include/op/scan/duckdb_mvcc_visibility.hpp` / `src/op/scan/duckdb_mvcc_visibility.cpp` | Snapshot visibility walk: delete keep-masks + pin-time DML guards |
+| `src/include/scan_manager/mvcc_mask_job.hpp` / `src/scan_manager/mvcc_mask_job.cpp` | Per-query delete-mask jobs over pinned entries |
+| `src/include/op/scan/duckdb_insert_delta.hpp` / `src/op/scan/duckdb_insert_delta.cpp` | Insert-delta capture + visibility count / staging-copy task bodies |
+| `src/include/scan_manager/insert_delta_job.hpp` / `src/scan_manager/insert_delta_job.cpp` | Per-query insert-delta jobs: bundling, staging carve, per-op split cuts |
 | `src/include/pin_table.hpp` / `src/pin_table.cpp` | `pin_table` / `unpin_table` + pin materialization |
 | `src/include/op/scan/cached_ranges.hpp` / `src/op/scan/cached_ranges.cpp` | Sorted byte-range coalescing/lookup |
 | `src/include/op/sirius_physical_gpu_values.hpp` / `src/op/sirius_physical_gpu_values.cpp` | `GPU_VALUES` source for `ColumnDataCollection`, empty-result, and dummy-scan inputs |

--- a/src/include/op/scan/duckdb_insert_delta.hpp
+++ b/src/include/op/scan/duckdb_insert_delta.hpp
@@ -83,11 +83,11 @@ struct insert_delta_column {
 
 /// One row group's slice of the insert delta.
 ///
-/// k_offset counts this row group's rows below n_cache. It is always 0 today:
-/// pins start checkpoint-clean and post-checkpoint appends open a fresh row
-/// group (RowGroupAppendMode::REQUIRE_NEW), so n_cache lands on a row-group
-/// boundary. The k > 0 handling stays in case an append path ever grows an
-/// existing row group's tail.
+/// k_offset counts this row group's rows below n_cache. Index-free tables
+/// keep it 0: post-checkpoint appends open a fresh row group, so n_cache
+/// lands on a row-group boundary. Indexed tables (e.g. a PRIMARY KEY) append
+/// into the existing tail row group instead, so the delta's first rows sit
+/// inside the boundary row group and k_offset > 0.
 struct insert_delta_row_group {
   duckdb::RowGroup* row_group{nullptr};  ///< tree-owned; stable while pinned (no checkpoints)
   duckdb::idx_t row_group_index{0};
@@ -125,7 +125,9 @@ struct insert_delta_plan {
  * touches the ClientContext). Captures the transaction, buffer manager, and
  * n_total snapshot, then enumerates skeleton row groups overlapping
  * [n_cache, n_total): pointers, indices, boundaries (clamped to the
- * snapshot), and version-state flags. Columns, staging offsets, and budgets
+ * snapshot), and version-state flags. The walk binary-searches the row group
+ * holding the last cached row and starts there, so its cost scales with the
+ * delta rather than the cached prefix. Columns, staging offsets, and budgets
  * stay empty until capture_insert_delta_row_group_range fills them.
  */
 insert_delta_plan prepare_insert_delta_capture(duckdb::DataTable& storage,

--- a/src/include/op/scan/duckdb_insert_delta.hpp
+++ b/src/include/op/scan/duckdb_insert_delta.hpp
@@ -121,19 +121,43 @@ struct insert_delta_plan {
 };
 
 /**
- * Build the insert-delta plan for one pinned duckdb table. Serial: call from
- * the prepare/query thread only, since it uses the ClientContext and takes
- * segment tree locks.
+ * Capture phase 1 (serial; prepare/query thread only — the only phase that
+ * touches the ClientContext). Captures the transaction, buffer manager, and
+ * n_total snapshot, then enumerates skeleton row groups overlapping
+ * [n_cache, n_total): pointers, indices, boundaries (clamped to the
+ * snapshot), and version-state flags. Columns, staging offsets, and budgets
+ * stay empty until capture_insert_delta_row_group_range fills them.
+ */
+insert_delta_plan prepare_insert_delta_capture(duckdb::DataTable& storage,
+                                               duckdb::ClientContext& context,
+                                               std::size_t n_cache);
+
+/**
+ * Capture phase 2: walk the column segment trees for skeleton row groups
+ * [rg_begin, min(rg_end, size)) of @p plan and return the completed row
+ * groups in order. Task-safe — touches only the row-group column trees
+ * (under their segment-tree locks), never the ClientContext or LocalStorage;
+ * disjoint ranges of one plan may run concurrently.
  *
- * Walks the row groups overlapping [n_cache, GetTotalRows()). Throws on
- * states the plan-time guards should have excluded or that break the pin
- * contract: a compressed transient segment, a varchar segment at the
+ * Throws on states the plan-time guards should have excluded or that break
+ * the pin contract: a compressed transient segment, a varchar segment at the
  * overflow-block limit, an unsupported persistent codec, an ARRAY column, or
  * non-StandardColumnData storage.
  *
  * @param storage_column_indices Union of the querying operators' storage
  *        columns; per-operator splits are cut from it later.
  * @param column_types Parallel to storage_column_indices.
+ */
+std::vector<insert_delta_row_group> capture_insert_delta_row_group_range(
+  insert_delta_plan const& plan,
+  std::size_t rg_begin,
+  std::size_t rg_end,
+  std::span<duckdb::storage_t const> storage_column_indices,
+  std::span<sirius::logical_type const> column_types);
+
+/**
+ * Serial convenience: prepare_insert_delta_capture plus one full-plan
+ * capture_insert_delta_row_group_range on the calling thread.
  */
 insert_delta_plan capture_insert_delta_plan(
   duckdb::DataTable& storage,

--- a/src/include/op/scan/duckdb_insert_delta.hpp
+++ b/src/include/op/scan/duckdb_insert_delta.hpp
@@ -19,7 +19,6 @@
 #include <duckdb/common/enums/compression_type.hpp>
 #include <duckdb/common/typedefs.hpp>
 #include <duckdb/common/types.hpp>
-#include <duckdb/function/partition_stats.hpp>
 #include <duckdb/transaction/transaction_data.hpp>
 #include <helper/logical_type.hpp>
 #include <op/scan/duckdb_native_metadata.hpp>
@@ -58,6 +57,10 @@ struct insert_delta_segment {
   duckdb::ColumnSegment* segment{nullptr};  ///< Pin target for the transient copy task
   bool is_transient{false};
   bool is_validity{false};
+  bool all_null{false};  ///< CONSTANT validity marked all-NULL by its stats; blockless
+  /// CONSTANT data segments: capture-time snapshot of the segment's own stats
+  /// (the constant value); see duckdb_segment_descriptor::segment_stats.
+  std::shared_ptr<duckdb::BaseStatistics> segment_stats;
   duckdb::block_id_t block_id{-1};                    ///< persistent only
   std::vector<duckdb::block_id_t> additional_blocks;  ///< persistent only (overflow blocks)
   duckdb::idx_t block_offset{0};                      ///< persistent only
@@ -112,9 +115,6 @@ struct insert_delta_plan {
   std::size_t n_cache{0};
   std::size_t n_total{0};  ///< GetTotalRows() snapshot; all walks clamp to it
   std::vector<insert_delta_row_group> row_groups;
-  /// Capture-time partition stats, carried onto delta splits so CONSTANT
-  /// segment decode never calls GetPartitionStats off the query thread.
-  std::shared_ptr<duckdb::vector<duckdb::PartitionStatistics>> partition_stats;
 
   [[nodiscard]] bool empty() const { return row_groups.empty(); }
   [[nodiscard]] std::size_t delta_rows() const { return n_total - n_cache; }

--- a/src/include/op/scan/duckdb_insert_delta.hpp
+++ b/src/include/op/scan/duckdb_insert_delta.hpp
@@ -41,25 +41,19 @@ class RowGroup;
 
 namespace sirius::op::scan {
 
-/**
- * @brief One segment's contribution to the insert delta of one row group.
- *
- * The delta is positional — physical rows [n_cache, n_total) — and a segment
- * joins it regardless of its type; only the BYTE PATH branches:
- *  - TRANSIENT (small committed appends): in-memory only. A prepare-time task
- *    pins the segment's buffer and memcpys [copy_src_offset, +bytes_size)
- *    into cuda-pinned staging (slab_offset within the row group's slab); the
- *    decode descriptor gets a host_ptr. Always UNCOMPRESSED (asserted).
- *  - PERSISTENT (bulk appends, optimistically flushed by MergeStorage):
- *    checkpoint-shaped blocks in the .db file, compressed like a checkpoint.
- *    The descriptor keeps block_id/block_offset and rides the decoder's
- *    existing file-read lane; no prepare-time byte work.
- *
- * `segment_start` is rebased to the row group's DELTA slice (absolute rowid
- * `rg.row_group_start + segment_start`); segments never straddle the pin
- * boundary (appends start exactly at the persistent tail), so only the tail
- * clamp against the n_total snapshot ever shortens one.
- */
+/// One segment's contribution to a row group's insert delta.
+///
+/// Only the byte path depends on the segment type. Transient segments live in
+/// memory and must be uncompressed; a prepare task copies
+/// [copy_src_offset, +bytes_size) into cuda-pinned staging at slab_offset and
+/// the decoder reads that host pointer. Persistent segments are bulk appends
+/// that MergeStorage optimistically flushed as checkpoint-shaped blocks; the
+/// decoder reads them from the .db file by block_id/block_offset and nothing
+/// is staged.
+///
+/// segment_start is relative to the row group's delta slice. Appends begin at
+/// the persistent tail, so a segment never straddles the pin boundary; only
+/// the clamp to the n_total snapshot can shorten one.
 struct insert_delta_segment {
   duckdb::ColumnSegment* segment{nullptr};  ///< Pin target for the transient copy task
   bool is_transient{false};
@@ -76,7 +70,7 @@ struct insert_delta_segment {
   std::size_t slab_offset{0};      ///< transient: byte offset within the row group's staging slab
 };
 
-/// Per-column delta segments, mirroring duckdb_column_metadata's data/validity split.
+/// One column's delta segments, split into data and validity.
 struct insert_delta_column {
   duckdb::idx_t column_id{0};
   bool is_varchar{false};
@@ -84,21 +78,17 @@ struct insert_delta_column {
   std::vector<insert_delta_segment> validity_segments;
 };
 
-/**
- * @brief One row group's slice of the insert delta.
- *
- * `k_offset` is the number of this row group's rows below n_cache. With
- * current DuckDB append semantics it is always 0 — post-checkpoint appends
- * open a FRESH row group (RowGroupAppendMode::REQUIRE_NEW), and pins start
- * checkpoint-clean, so n_cache lands on a row-group boundary. The k > 0
- * handling (boundary-vector intersection in the visibility walk, rebased
- * segment math) is kept as defensive generality against tail-growing append
- * variants.
- */
+/// One row group's slice of the insert delta.
+///
+/// k_offset counts this row group's rows below n_cache. It is always 0 today:
+/// pins start checkpoint-clean and post-checkpoint appends open a fresh row
+/// group (RowGroupAppendMode::REQUIRE_NEW), so n_cache lands on a row-group
+/// boundary. The k > 0 handling stays in case an append path ever grows an
+/// existing row group's tail.
 struct insert_delta_row_group {
   duckdb::RowGroup* row_group{nullptr};  ///< tree-owned; stable while pinned (no checkpoints)
   duckdb::idx_t row_group_index{0};
-  std::size_t row_group_start{0};  ///< absolute rowid of the FIRST DELTA row (rg start + k_offset)
+  std::size_t row_group_start{0};  ///< absolute rowid of the first delta row
   std::size_t k_offset{0};
   std::size_t row_count{0};  ///< delta rows covered (tail-clamped to the n_total snapshot)
   bool has_version_state{false};
@@ -108,15 +98,13 @@ struct insert_delta_row_group {
   std::size_t transient_staging_bytes{0};          ///< pinned slab bytes this row group needs
 };
 
-/**
- * @brief Serial capture of everything the insert-delta job needs for one
- *        pinned entry: the query transaction, the n_total snapshot, and the
- *        per-row-group segment plan over [n_cache, n_total).
- *
- * Holds tree-owned pointers (RowGroup / ColumnSegment) — stable for the
- * query's prepare window because checkpoints are suppressed while pinned and
- * committed segments are never rewritten in place.
- */
+/// Everything the insert-delta job needs for one pinned entry: the query
+/// transaction, the n_total snapshot, and the per-row-group segment plan for
+/// physical rows [n_cache, n_total).
+///
+/// Holds tree-owned RowGroup and ColumnSegment pointers. They stay valid for
+/// the prepare window because checkpoints are suppressed while pinned and
+/// committed segments are never rewritten in place.
 struct insert_delta_plan {
   duckdb::TransactionData transaction{
     duckdb::TransactionData(duckdb::transaction_t{0}, duckdb::transaction_t{0})};
@@ -133,21 +121,19 @@ struct insert_delta_plan {
 };
 
 /**
- * @brief Build the insert-delta plan for one pinned duckdb table. SERIAL —
- *        prepare/query thread only (ClientContext discipline; takes segment
- *        tree locks while walking).
+ * Build the insert-delta plan for one pinned duckdb table. Serial: call from
+ * the prepare/query thread only, since it uses the ClientContext and takes
+ * segment tree locks.
  *
- * Walks the row groups overlapping [n_cache, GetTotalRows()), branching per
- * SEGMENT on segment_type (see insert_delta_segment). Throws on states the
- * plan-time guards should have excluded or that violate the pin contract:
- * a compressed TRANSIENT segment (a checkpoint ran while pinned), a varchar
- * segment at/over the overflow-block limit, an unsupported persistent codec,
- * an ARRAY column (declined at plan time in v1), or non-StandardColumnData
- * storage.
+ * Walks the row groups overlapping [n_cache, GetTotalRows()). Throws on
+ * states the plan-time guards should have excluded or that break the pin
+ * contract: a compressed transient segment, a varchar segment at the
+ * overflow-block limit, an unsupported persistent codec, an ARRAY column, or
+ * non-StandardColumnData storage.
  *
- * @param storage_column_indices The union of the querying operators' storage
- *        columns (superset staging; per-operator splits are cut later).
- * @param column_types Parallel to @p storage_column_indices.
+ * @param storage_column_indices Union of the querying operators' storage
+ *        columns; per-operator splits are cut from it later.
+ * @param column_types Parallel to storage_column_indices.
  */
 insert_delta_plan capture_insert_delta_plan(
   duckdb::DataTable& storage,
@@ -157,15 +143,14 @@ insert_delta_plan capture_insert_delta_plan(
   std::span<sirius::logical_type const> column_types);
 
 /**
- * @brief Visibility counting pass for one delta row group — task-safe
- *        (GetSelVector serializes on the row group's own version lock).
+ * Count one delta row group's visible rows, setting one bit per visible row
+ * at mask_bit_offset + (row - first delta row). Task-safe: GetSelVector
+ * serializes on the row group's version lock.
  *
- * Sets one bit per VISIBLE delta row into @p mask_words at
- * @p mask_bit_offset + (row - first delta row); the caller pre-zeroes the
- * words (single writer per bundle mask, so no alignment constraints beyond
- * not sharing words across concurrent bundles).
+ * The caller pre-zeroes mask_words. Concurrent callers must not share mask
+ * words.
  *
- * @return the number of visible delta rows.
+ * @return Number of visible delta rows.
  */
 std::size_t count_visible_delta_rows(insert_delta_row_group const& rg,
                                      duckdb::TransactionData transaction,
@@ -173,11 +158,10 @@ std::size_t count_visible_delta_rows(insert_delta_row_group const& rg,
                                      std::size_t mask_bit_offset);
 
 /**
- * @brief Copy one delta row group's TRANSIENT segment bytes into its staging
- *        slab — task-safe. Pins each segment's buffer just long enough to
- *        memcpy [copy_src_offset, +bytes_size) to slab_base + slab_offset;
- *        no DuckDB handle outlives the call. Persistent segments need no
- *        byte work (the decoder's file lane reads them at materialize).
+ * Copy one delta row group's transient segment bytes into its staging slab.
+ * Task-safe. Each segment's buffer is pinned only for the memcpy; no DuckDB
+ * handle outlives the call. Persistent segments are skipped; the decoder
+ * reads them from the file.
  */
 void copy_delta_row_group(insert_delta_row_group const& rg,
                           duckdb::BufferManager& buffer_manager,

--- a/src/include/op/scan/duckdb_insert_delta.hpp
+++ b/src/include/op/scan/duckdb_insert_delta.hpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <duckdb/common/enums/compression_type.hpp>
+#include <duckdb/common/typedefs.hpp>
+#include <duckdb/common/types.hpp>
+#include <duckdb/function/partition_stats.hpp>
+#include <duckdb/transaction/transaction_data.hpp>
+#include <helper/logical_type.hpp>
+#include <op/scan/duckdb_native_metadata.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace duckdb {
+class BufferManager;
+class ClientContext;
+class ColumnSegment;
+class DataTable;
+class RowGroup;
+}  // namespace duckdb
+
+namespace sirius::op::scan {
+
+/**
+ * @brief One segment's contribution to the insert delta of one row group.
+ *
+ * The delta is positional — physical rows [n_cache, n_total) — and a segment
+ * joins it regardless of its type; only the BYTE PATH branches:
+ *  - TRANSIENT (small committed appends): in-memory only. A prepare-time task
+ *    pins the segment's buffer and memcpys [copy_src_offset, +bytes_size)
+ *    into cuda-pinned staging (slab_offset within the row group's slab); the
+ *    decode descriptor gets a host_ptr. Always UNCOMPRESSED (asserted).
+ *  - PERSISTENT (bulk appends, optimistically flushed by MergeStorage):
+ *    checkpoint-shaped blocks in the .db file, compressed like a checkpoint.
+ *    The descriptor keeps block_id/block_offset and rides the decoder's
+ *    existing file-read lane; no prepare-time byte work.
+ *
+ * `segment_start` is rebased to the row group's DELTA slice (absolute rowid
+ * `rg.row_group_start + segment_start`); segments never straddle the pin
+ * boundary (appends start exactly at the persistent tail), so only the tail
+ * clamp against the n_total snapshot ever shortens one.
+ */
+struct insert_delta_segment {
+  duckdb::ColumnSegment* segment{nullptr};  ///< Pin target for the transient copy task
+  bool is_transient{false};
+  bool is_validity{false};
+  duckdb::block_id_t block_id{-1};                    ///< persistent only
+  std::vector<duckdb::block_id_t> additional_blocks;  ///< persistent only (overflow blocks)
+  duckdb::idx_t block_offset{0};                      ///< persistent only
+  duckdb::idx_t segment_start{0};                     ///< rebased to the delta slice
+  duckdb::idx_t segment_count{0};                     ///< covered delta rows
+  duckdb::CompressionType compression{duckdb::CompressionType::COMPRESSION_AUTO};
+  std::optional<std::uint32_t> max_string_length;  ///< varchar data segments only
+  std::size_t bytes_size{0};  ///< staging extent (transient) / payload upper bound (persistent)
+  std::size_t copy_src_offset{0};  ///< transient: byte offset into the pinned buffer
+  std::size_t slab_offset{0};      ///< transient: byte offset within the row group's staging slab
+};
+
+/// Per-column delta segments, mirroring duckdb_column_metadata's data/validity split.
+struct insert_delta_column {
+  duckdb::idx_t column_id{0};
+  bool is_varchar{false};
+  std::vector<insert_delta_segment> data_segments;
+  std::vector<insert_delta_segment> validity_segments;
+};
+
+/**
+ * @brief One row group's slice of the insert delta.
+ *
+ * `k_offset` is the number of this row group's rows below n_cache. With
+ * current DuckDB append semantics it is always 0 — post-checkpoint appends
+ * open a FRESH row group (RowGroupAppendMode::REQUIRE_NEW), and pins start
+ * checkpoint-clean, so n_cache lands on a row-group boundary. The k > 0
+ * handling (boundary-vector intersection in the visibility walk, rebased
+ * segment math) is kept as defensive generality against tail-growing append
+ * variants.
+ */
+struct insert_delta_row_group {
+  duckdb::RowGroup* row_group{nullptr};  ///< tree-owned; stable while pinned (no checkpoints)
+  duckdb::idx_t row_group_index{0};
+  std::size_t row_group_start{0};  ///< absolute rowid of the FIRST DELTA row (rg start + k_offset)
+  std::size_t k_offset{0};
+  std::size_t row_count{0};  ///< delta rows covered (tail-clamped to the n_total snapshot)
+  bool has_version_state{false};
+  std::vector<insert_delta_column> columns;  ///< parallel to the capture's column list
+  std::size_t decoded_bytes_budget{0};
+  std::vector<std::size_t> varchar_bytes_per_col;  ///< parallel to columns; 0 for non-varchar
+  std::size_t transient_staging_bytes{0};          ///< pinned slab bytes this row group needs
+};
+
+/**
+ * @brief Serial capture of everything the insert-delta job needs for one
+ *        pinned entry: the query transaction, the n_total snapshot, and the
+ *        per-row-group segment plan over [n_cache, n_total).
+ *
+ * Holds tree-owned pointers (RowGroup / ColumnSegment) — stable for the
+ * query's prepare window because checkpoints are suppressed while pinned and
+ * committed segments are never rewritten in place.
+ */
+struct insert_delta_plan {
+  duckdb::TransactionData transaction{
+    duckdb::TransactionData(duckdb::transaction_t{0}, duckdb::transaction_t{0})};
+  duckdb::BufferManager* buffer_manager{nullptr};
+  std::size_t n_cache{0};
+  std::size_t n_total{0};  ///< GetTotalRows() snapshot; all walks clamp to it
+  std::vector<insert_delta_row_group> row_groups;
+  /// Capture-time partition stats, carried onto delta splits so CONSTANT
+  /// segment decode never calls GetPartitionStats off the query thread.
+  std::shared_ptr<duckdb::vector<duckdb::PartitionStatistics>> partition_stats;
+
+  [[nodiscard]] bool empty() const { return row_groups.empty(); }
+  [[nodiscard]] std::size_t delta_rows() const { return n_total - n_cache; }
+};
+
+/**
+ * @brief Build the insert-delta plan for one pinned duckdb table. SERIAL —
+ *        prepare/query thread only (ClientContext discipline; takes segment
+ *        tree locks while walking).
+ *
+ * Walks the row groups overlapping [n_cache, GetTotalRows()), branching per
+ * SEGMENT on segment_type (see insert_delta_segment). Throws on states the
+ * plan-time guards should have excluded or that violate the pin contract:
+ * a compressed TRANSIENT segment (a checkpoint ran while pinned), a varchar
+ * segment at/over the overflow-block limit, an unsupported persistent codec,
+ * an ARRAY column (declined at plan time in v1), or non-StandardColumnData
+ * storage.
+ *
+ * @param storage_column_indices The union of the querying operators' storage
+ *        columns (superset staging; per-operator splits are cut later).
+ * @param column_types Parallel to @p storage_column_indices.
+ */
+insert_delta_plan capture_insert_delta_plan(
+  duckdb::DataTable& storage,
+  duckdb::ClientContext& context,
+  std::size_t n_cache,
+  std::span<duckdb::storage_t const> storage_column_indices,
+  std::span<sirius::logical_type const> column_types);
+
+/**
+ * @brief Visibility counting pass for one delta row group — task-safe
+ *        (GetSelVector serializes on the row group's own version lock).
+ *
+ * Sets one bit per VISIBLE delta row into @p mask_words at
+ * @p mask_bit_offset + (row - first delta row); the caller pre-zeroes the
+ * words (single writer per bundle mask, so no alignment constraints beyond
+ * not sharing words across concurrent bundles).
+ *
+ * @return the number of visible delta rows.
+ */
+std::size_t count_visible_delta_rows(insert_delta_row_group const& rg,
+                                     duckdb::TransactionData transaction,
+                                     std::span<std::uint32_t> mask_words,
+                                     std::size_t mask_bit_offset);
+
+/**
+ * @brief Copy one delta row group's TRANSIENT segment bytes into its staging
+ *        slab — task-safe. Pins each segment's buffer just long enough to
+ *        memcpy [copy_src_offset, +bytes_size) to slab_base + slab_offset;
+ *        no DuckDB handle outlives the call. Persistent segments need no
+ *        byte work (the decoder's file lane reads them at materialize).
+ */
+void copy_delta_row_group(insert_delta_row_group const& rg,
+                          duckdb::BufferManager& buffer_manager,
+                          std::uint8_t* slab_base);
+
+}  // namespace sirius::op::scan

--- a/src/include/op/scan/duckdb_mvcc_visibility.hpp
+++ b/src/include/op/scan/duckdb_mvcc_visibility.hpp
@@ -88,9 +88,10 @@ struct mvcc_visibility_plan {
  *
  * Throws std::runtime_error on invariants validated at pin time
  * (validate_duckdb_pin_chunk): start_time < v_base (a re-pin raced
- * plan->prepare), non-contiguous or short row-group coverage, a chunk
- * boundary off a row-group start, or a slice offset not 32-row aligned (the
- * lock-free bit fill requires task ranges to never share a mask word).
+ * plan->prepare), non-contiguous or short row-group coverage, or a chunk
+ * boundary off a row-group start. Slice offsets may be unaligned
+ * (checkpoint-grown tables have row groups of arbitrary sizes); the mask job
+ * fills such chunks through a single task.
  */
 mvcc_visibility_plan capture_mvcc_visibility_plan(
   duckdb::DataTable& storage,
@@ -100,14 +101,14 @@ mvcc_visibility_plan capture_mvcc_visibility_plan(
 /**
  * @brief Fill the keep-mask bits for @p slices (all belonging to ONE chunk).
  *
- * Worker-safe with plain stores: concurrent calls over disjoint slice lists
- * write disjoint words (slice offsets are 32-row aligned, asserted at
- * capture). Writes exactly bits [chunk_offset, chunk_offset + row_count) per
- * slice, 1 = keep; a slice without version state bulk-sets ones with no MVCC
- * calls or locks, otherwise each 2048-row vector goes through
- * RowGroup::GetSelVector. Whole-word writes never collide with a later
- * writer (a partial vector ends its slice; a partial slice ends the table),
- * and padding bits past the covered range are don't-care.
+ * Worker-safe with plain stores when concurrent callers never share a mask
+ * word: the mask job slices parallel tasks only on word-aligned slice
+ * offsets and fills chunks with unaligned offsets (checkpoint-grown tables)
+ * through a single task. Writes exactly bits [chunk_offset, chunk_offset +
+ * row_count) per slice, 1 = keep — bit-exact at word edges, preserving
+ * neighbouring slices' bits (the words are zero-initialized at carve time);
+ * a slice without version state bulk-sets ones with no MVCC calls or locks,
+ * otherwise each 2048-row vector goes through RowGroup::GetSelVector.
  *
  * @return true when any row in the covered range was dropped.
  */

--- a/src/include/op/scan/duckdb_mvcc_visibility.hpp
+++ b/src/include/op/scan/duckdb_mvcc_visibility.hpp
@@ -129,6 +129,20 @@ bool any_update_chains(duckdb::DataTable& storage,
                        std::span<duckdb::storage_t const> storage_column_indices,
                        std::size_t row_prefix);
 
+/**
+ * @brief True when any row group carries TRANSIENT (in-memory, uncheckpointed)
+ *        segments on any of @p storage_column_indices.
+ *
+ * Committed small appends land as transient segments the pin's disk-image
+ * walk cannot stage; pin_table refuses such tables deliberately (CHECKPOINT
+ * folds them into the persistent image). Bulk-flushed appends (MergeStorage
+ * after a >= row-group-sized insert) are PERSISTENT-uncheckpointed and
+ * checkpoint-shaped — indistinguishable from checkpointed data, deliberately
+ * not detected here. SERIAL — may lazily load column data.
+ */
+bool any_uncheckpointed_appends(duckdb::DataTable& storage,
+                                std::span<duckdb::storage_t const> storage_column_indices);
+
 /// Whether the MVCC-blind disk-native read of a table is exact for a given
 /// snapshot, and if not, why.
 enum class native_read_mvcc_state : std::uint8_t {

--- a/src/include/op/scan/duckdb_mvcc_visibility.hpp
+++ b/src/include/op/scan/duckdb_mvcc_visibility.hpp
@@ -101,14 +101,14 @@ mvcc_visibility_plan capture_mvcc_visibility_plan(
 /**
  * @brief Fill the keep-mask bits for @p slices (all belonging to ONE chunk).
  *
- * Worker-safe with plain stores when concurrent callers never share a mask
- * word: the mask job slices parallel tasks only on word-aligned slice
- * offsets and fills chunks with unaligned offsets (checkpoint-grown tables)
- * through a single task. Writes exactly bits [chunk_offset, chunk_offset +
- * row_count) per slice, 1 = keep — bit-exact at word edges, preserving
- * neighbouring slices' bits (the words are zero-initialized at carve time);
- * a slice without version state bulk-sets ones with no MVCC calls or locks,
- * otherwise each 2048-row vector goes through RowGroup::GetSelVector.
+ * Worker-safe with plain stores as long as concurrent callers never share a
+ * mask word: the mask job slices parallel tasks only on word-aligned slice
+ * offsets and fills unaligned chunks through a single task. Writes exactly
+ * bits [chunk_offset, chunk_offset + row_count) per slice, 1 = keep;
+ * read-modify-write at word edges preserves neighbouring slices' bits (the
+ * words start zeroed). A slice without version state bulk-sets ones with no
+ * MVCC calls or locks; otherwise each 2048-row vector goes through
+ * RowGroup::GetSelVector.
  *
  * @return true when any row in the covered range was dropped.
  */
@@ -130,14 +130,13 @@ bool any_update_chains(duckdb::DataTable& storage,
                        std::size_t row_prefix);
 
 /**
- * @brief True when any row group carries TRANSIENT (in-memory, uncheckpointed)
- *        segments on any of @p storage_column_indices.
+ * True when any row group carries TRANSIENT (in-memory, uncheckpointed)
+ * segments on any of @p storage_column_indices.
  *
- * Committed small appends land as transient segments the pin's disk-image
- * walk cannot stage; pin_table refuses such tables deliberately (CHECKPOINT
- * folds them into the persistent image). Bulk-flushed appends (MergeStorage
- * after a >= row-group-sized insert) are PERSISTENT-uncheckpointed and
- * checkpoint-shaped — indistinguishable from checkpointed data, deliberately
+ * Small committed appends land as transient segments the pin's disk-image
+ * walk cannot stage, so pin_table refuses such tables; CHECKPOINT folds them
+ * into the persistent image. Bulk-flushed appends (MergeStorage after a
+ * row-group-sized insert) are persistent and checkpoint-shaped, so they are
  * not detected here. SERIAL — may lazily load column data.
  */
 bool any_uncheckpointed_appends(duckdb::DataTable& storage,

--- a/src/include/op/scan/duckdb_native_decoder.hpp
+++ b/src/include/op/scan/duckdb_native_decoder.hpp
@@ -59,19 +59,14 @@ std::vector<cudf::io::text::byte_range_info> row_group_file_ranges(
 ///            rowid synthesis,
 ///            host-backed segments (`host_ptr` set; insert-delta staging).
 /// @param datasource Read handle for the .db file; may be null only when
-///        every segment is host-backed (no file reads to stage).
-/// @param carried_partition_stats Capture-time stats for CONSTANT segment
-///        decode. When null they are fetched via DataTable::GetPartitionStats,
-///        which touches ClientContext and must not run off the query thread;
-///        off-thread decodes (insert delta) must carry them.
+///        no segment stages a file read (host-backed / blockless splits).
 /// @throws std::runtime_error on any codec the walker accepted but this decoder does not implement.
 std::unique_ptr<cudf::table> decode_duckdb_native_split(
   std::vector<duckdb_row_group_metadata> const& row_groups,
   duckdb_native_ingestible_table_info const& table_info,
   sirius::io::sirius_datasource* datasource,
   cucascade::memory::memory_space& mem_space,
-  rmm::cuda_stream_view stream,
-  duckdb::vector<duckdb::PartitionStatistics> const* carried_partition_stats = nullptr);
+  rmm::cuda_stream_view stream);
 
 //===----------------------------------------------------------------------===//
 // checked_array_child_advance

--- a/src/include/op/scan/duckdb_native_decoder.hpp
+++ b/src/include/op/scan/duckdb_native_decoder.hpp
@@ -57,15 +57,13 @@ std::vector<cudf::io::text::byte_range_info> row_group_file_ranges(
 ///            varchar data (UNCOMPRESSED / DICTIONARY / FSST / DICT_FSST),
 ///            validity (UNCOMPRESSED / EMPTY / CONSTANT / ROARING),
 ///            rowid synthesis,
-///            host-backed segments (descriptor `host_ptr` set — insert-delta staging).
-/// @param datasource Read handle for the .db file. May be null only when no
-///        segment stages a file read (every descriptor host-backed); a split
-///        that stages reads with a null datasource throws.
+///            host-backed segments (`host_ptr` set; insert-delta staging).
+/// @param datasource Read handle for the .db file; may be null only when
+///        every segment is host-backed (no file reads to stage).
 /// @param carried_partition_stats Capture-time stats for CONSTANT segment
-///        decode. When null, the stats are fetched via
-///        DataTable::GetPartitionStats — which touches ClientContext and must
-///        not run off the query thread; splits built off-thread (insert delta)
-///        carry them instead.
+///        decode. When null they are fetched via DataTable::GetPartitionStats,
+///        which touches ClientContext and must not run off the query thread;
+///        off-thread decodes (insert delta) must carry them.
 /// @throws std::runtime_error on any codec the walker accepted but this decoder does not implement.
 std::unique_ptr<cudf::table> decode_duckdb_native_split(
   std::vector<duckdb_row_group_metadata> const& row_groups,

--- a/src/include/op/scan/duckdb_native_decoder.hpp
+++ b/src/include/op/scan/duckdb_native_decoder.hpp
@@ -56,14 +56,24 @@ std::vector<cudf::io::text::byte_range_info> row_group_file_ranges(
 /// Supported: fixed-width data (UNCOMPRESSED / RLE / BITPACKING / CONSTANT),
 ///            varchar data (UNCOMPRESSED / DICTIONARY / FSST / DICT_FSST),
 ///            validity (UNCOMPRESSED / EMPTY / CONSTANT / ROARING),
-///            rowid synthesis.
+///            rowid synthesis,
+///            host-backed segments (descriptor `host_ptr` set — insert-delta staging).
+/// @param datasource Read handle for the .db file. May be null only when no
+///        segment stages a file read (every descriptor host-backed); a split
+///        that stages reads with a null datasource throws.
+/// @param carried_partition_stats Capture-time stats for CONSTANT segment
+///        decode. When null, the stats are fetched via
+///        DataTable::GetPartitionStats — which touches ClientContext and must
+///        not run off the query thread; splits built off-thread (insert delta)
+///        carry them instead.
 /// @throws std::runtime_error on any codec the walker accepted but this decoder does not implement.
 std::unique_ptr<cudf::table> decode_duckdb_native_split(
   std::vector<duckdb_row_group_metadata> const& row_groups,
   duckdb_native_ingestible_table_info const& table_info,
-  sirius::io::sirius_datasource& datasource,
+  sirius::io::sirius_datasource* datasource,
   cucascade::memory::memory_space& mem_space,
-  rmm::cuda_stream_view stream);
+  rmm::cuda_stream_view stream,
+  duckdb::vector<duckdb::PartitionStatistics> const* carried_partition_stats = nullptr);
 
 //===----------------------------------------------------------------------===//
 // checked_array_child_advance

--- a/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
+++ b/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
@@ -113,6 +113,17 @@ class duckdb_native_scan_info : public op::scan::scan_info {
   std::shared_ptr<sirius::io::sirius_datasource> datasource;
   /// Resolves block ids to file offsets when deriving the on-disk ranges below.
   duckdb::SingleFileBlockManager const* block_manager = nullptr;
+  /// Owners of the bytes host-backed descriptors (`host_ptr`) point into —
+  /// insert-delta staging. Shared across the per-operator split copies cut
+  /// from one delta capture; must outlive the decode of this split.
+  std::vector<std::shared_ptr<void>> staging_keepalive;
+  /// True when every descriptor is host-backed: the split stages no file
+  /// reads and may carry a null datasource.
+  bool host_backed_only = false;
+  /// Capture-time partition stats for CONSTANT segment decode (insert delta):
+  /// stand in for DataTable::GetPartitionStats, which touches ClientContext
+  /// and is not safe off the query thread.
+  std::shared_ptr<duckdb::vector<duckdb::PartitionStatistics>> carried_partition_stats;
 
   /// On-disk byte ranges this unit reads, derived from @ref row_groups so they always match the row
   /// groups currently held. The scan sequencer fadvises these to prefetch.

--- a/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
+++ b/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
@@ -117,13 +117,10 @@ class duckdb_native_scan_info : public op::scan::scan_info {
   /// into. Shared by the per-operator splits cut from one delta capture;
   /// must outlive this split's decode.
   std::vector<std::shared_ptr<void>> staging_keepalive;
-  /// True when every descriptor is host-backed: the split stages no file
-  /// reads and may carry a null datasource.
+  /// True when no descriptor reads the .db file (host-backed or blockless
+  /// stats-backed only): the split stages no file reads and may carry a null
+  /// datasource.
   bool host_backed_only = false;
-  /// Capture-time partition stats for CONSTANT segment decode; used instead
-  /// of DataTable::GetPartitionStats, which touches ClientContext and is not
-  /// safe off the query thread.
-  std::shared_ptr<duckdb::vector<duckdb::PartitionStatistics>> carried_partition_stats;
 
   /// On-disk byte ranges this unit reads, derived from @ref row_groups so they always match the row
   /// groups currently held. The scan sequencer fadvises these to prefetch.

--- a/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
+++ b/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
@@ -113,16 +113,16 @@ class duckdb_native_scan_info : public op::scan::scan_info {
   std::shared_ptr<sirius::io::sirius_datasource> datasource;
   /// Resolves block ids to file offsets when deriving the on-disk ranges below.
   duckdb::SingleFileBlockManager const* block_manager = nullptr;
-  /// Owners of the bytes host-backed descriptors (`host_ptr`) point into —
-  /// insert-delta staging. Shared across the per-operator split copies cut
-  /// from one delta capture; must outlive the decode of this split.
+  /// Owners of the bytes that host-backed descriptors (`host_ptr`) point
+  /// into. Shared by the per-operator splits cut from one delta capture;
+  /// must outlive this split's decode.
   std::vector<std::shared_ptr<void>> staging_keepalive;
   /// True when every descriptor is host-backed: the split stages no file
   /// reads and may carry a null datasource.
   bool host_backed_only = false;
-  /// Capture-time partition stats for CONSTANT segment decode (insert delta):
-  /// stand in for DataTable::GetPartitionStats, which touches ClientContext
-  /// and is not safe off the query thread.
+  /// Capture-time partition stats for CONSTANT segment decode; used instead
+  /// of DataTable::GetPartitionStats, which touches ClientContext and is not
+  /// safe off the query thread.
   std::shared_ptr<duckdb::vector<duckdb::PartitionStatistics>> carried_partition_stats;
 
   /// On-disk byte ranges this unit reads, derived from @ref row_groups so they always match the row

--- a/src/include/op/scan/duckdb_native_metadata.hpp
+++ b/src/include/op/scan/duckdb_native_metadata.hpp
@@ -28,6 +28,7 @@
 #include <duckdb/main/client_context.hpp>
 #include <duckdb/planner/table_filter.hpp>
 #include <duckdb/storage/data_table.hpp>
+#include <duckdb/storage/statistics/base_statistics.hpp>
 #include <duckdb/storage/storage_index.hpp>
 
 #include <cstddef>
@@ -68,6 +69,15 @@ struct duckdb_segment_descriptor {
   /// bytes' owner is the enclosing scan_info's staging keep-alive, never this
   /// descriptor.
   std::uint8_t const* host_ptr = nullptr;
+  /// Validity segments only: a CONSTANT run whose stats mark it all-NULL.
+  /// Blockless — no bytes exist anywhere; the decoder synthesizes zero
+  /// validity bits for the covered rows.
+  bool all_null = false;
+  /// CONSTANT data segments: snapshot of the segment's own statistics, taken
+  /// while the segment is in hand. The decoder must take the constant value
+  /// from here — row-group-level stats merge later appends into the same row
+  /// group and can drift away from this segment's value.
+  std::shared_ptr<duckdb::BaseStatistics> segment_stats;
 };
 
 /// Side note of metadata for ARRAY type

--- a/src/include/op/scan/duckdb_native_metadata.hpp
+++ b/src/include/op/scan/duckdb_native_metadata.hpp
@@ -60,8 +60,14 @@ struct duckdb_segment_descriptor {
   /// Some; Some(0) is the legal all-empty-row-group case.
   std::optional<std::uint32_t> max_string_length;
   /// Byte size of this segment's main-block payload. Excludes
-  /// `additional_blocks`; 0 when `block_id < 0`.
+  /// `additional_blocks`; 0 when `block_id < 0` and `host_ptr` is null.
   std::size_t bytes_size = 0;
+  /// Host-backed source: when set, the decoder copies [host_ptr, host_ptr +
+  /// bytes_size) to the device instead of reading `block_id` from the file.
+  /// Used by the insert-delta job for in-memory (transient) segments; the
+  /// bytes' owner is the enclosing scan_info's staging keep-alive, never this
+  /// descriptor.
+  std::uint8_t const* host_ptr = nullptr;
 };
 
 /// Side note of metadata for ARRAY type

--- a/src/include/scan_manager/insert_delta_job.hpp
+++ b/src/include/scan_manager/insert_delta_job.hpp
@@ -146,9 +146,10 @@ struct insert_delta_workset {
 void finalize_insert_delta_jobs(insert_delta_workset& workset);
 
 /**
- * Compute every pending request's delta bundles: prepare_insert_delta_tasks,
- * fan_out_and_join, then finalize_insert_delta_jobs. Blocks so serving starts
- * with finished staging and masks.
+ * Compute every pending request's delta bundles: prepare_insert_delta_tasks
+ * (which fans the capture's column walks out over the dispatcher itself),
+ * fan_out_and_join over the fill tasks, then finalize_insert_delta_jobs.
+ * Blocks so serving starts with finished staging and masks.
  *
  * @throws std::runtime_error on failure; the plan-time CPU fallback gate has
  *         already passed, as in run_mvcc_mask_jobs.

--- a/src/include/scan_manager/insert_delta_job.hpp
+++ b/src/include/scan_manager/insert_delta_job.hpp
@@ -112,9 +112,12 @@ struct insert_delta_workset {
 };
 
 /**
- * Build the workset for every pending request: capture serially (ClientContext
- * is not thread-safe), plan bundles, carve staging and masks, build fill
- * tasks. Nothing is dispatched here.
+ * Build the workset for every pending request: capture, plan bundles, carve
+ * staging and masks, build fill tasks. The capture is two-phase — a serial
+ * prepare does the ClientContext-touching work (transaction, buffer manager,
+ * row-group skeletons), then the column segment-tree walks fan out over
+ * @p dispatcher in metadata_parse_chunk()-sized row-group ranges and merge
+ * back in row-group order. The fill tasks themselves are not dispatched here.
  *
  * A bundle closes when the next row group would exceed the
  * approximate_batch_size byte budget, push a varchar column past the cudf
@@ -126,10 +129,12 @@ struct insert_delta_workset {
  * bytes fit, else pageable memory. Mask words start zeroed; fill tasks set
  * visible bits only.
  *
- * @throws std::runtime_error on capture, validation, or reservation failure.
+ * @throws std::runtime_error on capture, validation, or reservation failure;
+ *         capture-range worker exceptions propagate through fan_out_and_join.
  */
 [[nodiscard]] insert_delta_workset prepare_insert_delta_tasks(
   std::span<insert_delta_job_request> requests,
+  exec::scoped_dispatcher& dispatcher,
   cucascade::memory::memory_reservation_manager& reservation_manager,
   sirius::memory::topology_index const& topology,
   std::span<int const> gpu_ids);

--- a/src/include/scan_manager/insert_delta_job.hpp
+++ b/src/include/scan_manager/insert_delta_job.hpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "op/scan/duckdb_insert_delta.hpp"
+#include "scan_manager/mvcc_chunk_mask.hpp"
+#include "sirius_config.hpp"
+
+#include <absl/functional/any_invocable.h>
+
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace duckdb {
+class ClientContext;
+class DataTable;
+class SingleFileBlockManager;
+}  // namespace duckdb
+
+namespace cucascade::memory {
+class memory_reservation_manager;
+}  // namespace cucascade::memory
+
+namespace sirius::exec {
+class scoped_dispatcher;
+}  // namespace sirius::exec
+
+namespace sirius::io {
+class sirius_datasource;
+}  // namespace sirius::io
+
+namespace sirius::memory {
+class topology_index;
+}  // namespace sirius::memory
+
+namespace sirius::op::scan {
+class duckdb_native_scan_info;
+}  // namespace sirius::op::scan
+
+namespace sirius::scan_manager {
+
+/**
+ * @brief One finished, batch-sized unit of the insert delta: a run of the
+ *        plan's row groups, its visibility mask, and the pinned staging the
+ *        transient copies landed in. Per-operator splits are cut from these
+ *        (sharing the staging and mask storage) at provider handoff.
+ */
+struct insert_delta_bundle {
+  std::vector<std::size_t> rg_indices;  ///< indexes into the request plan's row_groups
+  std::size_t total_rows{0};
+  /// Empty (default) when every covered row is visible — the split then skips
+  /// the mask upload + apply entirely.
+  mvcc_chunk_mask mask;
+  /// Owner of the transient staging bytes descriptors point into (pinned
+  /// {reservation, blocks} bundle or the pageable fallback).
+  std::shared_ptr<void> staging;
+  std::uint8_t* slab_base{nullptr};        ///< contiguous staging base (null if none)
+  std::vector<std::size_t> rg_slab_base;   ///< parallel to rg_indices
+  std::vector<std::size_t> rg_bit_offset;  ///< parallel to rg_indices (mask bits)
+  int preferred_device{-1};                ///< round-robin GPU for this bundle
+};
+
+/**
+ * @brief One pending per-pinned-entry insert-delta computation, recorded by
+ *        the cache-match pass (deduped by entry — a self-join queues ONE
+ *        request, accumulating the union of the operators' columns) and
+ *        executed before serving starts.
+ */
+struct insert_delta_job_request {
+  duckdb::DataTable* storage{nullptr};
+  duckdb::ClientContext* context{nullptr};
+  std::size_t n_cache{0};
+  /// Union of the requesting operators' storage columns (superset staging;
+  /// per-operator splits select their subset at cut time).
+  std::vector<duckdb::storage_t> union_cols;
+  std::vector<sirius::logical_type> union_types;  ///< parallel to union_cols
+  std::size_t approximate_batch_size{sirius::config::DEFAULT_SCAN_TASK_BATCH_SIZE};
+  std::string entry_name;
+
+  /// OUT — filled by the job: the capture (owns segment refs the bundles
+  /// index into) and the finished bundles.
+  op::scan::insert_delta_plan plan;
+  std::vector<insert_delta_bundle> bundles;
+};
+
+/// Internal per-bundle fill bookkeeping; address-stable behind unique_ptr so
+/// tasks can hold pointers.
+struct insert_delta_work {
+  insert_delta_job_request* request{nullptr};
+  std::size_t bundle_index{0};
+  std::size_t visible{0};  ///< written by the bundle's single fill task
+};
+
+/**
+ * @brief Everything prepare stages and the later steps consume: per-bundle
+ *        works and the ready-to-dispatch fill tasks (one per bundle — a
+ *        bundle's mask is single-writer, so its bit offsets need no word
+ *        alignment).
+ */
+struct insert_delta_workset {
+  std::vector<std::unique_ptr<insert_delta_work>> works;
+  std::vector<absl::AnyInvocable<void()>> fill_tasks;
+};
+
+/**
+ * @brief Stage every pending request's delta work, dispatch-free: serial
+ *        captures (prepare thread — ClientContext discipline), bundle
+ *        planning, staging + mask carve, and fill-task construction.
+ *
+ * Bundle planning walks the captured row groups in order and closes a bundle
+ * when adding the next row group would (a) exceed approximate_batch_size by
+ * decoded-byte budget, (b) push any varchar column past the cudf int32 chars
+ * threshold, or (c) leave the bundle's cumulative row count off a byte
+ * boundary (row_count % 8 != 0) — staged validity runs require byte-aligned
+ * row offsets, so such a row group always ends its bundle.
+ *
+ * Staging + mask storage per bundle: one pinned staging block when the
+ * combined bytes fit (reservation-first, on the bundle's preferred GPU's NUMA
+ * node), else a pageable fallback (only the async-DMA benefit is lost). Mask
+ * words are zero-initialized; fill tasks set visible bits only.
+ *
+ * @throws std::runtime_error on capture/validation or reservation failures.
+ */
+[[nodiscard]] insert_delta_workset prepare_insert_delta_tasks(
+  std::span<insert_delta_job_request> requests,
+  cucascade::memory::memory_reservation_manager& reservation_manager,
+  sirius::memory::topology_index const& topology,
+  std::span<int const> gpu_ids);
+
+/**
+ * @brief Drop all-invisible bundles and reset all-visible bundles' masks to
+ *        the default (unmasked fast path). Call only after every fill task
+ *        ran.
+ */
+void finalize_insert_delta_jobs(insert_delta_workset& workset);
+
+/**
+ * @brief Compute every pending request's delta bundles; blocks in prepare so
+ *        serving starts with finished staging and masks. The composition:
+ *        @ref prepare_insert_delta_tasks → fan_out_and_join →
+ *        @ref finalize_insert_delta_jobs.
+ *
+ * @throws std::runtime_error — loud by design (past the plan-time CPU
+ *         fallback gate; see run_mvcc_mask_jobs for the rationale).
+ */
+void run_insert_delta_jobs(std::span<insert_delta_job_request> requests,
+                           exec::scoped_dispatcher& dispatcher,
+                           cucascade::memory::memory_reservation_manager& reservation_manager,
+                           sirius::memory::topology_index const& topology,
+                           std::span<int const> gpu_ids);
+
+/// One per-operator split cut from a bundle: the scan_info (metadata-flavor,
+/// decoded through the existing file/host lanes) plus the mask and placement
+/// the drain attaches to the outgoing scan_operator_input.
+struct insert_delta_split {
+  std::unique_ptr<op::scan::duckdb_native_scan_info> info;
+  mvcc_chunk_mask mask;
+  int preferred_device{-1};
+};
+
+/**
+ * @brief Cut one operator's splits from @p request's finished bundles.
+ *
+ * Columns are emitted in @p op_projected_cols order (each resolved into the
+ * request's union by storage index — a rowid projection throws, the pin
+ * declines those at plan time). Splits share the bundles' staging and mask
+ * storage via their owning pointers; @p datasource / @p block_manager feed
+ * the persistent segments' file reads and prefetch hints.
+ */
+std::vector<insert_delta_split> cut_delta_splits_for_op(
+  insert_delta_job_request const& request,
+  std::span<op::scan::projected_column const> op_projected_cols,
+  std::shared_ptr<sirius::io::sirius_datasource> datasource,
+  duckdb::SingleFileBlockManager const* block_manager);
+
+}  // namespace sirius::scan_manager

--- a/src/include/scan_manager/insert_delta_job.hpp
+++ b/src/include/scan_manager/insert_delta_job.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "op/scan/duckdb_insert_delta.hpp"
+#include "op/scan/duckdb_native_gpu_ingestible.hpp"
 #include "scan_manager/mvcc_chunk_mask.hpp"
 #include "sirius_config.hpp"
 
@@ -49,10 +50,6 @@ class sirius_datasource;
 namespace sirius::memory {
 class topology_index;
 }  // namespace sirius::memory
-
-namespace sirius::op::scan {
-class duckdb_native_scan_info;
-}  // namespace sirius::op::scan
 
 namespace sirius::scan_manager {
 

--- a/src/include/scan_manager/insert_delta_job.hpp
+++ b/src/include/scan_manager/insert_delta_job.hpp
@@ -54,19 +54,17 @@ class topology_index;
 namespace sirius::scan_manager {
 
 /**
- * @brief One finished, batch-sized unit of the insert delta: a run of the
- *        plan's row groups, its visibility mask, and the pinned staging the
- *        transient copies landed in. Per-operator splits are cut from these
- *        (sharing the staging and mask storage) at provider handoff.
+ * One batch-sized unit of the insert delta: a run of the plan's row groups,
+ * their visibility mask, and the staging the transient copies landed in.
+ * Per-operator splits are cut from these and share the same storage.
  */
 struct insert_delta_bundle {
   std::vector<std::size_t> rg_indices;  ///< indexes into the request plan's row_groups
   std::size_t total_rows{0};
-  /// Empty (default) when every covered row is visible — the split then skips
-  /// the mask upload + apply entirely.
+  /// Empty when every covered row is visible; the split then skips the mask
+  /// upload and apply entirely.
   mvcc_chunk_mask mask;
-  /// Owner of the transient staging bytes descriptors point into (pinned
-  /// {reservation, blocks} bundle or the pageable fallback).
+  /// Owns the staging bytes the descriptors point into, pinned or pageable.
   std::shared_ptr<void> staging;
   std::uint8_t* slab_base{nullptr};        ///< contiguous staging base (null if none)
   std::vector<std::size_t> rg_slab_base;   ///< parallel to rg_indices
@@ -75,30 +73,28 @@ struct insert_delta_bundle {
 };
 
 /**
- * @brief One pending per-pinned-entry insert-delta computation, recorded by
- *        the cache-match pass (deduped by entry — a self-join queues ONE
- *        request, accumulating the union of the operators' columns) and
- *        executed before serving starts.
+ * One pending insert-delta computation for a pinned entry, recorded by the
+ * cache-match pass and run before serving starts. Deduped per entry: a
+ * self-join queues one request holding the union of the operators' columns.
  */
 struct insert_delta_job_request {
   duckdb::DataTable* storage{nullptr};
   duckdb::ClientContext* context{nullptr};
   std::size_t n_cache{0};
-  /// Union of the requesting operators' storage columns (superset staging;
-  /// per-operator splits select their subset at cut time).
+  /// Union of the requesting operators' storage columns; each operator's
+  /// splits select their subset at cut time.
   std::vector<duckdb::storage_t> union_cols;
   std::vector<sirius::logical_type> union_types;  ///< parallel to union_cols
   std::size_t approximate_batch_size{sirius::config::DEFAULT_SCAN_TASK_BATCH_SIZE};
   std::string entry_name;
 
-  /// OUT — filled by the job: the capture (owns segment refs the bundles
-  /// index into) and the finished bundles.
+  /// Filled by the job. The plan owns the segment refs the bundles index into.
   op::scan::insert_delta_plan plan;
   std::vector<insert_delta_bundle> bundles;
 };
 
-/// Internal per-bundle fill bookkeeping; address-stable behind unique_ptr so
-/// tasks can hold pointers.
+/// Per-bundle fill bookkeeping. Held behind unique_ptr so tasks can keep
+/// stable pointers to it.
 struct insert_delta_work {
   insert_delta_job_request* request{nullptr};
   std::size_t bundle_index{0};
@@ -106,10 +102,9 @@ struct insert_delta_work {
 };
 
 /**
- * @brief Everything prepare stages and the later steps consume: per-bundle
- *        works and the ready-to-dispatch fill tasks (one per bundle — a
- *        bundle's mask is single-writer, so its bit offsets need no word
- *        alignment).
+ * Output of prepare_insert_delta_tasks: per-bundle works and the fill tasks
+ * ready to dispatch. One task per bundle, so each mask has a single writer
+ * and bit offsets need no word alignment.
  */
 struct insert_delta_workset {
   std::vector<std::unique_ptr<insert_delta_work>> works;
@@ -117,23 +112,21 @@ struct insert_delta_workset {
 };
 
 /**
- * @brief Stage every pending request's delta work, dispatch-free: serial
- *        captures (prepare thread — ClientContext discipline), bundle
- *        planning, staging + mask carve, and fill-task construction.
+ * Build the workset for every pending request: capture serially (ClientContext
+ * is not thread-safe), plan bundles, carve staging and masks, build fill
+ * tasks. Nothing is dispatched here.
  *
- * Bundle planning walks the captured row groups in order and closes a bundle
- * when adding the next row group would (a) exceed approximate_batch_size by
- * decoded-byte budget, (b) push any varchar column past the cudf int32 chars
- * threshold, or (c) leave the bundle's cumulative row count off a byte
- * boundary (row_count % 8 != 0) — staged validity runs require byte-aligned
- * row offsets, so such a row group always ends its bundle.
+ * A bundle closes when the next row group would exceed the
+ * approximate_batch_size byte budget, push a varchar column past the cudf
+ * int32 chars threshold, or leave the cumulative row count off a byte
+ * boundary. Staged validity needs byte-aligned row offsets, so a row group
+ * with row_count % 8 != 0 always ends its bundle.
  *
- * Staging + mask storage per bundle: one pinned staging block when the
- * combined bytes fit (reservation-first, on the bundle's preferred GPU's NUMA
- * node), else a pageable fallback (only the async-DMA benefit is lost). Mask
- * words are zero-initialized; fill tasks set visible bits only.
+ * Each bundle gets one pinned staging block on its GPU's NUMA node when the
+ * bytes fit, else pageable memory. Mask words start zeroed; fill tasks set
+ * visible bits only.
  *
- * @throws std::runtime_error on capture/validation or reservation failures.
+ * @throws std::runtime_error on capture, validation, or reservation failure.
  */
 [[nodiscard]] insert_delta_workset prepare_insert_delta_tasks(
   std::span<insert_delta_job_request> requests,
@@ -142,20 +135,18 @@ struct insert_delta_workset {
   std::span<int const> gpu_ids);
 
 /**
- * @brief Drop all-invisible bundles and reset all-visible bundles' masks to
- *        the default (unmasked fast path). Call only after every fill task
- *        ran.
+ * Drop all-invisible bundles and clear all-visible bundles' masks so they
+ * serve unmasked. Call only after every fill task has run.
  */
 void finalize_insert_delta_jobs(insert_delta_workset& workset);
 
 /**
- * @brief Compute every pending request's delta bundles; blocks in prepare so
- *        serving starts with finished staging and masks. The composition:
- *        @ref prepare_insert_delta_tasks → fan_out_and_join →
- *        @ref finalize_insert_delta_jobs.
+ * Compute every pending request's delta bundles: prepare_insert_delta_tasks,
+ * fan_out_and_join, then finalize_insert_delta_jobs. Blocks so serving starts
+ * with finished staging and masks.
  *
- * @throws std::runtime_error — loud by design (past the plan-time CPU
- *         fallback gate; see run_mvcc_mask_jobs for the rationale).
+ * @throws std::runtime_error on failure; the plan-time CPU fallback gate has
+ *         already passed, as in run_mvcc_mask_jobs.
  */
 void run_insert_delta_jobs(std::span<insert_delta_job_request> requests,
                            exec::scoped_dispatcher& dispatcher,
@@ -163,9 +154,8 @@ void run_insert_delta_jobs(std::span<insert_delta_job_request> requests,
                            sirius::memory::topology_index const& topology,
                            std::span<int const> gpu_ids);
 
-/// One per-operator split cut from a bundle: the scan_info (metadata-flavor,
-/// decoded through the existing file/host lanes) plus the mask and placement
-/// the drain attaches to the outgoing scan_operator_input.
+/// One per-operator split cut from a bundle: the scan info plus the mask and
+/// placement to attach to the outgoing scan_operator_input.
 struct insert_delta_split {
   std::unique_ptr<op::scan::duckdb_native_scan_info> info;
   mvcc_chunk_mask mask;
@@ -173,13 +163,13 @@ struct insert_delta_split {
 };
 
 /**
- * @brief Cut one operator's splits from @p request's finished bundles.
+ * Cut one operator's splits from @p request's finished bundles.
  *
- * Columns are emitted in @p op_projected_cols order (each resolved into the
- * request's union by storage index — a rowid projection throws, the pin
- * declines those at plan time). Splits share the bundles' staging and mask
- * storage via their owning pointers; @p datasource / @p block_manager feed
- * the persistent segments' file reads and prefetch hints.
+ * Columns are emitted in @p op_projected_cols order, resolved into the
+ * request's union by storage index. Rowid projections throw; the pin declines
+ * those at plan time. Splits share the bundles' staging and mask storage.
+ * @p datasource and @p block_manager serve the persistent segments' file
+ * reads.
  */
 std::vector<insert_delta_split> cut_delta_splits_for_op(
   insert_delta_job_request const& request,

--- a/src/include/scan_manager/load_balancing_scan_batch_coalescer.hpp
+++ b/src/include/scan_manager/load_balancing_scan_batch_coalescer.hpp
@@ -37,10 +37,10 @@
 namespace sirius::scan_manager {
 
 struct databatch_provider {
-  /// One cached chunk OR one insert-delta split, plus its (optional)
-  /// per-query MVCC keep-mask. A batch carries EITHER @ref data (resident
-  /// cached chunk) or @ref scan_info (metadata-flavor delta split, yielded
-  /// after the resident chunks); both null means end-of-stream.
+  /// One cached chunk or one insert-delta split, plus its (optional)
+  /// per-query MVCC keep-mask. A batch carries either @ref data (resident
+  /// cached chunk) or @ref scan_info (delta split, yielded after the
+  /// resident chunks); both null means end-of-stream.
   struct batch {
     std::shared_ptr<cucascade::data_batch> data;
     mvcc_chunk_mask mvcc_keep_mask;  ///< default = all rows visible

--- a/src/include/scan_manager/load_balancing_scan_batch_coalescer.hpp
+++ b/src/include/scan_manager/load_balancing_scan_batch_coalescer.hpp
@@ -37,11 +37,15 @@
 namespace sirius::scan_manager {
 
 struct databatch_provider {
-  /// One cached chunk plus its (optional) per-query MVCC keep-mask.
-  /// A default-constructed batch (null @ref data) means end-of-stream.
+  /// One cached chunk OR one insert-delta split, plus its (optional)
+  /// per-query MVCC keep-mask. A batch carries EITHER @ref data (resident
+  /// cached chunk) or @ref scan_info (metadata-flavor delta split, yielded
+  /// after the resident chunks); both null means end-of-stream.
   struct batch {
     std::shared_ptr<cucascade::data_batch> data;
     mvcc_chunk_mask mvcc_keep_mask;  ///< default = all rows visible
+    std::unique_ptr<op::scan::scan_info> scan_info;
+    int preferred_device{-1};  ///< placement for scan_info splits (-1 = none)
   };
 
   virtual ~databatch_provider()  = default;

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -510,9 +510,9 @@ class sirius_scan_manager {
   /// reset() for the prepare-threw case).
   std::vector<mvcc_mask_job_request> _pending_mvcc_mask_jobs;
 
-  /// One insert-delta computation per distinct pinned entry matched this
-  /// query (same dedup/lifecycle as the mask jobs above; later operators
-  /// union their columns into the pending request). The job no-ops when the
+  /// One insert-delta job per distinct pinned entry matched this query, with
+  /// the same dedup and lifecycle as the mask jobs above. Later operators
+  /// union their columns into the pending request. The job no-ops when the
   /// table has no rows beyond the pinned prefix.
   std::vector<insert_delta_job_request> _pending_insert_delta_jobs;
 

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -25,6 +25,7 @@
 #include "op/scan/gpu_ingestible_types.hpp"
 #include "scan_manager/config.hpp"
 #include "scan_manager/duckdb_mvcc_metadata.hpp"
+#include "scan_manager/insert_delta_job.hpp"
 #include "scan_manager/load_balancing_scan_batch_coalescer.hpp"
 #include "scan_manager/mvcc_mask_job.hpp"
 #include "scan_manager/pinned_chunk_stats.hpp"
@@ -225,7 +226,8 @@ std::unique_ptr<databatch_provider> make_provider_for_pinned_entry(
   std::span<std::size_t const> selected_columns,
   cached_scan_plan plan,
   const telemetry::batch_telemetry_info& telemetry_info,
-  mvcc_chunk_mask_set mvcc_masks = {});
+  mvcc_chunk_mask_set mvcc_masks               = {},
+  std::vector<insert_delta_split> delta_splits = {});
 
 /**
  * @brief Build the survivor plan for serving @p entry to a scan into @p requiested_column_ids with
@@ -507,6 +509,12 @@ class sirius_scan_manager {
   /// copies each completed set out and the vector is cleared (also cleared in
   /// reset() for the prepare-threw case).
   std::vector<mvcc_mask_job_request> _pending_mvcc_mask_jobs;
+
+  /// One insert-delta computation per distinct pinned entry matched this
+  /// query (same dedup/lifecycle as the mask jobs above; later operators
+  /// union their columns into the pending request). The job no-ops when the
+  /// table has no rows beyond the pinned prefix.
+  std::vector<insert_delta_job_request> _pending_insert_delta_jobs;
 
   /// Per-query sequencer for opportunistic fadvise calls.  Built fresh
   /// in @ref prepare_for_query, gets one @c pipeline_slot per non-cached

--- a/src/op/scan/duckdb_insert_delta.cpp
+++ b/src/op/scan/duckdb_insert_delta.cpp
@@ -321,8 +321,16 @@ insert_delta_plan prepare_insert_delta_capture(duckdb::DataTable& storage,
   if (plan.n_total <= n_cache) { return plan; }
 
   auto tree = storage.GetRowGroupCollection()->GetRowGroups();
-  for (duckdb::idx_t rg_index = 0;; ++rg_index) {
-    auto node = tree->GetSegmentByIndex(static_cast<int64_t>(rg_index));
+  auto lock = tree->Lock();
+  // Row groups are contiguous and tail-append-only, so nothing below the row
+  // group holding the last cached row can contain delta rows: binary-search
+  // that boundary instead of scanning the cached prefix. The boundary row
+  // group itself stays in the walk — an indexed table's appends grow its tail
+  // (the k_offset > 0 case) — and an unchanged one costs a single iteration.
+  auto const boundary_rg =
+    n_cache == 0 ? 0 : tree->GetSegmentIndex(lock, static_cast<duckdb::idx_t>(n_cache - 1));
+  for (duckdb::idx_t rg_index = boundary_rg;; ++rg_index) {
+    auto node = tree->GetSegmentByIndex(lock, static_cast<int64_t>(rg_index));
     if (!node) { break; }
     auto& rg            = node->GetNode();
     auto const rg_start = static_cast<std::size_t>(node->GetRowStart());

--- a/src/op/scan/duckdb_insert_delta.cpp
+++ b/src/op/scan/duckdb_insert_delta.cpp
@@ -1,0 +1,398 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/scan/duckdb_insert_delta.hpp"
+
+#include <cudf/utilities/bit.hpp>
+
+#include <duckdb/common/enums/scan_options.hpp>
+#include <duckdb/common/types/selection_vector.hpp>
+#include <duckdb/common/vector_size.hpp>
+#include <duckdb/function/compression_function.hpp>
+#include <duckdb/function/partition_stats.hpp>
+#include <duckdb/main/attached_database.hpp>
+#include <duckdb/storage/buffer/buffer_handle.hpp>
+#include <duckdb/storage/buffer_manager.hpp>
+#include <duckdb/storage/data_table.hpp>
+#include <duckdb/storage/segment/uncompressed.hpp>
+#include <duckdb/storage/statistics/base_statistics.hpp>
+#include <duckdb/storage/statistics/string_stats.hpp>
+#include <duckdb/storage/table/array_column_data.hpp>
+#include <duckdb/storage/table/column_data.hpp>
+#include <duckdb/storage/table/column_segment.hpp>
+#include <duckdb/storage/table/row_group.hpp>
+#include <duckdb/storage/table/row_group_collection.hpp>
+#include <duckdb/storage/table/row_group_segment_tree.hpp>
+#include <duckdb/storage/table/segment_tree.hpp>
+#include <duckdb/storage/table/standard_column_data.hpp>
+#include <duckdb/transaction/duck_transaction.hpp>
+
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace sirius::op::scan {
+
+namespace {
+
+constexpr char const* kTag = "[insert_delta]";
+
+[[noreturn]] void throw_capture(std::string what)
+{
+  throw std::runtime_error(std::string(kTag) + " " + std::move(what));
+}
+
+// Mirrors the walker's visitor (duckdb_native_metadata.cpp): collects a
+// segment's compression-function "additional" block ids (overflow blocks).
+struct collect_block_ids : public duckdb::BlockIdVisitor {
+  explicit collect_block_ids(std::vector<duckdb::block_id_t>& out) : out(out) {}
+  void Visit(duckdb::block_id_t block_id) override { out.push_back(block_id); }
+  std::vector<duckdb::block_id_t>& out;
+};
+
+bool is_constant_or_empty_validity(duckdb::CompressionType c)
+{
+  return c == duckdb::CompressionType::COMPRESSION_CONSTANT ||
+         c == duckdb::CompressionType::COMPRESSION_EMPTY;
+}
+
+/// One column tree's walk over the row group's delta slice [k, k + row_count)
+/// (row-group-relative rows). @p is_validity selects the validity rules
+/// (codec set, bit-granular staging extents).
+void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
+                     bool is_validity,
+                     bool is_varchar,
+                     sirius::logical_type const& type,
+                     duckdb::idx_t column_id,
+                     std::size_t rg_index,
+                     std::size_t k,
+                     std::size_t row_count,
+                     std::vector<insert_delta_segment>& out)
+{
+  auto const delta_end = k + row_count;
+  auto lock            = tree.Lock();
+  for (auto& node : tree.SegmentNodes(lock)) {
+    auto& segment        = node.GetNode();
+    auto const seg_start = static_cast<std::size_t>(node.GetRowStart());
+    auto const seg_end   = seg_start + static_cast<std::size_t>(segment.count);
+    auto const lo        = std::max(seg_start, k);
+    auto const hi        = std::min(seg_end, delta_end);
+    if (hi <= lo) { continue; }
+
+    auto const compression = segment.GetCompressionFunction().type;
+    if (is_validity && is_constant_or_empty_validity(compression)) { continue; }
+
+    insert_delta_segment out_seg;
+    out_seg.segment       = &segment;
+    out_seg.is_validity   = is_validity;
+    out_seg.segment_start = lo - k;
+    out_seg.segment_count = hi - lo;
+    out_seg.compression   = compression;
+
+    if (segment.segment_type == duckdb::ColumnSegmentType::TRANSIENT) {
+      // Small committed appends: in-memory only, and always UNCOMPRESSED —
+      // DuckDB compresses exclusively at checkpoint, which is suppressed
+      // while pinned. Anything else means a checkpoint ran under the pin.
+      if (compression != duckdb::CompressionType::COMPRESSION_UNCOMPRESSED) {
+        throw_capture("TRANSIENT segment on column " + std::to_string(column_id) + " row group " +
+                      std::to_string(rg_index) + " is compressed (" +
+                      duckdb::CompressionTypeToString(compression) +
+                      ") — a CHECKPOINT ran while the table was pinned");
+      }
+      out_seg.is_transient = true;
+      if (is_validity) {
+        // Bit-packed: byte-granular copies only. Transient validity starts
+        // exactly at the delta boundary (appends begin at the persistent
+        // tail); assert instead of assuming.
+        if ((lo - seg_start) % 8 != 0 || (lo - k) % 8 != 0) {
+          throw_capture("transient validity segment on column " + std::to_string(column_id) +
+                        " row group " + std::to_string(rg_index) +
+                        " does not start byte-aligned in the delta slice");
+        }
+        out_seg.copy_src_offset = (lo - seg_start) / 8;
+        out_seg.bytes_size      = ((hi - lo) + 7) / 8;
+      } else if (is_varchar) {
+        // Stage the segment's whole used extent: the uncompressed-string
+        // dictionary is self-describing ({size, end} header at the base,
+        // chars packed at the tail), so tail-clamped row counts read fine.
+        if (lo != seg_start) {
+          throw_capture("transient varchar segment on column " + std::to_string(column_id) +
+                        " row group " + std::to_string(rg_index) +
+                        " starts inside the cached prefix — positional drift");
+        }
+        out_seg.copy_src_offset = 0;
+        out_seg.bytes_size      = segment.SegmentSize();
+      } else {
+        auto const type_size    = type.fixed_width_byte_size();
+        out_seg.copy_src_offset = (lo - seg_start) * type_size;
+        out_seg.bytes_size      = (hi - lo) * type_size;
+      }
+    } else {
+      // Bulk-flushed appends (MergeStorage): checkpoint-shaped PERSISTENT
+      // blocks, compressed like a checkpoint — decoded through the existing
+      // file-read lane; no prepare-time byte work. Partial coverage is legal
+      // only at the n_total snapshot tail (a merge committing mid-capture).
+      if (lo != seg_start || (hi != seg_end && hi != delta_end)) {
+        throw_capture("persistent segment on column " + std::to_string(column_id) + " row group " +
+                      std::to_string(rg_index) +
+                      " straddles the delta boundary — positional drift");
+      }
+      bool const supported = is_validity ? is_supported_validity_compression(compression)
+                                         : is_supported_data_compression(compression);
+      if (!supported ||
+          (is_varchar && compression == duckdb::CompressionType::COMPRESSION_CONSTANT)) {
+        throw_capture("persistent delta segment on column " + std::to_string(column_id) +
+                      " row group " + std::to_string(rg_index) + ": unsupported compression " +
+                      duckdb::CompressionTypeToString(compression));
+      }
+      out_seg.block_id     = segment.GetBlockId();
+      out_seg.block_offset = segment.GetBlockOffset();
+      out_seg.bytes_size   = static_cast<std::size_t>(segment.GetBlockSize()) -
+                           static_cast<std::size_t>(out_seg.block_offset);
+      auto const& cf = segment.GetCompressionFunction();
+      if (segment.GetSegmentState() && cf.visit_block_ids) {
+        collect_block_ids visitor(out_seg.additional_blocks);
+        cf.visit_block_ids(segment, visitor);
+      }
+    }
+
+    if (is_varchar && !is_validity) {
+      // Same stat discipline as the walker: absent stat refuses, and a
+      // marker-bearing (overflow) segment must never reach the GPU string
+      // decoder. The plan-time table-stat probe normally declines first;
+      // this is the stats-drift backstop.
+      if (!duckdb::StringStats::HasMaxStringLength(segment.stats.statistics)) {
+        throw_capture("varchar delta segment on column " + std::to_string(column_id) +
+                      " row group " + std::to_string(rg_index) + ": Max String Length stat absent");
+      }
+      auto const max_len = duckdb::StringStats::MaxStringLength(segment.stats.statistics);
+      if (max_len >= duckdb::StringUncompressed::GetStringBlockLimit(segment.GetBlockSize())) {
+        throw_capture("varchar delta segment on column " + std::to_string(column_id) +
+                      " row group " + std::to_string(rg_index) +
+                      ": max string length reaches the overflow-block limit");
+      }
+      out_seg.max_string_length = static_cast<std::uint32_t>(max_len);
+    }
+
+    out.push_back(std::move(out_seg));
+  }
+}
+
+}  // namespace
+
+insert_delta_plan capture_insert_delta_plan(
+  duckdb::DataTable& storage,
+  duckdb::ClientContext& context,
+  std::size_t n_cache,
+  std::span<duckdb::storage_t const> storage_column_indices,
+  std::span<sirius::logical_type const> column_types)
+{
+  if (storage_column_indices.size() != column_types.size()) {
+    throw_capture("column index / type lists are not parallel");
+  }
+
+  insert_delta_plan plan;
+  auto& txn           = duckdb::DuckTransaction::Get(context, storage.GetAttached());
+  plan.transaction    = duckdb::TransactionData(txn);
+  plan.buffer_manager = &duckdb::BufferManager::GetBufferManager(context);
+  plan.n_cache        = n_cache;
+  plan.n_total        = static_cast<std::size_t>(storage.GetTotalRows());
+  if (plan.n_total <= n_cache) { return plan; }
+
+  // Capture-time partition stats: CONSTANT-compressed persistent delta
+  // segments decode their value from these, and GetPartitionStats touches
+  // ClientContext — not safe on the decode task threads.
+  plan.partition_stats = std::make_shared<duckdb::vector<duckdb::PartitionStatistics>>(
+    storage.GetPartitionStats(context));
+
+  auto tree = storage.GetRowGroupCollection()->GetRowGroups();
+  for (duckdb::idx_t rg_index = 0;; ++rg_index) {
+    auto node = tree->GetSegmentByIndex(static_cast<int64_t>(rg_index));
+    if (!node) { break; }
+    auto& rg            = node->GetNode();
+    auto const rg_start = static_cast<std::size_t>(node->GetRowStart());
+    if (rg_start >= plan.n_total) { break; }
+    auto const live_end = rg_start + static_cast<std::size_t>(rg.count.load());
+    if (live_end <= n_cache) { continue; }
+
+    insert_delta_row_group rg_plan;
+    rg_plan.row_group       = &rg;
+    rg_plan.row_group_index = rg_index;
+    rg_plan.k_offset        = n_cache > rg_start ? n_cache - rg_start : 0;
+    auto const covered_end  = std::min(live_end, plan.n_total);
+    if (covered_end <= rg_start + rg_plan.k_offset) { continue; }
+    rg_plan.row_count       = covered_end - (rg_start + rg_plan.k_offset);
+    rg_plan.row_group_start = rg_start + rg_plan.k_offset;
+    rg_plan.has_version_state =
+      duckdb::RowGroup::GetPartitionStats(*node).count_type == duckdb::CountType::COUNT_APPROXIMATE;
+
+    std::size_t slab   = 0;
+    std::size_t budget = 0;
+    rg_plan.varchar_bytes_per_col.assign(storage_column_indices.size(), 0);
+
+    for (std::size_t ci = 0; ci < storage_column_indices.size(); ++ci) {
+      auto const col   = storage_column_indices[ci];
+      auto& col_data   = rg.GetRawColumnData(col);
+      auto const& type = column_types[ci];
+
+      if (type.is_array() || dynamic_cast<duckdb::ArrayColumnData*>(&col_data) != nullptr) {
+        // v1 scope: ARRAY projections with a delta are declined at plan time;
+        // reaching capture means the delta appeared between plan and prepare.
+        throw_capture("ARRAY column " + std::to_string(col) +
+                      " in the insert delta is not supported");
+      }
+      auto* std_col = dynamic_cast<duckdb::StandardColumnData*>(&col_data);
+      if (std_col == nullptr) {
+        throw_capture("column " + std::to_string(col) + " storage for type " + type.to_string() +
+                      " is not StandardColumnData (nested/unsupported)");
+      }
+
+      insert_delta_column col_plan;
+      col_plan.column_id  = col;
+      col_plan.is_varchar = type.is_varchar();
+      walk_delta_tree(std_col->GetSegmentTree(),
+                      /*is_validity=*/false,
+                      col_plan.is_varchar,
+                      type,
+                      col,
+                      rg_index,
+                      rg_plan.k_offset,
+                      rg_plan.row_count,
+                      col_plan.data_segments);
+      walk_delta_tree(std_col->GetValidityData().GetSegmentTree(),
+                      /*is_validity=*/true,
+                      /*is_varchar=*/false,
+                      type,
+                      col,
+                      rg_index,
+                      rg_plan.k_offset,
+                      rg_plan.row_count,
+                      col_plan.validity_segments);
+
+      // The data segments must tile the delta slice exactly — a gap would
+      // decode garbage rows the mask never drops.
+      std::size_t data_rows = 0;
+      for (auto const& s : col_plan.data_segments) {
+        data_rows += s.segment_count;
+      }
+      if (data_rows != rg_plan.row_count) {
+        throw_capture("column " + std::to_string(col) + " row group " + std::to_string(rg_index) +
+                      ": delta segments cover " + std::to_string(data_rows) + " of " +
+                      std::to_string(rg_plan.row_count) + " rows");
+      }
+
+      // Staging slab layout (transient bytes) + scheduling budget.
+      for (auto* segs : {&col_plan.data_segments, &col_plan.validity_segments}) {
+        for (auto& s : *segs) {
+          if (!s.is_transient) { continue; }
+          slab          = (slab + 7) / 8 * 8;  // 8-byte align within the slab
+          s.slab_offset = slab;
+          slab += s.bytes_size;
+        }
+      }
+      if (col_plan.is_varchar) {
+        std::size_t varchar_bytes = 0;
+        for (auto const& s : col_plan.data_segments) {
+          varchar_bytes +=
+            s.segment_count * (s.max_string_length.has_value() ? *s.max_string_length : 0);
+        }
+        rg_plan.varchar_bytes_per_col[ci] = varchar_bytes;
+        budget += rg_plan.row_count * sizeof(std::uint32_t) + varchar_bytes;
+      } else {
+        budget += rg_plan.row_count * type.fixed_width_byte_size();
+      }
+
+      rg_plan.columns.push_back(std::move(col_plan));
+    }
+
+    rg_plan.transient_staging_bytes = slab;
+    rg_plan.decoded_bytes_budget    = budget;
+    plan.row_groups.push_back(std::move(rg_plan));
+  }
+  return plan;
+}
+
+std::size_t count_visible_delta_rows(insert_delta_row_group const& rg,
+                                     duckdb::TransactionData transaction,
+                                     std::span<std::uint32_t> mask_words,
+                                     std::size_t mask_bit_offset)
+{
+  auto const k   = rg.k_offset;
+  auto const end = k + rg.row_count;
+
+  auto set_range = [&](std::size_t from, std::size_t to) {  // rg-relative [from, to)
+    for (std::size_t r = from; r < to; ++r) {
+      cudf::set_bit_unsafe(mask_words.data(),
+                           static_cast<cudf::size_type>(mask_bit_offset + (r - k)));
+    }
+  };
+
+  if (!rg.has_version_state) {
+    // No version state at capture: every covered row is visible (the probe
+    // is conservative the other way — it can flag clean row groups, never
+    // miss dirty ones).
+    set_range(k, end);
+    return rg.row_count;
+  }
+
+  duckdb::SelectionVector sel(STANDARD_VECTOR_SIZE);
+  duckdb::ScanOptions const options{transaction};
+  std::size_t visible = 0;
+
+  for (std::size_t vec_start = (k / STANDARD_VECTOR_SIZE) * STANDARD_VECTOR_SIZE; vec_start < end;
+       vec_start += STANDARD_VECTOR_SIZE) {
+    auto const vector_idx = vec_start / STANDARD_VECTOR_SIZE;
+    auto const max_count  = std::min<std::size_t>(STANDARD_VECTOR_SIZE, end - vec_start);
+    auto const count      = static_cast<std::size_t>(rg.row_group->GetSelVector(
+      options, static_cast<duckdb::idx_t>(vector_idx), sel, static_cast<duckdb::idx_t>(max_count)));
+    auto const from       = std::max(vec_start, k);
+    if (count == max_count) {
+      // All visible — sel may be UNFILLED on this fast path; never read it.
+      set_range(from, vec_start + max_count);
+      visible += vec_start + max_count - from;
+      continue;
+    }
+    for (std::size_t i = 0; i < count; ++i) {
+      auto const pos = vec_start + static_cast<std::size_t>(sel.get_index(i));
+      if (pos < from) { continue; }
+      cudf::set_bit_unsafe(mask_words.data(),
+                           static_cast<cudf::size_type>(mask_bit_offset + (pos - k)));
+      ++visible;
+    }
+  }
+  return visible;
+}
+
+void copy_delta_row_group(insert_delta_row_group const& rg,
+                          duckdb::BufferManager& buffer_manager,
+                          std::uint8_t* slab_base)
+{
+  for (auto const& col : rg.columns) {
+    for (auto const* segs : {&col.data_segments, &col.validity_segments}) {
+      for (auto const& s : *segs) {
+        if (!s.is_transient) { continue; }
+        // Pin just long enough to memcpy; no DuckDB handle outlives the call.
+        auto handle = s.segment->block;
+        auto pin    = buffer_manager.Pin(handle);
+        std::memcpy(slab_base + s.slab_offset, pin.Ptr() + s.copy_src_offset, s.bytes_size);
+      }
+    }
+  }
+}
+
+}  // namespace sirius::op::scan

--- a/src/op/scan/duckdb_insert_delta.cpp
+++ b/src/op/scan/duckdb_insert_delta.cpp
@@ -212,19 +212,106 @@ void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
   }
 }
 
-}  // namespace
-
-insert_delta_plan capture_insert_delta_plan(
-  duckdb::DataTable& storage,
-  duckdb::ClientContext& context,
-  std::size_t n_cache,
+/// Fill one skeleton row group: walk its column segment trees into columns,
+/// assign staging slab offsets, and compute the byte budgets. Task-safe.
+insert_delta_row_group complete_delta_row_group(
+  insert_delta_row_group const& skeleton,
   std::span<duckdb::storage_t const> storage_column_indices,
   std::span<sirius::logical_type const> column_types)
 {
-  if (storage_column_indices.size() != column_types.size()) {
-    throw_capture("column index / type lists are not parallel");
+  insert_delta_row_group rg_plan = skeleton;
+  auto& rg                       = *rg_plan.row_group;
+  auto const rg_index            = rg_plan.row_group_index;
+
+  std::size_t slab   = 0;
+  std::size_t budget = 0;
+  rg_plan.varchar_bytes_per_col.assign(storage_column_indices.size(), 0);
+
+  for (std::size_t ci = 0; ci < storage_column_indices.size(); ++ci) {
+    auto const col   = storage_column_indices[ci];
+    auto& col_data   = rg.GetRawColumnData(col);
+    auto const& type = column_types[ci];
+
+    if (type.is_array() || dynamic_cast<duckdb::ArrayColumnData*>(&col_data) != nullptr) {
+      // ARRAY deltas are declined at plan time; hitting this means the
+      // delta appeared between plan and prepare.
+      throw_capture("ARRAY column " + std::to_string(col) +
+                    " in the insert delta is not supported");
+    }
+    auto* std_col = dynamic_cast<duckdb::StandardColumnData*>(&col_data);
+    if (std_col == nullptr) {
+      throw_capture("column " + std::to_string(col) + " storage for type " + type.to_string() +
+                    " is not StandardColumnData (nested/unsupported)");
+    }
+
+    insert_delta_column col_plan;
+    col_plan.column_id  = col;
+    col_plan.is_varchar = type.is_varchar();
+    walk_delta_tree(std_col->GetSegmentTree(),
+                    /*is_validity=*/false,
+                    col_plan.is_varchar,
+                    type,
+                    col,
+                    rg_index,
+                    rg_plan.k_offset,
+                    rg_plan.row_count,
+                    col_plan.data_segments);
+    walk_delta_tree(std_col->GetValidityData().GetSegmentTree(),
+                    /*is_validity=*/true,
+                    /*is_varchar=*/false,
+                    type,
+                    col,
+                    rg_index,
+                    rg_plan.k_offset,
+                    rg_plan.row_count,
+                    col_plan.validity_segments);
+
+    // The data segments must tile the delta slice exactly; a gap would
+    // decode garbage rows the mask never drops.
+    std::size_t data_rows = 0;
+    for (auto const& s : col_plan.data_segments) {
+      data_rows += s.segment_count;
+    }
+    if (data_rows != rg_plan.row_count) {
+      throw_capture("column " + std::to_string(col) + " row group " + std::to_string(rg_index) +
+                    ": delta segments cover " + std::to_string(data_rows) + " of " +
+                    std::to_string(rg_plan.row_count) + " rows");
+    }
+
+    for (auto* segs : {&col_plan.data_segments, &col_plan.validity_segments}) {
+      for (auto& s : *segs) {
+        if (!s.is_transient) { continue; }
+        slab          = (slab + 7) / 8 * 8;  // 8-byte align within the slab
+        s.slab_offset = slab;
+        slab += s.bytes_size;
+      }
+    }
+    if (col_plan.is_varchar) {
+      std::size_t varchar_bytes = 0;
+      for (auto const& s : col_plan.data_segments) {
+        varchar_bytes +=
+          s.segment_count * (s.max_string_length.has_value() ? *s.max_string_length : 0);
+      }
+      rg_plan.varchar_bytes_per_col[ci] = varchar_bytes;
+      budget += rg_plan.row_count * sizeof(std::uint32_t) + varchar_bytes;
+    } else {
+      budget += rg_plan.row_count * type.fixed_width_byte_size();
+    }
+
+    rg_plan.columns.push_back(std::move(col_plan));
   }
 
+  rg_plan.transient_staging_bytes = slab;
+  rg_plan.decoded_bytes_budget    = budget;
+  return rg_plan;
+}
+
+}  // namespace
+
+insert_delta_plan prepare_insert_delta_capture(duckdb::DataTable& storage,
+                                               duckdb::ClientContext& context,
+                                               std::size_t n_cache)
+{
   insert_delta_plan plan;
   auto& txn           = duckdb::DuckTransaction::Get(context, storage.GetAttached());
   plan.transaction    = duckdb::TransactionData(txn);
@@ -254,88 +341,45 @@ insert_delta_plan capture_insert_delta_plan(
     rg_plan.has_version_state =
       duckdb::RowGroup::GetPartitionStats(*node).count_type == duckdb::CountType::COUNT_APPROXIMATE;
 
-    std::size_t slab   = 0;
-    std::size_t budget = 0;
-    rg_plan.varchar_bytes_per_col.assign(storage_column_indices.size(), 0);
-
-    for (std::size_t ci = 0; ci < storage_column_indices.size(); ++ci) {
-      auto const col   = storage_column_indices[ci];
-      auto& col_data   = rg.GetRawColumnData(col);
-      auto const& type = column_types[ci];
-
-      if (type.is_array() || dynamic_cast<duckdb::ArrayColumnData*>(&col_data) != nullptr) {
-        // ARRAY deltas are declined at plan time; hitting this means the
-        // delta appeared between plan and prepare.
-        throw_capture("ARRAY column " + std::to_string(col) +
-                      " in the insert delta is not supported");
-      }
-      auto* std_col = dynamic_cast<duckdb::StandardColumnData*>(&col_data);
-      if (std_col == nullptr) {
-        throw_capture("column " + std::to_string(col) + " storage for type " + type.to_string() +
-                      " is not StandardColumnData (nested/unsupported)");
-      }
-
-      insert_delta_column col_plan;
-      col_plan.column_id  = col;
-      col_plan.is_varchar = type.is_varchar();
-      walk_delta_tree(std_col->GetSegmentTree(),
-                      /*is_validity=*/false,
-                      col_plan.is_varchar,
-                      type,
-                      col,
-                      rg_index,
-                      rg_plan.k_offset,
-                      rg_plan.row_count,
-                      col_plan.data_segments);
-      walk_delta_tree(std_col->GetValidityData().GetSegmentTree(),
-                      /*is_validity=*/true,
-                      /*is_varchar=*/false,
-                      type,
-                      col,
-                      rg_index,
-                      rg_plan.k_offset,
-                      rg_plan.row_count,
-                      col_plan.validity_segments);
-
-      // The data segments must tile the delta slice exactly; a gap would
-      // decode garbage rows the mask never drops.
-      std::size_t data_rows = 0;
-      for (auto const& s : col_plan.data_segments) {
-        data_rows += s.segment_count;
-      }
-      if (data_rows != rg_plan.row_count) {
-        throw_capture("column " + std::to_string(col) + " row group " + std::to_string(rg_index) +
-                      ": delta segments cover " + std::to_string(data_rows) + " of " +
-                      std::to_string(rg_plan.row_count) + " rows");
-      }
-
-      for (auto* segs : {&col_plan.data_segments, &col_plan.validity_segments}) {
-        for (auto& s : *segs) {
-          if (!s.is_transient) { continue; }
-          slab          = (slab + 7) / 8 * 8;  // 8-byte align within the slab
-          s.slab_offset = slab;
-          slab += s.bytes_size;
-        }
-      }
-      if (col_plan.is_varchar) {
-        std::size_t varchar_bytes = 0;
-        for (auto const& s : col_plan.data_segments) {
-          varchar_bytes +=
-            s.segment_count * (s.max_string_length.has_value() ? *s.max_string_length : 0);
-        }
-        rg_plan.varchar_bytes_per_col[ci] = varchar_bytes;
-        budget += rg_plan.row_count * sizeof(std::uint32_t) + varchar_bytes;
-      } else {
-        budget += rg_plan.row_count * type.fixed_width_byte_size();
-      }
-
-      rg_plan.columns.push_back(std::move(col_plan));
-    }
-
-    rg_plan.transient_staging_bytes = slab;
-    rg_plan.decoded_bytes_budget    = budget;
     plan.row_groups.push_back(std::move(rg_plan));
   }
+  return plan;
+}
+
+std::vector<insert_delta_row_group> capture_insert_delta_row_group_range(
+  insert_delta_plan const& plan,
+  std::size_t rg_begin,
+  std::size_t rg_end,
+  std::span<duckdb::storage_t const> storage_column_indices,
+  std::span<sirius::logical_type const> column_types)
+{
+  if (storage_column_indices.size() != column_types.size()) {
+    throw_capture("column index / type lists are not parallel");
+  }
+
+  rg_end = std::min(rg_end, plan.row_groups.size());
+  std::vector<insert_delta_row_group> out;
+  if (rg_begin >= rg_end) { return out; }
+  out.reserve(rg_end - rg_begin);
+  for (std::size_t i = rg_begin; i < rg_end; ++i) {
+    out.push_back(
+      complete_delta_row_group(plan.row_groups[i], storage_column_indices, column_types));
+  }
+  return out;
+}
+
+insert_delta_plan capture_insert_delta_plan(
+  duckdb::DataTable& storage,
+  duckdb::ClientContext& context,
+  std::size_t n_cache,
+  std::span<duckdb::storage_t const> storage_column_indices,
+  std::span<sirius::logical_type const> column_types)
+{
+  auto plan = prepare_insert_delta_capture(storage, context, n_cache);
+  // Run the range walk even on an empty plan so the parallel-lists check
+  // fires the same way in both call shapes.
+  plan.row_groups = capture_insert_delta_row_group_range(
+    plan, 0, plan.row_groups.size(), storage_column_indices, column_types);
   return plan;
 }
 

--- a/src/op/scan/duckdb_insert_delta.cpp
+++ b/src/op/scan/duckdb_insert_delta.cpp
@@ -94,16 +94,28 @@ void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
     if (hi <= lo) { continue; }
 
     auto const compression = segment.GetCompressionFunction().type;
-    if (is_validity && is_constant_or_empty_validity(compression)) { continue; }
+    // CONSTANT validity is uniform, with the direction in the segment stats:
+    // all-valid runs (like EMPTY, a no-op mask) decode to nothing, but an
+    // all-NULL run must reach the decoder so it synthesizes zero validity
+    // bits.
+    bool const all_null_validity = is_validity &&
+                                   compression == duckdb::CompressionType::COMPRESSION_CONSTANT &&
+                                   segment.stats.statistics.CanHaveNull();
+    if (is_validity && !all_null_validity && is_constant_or_empty_validity(compression)) {
+      continue;
+    }
 
     insert_delta_segment out_seg;
     out_seg.segment       = &segment;
     out_seg.is_validity   = is_validity;
+    out_seg.all_null      = all_null_validity;
     out_seg.segment_start = lo - k;
     out_seg.segment_count = hi - lo;
     out_seg.compression   = compression;
 
-    if (segment.segment_type == duckdb::ColumnSegmentType::TRANSIENT) {
+    if (all_null_validity) {
+      // Nothing to stage or read; the marker alone drives the decode.
+    } else if (segment.segment_type == duckdb::ColumnSegmentType::TRANSIENT) {
       // DuckDB compresses transient segments only at checkpoint, and
       // checkpoints are suppressed while pinned; a compressed one here means
       // a checkpoint ran anyway.
@@ -158,14 +170,24 @@ void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
                       " row group " + std::to_string(rg_index) + ": unsupported compression " +
                       duckdb::CompressionTypeToString(compression));
       }
-      out_seg.block_id     = segment.GetBlockId();
-      out_seg.block_offset = segment.GetBlockOffset();
-      out_seg.bytes_size   = static_cast<std::size_t>(segment.GetBlockSize()) -
-                           static_cast<std::size_t>(out_seg.block_offset);
-      auto const& cf = segment.GetCompressionFunction();
-      if (segment.GetSegmentState() && cf.visit_block_ids) {
-        collect_block_ids visitor(out_seg.additional_blocks);
-        cf.visit_block_ids(segment, visitor);
+      if (compression == duckdb::CompressionType::COMPRESSION_CONSTANT) {
+        // CONSTANT segments have no backing block (GetBlockSize() would
+        // null-deref); the block/byte fields stay unset. Snapshot the
+        // segment's own stats for the decoder: the constant value lives
+        // here, and row-group-level stats drift as later appends (e.g. into
+        // an indexed table's tail row group) merge into them.
+        out_seg.segment_stats =
+          std::make_shared<duckdb::BaseStatistics>(segment.stats.statistics.Copy());
+      } else {
+        out_seg.block_id     = segment.GetBlockId();
+        out_seg.block_offset = segment.GetBlockOffset();
+        out_seg.bytes_size   = static_cast<std::size_t>(segment.GetBlockSize()) -
+                             static_cast<std::size_t>(out_seg.block_offset);
+        auto const& cf = segment.GetCompressionFunction();
+        if (segment.GetSegmentState() && cf.visit_block_ids) {
+          collect_block_ids visitor(out_seg.additional_blocks);
+          cf.visit_block_ids(segment, visitor);
+        }
       }
     }
 
@@ -210,12 +232,6 @@ insert_delta_plan capture_insert_delta_plan(
   plan.n_cache        = n_cache;
   plan.n_total        = static_cast<std::size_t>(storage.GetTotalRows());
   if (plan.n_total <= n_cache) { return plan; }
-
-  // CONSTANT persistent segments decode their value from partition stats, and
-  // GetPartitionStats needs the ClientContext; capture the stats now rather
-  // than on a decode task thread.
-  plan.partition_stats = std::make_shared<duckdb::vector<duckdb::PartitionStatistics>>(
-    storage.GetPartitionStats(context));
 
   auto tree = storage.GetRowGroupCollection()->GetRowGroups();
   for (duckdb::idx_t rg_index = 0;; ++rg_index) {

--- a/src/op/scan/duckdb_insert_delta.cpp
+++ b/src/op/scan/duckdb_insert_delta.cpp
@@ -57,8 +57,7 @@ constexpr char const* kTag = "[insert_delta]";
   throw std::runtime_error(std::string(kTag) + " " + std::move(what));
 }
 
-// Mirrors the walker's visitor (duckdb_native_metadata.cpp): collects a
-// segment's compression-function "additional" block ids (overflow blocks).
+// Collects a segment's extra compression-function block ids (overflow blocks).
 struct collect_block_ids : public duckdb::BlockIdVisitor {
   explicit collect_block_ids(std::vector<duckdb::block_id_t>& out) : out(out) {}
   void Visit(duckdb::block_id_t block_id) override { out.push_back(block_id); }
@@ -71,9 +70,9 @@ bool is_constant_or_empty_validity(duckdb::CompressionType c)
          c == duckdb::CompressionType::COMPRESSION_EMPTY;
 }
 
-/// One column tree's walk over the row group's delta slice [k, k + row_count)
-/// (row-group-relative rows). @p is_validity selects the validity rules
-/// (codec set, bit-granular staging extents).
+/// Walk one column tree over the delta slice [k, k + row_count), in
+/// row-group-relative rows. Validity trees get their own codec rules and
+/// bit-granular staging extents.
 void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
                      bool is_validity,
                      bool is_varchar,
@@ -105,9 +104,9 @@ void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
     out_seg.compression   = compression;
 
     if (segment.segment_type == duckdb::ColumnSegmentType::TRANSIENT) {
-      // Small committed appends: in-memory only, and always UNCOMPRESSED —
-      // DuckDB compresses exclusively at checkpoint, which is suppressed
-      // while pinned. Anything else means a checkpoint ran under the pin.
+      // DuckDB compresses transient segments only at checkpoint, and
+      // checkpoints are suppressed while pinned; a compressed one here means
+      // a checkpoint ran anyway.
       if (compression != duckdb::CompressionType::COMPRESSION_UNCOMPRESSED) {
         throw_capture("TRANSIENT segment on column " + std::to_string(column_id) + " row group " +
                       std::to_string(rg_index) + " is compressed (" +
@@ -116,9 +115,9 @@ void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
       }
       out_seg.is_transient = true;
       if (is_validity) {
-        // Bit-packed: byte-granular copies only. Transient validity starts
-        // exactly at the delta boundary (appends begin at the persistent
-        // tail); assert instead of assuming.
+        // Validity is bit-packed, so the copy must start on a byte boundary.
+        // Transient validity starts exactly at the delta boundary, so this
+        // holds; check rather than assume.
         if ((lo - seg_start) % 8 != 0 || (lo - k) % 8 != 0) {
           throw_capture("transient validity segment on column " + std::to_string(column_id) +
                         " row group " + std::to_string(rg_index) +
@@ -127,9 +126,9 @@ void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
         out_seg.copy_src_offset = (lo - seg_start) / 8;
         out_seg.bytes_size      = ((hi - lo) + 7) / 8;
       } else if (is_varchar) {
-        // Stage the segment's whole used extent: the uncompressed-string
-        // dictionary is self-describing ({size, end} header at the base,
-        // chars packed at the tail), so tail-clamped row counts read fine.
+        // Stage the segment's whole used extent. The uncompressed-string
+        // dictionary is self-describing, so a tail-clamped row count still
+        // decodes correctly.
         if (lo != seg_start) {
           throw_capture("transient varchar segment on column " + std::to_string(column_id) +
                         " row group " + std::to_string(rg_index) +
@@ -143,10 +142,9 @@ void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
         out_seg.bytes_size      = (hi - lo) * type_size;
       }
     } else {
-      // Bulk-flushed appends (MergeStorage): checkpoint-shaped PERSISTENT
-      // blocks, compressed like a checkpoint — decoded through the existing
-      // file-read lane; no prepare-time byte work. Partial coverage is legal
-      // only at the n_total snapshot tail (a merge committing mid-capture).
+      // Persistent segments decode straight from the file; nothing is staged.
+      // Partial coverage is legal only at the n_total snapshot tail, where a
+      // merge committed mid-capture.
       if (lo != seg_start || (hi != seg_end && hi != delta_end)) {
         throw_capture("persistent segment on column " + std::to_string(column_id) + " row group " +
                       std::to_string(rg_index) +
@@ -172,10 +170,9 @@ void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
     }
 
     if (is_varchar && !is_validity) {
-      // Same stat discipline as the walker: absent stat refuses, and a
-      // marker-bearing (overflow) segment must never reach the GPU string
-      // decoder. The plan-time table-stat probe normally declines first;
-      // this is the stats-drift backstop.
+      // Overflow strings must never reach the GPU string decoder. The
+      // plan-time table-stat probe normally declines first; this catches
+      // stats drift.
       if (!duckdb::StringStats::HasMaxStringLength(segment.stats.statistics)) {
         throw_capture("varchar delta segment on column " + std::to_string(column_id) +
                       " row group " + std::to_string(rg_index) + ": Max String Length stat absent");
@@ -214,9 +211,9 @@ insert_delta_plan capture_insert_delta_plan(
   plan.n_total        = static_cast<std::size_t>(storage.GetTotalRows());
   if (plan.n_total <= n_cache) { return plan; }
 
-  // Capture-time partition stats: CONSTANT-compressed persistent delta
-  // segments decode their value from these, and GetPartitionStats touches
-  // ClientContext — not safe on the decode task threads.
+  // CONSTANT persistent segments decode their value from partition stats, and
+  // GetPartitionStats needs the ClientContext; capture the stats now rather
+  // than on a decode task thread.
   plan.partition_stats = std::make_shared<duckdb::vector<duckdb::PartitionStatistics>>(
     storage.GetPartitionStats(context));
 
@@ -251,8 +248,8 @@ insert_delta_plan capture_insert_delta_plan(
       auto const& type = column_types[ci];
 
       if (type.is_array() || dynamic_cast<duckdb::ArrayColumnData*>(&col_data) != nullptr) {
-        // v1 scope: ARRAY projections with a delta are declined at plan time;
-        // reaching capture means the delta appeared between plan and prepare.
+        // ARRAY deltas are declined at plan time; hitting this means the
+        // delta appeared between plan and prepare.
         throw_capture("ARRAY column " + std::to_string(col) +
                       " in the insert delta is not supported");
       }
@@ -284,7 +281,7 @@ insert_delta_plan capture_insert_delta_plan(
                       rg_plan.row_count,
                       col_plan.validity_segments);
 
-      // The data segments must tile the delta slice exactly — a gap would
+      // The data segments must tile the delta slice exactly; a gap would
       // decode garbage rows the mask never drops.
       std::size_t data_rows = 0;
       for (auto const& s : col_plan.data_segments) {
@@ -296,7 +293,6 @@ insert_delta_plan capture_insert_delta_plan(
                       std::to_string(rg_plan.row_count) + " rows");
       }
 
-      // Staging slab layout (transient bytes) + scheduling budget.
       for (auto* segs : {&col_plan.data_segments, &col_plan.validity_segments}) {
         for (auto& s : *segs) {
           if (!s.is_transient) { continue; }
@@ -343,9 +339,8 @@ std::size_t count_visible_delta_rows(insert_delta_row_group const& rg,
   };
 
   if (!rg.has_version_state) {
-    // No version state at capture: every covered row is visible (the probe
-    // is conservative the other way — it can flag clean row groups, never
-    // miss dirty ones).
+    // No version state at capture means every covered row is visible. The
+    // probe can flag a clean row group but never misses a dirty one.
     set_range(k, end);
     return rg.row_count;
   }
@@ -362,7 +357,7 @@ std::size_t count_visible_delta_rows(insert_delta_row_group const& rg,
       options, static_cast<duckdb::idx_t>(vector_idx), sel, static_cast<duckdb::idx_t>(max_count)));
     auto const from       = std::max(vec_start, k);
     if (count == max_count) {
-      // All visible — sel may be UNFILLED on this fast path; never read it.
+      // All rows visible. GetSelVector may leave sel unfilled here; never read it.
       set_range(from, vec_start + max_count);
       visible += vec_start + max_count - from;
       continue;

--- a/src/op/scan/duckdb_mvcc_visibility.cpp
+++ b/src/op/scan/duckdb_mvcc_visibility.cpp
@@ -45,14 +45,11 @@ constexpr std::size_t kWordBits = 32;
 static_assert(sizeof(std::uint32_t) == sizeof(cudf::bitmask_type),
               "bit-packed keep-masks assume cudf::bitmask_type is 32-bit");
 
-/// Set or clear bits [begin, begin + count) of @p words, bit-exact at both
-/// edges (read-modify-write on partial edge words, whole-word fills between).
-/// Any begin/count is legal: checkpoint-grown tables have row groups of
-/// arbitrary sizes, so slice offsets need not be word-aligned. The caller
-/// guarantees no CONCURRENT writer shares an edge word — the mask job slices
-/// parallel tasks only on word-aligned offsets and fills unaligned chunks
-/// through a single task — and prepare zero-initializes every carved mask,
-/// so edge reads never see indeterminate memory.
+/// Set or clear bits [begin, begin + count) of @p words: read-modify-write on
+/// partial edge words, whole-word fills between, so any begin/count is legal.
+/// Caller contract: no concurrent writer shares an edge word (the mask job
+/// slices parallel tasks only on word-aligned offsets), and the words start
+/// zeroed so edge reads never see indeterminate memory.
 void write_bit_range(std::span<std::uint32_t> words,
                      std::size_t begin,
                      std::size_t count,
@@ -171,9 +168,8 @@ mvcc_visibility_plan capture_mvcc_visibility_plan(
     }
 
     // Checkpoint-grown tables have row groups of arbitrary sizes, so this
-    // offset need not be word-aligned: the fill writer is bit-exact at word
-    // edges, and the mask job serializes chunks with unaligned offsets into
-    // a single fill task (parallel slicing requires aligned offsets).
+    // offset may be unaligned; the fill writer handles word edges and the
+    // mask job serializes unaligned chunks into a single fill task.
     auto const chunk_offset = expected_start - chunk_start;
 
     bool const dirty = row_group_has_version_state(*node);

--- a/src/op/scan/duckdb_mvcc_visibility.cpp
+++ b/src/op/scan/duckdb_mvcc_visibility.cpp
@@ -23,6 +23,7 @@
 #include <duckdb/function/partition_stats.hpp>
 #include <duckdb/storage/data_table.hpp>
 #include <duckdb/storage/table/column_data.hpp>
+#include <duckdb/storage/table/column_segment.hpp>
 #include <duckdb/storage/table/row_group.hpp>
 #include <duckdb/storage/table/row_group_collection.hpp>
 #include <duckdb/storage/table/row_group_segment_tree.hpp>
@@ -40,34 +41,43 @@ namespace {
 constexpr std::size_t kWordBits = 32;
 
 // The host fill writes uint32 words that mask_to_bools reads as
-// cudf::bitmask_type, and vectors are the intra-slice write unit — both must
-// be whole numbers of mask words. (The row-group size — the cross-TASK slice
-// unit — is per-database configuration, so capture checks it at runtime via
-// the chunk_offset % 32 assert instead.)
+// cudf::bitmask_type.
 static_assert(sizeof(std::uint32_t) == sizeof(cudf::bitmask_type),
               "bit-packed keep-masks assume cudf::bitmask_type is 32-bit");
-static_assert(STANDARD_VECTOR_SIZE % kWordBits == 0,
-              "vector-granular mask writes assume whole words per vector");
 
-/// Set or clear bits [begin, begin + count) of @p words. @p begin must be
-/// 32-aligned (vector offsets within 32-aligned slices always are). Writes
-/// whole words, including the padding bits of a trailing partial word — safe
-/// because a partial range is always the last write in its word (a partial
-/// vector ends its slice; a partial slice ends the table) and padding bits
-/// past the covered range are don't-care to mask_to_bools.
-void write_aligned_bit_range(std::span<std::uint32_t> words,
-                             std::size_t begin,
-                             std::size_t count,
-                             bool value)
+/// Set or clear bits [begin, begin + count) of @p words, bit-exact at both
+/// edges (read-modify-write on partial edge words, whole-word fills between).
+/// Any begin/count is legal: checkpoint-grown tables have row groups of
+/// arbitrary sizes, so slice offsets need not be word-aligned. The caller
+/// guarantees no CONCURRENT writer shares an edge word — the mask job slices
+/// parallel tasks only on word-aligned offsets and fills unaligned chunks
+/// through a single task — and prepare zero-initializes every carved mask,
+/// so edge reads never see indeterminate memory.
+void write_bit_range(std::span<std::uint32_t> words,
+                     std::size_t begin,
+                     std::size_t count,
+                     bool value)
 {
   if (count == 0) { return; }
-  auto const word       = begin / kWordBits;
-  auto const full_words = count / kWordBits;
-  std::fill_n(words.data() + word, full_words, value ? 0xFFFFFFFFu : 0u);
-  if (auto const rem = count % kWordBits) {
-    auto const tail          = cudf::set_least_significant_bits(static_cast<cudf::size_type>(rem));
-    words[word + full_words] = value ? tail : 0u;
+  auto const end       = begin + count;
+  auto const first     = begin / kWordBits;
+  auto const last      = (end - 1) / kWordBits;
+  auto const head_bits = begin % kWordBits;
+  auto const tail_bits = end % kWordBits;  // 0 => the last word is fully covered
+
+  std::uint32_t const head_mask = ~0u << head_bits;
+  std::uint32_t const tail_mask = tail_bits ? ~(~0u << tail_bits) : ~0u;
+
+  if (first == last) {
+    std::uint32_t const m = head_mask & tail_mask;
+    words[first]          = value ? (words[first] | m) : (words[first] & ~m);
+    return;
   }
+  words[first] = value ? (words[first] | head_mask) : (words[first] & ~head_mask);
+  std::fill(words.begin() + static_cast<std::ptrdiff_t>(first) + 1,
+            words.begin() + static_cast<std::ptrdiff_t>(last),
+            value ? 0xFFFFFFFFu : 0u);
+  words[last] = value ? (words[last] | tail_mask) : (words[last] & ~tail_mask);
 }
 
 /// Non-loading per-row-group version-state probe (see header docs for why
@@ -160,15 +170,11 @@ mvcc_visibility_plan capture_mvcc_visibility_plan(
         ", " + std::to_string(expected_start + covered) + "))");
     }
 
+    // Checkpoint-grown tables have row groups of arbitrary sizes, so this
+    // offset need not be word-aligned: the fill writer is bit-exact at word
+    // edges, and the mask job serializes chunks with unaligned offsets into
+    // a single fill task (parallel slicing requires aligned offsets).
     auto const chunk_offset = expected_start - chunk_start;
-    if (chunk_offset % kWordBits != 0) {
-      // Lock-free bit-packed fill invariant: task ranges slice on row-group
-      // boundaries, so every slice start must be 32-row aligned or parallel
-      // tasks could share a mask word.
-      throw std::runtime_error(
-        "[capture_mvcc_visibility_plan] slice offset " + std::to_string(chunk_offset) +
-        " within its chunk is not 32-row aligned (row-group size not a multiple of 32?)");
-    }
 
     bool const dirty = row_group_has_version_state(*node);
     plan.mvcc_row_groups[chunk_idx].push_back(
@@ -193,7 +199,7 @@ bool fill_keep_mask_for_row_groups(std::span<mvcc_row_group_slice const> slices,
     if (!slice.has_version_state) {
       // No version state at capture: every covered row is visible. No
       // GetVersionInfo, no GetSelVector, no version lock.
-      write_aligned_bit_range(chunk_mask_words, slice.chunk_offset, slice.row_count, true);
+      write_bit_range(chunk_mask_words, slice.chunk_offset, slice.row_count, true);
       continue;
     }
 
@@ -207,11 +213,11 @@ bool fill_keep_mask_for_row_groups(std::span<mvcc_row_group_slice const> slices,
 
       if (count == max_count) {
         // All visible — sel may be UNFILLED on this fast path; never read it.
-        write_aligned_bit_range(chunk_mask_words, off, max_count, true);
+        write_bit_range(chunk_mask_words, off, max_count, true);
         continue;
       }
       any_dropped = true;
-      write_aligned_bit_range(chunk_mask_words, off, max_count, false);
+      write_bit_range(chunk_mask_words, off, max_count, false);
       for (std::size_t i = 0; i < count; ++i) {
         cudf::set_bit_unsafe(chunk_mask_words.data(),
                              static_cast<cudf::size_type>(off + sel.get_index(i)));

--- a/src/op/scan/duckdb_mvcc_visibility.cpp
+++ b/src/op/scan/duckdb_mvcc_visibility.cpp
@@ -247,6 +247,25 @@ bool any_update_chains(duckdb::DataTable& storage,
   return false;
 }
 
+bool any_uncheckpointed_appends(duckdb::DataTable& storage,
+                                std::span<duckdb::storage_t const> storage_column_indices)
+{
+  if (storage_column_indices.empty()) { return false; }
+  auto tree = storage.GetRowGroupCollection()->GetRowGroups();
+  for (duckdb::idx_t rg_index = 0;; ++rg_index) {
+    auto node = tree->GetSegmentByIndex(static_cast<int64_t>(rg_index));
+    if (!node) { return false; }
+    auto& rg = node->GetNode();
+    for (auto col : storage_column_indices) {
+      for (auto& seg_node : rg.GetRawColumnData(col).GetSegmentTree().SegmentNodes()) {
+        if (seg_node.GetNode().segment_type == duckdb::ColumnSegmentType::TRANSIENT) {
+          return true;
+        }
+      }
+    }
+  }
+}
+
 native_read_mvcc_state check_native_read_mvcc_state(
   duckdb::DataTable& storage,
   std::span<duckdb::storage_t const> scanned_columns,

--- a/src/op/scan/duckdb_native_decoder.cpp
+++ b/src/op/scan/duckdb_native_decoder.cpp
@@ -329,8 +329,8 @@ void append_segment_file_ranges(duckdb::SingleFileBlockManager const& bm,
                                 duckdb_segment_descriptor const& seg,
                                 std::vector<cudf::io::text::byte_range_info>& out)
 {
-  // Main payload. CONSTANT/blockless segments have bytes_size == 0; host-backed
-  // (insert-delta) segments have bytes_size > 0 but no block — both read no file.
+  // Main payload. CONSTANT/blockless segments (bytes_size == 0) and
+  // host-backed segments (payload but no block) read no file.
   if (seg.bytes_size > 0 && seg.block_id >= 0) {
     auto const off =
       duckdb_block_payload_offset(bm, seg.block_id) + static_cast<std::size_t>(seg.block_offset);
@@ -425,9 +425,8 @@ staged_column stage_one_fixed_width_column(
       ss.compression = seg.compression;
 
       if (seg.host_ptr != nullptr) {
-        // Host-backed segment (insert-delta staging): the bytes already sit in
-        // host memory owned by the enclosing scan_info; ride the CONSTANT/
-        // ROARING host-copy lane instead of a file read.
+        // Host-backed segment: the bytes sit in host memory owned by the
+        // enclosing scan_info, so stage a host copy instead of a file read.
         stage_host_copy(s, {{}, seg.host_ptr, seg.bytes_size}, ss);
       } else if (seg.compression == duckdb::CompressionType::COMPRESSION_CONSTANT) {
         auto const& stats = constant_stats_for(
@@ -850,10 +849,9 @@ void submit_and_await(rmm::device_buffer& device_buf,
   }
 }
 
-/// @brief H2D for a split with no file reads (every segment host-backed or
-/// CPU-produced): no io, no pinned staging blocks, no SiriusContext — just the
-/// direct host->device copies, synced so the caller may drop the source
-/// buffers' owners afterwards (same discipline as submit_and_await).
+/// H2D for a split with no file reads: no io, no pinned staging blocks, no
+/// SiriusContext. Synchronizes before returning so the caller may drop the
+/// source buffers' owners, same as submit_and_await.
 void submit_host_only_and_await(rmm::device_buffer& device_buf,
                                 staging_state const& s,
                                 rmm::cuda_stream_view stream)
@@ -1102,8 +1100,7 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(
                      coalesce_max_gap,
                      stream);
   } else if (!staging.host_copies.empty()) {
-    // All-host split (insert-delta transient bytes / CONSTANT-only): no file
-    // io, no host staging blocks, no SiriusContext dependency.
+    // All-host split: no file io, no staging blocks, no SiriusContext needed.
     submit_host_only_and_await(device_buf, staging, stream);
   }
 

--- a/src/op/scan/duckdb_native_decoder.cpp
+++ b/src/op/scan/duckdb_native_decoder.cpp
@@ -329,7 +329,9 @@ void append_segment_file_ranges(duckdb::SingleFileBlockManager const& bm,
                                 duckdb_segment_descriptor const& seg,
                                 std::vector<cudf::io::text::byte_range_info>& out)
 {
-  if (seg.bytes_size > 0) {  // main payload; CONSTANT/blockless => bytes_size == 0, skip
+  // Main payload. CONSTANT/blockless segments have bytes_size == 0; host-backed
+  // (insert-delta) segments have bytes_size > 0 but no block — both read no file.
+  if (seg.bytes_size > 0 && seg.block_id >= 0) {
     auto const off =
       duckdb_block_payload_offset(bm, seg.block_id) + static_cast<std::size_t>(seg.block_offset);
     out.emplace_back(static_cast<std::int64_t>(off), static_cast<std::int64_t>(seg.bytes_size));

--- a/src/op/scan/duckdb_native_decoder.cpp
+++ b/src/op/scan/duckdb_native_decoder.cpp
@@ -50,7 +50,6 @@
 #include <cucascade/memory/memory_space.hpp>
 #include <duckdb/common/types/validity_mask.hpp>
 #include <duckdb/common/types/vector.hpp>
-#include <duckdb/function/partition_stats.hpp>
 #include <duckdb/main/attached_database.hpp>
 #include <duckdb/main/database.hpp>
 #include <duckdb/storage/block_manager.hpp>
@@ -58,7 +57,6 @@
 #include <duckdb/storage/buffer_manager.hpp>
 #include <duckdb/storage/compression/roaring/roaring.hpp>
 #include <duckdb/storage/single_file_block_manager.hpp>
-#include <duckdb/storage/statistics/array_stats.hpp>
 #include <duckdb/storage/statistics/base_statistics.hpp>
 #include <duckdb/storage/statistics/numeric_stats.hpp>
 #include <duckdb/storage/statistics/string_stats.hpp>
@@ -128,6 +126,7 @@ bool is_supported_varchar_codec(duckdb::CompressionType c)
 bool column_has_real_nulls(duckdb_column_metadata const& col)
 {
   for (auto const& v : col.validity_segments) {
+    if (v.all_null) { return true; }
     auto c = v.compression;
     if (c == duckdb::CompressionType::COMPRESSION_UNCOMPRESSED ||
         c == duckdb::CompressionType::COMPRESSION_ROARING) {
@@ -152,9 +151,9 @@ struct pinned_segment_bytes {
 //===----------------------------------------------------------------------===//
 // CONSTANT extraction.
 //
-// CONSTANT segments have block_id == -1; the constant value lives in
-// per-(rg, col) statistics. We pull stats from PartitionRowGroup at scan
-// time and copy the value into an owned buffer the kernel can read.
+// CONSTANT segments have block_id == -1; the constant value lives in the
+// segment's own statistics, snapshotted onto the descriptor by the walker.
+// Copy the value into an owned buffer the kernel can read.
 //===----------------------------------------------------------------------===//
 
 template <typename T>
@@ -238,6 +237,23 @@ pinned_segment_bytes decode_roaring_validity(duckdb::DatabaseInstance& db,
     }
   }
 
+  out.host_ptr = out.owned_bytes.data();
+  out.bytes    = out.owned_bytes.size();
+  return out;
+}
+
+// All-NULL constant runs carry no bytes anywhere; ship zeroed validity bits.
+pinned_segment_bytes make_all_null_validity_bytes(duckdb::idx_t row_count)
+{
+  pinned_segment_bytes out;
+  out.owned_bytes.assign((static_cast<std::size_t>(row_count) + 7) / 8, 0x00);
+  if (row_count % 8 != 0) {
+    // The GPU overlays validity runs by whole-byte copy onto an all-valid
+    // mask, so the padding bits of a trailing partial byte must stay 1 or
+    // they would null the next segment's leading rows. Every other validity
+    // source (DuckDB buffers, the ROARING decode above) keeps them set.
+    out.owned_bytes.back() = static_cast<uint8_t>(0xFFu << (row_count % 8));
+  }
   out.host_ptr = out.owned_bytes.data();
   out.bytes    = out.owned_bytes.size();
   return out;
@@ -372,39 +388,27 @@ void stage_device_read(staging_state& s,
   }
 }
 
-duckdb::BaseStatistics const& constant_stats_for(
-  std::vector<duckdb::PartitionStatistics> const& partition_stats,
-  duckdb::idx_t rg_idx,
-  duckdb::idx_t storage_idx,
-  std::vector<std::unique_ptr<duckdb::BaseStatistics>>& owned_stats_cache)
+// The walker guarantees CONSTANT descriptors carry their segment's stats.
+duckdb::BaseStatistics const& constant_segment_stats(duckdb_segment_descriptor const& seg,
+                                                     duckdb::idx_t column_id)
 {
-  if (rg_idx >= partition_stats.size() || !partition_stats[rg_idx].partition_row_group) {
+  if (!seg.segment_stats) {
     throw std::runtime_error(std::string(kTag) +
-                             " no PartitionRowGroup for CONSTANT lookup on rg " +
-                             std::to_string(rg_idx));
+                             " CONSTANT segment without carried segment stats (column " +
+                             std::to_string(column_id) + ")");
   }
-  auto stats = partition_stats[rg_idx].partition_row_group->GetColumnStatistics(
-    duckdb::StorageIndex(storage_idx));
-  if (!stats) {
-    throw std::runtime_error(std::string(kTag) +
-                             " PartitionRowGroup returned null stats for CONSTANT lookup");
-  }
-  owned_stats_cache.push_back(std::move(stats));
-  return *owned_stats_cache.back();
+  return *seg.segment_stats;
 }
 
 /// @brief Stage the data and validity segments for a fixed-width column, returning the staged
 /// segments and metadata for the scan kernel. Throws if an unsupported codec is encountered.
-staged_column stage_one_fixed_width_column(
-  staging_state& s,
-  duckdb::DatabaseInstance& db,
-  duckdb::BlockManager& block_manager,
-  duckdb::SingleFileBlockManager const& sf_bm,
-  std::vector<duckdb::PartitionStatistics> const& partition_stats,
-  std::vector<std::unique_ptr<duckdb::BaseStatistics>>& owned_stats_cache,
-  std::vector<duckdb_row_group_metadata> const& row_groups,
-  std::size_t projected_col_idx,
-  sirius::logical_type const& projected_type)
+staged_column stage_one_fixed_width_column(staging_state& s,
+                                           duckdb::DatabaseInstance& db,
+                                           duckdb::BlockManager& block_manager,
+                                           duckdb::SingleFileBlockManager const& sf_bm,
+                                           std::vector<duckdb_row_group_metadata> const& row_groups,
+                                           std::size_t projected_col_idx,
+                                           sirius::logical_type const& projected_type)
 {
   staged_column out;
 
@@ -429,8 +433,7 @@ staged_column stage_one_fixed_width_column(
         // enclosing scan_info, so stage a host copy instead of a file read.
         stage_host_copy(s, {{}, seg.host_ptr, seg.bytes_size}, ss);
       } else if (seg.compression == duckdb::CompressionType::COMPRESSION_CONSTANT) {
-        auto const& stats = constant_stats_for(
-          partition_stats, rg.row_group_index, col_md.column_id, owned_stats_cache);
+        auto const& stats = constant_segment_stats(seg, col_md.column_id);
         stage_host_copy(s, extract_constant_bytes(stats, projected_type), ss);
       } else {
         stage_device_read(s, sf_bm, seg, ss);
@@ -441,7 +444,7 @@ staged_column stage_one_fixed_width_column(
     //===----------Validity Segments----------===//
     if (column_has_real_nulls(col_md)) { out.has_nulls = true; }
     for (auto const& vseg : col_md.validity_segments) {
-      if (is_constant_or_empty_validity(vseg.compression)) { continue; }
+      if (is_constant_or_empty_validity(vseg.compression) && !vseg.all_null) { continue; }
       staged_segment vs;
       vs.row_offset = row_cursor + static_cast<uint32_t>(vseg.segment_start);
       vs.row_count  = static_cast<uint32_t>(vseg.segment_count);
@@ -449,7 +452,9 @@ staged_column stage_one_fixed_width_column(
       // we ship as UNCOMPRESSED — even when source was ROARING.
       vs.compression = duckdb::CompressionType::COMPRESSION_UNCOMPRESSED;
 
-      if (vseg.host_ptr != nullptr) {
+      if (vseg.all_null) {
+        stage_host_copy(s, make_all_null_validity_bytes(vseg.segment_count), vs);
+      } else if (vseg.host_ptr != nullptr) {
         stage_host_copy(s, {{}, vseg.host_ptr, vseg.bytes_size}, vs);
       } else if (vseg.compression == duckdb::CompressionType::COMPRESSION_ROARING) {
         // ROARING stays on BufferManager: CreatePersistentSegment drives
@@ -514,13 +519,15 @@ staged_column stage_one_varchar_column(staging_state& s,
     //===----------Validity Segments----------===//
     if (column_has_real_nulls(col_md)) { out.has_nulls = true; }
     for (auto const& vseg : col_md.validity_segments) {
-      if (is_constant_or_empty_validity(vseg.compression)) { continue; }
+      if (is_constant_or_empty_validity(vseg.compression) && !vseg.all_null) { continue; }
       staged_segment vs;
       vs.row_offset  = row_cursor + static_cast<uint32_t>(vseg.segment_start);
       vs.row_count   = static_cast<uint32_t>(vseg.segment_count);
       vs.compression = duckdb::CompressionType::COMPRESSION_UNCOMPRESSED;
 
-      if (vseg.host_ptr != nullptr) {
+      if (vseg.all_null) {
+        stage_host_copy(s, make_all_null_validity_bytes(vseg.segment_count), vs);
+      } else if (vseg.host_ptr != nullptr) {
         stage_host_copy(s, {{}, vseg.host_ptr, vseg.bytes_size}, vs);
       } else if (vseg.compression == duckdb::CompressionType::COMPRESSION_ROARING) {
         stage_host_copy(s, decode_roaring_validity(db, block_manager, vseg), vs);
@@ -545,16 +552,13 @@ staged_column stage_one_varchar_column(staging_state& s,
 /// + optional child validity (path [col,1,0]). The child segments are in element-units and
 /// DuckDB already emits child segment_start/segment_count in element units, so they drop
 /// straight into staged_segment.
-staged_column stage_one_array_column(
-  staging_state& s,
-  duckdb::DatabaseInstance& db,
-  duckdb::BlockManager& block_manager,
-  duckdb::SingleFileBlockManager const& sf_bm,
-  std::vector<duckdb::PartitionStatistics> const& partition_stats,
-  std::vector<std::unique_ptr<duckdb::BaseStatistics>>& owned_stats_cache,
-  std::vector<duckdb_row_group_metadata> const& row_groups,
-  std::size_t projected_col_idx,
-  sirius::logical_type const& projected_type)
+staged_column stage_one_array_column(staging_state& s,
+                                     duckdb::DatabaseInstance& db,
+                                     duckdb::BlockManager& block_manager,
+                                     duckdb::SingleFileBlockManager const& sf_bm,
+                                     std::vector<duckdb_row_group_metadata> const& row_groups,
+                                     std::size_t projected_col_idx,
+                                     sirius::logical_type const& projected_type)
 {
   staged_column out;
   out.is_array = true;
@@ -573,14 +577,16 @@ staged_column stage_one_array_column(
     // columns, so validity_segments (what column_has_real_nulls inspects) is
     // empty. Detect real nulls from the validity codec here.
     for (auto const& vseg : col_md.data_segments) {
-      if (is_constant_or_empty_validity(vseg.compression)) { continue; }
+      if (is_constant_or_empty_validity(vseg.compression) && !vseg.all_null) { continue; }
       out.has_nulls = true;
       staged_segment vs;
       vs.row_offset  = row_cursor + static_cast<uint32_t>(vseg.segment_start);
       vs.row_count   = static_cast<uint32_t>(vseg.segment_count);
       vs.compression = duckdb::CompressionType::COMPRESSION_UNCOMPRESSED;
 
-      if (vseg.compression == duckdb::CompressionType::COMPRESSION_ROARING) {
+      if (vseg.all_null) {
+        stage_host_copy(s, make_all_null_validity_bytes(vseg.segment_count), vs);
+      } else if (vseg.compression == duckdb::CompressionType::COMPRESSION_ROARING) {
         stage_host_copy(s, decode_roaring_validity(db, block_manager, vseg), vs);
       } else if (vseg.compression == duckdb::CompressionType::COMPRESSION_UNCOMPRESSED) {
         stage_device_read(s, sf_bm, vseg, vs);
@@ -605,12 +611,9 @@ staged_column stage_one_array_column(
       ss.compression = seg.compression;
 
       if (seg.compression == duckdb::CompressionType::COMPRESSION_CONSTANT) {
-        // GetColumnStatistics on an ARRAY column returns ArrayStats; the child's
-        // numeric min/max (what the CONSTANT value is derived from) lives in the
-        // nested child stats, so unwrap before extracting.
-        auto const& array_stats = constant_stats_for(
-          partition_stats, rg.row_group_index, col_md.column_id, owned_stats_cache);
-        auto const& child_stats = duckdb::ArrayStats::GetChildStats(array_stats);
+        // The child segment's own stats are child-typed numeric stats, so
+        // they extract directly — no ArrayStats unwrap.
+        auto const& child_stats = constant_segment_stats(seg, col_md.column_id);
         stage_host_copy(s, extract_constant_bytes(child_stats, child_type), ss);
       } else {
         stage_device_read(s, sf_bm, seg, ss);
@@ -620,14 +623,16 @@ staged_column stage_one_array_column(
 
     //===----------Child Validity (path [col, 1, 0])----------===//
     for (auto const& vseg : col_md.array_child_validity_segments) {
-      if (is_constant_or_empty_validity(vseg.compression)) { continue; }
+      if (is_constant_or_empty_validity(vseg.compression) && !vseg.all_null) { continue; }
       out.child_has_nulls = true;
       staged_segment vs;
       vs.row_offset  = child_elem_cursor + static_cast<uint32_t>(vseg.segment_start);
       vs.row_count   = static_cast<uint32_t>(vseg.segment_count);
       vs.compression = duckdb::CompressionType::COMPRESSION_UNCOMPRESSED;
 
-      if (vseg.compression == duckdb::CompressionType::COMPRESSION_ROARING) {
+      if (vseg.all_null) {
+        stage_host_copy(s, make_all_null_validity_bytes(vseg.segment_count), vs);
+      } else if (vseg.compression == duckdb::CompressionType::COMPRESSION_ROARING) {
         stage_host_copy(s, decode_roaring_validity(db, block_manager, vseg), vs);
       } else if (vseg.compression == duckdb::CompressionType::COMPRESSION_UNCOMPRESSED) {
         stage_device_read(s, sf_bm, vseg, vs);
@@ -969,8 +974,7 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(
   duckdb_native_ingestible_table_info const& table_info,
   sirius::io::sirius_datasource* datasource,
   cucascade::memory::memory_space& mem_space,
-  rmm::cuda_stream_view stream,
-  duckdb::vector<duckdb::PartitionStatistics> const* carried_partition_stats)
+  rmm::cuda_stream_view stream)
 {
   if (row_groups.empty()) {
     // Empty / fully-pruned split: emit a schema-correct 0-row table (one empty
@@ -1003,19 +1007,6 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(
       " missing io_ctx, io_obj, or SingleFileBlockManager for duckdb_native_scan");
   }
 
-  // PartitionRowGroup lookup needed for CONSTANT segments + held alive for the
-  // duration of the decode (its destructor releases an internal reference).
-  // Insert-delta splits carry capture-time stats instead: GetPartitionStats
-  // touches ClientContext / LocalStorage, which are not safe off the query
-  // thread, and delta decodes run on task threads.
-  duckdb::vector<duckdb::PartitionStatistics> fetched_partition_stats;
-  if (carried_partition_stats == nullptr) {
-    fetched_partition_stats = storage.GetPartitionStats(context);
-  }
-  auto const& partition_stats =
-    carried_partition_stats != nullptr ? *carried_partition_stats : fetched_partition_stats;
-  std::vector<std::unique_ptr<duckdb::BaseStatistics>> owned_stats_cache;
-
   auto mr_ref = mem_space.get_default_allocator();
 
   auto const num_cols = scan_info.projected_cols.size();
@@ -1046,25 +1037,11 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(
       staged_cols.push_back(
         stage_one_varchar_column(staging, db, block_manager, *sf_bm, row_groups, ci));
     } else if (scan_info.projected_types[ci].is_array()) {
-      staged_cols.push_back(stage_one_array_column(staging,
-                                                   db,
-                                                   block_manager,
-                                                   *sf_bm,
-                                                   partition_stats,
-                                                   owned_stats_cache,
-                                                   row_groups,
-                                                   ci,
-                                                   scan_info.projected_types[ci]));
+      staged_cols.push_back(stage_one_array_column(
+        staging, db, block_manager, *sf_bm, row_groups, ci, scan_info.projected_types[ci]));
     } else {
-      staged_cols.push_back(stage_one_fixed_width_column(staging,
-                                                         db,
-                                                         block_manager,
-                                                         *sf_bm,
-                                                         partition_stats,
-                                                         owned_stats_cache,
-                                                         row_groups,
-                                                         ci,
-                                                         scan_info.projected_types[ci]));
+      staged_cols.push_back(stage_one_fixed_width_column(
+        staging, db, block_manager, *sf_bm, row_groups, ci, scan_info.projected_types[ci]));
     }
   }
 

--- a/src/op/scan/duckdb_native_decoder.cpp
+++ b/src/op/scan/duckdb_native_decoder.cpp
@@ -422,8 +422,12 @@ staged_column stage_one_fixed_width_column(
       ss.row_count   = static_cast<uint32_t>(seg.segment_count);
       ss.compression = seg.compression;
 
-      pinned_segment_bytes p;
-      if (seg.compression == duckdb::CompressionType::COMPRESSION_CONSTANT) {
+      if (seg.host_ptr != nullptr) {
+        // Host-backed segment (insert-delta staging): the bytes already sit in
+        // host memory owned by the enclosing scan_info; ride the CONSTANT/
+        // ROARING host-copy lane instead of a file read.
+        stage_host_copy(s, {{}, seg.host_ptr, seg.bytes_size}, ss);
+      } else if (seg.compression == duckdb::CompressionType::COMPRESSION_CONSTANT) {
         auto const& stats = constant_stats_for(
           partition_stats, rg.row_group_index, col_md.column_id, owned_stats_cache);
         stage_host_copy(s, extract_constant_bytes(stats, projected_type), ss);
@@ -444,7 +448,9 @@ staged_column stage_one_fixed_width_column(
       // we ship as UNCOMPRESSED — even when source was ROARING.
       vs.compression = duckdb::CompressionType::COMPRESSION_UNCOMPRESSED;
 
-      if (vseg.compression == duckdb::CompressionType::COMPRESSION_ROARING) {
+      if (vseg.host_ptr != nullptr) {
+        stage_host_copy(s, {{}, vseg.host_ptr, vseg.bytes_size}, vs);
+      } else if (vseg.compression == duckdb::CompressionType::COMPRESSION_ROARING) {
         // ROARING stays on BufferManager: CreatePersistentSegment drives
         // reads internally and we don't have a host_read shape for it yet.
         stage_host_copy(s, decode_roaring_validity(db, block_manager, vseg), vs);
@@ -486,7 +492,7 @@ staged_column stage_one_varchar_column(staging_state& s,
                           std::to_string(static_cast<int>(seg.compression)) + " (column " +
                           std::to_string(col_md.column_id) + ")");
       }
-      if (seg.block_id < 0) {
+      if (seg.host_ptr == nullptr && seg.block_id < 0) {
         throw_unsupported("varchar CONSTANT segment (column " + std::to_string(col_md.column_id) +
                           ")");
       }
@@ -494,9 +500,13 @@ staged_column stage_one_varchar_column(staging_state& s,
       ss.row_offset        = row_cursor + static_cast<uint32_t>(seg.segment_start);
       ss.row_count         = static_cast<uint32_t>(seg.segment_count);
       ss.compression       = seg.compression;
-      ss.max_string_length = *seg.max_string_length;  // walker invariant
+      ss.max_string_length = *seg.max_string_length;  // walker/capture invariant
 
-      stage_device_read(s, sf_bm, seg, ss);
+      if (seg.host_ptr != nullptr) {
+        stage_host_copy(s, {{}, seg.host_ptr, seg.bytes_size}, ss);
+      } else {
+        stage_device_read(s, sf_bm, seg, ss);
+      }
       out.data.push_back(ss);
     }
 
@@ -509,8 +519,9 @@ staged_column stage_one_varchar_column(staging_state& s,
       vs.row_count   = static_cast<uint32_t>(vseg.segment_count);
       vs.compression = duckdb::CompressionType::COMPRESSION_UNCOMPRESSED;
 
-      pinned_segment_bytes p;
-      if (vseg.compression == duckdb::CompressionType::COMPRESSION_ROARING) {
+      if (vseg.host_ptr != nullptr) {
+        stage_host_copy(s, {{}, vseg.host_ptr, vseg.bytes_size}, vs);
+      } else if (vseg.compression == duckdb::CompressionType::COMPRESSION_ROARING) {
         stage_host_copy(s, decode_roaring_validity(db, block_manager, vseg), vs);
       } else if (vseg.compression == duckdb::CompressionType::COMPRESSION_UNCOMPRESSED) {
         stage_device_read(s, sf_bm, vseg, vs);
@@ -837,6 +848,22 @@ void submit_and_await(rmm::device_buffer& device_buf,
   }
 }
 
+/// @brief H2D for a split with no file reads (every segment host-backed or
+/// CPU-produced): no io, no pinned staging blocks, no SiriusContext — just the
+/// direct host->device copies, synced so the caller may drop the source
+/// buffers' owners afterwards (same discipline as submit_and_await).
+void submit_host_only_and_await(rmm::device_buffer& device_buf,
+                                staging_state const& s,
+                                rmm::cuda_stream_view stream)
+{
+  auto* device_base = static_cast<uint8_t*>(device_buf.data());
+  for (auto const& h : s.host_copies) {
+    RMM_CUDA_TRY(cudaMemcpyAsync(
+      device_base + h.device_offset, h.src_ptr, h.size, cudaMemcpyHostToDevice, stream.value()));
+  }
+  RMM_CUDA_TRY(cudaStreamSynchronize(stream.value()));
+}
+
 //===----------------------------------------------------------------------===//
 // Build codec runs from staged segments.
 //===----------------------------------------------------------------------===//
@@ -940,9 +967,10 @@ std::vector<cudf::io::text::byte_range_info> row_group_file_ranges(
 std::unique_ptr<cudf::table> decode_duckdb_native_split(
   std::vector<duckdb_row_group_metadata> const& row_groups,
   duckdb_native_ingestible_table_info const& table_info,
-  sirius::io::sirius_datasource& datasource,
+  sirius::io::sirius_datasource* datasource,
   cucascade::memory::memory_space& mem_space,
-  rmm::cuda_stream_view stream)
+  rmm::cuda_stream_view stream,
+  duckdb::vector<duckdb::PartitionStatistics> const* carried_partition_stats)
 {
   if (row_groups.empty()) {
     // Empty / fully-pruned split: emit a schema-correct 0-row table (one empty
@@ -977,7 +1005,15 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(
 
   // PartitionRowGroup lookup needed for CONSTANT segments + held alive for the
   // duration of the decode (its destructor releases an internal reference).
-  auto partition_stats = storage.GetPartitionStats(context);
+  // Insert-delta splits carry capture-time stats instead: GetPartitionStats
+  // touches ClientContext / LocalStorage, which are not safe off the query
+  // thread, and delta decodes run on task threads.
+  duckdb::vector<duckdb::PartitionStatistics> fetched_partition_stats;
+  if (carried_partition_stats == nullptr) {
+    fetched_partition_stats = storage.GetPartitionStats(context);
+  }
+  auto const& partition_stats =
+    carried_partition_stats != nullptr ? *carried_partition_stats : fetched_partition_stats;
   std::vector<std::unique_ptr<duckdb::BaseStatistics>> owned_stats_cache;
 
   auto mr_ref = mem_space.get_default_allocator();
@@ -1033,7 +1069,11 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(
   }
 
   rmm::device_buffer device_buf(staging.running_offset, stream, mr_ref);
-  if (staging.running_offset > 0) {
+  if (!staging.reads.empty()) {
+    if (datasource == nullptr) {
+      throw std::runtime_error(std::string(kTag) +
+                               " split staged file reads but carries no datasource");
+    }
     auto sirius_st = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
     if (!sirius_st) {
       throw std::runtime_error(std::string(kTag) + " no sirius_state on the ClientContext");
@@ -1054,11 +1094,15 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(
     std::size_t const coalesce_max_gap = sf_bm->GetBlockHeaderSize();
     submit_and_await(device_buf,
                      staging,
-                     datasource,
+                     *datasource,
                      sirius_st->get_memory_manager(),
                      host_numa,
                      coalesce_max_gap,
                      stream);
+  } else if (!staging.host_copies.empty()) {
+    // All-host split (insert-delta transient bytes / CONSTANT-only): no file
+    // io, no host staging blocks, no SiriusContext dependency.
+    submit_host_only_and_await(device_buf, staging, stream);
   }
 
   // Group fixed-width columns for a single gpu_decode_table call; varchar

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -305,12 +305,16 @@ filtered_table duckdb_native_gpu_ingestible::materialize_metadata_to_table(
   rmm::cuda_stream_view stream)
 {
   auto const& split = static_cast<duckdb_native_scan_info const&>(info);
-  if (!split.datasource) {
+  if (!split.datasource && !split.host_backed_only) {
     throw std::runtime_error("[duckdb_native_gpu_ingestible] scan_info has no datasource");
   }
   auto& mem_space_mut = const_cast<::cucascade::memory::memory_space&>(mem_space);
-  auto table =
-    decode_duckdb_native_split(split.row_groups, *_info, *split.datasource, mem_space_mut, stream);
+  auto table          = decode_duckdb_native_split(split.row_groups,
+                                          *_info,
+                                          split.datasource.get(),
+                                          mem_space_mut,
+                                          stream,
+                                          split.carried_partition_stats.get());
   SIRIUS_LOG_DEBUG(
     "[duckdb_native_gpu_ingestible::materialize_table] decoded split: row_groups={} rows={} "
     "cols={}",

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -309,12 +309,8 @@ filtered_table duckdb_native_gpu_ingestible::materialize_metadata_to_table(
     throw std::runtime_error("[duckdb_native_gpu_ingestible] scan_info has no datasource");
   }
   auto& mem_space_mut = const_cast<::cucascade::memory::memory_space&>(mem_space);
-  auto table          = decode_duckdb_native_split(split.row_groups,
-                                          *_info,
-                                          split.datasource.get(),
-                                          mem_space_mut,
-                                          stream,
-                                          split.carried_partition_stats.get());
+  auto table          = decode_duckdb_native_split(
+    split.row_groups, *_info, split.datasource.get(), mem_space_mut, stream);
   SIRIUS_LOG_DEBUG(
     "[duckdb_native_gpu_ingestible::materialize_table] decoded split: row_groups={} rows={} "
     "cols={}",

--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -166,7 +166,21 @@ duckdb_segment_descriptor fill_segment_descriptor(duckdb::ColumnSegment& segment
     collect_block_ids visitor(desc.additional_blocks);
     cf.visit_block_ids(segment, visitor);
   }
+  if (desc.compression == duckdb::CompressionType::COMPRESSION_CONSTANT) {
+    // Snapshot the segment's own stats: the constant value lives here, and
+    // row-group-level stats drift as later appends merge into them.
+    desc.segment_stats = std::make_shared<duckdb::BaseStatistics>(segment.stats.statistics.Copy());
+  }
   return desc;
+}
+
+// A CONSTANT validity segment is uniform, with the direction in its stats:
+// all-valid decodes to nothing, all-NULL carries the marker so the decoder
+// synthesizes zero validity bits.
+bool constant_validity_is_all_null(duckdb::ColumnSegment& segment)
+{
+  return segment.GetCompressionFunction().type == duckdb::CompressionType::COMPRESSION_CONSTANT &&
+         segment.stats.statistics.CanHaveNull();
 }
 
 // Grants access to ArrayColumnData's protected child/validity members. C++
@@ -225,7 +239,9 @@ std::optional<std::string> walk_array_column(duckdb::ColumnData& col_data,
                " row group " + std::to_string(rg_idx) + ": unsupported compression " +
                duckdb::CompressionTypeToString(compression);
       }
-      out.push_back(fill_segment_descriptor(segment, node.GetRowStart()));
+      auto desc     = fill_segment_descriptor(segment, node.GetRowStart());
+      desc.all_null = constant_validity_is_all_null(segment);
+      out.push_back(std::move(desc));
     }
     return std::nullopt;
   };
@@ -332,7 +348,9 @@ std::optional<std::string> walk_standard_column(duckdb::ColumnData& col_data,
              std::to_string(rg_idx) + ": unsupported compression " +
              duckdb::CompressionTypeToString(compression);
     }
-    col_md.validity_segments.push_back(fill_segment_descriptor(segment, node.GetRowStart()));
+    auto desc     = fill_segment_descriptor(segment, node.GetRowStart());
+    desc.all_null = constant_validity_is_all_null(segment);
+    col_md.validity_segments.push_back(std::move(desc));
   }
   return std::nullopt;
 }
@@ -485,7 +503,9 @@ bool is_supported_data_compression(duckdb::CompressionType c)
 bool is_supported_validity_compression(duckdb::CompressionType c)
 {
   switch (c) {
-    // CONSTANT is the all-valid case (all-null columns land in EMPTY).
+    // CONSTANT validity is uniform — all-valid or all-NULL, disambiguated by
+    // the segment stats (see constant_validity_is_all_null). EMPTY means the
+    // base data codec covers validity itself.
     // ROARING is host-decoded to a plain bitmap before the GPU sees it.
     case duckdb::CompressionType::COMPRESSION_UNCOMPRESSED:
     case duckdb::CompressionType::COMPRESSION_EMPTY:

--- a/src/op/scan/gpu_ingestible.cpp
+++ b/src/op/scan/gpu_ingestible.cpp
@@ -35,9 +35,9 @@ filtered_table gpu_ingestible::materialize_table(const op::scan::scan_operator_i
     split.prefetch(io::cache::prefetching_stage::disposable);
     auto materialized = materialize_metadata_to_table(split.get_scan_info(), *mem_space, stream);
     if (split.mvcc_keep_mask.has_mask()) {
-      // Insert-delta splits carry a per-split visibility mask; disk-walk
-      // splits never do. Same apply-and-await discipline as the resident
-      // branch below.
+      // Only insert-delta splits carry a visibility mask here; disk-walk
+      // splits never do. Sync before returning for the same reason as the
+      // cached branch below.
       auto const& mask = split.mvcc_keep_mask;
       auto view        = materialized.table.view();
       if (mask.row_count != static_cast<std::size_t>(view.num_rows())) {

--- a/src/op/scan/gpu_ingestible.cpp
+++ b/src/op/scan/gpu_ingestible.cpp
@@ -33,7 +33,25 @@ filtered_table gpu_ingestible::materialize_table(const op::scan::scan_operator_i
   auto* mem_space = split.gpu_memory_space;
   if (split.has_scan_metadata()) [[likely]] {
     split.prefetch(io::cache::prefetching_stage::disposable);
-    return materialize_metadata_to_table(split.get_scan_info(), *mem_space, stream);
+    auto materialized = materialize_metadata_to_table(split.get_scan_info(), *mem_space, stream);
+    if (split.mvcc_keep_mask.has_mask()) {
+      // Insert-delta splits carry a per-split visibility mask; disk-walk
+      // splits never do. Same apply-and-await discipline as the resident
+      // branch below.
+      auto const& mask = split.mvcc_keep_mask;
+      auto view        = materialized.table.view();
+      if (mask.row_count != static_cast<std::size_t>(view.num_rows())) {
+        throw std::runtime_error("[gpu_ingestible::materialize_table] mvcc keep-mask covers " +
+                                 std::to_string(mask.row_count) +
+                                 " rows but the materialized split has " +
+                                 std::to_string(view.num_rows()));
+      }
+      auto masked = apply_host_keep_bitmask(
+        view, mask.view(), mask.row_count, stream, mem_space->get_default_allocator());
+      stream.synchronize();
+      return {.table = owning_table_view{std::move(masked)}, .state = materialized.state};
+    }
+    return materialized;
   } else {
     auto batch  = split.get_cached_batch();
     auto rbatch = batch->to_read_only();

--- a/src/op/scan/sirius_gpu_scan_operator_data.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator_data.cpp
@@ -69,8 +69,17 @@ std::size_t scan_operator_input::get_estimated_size_in_bytes() const
 std::size_t scan_operator_input::get_estimated_working_set_size_in_bytes() const
 {
   if (std::holds_alternative<std::unique_ptr<scan_info>>(materialization_info)) {
-    return std::get<std::unique_ptr<scan_info>>(materialization_info)
-      ->estimated_working_set_bytes();
+    auto const decode_bytes =
+      std::get<std::unique_ptr<scan_info>>(materialization_info)->estimated_working_set_bytes();
+    if (mvcc_keep_mask.has_mask()) {
+      // A partially visible insert-delta split is mask-filtered right after
+      // decode: the decoded input and the compacted output (up to input-sized)
+      // coexist at peak, alongside the BOOL8 expansion column (1 B/row) and
+      // the uploaded bitmask words — the same envelope as the cached branch
+      // below.
+      return 2 * decode_bytes + mvcc_keep_mask.row_count + mvcc_keep_mask.view().size_bytes();
+    }
+    return decode_bytes;
   }
   auto const batch_bytes = get_estimated_size_in_bytes();
   if (mvcc_keep_mask.has_mask()) {

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -183,22 +183,35 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
             static_cast<unsigned long long>(entry->mvcc->v_base),
             table.name);
         }
-        // (b) insert-present: committed rows beyond the pinned prefix, or
-        // this transaction's own uncommitted appends (transaction-local
-        // storage) — not served from the cache until the insert-delta
-        // reader lands.
-        if (static_cast<std::size_t>(storage.GetTotalRows()) > n_cache) {
-          throw duckdb::NotImplementedException(
-            "duckdb-native scan: table '%s' has rows beyond the %llu pinned at pin time; "
-            "post-pin inserts are not served from the cache yet",
-            table.name,
-            static_cast<unsigned long long>(n_cache));
-        }
+        // (b) transaction-local appends: rows in this transaction's
+        // LocalStorage live outside the table's segment trees, so neither
+        // the cache nor the insert delta can serve them. Committed rows
+        // beyond the pinned prefix ARE served: the prepare-time insert-delta
+        // job stages them, masked to this snapshot's visibility.
         if (duckdb::LocalStorage::Get(context, storage.GetAttached()).GetStorage(storage)) {
           throw duckdb::NotImplementedException(
             "duckdb-native scan: table '%s' has uncommitted appends in this transaction; "
             "transaction-local inserts are not served from the cache",
             table.name);
+        }
+        // (b') v1 scope: the insert delta does not serve ARRAY columns —
+        // decline while rows beyond the pinned prefix exist (the capture's
+        // own ARRAY check backstops the plan→prepare insert race, loudly).
+        if (static_cast<std::size_t>(storage.GetTotalRows()) > n_cache) {
+          for (auto const& col_idx : column_ids) {
+            if (!col_idx.HasPrimaryIndex() || col_idx.IsRowIdColumn() ||
+                col_idx.IsVirtualColumn() || col_idx.IsEmptyColumn()) {
+              continue;
+            }
+            auto const primary = col_idx.GetPrimaryIndex();
+            if (primary < op.returned_types.size() &&
+                op.returned_types[primary].id() == duckdb::LogicalTypeId::ARRAY) {
+              throw duckdb::NotImplementedException(
+                "duckdb-native scan: table '%s' has rows beyond the pinned prefix and an ARRAY "
+                "projection; the insert delta does not serve ARRAY columns",
+                table.name);
+            }
+          }
         }
         bool pin_serves = !has_unservable_column;
         if (pin_serves && !column_ids.empty()) {

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -184,19 +184,19 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
             table.name);
         }
         // (b) transaction-local appends: rows in this transaction's
-        // LocalStorage live outside the table's segment trees, so neither
-        // the cache nor the insert delta can serve them. Committed rows
-        // beyond the pinned prefix ARE served: the prepare-time insert-delta
-        // job stages them, masked to this snapshot's visibility.
+        // LocalStorage live outside the table's segment trees, so neither the
+        // cache nor the insert delta can serve them. Committed rows beyond
+        // the pinned prefix are served by the prepare-time insert-delta job,
+        // masked to this snapshot's visibility.
         if (duckdb::LocalStorage::Get(context, storage.GetAttached()).GetStorage(storage)) {
           throw duckdb::NotImplementedException(
             "duckdb-native scan: table '%s' has uncommitted appends in this transaction; "
             "transaction-local inserts are not served from the cache",
             table.name);
         }
-        // (b') v1 scope: the insert delta does not serve ARRAY columns —
-        // decline while rows beyond the pinned prefix exist (the capture's
-        // own ARRAY check backstops the plan→prepare insert race, loudly).
+        // (b') the insert delta does not serve ARRAY columns, so decline
+        // while rows beyond the pinned prefix exist. Rows inserted after
+        // this check are caught by the capture's own ARRAY check.
         if (static_cast<std::size_t>(storage.GetTotalRows()) > n_cache) {
           for (auto const& col_idx : column_ids) {
             if (!col_idx.HasPrimaryIndex() || col_idx.IsRowIdColumn() ||

--- a/src/scan_manager/insert_delta_job.cpp
+++ b/src/scan_manager/insert_delta_job.cpp
@@ -44,8 +44,8 @@ namespace ccm = cucascade::memory;
 
 constexpr std::size_t kCarveAlign = 64;  // cache-line-aligned carve within the bundle storage
 
-/// Keeps a bundle's pinned staging alive for as long as any published split
-/// references it. Member order matters (blocks release into the reservation).
+/// Keeps a bundle's pinned staging alive while any split references it.
+/// Member order matters: blocks must be destroyed before the reservation.
 struct pinned_staging_bundle {
   std::unique_ptr<ccm::reservation> reservation;
   std::unique_ptr<ccm::fixed_size_host_memory_resource::multiple_blocks_allocation> blocks;
@@ -91,7 +91,7 @@ insert_delta_workset prepare_insert_delta_tasks(
         request.entry_name + "'");
     }
 
-    // Stage 1 — SERIAL capture (prepare thread; ClientContext discipline).
+    // Captures run serially on this thread; ClientContext is not thread-safe.
     try {
       request.plan = op::scan::capture_insert_delta_plan(*request.storage,
                                                          *request.context,
@@ -105,10 +105,9 @@ insert_delta_workset prepare_insert_delta_tasks(
     request.bundles.clear();
     if (request.plan.empty()) { continue; }
 
-    // Stage 2 — bundle planning: close on the byte budget, the cudf int32
-    // varchar-chars threshold, or a row count that leaves the cumulative
-    // bundle rows off a byte boundary (staged validity runs need byte-aligned
-    // row offsets).
+    // Close a bundle on the byte budget, the cudf int32 varchar threshold, or
+    // a cumulative row count off a byte boundary: staged validity needs
+    // byte-aligned row offsets.
     auto const& rgs = request.plan.row_groups;
     std::vector<std::vector<std::size_t>> bundles_rgs;
     {
@@ -147,9 +146,9 @@ insert_delta_workset prepare_insert_delta_tasks(
       flush();
     }
 
-    // Stage 3 — per-bundle storage carve (staging slab + mask words) and the
-    // fill task. One task per bundle: its mask is single-writer, so the bit
-    // offsets need no word alignment.
+    // Carve each bundle's staging slab and mask words, then build its fill
+    // task. One task per bundle keeps the mask single-writer, so bit offsets
+    // need no word alignment.
     for (auto& rg_list : bundles_rgs) {
       insert_delta_bundle bundle;
       bundle.rg_indices = std::move(rg_list);
@@ -169,7 +168,6 @@ insert_delta_workset prepare_insert_delta_tasks(
 
       std::uint8_t* base = nullptr;
       if (total_size <= block_size) {
-        // Reservation-first pinned storage on the bundle's GPU's NUMA node.
         ccm::any_memory_space_in_tier_with_preference host_req(
           ccm::Tier::HOST, numa_node_for_device(bundle.preferred_device, topology));
         auto reservation = reservation_manager.request_reservation(host_req, block_size);
@@ -191,9 +189,9 @@ insert_delta_workset prepare_insert_delta_tasks(
         base                = reinterpret_cast<std::uint8_t*>(pinned->blocks->at(0).data());
         bundle.staging      = std::move(pinned);
       } else {
-        // Staging blocks are not virtually contiguous, so an oversized bundle
-        // keeps plain pageable memory: cudaMemcpyAsync stages pageable bytes
-        // out before returning, so only the true-async-DMA benefit is lost.
+        // Staging blocks are not virtually contiguous, so oversized bundles
+        // use pageable memory. cudaMemcpyAsync stages pageable bytes before
+        // returning, so only the async-DMA benefit is lost.
         SIRIUS_LOG_INFO(
           "[prepare_insert_delta_tasks] pinned entry '{}': delta bundle needs {} bytes (> one "
           "{}-byte staging block); using pageable host memory for it",
@@ -245,11 +243,11 @@ void finalize_insert_delta_jobs(insert_delta_workset& workset)
   for (auto& work : workset.works) {
     auto& bundle = work->request->bundles[work->bundle_index];
     if (work->visible == bundle.total_rows) {
-      // Every covered row visible: serve unmasked (no upload, no kernel).
+      // Every row visible: serve unmasked.
       bundle.mask = mvcc_chunk_mask{};
     } else if (work->visible == 0) {
-      // Nothing visible (all inserted after this snapshot, or all deleted):
-      // tombstone; the sweep below drops it.
+      // Nothing visible under this snapshot: mark empty so the sweep below
+      // drops the bundle.
       bundle.total_rows = 0;
     }
     touched.insert(work->request);
@@ -280,7 +278,6 @@ std::vector<insert_delta_split> cut_delta_splits_for_op(
   std::shared_ptr<sirius::io::sirius_datasource> datasource,
   duckdb::SingleFileBlockManager const* block_manager)
 {
-  // Resolve each operator column into the request's union.
   std::vector<std::size_t> union_idx;
   union_idx.reserve(op_projected_cols.size());
   for (auto const& pc : op_projected_cols) {

--- a/src/scan_manager/insert_delta_job.cpp
+++ b/src/scan_manager/insert_delta_job.cpp
@@ -84,7 +84,9 @@ insert_delta_workset prepare_insert_delta_tasks(
   auto const block_size = probe_fsmr->get_block_size();
 
   // Capture phase 1, serial: the ClientContext-touching transaction/buffer-
-  // manager capture and row-group skeleton enumeration.
+  // manager capture plus the delta row-group skeleton walk, which starts at
+  // the binary-searched boundary row group rather than scanning the cached
+  // prefix.
   for (auto& request : requests) {
     if (!request.storage || !request.context) {
       throw std::runtime_error(

--- a/src/scan_manager/insert_delta_job.cpp
+++ b/src/scan_manager/insert_delta_job.cpp
@@ -63,6 +63,7 @@ std::size_t numa_node_for_device(int device, sirius::memory::topology_index cons
 
 insert_delta_workset prepare_insert_delta_tasks(
   std::span<insert_delta_job_request> requests,
+  exec::scoped_dispatcher& dispatcher,
   cucascade::memory::memory_reservation_manager& reservation_manager,
   sirius::memory::topology_index const& topology,
   std::span<int const> gpu_ids)
@@ -82,27 +83,71 @@ insert_delta_workset prepare_insert_delta_tasks(
   }
   auto const block_size = probe_fsmr->get_block_size();
 
-  std::size_t next_device = 0;
-
+  // Capture phase 1, serial: the ClientContext-touching transaction/buffer-
+  // manager capture and row-group skeleton enumeration.
   for (auto& request : requests) {
     if (!request.storage || !request.context) {
       throw std::runtime_error(
         "[prepare_insert_delta_tasks] malformed delta request for pinned entry '" +
         request.entry_name + "'");
     }
-
-    // Captures run serially on this thread; ClientContext is not thread-safe.
     try {
-      request.plan = op::scan::capture_insert_delta_plan(*request.storage,
-                                                         *request.context,
-                                                         request.n_cache,
-                                                         request.union_cols,
-                                                         request.union_types);
+      request.plan =
+        op::scan::prepare_insert_delta_capture(*request.storage, *request.context, request.n_cache);
     } catch (std::exception const& e) {
       throw std::runtime_error("[prepare_insert_delta_tasks] pinned entry '" + request.entry_name +
                                "': " + e.what());
     }
     request.bundles.clear();
+  }
+
+  // Capture phase 2, parallel: the column segment-tree walks, in row-group
+  // ranges of the shared metadata parse granularity. Each task fills its own
+  // output; the merge below reassembles row-group order deterministically.
+  {
+    struct capture_range_work {
+      insert_delta_job_request* request{nullptr};
+      std::size_t rg_begin{0};
+      std::size_t rg_end{0};
+      std::vector<op::scan::insert_delta_row_group> out;
+    };
+    std::vector<std::unique_ptr<capture_range_work>> range_works;
+    auto const parse_chunk = op::scan::metadata_parse_chunk();
+    for (auto& request : requests) {
+      auto const n_rgs = request.plan.row_groups.size();
+      for (std::size_t begin = 0; begin < n_rgs; begin += parse_chunk) {
+        auto work      = std::make_unique<capture_range_work>();
+        work->request  = &request;
+        work->rg_begin = begin;
+        work->rg_end   = std::min(begin + parse_chunk, n_rgs);
+        range_works.push_back(std::move(work));
+      }
+    }
+    std::vector<absl::AnyInvocable<void()>> range_tasks;
+    range_tasks.reserve(range_works.size());
+    for (auto& work : range_works) {
+      range_tasks.push_back([work_ptr = work.get()] {
+        auto* req = work_ptr->request;
+        try {
+          work_ptr->out = op::scan::capture_insert_delta_row_group_range(
+            req->plan, work_ptr->rg_begin, work_ptr->rg_end, req->union_cols, req->union_types);
+        } catch (std::exception const& e) {
+          throw std::runtime_error("[prepare_insert_delta_tasks] pinned entry '" + req->entry_name +
+                                   "': " + e.what());
+        }
+      });
+    }
+    fan_out_and_join(dispatcher, std::move(range_tasks), "insert-delta capture");
+    for (auto& work : range_works) {
+      for (std::size_t i = 0; i < work->out.size(); ++i) {
+        work->request->plan.row_groups[work->rg_begin + i] = std::move(work->out[i]);
+      }
+    }
+  }
+
+  std::size_t next_device = 0;
+
+  for (auto& request : requests) {
     if (request.plan.empty()) { continue; }
 
     // Close a bundle on the byte budget, the cudf int32 varchar threshold, or
@@ -263,7 +308,8 @@ void run_insert_delta_jobs(std::span<insert_delta_job_request> requests,
                            sirius::memory::topology_index const& topology,
                            std::span<int const> gpu_ids)
 {
-  auto workset = prepare_insert_delta_tasks(requests, reservation_manager, topology, gpu_ids);
+  auto workset =
+    prepare_insert_delta_tasks(requests, dispatcher, reservation_manager, topology, gpu_ids);
   if (workset.fill_tasks.empty()) { return; }
   SIRIUS_LOG_DEBUG("[run_insert_delta_jobs] {} bundle(s) across {} request(s)",
                    workset.works.size(),

--- a/src/scan_manager/insert_delta_job.cpp
+++ b/src/scan_manager/insert_delta_job.cpp
@@ -325,7 +325,6 @@ std::vector<insert_delta_split> cut_delta_splits_for_op(
   out.reserve(request.bundles.size());
   for (auto const& bundle : request.bundles) {
     auto info           = std::make_unique<op::scan::duckdb_native_scan_info>();
-    info->datasource    = datasource;
     info->block_manager = block_manager;
     if (bundle.staging) { info->staging_keepalive.push_back(bundle.staging); }
 
@@ -360,6 +359,10 @@ std::vector<insert_delta_split> cut_delta_splits_for_op(
       info->row_groups.push_back(std::move(md));
     }
     info->host_backed_only = !any_file_read;
+    // The prefetch handle inside a datasource is per-scan mutable state, so
+    // every file-backed split owns a fresh duplicate (matching the native-scan
+    // coalescer); splits that read no file carry none.
+    if (any_file_read && datasource) { info->datasource = datasource->duplicate(); }
 
     out.push_back({std::move(info), bundle.mask, bundle.preferred_device});
   }

--- a/src/scan_manager/insert_delta_job.cpp
+++ b/src/scan_manager/insert_delta_job.cpp
@@ -304,6 +304,8 @@ std::vector<insert_delta_split> cut_delta_splits_for_op(
       d.compression       = s.compression;
       d.max_string_length = s.max_string_length;
       d.bytes_size        = s.bytes_size;
+      d.all_null          = s.all_null;
+      d.segment_stats     = s.segment_stats;
       if (s.is_transient) {
         d.block_id     = -1;
         d.block_offset = 0;
@@ -312,7 +314,9 @@ std::vector<insert_delta_split> cut_delta_splits_for_op(
         d.block_id          = s.block_id;
         d.block_offset      = s.block_offset;
         d.additional_blocks = s.additional_blocks;
-        any_file_read       = true;
+        // Blockless persistent segments (CONSTANT data, all-NULL validity)
+        // decode from stats or synthesis and read no file.
+        if (d.block_id >= 0) { any_file_read = true; }
       }
       return d;
     };
@@ -320,10 +324,9 @@ std::vector<insert_delta_split> cut_delta_splits_for_op(
   std::vector<insert_delta_split> out;
   out.reserve(request.bundles.size());
   for (auto const& bundle : request.bundles) {
-    auto info                     = std::make_unique<op::scan::duckdb_native_scan_info>();
-    info->datasource              = datasource;
-    info->block_manager           = block_manager;
-    info->carried_partition_stats = request.plan.partition_stats;
+    auto info           = std::make_unique<op::scan::duckdb_native_scan_info>();
+    info->datasource    = datasource;
+    info->block_manager = block_manager;
     if (bundle.staging) { info->staging_keepalive.push_back(bundle.staging); }
 
     bool any_file_read = false;

--- a/src/scan_manager/insert_delta_job.cpp
+++ b/src/scan_manager/insert_delta_job.cpp
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "scan_manager/insert_delta_job.hpp"
+
+#include "log/logging.hpp"
+#include "memory/topology_index.hpp"
+#include "op/scan/duckdb_native_gpu_ingestible.hpp"
+#include "op/scan/duckdb_native_metadata.hpp"
+#include "scan_manager/mvcc_mask_job.hpp"
+
+#include <cucascade/memory/fixed_size_host_memory_resource.hpp>
+#include <cucascade/memory/memory_reservation.hpp>
+#include <cucascade/memory/memory_reservation_manager.hpp>
+#include <cucascade/memory/memory_space.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace sirius::scan_manager {
+
+namespace {
+
+namespace ccm = cucascade::memory;
+
+constexpr std::size_t kCarveAlign = 64;  // cache-line-aligned carve within the bundle storage
+
+/// Keeps a bundle's pinned staging alive for as long as any published split
+/// references it. Member order matters (blocks release into the reservation).
+struct pinned_staging_bundle {
+  std::unique_ptr<ccm::reservation> reservation;
+  std::unique_ptr<ccm::fixed_size_host_memory_resource::multiple_blocks_allocation> blocks;
+};
+
+std::size_t align_up(std::size_t v, std::size_t a) { return (v + a - 1) / a * a; }
+
+std::size_t numa_node_for_device(int device, sirius::memory::topology_index const& topology)
+{
+  int const numa = topology.numa_node_of(device);
+  return numa < 0 ? 0 : static_cast<std::size_t>(numa);
+}
+
+}  // namespace
+
+insert_delta_workset prepare_insert_delta_tasks(
+  std::span<insert_delta_job_request> requests,
+  cucascade::memory::memory_reservation_manager& reservation_manager,
+  sirius::memory::topology_index const& topology,
+  std::span<int const> gpu_ids)
+{
+  insert_delta_workset workset;
+  if (requests.empty()) { return workset; }
+
+  auto host_spaces = reservation_manager.get_memory_spaces_for_tier(ccm::Tier::HOST);
+  if (host_spaces.empty()) {
+    throw std::runtime_error("[prepare_insert_delta_tasks] no HOST-tier memory space registered");
+  }
+  auto const* probe_fsmr =
+    host_spaces.front()->get_memory_resource_as<ccm::fixed_size_host_memory_resource>();
+  if (probe_fsmr == nullptr) {
+    throw std::runtime_error(
+      "[prepare_insert_delta_tasks] host memory space is not a fixed_size_host_memory_resource");
+  }
+  auto const block_size = probe_fsmr->get_block_size();
+
+  std::size_t next_device = 0;
+
+  for (auto& request : requests) {
+    if (!request.storage || !request.context) {
+      throw std::runtime_error(
+        "[prepare_insert_delta_tasks] malformed delta request for pinned entry '" +
+        request.entry_name + "'");
+    }
+
+    // Stage 1 — SERIAL capture (prepare thread; ClientContext discipline).
+    try {
+      request.plan = op::scan::capture_insert_delta_plan(*request.storage,
+                                                         *request.context,
+                                                         request.n_cache,
+                                                         request.union_cols,
+                                                         request.union_types);
+    } catch (std::exception const& e) {
+      throw std::runtime_error("[prepare_insert_delta_tasks] pinned entry '" + request.entry_name +
+                               "': " + e.what());
+    }
+    request.bundles.clear();
+    if (request.plan.empty()) { continue; }
+
+    // Stage 2 — bundle planning: close on the byte budget, the cudf int32
+    // varchar-chars threshold, or a row count that leaves the cumulative
+    // bundle rows off a byte boundary (staged validity runs need byte-aligned
+    // row offsets).
+    auto const& rgs = request.plan.row_groups;
+    std::vector<std::vector<std::size_t>> bundles_rgs;
+    {
+      std::vector<std::size_t> cur;
+      std::size_t cur_budget = 0;
+      std::size_t cur_rows   = 0;
+      std::vector<std::size_t> cur_varchar(request.union_cols.size(), 0);
+      auto flush = [&] {
+        if (!cur.empty()) { bundles_rgs.push_back(std::move(cur)); }
+        cur.clear();
+        cur_budget = 0;
+        cur_rows   = 0;
+        std::fill(cur_varchar.begin(), cur_varchar.end(), 0);
+      };
+      for (std::size_t i = 0; i < rgs.size(); ++i) {
+        bool exceed = !cur.empty() &&
+                      (cur_budget + rgs[i].decoded_bytes_budget > request.approximate_batch_size);
+        if (!exceed && !cur.empty()) {
+          for (std::size_t c = 0; c < cur_varchar.size(); ++c) {
+            if (cur_varchar[c] + rgs[i].varchar_bytes_per_col[c] >=
+                op::scan::kCudfInt32StringsThreshold) {
+              exceed = true;
+              break;
+            }
+          }
+        }
+        if (exceed) { flush(); }
+        cur.push_back(i);
+        cur_budget += rgs[i].decoded_bytes_budget;
+        cur_rows += rgs[i].row_count;
+        for (std::size_t c = 0; c < cur_varchar.size(); ++c) {
+          cur_varchar[c] += rgs[i].varchar_bytes_per_col[c];
+        }
+        if (cur_rows % 8 != 0) { flush(); }  // validity byte-alignment cut
+      }
+      flush();
+    }
+
+    // Stage 3 — per-bundle storage carve (staging slab + mask words) and the
+    // fill task. One task per bundle: its mask is single-writer, so the bit
+    // offsets need no word alignment.
+    for (auto& rg_list : bundles_rgs) {
+      insert_delta_bundle bundle;
+      bundle.rg_indices = std::move(rg_list);
+
+      std::size_t slab_bytes = 0;
+      for (auto rg_idx : bundle.rg_indices) {
+        bundle.rg_bit_offset.push_back(bundle.total_rows);
+        bundle.rg_slab_base.push_back(slab_bytes);
+        bundle.total_rows += rgs[rg_idx].row_count;
+        slab_bytes = align_up(slab_bytes + rgs[rg_idx].transient_staging_bytes, kCarveAlign);
+      }
+      auto const n_words    = (bundle.total_rows + 31) / 32;
+      auto const mask_off   = align_up(slab_bytes, kCarveAlign);
+      auto const total_size = mask_off + n_words * sizeof(std::uint32_t);
+
+      bundle.preferred_device = gpu_ids.empty() ? -1 : gpu_ids[next_device++ % gpu_ids.size()];
+
+      std::uint8_t* base = nullptr;
+      if (total_size <= block_size) {
+        // Reservation-first pinned storage on the bundle's GPU's NUMA node.
+        ccm::any_memory_space_in_tier_with_preference host_req(
+          ccm::Tier::HOST, numa_node_for_device(bundle.preferred_device, topology));
+        auto reservation = reservation_manager.request_reservation(host_req, block_size);
+        if (!reservation) {
+          throw std::runtime_error(
+            "[prepare_insert_delta_tasks] failed to reserve " + std::to_string(block_size) +
+            " bytes of pinned host staging for pinned entry '" + request.entry_name + "'");
+        }
+        auto* fsmr = reservation->get_memory_space()
+                       .get_memory_resource_as<ccm::fixed_size_host_memory_resource>();
+        if (fsmr == nullptr || fsmr->get_block_size() != block_size) {
+          throw std::runtime_error(
+            "[prepare_insert_delta_tasks] reserved host space is not a "
+            "fixed_size_host_memory_resource with the expected block size");
+        }
+        auto pinned         = std::make_shared<pinned_staging_bundle>();
+        pinned->reservation = std::move(reservation);
+        pinned->blocks      = fsmr->allocate_multiple_blocks(block_size, pinned->reservation.get());
+        base                = reinterpret_cast<std::uint8_t*>(pinned->blocks->at(0).data());
+        bundle.staging      = std::move(pinned);
+      } else {
+        // Staging blocks are not virtually contiguous, so an oversized bundle
+        // keeps plain pageable memory: cudaMemcpyAsync stages pageable bytes
+        // out before returning, so only the true-async-DMA benefit is lost.
+        SIRIUS_LOG_INFO(
+          "[prepare_insert_delta_tasks] pinned entry '{}': delta bundle needs {} bytes (> one "
+          "{}-byte staging block); using pageable host memory for it",
+          request.entry_name,
+          total_size,
+          block_size);
+        auto storage   = std::make_shared<std::vector<std::uint8_t>>(total_size);
+        base           = storage->data();
+        bundle.staging = std::move(storage);
+      }
+      bundle.slab_base = base;
+
+      auto* words = reinterpret_cast<std::uint32_t*>(base + mask_off);
+      std::fill_n(words, n_words, 0u);  // fill tasks set visible bits only
+      bundle.mask = mvcc_chunk_mask{
+        std::shared_ptr<std::uint32_t[]>(std::shared_ptr<void>(bundle.staging), words),
+        bundle.total_rows};
+
+      auto work          = std::make_unique<insert_delta_work>();
+      work->request      = &request;
+      work->bundle_index = request.bundles.size();
+      request.bundles.push_back(std::move(bundle));
+
+      workset.fill_tasks.push_back([work_ptr = work.get()] {
+        auto* req = work_ptr->request;
+        auto& b   = req->bundles[work_ptr->bundle_index];
+        std::span<std::uint32_t> words_span{b.mask.words.get(), (b.total_rows + 31) / 32};
+        std::size_t visible = 0;
+        for (std::size_t i = 0; i < b.rg_indices.size(); ++i) {
+          auto const& rg = req->plan.row_groups[b.rg_indices[i]];
+          visible += op::scan::count_visible_delta_rows(
+            rg, req->plan.transaction, words_span, b.rg_bit_offset[i]);
+          if (rg.transient_staging_bytes != 0) {
+            op::scan::copy_delta_row_group(
+              rg, *req->plan.buffer_manager, b.slab_base + b.rg_slab_base[i]);
+          }
+        }
+        work_ptr->visible = visible;
+      });
+      workset.works.push_back(std::move(work));
+    }
+  }
+  return workset;
+}
+
+void finalize_insert_delta_jobs(insert_delta_workset& workset)
+{
+  std::unordered_set<insert_delta_job_request*> touched;
+  for (auto& work : workset.works) {
+    auto& bundle = work->request->bundles[work->bundle_index];
+    if (work->visible == bundle.total_rows) {
+      // Every covered row visible: serve unmasked (no upload, no kernel).
+      bundle.mask = mvcc_chunk_mask{};
+    } else if (work->visible == 0) {
+      // Nothing visible (all inserted after this snapshot, or all deleted):
+      // tombstone; the sweep below drops it.
+      bundle.total_rows = 0;
+    }
+    touched.insert(work->request);
+  }
+  for (auto* request : touched) {
+    std::erase_if(request->bundles, [](insert_delta_bundle const& b) { return b.total_rows == 0; });
+  }
+}
+
+void run_insert_delta_jobs(std::span<insert_delta_job_request> requests,
+                           exec::scoped_dispatcher& dispatcher,
+                           cucascade::memory::memory_reservation_manager& reservation_manager,
+                           sirius::memory::topology_index const& topology,
+                           std::span<int const> gpu_ids)
+{
+  auto workset = prepare_insert_delta_tasks(requests, reservation_manager, topology, gpu_ids);
+  if (workset.fill_tasks.empty()) { return; }
+  SIRIUS_LOG_DEBUG("[run_insert_delta_jobs] {} bundle(s) across {} request(s)",
+                   workset.works.size(),
+                   requests.size());
+  fan_out_and_join(dispatcher, std::move(workset.fill_tasks), "insert-delta fill");
+  finalize_insert_delta_jobs(workset);
+}
+
+std::vector<insert_delta_split> cut_delta_splits_for_op(
+  insert_delta_job_request const& request,
+  std::span<op::scan::projected_column const> op_projected_cols,
+  std::shared_ptr<sirius::io::sirius_datasource> datasource,
+  duckdb::SingleFileBlockManager const* block_manager)
+{
+  // Resolve each operator column into the request's union.
+  std::vector<std::size_t> union_idx;
+  union_idx.reserve(op_projected_cols.size());
+  for (auto const& pc : op_projected_cols) {
+    if (pc.is_rowid) {
+      throw std::runtime_error(
+        "[cut_delta_splits_for_op] rowid projections are not served from the pin (declined at "
+        "plan time)");
+    }
+    auto const sidx = pc.storage_idx.GetPrimaryIndex();
+    auto const it   = std::find(request.union_cols.begin(), request.union_cols.end(), sidx);
+    if (it == request.union_cols.end()) {
+      throw std::runtime_error("[cut_delta_splits_for_op] operator column " + std::to_string(sidx) +
+                               " missing from pinned entry '" + request.entry_name +
+                               "''s delta capture");
+    }
+    union_idx.push_back(static_cast<std::size_t>(it - request.union_cols.begin()));
+  }
+
+  auto to_descriptor =
+    [](op::scan::insert_delta_segment const& s, std::uint8_t* rg_slab, bool& any_file_read) {
+      op::scan::duckdb_segment_descriptor d{};
+      d.segment_start     = s.segment_start;
+      d.segment_count     = s.segment_count;
+      d.compression       = s.compression;
+      d.max_string_length = s.max_string_length;
+      d.bytes_size        = s.bytes_size;
+      if (s.is_transient) {
+        d.block_id     = -1;
+        d.block_offset = 0;
+        d.host_ptr     = rg_slab + s.slab_offset;
+      } else {
+        d.block_id          = s.block_id;
+        d.block_offset      = s.block_offset;
+        d.additional_blocks = s.additional_blocks;
+        any_file_read       = true;
+      }
+      return d;
+    };
+
+  std::vector<insert_delta_split> out;
+  out.reserve(request.bundles.size());
+  for (auto const& bundle : request.bundles) {
+    auto info                     = std::make_unique<op::scan::duckdb_native_scan_info>();
+    info->datasource              = datasource;
+    info->block_manager           = block_manager;
+    info->carried_partition_stats = request.plan.partition_stats;
+    if (bundle.staging) { info->staging_keepalive.push_back(bundle.staging); }
+
+    bool any_file_read = false;
+    for (std::size_t bi = 0; bi < bundle.rg_indices.size(); ++bi) {
+      auto const& rgp = request.plan.row_groups[bundle.rg_indices[bi]];
+      auto* rg_slab =
+        bundle.slab_base == nullptr ? nullptr : bundle.slab_base + bundle.rg_slab_base[bi];
+
+      op::scan::duckdb_row_group_metadata md;
+      md.row_group_index      = rgp.row_group_index;
+      md.row_group_start      = rgp.row_group_start;
+      md.row_count            = rgp.row_count;
+      md.decoded_bytes_budget = rgp.decoded_bytes_budget;
+      md.varchar_bytes_per_col.reserve(union_idx.size());
+      md.columns.reserve(union_idx.size());
+      for (auto ui : union_idx) {
+        auto const& src = rgp.columns[ui];
+        md.varchar_bytes_per_col.push_back(rgp.varchar_bytes_per_col[ui]);
+        op::scan::duckdb_column_metadata cm;
+        cm.column_id = src.column_id;
+        cm.data_segments.reserve(src.data_segments.size());
+        for (auto const& s : src.data_segments) {
+          cm.data_segments.push_back(to_descriptor(s, rg_slab, any_file_read));
+        }
+        cm.validity_segments.reserve(src.validity_segments.size());
+        for (auto const& s : src.validity_segments) {
+          cm.validity_segments.push_back(to_descriptor(s, rg_slab, any_file_read));
+        }
+        md.columns.push_back(std::move(cm));
+      }
+      info->row_groups.push_back(std::move(md));
+    }
+    info->host_backed_only = !any_file_read;
+
+    out.push_back({std::move(info), bundle.mask, bundle.preferred_device});
+  }
+  return out;
+}
+
+}  // namespace sirius::scan_manager

--- a/src/scan_manager/load_balancing_scan_batch_coalescer.cpp
+++ b/src/scan_manager/load_balancing_scan_batch_coalescer.cpp
@@ -176,11 +176,37 @@ void load_balancing_scan_batch_coalescer::drain_cached_provider(databatch_provid
   try {
     while (!stop.stop_requested()) {
       auto next = provider.get_next_batch();
-      if (!next.data) { break; }
-      auto split            = std::make_unique<op::scan::scan_operator_input>(std::move(next.data));
-      split->mvcc_keep_mask = std::move(next.mvcc_keep_mask);
-      split->row_filter_pending = row_filter_pending;
-      connector.push_split(std::move(split));
+      if (next.data) {
+        auto split = std::make_unique<op::scan::scan_operator_input>(std::move(next.data));
+        split->mvcc_keep_mask     = std::move(next.mvcc_keep_mask);
+        split->row_filter_pending = row_filter_pending;
+        connector.push_split(std::move(split));
+        continue;
+      }
+      if (next.scan_info) {
+        // Insert-delta split: metadata-flavor, decoded through the existing
+        // file/host lanes. No row_filter_pending — scan_info splits fold
+        // filter costs into their own estimates. Mirror the walk path's
+        // fadvise + opportunistic prefetch for its file ranges (persistent
+        // delta segments; host-backed splits hint nothing).
+        auto split = std::make_unique<op::scan::scan_operator_input>(std::move(next.scan_info));
+        split->mvcc_keep_mask = std::move(next.mvcc_keep_mask);
+        std::optional<int> device;
+        if (next.preferred_device >= 0) {
+          device = next.preferred_device;
+          split->set_preferred_device_id(next.preferred_device);
+        }
+        auto fadvise_hints = split->get_fadvise_hints();
+        for (auto& hint : fadvise_hints) {
+          if (hint.datasource && !hint.ranges.empty()) {
+            hint.datasource->fadvise(hint.ranges, device);
+          }
+        }
+        split->prefetch(io::cache::prefetching_stage::opportunistic);
+        connector.push_split(std::move(split));
+        continue;
+      }
+      break;  // end-of-stream
     }
     connector.close();
   } catch (...) {

--- a/src/scan_manager/load_balancing_scan_batch_coalescer.cpp
+++ b/src/scan_manager/load_balancing_scan_batch_coalescer.cpp
@@ -184,11 +184,10 @@ void load_balancing_scan_batch_coalescer::drain_cached_provider(databatch_provid
         continue;
       }
       if (next.scan_info) {
-        // Insert-delta split: metadata-flavor, decoded through the existing
-        // file/host lanes. No row_filter_pending — scan_info splits fold
-        // filter costs into their own estimates. Mirror the walk path's
-        // fadvise + opportunistic prefetch for its file ranges (persistent
-        // delta segments; host-backed splits hint nothing).
+        // Insert-delta split. row_filter_pending stays false: scan_info
+        // splits fold filter costs into their own estimates. Same fadvise +
+        // opportunistic prefetch as the walk path; host-backed splits have
+        // no file ranges, so the hints no-op.
         auto split = std::make_unique<op::scan::scan_operator_input>(std::move(next.scan_info));
         split->mvcc_keep_mask = std::move(next.mvcc_keep_mask);
         std::optional<int> device;

--- a/src/scan_manager/mvcc_mask_job.cpp
+++ b/src/scan_manager/mvcc_mask_job.cpp
@@ -29,6 +29,7 @@
 #include <cucascade/memory/memory_space.hpp>
 #include <duckdb/transaction/transaction_data.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -238,7 +239,7 @@ mvcc_mask_workset prepare_mvcc_mask_tasks(
           c,
           bytes,
           block_size);
-        auto storage = std::make_shared<std::vector<std::uint32_t>>(n_words);
+        auto storage = std::make_shared<std::vector<std::uint32_t>>(n_words, 0u);
         plan_requests[p]->masks[c] =
           mvcc_chunk_mask{std::shared_ptr<std::uint32_t[]>(storage, storage->data()), rows};
         workset.works.push_back(make_work(p, c));
@@ -285,11 +286,13 @@ mvcc_mask_workset prepare_mvcc_mask_tasks(
     bundle->blocks      = fsmr->allocate_multiple_blocks(total_bytes, bundle->reservation.get());
 
     for (auto const& slot : layout.slots) {
-      auto* base = reinterpret_cast<std::uint8_t*>(bundle->blocks->at(slot.block).data());
+      auto* base  = reinterpret_cast<std::uint8_t*>(bundle->blocks->at(slot.block).data());
+      auto* words = reinterpret_cast<std::uint32_t*>(base + slot.offset);
+      // Zero-initialize the carve: the fill writer is bit-exact at word edges
+      // and must never read indeterminate memory through them.
+      std::fill_n(words, slot.bytes / sizeof(std::uint32_t), 0u);
       plan_requests[slot.plan]->masks[slot.chunk] =
-        mvcc_chunk_mask{std::shared_ptr<std::uint32_t[]>(
-                          bundle, reinterpret_cast<std::uint32_t*>(base + slot.offset)),
-                        slot.rows};
+        mvcc_chunk_mask{std::shared_ptr<std::uint32_t[]>(bundle, words), slot.rows};
       workset.works.push_back(make_work(slot.plan, slot.chunk));
     }
   }
@@ -303,8 +306,17 @@ mvcc_mask_workset prepare_mvcc_mask_tasks(
   auto const parse_chunk = op::scan::metadata_parse_chunk();
   for (auto& work_ptr : workset.works) {
     auto* work = work_ptr.get();
-    for (std::size_t begin = 0; begin < work->slices.size(); begin += parse_chunk) {
-      auto const count = std::min(parse_chunk, work->slices.size() - begin);
+    // Parallel range slicing requires every slice to start on a mask-word
+    // boundary (concurrent tasks must never share a word). Checkpoint-grown
+    // tables can have row groups of any size, so a chunk with unaligned
+    // offsets fills through ONE task — serial within the chunk, still
+    // parallel across chunks and entries.
+    bool const word_aligned = std::all_of(work->slices.begin(),
+                                          work->slices.end(),
+                                          [](auto const& s) { return s.chunk_offset % 32 == 0; });
+    auto const step         = word_aligned ? parse_chunk : work->slices.size();
+    for (std::size_t begin = 0; begin < work->slices.size(); begin += step) {
+      auto const count = std::min(step, work->slices.size() - begin);
       workset.fill_tasks.push_back([work, begin, count] {
         auto const& mask = (*work->masks)[work->chunk_index];
         std::span<std::uint32_t> words{mask.words.get(), (mask.row_count + 31) / 32};

--- a/src/scan_manager/mvcc_mask_job.cpp
+++ b/src/scan_manager/mvcc_mask_job.cpp
@@ -306,11 +306,10 @@ mvcc_mask_workset prepare_mvcc_mask_tasks(
   auto const parse_chunk = op::scan::metadata_parse_chunk();
   for (auto& work_ptr : workset.works) {
     auto* work = work_ptr.get();
-    // Parallel range slicing requires every slice to start on a mask-word
-    // boundary (concurrent tasks must never share a word). Checkpoint-grown
-    // tables can have row groups of any size, so a chunk with unaligned
-    // offsets fills through ONE task — serial within the chunk, still
-    // parallel across chunks and entries.
+    // Parallel slicing requires every slice to start on a mask-word boundary
+    // (concurrent tasks must never share a word). Checkpoint-grown tables can
+    // have row groups of any size, so a chunk with unaligned offsets fills
+    // through a single task; other chunks still fill in parallel.
     bool const word_aligned = std::all_of(work->slices.begin(),
                                           work->slices.end(),
                                           [](auto const& s) { return s.chunk_offset % 32 == 0; });

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -52,6 +52,10 @@
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 #include <cucascade/memory/memory_reservation_manager.hpp>
 #include <cucascade/memory/memory_space.hpp>
+#include <duckdb/main/attached_database.hpp>
+#include <duckdb/storage/data_table.hpp>
+#include <duckdb/storage/single_file_block_manager.hpp>
+#include <duckdb/storage/storage_manager.hpp>
 
 #include <algorithm>
 #include <cstdint>
@@ -71,11 +75,13 @@ struct cached_databatch_provider : public databatch_provider {
                             std::span<std::size_t const> selected_columns,
                             cached_scan_plan plan,
                             const telemetry::batch_telemetry_info& telemetry_info,
-                            mvcc_chunk_mask_set mvcc_masks)
+                            mvcc_chunk_mask_set mvcc_masks,
+                            std::vector<insert_delta_split> delta_splits)
     : _plan(std::move(plan)),
       _entry(entry),
       _telemetry_info(telemetry_info),
-      _mvcc_masks(std::move(mvcc_masks))
+      _mvcc_masks(std::move(mvcc_masks)),
+      _delta_splits(std::move(delta_splits))
   {
     auto const& entry_column_names = _entry.cache_info.column_names();
     std::ranges::for_each(selected_columns, [this, &entry_column_names](size_t idx) {
@@ -86,9 +92,20 @@ struct cached_databatch_provider : public databatch_provider {
 
   databatch_provider::batch get_next_batch() override
   {
-    // The atomic cursor walks survivor positions, each mapping to a chunk index.
+    // The atomic cursor walks survivor positions, each mapping to a chunk
+    // index; positions past the survivors yield the insert-delta splits
+    // (each consumed exactly once — the cursor hands out unique positions).
     auto const cursor = _index.fetch_add(1);
-    if (cursor >= _plan.survivor_chunk_indices.size()) { return {}; }
+    if (cursor >= _plan.survivor_chunk_indices.size()) {
+      auto const delta_idx = cursor - _plan.survivor_chunk_indices.size();
+      if (delta_idx >= _delta_splits.size()) { return {}; }
+      auto& delta = _delta_splits[delta_idx];
+      databatch_provider::batch out;
+      out.mvcc_keep_mask   = std::move(delta.mask);
+      out.scan_info        = std::move(delta.info);
+      out.preferred_device = delta.preferred_device;
+      return out;
+    }
     auto const index = _plan.survivor_chunk_indices[cursor];
     std::shared_ptr<cucascade::data_batch> data;
     if (_entry.tier == cucascade::memory::Tier::GPU) {
@@ -148,6 +165,9 @@ struct cached_databatch_provider : public databatch_provider {
   /// This provider's own copy of the entry's per-chunk keep-masks (empty for
   /// parquet pins); word storage is shared through each mask's owning pointer.
   mvcc_chunk_mask_set _mvcc_masks;
+  /// This operator's insert-delta splits, yielded after the resident chunks
+  /// (staging and mask words shared with sibling operators' cuts).
+  std::vector<insert_delta_split> _delta_splits;
   std::atomic<std::size_t> _index{0};
 };
 
@@ -397,6 +417,17 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
     run_mvcc_mask_jobs(
       _pending_mvcc_mask_jobs, *_dispatcher, _reservation_manager, *_topology_index);
   }
+  // Insert-delta jobs run in the same block-in-prepare window: staging and
+  // masks are finished plain buffers before serving starts. No-ops when no
+  // pinned table has rows beyond its prefix.
+  if (!_pending_insert_delta_jobs.empty()) {
+    std::vector<int> const delta_gpu_ids(gpu_ids.begin(), gpu_ids.end());
+    run_insert_delta_jobs(_pending_insert_delta_jobs,
+                          *_dispatcher,
+                          _reservation_manager,
+                          *_topology_index,
+                          delta_gpu_ids);
+  }
 
   // Provider handoff, deferred to behind the mask run so ownership is a
   // sequential handoff instead of sharing: each matched op's provider takes
@@ -406,6 +437,7 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
   // serving still starts with finished masks.
   for (auto& assignment : cached_assignments) {
     mvcc_chunk_mask_set masks;  // stays empty for parquet pins
+    std::vector<insert_delta_split> delta_splits;
     if (assignment.entry->mvcc != nullptr) {
       auto request = std::ranges::find_if(
         _pending_mvcc_mask_jobs,
@@ -417,15 +449,52 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
           assignment.entry_name + "'");
       }
       masks = request->masks;
+
+      auto delta_request = std::ranges::find_if(
+        _pending_insert_delta_jobs,
+        [&](insert_delta_job_request const& r) { return r.entry_name == assignment.entry_name; });
+      if (delta_request != _pending_insert_delta_jobs.end() && !delta_request->bundles.empty()) {
+        auto const* duckdb_info =
+          dynamic_cast<op::scan::duckdb_native_ingestible_table_info const*>(
+            &assignment.op->get_ingestible().table_info());
+        if (duckdb_info == nullptr) {
+          throw std::runtime_error(
+            "[sirius_scan_manager::prepare_for_query] delta bundles pending for a non-duckdb "
+            "scan of entry '" +
+            assignment.entry_name + "'");
+        }
+        auto io_ctx = ioctx_for_path(duckdb_info->db_path);
+        if (!io_ctx) {
+          throw std::runtime_error(
+            "[sirius_scan_manager::prepare_for_query] no io backend supports the pinned "
+            "database path '" +
+            duckdb_info->db_path + "'");
+        }
+        auto const* sf_bm = dynamic_cast<duckdb::SingleFileBlockManager const*>(
+          &duckdb_info->storage->GetAttached().GetStorageManager().GetBlockManager());
+        delta_splits = cut_delta_splits_for_op(*delta_request,
+                                               duckdb_info->projected_cols,
+                                               io_ctx->open_datasource(duckdb_info->db_path),
+                                               sf_bm);
+        SIRIUS_LOG_INFO(
+          "[sirius_scan_manager] operator '{}' serves {} insert-delta split(s) of pinned entry "
+          "'{}' ({} delta row(s))",
+          assignment.op->get_operator_id(),
+          delta_splits.size(),
+          assignment.entry_name,
+          delta_request->plan.delta_rows());
+      }
     }
     auto provider = make_provider_for_pinned_entry(*assignment.entry,
                                                    assignment.columns,
                                                    std::move(assignment.plan),
                                                    assignment.op->batch_telemetry(),
-                                                   std::move(masks));
+                                                   std::move(masks),
+                                                   std::move(delta_splits));
     _metadata_processor->use_cached_entries_for_pipeline(assignment.op, std::move(provider));
   }
   _pending_mvcc_mask_jobs.clear();
+  _pending_insert_delta_jobs.clear();
 
   start_metadata_processing();
 }
@@ -557,6 +626,7 @@ void sirius_scan_manager::reset()
   _scan_op_order.clear();
   _providers_by_op.clear();
   _pending_mvcc_mask_jobs.clear();
+  _pending_insert_delta_jobs.clear();
   _metadata_processor.reset();
   _dispatcher = std::make_unique<exec::scoped_dispatcher>(_thread_pool, _thread_pool.num_threads());
 }
@@ -1031,10 +1101,15 @@ std::unique_ptr<databatch_provider> make_provider_for_pinned_entry(
   std::span<std::size_t const> selected_columns,
   cached_scan_plan plan,
   const telemetry::batch_telemetry_info& telemetry_info,
-  mvcc_chunk_mask_set mvcc_masks)
+  mvcc_chunk_mask_set mvcc_masks,
+  std::vector<insert_delta_split> delta_splits)
 {
-  return std::make_unique<cached_databatch_provider>(
-    entry, selected_columns, std::move(plan), telemetry_info, std::move(mvcc_masks));
+  return std::make_unique<cached_databatch_provider>(entry,
+                                                     selected_columns,
+                                                     std::move(plan),
+                                                     telemetry_info,
+                                                     std::move(mvcc_masks),
+                                                     std::move(delta_splits));
 }
 
 cached_scan_plan build_cached_scan_plan(pinned_entry const& entry,
@@ -1213,6 +1288,36 @@ std::optional<sirius_scan_manager::cached_assignment> sirius_scan_manager::try_m
               : std::vector<cucascade::memory::memory_space*>(n_chunks, entry.memory_space);
           request.entry_name = pinned_name;
           _pending_mvcc_mask_jobs.push_back(std::move(request));
+        }
+
+        // One insert-delta job per entry per query, same dedup: queued
+        // unconditionally for mvcc entries (the job no-ops when the table has
+        // no rows beyond the pinned prefix — this closes the plan→prepare
+        // insert race now that the plan-time insert guard is gone). Later
+        // operators union their columns in so the staging covers every
+        // requester; per-operator splits are cut at handoff.
+        auto delta_request = std::ranges::find_if(
+          _pending_insert_delta_jobs,
+          [&](insert_delta_job_request const& r) { return r.entry_name == pinned_name; });
+        if (delta_request == _pending_insert_delta_jobs.end()) {
+          insert_delta_job_request request;
+          request.storage                = duckdb_info->storage;
+          request.context                = duckdb_info->context;
+          request.n_cache                = entry.mvcc->n_cache();
+          request.approximate_batch_size = duckdb_info->approximate_batch_size;
+          request.entry_name             = pinned_name;
+          _pending_insert_delta_jobs.push_back(std::move(request));
+          delta_request = std::prev(_pending_insert_delta_jobs.end());
+        }
+        for (std::size_t ci = 0; ci < duckdb_info->projected_cols.size(); ++ci) {
+          auto const& pc = duckdb_info->projected_cols[ci];
+          if (pc.is_rowid) { continue; }
+          auto const sidx = pc.storage_idx.GetPrimaryIndex();
+          if (std::find(delta_request->union_cols.begin(), delta_request->union_cols.end(), sidx) ==
+              delta_request->union_cols.end()) {
+            delta_request->union_cols.push_back(sidx);
+            delta_request->union_types.push_back(duckdb_info->projected_types[ci]);
+          }
         }
       }
 

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -93,8 +93,8 @@ struct cached_databatch_provider : public databatch_provider {
   databatch_provider::batch get_next_batch() override
   {
     // The atomic cursor walks survivor positions, each mapping to a chunk
-    // index; positions past the survivors yield the insert-delta splits
-    // (each consumed exactly once — the cursor hands out unique positions).
+    // index; positions past the survivors yield the insert-delta splits.
+    // The cursor hands out unique positions, so each split is moved out once.
     auto const cursor = _index.fetch_add(1);
     if (cursor >= _plan.survivor_chunk_indices.size()) {
       auto const delta_idx = cursor - _plan.survivor_chunk_indices.size();
@@ -417,9 +417,9 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
     run_mvcc_mask_jobs(
       _pending_mvcc_mask_jobs, *_dispatcher, _reservation_manager, *_topology_index);
   }
-  // Insert-delta jobs run in the same block-in-prepare window: staging and
-  // masks are finished plain buffers before serving starts. No-ops when no
-  // pinned table has rows beyond its prefix.
+  // Insert-delta jobs block in prepare for the same reason: staging and
+  // masks must be finished before serving starts. No-op when no pinned
+  // table has rows beyond its prefix.
   if (!_pending_insert_delta_jobs.empty()) {
     std::vector<int> const delta_gpu_ids(gpu_ids.begin(), gpu_ids.end());
     run_insert_delta_jobs(_pending_insert_delta_jobs,
@@ -1290,12 +1290,11 @@ std::optional<sirius_scan_manager::cached_assignment> sirius_scan_manager::try_m
           _pending_mvcc_mask_jobs.push_back(std::move(request));
         }
 
-        // One insert-delta job per entry per query, same dedup: queued
-        // unconditionally for mvcc entries (the job no-ops when the table has
-        // no rows beyond the pinned prefix — this closes the plan→prepare
-        // insert race now that the plan-time insert guard is gone). Later
-        // operators union their columns in so the staging covers every
-        // requester; per-operator splits are cut at handoff.
+        // One insert-delta job per entry per query, deduped like the mask
+        // jobs. The job no-ops when no rows are beyond the pinned prefix, so
+        // queuing unconditionally is safe. Later operators union their
+        // columns in so the staging covers every requester; per-operator
+        // splits are cut at handoff.
         auto delta_request = std::ranges::find_if(
           _pending_insert_delta_jobs,
           [&](insert_delta_job_request const& r) { return r.entry_name == pinned_name; });

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -942,8 +942,8 @@ std::unique_ptr<sirius::op::scan::duckdb_native_ingestible_table_info> build_duc
 
   // Update chains version values in place, invisibly to the DELETE
   // keep-masks — a pin would serve stale values to every query until the
-  // chains are folded away. Refuse loudly; CHECKPOINT folds the chains into
-  // the base data.
+  // chains are folded away. Refuse; CHECKPOINT folds the chains into the
+  // base data.
   {
     std::vector<duckdb::storage_t> pinned_storage_cols(keep.begin(), keep.end());
     if (sirius::op::scan::any_update_chains(
@@ -955,10 +955,9 @@ std::unique_ptr<sirius::op::scan::duckdb_native_ingestible_table_info> build_duc
     }
     // Committed-but-uncheckpointed appends live in transient (in-memory)
     // segments the pin's disk-image walk cannot stage; without this check the
-    // failure surfaces as a decoder byte-size error deep in the pin. Refuse
-    // with the fix spelled out. Bulk-flushed appends (optimistically written
-    // by >= row-group-sized inserts) are checkpoint-shaped and ride along in
-    // the base — outside the supported contract, not detectable here.
+    // failure would surface as a decoder byte-size error deep in the pin.
+    // Bulk-flushed appends (>= row-group-sized inserts) are checkpoint-shaped
+    // and not detectable here.
     if (sirius::op::scan::any_uncheckpointed_appends(storage, pinned_storage_cols)) {
       throw InvalidInputException(
         "pin_table: table '%s' has uncheckpointed rows; run CHECKPOINT before pinning", table_ref);

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -937,7 +937,21 @@ std::unique_ptr<sirius::op::scan::duckdb_native_ingestible_table_info> build_duc
   auto schema_names   = columns.GetColumnNames();  // logical order
   auto schema_types   = columns.GetColumnTypes();  // logical order
 
-  auto keep            = resolve_pin_kept_indices(schema_names, cols);
+  auto keep = resolve_pin_kept_indices(schema_names, cols);
+  // ARRAY pins are unsupported: appended ARRAY rows live in the array-validity
+  // and child segment trees, which the uncheckpointed-append guard below does
+  // not walk, so a committed post-pin append would slip past the pin contract
+  // and only fail later, deep in metadata decoding. Refuse up front, before
+  // checkpoint suppression or any other pin side effect.
+  for (auto col : keep) {
+    if (schema_types[col].id() == LogicalTypeId::ARRAY) {
+      throw InvalidInputException(
+        "pin_table: column '%s' of table '%s' has ARRAY type, which duckdb-native pins do not "
+        "support; pin a column subset without it (cols=[...])",
+        schema_names[col],
+        table_ref);
+    }
+  }
   auto const canonical = storage.GetAttached().GetStorageManager().GetDBPath();
 
   // Update chains version values in place, invisibly to the DELETE

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -942,8 +942,8 @@ std::unique_ptr<sirius::op::scan::duckdb_native_ingestible_table_info> build_duc
 
   // Update chains version values in place, invisibly to the DELETE
   // keep-masks — a pin would serve stale values to every query until the
-  // chains are folded away. Refuse loudly (the transient-rows case already
-  // fails the same way); CHECKPOINT folds the chains into the base data.
+  // chains are folded away. Refuse loudly; CHECKPOINT folds the chains into
+  // the base data.
   {
     std::vector<duckdb::storage_t> pinned_storage_cols(keep.begin(), keep.end());
     if (sirius::op::scan::any_update_chains(
@@ -952,6 +952,16 @@ std::unique_ptr<sirius::op::scan::duckdb_native_ingestible_table_info> build_duc
         "pin_table: table '%s' has in-memory update chains on a pinned column; run CHECKPOINT "
         "before pinning",
         table_ref);
+    }
+    // Committed-but-uncheckpointed appends live in transient (in-memory)
+    // segments the pin's disk-image walk cannot stage; without this check the
+    // failure surfaces as a decoder byte-size error deep in the pin. Refuse
+    // with the fix spelled out. Bulk-flushed appends (optimistically written
+    // by >= row-group-sized inserts) are checkpoint-shaped and ride along in
+    // the base — outside the supported contract, not detectable here.
+    if (sirius::op::scan::any_uncheckpointed_appends(storage, pinned_storage_cols)) {
+      throw InvalidInputException(
+        "pin_table: table '%s' has uncheckpointed rows; run CHECKPOINT before pinning", table_ref);
     }
   }
 

--- a/test/cpp/integration/test_gpu_execution_aggregate_nulls.cpp
+++ b/test/cpp/integration/test_gpu_execution_aggregate_nulls.cpp
@@ -22,10 +22,6 @@
 // runs it once on the GPU (asserting a real GPU execution with no fallback) and
 // once on DuckDB CPU, then compares the results. The comparator is order-
 // insensitive, which suits GROUP BY output.
-//
-// Cases tagged [!shouldfail] document confirmed GPU/CPU divergences (tracked in
-// their own issues); the tag reports them as expected failures so CI stays green
-// until the underlying bug is fixed.
 
 #include <catch.hpp>
 #include <duckdb.hpp>
@@ -74,8 +70,7 @@ TEST_CASE_METHOD(AggNullFixture,
                  "gpu_execution COUNT(*) vs COUNT(col) with NULLs",
                  "[integration][gpu_execution][aggregate][nulls]")
 {
-  // COUNT(*) counts rows; COUNT(col) skips NULLs. (COUNT over a wholly-NULL
-  // column is broken -- see the [!shouldfail] case below.)
+  // COUNT(*) counts rows; COUNT(col) skips NULLs.
   compare_gpu_vs_cpu("SELECT COUNT(*), COUNT(v), COUNT(d), COUNT(f) FROM agg_n");
 }
 
@@ -134,30 +129,22 @@ TEST_CASE_METHOD(AggNullFixture,
   compare_gpu_vs_cpu("SELECT AVG(v), AVG(d), AVG(f) FROM agg_n");
 }
 
-//===----------------------------------------------------------------------===//
-// Known GPU divergences (quarantined) -- each tracked in its own issue; remove
-// the [!shouldfail] tag when the underlying bug is fixed.
-//===----------------------------------------------------------------------===//
-
-// KNOWN GPU DIVERGENCE (issue #1218):
-// A column that is entirely NULL loses its validity mask in the GPU native scan
-// and is read as sentinel values (INT_MAX), so aggregates over it see fake data:
-// SUM(allnull) returns 8*INT_MAX and COUNT(allnull) returns the row count (8)
-// instead of NULL / 0. All-NULL *groups* of a normally-nullable column are fine;
-// only a wholly-NULL column is affected.
-// Split into ungrouped/grouped cases: Catch2 aborts a test case at the first
-// REQUIRE failure, so bundling them would leave the grouped query unexercised.
+// A wholly-NULL column checkpoints to CONSTANT all-null validity; the native
+// scan synthesizes its null mask, so aggregates must see NULLs rather than
+// sentinel values. Split into ungrouped/grouped cases: Catch2 aborts a test
+// case at the first REQUIRE failure, so bundling them would leave the grouped
+// query unexercised.
 TEST_CASE_METHOD(AggNullFixture,
-                 "gpu_execution ungrouped aggregates over a wholly-NULL column [known divergence]",
-                 "[integration][gpu_execution][aggregate][nulls][!shouldfail]")
+                 "gpu_execution ungrouped aggregates over a wholly-NULL column",
+                 "[integration][gpu_execution][aggregate][nulls]")
 {
   compare_gpu_vs_cpu(
     "SELECT SUM(allnull), AVG(allnull), MIN(allnull), MAX(allnull), COUNT(allnull) FROM agg_n");
 }
 
 TEST_CASE_METHOD(AggNullFixture,
-                 "gpu_execution grouped aggregates over a wholly-NULL column [known divergence]",
-                 "[integration][gpu_execution][aggregate][nulls][!shouldfail]")
+                 "gpu_execution grouped aggregates over a wholly-NULL column",
+                 "[integration][gpu_execution][aggregate][nulls]")
 {
   compare_gpu_vs_cpu("SELECT g, SUM(allnull), COUNT(allnull) FROM agg_n GROUP BY g");
 }

--- a/test/cpp/integration/test_gpu_execution_array.cpp
+++ b/test/cpp/integration/test_gpu_execution_array.cpp
@@ -58,6 +58,33 @@ TEST_CASE_METHOD(ArrayFixture,
 }
 
 TEST_CASE_METHOD(ArrayFixture,
+                 "gpu_execution array - fully NULL array column",
+                 "[integration][gpu_execution][array][scan]")
+{
+  // Whole-column NULLs checkpoint to CONSTANT all-null array-level validity;
+  // the decoder must synthesize the null mask rather than treat it as valid.
+  run_ok("CREATE TABLE arr_allnull (id INTEGER, a INTEGER[3]);");
+  run_ok("INSERT INTO arr_allnull SELECT range::INTEGER, NULL::INTEGER[3] FROM range(3000);");
+  run_ok("CHECKPOINT;");
+  compare_gpu_vs_cpu("SELECT id, a FROM arr_allnull ORDER BY id;");
+  compare_gpu_vs_cpu("SELECT count(*), count(a) FROM arr_allnull;");
+}
+
+TEST_CASE_METHOD(ArrayFixture,
+                 "gpu_execution array - arrays of all-NULL elements",
+                 "[integration][gpu_execution][array][scan]")
+{
+  // Present arrays whose elements are all NULL: CONSTANT all-null child
+  // validity, decoded via the synthesized zero-bit path.
+  run_ok("CREATE TABLE arr_nullelems (id INTEGER, a INTEGER[3]);");
+  run_ok(
+    "INSERT INTO arr_nullelems SELECT range::INTEGER, "
+    "[NULL, NULL, NULL]::INTEGER[3] FROM range(3000);");
+  run_ok("CHECKPOINT;");
+  compare_gpu_vs_cpu("SELECT id, a FROM arr_nullelems ORDER BY id;");
+}
+
+TEST_CASE_METHOD(ArrayFixture,
                  "gpu_execution array - element types DOUBLE and BIGINT",
                  "[integration][gpu_execution][array][scan]")
 {

--- a/test/cpp/integration/test_pin_table_mvcc_delete.cpp
+++ b/test/cpp/integration/test_pin_table_mvcc_delete.cpp
@@ -345,6 +345,28 @@ TEST_CASE_METHOD(PinMvccDeleteFixture,
 }
 
 TEST_CASE_METHOD(PinMvccDeleteFixture,
+                 "mvcc guards: pinning a table with uncheckpointed appends is refused until "
+                 "CHECKPOINT",
+                 "[integration][gpu_execution][pin_table_mvcc_delete]")
+{
+  run_ok(
+    "CREATE TABLE t AS SELECT range::INTEGER AS k, (range * 2)::INTEGER AS v "
+    "FROM range(50000);");
+  run_ok("CHECKPOINT;");
+  run_ok("INSERT INTO t VALUES (50000, 100000);");  // small append -> transient segments
+
+  auto refused = con->Query("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+  REQUIRE(refused);
+  REQUIRE(refused->HasError());
+  REQUIRE_THAT(refused->GetError(), Catch::Contains("uncheckpointed rows"));
+
+  run_ok("CHECKPOINT;");  // flushes the append into the persistent image
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+  compare_gpu_vs_cpu("SELECT count(*), sum(v) FROM t;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccDeleteFixture,
                  "mvcc delete: a masked pinned table joins an unpinned table correctly",
                  "[integration][gpu_execution][pin_table_mvcc_delete]")
 {

--- a/test/cpp/integration/test_pin_table_mvcc_delete.cpp
+++ b/test/cpp/integration/test_pin_table_mvcc_delete.cpp
@@ -269,7 +269,7 @@ TEST_CASE_METHOD(PinMvccDeleteFixture,
 }
 
 TEST_CASE_METHOD(PinMvccDeleteFixture,
-                 "mvcc guards: committed post-pin inserts decline to CPU with correct rows",
+                 "mvcc insert: committed post-pin inserts serve from the cache plus the delta",
                  "[integration][gpu_execution][pin_table_mvcc_delete]")
 {
   run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(50000);");
@@ -277,12 +277,12 @@ TEST_CASE_METHOD(PinMvccDeleteFixture,
   run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
 
   run_ok("INSERT INTO t SELECT range::INTEGER + 50000 FROM range(100);");
-  expect_fallback_matches_cpu(*this, "SELECT count(*), max(k) FROM t;");
+  compare_gpu_vs_cpu("SELECT count(*), max(k), sum(k) FROM t;");
   run_ok("CALL unpin_table('t');");
 }
 
 TEST_CASE_METHOD(PinMvccDeleteFixture,
-                 "mvcc guards: own-transaction inserts decline, rollback resumes GPU serving",
+                 "mvcc guards: own-transaction inserts decline; commit serves, rollback resumes",
                  "[integration][gpu_execution][pin_table_mvcc_delete]")
 {
   run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(50000);");
@@ -295,6 +295,11 @@ TEST_CASE_METHOD(PinMvccDeleteFixture,
   run_ok("ROLLBACK;");
 
   compare_gpu_vs_cpu("SELECT count(*), max(k) FROM t;");  // cache serving resumes
+
+  run_ok("BEGIN TRANSACTION;");
+  run_ok("INSERT INTO t VALUES (900001), (900002);");
+  run_ok("COMMIT;");
+  compare_gpu_vs_cpu("SELECT count(*), max(k) FROM t;");  // committed rows ride the delta
   run_ok("CALL unpin_table('t');");
 }
 

--- a/test/cpp/integration/test_pin_table_mvcc_insert.cpp
+++ b/test/cpp/integration/test_pin_table_mvcc_insert.cpp
@@ -426,6 +426,29 @@ TEST_CASE_METHOD(PinMvccInsertFixture,
 }
 
 TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc guards: pinning an ARRAY column is refused",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok(
+    "CREATE TABLE t AS SELECT range::INTEGER AS k, "
+    "CAST([range::INTEGER, 1, 2] AS INTEGER[3]) AS a FROM range(1000);");
+  run_ok("CHECKPOINT;");
+
+  // Appended ARRAY rows hide in the array-validity/child segment trees the
+  // uncheckpointed-append guard cannot see, so ARRAY pins are refused outright
+  // — checkpoint-clean ones included.
+  auto refused = con->Query("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+  REQUIRE(refused);
+  REQUIRE(refused->HasError());
+  REQUIRE_THAT(refused->GetError(), Catch::Contains("ARRAY"));
+
+  // A subset pin that leaves the ARRAY column out still works.
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu', cols=['k']);");
+  compare_gpu_vs_cpu("SELECT count(*), sum(k) FROM t;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
                  "mvcc guards: ARRAY projections decline while a delta exists",
                  "[integration][gpu_execution][pin_table_mvcc_insert]")
 {
@@ -433,14 +456,15 @@ TEST_CASE_METHOD(PinMvccInsertFixture,
     "CREATE TABLE t AS SELECT range::INTEGER AS k, "
     "CAST([range::INTEGER, 1, 2] AS INTEGER[3]) AS a FROM range(20000);");
   run_ok("CHECKPOINT;");
-  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+  // ARRAY columns cannot be pinned, so pin the scalar subset.
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu', cols=['k']);");
 
   run_ok("INSERT INTO t VALUES (20000, CAST([9, 9, 9] AS INTEGER[3]));");
 
-  // Projecting the ARRAY column with delta rows present declines; the fallback
-  // must still return correct rows.
+  // Projecting the unpinned ARRAY column declines; the fallback must still
+  // return correct rows.
   expect_fallback_matches_cpu(*this, "SELECT k, a FROM t WHERE k >= 19998 ORDER BY k;");
-  // Projecting only the scalar column serves from cache + delta as usual.
+  // Projecting only the pinned scalar column serves from cache + delta.
   compare_gpu_vs_cpu("SELECT count(*), sum(k) FROM t;");
   run_ok("CALL unpin_table('t');");
 }

--- a/test/cpp/integration/test_pin_table_mvcc_insert.cpp
+++ b/test/cpp/integration/test_pin_table_mvcc_insert.cpp
@@ -177,6 +177,105 @@ TEST_CASE_METHOD(PinMvccInsertFixture,
 }
 
 TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: bulk constant inserts decode from blockless CONSTANT segments",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k, range::INTEGER AS v FROM range(20000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  // A full-row-group commit of a projected literal: MergeStorage flushes the
+  // constant column as blockless persistent CONSTANT segments, decoded from
+  // stats rather than the file.
+  run_ok("INSERT INTO t SELECT range::INTEGER + 20000, 7 FROM range(130000);");
+
+  compare_gpu_vs_cpu("SELECT count(*), sum(k), sum(v), min(v), max(v) FROM t;");
+  compare_gpu_vs_cpu("SELECT k, v FROM t WHERE k >= 149995 ORDER BY k;");
+  // Constant-column-only projection: the persistent delta splits become
+  // blockless-only (no file reads, no datasource) and must still serve.
+  compare_gpu_vs_cpu("SELECT sum(v), min(v), max(v) FROM t;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: appends into an indexed tail row group keep per-segment constants",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  // With a PRIMARY KEY, DuckDB appends into the existing tail row group
+  // instead of opening a fresh one, so the bulk-flushed CONSTANT segment's
+  // row group later gains rows with a different value: the row-group-level
+  // stats drift (min drops to 7) while the segment's own constant stays 9.
+  run_ok("CREATE TABLE t (k INTEGER PRIMARY KEY, v INTEGER);");
+  run_ok("INSERT INTO t SELECT range::INTEGER, range::INTEGER FROM range(20000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  run_ok("INSERT INTO t SELECT range::INTEGER + 20000, 9 FROM range(130000);");
+  run_ok("INSERT INTO t VALUES (150001, 7);");
+
+  compare_gpu_vs_cpu("SELECT count(*), sum(v), min(v), max(v) FROM t;");
+  compare_gpu_vs_cpu("SELECT k, v FROM t WHERE k >= 149998 ORDER BY k;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: bulk all-NULL inserts keep their NULLs",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  // The base carries an all-NULL column too, so the cached read exercises the
+  // same CONSTANT-validity decode as the delta.
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k, NULL::INTEGER AS v FROM range(20000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  // Bulk all-NULL column: the flushed data segments are CONSTANT sentinels and
+  // the NULL-ness lives only in the CONSTANT validity segments' stats.
+  run_ok("INSERT INTO t SELECT range::INTEGER + 20000, NULL::INTEGER FROM range(130000);");
+
+  compare_gpu_vs_cpu("SELECT count(*), count(v), sum(k) FROM t;");
+  compare_gpu_vs_cpu("SELECT k, v FROM t WHERE k >= 149995 ORDER BY k;");
+  // All-NULL-column-only projection: blockless-only splits, no datasource.
+  compare_gpu_vs_cpu("SELECT count(v) FROM t;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: bulk all-NULL varchar keeps its NULLs",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  // All-NULL VARCHAR flushes dictionary data with CONSTANT all-null validity
+  // (varchar data itself never compresses CONSTANT), exercising the varchar
+  // decoder's synthesized-validity path through both the base and the delta.
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k, NULL::VARCHAR AS s FROM range(20000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  run_ok("INSERT INTO t SELECT range::INTEGER + 20000, NULL::VARCHAR FROM range(130000);");
+
+  compare_gpu_vs_cpu("SELECT count(*), count(s) FROM t;");
+  compare_gpu_vs_cpu("SELECT k, s FROM t WHERE k >= 149995 ORDER BY k;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: an unaligned all-NULL row group does not bleed nulls forward",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  // 10001 all-NULL rows end mid-byte. When the next row group's valid rows
+  // decode in the same coalesced split, the synthesized validity's trailing
+  // padding bits must not null the following rows.
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k, NULL::INTEGER AS v FROM range(10001);");
+  run_ok("CHECKPOINT;");
+  run_ok("INSERT INTO t SELECT range::INTEGER + 10001, range::INTEGER FROM range(5000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  compare_gpu_vs_cpu("SELECT count(*), count(v), sum(v) FROM t;");
+  compare_gpu_vs_cpu("SELECT k, v FROM t WHERE k BETWEEN 9998 AND 10008 ORDER BY k;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
                  "mvcc insert: varchar and NULLs decode through the delta",
                  "[integration][gpu_execution][pin_table_mvcc_insert]")
 {

--- a/test/cpp/integration/test_pin_table_mvcc_insert.cpp
+++ b/test/cpp/integration/test_pin_table_mvcc_insert.cpp
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// MVCC insert end-to-end: a duckdb-pinned table keeps serving GPU queries
+// while INSERTs land — the prepare-time insert delta stages rows beyond the
+// pinned prefix (transient small appends AND bulk MergeStorage row groups)
+// and masks them to each query's snapshot, so every result equals DuckDB CPU
+// at that snapshot. States the delta cannot represent — transaction-local
+// appends, ARRAY projections, big-string deltas, rowid-only scans — decline
+// at plan time into a clean transparent CPU fallback with correct results.
+// The basic served/declined flips live beside the delete matrix in
+// test_pin_table_mvcc_delete.cpp; this file covers the wider insert matrix.
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <utils/gpu_execution_fixture.hpp>
+#include <utils/sirius_test_env.hpp>
+#include <utils/transparent_execution_test_utils.hpp>
+
+#include <memory>
+#include <string>
+
+using PinMvccInsertFixture = sirius::test::GpuExecutionFixture;
+
+namespace {
+
+/// Run @p query under gpu_execution=true expecting the plan-time guard to
+/// decline (transparent CPU fallback: {0 rebinds, 1 fallback, 0 executions})
+/// and the results to match a plain CPU run.
+void expect_fallback_matches_cpu(sirius::test::GpuExecutionFixture& fx, const std::string& query)
+{
+  fx.con->Query("SET gpu_execution = true;");
+  auto before     = sirius::test::get_transparent_execution_stats(*fx.con);
+  auto gpu_result = fx.con->Query(query);
+  REQUIRE(gpu_result);
+  if (gpu_result->HasError()) { UNSCOPED_INFO("guarded query error: " << gpu_result->GetError()); }
+  REQUIRE_FALSE(gpu_result->HasError());
+  auto after = sirius::test::get_transparent_execution_stats(*fx.con);
+  sirius::test::require_transparent_execution_delta(before, after, 0, 1, 0);
+
+  fx.con->Query("SET gpu_execution = false;");
+  auto cpu_result = fx.con->Query(query);
+  fx.con->Query("SET gpu_execution = true;");
+  REQUIRE(cpu_result);
+  REQUIRE_FALSE(cpu_result->HasError());
+
+  auto gpu_rows = sirius::test::GpuExecutionFixture::collect_rows(
+    gpu_result->Cast<duckdb::MaterializedQueryResult>());
+  auto cpu_rows = sirius::test::GpuExecutionFixture::collect_rows(
+    cpu_result->Cast<duckdb::MaterializedQueryResult>());
+  REQUIRE(gpu_rows == cpu_rows);
+}
+
+/// A second connection to the same database instance (concurrent-writer /
+/// older-snapshot roles).
+std::unique_ptr<duckdb::Connection> second_connection(sirius::test::GpuExecutionFixture& fx)
+{
+  if (sirius::test::g_integration_env && sirius::test::g_integration_env->is_active()) {
+    return std::make_unique<duckdb::Connection>(sirius::test::g_integration_env->make_connection());
+  }
+  REQUIRE(fx.db);
+  return std::make_unique<duckdb::Connection>(*fx.db);
+}
+
+void run_ok_on(duckdb::Connection& con, const std::string& sql)
+{
+  auto result = con.Query(sql);
+  REQUIRE(result);
+  if (result->HasError()) { UNSCOPED_INFO("query error: " << result->GetError()); }
+  REQUIRE_FALSE(result->HasError());
+}
+
+/// GPU-vs-CPU comparison on an arbitrary connection (no counter assertions —
+/// used where the interesting connection is not the fixture's own).
+void compare_gpu_vs_cpu_on(duckdb::Connection& con, const std::string& query)
+{
+  run_ok_on(con, "SET gpu_execution = true;");
+  auto gpu_result = con.Query(query);
+  REQUIRE(gpu_result);
+  if (gpu_result->HasError()) { UNSCOPED_INFO("gpu query error: " << gpu_result->GetError()); }
+  REQUIRE_FALSE(gpu_result->HasError());
+  run_ok_on(con, "SET gpu_execution = false;");
+  auto cpu_result = con.Query(query);
+  run_ok_on(con, "SET gpu_execution = true;");
+  REQUIRE(cpu_result);
+  REQUIRE_FALSE(cpu_result->HasError());
+  auto gpu_rows = sirius::test::GpuExecutionFixture::collect_rows(
+    gpu_result->Cast<duckdb::MaterializedQueryResult>());
+  auto cpu_rows = sirius::test::GpuExecutionFixture::collect_rows(
+    cpu_result->Cast<duckdb::MaterializedQueryResult>());
+  REQUIRE(gpu_rows == cpu_rows);
+}
+
+}  // namespace
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: rows inserted then deleted before the query never appear",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(50000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  run_ok("INSERT INTO t SELECT range::INTEGER + 50000 FROM range(200);");
+  run_ok("DELETE FROM t WHERE k >= 50100;");  // half the delta, tombstoned pre-query
+
+  compare_gpu_vs_cpu("SELECT count(*), max(k), sum(k) FROM t;");
+  compare_gpu_vs_cpu("SELECT k FROM t WHERE k >= 49990 ORDER BY k;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: an older snapshot does not see newer committed inserts",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(50000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  auto reader = second_connection(*this);
+  run_ok_on(*reader, "USE " + attach_alias + ";");
+  run_ok_on(*reader, "BEGIN TRANSACTION;");
+  run_ok_on(*reader, "SELECT count(*) FROM t;");  // pin the snapshot (lazy txn spawn)
+
+  run_ok("INSERT INTO t SELECT range::INTEGER + 50000 FROM range(500);");
+
+  // The old snapshot: delta rows exist physically but are invisible to it.
+  compare_gpu_vs_cpu_on(*reader, "SELECT count(*), max(k) FROM t;");
+  run_ok_on(*reader, "ROLLBACK;");
+
+  // A fresh snapshot sees them.
+  compare_gpu_vs_cpu("SELECT count(*), max(k) FROM t;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: base deletes and post-pin inserts combine in one query",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok(
+    "CREATE TABLE t AS SELECT range::INTEGER AS k, (range * 2)::INTEGER AS v "
+    "FROM range(200000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  run_ok("DELETE FROM t WHERE k % 1000 = 7;");  // masks over the cached base
+  run_ok("INSERT INTO t SELECT range::INTEGER + 200000, 0 FROM range(3000);");
+  run_ok("DELETE FROM t WHERE k >= 202000;");  // and over the delta
+
+  compare_gpu_vs_cpu("SELECT count(*), sum(k), sum(v) FROM t;");
+  compare_gpu_vs_cpu("SELECT k, v FROM t WHERE k > 199990 ORDER BY k;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: bulk inserts ride the persistent MergeStorage lane",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(50000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  // >= one row group in a single commit: optimistically flushed by
+  // MergeStorage as compressed PERSISTENT row groups — the delta's file lane.
+  run_ok("INSERT INTO t SELECT range::INTEGER + 50000 FROM range(130000);");
+  // Plus a small transient append on top: both lanes in one delta.
+  run_ok("INSERT INTO t VALUES (180000);");
+
+  compare_gpu_vs_cpu("SELECT count(*), max(k), sum(k) FROM t;");
+  compare_gpu_vs_cpu("SELECT count(*) FROM t WHERE k >= 100000;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: varchar and NULLs decode through the delta",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok(
+    "CREATE TABLE t AS SELECT range::INTEGER AS k, 'base_'||range AS s, "
+    "CASE WHEN range % 3 = 0 THEN NULL ELSE range::INTEGER END AS opt "
+    "FROM range(50000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  run_ok(
+    "INSERT INTO t SELECT range::INTEGER + 50000, "
+    "CASE WHEN range % 97 = 0 THEN '' ELSE 'delta_'||range END, "
+    "CASE WHEN range % 5 = 0 THEN NULL ELSE range::INTEGER END "
+    "FROM range(2000);");
+
+  compare_gpu_vs_cpu("SELECT count(*), count(opt), min(s), max(s) FROM t;");
+  compare_gpu_vs_cpu("SELECT k, s, opt FROM t WHERE k >= 49995 ORDER BY k;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: host-tier pins serve the delta too",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(80000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='host');");
+
+  run_ok("INSERT INTO t SELECT range::INTEGER + 80000 FROM range(1000);");
+  run_ok("DELETE FROM t WHERE k IN (5, 80003);");
+
+  compare_gpu_vs_cpu("SELECT count(*), sum(k) FROM t;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: a self-join shares one delta capture across both sides",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok(
+    "CREATE TABLE t AS SELECT range::INTEGER AS k, (range % 100)::INTEGER AS g "
+    "FROM range(60000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  run_ok("INSERT INTO t SELECT range::INTEGER + 60000, 7 FROM range(300);");
+
+  compare_gpu_vs_cpu(
+    "SELECT a.g, count(*) FROM t a JOIN t b ON a.k = b.k GROUP BY a.g ORDER BY a.g;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: joins with unpinned tables see the delta rows",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(60000);");
+  run_ok(
+    "CREATE TABLE u AS SELECT range::INTEGER AS k, (range % 10)::INTEGER AS g "
+    "FROM range(70000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  run_ok("INSERT INTO t SELECT range::INTEGER + 60000 FROM range(5000);");
+
+  compare_gpu_vs_cpu("SELECT u.g, count(*) FROM t JOIN u ON t.k = u.k GROUP BY u.g ORDER BY u.g;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: a delta growing across queries stays snapshot-exact",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(40000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  run_ok("INSERT INTO t VALUES (40000);");
+  compare_gpu_vs_cpu("SELECT count(*), max(k) FROM t;");
+
+  run_ok("INSERT INTO t SELECT range::INTEGER + 40001 FROM range(999);");
+  compare_gpu_vs_cpu("SELECT count(*), max(k) FROM t;");
+
+  run_ok("DELETE FROM t WHERE k = 40500;");
+  compare_gpu_vs_cpu("SELECT count(*), sum(k) FROM t;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: a tiny pin serves a delta larger than its base",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(10);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  run_ok("INSERT INTO t SELECT range::INTEGER + 10 FROM range(5000);");
+  compare_gpu_vs_cpu("SELECT count(*), sum(k) FROM t;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc insert: zone-map-pruned base still serves matching delta rows",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(100000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  run_ok("INSERT INTO t VALUES (1000000), (1000001);");
+
+  // The pushed filter prunes every cached chunk by zone map; only the delta
+  // rows match — they must still arrive.
+  compare_gpu_vs_cpu("SELECT count(*), sum(k) FROM t WHERE k >= 500000;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc guards: big-string deltas decline at plan time",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k, 'short_'||range AS s FROM range(20000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  // The overflow-length string lives only in the delta; the table-level stat
+  // (merged on append) makes the plan-time varchar probe decline the scan.
+  // The projection must include the string column — without it the scan
+  // legitimately serves from cache + delta.
+  run_ok("INSERT INTO t VALUES (20000, repeat('x', 5000));");
+  expect_fallback_matches_cpu(*this, "SELECT count(*), max(k), max(strlen(s)) FROM t;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc guards: rowid-only scans keep declining with a delta present",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok("CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(30000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  run_ok("INSERT INTO t VALUES (30000);");
+  // Bare count(*) binds only rowid — never cached, so the column-mismatch
+  // guard declines it; the CPU fallback must still count the delta row.
+  expect_fallback_matches_cpu(*this, "SELECT count(*) FROM t;");
+  run_ok("CALL unpin_table('t');");
+}
+
+TEST_CASE_METHOD(PinMvccInsertFixture,
+                 "mvcc guards: ARRAY projections decline while a delta exists",
+                 "[integration][gpu_execution][pin_table_mvcc_insert]")
+{
+  run_ok(
+    "CREATE TABLE t AS SELECT range::INTEGER AS k, "
+    "CAST([range::INTEGER, 1, 2] AS INTEGER[3]) AS a FROM range(20000);");
+  run_ok("CHECKPOINT;");
+  run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
+
+  run_ok("INSERT INTO t VALUES (20000, CAST([9, 9, 9] AS INTEGER[3]));");
+
+  // Projecting the ARRAY column with rows beyond the prefix declines (v1
+  // scope) — correct rows via the fallback.
+  expect_fallback_matches_cpu(*this, "SELECT k, a FROM t WHERE k >= 19998 ORDER BY k;");
+  // Projecting only the scalar column serves cache + delta as usual.
+  compare_gpu_vs_cpu("SELECT count(*), sum(k) FROM t;");
+  run_ok("CALL unpin_table('t');");
+}

--- a/test/cpp/integration/test_pin_table_mvcc_insert.cpp
+++ b/test/cpp/integration/test_pin_table_mvcc_insert.cpp
@@ -14,15 +14,10 @@
  * limitations under the License.
  */
 
-// MVCC insert end-to-end: a duckdb-pinned table keeps serving GPU queries
-// while INSERTs land — the prepare-time insert delta stages rows beyond the
-// pinned prefix (transient small appends AND bulk MergeStorage row groups)
-// and masks them to each query's snapshot, so every result equals DuckDB CPU
-// at that snapshot. States the delta cannot represent — transaction-local
-// appends, ARRAY projections, big-string deltas, rowid-only scans — decline
-// at plan time into a clean transparent CPU fallback with correct results.
-// The basic served/declined flips live beside the delete matrix in
-// test_pin_table_mvcc_delete.cpp; this file covers the wider insert matrix.
+// End-to-end MVCC INSERT tests for duckdb-pinned tables: post-pin rows serve
+// through the insert delta with snapshot-correct results, and shapes the delta
+// cannot represent decline into the transparent CPU fallback. The basic
+// served/declined flips live in test_pin_table_mvcc_delete.cpp.
 
 #include <catch.hpp>
 #include <duckdb.hpp>
@@ -37,9 +32,8 @@ using PinMvccInsertFixture = sirius::test::GpuExecutionFixture;
 
 namespace {
 
-/// Run @p query under gpu_execution=true expecting the plan-time guard to
-/// decline (transparent CPU fallback: {0 rebinds, 1 fallback, 0 executions})
-/// and the results to match a plain CPU run.
+/// Runs @p query expecting a plan-time decline into the transparent CPU
+/// fallback, then checks the results against a plain CPU run.
 void expect_fallback_matches_cpu(sirius::test::GpuExecutionFixture& fx, const std::string& query)
 {
   fx.con->Query("SET gpu_execution = true;");
@@ -64,8 +58,7 @@ void expect_fallback_matches_cpu(sirius::test::GpuExecutionFixture& fx, const st
   REQUIRE(gpu_rows == cpu_rows);
 }
 
-/// A second connection to the same database instance (concurrent-writer /
-/// older-snapshot roles).
+/// Opens a second connection to the same database (concurrent writer / older snapshot).
 std::unique_ptr<duckdb::Connection> second_connection(sirius::test::GpuExecutionFixture& fx)
 {
   if (sirius::test::g_integration_env && sirius::test::g_integration_env->is_active()) {
@@ -83,8 +76,7 @@ void run_ok_on(duckdb::Connection& con, const std::string& sql)
   REQUIRE_FALSE(result->HasError());
 }
 
-/// GPU-vs-CPU comparison on an arbitrary connection (no counter assertions —
-/// used where the interesting connection is not the fixture's own).
+/// Compares GPU vs CPU results on the given connection (no counter assertions).
 void compare_gpu_vs_cpu_on(duckdb::Connection& con, const std::string& query)
 {
   run_ok_on(con, "SET gpu_execution = true;");
@@ -173,10 +165,10 @@ TEST_CASE_METHOD(PinMvccInsertFixture,
   run_ok("CHECKPOINT;");
   run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
 
-  // >= one row group in a single commit: optimistically flushed by
-  // MergeStorage as compressed PERSISTENT row groups — the delta's file lane.
+  // A single commit of at least one full row group: MergeStorage flushes it as
+  // persistent row groups, the delta's file lane.
   run_ok("INSERT INTO t SELECT range::INTEGER + 50000 FROM range(130000);");
-  // Plus a small transient append on top: both lanes in one delta.
+  // Plus a small transient append: both lanes in one delta.
   run_ok("INSERT INTO t VALUES (180000);");
 
   compare_gpu_vs_cpu("SELECT count(*), max(k), sum(k) FROM t;");
@@ -297,8 +289,8 @@ TEST_CASE_METHOD(PinMvccInsertFixture,
 
   run_ok("INSERT INTO t VALUES (1000000), (1000001);");
 
-  // The pushed filter prunes every cached chunk by zone map; only the delta
-  // rows match — they must still arrive.
+  // The pushed filter zone-map-prunes every cached chunk; only the delta rows
+  // match and must still arrive.
   compare_gpu_vs_cpu("SELECT count(*), sum(k) FROM t WHERE k >= 500000;");
   run_ok("CALL unpin_table('t');");
 }
@@ -311,10 +303,9 @@ TEST_CASE_METHOD(PinMvccInsertFixture,
   run_ok("CHECKPOINT;");
   run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
 
-  // The overflow-length string lives only in the delta; the table-level stat
-  // (merged on append) makes the plan-time varchar probe decline the scan.
-  // The projection must include the string column — without it the scan
-  // legitimately serves from cache + delta.
+  // The overflow string lives only in the delta, but the table-level stat
+  // (merged on append) makes the plan-time varchar probe decline. The query
+  // must project the string column; without it the scan legitimately serves.
   run_ok("INSERT INTO t VALUES (20000, repeat('x', 5000));");
   expect_fallback_matches_cpu(*this, "SELECT count(*), max(k), max(strlen(s)) FROM t;");
   run_ok("CALL unpin_table('t');");
@@ -329,8 +320,8 @@ TEST_CASE_METHOD(PinMvccInsertFixture,
   run_ok("CALL pin_table(format='duckdb', name='t', tier='gpu');");
 
   run_ok("INSERT INTO t VALUES (30000);");
-  // Bare count(*) binds only rowid — never cached, so the column-mismatch
-  // guard declines it; the CPU fallback must still count the delta row.
+  // Bare count(*) binds only rowid, which is never cached, so the
+  // column-mismatch guard declines; the fallback must still count the delta row.
   expect_fallback_matches_cpu(*this, "SELECT count(*) FROM t;");
   run_ok("CALL unpin_table('t');");
 }
@@ -347,10 +338,10 @@ TEST_CASE_METHOD(PinMvccInsertFixture,
 
   run_ok("INSERT INTO t VALUES (20000, CAST([9, 9, 9] AS INTEGER[3]));");
 
-  // Projecting the ARRAY column with rows beyond the prefix declines (v1
-  // scope) — correct rows via the fallback.
+  // Projecting the ARRAY column with delta rows present declines; the fallback
+  // must still return correct rows.
   expect_fallback_matches_cpu(*this, "SELECT k, a FROM t WHERE k >= 19998 ORDER BY k;");
-  // Projecting only the scalar column serves cache + delta as usual.
+  // Projecting only the scalar column serves from cache + delta as usual.
   compare_gpu_vs_cpu("SELECT count(*), sum(k) FROM t;");
   run_ok("CALL unpin_table('t');");
 }

--- a/test/cpp/scan/test_duckdb_insert_delta.cpp
+++ b/test/cpp/scan/test_duckdb_insert_delta.cpp
@@ -135,7 +135,6 @@ TEST_CASE("insert delta: capture boundary math and transient segment lanes",
   REQUIRE(plan.n_total == kBase + kDelta);
   REQUIRE(plan.delta_rows() == kDelta);
   REQUIRE(plan.buffer_manager != nullptr);
-  REQUIRE(plan.partition_stats != nullptr);
   REQUIRE(plan.transaction.transaction_id != 0);
 
   REQUIRE(plan.row_groups.size() == 1);
@@ -320,6 +319,80 @@ TEST_CASE("insert delta: bulk-flushed appends keep persistent block references",
   }
   REQUIRE(saw_persistent);
   REQUIRE(saw_transient);
+  exec_ok(*env.con, "ROLLBACK");
+}
+
+TEST_CASE("insert delta: bulk constant inserts capture blockless CONSTANT segments",
+          "[duckdb_insert_delta][scan]")
+{
+  delta_test_db env;
+  exec_ok(*env.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(10000)");
+  exec_ok(*env.con, "CHECKPOINT");
+  // A full-row-group commit of a projected literal: every flushed segment's
+  // stats are constant, so DuckDB rewrites them as blockless CONSTANT
+  // segments (no backing block to read metadata from).
+  exec_ok(*env.con, "INSERT INTO t SELECT 7 FROM range(130000)");
+
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*env.con, "t");
+  std::vector<duckdb::storage_t> const cols{0};
+  std::vector<sirius::logical_type> types{sirius::logical_type::make(sirius::type_id::INTEGER)};
+  auto plan = capture_insert_delta_plan(storage, *env.con->context, 10000, cols, types);
+
+  REQUIRE(plan.n_total == 140000);
+  bool saw_constant = false;
+  for (auto const& rg : plan.row_groups) {
+    std::size_t covered = 0;
+    for (auto const& s : rg.columns[0].data_segments) {
+      covered += s.segment_count;
+      if (s.compression != duckdb::CompressionType::COMPRESSION_CONSTANT) { continue; }
+      saw_constant = true;
+      REQUIRE_FALSE(s.is_transient);
+      REQUIRE(s.block_id < 0);
+      REQUIRE(s.bytes_size == 0);
+      REQUIRE(s.additional_blocks.empty());
+      // The constant value decodes from the capture-time stats snapshot.
+      REQUIRE(s.segment_stats != nullptr);
+    }
+    REQUIRE(covered == rg.row_count);  // CONSTANT segments still tile the slice
+  }
+  REQUIRE(saw_constant);
+  exec_ok(*env.con, "ROLLBACK");
+}
+
+TEST_CASE("insert delta: all-NULL constant validity is captured, not skipped",
+          "[duckdb_insert_delta][scan]")
+{
+  delta_test_db env;
+  exec_ok(*env.con,
+          "CREATE TABLE t AS SELECT range::INTEGER AS k, range::INTEGER AS v FROM range(10000)");
+  exec_ok(*env.con, "CHECKPOINT");
+  // Bulk all-NULL column: the flushed data segment is CONSTANT at a sentinel
+  // value and the NULL-ness lives only in the CONSTANT validity segment's
+  // stats. Skipping it would serve the sentinels as valid rows.
+  exec_ok(*env.con,
+          "INSERT INTO t SELECT (10000+range)::INTEGER, NULL::INTEGER FROM range(130000)");
+
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*env.con, "t");
+  std::vector<duckdb::storage_t> const cols{0, 1};
+  std::vector<sirius::logical_type> types{sirius::logical_type::make(sirius::type_id::INTEGER),
+                                          sirius::logical_type::make(sirius::type_id::INTEGER)};
+  auto plan = capture_insert_delta_plan(storage, *env.con->context, 10000, cols, types);
+
+  bool saw_all_null = false;
+  for (auto const& rg : plan.row_groups) {
+    for (auto const& s : rg.columns[1].validity_segments) {
+      if (!s.all_null) { continue; }
+      saw_all_null = true;
+      REQUIRE(s.is_validity);
+      REQUIRE(s.compression == duckdb::CompressionType::COMPRESSION_CONSTANT);
+      REQUIRE_FALSE(s.is_transient);
+      REQUIRE(s.block_id < 0);
+      REQUIRE(s.bytes_size == 0);
+    }
+  }
+  REQUIRE(saw_all_null);
   exec_ok(*env.con, "ROLLBACK");
 }
 

--- a/test/cpp/scan/test_duckdb_insert_delta.cpp
+++ b/test/cpp/scan/test_duckdb_insert_delta.cpp
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-// Gates for the insert-delta capture and its task bodies: the positional
-// boundary math (n_cache mid-row-group and mid-vector), the per-SEGMENT lane
-// branch (transient -> staging copy, bulk-flushed persistent -> block refs),
-// the n_total snapshot clamp, visibility counting against the SQL rowid
-// oracle, and byte-exact transient staging. CPU-only: real file-backed
-// DuckDB databases, no GPU.
+// Unit tests for the insert-delta capture and its task bodies: boundary math,
+// transient vs bulk-flushed persistent segment lanes, snapshot visibility
+// counting, and byte-exact staging. CPU-only, against real file-backed DuckDB
+// databases. End-to-end coverage lives in test_pin_table_mvcc_insert.cpp.
 
 #include <catch.hpp>
 #include <duckdb.hpp>
@@ -91,20 +89,16 @@ duckdb::DataTable& resolve_storage(duckdb::Connection& con, const std::string& t
   return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
 }
 
-/// k INTEGER, v BIGINT, s VARCHAR — 130,000 checkpointed rows (n_cache) in
-/// row groups {122880, 7120}, then 5,000 committed small-append rows
-/// [130000, 135000). Post-checkpoint appends open a FRESH row group
-/// (RowGroupAppendMode::REQUIRE_NEW), so the delta is row group #2 with
-/// k_offset == 0: with checkpoint-clean pins, n_cache always lands on a
-/// row-group boundary. The k>0 math stays defensive generality.
+/// build_appended_table layout: 130,000 checkpointed rows (n_cache) in row
+/// groups {122880, 7120}, plus 5,000 committed small-append rows. The append
+/// opens a fresh row group, so the delta is row group #2 with k_offset == 0.
 constexpr std::size_t kBase  = 130000;
 constexpr std::size_t kDelta = 5000;
 
 void build_appended_table(duckdb::Connection& con)
 {
-  // Single-threaded build: parallel CTAS splits rows into per-thread batches
-  // with data-dependent row-group boundaries; the assertions below hardcode
-  // the sequential {122880, 7120} layout.
+  // Single-threaded CTAS keeps the row-group layout deterministic; the
+  // assertions hardcode the sequential {122880, 7120} split.
   exec_ok(con, "SET threads TO 1");
   exec_ok(con,
           "CREATE TABLE t AS SELECT range::INTEGER AS k, (range*10)::BIGINT AS v, "
@@ -166,8 +160,7 @@ TEST_CASE("insert delta: capture boundary math and transient segment lanes",
   REQUIRE(col_v.data_segments.size() == 1);
   REQUIRE(col_v.data_segments[0].bytes_size == kDelta * sizeof(int64_t));
 
-  // Varchar: whole used extent staged; the per-segment stat backstop filled
-  // max_string_length.
+  // Varchar: the whole used extent is staged and max_string_length is filled.
   auto const& col_s = rg.columns[2];
   REQUIRE_FALSE(col_s.data_segments.empty());
   for (auto const& s : col_s.data_segments) {
@@ -218,9 +211,8 @@ TEST_CASE("insert delta: an older snapshot cannot see newer committed rows",
   delta_test_db env;
   build_appended_table(*env.con);
 
-  // Open the snapshot FIRST, then commit more rows from a second connection.
-  // The per-database DuckTransaction spawns lazily on first access, so the
-  // snapshot is only pinned by actually touching the table.
+  // Open the snapshot first, then commit more rows from a second connection.
+  // The transaction spawns lazily, so touch the table to pin the snapshot.
   exec_ok(*env.con, "BEGIN TRANSACTION");
   exec_ok(*env.con, "SELECT count(*) FROM t");
   duckdb::Connection con2(*env.db);
@@ -229,7 +221,7 @@ TEST_CASE("insert delta: an older snapshot cannot see newer committed rows",
   auto& storage = resolve_storage(*env.con, "t");
   auto types    = all_types();
   auto plan     = capture_insert_delta_plan(storage, *env.con->context, kBase, kAllCols, types);
-  // The snapshot walk still SEES the newer physical rows...
+  // The snapshot walk still sees the newer physical rows...
   REQUIRE(plan.n_total == kBase + kDelta + 1000);
 
   std::size_t total_visible = 0;
@@ -295,8 +287,8 @@ TEST_CASE("insert delta: bulk-flushed appends keep persistent block references",
   delta_test_db env;
   exec_ok(*env.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(10000)");
   exec_ok(*env.con, "CHECKPOINT");
-  // >= one row group in a single commit: optimistically flushed by
-  // MergeStorage as PERSISTENT (checkpoint-shaped) row groups.
+  // A single commit of at least one full row group: MergeStorage flushes it as
+  // persistent, checkpoint-shaped row groups.
   exec_ok(*env.con, "INSERT INTO t SELECT (10000+range)::INTEGER FROM range(130000)");
   // And a small committed append on top: transient, in its own row group.
   exec_ok(*env.con, "INSERT INTO t VALUES (140000)");

--- a/test/cpp/scan/test_duckdb_insert_delta.cpp
+++ b/test/cpp/scan/test_duckdb_insert_delta.cpp
@@ -396,6 +396,37 @@ TEST_CASE("insert delta: all-NULL constant validity is captured, not skipped",
   exec_ok(*env.con, "ROLLBACK");
 }
 
+TEST_CASE("insert delta: appends into the boundary row group are captured",
+          "[duckdb_insert_delta][scan]")
+{
+  delta_test_db env;
+  // A PRIMARY KEY makes DuckDB append into the existing tail row group
+  // instead of opening a fresh one, so the delta begins inside the last
+  // cached row group (k_offset > 0). The skeleton walk starts at that
+  // boundary row group and must not skip past it.
+  exec_ok(*env.con, "CREATE TABLE t (k INTEGER PRIMARY KEY, v INTEGER)");
+  exec_ok(*env.con, "INSERT INTO t SELECT range, range FROM range(10000)");
+  exec_ok(*env.con, "CHECKPOINT");
+  exec_ok(*env.con, "INSERT INTO t VALUES (10000, 7), (10001, 8)");
+
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*env.con, "t");
+  std::vector<duckdb::storage_t> const cols{0, 1};
+  std::vector<sirius::logical_type> types{sirius::logical_type::make(sirius::type_id::INTEGER),
+                                          sirius::logical_type::make(sirius::type_id::INTEGER)};
+  auto plan = capture_insert_delta_plan(storage, *env.con->context, 10000, cols, types);
+
+  REQUIRE(plan.n_total == 10002);
+  REQUIRE(plan.row_groups.size() == 1);
+  auto const& rg = plan.row_groups[0];
+  REQUIRE(rg.row_group_index == 0);  // the boundary row group itself
+  REQUIRE(rg.k_offset == 10000);
+  REQUIRE(rg.row_count == 2);
+  REQUIRE(rg.row_group_start == 10000);
+  REQUIRE(rg.columns.size() == 2);
+  exec_ok(*env.con, "ROLLBACK");
+}
+
 TEST_CASE("insert delta: range capture merges to the serial plan", "[duckdb_insert_delta][scan]")
 {
   delta_test_db env;

--- a/test/cpp/scan/test_duckdb_insert_delta.cpp
+++ b/test/cpp/scan/test_duckdb_insert_delta.cpp
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Gates for the insert-delta capture and its task bodies: the positional
+// boundary math (n_cache mid-row-group and mid-vector), the per-SEGMENT lane
+// branch (transient -> staging copy, bulk-flushed persistent -> block refs),
+// the n_total snapshot clamp, visibility counting against the SQL rowid
+// oracle, and byte-exact transient staging. CPU-only: real file-backed
+// DuckDB databases, no GPU.
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/catalog/catalog.hpp>
+#include <duckdb/catalog/catalog_entry/duck_table_entry.hpp>
+#include <duckdb/main/client_context.hpp>
+#include <duckdb/storage/buffer_manager.hpp>
+#include <duckdb/storage/data_table.hpp>
+#include <op/scan/duckdb_insert_delta.hpp>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace sirius;
+using namespace sirius::op::scan;
+
+namespace {
+
+void exec_ok(duckdb::Connection& con, const std::string& q)
+{
+  auto result = con.Query(q);
+  REQUIRE(result);
+  if (result->HasError()) {
+    INFO("query failed: " << q << "\n  error: " << result->GetError());
+    REQUIRE_FALSE(result->HasError());
+  }
+}
+
+struct delta_test_db {
+  std::string path;
+  std::unique_ptr<duckdb::DuckDB> db;
+  std::unique_ptr<duckdb::Connection> con;
+
+  delta_test_db()
+  {
+    static int counter = 0;
+    path               = "/tmp/sirius_insert_delta_test_" + std::to_string(::getpid()) + "_" +
+           std::to_string(counter++) + ".db";
+    std::remove(path.c_str());
+    std::remove((path + ".wal").c_str());
+    db  = std::make_unique<duckdb::DuckDB>(path);
+    con = std::make_unique<duckdb::Connection>(*db);
+    con->Query("SET gpu_execution = false;");
+  }
+
+  ~delta_test_db()
+  {
+    con.reset();
+    db.reset();
+    std::remove(path.c_str());
+    std::remove((path + ".wal").c_str());
+  }
+};
+
+/// Requires an active transaction on @p con (catalog access needs one).
+duckdb::DataTable& resolve_storage(duckdb::Connection& con, const std::string& table_name)
+{
+  auto& ctx     = *con.context;
+  auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
+  duckdb::CatalogTransaction txn(catalog, ctx);
+  auto& schema = catalog.GetSchema(txn, "main");
+  auto entry   = schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, table_name);
+  REQUIRE(entry);
+  return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
+}
+
+/// k INTEGER, v BIGINT, s VARCHAR — 130,000 checkpointed rows (n_cache) in
+/// row groups {122880, 7120}, then 5,000 committed small-append rows
+/// [130000, 135000). Post-checkpoint appends open a FRESH row group
+/// (RowGroupAppendMode::REQUIRE_NEW), so the delta is row group #2 with
+/// k_offset == 0: with checkpoint-clean pins, n_cache always lands on a
+/// row-group boundary. The k>0 math stays defensive generality.
+constexpr std::size_t kBase  = 130000;
+constexpr std::size_t kDelta = 5000;
+
+void build_appended_table(duckdb::Connection& con)
+{
+  // Single-threaded build: parallel CTAS splits rows into per-thread batches
+  // with data-dependent row-group boundaries; the assertions below hardcode
+  // the sequential {122880, 7120} layout.
+  exec_ok(con, "SET threads TO 1");
+  exec_ok(con,
+          "CREATE TABLE t AS SELECT range::INTEGER AS k, (range*10)::BIGINT AS v, "
+          "'row_'||range AS s FROM range(130000)");
+  exec_ok(con, "CHECKPOINT");
+  exec_ok(con,
+          "INSERT INTO t SELECT (130000+range)::INTEGER, ((130000+range)*10)::BIGINT, "
+          "'row_'||(130000+range) FROM range(5000)");
+}
+
+std::vector<duckdb::storage_t> const kAllCols{0, 1, 2};
+
+std::vector<sirius::logical_type> all_types()
+{
+  return {sirius::logical_type::make(sirius::type_id::INTEGER),
+          sirius::logical_type::make(sirius::type_id::BIGINT),
+          sirius::logical_type::make(sirius::type_id::VARCHAR)};
+}
+
+}  // namespace
+
+TEST_CASE("insert delta: capture boundary math and transient segment lanes",
+          "[duckdb_insert_delta][scan]")
+{
+  delta_test_db env;
+  build_appended_table(*env.con);
+
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*env.con, "t");
+  auto types    = all_types();
+  auto plan     = capture_insert_delta_plan(storage, *env.con->context, kBase, kAllCols, types);
+
+  REQUIRE(plan.n_cache == kBase);
+  REQUIRE(plan.n_total == kBase + kDelta);
+  REQUIRE(plan.delta_rows() == kDelta);
+  REQUIRE(plan.buffer_manager != nullptr);
+  REQUIRE(plan.partition_stats != nullptr);
+  REQUIRE(plan.transaction.transaction_id != 0);
+
+  REQUIRE(plan.row_groups.size() == 1);
+  auto const& rg = plan.row_groups[0];
+  REQUIRE(rg.row_group_index == 2);  // the append opened a fresh row group
+  REQUIRE(rg.k_offset == 0);
+  REQUIRE(rg.row_count == kDelta);
+  REQUIRE(rg.row_group_start == kBase);
+  REQUIRE(rg.columns.size() == 3);
+
+  // Fixed-width columns: one transient data segment, rebased to slice start,
+  // sized exactly rows * type_size.
+  auto const& col_k = rg.columns[0];
+  REQUIRE(col_k.data_segments.size() == 1);
+  REQUIRE(col_k.data_segments[0].is_transient);
+  REQUIRE(col_k.data_segments[0].segment_start == 0);
+  REQUIRE(col_k.data_segments[0].segment_count == kDelta);
+  REQUIRE(col_k.data_segments[0].bytes_size == kDelta * sizeof(int32_t));
+  REQUIRE_FALSE(col_k.validity_segments.empty());
+
+  auto const& col_v = rg.columns[1];
+  REQUIRE(col_v.data_segments.size() == 1);
+  REQUIRE(col_v.data_segments[0].bytes_size == kDelta * sizeof(int64_t));
+
+  // Varchar: whole used extent staged; the per-segment stat backstop filled
+  // max_string_length.
+  auto const& col_s = rg.columns[2];
+  REQUIRE_FALSE(col_s.data_segments.empty());
+  for (auto const& s : col_s.data_segments) {
+    REQUIRE(s.is_transient);
+    REQUIRE(s.bytes_size > 0);
+    REQUIRE(s.max_string_length.has_value());
+  }
+
+  REQUIRE(rg.transient_staging_bytes > 0);
+  REQUIRE(rg.decoded_bytes_budget > 0);
+  exec_ok(*env.con, "ROLLBACK");
+}
+
+TEST_CASE("insert delta: visibility counting matches the rowid oracle",
+          "[duckdb_insert_delta][scan]")
+{
+  delta_test_db env;
+  build_appended_table(*env.con);
+  // Deletes in the delta (dropped by the count) and in the base (ignored).
+  exec_ok(*env.con, "DELETE FROM t WHERE k IN (5, 130000, 130001, 132048, 134999)");
+
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*env.con, "t");
+  auto types    = all_types();
+  auto plan     = capture_insert_delta_plan(storage, *env.con->context, kBase, kAllCols, types);
+  REQUIRE(plan.row_groups.size() == 1);
+  auto const& rg = plan.row_groups[0];
+
+  std::vector<std::uint32_t> words((kDelta + 31) / 32, 0u);
+  auto const visible = count_visible_delta_rows(rg, plan.transaction, words, 0);
+  REQUIRE(visible == kDelta - 4);  // the base delete does not count
+
+  for (std::size_t i = 0; i < kDelta; ++i) {
+    auto const rowid   = kBase + i;
+    bool const deleted = (rowid == 130000 || rowid == 130001 || rowid == 132048 || rowid == 134999);
+    bool const kept    = ((words[i / 32] >> (i % 32)) & 1u) != 0;
+    if (kept != !deleted) {
+      INFO("delta rowid " << rowid);
+      REQUIRE(kept == !deleted);
+    }
+  }
+  exec_ok(*env.con, "ROLLBACK");
+}
+
+TEST_CASE("insert delta: an older snapshot cannot see newer committed rows",
+          "[duckdb_insert_delta][scan]")
+{
+  delta_test_db env;
+  build_appended_table(*env.con);
+
+  // Open the snapshot FIRST, then commit more rows from a second connection.
+  // The per-database DuckTransaction spawns lazily on first access, so the
+  // snapshot is only pinned by actually touching the table.
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  exec_ok(*env.con, "SELECT count(*) FROM t");
+  duckdb::Connection con2(*env.db);
+  exec_ok(con2, "INSERT INTO t SELECT (135000+range)::INTEGER, 0::BIGINT, 'late' FROM range(1000)");
+
+  auto& storage = resolve_storage(*env.con, "t");
+  auto types    = all_types();
+  auto plan     = capture_insert_delta_plan(storage, *env.con->context, kBase, kAllCols, types);
+  // The snapshot walk still SEES the newer physical rows...
+  REQUIRE(plan.n_total == kBase + kDelta + 1000);
+
+  std::size_t total_visible = 0;
+  std::vector<std::uint32_t> words((plan.delta_rows() + 31) / 32, 0u);
+  std::size_t bit_offset = 0;
+  for (auto const& rg : plan.row_groups) {
+    total_visible += count_visible_delta_rows(rg, plan.transaction, words, bit_offset);
+    bit_offset += rg.row_count;
+  }
+  // ...but visibility excludes rows committed after this snapshot opened.
+  REQUIRE(total_visible == kDelta);
+  exec_ok(*env.con, "ROLLBACK");
+}
+
+TEST_CASE("insert delta: transient staging copies are byte-exact", "[duckdb_insert_delta][scan]")
+{
+  delta_test_db env;
+  build_appended_table(*env.con);
+
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*env.con, "t");
+  auto types    = all_types();
+  auto plan     = capture_insert_delta_plan(storage, *env.con->context, kBase, kAllCols, types);
+  REQUIRE(plan.row_groups.size() == 1);
+  auto const& rg = plan.row_groups[0];
+
+  std::vector<std::uint8_t> slab(rg.transient_staging_bytes, 0);
+  copy_delta_row_group(rg, *plan.buffer_manager, slab.data());
+
+  // k column: int32 values 130000..134999 at the segment's slab offset.
+  auto const& kseg = rg.columns[0].data_segments[0];
+  std::vector<int32_t> expected_k(kDelta);
+  for (std::size_t i = 0; i < kDelta; ++i) {
+    expected_k[i] = static_cast<int32_t>(kBase + i);
+  }
+  REQUIRE(
+    std::memcmp(slab.data() + kseg.slab_offset, expected_k.data(), kDelta * sizeof(int32_t)) == 0);
+
+  // v column: bigint values (rowid * 10).
+  auto const& vseg = rg.columns[1].data_segments[0];
+  std::vector<int64_t> expected_v(kDelta);
+  for (std::size_t i = 0; i < kDelta; ++i) {
+    expected_v[i] = static_cast<int64_t>((kBase + i) * 10);
+  }
+  REQUIRE(
+    std::memcmp(slab.data() + vseg.slab_offset, expected_v.data(), kDelta * sizeof(int64_t)) == 0);
+
+  // varchar: the staged dictionary header {size, end} must be self-consistent
+  // with the staged extent.
+  auto const& sseg        = rg.columns[2].data_segments[0];
+  std::uint32_t dict_size = 0;
+  std::uint32_t dict_end  = 0;
+  std::memcpy(&dict_size, slab.data() + sseg.slab_offset, sizeof(dict_size));
+  std::memcpy(&dict_end, slab.data() + sseg.slab_offset + 4, sizeof(dict_end));
+  REQUIRE(dict_end <= sseg.bytes_size);
+  REQUIRE(dict_size <= dict_end);
+  exec_ok(*env.con, "ROLLBACK");
+}
+
+TEST_CASE("insert delta: bulk-flushed appends keep persistent block references",
+          "[duckdb_insert_delta][scan]")
+{
+  delta_test_db env;
+  exec_ok(*env.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(10000)");
+  exec_ok(*env.con, "CHECKPOINT");
+  // >= one row group in a single commit: optimistically flushed by
+  // MergeStorage as PERSISTENT (checkpoint-shaped) row groups.
+  exec_ok(*env.con, "INSERT INTO t SELECT (10000+range)::INTEGER FROM range(130000)");
+  // And a small committed append on top: transient, in its own row group.
+  exec_ok(*env.con, "INSERT INTO t VALUES (140000)");
+
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*env.con, "t");
+  std::vector<duckdb::storage_t> const cols{0};
+  std::vector<sirius::logical_type> types{sirius::logical_type::make(sirius::type_id::INTEGER)};
+  auto plan = capture_insert_delta_plan(storage, *env.con->context, 10000, cols, types);
+
+  REQUIRE(plan.n_total == 140001);
+  REQUIRE(plan.row_groups.size() >= 2);
+
+  bool saw_persistent = false;
+  bool saw_transient  = false;
+  for (auto const& rg : plan.row_groups) {
+    for (auto const& s : rg.columns[0].data_segments) {
+      if (s.is_transient) {
+        saw_transient = true;
+      } else {
+        saw_persistent = true;
+        REQUIRE(s.block_id >= 0);
+        REQUIRE(s.bytes_size > 0);
+      }
+    }
+    if (!rg.columns[0].data_segments.empty() && !rg.columns[0].data_segments[0].is_transient) {
+      REQUIRE(rg.transient_staging_bytes == 0);
+    }
+  }
+  REQUIRE(saw_persistent);
+  REQUIRE(saw_transient);
+  exec_ok(*env.con, "ROLLBACK");
+}
+
+TEST_CASE("insert delta: no delta means an empty plan", "[duckdb_insert_delta][scan]")
+{
+  delta_test_db env;
+  exec_ok(*env.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(1000)");
+  exec_ok(*env.con, "CHECKPOINT");
+
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*env.con, "t");
+  std::vector<duckdb::storage_t> const cols{0};
+  std::vector<sirius::logical_type> types{sirius::logical_type::make(sirius::type_id::INTEGER)};
+  auto plan = capture_insert_delta_plan(storage, *env.con->context, 1000, cols, types);
+  REQUIRE(plan.empty());
+  REQUIRE(plan.delta_rows() == 0);
+  exec_ok(*env.con, "ROLLBACK");
+}

--- a/test/cpp/scan/test_duckdb_insert_delta.cpp
+++ b/test/cpp/scan/test_duckdb_insert_delta.cpp
@@ -396,6 +396,91 @@ TEST_CASE("insert delta: all-NULL constant validity is captured, not skipped",
   exec_ok(*env.con, "ROLLBACK");
 }
 
+TEST_CASE("insert delta: range capture merges to the serial plan", "[duckdb_insert_delta][scan]")
+{
+  delta_test_db env;
+  exec_ok(*env.con, "SET threads TO 1");
+  exec_ok(*env.con,
+          "CREATE TABLE t AS SELECT range::INTEGER AS k, 'row_'||range AS s FROM range(10000)");
+  exec_ok(*env.con, "CHECKPOINT");
+  // Four delta row groups: three persistent from the bulk flush plus the
+  // transient tail append.
+  exec_ok(*env.con,
+          "INSERT INTO t SELECT (10000+range)::INTEGER, 'row_'||(10000+range) FROM range(250000)");
+  exec_ok(*env.con, "INSERT INTO t VALUES (260000, 'tail')");
+
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*env.con, "t");
+  std::vector<duckdb::storage_t> const cols{0, 1};
+  std::vector<sirius::logical_type> types{sirius::logical_type::make(sirius::type_id::INTEGER),
+                                          sirius::logical_type::make(sirius::type_id::VARCHAR)};
+
+  auto serial = capture_insert_delta_plan(storage, *env.con->context, 10000, cols, types);
+  REQUIRE(serial.row_groups.size() >= 3);
+
+  auto plan = prepare_insert_delta_capture(storage, *env.con->context, 10000);
+  REQUIRE(plan.row_groups.size() == serial.row_groups.size());
+  for (auto const& rg : plan.row_groups) {
+    REQUIRE(rg.columns.empty());  // skeletons carry boundaries only
+  }
+
+  // Step-3 ranges leave a short tail range, and an oversized rg_end clamps.
+  std::vector<insert_delta_row_group> merged;
+  for (std::size_t begin = 0; begin < plan.row_groups.size(); begin += 3) {
+    auto part = capture_insert_delta_row_group_range(plan, begin, begin + 3, cols, types);
+    for (auto& rg : part) {
+      merged.push_back(std::move(rg));
+    }
+  }
+  REQUIRE(merged.size() == serial.row_groups.size());
+  REQUIRE(capture_insert_delta_row_group_range(
+            plan, plan.row_groups.size(), plan.row_groups.size() + 5, cols, types)
+            .empty());
+
+  auto require_same_segments = [](std::vector<insert_delta_segment> const& a,
+                                  std::vector<insert_delta_segment> const& b) {
+    REQUIRE(a.size() == b.size());
+    for (std::size_t i = 0; i < a.size(); ++i) {
+      REQUIRE(a[i].segment == b[i].segment);
+      REQUIRE(a[i].is_transient == b[i].is_transient);
+      REQUIRE(a[i].is_validity == b[i].is_validity);
+      REQUIRE(a[i].all_null == b[i].all_null);
+      REQUIRE((a[i].segment_stats != nullptr) == (b[i].segment_stats != nullptr));
+      REQUIRE(a[i].block_id == b[i].block_id);
+      REQUIRE(a[i].additional_blocks == b[i].additional_blocks);
+      REQUIRE(a[i].block_offset == b[i].block_offset);
+      REQUIRE(a[i].segment_start == b[i].segment_start);
+      REQUIRE(a[i].segment_count == b[i].segment_count);
+      REQUIRE(a[i].compression == b[i].compression);
+      REQUIRE(a[i].max_string_length == b[i].max_string_length);
+      REQUIRE(a[i].bytes_size == b[i].bytes_size);
+      REQUIRE(a[i].copy_src_offset == b[i].copy_src_offset);
+      REQUIRE(a[i].slab_offset == b[i].slab_offset);
+    }
+  };
+  for (std::size_t r = 0; r < merged.size(); ++r) {
+    auto const& a = merged[r];
+    auto const& b = serial.row_groups[r];
+    REQUIRE(a.row_group == b.row_group);
+    REQUIRE(a.row_group_index == b.row_group_index);
+    REQUIRE(a.row_group_start == b.row_group_start);
+    REQUIRE(a.k_offset == b.k_offset);
+    REQUIRE(a.row_count == b.row_count);
+    REQUIRE(a.has_version_state == b.has_version_state);
+    REQUIRE(a.transient_staging_bytes == b.transient_staging_bytes);
+    REQUIRE(a.decoded_bytes_budget == b.decoded_bytes_budget);
+    REQUIRE(a.varchar_bytes_per_col == b.varchar_bytes_per_col);
+    REQUIRE(a.columns.size() == b.columns.size());
+    for (std::size_t c = 0; c < a.columns.size(); ++c) {
+      REQUIRE(a.columns[c].column_id == b.columns[c].column_id);
+      REQUIRE(a.columns[c].is_varchar == b.columns[c].is_varchar);
+      require_same_segments(a.columns[c].data_segments, b.columns[c].data_segments);
+      require_same_segments(a.columns[c].validity_segments, b.columns[c].validity_segments);
+    }
+  }
+  exec_ok(*env.con, "ROLLBACK");
+}
+
 TEST_CASE("insert delta: no delta means an empty plan", "[duckdb_insert_delta][scan]")
 {
   delta_test_db env;

--- a/test/cpp/scan/test_duckdb_mvcc_visibility.cpp
+++ b/test/cpp/scan/test_duckdb_mvcc_visibility.cpp
@@ -483,6 +483,48 @@ TEST_CASE("mvcc visibility: any_update_chains flags updated columns only",
   exec_ok(*env.con, "ROLLBACK");
 }
 
+TEST_CASE("mvcc visibility: checkpoint-grown row groups fill at unaligned offsets",
+          "[duckdb_mvcc_visibility][scan]")
+{
+  vis_test_db env;
+  // Checkpoint, append, checkpoint again: the append lands in its own row
+  // group (checkpoint's small-row-group vacuum leaves the large first one
+  // alone), so the second slice starts at chunk offset 50000 — not a
+  // mask-word multiple (50000 % 32 == 16).
+  exec_ok(*env.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(50000)");
+  exec_ok(*env.con, "CHECKPOINT");
+  exec_ok(*env.con, "INSERT INTO t SELECT range::INTEGER + 50000 FROM range(100)");
+  exec_ok(*env.con, "CHECKPOINT");
+  // Straddle the row-group boundary and both edges of the shared mask word.
+  exec_ok(*env.con, "DELETE FROM t WHERE k IN (49995, 49999, 50000, 50001, 50031, 50032)");
+
+  constexpr std::size_t kTotal = 50100;
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*env.con, "t");
+  auto metadata = make_metadata(*env.con, storage, /*rgs_per_chunk=*/8);
+  REQUIRE(metadata.base_row_count_per_chunk == std::vector<std::size_t>{kTotal});
+
+  auto plan = capture_mvcc_visibility_plan(storage, *env.con->context, metadata);
+  REQUIRE(plan.mvcc_row_groups.size() == 1);
+  REQUIRE(plan.mvcc_row_groups[0].size() == 2);
+  REQUIRE(plan.mvcc_row_groups[0][1].chunk_offset == 50000);  // unaligned by design
+
+  std::vector<std::uint32_t> words((kTotal + 31) / 32, 0u);
+  bool const dropped =
+    fill_keep_mask_for_row_groups(plan.mvcc_row_groups[0], plan.transaction, words);
+  REQUIRE(dropped);
+
+  auto visible = visible_rowids(*env.con, "t", kTotal);
+  for (std::size_t i = 0; i < kTotal; ++i) {
+    bool const kept = ((words[i / 32] >> (i % 32)) & 1u) != 0;
+    if (kept != visible[i]) {
+      INFO("rowid " << i);
+      REQUIRE(kept == static_cast<bool>(visible[i]));
+    }
+  }
+  exec_ok(*env.con, "ROLLBACK");
+}
+
 TEST_CASE("mvcc visibility: fused native-read check is precise where the probe is conservative",
           "[duckdb_mvcc_visibility][scan]")
 {

--- a/test/cpp/scan/test_duckdb_mvcc_visibility.cpp
+++ b/test/cpp/scan/test_duckdb_mvcc_visibility.cpp
@@ -516,9 +516,8 @@ TEST_CASE("mvcc visibility: any_uncheckpointed_appends flags transient segments 
   REQUIRE_FALSE(any_uncheckpointed_appends(resolve_storage(*env.con, "t"), both));
   exec_ok(*env.con, "ROLLBACK");
 
-  // A bulk insert (>= one row group) is optimistically flushed by
-  // MergeStorage: PERSISTENT-uncheckpointed, checkpoint-shaped segments —
-  // deliberately NOT flagged (the documented pin asymmetry).
+  // A bulk insert (>= one row group) is optimistically flushed by MergeStorage
+  // as persistent, checkpoint-shaped segments; deliberately not flagged.
   vis_test_db bulk_env;
   exec_ok(*bulk_env.con, "CREATE TABLE tb(k INTEGER)");
   exec_ok(*bulk_env.con, "INSERT INTO tb SELECT range::INTEGER FROM range(130000)");
@@ -532,10 +531,9 @@ TEST_CASE("mvcc visibility: checkpoint-grown row groups fill at unaligned offset
           "[duckdb_mvcc_visibility][scan]")
 {
   vis_test_db env;
-  // Checkpoint, append, checkpoint again: the append lands in its own row
-  // group (checkpoint's small-row-group vacuum leaves the large first one
-  // alone), so the second slice starts at chunk offset 50000 — not a
-  // mask-word multiple (50000 % 32 == 16).
+  // Checkpoint, append, checkpoint again: the vacuum leaves the large first
+  // row group alone, so the append keeps its own row group and the second
+  // slice starts at unaligned chunk offset 50000 (50000 % 32 == 16).
   exec_ok(*env.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(50000)");
   exec_ok(*env.con, "CHECKPOINT");
   exec_ok(*env.con, "INSERT INTO t SELECT range::INTEGER + 50000 FROM range(100)");

--- a/test/cpp/scan/test_duckdb_mvcc_visibility.cpp
+++ b/test/cpp/scan/test_duckdb_mvcc_visibility.cpp
@@ -483,6 +483,51 @@ TEST_CASE("mvcc visibility: any_update_chains flags updated columns only",
   exec_ok(*env.con, "ROLLBACK");
 }
 
+TEST_CASE("mvcc visibility: any_uncheckpointed_appends flags transient segments only",
+          "[duckdb_mvcc_visibility][scan]")
+{
+  vis_test_db env;
+  exec_ok(*env.con,
+          "CREATE TABLE t AS SELECT range::INTEGER AS k, range::INTEGER AS v FROM range(10000)");
+  exec_ok(*env.con, "CHECKPOINT");
+
+  std::vector<duckdb::storage_t> const both{0, 1};
+
+  // Checkpointed image: everything persistent.
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  REQUIRE_FALSE(any_uncheckpointed_appends(resolve_storage(*env.con, "t"), both));
+  exec_ok(*env.con, "ROLLBACK");
+
+  // A committed small append lands as transient segments.
+  exec_ok(*env.con, "INSERT INTO t VALUES (10000, 10000)");
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  REQUIRE(any_uncheckpointed_appends(resolve_storage(*env.con, "t"), both));
+  exec_ok(*env.con, "ROLLBACK");
+
+  // CHECKPOINT folds the append into the persistent image.
+  exec_ok(*env.con, "CHECKPOINT");
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  REQUIRE_FALSE(any_uncheckpointed_appends(resolve_storage(*env.con, "t"), both));
+  exec_ok(*env.con, "ROLLBACK");
+
+  // Deletes carry version state but no transient segments.
+  exec_ok(*env.con, "DELETE FROM t WHERE rowid < 10");
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  REQUIRE_FALSE(any_uncheckpointed_appends(resolve_storage(*env.con, "t"), both));
+  exec_ok(*env.con, "ROLLBACK");
+
+  // A bulk insert (>= one row group) is optimistically flushed by
+  // MergeStorage: PERSISTENT-uncheckpointed, checkpoint-shaped segments —
+  // deliberately NOT flagged (the documented pin asymmetry).
+  vis_test_db bulk_env;
+  exec_ok(*bulk_env.con, "CREATE TABLE tb(k INTEGER)");
+  exec_ok(*bulk_env.con, "INSERT INTO tb SELECT range::INTEGER FROM range(130000)");
+  std::vector<duckdb::storage_t> const one{0};
+  exec_ok(*bulk_env.con, "BEGIN TRANSACTION");
+  REQUIRE_FALSE(any_uncheckpointed_appends(resolve_storage(*bulk_env.con, "tb"), one));
+  exec_ok(*bulk_env.con, "ROLLBACK");
+}
+
 TEST_CASE("mvcc visibility: checkpoint-grown row groups fill at unaligned offsets",
           "[duckdb_mvcc_visibility][scan]")
 {

--- a/test/cpp/scan/test_duckdb_native_host_backed_decode.cpp
+++ b/test/cpp/scan/test_duckdb_native_host_backed_decode.cpp
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-// Gates for the decoder's host-backed segment lane (insert-delta staging):
-// a split whose descriptors carry `host_ptr` must decode from those bytes
-// alone — no file reads, no datasource, no SiriusContext — and produce
-// exactly what SQL returns for the same rows. The byte source is the real
-// checkpointed table, checkpointed with force_compression='uncompressed' so
-// the segment payloads are byte-identical to the in-memory transient shape
-// the insert-delta job stages.
+// Tests for the decoder's host-backed segment lane (insert-delta staging):
+// splits whose descriptors carry host_ptr must decode from those bytes alone,
+// with no file reads and no datasource, and match SQL for the same rows.
 
 #include "test_utils.hpp"
 
@@ -68,8 +64,7 @@ void exec_ok(duckdb::Connection& con, const std::string& q)
   }
 }
 
-/// File-backed database: the byte source is real checkpointed segments, and
-/// the decoder requires a SingleFileBlockManager.
+/// File-backed database; the decoder requires a SingleFileBlockManager.
 struct host_backed_test_db {
   std::string path;
   std::unique_ptr<duckdb::DuckDB> db;
@@ -128,10 +123,8 @@ std::vector<duckdb_row_group_metadata> walk_all(duckdb::DataTable& storage,
   return std::move(range.row_groups);
 }
 
-/// Pin every block-backed segment, copy its payload bytes into test-owned host
-/// buffers, and point the descriptor's `host_ptr` at the copy — the exact move
-/// the insert-delta staging task performs. `clear_block_ids` additionally
-/// erases the block reference (the true delta descriptor shape).
+/// Copies each block-backed segment's payload to a host buffer and points
+/// host_ptr at it; clear_block_ids additionally erases the block reference.
 void host_back_segments(duckdb::ClientContext& ctx,
                         duckdb::DataTable& storage,
                         std::vector<duckdb_row_group_metadata>& row_groups,
@@ -149,7 +142,7 @@ void host_back_segments(duckdb::ClientContext& ctx,
     std::memcpy(owned->data(), pin.Ptr() + desc.block_offset, desc.bytes_size);
     desc.host_ptr = owned->data();
     if (clear_block_ids) {
-      desc.block_id     = INVALID_BLOCK;  // macro from duckdb/storage/storage_info.hpp
+      desc.block_id     = INVALID_BLOCK;
       desc.block_offset = 0;
     }
     keepalive.push_back(std::move(owned));
@@ -262,6 +255,8 @@ void require_matches_expected(cudf::table const& t,
 /// column, empty strings, and NULLs every 5th row in `opt`.
 void build_table(duckdb::Connection& con)
 {
+  // Uncompressed checkpoint keeps segment payloads byte-identical to the
+  // transient shape the insert-delta job stages.
   exec_ok(con, "SET force_compression='uncompressed'");
   exec_ok(con, "CREATE TABLE t(id INTEGER, value BIGINT, price DOUBLE, name VARCHAR, opt INTEGER)");
   exec_ok(con,
@@ -324,7 +319,7 @@ TEST_CASE("host-backed decode matches SQL with zero file reads",
 
   SECTION("host_ptr takes precedence over a still-valid block_id")
   {
-    // With a null datasource, any fall-through to the file lane would throw —
+    // With a null datasource any fall-through to the file lane would throw, so
     // decoding successfully proves host_ptr wins.
     host_back_segments(*env.con->context, storage, md, keepalive, /*clear_block_ids=*/false);
     auto table =
@@ -358,7 +353,7 @@ TEST_CASE("file reads staged without a datasource throw loudly",
 
   auto cols  = all_cols();
   auto types = all_types();
-  auto md    = walk_all(storage, *env.con->context, cols, types);  // block-backed, NOT host-backed
+  auto md    = walk_all(storage, *env.con->context, cols, types);  // block-backed, not host-backed
 
   duckdb_native_ingestible_table_info info;
   info.storage         = &storage;

--- a/test/cpp/scan/test_duckdb_native_host_backed_decode.cpp
+++ b/test/cpp/scan/test_duckdb_native_host_backed_decode.cpp
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Gates for the decoder's host-backed segment lane (insert-delta staging):
+// a split whose descriptors carry `host_ptr` must decode from those bytes
+// alone — no file reads, no datasource, no SiriusContext — and produce
+// exactly what SQL returns for the same rows. The byte source is the real
+// checkpointed table, checkpointed with force_compression='uncompressed' so
+// the segment payloads are byte-identical to the in-memory transient shape
+// the insert-delta job stages.
+
+#include "test_utils.hpp"
+
+#include <rmm/cuda_stream.hpp>
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/catalog/catalog.hpp>
+#include <duckdb/catalog/catalog_entry/duck_table_entry.hpp>
+#include <duckdb/common/constants.hpp>
+#include <duckdb/common/types/data_chunk.hpp>
+#include <duckdb/main/attached_database.hpp>
+#include <duckdb/main/client_context.hpp>
+#include <duckdb/storage/block_manager.hpp>
+#include <duckdb/storage/buffer/buffer_handle.hpp>
+#include <duckdb/storage/buffer_manager.hpp>
+#include <duckdb/storage/data_table.hpp>
+#include <duckdb/storage/storage_manager.hpp>
+#include <op/scan/duckdb_native_decoder.hpp>
+#include <op/scan/duckdb_native_gpu_ingestible.hpp>
+#include <op/scan/duckdb_native_metadata.hpp>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace sirius;
+using namespace sirius::op::scan;
+
+namespace {
+
+void exec_ok(duckdb::Connection& con, const std::string& q)
+{
+  auto result = con.Query(q);
+  REQUIRE(result);
+  if (result->HasError()) {
+    INFO("query failed: " << q << "\n  error: " << result->GetError());
+    REQUIRE_FALSE(result->HasError());
+  }
+}
+
+/// File-backed database: the byte source is real checkpointed segments, and
+/// the decoder requires a SingleFileBlockManager.
+struct host_backed_test_db {
+  std::string path;
+  std::unique_ptr<duckdb::DuckDB> db;
+  std::unique_ptr<duckdb::Connection> con;
+
+  host_backed_test_db()
+  {
+    static int counter = 0;
+    path               = "/tmp/sirius_host_backed_decode_test_" + std::to_string(::getpid()) + "_" +
+           std::to_string(counter++) + ".db";
+    std::remove(path.c_str());
+    std::remove((path + ".wal").c_str());
+    db  = std::make_unique<duckdb::DuckDB>(path);
+    con = std::make_unique<duckdb::Connection>(*db);
+    con->Query("SET gpu_execution = false;");
+  }
+
+  ~host_backed_test_db()
+  {
+    con.reset();
+    db.reset();
+    std::remove(path.c_str());
+    std::remove((path + ".wal").c_str());
+  }
+};
+
+/// Requires an active transaction on @p con (catalog access needs one).
+duckdb::DataTable& resolve_storage(duckdb::Connection& con, const std::string& table_name)
+{
+  auto& ctx     = *con.context;
+  auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
+  duckdb::CatalogTransaction txn(catalog, ctx);
+  auto& schema = catalog.GetSchema(txn, "main");
+  auto entry   = schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, table_name);
+  REQUIRE(entry);
+  return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
+}
+
+projected_column real_col(duckdb::idx_t col_id)
+{
+  projected_column pc;
+  pc.storage_idx = duckdb::StorageIndex(col_id);
+  pc.is_rowid    = false;
+  return pc;
+}
+
+std::vector<duckdb_row_group_metadata> walk_all(duckdb::DataTable& storage,
+                                                duckdb::ClientContext& ctx,
+                                                const std::vector<projected_column>& cols,
+                                                const std::vector<sirius::logical_type>& types)
+{
+  auto plan = prepare_duckdb_native_walk(storage, ctx, cols, types);
+  REQUIRE(plan.viable);
+  auto range = walk_duckdb_native_row_group_range(plan, 0, plan.n_row_groups);
+  REQUIRE(range.viable);
+  return std::move(range.row_groups);
+}
+
+/// Pin every block-backed segment, copy its payload bytes into test-owned host
+/// buffers, and point the descriptor's `host_ptr` at the copy — the exact move
+/// the insert-delta staging task performs. `clear_block_ids` additionally
+/// erases the block reference (the true delta descriptor shape).
+void host_back_segments(duckdb::ClientContext& ctx,
+                        duckdb::DataTable& storage,
+                        std::vector<duckdb_row_group_metadata>& row_groups,
+                        std::vector<std::shared_ptr<void>>& keepalive,
+                        bool clear_block_ids)
+{
+  auto& buffer_manager = duckdb::BufferManager::GetBufferManager(ctx);
+  auto& block_manager  = storage.GetAttached().GetStorageManager().GetBlockManager();
+
+  auto back_one = [&](duckdb_segment_descriptor& desc) {
+    if (desc.block_id < 0 || desc.bytes_size == 0) { return; }
+    auto handle = block_manager.RegisterBlock(desc.block_id);
+    auto pin    = buffer_manager.Pin(handle);
+    auto owned  = std::make_shared<std::vector<uint8_t>>(desc.bytes_size);
+    std::memcpy(owned->data(), pin.Ptr() + desc.block_offset, desc.bytes_size);
+    desc.host_ptr = owned->data();
+    if (clear_block_ids) {
+      desc.block_id     = INVALID_BLOCK;  // macro from duckdb/storage/storage_info.hpp
+      desc.block_offset = 0;
+    }
+    keepalive.push_back(std::move(owned));
+  };
+
+  for (auto& rg : row_groups) {
+    for (auto& col : rg.columns) {
+      for (auto& d : col.data_segments) {
+        back_one(d);
+      }
+      for (auto& v : col.validity_segments) {
+        back_one(v);
+      }
+    }
+  }
+}
+
+struct expected_rows {
+  std::vector<int32_t> id;
+  std::vector<int64_t> value;
+  std::vector<double> price;
+  std::vector<std::string> name;
+  std::vector<int32_t> opt;
+  std::vector<bool> opt_null;
+};
+
+expected_rows fetch_expected(duckdb::Connection& con)
+{
+  expected_rows out;
+  auto result = con.Query("SELECT id, value, price, name, opt FROM t ORDER BY rowid");
+  REQUIRE(result);
+  REQUIRE_FALSE(result->HasError());
+  while (auto chunk = result->Fetch()) {
+    for (duckdb::idx_t r = 0; r < chunk->size(); ++r) {
+      out.id.push_back(chunk->GetValue(0, r).GetValue<int32_t>());
+      out.value.push_back(chunk->GetValue(1, r).GetValue<int64_t>());
+      out.price.push_back(chunk->GetValue(2, r).GetValue<double>());
+      out.name.push_back(chunk->GetValue(3, r).GetValue<std::string>());
+      auto v = chunk->GetValue(4, r);
+      out.opt_null.push_back(v.IsNull());
+      out.opt.push_back(v.IsNull() ? 0 : v.GetValue<int32_t>());
+    }
+  }
+  return out;
+}
+
+template <typename T>
+std::vector<T> download(void const* d_ptr, std::size_t count, rmm::cuda_stream_view stream)
+{
+  std::vector<T> out(count);
+  cudaMemcpyAsync(out.data(), d_ptr, count * sizeof(T), cudaMemcpyDeviceToHost, stream.value());
+  cudaStreamSynchronize(stream.value());
+  return out;
+}
+
+void require_matches_expected(cudf::table const& t,
+                              expected_rows const& exp,
+                              rmm::cuda_stream_view stream)
+{
+  auto const n = exp.id.size();
+  REQUIRE(t.num_columns() == 5);
+  REQUIRE(static_cast<std::size_t>(t.num_rows()) == n);
+
+  REQUIRE(download<int32_t>(t.get_column(0).view().data<int32_t>(), n, stream) == exp.id);
+  REQUIRE(download<int64_t>(t.get_column(1).view().data<int64_t>(), n, stream) == exp.value);
+  REQUIRE(download<double>(t.get_column(2).view().data<double>(), n, stream) == exp.price);
+
+  // Strings: offsets + chars.
+  cudf::strings_column_view name_col(t.get_column(3).view());
+  auto offsets = sirius::scan_test_utils::copy_string_offsets(name_col.offsets());
+  REQUIRE(offsets.size() == n + 1);
+  std::vector<char> chars;
+  if (offsets.back() > 0) {
+    chars.resize(static_cast<std::size_t>(offsets.back()));
+    cudaMemcpyAsync(chars.data(),
+                    name_col.chars_begin(cudf::get_default_stream()),
+                    chars.size(),
+                    cudaMemcpyDeviceToHost,
+                    stream.value());
+    cudaStreamSynchronize(stream.value());
+  }
+  for (std::size_t i = 0; i < n; ++i) {
+    auto const start = static_cast<std::size_t>(offsets[i]);
+    auto const end   = static_cast<std::size_t>(offsets[i + 1]);
+    std::string actual;
+    if (end > start) { actual.assign(chars.data() + start, chars.data() + end); }
+    if (actual != exp.name[i]) { FAIL("name mismatch at row " << i); }
+  }
+
+  // Nullable column: values where valid, null mask bits everywhere.
+  auto const& opt_col        = t.get_column(4);
+  std::size_t expected_nulls = 0;
+  for (auto is_null : exp.opt_null) {
+    expected_nulls += is_null ? 1 : 0;
+  }
+  REQUIRE(static_cast<std::size_t>(opt_col.null_count()) == expected_nulls);
+  auto opt_vals = download<int32_t>(opt_col.view().data<int32_t>(), n, stream);
+  std::vector<uint32_t> null_words;
+  if (opt_col.view().null_mask() != nullptr) {
+    null_words = download<uint32_t>(opt_col.view().null_mask(), (n + 31) / 32, stream);
+  }
+  for (std::size_t i = 0; i < n; ++i) {
+    bool const valid = null_words.empty() ? true : ((null_words[i / 32] >> (i % 32)) & 1u) != 0u;
+    if (valid == exp.opt_null[i]) { FAIL("null-mask mismatch at row " << i); }
+    if (valid && opt_vals[i] != exp.opt[i]) { FAIL("opt value mismatch at row " << i); }
+  }
+}
+
+/// 130,000 rows: two row groups (122,880 + 7,120), several segments per
+/// column, empty strings, and NULLs every 5th row in `opt`.
+void build_table(duckdb::Connection& con)
+{
+  exec_ok(con, "SET force_compression='uncompressed'");
+  exec_ok(con, "CREATE TABLE t(id INTEGER, value BIGINT, price DOUBLE, name VARCHAR, opt INTEGER)");
+  exec_ok(con,
+          "INSERT INTO t SELECT i::INTEGER, (i*100)::BIGINT, i*1.5, "
+          "CASE WHEN i%97=0 THEN '' ELSE 'item_'||i END, "
+          "CASE WHEN i%5=0 THEN NULL ELSE (i%1000)::INTEGER END "
+          "FROM range(130000) tbl(i)");
+  exec_ok(con, "CHECKPOINT");
+}
+
+std::vector<projected_column> all_cols()
+{
+  return {real_col(0), real_col(1), real_col(2), real_col(3), real_col(4)};
+}
+
+std::vector<sirius::logical_type> all_types()
+{
+  return {sirius::logical_type::make(sirius::type_id::INTEGER),
+          sirius::logical_type::make(sirius::type_id::BIGINT),
+          sirius::logical_type::make(sirius::type_id::DOUBLE),
+          sirius::logical_type::make(sirius::type_id::VARCHAR),
+          sirius::logical_type::make(sirius::type_id::INTEGER)};
+}
+
+}  // namespace
+
+TEST_CASE("host-backed decode matches SQL with zero file reads",
+          "[scan][duckdb_native_host_backed]")
+{
+  host_backed_test_db env;
+  build_table(*env.con);
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*env.con, "t");
+
+  auto cols  = all_cols();
+  auto types = all_types();
+  auto md    = walk_all(storage, *env.con->context, cols, types);
+  auto exp   = fetch_expected(*env.con);
+
+  duckdb_native_ingestible_table_info info;
+  info.storage         = &storage;
+  info.context         = env.con->context.get();
+  info.projected_cols  = cols;
+  info.projected_types = types;
+
+  auto mem_mgr    = initialize_memory_manager();
+  auto* gpu_space = sirius::scan_test_utils::get_space(*mem_mgr, cucascade::memory::Tier::GPU);
+  REQUIRE(gpu_space != nullptr);
+  rmm::cuda_stream stream;
+
+  std::vector<std::shared_ptr<void>> keepalive;
+
+  SECTION("delta descriptor shape: block ids cleared, null datasource")
+  {
+    host_back_segments(*env.con->context, storage, md, keepalive, /*clear_block_ids=*/true);
+    auto table =
+      decode_duckdb_native_split(md, info, /*datasource=*/nullptr, *gpu_space, stream.view());
+    require_matches_expected(*table, exp, stream.view());
+  }
+
+  SECTION("host_ptr takes precedence over a still-valid block_id")
+  {
+    // With a null datasource, any fall-through to the file lane would throw —
+    // decoding successfully proves host_ptr wins.
+    host_back_segments(*env.con->context, storage, md, keepalive, /*clear_block_ids=*/false);
+    auto table =
+      decode_duckdb_native_split(md, info, /*datasource=*/nullptr, *gpu_space, stream.view());
+    require_matches_expected(*table, exp, stream.view());
+  }
+
+  SECTION("carried partition stats replace the ClientContext fetch")
+  {
+    host_back_segments(*env.con->context, storage, md, keepalive, /*clear_block_ids=*/true);
+    duckdb::vector<duckdb::PartitionStatistics> carried;  // no CONSTANT segments -> never consulted
+    auto table = decode_duckdb_native_split(
+      md, info, /*datasource=*/nullptr, *gpu_space, stream.view(), &carried);
+    require_matches_expected(*table, exp, stream.view());
+  }
+}
+
+TEST_CASE("file reads staged without a datasource throw loudly",
+          "[scan][duckdb_native_host_backed]")
+{
+  host_backed_test_db env;
+  exec_ok(*env.con, "SET force_compression='uncompressed'");
+  exec_ok(*env.con,
+          "CREATE TABLE t(id INTEGER, value BIGINT, price DOUBLE, name VARCHAR, opt INTEGER)");
+  exec_ok(*env.con,
+          "INSERT INTO t SELECT i::INTEGER, i::BIGINT, i*1.0, 'x'||i, i::INTEGER "
+          "FROM range(100) tbl(i)");
+  exec_ok(*env.con, "CHECKPOINT");
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*env.con, "t");
+
+  auto cols  = all_cols();
+  auto types = all_types();
+  auto md    = walk_all(storage, *env.con->context, cols, types);  // block-backed, NOT host-backed
+
+  duckdb_native_ingestible_table_info info;
+  info.storage         = &storage;
+  info.context         = env.con->context.get();
+  info.projected_cols  = cols;
+  info.projected_types = types;
+
+  auto mem_mgr    = initialize_memory_manager();
+  auto* gpu_space = sirius::scan_test_utils::get_space(*mem_mgr, cucascade::memory::Tier::GPU);
+  REQUIRE(gpu_space != nullptr);
+  rmm::cuda_stream stream;
+
+  bool threw_datasource = false;
+  try {
+    auto table =
+      decode_duckdb_native_split(md, info, /*datasource=*/nullptr, *gpu_space, stream.view());
+  } catch (std::exception const& e) {
+    threw_datasource = std::string(e.what()).find("datasource") != std::string::npos;
+  }
+  REQUIRE(threw_datasource);
+}

--- a/test/cpp/scan/test_duckdb_native_host_backed_decode.cpp
+++ b/test/cpp/scan/test_duckdb_native_host_backed_decode.cpp
@@ -42,6 +42,8 @@
 #include <op/scan/duckdb_native_decoder.hpp>
 #include <op/scan/duckdb_native_gpu_ingestible.hpp>
 #include <op/scan/duckdb_native_metadata.hpp>
+#include <op/scan/sirius_gpu_scan_operator_data.hpp>
+#include <scan_manager/mvcc_chunk_mask.hpp>
 #include <unistd.h>
 
 #include <cstdint>
@@ -377,4 +379,79 @@ TEST_CASE("file reads staged without a datasource throw loudly",
     threw_datasource = std::string(e.what()).find("datasource") != std::string::npos;
   }
   REQUIRE(threw_datasource);
+}
+
+TEST_CASE("materialize_table applies the mvcc keep-mask to metadata splits",
+          "[scan][duckdb_native_host_backed]")
+{
+  host_backed_test_db env;
+  build_table(*env.con);
+  exec_ok(*env.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*env.con, "t");
+
+  auto cols         = all_cols();
+  auto types        = all_types();
+  auto md           = walk_all(storage, *env.con->context, cols, types);
+  auto exp          = fetch_expected(*env.con);
+  auto const n_rows = exp.id.size();
+
+  auto mem_mgr    = initialize_memory_manager();
+  auto* gpu_space = sirius::scan_test_utils::get_space(*mem_mgr, cucascade::memory::Tier::GPU);
+  REQUIRE(gpu_space != nullptr);
+  rmm::cuda_stream stream;
+
+  std::vector<std::shared_ptr<void>> keepalive;
+  host_back_segments(*env.con->context, storage, md, keepalive, /*clear_block_ids=*/true);
+
+  auto info             = std::make_unique<duckdb_native_ingestible_table_info>();
+  info->storage         = &storage;
+  info->context         = env.con->context.get();
+  info->projected_cols  = cols;
+  info->projected_types = types;
+  auto ingestible       = make_ingestible(std::move(info));
+
+  // Keep every third row.
+  auto const n_words = (n_rows + 31) / 32;
+  auto words         = std::make_shared<std::vector<std::uint32_t>>(n_words, 0u);
+  std::size_t kept   = 0;
+  for (std::size_t i = 0; i < n_rows; ++i) {
+    if (i % 3 == 0) {
+      (*words)[i / 32] |= (1u << (i % 32));
+      ++kept;
+    }
+  }
+
+  SECTION("kept rows survive, dropped rows disappear")
+  {
+    auto sinfo               = std::make_unique<duckdb_native_scan_info>();
+    sinfo->row_groups        = std::move(md);
+    sinfo->host_backed_only  = true;
+    sinfo->staging_keepalive = keepalive;
+    scan_operator_input input(std::unique_ptr<scan_info>(std::move(sinfo)));
+    input.gpu_memory_space = gpu_space;
+    input.mvcc_keep_mask   = sirius::scan_manager::mvcc_chunk_mask{
+      std::shared_ptr<std::uint32_t[]>(words, words->data()), n_rows};
+
+    auto result = ingestible->materialize_table(input, stream.view());
+    auto view   = result.table.view();
+    REQUIRE(static_cast<std::size_t>(view.num_rows()) == kept);
+    auto ids = download<int32_t>(view.column(0).data<int32_t>(), kept, stream.view());
+    for (std::size_t k = 0; k < kept; ++k) {
+      if (ids[k] != exp.id[k * 3]) { FAIL("kept-row mismatch at " << k); }
+    }
+  }
+
+  SECTION("row-count mismatch throws")
+  {
+    auto sinfo               = std::make_unique<duckdb_native_scan_info>();
+    sinfo->row_groups        = std::move(md);
+    sinfo->host_backed_only  = true;
+    sinfo->staging_keepalive = keepalive;
+    scan_operator_input input(std::unique_ptr<scan_info>(std::move(sinfo)));
+    input.gpu_memory_space = gpu_space;
+    input.mvcc_keep_mask   = sirius::scan_manager::mvcc_chunk_mask{
+      std::shared_ptr<std::uint32_t[]>(words, words->data()), n_rows - 1};
+
+    REQUIRE_THROWS(ingestible->materialize_table(input, stream.view()));
+  }
 }

--- a/test/cpp/scan/test_duckdb_native_host_backed_decode.cpp
+++ b/test/cpp/scan/test_duckdb_native_host_backed_decode.cpp
@@ -326,15 +326,6 @@ TEST_CASE("host-backed decode matches SQL with zero file reads",
       decode_duckdb_native_split(md, info, /*datasource=*/nullptr, *gpu_space, stream.view());
     require_matches_expected(*table, exp, stream.view());
   }
-
-  SECTION("carried partition stats replace the ClientContext fetch")
-  {
-    host_back_segments(*env.con->context, storage, md, keepalive, /*clear_block_ids=*/true);
-    duckdb::vector<duckdb::PartitionStatistics> carried;  // no CONSTANT segments -> never consulted
-    auto table = decode_duckdb_native_split(
-      md, info, /*datasource=*/nullptr, *gpu_space, stream.view(), &carried);
-    require_matches_expected(*table, exp, stream.view());
-  }
 }
 
 TEST_CASE("file reads staged without a datasource throw loudly",

--- a/test/cpp/scan/test_duckdb_native_walker.cpp
+++ b/test/cpp/scan/test_duckdb_native_walker.cpp
@@ -171,6 +171,70 @@ TEST_CASE("walker accepts varchar below the overflow limit",
   REQUIRE_FALSE(md.row_groups.empty());
 }
 
+TEST_CASE("walker marks all-NULL constant validity and snapshots constant stats",
+          "[scan][duckdb_native_walker]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(k INTEGER, v INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range, NULL FROM range(3000)");
+  exec_ok(con, "CHECKPOINT");
+  auto& storage = get_storage(con, "t");
+
+  std::vector<projected_column> cols   = {real_col(0), real_col(1)};
+  std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER),
+                                          sirius::logical_type::make(sirius::type_id::INTEGER)};
+  auto md                              = walk_all(storage, *con.context, cols, ts);
+  REQUIRE(md.viable);
+  REQUIRE(md.row_groups.size() == 1);
+
+  // k never holds NULLs, so no validity segment carries the marker.
+  for (const auto& s : md.row_groups[0].columns[0].validity_segments) {
+    REQUIRE_FALSE(s.all_null);
+  }
+  // v is all-NULL: CONSTANT validity with the all-null marker, and the
+  // CONSTANT data segment snapshots its own stats for the value decode.
+  bool saw_all_null = false;
+  for (const auto& s : md.row_groups[0].columns[1].validity_segments) {
+    if (!s.all_null) { continue; }
+    saw_all_null = true;
+    REQUIRE(s.compression == duckdb::CompressionType::COMPRESSION_CONSTANT);
+  }
+  REQUIRE(saw_all_null);
+  bool saw_constant = false;
+  for (const auto& s : md.row_groups[0].columns[1].data_segments) {
+    if (s.compression != duckdb::CompressionType::COMPRESSION_CONSTANT) { continue; }
+    saw_constant = true;
+    REQUIRE(s.segment_stats != nullptr);
+  }
+  REQUIRE(saw_constant);
+}
+
+TEST_CASE("walker marks all-NULL constant validity on ARRAY trees", "[scan][duckdb_native_walker]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(a INTEGER[3])");
+  exec_ok(con, "INSERT INTO t SELECT NULL::INTEGER[3] FROM range(3000)");
+  exec_ok(con, "CHECKPOINT");
+  auto& storage = get_storage(con, "t");
+
+  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<sirius::logical_type> ts = {
+    sirius::logical_type::make_array(sirius::logical_type::make(sirius::type_id::INTEGER), 3)};
+  auto md = walk_all(storage, *con.context, cols, ts);
+  REQUIRE(md.viable);
+  REQUIRE_FALSE(md.row_groups.empty());
+
+  // Array-level validity (routed into data_segments) carries the marker for
+  // a fully-NULL ARRAY column.
+  bool saw_all_null = false;
+  for (const auto& rg : md.row_groups) {
+    for (const auto& s : rg.columns[0].data_segments) {
+      if (s.all_null) { saw_all_null = true; }
+    }
+  }
+  REQUIRE(saw_all_null);
+}
+
 // TEMPORARILY DISABLED: these cases call the removed monolithic walk_duckdb_native_metadata().
 // TODO: migrate to prepare_duckdb_native_walk() + walk_duckdb_native_row_group_range() and
 // re-enable — the duckdb_native_row_group_range result exposes the same .viable / .row_groups /

--- a/test/cpp/scan/test_parquet_scan_sizing.cpp
+++ b/test/cpp/scan/test_parquet_scan_sizing.cpp
@@ -193,6 +193,16 @@ TEST_CASE("parquet batches are capped by decode working set", "[scan][parquet][s
   scan::scan_operator_input input{std::move(first.front())};
   CHECK(input.get_estimated_size_in_bytes() == 20);
   CHECK(input.get_estimated_working_set_size_in_bytes() == 60);
+
+  // A keep-masked metadata split adds the filter-by-copy envelope on top of
+  // the decode working set: compacted output (input-bounded) + the BOOL8
+  // expansion (1 B/row) + the uploaded mask words.
+  scan::scan_operator_input masked{std::move(tail.front())};
+  constexpr std::size_t rows = 40;
+  auto words = std::make_shared<std::vector<std::uint32_t>>((rows + 31) / 32, 0xFFFFFFFFu);
+  masked.mvcc_keep_mask = sirius::scan_manager::mvcc_chunk_mask{{words, words->data()}, rows};
+  CHECK(masked.get_estimated_working_set_size_in_bytes() ==
+        2 * 60 + rows + masked.mvcc_keep_mask.view().size_bytes());
 }
 
 TEST_CASE("parquet synthetic filter-only columns only increase the decode working set",

--- a/test/cpp/scan_manager/test_insert_delta_job.cpp
+++ b/test/cpp/scan_manager/test_insert_delta_job.cpp
@@ -30,6 +30,8 @@
 #include <duckdb/storage/data_table.hpp>
 #include <exec/scoped_dispatcher.hpp>
 #include <exec/thread_pool.hpp>
+#include <io/kvikio/kvikio_context.hpp>
+#include <io/sirius_datasource.hpp>
 #include <memory/topology_index.hpp>
 #include <op/scan/duckdb_native_gpu_ingestible.hpp>
 #include <scan_manager/insert_delta_job.hpp>
@@ -39,6 +41,7 @@
 #include <cstdio>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 using sirius::scan_manager::cut_delta_splits_for_op;
@@ -307,7 +310,6 @@ TEST_CASE("insert-delta job: per-operator cuts subset the union and share storag
   REQUIRE(info_a.row_groups[0].columns.size() == 1);
   REQUIRE(info_a.row_groups[0].columns[0].column_id == 1);
   REQUIRE(info_a.row_groups[0].row_count == 1600);
-  REQUIRE(info_a.carried_partition_stats != nullptr);
   REQUIRE_FALSE(info_a.staging_keepalive.empty());
   // The host-backed descriptor points into the bundle's slab.
   auto const& seg_a = info_a.row_groups[0].columns[0].data_segments.at(0);
@@ -322,6 +324,107 @@ TEST_CASE("insert-delta job: per-operator cuts subset the union and share storag
   REQUIRE(splits_a[0].mask.words.get() == splits_b[0].mask.words.get());
   REQUIRE(splits_a[0].mask.has_mask());  // the delete keeps the mask alive
 
+  exec_ok(*tdb.con, "ROLLBACK");
+}
+
+TEST_CASE("insert-delta job: file-backed splits each own a duplicated datasource",
+          "[insert_delta_job][scan_manager]")
+{
+  job_test_db tdb;
+  exec_ok(*tdb.con, "SET threads TO 1");
+  exec_ok(*tdb.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(10000)");
+  exec_ok(*tdb.con, "CHECKPOINT");
+  // The bulk commit flushes persistent row groups (file-backed bundles); the
+  // separate small commit stays transient (a host-only bundle).
+  exec_ok(*tdb.con, "INSERT INTO t SELECT (10000+range)::INTEGER FROM range(250000)");
+  exec_ok(*tdb.con, "INSERT INTO t VALUES (260000)");
+
+  exec_ok(*tdb.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*tdb.con, "t");
+  std::vector<insert_delta_job_request> requests;
+  requests.push_back(make_request(
+    *tdb.con, storage, 10000, {0}, {sirius::logical_type::make(sirius::type_id::INTEGER)}));
+  requests[0].approximate_batch_size = 1;  // one bundle per row group
+  run(requests);
+  auto const& request = requests[0];
+  REQUIRE(request.bundles.size() >= 2);
+
+  auto ioctx = std::make_shared<sirius::io::kvikio_context>();
+  std::shared_ptr<sirius::io::sirius_datasource> datasource = ioctx->open_datasource(tdb.path);
+
+  std::vector<sirius::op::scan::projected_column> op{real_col(0)};
+  auto splits = cut_delta_splits_for_op(request, op, datasource, /*block_manager=*/nullptr);
+  REQUIRE(splits.size() == request.bundles.size());
+
+  // The datasource's prefetch handle is per-scan state: every file-backed
+  // split must own its own duplicate, never the shared original; host-only
+  // splits carry none.
+  std::unordered_set<sirius::io::sirius_datasource const*> seen;
+  bool saw_host_only = false;
+  for (auto const& split : splits) {
+    if (split.info->host_backed_only) {
+      saw_host_only = true;
+      REQUIRE(split.info->datasource == nullptr);
+      continue;
+    }
+    REQUIRE(split.info->datasource != nullptr);
+    REQUIRE(split.info->datasource.get() != datasource.get());
+    REQUIRE(seen.insert(split.info->datasource.get()).second);
+  }
+  REQUIRE(seen.size() >= 2);
+  REQUIRE(saw_host_only);
+  exec_ok(*tdb.con, "ROLLBACK");
+}
+
+TEST_CASE("insert-delta job: blockless-only splits carry no datasource",
+          "[insert_delta_job][scan_manager]")
+{
+  job_test_db tdb;
+  exec_ok(*tdb.con, "SET threads TO 1");
+  exec_ok(*tdb.con,
+          "CREATE TABLE t AS SELECT range::INTEGER AS k, range::INTEGER AS v FROM range(10000)");
+  exec_ok(*tdb.con, "CHECKPOINT");
+  // Constant column: the bulk-flushed v segments are blockless CONSTANT.
+  exec_ok(*tdb.con, "INSERT INTO t SELECT (10000+range)::INTEGER, 7 FROM range(130000)");
+
+  exec_ok(*tdb.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*tdb.con, "t");
+  std::vector<insert_delta_job_request> requests;
+  requests.push_back(make_request(*tdb.con,
+                                  storage,
+                                  10000,
+                                  {0, 1},
+                                  {sirius::logical_type::make(sirius::type_id::INTEGER),
+                                   sirius::logical_type::make(sirius::type_id::INTEGER)}));
+  requests[0].approximate_batch_size = 1;  // one bundle per row group
+  run(requests);
+  auto const& request = requests[0];
+
+  auto ioctx = std::make_shared<sirius::io::kvikio_context>();
+  std::shared_ptr<sirius::io::sirius_datasource> datasource = ioctx->open_datasource(tdb.path);
+
+  // An operator projecting only the constant column cuts splits whose
+  // persistent descriptors are all blockless: nothing reads the file, so the
+  // split is host-backed-only and carries no datasource.
+  std::vector<sirius::op::scan::projected_column> op{real_col(1)};
+  auto splits             = cut_delta_splits_for_op(request, op, datasource, nullptr);
+  bool saw_blockless_only = false;
+  for (auto const& split : splits) {
+    auto const& segs = split.info->row_groups.at(0).columns.at(0).data_segments;
+    bool blockless   = false;
+    for (auto const& s : segs) {
+      if (s.host_ptr == nullptr && s.block_id < 0) {
+        blockless = true;
+        REQUIRE(s.compression == duckdb::CompressionType::COMPRESSION_CONSTANT);
+        REQUIRE(s.segment_stats != nullptr);
+      }
+    }
+    if (!blockless) { continue; }
+    saw_blockless_only = true;
+    REQUIRE(split.info->host_backed_only);
+    REQUIRE(split.info->datasource == nullptr);
+  }
+  REQUIRE(saw_blockless_only);
   exec_ok(*tdb.con, "ROLLBACK");
 }
 

--- a/test/cpp/scan_manager/test_insert_delta_job.cpp
+++ b/test/cpp/scan_manager/test_insert_delta_job.cpp
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Gates for the prepare-time insert-delta job: bundles must carry finished
+// pinned staging + masks before serving starts, masks survive only where
+// rows are invisible (finalize drops all-invisible bundles and unmasks
+// all-visible ones), bundle planning respects the byte budget and the
+// validity byte-alignment cut, and per-operator cuts subset the union while
+// sharing the staged bytes and mask words.
+
+#include "operator/operator_test_utils.hpp"
+
+#include <catch.hpp>
+#include <cucascade/memory/topology_discovery.hpp>
+#include <duckdb.hpp>
+#include <duckdb/catalog/catalog.hpp>
+#include <duckdb/catalog/catalog_entry/duck_table_entry.hpp>
+#include <duckdb/main/client_context.hpp>
+#include <duckdb/storage/data_table.hpp>
+#include <exec/scoped_dispatcher.hpp>
+#include <exec/thread_pool.hpp>
+#include <memory/topology_index.hpp>
+#include <op/scan/duckdb_native_gpu_ingestible.hpp>
+#include <scan_manager/insert_delta_job.hpp>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+using sirius::scan_manager::cut_delta_splits_for_op;
+using sirius::scan_manager::insert_delta_job_request;
+using sirius::scan_manager::run_insert_delta_jobs;
+
+namespace {
+
+void exec_ok(duckdb::Connection& con, const std::string& q)
+{
+  auto result = con.Query(q);
+  REQUIRE(result);
+  if (result->HasError()) {
+    INFO("query failed: " << q << "\n  error: " << result->GetError());
+    REQUIRE_FALSE(result->HasError());
+  }
+}
+
+struct job_test_db {
+  std::string path;
+  std::unique_ptr<duckdb::DuckDB> db;
+  std::unique_ptr<duckdb::Connection> con;
+
+  job_test_db()
+  {
+    static int counter = 0;
+    path               = "/tmp/sirius_insert_delta_job_test_" + std::to_string(::getpid()) + "_" +
+           std::to_string(counter++) + ".db";
+    std::remove(path.c_str());
+    std::remove((path + ".wal").c_str());
+    db  = std::make_unique<duckdb::DuckDB>(path);
+    con = std::make_unique<duckdb::Connection>(*db);
+    con->Query("SET gpu_execution = false;");
+  }
+
+  ~job_test_db()
+  {
+    con.reset();
+    db.reset();
+    std::remove(path.c_str());
+    std::remove((path + ".wal").c_str());
+  }
+};
+
+/// Requires an active transaction on @p con.
+duckdb::DataTable& resolve_storage(duckdb::Connection& con, const std::string& table_name)
+{
+  auto& ctx     = *con.context;
+  auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
+  duckdb::CatalogTransaction txn(catalog, ctx);
+  auto& schema = catalog.GetSchema(txn, "main");
+  auto entry   = schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, table_name);
+  REQUIRE(entry);
+  return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
+}
+
+bool bit_at(std::span<std::uint32_t const> words, std::size_t i)
+{
+  return ((words[i / 32] >> (i % 32)) & 1u) != 0;
+}
+
+struct job_env {
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> mgr;
+  sirius::memory::topology_index topology;
+  std::vector<int> gpu_ids{0};
+
+  job_env()
+    : mgr(sirius::test::operator_utils::initialize_memory_manager()),
+      topology(cucascade::memory::system_topology_info{}, std::vector<int>{0})
+  {
+  }
+};
+
+job_env& env()
+{
+  static job_env e;
+  return e;
+}
+
+insert_delta_job_request make_request(duckdb::Connection& con,
+                                      duckdb::DataTable& storage,
+                                      std::size_t n_cache,
+                                      std::vector<duckdb::storage_t> cols,
+                                      std::vector<sirius::logical_type> types)
+{
+  insert_delta_job_request request;
+  request.storage     = &storage;
+  request.context     = con.context.get();
+  request.n_cache     = n_cache;
+  request.union_cols  = std::move(cols);
+  request.union_types = std::move(types);
+  request.entry_name  = "t";
+  return request;
+}
+
+sirius::op::scan::projected_column real_col(duckdb::idx_t col_id)
+{
+  sirius::op::scan::projected_column pc;
+  pc.storage_idx = duckdb::StorageIndex(col_id);
+  pc.is_rowid    = false;
+  return pc;
+}
+
+void run(std::vector<insert_delta_job_request>& requests)
+{
+  auto& e = env();
+  sirius::exec::static_thread_pool pool(4);
+  sirius::exec::scoped_dispatcher dispatcher(pool, 4);
+  run_insert_delta_jobs(requests, dispatcher, *e.mgr, e.topology, e.gpu_ids);
+}
+
+}  // namespace
+
+TEST_CASE("insert-delta job: bundles carry staged bytes and oracle-exact masks",
+          "[insert_delta_job][scan_manager]")
+{
+  job_test_db tdb;
+  exec_ok(*tdb.con, "SET threads TO 1");
+  exec_ok(*tdb.con,
+          "CREATE TABLE t AS SELECT range::INTEGER AS k, (range*10)::BIGINT AS v "
+          "FROM range(130000)");
+  exec_ok(*tdb.con, "CHECKPOINT");
+  exec_ok(*tdb.con,
+          "INSERT INTO t SELECT (130000+range)::INTEGER, ((130000+range)*10)::BIGINT "
+          "FROM range(5000)");
+  exec_ok(*tdb.con, "DELETE FROM t WHERE k IN (130001, 132048, 134999)");
+
+  exec_ok(*tdb.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*tdb.con, "t");
+  std::vector<insert_delta_job_request> requests;
+  requests.push_back(make_request(*tdb.con,
+                                  storage,
+                                  130000,
+                                  {0, 1},
+                                  {sirius::logical_type::make(sirius::type_id::INTEGER),
+                                   sirius::logical_type::make(sirius::type_id::BIGINT)}));
+  run(requests);
+
+  auto const& request = requests[0];
+  REQUIRE(request.bundles.size() == 1);
+  auto const& bundle = request.bundles[0];
+  REQUIRE(bundle.total_rows == 5000);
+  REQUIRE(bundle.slab_base != nullptr);
+  REQUIRE(bundle.preferred_device == 0);
+
+  REQUIRE(bundle.mask.has_mask());
+  REQUIRE(bundle.mask.row_count == 5000);
+  for (std::size_t i = 0; i < 5000; ++i) {
+    auto const rowid   = 130000 + i;
+    bool const deleted = (rowid == 130001 || rowid == 132048 || rowid == 134999);
+    if (bit_at(bundle.mask.view(), i) != !deleted) {
+      INFO("delta rowid " << rowid);
+      REQUIRE(bit_at(bundle.mask.view(), i) == !deleted);
+    }
+  }
+  exec_ok(*tdb.con, "ROLLBACK");
+}
+
+TEST_CASE("insert-delta job: all-visible bundles serve unmasked",
+          "[insert_delta_job][scan_manager]")
+{
+  job_test_db tdb;
+  exec_ok(*tdb.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(20000)");
+  exec_ok(*tdb.con, "CHECKPOINT");
+  exec_ok(*tdb.con, "INSERT INTO t SELECT (20000+range)::INTEGER FROM range(1000)");
+
+  exec_ok(*tdb.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*tdb.con, "t");
+  std::vector<insert_delta_job_request> requests;
+  requests.push_back(make_request(
+    *tdb.con, storage, 20000, {0}, {sirius::logical_type::make(sirius::type_id::INTEGER)}));
+  run(requests);
+
+  REQUIRE(requests[0].bundles.size() == 1);
+  REQUIRE(requests[0].bundles[0].total_rows == 1000);
+  REQUIRE_FALSE(requests[0].bundles[0].mask.has_mask());
+  exec_ok(*tdb.con, "ROLLBACK");
+}
+
+TEST_CASE("insert-delta job: all-invisible bundles are dropped", "[insert_delta_job][scan_manager]")
+{
+  job_test_db tdb;
+  exec_ok(*tdb.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(1000)");
+  exec_ok(*tdb.con, "CHECKPOINT");
+
+  // Pin the snapshot BEFORE the second connection's insert (the per-database
+  // transaction spawns lazily, so touch the table).
+  exec_ok(*tdb.con, "BEGIN TRANSACTION");
+  exec_ok(*tdb.con, "SELECT count(*) FROM t");
+  duckdb::Connection con2(*tdb.db);
+  exec_ok(con2, "INSERT INTO t SELECT (1000+range)::INTEGER FROM range(500)");
+
+  auto& storage = resolve_storage(*tdb.con, "t");
+  std::vector<insert_delta_job_request> requests;
+  requests.push_back(make_request(
+    *tdb.con, storage, 1000, {0}, {sirius::logical_type::make(sirius::type_id::INTEGER)}));
+  run(requests);
+
+  REQUIRE_FALSE(requests[0].plan.empty());  // the physical rows were captured...
+  REQUIRE(requests[0].bundles.empty());     // ...but nothing is visible to serve
+  exec_ok(*tdb.con, "ROLLBACK");
+}
+
+TEST_CASE("insert-delta job: a tiny byte budget splits bundles per row group",
+          "[insert_delta_job][scan_manager]")
+{
+  job_test_db tdb;
+  exec_ok(*tdb.con, "SET threads TO 1");
+  exec_ok(*tdb.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(10000)");
+  exec_ok(*tdb.con, "CHECKPOINT");
+  // Bulk insert: MergeStorage lands >= 2 persistent delta row groups.
+  exec_ok(*tdb.con, "INSERT INTO t SELECT (10000+range)::INTEGER FROM range(130000)");
+
+  exec_ok(*tdb.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*tdb.con, "t");
+  std::vector<insert_delta_job_request> requests;
+  requests.push_back(make_request(
+    *tdb.con, storage, 10000, {0}, {sirius::logical_type::make(sirius::type_id::INTEGER)}));
+  requests[0].approximate_batch_size = 1;  // force one bundle per row group
+  run(requests);
+
+  auto const& request = requests[0];
+  REQUIRE(request.plan.row_groups.size() >= 2);
+  REQUIRE(request.bundles.size() == request.plan.row_groups.size());
+  for (auto const& bundle : request.bundles) {
+    REQUIRE(bundle.rg_indices.size() == 1);
+    REQUIRE_FALSE(bundle.mask.has_mask());  // everything visible
+  }
+  exec_ok(*tdb.con, "ROLLBACK");
+}
+
+TEST_CASE("insert-delta job: per-operator cuts subset the union and share storage",
+          "[insert_delta_job][scan_manager]")
+{
+  job_test_db tdb;
+  exec_ok(*tdb.con,
+          "CREATE TABLE t AS SELECT range::INTEGER AS k, (range*10)::BIGINT AS v "
+          "FROM range(20000)");
+  exec_ok(*tdb.con, "CHECKPOINT");
+  exec_ok(*tdb.con,
+          "INSERT INTO t SELECT (20000+range)::INTEGER, ((20000+range)*10)::BIGINT "
+          "FROM range(1600)");
+  exec_ok(*tdb.con, "DELETE FROM t WHERE k = 20005");
+
+  exec_ok(*tdb.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*tdb.con, "t");
+  std::vector<insert_delta_job_request> requests;
+  requests.push_back(make_request(*tdb.con,
+                                  storage,
+                                  20000,
+                                  {0, 1},
+                                  {sirius::logical_type::make(sirius::type_id::INTEGER),
+                                   sirius::logical_type::make(sirius::type_id::BIGINT)}));
+  run(requests);
+  auto const& request = requests[0];
+  REQUIRE(request.bundles.size() == 1);
+
+  // Op A projects only column v (storage index 1).
+  std::vector<sirius::op::scan::projected_column> op_a{real_col(1)};
+  auto splits_a =
+    cut_delta_splits_for_op(request, op_a, /*datasource=*/nullptr, /*block_manager=*/nullptr);
+  REQUIRE(splits_a.size() == 1);
+  auto const& info_a = *splits_a[0].info;
+  REQUIRE(info_a.host_backed_only);
+  REQUIRE(info_a.row_groups.size() == 1);
+  REQUIRE(info_a.row_groups[0].columns.size() == 1);
+  REQUIRE(info_a.row_groups[0].columns[0].column_id == 1);
+  REQUIRE(info_a.row_groups[0].row_count == 1600);
+  REQUIRE(info_a.carried_partition_stats != nullptr);
+  REQUIRE_FALSE(info_a.staging_keepalive.empty());
+  // The host-backed descriptor points into the bundle's slab.
+  auto const& seg_a = info_a.row_groups[0].columns[0].data_segments.at(0);
+  REQUIRE(seg_a.host_ptr != nullptr);
+  REQUIRE(seg_a.host_ptr >= request.bundles[0].slab_base);
+
+  // Op B projects both columns; masks share the same words.
+  std::vector<sirius::op::scan::projected_column> op_b{real_col(0), real_col(1)};
+  auto splits_b = cut_delta_splits_for_op(request, op_b, nullptr, nullptr);
+  REQUIRE(splits_b.size() == 1);
+  REQUIRE(splits_b[0].info->row_groups[0].columns.size() == 2);
+  REQUIRE(splits_a[0].mask.words.get() == splits_b[0].mask.words.get());
+  REQUIRE(splits_a[0].mask.has_mask());  // the delete keeps the mask alive
+
+  exec_ok(*tdb.con, "ROLLBACK");
+}
+
+TEST_CASE("insert-delta job: no delta is a no-op", "[insert_delta_job][scan_manager]")
+{
+  job_test_db tdb;
+  exec_ok(*tdb.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(1000)");
+  exec_ok(*tdb.con, "CHECKPOINT");
+
+  exec_ok(*tdb.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*tdb.con, "t");
+  std::vector<insert_delta_job_request> requests;
+  requests.push_back(make_request(
+    *tdb.con, storage, 1000, {0}, {sirius::logical_type::make(sirius::type_id::INTEGER)}));
+  run(requests);
+  REQUIRE(requests[0].plan.empty());
+  REQUIRE(requests[0].bundles.empty());
+  exec_ok(*tdb.con, "ROLLBACK");
+}

--- a/test/cpp/scan_manager/test_insert_delta_job.cpp
+++ b/test/cpp/scan_manager/test_insert_delta_job.cpp
@@ -39,6 +39,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -425,6 +426,55 @@ TEST_CASE("insert-delta job: blockless-only splits carry no datasource",
     REQUIRE(split.info->datasource == nullptr);
   }
   REQUIRE(saw_blockless_only);
+  exec_ok(*tdb.con, "ROLLBACK");
+}
+
+TEST_CASE("insert-delta job: a delta spanning multiple capture ranges merges in order",
+          "[insert_delta_job][scan_manager]")
+{
+  // One row group per capture range so the delta below spans several
+  // dispatcher tasks.
+  setenv("SIRIUS_METADATA_PARSE_CHUNK", "1", 1);
+  struct chunk_env_restore {
+    ~chunk_env_restore() { unsetenv("SIRIUS_METADATA_PARSE_CHUNK"); }
+  } restore;
+
+  job_test_db tdb;
+  exec_ok(*tdb.con, "SET threads TO 1");
+  exec_ok(*tdb.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(10000)");
+  exec_ok(*tdb.con, "CHECKPOINT");
+  exec_ok(*tdb.con, "INSERT INTO t SELECT (10000+range)::INTEGER FROM range(250000)");
+  exec_ok(*tdb.con, "INSERT INTO t VALUES (260000)");
+
+  exec_ok(*tdb.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*tdb.con, "t");
+  std::vector<insert_delta_job_request> requests;
+  requests.push_back(make_request(
+    *tdb.con, storage, 10000, {0}, {sirius::logical_type::make(sirius::type_id::INTEGER)}));
+  run(requests);
+
+  auto const& request = requests[0];
+  REQUIRE(request.plan.row_groups.size() >= 3);
+
+  // Row-group order, contiguous boundaries, and filled columns survive the
+  // parallel merge.
+  std::size_t expected_start = 10000;
+  std::size_t plan_rows      = 0;
+  for (auto const& rg : request.plan.row_groups) {
+    REQUIRE(rg.row_group_start == expected_start);
+    REQUIRE(rg.k_offset == 0);
+    REQUIRE_FALSE(rg.columns.empty());
+    REQUIRE(rg.decoded_bytes_budget == rg.row_count * sizeof(int32_t));
+    expected_start += rg.row_count;
+    plan_rows += rg.row_count;
+  }
+  REQUIRE(plan_rows == 250001);
+
+  std::size_t bundle_rows = 0;
+  for (auto const& b : request.bundles) {
+    bundle_rows += b.total_rows;
+  }
+  REQUIRE(bundle_rows == 250001);
   exec_ok(*tdb.con, "ROLLBACK");
 }
 

--- a/test/cpp/scan_manager/test_insert_delta_job.cpp
+++ b/test/cpp/scan_manager/test_insert_delta_job.cpp
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-// Gates for the prepare-time insert-delta job: bundles must carry finished
-// pinned staging + masks before serving starts, masks survive only where
-// rows are invisible (finalize drops all-invisible bundles and unmasks
-// all-visible ones), bundle planning respects the byte budget and the
-// validity byte-alignment cut, and per-operator cuts subset the union while
-// sharing the staged bytes and mask words.
+// Tests for the prepare-time insert-delta job: bundle staging and masks,
+// finalize (all-invisible bundles dropped, all-visible ones unmasked),
+// byte-budget planning, and per-operator cuts that share the staged storage.
+// Capture-level tests live in test/cpp/scan/test_duckdb_insert_delta.cpp.
 
 #include "operator/operator_test_utils.hpp"
 
@@ -226,8 +224,8 @@ TEST_CASE("insert-delta job: all-invisible bundles are dropped", "[insert_delta_
   exec_ok(*tdb.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(1000)");
   exec_ok(*tdb.con, "CHECKPOINT");
 
-  // Pin the snapshot BEFORE the second connection's insert (the per-database
-  // transaction spawns lazily, so touch the table).
+  // Pin the snapshot before the second connection's insert: the transaction
+  // spawns lazily, so touch the table.
   exec_ok(*tdb.con, "BEGIN TRANSACTION");
   exec_ok(*tdb.con, "SELECT count(*) FROM t");
   duckdb::Connection con2(*tdb.db);

--- a/test/cpp/scan_manager/test_mvcc_mask_job.cpp
+++ b/test/cpp/scan_manager/test_mvcc_mask_job.cpp
@@ -271,6 +271,58 @@ TEST_CASE("run_mvcc_mask_jobs keeps pinned masks for dirty chunks only",
   exec_ok(*tdb.con, "ROLLBACK");
 }
 
+TEST_CASE("run_mvcc_mask_jobs fills checkpoint-grown chunks through a single task",
+          "[mvcc_mask_job][scan_manager]")
+{
+  auto& e = env();
+  job_test_db tdb;
+  // Checkpoint, append, checkpoint again: the append keeps its own row group,
+  // so its slice starts at bit offset 50000 — not a mask-word multiple — and
+  // the job must serialize this chunk's fill instead of slicing it across
+  // tasks.
+  exec_ok(*tdb.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(50000)");
+  exec_ok(*tdb.con, "CHECKPOINT");
+  exec_ok(*tdb.con, "INSERT INTO t SELECT range::INTEGER + 50000 FROM range(100)");
+  exec_ok(*tdb.con, "CHECKPOINT");
+  exec_ok(*tdb.con, "DELETE FROM t WHERE k IN (49995, 49999, 50000, 50001, 50031, 50032)");
+
+  exec_ok(*tdb.con, "BEGIN TRANSACTION");
+  auto& storage = resolve_storage(*tdb.con, "t");
+  auto metadata = make_metadata(*tdb.con, storage);
+  REQUIRE(metadata.base_row_count_per_chunk.size() == 1);
+
+  auto* host_space = e.mgr->get_memory_space(cucascade::memory::Tier::HOST, 0);
+  REQUIRE(host_space != nullptr);
+
+  mvcc_mask_job_request request;
+  request.masks        = mvcc_chunk_mask_set(1);
+  request.metadata     = metadata;
+  request.storage      = &storage;
+  request.context      = tdb.con->context.get();
+  request.chunk_spaces = {host_space};
+  request.entry_name   = "t";
+  std::vector<mvcc_mask_job_request> requests;
+  requests.push_back(std::move(request));
+
+  sirius::exec::static_thread_pool pool(4);
+  sirius::exec::scoped_dispatcher dispatcher(pool, 4);
+  run_mvcc_mask_jobs(requests, dispatcher, *e.mgr, e.topology);
+
+  auto const& mask = requests[0].masks[0];
+  REQUIRE(mask.has_mask());
+  REQUIRE(mask.row_count == 50100);
+  for (std::size_t r = 0; r < 50100; ++r) {
+    bool const deleted =
+      (r == 49995 || r == 49999 || r == 50000 || r == 50001 || r == 50031 || r == 50032);
+    if (bit_at(mask.view(), r) != !deleted) {
+      INFO("row " << r);
+      REQUIRE(bit_at(mask.view(), r) == !deleted);
+    }
+  }
+
+  exec_ok(*tdb.con, "ROLLBACK");
+}
+
 TEST_CASE("run_mvcc_mask_jobs is a no-op for version-state-free tables",
           "[mvcc_mask_job][scan_manager]")
 {

--- a/test/cpp/scan_manager/test_mvcc_mask_job.cpp
+++ b/test/cpp/scan_manager/test_mvcc_mask_job.cpp
@@ -277,9 +277,8 @@ TEST_CASE("run_mvcc_mask_jobs fills checkpoint-grown chunks through a single tas
   auto& e = env();
   job_test_db tdb;
   // Checkpoint, append, checkpoint again: the append keeps its own row group,
-  // so its slice starts at bit offset 50000 — not a mask-word multiple — and
-  // the job must serialize this chunk's fill instead of slicing it across
-  // tasks.
+  // so its slice starts at unaligned bit offset 50000 and the job must fill
+  // this chunk in a single task instead of slicing it across tasks.
   exec_ok(*tdb.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(50000)");
   exec_ok(*tdb.con, "CHECKPOINT");
   exec_ok(*tdb.con, "INSERT INTO t SELECT range::INTEGER + 50000 FROM range(100)");


### PR DESCRIPTION
PR4 of #819 (PR3 = #1142). A duckdb-pinned table now keeps serving GPU queries after INSERTs land, instead of declining the whole query to CPU.

## The idea

The pin caches the checkpointed prefix. Everything after it is the *insert delta*, captured fresh per query and masked to that query's snapshot:

```
physical row space of the table
┌───────────────────────────────┬───────────────────────────────┐
│         [0, n_cache)          │       [n_cache, n_total)      │
│   pinned at CHECKPOINT time   │      inserted after pin       │
│   resident GPU/host chunks    │      read per query           │
│   + delete keep-mask (PR3)    │      + visibility keep-mask   │
└───────────────────────────────┴───────────────────────────────┘
```

## How a query is served

```
prepare_for_query
│
├─ pinned-entry match ──► queue one delta job per entry (self-join = one job)
│
├─ run delta jobs (blocks until done):
│     capture row groups overlapping [n_cache, n_total)
│     │
│     ├─ TRANSIENT segment (small append, uncompressed)
│     │     └─► memcpy into cuda-pinned staging, release DuckDB pin
│     │
│     └─ PERSISTENT segment (bulk append, MergeStorage, checkpoint-compressed)
│           └─► keep block refs; the normal file lane reads it at decode
│
│     count visible rows per snapshot
│     ├─ all invisible ──► drop the row group
│     └─ partly visible ──► bit-packed keep-mask
│     bundle to ~batch size
│
└─ serving: resident chunks first, then delta splits
      └─► existing decode kernels ──► apply keep-mask ──► downstream
```

No new kernels: delta splits are ordinary duckdb-native scan splits, decoded on GPU even for host-tier pins.

## What still declines to CPU (plan time, transparent)

- the querying transaction's own uncommitted rows (LocalStorage)
- rowid-only projections (e.g. bare `count(*)`)
- ARRAY projections while a delta exists
- string columns whose stats exceed the GPU decode limits

`pin_table` now refuses uncheckpointed tables with a clear message (`run CHECKPOINT before pinning`) instead of an accidental decoder error.

## Bonus: PR3 bug fix

Tables whose row groups grew across a checkpoint made the delete-mask capture throw (`slice offset ... not 32-row aligned`), silently sending every query to CPU. Fixed with a bit-exact `write_bit_range` and a single-task fallback for unaligned chunks.

## Testing

New unit suites for the decoder host lane, the delta capture, and the job orchestration; a 14-case `[pin_table_mvcc_insert]` integration matrix (bulk MergeStorage lane, older snapshots, host tier, self-join, varchar+NULLs, guard declines); the two PR3 insert-decline tests flipped to served. Full `make test` green: 1,960 cases.

## Next

Delta promotion (follow-up PR): cache the decoded delta bytes in the entry and recompute only the visibility mask per query, so a stable delta stops being re-staged every query.
