### PR TITLE
fix(starrocks): lower decimal operations to fp64

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
@@ -679,12 +679,14 @@ pub(crate) fn aggregate_call(expr: &TExpr, ctx: &mut ExprContext<'_>) -> Result<
     }
     let return_primitive = type_mapper::scalar_primitive(&function.ret_type)?;
     let decimal_result = is_decimal(&function.ret_type)?;
-    // Temporal AVG has StarRocks-specific rounding semantics. Decimal SUM/AVG are lowered to FP64
-    // below because the Sirius GPU expression/aggregate path cannot consume decimal arithmetic.
+    // Decimal SUM/AVG are lowered to FP64 below because the Sirius GPU expression/aggregate
+    // path cannot consume decimal arithmetic; every other avg return type (temporal avg's
+    // StarRocks-specific rounding, in particular) has no GPU lowering.
     if name == "avg" && return_primitive != TPrimitiveType::DOUBLE && !decimal_result {
         return Err(TranslateError::UnsupportedExpression {
             node_type: root.node_type,
-            reason: "temporal avg is not supported",
+            reason: "avg is only supported where it lowers to the GPU's FP64 avg \
+                     (DOUBLE and DECIMAL inputs)",
         });
     }
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
@@ -354,6 +354,13 @@ fn translate_arithmetic(
         }
     };
     expect_child_count(node, &children, 2)?;
+    // Decimal arithmetic is evaluated in FP64: the Sirius GPU expression path cannot consume
+    // decimal arithmetic, and refusing it instead -- which is what this replaced -- rejects every
+    // TPC-H revenue query. The result is approximate and is NOT cast back: a project's output slot
+    // may be declared DECIMAL while the expression yields FP64, and nothing downstream can detect
+    // that, because a Substrait `ProjectRel` carries no per-column output type. Sums of money
+    // columns therefore differ from StarRocks in the last few digits (~1e-14 relative) and render
+    // as a double. A decimal-native GPU path is the real fix.
     let decimal = is_decimal(&node.type_)?;
     let children = if decimal {
         children

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
@@ -357,10 +357,12 @@ fn translate_arithmetic(
     // Decimal arithmetic is evaluated in FP64: the Sirius GPU expression path cannot consume
     // decimal arithmetic, and refusing it instead -- which is what this replaced -- rejects every
     // TPC-H revenue query. The result is approximate and is NOT cast back: a project's output slot
-    // may be declared DECIMAL while the expression yields FP64, and nothing downstream can detect
-    // that, because a Substrait `ProjectRel` carries no per-column output type. Sums of money
-    // columns therefore differ from StarRocks in the last few digits (~1e-14 relative) and render
-    // as a double. A decimal-native GPU path is the real fix.
+    // may be declared DECIMAL while the expression yields FP64. The emitted `Cast` and
+    // `ScalarFunction` nodes do carry the FP64 type; the mismatch is with anything that derives a
+    // row's schema from the frontend's slot types instead (a stream receiver, the result
+    // encoding), which still expects DECIMAL -- tracked in #1687. Sums of money columns therefore
+    // differ from StarRocks in the last few digits (~1e-14 relative) and render as a double. A
+    // decimal-native GPU path is the real fix.
     let decimal = is_decimal(&node.type_)?;
     let children = if decimal {
         children

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
@@ -255,19 +255,27 @@ fn translate_decimal_literal(node: &TExprNode, children: Vec<Expression>) -> Res
             field: "decimal_literal",
         })?;
     let decimal_type = type_mapper::map_type_desc(&node.type_, true)?;
-    let Some(substrait::proto::r#type::Kind::Decimal(decimal)) = decimal_type.kind else {
-        return Err(TranslateError::malformed(
-            "DECIMAL_LITERAL has non-decimal type",
-        ));
-    };
-    let value = encode_decimal(&lit.value, decimal.scale)?;
-    Ok(literal(expression::literal::LiteralType::Decimal(
-        expression::literal::Decimal {
-            value: value.to_vec(),
-            precision: decimal.precision,
-            scale: decimal.scale,
-        },
-    )))
+    match decimal_type.kind {
+        Some(substrait::proto::r#type::Kind::Decimal(decimal)) => {
+            let value = encode_decimal(&lit.value, decimal.scale)?;
+            Ok(literal(expression::literal::LiteralType::Decimal(
+                expression::literal::Decimal {
+                    value: value.to_vec(),
+                    precision: decimal.precision,
+                    scale: decimal.scale,
+                },
+            )))
+        }
+        Some(substrait::proto::r#type::Kind::Fp64(_)) => {
+            let value = lit.value.parse::<f64>().map_err(|_| {
+                TranslateError::malformed(format!("invalid decimal literal {:?}", lit.value))
+            })?;
+            Ok(literal(expression::literal::LiteralType::Fp64(value)))
+        }
+        _ => Err(TranslateError::malformed(
+            "DECIMAL_LITERAL has non-numeric type",
+        )),
+    }
 }
 
 /// Converts a StarRocks `DATE_LITERAL` into a Substrait date literal.
@@ -346,16 +354,26 @@ fn translate_arithmetic(
         }
     };
     expect_child_count(node, &children, 2)?;
-    // Decimal-typed arithmetic is rejected for now: the StarRocks-shaped cast/width combination
-    // reliably segfaults the engine's GPU projection (see the starrocks tpch crash repro);
-    // fail with a structured error instead of taking down the compute node.
-    if is_decimal(&node.type_)? {
-        return Err(TranslateError::UnsupportedExpression {
-            node_type: node.node_type,
-            reason: "decimal arithmetic is not supported yet (crashes the engine projection)",
-        });
-    }
-    let output_type = type_mapper::map_type_desc(&node.type_, node.is_nullable.unwrap_or(true))?;
+    let decimal = is_decimal(&node.type_)?;
+    let children = if decimal {
+        children
+            .into_iter()
+            .map(|input| Expression {
+                rex_type: Some(expression::RexType::Cast(Box::new(expression::Cast {
+                    r#type: Some(type_mapper::fp64_type(true)),
+                    input: Some(Box::new(input)),
+                    failure_behavior: expression::cast::FailureBehavior::ThrowException as i32,
+                }))),
+            })
+            .collect()
+    } else {
+        children
+    };
+    let output_type = if decimal {
+        type_mapper::fp64_type(node.is_nullable.unwrap_or(true))
+    } else {
+        type_mapper::map_type_desc(&node.type_, node.is_nullable.unwrap_or(true))?
+    };
     let anchor = ctx.registry.register_function(URN_ARITHMETIC, name);
     Ok(scalar_function(anchor, children, output_type))
 }
@@ -652,24 +670,36 @@ pub(crate) fn aggregate_call(expr: &TExpr, ctx: &mut ExprContext<'_>) -> Result<
             reason: "distinct aggregates over multiple columns are not supported",
         });
     }
-    // Only double-returning `avg` translates faithfully. StarRocks `avg` over decimals returns
-    // a decimal (DuckDB computes a double and the consumer ignores the declared output type),
-    // and temporal `avg` has StarRocks-specific day-rounding semantics.
-    if name == "avg" && type_mapper::scalar_primitive(&function.ret_type)? != TPrimitiveType::DOUBLE
-    {
+    let return_primitive = type_mapper::scalar_primitive(&function.ret_type)?;
+    let decimal_result = is_decimal(&function.ret_type)?;
+    // Temporal AVG has StarRocks-specific rounding semantics. Decimal SUM/AVG are lowered to FP64
+    // below because the Sirius GPU expression/aggregate path cannot consume decimal arithmetic.
+    if name == "avg" && return_primitive != TPrimitiveType::DOUBLE && !decimal_result {
         return Err(TranslateError::UnsupportedExpression {
             node_type: root.node_type,
-            reason: "only avg with a DOUBLE result is supported (decimal/temporal avg differ)",
+            reason: "temporal avg is not supported",
         });
     }
 
     let mut cursor = ExprNodeCursor::new(&expr.nodes);
     // Consume the root marker; its children are the aggregate arguments.
     cursor.idx = 1;
-    let arguments = (0..root.num_children)
+    let mut arguments = (0..root.num_children)
         .map(|_| cursor.translate_next(ctx))
         .collect::<Result<Vec<_>>>()?;
     cursor.ensure_consumed()?;
+    if decimal_result && matches!(name, "sum" | "avg") {
+        arguments = arguments
+            .into_iter()
+            .map(|input| Expression {
+                rex_type: Some(expression::RexType::Cast(Box::new(expression::Cast {
+                    r#type: Some(type_mapper::fp64_type(true)),
+                    input: Some(Box::new(input)),
+                    failure_behavior: expression::cast::FailureBehavior::ThrowException as i32,
+                }))),
+            })
+            .collect();
+    }
 
     Ok(AggregateCall {
         name: name.to_string(),

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -50,7 +50,7 @@
 //! | `COMPOUND_PRED`   | boolean function (`and`, `or`, `not`) |
 //! | `CAST_EXPR`       | cast (throwing failure behavior) |
 //! | `IS_NULL_PRED`    | `is_null` / `is_not_null` |
-//! | `ARITHMETIC_EXPR` | `add`/`subtract`/`multiply`/`divide`/`modulus` |
+//! | `ARITHMETIC_EXPR` | `add`/`subtract`/`multiply`/`divide`/`modulus` (decimal operands in FP64) |
 //! | `IN_PRED`         | singular-or-list (wrapped in `not` for `NOT IN`) |
 //! | `CASE_EXPR`       | if-then chain (no leading case operand) |
 //! | `FUNCTION_CALL`   | allowlisted scalar functions (`like`, `if`, `substring`, `year`, ...) |
@@ -64,6 +64,12 @@
 //! decimal precision &gt; 38 (both exceed the i128 decimal encoding), and
 //! non-scalar type nodes. `JSON`/`VARIANT` are surfaced as strings until richer
 //! support lands.
+//!
+//! Decimal arithmetic is **not exact**. `ARITHMETIC_EXPR` over decimal operands, and decimal
+//! `sum`/`avg`, are evaluated in FP64 because the GPU expression and aggregate paths cannot
+//! consume decimal arithmetic; decimal slots of precision &gt; 18 likewise map to FP64. Results
+//! are not cast back, so a column the frontend declared DECIMAL can arrive as a double and
+//! differ from StarRocks in its final digits.
 //!
 //! # Adding a node
 //!

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
@@ -23,6 +23,16 @@ pub(crate) fn bool_type() -> Type {
     }
 }
 
+/// Builds an FP64 type used to lower arithmetic Sirius cannot execute on decimal columns.
+pub(crate) fn fp64_type(nullable: bool) -> Type {
+    Type {
+        kind: Some(r#type::Kind::Fp64(r#type::Fp64 {
+            type_variation_reference: 0,
+            nullability: nullability(nullable),
+        })),
+    }
+}
+
 /// Maps a StarRocks type descriptor and slot nullability into a Substrait type.
 pub fn map_type_desc(type_desc: &TTypeDesc, nullable: bool) -> Result<Type> {
     let node = scalar_node(type_desc)?;
@@ -171,12 +181,19 @@ pub fn map_scalar_type(scalar: &TScalarType, nullable: bool) -> Result<Type> {
                     reason: "decimal precision above 38 has no safe v1 Substrait mapping",
                 });
             }
-            r#type::Kind::Decimal(r#type::Decimal {
-                precision,
-                scale: scalar.scale.unwrap_or(0),
-                type_variation_reference: 0,
-                nullability: n,
-            })
+            if precision <= 18 {
+                r#type::Kind::Decimal(r#type::Decimal {
+                    precision,
+                    scale: scalar.scale.unwrap_or(0),
+                    type_variation_reference: 0,
+                    nullability: n,
+                })
+            } else {
+                r#type::Kind::Fp64(r#type::Fp64 {
+                    type_variation_reference: 0,
+                    nullability: n,
+                })
+            }
         }
         TPrimitiveType::DECIMAL256 => {
             return Err(TranslateError::UnsupportedType {

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
@@ -221,3 +221,25 @@ pub fn map_scalar_type(scalar: &TScalarType, nullable: bool) -> Result<Type> {
 
     Ok(Type { kind: Some(kind) })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn decimal(precision: i32) -> TScalarType {
+        TScalarType::new(TPrimitiveType::DECIMAL128, None, Some(precision), Some(2))
+    }
+
+    /// Precision 18 is the last width kept as DECIMAL; 19 and up lower to FP64.
+    #[test]
+    fn decimal_precision_boundary_is_18() {
+        assert!(matches!(
+            map_scalar_type(&decimal(18), true).unwrap().kind,
+            Some(r#type::Kind::Decimal(_))
+        ));
+        assert!(matches!(
+            map_scalar_type(&decimal(19), true).unwrap().kind,
+            Some(r#type::Kind::Fp64(_))
+        ));
+    }
+}

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -2865,66 +2865,91 @@ fn unsupported_join_type_is_reported_before_missing_conjuncts() {
     assert_eq!(reason, "hash join type is unsupported");
 }
 
-/// Verifies decimal arithmetic is lowered to FP64 casts for the GPU expression evaluator.
-#[test]
-fn decimal_arithmetic_is_lowered_to_fp64() {
-    let decimal = scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(31), Some(4));
-    let mut arith = base_expr_node(TExprNodeType::ARITHMETIC_EXPR, decimal.clone(), 2);
-    arith.opcode = Some(TExprOpcode::MULTIPLY);
-    let mut nodes = vec![arith];
-    nodes.extend(slot_ref(1, 0, decimal.clone()).nodes);
-    nodes.extend(slot_ref(1, 0, decimal).nodes);
-
-    let translated = translate_fragment(&params(
-        Some(TPlan::new(vec![scan_node(0, 0)])),
-        Some(base_desc()),
-        Some(vec![TExpr::new(nodes)]),
-    ))
-    .unwrap();
-    let rel::RelType::Project(project) = root(&translated.plan)
-        .input
-        .as_ref()
-        .unwrap()
-        .rel_type
-        .as_ref()
-        .unwrap()
-    else {
-        panic!("expected output project");
+/// Asserts an expression is a throwing cast to FP64, the lowering every decimal operand and
+/// decimal aggregate argument goes through.
+fn assert_fp64_cast(expr: &substrait::proto::Expression) {
+    let Some(expression::RexType::Cast(cast)) = expr.rex_type.as_ref() else {
+        panic!("expected a cast, got {expr:?}");
     };
-    let expression::RexType::ScalarFunction(function) =
-        project.expressions[0].rex_type.as_ref().unwrap()
-    else {
-        panic!("expected arithmetic function");
-    };
-    assert!(function.arguments.iter().all(|argument| matches!(
-        argument.arg_type.as_ref().unwrap(),
-        substrait::proto::function_argument::ArgType::Value(substrait::proto::Expression {
-            rex_type: Some(expression::RexType::Cast(_)),
-        })
-    )));
-    assert!(matches!(
-        function
-            .output_type
-            .as_ref()
-            .unwrap()
-            .kind
-            .as_ref()
-            .unwrap(),
-        substrait::proto::r#type::Kind::Fp64(_)
-    ));
+    assert!(
+        matches!(
+            cast.r#type.as_ref().unwrap().kind,
+            Some(substrait::proto::r#type::Kind::Fp64(_))
+        ),
+        "cast target {:?}",
+        cast.r#type
+    );
+    assert_eq!(
+        cast.failure_behavior,
+        expression::cast::FailureBehavior::ThrowException as i32
+    );
 }
 
-/// Verifies decimal AVG arguments are lowered to FP64 for GPU execution.
+/// Verifies decimal arithmetic is lowered to throwing FP64 casts for the GPU expression
+/// evaluator, and that the result type is FP64 even when the FE result slot stays DECIMAL
+/// (precision <= 18, where `map_type_desc` alone would keep it decimal).
 #[test]
-fn decimal_avg_is_lowered_to_fp64() {
-    let decimal = scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(38), Some(8));
+fn decimal_arithmetic_is_lowered_to_fp64() {
+    for decimal in [
+        scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(31), Some(4)),
+        scalar_type_with(TPrimitiveType::DECIMAL64, None, Some(18), Some(2)),
+    ] {
+        let mut arith = base_expr_node(TExprNodeType::ARITHMETIC_EXPR, decimal.clone(), 2);
+        arith.opcode = Some(TExprOpcode::MULTIPLY);
+        let mut nodes = vec![arith];
+        nodes.extend(slot_ref(1, 0, decimal.clone()).nodes);
+        nodes.extend(slot_ref(1, 0, decimal.clone()).nodes);
+
+        let translated = translate_fragment(&params(
+            Some(TPlan::new(vec![scan_node(0, 0)])),
+            Some(base_desc()),
+            Some(vec![TExpr::new(nodes)]),
+        ))
+        .unwrap();
+        let rel::RelType::Project(project) = root(&translated.plan)
+            .input
+            .as_ref()
+            .unwrap()
+            .rel_type
+            .as_ref()
+            .unwrap()
+        else {
+            panic!("expected output project");
+        };
+        let expression::RexType::ScalarFunction(function) =
+            project.expressions[0].rex_type.as_ref().unwrap()
+        else {
+            panic!("expected arithmetic function");
+        };
+        assert_eq!(function.arguments.len(), 2, "{decimal:?}");
+        for argument in &function.arguments {
+            let substrait::proto::function_argument::ArgType::Value(value) =
+                argument.arg_type.as_ref().unwrap()
+            else {
+                panic!("expected a value argument");
+            };
+            assert_fp64_cast(value);
+        }
+        assert!(
+            matches!(
+                function.output_type.as_ref().unwrap().kind,
+                Some(substrait::proto::r#type::Kind::Fp64(_))
+            ),
+            "{decimal:?}"
+        );
+    }
+}
+
+/// Translates a one-phase aggregation with one measure over a BIGINT slot and returns that
+/// measure's (possibly lowered) argument.
+fn single_measure_argument(name: &str, ret_type: TTypeDesc) -> substrait::proto::Expression {
     let agg = aggregation_node(
         1,
         1,
         vec![slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))],
         vec![aggregate_expr(
-            "avg",
-            decimal,
+            name,
+            ret_type,
             Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
         )],
     );
@@ -2944,16 +2969,64 @@ fn decimal_avg_is_lowered_to_fp64() {
     else {
         panic!("expected aggregate");
     };
-    let argument = aggregate.measures[0].measure.as_ref().unwrap().arguments[0]
-        .arg_type
-        .as_ref()
-        .unwrap();
-    assert!(matches!(
-        argument,
-        substrait::proto::function_argument::ArgType::Value(substrait::proto::Expression {
-            rex_type: Some(expression::RexType::Cast(_)),
-        })
+    let substrait::proto::function_argument::ArgType::Value(value) =
+        aggregate.measures[0].measure.as_ref().unwrap().arguments[0]
+            .arg_type
+            .as_ref()
+            .unwrap()
+    else {
+        panic!("expected a value argument");
+    };
+    value.clone()
+}
+
+/// Verifies a decimal AVG argument is lowered to a throwing FP64 cast for GPU execution.
+#[test]
+fn decimal_avg_is_lowered_to_fp64() {
+    assert_fp64_cast(&single_measure_argument(
+        "avg",
+        scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(38), Some(8)),
     ));
+}
+
+/// Verifies a decimal SUM argument is lowered the same way, including when the FE result slot
+/// stays DECIMAL (precision <= 18).
+#[test]
+fn decimal_sum_is_lowered_to_fp64() {
+    assert_fp64_cast(&single_measure_argument(
+        "sum",
+        scalar_type_with(TPrimitiveType::DECIMAL64, None, Some(18), Some(2)),
+    ));
+}
+
+/// Verifies an avg that lowers to neither the DOUBLE nor the decimal path (temporal avg, with
+/// StarRocks-specific rounding) is refused with a reason that names what is supported.
+#[test]
+fn temporal_avg_is_rejected() {
+    let agg = aggregation_node(
+        1,
+        1,
+        vec![slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))],
+        vec![aggregate_expr(
+            "avg",
+            scalar_type(TPrimitiveType::DATE),
+            Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+        )],
+    );
+    let err = translate_fragment(&params(
+        Some(TPlan::new(vec![agg, scan_node(0, 0)])),
+        Some(agg_desc()),
+        None,
+    ))
+    .unwrap_err();
+    let TranslateError::UnsupportedExpression { node_type, reason } = err else {
+        panic!("expected an unsupported expression, got {err:?}");
+    };
+    assert_eq!(node_type, TExprNodeType::AGG_EXPR);
+    assert_eq!(
+        reason,
+        "avg is only supported where it lowers to the GPU's FP64 avg (DOUBLE and DECIMAL inputs)"
+    );
 }
 
 /// Verifies partitioned top-N sorts are rejected rather than run as a global sort.

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -1779,6 +1779,20 @@ fn decimal_literal_encodes_little_endian_unscaled_value() {
     }
 }
 
+/// A decimal literal wider than 18 digits follows the slot rule and is emitted as FP64.
+#[test]
+fn wide_decimal_literal_is_lowered_to_fp64() {
+    let plan = filter_with_conjunct(binary_pred(
+        TExprOpcode::EQ,
+        slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+        decimal_literal("1.5", 19, 2),
+    ));
+    match literal_type(scalar_arg(filter_condition(&plan), 1)) {
+        expression::literal::LiteralType::Fp64(value) => assert_eq!(*value, 1.5),
+        other => panic!("expected fp64 literal, got {other:?}"),
+    }
+}
+
 /// Verifies an integer literal that overflows its declared width is a malformed plan.
 #[test]
 fn integer_literal_overflowing_declared_width_is_error() {

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -2851,9 +2851,9 @@ fn unsupported_join_type_is_reported_before_missing_conjuncts() {
     assert_eq!(reason, "hash join type is unsupported");
 }
 
-/// Verifies decimal-typed arithmetic is rejected (it crashes the engine's GPU projection).
+/// Verifies decimal arithmetic is lowered to FP64 casts for the GPU expression evaluator.
 #[test]
-fn decimal_arithmetic_is_rejected() {
+fn decimal_arithmetic_is_lowered_to_fp64() {
     let decimal = scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(31), Some(4));
     let mut arith = base_expr_node(TExprNodeType::ARITHMETIC_EXPR, decimal.clone(), 2);
     arith.opcode = Some(TExprOpcode::MULTIPLY);
@@ -2861,27 +2861,48 @@ fn decimal_arithmetic_is_rejected() {
     nodes.extend(slot_ref(1, 0, decimal.clone()).nodes);
     nodes.extend(slot_ref(1, 0, decimal).nodes);
 
-    let err = translate_fragment(&params(
+    let translated = translate_fragment(&params(
         Some(TPlan::new(vec![scan_node(0, 0)])),
         Some(base_desc()),
         Some(vec![TExpr::new(nodes)]),
     ))
-    .unwrap_err();
-    assert!(
-        matches!(
-            err,
-            TranslateError::UnsupportedExpression {
-                node_type: TExprNodeType::ARITHMETIC_EXPR,
-                ..
-            }
-        ),
-        "{err:?}"
-    );
+    .unwrap();
+    let rel::RelType::Project(project) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected output project");
+    };
+    let expression::RexType::ScalarFunction(function) =
+        project.expressions[0].rex_type.as_ref().unwrap()
+    else {
+        panic!("expected arithmetic function");
+    };
+    assert!(function.arguments.iter().all(|argument| matches!(
+        argument.arg_type.as_ref().unwrap(),
+        substrait::proto::function_argument::ArgType::Value(substrait::proto::Expression {
+            rex_type: Some(expression::RexType::Cast(_)),
+        })
+    )));
+    assert!(matches!(
+        function
+            .output_type
+            .as_ref()
+            .unwrap()
+            .kind
+            .as_ref()
+            .unwrap(),
+        substrait::proto::r#type::Kind::Fp64(_)
+    ));
 }
 
-/// Verifies `avg` over decimals is rejected (DuckDB computes a double for decimal inputs).
+/// Verifies decimal AVG arguments are lowered to FP64 for GPU execution.
 #[test]
-fn decimal_avg_is_rejected() {
+fn decimal_avg_is_lowered_to_fp64() {
     let decimal = scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(38), Some(8));
     let agg = aggregation_node(
         1,
@@ -2893,16 +2914,32 @@ fn decimal_avg_is_rejected() {
             Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
         )],
     );
-    let err = translate_fragment(&params(
+    let translated = translate_fragment(&params(
         Some(TPlan::new(vec![agg, scan_node(0, 0)])),
         Some(agg_desc()),
         None,
     ))
-    .unwrap_err();
-    assert!(
-        matches!(err, TranslateError::UnsupportedExpression { .. }),
-        "{err:?}"
-    );
+    .unwrap();
+    let rel::RelType::Aggregate(aggregate) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected aggregate");
+    };
+    let argument = aggregate.measures[0].measure.as_ref().unwrap().arguments[0]
+        .arg_type
+        .as_ref()
+        .unwrap();
+    assert!(matches!(
+        argument,
+        substrait::proto::function_argument::ArgType::Value(substrait::proto::Expression {
+            rex_type: Some(expression::RexType::Cast(_)),
+        })
+    ));
 }
 
 /// Verifies partitioned top-N sorts are rejected rather than run as a global sort.


### PR DESCRIPTION
## Description
**Motivation.** The GPU expression and aggregate paths cannot consume decimal arithmetic. Today `translate_arithmetic` refuses every decimal `ARITHMETIC_EXPR` and `aggregate_call` refuses decimal `avg`, so TPC-H Q1 (`l_extendedprice*(1-l_discount)*(1+l_tax)`, three `avg`s), Q6 (`sum(l_extendedprice*l_discount)`) and every other revenue query fail to translate on the StarRocks CN.

**What changed.** Decimal operands of `ARITHMETIC_EXPR` and the arguments of decimal `sum`/`avg` are cast to FP64 (throwing cast) and the expression yields FP64; `DECIMAL_LITERAL` with precision > 18 becomes an FP64 literal; `map_scalar_type` keeps DECIMAL at precision <= 18 and maps wider decimals to FP64 (`type_mapper::fp64_type`). The lowering is **unconditional, approximate, and never cast back**: a slot the frontend declared DECIMAL can arrive as a double and differ from StarRocks in its last digits (~1e-14 relative). This is preferred over refusing the shape; a decimal-native GPU path is the real fix.

**Verified.** `cargo fmt --check`, `cargo clippy --all-targets --no-default-features -- -D warnings`, `cargo test --workspace --no-default-features` (new: `decimal_arithmetic_is_lowered_to_fp64` (precision 31 and 18, casts pinned as throwing FP64), `decimal_avg_is_lowered_to_fp64`, `decimal_sum_is_lowered_to_fp64`, `temporal_avg_is_rejected`, `wide_decimal_literal_is_lowered_to_fp64`, `type_mapper::tests::decimal_precision_boundary_is_18`). Local run on e7b1b6ec: fmt and clippy clean; starrocks-plan-translator 6 unit + 99 `translate.rs` tests, sirius-starrocks-cn 49 tests, all passing.

**Intentionally not handled.** Exchange-boundary type mismatch for FE precision <= 18 results and the scan/GROUP BY slot rewrite for precision > 18 are tracked as separate issues (see References). `AggregateFunction.output_type` on a decimal `sum`/`avg` measure stays the FE slot type over FP64-cast arguments; DuckDB's Substrait consumer ignores `output_type` and binds from the arguments, and the exchange-side mismatch is the issue above. A shared `cast_to_fp64` helper and the merge-phase guard on `aggregate_call` arrive with the two-phase aggregation PR.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
Refs #1109 and #1110 (introduced the decimal arithmetic and decimal avg refusals this replaces) and #1208 (Substrait add/subtract/multiply/divide/modulus aliases the lowered arithmetic resolves through), all merged. Follow-up issues: #1687, #1688.