### PR TITLE
feat(exec): build and run a streaming plan (#839)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,9 @@ set(EXTENSION_SOURCES
     src/exec/admission_control.cpp
     src/exec/batch_stream.cpp
     src/exec/stream_session.cpp
+    src/exec/stream_bind_catalog.cpp
+    src/exec/stream_plan_bindings.cpp
+    src/exec/streaming_fragment.cpp
     # I/O adapters (Phase 19 — io_uring + sirius_datasource)
     src/io/datasource_factory.cpp
     src/io/io_context.cpp
@@ -613,6 +616,7 @@ set(TEST_SOURCES
     test/cpp/exec/test_multi_index_priority_queue.cpp
     test/cpp/exec/test_semi_future.cpp
     test/cpp/exec/test_stream_session.cpp
+    test/cpp/exec/test_stream_bind_catalog.cpp
     test/cpp/expression/test_ast_aggregate.cpp
     test/cpp/expression/test_ast_clone.cpp
     test/cpp/expression/test_ast_substitute.cpp
@@ -722,6 +726,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_get_next_ports_after_sink.cpp
     test/cpp/pipeline/test_merge_pipeline_fusion.cpp
     test/cpp/pipeline/test_streaming_sink_root.cpp
+    test/cpp/exec/test_streaming_fragment.cpp
     test/cpp/pipeline/test_partition_build_pipelines.cpp
     test/cpp/pipeline/test_pipeline_dynamic_filter_native_shape.cpp
     test/cpp/pipeline/test_pipeline_schedule_canonical.cpp

--- a/docs/super-sirius/streaming-sessions.md
+++ b/docs/super-sirius/streaming-sessions.md
@@ -224,6 +224,40 @@ sweep can see and spill them (GPU → host → disk). Cross-fragment and cross-q
 scheduling concern (per-fragment priority), and a future sink↔source slowness signal would be
 additive — nothing in this design forecloses it.
 
+## `exec::streaming_fragment` — plan builder + blocking runner
+
+**Files:** `src/include/exec/streaming_fragment.hpp`, `src/exec/streaming_fragment.cpp`
+
+Owns a complete fragment life cycle: declares inputs, builds the plan, constructs the sink, runs,
+and keeps the output pullable after `run()` returns.
+
+```
+fragment_spec spec = { plan_source, inputs, outputs, partitioning };
+streaming_fragment frag(context, spec);
+frag.build(query_id);   // declare → plan → create operators → register with session
+// push batches into frag.session() here if this fragment has inputs
+frag.run();             // blocks until all pipelines finish
+// pull from frag.session() until drained
+```
+
+Two lifetime decisions are load-bearing:
+
+**Repositories outlive the engine.** The fragment creates every repository before planning and
+registers none of them with `data_repository_manager_`. The query window's mandatory cleanup
+(`StandaloneQueryScope::finish()`) therefore cannot touch them. A sender's output stays in its
+repository and is still there when the receiver runs — which is what makes sequential streaming
+work without copying.
+
+**One query window, shared.** `run()` reuses the caller's `StandaloneQueryScope` rather than
+opening its own. A second scope resets the task creator and scan manager that `build()` populated;
+the fragment would then run zero tasks and return silently empty. The caller brackets `build()`
+and `run()` in one window (as `Context::execute_substrait` does for ordinary queries).
+
+**`stream_bind_catalog` bridges bind time and plan time.** DuckDB's table-function bind runs
+long before physical planning. The catalog is registered as a `ClientContextState` so
+`sirius_stream_source(id)` can resolve a schema at bind time; the physical plan generator
+re-reads the catalog at plan time to build each `STREAMING_SOURCE`.
+
 ## Tests
 
 | File | Catch2 tag |
@@ -232,6 +266,9 @@ additive — nothing in this design forecloses it.
 | `test/cpp/operator/test_physical_streaming_source.cpp` | `[streaming_source]` |
 | `test/cpp/operator/test_physical_streaming_sink.cpp` | `[streaming_sink]` |
 | `test/cpp/exec/test_stream_session.cpp` | `[stream_session]` |
+| `test/cpp/exec/test_stream_bind_catalog.cpp` | `[stream_bind_catalog]` |
+| `test/cpp/exec/test_streaming_fragment.cpp` | `[streaming_fragment]` |
 
 A `recording_task_creator` stands in for the scheduler, so the live re-arm and the `on_data`
-hook path are proven without a live executor.
+hook path are proven without a live executor. `test_streaming_fragment.cpp` requires a GPU and
+a real DuckDB integration database (`[integration]` tag).

--- a/src/exec/stream_bind_catalog.cpp
+++ b/src/exec/stream_bind_catalog.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/stream_bind_catalog.hpp"
+
+#include "sirius/exception.hpp"
+
+#include <string>
+#include <utility>
+
+namespace sirius::exec {
+
+void stream_bind_catalog::declare(stream_id_t id, stream_input_binding binding)
+{
+  if (binding.repository == nullptr) {
+    throw sirius::invalid_input_exception("stream_bind_catalog: input stream " +
+                                          std::to_string(id) +
+                                          " must be declared with a repository");
+  }
+  if (binding.names.size() != binding.types.size()) {
+    throw sirius::invalid_input_exception(
+      "stream_bind_catalog: input stream " + std::to_string(id) + " declares " +
+      std::to_string(binding.names.size()) + " column names but " +
+      std::to_string(binding.types.size()) + " types");
+  }
+  if (binding.names.empty()) {
+    throw sirius::invalid_input_exception("stream_bind_catalog: input stream " +
+                                          std::to_string(id) + " must declare at least one column");
+  }
+
+  std::lock_guard<std::mutex> guard(_mutex);
+  _entries[id] = std::move(binding);
+}
+
+void stream_bind_catalog::clear()
+{
+  std::lock_guard<std::mutex> guard(_mutex);
+  _entries.clear();
+}
+
+bool stream_bind_catalog::contains(stream_id_t id) const
+{
+  std::lock_guard<std::mutex> guard(_mutex);
+  return _entries.find(id) != _entries.end();
+}
+
+namespace {
+
+[[noreturn]] void throw_undeclared(stream_id_t id)
+{
+  throw sirius::invalid_input_exception("stream_bind_catalog: no input stream declared with id " +
+                                        std::to_string(id));
+}
+
+}  // namespace
+
+const stream_input_binding& stream_bind_catalog::get(stream_id_t id) const
+{
+  std::lock_guard<std::mutex> guard(_mutex);
+  auto it = _entries.find(id);
+  if (it == _entries.end()) { throw_undeclared(id); }
+  return it->second;
+}
+
+void stream_bind_catalog::set_built(stream_id_t id, op::sirius_physical_streaming_source* built)
+{
+  std::lock_guard<std::mutex> guard(_mutex);
+  auto it = _entries.find(id);
+  if (it == _entries.end()) { throw_undeclared(id); }
+  it->second.built = built;
+}
+
+std::vector<stream_id_t> stream_bind_catalog::declared_streams() const
+{
+  std::lock_guard<std::mutex> guard(_mutex);
+  std::vector<stream_id_t> ids;
+  ids.reserve(_entries.size());
+  for (const auto& [id, _] : _entries) {
+    ids.push_back(id);
+  }
+  return ids;
+}
+
+}  // namespace sirius::exec

--- a/src/exec/stream_plan_bindings.cpp
+++ b/src/exec/stream_plan_bindings.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/stream_plan_bindings.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "helper/type_conversions.hpp"
+#include "sirius/exception.hpp"
+
+#include <stdexcept>
+
+namespace sirius::exec {
+
+namespace {
+
+/// Resolve the catalog registered on this connection, or explain why the fragment is not set up.
+duckdb::shared_ptr<stream_bind_catalog> catalog_for(duckdb::ClientContext& context)
+{
+  auto catalog = context.registered_state->Get<stream_bind_catalog>(stream_bind_catalog::kStateKey);
+  if (!catalog) {
+    throw std::runtime_error(
+      "sirius_stream_source: no stream catalog on this connection — the fragment must declare its "
+      "input streams before the plan is bound");
+  }
+  return catalog;
+}
+
+duckdb::unique_ptr<duckdb::FunctionData> stream_source_bind(
+  duckdb::ClientContext& context,
+  duckdb::TableFunctionBindInput& input,
+  duckdb::vector<duckdb::LogicalType>& return_types,
+  duckdb::vector<std::string>& names)
+{
+  if (input.inputs.size() != 1 || input.inputs[0].IsNull()) {
+    throw std::runtime_error("sirius_stream_source expects a single non-null stream id");
+  }
+  auto const stream_id = static_cast<stream_id_t>(input.inputs[0].GetValue<std::int64_t>());
+
+  // An unregistered id is a defined bind-time error, not a silent empty scan: it means the
+  // fragment's plan references a stream nobody declared, which would otherwise surface much
+  // later as a plan with no source.
+  auto const& binding = catalog_for(context)->get(stream_id);
+
+  names        = duckdb::vector<std::string>(binding.names.begin(), binding.names.end());
+  return_types = sirius::to_duckdb_vec(binding.types);
+  return duckdb::make_uniq<stream_source_bind_data>(stream_id);
+}
+
+/// Never runs. The Sirius plan generator replaces this scan with a STREAMING_SOURCE, and this
+/// path has no CPU fallback — a stream's batches only exist on the GPU side of the fragment.
+void stream_source_function(duckdb::ClientContext&, duckdb::TableFunctionInput&, duckdb::DataChunk&)
+{
+  throw std::runtime_error(
+    "sirius_stream_source cannot be executed by DuckDB: it is an internal marker for a Sirius "
+    "streaming input and is only valid inside a GPU-executed fragment plan");
+}
+
+}  // namespace
+
+void register_stream_source_function(duckdb::DatabaseInstance& instance)
+{
+  auto transaction = duckdb::CatalogTransaction::GetSystemTransaction(instance);
+  auto& catalog    = duckdb::Catalog::GetSystemCatalog(instance);
+
+  duckdb::TableFunction stream_source(kStreamSourceFunctionName,
+                                      {duckdb::LogicalType::BIGINT},
+                                      stream_source_function,
+                                      stream_source_bind);
+  // Projection pushdown is deliberately off: a streaming source hands over whole batches in the
+  // tier they already sit in, so there is no per-column read to prune.
+  duckdb::CreateTableFunctionInfo info(stream_source);
+  // Idempotent: the extension callback registers Sirius functions on every DuckDB instance in
+  // the process, and a caller (the FFI, a test) may also register explicitly. A duplicate is
+  // not an error.
+  info.on_conflict = duckdb::OnCreateConflict::IGNORE_ON_CONFLICT;
+  catalog.CreateTableFunction(transaction, info);
+}
+
+}  // namespace sirius::exec

--- a/src/exec/streaming_fragment.cpp
+++ b/src/exec/streaming_fragment.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/streaming_fragment.hpp"
+
+#include "planner/sirius_physical_plan_generator.hpp"
+#include "sirius/exception.hpp"
+#include "sirius_context.hpp"
+#include "sirius_engine.hpp"
+#include "sirius_interface.hpp"
+
+#include <string>
+#include <utility>
+
+namespace sirius::exec {
+
+namespace {
+
+constexpr const char* kFragmentQueryLabel = "sirius_streaming_fragment";
+
+duckdb::shared_ptr<stream_bind_catalog> catalog_for(duckdb::ClientContext& context)
+{
+  auto catalog = context.registered_state->Get<stream_bind_catalog>(stream_bind_catalog::kStateKey);
+  if (!catalog) {
+    throw sirius::invalid_input_exception(
+      "streaming_fragment: no stream catalog on this connection");
+  }
+  return catalog;
+}
+
+}  // namespace
+
+streaming_fragment::streaming_fragment(duckdb::ClientContext& context, fragment_spec spec)
+  : _context(context), _spec(std::move(spec))
+{
+  if (!_spec.plan_source) {
+    throw sirius::invalid_input_exception("streaming_fragment: a plan source is required");
+  }
+  if (_spec.outputs.empty()) {
+    throw sirius::invalid_input_exception(
+      "streaming_fragment: a fragment must declare at least one output stream");
+  }
+  if (_spec.outputs.size() > 1 && !_spec.partitioning.has_value()) {
+    throw sirius::invalid_input_exception(
+      "streaming_fragment: " + std::to_string(_spec.outputs.size()) +
+      " output streams need a partition spec; a gather fragment has exactly one");
+  }
+
+  // Created here, outside data_repository_manager_, so the window's mandatory cleanup
+  // (StandaloneQueryScope::finish()) cannot destroy them. This is what lets a sender's output
+  // outlive its own fragment.
+  for (const auto& [id, _] : _spec.inputs) {
+    _input_repos[id] = std::make_shared<cucascade::shared_data_repository>();
+  }
+  for (auto id : _spec.outputs) {
+    if (_output_repos.count(id) != 0) {
+      throw sirius::invalid_input_exception("streaming_fragment: duplicate output stream id " +
+                                            std::to_string(id));
+    }
+    _output_repos[id] = std::make_shared<cucascade::shared_data_repository>();
+  }
+}
+
+streaming_fragment::~streaming_fragment()
+{
+  // The catalog is per-connection and this fragment's declarations must not be visible to the
+  // next one. Swallow, because a throwing destructor during stack unwinding would terminate.
+  try {
+    catalog_for(_context)->clear();
+  } catch (...) {  // NOLINT(bugprone-empty-catch)
+  }
+}
+
+void streaming_fragment::build(sirius::query_id_t query_id)
+{
+  if (_built) { throw sirius::invalid_input_exception("streaming_fragment: already built"); }
+
+  auto catalog = catalog_for(_context);
+  catalog->clear();
+
+  // Declare every input before planning: sirius_stream_source's DuckDB bind resolves its schema
+  // from here, and create_plan(LogicalGet&) reads the repository and sender set back out.
+  for (const auto& [id, input] : _spec.inputs) {
+    catalog->declare(
+      id,
+      stream_input_binding{
+        input.names, input.types, _input_repos.at(id), input.expected_senders, nullptr});
+  }
+
+  auto logical_plan = _spec.plan_source(_context);
+  if (!logical_plan) {
+    throw sirius::invalid_input_exception("streaming_fragment: plan source produced no plan");
+  }
+
+  sirius::planner::sirius_physical_plan_generator generator(_context);
+  auto subtree = generator.create_plan(std::move(logical_plan));
+
+  // A STREAMING_SINK is a normal unary operator: the subtree goes in children[], unlike the
+  // RESULT_COLLECTOR, which keeps its child outside and needs special descent in the generator.
+  auto types       = subtree->types;
+  auto cardinality = subtree->estimated_cardinality;
+
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> sink_repos;
+  sink_repos.reserve(_spec.outputs.size());
+  for (auto id : _spec.outputs) {
+    sink_repos.push_back(_output_repos.at(id));
+  }
+
+  duckdb::unique_ptr<op::sirius_physical_streaming_sink> sink;
+  if (_spec.partitioning.has_value()) {
+    sink = duckdb::make_uniq<op::sirius_physical_streaming_sink>(
+      std::move(types), cardinality, std::move(sink_repos), *_spec.partitioning);
+  } else {
+    sink = duckdb::make_uniq<op::sirius_physical_streaming_sink>(
+      std::move(types), cardinality, sink_repos.front());
+  }
+  sink->children.push_back(std::move(subtree));
+
+  // Hand the plan to the engine and let it own the tree, which is the path a normal query
+  // takes. The fragment owns the engine, so the sink still outlives run() and stays pullable.
+  _iface = std::make_unique<sirius::sirius_interface>(
+    _context, std::optional<std::string>(kFragmentQueryLabel));
+  _engine = std::make_unique<sirius::sirius_engine>(_context, *_iface, query_id);
+  _engine->initialize(std::move(sink));
+
+  auto& sink_ref = _engine->sirius_physical_plan->Cast<op::sirius_physical_streaming_sink>();
+
+  // Register both ends with the session. The engine owns the operators; the session borrows.
+  _session.add_sink(_spec.outputs, sink_ref);
+  for (const auto& [id, _] : _spec.inputs) {
+    auto* built = catalog->get(id).built;
+    if (built == nullptr) {
+      // The plan never read this stream. Silently ignoring it would leave its senders with
+      // nowhere to push and the fragment waiting on a stream nothing drains.
+      throw sirius::invalid_input_exception("streaming_fragment: input stream " +
+                                            std::to_string(id) +
+                                            " was declared but the plan does not read it");
+    }
+    _session.add_source(id, *built);
+  }
+
+  _built = true;
+}
+
+void streaming_fragment::run()
+{
+  if (!_built) {
+    throw sirius::invalid_input_exception("streaming_fragment: build() must run before run()");
+  }
+
+  // The query window is the CALLER's, not the fragment's. Opening a StandaloneQueryScope resets
+  // the task creator and the operator-id counter, and its finish() resets the scan manager --
+  // all of which build() has already populated. Taking the slot here would discard those
+  // plan-time registrations, and the fragment would run zero tasks and return an empty output
+  // silently. The caller brackets build() and run() in one window, as Context::execute_substrait
+  // does.
+  _engine->execute();
+}
+
+const std::shared_ptr<cucascade::shared_data_repository>& streaming_fragment::input_repository(
+  stream_id_t id) const
+{
+  auto it = _input_repos.find(id);
+  if (it == _input_repos.end()) {
+    throw sirius::invalid_input_exception("streaming_fragment: no input stream with id " +
+                                          std::to_string(id));
+  }
+  return it->second;
+}
+
+const std::shared_ptr<cucascade::shared_data_repository>& streaming_fragment::output_repository(
+  stream_id_t id) const
+{
+  auto it = _output_repos.find(id);
+  if (it == _output_repos.end()) {
+    throw sirius::invalid_input_exception("streaming_fragment: no output stream with id " +
+                                          std::to_string(id));
+  }
+  return it->second;
+}
+
+}  // namespace sirius::exec

--- a/src/include/exec/stream_bind_catalog.hpp
+++ b/src/include/exec/stream_bind_catalog.hpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "duckdb/main/client_context_state.hpp"
+#include "exec/batch_stream.hpp"
+#include "exec/stream_session.hpp"
+#include "op/sirius_physical_streaming_source.hpp"
+
+#include <map>
+#include <mutex>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace sirius::exec {
+
+/// Everything needed to bind and then build one input stream.
+///
+/// The schema is supplied by the caller, never inferred: a stream has no file to probe, and the
+/// front end already knows the column types from its descriptor table. `sirius_stream_source`'s
+/// DuckDB bind reads `names` / `types` from here, and the physical plan generator reads
+/// `repository` / `expected_senders` to construct the operator.
+struct stream_input_binding {
+  std::vector<std::string> names;
+  duckdb::vector<sirius::logical_type> types;
+  std::shared_ptr<cucascade::shared_data_repository> repository;
+  std::set<sender_id_t> expected_senders;
+
+  /// Back-pointer to the operator the plan generator built for this id, filled in during
+  /// planning. The plan tree owns the operator; this is how the fragment finds it afterwards to
+  /// register it with its `stream_session`. Null until `create_plan(LogicalGet&)` has run.
+  op::sirius_physical_streaming_source* built = nullptr;
+};
+
+/// Per-connection registry of declared input streams, keyed by stream id.
+///
+/// It exists because a DuckDB table-function bind runs long before physical planning and has no
+/// route back to the fragment being built — only a `ClientContext`. Registering the catalog as a
+/// `ClientContextState` (exactly as the engine registers `SiriusContext` under `sirius_state`)
+/// gives the bind a lookup path, so `sirius_stream_source(id)` can resolve a schema with no file
+/// and no scan behind it.
+///
+/// One connection executes one fragment at a time, so a fragment declares its inputs before
+/// planning and clears them afterwards.
+class stream_bind_catalog : public duckdb::ClientContextState {
+ public:
+  /// ClientContextState key this catalog is registered under.
+  static constexpr const char* kStateKey = "sirius_stream_catalog";
+
+  /// Declare input stream `id`. Overwrites any previous declaration for the same id, so a reused
+  /// connection cannot serve a stale schema.
+  void declare(stream_id_t id, stream_input_binding binding);
+
+  /// Drop every declaration. Called when a fragment finishes.
+  void clear();
+
+  [[nodiscard]] bool contains(stream_id_t id) const;
+
+  /// @throws sirius::invalid_input_exception when `id` was never declared.
+  [[nodiscard]] const stream_input_binding& get(stream_id_t id) const;
+
+  /// Record the operator the plan generator built for `id`.
+  /// @throws sirius::invalid_input_exception when `id` was never declared.
+  void set_built(stream_id_t id, op::sirius_physical_streaming_source* built);
+
+  /// Declared stream ids, ascending.
+  [[nodiscard]] std::vector<stream_id_t> declared_streams() const;
+
+ private:
+  mutable std::mutex _mutex;
+  std::map<stream_id_t, stream_input_binding> _entries;
+};
+
+}  // namespace sirius::exec

--- a/src/include/exec/stream_plan_bindings.hpp
+++ b/src/include/exec/stream_plan_bindings.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/database.hpp"
+#include "exec/stream_bind_catalog.hpp"
+
+namespace sirius::exec {
+
+/// Name of the table function a fragment plan uses to read an input stream.
+inline constexpr const char* kStreamSourceFunctionName = "sirius_stream_source";
+
+/// Bind data for `sirius_stream_source(stream_id)`. Carries only the id — the schema is resolved
+/// at bind time from the connection's `stream_bind_catalog`, and the physical plan generator
+/// re-reads the catalog to build the operator.
+struct stream_source_bind_data : public duckdb::FunctionData {
+  explicit stream_source_bind_data(stream_id_t stream_id) : stream_id(stream_id) {}
+
+  stream_id_t stream_id;
+
+  duckdb::unique_ptr<duckdb::FunctionData> Copy() const override
+  {
+    return duckdb::make_uniq<stream_source_bind_data>(stream_id);
+  }
+
+  bool Equals(duckdb::FunctionData const& other_p) const override
+  {
+    auto const& other = other_p.Cast<stream_source_bind_data>();
+    return stream_id == other.stream_id;
+  }
+};
+
+/// Register `sirius_stream_source(stream_id BIGINT)` on `instance`'s system catalog.
+///
+/// A stream has no file to probe, so DuckDB's parquet binder cannot resolve a schema for it — a
+/// fake `local_files` URI would fail to bind. A table function carries its schema explicitly,
+/// which is why the exchange input is lowered to one. The bind reads the declared schema from the
+/// connection's `stream_bind_catalog`; the function body is never executed, because the Sirius
+/// plan generator replaces the scan with a `STREAMING_SOURCE`.
+void register_stream_source_function(duckdb::DatabaseInstance& instance);
+
+}  // namespace sirius::exec

--- a/src/include/exec/streaming_fragment.hpp
+++ b/src/include/exec/streaming_fragment.hpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "exec/stream_bind_catalog.hpp"
+#include "exec/stream_session.hpp"
+#include "op/sirius_physical_streaming_sink.hpp"
+#include "query_id.hpp"
+
+#include <duckdb/main/client_context.hpp>
+#include <duckdb/planner/logical_operator.hpp>
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace sirius {
+class sirius_engine;
+class sirius_interface;
+}  // namespace sirius
+
+namespace sirius::exec {
+
+/// Schema + provenance of one input stream, as the front end declares it.
+struct stream_input_spec {
+  std::vector<std::string> names;
+  duckdb::vector<sirius::logical_type> types;
+  /// Every sender expected to close this stream. The stream ends only once all of them have.
+  std::set<sender_id_t> expected_senders;
+};
+
+/// Produces the fragment's bound, optimized DuckDB logical plan.
+///
+/// A function because callers differ: Substrait bytes from a compute node, SQL from tests. Both
+/// end at a `LogicalOperator` the plan generator can lower.
+using logical_plan_source =
+  std::function<duckdb::unique_ptr<duckdb::LogicalOperator>(duckdb::ClientContext&)>;
+
+struct fragment_spec {
+  logical_plan_source plan_source;
+  /// One entry per exchange input. Ids are session-local.
+  std::map<stream_id_t, stream_input_spec> inputs;
+  /// One id per sink destination, positional: `outputs[i]` addresses partition i.
+  std::vector<stream_id_t> outputs;
+  /// Absent means gather (a single destination, no partitioning).
+  std::optional<op::partition_spec> partitioning;
+};
+
+/// One plan fragment, owning everything that must outlive a single query.
+///
+/// The repositories are plain `shared_ptr`s, never registered with `data_repository_manager_`,
+/// so the query window's mandatory cleanup (`StandaloneQueryScope::finish()`) cannot touch them.
+/// A sender's output therefore
+/// survives its own fragment and is still there when the receiver runs — the one fact that makes
+/// sequential streaming work.
+///
+/// The fragment owns the engine and the engine owns the plan, which keeps the sink pullable after
+/// `run()` while still taking the ordinary `initialize()` path.
+class streaming_fragment {
+ public:
+  streaming_fragment(duckdb::ClientContext& context, fragment_spec spec);
+  ~streaming_fragment();
+
+  streaming_fragment(const streaming_fragment&)            = delete;
+  streaming_fragment& operator=(const streaming_fragment&) = delete;
+
+  /// Build the plan: declare the inputs, lower them to STREAMING_SOURCEs, root the tree in a
+  /// STREAMING_SINK, and register both ends with the session. Separate from `run()` so a caller
+  /// can push into the inputs before execution starts.
+  /// @param query_id The caller's execution window (`SiriusContext::StandaloneQueryScope`); the
+  ///        engine wires this fragment's operators into that window's repository manager.
+  void build(sirius::query_id_t query_id);
+
+  /// Submit and block until the fragment's pipelines finish.
+  ///
+  /// The caller owns the query window and must bracket `build()` and `run()` in one
+  /// `SiriusContext::StandaloneQueryScope`. A window opened between them resets the task
+  /// creator and scan manager `build()` populated, and the fragment then runs zero tasks and
+  /// returns an empty output with no error.
+  /// @throws if `build()` has not run.
+  void run();
+
+  [[nodiscard]] stream_session& session() { return _session; }
+
+  /// The engine backing this fragment, for tests that need to inspect pipeline state.
+  [[nodiscard]] sirius::sirius_engine& engine() { return *_engine; }
+
+  /// The repository behind input stream `id`, for a caller that wants to inspect what it pushed.
+  [[nodiscard]] const std::shared_ptr<cucascade::shared_data_repository>& input_repository(
+    stream_id_t id) const;
+
+  /// The repository behind output stream `id`. This is what a downstream fragment consumes.
+  [[nodiscard]] const std::shared_ptr<cucascade::shared_data_repository>& output_repository(
+    stream_id_t id) const;
+
+ private:
+  duckdb::ClientContext& _context;
+  fragment_spec _spec;
+
+  // Declaration order IS the lifetime contract (members are destroyed in reverse): the
+  // repositories outlive the engine, the engine owns the plan, and the session -- which only
+  // borrows operators out of that plan -- is torn down first.
+  std::map<stream_id_t, std::shared_ptr<cucascade::shared_data_repository>> _input_repos;
+  std::map<stream_id_t, std::shared_ptr<cucascade::shared_data_repository>> _output_repos;
+  std::unique_ptr<sirius::sirius_interface> _iface;
+  std::unique_ptr<sirius::sirius_engine> _engine;
+  stream_session _session;
+
+  bool _built{false};
+};
+
+}  // namespace sirius::exec

--- a/src/include/planner/sirius_physical_plan_generator.hpp
+++ b/src/include/planner/sirius_physical_plan_generator.hpp
@@ -151,6 +151,13 @@ class sirius_physical_plan_generator {
   // &op);
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(duckdb::LogicalFilter& op);
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(duckdb::LogicalGet& op);
+
+  //! Builds the STREAMING_SOURCE a `sirius_stream_source(id)` read stands for, wired to the
+  //! repository and expected sender set the fragment declared for that id on this connection.
+  //! Records the built operator back into the catalog so the fragment can register it with its
+  //! stream_session once the plan tree owns it.
+  duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_streaming_source_plan(
+    duckdb::LogicalGet& op);
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(duckdb::LogicalLimit& op);
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(duckdb::LogicalOrder& op);
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(duckdb::LogicalTopN& op);

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -28,6 +28,8 @@
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/local_storage.hpp"
+#include "exec/stream_bind_catalog.hpp"
+#include "exec/stream_plan_bindings.hpp"
 #include "expression/ast/from_duckdb.hpp"
 #include "expression/ast/node.hpp"
 #include "helper/type_conversions.hpp"
@@ -87,6 +89,42 @@ duckdb::unique_ptr<duckdb::TableFilterSet> create_table_filter_set(
 }
 
 duckdb::unique_ptr<sirius::op::sirius_physical_operator>
+sirius_physical_plan_generator::create_streaming_source_plan(duckdb::LogicalGet& op)
+{
+  auto const* bind = dynamic_cast<sirius::exec::stream_source_bind_data const*>(op.bind_data.get());
+  if (bind == nullptr) {
+    throw duckdb::InternalException("sirius_stream_source is missing its stream bind data");
+  }
+
+  auto catalog = context.registered_state->Get<sirius::exec::stream_bind_catalog>(
+    sirius::exec::stream_bind_catalog::kStateKey);
+  if (!catalog) {
+    throw duckdb::InternalException(
+      "sirius_stream_source bound without a stream catalog on this connection");
+  }
+  auto const& binding = catalog->get(bind->stream_id);
+
+  // The source emits the whole declared schema. Projection pushdown is off for this function, so
+  // DuckDB projects above the scan; a narrowed column list here would mean the two disagree.
+  auto column_ids = op.GetColumnIds();
+  if (column_ids.size() != binding.types.size()) {
+    throw duckdb::NotImplementedException(
+      "sirius_stream_source: column projection into a stream read is not supported (stream "
+      "declares %llu columns, plan requests %llu)",
+      static_cast<unsigned long long>(binding.types.size()),
+      static_cast<unsigned long long>(column_ids.size()));
+  }
+
+  auto source = duckdb::make_uniq<sirius::op::sirius_physical_streaming_source>(
+    binding.types, op.EstimateCardinality(context), binding.repository, binding.expected_senders);
+
+  // The plan tree owns the operator from here; this back-pointer is how the fragment finds it
+  // again to register it with its stream_session.
+  catalog->set_built(bind->stream_id, source.get());
+  return source;
+}
+
+duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
 {
   auto column_ids = op.GetColumnIds();
@@ -94,7 +132,11 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   // Only GPU-route known table scan functions; all others (pragma, system catalog
   // functions, etc.) must fall back to CPU.
   static const std::unordered_set<std::string> kSupportedScanFunctions = {
-    "seq_scan", "parquet_scan", "read_parquet", "sirius_read_parquet"};
+    "seq_scan",
+    "parquet_scan",
+    "read_parquet",
+    "sirius_read_parquet",
+    sirius::exec::kStreamSourceFunctionName};
   if (kSupportedScanFunctions.find(op.function.name) == kSupportedScanFunctions.end()) {
     throw duckdb::NotImplementedException("Table function '{}' is not supported in Sirius",
                                           op.function.name);
@@ -107,6 +149,13 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   if (!op.projected_input.empty()) {
     throw duckdb::InternalException(
       "LogicalGet::project_input can only be set for table-in-out functions");
+  }
+
+  // A stream read is not a scan: there is no file, no metadata and nothing to push filters into.
+  // Swap it for the STREAMING_SOURCE the fragment already declared, wired to the repository its
+  // senders push into. Everything above it in the plan is bound exactly as for a real scan.
+  if (op.function.name == sirius::exec::kStreamSourceFunctionName) {
+    return create_streaming_source_plan(op);
   }
 
   // Plan-time probe for the duckdb-native seq_scan path: strings at/over

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -88,6 +88,7 @@ extern "C" int cudaProfilerStop();
 #include "gpu_physical_plan_generator.hpp"
 #endif
 #include "duckdb/main/connection_manager.hpp"
+#include "exec/stream_plan_bindings.hpp"
 #include "helper/type_conversions.hpp"
 #include "log/logging.hpp"
 #include "op/scan/duckdb_mvcc_visibility.hpp"
@@ -1538,6 +1539,11 @@ static void SiriusSetQueryLabelFunction(ClientContext& context,
 
 void SiriusExtension::RegisterGPUFunctions(DatabaseInstance& instance)
 {
+  // A fragment plan reads each of its exchange inputs through sirius_stream_source(id). Register
+  // it wherever Sirius is loaded, not just on the FFI's embedded DuckDB, so a fragment plan binds
+  // on the transparent path too.
+  sirius::exec::register_stream_source_function(instance);
+
   auto transaction = CatalogTransaction::GetSystemTransaction(instance);
   auto& catalog    = Catalog::GetSystemCatalog(instance);
 

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -34,7 +34,9 @@
 #include "duckdb/optimizer/optimizer.hpp"                  // duckdb::Optimizer
 #include "duckdb/parser/statement/relation_statement.hpp"  // duckdb::RelationStatement
 #include "duckdb/planner/planner.hpp"                      // duckdb::Planner
-#include "from_substrait.hpp"  // duckdb::SubstraitToDuckDB (compiled into libsirius)
+#include "exec/stream_bind_catalog.hpp"                    // sirius::exec::stream_bind_catalog
+#include "exec/stream_plan_bindings.hpp"  // sirius::exec::register_stream_source_function
+#include "from_substrait.hpp"             // duckdb::SubstraitToDuckDB (compiled into libsirius)
 #include "planner/sirius_physical_plan_generator.hpp"  // sirius::planner::sirius_physical_plan_generator
 #include "sirius_config.hpp"                           // sirius::sirius_config
 #include "sirius_context.hpp"                          // duckdb::SiriusContext
@@ -58,6 +60,10 @@ struct Context::Impl {
   duckdb::shared_ptr<duckdb::SiriusContext> context;
   duckdb::unique_ptr<duckdb::DuckDB> db;
   duckdb::unique_ptr<duckdb::Connection> conn;
+  //! Input streams declared for the fragment currently being planned. Dual ownership: also
+  //! inserted into registered_state (where the bind and the plan generator look it up). Held here
+  //! so the catalog outlives any registered_state reset and the `Context` can clear it directly.
+  duckdb::shared_ptr<sirius::exec::stream_bind_catalog> stream_catalog;
 
   void bring_up(sirius::sirius_config& config)
   {
@@ -99,6 +105,14 @@ struct Context::Impl {
     // embedded connection, mirroring OnConnectionOpened on the transparent path.
     client.registered_state->Insert("sirius_connection_state",
                                     duckdb::make_shared_ptr<duckdb::SiriusConnectionState>());
+
+    // A fragment reads each of its exchange inputs through sirius_stream_source(id). The
+    // function has to exist on this DuckDB before any fragment plan binds, and its bind needs
+    // somewhere to look up a schema for a stream that has no file behind it — the catalog,
+    // reached the same way the engine reaches its SiriusContext.
+    stream_catalog = duckdb::make_shared_ptr<sirius::exec::stream_bind_catalog>();
+    client.registered_state->Insert(sirius::exec::stream_bind_catalog::kStateKey, stream_catalog);
+    sirius::exec::register_stream_source_function(*db->instance);
     client.config.enable_optimizer = true;
     auto& disabled = duckdb::DBConfig::GetConfig(client).options.disabled_optimizers;
     disabled.insert(duckdb::OptimizerType::IN_CLAUSE);

--- a/test/cpp/exec/test_stream_bind_catalog.cpp
+++ b/test/cpp/exec/test_stream_bind_catalog.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <duckdb.hpp>
+#include <exec/stream_bind_catalog.hpp>
+#include <exec/stream_plan_bindings.hpp>
+#include <helper/type_conversions.hpp>
+#include <sirius/exception.hpp>
+
+#include <memory>
+#include <set>
+#include <vector>
+
+using namespace sirius::exec;
+
+namespace {
+
+duckdb::vector<sirius::logical_type> int_schema()
+{
+  return sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER});
+}
+
+stream_input_binding make_binding()
+{
+  return stream_input_binding{
+    {"a"}, int_schema(), std::make_shared<cucascade::shared_data_repository>(), {0}, nullptr};
+}
+
+}  // namespace
+
+// ============================================================================
+// CAT-1: a declared stream resolves to the schema it was declared with
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-1: a declared stream resolves its schema",
+          "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+  REQUIRE_FALSE(catalog.contains(7));
+
+  catalog.declare(7, make_binding());
+
+  REQUIRE(catalog.contains(7));
+  const auto& binding = catalog.get(7);
+  REQUIRE(binding.names.size() == 1);
+  REQUIRE(binding.names[0] == "a");
+  REQUIRE(binding.types.size() == 1);
+  REQUIRE(binding.repository != nullptr);
+  REQUIRE(binding.expected_senders == std::set<sender_id_t>{0});
+  // Nothing has planned yet, so no operator has been built for this id.
+  REQUIRE(binding.built == nullptr);
+}
+
+// ============================================================================
+// CAT-2: an undeclared id is a defined error, not an empty schema
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-2: an undeclared id throws", "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+  REQUIRE_THROWS_AS(catalog.get(1), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(catalog.set_built(1, nullptr), sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// CAT-3: a malformed declaration is rejected at declare time
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-3: a malformed declaration is rejected", "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+
+  // A stream with no repository has nowhere for its senders to push.
+  auto no_repo       = make_binding();
+  no_repo.repository = nullptr;
+  REQUIRE_THROWS_AS(catalog.declare(1, std::move(no_repo)), sirius::invalid_input_exception);
+
+  // Names and types must agree — DuckDB's bind hands back both, and a mismatch would surface
+  // much later as a column-count error inside the optimizer.
+  auto mismatched = make_binding();
+  mismatched.names.emplace_back("b");
+  REQUIRE_THROWS_AS(catalog.declare(2, std::move(mismatched)), sirius::invalid_input_exception);
+
+  auto empty = make_binding();
+  empty.names.clear();
+  empty.types.clear();
+  REQUIRE_THROWS_AS(catalog.declare(3, std::move(empty)), sirius::invalid_input_exception);
+
+  REQUIRE(catalog.declared_streams().empty());
+}
+
+// ============================================================================
+// CAT-4: the plan generator's back-pointer round-trips
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-4: the built operator is recorded", "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+  catalog.declare(4, make_binding());
+
+  auto* fake = reinterpret_cast<sirius::op::sirius_physical_streaming_source*>(0x1234);
+  catalog.set_built(4, fake);
+  REQUIRE(catalog.get(4).built == fake);
+}
+
+// ============================================================================
+// CAT-5: a fragment's declarations do not leak into the next one
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-5: clear drops every declaration", "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+  catalog.declare(1, make_binding());
+  catalog.declare(2, make_binding());
+  REQUIRE(catalog.declared_streams() == std::vector<stream_id_t>{1, 2});
+
+  catalog.clear();
+
+  REQUIRE(catalog.declared_streams().empty());
+  REQUIRE_FALSE(catalog.contains(1));
+  // A reused connection must not serve a stale schema for a recycled id.
+  REQUIRE_THROWS_AS(catalog.get(1), sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// CAT-6: redeclaring an id replaces it rather than keeping the old schema
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-6: a redeclared id is replaced", "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+  catalog.declare(1, make_binding());
+  catalog.set_built(1, reinterpret_cast<sirius::op::sirius_physical_streaming_source*>(0x1234));
+
+  auto replacement  = make_binding();
+  replacement.names = {"renamed"};
+  catalog.declare(1, std::move(replacement));
+
+  REQUIRE(catalog.get(1).names[0] == "renamed");
+  // The stale back-pointer must not survive: it refers to an operator from the previous plan.
+  REQUIRE(catalog.get(1).built == nullptr);
+}
+
+// ============================================================================
+// CAT-7: a stream read binds against the declared schema, with no file behind it
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-7: sirius_stream_source binds a declared stream",
+          "[stream_bind_catalog]")
+{
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  register_stream_source_function(*db.instance);
+
+  auto catalog = duckdb::make_shared_ptr<stream_bind_catalog>();
+  con.context->registered_state->Insert(stream_bind_catalog::kStateKey, catalog);
+
+  catalog->declare(
+    0,
+    stream_input_binding{{"l_orderkey", "l_comment"},
+                         sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{
+                           duckdb::LogicalType::BIGINT, duckdb::LogicalType::VARCHAR}),
+                         std::make_shared<cucascade::shared_data_repository>(),
+                         {0},
+                         nullptr});
+
+  // Binding is the whole point: DuckDB must resolve names and types for a relation that has no
+  // file, no catalog entry and no rows behind it. A parquet URI could not do this.
+  auto prepared = con.Prepare("SELECT * FROM sirius_stream_source(0)");
+  REQUIRE_FALSE(prepared->HasError());
+
+  REQUIRE(prepared->GetNames() == duckdb::vector<std::string>{"l_orderkey", "l_comment"});
+  REQUIRE(prepared->GetTypes() == duckdb::vector<duckdb::LogicalType>{
+                                    duckdb::LogicalType::BIGINT, duckdb::LogicalType::VARCHAR});
+
+  // A projection over the stream binds too, so the fragment's plan is not limited to SELECT *.
+  auto projected = con.Prepare("SELECT l_orderkey + 1 FROM sirius_stream_source(0)");
+  REQUIRE_FALSE(projected->HasError());
+}
+
+// ============================================================================
+// CAT-8: an undeclared stream fails at bind time, not at execution
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-8: an undeclared stream is a bind error",
+          "[stream_bind_catalog]")
+{
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  register_stream_source_function(*db.instance);
+
+  auto catalog = duckdb::make_shared_ptr<stream_bind_catalog>();
+  con.context->registered_state->Insert(stream_bind_catalog::kStateKey, catalog);
+
+  // Nothing declared id 9. Failing here means a fragment referencing a stream nobody set up is
+  // caught while planning, rather than surfacing later as a plan with no source.
+  auto prepared = con.Prepare("SELECT * FROM sirius_stream_source(9)");
+  REQUIRE(prepared->HasError());
+}
+
+// ============================================================================
+// CAT-9: without a catalog on the connection the function refuses to bind
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-9: no catalog on the connection is an error",
+          "[stream_bind_catalog]")
+{
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  register_stream_source_function(*db.instance);
+
+  auto prepared = con.Prepare("SELECT * FROM sirius_stream_source(0)");
+  REQUIRE(prepared->HasError());
+}

--- a/test/cpp/exec/test_streaming_fragment.cpp
+++ b/test/cpp/exec/test_streaming_fragment.cpp
@@ -1,0 +1,538 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../operator/operator_test_utils.hpp"
+#include "exec/streaming_fragment.hpp"
+#include "helper/type_conversions.hpp"
+#include "sirius/exception.hpp"
+#include "sirius_context.hpp"
+#include "sirius_engine.hpp"
+
+#include <catch.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <data/data_batch_utils.hpp>
+#include <duckdb.hpp>
+#include <utils/pipeline_conversion_test_utils.hpp>
+#include <utils/sirius_test_env.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+using namespace sirius::exec;
+
+namespace {
+
+//! A leaf source that produces real batches without depending on duckdb-native table ingestion:
+//! the GPU_VALUES path is self-contained, so the test isolates the streaming seam rather than
+//! the scan setup.
+constexpr const char* kLeafQuery = "SELECT a FROM (VALUES (1), (2), (3), (4), (5)) t(a)";
+constexpr std::size_t kLeafRows  = 5;
+
+fs::path lineitem_parquet_path()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return fs::path(SIRIUS_PROJECT_ROOT) / "test/cpp/integration/data/parquet/lineitem.parquet";
+#else
+  return fs::path(__FILE__).parent_path().parent_path() /
+         "integration/data/parquet/lineitem.parquet";
+#endif
+}
+
+fs::path integration_db_path()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return fs::path(SIRIUS_PROJECT_ROOT) / "test/cpp/integration/data/duckdb/integration.duckdb";
+#else
+  return fs::path(__FILE__).parent_path().parent_path() /
+         "integration/data/duckdb/integration.duckdb";
+#endif
+}
+
+struct fragment_fixture {
+  fragment_fixture()
+  {
+    REQUIRE(sirius::test::g_integration_env != nullptr);
+    if (!sirius::test::g_integration_env->is_active()) {
+      sirius::test::g_integration_env->resume();
+    }
+    con = std::make_unique<duckdb::Connection>(sirius::test::g_integration_env->make_connection());
+
+    auto db_path = integration_db_path();
+    REQUIRE(fs::exists(db_path));
+    auto result =
+      con->Query("ATTACH IF NOT EXISTS '" + db_path.string() + "' AS tpch (READ_ONLY);");
+    REQUIRE(result);
+    REQUIRE_FALSE(result->HasError());
+    result = con->Query("USE tpch;");
+    REQUIRE(result);
+    REQUIRE_FALSE(result->HasError());
+
+    // sirius_stream_source's bind resolves its schema here; the transparent path does not
+    // register a catalog, so the fragment supplies one for this connection.
+    catalog = duckdb::make_shared_ptr<stream_bind_catalog>();
+    con->context->registered_state->Insert(stream_bind_catalog::kStateKey, catalog);
+  }
+
+  std::unique_ptr<duckdb::Connection> con;
+  duckdb::shared_ptr<stream_bind_catalog> catalog;
+};
+
+//! The execution window a fragment's build/run must sit inside. RAII matters here: a `REQUIRE`
+//! that fails inside a hand-bracketed window would leave the slot held and self-deadlock in the
+//! test's `Rollback`, so the scope's destructor backstop is what lets a failing assertion fail.
+//! Tests that assert on post-cleanup state call `finish()` explicitly.
+using query_window = duckdb::SiriusContext::StandaloneQueryScope;
+
+//! Every INTEGER value sitting in an output stream, draining it. Row counts alone would not
+//! catch a hop that corrupted, dropped or duplicated values.
+std::vector<std::int32_t> drain_values(streaming_fragment& fragment, stream_id_t id)
+{
+  std::vector<std::int32_t> values;
+  while (auto batch = fragment.session().pull(id)) {
+    auto view = sirius::get_cudf_table_view(**batch);
+    auto col  = sirius::test::operator_utils::copy_column_to_host<std::int32_t>(view.column(0));
+    values.insert(values.end(), col.begin(), col.end());
+  }
+  std::sort(values.begin(), values.end());
+  return values;
+}
+
+//! Total rows sitting in an output stream, draining it.
+std::size_t drain_row_count(streaming_fragment& fragment, stream_id_t id)
+{
+  std::size_t rows = 0;
+  while (auto batch = fragment.session().pull(id)) {
+    rows += static_cast<std::size_t>(sirius::get_cudf_table_view(**batch).num_rows());
+  }
+  return rows;
+}
+
+}  // namespace
+
+// ============================================================================
+// FRAG-1: a leaf fragment runs to completion and parks its output
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-1: a leaf fragment runs and its output survives the window cleanup",
+                 "[integration][streaming_fragment]")
+{
+  fragment_spec spec;
+  spec.plan_source = sirius::test::sql_plan_source(kLeafQuery);
+  spec.outputs     = {0};
+
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  con->BeginTransaction();
+  try {
+    streaming_fragment fragment(*con->context, std::move(spec));
+
+    // One window spanning build + run: opening it resets the task creator, so opening it after
+    // build() would discard the plan-time registrations.
+    query_window window(*sirius_ctx, *con->context, "frag_1");
+    fragment.build(window.query_id());
+    // The whole point of change 2: without the completion gate this call never returns.
+    fragment.run();
+    window.finish();
+
+    // Diagnostic: separate "the source never produced a task" from "tasks ran but the sink got
+    // nothing". Without this the empty-output failure has two very different causes.
+    std::size_t created = 0, completed = 0;
+    for (const auto& p : fragment.engine().sirius_pipelines) {
+      created += p->get_tasks_created();
+      completed += p->get_tasks_completed();
+    }
+    INFO("pipelines=" << fragment.engine().sirius_pipelines.size()
+                      << " scheduled=" << fragment.engine().new_scheduled.size()
+                      << " tasks_created=" << created << " tasks_completed=" << completed);
+    REQUIRE(created > 0);
+
+    // Invariant 2 -- the output repository is session-owned, outside data_repository_manager_,
+    // so the window's mandatory cleanup cannot touch it. The batches are still here.
+    REQUIRE(fragment.output_repository(0)->total_size() > 0);
+    REQUIRE(drain_row_count(fragment, 0) == kLeafRows);
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}
+
+// ============================================================================
+// FRAG-2: two fragments chained by stream id produce the single-fragment answer
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-2: a two-fragment chain matches the equivalent single query",
+                 "[integration][streaming_fragment]")
+{
+  // The answer the chain must reproduce.
+  auto expected = con->Query(std::string("SELECT count(*) FROM (") + kLeafQuery + ") t");
+  REQUIRE_FALSE(expected->HasError());
+  auto const expected_rows = expected->GetValue(0, 0).GetValue<std::int64_t>();
+
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  con->BeginTransaction();
+  try {
+    // Sender: reads the table, writes to its output stream.
+    fragment_spec sender_spec;
+    sender_spec.plan_source = sirius::test::sql_plan_source(kLeafQuery);
+    sender_spec.outputs     = {0};
+    streaming_fragment sender(*con->context, std::move(sender_spec));
+
+    // Receiver: reads that stream instead of a table. No file, no parquet round-trip.
+    fragment_spec receiver_spec;
+    receiver_spec.plan_source =
+      sirius::test::sql_plan_source("SELECT a FROM sirius_stream_source(0)");
+    receiver_spec.inputs[0] = stream_input_spec{
+      {"a"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      {0}};
+    receiver_spec.outputs = {1};
+    streaming_fragment receiver(*con->context, std::move(receiver_spec));
+
+    // Each fragment gets its own query window, spanning its build and run. The sender's
+    // output repository is session-owned, so it survives the sender's window cleanup and is
+    // still there for the relay.
+    {
+      query_window sender_window(*sirius_ctx, *con->context, "frag_sender");
+      sender.build(sender_window.query_id());
+      sender.run();
+      sender_window.finish();
+    }
+
+    query_window receiver_window(*sirius_ctx, *con->context, "frag_receiver");
+    receiver.build(receiver_window.query_id());
+
+    // The relay the compute node will perform: pull from the sender's output stream and push
+    // into the receiver's input stream, as native batches. No Arrow, no disk.
+    std::size_t relayed_batches = 0;
+    while (auto batch = sender.session().pull(0)) {
+      REQUIRE(receiver.session().push(0, *batch));
+      ++relayed_batches;
+    }
+    REQUIRE(relayed_batches > 0);
+    receiver.session().close_input(0, 0);
+
+    receiver.run();
+    receiver_window.finish();
+
+    // Values, not just a count: the chain must deliver exactly what the sender produced.
+    auto const received = drain_values(receiver, 1);
+    REQUIRE(received.size() == static_cast<std::size_t>(expected_rows));
+    REQUIRE(received == std::vector<std::int32_t>{1, 2, 3, 4, 5});
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}
+
+// ============================================================================
+// FRAG-3: malformed specs are rejected at construction
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-3: a malformed fragment spec is rejected",
+                 "[integration][streaming_fragment]")
+{
+  auto source = sirius::test::sql_plan_source(kLeafQuery);
+
+  SECTION("no output stream")
+  {
+    fragment_spec spec;
+    spec.plan_source = source;
+    REQUIRE_THROWS_AS(streaming_fragment(*con->context, std::move(spec)),
+                      sirius::invalid_input_exception);
+  }
+
+  SECTION("fan-out without a partition spec")
+  {
+    // Two destinations and no partitioning would leave the sink unable to decide where a row
+    // goes, so it is refused rather than silently broadcasting.
+    fragment_spec spec;
+    spec.plan_source = source;
+    spec.outputs     = {0, 1};
+    REQUIRE_THROWS_AS(streaming_fragment(*con->context, std::move(spec)),
+                      sirius::invalid_input_exception);
+  }
+
+  SECTION("duplicate output id")
+  {
+    fragment_spec spec;
+    spec.plan_source  = source;
+    spec.outputs      = {0, 0};
+    spec.partitioning = sirius::op::partition_spec{{0}, {}};
+    REQUIRE_THROWS_AS(streaming_fragment(*con->context, std::move(spec)),
+                      sirius::invalid_input_exception);
+  }
+
+  SECTION("a declared input the plan never reads")
+  {
+    fragment_spec spec;
+    spec.plan_source = source;  // reads nation, not the stream
+    spec.inputs[7]   = stream_input_spec{
+        {"a"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+        {0}};
+    spec.outputs = {0};
+
+    auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+    con->BeginTransaction();
+    streaming_fragment fragment(*con->context, std::move(spec));
+    {
+      query_window window(*sirius_ctx, *con->context, "frag_3");
+      REQUIRE_THROWS_AS(fragment.build(window.query_id()), sirius::invalid_input_exception);
+    }
+    con->Rollback();
+  }
+}
+
+// ============================================================================
+// FRAG-CONTROL: does a RESULT_COLLECTOR-rooted plan execute when the engine is
+// driven directly? Isolates "streaming sink is broken" from "this harness is".
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-CONTROL: which queries actually materialize rows on the direct path",
+                 "[integration][streaming_fragment_control]")
+{
+  // Assert the ROW COUNT, not merely that execute() did not error. A plan that runs cleanly and
+  // produces nothing looks identical to a working one unless the rows are counted, and the whole
+  // streaming investigation hinges on knowing whether the source emits anything here at all.
+  auto row_count_of = [&](const std::string& query) -> std::size_t {
+    std::size_t rows = 0;
+    // with_initialized_engine synthesizes its own query id, but execute() still needs a real
+    // window open: only a window begin points the task creator at this connection.
+    auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+    REQUIRE(sirius_ctx != nullptr);
+    query_window window(*sirius_ctx, *con->context, "frag_control");
+    sirius::test::with_initialized_engine(*con, query, [&](sirius::sirius_engine& engine) {
+      REQUIRE(engine.has_result_collector());
+      engine.execute();
+      auto result = engine.get_result();
+      REQUIRE(result != nullptr);
+      REQUIRE_FALSE(result->HasError());
+      auto materialized =
+        duckdb::unique_ptr_cast<duckdb::QueryResult, duckdb::MaterializedQueryResult>(
+          std::move(result));
+      rows = materialized->RowCount();
+    });
+    window.finish();
+    return rows;
+  };
+
+  SECTION("VALUES leaf")
+  {
+    INFO("kLeafQuery = " << kLeafQuery);
+    REQUIRE(row_count_of(kLeafQuery) == kLeafRows);
+  }
+
+  SECTION("table scan") { REQUIRE(row_count_of("SELECT n_regionkey FROM nation") == 25); }
+
+  SECTION("filtered table scan")
+  {
+    REQUIRE(row_count_of("SELECT n_nationkey FROM nation WHERE n_regionkey = 1") == 5);
+  }
+}
+
+// ============================================================================
+// FRAG-4: the demo's real shape -- a parquet GPU scan across a fragment
+// boundary. VALUES is self-contained; a parquet scan exercises the actual
+// path the StarRocks compute node will drive, at real batch counts.
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-4: a parquet scan crosses a fragment boundary",
+                 "[integration][streaming_fragment]")
+{
+  auto const parquet = lineitem_parquet_path();
+  REQUIRE(fs::exists(parquet));
+
+  // A filtered projection, the shape TPC-H Q6 has: scan, filter, then exchange. The filter is on
+  // l_quantity deliberately: the file's five row groups are ordered by l_orderkey, so an
+  // l_orderkey range predicate prunes to a single row group and the scan would read a fraction
+  // of the file. l_quantity's statistics span every row group, so all five are read.
+  //
+  // This is still a ONE-batch hop -- the GPU scan emits a single batch per file regardless of
+  // row-group count. FRAG-5 is what covers a multi-batch stream.
+  auto const leaf =
+    "SELECT l_orderkey FROM read_parquet('" + parquet.string() + "') WHERE l_quantity < 2";
+
+  auto expected = con->Query("SELECT count(*) FROM (" + leaf + ") t");
+  REQUIRE_FALSE(expected->HasError());
+  auto const expected_rows =
+    static_cast<std::size_t>(expected->GetValue(0, 0).GetValue<std::int64_t>());
+  REQUIRE(expected_rows > 0);
+
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  con->BeginTransaction();
+  try {
+    fragment_spec sender_spec;
+    sender_spec.plan_source = sirius::test::sql_plan_source(leaf);
+    sender_spec.outputs     = {0};
+    streaming_fragment sender(*con->context, std::move(sender_spec));
+
+    fragment_spec receiver_spec;
+    receiver_spec.plan_source =
+      sirius::test::sql_plan_source("SELECT l_orderkey FROM sirius_stream_source(0)");
+    receiver_spec.inputs[0] = stream_input_spec{
+      {"l_orderkey"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::BIGINT}),
+      {0}};
+    receiver_spec.outputs = {1};
+    streaming_fragment receiver(*con->context, std::move(receiver_spec));
+
+    {
+      query_window sender_window(*sirius_ctx, *con->context, "frag4_sender");
+      sender.build(sender_window.query_id());
+      sender.run();
+      sender_window.finish();
+    }
+
+    query_window receiver_window(*sirius_ctx, *con->context, "frag4_receiver");
+    receiver.build(receiver_window.query_id());
+
+    std::size_t relayed_batches = 0;
+    std::size_t relayed_rows    = 0;
+    while (auto batch = sender.session().pull(0)) {
+      relayed_rows += static_cast<std::size_t>(sirius::get_cudf_table_view(**batch).num_rows());
+      REQUIRE(receiver.session().push(0, *batch));
+      ++relayed_batches;
+    }
+    REQUIRE(relayed_batches > 0);
+    // Everything the sender produced crosses the hop; nothing is dropped in transit.
+    REQUIRE(relayed_rows == expected_rows);
+    receiver.session().close_input(0, 0);
+
+    receiver.run();
+    receiver_window.finish();
+
+    REQUIRE(drain_row_count(receiver, 1) == expected_rows);
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}
+
+// ============================================================================
+// FRAG-5: a MULTI-BATCH stream drains completely.
+//
+// FRAG-2 and FRAG-4 both hop a single batch, which one task consumes in one
+// go. Whether a queue holding several batches drains is a separate question:
+// it is the task creator's per-batch loop and the pipeline's completion gate
+// that have to agree, and neither is exercised by a one-batch stream. Two
+// sender fragments fill the queue, because a GPU scan emits one batch per
+// file and a VALUES leaf one batch per fragment -- the batch count comes from
+// the number of senders, not from the leaf.
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-5: a multi-batch stream drains completely",
+                 "[integration][streaming_fragment]")
+{
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  // Disjoint halves, so the receiver's output identifies which batches arrived, not merely how
+  // many rows did.
+  constexpr const char* kFirstHalf  = "SELECT a FROM (VALUES (1), (2), (3)) t(a)";
+  constexpr const char* kSecondHalf = "SELECT a FROM (VALUES (4), (5), (6)) t(a)";
+
+  con->BeginTransaction();
+  try {
+    auto make_sender = [&](const char* query) {
+      fragment_spec spec;
+      spec.plan_source = sirius::test::sql_plan_source(query);
+      spec.outputs     = {0};
+      return std::make_unique<streaming_fragment>(*con->context, std::move(spec));
+    };
+
+    auto first  = make_sender(kFirstHalf);
+    auto second = make_sender(kSecondHalf);
+
+    fragment_spec receiver_spec;
+    receiver_spec.plan_source =
+      sirius::test::sql_plan_source("SELECT a FROM sirius_stream_source(0)");
+    receiver_spec.inputs[0] = stream_input_spec{
+      {"a"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      {0}};
+    receiver_spec.outputs = {1};
+    streaming_fragment receiver(*con->context, std::move(receiver_spec));
+
+    for (auto* sender : {first.get(), second.get()}) {
+      query_window sender_window(*sirius_ctx, *con->context, "frag5_sender");
+      sender->build(sender_window.query_id());
+      sender->run();
+      sender_window.finish();
+    }
+
+    query_window receiver_window(*sirius_ctx, *con->context, "frag5_receiver");
+    receiver.build(receiver_window.query_id());
+
+    std::size_t relayed_batches = 0;
+    for (auto* sender : {first.get(), second.get()}) {
+      while (auto batch = sender->session().pull(0)) {
+        REQUIRE(receiver.session().push(0, *batch));
+        ++relayed_batches;
+      }
+    }
+    // The premise of this test. If a sender ever starts emitting one batch per fragment run
+    // *and* the other stops emitting at all, the test would silently degrade to FRAG-2.
+    REQUIRE(relayed_batches > 1);
+    receiver.session().close_input(0, 0);
+
+    receiver.run();
+    receiver_window.finish();
+
+    // Diagnostic, not a contract: the source hands out one batch per task, so a healthy drain of
+    // N batches runs N tasks. Reported rather than asserted because coalescing batches into one
+    // task is a live design option -- if that lands, this number changes and the value assertion
+    // below is still the thing that must hold.
+    std::size_t created = 0, completed = 0;
+    for (const auto& p : receiver.engine().sirius_pipelines) {
+      created += p->get_tasks_created();
+      completed += p->get_tasks_completed();
+    }
+    INFO("relayed_batches=" << relayed_batches << " receiver tasks_created=" << created
+                            << " tasks_completed=" << completed);
+
+    // Every value from every batch: a receiver that ran one task and stopped would return the
+    // first batch's rows and look like a plausible partial success.
+    REQUIRE(drain_values(receiver, 1) == std::vector<std::int32_t>{1, 2, 3, 4, 5, 6});
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}

--- a/test/cpp/pipeline/test_streaming_sink_root.cpp
+++ b/test/cpp/pipeline/test_streaming_sink_root.cpp
@@ -121,6 +121,12 @@ TEST_CASE_METHOD(streaming_sink_root_fixture,
       REQUIRE_FALSE(engine.has_result_collector());
 
       REQUIRE(sink.num_output_streams() == 1);
+
+      // The pipeline must actually reach the scheduler. schedule_pipelines() walks the meta
+      // pipelines with skip=true, dropping the ROOT meta -- so a plan whose only real pipeline
+      // lands in the root meta would initialize, report the right shape, and then run zero
+      // tasks. That failure is silent: the query "completes" with an empty result.
+      REQUIRE_FALSE(engine.new_scheduled.empty());
     });
 }
 
@@ -177,5 +183,37 @@ TEST_CASE_METHOD(streaming_sink_root_fixture,
       for (std::size_t i = 0; i < 3; ++i) {
         REQUIRE_FALSE(sink.drained(i));
       }
+    });
+}
+
+// ============================================================================
+// SINKROOT-4: the A/B against the result collector. Same extraction, same plan
+// generator, same connection -- only the terminal operator differs. If this
+// fails while FRAG-CONTROL passes, the sink is at fault, not the harness.
+// ============================================================================
+
+TEST_CASE_METHOD(streaming_sink_root_fixture,
+                 "SINKROOT-4: a sink-rooted plan actually produces batches",
+                 "[integration][pipeline][streaming_sink_root_exec]")
+{
+  auto repos = make_repos(1);
+
+  sirius::test::with_initialized_streaming_fragment(
+    *con,
+    "SELECT a FROM (VALUES (1), (2), (3), (4), (5)) t(a)",
+    repos,
+    std::nullopt,
+    [&](sirius::sirius_engine& engine, sirius_physical_streaming_sink& sink) {
+      engine.execute();
+
+      std::size_t created = 0;
+      for (const auto& p : engine.sirius_pipelines) {
+        created += p->get_tasks_created();
+      }
+      INFO("pipelines=" << engine.sirius_pipelines.size() << " tasks_created=" << created);
+
+      // The sink holds the same repository the caller passed in.
+      REQUIRE(repos[0]->total_size() > 0);
+      REQUIRE(sink.num_output_streams() == 1);
     });
 }

--- a/test/cpp/utils/pipeline_conversion_test_utils.cpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.cpp
@@ -244,6 +244,15 @@ void with_initialized_engine(duckdb::Connection& con,
   }
 }
 
+exec::logical_plan_source sql_plan_source(const std::string& query)
+{
+  return [query](duckdb::ClientContext& context) {
+    optimizer_disable_guard guard(context);
+    auto extracted = extract_logical_plan_sirius_order(context, query);
+    return std::move(extracted.logical_plan);
+  };
+}
+
 void with_initialized_streaming_fragment(
   duckdb::Connection& con,
   const std::string& query,

--- a/test/cpp/utils/pipeline_conversion_test_utils.hpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "exec/streaming_fragment.hpp"
 #include "op/sirius_physical_streaming_sink.hpp"
 #include "query_id.hpp"
 
@@ -94,6 +95,11 @@ void with_conversion_result(
 void with_initialized_engine(duckdb::Connection& con,
                              const std::string& query,
                              const std::function<void(sirius_engine&)>& consume);
+
+//! A `logical_plan_source` that binds and optimizes `query`, applying the same optimizer disables
+//! the production path uses. Lets a test drive `streaming_fragment` from SQL where the compute
+//! node would hand over Substrait bytes. The caller must have a transaction open.
+exec::logical_plan_source sql_plan_source(const std::string& query);
 
 //! Like `with_initialized_engine`, but roots the plan in a STREAMING_SINK over `output_repos`
 //! instead of a RESULT_COLLECTOR — the shape a streaming fragment runs. The caller (standing in


### PR DESCRIPTION
Implements #839 (plan/execution half; the addressing half is part 4). Part 5 of a five-PR stack.

**What.** The layer that makes the other four runnable from outside. `exec::streaming_fragment` takes
a plan source plus its input and output stream declarations, builds a plan with `STREAMING_SOURCE`s at
its leaves and a `STREAMING_SINK` at its root, runs it, and hands back a `stream_session` addressing
both ends.

**Design: a stream is a table function, not a scan.** An exchange input has no file to probe, so
DuckDB's parquet binder cannot resolve a schema for it — a fake `local_files` URI simply fails to
bind. A table function carries its schema explicitly, so the input lowers to
`sirius_stream_source(id)`; its body never executes, because the plan generator replaces the
`LogicalGet` with a `STREAMING_SOURCE` first.

- **`stream_bind_catalog` bridges bind time and plan time.** Bind runs long before physical planning
  and sees only a `ClientContext`, so the catalog is a `ClientContextState`: bind reads
  `names`/`types`, the plan generator re-reads `repository`/`expected_senders` from the same entry and
  records a back-pointer, so no owning handle escapes the plan.
- **Output repositories are never registered with `data_repository_manager_`.** The query window's
  mandatory `StandaloneQueryScope::finish()` therefore cannot touch them, and a sender's output
  survives its own fragment — the single fact that makes sequential streaming work (FRAG-1).
- **Member declaration order *is* the lifetime contract.** Repositories outlive the engine, the engine
  owns the plan, the session — which only borrows out of it — is torn down first.
- **`build()` and `run()` must share one `StandaloneQueryScope`.** A window opened between them resets
  the task creator and scan manager `build()` populated; the fragment then runs zero tasks and returns
  empty **with no error**.
- **Projection pushdown is off; a column-count mismatch throws** rather than quietly producing
  wrong-width batches.

Two lines make it reachable, and only together: `sirius_plan_get.cpp` adds
`kStreamSourceFunctionName` to the names recognized as scans, and `sirius_extension.cpp` registers the
function wherever Sirius loads — not only on the FFI's embedded DuckDB — so a fragment plan binds on
the transparent path too. `sirius_ffi.cpp` holds the catalog on the connection as well as in
`registered_state`, so it outlives a state reset and `Context` can clear it directly.

**Reading order.**
1. `src/include/exec/streaming_fragment.hpp` — class comment is the lifetime contract.
2. `stream_plan_bindings.hpp`, `stream_bind_catalog.hpp` — why a table function, why a
   `ClientContextState`.
3. `src/planner/sirius_plan_get.cpp` — `create_streaming_source_plan` and the swap above it.
4. `src/exec/streaming_fragment.cpp` — `build()` then `run()`.
5. `test/cpp/exec/test_streaming_fragment.cpp`, `test_stream_bind_catalog.cpp` — FRAG-2 is the
   acceptance test (two-fragment chain matching the equivalent single query), FRAG-1 the
   survival-past-cleanup invariant, CAT-1…9 the bind path. FRAG-CONTROL is a control, not a feature
   test: a RESULT_COLLECTOR-rooted plan asserting row counts. SINKROOT-4 finally *executes* a
   sink-rooted plan rather than only initializing one.

### Stack: part 5 of 5
- **Base:** `stream/04-session` (#1323)
- **Depends on:** #1323 (part 4), transitively #1322 / #1321 / #1320
