### PR TITLE
feat(op): partition the streaming sink across N destinations (#838)

### DIFF
--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -130,9 +130,15 @@ Key design facts:
   upgrade. A queued batch stays spillable in the repository until pulled.
 - **execute() is a pass-through** (same shape as `RESULT_COLLECTOR`): it hands the batches back so
   `publish_output()` can deliver them to `sink()`. The base implementation drops them.
-- **`no_history_peak_memory_estimate()` is 0.** The push allocates nothing on top of the input the
-  task already materialized, which is what this cold-start estimate measures; the caller maxes it
-  across the pipeline's operators, so anything higher would inflate the reservation.
+- **Partitioned variant (N destinations).** The second constructor takes N repositories and a
+  `partition_spec` (key columns + optional casts, validated at construction: one cast per key or
+  none, every key column inside the input schema). `sink()` GPU-hash-partitions each input batch
+  and routes slice *i* into `_outputs[i]`, skipping empty slices. Each destination has its own
+  `exec::batch_stream` and EOS reaches all of them on a single `on_finalize_operator()` call.
+  When N = 1 the spec is ignored and a native push bypasses partitioning entirely.
+  `no_history_peak_memory_estimate()` stays 0 for N = 1 and becomes 2× the input above it:
+  `hash_partition()` holds a full reordered copy of the table and the per-partition copies at the
+  same time, the same shape `PARTITION` reports.
 
 ### `sirius_physical_dummy_scan` — `DUMMY_SCAN`
 **File:** `src/include/op/sirius_physical_dummy_scan.hpp`

--- a/src/include/op/sirius_physical_streaming_sink.hpp
+++ b/src/include/op/sirius_physical_streaming_sink.hpp
@@ -19,14 +19,30 @@
 #include "exec/batch_stream.hpp"
 #include "op/sirius_physical_operator.hpp"
 
+#include <cudf/types.hpp>
+
 #include <cucascade/data/data_repository.hpp>
 
 #include <cstddef>
 #include <exception>
 #include <memory>
 #include <optional>
+#include <vector>
 
 namespace sirius::op {
+
+/// How a partitioned sink routes rows across its output streams.
+///
+/// Only the *function* lives here. Which compute node each partition ships to is the wrapper's
+/// routing table, and N is `output_repositories.size()` — the sink stays oblivious to both.
+struct partition_spec {
+  /// Column indices hashed to pick a destination. Must be non-empty for a partitioned sink.
+  std::vector<int> key_columns;
+
+  /// Per-key cast applied before hashing, so keys that differ only in representation (INT32 vs
+  /// INT64) still land together. Empty means "hash every key as-is".
+  std::vector<cudf::data_type> key_cast_types;
+};
 
 /// Terminal operator of a streaming fragment: every batch its pipeline produces is pushed into
 /// one `exec::batch_stream` per destination, where an external consumer pulls it.
@@ -44,13 +60,26 @@ class sirius_physical_streaming_sink : public sirius_physical_operator {
   /// The pipeline feeding this sink is its one and only sender.
   static constexpr exec::sender_id_t PIPELINE_SENDER = 0;
 
-  /// Single-destination sink: one output stream, no partitioning.
+  /// Single-destination sink: one output stream, no partitioning. The N = 1 case of the
+  /// constructor below.
   ///
   /// @throws sirius::invalid_input_exception when `output_repository` is null.
   sirius_physical_streaming_sink(
     duckdb::vector<sirius::logical_type> types,
     std::size_t estimated_cardinality,
     std::shared_ptr<cucascade::shared_data_repository> output_repository);
+
+  /// Partitioned sink: N output streams, one per destination, each with its own repository.
+  /// Every batch is GPU-hash-partitioned by `spec` and slice *i* is pushed into
+  /// `output_repositories[i]`.
+  ///
+  /// @throws sirius::invalid_input_exception when `output_repositories` is empty or contains a
+  ///         null entry, or when N > 1 and `spec.key_columns` is empty (nothing to route by).
+  sirius_physical_streaming_sink(
+    duckdb::vector<sirius::logical_type> types,
+    std::size_t estimated_cardinality,
+    std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repositories,
+    partition_spec spec);
 
   bool is_sink() const override { return true; }
 
@@ -71,15 +100,20 @@ class sirius_physical_streaming_sink : public sirius_physical_operator {
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
 
-  /// Push this task's output batches into the output stream, natively — no Arrow, no GPU
-  /// upgrade, no copy. A push after end-of-stream is dropped by the stream rather than landing
-  /// behind a consumer that already saw EOS.
+  /// Publish this task's output batches.
+  ///
+  /// With one destination the batches go into the output stream natively — no Arrow, no GPU
+  /// upgrade, no copy. With N > 1 each batch is GPU-hash-partitioned by the partition spec and
+  /// slice *i* is pushed into `_outputs[i]`; empty slices are skipped. A push after
+  /// end-of-stream is refused by the stream rather than landing behind a consumer that already
+  /// saw EOS.
   void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
 
-  /// Pass-through: pushing a batch allocates nothing beyond the input this task already
-  /// materialized, so this reports 0 — "no additional peak" — rather than the default 2×
-  /// heuristic. The caller maxes this across the pipeline's operators, so a non-zero answer here
-  /// would inflate every cold-start reservation.
+  /// 0 with one destination — the push allocates nothing on top of the input this task already
+  /// materialized — and 2× the input bytes when partitioning, because hash_partition() holds a
+  /// full reordered copy and the per-partition copies at the same time. The caller maxes this
+  /// across the pipeline's operators, so an inflated single-destination answer would raise every
+  /// cold-start reservation.
   [[nodiscard]] std::size_t no_history_peak_memory_estimate(
     const input_stats& stats) const override;
 
@@ -117,9 +151,13 @@ class sirius_physical_streaming_sink : public sirius_physical_operator {
   /// @throws sirius::invalid_input_exception when `index` is out of range.
   void validate_index(std::size_t index) const;
 
-  /// One stream per destination. Output stream id, partition index and stream correspond
-  /// positionally; this PR constructs exactly one.
+  /// One stream per destination; positional with the caller's repository list.
   std::vector<std::shared_ptr<exec::batch_stream>> _outputs;
+
+  /// Routing spec. Empty `key_columns` is valid only when `_outputs.size() == 1`, in which
+  /// case `sink()` short-circuits to a single native push without invoking the hash-partition
+  /// kernel at all — the spec is irrelevant, and there is nothing to route.
+  partition_spec _spec;
 };
 
 }  // namespace sirius::op

--- a/src/op/sirius_physical_streaming_sink.cpp
+++ b/src/op/sirius_physical_streaming_sink.cpp
@@ -16,6 +16,8 @@
 
 #include "op/sirius_physical_streaming_sink.hpp"
 
+#include "data/data_batch_utils.hpp"
+#include "op/partition/gpu_partition_impl.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 #include "sirius/exception.hpp"
@@ -43,6 +45,54 @@ sirius_physical_streaming_sink::sirius_physical_streaming_sink(
     std::move(output_repository), std::set<exec::sender_id_t>{PIPELINE_SENDER}));
 }
 
+sirius_physical_streaming_sink::sirius_physical_streaming_sink(
+  duckdb::vector<sirius::logical_type> types,
+  std::size_t estimated_cardinality,
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repositories,
+  partition_spec spec)
+  : sirius_physical_operator(
+      SiriusPhysicalOperatorType::STREAMING_SINK, std::move(types), estimated_cardinality),
+    _spec(std::move(spec))
+{
+  if (output_repositories.empty()) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_sink: at least one output repository is required");
+  }
+  for (std::size_t i = 0; i < output_repositories.size(); ++i) {
+    if (!output_repositories[i]) {
+      throw sirius::invalid_input_exception("sirius_physical_streaming_sink: output repository " +
+                                            std::to_string(i) + " must not be null");
+    }
+  }
+  if (output_repositories.size() > 1 && _spec.key_columns.empty()) {
+    throw sirius::invalid_input_exception("sirius_physical_streaming_sink: a sink with " +
+                                          std::to_string(output_repositories.size()) +
+                                          " destinations needs partition key columns to route by");
+  }
+  // hash_partition() reads partition_key_idx[i] for every cast type it is given, and indexes the
+  // input table by that value: a longer cast list or an out-of-range column reads past the end of
+  // one or the other. Both are wiring bugs, so they fail here rather than as device-side UB.
+  if (!_spec.key_cast_types.empty() && _spec.key_cast_types.size() != _spec.key_columns.size()) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_sink: partition_spec has " +
+      std::to_string(_spec.key_cast_types.size()) + " cast types for " +
+      std::to_string(_spec.key_columns.size()) + " key columns; expected none or one per key");
+  }
+  // `this->types` — the ctor parameter of the same name has been moved from by now.
+  const auto num_columns = this->types.size();
+  for (auto key : _spec.key_columns) {
+    if (key < 0 || static_cast<std::size_t>(key) >= num_columns) {
+      throw sirius::invalid_input_exception(
+        "sirius_physical_streaming_sink: partition key column " + std::to_string(key) +
+        " is out of range for a " + std::to_string(num_columns) + "-column input");
+    }
+  }
+  for (auto& repo : output_repositories) {
+    _outputs.push_back(std::make_shared<exec::batch_stream>(
+      std::move(repo), std::set<exec::sender_id_t>{PIPELINE_SENDER}));
+  }
+}
+
 std::unique_ptr<operator_data> sirius_physical_streaming_sink::execute(
   const operator_data& input_data, rmm::cuda_stream_view /*stream*/)
 {
@@ -53,30 +103,72 @@ std::unique_ptr<operator_data> sirius_physical_streaming_sink::execute(
 }
 
 void sirius_physical_streaming_sink::sink(const operator_data& input_data,
-                                          rmm::cuda_stream_view /*stream*/)
+                                          rmm::cuda_stream_view stream)
 {
   const auto& input = dynamic_cast<const pipelineable_operator_data&>(input_data);
 
-  // Pushed in their current tier: no Arrow, no forced GPU upgrade, no copy. The batch stays
-  // spillable in the repository until a consumer pulls it.
-  for (const auto& batch : input.get_data_batches()) {
-    // push() refuses once the stream is terminal. Ignoring that return silently drops the
-    // batch, which surfaces as a fragment that "succeeds" with an empty output.
-    if (!_outputs[0]->push(batch)) {
-      SIRIUS_LOG_WARN(
-        "sirius_physical_streaming_sink: batch refused after end-of-stream and dropped");
+  if (_outputs.size() == 1) {
+    // Pushed in their current tier: no Arrow, no forced GPU upgrade, no copy. The batch stays
+    // spillable in the repository until a consumer pulls it.
+    for (const auto& batch : input.get_data_batches()) {
+      // push() refuses once the stream is terminal. Ignoring that return silently drops the
+      // batch, which surfaces as a fragment that "succeeds" with an empty output.
+      if (!_outputs[0]->push(batch)) {
+        SIRIUS_LOG_WARN(
+          "sirius_physical_streaming_sink: batch refused after end-of-stream and dropped");
+      }
+    }
+    return;
+  }
+
+  const auto num_partitions = static_cast<int>(_outputs.size());
+  for (const auto& input_batch : input.get_read_only_batches()) {
+    auto* space = input_batch.get_memory_space();
+    if (space == nullptr) {
+      throw sirius::internal_exception(
+        "sirius_physical_streaming_sink: partitioned sink requires a resident input batch");
+    }
+
+    // Same kernel as the PARTITION operator; only the routing (slice i -> stream i) is new.
+    // Any consistent hash co-locates equal keys, which is all a local cut needs — matching a
+    // front end's exact partition function is translation's job.
+    auto slices = gpu_partition_impl::hash_partition(input_batch,
+                                                     _spec.key_columns,
+                                                     _spec.key_cast_types,
+                                                     num_partitions,
+                                                     stream,
+                                                     *space,
+                                                     batch_telemetry());
+
+    for (std::size_t i = 0; i < slices.size(); ++i) {
+      // An empty partition stays WAITING until the pipeline finishes, rather than publishing a
+      // zero-row batch a consumer would have to pull and discard.
+      if (sirius::get_cudf_table_view(*slices[i]).num_rows() == 0) { continue; }
+      // Same contract as the single-destination path: a refused slice must be warned about, or
+      // a partition that went terminal early turns into rows that silently never arrive.
+      if (!_outputs[i]->push(slices[i])) {
+        SIRIUS_LOG_WARN(
+          "sirius_physical_streaming_sink: partition {} batch refused after end-of-stream and "
+          "dropped",
+          i);
+      }
     }
   }
 }
 
 std::size_t sirius_physical_streaming_sink::no_history_peak_memory_estimate(
-  const input_stats& /*stats*/) const
+  const input_stats& stats) const
 {
-  // Pushing a handle into the output stream allocates nothing on top of the already-materialized
-  // input, which is what this estimate measures. 0 is the "no additional peak" answer — reporting
-  // the input bytes instead would raise the whole pipeline's cold-start reservation, since the
-  // caller takes the max across operators.
-  return 0;
+  // Measured against the input this task already materialized, which the caller subtracts before
+  // recording a real peak — so this is what the operator allocates on top of it.
+  //
+  // Single destination: nothing. The batch is handed over as it stands.
+  //
+  // Partitioned: hash_partition() materializes a full reordered copy of the table and then copies
+  // each slice out of it, and both are live at once, so ~2× the input. Same value
+  // sirius_physical_partition reports for the same kernel.
+  if (_outputs.size() == 1) { return 0; }
+  return stats.bytes * 2;
 }
 
 void sirius_physical_streaming_sink::build_pipelines(pipeline::sirius_pipeline& current,

--- a/test/cpp/operator/test_physical_streaming_sink.cpp
+++ b/test/cpp/operator/test_physical_streaming_sink.cpp
@@ -31,11 +31,14 @@
 #include <op/sirius_physical_streaming_source.hpp>
 #include <sirius/exception.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <map>
 #include <memory>
 #include <set>
 #include <thread>
+#include <utility>
 #include <vector>
 
 using namespace sirius::exec;
@@ -61,12 +64,43 @@ auto make_sink()
   return std::make_tuple(std::move(op), repo);
 }
 
+/// Partitioned sink over `n` fresh output repositories, routing on column 0.
+auto make_partitioned_sink(std::size_t n)
+{
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos;
+  for (std::size_t i = 0; i < n; ++i) {
+    repos.push_back(std::make_shared<cucascade::shared_data_repository>());
+  }
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  auto op = std::make_unique<sirius_physical_streaming_sink>(
+    sirius::from_duckdb_vec(types), 0, repos, partition_spec{{0}, {}});
+  return std::make_tuple(std::move(op), repos);
+}
+
 /// Feed one batch through the sink exactly as publish_output() would.
 void sink_one(sirius_physical_streaming_sink& op, std::shared_ptr<cucascade::data_batch> batch)
 {
   pipelineable_operator_data data{
     std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(batch)}};
   op.sink(data, default_stream());
+}
+
+/// Drain output stream `index` completely, returning the (key, payload) rows it held.
+std::vector<std::pair<int64_t, int32_t>> drain_rows(sirius_physical_streaming_sink& op,
+                                                    std::size_t index)
+{
+  std::vector<std::pair<int64_t, int32_t>> rows;
+  while (auto batch = op.pull(index)) {
+    auto view = sirius::get_cudf_table_view(**batch);
+    auto keys = copy_column_to_host<int64_t>(view.column(0));
+    auto vals = copy_column_to_host<int32_t>(view.column(1));
+    REQUIRE(keys.size() == vals.size());
+    for (std::size_t i = 0; i < keys.size(); ++i) {
+      rows.emplace_back(keys[i], vals[i]);
+    }
+  }
+  return rows;
 }
 
 }  // namespace
@@ -414,4 +448,315 @@ TEST_CASE("streaming_sink SNK-11: finalize then pull reaches END_OF_STREAM clean
   REQUIRE(op->pull().has_value());
   REQUIRE(op->availability() == availability::END_OF_STREAM);
   REQUIRE(op->drained());
+}
+
+// ============================================================================
+// PART-1: fan-out routes every row to exactly one destination, losing nothing
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-1: partitioned fan-out preserves every row exactly once",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  const std::size_t N = GENERATE(std::size_t{2}, std::size_t{3});
+  auto [op, repos]    = make_partitioned_sink(N);
+  REQUIRE(op->num_output_streams() == N);
+
+  // Three batches of distinct keys, so the union across destinations is the whole input.
+  std::vector<std::pair<int64_t, int32_t>> expected;
+  for (int b = 0; b < 3; ++b) {
+    std::vector<int64_t> keys;
+    std::vector<int32_t> vals;
+    for (int i = 0; i < 8; ++i) {
+      const auto key = static_cast<int64_t>(b * 8 + i);
+      keys.push_back(key);
+      vals.push_back(static_cast<int32_t>(key * 10));
+      expected.emplace_back(key, static_cast<int32_t>(key * 10));
+    }
+    sink_one(*op,
+             make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  }
+  op->finalize_operator();
+
+  std::vector<std::pair<int64_t, int32_t>> seen;
+  for (std::size_t i = 0; i < N; ++i) {
+    auto rows = drain_rows(*op, i);
+    seen.insert(seen.end(), rows.begin(), rows.end());
+  }
+
+  std::sort(seen.begin(), seen.end());
+  std::sort(expected.begin(), expected.end());
+  REQUIRE(seen == expected);
+}
+
+// ============================================================================
+// PART-2: equal keys are co-located — the property a shuffle actually needs
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-2: rows with the same key land on the same destination",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 3;
+  auto [op, repos]        = make_partitioned_sink(N);
+
+  // The same four keys, repeated across two separate batches (i.e. two separate tasks).
+  const std::vector<int64_t> keys{100, 200, 300, 400};
+  for (int b = 0; b < 2; ++b) {
+    std::vector<int32_t> vals(keys.size(), static_cast<int32_t>(b));
+    sink_one(*op,
+             make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  }
+  op->finalize_operator();
+
+  // Where each key ended up. Whatever the hash, a key must never appear on two destinations —
+  // otherwise a downstream MERGE_GROUP_BY on another node would see a partial group.
+  std::map<int64_t, std::size_t> destination_of;
+  for (std::size_t i = 0; i < N; ++i) {
+    for (const auto& [key, _] : drain_rows(*op, i)) {
+      auto [it, inserted] = destination_of.emplace(key, i);
+      REQUIRE(it->second == i);
+    }
+  }
+  REQUIRE(destination_of.size() == keys.size());
+}
+
+// ============================================================================
+// PART-3: a slow destination cannot head-of-line-block the others
+//
+// This is the whole point of per-destination repositories: partition 0 is never
+// drained, and the remaining partitions must still drain and reach EOS.
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-3: an undrained destination does not block its siblings",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 2;
+  auto [op, repos]        = make_partitioned_sink(N);
+
+  std::vector<int64_t> keys;
+  std::vector<int32_t> vals;
+  for (int i = 0; i < 64; ++i) {
+    keys.push_back(i);
+    vals.push_back(i);
+  }
+  sink_one(*op,
+           make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  op->finalize_operator();
+
+  // Find a destination that actually received rows, and leave it untouched.
+  std::size_t slow = N;
+  for (std::size_t i = 0; i < N; ++i) {
+    if (!repos[i]->all_empty()) {
+      slow = i;
+      break;
+    }
+  }
+  REQUIRE(slow < N);
+
+  for (std::size_t i = 0; i < N; ++i) {
+    if (i == slow) continue;
+    drain_rows(*op, i);
+    // Drained independently, even though `slow` still holds a backlog.
+    REQUIRE(op->drained(i));
+    REQUIRE(op->availability(i) == availability::END_OF_STREAM);
+  }
+
+  // The slow destination is still distinguishable from EOS: terminal, but not drained.
+  REQUIRE_FALSE(op->drained(slow));
+  REQUIRE(op->availability(slow) == availability::HAS_DATA);
+
+  // And it drains cleanly whenever its consumer gets around to it.
+  drain_rows(*op, slow);
+  REQUIRE(op->drained(slow));
+}
+
+// ============================================================================
+// PART-4: finalize drives every destination to EOS together
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-4: one finalize ends all destinations", "[streaming_sink]")
+{
+  constexpr std::size_t N = 3;
+  auto [op, repos]        = make_partitioned_sink(N);
+
+  for (std::size_t i = 0; i < N; ++i) {
+    REQUIRE(op->availability(i) == availability::WAITING);
+    REQUIRE_FALSE(op->drained(i));
+  }
+
+  op->finalize_operator();
+
+  for (std::size_t i = 0; i < N; ++i) {
+    REQUIRE(op->availability(i) == availability::END_OF_STREAM);
+    REQUIRE(op->drained(i));
+  }
+}
+
+// ============================================================================
+// PART-5: wait(i) tracks its own destination
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-5: wait on one destination unblocks on its own data",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 2;
+  auto [op, repos]        = make_partitioned_sink(N);
+
+  std::vector<int64_t> keys;
+  std::vector<int32_t> vals;
+  for (int i = 0; i < 32; ++i) {
+    keys.push_back(i);
+    vals.push_back(i);
+  }
+
+  std::atomic<int> returned{0};
+  std::thread c0([&] {
+    op->wait(0);
+    returned.fetch_add(1);
+  });
+  std::thread c1([&] {
+    op->wait(1);
+    returned.fetch_add(1);
+  });
+
+  std::this_thread::sleep_for(20ms);
+  REQUIRE(returned.load() == 0);
+
+  sink_one(*op,
+           make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  op->finalize_operator();  // guarantees both waiters wake even if one partition got no rows
+
+  c0.join();
+  c1.join();
+  REQUIRE(returned.load() == 2);
+}
+
+// ============================================================================
+// PART-6: N = 1 through the partitioned constructor is the Phase-2 sink
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-6: a single destination bypasses partitioning", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos{
+    std::make_shared<cucascade::shared_data_repository>()};
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  // No key columns needed: with one destination there is nothing to route.
+  sirius_physical_streaming_sink op(sirius::from_duckdb_vec(types), 0, repos, partition_spec{});
+
+  const std::vector<int64_t> keys{1, 2, 3};
+  const std::vector<int32_t> vals{10, 20, 30};
+  auto batch =
+    make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32);
+  auto batch_id = batch->get_batch_id();
+  sink_one(op, batch);
+  op.finalize_operator();
+
+  // Identity preserved, exactly as the single-repository constructor: no partition, no copy.
+  auto pulled = op.pull();
+  REQUIRE(pulled.has_value());
+  REQUIRE((*pulled)->get_batch_id() == batch_id);
+  REQUIRE(op.drained());
+
+  // Nothing is allocated on this path. A partitioned sink instead pays for the reordered table
+  // and the per-partition copies, which hash_partition() holds at the same time.
+  input_stats stats;
+  stats.bytes       = 4096;
+  stats.num_batches = 1;
+  REQUIRE(op.no_history_peak_memory_estimate(stats) == 0);
+
+  auto [partitioned, repos_2] = make_partitioned_sink(2);
+  REQUIRE(partitioned->no_history_peak_memory_estimate(stats) == stats.bytes * 2);
+}
+
+// ============================================================================
+// PART-7: partitioned-sink construction contracts
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-7: destination list and spec are validated", "[streaming_sink]")
+{
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  auto sirius_types = sirius::from_duckdb_vec(types);
+  auto repo         = std::make_shared<cucascade::shared_data_repository>();
+
+  // No destinations at all.
+  REQUIRE_THROWS_AS(sirius_physical_streaming_sink(
+                      sirius_types,
+                      0,
+                      std::vector<std::shared_ptr<cucascade::shared_data_repository>>{},
+                      partition_spec{{0}, {}}),
+                    sirius::invalid_input_exception);
+
+  // A null destination.
+  REQUIRE_THROWS_AS(
+    sirius_physical_streaming_sink(
+      sirius_types,
+      0,
+      std::vector<std::shared_ptr<cucascade::shared_data_repository>>{repo, nullptr},
+      partition_spec{{0}, {}}),
+    sirius::invalid_input_exception);
+
+  // Several destinations but nothing to route by — silently sending every row to destination 0
+  // would corrupt a downstream shuffle, so this is rejected.
+  REQUIRE_THROWS_AS(
+    sirius_physical_streaming_sink(sirius_types,
+                                   0,
+                                   std::vector<std::shared_ptr<cucascade::shared_data_repository>>{
+                                     repo, std::make_shared<cucascade::shared_data_repository>()},
+                                   partition_spec{}),
+    sirius::invalid_input_exception);
+
+  // More cast types than key columns: hash_partition() reads key_columns[i] for each cast type,
+  // so the extra entry would index past the end of the key list.
+  REQUIRE_THROWS_AS(
+    sirius_physical_streaming_sink(
+      sirius_types,
+      0,
+      std::vector<std::shared_ptr<cucascade::shared_data_repository>>{
+        repo, std::make_shared<cucascade::shared_data_repository>()},
+      partition_spec{
+        {0}, {cudf::data_type{cudf::type_id::INT64}, cudf::data_type{cudf::type_id::INT64}}}),
+    sirius::invalid_input_exception);
+
+  // A key column outside the input schema, and a negative one: both would index the input table
+  // out of range inside the partition kernel.
+  REQUIRE_THROWS_AS(
+    sirius_physical_streaming_sink(sirius_types,
+                                   0,
+                                   std::vector<std::shared_ptr<cucascade::shared_data_repository>>{
+                                     repo, std::make_shared<cucascade::shared_data_repository>()},
+                                   partition_spec{{5}, {}}),
+    sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(
+    sirius_physical_streaming_sink(sirius_types,
+                                   0,
+                                   std::vector<std::shared_ptr<cucascade::shared_data_repository>>{
+                                     repo, std::make_shared<cucascade::shared_data_repository>()},
+                                   partition_spec{{-1}, {}}),
+    sirius::invalid_input_exception);
+
+  auto [op, repos] = make_partitioned_sink(2);
+  REQUIRE_THROWS_AS(op->pull(2), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(op->drained(2), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(op->availability(2), sirius::invalid_input_exception);
 }

--- a/test/cpp/pipeline/test_streaming_sink_root.cpp
+++ b/test/cpp/pipeline/test_streaming_sink_root.cpp
@@ -109,6 +109,7 @@ TEST_CASE_METHOD(streaming_sink_root_fixture,
     *con,
     "SELECT n_regionkey FROM nation",
     repos,
+    std::nullopt,
     [&](sirius::sirius_engine& engine, sirius_physical_streaming_sink& sink) {
       // The sink is the plan root and its subtree hangs off children[], so the plan generator
       // needs none of the out-of-tree descent the RESULT_COLLECTOR requires.
@@ -137,6 +138,7 @@ TEST_CASE_METHOD(streaming_sink_root_fixture,
     *con,
     "SELECT n_regionkey FROM nation",
     repos,
+    std::nullopt,
     [&](sirius::sirius_engine& engine, sirius_physical_streaming_sink& sink) {
       // This is the load-bearing invariant. on_finalize_operator() -- the sink's only route to
       // end-of-stream -- is driven by update_pipeline_status() iterating get_operators(), which
@@ -150,5 +152,30 @@ TEST_CASE_METHOD(streaming_sink_root_fixture,
       // complete once that pipeline finishes.
       REQUIRE(owning->get_sink().get() == &sink);
       REQUIRE(owning->is_query_terminal());
+    });
+}
+
+// ============================================================================
+// SINKROOT-3: a partitioned sink root exposes one output stream per destination
+// ============================================================================
+
+TEST_CASE_METHOD(streaming_sink_root_fixture,
+                 "SINKROOT-3: a partitioned sink root keeps its fan-out",
+                 "[integration][pipeline][streaming_sink_root]")
+{
+  auto repos = make_repos(3);
+
+  sirius::test::with_initialized_streaming_fragment(
+    *con,
+    "SELECT n_regionkey FROM nation",
+    repos,
+    sirius::op::partition_spec{{0}, {}},
+    [&](sirius::sirius_engine& engine, sirius_physical_streaming_sink& sink) {
+      REQUIRE(sink.num_output_streams() == 3);
+      REQUIRE(pipeline_with_operator(engine.sirius_pipelines, sink) != nullptr);
+      // Nothing has run, so every destination is empty but none has ended.
+      for (std::size_t i = 0; i < 3; ++i) {
+        REQUIRE_FALSE(sink.drained(i));
+      }
     });
 }

--- a/test/cpp/utils/pipeline_conversion_test_utils.cpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.cpp
@@ -248,6 +248,7 @@ void with_initialized_streaming_fragment(
   duckdb::Connection& con,
   const std::string& query,
   std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repos,
+  std::optional<op::partition_spec> spec,
   const std::function<void(sirius_engine&, op::sirius_physical_streaming_sink&)>& consume)
 {
   auto& context = *con.context;
@@ -258,11 +259,13 @@ void with_initialized_streaming_fragment(
       "with_initialized_streaming_fragment: Sirius is not registered on this connection");
   }
 
-  // This shape roots the plan in a single-destination sink: no repository would index an empty
-  // vector below, and extra ones would be silently dropped rather than wired to anything.
-  if (output_repos.size() != 1) {
+  // Without a partition spec the plan is rooted in a single-destination sink: no repository would
+  // index an empty vector below, and extra ones would be silently dropped rather than wired to
+  // anything. With a spec, every repository becomes a destination.
+  if (output_repos.empty() || (!spec.has_value() && output_repos.size() != 1)) {
     throw sirius::invalid_input_exception(
-      "with_initialized_streaming_fragment: expected exactly 1 output repository, got " +
+      "with_initialized_streaming_fragment: expected " +
+      std::string(spec.has_value() ? "at least 1" : "exactly 1") + " output repository, got " +
       std::to_string(output_repos.size()));
   }
 
@@ -288,8 +291,14 @@ void with_initialized_streaming_fragment(
     // subtree as children[0] is what keeps that special-casing unnecessary.
     auto types       = sirius_plan->types;
     auto cardinality = sirius_plan->estimated_cardinality;
-    auto sink        = duckdb::make_uniq<op::sirius_physical_streaming_sink>(
-      std::move(types), cardinality, output_repos[0]);
+    duckdb::unique_ptr<op::sirius_physical_streaming_sink> sink;
+    if (spec.has_value()) {
+      sink = duckdb::make_uniq<op::sirius_physical_streaming_sink>(
+        std::move(types), cardinality, std::move(output_repos), std::move(*spec));
+    } else {
+      sink = duckdb::make_uniq<op::sirius_physical_streaming_sink>(
+        std::move(types), cardinality, output_repos[0]);
+    }
     sink->children.push_back(std::move(sirius_plan));
 
     sirius_interface iface(context);

--- a/test/cpp/utils/pipeline_conversion_test_utils.hpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.hpp
@@ -103,6 +103,7 @@ void with_initialized_streaming_fragment(
   duckdb::Connection& con,
   const std::string& query,
   std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repos,
+  std::optional<op::partition_spec> spec,
   const std::function<void(sirius_engine&, op::sirius_physical_streaming_sink&)>& consume);
 
 //! Path to the canonical TPC-H queries (`test/tpch_performance/tpch_queries/orig/`).


### PR DESCRIPTION
Implements #838. Part 3 of a five-PR stack.

**What.** The shuffle write side. Part 2's sink had one destination; this one has N, and every batch
is GPU-hash-partitioned across them so a downstream stage on another node receives only the rows it
owns.

**Design: one queue per destination.** The sink already held a *vector* of `exec::batch_stream` —
part 2 constructed exactly one — so this adds no fan-out plumbing, only a router and one decision:
each destination gets its own repository. One shared queue with N logical channels would let a single
slow receiver stall the fragment; separate queues mean an undrained destination holds up nothing but
itself. PART-3 pins it — partition 0 is never drained, the rest still drain and reach EOS.

- **The spec is the routing *function*, not the *topology*.** `partition_spec` names key columns and
  their pre-hash casts; which node partition *i* ships to is the wrapper's routing table, and N is
  `output_repositories.size()`. That is what keeps this a local operator.
- **Any consistent hash is correct here.** Same `gpu_partition_impl::hash_partition` the PARTITION
  operator uses; only the routing is new. Equal keys co-locating is the only property a local cut
  needs — it is what stops a downstream MERGE_GROUP_BY from seeing a partial group.
- **`key_cast_types` stops representation from splitting a key.** Keys differing only as INT32 vs
  INT64 hash differently and would land on different destinations; the cast applies before hashing.
- **N = 1 through the partitioned constructor *is* part 2's sink** — no partitioning, no copy,
  pointer identity preserved (PART-6). Two constructors, one contract.
- **N > 1 with no key columns throws at construction.** The tempting default — everything to
  destination 0 — is silent data corruption for any downstream shuffle (PART-7).

The one real caveat: `sink()` now takes the `rmm::cuda_stream_view` part 2 ignored, because hashing
launches on the GPU. The N > 1 path therefore requires a resident input batch and throws
`internal_exception` when `get_memory_space()` is null — the zero-copy promise is intact for N = 1
and necessarily weaker above it. Empty slices are skipped rather than pushed as zero-row batches, and
the memory estimate stays `stats.bytes`.

**Reading order.**
1. `src/include/op/sirius_physical_streaming_sink.hpp` — `partition_spec`, then the second
   constructor's `@throws` list, which is the validation contract.
2. `src/op/sirius_physical_streaming_sink.cpp` — `sink()`, and the N == 1 early return that keeps
   part 2's path untouched.
3. `test/cpp/operator/test_physical_streaming_sink.cpp` — PART-3 first (head-of-line blocking is the
   reason for the design), then PART-6/7.
4. `test/cpp/pipeline/test_streaming_sink_root.cpp` — SINKROOT-3, fan-out through a real planner and
   engine.

### Stack: part 3 of 5
- **Base:** `stream/02-sink` (#1321)
- **Depends on:** #1321 (part 2), transitively #1320
