### PR TITLE
fix(aggregate): use non-null count as ungrouped AVG denominator

### DIFF
--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -370,8 +370,19 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
           auto scalar = cudf::reduce(col, *agg_op, out_type, std::nullopt, stream);
           cols.push_back(cudf::make_column_from_scalar(*scalar, 1, stream));
           if (spec.kind == aggregate_kind::AVG) {
-            auto count_scalar = make_numeric_scalar_with_value<int64_t>(
-              cudf::data_type{cudf::type_id::INT64}, static_cast<int64_t>(view.num_rows()), stream);
+            // AVG denominator is the count of non-null values (SUM skips NULLs).
+            // No NULLs -> row count suffices, so avoid the extra COUNT reduction.
+            std::unique_ptr<cudf::scalar> count_scalar;
+            if (!col.nullable() || col.null_count() == 0) {
+              count_scalar =
+                make_numeric_scalar_with_value<int64_t>(cudf::data_type{cudf::type_id::INT64},
+                                                        static_cast<int64_t>(view.num_rows()),
+                                                        stream);
+            } else {
+              auto count_agg = cudf::make_count_aggregation<cudf::reduce_aggregation>();
+              count_scalar   = cudf::reduce(
+                col, *count_agg, cudf::data_type{cudf::type_id::INT64}, std::nullopt, stream);
+            }
             cols.push_back(cudf::make_column_from_scalar(*count_scalar, 1, stream));
           }
           break;


### PR DESCRIPTION
Fixes one of the bugs uncovered in null test coverage addition, bug number 2) tracked here https://github.com/sirius-db/sirius/issues/1218

Ungrouped AVG divided SUM by the row count instead of the count of non-null values, so AVG over a column containing NULLs was wrong (e.g. 335/8 instead of 335/5). Use a COUNT reduction (null_policy EXCLUDE) for the denominator, matching SQL semantics and grouped AVG. Skip the reduction when the column has no NULLs to preserve the previous fast path.