### PR TITLE
Add support for compressing 16-bit datatypes

### DIFF
--- a/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
+++ b/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
@@ -238,12 +238,7 @@ static std::uint64_t leaf_alloc_bytes(std::string_view name,
   cudf::data_type const dt = tag_to_dtype(type_tag);
   auto const width         = static_cast<std::uint64_t>(cudf::size_of(dt));
   auto const elem          = std::max<std::uint64_t>(width, 1);
-  std::uint64_t pad_elems  = 0;
-  if (name == "packed") {
-    constexpr std::uint64_t kBitpackGatherSlopBytes = 2 * sizeof(std::uint32_t);
-    pad_elems                                       = (kBitpackGatherSlopBytes + elem - 1) / elem;
-  }
-  return (num_rows + pad_elems) * width;
+  return num_rows * width;
 }
 
 static std::unique_ptr<compressed_representation> rep_from_leaf_desc(
@@ -263,23 +258,8 @@ static std::unique_ptr<compressed_representation> rep_from_leaf_desc(
   auto make_col = [&](std::size_t i) -> std::unique_ptr<cudf::column> {
     auto const& bd     = bufs[i];
     cudf::data_type dt = tag_to_dtype(bd.type_tag);
-    // simpatico_bitunpack_one (decode kPrelude) does a fixed 3-word gather
-    // — packed[word_in], [word_in+1], [word_in+2] — so decoding the last
-    // element of a bitpacked "packed" buffer reads up to 2 uint32 words past
-    // its logical end. Over-allocate those buffers by 2 words of tail slop so
-    // the read stays in bounds. The slop is masked off in the decode, so its
-    // (uninitialized) contents never affect the result; only its addressability
-    // matters. Without it the OOB read faults the context and cascades into
-    // unrelated decode-kernel launch failures on concurrent streams.
-    constexpr cudf::size_type kBitpackGatherSlopBytes =
-      2 * static_cast<cudf::size_type>(sizeof(std::uint32_t));
-    cudf::size_type pad_elems = 0;
-    if (bd.name == "packed") {
-      auto const elem = std::max<std::size_t>(cudf::size_of(dt), 1);
-      pad_elems       = static_cast<cudf::size_type>((kBitpackGatherSlopBytes + elem - 1) / elem);
-    }
-    auto col = cudf::make_numeric_column(dt,
-                                         static_cast<cudf::size_type>(bd.num_rows) + pad_elems,
+    auto col           = cudf::make_numeric_column(dt,
+                                         static_cast<cudf::size_type>(bd.num_rows),
                                          cudf::mask_state::UNALLOCATED,
                                          stream,
                                          leaf_mr);

--- a/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
+++ b/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
@@ -240,16 +240,13 @@ std::unique_ptr<cudf::column> compact_bitpack_packed(cudf::column const& chunk_c
 
   const std::size_t live = static_cast<std::size_t>(live_packed_bytes);
 
-  // The decode bit-unpack gather (simpatico_bitunpack_one) loads three
-  // consecutive uint32 words unconditionally, so decoding the last element of
-  // simpatico_bitunpack_one unconditionally loads three consecutive uint32 words
-  // (w0, w1, w2) starting at word_in, so the last valid element can touch up to
-  // two words past the last live word.  Allocate three words of trailing slack
-  // (zero-initialised) so all three loads are always within the allocation.
-  // The column's logical size stays ``live`` so serialization remains tight.
-  constexpr std::size_t kDecodeGatherSlackBytes = 3 * sizeof(std::uint32_t);
+  // simpatico_bitunpack_one loads three consecutive uint32 words (w0/w1/w2);
+  // three guard words keep the last element's gather in-bounds.  They travel
+  // as part of the stored payload so num_rows already accounts for them.
+  constexpr std::size_t kGuardWords = 3;
+  const std::size_t guard_bytes     = kGuardWords * sizeof(std::uint32_t);
 
-  rmm::device_buffer dense(live + kDecodeGatherSlackBytes, stream, mr);
+  rmm::device_buffer dense(live + guard_bytes, stream, mr);
   if (live > 0) {
     const cudf::size_type num_chunks = chunk_count.size();
     const void* cc_p                 = chunk_count.view().head<void>();
@@ -294,15 +291,16 @@ std::unique_ptr<cudf::column> compact_bitpack_packed(cudf::column const& chunk_c
              "compact gather");
   }
 
-  // Zero the trailing gather slack so the decode over-read returns deterministic
-  // (masked-out) bytes rather than uninitialised memory.
-  cudaMemsetAsync(
-    static_cast<std::uint8_t*>(dense.data()) + live, 0, kDecodeGatherSlackBytes, stream.value());
+  // Zero the guard words so the decode over-read returns deterministic
+  // (masked-out) zeros rather than uninitialised memory.
+  cudaMemsetAsync(static_cast<std::uint8_t*>(dense.data()) + live, 0, guard_bytes, stream.value());
 
   // packed is uint32 words; UINT32 (size = words) keeps a >2GB dense buffer
-  // under cudf's 2^31-element cap. `live` is a byte count, always a multiple of 4.
+  // under cudf's 2^31-element cap.  The column size includes the guard words
+  // so they travel through serialisation/deserialisation without any special
+  // extra allocation at the read site.  `live` is always a multiple of 4.
   return std::make_unique<cudf::column>(cudf::data_type(cudf::type_id::UINT32),
-                                        static_cast<cudf::size_type>(live / 4),
+                                        static_cast<cudf::size_type>(live / 4 + kGuardWords),
                                         std::move(dense),
                                         rmm::device_buffer(0, stream, mr),
                                         0);

--- a/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
+++ b/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
@@ -242,12 +242,12 @@ std::unique_ptr<cudf::column> compact_bitpack_packed(cudf::column const& chunk_c
 
   // The decode bit-unpack gather (simpatico_bitunpack_one) loads three
   // consecutive uint32 words unconditionally, so decoding the last element of
-  // the last chunk touches up to two uint32 words past the live packed bytes.
-  // Allocate that much readable trailing slack (masked out of every decoded
-  // value); without it the gather over-reads the dense allocation — a real OOB
-  // caught by compute-sanitizer. The column's logical size stays ``live`` so
-  // serialization remains tight.
-  constexpr std::size_t kDecodeGatherSlackBytes = 2 * sizeof(std::uint32_t);
+  // simpatico_bitunpack_one unconditionally loads three consecutive uint32 words
+  // (w0, w1, w2) starting at word_in, so the last valid element can touch up to
+  // two words past the last live word.  Allocate three words of trailing slack
+  // (zero-initialised) so all three loads are always within the allocation.
+  // The column's logical size stays ``live`` so serialization remains tight.
+  constexpr std::size_t kDecodeGatherSlackBytes = 3 * sizeof(std::uint32_t);
 
   rmm::device_buffer dense(live + kDecodeGatherSlackBytes, stream, mr);
   if (live > 0) {

--- a/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
+++ b/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
@@ -1104,13 +1104,25 @@ static int launch_encode_fused_tree_impl(const simpatico::CodegenHead& head,
           const auto i_zz = find_buffer_idx(spec.buffers, node_id, "zigzag");
           const std::size_t zz_rows =
             static_cast<std::size_t>(num_chunks) * static_cast<std::size_t>(kChunkSize);
-          auto zz_col = std::make_unique<cudf::column>(original_type,
+          // Use the renderer's actual buffer elem_size to determine the column type.
+          // When Zigzag sits on an RLE "runs" channel the kernel processes int32_t
+          // run counts, so elem_size == 4 regardless of the column's element type.
+          // Using original_type for INT16 columns would make ANS compress only the
+          // low 2 bytes of each int32_t code, corrupting the run counts on decode.
+          const std::int32_t zz_elem_size = static_cast<std::int32_t>(spec.buffers[i_zz].elem_size);
+          const cudf::data_type zz_type =
+            (zz_elem_size == static_cast<std::int32_t>(cudf::size_of(original_type)))
+              ? original_type
+            : (zz_elem_size == 8) ? cudf::data_type(cudf::type_id::INT64)
+            : (zz_elem_size == 1) ? cudf::data_type(cudf::type_id::UINT8)
+                                  : cudf::data_type(cudf::type_id::INT32);
+          auto zz_col = std::make_unique<cudf::column>(zz_type,
                                                        static_cast<cudf::size_type>(zz_rows),
                                                        std::move(bufs[i_zz]),
                                                        rmm::device_buffer(0, stream),
                                                        0);
           auto rep    = std::make_unique<simpatico::codegen_fused_representation>(
-            simpatico::OpId::Zigzag, original_type, static_cast<cudf::size_type>(num_rows));
+            simpatico::OpId::Zigzag, zz_type, static_cast<cudf::size_type>(num_rows));
           rep->buffers.emplace_back("zigzag", std::move(zz_col));
           builder->leaves.emplace(origin.plan_node, std::move(rep));
           break;

--- a/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
+++ b/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
@@ -836,6 +836,15 @@ static int launch_encode_fused_tree_impl(const simpatico::CodegenHead& head,
     for (auto& p : dev_ptrs)
       args.push_back(&p);
 
+    {
+      CUfunction fn_enc   = kernel->func_for_current_device();
+      int static_smem_enc = 0;
+      cuFuncGetAttribute(&static_smem_enc, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, fn_enc);
+      if (static_smem_enc + spec.shared_bytes > 48 * 1024) {
+        cuFuncSetAttribute(
+          fn_enc, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, spec.shared_bytes);
+      }
+    }
     SIMPATICO_CU_CHECK(cuLaunchKernel(kernel->func_for_current_device(),
                                       static_cast<unsigned>(num_chunks),
                                       1,

--- a/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
+++ b/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
@@ -420,6 +420,9 @@ const char* dtype_to_cxx(const char* dtype)
   // SIGNED int8_t: zigzag's shift = elem_size*8-1 relies on sign-extension.
   // The output column retains the original UINT8 type_id.
   if (s == "uint8" || s == "uint8_t" || s == "int8" || s == "int8_t") return "int8_t";
+  // 16-bit signed/unsigned both process as int16_t; zigzag's shift = 15 relies
+  // on sign-extension, and the output column keeps the original UINT16 type_id.
+  if (s == "int16" || s == "int16_t" || s == "uint16" || s == "uint16_t") return "int16_t";
   // Unsigned 32/64-bit process as their same-width signed integer (bit-level
   // codecs roundtrip either way); the output column keeps the original UINT type.
   if (s == "uint32" || s == "uint32_t") return "int32_t";
@@ -595,9 +598,10 @@ bool launch_decode_fused_tree(codegen::jit::FusedTree const& tree,
                    dtype ? dtype : "(null)");
       return false;
     }
-    const std::size_t elem_size = (std::strcmp(cxx_dtype, "int64_t") == 0)  ? 8u
-                                  : (std::strcmp(cxx_dtype, "int8_t") == 0) ? 1u
-                                                                            : 4u;
+    const std::size_t elem_size = (std::strcmp(cxx_dtype, "int64_t") == 0)   ? 8u
+                                  : (std::strcmp(cxx_dtype, "int16_t") == 0) ? 2u
+                                  : (std::strcmp(cxx_dtype, "int8_t") == 0)  ? 1u
+                                                                             : 4u;
 
     // Device transients (bp_offsets/scratch) from the RMM async pool, freed
     // async on return.
@@ -1313,6 +1317,8 @@ bool launch_encode_fused_tree(CodegenHead const& head,
   switch (input_col.type().id()) {
     case cudf::type_id::INT8: dtype = "int8"; break;
     case cudf::type_id::UINT8: dtype = "uint8"; break;
+    case cudf::type_id::INT16: dtype = "int16"; break;
+    case cudf::type_id::UINT16: dtype = "uint16"; break;
     case cudf::type_id::INT32: dtype = "int32"; break;
     case cudf::type_id::INT64: dtype = "int64"; break;
     case cudf::type_id::UINT32: dtype = "uint32"; break;

--- a/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
+++ b/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
@@ -921,6 +921,7 @@ static int launch_encode_fused_tree_impl(const simpatico::CodegenHead& head,
           // be INT32 regardless of the column dtype.
           const cudf::data_type bp_elem_type =
             (spec.buffers[i_min].elem_size == 8)   ? cudf::data_type(cudf::type_id::INT64)
+            : (spec.buffers[i_min].elem_size == 2) ? cudf::data_type(cudf::type_id::INT16)
             : (spec.buffers[i_min].elem_size == 1) ? cudf::data_type(cudf::type_id::UINT8)
                                                    : cudf::data_type(cudf::type_id::INT32);
           auto mins_col = std::make_unique<cudf::column>(bp_elem_type,

--- a/src/compression/simpatico_codegen/src/bridge/offsets_cumsum.cu
+++ b/src/compression/simpatico_codegen/src/bridge/offsets_cumsum.cu
@@ -239,6 +239,12 @@ int simpatico_compact_raw_values(
                                        static_cast<std::int8_t*>(d_compact_v),
                                        offs,
                                        chunk_size);
+  } else if (elem_size == 2) {
+    compact_raw_values_kernel<std::int16_t>
+      <<<num_chunks, 128, 0, stream>>>(static_cast<const std::int16_t*>(d_padded_v),
+                                       static_cast<std::int16_t*>(d_compact_v),
+                                       offs,
+                                       chunk_size);
   } else {
     compact_raw_values_kernel<std::int32_t>
       <<<num_chunks, 128, 0, stream>>>(static_cast<const std::int32_t*>(d_padded_v),

--- a/src/compression/simpatico_codegen/src/decode/jit/renderer.cpp
+++ b/src/compression/simpatico_codegen/src/decode/jit/renderer.cpp
@@ -150,12 +150,6 @@ class Walker {
   std::vector<DecodeBufferSpec> buffers_;
   SharedMemAllocator sm_;
   std::unordered_map<const ::codegen::jit::FusedTree*, std::int32_t> ids_;
-  // When non-empty, zigzag_value_source_inline uses this expression as the
-  // per-chunk base index rather than chunk_start.  Set by emit_rle_producer
-  // while generating the Zigzag runs-child producer so that compact run-indexed
-  // data (total_runs elements, not chunk_id*kChunkSize strided) is accessed at
-  // the correct offset.
-  std::string zigzag_rle_base_override_;
 
   // DFS-preorder, lex-sorted children (std::map iteration) — must match
   // jit::assign_ids and the decode binder (bind_fused_subtree) so
@@ -669,14 +663,7 @@ void Walker::emit_rle_producer(const ::codegen::jit::FusedTree& node,
             << "));\n";
     } else {
       // Runs child needs materialisation; use SmemCountsReader functor.
-      // When the direct runs child is a leaf Zigzag its stored data is compact
-      // (total_runs elements indexed by global run number, not chunk-strided),
-      // so use rle_runs_offsets[chunk_id] as the base rather than chunk_start.
-      const bool runs_is_leaf_zigzag =
-        rit->second->op == ::codegen::OpKind::Zigzag && rit->second->children.empty();
-      if (runs_is_leaf_zigzag) zigzag_rle_base_override_ = p_off + "[chunk_id]";
       emit_producer(*rit->second, sh_counts, nruns, "int32_t");
-      zigzag_rle_base_override_.clear();
       body_ << "        __syncthreads();\n"
             << "        ::codegen::block_rle_decompress_fv<" << elem_type << ">(\n"
             << "            " << vread << ",\n"
@@ -874,14 +861,10 @@ ValueSource Walker::zigzag_value_source_inline(const ::codegen::jit::FusedTree& 
   add_param("const " + elem_type + "* __restrict__", p_data);
   add_buffer(id, "zigzag", esize);
 
-  // Stored element at this position.  Normally base == chunk_start
-  // (chunk_id*CHUNK), but when the Zigzag is an RLE's runs child the stored
-  // data is compact (total_runs elements indexed by global run number), so the
-  // base must be the cumulative run offset for this chunk instead.
-  const std::string base_expr =
-    zigzag_rle_base_override_.empty() ? "chunk_start" : zigzag_rle_base_override_;
+  // Stored element at this position (read once textually; compiler CSEs the
+  // duplicate load).  base == chunk_start (chunk_id*CHUNK), known at entry.
   const std::string load = "static_cast<" + utype + ">(static_cast<" + exact_unsigned(esize) +
-                           ">(" + p_data + "[" + base_expr + " + (__POS__)]))";
+                           ">(" + p_data + "[chunk_start + (__POS__)]))";
 
   ValueSource vs;
   vs.elem_type = elem_type;

--- a/src/compression/simpatico_codegen/src/decode/jit/renderer.cpp
+++ b/src/compression/simpatico_codegen/src/decode/jit/renderer.cpp
@@ -64,6 +64,7 @@ using ::codegen::jit::unsigned_counterpart;
 std::size_t dtype_elem_size(const std::string& name)
 {
   if (name == "int8_t") return 1;
+  if (name == "int16_t") return 2;
   if (name == "int32_t") return 4;
   if (name == "int64_t") return 8;
   return 0;  // 0 => unsupported (caller throws)
@@ -76,7 +77,10 @@ std::size_t dtype_elem_size(const std::string& name)
 // elements (exact width == counterpart width).
 const char* exact_unsigned(std::size_t elem_size)
 {
-  return (elem_size == 8) ? "uint64_t" : (elem_size == 1) ? "uint8_t" : "uint32_t";
+  return (elem_size == 8)   ? "uint64_t"
+         : (elem_size == 2) ? "uint16_t"
+         : (elem_size == 1) ? "uint8_t"
+                            : "uint32_t";
 }
 
 // Substitute a value source's __POS__ token with the given position expr.

--- a/src/compression/simpatico_codegen/src/decode/jit/renderer.cpp
+++ b/src/compression/simpatico_codegen/src/decode/jit/renderer.cpp
@@ -150,6 +150,12 @@ class Walker {
   std::vector<DecodeBufferSpec> buffers_;
   SharedMemAllocator sm_;
   std::unordered_map<const ::codegen::jit::FusedTree*, std::int32_t> ids_;
+  // When non-empty, zigzag_value_source_inline uses this expression as the
+  // per-chunk base index rather than chunk_start.  Set by emit_rle_producer
+  // while generating the Zigzag runs-child producer so that compact run-indexed
+  // data (total_runs elements, not chunk_id*kChunkSize strided) is accessed at
+  // the correct offset.
+  std::string zigzag_rle_base_override_;
 
   // DFS-preorder, lex-sorted children (std::map iteration) — must match
   // jit::assign_ids and the decode binder (bind_fused_subtree) so
@@ -663,7 +669,14 @@ void Walker::emit_rle_producer(const ::codegen::jit::FusedTree& node,
             << "));\n";
     } else {
       // Runs child needs materialisation; use SmemCountsReader functor.
+      // When the direct runs child is a leaf Zigzag its stored data is compact
+      // (total_runs elements indexed by global run number, not chunk-strided),
+      // so use rle_runs_offsets[chunk_id] as the base rather than chunk_start.
+      const bool runs_is_leaf_zigzag =
+        rit->second->op == ::codegen::OpKind::Zigzag && rit->second->children.empty();
+      if (runs_is_leaf_zigzag) zigzag_rle_base_override_ = p_off + "[chunk_id]";
       emit_producer(*rit->second, sh_counts, nruns, "int32_t");
+      zigzag_rle_base_override_.clear();
       body_ << "        __syncthreads();\n"
             << "        ::codegen::block_rle_decompress_fv<" << elem_type << ">(\n"
             << "            " << vread << ",\n"
@@ -861,12 +874,14 @@ ValueSource Walker::zigzag_value_source_inline(const ::codegen::jit::FusedTree& 
   add_param("const " + elem_type + "* __restrict__", p_data);
   add_buffer(id, "zigzag", esize);
 
-  // Stored element at this position (read once textually; compiler CSEs the
-  // duplicate load).  base == chunk_start (chunk_id*CHUNK), known at entry.
-  // Cast through the exact-width unsigned so a negative stored byte doesn't
-  // sign-extend garbage into the shift domain.
+  // Stored element at this position.  Normally base == chunk_start
+  // (chunk_id*CHUNK), but when the Zigzag is an RLE's runs child the stored
+  // data is compact (total_runs elements indexed by global run number), so the
+  // base must be the cumulative run offset for this chunk instead.
+  const std::string base_expr =
+    zigzag_rle_base_override_.empty() ? "chunk_start" : zigzag_rle_base_override_;
   const std::string load = "static_cast<" + utype + ">(static_cast<" + exact_unsigned(esize) +
-                           ">(" + p_data + "[chunk_start + (__POS__)]))";
+                           ">(" + p_data + "[" + base_expr + " + (__POS__)]))";
 
   ValueSource vs;
   vs.elem_type = elem_type;

--- a/src/compression/simpatico_codegen/src/encode/jit/renderer.cpp
+++ b/src/compression/simpatico_codegen/src/encode/jit/renderer.cpp
@@ -775,11 +775,14 @@ void Walker::emit_rle(const ::codegen::jit::FusedTree& node, LaneInput in)
   vals_in.elem_type   = in.elem_type;
   vals_in.read_expr   = sh_values + "[__LANE__]";
   vals_in.length_expr = v_nruns;
-  // Use smem accumulation for int32 values Bitpack leaves.
-  // int64 values (bits ≤ 64) would need 8 KB slab — too expensive for occupancy.
-  const bool vals_is_bp_leaf_i32 = vit->second->op == ::codegen::OpKind::Bitpack &&
-                                   vit->second->children.empty() && vals_in.elem_type == "int32_t";
-  if (vals_is_bp_leaf_i32) {
+  // Use smem accumulation for sub-64-bit values Bitpack leaves under RLE.
+  // int64 (8 KB slab) is too expensive for occupancy; int32/int16/int8 are all safe
+  // (slabs are 4 KB, 2 KB, 1 KB respectively).
+  const bool vals_is_bp_leaf_smem =
+    vit->second->op == ::codegen::OpKind::Bitpack && vit->second->children.empty() &&
+    (vals_in.elem_type == "int8_t" || vals_in.elem_type == "int16_t" ||
+     vals_in.elem_type == "int32_t");
+  if (vals_is_bp_leaf_smem) {
     emit_bitpack(*vit->second, std::move(vals_in), /*use_smem=*/true);
   } else {
     emit_node(*vit->second, std::move(vals_in));
@@ -1122,6 +1125,32 @@ void Walker::emit_bitpack(const ::codegen::jit::FusedTree& node, LaneInput in, b
         << "            atomicAdd(" << p_lws
         << " + (static_cast<uint32_t>(chunk_id) & 15u) * 32u, _pw);\n"
         << "        }\n";
+
+  // Fast path: when bits_v equals the full element width (int8→8, int16→16,
+  // int32→32) elements sit flush on 32-bit word boundaries, so we can do a
+  // coalesced direct store instead of the atomicOr scatter.  int64 (2 words per
+  // element) is handled by the regular path below.
+  if (op_dt->elem_size <= 4) {
+    const int elem_bits = static_cast<int>(op_dt->elem_size) * 8;
+    const int epw       = 32 / elem_bits;  // elements per uint32 word
+    body_ << "        if (" << bits_v << " == " << elem_bits << ") {\n"
+          << "            const int32_t _nwl_fp_" << idstr << " = (" << bp_len << " + " << (epw - 1)
+          << ") / " << epw << ";\n"
+          << "            for (int32_t _w = tid; _w < _nwl_fp_" << idstr << "; _w += 128) {\n"
+          << "                uint32_t _word = 0u;\n";
+    for (int s = 0; s < epw; s++) {
+      body_ << "                { const int32_t _idx = _w * " << epw << " + " << s << ";\n"
+            << "                  if (_idx < " << bp_len << ") {\n"
+            << "                      _word |= static_cast<uint32_t>(static_cast<uint64_t>("
+            << at_lane(in.read_expr, "_idx") << ") - static_cast<uint64_t>(" << cmin << "))"
+            << " << " << (s * elem_bits) << ";\n"
+            << "                  } }\n";
+    }
+    body_ << "                " << dst << "[_w] = _word;\n"
+          << "            }\n"
+          << "            break;\n"
+          << "        }\n";
+  }
 
   if (use_smem) {
     // Smem accumulation path: accumulate into per-block __shared__ slab,

--- a/src/compression/simpatico_codegen/src/encode/jit/renderer.cpp
+++ b/src/compression/simpatico_codegen/src/encode/jit/renderer.cpp
@@ -105,6 +105,7 @@ const DtypeInfo* lookup_dtype(const std::string& name)
 {
   static const std::unordered_map<std::string, DtypeInfo> table = {
     {"int8_t", {sizeof(std::int8_t), "INT8_MAX", "INT8_MIN"}},
+    {"int16_t", {sizeof(std::int16_t), "INT16_MAX", "INT16_MIN"}},
     {"int32_t", {sizeof(std::int32_t), "INT32_MAX", "INT32_MIN"}},
     {"int64_t", {sizeof(std::int64_t), "INT64_MAX", "INT64_MIN"}},
   };

--- a/src/compression/simpatico_codegen/src/plan/decompress.cpp
+++ b/src/compression/simpatico_codegen/src/plan/decompress.cpp
@@ -50,6 +50,8 @@ const char* codegen_dtype_str_for(cudf::data_type type)
   switch (type.id()) {
     case cudf::type_id::INT8: return "int8";
     case cudf::type_id::UINT8: return "uint8";
+    case cudf::type_id::INT16: return "int16";
+    case cudf::type_id::UINT16: return "uint16";
     case cudf::type_id::INT32: return "int32";
     case cudf::type_id::INT64: return "int64";
     case cudf::type_id::UINT32: return "uint32";

--- a/src/compression/simpatico_codegen/tests/gpu_encode.hpp
+++ b/src/compression/simpatico_codegen/tests/gpu_encode.hpp
@@ -179,6 +179,15 @@ inline GpuEncoded gpu_encode_tree(const codegen::jit::FusedTree& tree,
   for (auto& p : buf_ptrs)
     args.push_back(&p);
 
+  {
+    CUfunction fn_enc   = kernel->func_for_current_device();
+    int static_smem_enc = 0;
+    cuFuncGetAttribute(&static_smem_enc, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, fn_enc);
+    if (static_smem_enc + static_cast<int>(spec.shared_bytes) > 48 * 1024) {
+      cuFuncSetAttribute(
+        fn_enc, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, spec.shared_bytes);
+    }
+  }
   cu_check(cuLaunchKernel(kernel->func_for_current_device(),
                           static_cast<unsigned>(out.num_chunks),
                           1,

--- a/src/compression/simpatico_codegen/tests/jit_decode.hpp
+++ b/src/compression/simpatico_codegen/tests/jit_decode.hpp
@@ -138,13 +138,4 @@ inline std::vector<Element> jit_decode_tree(const jit::FusedTree& tree,
   return out;
 }
 
-inline bool columns_equal(const std::vector<std::int32_t>& a, const std::vector<std::int32_t>& b)
-{
-  if (a.size() != b.size()) return false;
-  for (std::size_t i = 0; i < a.size(); ++i) {
-    if (a[i] != b[i]) return false;
-  }
-  return true;
-}
-
 }  // namespace codegen_test

--- a/src/compression/simpatico_codegen/tests/test_fused_operator_sweep.cpp
+++ b/src/compression/simpatico_codegen/tests/test_fused_operator_sweep.cpp
@@ -37,12 +37,21 @@
 // shapes, plus boundary cases for leaf/passthrough forms and RLE nesting in
 // the runs branch. Set SIMPATICO_FUSED_SWEEP_DEPTH to override (default 4).
 //
-// Fixture
-// -------
-// int32_t throughout (matches the existing JIT-roundtrip tests).
-// Two synthetic columns: `synth_data` (generic, no-RLE shapes), and
-// `synth_rle_data` (chunk-varied RLE patterns).  Shapes containing
-// any Rle node use the RLE-friendly fixture.
+// Dtypes
+// ------
+// All four integer widths supported by the fused JIT path: int8_t, int16_t,
+// int32_t, int64_t.  Each dtype runs an independent set of synthetic fixtures
+// with values scaled to stay within the type's representable range.
+//
+// Parallelization
+// ---------------
+// NVRTC JIT-compiles one kernel per (shape, dtype) pair and that compilation
+// serialises on an internal per-process lock — multiple host threads add lock
+// contention without speedup.  The test uses the same posix_spawn multi-process
+// approach as test_operator_sweep: the orchestrator (no SIMPATICO_FUSED_SWEEP_SHARD
+// env var) spawns N workers, each processing 1/N of the (dtype, shape) work list
+// in round-robin.  N defaults to hardware_concurrency; override with
+// SIMPATICO_FUSED_SWEEP_WORKERS.
 
 #include "codegen/jit/fused_tree.hpp"
 #include "codegen/jit/kernel_cache.hpp"
@@ -51,14 +60,23 @@
 
 #include <cuda.h>
 
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <array>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
 #include <memory>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <vector>
+
+extern char** environ;
 
 namespace cc  = codegen;
 namespace jit = codegen::jit;
@@ -86,38 +104,47 @@ std::string cu_err_str(CUresult r)
   } while (0)
 
 // ---------------------------------------------------------------------
-// Synthetic data — identical to test_jit_roundtrip / test_encode_*
-// fixtures so a mismatch here is directly comparable.
+// Synthetic data — values scaled to fit within T's representable range
+// so the same template works for all supported widths.
 // ---------------------------------------------------------------------
-std::vector<int32_t> synth_data(int64_t n)
+template <typename T>
+std::vector<T> synth_data(int64_t n)
 {
-  std::vector<int32_t> data(static_cast<size_t>(n));
+  // kRange: the pattern amplitude, chosen so all generated values fit in T.
+  // int8_t: [-128,127], int16_t: [-32768,32767], wider types: no constraint.
+  constexpr int32_t kRange = sizeof(T) == 1 ? 50 : sizeof(T) == 2 ? 500 : 50000;
+  std::vector<T> data(static_cast<size_t>(n));
   for (int64_t i = 0; i < n; ++i) {
-    int32_t cid = static_cast<int32_t>(i / cc::kChunkSize);
-    int32_t pos = static_cast<int32_t>(i % cc::kChunkSize);
+    const int32_t cid = static_cast<int32_t>(i / cc::kChunkSize);
+    const int32_t pos = static_cast<int32_t>(i % cc::kChunkSize);
+    int32_t v;
     switch (cid % 4) {
-      case 0: data[i] = (pos & 1) ? 100 : 101; break;
-      case 1: data[i] = static_cast<int32_t>(200 + (pos % 200)); break;
-      case 2: data[i] = static_cast<int32_t>(-12345 + pos * 13); break;
-      case 3: data[i] = static_cast<int32_t>(pos * 7 - 50000); break;
+      case 0: v = kRange / 50 + (pos & 1); break;              // near-constant (bits≈1)
+      case 1: v = kRange / 5 + pos % (kRange / 5 + 1); break;  // small positive range
+      case 2: v = -(kRange / 10) + pos % (kRange / 2); break;  // crosses zero
+      case 3: v = (pos * 7) % kRange; break;                   // varied residuals
     }
+    data[i] = static_cast<T>(v);
   }
   return data;
 }
 
-// RLE-friendly fixture: spread of nruns_per_chunk to exercise the
-// trivial (1 run), small (4 runs), and worst (1024 runs) cases.
-std::vector<int32_t> synth_rle_data(int64_t n)
+// RLE-friendly fixture: varied run lengths to exercise trivial (1 run),
+// small (~4 runs), and worst (1024 runs) cases.
+template <typename T>
+std::vector<T> synth_rle_data(int64_t n)
 {
-  std::vector<int32_t> data(static_cast<size_t>(n));
+  constexpr int32_t kMax = sizeof(T) == 1 ? 100 : sizeof(T) == 2 ? 1000 : 100000;
+  std::vector<T> data(static_cast<size_t>(n));
   for (int64_t i = 0; i < n; ++i) {
-    int32_t cid = static_cast<int32_t>(i / cc::kChunkSize);
-    int32_t pos = static_cast<int32_t>(i % cc::kChunkSize);
+    const int32_t cid = static_cast<int32_t>(i / cc::kChunkSize);
+    const int32_t pos = static_cast<int32_t>(i % cc::kChunkSize);
+    int32_t v;
     switch (cid) {
-      case 0: data[i] = 42; break;
-      case 1: data[i] = pos / 256; break;
-      case 2: data[i] = static_cast<int32_t>(1000 + pos); break;
-      case 3: data[i] = (pos & 1) ? 50 : 51; break;
+      case 0: v = 42 % kMax; break;
+      case 1: v = (pos / 256) % kMax; break;
+      case 2: v = (kMax / 50 + pos) % kMax; break;
+      case 3: v = (pos & 1) ? 50 % kMax : 51 % kMax; break;
       default: {
         int32_t run_id = 0, cum = 0;
         const int32_t lens[5] = {17, 33, 80, 51, 44};
@@ -125,10 +152,11 @@ std::vector<int32_t> synth_rle_data(int64_t n)
           cum += lens[run_id % 5];
           ++run_id;
         }
-        data[i] = 7 + run_id * 3;
+        v = (7 + run_id * 3) % kMax;
         break;
       }
     }
+    data[i] = static_cast<T>(v);
   }
   return data;
 }
@@ -186,38 +214,18 @@ std::string tag(const jit::FusedTree& t)
   return os.str();
 }
 
-// Build a tree of exact `depth` from a list of depth-(d-1) children.
-// Each child becomes 5 new trees: Delta(c), For(c), Zigzag(c),
-// Rle(Bp, c), and Rle(Raw, c).
-// Raw terminal/passthrough forms are boundary cases below rather than recursive
-// inputs, so this grammar remains bounded and every recursive child is decoded.
 std::vector<Tree> compose_layer(const std::vector<Tree>& prev)
 {
   std::vector<Tree> out;
   out.reserve(prev.size() * 5);
   for (const auto& c : prev) {
-    out.push_back(jit::FusedTree::make(OpKind::Delta,
-                                       {
-                                         {"differences", c},
-                                       }));
-    out.push_back(jit::FusedTree::make(OpKind::For,
-                                       {
-                                         {"deltas", c},
-                                       }));
-    out.push_back(jit::FusedTree::make(OpKind::Zigzag,
-                                       {
-                                         {"zigzag", c},
-                                       }));
-    out.push_back(jit::FusedTree::make(OpKind::Rle,
-                                       {
-                                         {"runs", jit::FusedTree::make(OpKind::Bitpack)},
-                                         {"values", c},
-                                       }));
-    out.push_back(jit::FusedTree::make(OpKind::Rle,
-                                       {
-                                         {"runs", jit::FusedTree::make(OpKind::Raw)},
-                                         {"values", c},
-                                       }));
+    out.push_back(jit::FusedTree::make(OpKind::Delta, {{"differences", c}}));
+    out.push_back(jit::FusedTree::make(OpKind::For, {{"deltas", c}}));
+    out.push_back(jit::FusedTree::make(OpKind::Zigzag, {{"zigzag", c}}));
+    out.push_back(jit::FusedTree::make(
+      OpKind::Rle, {{"runs", jit::FusedTree::make(OpKind::Bitpack)}, {"values", c}}));
+    out.push_back(jit::FusedTree::make(
+      OpKind::Rle, {{"runs", jit::FusedTree::make(OpKind::Raw)}, {"values", c}}));
   }
   return out;
 }
@@ -226,83 +234,96 @@ std::vector<Tree> enumerate_shapes(int max_depth)
 {
   std::vector<std::vector<Tree>> by_depth(max_depth + 1);
   by_depth[1].push_back(jit::FusedTree::make(OpKind::Bitpack));
-  for (int d = 2; d <= max_depth; ++d) {
+  for (int d = 2; d <= max_depth; ++d)
     by_depth[d] = compose_layer(by_depth[d - 1]);
-  }
   std::vector<Tree> flat;
-  for (int d = 1; d <= max_depth; ++d) {
+  for (int d = 1; d <= max_depth; ++d)
     for (auto& t : by_depth[d])
       flat.push_back(t);
-  }
   return flat;
 }
 
-// Shapes the recursive grammar does not generate:
-//   * Zigzag may terminate as a leaf store.
-//   * Delta and For may terminate through a Raw passthrough child.
-//   * Rle may have Raw values, and may nest another Rle in its runs branch.
 std::vector<Tree> extra_shapes()
 {
   return {
     jit::FusedTree::make(OpKind::Zigzag),
-    jit::FusedTree::make(OpKind::Delta,
-                         {
-                           {"differences", jit::FusedTree::make(OpKind::Raw)},
-                         }),
-    jit::FusedTree::make(OpKind::For,
-                         {
-                           {"deltas", jit::FusedTree::make(OpKind::Raw)},
-                         }),
-    jit::FusedTree::make(OpKind::Rle,
-                         {
-                           {"runs", jit::FusedTree::make(OpKind::Raw)},
-                           {"values", jit::FusedTree::make(OpKind::Raw)},
-                         }),
+    jit::FusedTree::make(OpKind::Delta, {{"differences", jit::FusedTree::make(OpKind::Raw)}}),
+    jit::FusedTree::make(OpKind::For, {{"deltas", jit::FusedTree::make(OpKind::Raw)}}),
     jit::FusedTree::make(
       OpKind::Rle,
-      {
-        {"runs",
-         jit::FusedTree::make(OpKind::Rle,
-                              {
-                                {"runs", jit::FusedTree::make(OpKind::Raw)},
-                                {"values", jit::FusedTree::make(OpKind::Bitpack)},
-                              })},
-        {"values", jit::FusedTree::make(OpKind::Bitpack)},
-      }),
+      {{"runs", jit::FusedTree::make(OpKind::Raw)}, {"values", jit::FusedTree::make(OpKind::Raw)}}),
+    jit::FusedTree::make(
+      OpKind::Rle,
+      {{"runs",
+        jit::FusedTree::make(OpKind::Rle,
+                             {{"runs", jit::FusedTree::make(OpKind::Raw)},
+                              {"values", jit::FusedTree::make(OpKind::Bitpack)}})},
+       {"values", jit::FusedTree::make(OpKind::Bitpack)}}),
   };
 }
 
 // ---------------------------------------------------------------------
-// Per-shape runner — mirrors test_jit_roundtrip::run_shape with the
-// addition that errors are reported but don't abort the sweep.
+// Per-shape runner — templated over element type.
 // ---------------------------------------------------------------------
+template <typename T>
 int run_one_shape(const jit::FusedTree& tree,
-                  const std::string& tag,
-                  const std::vector<int32_t>& data,
-                  int arch_cc)
+                  const std::string& shape_tag,
+                  const std::vector<T>& data,
+                  int arch_cc,
+                  const char* dtype_str)
 {
   const int64_t n = static_cast<int64_t>(data.size());
   try {
     codegen_test::GpuEncoded encoded =
-      codegen_test::gpu_encode_tree<int32_t>(tree, "int32_t", data.data(), n, arch_cc);
+      codegen_test::gpu_encode_tree<T>(tree, dtype_str, data.data(), n, arch_cc);
     auto recovered =
-      codegen_test::jit_decode_tree<int32_t>(tree, "int32_t", n, encoded.buffers, encoded, arch_cc);
-    if (!codegen_test::columns_equal(recovered, data)) {
-      std::fprintf(stderr, "FAIL [%s] decode mismatch\n", tag.c_str());
+      codegen_test::jit_decode_tree<T>(tree, dtype_str, n, encoded.buffers, encoded, arch_cc);
+    if (recovered != data) {
+      std::fprintf(stderr, "FAIL [%s] decode mismatch\n", shape_tag.c_str());
       return 1;
     }
     return 0;
   } catch (const std::exception& e) {
-    std::fprintf(stderr, "FAIL [%s] %s\n", tag.c_str(), e.what());
+    std::fprintf(stderr, "FAIL [%s] %s\n", shape_tag.c_str(), e.what());
     return 1;
   }
 }
 
+// ---------------------------------------------------------------------
+// Dtype registry — all element types the fused JIT path supports.
+// cxx must match the renderer's lookup_dtype table (int8_t/int16_t/…).
+// ---------------------------------------------------------------------
+struct DtypeSpec {
+  const char* name;
+  const char* cxx;
+};
+constexpr std::array<DtypeSpec, 4> kDtypes = {
+  {{"i8", "int8_t"}, {"i16", "int16_t"}, {"i32", "int32_t"}, {"i64", "int64_t"}}};
+
+// Type-erased per-dtype runner (built at shard startup with pre-generated data).
+// Captures the typed data vectors by shared_ptr so the std::function is copyable.
+using ShapeRunner =
+  std::function<int(const jit::FusedTree&, const std::string& shape_tag, bool use_rle)>;
+
+template <typename T>
+ShapeRunner make_dtype_runner(int64_t n, int arch, const char* cxx)
+{
+  auto gdata = std::make_shared<std::vector<T>>(synth_data<T>(n));
+  auto rdata = std::make_shared<std::vector<T>>(synth_rle_data<T>(n));
+  return [gdata, rdata, arch, cxx](
+           const jit::FusedTree& t, const std::string& s_tag, bool use_rle) -> int {
+    return run_one_shape<T>(t, s_tag, use_rle ? *rdata : *gdata, arch, cxx);
+  };
+}
+
+// ---------------------------------------------------------------------
+// Env helpers.
+// ---------------------------------------------------------------------
 int env_depth(int default_depth)
 {
   if (const char* s = std::getenv("SIMPATICO_FUSED_SWEEP_DEPTH"); s != nullptr) {
     int v = std::atoi(s);
-    if (v >= 1 && v <= 6) return v;  // cap at 6 — anything more is hours
+    if (v >= 1 && v <= 6) return v;
     std::fprintf(stderr,
                  "warn: SIMPATICO_FUSED_SWEEP_DEPTH='%s' out of [1,6]; using default %d\n",
                  s,
@@ -311,51 +332,222 @@ int env_depth(int default_depth)
   return default_depth;
 }
 
-}  // namespace
+unsigned env_workers(unsigned default_workers)
+{
+  if (const char* s = std::getenv("SIMPATICO_FUSED_SWEEP_WORKERS"); s != nullptr) {
+    int v = std::atoi(s);
+    if (v >= 1) return static_cast<unsigned>(v);
+    std::fprintf(stderr,
+                 "warn: SIMPATICO_FUSED_SWEEP_WORKERS='%s' must be >= 1; using default %u\n",
+                 s,
+                 default_workers);
+  }
+  return default_workers;
+}
 
-int main()
+unsigned n_shards_for(std::size_t work_size)
+{
+  return std::min<unsigned>(env_workers(std::max(1u, std::thread::hardware_concurrency())),
+                            static_cast<unsigned>(work_size));
+}
+
+// fd the child writes its result line to.
+constexpr int kResultFd = 3;
+
+// ---------------------------------------------------------------------
+// Shard: process shard_idx % n_shards of all (dtype, shape) work items.
+// Reports "<passed_i> <total_i> " for each dtype over kResultFd.
+// ---------------------------------------------------------------------
+int run_shard(unsigned shard_idx, unsigned n_shards)
 {
   if (cudaSetDevice(0) != cudaSuccess) {
-    std::fprintf(stderr, "FAIL: cudaSetDevice(0) failed\n");
+    std::fprintf(stderr, "test_fused_operator_sweep: cudaSetDevice failed\n");
     return 1;
   }
-  // Single process, so clear at startup before any compile (see the sweep's
-  // orchestrator for the same option).
   if (std::getenv("SIMPATICO_JIT_CACHE_CLEAR")) codegen::jit::clear_jit_disk_cache();
+
   const int arch      = jit::arch_cc_for_current_device();
   const int max_depth = env_depth(/*default=*/4);
   const int64_t n     = 4321;
-  auto data_generic   = synth_data(n);
-  auto data_rle       = synth_rle_data(n);
 
   auto shapes = enumerate_shapes(max_depth);
   for (auto& t : extra_shapes())
     shapes.push_back(t);
-  std::printf("test_fused_operator_sweep: max_depth=%d shapes=%zu n=%lld\n",
-              max_depth,
-              shapes.size(),
-              static_cast<long long>(n));
+  const std::size_t n_shapes = shapes.size();
+  const std::size_t total    = kDtypes.size() * n_shapes;
 
-  int passed = 0;
-  std::vector<std::string> failures;
-  for (const auto& t : shapes) {
-    const std::string s_tag = tag(*t);
-    const auto& fixture     = contains_rle(*t) ? data_rle : data_generic;
-    if (run_one_shape(*t, s_tag, fixture, arch) == 0) {
-      std::printf("  %-50s OK\n", s_tag.c_str());
-      ++passed;
-    } else {
-      failures.push_back(s_tag);
+  // Build one type-erased runner per dtype (pre-generates data once per shard).
+  std::array<ShapeRunner, 4> runners = {
+    make_dtype_runner<int8_t>(n, arch, kDtypes[0].cxx),
+    make_dtype_runner<int16_t>(n, arch, kDtypes[1].cxx),
+    make_dtype_runner<int32_t>(n, arch, kDtypes[2].cxx),
+    make_dtype_runner<int64_t>(n, arch, kDtypes[3].cxx),
+  };
+
+  std::array<int, 4> passed_per_dtype = {};
+  std::array<int, 4> total_per_dtype  = {};
+
+  for (std::size_t flat = shard_idx; flat < total; flat += n_shards) {
+    const std::size_t di    = flat / n_shapes;
+    const std::size_t si    = flat % n_shapes;
+    const auto& t           = shapes[si];
+    const bool use_rle      = contains_rle(*t);
+    const std::string s_tag = std::string(kDtypes[di].name) + "/" + tag(*t);
+
+    ++total_per_dtype[di];
+    if (runners[di](*t, s_tag, use_rle) == 0) {
+      std::printf("  %-60s OK\n", s_tag.c_str());
+      ++passed_per_dtype[di];
     }
   }
 
-  std::printf("test_fused_operator_sweep: %d/%zu passed\n", passed, shapes.size());
-  if (!failures.empty()) {
-    std::fprintf(stderr, "test_fused_operator_sweep: %zu failures:\n", failures.size());
-    for (const auto& f : failures) {
-      std::fprintf(stderr, "  - %s\n", f.c_str());
+  // Report results over the pipe.
+  std::string report;
+  for (std::size_t di = 0; di < kDtypes.size(); ++di)
+    report +=
+      std::to_string(passed_per_dtype[di]) + " " + std::to_string(total_per_dtype[di]) + " ";
+  report += "\n";
+  std::size_t written = 0;
+  while (written < report.size()) {
+    ssize_t rc = ::write(kResultFd, report.data() + written, report.size() - written);
+    if (rc < 0) {
+      std::fprintf(
+        stderr, "test_fused_operator_sweep: write(kResultFd) failed: %s\n", std::strerror(errno));
+      return 1;
     }
+    written += static_cast<std::size_t>(rc);
+  }
+
+  for (std::size_t di = 0; di < kDtypes.size(); ++di)
+    if (passed_per_dtype[di] != total_per_dtype[di]) return 1;
+  return 0;
+}
+
+// ---------------------------------------------------------------------
+// Orchestrator: never touches CUDA.  Spawns n_shards copies of this
+// binary with SIMPATICO_FUSED_SWEEP_SHARD=i/n set, collects results.
+// ---------------------------------------------------------------------
+int run_orchestrator()
+{
+  auto shapes = enumerate_shapes(env_depth(/*default=*/4));
+  for (auto& t : extra_shapes())
+    shapes.push_back(t);
+  const std::size_t total = kDtypes.size() * shapes.size();
+  const unsigned n_shards = n_shards_for(total);
+
+  if (std::getenv("SIMPATICO_JIT_CACHE_CLEAR")) codegen::jit::clear_jit_disk_cache();
+
+  std::printf("test_fused_operator_sweep: max_depth=%d dtypes=%zu shapes=%zu total=%zu shards=%u\n",
+              env_depth(/*default=*/4),
+              kDtypes.size(),
+              shapes.size(),
+              total,
+              n_shards);
+
+  std::vector<pid_t> pids(n_shards);
+  std::vector<int> read_fds(n_shards);
+
+  for (unsigned i = 0; i < n_shards; ++i) {
+    int fds[2];
+    if (pipe(fds) != 0) {
+      std::fprintf(stderr, "test_fused_operator_sweep: pipe() failed\n");
+      return 1;
+    }
+
+    posix_spawn_file_actions_t fa;
+    posix_spawn_file_actions_init(&fa);
+    posix_spawn_file_actions_addclose(&fa, fds[0]);
+    posix_spawn_file_actions_adddup2(&fa, fds[1], kResultFd);
+    if (fds[1] != kResultFd) posix_spawn_file_actions_addclose(&fa, fds[1]);
+
+    const std::string env_entry =
+      "SIMPATICO_FUSED_SWEEP_SHARD=" + std::to_string(i) + "/" + std::to_string(n_shards);
+    std::vector<std::string> env_storage;
+    for (char** e = environ; *e != nullptr; ++e) {
+      if (std::strncmp(*e, "SIMPATICO_FUSED_SWEEP_SHARD=", 28) != 0) env_storage.emplace_back(*e);
+    }
+    env_storage.push_back(env_entry);
+    std::vector<char*> envp;
+    envp.reserve(env_storage.size() + 1);
+    for (auto& s : env_storage)
+      envp.push_back(s.data());
+    envp.push_back(nullptr);
+
+    char exe[]         = "/proc/self/exe";
+    char* argv_child[] = {exe, nullptr};
+
+    pid_t pid = -1;
+    int rc    = posix_spawn(&pid, exe, &fa, nullptr, argv_child, envp.data());
+    posix_spawn_file_actions_destroy(&fa);
+    close(fds[1]);
+
+    if (rc != 0) {
+      std::fprintf(
+        stderr, "test_fused_operator_sweep: posix_spawn failed: %s\n", std::strerror(rc));
+      close(fds[0]);
+      return 1;
+    }
+    pids[i]     = pid;
+    read_fds[i] = fds[0];
+  }
+
+  // Collect per-dtype passed/total from each shard.
+  std::array<long long, 4> total_passed = {};
+  std::array<long long, 4> total_total  = {};
+  bool any_failed                       = false;
+
+  for (unsigned i = 0; i < n_shards; ++i) {
+    std::string buf;
+    char chunk[4096];
+    ssize_t n_read;
+    while ((n_read = ::read(read_fds[i], chunk, sizeof(chunk))) > 0)
+      buf.append(chunk, static_cast<std::size_t>(n_read));
+    close(read_fds[i]);
+
+    std::istringstream iss(buf);
+    for (std::size_t di = 0; di < kDtypes.size(); ++di) {
+      long long p = 0, t = 0;
+      iss >> p >> t;
+      total_passed[di] += p;
+      total_total[di] += t;
+    }
+
+    int status = 0;
+    waitpid(pids[i], &status, 0);
+    if (!(WIFEXITED(status) && WEXITSTATUS(status) == 0)) {
+      any_failed = true;
+      std::fprintf(
+        stderr, "test_fused_operator_sweep: shard %u/%u failed (see stderr above)\n", i, n_shards);
+    }
+  }
+
+  long long grand_passed = 0, grand_total = 0;
+  for (std::size_t di = 0; di < kDtypes.size(); ++di) {
+    std::printf("  [%-4s] %lld/%lld passed\n", kDtypes[di].name, total_passed[di], total_total[di]);
+    grand_passed += total_passed[di];
+    grand_total += total_total[di];
+  }
+  std::printf("test_fused_operator_sweep: %lld/%lld passed\n", grand_passed, grand_total);
+  return any_failed ? 1 : 0;
+}
+
+}  // namespace
+
+int main()
+{
+  try {
+    if (const char* shard_env = std::getenv("SIMPATICO_FUSED_SWEEP_SHARD")) {
+      unsigned idx = 0, n = 1;
+      if (std::sscanf(shard_env, "%u/%u", &idx, &n) != 2 || n == 0 || idx >= n) {
+        std::fprintf(
+          stderr, "test_fused_operator_sweep: bad SIMPATICO_FUSED_SWEEP_SHARD='%s'\n", shard_env);
+        return 1;
+      }
+      return run_shard(idx, n);
+    }
+    return run_orchestrator();
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "test_fused_operator_sweep: FATAL: %s\n", e.what());
     return 1;
   }
-  return 0;
 }

--- a/src/compression/simpatico_codegen/tests/test_operator_sweep.cpp
+++ b/src/compression/simpatico_codegen/tests/test_operator_sweep.cpp
@@ -478,8 +478,14 @@ int run_shard(unsigned shard_idx, unsigned n_shards)
       }
     };
     must_apply("string", {"dictionary", "str_split"});
-    must_apply("i16", {"delta", "rle", "for", "zigzag", "bitpack"});
-    must_apply("u16", {"delta", "rle", "for", "zigzag", "bitpack"});
+    must_apply("i16", {"delta", "rle", "for", "zigzag", "bitpack", "ans", "bitcomp"});
+    must_apply("u16", {"delta", "rle", "for", "zigzag", "bitpack", "ans", "bitcomp"});
+    must_apply("i32", {"delta", "rle", "for", "zigzag", "bitpack", "ans", "bitcomp"});
+    must_apply("u32", {"delta", "rle", "for", "zigzag", "bitpack", "ans", "bitcomp"});
+    must_apply("i64", {"delta", "rle", "for", "zigzag", "bitpack", "ans", "bitcomp"});
+    must_apply("u64", {"delta", "rle", "for", "zigzag", "bitpack", "ans", "bitcomp"});
+    must_apply("f32", {"alp", "alp_rd", "for", "bitpack"});
+    must_apply("f64", {"alp", "alp_rd", "for", "bitpack"});
     must_apply("u8_binary", {"delta", "rle", "for", "zigzag", "bitpack"});
     must_apply("date", {"delta", "rle", "for", "zigzag", "bitpack", "ans", "bitcomp"});
   }

--- a/src/compression/simpatico_codegen/tests/test_operator_sweep.cpp
+++ b/src/compression/simpatico_codegen/tests/test_operator_sweep.cpp
@@ -143,13 +143,47 @@ std::unique_ptr<cudf::table> make_u8_table(int num_rows, int seed)
   return std::make_unique<cudf::table>(std::move(cols));
 }
 
+std::unique_ptr<cudf::table> make_int16_table(int num_rows, int seed)
+{
+  std::vector<std::int16_t> host(static_cast<std::size_t>(num_rows));
+  for (int r = 0; r < num_rows; ++r)
+    host[static_cast<std::size_t>(r)] = static_cast<std::int16_t>((r * 1009 + seed * 37) & 0x7FFF);
+  auto col = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT16}, num_rows, cudf::mask_state::UNALLOCATED);
+  if (cudaMemcpy(col->mutable_view().head<std::int16_t>(),
+                 host.data(),
+                 host.size() * sizeof(std::int16_t),
+                 cudaMemcpyHostToDevice) != cudaSuccess)
+    throw std::runtime_error("make_int16_table: cudaMemcpy failed");
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col));
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
+std::unique_ptr<cudf::table> make_uint16_table(int num_rows, int seed)
+{
+  std::vector<std::uint16_t> host(static_cast<std::size_t>(num_rows));
+  for (int r = 0; r < num_rows; ++r)
+    host[static_cast<std::size_t>(r)] = static_cast<std::uint16_t>((r * 1009 + seed * 37) & 0xFFFF);
+  auto col = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::UINT16}, num_rows, cudf::mask_state::UNALLOCATED);
+  if (cudaMemcpy(col->mutable_view().head<std::uint16_t>(),
+                 host.data(),
+                 host.size() * sizeof(std::uint16_t),
+                 cudaMemcpyHostToDevice) != cudaSuccess)
+    throw std::runtime_error("make_uint16_table: cudaMemcpy failed");
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col));
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
 // Canonical fixture order, shared by the orchestrator (sizing/labeling only,
 // no CUDA touched) and each shard (which actually builds them). MUST stay in
 // lockstep with build_fixtures() below — the orchestrator sizes/labels work by
 // index into this list, so a shorter list silently drops the trailing fixtures
 // from the sweep.
-constexpr std::array<char const*, 9> kFixtureNames = {
-  "i32", "i64", "u32", "u64", "f32", "f64", "u8_binary", "date", "string"};
+constexpr std::array<char const*, 11> kFixtureNames = {
+  "i16", "u16", "i32", "i64", "u32", "u64", "f32", "f64", "u8_binary", "date", "string"};
 
 struct fixture {
   std::string name;
@@ -168,6 +202,8 @@ std::vector<fixture> build_fixtures(rmm::cuda_stream_view stream, int n)
     f.table = std::move(t);
     fixtures.push_back(std::move(f));
   };
+  add_numeric("i16", make_int16_table(n, 9));
+  add_numeric("u16", make_uint16_table(n, 10));
   add_numeric("i32", make_int32_table(1, n, 1));
   add_numeric("i64", make_int64_table(1, n, 2));
   add_numeric("u32", make_uint32_table(1, n, 7));
@@ -442,6 +478,8 @@ int run_shard(unsigned shard_idx, unsigned n_shards)
       }
     };
     must_apply("string", {"dictionary", "str_split"});
+    must_apply("i16", {"delta", "rle", "for", "zigzag", "bitpack"});
+    must_apply("u16", {"delta", "rle", "for", "zigzag", "bitpack"});
     must_apply("u8_binary", {"delta", "rle", "for", "zigzag", "bitpack"});
     must_apply("date", {"delta", "rle", "for", "zigzag", "bitpack", "ans", "bitcomp"});
   }

--- a/src/compression/simpatico_codegen/tests/test_operator_sweep.cpp
+++ b/src/compression/simpatico_codegen/tests/test_operator_sweep.cpp
@@ -183,7 +183,7 @@ std::unique_ptr<cudf::table> make_uint16_table(int num_rows, int seed)
 // index into this list, so a shorter list silently drops the trailing fixtures
 // from the sweep.
 constexpr std::array<char const*, 11> kFixtureNames = {
-  "i16", "u16", "i32", "i64", "u32", "u64", "f32", "f64", "u8_binary", "date", "string"};
+  "i16", "i32", "i64", "u16", "u32", "u64", "f32", "f64", "u8_binary", "date", "string"};
 
 struct fixture {
   std::string name;
@@ -203,9 +203,9 @@ std::vector<fixture> build_fixtures(rmm::cuda_stream_view stream, int n)
     fixtures.push_back(std::move(f));
   };
   add_numeric("i16", make_int16_table(n, 9));
-  add_numeric("u16", make_uint16_table(n, 10));
   add_numeric("i32", make_int32_table(1, n, 1));
   add_numeric("i64", make_int64_table(1, n, 2));
+  add_numeric("u16", make_uint16_table(n, 10));
   add_numeric("u32", make_uint32_table(1, n, 7));
   add_numeric("u64", make_uint64_table(1, n, 8));
   add_numeric("f32", make_f32_table(1, n, 3));


### PR DESCRIPTION
Simpatico's fused codegen backend does not have support for 16-bit datatypes, this PR adds it (and tests).

Closes #1326 