### PR TITLE
feat(op): streaming sink over an output repository (#837)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ set(EXTENSION_SOURCES
     src/op/dynamic_filter_publisher.cpp
     src/op/sirius_dynamic_filter.cpp
     src/op/sirius_physical_column_data_scan.cpp
+    src/op/sirius_physical_streaming_sink.cpp
     src/op/sirius_physical_streaming_source.cpp
     src/op/sirius_physical_concat.cpp
     src/op/sirius_physical_cte.cpp
@@ -691,6 +692,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_physical_partition.cpp
     test/cpp/operator/test_physical_projection.cpp
     test/cpp/operator/test_physical_result_collector.cpp
+    test/cpp/operator/test_physical_streaming_sink.cpp
     test/cpp/operator/test_physical_streaming_source.cpp
     test/cpp/operator/test_physical_table_scan.cpp
     test/cpp/operator/test_no_history_peak_memory_estimate.cpp
@@ -717,6 +719,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_gpu_pipeline_disk_readback.cpp
     test/cpp/pipeline/test_get_next_ports_after_sink.cpp
     test/cpp/pipeline/test_merge_pipeline_fusion.cpp
+    test/cpp/pipeline/test_streaming_sink_root.cpp
     test/cpp/pipeline/test_partition_build_pipelines.cpp
     test/cpp/pipeline/test_pipeline_dynamic_filter_native_shape.cpp
     test/cpp/pipeline/test_pipeline_schedule_canonical.cpp

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -106,6 +106,34 @@ relieves memory pressure. Sirius has no upward "stop producing" signal today (hi
 `READY` / `WAITING` / nothing), so the intended lever is per-fragment priority, not a bounded
 queue.
 
+### `sirius_physical_streaming_sink` — `STREAMING_SINK`
+**File:** `src/include/op/sirius_physical_streaming_sink.hpp`
+
+Terminal operator of a streaming fragment: every batch the pipeline produces is pushed into one
+`exec::batch_stream` and exposed to an external consumer via `pull()` / `wait()` / `drained()`.
+
+Where the source stands where no table exists, the sink stands where no `RESULT_COLLECTOR` exists:
+the fragment's output travels over an exchange channel rather than into a query result. It is shaped
+like `RESULT_COLLECTOR` (appended to `current` in `build_pipelines`, set as the meta-pipeline sink)
+so the executor places it at `operators[last]` and drives its `on_finalize_operator()` — which is
+the only route to end-of-stream for the output stream.
+
+Key design facts:
+- **One sender, one finalize.** The pipeline feeding this sink is its single expected sender
+  (`PIPELINE_SENDER = 0`). `on_finalize_operator()` calls `close(PIPELINE_SENDER)` on the output
+  `exec::batch_stream`, which is what makes it terminal. Without `build_pipelines` placing the sink in
+  `operators`, `on_finalize_operator()` is never called and every consumer blocked in `wait()`
+  hangs forever with no error visible.
+- **No re-arm waker.** Unlike the source, the sink does not wire an `on_data` hook: its consumer
+  is an external thread blocking in `wait()`, not an engine task needing re-nomination.
+- **Native tier.** Batches are pushed in whatever tier they arrived — no Arrow, no forced GPU
+  upgrade. A queued batch stays spillable in the repository until pulled.
+- **execute() is a pass-through** (same shape as `RESULT_COLLECTOR`): it hands the batches back so
+  `publish_output()` can deliver them to `sink()`. The base implementation drops them.
+- **`no_history_peak_memory_estimate()` is 0.** The push allocates nothing on top of the input the
+  task already materialized, which is what this cold-start estimate measures; the caller maxes it
+  across the pipeline's operators, so anything higher would inflate the reservation.
+
 ### `sirius_physical_dummy_scan` — `DUMMY_SCAN`
 **File:** `src/include/op/sirius_physical_dummy_scan.hpp`
 
@@ -382,6 +410,7 @@ After pipeline finalization, `source` and `sink` are just aliases for the first 
 |----------|----------|-----------|
 | GPU_SCAN | Scan | Unified GPU scan source served by `sirius_scan_manager` via a per-format `gpu_ingestible` |
 | STREAMING_SOURCE | Scan | Exchange-input source; drains an `exec::batch_stream` (repository fed by `push()`, sender-aware EOS, producer-error plane) |
+| STREAMING_SINK | Exchange output | Terminal operator of a streaming fragment; pushes each batch into an `exec::batch_stream`; `on_finalize_operator()` closes the stream |
 | DUMMY_SCAN | Scan | Generates 1 row |
 | COLUMN_DATA_SCAN | Scan | Reads ColumnDataCollection |
 | FILTER | Relational | `expression_evaluator::select()` |

--- a/src/include/op/sirius_physical_operator_type.hpp
+++ b/src/include/op/sirius_physical_operator_type.hpp
@@ -148,7 +148,8 @@ enum class SiriusPhysicalOperatorType : uint8_t {
   GPU_VALUES,
   GPU_SCAN,
   DYNAMIC_FILTER,
-  STREAMING_SOURCE
+  STREAMING_SOURCE,
+  STREAMING_SINK
 };
 
 std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type);

--- a/src/include/op/sirius_physical_streaming_sink.hpp
+++ b/src/include/op/sirius_physical_streaming_sink.hpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "exec/batch_stream.hpp"
+#include "op/sirius_physical_operator.hpp"
+
+#include <cucascade/data/data_repository.hpp>
+
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <optional>
+
+namespace sirius::op {
+
+/// Terminal operator of a streaming fragment: every batch its pipeline produces is pushed into
+/// one `exec::batch_stream` per destination, where an external consumer pulls it.
+///
+/// Batches are exposed natively — in whatever tier they currently sit — so nothing is
+/// materialized or converted to Arrow on the way out, and a queued batch stays spillable by the
+/// downgrade executor until it is pulled.
+///
+/// Unlike the source, the sink arms no re-arm waker: its consumer is an external thread blocking
+/// in `wait()`, not an engine task that needs re-nominating.
+class sirius_physical_streaming_sink : public sirius_physical_operator {
+ public:
+  static constexpr SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::STREAMING_SINK;
+
+  /// The pipeline feeding this sink is its one and only sender.
+  static constexpr exec::sender_id_t PIPELINE_SENDER = 0;
+
+  /// Single-destination sink: one output stream, no partitioning.
+  ///
+  /// @throws sirius::invalid_input_exception when `output_repository` is null.
+  sirius_physical_streaming_sink(
+    duckdb::vector<sirius::logical_type> types,
+    std::size_t estimated_cardinality,
+    std::shared_ptr<cucascade::shared_data_repository> output_repository);
+
+  bool is_sink() const override { return true; }
+
+  //! The sink is appended to `current` (landing at operators[0] after the reverse) and set as
+  //! the sink of its own child meta pipeline. The base sink path skips the append, which leaves
+  //! the terminal operator out of the root pipeline and the source with nothing driving it.
+  void build_pipelines(pipeline::sirius_pipeline& current,
+                       pipeline::sirius_meta_pipeline& meta_pipeline) override;
+
+  // -----------------------------------------------------------------------
+  // Producer side (engine)
+  // -----------------------------------------------------------------------
+
+  /// Pass-through. The executor runs every operator in the chain, terminal sink included, and
+  /// feeds the chain's result back into sink(). The base implementation returns an empty batch
+  /// list, so without this override the sink receives nothing and the pipeline "succeeds" with
+  /// an empty output stream.
+  std::unique_ptr<operator_data> execute(const operator_data& input_data,
+                                         rmm::cuda_stream_view stream) override;
+
+  /// Push this task's output batches into the output stream, natively — no Arrow, no GPU
+  /// upgrade, no copy. A push after end-of-stream is dropped by the stream rather than landing
+  /// behind a consumer that already saw EOS.
+  void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+
+  /// Pass-through: pushing a batch allocates nothing beyond the input this task already
+  /// materialized, so this reports 0 — "no additional peak" — rather than the default 2×
+  /// heuristic. The caller maxes this across the pipeline's operators, so a non-zero answer here
+  /// would inflate every cold-start reservation.
+  [[nodiscard]] std::size_t no_history_peak_memory_estimate(
+    const input_stats& stats) const override;
+
+  // -----------------------------------------------------------------------
+  // Consumer side (external wrapper / session, never an engine task)
+  // -----------------------------------------------------------------------
+
+  /// Number of output streams this sink exposes. One per destination.
+  [[nodiscard]] std::size_t num_output_streams() const { return _outputs.size(); }
+
+  /// Non-blocking pull of the next batch of output stream `index`.
+  /// @return nullopt when nothing is available right now — which is *not* the same as EOS; ask
+  ///         `drained(index)` to tell the two apart.
+  /// @throws sirius::invalid_input_exception when `index` is out of range.
+  std::optional<std::shared_ptr<cucascade::data_batch>> pull(std::size_t index = 0);
+
+  /// Block until output stream `index` has a batch to pull or the stream has ended.
+  /// External threads only.
+  void wait(std::size_t index = 0);
+
+  /// True when the pipeline has finished AND output stream `index` is empty.
+  [[nodiscard]] bool drained(std::size_t index = 0) const;
+
+  /// Non-blocking classification of output stream `index`: HAS_DATA / WAITING / END_OF_STREAM.
+  [[nodiscard]] exec::batch_stream::availability availability(std::size_t index = 0) const;
+
+  /// The query died: poison every output stream. External consumers unblock from wait() and
+  /// collect the rethrow from pull() — never a clean end. First failure wins.
+  void fail_output(std::exception_ptr error);
+
+ protected:
+  /// The pipeline finishing is this stream's end-of-stream: it is the single expected sender.
+  void on_finalize_operator() override;
+
+  /// @throws sirius::invalid_input_exception when `index` is out of range.
+  void validate_index(std::size_t index) const;
+
+  /// One stream per destination. Output stream id, partition index and stream correspond
+  /// positionally; this PR constructs exactly one.
+  std::vector<std::shared_ptr<exec::batch_stream>> _outputs;
+};
+
+}  // namespace sirius::op

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -186,6 +186,13 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! Checks if the pipeline has been finished
   virtual bool is_pipeline_finished() const;
 
+  //! Whether this pipeline's sink terminates the query — it has no downstream consumer to
+  //! schedule and no repository wiring to emit, and its completion is what signals the future
+  //! `sirius_engine::execute()` waits on. True for a RESULT_COLLECTOR (the engine-injected root
+  //! of a normal query) and for a STREAMING_SINK (the root of a streaming fragment, whose output
+  //! leaves through session-owned repositories rather than a QueryResult).
+  [[nodiscard]] bool is_query_terminal() const;
+
   void mark_task_created();
   void mark_task_completed();
 

--- a/src/op/sirius_physical_operator_type.cpp
+++ b/src/op/sirius_physical_operator_type.cpp
@@ -115,6 +115,7 @@ std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type)
     case SiriusPhysicalOperatorType::GPU_SCAN: return "GPU_SCAN";
     case SiriusPhysicalOperatorType::DYNAMIC_FILTER: return "DYNAMIC_FILTER";
     case SiriusPhysicalOperatorType::STREAMING_SOURCE: return "STREAMING_SOURCE";
+    case SiriusPhysicalOperatorType::STREAMING_SINK: return "STREAMING_SINK";
     case SiriusPhysicalOperatorType::INVALID: break;
   }
   return "INVALID";

--- a/src/op/sirius_physical_streaming_sink.cpp
+++ b/src/op/sirius_physical_streaming_sink.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_physical_streaming_sink.hpp"
+
+#include "pipeline/sirius_meta_pipeline.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "sirius/exception.hpp"
+
+#include <cucascade/data/data_batch.hpp>
+#include <log/logging.hpp>
+
+#include <string>
+#include <utility>
+
+namespace sirius::op {
+
+sirius_physical_streaming_sink::sirius_physical_streaming_sink(
+  duckdb::vector<sirius::logical_type> types,
+  std::size_t estimated_cardinality,
+  std::shared_ptr<cucascade::shared_data_repository> output_repository)
+  : sirius_physical_operator(
+      SiriusPhysicalOperatorType::STREAMING_SINK, std::move(types), estimated_cardinality)
+{
+  if (!output_repository) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_sink: output_repository must not be null");
+  }
+  _outputs.push_back(std::make_shared<exec::batch_stream>(
+    std::move(output_repository), std::set<exec::sender_id_t>{PIPELINE_SENDER}));
+}
+
+std::unique_ptr<operator_data> sirius_physical_streaming_sink::execute(
+  const operator_data& input_data, rmm::cuda_stream_view /*stream*/)
+{
+  // As sirius_physical_result_collector does: hand the batches back so publish_output() can
+  // deliver them to sink(). The base implementation would drop them.
+  return std::make_unique<pipelineable_operator_data>(
+    dynamic_cast<const pipelineable_operator_data&>(input_data).get_read_only_batches());
+}
+
+void sirius_physical_streaming_sink::sink(const operator_data& input_data,
+                                          rmm::cuda_stream_view /*stream*/)
+{
+  const auto& input = dynamic_cast<const pipelineable_operator_data&>(input_data);
+
+  // Pushed in their current tier: no Arrow, no forced GPU upgrade, no copy. The batch stays
+  // spillable in the repository until a consumer pulls it.
+  for (const auto& batch : input.get_data_batches()) {
+    // push() refuses once the stream is terminal. Ignoring that return silently drops the
+    // batch, which surfaces as a fragment that "succeeds" with an empty output.
+    if (!_outputs[0]->push(batch)) {
+      SIRIUS_LOG_WARN(
+        "sirius_physical_streaming_sink: batch refused after end-of-stream and dropped");
+    }
+  }
+}
+
+std::size_t sirius_physical_streaming_sink::no_history_peak_memory_estimate(
+  const input_stats& /*stats*/) const
+{
+  // Pushing a handle into the output stream allocates nothing on top of the already-materialized
+  // input, which is what this estimate measures. 0 is the "no additional peak" answer — reporting
+  // the input bytes instead would raise the whole pipeline's cold-start reservation, since the
+  // caller takes the max across operators.
+  return 0;
+}
+
+void sirius_physical_streaming_sink::build_pipelines(pipeline::sirius_pipeline& current,
+                                                     pipeline::sirius_meta_pipeline& meta_pipeline)
+{
+  if (children.size() != 1) {
+    throw sirius::internal_exception(
+      "sirius_physical_streaming_sink: expects exactly one child subtree");
+  }
+
+  // Append to `current` so the terminal operator is part of the root pipeline, then start the
+  // real pipeline from the child. Same shape as RESULT_COLLECTOR.
+  auto& state = meta_pipeline.get_state();
+  state.add_pipeline_operator(current, *this);
+
+  auto& child_meta_pipeline = meta_pipeline.create_child_meta_pipeline(current, *this);
+  child_meta_pipeline.build(*children[0]);
+}
+
+void sirius_physical_streaming_sink::on_finalize_operator()
+{
+  // The pipeline is the single sender, so its completion is end-of-stream for all outputs.
+  for (auto& s : _outputs) {
+    s->close(PIPELINE_SENDER);
+  }
+}
+
+void sirius_physical_streaming_sink::validate_index(std::size_t index) const
+{
+  if (index >= _outputs.size()) {
+    throw sirius::invalid_input_exception("sirius_physical_streaming_sink: output stream index " +
+                                          std::to_string(index) + " out of range (" +
+                                          std::to_string(_outputs.size()) + " streams)");
+  }
+}
+
+std::optional<std::shared_ptr<cucascade::data_batch>> sirius_physical_streaming_sink::pull(
+  std::size_t index)
+{
+  validate_index(index);
+  auto batch = _outputs[index]->try_pull();
+  if (!batch) { return std::nullopt; }
+  return batch;
+}
+
+void sirius_physical_streaming_sink::wait(std::size_t index)
+{
+  validate_index(index);
+  _outputs[index]->wait();
+}
+
+bool sirius_physical_streaming_sink::drained(std::size_t index) const
+{
+  validate_index(index);
+  return _outputs[index]->drained();
+}
+
+exec::batch_stream::availability sirius_physical_streaming_sink::availability(
+  std::size_t index) const
+{
+  validate_index(index);
+  return _outputs[index]->classify();
+}
+
+void sirius_physical_streaming_sink::fail_output(std::exception_ptr error)
+{
+  for (auto& s : _outputs) {
+    s->fail(error);
+  }
+}
+
+}  // namespace sirius::op

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -445,11 +445,8 @@ void gpu_pipeline_executor::manager_loop()
         // which may destroy the engine and its operators. We must not schedule
         // tasks that reference those operators after signaling completion.
         bool query_complete = false;
-        if (_completion_handler && pipeline) {
-          auto sink = pipeline->get_sink();
-          if (sink && sink->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
-            query_complete = pipeline->is_pipeline_finished();
-          }
+        if (_completion_handler && pipeline && pipeline->is_query_terminal()) {
+          query_complete = pipeline->is_pipeline_finished();
         }
 
         if (!query_complete && _task_creator) {

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -337,17 +337,22 @@ bool sirius_pipeline::is_pipeline_finished() const
   return pipeline_finished.load();
 }
 
+bool sirius_pipeline::is_query_terminal() const
+{
+  auto s = get_sink();
+  if (!s) { return false; }
+  return s->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR ||
+         s->type == op::SiriusPhysicalOperatorType::STREAMING_SINK;
+}
+
 void sirius_pipeline::set_task_creator(sirius::creator::task_creator* tc) { _task_creator = tc; }
 
 void sirius_pipeline::notify_downstream_pipelines(bool original_pipeline)
 {
-  // If this pipeline's sink is the RESULT_COLLECTOR, it is the terminal
-  // pipeline of the query — there is no downstream consumer to schedule and
-  // no parent pipeline whose status needs updating. Returning early avoids
-  // racing with engine teardown after mark_completed() signals the future.
-  if (auto s = get_sink(); s && s->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
-    return;
-  }
+  // A query-terminal sink ends the query — there is no downstream consumer to schedule and
+  // no parent pipeline whose status needs updating. Returning early avoids racing with engine
+  // teardown after mark_completed() signals the future.
+  if (is_query_terminal()) { return; }
 
   // Schedule output consumers via the task_creator so downstream pipelines
   // whose FULL-barrier ports are now unblocked will get tasks created.

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -284,8 +284,11 @@ void sirius_pipeline_converter::compute_repository_wiring(sirius_pipeline_build_
 
     using T = op::SiriusPhysicalOperatorType;
 
-    // RESULT_COLLECTOR is a terminal sink — nothing to emit.
-    if (sink_op->type == T::RESULT_COLLECTOR) { continue; }
+    // A query-terminal sink has no downstream pipeline — nothing to emit. A STREAMING_SINK root
+    // would also fall through to the `!parent_op` check below, but only while it stays the plan
+    // root; skip it explicitly. The predicate lives on the pipeline so the terminal-sink set is
+    // defined once, here and in the executor's completion check.
+    if (pipeline->is_query_terminal()) { continue; }
 
     // CTE fans out to its sibling `cte_scans` (parent_op alone doesn't encode them).
     // CTE_SCAN never lands in any pipeline's operators[], so consumers resolve via

--- a/test/cpp/operator/test_physical_streaming_sink.cpp
+++ b/test/cpp/operator/test_physical_streaming_sink.cpp
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator_test_utils.hpp"
+
+#include <catch.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <data/data_batch_utils.hpp>
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <exec/batch_stream.hpp>
+#include <expression/ast/from_duckdb.hpp>
+#include <helper/type_conversions.hpp>
+#include <op/sirius_physical_filter.hpp>
+#include <op/sirius_physical_streaming_sink.hpp>
+#include <op/sirius_physical_streaming_source.hpp>
+#include <sirius/exception.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <set>
+#include <thread>
+#include <vector>
+
+using namespace sirius::exec;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+using namespace std::chrono_literals;
+
+namespace {
+
+using namespace sirius::test::operator_utils;
+
+using availability = batch_stream::availability;
+
+/// Single-destination sink over a fresh output repository.
+auto make_sink()
+{
+  auto repo = std::make_shared<cucascade::shared_data_repository>();
+  auto op   = std::make_unique<sirius_physical_streaming_sink>(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    repo);
+  return std::make_tuple(std::move(op), repo);
+}
+
+/// Feed one batch through the sink exactly as publish_output() would.
+void sink_one(sirius_physical_streaming_sink& op, std::shared_ptr<cucascade::data_batch> batch)
+{
+  pipelineable_operator_data data{
+    std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(batch)}};
+  op.sink(data, default_stream());
+}
+
+}  // namespace
+
+// ============================================================================
+// SNK-1: sink() publishes exactly the batches it was given, natively
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-1: sunk batches appear in the output repository in order",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr int K = 4;
+  auto [op, repo] = make_sink();
+
+  std::vector<uint64_t> pushed_ids;
+  for (int i = 0; i < K; ++i) {
+    auto batch = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    pushed_ids.push_back(batch->get_batch_id());
+    sink_one(*op, batch);
+  }
+
+  REQUIRE(repo->total_size() == K);
+
+  // Pointer identity end-to-end: the sink pushed the batch itself, not a copy or a conversion.
+  std::vector<uint64_t> pulled_ids;
+  while (auto batch = op->pull()) {
+    pulled_ids.push_back((*batch)->get_batch_id());
+  }
+  REQUIRE(pulled_ids == pushed_ids);
+  REQUIRE(repo->total_size() == 0);
+}
+
+// ============================================================================
+// SNK-2: end-of-stream is never reported while the pipeline is still running
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-2: an open sink is WAITING or HAS_DATA, never EOS",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repo] = make_sink();
+
+  // Open + empty: more output may still arrive — the consumer must not conclude EOS.
+  REQUIRE(op->availability() == availability::WAITING);
+  REQUIRE_FALSE(op->drained());
+  REQUIRE_FALSE(op->pull().has_value());
+
+  sink_one(*op, make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32));
+  REQUIRE(op->availability() == availability::HAS_DATA);
+  REQUIRE_FALSE(op->drained());
+}
+
+// ============================================================================
+// SNK-3: finalize is end-of-stream; queued output still outranks it
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-3: finalize drives EOS only once the output is drained",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repo] = make_sink();
+  sink_one(*op, make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32));
+
+  op->finalize_operator();
+
+  // Terminal, but the accepted batch is still pullable — data wins over EOS (classify()).
+  REQUIRE(op->availability() == availability::HAS_DATA);
+  REQUIRE_FALSE(op->drained());
+
+  REQUIRE(op->pull().has_value());
+  REQUIRE(op->availability() == availability::END_OF_STREAM);
+  REQUIRE(op->drained());
+  REQUIRE_FALSE(op->pull().has_value());
+}
+
+// ============================================================================
+// SNK-4: an empty fragment reaches EOS on finalize alone
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-4: a fragment that produced nothing still reaches EOS",
+          "[streaming_sink]")
+{
+  auto [op, repo] = make_sink();
+
+  REQUIRE_FALSE(op->drained());
+  op->finalize_operator();
+  REQUIRE(op->drained());
+  REQUIRE(op->availability() == availability::END_OF_STREAM);
+}
+
+// ============================================================================
+// SNK-5: no output is accepted after end-of-stream
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-5: sink after finalize is dropped", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repo] = make_sink();
+  op->finalize_operator();
+
+  // A late batch must not land behind a consumer that already observed END_OF_STREAM.
+  sink_one(*op, make_numeric_batch<int32_t>(*gpu_space, {99}, cudf::type_id::INT32));
+  REQUIRE(repo->total_size() == 0);
+  REQUIRE(op->drained());
+}
+
+// ============================================================================
+// SNK-6: wait() unblocks on a sunk batch
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-6: wait unblocks when the pipeline produces", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repo] = make_sink();
+  auto batch      = make_numeric_batch<int32_t>(*gpu_space, {5}, cudf::type_id::INT32);
+  std::atomic<bool> returned{false};
+
+  std::thread consumer([&] {
+    op->wait();
+    returned = true;
+  });
+
+  std::this_thread::sleep_for(20ms);
+  REQUIRE_FALSE(returned.load());
+
+  sink_one(*op, batch);
+  consumer.join();
+
+  REQUIRE(returned.load());
+  REQUIRE(op->pull().has_value());
+}
+
+// ============================================================================
+// SNK-7: wait() unblocks on finalize of an empty stream
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-7: wait unblocks on end-of-stream", "[streaming_sink]")
+{
+  auto [op, repo] = make_sink();
+  std::atomic<bool> returned{false};
+
+  std::thread consumer([&] {
+    op->wait();
+    returned = true;
+  });
+
+  std::this_thread::sleep_for(20ms);
+  REQUIRE_FALSE(returned.load());
+
+  op->finalize_operator();
+  consumer.join();
+
+  REQUIRE(returned.load());
+  REQUIRE(op->drained());
+}
+
+// ============================================================================
+// SNK-8: construction and addressing contracts
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-8: null repository and out-of-range index are rejected",
+          "[streaming_sink]")
+{
+  auto types =
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER});
+
+  REQUIRE_THROWS_AS(sirius_physical_streaming_sink(types, 0, nullptr),
+                    sirius::invalid_input_exception);
+
+  auto [op, repo] = make_sink();
+  REQUIRE(op->num_output_streams() == 1);
+  REQUIRE(op->is_sink());
+  REQUIRE_THROWS_AS(op->pull(1), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(op->drained(1), sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// SNK-9: the memory estimate reports no additional peak
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-9: memory estimate reports no additional peak", "[streaming_sink]")
+{
+  auto [op, repo] = make_sink();
+
+  input_stats stats;
+  stats.bytes       = 4096;
+  stats.num_batches = 2;
+
+  // Nothing is allocated on top of the input, and the caller maxes this across the pipeline.
+  REQUIRE(op->no_history_peak_memory_estimate(stats) == 0);
+}
+
+// ============================================================================
+// SNK-10: source → filter → sink round-trip over native batches only
+//
+// The acceptance demo for the data path: a batch pushed into a streaming source comes back out
+// of a streaming sink, filtered, with no channel and no Arrow anywhere in between.
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-10: source to filter to sink round-trips native batches",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream = default_stream();
+
+  auto source_repo = std::make_shared<cucascade::shared_data_repository>();
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  sirius_physical_streaming_source source(
+    sirius::from_duckdb_vec(types), 0, source_repo, std::set<sender_id_t>{0});
+
+  auto [sink, sink_repo] = make_sink();
+
+  // col0 = filter key (int64), col1 = int32 payload.
+  std::vector<int64_t> filter_col{1, 5, 2, 8, 3};
+  std::vector<int32_t> data_col{10, 50, 20, 80, 30};
+  auto batch =
+    make_two_column_batch<int64_t, int32_t>(*gpu_space, filter_col, data_col, cudf::type_id::INT32);
+
+  REQUIRE(source.push(batch));
+  source.close_input(0);
+
+  // FILTER: col0 > 3.
+  auto filter_expr_duck = duckdb::make_uniq<duckdb::BoundComparisonExpression>(
+    duckdb::ExpressionType::COMPARE_GREATERTHAN,
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(
+      duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), 0),
+    duckdb::make_uniq<duckdb::BoundConstantExpression>(duckdb::Value::BIGINT(3)));
+  sirius_physical_filter filter_op(
+    sirius::from_duckdb_vec(types), sirius::ast::from_duckdb(*filter_expr_duck), 0);
+
+  // Drive the fragment: source → filter → sink, one task per batch.
+  while (true) {
+    auto hint = source.get_next_task_hint();
+    if (!hint.has_value()) break;  // EOS
+    REQUIRE(hint->hint == TaskCreationHint::READY);
+
+    auto input = source.get_next_task_input_data();
+    REQUIRE(input != nullptr);
+    auto source_out = source.execute(*input, stream);
+    auto filter_out = filter_op.execute(*source_out, stream);
+    sink->sink(*filter_out, stream);
+  }
+  sink->finalize_operator();
+
+  // The consumer sees exactly the filtered rows, and then a clean end-of-stream.
+  auto out = sink->pull();
+  REQUIRE(out.has_value());
+
+  auto view       = sirius::get_cudf_table_view(**out);
+  auto res_filter = copy_column_to_host<int64_t>(view.column(0));
+  auto res_data   = copy_column_to_host<int32_t>(view.column(1));
+  REQUIRE(res_filter == std::vector<int64_t>{5, 8});
+  REQUIRE(res_data == std::vector<int32_t>{50, 80});
+
+  REQUIRE(sink->drained());
+  REQUIRE(sink->availability() == availability::END_OF_STREAM);
+}
+
+// ============================================================================
+// SINK-ERR-1: fail_output() unblocks a consumer blocked in wait() and rethrows
+// ============================================================================
+
+TEST_CASE("streaming_sink SINK-ERR-1: fail_output unblocks wait and rethrows in pull",
+          "[streaming_sink]")
+{
+  auto [op, repo] = make_sink();
+  std::atomic<bool> returned{false};
+
+  std::thread consumer([&] {
+    op->wait();
+    returned = true;
+  });
+
+  std::this_thread::sleep_for(20ms);
+  REQUIRE_FALSE(returned.load());
+
+  auto err = std::make_exception_ptr(std::runtime_error("query failed"));
+  op->fail_output(err);
+  consumer.join();
+
+  REQUIRE(returned.load());
+  // pull() rethrows the injected error — never a quiet clean end.
+  REQUIRE_THROWS_AS(op->pull(), std::runtime_error);
+}
+
+// ============================================================================
+// SINK-ERR-2: availability never reports EOS and drained stays false under error
+// ============================================================================
+
+TEST_CASE("streaming_sink SINK-ERR-2: errored stream never reports clean end", "[streaming_sink]")
+{
+  auto [op, repo] = make_sink();
+
+  auto err = std::make_exception_ptr(std::runtime_error("query failed"));
+  op->fail_output(err);
+
+  // A pending error reads as HAS_DATA (P4): the consumer comes back to collect the rethrow.
+  REQUIRE(op->availability() == availability::HAS_DATA);
+  // drained() stays false: the error is never consumed, so EOS is never a clean end.
+  REQUIRE_FALSE(op->drained());
+}
+
+// ============================================================================
+// SNK-11: after finalize, accepted data is still pullable before drained() is true
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-11: finalize then pull reaches END_OF_STREAM cleanly",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repo] = make_sink();
+
+  // Sink one batch then finalize.
+  sink_one(*op, make_numeric_batch<int32_t>(*gpu_space, {42}, cudf::type_id::INT32));
+  op->finalize_operator();
+
+  // Stream 0 is terminal but not drained — the queued batch is still pullable.
+  REQUIRE(op->availability() == availability::HAS_DATA);
+  REQUIRE_FALSE(op->drained());
+
+  // Pull drains it; now it's at a clean end.
+  REQUIRE(op->pull().has_value());
+  REQUIRE(op->availability() == availability::END_OF_STREAM);
+  REQUIRE(op->drained());
+}

--- a/test/cpp/pipeline/test_streaming_sink_root.cpp
+++ b/test/cpp/pipeline/test_streaming_sink_root.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_physical_operator_type.hpp"
+#include "op/sirius_physical_streaming_sink.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "sirius_engine.hpp"
+
+#include <catch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <duckdb.hpp>
+#include <utils/pipeline_conversion_test_utils.hpp>
+#include <utils/sirius_test_env.hpp>
+
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+using sirius::op::sirius_physical_streaming_sink;
+using sirius::op::SiriusPhysicalOperatorType;
+using sirius::pipeline::sirius_pipeline;
+
+namespace {
+
+fs::path integration_db_path()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return fs::path(SIRIUS_PROJECT_ROOT) / "test/cpp/integration/data/duckdb/integration.duckdb";
+#else
+  return fs::path(__FILE__).parent_path().parent_path() /
+         "integration/data/duckdb/integration.duckdb";
+#endif
+}
+
+struct streaming_sink_root_fixture {
+  streaming_sink_root_fixture()
+  {
+    REQUIRE(sirius::test::g_integration_env != nullptr);
+    if (!sirius::test::g_integration_env->is_active()) {
+      sirius::test::g_integration_env->resume();
+    }
+    con = std::make_unique<duckdb::Connection>(sirius::test::g_integration_env->make_connection());
+
+    auto db_path = integration_db_path();
+    REQUIRE(fs::exists(db_path));
+    auto result =
+      con->Query("ATTACH IF NOT EXISTS '" + db_path.string() + "' AS tpch (READ_ONLY);");
+    REQUIRE(result);
+    REQUIRE_FALSE(result->HasError());
+    result = con->Query("USE tpch;");
+    REQUIRE(result);
+    REQUIRE_FALSE(result->HasError());
+  }
+
+  std::unique_ptr<duckdb::Connection> con;
+};
+
+std::vector<std::shared_ptr<cucascade::shared_data_repository>> make_repos(std::size_t n)
+{
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos;
+  repos.reserve(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    repos.push_back(std::make_shared<cucascade::shared_data_repository>());
+  }
+  return repos;
+}
+
+//! The pipeline whose `operators` contain `op`, or nullptr.
+const sirius_pipeline* pipeline_with_operator(
+  const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines,
+  const sirius::op::sirius_physical_operator& target)
+{
+  for (const auto& pipeline : pipelines) {
+    for (const auto& op : pipeline->get_operators()) {
+      if (&op.get() == &target) { return pipeline.get(); }
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+// ============================================================================
+// SINKROOT-1: a fragment plan rooted in a STREAMING_SINK initializes
+// ============================================================================
+
+TEST_CASE_METHOD(streaming_sink_root_fixture,
+                 "SINKROOT-1: a streaming-sink-rooted plan initializes",
+                 "[integration][pipeline][streaming_sink_root]")
+{
+  auto repos = make_repos(1);
+
+  sirius::test::with_initialized_streaming_fragment(
+    *con,
+    "SELECT n_regionkey FROM nation",
+    repos,
+    [&](sirius::sirius_engine& engine, sirius_physical_streaming_sink& sink) {
+      // The sink is the plan root and its subtree hangs off children[], so the plan generator
+      // needs none of the out-of-tree descent the RESULT_COLLECTOR requires.
+      REQUIRE(sink.type == SiriusPhysicalOperatorType::STREAMING_SINK);
+      REQUIRE(sink.children.size() == 1);
+      REQUIRE(sink.get_parent_op() == nullptr);
+
+      // A streaming fragment never produces a QueryResult.
+      REQUIRE_FALSE(engine.has_result_collector());
+
+      REQUIRE(sink.num_output_streams() == 1);
+    });
+}
+
+// ============================================================================
+// SINKROOT-2: the sink lands in a pipeline's operators, so EOS can fire
+// ============================================================================
+
+TEST_CASE_METHOD(streaming_sink_root_fixture,
+                 "SINKROOT-2: the streaming sink reaches a pipeline's operators",
+                 "[integration][pipeline][streaming_sink_root]")
+{
+  auto repos = make_repos(1);
+
+  sirius::test::with_initialized_streaming_fragment(
+    *con,
+    "SELECT n_regionkey FROM nation",
+    repos,
+    [&](sirius::sirius_engine& engine, sirius_physical_streaming_sink& sink) {
+      // This is the load-bearing invariant. on_finalize_operator() -- the sink's only route to
+      // end-of-stream -- is driven by update_pipeline_status() iterating get_operators(), which
+      // returns the `operators` vector and EXCLUDES the source/sink members. If the sink is not
+      // in that vector, EOS never fires and every consumer blocked in wait() hangs forever, with
+      // no error anywhere.
+      const auto* owning = pipeline_with_operator(engine.sirius_pipelines, sink);
+      REQUIRE(owning != nullptr);
+
+      // And it is the pipeline's terminal sink, which is what tells the executor the query is
+      // complete once that pipeline finishes.
+      REQUIRE(owning->get_sink().get() == &sink);
+      REQUIRE(owning->is_query_terminal());
+    });
+}

--- a/test/cpp/utils/pipeline_conversion_test_utils.cpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.cpp
@@ -22,6 +22,7 @@
 #include "pipeline/sirius_pipeline.hpp"
 #include "pipeline/sirius_pipeline_converter.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
+#include "sirius/exception.hpp"
 #include "sirius_context.hpp"
 #include "sirius_engine.hpp"
 #include "sirius_interface.hpp"
@@ -235,6 +236,69 @@ void with_initialized_engine(duckdb::Connection& con,
     sirius_engine engine(context, iface, test_query.query_id());
     engine.initialize(std::move(collector));
     consume(engine);
+
+    con.Rollback();
+  } catch (...) {
+    con.Rollback();
+    throw;
+  }
+}
+
+void with_initialized_streaming_fragment(
+  duckdb::Connection& con,
+  const std::string& query,
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repos,
+  const std::function<void(sirius_engine&, op::sirius_physical_streaming_sink&)>& consume)
+{
+  auto& context = *con.context;
+
+  auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  if (!sirius_ctx) {
+    throw sirius::invalid_input_exception(
+      "with_initialized_streaming_fragment: Sirius is not registered on this connection");
+  }
+
+  // This shape roots the plan in a single-destination sink: no repository would index an empty
+  // vector below, and extra ones would be silently dropped rather than wired to anything.
+  if (output_repos.size() != 1) {
+    throw sirius::invalid_input_exception(
+      "with_initialized_streaming_fragment: expected exactly 1 output repository, got " +
+      std::to_string(output_repos.size()));
+  }
+
+  con.BeginTransaction();
+  try {
+    // The real execution window, not scoped_test_query: consume() may execute(), and only a
+    // window begin points the task creator at this connection. Sink output repositories are
+    // never registered with the window's repository manager, so they survive finish().
+    duckdb::SiriusContext::StandaloneQueryScope window(
+      *sirius_ctx, context, "streaming_fragment_test");
+
+    extracted_plan extracted;
+    {
+      optimizer_disable_guard guard(context);
+      extracted = extract_logical_plan_sirius_order(context, query);
+    }
+
+    sirius::planner::sirius_physical_plan_generator physical_planner(context);
+    auto sirius_plan = physical_planner.create_plan(std::move(extracted.logical_plan));
+
+    // A STREAMING_SINK is a normal unary operator, unlike the RESULT_COLLECTOR, which keeps its
+    // child outside `children[]` and needs special descent in the plan generator. Attaching the
+    // subtree as children[0] is what keeps that special-casing unnecessary.
+    auto types       = sirius_plan->types;
+    auto cardinality = sirius_plan->estimated_cardinality;
+    auto sink        = duckdb::make_uniq<op::sirius_physical_streaming_sink>(
+      std::move(types), cardinality, output_repos[0]);
+    sink->children.push_back(std::move(sirius_plan));
+
+    sirius_interface iface(context);
+    sirius_engine engine(context, iface, window.query_id());
+    // The fragment owns the plan; the engine borrows it. initialize() would take ownership and
+    // destroy the sink with the engine, leaving nothing to pull from afterwards.
+    engine.initialize_internal(*sink);
+    consume(engine, *sink);
+    window.finish();
 
     con.Rollback();
   } catch (...) {

--- a/test/cpp/utils/pipeline_conversion_test_utils.hpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.hpp
@@ -16,14 +16,19 @@
 
 #pragma once
 
+#include "op/sirius_physical_streaming_sink.hpp"
 #include "query_id.hpp"
 
+#include <cucascade/data/data_repository.hpp>
 #include <duckdb/main/connection.hpp>
 
 #include <cstdint>
 #include <filesystem>
 #include <functional>
+#include <memory>
+#include <optional>
 #include <string>
+#include <vector>
 
 namespace duckdb {
 class SiriusContext;
@@ -89,6 +94,16 @@ void with_conversion_result(
 void with_initialized_engine(duckdb::Connection& con,
                              const std::string& query,
                              const std::function<void(sirius_engine&)>& consume);
+
+//! Like `with_initialized_engine`, but roots the plan in a STREAMING_SINK over `output_repos`
+//! instead of a RESULT_COLLECTOR — the shape a streaming fragment runs. The caller (standing in
+//! for the fragment) owns the plan tree, so the engine borrows it via `initialize_internal`.
+//! `consume` runs while both are alive.
+void with_initialized_streaming_fragment(
+  duckdb::Connection& con,
+  const std::string& query,
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repos,
+  const std::function<void(sirius_engine&, op::sirius_physical_streaming_sink&)>& consume);
 
 //! Path to the canonical TPC-H queries (`test/tpch_performance/tpch_queries/orig/`).
 std::filesystem::path tpch_queries_dir();


### PR DESCRIPTION
Implements #837. Part 2 of a five-PR stack.

**What.** Where STREAMING_SOURCE is the plan leaf for a fragment's input, STREAMING_SINK is the plan
root for its output. Every batch the pipeline produces is pushed into one `exec::batch_stream`; an
external consumer pulls via `pull()` / `wait()` / `drained()`.

**Design: one difference drives everything.** The sink is shaped like RESULT_COLLECTOR — it overrides
`build_pipelines()` to append itself to `operators[]` — because `on_finalize_operator()` is the only
route to end-of-stream. Without the sink in `operators[]`, `update_pipeline_status()` never calls
`on_finalize_operator()`, the stream stays open forever, and every consumer blocked in `wait()` hangs
with no error anywhere.

- **One sender, one finalize.** The pipeline is `PIPELINE_SENDER = 0`. EOS fires from
  `on_finalize_operator()`, not from any external `close_input`.
- **No `on_data` hook.** The sink's consumer is an external thread in `wait()`, not an engine task
  needing re-nomination.
- **Native tier.** `sink()` pushes batches as-is; no Arrow, no GPU upgrade. `execute()` is a
  pass-through so `publish_output()` has something to deliver; the base implementation drops the
  batches.
- **`sirius_pipeline::is_query_terminal()` replaces three RESULT_COLLECTOR checks.** Each asked "is
  this sink a RESULT_COLLECTOR?" when it meant "does this sink end the query?", and all three answer
  wrong for a STREAMING_SINK: the executor's manager loop never marks the query complete (so
  `execute()` waits on a future nobody signals), `notify_downstream_pipelines()` walks consumers that
  do not exist, and `compute_repository_wiring()` emits wiring for a missing downstream pipeline. One
  predicate, three call sites, no behavior change for RESULT_COLLECTOR.

**Reading order.**
1. `src/include/op/sirius_physical_streaming_sink.hpp` — class comment frames the contrast with
   RESULT_COLLECTOR; `sirius_physical_operator_type.{hpp,cpp}` add the enumerator.
2. `src/op/sirius_physical_streaming_sink.cpp` — `sink()` and `build_pipelines()`.
3. `src/pipeline/sirius_pipeline.{hpp,cpp}`, `gpu_pipeline_executor.cpp`,
   `sirius_pipeline_converter.cpp` — `is_query_terminal()`, the checks it replaces, and the wiring of
   the sink into the plan.
4. `docs/super-sirius/operators.md` — STREAMING_SINK section + summary table.
5. `test/cpp/operator/test_physical_streaming_sink.cpp` — SNK-1…11, SINK-ERR-1…2.
6. `test/cpp/pipeline/test_streaming_sink_root.cpp` — SINKROOT-1…2 over a real planner and engine;
   `pipeline_conversion_test_utils` gains `with_initialized_streaming_fragment`, the sink-rooted
   counterpart to `with_initialized_engine`.

### Stack: part 2 of 5
- **Base:** `stream/01-source` (#1320)
- **Depends on:** #1320 (part 1)
