### PR TITLE
fix(scan): re-evaluate pipeline status when the split connector closes

### DIFF
--- a/src/include/scan_manager/load_balancing_scan_batch_coalescer.hpp
+++ b/src/include/scan_manager/load_balancing_scan_batch_coalescer.hpp
@@ -108,6 +108,11 @@ class load_balancing_scan_batch_coalescer {
 
     std::size_t op_id{0};
     std::size_t pipeline_id{0};
+    /// The scan operator this slot feeds. Needed so closing the connector can
+    /// ask the task_creator to revisit the operator: pipeline completion is
+    /// only re-evaluated at a task-creation exit, and closing the source is the
+    /// last thing that can make the pipeline finishable. See notify_source_closed().
+    op::scan::sirius_gpu_scan_operator* scan_op{nullptr};
     using provider_value_t = exec::try_t<std::unique_ptr<op::scan::scan_info>>;
     duckdb_moodycamel::BlockingConcurrentQueue<provider_value_t> queue;
     std::shared_ptr<op::scan::batch_coalescer> coalescer;

--- a/src/scan_manager/load_balancing_scan_batch_coalescer.cpp
+++ b/src/scan_manager/load_balancing_scan_batch_coalescer.cpp
@@ -18,7 +18,37 @@
 
 #include "exec/try.hpp"
 #include "log/logging.hpp"
+#include "op/scan/sirius_gpu_scan_operator.hpp"
 #include "op/scan/sirius_gpu_scan_operator_data.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+
+namespace {
+
+/// Re-evaluate pipeline completion now that the source is exhausted.
+///
+/// `sirius_pipeline::update_pipeline_status()` finishes a pipeline only when
+/// source-exhaustion AND the balanced task counters hold *at the moment it
+/// runs*, so every event that can flip one of those conjuncts must be paired
+/// with a call. Task completion is paired via `mark_task_completed()`; closing
+/// the split connector is the source-exhaustion edge and was unpaired on the
+/// scan path. When the connector closes after the last task completed and after
+/// the last task-creation exit, nothing re-checked the condition: the pipeline
+/// stayed unfinished forever, so a downstream hash join gated on its
+/// `probe_finished` parked with build batches still in its ports and every
+/// engine thread went idle with the query never completing.
+///
+/// This must call update_pipeline_status() directly rather than going through
+/// task_creator::schedule(): a scheduled request is dropped whenever
+/// get_operator_for_next_task() returns null, and the re-evaluation inside the
+/// creation path would then never run. `sirius_physical_streaming_source` pairs
+/// its own channel close the same way.
+void notify_source_closed(sirius::op::scan::sirius_gpu_scan_operator* scan_op)
+{
+  if (scan_op == nullptr) { return; }
+  if (auto pipeline = scan_op->get_pipeline()) { pipeline->update_pipeline_status(false); }
+}
+
+}  // namespace
 
 #include <stop_token>
 #include <utility>
@@ -38,6 +68,7 @@ load_balancing_scan_batch_coalescer::register_pipeline(op::scan::sirius_gpu_scan
   auto pipeline_id = scan_op->get_pipeline()->get_pipeline_id();
   auto state       = std::make_unique<metadata_processing_state>(
     uid, pipeline_id, std::move(coalescer), std::move(connector), std::move(balancer));
+  state->scan_op = scan_op;
   _pipeline_order.push_back(uid);
   auto state_ptr = state.get();
   _slots[uid]    = std::move(state);
@@ -152,20 +183,24 @@ void load_balancing_scan_batch_coalescer::process_provider_inputs(metadata_proce
         emit(std::move(batch));
       }
       state.connector->close();
+      notify_source_closed(state.scan_op);
     } catch (...) {
       state.connector->close(std::current_exception());
+      notify_source_closed(state.scan_op);
     }
     return;
   }
 
   // Stop requested between iterations — close so downstream consumers unblock.
   state.connector->close();
+  notify_source_closed(state.scan_op);
 }
 
 void load_balancing_scan_batch_coalescer::process_cached_entries(metadata_processing_state& state,
                                                                  std::stop_token const& stop)
 {
   drain_cached_provider(*state.batch_provider, *state.connector, stop, state.row_filter_pending);
+  notify_source_closed(state.scan_op);
 }
 
 void load_balancing_scan_batch_coalescer::drain_cached_provider(databatch_provider& provider,


### PR DESCRIPTION
## Problem

Pipeline completion is a conjunction — source exhausted AND first node drained AND `tasks_created == tasks_completed` — that `update_pipeline_status()` only re-evaluates at call sites paired with those facts. Whichever fact flips **last** must trigger a re-check, or the pipeline never finishes.

Task completion is paired via `mark_task_completed()`. Closing the split connector is the source-exhaustion edge, and on the scan path it was **unpaired**: the close happens on the scan-manager thread ([`load_balancing_scan_batch_coalescer.cpp`](../blob/dev/src/scan_manager/load_balancing_scan_batch_coalescer.cpp)) and pokes neither call site.

When the connector closes *after* the last task completed and *after* the last task-creation exit, the conjunction is never re-tested. The pipeline stays unfinished forever; a downstream hash join gated on its `probe_finished` parks with build batches still resident, and every engine thread goes idle with the query never completing.

## Fix

Pair the edge with a direct `update_pipeline_status()` call at each `connector->close()` site.

This mirrors existing precedent — `sirius_physical_streaming_source` already pairs its own channel close exactly this way:

```cpp
if (_input_channel->closed()) { pipeline->update_pipeline_status(false); }
```

The call must be **direct** rather than routed through `task_creator::schedule()`: a scheduled request is dropped whenever `get_operator_for_next_task()` returns null, so the re-evaluation inside the creation path would never run. (I tried the scheduled version first; it did not help.)

## Verification

SF1000, 4x GB200, scan-from-disk, dynamic filter pushdown on:

| build | hangs |
|---|---|
| before | 6 / 18 (~33%) |
| with this fix alone | 2 / 20 (~10%) |

## Relationship to #1344

This closes one unpaired edge but **not** the whole class. sirius-db/sirius#1344 fixes another one (the dropped-request path in `task_creator::manager_loop`) and is what takes the hang rate to zero.

Being straight about the evidence: an ablation running as I write this — #1344 alone, without this change — is clean so far (17/25 at time of writing), which suggests #1344 may be sufficient on its own and this change is not load-bearing. I'll update this PR with the final number.

I'm proposing it anyway because it is a genuine missing pairing on its own terms, consistent with how `streaming_source` already handles the same edge, and because it independently cut the failure rate by a factor of three. But if reviewers prefer the minimal change, #1344 is the one that matters and this can be closed without loss.

The two are independent (different files, no overlap) and can land in either order.

Based on `2f6192af`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)