### PR TITLE
test: speed up partitioned anti-join (misfit key) tests by shrinking the build side

### DIFF
--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -2154,18 +2154,24 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
     "from nation n join region r on n.n_regionkey = r.r_regionkey;");
 }
 
+// Regression test: n_nationkey (INT32) and c_custkey (INT64) were hashed with different physical
+// types, so cuDF murmur3 sent the same integer to different partitions and matching keys were
+// missed. The bug is deterministic per key value, so restricting the build side to c_custkey <= 25
+// still triggers it (INT32/INT64 misfit + partitioning both preserved) while keeping the anti-join
+// result identical — only n_nationkey=0 is unmatched, since keys 1..24 match customers 1..25.
+// The subset also avoids partitioning the full 150k-row customer table (hash_partition_bytes=1
+// makes num_partitions grow with row count), which is what made this test slow.
+constexpr const char* kMisfitAntiJoin =
+  "select n.n_nationkey, n.n_regionkey from nation n "
+  "anti join (select c_custkey from customer where c_custkey <= 25) c "
+  "on n.n_nationkey = c.c_custkey;";
+
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - partitioned anti join (misfit key)",
                  "[integration][gpu_execution][antijoin][partitioned_join]")
 {
-  // n_nationkey = 0..24; c_custkey = 1..150000. Only n_nationkey=0 has no match.
-  // Regression test for the bug where n_nationkey (INT32) and c_custkey (INT64) were hashed
-  // using different physical types: cuDF murmur3 produces different hash values for the same
-  // integer in INT32 vs INT64, so matching keys landed in different partitions.
   partition_size_guard guard(*con, 1);
-  compare_gpu_vs_cpu(
-    "select n.n_nationkey, n.n_regionkey from nation n "
-    "anti join customer c on n.n_nationkey = c.c_custkey;");
+  compare_gpu_vs_cpu(kMisfitAntiJoin);
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
@@ -2173,9 +2179,7 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "[integration][gpu_execution][antijoin][partitioned_join]")
 {
   partition_size_guard guard(*con, 1);
-  compare_gpu_vs_cpu(
-    "select n.n_nationkey, n.n_regionkey from nation n "
-    "anti join customer c on n.n_nationkey = c.c_custkey;");
+  compare_gpu_vs_cpu(kMisfitAntiJoin);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What

The two `gpu_execution - partitioned anti join (misfit key)` tests (DuckDB-native
and parquet variants) took far longer to run than every other test in the suite.
This refactors them to run in a fraction of the time while preserving exactly what
they cover.

## Why it was slow

Both tests set `hash_partition_bytes = 1` (via `partition_size_guard`) to force hash
partitioning to actually run on small TPC-H tables. With that setting,
`natural_num_partitions()` computes `num_partitions = ceil(total_bytes / 1) = total_bytes`.

Every *other* partitioned test joins against `region` (5 rows) or `nation` (25 rows),
so the byte count — and thus partition count — is tiny. The two misfit tests are the
only ones that put the **150,000-row `customer` table** on a join side, exploding it
into ~10⁵–10⁶ partitions, each incurring its own per-partition build/probe iteration.
That partition blow-up dominated the runtime.

## The fix

The regression these tests guard against is that `n_nationkey` (INT32) and `c_custkey`
(INT64) were hashed with different physical types — cuDF murmur3 gives the same integer
different hash values in INT32 vs INT64, so matching keys landed in different partitions.
This bug is **deterministic per key value**, so it reproduces at any scale as long as:

1. the two join keys keep their INT32-vs-INT64 misfit, and
2. hash partitioning actually runs (`num_partitions ≥ 2`).

So the tests now restrict the build side to a small subset via a derived table:

```sql
anti join (select c_custkey from customer where c_custkey <= 25) c
  on n.n_nationkey = c.c_custkey
```

## Test timing gains

228s + 216s -> 0.3 + 0.4s on my L4 omnistation