### PR TITLE
feat(exec): stream_session, the id-addressed streaming router (#839)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ set(EXTENSION_SOURCES
     # Execution primitives (slot-based backpressure / completion tracking)
     src/exec/admission_control.cpp
     src/exec/batch_stream.cpp
+    src/exec/stream_session.cpp
     # I/O adapters (Phase 19 — io_uring + sirius_datasource)
     src/io/datasource_factory.cpp
     src/io/io_context.cpp
@@ -611,6 +612,7 @@ set(TEST_SOURCES
     test/cpp/exec/test_interruptible_mpmc.cpp
     test/cpp/exec/test_multi_index_priority_queue.cpp
     test/cpp/exec/test_semi_future.cpp
+    test/cpp/exec/test_stream_session.cpp
     test/cpp/expression/test_ast_aggregate.cpp
     test/cpp/expression/test_ast_clone.cpp
     test/cpp/expression/test_ast_substitute.cpp

--- a/docs/super-sirius/streaming-sessions.md
+++ b/docs/super-sirius/streaming-sessions.md
@@ -1,0 +1,237 @@
+# Stream Sessions
+
+A **stream session** is the boundary object for one Sirius plan fragment in a distributed query.
+It gives the wrapper above the engine a single, id-addressed handle to feed batches into the
+fragment and collect batches out of it:
+
+```
+push(stream_id, batch)              // feed an input stream
+close_input(stream_id, sender_id)   // one remote sender is done producing
+pull(stream_id) -> optional<batch>  // collect from an output stream (non-blocking)
+wait(stream_id)                     // block until data arrives or the stream ends
+drained(stream_id) -> bool          // stream ended cleanly and nothing is left
+```
+
+Sirius itself stays **fragment-blind**: it never learns that it is distributed, which compute
+node a partition ships to, or how many nodes exist. One session models one fragment; pairing a
+leaf fragment's output id with a root fragment's input id — across sessions and nodes — is the
+wrapper's routing table, never the engine's.
+
+A session is built from three pieces:
+
+| Piece | Role |
+|---|---|
+| `STREAMING_SOURCE` operator | The fragment's input boundary — remote senders push batches in |
+| `STREAMING_SINK` operator | The fragment's output boundary — external consumers pull batches out |
+| `exec::batch_stream` | The one-directional stream primitive both operators are built on |
+
+The session (`exec::stream_session`) is the id-addressed router over these operators.
+
+## The model: the repository is the queue
+
+A `cucascade::shared_data_repository` already *is* a thread-safe queue of `data_batch`es, and it
+is what the downgrade executor sweeps for spill candidates. What it lacks is the **lifecycle** of
+a stream: who is still producing, whether "nothing right now" means *wait* or *the stream is
+over*, and how a starved consumer gets woken. So each streaming operator owns both:
+
+| Concern | Owned by |
+|---|---|
+| The queue of batches | `cucascade::shared_data_repository` |
+| End-of-stream, availability, waking | `exec::batch_stream` |
+
+Batches cross the boundary **natively**, as `cucascade::data_batch`, in whatever tier they
+currently sit. Nothing is materialized to Arrow on the way in or out, so a queued batch stays
+spillable (GPU → host → disk) right up until it is pulled, and `pull()` hands it back in its
+current tier without forcing an upgrade.
+
+There is no bounded channel and no channel-level backpressure; see
+[No backpressure](#no-backpressure).
+
+## `exec::batch_stream`
+
+**Files:** `src/include/exec/batch_stream.hpp`, `src/exec/batch_stream.cpp`
+
+One direction of batch flow: N declared senders push into one repository; consumers pull, poll,
+or block.
+
+```cpp
+class batch_stream {
+ public:
+  enum class availability { HAS_DATA, WAITING, END_OF_STREAM };
+
+  batch_stream(shared_ptr<shared_data_repository> repo, set<sender_id_t> expected);
+
+  // Producer
+  [[nodiscard]] bool push(shared_ptr<data_batch>);  // false once terminal
+  void close(sender_id_t);       // idempotent per sender; set-based fan-in
+  void fail(exception_ptr);      // immediate, first failure wins
+
+  // Consumer
+  shared_ptr<data_batch> try_pull();  // rethrows a pending error before popping
+  availability classify() const;
+  bool drained() const;               // clean end only
+  void wait();                        // not atomic with try_pull — loop and re-check
+
+  // Hooks (single slot; fire after unlocking; registering on an ended stream fires immediately)
+  void set_on_data(function<void()>);           // persistent — fires on every push and on fail()
+  void set_on_end_of_stream(function<void()>);
+};
+```
+
+Three behaviors are load-bearing:
+
+- **End-of-stream is a set, not a counter.** A fan-in stream fed by N remote senders is over only
+  when all N *distinct* senders have closed. A repeated close is a no-op; an unexpected sender id
+  is a defined error. A counter could not tell "both senders closed once" from "one closed twice".
+- **Push, close, and every emptiness check share one lock.** No batch is ever admitted after
+  end-of-stream, and every batch is in the repository before the wake that announces it. Hooks
+  fire after the lock is released, so a hook may safely re-enter the scheduler.
+- **`classify()` separates "not yet" from "never".** Queued data outranks terminal: EOS is never
+  reported while an accepted batch is still pullable. A pending error reads as `HAS_DATA` even
+  over an empty queue — the only way out is the rethrow from `try_pull()`, never a clean finish
+  that would let a failed query succeed silently.
+
+| terminal? | error? | repo empty? | `classify()` |
+|---|---|---|---|
+| no | no | no | `HAS_DATA` |
+| no | no | yes | `WAITING` |
+| yes | no | no | `HAS_DATA` |
+| yes | no | yes | `END_OF_STREAM` |
+| either | yes | either | `HAS_DATA` |
+
+`wait()` blocks until `classify() != WAITING`. Engine workers never call it — it is for the
+wrapper's external threads.
+
+## `STREAMING_SOURCE` — the input boundary
+
+**Files:** `src/include/op/sirius_physical_streaming_source.hpp`,
+`src/op/sirius_physical_streaming_source.cpp`
+
+Wraps one `batch_stream` constructed with the fragment's expected sender set. Remote producers
+call `push(batch)` and `close_input(sender_id)`; the engine sees an ordinary source whose task
+hint mirrors the stream state:
+
+| Stream state | `get_next_task_hint()` |
+|---|---|
+| `HAS_DATA` | `READY{this}` |
+| `WAITING` | `WAITING{nullptr}` |
+| `END_OF_STREAM` | `std::nullopt` |
+
+Each task pulls one batch, zero-copy, rethrowing any pending error; `execute()` is a
+pass-through.
+
+**The live re-arm.** The engine is pull-scheduled: a source that answers `WAITING` is dropped,
+and the only built-in re-nomination is task completion — so a starved stream-fed source has no
+completing task to wake it. The source therefore wires `set_on_data` (persistent, fires on every
+push) to `task_creator::schedule(head)`, which only enqueues onto a thread-safe queue and is safe
+to call from any thread. Because the hook is persistent, there is no waker to re-arm and no
+notification to miss. Separately, `set_on_end_of_stream` updates the pipeline status so that a
+stream closing with **no task in flight** (an empty stream, or a late close) still lets the
+pipeline finish and schedules its consumers.
+
+## `STREAMING_SINK` — the output boundary
+
+**Files:** `src/include/op/sirius_physical_streaming_sink.hpp`,
+`src/op/sirius_physical_streaming_sink.cpp`
+
+A pipeline-terminal operator. `sink()` pushes each output batch into an output `batch_stream`;
+the pipeline-finish hook (`on_finalize_operator()`) closes every stream, which is what makes
+`END_OF_STREAM` observable. Consumers use `pull(i)` / `wait(i)` / `drained(i)` /
+`availability(i)`. Unlike the source it registers no `on_data` hook: its consumer is an external
+thread blocking in `wait()`, not an engine task that needs re-nominating.
+
+### Partition fan-out
+
+A sink can expose **N output streams**, one per destination, each backed by its own repository.
+`sink()` GPU-hash-partitions each batch by the `partition_spec` key columns (the same
+`hash_partition` kernel the `PARTITION` operator uses) and pushes slice *i* into stream *i*;
+empty slices are skipped. A slow receiver's backlog accumulates in its own repository — spillable
+by the downgrade executor — without head-of-line-blocking the others. The single-destination sink
+is the N = 1 case and skips partitioning entirely.
+
+```cpp
+struct partition_spec {
+  std::vector<int> key_columns;                 // hashed to pick a destination
+  std::vector<cudf::data_type> key_cast_types;  // per-key cast so INT32/INT64 keys agree
+};
+```
+
+Rules:
+
+- N > 1 with no key columns is a **construction error** — silently routing every row to
+  destination 0 would corrupt a downstream shuffle rather than fail loudly.
+- Output stream id, partition index, and repository correspond **positionally**; `drained(i)` and
+  `wait(i)` are independent per stream, so a slow receiver stays distinguishable from EOS.
+- All partitions share one sender (`PIPELINE_SENDER`), so pipeline finish drives all N streams to
+  EOS together.
+- *Which* compute node each partition ships to is the wrapper's routing table — the sink stays
+  oblivious to destinations.
+
+## `exec::stream_session` — the id-addressed router
+
+**Files:** `src/include/exec/stream_session.hpp`, `src/exec/stream_session.cpp`
+
+```
+push(stream_id, batch)              // → source.push
+close_input(stream_id, sender_id)   // → source.close_input(sender)
+pull(stream_id) -> optional         // → sink.pull(partition)
+wait(stream_id)                     // → sink.wait(partition)
+drained(stream_id) -> bool          // → sink.drained(partition)
+```
+
+- Stream ids are **session-local** and **direction-separated** — two independent namespaces:
+  `push`/`close_input` resolve input streams (sources); `pull`/`wait`/`drained` resolve output
+  streams (sink partitions). A partitioned sink registers N ids, one per destination. An unknown
+  id is a defined error.
+- The session holds **no repositories** — it forwards to the operators, which own the queues. It
+  builds no plan, submits nothing to the scheduler, and owns no teardown; it wraps
+  already-instantiated operators.
+- A **leaf**-fragment session registers only sink ids (a session with no input streams is
+  legitimate); a **root**-fragment session registers a source id plus sink ids.
+
+> **Gotcha for plan-launcher work.** The sink is the pipeline **tail**, and it lands in
+> `operators[0]` so that finishing the pipeline reaches it and fires end-of-stream. A plan
+> launcher must key on that structure rather than on `is_source()`.
+
+## Worked example: distributed GROUP BY
+
+The flagship case composes entirely from the pieces above — no extra operator, no new mechanism.
+The front end emits two fragment shapes:
+
+```
+Leaf fragment (every node, over its shard)    Root fragment (every node, owns one key range)
+  partitioned STREAMING_SINK                    STREAMING_SINK (N = 1)
+  └─ HASH_GROUP_BY  (partial)                   └─ MERGE_GROUP_BY (final)
+     └─ GPU_SCAN                                   └─ STREAMING_SOURCE
+                                                      (expected = {0 … N-1})
+```
+
+The shuffle in the middle becomes the leaf sink's N per-destination streams, the wrapper's
+transport hop, and the root source's sender-aware fan-in. The aggregate algebra is unchanged
+(`SUM→SUM`, `COUNT→SUM` of partial counts, `AVG` carrying `(sum, cnt)`) — distributed GROUP BY is
+a data-movement and lifecycle problem, which is exactly the seam these pieces fill.
+
+The leaf session's EOS comes from its scan finishing (pipeline finish → close), not from any
+`close_input`. The root session's source reaches EOS only after all N distinct senders close — a
+repeated close from one sender cannot terminate it early.
+
+## No backpressure
+
+Streams never infer pressure from queue depth, and the engine has no "slow down" task hint — so
+the streaming layer deliberately carries no channel-level backpressure. Pressure relief comes
+from the **downgrade executor** instead: queued batches sit in repositories where the memory
+sweep can see and spill them (GPU → host → disk). Cross-fragment and cross-query pressure is a
+scheduling concern (per-fragment priority), and a future sink↔source slowness signal would be
+additive — nothing in this design forecloses it.
+
+## Tests
+
+| File | Catch2 tag |
+|---|---|
+| `test/cpp/exec/test_batch_stream.cpp` | `[batch_stream]` |
+| `test/cpp/operator/test_physical_streaming_source.cpp` | `[streaming_source]` |
+| `test/cpp/operator/test_physical_streaming_sink.cpp` | `[streaming_sink]` |
+| `test/cpp/exec/test_stream_session.cpp` | `[stream_session]` |
+
+A `recording_task_creator` stands in for the scheduler, so the live re-arm and the `on_data`
+hook path are proven without a live executor.

--- a/src/exec/stream_session.cpp
+++ b/src/exec/stream_session.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/stream_session.hpp"
+
+#include "sirius/exception.hpp"
+
+#include <string>
+#include <utility>
+
+namespace sirius::exec {
+
+void stream_session::add_source(stream_id_t id, op::sirius_physical_streaming_source& source)
+{
+  if (!_sources.emplace(id, &source).second) {
+    throw sirius::invalid_input_exception("stream_session: input stream " + std::to_string(id) +
+                                          " is already registered");
+  }
+}
+
+void stream_session::add_sink(std::vector<stream_id_t> ids,
+                              op::sirius_physical_streaming_sink& sink)
+{
+  if (ids.size() != sink.num_output_streams()) {
+    throw sirius::invalid_input_exception(
+      "stream_session: sink exposes " + std::to_string(sink.num_output_streams()) +
+      " output streams but " + std::to_string(ids.size()) + " ids were given");
+  }
+
+  // Positional by contract: ids[i] ↔ sink partition i ↔ output repository i.
+  for (std::size_t partition = 0; partition < ids.size(); ++partition) {
+    if (!_sinks.emplace(ids[partition], sink_output{&sink, partition}).second) {
+      throw sirius::invalid_input_exception("stream_session: output stream " +
+                                            std::to_string(ids[partition]) +
+                                            " is already registered");
+    }
+  }
+}
+
+std::vector<stream_id_t> stream_session::input_streams() const
+{
+  std::vector<stream_id_t> ids;
+  ids.reserve(_sources.size());
+  for (const auto& [id, _] : _sources) {
+    ids.push_back(id);
+  }
+  return ids;
+}
+
+std::vector<stream_id_t> stream_session::output_streams() const
+{
+  std::vector<stream_id_t> ids;
+  ids.reserve(_sinks.size());
+  for (const auto& [id, _] : _sinks) {
+    ids.push_back(id);
+  }
+  return ids;
+}
+
+op::sirius_physical_streaming_source& stream_session::resolve_source(stream_id_t id) const
+{
+  auto it = _sources.find(id);
+  if (it == _sources.end()) {
+    throw sirius::invalid_input_exception("stream_session: no input stream with id " +
+                                          std::to_string(id));
+  }
+  return *it->second;
+}
+
+const stream_session::sink_output& stream_session::resolve_sink(stream_id_t id) const
+{
+  auto it = _sinks.find(id);
+  if (it == _sinks.end()) {
+    throw sirius::invalid_input_exception("stream_session: no output stream with id " +
+                                          std::to_string(id));
+  }
+  return it->second;
+}
+
+bool stream_session::push(stream_id_t id, std::shared_ptr<cucascade::data_batch> batch)
+{
+  return resolve_source(id).push(std::move(batch));
+}
+
+void stream_session::close_input(stream_id_t id, sender_id_t sender)
+{
+  resolve_source(id).close_input(sender);
+}
+
+std::optional<std::shared_ptr<cucascade::data_batch>> stream_session::pull(stream_id_t id)
+{
+  const auto& out = resolve_sink(id);
+  return out.sink->pull(out.partition);
+}
+
+void stream_session::wait(stream_id_t id)
+{
+  const auto& out = resolve_sink(id);
+  out.sink->wait(out.partition);
+}
+
+bool stream_session::drained(stream_id_t id) const
+{
+  const auto& out = resolve_sink(id);
+  return out.sink->drained(out.partition);
+}
+
+}  // namespace sirius::exec

--- a/src/include/exec/stream_session.hpp
+++ b/src/include/exec/stream_session.hpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "exec/batch_stream.hpp"
+#include "op/sirius_physical_streaming_sink.hpp"
+#include "op/sirius_physical_streaming_source.hpp"
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace sirius::exec {
+
+/// Session-local address of one stream. Ids are **direction-separated**: an id passed to
+/// `push` / `close_input` names an *input* stream, an id passed to `pull` / `wait` / `drained`
+/// names an *output* stream, and the two are independent namespaces. Nothing pairs a leaf
+/// fragment's output id with a root fragment's input id inside the engine — that routing table
+/// is the wrapper's, built from the front end's plan.
+using stream_id_t = std::uint64_t;
+
+/// Routes the streaming API by stream id over a plan fragment's already-built streaming
+/// operators. One session models one fragment.
+///
+/// A router and nothing more: each call resolves an id to an operator and forwards. The
+/// operators work on their own — a source's re-arm is wired through its pipeline, not here — so
+/// the session adds addressing, not behaviour.
+///
+/// It does not own the operators it routes to. A plan tree owns its operators uniquely
+/// (`sirius_physical_operator::children` is a vector of `duckdb::unique_ptr`), so an operator
+/// inside a plan cannot be handed out as an owning pointer. Whatever owns the plan must outlive
+/// the session.
+///
+/// Not thread-safe for registration: `add_source` / `add_sink` run at build time, before any
+/// producer or consumer thread touches the session. The forwarded calls themselves are as
+/// thread-safe as the operators they reach (the lifecycle and the repository both lock).
+class stream_session {
+ public:
+  stream_session()                                     = default;
+  stream_session(stream_session&&) noexcept            = default;
+  stream_session& operator=(stream_session&&) noexcept = default;
+  stream_session(const stream_session&)                = delete;
+  stream_session& operator=(const stream_session&)     = delete;
+
+  // -----------------------------------------------------------------------
+  // Registration (build time)
+  // -----------------------------------------------------------------------
+
+  /// Register a streaming source under the input stream id `id`. The session does not take
+  /// ownership; `source` must outlive it.
+  /// @throws sirius::invalid_input_exception on a duplicate input id.
+  void add_source(stream_id_t id, op::sirius_physical_streaming_source& source);
+
+  /// Register a streaming sink under `ids`, one id per output stream: `ids[i]` addresses the
+  /// sink's partition `i`, which is its output repository `i`. A single-destination sink takes
+  /// exactly one id. The session does not take ownership; `sink` must outlive it.
+  /// @throws sirius::invalid_input_exception on a duplicate output id, or an `ids` size that
+  ///         does not match the sink's output stream count.
+  void add_sink(std::vector<stream_id_t> ids, op::sirius_physical_streaming_sink& sink);
+
+  /// Registered input stream ids, ascending. Empty for a leaf fragment, which produces but
+  /// never receives.
+  [[nodiscard]] std::vector<stream_id_t> input_streams() const;
+
+  /// Registered output stream ids, ascending.
+  [[nodiscard]] std::vector<stream_id_t> output_streams() const;
+
+  // -----------------------------------------------------------------------
+  // Producer side — input streams
+  // -----------------------------------------------------------------------
+
+  /// Hand `batch` to the source registered under `id`.
+  /// @return false when the stream already reached end-of-stream and the batch was refused.
+  /// @throws sirius::invalid_input_exception when `id` is not a registered input stream.
+  bool push(stream_id_t id, std::shared_ptr<cucascade::data_batch> batch);
+
+  /// Record that `sender` has finished producing into input stream `id`. Idempotent per
+  /// sender; the stream ends only once every expected sender has closed.
+  /// @throws sirius::invalid_input_exception when `id` is not a registered input stream, or
+  ///         when `sender` is not one of that stream's expected senders.
+  void close_input(stream_id_t id, sender_id_t sender);
+
+  // -----------------------------------------------------------------------
+  // Consumer side — output streams
+  // -----------------------------------------------------------------------
+
+  /// Non-blocking pull from output stream `id`. `nullopt` means "nothing right now", which is
+  /// not the same as end-of-stream — `drained(id)` distinguishes them.
+  /// @throws sirius::invalid_input_exception when `id` is not a registered output stream.
+  std::optional<std::shared_ptr<cucascade::data_batch>> pull(stream_id_t id);
+
+  /// Block until output stream `id` has a batch or has ended. External threads only.
+  /// @throws sirius::invalid_input_exception when `id` is not a registered output stream.
+  void wait(stream_id_t id);
+
+  /// True when output stream `id` has ended and holds nothing more.
+  /// @throws sirius::invalid_input_exception when `id` is not a registered output stream.
+  [[nodiscard]] bool drained(stream_id_t id) const;
+
+ private:
+  /// An output id resolves to one sink *and* the partition within it. Non-owning.
+  struct sink_output {
+    op::sirius_physical_streaming_sink* sink;
+    std::size_t partition;
+  };
+
+  /// @throws sirius::invalid_input_exception when `id` is not a registered input stream.
+  [[nodiscard]] op::sirius_physical_streaming_source& resolve_source(stream_id_t id) const;
+  /// @throws sirius::invalid_input_exception when `id` is not a registered output stream.
+  [[nodiscard]] const sink_output& resolve_sink(stream_id_t id) const;
+
+  std::map<stream_id_t, op::sirius_physical_streaming_source*> _sources;
+  std::map<stream_id_t, sink_output> _sinks;
+};
+
+}  // namespace sirius::exec

--- a/test/cpp/exec/test_stream_session.cpp
+++ b/test/cpp/exec/test_stream_session.cpp
@@ -1,0 +1,458 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../operator/operator_test_utils.hpp"
+
+#include <catch.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <data/data_batch_utils.hpp>
+#include <exec/stream_session.hpp>
+#include <helper/type_conversions.hpp>
+#include <sirius/exception.hpp>
+
+#include <memory>
+#include <set>
+#include <vector>
+
+using namespace sirius::exec;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+
+namespace {
+
+using namespace sirius::test::operator_utils;
+
+/// A streaming source plus the repository behind it, so a test can inspect where a routed push
+/// actually landed.
+struct source_fixture {
+  std::shared_ptr<sirius_physical_streaming_source> source;
+  std::shared_ptr<cucascade::shared_data_repository> repo;
+};
+
+source_fixture make_source(std::set<sender_id_t> expected = {0})
+{
+  auto repo   = std::make_shared<cucascade::shared_data_repository>();
+  auto source = std::make_shared<sirius_physical_streaming_source>(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    repo,
+    std::move(expected));
+  return {std::move(source), std::move(repo)};
+}
+
+struct sink_fixture {
+  std::shared_ptr<sirius_physical_streaming_sink> sink;
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos;
+};
+
+/// Single-destination sink (INTEGER payload, no partitioning).
+sink_fixture make_sink()
+{
+  auto repo = std::make_shared<cucascade::shared_data_repository>();
+  auto sink = std::make_shared<sirius_physical_streaming_sink>(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    repo);
+  return {std::move(sink), {std::move(repo)}};
+}
+
+/// Partitioned sink over `n` destinations, routing on column 0 of a (BIGINT, INTEGER) schema.
+sink_fixture make_partitioned_sink(std::size_t n)
+{
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos;
+  for (std::size_t i = 0; i < n; ++i) {
+    repos.push_back(std::make_shared<cucascade::shared_data_repository>());
+  }
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  auto sink = std::make_shared<sirius_physical_streaming_sink>(
+    sirius::from_duckdb_vec(types), 0, repos, partition_spec{{0}, {}});
+  return {std::move(sink), std::move(repos)};
+}
+
+/// Feed one batch through a sink exactly as publish_output() would.
+void sink_one(sirius_physical_streaming_sink& sink, std::shared_ptr<cucascade::data_batch> batch)
+{
+  pipelineable_operator_data data{
+    std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(batch)}};
+  sink.sink(data, default_stream());
+}
+
+}  // namespace
+
+// ============================================================================
+// SESS-1: registration is reflected in the two id namespaces
+// ============================================================================
+
+TEST_CASE("stream_session SESS-1: input and output ids are separate namespaces", "[stream_session]")
+{
+  auto in  = make_source();
+  auto out = make_sink();
+
+  stream_session session;
+  // Deliberately the same numeric id on both sides: direction, not the number, disambiguates.
+  session.add_source(7, *in.source);
+  session.add_sink({7}, *out.sink);
+
+  REQUIRE(session.input_streams() == std::vector<stream_id_t>{7});
+  REQUIRE(session.output_streams() == std::vector<stream_id_t>{7});
+}
+
+// ============================================================================
+// SESS-2: push routes to the addressed source, and only that one
+// ============================================================================
+
+TEST_CASE("stream_session SESS-2: push reaches only the addressed source", "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto a = make_source();
+  auto b = make_source();
+
+  stream_session session;
+  session.add_source(10, *a.source);
+  session.add_source(20, *b.source);
+
+  REQUIRE(session.push(10, make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32)));
+  REQUIRE(a.repo->total_size() == 1);
+  REQUIRE(b.repo->total_size() == 0);
+
+  REQUIRE(session.push(20, make_numeric_batch<int32_t>(*gpu_space, {2}, cudf::type_id::INT32)));
+  REQUIRE(a.repo->total_size() == 1);
+  REQUIRE(b.repo->total_size() == 1);
+}
+
+// ============================================================================
+// SESS-3: close_input marks one sender of one stream
+// ============================================================================
+
+TEST_CASE("stream_session SESS-3: close_input is scoped to its stream and sender",
+          "[stream_session]")
+{
+  auto a = make_source({0, 1});
+  auto b = make_source({0});
+
+  stream_session session;
+  session.add_source(10, *a.source);
+  session.add_source(20, *b.source);
+
+  session.close_input(10, 0);
+  REQUIRE(a.source->stream().sender_closed(0));
+  REQUIRE_FALSE(a.source->stream().terminal());  // still waiting on sender 1
+  REQUIRE_FALSE(b.source->stream().terminal());  // untouched
+
+  session.close_input(20, 0);
+  REQUIRE(b.source->stream().terminal());
+  REQUIRE_FALSE(a.source->stream().terminal());
+}
+
+// ============================================================================
+// SESS-4: pull / wait / drained read only the addressed output stream
+// ============================================================================
+
+TEST_CASE("stream_session SESS-4: output calls resolve to one sink partition", "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto a = make_sink();
+  auto b = make_sink();
+
+  stream_session session;
+  session.add_sink({100}, *a.sink);
+  session.add_sink({200}, *b.sink);
+
+  auto batch    = make_numeric_batch<int32_t>(*gpu_space, {42}, cudf::type_id::INT32);
+  auto batch_id = batch->get_batch_id();
+  sink_one(*a.sink, batch);
+
+  REQUIRE_FALSE(session.pull(200).has_value());
+  auto pulled = session.pull(100);
+  REQUIRE(pulled.has_value());
+  REQUIRE((*pulled)->get_batch_id() == batch_id);
+
+  a.sink->finalize_operator();
+  REQUIRE(session.drained(100));
+  REQUIRE_FALSE(session.drained(200));
+}
+
+// ============================================================================
+// SESS-5: a partitioned sink registers one id per destination, positionally
+// ============================================================================
+
+TEST_CASE("stream_session SESS-5: each sink partition gets its own stream id", "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 3;
+  auto out                = make_partitioned_sink(N);
+
+  stream_session session;
+  const std::vector<stream_id_t> ids{300, 301, 302};
+  session.add_sink(ids, *out.sink);
+  REQUIRE(session.output_streams() == ids);
+
+  std::vector<int64_t> keys;
+  std::vector<int32_t> vals;
+  for (int i = 0; i < 32; ++i) {
+    keys.push_back(i);
+    vals.push_back(i);
+  }
+  sink_one(*out.sink,
+           make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  out.sink->finalize_operator();
+
+  // ids[i] must address repository i and nothing else.
+  for (std::size_t i = 0; i < N; ++i) {
+    const bool repo_has_data = !out.repos[i]->all_empty();
+    REQUIRE(session.drained(ids[i]) == !repo_has_data);
+    REQUIRE(session.pull(ids[i]).has_value() == repo_has_data);
+  }
+}
+
+// ============================================================================
+// SESS-6: an unknown id is a defined error on every verb
+// ============================================================================
+
+TEST_CASE("stream_session SESS-6: unknown ids are rejected", "[stream_session]")
+{
+  auto in  = make_source();
+  auto out = make_sink();
+
+  stream_session session;
+  session.add_source(1, *in.source);
+  session.add_sink({2}, *out.sink);
+
+  REQUIRE_THROWS_AS(session.push(99, nullptr), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(session.close_input(99, 0), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(session.pull(99), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(session.drained(99), sirius::invalid_input_exception);
+
+  // An output id is not usable as an input id, and vice versa — the namespaces do not leak.
+  REQUIRE_THROWS_AS(session.push(2, nullptr), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(session.pull(1), sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// SESS-7: registration contracts
+// ============================================================================
+
+TEST_CASE("stream_session SESS-7: registration is validated", "[stream_session]")
+{
+  auto in    = make_source();
+  auto other = make_source();
+  auto out   = make_partitioned_sink(2);
+  auto spare = make_sink();
+
+  stream_session session;
+  session.add_source(1, *in.source);
+
+  // A duplicate id must be rejected rather than silently rebinding the stream to another
+  // operator. (Registration takes a reference, so a null operator is not expressible.)
+  REQUIRE_THROWS_AS(session.add_source(1, *other.source), sirius::invalid_input_exception);
+
+  // One id per destination — an id list that does not match the sink's fan-out would silently
+  // leave a partition unaddressable.
+  REQUIRE_THROWS_AS(session.add_sink({10}, *out.sink), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(session.add_sink({10, 11, 12}, *out.sink), sirius::invalid_input_exception);
+
+  session.add_sink({10, 11}, *out.sink);
+  REQUIRE_THROWS_AS(session.add_sink({11}, *spare.sink), sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// SESS-8: a source → sink fragment driven entirely by stream id
+// ============================================================================
+
+TEST_CASE("stream_session SESS-8: a fragment round-trips native batches by id", "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream = default_stream();
+  auto in     = make_source();
+  auto out    = make_sink();
+
+  stream_session session;
+  session.add_source(1, *in.source);
+  session.add_sink({2}, *out.sink);
+
+  constexpr int K = 3;
+  std::vector<uint64_t> pushed_ids;
+  for (int i = 0; i < K; ++i) {
+    auto batch = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    pushed_ids.push_back(batch->get_batch_id());
+    REQUIRE(session.push(1, batch));
+  }
+  session.close_input(1, 0);
+
+  // Drive the fragment: source → sink, one task per batch, exactly as the executor would.
+  while (auto hint = in.source->get_next_task_hint()) {
+    REQUIRE(hint->hint == TaskCreationHint::READY);
+    auto input = in.source->get_next_task_input_data();
+    REQUIRE(input != nullptr);
+    auto produced = in.source->execute(*input, stream);
+    out.sink->sink(*produced, stream);
+  }
+  out.sink->finalize_operator();
+
+  std::vector<uint64_t> pulled_ids;
+  while (auto batch = session.pull(2)) {
+    pulled_ids.push_back((*batch)->get_batch_id());
+  }
+  REQUIRE(pulled_ids == pushed_ids);
+  REQUIRE(session.drained(2));
+}
+
+// ============================================================================
+// SESS-9: leaf-fragment shape — a partitioned sink and NO source.
+//
+// The leaf of a distributed GROUP BY: scan → partial aggregate → partitioned
+// STREAMING_SINK. Its EOS is driven by the scan finishing, not by any
+// close_input, so a session with zero input streams must be legitimate.
+// ============================================================================
+
+TEST_CASE("stream_session SESS-9: a leaf fragment registers only output streams",
+          "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 2;
+  auto out                = make_partitioned_sink(N);
+
+  stream_session session;
+  const std::vector<stream_id_t> ids{500, 501};
+  session.add_sink(ids, *out.sink);
+
+  REQUIRE(session.input_streams().empty());
+  REQUIRE(session.output_streams() == ids);
+
+  std::vector<int64_t> keys;
+  std::vector<int32_t> vals;
+  for (int i = 0; i < 16; ++i) {
+    keys.push_back(i);
+    vals.push_back(i * 2);
+  }
+  sink_one(*out.sink,
+           make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+
+  // Still producing: no destination may report EOS yet.
+  for (auto id : ids) {
+    REQUIRE_FALSE(session.drained(id));
+  }
+
+  out.sink->finalize_operator();
+
+  int total_rows = 0;
+  for (auto id : ids) {
+    while (auto batch = session.pull(id)) {
+      total_rows += sirius::get_cudf_table_view(**batch).num_rows();
+    }
+    REQUIRE(session.drained(id));
+  }
+  REQUIRE(total_rows == static_cast<int>(keys.size()));
+}
+
+// ============================================================================
+// SESS-10: root-fragment shape — one fan-in source fed by N remote senders.
+//
+// The root of a distributed GROUP BY: STREAMING_SOURCE → final merge →
+// STREAMING_SINK. EOS must wait for all N *distinct* senders; a duplicate
+// close from one sender must not advance it.
+// ============================================================================
+
+TEST_CASE("stream_session SESS-10: a root fragment ends only after every sender closes",
+          "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream = default_stream();
+  auto in     = make_source({0, 1});
+  auto out    = make_sink();
+
+  stream_session session;
+  session.add_source(600, *in.source);
+  session.add_sink({601}, *out.sink);
+
+  // Sender 0 delivers and closes; sender 1 is still going.
+  REQUIRE(session.push(600, make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32)));
+  session.close_input(600, 0);
+
+  // A duplicate close from sender 0 must not stand in for sender 1 — the failure mode a bare
+  // counter would have, and one that would truncate the root's input.
+  session.close_input(600, 0);
+  REQUIRE_FALSE(in.source->all_ports_empty());
+
+  REQUIRE(session.push(600, make_numeric_batch<int32_t>(*gpu_space, {2}, cudf::type_id::INT32)));
+  session.close_input(600, 1);
+
+  int received = 0;
+  while (auto hint = in.source->get_next_task_hint()) {
+    REQUIRE(hint->hint == TaskCreationHint::READY);
+    auto input = in.source->get_next_task_input_data();
+    REQUIRE(input != nullptr);
+    auto produced = in.source->execute(*input, stream);
+    out.sink->sink(*produced, stream);
+    ++received;
+  }
+  out.sink->finalize_operator();
+
+  REQUIRE(received == 2);
+  REQUIRE(in.source->all_ports_empty());
+
+  int pulled = 0;
+  while (session.pull(601)) {
+    ++pulled;
+  }
+  REQUIRE(pulled == 2);
+  REQUIRE(session.drained(601));
+}
+
+// ============================================================================
+// SESS-11: the session is move-only, and moves keep its routing intact
+// ============================================================================
+
+TEST_CASE("stream_session SESS-11: a moved session still routes", "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  static_assert(!std::is_copy_constructible_v<stream_session>);
+  static_assert(std::is_move_constructible_v<stream_session>);
+
+  auto in = make_source();
+
+  stream_session original;
+  original.add_source(1, *in.source);
+
+  stream_session moved{std::move(original)};
+  REQUIRE(moved.input_streams() == std::vector<stream_id_t>{1});
+  REQUIRE(moved.push(1, make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32)));
+  REQUIRE(in.repo->total_size() == 1);
+}


### PR DESCRIPTION
Implements #839 (addressing half; the plan/execution half is part 5). Part 4 of a five-PR stack.

**What.** The switchboard. Parts 1–3 built the two boundaries a fragment has — a source you push
into, a sink you pull from — but nothing yet says *which* stream a given push or pull means.
`exec::stream_session` is one fragment's id → operator table, and the first thing in this stack an
external caller can hold.

**Design: a router, and nothing more.** Every call resolves an id and forwards. The session runs no
lifecycle, holds no lock, and adds no behaviour — a source's re-arm is wired through its pipeline,
not here. The one structural decision is that an output id resolves to a `{sink, partition}` *pair*:
had it resolved to a sink alone, part 3's N destinations would be unaddressable from outside and the
partitioned fan-out would be invisible above the engine.

- **Ids are direction-separated.** `push` / `close_input` name *input* streams; `pull` / `wait` /
  `drained` name *output* streams — independent namespaces, so input 0 and output 0 differ. Nothing
  in the engine pairs a leaf's output id with a root's input id; that table is the wrapper's (SESS-1).
- **`add_sink(ids, sink)` takes one id per output stream.** `ids[i]` addresses partition *i*; a count
  disagreeing with the sink's stream count throws (SESS-4/5).
- **It owns nothing it routes to.** A plan tree owns its operators as `duckdb::unique_ptr`, so the
  session stores raw pointers and whatever owns the plan must outlive it. Movable, non-copyable
  (SESS-11).
- **No lock of its own.** Registration is build-time and single-threaded; forwarded calls are as
  thread-safe as the operators they reach, and both the stream and the repository already lock. A
  session-level lock would be a second lock over the same state and a chance to invert.
- **Unknown and duplicate ids throw** (SESS-6/7). Leaf vs root fragments differ only in what they
  register — a leaf has no input streams (SESS-9), a root's input inherits part 1's sender-set EOS
  (SESS-10).

**Reading order.**
1. `src/include/exec/stream_session.hpp` — class comment states the ownership and thread-safety
   contract; the `@throws` clauses are the rest of it.
2. `src/exec/stream_session.cpp` — resolve-and-forward, ~120 lines with no state machine in it.
3. `docs/super-sirius/streaming-sessions.md` — new file, the cross-cutting doc for the whole
   subsystem (stream, source, sink, session, the no-backpressure bet, the `exchange_channel`
   migration table).
4. `test/cpp/exec/test_stream_session.cpp` — SESS-1 for namespace separation, SESS-4/5 for partition
   addressing, SESS-8 for a native round-trip by id.

### Stack: part 4 of 5
- **Base:** `stream/03-sink-partition` (#1322)
- **Depends on:** #1322 (part 3), transitively #1321 / #1320
