### PR TITLE
bench: label each query execution for quent telemetry

### DIFF
--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -390,6 +390,13 @@ def run_grouped(
                 try:
                     for it in range(iterations):
                         log(f"--- q{qnum} iter{it} engine={name} ---")
+                        if use_gpu:
+                            try:
+                                con.execute(
+                                    f"CALL sirius_set_query_label('q{qnum}_iter{it}')"
+                                ).fetchall()
+                            except Exception as e:
+                                log(f"  query label failed (non-fatal): {e}")
                         _run_one(
                             writer,
                             con,


### PR DESCRIPTION
`performance_test.py` never sets a query label, so quent captures show every execution as `unnamed_query` — a grouped-mode session with 22 queries × N iterations can only be attributed by execution order. This calls `sirius_set_query_label('q<N>_iter<i>')` before each GPU execution (non-fatal if the function is unavailable), making quent sessions navigable per query.

Used for all the quent DAG sessions behind #1349's analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)