### PR TITLE
refactor(sirius): consolidate NUMA↔GPU maps onto topology_index

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -17,6 +17,7 @@
 #include "creator/task_creator.hpp"
 
 #include "log/logging.hpp"
+#include "memory/topology_index.hpp"
 #include "op/scan/sirius_gpu_scan_operator_data.hpp"
 #include "op/sirius_physical_delim_join.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
@@ -45,36 +46,28 @@ namespace sirius::creator {
 
 task_creator::task_creator(task_creator_config config,
                            sirius::memory::sirius_memory_reservation_manager& mem_res_mgr,
-                           const cucascade::memory::system_topology_info* sys_topology)
+                           std::shared_ptr<const sirius::memory::topology_index> topology_index)
   : _running(false),
     _config(std::move(config)),
     _mem_res_mgr(mem_res_mgr),
-    _sys_topology(sys_topology)
+    _topology_index(std::move(topology_index))
 {
-  // Normalize numa_node=-1 (Linux convention for non-NUMA / single-NUMA
-  // hosts) to 0 so it matches the host memory space, which is built with
-  // numa_id=0 on those hosts. Without normalization, host-sourced tasks on
-  // single-NUMA boxes fall through to the default GPU.
+  // NUMA-aware GPU routing (HOST-data locality via gpus_of(numa)) is served by
+  // the shared topology_index; no ad-hoc device<->NUMA maps are built here.
+  // numa_node -1 ("unknown", per the Linux /sys/bus/pci/devices/*/numa_node
+  // convention on non-NUMA / single-NUMA hosts) is the index's grouping key and
+  // is queried verbatim at routing time.
   //
-  // Record every GPU under its NUMA key (not just the first) so the
-  // round-robin walk spreads work across all GPUs sharing a NUMA node.
-  if (_sys_topology) {
-    for (size_t i = 0; i < _sys_topology->gpus.size(); ++i) {
-      auto raw_numa       = _sys_topology->gpus[i].numa_node;
-      int normalized_numa = (raw_numa < 0) ? 0 : raw_numa;
-      _numa_to_gpu[normalized_numa].push_back(static_cast<int>(_sys_topology->gpus[i].id));
-    }
+  // Materialize the active executor set sorted+deduped (topology_index preserves
+  // manager order, not sorted order) so partition affinity below stays inverse
+  // to sirius_physical_partition's device->slot mapping.
+  if (_topology_index) {
+    auto ids        = _topology_index->gpu_ids();
+    _active_gpu_ids = std::vector<int>(ids.begin(), ids.end());
+    std::sort(_active_gpu_ids.begin(), _active_gpu_ids.end());
+    _active_gpu_ids.erase(std::unique(_active_gpu_ids.begin(), _active_gpu_ids.end()),
+                          _active_gpu_ids.end());
   }
-
-  // Device ids that actually have a GPU executor (memory-manager GPU spaces);
-  // partition affinity indexes this, not the physical topology, so the pin
-  // resolves to a real executor when num_gpus < physical GPU count.
-  for (auto const* space : _mem_res_mgr.get_memory_spaces_for_tier(cucascade::memory::Tier::GPU)) {
-    if (space) { _active_gpu_ids.push_back(space->get_device_id()); }
-  }
-  std::sort(_active_gpu_ids.begin(), _active_gpu_ids.end());
-  _active_gpu_ids.erase(std::unique(_active_gpu_ids.begin(), _active_gpu_ids.end()),
-                        _active_gpu_ids.end());
 }
 
 task_creator::~task_creator() { stop(); }
@@ -363,16 +356,11 @@ void task_creator::manager_loop()
                 if (space->get_tier() == cucascade::memory::Tier::GPU) {
                   gpu_bytes[space->get_device_id()] += size;
                 } else if (space->get_tier() == cucascade::memory::Tier::HOST) {
-                  // Normalize numa_id=-1 (non-NUMA / single-NUMA hosts, per
-                  // the Linux /sys/bus/pci/devices/*/numa_node convention)
-                  // to 0 so the NUMA-affinity lookup matches the normalized
-                  // `_numa_to_gpu` map key. Without this, host_bytes[-1]
-                  // never hits `_numa_to_gpu[0]`, preferred_device_id stays
-                  // nullopt, and every host-sourced pipeline task falls
-                  // back to `_gpu_executors.begin()->first`.
-                  int host_key = space->get_device_id();
-                  if (host_key < 0) host_key = 0;
-                  host_bytes[host_key] += size;
+                  // Key by the host space's NUMA node verbatim; topology_index
+                  // groups GPUs under that same key (including the -1 "unknown"
+                  // sentinel for non-NUMA / single-NUMA hosts), so gpus_of()
+                  // resolves without any normalization.
+                  host_bytes[space->get_device_id()] += size;
                 }
               }
               if (!gpu_bytes.empty()) {
@@ -382,7 +370,7 @@ void task_creator::manager_loop()
                                    gpu_bytes.end(),
                                    [](const auto& a, const auto& b) { return a.second < b.second; })
                     ->first;
-              } else if (!host_bytes.empty() && !_numa_to_gpu.empty()) {
+              } else if (!host_bytes.empty() && _topology_index) {
                 // NUMA-affinity: no GPU data, route to a GPU on the same
                 // NUMA as the host data. When that NUMA hosts multiple
                 // GPUs, pick round-robin across them — pinning every
@@ -393,10 +381,10 @@ void task_creator::manager_loop()
                                    host_bytes.end(),
                                    [](const auto& a, const auto& b) { return a.second < b.second; })
                     ->first;
-                auto it = _numa_to_gpu.find(top_host);
-                if (it != _numa_to_gpu.end() && !it->second.empty()) {
-                  auto idx            = _numa_to_gpu_rr.fetch_add(1) % it->second.size();
-                  preferred_device_id = it->second[idx];
+                auto gpus = _topology_index->gpus_of(top_host);
+                if (!gpus.empty()) {
+                  auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
+                  preferred_device_id = gpus[idx];
                 }
               }
               SIRIUS_LOG_DEBUG(
@@ -425,18 +413,16 @@ void task_creator::manager_loop()
                     if (space->get_tier() == cucascade::memory::Tier::GPU) {
                       preferred_device_id = space->get_device_id();
                     } else if (space->get_tier() == cucascade::memory::Tier::HOST &&
-                               !_numa_to_gpu.empty()) {
+                               _topology_index) {
                       // tier='host' pinned chunks carry a NUMA-local host
-                      // memory_space; map back through _numa_to_gpu to pick
-                      // a GPU on the same NUMA. Normalize numa_id=-1 to 0
-                      // to match the convention used by the pipelineable
-                      // locality block above.
-                      int host_key = space->get_device_id();
-                      if (host_key < 0) host_key = 0;
-                      auto it = _numa_to_gpu.find(host_key);
-                      if (it != _numa_to_gpu.end() && !it->second.empty()) {
-                        auto idx            = _numa_to_gpu_rr.fetch_add(1) % it->second.size();
-                        preferred_device_id = it->second[idx];
+                      // memory_space; map back through the topology index to
+                      // pick a GPU on the same NUMA. The host space's device id
+                      // is the NUMA key verbatim (-1 = "unknown"), matching the
+                      // pipelineable locality block above.
+                      auto gpus = _topology_index->gpus_of(space->get_device_id());
+                      if (!gpus.empty()) {
+                        auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
+                        preferred_device_id = gpus[idx];
                       }
                     }
                     SIRIUS_LOG_DEBUG(

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -28,7 +28,6 @@
 #include <blockingconcurrentqueue.h>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
-#include <cucascade/memory/topology_discovery.hpp>
 
 #include <atomic>
 #include <memory>
@@ -44,6 +43,10 @@ class sirius_pipeline_task_global_state;
 namespace sirius::planner {
 class query;
 }  // namespace sirius::planner
+
+namespace sirius::memory {
+class topology_index;
+}  // namespace sirius::memory
 
 namespace sirius::creator {
 
@@ -74,11 +77,11 @@ class task_creator {
    *
    * @param config Configuration for the thread pool (thread count, name prefix, CPU affinity).
    * @param mem_res_mgr Reference to the memory reservation manager.
-   * @param sys_topology Optional system topology info for NUMA-aware GPU routing.
+   * @param topology_index Optional shared GPU<->NUMA index for NUMA-aware GPU routing.
    */
   task_creator(task_creator_config config,
                sirius::memory::sirius_memory_reservation_manager& mem_res_mgr,
-               const cucascade::memory::system_topology_info* sys_topology = nullptr);
+               std::shared_ptr<const sirius::memory::topology_index> topology_index = nullptr);
 
   /**
    * @brief Destructor that ensures the thread pool is stopped.
@@ -201,21 +204,22 @@ class task_creator {
   std::unique_ptr<duckdb::ExecutionContext> _execution_context;
   std::mutex _global_state_mutex;  // Protect concurrent access to the map
 
-  /// System topology for NUMA-aware GPU routing (non-owning, may be null)
-  const cucascade::memory::system_topology_info* _sys_topology{nullptr};
-  /// Maps NUMA node ID -> all GPU device_ids on that NUMA node (for HOST data
-  /// locality). A NUMA node can host multiple GPUs; the NUMA-affinity rule
-  /// round-robins across the vector so work spreads instead of pinning to the
-  /// first GPU.
-  /// GPUs that report numa_node=-1 (non-NUMA / single-NUMA hosts, per the
-  /// Linux /sys/bus/pci/devices/*/numa_node convention) are normalized to
-  /// NUMA 0 so they match the host memory space built for the single node.
-  std::unordered_map<int, std::vector<int>> _numa_to_gpu;
+  /// Shared GPU<->NUMA topology index for NUMA-aware GPU routing (may be null).
+  /// Scoped to the memory manager's reserved GPU/HOST spaces:
+  ///  - gpus_of(numa) drives HOST-data locality (a NUMA node can host multiple
+  ///    GPUs; the round-robin below spreads work across them). NUMA node -1 is
+  ///    the "unknown" key (non-NUMA / single-NUMA hosts) and is queried
+  ///    verbatim from the host memory space's device id.
+  ///  - gpu_ids() is the active executor set that partition affinity indexes,
+  ///    so the pin resolves to a real executor when num_gpus < physical count.
+  std::shared_ptr<const sirius::memory::topology_index> _topology_index;
   /// Round-robin counter for NUMA-affinity routing when multiple GPUs share a NUMA node.
-  std::atomic<uint64_t> _numa_to_gpu_rr{0};
-  /// Sorted device ids that actually have a GPU executor (memory-manager GPU
-  /// spaces). Partition affinity indexes this, not the physical topology, so the
-  /// pin resolves to a real executor when num_gpus < physical GPU count.
+  std::atomic<uint64_t> _numa_affinity_rr{0};
+  /// Sorted, deduped active GPU device ids, materialized from
+  /// `_topology_index->gpu_ids()` at construction. Partition affinity indexes
+  /// this (`_active_gpu_ids[partition_idx % size]`); it must stay in the same
+  /// sorted order that sirius_physical_partition uses for its device->slot
+  /// mapping (see sirius_engine.cpp) so the two remain inverse to each other.
   std::vector<int> _active_gpu_ids;
 };
 

--- a/src/include/memory/numa_small_pinned_mr.hpp
+++ b/src/include/memory/numa_small_pinned_mr.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "memory/topology_index.hpp"
+
 #include <cuda/memory_resource>
 #include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
@@ -40,7 +42,8 @@ namespace sirius::memory {
 ///
 /// This wrapper owns one @c small_pinned_host_memory_resource per NUMA
 /// node and dispatches each allocate/deallocate by reading
-/// @c cudaGetDevice() and looking it up in a device-id -> NUMA node map.
+/// @c cudaGetDevice() and resolving its NUMA node through the shared
+/// @c topology_index (the single source of truth for GPU<->NUMA mapping).
 /// A small ptr -> NUMA-node table is kept under a mutex so that
 /// @c deallocate can return blocks to the originating per-node pool when
 /// @c cudaGetDevice() at free-time disagrees with @c cudaGetDevice() at
@@ -54,18 +57,21 @@ namespace sirius::memory {
 class numa_small_pinned_mr {
  public:
   /// @brief Build the dispatcher.
-  /// @param per_node_pools   slab MRs keyed by NUMA node id (normalized; -1 -> 0)
-  /// @param device_to_numa   map from CUDA device id to normalized NUMA node id
-  /// @param fallback_node    NUMA node used when @c cudaGetDevice() returns a
-  ///                         device not present in @c device_to_numa (e.g.
-  ///                         host-only threads). Must be present in @c per_node_pools.
+  /// @param per_node_pools   slab MRs keyed by NUMA node id (verbatim from the
+  ///                         host memory-space device ids; -1 is the "unknown"
+  ///                         sentinel, matching @c topology_index).
+  /// @param topology         shared GPU<->NUMA index used to resolve the current
+  ///                         CUDA device's NUMA node at allocate/deallocate time.
+  /// @param fallback_node    NUMA node used when the current device's NUMA node
+  ///                         has no matching pool (e.g. host-only threads). Must
+  ///                         be present in @c per_node_pools.
   numa_small_pinned_mr(
     std::unordered_map<int, std::unique_ptr<cucascade::memory::small_pinned_host_memory_resource>>
       per_node_pools,
-    std::unordered_map<int, int> device_to_numa,
+    std::shared_ptr<const topology_index> topology,
     int fallback_node)
     : pools_(std::move(per_node_pools)),
-      device_to_numa_(std::move(device_to_numa)),
+      topology_(std::move(topology)),
       fallback_node_(fallback_node)
   {
   }
@@ -133,8 +139,10 @@ class numa_small_pinned_mr {
   {
     int dev = -1;
     cudaGetDevice(&dev);  // best-effort; failures imply we should use fallback
-    if (auto it = device_to_numa_.find(dev); it != device_to_numa_.end()) { return it->second; }
-    return fallback_node_;
+    // numa_node_of() returns -1 for a device outside the index, which is also a
+    // legitimate pool key on single-NUMA hosts; pool_for_current_device() and
+    // deallocate() fall back when the resolved node has no matching pool.
+    return topology_ ? topology_->numa_node_of(dev) : fallback_node_;
   }
 
   cucascade::memory::small_pinned_host_memory_resource& pool_for_current_device()
@@ -147,7 +155,7 @@ class numa_small_pinned_mr {
 
   std::unordered_map<int, std::unique_ptr<cucascade::memory::small_pinned_host_memory_resource>>
     pools_;
-  std::unordered_map<int, int> device_to_numa_;
+  std::shared_ptr<const topology_index> topology_;
   int fallback_node_;
   // Allocate-time -> deallocate-time NUMA-node lookup. The cuDF pinned MR
   // is shared across worker threads that may be bound to different GPUs;

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -52,6 +52,7 @@ class small_pinned_host_memory_resource;
 
 namespace sirius::memory {
 class numa_small_pinned_mr;
+class topology_index;
 }  // namespace sirius::memory
 
 namespace sirius {
@@ -329,6 +330,13 @@ class SiriusContext : public ClientContextState {
   bool is_initialized_ = false;
   sirius::sirius_config config_;
   std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory_manager_;
+  // Single source of truth for the GPU<->NUMA hardware topology, scoped to the
+  // memory manager's reserved GPU/HOST spaces. Shared by shared_ptr copy with
+  // the small-pinned allocator, downgrade executors, task_creator, and
+  // scan_manager so every NUMA-aware routing decision reads one consistent
+  // index instead of rebuilding ad-hoc device<->NUMA maps. Owns a copy of the
+  // topology and holds no device resources, so teardown order is unconstrained.
+  std::shared_ptr<const sirius::memory::topology_index> topology_index_;
   // P2P: set of (src, dst) GPU pairs where cudaDeviceEnablePeerAccess
   // succeeded in initialize(). Populated under rmm::cuda_set_device_raii, one
   // call per pair. Consumed by is_peer_access_enabled() and any Sirius-side

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -374,6 +374,13 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
     }
   }
 
+  // Build the single GPU<->NUMA topology index now that the memory manager's
+  // GPU/HOST spaces exist. Every NUMA-aware component below (small-pinned
+  // allocator, downgrade executors, task_creator, scan_manager) shares this one
+  // index by shared_ptr copy instead of rebuilding its own device<->NUMA map.
+  topology_index_ = std::make_shared<const sirius::memory::topology_index>(
+    config_.get_hw_topology(), *memory_manager_);
+
   // Enable P2P peer access for every available GPU pair.
   // cucascade::convert_gpu_to_gpu calls cudaMemcpyPeerAsync on every GPU->GPU
   // conversion. For that call to bypass host staging, peer access must be
@@ -442,26 +449,18 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
         auto* fsmr =
           host_space->get_memory_resource_as<cucascade::memory::fixed_size_host_memory_resource>();
         if (fsmr == nullptr) { continue; }
-        int raw_numa = host_space->get_device_id();
-        int node     = (raw_numa < 0) ? 0 : raw_numa;
+        // Key each pool by the host space's NUMA node verbatim (-1 is the
+        // "unknown" sentinel), matching topology_index::numa_node_of() so the
+        // allocator's device->node lookups resolve to the right pool.
+        int node = host_space->get_device_id();
         if (fallback_node < 0) { fallback_node = node; }
         per_node_pools.emplace(
           node, std::make_unique<cucascade::memory::small_pinned_host_memory_resource>(*fsmr));
       }
       if (!per_node_pools.empty()) {
         if (fallback_node < 0) { fallback_node = per_node_pools.begin()->first; }
-        std::unordered_map<int, int> device_to_numa_copy;
-        for (auto const* gpu_space :
-             memory_manager_->get_memory_spaces_for_tier(cucascade::memory::Tier::GPU)) {
-          int const dev = gpu_space->get_device_id();
-          int raw_numa  = -1;
-          if (dev >= 0 && static_cast<unsigned>(dev) < topo.gpus.size()) {
-            raw_numa = topo.gpus[dev].numa_node;
-          }
-          device_to_numa_copy[dev] = (raw_numa < 0) ? 0 : raw_numa;
-        }
         small_pinned_allocator_ = std::make_unique<sirius::memory::numa_small_pinned_mr>(
-          std::move(per_node_pools), std::move(device_to_numa_copy), fallback_node);
+          std::move(per_node_pools), topology_index_, fallback_node);
         small_pinned_allocator_view_.emplace(
           sirius::memory::make_host_device_resource_view_checked(small_pinned_allocator_.get()));
         prev_pinned_threshold_ = cudf::get_allocate_host_as_pinned_threshold();
@@ -498,16 +497,14 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
   auto create_executors_for_tier = [&](cucascade::memory::Tier tier) {
     auto spaces          = memory_manager_->get_memory_spaces_for_tier(tier);
     auto const& base_cfg = config_.get_downgrade_executor_config();
-    auto const& topo     = config_.get_hw_topology();
     for (auto* space : spaces) {
       // Copy the base downgrade_executor_config so we can attach a per-GPU NUMA preference
       // without mutating the shared config owned by sirius_config.
       sirius::exec::downgrade_executor_config dg_cfg = base_cfg;
       if (tier == cucascade::memory::Tier::GPU) {
-        auto dev_id = space->get_device_id();
-        if (dev_id >= 0 && static_cast<unsigned>(dev_id) < topo.gpus.size()) {
-          dg_cfg.preferred_numa_node = topo.gpus[dev_id].numa_node;
-        }
+        // NUMA-local host space to prefer for GPU->HOST downgrade. -1 ("unknown",
+        // e.g. single-NUMA hosts) selects the host space with device_id -1.
+        dg_cfg.preferred_numa_node = topology_index_->numa_node_of(space->get_device_id());
       }
       auto executor = std::make_unique<sirius::parallel::downgrade_executor>(
         dg_cfg,
@@ -531,14 +528,12 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
                                                        &downgrade_executors_);
 
   task_creator_ = std::make_unique<sirius::creator::task_creator>(
-    config_.get_task_creator_config(), *memory_manager_, &config_.get_hw_topology());
+    config_.get_task_creator_config(), *memory_manager_, topology_index_);
   task_creator_->set_task_scheduler(*task_scheduler_);
   task_scheduler_->set_task_creator(*task_creator_);
 
-  auto hw_topology_index = std::make_shared<const sirius::memory::topology_index>(
-    config_.get_hw_topology(), *memory_manager_);
   scan_manager_ = std::make_unique<sirius::scan_manager::sirius_scan_manager>(
-    config_.get_scan_manager_config(), *memory_manager_, std::move(hw_topology_index));
+    config_.get_scan_manager_config(), *memory_manager_, topology_index_);
 
   // Wire the pipeline task queue into downgrade executors now that task_scheduler_
   // has been constructed.
@@ -603,6 +598,10 @@ void SiriusContext::terminate()
 
   memory_manager_->shutdown();
   memory_manager_.reset();
+
+  // Owns only a topology copy (no device resources); drop after the components
+  // that held shared_ptr copies of it are gone.
+  topology_index_.reset();
 
   is_initialized_ = false;
 }


### PR DESCRIPTION
## Summary

`SiriusContext` and its owned components each built their own ad-hoc device↔NUMA maps for NUMA-aware GPU routing. This consolidates them onto the existing single source of truth, `sirius::memory::topology_index`: one shared `shared_ptr<const topology_index>` is built once in `SiriusContext::initialize()` and injected into every NUMA-aware component instead of each rebuilding its own map.

## What changed

- **`sirius_context`**: build the shared `topology_index_` once (after the memory manager is populated); reuse it for `task_creator` and `scan_manager` (previously a *second* index was built inline for the scan manager); reset it in `terminate()`.
- **`numa_small_pinned_mr`**: drop the `device_to_numa_` map; resolve the current device's NUMA node via the shared index. Pools stay keyed by the host-space device id verbatim.
- **`task_creator`**: drop `_sys_topology` / `_numa_to_gpu`; host-locality routing uses `gpus_of()`, and the sorted active-executor set derives from `gpu_ids()` (kept sorted+deduped to stay inverse to `sirius_physical_partition`'s device→slot mapping).
- **downgrade executors**: per-GPU `preferred_numa_node` now uses `numa_node_of(device_id)`.

## Design decision

Adopts `topology_index`'s `-1`-as-"unknown" sentinel semantics and **drops the prior `-1`→`0` NUMA normalization**. The index's manager-based constructor cross-checks each GPU's NUMA node against the HOST memory-space device ids, so `numa_node_of()` / `gpus_of()` resolve verbatim (single-NUMA hosts report host-space device id `-1`, consistent with the pre-existing defensive `(raw_numa < 0)` checks).

Scoped to `SiriusContext` and its owned components. `pin_table` / `sirius_extension`'s `host_space_by_gpu` (a gpu→`memory_space*` map — a different kind) is intentionally left untouched.

## Incidental fix

The old downgrade code indexed `topo.gpus[dev_id].numa_node` by device id, whereas `numa_node_of()` matches on the topology entry's `.id` field — so this also fixes a latent bug on hosts where device id ≠ topology-vector index.

## Testing

Reviewed by an internal C++ reviewer (correctness of lifetime/teardown, pool key-matching, partition-affinity ordering, null-safety — all clear). **Draft** because the full `pixi run make test` could not be run in my local environment (uninitialized `duckdb` submodule); relying on CI to validate the build. Existing `test/cpp/memory/test_topology_index.cpp` covers the index itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)