### PR TITLE
fix(starrocks): lower anti joins

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -33,7 +33,7 @@
 //! | `PROJECT_NODE`       | `ProjectRel`       |
 //! | `AGGREGATION_NODE`   | `AggregateRel` (finalized one-phase only, `new_planner_agg_stage=1`) |
 //! | `SORT_NODE`          | `ProjectRel` (sort tuple) + `SortRel` (global row-number top-N only) |
-//! | `HASH_JOIN_NODE`     | `JoinRel` (inner/outer/left-semi; anti joins are rejected) |
+//! | `HASH_JOIN_NODE`      | `JoinRel` (inner/outer/left-semi; left/right anti as outer join + `is_null` filter, null-aware left anti as mark join + `not`) |
 //! | `NESTLOOP_JOIN_NODE` | `JoinRel` (constant-key inner) + optional `FilterRel`, inner/cross only |
 //!
 //! Node-level `conjuncts` (scan/filter predicates, HAVING, post-join filters) become a

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -8,8 +8,8 @@ use substrait::proto::read_rel::local_files::file_or_files::{
 use substrait::proto::read_rel::{LocalFiles, NamedTable, ReadType};
 use substrait::proto::{
     AggregateFunction, AggregateRel, Expression, FetchRel, FilterRel, JoinRel, ProjectRel, ReadRel,
-    Rel, RelCommon, SortField, SortRel, aggregate_rel, fetch_rel, function_argument, join_rel, rel,
-    rel_common, sort_field,
+    Rel, RelCommon, SortField, SortRel, aggregate_rel, expression, fetch_rel, function_argument,
+    join_rel, rel, rel_common, sort_field,
 };
 
 use crate::descriptor_table::DescriptorTable;
@@ -758,6 +758,7 @@ fn translate_hash_join(
         JoinOutput::LeftAnti => {
             let (_, right_key) = first_equality
                 .ok_or_else(|| TranslateError::malformed("left anti join has no equality key"))?;
+            require_column_key(node, &right_key)?;
             let filtered = filter_is_null(joined, right_key, ctx);
             emit_columns(
                 filtered.rel,
@@ -768,6 +769,7 @@ fn translate_hash_join(
         JoinOutput::RightAnti => {
             let (left_key, _) = first_equality
                 .ok_or_else(|| TranslateError::malformed("right anti join has no equality key"))?;
+            require_column_key(node, &left_key)?;
             let filtered = filter_is_null(joined, left_key, ctx);
             let start = left.output_width as i32;
             let end = start + right.output_width as i32;
@@ -1169,6 +1171,33 @@ fn filter_rel(input: TranslatedRel, condition: Expression) -> TranslatedRel {
         row_tuples: input.row_tuples,
         output_width,
     }
+}
+
+/// Refuses an anti join whose null-tested key is not a column reference (casts allowed).
+///
+/// The outer-join + `is_null(key)` lowering identifies an unmatched row by the NULL padding the
+/// join puts on the other side. That is only exact when the key expression propagates NULL: a
+/// column reference does, and so does a cast of one, but `if`/`case`/`coalesce` over a column can
+/// yield a non-NULL value for the padded row, and the filter would then drop an unmatched row as
+/// if it had matched. Refuse those shapes rather than return too few rows.
+fn require_column_key(node: &TPlanNode, key: &Expression) -> Result<()> {
+    fn is_column_reference(expr: &Expression) -> bool {
+        match expr.rex_type.as_ref() {
+            Some(expression::RexType::Selection(_)) => true,
+            Some(expression::RexType::Cast(cast)) => {
+                cast.input.as_deref().is_some_and(is_column_reference)
+            }
+            _ => false,
+        }
+    }
+    if is_column_reference(key) {
+        return Ok(());
+    }
+    Err(TranslateError::UnsupportedPlanNode {
+        node_id: node.node_id,
+        node_type: node.node_type,
+        reason: "anti join key is not a plain column reference",
+    })
 }
 
 /// Filters to rows where an equality-key expression is null.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -664,9 +664,10 @@ fn translate_hash_join(
     // NULL-ness is decided per probe row. Neither executor does that: DuckDB sets one global
     // `has_null` if any build row has a NULL in any equality key and then rewrites every FALSE
     // marker to NULL (`duckdb/src/execution/join_hashtable.cpp:431` and `:1211-1217`), and the
-    // GPU path does the same with `table_has_any_null(right_keys)`
-    // (`src/op/sirius_physical_hash_join.cpp:1657`). The per-group path that would be correct is
-    // only reachable from DuckDB's own delim-join planner, never from a Substrait `JoinRel`.
+    // GPU path does the same with `set_build_has_null(_build_has_null,
+    // table_has_any_null(right_keys))` in `src/op/sirius_physical_hash_join.cpp`. The per-group
+    // path that would be correct is only reachable from DuckDB's own delim-join planner, never
+    // from a Substrait `JoinRel`.
     //
     // That is exact for a single equality key and nothing else, because then "unmatched with a
     // NULL somewhere on the build side" really is UNKNOWN. It is wrong as soon as another

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -638,17 +638,19 @@ fn translate_hash_join(
             context: "HASH_JOIN_NODE",
             field: "hash_join_node",
         })?;
-    // Validated before the conjuncts so an unsupported op is reported as such, rather than as the
-    // missing conjuncts an anti join arrives with once the FE has folded its predicate away.
-    //
-    // Anti joins (from NOT IN / NOT EXISTS rewrites) are not translated: DuckDB's Substrait
-    // consumer has no left-anti conversion, so an emitted plan would fail downstream anyway.
-    let (join_type, semi) = match join.join_op {
-        TJoinOp::INNER_JOIN => (join_rel::JoinType::Inner, false),
-        TJoinOp::LEFT_OUTER_JOIN => (join_rel::JoinType::Left, false),
-        TJoinOp::RIGHT_OUTER_JOIN => (join_rel::JoinType::Right, false),
-        TJoinOp::FULL_OUTER_JOIN => (join_rel::JoinType::Outer, false),
-        TJoinOp::LEFT_SEMI_JOIN => (join_rel::JoinType::LeftSemi, true),
+    // Validated before the conjuncts so an unsupported op is reported as such, rather than as
+    // missing conjuncts, which some join shapes arrive with once the FE has folded predicates away.
+    let (join_type, output) = match join.join_op {
+        TJoinOp::INNER_JOIN => (join_rel::JoinType::Inner, JoinOutput::Both),
+        TJoinOp::LEFT_OUTER_JOIN => (join_rel::JoinType::Left, JoinOutput::Both),
+        TJoinOp::RIGHT_OUTER_JOIN => (join_rel::JoinType::Right, JoinOutput::Both),
+        TJoinOp::FULL_OUTER_JOIN => (join_rel::JoinType::Outer, JoinOutput::Both),
+        TJoinOp::LEFT_SEMI_JOIN => (join_rel::JoinType::LeftSemi, JoinOutput::Left),
+        TJoinOp::LEFT_ANTI_JOIN => (join_rel::JoinType::Left, JoinOutput::LeftAnti),
+        TJoinOp::RIGHT_ANTI_JOIN => (join_rel::JoinType::Right, JoinOutput::RightAnti),
+        TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN => {
+            (join_rel::JoinType::LeftMark, JoinOutput::NullAwareLeftAnti)
+        }
         _ => {
             return Err(TranslateError::UnsupportedPlanNode {
                 node_id: node.node_id,
@@ -664,6 +666,7 @@ fn translate_hash_join(
 
     let combined_tuples = [left.row_tuples.as_slice(), right.row_tuples.as_slice()].concat();
     let mut conditions = Vec::new();
+    let mut first_equality = None;
     for eq in &join.eq_join_conjuncts {
         if let Some(opcode) = eq.opcode
             && opcode != TExprOpcode::EQ
@@ -678,6 +681,9 @@ fn translate_hash_join(
         let left_expr = eq.left.translate(&mut expr_ctx)?;
         let mut expr_ctx = ctx.expr_context(&combined_tuples);
         let right_expr = eq.right.translate(&mut expr_ctx)?;
+        if first_equality.is_none() {
+            first_equality = Some((left_expr.clone(), right_expr.clone()));
+        }
         let anchor = ctx.registry.register_function(URN_COMPARISON, "equal");
         conditions.push(expr_translator::scalar_function(
             anchor,
@@ -695,11 +701,13 @@ fn translate_hash_join(
         reason: "hash join without join conjuncts",
     })?;
 
-    // Semi joins emit only the probe-side row; other joins emit probe then build columns.
-    let (row_tuples, output_width) = if semi {
-        (left.row_tuples.clone(), left.output_width)
-    } else {
-        (combined_tuples, left.output_width + right.output_width)
+    let (row_tuples, output_width) = match output {
+        JoinOutput::Left => (left.row_tuples.clone(), left.output_width),
+        JoinOutput::NullAwareLeftAnti => (left.row_tuples.clone(), left.output_width + 1),
+        _ => (
+            combined_tuples.clone(),
+            left.output_width + right.output_width,
+        ),
     };
 
     let joined = TranslatedRel {
@@ -715,8 +723,53 @@ fn translate_hash_join(
         row_tuples,
         output_width,
     };
+    let joined = match output {
+        JoinOutput::LeftAnti => {
+            let (_, right_key) = first_equality
+                .ok_or_else(|| TranslateError::malformed("left anti join has no equality key"))?;
+            let filtered = filter_is_null(joined, right_key, ctx);
+            emit_columns(
+                filtered.rel,
+                (0..left.output_width as i32).collect(),
+                left.row_tuples,
+            )
+        }
+        JoinOutput::RightAnti => {
+            let (left_key, _) = first_equality
+                .ok_or_else(|| TranslateError::malformed("right anti join has no equality key"))?;
+            let filtered = filter_is_null(joined, left_key, ctx);
+            let start = left.output_width as i32;
+            let end = start + right.output_width as i32;
+            emit_columns(filtered.rel, (start..end).collect(), right.row_tuples)
+        }
+        JoinOutput::NullAwareLeftAnti => {
+            let marker = field_selection(left.output_width as i32);
+            let not_anchor = ctx.registry.register_function(URN_BOOLEAN, "not");
+            let condition = expr_translator::scalar_function(
+                not_anchor,
+                vec![marker],
+                crate::type_mapper::bool_type(),
+            );
+            let filtered = filter_rel(joined, condition);
+            emit_columns(
+                filtered.rel,
+                (0..left.output_width as i32).collect(),
+                left.row_tuples,
+            )
+        }
+        _ => joined,
+    };
     // Node conjuncts are post-join predicates over the join's output row.
     apply_conjuncts(joined, node, ctx)
+}
+
+#[derive(Clone, Copy)]
+enum JoinOutput {
+    Both,
+    Left,
+    LeftAnti,
+    RightAnti,
+    NullAwareLeftAnti,
 }
 
 /// Translates an inner/cross `NESTLOOP_JOIN_NODE` into an equality join on synthetic constants.
@@ -1069,6 +1122,34 @@ fn i32_literal(value: i32) -> Expression {
             },
         )),
     }
+}
+
+/// Wraps a relation in a filter without changing its row layout.
+fn filter_rel(input: TranslatedRel, condition: Expression) -> TranslatedRel {
+    let output_width = input.output_width;
+    TranslatedRel {
+        rel: Rel {
+            rel_type: Some(rel::RelType::Filter(Box::new(FilterRel {
+                input: Some(Box::new(input.rel)),
+                condition: Some(Box::new(condition)),
+                ..Default::default()
+            }))),
+        },
+        row_tuples: input.row_tuples,
+        output_width,
+    }
+}
+
+/// Filters to rows where an equality-key expression is null.
+fn filter_is_null(
+    input: TranslatedRel,
+    key: Expression,
+    ctx: &mut PlanContext<'_>,
+) -> TranslatedRel {
+    let anchor = ctx.registry.register_function(URN_COMPARISON, "is_null");
+    let condition =
+        expr_translator::scalar_function(anchor, vec![key], crate::type_mapper::bool_type());
+    filter_rel(input, condition)
 }
 
 /// Wraps a relation in a Substrait filter when the StarRocks node has conjuncts.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -660,6 +660,37 @@ fn translate_hash_join(
         }
     };
 
+    // A null-aware anti join is only equivalent to `LeftMark + NOT(marker)` when the marker's
+    // NULL-ness is decided per probe row. Neither executor does that: DuckDB sets one global
+    // `has_null` if any build row has a NULL in any equality key and then rewrites every FALSE
+    // marker to NULL (`duckdb/src/execution/join_hashtable.cpp:431` and `:1211-1217`), and the
+    // GPU path does the same with `table_has_any_null(right_keys)`
+    // (`src/op/sirius_physical_hash_join.cpp:1657`). The per-group path that would be correct is
+    // only reachable from DuckDB's own delim-join planner, never from a Substrait `JoinRel`.
+    //
+    // That is exact for a single equality key and nothing else, because then "unmatched with a
+    // NULL somewhere on the build side" really is UNKNOWN. It is wrong as soon as another
+    // predicate can make a row definitely non-matching: a correlated `NOT IN` puts its
+    // correlation predicate in `other_join_conjuncts` (FE `QuantifiedApply2JoinRule` builds
+    // `eq AND correlatedConjuncts AND predicate`, and `JoinHelper` filters correlated equalities
+    // out of the eq conjuncts), and a tuple `NOT IN` arrives as several eq conjuncts. In both
+    // cases a row that is definitely FALSE is reported UNKNOWN and silently dropped, so
+    // `NOT IN` returns too few rows -- often none. StarRocks itself does not have this problem;
+    // its BE only short-circuits when `_other_join_conjunct_ctxs` is empty.
+    if matches!(join.join_op, TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN)
+        && (join.eq_join_conjuncts.len() != 1
+            || join
+                .other_join_conjuncts
+                .as_ref()
+                .is_some_and(|conjuncts| !conjuncts.is_empty()))
+    {
+        return Err(TranslateError::UnsupportedPlanNode {
+            node_id: node.node_id,
+            node_type: node.node_type,
+            reason: "null-aware left anti join with correlated or multi-column keys",
+        });
+    }
+
     let mut children = children.into_iter();
     let left = children.next().unwrap();
     let right = children.next().unwrap();

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -3615,16 +3615,6 @@ fn sort_with_conjuncts_is_rejected() {
     );
 }
 
-/// Reads a relation's `RelCommon` emit mapping — what a consumer actually projects by.
-fn emit_mapping(common: Option<&substrait::proto::RelCommon>) -> Vec<i32> {
-    let Some(substrait::proto::rel_common::EmitKind::Emit(emit)) =
-        common.and_then(|common| common.emit_kind.as_ref())
-    else {
-        panic!("expected an explicit emit mapping");
-    };
-    emit.output_mapping.clone()
-}
-
 /// A two-column left side and a one-column right side, so the synthetic-key arithmetic cannot be
 /// satisfied by more than one formula.
 fn asymmetric_join_desc() -> TDescriptorTable {
@@ -3741,4 +3731,70 @@ fn bare_cross_join_translates_to_constant_key_join() {
         })
         .collect();
     assert_eq!(operands, vec![2, 4]);
+}
+
+/// A null-aware anti join is only equivalent to `LeftMark + NOT(marker)` when one equality key
+/// decides the match. Both executors null out *every* unmatched marker as soon as any build row
+/// has a NULL in any key, so a row made definitely non-matching by a second predicate is reported
+/// UNKNOWN and dropped. Correlated `NOT IN` (correlation predicate in `other_join_conjuncts`) and
+/// tuple `NOT IN` (several eq conjuncts) are therefore refused rather than silently returning too
+/// few rows.
+#[test]
+fn null_aware_anti_join_with_extra_predicates_is_rejected() {
+    let extra_eq = || {
+        TEqJoinCondition::new(
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+            Some(TExprOpcode::EQ),
+        )
+    };
+    let correlation = || {
+        binary_pred(
+            TExprOpcode::EQ,
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+        )
+    };
+
+    // Tuple NOT IN: two equality keys.
+    let mut multi_key = hash_join_node(TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN);
+    multi_key
+        .hash_join_node
+        .as_mut()
+        .unwrap()
+        .eq_join_conjuncts
+        .push(extra_eq());
+
+    // Correlated NOT IN: the correlation predicate rides in other_join_conjuncts.
+    let mut correlated = hash_join_node(TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN);
+    correlated
+        .hash_join_node
+        .as_mut()
+        .unwrap()
+        .other_join_conjuncts = Some(vec![correlation()]);
+
+    for (label, join) in [
+        ("tuple NOT IN", multi_key),
+        ("correlated NOT IN", correlated),
+    ] {
+        let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
+        let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
+        let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
+            panic!("{label}: expected an unsupported plan node, got {err:?}");
+        };
+        assert_eq!(
+            reason, "null-aware left anti join with correlated or multi-column keys",
+            "{label}"
+        );
+    }
+
+    // The single-key, no-extra-conjunct form stays supported: there, "unmatched with a NULL on
+    // the build side" really is UNKNOWN, so the global rule is exact.
+    let plan = TPlan::new(vec![
+        hash_join_node(TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN),
+        scan_node(0, 0),
+        scan_node(1, 1),
+    ]);
+    translate_fragment(&params(Some(plan), Some(join_desc()), None))
+        .expect("plain single-key null-aware anti join is still supported");
 }

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -3733,6 +3733,58 @@ fn bare_cross_join_translates_to_constant_key_join() {
     assert_eq!(operands, vec![2, 4]);
 }
 
+/// The outer-join + `is_null(key)` lowering tells an unmatched row by the NULL the join pads the
+/// other side with, so the null-tested key must propagate NULL. A column reference does, and so
+/// does a cast of one; an arithmetic (or `if`/`case`) expression over the key is refused rather
+/// than risk dropping unmatched rows.
+#[test]
+fn anti_join_with_non_column_key_is_rejected() {
+    let times_two = |slot_id: i32, tuple_id: i32| {
+        let mut arith = base_expr_node(
+            TExprNodeType::ARITHMETIC_EXPR,
+            scalar_type(TPrimitiveType::BIGINT),
+            2,
+        );
+        arith.opcode = Some(TExprOpcode::MULTIPLY);
+        let mut nodes = vec![arith];
+        nodes.extend(slot_ref(slot_id, tuple_id, scalar_type(TPrimitiveType::BIGINT)).nodes);
+        nodes.extend(int_literal(2).nodes);
+        TExpr::new(nodes)
+    };
+
+    // LEFT ANTI null-tests the build (right) key; RIGHT ANTI null-tests the probe (left) key.
+    let mut left_anti = hash_join_node(TJoinOp::LEFT_ANTI_JOIN);
+    left_anti.hash_join_node.as_mut().unwrap().eq_join_conjuncts[0].right = times_two(1, 1);
+    let mut right_anti = hash_join_node(TJoinOp::RIGHT_ANTI_JOIN);
+    right_anti
+        .hash_join_node
+        .as_mut()
+        .unwrap()
+        .eq_join_conjuncts[0]
+        .left = times_two(1, 0);
+    for (label, join) in [("LEFT_ANTI", left_anti), ("RIGHT_ANTI", right_anti)] {
+        let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
+        let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
+        let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
+            panic!("{label}: expected an unsupported plan node, got {err:?}");
+        };
+        assert_eq!(
+            reason, "anti join key is not a plain column reference",
+            "{label}"
+        );
+    }
+
+    // A cast over the column keeps NULL as NULL and stays supported.
+    let mut cast_key = hash_join_node(TJoinOp::LEFT_ANTI_JOIN);
+    cast_key.hash_join_node.as_mut().unwrap().eq_join_conjuncts[0].right = cast_expr(
+        scalar_type(TPrimitiveType::BIGINT),
+        slot_ref(1, 1, scalar_type(TPrimitiveType::INT)),
+    );
+    let plan = TPlan::new(vec![cast_key, scan_node(0, 0), scan_node(1, 1)]);
+    translate_fragment(&params(Some(plan), Some(join_desc()), None))
+        .expect("a cast of a column reference is still a column key");
+}
+
 /// A null-aware anti join is only equivalent to `LeftMark + NOT(marker)` when one equality key
 /// decides the match. Both executors null out *every* unmatched marker as soon as any build row
 /// has a NULL in any key, so a row made definitely non-matching by a second predicate is reported

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -2819,16 +2819,6 @@ fn aggregation_conjuncts_become_having_filter() {
     };
 }
 
-/// Reads a relation's `RelCommon` emit mapping — what a consumer actually projects by.
-fn emit_mapping(common: Option<&substrait::proto::RelCommon>) -> Vec<i32> {
-    let Some(substrait::proto::rel_common::EmitKind::Emit(emit)) =
-        common.and_then(|common| common.emit_kind.as_ref())
-    else {
-        panic!("expected an explicit emit mapping");
-    };
-    emit.output_mapping.clone()
-}
-
 /// Names the extension function a scalar-function expression invokes.
 fn scalar_function_name(
     plan: &substrait::proto::Plan,
@@ -2859,23 +2849,26 @@ fn scalar_function_name(
 /// every one of them is a different answer.
 #[test]
 fn anti_hash_joins_are_lowered() {
-    for (join_op, want_type, want_filter, want_emit) in [
+    for (join_op, want_type, want_filter, want_filter_field, want_emit) in [
         (
             TJoinOp::LEFT_ANTI_JOIN,
             substrait::proto::join_rel::JoinType::Left,
             "is_null",
+            vec![1],
             vec![0],
         ),
         (
             TJoinOp::RIGHT_ANTI_JOIN,
             substrait::proto::join_rel::JoinType::Right,
             "is_null",
+            vec![0],
             vec![1],
         ),
         (
             TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN,
             substrait::proto::join_rel::JoinType::LeftMark,
             "not",
+            vec![1],
             vec![0],
         ),
     ] {
@@ -2910,6 +2903,22 @@ fn anti_hash_joins_are_lowered() {
             want_filter,
             "{join_op:?}"
         );
+        let expression::RexType::ScalarFunction(scalar) = filter
+            .condition
+            .as_ref()
+            .unwrap()
+            .rex_type
+            .as_ref()
+            .unwrap()
+        else {
+            panic!("{join_op:?}: expected a scalar-function filter");
+        };
+        assert_eq!(
+            argument_field_indices(scalar),
+            want_filter_field,
+            "{join_op:?}: the filter must test the build key (left anti), the probe key (right \
+             anti) or the appended marker (null-aware)"
+        );
 
         let rel::RelType::Join(join) = filter.input.as_ref().unwrap().rel_type.as_ref().unwrap()
         else {
@@ -2917,6 +2926,124 @@ fn anti_hash_joins_are_lowered() {
         };
         assert_eq!(join.r#type, want_type as i32, "{join_op:?}");
     }
+}
+
+/// The outer-join + `is_null(key)` lowering tells an unmatched row by the NULL the join pads the
+/// other side with, so the null-tested key must propagate NULL. A column reference does, and so
+/// does a cast of one; an arithmetic (or `if`/`case`) expression over the key is refused rather
+/// than risk dropping unmatched rows.
+#[test]
+fn anti_join_with_non_column_key_is_rejected() {
+    let times_two = |slot_id: i32, tuple_id: i32| {
+        let mut arith = base_expr_node(
+            TExprNodeType::ARITHMETIC_EXPR,
+            scalar_type(TPrimitiveType::BIGINT),
+            2,
+        );
+        arith.opcode = Some(TExprOpcode::MULTIPLY);
+        let mut nodes = vec![arith];
+        nodes.extend(slot_ref(slot_id, tuple_id, scalar_type(TPrimitiveType::BIGINT)).nodes);
+        nodes.extend(int_literal(2).nodes);
+        TExpr::new(nodes)
+    };
+
+    // LEFT ANTI null-tests the build (right) key; RIGHT ANTI null-tests the probe (left) key.
+    let mut left_anti = hash_join_node(TJoinOp::LEFT_ANTI_JOIN);
+    left_anti.hash_join_node.as_mut().unwrap().eq_join_conjuncts[0].right = times_two(1, 1);
+    let mut right_anti = hash_join_node(TJoinOp::RIGHT_ANTI_JOIN);
+    right_anti
+        .hash_join_node
+        .as_mut()
+        .unwrap()
+        .eq_join_conjuncts[0]
+        .left = times_two(1, 0);
+    for (label, join) in [("LEFT_ANTI", left_anti), ("RIGHT_ANTI", right_anti)] {
+        let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
+        let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
+        let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
+            panic!("{label}: expected an unsupported plan node, got {err:?}");
+        };
+        assert_eq!(
+            reason, "anti join key is not a plain column reference",
+            "{label}"
+        );
+    }
+
+    // A cast over the column keeps NULL as NULL and stays supported.
+    let mut cast_key = hash_join_node(TJoinOp::LEFT_ANTI_JOIN);
+    cast_key.hash_join_node.as_mut().unwrap().eq_join_conjuncts[0].right = cast_expr(
+        scalar_type(TPrimitiveType::BIGINT),
+        slot_ref(1, 1, scalar_type(TPrimitiveType::INT)),
+    );
+    let plan = TPlan::new(vec![cast_key, scan_node(0, 0), scan_node(1, 1)]);
+    translate_fragment(&params(Some(plan), Some(join_desc()), None))
+        .expect("a cast of a column reference is still a column key");
+}
+
+/// A null-aware anti join is only equivalent to `LeftMark + NOT(marker)` when one equality key
+/// decides the match. Both executors null out *every* unmatched marker as soon as any build row
+/// has a NULL in any key, so a row made definitely non-matching by a second predicate is reported
+/// UNKNOWN and dropped. Correlated `NOT IN` (correlation predicate in `other_join_conjuncts`) and
+/// tuple `NOT IN` (several eq conjuncts) are therefore refused rather than silently returning too
+/// few rows.
+#[test]
+fn null_aware_anti_join_with_extra_predicates_is_rejected() {
+    let extra_eq = || {
+        TEqJoinCondition::new(
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+            Some(TExprOpcode::EQ),
+        )
+    };
+    let correlation = || {
+        binary_pred(
+            TExprOpcode::EQ,
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+        )
+    };
+
+    // Tuple NOT IN: two equality keys.
+    let mut multi_key = hash_join_node(TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN);
+    multi_key
+        .hash_join_node
+        .as_mut()
+        .unwrap()
+        .eq_join_conjuncts
+        .push(extra_eq());
+
+    // Correlated NOT IN: the correlation predicate rides in other_join_conjuncts.
+    let mut correlated = hash_join_node(TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN);
+    correlated
+        .hash_join_node
+        .as_mut()
+        .unwrap()
+        .other_join_conjuncts = Some(vec![correlation()]);
+
+    for (label, join) in [
+        ("tuple NOT IN", multi_key),
+        ("correlated NOT IN", correlated),
+    ] {
+        let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
+        let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
+        let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
+            panic!("{label}: expected an unsupported plan node, got {err:?}");
+        };
+        assert_eq!(
+            reason, "null-aware left anti join with correlated or multi-column keys",
+            "{label}"
+        );
+    }
+
+    // The single-key, no-extra-conjunct form stays supported: there, "unmatched with a NULL on
+    // the build side" really is UNKNOWN, so the global rule is exact.
+    let plan = TPlan::new(vec![
+        hash_join_node(TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN),
+        scan_node(0, 0),
+        scan_node(1, 1),
+    ]);
+    translate_fragment(&params(Some(plan), Some(join_desc()), None))
+        .expect("plain single-key null-aware anti join is still supported");
 }
 
 /// Verifies an unsupported join op is named as the reason even when the plan also carries no join
@@ -3615,6 +3742,16 @@ fn sort_with_conjuncts_is_rejected() {
     );
 }
 
+/// Reads a relation's `RelCommon` emit mapping — what a consumer actually projects by.
+fn emit_mapping(common: Option<&substrait::proto::RelCommon>) -> Vec<i32> {
+    let Some(substrait::proto::rel_common::EmitKind::Emit(emit)) =
+        common.and_then(|common| common.emit_kind.as_ref())
+    else {
+        panic!("expected an explicit emit mapping");
+    };
+    emit.output_mapping.clone()
+}
+
 /// A two-column left side and a one-column right side, so the synthetic-key arithmetic cannot be
 /// satisfied by more than one formula.
 fn asymmetric_join_desc() -> TDescriptorTable {
@@ -3731,122 +3868,4 @@ fn bare_cross_join_translates_to_constant_key_join() {
         })
         .collect();
     assert_eq!(operands, vec![2, 4]);
-}
-
-/// The outer-join + `is_null(key)` lowering tells an unmatched row by the NULL the join pads the
-/// other side with, so the null-tested key must propagate NULL. A column reference does, and so
-/// does a cast of one; an arithmetic (or `if`/`case`) expression over the key is refused rather
-/// than risk dropping unmatched rows.
-#[test]
-fn anti_join_with_non_column_key_is_rejected() {
-    let times_two = |slot_id: i32, tuple_id: i32| {
-        let mut arith = base_expr_node(
-            TExprNodeType::ARITHMETIC_EXPR,
-            scalar_type(TPrimitiveType::BIGINT),
-            2,
-        );
-        arith.opcode = Some(TExprOpcode::MULTIPLY);
-        let mut nodes = vec![arith];
-        nodes.extend(slot_ref(slot_id, tuple_id, scalar_type(TPrimitiveType::BIGINT)).nodes);
-        nodes.extend(int_literal(2).nodes);
-        TExpr::new(nodes)
-    };
-
-    // LEFT ANTI null-tests the build (right) key; RIGHT ANTI null-tests the probe (left) key.
-    let mut left_anti = hash_join_node(TJoinOp::LEFT_ANTI_JOIN);
-    left_anti.hash_join_node.as_mut().unwrap().eq_join_conjuncts[0].right = times_two(1, 1);
-    let mut right_anti = hash_join_node(TJoinOp::RIGHT_ANTI_JOIN);
-    right_anti
-        .hash_join_node
-        .as_mut()
-        .unwrap()
-        .eq_join_conjuncts[0]
-        .left = times_two(1, 0);
-    for (label, join) in [("LEFT_ANTI", left_anti), ("RIGHT_ANTI", right_anti)] {
-        let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
-        let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
-        let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
-            panic!("{label}: expected an unsupported plan node, got {err:?}");
-        };
-        assert_eq!(
-            reason, "anti join key is not a plain column reference",
-            "{label}"
-        );
-    }
-
-    // A cast over the column keeps NULL as NULL and stays supported.
-    let mut cast_key = hash_join_node(TJoinOp::LEFT_ANTI_JOIN);
-    cast_key.hash_join_node.as_mut().unwrap().eq_join_conjuncts[0].right = cast_expr(
-        scalar_type(TPrimitiveType::BIGINT),
-        slot_ref(1, 1, scalar_type(TPrimitiveType::INT)),
-    );
-    let plan = TPlan::new(vec![cast_key, scan_node(0, 0), scan_node(1, 1)]);
-    translate_fragment(&params(Some(plan), Some(join_desc()), None))
-        .expect("a cast of a column reference is still a column key");
-}
-
-/// A null-aware anti join is only equivalent to `LeftMark + NOT(marker)` when one equality key
-/// decides the match. Both executors null out *every* unmatched marker as soon as any build row
-/// has a NULL in any key, so a row made definitely non-matching by a second predicate is reported
-/// UNKNOWN and dropped. Correlated `NOT IN` (correlation predicate in `other_join_conjuncts`) and
-/// tuple `NOT IN` (several eq conjuncts) are therefore refused rather than silently returning too
-/// few rows.
-#[test]
-fn null_aware_anti_join_with_extra_predicates_is_rejected() {
-    let extra_eq = || {
-        TEqJoinCondition::new(
-            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
-            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
-            Some(TExprOpcode::EQ),
-        )
-    };
-    let correlation = || {
-        binary_pred(
-            TExprOpcode::EQ,
-            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
-            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
-        )
-    };
-
-    // Tuple NOT IN: two equality keys.
-    let mut multi_key = hash_join_node(TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN);
-    multi_key
-        .hash_join_node
-        .as_mut()
-        .unwrap()
-        .eq_join_conjuncts
-        .push(extra_eq());
-
-    // Correlated NOT IN: the correlation predicate rides in other_join_conjuncts.
-    let mut correlated = hash_join_node(TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN);
-    correlated
-        .hash_join_node
-        .as_mut()
-        .unwrap()
-        .other_join_conjuncts = Some(vec![correlation()]);
-
-    for (label, join) in [
-        ("tuple NOT IN", multi_key),
-        ("correlated NOT IN", correlated),
-    ] {
-        let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
-        let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
-        let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
-            panic!("{label}: expected an unsupported plan node, got {err:?}");
-        };
-        assert_eq!(
-            reason, "null-aware left anti join with correlated or multi-column keys",
-            "{label}"
-        );
-    }
-
-    // The single-key, no-extra-conjunct form stays supported: there, "unmatched with a NULL on
-    // the build side" really is UNKNOWN, so the global rule is exact.
-    let plan = TPlan::new(vec![
-        hash_join_node(TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN),
-        scan_node(0, 0),
-        scan_node(1, 1),
-    ]);
-    translate_fragment(&params(Some(plan), Some(join_desc()), None))
-        .expect("plain single-key null-aware anti join is still supported");
 }

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -2819,13 +2819,65 @@ fn aggregation_conjuncts_become_having_filter() {
     };
 }
 
-/// Verifies anti joins are lowered through supported outer/mark join forms.
+/// Reads a relation's `RelCommon` emit mapping — what a consumer actually projects by.
+fn emit_mapping(common: Option<&substrait::proto::RelCommon>) -> Vec<i32> {
+    let Some(substrait::proto::rel_common::EmitKind::Emit(emit)) =
+        common.and_then(|common| common.emit_kind.as_ref())
+    else {
+        panic!("expected an explicit emit mapping");
+    };
+    emit.output_mapping.clone()
+}
+
+/// Names the extension function a scalar-function expression invokes.
+fn scalar_function_name(
+    plan: &substrait::proto::Plan,
+    expr: &substrait::proto::Expression,
+) -> String {
+    let expression::RexType::ScalarFunction(call) = expr.rex_type.as_ref().unwrap() else {
+        panic!("expected a scalar function, got {expr:?}");
+    };
+    plan.extensions
+        .iter()
+        .find_map(|ext| {
+            match ext.mapping_type.as_ref().unwrap() {
+            substrait::proto::extensions::simple_extension_declaration::MappingType
+                ::ExtensionFunction(f) if f.function_anchor == call.function_reference =>
+            {
+                Some(f.name.clone())
+            }
+            _ => None,
+        }
+        })
+        .unwrap_or_else(|| panic!("no extension for anchor {}", call.function_reference))
+}
+
+/// Verifies each anti join is lowered through the specific supported form it needs, not merely
+/// that it translates: a left anti becomes a LEFT join filtered on the build key being NULL, a
+/// right anti mirrors that, and a null-aware left anti becomes a MARK join filtered on NOT of the
+/// marker column the join appends. Asserting only the output arity cannot tell these apart, and
+/// every one of them is a different answer.
 #[test]
 fn anti_hash_joins_are_lowered() {
-    for join_op in [
-        TJoinOp::LEFT_ANTI_JOIN,
-        TJoinOp::RIGHT_ANTI_JOIN,
-        TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN,
+    for (join_op, want_type, want_filter, want_emit) in [
+        (
+            TJoinOp::LEFT_ANTI_JOIN,
+            substrait::proto::join_rel::JoinType::Left,
+            "is_null",
+            vec![0],
+        ),
+        (
+            TJoinOp::RIGHT_ANTI_JOIN,
+            substrait::proto::join_rel::JoinType::Right,
+            "is_null",
+            vec![1],
+        ),
+        (
+            TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN,
+            substrait::proto::join_rel::JoinType::LeftMark,
+            "not",
+            vec![0],
+        ),
     ] {
         let plan = TPlan::new(vec![
             hash_join_node(join_op),
@@ -2834,7 +2886,36 @@ fn anti_hash_joins_are_lowered() {
         ]);
         let translated = translate_fragment(&params(Some(plan), Some(join_desc()), None))
             .unwrap_or_else(|err| panic!("{join_op:?}: {err:?}"));
-        assert_eq!(root(&translated.plan).names.len(), 1);
+
+        let root = root(&translated.plan);
+        assert_eq!(root.names.len(), 1, "{join_op:?}");
+        let rel::RelType::Project(project) =
+            root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+        else {
+            panic!("{join_op:?}: expected the output projection under the root");
+        };
+        assert_eq!(
+            emit_mapping(project.common.as_ref()),
+            want_emit,
+            "{join_op:?}"
+        );
+
+        let rel::RelType::Filter(filter) =
+            project.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+        else {
+            panic!("{join_op:?}: expected the anti-join filter under the projection");
+        };
+        assert_eq!(
+            scalar_function_name(&translated.plan, filter.condition.as_ref().unwrap()),
+            want_filter,
+            "{join_op:?}"
+        );
+
+        let rel::RelType::Join(join) = filter.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+        else {
+            panic!("{join_op:?}: expected the join under the filter");
+        };
+        assert_eq!(join.r#type, want_type as i32, "{join_op:?}");
     }
 }
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -2819,28 +2819,30 @@ fn aggregation_conjuncts_become_having_filter() {
     };
 }
 
-/// Verifies anti joins are rejected: the Substrait consumer has no left-anti conversion.
+/// Verifies anti joins are lowered through supported outer/mark join forms.
 #[test]
-fn anti_hash_join_is_rejected() {
-    for join_op in [TJoinOp::LEFT_ANTI_JOIN, TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN] {
+fn anti_hash_joins_are_lowered() {
+    for join_op in [
+        TJoinOp::LEFT_ANTI_JOIN,
+        TJoinOp::RIGHT_ANTI_JOIN,
+        TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN,
+    ] {
         let plan = TPlan::new(vec![
             hash_join_node(join_op),
             scan_node(0, 0),
             scan_node(1, 1),
         ]);
-        let err = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap_err();
-        assert!(
-            matches!(err, TranslateError::UnsupportedPlanNode { .. }),
-            "{join_op:?}: {err:?}"
-        );
+        let translated = translate_fragment(&params(Some(plan), Some(join_desc()), None))
+            .unwrap_or_else(|err| panic!("{join_op:?}: {err:?}"));
+        assert_eq!(root(&translated.plan).names.len(), 1);
     }
 }
 
 /// Verifies an unsupported join op is named as the reason even when the plan also carries no join
-/// conjuncts, which is the shape an anti join arrives in once the FE has folded its predicate away.
+/// conjuncts, which is the shape some join types arrive in once the FE has folded predicates away.
 #[test]
 fn unsupported_join_type_is_reported_before_missing_conjuncts() {
-    let mut join = hash_join_node(TJoinOp::LEFT_ANTI_JOIN);
+    let mut join = hash_join_node(TJoinOp::CROSS_JOIN);
     join.hash_join_node.as_mut().unwrap().eq_join_conjuncts = vec![];
     let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
 


### PR DESCRIPTION
## Description
**Motivation.** StarRocks emits `LEFT_ANTI_JOIN`/`RIGHT_ANTI_JOIN` for `NOT EXISTS` and `NULL_AWARE_LEFT_ANTI_JOIN` for `NOT IN`; the translator refused all three. DuckDB's Substrait consumer (`substrait/src/from_substrait.cpp` `TransformJoinOp`; join-type cases at lines 543-566 of the pinned submodule, duckdb 1.5.5) has no `JOIN_TYPE_LEFT_ANTI` arm but maps `JOIN_TYPE_LEFT_MARK` to `JoinType::MARK`.

**What changed.** `LEFT_ANTI` → left outer join + `is_null(<build key>)` filter emitting only probe columns; `RIGHT_ANTI` mirrors it; `NULL_AWARE_LEFT_ANTI` → `LeftMark` + `not(marker)`. The lowerings are asserted (join type, filter function, emit mapping), not just "translates". `LEFT_ANTI`/`RIGHT_ANTI` are refused ("anti join key is not a plain column reference") when the null-tested key is not a column reference or a cast of one: the `is_null` test identifies an unmatched row by the join's NULL padding, which only works for NULL-propagating keys; an `if`/`case`/`coalesce` key could report an unmatched row as matched. `NULL_AWARE_LEFT_ANTI` is refused unless it has exactly one equality key and no `other_join_conjuncts` ("null-aware left anti join with correlated or multi-column keys"): both executors decide the marker's NULL-ness with one global build-has-null flag (`join_hashtable.cpp`, `sirius_physical_hash_join.cpp` `table_has_any_null`), so a row another predicate makes definitely FALSE would be reported UNKNOWN and silently dropped.

**Verified.** fmt/clippy/`cargo test --workspace --no-default-features`: `anti_hash_joins_are_lowered` (join type, filter function, which field the filter tests, emit mapping), `null_aware_anti_join_with_extra_predicates_is_rejected`, `anti_join_with_non_column_key_is_rejected`; `anti_hash_join_is_rejected` removed and `unsupported_join_type_is_reported_before_missing_conjuncts` retargeted from LEFT_ANTI to CROSS_JOIN. Local run on 1c0ba171: fmt and clippy clean; starrocks-plan-translator 5 unit + 98 `translate.rs` tests, sirius-starrocks-cn 49 tests, all passing.

**Intentionally not handled.** Only the first equality key is null-tested (exact given the column-key rule, but a multi-key `is_null` AND would let the rule relax later); `eq.opcode == None` is treated as EQ; no end-to-end Q16/Q21/Q22 run — tracked as issues (References). Intended to unblock TPC-H Q16/Q21/Q22 translation (not run end to end, #1691); Q1/Q6 unaffected.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
Refs #1111 (merged). Follow-up issues: #1689, #1690, #1691.