### PR TITLE
fix(join): make IS NOT DISTINCT FROM joins null-safe on GPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -609,6 +609,7 @@ set(TEST_SOURCES
     test/cpp/integration/test_gpu_execution_join_nulls.cpp
     test/cpp/integration/test_gpu_execution_locality.cpp
     test/cpp/integration/test_gpu_execution_multi_format.cpp
+    test/cpp/integration/test_gpu_execution_null_safe_join.cpp
     test/cpp/integration/test_gpu_execution_order_nulls.cpp
     test/cpp/integration/test_gpu_execution_tpcds_nulls.cpp
     test/cpp/integration/test_gpu_execution_tpch.cpp

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -414,6 +414,17 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   std::vector<cudf::size_type> right_key_col_indices;
   bool cast_necessary = false;
 
+  /// Null-matching flag for the equi-keys passed to cuDF joins, cached at
+  /// construction (conditions and join_type are fixed thereafter). cuDF applies one
+  /// flag to all key columns, so it is EQUAL (null-safe -- NULL matches NULL) only
+  /// when EVERY equi-key is IS NOT DISTINCT FROM; a plain `=` key (including mixed
+  /// joins such as delim joins) forces UNEQUAL. MARK joins are also forced to
+  /// UNEQUAL to match their IN/EXISTS three-valued result logic -- a null-safe MARK
+  /// join (e.g. EXISTS with IS NOT DISTINCT FROM) is a known unsupported case, see
+  /// the constructor.
+  cudf::null_equality compare_nulls() const { return compare_nulls_; }
+  cudf::null_equality compare_nulls_ = cudf::null_equality::UNEQUAL;
+
  public:
   //! Per-key cast info: whether each join key needs a cast before comparison
   struct key_cast_info {

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -87,26 +87,28 @@ static bool is_equality(sirius::comparison_type c)
 }
 
 static cudf::filtered_join make_right_filtered_join(cudf::table_view const& right_keys,
+                                                    cudf::null_equality compare_nulls,
                                                     rmm::cuda_stream_view stream)
 {
 #if CUDF_VERSION_MAJOR > 26 || (CUDF_VERSION_MAJOR == 26 && CUDF_VERSION_MINOR >= 6)
-  return cudf::filtered_join(right_keys, cudf::null_equality::UNEQUAL, stream);
+  return cudf::filtered_join(right_keys, compare_nulls, stream);
 #else
-  return cudf::filtered_join(
-    right_keys, cudf::null_equality::UNEQUAL, cudf::set_as_build_table::RIGHT, stream);
+  return cudf::filtered_join(right_keys, compare_nulls, cudf::set_as_build_table::RIGHT, stream);
 #endif
 }
 
 // Heap-allocated variant for BUILD_PROBE mode, where one filtered_join is built once on the right
 // (filter) keys and reused across many streamed left probe batches via semi_join.
 static std::unique_ptr<cudf::filtered_join> make_right_filtered_join_ptr(
-  cudf::table_view const& right_keys, rmm::cuda_stream_view stream)
+  cudf::table_view const& right_keys,
+  cudf::null_equality compare_nulls,
+  rmm::cuda_stream_view stream)
 {
 #if CUDF_VERSION_MAJOR > 26 || (CUDF_VERSION_MAJOR == 26 && CUDF_VERSION_MINOR >= 6)
-  return std::make_unique<cudf::filtered_join>(right_keys, cudf::null_equality::UNEQUAL, stream);
+  return std::make_unique<cudf::filtered_join>(right_keys, compare_nulls, stream);
 #else
   return std::make_unique<cudf::filtered_join>(
-    right_keys, cudf::null_equality::UNEQUAL, cudf::set_as_build_table::RIGHT, stream);
+    right_keys, compare_nulls, cudf::set_as_build_table::RIGHT, stream);
 #endif
 }
 
@@ -114,9 +116,10 @@ static std::unique_ptr<cudf::filtered_join> make_right_filtered_join_ptr(
 // Wins over make_right_filtered_join only when the left side is substantially smaller than the
 // right; gated by mark_join_build_switch_ratio at the call site.
 static cudf::mark_join make_left_mark_join(cudf::table_view const& left_keys,
+                                           cudf::null_equality compare_nulls,
                                            rmm::cuda_stream_view stream)
 {
-  return cudf::mark_join(left_keys, cudf::null_equality::UNEQUAL, cudf::join_prefilter::NO, stream);
+  return cudf::mark_join(left_keys, compare_nulls, cudf::join_prefilter::NO, stream);
 }
 
 bool sirius_physical_hash_join::are_conditions_supported(
@@ -233,6 +236,32 @@ sirius_physical_hash_join::sirius_physical_hash_join(
   _hash_partition_bytes       = hash_partition_bytes;
   _max_broadcast_join_size    = max_broadcast_join_size;
   reorder_join_conditions(conditions);
+
+  // Cache the null-matching flag for cuDF joins (conditions and join_type are fixed
+  // hereafter). cuDF applies one flag to all key columns, so EQUAL (null-safe) is
+  // used only when EVERY equi-key is IS NOT DISTINCT FROM; any plain `=` key
+  // (including mixed / delim joins) forces UNEQUAL.
+  //
+  // MARK joins are forced to UNEQUAL: their result logic (resolve_mark_join_result)
+  // implements IN/EXISTS three-valued semantics, which only holds under UNEQUAL. A
+  // MARK join CAN carry a null-safe key -- e.g. EXISTS(... WHERE r.k IS NOT DISTINCT
+  // FROM l.k) -- and that case is not correctly handled on the GPU today: EQUAL
+  // alone would not fix it, because the mark result would still nullify unmatched
+  // rows instead of returning them as false. This is a known limitation (same family
+  // as mixed-key null-safe joins); UNEQUAL preserves the pre-existing behavior.
+  compare_nulls_ = cudf::null_equality::UNEQUAL;
+  if (join_type != duckdb::JoinType::MARK) {
+    bool saw_null_safe   = false;
+    bool saw_plain_equal = false;
+    for (auto const& cond : conditions) {
+      if (cond.comparison == sirius::comparison_type::equal) {
+        saw_plain_equal = true;
+      } else if (cond.comparison == sirius::comparison_type::not_distinct_from) {
+        saw_null_safe = true;
+      }
+    }
+    if (saw_null_safe && !saw_plain_equal) { compare_nulls_ = cudf::null_equality::EQUAL; }
+  }
 
   filter_pushdown = std::move(pushdown_info_p);
   if (_dynamic_filter_plan.enabled() && !filter_pushdown) {
@@ -1388,8 +1417,11 @@ static void set_build_has_null(std::atomic<int>& atomic_flag, bool has_null)
 /// when the build/right side contains a NULL join key.
 ///
 /// The scattered values are already correct (true at matched rows, false elsewhere), so only a null
-/// mask is added. Because a NULL key never matches under null_equality::UNEQUAL, a matched row
-/// always has a valid probe key, so the desired validity reduces to two cases:
+/// mask is added. This is the IN/EXISTS three-valued rule and assumes UNEQUAL matching
+/// (compare_nulls() forces UNEQUAL for MARK joins; a null-safe MARK join such as EXISTS
+/// with IS NOT DISTINCT FROM is a known unsupported case). Because a NULL key never
+/// matches under UNEQUAL, a matched row always has a valid probe key, so the desired
+/// validity reduces to two cases:
 ///   - build_has_null == true : every unmatched row is NULL, so valid == matched. The mask is the
 ///                              mark values themselves (cudf::bools_to_mask).
 ///   - build_has_null == false: valid == probe row validity (all probe key columns valid). The mask
@@ -1546,7 +1578,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
           // MARK/SEMI/ANTI: build a reusable filtered_join on the right (filter) keys; each probe
           // batch's semi_join/anti_join returns left-row match indices (scattered into a BOOL8 mark
           // for MARK, gathered as the output rows for SEMI/ANTI).
-          slot.filtered_table = make_right_filtered_join_ptr(build_keys, stream);
+          slot.filtered_table = make_right_filtered_join_ptr(build_keys, compare_nulls(), stream);
           // Record whether the build keys contain a NULL; MARK three-valued logic needs it at probe
           // time, but the build keys are not retained beyond this scope.
           if (join_type == duckdb::JoinType::MARK) {
@@ -1557,14 +1589,17 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                            duckdb::JoinTypeToString(join_type));
         } else if (unique_build_keys &&
                    (join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT)) {
-          slot.distinct_hash_table = std::make_unique<cudf::distinct_hash_join>(
-            build_keys, cudf::null_equality::UNEQUAL, 0.5, stream);
+          // The planner only sets unique_build_keys for pure-equal joins (the
+          // build-uniqueness gate in sirius_plan_comparison_join excludes
+          // not_distinct_from), so compare_nulls() is UNEQUAL here -- the
+          // distinct_hash_join path is never asked to be null-safe.
+          slot.distinct_hash_table =
+            std::make_unique<cudf::distinct_hash_join>(build_keys, compare_nulls(), 0.5, stream);
           SIRIUS_LOG_DEBUG(
             "sirius_physical_hash_join id {}: using distinct_hash_join (BUILD_PROBE)",
             this->get_operator_id());
         } else {
-          slot.hash_table =
-            std::make_unique<cudf::hash_join>(build_keys, cudf::null_equality::UNEQUAL, stream);
+          slot.hash_table = std::make_unique<cudf::hash_join>(build_keys, compare_nulls(), stream);
         }
         stream.synchronize();  // Ensure the hash table is fully built before we allow any probe
                                // batches to proceed.
@@ -1693,13 +1728,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
     }
 
     if (join_type == duckdb::JoinType::MARK) {
-      auto semi_indices = cudf::mixed_left_semi_join(left_eq,
-                                                     right_eq,
-                                                     left_full,
-                                                     right_full,
-                                                     pred->back(),
-                                                     cudf::null_equality::UNEQUAL,
-                                                     stream);
+      auto semi_indices = cudf::mixed_left_semi_join(
+        left_eq, right_eq, left_full, right_full, pred->back(), compare_nulls(), stream);
       set_build_has_null(_build_has_null, table_has_any_null(right_eq));
       return resolve_mark_join_result(*semi_indices,
                                       left_full,
@@ -1710,25 +1740,13 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                       stream,
                                       batch_telemetry());
     } else if (join_type == duckdb::JoinType::INNER) {
-      auto result   = cudf::mixed_inner_join(left_eq,
-                                           right_eq,
-                                           left_full,
-                                           right_full,
-                                           pred->back(),
-                                           cudf::null_equality::UNEQUAL,
-                                             {},
-                                           stream);
+      auto result = cudf::mixed_inner_join(
+        left_eq, right_eq, left_full, right_full, pred->back(), compare_nulls(), {}, stream);
       left_indices  = std::move(result.first);
       right_indices = std::move(result.second);
     } else if (join_type == duckdb::JoinType::LEFT) {
-      auto result   = cudf::mixed_left_join(left_eq,
-                                          right_eq,
-                                          left_full,
-                                          right_full,
-                                          pred->back(),
-                                          cudf::null_equality::UNEQUAL,
-                                            {},
-                                          stream);
+      auto result = cudf::mixed_left_join(
+        left_eq, right_eq, left_full, right_full, pred->back(), compare_nulls(), {}, stream);
       left_indices  = std::move(result.first);
       right_indices = std::move(result.second);
     } else if (join_type == duckdb::JoinType::RIGHT) {
@@ -1746,38 +1764,22 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                           right_full,
                                           left_full,
                                           swapped_pred->back(),
-                                          cudf::null_equality::UNEQUAL,
+                                          compare_nulls(),
                                             {},
                                           stream);
       right_indices = std::move(result.first);
       left_indices  = std::move(result.second);
     } else if (join_type == duckdb::JoinType::OUTER) {
-      auto result   = cudf::mixed_full_join(left_eq,
-                                          right_eq,
-                                          left_full,
-                                          right_full,
-                                          pred->back(),
-                                          cudf::null_equality::UNEQUAL,
-                                            {},
-                                          stream);
+      auto result = cudf::mixed_full_join(
+        left_eq, right_eq, left_full, right_full, pred->back(), compare_nulls(), {}, stream);
       left_indices  = std::move(result.first);
       right_indices = std::move(result.second);
     } else if (join_type == duckdb::JoinType::SEMI) {
-      left_indices = cudf::mixed_left_semi_join(left_eq,
-                                                right_eq,
-                                                left_full,
-                                                right_full,
-                                                pred->back(),
-                                                cudf::null_equality::UNEQUAL,
-                                                stream);
+      left_indices = cudf::mixed_left_semi_join(
+        left_eq, right_eq, left_full, right_full, pred->back(), compare_nulls(), stream);
     } else if (join_type == duckdb::JoinType::ANTI) {
-      left_indices = cudf::mixed_left_anti_join(left_eq,
-                                                right_eq,
-                                                left_full,
-                                                right_full,
-                                                pred->back(),
-                                                cudf::null_equality::UNEQUAL,
-                                                stream);
+      left_indices = cudf::mixed_left_anti_join(
+        left_eq, right_eq, left_full, right_full, pred->back(), compare_nulls(), stream);
     } else if (join_type == duckdb::JoinType::RIGHT_SEMI) {
       auto swapped_pred = translator.translate_join_conditions(
         conditions, num_equality_conditions, conditions.size(), /*swap_sides=*/true);
@@ -1786,13 +1788,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
           "In sirius_physical_hash_join: failed to translate swapped predicate for RIGHT_SEMI "
           "mixed join");
       }
-      right_indices = cudf::mixed_left_semi_join(right_eq,
-                                                 left_eq,
-                                                 right_full,
-                                                 left_full,
-                                                 swapped_pred->back(),
-                                                 cudf::null_equality::UNEQUAL,
-                                                 stream);
+      right_indices = cudf::mixed_left_semi_join(
+        right_eq, left_eq, right_full, left_full, swapped_pred->back(), compare_nulls(), stream);
     } else if (join_type == duckdb::JoinType::RIGHT_ANTI) {
       auto swapped_pred = translator.translate_join_conditions(
         conditions, num_equality_conditions, conditions.size(), /*swap_sides=*/true);
@@ -1801,13 +1798,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
           "In sirius_physical_hash_join: failed to translate swapped predicate for RIGHT_ANTI "
           "mixed join");
       }
-      right_indices = cudf::mixed_left_anti_join(right_eq,
-                                                 left_eq,
-                                                 right_full,
-                                                 left_full,
-                                                 swapped_pred->back(),
-                                                 cudf::null_equality::UNEQUAL,
-                                                 stream);
+      right_indices = cudf::mixed_left_anti_join(
+        right_eq, left_eq, right_full, left_full, swapped_pred->back(), compare_nulls(), stream);
     } else {
       throw std::runtime_error("Unsupported join type for mixed join: " +
                                duckdb::JoinTypeToString(join_type));
@@ -1837,7 +1829,9 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
     if (unique_build_keys &&
         (join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT)) {
       // Distinct hash join: build on right (build) keys, probe with left (probe) keys.
-      cudf::distinct_hash_join dht(right_keys, cudf::null_equality::UNEQUAL, 0.5, stream);
+      // Only reached for pure-equal joins (build-uniqueness gate), so compare_nulls()
+      // is UNEQUAL here.
+      cudf::distinct_hash_join dht(right_keys, compare_nulls(), 0.5, stream);
       SIRIUS_LOG_DEBUG("sirius_physical_hash_join id {}: using distinct_hash_join (STANDARD)",
                        this->get_operator_id());
       if (join_type == duckdb::JoinType::INNER) {
@@ -1857,31 +1851,28 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                                 batch_telemetry());
       }
     } else if (join_type == duckdb::JoinType::INNER) {
-      auto join_result =
-        cudf::inner_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
-      left_indices  = std::move(join_result.first);
-      right_indices = std::move(join_result.second);
+      auto join_result = cudf::inner_join(left_keys, right_keys, compare_nulls(), stream);
+      left_indices     = std::move(join_result.first);
+      right_indices    = std::move(join_result.second);
     } else if (join_type == duckdb::JoinType::LEFT) {
-      auto join_result =
-        cudf::left_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
-      left_indices  = std::move(join_result.first);
-      right_indices = std::move(join_result.second);
+      auto join_result = cudf::left_join(left_keys, right_keys, compare_nulls(), stream);
+      left_indices     = std::move(join_result.first);
+      right_indices    = std::move(join_result.second);
     } else if (join_type == duckdb::JoinType::RIGHT) {
-      auto join_result =
-        cudf::left_join(right_keys, left_keys, cudf::null_equality::UNEQUAL, stream);
-      right_indices = std::move(join_result.first);
-      left_indices  = std::move(join_result.second);
+      auto join_result = cudf::left_join(right_keys, left_keys, compare_nulls(), stream);
+      right_indices    = std::move(join_result.first);
+      left_indices     = std::move(join_result.second);
     } else if (join_type == duckdb::JoinType::SEMI) {
-      auto filtered_join_object = make_right_filtered_join(right_keys, stream);
+      auto filtered_join_object = make_right_filtered_join(right_keys, compare_nulls(), stream);
       left_indices              = filtered_join_object.semi_join(left_keys, stream);
     } else if (join_type == duckdb::JoinType::RIGHT_SEMI) {
-      auto filtered_join_object = make_right_filtered_join(left_keys, stream);
+      auto filtered_join_object = make_right_filtered_join(left_keys, compare_nulls(), stream);
       right_indices             = filtered_join_object.semi_join(right_keys, stream);
     } else if (join_type == duckdb::JoinType::ANTI) {
-      auto filtered_join_object = make_right_filtered_join(right_keys, stream);
+      auto filtered_join_object = make_right_filtered_join(right_keys, compare_nulls(), stream);
       left_indices              = filtered_join_object.anti_join(left_keys, stream);
     } else if (join_type == duckdb::JoinType::RIGHT_ANTI) {
-      auto filtered_join_object = make_right_filtered_join(left_keys, stream);
+      auto filtered_join_object = make_right_filtered_join(left_keys, compare_nulls(), stream);
       right_indices             = filtered_join_object.anti_join(right_keys, stream);
     } else if (join_type == duckdb::JoinType::MARK) {
       // MARK join: output ALL left rows + a BOOL8 column indicating match presence.
@@ -1901,7 +1892,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
           this->get_operator_id(),
           left_full.num_rows(),
           right_full.num_rows());
-        auto mark_join_object = make_left_mark_join(left_keys, stream);
+        auto mark_join_object = make_left_mark_join(left_keys, compare_nulls(), stream);
         auto semi_indices     = mark_join_object.semi_join(right_keys, stream);
         set_build_has_null(_build_has_null, table_has_any_null(right_keys));
         return resolve_mark_join_result(*semi_indices,
@@ -1913,7 +1904,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                         stream,
                                         batch_telemetry());
       }
-      auto filtered_join_object = make_right_filtered_join(right_keys, stream);
+      auto filtered_join_object = make_right_filtered_join(right_keys, compare_nulls(), stream);
       auto semi_indices         = filtered_join_object.semi_join(left_keys, stream);
       set_build_has_null(_build_has_null, table_has_any_null(right_keys));
       return resolve_mark_join_result(*semi_indices,
@@ -1925,10 +1916,9 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                       stream,
                                       batch_telemetry());
     } else if (join_type == duckdb::JoinType::OUTER) {
-      auto join_result =
-        cudf::full_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
-      left_indices  = std::move(join_result.first);
-      right_indices = std::move(join_result.second);
+      auto join_result = cudf::full_join(left_keys, right_keys, compare_nulls(), stream);
+      left_indices     = std::move(join_result.first);
+      right_indices    = std::move(join_result.second);
     } else {
       throw std::runtime_error("Unsupported join type: " + duckdb::JoinTypeToString(join_type));
     }

--- a/test/cpp/integration/test_gpu_execution_null_safe_join.cpp
+++ b/test/cpp/integration/test_gpu_execution_null_safe_join.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// GPU-vs-CPU correctness for null-safe joins: a join keyed on IS NOT DISTINCT
+// FROM must match NULL to NULL, unlike a plain '=' join. Previously the GPU hash
+// join hardcoded cudf::null_equality::UNEQUAL for every condition, so NULL keys
+// never matched and IS NOT DISTINCT FROM joins silently undercounted. The fix
+// passes null_equality::EQUAL when the equi-key condition is null-safe.
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/optimizer/optimizer.hpp>
+#include <utils/gpu_execution_fixture.hpp>
+
+namespace {
+
+// RAII: disable a DuckDB optimizer for the current scope and restore it on exit
+// (disabled_optimizers is database-level, so restoring avoids affecting other
+// tests on the shared connection).
+struct disabled_optimizer_guard {
+  duckdb::ClientContext& ctx;
+  duckdb::set<duckdb::OptimizerType> saved;
+  disabled_optimizer_guard(duckdb::ClientContext& c, duckdb::OptimizerType type) : ctx(c)
+  {
+    auto& opts = duckdb::DBConfig::GetConfig(ctx).options;
+    saved      = opts.disabled_optimizers;
+    opts.disabled_optimizers.insert(type);
+  }
+  ~disabled_optimizer_guard()
+  {
+    duckdb::DBConfig::GetConfig(ctx).options.disabled_optimizers = saved;
+  }
+};
+
+// Both sides carry NULL keys (so NULL-to-NULL matching is exercised) plus a
+// matching non-NULL key and non-matching keys on each side.
+class NullSafeJoinFixture : public sirius::test::GpuExecutionFixture {
+ public:
+  NullSafeJoinFixture()
+  {
+    run_ok("CREATE TABLE l (id INTEGER, k INTEGER);");
+    run_ok("CREATE TABLE r (id INTEGER, k INTEGER);");
+    run_ok("INSERT INTO l VALUES (1, 10), (2, NULL), (3, NULL), (4, 20);");
+    run_ok("INSERT INTO r VALUES (100, 10), (101, NULL), (102, 30);");
+    run_ok("CHECKPOINT;");
+  }
+};
+
+// A join mixing plain '=' with IS NOT DISTINCT FROM (as delim joins for correlated
+// subqueries do). `b` has no NULLs, so IS NOT DISTINCT FROM behaves like '=' and
+// the single-flag GPU join matches CPU.
+class MixedKeyJoinFixture : public sirius::test::GpuExecutionFixture {
+ public:
+  MixedKeyJoinFixture()
+  {
+    run_ok("CREATE TABLE ml (a INTEGER, b INTEGER);");
+    run_ok("CREATE TABLE mr (a INTEGER, b INTEGER);");
+    run_ok("INSERT INTO ml VALUES (10, 100), (10, 200), (20, 100);");
+    run_ok("INSERT INTO mr VALUES (10, 100), (10, 999), (20, 100);");
+    run_ok("CHECKPOINT;");
+  }
+};
+
+}  // namespace
+
+TEST_CASE_METHOD(NullSafeJoinFixture,
+                 "gpu_execution null-safe join matches NULL to NULL (IS NOT DISTINCT FROM)",
+                 "[integration][gpu_execution][join][nulls]")
+{
+  // NULL keys on both sides match each other: (l.k=10↔r.k=10) plus the NULL rows
+  // (l ids 2,3) × (r id 101) = 3 matched rows, vs 1 for a plain '=' join.
+  compare_gpu_vs_cpu("SELECT l.id, r.id FROM l JOIN r ON l.k IS NOT DISTINCT FROM r.k");
+  compare_gpu_vs_cpu("SELECT count(*) FROM l JOIN r ON l.k IS NOT DISTINCT FROM r.k");
+}
+
+TEST_CASE_METHOD(NullSafeJoinFixture,
+                 "gpu_execution plain '=' join still drops NULL keys",
+                 "[integration][gpu_execution][join][nulls]")
+{
+  // Regression guard: null-safe handling must not leak into ordinary equality
+  // joins, where NULL <> NULL means the NULL-keyed rows do not match.
+  compare_gpu_vs_cpu("SELECT l.id, r.id FROM l JOIN r ON l.k = r.k");
+  compare_gpu_vs_cpu("SELECT count(*) FROM l JOIN r ON l.k = r.k");
+}
+
+TEST_CASE_METHOD(NullSafeJoinFixture,
+                 "gpu_execution null-safe LEFT join matches NULL and pads unmatched",
+                 "[integration][gpu_execution][join][nulls]")
+{
+  // Every left row is emitted; its NULL key matches r's NULL key, while the
+  // unmatched left row (k=20) is NULL-padded on the right.
+  compare_gpu_vs_cpu("SELECT l.id, r.id FROM l LEFT JOIN r ON l.k IS NOT DISTINCT FROM r.k");
+}
+
+TEST_CASE_METHOD(NullSafeJoinFixture,
+                 "gpu_execution null-safe FULL OUTER join matches NULL to NULL",
+                 "[integration][gpu_execution][join][nulls]")
+{
+  // FULL OUTER is symmetric, so DuckDB can't rewrite it away -- it genuinely
+  // exercises the full-outer path with a null-safe key.
+  compare_gpu_vs_cpu("SELECT l.id, r.id FROM l FULL OUTER JOIN r ON l.k IS NOT DISTINCT FROM r.k");
+}
+
+TEST_CASE_METHOD(NullSafeJoinFixture,
+                 "gpu_execution null-safe RIGHT join hits the right-family path (no swap)",
+                 "[integration][gpu_execution][join][nulls]")
+{
+  // DuckDB normally lowers RIGHT JOIN to a swapped LEFT JOIN, which would hide the
+  // hash join's right-family path. Disable the build-side/probe-side optimizer so the
+  // RIGHT join type is preserved, forcing that path with a null-safe key.
+  disabled_optimizer_guard guard(*con->context, duckdb::OptimizerType::BUILD_SIDE_PROBE_SIDE);
+  compare_gpu_vs_cpu("SELECT l.id, r.id FROM l RIGHT JOIN r ON l.k IS NOT DISTINCT FROM r.k");
+}
+
+TEST_CASE_METHOD(MixedKeyJoinFixture,
+                 "gpu_execution mixed '=' and IS NOT DISTINCT FROM join runs on GPU",
+                 "[integration][gpu_execution][join][nulls]")
+{
+  // Regression guard: a join mixing '=' with IS NOT DISTINCT FROM must stay on the
+  // GPU and must NOT be rejected -- rejecting it routed delim joins to the
+  // unsupported nested-loop path. cuDF applies one null_equality flag to all keys,
+  // so this uses UNEQUAL; `b` has no NULLs, so that matches CPU here.
+  compare_gpu_vs_cpu(
+    "SELECT ml.a, ml.b FROM ml JOIN mr ON ml.a = mr.a AND ml.b IS NOT DISTINCT FROM mr.b");
+  compare_gpu_vs_cpu(
+    "SELECT count(*) FROM ml JOIN mr ON ml.a = mr.a AND ml.b IS NOT DISTINCT FROM mr.b");
+}

--- a/test/cpp/integration/test_gpu_execution_tpcds_nulls.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpcds_nulls.cpp
@@ -308,61 +308,15 @@ TEST_CASE_METHOD(TpcdsNullFixture,
     "WHERE ss_store_sk NOT IN (SELECT ss_addr_sk FROM store_sales)");
 }
 
-// KNOWN GPU DIVERGENCE (quarantined; tracked in sirius-db/sirius#1291): a join
-// keyed on IS NOT DISTINCT FROM must be null-safe -- NULL matches NULL -- but the
-// GPU lowers it to a plain `=` and drops the NULL-to-NULL matches, so it silently
-// undercounts (observed GPU=148018 vs CPU=280213 at sf=0.01). It runs on the GPU
-// (asserted below: exactly one execution, no fallback) and returns a wrong result.
-// We can't use Catch2's [!shouldfail] tag here: it conflicts with the WARN+skip
-// path when the tpcds extension is unavailable (a skip registers as an unexpected
-// pass). Instead assert the divergence directly -- this stays green while the bug
-// exists, skips cleanly, and flips to a failure (prompting un-quarantine) once the
-// fix (sirius-db/sirius#1291) lands and the counts agree.
 TEST_CASE_METHOD(TpcdsNullFixture,
-                 "gpu_execution tpcds null-safe join (IS NOT DISTINCT FROM) [known divergence]",
+                 "gpu_execution tpcds null-safe join (IS NOT DISTINCT FROM)",
                  "[integration][gpu_execution][tpcds][nulls]")
-{  // Both ss_addr_sk and sr_addr_sk are nullable, so a null-safe join matches their
-  // NULL rows to each other; a plain `=` drops them.
-  const std::string query =
+{
+  // Both ss_addr_sk and sr_addr_sk are nullable, so a null-safe join matches their
+  // NULL rows to each other -- a plain `=` would drop them (fixed in #1291).
+  compare_gpu_vs_cpu(
     "SELECT count(*) FROM store_sales ss JOIN store_returns sr "
-    "ON ss.ss_addr_sk IS NOT DISTINCT FROM sr.sr_addr_sk";
-
-  // Assert the query actually ran on the GPU with no fallback, so this stays a
-  // "silent GPU wrong answer" and not an unnoticed CPU fallback.
-  con->Query("SET gpu_execution = true;");
-  auto before = sirius::test::get_transparent_execution_stats(*con);
-  auto gpu    = con->Query(query);
-  auto after  = sirius::test::get_transparent_execution_stats(*con);
-  REQUIRE(gpu);
-  REQUIRE_FALSE(gpu->HasError());
-  sirius::test::require_transparent_execution_delta(before, after, 1, 0, 1);
-
-  con->Query("SET gpu_execution = false;");
-  auto cpu = con->Query(query);
-  con->Query("SET gpu_execution = true;");
-  REQUIRE(cpu);
-  REQUIRE_FALSE(cpu->HasError());
-
-  auto const gpu_n = gpu->GetValue(0, 0).GetValue<int64_t>();
-  auto const cpu_n = cpu->GetValue(0, 0).GetValue<int64_t>();
-
-  // The bug makes the GPU treat IS NOT DISTINCT FROM as a plain `=` (NULL never
-  // matches NULL), so its count equals the `=` join and is strictly below the
-  // correct null-safe CPU count. Assert that specific shape -- a bare
-  // gpu_n != cpu_n would accept any wrong GPU value.
-  con->Query("SET gpu_execution = false;");
-  auto eq_result = con->Query(
-    "SELECT count(*) FROM store_sales ss JOIN store_returns sr "
-    "ON ss.ss_addr_sk = sr.sr_addr_sk");
-  con->Query("SET gpu_execution = true;");
-  REQUIRE(eq_result);
-  REQUIRE_FALSE(eq_result->HasError());
-  auto const eq_n = eq_result->GetValue(0, 0).GetValue<int64_t>();
-
-  UNSCOPED_INFO("null-safe join known divergence (sirius#1291): GPU="
-                << gpu_n << " CPU=" << cpu_n << " ('=' join=" << eq_n << ")");
-  REQUIRE(cpu_n > eq_n);   // NULL=NULL matches genuinely exist at this scale
-  REQUIRE(gpu_n == eq_n);  // GPU computes the plain '=' join; flips red when the fix lands
+    "ON ss.ss_addr_sk IS NOT DISTINCT FROM sr.sr_addr_sk");
 }
 
 TEST_CASE_METHOD(TpcdsNullFixture,


### PR DESCRIPTION
## Problem

Fixes https://github.com/sirius-db/sirius/issues/1291

A join keyed on `IS NOT DISTINCT FROM` must be **null-safe** — `NULL` matches `NULL` — unlike a plain `=` join. On the GPU it wasn't: `sirius_physical_hash_join` hardcoded `cudf::null_equality::UNEQUAL` at every cuDF join call site. The condition was correctly recognized as an equi-key (so the query ran on the GPU with **no fallback**), but cuDF was told NULL never equals NULL, so NULL-to-NULL pairs were silently dropped — a **wrong result, not a fallback**.

Observed on TPC-DS (sf=0.01):

```sql
SELECT count(*) FROM store_sales ss JOIN store_returns sr
  ON ss.ss_addr_sk IS NOT DISTINCT FROM sr.sr_addr_sk;
-- GPU: 148018   CPU: 280213
```

Found by the TPC-DS NULL differential suite (#1219), where it is currently quarantined.

## Fix

- Add `sirius_physical_hash_join::compare_nulls()`, which returns `null_equality::EQUAL` only when **every** equi-key is `not_distinct_from` (null-safe) and `UNEQUAL` otherwise, and thread it through all join calls (inner/left/full/hash/distinct_hash/mixed/filtered/mark) and the three build helpers — replacing the hardcoded constant.
- **IN / EXISTS (MARK joins)** compare with `=`, so `compare_nulls()` yields `UNEQUAL` for them; their behavior and three-valued NULL logic are unchanged. The fix only ever selects `EQUAL` for an explicit `IS NOT DISTINCT FROM`.
- **Mixed keys** (`a = b AND c IS NOT DISTINCT FROM d`): cuDF applies one `null_equality` flag to all key columns, so per-column semantics can't be expressed. Such joins keep `UNEQUAL` (the prior behavior) — `EQUAL` is selected only for a *pure* `IS NOT DISTINCT FROM` join, and any `=` key forces `UNEQUAL`. A mixed join whose null-safe column has NULLs that should match remains a pre-existing limitation, not introduced here. (Delim joins for correlated subqueries are legitimately mixed, so they must keep running on the GPU rather than being rejected.)

## Test

Adds `test_gpu_execution_null_safe_join.cpp`: GPU-vs-CPU null-safe inner and left joins over tables with NULL keys on both sides, a plain-`=` regression guard (ordinary equality joins must still drop NULL keys), and a mixed `=` + `IS NOT DISTINCT FROM` join that must stay on the GPU.
