### PR TITLE
fix(expression): use Kleene 3-valued logic for AND/OR

### DIFF
--- a/src/expression_evaluator/gpu_expression_translator.cpp
+++ b/src/expression_evaluator/gpu_expression_translator.cpp
@@ -579,9 +579,11 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
   // Resolve the cuDF operator once up front rather than re-checking per child.
   cudf::ast::ast_operator cudf_op{};
   using enum sirius::ast::conjunction::kind;
+  // SQL AND/OR use Kleene three-valued logic (TRUE OR NULL = TRUE), so use cuDF's
+  // NULL_LOGICAL_* operators rather than the null-propagating LOGICAL_*.
   switch (alt.op) {
-    case op_and: cudf_op = cudf::ast::ast_operator::LOGICAL_AND; break;
-    case op_or: cudf_op = cudf::ast::ast_operator::LOGICAL_OR; break;
+    case op_and: cudf_op = cudf::ast::ast_operator::NULL_LOGICAL_AND; break;
+    case op_or: cudf_op = cudf::ast::ast_operator::NULL_LOGICAL_OR; break;
     default:
       SIRIUS_LOG_DEBUG("[expression_translator] Unsupported conjunction type: {}",
                        static_cast<int>(alt.op));

--- a/src/expression_evaluator/specializations/conjunction.cpp
+++ b/src/expression_evaluator/specializations/conjunction.cpp
@@ -33,9 +33,11 @@ namespace {
 
 cudf::ast::ast_operator conjunction_op_to_ast(sirius::ast::conjunction::kind op)
 {
+  // SQL AND/OR use Kleene three-valued logic (e.g. TRUE OR NULL = TRUE), so use
+  // cuDF's NULL_LOGICAL_* operators rather than the null-propagating LOGICAL_*.
   switch (op) {
-    case sirius::ast::conjunction::kind::op_and: return cudf::ast::ast_operator::LOGICAL_AND;
-    case sirius::ast::conjunction::kind::op_or: return cudf::ast::ast_operator::LOGICAL_OR;
+    case sirius::ast::conjunction::kind::op_and: return cudf::ast::ast_operator::NULL_LOGICAL_AND;
+    case sirius::ast::conjunction::kind::op_or: return cudf::ast::ast_operator::NULL_LOGICAL_OR;
     default:
       throw invalid_input_exception(
         "[expression_evaluator:conjunction] unrecognized conjunction type {}",
@@ -45,9 +47,10 @@ cudf::ast::ast_operator conjunction_op_to_ast(sirius::ast::conjunction::kind op)
 
 cudf::binary_operator conjunction_op_to_binary(sirius::ast::conjunction::kind op)
 {
+  // Kleene three-valued logic (SQL semantics); see conjunction_op_to_ast.
   switch (op) {
-    case sirius::ast::conjunction::kind::op_and: return cudf::binary_operator::LOGICAL_AND;
-    case sirius::ast::conjunction::kind::op_or: return cudf::binary_operator::LOGICAL_OR;
+    case sirius::ast::conjunction::kind::op_and: return cudf::binary_operator::NULL_LOGICAL_AND;
+    case sirius::ast::conjunction::kind::op_or: return cudf::binary_operator::NULL_LOGICAL_OR;
     default:
       throw invalid_input_exception(
         "[expression_evaluator:conjunction] unrecognized conjunction type {}",

--- a/test/cpp/integration/test_gpu_execution_filter_nulls.cpp
+++ b/test/cpp/integration/test_gpu_execution_filter_nulls.cpp
@@ -129,25 +129,19 @@ TEST_CASE_METHOD(NullDataFixture,
   compare_gpu_vs_cpu("SELECT id, (NOT (i = 10)) AS r FROM nt");
 }
 
-// KNOWN GPU DIVERGENCE (issue #1218):
-// SQL three-valued logic says `TRUE OR UNKNOWN = TRUE`, but Sirius's GPU OR
-// naively propagates NULL (`TRUE OR NULL -> NULL`), so a row where one branch is
-// TRUE and the other is NULL is wrongly filtered out. Each divergent query is its
-// own case: Catch2 aborts a test case at the first REQUIRE failure, so bundling
-// them would leave the later queries unexercised. Tagged [!shouldfail] so they
-// document the bug without failing CI; remove the tag when the GPU predicate
-// evaluator implements 3-valued OR correctly.
+// SQL three-valued logic: TRUE OR UNKNOWN = TRUE, so a row where one branch is
+// TRUE and the other is NULL is kept.
 TEST_CASE_METHOD(NullDataFixture,
-                 "gpu_execution three-valued OR, TRUE-OR-NULL branch [known divergence]",
-                 "[integration][gpu_execution][filter][nulls][!shouldfail]")
+                 "gpu_execution three-valued OR, TRUE-OR-NULL branch",
+                 "[integration][gpu_execution][filter][nulls]")
 {
-  // Row (i=10, b=NULL) satisfies `i = 10` yet GPU drops it because `b = 200` is NULL.
+  // Row (i=10, b=NULL) satisfies `i = 10`, so it is kept even though `b = 200` is NULL.
   compare_gpu_vs_cpu("SELECT id FROM nt WHERE i = 10 OR b = 200");
 }
 
 TEST_CASE_METHOD(NullDataFixture,
-                 "gpu_execution three-valued OR, IS-NULL-OR-match branch [known divergence]",
-                 "[integration][gpu_execution][filter][nulls][!shouldfail]")
+                 "gpu_execution three-valued OR, IS-NULL-OR-match branch",
+                 "[integration][gpu_execution][filter][nulls]")
 {
   compare_gpu_vs_cpu("SELECT id FROM nt WHERE (i IS NULL) OR (b = 100)");
 }


### PR DESCRIPTION
Fixes the three-valued `OR` bug in #1218.

Sirius mapped SQL `AND`/`OR` to cuDF's null-propagating `LOGICAL_AND`/`LOGICAL_OR`,
so `TRUE OR NULL` gave `NULL` instead of `TRUE`. `WHERE` then dropped rows where one
`OR` branch was TRUE and the other NULL — e.g. `WHERE i = 10 OR b = 200` lost the
`i=10, b=NULL` row.

Fix: use the Kleene operators `NULL_LOGICAL_AND`/`NULL_LOGICAL_OR` (SQL semantics)
at all three conjunction translation sites (AST + binary_operation paths). These
are always correct — identical to `LOGICAL_*` when operands are non-null — so no
nullability-based selection is needed.

Un-quarantines the two three-valued `OR` tests; `[filter][nulls]` green on the VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)