### PR TITLE
feat(starrocks): translate materialized exchanges

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/descriptor_table.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/descriptor_table.rs
@@ -238,23 +238,43 @@ impl DescriptorTable {
 
     /// Builds the Substrait schema for a StarRocks tuple.
     pub fn named_struct(&self, tuple_id: i32) -> Result<NamedStruct> {
-        let (names, types): (Vec<_>, Vec<_>) = self
-            .materialized_slot_ids(tuple_id)?
-            .into_iter()
-            .map(|slot_id| {
+        self.named_struct_for_tuples(&[tuple_id], None)
+    }
+
+    /// Builds the Substrait schema for a row layout spanning one or more tuples.
+    ///
+    /// `names` overrides descriptor names when an exchange input was materialized with the
+    /// sender fragment's output names. Types and field order always come from the receiver's
+    /// descriptor table.
+    pub(crate) fn named_struct_for_tuples(
+        &self,
+        tuple_ids: &[i32],
+        names: Option<&[String]>,
+    ) -> Result<NamedStruct> {
+        let mut descriptor_names = Vec::new();
+        let mut types = Vec::new();
+        for &tuple_id in tuple_ids {
+            for slot_id in self.materialized_slot_ids(tuple_id)? {
                 let slot = self.slot(tuple_id, slot_id)?;
-                let substrait_type =
+                descriptor_names.push(slot.output_name());
+                types.push(
                     slot.substrait_type
                         .clone()
                         .ok_or(TranslateError::MissingField {
                             context: "materialized TSlotDescriptor",
                             field: "slotType",
-                        })?;
-                Ok((slot.output_name(), substrait_type))
-            })
-            .collect::<Result<Vec<_>>>()?
-            .into_iter()
-            .unzip();
+                        })?,
+                );
+            }
+        }
+        let names = names.map_or(descriptor_names, <[String]>::to_vec);
+        if names.len() != types.len() {
+            return Err(TranslateError::descriptor(format!(
+                "row layout {tuple_ids:?} has {} fields but exchange input has {} names",
+                types.len(),
+                names.len()
+            )));
+        }
 
         Ok(NamedStruct {
             names,

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -6,9 +6,8 @@
 //! invariants over breadth: it translates one fragment at a time, and everything
 //! outside the supported surface returns a structured [`TranslateError`] that
 //! names the offending node/type — so the next contributor knows exactly what to
-//! implement next. In particular `EXCHANGE_NODE` is rejected: a fragment is
-//! translated in isolation, and multi-fragment plans (every exchange is a
-//! fragment boundary) are a later milestone.
+//! implement next. `EXCHANGE_NODE` requires an explicit, materialized same-node
+//! input supplied by the compute-node wrapper.
 //!
 //! # Wire format: flat preorder
 //!
@@ -35,6 +34,7 @@
 //! | `SORT_NODE`          | `ProjectRel` (sort tuple) + `SortRel` (global row-number top-N only) |
 //! | `HASH_JOIN_NODE`     | `JoinRel` (inner/outer/left-semi; anti joins are rejected) |
 //! | `NESTLOOP_JOIN_NODE` | `JoinRel` (constant-key inner) + optional `FilterRel`, inner/cross only |
+//! | `EXCHANGE_NODE`      | `ReadRel` (`local_files`, with an explicit materialized input) |
 //!
 //! Node-level `conjuncts` (scan/filter predicates, HAVING, post-join filters) become a
 //! `FilterRel` over the node's output on every supported node.
@@ -124,6 +124,17 @@ pub struct TranslatedPlan {
     pub output_names: Vec<String>,
 }
 
+/// A fully materialized same-node input for one StarRocks exchange node.
+#[derive(Clone, Debug)]
+pub struct ExchangeInput {
+    /// Receiver `EXCHANGE_NODE` id.
+    pub node_id: i32,
+    /// Local parquet files containing the sender fragment output.
+    pub paths: Vec<String>,
+    /// Sender output names as written to those parquet files.
+    pub names: Vec<String>,
+}
+
 impl TranslatedPlan {
     /// Returns a human-readable Substrait text formatter for logging and debugging.
     pub fn explain(&self) -> PlanExplain<'_> {
@@ -195,6 +206,15 @@ impl PlanTranslator {
 
     /// Translates a StarRocks execution fragment into a Substrait plan.
     pub fn translate_fragment(&self, params: &TExecPlanFragmentParams) -> Result<TranslatedPlan> {
+        self.translate_fragment_with_exchange_inputs(params, &[])
+    }
+
+    /// Translates a fragment with fully materialized inputs for its same-node exchange nodes.
+    pub fn translate_fragment_with_exchange_inputs(
+        &self,
+        params: &TExecPlanFragmentParams,
+        exchange_inputs: &[ExchangeInput],
+    ) -> Result<TranslatedPlan> {
         let fragment = params
             .fragment
             .as_ref()
@@ -216,9 +236,18 @@ impl PlanTranslator {
 
         let desc = DescriptorTable::try_from(desc_tbl)?;
         let scan_paths = ScanFilePaths::from_fragment(params, &desc)?;
+        let exchange_inputs = exchange_inputs
+            .iter()
+            .map(|input| (input.node_id, input))
+            .collect::<HashMap<_, _>>();
         let mut registry = ExtensionRegistry::new();
-        let mut translated =
-            node_translator::translate_plan(plan, &desc, &scan_paths, &mut registry)?;
+        let mut translated = node_translator::translate_plan(
+            plan,
+            &desc,
+            &scan_paths,
+            &exchange_inputs,
+            &mut registry,
+        )?;
 
         let output_names = if let Some(output_exprs) = fragment
             .output_exprs

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -17,7 +17,9 @@ use crate::error::{Result, TranslateError};
 use crate::expr_translator::{self, ExprContext, TranslateExpr};
 use crate::scan_paths::ScanFilePaths;
 use crate::type_mapper;
-use crate::{ExtensionRegistry, URN_AGGREGATE, URN_ARITHMETIC, URN_BOOLEAN, URN_COMPARISON};
+use crate::{
+    ExchangeInput, ExtensionRegistry, URN_AGGREGATE, URN_ARITHMETIC, URN_BOOLEAN, URN_COMPARISON,
+};
 
 /// Partially translated relation plus the StarRocks row layout it emits.
 pub(crate) struct TranslatedRel {
@@ -48,6 +50,8 @@ struct PlanContext<'a> {
     /// scan ranges. Scans with paths emit a `local_files` read; path-less scans
     /// fall back to a named-table read.
     scan_paths: &'a ScanFilePaths,
+    /// Materialized same-node inputs keyed by receiver exchange node id.
+    exchange_inputs: &'a std::collections::HashMap<i32, &'a ExchangeInput>,
     /// Substrait extension registry shared across the whole plan.
     registry: &'a mut ExtensionRegistry,
 }
@@ -57,11 +61,13 @@ impl<'a> PlanContext<'a> {
     fn new(
         desc: &'a DescriptorTable,
         scan_paths: &'a ScanFilePaths,
+        exchange_inputs: &'a std::collections::HashMap<i32, &'a ExchangeInput>,
         registry: &'a mut ExtensionRegistry,
     ) -> Self {
         Self {
             desc,
             scan_paths,
+            exchange_inputs,
             registry,
         }
     }
@@ -155,6 +161,7 @@ fn translate_plan_node(
         TPlanNodeType::SORT_NODE => translate_sort(node, children, ctx),
         TPlanNodeType::HASH_JOIN_NODE => translate_hash_join(node, children, ctx),
         TPlanNodeType::NESTLOOP_JOIN_NODE => translate_nestloop_join(node, children, ctx),
+        TPlanNodeType::EXCHANGE_NODE => translate_exchange(node, children, ctx),
         _ => Err(TranslateError::UnsupportedPlanNode {
             node_id: node.node_id,
             node_type: node.node_type,
@@ -176,6 +183,11 @@ fn apply_fetch(input: TranslatedRel, node: &TPlanNode) -> TranslatedRel {
         .sort_node
         .as_ref()
         .and_then(|sort| sort.offset)
+        .or_else(|| {
+            node.exchange_node
+                .as_ref()
+                .and_then(|exchange| exchange.offset)
+        })
         .unwrap_or(0);
     if node.limit < 0 && offset == 0 {
         return input;
@@ -295,10 +307,68 @@ pub(crate) fn translate_plan(
     plan: &TPlan,
     desc: &DescriptorTable,
     scan_paths: &ScanFilePaths,
+    exchange_inputs: &std::collections::HashMap<i32, &ExchangeInput>,
     registry: &mut ExtensionRegistry,
 ) -> Result<TranslatedRel> {
-    let mut ctx = PlanContext::new(desc, scan_paths, registry);
+    let mut ctx = PlanContext::new(desc, scan_paths, exchange_inputs, registry);
     plan.translate(&mut ctx)
+}
+
+/// Replaces a receiver exchange boundary with a read of its fully materialized sender output.
+fn translate_exchange(
+    node: &TPlanNode,
+    children: Vec<TranslatedRel>,
+    ctx: &mut PlanContext<'_>,
+) -> Result<TranslatedRel> {
+    expect_children(node, &children, 0)?;
+    let exchange = node
+        .exchange_node
+        .as_ref()
+        .ok_or(TranslateError::MissingField {
+            context: "EXCHANGE_NODE",
+            field: "exchange_node",
+        })?;
+    if exchange.sort_info.is_some() {
+        return Err(TranslateError::UnsupportedPlanNode {
+            node_id: node.node_id,
+            node_type: node.node_type,
+            reason: "merging exchanges are not supported by sequential execution",
+        });
+    }
+    if exchange.input_row_tuples.is_empty() {
+        return Err(TranslateError::MissingField {
+            context: "TExchangeNode",
+            field: "input_row_tuples",
+        });
+    }
+    let input =
+        ctx.exchange_inputs
+            .get(&node.node_id)
+            .ok_or(TranslateError::UnsupportedPlanNode {
+                node_id: node.node_id,
+                node_type: node.node_type,
+                reason: "exchange node requires a materialized same-node input",
+            })?;
+    if input.paths.is_empty() {
+        return Err(TranslateError::malformed(format!(
+            "exchange node {} has no materialized input files",
+            node.node_id
+        )));
+    }
+    let schema = ctx
+        .desc
+        .named_struct_for_tuples(&exchange.input_row_tuples, Some(&input.names))?;
+    let output_width = schema
+        .r#struct
+        .as_ref()
+        .map(|structure| structure.types.len())
+        .unwrap_or(0);
+    let translated = TranslatedRel {
+        rel: local_files_rel(schema, &input.paths),
+        row_tuples: exchange.input_row_tuples.clone(),
+        output_width,
+    };
+    apply_conjuncts(translated, node, ctx)
 }
 
 /// Translates a one-phase `AGGREGATION_NODE` into a Substrait aggregate relation.
@@ -859,17 +929,7 @@ fn scan_rel(desc: &DescriptorTable, tuple_id: i32, file_paths: &[String]) -> Res
             ..Default::default()
         })
     } else {
-        ReadType::LocalFiles(LocalFiles {
-            items: file_paths
-                .iter()
-                .map(|path| FileOrFiles {
-                    path_type: Some(PathType::UriFile(path.clone())),
-                    file_format: Some(FileFormat::Parquet(ParquetReadOptions {})),
-                    ..Default::default()
-                })
-                .collect(),
-            ..Default::default()
-        })
+        return Ok(local_files_rel(desc.named_struct(tuple_id)?, file_paths));
     };
     Ok(Rel {
         rel_type: Some(rel::RelType::Read(Box::new(ReadRel {
@@ -878,6 +938,27 @@ fn scan_rel(desc: &DescriptorTable, tuple_id: i32, file_paths: &[String]) -> Res
             ..Default::default()
         }))),
     })
+}
+
+/// Builds a local parquet read with an explicit schema.
+fn local_files_rel(schema: substrait::proto::NamedStruct, file_paths: &[String]) -> Rel {
+    Rel {
+        rel_type: Some(rel::RelType::Read(Box::new(ReadRel {
+            base_schema: Some(schema),
+            read_type: Some(ReadType::LocalFiles(LocalFiles {
+                items: file_paths
+                    .iter()
+                    .map(|path| FileOrFiles {
+                        path_type: Some(PathType::UriFile(path.clone())),
+                        file_format: Some(FileFormat::Parquet(ParquetReadOptions {})),
+                        ..Default::default()
+                    })
+                    .collect(),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }))),
+    }
 }
 
 /// Translates a StarRocks project node while preserving descriptor output order.
@@ -937,7 +1018,8 @@ pub(crate) fn project_exprs(
     // Root projections evaluate over already-translated inputs, so there are no
     // scan nodes to resolve file paths for.
     let scan_paths = ScanFilePaths::default();
-    let mut ctx = PlanContext::new(desc, &scan_paths, registry);
+    let exchange_inputs = std::collections::HashMap::new();
+    let mut ctx = PlanContext::new(desc, &scan_paths, &exchange_inputs, registry);
     project_exprs_with_context(input, exprs, &mut ctx)
 }
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use starrocks_plan_translator::{
-    ExtensionRegistry, PlanTranslator, TranslateError, URN_BOOLEAN, URN_COMPARISON,
+    ExchangeInput, ExtensionRegistry, PlanTranslator, TranslateError, URN_BOOLEAN, URN_COMPARISON,
     translate_fragment,
 };
 use starrocks_thrift::descriptors::{
@@ -19,8 +19,9 @@ use starrocks_thrift::opcodes::TExprOpcode;
 use starrocks_thrift::partitions::{TDataPartition, TPartitionType};
 use starrocks_thrift::plan_nodes::{
     TAggregationNode, TBrokerRangeDesc, TBrokerScanRange, TBrokerScanRangeParams, TEqJoinCondition,
-    TFileFormatType, TFileScanNode, TFileScanType, THashJoinNode, TJoinOp, TNestLoopJoinNode,
-    TPlan, TPlanNode, TPlanNodeType, TProjectNode, TScanRange, TSelectNode, TSortInfo, TSortNode,
+    TExchangeNode, TFileFormatType, TFileScanNode, TFileScanType, THashJoinNode, TJoinOp,
+    TNestLoopJoinNode, TPlan, TPlanNode, TPlanNodeType, TProjectNode, TScanRange, TSelectNode,
+    TSortInfo, TSortNode,
 };
 use starrocks_thrift::planner::TPlanFragment;
 use starrocks_thrift::types::{
@@ -2578,11 +2579,18 @@ fn nestloop_join_without_a_liftable_comparison_still_translates() {
     }
 }
 
-/// Verifies an exchange node is still rejected: fragments are translated in isolation and
-/// multi-fragment plans are a later milestone.
+/// Verifies an exchange node without a materialized input is rejected.
 #[test]
 fn exchange_node_is_rejected() {
-    let exchange = base_plan_node(1, TPlanNodeType::EXCHANGE_NODE, 0, vec![0]);
+    let mut exchange = base_plan_node(1, TPlanNodeType::EXCHANGE_NODE, 0, vec![0]);
+    exchange.exchange_node = Some(TExchangeNode::new(
+        vec![0],
+        None,
+        None,
+        Some(TPartitionType::UNPARTITIONED),
+        Some(true),
+        None,
+    ));
     let err = translate_fragment(&params(
         Some(TPlan::new(vec![exchange])),
         Some(base_desc()),
@@ -2596,6 +2604,60 @@ fn exchange_node_is_rejected() {
             ..
         }
     ));
+}
+
+/// Verifies a materialized exchange becomes the read below the receiver aggregate.
+#[test]
+fn materialized_exchange_feeds_aggregate() {
+    let mut exchange = base_plan_node(7, TPlanNodeType::EXCHANGE_NODE, 0, vec![0]);
+    exchange.exchange_node = Some(TExchangeNode::new(
+        vec![0],
+        None,
+        None,
+        Some(TPartitionType::UNPARTITIONED),
+        Some(true),
+        None,
+    ));
+    let aggregate = aggregation_node(
+        8,
+        1,
+        vec![slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))],
+        vec![aggregate_expr(
+            "sum",
+            scalar_type(TPrimitiveType::BIGINT),
+            Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+        )],
+    );
+    let translated = PlanTranslator::new()
+        .translate_fragment_with_exchange_inputs(
+            &params(
+                Some(TPlan::new(vec![aggregate, exchange])),
+                Some(agg_desc()),
+                None,
+            ),
+            &[ExchangeInput {
+                node_id: 7,
+                paths: vec!["/tmp/materialized-exchange.parquet".to_string()],
+                names: vec!["id".to_string(), "name".to_string()],
+            }],
+        )
+        .unwrap();
+
+    let root = root(&translated.plan);
+    let rel::RelType::Aggregate(aggregate) =
+        root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected aggregate receiver");
+    };
+    let rel::RelType::Read(read) = aggregate.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected materialized exchange read");
+    };
+    let Some(read_rel::ReadType::LocalFiles(files)) = read.read_type.as_ref() else {
+        panic!("expected local_files exchange input");
+    };
+    assert_eq!(files.items.len(), 1);
+    assert_eq!(read.base_schema.as_ref().unwrap().names, vec!["id", "name"]);
 }
 
 /// Returns every extension function name declared by the plan.

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -2638,7 +2638,10 @@ fn materialized_exchange_feeds_aggregate() {
             &[ExchangeInput {
                 node_id: 7,
                 paths: vec!["/tmp/materialized-exchange.parquet".to_string()],
-                names: vec!["id".to_string(), "name".to_string()],
+                // Deliberately unlike the descriptor's own names: the sender's names are what
+                // must reach `base_schema`, and matching names cannot tell the override from no
+                // override at all.
+                names: vec!["sender_id".to_string(), "sender_name".to_string()],
             }],
         )
         .unwrap();
@@ -2657,7 +2660,22 @@ fn materialized_exchange_feeds_aggregate() {
         panic!("expected local_files exchange input");
     };
     assert_eq!(files.items.len(), 1);
-    assert_eq!(read.base_schema.as_ref().unwrap().names, vec!["id", "name"]);
+    let base_schema = read.base_schema.as_ref().unwrap();
+    assert_eq!(base_schema.names, vec!["sender_id", "sender_name"]);
+    // The names come from the sender; the types still come from the descriptor.
+    let kinds: Vec<_> = base_schema
+        .r#struct
+        .as_ref()
+        .unwrap()
+        .types
+        .iter()
+        .map(|ty| match ty.kind.as_ref().expect("column type") {
+            substrait::proto::r#type::Kind::I64(_) => "i64",
+            substrait::proto::r#type::Kind::Varchar(_) => "varchar",
+            other => panic!("unexpected exchange column type {other:?}"),
+        })
+        .collect();
+    assert_eq!(kinds, vec!["i64", "varchar"]);
 }
 
 /// Returns every extension function name declared by the plan.

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -3739,3 +3739,152 @@ fn bare_cross_join_translates_to_constant_key_join() {
         .collect();
     assert_eq!(operands, vec![2, 4]);
 }
+
+/// Builds an EXCHANGE_NODE with id 7 over `input_row_tuples`, optionally merging or offset.
+fn exchange_node_with(
+    input_row_tuples: Vec<i32>,
+    sort_info: Option<TSortInfo>,
+    offset: Option<i64>,
+) -> TPlanNode {
+    let mut exchange = base_plan_node(7, TPlanNodeType::EXCHANGE_NODE, 0, vec![0]);
+    exchange.exchange_node = Some(TExchangeNode::new(
+        input_row_tuples,
+        sort_info,
+        offset,
+        Some(TPartitionType::UNPARTITIONED),
+        Some(true),
+        None,
+    ));
+    exchange
+}
+
+/// Translates a lone exchange node with the given materialized inputs.
+fn translate_exchange_only(
+    exchange: TPlanNode,
+    inputs: &[ExchangeInput],
+) -> Result<substrait::proto::Plan, TranslateError> {
+    PlanTranslator::new()
+        .translate_fragment_with_exchange_inputs(
+            &params(Some(TPlan::new(vec![exchange])), Some(agg_desc()), None),
+            inputs,
+        )
+        .map(|translated| translated.plan)
+}
+
+/// The materialized input for node 7 covering `agg_desc`'s tuple 0.
+fn exchange_input_for_node_7() -> ExchangeInput {
+    ExchangeInput {
+        node_id: 7,
+        paths: vec!["/tmp/materialized-exchange.parquet".to_string()],
+        names: vec!["sender_id".to_string(), "sender_name".to_string()],
+    }
+}
+
+/// A merging exchange carries the cross-fragment ORDER BY. Reading its inputs as plain files
+/// discards that order, so the query would return unordered rows with no error.
+#[test]
+fn merging_exchange_is_rejected() {
+    let sort_info = TSortInfo::new(
+        vec![slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))],
+        vec![true],
+        vec![false],
+        None,
+    );
+    let err = translate_exchange_only(
+        exchange_node_with(vec![0], Some(sort_info), None),
+        &[exchange_input_for_node_7()],
+    )
+    .unwrap_err();
+    let TranslateError::UnsupportedPlanNode { reason, .. } = err else {
+        panic!("expected an unsupported plan node, got {err:?}");
+    };
+    assert_eq!(
+        reason,
+        "merging exchanges are not supported by sequential execution"
+    );
+}
+
+/// Without `input_row_tuples` there is no row layout to bind the materialized files against.
+#[test]
+fn exchange_without_input_row_tuples_is_rejected() {
+    let err = translate_exchange_only(
+        exchange_node_with(Vec::new(), None, None),
+        &[exchange_input_for_node_7()],
+    )
+    .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            TranslateError::MissingField {
+                context: "TExchangeNode",
+                field: "input_row_tuples"
+            }
+        ),
+        "{err:?}"
+    );
+}
+
+/// An exchange whose sender produced no file cannot be read as one. Accepting it would emit a
+/// `local_files` read over an empty list, which binds to nothing.
+#[test]
+fn exchange_with_no_materialized_files_is_rejected() {
+    let err = translate_exchange_only(
+        exchange_node_with(vec![0], None, None),
+        &[ExchangeInput {
+            node_id: 7,
+            paths: Vec::new(),
+            names: vec!["sender_id".to_string(), "sender_name".to_string()],
+        }],
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, TranslateError::MalformedPlan { .. }),
+        "{err:?}"
+    );
+}
+
+/// The sender's name list must have one entry per column of the declared row layout; a mismatch
+/// would otherwise bind columns positionally under the wrong names.
+#[test]
+fn exchange_names_must_match_the_row_layout_arity() {
+    let err = translate_exchange_only(
+        exchange_node_with(vec![0], None, None),
+        &[ExchangeInput {
+            node_id: 7,
+            paths: vec!["/tmp/materialized-exchange.parquet".to_string()],
+            names: vec!["only_one".to_string()],
+        }],
+    )
+    .unwrap_err();
+    assert!(matches!(err, TranslateError::Descriptor(_)), "{err:?}");
+}
+
+/// An exchange node carries its own skip offset, not just a sort. It must reach the fetch with an
+/// explicit unlimited count, or the consumer decodes the unset count as `LIMIT 0`.
+#[test]
+#[allow(deprecated)]
+fn exchange_offset_becomes_a_fetch() {
+    let plan = translate_exchange_only(
+        exchange_node_with(vec![0], None, Some(5)),
+        &[exchange_input_for_node_7()],
+    )
+    .unwrap();
+    let rel::RelType::Fetch(fetch) = root(&plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected the exchange offset to become a fetch");
+    };
+    assert_eq!(
+        fetch.count_mode,
+        Some(substrait::proto::fetch_rel::CountMode::Count(-1))
+    );
+    assert_eq!(
+        fetch.offset_mode,
+        Some(substrait::proto::fetch_rel::OffsetMode::Offset(5))
+    );
+}


### PR DESCRIPTION
Translate exchange nodes from explicit materialized local Parquet inputs.

Depends on #1111.