### PR TITLE
Allow some more dynamic filters to be published

### DIFF
--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -327,6 +327,16 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   /// decision so the partition can finish its own wiring (e.g. enabling build-side concat_all).
   partition_strategy get_partition_strategy(const partition_sizing_input& in) override;
 
+  /// True when this join publishes dynamic filters (a filter-pushdown plan with wired probe
+  /// targets). The upstream PARTITION folds a single-partition build to one batch for such a join
+  /// so the one-shot publisher sees the whole key set.
+  [[nodiscard]] bool publishes_dynamic_filters() const;
+
+  /// Reported by the upstream PARTITION at sizing time: the build port will deliver one
+  /// concat-folded batch covering the entire build side (single-partition or broadcast build).
+  /// Precondition for claiming a build batch for dynamic-filter publication, in any join mode.
+  void set_build_arrives_whole(bool arrives_whole);
+
   /// @brief True when this join runs in build-then-probe mode (see `get_partition_strategy`).
   [[nodiscard]] bool is_build_probe_mode();
 
@@ -379,6 +389,12 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   // Broadcast (small build table) BUILD_PROBE join: the build side is replicated to every slot and
   // the probe side is streamed unpartitioned.
   bool _broadcast = false;
+
+  // Whether the build port delivers one concat-folded batch covering the entire build side
+  // (single-partition or broadcast build with a concat_all'd build-side CONCAT). Set by the
+  // upstream PARTITION at sizing time; the one-shot dynamic-filter publisher only claims a build
+  // batch when this holds. Guarded by op_state_mutex.
+  bool _build_arrives_whole = false;
 
   // Whether any build-side join key column contains a NULL. Used exclusively for MARK join
   // three-valued logic. Sentinel -1 = unset, 0 = false, 1 = true. Join-wide (not per-partition)

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -1982,14 +1982,37 @@ void sirius_physical_hash_join::push_data_batch_partitioned(
   //   - Broadcast (`_broadcast`)
   std::optional<::cucascade::read_only_data_batch> build_ro;
   if (port_id == "build" && batch) {
-    bool claim = false;
+    bool claim                    = false;
+    bool wired_but_multipartition = false;
+    std::size_t build_partitions  = 0;
     {
       std::scoped_lock lg(op_state_mutex);
-      claim = _dynamic_filter_publication_state.load(std::memory_order_acquire) ==
-                dynamic_filter_publication_state::OPEN &&
-              _join_mode == HASH_JOIN_MODE::BUILD_PROBE &&
-              (_partition_build_states.size() == 1 || _broadcast) && filter_pushdown &&
-              _dynamic_filter_plan.enabled();
+      const bool open = _dynamic_filter_publication_state.load(std::memory_order_acquire) ==
+                        dynamic_filter_publication_state::OPEN;
+      const bool wired                  = filter_pushdown && _dynamic_filter_plan.enabled();
+      const bool single_partition_build = _partition_build_states.size() == 1 || _broadcast;
+      build_partitions                  = _partition_build_states.size();
+      claim = open && _join_mode == HASH_JOIN_MODE::BUILD_PROBE && single_partition_build && wired;
+
+      // A join that has a filter plan and is still open, but cannot use the
+      // one-shot publisher, silently publishes nothing. Two ways to land here,
+      // and BOTH are the multi-partition case:
+      //   - BUILD_PROBE whose build spans >1 partition, and
+      //   - STANDARD / MIXED_JOIN, which are the partitioned modes to begin with.
+      // Deliberately NOT gated on BUILD_PROBE: gating on it would only ever find
+      // multi-partition builds among the single-partition-shaped joins, which is
+      // empty by construction and reports a reassuring zero.
+      wired_but_multipartition = open && wired && !single_partition_build;
+    }
+    if (wired_but_multipartition) {
+      SIRIUS_LOG_DEBUG(
+        "[sirius_physical_hash_join] dynamic filter NOT published (id={}): mode={} build spans {} "
+        "partition(s); the publisher requires a single-partition or broadcast build",
+        get_operator_id(),
+        _join_mode == HASH_JOIN_MODE::BUILD_PROBE  ? "BUILD_PROBE"
+        : _join_mode == HASH_JOIN_MODE::MIXED_JOIN ? "MIXED_JOIN"
+                                                   : "STANDARD",
+        build_partitions);
     }
     if (claim) { build_ro.emplace(batch->to_read_only()); }
   }

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -808,6 +808,18 @@ bool sirius_physical_hash_join::is_build_probe_mode()
   return _join_mode == HASH_JOIN_MODE::BUILD_PROBE;
 }
 
+bool sirius_physical_hash_join::publishes_dynamic_filters() const
+{
+  // Both are fixed at construction, so this needs no lock.
+  return filter_pushdown != nullptr && _dynamic_filter_plan.enabled();
+}
+
+void sirius_physical_hash_join::set_build_arrives_whole(bool arrives_whole)
+{
+  std::lock_guard<std::mutex> lg(op_state_mutex);
+  _build_arrives_whole = arrives_whole;
+}
+
 std::vector<build_probe_slot_view> sirius_physical_hash_join::snapshot_build_probe_slots()
 {
   auto* build_port = get_port("build");
@@ -1975,44 +1987,40 @@ void sirius_physical_hash_join::push_data_batch_partitioned(
 {
   //===----------Dynamic Table Filters----------===//
   // Build-side dynamic-filter publish: the moment the (single, concat-folded) build batch arrives,
-  // compute and publish the filter from the build keys. This is gated to the two BUILD_PROBE shapes
-  // where a single partition's build batch covers the whole build side, so the one-shot publisher
-  // and its single-GPU reduction emit a complete filter:
-  //   - Single partition (`size() == 1`)
-  //   - Broadcast (`_broadcast`)
+  // compute and publish the filter from the build keys.
+  //
+  // The publisher is one-shot, so the batch it claims must carry the WHOLE build side — a filter
+  // built from part of the key set would drop probe rows that do in fact join. The upstream
+  // PARTITION knows whether that holds (a single-partition or broadcast build, folded to one batch
+  // by a concat_all build-side CONCAT) and reports it at sizing time through
+  // `set_build_arrives_whole`. The join mode is deliberately not part of the condition: a
+  // single-partition STANDARD / MIXED_JOIN build publishes on the same terms as BUILD_PROBE.
   std::optional<::cucascade::read_only_data_batch> build_ro;
   if (port_id == "build" && batch) {
-    bool claim                    = false;
-    bool wired_but_multipartition = false;
-    std::size_t build_partitions  = 0;
+    bool claim              = false;
+    bool wired_but_unusable = false;
+    HASH_JOIN_MODE mode     = HASH_JOIN_MODE::STANDARD;
     {
       std::scoped_lock lg(op_state_mutex);
       const bool open = _dynamic_filter_publication_state.load(std::memory_order_acquire) ==
                         dynamic_filter_publication_state::OPEN;
-      const bool wired                  = filter_pushdown && _dynamic_filter_plan.enabled();
-      const bool single_partition_build = _partition_build_states.size() == 1 || _broadcast;
-      build_partitions                  = _partition_build_states.size();
-      claim = open && _join_mode == HASH_JOIN_MODE::BUILD_PROBE && single_partition_build && wired;
+      const bool wired = filter_pushdown && _dynamic_filter_plan.enabled();
+      claim            = open && wired && _build_arrives_whole;
 
-      // A join that has a filter plan and is still open, but cannot use the
-      // one-shot publisher, silently publishes nothing. Two ways to land here,
-      // and BOTH are the multi-partition case:
-      //   - BUILD_PROBE whose build spans >1 partition, and
-      //   - STANDARD / MIXED_JOIN, which are the partitioned modes to begin with.
-      // Deliberately NOT gated on BUILD_PROBE: gating on it would only ever find
-      // multi-partition builds among the single-partition-shaped joins, which is
-      // empty by construction and reports a reassuring zero.
-      wired_but_multipartition = open && wired && !single_partition_build;
+      // A join that has a filter plan and is still open but cannot use the one-shot publisher
+      // silently publishes nothing — say so.
+      wired_but_unusable = open && wired && !claim;
+      mode               = _join_mode;
     }
-    if (wired_but_multipartition) {
+    if (wired_but_unusable) {
       SIRIUS_LOG_DEBUG(
-        "[sirius_physical_hash_join] dynamic filter NOT published (id={}): mode={} build spans {} "
-        "partition(s); the publisher requires a single-partition or broadcast build",
+        "[sirius_physical_hash_join] dynamic filter NOT published (id={}): mode={}; the build does "
+        "not arrive as a single batch covering the whole build side (multi-partition, or no "
+        "concat-folded build — see this join's partition strategy log line)",
         get_operator_id(),
-        _join_mode == HASH_JOIN_MODE::BUILD_PROBE  ? "BUILD_PROBE"
-        : _join_mode == HASH_JOIN_MODE::MIXED_JOIN ? "MIXED_JOIN"
-                                                   : "STANDARD",
-        build_partitions);
+        mode == HASH_JOIN_MODE::BUILD_PROBE  ? "BUILD_PROBE"
+        : mode == HASH_JOIN_MODE::MIXED_JOIN ? "MIXED_JOIN"
+                                             : "STANDARD");
     }
     if (claim) { build_ro.emplace(batch->to_read_only()); }
   }

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -418,13 +418,12 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
                                    "single batch (concat_all)");
         }
         build_arrives_whole = strategy.num_partitions == 1 || strategy.broadcast;
-      } else if (strategy.num_partitions == 1 && hash_join != nullptr &&
+      } else if (in.is_build_side && strategy.num_partitions == 1 && hash_join != nullptr &&
                  hash_join->publishes_dynamic_filters()) {
-        // Not BUILD_PROBE, but the whole build lands in one partition and the join publishes a
-        // dynamic filter from a single build batch. Folding that partition costs nothing in data
-        // volume — it is the same rows either way — and only moves a batch boundary, so the filter
-        // can be published from a key set that is provably complete. Unlike BUILD_PROBE this is an
-        // optimisation, not an invariant: if no build-side CONCAT exists, publication is skipped.
+        // Not BUILD_PROBE, but the build lands in one partition and this join publishes a filter
+        // from a single build batch, so folding it only moves a batch boundary. Best-effort: no
+        // build-side CONCAT means no publication. Build-side sizing is required — right-family
+        // joins size from the probe, where one partition says nothing about the build's size.
         bool const found_this    = enable_build_concat_all(*this);
         bool const found_sibling = enable_build_concat_all(sibling);
         build_arrives_whole      = found_this || found_sibling;

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -402,7 +402,9 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
                                       has_build_concat(*this) || has_build_concat(sibling)};
       // The consumer owns the decision: it computes the count / broadcast flag, updates its own
       // execution state (e.g. hash-join BUILD_PROBE mode), and pre-sizes its own input repos.
-      auto const strategy = consumer->get_partition_strategy(in);
+      auto const strategy      = consumer->get_partition_strategy(in);
+      auto* hash_join          = dynamic_cast<sirius_physical_hash_join*>(consumer);
+      bool build_arrives_whole = false;
       if (strategy.build_probe) {
         // Configure both siblings' build-side CONCAT (do not short-circuit) and require that at
         // least one build-side CONCAT exists — BUILD_PROBE cannot run without a concat_all'd build.
@@ -415,7 +417,19 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
                                    "to fold the build into a "
                                    "single batch (concat_all)");
         }
+        build_arrives_whole = strategy.num_partitions == 1 || strategy.broadcast;
+      } else if (strategy.num_partitions == 1 && hash_join != nullptr &&
+                 hash_join->publishes_dynamic_filters()) {
+        // Not BUILD_PROBE, but the whole build lands in one partition and the join publishes a
+        // dynamic filter from a single build batch. Folding that partition costs nothing in data
+        // volume — it is the same rows either way — and only moves a batch boundary, so the filter
+        // can be published from a key set that is provably complete. Unlike BUILD_PROBE this is an
+        // optimisation, not an invariant: if no build-side CONCAT exists, publication is skipped.
+        bool const found_this    = enable_build_concat_all(*this);
+        bool const found_sibling = enable_build_concat_all(sibling);
+        build_arrives_whole      = found_this || found_sibling;
       }
+      if (hash_join != nullptr) { hash_join->set_build_arrives_whole(build_arrives_whole); }
       _broadcast              = strategy.broadcast;
       sibling._broadcast      = strategy.broadcast;
       _num_partitions         = strategy.num_partitions;

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -358,6 +358,37 @@ std::vector<std::size_t> build_key_domain_cardinalities(duckdb::LogicalCompariso
 }  // namespace
 //===----------------------------------------------------------------------===//
 
+/// True when @p op is a *derived* relation rather than a base table read: its
+/// subtree contains a join, aggregate, or set operation that has already reduced
+/// its key set.
+///
+/// This is the distinction the "unfiltered build side" refusal actually needs.
+/// An unfiltered base relation is the whole key domain, so a dynamic filter from
+/// it keeps every probe row. An unfiltered *derived* relation is not — a join
+/// output carries only the keys that survived the join, and can be far smaller
+/// than the domain even though no predicate appears anywhere below it.
+///
+/// Descends through the pass-through operators (projection, filter, order) that
+/// sit between a join and its real input; stops at the first reducing operator.
+static bool build_side_is_derived(const duckdb::LogicalOperator* op)
+{
+  if (op == nullptr) { return false; }
+  switch (op->type) {
+    case duckdb::LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+    case duckdb::LogicalOperatorType::LOGICAL_ANY_JOIN:
+    case duckdb::LogicalOperatorType::LOGICAL_DELIM_JOIN:
+    case duckdb::LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+    case duckdb::LogicalOperatorType::LOGICAL_DISTINCT:
+    case duckdb::LogicalOperatorType::LOGICAL_INTERSECT:
+    case duckdb::LogicalOperatorType::LOGICAL_EXCEPT: return true;
+    default: break;
+  }
+  for (auto const& child : op->children) {
+    if (build_side_is_derived(child.get())) { return true; }
+  }
+  return false;
+}
+
 /// A join equality-condition side that is a plain column reference (BOUND_REF) or a cast of one
 /// (BOUND_CAST(BOUND_REF)) is already handled directly by the hash-join key extraction and by the
 /// PARTITION operator's cast-alignment logic, so it needs no materialization.
@@ -543,12 +574,31 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
       // An unfiltered build is (for FK-shaped joins) the whole key domain — its filter keeps
       // every probe row by construction, so wiring a producer target for it only buys overhead.
       // DuckDB's flag covers the delim-join case where the effective build data is children[0].
-      if (!op.filter_pushdown->build_side_has_filter) {
+      //
+      // But "unfiltered" only implies "whole key domain" when the build side IS a base table.
+      // A build that is itself a join or aggregate output has already been reduced, so its key
+      // set is a strict subset of the domain and its filter can be highly selective even with
+      // no predicate anywhere in its subtree. TPC-H q3 is the case in point: the build of
+      // orders⋈lineitem is the output of customer⋈orders, and the filter it would produce keeps
+      // ~1% of lineitem.
+      //
+      // So the refusal now applies only to a base-relation build. For a derived build we wire
+      // the producer and let the *runtime* selectivity gate decide — it measures what the filter
+      // actually keeps and disables it if that is not worth the probe-side cost, which is a real
+      // measurement rather than a plan-time guess.
+      const bool derived_build = build_side_is_derived(op.children[1].get());
+      if (!op.filter_pushdown->build_side_has_filter && !derived_build) {
         SIRIUS_LOG_INFO(
-          "[sirius_plan_comparison_join] Not wiring dynamic filter(s): build side is "
-          "unfiltered (build est {} rows).",
+          "[sirius_plan_comparison_join] Not wiring dynamic filter(s): build side is an "
+          "unfiltered base relation (build est {} rows).",
           rhs_cardinality);
       } else {
+        if (!op.filter_pushdown->build_side_has_filter) {
+          SIRIUS_LOG_INFO(
+            "[sirius_plan_comparison_join] Wiring dynamic filter(s) for an unfiltered but "
+            "derived build side (build est {} rows); runtime selectivity gate decides.",
+            rhs_cardinality);
+        }
         auto& memory_manager = sirius_context->get_memory_manager();
         auto const gpu_spaces =
           memory_manager.get_memory_spaces_for_tier(cucascade::memory::Tier::GPU);


### PR DESCRIPTION
Two changes that widen dynamic-filter coverage without changing how any join executes.

  **1. Wire filters for unfiltered but *derived* build sides** (`aa9a80d9`). The "unfiltered
  build = whole key domain" refusal is only true for base tables. A build that is itself a
  join/aggregate output has already been reduced, so its filter can be highly selective.
  Those are now wired, and the runtime selectivity gate decides. Also adds a
  `dynamic filter NOT published` diagnostic for joins that are wired but never publish.

  **2. Publish from any single-partition folded build** (`d915715c`). The publisher was gated
  on `_join_mode == BUILD_PROBE`, but what it actually needs is a batch carrying the whole
  build side. The PARTITION operator now folds (`concat_all`) a single-partition build whose
  join publishes filters and reports it via `set_build_arrives_whole()`; the claim drops the
  mode test. This recovers e.g. q21 `id=51`, a MIXED_JOIN with an 855 MB single-partition
  build whose filter removes ~94% of q21's largest probe stream.

  ## Results

  TPC-H SF1000 vs `dev`, 3 iterations, grouped, pinned to host, best-of-3:

  | | dev | this branch |
  |---|---|---|
  | 22-query sum | 20.7602s | **20.1328s (−3.0%)** |
  | q21 | 2.6474s | **2.0941s (−20.9%)** |
  | filters published / iteration | 37 | **40** |

  No join changes execution mode; all 22 query outputs are byte-identical to `dev`.
