### PR TITLE
Enable cucascade-io backed by abseil + duckdb's moodycamel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,8 +154,23 @@ set(CUCASCADE_WARNINGS_AS_ERRORS
     OFF
     CACHE BOOL "" FORCE)
 set(CUCASCADE_BUILD_IO
-    OFF
+    ON
     CACHE BOOL "" FORCE)
+# cucascade-io's callable and lock-free queues are swappable so they can reuse
+# the copies sirius already links, instead of an in-tree callable and a fetched
+# concurrentqueue: absl::AnyInvocable backs cucascade::exec::invocable, and
+# duckdb's vendored concurrentqueue (namespace duckdb_moodycamel, already on the
+# include path via duckdb) backs the queues. absl::any_invocable is resolved by
+# the find_package(absl) above, so cucascade reuses that target.
+set(CUCASCADE_USE_ABSEIL_INVOCABLE
+    ON
+    CACHE BOOL "" FORCE)
+set(CUCASCADE_MOODYCAMEL_INCLUDE_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/duckdb/third_party/concurrentqueue"
+    CACHE PATH "" FORCE)
+set(CUCASCADE_MOODYCAMEL_NAMESPACE
+    "duckdb_moodycamel"
+    CACHE STRING "" FORCE)
 add_subdirectory(cucascade "${CMAKE_BINARY_DIR}/cucascade" EXCLUDE_FROM_ALL)
 
 if(VCPKG_BUILD AND TARGET CUDA::cudart_static)
@@ -182,9 +197,17 @@ if(VCPKG_BUILD AND TARGET CUDA::cudart_static)
                                                       Static)
   endfunction()
 
-  foreach(_target
-          cucascade_objects cucascade_static cucascade_shared
-          cucascade_cudf_objects cucascade_cudf_static cucascade_cudf_shared)
+  foreach(
+    _target
+    cucascade_objects
+    cucascade_static
+    cucascade_shared
+    cucascade_cudf_objects
+    cucascade_cudf_static
+    cucascade_cudf_shared
+    cucascade_io_objects
+    cucascade_io_static
+    cucascade_io_shared)
     if(TARGET "${_target}")
       sirius_prefer_static_cudart("${_target}")
     endif()
@@ -550,10 +573,20 @@ endif()
 # cucascade_static / telemetry_bridge). cucascade upstream PR #126 split
 # topology_discovery into its own static target, and PR #150 split the
 # cudf-coupled code into cucascade_cudf_static — list both here so the export
-# set covers the full dependency chain.
+# set covers the full dependency chain. With CUCASCADE_BUILD_IO=ON,
+# cucascade_cudf_static also PUBLIC-links cucascade_io_static (which links the
+# cucascade_io_thirdparty interface target); add both so this export set stays
+# self-contained instead of referencing them from cucascade's own
+# cuCascadeTargets export, mirroring why the cucascade_* targets are listed here
+# rather than resolved via find_package.
 install(
-  TARGETS sirius_extension cucascade_static cucascade_cudf_static
-          cucascade_topology_discovery_static telemetry_bridge
+  TARGETS sirius_extension
+          cucascade_static
+          cucascade_cudf_static
+          cucascade_io_static
+          cucascade_io_thirdparty
+          cucascade_topology_discovery_static
+          telemetry_bridge
   EXPORT "${DUCKDB_EXPORT_SET}"
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
   ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")


### PR DESCRIPTION
## What

Turns on the cucascade-io library in the sirius build and wires its swappable
third-party backends to the copies sirius already links, so nothing is
duplicated or fetched:

- `CUCASCADE_BUILD_IO=ON`
- `CUCASCADE_USE_ABSEIL_INVOCABLE=ON` → `cucascade::exec::invocable` becomes
  `absl::AnyInvocable`, reusing the `absl::any_invocable` target from the
  existing `find_package(absl)`.
- `CUCASCADE_MOODYCAMEL_INCLUDE_DIR` + `CUCASCADE_MOODYCAMEL_NAMESPACE` point
  cucascade's lock-free queues at duckdb's vendored concurrentqueue
  (namespace `duckdb_moodycamel`).

`cucascade_cudf_static` now PUBLIC-links `cucascade_io_static`, so
`cucascade_io_static` / `cucascade_io_thirdparty` are added to the duckdb export
set (keeping it self-contained) and to the static-cudart `foreach`.

Bumps the `cucascade` submodule to the commit that adds these knobs.

## Depends on
- NVIDIA/cuCascade#168 (the cucascade side). The submodule bump points at that
  PR's head SHA; it resolves from a clean clone once #168 merges to
  `NVIDIA/cuCascade:main`.

## Verification
Built `cucascade_io_objects` + `cucascade_cudf_objects` inside sirius's
environment (its pixi-env abseil + duckdb's concurrentqueue). Object symbols
confirm `invocable` resolved to `absl::…AnyInvocable` and the queues to
`duckdb_moodycamel::ConcurrentQueue<…>`, with no fetch. The export-set change was
validated against a probe mirroring sirius's `install(TARGETS ... EXPORT)`.

## Not included
Sirius still ships its own `src/include/io/` (`sirius::io::*`). This only
builds/links cucascade-io (no namespace clash with sirius's own io); routing
sirius's call sites onto it is a follow-up.

## Draft because
A full end-to-end sirius link was not run here (needs all submodules + a
from-scratch dep build); the cucascade dependency PR (#168) is not yet merged.