### PR TITLE
CI: Switch to T4 GPU Testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build
         env:
-          CUDAARCHS: "89" # 75 for T4 capability; 89 for L4 capability
+          CUDAARCHS: "75" # 75 for T4 capability; 89 for L4 capability
         run: make -j$(nproc)
 
       - name: Package build artifacts
@@ -110,7 +110,7 @@ jobs:
           - cuda:
               run-on-pr: ${{ fromJSON(github.event_name == 'pull_request' && 'false' || 'null') }}
       fail-fast: false
-    runs-on: ${{ fromJSON(format('["self-hosted", "{0}", "gpu-2xl4"]', matrix.cuda.runner)) }}
+    runs-on: ${{ fromJSON(format('["self-hosted", "{0}", "gpu-2xt4"]', matrix.cuda.runner)) }}
     timeout-minutes: 60
     env:
       CUDA_CACHE_PATH: /home/runner/actions-runner/_work/.cuda-cache


### PR DESCRIPTION
Closes #1258

This changes our GPU testing from current L4s to T4s. This is to address the availability concerns raised in #1258. While we originally were going to test T4s in parallel to gather data, the observed 2+ hour wait of one of the L4 runners forced us to switch fully in order to unblock the development team. The same work done in #1258 will be done in a new issue to track the stability of this change after merge