### PR TITLE
fix(starrocks): materialize common project slots

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
@@ -21,6 +21,8 @@ pub(crate) struct ExprContext<'a> {
     registry: &'a mut ExtensionRegistry,
     /// Tuple ids that describe the input row visible to this expression.
     row_tuples: &'a [i32],
+    /// Synthetic StarRocks slots appended while evaluating common project expressions.
+    slot_overrides: Option<&'a std::collections::HashMap<(i32, i32), usize>>,
 }
 
 impl<'a> ExprContext<'a> {
@@ -34,6 +36,23 @@ impl<'a> ExprContext<'a> {
             desc,
             registry,
             row_tuples,
+            slot_overrides: None,
+        }
+    }
+
+    /// Creates an expression context that can resolve synthetic slots not present
+    /// in the descriptor table.
+    pub(crate) fn with_slot_overrides(
+        desc: &'a DescriptorTable,
+        registry: &'a mut ExtensionRegistry,
+        row_tuples: &'a [i32],
+        slot_overrides: &'a std::collections::HashMap<(i32, i32), usize>,
+    ) -> Self {
+        Self {
+            desc,
+            registry,
+            row_tuples,
+            slot_overrides: Some(slot_overrides),
         }
     }
 }
@@ -147,9 +166,18 @@ fn translate_slot_ref(
         context: "SLOT_REF",
         field: "slot_ref",
     })?;
-    let field =
-        ctx.desc
-            .slot_global_index(slot_ref.tuple_id, slot_ref.slot_id, ctx.row_tuples)? as i32;
+    let field = ctx
+        .slot_overrides
+        .and_then(|overrides| {
+            overrides
+                .get(&(slot_ref.tuple_id, slot_ref.slot_id))
+                .copied()
+        })
+        .map(Ok)
+        .unwrap_or_else(|| {
+            ctx.desc
+                .slot_global_index(slot_ref.tuple_id, slot_ref.slot_id, ctx.row_tuples)
+        })? as i32;
     Ok(Expression {
         rex_type: Some(expression::RexType::Selection(Box::new(FieldReference {
             reference_type: Some(field_reference::ReferenceType::DirectReference(

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -30,7 +30,7 @@
 //! | `FILE_SCAN_NODE`     | `ReadRel` (local files) |
 //! | `HDFS_SCAN_NODE`     | `ReadRel` (named table) |
 //! | `SELECT_NODE`        | `FilterRel`        |
-//! | `PROJECT_NODE`       | `ProjectRel`       |
+//! | `PROJECT_NODE`       | `ProjectRel` (common slots materialized first as hidden `ProjectRel`s) |
 //! | `AGGREGATION_NODE`   | `AggregateRel` (finalized one-phase only, `new_planner_agg_stage=1`) |
 //! | `SORT_NODE`          | `ProjectRel` (sort tuple) + `SortRel` (global row-number top-N only) |
 //! | `HASH_JOIN_NODE`      | `JoinRel` (inner/outer/left-semi; left/right anti as outer join + `is_null` filter, null-aware left anti as mark join + `not`) |

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -70,6 +70,15 @@ impl<'a> PlanContext<'a> {
     fn expr_context<'b>(&'b mut self, row_tuples: &'b [i32]) -> ExprContext<'b> {
         ExprContext::new(self.desc, self.registry, row_tuples)
     }
+
+    /// Creates an expression context with synthetic slot-to-column mappings.
+    fn expr_context_with_slots<'b>(
+        &'b mut self,
+        row_tuples: &'b [i32],
+        slot_overrides: &'b std::collections::HashMap<(i32, i32), usize>,
+    ) -> ExprContext<'b> {
+        ExprContext::with_slot_overrides(self.desc, self.registry, row_tuples, slot_overrides)
+    }
 }
 
 /// Trait implemented by StarRocks plan objects that can become Substrait relations.
@@ -997,6 +1006,19 @@ fn translate_project_node(
         node.row_tuples.clone()
     };
 
+    let output_tuple = output_tuples[0];
+    let mut input = child;
+    let mut common_slots = std::collections::HashMap::new();
+    for (&slot_id, expr) in project_node.common_slot_map.as_ref().into_iter().flatten() {
+        let expression = {
+            let mut expr_ctx = ctx.expr_context_with_slots(&input.row_tuples, &common_slots);
+            expr.translate(&mut expr_ctx)?
+        };
+        let field = input.output_width;
+        input = append_project(input, expression);
+        common_slots.insert((output_tuple, slot_id), field);
+    }
+
     let mut expressions = Vec::new();
     for &tuple_id in &output_tuples {
         for slot_id in ctx.desc.materialized_slot_ids(tuple_id)? {
@@ -1006,12 +1028,12 @@ fn translate_project_node(
                     node.node_id, slot_id
                 ))
             })?;
-            let mut expr_ctx = ctx.expr_context(&child.row_tuples);
+            let mut expr_ctx = ctx.expr_context_with_slots(&input.row_tuples, &common_slots);
             expressions.push(expr.translate(&mut expr_ctx)?);
         }
     }
 
-    Ok(project_rel(child, expressions, output_tuples))
+    Ok(project_rel(input, expressions, output_tuples))
 }
 
 /// Adds a root projection over explicit fragment output expressions.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -274,12 +274,12 @@ fn translate_scan(
     apply_conjuncts(input, node, ctx)
 }
 
-/// Wraps the child relation of a `SELECT_NODE` with its filter conjuncts.
 /// Refuses a node whose `common_slot_map` this translator does not materialize.
 ///
-/// Only `PROJECT_NODE` appends its common slots. Every other node carrying the field would have
-/// its shared sub-expressions dropped, and any slot ref resolving to one of them then reads a
-/// column that was never emitted -- wrong values under the right names, with no error.
+/// Only `PROJECT_NODE` appends its common slots. On every other node carrying the field the
+/// shared sub-expressions would be read past: a conjunct or key that references one of them then
+/// fails later with an opaque descriptor error (`slot N (tuple T) is not part of row_tuples`),
+/// and a map nothing references is silently ignored. Report the unsupported shape up front.
 fn reject_common_slots(
     node: &TPlanNode,
     common_slot_map: Option<&BTreeMap<TSlotId, TExpr>>,
@@ -294,6 +294,7 @@ fn reject_common_slots(
     Ok(())
 }
 
+/// Wraps the child relation of a `SELECT_NODE` with its filter conjuncts.
 fn translate_select(
     node: &TPlanNode,
     children: Vec<TranslatedRel>,

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -1,6 +1,9 @@
+use std::collections::BTreeMap;
+
 use starrocks_thrift::exprs::TExpr;
 use starrocks_thrift::opcodes::TExprOpcode;
 use starrocks_thrift::plan_nodes::{TJoinOp, TPlan, TPlanNode, TPlanNodeType, TSortInfo};
+use starrocks_thrift::types::TSlotId;
 use substrait::proto::read_rel::local_files::FileOrFiles;
 use substrait::proto::read_rel::local_files::file_or_files::{
     FileFormat, ParquetReadOptions, PathType,
@@ -272,12 +275,37 @@ fn translate_scan(
 }
 
 /// Wraps the child relation of a `SELECT_NODE` with its filter conjuncts.
+/// Refuses a node whose `common_slot_map` this translator does not materialize.
+///
+/// Only `PROJECT_NODE` appends its common slots. Every other node carrying the field would have
+/// its shared sub-expressions dropped, and any slot ref resolving to one of them then reads a
+/// column that was never emitted -- wrong values under the right names, with no error.
+fn reject_common_slots(
+    node: &TPlanNode,
+    common_slot_map: Option<&BTreeMap<TSlotId, TExpr>>,
+) -> Result<()> {
+    if common_slot_map.is_some_and(|map| !map.is_empty()) {
+        return Err(TranslateError::UnsupportedPlanNode {
+            node_id: node.node_id,
+            node_type: node.node_type,
+            reason: "common slots are only materialized on PROJECT_NODE",
+        });
+    }
+    Ok(())
+}
+
 fn translate_select(
     node: &TPlanNode,
     children: Vec<TranslatedRel>,
     ctx: &mut PlanContext<'_>,
 ) -> Result<TranslatedRel> {
     expect_children(node, &children, 1)?;
+    reject_common_slots(
+        node,
+        node.select_node
+            .as_ref()
+            .and_then(|select| select.common_slot_map.as_ref()),
+    )?;
     apply_conjuncts(children.into_iter().next().unwrap(), node, ctx)
 }
 
@@ -640,6 +668,12 @@ fn translate_hash_join(
     ctx: &mut PlanContext<'_>,
 ) -> Result<TranslatedRel> {
     expect_children(node, &children, 2)?;
+    reject_common_slots(
+        node,
+        node.hash_join_node
+            .as_ref()
+            .and_then(|join| join.common_slot_map.as_ref()),
+    )?;
     let join = node
         .hash_join_node
         .as_ref()
@@ -830,6 +864,7 @@ fn translate_nestloop_join(
             context: "NESTLOOP_JOIN_NODE",
             field: "nestloop_join_node",
         })?;
+    reject_common_slots(node, join.common_slot_map.as_ref())?;
     match join.join_op {
         None | Some(TJoinOp::CROSS_JOIN) | Some(TJoinOp::INNER_JOIN) => {}
         Some(_) => {

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -1126,9 +1126,9 @@ fn project_common_slots_are_materialized_before_visible_expressions() {
     let desc = desc_table(
         vec![(0, Some(100)), (1, None)],
         vec![
-            slot(1, 0, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
-            slot(2, 0, 1, "name", scalar_type(TPrimitiveType::VARCHAR)),
-            slot(3, 1, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(1, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(3, 1, "id", scalar_type(TPrimitiveType::BIGINT)),
         ],
     );
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -1164,10 +1164,27 @@ fn project_common_slots_are_materialized_before_visible_expressions() {
         panic!("expected struct field");
     };
     assert_eq!(field.field, 2);
-    assert!(matches!(
-        visible.input.as_ref().unwrap().rel_type.as_ref().unwrap(),
-        rel::RelType::Project(_)
-    ));
+
+    // The hidden project must pass its two input columns through and append the common slot,
+    // and the visible project must then read past all three. Asserting only that a project
+    // exists leaves the emit mappings -- the single line this lowering rests on -- unobserved.
+    let rel::RelType::Project(hidden) = visible.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected the hidden project under the visible one");
+    };
+    assert_eq!(hidden.expressions.len(), 1);
+    assert_eq!(emit_mapping(hidden.common.as_ref()), vec![0, 1, 2]);
+    assert_eq!(emit_mapping(visible.common.as_ref()), vec![3]);
+}
+
+/// Reads a relation's `RelCommon` emit mapping, which is what a consumer projects by.
+fn emit_mapping(common: Option<&substrait::proto::RelCommon>) -> Vec<i32> {
+    let Some(substrait::proto::rel_common::EmitKind::Emit(emit)) =
+        common.and_then(|common| common.emit_kind.as_ref())
+    else {
+        panic!("expected an explicit emit mapping");
+    };
+    emit.output_mapping.clone()
 }
 
 /// Verifies fragment output expressions add the final root projection.

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -1112,6 +1112,64 @@ fn scan_project_preserves_descriptor_output_order() {
     }
 }
 
+/// Verifies hidden project expressions are appended in key order and can be
+/// referenced by visible expressions without descriptor-table slots.
+#[test]
+fn project_common_slots_are_materialized_before_visible_expressions() {
+    let mut common_slot_map = BTreeMap::new();
+    common_slot_map.insert(5, slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)));
+    let mut slot_map = BTreeMap::new();
+    slot_map.insert(3, slot_ref(5, 1, scalar_type(TPrimitiveType::BIGINT)));
+
+    let mut project = base_plan_node(1, TPlanNodeType::PROJECT_NODE, 1, vec![1]);
+    project.project_node = Some(TProjectNode::new(Some(slot_map), Some(common_slot_map)));
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None)],
+        vec![
+            slot(1, 0, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, 1, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(3, 1, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![project, scan_node(0, 0)])),
+        Some(desc),
+        None,
+    ))
+    .unwrap();
+    let rel::RelType::Project(visible) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected visible project");
+    };
+    let expression::RexType::Selection(selection) =
+        visible.expressions[0].rex_type.as_ref().unwrap()
+    else {
+        panic!("expected common-slot selection");
+    };
+    let expression::field_reference::ReferenceType::DirectReference(segment) =
+        selection.reference_type.as_ref().unwrap()
+    else {
+        panic!("expected direct field reference");
+    };
+    let expression::reference_segment::ReferenceType::StructField(field) =
+        segment.reference_type.as_ref().unwrap()
+    else {
+        panic!("expected struct field");
+    };
+    assert_eq!(field.field, 2);
+    assert!(matches!(
+        visible.input.as_ref().unwrap().rel_type.as_ref().unwrap(),
+        rel::RelType::Project(_)
+    ));
+}
+
 /// Verifies fragment output expressions add the final root projection.
 #[test]
 fn fragment_output_exprs_add_root_projection() {

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -214,6 +214,20 @@ fn bool_literal(value: bool) -> TExpr {
     TExpr::new(vec![node])
 }
 
+/// Builds an arithmetic expression and appends child nodes in preorder.
+fn arithmetic(opcode: TExprOpcode, left: TExpr, right: TExpr) -> TExpr {
+    let mut node = base_expr_node(
+        TExprNodeType::ARITHMETIC_EXPR,
+        scalar_type(TPrimitiveType::BIGINT),
+        2,
+    );
+    node.opcode = Some(opcode);
+    let mut nodes = vec![node];
+    nodes.extend(left.nodes);
+    nodes.extend(right.nodes);
+    TExpr::new(nodes)
+}
+
 /// Builds a binary predicate expression and appends child nodes in preorder.
 fn binary_pred(opcode: TExprOpcode, left: TExpr, right: TExpr) -> TExpr {
     let mut node = base_expr_node(
@@ -1175,6 +1189,87 @@ fn project_common_slots_are_materialized_before_visible_expressions() {
     assert_eq!(hidden.expressions.len(), 1);
     assert_eq!(emit_mapping(hidden.common.as_ref()), vec![0, 1, 2]);
     assert_eq!(emit_mapping(visible.common.as_ref()), vec![3]);
+}
+
+/// A later hidden slot may name an earlier one. The translator appends one
+/// project per entry in ascending slot id, so the second expression already
+/// sees the first column. Putting every hidden expression in one `ProjectRel`
+/// would evaluate them all against the scan and this case would break.
+#[test]
+fn nested_common_slots_are_appended_in_slot_id_order() {
+    let bigint = scalar_type(TPrimitiveType::BIGINT);
+    let mut common_slot_map = BTreeMap::new();
+    common_slot_map.insert(4, slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR)));
+    common_slot_map.insert(5, slot_ref(1, 0, bigint.clone()));
+    common_slot_map.insert(
+        6,
+        arithmetic(
+            TExprOpcode::ADD,
+            slot_ref(5, 1, bigint.clone()),
+            int_literal(1),
+        ),
+    );
+    let mut slot_map = BTreeMap::new();
+    slot_map.insert(3, slot_ref(6, 1, bigint));
+
+    let mut project = base_plan_node(1, TPlanNodeType::PROJECT_NODE, 1, vec![1]);
+    project.project_node = Some(TProjectNode::new(Some(slot_map), Some(common_slot_map)));
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None)],
+        vec![
+            slot(1, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(3, 1, "id", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![project, scan_node(0, 0)])),
+        Some(desc),
+        None,
+    ))
+    .unwrap();
+    let visible = as_project(root(&translated.plan).input.as_ref().unwrap());
+    assert_eq!(struct_field(&visible.expressions[0]), 4);
+    assert_eq!(emit_mapping(visible.common.as_ref()), vec![5]);
+
+    let cse2 = as_project(visible.input.as_ref().unwrap());
+    assert_eq!(struct_field(scalar_arg(&cse2.expressions[0], 0)), 3);
+    assert_eq!(emit_mapping(cse2.common.as_ref()), vec![0, 1, 2, 3, 4]);
+
+    let cse1 = as_project(cse2.input.as_ref().unwrap());
+    assert_eq!(struct_field(&cse1.expressions[0]), 0);
+    assert_eq!(emit_mapping(cse1.common.as_ref()), vec![0, 1, 2, 3]);
+
+    let first = as_project(cse1.input.as_ref().unwrap());
+    assert_eq!(struct_field(&first.expressions[0]), 1);
+    assert_eq!(emit_mapping(first.common.as_ref()), vec![0, 1, 2]);
+}
+
+/// Unwraps a Substrait project relation.
+fn as_project(rel: &substrait::proto::Rel) -> &substrait::proto::ProjectRel {
+    match rel.rel_type.as_ref().unwrap() {
+        rel::RelType::Project(project) => project,
+        other => panic!("expected project rel, got {other:?}"),
+    }
+}
+
+/// Reads the zero-based field index from a Substrait struct-field selection.
+fn struct_field(expr: &substrait::proto::Expression) -> i32 {
+    let expression::RexType::Selection(selection) = expr.rex_type.as_ref().unwrap() else {
+        panic!("expected field selection");
+    };
+    let expression::field_reference::ReferenceType::DirectReference(segment) =
+        selection.reference_type.as_ref().unwrap()
+    else {
+        panic!("expected direct field reference");
+    };
+    let expression::reference_segment::ReferenceType::StructField(field) =
+        segment.reference_type.as_ref().unwrap()
+    else {
+        panic!("expected struct field");
+    };
+    field.field
 }
 
 /// Reads a relation's `RelCommon` emit mapping, which is what a consumer projects by.

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -3941,16 +3941,6 @@ fn sort_with_conjuncts_is_rejected() {
     );
 }
 
-/// Reads a relation's `RelCommon` emit mapping — what a consumer actually projects by.
-fn emit_mapping(common: Option<&substrait::proto::RelCommon>) -> Vec<i32> {
-    let Some(substrait::proto::rel_common::EmitKind::Emit(emit)) =
-        common.and_then(|common| common.emit_kind.as_ref())
-    else {
-        panic!("expected an explicit emit mapping");
-    };
-    emit.output_mapping.clone()
-}
-
 /// A two-column left side and a one-column right side, so the synthetic-key arithmetic cannot be
 /// satisfied by more than one formula.
 fn asymmetric_join_desc() -> TDescriptorTable {
@@ -4067,4 +4057,51 @@ fn bare_cross_join_translates_to_constant_key_join() {
         })
         .collect();
     assert_eq!(operands, vec![2, 4]);
+}
+
+/// Only `PROJECT_NODE` materializes its common slots. A `SELECT_NODE`, hash join or nested-loop
+/// join carrying the same field is refused rather than having its shared sub-expressions dropped
+/// — a slot ref resolving to one of them would otherwise read a column that was never emitted.
+#[test]
+fn common_slots_outside_a_project_are_rejected() {
+    let common = || {
+        let mut map = BTreeMap::new();
+        map.insert(5, slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)));
+        Some(map)
+    };
+
+    let mut select = base_plan_node(1, TPlanNodeType::SELECT_NODE, 1, vec![0]);
+    select.select_node = Some(TSelectNode::new(common()));
+    let select_plan = TPlan::new(vec![select, scan_node(0, 0)]);
+
+    let mut hash_join = hash_join_node(TJoinOp::INNER_JOIN);
+    hash_join.hash_join_node.as_mut().unwrap().common_slot_map = common();
+    let hash_plan = TPlan::new(vec![hash_join, scan_node(0, 0), scan_node(1, 1)]);
+
+    let mut nestloop = nestloop_join_node(
+        TJoinOp::INNER_JOIN,
+        vec![binary_pred(
+            TExprOpcode::LT,
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+        )],
+    );
+    nestloop
+        .nestloop_join_node
+        .as_mut()
+        .unwrap()
+        .common_slot_map = common();
+    let nestloop_plan = TPlan::new(vec![nestloop, scan_node(0, 0), scan_node(1, 1)]);
+
+    for (label, plan, desc) in [
+        ("SELECT_NODE", select_plan, base_desc()),
+        ("HASH_JOIN_NODE", hash_plan, join_desc()),
+        ("NESTLOOP_JOIN_NODE", nestloop_plan, join_desc()),
+    ] {
+        let err = translate_fragment(&params(Some(plan), Some(desc), None)).unwrap_err();
+        let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
+            panic!("{label}: expected an unsupported plan node, got {err:?}");
+        };
+        assert_eq!(reason, "common slots are only materialized on PROJECT_NODE");
+    }
 }

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -1272,14 +1272,51 @@ fn struct_field(expr: &substrait::proto::Expression) -> i32 {
     field.field
 }
 
-/// Reads a relation's `RelCommon` emit mapping, which is what a consumer projects by.
-fn emit_mapping(common: Option<&substrait::proto::RelCommon>) -> Vec<i32> {
-    let Some(substrait::proto::rel_common::EmitKind::Emit(emit)) =
-        common.and_then(|common| common.emit_kind.as_ref())
-    else {
-        panic!("expected an explicit emit mapping");
+/// Only `PROJECT_NODE` materializes its common slots. A `SELECT_NODE`, hash join or nested-loop
+/// join carrying the same field is refused rather than having its shared sub-expressions dropped
+/// — a slot ref resolving to one of them would otherwise read a column that was never emitted.
+#[test]
+fn common_slots_outside_a_project_are_rejected() {
+    let common = || {
+        let mut map = BTreeMap::new();
+        map.insert(5, slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)));
+        Some(map)
     };
-    emit.output_mapping.clone()
+
+    let mut select = base_plan_node(1, TPlanNodeType::SELECT_NODE, 1, vec![0]);
+    select.select_node = Some(TSelectNode::new(common()));
+    let select_plan = TPlan::new(vec![select, scan_node(0, 0)]);
+
+    let mut hash_join = hash_join_node(TJoinOp::INNER_JOIN);
+    hash_join.hash_join_node.as_mut().unwrap().common_slot_map = common();
+    let hash_plan = TPlan::new(vec![hash_join, scan_node(0, 0), scan_node(1, 1)]);
+
+    let mut nestloop = nestloop_join_node(
+        TJoinOp::INNER_JOIN,
+        vec![binary_pred(
+            TExprOpcode::LT,
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+        )],
+    );
+    nestloop
+        .nestloop_join_node
+        .as_mut()
+        .unwrap()
+        .common_slot_map = common();
+    let nestloop_plan = TPlan::new(vec![nestloop, scan_node(0, 0), scan_node(1, 1)]);
+
+    for (label, plan, desc) in [
+        ("SELECT_NODE", select_plan, base_desc()),
+        ("HASH_JOIN_NODE", hash_plan, join_desc()),
+        ("NESTLOOP_JOIN_NODE", nestloop_plan, join_desc()),
+    ] {
+        let err = translate_fragment(&params(Some(plan), Some(desc), None)).unwrap_err();
+        let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
+            panic!("{label}: expected an unsupported plan node, got {err:?}");
+        };
+        assert_eq!(reason, "common slots are only materialized on PROJECT_NODE");
+    }
 }
 
 /// Verifies fragment output expressions add the final root projection.
@@ -4036,6 +4073,16 @@ fn sort_with_conjuncts_is_rejected() {
     );
 }
 
+/// Reads a relation's `RelCommon` emit mapping — what a consumer actually projects by.
+fn emit_mapping(common: Option<&substrait::proto::RelCommon>) -> Vec<i32> {
+    let Some(substrait::proto::rel_common::EmitKind::Emit(emit)) =
+        common.and_then(|common| common.emit_kind.as_ref())
+    else {
+        panic!("expected an explicit emit mapping");
+    };
+    emit.output_mapping.clone()
+}
+
 /// A two-column left side and a one-column right side, so the synthetic-key arithmetic cannot be
 /// satisfied by more than one formula.
 fn asymmetric_join_desc() -> TDescriptorTable {
@@ -4152,51 +4199,4 @@ fn bare_cross_join_translates_to_constant_key_join() {
         })
         .collect();
     assert_eq!(operands, vec![2, 4]);
-}
-
-/// Only `PROJECT_NODE` materializes its common slots. A `SELECT_NODE`, hash join or nested-loop
-/// join carrying the same field is refused rather than having its shared sub-expressions dropped
-/// — a slot ref resolving to one of them would otherwise read a column that was never emitted.
-#[test]
-fn common_slots_outside_a_project_are_rejected() {
-    let common = || {
-        let mut map = BTreeMap::new();
-        map.insert(5, slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)));
-        Some(map)
-    };
-
-    let mut select = base_plan_node(1, TPlanNodeType::SELECT_NODE, 1, vec![0]);
-    select.select_node = Some(TSelectNode::new(common()));
-    let select_plan = TPlan::new(vec![select, scan_node(0, 0)]);
-
-    let mut hash_join = hash_join_node(TJoinOp::INNER_JOIN);
-    hash_join.hash_join_node.as_mut().unwrap().common_slot_map = common();
-    let hash_plan = TPlan::new(vec![hash_join, scan_node(0, 0), scan_node(1, 1)]);
-
-    let mut nestloop = nestloop_join_node(
-        TJoinOp::INNER_JOIN,
-        vec![binary_pred(
-            TExprOpcode::LT,
-            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
-            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
-        )],
-    );
-    nestloop
-        .nestloop_join_node
-        .as_mut()
-        .unwrap()
-        .common_slot_map = common();
-    let nestloop_plan = TPlan::new(vec![nestloop, scan_node(0, 0), scan_node(1, 1)]);
-
-    for (label, plan, desc) in [
-        ("SELECT_NODE", select_plan, base_desc()),
-        ("HASH_JOIN_NODE", hash_plan, join_desc()),
-        ("NESTLOOP_JOIN_NODE", nestloop_plan, join_desc()),
-    ] {
-        let err = translate_fragment(&params(Some(plan), Some(desc), None)).unwrap_err();
-        let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
-            panic!("{label}: expected an unsupported plan node, got {err:?}");
-        };
-        assert_eq!(reason, "common slots are only materialized on PROJECT_NODE");
-    }
 }

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -1273,8 +1273,8 @@ fn struct_field(expr: &substrait::proto::Expression) -> i32 {
 }
 
 /// Only `PROJECT_NODE` materializes its common slots. A `SELECT_NODE`, hash join or nested-loop
-/// join carrying the same field is refused rather than having its shared sub-expressions dropped
-/// — a slot ref resolving to one of them would otherwise read a column that was never emitted.
+/// join carrying the same field is refused up front with a clear reason, instead of failing later
+/// with an opaque descriptor error when a conjunct references one of the shared sub-expressions.
 #[test]
 fn common_slots_outside_a_project_are_rejected() {
     let common = || {


### PR DESCRIPTION
## Description
**Motivation.** A `PROJECT_NODE` whose `common_slot_map` is non-empty failed to translate: its `slot_map` expressions reference common slot ids that no tuple materializes, so `translate_slot_ref` hit a descriptor error. The FE emits this shape whenever a sub-expression is shared by several output columns.

**What changed.** Common expressions are materialized first as hidden columns (one `ProjectRel` per common slot, in ascending slot-id order, chaining allowed), visible expressions read them through `ExprContext::slot_overrides`, and the emit mapping hides the scratch columns from parents. `SELECT_NODE`/`HASH_JOIN_NODE`/`NESTLOOP_JOIN_NODE` with a `common_slot_map` are refused ("common slots are only materialized on PROJECT_NODE") so the unsupported shape is reported up front instead of failing later with an opaque descriptor error (`slot N (tuple T) is not part of row_tuples`) when a conjunct references one of them.

**Verified.** fmt/clippy/`cargo test --workspace --no-default-features`: `project_common_slots_are_materialized_before_visible_expressions`, `nested_common_slots_are_appended_in_slot_id_order`, `common_slots_outside_a_project_are_rejected`. Local run on a33e1ffb (rebased onto dev 909d6cb1 after #1235 and #1236 merged): fmt and clippy clean; starrocks-plan-translator 6 unit + 104 `translate.rs` tests, sirius-starrocks-cn 49 tests, all passing. Merge check: merges cleanly with #1232 in either order.

**Intentionally not handled.** Common slots consumed *above* the project (TPC-H q14 shape) — lands with the carried-slots PR carved out of feat/pin-table-cn (no issue yet); the over-broad refusal on non-PROJECT nodes is tracked in #1692.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
Refs #1111 (merged). Follow-up issue: #1692.