### PR TITLE
Fix Simpatico multi-GPU stream affinity

### DIFF
--- a/src/compression/simpatico_codegen/CMakeLists.txt
+++ b/src/compression/simpatico_codegen/CMakeLists.txt
@@ -221,6 +221,7 @@ add_codegen_host_test(test_fused_operator_sweep)
 add_codegen_host_test(test_operator_sweep)
 add_codegen_host_test(test_representation_contract)
 add_codegen_host_test(test_bitpack_layout_contract)
+add_codegen_host_test(test_multi_gpu_stream_affinity)
 
 # Multi-mode CLI. Target is simpatico_cli to avoid clashing with the lib target;
 # the installed binary is named 'simpatico'.
@@ -253,3 +254,5 @@ add_test(NAME fused_operator_sweep COMMAND test_fused_operator_sweep)
 add_test(NAME operator_sweep COMMAND test_operator_sweep)
 add_test(NAME representation_contract COMMAND test_representation_contract)
 add_test(NAME bitpack_layout_contract COMMAND test_bitpack_layout_contract)
+# Self-skips (PASS) on a single-GPU host.
+add_test(NAME multi_gpu_stream_affinity COMMAND test_multi_gpu_stream_affinity)

--- a/src/compression/simpatico_codegen/CMakeLists.txt
+++ b/src/compression/simpatico_codegen/CMakeLists.txt
@@ -254,5 +254,4 @@ add_test(NAME fused_operator_sweep COMMAND test_fused_operator_sweep)
 add_test(NAME operator_sweep COMMAND test_operator_sweep)
 add_test(NAME representation_contract COMMAND test_representation_contract)
 add_test(NAME bitpack_layout_contract COMMAND test_bitpack_layout_contract)
-# Self-skips (PASS) on a single-GPU host.
 add_test(NAME multi_gpu_stream_affinity COMMAND test_multi_gpu_stream_affinity)

--- a/src/compression/simpatico_codegen/src/simpatico_codegen.cpp
+++ b/src/compression/simpatico_codegen/src/simpatico_codegen.cpp
@@ -15,6 +15,7 @@
 #include <nvtx3/nvtx3.hpp>
 
 #include <atomic>
+#include <map>
 #include <mutex>
 #include <span>
 #include <stdexcept>
@@ -108,17 +109,29 @@ void validate_column_names(std::vector<std::string> const& column_names, size_t 
 // result is safe to free by any stream (including the RMM default) with no
 // external rebinding. Streams are recycled between calls, so this also avoids
 // per-call stream create/destroy churn.
+//
+// The free lists are keyed by device. A CUDA stream belongs to the device that
+// was current when it was created, and driving work on a stream from another
+// device is invalid — kernel launches fail with "invalid resource handle" and
+// the async copies/codec calls around them can fault the context with
+// cudaErrorIllegalAddress. In the affected Sirius path, multi-GPU pin_table
+// compression uses a caller-owned pool; this cache is exercised by the
+// subsequent per-device threaded decode. Without the device key, one device's
+// completed decode can recycle its streams into the next device's decode.
 class stream_cache {
  public:
-  // Hand out n valid streams, reusing recycled ones and creating the rest.
-  std::vector<cudaStream_t> checkout(size_t n)
+  // Hand out n valid streams belonging to `device`, reusing ones recycled from
+  // that device and creating the rest. The caller must have `device` current:
+  // cudaStreamCreateWithFlags binds the new streams to the current device.
+  std::vector<cudaStream_t> checkout(int device, size_t n)
   {
     std::vector<cudaStream_t> out;
     out.reserve(n);
     std::lock_guard<std::mutex> lock(mu_);
-    while (out.size() < n && !free_.empty()) {
-      out.push_back(free_.back());
-      free_.pop_back();
+    auto& free_list = free_[device];
+    while (out.size() < n && !free_list.empty()) {
+      out.push_back(free_list.back());
+      free_list.pop_back();
     }
     while (out.size() < n) {
       cudaStream_t s{};
@@ -127,18 +140,22 @@ class stream_cache {
     }
     return out;
   }
-  // Return streams for reuse. They are kept alive (never destroyed): buffers of
-  // previously-returned results may still reference them for their async free.
-  void check_in(std::vector<cudaStream_t>& streams)
+
+  // Return `device`'s streams for reuse. They are kept alive (never destroyed):
+  // buffers of previously-returned results may still reference them for their
+  // async free. `device` must be the one they were checked out with, so they go
+  // back to the free list of the device they actually belong to.
+  void check_in(int device, std::vector<cudaStream_t>& streams)
   {
     std::lock_guard<std::mutex> lock(mu_);
-    free_.insert(free_.end(), streams.begin(), streams.end());
+    auto& free_list = free_[device];
+    free_list.insert(free_list.end(), streams.begin(), streams.end());
     streams.clear();
   }
 
  private:
   std::mutex mu_;
-  std::vector<cudaStream_t> free_;
+  std::map<int, std::vector<cudaStream_t>> free_;
 };
 
 stream_cache& global_stream_cache()
@@ -153,19 +170,30 @@ stream_cache& global_stream_cache()
 // its eventual async free even after this pool is gone. Concurrent leases get
 // disjoint streams (checkout is mutex-guarded and pops distinct handles), so each
 // call's sync_all only touches its own streams.
+//
+// Public internal-parallel calls retain the caller's current device for the
+// synchronous lease lifetime, and run_column_workers binds each worker thread
+// to that device. Capture it once so checkout and return use the same free list.
 struct leased_pool {
   stream_pool pool;
+  int device = 0;
 
   explicit leased_pool(int column_threads)
   {
-    pool.streams = global_stream_cache().checkout(static_cast<size_t>(std::max(1, column_threads)));
+    if (cudaGetDevice(&device) != cudaSuccess)
+      throw plan_error("failed to query the current device for the internal stream lease");
+
+    pool.streams =
+      global_stream_cache().checkout(device, static_cast<size_t>(std::max(1, column_threads)));
+
     if (pool.streams.empty()) throw plan_error("failed to lease internal streams");
   }
+
   ~leased_pool()
   {
     pool.sync_all();
     global_stream_cache().check_in(
-      pool.streams);  // leaves pool.streams empty; ~stream_pool is a no-op
+      device, pool.streams);  // leaves pool.streams empty; ~stream_pool is a no-op
   }
 
   leased_pool(const leased_pool&)            = delete;

--- a/src/compression/simpatico_codegen/src/simpatico_codegen.cpp
+++ b/src/compression/simpatico_codegen/src/simpatico_codegen.cpp
@@ -109,20 +109,10 @@ void validate_column_names(std::vector<std::string> const& column_names, size_t 
 // result is safe to free by any stream (including the RMM default) with no
 // external rebinding. Streams are recycled between calls, so this also avoids
 // per-call stream create/destroy churn.
-//
-// The free lists are keyed by device. A CUDA stream belongs to the device that
-// was current when it was created, and driving work on a stream from another
-// device is invalid — kernel launches fail with "invalid resource handle" and
-// the async copies/codec calls around them can fault the context with
-// cudaErrorIllegalAddress. In the affected Sirius path, multi-GPU pin_table
-// compression uses a caller-owned pool; this cache is exercised by the
-// subsequent per-device threaded decode. Without the device key, one device's
-// completed decode can recycle its streams into the next device's decode.
+// CUDA streams are device-bound, so recycled streams are keyed by device.
 class stream_cache {
  public:
-  // Hand out n valid streams belonging to `device`, reusing ones recycled from
-  // that device and creating the rest. The caller must have `device` current:
-  // cudaStreamCreateWithFlags binds the new streams to the current device.
+  // The caller must have `device` current when new streams are created.
   std::vector<cudaStream_t> checkout(int device, size_t n)
   {
     std::vector<cudaStream_t> out;
@@ -141,10 +131,7 @@ class stream_cache {
     return out;
   }
 
-  // Return `device`'s streams for reuse. They are kept alive (never destroyed):
-  // buffers of previously-returned results may still reference them for their
-  // async free. `device` must be the one they were checked out with, so they go
-  // back to the free list of the device they actually belong to.
+  // Return streams to the same device list they were checked out from.
   void check_in(int device, std::vector<cudaStream_t>& streams)
   {
     std::lock_guard<std::mutex> lock(mu_);
@@ -170,10 +157,7 @@ stream_cache& global_stream_cache()
 // its eventual async free even after this pool is gone. Concurrent leases get
 // disjoint streams (checkout is mutex-guarded and pops distinct handles), so each
 // call's sync_all only touches its own streams.
-//
-// Public internal-parallel calls retain the caller's current device for the
-// synchronous lease lifetime, and run_column_workers binds each worker thread
-// to that device. Capture it once so checkout and return use the same free list.
+// Capture the current device once for both checkout and check-in.
 struct leased_pool {
   stream_pool pool;
   int device = 0;

--- a/src/compression/simpatico_codegen/tests/test_multi_gpu_stream_affinity.cpp
+++ b/src/compression/simpatico_codegen/tests/test_multi_gpu_stream_affinity.cpp
@@ -1,15 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Regression for device affinity in the process-lifetime stream cache used by
-// the `int column_threads` decode overload.
-//
-// Compression deliberately uses the serial-stream overload so it cannot seed
-// or consume the cache under test. The first decode on device 0 fills the old
-// process-wide free list with device-0 streams; the next decode on device 1
-// would then receive those foreign streams and fail. Returning to device 0
-// checks that both device-local cache lists remain usable.
-//
-// Self-skips successfully when fewer than two GPUs are visible.
+// Serial compression keeps the cache untouched; threaded decodes on devices
+// 0 -> 1 -> 0 verify that cached streams remain device-local. Self-skips when
+// fewer than two GPUs are visible.
 
 #include "api/simpatico_codegen.hpp"
 #include "test_utils.hpp"
@@ -49,16 +42,12 @@ void decode_on_current_device(int device)
 {
   auto const label = "device " + std::to_string(device);
 
-  // RMM owns this resource in its per-device map for the process lifetime.
-  // Every device allocation below is destroyed before the enclosing device
-  // guard, and this reference is never used after the current device changes.
   auto const mr = rmm::mr::get_current_device_resource_ref();
 
   rmm::cuda_stream serial_stream{rmm::cuda_stream::flags::non_blocking};
   auto input = make_int32_table(kNumColumns, kNumRows, 13 + device);
 
-  // Keep compression off the internal stream cache so this test isolates the
-  // cache-bearing threaded decode overload.
+  // Keep compression off the internal stream cache.
   auto compressed =
     simpatico::compress_with_plan(input->view(), kPlanDsl, serial_stream.view(), mr);
   serial_stream.synchronize();
@@ -77,8 +66,7 @@ void decode_on_current_device(int device)
            (label + ": column " + std::to_string(column) + " byte mismatch").c_str());
   }
 
-  // Surface any asynchronous fault left on this device by a foreign-stream
-  // launch even if an earlier API call did not report it synchronously.
+  // Surface asynchronous device faults.
   if (auto const status = cudaDeviceSynchronize(); status != cudaSuccess) {
     throw std::runtime_error(label +
                              ": cudaDeviceSynchronize failed: " + cudaGetErrorString(status));

--- a/src/compression/simpatico_codegen/tests/test_multi_gpu_stream_affinity.cpp
+++ b/src/compression/simpatico_codegen/tests/test_multi_gpu_stream_affinity.cpp
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression for device affinity in the process-lifetime stream cache used by
+// the `int column_threads` decode overload.
+//
+// Compression deliberately uses the serial-stream overload so it cannot seed
+// or consume the cache under test. The first decode on device 0 fills the old
+// process-wide free list with device-0 streams; the next decode on device 1
+// would then receive those foreign streams and fail. Returning to device 0
+// checks that both device-local cache lists remain usable.
+//
+// Self-skips successfully when fewer than two GPUs are visible.
+
+#include "api/simpatico_codegen.hpp"
+#include "test_utils.hpp"
+
+#include <cudf/table/table.hpp>
+
+#include <rmm/cuda_device.hpp>
+#include <rmm/cuda_stream.hpp>
+#include <rmm/mr/per_device_resource.hpp>
+
+#include <cuda_runtime.h>
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+constexpr int kColumnThreads = 4;
+constexpr int kNumColumns    = 4;
+constexpr int kNumRows       = 65536;
+
+char const* const kPlanDsl =
+  "input -> delta -> differences\n"
+  "delta.differences -> bitpack\n"
+  "---\n"
+  "input -> delta -> differences\n"
+  "delta.differences -> bitpack\n"
+  "---\n"
+  "input -> delta -> differences\n"
+  "delta.differences -> bitpack\n"
+  "---\n"
+  "input -> delta -> differences\n"
+  "delta.differences -> bitpack\n";
+
+void decode_on_current_device(int device)
+{
+  auto const label = "device " + std::to_string(device);
+
+  // RMM owns this resource in its per-device map for the process lifetime.
+  // Every device allocation below is destroyed before the enclosing device
+  // guard, and this reference is never used after the current device changes.
+  auto const mr = rmm::mr::get_current_device_resource_ref();
+
+  rmm::cuda_stream serial_stream{rmm::cuda_stream::flags::non_blocking};
+  auto input = make_int32_table(kNumColumns, kNumRows, 13 + device);
+
+  // Keep compression off the internal stream cache so this test isolates the
+  // cache-bearing threaded decode overload.
+  auto compressed =
+    simpatico::compress_with_plan(input->view(), kPlanDsl, serial_stream.view(), mr);
+  serial_stream.synchronize();
+
+  expect(compressed.num_columns() == static_cast<std::size_t>(kNumColumns),
+         (label + ": compressed column count").c_str());
+  expect(compressed.num_rows() == kNumRows, (label + ": compressed row count").c_str());
+
+  auto decoded = simpatico::decompress(compressed, kColumnThreads, mr);
+  expect(decoded != nullptr, (label + ": decode returned null").c_str());
+  expect(decoded->num_columns() == kNumColumns, (label + ": decoded column count").c_str());
+  expect(decoded->num_rows() == kNumRows, (label + ": decoded row count").c_str());
+
+  for (int column = 0; column < kNumColumns; ++column) {
+    expect(columns_equal(input->view().column(column), decoded->view().column(column)),
+           (label + ": column " + std::to_string(column) + " byte mismatch").c_str());
+  }
+
+  // Surface any asynchronous fault left on this device by a foreign-stream
+  // launch even if an earlier API call did not report it synchronously.
+  if (auto const status = cudaDeviceSynchronize(); status != cudaSuccess) {
+    throw std::runtime_error(label +
+                             ": cudaDeviceSynchronize failed: " + cudaGetErrorString(status));
+  }
+}
+
+void decode_on_device(int device)
+{
+  rmm::cuda_set_device_raii const device_guard{rmm::cuda_device_id{device}};
+  decode_on_current_device(device);
+}
+
+}  // namespace
+
+int main()
+{
+  int device_count       = 0;
+  auto const count_error = cudaGetDeviceCount(&device_count);
+  if (count_error != cudaSuccess) {
+    std::fprintf(stderr,
+                 "test_multi_gpu_stream_affinity: cudaGetDeviceCount failed: %s\n",
+                 cudaGetErrorString(count_error));
+    return 1;
+  }
+  if (device_count < 2) {
+    std::printf("test_multi_gpu_stream_affinity: SKIP (needs >= 2 GPUs, found %d)\n", device_count);
+    return 0;
+  }
+
+  try {
+    decode_on_device(0);
+    decode_on_device(1);
+    decode_on_device(0);
+    std::printf("test_multi_gpu_stream_affinity: PASS\n");
+    return 0;
+  } catch (std::exception const& error) {
+    std::fprintf(stderr, "test_multi_gpu_stream_affinity: FAIL: %s\n", error.what());
+    return 1;
+  }
+}


### PR DESCRIPTION
NOTE: this is admittedly a temporary fix, until Simpatico uses the Sirius stream pool.
Fixes #1330 

## What changed

- key Simpatico's process-lifetime internal stream-cache free lists by CUDA device
- capture the lease device once and use it consistently for checkout and return
- add a focused multi-GPU regression that uses serial compression and threaded decode in device order `0 -> 1 -> 0`
- register the regression as a standalone target and CTest

## Root cause

The `int column_threads` overloads leased worker streams from one process-wide free list. CUDA streams are device-bound, so after a threaded decode on one GPU, a later decode on another GPU could receive foreign stream handles. Kernel launches then fail with `invalid resource handle`, and surrounding asynchronous CUDA work can surface `cudaErrorIllegalAddress`.

`pin_table` compression itself uses a caller-owned stream pool; the affected cache is exercised by the subsequent per-device threaded decode path.

## Impact

Multi-GPU scans of compressed pinned tables keep internal decode streams on their owning CUDA device, preventing the observed GPU fallback and poisoned-context hang on the following iteration.