### PR TITLE
Test Code only - Test deep S3 glob matcher patterns

### DIFF
--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -33,7 +33,6 @@
 
 #include <arpa/inet.h>
 #include <config.hpp>
-#include <cucascade/memory/topology_discovery.hpp>
 #include <log/logging.hpp>
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -90,27 +89,10 @@ std::string require_env(std::string const& name)
   return value;
 }
 
-cucascade::memory::system_topology_info single_gpu_topology()
-{
-  cucascade::memory::system_topology_info topology;
-  topology.num_gpus = 1;
-  cucascade::memory::gpu_topology_info gpu;
-  gpu.id        = 0;
-  gpu.numa_node = 0;
-  topology.gpus.push_back(std::move(gpu));
-  return topology;
-}
-
-std::shared_ptr<const sirius::memory::topology_index> single_gpu_index()
-{
-  return std::make_shared<sirius::memory::topology_index>(single_gpu_topology(),
-                                                          std::vector<int>{0});
-}
-
 struct scan_manager_fixture {
   std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory =
     initialize_memory_manager(1);
-  std::shared_ptr<const sirius::memory::topology_index> topology = single_gpu_index();
+  std::shared_ptr<const sirius::memory::topology_index> topology = discover_topology_index(*memory);
 };
 
 scan_manager_config make_minio_rest_config()

--- a/test/cpp/io/s3/test_sirius_httpfs.cpp
+++ b/test/cpp/io/s3/test_sirius_httpfs.cpp
@@ -18,7 +18,6 @@
 #include "utils/s3_container.hpp"
 
 #include <arpa/inet.h>
-#include <cucascade/memory/topology_discovery.hpp>
 #include <duckdb.hpp>
 #include <duckdb/common/file_system.hpp>
 #include <duckdb/common/open_file_info.hpp>
@@ -310,27 +309,10 @@ class exposed_sirius_httpfs final : public sirius::io::s3::sirius_httpfs {
   using sirius::io::s3::sirius_httpfs::SupportsOpenFileExtended;
 };
 
-cucascade::memory::system_topology_info single_gpu_topology()
-{
-  cucascade::memory::system_topology_info topology;
-  topology.num_gpus = 1;
-  cucascade::memory::gpu_topology_info gpu;
-  gpu.id        = 0;
-  gpu.numa_node = 0;
-  topology.gpus.push_back(std::move(gpu));
-  return topology;
-}
-
-std::shared_ptr<const sirius::memory::topology_index> single_gpu_index()
-{
-  return std::make_shared<sirius::memory::topology_index>(single_gpu_topology(),
-                                                          std::vector<int>{0});
-}
-
 struct glob_scan_manager_fixture {
   std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory =
     initialize_memory_manager(1);
-  std::shared_ptr<const sirius::memory::topology_index> topology = single_gpu_index();
+  std::shared_ptr<const sirius::memory::topology_index> topology = discover_topology_index(*memory);
 };
 
 sirius::scan_manager::scan_manager_config make_fake_list_config(std::string endpoint)

--- a/test/cpp/io/s3/test_sirius_httpfs.cpp
+++ b/test/cpp/io/s3/test_sirius_httpfs.cpp
@@ -10,24 +10,37 @@
 #include "io/s3/sirius_httpfs.hpp"
 #include "io/sirius_datasource.hpp"
 #include "io/uri_parser.hpp"
+#include "memory/topology_index.hpp"
+#include "scan/test_utils.hpp"
+#include "scan_manager/sirius_scan_manager.hpp"
 #include "sirius_context.hpp"
 #include "sirius_extension.hpp"
 #include "utils/s3_container.hpp"
 
+#include <arpa/inet.h>
+#include <cucascade/memory/topology_discovery.hpp>
 #include <duckdb.hpp>
 #include <duckdb/common/file_system.hpp>
 #include <duckdb/common/open_file_info.hpp>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
+#include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -297,6 +310,264 @@ class exposed_sirius_httpfs final : public sirius::io::s3::sirius_httpfs {
   using sirius::io::s3::sirius_httpfs::SupportsOpenFileExtended;
 };
 
+cucascade::memory::system_topology_info single_gpu_topology()
+{
+  cucascade::memory::system_topology_info topology;
+  topology.num_gpus = 1;
+  cucascade::memory::gpu_topology_info gpu;
+  gpu.id        = 0;
+  gpu.numa_node = 0;
+  topology.gpus.push_back(std::move(gpu));
+  return topology;
+}
+
+std::shared_ptr<const sirius::memory::topology_index> single_gpu_index()
+{
+  return std::make_shared<sirius::memory::topology_index>(single_gpu_topology(),
+                                                          std::vector<int>{0});
+}
+
+struct glob_scan_manager_fixture {
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory =
+    initialize_memory_manager(1);
+  std::shared_ptr<const sirius::memory::topology_index> topology = single_gpu_index();
+};
+
+sirius::scan_manager::scan_manager_config make_fake_list_config(std::string endpoint)
+{
+  sirius::scan_manager::scan_manager_config cfg{};
+  cfg.use_sirius_datasource        = true;
+  cfg.object_store.endpoint        = std::move(endpoint);
+  cfg.object_store.region          = "us-east-1";
+  cfg.object_store.access_key      = "glob-stress-access-key";
+  cfg.object_store.secret_key      = "glob-stress-secret-key";
+  cfg.object_store.tls_verify      = false;
+  cfg.rest.request_timeout_s       = 2;
+  cfg.rest.max_connections         = 1;
+  cfg.rest.max_retry_attempts      = 1;
+  cfg.rest.max_auth_retry_attempts = 1;
+  cfg.rest.retry_backoff_base      = std::chrono::milliseconds{0};
+  cfg.rest.retry_jitter            = std::chrono::milliseconds{0};
+  cfg.rest.honor_retry_after       = false;
+  cfg.rest_n_reactors              = 1;
+  cfg.enable_prefetch_cache        = false;
+  return cfg;
+}
+
+class generated_list_http_server {
+ public:
+  explicit generated_list_http_server(std::vector<std::string> keys) : _keys(std::move(keys))
+  {
+    _listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (_listen_fd < 0) { throw std::runtime_error("socket failed: " + errno_message()); }
+
+    int one = 1;
+    if (::setsockopt(_listen_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) != 0) {
+      throw std::runtime_error("setsockopt failed: " + errno_message());
+    }
+
+    sockaddr_in addr{};
+    addr.sin_family      = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port        = 0;
+    if (::bind(_listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+      throw std::runtime_error("bind failed: " + errno_message());
+    }
+    if (::listen(_listen_fd, 8) != 0) {
+      throw std::runtime_error("listen failed: " + errno_message());
+    }
+
+    socklen_t len = sizeof(addr);
+    if (::getsockname(_listen_fd, reinterpret_cast<sockaddr*>(&addr), &len) != 0) {
+      throw std::runtime_error("getsockname failed: " + errno_message());
+    }
+    _port   = ntohs(addr.sin_port);
+    _thread = std::thread([this] { accept_loop(); });
+  }
+
+  ~generated_list_http_server()
+  {
+    _stop.store(true);
+    if (_listen_fd >= 0) {
+      ::shutdown(_listen_fd, SHUT_RDWR);
+      ::close(_listen_fd);
+      _listen_fd = -1;
+    }
+    if (_thread.joinable()) { _thread.join(); }
+    for (auto& worker : _workers) {
+      if (worker.joinable()) { worker.join(); }
+    }
+  }
+
+  generated_list_http_server(generated_list_http_server const&)            = delete;
+  generated_list_http_server& operator=(generated_list_http_server const&) = delete;
+
+  [[nodiscard]] std::string endpoint() const { return "http://127.0.0.1:" + std::to_string(_port); }
+
+ private:
+  static std::string errno_message() { return std::strerror(errno); }
+
+  static std::string request_target(std::string const& request)
+  {
+    auto const first_space = request.find(' ');
+    if (first_space == std::string::npos) { return {}; }
+    auto const second_space = request.find(' ', first_space + 1);
+    if (second_space == std::string::npos) { return {}; }
+    return request.substr(first_space + 1, second_space - first_space - 1);
+  }
+
+  static int from_hex(char c)
+  {
+    if (c >= '0' && c <= '9') { return c - '0'; }
+    if (c >= 'a' && c <= 'f') { return c - 'a' + 10; }
+    if (c >= 'A' && c <= 'F') { return c - 'A' + 10; }
+    return -1;
+  }
+
+  static std::string percent_decode(std::string_view value)
+  {
+    std::string out;
+    out.reserve(value.size());
+    for (std::size_t i = 0; i < value.size(); ++i) {
+      if (value[i] == '%' && i + 2 < value.size()) {
+        auto const hi = from_hex(value[i + 1]);
+        auto const lo = from_hex(value[i + 2]);
+        if (hi >= 0 && lo >= 0) {
+          out.push_back(static_cast<char>((hi << 4) | lo));
+          i += 2;
+          continue;
+        }
+      }
+      out.push_back(value[i]);
+    }
+    return out;
+  }
+
+  static std::string query_value(std::string const& target, std::string_view key)
+  {
+    auto const query_pos = target.find('?');
+    if (query_pos == std::string::npos) { return {}; }
+    auto const query  = std::string_view{target}.substr(query_pos + 1);
+    auto const needle = std::string{key} + "=";
+    for (std::size_t pos = 0; pos < query.size();) {
+      auto amp = query.find('&', pos);
+      if (amp == std::string_view::npos) { amp = query.size(); }
+      auto const part        = query.substr(pos, amp - pos);
+      auto const needle_view = std::string_view{needle};
+      if (part.size() >= needle_view.size() && part.substr(0, needle_view.size()) == needle_view) {
+        return percent_decode(part.substr(needle_view.size()));
+      }
+      pos = amp + 1;
+    }
+    return {};
+  }
+
+  static std::string xml_escape(std::string_view value)
+  {
+    std::string out;
+    out.reserve(value.size());
+    for (char c : value) {
+      switch (c) {
+        case '&': out += "&amp;"; break;
+        case '<': out += "&lt;"; break;
+        case '>': out += "&gt;"; break;
+        case '"': out += "&quot;"; break;
+        case '\'': out += "&apos;"; break;
+        default: out.push_back(c); break;
+      }
+    }
+    return out;
+  }
+
+  static void send_all(int fd, std::string_view bytes)
+  {
+    std::size_t sent = 0;
+    while (sent < bytes.size()) {
+      auto const written = ::send(fd, bytes.data() + sent, bytes.size() - sent, MSG_NOSIGNAL);
+      if (written <= 0) { return; }
+      sent += static_cast<std::size_t>(written);
+    }
+  }
+
+  void accept_loop()
+  {
+    while (!_stop.load()) {
+      sockaddr_in client{};
+      socklen_t len = sizeof(client);
+      auto const fd = ::accept(_listen_fd, reinterpret_cast<sockaddr*>(&client), &len);
+      if (fd < 0) {
+        if (_stop.load()) { return; }
+        continue;
+      }
+      _workers.emplace_back([this, fd] {
+        handle_client(fd);
+        ::close(fd);
+      });
+    }
+  }
+
+  void handle_client(int fd)
+  {
+    std::string request(16 * 1024, '\0');
+    auto const received = ::recv(fd, request.data(), request.size(), 0);
+    if (received <= 0) { return; }
+    request.resize(static_cast<std::size_t>(received));
+
+    auto const target = request_target(request);
+    if (request.rfind("GET ", 0) != 0 || target.find("list-type=2") == std::string::npos) {
+      send_all(fd,
+               "HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+      return;
+    }
+
+    auto const prefix = query_value(target, "prefix");
+    std::ostringstream xml;
+    xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+           "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
+           "<IsTruncated>false</IsTruncated>";
+    for (auto const& key : _keys) {
+      if (key.rfind(prefix, 0) != 0) { continue; }
+      xml << "<Contents><Key>" << xml_escape(key) << "</Key><Size>" << key.size()
+          << "</Size></Contents>";
+    }
+    xml << "</ListBucketResult>";
+
+    auto const body     = xml.str();
+    auto const response = "HTTP/1.1 200 OK\r\nContent-Type: application/xml\r\nContent-Length: " +
+                          std::to_string(body.size()) + "\r\nConnection: close\r\n\r\n" + body;
+    send_all(fd, response);
+  }
+
+  int _listen_fd{-1};
+  std::uint16_t _port{0};
+  std::vector<std::string> _keys;
+  std::atomic<bool> _stop{false};
+  std::thread _thread;
+  std::vector<std::thread> _workers;
+};
+
+std::string deep_key(std::string_view prefix, std::size_t depth, std::string_view tail)
+{
+  std::string key{prefix};
+  for (std::size_t i = 0; i < depth; ++i) {
+    key += "segment-" + std::to_string(i) + "/";
+  }
+  key += tail;
+  return key;
+}
+
+std::vector<std::string> glob_paths(sirius::scan_manager::sirius_scan_manager& manager,
+                                    std::string const& pattern)
+{
+  auto files = sirius::io::s3::expand_glob(pattern, manager);
+  std::vector<std::string> paths;
+  paths.reserve(files.size());
+  for (auto const& file : files) {
+    paths.push_back(file.path);
+  }
+  return paths;
+}
+
 }  // namespace
 
 TEST_CASE("S3 LIST keys retain literal identity when embedded in object URIs",
@@ -326,6 +597,63 @@ TEST_CASE("S3 object URI parsing preserves ordinary keys byte for byte", "[s3][f
     {
       CHECK(sirius::io::parse("s3://bkt/" + std::string{key}).path == key);
     }
+  }
+}
+
+TEST_CASE("S3 glob matcher handles deep crawl patterns without backtracking blowup",
+          "[s3][filesystem][glob]")
+{
+  auto const stress_key = deep_key("stress/", 28, "y.parquet");
+  std::vector<std::string> const keys{
+    "prefix/x.parquet",
+    "prefix/a/b/x.parquet",
+    "prefix/a/b/y.parquet",
+    "prefix/part-alpha/filea1.parquet",
+    "prefix/deep/part-z/fileb2.parquet",
+    "prefix/deep/notpart-z/filea3.parquet",
+    "prefix/deep/part-z/filec4.parquet",
+    "prefix/deep/part-z/filea12.parquet",
+    "tail.parquet",
+    "leading/a/tail.parquet",
+    "leading/a/not-tail.csv",
+    stress_key,
+  };
+  generated_list_http_server server(keys);
+  glob_scan_manager_fixture fixture;
+  sirius::scan_manager::sirius_scan_manager manager{
+    make_fake_list_config(server.endpoint()), *fixture.memory, fixture.topology};
+
+  CHECK(
+    glob_paths(manager, "s3://bucket/prefix/**/x.parquet") ==
+    std::vector<std::string>{"s3://bucket/prefix/a/b/x.parquet", "s3://bucket/prefix/x.parquet"});
+
+  CHECK(glob_paths(manager, "s3://bucket/prefix/**/part-*/file[ab]?.parquet") ==
+        std::vector<std::string>{"s3://bucket/prefix/deep/part-z/fileb2.parquet",
+                                 "s3://bucket/prefix/part-alpha/filea1.parquet"});
+
+  CHECK(glob_paths(manager, "s3://bucket/**/tail.parquet") ==
+        std::vector<std::string>{"s3://bucket/leading/a/tail.parquet", "s3://bucket/tail.parquet"});
+
+  CHECK(glob_paths(manager, "s3://bucket/prefix/**") ==
+        std::vector<std::string>{"s3://bucket/prefix/a/b/x.parquet",
+                                 "s3://bucket/prefix/a/b/y.parquet",
+                                 "s3://bucket/prefix/deep/notpart-z/filea3.parquet",
+                                 "s3://bucket/prefix/deep/part-z/filea12.parquet",
+                                 "s3://bucket/prefix/deep/part-z/fileb2.parquet",
+                                 "s3://bucket/prefix/deep/part-z/filec4.parquet",
+                                 "s3://bucket/prefix/part-alpha/filea1.parquet",
+                                 "s3://bucket/prefix/x.parquet"});
+
+  auto const started = std::chrono::steady_clock::now();
+  auto const stress_matches =
+    glob_paths(manager, "s3://bucket/stress/**/**/**/**/**/**/**/**/**/**/x.parquet");
+  auto const elapsed = std::chrono::steady_clock::now() - started;
+
+  INFO("memoized deep-crawl mismatch completed in "
+       << std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count() << " ms");
+  CHECK(stress_matches.empty());
+  if (elapsed > std::chrono::seconds{1}) {
+    WARN("deep-crawl glob match exceeded the expected memoized runtime");
   }
 }
 

--- a/test/cpp/scan/test_utils.hpp
+++ b/test/cpp/scan/test_utils.hpp
@@ -21,6 +21,7 @@
 
 // sirius
 #include "memory/sirius_memory_reservation_manager.hpp"
+#include "memory/topology_index.hpp"
 
 // data representations
 #include <data/data_batch_utils.hpp>
@@ -30,6 +31,7 @@
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
+#include <cucascade/memory/topology_discovery.hpp>
 #include <data/sirius_converter_registry.hpp>
 #include <helper/helper.hpp>
 
@@ -87,6 +89,15 @@ inline std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> initia
   // Initialize converters used by data representations
   sirius::converter_registry::initialize();
   return manager;
+}
+
+inline std::shared_ptr<const sirius::memory::topology_index> discover_topology_index(
+  const sirius::memory::sirius_memory_reservation_manager& manager)
+{
+  cucascade::memory::system_topology_info topology;
+  cucascade::memory::topology_discovery discovery;
+  if (discovery.discover()) { topology = discovery.get_topology(); }
+  return std::make_shared<sirius::memory::topology_index>(std::move(topology), manager);
 }
 
 namespace sirius::scan_test_utils {

--- a/test/cpp/scan_manager/test_describe_parquet_s3.cpp
+++ b/test/cpp/scan_manager/test_describe_parquet_s3.cpp
@@ -24,7 +24,6 @@
 #include "scan_manager/sirius_scan_manager.hpp"
 #include "utils/s3_container.hpp"
 
-#include <cucascade/memory/topology_discovery.hpp>
 #include <duckdb.hpp>
 
 #include <cstdint>
@@ -60,27 +59,10 @@ std::string require_env(std::string const& name)
   return value;
 }
 
-cucascade::memory::system_topology_info single_gpu_topology()
-{
-  cucascade::memory::system_topology_info topology;
-  topology.num_gpus = 1;
-  cucascade::memory::gpu_topology_info gpu;
-  gpu.id        = 0;
-  gpu.numa_node = 0;
-  topology.gpus.push_back(std::move(gpu));
-  return topology;
-}
-
-std::shared_ptr<const sirius::memory::topology_index> single_gpu_index()
-{
-  return std::make_shared<sirius::memory::topology_index>(single_gpu_topology(),
-                                                          std::vector<int>{0});
-}
-
 struct scan_manager_fixture {
   std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory =
     initialize_memory_manager(1);
-  std::shared_ptr<const sirius::memory::topology_index> topology = single_gpu_index();
+  std::shared_ptr<const sirius::memory::topology_index> topology = discover_topology_index(*memory);
 };
 
 scan_manager_config make_minio_rest_config(bool perf_instrumentation = false)

--- a/test/cpp/scan_manager/test_s3_routing_cutover.cpp
+++ b/test/cpp/scan_manager/test_s3_routing_cutover.cpp
@@ -38,7 +38,6 @@
 #include <rmm/device_buffer.hpp>
 
 #include <arpa/inet.h>
-#include <cucascade/memory/topology_discovery.hpp>
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/time.h>
@@ -151,23 +150,6 @@ bool is_local_backend(std::optional<io_context_type> type)
   return type.has_value() && (*type == io_context_type::uring || *type == io_context_type::kvikio);
 }
 
-cucascade::memory::system_topology_info single_gpu_topology()
-{
-  cucascade::memory::system_topology_info topology;
-  topology.num_gpus = 1;
-  cucascade::memory::gpu_topology_info gpu;
-  gpu.id        = 0;
-  gpu.numa_node = 0;
-  topology.gpus.push_back(std::move(gpu));
-  return topology;
-}
-
-std::shared_ptr<const sirius::memory::topology_index> single_gpu_index()
-{
-  return std::make_shared<sirius::memory::topology_index>(single_gpu_topology(),
-                                                          std::vector<int>{0});
-}
-
 scan_manager_config make_s3_scan_config(std::string endpoint, bool use_sirius_datasource)
 {
   scan_manager_config cfg{};
@@ -194,7 +176,7 @@ scan_manager_config make_s3_scan_config(std::string endpoint, bool use_sirius_da
 struct scan_manager_fixture {
   std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory =
     initialize_memory_manager(1);
-  std::shared_ptr<const sirius::memory::topology_index> topology = single_gpu_index();
+  std::shared_ptr<const sirius::memory::topology_index> topology = discover_topology_index(*memory);
 };
 
 std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info> make_nation_table_info(


### PR DESCRIPTION
Guard the glob matcher memo against backtracking blowup

The S3 glob matcher, match_glob_segments in src/io/s3/sirius_httpfs.cpp, memoizes on (key_index, pattern_index). Drop that memo and matching a pattern with several ** segments against a deep key goes exponential — the function comment says as much. Nothing tested it, so a refactor that broke the memo would pass review and CI and only show up in production as a hang on one particular pattern shape.

This pins the behavior with a regression test.

The load-bearing case globs stress/**/**/.../**/x.parquet (ten **) against a 30-segment key that ends in y.parquet. The tail mismatch is deliberate: to conclude "no match" the matcher has to exhaust every way of splitting the 28 middle segments across the ten ** groups — about 124 million arrangements — which is exactly what the memo folds down to a few hundred states. With the memo it returns in well under a millisecond; without it the test hangs. The elapsed time is logged and a soft warning fires past one second, but the assertion is only that the call returns and returns empty, so there is no wall-clock flake.

The same case also checks the ** semantics against fixed keys: zero- and multi-segment **, leading and trailing **, and * / ? / [...] mixed into a segment next to a spanning **, asserting both the keys that should match and the near-misses that shouldn't (wrong prefix, wrong character class, extra trailing character, wrong extension).

Test only, no production change. It uses the in-process fake LIST server, so it needs no bucket and no network. 
Runs in the normal suite under [s3][filesystem][glob] (make s3-test) and adds one Catch2 case.