### PR TITLE
feat(op): streaming sink over an output repository (#837)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ set(EXTENSION_SOURCES
     src/op/dynamic_filter_publisher.cpp
     src/op/sirius_dynamic_filter.cpp
     src/op/sirius_physical_column_data_scan.cpp
+    src/op/sirius_physical_streaming_sink.cpp
     src/op/sirius_physical_streaming_source.cpp
     src/op/sirius_physical_concat.cpp
     src/op/sirius_physical_cte.cpp
@@ -664,6 +665,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_physical_partition.cpp
     test/cpp/operator/test_physical_projection.cpp
     test/cpp/operator/test_physical_result_collector.cpp
+    test/cpp/operator/test_physical_streaming_sink.cpp
     test/cpp/operator/test_physical_streaming_source.cpp
     test/cpp/operator/test_physical_table_scan.cpp
     test/cpp/operator/test_no_history_peak_memory_estimate.cpp
@@ -689,6 +691,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_gpu_pipeline_disk_readback.cpp
     test/cpp/pipeline/test_get_next_ports_after_sink.cpp
     test/cpp/pipeline/test_merge_pipeline_fusion.cpp
+    test/cpp/pipeline/test_streaming_sink_root.cpp
     test/cpp/pipeline/test_partition_build_pipelines.cpp
     test/cpp/pipeline/test_pipeline_dynamic_filter_native_shape.cpp
     test/cpp/pipeline/test_pipeline_schedule_canonical.cpp

--- a/src/include/op/sirius_physical_operator_type.hpp
+++ b/src/include/op/sirius_physical_operator_type.hpp
@@ -148,7 +148,8 @@ enum class SiriusPhysicalOperatorType : uint8_t {
   GPU_VALUES,
   GPU_SCAN,
   DYNAMIC_FILTER,
-  STREAMING_SOURCE
+  STREAMING_SOURCE,
+  STREAMING_SINK
 };
 
 std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type);

--- a/src/include/op/sirius_physical_streaming_sink.hpp
+++ b/src/include/op/sirius_physical_streaming_sink.hpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "exec/stream_lifecycle.hpp"
+#include "op/sirius_physical_operator.hpp"
+
+#include <cucascade/data/data_repository.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+
+namespace sirius::op {
+
+/// Terminal operator of a streaming fragment: every batch its pipeline produces is pushed into
+/// an output `cucascade::shared_data_repository`, where an external consumer pulls it.
+///
+/// Batches are exposed natively — in whatever tier they currently sit — so nothing is
+/// materialized or converted to Arrow on the way out, and a queued batch stays spillable by the
+/// downgrade executor until it is pulled.
+///
+/// Unlike the source, the sink arms no re-arm waker: its consumer is an external thread blocking
+/// in `wait()`, not an engine task that needs re-nominating.
+class sirius_physical_streaming_sink : public sirius_physical_operator {
+ public:
+  static constexpr SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::STREAMING_SINK;
+
+  /// The pipeline feeding this sink is its one and only sender.
+  static constexpr exec::sender_id_t PIPELINE_SENDER = 0;
+
+  /// Single-destination sink: one output stream, no partitioning.
+  ///
+  /// @throws sirius::invalid_input_exception when `output_repository` is null.
+  sirius_physical_streaming_sink(
+    duckdb::vector<sirius::logical_type> types,
+    std::size_t estimated_cardinality,
+    std::shared_ptr<cucascade::shared_data_repository> output_repository);
+
+  bool is_sink() const override { return true; }
+
+  //! The sink is appended to `current` (landing at operators[0] after the reverse) and set as
+  //! the sink of its own child meta pipeline. The base sink path skips the append, which leaves
+  //! the terminal operator out of the root pipeline and the source with nothing driving it.
+  void build_pipelines(pipeline::sirius_pipeline& current,
+                       pipeline::sirius_meta_pipeline& meta_pipeline) override;
+
+  // -----------------------------------------------------------------------
+  // Producer side (engine)
+  // -----------------------------------------------------------------------
+
+  /// Pass-through. The executor runs every operator in the chain, terminal sink included, and
+  /// feeds the chain's result back into sink(). The base implementation returns an empty batch
+  /// list, so without this override the sink receives nothing and the pipeline "succeeds" with
+  /// an empty output stream.
+  std::unique_ptr<operator_data> execute(const operator_data& input_data,
+                                         rmm::cuda_stream_view stream) override;
+
+  /// Push this task's output batches into the output repository, natively — no Arrow, no GPU
+  /// upgrade, no copy. A push after end-of-stream is dropped by the lifecycle rather than
+  /// landing behind a consumer that already saw EOS.
+  void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+
+  /// Pass-through: pushing a batch allocates nothing, so report the input bytes instead of the
+  /// default 2× heuristic (matches the streaming source).
+  [[nodiscard]] std::size_t no_history_peak_memory_estimate(
+    const input_stats& stats) const override;
+
+  // -----------------------------------------------------------------------
+  // Consumer side (external wrapper / session, never an engine task)
+  // -----------------------------------------------------------------------
+
+  /// Number of output streams this sink exposes. One per destination.
+  [[nodiscard]] std::size_t num_output_streams() const { return _output_repositories.size(); }
+
+  /// Non-blocking pull of the next batch of output stream `index`.
+  /// @return nullopt when nothing is available right now — which is *not* the same as EOS; ask
+  ///         `drained(index)` to tell the two apart.
+  /// @throws sirius::invalid_input_exception when `index` is out of range.
+  std::optional<std::shared_ptr<cucascade::data_batch>> pull(std::size_t index = 0);
+
+  /// Block until output stream `index` has a batch to pull or the stream has ended.
+  /// External threads only.
+  void wait(std::size_t index = 0);
+
+  /// True when the pipeline has finished AND output stream `index` is empty.
+  [[nodiscard]] bool drained(std::size_t index = 0) const;
+
+  /// Non-blocking classification of output stream `index`: HAS_DATA / WAITING / END_OF_STREAM.
+  [[nodiscard]] exec::stream_lifecycle::availability availability(std::size_t index = 0) const;
+
+ protected:
+  /// The pipeline finishing is this stream's end-of-stream: it is the single expected sender.
+  /// All output streams go terminal together.
+  void on_finalize_operator() override;
+
+  /// @throws sirius::invalid_input_exception when `index` is out of range.
+  void validate_index(std::size_t index) const;
+
+  /// One repository per destination. Output stream id, partition index and repository
+  /// correspond positionally.
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> _output_repositories;
+
+  /// Shared by every output stream — the pipeline is one sender feeding all of them, so they
+  /// reach end-of-stream together. Per-stream `drained()` / `wait()` still AND this terminal
+  /// flag with that stream's own emptiness, so a slow destination stays distinguishable.
+  exec::stream_lifecycle _lifecycle;
+};
+
+}  // namespace sirius::op

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -186,6 +186,13 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! Checks if the pipeline has been finished
   virtual bool is_pipeline_finished() const;
 
+  //! Whether this pipeline's sink terminates the query — it has no downstream consumer to
+  //! schedule and no repository wiring to emit, and its completion is what signals the future
+  //! `sirius_engine::execute()` waits on. True for a RESULT_COLLECTOR (the engine-injected root
+  //! of a normal query) and for a STREAMING_SINK (the root of a streaming fragment, whose output
+  //! leaves through session-owned repositories rather than a QueryResult).
+  [[nodiscard]] bool is_query_terminal() const;
+
   void mark_task_created();
   void mark_task_completed();
 

--- a/src/op/sirius_physical_operator_type.cpp
+++ b/src/op/sirius_physical_operator_type.cpp
@@ -115,6 +115,7 @@ std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type)
     case SiriusPhysicalOperatorType::GPU_SCAN: return "GPU_SCAN";
     case SiriusPhysicalOperatorType::DYNAMIC_FILTER: return "DYNAMIC_FILTER";
     case SiriusPhysicalOperatorType::STREAMING_SOURCE: return "STREAMING_SOURCE";
+    case SiriusPhysicalOperatorType::STREAMING_SINK: return "STREAMING_SINK";
     case SiriusPhysicalOperatorType::INVALID: break;
   }
   return "INVALID";

--- a/src/op/sirius_physical_streaming_sink.cpp
+++ b/src/op/sirius_physical_streaming_sink.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_physical_streaming_sink.hpp"
+
+#include "sirius/exception.hpp"
+#include <log/logging.hpp>
+
+#include "pipeline/sirius_meta_pipeline.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+
+#include <cucascade/data/data_batch.hpp>
+
+#include <string>
+#include <utility>
+
+namespace sirius::op {
+
+sirius_physical_streaming_sink::sirius_physical_streaming_sink(
+  duckdb::vector<sirius::logical_type> types,
+  std::size_t estimated_cardinality,
+  std::shared_ptr<cucascade::shared_data_repository> output_repository)
+  : sirius_physical_operator(
+      SiriusPhysicalOperatorType::STREAMING_SINK, std::move(types), estimated_cardinality),
+    _lifecycle(std::set<exec::sender_id_t>{PIPELINE_SENDER})
+{
+  if (!output_repository) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_sink: output_repository must not be null");
+  }
+  _output_repositories.push_back(std::move(output_repository));
+}
+
+std::unique_ptr<operator_data> sirius_physical_streaming_sink::execute(
+  const operator_data& input_data, rmm::cuda_stream_view /*stream*/)
+{
+  // As sirius_physical_result_collector does: hand the batches back so publish_output() can
+  // deliver them to sink(). The base implementation would drop them.
+  return std::make_unique<pipelineable_operator_data>(
+    dynamic_cast<const pipelineable_operator_data&>(input_data).get_read_only_batches());
+}
+
+void sirius_physical_streaming_sink::sink(const operator_data& input_data,
+                                          rmm::cuda_stream_view /*stream*/)
+{
+  const auto& input = dynamic_cast<const pipelineable_operator_data&>(input_data);
+
+  // Pushed in their current tier: no Arrow, no forced GPU upgrade, no copy. The batch stays
+  // spillable in the repository until a consumer pulls it.
+  for (const auto& batch : input.get_data_batches()) {
+    // admit() refuses once the stream is terminal. Ignoring that return silently drops the
+    // batch, which surfaces as a fragment that "succeeds" with an empty output.
+    if (!_lifecycle.admit([&] { _output_repositories[0]->add_data_batch(batch); })) {
+      SIRIUS_LOG_WARN(
+        "sirius_physical_streaming_sink: batch refused after end-of-stream and dropped");
+    }
+  }
+}
+
+std::size_t sirius_physical_streaming_sink::no_history_peak_memory_estimate(
+  const input_stats& stats) const
+{
+  // Pushing a handle into the output repository allocates nothing new.
+  return stats.bytes;
+}
+
+void sirius_physical_streaming_sink::build_pipelines(pipeline::sirius_pipeline& current,
+                                                     pipeline::sirius_meta_pipeline& meta_pipeline)
+{
+  if (children.size() != 1) {
+    throw sirius::internal_exception(
+      "sirius_physical_streaming_sink: expects exactly one child subtree");
+  }
+
+  // Append to `current` so the terminal operator is part of the root pipeline, then start the
+  // real pipeline from the child. Same shape as RESULT_COLLECTOR.
+  auto& state = meta_pipeline.get_state();
+  state.add_pipeline_operator(current, *this);
+
+  auto& child_meta_pipeline = meta_pipeline.create_child_meta_pipeline(current, *this);
+  child_meta_pipeline.build(*children[0]);
+}
+
+void sirius_physical_streaming_sink::on_finalize_operator()
+{
+  // The pipeline is the single sender, so its completion is end-of-stream. Before this a
+  // consumer finding the repository empty must be told WAITING, never EOS.
+  _lifecycle.mark_sender_done(PIPELINE_SENDER);
+}
+
+void sirius_physical_streaming_sink::validate_index(std::size_t index) const
+{
+  if (index >= _output_repositories.size()) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_sink: output stream index " + std::to_string(index) +
+      " out of range (" + std::to_string(_output_repositories.size()) + " streams)");
+  }
+}
+
+std::optional<std::shared_ptr<cucascade::data_batch>> sirius_physical_streaming_sink::pull(
+  std::size_t index)
+{
+  validate_index(index);
+  auto batch = _output_repositories[index]->pop_next_data_batch();
+  if (!batch) { return std::nullopt; }
+  return batch;
+}
+
+void sirius_physical_streaming_sink::wait(std::size_t index)
+{
+  validate_index(index);
+  auto* repo = _output_repositories[index].get();
+  _lifecycle.wait([repo] { return repo->all_empty(); });
+}
+
+bool sirius_physical_streaming_sink::drained(std::size_t index) const
+{
+  validate_index(index);
+  // ANDed with *this* stream's emptiness: the terminal flag is shared across destinations, so a
+  // partition with a backlog must not read as drained just because its siblings are.
+  return _lifecycle.drained(_output_repositories[index]->all_empty());
+}
+
+exec::stream_lifecycle::availability sirius_physical_streaming_sink::availability(
+  std::size_t index) const
+{
+  validate_index(index);
+  return _lifecycle.classify(_output_repositories[index]->all_empty());
+}
+
+}  // namespace sirius::op

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -445,11 +445,8 @@ void gpu_pipeline_executor::manager_loop()
         // which may destroy the engine and its operators. We must not schedule
         // tasks that reference those operators after signaling completion.
         bool query_complete = false;
-        if (_completion_handler && pipeline) {
-          auto sink = pipeline->get_sink();
-          if (sink && sink->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
-            query_complete = pipeline->is_pipeline_finished();
-          }
+        if (_completion_handler && pipeline && pipeline->is_query_terminal()) {
+          query_complete = pipeline->is_pipeline_finished();
         }
 
         if (!query_complete && _task_creator) {

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -337,17 +337,22 @@ bool sirius_pipeline::is_pipeline_finished() const
   return pipeline_finished.load();
 }
 
+bool sirius_pipeline::is_query_terminal() const
+{
+  auto s = get_sink();
+  if (!s) { return false; }
+  return s->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR ||
+         s->type == op::SiriusPhysicalOperatorType::STREAMING_SINK;
+}
+
 void sirius_pipeline::set_task_creator(sirius::creator::task_creator* tc) { _task_creator = tc; }
 
 void sirius_pipeline::notify_downstream_pipelines(bool original_pipeline)
 {
-  // If this pipeline's sink is the RESULT_COLLECTOR, it is the terminal
-  // pipeline of the query — there is no downstream consumer to schedule and
-  // no parent pipeline whose status needs updating. Returning early avoids
-  // racing with engine teardown after mark_completed() signals the future.
-  if (auto s = get_sink(); s && s->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
-    return;
-  }
+  // A query-terminal sink ends the query — there is no downstream consumer to schedule and
+  // no parent pipeline whose status needs updating. Returning early avoids racing with engine
+  // teardown after mark_completed() signals the future.
+  if (is_query_terminal()) { return; }
 
   // Schedule output consumers via the task_creator so downstream pipelines
   // whose FULL-barrier ports are now unblocked will get tasks created.

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -278,8 +278,10 @@ void sirius_pipeline_converter::compute_repository_wiring(sirius_pipeline_build_
 
     using T = op::SiriusPhysicalOperatorType;
 
-    // RESULT_COLLECTOR is a terminal sink — nothing to emit.
-    if (sink_op->type == T::RESULT_COLLECTOR) { continue; }
+    // A query-terminal sink (RESULT_COLLECTOR, STREAMING_SINK) has no downstream pipeline —
+    // nothing to emit. A STREAMING_SINK root would also fall through to the `!parent_op`
+    // check below, but only while it stays the plan root; skip it explicitly.
+    if (sink_op->type == T::RESULT_COLLECTOR || sink_op->type == T::STREAMING_SINK) { continue; }
 
     // CTE fans out to its sibling `cte_scans` (parent_op alone doesn't encode them).
     // CTE_SCAN never lands in any pipeline's operators[], so consumers resolve via

--- a/test/cpp/operator/test_physical_streaming_sink.cpp
+++ b/test/cpp/operator/test_physical_streaming_sink.cpp
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator_test_utils.hpp"
+
+#include <catch.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <data/data_batch_utils.hpp>
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <exec/stream_lifecycle.hpp>
+#include <expression/ast/from_duckdb.hpp>
+#include <helper/type_conversions.hpp>
+#include <op/sirius_physical_filter.hpp>
+#include <op/sirius_physical_streaming_sink.hpp>
+#include <op/sirius_physical_streaming_source.hpp>
+#include <sirius/exception.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <set>
+#include <thread>
+#include <vector>
+
+using namespace sirius::exec;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+using namespace std::chrono_literals;
+
+namespace {
+
+using namespace sirius::test::operator_utils;
+
+using availability = stream_lifecycle::availability;
+
+/// Single-destination sink over a fresh output repository.
+auto make_sink()
+{
+  auto repo = std::make_shared<cucascade::shared_data_repository>();
+  auto op   = std::make_unique<sirius_physical_streaming_sink>(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    repo);
+  return std::make_tuple(std::move(op), repo);
+}
+
+/// Feed one batch through the sink exactly as publish_output() would.
+void sink_one(sirius_physical_streaming_sink& op, std::shared_ptr<cucascade::data_batch> batch)
+{
+  pipelineable_operator_data data{
+    std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(batch)}};
+  op.sink(data, default_stream());
+}
+
+}  // namespace
+
+// ============================================================================
+// SNK-1: sink() publishes exactly the batches it was given, natively
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-1: sunk batches appear in the output repository in order",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr int K = 4;
+  auto [op, repo] = make_sink();
+
+  std::vector<uint64_t> pushed_ids;
+  for (int i = 0; i < K; ++i) {
+    auto batch = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    pushed_ids.push_back(batch->get_batch_id());
+    sink_one(*op, batch);
+  }
+
+  REQUIRE(repo->total_size() == K);
+
+  // Pointer identity end-to-end: the sink pushed the batch itself, not a copy or a conversion.
+  std::vector<uint64_t> pulled_ids;
+  while (auto batch = op->pull()) {
+    pulled_ids.push_back((*batch)->get_batch_id());
+  }
+  REQUIRE(pulled_ids == pushed_ids);
+  REQUIRE(repo->total_size() == 0);
+}
+
+// ============================================================================
+// SNK-2: end-of-stream is never reported while the pipeline is still running
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-2: an open sink is WAITING or HAS_DATA, never EOS",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repo] = make_sink();
+
+  // Open + empty: more output may still arrive — the consumer must not conclude EOS.
+  REQUIRE(op->availability() == availability::WAITING);
+  REQUIRE_FALSE(op->drained());
+  REQUIRE_FALSE(op->pull().has_value());
+
+  sink_one(*op, make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32));
+  REQUIRE(op->availability() == availability::HAS_DATA);
+  REQUIRE_FALSE(op->drained());
+}
+
+// ============================================================================
+// SNK-3: finalize is end-of-stream; queued output still outranks it
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-3: finalize drives EOS only once the output is drained",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repo] = make_sink();
+  sink_one(*op, make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32));
+
+  op->finalize_operator();
+
+  // Terminal, but the accepted batch is still pullable — invariant 2.
+  REQUIRE(op->availability() == availability::HAS_DATA);
+  REQUIRE_FALSE(op->drained());
+
+  REQUIRE(op->pull().has_value());
+  REQUIRE(op->availability() == availability::END_OF_STREAM);
+  REQUIRE(op->drained());
+  REQUIRE_FALSE(op->pull().has_value());
+}
+
+// ============================================================================
+// SNK-4: an empty fragment reaches EOS on finalize alone
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-4: a fragment that produced nothing still reaches EOS",
+          "[streaming_sink]")
+{
+  auto [op, repo] = make_sink();
+
+  REQUIRE_FALSE(op->drained());
+  op->finalize_operator();
+  REQUIRE(op->drained());
+  REQUIRE(op->availability() == availability::END_OF_STREAM);
+}
+
+// ============================================================================
+// SNK-5: no output is accepted after end-of-stream
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-5: sink after finalize is dropped", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repo] = make_sink();
+  op->finalize_operator();
+
+  // A late batch must not land behind a consumer that already observed END_OF_STREAM.
+  sink_one(*op, make_numeric_batch<int32_t>(*gpu_space, {99}, cudf::type_id::INT32));
+  REQUIRE(repo->total_size() == 0);
+  REQUIRE(op->drained());
+}
+
+// ============================================================================
+// SNK-6: wait() unblocks on a sunk batch
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-6: wait unblocks when the pipeline produces", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repo] = make_sink();
+  auto batch      = make_numeric_batch<int32_t>(*gpu_space, {5}, cudf::type_id::INT32);
+  std::atomic<bool> returned{false};
+
+  std::thread consumer([&] {
+    op->wait();
+    returned = true;
+  });
+
+  std::this_thread::sleep_for(20ms);
+  REQUIRE_FALSE(returned.load());
+
+  sink_one(*op, batch);
+  consumer.join();
+
+  REQUIRE(returned.load());
+  REQUIRE(op->pull().has_value());
+}
+
+// ============================================================================
+// SNK-7: wait() unblocks on finalize of an empty stream
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-7: wait unblocks on end-of-stream", "[streaming_sink]")
+{
+  auto [op, repo] = make_sink();
+  std::atomic<bool> returned{false};
+
+  std::thread consumer([&] {
+    op->wait();
+    returned = true;
+  });
+
+  std::this_thread::sleep_for(20ms);
+  REQUIRE_FALSE(returned.load());
+
+  op->finalize_operator();
+  consumer.join();
+
+  REQUIRE(returned.load());
+  REQUIRE(op->drained());
+}
+
+// ============================================================================
+// SNK-8: construction and addressing contracts
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-8: null repository and out-of-range index are rejected",
+          "[streaming_sink]")
+{
+  auto types =
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER});
+
+  REQUIRE_THROWS_AS(sirius_physical_streaming_sink(types, 0, nullptr),
+                    sirius::invalid_input_exception);
+
+  auto [op, repo] = make_sink();
+  REQUIRE(op->num_output_streams() == 1);
+  REQUIRE(op->is_sink());
+  REQUIRE_THROWS_AS(op->pull(1), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(op->drained(1), sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// SNK-9: the memory estimate is a pass-through
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-9: memory estimate is stats.bytes", "[streaming_sink]")
+{
+  auto [op, repo] = make_sink();
+
+  input_stats stats;
+  stats.bytes       = 4096;
+  stats.num_batches = 2;
+
+  REQUIRE(op->no_history_peak_memory_estimate(stats) == stats.bytes);
+}
+
+// ============================================================================
+// SNK-10: source → filter → sink round-trip over native batches only
+//
+// The acceptance demo for the data path: a batch pushed into a streaming source comes back out
+// of a streaming sink, filtered, with no channel and no Arrow anywhere in between.
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-10: source to filter to sink round-trips native batches",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream = default_stream();
+
+  auto source_repo = std::make_shared<cucascade::shared_data_repository>();
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  sirius_physical_streaming_source source(
+    sirius::from_duckdb_vec(types), 0, source_repo, std::set<sender_id_t>{0});
+
+  auto [sink, sink_repo] = make_sink();
+
+  // col0 = filter key (int64), col1 = int32 payload.
+  std::vector<int64_t> filter_col{1, 5, 2, 8, 3};
+  std::vector<int32_t> data_col{10, 50, 20, 80, 30};
+  auto batch =
+    make_two_column_batch<int64_t, int32_t>(*gpu_space, filter_col, data_col, cudf::type_id::INT32);
+
+  REQUIRE(source.push(batch));
+  source.close_input(0);
+
+  // FILTER: col0 > 3.
+  auto filter_expr_duck = duckdb::make_uniq<duckdb::BoundComparisonExpression>(
+    duckdb::ExpressionType::COMPARE_GREATERTHAN,
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(
+      duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), 0),
+    duckdb::make_uniq<duckdb::BoundConstantExpression>(duckdb::Value::BIGINT(3)));
+  sirius_physical_filter filter_op(
+    sirius::from_duckdb_vec(types), sirius::ast::from_duckdb(*filter_expr_duck), 0);
+
+  // Drive the fragment: source → filter → sink, one task per batch.
+  while (true) {
+    auto hint = source.get_next_task_hint();
+    if (!hint.has_value()) break;  // EOS
+    REQUIRE(hint->hint == TaskCreationHint::READY);
+
+    auto input = source.get_next_task_input_data();
+    REQUIRE(input != nullptr);
+    auto source_out = source.execute(*input, stream);
+    auto filter_out = filter_op.execute(*source_out, stream);
+    sink->sink(*filter_out, stream);
+  }
+  sink->finalize_operator();
+
+  // The consumer sees exactly the filtered rows, and then a clean end-of-stream.
+  auto out = sink->pull();
+  REQUIRE(out.has_value());
+
+  auto view       = sirius::get_cudf_table_view(**out);
+  auto res_filter = copy_column_to_host<int64_t>(view.column(0));
+  auto res_data   = copy_column_to_host<int32_t>(view.column(1));
+  REQUIRE(res_filter == std::vector<int64_t>{5, 8});
+  REQUIRE(res_data == std::vector<int32_t>{50, 80});
+
+  REQUIRE(sink->drained());
+  REQUIRE(sink->availability() == availability::END_OF_STREAM);
+}

--- a/test/cpp/pipeline/test_streaming_sink_root.cpp
+++ b/test/cpp/pipeline/test_streaming_sink_root.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_physical_operator_type.hpp"
+#include "op/sirius_physical_streaming_sink.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "sirius_engine.hpp"
+
+#include <catch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <duckdb.hpp>
+#include <utils/pipeline_conversion_test_utils.hpp>
+#include <utils/sirius_test_env.hpp>
+
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+using sirius::op::sirius_physical_streaming_sink;
+using sirius::op::SiriusPhysicalOperatorType;
+using sirius::pipeline::sirius_pipeline;
+
+namespace {
+
+fs::path integration_db_path()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return fs::path(SIRIUS_PROJECT_ROOT) / "test/cpp/integration/data/duckdb/integration.duckdb";
+#else
+  return fs::path(__FILE__).parent_path().parent_path() /
+         "integration/data/duckdb/integration.duckdb";
+#endif
+}
+
+struct streaming_sink_root_fixture {
+  streaming_sink_root_fixture()
+  {
+    REQUIRE(sirius::test::g_integration_env != nullptr);
+    if (!sirius::test::g_integration_env->is_active()) {
+      sirius::test::g_integration_env->resume();
+    }
+    con = std::make_unique<duckdb::Connection>(sirius::test::g_integration_env->make_connection());
+
+    auto db_path = integration_db_path();
+    REQUIRE(fs::exists(db_path));
+    auto result =
+      con->Query("ATTACH IF NOT EXISTS '" + db_path.string() + "' AS tpch (READ_ONLY);");
+    REQUIRE(result);
+    REQUIRE_FALSE(result->HasError());
+    result = con->Query("USE tpch;");
+    REQUIRE(result);
+    REQUIRE_FALSE(result->HasError());
+  }
+
+  std::unique_ptr<duckdb::Connection> con;
+};
+
+std::vector<std::shared_ptr<cucascade::shared_data_repository>> make_repos(std::size_t n)
+{
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos;
+  repos.reserve(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    repos.push_back(std::make_shared<cucascade::shared_data_repository>());
+  }
+  return repos;
+}
+
+//! The pipeline whose `operators` contain `op`, or nullptr.
+const sirius_pipeline* pipeline_with_operator(
+  const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines,
+  const sirius::op::sirius_physical_operator& target)
+{
+  for (const auto& pipeline : pipelines) {
+    for (const auto& op : pipeline->get_operators()) {
+      if (&op.get() == &target) { return pipeline.get(); }
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+// ============================================================================
+// SINKROOT-1: a fragment plan rooted in a STREAMING_SINK initializes
+// ============================================================================
+
+TEST_CASE_METHOD(streaming_sink_root_fixture,
+                 "SINKROOT-1: a streaming-sink-rooted plan initializes",
+                 "[integration][pipeline][streaming_sink_root]")
+{
+  auto repos = make_repos(1);
+
+  sirius::test::with_initialized_streaming_fragment(
+    *con,
+    "SELECT n_regionkey FROM nation",
+    repos,
+    std::nullopt,
+    [&](sirius::sirius_engine& engine, sirius_physical_streaming_sink& sink) {
+      // The sink is the plan root and its subtree hangs off children[], so the plan generator
+      // needs none of the out-of-tree descent the RESULT_COLLECTOR requires.
+      REQUIRE(sink.type == SiriusPhysicalOperatorType::STREAMING_SINK);
+      REQUIRE(sink.children.size() == 1);
+      REQUIRE(sink.get_parent_op() == nullptr);
+
+      // A streaming fragment never produces a QueryResult.
+      REQUIRE_FALSE(engine.has_result_collector());
+
+      REQUIRE(sink.num_output_streams() == 1);
+    });
+}
+
+// ============================================================================
+// SINKROOT-2: the sink lands in a pipeline's operators, so EOS can fire
+// ============================================================================
+
+TEST_CASE_METHOD(streaming_sink_root_fixture,
+                 "SINKROOT-2: the streaming sink reaches a pipeline's operators",
+                 "[integration][pipeline][streaming_sink_root]")
+{
+  auto repos = make_repos(1);
+
+  sirius::test::with_initialized_streaming_fragment(
+    *con,
+    "SELECT n_regionkey FROM nation",
+    repos,
+    std::nullopt,
+    [&](sirius::sirius_engine& engine, sirius_physical_streaming_sink& sink) {
+      // This is the load-bearing invariant. on_finalize_operator() -- the sink's only route to
+      // end-of-stream -- is driven by update_pipeline_status() iterating get_operators(), which
+      // returns the `operators` vector and EXCLUDES the source/sink members. If the sink is not
+      // in that vector, EOS never fires and every consumer blocked in wait() hangs forever, with
+      // no error anywhere.
+      const auto* owning = pipeline_with_operator(engine.sirius_pipelines, sink);
+      REQUIRE(owning != nullptr);
+
+      // And it is the pipeline's terminal sink, which is what tells the executor the query is
+      // complete once that pipeline finishes.
+      REQUIRE(owning->get_sink().get() == &sink);
+      REQUIRE(owning->is_query_terminal());
+    });
+}
+
+// ============================================================================
+// SINKROOT-3: a partitioned sink root exposes one output stream per destination
+// ============================================================================
+
+TEST_CASE_METHOD(streaming_sink_root_fixture,
+                 "SINKROOT-3: a partitioned sink root keeps its fan-out",
+                 "[integration][pipeline][streaming_sink_root]")
+{
+  auto repos = make_repos(3);
+
+  sirius::test::with_initialized_streaming_fragment(
+    *con,
+    "SELECT n_regionkey FROM nation",
+    repos,
+    sirius::op::partition_spec{{0}, {}},
+    [&](sirius::sirius_engine& engine, sirius_physical_streaming_sink& sink) {
+      REQUIRE(sink.num_output_streams() == 3);
+      REQUIRE(pipeline_with_operator(engine.sirius_pipelines, sink) != nullptr);
+      // Nothing has run, so every destination is empty but none has ended.
+      for (std::size_t i = 0; i < 3; ++i) {
+        REQUIRE_FALSE(sink.drained(i));
+      }
+    });
+}

--- a/test/cpp/utils/pipeline_conversion_test_utils.cpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.cpp
@@ -213,6 +213,55 @@ void with_initialized_engine(duckdb::Connection& con,
   }
 }
 
+void with_initialized_streaming_fragment(
+  duckdb::Connection& con,
+  const std::string& query,
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repos,
+  std::optional<op::partition_spec> spec,
+  const std::function<void(sirius_engine&, op::sirius_physical_streaming_sink&)>& consume)
+{
+  auto& context = *con.context;
+
+  con.BeginTransaction();
+  try {
+    extracted_plan extracted;
+    {
+      optimizer_disable_guard guard(context);
+      extracted = extract_logical_plan_sirius_order(context, query);
+    }
+
+    sirius::planner::sirius_physical_plan_generator physical_planner(context);
+    auto sirius_plan = physical_planner.create_plan(std::move(extracted.logical_plan));
+
+    // A STREAMING_SINK is a normal unary operator, unlike the RESULT_COLLECTOR, which keeps its
+    // child outside `children[]` and needs special descent in the plan generator. Attaching the
+    // subtree as children[0] is what keeps that special-casing unnecessary.
+    auto types       = sirius_plan->types;
+    auto cardinality = sirius_plan->estimated_cardinality;
+    duckdb::unique_ptr<op::sirius_physical_streaming_sink> sink;
+    if (spec.has_value()) {
+      sink = duckdb::make_uniq<op::sirius_physical_streaming_sink>(
+        std::move(types), cardinality, std::move(output_repos), std::move(*spec));
+    } else {
+      sink = duckdb::make_uniq<op::sirius_physical_streaming_sink>(
+        std::move(types), cardinality, output_repos.front());
+    }
+    sink->children.push_back(std::move(sirius_plan));
+
+    sirius_interface iface(context);
+    sirius_engine engine(context, iface);
+    // The fragment owns the plan; the engine borrows it. initialize() would take ownership and
+    // destroy the sink with the engine, leaving nothing to pull from afterwards.
+    engine.initialize_internal(*sink);
+    consume(engine, *sink);
+
+    con.Rollback();
+  } catch (...) {
+    con.Rollback();
+    throw;
+  }
+}
+
 std::string convert_query_to_dump(duckdb::Connection& con, const std::string& query)
 {
   std::string dump;

--- a/test/cpp/utils/pipeline_conversion_test_utils.hpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.hpp
@@ -16,11 +16,17 @@
 
 #pragma once
 
+#include "op/sirius_physical_streaming_sink.hpp"
+
+#include <cucascade/data/data_repository.hpp>
 #include <duckdb/main/connection.hpp>
 
 #include <filesystem>
 #include <functional>
+#include <memory>
+#include <optional>
 #include <string>
+#include <vector>
 
 namespace sirius::pipeline {
 struct pipeline_conversion_result;
@@ -55,6 +61,17 @@ void with_conversion_result(
 void with_initialized_engine(duckdb::Connection& con,
                              const std::string& query,
                              const std::function<void(sirius_engine&)>& consume);
+
+//! Like `with_initialized_engine`, but roots the plan in a STREAMING_SINK over `output_repos`
+//! instead of a RESULT_COLLECTOR — the shape a streaming fragment runs. The caller (standing in
+//! for the fragment) owns the plan tree, so the engine borrows it via `initialize_internal`.
+//! `consume` runs while both are alive.
+void with_initialized_streaming_fragment(
+  duckdb::Connection& con,
+  const std::string& query,
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repos,
+  std::optional<op::partition_spec> spec,
+  const std::function<void(sirius_engine&, op::sirius_physical_streaming_sink&)>& consume);
 
 //! Path to the canonical TPC-H queries (`test/tpch_performance/tpch_queries/orig/`).
 std::filesystem::path tpch_queries_dir();


### PR DESCRIPTION
Stack from ghstack (oldest at bottom):

* [#1301](https://github.com/sirius-db/sirius/pull/1301) feat(exec): build and run a streaming plan (#839)
* [#1300](https://github.com/sirius-db/sirius/pull/1300) feat(exec): stream_session, the id-addressed streaming router (#839)
* [#1299](https://github.com/sirius-db/sirius/pull/1299) feat(op): partition the streaming sink across N destinations (#838)
* **--> [#1298](https://github.com/sirius-db/sirius/pull/1298) feat(op): streaming sink over an output repository (#837)**
* [#1297](https://github.com/sirius-db/sirius/pull/1297) feat(exec): repository-backed streaming source with sender-aware EOS (#836)

Closes #837

---

## What

A sink that publishes each task's batches into a `shared_data_repository` as they are produced, so a stage emits incrementally instead of materializing into a `ColumnDataCollection`. Batches are pushed in their current memory tier — no Arrow, no forced GPU upgrade, no copy — and stay spillable until a consumer pulls them.

Direct repository access rather than the bounded `exchange_channel` the original issue specified, per #1276.

## How it works

Three things the operator needs to work at all, none of them obvious from the issue text:

- **`execute()` is overridden.** The executor runs every operator in the chain, terminal sink included, and feeds the chain's result back into `sink()`. The base implementation returns an empty batch list, so without the override the sink discards the pipeline's data and receives that emptiness back — the query succeeds with an empty output stream and no error anywhere.
- **`build_pipelines()` appends the sink to the current pipeline**, mirroring `RESULT_COLLECTOR`. The base sink path skips the append, which leaves the terminal operator out of the root pipeline and the source with nothing driving it.
- **`is_query_terminal()` now covers `STREAMING_SINK`** as well as `RESULT_COLLECTOR`, so a sink-rooted plan signals completion. Without it the pipelines finish and `sirius_engine::execute()` blocks on its future forever.

`sink()` also checks `admit()`'s return: a batch arriving after end-of-stream is warned about rather than dropped in silence.

## Testing

`SINKROOT-1..4` drive the sink through a **real query** — the plan-root contract, the operator landing in `operators[0]`, and rows actually reaching the repository. Every prior streaming test called `sink()` directly with hand-built operator data, bypassing the executor, which is why the `execute()` defect was invisible.

## Files changed

| File | Change |
|---|---|
| `src/op/sirius_physical_streaming_sink.{hpp,cpp}` | New: repository-backed sink, `execute()` pass-through, `build_pipelines`, EOS on finalize |
| `src/pipeline/sirius_pipeline.{hpp,cpp}` | `is_query_terminal()` covers `STREAMING_SINK` |
| `src/pipeline/gpu_pipeline_executor.cpp` | Completion gate keyed on `is_query_terminal()` |
| `src/pipeline/sirius_pipeline_converter.cpp` | Terminal-sink pipeline wiring |
| `test/cpp/pipeline/test_streaming_sink_root.cpp` | New: `SINKROOT-1..4` over a real query |
