### PR TITLE
[Concurrency] Per query data repository manager registry, plus query_id and operator_id fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,6 +598,7 @@ set(TEST_SOURCES
     test/cpp/config/test_context.cpp
     test/cpp/config/test_object_store_config.cpp
     test/cpp/data/test_convertible_data_batch.cpp
+    test/cpp/data/test_data_repository_manager_registry.cpp
     test/cpp/data/test_convertible_gpu_pipeline_task.cpp
     test/cpp/downgrade/test_downgrade_disk.cpp
     test/cpp/downgrade/test_downgrade_executor.cpp
@@ -704,6 +705,7 @@ set(TEST_SOURCES
     test/cpp/planner/test_plan_tree_shape.cpp
     test/cpp/planner/test_projection_fold.cpp
     test/cpp/planner/test_sirius_read_parquet_scan.cpp
+    test/cpp/planner/test_query_id.cpp
     test/cpp/planner/test_query_index.cpp
     test/cpp/pipeline/test_batch_lock_utils.cpp
     test/cpp/pipeline/test_gpu_pipeline_executor.cpp

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -193,9 +193,9 @@ task_creator::compute_pipeline_priorities(const sirius::planner::query& query) c
   // Inject the query id into the high 32 bits so tasks are ordered by query first, then by the
   // within-query pipeline rank in the low 32 bits. The priority queue picks the LOWEST value first,
   // so an earlier query (smaller id) always runs before a later one, and within a query the dense
-  // 0..N-1 rank preserves pipeline execution order.
-  const exec::queue_priority query_bits = static_cast<exec::queue_priority>(query.get_query_id())
-                                          << 32;
+  // 0..N-1 rank preserves pipeline execution order. See query_priority_bits() for the masking
+  // contract that keeps the packed value non-negative.
+  const exec::queue_priority query_bits = sirius::query_priority_bits(query.query_id());
   for (auto& [pipeline, priority] : priorities) {
     const auto rank = std::lower_bound(sorted.begin(), sorted.end(), priority) - sorted.begin();
     priority        = query_bits | static_cast<exec::queue_priority>(rank);

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -41,13 +41,13 @@ static std::string tier_to_string(cucascade::memory::Tier tier)
 
 downgrade_executor::downgrade_executor(
   exec::downgrade_executor_config config,
-  cucascade::shared_data_repository_manager& data_repo_mgr,
+  sirius::data::data_repository_manager_registry& data_repo_registry,
   cucascade::memory::memory_space_id space_id,
   cucascade::memory::memory_space* memory_space,
   sirius::memory::sirius_memory_reservation_manager& reservation_manager,
   sirius::exec::multi_index_priority_queue<sirius::parallel::itask>* pipeline_task_queue)
   : _config(std::move(config)),
-    _data_repo_mgr(data_repo_mgr),
+    _data_repo_registry(data_repo_registry),
     _space_id(space_id),
     _memory_space(memory_space),
     _source_label(tier_to_string(space_id.tier) + ":" + std::to_string(space_id.device_id)),
@@ -200,74 +200,83 @@ void downgrade_executor::processing_loop()
     }
 
     // === TIER 1: Data repositories ===
-    // Visited in get_repositories() order — ascending {operator_id, port_id} — with early
-    // stop once the reservation is satisfied, so operator-ID numbering (a global
-    // construction counter assigned during plan generation) decides which batches spill
-    // first. get_all_convertible() snapshots eligible batches once per repo so a batch
-    // isn't re-scanned before leaving idle.
+    // Memory pressure is a global condition, so candidates are drawn from EVERY in-flight
+    // query: outer loop ascending by query id, inner loop in get_repositories() order —
+    // ascending {operator_id, port_id} — with early stop once the reservation is satisfied.
+    // Operator ids restart at 0 per query, so ordering is (query id, operator id) rather than
+    // a single global counter. This inherits "lowest query id spills first", which is
+    // arbitrary across concurrent queries; a deliberate fairness policy is still owed here.
+    // get_all_convertible() snapshots eligible batches once per repo so a batch isn't
+    // re-scanned before leaving idle. Managers are held by shared_ptr for the duration of the
+    // sweep, so a query ending concurrently cannot pull one out from under this loop.
     bool pool_interrupted = false;
-    auto repos            = _data_repo_mgr.get_repositories();
-    for (auto* repo : repos) {
-      if (req->satisfied.load()) break;
-
-      convertible_data_batch_provider provider(repo);
-      auto candidates = provider.get_all_convertible(
-        source_space, /*front_to_back=*/false, /*ignore_subscribed=*/true);
-      for (auto& candidate : candidates) {
+    for (auto const& manager : _data_repo_registry.get_all()) {
+      if (req->satisfied.load() || pool_interrupted) break;
+      auto repos = manager->get_repositories();
+      for (auto* repo : repos) {
         if (req->satisfied.load()) break;
 
-        auto candidate_bytes = candidate->bytes_in_space(source_space);
+        convertible_data_batch_provider provider(repo);
+        auto candidates = provider.get_all_convertible(
+          source_space, /*front_to_back=*/false, /*ignore_subscribed=*/true);
+        for (auto& candidate : candidates) {
+          if (req->satisfied.load()) break;
 
-        auto slot = _pool->reserve();
-        if (!slot) {
-          pool_interrupted = true;
-          break;
-        }
+          auto candidate_bytes = candidate->bytes_in_space(source_space);
 
-        // Re-check after reserve() returns -- the previous candidate's worker may
-        // have set satisfied while we were blocked waiting for a thread slot.
-        if (req->satisfied.load()) break;
+          auto slot = _pool->reserve();
+          if (!slot) {
+            pool_interrupted = true;
+            break;
+          }
 
-        auto exc_stream = _stream_pool->acquire_stream(
-          cucascade::memory::exclusive_stream_pool::stream_acquire_policy::GROW);
+          // Re-check after reserve() returns -- the previous candidate's worker may
+          // have set satisfied while we were blocked waiting for a thread slot.
+          if (req->satisfied.load()) break;
 
-        _pool->dispatch(
-          std::move(slot),
-          [cand       = std::move(candidate),
-           req_ptr    = req.get(),
-           &res_mgr   = _reservation_manager,
-           &targets   = target_spaces,
-           exc_stream = std::move(exc_stream),
-           candidate_bytes,
-           host_end_idx,
-           &repo_stats,
-           &host_target_stats,
-           &disk_target_stats]() mutable {
-            try {
-              auto result = cand->convert(targets, exc_stream, res_mgr, false);
-              if (result) {
-                req_ptr->bytes_freed.fetch_add(candidate_bytes, std::memory_order_relaxed);
-                req_ptr->batches_downgraded.fetch_add(1, std::memory_order_relaxed);
-                repo_stats.batches.fetch_add(1, std::memory_order_relaxed);
-                repo_stats.bytes.fetch_add(candidate_bytes, std::memory_order_relaxed);
-                for (size_t i = 0; i < result->size(); ++i) {
-                  if ((*result)[i] == 0) continue;
-                  if (i < host_end_idx) {
-                    host_target_stats.batches.fetch_add(1, std::memory_order_relaxed);
-                    host_target_stats.bytes.fetch_add((*result)[i], std::memory_order_relaxed);
-                  } else {
-                    disk_target_stats.batches.fetch_add(1, std::memory_order_relaxed);
-                    disk_target_stats.bytes.fetch_add((*result)[i], std::memory_order_relaxed);
+          auto exc_stream = _stream_pool->acquire_stream(
+            cucascade::memory::exclusive_stream_pool::stream_acquire_policy::GROW);
+
+          _pool->dispatch(
+            std::move(slot),
+            [cand       = std::move(candidate),
+             req_ptr    = req.get(),
+             &res_mgr   = _reservation_manager,
+             &targets   = target_spaces,
+             exc_stream = std::move(exc_stream),
+             candidate_bytes,
+             host_end_idx,
+             &repo_stats,
+             &host_target_stats,
+             &disk_target_stats]() mutable {
+              try {
+                auto result = cand->convert(targets, exc_stream, res_mgr, false);
+                if (result) {
+                  req_ptr->bytes_freed.fetch_add(candidate_bytes, std::memory_order_relaxed);
+                  req_ptr->batches_downgraded.fetch_add(1, std::memory_order_relaxed);
+                  repo_stats.batches.fetch_add(1, std::memory_order_relaxed);
+                  repo_stats.bytes.fetch_add(candidate_bytes, std::memory_order_relaxed);
+                  for (size_t i = 0; i < result->size(); ++i) {
+                    if ((*result)[i] == 0) continue;
+                    if (i < host_end_idx) {
+                      host_target_stats.batches.fetch_add(1, std::memory_order_relaxed);
+                      host_target_stats.bytes.fetch_add((*result)[i], std::memory_order_relaxed);
+                    } else {
+                      disk_target_stats.batches.fetch_add(1, std::memory_order_relaxed);
+                      disk_target_stats.bytes.fetch_add((*result)[i], std::memory_order_relaxed);
+                    }
+                  }
+                  if (req_ptr->predicate && req_ptr->predicate()) {
+                    req_ptr->satisfied.store(true);
                   }
                 }
-                if (req_ptr->predicate && req_ptr->predicate()) { req_ptr->satisfied.store(true); }
+              } catch (const std::exception& e) {
+                SIRIUS_LOG_ERROR("[downgrade] convert failed from data repository: {}", e.what());
               }
-            } catch (const std::exception& e) {
-              SIRIUS_LOG_ERROR("[downgrade] convert failed from data repository: {}", e.what());
-            }
-          });
+            });
+        }
+        if (pool_interrupted) break;
       }
-      if (pool_interrupted) break;
     }
 
     // === TIER 2: task_scheduler task queue ===

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <ranges>
 #include <thread>
 #include <vector>
 
@@ -201,16 +202,26 @@ void downgrade_executor::processing_loop()
 
     // === TIER 1: Data repositories ===
     // Memory pressure is a global condition, so candidates are drawn from EVERY in-flight
-    // query: outer loop ascending by query id, inner loop in get_repositories() order —
-    // ascending {operator_id, port_id} — with early stop once the reservation is satisfied.
-    // Operator ids restart at 0 per query, so ordering is (query id, operator id) rather than
-    // a single global counter. This inherits "lowest query id spills first", which is
-    // arbitrary across concurrent queries; a deliberate fairness policy is still owed here.
+    // query: outer loop DESCENDING by query id (newest query first), inner loop in
+    // get_repositories() order — ascending {operator_id, port_id} — with early stop once the
+    // reservation is satisfied. Operator ids restart at 0 per query, so ordering is
+    // (query id, operator id) rather than a single global counter.
+    //
+    // Newest-first is the fairness policy: query ids are monotonic, so the newest query is the
+    // one that has made the least progress, and spilling it costs the least re-materialization
+    // work. It also keeps the oldest query's working set resident so it can finish and release
+    // its memory, which is what actually relieves the pressure — spilling the oldest query
+    // instead would slow down the query closest to completing while newer arrivals keep
+    // allocating. This makes the pressure response FIFO: earliest queries keep execution
+    // priority, latest queries pay for the memory.
+    //
+    // get_all() returns ascending by query id, so this iterates the snapshot in reverse.
     // get_all_convertible() snapshots eligible batches once per repo so a batch isn't
     // re-scanned before leaving idle. Managers are held by shared_ptr for the duration of the
     // sweep, so a query ending concurrently cannot pull one out from under this loop.
     bool pool_interrupted = false;
-    for (auto const& manager : _data_repo_registry.get_all()) {
+    auto const managers   = _data_repo_registry.get_all();
+    for (auto const& manager : std::views::reverse(managers)) {
       if (req->satisfied.load() || pool_interrupted) break;
       auto repos = manager->get_repositories();
       for (auto* repo : repos) {

--- a/src/include/data/data_repository_manager_registry.hpp
+++ b/src/include/data/data_repository_manager_registry.hpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "query_id.hpp"
+
+#include <cucascade/data/data_repository_manager.hpp>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace sirius::data {
+
+/**
+ * @brief Owns one `cucascade::shared_data_repository_manager` per in-flight query.
+ *
+ * Replaces the single SiriusContext-wide manager. Operator ids restart at 0 for every query
+ * (see `pipeline::assign_operator_ids`), so the `{operator_id, port_id}` repository keys are
+ * only unique *within* a query — each query therefore needs its own manager. Ending a query
+ * drops only that query's repositories instead of wiping every in-flight query's data.
+ *
+ * Managers are handed out as `shared_ptr` rather than references: a downgrade worker may be
+ * sweeping a manager while its query ends, and shared ownership means the manager object
+ * survives until the last borrower releases it instead of dangling.
+ *
+ * Thread-safe. `get_all()` returns a snapshot built under the lock so callers can iterate
+ * without holding it — memory-pressure sweeps are long and blocking, and holding this mutex
+ * across one would serialize query begin/end behind spilling.
+ */
+class data_repository_manager_registry {
+ public:
+  using manager_type           = cucascade::shared_data_repository_manager;
+  using manager_ptr            = std::shared_ptr<manager_type>;
+  using leaked_repository_info = manager_type::leaked_repository_info;
+
+  data_repository_manager_registry()  = default;
+  ~data_repository_manager_registry() = default;
+
+  data_repository_manager_registry(const data_repository_manager_registry&)            = delete;
+  data_repository_manager_registry& operator=(const data_repository_manager_registry&) = delete;
+  data_repository_manager_registry(data_repository_manager_registry&&)                 = delete;
+  data_repository_manager_registry& operator=(data_repository_manager_registry&&)      = delete;
+
+  /**
+   * @brief Create the manager for @p query_id.
+   *
+   * Called once per execution window, before any repository is wired. Windows that never wire
+   * repositories (e.g. `pin_table`) simply end up with an empty manager, which keeps the
+   * "inside a window implies a manager exists" invariant cheap to rely on.
+   *
+   * @throws std::runtime_error if @p query_id is already registered — window ids are
+   *         monotonic, so a duplicate means a lifecycle bug rather than a recoverable state.
+   */
+  manager_ptr create_for_query(sirius::query_id_t query_id)
+  {
+    auto manager = std::make_shared<manager_type>();
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      auto [it, inserted] = managers_.emplace(query_id, std::move(manager));
+      if (!inserted) {
+        throw std::runtime_error(
+          "data_repository_manager_registry: a manager is already registered for query " +
+          std::to_string(sirius::value_of(query_id)));
+      }
+      return it->second;
+    }
+  }
+
+  /// \brief The manager for @p query_id, or nullptr if none is registered.
+  [[nodiscard]] manager_ptr get(sirius::query_id_t query_id) const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = managers_.find(query_id);
+    return it == managers_.end() ? nullptr : it->second;
+  }
+
+  /**
+   * @brief Snapshot of every live manager, in ascending query-id order.
+   *
+   * Used by the downgrade executors, which must see across all in-flight queries because
+   * memory pressure is a global condition. Ordering is deterministic so spill-candidate
+   * selection stays reproducible across runs.
+   */
+  [[nodiscard]] std::vector<manager_ptr> get_all() const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<manager_ptr> result;
+    result.reserve(managers_.size());
+    for (const auto& [id, manager] : managers_) {
+      result.push_back(manager);
+    }
+    return result;
+  }
+
+  /**
+   * @brief Drop @p query_id's manager and report any repositories that still held batches.
+   *
+   * Unregisters first, then clears the extracted manager so the report carries the same
+   * `{operator_id, port_id, count}` detail the single-manager path produced.
+   *
+   * Precondition: every borrower of this query's repositories has been quiesced (the query
+   * cleanup path drains the downgrade executors first). Clearing while a worker still holds a
+   * raw `data_repository*` obtained from this manager would dangle — shared ownership protects
+   * the manager object, not the repositories inside it.
+   *
+   * @return Per-repository info for each repository that still had un-consumed batches; empty
+   *         when @p query_id is not registered (erasing an unknown id is a no-op).
+   */
+  std::vector<leaked_repository_info> erase(sirius::query_id_t query_id)
+  {
+    manager_ptr manager;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      auto it = managers_.find(query_id);
+      if (it == managers_.end()) { return {}; }
+      manager = std::move(it->second);
+      managers_.erase(it);
+    }
+    return manager ? manager->clear_all_repositories() : std::vector<leaked_repository_info>{};
+  }
+
+  /// \brief Drop every manager. For SiriusContext teardown, after all workers are stopped.
+  void clear()
+  {
+    std::map<query_id_t, manager_ptr> drained;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      drained.swap(managers_);
+    }
+    // Destroyed outside the lock: manager destruction releases data batches, which can run
+    // arbitrary deallocation work that must not happen with the registry mutex held.
+  }
+
+  /// \brief Number of queries currently holding a manager.
+  [[nodiscard]] size_t size() const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return managers_.size();
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  /// std::map (not unordered_map) so get_all() iteration is ascending by query id.
+  std::map<sirius::query_id_t, manager_ptr> managers_;
+};
+
+}  // namespace sirius::data

--- a/src/include/data/data_repository_manager_registry.hpp
+++ b/src/include/data/data_repository_manager_registry.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Sirius Contributors.
+ * Copyright 2026, Sirius Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,8 +75,8 @@ class data_repository_manager_registry {
   {
     auto manager = std::make_shared<manager_type>();
     {
-      std::lock_guard<std::mutex> lock(mutex_);
-      auto [it, inserted] = managers_.emplace(query_id, std::move(manager));
+      std::lock_guard<std::mutex> lock(_mutex);
+      auto [it, inserted] = _managers.emplace(query_id, std::move(manager));
       if (!inserted) {
         throw std::runtime_error(
           "data_repository_manager_registry: a manager is already registered for query " +
@@ -89,9 +89,9 @@ class data_repository_manager_registry {
   /// \brief The manager for @p query_id, or nullptr if none is registered.
   [[nodiscard]] manager_ptr get(sirius::query_id_t query_id) const
   {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto it = managers_.find(query_id);
-    return it == managers_.end() ? nullptr : it->second;
+    std::lock_guard<std::mutex> lock(_mutex);
+    auto it = _managers.find(query_id);
+    return it == _managers.end() ? nullptr : it->second;
   }
 
   /**
@@ -99,14 +99,16 @@ class data_repository_manager_registry {
    *
    * Used by the downgrade executors, which must see across all in-flight queries because
    * memory pressure is a global condition. Ordering is deterministic so spill-candidate
-   * selection stays reproducible across runs.
+   * selection stays reproducible across runs. Note that the executors walk this snapshot in
+   * REVERSE (newest query first) to keep the oldest query's data resident; ascending is just
+   * the canonical order to return, not the sweep order.
    */
   [[nodiscard]] std::vector<manager_ptr> get_all() const
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(_mutex);
     std::vector<manager_ptr> result;
-    result.reserve(managers_.size());
-    for (const auto& [id, manager] : managers_) {
+    result.reserve(_managers.size());
+    for (const auto& [id, manager] : _managers) {
       result.push_back(manager);
     }
     return result;
@@ -130,11 +132,11 @@ class data_repository_manager_registry {
   {
     manager_ptr manager;
     {
-      std::lock_guard<std::mutex> lock(mutex_);
-      auto it = managers_.find(query_id);
-      if (it == managers_.end()) { return {}; }
+      std::lock_guard<std::mutex> lock(_mutex);
+      auto it = _managers.find(query_id);
+      if (it == _managers.end()) { return {}; }
       manager = std::move(it->second);
-      managers_.erase(it);
+      _managers.erase(it);
     }
     return manager ? manager->clear_all_repositories() : std::vector<leaked_repository_info>{};
   }
@@ -144,8 +146,8 @@ class data_repository_manager_registry {
   {
     std::map<query_id_t, manager_ptr> drained;
     {
-      std::lock_guard<std::mutex> lock(mutex_);
-      drained.swap(managers_);
+      std::lock_guard<std::mutex> lock(_mutex);
+      drained.swap(_managers);
     }
     // Destroyed outside the lock: manager destruction releases data batches, which can run
     // arbitrary deallocation work that must not happen with the registry mutex held.
@@ -154,14 +156,14 @@ class data_repository_manager_registry {
   /// \brief Number of queries currently holding a manager.
   [[nodiscard]] size_t size() const
   {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return managers_.size();
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _managers.size();
   }
 
  private:
-  mutable std::mutex mutex_;
+  mutable std::mutex _mutex;
   /// std::map (not unordered_map) so get_all() iteration is ascending by query id.
-  std::map<sirius::query_id_t, manager_ptr> managers_;
+  std::map<sirius::query_id_t, manager_ptr> _managers;
 };
 
 }  // namespace sirius::data

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "data/data_repository_manager_registry.hpp"
 #include "exec/bounded_thread_pool.hpp"
 #include "exec/config.hpp"
 #include "exec/interruptible_mpmc.hpp"
@@ -75,7 +76,7 @@ class downgrade_executor {
    * @brief Constructs a new downgrade_executor bound to a specific memory space.
    *
    * @param config Configuration for the thread pool (thread count, etc.)
-   * @param data_repo_mgr Reference to the data repository manager
+   * @param data_repo_registry Registry of every in-flight query's data repository manager
    * @param space_id The memory space this executor is responsible for downgrading FROM
    * @param memory_space Pointer to the memory space (for pressure queries; nullptr disables
    * monitor)
@@ -84,7 +85,7 @@ class downgrade_executor {
    */
   explicit downgrade_executor(
     exec::downgrade_executor_config config,
-    cucascade::shared_data_repository_manager& data_repo_mgr,
+    sirius::data::data_repository_manager_registry& data_repo_registry,
     cucascade::memory::memory_space_id space_id,
     cucascade::memory::memory_space* memory_space,
     sirius::memory::sirius_memory_reservation_manager& reservation_manager,
@@ -199,7 +200,9 @@ class downgrade_executor {
   std::mutex _monitor_cv_mutex;
   std::condition_variable _monitor_cv;
 
-  cucascade::shared_data_repository_manager& _data_repo_mgr;
+  /// Every in-flight query's repository manager. Memory pressure is a global condition, so
+  /// spill candidates are drawn from across all live queries, not just one.
+  sirius::data::data_repository_manager_registry& _data_repo_registry;
   cucascade::memory::memory_space_id _space_id;
   cucascade::memory::memory_space* _memory_space;
   std::string _source_label;

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -29,6 +29,7 @@
 
 #include <array>
 #include <atomic>
+#include <limits>
 #include <list>
 #include <memory>
 #include <optional>
@@ -373,20 +374,19 @@ struct input_stats {
 class sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::INVALID;
-  //! Static counter for generating unique operator IDs
-  static inline std::atomic<size_t> next_operator_id{0};
+  //! Sentinel for `operator_id` before `pipeline::assign_operator_ids` numbers the plan.
+  //! Operators are constructed without an id so that two queries can build their plans
+  //! concurrently; ids are stamped in a single pass once the plan is complete.
+  static constexpr size_t invalid_operator_id = std::numeric_limits<size_t>::max();
 
  public:
   sirius_physical_operator(SiriusPhysicalOperatorType type,
                            duckdb::vector<sirius::logical_type> types,
                            std::size_t estimated_cardinality)
-    : type(type),
-      types(std::move(types)),
-      estimated_cardinality(estimated_cardinality),
-      operator_id(next_operator_id++)
+    : type(type), types(std::move(types)), estimated_cardinality(estimated_cardinality)
   {
   }
-  sirius_physical_operator() : operator_id(next_operator_id++) {}
+  sirius_physical_operator() {}
   virtual ~sirius_physical_operator() {}
 
   //! The physical operator type. Default-initialized to INVALID for the test-only default
@@ -399,8 +399,10 @@ class sirius_physical_operator {
   duckdb::vector<sirius::logical_type> types;
   //! The estimated cardinality of this physical operator
   std::size_t estimated_cardinality;
-  //! The unique ID of this operator (auto-incremented at creation)
-  size_t operator_id;
+  //! The unique ID of this operator within its query. Stamped by
+  //! `pipeline::assign_operator_ids` after plan construction completes; read it through
+  //! `get_operator_id()`, which rejects the unassigned sentinel.
+  size_t operator_id = invalid_operator_id;
 
   //! Lock for concurrent access to operator state
   std::mutex lock;
@@ -419,8 +421,23 @@ class sirius_physical_operator {
   //! Return a vector of the types that will be returned by this operator
   const duckdb::vector<sirius::logical_type>& get_types() const { return types; }
 
-  //! Get the unique operator ID
-  size_t get_operator_id() const { return operator_id; }
+  //! Get the unique operator ID.
+  //! Throws if the plan was not numbered by `pipeline::assign_operator_ids`. An unassigned
+  //! id would otherwise silently collide in the operator-id-keyed maps (repositories,
+  //! task-creator global states) and mis-route data, so this fails loudly in every build.
+  size_t get_operator_id() const
+  {
+    if (operator_id == invalid_operator_id) {
+      throw sirius::internal_exception(
+        "sirius_physical_operator::get_operator_id: operator '{}' has no id assigned; "
+        "pipeline::assign_operator_ids must run over the plan before execution",
+        get_name());
+    }
+    return operator_id;
+  }
+
+  //! Whether this operator has been numbered yet.
+  [[nodiscard]] bool has_operator_id() const noexcept { return operator_id != invalid_operator_id; }
 
   //! Bundle this operator's telemetry attribution (context + producing pipeline)
   //! for passing to the data_batch factories. Returns {nullptr, nil-UUID} if this

--- a/src/include/pipeline/repository_wiring.hpp
+++ b/src/include/pipeline/repository_wiring.hpp
@@ -68,5 +68,28 @@ struct repository_wiring {
 void materialize_repository_wiring(const std::vector<repository_wiring>& wirings,
                                    cucascade::shared_data_repository_manager& data_repo_manager);
 
+/**
+ * @brief Stamp every operator in @p pipelines with a dense, 0-based id for this query.
+ *
+ * Operators are constructed with `sirius_physical_operator::invalid_operator_id` so that plan
+ * construction carries no cross-query state and two queries can be planned concurrently. This
+ * pass runs once, after the pipeline converter has produced the final pipeline set and before
+ * anything reads an operator id — `materialize_repository_wiring` above is the first consumer,
+ * since it keys each repository on the destination operator's id.
+ *
+ * Ids are assigned in pipeline-scheduling order and, within a pipeline, in
+ * source -> operators -> sink order. Each operator is numbered on first visit, so an operator
+ * appearing in several pipelines keeps one stable id. The resulting ids are `0..N-1`, no gaps.
+ *
+ * The pipeline set — not the plan tree — is the traversal root on purpose:
+ * `sirius_physical_delim_join` owns its `join` and `distinct_root` subtrees outside `children`
+ * and does not override `get_children()`, so a tree walk would miss them. Every operator that
+ * executes belongs to a pipeline.
+ *
+ * @param pipelines The query's pipelines, in scheduling order.
+ * @return The number of operators numbered (i.e. one past the highest id assigned).
+ */
+size_t assign_operator_ids(const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines);
+
 }  // namespace pipeline
 }  // namespace sirius

--- a/src/include/planner/query.hpp
+++ b/src/include/planner/query.hpp
@@ -19,6 +19,7 @@
 #include "duckdb/common/unordered_map.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "pipeline/sirius_pipeline.hpp"
+#include "query_id.hpp"
 #include "telemetry-bridge/gen/uuid.rs.h"
 #include "telemetry/telemetry_context.hpp"
 
@@ -44,10 +45,12 @@ class query {
    * @brief Construct a new query object.
    *
    * @param pipelines The ordered pipelines required to execute this query.
+   * @param query_id The enclosing execution window's id — the engine-wide query identity.
    * @param telemetry_info Info useful for emitting identifiable telemetry.
    */
   query(duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>> pipelines,
         const quent::Context& context,
+        sirius::query_id_t query_id,
         telemetry::query_telemetry_info telemetry_info);
 
   ~query() = default;
@@ -85,21 +88,22 @@ class query {
     const;
 
   /**
-   * @brief Monotonic id assigned at construction; earlier queries get a lower id.
+   * @brief This query's engine-wide id, assigned when its execution window opened.
    *
-   * Used as the high 32 bits of a task's scheduling priority so all tasks of an earlier query are
-   * dispatched before those of a later one (the priority queue picks the lowest value first).
+   * Earlier queries get a lower id, so it doubles as the high bits of a task's scheduling
+   * priority: all tasks of an earlier query are dispatched before those of a later one (the
+   * priority queue picks the lowest value first). The same id keys this query's data repository
+   * manager and its window log lines.
    */
-  [[nodiscard]] uint32_t get_query_id() const { return _query_id; }
+  [[nodiscard]] sirius::query_id_t query_id() const noexcept { return _query_id; }
 
  private:
   //! Builds the internal data structures from the pipelines
   void build_indices();
 
-  //! Process-wide monotonic counter; each query claims the next value as its id at construction.
-  static std::atomic<uint32_t> _query_counter;
-  //! This query's id (lower = created earlier = scheduled first).
-  uint32_t _query_id;
+  //! This query's id (lower = created earlier = scheduled first), supplied by the execution
+  //! window rather than minted here — see sirius::query_id_t.
+  sirius::query_id_t _query_id;
   //! Unique ID for this plan
   uuid::UUID _plan_id;
   //! Pipelines and the order in which they must be executed in order to successfully complete the

--- a/src/include/planner/query.hpp
+++ b/src/include/planner/query.hpp
@@ -45,7 +45,7 @@ class query {
    * @brief Construct a new query object.
    *
    * @param pipelines The ordered pipelines required to execute this query.
-   * @param query_id The enclosing execution window's id — the engine-wide query identity.
+   * @param query_id The engine-wide query identity.
    * @param telemetry_info Info useful for emitting identifiable telemetry.
    */
   query(duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>> pipelines,

--- a/src/include/query_id.hpp
+++ b/src/include/query_id.hpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <format>
+
+namespace sirius {
+
+/**
+ * @brief Identifies one execution window, i.e. one query, within a SiriusContext.
+ *
+ * Minted once when the window opens (`SiriusContext::StandaloneQueryScope`) and used as THE
+ * query identity everywhere downstream: which data repository manager the query owns, which
+ * repositories its cleanup drops, its task scheduling priority, and its log/telemetry
+ * correlation key.
+ *
+ * 32-bit because `task_creator` packs it into the high bits of a 64-bit
+ * `exec::queue_priority`; see `query_priority_bits()` for the packing contract.
+ *
+ * A distinct enum type rather than a `uint64_t` alias: operator ids, pipeline ids, connection
+ * ids and per-connection query ordinals are all plain integers in this codebase, and letting a
+ * query id be silently interchangeable with them is what allowed two independent query-id
+ * counters to coexist unnoticed.
+ */
+enum class query_id_t : std::uint32_t {};
+
+/// \brief The underlying integer, for formatting, hashing and bit packing.
+[[nodiscard]] constexpr std::uint32_t value_of(query_id_t id) noexcept
+{
+  return static_cast<std::uint32_t>(id);
+}
+
+/// \brief Build a query id from a raw counter value.
+[[nodiscard]] constexpr query_id_t make_query_id(std::uint32_t value) noexcept
+{
+  return static_cast<query_id_t>(value);
+}
+
+/**
+ * @brief The task-scheduling priority contribution of a query: its id in the high 32 bits.
+ *
+ * The task priority queue pops the LOWEST value first, so packing the id above the
+ * within-query pipeline rank makes every task of an earlier query dispatch before any task of
+ * a later one, while the low 32 bits preserve pipeline order within a query.
+ *
+ * Masked to 31 bits because the priority is a SIGNED 64-bit value: an id with bit 31 set would
+ * shift into the sign bit and invert the ordering. Scheduling order therefore wraps every 2^31
+ * queries in a single process — at that point a fresh query sorts ahead of older in-flight
+ * ones. That is a known limitation of packing the id into the priority at all.
+ */
+[[nodiscard]] constexpr std::int64_t query_priority_bits(query_id_t id) noexcept
+{
+  return static_cast<std::int64_t>(value_of(id) & 0x7FFF'FFFFU) << 32;
+}
+
+}  // namespace sirius
+
+/// Logging is std::format-based (see log/logging.hpp) and C++20 std::format has no built-in
+/// support for enums, so query ids would otherwise have to be cast at every log site.
+template <>
+struct std::formatter<sirius::query_id_t> : std::formatter<std::uint32_t> {
+  auto format(sirius::query_id_t id, std::format_context& ctx) const
+  {
+    return std::formatter<std::uint32_t>::format(sirius::value_of(id), ctx);
+  }
+};

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "creator/task_creator.hpp"
+#include "data/data_repository_manager_registry.hpp"
 #include "downgrade/downgrade_executor.hpp"
 #include "memory/resource_ref_utils.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
@@ -386,12 +387,18 @@ class SiriusContext : public ClientContextState {
     /// slot nor poison the runtime.
     void finish();
 
+    /// \brief This window's query id — the key its data repositories are registered under.
+    /// Pass it to the execution path (sirius_execute_query) so operators wire into this
+    /// query's manager rather than a shared one.
+    [[nodiscard]] sirius::query_id_t query_id() const noexcept { return window_id_; }
+
    private:
     enum class scope_state : uint8_t { ACTIVE, FINISHED, FAILED };
     /// Best-effort window begin/end log line — never throws.
     void log_window_event(char const* event, char const* outcome) const noexcept;
     SiriusContext& ctx_;
-    uint64_t window_id_;
+    /// This window's query id; see sirius::query_id_t.
+    sirius::query_id_t window_id_;
     uint64_t connection_id_;
     uint64_t query_ordinal_;
     /// Pool-stat tags carrying the full window key, rendered into fixed
@@ -421,9 +428,18 @@ class SiriusContext : public ClientContextState {
   [[nodiscard]] sirius::memory::sirius_memory_reservation_manager& get_memory_manager();
   [[nodiscard]] const sirius::memory::sirius_memory_reservation_manager& get_memory_manager() const;
 
-  [[nodiscard]] cucascade::shared_data_repository_manager& get_data_repository_manager();
-  [[nodiscard]] const cucascade::shared_data_repository_manager& get_data_repository_manager()
-    const;
+  /// \brief The data repository manager owned by @p query_id's execution window.
+  /// \return The manager, or nullptr when no window is registered under that id.
+  [[nodiscard]] sirius::data::data_repository_manager_registry::manager_ptr
+  get_data_repository_manager(sirius::query_id_t query_id) const;
+
+  /// \brief Snapshot of every in-flight query's manager, ascending by query id.
+  /// Memory pressure is a global condition, so the downgrade executors sweep across all of them.
+  [[nodiscard]] std::vector<sirius::data::data_repository_manager_registry::manager_ptr>
+  get_data_repository_managers() const;
+
+  /// \brief The registry itself, for subsystems that hold a long-lived binding to it.
+  [[nodiscard]] sirius::data::data_repository_manager_registry& get_data_repository_registry();
 
   [[nodiscard]] sirius::pipeline::task_scheduler& get_task_scheduler();
   [[nodiscard]] const sirius::pipeline::task_scheduler& get_task_scheduler() const;
@@ -468,6 +484,7 @@ class SiriusContext : public ClientContextState {
   /// \param pipelines The ordered pipelines for the query.
   /// \param telemetry_info Info useful for emitting identifiable telemetry.
   void create_query(duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>> pipelines,
+                    sirius::query_id_t query_id,
                     sirius::telemetry::query_telemetry_info telemetry_info);
 
   /// \brief Get the current query.
@@ -511,21 +528,24 @@ class SiriusContext : public ClientContextState {
   /// window (it releases and throws instead of running any shared mutation).
   void acquire_query_lifecycle_slot(ClientContext* context);
   void release_query_lifecycle_slot() noexcept;
-  /// The begin-of-window shared mutations (operator-id reset, task_creator
-  /// reset/bind) — runs INSIDE the held slot, per the frozen "after acquire +
-  /// health check, before final create_plan" placement.
+  /// The begin-of-window shared mutations (repository-manager registration,
+  /// task_creator reset/bind) — runs INSIDE the held slot, per the frozen
+  /// "after acquire + health check, before final create_plan" placement.
   void begin_execution_window(ClientContext& context,
+                              sirius::query_id_t query_id,
                               std::string_view window_label,
                               std::string_view pool_tag);
   /// The mandatory per-query cleanup (the former QueryEnd body, order
   /// preserved). Runs INSIDE the held slot; may throw. Only the mandatory
   /// steps (query/drain/repositories/scan/task resets) can throw out of it —
   /// telemetry and logging inside are best-effort and never abort the
-  /// remaining steps. @p end_tag keys the pool-stats log line to the window.
-  void run_mandatory_cleanup(std::string_view end_tag);
+  /// remaining steps. @p query_id selects which query's repositories to drop;
+  /// @p end_tag keys the pool-stats log line to the window.
+  void run_mandatory_cleanup(sirius::query_id_t query_id, std::string_view end_tag);
   /// noexcept variant for the StandaloneQueryScope destructor backstop: one
   /// attempt; on failure marks the runtime UNAVAILABLE.
-  void run_mandatory_cleanup_backstop(std::string_view end_tag) noexcept;
+  void run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
+                                      std::string_view end_tag) noexcept;
 
   /// \brief Best-effort task_creator reset for latched-unavailable paths,
   /// where no later window will ever run the in-cleanup reset.
@@ -548,7 +568,9 @@ class SiriusContext : public ClientContextState {
   // See runtime_health: latched when a mandatory cleanup step fails.
   std::atomic<bool> runtime_unavailable_{false};
   // Monotonic execution-window id for window-keyed logging.
-  std::atomic<uint64_t> next_window_id_{0};
+  /// 32-bit to match sirius::query_id_t, which task_creator packs into the scheduling
+  /// priority. The first window gets id 1, so 0 is never a live query id.
+  std::atomic<std::uint32_t> next_window_id_{0};
   bool is_initialized_ = false;
   sirius::sirius_config config_;
   std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory_manager_;
@@ -588,7 +610,12 @@ class SiriusContext : public ClientContextState {
   std::optional<rmm::host_device_async_resource_ref> prev_pinned_mr_{};
   std::size_t prev_pinned_threshold_{0};
   std::shared_ptr<const sirius::telemetry::telemetry_context> telemetry_context_;
-  std::unique_ptr<cucascade::shared_data_repository_manager> data_repository_manager_;
+  /// One data repository manager per in-flight query, keyed by execution-window id.
+  /// Replaces the former single SiriusContext-wide manager so query end drops only its own
+  /// repositories. Declared here (not as a unique_ptr) because the registry itself holds no
+  /// GPU resources — the managers it owns do, and those are dropped in terminate() before the
+  /// memory manager goes away.
+  sirius::data::data_repository_manager_registry data_repository_registry_;
   std::unique_ptr<sirius::pipeline::task_scheduler> task_scheduler_;
   std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>> downgrade_executors_;
   std::unique_ptr<sirius::creator::task_creator> task_creator_;

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -428,8 +428,8 @@ class SiriusContext : public ClientContextState {
   [[nodiscard]] sirius::memory::sirius_memory_reservation_manager& get_memory_manager();
   [[nodiscard]] const sirius::memory::sirius_memory_reservation_manager& get_memory_manager() const;
 
-  /// \brief The data repository manager owned by @p query_id's execution window.
-  /// \return The manager, or nullptr when no window is registered under that id.
+  /// \brief The data repository manager owned by @p query_id's query
+  /// \return The manager, or nullptr
   [[nodiscard]] sirius::data::data_repository_manager_registry::manager_ptr
   get_data_repository_manager(sirius::query_id_t query_id) const;
 
@@ -610,11 +610,7 @@ class SiriusContext : public ClientContextState {
   std::optional<rmm::host_device_async_resource_ref> prev_pinned_mr_{};
   std::size_t prev_pinned_threshold_{0};
   std::shared_ptr<const sirius::telemetry::telemetry_context> telemetry_context_;
-  /// One data repository manager per in-flight query, keyed by execution-window id.
-  /// Replaces the former single SiriusContext-wide manager so query end drops only its own
-  /// repositories. Declared here (not as a unique_ptr) because the registry itself holds no
-  /// GPU resources — the managers it owns do, and those are dropped in terminate() before the
-  /// memory manager goes away.
+  /// One data repository manager per in-flight query, keyed by query_id.
   sirius::data::data_repository_manager_registry data_repository_registry_;
   std::unique_ptr<sirius::pipeline::task_scheduler> task_scheduler_;
   std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>> downgrade_executors_;

--- a/src/include/sirius_engine.hpp
+++ b/src/include/sirius_engine.hpp
@@ -57,14 +57,12 @@ class sirius_engine {
   friend class pipeline::sirius_meta_pipeline;
 
  public:
-  /// @param query_id The enclosing execution window's id. Selects which per-query data
-  ///        repository manager this plan's pipelines wire their repositories into.
   explicit sirius_engine(duckdb::ClientContext& context,
                          sirius_interface& sirius_iface,
                          sirius::query_id_t query_id);
   ~sirius_engine();
 
-  /// \brief The execution window this engine belongs to.
+  /// \brief The query_id this engine belongs to.
   [[nodiscard]] sirius::query_id_t query_id() const noexcept { return query_id_; }
 
   duckdb::ClientContext& context;
@@ -108,7 +106,6 @@ class sirius_engine {
   bool query_finished;
 
  private:
-  /// Execution-window id; picks this query's data repository manager out of the registry.
   sirius::query_id_t query_id_;
   std::shared_ptr<const telemetry::telemetry_context> telemetry_context_;
   rust::Box<quent::query::QueryHandle> query_handle_;

--- a/src/include/sirius_engine.hpp
+++ b/src/include/sirius_engine.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "data/data_repository_manager_registry.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/pair.hpp"
@@ -56,8 +57,15 @@ class sirius_engine {
   friend class pipeline::sirius_meta_pipeline;
 
  public:
-  explicit sirius_engine(duckdb::ClientContext& context, sirius_interface& sirius_iface);
+  /// @param query_id The enclosing execution window's id. Selects which per-query data
+  ///        repository manager this plan's pipelines wire their repositories into.
+  explicit sirius_engine(duckdb::ClientContext& context,
+                         sirius_interface& sirius_iface,
+                         sirius::query_id_t query_id);
   ~sirius_engine();
+
+  /// \brief The execution window this engine belongs to.
+  [[nodiscard]] sirius::query_id_t query_id() const noexcept { return query_id_; }
 
   duckdb::ClientContext& context;
   sirius_interface& sirius_iface;
@@ -100,6 +108,8 @@ class sirius_engine {
   bool query_finished;
 
  private:
+  /// Execution-window id; picks this query's data repository manager out of the registry.
+  sirius::query_id_t query_id_;
   std::shared_ptr<const telemetry::telemetry_context> telemetry_context_;
   rust::Box<quent::query::QueryHandle> query_handle_;
 };

--- a/src/include/sirius_interface.hpp
+++ b/src/include/sirius_interface.hpp
@@ -105,9 +105,6 @@ class sirius_interface {
     const duckdb::PendingQueryParameters& parameters,
     sirius::query_id_t query_id);
   //! Execute the query
-  //! Execute the query. @p query_id is the enclosing execution window's id
-  //! (SiriusContext::StandaloneQueryScope::query_id()); it selects the data repository manager
-  //! this query's operators wire into.
   duckdb::unique_ptr<duckdb::QueryResult> sirius_execute_query(
     duckdb::ClientContext& context,
     const duckdb::string& query,

--- a/src/include/sirius_interface.hpp
+++ b/src/include/sirius_interface.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "data/data_repository_manager_registry.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "sirius_engine.hpp"
 
@@ -94,19 +95,25 @@ class sirius_interface {
   duckdb::unique_ptr<duckdb::PendingQueryResult> sirius_pending_statement_internal(
     duckdb::ClientContext& context,
     duckdb::shared_ptr<sirius_prepared_statement_data>& statement_p,
-    const duckdb::PendingQueryParameters& parameters);
+    const duckdb::PendingQueryParameters& parameters,
+    sirius::query_id_t query_id);
   //! Create the pending statement or prepared statement
   duckdb::unique_ptr<duckdb::PendingQueryResult> sirius_pending_statement_or_prepared_statement(
     duckdb::ClientContext& context,
     const duckdb::string& query,
     duckdb::shared_ptr<sirius_prepared_statement_data>& statement_p,
-    const duckdb::PendingQueryParameters& parameters);
+    const duckdb::PendingQueryParameters& parameters,
+    sirius::query_id_t query_id);
   //! Execute the query
+  //! Execute the query. @p query_id is the enclosing execution window's id
+  //! (SiriusContext::StandaloneQueryScope::query_id()); it selects the data repository manager
+  //! this query's operators wire into.
   duckdb::unique_ptr<duckdb::QueryResult> sirius_execute_query(
     duckdb::ClientContext& context,
     const duckdb::string& query,
     duckdb::shared_ptr<sirius_prepared_statement_data>& statement_p,
-    const duckdb::PendingQueryParameters& parameters);
+    const duckdb::PendingQueryParameters& parameters,
+    sirius::query_id_t query_id);
   //! Execute the pending query result
   duckdb::unique_ptr<duckdb::QueryResult> sirius_execute_pending_query_result(
     duckdb::PendingQueryResult& pending);

--- a/src/include/telemetry/telemetry_context.hpp
+++ b/src/include/telemetry/telemetry_context.hpp
@@ -114,11 +114,9 @@ class telemetry_context {
 // A POD to hold common identifiers for useful telemetry.
 struct query_telemetry_info {
   /// Quent's own UUID for this query (`QueryHandle::uuid()`), authoritative within telemetry.
-  /// Named distinctly from `query_id` below so the two identities are never confused.
   uuid::UUID telemetry_query_id;
   uuid::UUID worker_id;
-  /// The engine-wide numeric query id (the execution window's id). Carried alongside the UUID
-  /// so telemetry records can be correlated with window-keyed log lines.
+  /// The engine-wide numeric query id (the execution window's id).
   sirius::query_id_t query_id;
 };
 

--- a/src/include/telemetry/telemetry_context.hpp
+++ b/src/include/telemetry/telemetry_context.hpp
@@ -18,6 +18,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "log/logging.hpp"
+#include "query_id.hpp"
 #include "telemetry-bridge/gen/context.rs.h"
 #include "telemetry-bridge/gen/engine.rs.h"
 #include "telemetry-bridge/gen/executor_thread.rs.h"
@@ -112,8 +113,13 @@ class telemetry_context {
 
 // A POD to hold common identifiers for useful telemetry.
 struct query_telemetry_info {
-  uuid::UUID query_id;
+  /// Quent's own UUID for this query (`QueryHandle::uuid()`), authoritative within telemetry.
+  /// Named distinctly from `query_id` below so the two identities are never confused.
+  uuid::UUID telemetry_query_id;
   uuid::UUID worker_id;
+  /// The engine-wide numeric query id (the execution window's id). Carried alongside the UUID
+  /// so telemetry records can be correlated with window-keyed log lines.
+  sirius::query_id_t query_id;
 };
 
 /// Emit plan-level telemetry (operator declarations, port declarations, edges)

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -162,11 +162,7 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
           return a->get_available_memory() < b->get_available_memory();
         });
 
-      auto& registry = sirius::converter_registry::get();
-      // Use the process-wide batch-id counter that every other producer uses
-      // (sirius::get_next_batch_id, data_batch_utils.hpp) rather than a repository manager's
-      // own counter: managers are now per-query, so a manager-local counter would restart at 0
-      // for each query and collide with ids already present in a repository.
+      auto& registry     = sirius::converter_registry::get();
       auto next_batch_id = sirius::get_next_batch_id();
 
       auto host_reservation =

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -162,9 +162,12 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
           return a->get_available_memory() < b->get_available_memory();
         });
 
-      auto& registry      = sirius::converter_registry::get();
-      auto& data_repo_mgr = sirius_ctx->get_data_repository_manager();
-      auto next_batch_id  = data_repo_mgr.get_next_data_batch_id();
+      auto& registry = sirius::converter_registry::get();
+      // Use the process-wide batch-id counter that every other producer uses
+      // (sirius::get_next_batch_id, data_batch_utils.hpp) rather than a repository manager's
+      // own counter: managers are now per-query, so a manager-local counter would restart at 0
+      // for each query and collide with ids already present in a repository.
+      auto next_batch_id = sirius::get_next_batch_id();
 
       auto host_reservation =
         const_cast<cucascade::memory::memory_space*>(mem_space)->make_reservation_or_null(

--- a/src/pipeline/repository_wiring_materializer.cpp
+++ b/src/pipeline/repository_wiring_materializer.cpp
@@ -27,6 +27,34 @@
 namespace sirius {
 namespace pipeline {
 
+namespace {
+
+//! Number @p op if it has not been numbered yet, advancing @p next_id.
+void assign_if_unassigned(op::sirius_physical_operator& op, size_t& next_id)
+{
+  if (!op.has_operator_id()) { op.operator_id = next_id++; }
+}
+
+}  // namespace
+
+size_t assign_operator_ids(const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines)
+{
+  size_t next_id = 0;
+  for (const auto& pipeline : pipelines) {
+    if (!pipeline) { continue; }
+
+    // source and sink are visited explicitly rather than relying on get_operators() to
+    // contain them: a pipeline can carry a sink with an empty operators list (the
+    // destination resolution below special-cases exactly that shape).
+    if (auto source = pipeline->get_source()) { assign_if_unassigned(*source, next_id); }
+    for (auto& op : pipeline->get_operators()) {
+      assign_if_unassigned(op.get(), next_id);
+    }
+    if (auto sink = pipeline->get_sink()) { assign_if_unassigned(*sink, next_id); }
+  }
+  return next_id;
+}
+
 void materialize_repository_wiring(const std::vector<repository_wiring>& wirings,
                                    cucascade::shared_data_repository_manager& data_repo_manager)
 {
@@ -35,7 +63,7 @@ void materialize_repository_wiring(const std::vector<repository_wiring>& wirings
     auto* next_op       = dest_pipeline->get_operators().size() == 0
                             ? dest_pipeline->get_sink().get()
                             : &dest_pipeline->get_operators()[0].get();
-    const size_t op_id  = next_op->operator_id;
+    const size_t op_id  = next_op->get_operator_id();
 
     data_repo_manager.add_new_repository(
       op_id, wiring.port_id, std::make_unique<::cucascade::shared_data_repository>());

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -30,6 +30,7 @@
 #include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_operator_type.hpp"
 #include "op/sirius_physical_partition.hpp"
+#include "pipeline/repository_wiring.hpp"
 
 #include <algorithm>
 #include <functional>
@@ -61,6 +62,11 @@ pipeline_conversion_result sirius_pipeline_converter::convert(sirius_meta_pipeli
   // Must run after finalize_pipeline_structure (populates `dependencies`) and after
   // link_join_partition_siblings (reads dependencies[0]/[1] positionally pre-reorder).
   reorder_pipelines_topologically(scheduled_);
+
+  // Number the operators now that the pipeline set is final and topologically ordered. This is
+  // the one point every caller shares — the engine, and the plan-inspection paths that convert
+  // without building an engine — so no consumer can observe an unnumbered plan.
+  assign_operator_ids(scheduled_);
 
   return {std::move(scheduled_), std::move(repository_wirings_), meta_pipeline_count_};
 }

--- a/src/planner/query.cpp
+++ b/src/planner/query.cpp
@@ -22,14 +22,11 @@
 
 namespace sirius::planner {
 
-std::atomic<uint32_t> query::_query_counter{0};
-
 query::query(duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>> pipelines,
              const quent::Context& context,
+             sirius::query_id_t query_id,
              telemetry::query_telemetry_info telemetry_info)
-  : _query_id(_query_counter.fetch_add(1, std::memory_order_relaxed)),
-    _plan_id(uuid::now_v7()),
-    _pipelines(std::move(pipelines))
+  : _query_id(query_id), _plan_id(uuid::now_v7()), _pipelines(std::move(pipelines))
 {
   build_indices();
   telemetry::emit_plan_telemetry(context, _pipelines, _plan_id, telemetry_info);

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -285,9 +285,7 @@ void SiriusContext::begin_execution_window(ClientContext& context,
     SIRIUS_LOG_INFO("QueryBegin: {}", window_label);
   } catch (...) {  // best-effort observability
   }
-  // Register this window's repository manager up front so "inside a window implies a manager
-  // exists" holds for every path. Windows that never wire repositories (pin_table, the FFI
-  // entry point) just carry an empty one; run_mandatory_cleanup erases it either way.
+  // Register this query's repository manager up front
   data_repository_registry_.create_for_query(query_id);
   task_creator_->reset();
   task_creator_->set_client_context(context);

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -270,6 +270,7 @@ void SiriusContext::throw_runtime_unavailable() const
 }
 
 void SiriusContext::begin_execution_window(ClientContext& context,
+                                           sirius::query_id_t query_id,
                                            std::string_view window_label,
                                            std::string_view pool_tag)
 {
@@ -284,11 +285,15 @@ void SiriusContext::begin_execution_window(ClientContext& context,
     SIRIUS_LOG_INFO("QueryBegin: {}", window_label);
   } catch (...) {  // best-effort observability
   }
+  // Register this window's repository manager up front so "inside a window implies a manager
+  // exists" holds for every path. Windows that never wire repositories (pin_table, the FFI
+  // entry point) just carry an empty one; run_mandatory_cleanup erases it either way.
+  data_repository_registry_.create_for_query(query_id);
   task_creator_->reset();
   task_creator_->set_client_context(context);
 }
 
-void SiriusContext::run_mandatory_cleanup(std::string_view end_tag)
+void SiriusContext::run_mandatory_cleanup(sirius::query_id_t query_id, std::string_view end_tag)
 {
   // Observability inside the cleanup is best-effort: only the mandatory steps
   // (query/drain/repository/scan/task resets) may throw out of this function
@@ -320,15 +325,18 @@ void SiriusContext::run_mandatory_cleanup(std::string_view end_tag)
   } catch (...) {
   }
 
-  // Clear all data repositories between queries.
+  // Drop THIS query's data repositories, leaving any other in-flight query's untouched.
   // Any batches still present are leaked — operators should have popped everything.
-  if (data_repository_manager_) {
-    auto leaked = data_repository_manager_->clear_all_repositories();
+  // Safe to clear here because the downgrade executors were drained above, so nothing still
+  // holds a raw data_repository* borrowed from this query's manager.
+  {
+    auto leaked = data_repository_registry_.erase(query_id);
     try {
       for (auto const& info : leaked) {
         SIRIUS_LOG_WARN(
-          "SiriusContext::run_mandatory_cleanup: operator {} port '{}' still had {} un-consumed "
-          "data batch(es) (memory leak).",
+          "SiriusContext::run_mandatory_cleanup: query {} operator {} port '{}' still had {} "
+          "un-consumed data batch(es) (memory leak).",
+          query_id,
           info.operator_id,
           info.port_id,
           info.count);
@@ -357,10 +365,11 @@ void SiriusContext::run_mandatory_cleanup(std::string_view end_tag)
   }
 }
 
-void SiriusContext::run_mandatory_cleanup_backstop(std::string_view end_tag) noexcept
+void SiriusContext::run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
+                                                   std::string_view end_tag) noexcept
 {
   try {
-    run_mandatory_cleanup(end_tag);
+    run_mandatory_cleanup(query_id, end_tag);
   } catch (std::exception& e) {
     mark_runtime_unavailable();
     drop_task_creator_state_best_effort();
@@ -420,7 +429,7 @@ void SiriusContext::StandaloneQueryScope::log_window_event(char const* event,
 SiriusContext::StandaloneQueryScope::StandaloneQueryScope(SiriusContext& ctx,
                                                           ClientContext& context,
                                                           std::string_view window_label)
-  : ctx_(ctx), window_id_(0), connection_id_(0), query_ordinal_(0)
+  : ctx_(ctx), window_id_(sirius::make_query_id(0)), connection_id_(0), query_ordinal_(0)
 {
   if (auto conn_state = get_sirius_connection_state(context)) {
     connection_id_ = conn_state->connection_id();
@@ -429,26 +438,27 @@ SiriusContext::StandaloneQueryScope::StandaloneQueryScope(SiriusContext& ctx,
   // Window id + keyed tags are prepared BEFORE the slot is acquired: after
   // acquire, no statement on any path allocates, so release cannot be skipped
   // (and the noexcept destructor cannot terminate) for an allocation reason.
-  window_id_ = ctx_.next_window_id_.fetch_add(1, std::memory_order_relaxed) + 1;
+  window_id_ =
+    sirius::make_query_id(ctx_.next_window_id_.fetch_add(1, std::memory_order_relaxed) + 1);
   std::snprintf(begin_tag_,
                 sizeof(begin_tag_),
                 "QueryBegin instance=%p connection=%llu window=%llu query=%llu",
                 static_cast<const void*>(&ctx_),
                 static_cast<unsigned long long>(connection_id_),
-                static_cast<unsigned long long>(window_id_),
+                static_cast<unsigned long long>(sirius::value_of(window_id_)),
                 static_cast<unsigned long long>(query_ordinal_));
   std::snprintf(end_tag_,
                 sizeof(end_tag_),
                 "QueryEnd instance=%p connection=%llu window=%llu query=%llu",
                 static_cast<const void*>(&ctx_),
                 static_cast<unsigned long long>(connection_id_),
-                static_cast<unsigned long long>(window_id_),
+                static_cast<unsigned long long>(sirius::value_of(window_id_)),
                 static_cast<unsigned long long>(query_ordinal_));
 
   ctx_.acquire_query_lifecycle_slot(&context);
   log_window_event("begin", "-");
   try {
-    ctx_.begin_execution_window(context, window_label, begin_tag_);
+    ctx_.begin_execution_window(context, window_id_, window_label, begin_tag_);
   } catch (std::exception& e) {
     // A failed begin may have left the shared runtime part-mutated. This must
     // NEVER be classified as an ordinary GPU failure (which entry points would
@@ -457,7 +467,7 @@ SiriusContext::StandaloneQueryScope::StandaloneQueryScope(SiriusContext& ctx,
     // catch blocks rethrow it as-is instead of falling back.
     state_ = scope_state::FAILED;
     ctx_.mark_runtime_unavailable();
-    ctx_.run_mandatory_cleanup_backstop(end_tag_);
+    ctx_.run_mandatory_cleanup_backstop(window_id_, end_tag_);
     log_window_event("end", "begin_failed");
     ctx_.release_query_lifecycle_slot();
     throw SiriusBeginWindowFailureException(
@@ -466,7 +476,7 @@ SiriusContext::StandaloneQueryScope::StandaloneQueryScope(SiriusContext& ctx,
   } catch (...) {
     state_ = scope_state::FAILED;
     ctx_.mark_runtime_unavailable();
-    ctx_.run_mandatory_cleanup_backstop(end_tag_);
+    ctx_.run_mandatory_cleanup_backstop(window_id_, end_tag_);
     log_window_event("end", "begin_failed");
     ctx_.release_query_lifecycle_slot();
     throw SiriusBeginWindowFailureException(
@@ -487,7 +497,7 @@ void SiriusContext::StandaloneQueryScope::finish()
   } releaser{ctx_};
 
   try {
-    ctx_.run_mandatory_cleanup(end_tag_);
+    ctx_.run_mandatory_cleanup(window_id_, end_tag_);
   } catch (...) {
     // A mandatory-cleanup failure means the shared runtime can no longer be
     // trusted; the destructor must NOT run a second pass over half-cleaned
@@ -513,7 +523,7 @@ SiriusContext::StandaloneQueryScope::~StandaloneQueryScope() noexcept
   // One backstop cleanup attempt; on failure the runtime is latched
   // unavailable. The slot is released exactly once either way; logging is
   // noexcept-wrapped so the destructor can never terminate.
-  ctx_.run_mandatory_cleanup_backstop(end_tag_);
+  ctx_.run_mandatory_cleanup_backstop(window_id_, end_tag_);
   log_window_event("end", "unwind");
   ctx_.release_query_lifecycle_slot();
   state_ = scope_state::FAILED;
@@ -704,7 +714,8 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
     }
   }
 
-  data_repository_manager_ = std::make_unique<cucascade::shared_data_repository_manager>();
+  // Managers are created per execution window (begin_execution_window), not here; the registry
+  // starts empty and only ever holds entries for in-flight queries.
 
   // Create one downgrade executor per GPU memory space BEFORE task_scheduler,
   // so pointers are available for injection into gpu_pipeline_executors.
@@ -730,7 +741,7 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
       }
       auto executor = std::make_unique<sirius::parallel::downgrade_executor>(
         dg_cfg,
-        *data_repository_manager_,
+        data_repository_registry_,
         space->get_id(),
         const_cast<cucascade::memory::memory_space*>(space),
         *memory_manager_);
@@ -803,8 +814,10 @@ void SiriusContext::terminate()
 
   scan_manager_.reset();
 
-  // Drop any remaining repositories while the memory manager is still alive.
-  data_repository_manager_.reset();
+  // Drop any remaining per-query repositories while the memory manager is still alive. The
+  // downgrade executors (the only other holders of a manager reference) were stopped above, so
+  // no borrower can outlive this.
+  data_repository_registry_.clear();
 
   // Restore the previous cuDF pinned memory resource and threshold before destroying the
   // slab allocator — cuDF holds a non-owning reference and would dangle after reset().
@@ -841,16 +854,24 @@ const sirius::memory::sirius_memory_reservation_manager& SiriusContext::get_memo
   return *memory_manager_;
 }
 
-cucascade::shared_data_repository_manager& SiriusContext::get_data_repository_manager()
+sirius::data::data_repository_manager_registry::manager_ptr
+SiriusContext::get_data_repository_manager(sirius::query_id_t query_id) const
 {
   throw_if_not_initialized();
-  return *data_repository_manager_;
+  return data_repository_registry_.get(query_id);
 }
 
-const cucascade::shared_data_repository_manager& SiriusContext::get_data_repository_manager() const
+std::vector<sirius::data::data_repository_manager_registry::manager_ptr>
+SiriusContext::get_data_repository_managers() const
 {
   throw_if_not_initialized();
-  return *data_repository_manager_;
+  return data_repository_registry_.get_all();
+}
+
+sirius::data::data_repository_manager_registry& SiriusContext::get_data_repository_registry()
+{
+  throw_if_not_initialized();
+  return data_repository_registry_;
 }
 
 sirius::pipeline::task_scheduler& SiriusContext::get_task_scheduler()
@@ -925,11 +946,12 @@ std::shared_ptr<const sirius::telemetry::telemetry_context> SiriusContext::get_t
 
 void SiriusContext::create_query(
   duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>> pipelines,
+  sirius::query_id_t query_id,
   sirius::telemetry::query_telemetry_info telemetry_info)
 {
   throw_if_not_initialized();
   query_ = duckdb::make_shared_ptr<sirius::planner::query>(
-    std::move(pipelines), telemetry_context_->context(), telemetry_info);
+    std::move(pipelines), telemetry_context_->context(), query_id, telemetry_info);
   task_scheduler_->prepare_for_query(query_);
   task_creator_->prepare_for_query(*query_);
   scan_manager_->prepare_for_query(*query_,

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -274,8 +274,7 @@ void SiriusContext::begin_execution_window(ClientContext& context,
                                            std::string_view pool_tag)
 {
   // Runs inside the held slot, after acquire and the health check and before
-  // the final create_plan. Operator ids restart at 0 per query; u32 telemetry,
-  // hash-join partition tags and GPU placement key off them.
+  // the final create_plan.
   // Logging around the mutations is best-effort: a logging failure must never
   // leave the runtime half-begun (the mutations themselves are the only
   // throwing steps that matter; a throw here is handled by the scope ctor's
@@ -285,7 +284,6 @@ void SiriusContext::begin_execution_window(ClientContext& context,
     SIRIUS_LOG_INFO("QueryBegin: {}", window_label);
   } catch (...) {  // best-effort observability
   }
-  sirius::op::sirius_physical_operator::next_operator_id.store(0);
   task_creator_->reset();
   task_creator_->set_client_context(context);
 }

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -242,9 +242,6 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
   pipeline::sirius_pipeline_converter converter(build_ctx, op_params);
   auto result = converter.convert(*root_pipeline);
 
-  // Operator ids were stamped by the converter (see assign_operator_ids); repository wiring
-  // below is the first consumer of them. Ids restart at 0 per query, so they are only unique
-  // within this query's manager — hence the lookup by query_id rather than a shared manager.
   auto repo_manager = sirius_ctx_ptr->get_data_repository_manager(query_id_);
   if (!repo_manager) {
     throw sirius::internal_exception(

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -69,9 +69,12 @@ std::shared_ptr<const telemetry::telemetry_context> get_telemetry_context_from_c
 
 }  // namespace
 
-sirius_engine::sirius_engine(duckdb::ClientContext& context, sirius_interface& sirius_iface)
+sirius_engine::sirius_engine(duckdb::ClientContext& context,
+                             sirius_interface& sirius_iface,
+                             sirius::query_id_t query_id)
   : context(context),
     sirius_iface(sirius_iface),
+    query_id_(query_id),
     telemetry_context_(get_telemetry_context_from_client_context(this->context)),
     query_handle_(
       quent::query::create(telemetry_context_->context(),
@@ -138,11 +141,22 @@ void sirius_engine::execute()
     throw invalid_input_exception("Sirius context is not initialized.");
   }
 
+  // Quent mints its own UUID for the query and its Init struct takes no caller-supplied id, so
+  // telemetry stays UUID-native while the engine uses the numeric window id. Emit the mapping
+  // once so log lines (keyed by query id) and telemetry (keyed by UUID) can be joined.
+  auto const telemetry_uuid = query_handle_->uuid();
+  SIRIUS_LOG_INFO("query {} telemetry_query={:016x}{:016x}",
+                  query_id_,
+                  telemetry_uuid.high_bits,
+                  telemetry_uuid.low_bits);
+
   // Create the query with the pipelines
   sirius_ctx->create_query(std::move(new_scheduled),
+                           query_id_,
                            telemetry::query_telemetry_info{
-                             .query_id  = query_handle_->uuid(),
-                             .worker_id = telemetry_context_->worker_id(),
+                             .telemetry_query_id = telemetry_uuid,
+                             .worker_id          = telemetry_context_->worker_id(),
+                             .query_id           = query_id_,
                            });
   auto future = sirius_ctx->get_task_scheduler().start_query();
   try {
@@ -229,10 +243,18 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
   auto result = converter.convert(*root_pipeline);
 
   // Operator ids were stamped by the converter (see assign_operator_ids); repository wiring
-  // below is the first consumer of them.
+  // below is the first consumer of them. Ids restart at 0 per query, so they are only unique
+  // within this query's manager — hence the lookup by query_id rather than a shared manager.
+  auto repo_manager = sirius_ctx_ptr->get_data_repository_manager(query_id_);
+  if (!repo_manager) {
+    throw sirius::internal_exception(
+      "sirius_engine::initialize_internal: no data repository manager registered for query {}; "
+      "the engine must run inside a SiriusContext execution window",
+      query_id_);
+  }
+
   // Materialize plan-time wiring descriptors into runtime repositories and ports.
-  pipeline::materialize_repository_wiring(result.repository_wirings,
-                                          sirius_ctx_ptr->get_data_repository_manager());
+  pipeline::materialize_repository_wiring(result.repository_wirings, *repo_manager);
 
   new_scheduled   = std::move(result.scheduled_pipelines);
   total_pipelines = result.meta_pipeline_count;

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -228,16 +228,14 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
   pipeline::sirius_pipeline_converter converter(build_ctx, op_params);
   auto result = converter.convert(*root_pipeline);
 
+  // Operator ids were stamped by the converter (see assign_operator_ids); repository wiring
+  // below is the first consumer of them.
   // Materialize plan-time wiring descriptors into runtime repositories and ports.
   pipeline::materialize_repository_wiring(result.repository_wirings,
                                           sirius_ctx_ptr->get_data_repository_manager());
 
   new_scheduled   = std::move(result.scheduled_pipelines);
   total_pipelines = result.meta_pipeline_count;
-
-  // NOTE: dead code preserved for operator ID numbering stability
-  auto invalid_op = make_uniq<op::sirius_physical_operator>(
-    op::SiriusPhysicalOperatorType::INVALID, duckdb::vector<sirius::logical_type>{}, 0);
 
   // Collect all pipelines for progress tracking
   root_pipeline->get_pipelines(sirius_pipelines, true);

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -659,8 +659,8 @@ void SiriusExtension::GPUExecutionFunction(ClientContext& context,
           std::move(prepared), std::move(sirius_physical_plan));
 
         gstate.sirius_iface = make_uniq<::sirius::sirius_interface>(context, data.query_label);
-        gstate.res =
-          gstate.sirius_iface->sirius_execute_query(context, data.query, gpu_prepared, {});
+        gstate.res          = gstate.sirius_iface->sirius_execute_query(
+          context, data.query, gpu_prepared, {}, window->query_id());
         if (gstate.res->HasError()) {
           gpu_error = gstate.res->GetErrorObject();
           gstate.res.reset();

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -183,7 +183,7 @@ void Context::execute_substrait(const std::string& plan, std::uintptr_t out_stre
 
       sirius::sirius_interface iface(client, std::optional<std::string>(kQueryLabel));
       result = iface.sirius_execute_query(
-        client, kQueryLabel, gpu_prepared, duckdb::PendingQueryParameters{});
+        client, kQueryLabel, gpu_prepared, duckdb::PendingQueryParameters{}, window.query_id());
       window.finish();
     }
   } catch (...) {

--- a/src/sirius_interface.cpp
+++ b/src/sirius_interface.cpp
@@ -132,12 +132,13 @@ sirius_interface::sirius_pending_statement_or_prepared_statement(
   duckdb::ClientContext& context,
   const duckdb::string& query,
   duckdb::shared_ptr<sirius_prepared_statement_data>& statement_p,
-  const duckdb::PendingQueryParameters& parameters)
+  const duckdb::PendingQueryParameters& parameters,
+  sirius::query_id_t query_id)
 {
   begin_query_internal(query);
 
   duckdb::unique_ptr<duckdb::PendingQueryResult> pending =
-    sirius_pending_statement_internal(context, statement_p, parameters);
+    sirius_pending_statement_internal(context, statement_p, parameters, query_id);
 
   if (pending->HasError()) { return pending; }
   D_ASSERT(sirius_active_query->is_open_result(*pending));
@@ -148,18 +149,20 @@ sirius_interface::sirius_pending_statement_or_prepared_statement(
 duckdb::unique_ptr<duckdb::PendingQueryResult> sirius_interface::sirius_pending_statement_internal(
   duckdb::ClientContext& context,
   duckdb::shared_ptr<sirius_prepared_statement_data>& statement_p,
-  const duckdb::PendingQueryParameters& parameters)
+  const duckdb::PendingQueryParameters& parameters,
+  sirius::query_id_t query_id)
 {
   D_ASSERT(sirius_active_query);
   auto& statement = *(statement_p->prepared);
 
   bind_prepared_statement_parameters(statement, parameters);
 
-  duckdb::unique_ptr<sirius_engine> temp = duckdb::make_uniq<sirius_engine>(context, *this);
-  auto prop                              = temp->context.GetClientProperties();
-  sirius_active_query->engine            = std::move(temp);
-  auto& engine                           = get_sirius_engine();
-  bool stream_result                     = false;
+  duckdb::unique_ptr<sirius_engine> temp =
+    duckdb::make_uniq<sirius_engine>(context, *this, query_id);
+  auto prop                   = temp->context.GetClientProperties();
+  sirius_active_query->engine = std::move(temp);
+  auto& engine                = get_sirius_engine();
+  bool stream_result          = false;
 
   duckdb::unique_ptr<op::sirius_physical_result_collector> sirius_collector =
     duckdb::make_uniq_base<op::sirius_physical_result_collector,
@@ -215,11 +218,12 @@ duckdb::unique_ptr<duckdb::QueryResult> sirius_interface::sirius_execute_query(
   duckdb::ClientContext& context,
   const duckdb::string& query,
   duckdb::shared_ptr<sirius_prepared_statement_data>& statement_p,
-  const duckdb::PendingQueryParameters& parameters)
+  const duckdb::PendingQueryParameters& parameters,
+  sirius::query_id_t query_id)
 {
   try {
-    auto pending_query =
-      sirius_pending_statement_or_prepared_statement(context, query, statement_p, parameters);
+    auto pending_query = sirius_pending_statement_or_prepared_statement(
+      context, query, statement_p, parameters, query_id);
 
     if (pending_query->HasError()) {
       if (sirius_active_query) { cleanup_internal(nullptr, false); }

--- a/src/telemetry/telemetry_context.cpp
+++ b/src/telemetry/telemetry_context.cpp
@@ -244,7 +244,8 @@ void emit_plan_telemetry(
                         quent::plan::Declaration{
                           .parent =
                             quent::plan::Parent{
-                              .query_id = telemetry_info.query_id,
+                              // Quent's own query UUID, not the engine's numeric query id.
+                              .query_id = telemetry_info.telemetry_query_id,
                               .plan_id  = uuid::new_nil(),  // no parent plan
                             },
                           .instance_name = "pipeline_plan",

--- a/src/telemetry/telemetry_context.cpp
+++ b/src/telemetry/telemetry_context.cpp
@@ -183,7 +183,7 @@ void emit_plan_telemetry(
       std::string chain{};
       for (const auto& name : operators | std::views::transform([](const auto& op) {
                                 return std::format(
-                                  "{}({})", op.get().get_name(), op.get().operator_id);
+                                  "{}({})", op.get().get_name(), op.get().get_operator_id());
                               })) {
         if (chain.empty()) {
           chain = name;

--- a/src/telemetry/telemetry_context.cpp
+++ b/src/telemetry/telemetry_context.cpp
@@ -244,7 +244,6 @@ void emit_plan_telemetry(
                         quent::plan::Declaration{
                           .parent =
                             quent::plan::Parent{
-                              // Quent's own query UUID, not the engine's numeric query id.
                               .query_id = telemetry_info.telemetry_query_id,
                               .plan_id  = uuid::new_nil(),  // no parent plan
                             },

--- a/src/transparent/physical_sirius_execution.cpp
+++ b/src/transparent/physical_sirius_execution.cpp
@@ -237,7 +237,7 @@ duckdb::SourceResultType PhysicalSiriusExecution::GetDataInternal(
       // Execute via the standard sirius_interface path.
       duckdb::PendingQueryParameters parameters;
       state.result = state.iface->sirius_execute_query(
-        context.client, "transparent_execution", gpu_prepared, parameters);
+        context.client, "transparent_execution", gpu_prepared, parameters, window->query_id());
 
       if (state.result->HasError()) {
         gpu_error = state.result->GetErrorObject();

--- a/test/cpp/data/test_data_repository_manager_registry.cpp
+++ b/test/cpp/data/test_data_repository_manager_registry.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <data/data_repository_manager_registry.hpp>
+
+#include <memory>
+#include <vector>
+
+using sirius::query_id_t;
+using sirius::data::data_repository_manager_registry;
+
+namespace {
+
+const query_id_t kQueryA = sirius::make_query_id(1);
+const query_id_t kQueryB = sirius::make_query_id(2);
+
+}  // namespace
+
+TEST_CASE("registry: create_for_query registers a retrievable manager", "[repository_registry]")
+{
+  data_repository_manager_registry registry;
+  REQUIRE(registry.size() == 0);
+
+  auto manager = registry.create_for_query(kQueryA);
+  REQUIRE(manager != nullptr);
+  CHECK(registry.size() == 1);
+  // get() returns the same instance, not a copy.
+  CHECK(registry.get(kQueryA).get() == manager.get());
+}
+
+TEST_CASE("registry: get of an unregistered query returns nullptr", "[repository_registry]")
+{
+  data_repository_manager_registry registry;
+  CHECK(registry.get(kQueryA) == nullptr);
+
+  registry.create_for_query(kQueryA);
+  CHECK(registry.get(kQueryB) == nullptr);
+}
+
+TEST_CASE("registry: duplicate query id is rejected", "[repository_registry]")
+{
+  data_repository_manager_registry registry;
+  registry.create_for_query(kQueryA);
+  // Window ids are monotonic, so a duplicate signals a lifecycle bug rather than a
+  // recoverable state — it must not silently replace the in-flight query's manager.
+  CHECK_THROWS_AS(registry.create_for_query(kQueryA), std::runtime_error);
+  CHECK(registry.size() == 1);
+}
+
+TEST_CASE("registry: queries own independent managers", "[repository_registry]")
+{
+  data_repository_manager_registry registry;
+  auto manager_a = registry.create_for_query(kQueryA);
+  auto manager_b = registry.create_for_query(kQueryB);
+  REQUIRE(manager_a.get() != manager_b.get());
+
+  // Operator ids restart at 0 for every query, so the same {operator_id, port_id} key is
+  // registered in both managers. This is exactly what the single shared manager could not do.
+  manager_a->add_new_repository(0, "default", std::make_unique<cucascade::data_repository>());
+  CHECK_NOTHROW(
+    manager_b->add_new_repository(0, "default", std::make_unique<cucascade::data_repository>()));
+
+  CHECK(manager_a->get_repository(0, "default").get() !=
+        manager_b->get_repository(0, "default").get());
+}
+
+TEST_CASE("registry: erase drops only the named query", "[repository_registry]")
+{
+  data_repository_manager_registry registry;
+  auto manager_a = registry.create_for_query(kQueryA);
+  auto manager_b = registry.create_for_query(kQueryB);
+  manager_a->add_new_repository(0, "default", std::make_unique<cucascade::data_repository>());
+  manager_b->add_new_repository(0, "default", std::make_unique<cucascade::data_repository>());
+
+  registry.erase(kQueryA);
+
+  CHECK(registry.get(kQueryA) == nullptr);
+  REQUIRE(registry.get(kQueryB) != nullptr);
+  CHECK(registry.size() == 1);
+  // The surviving query's repositories are untouched — the property the wholesale
+  // clear_all_repositories() teardown could not provide.
+  CHECK_NOTHROW(manager_b->get_repository(0, "default"));
+}
+
+TEST_CASE("registry: erasing an unknown query is a no-op", "[repository_registry]")
+{
+  data_repository_manager_registry registry;
+  registry.create_for_query(kQueryA);
+
+  auto leaked = registry.erase(kQueryB);
+
+  CHECK(leaked.empty());
+  CHECK(registry.size() == 1);
+  CHECK(registry.get(kQueryA) != nullptr);
+}
+
+TEST_CASE("registry: erase reports repositories that still held batches", "[repository_registry]")
+{
+  data_repository_manager_registry registry;
+  auto manager = registry.create_for_query(kQueryA);
+  manager->add_new_repository(7, "build", std::make_unique<cucascade::data_repository>());
+
+  // Nothing was pushed, so a clean query reports no leaks.
+  auto leaked = registry.erase(kQueryA);
+  CHECK(leaked.empty());
+}
+
+TEST_CASE("registry: get_all returns every manager in ascending query order",
+          "[repository_registry]")
+{
+  data_repository_manager_registry registry;
+  // Registered out of order to prove the ordering comes from the container, not insertion.
+  auto manager_b = registry.create_for_query(kQueryB);
+  auto manager_a = registry.create_for_query(kQueryA);
+
+  auto all = registry.get_all();
+
+  REQUIRE(all.size() == 2);
+  // Ascending query id keeps downgrade spill-candidate selection reproducible across runs.
+  CHECK(all[0].get() == manager_a.get());
+  CHECK(all[1].get() == manager_b.get());
+}
+
+TEST_CASE("registry: a borrowed manager outlives erase", "[repository_registry]")
+{
+  data_repository_manager_registry registry;
+  // Mirrors a downgrade worker holding a manager from get_all() while the query ends.
+  auto borrowed = registry.create_for_query(kQueryA);
+  std::weak_ptr<cucascade::shared_data_repository_manager> observer = borrowed;
+
+  registry.erase(kQueryA);
+
+  CHECK(registry.get(kQueryA) == nullptr);
+  // Shared ownership means the manager object survives until the borrower releases it,
+  // instead of leaving the worker with a dangling reference.
+  CHECK_FALSE(observer.expired());
+
+  borrowed.reset();
+  CHECK(observer.expired());
+}
+
+TEST_CASE("registry: clear drops every manager", "[repository_registry]")
+{
+  data_repository_manager_registry registry;
+  registry.create_for_query(kQueryA);
+  registry.create_for_query(kQueryB);
+
+  registry.clear();
+
+  CHECK(registry.size() == 0);
+  CHECK(registry.get(kQueryA) == nullptr);
+  CHECK(registry.get(kQueryB) == nullptr);
+  CHECK(registry.get_all().empty());
+  // After clear the ids are free again, so teardown followed by reuse is legal.
+  CHECK_NOTHROW(registry.create_for_query(kQueryA));
+}

--- a/test/cpp/downgrade/test_downgrade_disk.cpp
+++ b/test/cpp/downgrade/test_downgrade_disk.cpp
@@ -18,6 +18,7 @@
 
 // sirius
 #include "data/convertible_data_batch.hpp"
+#include "data/data_repository_manager_registry.hpp"
 #include "downgrade/downgrade_executor.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 
@@ -114,6 +115,10 @@ std::vector<std::unique_ptr<cucascade::memory::reservation>> exhaust_host_capaci
 
 const auto GPU_SPACE_ID = cucascade::memory::memory_space_id(cucascade::memory::Tier::GPU, 0);
 
+// These tests exercise a single query's repositories; the executor sweeps the registry,
+// so each test registers its manager under one fixed query id.
+const sirius::query_id_t kTestQueryId = sirius::make_query_id(1);
+
 // Build a manager with a small HOST tier and NO disk, with a low GPU downgrade trigger so that
 // modest GPU pressure is enough to keep should_downgrade_memory() true. Used to reproduce the
 // "monitor spins because nothing can be downgraded" scenario.
@@ -142,14 +147,15 @@ std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> make_no_disk_
   return manager;
 }
 
-downgrade_executor make_monitoring_executor(cucascade::shared_data_repository_manager& repo_mgr,
-                                            cucascade::memory::memory_space* gpu_space,
-                                            sirius::memory::sirius_memory_reservation_manager& mgr)
+downgrade_executor make_monitoring_executor(
+  sirius::data::data_repository_manager_registry& repo_registry,
+  cucascade::memory::memory_space* gpu_space,
+  sirius::memory::sirius_memory_reservation_manager& mgr)
 {
   sirius::exec::downgrade_executor_config config{
     .thread_pool    = {.num_threads = 1, .thread_name_prefix = "downgrade"},
     .monitor_period = std::chrono::milliseconds{10}};
-  return downgrade_executor(config, repo_mgr, GPU_SPACE_ID, gpu_space, mgr);
+  return downgrade_executor(config, repo_registry, GPU_SPACE_ID, gpu_space, mgr);
 }
 
 }  // namespace
@@ -333,8 +339,9 @@ TEST_CASE("monitor backs off when no downgrade target is viable (no disk)", "[do
   REQUIRE(gpu_hold);
   REQUIRE(gpu_space->should_downgrade_memory());
 
-  cucascade::shared_data_repository_manager repo_mgr;
-  auto executor = make_monitoring_executor(repo_mgr, gpu_space, *mem_mgr);
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
+  auto executor  = make_monitoring_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   using namespace std::chrono_literals;
@@ -366,8 +373,9 @@ TEST_CASE("monitor resumes after a downgrade target frees up (no disk)", "[downg
   REQUIRE(gpu_hold);
   REQUIRE(gpu_space->should_downgrade_memory());
 
-  cucascade::shared_data_repository_manager repo_mgr;
-  auto executor = make_monitoring_executor(repo_mgr, gpu_space, *mem_mgr);
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
+  auto executor  = make_monitoring_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   using namespace std::chrono_literals;
@@ -430,8 +438,9 @@ TEST_CASE("monitor backs off when HOST is full of stored downgraded data (no dis
   REQUIRE(gpu_hold);
   REQUIRE(gpu_space->should_downgrade_memory());
 
-  cucascade::shared_data_repository_manager repo_mgr;
-  auto executor = make_monitoring_executor(repo_mgr, gpu_space, *mem_mgr);
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
+  auto executor  = make_monitoring_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   using namespace std::chrono_literals;
@@ -470,8 +479,9 @@ TEST_CASE("HOST-source monitor backs off when no disk is configured", "[downgrad
   sirius::exec::downgrade_executor_config config{
     .thread_pool    = {.num_threads = 1, .thread_name_prefix = "downgrade-host"},
     .monitor_period = std::chrono::milliseconds{10}};
-  cucascade::shared_data_repository_manager repo_mgr;
-  downgrade_executor executor(config, repo_mgr, host_space->get_id(), host_space, *mem_mgr);
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
+  downgrade_executor executor(config, repo_registry, host_space->get_id(), host_space, *mem_mgr);
   executor.start();
 
   using namespace std::chrono_literals;

--- a/test/cpp/downgrade/test_downgrade_executor.cpp
+++ b/test/cpp/downgrade/test_downgrade_executor.cpp
@@ -17,6 +17,7 @@
 #include "catch.hpp"
 
 // sirius
+#include "data/data_repository_manager_registry.hpp"
 #include "downgrade/downgrade_executor.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 // data utilities
@@ -63,6 +64,10 @@ size_t get_batch_size(cucascade::data_batch& batch)
 }
 
 const auto GPU_SPACE_ID = cucascade::memory::memory_space_id(cucascade::memory::Tier::GPU, 0);
+
+// These tests exercise a single query's repositories; the executor sweeps the registry,
+// so each test registers its manager under one fixed query id.
+const sirius::query_id_t kTestQueryId = sirius::make_query_id(1);
 
 std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> make_test_memory_manager()
 {
@@ -118,14 +123,14 @@ std::shared_ptr<cucascade::data_batch> make_gpu_batch(cucascade::memory::memory_
  *
  * Pass nullptr for memory_space when the monitor loop shouldn't trigger automatically.
  */
-downgrade_executor make_test_executor(cucascade::shared_data_repository_manager& repo_mgr,
+downgrade_executor make_test_executor(sirius::data::data_repository_manager_registry& repo_registry,
                                       cucascade::memory::memory_space* gpu_space,
                                       sirius::memory::sirius_memory_reservation_manager& mem_mgr)
 {
   sirius::exec::downgrade_executor_config config{
     .thread_pool    = {.num_threads = 1, .thread_name_prefix = "downgrade"},
     .monitor_period = std::chrono::milliseconds{0}};
-  return downgrade_executor(config, repo_mgr, GPU_SPACE_ID, gpu_space, mem_mgr);
+  return downgrade_executor(config, repo_registry, GPU_SPACE_ID, gpu_space, mem_mgr);
 }
 
 }  // namespace
@@ -138,10 +143,11 @@ TEST_CASE("Downgrade executor starts and stops cleanly", "[downgrade_executor]")
 {
   auto mem_mgr    = make_test_memory_manager();
   auto* gpu_space = get_gpu_space(*mem_mgr);
-  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
 
   // nullptr memory_space — monitor loop won't trigger, just tests lifecycle
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
 
   REQUIRE_NOTHROW(executor.start());
   REQUIRE_NOTHROW(executor.stop());
@@ -151,9 +157,10 @@ TEST_CASE("request_free_memory_and_wait with no repositories returns 0", "[downg
 {
   auto mem_mgr    = make_test_memory_manager();
   auto* gpu_space = get_gpu_space(*mem_mgr);
-  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   size_t freed = executor.request_free_memory_and_wait(1024);
@@ -168,11 +175,12 @@ TEST_CASE("request_free_memory_and_wait downgrades GPU batches to HOST", "[downg
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
-  auto repo   = std::make_unique<cucascade::shared_data_repository>();
-  auto batch1 = make_gpu_batch(*gpu_space);
-  auto batch2 = make_gpu_batch(*gpu_space);
-  auto batch3 = make_gpu_batch(*gpu_space);
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
+  auto repo      = std::make_unique<cucascade::shared_data_repository>();
+  auto batch1    = make_gpu_batch(*gpu_space);
+  auto batch2    = make_gpu_batch(*gpu_space);
+  auto batch3    = make_gpu_batch(*gpu_space);
   repo->add_data_batch(batch1);
   repo->add_data_batch(batch2);
   repo->add_data_batch(batch3);
@@ -182,7 +190,7 @@ TEST_CASE("request_free_memory_and_wait downgrades GPU batches to HOST", "[downg
   REQUIRE(get_batch_tier(*batch2) == cucascade::memory::Tier::GPU);
   REQUIRE(get_batch_tier(*batch3) == cucascade::memory::Tier::GPU);
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   size_t freed = executor.request_free_memory_and_wait(1ull << 30);
@@ -201,8 +209,9 @@ TEST_CASE("request_free_memory respects byte target via predicate", "[downgrade_
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
-  auto repo = std::make_unique<cucascade::shared_data_repository>();
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
+  auto repo      = std::make_unique<cucascade::shared_data_repository>();
   std::vector<std::shared_ptr<cucascade::data_batch>> batches;
   for (int i = 0; i < 5; ++i) {
     auto batch = make_gpu_batch(*gpu_space);
@@ -214,7 +223,7 @@ TEST_CASE("request_free_memory respects byte target via predicate", "[downgrade_
   size_t one_batch_size = get_batch_size(*batches[0]);
   REQUIRE(one_batch_size > 0);
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   size_t freed = executor.request_free_memory_and_wait(one_batch_size);
@@ -239,7 +248,8 @@ TEST_CASE("request_free_memory downgrades across multiple repos", "[downgrade_ex
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
 
   auto repo_non_partitioned = std::make_unique<cucascade::shared_data_repository>();
   auto batch_np1            = make_gpu_batch(*gpu_space);
@@ -260,7 +270,7 @@ TEST_CASE("request_free_memory downgrades across multiple repos", "[downgrade_ex
 
   size_t one_batch_size = get_batch_size(*batch_p0);
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   // Request enough to downgrade at least one batch
@@ -283,12 +293,13 @@ TEST_CASE("request_free_memory iterates partitions from last to first", "[downgr
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
-  auto repo     = std::make_unique<cucascade::shared_data_repository>();
-  auto batch_p0 = make_gpu_batch(*gpu_space);
-  auto batch_p1 = make_gpu_batch(*gpu_space);
-  auto batch_p2 = make_gpu_batch(*gpu_space);
-  auto batch_p3 = make_gpu_batch(*gpu_space);
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
+  auto repo      = std::make_unique<cucascade::shared_data_repository>();
+  auto batch_p0  = make_gpu_batch(*gpu_space);
+  auto batch_p1  = make_gpu_batch(*gpu_space);
+  auto batch_p2  = make_gpu_batch(*gpu_space);
+  auto batch_p3  = make_gpu_batch(*gpu_space);
   repo->add_data_batch(batch_p0, 0);
   repo->add_data_batch(batch_p1, 1);
   repo->add_data_batch(batch_p2, 2);
@@ -297,7 +308,7 @@ TEST_CASE("request_free_memory iterates partitions from last to first", "[downgr
 
   size_t two_batches = get_batch_size(*batch_p0) * 2;
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   size_t freed = executor.request_free_memory_and_wait(two_batches);
@@ -317,11 +328,12 @@ TEST_CASE("request_free_memory skips active partitions in first pass", "[downgra
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
-  auto repo     = std::make_unique<cucascade::shared_data_repository>();
-  auto batch_p0 = make_gpu_batch(*gpu_space);
-  auto batch_p1 = make_gpu_batch(*gpu_space);
-  auto batch_p2 = make_gpu_batch(*gpu_space);
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
+  auto repo      = std::make_unique<cucascade::shared_data_repository>();
+  auto batch_p0  = make_gpu_batch(*gpu_space);
+  auto batch_p1  = make_gpu_batch(*gpu_space);
+  auto batch_p2  = make_gpu_batch(*gpu_space);
   repo->add_data_batch(batch_p0, 0);
   repo->add_data_batch(batch_p1, 1);
   repo->add_data_batch(batch_p2, 2);
@@ -332,7 +344,7 @@ TEST_CASE("request_free_memory skips active partitions in first pass", "[downgra
 
   size_t three_batches = get_batch_size(*batch_p0) * 3;
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   size_t freed = executor.request_free_memory_and_wait(three_batches);
@@ -355,7 +367,8 @@ TEST_CASE("request_free_memory skips batches already on HOST", "[downgrade_execu
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr  = *repo_registry.create_for_query(kTestQueryId);
   auto repo       = std::make_unique<cucascade::shared_data_repository>();
   auto gpu_batch  = make_gpu_batch(*gpu_space);
   auto gpu_batch2 = make_gpu_batch(*gpu_space);
@@ -381,7 +394,7 @@ TEST_CASE("request_free_memory skips batches already on HOST", "[downgrade_execu
 
   repo_mgr.add_new_repository(1, "out", std::move(repo));
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   size_t freed = executor.request_free_memory_and_wait(1ull << 30);
@@ -399,13 +412,14 @@ TEST_CASE("request_free_memory returns future that resolves to bytes freed", "[d
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
-  auto repo  = std::make_unique<cucascade::shared_data_repository>();
-  auto batch = make_gpu_batch(*gpu_space);
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
+  auto repo      = std::make_unique<cucascade::shared_data_repository>();
+  auto batch     = make_gpu_batch(*gpu_space);
   repo->add_data_batch(batch);
   repo_mgr.add_new_repository(1, "out", std::move(repo));
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   auto future  = executor.request_free_memory(1ull << 30);
@@ -422,8 +436,9 @@ TEST_CASE("request_downgrade with custom predicate stops when satisfied", "[down
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
-  auto repo = std::make_unique<cucascade::shared_data_repository>();
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
+  auto repo      = std::make_unique<cucascade::shared_data_repository>();
   std::vector<std::shared_ptr<cucascade::data_batch>> batches;
   for (int i = 0; i < 5; ++i) {
     auto batch = make_gpu_batch(*gpu_space);
@@ -434,7 +449,7 @@ TEST_CASE("request_downgrade with custom predicate stops when satisfied", "[down
 
   std::atomic<size_t> call_count{0};
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   // Predicate returns true on first call — should stop after ~1 batch
@@ -464,14 +479,15 @@ TEST_CASE("request_free_memory partial fulfillment returns actual bytes freed",
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr    = *repo_registry.create_for_query(kTestQueryId);
   auto repo         = std::make_unique<cucascade::shared_data_repository>();
   auto batch        = make_gpu_batch(*gpu_space);
   size_t batch_size = get_batch_size(*batch);
   repo->add_data_batch(batch);
   repo_mgr.add_new_repository(1, "out", std::move(repo));
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   // Request far more than available

--- a/test/cpp/downgrade/test_downgrade_lifecycle.cpp
+++ b/test/cpp/downgrade/test_downgrade_lifecycle.cpp
@@ -17,6 +17,7 @@
 #include "catch.hpp"
 
 // sirius
+#include "data/data_repository_manager_registry.hpp"
 #include "downgrade/downgrade_executor.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 
@@ -52,6 +53,10 @@ using namespace std::chrono_literals;
 namespace {
 
 const auto GPU_SPACE_ID = cucascade::memory::memory_space_id(cucascade::memory::Tier::GPU, 0);
+
+// These tests exercise a single query's repositories; the executor sweeps the registry,
+// so each test registers its manager under one fixed query id.
+const sirius::query_id_t kTestQueryId = sirius::make_query_id(1);
 
 /// Helper: get the tier of a data_batch using a temporary read-only lock.
 inline cucascade::memory::Tier get_batch_tier(cucascade::data_batch& batch)
@@ -109,7 +114,7 @@ std::shared_ptr<cucascade::data_batch> make_gpu_batch(cucascade::memory::memory_
     std::move(table), gpu_space, stream, sirius::telemetry::batch_telemetry_info{});
 }
 
-downgrade_executor make_test_executor(cucascade::shared_data_repository_manager& repo_mgr,
+downgrade_executor make_test_executor(sirius::data::data_repository_manager_registry& repo_registry,
                                       cucascade::memory::memory_space* gpu_space,
                                       sirius::memory::sirius_memory_reservation_manager& mem_mgr,
                                       std::chrono::milliseconds monitor_period = {})
@@ -117,7 +122,7 @@ downgrade_executor make_test_executor(cucascade::shared_data_repository_manager&
   sirius::exec::downgrade_executor_config config{
     .thread_pool    = {.num_threads = 1, .thread_name_prefix = "downgrade"},
     .monitor_period = monitor_period};
-  return downgrade_executor(config, repo_mgr, GPU_SPACE_ID, gpu_space, mem_mgr);
+  return downgrade_executor(config, repo_registry, GPU_SPACE_ID, gpu_space, mem_mgr);
 }
 
 }  // namespace
@@ -130,10 +135,11 @@ TEST_CASE("start_stop_cycle", "[downgrade_lifecycle]")
 {
   auto mem_mgr    = make_test_memory_manager();
   auto* gpu_space = get_gpu_space(*mem_mgr);
-  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
 
   // nullptr memory_space -- monitor loop won't trigger
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
 
   // First start/stop cycle
   REQUIRE_NOTHROW(executor.start());
@@ -159,7 +165,8 @@ TEST_CASE("drain_clears_pending_requests", "[downgrade_lifecycle]")
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
 
   // Create a repo with some batches and register with manager
   auto repo   = std::make_unique<cucascade::shared_data_repository>();
@@ -171,7 +178,7 @@ TEST_CASE("drain_clears_pending_requests", "[downgrade_lifecycle]")
   repo->add_data_batch(batch3);
   repo_mgr.add_new_repository(1, "out", std::move(repo));
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   // Request downgrade of all GPU data
@@ -216,7 +223,8 @@ TEST_CASE("drain_releases_batch_references", "[downgrade_lifecycle]")
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
 
   // Create a repo with GPU data and register with manager
   auto repo  = std::make_unique<cucascade::shared_data_repository>();
@@ -226,7 +234,7 @@ TEST_CASE("drain_releases_batch_references", "[downgrade_lifecycle]")
 
   REQUIRE(get_batch_tier(*batch) == cucascade::memory::Tier::GPU);
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   // Record the use_count before scheduling -- the test holds a reference
@@ -261,7 +269,8 @@ TEST_CASE("monitor_loop_triggers_downgrade", "[downgrade_lifecycle]")
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
 
   // Create a repo with GPU data and register it with the manager
   auto repo   = std::make_unique<cucascade::shared_data_repository>();
@@ -279,7 +288,7 @@ TEST_CASE("monitor_loop_triggers_downgrade", "[downgrade_lifecycle]")
 
   // Start executor with monitor enabled (non-zero period)
   auto executor = make_test_executor(
-    repo_mgr, gpu_space, *mem_mgr, /*monitor_period=*/std::chrono::milliseconds{10});
+    repo_registry, gpu_space, *mem_mgr, /*monitor_period=*/std::chrono::milliseconds{10});
   executor.start();
 
   // Wait up to 2s for the monitor to detect pressure and trigger downgrade.
@@ -321,9 +330,10 @@ TEST_CASE("concurrent_api_safety", "[downgrade_lifecycle]")
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   // Launch 4 threads, each requesting memory reclamation concurrently.
@@ -389,9 +399,10 @@ TEST_CASE("stop_cancels_pending_requests", "[downgrade_lifecycle]")
 {
   auto mem_mgr    = make_test_memory_manager();
   auto* gpu_space = get_gpu_space(*mem_mgr);
-  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   // Enqueue several requests then immediately stop.
@@ -421,9 +432,10 @@ TEST_CASE("drain_cancels_pending_requests_with_exception", "[downgrade_lifecycle
 {
   auto mem_mgr    = make_test_memory_manager();
   auto* gpu_space = get_gpu_space(*mem_mgr);
-  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
   executor.start();
 
   std::vector<std::future<size_t>> futures;
@@ -456,9 +468,10 @@ TEST_CASE("cuda_stream_lifecycle", "[downgrade_lifecycle]")
   auto* gpu_space = get_gpu_space(*mem_mgr);
   REQUIRE(gpu_space != nullptr);
 
-  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::data::data_repository_manager_registry repo_registry;
+  auto& repo_mgr = *repo_registry.create_for_query(kTestQueryId);
 
-  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  auto executor = make_test_executor(repo_registry, gpu_space, *mem_mgr);
 
   // First start -- stream should be created
   executor.start();

--- a/test/cpp/operator/test_physical_concat.cpp
+++ b/test/cpp/operator/test_physical_concat.cpp
@@ -58,6 +58,16 @@ struct hash_join_test_fixture {
   duckdb::unique_ptr<sirius_physical_hash_join> hash_join;
 };
 
+//! Depth-first, root-first numbering of a bare operator tree, standing in for
+//! pipeline::assign_operator_ids in fixtures that never build pipelines.
+void number_operator_tree(sirius_physical_operator& op, size_t& next_id)
+{
+  op.operator_id = next_id++;
+  for (auto& child : op.children) {
+    if (child) { number_operator_tree(*child, next_id); }
+  }
+}
+
 /**
  * @brief Create a minimal sirius_physical_hash_join for testing concat.
  *
@@ -109,6 +119,12 @@ hash_join_test_fixture create_test_hash_join(
     sirius::config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES,
     sirius::op::dynamic_filter_publish_plan{},  // dynamic_filter_plan
     hash_partition_bytes);
+
+  // These fixtures build a bare operator tree with no pipelines, so the converter's
+  // assign_operator_ids never runs over it. Number it here — operator code reads
+  // get_operator_id(), which rejects the unassigned sentinel.
+  size_t next_id = 0;
+  number_operator_tree(*fixture.hash_join, next_id);
 
   return fixture;
 }
@@ -667,6 +683,11 @@ TEST_CASE("right-family sibling partitions round up from the probe input", "[phy
   };
   sirius_physical_partition build_partition(make_types(), 4, fixture.hash_join.get(), true);
   sirius_physical_partition probe_partition(make_types(), 9, fixture.hash_join.get(), false);
+  // These partitions hang off the join by pointer, not as children, so create_test_hash_join's
+  // numbering does not reach them. Number them past the join tree's ids.
+  size_t partition_next_id = 100;
+  number_operator_tree(build_partition, partition_next_id);
+  number_operator_tree(probe_partition, partition_next_id);
   build_partition.set_sibling_partition_op(&probe_partition);
   probe_partition.set_sibling_partition_op(&build_partition);
   build_partition.set_drives_partition_count(false);

--- a/test/cpp/operator/test_physical_mark_join.cpp
+++ b/test/cpp/operator/test_physical_mark_join.cpp
@@ -48,6 +48,16 @@ struct mark_join_fixture {
   duckdb::unique_ptr<sirius_physical_hash_join> hash_join;
 };
 
+//! Depth-first, root-first numbering of a bare operator tree, standing in for
+//! pipeline::assign_operator_ids in fixtures that never build pipelines.
+void number_operator_tree(sirius::op::sirius_physical_operator& op, size_t& next_id)
+{
+  op.operator_id = next_id++;
+  for (auto& child : op.children) {
+    if (child) { number_operator_tree(*child, next_id); }
+  }
+}
+
 struct nlj_projection_fixture {
   duckdb::unique_ptr<duckdb::LogicalComparisonJoin> logical_join;
   duckdb::unique_ptr<sirius_physical_nested_loop_join> nlj;
@@ -98,6 +108,11 @@ mark_join_fixture create_mark_join()
     sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{}),  // delim_types
     1000,
     nullptr);
+
+  // No pipelines exist in this fixture, so the converter's assign_operator_ids never runs.
+  // Number the tree here — operator code reads get_operator_id(), which rejects the sentinel.
+  size_t next_id = 0;
+  number_operator_tree(*f.hash_join, next_id);
 
   return f;
 }

--- a/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
@@ -24,6 +24,7 @@
 #include "op/sirius_physical_operator.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
 #include "pipeline/oom_reschedule_exception.hpp"
+#include "pipeline/repository_wiring.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 #include "pipeline/sirius_pipeline_task_states.hpp"
 #include "utils/telemetry_utils.hpp"
@@ -204,6 +205,10 @@ pipeline_context create_pipeline_context()
   build_state.set_pipeline_source(*ctx.pipeline, *ctx.stub_source);
   build_state.add_pipeline_operator(*ctx.pipeline, *ctx.stub_op);
   build_state.set_pipeline_sink(*ctx.pipeline, *ctx.stub_op, 1);
+
+  // Number the stubs as the converter does in production; task execution reads operator ids.
+  duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>> pipelines{ctx.pipeline};
+  sirius::pipeline::assign_operator_ids(pipelines);
   return ctx;
 }
 

--- a/test/cpp/pipeline/test_plan_printer.cpp
+++ b/test/cpp/pipeline/test_plan_printer.cpp
@@ -43,6 +43,7 @@
 #include <sirius_engine.hpp>
 #include <sirius_extension.hpp>
 #include <sirius_interface.hpp>
+#include <utils/pipeline_conversion_test_utils.hpp>
 
 // duckdb
 #include <duckdb.hpp>
@@ -465,6 +466,10 @@ struct engine_test_state {
   // Owns the physical plan and its DuckDB RowGroups. Must destruct after `engine` (which
   // references the plan) but before `db` (RowGroups free blocks via db's buffer manager).
   duckdb::shared_ptr<sirius_prepared_statement_data> prepared;
+  // Registers this plan's data repository manager (no execution window is opened here).
+  // Declared before `engine` so it is destroyed after it — the engine's repositories live in
+  // the manager this owns.
+  std::unique_ptr<sirius::test::scoped_test_query> test_query;
   duckdb::unique_ptr<sirius_engine> engine;
 };
 
@@ -487,8 +492,10 @@ engine_test_state setup_and_initialize(const std::string& query)
   auto gpu_plan = generate_gpu_plan(*state.con, query, state.prepared);
   REQUIRE(gpu_plan != nullptr);
 
-  state.iface  = duckdb::make_uniq<sirius_interface>(*state.con->context);
-  state.engine = duckdb::make_uniq<sirius_engine>(*state.con->context, *state.iface);
+  state.iface      = duckdb::make_uniq<sirius_interface>(*state.con->context);
+  state.test_query = std::make_unique<sirius::test::scoped_test_query>(*state.con->context);
+  state.engine     = duckdb::make_uniq<sirius_engine>(
+    *state.con->context, *state.iface, state.test_query->query_id());
   state.engine->initialize(std::move(gpu_plan));
 
   return state;

--- a/test/cpp/pipeline/test_repository_wiring_materializer.cpp
+++ b/test/cpp/pipeline/test_repository_wiring_materializer.cpp
@@ -51,10 +51,18 @@ class wiring_test_env {
 
   duckdb::shared_ptr<sirius_pipeline> make_pipeline()
   {
-    return duckdb::make_shared_ptr<sirius_pipeline>(build_ctx);
+    auto pipeline = duckdb::make_shared_ptr<sirius_pipeline>(build_ctx);
+    pipelines.push_back(pipeline);
+    return pipeline;
   }
 
+  // Number every operator built so far, exactly as sirius_engine does between pipeline
+  // conversion and repository wiring. materialize_repository_wiring reads operator ids,
+  // so this must run first.
+  void assign_ids() { sirius::pipeline::assign_operator_ids(pipelines); }
+
   sirius::pipeline::pipeline_build_context build_ctx{nullptr};
+  duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> pipelines;
 };
 
 // Build a pipeline with the given sink and operator list. `operators` may be
@@ -98,6 +106,8 @@ TEST_CASE("materialize: basic 4-arg-style wiring attaches port and records sink 
                                              src_pipeline,
                                              dest_pipeline}};
 
+  env.assign_ids();
+
   materialize_repository_wiring(wirings, mgr);
 
   // Port should land on dest_first_op (operators[0]), not on dest_sink.
@@ -137,6 +147,8 @@ TEST_CASE("materialize: empty operators routes port onto destination sink",
                                              src_pipeline,
                                              dest_pipeline}};
 
+  env.assign_ids();
+
   materialize_repository_wiring(wirings, mgr);
 
   auto* port = dest_sink.get_port("scan");
@@ -171,6 +183,8 @@ TEST_CASE("materialize: explicit source op (5-arg-style) records fanout on the s
                                              &sub_emitter,  // explicit source op
                                              src_pipeline,
                                              dest_pipeline}};
+
+  env.assign_ids();
 
   materialize_repository_wiring(wirings, mgr);
 
@@ -212,6 +226,8 @@ TEST_CASE("materialize: multiple wirings to the same destination attach distinct
      build_pipeline_handle,
      dest_pipeline},
   };
+
+  env.assign_ids();
 
   materialize_repository_wiring(wirings, mgr);
 
@@ -274,6 +290,7 @@ TEST_CASE("materialize: delim join destinations use the generic path with no sib
 
   // Must not throw (the LEFT-delim "should never be a source" invariant is gone), and the port
   // lands only on the destination's operators[0].
+  env.assign_ids();
   REQUIRE_NOTHROW(materialize_repository_wiring(wirings, mgr));
 
   auto* delim_port = right_delim->get_port("build");

--- a/test/cpp/planner/test_query_id.cpp
+++ b/test/cpp/planner/test_query_id.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "planner/query.hpp"
+#include "query_id.hpp"
+#include "utils/telemetry_utils.hpp"
+
+#include <catch.hpp>
+
+#include <cstdint>
+#include <format>
+#include <limits>
+
+using sirius::make_query_id;
+using sirius::query_id_t;
+using sirius::query_priority_bits;
+using sirius::value_of;
+
+TEST_CASE("query_id: round-trips through its underlying value", "[query_id]")
+{
+  CHECK(value_of(make_query_id(0)) == 0U);
+  CHECK(value_of(make_query_id(42)) == 42U);
+  CHECK(value_of(make_query_id(std::numeric_limits<std::uint32_t>::max())) ==
+        std::numeric_limits<std::uint32_t>::max());
+}
+
+TEST_CASE("query_id: orders by underlying value", "[query_id]")
+{
+  // std::map in the repository registry relies on this ordering for its ascending get_all().
+  CHECK(make_query_id(1) < make_query_id(2));
+  CHECK(make_query_id(2) > make_query_id(1));
+  CHECK(make_query_id(7) == make_query_id(7));
+}
+
+TEST_CASE("query_id: formats as its numeric value", "[query_id]")
+{
+  // Logging is std::format-based and C++20 has no built-in enum formatting, so query_id_t
+  // carries its own formatter; without it every log site would need a cast.
+  CHECK(std::format("{}", make_query_id(1234)) == "1234");
+}
+
+TEST_CASE("query_id: priority bits place the id above the pipeline rank", "[query_id]")
+{
+  // The low 32 bits are left free for the within-query pipeline rank.
+  CHECK(query_priority_bits(make_query_id(0)) == 0);
+  CHECK(query_priority_bits(make_query_id(1)) == (std::int64_t{1} << 32));
+  CHECK(query_priority_bits(make_query_id(3)) == (std::int64_t{3} << 32));
+}
+
+TEST_CASE("query_id: an earlier query always sorts before a later one", "[query_id]")
+{
+  // The priority queue pops the lowest value first, so every task of query N (even its last
+  // pipeline) must sort ahead of query N+1's first pipeline.
+  constexpr std::int64_t max_rank = 0xFFFF'FFFF;
+  const auto earlier_last         = query_priority_bits(make_query_id(5)) | max_rank;
+  const auto later_first          = query_priority_bits(make_query_id(6));
+  CHECK(earlier_last < later_first);
+}
+
+TEST_CASE("query_id: priority bits stay non-negative with bit 31 set", "[query_id]")
+{
+  // Regression: queue_priority is SIGNED. Before masking, an id >= 2^31 shifted into the sign
+  // bit, making the packed priority negative and inverting the "earlier query first" ordering.
+  const auto high_id = make_query_id(0x8000'0000U);
+  CHECK(query_priority_bits(high_id) >= 0);
+
+  const auto higher_id = make_query_id(0xFFFF'FFFFU);
+  CHECK(query_priority_bits(higher_id) >= 0);
+
+  // The mask is what makes this hold: bit 31 is dropped rather than shifted into the sign bit.
+  CHECK(query_priority_bits(high_id) == query_priority_bits(make_query_id(0)));
+}
+
+TEST_CASE("planner::query reports the id it was constructed with", "[query_id]")
+{
+  // The query no longer mints its own id from a private counter; it must carry the execution
+  // window's id so repositories, scheduling and window logs all agree.
+  auto tctx           = sirius::test::make_test_telemetry_context();
+  const auto query_id = make_query_id(9876);
+  sirius::telemetry::query_telemetry_info tinfo{
+    tctx->engine_id(), tctx->worker_id(), query_id};
+
+  sirius::planner::query q(
+    duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>>{},
+    tctx->context(),
+    query_id,
+    tinfo);
+
+  CHECK(q.query_id() == query_id);
+}
+
+TEST_CASE("planner::query ids are not drawn from a shared counter", "[query_id]")
+{
+  // Two queries built with the same id keep it: nothing auto-increments behind the caller's
+  // back, which is what allowed a second, independent query-id counter to exist.
+  auto tctx           = sirius::test::make_test_telemetry_context();
+  const auto query_id = make_query_id(11);
+  sirius::telemetry::query_telemetry_info tinfo{
+    tctx->engine_id(), tctx->worker_id(), query_id};
+
+  sirius::planner::query first(
+    duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>>{},
+    tctx->context(),
+    query_id,
+    tinfo);
+  sirius::planner::query second(
+    duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>>{},
+    tctx->context(),
+    query_id,
+    tinfo);
+
+  CHECK(first.query_id() == query_id);
+  CHECK(second.query_id() == query_id);
+}

--- a/test/cpp/planner/test_query_id.cpp
+++ b/test/cpp/planner/test_query_id.cpp
@@ -90,14 +90,12 @@ TEST_CASE("planner::query reports the id it was constructed with", "[query_id]")
   // window's id so repositories, scheduling and window logs all agree.
   auto tctx           = sirius::test::make_test_telemetry_context();
   const auto query_id = make_query_id(9876);
-  sirius::telemetry::query_telemetry_info tinfo{
-    tctx->engine_id(), tctx->worker_id(), query_id};
+  sirius::telemetry::query_telemetry_info tinfo{tctx->engine_id(), tctx->worker_id(), query_id};
 
-  sirius::planner::query q(
-    duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>>{},
-    tctx->context(),
-    query_id,
-    tinfo);
+  sirius::planner::query q(duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>>{},
+                           tctx->context(),
+                           query_id,
+                           tinfo);
 
   CHECK(q.query_id() == query_id);
 }
@@ -108,8 +106,7 @@ TEST_CASE("planner::query ids are not drawn from a shared counter", "[query_id]"
   // back, which is what allowed a second, independent query-id counter to exist.
   auto tctx           = sirius::test::make_test_telemetry_context();
   const auto query_id = make_query_id(11);
-  sirius::telemetry::query_telemetry_info tinfo{
-    tctx->engine_id(), tctx->worker_id(), query_id};
+  sirius::telemetry::query_telemetry_info tinfo{tctx->engine_id(), tctx->worker_id(), query_id};
 
   sirius::planner::query first(
     duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>>{},

--- a/test/cpp/planner/test_query_index.cpp
+++ b/test/cpp/planner/test_query_index.cpp
@@ -16,6 +16,7 @@
 
 #include "catch.hpp"
 #include "pipeline/pipeline_build_context.hpp"
+#include "pipeline/repository_wiring.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 #include "planner/query_index.hpp"
 
@@ -94,8 +95,12 @@ class dag_builder {
       sirius_physical_operator::next_port_info{consumer_op, name, uuid::now_v7()});
   }
 
-  const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines() const
+  // Numbers the DAG before handing it out, mirroring sirius_engine: query_index keys its
+  // branch map on operator ids, so they must be stamped first. Idempotent — operators
+  // already numbered keep their id.
+  const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines()
   {
+    sirius::pipeline::assign_operator_ids(_pipelines);
     return _pipelines;
   }
 

--- a/test/cpp/scan_manager/test_s3_routing_cutover.cpp
+++ b/test/cpp/scan_manager/test_s3_routing_cutover.cpp
@@ -256,11 +256,13 @@ sirius::io::ioctx_resolver make_datasource_resolver(sirius_scan_manager& manager
 
 sirius::planner::query make_empty_query()
 {
-  auto tctx = sirius::test::make_test_telemetry_context();
-  sirius::telemetry::query_telemetry_info tinfo{tctx->engine_id(), tctx->worker_id()};
+  auto tctx           = sirius::test::make_test_telemetry_context();
+  const auto query_id = sirius::make_query_id(1);
+  sirius::telemetry::query_telemetry_info tinfo{tctx->engine_id(), tctx->worker_id(), query_id};
   return sirius::planner::query(
     duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>>{},
     tctx->context(),
+    query_id,
     tinfo);
 }
 

--- a/test/cpp/utils/pipeline_conversion_test_utils.cpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.cpp
@@ -118,33 +118,33 @@ extracted_plan extract_logical_plan_sirius_order(duckdb::ClientContext& context,
   return {std::move(plan), std::move(prepared)};
 }
 
-//! Clears the SiriusContext-wide data repositories on construction and destruction.
-//! No-op when Sirius is not registered on the connection.
-class scoped_repository_reset {
- public:
-  explicit scoped_repository_reset(duckdb::ClientContext& context)
-    : ctx_(context.registered_state->Get<duckdb::SiriusContext>("sirius_state"))
-  {
-    clear();
-  }
-  ~scoped_repository_reset() { clear(); }
-  scoped_repository_reset(const scoped_repository_reset&)            = delete;
-  scoped_repository_reset& operator=(const scoped_repository_reset&) = delete;
-
- private:
-  void clear() noexcept
-  {
-    if (!ctx_ || !ctx_->is_initialized()) { return; }
-    try {
-      ctx_->get_data_repository_manager().clear_all_repositories();
-    } catch (...) {  // best-effort: never throw out of a test-scaffolding destructor
-    }
-  }
-
-  duckdb::shared_ptr<duckdb::SiriusContext> ctx_;
-};
+//! Starts far above any window id a test process will reach, so a synthetic query can never
+//! collide with a genuine execution window's registration (the registry rejects duplicates).
+sirius::query_id_t next_test_query_id()
+{
+  static std::atomic<std::uint32_t> counter{1'000'000};
+  return sirius::make_query_id(counter.fetch_add(1, std::memory_order_relaxed));
+}
 
 }  // namespace
+
+scoped_test_query::scoped_test_query(duckdb::ClientContext& context)
+  : ctx_(context.registered_state->Get<duckdb::SiriusContext>("sirius_state")),
+    query_id_(next_test_query_id())
+{
+  if (usable()) { ctx_->get_data_repository_registry().create_for_query(query_id_); }
+}
+
+scoped_test_query::~scoped_test_query()
+{
+  if (!usable()) { return; }
+  try {
+    ctx_->get_data_repository_registry().erase(query_id_);
+  } catch (...) {  // best-effort: never throw out of a test-scaffolding destructor
+  }
+}
+
+bool scoped_test_query::usable() const noexcept { return ctx_ && ctx_->is_initialized(); }
 
 void with_conversion_result(
   duckdb::Connection& con,
@@ -211,13 +211,9 @@ void with_initialized_engine(duckdb::Connection& con,
 {
   auto& context = *con.context;
 
-  // This helper builds a plan and wires its repositories into the SiriusContext-wide manager
-  // without opening an execution window, so nothing runs the per-query cleanup that production
-  // gets from SiriusContext::run_mandatory_cleanup. Operator ids restart at 0 for every plan,
-  // so leftover repositories would collide on {operator_id, port_id} with the next plan built
-  // here — or with the next real GPU query in the same process. Clear on both entry and exit so
-  // the helper leaves the manager as it found it.
-  scoped_repository_reset repo_reset(context);
+  // Stands in for the execution window this helper never opens: registers this plan's
+  // repository manager and drops it (with its repositories) on the way out.
+  scoped_test_query test_query(context);
 
   con.BeginTransaction();
   try {
@@ -236,7 +232,7 @@ void with_initialized_engine(duckdb::Connection& con,
                              op::sirius_physical_materialized_collector>(*prepared, context);
 
     sirius_interface iface(context);
-    sirius_engine engine(context, iface);
+    sirius_engine engine(context, iface, test_query.query_id());
     engine.initialize(std::move(collector));
     consume(engine);
 

--- a/test/cpp/utils/pipeline_conversion_test_utils.cpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.cpp
@@ -118,6 +118,32 @@ extracted_plan extract_logical_plan_sirius_order(duckdb::ClientContext& context,
   return {std::move(plan), std::move(prepared)};
 }
 
+//! Clears the SiriusContext-wide data repositories on construction and destruction.
+//! No-op when Sirius is not registered on the connection.
+class scoped_repository_reset {
+ public:
+  explicit scoped_repository_reset(duckdb::ClientContext& context)
+    : ctx_(context.registered_state->Get<duckdb::SiriusContext>("sirius_state"))
+  {
+    clear();
+  }
+  ~scoped_repository_reset() { clear(); }
+  scoped_repository_reset(const scoped_repository_reset&)            = delete;
+  scoped_repository_reset& operator=(const scoped_repository_reset&) = delete;
+
+ private:
+  void clear() noexcept
+  {
+    if (!ctx_ || !ctx_->is_initialized()) { return; }
+    try {
+      ctx_->get_data_repository_manager().clear_all_repositories();
+    } catch (...) {  // best-effort: never throw out of a test-scaffolding destructor
+    }
+  }
+
+  duckdb::shared_ptr<duckdb::SiriusContext> ctx_;
+};
+
 }  // namespace
 
 void with_conversion_result(
@@ -184,6 +210,14 @@ void with_initialized_engine(duckdb::Connection& con,
                              const std::function<void(sirius_engine&)>& consume)
 {
   auto& context = *con.context;
+
+  // This helper builds a plan and wires its repositories into the SiriusContext-wide manager
+  // without opening an execution window, so nothing runs the per-query cleanup that production
+  // gets from SiriusContext::run_mandatory_cleanup. Operator ids restart at 0 for every plan,
+  // so leftover repositories would collide on {operator_id, port_id} with the next plan built
+  // here — or with the next real GPU query in the same process. Clear on both entry and exit so
+  // the helper leaves the manager as it found it.
+  scoped_repository_reset repo_reset(context);
 
   con.BeginTransaction();
   try {

--- a/test/cpp/utils/pipeline_conversion_test_utils.hpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.hpp
@@ -16,11 +16,18 @@
 
 #pragma once
 
+#include "query_id.hpp"
+
 #include <duckdb/main/connection.hpp>
 
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <string>
+
+namespace duckdb {
+class SiriusContext;
+}  // namespace duckdb
 
 namespace sirius::pipeline {
 struct pipeline_conversion_result;
@@ -31,6 +38,33 @@ class sirius_engine;
 }
 
 namespace sirius::test {
+
+//! Registers a data repository manager for a synthetic query and drops it on scope exit,
+//! standing in for a real `SiriusContext::StandaloneQueryScope`.
+//!
+//! Tests that build a `sirius_engine` directly never open an execution window, so nothing
+//! would otherwise create the manager the engine requires, nor clean it up afterwards.
+//! Leaving repositories behind also breaks the *next* real GPU query in the process, since
+//! operator ids restart at 0 for every plan and would collide on `{operator_id, port_id}`.
+//!
+//! Construct it before the engine and keep it alive for at least as long: pass `query_id()`
+//! to the `sirius_engine` constructor. No-op when Sirius is not registered on the connection.
+class scoped_test_query {
+ public:
+  explicit scoped_test_query(duckdb::ClientContext& context);
+  ~scoped_test_query();
+
+  scoped_test_query(const scoped_test_query&)            = delete;
+  scoped_test_query& operator=(const scoped_test_query&) = delete;
+
+  [[nodiscard]] sirius::query_id_t query_id() const noexcept { return query_id_; }
+
+ private:
+  [[nodiscard]] bool usable() const noexcept;
+
+  duckdb::shared_ptr<duckdb::SiriusContext> ctx_;
+  sirius::query_id_t query_id_;
+};
 
 //! Drive the full sirius planner + meta_pipeline + converter flow on `query` (with the
 //! production optimizer disables) and return `dump_pipeline_conversion_result(...)`; stops


### PR DESCRIPTION
This PR addresses 3 main problems in the context of concurrent query execution:

Problem 1. Sirius had a single shared_data_repository_manager owned by SiriusContext, shared by every in-flight query, and repositories were keyed by {operator_id, port_id}. At query end, the data_repository_manager would get cleared, which causes problems with concurrent query execution.
Solution: We how have a data_repository_manager_registry still owned by the SiriusContext, so that we have one shared_data_repository_manager per query. 

Problem 2. Operator ids were assigned at construction from a static inline counter, which was then reset for the next query. This means that concurrent query operator graphs would be using and incrementing the same counter.
Solution: Now we dont have a static inline counter. Instead, after all the operators are created. We iterate over them and assign them an id.

Problem 3. Query_ids were defined differently in different parts of the engine. This PR unifies some of them. NOTE: the Quent telemetry uses its own query id. If necessary this can be addressed later.
Solution: We now have a strongly typed unified query_id.

What changed

1. query_id_t, one query identity (src/include/query_id.hpp)

An enum class query_id_t : uint32_t minted once per execution window (SiriusContext::StandaloneQueryScope) and threaded through everything downstream: which repository manager the query owns, which repositories its cleanup drops, its scheduling priority, and its log/telemetry correlation key. planner::query no longer mints its own; it receives the window's id.

A distinct enum type rather than a uint64_t alias, precisely because operator ids, pipeline ids, connection ids and per-connection query ordinals are all plain integers here; making them silently interchangeable is what let the duplicate counters coexist. query_priority_bits() centralizes the priority-packing contract (masked to 31 bits so the id cannot shift into the sign bit of the signed queue_priority and invert scheduling order). A std::formatter specialization keeps log sites cast-free.

2. data_repository_manager_registry (src/include/data/data_repository_manager_registry.hpp)

One shared_data_repository_manager per in-flight query, keyed by query_id_t. Query end drops only that query's repositories. Managers are handed out as shared_ptr because a downgrade worker may be sweeping a manager while its query ends, and shared ownership keeps the manager object alive until the last borrower releases it.

get_all() returns a snapshot built under the lock, so the downgrade executors can iterate without holding the mutex across a long spill sweep (that would serialize query begin/end behind spilling). std::map rather than unordered_map so spill-candidate ordering is deterministic across runs. create_for_query throws on a duplicate id: window ids are monotonic, so a duplicate is a lifecycle bug, not recoverable state.

The downgrade executors now bind to the registry rather than a single manager, since memory pressure is a global condition and spill candidates must be drawn across all live queries.

3. Operator ids are per-query and stamped in one pass

next_operator_id is gone. Operators are constructed with an invalid_operator_id sentinel; pipeline::assign_operator_ids numbers the final pipeline set 0..N-1 in scheduling order (source, then operators, then sink; first visit wins, so an operator appearing in several pipelines keeps one id). It runs inside sirius_pipeline_converter::convert(), the one point every caller shares, including plan-inspection paths that never build an engine, so no consumer can observe an unnumbered plan.

The pipeline set, not the plan tree, is the traversal root on purpose: sirius_physical_delim_join owns its join and distinct_root subtrees outside children and does not override get_children(), so a tree walk would miss them. Every operator that executes belongs to a pipeline.

get_operator_id() now throws on the sentinel rather than returning it. An unassigned id would otherwise silently collide in the operator-id-keyed maps (repositories, task-creator global states) and mis-route data, so it fails loudly in every build, not just debug.

Tradeoffs and known limits

- Scheduling order wraps every 2^31 queries in one process, at which point a fresh query sorts ahead of older in-flight ones. This is inherent to packing the id into the priority at all, and is documented at query_priority_bits().
- registry::erase requires quiesced borrowers. Shared ownership protects the manager object, not the repositories inside it; the cleanup path drains the downgrade executors first. This precondition is documented, not enforced.
- The first window gets id 1, so 0 is never a live query id.

Tests

- test/cpp/data/test_data_repository_manager_registry.cpp: registration, per-query isolation, get_all() ordering, duplicate-id rejection, erase reporting.
- test/cpp/planner/test_query_id.cpp: id propagation and priority packing.
- New sirius::test::scoped_test_query helper. Tests that build a sirius_engine directly never open a real execution window, so nothing would create the manager the engine needs or clean it up. Leaving repositories behind would break the next real GPU query in the process, since operator ids now restart at 0 per plan and would collide on {operator_id, port_id}.
- Existing downgrade, pipeline, and planner tests updated for the new signatures.