### PR TITLE
feat(bypass): skip partition stages for small whole-query scans (#990)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,6 +610,7 @@ set(TEST_SOURCES
     test/cpp/integration/test_gpu_execution_locality.cpp
     test/cpp/integration/test_gpu_execution_multi_format.cpp
     test/cpp/integration/test_gpu_execution_order_nulls.cpp
+    test/cpp/integration/test_gpu_execution_small_query_bypass.cpp
     test/cpp/integration/test_gpu_execution_tpch.cpp
     test/cpp/integration/test_gpu_execution_tpch_mgpu_audit.cpp
     test/cpp/integration/test_pin_table_host_streaming.cpp
@@ -692,6 +693,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_pipeline_schedule_canonical.cpp
     test/cpp/pipeline/test_plan_printer.cpp
     test/cpp/pipeline/test_repository_wiring_materializer.cpp
+    test/cpp/pipeline/test_small_query_bypass_converter.cpp
     test/cpp/pipeline/test_task_scheduler.cpp
     test/cpp/scan/bench_decode_codecs.cpp
     test/cpp/scan/test_can_serve_with_columns.cpp

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -90,6 +90,7 @@ sirius:
     hash_partition_bytes:       805306368   # 768 MiB
     concat_batch_bytes:         805306368   # 768 MiB
     max_build_hash_table_bytes: 805306368   # 768 MiB
+    small_query_bytes_threshold: 256MiB      # default; 0 disables
     enable_dynamic_filter_pushdown: true    # BUILD_PROBE raw/hash IN-list or Bloom filters
     enable_dynamic_zone_map_filter: false  # optional parquet-read/native-post-decode min/max
     dynamic_filter_domain_coverage_threshold: 0.9  # skip keys the build's domain coverage exceeds
@@ -351,11 +352,33 @@ Four optional nested sub-configs tune the individual backends and caches:
 | `max_broadcast_join_size` | 256 MB | Max build-side size eligible for a broadcast join. A build below this size is replicated to every GPU (instead of hash-partitioned) when it is tiny, or when the DuckDB-estimated probe-to-build row ratio is at least `num_gpus * 1.25`. |
 | `max_sort_partition_memory_fraction` | 0.33 | Fraction of GPU memory per sort partition when `max_sort_partition_bytes` is 0 |
 | `mark_join_build_switch_ratio` | 8.0 | For STANDARD MARK joins, build on the smaller (left) side when `right_rows >= ratio * left_rows` (0 disables) |
+| `small_query_bytes_threshold` | 256 MiB | Skip partition and sort-sampling stages when the summed estimated base-scan bytes are below the effective threshold; 0 disables. |
 | `enable_dynamic_filter_pushdown` | true | Master switch for dynamic table-filter pushdown. An eligible `BUILD_PROBE` hash-join build selects a raw exact IN-list for 1–12 supported build rows, otherwise a hash IN-list if it fits the smallest probe-GPU L2 or a Bloom, for post-decode application by the probe scan. |
 | `enable_dynamic_zone_map_filter` | false | Additionally publish build-key min/max bounds. Parquet scans use them for read-time row-group pruning; duckdb-native scans apply them row-wise post-decode. Requires `enable_dynamic_filter_pushdown`; intended for clustered-keyset workloads. |
 | `dynamic_filter_domain_coverage_threshold` | 0.9 | Skip publishing a key's dynamic filters when the build covers at least this fraction of the key's domain; ≥ 1.0 effectively disables the gate. |
 | `dynamic_filter_keep_threshold` | 0.9 | Disable a probe scan's post-decode dynamic filtering once a measured split keeps more than this fraction of its rows; in [0, 1], 1.0 keeps filtering always on. |
 | `enable_pinned_zone_map_pruning` | true | Capture per-chunk min/max statistics while pinning and use them to skip cached chunks that cannot match a scan filter. |
+
+`small_query_bytes_threshold` is enabled by default. Its effective value is clamped to
+`scan_task_batch_size`, and bypass activates only when the estimate is strictly below that value.
+The estimate sums each base scan's `cardinality × projected row width`: fixed-width columns use
+their exact byte size, VARCHAR columns use the maximum string length from column statistics (and
+the query is ineligible when that statistic is unavailable, rather than assuming a flat width), and
+`COLUMN_DATA_SCAN` sources (e.g. `VALUES`) are measured from their materialized size. CTE,
+delim-join, recursive, nested-type, and overflowing estimates are ineligible. When more than one
+GPU is configured, any plan containing a hash or nested-loop join is also ineligible: the bypass
+runs the whole query on a single partition (GPU 0), so a join that amplifies its output is kept on
+the partitioned path, which spreads that output across GPUs and keeps each cuDF gather under the
+per-column row limit. The bypass removes `PARTITION`, `SORT_SAMPLE`, and `SORT_PARTITION`, but
+retains CONCAT and merge operators for correctness. Bypassed joins remain in STANDARD mode, so
+BUILD_PROBE selection and dynamic-filter publication do not run.
+
+The gate bounds only base-scan *input* bytes; it does not model join or aggregate *output* fan-out.
+The multi-GPU join exclusion above removes the case where the bypass would concentrate an amplified
+join result onto one GPU that the partitioned path would have distributed. A single-GPU run has no
+such distributed alternative, so there an amplifying join (or a materialized side folded by
+`concat_all`) carries the same per-gather memory / cuDF row limits as the normal path — raise the
+threshold with that in mind.
 
 **Note:** `max_build_hash_table_bytes` can be larger than `concat_batch_bytes`. When it is, the partition operator configures CONCAT to concatenate all batches, enabling the more efficient BUILD_PROBE join mode for larger build sides. Other joins (STANDARD, MIXED) still use `concat_batch_bytes` as the batch size threshold.
 
@@ -526,6 +549,15 @@ These can also be set at load via the `SIRIUS_LOG_BACKEND`, `SIRIUS_LOG_DIR`, an
 | `max_build_hash_table_bytes` | 500 MB | Max build-side hash table bytes |
 | `max_broadcast_join_size` | 256 MB | Max build-side size eligible for a broadcast join |
 | `mark_join_build_switch_ratio` | 8.0 | STANDARD MARK join build-side switch ratio (0 disables) |
+| `small_query_bytes_threshold` | 256 MiB | Whole-query base-scan byte threshold for skipping partition and sort-sampling stages; clamped to `scan_task_batch_size`; 0 disables. |
+
+```sql
+-- The bypass is enabled at 256 MiB by default. Change the threshold if needed.
+SET small_query_bytes_threshold = 134217728; -- 128 MiB
+
+-- Disable the bypass.
+SET small_query_bytes_threshold = 0;
+```
 
 ### Dynamic Filters
 

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -61,6 +61,10 @@ constexpr double DEFAULT_MAX_SORT_PARTITION_MEMORY_FRACTION = 0.33;
 /// disable (always use filtered_join).
 constexpr double DEFAULT_MARK_JOIN_BUILD_SWITCH_RATIO = 8.0;
 
+/// Default for operator_params::small_query_bytes_threshold (issue #990): enabled at 256 MiB,
+/// set to 0 to disable.
+constexpr uint64_t DEFAULT_SMALL_QUERY_BYTES_THRESHOLD = 256ULL * 1024 * 1024;
+
 }  // namespace config
 
 /// Parameters controlling operator-level resource sizing.
@@ -130,6 +134,16 @@ struct operator_params {
   /// pin-time statistics capture and the serve-side survivor plan: a table pinned while the flag is
   /// off carries no zone maps and cannot prune until re-pinned with the flag on.
   bool enable_pinned_zone_map_pruning = true;
+
+  /// Whole-query small-data gate (issue #990): when the summed estimated bytes across all base
+  /// scans is below this threshold (clamped to scan_task_batch_size so every scan is single-batch),
+  /// the plan generator skips PARTITION / SORT_SAMPLE / SORT_PARTITION and wires producers into the
+  /// terminal CONCAT / MERGE operators (kept for AVG / COUNT(DISTINCT) / OFFSET finalization and to
+  /// absorb estimate misses). 0 disables. Ineligible: CTE / delim / recursive plans, VARCHAR scans
+  /// without a max-length statistic, and — on multi-GPU — any plan with a join. Bypassed joins stay
+  /// STANDARD (no BUILD_PROBE / dynamic filters). The estimate models leaf-scan input only, not
+  /// join / aggregate output fan-out.
+  uint64_t small_query_bytes_threshold = config::DEFAULT_SMALL_QUERY_BYTES_THRESHOLD;
 };
 
 struct telemetry_config {

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -43,16 +43,17 @@ sirius_physical_concat::sirius_physical_concat(duckdb::vector<sirius::logical_ty
     auto hash_join = dynamic_cast<sirius_physical_hash_join*>(downstream_join);
     if (hash_join->join_type == duckdb::JoinType::LEFT ||
         hash_join->join_type == duckdb::JoinType::ANTI ||
-        hash_join->join_type == duckdb::JoinType::SEMI) {
-      // if the join type is left or anti, then we need to concat all the batches into one batch for
-      // the build side
+        hash_join->join_type == duckdb::JoinType::SEMI ||
+        hash_join->join_type == duckdb::JoinType::MARK) {
+      // LEFT/ANTI/SEMI need the complete build side to preserve their global join semantics.
+      // MARK also emits every probe row once with one existence result across the entire build
+      // relation; processing separate build batches would emit the probe rows once per batch.
       _concat_all = is_build;
     } else if (hash_join->is_right_family()) {
       // if the join type is right or right anti, then we need to concat all the batches into one
       // batch for the probe side
       _concat_all = !is_build;
-    } else if (hash_join->join_type == duckdb::JoinType::INNER ||
-               hash_join->join_type == duckdb::JoinType::MARK) {
+    } else if (hash_join->join_type == duckdb::JoinType::INNER) {
       _concat_all = false;
     } else if (hash_join->join_type == duckdb::JoinType::OUTER) {
       _concat_all = true;
@@ -173,13 +174,20 @@ std::unique_ptr<operator_data> sirius_physical_concat::execute(const operator_da
                                                                rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_concat::execute"};
-  auto partitioned_input_data = dynamic_cast<const partitioned_operator_data*>(&input_data);
-  if (partitioned_input_data == nullptr) {
+  // Normal path: input is a partitioned_operator_data produced by an upstream PARTITION. The
+  // small-query bypass (issue #990) omits PARTITION, so CONCAT streams the producer's batches
+  // directly (a single scan batch, guaranteed by the gate's single-batch clamp). Accept any
+  // pipelineable_operator_data and treat unpartitioned input as partition 0, matching the hash
+  // join's "unpartitioned pushes land in partition 0 on both sides" contract.
+  auto pipelineable_input_data = dynamic_cast<const pipelineable_operator_data*>(&input_data);
+  if (pipelineable_input_data == nullptr) {
     throw std::runtime_error(
-      "sirius_physical_concat: input_data is not a partitioned_operator_data");
+      "sirius_physical_concat: input_data is not a pipelineable_operator_data");
   }
-  const auto& input_batches = partitioned_input_data->get_read_only_batches();
-  auto partition_idx        = partitioned_input_data->get_partition_idx();
+  auto partitioned_input_data = dynamic_cast<const partitioned_operator_data*>(&input_data);
+  const auto& input_batches   = pipelineable_input_data->get_read_only_batches();
+  const std::size_t partition_idx =
+    partitioned_input_data != nullptr ? partitioned_input_data->get_partition_idx() : 0;
   if (input_batches.empty()) {
     return std::make_unique<partitioned_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{}, partition_idx);

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -853,6 +853,10 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
 
   // One-time initialization: snapshot all batch IDs from both ports.
   if (left_batch_ids.empty() && right_batch_ids.empty()) {
+    // Both ports must agree on partition count. This holds with PARTITION stages (siblings
+    // negotiate one count) and in the small-query bypass (unpartitioned pushes land in
+    // partition 0 on both sides). A repository never drops below its default of 1 partition, so
+    // an empty side reports 1 (not 0) and still matches a non-empty side that also stayed at 1.
     if (ports["default"]->repo->num_partitions() != ports["build"]->repo->num_partitions()) {
       throw std::runtime_error(
         "In sirius_physical_hash_join:Number of partitions for left and right ports must be the "

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -199,7 +199,14 @@ op::MemoryBarrierType sirius_pipeline_converter::resolve_barrier(
   // Sort sinks process batches as they arrive. GPU_SCAN is intentionally excluded
   // (legacy gives it FULL/PARTIAL, not PIPELINE); SORT_SAMPLE is never a pipeline
   // sink (it runs as an intermediate in the SORT_PARTITION pipeline).
-  if (sink.type == T::ORDER_BY) { return op::MemoryBarrierType::PIPELINE; }
+  // Small-query bypass (issue #990): ORDER_BY's tree parent is MERGE_SORT directly
+  // (no SORT_SAMPLE/SORT_PARTITION) — merge must wait for ALL local sorts (FULL).
+  if (sink.type == T::ORDER_BY) {
+    if (dest.get_sink() && dest.get_sink()->type == T::MERGE_SORT) {
+      return op::MemoryBarrierType::FULL;
+    }
+    return op::MemoryBarrierType::PIPELINE;
+  }
   // Producers that feed CONCAT can drain incrementally (PARTIAL); otherwise wait
   // for the upstream pipeline to finish (FULL).
   if (sink.type == T::PARTITION || sink.type == T::UNGROUPED_AGGREGATE || sink.type == T::TOP_N ||
@@ -422,10 +429,27 @@ void sirius_pipeline_converter::link_join_partition_siblings()
     // both can stream the probe, so the upstream→probe-partition edge is PARTIAL for both.
     if (pipeline->source->type == op::SiriusPhysicalOperatorType::HASH_JOIN ||
         pipeline->source->type == op::SiriusPhysicalOperatorType::NESTED_LOOP_JOIN) {
-      auto build_concat_pipeline    = pipeline->dependencies[0];
+      D_ASSERT(pipeline->dependencies.size() >= 2);
+      if (pipeline->dependencies.size() < 2) { continue; }
+
+      auto build_concat_pipeline = pipeline->dependencies[0];
+      auto probe_concat_pipeline = pipeline->dependencies[1];
+      // Small-query bypass (issue #990): no PARTITION stages — concat pipelines hang
+      // directly off the raw producers. A producer that fits in the CONCAT pipeline leaves
+      // that pipeline with no dependencies, so check before looking for its PARTITION parent.
+      if (build_concat_pipeline->dependencies.empty() ||
+          probe_concat_pipeline->dependencies.empty()) {
+        continue;
+      }
+
       auto build_partition_pipeline = build_concat_pipeline->dependencies[0];
-      auto probe_concat_pipeline    = pipeline->dependencies[1];
       auto probe_partition_pipeline = probe_concat_pipeline->dependencies[0];
+      using T                       = op::SiriusPhysicalOperatorType;
+      const bool build_has_partition =
+        build_partition_pipeline->get_sink()->type == T::PARTITION ||
+        build_partition_pipeline->get_sink()->type == T::RIGHT_DELIM_JOIN;
+      const bool probe_has_partition = probe_partition_pipeline->get_sink()->type == T::PARTITION;
+      if (!build_has_partition || !probe_has_partition) { continue; }
       // Positional roles are guaranteed by finalize_pipeline_structure() (tree path) /
       // emission order (legacy). A swap here mislinks sibling partitions and, for
       // right-family joins, drives_partition_count.

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -31,6 +31,8 @@
 #include "duckdb/planner/operator/list.hpp"
 #include "duckdb/planner/operator/logical_extension_operator.hpp"
 #include "duckdb/planner/table_filter.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/storage/statistics/string_stats.hpp"
 #include "duckdb/storage/storage_manager.hpp"
 #include "log/logging.hpp"
 #include "op/scan/duckdb_native_gpu_ingestible.hpp"
@@ -60,12 +62,31 @@
 #include "sirius_config.hpp"
 #include "sirius_context.hpp"
 
+#include <algorithm>
+#include <limits>
 #include <numeric>
+#include <optional>
 #include <utility>
 
 namespace sirius::planner {
 
 namespace {
+
+constexpr bool uint64_add_overflows(uint64_t lhs, uint64_t rhs)
+{
+  return rhs > std::numeric_limits<uint64_t>::max() - lhs;
+}
+
+constexpr bool uint64_multiply_overflows(uint64_t lhs, uint64_t rhs)
+{
+  return lhs != 0 && rhs > std::numeric_limits<uint64_t>::max() / lhs;
+}
+
+static_assert(uint64_add_overflows(std::numeric_limits<uint64_t>::max(), 1));
+static_assert(!uint64_add_overflows(std::numeric_limits<uint64_t>::max() - 1, 1));
+static_assert(uint64_multiply_overflows(uint64_t{1} << 63, 2));
+static_assert(!uint64_multiply_overflows(std::numeric_limits<uint64_t>::max(), 1));
+
 bool is_nested_logical_type(duckdb::LogicalType const& type)
 {
   auto const id = type.id();
@@ -80,6 +101,165 @@ bool dynamic_filter_pushdown_enabled(duckdb::ClientContext& context)
   auto state = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
   if (!state) { return false; }
   return state->get_config().get_operator_params().enable_dynamic_filter_pushdown;
+}
+
+/// The effective single-batch size cap. `scan_task_batch_size == 0` is the "use the default"
+/// sentinel elsewhere in this pass (replace_with_gpu_values, scan-source wiring), so the
+/// small-query gate honors it too — otherwise setting it to 0 would make every scan compare
+/// `>= 0` (always ineligible) and zero the threshold, silently disabling the bypass.
+uint64_t effective_scan_task_batch_size(const sirius::operator_params& op_params)
+{
+  return op_params.scan_task_batch_size == 0 ? sirius::config::DEFAULT_SCAN_TASK_BATCH_SIZE
+                                             : op_params.scan_task_batch_size;
+}
+
+/// Conservative per-row byte width of a scan's VARCHAR column `col`, derived from its table
+/// statistics' maximum string length (which is >= the average, so this never under-counts).
+/// Returns nullopt when no reliable bound is available so the caller can fail closed rather than
+/// fall back to a flat estimate that under-counts wide-text columns (issue #990). Handles both the
+/// plain `statistics` callback (parquet: column_t index) and `statistics_extended` (duck tables:
+/// ColumnIndex).
+std::optional<uint64_t> scan_varchar_max_bytes(op::sirius_physical_table_scan& scan_op,
+                                               duckdb::ClientContext& context,
+                                               const duckdb::ColumnIndex& col)
+{
+  if (!scan_op.bind_data || !col.HasPrimaryIndex()) { return std::nullopt; }
+  duckdb::unique_ptr<duckdb::BaseStatistics> stats;
+  if (scan_op.function.statistics_extended) {
+    duckdb::TableFunctionGetStatisticsInput input(scan_op.bind_data.get(), col);
+    stats = scan_op.function.statistics_extended(context, input);
+  } else if (scan_op.function.statistics) {
+    stats = scan_op.function.statistics(context, scan_op.bind_data.get(), col.GetPrimaryIndex());
+  }
+  if (!stats || !duckdb::StringStats::HasMaxStringLength(*stats)) { return std::nullopt; }
+  return static_cast<uint64_t>(duckdb::StringStats::MaxStringLength(*stats));
+}
+
+/// Sums estimated output bytes of every base scan (TABLE_SCAN metadata estimate +
+/// COLUMN_DATA_SCAN exact materialized size) for the whole-query small-data gate (issue #990).
+/// Returns nullopt when the query is ineligible: delim joins / CTEs (data recirculation is not
+/// bounded by scan metadata), scans with non-fixed-width non-VARCHAR columns, any single scan
+/// whose estimate reaches scan_task_batch_size, or any other unmeasured leaf source (a childless
+/// operator other than the data-free EMPTY_RESULT / DUMMY_SCAN).
+std::optional<uint64_t> estimate_base_scan_bytes(op::sirius_physical_operator& plan,
+                                                 duckdb::ClientContext& context,
+                                                 const sirius::operator_params& op_params)
+{
+  using op::SiriusPhysicalOperatorType;
+  switch (plan.type) {
+    case SiriusPhysicalOperatorType::LEFT_DELIM_JOIN:
+    case SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN:
+    case SiriusPhysicalOperatorType::RECURSIVE_CTE:
+    case SiriusPhysicalOperatorType::RECURSIVE_KEY_CTE:
+    case SiriusPhysicalOperatorType::CTE:
+    case SiriusPhysicalOperatorType::RECURSIVE_CTE_SCAN:
+    case SiriusPhysicalOperatorType::RECURSIVE_RECURRING_CTE_SCAN:
+    case SiriusPhysicalOperatorType::CTE_SCAN:
+    case SiriusPhysicalOperatorType::DELIM_SCAN: return std::nullopt;
+    case SiriusPhysicalOperatorType::RESULT_COLLECTOR:
+      return estimate_base_scan_bytes(
+        plan.Cast<op::sirius_physical_result_collector>().plan, context, op_params);
+    case SiriusPhysicalOperatorType::TABLE_SCAN: {
+      auto& scan_op = plan.Cast<op::sirius_physical_table_scan>();
+      // Prefer the table function's own estimate: exact for parquet (footer counts) and duck
+      // tables, and pre-filter (a filtered scan can only produce less).
+      uint64_t rows = scan_op.estimated_cardinality;
+      if (scan_op.function.cardinality && scan_op.bind_data) {
+        auto stats = scan_op.function.cardinality(context, scan_op.bind_data.get());
+        if (stats && stats->has_estimated_cardinality) { rows = stats->estimated_cardinality; }
+      }
+      uint64_t row_width = 0;
+      for (std::size_t i = 0; i < scan_op.types.size(); ++i) {
+        const auto& type = scan_op.types[i];
+        uint64_t column_width;
+        if (type.id() == sirius::type_id::VARCHAR) {
+          // Map the projected output column to its table ColumnIndex, then take the stats-derived
+          // max width. A flat estimate would under-count wide-text columns and break the
+          // single-batch invariant, so fail closed when a reliable bound is unavailable.
+          std::size_t col_ids_idx = i;
+          if (!scan_op.projection_ids.empty()) {
+            if (i >= scan_op.projection_ids.size()) { return std::nullopt; }
+            col_ids_idx = scan_op.projection_ids[i];
+          }
+          if (col_ids_idx >= scan_op.column_ids.size()) { return std::nullopt; }
+          auto max_bytes =
+            scan_varchar_max_bytes(scan_op, context, scan_op.column_ids[col_ids_idx]);
+          if (!max_bytes) { return std::nullopt; }
+          column_width = *max_bytes;
+        } else if (type.is_fixed_width()) {
+          column_width = type.fixed_width_byte_size();
+        } else {
+          return std::nullopt;  // nested / unknown-width column: ineligible
+        }
+        if (uint64_add_overflows(row_width, column_width)) { return std::nullopt; }
+        row_width += column_width;
+      }
+      if (uint64_multiply_overflows(row_width, rows)) { return std::nullopt; }
+      // Floor at one cardinality-sentinel byte per row so a zero-column projection (e.g. a bare
+      // COUNT(*) scan, row_width == 0) is not scored as 0 bytes at any cardinality -- mirroring the
+      // COLUMN_DATA_SCAN case below. For row_width >= 1 this is a no-op (rows * row_width >= rows).
+      const uint64_t bytes = std::max<uint64_t>(rows * row_width, rows);
+      // Each scan must stay single-batch for the bypass reasoning to hold.
+      if (bytes >= effective_scan_task_batch_size(op_params)) { return std::nullopt; }
+      return bytes;
+    }
+    case SiriusPhysicalOperatorType::COLUMN_DATA_SCAN: {
+      auto& col_scan = plan.Cast<op::sirius_physical_column_data_scan>();
+      // A null collection is the LEFT_DELIM_JOIN cached chunk / CTE scan (data filled at
+      // runtime, not bounded by metadata) — ineligible. Otherwise the collection is fully
+      // materialized, so measure it exactly with the same metric the GPU source-size gate
+      // uses (throw_if_collection_too_large): a zero-column collection still needs one
+      // cardinality-sentinel byte per row on the GPU.
+      if (!col_scan.collection) { return std::nullopt; }
+      const auto& coll    = *col_scan.collection;
+      const uint64_t rows = coll.Count();
+      const uint64_t bytes =
+        coll.Types().empty() ? std::max<uint64_t>(coll.SizeInBytes(), rows) : coll.SizeInBytes();
+      // Single-batch invariant, matching the TABLE_SCAN branch.
+      if (bytes >= effective_scan_task_batch_size(op_params)) { return std::nullopt; }
+      return bytes;
+    }
+    default: {
+      // A childless operator is a leaf source. Data-carrying leaves are measured by their own case
+      // above (TABLE_SCAN, COLUMN_DATA_SCAN — the latter also backs VALUES / EXPRESSION_SCAN). Only
+      // the data-free EMPTY_RESULT / DUMMY_SCAN score 0 here; any other unrecognized leaf is
+      // fail-closed to ineligible rather than silently scored as 0, which would break the gate.
+      if (plan.children.empty()) {
+        switch (plan.type) {
+          case SiriusPhysicalOperatorType::EMPTY_RESULT:
+          case SiriusPhysicalOperatorType::DUMMY_SCAN: return uint64_t{0};
+          default: return std::nullopt;
+        }
+      }
+      uint64_t total = 0;
+      for (auto& child : plan.children) {
+        auto child_bytes = estimate_base_scan_bytes(*child, context, op_params);
+        if (!child_bytes) { return std::nullopt; }
+        if (uint64_add_overflows(total, *child_bytes)) { return std::nullopt; }
+        total += *child_bytes;
+      }
+      return total;
+    }
+  }
+}
+
+/// Whether the plan tree contains a hash join or nested-loop join. Only the bypass-eligible spine
+/// is walked (children[] + the result collector's plan); delim/CTE plans are already excluded by
+/// estimate_base_scan_bytes, so their out-of-children[] subtrees need not be visited here.
+bool plan_contains_join(const op::sirius_physical_operator& plan)
+{
+  using op::SiriusPhysicalOperatorType;
+  if (plan.type == SiriusPhysicalOperatorType::HASH_JOIN ||
+      plan.type == SiriusPhysicalOperatorType::NESTED_LOOP_JOIN) {
+    return true;
+  }
+  if (plan.type == SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
+    return plan_contains_join(plan.Cast<op::sirius_physical_result_collector>().plan);
+  }
+  for (const auto& child : plan.children) {
+    if (child && plan_contains_join(*child)) { return true; }
+  }
+  return false;
 }
 
 //! Insert `factory(std::move(parent.children[i]))` between `parent` and its i-th child. The
@@ -355,26 +535,34 @@ void replace_with_gpu_values(duckdb::unique_ptr<sirius::op::sirius_physical_oper
 
 //! Replace a HASH_GROUP_BY slot with `GROUPED_AGGREGATE_MERGE → PARTITION → HASH_GROUP_BY →
 //! original_input`: the original stays the per-thread sink, PARTITION buckets for the merge.
+//! Small-query bypass skips PARTITION and wires MERGE → HASH_GROUP_BY directly (same shape as
+//! UNGROUPED_AGGREGATE).
 void wrap_hash_group_by(duckdb::unique_ptr<sirius::op::sirius_physical_operator>& slot,
-                        const sirius::operator_params& op_params)
+                        const sirius::operator_params& op_params,
+                        bool small_query_bypass)
 {
   wrap_above(slot, [&](duckdb::unique_ptr<sirius::op::sirius_physical_operator> hgb_op) {
     auto* hgb_ptr = hgb_op.get();
 
-    auto partition =
-      duckdb::make_uniq<sirius::op::sirius_physical_partition>(hgb_ptr->types,
-                                                               hgb_ptr->estimated_cardinality,
-                                                               /*key_source=*/hgb_ptr,
-                                                               /*is_build=*/false);
-    auto* partition_ptr = partition.get();
-    partition->children.push_back(std::move(hgb_op));
-
     auto merge = duckdb::make_uniq<sirius::op::sirius_physical_grouped_aggregate_merge>(
       &hgb_ptr->Cast<sirius::op::sirius_physical_grouped_aggregate>(),
       op_params.hash_partition_bytes);
-    // The partition's downstream sizing consumer is the merge (key_source hgb only supplies keys).
-    partition_ptr->set_downstream_consumer_op(merge.get());
-    merge->children.push_back(std::move(partition));
+
+    if (small_query_bypass) {
+      merge->children.push_back(std::move(hgb_op));
+    } else {
+      auto partition =
+        duckdb::make_uniq<sirius::op::sirius_physical_partition>(hgb_ptr->types,
+                                                                 hgb_ptr->estimated_cardinality,
+                                                                 /*key_source=*/hgb_ptr,
+                                                                 /*is_build=*/false);
+      auto* partition_ptr = partition.get();
+      partition->children.push_back(std::move(hgb_op));
+      // The partition's downstream sizing consumer is the merge (key_source hgb only supplies
+      // keys).
+      partition_ptr->set_downstream_consumer_op(merge.get());
+      merge->children.push_back(std::move(partition));
+    }
     return merge;
   });
 }
@@ -409,8 +597,10 @@ void wrap_top_n(duckdb::unique_ptr<sirius::op::sirius_physical_operator>& slot)
 //! column stays visible to SORT_SAMPLE / SORT_PARTITION; a non-identity original projection is
 //! restored on MERGE_SORT via `set_final_projections`. SORT_SAMPLE is a non-sink, so it lands
 //! in `operators[]` of the SORT_PARTITION pipeline (3-pipeline shape, matching legacy).
+//! Small-query bypass skips SORT_SAMPLE/SORT_PARTITION and wires MERGE_SORT → ORDER_BY.
 void wrap_order_by(duckdb::unique_ptr<sirius::op::sirius_physical_operator>& slot,
-                   const sirius::operator_params& op_params)
+                   const sirius::operator_params& op_params,
+                   bool small_query_bypass)
 {
   wrap_above(slot, [&](duckdb::unique_ptr<sirius::op::sirius_physical_operator> order_op) {
     auto* order_ptr = &order_op->Cast<sirius::op::sirius_physical_order>();
@@ -429,18 +619,6 @@ void wrap_order_by(duckdb::unique_ptr<sirius::op::sirius_physical_operator>& slo
     }
     order_ptr->projections = std::move(identity_proj);
     order_ptr->types       = child_types;
-
-    auto sample = duckdb::make_uniq<sirius::op::sirius_physical_sort_sample>(
-      order_ptr,
-      op_params.sort_sample_bytes,
-      op_params.max_sort_partition_bytes,
-      op_params.max_sort_partition_memory_fraction);
-    auto* sample_ptr = sample.get();
-    sample->children.push_back(std::move(order_op));
-
-    auto partition = duckdb::make_uniq<sirius::op::sirius_physical_sort_partition>(order_ptr);
-    partition->set_sample_op(sample_ptr);
-    partition->children.push_back(std::move(sample));
 
     auto merge = duckdb::make_uniq<sirius::op::sirius_physical_merge_sort>(order_ptr);
 
@@ -462,7 +640,23 @@ void wrap_order_by(duckdb::unique_ptr<sirius::op::sirius_physical_operator>& slo
       merge->set_final_projections(std::move(original_projections), std::move(output_types));
     }
 
-    merge->children.push_back(std::move(partition));
+    if (small_query_bypass) {
+      merge->children.push_back(std::move(order_op));
+    } else {
+      auto sample = duckdb::make_uniq<sirius::op::sirius_physical_sort_sample>(
+        order_ptr,
+        op_params.sort_sample_bytes,
+        op_params.max_sort_partition_bytes,
+        op_params.max_sort_partition_memory_fraction);
+      auto* sample_ptr = sample.get();
+      sample->children.push_back(std::move(order_op));
+
+      auto partition = duckdb::make_uniq<sirius::op::sirius_physical_sort_partition>(order_ptr);
+      partition->set_sample_op(sample_ptr);
+      partition->children.push_back(std::move(sample));
+
+      merge->children.push_back(std::move(partition));
+    }
     return merge;
   });
 }
@@ -470,10 +664,13 @@ void wrap_order_by(duckdb::unique_ptr<sirius::op::sirius_physical_operator>& slo
 //! Wrap `join_op.children[child_idx]` with `CONCAT → PARTITION → original_child`. `is_build`
 //! flips build/probe semantics in both wrappers; `join_op` is PARTITION's `key_source`
 //! (determines partition keys) and CONCAT's `downstream_join` (picks the coalescing mode).
+//! Small-query bypass keeps CONCAT (fold-to-one-batch / estimate-miss absorption) but skips
+//! PARTITION: `CONCAT → original_child`.
 void wrap_join_child(sirius::op::sirius_physical_operator& join_op,
                      std::size_t child_idx,
                      bool is_build,
-                     const sirius::operator_params& op_params)
+                     const sirius::operator_params& op_params,
+                     bool small_query_bypass)
 {
   D_ASSERT(join_op.type == sirius::op::SiriusPhysicalOperatorType::HASH_JOIN ||
            join_op.type == sirius::op::SiriusPhysicalOperatorType::NESTED_LOOP_JOIN);
@@ -490,13 +687,17 @@ void wrap_join_child(sirius::op::sirius_physical_operator& join_op,
                                                               /*downstream_join=*/join_op_ptr,
                                                               is_build,
                                                               op_params.concat_batch_bytes);
-      auto partition =
-        duckdb::make_uniq<sirius::op::sirius_physical_partition>(std::move(child_types),
-                                                                 est_card,
-                                                                 /*key_source=*/join_op_ptr,
-                                                                 is_build);
-      partition->children.push_back(std::move(child_orig));
-      concat->children.push_back(std::move(partition));
+      if (small_query_bypass) {
+        concat->children.push_back(std::move(child_orig));
+      } else {
+        auto partition =
+          duckdb::make_uniq<sirius::op::sirius_physical_partition>(std::move(child_types),
+                                                                   est_card,
+                                                                   /*key_source=*/join_op_ptr,
+                                                                   is_build);
+        partition->children.push_back(std::move(child_orig));
+        concat->children.push_back(std::move(partition));
+      }
       return concat;
     });
 }
@@ -504,13 +705,14 @@ void wrap_join_child(sirius::op::sirius_physical_operator& join_op,
 //! Wrap both children of a HASH_JOIN / NESTED_LOOP_JOIN with the CONCAT/PARTITION feeder
 //! chain: probe = children[0], build = children[1]. A missing side is skipped.
 void wrap_join(sirius::op::sirius_physical_operator& join_op,
-               const sirius::operator_params& op_params)
+               const sirius::operator_params& op_params,
+               bool small_query_bypass)
 {
   if (join_op.children.size() >= 1) {
-    wrap_join_child(join_op, /*child_idx=*/0, /*is_build=*/false, op_params);
+    wrap_join_child(join_op, /*child_idx=*/0, /*is_build=*/false, op_params, small_query_bypass);
   }
   if (join_op.children.size() >= 2) {
-    wrap_join_child(join_op, /*child_idx=*/1, /*is_build=*/true, op_params);
+    wrap_join_child(join_op, /*child_idx=*/1, /*is_build=*/true, op_params, small_query_bypass);
   }
 }
 
@@ -519,7 +721,8 @@ void wrap_join(sirius::op::sirius_physical_operator& join_op,
 void insert_gpu_pipeline_operators_recursive(
   duckdb::unique_ptr<sirius::op::sirius_physical_operator>& slot,
   const sirius::operator_params& op_params,
-  duckdb::ClientContext& context);
+  duckdb::ClientContext& context,
+  bool small_query_bypass);
 
 //! Replace a DELIM JOIN's `distinct_root` (the bare DISTINCT) with `DISTINCT_MERGE ->
 //! PARTITION_DISTINCT -> original DISTINCT`. The non-owning `delim_base.distinct` borrow stays
@@ -562,17 +765,23 @@ void wrap_delim_distinct(sirius::op::sirius_physical_delim_join& delim_base,
 //!   - RIGHT_DELIM_JOIN: point `partition_join` at the freshly-inserted build-side PARTITION.
 void wrap_delim_join(duckdb::unique_ptr<sirius::op::sirius_physical_operator>& slot,
                      const sirius::operator_params& op_params,
-                     duckdb::ClientContext& context)
+                     duckdb::ClientContext& context,
+                     bool small_query_bypass)
 {
+  // estimate_base_scan_bytes returns nullopt for any delim plan, so bypass is never true
+  // here. RIGHT_DELIM_JOIN::partition_join wiring below assumes a build-side PARTITION.
+  D_ASSERT(!small_query_bypass);
+
   auto& delim_base = slot->Cast<sirius::op::sirius_physical_delim_join>();
 
   if (delim_base.join) {
-    insert_gpu_pipeline_operators_recursive(delim_base.join, op_params, context);
+    insert_gpu_pipeline_operators_recursive(
+      delim_base.join, op_params, context, small_query_bypass);
   }
   if (delim_base.distinct_root) {
     // `distinct_root` still holds the bare DISTINCT: wrap below it first, then above.
     for (auto& child_slot : delim_base.distinct_root->children) {
-      insert_gpu_pipeline_operators_recursive(child_slot, op_params, context);
+      insert_gpu_pipeline_operators_recursive(child_slot, op_params, context, small_query_bypass);
     }
     wrap_delim_distinct(delim_base, op_params);
   }
@@ -603,12 +812,13 @@ void wrap_delim_join(duckdb::unique_ptr<sirius::op::sirius_physical_operator>& s
 void insert_gpu_pipeline_operators_recursive(
   duckdb::unique_ptr<sirius::op::sirius_physical_operator>& slot,
   const sirius::operator_params& op_params,
-  duckdb::ClientContext& context)
+  duckdb::ClientContext& context,
+  bool small_query_bypass)
 {
   if (!slot) { return; }
 
   for (auto& child_slot : slot->children) {
-    insert_gpu_pipeline_operators_recursive(child_slot, op_params, context);
+    insert_gpu_pipeline_operators_recursive(child_slot, op_params, context, small_query_bypass);
   }
 
   switch (slot->type) {
@@ -636,20 +846,22 @@ void insert_gpu_pipeline_operators_recursive(
       break;
     }
     case sirius::op::SiriusPhysicalOperatorType::HASH_GROUP_BY:
-      wrap_hash_group_by(slot, op_params);
+      wrap_hash_group_by(slot, op_params, small_query_bypass);
       break;
     case sirius::op::SiriusPhysicalOperatorType::UNGROUPED_AGGREGATE:
       wrap_ungrouped_aggregate(slot);
       break;
-    case sirius::op::SiriusPhysicalOperatorType::ORDER_BY: wrap_order_by(slot, op_params); break;
+    case sirius::op::SiriusPhysicalOperatorType::ORDER_BY:
+      wrap_order_by(slot, op_params, small_query_bypass);
+      break;
     case sirius::op::SiriusPhysicalOperatorType::TOP_N: wrap_top_n(slot); break;
     case sirius::op::SiriusPhysicalOperatorType::HASH_JOIN:
     case sirius::op::SiriusPhysicalOperatorType::NESTED_LOOP_JOIN:
-      wrap_join(*slot, op_params);
+      wrap_join(*slot, op_params, small_query_bypass);
       break;
     case sirius::op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN:
     case sirius::op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN:
-      wrap_delim_join(slot, op_params, context);
+      wrap_delim_join(slot, op_params, context, small_query_bypass);
       break;
     default: break;
   }
@@ -846,10 +1058,46 @@ void sirius_physical_plan_generator::insert_gpu_pipeline_operators(
   // Sink wraps need the sizing params from SiriusContext. If it's missing, default-constructed
   // op_params make the wraps fall back to the operators' own constructor defaults.
   sirius::operator_params op_params;
+  int num_gpus = 1;
   if (auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state")) {
     op_params = sirius_ctx->get_config().get_operator_params();
+    num_gpus  = static_cast<int>(sirius_ctx->get_config().get_hw_topology().gpus.size());
   }
-  insert_gpu_pipeline_operators_recursive(plan, op_params, context);
+
+  // Whole-query small-data gate (issue #990): decide before wrapping so PARTITION /
+  // SORT_SAMPLE / SORT_PARTITION stages are omitted from the tree. Clamped to
+  // scan_task_batch_size so each scan is guaranteed single-batch; retained CONCAT/MERGE
+  // operators absorb estimate misses. See operator_params::small_query_bytes_threshold
+  // for eligibility limits (CTE/delim excluded; leaf-scan estimate only; no BUILD_PROBE).
+  bool small_query_bypass = false;
+  if (op_params.small_query_bytes_threshold > 0) {
+    auto scan_bytes = estimate_base_scan_bytes(*plan, context, op_params);
+    const uint64_t effective_threshold =
+      std::min(op_params.small_query_bytes_threshold, effective_scan_task_batch_size(op_params));
+    if (scan_bytes && *scan_bytes < effective_threshold) {
+      // Multi-GPU join guard: the bypass emits no PARTITION, so set_num_gpus is never called and
+      // the whole query runs on one partition / GPU 0. A join can amplify its output far past its
+      // (sub-threshold) inputs; the partitioned path would hash-partition that blow-up across GPUs
+      // (each cudf gather under the 2^31-row limit), whereas the bypass would materialize one
+      // oversized gather on GPU 0 and crash. Keep join-bearing plans on the partitioned path when
+      // more than one GPU is available; single-GPU has no such distributed alternative to give up.
+      if (num_gpus > 1 && plan_contains_join(*plan)) {
+        SIRIUS_LOG_INFO(
+          "[sirius_physical_plan_generator] small-query bypass declined: plan has a join on {} "
+          "GPUs; keeping the partitioned path for output fan-out safety",
+          num_gpus);
+      } else {
+        small_query_bypass = true;
+        SIRIUS_LOG_INFO(
+          "[sirius_physical_plan_generator] small-query bypass active: estimated base scan bytes "
+          "{} < threshold {}; skipping partition stages",
+          *scan_bytes,
+          effective_threshold);
+      }
+    }
+  }
+
+  insert_gpu_pipeline_operators_recursive(plan, op_params, context, small_query_bypass);
 }
 
 sirius::OrderPreservationType sirius_physical_plan_generator::order_preservation_recursive(

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -191,6 +191,7 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
              opt.dynamic_filter_domain_coverage_threshold);
   r.optional("dynamic_filter_keep_threshold", opt.dynamic_filter_keep_threshold);
   r.optional("enable_pinned_zone_map_pruning", opt.enable_pinned_zone_map_pruning);
+  r.optional("small_query_bytes_threshold", yaml::bytes(opt.small_query_bytes_threshold));
   r.reject_unknown();
 }
 

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1657,6 +1657,15 @@ static void SetLogBackend(ClientContext& context, SetScope scope, Value& paramet
   SIRIUS_LOG_DEBUG("Updated config LOG_BACKEND to {}", Config::LOG_BACKEND);
 }
 
+static void SetSmallQueryBytesThreshold(ClientContext& context, SetScope scope, Value& parameter)
+{
+  auto* params = get_operator_params(context);
+  if (!params) { return; }
+  params->small_query_bytes_threshold = UBigIntValue::Get(parameter);
+  SIRIUS_LOG_DEBUG("Updated config SMALL_QUERY_BYTES_THRESHOLD to {}",
+                   params->small_query_bytes_threshold);
+}
+
 static void SetLogLevel(ClientContext& context, SetScope scope, Value& parameter)
 {
   Config::LOG_LEVEL = StringValue::Get(parameter);
@@ -1956,6 +1965,15 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
                             LogicalType::UBIGINT,
                             Value::UBIGINT(sirius::operator_params{}.sort_sample_bytes),
                             SetSortSampleBytes);
+
+  config.AddExtensionOption(
+    "small_query_bytes_threshold",
+    "Skip PARTITION / SORT_SAMPLE / SORT_PARTITION when summed estimated base-scan bytes "
+    "are below this threshold (default 256 MiB; 0 = disabled). CTE/delim plans are ineligible; "
+    "bypass uses STANDARD joins (no BUILD_PROBE / dynamic filters)",
+    LogicalType::UBIGINT,
+    Value::UBIGINT(sirius::operator_params{}.small_query_bytes_threshold),
+    SetSmallQueryBytesThreshold);
 
   config.AddExtensionOption("max_build_hash_table_bytes",
                             "Maximum size a build-side table can be where it will create a "

--- a/test/cpp/integration/test_gpu_execution_small_query_bypass.cpp
+++ b/test/cpp/integration/test_gpu_execution_small_query_bypass.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_gpu_execution_small_query_bypass.cpp
+ * @brief End-to-end correctness tests for the small-query bypass (issue #990).
+ *
+ * Primary Super Sirius coverage for this feature (Catch2 / GpuExecutionFixture).
+ * Pipeline structure assertions live in test_small_query_bypass_converter.cpp.
+ *
+ * By default, queries whose summed base-scan bytes fall under the 256 MiB
+ * `small_query_bytes_threshold` skip the partition stages (PARTITION,
+ * SORT_SAMPLE, SORT_PARTITION) at plan-generation time. These tests run a battery of
+ * queries over tiny tables — every one of them takes the bypass — through
+ * transparent GPU execution and compare against DuckDB CPU results. The battery
+ * deliberately covers the shapes whose correctness depends on the retained
+ * terminal operators: AVG and COUNT(DISTINCT) finalization (MERGE_GROUP_BY),
+ * OFFSET (MERGE_TOP_N), non-inner joins (build CONCAT fold), and an ORDER BY
+ * whose projection drops the sort key (MERGE_SORT final projection).
+ *
+ * A final test re-runs a subset with the threshold at 0 (bypass disabled) to
+ * confirm identical behavior on the normal partitioned path.
+ *
+ * Known limits of the gate (see operator_params::small_query_bytes_threshold):
+ * leaf-scan byte sum (no join blow-up model), CTE/delim excluded,
+ * STANDARD joins only (no BUILD_PROBE / dynamic filters on the bypass path).
+ */
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <utils/gpu_execution_fixture.hpp>
+
+#include <string>
+
+namespace {
+
+class SmallQueryBypassExecFixture : public sirius::test::GpuExecutionFixture {
+ public:
+  void create_test_tables()
+  {
+    run_ok("CREATE TABLE dim (id INTEGER, name VARCHAR);");
+    run_ok("INSERT INTO dim VALUES (1, 'a'), (2, 'b'), (3, 'c');");
+    run_ok("CREATE TABLE fact (dim_id INTEGER, qty INTEGER, price DOUBLE);");
+    run_ok("INSERT INTO fact VALUES (1, 10, 1.5), (1, 20, 2.5), (2, 30, 3.5), (4, 40, 4.5);");
+    run_ok("CHECKPOINT;");
+  }
+
+  void set_threshold_256mb() { run_ok("SET small_query_bytes_threshold = 268435456;"); }
+
+  void set_threshold_disabled() { run_ok("SET small_query_bytes_threshold = 0;"); }
+};
+
+}  // namespace
+
+TEST_CASE_METHOD(SmallQueryBypassExecFixture,
+                 "small-query bypass exec - aggregates (AVG, COUNT DISTINCT)",
+                 "[integration][gpu_execution][small_query_bypass]")
+{
+  create_test_tables();
+  set_threshold_256mb();
+
+  // AVG partial states (SUM + COUNT) are finalized in MERGE_GROUP_BY.
+  compare_gpu_vs_cpu(
+    "SELECT dim_id, AVG(qty), COUNT(*), SUM(qty) FROM fact GROUP BY dim_id ORDER BY dim_id;");
+  // COUNT(DISTINCT) collect-lists are finalized in MERGE_GROUP_BY. (Ungrouped distinct aggregates
+  // are unsupported on the GPU path — UNGROUPED_AGGREGATE, not MERGE_GROUP_BY — and orthogonal to
+  // the bypass, so only the grouped case is exercised here.)
+  compare_gpu_vs_cpu("SELECT dim_id, COUNT(DISTINCT qty) FROM fact GROUP BY dim_id;");
+  // Ungrouped aggregate (chain already minimal; must stay correct with the flag on).
+  compare_gpu_vs_cpu("SELECT SUM(qty), AVG(price) FROM fact;");
+
+  set_threshold_disabled();
+}
+
+TEST_CASE_METHOD(SmallQueryBypassExecFixture,
+                 "small-query bypass exec - order by and top-n with offset",
+                 "[integration][gpu_execution][small_query_bypass]")
+{
+  create_test_tables();
+  set_threshold_256mb();
+
+  // Projection drops the sort key: MERGE_SORT applies the final projection.
+  compare_gpu_vs_cpu("SELECT qty FROM fact ORDER BY dim_id DESC, qty DESC;");
+  compare_gpu_vs_cpu("SELECT dim_id, qty FROM fact ORDER BY qty;");
+  // OFFSET is applied only in MERGE_TOP_N.
+  compare_gpu_vs_cpu("SELECT qty FROM fact ORDER BY qty LIMIT 2 OFFSET 1;");
+  compare_gpu_vs_cpu("SELECT qty FROM fact ORDER BY qty DESC LIMIT 10 OFFSET 2;");
+
+  set_threshold_disabled();
+}
+
+TEST_CASE_METHOD(SmallQueryBypassExecFixture,
+                 "small-query bypass exec - join types",
+                 "[integration][gpu_execution][small_query_bypass]")
+{
+  create_test_tables();
+  set_threshold_256mb();
+
+  // INNER
+  compare_gpu_vs_cpu(
+    "SELECT d.name, f.qty FROM fact f JOIN dim d ON f.dim_id = d.id ORDER BY f.qty;");
+  // LEFT (unmatched probe rows must survive — needs the concat_all build fold)
+  compare_gpu_vs_cpu(
+    "SELECT f.qty, d.name FROM fact f LEFT JOIN dim d ON f.dim_id = d.id ORDER BY f.qty;");
+  // RIGHT (DuckDB plans it as a flipped LEFT join)
+  compare_gpu_vs_cpu(
+    "SELECT d.name, f.qty FROM fact f RIGHT JOIN dim d ON f.dim_id = d.id "
+    "ORDER BY d.name, f.qty;");
+  // SEMI via IN
+  compare_gpu_vs_cpu("SELECT qty FROM fact WHERE dim_id IN (SELECT id FROM dim) ORDER BY qty;");
+  // ANTI via NOT IN (dim.id has no NULLs)
+  compare_gpu_vs_cpu("SELECT qty FROM fact WHERE dim_id NOT IN (SELECT id FROM dim) ORDER BY qty;");
+  // MARK join (IN as a projected boolean)
+  compare_gpu_vs_cpu("SELECT id, id IN (SELECT dim_id FROM fact) FROM dim ORDER BY id;");
+
+  set_threshold_disabled();
+}
+
+TEST_CASE_METHOD(SmallQueryBypassExecFixture,
+                 "small-query bypass exec - multi-join and join + aggregate",
+                 "[integration][gpu_execution][small_query_bypass]")
+{
+  create_test_tables();
+  run_ok("CREATE TABLE dim2 (id INTEGER, tag VARCHAR);");
+  run_ok("INSERT INTO dim2 VALUES (1, 'x'), (2, 'y');");
+  run_ok("CHECKPOINT;");
+  set_threshold_256mb();
+
+  // Two joins: one is mid-pipeline (split_intermediate_joins bypass path).
+  compare_gpu_vs_cpu(
+    "SELECT f.qty, d.name, d2.tag FROM fact f "
+    "JOIN dim d ON f.dim_id = d.id JOIN dim2 d2 ON f.dim_id = d2.id ORDER BY f.qty;");
+  // Join feeding a grouped aggregate feeding an order-by: chains all bypass shapes.
+  compare_gpu_vs_cpu(
+    "SELECT d.name, AVG(f.qty) AS a, COUNT(*) FROM fact f "
+    "JOIN dim d ON f.dim_id = d.id GROUP BY d.name ORDER BY a DESC;");
+
+  set_threshold_disabled();
+}
+
+TEST_CASE_METHOD(SmallQueryBypassExecFixture,
+                 "small-query bypass exec - correlated subquery is excluded and falls back to CPU",
+                 "[integration][gpu_execution][small_query_bypass]")
+{
+  create_test_tables();
+  set_threshold_256mb();
+
+  // A correlated scalar subquery plans as a delim join whose inner join is a JoinType::SINGLE.
+  // That (a) makes the whole query ineligible for the bypass (delim exclusion), and (b) is
+  // unsupported by sirius_physical_concat (SINGLE), so GPU plan generation throws and the query
+  // falls back to DuckDB CPU at plan time -- still returning correct results. Assert the graceful
+  // plan-time fallback: not rebound, never GPU-executed, no runtime failure.
+  const std::string query =
+    "SELECT d.id, (SELECT COUNT(*) FROM fact f WHERE f.dim_id = d.id) FROM dim d ORDER BY d.id;";
+  con->Query("SET gpu_execution = true;");
+  const auto before = sirius::test::get_transparent_execution_stats(*con);
+  auto result       = con->Query(query);
+  const auto after  = sirius::test::get_transparent_execution_stats(*con);
+  REQUIRE(result);
+  REQUIRE_FALSE(result->HasError());
+  CHECK(after.successful_rebinds == before.successful_rebinds);  // not rebound onto the GPU
+  CHECK(after.executions == before.executions);                  // never GPU-executed
+  CHECK(after.fallbacks > before.fallbacks);                     // plan-time fallback to CPU
+  CHECK(after.runtime_fallbacks == before.runtime_fallbacks);    // not a runtime failure
+
+  set_threshold_disabled();
+}
+
+TEST_CASE_METHOD(SmallQueryBypassExecFixture,
+                 "small-query bypass exec - threshold 0 disables the bypass",
+                 "[integration][gpu_execution][small_query_bypass]")
+{
+  create_test_tables();
+  set_threshold_disabled();
+
+  // Same shapes on the normal partitioned path: results must be identical.
+  compare_gpu_vs_cpu(
+    "SELECT dim_id, AVG(qty), COUNT(DISTINCT qty) FROM fact GROUP BY dim_id ORDER BY dim_id;");
+  compare_gpu_vs_cpu(
+    "SELECT f.qty, d.name FROM fact f LEFT JOIN dim d ON f.dim_id = d.id ORDER BY f.qty;");
+  compare_gpu_vs_cpu("SELECT qty FROM fact ORDER BY qty LIMIT 2 OFFSET 1;");
+}

--- a/test/cpp/operator/mgpu_test_utils.hpp
+++ b/test/cpp/operator/mgpu_test_utils.hpp
@@ -130,7 +130,11 @@ inline void write_mgpu_yaml(std::filesystem::path const& yaml_path,
     << params.concat_batch_bytes
     << "\n"
        "    max_build_hash_table_bytes: "
-    << params.max_build_hash_table_bytes << "\n";
+    << params.max_build_hash_table_bytes
+    << "\n"
+       // Disable the small-query bypass so these tests still take the partitioned multi-GPU path
+       // over their small fixtures (issue #990).
+       "    small_query_bytes_threshold: 0\n";
 }
 
 /**

--- a/test/cpp/operator/test_physical_concat.cpp
+++ b/test/cpp/operator/test_physical_concat.cpp
@@ -529,6 +529,45 @@ TEST_CASE("sirius_physical_concat with concat_all=true ignores threshold", "[phy
   REQUIRE(result2 == nullptr);
 }
 
+TEST_CASE("sirius_physical_concat folds the complete MARK build side", "[physical_concat]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space != nullptr);
+
+  constexpr uint64_t threshold = 1;
+  auto fixture = create_test_hash_join(duckdb::JoinType::MARK, {duckdb::LogicalType::INTEGER});
+  sirius_physical_concat concat_op(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    /*is_build=*/true,
+    threshold);
+
+  auto repo                 = std::make_unique<cucascade::shared_data_repository>();
+  constexpr int num_batches = 3;
+  for (int b = 0; b < num_batches; ++b) {
+    std::vector<int32_t> values = {b};
+    auto batch                  = make_numeric_batch<int32_t>(*space, values, cudf::type_id::INT32);
+    repo->add_data_batch(std::move(batch), 0);
+  }
+
+  auto port           = std::make_unique<sirius_physical_operator::port>();
+  port->type          = MemoryBarrierType::FULL;
+  port->repo          = repo.get();
+  port->src_pipeline  = nullptr;
+  port->dest_pipeline = nullptr;
+  concat_op.add_port("input", std::move(port));
+
+  // MARK must evaluate one existence result against the complete build relation.
+  // Even though every batch exceeds the threshold, all build batches are returned together.
+  auto result = concat_op.get_next_task_input_data();
+  REQUIRE(result != nullptr);
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*result).get_data_batches().size() ==
+          static_cast<std::size_t>(num_batches));
+  auto result2 = concat_op.get_next_task_input_data();
+  REQUIRE(result2 == nullptr);
+}
+
 //===----------------------------------------------------------------------===//
 // 3. Constructor tests
 //===----------------------------------------------------------------------===//

--- a/test/cpp/pipeline/test_merge_pipeline_fusion.cpp
+++ b/test/cpp/pipeline/test_merge_pipeline_fusion.cpp
@@ -100,6 +100,13 @@ struct merge_fusion_fixture {
     result = con->Query("USE tpch;");
     REQUIRE(result);
     REQUIRE_FALSE(result->HasError());
+    // These tests assert the partitioned fusion shape (a PARTITION pipeline must exist). The
+    // small-query bypass is on by default (256 MiB) and would drop PARTITION for these tiny
+    // TPC-H tables; disable it so fusion is exercised on the partitioned path. Fusion composed
+    // with the bypass is covered separately in test_small_query_bypass_converter.cpp.
+    result = con->Query("SET small_query_bytes_threshold = 0;");
+    REQUIRE(result);
+    REQUIRE_FALSE(result->HasError());
   }
 
   std::unique_ptr<duckdb::Connection> con;

--- a/test/cpp/pipeline/test_partition_build_pipelines.cpp
+++ b/test/cpp/pipeline/test_partition_build_pipelines.cpp
@@ -138,6 +138,9 @@ struct partition_build_fixture {
     r = con->Query("USE tpch;");
     REQUIRE(r);
     REQUIRE_FALSE(r->HasError());
+    r = con->Query("SET small_query_bytes_threshold = 0;");
+    REQUIRE(r);
+    REQUIRE_FALSE(r->HasError());
   }
 
   std::unique_ptr<duckdb::Connection> con;

--- a/test/cpp/pipeline/test_pipeline_dynamic_filter_native_shape.cpp
+++ b/test/cpp/pipeline/test_pipeline_dynamic_filter_native_shape.cpp
@@ -87,6 +87,10 @@ TEST_CASE("duckdb-native scans consume dynamic filters", "[integration][pipeline
   r = con.Query("USE tpch;");
   REQUIRE(r);
   REQUIRE_FALSE(r->HasError());
+  // Dynamic-filter publication requires the partitioned BUILD_PROBE path.
+  r = con.Query("SET small_query_bytes_threshold = 0;");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
 
   const std::string join_query =
     "SELECT count(*) FROM lineitem, part WHERE l_partkey = p_partkey AND p_size = 15";

--- a/test/cpp/pipeline/test_small_query_bypass_converter.cpp
+++ b/test/cpp/pipeline/test_small_query_bypass_converter.cpp
@@ -1,0 +1,368 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_small_query_bypass_converter.cpp
+ * @brief Plan-time structure tests for the small-query bypass (issue #990).
+ *
+ * Runs real SQL through the DuckDB planner and the Sirius physical plan
+ * generator (which applies the bypass when `small_query_bytes_threshold` is
+ * set), then converts the plan to pipelines and asserts on structure:
+ *   - bypass ON:  no PARTITION / SORT_SAMPLE / SORT_PARTITION anywhere;
+ *                 the terminal CONCAT / MERGE_* operators are still present;
+ *                 the ORDER_BY -> MERGE_SORT wiring uses a FULL barrier;
+ *                 the build-side CONCAT still wires a "build" port.
+ *   - bypass OFF: an explicit zero threshold keeps the partition stages.
+ *
+ * The converter is exercised directly (no GPU execution), mirroring
+ * sirius_engine::initialize_internal after plan generation.
+ */
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/execution/column_binding_resolver.hpp>
+#include <duckdb/main/prepared_statement_data.hpp>
+#include <duckdb/optimizer/optimizer.hpp>
+#include <duckdb/parser/parser.hpp>
+#include <duckdb/planner/planner.hpp>
+#include <op/sirius_physical_operator.hpp>
+#include <op/sirius_physical_operator_type.hpp>
+#include <op/sirius_physical_result_collector.hpp>
+#include <pipeline/pipeline_build_context.hpp>
+#include <pipeline/repository_wiring.hpp>
+#include <pipeline/sirius_meta_pipeline.hpp>
+#include <pipeline/sirius_pipeline.hpp>
+#include <pipeline/sirius_pipeline_converter.hpp>
+#include <planner/sirius_physical_plan_generator.hpp>
+#include <sirius_config.hpp>
+#include <sirius_interface.hpp>
+#include <utils/gpu_execution_fixture.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+using sirius::op::sirius_physical_operator;
+using sirius::op::SiriusPhysicalOperatorType;
+using sirius::pipeline::pipeline_conversion_result;
+using sirius::pipeline::sirius_pipeline;
+
+namespace {
+
+/// Fixture: file-backed DuckDB with the Sirius extension loaded (shared
+/// integration env when available), plus a converter driver.
+class SmallQueryBypassFixture : public sirius::test::GpuExecutionFixture {
+ public:
+  void create_test_tables()
+  {
+    run_ok("CREATE TABLE dim (id INTEGER, name VARCHAR);");
+    run_ok("INSERT INTO dim VALUES (1, 'a'), (2, 'b'), (3, 'c');");
+    run_ok("CREATE TABLE fact (dim_id INTEGER, qty INTEGER);");
+    run_ok("INSERT INTO fact VALUES (1, 10), (1, 20), (2, 30), (4, 40);");
+    run_ok("CHECKPOINT;");
+  }
+
+  /// Plan `query` with the real DuckDB planner + Sirius plan generator and run
+  /// the pipeline converter. Bypass is controlled via `small_query_bytes_threshold`
+  /// before planning (wraps happen inside create_plan).
+  /// @param threshold_bytes If set, uses that threshold; otherwise true → 256 MiB,
+  ///        false → 0 (disabled).
+  pipeline_conversion_result convert_query(const std::string& query,
+                                           bool small_query_bypass,
+                                           std::optional<uint64_t> threshold_bytes = std::nullopt)
+  {
+    auto& context = *con->context;
+
+    const uint64_t threshold =
+      threshold_bytes.value_or(small_query_bypass ? uint64_t{268435456} : uint64_t{0});
+    run_ok("SET small_query_bytes_threshold = " + std::to_string(threshold) + ";");
+
+    context.config.enable_optimizer      = true;
+    context.config.use_replacement_scans = false;
+
+    run_ok("BEGIN TRANSACTION;");
+
+    duckdb::Parser parser(context.GetParserOptions());
+    parser.ParseQuery(query);
+    REQUIRE(parser.statements.size() == 1);
+
+    duckdb::Planner planner(context);
+    auto statement_type = parser.statements[0]->type;
+    planner.CreatePlan(std::move(parser.statements[0]));
+    REQUIRE(planner.plan);
+
+    auto prepared       = duckdb::make_shared_ptr<duckdb::PreparedStatementData>(statement_type);
+    prepared->names     = planner.names;
+    prepared->types     = planner.types;
+    prepared->value_map = std::move(planner.value_map);
+
+    duckdb::Optimizer optimizer(*planner.binder, context);
+    auto logical_plan = optimizer.Optimize(std::move(planner.plan));
+    logical_plan->ResolveOperatorTypes();
+    duckdb::ColumnBindingResolver resolver;
+    duckdb::ColumnBindingResolver::Verify(*logical_plan);
+    resolver.VisitOperator(*logical_plan);
+
+    sirius::planner::sirius_physical_plan_generator physical_planner(context);
+    auto sirius_plan = physical_planner.create_plan(std::move(logical_plan));
+    REQUIRE(sirius_plan);
+
+    // Wrap in a result collector, like the transparent execution path does.
+    // Keep the prepared-statement data alive for the collector's lifetime.
+    prepared_data_ = duckdb::make_shared_ptr<sirius::sirius_prepared_statement_data>(
+      prepared, std::move(sirius_plan));
+    auto collector = duckdb::make_uniq_base<sirius::op::sirius_physical_result_collector,
+                                            sirius::op::sirius_physical_materialized_collector>(
+      *prepared_data_, context);
+
+    // RESULT_COLLECTOR wrap lands after create_plan's set_parent_ops — re-walk.
+    sirius::planner::sirius_physical_plan_generator::set_parent_ops(*collector,
+                                                                    /*parent=*/nullptr);
+
+    run_ok("COMMIT TRANSACTION;");
+
+    // Mirror sirius_engine::initialize_internal: meta-pipeline build + convert.
+    sirius::pipeline::pipeline_build_context build_ctx{nullptr, true, 1};
+
+    sirius::pipeline::sirius_pipeline_build_state state;
+    auto root_pipeline =
+      duckdb::make_shared_ptr<sirius::pipeline::sirius_meta_pipeline>(build_ctx, state, nullptr);
+    root_pipeline->build(*collector);
+    root_pipeline->ready();
+
+    sirius::operator_params op_params{};
+    sirius::pipeline::sirius_pipeline_converter converter(build_ctx, op_params);
+    auto result = converter.convert(*root_pipeline);
+
+    // The collector (and the plan inside prepared_data_) must outlive the
+    // conversion result — pipelines hold raw pointers into the plan.
+    collectors_.push_back(std::move(collector));
+    return result;
+  }
+
+  duckdb::shared_ptr<sirius::sirius_prepared_statement_data> prepared_data_;
+  std::vector<duckdb::unique_ptr<sirius::op::sirius_physical_result_collector>> collectors_;
+};
+
+/// Count operators of `type` across pipeline sources, operators, and sinks.
+size_t count_ops(const pipeline_conversion_result& result, SiriusPhysicalOperatorType type)
+{
+  size_t count = 0;
+  for (const auto& pipeline : result.scheduled_pipelines) {
+    // After finalize_pipeline_structure, operators[] spans source..sink.
+    for (const auto& op : pipeline->get_operators()) {
+      if (op.get().type == type) { count++; }
+    }
+  }
+  return count;
+}
+
+bool has_partition_stage(const pipeline_conversion_result& result)
+{
+  return count_ops(result, SiriusPhysicalOperatorType::PARTITION) > 0 ||
+         count_ops(result, SiriusPhysicalOperatorType::SORT_SAMPLE) > 0 ||
+         count_ops(result, SiriusPhysicalOperatorType::SORT_PARTITION) > 0;
+}
+
+/// GPU count the bypass gate sees (same source the multi-GPU join guard reads). Joins decline the
+/// bypass when this is > 1, so join-shape assertions must branch on it.
+int active_num_gpus(duckdb::Connection& con)
+{
+  return static_cast<int>(
+    sirius::test::get_registered_sirius_context(con)->get_hw_topology().gpus.size());
+}
+
+}  // namespace
+
+TEST_CASE("small-query bypass defaults to 256 MiB", "[integration][small_query_bypass][converter]")
+{
+  CHECK(sirius::operator_params{}.small_query_bytes_threshold == uint64_t{256} * 1024 * 1024);
+}
+
+TEST_CASE_METHOD(SmallQueryBypassFixture,
+                 "small-query bypass - GROUP_BY skips PARTITION, keeps MERGE_GROUP_BY",
+                 "[integration][small_query_bypass][converter]")
+{
+  create_test_tables();
+  const std::string query = "SELECT dim_id, AVG(qty) FROM fact GROUP BY dim_id;";
+
+  auto bypass = convert_query(query, /*small_query_bypass=*/true);
+  CHECK_FALSE(has_partition_stage(bypass));
+  CHECK(count_ops(bypass, SiriusPhysicalOperatorType::MERGE_GROUP_BY) > 0);
+
+  // The GROUP_BY pipeline must feed the MERGE_GROUP_BY pipeline directly.
+  bool group_by_feeds_merge = false;
+  for (const auto& wiring : bypass.repository_wirings) {
+    if (wiring.source_pipeline->get_sink()->type == SiriusPhysicalOperatorType::HASH_GROUP_BY &&
+        wiring.dest_pipeline->get_sink()->type == SiriusPhysicalOperatorType::MERGE_GROUP_BY) {
+      group_by_feeds_merge = true;
+    }
+  }
+  CHECK(group_by_feeds_merge);
+
+  auto normal = convert_query(query, /*small_query_bypass=*/false);
+  CHECK(count_ops(normal, SiriusPhysicalOperatorType::PARTITION) > 0);
+  CHECK(count_ops(normal, SiriusPhysicalOperatorType::MERGE_GROUP_BY) > 0);
+}
+
+TEST_CASE_METHOD(SmallQueryBypassFixture,
+                 "small-query bypass - HASH_JOIN skips PARTITION, keeps build CONCAT",
+                 "[integration][small_query_bypass][converter]")
+{
+  create_test_tables();
+  const std::string query = "SELECT f.qty FROM fact f JOIN dim d ON f.dim_id = d.id;";
+
+  auto bypass = convert_query(query, /*small_query_bypass=*/true);
+  if (active_num_gpus(*con) > 1) {
+    // Multi-GPU join guard (issue #990): join-bearing plans decline the bypass and keep the
+    // partitioned path even under the small-query threshold.
+    CHECK(count_ops(bypass, SiriusPhysicalOperatorType::PARTITION) > 0);
+  } else {
+    CHECK_FALSE(has_partition_stage(bypass));
+    CHECK(count_ops(bypass, SiriusPhysicalOperatorType::CONCAT) > 0);
+
+    // A "build" wiring must target the pipeline that contains the HASH_JOIN.
+    bool build_port_targets_join = false;
+    for (const auto& wiring : bypass.repository_wirings) {
+      if (wiring.port_id != "build") { continue; }
+      const auto& dest = wiring.dest_pipeline;
+      for (const auto& op : dest->get_operators()) {
+        if (op.get().type == SiriusPhysicalOperatorType::HASH_JOIN) {
+          build_port_targets_join = true;
+        }
+      }
+    }
+    CHECK(build_port_targets_join);
+  }
+
+  auto normal = convert_query(query, /*small_query_bypass=*/false);
+  CHECK(count_ops(normal, SiriusPhysicalOperatorType::PARTITION) > 0);
+}
+
+TEST_CASE_METHOD(SmallQueryBypassFixture,
+                 "small-query bypass - ORDER_BY skips SORT_SAMPLE/SORT_PARTITION, FULL barrier "
+                 "into MERGE_SORT",
+                 "[integration][small_query_bypass][converter]")
+{
+  create_test_tables();
+  // Projection drops the sort key, so MERGE_SORT must carry the final projection.
+  const std::string query = "SELECT qty FROM fact ORDER BY dim_id;";
+
+  auto bypass = convert_query(query, /*small_query_bypass=*/true);
+  CHECK_FALSE(has_partition_stage(bypass));
+  CHECK(count_ops(bypass, SiriusPhysicalOperatorType::MERGE_SORT) > 0);
+
+  // ORDER_BY -> MERGE_SORT wiring must be FULL (merge waits for all local sorts).
+  bool found_order_to_merge = false;
+  for (const auto& wiring : bypass.repository_wirings) {
+    if (wiring.source_pipeline->get_sink()->type == SiriusPhysicalOperatorType::ORDER_BY &&
+        wiring.dest_pipeline->get_sink()->type == SiriusPhysicalOperatorType::MERGE_SORT) {
+      found_order_to_merge = true;
+      CHECK(wiring.barrier_type == sirius::op::MemoryBarrierType::FULL);
+    }
+  }
+  CHECK(found_order_to_merge);
+
+  auto normal = convert_query(query, /*small_query_bypass=*/false);
+  CHECK(count_ops(normal, SiriusPhysicalOperatorType::SORT_SAMPLE) > 0);
+  CHECK(count_ops(normal, SiriusPhysicalOperatorType::SORT_PARTITION) > 0);
+}
+
+TEST_CASE_METHOD(SmallQueryBypassFixture,
+                 "small-query bypass - multi-join query has no partitions in bypass mode",
+                 "[integration][small_query_bypass][converter]")
+{
+  create_test_tables();
+  run_ok("CREATE TABLE dim2 (id INTEGER, tag VARCHAR);");
+  run_ok("INSERT INTO dim2 VALUES (1, 'x'), (2, 'y');");
+  run_ok("CHECKPOINT;");
+
+  // Two joins so both build and probe sides exercise wrap_join_child.
+  const std::string query =
+    "SELECT f.qty, d.name, d2.tag FROM fact f "
+    "JOIN dim d ON f.dim_id = d.id JOIN dim2 d2 ON f.dim_id = d2.id;";
+
+  auto bypass = convert_query(query, /*small_query_bypass=*/true);
+  if (active_num_gpus(*con) > 1) {
+    // Multi-GPU join guard (issue #990): join-bearing plans keep the partitioned path.
+    CHECK(count_ops(bypass, SiriusPhysicalOperatorType::PARTITION) >= 2);
+  } else {
+    CHECK_FALSE(has_partition_stage(bypass));
+    // Both joins keep their CONCATs (one build-side each, plus probe-side concats).
+    CHECK(count_ops(bypass, SiriusPhysicalOperatorType::CONCAT) >= 2);
+  }
+
+  auto normal = convert_query(query, /*small_query_bypass=*/false);
+  CHECK(count_ops(normal, SiriusPhysicalOperatorType::PARTITION) >= 2);
+}
+
+TEST_CASE_METHOD(SmallQueryBypassFixture,
+                 "small-query bypass - threshold below scan estimate keeps partitions",
+                 "[integration][small_query_bypass][converter]")
+{
+  create_test_tables();
+  // fact is 4 rows × 2 INT cols ≈ 32 bytes; a 1-byte threshold must not activate bypass.
+  const std::string query = "SELECT dim_id, AVG(qty) FROM fact GROUP BY dim_id;";
+  auto result = convert_query(query, /*small_query_bypass=*/true, /*threshold_bytes=*/uint64_t{1});
+  CHECK(count_ops(result, SiriusPhysicalOperatorType::PARTITION) > 0);
+  CHECK(count_ops(result, SiriusPhysicalOperatorType::MERGE_GROUP_BY) > 0);
+}
+
+TEST_CASE_METHOD(SmallQueryBypassFixture,
+                 "small-query bypass - materialized CTE keeps partitions",
+                 "[integration][small_query_bypass][converter]")
+{
+  create_test_tables();
+  // Materialized CTEs make the whole query ineligible even with a high threshold.
+  const std::string query =
+    "WITH c AS MATERIALIZED (SELECT * FROM fact) "
+    "SELECT dim_id, count(*) FROM c GROUP BY dim_id ORDER BY dim_id;";
+
+  auto result = convert_query(query, /*small_query_bypass=*/true);
+  CHECK(has_partition_stage(result));
+}
+
+// Regression for issue #990: a VALUES list is planned as a COLUMN_DATA_SCAN whose materialized
+// bytes must be counted in the gate. If it were scored as 0 (the old `default:`-case bug), the
+// estimate would fall below any threshold and wrongly bypass — dropping the PARTITION that the
+// retained _concat_all build-side CONCAT relies on for a potentially large source.
+TEST_CASE_METHOD(SmallQueryBypassFixture,
+                 "small-query bypass - COLUMN_DATA_SCAN (VALUES) bytes are counted, not zero",
+                 "[integration][small_query_bypass][converter]")
+{
+  // The only base scan is the VALUES-backed COLUMN_DATA_SCAN, so the gate estimate is entirely
+  // that scan's size. GROUP BY inserts a PARTITION in non-bypass mode.
+  std::string values = "(0)";
+  for (int i = 1; i < 100; ++i) {
+    values += ",(" + std::to_string(i) + ")";
+  }
+  const std::string query =
+    "SELECT v.id, COUNT(*) FROM (VALUES " + values + ") AS v(id) GROUP BY v.id;";
+
+  // threshold = 1 byte: below any non-zero estimate, so bypass must NOT activate. Pre-fix the
+  // COLUMN_DATA_SCAN scored 0 (0 < 1) and wrongly bypassed; counted, it is >0 (>= 1) and keeps
+  // the PARTITION. This cleanly separates "0" from "counted" with no size calibration.
+  auto counted = convert_query(query, /*small_query_bypass=*/true, /*threshold_bytes=*/uint64_t{1});
+  CHECK(count_ops(counted, SiriusPhysicalOperatorType::PARTITION) > 0);
+  CHECK(count_ops(counted, SiriusPhysicalOperatorType::MERGE_GROUP_BY) > 0);
+
+  // At the default 256 MiB threshold the small VALUES stays comfortably eligible: measuring the
+  // collection must not make ordinary VALUES queries ineligible for the bypass.
+  auto eligible = convert_query(query, /*small_query_bypass=*/true);
+  CHECK_FALSE(has_partition_stage(eligible));
+  CHECK(count_ops(eligible, SiriusPhysicalOperatorType::MERGE_GROUP_BY) > 0);
+}

--- a/test/cpp/planner/test_plan_tree_shape.cpp
+++ b/test/cpp/planner/test_plan_tree_shape.cpp
@@ -287,6 +287,9 @@ struct plan_tree_shape_fixture {
     db = std::make_unique<DuckDB>(_db_path.path());
     setenv("SIRIUS_DISABLE", "1", 1);
     con = std::make_unique<Connection>(*db);
+    // This suite asserts the full partitioned tree shape, so opt out of the
+    // production-default small-query bypass for its tiny fixture tables.
+    con->Query("SET small_query_bytes_threshold = 0");
 
     // big_left is larger so the optimizer keeps small_right as the build side.
     con->Query("CREATE TABLE big_left (id INTEGER, val INTEGER)");


### PR DESCRIPTION
## What & why

When a whole query's data is small, the partition / sort-sampling machinery is pure
overhead — it exists to chunk large data across tasks and GPUs. This adds a **whole-query
small-data gate**: when the summed estimated bytes across all base scans fall below
`small_query_bytes_threshold` (default **256 MiB**, clamped to `scan_task_batch_size` so
every scan is single-batch), the plan generator skips `PARTITION` / `SORT_SAMPLE` /
`SORT_PARTITION` and wires producers directly into the retained terminal `CONCAT` / `MERGE`
operators.

## How it works

- **Gate** (`estimate_base_scan_bytes`): sums `TABLE_SCAN` (metadata cardinality × row width,
  with VARCHAR width taken from the column's max-length statistic and **failing closed** when
  that stat is missing) and `COLUMN_DATA_SCAN` (exact materialized size). Decided once,
  whole-query, before wrapping.
- **Retained operators carry correctness**: `CONCAT` now accepts non-partitioned input as
  partition 0, and MARK folds the complete build side via `_concat_all` so the unpartitioned
  path stays correct. `ORDER_BY → MERGE_SORT` uses a `FULL` barrier; join sibling-linking
  guards against the absent `PARTITION`.
- New `small_query_bytes_threshold` config / `SET` option (`0` disables).

## Eligibility & limits

Ineligible (fall through to the normal partitioned path): CTE / delim / recursive plans,
VARCHAR scans with no max-length statistic, and — **on multi-GPU** — any plan containing a
join. That last guard is deliberate: the bypass runs everything on one partition (GPU 0), so
a join whose output amplifies past cuDF's per-column row limit would crash where the
partitioned path spreads it across GPUs. Bypassed joins stay STANDARD (no BUILD_PROBE /
dynamic filters). The gate models leaf-scan **input** only, not join / aggregate **output**
fan-out.

## Correctness

Skipping partitioning never changes results — it's a scaling device, not a semantic one. The
`CONCAT` `_concat_all` fold, the STANDARD join batch grid, and the k-way `MERGE_SORT` are all
partition-count-agnostic, and the gate only ever sees supported operators (anything else has
already fallen back to CPU at plan time).

## Testing

- `test_small_query_bypass_converter` — asserts the bypassed plan omits the partition stages
  and keeps the terminal `CONCAT` / `MERGE` operators; covers gate eligibility (threshold,
  materialized CTE, `COLUMN_DATA_SCAN`).
- `test_gpu_execution_small_query_bypass` — GPU-vs-CPU correctness across aggregates,
  `ORDER BY` / TOP-N + OFFSET, all join types, and the correlated-subquery exclusion.
- `test_physical_concat` — MARK build-side `_concat_all` fold.
- Full C++ suite green on-device.

## Follow-ups (deferred)

- Runtime coverage for the multi-GPU join guard (needs a `num_gpus` test seam) and the
  multi-partial merge path under bypass (needs integration-scale amplifying data).
- Optional: a coarse output-cardinality estimate to allow selective joins to bypass on
  multi-GPU instead of the blunt "any join → partitioned path".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
