### PR TITLE
fix(starrocks): lower cross joins to equality joins

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -34,7 +34,7 @@
 //! | `AGGREGATION_NODE`   | `AggregateRel` (finalized one-phase only, `new_planner_agg_stage=1`) |
 //! | `SORT_NODE`          | `ProjectRel` (sort tuple) + `SortRel` (global row-number top-N only) |
 //! | `HASH_JOIN_NODE`     | `JoinRel` (inner/outer/left-semi; anti joins are rejected) |
-//! | `NESTLOOP_JOIN_NODE` | `CrossRel` (+ `FilterRel`), inner/cross only |
+//! | `NESTLOOP_JOIN_NODE` | `JoinRel` (constant-key inner) + optional `FilterRel`, inner/cross only |
 //!
 //! Node-level `conjuncts` (scan/filter predicates, HAVING, post-join filters) become a
 //! `FilterRel` over the node's output on every supported node.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -1,4 +1,4 @@
-use starrocks_thrift::exprs::{TExpr, TExprNodeType};
+use starrocks_thrift::exprs::TExpr;
 use starrocks_thrift::opcodes::TExprOpcode;
 use starrocks_thrift::plan_nodes::{TJoinOp, TPlan, TPlanNode, TPlanNodeType, TSortInfo};
 use substrait::proto::read_rel::local_files::FileOrFiles;
@@ -7,9 +7,9 @@ use substrait::proto::read_rel::local_files::file_or_files::{
 };
 use substrait::proto::read_rel::{LocalFiles, NamedTable, ReadType};
 use substrait::proto::{
-    AggregateFunction, AggregateRel, CrossRel, Expression, FetchRel, FilterRel, JoinRel,
-    ProjectRel, ReadRel, Rel, RelCommon, SortField, SortRel, aggregate_rel, fetch_rel,
-    function_argument, join_rel, rel, rel_common, sort_field,
+    AggregateFunction, AggregateRel, Expression, FetchRel, FilterRel, JoinRel, ProjectRel, ReadRel,
+    Rel, RelCommon, SortField, SortRel, aggregate_rel, fetch_rel, function_argument, join_rel, rel,
+    rel_common, sort_field,
 };
 
 use crate::descriptor_table::DescriptorTable;
@@ -719,8 +719,8 @@ fn translate_hash_join(
     apply_conjuncts(joined, node, ctx)
 }
 
-/// Translates a `NESTLOOP_JOIN_NODE` into a Substrait cross product with the join conjuncts as a
-/// filter on top. Only inner/cross nested-loop joins are supported.
+/// Translates an inner/cross `NESTLOOP_JOIN_NODE` into an equality join on synthetic constants.
+/// This preserves Cartesian-product semantics without requiring a GPU cross-product operator.
 fn translate_nestloop_join(
     node: &TPlanNode,
     children: Vec<TranslatedRel>,
@@ -747,83 +747,72 @@ fn translate_nestloop_join(
     let mut children = children.into_iter();
     let left = children.next().unwrap();
     let right = children.next().unwrap();
+    let left_width = left.output_width;
+    let right_width = right.output_width;
     let row_tuples = [left.row_tuples.as_slice(), right.row_tuples.as_slice()].concat();
-    let output_width = left.output_width + right.output_width;
-
-    let conjuncts = join.join_conjuncts.as_deref().unwrap_or_default();
-    let mut conditions = Vec::with_capacity(conjuncts.len());
-    for expr in conjuncts {
-        let mut expr_ctx = ctx.expr_context(&row_tuples);
-        conditions.push(expr.translate(&mut expr_ctx)?);
-    }
-    // A conjunct-free cross product is rejected: the GPU physical planner has no cross-product
-    // operator, so the plan would translate and then fail at execution.
-    let condition = and_conditions(conditions, ctx).ok_or(TranslateError::UnsupportedPlanNode {
-        node_id: node.node_id,
-        node_type: node.node_type,
-        reason: "cross joins without join conjuncts are not supported",
-    })?;
-    if !conjuncts
-        .iter()
-        .any(|conjunct| becomes_join_condition(conjunct, &left.row_tuples, &right.row_tuples))
-    {
-        return Err(TranslateError::UnsupportedPlanNode {
-            node_id: node.node_id,
-            node_type: node.node_type,
-            reason: "nested-loop joins need a comparison between the two inputs",
-        });
-    }
-
-    let cross = Rel {
-        rel_type: Some(rel::RelType::Cross(Box::new(CrossRel {
-            left: Some(Box::new(left.rel)),
-            right: Some(Box::new(right.rel)),
-            ..Default::default()
-        }))),
-    };
-    let filtered = TranslatedRel {
+    let left = append_project(left, i32_literal(1));
+    let right = append_project(right, i32_literal(1));
+    let equal_anchor = ctx.registry.register_function(URN_COMPARISON, "equal");
+    let condition = expr_translator::scalar_function(
+        equal_anchor,
+        vec![
+            field_selection(left_width as i32),
+            field_selection((left.output_width + right_width) as i32),
+        ],
+        crate::type_mapper::bool_type(),
+    );
+    let joined = TranslatedRel {
         rel: Rel {
-            rel_type: Some(rel::RelType::Filter(Box::new(FilterRel {
-                input: Some(Box::new(cross)),
-                condition: Some(Box::new(condition)),
+            rel_type: Some(rel::RelType::Join(Box::new(JoinRel {
+                left: Some(Box::new(left.rel)),
+                right: Some(Box::new(right.rel)),
+                expression: Some(Box::new(condition)),
+                r#type: join_rel::JoinType::Inner as i32,
                 ..Default::default()
             }))),
         },
-        row_tuples,
-        output_width,
+        row_tuples: row_tuples.clone(),
+        output_width: left.output_width + right.output_width,
+    };
+    let mut mapping = (0..left_width as i32).collect::<Vec<_>>();
+    mapping.extend(left.output_width as i32..left.output_width as i32 + right_width as i32);
+    let cross = emit_columns(joined, mapping, row_tuples);
+    let filtered = if let Some(conjuncts) = join
+        .join_conjuncts
+        .as_ref()
+        .filter(|conjuncts| !conjuncts.is_empty())
+    {
+        let mut conditions = Vec::with_capacity(conjuncts.len());
+        for expr in conjuncts {
+            let mut expr_ctx = ctx.expr_context(&cross.row_tuples);
+            conditions.push(expr.translate(&mut expr_ctx)?);
+        }
+        match and_conditions(conditions, ctx) {
+            Some(condition) => {
+                let TranslatedRel {
+                    rel,
+                    row_tuples,
+                    output_width,
+                } = cross;
+                TranslatedRel {
+                    rel: Rel {
+                        rel_type: Some(rel::RelType::Filter(Box::new(FilterRel {
+                            input: Some(Box::new(rel)),
+                            condition: Some(Box::new(condition)),
+                            ..Default::default()
+                        }))),
+                    },
+                    row_tuples,
+                    output_width,
+                }
+            }
+            None => cross,
+        }
+    } else {
+        cross
     };
     // Node conjuncts are post-join predicates over the join's output row.
     apply_conjuncts(filtered, node, ctx)
-}
-
-/// Returns whether DuckDB will lift `conjunct` out of the filter above the cross product and into
-/// a join condition.
-///
-/// `FilterPushdown::PushdownCrossProduct` splits that filter by side: a predicate reading only one
-/// input is pushed into that input, and only predicates reading both become join conditions —
-/// which `ExtractJoinConditions` then keeps as conditions when the predicate is a comparison, and
-/// demotes to an any-join otherwise. With no such predicate the plan lowers to a bare cross
-/// product or an any-join, and the GPU planner implements neither
-/// (`sirius_physical_plan_generator.cpp`), so it would fail at execution instead of here.
-///
-/// This approximates the rule from the one side that matters: a comparison whose own operands each
-/// read both inputs (`a.x + b.y < 10`) also becomes an any-join, and is accepted here.
-fn becomes_join_condition(conjunct: &TExpr, left_tuples: &[i32], right_tuples: &[i32]) -> bool {
-    conjunct
-        .nodes
-        .first()
-        .is_some_and(|root| root.node_type == TExprNodeType::BINARY_PRED)
-        && reads_tuples(conjunct, left_tuples)
-        && reads_tuples(conjunct, right_tuples)
-}
-
-/// Returns whether any slot reference in `expr` belongs to one of `tuples`.
-fn reads_tuples(expr: &TExpr, tuples: &[i32]) -> bool {
-    expr.nodes.iter().any(|node| {
-        node.slot_ref
-            .as_ref()
-            .is_some_and(|slot_ref| tuples.contains(&slot_ref.tuple_id))
-    })
 }
 
 /// Combines boolean conditions with `and`.
@@ -990,6 +979,91 @@ fn project_rel(
         },
         row_tuples,
         output_width,
+    }
+}
+
+/// Appends one expression to a relation while retaining all existing columns.
+fn append_project(input: TranslatedRel, expression: Expression) -> TranslatedRel {
+    let output_width = input.output_width + 1;
+    TranslatedRel {
+        rel: Rel {
+            rel_type: Some(rel::RelType::Project(Box::new(ProjectRel {
+                common: Some(RelCommon {
+                    emit_kind: Some(rel_common::EmitKind::Emit(rel_common::Emit {
+                        output_mapping: (0..output_width as i32).collect(),
+                    })),
+                    ..Default::default()
+                }),
+                input: Some(Box::new(input.rel)),
+                expressions: vec![expression],
+                ..Default::default()
+            }))),
+        },
+        row_tuples: input.row_tuples,
+        output_width,
+    }
+}
+
+/// Emits selected input columns without evaluating new expressions.
+fn emit_columns(
+    input: TranslatedRel,
+    output_mapping: Vec<i32>,
+    row_tuples: Vec<i32>,
+) -> TranslatedRel {
+    let output_width = output_mapping.len();
+    TranslatedRel {
+        rel: Rel {
+            rel_type: Some(rel::RelType::Project(Box::new(ProjectRel {
+                common: Some(RelCommon {
+                    emit_kind: Some(rel_common::EmitKind::Emit(rel_common::Emit {
+                        output_mapping,
+                    })),
+                    ..Default::default()
+                }),
+                input: Some(Box::new(input.rel)),
+                ..Default::default()
+            }))),
+        },
+        row_tuples,
+        output_width,
+    }
+}
+
+/// Builds a direct field selection against the current relation output.
+fn field_selection(field: i32) -> Expression {
+    use substrait::proto::expression::field_reference;
+    use substrait::proto::expression::reference_segment;
+    use substrait::proto::expression::{FieldReference, ReferenceSegment};
+
+    Expression {
+        rex_type: Some(substrait::proto::expression::RexType::Selection(Box::new(
+            FieldReference {
+                reference_type: Some(field_reference::ReferenceType::DirectReference(
+                    ReferenceSegment {
+                        reference_type: Some(reference_segment::ReferenceType::StructField(
+                            Box::new(reference_segment::StructField { field, child: None }),
+                        )),
+                    },
+                )),
+                root_type: Some(field_reference::RootType::RootReference(
+                    field_reference::RootReference {},
+                )),
+            },
+        ))),
+    }
+}
+
+/// Builds an i32 literal used as a synthetic Cartesian-product key.
+fn i32_literal(value: i32) -> Expression {
+    Expression {
+        rex_type: Some(substrait::proto::expression::RexType::Literal(
+            substrait::proto::expression::Literal {
+                literal_type: Some(substrait::proto::expression::literal::LiteralType::I32(
+                    value,
+                )),
+                ..Default::default()
+            },
+        )),
     }
 }
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -744,6 +744,14 @@ fn translate_nestloop_join(
             });
         }
     }
+    // Lowering a Cartesian product to a constant-key equality join replaced the rejection that
+    // used to refuse it ("the GPU physical planner has no cross-product operator"), so this shape
+    // now reaches the GPU instead of failing translation. Nothing here bounds its size: the FE
+    // reports `cardinality: 1` for every FILES() external scan, so the translator has no estimate
+    // to gate on, and TPC-H q08/q09 at SF100 plan a genuine `NESTLOOP JOIN / CROSS JOIN` whose
+    // build side exhausts memory. Bounding it belongs to the executor, which knows the real row
+    // counts; refusing it here would also refuse the small cross joins the FE emits from
+    // scalar-subquery rewrites.
     let mut children = children.into_iter();
     let left = children.next().unwrap();
     let right = children.next().unwrap();

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -761,18 +761,18 @@ fn translate_nestloop_join(
         ],
         crate::type_mapper::bool_type(),
     );
-    let joined = TranslatedRel {
-        rel: Rel {
-            rel_type: Some(rel::RelType::Join(Box::new(JoinRel {
-                left: Some(Box::new(left.rel)),
-                right: Some(Box::new(right.rel)),
-                expression: Some(Box::new(condition)),
-                r#type: join_rel::JoinType::Inner as i32,
-                ..Default::default()
-            }))),
-        },
-        row_tuples: row_tuples.clone(),
-        output_width: left.output_width + right.output_width,
+    // Kept as a bare `Rel`, not a `TranslatedRel`: the join row carries both synthetic keys, so
+    // it is two columns wider than `row_tuples` describes, and a `TranslatedRel` claiming that
+    // layout would resolve every right-side slot to the wrong index. The projection below drops
+    // the keys and restores the invariant.
+    let joined = Rel {
+        rel_type: Some(rel::RelType::Join(Box::new(JoinRel {
+            left: Some(Box::new(left.rel)),
+            right: Some(Box::new(right.rel)),
+            expression: Some(Box::new(condition)),
+            r#type: join_rel::JoinType::Inner as i32,
+            ..Default::default()
+        }))),
     };
     let mut mapping = (0..left_width as i32).collect::<Vec<_>>();
     mapping.extend(left.output_width as i32..left.output_width as i32 + right_width as i32);
@@ -1005,11 +1005,7 @@ fn append_project(input: TranslatedRel, expression: Expression) -> TranslatedRel
 }
 
 /// Emits selected input columns without evaluating new expressions.
-fn emit_columns(
-    input: TranslatedRel,
-    output_mapping: Vec<i32>,
-    row_tuples: Vec<i32>,
-) -> TranslatedRel {
+fn emit_columns(input: Rel, output_mapping: Vec<i32>, row_tuples: Vec<i32>) -> TranslatedRel {
     let output_width = output_mapping.len();
     TranslatedRel {
         rel: Rel {
@@ -1020,7 +1016,7 @@ fn emit_columns(
                     })),
                     ..Default::default()
                 }),
-                input: Some(Box::new(input.rel)),
+                input: Some(Box::new(input)),
                 ..Default::default()
             }))),
         },

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -3610,3 +3610,52 @@ fn constant_key_join_indexes_past_the_synthetic_keys() {
         .collect();
     assert_eq!(operands, vec![2, 4]);
 }
+
+/// `SELECT * FROM a, b` — a nested-loop join with no conjuncts at all. This is the shape the PR
+/// exists to accept, and it takes the one branch the conjunct-carrying tests never reach: no
+/// filter is emitted, so the projection is the root's direct input.
+#[test]
+fn bare_cross_join_translates_to_constant_key_join() {
+    let join = nestloop_join_node(TJoinOp::CROSS_JOIN, Vec::new());
+    let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
+    let translated =
+        translate_fragment(&params(Some(plan), Some(asymmetric_join_desc()), None)).unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["a", "a2", "b"]);
+    let rel::RelType::Project(project) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected the output projection directly under the root, with no filter");
+    };
+    assert!(project.expressions.is_empty());
+    assert_eq!(emit_mapping(project.common.as_ref()), vec![0, 1, 3]);
+
+    let rel::RelType::Join(join) = project.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected constant-key join under projection");
+    };
+    assert_eq!(
+        join.r#type,
+        substrait::proto::join_rel::JoinType::Inner as i32
+    );
+    // Both operands are the appended literal keys, so the join is a Cartesian product expressed
+    // as an equality the GPU planner accepts.
+    let expression::RexType::ScalarFunction(condition) =
+        join.expression.as_ref().unwrap().rex_type.as_ref().unwrap()
+    else {
+        panic!("expected a scalar-function join condition");
+    };
+    let operands: Vec<_> = condition
+        .arguments
+        .iter()
+        .map(|arg| {
+            let substrait::proto::function_argument::ArgType::Value(expr) =
+                arg.arg_type.as_ref().unwrap()
+            else {
+                panic!("expected a value argument");
+            };
+            field_index(expr)
+        })
+        .collect();
+    assert_eq!(operands, vec![2, 4]);
+}

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -3531,3 +3531,82 @@ fn sort_with_conjuncts_is_rejected() {
         "{err:?}"
     );
 }
+
+/// Reads a relation's `RelCommon` emit mapping — what a consumer actually projects by.
+fn emit_mapping(common: Option<&substrait::proto::RelCommon>) -> Vec<i32> {
+    let Some(substrait::proto::rel_common::EmitKind::Emit(emit)) =
+        common.and_then(|common| common.emit_kind.as_ref())
+    else {
+        panic!("expected an explicit emit mapping");
+    };
+    emit.output_mapping.clone()
+}
+
+/// A two-column left side and a one-column right side, so the synthetic-key arithmetic cannot be
+/// satisfied by more than one formula.
+fn asymmetric_join_desc() -> TDescriptorTable {
+    desc_table(
+        vec![(0, Some(100)), (1, Some(100))],
+        vec![
+            slot(1, 0, "a", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, "a2", scalar_type(TPrimitiveType::BIGINT)),
+            slot(1, 1, "b", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    )
+}
+
+/// Pins the synthetic-key index arithmetic, which is the only thing in this lowering that can be
+/// wrong. With one column per side every off-by-one formula produces the same numbers; with a
+/// 2x1 descriptor the join row is `[a, a2, key_l, b, key_r]`, so the condition must compare
+/// fields 2 and 4 and the projection must emit `[0, 1, 3]` — dropping both synthetic keys.
+#[test]
+fn constant_key_join_indexes_past_the_synthetic_keys() {
+    let join = nestloop_join_node(
+        TJoinOp::CROSS_JOIN,
+        vec![binary_pred(
+            TExprOpcode::LT,
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+        )],
+    );
+    let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
+    let translated =
+        translate_fragment(&params(Some(plan), Some(asymmetric_join_desc()), None)).unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["a", "a2", "b"]);
+    let rel::RelType::Filter(filter) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected filter over constant-key join");
+    };
+    let rel::RelType::Project(project) = filter.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected output projection under filter");
+    };
+    // The projection only drops columns; it must not compute anything.
+    assert!(project.expressions.is_empty());
+    assert_eq!(emit_mapping(project.common.as_ref()), vec![0, 1, 3]);
+
+    let rel::RelType::Join(join) = project.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected constant-key join under projection");
+    };
+    let expression::RexType::ScalarFunction(condition) =
+        join.expression.as_ref().unwrap().rex_type.as_ref().unwrap()
+    else {
+        panic!("expected a scalar-function join condition");
+    };
+    let operands: Vec<_> = condition
+        .arguments
+        .iter()
+        .map(|arg| {
+            let substrait::proto::function_argument::ArgType::Value(expr) =
+                arg.arg_type.as_ref().unwrap()
+            else {
+                panic!("expected a value argument");
+            };
+            field_index(expr)
+        })
+        .collect();
+    assert_eq!(operands, vec![2, 4]);
+}

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -2471,7 +2471,7 @@ fn or_pred(left: TExpr, right: TExpr) -> TExpr {
     TExpr::new(nodes)
 }
 
-/// Verifies a cross nested-loop join with a conjunct becomes filter-over-cross-product.
+/// Verifies a cross nested-loop join becomes a filtered constant-key equality join.
 #[test]
 fn nestloop_join_translates_to_filtered_cross_rel() {
     let join = nestloop_join_node(
@@ -2489,11 +2489,20 @@ fn nestloop_join_translates_to_filtered_cross_rel() {
     assert_eq!(root.names, vec!["a", "b"]);
     let rel::RelType::Filter(filter) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
     else {
-        panic!("expected filter over cross product");
+        panic!("expected filter over constant-key join");
     };
-    let rel::RelType::Cross(_) = filter.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
-        panic!("expected cross product under filter");
+    let rel::RelType::Project(project) = filter.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected output projection under filter");
     };
+    let rel::RelType::Join(join) = project.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected constant-key join under projection");
+    };
+    assert_eq!(
+        join.r#type,
+        substrait::proto::join_rel::JoinType::Inner as i32
+    );
 }
 
 /// Verifies a nested-loop join that is not inner or cross is rejected: the translation emits a
@@ -2521,13 +2530,11 @@ fn non_inner_nestloop_join_is_rejected() {
     }
 }
 
-/// Verifies a nested-loop join is rejected unless a conjunct survives as a join condition.
-///
-/// A predicate reading one input is pushed into that input and leaves a bare cross product; a
-/// disjunction reading both is demoted to an any-join. The GPU planner has neither operator, so
-/// either shape would translate here and then fail at execution.
+/// Verifies a nested-loop join still translates when the conjunct would not lift into a
+/// comparison join: the synthetic constant key is the join condition, and the original
+/// predicate stays a filter.
 #[test]
-fn nestloop_join_without_a_liftable_comparison_is_rejected() {
+fn nestloop_join_without_a_liftable_comparison_still_translates() {
     let bigint = || scalar_type(TPrimitiveType::BIGINT);
     let probe_side_only = binary_pred(TExprOpcode::LT, slot_ref(1, 0, bigint()), int_literal(10));
     let disjunction = or_pred(
@@ -2549,13 +2556,24 @@ fn nestloop_join_without_a_liftable_comparison_is_rejected() {
             scan_node(0, 0),
             scan_node(1, 1),
         ]);
-        let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
-        let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
-            panic!("expected an unsupported plan node, got {err:?}");
+        let translated = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap();
+        let root = root(&translated.plan);
+        let rel::RelType::Filter(filter) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+        else {
+            panic!("expected filter over constant-key join");
+        };
+        let rel::RelType::Project(project) =
+            filter.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+        else {
+            panic!("expected output projection under filter");
+        };
+        let rel::RelType::Join(join) = project.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+        else {
+            panic!("expected constant-key join under projection");
         };
         assert_eq!(
-            reason,
-            "nested-loop joins need a comparison between the two inputs"
+            join.r#type,
+            substrait::proto::join_rel::JoinType::Inner as i32
         );
     }
 }
@@ -2969,7 +2987,7 @@ fn sort_tuple_exprs_come_from_sort_info() {
 }
 
 /// Verifies GPU-executor guards: non-constant LIKE patterns, non-constant substring bounds,
-/// bare cross joins, and ungrouped DISTINCT aggregates are rejected.
+/// and ungrouped DISTINCT aggregates are rejected.
 #[test]
 fn gpu_unsupported_shapes_are_rejected() {
     // LIKE with a column pattern (not a literal).
@@ -3018,23 +3036,6 @@ fn gpu_unsupported_shapes_are_rejected() {
     .unwrap_err();
     assert!(
         matches!(err, TranslateError::UnsupportedExpression { .. }),
-        "{err:?}"
-    );
-
-    // Nested-loop join without conjuncts (bare cross product).
-    let mut join = base_plan_node(2, TPlanNodeType::NESTLOOP_JOIN_NODE, 2, vec![0, 1]);
-    join.nestloop_join_node = Some(TNestLoopJoinNode::new(
-        Some(TJoinOp::CROSS_JOIN),
-        None,
-        None,
-        None,
-        None,
-        None,
-    ));
-    let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
-    let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
-    assert!(
-        matches!(err, TranslateError::UnsupportedPlanNode { .. }),
         "{err:?}"
     );
 

--- a/src/expression_evaluator/regex/regex_playground.cpp
+++ b/src/expression_evaluator/regex/regex_playground.cpp
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+// clang-format off
+#include <variant>
 #include "expression_evaluator/regex/regex_playground.hpp"
+// clang-format on
 
 #include <cudf/reduction.hpp>
 #include <cudf/scalar/scalar.hpp>

--- a/src/include/expression_evaluator/regex/regex_playground.hpp
+++ b/src/include/expression_evaluator/regex/regex_playground.hpp
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <variant>
-
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/transform.hpp>

--- a/src/include/expression_evaluator/regex/regex_playground.hpp
+++ b/src/include/expression_evaluator/regex/regex_playground.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <variant>
+
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/transform.hpp>


### PR DESCRIPTION
Lower Cartesian products to constant-key equality joins supported by the GPU planner.

Depends on #1111.