### PR TITLE
fix(starrocks): combine complete scan splits

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/error.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/error.rs
@@ -38,7 +38,7 @@ pub enum TranslateError {
         reason: &'static str,
     },
     /// A FILE_SCAN broker scan range is outside the supported v1 slice (e.g. a
-    /// non-parquet format or a byte-range split).
+    /// non-parquet format, or byte-range splits that do not tile their file).
     #[error("unsupported scan range at node {node_id}: {reason}")]
     UnsupportedScanRange {
         /// StarRocks plan-node id of the scan.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
@@ -218,6 +218,14 @@ impl ScanFilePaths {
                             "byte-range splits do not tile the parquet file",
                         ));
                     }
+                    // A split that runs past EOF is malformed metadata, not a whole-file read;
+                    // without this the sweep below only asks whether EOF was reached.
+                    if end > file_size {
+                        return Err(Self::unsupported(
+                            node_id,
+                            "byte-range split extends past the end of the parquet file",
+                        ));
+                    }
                     covered_until = end;
                 }
                 if covered_until < file_size {

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
@@ -156,18 +156,23 @@ impl ScanFilePaths {
                 intervals.sort_unstable();
                 let mut covered_until = 0;
                 for (start, end) in intervals {
-                    if start < 0 || end <= start || start > covered_until {
+                    // Each split must begin exactly where the previous one ended. `>` alone
+                    // rejects gaps but absorbs overlaps into `covered_until`, and an overlap
+                    // survives as a single whole-file read: Sirius would scan the shared row
+                    // groups once where StarRocks scans them on both instances, so `count(*)`
+                    // disagrees with no error.
+                    if start < 0 || end <= start || start != covered_until {
                         return Err(Self::unsupported(
                             node_id,
-                            "byte-range splits do not cover the whole parquet file",
+                            "byte-range splits do not tile the parquet file",
                         ));
                     }
-                    covered_until = covered_until.max(end);
+                    covered_until = end;
                 }
                 if covered_until < file_size {
                     return Err(Self::unsupported(
                         node_id,
-                        "byte-range splits do not cover the whole parquet file",
+                        "byte-range splits do not tile the parquet file",
                     ));
                 }
                 debug_assert!(!path.is_empty());

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
@@ -20,18 +20,27 @@ use crate::error::{Result, TranslateError};
 ///
 /// Collection fails closed: only the slice that maps faithfully onto a
 /// `parquet_scan` over local files is accepted — a `FILES()` query (not a load),
-/// reading whole local parquet files whose columns are direct passthroughs to the
-/// scan tuple. Anything else (loads, byte-range splits, remote schemes, casts or
-/// other column transforms, path-derived or flexibly-mapped columns) is rejected
+/// reading local parquet files whose columns are direct passthroughs to the scan
+/// tuple. Byte-range splits assigned to one fragment are collapsed only when they
+/// collectively cover the whole file. Anything else (loads, partial files, remote
+/// schemes, casts or other column transforms, path-derived or flexibly-mapped columns) is rejected
 /// with [`TranslateError::UnsupportedScanRange`] rather than silently producing
 /// wrong results.
 #[derive(Debug, Default)]
 pub(crate) struct ScanFilePaths {
     by_node: HashMap<i32, Vec<String>>,
+    byte_ranges: HashMap<i32, HashMap<String, Vec<ByteRange>>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ByteRange {
+    start: i64,
+    size: i64,
+    file_size: Option<i64>,
 }
 
 impl ScanFilePaths {
-    /// Collects whole-file parquet paths from `params`' broker scan ranges.
+    /// Collects complete parquet paths from `params`' broker scan ranges.
     ///
     /// Ranges arrive either per node (`per_node_scan_ranges`) or, for pipeline
     /// fragments, per driver sequence (`node_to_per_driver_seq_scan_ranges`);
@@ -65,6 +74,7 @@ impl ScanFilePaths {
                 }
             }
         }
+        paths.validate_complete_files()?;
         Ok(paths)
     }
 
@@ -77,7 +87,7 @@ impl ScanFilePaths {
             .unwrap_or_default()
     }
 
-    /// Validates and appends the whole-file parquet paths in `ranges` to `node_id`.
+    /// Validates and appends parquet paths and byte ranges in `ranges` to `node_id`.
     fn add_ranges(
         &mut self,
         node_id: i32,
@@ -91,10 +101,76 @@ impl ScanFilePaths {
             Self::check_params(node_id, &broker.params, desc)?;
             for range_desc in &broker.ranges {
                 Self::check_range(node_id, range_desc)?;
-                self.by_node
+                let node_paths = self.by_node.entry(node_id).or_default();
+                if !node_paths.contains(&range_desc.path) {
+                    node_paths.push(range_desc.path.clone());
+                }
+                self.byte_ranges
                     .entry(node_id)
                     .or_default()
-                    .push(range_desc.path.clone());
+                    .entry(range_desc.path.clone())
+                    .or_default()
+                    .push(ByteRange {
+                        start: range_desc.start_offset,
+                        size: range_desc.size,
+                        file_size: range_desc.file_size,
+                    });
+            }
+        }
+        Ok(())
+    }
+
+    /// Ensures split ranges assigned to this fragment collectively cover each file exactly once.
+    fn validate_complete_files(&self) -> Result<()> {
+        for (&node_id, files) in &self.byte_ranges {
+            for (path, ranges) in files {
+                let Some(file_size) = ranges.first().and_then(|range| range.file_size) else {
+                    return Err(Self::unsupported(
+                        node_id,
+                        "scan range is missing the parquet file size",
+                    ));
+                };
+                if file_size <= 0
+                    || ranges
+                        .iter()
+                        .any(|range| range.file_size != Some(file_size))
+                {
+                    return Err(Self::unsupported(
+                        node_id,
+                        "scan ranges disagree on the parquet file size",
+                    ));
+                }
+                let mut intervals = ranges
+                    .iter()
+                    .map(|range| {
+                        let end = if range.size == -1 {
+                            file_size
+                        } else if range.size > 0 {
+                            range.start.checked_add(range.size).unwrap_or(i64::MAX)
+                        } else {
+                            -1
+                        };
+                        (range.start, end)
+                    })
+                    .collect::<Vec<_>>();
+                intervals.sort_unstable();
+                let mut covered_until = 0;
+                for (start, end) in intervals {
+                    if start < 0 || end <= start || start > covered_until {
+                        return Err(Self::unsupported(
+                            node_id,
+                            "byte-range splits do not cover the whole parquet file",
+                        ));
+                    }
+                    covered_until = covered_until.max(end);
+                }
+                if covered_until < file_size {
+                    return Err(Self::unsupported(
+                        node_id,
+                        "byte-range splits do not cover the whole parquet file",
+                    ));
+                }
+                debug_assert!(!path.is_empty());
             }
         }
         Ok(())
@@ -169,7 +245,7 @@ impl ScanFilePaths {
         Ok(())
     }
 
-    /// Rejects a single broker range outside the supported whole-file local-parquet slice.
+    /// Rejects a broker range outside the supported local-parquet slice.
     fn check_range(node_id: i32, desc: &TBrokerRangeDesc) -> Result<()> {
         if desc.format_type != TFileFormatType::FORMAT_PARQUET {
             return Err(Self::unsupported(
@@ -183,24 +259,6 @@ impl ScanFilePaths {
             return Err(Self::unsupported(
                 node_id,
                 "only broker-descriptor file scan ranges are supported",
-            ));
-        }
-        // Whole-file only: DuckDB's `local_files` reader ignores per-file byte
-        // offsets, so accept a range only when it provably covers the whole,
-        // non-empty file. A FILES() query stats each file, so require a known
-        // positive `file_size` reached by reading to EOF (`size == -1`) or by a
-        // bounded size at least that large. Unknown size, an empty file, or a
-        // bounded size short of the file are rejected rather than silently reading
-        // the wrong bytes.
-        let whole_file = desc.start_offset == 0
-            && match desc.file_size {
-                Some(file_size) => file_size > 0 && (desc.size == -1 || desc.size >= file_size),
-                None => false,
-            };
-        if !whole_file {
-            return Err(Self::unsupported(
-                node_id,
-                "byte-range split scan ranges are not supported",
             ));
         }
         // StarRocks appends path-derived columns after the physical parquet

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
@@ -104,6 +104,18 @@ impl ScanFilePaths {
         byte_ranges: &mut CollectedRanges,
     ) -> Result<()> {
         for range in ranges {
+            // Incremental delivery: more ranges follow through deliver_scan_ranges, which this
+            // CN does not implement — accepting the prefix would silently read a subset.
+            if range.has_more == Some(true) {
+                return Err(Self::unsupported(
+                    node_id,
+                    "incremental scan-range delivery (has_more) is not supported",
+                ));
+            }
+            // An explicitly empty placeholder range carries no file.
+            if range.empty == Some(true) {
+                continue;
+            }
             let Some(broker) = range.scan_range.broker_scan_range.as_ref() else {
                 continue;
             };
@@ -132,16 +144,17 @@ impl ScanFilePaths {
     /// Ensures split ranges assigned to this fragment collectively cover each file
     /// exactly once.
     ///
-    /// Completeness is required because the range cannot be plumbed through. DuckDB's
-    /// Substrait `local_files` reader drops `FileOrFiles.start` / `.length`, and
+    /// Completeness is required because the range is not plumbed through yet: today
+    /// DuckDB's Substrait `local_files` reader drops `FileOrFiles.start` / `.length`, and
     /// `parquet_scan` has no byte-range parameter, so `scan_rel` can only ever emit
     /// `parquet_scan(<whole path>)` — see the item it builds in `node_translator`. The
-    /// only split this translation can honor is therefore one it does not have to
+    /// only split this translation can honor today is therefore one it does not have to
     /// honor at all: ranges that tile the file from byte 0 to EOF, where reading the
     /// whole file *is* exactly the work this fragment was assigned. A lone partial
-    /// split has no faithful whole-file spelling and is refused.
+    /// split has no faithful whole-file spelling and is refused. Explicit partial splits
+    /// are enabled by the engine byte-range stack (follow-up).
     ///
-    /// That is why [`ByteRange`] is validated and discarded rather than forwarded.
+    /// That is why [`ByteRange`] is validated and discarded rather than forwarded for now.
     fn validate_complete_files(byte_ranges: &CollectedRanges) -> Result<()> {
         for (&node_id, files) in byte_ranges {
             for ranges in files.values() {

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
@@ -1,6 +1,6 @@
 //! Per-scan-node parquet file paths collected from a fragment's broker scan ranges.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use starrocks_thrift::exprs::TExprNodeType;
 use starrocks_thrift::internal_service::{TExecPlanFragmentParams, TScanRangeParams};
@@ -23,14 +23,21 @@ use crate::error::{Result, TranslateError};
 /// reading local parquet files whose columns are direct passthroughs to the scan
 /// tuple. Byte-range splits assigned to one fragment are collapsed only when they
 /// collectively cover the whole file. Anything else (loads, partial files, remote
-/// schemes, casts or other column transforms, path-derived or flexibly-mapped columns) is rejected
-/// with [`TranslateError::UnsupportedScanRange`] rather than silently producing
-/// wrong results.
+/// schemes, casts or other column transforms, path-derived or flexibly-mapped
+/// columns) is rejected with [`TranslateError::UnsupportedScanRange`] rather than
+/// silently producing wrong results.
 #[derive(Debug, Default)]
 pub(crate) struct ScanFilePaths {
     by_node: HashMap<i32, Vec<String>>,
-    byte_ranges: HashMap<i32, HashMap<String, Vec<ByteRange>>>,
 }
+
+/// Byte ranges seen while collecting one fragment, keyed `node -> path -> ranges`.
+///
+/// Local to collection: the ranges are only ever used to prove each file is covered
+/// completely, and nothing downstream can act on them (see `validate_complete_files`).
+/// `BTreeMap` so a fragment with several offending nodes or files always reports the
+/// same one — a `HashMap` here makes the error text vary run to run.
+type CollectedRanges = BTreeMap<i32, BTreeMap<String, Vec<ByteRange>>>;
 
 #[derive(Clone, Copy, Debug)]
 struct ByteRange {
@@ -50,11 +57,12 @@ impl ScanFilePaths {
         desc: &DescriptorTable,
     ) -> Result<Self> {
         let mut paths = Self::default();
+        let mut byte_ranges = CollectedRanges::new();
         let Some(exec_params) = params.params.as_ref() else {
             return Ok(paths);
         };
         for (node_id, ranges) in &exec_params.per_node_scan_ranges {
-            paths.add_ranges(*node_id, ranges, desc)?;
+            paths.add_ranges(*node_id, ranges, desc, &mut byte_ranges)?;
         }
         if let Some(per_driver) = exec_params.node_to_per_driver_seq_scan_ranges.as_ref() {
             for (node_id, per_seq) in per_driver {
@@ -70,11 +78,11 @@ impl ScanFilePaths {
                     ));
                 }
                 for ranges in per_seq.values() {
-                    paths.add_ranges(*node_id, ranges, desc)?;
+                    paths.add_ranges(*node_id, ranges, desc, &mut byte_ranges)?;
                 }
             }
         }
-        paths.validate_complete_files()?;
+        Self::validate_complete_files(&byte_ranges)?;
         Ok(paths)
     }
 
@@ -93,6 +101,7 @@ impl ScanFilePaths {
         node_id: i32,
         ranges: &[TScanRangeParams],
         desc: &DescriptorTable,
+        byte_ranges: &mut CollectedRanges,
     ) -> Result<()> {
         for range in ranges {
             let Some(broker) = range.scan_range.broker_scan_range.as_ref() else {
@@ -105,7 +114,7 @@ impl ScanFilePaths {
                 if !node_paths.contains(&range_desc.path) {
                     node_paths.push(range_desc.path.clone());
                 }
-                self.byte_ranges
+                byte_ranges
                     .entry(node_id)
                     .or_default()
                     .entry(range_desc.path.clone())
@@ -120,24 +129,53 @@ impl ScanFilePaths {
         Ok(())
     }
 
-    /// Ensures split ranges assigned to this fragment collectively cover each file exactly once.
-    fn validate_complete_files(&self) -> Result<()> {
-        for (&node_id, files) in &self.byte_ranges {
-            for (path, ranges) in files {
-                let Some(file_size) = ranges.first().and_then(|range| range.file_size) else {
+    /// Ensures split ranges assigned to this fragment collectively cover each file
+    /// exactly once.
+    ///
+    /// Completeness is required because the range cannot be plumbed through. DuckDB's
+    /// Substrait `local_files` reader drops `FileOrFiles.start` / `.length`, and
+    /// `parquet_scan` has no byte-range parameter, so `scan_rel` can only ever emit
+    /// `parquet_scan(<whole path>)` — see the item it builds in `node_translator`. The
+    /// only split this translation can honor is therefore one it does not have to
+    /// honor at all: ranges that tile the file from byte 0 to EOF, where reading the
+    /// whole file *is* exactly the work this fragment was assigned. A lone partial
+    /// split has no faithful whole-file spelling and is refused.
+    ///
+    /// That is why [`ByteRange`] is validated and discarded rather than forwarded.
+    fn validate_complete_files(byte_ranges: &CollectedRanges) -> Result<()> {
+        for (&node_id, files) in byte_ranges {
+            for ranges in files.values() {
+                // Ask "is any size missing" before "do the sizes agree": both questions
+                // are about `file_size`, and checking agreement first reports a missing
+                // size as a disagreement whenever the incomplete range is not the one
+                // that happened to be inserted first.
+                if ranges.iter().any(|range| range.file_size.is_none()) {
                     return Err(Self::unsupported(
                         node_id,
                         "scan range is missing the parquet file size",
                     ));
+                }
+                // `add_ranges` only ever creates an entry by pushing, so an empty vector
+                // does not occur; if one ever does there is nothing to validate.
+                let Some(file_size) = ranges.first().and_then(|range| range.file_size) else {
+                    continue;
                 };
-                if file_size <= 0
-                    || ranges
-                        .iter()
-                        .any(|range| range.file_size != Some(file_size))
+                if ranges
+                    .iter()
+                    .any(|range| range.file_size != Some(file_size))
                 {
                     return Err(Self::unsupported(
                         node_id,
                         "scan ranges disagree on the parquet file size",
+                    ));
+                }
+                // Its own branch, not folded into the disagreement above: an empty file
+                // is a coherent thing the frontend can describe, and reporting it as a
+                // disagreement sends the reader looking for a second, differing range.
+                if file_size <= 0 {
+                    return Err(Self::unsupported(
+                        node_id,
+                        "parquet scan range reports an empty or negative file size",
                     ));
                 }
                 let mut intervals = ranges
@@ -175,7 +213,6 @@ impl ScanFilePaths {
                         "byte-range splits do not tile the parquet file",
                     ));
                 }
-                debug_assert!(!path.is_empty());
             }
         }
         Ok(())

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -4240,3 +4240,39 @@ fn bare_cross_join_translates_to_constant_key_join() {
         .collect();
     assert_eq!(operands, vec![2, 4]);
 }
+
+/// Two splits that both cover the head of the file are refused. They "cover" every byte, so a
+/// sweep that only rejects gaps collapses them into one whole-file read — Sirius would scan the
+/// shared row groups once where StarRocks scans them on both instances, and `count(*)` would
+/// disagree with no error.
+#[test]
+fn overlapping_split_broker_ranges_are_unsupported() {
+    let path = "file:///data/users.parquet";
+    let mut fragment = params_with_scan_range(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        0,
+        broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, 1024, Some(1024)),
+    );
+    fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap()
+        .push(TScanRangeParams::new(
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, 512, Some(1024)),
+            None,
+            None,
+            None,
+        ));
+    let err = PlanTranslator::new()
+        .translate_fragment(&fragment)
+        .unwrap_err();
+    let TranslateError::UnsupportedScanRange { node_id, reason } = err else {
+        panic!("expected an unsupported scan range, got {err:?}");
+    };
+    assert_eq!(node_id, 0);
+    assert_eq!(reason, "byte-range splits do not tile the parquet file");
+}

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -682,6 +682,46 @@ fn split_broker_range_is_unsupported() {
     }
 }
 
+/// Verifies complete byte-range splits are collapsed to one whole-file local read.
+#[test]
+fn complete_split_broker_ranges_produce_one_local_file() {
+    let path = "file:///data/users.parquet";
+    let mut fragment = params_with_scan_range(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        0,
+        broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, 512, Some(1024)),
+    );
+    fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap()
+        .push(TScanRangeParams::new(
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 512, 512, Some(1024)),
+            None,
+            None,
+            None,
+        ));
+    let translated = PlanTranslator::new().translate_fragment(&fragment).unwrap();
+    let rel::RelType::Read(read) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected local read");
+    };
+    let Some(read_rel::ReadType::LocalFiles(files)) = read.read_type.as_ref() else {
+        panic!("expected local files");
+    };
+    assert_eq!(files.items.len(), 1);
+}
+
 /// Verifies a scan range delivered via the pipeline per-driver-sequence map is
 /// collected too (not just `per_node_scan_ranges`).
 #[test]

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -759,6 +759,182 @@ fn complete_split_broker_ranges_produce_one_local_file() {
     assert_eq!(files.items.len(), 1);
 }
 
+/// Builds fragment params whose node-0 scan carries every `(start, size)` split of `path`, all
+/// declaring `file_size`, in the order given.
+fn params_with_splits(
+    path: &str,
+    file_size: i64,
+    splits: &[(i64, i64)],
+) -> TExecPlanFragmentParams {
+    let (first, rest) = splits.split_first().expect("at least one split");
+    let mut fragment = params_with_scan_range(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        0,
+        broker_scan_range(
+            path,
+            TFileFormatType::FORMAT_PARQUET,
+            first.0,
+            first.1,
+            Some(file_size),
+        ),
+    );
+    let ranges = fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap();
+    for &(start, size) in rest {
+        ranges.push(TScanRangeParams::new(
+            broker_scan_range(
+                path,
+                TFileFormatType::FORMAT_PARQUET,
+                start,
+                size,
+                Some(file_size),
+            ),
+            None,
+            None,
+            None,
+        ));
+    }
+    fragment
+}
+
+/// Translates `splits` and returns the `UnsupportedScanRange` reason they were refused with.
+fn splits_rejected_because(file_size: i64, splits: &[(i64, i64)]) -> &'static str {
+    let err = PlanTranslator::new()
+        .translate_fragment(&params_with_splits(
+            "file:///data/users.parquet",
+            file_size,
+            splits,
+        ))
+        .unwrap_err();
+    let TranslateError::UnsupportedScanRange { node_id, reason } = err else {
+        panic!("expected an unsupported scan range, got {err:?}");
+    };
+    assert_eq!(node_id, 0);
+    reason
+}
+
+/// Splits that leave a hole are refused: collapsing them to a whole-file read would scan the
+/// hole, which a sibling instance is already scanning.
+#[test]
+fn split_broker_ranges_with_a_gap_are_unsupported() {
+    assert_eq!(
+        splits_rejected_because(1024, &[(0, 256), (512, 512)]),
+        "byte-range splits do not tile the parquet file"
+    );
+}
+
+/// Splits that tile a prefix but stop short of the file are refused: the tail would be dropped.
+#[test]
+fn split_broker_ranges_covering_only_a_prefix_are_unsupported() {
+    assert_eq!(
+        splits_rejected_because(1024, &[(0, 256), (256, 256)]),
+        "byte-range splits do not tile the parquet file"
+    );
+}
+
+/// Two splits that both cover the head of the file are refused. They "cover" every byte, so a
+/// sweep that only rejects gaps collapses them into one whole-file read — Sirius would scan the
+/// shared row groups once where StarRocks scans them on both instances, and `count(*)` would
+/// disagree with no error.
+#[test]
+fn overlapping_split_broker_ranges_are_unsupported() {
+    assert_eq!(
+        splits_rejected_because(1024, &[(0, 1024), (0, 512)]),
+        "byte-range splits do not tile the parquet file"
+    );
+}
+
+/// Splits of one file that disagree on how big that file is are refused — the coverage check
+/// would otherwise be measured against an arbitrary one of them.
+#[test]
+fn split_broker_ranges_disagreeing_on_file_size_are_unsupported() {
+    let path = "file:///data/users.parquet";
+    let mut fragment = params_with_splits(path, 1024, &[(0, 512)]);
+    fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap()
+        .push(TScanRangeParams::new(
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 512, 512, Some(2048)),
+            None,
+            None,
+            None,
+        ));
+    let err = PlanTranslator::new()
+        .translate_fragment(&fragment)
+        .unwrap_err();
+    let TranslateError::UnsupportedScanRange { reason, .. } = err else {
+        panic!("expected an unsupported scan range, got {err:?}");
+    };
+    assert_eq!(reason, "scan ranges disagree on the parquet file size");
+}
+
+/// A split missing its `file_size` reports as missing wherever it lands in the list, not
+/// only when it happens to be inserted first. Checking agreement before presence made the
+/// message depend on arrival order: the same fragment reported "missing" or "disagree"
+/// depending on which range the FE sent first.
+#[test]
+fn split_broker_range_missing_file_size_after_the_first_is_unsupported() {
+    let path = "file:///data/users.parquet";
+    let mut fragment = params_with_splits(path, 1024, &[(0, 512)]);
+    fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap()
+        .push(TScanRangeParams::new(
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 512, 512, None),
+            None,
+            None,
+            None,
+        ));
+    let err = PlanTranslator::new()
+        .translate_fragment(&fragment)
+        .unwrap_err();
+    let TranslateError::UnsupportedScanRange { reason, .. } = err else {
+        panic!("expected an unsupported scan range, got {err:?}");
+    };
+    assert_eq!(reason, "scan range is missing the parquet file size");
+}
+
+/// Splits arriving out of order still tile the file: the sweep sorts before checking, and the FE
+/// does not promise an order. Without the sort this case would be refused.
+#[test]
+fn split_broker_ranges_in_descending_order_are_accepted() {
+    let translated = PlanTranslator::new()
+        .translate_fragment(&params_with_splits(
+            "file:///data/users.parquet",
+            1024,
+            &[(512, 512), (0, 512)],
+        ))
+        .unwrap();
+    let rel::RelType::Read(read) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected local read");
+    };
+    let Some(read_rel::ReadType::LocalFiles(files)) = read.read_type.as_ref() else {
+        panic!("expected local files");
+    };
+    assert_eq!(files.items.len(), 1);
+}
+
 /// Verifies a scan range delivered via the pipeline per-driver-sequence map is
 /// collected too (not just `per_node_scan_ranges`).
 #[test]
@@ -4292,180 +4468,4 @@ fn bare_cross_join_translates_to_constant_key_join() {
         })
         .collect();
     assert_eq!(operands, vec![2, 4]);
-}
-
-/// Builds fragment params whose node-0 scan carries every `(start, size)` split of `path`, all
-/// declaring `file_size`, in the order given.
-fn params_with_splits(
-    path: &str,
-    file_size: i64,
-    splits: &[(i64, i64)],
-) -> TExecPlanFragmentParams {
-    let (first, rest) = splits.split_first().expect("at least one split");
-    let mut fragment = params_with_scan_range(
-        TPlan::new(vec![scan_node(0, 0)]),
-        base_desc(),
-        0,
-        broker_scan_range(
-            path,
-            TFileFormatType::FORMAT_PARQUET,
-            first.0,
-            first.1,
-            Some(file_size),
-        ),
-    );
-    let ranges = fragment
-        .params
-        .as_mut()
-        .unwrap()
-        .per_node_scan_ranges
-        .get_mut(&0)
-        .unwrap();
-    for &(start, size) in rest {
-        ranges.push(TScanRangeParams::new(
-            broker_scan_range(
-                path,
-                TFileFormatType::FORMAT_PARQUET,
-                start,
-                size,
-                Some(file_size),
-            ),
-            None,
-            None,
-            None,
-        ));
-    }
-    fragment
-}
-
-/// Translates `splits` and returns the `UnsupportedScanRange` reason they were refused with.
-fn splits_rejected_because(file_size: i64, splits: &[(i64, i64)]) -> &'static str {
-    let err = PlanTranslator::new()
-        .translate_fragment(&params_with_splits(
-            "file:///data/users.parquet",
-            file_size,
-            splits,
-        ))
-        .unwrap_err();
-    let TranslateError::UnsupportedScanRange { node_id, reason } = err else {
-        panic!("expected an unsupported scan range, got {err:?}");
-    };
-    assert_eq!(node_id, 0);
-    reason
-}
-
-/// Splits that leave a hole are refused: collapsing them to a whole-file read would scan the
-/// hole, which a sibling instance is already scanning.
-#[test]
-fn split_broker_ranges_with_a_gap_are_unsupported() {
-    assert_eq!(
-        splits_rejected_because(1024, &[(0, 256), (512, 512)]),
-        "byte-range splits do not tile the parquet file"
-    );
-}
-
-/// Splits that tile a prefix but stop short of the file are refused: the tail would be dropped.
-#[test]
-fn split_broker_ranges_covering_only_a_prefix_are_unsupported() {
-    assert_eq!(
-        splits_rejected_because(1024, &[(0, 256), (256, 256)]),
-        "byte-range splits do not tile the parquet file"
-    );
-}
-
-/// Two splits that both cover the head of the file are refused. They "cover" every byte, so a
-/// sweep that only rejects gaps collapses them into one whole-file read — Sirius would scan the
-/// shared row groups once where StarRocks scans them on both instances, and `count(*)` would
-/// disagree with no error.
-#[test]
-fn overlapping_split_broker_ranges_are_unsupported() {
-    assert_eq!(
-        splits_rejected_because(1024, &[(0, 1024), (0, 512)]),
-        "byte-range splits do not tile the parquet file"
-    );
-}
-
-/// Splits of one file that disagree on how big that file is are refused — the coverage check
-/// would otherwise be measured against an arbitrary one of them.
-#[test]
-fn split_broker_ranges_disagreeing_on_file_size_are_unsupported() {
-    let path = "file:///data/users.parquet";
-    let mut fragment = params_with_splits(path, 1024, &[(0, 512)]);
-    fragment
-        .params
-        .as_mut()
-        .unwrap()
-        .per_node_scan_ranges
-        .get_mut(&0)
-        .unwrap()
-        .push(TScanRangeParams::new(
-            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 512, 512, Some(2048)),
-            None,
-            None,
-            None,
-        ));
-    let err = PlanTranslator::new()
-        .translate_fragment(&fragment)
-        .unwrap_err();
-    let TranslateError::UnsupportedScanRange { reason, .. } = err else {
-        panic!("expected an unsupported scan range, got {err:?}");
-    };
-    assert_eq!(reason, "scan ranges disagree on the parquet file size");
-}
-
-/// A split missing its `file_size` reports as missing wherever it lands in the list, not
-/// only when it happens to be inserted first. Checking agreement before presence made the
-/// message depend on arrival order: the same fragment reported "missing" or "disagree"
-/// depending on which range the FE sent first.
-#[test]
-fn split_broker_range_missing_file_size_after_the_first_is_unsupported() {
-    let path = "file:///data/users.parquet";
-    let mut fragment = params_with_splits(path, 1024, &[(0, 512)]);
-    fragment
-        .params
-        .as_mut()
-        .unwrap()
-        .per_node_scan_ranges
-        .get_mut(&0)
-        .unwrap()
-        .push(TScanRangeParams::new(
-            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 512, 512, None),
-            None,
-            None,
-            None,
-        ));
-    let err = PlanTranslator::new()
-        .translate_fragment(&fragment)
-        .unwrap_err();
-    let TranslateError::UnsupportedScanRange { reason, .. } = err else {
-        panic!("expected an unsupported scan range, got {err:?}");
-    };
-    assert_eq!(reason, "scan range is missing the parquet file size");
-}
-
-/// Splits arriving out of order still tile the file: the sweep sorts before checking, and the FE
-/// does not promise an order. Without the sort this case would be refused.
-#[test]
-fn split_broker_ranges_in_descending_order_are_accepted() {
-    let translated = PlanTranslator::new()
-        .translate_fragment(&params_with_splits(
-            "file:///data/users.parquet",
-            1024,
-            &[(512, 512), (0, 512)],
-        ))
-        .unwrap();
-    let rel::RelType::Read(read) = root(&translated.plan)
-        .input
-        .as_ref()
-        .unwrap()
-        .rel_type
-        .as_ref()
-        .unwrap()
-    else {
-        panic!("expected local read");
-    };
-    let Some(read_rel::ReadType::LocalFiles(files)) = read.read_type.as_ref() else {
-        panic!("expected local files");
-    };
-    assert_eq!(files.items.len(), 1);
 }

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -838,6 +838,21 @@ fn split_broker_ranges_covering_only_a_prefix_are_unsupported() {
     );
 }
 
+/// A split that runs past the end of the file is malformed metadata, not a whole-file read. The
+/// sweep only asked whether EOF had been reached, so `(512, 1024)` over a 1024-byte file collapsed
+/// to a whole-file read instead of being refused.
+#[test]
+fn split_broker_ranges_extending_past_eof_are_unsupported() {
+    assert_eq!(
+        splits_rejected_because(1024, &[(0, 512), (512, 1024)]),
+        "byte-range split extends past the end of the parquet file"
+    );
+    assert_eq!(
+        splits_rejected_because(1024, &[(0, 2048)]),
+        "byte-range split extends past the end of the parquet file"
+    );
+}
+
 /// Two splits that both cover the head of the file are refused. They "cover" every byte, so a
 /// sweep that only rejects gaps collapses them into one whole-file read — Sirius would scan the
 /// shared row groups once where StarRocks scans them on both instances, and `count(*)` would

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -682,6 +682,43 @@ fn split_broker_range_is_unsupported() {
     }
 }
 
+/// Verifies incremental scan-range delivery is refused: this CN never receives the rest, so
+/// accepting the prefix would silently read a subset of the data.
+#[test]
+fn has_more_scan_ranges_are_refused() {
+    let mut fragment = params_with_scan_range(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        0,
+        broker_scan_range(
+            "file:///data/users.parquet",
+            TFileFormatType::FORMAT_PARQUET,
+            0,
+            -1,
+            Some(1024),
+        ),
+    );
+    fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap()[0]
+        .has_more = Some(true);
+    let err = PlanTranslator::new()
+        .translate_fragment(&fragment)
+        .unwrap_err();
+    let TranslateError::UnsupportedScanRange { node_id, reason } = err else {
+        panic!("expected an unsupported scan range, got {err:?}");
+    };
+    assert_eq!(node_id, 0);
+    assert_eq!(
+        reason,
+        "incremental scan-range delivery (has_more) is not supported"
+    );
+}
+
 /// Verifies complete byte-range splits are collapsed to one whole-file local read.
 #[test]
 fn complete_split_broker_ranges_produce_one_local_file() {

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -4241,19 +4241,103 @@ fn bare_cross_join_translates_to_constant_key_join() {
     assert_eq!(operands, vec![2, 4]);
 }
 
+/// Builds fragment params whose node-0 scan carries every `(start, size)` split of `path`, all
+/// declaring `file_size`, in the order given.
+fn params_with_splits(
+    path: &str,
+    file_size: i64,
+    splits: &[(i64, i64)],
+) -> TExecPlanFragmentParams {
+    let (first, rest) = splits.split_first().expect("at least one split");
+    let mut fragment = params_with_scan_range(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        0,
+        broker_scan_range(
+            path,
+            TFileFormatType::FORMAT_PARQUET,
+            first.0,
+            first.1,
+            Some(file_size),
+        ),
+    );
+    let ranges = fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap();
+    for &(start, size) in rest {
+        ranges.push(TScanRangeParams::new(
+            broker_scan_range(
+                path,
+                TFileFormatType::FORMAT_PARQUET,
+                start,
+                size,
+                Some(file_size),
+            ),
+            None,
+            None,
+            None,
+        ));
+    }
+    fragment
+}
+
+/// Translates `splits` and returns the `UnsupportedScanRange` reason they were refused with.
+fn splits_rejected_because(file_size: i64, splits: &[(i64, i64)]) -> &'static str {
+    let err = PlanTranslator::new()
+        .translate_fragment(&params_with_splits(
+            "file:///data/users.parquet",
+            file_size,
+            splits,
+        ))
+        .unwrap_err();
+    let TranslateError::UnsupportedScanRange { node_id, reason } = err else {
+        panic!("expected an unsupported scan range, got {err:?}");
+    };
+    assert_eq!(node_id, 0);
+    reason
+}
+
+/// Splits that leave a hole are refused: collapsing them to a whole-file read would scan the
+/// hole, which a sibling instance is already scanning.
+#[test]
+fn split_broker_ranges_with_a_gap_are_unsupported() {
+    assert_eq!(
+        splits_rejected_because(1024, &[(0, 256), (512, 512)]),
+        "byte-range splits do not tile the parquet file"
+    );
+}
+
+/// Splits that tile a prefix but stop short of the file are refused: the tail would be dropped.
+#[test]
+fn split_broker_ranges_covering_only_a_prefix_are_unsupported() {
+    assert_eq!(
+        splits_rejected_because(1024, &[(0, 256), (256, 256)]),
+        "byte-range splits do not tile the parquet file"
+    );
+}
+
 /// Two splits that both cover the head of the file are refused. They "cover" every byte, so a
 /// sweep that only rejects gaps collapses them into one whole-file read — Sirius would scan the
 /// shared row groups once where StarRocks scans them on both instances, and `count(*)` would
 /// disagree with no error.
 #[test]
 fn overlapping_split_broker_ranges_are_unsupported() {
-    let path = "file:///data/users.parquet";
-    let mut fragment = params_with_scan_range(
-        TPlan::new(vec![scan_node(0, 0)]),
-        base_desc(),
-        0,
-        broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, 1024, Some(1024)),
+    assert_eq!(
+        splits_rejected_because(1024, &[(0, 1024), (0, 512)]),
+        "byte-range splits do not tile the parquet file"
     );
+}
+
+/// Splits of one file that disagree on how big that file is are refused — the coverage check
+/// would otherwise be measured against an arbitrary one of them.
+#[test]
+fn split_broker_ranges_disagreeing_on_file_size_are_unsupported() {
+    let path = "file:///data/users.parquet";
+    let mut fragment = params_with_splits(path, 1024, &[(0, 512)]);
     fragment
         .params
         .as_mut()
@@ -4262,7 +4346,7 @@ fn overlapping_split_broker_ranges_are_unsupported() {
         .get_mut(&0)
         .unwrap()
         .push(TScanRangeParams::new(
-            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, 512, Some(1024)),
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 512, 512, Some(2048)),
             None,
             None,
             None,
@@ -4270,9 +4354,35 @@ fn overlapping_split_broker_ranges_are_unsupported() {
     let err = PlanTranslator::new()
         .translate_fragment(&fragment)
         .unwrap_err();
-    let TranslateError::UnsupportedScanRange { node_id, reason } = err else {
+    let TranslateError::UnsupportedScanRange { reason, .. } = err else {
         panic!("expected an unsupported scan range, got {err:?}");
     };
-    assert_eq!(node_id, 0);
-    assert_eq!(reason, "byte-range splits do not tile the parquet file");
+    assert_eq!(reason, "scan ranges disagree on the parquet file size");
+}
+
+/// Splits arriving out of order still tile the file: the sweep sorts before checking, and the FE
+/// does not promise an order. Without the sort this case would be refused.
+#[test]
+fn split_broker_ranges_in_descending_order_are_accepted() {
+    let translated = PlanTranslator::new()
+        .translate_fragment(&params_with_splits(
+            "file:///data/users.parquet",
+            1024,
+            &[(512, 512), (0, 512)],
+        ))
+        .unwrap();
+    let rel::RelType::Read(read) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected local read");
+    };
+    let Some(read_rel::ReadType::LocalFiles(files)) = read.read_type.as_ref() else {
+        panic!("expected local files");
+    };
+    assert_eq!(files.items.len(), 1);
 }

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -893,16 +893,32 @@ fn bounded_split_with_unknown_file_size_is_unsupported() {
 }
 
 /// Verifies an empty (zero-byte) file range is rejected: it is not a readable
-/// parquet file, so it must not be passed to `parquet_scan`.
+/// parquet file, so it must not be passed to `parquet_scan`. Pins the reason too —
+/// an empty file used to be reported as a file-size disagreement, which sent the
+/// reader hunting for a second, differing range that does not exist.
 #[test]
 fn empty_file_scan_range_is_unsupported() {
-    assert_scan_range_unsupported(broker_scan_range(
-        "file:///data/users.parquet",
-        TFileFormatType::FORMAT_PARQUET,
-        0,
-        0,
-        Some(0),
-    ));
+    let err = PlanTranslator::new()
+        .translate_fragment(&params_with_scan_range(
+            TPlan::new(vec![scan_node(0, 0)]),
+            base_desc(),
+            0,
+            broker_scan_range(
+                "file:///data/users.parquet",
+                TFileFormatType::FORMAT_PARQUET,
+                0,
+                0,
+                Some(0),
+            ),
+        ))
+        .unwrap_err();
+    let TranslateError::UnsupportedScanRange { reason, .. } = err else {
+        panic!("expected an unsupported scan range, got {err:?}");
+    };
+    assert_eq!(
+        reason,
+        "parquet scan range reports an empty or negative file size"
+    );
 }
 
 /// Verifies a renamed column mapping is rejected: destination slot 1 ("id") fed
@@ -4358,6 +4374,36 @@ fn split_broker_ranges_disagreeing_on_file_size_are_unsupported() {
         panic!("expected an unsupported scan range, got {err:?}");
     };
     assert_eq!(reason, "scan ranges disagree on the parquet file size");
+}
+
+/// A split missing its `file_size` reports as missing wherever it lands in the list, not
+/// only when it happens to be inserted first. Checking agreement before presence made the
+/// message depend on arrival order: the same fragment reported "missing" or "disagree"
+/// depending on which range the FE sent first.
+#[test]
+fn split_broker_range_missing_file_size_after_the_first_is_unsupported() {
+    let path = "file:///data/users.parquet";
+    let mut fragment = params_with_splits(path, 1024, &[(0, 512)]);
+    fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap()
+        .push(TScanRangeParams::new(
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 512, 512, None),
+            None,
+            None,
+            None,
+        ));
+    let err = PlanTranslator::new()
+        .translate_fragment(&fragment)
+        .unwrap_err();
+    let TranslateError::UnsupportedScanRange { reason, .. } = err else {
+        panic!("expected an unsupported scan range, got {err:?}");
+    };
+    assert_eq!(reason, "scan range is missing the parquet file size");
 }
 
 /// Splits arriving out of order still tile the file: the sweep sorts before checking, and the FE

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -719,6 +719,64 @@ fn has_more_scan_ranges_are_refused() {
     );
 }
 
+/// The FE ends a connector scan's assignment with a placeholder `TScanRangeParams` that carries
+/// an empty `scan_range`, `empty = true` and `has_more` telling whether more ranges follow. The
+/// placeholder itself is skipped; only `has_more = true` refuses the fragment, so the order of the
+/// two checks matters and is pinned here.
+#[test]
+fn empty_placeholder_scan_ranges_are_skipped() {
+    let path = "file:///data/users.parquet";
+    let placeholder = |has_more: bool| {
+        TScanRangeParams::new(TScanRange::default(), None, Some(true), Some(has_more))
+    };
+    let with_placeholder = |has_more: bool| {
+        let mut fragment = params_with_scan_range(
+            TPlan::new(vec![scan_node(0, 0)]),
+            base_desc(),
+            0,
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, -1, Some(1024)),
+        );
+        fragment
+            .params
+            .as_mut()
+            .unwrap()
+            .per_node_scan_ranges
+            .get_mut(&0)
+            .unwrap()
+            .push(placeholder(has_more));
+        fragment
+    };
+
+    let translated = PlanTranslator::new()
+        .translate_fragment(&with_placeholder(false))
+        .expect("an empty placeholder without has_more is skipped");
+    let rel::RelType::Read(read) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected local read");
+    };
+    let Some(read_rel::ReadType::LocalFiles(files)) = read.read_type.as_ref() else {
+        panic!("expected local files");
+    };
+    assert_eq!(files.items.len(), 1);
+
+    let err = PlanTranslator::new()
+        .translate_fragment(&with_placeholder(true))
+        .unwrap_err();
+    let TranslateError::UnsupportedScanRange { reason, .. } = err else {
+        panic!("expected an unsupported scan range, got {err:?}");
+    };
+    assert_eq!(
+        reason,
+        "incremental scan-range delivery (has_more) is not supported"
+    );
+}
+
 /// Verifies complete byte-range splits are collapsed to one whole-file local read.
 #[test]
 fn complete_split_broker_ranges_produce_one_local_file() {
@@ -853,6 +911,20 @@ fn split_broker_ranges_extending_past_eof_are_unsupported() {
     );
 }
 
+/// A zero-length split covers nothing, so it can never be part of a tiling: `(0, 0)` is refused
+/// outright, and a zero-length tail `(1024, -1)` after a whole-file split trips the same rule.
+#[test]
+fn zero_size_split_is_unsupported() {
+    assert_eq!(
+        splits_rejected_because(1024, &[(0, 0)]),
+        "byte-range splits do not tile the parquet file"
+    );
+    assert_eq!(
+        splits_rejected_because(1024, &[(0, 1024), (1024, -1)]),
+        "byte-range splits do not tile the parquet file"
+    );
+}
+
 /// Two splits that both cover the head of the file are refused. They "cover" every byte, so a
 /// sweep that only rejects gaps collapses them into one whole-file read — Sirius would scan the
 /// shared row groups once where StarRocks scans them on both instances, and `count(*)` would
@@ -934,6 +1006,53 @@ fn split_broker_ranges_in_descending_order_are_accepted() {
             &[(512, 512), (0, 512)],
         ))
         .unwrap();
+    let rel::RelType::Read(read) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected local read");
+    };
+    let Some(read_rel::ReadType::LocalFiles(files)) = read.read_type.as_ref() else {
+        panic!("expected local files");
+    };
+    assert_eq!(files.items.len(), 1);
+}
+
+/// The motivating shape: with pipeline dop the FE hands one instance several splits of the same
+/// file under different driver sequences. They must be combined across sequences into one
+/// whole-file read, not validated per sequence.
+#[test]
+fn per_driver_split_ranges_across_sequences_produce_one_local_file() {
+    let path = "file:///data/users.parquet";
+    let mut fragment = params_with_per_driver_scan_range(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        0,
+        broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, 512, Some(1024)),
+    );
+    fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .node_to_per_driver_seq_scan_ranges
+        .as_mut()
+        .unwrap()
+        .get_mut(&0)
+        .unwrap()
+        .insert(
+            1,
+            vec![TScanRangeParams::new(
+                broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 512, 512, Some(1024)),
+                None,
+                None,
+                None,
+            )],
+        );
+    let translated = PlanTranslator::new().translate_fragment(&fragment).unwrap();
     let rel::RelType::Read(read) = root(&translated.plan)
         .input
         .as_ref()

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -879,16 +879,32 @@ fn bounded_split_with_unknown_file_size_is_unsupported() {
 }
 
 /// Verifies an empty (zero-byte) file range is rejected: it is not a readable
-/// parquet file, so it must not be passed to `parquet_scan`.
+/// parquet file, so it must not be passed to `parquet_scan`. Pins the reason too —
+/// an empty file used to be reported as a file-size disagreement, which sent the
+/// reader hunting for a second, differing range that does not exist.
 #[test]
 fn empty_file_scan_range_is_unsupported() {
-    assert_scan_range_unsupported(broker_scan_range(
-        "file:///data/users.parquet",
-        TFileFormatType::FORMAT_PARQUET,
-        0,
-        0,
-        Some(0),
-    ));
+    let err = PlanTranslator::new()
+        .translate_fragment(&params_with_scan_range(
+            TPlan::new(vec![scan_node(0, 0)]),
+            base_desc(),
+            0,
+            broker_scan_range(
+                "file:///data/users.parquet",
+                TFileFormatType::FORMAT_PARQUET,
+                0,
+                0,
+                Some(0),
+            ),
+        ))
+        .unwrap_err();
+    let TranslateError::UnsupportedScanRange { reason, .. } = err else {
+        panic!("expected an unsupported scan range, got {err:?}");
+    };
+    assert_eq!(
+        reason,
+        "parquet scan range reports an empty or negative file size"
+    );
 }
 
 /// Verifies a renamed column mapping is rejected: destination slot 1 ("id") fed
@@ -3688,6 +3704,36 @@ fn split_broker_ranges_disagreeing_on_file_size_are_unsupported() {
         panic!("expected an unsupported scan range, got {err:?}");
     };
     assert_eq!(reason, "scan ranges disagree on the parquet file size");
+}
+
+/// A split missing its `file_size` reports as missing wherever it lands in the list, not
+/// only when it happens to be inserted first. Checking agreement before presence made the
+/// message depend on arrival order: the same fragment reported "missing" or "disagree"
+/// depending on which range the FE sent first.
+#[test]
+fn split_broker_range_missing_file_size_after_the_first_is_unsupported() {
+    let path = "file:///data/users.parquet";
+    let mut fragment = params_with_splits(path, 1024, &[(0, 512)]);
+    fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap()
+        .push(TScanRangeParams::new(
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 512, 512, None),
+            None,
+            None,
+            None,
+        ));
+    let err = PlanTranslator::new()
+        .translate_fragment(&fragment)
+        .unwrap_err();
+    let TranslateError::UnsupportedScanRange { reason, .. } = err else {
+        panic!("expected an unsupported scan range, got {err:?}");
+    };
+    assert_eq!(reason, "scan range is missing the parquet file size");
 }
 
 /// Splits arriving out of order still tile the file: the sweep sorts before checking, and the FE

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -668,6 +668,46 @@ fn split_broker_range_is_unsupported() {
     }
 }
 
+/// Verifies complete byte-range splits are collapsed to one whole-file local read.
+#[test]
+fn complete_split_broker_ranges_produce_one_local_file() {
+    let path = "file:///data/users.parquet";
+    let mut fragment = params_with_scan_range(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        0,
+        broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, 512, Some(1024)),
+    );
+    fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap()
+        .push(TScanRangeParams::new(
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 512, 512, Some(1024)),
+            None,
+            None,
+            None,
+        ));
+    let translated = PlanTranslator::new().translate_fragment(&fragment).unwrap();
+    let rel::RelType::Read(read) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected local read");
+    };
+    let Some(read_rel::ReadType::LocalFiles(files)) = read.read_type.as_ref() else {
+        panic!("expected local files");
+    };
+    assert_eq!(files.items.len(), 1);
+}
+
 /// Verifies a scan range delivered via the pipeline per-driver-sequence map is
 /// collected too (not just `per_node_scan_ranges`).
 #[test]

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -3571,19 +3571,103 @@ fn sort_with_conjuncts_is_rejected() {
     );
 }
 
+/// Builds fragment params whose node-0 scan carries every `(start, size)` split of `path`, all
+/// declaring `file_size`, in the order given.
+fn params_with_splits(
+    path: &str,
+    file_size: i64,
+    splits: &[(i64, i64)],
+) -> TExecPlanFragmentParams {
+    let (first, rest) = splits.split_first().expect("at least one split");
+    let mut fragment = params_with_scan_range(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        0,
+        broker_scan_range(
+            path,
+            TFileFormatType::FORMAT_PARQUET,
+            first.0,
+            first.1,
+            Some(file_size),
+        ),
+    );
+    let ranges = fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap();
+    for &(start, size) in rest {
+        ranges.push(TScanRangeParams::new(
+            broker_scan_range(
+                path,
+                TFileFormatType::FORMAT_PARQUET,
+                start,
+                size,
+                Some(file_size),
+            ),
+            None,
+            None,
+            None,
+        ));
+    }
+    fragment
+}
+
+/// Translates `splits` and returns the `UnsupportedScanRange` reason they were refused with.
+fn splits_rejected_because(file_size: i64, splits: &[(i64, i64)]) -> &'static str {
+    let err = PlanTranslator::new()
+        .translate_fragment(&params_with_splits(
+            "file:///data/users.parquet",
+            file_size,
+            splits,
+        ))
+        .unwrap_err();
+    let TranslateError::UnsupportedScanRange { node_id, reason } = err else {
+        panic!("expected an unsupported scan range, got {err:?}");
+    };
+    assert_eq!(node_id, 0);
+    reason
+}
+
+/// Splits that leave a hole are refused: collapsing them to a whole-file read would scan the
+/// hole, which a sibling instance is already scanning.
+#[test]
+fn split_broker_ranges_with_a_gap_are_unsupported() {
+    assert_eq!(
+        splits_rejected_because(1024, &[(0, 256), (512, 512)]),
+        "byte-range splits do not tile the parquet file"
+    );
+}
+
+/// Splits that tile a prefix but stop short of the file are refused: the tail would be dropped.
+#[test]
+fn split_broker_ranges_covering_only_a_prefix_are_unsupported() {
+    assert_eq!(
+        splits_rejected_because(1024, &[(0, 256), (256, 256)]),
+        "byte-range splits do not tile the parquet file"
+    );
+}
+
 /// Two splits that both cover the head of the file are refused. They "cover" every byte, so a
 /// sweep that only rejects gaps collapses them into one whole-file read — Sirius would scan the
 /// shared row groups once where StarRocks scans them on both instances, and `count(*)` would
 /// disagree with no error.
 #[test]
 fn overlapping_split_broker_ranges_are_unsupported() {
-    let path = "file:///data/users.parquet";
-    let mut fragment = params_with_scan_range(
-        TPlan::new(vec![scan_node(0, 0)]),
-        base_desc(),
-        0,
-        broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, 1024, Some(1024)),
+    assert_eq!(
+        splits_rejected_because(1024, &[(0, 1024), (0, 512)]),
+        "byte-range splits do not tile the parquet file"
     );
+}
+
+/// Splits of one file that disagree on how big that file is are refused — the coverage check
+/// would otherwise be measured against an arbitrary one of them.
+#[test]
+fn split_broker_ranges_disagreeing_on_file_size_are_unsupported() {
+    let path = "file:///data/users.parquet";
+    let mut fragment = params_with_splits(path, 1024, &[(0, 512)]);
     fragment
         .params
         .as_mut()
@@ -3592,7 +3676,7 @@ fn overlapping_split_broker_ranges_are_unsupported() {
         .get_mut(&0)
         .unwrap()
         .push(TScanRangeParams::new(
-            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, 512, Some(1024)),
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 512, 512, Some(2048)),
             None,
             None,
             None,
@@ -3600,9 +3684,35 @@ fn overlapping_split_broker_ranges_are_unsupported() {
     let err = PlanTranslator::new()
         .translate_fragment(&fragment)
         .unwrap_err();
-    let TranslateError::UnsupportedScanRange { node_id, reason } = err else {
+    let TranslateError::UnsupportedScanRange { reason, .. } = err else {
         panic!("expected an unsupported scan range, got {err:?}");
     };
-    assert_eq!(node_id, 0);
-    assert_eq!(reason, "byte-range splits do not tile the parquet file");
+    assert_eq!(reason, "scan ranges disagree on the parquet file size");
+}
+
+/// Splits arriving out of order still tile the file: the sweep sorts before checking, and the FE
+/// does not promise an order. Without the sort this case would be refused.
+#[test]
+fn split_broker_ranges_in_descending_order_are_accepted() {
+    let translated = PlanTranslator::new()
+        .translate_fragment(&params_with_splits(
+            "file:///data/users.parquet",
+            1024,
+            &[(512, 512), (0, 512)],
+        ))
+        .unwrap();
+    let rel::RelType::Read(read) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected local read");
+    };
+    let Some(read_rel::ReadType::LocalFiles(files)) = read.read_type.as_ref() else {
+        panic!("expected local files");
+    };
+    assert_eq!(files.items.len(), 1);
 }

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -3570,3 +3570,39 @@ fn sort_with_conjuncts_is_rejected() {
         "{err:?}"
     );
 }
+
+/// Two splits that both cover the head of the file are refused. They "cover" every byte, so a
+/// sweep that only rejects gaps collapses them into one whole-file read — Sirius would scan the
+/// shared row groups once where StarRocks scans them on both instances, and `count(*)` would
+/// disagree with no error.
+#[test]
+fn overlapping_split_broker_ranges_are_unsupported() {
+    let path = "file:///data/users.parquet";
+    let mut fragment = params_with_scan_range(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        0,
+        broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, 1024, Some(1024)),
+    );
+    fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap()
+        .push(TScanRangeParams::new(
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, 512, Some(1024)),
+            None,
+            None,
+            None,
+        ));
+    let err = PlanTranslator::new()
+        .translate_fragment(&fragment)
+        .unwrap_err();
+    let TranslateError::UnsupportedScanRange { node_id, reason } = err else {
+        panic!("expected an unsupported scan range, got {err:?}");
+    };
+    assert_eq!(node_id, 0);
+    assert_eq!(reason, "byte-range splits do not tile the parquet file");
+}


### PR DESCRIPTION
## Description
**Motivation.** `check_range` refused any broker range that was not provably the whole file, so a fragment instance that owns *every* split of a file (routine with pipeline dop: several driver-sequence splits of one file land on one instance) failed outright, and a `FILES()` scan of any parquet file above `min_bytes_per_broker_scanner` could not run on the CN.

**What changed.** Ranges are collected per node and path (`CollectedRanges`, BTreeMap for deterministic diagnostics) and `validate_complete_files` accepts exactly one shape: a strict tiling from byte 0 to EOF, collapsed to one whole-file `local_files` item. Gaps, prefixes and overlaps are refused with one reason ("byte-range splits do not tile the parquet file"); a missing file size, disagreeing file sizes, an empty or negative file size and a split past EOF each have their own reason, and a missing size is reported before a disagreement. Incremental delivery (`has_more`) is refused, empty placeholder ranges are skipped, and a split that runs past EOF is refused instead of being collapsed to a whole-file read.

**Verified.** fmt/clippy/`cargo test --workspace --no-default-features`: `complete_split_broker_ranges_produce_one_local_file`, `split_broker_ranges_with_a_gap_are_unsupported`, `split_broker_ranges_covering_only_a_prefix_are_unsupported`, `overlapping_split_broker_ranges_are_unsupported`, `split_broker_ranges_disagreeing_on_file_size_are_unsupported`, `split_broker_range_missing_file_size_after_the_first_is_unsupported`, `split_broker_ranges_in_descending_order_are_accepted`, `has_more_scan_ranges_are_refused`, `split_broker_ranges_extending_past_eof_are_unsupported`, `empty_placeholder_scan_ranges_are_skipped`, `zero_size_split_is_unsupported`, `per_driver_split_ranges_across_sequences_produce_one_local_file`. Local run on 663fc838 (rebased onto dev c7b21ae7 after #1233, #1235 and #1236 merged): fmt and clippy clean; starrocks-plan-translator 6 unit + 116 `translate.rs` tests, sirius-starrocks-cn 49 tests, all passing.

**Intentionally not handled.** A lone partial split is still refused: emitting `FileOrFiles.start/length` requires the engine-side byte-range work (row-group ownership rule, ingestible range filter, Substrait range registry). That stack replaces `validate_complete_files` with explicit splits; it is not part of this PR.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
Originally stacked on #1111 (merged), now independent. Refs #1021 (introduced the whole-file-only `check_range` this replaces, merged). Follow-up: the engine byte-range stack is tracked in #1635 and supersedes the closed #1636-#1639.