### PR TITLE
feat(s3): read S3 object keys literally to match AWS CLI semantics

### DIFF
--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -401,6 +401,10 @@ The scan manager builds one ioctx for the run: `uring_ioctx` when `use_sirius_da
 
 `rest_ioctx = templated_ioctx<rest_reactor>` handles `s3://` paths for AWS S3 and compatible stores such as MinIO. The `gs://` and `azure://` schemes parsed by `uri_parser` have no registered backend. DuckDB uses the read-only `sirius_httpfs` to bind transparent `read_parquet('s3://...')` queries, while scan-manager callers can open the same path directly through the datasource registry. S3 scans require GPU execution and have no DuckDB CPU fallback.
 
+**Key semantics.** The key portion of an `s3://` URI is literal text. `uri_parser` does not percent-decode it or split it at `?` or `#`; SigV4 applies RFC 3986 encoding when it builds the request, matching AWS CLI behavior. So `s3://bucket/my%20file.parquet` addresses the key `my%20file.parquet`; use an actual space to address `my file.parquet`.
+
+DuckDB still decodes Hive partition values, so `col=a%20b/` yields `a b`. Glob syntax is unchanged: `?` in a pattern is still a wildcard. A concrete key whose directory segment contains both `=` and a literal `?` is rejected, because DuckDB would drop that partition column; encode it as `%3F`. A `?` in the final filename is allowed.
+
 **Opening objects.** A generic open issues a blocking HEAD to obtain the object size. A `parquet_footer_probe` open uses a suffix-range GET to obtain both the size and the footer bytes; those bytes stay on the resulting `rest_io_object` and serve the binder's footer reads. If the suffix response cannot be used, the open falls back to HEAD. Parsed footer metadata is stored separately in the ioctx's `metadata_store`.
 
 **Reads.** Each `rest_reactor` runs a libcurl multi handle on one epoll worker thread and reuses a pool of easy handles. Ranged GETs are asynchronous and can scatter one response across adjacent destination segments. The response's `Content-Range` and byte count are checked before the request completes. HEAD, LIST, and footer-probe requests use blocking easy handles on the caller thread; they share DNS and TLS-session caches with the workers.

--- a/src/include/io/s3/s3_object_ref.hpp
+++ b/src/include/io/s3/s3_object_ref.hpp
@@ -24,12 +24,13 @@ namespace sirius::io::s3 {
  * @brief Object reference passed to the credential / authorizer seam.
  *
  * @c bucket carries the object-store bucket name (no scheme, no trailing
- * slashes). @c key carries the object key, RFC3986-decoded — the
- * provider / authorizer re-encodes for canonical URI construction.
+ * slashes). @c key carries the RAW, literal object key bytes (a `%`, `?` or
+ * `#` in the key is a literal byte, not an escape) — the provider / authorizer
+ * RFC3986-encodes it once for canonical URI construction, so a literal `%`
+ * becomes `%25` on the wire.
  *
- * Shared by both @c credential_provider (the legacy presign-only seam) and
- * @c s3_request_authorizer (the newer presigned/header seam) so the two
- * interfaces agree on the object-identity type.
+ * Used by @c s3_request_authorizer (the presigned/header signing seam) as the
+ * object-identity type.
  */
 struct s3_object_ref {
   std::string bucket;

--- a/src/include/io/s3/sirius_httpfs.hpp
+++ b/src/include/io/s3/sirius_httpfs.hpp
@@ -92,8 +92,9 @@ class sirius_httpfs : public duckdb::FileSystem {
   /// expands via one paginated S3 LIST (see @ref expand_glob) under four
   /// contracts: it is gated like @ref OpenFile (resolvable @c ClientContext,
   /// @c gpu_execution on, no CPU-fallback replay); each match carries its
-  /// LIST-provided size so the open needs no HEAD; a matched key containing a
-  /// percent-encoded sequence (@c % + two hex digits) throws; and zero matches
+  /// LIST-provided size so the open needs no HEAD; matched keys are embedded
+  /// literally, except a key with a literal @c '?' in a Hive partition segment
+  /// throws (it would be silently dropped from partitioning); and zero matches
   /// yield an empty vector.
   duckdb::vector<duckdb::OpenFileInfo> Glob(const std::string& path,
                                             duckdb::FileOpener* opener = nullptr) override;
@@ -108,17 +109,6 @@ class sirius_httpfs : public duckdb::FileSystem {
  protected:
   bool SupportsOpenFileExtended() const override { return true; }
 };
-
-/// Escape a literal S3 object key for embedding into an @c s3:// URI so the
-/// later @c sirius::io::parse() of that URI restores the exact key bytes.
-/// LIST returns keys as literal bytes, but the open path treats the produced
-/// string as a URI — @c '#' starts a fragment, @c '?' starts a query, and
-/// @c %xx percent-decodes — so exactly those three bytes are escaped
-/// (@c '%'→"%25" first, then @c '#'→"%23", @c '?'→"%3F"). Every other byte,
-/// including @c '/', @c '=' and space, stays literal: hive-partition path
-/// text (@c col=a b/) must survive unchanged. Identity for keys without
-/// @c %/#/?, i.e. every plain key round-trips byte-identically.
-std::string escape_s3_key_for_uri(std::string_view key);
 
 /// Expand an @c s3:// glob @p pattern into concrete object URIs via one
 /// paginated ListObjectsV2 sweep, streamed page-by-page (peak memory = one

--- a/src/include/io/uri_parser.hpp
+++ b/src/include/io/uri_parser.hpp
@@ -30,14 +30,17 @@ namespace sirius::io {
  *   - @c host is the authority verbatim (no percent-decoding); may contain
  *     @c ":port" (e.g. `bucket:9000`). Empty for schemes without an authority
  *     (the `file` scheme and bare absolute paths).
- *   - @c path is percent-decoded. For object-store schemes (s3/gs/azure) it
- *     is the object key after stripping exactly one bucket/key separator
- *     slash; further leading slashes are part of the key per S3 REST
- *     semantics (e.g. `s3://b/k` -> `k`, `s3://b//k` -> `/k`,
- *     `s3://b///k` -> `//k`). For the `file` scheme it keeps its leading
- *     `/`.
+ *   - @c path is percent-decoded EXCEPT for the `s3` scheme, whose key is taken
+ *     literally (AWS-CLI semantics): `s3://b/a%20b` -> `a%20b`, and `?`/`#` are
+ *     ordinary key bytes, not delimiters. For the other object-store schemes
+ *     (gs/azure/http/https/rdma_s3) @c path is the percent-decoded object key.
+ *     All object-store schemes strip exactly one bucket/key separator slash;
+ *     further leading slashes are part of the key per S3 REST semantics (e.g.
+ *     `s3://b/k` -> `k`, `s3://b//k` -> `/k`, `s3://b///k` -> `//k`). For the
+ *     `file` scheme @c path keeps its leading `/`.
  *   - @c query holds percent-decoded values. Duplicate keys are last-wins
  *     (unordered_map cannot represent multi-values; matches AWS SDK behavior).
+ *     The `s3` scheme never populates @c query (its `?...` is literal key bytes).
  */
 struct parsed_uri {
   std::string scheme;
@@ -50,11 +53,13 @@ struct parsed_uri {
  * @brief Parse @p uri into a @c parsed_uri.
  *
  * Supported shapes:
- *   - `s3://bucket/key`, `s3://bucket/key?region=us-west-2`
- *   - `gs://bucket/key`, `azure://container/blob`
+ *   - `s3://bucket/key` — key taken LITERALLY (no percent-decode, no `?`/`#`
+ *     split): `s3://b/a%20b` opens the object whose key is `a%20b`
+ *   - `gs://bucket/key`, `azure://container/blob` (percent-decoded key + query)
  *   - `file:///abs/path`, bare absolute `/abs/path`
- *   - Uppercase schemes (normalized to lowercase)
- *   - Fragments (`#...`) are silently stripped
+ *   - Uppercase schemes (normalized to lowercase; `S3://` takes the literal path)
+ *   - Fragments (`#...`) are silently stripped for non-s3 schemes; for s3 a `#`
+ *     is a literal key byte
  *   - Exactly one bucket/key separator slash is consumed; any further
  *     leading slashes survive into the key (`s3://b/k` -> `k`;
  *     `s3://b//k` -> `/k`; `s3://b///k` -> `//k`)
@@ -64,8 +69,9 @@ struct parsed_uri {
  *   - empty scheme (`://foo`)
  *   - relative bare path (`relative/x`, `./x`)
  *   - empty object key (`s3://bucket`, `s3://bucket/`)
- *   - empty query key (`?=val`)
- *   - malformed percent-encoding (`%ZZ`, truncated `%A`)
+ *   - empty query key (`?=val`) — non-s3 schemes only
+ *   - malformed percent-encoding (`%ZZ`, truncated `%A`) — non-s3 schemes only
+ *     (for s3 these are valid literal key bytes)
  */
 parsed_uri parse(std::string_view uri);
 

--- a/src/io/s3/sirius_httpfs.cpp
+++ b/src/io/s3/sirius_httpfs.cpp
@@ -333,37 +333,26 @@ duckdb::vector<duckdb::OpenFileInfo> sirius_httpfs::Glob(const std::string& path
 
 namespace {
 
-// True when @p key contains '%' followed by two hex digits. DuckDB decodes hive
-// partition values from the path, so a literal %HH key cannot currently preserve
-// both object identity and partition values; expand_glob rejects it. ('#', '?'
-// and bare-'%' keys round-trip exactly and stay supported.)
-bool key_has_percent_encoded_sequence(std::string_view key)
+// True when @p key has a directory segment (not the final filename) that is a Hive
+// partition (has '=') and also contains a literal '?'. DuckDB's Parse cancels
+// partition candidacy on any '?' in a segment, so such a directory would be
+// silently dropped from partitioning. An escaped '%3F' is safe.
+bool key_has_literal_question_in_hive_segment(std::string_view key)
 {
-  auto const is_hex = [](char c) {
-    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
-  };
-  for (std::size_t i = 0; i + 2 < key.size(); ++i) {
-    if (key[i] == '%' && is_hex(key[i + 1]) && is_hex(key[i + 2])) { return true; }
+  std::size_t seg_start = 0;
+  for (std::size_t i = 0; i < key.size(); ++i) {
+    if (key[i] == '/') {  // close a directory segment; the trailing filename is skipped
+      auto const seg = key.substr(seg_start, i - seg_start);
+      if (seg.find('=') != std::string_view::npos && seg.find('?') != std::string_view::npos) {
+        return true;
+      }
+      seg_start = i + 1;
+    }
   }
   return false;
 }
 
 }  // namespace
-
-std::string escape_s3_key_for_uri(std::string_view key)
-{
-  std::string out;
-  out.reserve(key.size());
-  for (char const c : key) {
-    switch (c) {
-      case '%': out += "%25"; break;
-      case '#': out += "%23"; break;
-      case '?': out += "%3F"; break;
-      default: out += c;
-    }
-  }
-  return out;
-}
 
 duckdb::vector<duckdb::OpenFileInfo> expand_glob(
   std::string const& pattern,
@@ -422,24 +411,22 @@ duckdb::vector<duckdb::OpenFileInfo> expand_glob(
           matched = match_glob_no_crawl(key_segments, pattern_segments);
         }
         if (!matched) { continue; }
-        // Match-scoped fail-loud guard (see key_has_percent_encoded_sequence):
-        // unmatched keys under the same prefix stay harmless.
-        if (key_has_percent_encoded_sequence(entry.key)) {
+        // Fail loud on a literal '?' in a Hive partition segment (see above);
+        // match-scoped, so unmatched keys under the prefix are unaffected.
+        if (key_has_literal_question_in_hive_segment(entry.key)) {
           throw duckdb::IOException(
             "[sirius_httpfs] glob '" + pattern + "' matched S3 key '" + entry.key +
-            "' containing a percent-encoded sequence; hive/filename semantics for such keys are "
-            "not preserved over s3:// yet — rename the object or exclude it from the glob");
+            "' with a literal '?' in a Hive partition segment; percent-encode it (%3F) or exclude "
+            "it from the glob");
         }
         if (matches.size() >= match_cap) {
           throw duckdb::IOException("[sirius_httpfs] glob '" + pattern + "' matched more than " +
                                     std::to_string(match_cap) +
                                     " objects — narrow the glob prefix");
         }
-        // Matching runs on the literal key bytes above; only the URI embedding
-        // escapes them, so the later parse() of this path restores the exact
-        // key (see escape_s3_key_for_uri).
-        duckdb::OpenFileInfo info("s3://" + std::string{bucket} + "/" +
-                                  escape_s3_key_for_uri(entry.key));
+        // Embed the raw LIST key verbatim: the signing layer RFC3986-encodes it and
+        // uri_parser does not decode the s3 key, so the LIST key == the opened key.
+        duckdb::OpenFileInfo info("s3://" + std::string{bucket} + "/" + std::string{entry.key});
         if (entry.size <= static_cast<std::uint64_t>(std::numeric_limits<int64_t>::max())) {
           info.extended_info = duckdb::make_shared_ptr<duckdb::ExtendedOpenFileInfo>();
           info.extended_info->options["file_size"] =

--- a/src/io/uri_parser.cpp
+++ b/src/io/uri_parser.cpp
@@ -27,6 +27,7 @@ namespace {
 
 constexpr std::string_view kSchemeDelim = "://";
 constexpr std::string_view kFileScheme  = "file";
+constexpr std::string_view kS3Scheme    = "s3";
 
 [[noreturn]] void fail(std::string_view reason, std::string_view uri)
 {
@@ -124,6 +125,27 @@ std::string to_lower(std::string_view s)
 parsed_uri parse(std::string_view uri)
 {
   if (uri.empty()) fail("empty URI", uri);
+
+  // S3 object keys are literal: '%', '?', '#' are ordinary key bytes. Handle s3
+  // before the fragment strip / query split / percent-decode below (which would
+  // mutate the key) and return the raw key. Non-s3 schemes fall through unchanged.
+  if (auto delim = uri.find(kSchemeDelim);
+      delim != std::string_view::npos && delim > 0 && to_lower(uri.substr(0, delim)) == kS3Scheme) {
+    auto rest    = uri.substr(delim + kSchemeDelim.size());
+    auto slash   = rest.find('/');
+    auto host_sv = (slash == std::string_view::npos) ? rest : rest.substr(0, slash);
+    auto key_sv  = (slash == std::string_view::npos) ? std::string_view{} : rest.substr(slash);
+    if (host_sv.empty()) fail("empty host", uri);
+    // Strip exactly one bucket/key separator slash (S3 REST semantics, matching
+    // the general object-store branch); any further leading slashes are key bytes.
+    if (!key_sv.empty() && key_sv.front() == '/') key_sv.remove_prefix(1);
+    if (key_sv.empty()) fail("empty object key", uri);
+    parsed_uri s3;
+    s3.scheme = std::string{kS3Scheme};
+    s3.host   = std::string{host_sv};
+    s3.path   = std::string{key_sv};  // RAW literal key: no percent-decode.
+    return s3;
+  }
 
   // Strip fragment early: fragments have no semantics for object-store URIs.
   // Why: users may paste browser URLs; silent drop avoids noisy errors.

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -9,6 +9,7 @@
 #include "io/io_context.hpp"
 #include "io/rest/rest_ioctx.hpp"
 #include "io/s3/s3_object_ref.hpp"
+#include "io/s3/sirius_httpfs.hpp"
 #include "io/s3/sirius_sigv4_authorizer.hpp"
 #include "sirius_context.hpp"
 #include "sirius_extension.hpp"
@@ -2531,7 +2532,7 @@ TEST_CASE("transparent S3 read_parquet expands globbed parquet files",
   sirius::test::require_transparent_execution_delta(before_stats, after_stats, 1, 0, 1);
 }
 
-TEST_CASE("transparent S3 glob rejects a matched percent-encoded key instead of opening its decoy",
+TEST_CASE("transparent S3 glob opens the literal percent key instead of its slash decoy",
           "[s3][integration][sql][gpu_execution][transparent][glob]")
 {
   auto env = load_s3_test_env();
@@ -2541,10 +2542,17 @@ TEST_CASE("transparent S3 glob rejects a matched percent-encoded key instead of 
   set_gpu_execution(fixture.con, true);
   require_s3_keys_listed(fixture, *env, {"glob-enc/a%2Fb.parquet", "glob-enc/a/b.parquet"});
 
-  auto const s3_query = "SELECT count(*) FROM " + s3_parquet_glob_scan(*env, "glob-enc/a*.parquet");
+  auto const s3_scan    = s3_parquet_glob_scan(*env, "glob-enc/a*.parquet");
+  auto const local_scan = local_parquet_glob_scan(*env, "glob-enc/a*.parquet");
+  auto const s3_query =
+    "SELECT n_nationkey, n_name FROM " + s3_scan + " ORDER BY n_nationkey, n_name";
+  auto const local_query =
+    "SELECT n_nationkey, n_name FROM " + local_scan + " ORDER BY n_nationkey, n_name";
 
-  CHECK_THROWS_WITH(query_or_throw_on_error(fixture.con, s3_query),
-                    Catch::Contains("percent-encoded"));
+  compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+  auto result = require_query_ok(fixture.con, "SELECT count(*) FROM " + s3_scan);
+  REQUIRE(result->RowCount() == 1);
+  CHECK(result->GetValue(0, 0).GetValue<int64_t>() == 25);
 }
 
 TEST_CASE("transparent S3 glob opens keys containing URI fragment and query delimiters",
@@ -2585,7 +2593,7 @@ TEST_CASE("transparent S3 glob opens a key containing a literal percent byte",
   compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
 }
 
-TEST_CASE("transparent S3 glob rejects a matched Hive-style percent-encoded key",
+TEST_CASE("transparent S3 glob decodes a percent-encoded Hive value exactly once",
           "[s3][integration][sql][gpu_execution][transparent][glob]")
 {
   auto env = load_s3_test_env();
@@ -2595,11 +2603,176 @@ TEST_CASE("transparent S3 glob rejects a matched Hive-style percent-encoded key"
   set_gpu_execution(fixture.con, true);
   require_s3_keys_listed(fixture, *env, {"glob-enc/t/col=a%20b/p0.parquet"});
 
-  auto const s3_query =
-    "SELECT count(*) FROM " + s3_parquet_glob_scan(*env, "glob-enc/t/*/*.parquet");
+  auto const options     = std::string_view{", hive_partitioning=true"};
+  auto const s3_scan     = s3_parquet_glob_scan(*env, "glob-enc/t/*/*.parquet", options);
+  auto const local_scan  = local_parquet_glob_scan(*env, "glob-enc/t/*/*.parquet", options);
+  auto const s3_query    = "SELECT col, count(*) FROM " + s3_scan + " GROUP BY col ORDER BY col";
+  auto const local_query = "SELECT col, count(*) FROM " + local_scan + " GROUP BY col ORDER BY col";
 
-  CHECK_THROWS_WITH(query_or_throw_on_error(fixture.con, s3_query),
-                    Catch::Contains("percent-encoded"));
+  compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+  auto result = require_query_ok(fixture.con, s3_query);
+  REQUIRE(result->RowCount() == 1);
+  CHECK(result->GetValue(0, 0).ToString() == "a b");
+  CHECK(result->GetValue(1, 0).GetValue<int64_t>() == 25);
+}
+
+TEST_CASE("S3 direct and glob routes share the literal object cache identity",
+          "[s3][integration][filesystem][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  auto& manager          = require_sirius_context(fixture).get_scan_manager();
+  auto const direct_uri  = s3_uri(env->bucket, "glob-enc/a%2Fb.parquet");
+  auto direct_datasource = manager.create_datasource(direct_uri);
+  REQUIRE(direct_datasource != nullptr);
+
+  auto glob_files =
+    sirius::io::s3::expand_glob(s3_uri(env->bucket, "glob-enc/a*.parquet"), manager);
+  REQUIRE(glob_files.size() == 1);
+  auto glob_datasource = manager.create_datasource(glob_files.front().path);
+  REQUIRE(glob_datasource != nullptr);
+
+  CHECK(glob_files.front().path == direct_uri);
+  CHECK(glob_datasource->io_object().object_path() == direct_datasource->io_object().object_path());
+  CHECK(glob_datasource->io_object().raw_file_cache_id() ==
+        direct_datasource->io_object().raw_file_cache_id());
+  CHECK(glob_datasource->io_object().size() == direct_datasource->io_object().size());
+}
+
+TEST_CASE("transparent S3 non-glob reads distinguish literal percent keys from spaces",
+          "[s3][integration][sql][gpu_execution][transparent]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+
+  auto const literal_scan =
+    "read_parquet(" + sql_quote(s3_uri(env->bucket, "glob-enc/f%20g.parquet")) + ")";
+  auto const literal_local = local_parquet_glob_scan(*env, "glob-enc/f%20g.parquet");
+  auto const space_scan =
+    "read_parquet(" + sql_quote(s3_uri(env->bucket, "glob-enc/f g.parquet")) + ")";
+  auto const space_local = local_parquet_glob_scan(*env, "glob-enc/f g.parquet");
+
+  compare_transparent_s3_gpu_to_local_cpu(fixture,
+                                          "SELECT count(*) FROM " + literal_scan + " ORDER BY 1",
+                                          "SELECT count(*) FROM " + literal_local + " ORDER BY 1");
+  compare_transparent_s3_gpu_to_local_cpu(fixture,
+                                          "SELECT count(*) FROM " + space_scan + " ORDER BY 1",
+                                          "SELECT count(*) FROM " + space_local + " ORDER BY 1");
+
+  auto literal_result = require_query_ok(fixture.con, "SELECT count(*) FROM " + literal_scan);
+  auto space_result   = require_query_ok(fixture.con, "SELECT count(*) FROM " + space_scan);
+  CHECK(literal_result->GetValue(0, 0).GetValue<int64_t>() == 25);
+  CHECK(space_result->GetValue(0, 0).GetValue<int64_t>() == 5);
+}
+
+TEST_CASE("transparent S3 glob rejects a literal question mark in a Hive partition segment",
+          "[s3][integration][sql][gpu_execution][transparent][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+  require_s3_keys_listed(fixture, *env, {"glob-enc/q/col=a?b/p0.parquet"});
+
+  auto const scan =
+    s3_parquet_glob_scan(*env, "glob-enc/q/col=a?b/*.parquet", ", hive_partitioning=true");
+  CHECK_THROWS_WITH(query_or_throw_on_error(fixture.con, "SELECT count(*) FROM " + scan),
+                    Catch::Contains("literal '?'"));
+}
+
+TEST_CASE("transparent S3 glob rejects a question mark before the Hive partition separator",
+          "[s3][integration][sql][gpu_execution][transparent][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+  require_s3_keys_listed(fixture, *env, {"glob-enc/guard-before/co?l=value/p0.parquet"});
+
+  auto const scan =
+    s3_parquet_glob_scan(*env, "glob-enc/guard-before/*/*.parquet", ", hive_partitioning=true");
+  CHECK_THROWS_WITH(query_or_throw_on_error(fixture.con, "SELECT count(n_nationkey) FROM " + scan),
+                    Catch::Contains("literal '?'"));
+}
+
+TEST_CASE("transparent S3 glob permits a question mark in the terminal filename",
+          "[s3][integration][sql][gpu_execution][transparent][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+  require_s3_keys_listed(fixture, *env, {"glob-enc/guard-filename/report=foo?bar.parquet"});
+
+  auto const options = std::string_view{", hive_partitioning=true"};
+  auto const s3_scan =
+    s3_parquet_glob_scan(*env, "glob-enc/guard-filename/report*.parquet", options);
+  auto const local_scan =
+    local_parquet_glob_scan(*env, "glob-enc/guard-filename/report*.parquet", options);
+  auto const s3_query    = "SELECT count(n_nationkey) FROM " + s3_scan;
+  auto const local_query = "SELECT count(n_nationkey) FROM " + local_scan;
+
+  compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+  auto result = require_query_ok(fixture.con, s3_query);
+  REQUIRE(result->RowCount() == 1);
+  CHECK(result->GetValue(0, 0).GetValue<int64_t>() == 25);
+}
+
+TEST_CASE("transparent S3 glob supports an encoded question mark in a Hive partition value",
+          "[s3][integration][sql][gpu_execution][transparent][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+  require_s3_keys_listed(fixture, *env, {"glob-enc/q/col=a%3Fb/p0.parquet"});
+
+  auto const options     = std::string_view{", hive_partitioning=true"};
+  auto const s3_scan     = s3_parquet_glob_scan(*env, "glob-enc/q/col=a%3F*/*.parquet", options);
+  auto const local_scan  = local_parquet_glob_scan(*env, "glob-enc/q/col=a%3F*/*.parquet", options);
+  auto const s3_query    = "SELECT col, count(*) FROM " + s3_scan + " GROUP BY col ORDER BY col";
+  auto const local_query = "SELECT col, count(*) FROM " + local_scan + " GROUP BY col ORDER BY col";
+
+  compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+  auto result = require_query_ok(fixture.con, s3_query);
+  REQUIRE(result->RowCount() == 1);
+  CHECK(result->GetValue(0, 0).ToString() == "a?b");
+  CHECK(result->GetValue(1, 0).GetValue<int64_t>() == 25);
+}
+
+TEST_CASE("S3 glob results are sorted by raw literal key bytes",
+          "[s3][integration][filesystem][glob]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  auto& manager = require_sirius_context(fixture).get_scan_manager();
+  auto files    = sirius::io::s3::expand_glob(s3_uri(env->bucket, "glob-enc/*.parquet"), manager);
+
+  std::vector<std::string> actual;
+  actual.reserve(files.size());
+  for (auto const& file : files) {
+    actual.push_back(file.path);
+  }
+  std::vector<std::string> const expected{
+    s3_uri(env->bucket, "glob-enc/100%.parquet"),
+    s3_uri(env->bucket, "glob-enc/a%2Fb.parquet"),
+    s3_uri(env->bucket, "glob-enc/f g.parquet"),
+    s3_uri(env->bucket, "glob-enc/f%20g.parquet"),
+    s3_uri(env->bucket, "glob-enc/x#1.parquet"),
+    s3_uri(env->bucket, "glob-enc/y?v.parquet"),
+  };
+  CHECK(actual == expected);
 }
 
 TEST_CASE("transparent S3 glob ignores percent-encoded keys outside the match",

--- a/test/cpp/io/s3/test_sigv4.cpp
+++ b/test/cpp/io/s3/test_sigv4.cpp
@@ -106,6 +106,13 @@ TEST_CASE("uri_encode follows RFC3986 rules needed by SigV4", "[s3][sigv4]")
   CHECK(uri_encode("~!@#$", true) == "~%21%40%23%24");
 }
 
+TEST_CASE("uri_encode canonicalizes literal S3 keys exactly once", "[s3][sigv4]")
+{
+  CHECK(uri_encode("path with space.parquet", false) == "path%20with%20space.parquet");
+  CHECK(uri_encode("100%.parquet", false) == "100%25.parquet");
+  CHECK(uri_encode("a%2Fb.parquet", false) == "a%252Fb.parquet");
+}
+
 TEST_CASE("sign_request rejects incomplete signer config", "[s3][sigv4]")
 {
   auto creds = aws_example_creds();

--- a/test/cpp/io/s3/test_sirius_httpfs.cpp
+++ b/test/cpp/io/s3/test_sirius_httpfs.cpp
@@ -22,8 +22,10 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -112,6 +114,13 @@ std::string thrown_message(Fn&& fn)
     return "<non-std exception>";
   }
   return {};
+}
+
+std::string read_text_file(fs::path const& path)
+{
+  std::ifstream in(path);
+  if (!in) { throw std::runtime_error("cannot open source file: " + path.string()); }
+  return {std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
 }
 
 void load_sirius_extension(duckdb::DuckDB& db)
@@ -290,17 +299,17 @@ class exposed_sirius_httpfs final : public sirius::io::s3::sirius_httpfs {
 
 }  // namespace
 
-TEST_CASE("S3 LIST keys survive the URI embedding escape seam", "[s3][filesystem][glob]")
+TEST_CASE("S3 LIST keys retain literal identity when embedded in object URIs",
+          "[s3][filesystem][glob]")
 {
   for (auto const key : {std::string_view{"a%2Fb.p"},
-                         std::string_view{"x#1.p"},
-                         std::string_view{"y?v.p"},
-                         std::string_view{"100%.p"},
-                         std::string_view{"col=a%20b/p0.p"}}) {
+                         std::string_view{"a%20b.p"},
+                         std::string_view{"a#b.p"},
+                         std::string_view{"a?b.p"},
+                         std::string_view{"100%x.p"}}) {
     DYNAMIC_SECTION("key=" << key)
     {
-      auto const escaped = sirius::io::s3::escape_s3_key_for_uri(key);
-      auto const parsed  = sirius::io::parse("s3://bkt/" + escaped);
+      auto const parsed = sirius::io::parse("s3://bkt/" + std::string{key});
 
       CHECK(parsed.host == "bkt");
       CHECK(parsed.path == key);
@@ -308,14 +317,33 @@ TEST_CASE("S3 LIST keys survive the URI embedding escape seam", "[s3][filesystem
   }
 }
 
-TEST_CASE("S3 LIST key URI escaping preserves ordinary keys byte for byte",
-          "[s3][filesystem][glob]")
+TEST_CASE("S3 object URI parsing preserves ordinary keys byte for byte", "[s3][filesystem][glob]")
 {
   for (auto const key : {std::string_view{"plain.parquet"},
                          std::string_view{"year=2026/part 0.parquet"},
                          std::string_view{"nested/path/file.parquet"}}) {
-    DYNAMIC_SECTION("key=" << key) { CHECK(sirius::io::s3::escape_s3_key_for_uri(key) == key); }
+    DYNAMIC_SECTION("key=" << key)
+    {
+      CHECK(sirius::io::parse("s3://bkt/" + std::string{key}).path == key);
+    }
   }
+}
+
+TEST_CASE("S3 literal-key implementation contains no retired URI escape or percent guard",
+          "[s3][filesystem][glob]")
+{
+  auto const root   = fs::path{SIRIUS_PROJECT_ROOT};
+  auto const source = read_text_file(root / "src" / "io" / "s3" / "sirius_httpfs.cpp");
+  auto const header = read_text_file(root / "src" / "include" / "io" / "s3" / "sirius_httpfs.hpp");
+  auto const implementation = source + header;
+
+  auto const retired_escape  = std::string{"escape_s3_key_"} + "for_uri";
+  auto const retired_guard   = std::string{"key_has_percent_encoded_"} + "sequence";
+  auto const retired_wording = std::string{"containing a percent-"} + "encoded sequence";
+
+  CHECK(implementation.find(retired_escape) == std::string::npos);
+  CHECK(implementation.find(retired_guard) == std::string::npos);
+  CHECK(implementation.find(retired_wording) == std::string::npos);
 }
 
 TEST_CASE("sirius_httpfs claims only valid S3 object paths", "[s3][filesystem]")

--- a/test/cpp/io/test_uri_parser.cpp
+++ b/test/cpp/io/test_uri_parser.cpp
@@ -23,7 +23,7 @@ using sirius::io::parse;
 
 TEST_CASE("uri_parser parses bare absolute paths as file URIs", "[uri_parser]")
 {
-  auto parsed = parse("/tmp/sirius%20data.parquet?version=1&flag");
+  auto parsed = parse("/tmp/sirius%20data.parquet?version=1&flag#ignored");
 
   CHECK(parsed.scheme == "file");
   CHECK(parsed.host.empty());
@@ -35,23 +35,54 @@ TEST_CASE("uri_parser parses bare absolute paths as file URIs", "[uri_parser]")
 
 TEST_CASE("uri_parser parses file scheme with absolute path", "[uri_parser]")
 {
-  auto parsed = parse("file:///var/data/table.parquet");
+  auto parsed = parse("file:///var/data/table%20one.parquet?version=1#ignored");
 
   CHECK(parsed.scheme == "file");
   CHECK(parsed.host.empty());
-  CHECK(parsed.path == "/var/data/table.parquet");
+  CHECK(parsed.path == "/var/data/table one.parquet");
+  REQUIRE(parsed.query.size() == 1);
+  CHECK(parsed.query.at("version") == "1");
+}
+
+TEST_CASE("uri_parser treats S3 object keys as literal bytes", "[uri_parser][s3]")
+{
+  auto parsed = parse("s3://bkt/a%20b");
+
+  CHECK(parsed.scheme == "s3");
+  CHECK(parsed.host == "bkt");
+  CHECK(parsed.path == "a%20b");
   CHECK(parsed.query.empty());
 }
 
-TEST_CASE("uri_parser parses object-store URIs", "[uri_parser]")
+TEST_CASE("uri_parser keeps query and fragment delimiters inside S3 keys", "[uri_parser][s3]")
 {
-  auto parsed = parse("S3://bucket-name//path/to/object%20one.parquet?region=us-west-2");
+  auto query_key = parse("s3://bkt/k?region=x");
+  CHECK(query_key.path == "k?region=x");
+  CHECK(query_key.query.empty());
 
+  auto fragment_key = parse("s3://bkt/k#frag");
+  CHECK(fragment_key.path == "k#frag");
+  CHECK(fragment_key.query.empty());
+
+  auto empty_query_key = parse("s3://bkt/key?=value");
+  CHECK(empty_query_key.path == "key?=value");
+  CHECK(empty_query_key.query.empty());
+}
+
+TEST_CASE("uri_parser accepts malformed percent sequences as literal S3 key bytes",
+          "[uri_parser][s3]")
+{
+  CHECK(parse("s3://bkt/key%ZZ").path == "key%ZZ");
+  CHECK(parse("s3://bkt/key%A").path == "key%A");
+}
+
+TEST_CASE("uri_parser applies the literal S3 path to uppercase schemes", "[uri_parser][s3]")
+{
+  auto parsed = parse("S3://bkt/a%20b");
   CHECK(parsed.scheme == "s3");
-  CHECK(parsed.host == "bucket-name");
-  CHECK(parsed.path == "/path/to/object one.parquet");
-  REQUIRE(parsed.query.size() == 1);
-  CHECK(parsed.query.at("region") == "us-west-2");
+  CHECK(parsed.host == "bkt");
+  CHECK(parsed.path == "a%20b");
+  CHECK(parsed.query.empty());
 }
 
 TEST_CASE("uri_parser preserves S3 leading slashes in object key", "[uri_parser]")
@@ -67,22 +98,28 @@ TEST_CASE("uri_parser preserves S3 leading slashes in object key", "[uri_parser]
 
 TEST_CASE("uri_parser accepts project-internal schemes", "[uri_parser]")
 {
-  auto parsed = parse("rdma_s3://bucket/key");
+  auto parsed = parse("rdma_s3://bucket/a%20b?x=1#ignored");
 
   CHECK(parsed.scheme == "rdma_s3");
   CHECK(parsed.host == "bucket");
-  CHECK(parsed.path == "key");
-}
-
-TEST_CASE("uri_parser strips fragments before parsing", "[uri_parser]")
-{
-  auto parsed = parse("s3://bucket/key.parquet?x=1#ignored");
-
-  CHECK(parsed.scheme == "s3");
-  CHECK(parsed.host == "bucket");
-  CHECK(parsed.path == "key.parquet");
+  CHECK(parsed.path == "a b");
   REQUIRE(parsed.query.size() == 1);
   CHECK(parsed.query.at("x") == "1");
+}
+
+TEST_CASE("uri_parser leaves non-S3 object-store URI semantics unchanged", "[uri_parser]")
+{
+  for (auto const scheme : {"gs", "azure", "http", "https"}) {
+    DYNAMIC_SECTION("scheme=" << scheme)
+    {
+      auto parsed = parse(std::string{scheme} + "://bkt/a%20b?x=1#ignored");
+      CHECK(parsed.scheme == scheme);
+      CHECK(parsed.host == "bkt");
+      CHECK(parsed.path == "a b");
+      REQUIRE(parsed.query.size() == 1);
+      CHECK(parsed.query.at("x") == "1");
+    }
+  }
 }
 
 TEST_CASE("uri_parser query parser decodes values and keeps last duplicate", "[uri_parser]")
@@ -103,7 +140,4 @@ TEST_CASE("uri_parser rejects malformed input", "[uri_parser]")
   CHECK_THROWS_AS(parse("file://relative/path"), std::invalid_argument);
   CHECK_THROWS_AS(parse("s3://bucket"), std::invalid_argument);
   CHECK_THROWS_AS(parse("s3://bucket/"), std::invalid_argument);
-  CHECK_THROWS_AS(parse("s3://bucket/key?=value"), std::invalid_argument);
-  CHECK_THROWS_AS(parse("s3://bucket/key%ZZ"), std::invalid_argument);
-  CHECK_THROWS_AS(parse("s3://bucket/key%A"), std::invalid_argument);
 }

--- a/test/cpp/utils/s3_container.cpp
+++ b/test/cpp/utils/s3_container.cpp
@@ -227,13 +227,19 @@ void create_special_key_fixtures(fs::path const& fixture_dir)
 
   auto const root = fixture_dir / "glob-enc";
   fs::remove_all(root);
-  std::array<std::pair<fs::path, fs::path>, 6> const fixtures{{
+  std::array<std::pair<fs::path, fs::path>, 12> const fixtures{{
     {nation, root / "a%2Fb.parquet"},
     {region, root / "a" / "b.parquet"},
     {nation, root / "x#1.parquet"},
     {nation, root / "y?v.parquet"},
     {nation, root / "100%.parquet"},
     {nation, root / "t" / "col=a%20b" / "p0.parquet"},
+    {nation, root / "q" / "col=a%3Fb" / "p0.parquet"},
+    {nation, root / "q" / "col=a?b" / "p0.parquet"},
+    {nation, root / "f%20g.parquet"},
+    {region, root / "f g.parquet"},
+    {nation, root / "guard-before" / "co?l=value" / "p0.parquet"},
+    {nation, root / "guard-filename" / "report=foo?bar.parquet"},
   }};
   for (auto const& [source, destination] : fixtures) {
     fs::create_directories(destination.parent_path());


### PR DESCRIPTION
S3 keys were being decoded in the wrong layer.

`uri_parser` percent-decoded the key before signing, so a literal key such as `report%2024.parquet` could resolve to `report 24.parquet` instead. Hive paths had the same problem: Sirius decoded `col=a%20b/`, then DuckDB decoded it again when reading the partition value. The glob path rejected `%HH` keys to avoid silently opening the wrong object.

This change keeps the S3 key literal through parsing and glob expansion:

- `uri_parser` no longer percent-decodes S3 keys or treats `?` and `#` as URL delimiters.
- Glob expansion passes the raw key returned by S3 LIST directly to the file list.
- The existing SigV4 signer encodes the raw key once when building the wire path.
- DuckDB remains responsible for decoding Hive partition values.

A object key such as `report%2024.parquet` now addresses the literal object, and a Hive path `col=a%20b/` produces the partition value `a b` after DuckDB's single decode, matching the same tree on local storage.

This changes the meaning of directly typed S3 URLs. To read an object whose key contains a space, use a literal space:

- `s3://bucket/my file.parquet` addresses `my file.parquet`
- `s3://bucket/my%20file.parquet` addresses the literal key `my%20file.parquet`

The same rule applies to `%`, `?`, and `#`.

A literal `?` inside a Hive partition directory, such as `col=a?b/`, is rejected because DuckDB would otherwise omit that partition value. The encoded form, `col=a%3Fb/`, remains supported and produces the value `a?b`. A `?` in the final filename is allowed.

The change also removes the old escape/decode round trip and the temporary guard that rejected `%HH` keys. The behavior is documented in `docs/super-sirius/scan.md`.

Test coverage includes:

- Literal S3 parsing and unchanged behavior for other URI schemes
- SigV4 single encoding of raw keys
- Literal `%2F` keys versus slash-separated decoys
- Literal `%20` filenames
- Hive `%20` and `%3F` partition values
- Direct and glob routes resolving to the same cache identity
- Literal `?` guard boundaries
- Raw-key sort order
