### PR TITLE
RFC: downgraded-task input prefetcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,7 @@ set(EXTENSION_SOURCES
     src/op/sirius_physical_top_n.cpp
     src/op/sirius_physical_ungrouped_aggregate.cpp
     src/parallel/task_executor.cpp
+    src/pipeline/downgraded_task_prefetcher.cpp
     src/pipeline/gpu_pipeline_executor.cpp
     src/pipeline/gpu_pipeline_task.cpp
     src/pipeline/sirius_pipeline_itask.cpp
@@ -370,6 +371,7 @@ set(EXTENSION_SOURCES
     src/scan_manager/mvcc_mask_job.cpp
     src/scan_manager/pinned_chunk_stats.cpp
     src/scan_manager/round_robin_strategy.cpp
+    src/scan_manager/memory_prefetcher.cpp
     src/scan_manager/sirius_scan_manager.cpp
     src/scan_manager/split_connector.cpp
     src/scan_manager/split_provider.cpp
@@ -709,6 +711,7 @@ set(TEST_SOURCES
     test/cpp/planner/test_query_id.cpp
     test/cpp/planner/test_query_index.cpp
     test/cpp/pipeline/test_batch_lock_utils.cpp
+    test/cpp/pipeline/test_downgraded_task_prefetcher.cpp
     test/cpp/pipeline/test_gpu_pipeline_executor.cpp
     test/cpp/pipeline/test_oom_reschedule.cpp
     test/cpp/pipeline/test_pipeline_memory_history.cpp

--- a/src/include/exec/multi_index_priority_queue.hpp
+++ b/src/include/exec/multi_index_priority_queue.hpp
@@ -429,6 +429,30 @@ class multi_index_priority_queue {
     std::lock_guard<std::mutex> lock(_mutex);
     return _levels.empty();
   }
+
+  /// Visits every queued task in dispatch order (lowest priority level first,
+  /// FIFO within a level; reversed when @p front_to_back is false) without
+  /// removing anything. The visitor returns false to stop the walk early. Runs
+  /// under the queue mutex: the visitor must be lightweight and must not touch
+  /// the queue. Used by the downgraded-task prefetcher to snapshot the inputs
+  /// of soon-to-run tasks.
+  void for_each_mutable(const std::function<bool(Task&)>& visitor, bool front_to_back)
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (front_to_back) {
+      for (auto& [prio, lvl] : _levels) {
+        for (auto& n : lvl.tasks) {
+          if (!visitor(*n.task)) { return; }
+        }
+      }
+    } else {
+      for (auto it = _levels.rbegin(); it != _levels.rend(); ++it) {
+        for (auto n = it->second.tasks.rbegin(); n != it->second.tasks.rend(); ++n) {
+          if (!visitor(*n->task)) { return; }
+        }
+      }
+    }
+  }
   [[nodiscard]] std::size_t size() const
   {
     std::lock_guard<std::mutex> lock(_mutex);

--- a/src/include/pipeline/downgraded_task_prefetcher.hpp
+++ b/src/include/pipeline/downgraded_task_prefetcher.hpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "exec/multi_index_priority_queue.hpp"
+#include "memory/sirius_memory_reservation_manager.hpp"
+#include "parallel/task.hpp"
+
+#include <cucascade/memory/memory_space.hpp>
+#include <cucascade/memory/stream_pool.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace sirius::pipeline {
+
+/**
+ * @brief Background HOST/DISK->GPU upgrader for the inputs of queued pipeline tasks.
+ *
+ * Under memory pressure the downgrade executor spills the input batches of
+ * queued gpu_pipeline_tasks (and of repository batches that later become task
+ * inputs) to HOST or DISK. When such a task is finally dispatched, the upgrade
+ * back to GPU happens synchronously inside prepare_for_processing
+ * (lock_or_prepare_batch), serializing the H2D copy (or disk read) with the
+ * task's compute — the same copy/compute alternation the scan prefetcher
+ * eliminates for pinned-cache scan splits.
+ *
+ * This prefetcher overlaps the two: worker threads walk the pending tasks in
+ * dispatch order (the scheduler's matcher pops with pop_if(front_to_back=true),
+ * so the queue front is next to run) and convert their non-GPU-resident input
+ * batches back to GPU tier early, on dedicated streams, gated on GPU memory
+ * headroom. When the task later runs, prepare_for_processing finds the batch
+ * already GPU-resident and skips the upload.
+ *
+ * Races with a consumer (or with the downgrade executor) are arbitrated by the
+ * data_batch state machine: conversion goes through convertible_data_batch with
+ * blocking=false (try_to_mutable, skip on contention), and
+ * prepare_for_processing re-checks the tier under its own exclusive lock.
+ *
+ * Downgrade tug-of-war safety: the downgrade executor only fires under memory
+ * pressure (should_downgrade_memory), while this prefetcher only upgrades while
+ * at least min_free_fraction of the GPU space would remain free afterwards —
+ * the two regimes are disjoint by construction, so the prefetcher can never
+ * feed an eviction storm. Additionally the Tier-2 eviction search walks the
+ * queue back-to-front (farthest from dispatch), the opposite end from the one
+ * prefetched here.
+ *
+ * Unlike the scan prefetcher there is no drain guard: each dispatched task
+ * upgrades only its own few input batches (not a long shared queue of
+ * conversions), so lock contention with a preparing task at worst delays that
+ * task by the remainder of one in-flight conversion it would have had to
+ * perform itself anyway.
+ */
+class downgraded_task_prefetcher {
+ public:
+  struct config {
+    /// Number of prefetch worker threads (each with its own stream).
+    std::size_t num_threads{2};
+    /// Keep at least this fraction of the GPU space free after each upgrade.
+    double min_free_fraction{0.4};
+    /// Worker sweep interval while waiting for headroom / new tasks.
+    std::size_t poll_interval_ms{2};
+    /// Only prefetch inputs of the first this-many tasks in dispatch order.
+    /// Bounds the prefetched-but-unconsumed GPU footprint to what is about to
+    /// be consumed anyway — an unbounded walk under a small GPU budget fills
+    /// the space with queued-task inputs and starves the running pipeline.
+    std::size_t max_lookahead_tasks{4};
+    /// After observing memory pressure (downgrade trigger or floor breach),
+    /// stay idle until this long passes with no further pressure. Prevents the
+    /// downgrade<->prefetch bounce: right after an eviction frees memory the
+    /// instantaneous headroom looks fine, but the system is still pressured
+    /// and upgrading would hand batches straight back to the eviction path.
+    std::size_t pressure_quiet_ms{250};
+    /// EXPERIMENT: keep prefetching while the downgrade executor is actively
+    /// evicting (skips the should_downgrade/quiet-period gate; the per-batch
+    /// headroom floor still applies as the OOM guard). Safe only when eviction
+    /// victims and prefetch targets are order-disjoint (front-of-queue targets
+    /// vs back/last-consumed victims).
+    bool prefetch_during_pressure{false};
+  };
+
+  downgraded_task_prefetcher(config cfg,
+                             exec::multi_index_priority_queue<sirius::parallel::itask>& task_queue,
+                             sirius::memory::sirius_memory_reservation_manager& res_mgr,
+                             cucascade::memory::memory_space* gpu_space);
+
+  ~downgraded_task_prefetcher();
+
+  downgraded_task_prefetcher(const downgraded_task_prefetcher&)            = delete;
+  downgraded_task_prefetcher& operator=(const downgraded_task_prefetcher&) = delete;
+  downgraded_task_prefetcher(downgraded_task_prefetcher&&)                 = delete;
+  downgraded_task_prefetcher& operator=(downgraded_task_prefetcher&&)      = delete;
+
+  /// Request stop and join all workers. Idempotent.
+  void stop();
+
+  [[nodiscard]] std::size_t batches_prefetched() const
+  {
+    return _batches_prefetched.load(std::memory_order_relaxed);
+  }
+  [[nodiscard]] std::size_t bytes_prefetched() const
+  {
+    return _bytes_prefetched.load(std::memory_order_relaxed);
+  }
+
+ private:
+  void worker_loop();
+
+  /// Attempt one sweep over the queued tasks; returns the number of batches converted.
+  std::size_t sweep(rmm::cuda_stream_view stream);
+
+  config _config;
+  exec::multi_index_priority_queue<sirius::parallel::itask>& _task_queue;
+  sirius::memory::sirius_memory_reservation_manager& _res_mgr;
+  cucascade::memory::memory_space* _gpu_space;
+  /// Single-element target list passed to convertible_data_batch::convert.
+  std::vector<const cucascade::memory::memory_space*> _targets;
+
+  /// Dedicated streams so prefetch copies never share a stream with pipeline
+  /// task work.
+  std::unique_ptr<cucascade::memory::exclusive_stream_pool> _stream_pool;
+
+  /// steady_clock ms timestamp of the last observed memory pressure; sweeps
+  /// stay idle until pressure_quiet_ms elapse with no pressure.
+  std::atomic<std::int64_t> _last_pressure_ms{0};
+
+  std::atomic<bool> _running{true};
+  std::atomic<std::size_t> _batches_prefetched{0};
+  std::atomic<std::size_t> _bytes_prefetched{0};
+  /// Per-source-tier counts, for post-run analysis of what was upgraded.
+  std::atomic<std::size_t> _host_batches{0};
+  std::atomic<std::size_t> _disk_batches{0};
+  std::vector<std::thread> _workers;
+};
+
+}  // namespace sirius::pipeline

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -22,6 +22,7 @@
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "parallel/task.hpp"
 #include "pipeline/completion_handler.hpp"
+#include "pipeline/downgraded_task_prefetcher.hpp"
 #include "pipeline/gpu_pipeline_executor.hpp"
 #include "pipeline/task_request.hpp"
 #include "planner/query.hpp"
@@ -215,6 +216,11 @@ class task_scheduler {
  private:
   void management_eventloop();
 
+  /// Build and start the HOST/DISK->GPU input prefetcher for queued tasks when
+  /// enabled via SIRIUS_TASK_PREFETCH=1 (see downgraded_task_prefetcher.hpp).
+  /// No-op otherwise.
+  void maybe_start_downgraded_task_prefetcher();
+
   std::mutex _query_mutex;
   duckdb::shared_ptr<planner::query> _query;
 
@@ -242,6 +248,13 @@ class task_scheduler {
   /// arises from which executor sends a device_ready signal first, not from a
   /// counter. Field retained for source compat with set_no_pref_rr_counter_for_testing.
   std::atomic<size_t> _no_pref_rr_counter{0};
+
+  /// For resolving the GPU memory space and reservations of the downgraded-task
+  /// prefetcher (started in start() when SIRIUS_TASK_PREFETCH=1).
+  sirius::memory::sirius_memory_reservation_manager& _mem_mgr;
+  /// Background HOST/DISK->GPU upgrader for queued tasks' downgraded inputs;
+  /// stopped first in stop() so no conversion is in flight during teardown.
+  std::unique_ptr<downgraded_task_prefetcher> _task_prefetcher;
 
   sirius::creator::task_creator* _task_creator{nullptr};
   std::unique_ptr<completion_handler> _completion_handler;

--- a/src/pipeline/downgraded_task_prefetcher.cpp
+++ b/src/pipeline/downgraded_task_prefetcher.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "pipeline/downgraded_task_prefetcher.hpp"
+
+#include "data/convertible_data_batch.hpp"
+#include "data/convertible_gpu_pipeline_task.hpp"
+#include "log/logging.hpp"
+
+#include <cuda_runtime_api.h>
+
+#include <cucascade/data/data_batch.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <exception>
+
+namespace sirius::pipeline {
+
+downgraded_task_prefetcher::downgraded_task_prefetcher(
+  config cfg,
+  exec::multi_index_priority_queue<sirius::parallel::itask>& task_queue,
+  sirius::memory::sirius_memory_reservation_manager& res_mgr,
+  cucascade::memory::memory_space* gpu_space)
+  : _config(cfg), _task_queue(task_queue), _res_mgr(res_mgr), _gpu_space(gpu_space)
+{
+  if (_gpu_space == nullptr) {
+    _running.store(false);
+    return;
+  }
+  _targets.push_back(_gpu_space);
+  _stream_pool = std::make_unique<cucascade::memory::exclusive_stream_pool>(
+    rmm::cuda_device_id{_gpu_space->get_device_id()}, _config.num_threads);
+  _workers.reserve(_config.num_threads);
+  for (std::size_t i = 0; i < _config.num_threads; ++i) {
+    _workers.emplace_back([this] { worker_loop(); });
+  }
+  SIRIUS_LOG_INFO("[task_prefetch] started: {} threads, min_free_fraction={:.2f}",
+                  _config.num_threads,
+                  _config.min_free_fraction);
+}
+
+downgraded_task_prefetcher::~downgraded_task_prefetcher() { stop(); }
+
+void downgraded_task_prefetcher::stop()
+{
+  bool expected = true;
+  if (_running.compare_exchange_strong(expected, false)) {
+    SIRIUS_LOG_INFO("[task_prefetch] stopping: upgraded {} batches / {} bytes ({} host, {} disk)",
+                    _batches_prefetched.load(),
+                    _bytes_prefetched.load(),
+                    _host_batches.load(),
+                    _disk_batches.load());
+  }
+  for (auto& worker : _workers) {
+    if (worker.joinable()) { worker.join(); }
+  }
+  _workers.clear();
+}
+
+void downgraded_task_prefetcher::worker_loop()
+{
+  // Bind the worker to the target GPU so conversions allocate on the right
+  // device context (the prefetcher is single-GPU scoped, but the process
+  // default device is not guaranteed to match).
+  cudaError_t err = cudaSetDevice(_gpu_space->get_device_id());
+  if (err != cudaSuccess) {
+    SIRIUS_LOG_ERROR("[task_prefetch] worker init: cudaSetDevice({}) failed: {}",
+                     _gpu_space->get_device_id(),
+                     cudaGetErrorString(err));
+    return;
+  }
+  auto stream = _stream_pool->acquire_stream();
+  while (_running.load(std::memory_order_relaxed)) {
+    std::size_t converted = 0;
+    try {
+      converted = sweep(stream.get());
+    } catch (const std::exception& e) {
+      SIRIUS_LOG_WARN("[task_prefetch] sweep error (backing off): {}", e.what());
+    }
+
+    if (!_running.load(std::memory_order_relaxed)) { break; }
+
+    if (converted == 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(_config.poll_interval_ms));
+    }
+  }
+}
+
+std::size_t downgraded_task_prefetcher::sweep(rmm::cuda_stream_view stream)
+{
+  std::size_t converted     = 0;
+  const auto max_memory     = _gpu_space->get_max_memory();
+  const auto min_free_bytes = static_cast<std::size_t>(_config.min_free_fraction * max_memory);
+  // get_available_memory() can exceed get_max_memory() when the usage limit is
+  // larger than the reservation limit; cap it so the floor fraction is always
+  // relative to the same (reservable) budget the conversions draw from.
+  const auto available = [&] { return std::min(_gpu_space->get_available_memory(), max_memory); };
+  const auto now_ms    = [] {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+  };
+  // Pressure check with hysteresis: any pressure observation (downgrade
+  // trigger or floor breach) idles the prefetcher until pressure_quiet_ms of
+  // continuous calm. The instantaneous headroom right after an eviction looks
+  // fine, but upgrading then would hand batches straight back to the eviction
+  // path (observed as a downgrade<->prefetch bounce under small GPU budgets).
+  const auto under_pressure = [&] {
+    if (_gpu_space->should_downgrade_memory() || available() < min_free_bytes) {
+      _last_pressure_ms.store(now_ms(), std::memory_order_relaxed);
+      return true;
+    }
+    const auto last = _last_pressure_ms.load(std::memory_order_relaxed);
+    return last != 0 && now_ms() - last < static_cast<std::int64_t>(_config.pressure_quiet_ms);
+  };
+
+  if (!_config.prefetch_during_pressure && under_pressure()) { return 0; }
+  if (_config.prefetch_during_pressure && available() < min_free_bytes) { return 0; }
+  if (_task_queue.empty()) { return 0; }
+
+  // Snapshot the input batches of the next max_lookahead_tasks pending tasks
+  // in dispatch order (the scheduler's matcher pops with
+  // pop_if(front_to_back=true), so the front of the queue is the next task to
+  // run). The lookahead bound keeps the prefetched-but-unconsumed footprint
+  // proportional to imminent work. shared_ptr copies only — the visitor runs
+  // under the queue mutex and must stay lightweight.
+  std::vector<std::shared_ptr<cucascade::data_batch>> candidates;
+  std::size_t tasks_seen = 0;
+  _task_queue.for_each_mutable(
+    [&candidates, &tasks_seen, this](sirius::parallel::itask& task) {
+      auto* operator_data = convertible_gpu_pipeline_task::get_pipelineable_data(task);
+      if (operator_data == nullptr) { return true; }
+      for (const auto& batch : operator_data->get_data_batches()) {
+        if (batch) { candidates.push_back(batch); }
+      }
+      return ++tasks_seen < _config.max_lookahead_tasks;
+    },
+    /*front_to_back=*/true);
+
+  for (const auto& batch : candidates) {
+    if (!_running.load(std::memory_order_relaxed)) { return converted; }
+
+    // Cheap pre-check under a shared lock; skip GPU-resident or busy batches
+    // (a busy batch is being handled by its task or by the downgrade executor).
+    std::size_t batch_bytes = 0;
+    auto source_tier        = cucascade::memory::Tier::GPU;
+    {
+      auto ro = batch->try_to_read_only();
+      if (!ro || ro->get_data() == nullptr ||
+          ro->get_current_tier() == cucascade::memory::Tier::GPU) {
+        continue;
+      }
+      batch_bytes = ro->get_data()->get_size_in_bytes();
+      source_tier = ro->get_current_tier();
+    }
+
+    // Headroom gate: never let prefetched bytes push the space below the free
+    // floor (or into the downgrade trigger — that would hand the batch right
+    // back to the eviction path). Later candidates belong to tasks at least as
+    // far from dispatch, so stop the whole sweep and retry after tasks free
+    // memory.
+    if (!_config.prefetch_during_pressure && under_pressure()) { return converted; }
+    if (available() < batch_bytes + min_free_bytes) { return converted; }
+
+    // convertible_data_batch handles try_to_mutable (skip on contention), the
+    // GPU reservation, the conversion, and idle-state restore on all paths.
+    sirius::convertible_data_batch upgrader(batch);
+    auto result = upgrader.convert(_targets, stream, _res_mgr, /*blocking=*/false);
+    if (!result) { continue; }
+
+    ++converted;
+    _batches_prefetched.fetch_add(1, std::memory_order_relaxed);
+    _bytes_prefetched.fetch_add(batch_bytes, std::memory_order_relaxed);
+    if (source_tier == cucascade::memory::Tier::DISK) {
+      _disk_batches.fetch_add(1, std::memory_order_relaxed);
+    } else {
+      _host_batches.fetch_add(1, std::memory_order_relaxed);
+    }
+    SIRIUS_LOG_DEBUG("[task_prefetch] upgraded batch {} ({} bytes, from {}) ahead of dispatch",
+                     batch->get_batch_id(),
+                     batch_bytes,
+                     source_tier == cucascade::memory::Tier::DISK ? "DISK" : "HOST");
+  }
+  return converted;
+}
+
+}  // namespace sirius::pipeline

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -35,10 +35,12 @@
 #include <cucascade/memory/memory_space.hpp>
 
 #include <algorithm>
+#include <cstdlib>
 #include <limits>
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -78,6 +80,7 @@ task_scheduler::task_scheduler(
                               0,
                               exec::no_preferred_device};
     }),
+    _mem_mgr(mem_mgr),
     _telemetry_context(std::move(telemetry_context))
 {
   _task_queue_telemetry = std::make_unique<telemetry::TaskQueueHandleWrapper>(
@@ -150,12 +153,55 @@ void task_scheduler::start()
     gpu_exec->start();
   }
   _management_thread = std::thread(&task_scheduler::management_eventloop, this);
+  maybe_start_downgraded_task_prefetcher();
+}
+
+void task_scheduler::maybe_start_downgraded_task_prefetcher()
+{
+  const char* enabled = std::getenv("SIRIUS_TASK_PREFETCH");
+  if (enabled == nullptr || std::string_view{enabled} != "1") { return; }
+
+  // Prototype scope: a single GPU space, mirroring the scan prefetcher.
+  // Multi-GPU needs per-task preferred-device routing to pick the target
+  // space; converting to the wrong space would strand data cross-device.
+  auto gpu_spaces = _mem_mgr.get_memory_spaces_for_tier(cucascade::memory::Tier::GPU);
+  if (gpu_spaces.size() != 1) {
+    SIRIUS_LOG_WARN("[task_prefetch] disabled: prototype supports exactly 1 GPU space (found {})",
+                    gpu_spaces.size());
+    return;
+  }
+  auto* gpu_space =
+    _mem_mgr.get_memory_space(cucascade::memory::Tier::GPU, gpu_spaces.front()->get_device_id());
+  if (gpu_space == nullptr) { return; }
+
+  downgraded_task_prefetcher::config cfg{};
+  if (const char* threads = std::getenv("SIRIUS_TASK_PREFETCH_THREADS")) {
+    cfg.num_threads = std::max(1UL, std::strtoul(threads, nullptr, 10));
+  }
+  if (const char* frac = std::getenv("SIRIUS_TASK_PREFETCH_MIN_FREE_FRACTION")) {
+    cfg.min_free_fraction = std::clamp(std::strtod(frac, nullptr), 0.05, 0.95);
+  }
+  if (const char* lookahead = std::getenv("SIRIUS_TASK_PREFETCH_LOOKAHEAD")) {
+    cfg.max_lookahead_tasks = std::max(1UL, std::strtoul(lookahead, nullptr, 10));
+  }
+  if (const char* during = std::getenv("SIRIUS_TASK_PREFETCH_DURING_PRESSURE")) {
+    cfg.prefetch_during_pressure = std::string_view{during} == "1";
+  }
+  if (const char* quiet = std::getenv("SIRIUS_TASK_PREFETCH_QUIET_MS")) {
+    cfg.pressure_quiet_ms = std::strtoul(quiet, nullptr, 10);
+  }
+
+  _task_prefetcher =
+    std::make_unique<downgraded_task_prefetcher>(cfg, _task_queue, _mem_mgr, gpu_space);
 }
 
 void task_scheduler::stop()
 {
   bool expected = true;
   if (!_running.compare_exchange_strong(expected, false)) { return; }
+  // Stop the prefetcher first: its workers hold references to queued tasks'
+  // batches and must not start conversions while teardown drains the queue.
+  _task_prefetcher.reset();
   // Pull-signal model: the management event loop blocks on
   // _task_request_channel.get(), so closing the channel is what wakes it.
   // _task_queue.interrupt() is still useful to reject any concurrent

--- a/test/cpp/pipeline/test_downgraded_task_prefetcher.cpp
+++ b/test/cpp/pipeline/test_downgraded_task_prefetcher.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "operator/operator_test_utils.hpp"
+
+#include <rmm/cuda_stream.hpp>
+
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/memory/common.hpp>
+#include <cucascade/memory/memory_space.hpp>
+#include <data/convertible_data_batch.hpp>
+#include <exec/multi_index_priority_queue.hpp>
+#include <op/sirius_physical_operator.hpp>
+#include <parallel/task.hpp>
+#include <pipeline/downgraded_task_prefetcher.hpp>
+#include <pipeline/gpu_pipeline_task.hpp>
+#include <pipeline/sirius_pipeline_task_states.hpp>
+#include <utils/telemetry_utils.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+
+// Shared test environment: initialize memory manager once for all tests in this
+// file (mirrors test_convertible_gpu_pipeline_task.cpp).
+struct test_env {
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> mgr;
+  cucascade::memory::memory_space* gpu_space;
+  cucascade::memory::memory_space* host_space;
+  rmm::cuda_stream conv_stream;
+
+  test_env()
+    : mgr(sirius::test::operator_utils::initialize_memory_manager()),
+      gpu_space(mgr->get_memory_space(cucascade::memory::Tier::GPU, 0)),
+      host_space(mgr->get_memory_space(cucascade::memory::Tier::HOST, 0)),
+      conv_stream()
+  {
+  }
+
+  rmm::cuda_stream_view stream() { return conv_stream.view(); }
+};
+
+test_env& env()
+{
+  static test_env e;
+  return e;
+}
+
+/// Minimal dummy task that is NOT a gpu_pipeline_task — the prefetcher must skip it.
+class dummy_task_local_state : public sirius::parallel::itask_local_state {};
+class dummy_task : public sirius::parallel::itask {
+ public:
+  dummy_task() : itask(0, std::make_unique<dummy_task_local_state>(), nullptr) {}
+  void execute(rmm::cuda_stream_view /*stream*/) override {}
+};
+
+/// Helper: create a gpu_pipeline_task with the given data batches (idle state).
+std::unique_ptr<sirius::pipeline::gpu_pipeline_task> make_test_gpu_task(
+  uint64_t task_id, std::vector<std::shared_ptr<cucascade::data_batch>> batches)
+{
+  auto op_data = std::make_unique<sirius::op::pipelineable_operator_data>(std::move(batches));
+  auto local =
+    std::make_unique<sirius::pipeline::gpu_pipeline_task_local_state>(std::move(op_data));
+  auto global = std::make_shared<sirius::pipeline::gpu_pipeline_task_global_state>(
+    nullptr, sirius::test::make_test_telemetry_context());
+
+  return std::make_unique<sirius::pipeline::gpu_pipeline_task>(
+    task_id,
+    std::vector<cucascade::shared_data_repository*>{},
+    std::move(local),
+    std::move(global));
+}
+
+/// Helper: make a batch that is resident on the HOST tier (created on GPU, then
+/// downgraded — the same path the downgrade executor takes).
+std::shared_ptr<cucascade::data_batch> make_host_batch(test_env& e,
+                                                       std::vector<int32_t> values = {1, 2, 3})
+{
+  auto batch = sirius::test::operator_utils::make_numeric_batch(
+    *e.gpu_space, std::move(values), cudf::type_id::INT32);
+  sirius::convertible_data_batch downgrader(batch);
+  auto result = downgrader.convert({e.host_space}, e.stream(), *e.mgr, /*blocking=*/true);
+  REQUIRE(result.has_value());
+  return batch;
+}
+
+inline cucascade::memory::Tier get_batch_tier(cucascade::data_batch& batch)
+{
+  auto ro = batch.to_read_only();
+  return ro.get_memory_space()->get_tier();
+}
+
+/// Poll until the prefetcher reports @p n upgraded batches, or 5s elapse.
+bool wait_for_prefetched(sirius::pipeline::downgraded_task_prefetcher& p, std::size_t n)
+{
+  const auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (p.batches_prefetched() >= n) { return true; }
+    std::this_thread::sleep_for(2ms);
+  }
+  return p.batches_prefetched() >= n;
+}
+
+}  // anonymous namespace
+
+TEST_CASE("prefetcher upgrades HOST input of queued task to GPU", "[downgraded_task_prefetcher]")
+{
+  auto& e = env();
+
+  sirius::exec::multi_index_priority_queue<sirius::parallel::itask> queue(
+    [](const sirius::parallel::itask&) {
+      return sirius::exec::index_keys{
+        0, sirius::op::SiriusPhysicalOperatorType::INVALID, 0, sirius::exec::no_preferred_device};
+    });
+  auto batch = make_host_batch(e);
+  REQUIRE(get_batch_tier(*batch) == cucascade::memory::Tier::HOST);
+  queue.push((make_test_gpu_task(1, {batch})));
+
+  sirius::pipeline::downgraded_task_prefetcher::config cfg{};
+  cfg.num_threads       = 1;
+  cfg.min_free_fraction = 0.05;
+  sirius::pipeline::downgraded_task_prefetcher prefetcher(cfg, queue, *e.mgr, e.gpu_space);
+
+  REQUIRE(wait_for_prefetched(prefetcher, 1));
+  prefetcher.stop();
+
+  // The batch is back on GPU, idle, and the task never left the queue.
+  REQUIRE(get_batch_tier(*batch) == cucascade::memory::Tier::GPU);
+  REQUIRE(batch->get_state() == cucascade::batch_state::idle);
+  REQUIRE(queue.size() == 1);
+  REQUIRE(prefetcher.bytes_prefetched() > 0);
+}
+
+TEST_CASE("prefetcher upgrades multiple queued tasks in dispatch order",
+          "[downgraded_task_prefetcher]")
+{
+  auto& e = env();
+
+  sirius::exec::multi_index_priority_queue<sirius::parallel::itask> queue(
+    [](const sirius::parallel::itask&) {
+      return sirius::exec::index_keys{
+        0, sirius::op::SiriusPhysicalOperatorType::INVALID, 0, sirius::exec::no_preferred_device};
+    });
+  std::vector<std::shared_ptr<cucascade::data_batch>> batches;
+  for (int i = 0; i < 3; ++i) {
+    auto batch = make_host_batch(e, {i, i + 1, i + 2});
+    batches.push_back(batch);
+    queue.push((make_test_gpu_task(i + 1, {batch})));
+  }
+
+  sirius::pipeline::downgraded_task_prefetcher::config cfg{};
+  cfg.num_threads       = 1;
+  cfg.min_free_fraction = 0.05;
+  sirius::pipeline::downgraded_task_prefetcher prefetcher(cfg, queue, *e.mgr, e.gpu_space);
+
+  REQUIRE(wait_for_prefetched(prefetcher, 3));
+  prefetcher.stop();
+
+  for (auto& batch : batches) {
+    REQUIRE(get_batch_tier(*batch) == cucascade::memory::Tier::GPU);
+    REQUIRE(batch->get_state() == cucascade::batch_state::idle);
+  }
+  REQUIRE(queue.size() == 3);
+}
+
+TEST_CASE("prefetcher leaves GPU-resident inputs alone", "[downgraded_task_prefetcher]")
+{
+  auto& e = env();
+
+  sirius::exec::multi_index_priority_queue<sirius::parallel::itask> queue(
+    [](const sirius::parallel::itask&) {
+      return sirius::exec::index_keys{
+        0, sirius::op::SiriusPhysicalOperatorType::INVALID, 0, sirius::exec::no_preferred_device};
+    });
+  auto batch = sirius::test::operator_utils::make_numeric_batch(
+    *e.gpu_space, std::vector<int32_t>{1, 2, 3}, cudf::type_id::INT32);
+  queue.push((make_test_gpu_task(1, {batch})));
+
+  sirius::pipeline::downgraded_task_prefetcher::config cfg{};
+  cfg.num_threads       = 1;
+  cfg.min_free_fraction = 0.05;
+  sirius::pipeline::downgraded_task_prefetcher prefetcher(cfg, queue, *e.mgr, e.gpu_space);
+
+  std::this_thread::sleep_for(100ms);
+  prefetcher.stop();
+
+  REQUIRE(prefetcher.batches_prefetched() == 0);
+  REQUIRE(get_batch_tier(*batch) == cucascade::memory::Tier::GPU);
+}
+
+TEST_CASE("headroom floor blocks prefetch", "[downgraded_task_prefetcher]")
+{
+  auto& e = env();
+
+  sirius::exec::multi_index_priority_queue<sirius::parallel::itask> queue(
+    [](const sirius::parallel::itask&) {
+      return sirius::exec::index_keys{
+        0, sirius::op::SiriusPhysicalOperatorType::INVALID, 0, sirius::exec::no_preferred_device};
+    });
+  auto batch = make_host_batch(e);
+  queue.push((make_test_gpu_task(1, {batch})));
+
+  sirius::pipeline::downgraded_task_prefetcher::config cfg{};
+  cfg.num_threads = 1;
+  // available <= max_memory always, so a floor of the full space blocks every upgrade.
+  cfg.min_free_fraction = 1.0;
+  sirius::pipeline::downgraded_task_prefetcher prefetcher(cfg, queue, *e.mgr, e.gpu_space);
+
+  std::this_thread::sleep_for(100ms);
+  prefetcher.stop();
+
+  REQUIRE(prefetcher.batches_prefetched() == 0);
+  REQUIRE(get_batch_tier(*batch) == cucascade::memory::Tier::HOST);
+}
+
+TEST_CASE("busy batch is skipped, then picked up once released", "[downgraded_task_prefetcher]")
+{
+  auto& e = env();
+
+  sirius::exec::multi_index_priority_queue<sirius::parallel::itask> queue(
+    [](const sirius::parallel::itask&) {
+      return sirius::exec::index_keys{
+        0, sirius::op::SiriusPhysicalOperatorType::INVALID, 0, sirius::exec::no_preferred_device};
+    });
+  auto batch = make_host_batch(e);
+  queue.push((make_test_gpu_task(1, {batch})));
+
+  // Hold the exclusive lock: the prefetcher's try_to_mutable must skip.
+  auto exclusive_lock = std::make_optional(batch->to_mutable());
+
+  sirius::pipeline::downgraded_task_prefetcher::config cfg{};
+  cfg.num_threads       = 1;
+  cfg.min_free_fraction = 0.05;
+  sirius::pipeline::downgraded_task_prefetcher prefetcher(cfg, queue, *e.mgr, e.gpu_space);
+
+  std::this_thread::sleep_for(100ms);
+  REQUIRE(prefetcher.batches_prefetched() == 0);
+
+  // Release the lock — the next sweep should convert it.
+  exclusive_lock.reset();
+  REQUIRE(wait_for_prefetched(prefetcher, 1));
+  prefetcher.stop();
+
+  REQUIRE(get_batch_tier(*batch) == cucascade::memory::Tier::GPU);
+}
+
+TEST_CASE("non-gpu_pipeline_task entries are tolerated", "[downgraded_task_prefetcher]")
+{
+  auto& e = env();
+
+  sirius::exec::multi_index_priority_queue<sirius::parallel::itask> queue(
+    [](const sirius::parallel::itask&) {
+      return sirius::exec::index_keys{
+        0, sirius::op::SiriusPhysicalOperatorType::INVALID, 0, sirius::exec::no_preferred_device};
+    });
+  queue.push((std::make_unique<dummy_task>()));
+  auto batch = make_host_batch(e);
+  queue.push((make_test_gpu_task(1, {batch})));
+
+  sirius::pipeline::downgraded_task_prefetcher::config cfg{};
+  cfg.num_threads       = 1;
+  cfg.min_free_fraction = 0.05;
+  sirius::pipeline::downgraded_task_prefetcher prefetcher(cfg, queue, *e.mgr, e.gpu_space);
+
+  REQUIRE(wait_for_prefetched(prefetcher, 1));
+  prefetcher.stop();
+
+  REQUIRE(get_batch_tier(*batch) == cucascade::memory::Tier::GPU);
+  REQUIRE(queue.size() == 2);
+}


### PR DESCRIPTION
Note: Not sure if this is a good approach yet or if we should find a way to fold this into the memory_prefetcher since they would almost always be leveraging the same i/o path, host to device.

## What

The memory-prefetcher concept (#1181) applied to the other host→GPU path: inputs of **queued pipeline tasks** that were downgraded to HOST/DISK get converted back to GPU tier ahead of dispatch, instead of synchronously inside `prepare_for_processing`. Workers walk the task queue in dispatch order (mirroring the scheduler's `pop_if(front_to_back=true)`) via a new `inspectable_mpsc::for_each_mutable` visitor, and upgrade through the downgrade path's own `convertible_data_batch` (non-blocking lock, reservation-backed, RAII idle-restore). Env-gated off (`SIRIUS_TASK_PREFETCH=1`); single-GPU scope; 6-case Catch2 suite.

Two safety mechanisms, both empirically required on GB300/SF1000:
- **Pressure-quiet hysteresis** (250 ms): without it, the prefetcher re-upgrades batches the downgrade executor just evicted and can wedge the engine at the memory budget under constrained GPU configs (reproduced and fixed during development).
- **Dispatch-order lookahead cap** (4 tasks): bounds the non-reclaimable prefetched footprint.

## Honest evaluation — why RFC/draft

- At the standard 0.95 GPU budget, q9/q21 at SF1000 never downgrade on current dev (zero downgrade events at debug level) — the prefetcher is a verified no-op there.
- Under an artificially constrained budget (0.4), it stages 15-20 GB/query correctly with byte-identical results and unchanged downgrade counts, but hot timings are **neutral**: the calm windows in which it may act don't overlap the downgrade traffic it would need to hide.
- The motivating regime is genuinely oversized workloads — disk-spill readback through the serialized `pipeline_io_backend` — which this box's HBM can't produce at SF1K. Parking as draft until such a workload validates (or falsifies) the win.

Note: branch is based on dev@3ee47f8b and needs a rebase before any serious review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)