### PR TITLE
TPC-H harness: SIRIUS_PRE_SQL hook + per-table pin-tier overrides

### DIFF
--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -295,6 +295,10 @@ def open_connection(source, gpu_execution=False, data_source="parquet"):
         log(f"Loading Sirius extension from {EXTENSION_PATH}")
         con.execute(f"LOAD '{EXTENSION_PATH}'")
         log("Sirius extension loaded")
+        pre_sql = os.environ.get("SIRIUS_PRE_SQL", "")
+        if pre_sql:
+            log(f"Executing SIRIUS_PRE_SQL: {pre_sql}")
+            _execute_multi(con, pre_sql)
     return con
 
 

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -539,6 +539,10 @@ def _build_nsys_temp_sql(qnum, source, iterations, pin, qdir, data_source="parqu
         parts.append(_build_views_sql(source).rstrip("\n"))
     parts.append("INSERT INTO _timings VALUES (1, 'views', current_timestamp);")
 
+    pre_sql = os.environ.get("SIRIUS_PRE_SQL", "").strip()
+    if pre_sql:
+        parts.append(pre_sql.rstrip(";") + ";")
+
     if pin != "none":
         parts.append(emit_pin(qnum, source, data_source))
 

--- a/test/tpch_performance/tpch_pin_columns.py
+++ b/test/tpch_performance/tpch_pin_columns.py
@@ -270,7 +270,9 @@ def _pin_call(table: str, cols: list[str], source: str, data_source: str) -> str
     duckdb:  no positional path — the table is named by 'name' and resolved from
              the attached catalog; the source is selected with format='duckdb'.
     """
-    tier = os.environ.get("SIRIUS_PIN_TIER", "gpu")
+    tier = os.environ.get(
+        f"SIRIUS_PIN_TIER_{table.upper()}", os.environ.get("SIRIUS_PIN_TIER", "gpu")
+    )
     col_literals = ",".join(f"'{c}'" for c in cols)
     if data_source == "duckdb":
         return (


### PR DESCRIPTION
Two ~4-line hooks in the TPC-H performance harness that make compressed and mixed-tier pinning experiments runnable without harness edits:

- **`SIRIUS_PRE_SQL`** (performance_test.py): semicolon-separated SQL executed right after `LOAD`, e.g. `SET pin_table_compression = true; SET pin_table_input_compression_plan_dir = '...'`.
- **`SIRIUS_PIN_TIER_<TABLE>`** (tpch_pin_columns.py): per-table override of the global `SIRIUS_PIN_TIER`, so one run can pin `lineitem` to `gpu` and `partsupp` to `host`.

Used to produce the GB300 SF1000 results in the compressed-pinning docs PR (baseline 20.74 s → 16.66 s hot with lineitem+orders GPU-pinned compressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)