### PR TITLE
[DO NOT MERGE]: feat(scan): add parquet pin tier (pinned raw column-chunk bytes)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,7 @@ set(EXTENSION_SOURCES
     # Execution primitives (slot-based backpressure / completion tracking)
     src/exec/admission_control.cpp
     # I/O adapters (Phase 19 — io_uring + sirius_datasource)
+    src/io/cached_range_datasource.cpp
     src/io/datasource_factory.cpp
     src/io/io_context.cpp
     src/io/parquet_helpers.cpp

--- a/src/include/io/cached_range_datasource.hpp
+++ b/src/include/io/cached_range_datasource.hpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/io/datasource.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <io/sirius_datasource.hpp>
+#include <op/scan/cached_ranges.hpp>
+
+#include <future>
+#include <memory>
+
+namespace sirius::io {
+
+// ---------------------------------------------------------------------------
+// cached_range_datasource
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief A @c cudf::io::datasource that serves reads from pinned host buffers.
+ *
+ * Backs the parquet pin tier: at pin time a table's column-chunk byte ranges are
+ * read once from disk into pinned host memory and packed into a
+ * @c op::scan::cache_ranges. At query time this datasource fronts the decode:
+ * every @c host_read whose @c [offset, size) is fully covered by the cached
+ * ranges is answered by @c memcpy from pinned memory; any read that falls
+ * outside the cache (the parquet footer, page index, or a column that was not
+ * pinned) is delegated to the @p fallback @c sirius_datasource, which reads it
+ * from the file.
+ *
+ * Device reads are disabled (@c supports_device_read returns false) so cuDF
+ * always takes the host path — the cached read is a pinned-memory copy and cuDF
+ * performs the host-to-device transfer itself.
+ */
+class cached_range_datasource : public cudf::io::datasource {
+ public:
+  cached_range_datasource(std::shared_ptr<op::scan::cache_ranges> ranges,
+                          std::shared_ptr<sirius_datasource> fallback);
+
+  ~cached_range_datasource() override = default;
+
+  cached_range_datasource(cached_range_datasource const&)            = delete;
+  cached_range_datasource& operator=(cached_range_datasource const&) = delete;
+
+  [[nodiscard]] size_t size() const override;
+
+  // The pinned buffers are CUDA-pinned host memory, so device reads are served
+  // by an H2D copy — matching sirius_datasource, whose device-read preference the
+  // cuDF GPU parquet decoder relies on (the host-only path crashes it).
+  [[nodiscard]] bool supports_device_read() const override { return true; }
+
+  [[nodiscard]] bool is_device_read_preferred(size_t) const override { return true; }
+
+  size_t host_read(size_t offset, size_t size, uint8_t* dst) override;
+
+  std::unique_ptr<datasource::buffer> host_read(size_t offset, size_t size) override;
+
+  std::unique_ptr<datasource::buffer> device_read(size_t offset,
+                                                  size_t size,
+                                                  rmm::cuda_stream_view stream) override;
+
+  size_t device_read(size_t offset,
+                     size_t size,
+                     uint8_t* dst,
+                     rmm::cuda_stream_view stream) override;
+
+  std::future<size_t> device_read_async(size_t offset,
+                                        size_t size,
+                                        uint8_t* dst,
+                                        rmm::cuda_stream_view stream) override;
+
+ private:
+  std::shared_ptr<op::scan::cache_ranges> _ranges;
+  std::shared_ptr<sirius_datasource> _fallback;
+};
+
+}  // namespace sirius::io

--- a/src/include/op/scan/parquet_gpu_ingestible.hpp
+++ b/src/include/op/scan/parquet_gpu_ingestible.hpp
@@ -31,6 +31,9 @@
 #include <duckdb/planner/expression.hpp>
 #include <duckdb/planner/table_filter.hpp>
 
+// cucascade
+#include <cucascade/memory/fixed_size_host_memory_resource.hpp>
+
 // cudf
 #include <cudf/io/parquet.hpp>
 
@@ -42,6 +45,7 @@
 #include <memory>
 #include <span>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace sirius::scan_manager {
@@ -199,6 +203,10 @@ class parquet_file_scan_info : public scan_info {
   /// Pre-built datasource for this file, reused by @c materialize_table. May be
   /// null for local paths no sirius backend claims.
   std::shared_ptr<io::sirius_datasource> datasource;
+  /// Pinned column-chunk byte ranges for this file when the scan is served from
+  /// a parquet-tier pin (null otherwise). Attached by @c build_file_scan_info
+  /// from the ingestible's pinned cache and propagated onto each row_group_slice.
+  std::shared_ptr<cache_ranges> cached_ranges;
   /// Pruned row groups for this file, in file order, with byte accounting.
   std::vector<row_group_entry> row_groups;
   /// Shared reader options (column projection), used to compute the column-chunk
@@ -236,6 +244,22 @@ class parquet_file_scan_info : public scan_info {
   /// @c hybrid_scan_reader::all_column_chunks_byte_ranges, honoring the
   /// reader_options column projection).
   [[nodiscard]] std::vector<fadvise_entry> fadvise_entries() const override;
+};
+
+//===----------------------------------------------------------------------===//
+// parquet_pinned_ranges
+//===----------------------------------------------------------------------===//
+/**
+ * @brief Pin-time result of @ref parquet_gpu_ingestible::pin_parquet_ranges.
+ *
+ * @c ranges_by_file maps each resolved file path to the pinned column-chunk
+ * byte ranges the serve path attaches to that file's slices. @c allocations
+ * owns the pinned host blocks the ranges' buffers point into — it must outlive
+ * @c ranges_by_file (@c cache_ranges holds non-owning pointers).
+ */
+struct parquet_pinned_ranges {
+  std::unordered_map<std::string, std::shared_ptr<cache_ranges>> ranges_by_file;
+  std::vector<cucascade::memory::fixed_multiple_blocks_allocation> allocations;
 };
 
 //===----------------------------------------------------------------------===//
@@ -289,6 +313,28 @@ class parquet_gpu_ingestible : public gpu_ingestible {
     return _duckdb_filter_expression != nullptr;
   }
 
+  /// Read the pinned columns' column-chunk byte ranges for every resolved file
+  /// into pinned host memory (1MB blocks from @p host_mr) and pack them into a
+  /// per-file @c cache_ranges. Drives the parquet pin tier. The reader options
+  /// carry the pinned column projection (set in the constructor), so only the
+  /// pinned columns' chunks are read. @p device_id / @p numa_id are stored on
+  /// each @c cache_ranges as copy-placement hints.
+  parquet_pinned_ranges pin_parquet_ranges(
+    io::sirius_ioctx& io_ctx,
+    cucascade::memory::fixed_size_host_memory_resource& host_mr,
+    int device_id,
+    int numa_id);
+
+  /// Point the serve-time read at a parquet pin's cached byte ranges (keyed by
+  /// file path). @c build_file_scan_info attaches the matching entry to each
+  /// file's slices; an absent entry reads from disk as usual. Non-owning — the
+  /// map (owned by the pinned_entry) must outlive this ingestible's scan.
+  void set_pinned_parquet_cache(
+    const std::unordered_map<std::string, std::shared_ptr<cache_ranges>>* cache)
+  {
+    _pinned_cache = cache;
+  }
+
  private:
   /// Read one file's footer, prune its row groups against the filter, and record
   /// per-row-group byte accounting. Returns a single @c parquet_file_scan_info.
@@ -319,6 +365,11 @@ class parquet_gpu_ingestible : public gpu_ingestible {
   // AST-capable filters are ANDed into the parquet reader filter; membership filtering happens in
   // the downstream dynamic-filter operator.
   std::shared_ptr<sirius::op::sirius_dynamic_filter_set> _sirius_dynamic_filters;
+
+  // Parquet-tier pin cache (file path -> pinned column-chunk byte ranges), or
+  // null for an ordinary disk scan. Set by the scan manager in prepare_for_query
+  // when a parquet pin can serve this scan; consulted by build_file_scan_info.
+  const std::unordered_map<std::string, std::shared_ptr<cache_ranges>>* _pinned_cache{nullptr};
 };
 
 std::shared_ptr<parquet_gpu_ingestible> make_ingestible(

--- a/src/include/op/scan/row_group_metadata.hpp
+++ b/src/include/op/scan/row_group_metadata.hpp
@@ -18,6 +18,7 @@
 
 // sirius
 #include <io/sirius_datasource.hpp>
+#include <op/scan/cached_ranges.hpp>
 // cudf
 
 #include <cudf/io/experimental/hybrid_scan.hpp>
@@ -71,6 +72,12 @@ struct row_group_slice {
   /// and reused by materialize_table. When null, materialize_table falls
   /// back to cudf::io::datasource::create(file_path).
   std::shared_ptr<io::sirius_datasource> datasource;
+  /// Pinned column-chunk byte ranges for this file, when the scan is served
+  /// from a parquet-tier pin. When set, materialize_table reads through a
+  /// cached_range_datasource (pinned memory, @c datasource as disk fallback);
+  /// null for an ordinary disk scan. Set after construction by the coalescer
+  /// from @c parquet_file_scan_info::cached_ranges.
+  std::shared_ptr<cache_ranges> cached_ranges;
 };
 
 //===----------------------------------------------------------------------===//

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -22,6 +22,7 @@
 #include "io/datasource_factory.hpp"
 #include "io/s3/s3_list_parser.hpp"
 #include "io/sirius_datasource.hpp"
+#include "op/scan/cached_ranges.hpp"
 #include "op/scan/gpu_ingestible_types.hpp"
 #include "scan_manager/config.hpp"
 #include "scan_manager/duckdb_mvcc_metadata.hpp"
@@ -36,6 +37,7 @@
 #include <cudf/table/table.hpp>
 
 #include <cucascade/cudf/host_data_representation.hpp>
+#include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <duckdb/common/column_index.hpp>
 #include <duckdb/common/types.hpp>
@@ -166,6 +168,16 @@ struct pinned_entry {
   /// pinned columns. The cached_split_provider slices these by column index when
   /// serving a particular scan. Populated by @ref insert_pinned_entry_host.
   std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks;
+  /// PARQUET-tier storage: file path -> pinned column-chunk byte ranges. Non-empty
+  /// ONLY for parquet-tier pins, which are served differently from GPU/HOST: the
+  /// scan runs the ordinary parquet decode path with reads answered from these
+  /// pinned buffers (see @ref parquet_gpu_ingestible::set_pinned_parquet_cache),
+  /// not as resident data_batches. Its non-emptiness is the parquet-tier
+  /// discriminator — such entries are skipped by @ref try_match_cached_entry.
+  std::unordered_map<std::string, std::shared_ptr<op::scan::cache_ranges>> parquet_ranges_by_file;
+  /// Owns the pinned host blocks the ranges in @c parquet_ranges_by_file point
+  /// into (@c cache_ranges holds non-owning pointers). Held for the entry's life.
+  std::vector<cucascade::memory::fixed_multiple_blocks_allocation> parquet_allocations;
   /// Tier the pinned data resides in. Drives which storage member above is used
   /// and which cached_split_provider variant @ref create_provider_for builds.
   cucascade::memory::Tier tier{cucascade::memory::Tier::GPU};
@@ -390,6 +402,28 @@ class sirius_scan_manager {
     cucascade::memory::memory_space& memory_space,
     duckdb::vector<duckdb::LogicalType> column_types                                 = {},
     std::vector<std::vector<duckdb::unique_ptr<duckdb::BaseStatistics>>> chunk_stats = {});
+
+  /// \brief Pin the parquet-tier entry for a table.
+  ///
+  /// Unlike the GPU/HOST tiers (which store decoded columns and serve them
+  /// resident), this stores raw parquet column-chunk bytes in pinned host
+  /// memory as per-file @c cache_ranges. A matching scan runs the ordinary
+  /// parquet decode path with each @c row_group_slice's reads answered from the
+  /// pinned buffers (@ref parquet_gpu_ingestible::set_pinned_parquet_cache),
+  /// falling back to the file for any uncached read. Always REPLACES any
+  /// existing entry for @p name.
+  ///
+  /// \param name           Table name key.
+  /// \param cache_info     Cache identity (parquet file set) + cached columns;
+  ///                       drives cache-hit matching.
+  /// \param ranges_by_file File path -> pinned column-chunk byte ranges.
+  /// \param allocations    Owns the pinned host blocks the ranges point into;
+  ///                       moved into the entry so the buffers stay alive.
+  void insert_pinned_entry_parquet(
+    const std::string& name,
+    cache_entry_info cache_info,
+    std::unordered_map<std::string, std::shared_ptr<op::scan::cache_ranges>> ranges_by_file,
+    std::vector<cucascade::memory::fixed_multiple_blocks_allocation> allocations);
 
   /// \brief Attach MVCC snapshot metadata to the pinned entry for @p name.
   ///

--- a/src/io/cached_range_datasource.cpp
+++ b/src/io/cached_range_datasource.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <rmm/device_buffer.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <io/cached_range_datasource.hpp>
+#include <log/logging.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace sirius::io {
+
+cached_range_datasource::cached_range_datasource(std::shared_ptr<op::scan::cache_ranges> ranges,
+                                                 std::shared_ptr<sirius_datasource> fallback)
+  : _ranges(std::move(ranges)), _fallback(std::move(fallback))
+{
+}
+
+size_t cached_range_datasource::size() const { return _fallback->size(); }
+
+size_t cached_range_datasource::host_read(size_t offset, size_t size, uint8_t* dst)
+{
+  // Serve from pinned memory when the whole read is cached; otherwise the range
+  // was never pinned (footer, page index, or an unpinned column) — read it from
+  // the file through the fallback datasource.
+  if (auto spans = _ranges->get_ranges(offset, size)) {
+    size_t written = 0;
+    for (auto const& span : *spans) {
+      std::memcpy(dst + written, span.data(), span.size());
+      written += span.size();
+    }
+    return written;
+  }
+  SIRIUS_LOG_WARN(
+    "[cached_range_datasource] host_read FALLBACK to disk off={} size={}", offset, size);
+  return _fallback->host_read(offset, size, dst);
+}
+
+std::unique_ptr<cudf::io::datasource::buffer> cached_range_datasource::host_read(size_t offset,
+                                                                                 size_t size)
+{
+  std::vector<uint8_t> buf(size);
+  auto const n = host_read(offset, size, buf.data());
+  buf.resize(n);
+  return cudf::io::datasource::buffer::create(std::move(buf));
+}
+
+size_t cached_range_datasource::device_read(size_t offset,
+                                            size_t size,
+                                            uint8_t* dst,
+                                            rmm::cuda_stream_view stream)
+{
+  auto spans = _ranges->get_ranges(offset, size);
+  if (!spans) {
+    SIRIUS_LOG_WARN(
+      "[cached_range_datasource] device_read FALLBACK to disk off={} size={}", offset, size);
+    return _fallback->device_read(offset, size, dst, stream);
+  }
+  // The cached spans live in CUDA-pinned host memory, so the H2D copies are
+  // truly async on the stream. Synchronize before returning: the sync device_read
+  // contract is that the bytes are resident in dst on return.
+  size_t written = 0;
+  for (auto const& span : *spans) {
+    cudaMemcpyAsync(
+      dst + written, span.data(), span.size(), cudaMemcpyHostToDevice, stream.value());
+    written += span.size();
+  }
+  stream.synchronize();
+  return written;
+}
+
+std::unique_ptr<cudf::io::datasource::buffer> cached_range_datasource::device_read(
+  size_t offset, size_t size, rmm::cuda_stream_view stream)
+{
+  rmm::device_buffer buf(size, stream);
+  auto n = device_read(offset, size, reinterpret_cast<uint8_t*>(buf.data()), stream);
+  n      = std::min(n, size);
+  buf.resize(n, stream);
+  return cudf::io::datasource::buffer::create(std::move(buf));
+}
+
+std::future<size_t> cached_range_datasource::device_read_async(size_t offset,
+                                                               size_t size,
+                                                               uint8_t* dst,
+                                                               rmm::cuda_stream_view stream)
+{
+  auto spans = _ranges->get_ranges(offset, size);
+  if (!spans) {
+    SIRIUS_LOG_WARN(
+      "[cached_range_datasource] device_read_async FALLBACK to disk off={} size={}", offset, size);
+    return _fallback->device_read_async(offset, size, dst, stream);
+  }
+  // Enqueue the H2D copies on the stream and return the count immediately; the
+  // copies are stream-ordered against the decode that consumes them, so no host
+  // sync is needed here (matching a device-read datasource's async contract).
+  size_t written = 0;
+  for (auto const& span : *spans) {
+    cudaMemcpyAsync(
+      dst + written, span.data(), span.size(), cudaMemcpyHostToDevice, stream.value());
+    written += span.size();
+  }
+  std::promise<size_t> p;
+  p.set_value(written);
+  return p.get_future();
+}
+
+}  // namespace sirius::io

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -21,6 +21,7 @@
 #include <expression/ast/from_duckdb.hpp>
 #include <expression_evaluator/expression_evaluator.hpp>
 #include <expression_evaluator/gpu_expression_translator_internal.hpp>
+#include <io/cached_range_datasource.hpp>
 #include <io/io_context.hpp>
 #include <io/sirius_datasource.hpp>
 #include <log/logging.hpp>
@@ -144,7 +145,9 @@ class parquet_batch_coalescer : public batch_coalescer {
                            cur_working,
                            cur_comp,
                            std::move(slice_ds));
-      _produced_any = true;
+      // Parquet-tier pin: the whole file's cache_ranges serves every slice of it.
+      _slices.back().cached_ranges = file->cached_ranges;
+      _produced_any                = true;
       _acc_working_bytes += cur_working;
       _acc_rows += cur_rows;
       cur_rgs.clear();
@@ -285,6 +288,9 @@ std::vector<scan_info::fadvise_entry> parquet_split_info::fadvise_entries() cons
   entries.reserve(rg_slices.size());
   for (auto const& slice : rg_slices) {
     if (!slice.file_metadata) { continue; }
+    // Parquet-tier pin: the read is served from pinned memory, so there is no
+    // disk prefetch to hint.
+    if (slice.cached_ranges) { continue; }
     append_fadvise_entry(entries, slice.datasource, [&slice, this] {
       return column_chunk_ranges(*slice.file_metadata, *reader_options, slice.row_group_indices);
     });
@@ -652,6 +658,12 @@ std::unique_ptr<scan_info> parquet_gpu_ingestible::build_file_scan_info(
   out->datasource              = std::move(sirius_ds);
   out->reader_options          = _reader_options;
   out->disable_filter_pushdown = disable_filter_pushdown;
+  // Parquet-tier pin: serve this file's column-chunk reads from the pinned byte
+  // ranges (materialize_table wraps out->datasource as the disk fallback).
+  if (_pinned_cache) {
+    auto it = _pinned_cache->find(file_path);
+    if (it != _pinned_cache->end()) { out->cached_ranges = it->second; }
+  }
   out->row_groups.reserve(row_group_indices.size());
   for (auto const rg_idx : row_group_indices) {
     auto const estimate = rg_contribution(metadata.row_groups[rg_idx]);
@@ -676,6 +688,92 @@ std::unique_ptr<scan_info> parquet_gpu_ingestible::build_file_scan_info(
 }
 
 //===----------------------------------------------------------------------===//
+// pin_parquet_ranges — pin-time read of column-chunk bytes into pinned memory
+//===----------------------------------------------------------------------===//
+parquet_pinned_ranges parquet_gpu_ingestible::pin_parquet_ranges(
+  io::sirius_ioctx& io_ctx,
+  cucascade::memory::fixed_size_host_memory_resource& host_mr,
+  int device_id,
+  int numa_id)
+{
+  parquet_pinned_ranges result;
+  auto const block_size = host_mr.get_block_size();
+
+  for (auto const& file_path : _file_paths) {
+    auto ds = io_ctx.open_datasource(file_path, io::open_hint::parquet_footer_probe);
+    if (!ds) {
+      throw std::runtime_error("[parquet_gpu_ingestible] pin: no backend supports path: " +
+                               file_path);
+    }
+    // _reader_options carries the pinned column projection (set in the ctor), so
+    // the byte ranges below cover only the pinned columns' chunks.
+    auto opts = *_reader_options;
+
+    // Footer metadata — from the datasource's cached parse when present, else fetch + parse.
+    std::shared_ptr<cudf::io::parquet::FileMetaData const> file_metadata;
+    if (auto cached = ds->metadata()) {
+      if (auto pm = std::dynamic_pointer_cast<parquet_metadata>(std::move(cached))) {
+        file_metadata = pm->file_metadata();
+      }
+    }
+    if (!file_metadata) {
+      auto footer           = cudf::io::parquet::fetch_footer_to_host(*ds);
+      auto const footer_len = footer->size();
+      hybrid_scan_reader footer_reader(
+        cudf::host_span<uint8_t const>(footer->data(), footer->size()), opts);
+      file_metadata =
+        std::make_shared<cudf::io::parquet::FileMetaData const>(footer_reader.parquet_metadata());
+      [[maybe_unused]] auto const stored =
+        ds->store_metadata(std::make_shared<parquet_metadata>(file_metadata, footer_len));
+    }
+
+    // Column-chunk byte ranges for the pinned columns across every row group.
+    hybrid_scan_reader reader(*file_metadata, opts);
+    auto row_groups = reader.all_row_groups(opts);
+    auto ranges     = reader.all_column_chunks_byte_ranges(
+      cudf::host_span<cudf::size_type const>(row_groups.data(), row_groups.size()), opts);
+    if (ranges.empty()) { continue; }
+
+    // cache_ranges requires sorted, non-overlapping ranges; column chunks never
+    // overlap, so sorting by offset is enough.
+    std::sort(ranges.begin(), ranges.end(), [](auto const& a, auto const& b) {
+      return a.offset() < b.offset();
+    });
+    std::size_t total_bytes = 0;
+    for (auto const& r : ranges) {
+      total_bytes += static_cast<std::size_t>(r.size());
+    }
+
+    // Allocate pinned 1MB blocks and fill them with the range payloads packed
+    // contiguously — the flat layout cache_ranges::get_ranges expects.
+    auto alloc             = host_mr.allocate_multiple_blocks(total_bytes);
+    auto const blocks      = alloc->get_blocks();
+    std::size_t packed_pos = 0;
+    for (auto const& r : ranges) {
+      auto const off   = static_cast<std::size_t>(r.offset());
+      auto const sz    = static_cast<std::size_t>(r.size());
+      std::size_t done = 0;
+      while (done < sz) {
+        std::size_t const chunk_idx   = packed_pos / block_size;
+        std::size_t const chunk_local = packed_pos % block_size;
+        std::size_t const take        = std::min(sz - done, block_size - chunk_local);
+        ds->host_read(
+          off + done, take, reinterpret_cast<uint8_t*>(blocks[chunk_idx]) + chunk_local);
+        done += take;
+        packed_pos += take;
+      }
+    }
+
+    std::vector<std::byte*> buffers(blocks.begin(), blocks.end());
+    auto cr = std::make_shared<cache_ranges>(
+      std::move(ranges), std::move(buffers), block_size, device_id, numa_id);
+    result.ranges_by_file.emplace(file_path, std::move(cr));
+    result.allocations.push_back(std::move(alloc));
+  }
+  return result;
+}
+
+//===----------------------------------------------------------------------===//
 // materialize_table — ports read_table_from_metadata
 //===----------------------------------------------------------------------===//
 filtered_table parquet_gpu_ingestible::materialize_metadata_to_table(
@@ -692,8 +790,16 @@ filtered_table parquet_gpu_ingestible::materialize_metadata_to_table(
   metadatas.reserve(split.rg_slices.size());
   rg_per_src.reserve(split.rg_slices.size());
 
+  // Parquet-tier pin: reads for a cached slice go through a cached_range_datasource
+  // (pinned host memory, its sirius_datasource as the disk fallback). These wrappers
+  // must outlive the read_parquet call below, so keep them owned here.
+  std::vector<std::unique_ptr<io::cached_range_datasource>> cached_sources;
   for (auto const& slice : split.rg_slices) {
-    if (slice.datasource) {
+    if (slice.cached_ranges && slice.datasource) {
+      cached_sources.push_back(
+        std::make_unique<io::cached_range_datasource>(slice.cached_ranges, slice.datasource));
+      sources.push_back(cudf::io::datasource::create(cached_sources.back().get()));
+    } else if (slice.datasource) {
       sources.push_back(cudf::io::datasource::create(slice.datasource.get()));
     } else {
       sources.push_back(cudf::io::datasource::create(slice.file_path));

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -367,6 +367,24 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
       _scan_op_order.push_back(op);
       continue;
     }
+    // Parquet-tier pin: point this scan's ingestible at the cached byte ranges
+    // when a parquet pin can serve it. The scan still uses the ordinary disk
+    // split_provider below — each row_group_slice's reads are answered from
+    // pinned memory (cached_range_datasource), falling back to the file for any
+    // uncached read.
+    for (auto const& [pinned_name, entry] : _pinned_entries) {
+      if (entry.parquet_ranges_by_file.empty()) { continue; }
+      if (entry.cache_info.can_serve_with_columns(op->get_ingestible().table_info()).empty()) {
+        continue;
+      }
+      if (auto* pq = dynamic_cast<op::scan::parquet_gpu_ingestible*>(&op->get_ingestible())) {
+        pq->set_pinned_parquet_cache(&entry.parquet_ranges_by_file);
+        SIRIUS_LOG_INFO("[sirius_scan_manager] serving operator '{}' from parquet pin '{}'",
+                        op->get_operator_id(),
+                        pinned_name);
+      }
+      break;
+    }
     auto provider = std::make_unique<split_provider>(
       op->get_ingestible(),
       [this](std::string_view file_path) -> std::shared_ptr<io::sirius_ioctx> {
@@ -953,6 +971,22 @@ void sirius_scan_manager::insert_pinned_entry_host(
   _pinned_entries[name] = std::move(entry);
 }
 
+void sirius_scan_manager::insert_pinned_entry_parquet(
+  const std::string& name,
+  cache_entry_info cache_info,
+  std::unordered_map<std::string, std::shared_ptr<op::scan::cache_ranges>> ranges_by_file,
+  std::vector<cucascade::memory::fixed_multiple_blocks_allocation> allocations)
+{
+  // Parquet-tier pins hold raw column-chunk bytes, not decoded chunks, and are
+  // served through the ordinary decode path (see prepare_for_query). Always
+  // replace: re-pinning re-reads the files.
+  pinned_entry entry;
+  entry.cache_info             = std::move(cache_info);
+  entry.parquet_ranges_by_file = std::move(ranges_by_file);
+  entry.parquet_allocations    = std::move(allocations);
+  _pinned_entries[name]        = std::move(entry);
+}
+
 void sirius_scan_manager::attach_mvcc_metadata(const std::string& name,
                                                duckdb_mvcc_metadata metadata)
 {
@@ -1123,6 +1157,10 @@ std::optional<sirius_scan_manager::cached_assignment> sirius_scan_manager::try_m
   const auto& table_info = op->get_ingestible().table_info();
 
   for (auto const& [pinned_name, entry] : _pinned_entries) {
+    // Parquet-tier pins are not served resident: they run the ordinary decode
+    // path with reads answered from pinned byte ranges, wired in
+    // prepare_for_query. Skip them here.
+    if (!entry.parquet_ranges_by_file.empty()) { continue; }
     // Identity + serviceability gate: empty when this cache cannot serve the scan
     // (wrong format / file-set / table, or missing a requested column).
     if (entry.cache_info.can_serve_with_columns(table_info).empty()) { continue; }

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1004,9 +1004,9 @@ unique_ptr<FunctionData> SiriusExtension::PinTableBind(ClientContext& context,
     throw BinderException("pin_table requires a 'tier' named parameter");
   }
   result->args.tier = tier_it->second.ToString();
-  if (result->args.tier != "gpu" && result->args.tier != "host") {
+  if (result->args.tier != "gpu" && result->args.tier != "host" && result->args.tier != "parquet") {
     throw NotImplementedException("pin_table tier='" + result->args.tier +
-                                  "' is not supported (only 'gpu' and 'host')");
+                                  "' is not supported (only 'gpu', 'host', and 'parquet')");
   }
 
   auto name_it = input.named_parameters.find("name");
@@ -1105,7 +1105,7 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
   // memory_space whose NUMA node matches the GPU. Fall back to host_spaces[0]
   // when the GPU's NUMA node is unknown or no matching host space exists.
   std::unordered_map<int, cucascade::memory::memory_space*> host_space_by_gpu;
-  if (data.args.tier == "host") {
+  if (data.args.tier == "host" || data.args.tier == "parquet") {
     auto host_spaces = memory_manager.get_memory_spaces_for_tier(cucascade::memory::Tier::HOST);
     if (host_spaces.empty()) {
       throw InvalidInputException("pin_table: no HOST memory space available");
@@ -1216,6 +1216,32 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
       mvcc.base_row_count_per_chunk = std::move(mat.base_row_count_per_chunk);
       scan_mgr.attach_mvcc_metadata(data.args.name, std::move(mvcc));
     }
+  } else if (data.args.tier == "parquet") {
+    // Parquet tier: read the pinned columns' raw column-chunk bytes once into
+    // pinned host memory (1MB blocks) and cache them as per-file byte ranges. A
+    // later scan runs the ordinary parquet decode path with its reads served
+    // from these pinned buffers instead of the disk.
+    auto* pq = dynamic_cast<sirius::op::scan::parquet_gpu_ingestible*>(ingestible.get());
+    if (pq == nullptr) {
+      // build_parquet_pin_info always yields a parquet ingestible; a null here
+      // means a duckdb source, which has no on-disk column-chunk layout to pin.
+      throw NotImplementedException(
+        "pin_table tier='parquet' is only supported for parquet sources");
+    }
+    int const first_gpu_id = gpu_spaces_mut[0]->get_device_id();
+    auto* host_space       = host_space_by_gpu.at(first_gpu_id);
+    auto* host_mr =
+      host_space->get_memory_resource_as<cucascade::memory::fixed_size_host_memory_resource>();
+    if (host_mr == nullptr) {
+      throw InvalidInputException(
+        "pin_table: host memory space has no fixed-size block allocator for the parquet tier");
+    }
+    auto pinned = pq->pin_parquet_ranges(
+      *scan_mgr.io_ctx(), *host_mr, first_gpu_id, host_space->get_device_id());
+    scan_mgr.insert_pinned_entry_parquet(data.args.name,
+                                         std::move(cache_info),
+                                         std::move(pinned.ranges_by_file),
+                                         std::move(pinned.allocations));
   } else {
     // GPU tier: materialize every batch as a GPU-resident cudf::table (with its GPU
     // placement) and pin them in place.

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -48,7 +48,7 @@ def log(msg):
 
 MODES = ("grouped", "sequential", "isolated", "nsys-profile")
 ENGINE_CHOICES = ("gpu", "cpu", "both")
-PIN_CHOICES = ("none", "gpu", "host")
+PIN_CHOICES = ("none", "gpu", "host", "parquet")
 DATA_SOURCE_CHOICES = ("parquet", "duckdb")
 TPCH_TABLES = (
     "customer",


### PR DESCRIPTION
## What

Adds a third `pin_table` tier — **`tier='parquet'`** — alongside `gpu` and `host`. Instead of caching *decoded* cuDF columns, it pins the **raw, undecoded parquet column-chunk bytes** in CUDA-pinned host memory and serves them into the normal GPU decode path. A query then pays GPU decode + H2D but skips the file read, at a much smaller host-memory footprint than the host tier (compressed vs decoded).

## How

- **`cached_range_datasource`** (new, `src/io/cached_range_datasource.*`) — a `cudf::io::datasource` that serves reads from a `cache_ranges` (pinned host blocks) and falls back to `sirius_datasource` for any uncached bytes (footer / page index / unpinned columns). It implements **device reads** (H2D copy from the pinned buffers); cuDF's GPU parquet decoder relies on device reads, and a host-only datasource crashes it for column chunks larger than the 1 MB block size.
- **`parquet_gpu_ingestible::pin_parquet_ranges`** — reads the pinned columns' column-chunk byte ranges (`hybrid_scan_reader::all_column_chunks_byte_ranges`) into 1 MB pinned blocks (`fixed_size_host_memory_resource`), packed as a per-file `cache_ranges`.
- **Serve path** — `sirius_scan_manager::prepare_for_query` attaches a matching pin's ranges to the scan's ingestible (`set_pinned_parquet_cache`); `build_file_scan_info` puts them on each `row_group_slice`; `materialize_metadata_to_table` wraps each cached slice in a `cached_range_datasource`. Parquet-tier entries are skipped by `try_match_cached_entry` (they run the fresh decode path, not resident batches).
- **`pinned_entry`** gains `parquet_ranges_by_file` + owning `parquet_allocations`; `insert_pinned_entry_parquet` stores them.
- **Test** — `"parquet"` added to `PIN_CHOICES` in `test/tpch_performance/performance_test.py` (carried via the existing `SIRIUS_PIN_TIER` plumbing).

## Validation

TPC-H **sf100, all 22 queries** pass GPU-vs-DuckDB `--validation` (byte-exact / within float tolerance) with the pin serving **every** scan and **zero** device-read fallbacks (verified via the `cached_range_datasource` FALLBACK WARN logs — 0 across host/device/device_async paths).

Usage:
```sql
CALL pin_table('<glob>.parquet', tier='parquet', name='lineitem', cols=['l_returnflag', ...]);
```
or via the benchmark harness: `performance_test.py --pin=parquet ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)