### PR TITLE
ci: allow distribution workflow to be manually dispatched

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -19,6 +19,7 @@ on:
       - dev
   merge_group:
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Allows testing PRs that may impact Distribution workflow prior to the merge queue.