### PR TITLE
docs: add PR template to repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,4 +11,4 @@
 - [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)
 
 ## References
-<!-- Add open issues with "Closes #issue" to close or "Refs #issue" for reference and any relevant URLs -->
+<!-- Add open issues with "Closes #issue" to close or "Refs #issue" for reference, and any relevant URLs -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+<!-- Edit PR title: "<type>[optional scope]: <short description>", see CONTRIBUTING.md for guidance -->
+
+## Description
+<!-- Provide a standalone description of changes in this PR -->
+<!-- For design docs targeting docs/experimental, note this in the description -->
+
+## Checklist
+- [ ] Read CONTRIBUTING.md
+- [ ] Cover changes with new or existing tests
+- [ ] Document configuration changes in code and summarize in the description above
+- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)
+
+## References
+<!-- Add open issues with "Closes #issue" to close or "Refs #issue" for reference and any relevant URLs -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,3 +75,28 @@ When the C++ unit test job fails or times out, the workflow automatically upload
 - The last test number logged before output stops — this is the test that hung or crashed
 - Any CUDA error messages preceding the hang
 - Stack traces if the binary aborted
+
+## Pull requests
+
+### Commit and title convention
+
+Sirius squash-merges PRs, the PR titles become the commit message on merge. Commits and PR titles follow [Conventional Commits](https://www.conventionalcommits.org/) format for readability.
+
+Example of Conventional Commits:
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Scope is optional — use it when the change is clearly localized to a subsystem (e.g. `fix(join):`, `ci(distribution):`), omit it for cross-cutting changes.
+
+New contributors: put your best title — reviewers will help refine it before merge.
+
+### Configuration changes
+
+If your PR changes any Sirius configuration option:
+1. Document the change inline where the config lives (code comments, settings files)
+2. Summarize the change in the PR description for reviewers and the changelog


### PR DESCRIPTION
Includes documentation updates to `CONTRIBUTING.md` for PR title conventions as well as a PR template for the repo based on feedback in #1252. Using the [cuDF PR Template ](https://github.com/rapidsai/cudf/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1) as the base, I've added the following:

1. Explicit call out of PR title based on Conventional Commits with added documentation to `CONTRIBUTING.md`
2. Added call out about design docs in Description
3. Kept checklist for updating tests
4. Added checklist for documenting configuration changes and summarizing them in Description
5. Added checklist for human and agent documentation updates
6. Created References section with instructions to add relevant issues and URLs

Will use the review process to refine this template before merging to the repo

Closes #1252 