### PR TITLE
fix(pipeline): re-evaluate pipeline status when a task request is dropped

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -356,9 +356,23 @@ void task_creator::manager_loop()
     auto request_kind = request->type;
     if (node == nullptr) { continue; }
 
+    auto requested_pipeline = node->get_pipeline();
+
     node = get_operator_for_next_task(node);
 
-    if (node == nullptr) { continue; }
+    if (node == nullptr) {
+      // No task to create — but getting here still ran the operator's
+      // get_next_task_hint(), and for a hash join that call performs
+      // refresh_cross_schedule()'s discard sweep, which drains batches whose
+      // opposite side has just finished. That can be the very thing that makes
+      // the pipeline finishable, and the dispatch path below (whose exit
+      // re-evaluates status for exactly this reason) is skipped on this branch.
+      // Without re-evaluating here the pipeline stays unfinished forever and
+      // every downstream consumer parks. See the paired call before the
+      // dispatch lambda returns.
+      if (requested_pipeline) { requested_pipeline->update_pipeline_status(false); }
+      continue;
+    }
 
     // Dispatch the task creation work to the pool
     _bounded_pool->dispatch(std::move(slot), [this, node, request_kind]() mutable {

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -361,15 +361,9 @@ void task_creator::manager_loop()
     node = get_operator_for_next_task(node);
 
     if (node == nullptr) {
-      // No task to create — but getting here still ran the operator's
-      // get_next_task_hint(), and for a hash join that call performs
-      // refresh_cross_schedule()'s discard sweep, which drains batches whose
-      // opposite side has just finished. That can be the very thing that makes
-      // the pipeline finishable, and the dispatch path below (whose exit
-      // re-evaluates status for exactly this reason) is skipped on this branch.
-      // Without re-evaluating here the pipeline stays unfinished forever and
-      // every downstream consumer parks. See the paired call before the
-      // dispatch lambda returns.
+      // Same re-evaluation the creation path does on exit: get_next_task_hint()
+      // above can have drained ports (hash join's discard sweep), making the
+      // pipeline finishable.
       if (requested_pipeline) { requested_pipeline->update_pipeline_status(false); }
       continue;
     }


### PR DESCRIPTION
## Problem

Multi-GPU TPC-H runs hang intermittently (~33% of runs at SF1000 on 4 GPUs). The query never returns, every Sirius thread parks idle, and DuckDB's main thread spins in `CompletePendingQuery`. It is a pure liveness bug — a query either completes correctly in seconds or wedges forever; results are never wrong.

## Root cause

Pipeline completion is a conjunction (source exhausted AND first node drained AND `tasks_created == tasks_completed`) that `update_pipeline_status()` only re-evaluates at call sites paired with those facts. Whichever fact flips last must trigger a re-check.

`task_creator::manager_loop()` drops a request when `get_operator_for_next_task()` returns null:

```cpp
node = get_operator_for_next_task(node);
if (node == nullptr) { continue; }   // skips the re-evaluation below
```

That `continue` bypasses the re-evaluation the dispatch path performs at every creation exit — the one whose comment says it exists because *"last task completed at T1, connector closed at T2>T1 has no later mark_task_completed() to re-check the pipeline ... Without it, normal fast-GPU queries would hang."*

The early exit is not inert. Reaching it already called the operator's `get_next_task_hint()`, and for a hash join that runs `refresh_cross_schedule()`, **whose discard sweep releases batches whose opposite side has just finished**. So the ports get drained and then nothing re-checks the pipeline.

Concretely, on q8:

1. The probe-side pipeline finishes.
2. The executor schedules the hash join as a downstream consumer.
3. `get_next_task_hint()` runs the discard sweep, freeing the retained build batches.
4. The hint reports `done` → `get_operator_for_next_task()` returns null.
5. `continue` — pipeline status never re-evaluated.

The pipeline is permanently unfinished, so every downstream consumer gated on it parks.

A debug dump at the stall showed the join's pipeline with `tasks 26/26` balanced but `src_ports_empty=false` — state observed *before* the sweep that had already freed those batches. All upstream pipelines logged `FINISHED` with balanced counters, ruling out any lost completion signal across GPUs or streams.

## Fix

Re-evaluate pipeline status on the drop path, so the state change the hint just made is actually observed.

## Verification

SF1000, 4x GB200, scan-from-disk, dynamic filter pushdown on:

| build | hangs |
|---|---|
| before | 6 / 18 (~33%) |
| after (q1-q8) | **0 / 25** |
| after (all 22 queries) | **0 / 15** |

0/25 against a 33% baseline is ~6e-5 by chance.

## Notes

This is one instance of a broader design issue — completion is edge-triggered with several events racing its re-evaluation sites, as flagged by the existing `todo (amin): there is a potential race condition` on `is_pipeline_finished()`. A separate PR fixes another unpaired edge (source exhaustion on the scan path). Making completion level-triggered would remove the class entirely, but is a larger redesign.

Based on `2f6192af`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)