### PR TITLE
fix: retry transient CUDA kernel-launch failures as task reschedules

### DIFF
--- a/src/include/pipeline/oom_reschedule_exception.hpp
+++ b/src/include/pipeline/oom_reschedule_exception.hpp
@@ -66,22 +66,15 @@ class oom_reschedule_exception : public task_reschedule_exception {
   using task_reschedule_exception::task_reschedule_exception;
 };
 
-/**
- * @brief Reschedule request from a transient CUDA kernel-launch failure.
- *
- * cudaErrorLaunchOutOfResources and cudaErrorInvalidValue can occur when
- * PDL scheduling credits are exhausted by concurrent streams on the same GPU.
- * Rescheduling after a brief back-off lets the competing kernels drain.
- */
+/** @brief Reschedule request from a transient CUDA kernel-launch failure. */
 class cuda_launch_reschedule_exception : public task_reschedule_exception {
  public:
   cuda_launch_reschedule_exception(std::unique_ptr<op::operator_data> intermediate_data,
                                    size_t resume_operator_index,
                                    int cuda_error_code,
                                    std::string message)
-    : task_reschedule_exception(std::move(intermediate_data),
-                                resume_operator_index,
-                                std::move(message)),
+    : task_reschedule_exception(
+        std::move(intermediate_data), resume_operator_index, std::move(message)),
       _cuda_error_code(cuda_error_code)
   {
   }

--- a/src/include/pipeline/oom_reschedule_exception.hpp
+++ b/src/include/pipeline/oom_reschedule_exception.hpp
@@ -26,34 +26,28 @@
 namespace sirius::pipeline {
 
 /**
- * @brief Exception thrown when an OOM occurs during pipeline task execution.
+ * @brief Base exception for pipeline task reschedule requests.
  *
- * This exception carries the intermediate operator data and the index of the
- * operator that failed, allowing the executor to reschedule the task to resume
- * from the point of failure.
+ * Carries the operator input data at the point of failure and the operator
+ * index to resume from, allowing the executor to requeue the task without
+ * falling back to CPU.  Derived types distinguish the failure reason.
  */
-class oom_reschedule_exception : public std::exception {
+class task_reschedule_exception : public std::exception {
  public:
-  oom_reschedule_exception(std::unique_ptr<op::operator_data> intermediate_data,
-                           size_t resume_operator_index,
-                           std::string message)
+  task_reschedule_exception(std::unique_ptr<op::operator_data> intermediate_data,
+                            size_t resume_operator_index,
+                            std::string message)
     : _intermediate_data(std::move(intermediate_data)),
       _resume_operator_index(resume_operator_index),
       _message(std::move(message))
   {
   }
 
-  /**
-   * @brief Release ownership of the intermediate data.
-   */
   std::unique_ptr<op::operator_data> release_intermediate_data()
   {
     return std::move(_intermediate_data);
   }
 
-  /**
-   * @brief Get the operator index to resume from.
-   */
   [[nodiscard]] size_t get_resume_operator_index() const noexcept { return _resume_operator_index; }
 
   [[nodiscard]] const char* what() const noexcept override { return _message.c_str(); }
@@ -62,6 +56,40 @@ class oom_reschedule_exception : public std::exception {
   std::unique_ptr<op::operator_data> _intermediate_data;
   size_t _resume_operator_index;
   std::string _message;
+};
+
+/**
+ * @brief Reschedule request from an out-of-memory failure.
+ */
+class oom_reschedule_exception : public task_reschedule_exception {
+ public:
+  using task_reschedule_exception::task_reschedule_exception;
+};
+
+/**
+ * @brief Reschedule request from a transient CUDA kernel-launch failure.
+ *
+ * cudaErrorLaunchOutOfResources and cudaErrorInvalidValue can occur when
+ * PDL scheduling credits are exhausted by concurrent streams on the same GPU.
+ * Rescheduling after a brief back-off lets the competing kernels drain.
+ */
+class cuda_launch_reschedule_exception : public task_reschedule_exception {
+ public:
+  cuda_launch_reschedule_exception(std::unique_ptr<op::operator_data> intermediate_data,
+                                   size_t resume_operator_index,
+                                   int cuda_error_code,
+                                   std::string message)
+    : task_reschedule_exception(std::move(intermediate_data),
+                                resume_operator_index,
+                                std::move(message)),
+      _cuda_error_code(cuda_error_code)
+  {
+  }
+
+  [[nodiscard]] int get_cuda_error_code() const noexcept { return _cuda_error_code; }
+
+ private:
+  int _cuda_error_code;
 };
 
 }  // namespace sirius::pipeline

--- a/src/op/partition/gpu_partition_impl.cpp
+++ b/src/op/partition/gpu_partition_impl.cpp
@@ -17,9 +17,12 @@
 #include "op/partition/gpu_partition_impl.hpp"
 
 #include "data/data_batch_utils.hpp"
+#include "log/logging.hpp"
 
 #include <cudf/partitioning.hpp>
 #include <cudf/unary.hpp>
+
+#include <cuda_runtime.h>
 
 namespace sirius {
 namespace op {
@@ -63,6 +66,12 @@ std::vector<std::shared_ptr<cucascade::data_batch>> gpu_partition_impl::hash_par
   }
   cudf::table_view effective_table(all_col_views);
   const int orig_num_cols = input_table.num_columns();
+
+  // Clear any stale per-thread sticky CUDA error before entering cuDF.  A residual error
+  // from a prior call would be caught by CUB's cudaPeekAtLastError() inside the
+  // thrust::exclusive_scan that cudf::hash_partition() calls internally, producing a
+  // misleading error attribution.
+  (void)cudaGetLastError();
 
   auto partition_result = cudf::hash_partition(effective_table,
                                                effective_key_idx,

--- a/src/op/partition/gpu_partition_impl.cpp
+++ b/src/op/partition/gpu_partition_impl.cpp
@@ -17,7 +17,6 @@
 #include "op/partition/gpu_partition_impl.hpp"
 
 #include "data/data_batch_utils.hpp"
-#include "log/logging.hpp"
 
 #include <cudf/partitioning.hpp>
 #include <cudf/unary.hpp>
@@ -67,10 +66,8 @@ std::vector<std::shared_ptr<cucascade::data_batch>> gpu_partition_impl::hash_par
   cudf::table_view effective_table(all_col_views);
   const int orig_num_cols = input_table.num_columns();
 
-  // Clear any stale per-thread sticky CUDA error before entering cuDF.  A residual error
-  // from a prior call would be caught by CUB's cudaPeekAtLastError() inside the
-  // thrust::exclusive_scan that cudf::hash_partition() calls internally, producing a
-  // misleading error attribution.
+  // cudf::hash_partition's CUB dispatch calls cudaPeekAtLastError(); a stale sticky
+  // error from an earlier call would be misattributed to the scan inside hash_partition.
   (void)cudaGetLastError();
 
   auto partition_result = cudf::hash_partition(effective_table,

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -308,7 +308,7 @@ void gpu_pipeline_executor::manager_loop()
         try {
           task->execute(exc_stream);
           _tasks_executed.fetch_add(1, std::memory_order_relaxed);
-        } catch (oom_reschedule_exception& oom) {
+        } catch (task_reschedule_exception& ex) {
           if (_completion_handler && _completion_handler->has_error()) {
             // If the completion handler is already in an error state, then we can just return and
             // not try to reschedule
@@ -316,10 +316,10 @@ void gpu_pipeline_executor::manager_loop()
           }
           auto* gpu_task = cast_to_gpu_pipeline_task(task.get());
           if (!gpu_task) {
-            SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to cast task for OOM reschedule");
+            SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to cast task for reschedule");
             if (_completion_handler) {
               _completion_handler->report_error(
-                "GPU Pipeline Executor: Failed to cast task for OOM reschedule");
+                "GPU Pipeline Executor: Failed to cast task for reschedule");
             }
             return;
           }
@@ -345,34 +345,36 @@ void gpu_pipeline_executor::manager_loop()
           // too short. With 100 retries × 50 ms backoff (~5 s) the probe
           // tasks get enough patience to clear the contention window while
           // still bailing out on truly wedged queries.
-          static constexpr uint32_t MAX_OOM_RETRIES = 100;
-          if (next_retry_count > MAX_OOM_RETRIES) {
+          static constexpr uint32_t MAX_RETRIES = 100;
+          if (next_retry_count > MAX_RETRIES) {
             SIRIUS_LOG_ERROR(
-              "GPU Pipeline Executor: task {} (original task {}) exceeded {} OOM retries at "
-              "operator index {} — terminating query",
+              "GPU Pipeline Executor: task {} (original task {}) exceeded {} retries at "
+              "operator index {} — terminating query: {}",
               gpu_task->get_task_id(),
               orig_task_id,
-              MAX_OOM_RETRIES,
-              oom.get_resume_operator_index());
+              MAX_RETRIES,
+              ex.get_resume_operator_index(),
+              ex.what());
             if (_completion_handler) {
               _completion_handler->report_error(std::make_exception_ptr(
-                std::runtime_error("GPU pipeline task exceeded maximum OOM retry limit (" +
-                                   std::to_string(MAX_OOM_RETRIES) + ") for original task " +
-                                   std::to_string(orig_task_id))));
+                std::runtime_error("GPU pipeline task exceeded maximum retry limit (" +
+                                   std::to_string(MAX_RETRIES) + ") for original task " +
+                                   std::to_string(orig_task_id) + ": " + ex.what())));
             }
             return;
           }
 
           SIRIUS_LOG_WARN(
-            "GPU Pipeline Executor: OOM reschedule (retry {}/{}) for task {} (original task {}), "
-            "resuming from operator index {}",
+            "GPU Pipeline Executor: reschedule (retry {}/{}) for task {} (original task {}), "
+            "resuming from operator index {}: {}",
             next_retry_count,
-            MAX_OOM_RETRIES,
+            MAX_RETRIES,
             gpu_task->get_task_id(),
             orig_task_id,
-            oom.get_resume_operator_index());
+            ex.get_resume_operator_index(),
+            ex.what());
 
-          auto intermediate_data = oom.release_intermediate_data();
+          auto intermediate_data = ex.release_intermediate_data();
           if (auto pipelineable_data =
                 dynamic_cast<op::pipelineable_operator_data*>(intermediate_data.get())) {
             // We want to release the read-only lock on the data so that when its added back to the
@@ -382,7 +384,7 @@ void gpu_pipeline_executor::manager_loop()
 
           // Build the rescheduled task via virtual factory (preserves derived type).
           auto new_local_state = std::make_unique<gpu_pipeline_task_local_state>(
-            std::move(intermediate_data), oom.get_resume_operator_index());
+            std::move(intermediate_data), ex.get_resume_operator_index());
           new_local_state->retry_count      = next_retry_count;
           new_local_state->original_task_id = orig_task_id;
 

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -356,10 +356,9 @@ void gpu_pipeline_executor::manager_loop()
               ex.get_resume_operator_index(),
               ex.what());
             if (_completion_handler) {
-              _completion_handler->report_error(std::make_exception_ptr(
-                std::runtime_error("GPU pipeline task exceeded maximum retry limit (" +
-                                   std::to_string(MAX_RETRIES) + ") for original task " +
-                                   std::to_string(orig_task_id) + ": " + ex.what())));
+              _completion_handler->report_error(std::make_exception_ptr(std::runtime_error(
+                "GPU pipeline task exceeded maximum retry limit (" + std::to_string(MAX_RETRIES) +
+                ") for original task " + std::to_string(orig_task_id) + ": " + ex.what())));
             }
             return;
           }

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -168,19 +168,14 @@ std::unique_ptr<op::operator_data> run_one_operator(
   try {
     operator_output_data = op.execute(operator_input_data, stream);
   } catch (const std::exception& ex) {
-    // Always log which operator threw so we can identify the failing source.
-    // NOTE: Thrust's throw_on_error() calls cudaGetLastError() before throwing to clear
-    // the sticky per-thread error (prevents leaking).  So cudaGetLastError() here will
-    // almost always return cudaSuccess; we log it only when non-zero (rare path).
     auto sticky_err = cudaGetLastError();
     if (sticky_err != cudaSuccess) {
-      SIRIUS_LOG_WARN(
-        "Pipeline {}: {} (id={}) threw + left sticky CUDA error: [{}] {} — clearing",
-        pipeline->get_pipeline_id(),
-        op.get_name(),
-        op.get_operator_id(),
-        static_cast<int>(sticky_err),
-        cudaGetErrorString(sticky_err));
+      SIRIUS_LOG_WARN("Pipeline {}: {} (id={}) threw + left sticky CUDA error: [{}] {} — clearing",
+                      pipeline->get_pipeline_id(),
+                      op.get_name(),
+                      op.get_operator_id(),
+                      static_cast<int>(sticky_err),
+                      cudaGetErrorString(sticky_err));
     }
     SIRIUS_LOG_WARN("Pipeline {}: {} (id={}) threw during execute: {}",
                     pipeline->get_pipeline_id(),
@@ -190,9 +185,6 @@ std::unique_ptr<op::operator_data> run_one_operator(
     throw;
   }
 
-  // Detect and clear any sticky CUDA error silently left after a successful execute()
-  // (e.g. a failed kernel launch that did not throw).  If left it would propagate into
-  // the next operator's CUB dispatch via cudaPeekAtLastError().
   if (auto sticky_err = cudaGetLastError(); sticky_err != cudaSuccess) {
     SIRIUS_LOG_WARN(
       "Pipeline {}: {} (id={}) left a sticky CUDA error after execute: [{}] {} — clearing",
@@ -399,11 +391,6 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
         i,
         "OOM at operator " + op.get_name() + " (index " + std::to_string(i) + ")");
     } catch (const thrust::system_error& cuda_err) {
-      // Transient CUDA kernel-launch failures (cudaErrorLaunchOutOfResources when PDL
-      // scheduling credits are exhausted by concurrent streams, or cudaErrorInvalidValue
-      // when PDL attributes are rejected) are retryable: reschedule the task at this
-      // operator so it re-runs after the executor's back-off.  All other CUDA errors
-      // (kernel execution faults, invalid pointers, etc.) are not retried.
       auto err = static_cast<cudaError_t>(cuda_err.code().value());
       if (err == cudaErrorLaunchOutOfResources || err == cudaErrorInvalidValue) {
         SIRIUS_LOG_WARN(

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -24,6 +24,7 @@
 #include "telemetry/telemetry_context.hpp"
 
 #include <nvtx3/nvtx3.hpp>
+#include <thrust/system/system_error.h>
 
 #include <absl/cleanup/cleanup.h>
 #include <cucascade/data/data_repository.hpp>
@@ -162,8 +163,46 @@ std::unique_ptr<op::operator_data> run_one_operator(
   auto nvtx_label = std::format(
     "Pipeline {}: {} (id={})", pipeline->get_pipeline_id(), op.get_name(), op.get_operator_id());
   nvtx3::scoped_range nvtx_range{nvtx_label.c_str()};
-  auto start                = std::chrono::high_resolution_clock::now();
-  auto operator_output_data = op.execute(operator_input_data, stream);
+  auto start = std::chrono::high_resolution_clock::now();
+  std::unique_ptr<op::operator_data> operator_output_data;
+  try {
+    operator_output_data = op.execute(operator_input_data, stream);
+  } catch (const std::exception& ex) {
+    // Always log which operator threw so we can identify the failing source.
+    // NOTE: Thrust's throw_on_error() calls cudaGetLastError() before throwing to clear
+    // the sticky per-thread error (prevents leaking).  So cudaGetLastError() here will
+    // almost always return cudaSuccess; we log it only when non-zero (rare path).
+    auto sticky_err = cudaGetLastError();
+    if (sticky_err != cudaSuccess) {
+      SIRIUS_LOG_WARN(
+        "Pipeline {}: {} (id={}) threw + left sticky CUDA error: [{}] {} — clearing",
+        pipeline->get_pipeline_id(),
+        op.get_name(),
+        op.get_operator_id(),
+        static_cast<int>(sticky_err),
+        cudaGetErrorString(sticky_err));
+    }
+    SIRIUS_LOG_WARN("Pipeline {}: {} (id={}) threw during execute: {}",
+                    pipeline->get_pipeline_id(),
+                    op.get_name(),
+                    op.get_operator_id(),
+                    ex.what());
+    throw;
+  }
+
+  // Detect and clear any sticky CUDA error silently left after a successful execute()
+  // (e.g. a failed kernel launch that did not throw).  If left it would propagate into
+  // the next operator's CUB dispatch via cudaPeekAtLastError().
+  if (auto sticky_err = cudaGetLastError(); sticky_err != cudaSuccess) {
+    SIRIUS_LOG_WARN(
+      "Pipeline {}: {} (id={}) left a sticky CUDA error after execute: [{}] {} — clearing",
+      pipeline->get_pipeline_id(),
+      op.get_name(),
+      op.get_operator_id(),
+      static_cast<int>(sticky_err),
+      cudaGetErrorString(sticky_err));
+  }
+
   stream.synchronize();
   auto end      = std::chrono::high_resolution_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
@@ -359,6 +398,36 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
         std::move(operator_input_output_data),
         i,
         "OOM at operator " + op.get_name() + " (index " + std::to_string(i) + ")");
+    } catch (const thrust::system_error& cuda_err) {
+      // Transient CUDA kernel-launch failures (cudaErrorLaunchOutOfResources when PDL
+      // scheduling credits are exhausted by concurrent streams, or cudaErrorInvalidValue
+      // when PDL attributes are rejected) are retryable: reschedule the task at this
+      // operator so it re-runs after the executor's back-off.  All other CUDA errors
+      // (kernel execution faults, invalid pointers, etc.) are not retried.
+      auto err = static_cast<cudaError_t>(cuda_err.code().value());
+      if (err == cudaErrorLaunchOutOfResources || err == cudaErrorInvalidValue) {
+        SIRIUS_LOG_WARN(
+          "Pipeline {}: CUDA launch error [{}] {} at operator {} (id={}, index {}/{}), "
+          "rescheduling task {}",
+          pipeline->get_pipeline_id(),
+          static_cast<int>(err),
+          cudaGetErrorString(err),
+          op.get_name(),
+          op.get_operator_id(),
+          i,
+          operators.size(),
+          _task_id);
+        throw cuda_launch_reschedule_exception(
+          std::move(operator_input_output_data),
+          i,
+          static_cast<int>(err),
+          std::format("CUDA launch error [{}] {} at operator {} (index {})",
+                      static_cast<int>(err),
+                      cudaGetErrorString(err),
+                      op.get_name(),
+                      i));
+      }
+      throw;
     }
   }
 


### PR DESCRIPTION
## Problem

`cudf::hash_partition()` launches a murmur3 hash kernel via the CUDA Runtime API. When the pipeline executor runs 4 concurrent streams per GPU (`num_threads: 4`), all 4 streams can reach `cudf::hash_partition()` at the same time. The simultaneous PDL (Programmatic Dependent Launch) kernel launches exhaust the GPU's PDL scheduling credit pool, causing some launches to fail synchronously with `cudaErrorLaunchOutOfResources` or `cudaErrorInvalidValue`.

The failed launch sets the per-thread CUDA sticky last error. The immediately-following `thrust::exclusive_scan` (inside `cudf::hash_partition`) calls CUB's `cudaPeekAtLastError()`, which catches the error and throws — triggering the GPU→CPU fallback (~7 s vs ~1.1 s on SF1000 4-GPU). This caused q13 and q18 to hit ~50% slow iterations on the GB200×4 bench machine.

**Diagnosis trail:**
- Added `cudaGetLastError()` in `run_one_operator()`'s catch block → discovered `thrust::throw_on_error()` clears the sticky error before throwing (intentional Thrust design), so the catch always sees success
- Added operator-name logging to the catch → confirmed every failure is `PARTITION (id=32/52)`, never JOIN or GROUPBY
- The error is set inside `cudf::hash_partition()` (pre-check before the call is always clean)
- Three tasks fail simultaneously at the same millisecond with *different* error codes (`cudaErrorInvalidValue` vs `cudaErrorLaunchOutOfResources`) → PDL credit pool contention across 4 concurrent streams

## Fix

Catch `thrust::system_error` for those two retryable error codes in `compute_task()`'s operator loop and convert to a new `cuda_launch_reschedule_exception`, handled by the existing executor back-off + reschedule path (50 ms, up to 100 retries). All failures recovered at retry 1/100 in testing.

**Exception hierarchy** (`oom_reschedule_exception.hpp`):
```
task_reschedule_exception          ← new base (intermediate_data, resume_index, message)
├── oom_reschedule_exception       ← unchanged API, inherits ctor via using
└── cuda_launch_reschedule_exception  ← new, adds cuda_error_code (int)
```

`gpu_pipeline_executor` now catches `task_reschedule_exception&` for both cases; log messages use `ex.what()` to distinguish OOM vs CUDA launch errors.

Also adds `(void)cudaGetLastError()` before `cudf::hash_partition()` to defensively clear any stale per-thread sticky error that could be misattributed to the scan inside `hash_partition`.

## Test plan

- [ ] Ran 8-iteration SF1000 4-GPU investigation for q13 and q18 before fix: ~50% iterations at ~7 s (GPU→CPU fallback)
- [ ] Ran same investigation after fix: all 16 iterations at 1.1–1.4 s, zero fallbacks
- [ ] Log shows `reschedule (retry 1/100) ... : CUDA launch error [701] ... at operator PARTITION` — correct exception type and message
- [ ] All `[pipeline]` unit tests pass; `oom_reschedule_exception` API is unchanged (existing callers unaffected)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)