### PR TITLE
feat(op): partition the streaming sink across N destinations (#838)

### DIFF
--- a/src/include/op/sirius_physical_streaming_sink.hpp
+++ b/src/include/op/sirius_physical_streaming_sink.hpp
@@ -19,13 +19,29 @@
 #include "exec/stream_lifecycle.hpp"
 #include "op/sirius_physical_operator.hpp"
 
+#include <cudf/types.hpp>
+
 #include <cucascade/data/data_repository.hpp>
 
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <vector>
 
 namespace sirius::op {
+
+/// How a partitioned sink routes rows across its output streams.
+///
+/// Only the *function* lives here. Which compute node each partition ships to is the wrapper's
+/// routing table, and N is `output_repositories.size()` — the sink stays oblivious to both.
+struct partition_spec {
+  /// Column indices hashed to pick a destination. Must be non-empty for a partitioned sink.
+  std::vector<int> key_columns;
+
+  /// Per-key cast applied before hashing, so keys that differ only in representation (INT32 vs
+  /// INT64) still land together. Empty means "hash every key as-is".
+  std::vector<cudf::data_type> key_cast_types;
+};
 
 /// Terminal operator of a streaming fragment: every batch its pipeline produces is pushed into
 /// an output `cucascade::shared_data_repository`, where an external consumer pulls it.
@@ -43,13 +59,26 @@ class sirius_physical_streaming_sink : public sirius_physical_operator {
   /// The pipeline feeding this sink is its one and only sender.
   static constexpr exec::sender_id_t PIPELINE_SENDER = 0;
 
-  /// Single-destination sink: one output stream, no partitioning.
+  /// Single-destination sink: one output stream, no partitioning. The N = 1 case of the
+  /// constructor below.
   ///
   /// @throws sirius::invalid_input_exception when `output_repository` is null.
   sirius_physical_streaming_sink(
     duckdb::vector<sirius::logical_type> types,
     std::size_t estimated_cardinality,
     std::shared_ptr<cucascade::shared_data_repository> output_repository);
+
+  /// Partitioned sink: N output streams, one per destination, each with its own repository.
+  /// Every batch is GPU-hash-partitioned by `spec` and slice *i* is pushed into
+  /// `output_repositories[i]`.
+  ///
+  /// @throws sirius::invalid_input_exception when `output_repositories` is empty or contains a
+  ///         null entry, or when N > 1 and `spec.key_columns` is empty (nothing to route by).
+  sirius_physical_streaming_sink(
+    duckdb::vector<sirius::logical_type> types,
+    std::size_t estimated_cardinality,
+    std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repositories,
+    partition_spec spec);
 
   bool is_sink() const override { return true; }
 
@@ -70,13 +99,18 @@ class sirius_physical_streaming_sink : public sirius_physical_operator {
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
 
-  /// Push this task's output batches into the output repository, natively — no Arrow, no GPU
-  /// upgrade, no copy. A push after end-of-stream is dropped by the lifecycle rather than
-  /// landing behind a consumer that already saw EOS.
+  /// Publish this task's output batches.
+  ///
+  /// With one destination the batches go straight into the output repository, natively — no
+  /// Arrow, no GPU upgrade, no copy. With N > 1 each batch is GPU-hash-partitioned by the
+  /// partition spec and slice *i* goes into repository *i*; empty slices are skipped rather
+  /// than published as zero-row batches. A push after end-of-stream is dropped by the lifecycle
+  /// rather than landing behind a consumer that already saw EOS.
   void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
 
-  /// Pass-through: pushing a batch allocates nothing, so report the input bytes instead of the
-  /// default 2× heuristic (matches the streaming source).
+  /// Report the input bytes rather than the default 2× heuristic (matching the streaming
+  /// source). With one destination the push allocates nothing at all; with N the partition
+  /// produces about one input's worth of new device memory. Neither warrants 2×.
   [[nodiscard]] std::size_t no_history_peak_memory_estimate(
     const input_stats& stats) const override;
 
@@ -114,6 +148,9 @@ class sirius_physical_streaming_sink : public sirius_physical_operator {
   /// One repository per destination. Output stream id, partition index and repository
   /// correspond positionally.
   std::vector<std::shared_ptr<cucascade::shared_data_repository>> _output_repositories;
+
+  /// Empty `key_columns` means "not partitioned" — only valid when there is one destination.
+  partition_spec _spec;
 
   /// Shared by every output stream — the pipeline is one sender feeding all of them, so they
   /// reach end-of-stream together. Per-stream `drained()` / `wait()` still AND this terminal

--- a/src/op/sirius_physical_streaming_sink.cpp
+++ b/src/op/sirius_physical_streaming_sink.cpp
@@ -16,13 +16,14 @@
 
 #include "op/sirius_physical_streaming_sink.hpp"
 
-#include "sirius/exception.hpp"
-#include <log/logging.hpp>
-
+#include "data/data_batch_utils.hpp"
+#include "op/partition/gpu_partition_impl.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
+#include "sirius/exception.hpp"
 
 #include <cucascade/data/data_batch.hpp>
+#include <log/logging.hpp>
 
 #include <string>
 #include <utility>
@@ -44,6 +45,34 @@ sirius_physical_streaming_sink::sirius_physical_streaming_sink(
   _output_repositories.push_back(std::move(output_repository));
 }
 
+sirius_physical_streaming_sink::sirius_physical_streaming_sink(
+  duckdb::vector<sirius::logical_type> types,
+  std::size_t estimated_cardinality,
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repositories,
+  partition_spec spec)
+  : sirius_physical_operator(
+      SiriusPhysicalOperatorType::STREAMING_SINK, std::move(types), estimated_cardinality),
+    _output_repositories(std::move(output_repositories)),
+    _spec(std::move(spec)),
+    _lifecycle(std::set<exec::sender_id_t>{PIPELINE_SENDER})
+{
+  if (_output_repositories.empty()) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_sink: at least one output repository is required");
+  }
+  for (std::size_t i = 0; i < _output_repositories.size(); ++i) {
+    if (!_output_repositories[i]) {
+      throw sirius::invalid_input_exception("sirius_physical_streaming_sink: output repository " +
+                                            std::to_string(i) + " must not be null");
+    }
+  }
+  if (_output_repositories.size() > 1 && _spec.key_columns.empty()) {
+    throw sirius::invalid_input_exception("sirius_physical_streaming_sink: a sink with " +
+                                          std::to_string(_output_repositories.size()) +
+                                          " destinations needs partition key columns to route by");
+  }
+}
+
 std::unique_ptr<operator_data> sirius_physical_streaming_sink::execute(
   const operator_data& input_data, rmm::cuda_stream_view /*stream*/)
 {
@@ -54,18 +83,48 @@ std::unique_ptr<operator_data> sirius_physical_streaming_sink::execute(
 }
 
 void sirius_physical_streaming_sink::sink(const operator_data& input_data,
-                                          rmm::cuda_stream_view /*stream*/)
+                                          rmm::cuda_stream_view stream)
 {
   const auto& input = dynamic_cast<const pipelineable_operator_data&>(input_data);
 
-  // Pushed in their current tier: no Arrow, no forced GPU upgrade, no copy. The batch stays
-  // spillable in the repository until a consumer pulls it.
-  for (const auto& batch : input.get_data_batches()) {
-    // admit() refuses once the stream is terminal. Ignoring that return silently drops the
-    // batch, which surfaces as a fragment that "succeeds" with an empty output.
-    if (!_lifecycle.admit([&] { _output_repositories[0]->add_data_batch(batch); })) {
-      SIRIUS_LOG_WARN(
-        "sirius_physical_streaming_sink: batch refused after end-of-stream and dropped");
+  if (_output_repositories.size() == 1) {
+    // Pushed in their current tier: no Arrow, no forced GPU upgrade, no copy. The batch stays
+    // spillable in the repository until a consumer pulls it.
+    for (const auto& batch : input.get_data_batches()) {
+      // admit() refuses once the stream is terminal. Ignoring that return silently drops the
+      // batch, which surfaces as a fragment that "succeeds" with an empty output.
+      if (!_lifecycle.admit([&] { _output_repositories[0]->add_data_batch(batch); })) {
+        SIRIUS_LOG_WARN(
+          "sirius_physical_streaming_sink: batch refused after end-of-stream and dropped");
+      }
+    }
+    return;
+  }
+
+  const auto num_partitions = static_cast<int>(_output_repositories.size());
+  for (const auto& input_batch : input.get_read_only_batches()) {
+    auto* space = input_batch.get_memory_space();
+    if (space == nullptr) {
+      throw sirius::internal_exception(
+        "sirius_physical_streaming_sink: partitioned sink requires a resident input batch");
+    }
+
+    // Same kernel as the PARTITION operator; only the routing (slice i -> repository i) is new.
+    // Any consistent hash co-locates equal keys, which is all a local cut needs — matching a
+    // front end's exact partition function is translation's job.
+    auto slices = gpu_partition_impl::hash_partition(input_batch,
+                                                     _spec.key_columns,
+                                                     _spec.key_cast_types,
+                                                     num_partitions,
+                                                     stream,
+                                                     *space,
+                                                     batch_telemetry());
+
+    for (std::size_t i = 0; i < slices.size(); ++i) {
+      // An empty partition stays WAITING until the pipeline finishes, rather than publishing a
+      // zero-row batch a consumer would have to pull and discard.
+      if (sirius::get_cudf_table_view(*slices[i]).num_rows() == 0) { continue; }
+      _lifecycle.admit([&] { _output_repositories[i]->add_data_batch(slices[i]); });
     }
   }
 }
@@ -73,7 +132,8 @@ void sirius_physical_streaming_sink::sink(const operator_data& input_data,
 std::size_t sirius_physical_streaming_sink::no_history_peak_memory_estimate(
   const input_stats& stats) const
 {
-  // Pushing a handle into the output repository allocates nothing new.
+  // A single-destination push allocates nothing; a partitioned one rewrites the input into N
+  // slices, i.e. roughly one input's worth. Both are well under the 2× default.
   return stats.bytes;
 }
 
@@ -129,8 +189,8 @@ void sirius_physical_streaming_sink::wait(std::size_t index)
 bool sirius_physical_streaming_sink::drained(std::size_t index) const
 {
   validate_index(index);
-  // ANDed with *this* stream's emptiness: the terminal flag is shared across destinations, so a
-  // partition with a backlog must not read as drained just because its siblings are.
+  // ANDed with this stream's own emptiness: the terminal flag is shared across destinations, so
+  // a partition with a backlog must not read as drained because its siblings are.
   return _lifecycle.drained(_output_repositories[index]->all_empty());
 }
 

--- a/test/cpp/operator/test_physical_streaming_sink.cpp
+++ b/test/cpp/operator/test_physical_streaming_sink.cpp
@@ -31,11 +31,14 @@
 #include <op/sirius_physical_streaming_source.hpp>
 #include <sirius/exception.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <map>
 #include <memory>
 #include <set>
 #include <thread>
+#include <utility>
 #include <vector>
 
 using namespace sirius::exec;
@@ -61,12 +64,43 @@ auto make_sink()
   return std::make_tuple(std::move(op), repo);
 }
 
+/// Partitioned sink over `n` fresh output repositories, routing on column 0.
+auto make_partitioned_sink(std::size_t n)
+{
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos;
+  for (std::size_t i = 0; i < n; ++i) {
+    repos.push_back(std::make_shared<cucascade::shared_data_repository>());
+  }
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  auto op = std::make_unique<sirius_physical_streaming_sink>(
+    sirius::from_duckdb_vec(types), 0, repos, partition_spec{{0}, {}});
+  return std::make_tuple(std::move(op), repos);
+}
+
 /// Feed one batch through the sink exactly as publish_output() would.
 void sink_one(sirius_physical_streaming_sink& op, std::shared_ptr<cucascade::data_batch> batch)
 {
   pipelineable_operator_data data{
     std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(batch)}};
   op.sink(data, default_stream());
+}
+
+/// Drain output stream `index` completely, returning the (key, payload) rows it held.
+std::vector<std::pair<int64_t, int32_t>> drain_rows(sirius_physical_streaming_sink& op,
+                                                    std::size_t index)
+{
+  std::vector<std::pair<int64_t, int32_t>> rows;
+  while (auto batch = op.pull(index)) {
+    auto view = sirius::get_cudf_table_view(**batch);
+    auto keys = copy_column_to_host<int64_t>(view.column(0));
+    auto vals = copy_column_to_host<int32_t>(view.column(1));
+    REQUIRE(keys.size() == vals.size());
+    for (std::size_t i = 0; i < keys.size(); ++i) {
+      rows.emplace_back(keys[i], vals[i]);
+    }
+  }
+  return rows;
 }
 
 }  // namespace
@@ -342,4 +376,276 @@ TEST_CASE("streaming_sink SNK-10: source to filter to sink round-trips native ba
 
   REQUIRE(sink->drained());
   REQUIRE(sink->availability() == availability::END_OF_STREAM);
+}
+
+// ============================================================================
+// PART-1: fan-out routes every row to exactly one destination, losing nothing
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-1: partitioned fan-out preserves every row exactly once",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  const std::size_t N = GENERATE(std::size_t{2}, std::size_t{3});
+  auto [op, repos]    = make_partitioned_sink(N);
+  REQUIRE(op->num_output_streams() == N);
+
+  // Three batches of distinct keys, so the union across destinations is the whole input.
+  std::vector<std::pair<int64_t, int32_t>> expected;
+  for (int b = 0; b < 3; ++b) {
+    std::vector<int64_t> keys;
+    std::vector<int32_t> vals;
+    for (int i = 0; i < 8; ++i) {
+      const auto key = static_cast<int64_t>(b * 8 + i);
+      keys.push_back(key);
+      vals.push_back(static_cast<int32_t>(key * 10));
+      expected.emplace_back(key, static_cast<int32_t>(key * 10));
+    }
+    sink_one(*op,
+             make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  }
+  op->finalize_operator();
+
+  std::vector<std::pair<int64_t, int32_t>> seen;
+  for (std::size_t i = 0; i < N; ++i) {
+    auto rows = drain_rows(*op, i);
+    seen.insert(seen.end(), rows.begin(), rows.end());
+  }
+
+  std::sort(seen.begin(), seen.end());
+  std::sort(expected.begin(), expected.end());
+  REQUIRE(seen == expected);
+}
+
+// ============================================================================
+// PART-2: equal keys are co-located — the property a shuffle actually needs
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-2: rows with the same key land on the same destination",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 3;
+  auto [op, repos]        = make_partitioned_sink(N);
+
+  // The same four keys, repeated across two separate batches (i.e. two separate tasks).
+  const std::vector<int64_t> keys{100, 200, 300, 400};
+  for (int b = 0; b < 2; ++b) {
+    std::vector<int32_t> vals(keys.size(), static_cast<int32_t>(b));
+    sink_one(*op,
+             make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  }
+  op->finalize_operator();
+
+  // Where each key ended up. Whatever the hash, a key must never appear on two destinations —
+  // otherwise a downstream MERGE_GROUP_BY on another node would see a partial group.
+  std::map<int64_t, std::size_t> destination_of;
+  for (std::size_t i = 0; i < N; ++i) {
+    for (const auto& [key, _] : drain_rows(*op, i)) {
+      auto [it, inserted] = destination_of.emplace(key, i);
+      REQUIRE(it->second == i);
+    }
+  }
+  REQUIRE(destination_of.size() == keys.size());
+}
+
+// ============================================================================
+// PART-3: a slow destination cannot head-of-line-block the others
+//
+// This is the whole point of per-destination repositories: partition 0 is never
+// drained, and the remaining partitions must still drain and reach EOS.
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-3: an undrained destination does not block its siblings",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 2;
+  auto [op, repos]        = make_partitioned_sink(N);
+
+  std::vector<int64_t> keys;
+  std::vector<int32_t> vals;
+  for (int i = 0; i < 64; ++i) {
+    keys.push_back(i);
+    vals.push_back(i);
+  }
+  sink_one(*op,
+           make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  op->finalize_operator();
+
+  // Find a destination that actually received rows, and leave it untouched.
+  std::size_t slow = N;
+  for (std::size_t i = 0; i < N; ++i) {
+    if (!repos[i]->all_empty()) {
+      slow = i;
+      break;
+    }
+  }
+  REQUIRE(slow < N);
+
+  for (std::size_t i = 0; i < N; ++i) {
+    if (i == slow) continue;
+    drain_rows(*op, i);
+    // Drained independently, even though `slow` still holds a backlog.
+    REQUIRE(op->drained(i));
+    REQUIRE(op->availability(i) == availability::END_OF_STREAM);
+  }
+
+  // The slow destination is still distinguishable from EOS: terminal, but not drained.
+  REQUIRE_FALSE(op->drained(slow));
+  REQUIRE(op->availability(slow) == availability::HAS_DATA);
+
+  // And it drains cleanly whenever its consumer gets around to it.
+  drain_rows(*op, slow);
+  REQUIRE(op->drained(slow));
+}
+
+// ============================================================================
+// PART-4: finalize drives every destination to EOS together
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-4: one finalize ends all destinations", "[streaming_sink]")
+{
+  constexpr std::size_t N = 3;
+  auto [op, repos]        = make_partitioned_sink(N);
+
+  for (std::size_t i = 0; i < N; ++i) {
+    REQUIRE(op->availability(i) == availability::WAITING);
+    REQUIRE_FALSE(op->drained(i));
+  }
+
+  op->finalize_operator();
+
+  for (std::size_t i = 0; i < N; ++i) {
+    REQUIRE(op->availability(i) == availability::END_OF_STREAM);
+    REQUIRE(op->drained(i));
+  }
+}
+
+// ============================================================================
+// PART-5: wait(i) tracks its own destination
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-5: wait on one destination unblocks on its own data",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 2;
+  auto [op, repos]        = make_partitioned_sink(N);
+
+  std::vector<int64_t> keys;
+  std::vector<int32_t> vals;
+  for (int i = 0; i < 32; ++i) {
+    keys.push_back(i);
+    vals.push_back(i);
+  }
+
+  std::atomic<int> returned{0};
+  std::thread c0([&] {
+    op->wait(0);
+    returned.fetch_add(1);
+  });
+  std::thread c1([&] {
+    op->wait(1);
+    returned.fetch_add(1);
+  });
+
+  std::this_thread::sleep_for(20ms);
+  REQUIRE(returned.load() == 0);
+
+  sink_one(*op,
+           make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  op->finalize_operator();  // guarantees both waiters wake even if one partition got no rows
+
+  c0.join();
+  c1.join();
+  REQUIRE(returned.load() == 2);
+}
+
+// ============================================================================
+// PART-6: N = 1 through the partitioned constructor is the Phase-2 sink
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-6: a single destination bypasses partitioning", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos{
+    std::make_shared<cucascade::shared_data_repository>()};
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  // No key columns needed: with one destination there is nothing to route.
+  sirius_physical_streaming_sink op(sirius::from_duckdb_vec(types), 0, repos, partition_spec{});
+
+  const std::vector<int64_t> keys{1, 2, 3};
+  const std::vector<int32_t> vals{10, 20, 30};
+  auto batch =
+    make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32);
+  auto batch_id = batch->get_batch_id();
+  sink_one(op, batch);
+  op.finalize_operator();
+
+  // Identity preserved, exactly as the single-repository constructor: no partition, no copy.
+  auto pulled = op.pull();
+  REQUIRE(pulled.has_value());
+  REQUIRE((*pulled)->get_batch_id() == batch_id);
+  REQUIRE(op.drained());
+}
+
+// ============================================================================
+// PART-7: partitioned-sink construction contracts
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-7: destination list and spec are validated", "[streaming_sink]")
+{
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  auto sirius_types = sirius::from_duckdb_vec(types);
+  auto repo         = std::make_shared<cucascade::shared_data_repository>();
+
+  // No destinations at all.
+  REQUIRE_THROWS_AS(sirius_physical_streaming_sink(
+                      sirius_types,
+                      0,
+                      std::vector<std::shared_ptr<cucascade::shared_data_repository>>{},
+                      partition_spec{{0}, {}}),
+                    sirius::invalid_input_exception);
+
+  // A null destination.
+  REQUIRE_THROWS_AS(
+    sirius_physical_streaming_sink(
+      sirius_types,
+      0,
+      std::vector<std::shared_ptr<cucascade::shared_data_repository>>{repo, nullptr},
+      partition_spec{{0}, {}}),
+    sirius::invalid_input_exception);
+
+  // Several destinations but nothing to route by — silently sending every row to destination 0
+  // would corrupt a downstream shuffle, so this is rejected.
+  REQUIRE_THROWS_AS(
+    sirius_physical_streaming_sink(sirius_types,
+                                   0,
+                                   std::vector<std::shared_ptr<cucascade::shared_data_repository>>{
+                                     repo, std::make_shared<cucascade::shared_data_repository>()},
+                                   partition_spec{}),
+    sirius::invalid_input_exception);
+
+  auto [op, repos] = make_partitioned_sink(2);
+  REQUIRE_THROWS_AS(op->pull(2), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(op->drained(2), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(op->availability(2), sirius::invalid_input_exception);
 }


### PR DESCRIPTION
Stack from ghstack (oldest at bottom):

* [#1301](https://github.com/sirius-db/sirius/pull/1301) feat(exec): build and run a streaming plan (#839)
* [#1300](https://github.com/sirius-db/sirius/pull/1300) feat(exec): stream_session, the id-addressed streaming router (#839)
* **--> [#1299](https://github.com/sirius-db/sirius/pull/1299) feat(op): partition the streaming sink across N destinations (#838)**
* [#1298](https://github.com/sirius-db/sirius/pull/1298) feat(op): streaming sink over an output repository (#837)
* [#1297](https://github.com/sirius-db/sirius/pull/1297) feat(exec): repository-backed streaming source with sender-aware EOS (#836)

Closes #838

---

## What

Gives the sink N output repositories and routes each batch across them, so partitions can be split out to different receivers instead of one slow consumer blocking the rest.

Fan-out is over direct repository access, not per-partition channels, per #1276.

## How it works

Partitioning runs on the GPU with the same `hash_partition` kernel the `PARTITION` operator uses; only the routing (slice *i* → repository *i*) is new. Any consistent hash co-locates equal keys, which is what a local single-node cut needs — reproducing StarRocks' exact partition function is translation's job. Empty slices are skipped rather than published as zero-row batches a consumer would have to pull and discard.

The memory-estimate rationale is corrected here too: a single-destination push allocates nothing, but a partitioned one rewrites the input into slices, so "pushing a batch allocates nothing" was only true before this change. The estimate itself is unchanged and still well under the 2× default.

## Not covered

Coverage here is **unit-level only** — the demo path exercises a gather exchange, so nothing drives this end to end yet.

Deferred, each with its real blocker:
- hashing beyond the default, coalescing, and range-partitioning are unimplemented;
- end-to-end shuffle is additionally blocked by the StarRocks translator rejecting two-phase aggregation, the compute node never reading `TDataStreamSink.output_partition`, and the sender broadcasting a clone to every destination.

## Files changed

| File | Change |
|---|---|
| `src/op/sirius_physical_streaming_sink.{hpp,cpp}` | `partition_spec`, N-destination constructor, GPU hash routing |
| `test/cpp/operator/test_physical_streaming_sink.cpp` | Partitioning cases |
