### PR TITLE
Zero-copy scan materialize for per-query converted pinned chunks

### DIFF
--- a/src/include/op/scan/sirius_gpu_scan_operator_data.hpp
+++ b/src/include/op/scan/sirius_gpu_scan_operator_data.hpp
@@ -146,6 +146,22 @@ class scan_operator_input : public op::operator_data {
   /// copy). Stamped by drain_cached_provider on resident splits; scan_info
   /// splits fold filter costs into their own estimates instead.
   bool row_filter_pending{false};
+  /// Per-query table taken out of the cached wrapper batch right after
+  /// prepare_for_processing's conversion produced it (decompressed or
+  /// uploaded fresh for this split) — never raw GPU pin storage, which is
+  /// served as a plain gpu_table_representation and never converted.
+  /// Consumed at most once by materialize_table, which moves it into the
+  /// scan output instead of deep-copying the batch. Mutable: the operator
+  /// only sees its input as const during execute.
+  mutable std::unique_ptr<cudf::table> stolen_table;
+  /// Size of the stolen table, kept past consumption so OOM-retry size
+  /// estimates stay accurate while the wrapper batch holds only an empty
+  /// placeholder.
+  std::size_t stolen_table_bytes{0};
+  /// Set when materialize_table consumes the stolen table. A re-entry after
+  /// consumption (scan-internal OOM retry) must fail loudly rather than
+  /// serve the emptied wrapper batch as zero rows.
+  mutable bool stolen_table_consumed{false};
 };
 
 }  // namespace sirius::op::scan

--- a/src/op/scan/gpu_ingestible.cpp
+++ b/src/op/scan/gpu_ingestible.cpp
@@ -53,6 +53,19 @@ filtered_table gpu_ingestible::materialize_table(const op::scan::scan_operator_i
     }
     return materialized;
   } else {
+    if (split.stolen_table) {
+      // prepare_for_processing took ownership of the wrapper batch's per-query
+      // table; move it straight into the scan output — the owned-table
+      // owning_table_view releases by moving columns, so no copy is made.
+      split.stolen_table_consumed = true;
+      return {.table = owning_table_view{std::move(split.stolen_table)},
+              .state = filter_state::UNFILTERED};
+    }
+    if (split.stolen_table_consumed) {
+      throw std::runtime_error(
+        "[gpu_ingestible::materialize_table] the split's stolen table was already consumed; "
+        "refusing to re-materialize from the emptied wrapper batch");
+    }
     auto batch  = split.get_cached_batch();
     auto rbatch = batch->to_read_only();
     auto view   = get_cudf_table_view(rbatch);

--- a/src/op/scan/sirius_gpu_scan_operator_data.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator_data.cpp
@@ -15,11 +15,14 @@
  */
 
 // sirius
+#include <cudf/table/table.hpp>
+
 #include <cucascade/cudf/gpu_data_representation.hpp>
 #include <data/sirius_converter_registry.hpp>
 #include <op/scan/sirius_gpu_scan_operator_data.hpp>
 
 #include <algorithm>
+#include <memory>
 
 namespace sirius::op::scan {
 
@@ -33,7 +36,7 @@ void scan_operator_input::prepare_for_processing(
   }
   auto batch = std::get<std::shared_ptr<cucascade::data_batch>>(materialization_info);
 
-  if (batch && requested_memory_space) {
+  if (batch && requested_memory_space && !stolen_table && !stolen_table_consumed) {
     bool needs_upload = false;
     {
       auto ro          = batch->to_read_only();
@@ -51,6 +54,24 @@ void scan_operator_input::prepare_for_processing(
       auto mut       = batch->to_mutable();
       mut.convert_to<::cucascade::gpu_table_representation>(
         registry, requested_memory_space, stream);
+      // The conversion output is a fresh per-query table (raw GPU pins serve a
+      // plain gpu_table_representation and never reach this branch), so an
+      // unmasked, unfiltered scan may take ownership of it here instead of
+      // deep-copying it at materialize. Masked / row-filtered splits keep the
+      // view path: they filter by copy and need the source view alive — and
+      // skipping them means the scan allocates nothing after the take, so an
+      // OOM retry can never re-enter materialize on a consumed split.
+      if (!mvcc_keep_mask.has_mask() && !row_filter_pending) {
+        if (auto* gpu_rep = dynamic_cast<::cucascade::gpu_table_representation*>(mut.get_data())) {
+          auto& space        = gpu_rep->get_memory_space();
+          stolen_table_bytes = gpu_rep->get_size_in_bytes();
+          stolen_table       = gpu_rep->release_table(stream);
+          // The batch cannot hold null data and its size/view queries
+          // dereference the table, so leave a valid empty placeholder.
+          mut.set_data(std::make_unique<::cucascade::gpu_table_representation>(
+            std::make_unique<cudf::table>(), space, rmm::cuda_stream_view{}));
+        }
+      }
     }
   }
 
@@ -66,6 +87,10 @@ std::size_t scan_operator_input::get_estimated_size_in_bytes() const
     return std::get<std::unique_ptr<scan_info>>(materialization_info)->estimated_bytes();
   }
   if (std::holds_alternative<std::shared_ptr<cucascade::data_batch>>(materialization_info)) {
+    // Once prepare_for_processing has taken the wrapper's table the batch only
+    // holds an empty placeholder; answer from the stolen table so OOM-retry
+    // estimates keep covering the live data.
+    if (stolen_table_bytes > 0) { return stolen_table_bytes; }
     auto batch = std::get<std::shared_ptr<cucascade::data_batch>>(materialization_info);
 
     auto ro          = batch->to_read_only();

--- a/test/cpp/scan_manager/test_cached_serving_hardening.cpp
+++ b/test/cpp/scan_manager/test_cached_serving_hardening.cpp
@@ -51,6 +51,7 @@
 #include <cucascade/memory/memory_space.hpp>
 #include <data/data_batch_utils.hpp>
 #include <data/sirius_converter_registry.hpp>
+#include <op/scan/gpu_ingestible.hpp>
 #include <op/scan/sirius_gpu_scan_operator_data.hpp>
 #include <scan_manager/load_balancing_scan_batch_coalescer.hpp>
 #include <scan_manager/mvcc_chunk_mask.hpp>
@@ -218,6 +219,76 @@ std::shared_ptr<cucascade::data_batch> make_test_batch(test_env& e, std::size_t 
   auto repr             = std::make_unique<cucascade::gpu_table_representation>(
     cudf::table_view(views), std::move(columns), alloc_size, *e.gpu_space, rmm::cuda_stream_view{});
   return cucascade::data_batch::make(sirius::get_next_batch_id(), std::move(repr));
+}
+
+/// HOST-resident wrapper batch (single INT32 column) — the shape a host-pinned
+/// chunk's per-query slice arrives in, which prepare_for_processing converts
+/// to a fresh owned GPU table.
+std::shared_ptr<cucascade::data_batch> make_host_batch(test_env& e,
+                                                       std::vector<int32_t> const& values)
+{
+  auto shared = make_gpu_column(*e.gpu_space, values);
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::make_unique<cudf::column>(
+    shared->view(), e.stream(), e.gpu_space->get_default_allocator()));
+  cucascade::gpu_table_representation gpu_repr(
+    std::make_unique<cudf::table>(std::move(cols)), *e.gpu_space, e.stream());
+  auto host_repr = sirius::converter_registry::get().convert<cucascade::host_data_representation>(
+    gpu_repr, e.host_space, e.stream());
+  e.stream().synchronize();
+  return cucascade::data_batch::make(sirius::get_next_batch_id(), std::move(host_repr));
+}
+
+/// Minimal concrete gpu_ingestible: materialize_table's resident branch calls
+/// no virtuals, so every override is an unreachable stub.
+struct stub_table_info final : sirius::op::scan::ingestible_table_info {
+  [[nodiscard]] std::span<std::string const> column_names() const override { return {}; }
+  [[nodiscard]] std::span<std::string const> file_paths() const override { return {}; }
+};
+
+struct stub_ingestible final : sirius::op::scan::gpu_ingestible {
+  [[nodiscard]] std::unique_ptr<sirius::op::scan::batch_coalescer> create_batch_coalescer()
+    const override
+  {
+    return nullptr;
+  }
+  [[nodiscard]] bool has_processed_all_metadata() const override { return true; }
+  metadata_scan_task_t next_split_provider(sirius::io::ioctx_resolver /*resolve*/) override
+  {
+    return {};
+  }
+  sirius::op::scan::filtered_table materialize_metadata_to_table(
+    const sirius::op::scan::scan_info& /*info*/,
+    const cucascade::memory::memory_space& /*mem_space*/,
+    rmm::cuda_stream_view /*stream*/) override
+  {
+    throw std::logic_error("stub_ingestible::materialize_metadata_to_table is unreachable");
+  }
+  std::unique_ptr<cudf::table> post_filter_and_project(
+    sirius::op::scan::filtered_table&& /*input*/,
+    const cucascade::memory::memory_space& /*mem_space*/,
+    rmm::cuda_stream_view /*stream*/) override
+  {
+    throw std::logic_error("stub_ingestible::post_filter_and_project is unreachable");
+  }
+  [[nodiscard]] const sirius::op::scan::ingestible_table_info& table_info() const noexcept override
+  {
+    return _info;
+  }
+  [[nodiscard]] std::vector<std::size_t> materialized_column_order() const override { return {}; }
+
+  stub_table_info _info;
+};
+
+/// Copy the single INT32 column of @p table back to host for content checks.
+std::vector<int32_t> to_host(cudf::table_view const& view)
+{
+  std::vector<int32_t> out(static_cast<std::size_t>(view.num_rows()));
+  cudaMemcpy(out.data(),
+             view.column(0).data<int32_t>(),
+             sizeof(int32_t) * out.size(),
+             cudaMemcpyDeviceToHost);
+  return out;
 }
 
 /// All-ones keep-mask over @p rows rows, its words aliasing a plain vector —
@@ -544,5 +615,115 @@ TEST_CASE("validate_pinned_entry_for_serving refuses malformed entries",
     entry.device_chunks[0].columns[0] = nullptr;
     REQUIRE_THROWS_AS(validate_pinned_entry_for_serving(entry, std::vector<std::size_t>{0}),
                       std::runtime_error);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// prepare_for_processing steal (zero-copy scan materialize)
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("prepare_for_processing steals the converted table from a per-query wrapper batch",
+          "[cached_serving][scan_manager]")
+{
+  auto& e = env();
+  std::vector<int32_t> const values{10, 11, 12, 13};
+  auto batch = make_host_batch(e, values);
+
+  sirius::op::scan::scan_operator_input split{batch};
+  split.prepare_for_processing(e.gpu_space, e.stream());
+
+  // The uploaded table was taken out of the wrapper; the batch is left holding
+  // a valid empty placeholder, and size estimates answer from the stolen table.
+  REQUIRE(split.stolen_table != nullptr);
+  REQUIRE(split.stolen_table_bytes > 0);
+  REQUIRE(split.get_estimated_size_in_bytes() == split.stolen_table_bytes);
+  {
+    auto ro = batch->to_read_only();
+    REQUIRE(ro.get_current_tier() == cucascade::memory::Tier::GPU);
+    REQUIRE(ro.get_data() != nullptr);
+    REQUIRE(ro.get_data()->get_size_in_bytes() == 0);
+  }
+
+  stub_ingestible ingestible;
+  auto result = ingestible.materialize_table(split, e.stream());
+  REQUIRE(result.state == sirius::op::scan::filter_state::UNFILTERED);
+  auto out = result.table.release(e.stream(), e.gpu_space->get_default_allocator());
+  REQUIRE(out != nullptr);
+  e.stream().synchronize();
+  REQUIRE(to_host(out->view()) == values);
+  REQUIRE(split.stolen_table == nullptr);
+  REQUIRE(split.stolen_table_consumed);
+
+  // Re-entry after consumption (scan-internal OOM retry) fails loudly instead
+  // of serving the emptied wrapper as zero rows...
+  REQUIRE_THROWS_AS(ingestible.materialize_table(split, e.stream()), std::runtime_error);
+  // ...and a re-prepare is a no-op: no second conversion, no second steal.
+  split.prepare_for_processing(e.gpu_space, e.stream());
+  REQUIRE(split.stolen_table == nullptr);
+  REQUIRE(split.get_estimated_size_in_bytes() == split.stolen_table_bytes);
+}
+
+TEST_CASE("prepare_for_processing never steals from a GPU-resident (pin-shaped) batch",
+          "[cached_serving][scan_manager]")
+{
+  auto& e = env();
+  // View-backed shared columns already on the GPU tier — the exact shape a raw
+  // GPU pin serves; no conversion happens, so nothing may be stolen.
+  auto batch             = make_test_batch(e, 4);
+  auto const size_before = [&] {
+    auto ro = batch->to_read_only();
+    return ro.get_data()->get_size_in_bytes();
+  }();
+  REQUIRE(size_before > 0);
+
+  sirius::op::scan::scan_operator_input split{batch};
+  split.prepare_for_processing(e.gpu_space, e.stream());
+  REQUIRE(split.stolen_table == nullptr);
+  REQUIRE(split.stolen_table_bytes == 0);
+
+  stub_ingestible ingestible;
+  auto result = ingestible.materialize_table(split, e.stream());
+  REQUIRE(result.state == sirius::op::scan::filter_state::UNFILTERED);
+  auto out = result.table.release(e.stream(), e.gpu_space->get_default_allocator());
+  REQUIRE(out != nullptr);
+  e.stream().synchronize();
+  REQUIRE(to_host(out->view()) == std::vector<int32_t>(4, 7));
+
+  // Pin-shaped storage untouched: same representation, same bytes.
+  auto ro = batch->to_read_only();
+  REQUIRE(ro.get_data() != nullptr);
+  REQUIRE(ro.get_data()->get_size_in_bytes() == size_before);
+}
+
+TEST_CASE("prepare_for_processing skips the steal for masked or row-filtered splits",
+          "[cached_serving][scan_manager]")
+{
+  auto& e = env();
+  std::vector<int32_t> const values{20, 21, 22, 23};
+
+  SECTION("mvcc keep-mask pending")
+  {
+    auto batch = make_host_batch(e, values);
+    sirius::op::scan::scan_operator_input split{batch};
+    split.mvcc_keep_mask = make_test_mask(values.size());
+    split.prepare_for_processing(e.gpu_space, e.stream());
+    REQUIRE(split.stolen_table == nullptr);
+    // Converted in place but not stolen: the masked materialize path filters
+    // by copy from the batch's view.
+    auto ro = batch->to_read_only();
+    REQUIRE(ro.get_current_tier() == cucascade::memory::Tier::GPU);
+    REQUIRE(ro.get_data()->get_size_in_bytes() > 0);
+  }
+
+  SECTION("row filter pending")
+  {
+    auto batch = make_host_batch(e, values);
+    sirius::op::scan::scan_operator_input split{batch};
+    split.row_filter_pending = true;
+    split.prepare_for_processing(e.gpu_space, e.stream());
+    REQUIRE(split.stolen_table == nullptr);
+    auto ro = batch->to_read_only();
+    REQUIRE(ro.get_current_tier() == cucascade::memory::Tier::GPU);
+    REQUIRE(ro.get_data()->get_size_in_bytes() > 0);
   }
 }

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -295,6 +295,10 @@ def open_connection(source, gpu_execution=False, data_source="parquet"):
         log(f"Loading Sirius extension from {EXTENSION_PATH}")
         con.execute(f"LOAD '{EXTENSION_PATH}'")
         log("Sirius extension loaded")
+        pre_sql = os.environ.get("SIRIUS_PRE_SQL", "")
+        if pre_sql:
+            log(f"Executing SIRIUS_PRE_SQL: {pre_sql}")
+            _execute_multi(con, pre_sql)
     return con
 
 

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -539,6 +539,10 @@ def _build_nsys_temp_sql(qnum, source, iterations, pin, qdir, data_source="parqu
         parts.append(_build_views_sql(source).rstrip("\n"))
     parts.append("INSERT INTO _timings VALUES (1, 'views', current_timestamp);")
 
+    pre_sql = os.environ.get("SIRIUS_PRE_SQL", "").strip()
+    if pre_sql:
+        parts.append(pre_sql.rstrip(";") + ";")
+
     if pin != "none":
         parts.append(emit_pin(qnum, source, data_source))
 

--- a/test/tpch_performance/tpch_pin_columns.py
+++ b/test/tpch_performance/tpch_pin_columns.py
@@ -270,7 +270,9 @@ def _pin_call(table: str, cols: list[str], source: str, data_source: str) -> str
     duckdb:  no positional path — the table is named by 'name' and resolved from
              the attached catalog; the source is selected with format='duckdb'.
     """
-    tier = os.environ.get("SIRIUS_PIN_TIER", "gpu")
+    tier = os.environ.get(
+        f"SIRIUS_PIN_TIER_{table.upper()}", os.environ.get("SIRIUS_PIN_TIER", "gpu")
+    )
     col_literals = ",".join(f"'{c}'" for c in cols)
     if data_source == "duckdb":
         return (


### PR DESCRIPTION
When a pinned-cache scan split needs conversion at prepare time — a compressed GPU/host pin decompressed on demand, or a host pin uploaded — the converted table exists only for this query (the wrapper batch is per-query and dropped after the scan). `materialize_table` nevertheless served it through a read-lock-backed `owning_table_view`, whose `release()` deep-copies every column: **~408 GB of device-to-device memcpy per 1.81 s hot q9 iteration** at SF1000 with compressed GPU pins (nsys, memcpy→NVTX correlation), plus second-order congestion (decompress workers waiting 4.4 ms per 0.3 ms decode).

This takes ownership instead: right after `prepare_for_processing`'s `convert_to` (same exclusive lock), move the fresh table out via `gpu_table_representation::release_table()` (a move for the owned alternative — no device copy), park it on the `scan_operator_input`, and leave the batch a valid empty placeholder. `materialize_table` moves the parked table into the scan output through the existing `no_alloc_materializable` path.

Safety invariants (each unit-tested):
- **Raw GPU pin storage is never stolen** — it never enters the conversion branch (`needs_upload == false`).
- Masked / row-filtered splits keep the copying view path (they need the source view alive), which also closes the OOM-retry window: an unmasked, unfiltered scan allocates nothing after the take.
- Re-running `prepare_for_processing` is a no-op once parked/consumed; size estimates answer from the recorded size; a materialize re-entry after consumption throws loudly instead of serving zero rows.

Validation:
- Full unit suite passes (2226 cases); 3 new `[cached_serving]` tests.
- SF10: q1,3,4,9,10,13,16,19 byte-identical across gpu-raw / host-raw / gpu-compressed / host-compressed pin configs.
- SF1000 same-session A/B (GPU-pinned compressed lineitem+orders, hot mean of 4 iters): **q9 1.825 → 1.734 s (−4.9%), q18 1.262 → 1.194 s (−5.4%)**, row counts and results identical.

Companion PRs: #1354 (plan fixes), #1355 (harness hooks used for validation), #1356 (compressed-pinning docs with the profiling evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)