### PR TITLE
Bump duckdb submodule to upstream main and port to the new APIs

### DIFF
--- a/src/expression/from_duckdb.cpp
+++ b/src/expression/from_duckdb.cpp
@@ -84,17 +84,20 @@ std::optional<std::vector<std::unique_ptr<node>>> translate_children(Children co
 std::unique_ptr<node> translate_reference(duckdb::BoundReferenceExpression const& expr)
 {
   return std::make_unique<node>(
-    reference{static_cast<uint32_t>(expr.index), sirius::from_duckdb(expr.return_type)});
+    reference{static_cast<uint32_t>(expr.Index()), sirius::from_duckdb(expr.GetReturnType())});
 }
 
 std::unique_ptr<node> translate_constant(duckdb::BoundConstantExpression const& expr)
 {
-  auto return_type = sirius::from_duckdb(expr.return_type);
-  auto payload     = sirius::from_duckdb(expr.value, return_type);
+  auto return_type = sirius::from_duckdb(expr.GetReturnType());
+  auto payload     = sirius::from_duckdb(expr.GetValue(), return_type);
   return std::make_unique<node>(constant{std::move(payload), std::move(return_type)});
 }
 
-std::unique_ptr<node> translate_comparison(duckdb::BoundComparisonExpression const& expr)
+// Comparisons, casts and BETWEENs are all BoundFunctionExpression upstream,
+// discriminated by ExpressionType; the Bound*Expression names are now only
+// static-helper namespaces over that representation.
+std::unique_ptr<node> translate_comparison(duckdb::BoundFunctionExpression const& expr)
 {
   // Filter the BoundComparisonExpression ExpressionType down to the set that the
   // Sirius comparison node carries (sirius::comparison_type). The set mirrors
@@ -110,8 +113,8 @@ std::unique_ptr<node> translate_comparison(duckdb::BoundComparisonExpression con
     case duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM: break;
     default: return nullptr;
   }
-  auto left  = from_duckdb(*expr.left);
-  auto right = from_duckdb(*expr.right);
+  auto left  = from_duckdb(duckdb::BoundComparisonExpression::Left(expr));
+  auto right = from_duckdb(duckdb::BoundComparisonExpression::Right(expr));
   if (!left || !right) { return nullptr; }
   return std::make_unique<node>(comparison{
     /*op=*/sirius::from_duckdb(expr.GetExpressionType()),
@@ -128,72 +131,74 @@ std::unique_ptr<node> translate_conjunction(duckdb::BoundConjunctionExpression c
     case duckdb::ExpressionType::CONJUNCTION_OR: op = conjunction::kind::op_or; break;
     default: return nullptr;
   }
-  auto children = translate_children(expr.children);
+  auto children = translate_children(expr.GetChildren());
   if (!children) { return nullptr; }
   return std::make_unique<node>(conjunction{op, std::move(*children)});
 }
 
-std::unique_ptr<node> translate_between(duckdb::BoundBetweenExpression const& expr)
+std::unique_ptr<node> translate_between(duckdb::BoundFunctionExpression const& expr)
 {
-  auto input = from_duckdb(*expr.input);
-  auto lower = from_duckdb(*expr.lower);
-  auto upper = from_duckdb(*expr.upper);
+  auto input = from_duckdb(duckdb::BoundBetweenExpression::Input(expr));
+  auto lower = from_duckdb(duckdb::BoundBetweenExpression::LowerBound(expr));
+  auto upper = from_duckdb(duckdb::BoundBetweenExpression::UpperBound(expr));
   if (!input || !lower || !upper) { return nullptr; }
   return std::make_unique<node>(between{
     /*input=*/std::move(input),
     /*lower=*/std::move(lower),
     /*upper=*/std::move(upper),
-    /*lower_inclusive=*/expr.lower_inclusive,
-    /*upper_inclusive=*/expr.upper_inclusive,
+    /*lower_inclusive=*/duckdb::BoundBetweenExpression::LowerInclusive(expr),
+    /*upper_inclusive=*/duckdb::BoundBetweenExpression::UpperInclusive(expr),
   });
 }
 
 std::unique_ptr<node> translate_case(duckdb::BoundCaseExpression const& expr)
 {
   std::vector<case_expr::when_then> cases;
-  cases.reserve(expr.case_checks.size());
-  for (auto const& check : expr.case_checks) {
+  cases.reserve(expr.CaseChecks().size());
+  for (auto const& check : expr.CaseChecks()) {
     auto when_node = from_duckdb(*check.when_expr);
     auto then_node = from_duckdb(*check.then_expr);
     if (!when_node || !then_node) { return nullptr; }
     cases.push_back(case_expr::when_then{std::move(when_node), std::move(then_node)});
   }
-  auto else_node = from_duckdb(*expr.else_expr);
+  auto else_node = from_duckdb(expr.Else());
   if (!else_node) { return nullptr; }
   return std::make_unique<node>(
-    case_expr{std::move(cases), std::move(else_node), sirius::from_duckdb(expr.return_type)});
+    case_expr{std::move(cases), std::move(else_node), sirius::from_duckdb(expr.GetReturnType())});
 }
 
-std::unique_ptr<node> translate_cast(duckdb::BoundCastExpression const& expr)
+std::unique_ptr<node> translate_cast(duckdb::BoundFunctionExpression const& expr)
 {
-  auto child = from_duckdb(*expr.child);
+  auto child = from_duckdb(duckdb::BoundCastExpression::Child(expr));
   if (!child) { return nullptr; }
-  auto target_type = sirius::from_duckdb(expr.return_type);
+  auto target_type = sirius::from_duckdb(expr.GetReturnType());
   return std::make_unique<node>(cast{
     /*child=*/std::move(child),
     /*target_type=*/std::move(target_type),
-    /*try_cast=*/expr.try_cast,
+    /*try_cast=*/duckdb::BoundCastExpression::IsTryCast(expr),
   });
 }
 
 std::unique_ptr<node> translate_function(duckdb::BoundFunctionExpression const& expr)
 {
-  auto func_id_opt = sirius::from_duckdb_function_name(expr.function.name);
+  auto func_id_opt =
+    sirius::from_duckdb_function_name(expr.Function().GetName().GetIdentifierName());
   if (!func_id_opt.has_value()) { return nullptr; }
-  auto arguments = translate_children(expr.children);
+  auto arguments = translate_children(expr.GetChildren());
   if (!arguments) { return nullptr; }
-  auto return_type = sirius::from_duckdb(expr.return_type);
+  auto return_type = sirius::from_duckdb(expr.GetReturnType());
   return std::make_unique<node>(
     function_call{*func_id_opt, std::move(*arguments), std::move(return_type)});
 }
 
 std::unique_ptr<node> translate_aggregate(duckdb::BoundAggregateExpression const& aggr)
 {
-  auto agg_id_opt = sirius::from_duckdb_aggregate_name(aggr.function.name);
+  auto agg_id_opt =
+    sirius::from_duckdb_aggregate_name(aggr.Function().GetName().GetIdentifierName());
   if (!agg_id_opt.has_value()) { return nullptr; }
-  auto arguments = translate_children(aggr.children);
+  auto arguments = translate_children(aggr.GetChildren());
   if (!arguments) { return nullptr; }
-  auto return_type = sirius::from_duckdb(aggr.return_type);
+  auto return_type = sirius::from_duckdb(aggr.GetReturnType());
   return std::make_unique<node>(
     aggregate{*agg_id_opt, std::move(*arguments), std::move(return_type), aggr.IsDistinct()});
 }
@@ -214,25 +219,25 @@ std::unique_ptr<node> translate_operator(duckdb::BoundOperatorExpression const& 
     default: break;
   }
   if (unary_kind != unary_op::kind::invalid) {
-    D_ASSERT(!expr.children.empty());
-    auto child = from_duckdb(*expr.children[0]);
+    D_ASSERT(!expr.GetChildren().empty());
+    auto child = from_duckdb(*expr.GetChildren()[0]);
     if (!child) { return nullptr; }
     return std::make_unique<node>(unary_op{unary_kind, std::move(child)});
   }
 
   if (op_type == duckdb::ExpressionType::OPERATOR_COALESCE) {
-    auto children = translate_children(expr.children);
+    auto children = translate_children(expr.GetChildren());
     if (!children) { return nullptr; }
     return std::make_unique<node>(
-      coalesce{std::move(*children), sirius::from_duckdb(expr.return_type)});
+      coalesce{std::move(*children), sirius::from_duckdb(expr.GetReturnType())});
   }
 
   if (op_type == duckdb::ExpressionType::COMPARE_IN ||
       op_type == duckdb::ExpressionType::COMPARE_NOT_IN) {
-    D_ASSERT(!expr.children.empty());
-    auto probe = from_duckdb(*expr.children[0]);
+    D_ASSERT(!expr.GetChildren().empty());
+    auto probe = from_duckdb(*expr.GetChildren()[0]);
     if (!probe) { return nullptr; }
-    auto values = translate_children(expr.children, /*start=*/1);
+    auto values = translate_children(expr.GetChildren(), /*start=*/1);
     if (!values) { return nullptr; }
     return std::make_unique<node>(in_list{
       /*probe=*/std::move(probe),
@@ -251,20 +256,25 @@ std::unique_ptr<node> from_duckdb(duckdb::Expression const& expr)
   switch (expr.GetExpressionClass()) {
     case duckdb::ExpressionClass::BOUND_AGGREGATE:
       return translate_aggregate(expr.Cast<duckdb::BoundAggregateExpression>());
-    case duckdb::ExpressionClass::BOUND_BETWEEN:
-      return translate_between(expr.Cast<duckdb::BoundBetweenExpression>());
     case duckdb::ExpressionClass::BOUND_CASE:
       return translate_case(expr.Cast<duckdb::BoundCaseExpression>());
-    case duckdb::ExpressionClass::BOUND_CAST:
-      return translate_cast(expr.Cast<duckdb::BoundCastExpression>());
-    case duckdb::ExpressionClass::BOUND_COMPARISON:
-      return translate_comparison(expr.Cast<duckdb::BoundComparisonExpression>());
     case duckdb::ExpressionClass::BOUND_CONJUNCTION:
       return translate_conjunction(expr.Cast<duckdb::BoundConjunctionExpression>());
     case duckdb::ExpressionClass::BOUND_CONSTANT:
       return translate_constant(expr.Cast<duckdb::BoundConstantExpression>());
-    case duckdb::ExpressionClass::BOUND_FUNCTION:
-      return translate_function(expr.Cast<duckdb::BoundFunctionExpression>());
+    case duckdb::ExpressionClass::BOUND_FUNCTION: {
+      // Casts, BETWEENs and comparisons are function expressions upstream;
+      // split them back out before falling through to a real function call.
+      auto const& function_expr = expr.Cast<duckdb::BoundFunctionExpression>();
+      if (duckdb::BoundCastExpression::IsCast(expr)) { return translate_cast(function_expr); }
+      if (expr.GetExpressionType() == duckdb::ExpressionType::COMPARE_BETWEEN) {
+        return translate_between(function_expr);
+      }
+      if (duckdb::BoundComparisonExpression::IsComparison(expr)) {
+        return translate_comparison(function_expr);
+      }
+      return translate_function(function_expr);
+    }
     case duckdb::ExpressionClass::BOUND_OPERATOR:
       return translate_operator(expr.Cast<duckdb::BoundOperatorExpression>());
     case duckdb::ExpressionClass::BOUND_PARAMETER: return nullptr;

--- a/src/expression/join_condition.cpp
+++ b/src/expression/join_condition.cpp
@@ -74,9 +74,9 @@ namespace {
 join_condition wrap_one(duckdb::JoinCondition& c)
 {
   return join_condition{
-    sirius::ast::from_duckdb(*c.left),
-    sirius::ast::from_duckdb(*c.right),
-    from_duckdb(c.comparison),
+    sirius::ast::from_duckdb(c.GetLHS()),
+    sirius::ast::from_duckdb(c.GetRHS()),
+    from_duckdb(c.GetComparisonType()),
   };
 }
 

--- a/src/expression/to_duckdb.cpp
+++ b/src/expression/to_duckdb.cpp
@@ -112,7 +112,7 @@ std::unique_ptr<duckdb::Expression> to_duckdb(comparison const& alt)
 {
   auto left  = to_duck_ptr(to_duckdb(*alt.left));
   auto right = to_duck_ptr(to_duckdb(*alt.right));
-  return from_duck_derived_ptr(duckdb::make_uniq<duckdb::BoundComparisonExpression>(
+  return from_duck_ptr(duckdb::BoundComparisonExpression::Create(
     sirius::to_duckdb(alt.op), std::move(left), std::move(right)));
 }
 
@@ -130,19 +130,18 @@ std::unique_ptr<duckdb::Expression> to_duckdb(conjunction const& alt)
   }
   auto out = duckdb::make_uniq<duckdb::BoundConjunctionExpression>(etype);
   for (auto const& child : alt.children) {
-    out->children.push_back(to_duck_ptr(to_duckdb(*child)));
+    out->GetChildrenMutable().push_back(to_duck_ptr(to_duckdb(*child)));
   }
   return from_duck_derived_ptr(std::move(out));
 }
 
 std::unique_ptr<duckdb::Expression> to_duckdb(between const& alt)
 {
-  return from_duck_derived_ptr(
-    duckdb::make_uniq<duckdb::BoundBetweenExpression>(to_duck_ptr(to_duckdb(*alt.input)),
-                                                      to_duck_ptr(to_duckdb(*alt.lower)),
-                                                      to_duck_ptr(to_duckdb(*alt.upper)),
-                                                      alt.lower_inclusive,
-                                                      alt.upper_inclusive));
+  return from_duck_ptr(duckdb::BoundBetweenExpression::Create(to_duck_ptr(to_duckdb(*alt.input)),
+                                                              to_duck_ptr(to_duckdb(*alt.lower)),
+                                                              to_duck_ptr(to_duckdb(*alt.upper)),
+                                                              alt.lower_inclusive,
+                                                              alt.upper_inclusive));
 }
 
 std::unique_ptr<duckdb::Expression> to_duckdb(case_expr const& alt)
@@ -153,14 +152,14 @@ std::unique_ptr<duckdb::Expression> to_duckdb(case_expr const& alt)
   // expression's return_type via to_duckdb, so the real type must be preserved
   // here to avoid spurious down-casts of the materialized result.
   auto out = duckdb::make_uniq<duckdb::BoundCaseExpression>(sirius::to_duckdb(alt.return_type()));
-  out->case_checks.reserve(alt.cases.size());
+  out->CaseChecksMutable().reserve(alt.cases.size());
   for (auto const& wt : alt.cases) {
     duckdb::BoundCaseCheck check;
     check.when_expr = to_duck_ptr(to_duckdb(*wt.when_));
     check.then_expr = to_duck_ptr(to_duckdb(*wt.then_));
-    out->case_checks.push_back(std::move(check));
+    out->CaseChecksMutable().push_back(std::move(check));
   }
-  out->else_expr = to_duck_ptr(to_duckdb(*alt.else_));
+  out->ElseMutable() = to_duck_ptr(to_duckdb(*alt.else_));
   return from_duck_derived_ptr(std::move(out));
 }
 
@@ -169,13 +168,12 @@ std::unique_ptr<duckdb::Expression> to_duckdb(cast const& alt)
   auto child       = to_duck_ptr(to_duckdb(*alt.child));
   auto target_type = sirius::to_duckdb(alt.target_type);
   if (alt.try_cast) {
-    // Try-cast surface uses the full ctor with is_try_cast=true.
-    // (BoundCastExpression::AddDefaultCastToType always sets is_try_cast=false.)
-    return from_duck_derived_ptr(
-      duckdb::make_uniq<duckdb::BoundCastExpression>(std::move(child),
-                                                     std::move(target_type),
-                                                     duckdb::BoundCastInfo{nullptr},
-                                                     /*is_try_cast=*/true));
+    // Try-cast surface uses the full factory with try_cast=true.
+    // (BoundCastExpression::AddDefaultCastToType always sets try_cast=false.)
+    return from_duck_ptr(duckdb::BoundCastExpression::Create(std::move(child),
+                                                             target_type,
+                                                             duckdb::BoundCastInfo{nullptr},
+                                                             /*try_cast=*/true));
   }
   return from_duck_ptr(
     duckdb::BoundCastExpression::AddDefaultCastToType(std::move(child), std::move(target_type)));
@@ -199,7 +197,7 @@ std::unique_ptr<duckdb::Expression> to_duckdb(unary_op const& alt)
   }
   auto out =
     duckdb::make_uniq<duckdb::BoundOperatorExpression>(etype, duckdb::LogicalType::BOOLEAN);
-  out->children.push_back(to_duck_ptr(to_duckdb(*alt.child)));
+  out->GetChildrenMutable().push_back(to_duck_ptr(to_duckdb(*alt.child)));
   return from_duck_derived_ptr(std::move(out));
 }
 
@@ -213,7 +211,7 @@ std::unique_ptr<duckdb::Expression> to_duckdb(coalesce const& alt)
   auto out = duckdb::make_uniq<duckdb::BoundOperatorExpression>(
     duckdb::ExpressionType::OPERATOR_COALESCE, sirius::to_duckdb(alt.return_type()));
   for (auto const& child : alt.children) {
-    out->children.push_back(to_duck_ptr(to_duckdb(*child)));
+    out->GetChildrenMutable().push_back(to_duck_ptr(to_duckdb(*child)));
   }
   return from_duck_derived_ptr(std::move(out));
 }
@@ -223,9 +221,9 @@ std::unique_ptr<duckdb::Expression> to_duckdb(in_list const& alt)
   auto out = duckdb::make_uniq<duckdb::BoundOperatorExpression>(
     alt.negated ? duckdb::ExpressionType::COMPARE_NOT_IN : duckdb::ExpressionType::COMPARE_IN,
     duckdb::LogicalType::BOOLEAN);
-  out->children.push_back(to_duck_ptr(to_duckdb(*alt.probe)));
+  out->GetChildrenMutable().push_back(to_duck_ptr(to_duckdb(*alt.probe)));
   for (auto const& value : alt.values) {
-    out->children.push_back(to_duck_ptr(to_duckdb(*value)));
+    out->GetChildrenMutable().push_back(to_duck_ptr(to_duckdb(*value)));
   }
   return from_duck_derived_ptr(std::move(out));
 }
@@ -239,8 +237,10 @@ std::unique_ptr<duckdb::Expression> to_duckdb(function_call const& alt)
   // (function.cpp) dispatches via the function-name lookup, never
   // invokes function_ptr_t or inspects arguments().
   auto name = std::string{sirius::to_duckdb_function_name(alt.function())};
-  duckdb::ScalarFunction stub_fn(
-    std::move(name), duckdb::vector<duckdb::LogicalType>{}, return_type, /*function=*/nullptr);
+  duckdb::ScalarFunction stub_fn(duckdb::Identifier{std::move(name)},
+                                 duckdb::vector<duckdb::LogicalType>{},
+                                 std::move(return_type),
+                                 /*function=*/nullptr);
 
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
   children.reserve(alt.arguments().size());
@@ -248,11 +248,9 @@ std::unique_ptr<duckdb::Expression> to_duckdb(function_call const& alt)
     children.push_back(to_duck_ptr(to_duckdb(*arg)));
   }
 
-  return from_duck_derived_ptr(
-    duckdb::make_uniq<duckdb::BoundFunctionExpression>(std::move(return_type),
-                                                       std::move(stub_fn),
-                                                       std::move(children),
-                                                       /*bind_info=*/nullptr));
+  // BoundFunctionExpression takes its return_type from the bound function.
+  return from_duck_derived_ptr(duckdb::make_uniq<duckdb::BoundFunctionExpression>(
+    duckdb::BoundScalarFunction(stub_fn), std::move(children), /*bind_info=*/nullptr));
 }
 
 std::unique_ptr<duckdb::Expression> to_duckdb(aggregate const& /*alt*/)

--- a/src/helper/type_conversions.cpp
+++ b/src/helper/type_conversions.cpp
@@ -128,4 +128,25 @@ duckdb::vector<duckdb::LogicalType> to_duckdb_vec(const duckdb::vector<logical_t
   return result;
 }
 
+duckdb::vector<std::string> from_duckdb_names(const duckdb::vector<duckdb::Identifier>& names)
+{
+  duckdb::vector<std::string> result;
+  result.reserve(names.size());
+  for (const auto& name : names) {
+    result.push_back(name.GetIdentifierName());
+  }
+  return result;
+}
+
+duckdb::vector<std::size_t> from_duckdb_projection_ids(
+  const duckdb::vector<duckdb::ProjectionIndex>& ids)
+{
+  duckdb::vector<std::size_t> result;
+  result.reserve(ids.size());
+  for (const auto& id : ids) {
+    result.push_back(id.GetIndex());
+  }
+  return result;
+}
+
 }  // namespace sirius

--- a/src/include/helper/type_conversions.hpp
+++ b/src/include/helper/type_conversions.hpp
@@ -23,8 +23,13 @@
 
 #include "helper/logical_type.hpp"
 
+#include <duckdb/common/identifier.hpp>
+#include <duckdb/common/projection_index.hpp>
 #include <duckdb/common/types.hpp>
 #include <duckdb/common/vector.hpp>
+
+#include <cstddef>
+#include <string>
 
 namespace sirius {
 
@@ -67,5 +72,24 @@ duckdb::vector<logical_type> from_duckdb_vec(const duckdb::vector<duckdb::Logica
  * ColumnDataCollection). Accepts duckdb::vector via base-class reference.
  */
 duckdb::vector<duckdb::LogicalType> to_duckdb_vec(const duckdb::vector<logical_type>& types);
+
+/**
+ * @brief Unwrap DuckDB Identifier column names to plain strings.
+ *
+ * Convenience wrapper for operator constructor call sites: DuckDB plan nodes
+ * carry names as case-insensitive Identifier, while sirius operators store
+ * plain strings.
+ */
+duckdb::vector<std::string> from_duckdb_names(const duckdb::vector<duckdb::Identifier>& names);
+
+/**
+ * @brief Unwrap DuckDB ProjectionIndex vectors to plain positions.
+ *
+ * Convenience wrapper for operator constructor call sites: DuckDB plan nodes
+ * carry projection maps as ProjectionIndex, while sirius operators store
+ * plain positions.
+ */
+duckdb::vector<std::size_t> from_duckdb_projection_ids(
+  const duckdb::vector<duckdb::ProjectionIndex>& ids);
 
 }  // namespace sirius

--- a/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
+++ b/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
@@ -30,6 +30,7 @@
 #include <duckdb/main/client_context.hpp>
 #include <duckdb/planner/expression.hpp>
 #include <duckdb/planner/table_filter.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
 #include <duckdb/storage/data_table.hpp>
 
 // standard library

--- a/src/include/op/scan/parquet_gpu_ingestible.hpp
+++ b/src/include/op/scan/parquet_gpu_ingestible.hpp
@@ -30,6 +30,7 @@
 #include <duckdb/common/vector.hpp>
 #include <duckdb/planner/expression.hpp>
 #include <duckdb/planner/table_filter.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
 
 // cudf
 #include <cudf/io/parquet.hpp>

--- a/src/include/op/sirius_physical_table_scan.hpp
+++ b/src/include/op/sirius_physical_table_scan.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "duckdb/common/extra_operator_info.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/planner/table_filter.hpp"

--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -25,6 +25,11 @@
 
 // duckdb
 #include <duckdb/common/types/decimal.hpp>
+#include <duckdb/common/vector/array_vector.hpp>
+#include <duckdb/common/vector/flat_vector.hpp>
+#include <duckdb/common/vector/list_vector.hpp>
+#include <duckdb/common/vector/string_vector.hpp>
+#include <duckdb/common/vector/struct_vector.hpp>
 #include <duckdb/common/vector_operations/vector_operations.hpp>
 #include <duckdb/common/vector_size.hpp>
 #include <duckdb/main/client_context.hpp>
@@ -33,6 +38,24 @@
 #include <algorithm>
 
 namespace sirius::op::result {
+
+namespace {
+
+// DuckDB dropped StringVector::AddBuffer; an owned string payload is now glued to
+// the vector as auxiliary data, which keeps it alive for as long as the string_t
+// values point into it.
+struct string_payload_holder : duckdb::AuxiliaryDataHolder {
+  explicit string_payload_holder(std::size_t bytes)
+    : bytes(bytes), data(duckdb::make_unsafe_uniq_array_uninitialized<duckdb::data_t>(bytes))
+  {
+  }
+  duckdb::idx_t GetAllocationSize() const override { return bytes; }
+
+  std::size_t bytes;
+  duckdb::unsafe_unique_array<duckdb::data_t> data;
+};
+
+}  // namespace
 
 host_table_chunk_reader::column_reader::column_reader(
   cucascade::memory::column_metadata const& col,
@@ -152,12 +175,12 @@ void host_table_chunk_reader::column_reader::copy_fixed_width(
   // by copying into a temp vector and using DuckDB's cast.
   auto const type_size =
     static_cast<size_t>(duckdb::GetTypeIdSize(vector.GetType().InternalType()));
-  auto* dest_ptr = duckdb::FlatVector::GetData(vector);
+  auto* dest_ptr = duckdb::FlatVector::GetDataMutable(vector);
   data_accessor.memcpy_to(allocation, dest_ptr, count * type_size);
 
   // Do the validity mask copy, if necessary
   if (null_count != 0) {
-    auto& validity = duckdb::FlatVector::Validity(vector);
+    auto& validity = duckdb::FlatVector::ValidityMutable(vector);
     copy_validity_range(validity, row_offset, count, allocation);
   }
 }
@@ -173,7 +196,7 @@ void make_duckdb_strings(memory::multiple_blocks_allocation_accessor<OffsetType>
                          size_t end_offset,
                          duckdb::data_ptr_t str_buffer_ptr)
 {
-  auto* strings = duckdb::FlatVector::GetData<duckdb::string_t>(vector);
+  auto* strings = duckdb::FlatVector::GetDataMutable<duckdb::string_t>(vector);
   size_t start  = start_offset;
   offset_accessor.advance();
   size_t offset_counter = 0;
@@ -230,41 +253,39 @@ void host_table_chunk_reader::column_reader::copy_string(
     auto start_offset           = offset_accessor_64.get_current(allocation);
     auto end_offset             = offset_accessor_64.get(row_offset + count, allocation);
     auto const total_data_bytes = end_offset - start_offset;
-    auto str_buffer             = duckdb::make_buffer<duckdb::VectorBuffer>(total_data_bytes);
-    auto str_buffer_ptr         = str_buffer->GetData();
+    auto str_buffer             = duckdb::make_uniq<string_payload_holder>(total_data_bytes);
+    auto str_buffer_ptr         = str_buffer->data.get();
     data_accessor.memcpy_to(allocation, str_buffer_ptr, total_data_bytes);
 
     if (null_count != 0) {
-      auto& validity = duckdb::FlatVector::Validity(vector);
+      auto& validity = duckdb::FlatVector::ValidityMutable(vector);
       copy_validity_range(validity, row_offset, count, allocation);
       detail::make_duckdb_strings<true, int64_t>(
         offset_accessor_64, allocation, vector, count, start_offset, end_offset, str_buffer_ptr);
-      duckdb::StringVector::AddBuffer(vector, str_buffer);
     } else {
       detail::make_duckdb_strings<false, int64_t>(
         offset_accessor_64, allocation, vector, count, start_offset, end_offset, str_buffer_ptr);
-      duckdb::StringVector::AddBuffer(vector, str_buffer);
     }
+    duckdb::StringVector::AddAuxiliaryData(vector, std::move(str_buffer));
   } else {
     // INT32 offsets (from scan task)
     auto start_offset = static_cast<size_t>(offset_accessor_32.get_current(allocation));
     auto end_offset   = static_cast<size_t>(offset_accessor_32.get(row_offset + count, allocation));
     auto const total_data_bytes = end_offset - start_offset;
-    auto str_buffer             = duckdb::make_buffer<duckdb::VectorBuffer>(total_data_bytes);
-    auto str_buffer_ptr         = str_buffer->GetData();
+    auto str_buffer             = duckdb::make_uniq<string_payload_holder>(total_data_bytes);
+    auto str_buffer_ptr         = str_buffer->data.get();
     data_accessor.memcpy_to(allocation, str_buffer_ptr, total_data_bytes);
 
     if (null_count != 0) {
-      auto& validity = duckdb::FlatVector::Validity(vector);
+      auto& validity = duckdb::FlatVector::ValidityMutable(vector);
       copy_validity_range(validity, row_offset, count, allocation);
       detail::make_duckdb_strings<true, int32_t>(
         offset_accessor_32, allocation, vector, count, start_offset, end_offset, str_buffer_ptr);
-      duckdb::StringVector::AddBuffer(vector, str_buffer);
     } else {
       detail::make_duckdb_strings<false, int32_t>(
         offset_accessor_32, allocation, vector, count, start_offset, end_offset, str_buffer_ptr);
-      duckdb::StringVector::AddBuffer(vector, str_buffer);
     }
+    duckdb::StringVector::AddAuxiliaryData(vector, std::move(str_buffer));
   }
 }
 
@@ -283,12 +304,12 @@ void host_table_chunk_reader::column_reader::copy_array(
   child_vec.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
   auto const child_width =
     static_cast<size_t>(duckdb::GetTypeIdSize(child_vec.GetType().InternalType()));
-  auto* child_dest = duckdb::FlatVector::GetData(child_vec);
+  auto* child_dest = duckdb::FlatVector::GetDataMutable(child_vec);
   data_accessor.memcpy_to(allocation, child_dest, count * array_size * child_width);
 
   // List-level validity
   if (null_count != 0) {
-    auto& validity = duckdb::FlatVector::Validity(vector);
+    auto& validity = duckdb::FlatVector::ValidityMutable(vector);
     copy_validity_range(validity, row_offset, count, allocation);
   }
 
@@ -298,7 +319,7 @@ void host_table_chunk_reader::column_reader::copy_array(
   if (child_null_count != 0) {
     auto const child_count = count * array_size;
     assert(utils::mod_8(row_offset * array_size) == 0);  // byte-aligned start
-    auto& child_validity = duckdb::FlatVector::Validity(child_vec);
+    auto& child_validity = duckdb::FlatVector::ValidityMutable(child_vec);
     child_validity.Initialize(child_count);
     auto* child_validity_ptr = reinterpret_cast<uint8_t*>(child_validity.GetData());
     child_mask_accessor.memcpy_to(allocation, child_validity_ptr, utils::ceil_div_8(child_count));
@@ -405,9 +426,10 @@ void host_table_chunk_reader::column_reader::read_into(
       auto& entries = duckdb::StructVector::GetEntries(vector);
       assert(entries.size() == children.size());
       for (size_t f = 0; f < children.size(); ++f) {
-        children[f].read_into(client_ctx, *entries[f], row_offset, count, allocation);
+        children[f].read_into(client_ctx, entries[f], row_offset, count, allocation);
       }
-      copy_validity_range(duckdb::FlatVector::Validity(vector), row_offset, count, allocation);
+      copy_validity_range(
+        duckdb::FlatVector::ValidityMutable(vector), row_offset, count, allocation);
       break;
     }
     case cudf::type_id::LIST: {
@@ -428,7 +450,8 @@ void host_table_chunk_reader::column_reader::read_into(
         list_entries[i].offset = static_cast<uint64_t>(lo - base);
         list_entries[i].length = static_cast<uint64_t>(hi - lo);
       }
-      copy_validity_range(duckdb::FlatVector::Validity(vector), row_offset, count, allocation);
+      copy_validity_range(
+        duckdb::FlatVector::ValidityMutable(vector), row_offset, count, allocation);
 
       auto const child_count = static_cast<size_t>(offset_at(row_offset + count) - base);
       duckdb::ListVector::Reserve(vector, child_count);

--- a/src/op/scan/duckdb_insert_delta.cpp
+++ b/src/op/scan/duckdb_insert_delta.cpp
@@ -30,6 +30,7 @@
 #include <duckdb/storage/segment/uncompressed.hpp>
 #include <duckdb/storage/statistics/base_statistics.hpp>
 #include <duckdb/storage/statistics/string_stats.hpp>
+#include <duckdb/storage/storage_index.hpp>
 #include <duckdb/storage/table/array_column_data.hpp>
 #include <duckdb/storage/table/column_data.hpp>
 #include <duckdb/storage/table/column_segment.hpp>
@@ -100,7 +101,7 @@ void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
     // bits.
     bool const all_null_validity = is_validity &&
                                    compression == duckdb::CompressionType::COMPRESSION_CONSTANT &&
-                                   segment.stats.statistics.CanHaveNull();
+                                   segment.GetStats().CanHaveNull();
     if (is_validity && !all_null_validity && is_constant_or_empty_validity(compression)) {
       continue;
     }
@@ -115,7 +116,7 @@ void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
 
     if (all_null_validity) {
       // Nothing to stage or read; the marker alone drives the decode.
-    } else if (segment.segment_type == duckdb::ColumnSegmentType::TRANSIENT) {
+    } else if (segment.GetSegmentType() == duckdb::ColumnSegmentType::TRANSIENT) {
       // DuckDB compresses transient segments only at checkpoint, and
       // checkpoints are suppressed while pinned; a compressed one here means
       // a checkpoint ran anyway.
@@ -176,8 +177,7 @@ void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
         // segment's own stats for the decoder: the constant value lives
         // here, and row-group-level stats drift as later appends (e.g. into
         // an indexed table's tail row group) merge into them.
-        out_seg.segment_stats =
-          std::make_shared<duckdb::BaseStatistics>(segment.stats.statistics.Copy());
+        out_seg.segment_stats = std::make_shared<duckdb::BaseStatistics>(segment.GetStats().Copy());
       } else {
         out_seg.block_id     = segment.GetBlockId();
         out_seg.block_offset = segment.GetBlockOffset();
@@ -195,11 +195,11 @@ void walk_delta_tree(duckdb::ColumnSegmentTree& tree,
       // Overflow strings must never reach the GPU string decoder. The
       // plan-time table-stat probe normally declines first; this catches
       // stats drift.
-      if (!duckdb::StringStats::HasMaxStringLength(segment.stats.statistics)) {
+      if (!duckdb::StringStats::HasMaxStringLength(segment.GetStats())) {
         throw_capture("varchar delta segment on column " + std::to_string(column_id) +
                       " row group " + std::to_string(rg_index) + ": Max String Length stat absent");
       }
-      auto const max_len = duckdb::StringStats::MaxStringLength(segment.stats.statistics);
+      auto const max_len = duckdb::StringStats::MaxStringLength(segment.GetStats());
       if (max_len >= duckdb::StringUncompressed::GetStringBlockLimit(segment.GetBlockSize())) {
         throw_capture("varchar delta segment on column " + std::to_string(column_id) +
                       " row group " + std::to_string(rg_index) +
@@ -346,8 +346,11 @@ insert_delta_plan prepare_insert_delta_capture(duckdb::DataTable& storage,
     if (covered_end <= rg_start + rg_plan.k_offset) { continue; }
     rg_plan.row_count       = covered_end - (rg_start + rg_plan.k_offset);
     rg_plan.row_group_start = rg_start + rg_plan.k_offset;
-    rg_plan.has_version_state =
-      duckdb::RowGroup::GetPartitionStats(*node).count_type == duckdb::CountType::COUNT_APPROXIMATE;
+    // COUNT_APPROXIMATE stopped covering committed deletes; MinMaxIsExact is
+    // cleared exactly when some physical row is not visible under the scan's
+    // transaction (the StorageIndex is ignored — the flag is per row group).
+    rg_plan.has_version_state = !duckdb::RowGroup::GetPartitionStats(*node, plan.transaction)
+                                   .partition_row_group->MinMaxIsExact(duckdb::StorageIndex());
 
     plan.row_groups.push_back(std::move(rg_plan));
   }
@@ -450,7 +453,7 @@ void copy_delta_row_group(insert_delta_row_group const& rg,
       for (auto const& s : *segs) {
         if (!s.is_transient) { continue; }
         // Pin just long enough to memcpy; no DuckDB handle outlives the call.
-        auto handle = s.segment->block;
+        auto handle = s.segment->GetBlockHandle();
         auto pin    = buffer_manager.Pin(handle);
         std::memcpy(slab_base + s.slab_offset, pin.Ptr() + s.copy_src_offset, s.bytes_size);
       }

--- a/src/op/scan/duckdb_mvcc_visibility.cpp
+++ b/src/op/scan/duckdb_mvcc_visibility.cpp
@@ -22,6 +22,7 @@
 #include <duckdb/common/vector_size.hpp>
 #include <duckdb/function/partition_stats.hpp>
 #include <duckdb/storage/data_table.hpp>
+#include <duckdb/storage/storage_index.hpp>
 #include <duckdb/storage/table/column_data.hpp>
 #include <duckdb/storage/table/column_segment.hpp>
 #include <duckdb/storage/table/row_group.hpp>
@@ -78,14 +79,16 @@ void write_bit_range(std::span<std::uint32_t> words,
 }
 
 /// Non-loading per-row-group version-state probe (see header docs for why
-/// this is a safe skip signal). Goes through the public GetPartitionStats
-/// surface: DuckDB marks a row group's count APPROXIMATE exactly when it has
-/// version state — in-memory row versions or unloaded persisted deletes
-/// (RowGroup::HasUnloadedDeletes / GetVersionInfoIfLoaded are private).
-bool row_group_has_version_state(duckdb::SegmentNode<duckdb::RowGroup>& node)
+/// this is a safe skip signal). COUNT_APPROXIMATE stopped covering committed
+/// deletes, so read MinMaxIsExact instead: DuckDB clears it exactly when some
+/// physical row is not visible under `transaction` — unloaded or loaded
+/// deletes, committed or not, or a visible-count mismatch. The StorageIndex
+/// is ignored; the flag is per row group, not per column.
+bool row_group_has_version_state(duckdb::SegmentNode<duckdb::RowGroup>& node,
+                                 duckdb::TransactionData transaction)
 {
-  return duckdb::RowGroup::GetPartitionStats(node).count_type ==
-         duckdb::CountType::COUNT_APPROXIMATE;
+  auto const stats = duckdb::RowGroup::GetPartitionStats(node, transaction);
+  return !stats.partition_row_group->MinMaxIsExact(duckdb::StorageIndex());
 }
 
 }  // namespace
@@ -172,7 +175,7 @@ mvcc_visibility_plan capture_mvcc_visibility_plan(
     // mask job serializes unaligned chunks into a single fill task.
     auto const chunk_offset = expected_start - chunk_start;
 
-    bool const dirty = row_group_has_version_state(*node);
+    bool const dirty = row_group_has_version_state(*node, plan.transaction);
     plan.mvcc_row_groups[chunk_idx].push_back(
       {&rg, node->GetRowStart(), chunk_offset, covered, dirty});
     if (dirty) { plan.chunk_has_version_state[chunk_idx] = true; }
@@ -254,7 +257,7 @@ bool any_uncheckpointed_appends(duckdb::DataTable& storage,
     auto& rg = node->GetNode();
     for (auto col : storage_column_indices) {
       for (auto& seg_node : rg.GetRawColumnData(col).GetSegmentTree().SegmentNodes()) {
-        if (seg_node.GetNode().segment_type == duckdb::ColumnSegmentType::TRANSIENT) {
+        if (seg_node.GetNode().GetSegmentType() == duckdb::ColumnSegmentType::TRANSIENT) {
           return true;
         }
       }
@@ -277,7 +280,7 @@ native_read_mvcc_state check_native_read_mvcc_state(
         return native_read_mvcc_state::has_update_chains;
       }
     }
-    if (!row_group_has_version_state(*node)) { continue; }
+    if (!row_group_has_version_state(*node, transaction)) { continue; }
     // Read the physical count first: a concurrent append makes the two
     // counts diverge in either order, so a race can only refuse.
     auto const physical = static_cast<duckdb::idx_t>(rg.count.load());

--- a/src/op/scan/duckdb_native_decoder.cpp
+++ b/src/op/scan/duckdb_native_decoder.cpp
@@ -50,6 +50,7 @@
 #include <cucascade/memory/memory_space.hpp>
 #include <duckdb/common/types/validity_mask.hpp>
 #include <duckdb/common/types/vector.hpp>
+#include <duckdb/common/vector/flat_vector.hpp>
 #include <duckdb/main/attached_database.hpp>
 #include <duckdb/main/database.hpp>
 #include <duckdb/storage/block_manager.hpp>
@@ -209,7 +210,6 @@ pinned_segment_bytes decode_roaring_validity(duckdb::DatabaseInstance& db,
     block_manager,
     desc.block_id,
     desc.block_offset,
-    validity_type,
     desc.segment_count,
     duckdb::CompressionType::COMPRESSION_ROARING,
     duckdb::BaseStatistics::CreateEmpty(validity_type),
@@ -225,10 +225,10 @@ pinned_segment_bytes decode_roaring_validity(duckdb::DatabaseInstance& db,
 
   for (duckdb::idx_t scanned = 0; scanned < row_count; scanned += CHUNK) {
     auto const to_scan = std::min<duckdb::idx_t>(CHUNK, row_count - scanned);
-    auto& vm           = duckdb::FlatVector::Validity(tmp);
+    auto& vm           = duckdb::FlatVector::ValidityMutable(tmp);
     vm.SetAllValid(CHUNK);
-    rs.ScanPartial(scanned, tmp, /*offset=*/0, to_scan);
-    if (!vm.AllValid()) {
+    rs.ScanPartial(scanned, vm, /*offset=*/0, to_scan);
+    if (!vm.CannotHaveNull()) {
       std::size_t const byte_offset   = scanned / 8;
       std::size_t const bytes_to_copy = (to_scan + 7) / 8;
       std::memcpy(out.owned_bytes.data() + byte_offset,

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -31,6 +31,8 @@
 #include <op/sirius_dynamic_filter.hpp>
 
 // duckdb
+#include <duckdb/main/attached_database.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
 #include <duckdb/storage/single_file_block_manager.hpp>
 #include <duckdb/storage/storage_manager.hpp>
 
@@ -222,7 +224,7 @@ duckdb_native_gpu_ingestible::duckdb_native_gpu_ingestible(
   auto const& source_ids = bind.projection_ids.empty() ? source_ids_fallback : bind.projection_ids;
 
   // Pre-build the coalesced filter expression once.
-  if (bind.table_filters && !bind.table_filters->filters.empty()) {
+  if (bind.table_filters && bind.table_filters->HasFilters()) {
     std::vector<std::optional<std::size_t>> emission_order_map(bind.column_ids.size());
     for (std::size_t k = 0; k < source_ids.size(); ++k) {
       emission_order_map[source_ids[k]] = k;

--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -26,7 +26,10 @@
 #include <duckdb/function/compression_function.hpp>
 #include <duckdb/function/partition_stats.hpp>
 #include <duckdb/main/attached_database.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <duckdb/planner/filter/expression_filter.hpp>
 #include <duckdb/planner/table_filter.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
 #include <duckdb/storage/block_manager.hpp>
 #include <duckdb/storage/segment/uncompressed.hpp>
 #include <duckdb/storage/statistics/base_statistics.hpp>
@@ -151,7 +154,7 @@ duckdb_segment_descriptor fill_segment_descriptor(duckdb::ColumnSegment& segment
   desc.compression   = segment.GetCompressionFunction().type;
   desc.segment_start = segment_start;
   desc.segment_count = segment.count;
-  if (segment.segment_type == duckdb::ColumnSegmentType::PERSISTENT) {
+  if (segment.GetSegmentType() == duckdb::ColumnSegmentType::PERSISTENT) {
     desc.block_id     = segment.GetBlockId();
     desc.block_offset = segment.GetBlockOffset();
   } else {
@@ -169,7 +172,7 @@ duckdb_segment_descriptor fill_segment_descriptor(duckdb::ColumnSegment& segment
   if (desc.compression == duckdb::CompressionType::COMPRESSION_CONSTANT) {
     // Snapshot the segment's own stats: the constant value lives here, and
     // row-group-level stats drift as later appends merge into them.
-    desc.segment_stats = std::make_shared<duckdb::BaseStatistics>(segment.stats.statistics.Copy());
+    desc.segment_stats = std::make_shared<duckdb::BaseStatistics>(segment.GetStats().Copy());
   }
   return desc;
 }
@@ -180,7 +183,7 @@ duckdb_segment_descriptor fill_segment_descriptor(duckdb::ColumnSegment& segment
 bool constant_validity_is_all_null(duckdb::ColumnSegment& segment)
 {
   return segment.GetCompressionFunction().type == duckdb::CompressionType::COMPRESSION_CONSTANT &&
-         segment.stats.statistics.CanHaveNull();
+         segment.GetStats().CanHaveNull();
 }
 
 // Grants access to ArrayColumnData's protected child/validity members. C++
@@ -321,11 +324,11 @@ std::optional<std::string> walk_standard_column(duckdb::ColumnData& col_data,
       }
       // Read the per-segment Max String Length stat TYPED (exact)
       // Absent stat -> refuse so consumers deref unchecked.
-      if (!duckdb::StringStats::HasMaxStringLength(segment.stats.statistics)) {
+      if (!duckdb::StringStats::HasMaxStringLength(segment.GetStats())) {
         return "varchar segment on column " + std::to_string(column_id) + " row group " +
                std::to_string(rg_idx) + ": Max String Length stat absent from segment stats";
       }
-      desc.max_string_length = duckdb::StringStats::MaxStringLength(segment.stats.statistics);
+      desc.max_string_length = duckdb::StringStats::MaxStringLength(segment.GetStats());
       // Stats-drift guard: a marker-bearing segment must never reach the GPU string
       // decoder. Mirrors the refusal in prepare_duckdb_native_walk (see rationale there).
       if (*desc.max_string_length >=
@@ -397,7 +400,7 @@ void compute_segment_bytes_size(std::vector<duckdb_row_group_metadata>& row_grou
 /// by this walker.
 bool filter_is_prunable(duckdb::TableFilterType t)
 {
-  return t != duckdb::TableFilterType::DYNAMIC_FILTER;
+  return t != duckdb::TableFilterType::LEGACY_DYNAMIC_FILTER;
 }
 
 std::size_t estimate_decoded_bytes_budget(duckdb::idx_t row_count,
@@ -435,15 +438,24 @@ bool row_group_pruned_by_filter_stats(duckdb::PartitionRowGroup& prg,
                                       const duckdb::TableFilterSet& table_filters,
                                       const duckdb::vector<duckdb::ColumnIndex>& column_ids)
 {
-  for (auto const& [col_idx, filter] : table_filters.filters) {
-    if (!filter_is_prunable(filter->filter_type)) { continue; }
+  for (auto const& entry : table_filters) {
+    auto const col_idx = static_cast<duckdb::idx_t>(entry.GetIndex());
+    auto const& filter = entry.Filter();
+    if (!filter_is_prunable(filter.filter_type)) { continue; }
     if (col_idx >= column_ids.size()) { continue; }  // defensive
     auto const& column_id = column_ids[col_idx];
     if (!column_index_can_have_storage_stats(column_id)) { continue; }
 
     auto stats = prg.GetColumnStatistics(duckdb::StorageIndex(column_id.GetPrimaryIndex()));
     if (!stats) { continue; }  // no stats -> cannot prune
-    if (filter->CheckStatistics(*stats) == duckdb::FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+    // TableFilter no longer carries CheckStatistics; filters are pruned through their
+    // expression form. The reference index is irrelevant here — the pruner only reads
+    // the expression shape against the single column's stats.
+    auto const column_ref =
+      duckdb::make_uniq<duckdb::BoundReferenceExpression>(stats->GetType(), duckdb::idx_t(0));
+    auto const filter_expr = filter.ToExpression(*column_ref);
+    if (duckdb::ExpressionFilter::CheckExpressionStatistics(*filter_expr, *stats) ==
+        duckdb::FilterPropagateResult::FILTER_ALWAYS_FALSE) {
       return true;
     }
   }
@@ -458,7 +470,7 @@ bool row_group_pruned_by_filter_stats(duckdb::PartitionRowGroup& prg,
 /// and lets the all-pruned case route to DuckDB CPU before the async scan starts.
 void mark_row_groups_pruned_by_filter_stats(duckdb_native_walk_plan& plan)
 {
-  if (plan.table_filters == nullptr || plan.table_filters->filters.empty() ||
+  if (plan.table_filters == nullptr || !plan.table_filters->HasFilters() ||
       plan.column_ids == nullptr || plan.column_ids->empty()) {
     return;
   }

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -49,6 +49,7 @@
 
 // duckdb
 #include <duckdb/common/hive_partitioning.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
 
 // uring_reactor MUST be included last among sirius headers: liburing.h,
 // pulled in transitively, defines a BLOCK_SIZE macro that collides with the
@@ -350,7 +351,7 @@ parquet_gpu_ingestible::parquet_gpu_ingestible(std::unique_ptr<parquet_ingestibl
   // column_ids with empty projection_ids, the no-pushdown sirius_read_parquet
   // case), filter pushdown, or hive-partition injection — needs column names.
   bool const needs_names = !bind.projection_ids.empty() ||
-                           (bind.table_filters && !bind.table_filters->filters.empty()) ||
+                           (bind.table_filters && bind.table_filters->HasFilters()) ||
                            !bind.partition_indices.empty() ||
                            column_ids_need_reader_projection(bind.column_ids, bind.names.size());
   if (needs_names && bind.names.empty()) {
@@ -369,7 +370,7 @@ parquet_gpu_ingestible::parquet_gpu_ingestible(std::unique_ptr<parquet_ingestibl
   // AST translation deferred to materialize_table so a task-local stream is used.
   // Filters on hive-partition columns are dropped — those columns aren't in the
   // parquet file (DuckDB prunes them at the file-list level already).
-  if (bind.table_filters && !bind.table_filters->filters.empty()) {
+  if (bind.table_filters && bind.table_filters->HasFilters()) {
     auto duckdb_expression =
       sirius::op::convert_table_filters_to_expression(*bind.table_filters,
                                                       bind.column_ids,

--- a/src/op/scan/scan_utils.cpp
+++ b/src/op/scan/scan_utils.cpp
@@ -17,6 +17,7 @@
 // sirius
 #include <duckdb/planner/expression/bound_conjunction_expression.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
 #include <expression/ast/from_duckdb.hpp>
 #include <helper/type_conversions.hpp>
 #include <log/logging.hpp>
@@ -63,10 +64,12 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
 {
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> filter_expressions;
 
-  for (auto& [column_index, filter] : filters.filters) {
+  for (auto& filter_entry : filters) {
+    auto const column_index = static_cast<duckdb::idx_t>(filter_entry.GetIndex());
+    auto const& filter      = filter_entry.Filter();
     // Skip optional and IS_NOT_NULL filters
-    if (filter->filter_type == duckdb::TableFilterType::OPTIONAL_FILTER ||
-        filter->filter_type == duckdb::TableFilterType::IS_NOT_NULL) {
+    if (filter.filter_type == duckdb::TableFilterType::LEGACY_OPTIONAL_FILTER ||
+        filter.filter_type == duckdb::TableFilterType::LEGACY_IS_NOT_NULL) {
       continue;
     }
 
@@ -83,7 +86,7 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
                      column_index,
                      primary_idx,
                      col_type.to_string(),
-                     static_cast<int>(filter->filter_type));
+                     static_cast<int>(filter.filter_type));
 
     auto const& batch_pos = batch_position_by_column_id[column_index];
     if (!batch_pos.has_value()) {
@@ -96,7 +99,7 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
 
     auto column_ref = duckdb::make_uniq<duckdb::BoundReferenceExpression>(
       sirius::to_duckdb(col_type), batch_column_index);
-    auto expr = filter->ToExpression(*column_ref);
+    auto expr = filter.ToExpression(*column_ref);
     filter_expressions.push_back(std::move(expr));
   }
 
@@ -106,7 +109,7 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
   auto conjunction =
     duckdb::make_uniq<duckdb::BoundConjunctionExpression>(duckdb::ExpressionType::CONJUNCTION_AND);
   for (auto& expr : filter_expressions) {
-    conjunction->children.push_back(std::move(expr));
+    conjunction->GetChildrenMutable().push_back(std::move(expr));
   }
   return conjunction;
 }

--- a/src/op/sirius_physical_gpu_values.cpp
+++ b/src/op/sirius_physical_gpu_values.cpp
@@ -35,6 +35,7 @@
 #include <duckdb/common/types/data_chunk.hpp>
 #include <duckdb/common/types/validity_mask.hpp>
 #include <duckdb/common/types/vector.hpp>
+#include <duckdb/common/vector/flat_vector.hpp>
 
 #include <algorithm>
 #include <cstring>

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -74,7 +74,7 @@ static void collect_bound_ref_indices(const duckdb::Expression& expr,
                                       std::unordered_set<std::size_t>& indices)
 {
   if (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
-    indices.insert(expr.Cast<duckdb::BoundReferenceExpression>().index);
+    indices.insert(expr.Cast<duckdb::BoundReferenceExpression>().Index());
     return;
   }
   duckdb::ExpressionIterator::EnumerateChildren(
@@ -340,17 +340,17 @@ sirius_physical_hash_join::sirius_physical_hash_join(
     auto right_class = right_expr->GetExpressionClass();
 
     if (left_class == duckdb::ExpressionClass::BOUND_REF) {
-      left_key_col_indices.push_back(left_expr->Cast<duckdb::BoundReferenceExpression>().index);
-    } else if (left_class == duckdb::ExpressionClass::BOUND_CAST) {
-      auto& bound_cast = left_expr->Cast<duckdb::BoundCastExpression>();
-      if (bound_cast.child->GetExpressionClass() != duckdb::ExpressionClass::BOUND_REF) {
+      left_key_col_indices.push_back(left_expr->Cast<duckdb::BoundReferenceExpression>().Index());
+    } else if (duckdb::BoundCastExpression::IsCast(*left_expr)) {
+      auto& cast_child =
+        duckdb::BoundCastExpression::Child(left_expr->Cast<duckdb::BoundFunctionExpression>());
+      if (cast_child.GetExpressionClass() != duckdb::ExpressionClass::BOUND_REF) {
         throw std::runtime_error(
           "Unsupported join condition: BOUND_CAST child is not BOUND_REF (left)");
       }
-      left_key_col_indices.push_back(
-        bound_cast.child->Cast<duckdb::BoundReferenceExpression>().index);
+      left_key_col_indices.push_back(cast_child.Cast<duckdb::BoundReferenceExpression>().Index());
       cast_info.cast_left        = true;
-      cast_info.left_target_type = duckdb::GetCudfType(left_expr->return_type);
+      cast_info.left_target_type = duckdb::GetCudfType(left_expr->GetReturnType());
       cast_necessary             = true;
     } else {
       throw std::runtime_error("Unsupported join condition left expression");
@@ -358,17 +358,17 @@ sirius_physical_hash_join::sirius_physical_hash_join(
 
     // Extract right key index (may be BOUND_REF or BOUND_CAST wrapping a BOUND_REF)
     if (right_class == duckdb::ExpressionClass::BOUND_REF) {
-      right_key_col_indices.push_back(right_expr->Cast<duckdb::BoundReferenceExpression>().index);
-    } else if (right_class == duckdb::ExpressionClass::BOUND_CAST) {
-      auto& bound_cast = right_expr->Cast<duckdb::BoundCastExpression>();
-      if (bound_cast.child->GetExpressionClass() != duckdb::ExpressionClass::BOUND_REF) {
+      right_key_col_indices.push_back(right_expr->Cast<duckdb::BoundReferenceExpression>().Index());
+    } else if (duckdb::BoundCastExpression::IsCast(*right_expr)) {
+      auto& cast_child =
+        duckdb::BoundCastExpression::Child(right_expr->Cast<duckdb::BoundFunctionExpression>());
+      if (cast_child.GetExpressionClass() != duckdb::ExpressionClass::BOUND_REF) {
         throw std::runtime_error(
           "Unsupported join condition: BOUND_CAST child is not BOUND_REF (right)");
       }
-      right_key_col_indices.push_back(
-        bound_cast.child->Cast<duckdb::BoundReferenceExpression>().index);
+      right_key_col_indices.push_back(cast_child.Cast<duckdb::BoundReferenceExpression>().Index());
       cast_info.cast_right        = true;
-      cast_info.right_target_type = duckdb::GetCudfType(right_expr->return_type);
+      cast_info.right_target_type = duckdb::GetCudfType(right_expr->GetReturnType());
       cast_necessary              = true;
     } else {
       throw std::runtime_error("Unsupported join condition right expression");

--- a/src/op/sirius_physical_merge_sort.cpp
+++ b/src/op/sirius_physical_merge_sort.cpp
@@ -130,10 +130,10 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
   null_precedence.reserve(orders.size());
 
   for (auto const& ord : orders) {
-    if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
+    if (ord.expression->GetExpressionClass() != duckdb::ExpressionClass::BOUND_REF) {
       throw not_implemented_exception("Merge sort only supports bound reference expressions");
     }
-    auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
+    auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().Index());
     order_key_idx.push_back(idx);
     column_order.push_back(to_cudf_order(ord.type));
     null_precedence.push_back(to_cudf_null_order(ord.type, ord.null_order));

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -203,9 +203,9 @@ bool sirius_physical_nested_loop_join::is_supported(
   if (join_type == duckdb::JoinType::MARK) { return true; }
   for (auto& cond : conditions) {
     auto left_expr = sirius::ast::to_duckdb(*cond.left);
-    if (left_expr->return_type.InternalType() == duckdb::PhysicalType::STRUCT ||
-        left_expr->return_type.InternalType() == duckdb::PhysicalType::LIST ||
-        left_expr->return_type.InternalType() == duckdb::PhysicalType::ARRAY) {
+    if (left_expr->GetReturnType().InternalType() == duckdb::PhysicalType::STRUCT ||
+        left_expr->GetReturnType().InternalType() == duckdb::PhysicalType::LIST ||
+        left_expr->GetReturnType().InternalType() == duckdb::PhysicalType::ARRAY) {
       return false;
     }
   }
@@ -228,7 +228,7 @@ duckdb::vector<sirius::logical_type> sirius_physical_nested_loop_join::get_join_
   duckdb::vector<sirius::logical_type> result;
   for (auto& op : conditions) {
     auto right_expr = sirius::ast::to_duckdb(*op.right);
-    result.push_back(sirius::from_duckdb(right_expr->return_type));
+    result.push_back(sirius::from_duckdb(right_expr->GetReturnType()));
   }
   return result;
 }
@@ -369,19 +369,20 @@ const cudf::ast::expression& fold_logical_and(
 // subquery result = single column, index 0).
 bool get_column_index(const duckdb::Expression& expr, cudf::size_type& out_idx)
 {
-  if (expr.expression_class == duckdb::ExpressionClass::BOUND_REF) {
-    out_idx = static_cast<cudf::size_type>(expr.Cast<duckdb::BoundReferenceExpression>().index);
+  if (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
+    out_idx = static_cast<cudf::size_type>(expr.Cast<duckdb::BoundReferenceExpression>().Index());
     return true;
   }
-  if (expr.expression_class == duckdb::ExpressionClass::BOUND_CAST) {
-    const auto& cast_expr = expr.Cast<duckdb::BoundCastExpression>();
-    if (cast_expr.child->expression_class == duckdb::ExpressionClass::BOUND_REF) {
-      out_idx = static_cast<cudf::size_type>(
-        cast_expr.child->Cast<duckdb::BoundReferenceExpression>().index);
+  if (duckdb::BoundCastExpression::IsCast(expr)) {
+    const auto& cast_child =
+      duckdb::BoundCastExpression::Child(expr.Cast<duckdb::BoundFunctionExpression>());
+    if (cast_child.GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
+      out_idx =
+        static_cast<cudf::size_type>(cast_child.Cast<duckdb::BoundReferenceExpression>().Index());
       return true;
     }
   }
-  if (expr.expression_class == duckdb::ExpressionClass::BOUND_SUBQUERY) {
+  if (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_SUBQUERY) {
     out_idx = 0;
     return true;
   }
@@ -690,11 +691,11 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
         col_views.push_back(expr_view.column(0));
         expression_res_scope_hodler.push_back(std::move(expr_result_table));
       } else {
-        auto target_type = duckdb::GetCudfType(expr.return_type);
+        auto target_type = duckdb::GetCudfType(expr.GetReturnType());
 
         // now lets see if we have to cast
         if (table.column(source_idx).type() != target_type) {
-          if (expr.expression_class != duckdb::ExpressionClass::BOUND_CAST) {
+          if (!duckdb::BoundCastExpression::IsCast(expr)) {
             // We might want to just change this to an ASSERT
             throw std::runtime_error(
               "sirius_physical_nested_loop_join: unexpected, column type does not match, yet "

--- a/src/op/sirius_physical_order.cpp
+++ b/src/op/sirius_physical_order.cpp
@@ -56,10 +56,10 @@ std::unique_ptr<operator_data> sirius_physical_order::execute(const operator_dat
   null_precedence.reserve(orders.size());
 
   for (auto const& ord : orders) {
-    if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
+    if (ord.expression->GetExpressionClass() != duckdb::ExpressionClass::BOUND_REF) {
       throw not_implemented_exception("Order by only supports bound reference expressions");
     }
-    auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
+    auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().Index());
     order_key_idx.push_back(idx);
     column_order.push_back(to_cudf_order(ord.type));
     null_precedence.push_back(to_cudf_null_order(ord.type, ord.null_order));

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -41,12 +41,13 @@ namespace {
 std::optional<std::size_t> extract_bound_ref_index(const duckdb::Expression& expr)
 {
   if (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
-    return expr.Cast<duckdb::BoundReferenceExpression>().index;
+    return expr.Cast<duckdb::BoundReferenceExpression>().Index();
   }
-  if (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_CAST) {
-    auto& cast_expr = expr.Cast<duckdb::BoundCastExpression>();
-    if (cast_expr.child->GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
-      return cast_expr.child->Cast<duckdb::BoundReferenceExpression>().index;
+  if (duckdb::BoundCastExpression::IsCast(expr)) {
+    auto& cast_child =
+      duckdb::BoundCastExpression::Child(expr.Cast<duckdb::BoundFunctionExpression>());
+    if (cast_child.GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
+      return cast_child.Cast<duckdb::BoundReferenceExpression>().Index();
     }
   }
   return std::nullopt;
@@ -117,8 +118,8 @@ void sirius_physical_partition::get_partition_keys_and_type(sirius_physical_oper
         } else {
           _partition_keys.push_back(left_index.value());
         }
-        if (key_expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_CAST) {
-          _partition_key_cast_types.push_back(duckdb::GetCudfType(key_expr.return_type));
+        if (duckdb::BoundCastExpression::IsCast(key_expr)) {
+          _partition_key_cast_types.push_back(duckdb::GetCudfType(key_expr.GetReturnType()));
         } else {
           _partition_key_cast_types.push_back(cudf::data_type{cudf::type_id::EMPTY});
         }
@@ -140,7 +141,7 @@ void sirius_physical_partition::get_partition_keys_and_type(sirius_physical_oper
     //   for (auto& group_idx : grouped_aggregate_op.grouping_sets[i]) {
     //     auto& group = grouped_aggregate_op.grouped_aggregate_data.groups[group_idx];
     //     if (group->GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
-    //       _partition_keys.push_back(group->Cast<duckdb::BoundReferenceExpression>().index);
+    //       _partition_keys.push_back(group->Cast<duckdb::BoundReferenceExpression>().Index());
     //     }
     //   }
     // }

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -56,7 +56,7 @@ sirius_physical_result_collector::sirius_physical_result_collector(
     statement_type(data.prepared->statement_type),
     properties(data.prepared->properties),
     plan(*data.sirius_physical_plan),
-    names(data.prepared->names)
+    names(from_duckdb_names(data.prepared->names))
 {
   this->types = sirius::from_duckdb_vec(data.prepared->types);
   // Full DuckDB types incl. nested children — sirius::logical_type cannot

--- a/src/op/sirius_physical_sort_partition.cpp
+++ b/src/op/sirius_physical_sort_partition.cpp
@@ -80,10 +80,10 @@ std::unique_ptr<operator_data> sirius_physical_sort_partition::execute(
   null_precedence.reserve(orders.size());
 
   for (auto const& ord : orders) {
-    if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
+    if (ord.expression->GetExpressionClass() != duckdb::ExpressionClass::BOUND_REF) {
       throw not_implemented_exception("Sort partition only supports bound reference expressions");
     }
-    auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
+    auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().Index());
     order_key_idx.push_back(idx);
     column_order.push_back(to_cudf_order(ord.type));
     null_precedence.push_back(to_cudf_null_order(ord.type, ord.null_order));

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -209,10 +209,10 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
     null_precedence.reserve(orders.size());
 
     for (auto const& ord : orders) {
-      if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
+      if (ord.expression->GetExpressionClass() != duckdb::ExpressionClass::BOUND_REF) {
         throw not_implemented_exception("Sort sample only supports bound reference expressions");
       }
-      auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
+      auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().Index());
       order_key_idx.push_back(idx);
       column_order.push_back(to_cudf_order(ord.type));
       null_precedence.push_back(to_cudf_null_order(ord.type, ord.null_order));

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -31,6 +31,7 @@
 
 #include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
 
 #include <format>
 

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -63,11 +63,11 @@ std::unique_ptr<cudf::table> compute_top_n_table(
   std::unique_ptr<cudf::table> kept;
   if (orders.size() == 1) {
     auto const& ord = orders[0];
-    if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
+    if (ord.expression->GetExpressionClass() != duckdb::ExpressionClass::BOUND_REF) {
       throw not_implemented_exception("TopN only supports bound reference expressions");
     }
-    auto const idx =
-      static_cast<cudf::size_type>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
+    auto const idx = static_cast<cudf::size_type>(
+      ord.expression->Cast<duckdb::BoundReferenceExpression>().Index());
     if (idx < 0 || idx >= input.num_columns()) {
       throw internal_exception("TopN order index out of range");
     }
@@ -109,11 +109,11 @@ std::unique_ptr<cudf::table> compute_top_n_table(
     null_orders.reserve(orders.size());
 
     for (auto const& ord : orders) {
-      if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
+      if (ord.expression->GetExpressionClass() != duckdb::ExpressionClass::BOUND_REF) {
         throw not_implemented_exception("TopN only supports bound reference expressions");
       }
       auto const idx = static_cast<cudf::size_type>(
-        ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
+        ord.expression->Cast<duckdb::BoundReferenceExpression>().Index());
       if (idx < 0 || idx >= input.num_columns()) {
         throw internal_exception("TopN order index out of range");
       }

--- a/src/pipeline/sirius_plan_printer.cpp
+++ b/src/pipeline/sirius_plan_printer.cpp
@@ -313,7 +313,7 @@ std::vector<std::string> sirius_plan_printer::get_operator_detail_lines(
   std::string scan_name;
   switch (op.type) {
     case op::SiriusPhysicalOperatorType::TABLE_SCAN:
-      scan_name = op.Cast<op::sirius_physical_table_scan>().function.name;
+      scan_name = op.Cast<op::sirius_physical_table_scan>().function.name.GetIdentifierName();
       break;
     default: break;
   }

--- a/src/planner/duckdb_join_filter_candidate_adapter.cpp
+++ b/src/planner/duckdb_join_filter_candidate_adapter.cpp
@@ -319,7 +319,7 @@ duckdb_join_filter_candidate extract(duckdb::LogicalComparisonJoin const& op)
       return malformed();
     }
     condition_indexes.push_back(condition_index);
-    condition_comparisons.push_back(op.conditions[condition_index].comparison);
+    condition_comparisons.push_back(op.conditions[condition_index].GetComparisonType());
   }
 
   if (info.probe_info.empty()) {

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -23,14 +23,17 @@
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/execution/column_binding_resolver.hpp"
 #include "duckdb/function/table/table_scan.hpp"
+#include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/main/profiler/metrics.hpp"
 #include "duckdb/main/query_profiler.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/list.hpp"
 #include "duckdb/planner/operator/logical_extension_operator.hpp"
 #include "duckdb/planner/table_filter.hpp"
+#include "duckdb/planner/table_filter_set.hpp"
 #include "duckdb/storage/storage_manager.hpp"
 #include "log/logging.hpp"
 #include "op/scan/duckdb_native_gpu_ingestible.hpp"
@@ -175,9 +178,9 @@ build_duckdb_native_table_info(sirius::op::sirius_physical_table_scan& scan_op,
   // DuckTableEntry so it matches the pin-side derivation (build_duckdb_pin_info)
   // exactly. Without these a pin_table(format='duckdb', ...) query silently misses
   // the pinned cache and falls through to disk.
-  info->catalog_name           = table.ParentCatalog().GetName();
-  info->schema_name            = table.ParentSchema().name;
-  info->table_name             = table.name;
+  info->catalog_name           = table.ParentCatalog().GetName().GetIdentifierName();
+  info->schema_name            = table.ParentSchema().name.GetIdentifierName();
+  info->table_name             = table.name.GetIdentifierName();
   info->approximate_batch_size = op_params.scan_task_batch_size;
 
   std::vector<std::size_t> source_ids_fallback;
@@ -208,12 +211,7 @@ build_duckdb_native_table_info(sirius::op::sirius_physical_table_scan& scan_op,
   }
 
   // Filters drive row-group pruning in the metadata walk and post-decode filtering.
-  if (scan_op.table_filters) {
-    info->table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
-    for (auto& [col_idx, filt] : scan_op.table_filters->filters) {
-      info->table_filters->filters[col_idx] = filt->Copy();
-    }
-  }
+  if (scan_op.table_filters) { info->table_filters = scan_op.table_filters->Copy(); }
   info->column_ids     = scan_op.column_ids;
   info->projection_ids = scan_op.projection_ids;
   info->returned_types = scan_op.returned_types;
@@ -661,12 +659,12 @@ void sirius_physical_plan_generator::reject_nested_column_operation(duckdb::Expr
                                                                     std::string_view operation)
 {
   // A nested-typed BOUND_REF names the offending column directly.
-  if (is_nested_logical_type(expr.return_type) &&
+  if (is_nested_logical_type(expr.GetReturnType()) &&
       expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
-    auto name = expr.GetName();
+    std::string name = expr.GetName().GetIdentifierName();
     if (name.empty()) { name = expr.ToString(); }
     throw std::runtime_error("nested column operation on column '" + name + "' (" +
-                             expr.return_type.ToString() + ") is unsupported in " +
+                             expr.GetReturnType().ToString() + ") is unsupported in " +
                              std::string(operation) +
                              ": Sirius reads and projects nested columns but cannot operate on "
                              "them yet");
@@ -680,9 +678,9 @@ void sirius_physical_plan_generator::reject_nested_column_operation(duckdb::Expr
 
   // Constructed nested values (struct_pack, list constructors, ...) cannot run
   // on the GPU path either.
-  if (is_nested_logical_type(expr.return_type)) {
+  if (is_nested_logical_type(expr.GetReturnType())) {
     throw std::runtime_error("nested column operation on '" + expr.ToString() + "' (" +
-                             expr.return_type.ToString() + ") is unsupported in " +
+                             expr.GetReturnType().ToString() + ") is unsupported in " +
                              std::string(operation));
   }
 }
@@ -905,20 +903,23 @@ sirius_physical_plan_generator::create_plan(duckdb::unique_ptr<duckdb::LogicalOp
   auto& profiler = duckdb::QueryProfiler::Get(context);
 
   // Resolve the types of each operator.
-  profiler.StartPhase(duckdb::MetricType::PHYSICAL_PLANNER_RESOLVE_TYPES);
-  op->ResolveOperatorTypes();
-  profiler.EndPhase();
+  {
+    auto timer = profiler.StartTimer<duckdb::MetricPhysicalPlannerResolveTypes>();
+    op->ResolveOperatorTypes();
+  }
 
   // Resolve the column references.
-  profiler.StartPhase(duckdb::MetricType::PHYSICAL_PLANNER_COLUMN_BINDING);
-  duckdb::ColumnBindingResolver resolver;
-  resolver.VisitOperator(*op);
-  profiler.EndPhase();
+  {
+    auto timer = profiler.StartTimer<duckdb::MetricPhysicalPlannerColumnBinding>();
+    duckdb::ColumnBindingResolver resolver;
+    resolver.VisitOperator(*op);
+  }
 
   // then create the main physical plan
-  profiler.StartPhase(duckdb::MetricType::PHYSICAL_PLANNER_CREATE_PLAN);
-  auto plan = create_plan(*op);
-  profiler.EndPhase();
+  auto plan = [&] {
+    auto timer = profiler.StartTimer<duckdb::MetricPhysicalPlannerCreatePlan>();
+    return create_plan(*op);
+  }();
 
   plan = fold_adjacent_projections(std::move(plan));
   plan->verify();

--- a/src/planner/sirius_plan_aggregate.cpp
+++ b/src/planner/sirius_plan_aggregate.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/execution/operator/aggregate/physical_perfecthash_aggregate.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/function/partition_stats.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
@@ -81,33 +82,33 @@ duckdb::unique_ptr<sirius::op::sirius_physical_operator> extract_aggregate_expre
   // bind sorted aggregates
   for (auto& aggr : aggregates) {
     auto& bound_aggr = aggr->Cast<duckdb::BoundAggregateExpression>();
-    if (bound_aggr.order_bys) {
+    if (bound_aggr.GetOrderBys()) {
       duckdb::FunctionBinder::BindSortedAggregate(context, bound_aggr, groups, grouping_sets);
     }
   }
   for (auto& group : groups) {
-    auto ref =
-      duckdb::make_uniq<duckdb::BoundReferenceExpression>(group->return_type, expressions.size());
-    types.push_back(group->return_type);
+    auto ref = duckdb::make_uniq<duckdb::BoundReferenceExpression>(group->GetReturnType(),
+                                                                   expressions.size());
+    types.push_back(group->GetReturnType());
     expressions.push_back(std::move(group));
     group = std::move(ref);
   }
   for (auto& aggr : aggregates) {
     auto& bound_aggr = aggr->Cast<duckdb::BoundAggregateExpression>();
-    for (auto& child_expr : bound_aggr.children) {
-      auto ref = duckdb::make_uniq<duckdb::BoundReferenceExpression>(child_expr->return_type,
+    for (auto& child_expr : bound_aggr.GetChildrenMutable()) {
+      auto ref = duckdb::make_uniq<duckdb::BoundReferenceExpression>(child_expr->GetReturnType(),
                                                                      expressions.size());
-      types.push_back(child_expr->return_type);
+      types.push_back(child_expr->GetReturnType());
       expressions.push_back(std::move(child_expr));
       child_expr = std::move(ref);
     }
-    if (bound_aggr.filter) {
-      auto& filter = bound_aggr.filter;
-      auto ref     = duckdb::make_uniq<duckdb::BoundReferenceExpression>(filter->return_type,
+    if (bound_aggr.GetFilter()) {
+      auto& filter = bound_aggr.GetFilterMutable();
+      auto ref     = duckdb::make_uniq<duckdb::BoundReferenceExpression>(filter->GetReturnType(),
                                                                      expressions.size());
-      types.push_back(filter->return_type);
+      types.push_back(filter->GetReturnType());
       expressions.push_back(std::move(filter));
-      bound_aggr.filter = std::move(ref);
+      bound_aggr.GetFilterMutable() = std::move(ref);
     }
   }
   if (expressions.empty()) { return child; }
@@ -149,7 +150,7 @@ static bool can_use_partitioned_aggregate(duckdb::ClientContext& context,
     // only support bound reference here
     if (group_expr->GetExpressionType() != duckdb::ExpressionType::BOUND_REF) { return false; }
     auto& ref = group_expr->Cast<duckdb::BoundReferenceExpression>();
-    partition_columns.push_back(ref.index);
+    partition_columns.push_back(ref.Index());
   }
   // traverse the children of the aggregate to find the source operator
   duckdb::reference<sirius::op::sirius_physical_operator> child_ref(child);
@@ -219,7 +220,7 @@ static bool can_use_perfect_hash_aggregate(duckdb::ClientContext& context,
     auto& group = op.groups[group_idx];
     auto& stats = op.group_stats[group_idx];
 
-    switch (group->return_type.InternalType()) {
+    switch (group->GetReturnType().InternalType()) {
       case duckdb::PhysicalType::INT8:
       case duckdb::PhysicalType::INT16:
       case duckdb::PhysicalType::INT32:
@@ -233,7 +234,7 @@ static bool can_use_perfect_hash_aggregate(duckdb::ClientContext& context,
         return false;
     }
     // check if the group has stats available
-    auto& group_type = group->return_type;
+    auto& group_type = group->GetReturnType();
     if (!stats) {
       // no stats, but we might still be able to use perfect hashing if the type is small enough
       // for small types we can just set the stats to [type_min, type_max]
@@ -297,7 +298,7 @@ static bool can_use_perfect_hash_aggregate(duckdb::ClientContext& context,
   }
   for (auto& expression : op.expressions) {
     auto& aggregate = expression->Cast<duckdb::BoundAggregateExpression>();
-    if (aggregate.IsDistinct() || !aggregate.function.combine) {
+    if (aggregate.IsDistinct() || !aggregate.Function().HasStateCombineCallback()) {
       // distinct aggregates are not supported in perfect hash aggregates
       return false;
     }
@@ -315,8 +316,8 @@ static void downcast_hugeint_types(duckdb::vector<duckdb::LogicalType>& types,
     if (type == duckdb::LogicalType::HUGEINT) { type = duckdb::LogicalType::BIGINT; }
   }
   for (auto& expr : exprs) {
-    if (expr->return_type == duckdb::LogicalType::HUGEINT) {
-      expr->return_type = duckdb::LogicalType::BIGINT;
+    if (expr->GetReturnType() == duckdb::LogicalType::HUGEINT) {
+      expr->SetReturnType(duckdb::LogicalType::BIGINT);
     }
   }
 }
@@ -342,7 +343,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
   bool can_use_simple_aggregation = true;
   for (auto& expression : op.expressions) {
     auto& aggregate = expression->Cast<duckdb::BoundAggregateExpression>();
-    if (!aggregate.function.simple_update) {
+    if (!aggregate.Function().GetStateClusterUpdateCallback()) {
       // unsupported aggregate for simple aggregation: use hash aggregation
       can_use_simple_aggregation = false;
       break;
@@ -378,6 +379,20 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
   // use a partitioned or perfect hash aggregate if possible
   duckdb::vector<duckdb::column_t> partition_columns;
   duckdb::vector<std::size_t> required_bits;
+
+  // DuckDB tracks grouping-function columns as ProjectionIndex; the sirius
+  // operator keeps plain positions. Converted once up front — the three
+  // construction branches below are mutually exclusive.
+  duckdb::vector<duckdb::unsafe_vector<std::size_t>> grouping_functions;
+  grouping_functions.reserve(op.grouping_functions.size());
+  for (auto const& grouping_function : op.grouping_functions) {
+    duckdb::unsafe_vector<std::size_t> positions;
+    positions.reserve(grouping_function.size());
+    for (auto const& position : grouping_function) {
+      positions.push_back(position.GetIndex());
+    }
+    grouping_functions.push_back(std::move(positions));
+  }
   if (can_use_simple_aggregation &&
       can_use_partitioned_aggregate(context, op, *plan, partition_columns)) {
     auto group_by = duckdb::make_uniq_base<sirius::op::sirius_physical_operator,
@@ -386,7 +401,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
       translate_expressions(std::move(op.expressions)),
       translate_expressions(std::move(op.groups)),
       std::move(op.grouping_sets),
-      std::move(op.grouping_functions),
+      std::move(grouping_functions),
       op.estimated_cardinality,
       group_validity,
       op.distinct_validity);
@@ -401,7 +416,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
       translate_expressions(std::move(op.expressions)),
       translate_expressions(std::move(op.groups)),
       std::move(op.grouping_sets),
-      std::move(op.grouping_functions),
+      std::move(grouping_functions),
       op.estimated_cardinality,
       group_validity,
       op.distinct_validity);
@@ -415,7 +430,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
     translate_expressions(std::move(op.expressions)),
     translate_expressions(std::move(op.groups)),
     std::move(op.grouping_sets),
-    std::move(op.grouping_functions),
+    std::move(grouping_functions),
     op.estimated_cardinality,
     group_validity,
     op.distinct_validity);

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -162,7 +162,7 @@ static std::unordered_set<duckdb::idx_t> prove_unique_columns(duckdb::LogicalOpe
       for (duckdb::idx_t i = 0; i < proj.expressions.size(); i++) {
         auto& expr = proj.expressions[i];
         if (expr->GetExpressionClass() != duckdb::ExpressionClass::BOUND_REF) { continue; }
-        auto child_idx = expr->Cast<duckdb::BoundReferenceExpression>().index;
+        auto child_idx = expr->Cast<duckdb::BoundReferenceExpression>().Index();
         if (child_unique.count(child_idx)) { remapped.insert(i); }
       }
       // All child unique columns must map through.
@@ -181,12 +181,12 @@ static std::unordered_set<duckdb::idx_t> prove_unique_columns(duckdb::LogicalOpe
       // Collect equality key columns on each side (only direct column refs).
       std::unordered_set<duckdb::idx_t> left_eq_keys, right_eq_keys;
       for (const auto& c : join.conditions) {
-        if (c.comparison != duckdb::ExpressionType::COMPARE_EQUAL) { continue; }
-        if (c.left->GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
-          left_eq_keys.insert(c.left->Cast<duckdb::BoundReferenceExpression>().index);
+        if (c.GetComparisonType() != duckdb::ExpressionType::COMPARE_EQUAL) { continue; }
+        if (c.GetLHS().GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
+          left_eq_keys.insert(c.GetLHS().Cast<duckdb::BoundReferenceExpression>().Index());
         }
-        if (c.right->GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
-          right_eq_keys.insert(c.right->Cast<duckdb::BoundReferenceExpression>().index);
+        if (c.GetRHS().GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
+          right_eq_keys.insert(c.GetRHS().Cast<duckdb::BoundReferenceExpression>().Index());
         }
       }
 
@@ -228,7 +228,7 @@ static std::unordered_set<duckdb::idx_t> prove_unique_columns(duckdb::LogicalOpe
 
       // Remap child unique indices through a projection map to output positions.
       auto remap = [](const std::unordered_set<duckdb::idx_t>& child_unique,
-                      const duckdb::vector<duckdb::idx_t>& proj_map,
+                      const duckdb::vector<duckdb::ProjectionIndex>& proj_map,
                       duckdb::idx_t offset) -> std::unordered_set<duckdb::idx_t> {
         std::unordered_set<duckdb::idx_t> mapped;
         if (proj_map.empty()) {
@@ -300,7 +300,7 @@ duckdb::LogicalGet* trace_binding_to_get(duckdb::LogicalOperator& node,
         return nullptr;
       }
       return trace_binding_to_get(*node.children[0],
-                                  expr.Cast<duckdb::BoundColumnRefExpression>().binding);
+                                  expr.Cast<duckdb::BoundColumnRefExpression>().Binding());
     }
     case duckdb::LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
       auto& aggr = node.Cast<duckdb::LogicalAggregate>();
@@ -313,7 +313,7 @@ duckdb::LogicalGet* trace_binding_to_get(duckdb::LogicalOperator& node,
         return nullptr;
       }
       return trace_binding_to_get(*node.children[0],
-                                  expr.Cast<duckdb::BoundColumnRefExpression>().binding);
+                                  expr.Cast<duckdb::BoundColumnRefExpression>().Binding());
     }
     default: {
       // Table indexes are binder-unique, so recursing into every child finds the owning subtree
@@ -338,10 +338,10 @@ std::vector<std::size_t> build_key_domain_cardinalities(duckdb::LogicalCompariso
   for (std::size_t k = 0; k < pushed.size(); ++k) {
     auto const cond_idx = pushed[k];
     if (cond_idx >= op.conditions.size()) { continue; }
-    auto& key = *op.conditions[cond_idx].right;
+    auto& key = op.conditions[cond_idx].GetRHS();
     if (key.GetExpressionClass() != duckdb::ExpressionClass::BOUND_COLUMN_REF) { continue; }
     auto* get =
-      trace_binding_to_get(*op.children[1], key.Cast<duckdb::BoundColumnRefExpression>().binding);
+      trace_binding_to_get(*op.children[1], key.Cast<duckdb::BoundColumnRefExpression>().Binding());
     if (get == nullptr) { continue; }
     std::size_t card = 0;
     if (get->function.cardinality) {
@@ -364,9 +364,9 @@ std::vector<std::size_t> build_key_domain_cardinalities(duckdb::LogicalCompariso
 static bool is_trivial_key_side(const duckdb::Expression& expr)
 {
   if (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) { return true; }
-  if (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_CAST) {
-    return expr.Cast<duckdb::BoundCastExpression>().child->GetExpressionClass() ==
-           duckdb::ExpressionClass::BOUND_REF;
+  if (duckdb::BoundCastExpression::IsCast(expr)) {
+    return duckdb::BoundCastExpression::Child(expr.Cast<duckdb::BoundFunctionExpression>())
+             .GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF;
   }
   return false;
 }
@@ -393,7 +393,7 @@ static void materialize_expression_join_keys(
   duckdb::unique_ptr<sirius::op::sirius_physical_operator>& right)
 {
   auto materialize_side = [&](duckdb::unique_ptr<sirius::op::sirius_physical_operator>& child,
-                              duckdb::vector<duckdb::idx_t>& projection_map,
+                              duckdb::vector<duckdb::ProjectionIndex>& projection_map,
                               bool is_left) {
     const std::size_t old_width = child->types.size();
 
@@ -403,17 +403,17 @@ static void materialize_expression_join_keys(
     duckdb::vector<sirius::logical_type> key_types;
     for (std::size_t i = 0; i < op.conditions.size(); i++) {
       auto& cond = op.conditions[i];
-      if (cond.comparison != duckdb::ExpressionType::COMPARE_EQUAL &&
-          cond.comparison != duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+      if (cond.GetComparisonType() != duckdb::ExpressionType::COMPARE_EQUAL &&
+          cond.GetComparisonType() != duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
         continue;  // inequality sides are evaluated inline as the mixed-join predicate
       }
-      auto& side_expr = is_left ? cond.left : cond.right;
+      auto& side_expr = is_left ? cond.LeftReference() : cond.RightReference();
       if (is_trivial_key_side(*side_expr)) { continue; }
       auto node = sirius::ast::from_duckdb(*side_expr);
       if (!node) { continue; }  // untranslatable: leave for the existing downstream throw
       cond_indices.push_back(i);
       key_exprs.push_back(std::move(node));
-      key_types.push_back(sirius::from_duckdb(side_expr->return_type));
+      key_types.push_back(sirius::from_duckdb(side_expr->GetReturnType()));
     }
 
     if (cond_indices.empty()) { return; }
@@ -440,10 +440,10 @@ static void materialize_expression_join_keys(
     // Rewrite each materialized condition side to reference its appended column.
     for (std::size_t k = 0; k < cond_indices.size(); k++) {
       const std::size_t new_index = old_width + k;
-      auto& side_expr =
-        is_left ? op.conditions[cond_indices[k]].left : op.conditions[cond_indices[k]].right;
+      auto& side_expr             = is_left ? op.conditions[cond_indices[k]].LeftReference()
+                                            : op.conditions[cond_indices[k]].RightReference();
       side_expr =
-        duckdb::make_uniq<duckdb::BoundReferenceExpression>(side_expr->return_type, new_index);
+        duckdb::make_uniq<duckdb::BoundReferenceExpression>(side_expr->GetReturnType(), new_index);
     }
 
     // Exclude the synthetic key column(s) from the join output. An empty projection map means
@@ -453,7 +453,7 @@ static void materialize_expression_join_keys(
     if (projection_map.empty()) {
       projection_map.reserve(old_width);
       for (std::size_t c = 0; c < old_width; c++) {
-        projection_map.push_back(static_cast<duckdb::idx_t>(c));
+        projection_map.push_back(duckdb::ProjectionIndex(c));
       }
     }
   };
@@ -470,8 +470,8 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
 
   // Reject nested join keys before planning either child.
   for (auto const& condition : op.conditions) {
-    reject_nested_column_operation(*condition.left, "a join condition");
-    reject_nested_column_operation(*condition.right, "a join condition");
+    reject_nested_column_operation(condition.GetLHS(), "a join condition");
+    reject_nested_column_operation(condition.GetRHS(), "a join condition");
   }
 
   std::size_t lhs_cardinality = op.children[0]->EstimateCardinality(context);
@@ -627,8 +627,8 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
       std::move(right),
       std::move(conditions),
       op.join_type,
-      op.left_projection_map,
-      op.right_projection_map,
+      sirius::from_duckdb_projection_ids(op.left_projection_map),
+      sirius::from_duckdb_projection_ids(op.right_projection_map),
       sirius::from_duckdb_vec(op.mark_types),
       op.estimated_cardinality,
       std::move(op.filter_pushdown),
@@ -636,8 +636,19 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
       std::move(filter_plan),
       op_params.hash_partition_bytes,
       op_params.max_broadcast_join_size);
-    auto& hj                        = join->Cast<sirius::op::sirius_physical_hash_join>();
-    hj.join_stats                   = std::move(op.join_stats);
+    auto& hj = join->Cast<sirius::op::sirius_physical_hash_join>();
+    // DuckDB moved join-key statistics out of LogicalJoin and into the individual
+    // JoinConditions; rebuild the flat [left, right] per-condition vector. Kept
+    // all-or-nothing, matching the old optimizer, which cleared the whole vector
+    // whenever a condition was dropped.
+    for (auto const& cond : op.conditions) {
+      if (!cond.IsComparison() || !cond.GetLeftStats() || !cond.GetRightStats()) {
+        hj.join_stats.clear();
+        break;
+      }
+      hj.join_stats.push_back(cond.GetLeftStats()->ToUnique());
+      hj.join_stats.push_back(cond.GetRightStats()->ToUnique());
+    }
     hj.mark_join_build_switch_ratio = op_params.mark_join_build_switch_ratio;
 
     // --- Detect build-side key uniqueness ---
@@ -663,7 +674,7 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
           keys_extractable = false;
           break;
         }
-        build_key_cols.insert(right_expr->Cast<duckdb::BoundReferenceExpression>().index);
+        build_key_cols.insert(right_expr->Cast<duckdb::BoundReferenceExpression>().Index());
       }
       if (keys_extractable && !build_key_cols.empty()) {
         // build_side_unique_cols was computed before create_plan (which moves logical node data).
@@ -718,15 +729,15 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
   // }
   if (nlj_is_supported) {
     // inequality join: use nested loop; pass projection maps so output column order matches plan
-    auto join =
-      duckdb::make_uniq<sirius::op::sirius_physical_nested_loop_join>(op,
-                                                                      std::move(left),
-                                                                      std::move(right),
-                                                                      std::move(conditions),
-                                                                      op.join_type,
-                                                                      op.estimated_cardinality,
-                                                                      op.left_projection_map,
-                                                                      op.right_projection_map);
+    auto join = duckdb::make_uniq<sirius::op::sirius_physical_nested_loop_join>(
+      op,
+      std::move(left),
+      std::move(right),
+      std::move(conditions),
+      op.join_type,
+      op.estimated_cardinality,
+      sirius::from_duckdb_projection_ids(op.left_projection_map),
+      sirius::from_duckdb_projection_ids(op.right_projection_map));
     return join;
   }
 

--- a/src/planner/sirius_plan_cte.cpp
+++ b/src/planner/sirius_plan_cte.cpp
@@ -34,9 +34,9 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalMaterializedCTE& op)
   // duckdb::make_shared_ptr<duckdb::GPUIntermediateRelation>(op.children[0]->types.size());
 
   // Add the ColumnDataCollection to the context of this PhysicalPlanGenerator
-  recursive_cte_tables[op.table_index] = working_table;
-  // gpu_recursive_cte_tables[op.table_index] = working_table_gpu;
-  materialized_ctes[op.table_index] =
+  recursive_cte_tables[op.table_index.index] = working_table;
+  // gpu_recursive_cte_tables[op.table_index.index] = working_table_gpu;
+  materialized_ctes[op.table_index.index] =
     duckdb::vector<duckdb::const_reference<sirius::op::sirius_physical_operator>>();
 
   // Create the plan for the left side. This is the materialization.
@@ -51,15 +51,15 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalMaterializedCTE& op)
   // Capture left->types before std::move(left) so argument evaluation order is well-defined.
   auto producer_types = left->types;
   duckdb::unique_ptr<sirius::op::sirius_physical_cte> cte;
-  cte                = duckdb::make_uniq<sirius::op::sirius_physical_cte>(op.ctename,
-                                                           op.table_index,
+  cte = duckdb::make_uniq<sirius::op::sirius_physical_cte>(op.ctename.GetIdentifierName(),
+                                                           op.table_index.index,
                                                            std::move(producer_types),
                                                            std::move(left),
                                                            std::move(right),
                                                            op.estimated_cardinality);
   cte->working_table = working_table;
   // cte->working_table_gpu = working_table_gpu;
-  cte->cte_scans = materialized_ctes[op.table_index];
+  cte->cte_scans = materialized_ctes[op.table_index.index];
 
   return std::move(cte);
 }

--- a/src/planner/sirius_plan_delim_join.cpp
+++ b/src/planner/sirius_plan_delim_join.cpp
@@ -92,9 +92,9 @@ sirius_physical_plan_generator::plan_delim_join(duckdb::LogicalComparisonJoin& o
   for (auto& delim_expr : op.duplicate_eliminated_columns) {
     D_ASSERT(delim_expr->GetExpressionType() == duckdb::ExpressionType::BOUND_REF);
     auto& bound_ref = delim_expr->Cast<duckdb::BoundReferenceExpression>();
-    delim_types.push_back(bound_ref.return_type);
-    distinct_groups.push_back(
-      duckdb::make_uniq<duckdb::BoundReferenceExpression>(bound_ref.return_type, bound_ref.index));
+    delim_types.push_back(bound_ref.GetReturnType());
+    distinct_groups.push_back(duckdb::make_uniq<duckdb::BoundReferenceExpression>(
+      bound_ref.GetReturnType(), bound_ref.Index()));
   }
   // now create the duplicate eliminated join
   duckdb::unique_ptr<sirius::op::sirius_physical_delim_join> delim_join;

--- a/src/planner/sirius_plan_filter.cpp
+++ b/src/planner/sirius_plan_filter.cpp
@@ -74,7 +74,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalFilter& op)
       auto conjunction = duckdb::make_uniq<duckdb::BoundConjunctionExpression>(
         duckdb::ExpressionType::CONJUNCTION_AND);
       for (auto& expr : op.expressions) {
-        conjunction->children.push_back(std::move(expr));
+        conjunction->GetChildrenMutable().push_back(std::move(expr));
       }
       combined = std::move(conjunction);
     } else {

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -69,11 +69,11 @@ duckdb::unique_ptr<duckdb::TableFilterSet> create_table_filter_set(
 {
   // create the table filter map
   auto table_filter_set = duckdb::make_uniq<duckdb::TableFilterSet>();
-  for (auto& table_filter : table_filters.filters) {
+  for (auto& table_filter : table_filters) {
     // find the relative column index from the absolute column index into the table
     duckdb::optional_idx column_index;
     for (std::size_t i = 0; i < column_ids.size(); i++) {
-      if (table_filter.first == column_ids[i].GetPrimaryIndex()) {
+      if (table_filter.GetIndex() == column_ids[i].GetPrimaryIndex()) {
         column_index = i;
         break;
       }
@@ -81,7 +81,8 @@ duckdb::unique_ptr<duckdb::TableFilterSet> create_table_filter_set(
     if (!column_index.IsValid()) {
       throw duckdb::InternalException("Could not find column index for table filter");
     }
-    table_filter_set->filters[column_index.GetIndex()] = std::move(table_filter.second);
+    table_filter_set->PushFilter(duckdb::ProjectionIndex(column_index.GetIndex()),
+                                 table_filter.TakeFilter());
   }
   return table_filter_set;
 }
@@ -95,7 +96,8 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   // functions, etc.) must fall back to CPU.
   static const std::unordered_set<std::string> kSupportedScanFunctions = {
     "seq_scan", "parquet_scan", "read_parquet", "sirius_read_parquet"};
-  if (kSupportedScanFunctions.find(op.function.name) == kSupportedScanFunctions.end()) {
+  if (kSupportedScanFunctions.find(op.function.name.GetIdentifierName()) ==
+      kSupportedScanFunctions.end()) {
     throw duckdb::NotImplementedException("Table function '{}' is not supported in Sirius",
                                           op.function.name);
   }
@@ -160,7 +162,9 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
         if (auto sirius_state =
               context.registered_state->Get<duckdb::SiriusContext>("sirius_state")) {
           entry = sirius_state->get_scan_manager().find_pinned_entry_for_duckdb_table(
-            table.ParentCatalog().GetName(), table.ParentSchema().name, table.name);
+            table.ParentCatalog().GetName().GetIdentifierName(),
+            table.ParentSchema().name.GetIdentifierName(),
+            table.name.GetIdentifierName());
         }
       }
       if (entry != nullptr && entry->mvcc != nullptr) {
@@ -317,15 +321,16 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   }
 
   duckdb::unique_ptr<duckdb::TableFilterSet> table_filters;
-  if (!op.table_filters.filters.empty()) {
+  if (op.table_filters.HasFilters()) {
     table_filters = create_table_filter_set(op.table_filters, column_ids);
     // Predicates pushed into table_filters bypass the LogicalFilter guard —
     // reject nested columns here too (e.g. `WHERE items IS NULL`).
-    for (auto const& entry : table_filters->filters) {
-      auto const column_id = column_ids[entry.first].GetPrimaryIndex();
+    for (auto const& entry : *table_filters) {
+      auto const column_id = column_ids[entry.GetIndex()].GetPrimaryIndex();
       if (column_id < op.returned_types.size()) {
-        auto const column_name =
-          column_id < op.names.size() ? op.names[column_id] : std::to_string(column_id);
+        auto const column_name = column_id < op.names.size()
+                                   ? op.names[column_id].GetIdentifierName()
+                                   : std::to_string(column_id);
         reject_nested_column_type(op.returned_types[column_id], column_name, "a filter predicate");
       }
     }
@@ -340,49 +345,49 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   // Since we don't pass filters to the DuckDB table function (they're applied by Sirius),
   // we need to ensure all filter columns are included in BOTH column_ids and projection_ids.
   // We track the original projection_ids so we can project back after filtering.
-  duckdb::vector<std::size_t> original_projection_ids = projection_ids;
+  duckdb::vector<duckdb::ProjectionIndex> original_projection_ids = projection_ids;
 
   // Save the original types before we modify projection_ids, because modifying projection_ids
   // might affect the types when we call ResolveOperatorTypes()
   duckdb::vector<duckdb::LogicalType> original_types = op.types;
 
   if (table_filters) {
-    for (auto& entry : table_filters->filters) {
-      // entry.first is the column index in the table_filters (after remapping by
+    for (auto& entry : *table_filters) {
+      // entry.GetIndex() is the column index in the table_filters (after remapping by
       // create_table_filter_set) We need to ensure this column is in projection_ids so it gets
       // scanned by DuckDB
 
       bool found_in_projection = false;
       for (std::size_t j = 0; j < projection_ids.size(); j++) {
-        if (projection_ids[j] == entry.first) {
+        if (projection_ids[j] == entry.GetIndex()) {
           found_in_projection = true;
           break;
         }
       }
 
-      if (!found_in_projection) { projection_ids.push_back(entry.first); }
+      if (!found_in_projection) { projection_ids.push_back(entry.GetIndex()); }
     }
   }
 
   // Handle cases where table function doesn't support pushdown for specific column types
   if (table_filters && op.function.supports_pushdown_type) {
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list;
-    duckdb::unordered_set<std::size_t> to_remove;
-    for (auto& entry : table_filters->filters) {
-      auto column_id = column_ids[entry.first].GetPrimaryIndex();
+    duckdb::vector<duckdb::ProjectionIndex> to_remove;
+    for (auto& entry : *table_filters) {
+      auto column_id = column_ids[entry.GetIndex()].GetPrimaryIndex();
       auto& type     = op.returned_types[column_id];
 
       // If the table function doesn't support pushdown for this column type,
       // create a separate filter operator for it
       if (!op.function.supports_pushdown_type(*op.bind_data, column_id)) {
-        std::size_t column_id_filter = entry.first;
+        std::size_t column_id_filter = entry.GetIndex();
         auto column = duckdb::make_uniq<duckdb::BoundReferenceExpression>(type, column_id_filter);
-        select_list.push_back(entry.second->ToExpression(*column));
-        to_remove.insert(entry.first);
+        select_list.push_back(entry.Filter().ToExpression(*column));
+        to_remove.push_back(entry.GetIndex());
       }
     }
     for (auto& col : to_remove) {
-      table_filters->filters.erase(col);
+      table_filters->RemoveFilterByColumnIndex(col);
     }
 
     if (!select_list.empty()) {
@@ -397,7 +402,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
         auto conjunction = duckdb::make_uniq<duckdb::BoundConjunctionExpression>(
           duckdb::ExpressionType::CONJUNCTION_AND);
         for (auto& expr : select_list) {
-          conjunction->children.push_back(std::move(expr));
+          conjunction->GetChildrenMutable().push_back(std::move(expr));
         }
         combined = std::move(conjunction);
       } else {
@@ -420,7 +425,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
       sirius::from_duckdb_vec(op.returned_types),
       column_ids,
       duckdb::vector<duckdb::column_t>(),
-      op.names,
+      sirius::from_duckdb_names(op.names),
       std::move(table_filters),
       op.estimated_cardinality,
       std::move(op.extra_info),
@@ -484,8 +489,8 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
     std::move(op.bind_data),
     sirius::from_duckdb_vec(op.returned_types),
     column_ids,
-    op.projection_ids,
-    op.names,
+    sirius::from_duckdb_projection_ids(op.projection_ids),
+    sirius::from_duckdb_names(op.names),
     std::move(table_filters),
     op.estimated_cardinality,
     std::move(op.extra_info),

--- a/src/planner/sirius_plan_order.cpp
+++ b/src/planner/sirius_plan_order.cpp
@@ -30,7 +30,10 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalOrder& op)
   if (!op.orders.empty()) {
     duckdb::vector<std::size_t> projection_map;
     if (op.HasProjectionMap()) {
-      projection_map = std::move(op.projection_map);
+      projection_map.reserve(op.projection_map.size());
+      for (auto const& proj_idx : op.projection_map) {
+        projection_map.push_back(proj_idx.GetIndex());
+      }
     } else {
       for (std::size_t i = 0; i < plan->types.size(); i++) {
         projection_map.push_back(i);

--- a/src/planner/sirius_plan_projection.cpp
+++ b/src/planner/sirius_plan_projection.cpp
@@ -63,9 +63,9 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalProjection& op)
     // e.g. PROJECTION(#0, #1, #2, #3, ...)
     bool omit_projection = true;
     for (std::size_t i = 0; i < op.types.size(); i++) {
-      if (op.expressions[i]->type == duckdb::ExpressionType::BOUND_REF) {
+      if (op.expressions[i]->GetExpressionType() == duckdb::ExpressionType::BOUND_REF) {
         auto& bound_ref = op.expressions[i]->Cast<duckdb::BoundReferenceExpression>();
-        if (bound_ref.index == i) { continue; }
+        if (bound_ref.Index() == i) { continue; }
       }
       omit_projection = false;
       break;

--- a/src/planner/sirius_plan_recursive_cte.cpp
+++ b/src/planner/sirius_plan_recursive_cte.cpp
@@ -30,7 +30,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalCTERef& op)
 
   // Check if this LogicalCTERef is supposed to scan a materialized CTE.
   // Lookup if there is a materialized CTE for the cte_index.
-  auto materialized_cte = materialized_ctes.find(op.cte_index);
+  auto materialized_cte = materialized_ctes.find(op.cte_index.index);
 
   // If this check fails, this is a reference to a materialized recursive CTE.
   if (materialized_cte != materialized_ctes.end()) {
@@ -38,9 +38,9 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalCTERef& op)
       sirius::from_duckdb_vec(op.chunk_types),
       sirius::op::SiriusPhysicalOperatorType::CTE_SCAN,
       op.estimated_cardinality,
-      op.cte_index);
+      op.cte_index.index);
 
-    auto cte = recursive_cte_tables.find(op.cte_index);
+    auto cte = recursive_cte_tables.find(op.cte_index.index);
     if (cte == recursive_cte_tables.end()) {
       throw duckdb::InvalidInputException("Referenced materialized CTE does not exist.");
     }
@@ -48,7 +48,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalCTERef& op)
     chunk_scan->collection = cte->second.get();
     // materialized_cte->second.push_back(*chunk_scan.get())
 
-    // auto gpu_cte = gpu_recursive_cte_tables.find(op.cte_index);
+    // auto gpu_cte = gpu_recursive_cte_tables.find(op.cte_index.index);
     // if (gpu_cte == gpu_recursive_cte_tables.end()) {
     //   throw duckdb::InvalidInputException("Referenced materialized CTE does not exist.");
     // }
@@ -61,14 +61,14 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalCTERef& op)
 
   throw duckdb::NotImplementedException("Recursive CTE is not implemented");
 
-  auto cte = recursive_cte_tables.find(op.cte_index);
+  auto cte = recursive_cte_tables.find(op.cte_index.index);
   if (cte == recursive_cte_tables.end()) {
     throw duckdb::InvalidInputException("Referenced recursive CTE does not exist.");
   }
 
   // If we found a recursive CTE and we want to scan the recurring table, we search for it,
   if (op.is_recurring) {
-    cte = recurring_cte_tables.find(op.cte_index);
+    cte = recurring_cte_tables.find(op.cte_index.index);
     if (cte == recurring_cte_tables.end()) {
       throw duckdb::InvalidInputException(
         "RECURRING can only be used with USING KEY in recursive CTE.");
@@ -79,7 +79,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalCTERef& op)
     sirius::from_duckdb_vec(cte->second.get()->Types()),
     sirius::op::SiriusPhysicalOperatorType::RECURSIVE_CTE_SCAN,
     op.estimated_cardinality,
-    op.cte_index);
+    op.cte_index.index);
 
   chunk_scan->collection = cte->second.get();
   return std::move(chunk_scan);

--- a/src/scan_manager/pinned_chunk_stats.cpp
+++ b/src/scan_manager/pinned_chunk_stats.cpp
@@ -28,8 +28,10 @@
 #include <duckdb/common/types/date.hpp>
 #include <duckdb/common/types/timestamp.hpp>
 #include <duckdb/common/types/value.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
 #include <duckdb/planner/filter/conjunction_filter.hpp>
 #include <duckdb/planner/filter/constant_filter.hpp>
+#include <duckdb/planner/filter/expression_filter.hpp>
 #include <duckdb/planner/filter/in_filter.hpp>
 #include <duckdb/planner/filter/optional_filter.hpp>
 #include <duckdb/storage/statistics/numeric_stats.hpp>
@@ -225,8 +227,8 @@ pinned_zone_maps pinned_zone_maps::remap(pinned_zone_maps incoming,
 bool filter_safe_for_stats(duckdb::TableFilter const& filter, duckdb::LogicalType const& stats_type)
 {
   switch (filter.filter_type) {
-    case duckdb::TableFilterType::CONSTANT_COMPARISON: {
-      auto const& cf = filter.Cast<duckdb::ConstantFilter>();
+    case duckdb::TableFilterType::LEGACY_CONSTANT_COMPARISON: {
+      auto const& cf = filter.Cast<duckdb::LegacyConstantFilter>();
       switch (cf.comparison_type) {
         case duckdb::ExpressionType::COMPARE_EQUAL:
         case duckdb::ExpressionType::COMPARE_NOTEQUAL:
@@ -241,19 +243,19 @@ bool filter_safe_for_stats(duckdb::TableFilter const& filter, duckdb::LogicalTyp
       // stay defensive on both.
       return !cf.constant.IsNull() && cf.constant.type() == stats_type;
     }
-    case duckdb::TableFilterType::IS_NULL:
-    case duckdb::TableFilterType::IS_NOT_NULL: return true;
-    case duckdb::TableFilterType::IN_FILTER: {
-      auto const& in = filter.Cast<duckdb::InFilter>();
+    case duckdb::TableFilterType::LEGACY_IS_NULL:
+    case duckdb::TableFilterType::LEGACY_IS_NOT_NULL: return true;
+    case duckdb::TableFilterType::LEGACY_IN_FILTER: {
+      auto const& in = filter.Cast<duckdb::LegacyInFilter>();
       return !in.values.empty() && std::ranges::all_of(in.values, [&](duckdb::Value const& v) {
         return !v.IsNull() && v.type() == stats_type;
       });
     }
-    case duckdb::TableFilterType::CONJUNCTION_AND:
-    case duckdb::TableFilterType::CONJUNCTION_OR: {
-      auto const& children = filter.filter_type == duckdb::TableFilterType::CONJUNCTION_AND
-                               ? filter.Cast<duckdb::ConjunctionAndFilter>().child_filters
-                               : filter.Cast<duckdb::ConjunctionOrFilter>().child_filters;
+    case duckdb::TableFilterType::LEGACY_CONJUNCTION_AND:
+    case duckdb::TableFilterType::LEGACY_CONJUNCTION_OR: {
+      auto const& children = filter.filter_type == duckdb::TableFilterType::LEGACY_CONJUNCTION_AND
+                               ? filter.Cast<duckdb::LegacyConjunctionAndFilter>().child_filters
+                               : filter.Cast<duckdb::LegacyConjunctionOrFilter>().child_filters;
       // A childless OR would propagate FILTER_ALWAYS_FALSE and prune unconditionally; a childless
       // AND is merely vacuous. Neither shape is produced by the binder, so reject both rather than
       // reason about them.
@@ -262,10 +264,10 @@ bool filter_safe_for_stats(duckdb::TableFilter const& filter, duckdb::LogicalTyp
                return c && filter_safe_for_stats(*c, stats_type);
              });
     }
-    case duckdb::TableFilterType::OPTIONAL_FILTER: {
+    case duckdb::TableFilterType::LEGACY_OPTIONAL_FILTER: {
       // OptionalFilter's child may legitimately be nullptr (its constructor defaults it); an empty
       // optional constrains nothing and cannot prune.
-      auto const& opt = filter.Cast<duckdb::OptionalFilter>();
+      auto const& opt = filter.Cast<duckdb::LegacyOptionalFilter>();
       return opt.child_filter && filter_safe_for_stats(*opt.child_filter, stats_type);
     }
     // DYNAMIC (mutable at run time), STRUCT_EXTRACT / EXPRESSION / BLOOM
@@ -280,10 +282,13 @@ bool chunk_provably_empty(duckdb::TableFilter const& filter,
 {
   try {
     if (!filter_safe_for_stats(filter, stats.GetType())) { return false; }
-    // CheckStatistics needs a non-const reference to the stats object. Copy instead of const_cast
-    // to keep CheckStatistics safe.
-    auto local_stats = stats.Copy();
-    return filter.CheckStatistics(local_stats) ==
+    // TableFilter no longer carries CheckStatistics; filters are pruned through their
+    // expression form. The reference index is irrelevant — the pruner only matches the
+    // expression shape against this one column's stats.
+    auto const column_ref =
+      duckdb::make_uniq<duckdb::BoundReferenceExpression>(stats.GetType(), duckdb::idx_t(0));
+    auto const filter_expr = filter.ToExpression(*column_ref);
+    return duckdb::ExpressionFilter::CheckExpressionStatistics(*filter_expr, stats) ==
            duckdb::FilterPropagateResult::FILTER_ALWAYS_FALSE;
   } catch (std::exception const& e) {
     // Don't propagate exceptions here on statistics checks; otherwise, a cache miss is generated

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -53,6 +53,7 @@
 #include <cucascade/memory/memory_reservation_manager.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <duckdb/main/attached_database.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
 #include <duckdb/storage/data_table.hpp>
 #include <duckdb/storage/single_file_block_manager.hpp>
 #include <duckdb/storage/storage_manager.hpp>
@@ -1247,7 +1248,7 @@ cached_scan_plan build_cached_scan_plan(pinned_entry const& entry,
     plan.survivor_chunk_indices.push_back(c);
   }
   if (n_chunks == 0 || !entry.zone_maps.has_stats() || table_filters == nullptr ||
-      table_filters->filters.empty() || column_ids == nullptr) {
+      !table_filters->HasFilters() || column_ids == nullptr) {
     return plan;
   }
 
@@ -1265,8 +1266,9 @@ cached_scan_plan build_cached_scan_plan(pinned_entry const& entry,
     std::size_t entry_pos;
   };
   std::vector<usable_filter> usable;
-  for (auto const& [col_idx, filter] : table_filters->filters) {
-    if (!filter) { continue; }
+  for (auto const& entry_filter : *table_filters) {
+    auto const col_idx = static_cast<duckdb::idx_t>(entry_filter.GetIndex());
+    auto const& filter = entry_filter.Filter();
     if (col_idx >= column_ids->size()) { continue; }  // defensive
     auto const& column_id = (*column_ids)[col_idx];
     // rowid / empty / virtual sentinels have no storage stats.
@@ -1278,8 +1280,8 @@ cached_scan_plan build_cached_scan_plan(pinned_entry const& entry,
     if (it == entry_pos_by_primary.end()) { continue; }
     auto const pos = it->second;
     if (pos >= entry.zone_maps.column_count()) { continue; }  // absent for this column
-    if (!filter_safe_for_stats(*filter, entry.zone_maps.column_type(pos))) { continue; }
-    usable.push_back({filter.get(), pos});
+    if (!filter_safe_for_stats(filter, entry.zone_maps.column_type(pos))) { continue; }
+    usable.push_back({&filter, pos});
   }
   if (usable.empty()) { return plan; }
 

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -25,6 +25,7 @@
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/planner.hpp"
+#include "helper/type_conversions.hpp"
 #include "log/duckdb_sink.hpp"
 #include "log/logging.hpp"
 #include "log/noop_sink.hpp"
@@ -1255,14 +1256,14 @@ RebindQueryInfo SiriusContext::OnFinalizePrepare(ClientContext& context,
 
     // Create a new DuckDB PhysicalPlan containing our custom operator.
     auto new_physical_plan = make_uniq<PhysicalPlan>(Allocator::Get(context));
-    auto& sirius_op =
-      new_physical_plan->Make<sirius::transparent::PhysicalSiriusExecution>(std::move(logical_plan),
-                                                                            current_query_sql,
-                                                                            prepared.types,
-                                                                            prepared.names,
-                                                                            std::move(cpu_fallback),
-                                                                            plan_reads_s3,
-                                                                            0);
+    auto& sirius_op        = new_physical_plan->Make<sirius::transparent::PhysicalSiriusExecution>(
+      std::move(logical_plan),
+      current_query_sql,
+      prepared.types,
+      sirius::from_duckdb_names(prepared.names),
+      std::move(cpu_fallback),
+      plan_reads_s3,
+      0);
     new_physical_plan->SetRoot(sirius_op);
 
     // Replace the DuckDB CPU physical plan.

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -60,12 +60,14 @@ extern "C" int cudaProfilerStop();
 #include "duckdb/main/prepared_statement_data.hpp"
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/main/relation.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/parser/column_list.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/planner/planner.hpp"
+#include "duckdb/planner/table_filter_set.hpp"
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
@@ -240,7 +242,7 @@ struct SiriusTableFunctionData : public TableFunctionData {
   // PreparedStatementData from these (parameterized execution is not
   // supported on this path, so no value_map is needed — same as the
   // transparent operator's minimal PreparedStatementData).
-  vector<string> bind_names;
+  vector<Identifier> bind_names;
   vector<LogicalType> bind_types;
   std::optional<std::string> query_label;
   //! Original options from the connection
@@ -252,7 +254,8 @@ struct SiriusTableFunctionData : public TableFunctionData {
     original_config = context.config;
     // The user might want to disable the optimizer of the new connection.
     // (connection-local ClientConfig — safe to toggle per execution)
-    context.config.enable_optimizer = enable_optimizer;
+    Settings::Set<EnableOptimizerSetting>(
+      context, SetScope::SESSION, Value::BOOLEAN(enable_optimizer));
     // The old per-query DBConfig::disabled_optimizers save/modify/restore is
     // gone: that set is DB-global and read locklessly by every connection's
     // optimizer, so per-query mutation was an unprotected concurrent write.
@@ -279,7 +282,7 @@ struct SiriusTableFunctionData : public TableFunctionData {
 
       plan = std::move(planner.plan);
 
-      if (context.config.enable_optimizer) {
+      if (Settings::Get<EnableOptimizerSetting>(context)) {
         Optimizer optimizer(*planner.binder, context);
         plan = optimizer.Optimize(std::move(plan));
       }
@@ -289,7 +292,7 @@ struct SiriusTableFunctionData : public TableFunctionData {
       plan->ResolveOperatorTypes();
 
       ColumnBindingResolver resolver;
-      ColumnBindingResolver::Verify(*plan);
+      ColumnBindingResolver::Verify(context, *plan);
       resolver.VisitOperator(*plan);
     } catch (...) {
       CleanupConnection(context);
@@ -324,7 +327,8 @@ struct GPUTableFunctionData : public TableFunctionData {
     original_disabled_optimizers = DBConfig::GetConfig(context).options.disabled_optimizers;
 
     // The user might want to disable the optimizer of the new connection
-    context.config.enable_optimizer = enable_optimizer;
+    Settings::Set<EnableOptimizerSetting>(
+      context, SetScope::SESSION, Value::BOOLEAN(enable_optimizer));
     // We want for sure to disable the internal compression optimizations.
     // These are DuckDB specific, no other system implements these. Also,
     // respect the user's settings if they chose to disable any specific optimizers.
@@ -371,7 +375,7 @@ struct GPUTableFunctionData : public TableFunctionData {
 
       plan = std::move(planner.plan);
 
-      if (context.config.enable_optimizer) {
+      if (Settings::Get<EnableOptimizerSetting>(context)) {
         Optimizer optimizer(*planner.binder, context);
         plan = optimizer.Optimize(std::move(plan));
       }
@@ -381,7 +385,7 @@ struct GPUTableFunctionData : public TableFunctionData {
       plan->ResolveOperatorTypes();
 
       ColumnBindingResolver resolver;
-      ColumnBindingResolver::Verify(*plan);
+      ColumnBindingResolver::Verify(context, *plan);
       resolver.VisitOperator(*plan);
     } catch (...) {
       CleanupConnection(context);
@@ -551,7 +555,7 @@ unique_ptr<FunctionData> SiriusExtension::GPUExecutionBind(ClientContext& contex
   }
   // however, give precedence to a query_label that was set inline in with
   // gpu_execution SQL call.
-  if (auto it = input.named_parameters.find(QUERY_LABEL_PARAM_KEY);
+  if (auto it = input.named_parameters.find(Identifier(QUERY_LABEL_PARAM_KEY));
       it != input.named_parameters.end() && not it->second.IsNull()) {
     query_label = it->second.ToString();
   }
@@ -732,7 +736,7 @@ void SiriusExtension::GPUExecutionFunction(ClientContext& context,
   SIRIUS_LOG_DEBUG("Query plan:\n{}", plan->ToString());
 
   ColumnBindingResolver resolver;
-  resolver.Verify(*plan);
+  ColumnBindingResolver::Verify(context, *plan);
   resolver.VisitOperator(*plan);
 
   plan->ResolveOperatorTypes();
@@ -979,17 +983,18 @@ std::unique_ptr<sirius::op::scan::duckdb_native_ingestible_table_info> build_duc
   // 'table_ref' is the (optionally schema/catalog-qualified) table name. Resolve it
   // through the catalog honoring the client's search path — so a bare name picks up
   // the current/USE'd database — yielding the same DataTable* a query-time scan binds.
-  auto const qname          = duckdb::QualifiedName::Parse(table_ref);
-  std::string const catalog = qname.catalog;  // empty => search path
-  std::string const schema  = !qname.schema.empty() ? qname.schema : schema_override;
-  std::string const& table  = qname.name;
+  auto const qname                 = duckdb::QualifiedName::Parse(table_ref);
+  duckdb::Identifier const catalog = qname.Catalog();  // empty => search path
+  duckdb::Identifier const schema =
+    !qname.Schema().empty() ? qname.Schema() : duckdb::Identifier(schema_override);
+  duckdb::Identifier const& table = qname.Name();
 
   // Non-template catalog lookup + Cast (mirroring the pipeline converter). The
   // templated Catalog::GetEntry<DuckTableEntry> would ODR-use DuckTableEntry::Name
   // (a static constexpr inherited from TableCatalogEntry), emitting a duplicate
   // symbol against libduckdb_static at link time.
-  auto& entry_base =
-    duckdb::Catalog::GetEntry(context, duckdb::CatalogType::TABLE_ENTRY, catalog, schema, table);
+  auto& entry_base = duckdb::Catalog::GetEntry(
+    context, duckdb::CatalogType::TABLE_ENTRY, duckdb::QualifiedName(catalog, schema, table));
   auto& entry         = entry_base.Cast<duckdb::DuckTableEntry>();
   auto& storage       = entry.GetStorage();
   auto const& columns = entry.GetColumns();
@@ -1043,9 +1048,9 @@ std::unique_ptr<sirius::op::scan::duckdb_native_ingestible_table_info> build_duc
   info->db_path = canonical;
   // Qualified-name identity for the pin cache — derived from the resolved
   // DuckTableEntry so it matches the query-side derivation (the pipeline converter).
-  info->catalog_name           = entry.ParentCatalog().GetName();
-  info->schema_name            = entry.ParentSchema().name;
-  info->table_name             = entry.name;
+  info->catalog_name           = entry.ParentCatalog().GetName().GetIdentifierName();
+  info->schema_name            = entry.ParentSchema().name.GetIdentifierName();
+  info->table_name             = entry.name.GetIdentifierName();
   info->approximate_batch_size = batch_size;
   // Full-schema names (logical order) so column_names() can derive the
   // column_ids-aligned view; the decoder itself ignores names.
@@ -1253,7 +1258,7 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
     // start_time domain, and pins usually target an ATTACHed .db (the catalog
     // resolved by build_duckdb_pin_info), so read the fence off that catalog's
     // DuckTransaction.
-    auto& pinned_catalog = Catalog::GetCatalog(context, info->catalog_name);
+    auto& pinned_catalog = Catalog::GetCatalog(context, Identifier(info->catalog_name));
     duckdb_pin_v_base    = DuckTransaction::Get(context, pinned_catalog).start_time;
     ingestible           = sirius::op::scan::make_ingestible(std::move(info));
   } else {  // parquet
@@ -1558,8 +1563,8 @@ void SiriusExtension::RegisterGPUFunctions(DatabaseInstance& instance)
                               GPUExecutionFunction,
                               SiriusExtension::GPUExecutionBind,
                               SiriusExtension::GPUExecutionInitGlobal);
-  gpu_execution.named_parameters["enable_optimizer"]    = LogicalType::BOOLEAN;
-  gpu_execution.named_parameters[QUERY_LABEL_PARAM_KEY] = LogicalType::VARCHAR;
+  gpu_execution.named_parameters["enable_optimizer"]                = LogicalType::BOOLEAN;
+  gpu_execution.named_parameters[Identifier(QUERY_LABEL_PARAM_KEY)] = LogicalType::VARCHAR;
   CreateTableFunctionInfo gpu_execution_info(gpu_execution);
   catalog.CreateTableFunction(transaction, gpu_execution_info);
 

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -31,6 +31,7 @@
 #include "duckdb/main/prepared_statement_data.hpp"         // duckdb::PreparedStatementData
 #include "duckdb/main/query_result.hpp"                    // duckdb::QueryResult
 #include "duckdb/main/relation.hpp"                        // duckdb::Relation
+#include "duckdb/main/settings.hpp"                        // duckdb::EnableOptimizerSetting
 #include "duckdb/optimizer/optimizer.hpp"                  // duckdb::Optimizer
 #include "duckdb/parser/statement/relation_statement.hpp"  // duckdb::RelationStatement
 #include "duckdb/planner/planner.hpp"                      // duckdb::Planner
@@ -99,7 +100,8 @@ struct Context::Impl {
     // embedded connection, mirroring OnConnectionOpened on the transparent path.
     client.registered_state->Insert("sirius_connection_state",
                                     duckdb::make_shared_ptr<duckdb::SiriusConnectionState>());
-    client.config.enable_optimizer = true;
+    duckdb::Settings::Set<duckdb::EnableOptimizerSetting>(
+      client, duckdb::SetScope::SESSION, duckdb::Value::BOOLEAN(true));
     auto& disabled = duckdb::DBConfig::GetConfig(client).options.disabled_optimizers;
     disabled.insert(duckdb::OptimizerType::IN_CLAUSE);
     disabled.insert(duckdb::OptimizerType::COMPRESSED_MATERIALIZATION);
@@ -159,13 +161,13 @@ void Context::execute_substrait(const std::string& plan, std::uintptr_t out_stre
     prepared->value_map = std::move(planner.value_map);
 
     auto logical_plan = std::move(planner.plan);
-    if (client.config.enable_optimizer) {
+    if (duckdb::Settings::Get<duckdb::EnableOptimizerSetting>(client)) {
       duckdb::Optimizer optimizer(*planner.binder, client);
       logical_plan = optimizer.Optimize(std::move(logical_plan));
     }
     logical_plan->ResolveOperatorTypes();
     duckdb::ColumnBindingResolver resolver;
-    duckdb::ColumnBindingResolver::Verify(*logical_plan);
+    duckdb::ColumnBindingResolver::Verify(client, *logical_plan);
     resolver.VisitOperator(*logical_plan);
 
     // 3. DuckDB LogicalOperator -> Sirius GPU physical plan -> execute directly

--- a/src/sirius_interface.cpp
+++ b/src/sirius_interface.cpp
@@ -32,11 +32,12 @@
 
 namespace sirius {
 
-void bind_prepared_statement_parameters(duckdb::PreparedStatementData& statement,
+void bind_prepared_statement_parameters(duckdb::ClientContext& context,
+                                        duckdb::PreparedStatementData& statement,
                                         const duckdb::PendingQueryParameters& parameters)
 {
-  duckdb::case_insensitive_map_t<duckdb::BoundParameterData> owned_values;
-  statement.Bind(std::move(owned_values));
+  duckdb::identifier_map_t<duckdb::BoundParameterData> owned_values;
+  statement.Bind(context, owned_values);
 }
 
 sirius_interface::sirius_interface(duckdb::ClientContext& client_context,
@@ -155,7 +156,7 @@ duckdb::unique_ptr<duckdb::PendingQueryResult> sirius_interface::sirius_pending_
   D_ASSERT(sirius_active_query);
   auto& statement = *(statement_p->prepared);
 
-  bind_prepared_statement_parameters(statement, parameters);
+  bind_prepared_statement_parameters(context, statement, parameters);
 
   duckdb::unique_ptr<sirius_engine> temp =
     duckdb::make_uniq<sirius_engine>(context, *this, query_id);

--- a/src/transparent/physical_sirius_execution.cpp
+++ b/src/transparent/physical_sirius_execution.cpp
@@ -179,7 +179,11 @@ duckdb::SourceResultType PhysicalSiriusExecution::GetDataInternal(
       auto prepared = duckdb::make_shared_ptr<duckdb::PreparedStatementData>(
         duckdb::StatementType::SELECT_STATEMENT);
       prepared->types = types;
-      prepared->names = result_names_;
+      prepared->names.clear();
+      prepared->names.reserve(result_names_.size());
+      for (auto const& name : result_names_) {
+        prepared->names.emplace_back(name);
+      }
 
       // Rebuild a fresh Sirius physical plan for this execution. DuckDB may reuse
       // the same prepared physical operator across multiple EXECUTE calls.

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -34,6 +34,7 @@
 #include <duckdb.hpp>
 #include <duckdb/execution/execution_context.hpp>
 #include <duckdb/main/client_config.hpp>
+#include <duckdb/main/settings.hpp>
 #include <memory/sirius_memory_reservation_manager.hpp>
 #include <utils/utils.hpp>
 
@@ -614,11 +615,12 @@ TEST_CASE("Per-connection state isolates and expires the transparent capture",
   REQUIRE(plan != nullptr);
   conn_state->set_captured_plan(std::move(plan));
 
-  auto const before_prepare      = sirius_ctx->get_transparent_execution_stats();
-  auto& client_config            = duckdb::ClientConfig::GetConfig(client_ctx);
-  client_config.enable_optimizer = false;
-  auto prepared                  = con.Prepare("SELECT 42;");  // SAME SQL as the capture
-  client_config.enable_optimizer = true;
+  auto const before_prepare = sirius_ctx->get_transparent_execution_stats();
+  duckdb::Settings::Set<duckdb::EnableOptimizerSetting>(
+    client_ctx, duckdb::SetScope::SESSION, duckdb::Value::BOOLEAN(false));
+  auto prepared = con.Prepare("SELECT 42;");  // SAME SQL as the capture
+  duckdb::Settings::Set<duckdb::EnableOptimizerSetting>(
+    client_ctx, duckdb::SetScope::SESSION, duckdb::Value::BOOLEAN(true));
   REQUIRE_FALSE(prepared->HasError());
   auto const after_prepare = sirius_ctx->get_transparent_execution_stats();
 

--- a/test/cpp/expression/test_ast_aggregate.cpp
+++ b/test/cpp/expression/test_ast_aggregate.cpp
@@ -78,8 +78,15 @@ AggregateFunction make_dummy_aggregate(std::string const& name,
                                        duckdb::vector<LogicalType> const& args,
                                        LogicalType const& ret_type)
 {
-  return AggregateFunction(
-    name, args, ret_type, 0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  return AggregateFunction(duckdb::Identifier(name),
+                           args,
+                           ret_type,
+                           nullptr,
+                           nullptr,
+                           nullptr,
+                           nullptr,
+                           nullptr,
+                           duckdb::FunctionNullHandling::DEFAULT_NULL_HANDLING);
 }
 
 }  // namespace
@@ -163,8 +170,11 @@ TEST_CASE("ast_aggregate - sum over a single reference translates to aggregate n
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
   auto fn = make_dummy_aggregate(
     "sum", {LogicalType{LogicalTypeId::INTEGER}}, LogicalType{LogicalTypeId::BIGINT});
-  auto expr = duckdb::make_uniq<BoundAggregateExpression>(
-    fn, std::move(children), nullptr, nullptr, AggregateType::NON_DISTINCT);
+  auto expr = duckdb::make_uniq<BoundAggregateExpression>(duckdb::BoundAggregateFunction(fn),
+                                                          std::move(children),
+                                                          nullptr,
+                                                          nullptr,
+                                                          AggregateType::NON_DISTINCT);
 
   auto out = sirius::ast::from_duckdb(*expr);
   REQUIRE(out);
@@ -181,8 +191,11 @@ TEST_CASE("ast_aggregate - count_star with no children translates without throwi
 {
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;  // empty
   auto fn   = make_dummy_aggregate("count_star", {}, LogicalType{LogicalTypeId::BIGINT});
-  auto expr = duckdb::make_uniq<BoundAggregateExpression>(
-    fn, std::move(children), nullptr, nullptr, AggregateType::NON_DISTINCT);
+  auto expr = duckdb::make_uniq<BoundAggregateExpression>(duckdb::BoundAggregateFunction(fn),
+                                                          std::move(children),
+                                                          nullptr,
+                                                          nullptr,
+                                                          AggregateType::NON_DISTINCT);
 
   std::unique_ptr<node> out;
   REQUIRE_NOTHROW(out = sirius::ast::from_duckdb(*expr));
@@ -207,14 +220,17 @@ TEST_CASE("ast_aggregate - COUNT(DISTINCT struct_pack(a, b)) recurses children a
   ScalarFunction struct_fn(
     "struct_pack", duckdb::vector<LogicalType>{}, struct_return_type, /*function=*/nullptr);
   auto struct_pack_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    struct_return_type, struct_fn, std::move(struct_children), /*bind_info=*/nullptr);
+    duckdb::BoundScalarFunction(struct_fn), std::move(struct_children), /*bind_info=*/nullptr);
 
   // Outer count(DISTINCT struct_pack(a, b)).
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> agg_children;
   agg_children.push_back(std::move(struct_pack_expr));
   auto fn = make_dummy_aggregate("count", {struct_return_type}, LogicalType{LogicalTypeId::BIGINT});
-  auto expr = duckdb::make_uniq<BoundAggregateExpression>(
-    fn, std::move(agg_children), nullptr, nullptr, AggregateType::DISTINCT);
+  auto expr = duckdb::make_uniq<BoundAggregateExpression>(duckdb::BoundAggregateFunction(fn),
+                                                          std::move(agg_children),
+                                                          nullptr,
+                                                          nullptr,
+                                                          AggregateType::DISTINCT);
 
   auto out = sirius::ast::from_duckdb(*expr);
   REQUIRE(out);
@@ -236,8 +252,11 @@ TEST_CASE("ast_aggregate - unsupported aggregate name yields nullptr fallback (n
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::DOUBLE}, 0));
   auto fn = make_dummy_aggregate(
     "stddev", {LogicalType{LogicalTypeId::DOUBLE}}, LogicalType{LogicalTypeId::DOUBLE});
-  auto expr = duckdb::make_uniq<BoundAggregateExpression>(
-    fn, std::move(children), nullptr, nullptr, AggregateType::NON_DISTINCT);
+  auto expr = duckdb::make_uniq<BoundAggregateExpression>(duckdb::BoundAggregateFunction(fn),
+                                                          std::move(children),
+                                                          nullptr,
+                                                          nullptr,
+                                                          AggregateType::NON_DISTINCT);
 
   std::unique_ptr<node> out;
   REQUIRE_NOTHROW(out = sirius::ast::from_duckdb(*expr));

--- a/test/cpp/expression/test_ast_from_duckdb.cpp
+++ b/test/cpp/expression/test_ast_from_duckdb.cpp
@@ -25,6 +25,7 @@
 
 #include "ast_test_builders.hpp"
 #include "catch.hpp"
+#include "duckdb/main/settings.hpp"
 #include "expression/ast/from_duckdb.hpp"
 
 // sirius — node accessors and per-node struct types
@@ -179,7 +180,7 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON EQUAL translates to comparison nod
 {
   auto left  = make_bound_ref(0);
   auto right = make_bound_int_const(3);
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
+  auto expr  = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_EQUAL, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
   REQUIRE(out);
@@ -197,7 +198,7 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON NOTEQUAL translates to comparison 
 {
   auto left  = make_bound_ref(0);
   auto right = make_bound_int_const(3);
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
+  auto expr  = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_NOTEQUAL, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
   REQUIRE(out);
@@ -210,7 +211,7 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON LESSTHAN translates to comparison 
 {
   auto left  = make_bound_ref(0);
   auto right = make_bound_int_const(3);
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
+  auto expr  = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_LESSTHAN, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
   REQUIRE(out);
@@ -223,7 +224,7 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON LESSTHANOREQUALTO translates to co
 {
   auto left  = make_bound_ref(0);
   auto right = make_bound_int_const(3);
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
+  auto expr  = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
   REQUIRE(out);
@@ -236,7 +237,7 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON GREATERTHAN translates to comparis
 {
   auto left  = make_bound_ref(0);
   auto right = make_bound_int_const(3);
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
+  auto expr  = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_GREATERTHAN, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
   REQUIRE(out);
@@ -249,7 +250,7 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON GREATERTHANOREQUALTO translates to
 {
   auto left  = make_bound_ref(0);
   auto right = make_bound_int_const(3);
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
+  auto expr  = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
   REQUIRE(out);
@@ -262,7 +263,7 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON DISTINCT_FROM translates to compar
 {
   auto left  = make_bound_ref(0);
   auto right = make_bound_int_const(3);
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
+  auto expr  = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_DISTINCT_FROM, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
   REQUIRE(out);
@@ -275,7 +276,7 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON NOT_DISTINCT_FROM translates to co
 {
   auto left  = make_bound_ref(0);
   auto right = make_bound_int_const(3);
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
+  auto expr  = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_NOT_DISTINCT_FROM, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
   REQUIRE(out);
@@ -291,8 +292,8 @@ TEST_CASE("ast_from_duckdb - BOUND_CONJUNCTION AND translates to conjunction(op_
           "[ast_from_duckdb]")
 {
   auto and_expr = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
-  and_expr->children.push_back(make_bound_ref(0, LogicalTypeId::BOOLEAN));
-  and_expr->children.push_back(make_bound_ref(1, LogicalTypeId::BOOLEAN));
+  and_expr->GetChildrenMutable().push_back(make_bound_ref(0, LogicalTypeId::BOOLEAN));
+  and_expr->GetChildrenMutable().push_back(make_bound_ref(1, LogicalTypeId::BOOLEAN));
   auto out = sirius::ast::from_duckdb(*and_expr);
   REQUIRE(out);
   REQUIRE(out->holds<conjunction>());
@@ -307,8 +308,8 @@ TEST_CASE("ast_from_duckdb - BOUND_CONJUNCTION OR translates to conjunction(op_o
           "[ast_from_duckdb]")
 {
   auto or_expr = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR);
-  or_expr->children.push_back(make_bound_ref(0, LogicalTypeId::BOOLEAN));
-  or_expr->children.push_back(make_bound_ref(1, LogicalTypeId::BOOLEAN));
+  or_expr->GetChildrenMutable().push_back(make_bound_ref(0, LogicalTypeId::BOOLEAN));
+  or_expr->GetChildrenMutable().push_back(make_bound_ref(1, LogicalTypeId::BOOLEAN));
   auto out = sirius::ast::from_duckdb(*or_expr);
   REQUIRE(out);
   REQUIRE(out->holds<conjunction>());
@@ -322,11 +323,11 @@ TEST_CASE("ast_from_duckdb - BOUND_CONJUNCTION OR translates to conjunction(op_o
 TEST_CASE("ast_from_duckdb - BOUND_BETWEEN translates to between node with inclusive bounds",
           "[ast_from_duckdb]")
 {
-  auto bt  = duckdb::make_uniq<BoundBetweenExpression>(make_bound_ref(0),
-                                                      make_bound_int_const(1),
-                                                      make_bound_int_const(10),
-                                                      /*lower_inclusive=*/true,
-                                                      /*upper_inclusive=*/true);
+  auto bt  = BoundBetweenExpression::Create(make_bound_ref(0),
+                                           make_bound_int_const(1),
+                                           make_bound_int_const(10),
+                                           /*lower_inclusive=*/true,
+                                           /*upper_inclusive=*/true);
   auto out = sirius::ast::from_duckdb(*bt);
   REQUIRE(out);
   REQUIRE(out->holds<between>());
@@ -349,7 +350,7 @@ TEST_CASE("ast_from_duckdb - BOUND_CASE WHEN/THEN/ELSE translates to case_expr",
           "[ast_from_duckdb]")
 {
   // CASE WHEN col(0) = 1 THEN 10 ELSE 0 END
-  auto check_expr = duckdb::make_uniq<BoundComparisonExpression>(
+  auto check_expr = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_EQUAL, make_bound_ref(0), make_bound_int_const(1));
   auto then_expr = make_bound_int_const(10);
 
@@ -359,8 +360,8 @@ TEST_CASE("ast_from_duckdb - BOUND_CASE WHEN/THEN/ELSE translates to case_expr",
 
   auto else_expr = make_bound_int_const(0);
   auto case_node = duckdb::make_uniq<BoundCaseExpression>(LogicalType{LogicalTypeId::INTEGER});
-  case_node->else_expr = std::move(else_expr);
-  case_node->case_checks.push_back(std::move(case_check));
+  case_node->ElseMutable() = std::move(else_expr);
+  case_node->CaseChecksMutable().push_back(std::move(case_check));
 
   auto out = sirius::ast::from_duckdb(*case_node);
   REQUIRE(out);
@@ -377,7 +378,7 @@ TEST_CASE("ast_from_duckdb - BOUND_CASE with unsupported WHEN propagates nullptr
 {
   // The WHEN subexpression is a BoundParameterExpression (unsupported -> nullptr).
   // The whole CASE must collapse to nullptr.
-  auto bad_when  = duckdb::make_uniq<BoundParameterExpression>(std::string{"p_when"});
+  auto bad_when  = duckdb::make_uniq<BoundParameterExpression>(duckdb::Identifier{"p_when"});
   auto then_expr = make_bound_int_const(10);
 
   BoundCaseCheck case_check;
@@ -386,8 +387,8 @@ TEST_CASE("ast_from_duckdb - BOUND_CASE with unsupported WHEN propagates nullptr
 
   auto else_expr = make_bound_int_const(0);
   auto case_node = duckdb::make_uniq<BoundCaseExpression>(LogicalType{LogicalTypeId::INTEGER});
-  case_node->else_expr = std::move(else_expr);
-  case_node->case_checks.push_back(std::move(case_check));
+  case_node->ElseMutable() = std::move(else_expr);
+  case_node->CaseChecksMutable().push_back(std::move(case_check));
 
   REQUIRE(sirius::ast::from_duckdb(*case_node) == nullptr);
 }
@@ -432,13 +433,12 @@ TEST_CASE("ast_from_duckdb - BOUND_CAST honors try_cast = true", "[ast_from_duck
 TEST_CASE("ast_from_duckdb - BOUND_FUNCTION '+' resolves to function_id::add", "[ast_from_duckdb]")
 {
   auto add_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
+    duckdb::BoundScalarFunction(ScalarFunction(
+      "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr)),
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>{},
     nullptr);
-  add_expr->children.push_back(make_bound_ref(0));
-  add_expr->children.push_back(make_bound_int_const(3));
+  add_expr->GetChildrenMutable().push_back(make_bound_ref(0));
+  add_expr->GetChildrenMutable().push_back(make_bound_int_const(3));
 
   auto out = sirius::ast::from_duckdb(*add_expr);
   REQUIRE(out);
@@ -453,16 +453,16 @@ TEST_CASE("ast_from_duckdb - BOUND_FUNCTION 'substring' resolves to function_id:
           "[ast_from_duckdb]")
 {
   auto fn_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::VARCHAR},
-    ScalarFunction("substring",
-                   {LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER},
-                   LogicalType::VARCHAR,
-                   nullptr),
+    duckdb::BoundScalarFunction(
+      ScalarFunction("substring",
+                     {LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER},
+                     LogicalType::VARCHAR,
+                     nullptr)),
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>{},
     nullptr);
-  fn_expr->children.push_back(make_bound_ref(0, LogicalTypeId::VARCHAR));
-  fn_expr->children.push_back(make_bound_int_const(1));
-  fn_expr->children.push_back(make_bound_int_const(3));
+  fn_expr->GetChildrenMutable().push_back(make_bound_ref(0, LogicalTypeId::VARCHAR));
+  fn_expr->GetChildrenMutable().push_back(make_bound_int_const(1));
+  fn_expr->GetChildrenMutable().push_back(make_bound_int_const(3));
 
   auto out = sirius::ast::from_duckdb(*fn_expr);
   REQUIRE(out);
@@ -474,16 +474,16 @@ TEST_CASE("ast_from_duckdb - BOUND_FUNCTION 'substr' alias resolves to function_
           "[ast_from_duckdb]")
 {
   auto fn_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::VARCHAR},
-    ScalarFunction("substr",
-                   {LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER},
-                   LogicalType::VARCHAR,
-                   nullptr),
+    duckdb::BoundScalarFunction(
+      ScalarFunction("substr",
+                     {LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER},
+                     LogicalType::VARCHAR,
+                     nullptr)),
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>{},
     nullptr);
-  fn_expr->children.push_back(make_bound_ref(0, LogicalTypeId::VARCHAR));
-  fn_expr->children.push_back(make_bound_int_const(1));
-  fn_expr->children.push_back(make_bound_int_const(3));
+  fn_expr->GetChildrenMutable().push_back(make_bound_ref(0, LogicalTypeId::VARCHAR));
+  fn_expr->GetChildrenMutable().push_back(make_bound_int_const(1));
+  fn_expr->GetChildrenMutable().push_back(make_bound_int_const(3));
 
   auto out = sirius::ast::from_duckdb(*fn_expr);
   REQUIRE(out);
@@ -494,11 +494,11 @@ TEST_CASE("ast_from_duckdb - BOUND_FUNCTION 'substr' alias resolves to function_
 TEST_CASE("ast_from_duckdb - BOUND_FUNCTION unknown name returns nullptr", "[ast_from_duckdb]")
 {
   auto fn_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction("nonexistent_fn", {LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
+    duckdb::BoundScalarFunction(
+      ScalarFunction("nonexistent_fn", {LogicalType::INTEGER}, LogicalType::INTEGER, nullptr)),
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>{},
     nullptr);
-  fn_expr->children.push_back(make_bound_ref(0));
+  fn_expr->GetChildrenMutable().push_back(make_bound_ref(0));
 
   REQUIRE(sirius::ast::from_duckdb(*fn_expr) == nullptr);
 }
@@ -514,7 +514,7 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR NOT translates to unary_op(op_not)",
 {
   auto not_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT,
                                                              LogicalType{LogicalTypeId::BOOLEAN});
-  not_expr->children.push_back(make_bound_ref(0, LogicalTypeId::BOOLEAN));
+  not_expr->GetChildrenMutable().push_back(make_bound_ref(0, LogicalTypeId::BOOLEAN));
   auto out = sirius::ast::from_duckdb(*not_expr);
   REQUIRE(out);
   REQUIRE(out->holds<unary_op>());
@@ -528,7 +528,7 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR IS_NULL translates to unary_op(op_is
 {
   auto is_null_expr = duckdb::make_uniq<BoundOperatorExpression>(
     ExpressionType::OPERATOR_IS_NULL, LogicalType{LogicalTypeId::BOOLEAN});
-  is_null_expr->children.push_back(make_bound_ref(0));
+  is_null_expr->GetChildrenMutable().push_back(make_bound_ref(0));
   auto out = sirius::ast::from_duckdb(*is_null_expr);
   REQUIRE(out);
   REQUIRE(out->holds<unary_op>());
@@ -540,7 +540,7 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR IS_NOT_NULL translates to unary_op(o
 {
   auto is_not_null_expr = duckdb::make_uniq<BoundOperatorExpression>(
     ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType{LogicalTypeId::BOOLEAN});
-  is_not_null_expr->children.push_back(make_bound_ref(0));
+  is_not_null_expr->GetChildrenMutable().push_back(make_bound_ref(0));
   auto out = sirius::ast::from_duckdb(*is_not_null_expr);
   REQUIRE(out);
   REQUIRE(out->holds<unary_op>());
@@ -552,7 +552,7 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR TRY translates to unary_op(op_try)",
 {
   auto try_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_TRY,
                                                              LogicalType{LogicalTypeId::INTEGER});
-  try_expr->children.push_back(make_bound_ref(0));
+  try_expr->GetChildrenMutable().push_back(make_bound_ref(0));
   auto out = sirius::ast::from_duckdb(*try_expr);
   REQUIRE(out);
   REQUIRE(out->holds<unary_op>());
@@ -564,9 +564,9 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COALESCE translates to coalesce(N ch
 {
   auto coalesce_expr = duckdb::make_uniq<BoundOperatorExpression>(
     ExpressionType::OPERATOR_COALESCE, LogicalType{LogicalTypeId::INTEGER});
-  coalesce_expr->children.push_back(make_bound_ref(0));
-  coalesce_expr->children.push_back(make_bound_ref(1));
-  coalesce_expr->children.push_back(make_bound_int_const(0));
+  coalesce_expr->GetChildrenMutable().push_back(make_bound_ref(0));
+  coalesce_expr->GetChildrenMutable().push_back(make_bound_ref(1));
+  coalesce_expr->GetChildrenMutable().push_back(make_bound_int_const(0));
 
   auto out = sirius::ast::from_duckdb(*coalesce_expr);
   REQUIRE(out);
@@ -579,10 +579,10 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COMPARE_IN translates to in_list(neg
 {
   auto in_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
                                                             LogicalType{LogicalTypeId::BOOLEAN});
-  in_expr->children.push_back(make_bound_ref(0));
-  in_expr->children.push_back(make_bound_int_const(2));
-  in_expr->children.push_back(make_bound_int_const(5));
-  in_expr->children.push_back(make_bound_int_const(8));
+  in_expr->GetChildrenMutable().push_back(make_bound_ref(0));
+  in_expr->GetChildrenMutable().push_back(make_bound_int_const(2));
+  in_expr->GetChildrenMutable().push_back(make_bound_int_const(5));
+  in_expr->GetChildrenMutable().push_back(make_bound_int_const(8));
 
   auto out = sirius::ast::from_duckdb(*in_expr);
   REQUIRE(out);
@@ -599,9 +599,9 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COMPARE_NOT_IN translates to in_list
 {
   auto in_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_NOT_IN,
                                                             LogicalType{LogicalTypeId::BOOLEAN});
-  in_expr->children.push_back(make_bound_ref(0));
-  in_expr->children.push_back(make_bound_int_const(2));
-  in_expr->children.push_back(make_bound_int_const(4));
+  in_expr->GetChildrenMutable().push_back(make_bound_ref(0));
+  in_expr->GetChildrenMutable().push_back(make_bound_int_const(2));
+  in_expr->GetChildrenMutable().push_back(make_bound_int_const(4));
 
   auto out = sirius::ast::from_duckdb(*in_expr);
   REQUIRE(out);
@@ -618,8 +618,8 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR unsupported ExpressionType returns n
   // the demultiplex table; signal fallback via nullptr.
   auto nullif_expr = duckdb::make_uniq<BoundOperatorExpression>(
     ExpressionType::OPERATOR_NULLIF, LogicalType{LogicalTypeId::INTEGER});
-  nullif_expr->children.push_back(make_bound_ref(0));
-  nullif_expr->children.push_back(make_bound_int_const(0));
+  nullif_expr->GetChildrenMutable().push_back(make_bound_ref(0));
+  nullif_expr->GetChildrenMutable().push_back(make_bound_int_const(0));
 
   REQUIRE(sirius::ast::from_duckdb(*nullif_expr) == nullptr);
 }
@@ -629,10 +629,10 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR NOT with unsupported child propagate
 {
   // BoundParameterExpression translates to nullptr (BOUND_PARAMETER class).
   // Wrapping it in NOT must propagate the nullptr up.
-  auto bad_child = duckdb::make_uniq<BoundParameterExpression>(std::string{"p_not"});
+  auto bad_child = duckdb::make_uniq<BoundParameterExpression>(duckdb::Identifier{"p_not"});
   auto not_expr  = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT,
                                                              LogicalType{LogicalTypeId::BOOLEAN});
-  not_expr->children.push_back(std::move(bad_child));
+  not_expr->GetChildrenMutable().push_back(std::move(bad_child));
 
   REQUIRE(sirius::ast::from_duckdb(*not_expr) == nullptr);
 }
@@ -640,12 +640,12 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR NOT with unsupported child propagate
 TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COMPARE_IN with unsupported probe propagates nullptr",
           "[ast_from_duckdb]")
 {
-  auto bad_probe = duckdb::make_uniq<BoundParameterExpression>(std::string{"p_in"});
+  auto bad_probe = duckdb::make_uniq<BoundParameterExpression>(duckdb::Identifier{"p_in"});
   auto in_expr   = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
                                                             LogicalType{LogicalTypeId::BOOLEAN});
-  in_expr->children.push_back(std::move(bad_probe));
-  in_expr->children.push_back(make_bound_int_const(2));
-  in_expr->children.push_back(make_bound_int_const(3));
+  in_expr->GetChildrenMutable().push_back(std::move(bad_probe));
+  in_expr->GetChildrenMutable().push_back(make_bound_int_const(2));
+  in_expr->GetChildrenMutable().push_back(make_bound_int_const(3));
 
   REQUIRE(sirius::ast::from_duckdb(*in_expr) == nullptr);
 }
@@ -653,12 +653,12 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COMPARE_IN with unsupported probe pr
 TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COALESCE with unsupported child propagates nullptr",
           "[ast_from_duckdb]")
 {
-  auto bad_child     = duckdb::make_uniq<BoundParameterExpression>(std::string{"p_coalesce"});
+  auto bad_child = duckdb::make_uniq<BoundParameterExpression>(duckdb::Identifier{"p_coalesce"});
   auto coalesce_expr = duckdb::make_uniq<BoundOperatorExpression>(
     ExpressionType::OPERATOR_COALESCE, LogicalType{LogicalTypeId::INTEGER});
-  coalesce_expr->children.push_back(make_bound_ref(0));
-  coalesce_expr->children.push_back(std::move(bad_child));
-  coalesce_expr->children.push_back(make_bound_int_const(7));
+  coalesce_expr->GetChildrenMutable().push_back(make_bound_ref(0));
+  coalesce_expr->GetChildrenMutable().push_back(std::move(bad_child));
+  coalesce_expr->GetChildrenMutable().push_back(make_bound_int_const(7));
 
   REQUIRE(sirius::ast::from_duckdb(*coalesce_expr) == nullptr);
 }
@@ -669,7 +669,7 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COALESCE with unsupported child prop
 
 TEST_CASE("ast_from_duckdb - BOUND_PARAMETER returns nullptr", "[ast_from_duckdb]")
 {
-  auto param_expr = duckdb::make_uniq<BoundParameterExpression>(std::string{"p1"});
+  auto param_expr = duckdb::make_uniq<BoundParameterExpression>(duckdb::Identifier{"p1"});
   REQUIRE(sirius::ast::from_duckdb(*param_expr) == nullptr);
 }
 
@@ -706,7 +706,8 @@ TEST_CASE("ast_from_duckdb - real Binder output translates to non-null trees",
   // EMPTY_RESULT, stripping out every BoundExpression. Run the planner without
   // the optimizer so the test actually exercises from_duckdb on real Binder
   // output.
-  duckdb::ClientConfig::GetConfig(*conn.context).enable_optimizer = false;
+  duckdb::Settings::Set<duckdb::EnableOptimizerSetting>(
+    *conn.context, duckdb::SetScope::SESSION, duckdb::Value::BOOLEAN(false));
 
   auto plan =
     conn.ExtractPlan("SELECT a + 3, b LIKE 'x%', c IS NOT NULL FROM t WHERE a BETWEEN 1 AND 10");

--- a/test/cpp/expression/test_ast_to_duckdb.cpp
+++ b/test/cpp/expression/test_ast_to_duckdb.cpp
@@ -298,7 +298,7 @@ TEST_CASE("ast_to_duckdb - reference translates to BoundReferenceExpression (col
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_REF);
   auto const& ref = out->Cast<BoundReferenceExpression>();
-  REQUIRE(ref.index == 3);
+  REQUIRE(ref.Index() == 3);
 }
 
 // ============================================================================
@@ -316,7 +316,7 @@ TEST_CASE("ast_to_duckdb - constant INTEGER round-trips to BoundConstantExpressi
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT);
   auto const& bc = out->Cast<BoundConstantExpression>();
-  REQUIRE(bc.value == Value::INTEGER(42));
+  REQUIRE(bc.GetValue() == Value::INTEGER(42));
 }
 
 TEST_CASE("ast_to_duckdb - constant VARCHAR round-trips to BoundConstantExpression",
@@ -330,7 +330,7 @@ TEST_CASE("ast_to_duckdb - constant VARCHAR round-trips to BoundConstantExpressi
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT);
   auto const& bc = out->Cast<BoundConstantExpression>();
-  REQUIRE(bc.value == Value("hello"));
+  REQUIRE(bc.GetValue() == Value("hello"));
 }
 
 TEST_CASE("ast_to_duckdb - constant typed NULL (INTEGER) round-trips to BoundConstantExpression",
@@ -344,8 +344,8 @@ TEST_CASE("ast_to_duckdb - constant typed NULL (INTEGER) round-trips to BoundCon
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT);
   auto const& bc = out->Cast<BoundConstantExpression>();
-  REQUIRE(bc.value.IsNull());
-  REQUIRE(bc.value.type().id() == LogicalTypeId::INTEGER);
+  REQUIRE(bc.GetValue().IsNull());
+  REQUIRE(bc.GetValue().type().id() == LogicalTypeId::INTEGER);
 }
 
 TEST_CASE("ast_to_duckdb - constant DECIMAL64 round-trips to BoundConstantExpression",
@@ -359,7 +359,7 @@ TEST_CASE("ast_to_duckdb - constant DECIMAL64 round-trips to BoundConstantExpres
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT);
   auto const& bc = out->Cast<BoundConstantExpression>();
-  REQUIRE(bc.value.type().id() == LogicalTypeId::DECIMAL);
+  REQUIRE(bc.GetValue().type().id() == LogicalTypeId::DECIMAL);
 }
 
 // ============================================================================
@@ -372,11 +372,11 @@ TEST_CASE("ast_to_duckdb - comparison EQUAL translates to COMPARE_EQUAL", "[ast_
   auto out = sirius::ast::to_duckdb(orig);
   REQUIRE(out);
   REQUIRE(out->GetExpressionType() == ExpressionType::COMPARE_EQUAL);
-  auto const& cmp = out->Cast<BoundComparisonExpression>();
-  REQUIRE(cmp.left);
-  REQUIRE(cmp.right);
-  REQUIRE(cmp.left->GetExpressionClass() == ExpressionClass::BOUND_REF);
-  REQUIRE(cmp.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT);
+  REQUIRE(BoundComparisonExpression::IsComparison(*out));
+  auto const& cmp = out->Cast<BoundFunctionExpression>();
+  REQUIRE(BoundComparisonExpression::Left(cmp).GetExpressionClass() == ExpressionClass::BOUND_REF);
+  REQUIRE(BoundComparisonExpression::Right(cmp).GetExpressionClass() ==
+          ExpressionClass::BOUND_CONSTANT);
 }
 
 TEST_CASE("ast_to_duckdb - comparison NOT_EQUAL translates to COMPARE_NOTEQUAL", "[ast_to_duckdb]")
@@ -437,7 +437,7 @@ TEST_CASE("ast_to_duckdb - conjunction AND translates to BoundConjunctionExpress
   REQUIRE(out->GetExpressionType() == ExpressionType::CONJUNCTION_AND);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION);
   auto const& conj = out->Cast<BoundConjunctionExpression>();
-  REQUIRE(conj.children.size() == 2);
+  REQUIRE(conj.GetChildren().size() == 2);
 }
 
 TEST_CASE("ast_to_duckdb - conjunction OR (3 children) translates to BoundConjunctionExpression",
@@ -452,7 +452,7 @@ TEST_CASE("ast_to_duckdb - conjunction OR (3 children) translates to BoundConjun
   REQUIRE(out);
   REQUIRE(out->GetExpressionType() == ExpressionType::CONJUNCTION_OR);
   auto const& conj = out->Cast<BoundConjunctionExpression>();
-  REQUIRE(conj.children.size() == 3);
+  REQUIRE(conj.GetChildren().size() == 3);
 }
 
 // ============================================================================
@@ -471,13 +471,11 @@ TEST_CASE("ast_to_duckdb - between translates to BoundBetweenExpression (inclusi
   }};
   auto out = sirius::ast::to_duckdb(orig);
   REQUIRE(out);
-  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_BETWEEN);
-  auto const& bt = out->Cast<BoundBetweenExpression>();
-  REQUIRE(bt.lower_inclusive == true);
-  REQUIRE(bt.upper_inclusive == true);
-  REQUIRE(bt.input);
-  REQUIRE(bt.lower);
-  REQUIRE(bt.upper);
+  REQUIRE(out->GetExpressionType() == ExpressionType::COMPARE_BETWEEN);
+  auto const& bt = out->Cast<BoundFunctionExpression>();
+  REQUIRE(BoundBetweenExpression::LowerInclusive(bt) == true);
+  REQUIRE(BoundBetweenExpression::UpperInclusive(bt) == true);
+  REQUIRE(bt.GetChildren().size() == 3);
 }
 
 // ============================================================================
@@ -500,11 +498,11 @@ TEST_CASE("ast_to_duckdb - case_expr (single WHEN/THEN + ELSE) translates to Bou
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CASE);
   auto const& ce = out->Cast<BoundCaseExpression>();
-  REQUIRE(ce.return_type.id() == LogicalTypeId::INTEGER);
-  REQUIRE(ce.case_checks.size() == 1);
-  REQUIRE(ce.case_checks[0].when_expr);
-  REQUIRE(ce.case_checks[0].then_expr);
-  REQUIRE(ce.else_expr);
+  REQUIRE(ce.GetReturnType().id() == LogicalTypeId::INTEGER);
+  REQUIRE(ce.CaseChecks().size() == 1);
+  REQUIRE(ce.CaseChecks()[0].when_expr);
+  REQUIRE(ce.CaseChecks()[0].then_expr);
+  REQUIRE(ce.Else().GetExpressionClass() == ExpressionClass::BOUND_CONSTANT);
 }
 
 TEST_CASE("ast_to_duckdb - case_expr (two WHEN/THEN + ELSE) translates to BoundCaseExpression",
@@ -527,7 +525,7 @@ TEST_CASE("ast_to_duckdb - case_expr (two WHEN/THEN + ELSE) translates to BoundC
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CASE);
   auto const& ce = out->Cast<BoundCaseExpression>();
-  REQUIRE(ce.case_checks.size() == 2);
+  REQUIRE(ce.CaseChecks().size() == 2);
 }
 
 // ============================================================================
@@ -544,10 +542,10 @@ TEST_CASE("ast_to_duckdb - cast INTEGER->BIGINT (default) translates to BoundCas
   }};
   auto out = sirius::ast::to_duckdb(orig);
   REQUIRE(out);
-  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CAST);
-  auto const& ct = out->Cast<BoundCastExpression>();
-  REQUIRE(ct.try_cast == false);
-  REQUIRE(ct.return_type.id() == LogicalTypeId::BIGINT);
+  REQUIRE(BoundCastExpression::IsCast(*out));
+  auto const& ct = out->Cast<BoundFunctionExpression>();
+  REQUIRE(BoundCastExpression::IsTryCast(ct) == false);
+  REQUIRE(ct.GetReturnType().id() == LogicalTypeId::BIGINT);
 }
 
 TEST_CASE("ast_to_duckdb - cast INTEGER->BIGINT (try_cast=true) translates to BoundCastExpression",
@@ -560,10 +558,10 @@ TEST_CASE("ast_to_duckdb - cast INTEGER->BIGINT (try_cast=true) translates to Bo
   }};
   auto out = sirius::ast::to_duckdb(orig);
   REQUIRE(out);
-  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CAST);
-  auto const& ct = out->Cast<BoundCastExpression>();
-  REQUIRE(ct.try_cast == true);
-  REQUIRE(ct.return_type.id() == LogicalTypeId::BIGINT);
+  REQUIRE(BoundCastExpression::IsCast(*out));
+  auto const& ct = out->Cast<BoundFunctionExpression>();
+  REQUIRE(BoundCastExpression::IsTryCast(ct) == true);
+  REQUIRE(ct.GetReturnType().id() == LogicalTypeId::BIGINT);
 }
 
 // ============================================================================
@@ -576,7 +574,7 @@ TEST_CASE("ast_to_duckdb - unary_op op_not translates to OPERATOR_NOT", "[ast_to
   auto out = sirius::ast::to_duckdb(orig);
   REQUIRE(out);
   REQUIRE(out->GetExpressionType() == ExpressionType::OPERATOR_NOT);
-  REQUIRE(out->Cast<BoundOperatorExpression>().children.size() == 1);
+  REQUIRE(out->Cast<BoundOperatorExpression>().GetChildren().size() == 1);
 }
 
 TEST_CASE("ast_to_duckdb - unary_op op_is_null translates to OPERATOR_IS_NULL", "[ast_to_duckdb]")
@@ -618,8 +616,8 @@ TEST_CASE("ast_to_duckdb - coalesce (3 args) translates to OPERATOR_COALESCE", "
   auto out = sirius::ast::to_duckdb(orig);
   REQUIRE(out);
   REQUIRE(out->GetExpressionType() == ExpressionType::OPERATOR_COALESCE);
-  REQUIRE(out->Cast<BoundOperatorExpression>().return_type.id() == LogicalTypeId::INTEGER);
-  REQUIRE(out->Cast<BoundOperatorExpression>().children.size() == 3);
+  REQUIRE(out->Cast<BoundOperatorExpression>().GetReturnType().id() == LogicalTypeId::INTEGER);
+  REQUIRE(out->Cast<BoundOperatorExpression>().GetChildren().size() == 3);
 }
 
 // ============================================================================
@@ -641,7 +639,7 @@ TEST_CASE("ast_to_duckdb - in_list (negated=false) translates to COMPARE_IN", "[
   REQUIRE(out);
   REQUIRE(out->GetExpressionType() == ExpressionType::COMPARE_IN);
   // probe + 3 values = 4 children.
-  REQUIRE(out->Cast<BoundOperatorExpression>().children.size() == 4);
+  REQUIRE(out->Cast<BoundOperatorExpression>().GetChildren().size() == 4);
 }
 
 TEST_CASE("ast_to_duckdb - in_list (negated=true) translates to COMPARE_NOT_IN", "[ast_to_duckdb]")
@@ -676,9 +674,9 @@ TEST_CASE("ast_to_duckdb - function_call add translates to BoundFunctionExpressi
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
   auto const& fn = out->Cast<BoundFunctionExpression>();
-  REQUIRE(fn.function.name == "+");
-  REQUIRE(fn.children.size() == 2);
-  REQUIRE(fn.return_type.id() == LogicalTypeId::INTEGER);
+  REQUIRE(fn.Function().GetName() == "+");
+  REQUIRE(fn.GetChildren().size() == 2);
+  REQUIRE(fn.GetReturnType().id() == LogicalTypeId::INTEGER);
 }
 
 TEST_CASE("ast_to_duckdb - function_call substring translates to BoundFunctionExpression",
@@ -695,8 +693,8 @@ TEST_CASE("ast_to_duckdb - function_call substring translates to BoundFunctionEx
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
   auto const& fn = out->Cast<BoundFunctionExpression>();
-  REQUIRE(fn.function.name == "substring");
-  REQUIRE(fn.children.size() == 3);
+  REQUIRE(fn.Function().GetName() == "substring");
+  REQUIRE(fn.GetChildren().size() == 3);
 }
 
 TEST_CASE("ast_to_duckdb - function_call like translates to BoundFunctionExpression",
@@ -712,8 +710,8 @@ TEST_CASE("ast_to_duckdb - function_call like translates to BoundFunctionExpress
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
   auto const& fn = out->Cast<BoundFunctionExpression>();
-  REQUIRE(fn.function.name == "~~");
-  REQUIRE(fn.children.size() == 2);
+  REQUIRE(fn.Function().GetName() == "~~");
+  REQUIRE(fn.GetChildren().size() == 2);
 }
 
 TEST_CASE("ast_to_duckdb - function_call regexp_replace translates to BoundFunctionExpression",
@@ -730,8 +728,8 @@ TEST_CASE("ast_to_duckdb - function_call regexp_replace translates to BoundFunct
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
   auto const& fn = out->Cast<BoundFunctionExpression>();
-  REQUIRE(fn.function.name == "regexp_replace");
-  REQUIRE(fn.children.size() == 3);
+  REQUIRE(fn.Function().GetName() == "regexp_replace");
+  REQUIRE(fn.GetChildren().size() == 3);
 }
 
 TEST_CASE("ast_to_duckdb - function_call year translates to BoundFunctionExpression",
@@ -746,8 +744,8 @@ TEST_CASE("ast_to_duckdb - function_call year translates to BoundFunctionExpress
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
   auto const& fn = out->Cast<BoundFunctionExpression>();
-  REQUIRE(fn.function.name == "year");
-  REQUIRE(fn.children.size() == 1);
+  REQUIRE(fn.Function().GetName() == "year");
+  REQUIRE(fn.GetChildren().size() == 1);
 }
 
 // ============================================================================
@@ -777,7 +775,7 @@ TEST_CASE("ast_to_duckdb - case_expr preserves non-INTEGER (DECIMAL) return_type
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CASE);
   // Must be the recorded DECIMAL type, NOT an INTEGER placeholder.
-  REQUIRE(out->Cast<BoundCaseExpression>().return_type.id() == LogicalTypeId::DECIMAL);
+  REQUIRE(out->Cast<BoundCaseExpression>().GetReturnType().id() == LogicalTypeId::DECIMAL);
 }
 
 TEST_CASE("ast_to_duckdb - coalesce preserves non-INTEGER (DECIMAL) return_type", "[ast_to_duckdb]")
@@ -791,7 +789,7 @@ TEST_CASE("ast_to_duckdb - coalesce preserves non-INTEGER (DECIMAL) return_type"
   REQUIRE(out);
   REQUIRE(out->GetExpressionType() == ExpressionType::OPERATOR_COALESCE);
   // Must be the recorded DECIMAL type, NOT an INTEGER placeholder.
-  REQUIRE(out->Cast<BoundOperatorExpression>().return_type.id() == LogicalTypeId::DECIMAL);
+  REQUIRE(out->Cast<BoundOperatorExpression>().GetReturnType().id() == LogicalTypeId::DECIMAL);
 }
 
 // ============================================================================

--- a/test/cpp/expression/test_comparison_type_mapping.cpp
+++ b/test/cpp/expression/test_comparison_type_mapping.cpp
@@ -62,11 +62,7 @@ duckdb::JoinCondition make_cond(duckdb::unique_ptr<duckdb::Expression> left,
                                 duckdb::unique_ptr<duckdb::Expression> right,
                                 duckdb::ExpressionType comparison)
 {
-  duckdb::JoinCondition c;
-  c.left       = std::move(left);
-  c.right      = std::move(right);
-  c.comparison = comparison;
-  return c;
+  return duckdb::JoinCondition(std::move(left), std::move(right), comparison);
 }
 
 // Assert the AST node is an INTEGER constant equal to `expected`.

--- a/test/cpp/expression_evaluator/test_expression_evaluator_ast_equivalence.cpp
+++ b/test/cpp/expression_evaluator/test_expression_evaluator_ast_equivalence.cpp
@@ -246,7 +246,7 @@ TEST_CASE("ast_equivalence - constant VARCHAR", "[expression_evaluator_ast]")
 
 TEST_CASE("ast_equivalence - comparison EQUAL (MATERIALIZE)", "[expression_evaluator_ast]")
 {
-  auto duck_expr = duckdb::make_uniq<BoundComparisonExpression>(
+  auto duck_expr = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_EQUAL, duck_int_ref(0), duck_int_const(5));
   auto hand_ast = make_cmp(sirius::comparison_type::equal, make_ref(0), make_int_const(5));
   expect_hand_eq_translated(
@@ -255,7 +255,7 @@ TEST_CASE("ast_equivalence - comparison EQUAL (MATERIALIZE)", "[expression_evalu
 
 TEST_CASE("ast_equivalence - comparison EQUAL (AST_INTERPRET)", "[expression_evaluator_ast]")
 {
-  auto duck_expr = duckdb::make_uniq<BoundComparisonExpression>(
+  auto duck_expr = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_EQUAL, duck_int_ref(0), duck_int_const(5));
   auto hand_ast = make_cmp(sirius::comparison_type::equal, make_ref(0), make_int_const(5));
   expect_hand_eq_translated(
@@ -264,7 +264,7 @@ TEST_CASE("ast_equivalence - comparison EQUAL (AST_INTERPRET)", "[expression_eva
 
 TEST_CASE("ast_equivalence - comparison LESSTHAN (MATERIALIZE)", "[expression_evaluator_ast]")
 {
-  auto duck_expr = duckdb::make_uniq<BoundComparisonExpression>(
+  auto duck_expr = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_LESSTHAN, duck_int_ref(0), duck_int_const(5));
   auto hand_ast = make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(5));
   expect_hand_eq_translated(
@@ -278,13 +278,13 @@ TEST_CASE("ast_equivalence - comparison LESSTHAN (MATERIALIZE)", "[expression_ev
 namespace {
 duckdb::unique_ptr<Expression> duck_and_1_9()
 {
-  auto duck_lhs = duckdb::make_uniq<BoundComparisonExpression>(
+  auto duck_lhs = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_GREATERTHAN, duck_int_ref(0), duck_int_const(1));
-  auto duck_rhs = duckdb::make_uniq<BoundComparisonExpression>(
+  auto duck_rhs = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_LESSTHAN, duck_int_ref(0), duck_int_const(9));
   auto duck_expr = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
-  duck_expr->children.push_back(std::move(duck_lhs));
-  duck_expr->children.push_back(std::move(duck_rhs));
+  duck_expr->GetChildrenMutable().push_back(std::move(duck_lhs));
+  duck_expr->GetChildrenMutable().push_back(std::move(duck_rhs));
   return duckdb::unique_ptr<Expression>(duck_expr.release());
 }
 
@@ -319,7 +319,7 @@ TEST_CASE("ast_equivalence - conjunction AND (AST_INTERPRET)", "[expression_eval
 
 TEST_CASE("ast_equivalence - between (MATERIALIZE)", "[expression_evaluator_ast]")
 {
-  auto duck_expr = duckdb::make_uniq<BoundBetweenExpression>(
+  auto duck_expr = BoundBetweenExpression::Create(
     duck_int_ref(0), duck_int_const(5), duck_int_const(15), /*lo=*/true, /*hi=*/true);
   auto hand_ast = make_between(make_ref(0), make_int_const(5), make_int_const(15), true, true);
   expect_hand_eq_translated(
@@ -332,14 +332,14 @@ TEST_CASE("ast_equivalence - between (MATERIALIZE)", "[expression_evaluator_ast]
 
 TEST_CASE("ast_equivalence - case_expr WHEN/THEN/ELSE (MATERIALIZE)", "[expression_evaluator_ast]")
 {
-  auto duck_when = duckdb::make_uniq<BoundComparisonExpression>(
+  auto duck_when = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_EQUAL, duck_int_ref(0), duck_int_const(5));
   BoundCaseCheck check;
   check.when_expr = std::move(duck_when);
   check.then_expr = duck_int_const(10);
   auto duck_expr  = duckdb::make_uniq<BoundCaseExpression>(LogicalType{LogicalTypeId::INTEGER});
-  duck_expr->case_checks.push_back(std::move(check));
-  duck_expr->else_expr = duck_int_const(0);
+  duck_expr->CaseChecksMutable().push_back(std::move(check));
+  duck_expr->ElseMutable() = duck_int_const(0);
 
   std::vector<sirius::ast::case_expr::when_then> cases;
   cases.push_back(sirius::ast::case_expr::when_then{
@@ -374,11 +374,11 @@ TEST_CASE("ast_equivalence - cast INTEGER->BIGINT (MATERIALIZE)", "[expression_e
 TEST_CASE("ast_equivalence - unary_op NOT (MATERIALIZE)", "[expression_evaluator_ast]")
 {
   // Need a BOOLEAN-producing child; use a comparison.
-  auto duck_inner = duckdb::make_uniq<BoundComparisonExpression>(
+  auto duck_inner = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_EQUAL, duck_int_ref(0), duck_int_const(5));
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT,
                                                               LogicalType{LogicalTypeId::BOOLEAN});
-  duck_expr->children.push_back(std::move(duck_inner));
+  duck_expr->GetChildrenMutable().push_back(std::move(duck_inner));
 
   auto hand_ast =
     make_unary(sirius::ast::unary_op::kind::op_not,
@@ -392,7 +392,7 @@ TEST_CASE("ast_equivalence - unary_op IS_NULL (MATERIALIZE)", "[expression_evalu
 {
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL,
                                                               LogicalType{LogicalTypeId::BOOLEAN});
-  duck_expr->children.push_back(duck_int_ref(0));
+  duck_expr->GetChildrenMutable().push_back(duck_int_ref(0));
 
   auto hand_ast = make_unary(sirius::ast::unary_op::kind::op_is_null, make_ref(0));
 
@@ -404,7 +404,7 @@ TEST_CASE("ast_equivalence - unary_op IS_NOT_NULL (MATERIALIZE)", "[expression_e
 {
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL,
                                                               LogicalType{LogicalTypeId::BOOLEAN});
-  duck_expr->children.push_back(duck_int_ref(0));
+  duck_expr->GetChildrenMutable().push_back(duck_int_ref(0));
 
   auto hand_ast = make_unary(sirius::ast::unary_op::kind::op_is_not_null, make_ref(0));
 
@@ -422,7 +422,7 @@ TEST_CASE("ast_equivalence - unary_op TRY translation (no exec)", "[expression_e
   // the underlying OPERATOR_TRY specialization lands.
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_TRY,
                                                               LogicalType{LogicalTypeId::INTEGER});
-  duck_expr->children.push_back(duck_int_ref(0));
+  duck_expr->GetChildrenMutable().push_back(duck_int_ref(0));
 
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
@@ -442,8 +442,8 @@ TEST_CASE("ast_equivalence - coalesce (MATERIALIZE)", "[expression_evaluator_ast
 {
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_COALESCE,
                                                               LogicalType{LogicalTypeId::INTEGER});
-  duck_expr->children.push_back(duck_int_ref(0));
-  duck_expr->children.push_back(duck_int_const(0));
+  duck_expr->GetChildrenMutable().push_back(duck_int_ref(0));
+  duck_expr->GetChildrenMutable().push_back(duck_int_const(0));
 
   std::vector<std::unique_ptr<sirius::ast::node>> children;
   children.push_back(make_ref(0));
@@ -464,10 +464,10 @@ duckdb::unique_ptr<Expression> duck_in_2_5_8()
 {
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
                                                               LogicalType{LogicalTypeId::BOOLEAN});
-  duck_expr->children.push_back(duck_int_ref(0));
-  duck_expr->children.push_back(duck_int_const(2));
-  duck_expr->children.push_back(duck_int_const(5));
-  duck_expr->children.push_back(duck_int_const(8));
+  duck_expr->GetChildrenMutable().push_back(duck_int_ref(0));
+  duck_expr->GetChildrenMutable().push_back(duck_int_const(2));
+  duck_expr->GetChildrenMutable().push_back(duck_int_const(5));
+  duck_expr->GetChildrenMutable().push_back(duck_int_const(8));
   return duckdb::unique_ptr<Expression>(duck_expr.release());
 }
 
@@ -505,13 +505,12 @@ namespace {
 duckdb::unique_ptr<Expression> duck_add_3()
 {
   auto duck_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
+    duckdb::BoundScalarFunction(ScalarFunction(
+      "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr)),
     duckdb::vector<duckdb::unique_ptr<Expression>>{},
     nullptr);
-  duck_expr->children.push_back(duck_int_ref(0));
-  duck_expr->children.push_back(duck_int_const(3));
+  duck_expr->GetChildrenMutable().push_back(duck_int_ref(0));
+  duck_expr->GetChildrenMutable().push_back(duck_int_const(3));
   return duckdb::unique_ptr<Expression>(duck_expr.release());
 }
 

--- a/test/cpp/integration/test_pin_table_mvcc_foundation.cpp
+++ b/test/cpp/integration/test_pin_table_mvcc_foundation.cpp
@@ -174,8 +174,9 @@ TEST_CASE_METHOD(PinMvccFixture,
   // default in-memory catalog's — each AttachedDatabase counts independently).
   run_ok("BEGIN TRANSACTION;");
   run_ok("CALL pin_table(format='duckdb', name='mvcc_vbase_t', tier='gpu');");
-  auto& pinned_catalog = duckdb::Catalog::GetCatalog(*con->context, attach_alias);
-  auto const expected  = duckdb::DuckTransaction::Get(*con->context, pinned_catalog).start_time;
+  auto& pinned_catalog =
+    duckdb::Catalog::GetCatalog(*con->context, duckdb::Identifier(attach_alias));
+  auto const expected = duckdb::DuckTransaction::Get(*con->context, pinned_catalog).start_time;
   run_ok("COMMIT;");
 
   auto probe = probe_entry(*con, "mvcc_vbase_t");

--- a/test/cpp/integration/test_pin_table_zone_map_pruning.cpp
+++ b/test/cpp/integration/test_pin_table_zone_map_pruning.cpp
@@ -30,6 +30,7 @@
 #include <duckdb.hpp>
 #include <duckdb/planner/filter/constant_filter.hpp>
 #include <duckdb/planner/table_filter.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
 #include <scan_manager/sirius_scan_manager.hpp>
 #include <unistd.h>
 #include <utils/sirius_test_env.hpp>
@@ -167,9 +168,9 @@ std::size_t entry_chunk_count(sirius::scan_manager::pinned_entry const& e)
 std::size_t probe_pruned_count(sirius::scan_manager::pinned_entry const& e)
 {
   duckdb::TableFilterSet fs;
-  duckdb::unique_ptr<duckdb::TableFilter> f = duckdb::make_uniq<duckdb::ConstantFilter>(
+  duckdb::unique_ptr<duckdb::TableFilter> f = duckdb::make_uniq<duckdb::LegacyConstantFilter>(
     duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::BIGINT(kSelectiveLo));
-  fs.filters[0] = std::move(f);
+  fs.PushFilter(duckdb::ProjectionIndex(0), std::move(f));
   duckdb::vector<duckdb::ColumnIndex> qcols;
   qcols.emplace_back(duckdb::ColumnIndex(0));
   return sirius::scan_manager::build_cached_scan_plan(e, &fs, &qcols).pruned;

--- a/test/cpp/integration/test_query_lifecycle_slot.cpp
+++ b/test/cpp/integration/test_query_lifecycle_slot.cpp
@@ -38,6 +38,7 @@
 #include <duckdb/main/client_config.hpp>
 #include <duckdb/main/client_data.hpp>
 #include <duckdb/main/pending_query_result.hpp>
+#include <duckdb/main/settings.hpp>
 #include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -1179,20 +1180,23 @@ void run_ac6_capture_generation(duckdb::Connection& connection,
   // planning generation, not incidentally cleared by another QueryBegin.
   connection.context->client_data->catalog_search_path->Set(
     duckdb::CatalogSearchEntry::Parse("new_scope"), duckdb::CatalogSetPathType::SET_SCHEMAS);
-  auto& client_config            = duckdb::ClientConfig::GetConfig(*connection.context);
-  client_config.enable_optimizer = false;
+  auto set_optimizer = [&](bool enabled) {
+    duckdb::Settings::Set<duckdb::EnableOptimizerSetting>(
+      *connection.context, duckdb::SetScope::SESSION, duckdb::Value::BOOLEAN(enabled));
+  };
+  set_optimizer(false);
 
   auto const stats_before_prepare = sirius::test::get_transparent_execution_stats(connection);
   mark_workload_started(output_path, out);
   auto prepared = connection.Prepare("SELECT count(*) FROM t;");
   if (!require_success(prepared.get(), "AC-6 Prepare", out)) {
-    client_config.enable_optimizer = true;
+    set_optimizer(true);
     (void)connection.Query("ROLLBACK;");
     return;
   }
   auto const stats_after_prepare = sirius::test::get_transparent_execution_stats(connection);
   if (stats_after_prepare.successful_rebinds != stats_before_prepare.successful_rebinds) {
-    client_config.enable_optimizer = true;
+    set_optimizer(true);
     (void)connection.Query("ROLLBACK;");
     out.error = "AC-6 first Prepare changed successful_rebinds from " +
                 std::to_string(stats_before_prepare.successful_rebinds) + " to " +
@@ -1204,10 +1208,10 @@ void run_ac6_capture_generation(duckdb::Connection& connection,
   try {
     execute_ok = run_prepared_scalar(*prepared, "7", "AC-6 Execute", out.error);
   } catch (...) {
-    client_config.enable_optimizer = true;
+    set_optimizer(true);
     throw;
   }
-  client_config.enable_optimizer = true;
+  set_optimizer(true);
   if (!execute_ok) {
     (void)connection.Query("ROLLBACK;");
     return;

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -1753,7 +1753,7 @@ duckdb::unique_ptr<duckdb::FunctionData> bind_sirius_read_parquet(
 
     duckdb::named_parameter_map_t named_parameters;
     duckdb::vector<duckdb::LogicalType> input_table_types;
-    duckdb::vector<std::string> input_table_names;
+    duckdb::vector<duckdb::Identifier> input_table_names;
 
     duckdb::TableFunctionRef ref;
     duckdb::vector<duckdb::unique_ptr<duckdb::ParsedExpression>> children;

--- a/test/cpp/integration/test_tpcds_plan_translation.cpp
+++ b/test/cpp/integration/test_tpcds_plan_translation.cpp
@@ -33,6 +33,7 @@
  * returning the result as a row instead of attempting execution.
  */
 
+#include "duckdb/main/settings.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
 #include <catch.hpp>
@@ -99,7 +100,7 @@ unique_ptr<FunctionData> PlanCheckBind(ClientContext& context,
     auto plan = std::move(planner.plan);
 
     // 3. Optimize
-    if (context.config.enable_optimizer) {
+    if (duckdb::Settings::Get<duckdb::EnableOptimizerSetting>(context)) {
       Optimizer optimizer(*planner.binder, context);
       plan = optimizer.Optimize(std::move(plan));
     }
@@ -108,7 +109,7 @@ unique_ptr<FunctionData> PlanCheckBind(ClientContext& context,
     plan->ResolveOperatorTypes();
 
     ColumnBindingResolver resolver;
-    ColumnBindingResolver::Verify(*plan);
+    ColumnBindingResolver::Verify(context, *plan);
     resolver.VisitOperator(*plan);
 
     // 5. Translate to Sirius physical plan
@@ -256,7 +257,7 @@ unique_ptr<FunctionData> GPUPlanCheckBind(ClientContext& context,
     auto plan = std::move(planner.plan);
 
     // 3. Optimize
-    if (context.config.enable_optimizer) {
+    if (duckdb::Settings::Get<duckdb::EnableOptimizerSetting>(context)) {
       Optimizer optimizer(*planner.binder, context);
       plan = optimizer.Optimize(std::move(plan));
     }
@@ -265,7 +266,7 @@ unique_ptr<FunctionData> GPUPlanCheckBind(ClientContext& context,
     plan->ResolveOperatorTypes();
 
     ColumnBindingResolver resolver;
-    ColumnBindingResolver::Verify(*plan);
+    ColumnBindingResolver::Verify(context, *plan);
     resolver.VisitOperator(*plan);
 
     // 5. Check operator support against the legacy GPU planner dispatch table

--- a/test/cpp/operator/aggregate/aggregate_test_utils.hpp
+++ b/test/cpp/operator/aggregate/aggregate_test_utils.hpp
@@ -56,12 +56,21 @@ struct AggregateExpressionResult {
  * Creates a minimal AggregateFunction with just name and types,
  * suitable for GPU operator testing where full aggregate logic isn't needed.
  */
-inline duckdb::AggregateFunction MakeDummyAggregate(const std::string& name,
-                                                    const duckdb::vector<duckdb::LogicalType>& args,
-                                                    const duckdb::LogicalType& ret_type)
+inline duckdb::BoundAggregateFunction MakeDummyAggregate(
+  const std::string& name,
+  const duckdb::vector<duckdb::LogicalType>& args,
+  const duckdb::LogicalType& ret_type)
 {
-  return duckdb::AggregateFunction(
-    name, args, ret_type, 0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  return duckdb::BoundAggregateFunction(
+    duckdb::AggregateFunction(duckdb::Identifier(name),
+                              args,
+                              ret_type,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              duckdb::FunctionNullHandling::DEFAULT_NULL_HANDLING));
 }
 
 /**
@@ -132,7 +141,7 @@ AggregateExpressionResult create_aggregate_expressions(
       duckdb::make_uniq<duckdb::BoundReferenceExpression>(Traits::logical_type(), agg_idx));
 
     // Create the dummy aggregate function
-    duckdb::AggregateFunction agg_function =
+    duckdb::BoundAggregateFunction agg_function =
       MakeDummyAggregate(agg_name, {Traits::logical_type()}, ret_type);
 
     // Create the BoundAggregateExpression
@@ -447,7 +456,7 @@ AggregateExpressionResult create_count_distinct_expressions(
   agg_children.push_back(
     duckdb::make_uniq<duckdb::BoundReferenceExpression>(ValTraits::logical_type(), agg_col_idx));
 
-  duckdb::AggregateFunction agg_function =
+  duckdb::BoundAggregateFunction agg_function =
     MakeDummyAggregate("count", {ValTraits::logical_type()}, duckdb::LogicalType::BIGINT);
 
   auto agg_expr =
@@ -504,7 +513,7 @@ inline AggregateExpressionResult create_count_distinct_struct_col_expressions(
 
   duckdb::ScalarFunction struct_fn("struct_pack", struct_arg_types, struct_return_type, nullptr);
   auto struct_expr = duckdb::make_uniq<duckdb::BoundFunctionExpression>(
-    struct_return_type, std::move(struct_fn), std::move(struct_children), nullptr);
+    duckdb::BoundScalarFunction(struct_fn), std::move(struct_children), nullptr);
 
   // COUNT(DISTINCT struct_expr) aggregate expression
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> agg_children;
@@ -512,7 +521,7 @@ inline AggregateExpressionResult create_count_distinct_struct_col_expressions(
 
   auto agg_fn = MakeDummyAggregate("count", {struct_return_type}, duckdb::LogicalType::BIGINT);
   auto count_distinct_expr =
-    duckdb::make_uniq<duckdb::BoundAggregateExpression>(agg_fn,
+    duckdb::make_uniq<duckdb::BoundAggregateExpression>(duckdb::BoundAggregateFunction(agg_fn),
                                                         std::move(agg_children),
                                                         nullptr,  // filter
                                                         nullptr,  // bind_info

--- a/test/cpp/operator/test_host_table_chunk_reader.cpp
+++ b/test/cpp/operator/test_host_table_chunk_reader.cpp
@@ -290,7 +290,8 @@ TEST_CASE("host_table_chunk_reader produces correct DataChunks",
     REQUIRE(reader.get_next_chunk(chunk));
 
     auto const count = static_cast<size_t>(chunk.size());
-    REQUIRE(chunk.GetCapacity() == static_cast<duckdb::idx_t>(count));
+    // DataChunk::GetCapacity was removed upstream; exact-capacity sizing is no
+    // longer observable, so only the row count is asserted.
     auto* int32_data = duckdb::FlatVector::GetData<int32_t>(chunk.data[0]);
     auto* int64_data = duckdb::FlatVector::GetData<int64_t>(chunk.data[1]);
     auto* str_data   = duckdb::FlatVector::GetData<duckdb::string_t>(chunk.data[2]);

--- a/test/cpp/operator/test_no_history_peak_memory_estimate.cpp
+++ b/test/cpp/operator/test_no_history_peak_memory_estimate.cpp
@@ -58,10 +58,10 @@ hash_join_fixture make_hash_join()
     0);
 
   duckdb::vector<duckdb::JoinCondition> conditions;
-  duckdb::JoinCondition cond;
-  cond.left  = duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  cond.right = duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  cond.comparison = duckdb::ExpressionType::COMPARE_EQUAL;
+  duckdb::JoinCondition cond(
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0),
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0),
+    duckdb::ExpressionType::COMPARE_EQUAL);
   conditions.push_back(std::move(cond));
 
   f.hash_join = duckdb::make_uniq<sirius_physical_hash_join>(

--- a/test/cpp/operator/test_physical_concat.cpp
+++ b/test/cpp/operator/test_physical_concat.cpp
@@ -98,10 +98,10 @@ hash_join_test_fixture create_test_hash_join(
 
   // Create a single equality join condition (column 0 = column 0)
   duckdb::vector<duckdb::JoinCondition> conditions;
-  duckdb::JoinCondition cond;
-  cond.left  = duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  cond.right = duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  cond.comparison = duckdb::ExpressionType::COMPARE_EQUAL;
+  duckdb::JoinCondition cond(
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0),
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0),
+    duckdb::ExpressionType::COMPARE_EQUAL);
   conditions.push_back(std::move(cond));
 
   // Build the hash join

--- a/test/cpp/operator/test_physical_filter.cpp
+++ b/test/cpp/operator/test_physical_filter.cpp
@@ -80,7 +80,7 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
       *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);
   }
 
-  auto filter_duckdb = duckdb::make_uniq<BoundComparisonExpression>(
+  auto filter_duckdb = BoundComparisonExpression::Create(
     ExpressionType::COMPARE_GREATERTHAN,
     duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT),
                                                 0),

--- a/test/cpp/operator/test_physical_mark_join.cpp
+++ b/test/cpp/operator/test_physical_mark_join.cpp
@@ -91,10 +91,10 @@ mark_join_fixture create_mark_join()
     0);
 
   duckdb::vector<duckdb::JoinCondition> conditions;
-  duckdb::JoinCondition cond;
-  cond.left       = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  cond.right      = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  cond.comparison = duckdb::ExpressionType::COMPARE_EQUAL;
+  duckdb::JoinCondition cond(
+    duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0),
+    duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0),
+    duckdb::ExpressionType::COMPARE_EQUAL);
   conditions.push_back(std::move(cond));
 
   f.hash_join = duckdb::make_uniq<sirius_physical_hash_join>(
@@ -157,10 +157,10 @@ nlj_projection_fixture create_projected_nlj(duckdb::JoinType join_type,
     0);
 
   duckdb::vector<duckdb::JoinCondition> conditions;
-  duckdb::JoinCondition cond;
-  cond.left       = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  cond.right      = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  cond.comparison = comparison;
+  duckdb::JoinCondition cond(
+    duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0),
+    duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0),
+    comparison);
   conditions.push_back(std::move(cond));
 
   f.nlj = duckdb::make_uniq<sirius_physical_nested_loop_join>(
@@ -200,15 +200,15 @@ nlj_projection_fixture create_projected_nlj_two_cond(duckdb::ExpressionType comp
     0);
 
   duckdb::vector<duckdb::JoinCondition> conditions;
-  duckdb::JoinCondition cond0;
-  cond0.left       = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  cond0.right      = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  cond0.comparison = comparison0;
+  duckdb::JoinCondition cond0(
+    duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0),
+    duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0),
+    comparison0);
   conditions.push_back(std::move(cond0));
-  duckdb::JoinCondition cond1;
-  cond1.left       = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 2);
-  cond1.right      = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 1);
-  cond1.comparison = comparison1;
+  duckdb::JoinCondition cond1(
+    duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 2),
+    duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 1),
+    comparison1);
   conditions.push_back(std::move(cond1));
 
   f.nlj = duckdb::make_uniq<sirius_physical_nested_loop_join>(
@@ -549,15 +549,15 @@ TEST_CASE("sirius_physical_hash_join mark join - mixed conditions are unsupporte
 
   // Equality (left.col0 = right.col0) + inequality (left.col1 < right.col0) => mixed shape.
   duckdb::vector<duckdb::JoinCondition> conditions;
-  duckdb::JoinCondition eq;
-  eq.left       = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  eq.right      = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  eq.comparison = duckdb::ExpressionType::COMPARE_EQUAL;
+  duckdb::JoinCondition eq(
+    duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0),
+    duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0),
+    duckdb::ExpressionType::COMPARE_EQUAL);
   conditions.push_back(std::move(eq));
-  duckdb::JoinCondition lt;
-  lt.left       = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 1);
-  lt.right      = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  lt.comparison = duckdb::ExpressionType::COMPARE_LESSTHAN;
+  duckdb::JoinCondition lt(
+    duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 1),
+    duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0),
+    duckdb::ExpressionType::COMPARE_LESSTHAN);
   conditions.push_back(std::move(lt));
 
   REQUIRE_THROWS_AS(duckdb::make_uniq<sirius_physical_hash_join>(

--- a/test/cpp/operator/test_physical_streaming_source.cpp
+++ b/test/cpp/operator/test_physical_streaming_source.cpp
@@ -521,7 +521,7 @@ TEST_CASE("streaming_source SRC-17: execute output feeds into real sirius_physic
   auto source_out   = op->execute(*source_input, stream);
 
   // Build filter: col0 > 3 (BIGINT).
-  auto filter_expr_duck = duckdb::make_uniq<duckdb::BoundComparisonExpression>(
+  auto filter_expr_duck = duckdb::BoundComparisonExpression::Create(
     duckdb::ExpressionType::COMPARE_GREATERTHAN,
     duckdb::make_uniq<duckdb::BoundReferenceExpression>(
       duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), 0),

--- a/test/cpp/operator/test_physical_table_scan.cpp
+++ b/test/cpp/operator/test_physical_table_scan.cpp
@@ -82,9 +82,9 @@ TEMPLATE_TEST_CASE(
 
   // Create table filter set with a filter on first column (filter_vals > 3)
   auto table_filters   = duckdb::make_uniq<duckdb::TableFilterSet>();
-  auto constant_filter = duckdb::make_uniq<duckdb::ConstantFilter>(
+  auto constant_filter = duckdb::make_uniq<duckdb::LegacyConstantFilter>(
     duckdb::ExpressionType::COMPARE_GREATERTHAN, duckdb::Value::BIGINT(3));
-  table_filters->PushFilter(duckdb::ColumnIndex(0), std::move(constant_filter));
+  table_filters->PushFilter(duckdb::ProjectionIndex(0), std::move(constant_filter));
 
   // Setup types for the table scan
   duckdb::vector<duckdb::LogicalType> types;
@@ -277,13 +277,13 @@ TEST_CASE("sirius_physical_table_scan with multiple filters", "[physical_table_s
   // col0 > 2 AND col1 <= 30
   auto table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
 
-  auto filter0 = duckdb::make_uniq<duckdb::ConstantFilter>(
+  auto filter0 = duckdb::make_uniq<duckdb::LegacyConstantFilter>(
     duckdb::ExpressionType::COMPARE_GREATERTHAN, duckdb::Value::BIGINT(2));
-  table_filters->PushFilter(duckdb::ColumnIndex(0), std::move(filter0));
+  table_filters->PushFilter(duckdb::ProjectionIndex(0), std::move(filter0));
 
-  auto filter1 = duckdb::make_uniq<duckdb::ConstantFilter>(
+  auto filter1 = duckdb::make_uniq<duckdb::LegacyConstantFilter>(
     duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO, duckdb::Value::INTEGER(30));
-  table_filters->PushFilter(duckdb::ColumnIndex(1), std::move(filter1));
+  table_filters->PushFilter(duckdb::ProjectionIndex(1), std::move(filter1));
 
   // Setup types
   duckdb::vector<duckdb::LogicalType> types;
@@ -350,9 +350,9 @@ TEST_CASE("sirius_physical_table_scan filters all rows", "[physical_table_scan]"
 
   // Filter that excludes all rows: col0 > 100
   auto table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
-  auto filter        = duckdb::make_uniq<duckdb::ConstantFilter>(
+  auto filter        = duckdb::make_uniq<duckdb::LegacyConstantFilter>(
     duckdb::ExpressionType::COMPARE_GREATERTHAN, duckdb::Value::BIGINT(100));
-  table_filters->PushFilter(duckdb::ColumnIndex(0), std::move(filter));
+  table_filters->PushFilter(duckdb::ProjectionIndex(0), std::move(filter));
 
   // Setup types
   duckdb::vector<duckdb::LogicalType> types;

--- a/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
+++ b/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
@@ -63,12 +63,20 @@ inline duckdb::vector<std::unique_ptr<sirius::ast::node>> translate_expressions(
 
 // Helper to create a dummy AggregateFunction since we only need the name and types for the GPU
 // operator
-AggregateFunction MakeDummyAggregate(const std::string& name,
-                                     const duckdb::vector<LogicalType>& args,
-                                     const LogicalType& ret_type)
+duckdb::BoundAggregateFunction MakeDummyAggregate(const std::string& name,
+                                                  const duckdb::vector<LogicalType>& args,
+                                                  const LogicalType& ret_type)
 {
-  return AggregateFunction(
-    name, args, ret_type, 0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  return duckdb::BoundAggregateFunction(
+    AggregateFunction(duckdb::Identifier(name),
+                      args,
+                      ret_type,
+                      nullptr,
+                      nullptr,
+                      nullptr,
+                      nullptr,
+                      nullptr,
+                      duckdb::FunctionNullHandling::DEFAULT_NULL_HANDLING));
 }
 
 TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COUNT",

--- a/test/cpp/pipeline/test_modified_pipeline.cpp
+++ b/test/cpp/pipeline/test_modified_pipeline.cpp
@@ -32,6 +32,8 @@
  */
 
 // catch2
+#include "duckdb/main/settings.hpp"
+
 #include <catch.hpp>
 
 // sirius
@@ -353,7 +355,8 @@ duckdb::unique_ptr<sirius_physical_operator> generate_gpu_plan(Connection& con,
 {
   // Create a separate connection for extracting the logical plan (like SiriusInitPlanExtractor)
   // Connection plan_conn(*con.context->db);
-  con.context->config.enable_optimizer      = true;
+  duckdb::Settings::Set<duckdb::EnableOptimizerSetting>(
+    *con.context, duckdb::SetScope::SESSION, duckdb::Value::BOOLEAN(true));
   con.context->config.use_replacement_scans = false;
 
   set<OptimizerType> disabled_optimizers;
@@ -390,7 +393,7 @@ duckdb::unique_ptr<sirius_physical_operator> generate_gpu_plan(Connection& con,
   // After optimization, refresh types before column binding resolution
   logical_plan->ResolveOperatorTypes();
   duckdb::ColumnBindingResolver resolver;
-  duckdb::ColumnBindingResolver::Verify(*logical_plan);
+  duckdb::ColumnBindingResolver::Verify(*con.context, *logical_plan);
   resolver.VisitOperator(*logical_plan);
 
   // Create the raw GPU physical plan

--- a/test/cpp/pipeline/test_plan_printer.cpp
+++ b/test/cpp/pipeline/test_plan_printer.cpp
@@ -29,6 +29,8 @@
  */
 
 // catch2
+#include "duckdb/main/settings.hpp"
+
 #include <catch.hpp>
 
 // sirius
@@ -354,7 +356,8 @@ duckdb::unique_ptr<sirius_physical_operator> generate_gpu_plan(
   const std::string& query,
   duckdb::shared_ptr<sirius_prepared_statement_data>& out_prepared)
 {
-  con.context->config.enable_optimizer      = true;
+  duckdb::Settings::Set<duckdb::EnableOptimizerSetting>(
+    *con.context, duckdb::SetScope::SESSION, duckdb::Value::BOOLEAN(true));
   con.context->config.use_replacement_scans = false;
 
   set<OptimizerType> disabled_optimizers;
@@ -385,7 +388,7 @@ duckdb::unique_ptr<sirius_physical_operator> generate_gpu_plan(
 
   logical_plan->ResolveOperatorTypes();
   duckdb::ColumnBindingResolver resolver;
-  duckdb::ColumnBindingResolver::Verify(*logical_plan);
+  duckdb::ColumnBindingResolver::Verify(*con.context, *logical_plan);
   resolver.VisitOperator(*logical_plan);
 
   sirius_physical_plan_generator physical_planner(*con.context);

--- a/test/cpp/planner/test_distinct_hash_join_detection.cpp
+++ b/test/cpp/planner/test_distinct_hash_join_detection.cpp
@@ -20,6 +20,7 @@
  *        build-side keys are proven unique at plan construction time.
  */
 
+#include "duckdb/main/settings.hpp"
 #include "op/sirius_physical_hash_join.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
@@ -97,7 +98,7 @@ duckdb::unique_ptr<sirius::op::sirius_physical_operator> generate_sirius_plan(
 
     auto plan = std::move(planner.plan);
 
-    if (context.config.enable_optimizer) {
+    if (duckdb::Settings::Get<duckdb::EnableOptimizerSetting>(context)) {
       Optimizer optimizer(*planner.binder, context);
       plan = optimizer.Optimize(std::move(plan));
     }
@@ -105,7 +106,7 @@ duckdb::unique_ptr<sirius::op::sirius_physical_operator> generate_sirius_plan(
     plan->ResolveOperatorTypes();
 
     ColumnBindingResolver resolver;
-    ColumnBindingResolver::Verify(*plan);
+    ColumnBindingResolver::Verify(context, *plan);
     resolver.VisitOperator(*plan);
 
     sirius::planner::sirius_physical_plan_generator gen(context);

--- a/test/cpp/planner/test_duckdb_join_filter_candidate_adapter.cpp
+++ b/test/cpp/planner/test_duckdb_join_filter_candidate_adapter.cpp
@@ -51,13 +51,10 @@ namespace {
 
 duckdb::JoinCondition make_condition(duckdb::ExpressionType comparison)
 {
-  duckdb::JoinCondition cond;
-  cond.left =
-    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0ULL);
-  cond.right =
-    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0ULL);
-  cond.comparison = comparison;
-  return cond;
+  return duckdb::JoinCondition(
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0ULL),
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0ULL),
+    comparison);
 }
 
 duckdb::unique_ptr<duckdb::LogicalComparisonJoin> make_join(
@@ -78,8 +75,9 @@ duckdb::JoinFilterPushdownFilter make_target(duckdb::shared_ptr<duckdb::DynamicT
   pi.dynamic_filters = std::move(dyn);
   for (duckdb::idx_t i = 0; i < column_count; ++i) {
     duckdb::JoinFilterPushdownColumn col;
-    col.probe_column_index = duckdb::ColumnBinding{0, i};
-    col.storage_type       = duckdb::LogicalType::INTEGER;
+    col.probe_column_index =
+      duckdb::ColumnBinding{duckdb::TableIndex(0), duckdb::ProjectionIndex(i)};
+    col.storage_type = duckdb::LogicalType::INTEGER;
     pi.columns.push_back(col);
   }
   return pi;
@@ -99,11 +97,11 @@ duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> make_pushdown_info(
 duckdb::unique_ptr<duckdb::LogicalGet> make_get()
 {
   return duckdb::make_uniq<duckdb::LogicalGet>(
-    /*table_index=*/0,
+    duckdb::TableIndex(0),
     duckdb::TableFunction(),
     /*bind_data=*/nullptr,
     duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER},
-    duckdb::vector<duckdb::string>{"a"});
+    duckdb::vector<duckdb::Identifier>{"a"});
 }
 
 /// The malformed contract: only `kind` is meaningful; every other field is default/empty.

--- a/test/cpp/planner/test_dynamic_filter_router.cpp
+++ b/test/cpp/planner/test_dynamic_filter_router.cpp
@@ -29,6 +29,7 @@
 #include <catch.hpp>
 #include <duckdb.hpp>
 #include <duckdb/planner/table_filter.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
 
 using sirius::op::sirius_dynamic_filter_set;
 using sirius::planner::sirius_physical_plan_generator;

--- a/test/cpp/planner/test_join_expression_key.cpp
+++ b/test/cpp/planner/test_join_expression_key.cpp
@@ -21,6 +21,7 @@
  *        plain column reference so PARTITION/CONCAT/hash-join see an ordinary column index.
  */
 
+#include "duckdb/main/settings.hpp"
 #include "expression/ast/to_duckdb.hpp"
 #include "expression/join_condition.hpp"
 #include "op/sirius_physical_hash_join.hpp"
@@ -99,7 +100,7 @@ duckdb::unique_ptr<sirius::op::sirius_physical_operator> generate_sirius_plan(
 
     auto plan = std::move(planner.plan);
 
-    if (context.config.enable_optimizer) {
+    if (duckdb::Settings::Get<duckdb::EnableOptimizerSetting>(context)) {
       Optimizer optimizer(*planner.binder, context);
       plan = optimizer.Optimize(std::move(plan));
     }
@@ -107,7 +108,7 @@ duckdb::unique_ptr<sirius::op::sirius_physical_operator> generate_sirius_plan(
     plan->ResolveOperatorTypes();
 
     ColumnBindingResolver resolver;
-    ColumnBindingResolver::Verify(*plan);
+    ColumnBindingResolver::Verify(context, *plan);
     resolver.VisitOperator(*plan);
 
     sirius::planner::sirius_physical_plan_generator gen(context);

--- a/test/cpp/planner/test_plan_tree_shape.cpp
+++ b/test/cpp/planner/test_plan_tree_shape.cpp
@@ -23,6 +23,7 @@
  *        every operator's `_parent_op` matches its position in the final tree.
  */
 
+#include "duckdb/main/settings.hpp"
 #include "op/sirius_physical_column_data_scan.hpp"
 #include "op/sirius_physical_concat.hpp"
 #include "op/sirius_physical_delim_join.hpp"
@@ -113,7 +114,7 @@ duckdb::unique_ptr<sirius_physical_operator> generate_sirius_plan(Connection& co
 
     auto plan = std::move(planner.plan);
 
-    if (context.config.enable_optimizer) {
+    if (duckdb::Settings::Get<duckdb::EnableOptimizerSetting>(context)) {
       Optimizer optimizer(*planner.binder, context);
       plan = optimizer.Optimize(std::move(plan));
     }
@@ -121,7 +122,7 @@ duckdb::unique_ptr<sirius_physical_operator> generate_sirius_plan(Connection& co
     plan->ResolveOperatorTypes();
 
     ColumnBindingResolver resolver;
-    ColumnBindingResolver::Verify(*plan);
+    ColumnBindingResolver::Verify(context, *plan);
     resolver.VisitOperator(*plan);
 
     sirius::planner::sirius_physical_plan_generator gen(context);

--- a/test/cpp/scan/test_duckdb_block_layout.cpp
+++ b/test/cpp/scan/test_duckdb_block_layout.cpp
@@ -25,6 +25,7 @@
 #include <duckdb/storage/block_manager.hpp>
 #include <duckdb/storage/buffer/buffer_handle.hpp>
 #include <duckdb/storage/buffer_manager.hpp>
+#include <duckdb/storage/data_table.hpp>
 #include <duckdb/storage/single_file_block_manager.hpp>
 #include <duckdb/storage/storage_info.hpp>
 #include <duckdb/storage/storage_manager.hpp>
@@ -83,7 +84,8 @@ duckdb::DataTable& get_storage(duckdb::Connection& con, const std::string& table
   auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
   duckdb::CatalogTransaction txn(catalog, ctx);
   auto& schema = catalog.GetSchema(txn, "main");
-  auto entry   = schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, table_name);
+  auto entry =
+    schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, duckdb::Identifier(table_name));
   REQUIRE(entry);
   return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
 }

--- a/test/cpp/scan/test_duckdb_insert_delta.cpp
+++ b/test/cpp/scan/test_duckdb_insert_delta.cpp
@@ -84,7 +84,8 @@ duckdb::DataTable& resolve_storage(duckdb::Connection& con, const std::string& t
   auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
   duckdb::CatalogTransaction txn(catalog, ctx);
   auto& schema = catalog.GetSchema(txn, "main");
-  auto entry   = schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, table_name);
+  auto entry =
+    schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, duckdb::Identifier(table_name));
   REQUIRE(entry);
   return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
 }

--- a/test/cpp/scan/test_duckdb_mvcc_visibility.cpp
+++ b/test/cpp/scan/test_duckdb_mvcc_visibility.cpp
@@ -110,7 +110,8 @@ duckdb::DataTable& resolve_storage(duckdb::Connection& con, const std::string& t
   auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
   duckdb::CatalogTransaction txn(catalog, ctx);
   auto& schema = catalog.GetSchema(txn, "main");
-  auto entry   = schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, table_name);
+  auto entry =
+    schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, duckdb::Identifier(table_name));
   REQUIRE(entry);
   return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
 }

--- a/test/cpp/scan/test_duckdb_native_dynamic_filter_remap.cpp
+++ b/test/cpp/scan/test_duckdb_native_dynamic_filter_remap.cpp
@@ -19,9 +19,11 @@
 #include <duckdb/catalog/catalog.hpp>
 #include <duckdb/catalog/catalog_entry/duck_table_entry.hpp>
 #include <duckdb/common/column_index.hpp>
+#include <duckdb/main/attached_database.hpp>
 #include <duckdb/main/client_context.hpp>
 #include <duckdb/planner/filter/constant_filter.hpp>
 #include <duckdb/planner/table_filter.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
 #include <duckdb/storage/data_table.hpp>
 #include <duckdb/storage/storage_manager.hpp>
 #include <op/scan/duckdb_native_gpu_ingestible.hpp>
@@ -63,7 +65,8 @@ duckdb::DataTable& get_storage(duckdb::Connection& con, const std::string& table
   auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
   duckdb::CatalogTransaction txn(catalog, ctx);
   auto& schema = catalog.GetSchema(txn, "main");
-  auto entry   = schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, table_name);
+  auto entry =
+    schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, duckdb::Identifier(table_name));
   REQUIRE(entry);
   return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
 }
@@ -197,8 +200,10 @@ TEST_CASE("duckdb-native ingestible installs the dynamic-filter column remap",
     auto channel        = std::make_shared<sirius::op::sirius_dynamic_filter_set>();
     auto info           = make_info(storage, *con.context, all_cols, {0, 1, 2}, 2, channel);
     info->table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
-    info->table_filters->filters[2] = duckdb::make_uniq<duckdb::ConstantFilter>(
-      duckdb::ExpressionType::COMPARE_GREATERTHAN, duckdb::Value::INTEGER(10));
+    info->table_filters->PushFilter(
+      duckdb::ProjectionIndex(2),
+      duckdb::make_uniq<duckdb::LegacyConstantFilter>(duckdb::ExpressionType::COMPARE_GREATERTHAN,
+                                                      duckdb::Value::INTEGER(10)));
     auto ingestible = make_ingestible(std::move(info));
     REQUIRE(ingestible);
 

--- a/test/cpp/scan/test_duckdb_native_host_backed_decode.cpp
+++ b/test/cpp/scan/test_duckdb_native_host_backed_decode.cpp
@@ -98,7 +98,8 @@ duckdb::DataTable& resolve_storage(duckdb::Connection& con, const std::string& t
   auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
   duckdb::CatalogTransaction txn(catalog, ctx);
   auto& schema = catalog.GetSchema(txn, "main");
-  auto entry   = schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, table_name);
+  auto entry =
+    schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, duckdb::Identifier(table_name));
   REQUIRE(entry);
   return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
 }

--- a/test/cpp/scan/test_duckdb_native_walker.cpp
+++ b/test/cpp/scan/test_duckdb_native_walker.cpp
@@ -65,7 +65,8 @@ duckdb::DataTable& get_storage(duckdb::Connection& con, const std::string& table
   auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
   duckdb::CatalogTransaction txn(catalog, ctx);
   auto& schema = catalog.GetSchema(txn, "main");
-  auto entry   = schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, table_name);
+  auto entry =
+    schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, duckdb::Identifier(table_name));
   REQUIRE(entry);
   return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
 }
@@ -294,7 +295,7 @@ filter_ctx make_constant_filter(duckdb::idx_t col_key,
 {
   filter_ctx ctx;
   ctx.filters.filters[col_key] =
-    duckdb::make_uniq<duckdb::ConstantFilter>(cmp, std::move(constant));
+    duckdb::make_uniq<duckdb::LegacyConstantFilter>(cmp, std::move(constant));
   // column_ids must be indexable at col_key; pad with the same storage_idx.
   ctx.column_ids.resize(col_key + 1, duckdb::ColumnIndex(storage_idx));
   ctx.column_ids[col_key] = duckdb::ColumnIndex(storage_idx);
@@ -932,7 +933,7 @@ TEST_CASE("statistics pruning prunes through an OPTIONAL_FILTER wrapper",
 
   filter_ctx ctx;
   ctx.filters.filters[0] =
-    duckdb::make_uniq<duckdb::OptionalFilter>(duckdb::make_uniq<duckdb::ConstantFilter>(
+    duckdb::make_uniq<duckdb::LegacyOptionalFilter>(duckdb::make_uniq<duckdb::LegacyConstantFilter>(
       duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(250000)));
   ctx.column_ids.push_back(duckdb::ColumnIndex(0));
 

--- a/test/cpp/scan_manager/test_insert_delta_job.cpp
+++ b/test/cpp/scan_manager/test_insert_delta_job.cpp
@@ -94,7 +94,8 @@ duckdb::DataTable& resolve_storage(duckdb::Connection& con, const std::string& t
   auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
   duckdb::CatalogTransaction txn(catalog, ctx);
   auto& schema = catalog.GetSchema(txn, "main");
-  auto entry   = schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, table_name);
+  auto entry =
+    schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, duckdb::Identifier(table_name));
   REQUIRE(entry);
   return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
 }

--- a/test/cpp/scan_manager/test_mvcc_mask_job.cpp
+++ b/test/cpp/scan_manager/test_mvcc_mask_job.cpp
@@ -102,7 +102,8 @@ duckdb::DataTable& resolve_storage(duckdb::Connection& con, const std::string& t
   auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
   duckdb::CatalogTransaction txn(catalog, ctx);
   auto& schema = catalog.GetSchema(txn, "main");
-  auto entry   = schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, table_name);
+  auto entry =
+    schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, duckdb::Identifier(table_name));
   REQUIRE(entry);
   return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
 }

--- a/test/cpp/scan_manager/test_pinned_chunk_stats.cpp
+++ b/test/cpp/scan_manager/test_pinned_chunk_stats.cpp
@@ -59,6 +59,7 @@
 #include <duckdb/planner/filter/optional_filter.hpp>
 #include <duckdb/planner/filter/struct_filter.hpp>
 #include <duckdb/planner/table_filter.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
 #include <duckdb/storage/statistics/base_statistics.hpp>
 #include <duckdb/storage/statistics/numeric_stats.hpp>
 #include <scan_manager/pinned_chunk_stats.hpp>
@@ -95,17 +96,17 @@ filter_ptr make_filter(ARGS&&... args)
 
 filter_ptr cmp(ExpressionType comparison, Value constant)
 {
-  return make_filter<duckdb::ConstantFilter>(comparison, std::move(constant));
+  return make_filter<duckdb::LegacyConstantFilter>(comparison, std::move(constant));
 }
 
 filter_ptr in_list(duckdb::vector<Value> values)
 {
-  return make_filter<duckdb::InFilter>(std::move(values));
+  return make_filter<duckdb::LegacyInFilter>(std::move(values));
 }
 
 filter_ptr and_of(filter_ptr a, filter_ptr b)
 {
-  auto conj = duckdb::make_uniq<duckdb::ConjunctionAndFilter>();
+  auto conj = duckdb::make_uniq<duckdb::LegacyConjunctionAndFilter>();
   conj->child_filters.push_back(std::move(a));
   conj->child_filters.push_back(std::move(b));
   return filter_ptr{std::move(conj)};
@@ -113,7 +114,7 @@ filter_ptr and_of(filter_ptr a, filter_ptr b)
 
 filter_ptr or_of(filter_ptr a, filter_ptr b)
 {
-  auto conj = duckdb::make_uniq<duckdb::ConjunctionOrFilter>();
+  auto conj = duckdb::make_uniq<duckdb::LegacyConjunctionOrFilter>();
   conj->child_filters.push_back(std::move(a));
   conj->child_filters.push_back(std::move(b));
   return filter_ptr{std::move(conj)};
@@ -121,10 +122,10 @@ filter_ptr or_of(filter_ptr a, filter_ptr b)
 
 filter_ptr optional_of(filter_ptr child)
 {
-  return make_filter<duckdb::OptionalFilter>(std::move(child));
+  return make_filter<duckdb::LegacyOptionalFilter>(std::move(child));
 }
 
-filter_ptr dynamic_placeholder() { return make_filter<duckdb::DynamicFilter>(); }
+filter_ptr dynamic_placeholder() { return make_filter<duckdb::LegacyDynamicFilter>(); }
 
 /// Stats exactly as compute_pinned_chunk_stats builds them: CreateUnknown +
 /// bounds + exact chunk-level null flags.
@@ -164,15 +165,15 @@ TEST_CASE("pinned_chunk_stats - classifier accepts allowed static shapes", "[pin
   }
 
   REQUIRE(filter_safe_for_stats(*in_list({Value::INTEGER(1), Value::INTEGER(2)}), type));
-  REQUIRE(filter_safe_for_stats(duckdb::IsNullFilter{}, type));
-  REQUIRE(filter_safe_for_stats(duckdb::IsNotNullFilter{}, type));
+  REQUIRE(filter_safe_for_stats(duckdb::LegacyIsNullFilter{}, type));
+  REQUIRE(filter_safe_for_stats(duckdb::LegacyIsNotNullFilter{}, type));
 
   auto conjunctions = and_of(cmp(ExpressionType::COMPARE_GREATERTHAN, Value::INTEGER(1)),
                              cmp(ExpressionType::COMPARE_LESSTHAN, Value::INTEGER(10)));
   REQUIRE(filter_safe_for_stats(*conjunctions, type));
 
   auto nested = optional_of(
-    or_of(make_filter<duckdb::IsNullFilter>(),
+    or_of(make_filter<duckdb::LegacyIsNullFilter>(),
           and_of(cmp(ExpressionType::COMPARE_EQUAL, Value::INTEGER(5)),
                  cmp(ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value::INTEGER(0)))));
   REQUIRE(filter_safe_for_stats(*nested, type));
@@ -190,10 +191,10 @@ TEST_CASE("pinned_chunk_stats - classifier rejects dynamic filters at any depth"
   REQUIRE_FALSE(filter_safe_for_stats(*dynamic_placeholder(), type));
   REQUIRE_FALSE(filter_safe_for_stats(*optional_of(dynamic_placeholder()), type));
   REQUIRE_FALSE(filter_safe_for_stats(
-    *or_of(make_filter<duckdb::IsNullFilter>(), dynamic_placeholder()), type));
+    *or_of(make_filter<duckdb::LegacyIsNullFilter>(), dynamic_placeholder()), type));
   // The shape a runtime join filter actually arrives in.
   REQUIRE_FALSE(filter_safe_for_stats(
-    *optional_of(or_of(make_filter<duckdb::IsNullFilter>(), dynamic_placeholder())), type));
+    *optional_of(or_of(make_filter<duckdb::LegacyIsNullFilter>(), dynamic_placeholder())), type));
   // Deep nesting: one dynamic leaf poisons the whole tree.
   REQUIRE_FALSE(filter_safe_for_stats(
     *and_of(or_of(cmp(ExpressionType::COMPARE_EQUAL, Value::INTEGER(1)), dynamic_placeholder()),
@@ -215,7 +216,8 @@ TEST_CASE("pinned_chunk_stats - classifier rejects unsupported shapes and malfor
     filter_safe_for_stats(*cmp(ExpressionType::COMPARE_DISTINCT_FROM, Value::INTEGER(1)), type));
 
   REQUIRE_FALSE(filter_safe_for_stats(
-    duckdb::StructFilter{0, "child", cmp(ExpressionType::COMPARE_EQUAL, Value::INTEGER(1))}, type));
+    duckdb::LegacyStructFilter{0, "child", cmp(ExpressionType::COMPARE_EQUAL, Value::INTEGER(1))},
+    type));
 
   duckdb::ExpressionFilter expression_filter{
     duckdb::make_uniq<duckdb::BoundConstantExpression>(Value::BOOLEAN(true))};
@@ -223,21 +225,22 @@ TEST_CASE("pinned_chunk_stats - classifier rejects unsupported shapes and malfor
 
   // Childless conjunctions cannot occur from the binder; both reject (a
   // childless OR would fold to FILTER_ALWAYS_FALSE and prune unconditionally).
-  REQUIRE_FALSE(filter_safe_for_stats(duckdb::ConjunctionAndFilter{}, type));
-  REQUIRE_FALSE(filter_safe_for_stats(duckdb::ConjunctionOrFilter{}, type));
+  REQUIRE_FALSE(filter_safe_for_stats(duckdb::LegacyConjunctionAndFilter{}, type));
+  REQUIRE_FALSE(filter_safe_for_stats(duckdb::LegacyConjunctionOrFilter{}, type));
 
   // OptionalFilter's child defaults to nullptr; its CheckStatistics derefs the
   // child unconditionally, so the classifier must reject childless optionals.
-  REQUIRE_FALSE(filter_safe_for_stats(duckdb::OptionalFilter{}, type));
+  REQUIRE_FALSE(filter_safe_for_stats(duckdb::LegacyOptionalFilter{}, type));
 
   // InFilter's constructor bans null/empty values, so violate the invariants
   // by mutating the public field — the classifier must stay total anyway.
   auto in_with_null = in_list({Value::INTEGER(1)});
-  in_with_null->Cast<duckdb::InFilter>().values.emplace_back(LogicalType::INTEGER);  // NULL value
+  in_with_null->Cast<duckdb::LegacyInFilter>().values.emplace_back(
+    LogicalType::INTEGER);  // NULL value
   REQUIRE_FALSE(filter_safe_for_stats(*in_with_null, type));
 
   auto in_emptied = in_list({Value::INTEGER(1)});
-  in_emptied->Cast<duckdb::InFilter>().values.clear();
+  in_emptied->Cast<duckdb::LegacyInFilter>().values.clear();
   REQUIRE_FALSE(filter_safe_for_stats(*in_emptied, type));
 }
 
@@ -335,9 +338,9 @@ TEST_CASE("pinned_chunk_stats - prune handles null-based proofs", "[pinned_chunk
   auto const with_nulls =
     make_stats(LogicalType::INTEGER, Value::INTEGER(10), Value::INTEGER(20), /*has_null=*/true);
 
-  REQUIRE(chunk_provably_empty(duckdb::IsNullFilter{}, no_nulls));
-  REQUIRE_FALSE(chunk_provably_empty(duckdb::IsNullFilter{}, with_nulls));
-  REQUIRE_FALSE(chunk_provably_empty(duckdb::IsNotNullFilter{}, with_nulls));
+  REQUIRE(chunk_provably_empty(duckdb::LegacyIsNullFilter{}, no_nulls));
+  REQUIRE_FALSE(chunk_provably_empty(duckdb::LegacyIsNullFilter{}, with_nulls));
+  REQUIRE_FALSE(chunk_provably_empty(duckdb::LegacyIsNotNullFilter{}, with_nulls));
 
   // All-null statistics: compute_pinned_chunk_stats never produces these
   // (all-null columns get a null stats cell), but the prune check's contract
@@ -345,7 +348,7 @@ TEST_CASE("pinned_chunk_stats - prune handles null-based proofs", "[pinned_chunk
   auto all_null = duckdb::NumericStats::CreateUnknown(LogicalType::INTEGER);
   all_null.Set(duckdb::StatsInfo::CANNOT_HAVE_VALID_VALUES);
   all_null.SetHasNull();
-  REQUIRE(chunk_provably_empty(duckdb::IsNotNullFilter{}, all_null));
+  REQUIRE(chunk_provably_empty(duckdb::LegacyIsNotNullFilter{}, all_null));
   // Constant comparisons need a non-null row to match, so all-null prunes too.
   REQUIRE(chunk_provably_empty(*cmp(ExpressionType::COMPARE_EQUAL, Value::INTEGER(15)), all_null));
 }
@@ -366,7 +369,7 @@ TEST_CASE("pinned_chunk_stats - prune is conservative on unsafe input", "[pinned
   REQUIRE_FALSE(
     chunk_provably_empty(*cmp(ExpressionType::COMPARE_GREATERTHAN, Value::INTEGER(1)), date_stats));
   REQUIRE_FALSE(chunk_provably_empty(*dynamic_placeholder(), date_stats));
-  REQUIRE_FALSE(chunk_provably_empty(duckdb::OptionalFilter{}, date_stats));
+  REQUIRE_FALSE(chunk_provably_empty(duckdb::LegacyOptionalFilter{}, date_stats));
 }
 
 // ============================================================================
@@ -829,7 +832,7 @@ pinned_entry make_plan_entry(std::size_t n_chunks, std::vector<duckdb::idx_t> co
 duckdb::TableFilterSet make_filter_set(duckdb::idx_t key, filter_ptr f)
 {
   duckdb::TableFilterSet fs;
-  fs.filters[key] = std::move(f);
+  fs.PushFilter(duckdb::ProjectionIndex(key), std::move(f));
   return fs;
 }
 
@@ -940,10 +943,11 @@ TEST_CASE("build_cached_scan_plan - identity plan whenever pruning is not provab
   SECTION("dynamic filter rejects; a usable sibling filter still prunes")
   {
     duckdb::TableFilterSet fs;
-    fs.filters[0] = dynamic_placeholder();
+    fs.PushFilter(duckdb::ProjectionIndex(0), dynamic_placeholder());
     duckdb::vector<duckdb::ColumnIndex> two_cols{duckdb::ColumnIndex(3), duckdb::ColumnIndex(3)};
-    fs.filters[1] = cmp(ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value::INTEGER(1000));
-    auto plan     = build_cached_scan_plan(entry, &fs, &two_cols);
+    fs.PushFilter(duckdb::ProjectionIndex(1),
+                  cmp(ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value::INTEGER(1000)));
+    auto plan = build_cached_scan_plan(entry, &fs, &two_cols);
     REQUIRE(plan.survivor_chunk_indices == survivors_t{1, 2});
     REQUIRE(plan.pruned == 1);
   }

--- a/test/cpp/transparent/test_preserve_dynamic_filter_metadata.cpp
+++ b/test/cpp/transparent/test_preserve_dynamic_filter_metadata.cpp
@@ -89,12 +89,14 @@ duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> make_pushdown_info(
   pi.dynamic_filters = std::move(dyn_filters);
 
   duckdb::JoinFilterPushdownColumn col_a;
-  col_a.probe_column_index = duckdb::ColumnBinding{1, 2};
-  col_a.storage_type       = duckdb::LogicalType::INTEGER;
+  col_a.probe_column_index =
+    duckdb::ColumnBinding{duckdb::TableIndex(1), duckdb::ProjectionIndex(2)};
+  col_a.storage_type = duckdb::LogicalType::INTEGER;
   duckdb::JoinFilterPushdownColumn col_b;
-  col_b.probe_column_index = duckdb::ColumnBinding{1, 3};
-  col_b.storage_type       = duckdb::LogicalType::BIGINT;
-  pi.columns               = {col_a, col_b};
+  col_b.probe_column_index =
+    duckdb::ColumnBinding{duckdb::TableIndex(1), duckdb::ProjectionIndex(3)};
+  col_b.storage_type = duckdb::LogicalType::BIGINT;
+  pi.columns         = {col_a, col_b};
 
   info->probe_info.push_back(std::move(pi));
   return info;

--- a/test/cpp/utils/pipeline_conversion_test_utils.cpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.cpp
@@ -107,13 +107,13 @@ extracted_plan extract_logical_plan_sirius_order(duckdb::ClientContext& context,
   prepared->value_map = std::move(planner.value_map);
 
   duckdb::unique_ptr<duckdb::LogicalOperator> plan = std::move(planner.plan);
-  if (context.config.enable_optimizer) {
+  if (duckdb::Settings::Get<duckdb::EnableOptimizerSetting>(context)) {
     duckdb::Optimizer optimizer(*planner.binder, context);
     plan = optimizer.Optimize(std::move(plan));
   }
   plan->ResolveOperatorTypes();
   duckdb::ColumnBindingResolver resolver;
-  duckdb::ColumnBindingResolver::Verify(*plan);
+  duckdb::ColumnBindingResolver::Verify(context, *plan);
   resolver.VisitOperator(*plan);
   return {std::move(plan), std::move(prepared)};
 }


### PR DESCRIPTION
Bumps the duckdb submodule from v1.5.4 (`08e34c44`) to main tip (`ee6ce3cd`, `v1.5.4-9924`) and ports Sirius to the reworked APIs. Draft — see verification status below.

## What changed upstream, and how Sirius adapts

| Upstream change | Port |
|---|---|
| `Bound{Comparison,Cast,Between}Expression` collapsed into `BoundFunctionExpression` (old names = static-helper structs) | `from_duckdb` splits `BOUND_FUNCTION` back into cast/between/comparison/function via `IsCast`/`COMPARE_BETWEEN`/`IsComparison`; construction via `::Create` factories |
| Expression/plan members encapsulated | `GetReturnType`, `GetChildren[Mutable]`, `Index`, `Binding`, `JoinCondition::GetLHS/GetRHS/GetComparisonType`, `ColumnSegment::GetStats/GetSegmentType/GetBlockHandle`, … |
| Typed names/indexes: `Identifier`, `ProjectionIndex`, `TableIndex` | new boundary helpers `sirius::from_duckdb_names` / `from_duckdb_projection_ids` (helper/type_conversions) unwrap at operator-constructor call sites; operator headers unchanged |
| `TableFilterSet` opaque (own header, `PushFilter`/iterators); filters renamed `Legacy*`; `TableFilter::CheckStatistics` removed | iteration via the new API; zone-map pruning through `ToExpression` + `ExpressionFilter::CheckExpressionStatistics` |
| `StringVector::AddBuffer` removed; `FlatVector::GetData` const-only; vector helpers moved | owned string payloads via `AddAuxiliaryData`; `GetDataMutable` on write paths |
| `enable_optimizer` → typed settings; `ColumnBindingResolver::Verify(context, op)`; profiler phases → RAII timers; `join_stats` moved into `JoinCondition` | ported accordingly |

## ⚠️ Review focus: MVCC version-state probe (semantic change, not a rename)

`RowGroup::GetPartitionStats` no longer reports `COUNT_APPROXIMATE` for **committed** deletes — the exact signal Sirius's version-state probe relied on. Unfixed, a committed `DELETE` would have been read back as live rows by the GPU native scan, silently.

The probe (`duckdb_mvcc_visibility.cpp`, `duckdb_insert_delta.cpp`) now reads `!stats.partition_row_group->MinMaxIsExact(StorageIndex())` under the scan's own transaction. `is_exact` is cleared exactly when some physical row is not visible (unloaded or loaded deletes, committed or not, or a visible-count mismatch), so its negation is a no-false-negative version-state signal. It leans on `DuckDBPartitionRowGroup` ignoring the `StorageIndex` argument (the flag is per row group) — flagged in comments.

## Cross-repo dependency

The vendored substrait reader is ported in sirius-db/duckdb-substrait-extension#2; this PR's substrait gitlink points at that branch. **#2 must merge first**, then this PR re-pins to the merged commit.

## Verification status (why draft)

- [x] Full build green: static lib + loadable extension + `sirius_unittest`, 1300/1300 targets
- [x] AST translation tests: 87/87 (334 assertions)
- [ ] Full `sirius_unittest` suite on GPU
- [ ] **GPU-vs-CPU differential tests over DELETE scenarios** (gates the MVCC probe change; storage version also moved 64→69 under the native decoders)
- [ ] `distribution.yml` `duckdb_version: v1.5.4` and `pixi.toml` `duckdb = "=1.5.4"` (python-duckdb) — no matching release exists for a main pin; needs a decision
