### PR TITLE
Reject unsupported expressions during GPU plan construction

### DIFF
--- a/src/expression/from_duckdb.cpp
+++ b/src/expression/from_duckdb.cpp
@@ -271,7 +271,7 @@ std::unique_ptr<node> from_duckdb(duckdb::Expression const& expr)
     case duckdb::ExpressionClass::BOUND_REF:
       return translate_reference(expr.Cast<duckdb::BoundReferenceExpression>());
     default:
-      throw duckdb::InternalException("[sirius::ast::from_duckdb] Unknown ExpressionClass: {}",
+      throw duckdb::InternalException("[sirius::ast::from_duckdb] Unknown ExpressionClass: %d",
                                       expr.GetExpressionClass());
   }
 }

--- a/src/expression/join_condition.cpp
+++ b/src/expression/join_condition.cpp
@@ -20,6 +20,7 @@
 
 // duckdb
 #include <duckdb/common/enums/expression_type.hpp>
+#include <duckdb/common/exception.hpp>
 #include <duckdb/planner/joinside.hpp>
 
 // standard library
@@ -73,9 +74,24 @@ namespace {
 // conditions vector is consumed at the call boundary).
 join_condition wrap_one(duckdb::JoinCondition& c)
 {
+  // A side from_duckdb cannot represent yields a null node, which the hash-join
+  // constructor later dereferences through ast::to_duckdb. Refuse the plan here
+  // so the query falls back to DuckDB's CPU execution instead.
+  auto left  = sirius::ast::from_duckdb(*c.left);
+  auto right = sirius::ast::from_duckdb(*c.right);
+  if (left == nullptr) {
+    throw duckdb::NotImplementedException(
+      "Unsupported expression on the left side of a join condition (falling back to CPU): " +
+      c.left->ToString());
+  }
+  if (right == nullptr) {
+    throw duckdb::NotImplementedException(
+      "Unsupported expression on the right side of a join condition (falling back to CPU): " +
+      c.right->ToString());
+  }
   return join_condition{
-    sirius::ast::from_duckdb(*c.left),
-    sirius::ast::from_duckdb(*c.right),
+    std::move(left),
+    std::move(right),
     from_duckdb(c.comparison),
   };
 }

--- a/src/expression/join_condition.cpp
+++ b/src/expression/join_condition.cpp
@@ -74,9 +74,7 @@ namespace {
 // conditions vector is consumed at the call boundary).
 join_condition wrap_one(duckdb::JoinCondition& c)
 {
-  // A side from_duckdb cannot represent yields a null node, which the hash-join
-  // constructor later dereferences through ast::to_duckdb. Refuse the plan here
-  // so the query falls back to DuckDB's CPU execution instead.
+  // Both join-condition expressions must be translatable before the hash join stores them.
   auto left  = sirius::ast::from_duckdb(*c.left);
   auto right = sirius::ast::from_duckdb(*c.right);
   if (left == nullptr) {

--- a/src/include/util/duckdb_error_message.hpp
+++ b/src/include/util/duckdb_error_message.hpp
@@ -23,34 +23,16 @@
 
 namespace sirius {
 
-/// \brief The human-readable message of \p e, without DuckDB's serialized envelope.
+/// \brief Returns DuckDB's message without its serialized exception envelope.
 ///
-/// `std::exception::what()` on a DuckDB exception carrying extra info is not
-/// prose — it is a JSON object (`{"exception_type":…,"exception_message":…}`).
-/// Concatenating it into a user-facing error leaks an internal wire format.
-/// `duckdb::ErrorData` parses that envelope and exposes the message alone.
-///
-/// The extraction can fail two ways, and both have to fall back to the raw text.
-///
-/// It can throw: a message that merely *starts* with `{` without being valid JSON
-/// makes the parser throw, and the construction can also throw on allocation.
-///
-/// And it can succeed while yielding nothing. The parser treats any `{`-leading
-/// valid JSON as an envelope but fills the message **only** from an
-/// `exception_message` key; every other key goes to extra info. So a legal JSON
-/// object that simply is not DuckDB's envelope — `{"error":"missing"}` — extracts
-/// to the empty string, and returning that would discard the original error.
-///
-/// Both call sites need this where throwing is not an option: inside a DuckDB
-/// optimizer extension hook, which has no error path, and inside catch handlers
-/// whose exception must not be replaced by a secondary one. A worse message is
-/// always preferable to losing the original error.
+/// Falls back to `what()` if parsing fails or yields an empty message. This
+/// function is noexcept because it is used from catch paths and optimizer hooks.
 [[nodiscard]] inline std::string sanitized_message(std::exception const& e) noexcept
 {
   try {
     auto message = duckdb::ErrorData(e).RawMessage();
     if (!message.empty()) { return message; }
-  } catch (...) {  // NOLINT(bugprone-empty-catch) — fall through to the raw text
+  } catch (...) {  // NOLINT(bugprone-empty-catch): fall back to e.what()
   }
   try {
     return e.what();

--- a/src/include/util/duckdb_error_message.hpp
+++ b/src/include/util/duckdb_error_message.hpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <duckdb/common/error_data.hpp>
+
+#include <exception>
+#include <string>
+
+namespace sirius {
+
+/// \brief The human-readable message of \p e, without DuckDB's serialized envelope.
+///
+/// `std::exception::what()` on a DuckDB exception carrying extra info is not
+/// prose — it is a JSON object (`{"exception_type":…,"exception_message":…}`).
+/// Concatenating it into a user-facing error leaks an internal wire format.
+/// `duckdb::ErrorData` parses that envelope and exposes the message alone.
+///
+/// The parse can fail: a message that merely *starts* with `{` and is not valid
+/// JSON makes the parser throw, and the construction can also throw on
+/// allocation. Both call sites need this in places where throwing is not an
+/// option — inside a DuckDB optimizer extension hook, which has no error path,
+/// and inside catch handlers whose exception must not be replaced by a
+/// secondary one. So the conversion is treated as fallible by construction:
+/// on any failure the original `what()` text is returned unchanged. A worse
+/// message is always preferable to losing the original error.
+[[nodiscard]] inline std::string sanitized_message(std::exception const& e) noexcept
+{
+  try {
+    return duckdb::ErrorData(e).RawMessage();
+  } catch (...) {
+    try {
+      return e.what();
+    } catch (...) {
+      return "<unavailable>";
+    }
+  }
+}
+
+}  // namespace sirius

--- a/src/include/util/duckdb_error_message.hpp
+++ b/src/include/util/duckdb_error_message.hpp
@@ -30,24 +30,32 @@ namespace sirius {
 /// Concatenating it into a user-facing error leaks an internal wire format.
 /// `duckdb::ErrorData` parses that envelope and exposes the message alone.
 ///
-/// The parse can fail: a message that merely *starts* with `{` and is not valid
-/// JSON makes the parser throw, and the construction can also throw on
-/// allocation. Both call sites need this in places where throwing is not an
-/// option — inside a DuckDB optimizer extension hook, which has no error path,
-/// and inside catch handlers whose exception must not be replaced by a
-/// secondary one. So the conversion is treated as fallible by construction:
-/// on any failure the original `what()` text is returned unchanged. A worse
-/// message is always preferable to losing the original error.
+/// The extraction can fail two ways, and both have to fall back to the raw text.
+///
+/// It can throw: a message that merely *starts* with `{` without being valid JSON
+/// makes the parser throw, and the construction can also throw on allocation.
+///
+/// And it can succeed while yielding nothing. The parser treats any `{`-leading
+/// valid JSON as an envelope but fills the message **only** from an
+/// `exception_message` key; every other key goes to extra info. So a legal JSON
+/// object that simply is not DuckDB's envelope — `{"error":"missing"}` — extracts
+/// to the empty string, and returning that would discard the original error.
+///
+/// Both call sites need this where throwing is not an option: inside a DuckDB
+/// optimizer extension hook, which has no error path, and inside catch handlers
+/// whose exception must not be replaced by a secondary one. A worse message is
+/// always preferable to losing the original error.
 [[nodiscard]] inline std::string sanitized_message(std::exception const& e) noexcept
 {
   try {
-    return duckdb::ErrorData(e).RawMessage();
+    auto message = duckdb::ErrorData(e).RawMessage();
+    if (!message.empty()) { return message; }
+  } catch (...) {  // NOLINT(bugprone-empty-catch) — fall through to the raw text
+  }
+  try {
+    return e.what();
   } catch (...) {
-    try {
-      return e.what();
-    } catch (...) {
-      return "<unavailable>";
-    }
+    return "<unavailable>";
   }
 }
 

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -377,13 +377,7 @@ parquet_gpu_ingestible::parquet_gpu_ingestible(std::unique_ptr<parquet_ingestibl
                                                       _plan->batch_position_by_column_id,
                                                       _plan->partition_primary_indices);
     if (duckdb_expression) {
-      // Prove the predicate translates before any IO is scheduled. The four
-      // sites below re-translate per task and dereference the result; a null
-      // there would either crash or, on the paths that tolerate it, drop the
-      // filter and emit rows it should have removed. Failing here converts both
-      // into one clear error at construction time. The planner refuses such
-      // plans first (sirius_plan_get.cpp), so reaching this throw indicates a
-      // route that bypassed that gate.
+      // Validate before scan tasks retranslate and dereference the predicate.
       if (sirius::ast::from_duckdb(*duckdb_expression) == nullptr) {
         throw duckdb::InvalidInputException(
           "parquet scan: cannot evaluate pushed-down predicate on GPU: %s",
@@ -549,7 +543,6 @@ std::unique_ptr<scan_info> parquet_gpu_ingestible::build_file_scan_info(
     };
     gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
     auto sirius_filter_ast = sirius::ast::from_duckdb(*_duckdb_filter_expression);
-    // Validated at construction; assert the invariant rather than dereference blind.
     D_ASSERT(sirius_filter_ast != nullptr);
     ast_expression = translator.translate_expression_with_names(*sirius_filter_ast, name_resolver);
     if (ast_expression) { opts.set_filter(ast_expression->back()); }
@@ -788,7 +781,6 @@ filtered_table parquet_gpu_ingestible::materialize_metadata_to_table(
 
   if (_duckdb_filter_expression && !split.disable_filter_pushdown && !all_slices_pruned) {
     auto sirius_filter_ast = sirius::ast::from_duckdb(*_duckdb_filter_expression);
-    // Validated at construction; assert the invariant rather than dereference blind.
     D_ASSERT(sirius_filter_ast != nullptr);
     auto name_resolver = [plan = split.plan](duckdb::idx_t ref_index) -> std::string {
       return plan->batch_column_name(ref_index);

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -376,7 +376,21 @@ parquet_gpu_ingestible::parquet_gpu_ingestible(std::unique_ptr<parquet_ingestibl
                                                       bind.returned_types,
                                                       _plan->batch_position_by_column_id,
                                                       _plan->partition_primary_indices);
-    if (duckdb_expression) { _duckdb_filter_expression = std::move(duckdb_expression); }
+    if (duckdb_expression) {
+      // Prove the predicate translates before any IO is scheduled. The four
+      // sites below re-translate per task and dereference the result; a null
+      // there would either crash or, on the paths that tolerate it, drop the
+      // filter and emit rows it should have removed. Failing here converts both
+      // into one clear error at construction time. The planner refuses such
+      // plans first (sirius_plan_get.cpp), so reaching this throw indicates a
+      // route that bypassed that gate.
+      if (sirius::ast::from_duckdb(*duckdb_expression) == nullptr) {
+        throw duckdb::InvalidInputException(
+          "parquet scan: cannot evaluate pushed-down predicate on GPU: %s",
+          duckdb_expression->ToString());
+      }
+      _duckdb_filter_expression = std::move(duckdb_expression);
+    }
   }
 
   // Shared reader options — column projection only. set_filter is never applied
@@ -535,6 +549,8 @@ std::unique_ptr<scan_info> parquet_gpu_ingestible::build_file_scan_info(
     };
     gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
     auto sirius_filter_ast = sirius::ast::from_duckdb(*_duckdb_filter_expression);
+    // Validated at construction; assert the invariant rather than dereference blind.
+    D_ASSERT(sirius_filter_ast != nullptr);
     ast_expression = translator.translate_expression_with_names(*sirius_filter_ast, name_resolver);
     if (ast_expression) { opts.set_filter(ast_expression->back()); }
   }
@@ -772,7 +788,9 @@ filtered_table parquet_gpu_ingestible::materialize_metadata_to_table(
 
   if (_duckdb_filter_expression && !split.disable_filter_pushdown && !all_slices_pruned) {
     auto sirius_filter_ast = sirius::ast::from_duckdb(*_duckdb_filter_expression);
-    auto name_resolver     = [plan = split.plan](duckdb::idx_t ref_index) -> std::string {
+    // Validated at construction; assert the invariant rather than dereference blind.
+    D_ASSERT(sirius_filter_ast != nullptr);
+    auto name_resolver = [plan = split.plan](duckdb::idx_t ref_index) -> std::string {
       return plan->batch_column_name(ref_index);
     };
     gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -161,8 +161,6 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
   if (table_filters) {
     auto duckdb_filter = convert_table_filters_to_expression(
       *table_filters, column_ids, returned_types, batch_column_map);
-    // No converted filter means the predicates were handled elsewhere. A converted
-    // filter that cannot be translated must fail instead of passing rows through.
     if (duckdb_filter) {
       local_filter_expr = sirius::ast::from_duckdb(*duckdb_filter);
       if (local_filter_expr == nullptr) {

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -161,7 +161,24 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
   if (table_filters) {
     auto duckdb_filter = convert_table_filters_to_expression(
       *table_filters, column_ids, returned_types, batch_column_map);
-    if (duckdb_filter) { local_filter_expr = sirius::ast::from_duckdb(*duckdb_filter); }
+    // A null converter result and a null translation mean different things and
+    // must not be collapsed. The converter returns nothing only when every
+    // predicate was already discharged — an advisory OPTIONAL_FILTER, an
+    // IS_NOT_NULL applied elsewhere, or a hive partition column pruned at the
+    // file-list level — in which case passing the batch through is correct. A
+    // translation that fails, on the other hand, means the filter cannot be
+    // applied at all; passing the batch through would silently emit rows the
+    // predicate should have removed. Fail closed instead. The planner refuses
+    // such plans before they get here (sirius_plan_get.cpp), so reaching this
+    // throw indicates a route that bypassed that gate.
+    if (duckdb_filter) {
+      local_filter_expr = sirius::ast::from_duckdb(*duckdb_filter);
+      if (local_filter_expr == nullptr) {
+        throw duckdb::InvalidInputException(
+          "TABLE_SCAN filter: cannot evaluate pushed-down predicate on GPU: %s",
+          duckdb_filter->ToString());
+      }
+    }
   }
 
   if (local_filter_expr != nullptr) {

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -161,16 +161,8 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
   if (table_filters) {
     auto duckdb_filter = convert_table_filters_to_expression(
       *table_filters, column_ids, returned_types, batch_column_map);
-    // A null converter result and a null translation mean different things and
-    // must not be collapsed. The converter returns nothing only when every
-    // predicate was already discharged — an advisory OPTIONAL_FILTER, an
-    // IS_NOT_NULL applied elsewhere, or a hive partition column pruned at the
-    // file-list level — in which case passing the batch through is correct. A
-    // translation that fails, on the other hand, means the filter cannot be
-    // applied at all; passing the batch through would silently emit rows the
-    // predicate should have removed. Fail closed instead. The planner refuses
-    // such plans before they get here (sirius_plan_get.cpp), so reaching this
-    // throw indicates a route that bypassed that gate.
+    // No converted filter means the predicates were handled elsewhere. A converted
+    // filter that cannot be translated must fail instead of passing rows through.
     if (duckdb_filter) {
       local_filter_expr = sirius::ast::from_duckdb(*duckdb_filter);
       if (local_filter_expr == nullptr) {

--- a/src/planner/sirius_plan_aggregate.cpp
+++ b/src/planner/sirius_plan_aggregate.cpp
@@ -163,10 +163,7 @@ static bool can_use_partitioned_aggregate(duckdb::ClientContext& context,
         for (auto& partition_col : partition_columns) {
           // we only support bound reference here
           auto const* expr = projection.select_list[partition_col].get();
-          // A null slot means the projection carried an expression from_duckdb
-          // could not represent. The projection builder now refuses those, so
-          // this is defence in depth for a walk that descends into an already
-          // constructed child operator.
+          // A partition key must reference a translated projection expression.
           if (expr == nullptr) { return false; }
           if (!expr->holds<sirius::ast::reference>()) { return false; }
           new_columns.push_back(expr->get<sirius::ast::reference>().column_index);

--- a/src/planner/sirius_plan_aggregate.cpp
+++ b/src/planner/sirius_plan_aggregate.cpp
@@ -163,7 +163,6 @@ static bool can_use_partitioned_aggregate(duckdb::ClientContext& context,
         for (auto& partition_col : partition_columns) {
           // we only support bound reference here
           auto const* expr = projection.select_list[partition_col].get();
-          // A partition key must reference a translated projection expression.
           if (expr == nullptr) { return false; }
           if (!expr->holds<sirius::ast::reference>()) { return false; }
           new_columns.push_back(expr->get<sirius::ast::reference>().column_index);

--- a/src/planner/sirius_plan_aggregate.cpp
+++ b/src/planner/sirius_plan_aggregate.cpp
@@ -163,6 +163,11 @@ static bool can_use_partitioned_aggregate(duckdb::ClientContext& context,
         for (auto& partition_col : partition_columns) {
           // we only support bound reference here
           auto const* expr = projection.select_list[partition_col].get();
+          // A null slot means the projection carried an expression from_duckdb
+          // could not represent. The projection builder now refuses those, so
+          // this is defence in depth for a walk that descends into an already
+          // constructed child operator.
+          if (expr == nullptr) { return false; }
           if (!expr->holds<sirius::ast::reference>()) { return false; }
           new_columns.push_back(expr->get<sirius::ast::reference>().column_index);
         }

--- a/src/planner/sirius_plan_filter.cpp
+++ b/src/planner/sirius_plan_filter.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "duckdb/common/exception.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
@@ -91,11 +92,23 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalFilter& op)
       }
     }
 
-    auto filter =
-      duckdb::make_uniq<sirius::op::sirius_physical_filter>(std::move(filter_types),
-                                                            sirius::ast::from_duckdb(*combined),
-                                                            op.estimated_cardinality,
-                                                            std::move(output_indices));
+    // from_duckdb returns null for a predicate it cannot represent, and the
+    // operator dereferences it without checking — undefined behaviour, whatever it
+    // happens to look like on a given build. Refuse the plan so a null can never
+    // reach the operator. A cross-side non-equi predicate is the shape that gets
+    // here: DuckDB can neither make it a join condition nor push it into a scan.
+    //
+    // The guard belongs on this call, not on the translate_expressions below — that
+    // one is fed only by locally synthesized reference expressions.
+    auto predicate = sirius::ast::from_duckdb(*combined);
+    if (predicate == nullptr) {
+      throw duckdb::NotImplementedException("Unsupported filter predicate (falling back to CPU): " +
+                                            combined->ToString());
+    }
+    auto filter = duckdb::make_uniq<sirius::op::sirius_physical_filter>(std::move(filter_types),
+                                                                        std::move(predicate),
+                                                                        op.estimated_cardinality,
+                                                                        std::move(output_indices));
     filter->children.push_back(std::move(plan));
     plan = std::move(filter);
   } else if (op.HasProjectionMap()) {

--- a/src/planner/sirius_plan_filter.cpp
+++ b/src/planner/sirius_plan_filter.cpp
@@ -92,14 +92,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalFilter& op)
       }
     }
 
-    // from_duckdb returns null for a predicate it cannot represent, and the
-    // operator dereferences it without checking — undefined behaviour, whatever it
-    // happens to look like on a given build. Refuse the plan so a null can never
-    // reach the operator. A cross-side non-equi predicate is the shape that gets
-    // here: DuckDB can neither make it a join condition nor push it into a scan.
-    //
-    // The guard belongs on this call, not on the translate_expressions below — that
-    // one is fed only by locally synthesized reference expressions.
+    // Reject unsupported predicates before the physical filter stores them.
     auto predicate = sirius::ast::from_duckdb(*combined);
     if (predicate == nullptr) {
       throw duckdb::NotImplementedException("Unsupported filter predicate (falling back to CPU): " +

--- a/src/planner/sirius_plan_filter.cpp
+++ b/src/planner/sirius_plan_filter.cpp
@@ -92,7 +92,6 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalFilter& op)
       }
     }
 
-    // Reject unsupported predicates before the physical filter stores them.
     auto predicate = sirius::ast::from_duckdb(*combined);
     if (predicate == nullptr) {
       throw duckdb::NotImplementedException("Unsupported filter predicate (falling back to CPU): " +

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -62,20 +62,26 @@ duckdb::vector<std::unique_ptr<sirius::ast::node>> translate_expressions(
   return out;
 }
 
-// Pushed-down filters bypass LogicalFilter. Match the runtime converter's skip
-// set, then validate the remaining predicate at plan time. The runtime translates
-// again because it resolves references against batch-relative positions.
+// An OPTIONAL_FILTER is advisory and an IS_NOT_NULL is applied by the scan itself, so
+// neither contributes to the predicate convert_table_filters_to_expression builds
+// (scan_utils.cpp). This must stay in step with that skip set: probing a filter the
+// scan discharges would reject plans the scan handles correctly.
+[[nodiscard]] bool is_discharged_without_translation(duckdb::TableFilterType filter_type)
+{
+  return filter_type == duckdb::TableFilterType::OPTIONAL_FILTER ||
+         filter_type == duckdb::TableFilterType::IS_NOT_NULL;
+}
+
+// Pushed-down filters bypass LogicalFilter, so validate the remaining predicate at plan
+// time. The runtime translates again because it resolves references against
+// batch-relative positions.
 void reject_untranslatable_table_filter(duckdb::TableFilter const& filter,
                                         duckdb::LogicalType const& column_type,
                                         std::string const& column_name)
 {
-  if (filter.filter_type == duckdb::TableFilterType::OPTIONAL_FILTER ||
-      filter.filter_type == duckdb::TableFilterType::IS_NOT_NULL) {
-    return;
-  }
+  if (is_discharged_without_translation(filter.filter_type)) { return; }
   auto column_ref = duckdb::make_uniq<duckdb::BoundReferenceExpression>(column_type, 0);
   auto expression = filter.ToExpression(*column_ref);
-  if (!expression) { return; }
   if (sirius::ast::from_duckdb(*expression) == nullptr) {
     throw duckdb::NotImplementedException("Unsupported filter predicate on column '" + column_name +
                                           "' (falling back to CPU): " + expression->ToString());

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -131,7 +131,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   static const std::unordered_set<std::string> kSupportedScanFunctions = {
     "seq_scan", "parquet_scan", "read_parquet", "sirius_read_parquet"};
   if (kSupportedScanFunctions.find(op.function.name) == kSupportedScanFunctions.end()) {
-    throw duckdb::NotImplementedException("Table function '{}' is not supported in Sirius",
+    throw duckdb::NotImplementedException("Table function '%s' is not supported in Sirius",
                                           op.function.name);
   }
 

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -62,24 +62,9 @@ duckdb::vector<std::unique_ptr<sirius::ast::node>> translate_expressions(
   return out;
 }
 
-// A predicate the optimizer pushed into LogicalGet::table_filters never reaches
-// the LogicalFilter builder, so it also escapes that builder's translation
-// guard. If Sirius cannot translate its expression form, the scan operators see
-// a null AST: the parquet path dereferences it, and the DuckDB-native path reads
-// it as "no filter" and passes every row through. Refuse the plan here so the
-// query falls back to DuckDB's CPU execution instead.
-//
-// The skip set mirrors convert_table_filters_to_expression (scan_utils.cpp),
-// which is what the scan operators actually build from: OPTIONAL_FILTER is
-// advisory, and IS_NOT_NULL is discharged before the expression is built.
-// Probing anything it skips would reject plans the runtime handles correctly.
-//
-// The probe translates a second time rather than handing its result to the
-// runtime. That is deliberate: the runtime resolves references to batch-relative
-// positions that do not exist at plan time, so the two translations have
-// different inputs. Both are side-effect free — TableFilter::ToExpression
-// returns a fresh expression and from_duckdb takes its argument by const
-// reference.
+// Pushed-down filters bypass LogicalFilter. Match the runtime converter's skip
+// set, then validate the remaining predicate at plan time. The runtime translates
+// again because it resolves references against batch-relative positions.
 void reject_untranslatable_table_filter(duckdb::TableFilter const& filter,
                                         duckdb::LogicalType const& column_type,
                                         std::string const& column_name)

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -62,6 +62,41 @@ duckdb::vector<std::unique_ptr<sirius::ast::node>> translate_expressions(
   return out;
 }
 
+// A predicate the optimizer pushed into LogicalGet::table_filters never reaches
+// the LogicalFilter builder, so it also escapes that builder's translation
+// guard. If Sirius cannot translate its expression form, the scan operators see
+// a null AST: the parquet path dereferences it, and the DuckDB-native path reads
+// it as "no filter" and passes every row through. Refuse the plan here so the
+// query falls back to DuckDB's CPU execution instead.
+//
+// The skip set mirrors convert_table_filters_to_expression (scan_utils.cpp),
+// which is what the scan operators actually build from: OPTIONAL_FILTER is
+// advisory, and IS_NOT_NULL is discharged before the expression is built.
+// Probing anything it skips would reject plans the runtime handles correctly.
+//
+// The probe translates a second time rather than handing its result to the
+// runtime. That is deliberate: the runtime resolves references to batch-relative
+// positions that do not exist at plan time, so the two translations have
+// different inputs. Both are side-effect free — TableFilter::ToExpression
+// returns a fresh expression and from_duckdb takes its argument by const
+// reference.
+void reject_untranslatable_table_filter(duckdb::TableFilter const& filter,
+                                        duckdb::LogicalType const& column_type,
+                                        std::string const& column_name)
+{
+  if (filter.filter_type == duckdb::TableFilterType::OPTIONAL_FILTER ||
+      filter.filter_type == duckdb::TableFilterType::IS_NOT_NULL) {
+    return;
+  }
+  auto column_ref = duckdb::make_uniq<duckdb::BoundReferenceExpression>(column_type, 0);
+  auto expression = filter.ToExpression(*column_ref);
+  if (!expression) { return; }
+  if (sirius::ast::from_duckdb(*expression) == nullptr) {
+    throw duckdb::NotImplementedException("Unsupported filter predicate on column '" + column_name +
+                                          "' (falling back to CPU): " + expression->ToString());
+  }
+}
+
 }  // namespace
 
 duckdb::unique_ptr<duckdb::TableFilterSet> create_table_filter_set(
@@ -327,6 +362,8 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
         auto const column_name =
           column_id < op.names.size() ? op.names[column_id] : std::to_string(column_id);
         reject_nested_column_type(op.returned_types[column_id], column_name, "a filter predicate");
+        reject_untranslatable_table_filter(
+          *entry.second, op.returned_types[column_id], column_name);
       }
     }
   }

--- a/src/planner/sirius_plan_order.cpp
+++ b/src/planner/sirius_plan_order.cpp
@@ -26,10 +26,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalOrder& op)
 {
   D_ASSERT(op.children.size() == 1);
 
-  // Only the sort KEYS are rejected — a nested column that is merely carried
-  // through the operator is the supported read-and-project shape. Sorting on
-  // one reaches cudf::sorted_order and fails at runtime for STRUCT, LIST and
-  // MAP alike, so refuse it at plan time and fall back to CPU instead.
+  // Nested columns may pass through this operator, but cannot be sort keys.
   for (auto const& order : op.orders) {
     reject_nested_column_operation(*order.expression, "ORDER BY");
   }

--- a/src/planner/sirius_plan_order.cpp
+++ b/src/planner/sirius_plan_order.cpp
@@ -26,6 +26,14 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalOrder& op)
 {
   D_ASSERT(op.children.size() == 1);
 
+  // Only the sort KEYS are rejected — a nested column that is merely carried
+  // through the operator is the supported read-and-project shape. Sorting on
+  // one reaches cudf::sorted_order and fails at runtime for STRUCT, LIST and
+  // MAP alike, so refuse it at plan time and fall back to CPU instead.
+  for (auto const& order : op.orders) {
+    reject_nested_column_operation(*order.expression, "ORDER BY");
+  }
+
   auto plan = create_plan(*op.children[0]);
   if (!op.orders.empty()) {
     duckdb::vector<std::size_t> projection_map;

--- a/src/planner/sirius_plan_projection.cpp
+++ b/src/planner/sirius_plan_projection.cpp
@@ -28,23 +28,8 @@ namespace sirius::planner {
 
 namespace {
 
-// Translate a vector of DuckDB expressions into Sirius AST nodes at the planner
-// boundary. The source vector is drained; size and order are preserved, and a
-// non-null input expression never yields a null Sirius node: from_duckdb returns
-// null for a shape it cannot represent (an unmapped function, a struct/list
-// element access), and the projection operator dereferences its select list
-// unconditionally. Rather than build a GPU plan containing null nodes, throw so
-// the query falls back to DuckDB's CPU execution.
-//
-// The decision is a plan capability, not a data-dependent one: an untranslatable
-// expression makes the plan unsupported even when no batch would ever have
-// reached the projection — an empty source is the reachable case.
-//
-// It does not extend to shapes DuckDB collapses before the plan gets here.
-// `LIMIT 0` becomes a childless LogicalEmptyResult during filter pushdown, and a
-// predicate that statistics prove false takes the projection with it during
-// statistics propagation; both passes run before the optimizer extension hook.
-// Those plans carry no expression to reject and are supported on the GPU.
+// Translate at the planner boundary and reject unsupported expressions before
+// they enter a physical projection. The source vector is consumed in order.
 duckdb::vector<std::unique_ptr<sirius::ast::node>> translate_expressions(
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs)
 {

--- a/src/planner/sirius_plan_projection.cpp
+++ b/src/planner/sirius_plan_projection.cpp
@@ -29,16 +29,34 @@ namespace sirius::planner {
 namespace {
 
 // Translate a vector of DuckDB expressions into Sirius AST nodes at the planner
-// boundary. The source vector is drained; size and order are preserved, with a
-// null slot wherever from_duckdb declines an unsupported shape (a fallback
-// signal) — matching the prior bulk-translation null-skip semantics.
+// boundary. The source vector is drained; size and order are preserved, and a
+// non-null input expression never yields a null Sirius node: from_duckdb returns
+// null for a shape it cannot represent (an unmapped function, a struct/list
+// element access), and the projection operator dereferences its select list
+// unconditionally. Rather than build a GPU plan containing null nodes, throw so
+// the query falls back to DuckDB's CPU execution.
+//
+// The decision is a plan capability, not a data-dependent one: an untranslatable
+// expression makes the plan unsupported even when no batch would ever have
+// reached the projection — an empty source is the reachable case.
+//
+// It does not extend to shapes DuckDB collapses before the plan gets here.
+// `LIMIT 0` becomes a childless LogicalEmptyResult during filter pushdown, and a
+// predicate that statistics prove false takes the projection with it during
+// statistics propagation; both passes run before the optimizer extension hook.
+// Those plans carry no expression to reject and are supported on the GPU.
 duckdb::vector<std::unique_ptr<sirius::ast::node>> translate_expressions(
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs)
 {
   duckdb::vector<std::unique_ptr<sirius::ast::node>> out;
   out.reserve(exprs.size());
   for (auto& e : exprs) {
-    out.push_back(e ? sirius::ast::from_duckdb(*e) : nullptr);
+    auto translated = e ? sirius::ast::from_duckdb(*e) : nullptr;
+    if (e && translated == nullptr) {
+      throw duckdb::NotImplementedException(
+        "Unsupported expression in projection (falling back to CPU): " + e->ToString());
+    }
+    out.push_back(std::move(translated));
   }
   return out;
 }

--- a/src/planner/sirius_plan_top_n.cpp
+++ b/src/planner/sirius_plan_top_n.cpp
@@ -26,6 +26,12 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalTopN& op)
 {
   D_ASSERT(op.children.size() == 1);
 
+  // Same sort-key rule as LogicalOrder — LogicalTopN is what `ORDER BY … LIMIT n`
+  // becomes, so the message names what the user wrote.
+  for (auto const& order : op.orders) {
+    reject_nested_column_operation(*order.expression, "ORDER BY");
+  }
+
   auto plan = create_plan(*op.children[0]);
 
   auto top_n = duckdb::make_uniq<sirius::op::sirius_physical_top_n>(

--- a/src/planner/sirius_plan_top_n.cpp
+++ b/src/planner/sirius_plan_top_n.cpp
@@ -26,8 +26,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalTopN& op)
 {
   D_ASSERT(op.children.size() == 1);
 
-  // Same sort-key rule as LogicalOrder — LogicalTopN is what `ORDER BY … LIMIT n`
-  // becomes, so the message names what the user wrote.
+  // Apply the same sort-key restrictions as LogicalOrder.
   for (auto const& order : op.orders) {
     reject_nested_column_operation(*order.expression, "ORDER BY");
   }

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -38,6 +38,7 @@
 #include "telemetry/batch_telemetry.hpp"
 #include "transparent/physical_sirius_execution.hpp"
 #include "transparent/sirius_optimizer_extension.hpp"
+#include "util/duckdb_error_message.hpp"
 
 #include <cudf/utilities/pinned_memory.hpp>
 
@@ -1157,25 +1158,28 @@ RebindQueryInfo SiriusContext::OnFinalizePrepare(ClientContext& context,
       if (sirius::references_sirius_owned_s3_parquet(current_query_sql)) { throw; }
       if (!duckdb_fallback_enabled(context)) { throw; }
       record_transparent_fallback();
-      SIRIUS_LOG_INFO("Transparent execution fallback (runtime unavailable): {}", e.what());
+      SIRIUS_LOG_INFO("Transparent execution fallback (runtime unavailable): {}",
+                      sirius::sanitized_message(e));
       return RebindQueryInfo::DO_NOT_REBIND;
     } catch (NotImplementedException& e) {
       // No captured plan to inspect on the replan path; guard on the SQL text so
       // a direct read_parquet('s3://') that fails to re-plan does not CPU-fall-back.
-      throw_if_s3_no_cpu_fallback(false, current_query_sql, e.what());
+      throw_if_s3_no_cpu_fallback(false, current_query_sql, sirius::sanitized_message(e));
       if (!duckdb_fallback_enabled(context)) {
         rethrow_gpu_error_no_fallback(e, "GPU plan generation failed: ");
       }
       record_transparent_fallback();
-      SIRIUS_LOG_INFO("Transparent execution fallback (replan unsupported): {}", e.what());
+      SIRIUS_LOG_INFO("Transparent execution fallback (replan unsupported): {}",
+                      sirius::sanitized_message(e));
       return RebindQueryInfo::DO_NOT_REBIND;
     } catch (std::exception& e) {
-      throw_if_s3_no_cpu_fallback(false, current_query_sql, e.what());
+      throw_if_s3_no_cpu_fallback(false, current_query_sql, sirius::sanitized_message(e));
       if (!duckdb_fallback_enabled(context)) {
         rethrow_gpu_error_no_fallback(e, "GPU plan generation failed: ");
       }
       record_transparent_fallback();
-      SIRIUS_LOG_INFO("Transparent execution fallback (replan failed): {}", e.what());
+      SIRIUS_LOG_INFO("Transparent execution fallback (replan failed): {}",
+                      sirius::sanitized_message(e));
       return RebindQueryInfo::DO_NOT_REBIND;
     }
     if (!logical_plan) { return RebindQueryInfo::DO_NOT_REBIND; }
@@ -1261,22 +1265,24 @@ RebindQueryInfo SiriusContext::OnFinalizePrepare(ClientContext& context,
     if (plan_reads_s3) { throw; }
     if (!duckdb_fallback_enabled(context)) { throw; }
     record_transparent_fallback();
-    SIRIUS_LOG_INFO("Transparent execution fallback (runtime unavailable): {}", e.what());
+    SIRIUS_LOG_INFO("Transparent execution fallback (runtime unavailable): {}",
+                    sirius::sanitized_message(e));
     return RebindQueryInfo::DO_NOT_REBIND;
   } catch (NotImplementedException& e) {
-    throw_if_s3_no_cpu_fallback(plan_reads_s3, current_query_sql, e.what());
+    throw_if_s3_no_cpu_fallback(plan_reads_s3, current_query_sql, sirius::sanitized_message(e));
     if (!duckdb_fallback_enabled(context)) {
       rethrow_gpu_error_no_fallback(e, "GPU plan generation failed: ");
     }
     record_transparent_fallback();
-    SIRIUS_LOG_INFO("Transparent execution fallback (unsupported): {}", e.what());
+    SIRIUS_LOG_INFO("Transparent execution fallback (unsupported): {}",
+                    sirius::sanitized_message(e));
   } catch (std::exception& e) {
-    throw_if_s3_no_cpu_fallback(plan_reads_s3, current_query_sql, e.what());
+    throw_if_s3_no_cpu_fallback(plan_reads_s3, current_query_sql, sirius::sanitized_message(e));
     if (!duckdb_fallback_enabled(context)) {
       rethrow_gpu_error_no_fallback(e, "GPU plan generation failed: ");
     }
     record_transparent_fallback();
-    SIRIUS_LOG_INFO("Transparent execution fallback: {}", e.what());
+    SIRIUS_LOG_INFO("Transparent execution fallback: {}", sirius::sanitized_message(e));
   }
 
   return RebindQueryInfo::DO_NOT_REBIND;

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1662,7 +1662,7 @@ static void ApplyExpressionEvaluatorStrategy(const std::string& value)
   sirius::expression_evaluator_strategy parsed;
   if (!sirius::string_to_strategy(value, parsed)) {
     throw InvalidInputException(
-      "Invalid expression_evaluator_strategy '{}'. Valid values: materialize, ast_interpret, "
+      "Invalid expression_evaluator_strategy '%s'. Valid values: materialize, ast_interpret, "
       "ast_jit",
       value);
   }
@@ -1822,7 +1822,7 @@ static void SetMaxSortPartitionMemoryFraction(ClientContext& context,
   const double fraction = parameter.GetValue<double>();
   if (fraction < 0.0 || fraction > 1.0) {
     throw InvalidInputException(
-      "max_sort_partition_memory_fraction must be between 0.0 and 1.0, got {}", fraction);
+      "max_sort_partition_memory_fraction must be between 0.0 and 1.0, got %f", fraction);
   }
   params->max_sort_partition_memory_fraction = fraction;
   SIRIUS_LOG_DEBUG("Updated config MAX_SORT_PARTITION_MEMORY_FRACTION to {}",
@@ -1927,7 +1927,7 @@ static void SetMarkJoinBuildSwitchRatio(ClientContext& context, SetScope scope, 
   auto slot          = lock_operator_params_slot(context);
   const double ratio = parameter.GetValue<double>();
   if (ratio < 0.0) {
-    throw InvalidInputException("mark_join_build_switch_ratio must be >= 0.0, got {}", ratio);
+    throw InvalidInputException("mark_join_build_switch_ratio must be >= 0.0, got %f", ratio);
   }
   params->mark_join_build_switch_ratio = ratio;
   SIRIUS_LOG_DEBUG("Updated config MARK_JOIN_BUILD_SWITCH_RATIO to {}",

--- a/src/transparent/sirius_optimizer_extension.cpp
+++ b/src/transparent/sirius_optimizer_extension.cpp
@@ -70,16 +70,8 @@ void sirius_optimizer_hook(duckdb::OptimizerExtensionInput& input,
   // reaches finalize (e.g. Connection::ExtractPlan) is structurally rejected
   // at the next attempt by the generation check.
   //
-  // One catch arm, not two: the copy fails either because an operator refuses to
-  // serialize (NotImplementedException) or because the round-trip rejects it
-  // some other way (SerializationException from an operator type the
-  // deserializer does not handle). Both mean the same thing here — no GPU — and
-  // splitting them left the first arm silent, so a whole class of "why did this
-  // query not go to the GPU" left no trace at any log level.
-  //
-  // This hook must not throw: DuckDB has no error path for an optimizer
-  // extension, so an escaping exception would surface as a query failure on a
-  // path whose only job is to *decline*. sanitized_message keeps that property.
+  // Plan-copy failures make the query ineligible for GPU execution. Optimizer
+  // hooks must not throw, so log a readable message and decline the plan.
   try {
     conn_state->set_captured_plan(copy_logical_plan(*plan, context));
   } catch (std::exception& e) {

--- a/src/transparent/sirius_optimizer_extension.cpp
+++ b/src/transparent/sirius_optimizer_extension.cpp
@@ -24,6 +24,7 @@
 #include <duckdb/main/client_context.hpp>
 #include <duckdb/main/config.hpp>
 #include <log/logging.hpp>
+#include <util/duckdb_error_message.hpp>
 
 #include <exception>
 #include <utility>
@@ -68,12 +69,22 @@ void sirius_optimizer_hook(duckdb::OptimizerExtensionInput& input,
   // throws and we fall back to CPU. A capture whose planning attempt never
   // reaches finalize (e.g. Connection::ExtractPlan) is structurally rejected
   // at the next attempt by the generation check.
+  //
+  // One catch arm, not two: the copy fails either because an operator refuses to
+  // serialize (NotImplementedException) or because the round-trip rejects it
+  // some other way (SerializationException from an operator type the
+  // deserializer does not handle). Both mean the same thing here — no GPU — and
+  // splitting them left the first arm silent, so a whole class of "why did this
+  // query not go to the GPU" left no trace at any log level.
+  //
+  // This hook must not throw: DuckDB has no error path for an optimizer
+  // extension, so an escaping exception would surface as a query failure on a
+  // path whose only job is to *decline*. sanitized_message keeps that property.
   try {
     conn_state->set_captured_plan(copy_logical_plan(*plan, context));
-  } catch (duckdb::NotImplementedException&) {
-    // Plan not serializable — skip GPU.
   } catch (std::exception& e) {
-    SIRIUS_LOG_DEBUG("Transparent execution: failed to copy logical plan: {}", e.what());
+    SIRIUS_LOG_DEBUG("Transparent execution: failed to copy logical plan: {}",
+                     sirius::sanitized_message(e));
   }
 }
 

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -3810,6 +3810,29 @@ TEST_CASE("transparent S3 window query reports unsupported S3 CPU fallback",
   CHECK(error.find("no filesystem") == std::string::npos);
 }
 
+TEST_CASE("transparent S3 projection fallback reports prose instead of an exception envelope",
+          "[s3][integration][sql][gpu_execution][fallback][transparent]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+  auto const query =
+    "SELECT abs(n_nationkey - 100) FROM " + s3_parquet_scan(*env, "nation") + " LIMIT 1";
+  auto result = fixture.con.Query(query);
+  REQUIRE(result);
+  REQUIRE(result->HasError());
+
+  auto const error = result->GetError();
+  INFO(error);
+  CHECK(error.find("S3 CPU fallback is not supported") != std::string::npos);
+  CHECK(error.find("Underlying GPU error: Unsupported expression in projection") !=
+        std::string::npos);
+  CHECK(error.find("\"exception_type\"") == std::string::npos);
+  CHECK(error.find("\"exception_message\"") == std::string::npos);
+}
+
 TEST_CASE("transparent S3 view fallback is rejected instead of replaying on CPU",
           "[s3][integration][sql][gpu_execution][fallback][transparent]")
 {

--- a/test/cpp/integration/test_transparent_runtime_fallback.cpp
+++ b/test/cpp/integration/test_transparent_runtime_fallback.cpp
@@ -23,18 +23,35 @@
 #include <catch.hpp>
 #include <duckdb.hpp>
 #include <duckdb/main/client_context.hpp>
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/wait.h>
 #include <unistd.h>  // getpid
+#include <util/duckdb_error_message.hpp>
+#include <utils/gpu_execution_fixture.hpp>
 #include <utils/sirius_test_env.hpp>
 #include <utils/transparent_execution_test_utils.hpp>
 
 #include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <memory>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 #include <system_error>
+#include <thread>
+#include <utility>
+#include <vector>
 
 namespace fs = std::filesystem;
+
+extern char** environ;
 
 namespace {
 
@@ -324,4 +341,463 @@ TEST_CASE_METHOD(RuntimeFallbackFixture,
   con->Query("SET enable_duckdb_fallback = true;");
   con->context->TryGetCurrentSetting("enable_duckdb_fallback", v);
   REQUIRE(v.GetValue<bool>() == true);
+}
+
+namespace {
+
+constexpr char kS3MixChildCase[]        = "S3 mix fallback child runner";
+constexpr char kS3MixScenarioEnv[]      = "SIRIUS_S3MIX_CHILD_SCENARIO";
+constexpr char kRuntimeFallbackBanner[] = "Error in Sirius GPU execution, fallback to DuckDB";
+
+std::string sql_literal(std::string const& value)
+{
+  std::string out;
+  out.reserve(value.size() + 2);
+  out.push_back('\'');
+  for (auto const c : value) {
+    if (c == '\'') { out.push_back('\''); }
+    out.push_back(c);
+  }
+  out.push_back('\'');
+  return out;
+}
+
+class S3MixFixture : public sirius::test::GpuExecutionFixture {
+ public:
+  S3MixFixture()
+  {
+    static std::atomic<std::uint64_t> next_id{0};
+    work_dir = fs::temp_directory_path() / ("sirius_s3mix_" + std::to_string(::getpid()) + "_" +
+                                            std::to_string(next_id.fetch_add(1)));
+    fs::create_directories(work_dir);
+    parquet_path = work_dir / "nested.parquet";
+    empty_path   = work_dir / "empty.parquet";
+
+    std::string const source =
+      "SELECT CAST(i - 100 AS BIGINT) AS id, "
+      "CAST(i - 100 AS BIGINT) AS a, CAST(i AS BIGINT) AS b, "
+      "CASE WHEN i % 7 = 0 THEN NULL ELSE CAST(i - 100 AS BIGINT) END AS x, "
+      "struct_pack(a := i, b := i * 10) AS st, "
+      "[i, i + 1] AS li, MAP([1, 2], [i, i + 1]) AS mp "
+      "FROM range(300) t(i)";
+
+    run_ok("SET gpu_execution = false;");
+    run_ok("COPY (" + source + ") TO " + sql_literal(parquet_path.string()) + " (FORMAT PARQUET);");
+    run_ok("COPY (SELECT * FROM (" + source + ") empty_source WHERE false) TO " +
+           sql_literal(empty_path.string()) + " (FORMAT PARQUET);");
+    run_ok("CREATE TABLE mix_native AS " + source + ";");
+    run_ok("CHECKPOINT;");
+
+    auto const partition_dir = work_dir / "hive" / "part=1";
+    fs::create_directories(partition_dir);
+    fs::copy_file(
+      parquet_path, partition_dir / "data.parquet", fs::copy_options::overwrite_existing);
+    run_ok("SET gpu_execution = true;");
+  }
+
+  ~S3MixFixture() { fs::remove_all(work_dir); }
+
+  std::string parquet_scan() const
+  {
+    return "read_parquet(" + sql_literal(parquet_path.string()) + ")";
+  }
+
+  std::string empty_scan() const
+  {
+    return "read_parquet(" + sql_literal(empty_path.string()) + ")";
+  }
+
+  std::string hive_scan() const
+  {
+    return "read_parquet(" + sql_literal((work_dir / "hive" / "*" / "*.parquet").string()) +
+           ", hive_partitioning=true)";
+  }
+
+  std::vector<std::vector<std::string>> require_query_matches_cpu(
+    std::string const& query,
+    std::uint64_t expected_rebinds,
+    std::uint64_t expected_fallbacks,
+    std::uint64_t expected_executions,
+    std::optional<std::string> expected_first_value = std::nullopt,
+    std::uint64_t expected_runtime_fallbacks        = 0)
+  {
+    UNSCOPED_INFO("query: " << query);
+    run_ok("SET gpu_execution = false;");
+    auto cpu = con->Query(query);
+    REQUIRE(cpu);
+    if (cpu->HasError()) { UNSCOPED_INFO("CPU query error: " << cpu->GetError()); }
+    REQUIRE_FALSE(cpu->HasError());
+
+    run_ok("SET gpu_execution = true;");
+    auto const before = sirius::test::get_transparent_execution_stats(*con);
+    auto gpu          = con->Query(query);
+    REQUIRE(gpu);
+    if (gpu->HasError()) { UNSCOPED_INFO("GPU/fallback query error: " << gpu->GetError()); }
+    REQUIRE_FALSE(gpu->HasError());
+    auto const after = sirius::test::get_transparent_execution_stats(*con);
+    INFO("query: " << query);
+    REQUIRE(after.runtime_fallbacks == before.runtime_fallbacks + expected_runtime_fallbacks);
+    sirius::test::require_transparent_execution_delta(before,
+                                                      after,
+                                                      expected_rebinds,
+                                                      expected_fallbacks,
+                                                      expected_executions,
+                                                      expected_runtime_fallbacks);
+
+    REQUIRE(gpu->ColumnCount() == cpu->ColumnCount());
+    REQUIRE(gpu->RowCount() == cpu->RowCount());
+    if (expected_first_value.has_value()) {
+      REQUIRE(gpu->RowCount() > 0);
+      CHECK(gpu->GetValue(0, 0).ToString() == *expected_first_value);
+    }
+
+    auto gpu_rows =
+      sirius::test::GpuExecutionFixture::collect_rows(gpu->Cast<duckdb::MaterializedQueryResult>());
+    auto cpu_rows =
+      sirius::test::GpuExecutionFixture::collect_rows(cpu->Cast<duckdb::MaterializedQueryResult>());
+    CHECK(gpu_rows == cpu_rows);
+    return gpu_rows;
+  }
+
+  void require_plan_fallback(std::string const& query,
+                             std::optional<std::string> expected_first_value = std::nullopt)
+  {
+    (void)require_query_matches_cpu(query, 0, 1, 0, std::move(expected_first_value));
+  }
+
+  void require_gpu(std::string const& query,
+                   std::optional<std::string> expected_first_value = std::nullopt)
+  {
+    (void)require_query_matches_cpu(query, 1, 0, 1, std::move(expected_first_value));
+  }
+
+ private:
+  fs::path work_dir;
+  fs::path parquet_path;
+  fs::path empty_path;
+};
+
+void run_s3mix_scenario(std::string const& scenario)
+{
+  S3MixFixture fixture;
+  auto const parquet = fixture.parquet_scan();
+
+  if (scenario == "projection_round") {
+    fixture.require_plan_fallback("SELECT round(id) FROM " + parquet + " LIMIT 3", "-100");
+  } else if (scenario == "projection_struct_extract") {
+    fixture.require_plan_fallback("SELECT st.a FROM " + parquet + " LIMIT 3", "0");
+  } else if (scenario == "projection_list_extract") {
+    fixture.require_plan_fallback("SELECT li[1] FROM " + parquet + " LIMIT 3", "0");
+  } else if (scenario == "order_round") {
+    fixture.require_plan_fallback("SELECT id FROM " + parquet + " ORDER BY round(id) LIMIT 3",
+                                  "-100");
+  } else if (scenario == "topn_round") {
+    fixture.require_plan_fallback("SELECT id FROM " + parquet + " ORDER BY round(id) DESC LIMIT 3",
+                                  "199");
+  } else if (scenario == "aggregate_child_projection") {
+    fixture.require_plan_fallback(
+      "SELECT r, count(*) FROM "
+      "(SELECT round(a) AS r, b FROM " +
+      parquet + ") q GROUP BY r");
+  } else if (scenario == "join_round") {
+    fixture.require_plan_fallback(
+      "SELECT count(*) FROM " + parquet + " a JOIN " + parquet + " b ON round(a.id) = round(b.id)",
+      "300");
+  } else if (scenario == "regression_bundle") {
+    fixture.require_gpu("SELECT st FROM " + parquet);
+    fixture.require_gpu("SELECT li FROM " + parquet);
+
+    fixture.require_plan_fallback("SELECT count(*) FROM " + parquet + " WHERE round(id) > 1",
+                                  "198");
+    fixture.require_plan_fallback("SELECT count(*) FROM mix_native WHERE round(id) > 1", "198");
+    fixture.require_gpu("SELECT count(id) FROM " + fixture.hive_scan() + " WHERE part = 1", "300");
+
+    fixture.require_gpu("SELECT count(st) FROM " + parquet, "300");
+    fixture.require_gpu("SELECT count(li) FROM " + parquet, "300");
+    fixture.require_plan_fallback("SELECT count(round(x)) FROM " + parquet, "257");
+  } else if (scenario == "parquet_is_not_null") {
+    fixture.require_gpu("SELECT count(*) FROM " + parquet + " WHERE x IS NOT NULL", "257");
+  } else if (scenario == "native_is_not_null") {
+    fixture.require_gpu("SELECT count(*) FROM mix_native WHERE x IS NOT NULL", "257");
+  } else if (scenario == "nested_sort_regression") {
+    for (auto const* key : {"st", "li", "mp"}) {
+      fixture.require_plan_fallback("SELECT id FROM " + parquet + " ORDER BY " + key);
+      fixture.require_plan_fallback("SELECT id FROM " + parquet + " ORDER BY " + key + " LIMIT 5");
+    }
+    fixture.require_gpu("SELECT id FROM " + parquet + " ORDER BY id LIMIT 5", "-100");
+  } else if (scenario == "zero_limit") {
+    fixture.require_gpu("SELECT round(id) FROM " + parquet + " LIMIT 0");
+  } else if (scenario == "zero_empty") {
+    fixture.require_plan_fallback("SELECT round(id) FROM " + fixture.empty_scan());
+  } else if (scenario == "zero_stats_pruned") {
+    fixture.require_gpu("SELECT round(id) FROM " + parquet + " WHERE id > 10000");
+  } else {
+    FAIL("unknown S3 mix child scenario: " << scenario);
+  }
+}
+
+struct child_result {
+  bool timed_out{false};
+  bool exited{false};
+  int exit_code{-1};
+  int signal{-1};
+  std::string output;
+};
+
+child_result run_s3mix_child(std::string const& scenario, std::chrono::seconds timeout)
+{
+  if (sirius::test::g_integration_env != nullptr && sirius::test::g_integration_env->is_active()) {
+    sirius::test::g_integration_env->pause();
+  }
+
+  static std::atomic<std::uint64_t> next_id{0};
+  auto const output_path =
+    fs::temp_directory_path() / ("sirius_s3mix_child_" + std::to_string(::getpid()) + "_" +
+                                 std::to_string(next_id.fetch_add(1)) + ".log");
+  int const fd = ::open(output_path.c_str(), O_CREAT | O_TRUNC | O_WRONLY, 0600);
+  REQUIRE(fd >= 0);
+
+  std::vector<std::string> child_args{"sirius_unittest", kS3MixChildCase, "--reporter", "compact"};
+  std::vector<char*> child_argv;
+  child_argv.reserve(child_args.size() + 1);
+  for (auto& arg : child_args) {
+    child_argv.push_back(arg.data());
+  }
+  child_argv.push_back(nullptr);
+
+  auto const scenario_prefix = std::string{kS3MixScenarioEnv} + "=";
+  std::vector<std::string> child_environment;
+  for (auto entry = environ; entry != nullptr && *entry != nullptr; ++entry) {
+    std::string value{*entry};
+    if (value.rfind(scenario_prefix, 0) != 0) { child_environment.push_back(std::move(value)); }
+  }
+  child_environment.push_back(scenario_prefix + scenario);
+
+  std::vector<char*> child_envp;
+  child_envp.reserve(child_environment.size() + 1);
+  for (auto& entry : child_environment) {
+    child_envp.push_back(entry.data());
+  }
+  child_envp.push_back(nullptr);
+
+  char* const* child_argv_ptr = child_argv.data();
+  char* const* child_envp_ptr = child_envp.data();
+  auto const pid              = ::fork();
+  REQUIRE(pid >= 0);
+  if (pid == 0) {
+    (void)::dup2(fd, STDOUT_FILENO);
+    (void)::dup2(fd, STDERR_FILENO);
+    (void)::close(fd);
+    ::execve("/proc/self/exe", child_argv_ptr, child_envp_ptr);
+    ::_exit(127);
+  }
+  (void)::close(fd);
+
+  int status       = 0;
+  auto const stop  = std::chrono::steady_clock::now() + timeout;
+  bool timed_out   = true;
+  bool wait_failed = false;
+  while (std::chrono::steady_clock::now() < stop) {
+    auto const waited = ::waitpid(pid, &status, WNOHANG);
+    if (waited == pid) {
+      timed_out = false;
+      break;
+    }
+    if (waited < 0 && errno != EINTR) {
+      timed_out   = false;
+      wait_failed = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds{50});
+  }
+  if (timed_out) {
+    (void)::kill(pid, SIGKILL);
+    while (::waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
+  }
+
+  std::ifstream input(output_path);
+  std::ostringstream text;
+  text << input.rdbuf();
+  std::error_code ec;
+  fs::remove(output_path, ec);
+
+  child_result result;
+  result.timed_out = timed_out;
+  result.exited    = !timed_out && !wait_failed && WIFEXITED(status);
+  result.exit_code = result.exited ? WEXITSTATUS(status) : -1;
+  result.signal    = !timed_out && !wait_failed && WIFSIGNALED(status) ? WTERMSIG(status) : -1;
+  result.output    = text.str();
+  return result;
+}
+
+void require_s3mix_child_survives(std::string const& scenario,
+                                  bool forbid_runtime_banner         = false,
+                                  std::chrono::seconds const timeout = std::chrono::seconds{90})
+{
+  auto result = run_s3mix_child(scenario, timeout);
+  INFO("scenario=" << scenario);
+  INFO("child output:\n" << result.output);
+  CHECK_FALSE(result.timed_out);
+  CHECK(result.signal == -1);
+  REQUIRE(result.exited);
+  CHECK(result.exit_code == 0);
+  if (forbid_runtime_banner) {
+    CHECK(result.output.find(kRuntimeFallbackBanner) == std::string::npos);
+  }
+}
+
+}  // namespace
+
+TEST_CASE("S3 mix fallback child runner", "[.][transparent][integration][s3mix_child]")
+{
+  auto const* scenario = std::getenv(kS3MixScenarioEnv);
+  if (scenario == nullptr) { return; }
+  run_s3mix_scenario(scenario);
+}
+
+TEST_CASE("unsupported parquet round projection falls back without killing the process",
+          "[transparent][fallback][integration][s3mix]")
+{
+  require_s3mix_child_survives("projection_round");
+}
+
+TEST_CASE("unsupported parquet struct extraction falls back without killing the process",
+          "[transparent][fallback][integration][s3mix]")
+{
+  require_s3mix_child_survives("projection_struct_extract");
+}
+
+TEST_CASE("unsupported parquet list extraction falls back without killing the process",
+          "[transparent][fallback][integration][s3mix]")
+{
+  require_s3mix_child_survives("projection_list_extract");
+}
+
+TEST_CASE("unsupported ORDER BY expression falls back without killing the process",
+          "[transparent][fallback][integration][s3mix]")
+{
+  require_s3mix_child_survives("order_round");
+}
+
+TEST_CASE("unsupported TOP-N expression falls back without killing the process",
+          "[transparent][fallback][integration][s3mix]")
+{
+  require_s3mix_child_survives("topn_round");
+}
+
+TEST_CASE("unsupported aggregate child projection falls back without killing the process",
+          "[transparent][fallback][integration][s3mix]")
+{
+  require_s3mix_child_survives("aggregate_child_projection");
+}
+
+TEST_CASE("unsupported join expressions fall back without killing the process",
+          "[transparent][fallback][integration][s3mix]")
+{
+  require_s3mix_child_survives("join_round");
+}
+
+TEST_CASE("S3 mix fallback guards preserve supported nested and aggregate behavior",
+          "[transparent][fallback][integration][s3mix]")
+{
+  require_s3mix_child_survives("regression_bundle");
+}
+
+TEST_CASE("an unsupported filter above a join falls back during planning",
+          "[transparent][fallback][integration][s3mix][filter]")
+{
+  S3MixFixture fixture;
+  auto const parquet = fixture.parquet_scan();
+
+  fixture.require_plan_fallback("SELECT count(*) FROM " + parquet + " a JOIN " + parquet +
+                                  " b ON a.id = b.id WHERE round(a.a + b.b) > 1",
+                                "249");
+  fixture.require_gpu("SELECT count(*) FROM " + parquet + " a JOIN " + parquet +
+                        " b ON a.id = b.id WHERE a.a + b.b > 1",
+                      "249");
+}
+
+TEST_CASE("supported IS NOT NULL filter stays on GPU for parquet",
+          "[transparent][fallback][integration][s3mix][filter]")
+{
+  require_s3mix_child_survives("parquet_is_not_null");
+}
+
+TEST_CASE("supported IS NOT NULL filter stays on GPU for native storage",
+          "[transparent][fallback][integration][s3mix][filter]")
+{
+  require_s3mix_child_survives("native_is_not_null");
+}
+
+TEST_CASE("nested sort keys fall back during planning rather than execution",
+          "[transparent][fallback][integration][s3mix]")
+{
+  require_s3mix_child_survives("nested_sort_regression", true);
+}
+
+TEST_CASE("LIMIT zero is optimized to an empty result that stays on GPU",
+          "[transparent][fallback][integration][s3mix][zero-input]")
+{
+  require_s3mix_child_survives("zero_limit", false, std::chrono::seconds{30});
+}
+
+TEST_CASE("unsupported projection over an empty parquet falls back during planning",
+          "[transparent][fallback][integration][s3mix][zero-input]")
+{
+  require_s3mix_child_survives("zero_empty", false, std::chrono::seconds{30});
+}
+
+TEST_CASE("a stats-pruned scan is optimized to an empty result that stays on GPU",
+          "[transparent][fallback][integration][s3mix][zero-input]")
+{
+  require_s3mix_child_survives("zero_stats_pruned", false, std::chrono::seconds{30});
+}
+
+TEST_CASE_METHOD(RuntimeFallbackFixture,
+                 "unsupported table-function diagnostics include the function name",
+                 "[transparent][fallback][integration][s3mix][diagnostics]")
+{
+  auto const csv_path =
+    fs::temp_directory_path() / ("sirius_s3mix_" + std::to_string(::getpid()) + ".csv");
+  {
+    std::ofstream csv(csv_path);
+    csv << "id\n1\n";
+  }
+
+  auto const inner = "SELECT * FROM read_csv_auto(" + sql_literal(csv_path.string()) + ")";
+  std::string escaped;
+  escaped.reserve(inner.size());
+  for (auto const c : inner) {
+    if (c == '\'') { escaped.push_back('\''); }
+    escaped.push_back(c);
+  }
+  auto disable_fallback = con->Query("SET enable_duckdb_fallback = false;");
+  REQUIRE(disable_fallback);
+  REQUIRE_FALSE(disable_fallback->HasError());
+  auto disable_transparent = con->Query("SET gpu_execution = false;");
+  REQUIRE(disable_transparent);
+  REQUIRE_FALSE(disable_transparent->HasError());
+  auto result = con->Query("SELECT * FROM gpu_execution('" + escaped + "')");
+  std::error_code ec;
+  fs::remove(csv_path, ec);
+
+  REQUIRE(result);
+  REQUIRE(result->HasError());
+  INFO(result->GetError());
+  CHECK(result->GetError().find("Table function 'read_csv_auto' is not supported in Sirius") !=
+        std::string::npos);
+}
+
+TEST_CASE("DuckDB diagnostic sanitizer preserves invalid JSON-like messages",
+          "[transparent][fallback][s3mix][diagnostics]")
+{
+  std::runtime_error error("{not valid JSON");
+  CHECK(sirius::sanitized_message(error) == error.what());
+}
+
+TEST_CASE("DuckDB diagnostic sanitizer preserves valid non-envelope JSON messages",
+          "[transparent][fallback][s3mix][diagnostics]")
+{
+  std::runtime_error error(R"({"error":"missing"})");
+  CHECK(sirius::sanitized_message(error) == error.what());
 }

--- a/test/cpp/operator/test_physical_table_scan.cpp
+++ b/test/cpp/operator/test_physical_table_scan.cpp
@@ -22,8 +22,13 @@
 #include <catch.hpp>
 #include <cucascade/cudf/gpu_data_representation.hpp>
 #include <duckdb/function/table_function.hpp>
+#include <duckdb/planner/expression/bound_function_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
 #include <duckdb/planner/filter/constant_filter.hpp>
+#include <duckdb/planner/filter/expression_filter.hpp>
 #include <duckdb/planner/table_filter.hpp>
+#include <expression/ast/from_duckdb.hpp>
+#include <op/scan/scan_utils.hpp>
 #include <op/sirius_physical_table_scan.hpp>
 
 using namespace duckdb;
@@ -34,6 +39,26 @@ using namespace cucascade::memory;
 namespace {
 
 using namespace sirius::test::operator_utils;
+
+duckdb::unique_ptr<duckdb::Expression> make_untranslatable_filter_expression()
+{
+  auto expression = duckdb::make_uniq<duckdb::BoundFunctionExpression>(
+    duckdb::LogicalType::BOOLEAN,
+    duckdb::ScalarFunction("sirius_unmapped_filter",
+                           {duckdb::LogicalType::BIGINT},
+                           duckdb::LogicalType::BOOLEAN,
+                           nullptr),
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>{},
+    nullptr);
+  expression->children.push_back(
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::BIGINT, 0));
+  return expression;
+}
+
+duckdb::unique_ptr<duckdb::TableFilter> make_untranslatable_filter()
+{
+  return duckdb::make_uniq<duckdb::ExpressionFilter>(make_untranslatable_filter_expression());
+}
 }  // namespace
 
 TEMPLATE_TEST_CASE(
@@ -393,4 +418,99 @@ TEST_CASE("sirius_physical_table_scan filters all rows", "[physical_table_scan]"
     *dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()[0]);
   REQUIRE(view.num_columns() == 2);
   REQUIRE(view.num_rows() == 0);
+}
+
+TEST_CASE("table-filter conversion distinguishes discharged filters from failed translations",
+          "[physical_table_scan][table_filter]")
+{
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<duckdb::LogicalType> duckdb_types{duckdb::LogicalType::BIGINT,
+                                                   duckdb::LogicalType::BIGINT};
+  auto const returned_types = sirius::from_duckdb_vec(duckdb_types);
+  auto const batch_map      = sirius::op::build_batch_column_map({}, column_ids.size());
+
+  SECTION("partition-only filter is discharged")
+  {
+    duckdb::TableFilterSet filters;
+    filters.filters[0] = duckdb::make_uniq<duckdb::ConstantFilter>(
+      duckdb::ExpressionType::COMPARE_EQUAL, duckdb::Value::BIGINT(1));
+    CHECK(sirius::op::convert_table_filters_to_expression(
+            filters, column_ids, returned_types, batch_map, {0}) == nullptr);
+  }
+
+  SECTION("plain data filter produces a translatable expression")
+  {
+    duckdb::TableFilterSet filters;
+    filters.filters[0] = duckdb::make_uniq<duckdb::ConstantFilter>(
+      duckdb::ExpressionType::COMPARE_GREATERTHAN, duckdb::Value::BIGINT(1));
+    auto expression = sirius::op::convert_table_filters_to_expression(
+      filters, column_ids, returned_types, batch_map);
+    REQUIRE(expression);
+    CHECK(sirius::ast::from_duckdb(*expression) != nullptr);
+  }
+
+  SECTION("unsupported data filter remains distinguishable from an empty conversion")
+  {
+    duckdb::TableFilterSet filters;
+    filters.filters[0] = make_untranslatable_filter();
+    auto expression    = sirius::op::convert_table_filters_to_expression(
+      filters, column_ids, returned_types, batch_map);
+    REQUIRE(expression);
+    CHECK(sirius::ast::from_duckdb(*expression) == nullptr);
+  }
+
+  SECTION("partition and data filters retain the data predicate")
+  {
+    duckdb::TableFilterSet filters;
+    filters.filters[0] = duckdb::make_uniq<duckdb::ConstantFilter>(
+      duckdb::ExpressionType::COMPARE_EQUAL, duckdb::Value::BIGINT(1));
+    filters.filters[1] = duckdb::make_uniq<duckdb::ConstantFilter>(
+      duckdb::ExpressionType::COMPARE_GREATERTHAN, duckdb::Value::BIGINT(2));
+    auto expression = sirius::op::convert_table_filters_to_expression(
+      filters, column_ids, returned_types, batch_map, {0});
+    REQUIRE(expression);
+    CHECK(sirius::ast::from_duckdb(*expression) != nullptr);
+  }
+}
+
+TEST_CASE("sirius_physical_table_scan fails closed for an untranslatable pushed-down filter",
+          "[physical_table_scan][table_filter]")
+{
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
+  auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  REQUIRE(space);
+
+  std::vector<int64_t> filter_values{1, 2, 3};
+  std::vector<int32_t> data_values{10, 20, 30};
+  auto input_batch = make_two_column_batch<int64_t, int32_t>(
+    *space, filter_values, data_values, cudf::type_id::INT32, std::nullopt);
+
+  auto table_filters        = duckdb::make_uniq<duckdb::TableFilterSet>();
+  table_filters->filters[0] = make_untranslatable_filter();
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<duckdb::idx_t> projection_ids{0, 1};
+  duckdb::vector<std::string> names{"filter_col", "data_col"};
+  duckdb::vector<duckdb::Value> parameters;
+  duckdb::virtual_column_map_t virtual_columns;
+  duckdb::TableFunction table_function("test_scan", {}, nullptr, nullptr);
+
+  sirius_physical_table_scan table_scan(sirius::from_duckdb_vec(types),
+                                        std::move(table_function),
+                                        nullptr,
+                                        sirius::from_duckdb_vec(types),
+                                        std::move(column_ids),
+                                        std::move(projection_ids),
+                                        std::move(names),
+                                        std::move(table_filters),
+                                        filter_values.size(),
+                                        duckdb::ExtraOperatorInfo(),
+                                        std::move(parameters),
+                                        std::move(virtual_columns));
+  std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
+
+  CHECK_THROWS_WITH(
+    table_scan.execute(pipelineable_operator_data(inputs), cudf::get_default_stream()),
+    Catch::Contains("cannot evaluate pushed-down predicate"));
 }

--- a/test/cpp/planner/test_plan_tree_shape.cpp
+++ b/test/cpp/planner/test_plan_tree_shape.cpp
@@ -36,6 +36,10 @@
 #include <duckdb/main/config.hpp>
 #include <duckdb/optimizer/optimizer.hpp>
 #include <duckdb/parser/parser.hpp>
+#include <duckdb/planner/expression/bound_function_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <duckdb/planner/filter/expression_filter.hpp>
+#include <duckdb/planner/operator/logical_get.hpp>
 #include <duckdb/planner/planner.hpp>
 #include <unistd.h>
 
@@ -205,6 +209,21 @@ std::string tree_to_string(sirius_physical_operator* root)
   std::ostringstream out;
   tree_to_string(root, 0, out);
   return out.str();
+}
+
+duckdb::unique_ptr<duckdb::Expression> untranslatable_table_filter_expression()
+{
+  auto expression = duckdb::make_uniq<duckdb::BoundFunctionExpression>(
+    duckdb::LogicalType::BOOLEAN,
+    duckdb::ScalarFunction("sirius_unmapped_filter",
+                           {duckdb::LogicalType::BIGINT},
+                           duckdb::LogicalType::BOOLEAN,
+                           nullptr),
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>{},
+    nullptr);
+  expression->children.push_back(
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::BIGINT, 0));
+  return expression;
 }
 
 /// Every operator's `_parent_op` must equal its position in the final tree; delim joins
@@ -529,4 +548,31 @@ TEST_CASE_METHOD(plan_tree_shape_fixture,
       }
     }
   }
+}
+
+TEST_CASE_METHOD(plan_tree_shape_fixture,
+                 "plan generation rejects an untranslatable pushed-down table filter",
+                 "[plan_tree_shape][table_filter][isolated_context]")
+{
+  duckdb::TableFunction function;
+  function.name                = "seq_scan";
+  function.projection_pushdown = true;
+  function.filter_pushdown     = true;
+
+  auto get = duckdb::make_uniq<duckdb::LogicalGet>(
+    0,
+    std::move(function),
+    nullptr,
+    duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::BIGINT},
+    duckdb::vector<duckdb::string>{"id"});
+  get->SetColumnIds({duckdb::ColumnIndex(0)});
+  get->projection_ids        = {0};
+  get->estimated_cardinality = 1;
+  get->table_filters.filters[0] =
+    duckdb::make_uniq<duckdb::ExpressionFilter>(untranslatable_table_filter_expression());
+
+  duckdb::unique_ptr<duckdb::LogicalOperator> logical = std::move(get);
+  sirius::planner::sirius_physical_plan_generator generator(*con->context);
+  CHECK_THROWS_WITH(generator.create_plan(std::move(logical)),
+                    Catch::Contains("Unsupported filter predicate on column 'id'"));
 }


### PR DESCRIPTION
## Problem

Some unsupported expressions were added to GPU plans as null expression nodes.

`from_duckdb()` returns `nullptr` for expressions it cannot translate. Unmapped scalar functions are one source; the relevant struct/list/map extraction functions are not mapped either. Several plan builders did not check that result.

Seven reproduced shapes dereferenced a null translation and crashed the process. An ordinary filter above a join followed a different path: in the tested build, dereferencing the null expression propagated it into the expression evaluator, whose null check turned it into a mid-query failure and runtime CPU fallback. The dereference is still undefined behavior. This PR rejects the predicate during planning instead.

Affected shapes included:

- projections such as `round(x)`, `s.a`, and `lst[1]`
- sort keys computed by a projection, such as `ORDER BY round(x)`
- pushed-down and ordinary filters
- join conditions

## Fix

Plan construction now rejects expressions that cannot be translated in:

- projections
- pushed-down scan filters
- ordinary filters
- join conditions

Transparent execution then falls back to DuckDB CPU instead of installing an invalid GPU plan. Scan-side checks also distinguish an intentionally skipped filter from a failed translation, so an unsupported predicate cannot be silently dropped.

Nested sort keys are handled separately: STRUCT, LIST, and MAP keys are now rejected during planning instead of failing inside cuDF at runtime. Nested columns that only pass through the operator are unaffected, and supported operations such as `count(struct_col)` and `count(list_col)` are unchanged.

A defensive check also prevents partitioned-aggregate eligibility from dereferencing a malformed child projection.

The PR also fixes related diagnostics:

- DuckDB exception messages now use the correct printf-style placeholders.
- User-visible fallback errors no longer include DuckDB's serialized JSON envelope.
- Valid JSON that is not a DuckDB exception envelope is preserved unchanged.
- Plan-copy failures now all emit the same debug log; `NotImplementedException` was previously silent.

## Behavior

The affected queries now return the same result as `gpu_execution=false` instead of crashing or failing mid-query.

An unsupported expression is treated as a plan capability decision. If it remains in the logical plan, the query falls back even when the input is empty. Queries such as `LIMIT 0` or statistics-pruned scans can still stay on the GPU when DuckDB removes the unsupported expression before Sirius sees the plan.

Query recovery after a task-creation failure is handled separately and is not part of this PR.

## Verification

| Gate | Result |
|---|---|
| `make test` | 2221/2221 cases, 32,522,291 assertions |
| `make s3-test` | 90/90 cases, 31,383 assertions |
| `make s3-test-large` | 5/5 + 3/3 cases |
| `pre-commit run -a` | pass |
| `git diff --check` | pass |

Each production commit built independently, and the final branch passed a clean build.

Regression tests run the former crash shapes in isolated processes, compare results with DuckDB CPU execution, and assert plan-time fallback. Control cases verify that supported nested projections, aggregates, filters, and sort keys remain on the GPU.
