### PR TITLE
fix(sirius): reset standalone query state

### DIFF
--- a/rust/crates/sirius/src/lib.rs
+++ b/rust/crates/sirius/src/lib.rs
@@ -217,16 +217,22 @@ mod tests {
             vec!["id".to_string(), "name".to_string()],
         );
 
-        // Drop the context before inspecting the result to prove the returned
-        // batches own their data independently of the engine context.
-        let batches = {
+        // Execute twice on one context to verify standalone query state is reset,
+        // then drop it before inspecting the returned owned batches.
+        let results = {
             let mut ctx = SiriusContext::new().expect("bring up sirius context");
-            ctx.execute_substrait(&plan)
-                .expect("execute substrait plan")
+            vec![
+                ctx.execute_substrait(&plan)
+                    .expect("execute first substrait plan"),
+                ctx.execute_substrait(&plan)
+                    .expect("execute second substrait plan"),
+            ]
         };
 
-        let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
-        assert_eq!(total_rows, 3, "expected 3 rows from the parquet fixture");
+        for batches in results {
+            let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+            assert_eq!(total_rows, 3, "expected 3 rows from the parquet fixture");
+        }
     }
 
     /// A missing config file is rejected before any GPU work (`load_from_file`

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -86,6 +86,9 @@ class SiriusContext : public ClientContextState {
   /// \param context The client context.
   void QueryBegin(ClientContext& context) final;
 
+  /// \brief Starts a query for execution paths that bypass DuckDB's active-query state.
+  void QueryBeginStandalone(ClientContext& context, std::string_view query_label);
+
   /// \brief Called at the end of a query execution.
   void QueryEnd() final;
 

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -216,6 +216,25 @@ void SiriusContext::QueryBegin(ClientContext& context)
   }
 }
 
+void SiriusContext::QueryBeginStandalone(ClientContext& context, std::string_view query_label)
+{
+  if (is_internal_query_active()) { return; }
+
+  acquire_query_lifecycle_slot();
+
+  try {
+    log_pool_stats("QueryBegin");
+    captured_logical_plan_.reset();
+    sirius::op::sirius_physical_operator::next_operator_id.store(0);
+    SIRIUS_LOG_INFO("QueryBegin: {}", query_label);
+    task_creator_->reset();
+    task_creator_->set_client_context(context);
+  } catch (...) {
+    release_query_lifecycle_slot();
+    throw;
+  }
+}
+
 void SiriusContext::QueryEnd()
 {
   // Suppress state mutations triggered by internal connections (e.g. internal metadata lookups).

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -47,6 +47,7 @@ namespace sirius::ffi {
 namespace {
 // ClientContextState key the GPU engine resolves its SiriusContext under.
 constexpr const char* kSiriusStateKey = "sirius_state";
+constexpr const char* kQueryLabel     = "sirius_ffi";
 // Arrow record-batch size for the exported stream; the consumer re-batches as needed.
 constexpr duckdb::idx_t kArrowBatchSize = 1u << 20;
 }  // namespace
@@ -139,7 +140,7 @@ void Context::execute_substrait(const std::string& plan, std::uintptr_t out_stre
   bool query_started = false;
   duckdb::unique_ptr<duckdb::QueryResult> result;
   try {
-    impl_->context->QueryBeginStandalone(client, "starrocks_substrait");
+    impl_->context->QueryBeginStandalone(client, kQueryLabel);
     query_started = true;
 
     // 1. Substrait bytes -> DuckDB Relation. DuckDB is used only for this lowering.
@@ -173,9 +174,9 @@ void Context::execute_substrait(const std::string& plan, std::uintptr_t out_stre
     auto gpu_prepared = duckdb::make_shared_ptr<sirius::sirius_prepared_statement_data>(
       std::move(prepared), std::move(physical_plan));
 
-    sirius::sirius_interface iface(client, std::optional<std::string>("starrocks_substrait"));
+    sirius::sirius_interface iface(client, std::optional<std::string>(kQueryLabel));
     result = iface.sirius_execute_query(
-      client, "starrocks_substrait", gpu_prepared, duckdb::PendingQueryParameters{});
+      client, kQueryLabel, gpu_prepared, duckdb::PendingQueryParameters{});
 
     // This standalone path bypasses DuckDB's normal query entry point, so its
     // ClientContextState callbacks are not invoked automatically. End every

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -136,8 +136,12 @@ void Context::execute_substrait(const std::string& plan, std::uintptr_t out_stre
   // execution is eager (the result is materialized), so the transaction can close
   // before the Arrow stream is consumed.
   impl_->conn->BeginTransaction();
+  bool query_started = false;
   duckdb::unique_ptr<duckdb::QueryResult> result;
   try {
+    impl_->context->QueryBeginStandalone(client, "starrocks_substrait");
+    query_started = true;
+
     // 1. Substrait bytes -> DuckDB Relation. DuckDB is used only for this lowering.
     duckdb::SubstraitToDuckDB transformer(impl_->conn->context, plan, /*json=*/false);
     auto relation = transformer.TransformPlan();
@@ -172,7 +176,20 @@ void Context::execute_substrait(const std::string& plan, std::uintptr_t out_stre
     sirius::sirius_interface iface(client, std::optional<std::string>("starrocks_substrait"));
     result = iface.sirius_execute_query(
       client, "starrocks_substrait", gpu_prepared, duckdb::PendingQueryParameters{});
+
+    // This standalone path bypasses DuckDB's normal query entry point, so its
+    // ClientContextState callbacks are not invoked automatically. End every
+    // single-shot execution explicitly to clear repositories, scan providers,
+    // and task-creator state before the next fragment.
+    impl_->context->QueryEnd();
+    query_started = false;
   } catch (...) {
+    if (query_started) {
+      try {
+        impl_->context->QueryEnd();
+      } catch (...) {
+      }
+    }
     impl_->conn->Rollback();
     throw;
   }


### PR DESCRIPTION
Reset standalone query state around each Substrait execution.

Test: repeated GPU execution through one Sirius context.