### PR TITLE
docs: add print_env script for bug reports

### DIFF
--- a/print_env.sh
+++ b/print_env.sh
@@ -5,8 +5,8 @@
 # Reports relevant environment information useful for diagnosing and
 # debugging Sirius issues.
 # Usage:
-# "./scripts/print_env.sh" - prints to stdout
-# "./scripts/print_env.sh > env.txt" - prints to file "env.txt"
+# "bash print_env.sh" - prints to stdout
+# "bash print_env.sh > env.txt" - prints to file "env.txt"
 
 print_env() {
 echo "***git***"
@@ -79,6 +79,7 @@ if type "rustc" &> /dev/null; then
 else
     echo "rustc not found"
 fi
+echo
 if type "cargo" &> /dev/null; then
     which cargo && cargo --version
 else

--- a/print_env.sh
+++ b/print_env.sh
@@ -8,6 +8,22 @@
 # "bash print_env.sh" - prints to stdout
 # "bash print_env.sh > env.txt" - prints to file "env.txt"
 
+MISSING_RUNTIME=()
+MISSING_BUILD=()
+MISSING_OPTIONAL=()
+
+check_tools() {
+    type "git"        &>/dev/null || MISSING_RUNTIME+=("git")
+    type "nvidia-smi" &>/dev/null || MISSING_RUNTIME+=("nvidia-smi")
+    type "pixi"       &>/dev/null || MISSING_RUNTIME+=("pixi")
+    type "nvcc"       &>/dev/null || MISSING_BUILD+=("nvcc")
+    type "cmake"      &>/dev/null || MISSING_BUILD+=("cmake")
+    type "g++"        &>/dev/null || MISSING_BUILD+=("g++")
+    type "clang"      &>/dev/null || MISSING_BUILD+=("clang")
+    type "rustc"      &>/dev/null || MISSING_OPTIONAL+=("rustc")
+    type "cargo"      &>/dev/null || MISSING_OPTIONAL+=("cargo")
+}
+
 print_env() {
 echo "***git***"
 if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]; then
@@ -138,6 +154,22 @@ else
 fi
 echo
 }
+
+check_tools
+
+if [ ${#MISSING_RUNTIME[@]} -gt 0 ]; then
+    echo "ERROR:   Missing runtime tools required to run Sirius: ${MISSING_RUNTIME[*]}"
+    echo "Please install the missing tools and try again."
+    exit 1
+fi
+if [ ${#MISSING_BUILD[@]} -gt 0 ]; then
+    echo ""
+    echo "WARNING: Missing build tools (not required to run Sirius): ${MISSING_BUILD[*]}"
+fi
+if [ ${#MISSING_OPTIONAL[@]} -gt 0 ]; then
+    echo ""
+    echo "NOTE:    Optional tools not found: ${MISSING_OPTIONAL[*]}"
+fi
 
 echo "<details><summary>Click here to see environment details</summary><pre>"
 echo "     "

--- a/print_env.sh
+++ b/print_env.sh
@@ -122,9 +122,16 @@ printf '%-32s: %s\n' CUDA_VISIBLE_DEVICES "$CUDA_VISIBLE_DEVICES"
 printf '%-32s: %s\n' CUDA_CACHE_PATH "$CUDA_CACHE_PATH"
 echo
 
-echo "***pixi info & packages***"
+echo "***pixi info***"
 if type "pixi" &> /dev/null; then
     pixi info
+else
+    echo "pixi not found"
+fi
+echo
+
+echo "***pixi list***"
+if type "pixi" &> /dev/null; then
     pixi list
 else
     echo "pixi not found"

--- a/scripts/print_env.sh
+++ b/scripts/print_env.sh
@@ -3,83 +3,132 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, Sirius Contributors.
 # SPDX-License-Identifier: Apache-2.0
 # Reports relevant environment information useful for diagnosing and
-# debugging cuDF issues.
+# debugging Sirius issues.
 # Usage:
 # "./scripts/print_env.sh" - prints to stdout
 # "./scripts/print_env.sh > env.txt" - prints to file "env.txt"
 
 print_env() {
-echo "**git***"
+echo "***git***"
 if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]; then
-git log --decorate -n 1
-echo "**git submodules***"
-git submodule status --recursive
+    git log --decorate -n 1
+    echo "***git submodules***"
+    git submodule status --recursive
 else
-echo "Not inside a git repository"
+    echo "Not inside a git repository"
 fi
 echo
 
-echo "***OS Information***"
-cat /etc/*-release
+echo "***OS information***"
+cat /etc/*-release 2>/dev/null
 uname -a
 echo
 
-echo "***GPU Information***"
-nvidia-smi
+echo "***GPU information & topology***"
+if type "nvidia-smi" &> /dev/null; then
+    nvidia-smi
+    nvidia-smi topo -m
+else
+    echo "nvidia-smi not found"
+fi
 echo
 
 echo "***CPU***"
-lscpu
+if type "lscpu" &> /dev/null; then
+    lscpu
+else
+    sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "CPU info unavailable"
+fi
 echo
 
 echo "***CMake***"
-which cmake && cmake --version
+if type "cmake" &> /dev/null; then
+    which cmake && cmake --version
+else
+    echo "cmake not found"
+fi
 echo
 
 echo "***g++***"
-which g++ && g++ --version
+if type "g++" &> /dev/null; then
+    which g++ && g++ --version
+else
+    echo "g++ not found"
+fi
+echo
+
+echo "***clang***"
+if type "clang" &> /dev/null; then
+    which clang && clang --version
+else
+    echo "clang not found"
+fi
 echo
 
 echo "***nvcc***"
-which nvcc && nvcc --version
-echo
-
-echo "***Python***"
-which python && python -c "import sys; print('Python {0}.{1}.{2}'.format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))"
-echo
-
-echo "***Environment Variables***"
-
-printf '%-32s: %s\n' PATH $PATH
-
-printf '%-32s: %s\n' LD_LIBRARY_PATH $LD_LIBRARY_PATH
-
-printf '%-32s: %s\n' NUMBAPRO_NVVM $NUMBAPRO_NVVM
-
-printf '%-32s: %s\n' NUMBAPRO_LIBDEVICE $NUMBAPRO_LIBDEVICE
-
-printf '%-32s: %s\n' CONDA_PREFIX $CONDA_PREFIX
-
-printf '%-32s: %s\n' PYTHON_PATH $PYTHON_PATH
-
-echo
-
-
-# Print conda packages if conda exists
-if type "conda" &> /dev/null; then
-echo '***conda packages***'
-which conda && conda list
-echo
-# Print pip packages if pip exists
-elif type "pip" &> /dev/null; then
-echo "conda not found"
-echo "***pip packages***"
-which pip && pip list
-echo
+if type "nvcc" &> /dev/null; then
+    which nvcc && nvcc --version
 else
-echo "conda not found"
-echo "pip not found"
+    echo "nvcc not found"
 fi
+echo
+
+echo "***Rust***"
+if type "rustc" &> /dev/null; then
+    which rustc && rustc --version
+else
+    echo "rustc not found"
+fi
+if type "cargo" &> /dev/null; then
+    which cargo && cargo --version
+else
+    echo "cargo not found"
+fi
+echo
+
+echo "***pixi***"
+if type "pixi" &> /dev/null; then
+    which pixi && pixi --version
+else
+    echo "pixi not found"
+fi
+echo
+
+echo "***DuckDB***"
+if [ -f "build/release/duckdb" ]; then
+    build/release/duckdb --version
+elif [ -f "build/debug/duckdb" ]; then
+    build/debug/duckdb --version
+else
+    echo "DuckDB binary not found in build/"
+fi
+echo
+
+echo "***Sirius build type***"
+if [ -d "build/release" ]; then
+    echo "release build present"
+elif [ -d "build/debug" ]; then
+    echo "debug build present"
+else
+    echo "No build directory found"
+fi
+echo
+
+echo "***Environment variables***"
+printf '%-32s: %s\n' PATH "$PATH"
+printf '%-32s: %s\n' LD_LIBRARY_PATH "$LD_LIBRARY_PATH"
+printf '%-32s: %s\n' CUDA_VISIBLE_DEVICES "$CUDA_VISIBLE_DEVICES"
+printf '%-32s: %s\n' CUDA_CACHE_PATH "$CUDA_CACHE_PATH"
+echo
+
+echo "***pixi info & packages***"
+if type "pixi" &> /dev/null; then
+    pixi info
+    pixi list
+else
+    echo "pixi not found"
+fi
+echo
 }
 
 echo "<details><summary>Click here to see environment details</summary><pre>"

--- a/scripts/print_env.sh
+++ b/scripts/print_env.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, Sirius Contributors.
+# SPDX-License-Identifier: Apache-2.0
+# Reports relevant environment information useful for diagnosing and
+# debugging cuDF issues.
+# Usage:
+# "./scripts/print_env.sh" - prints to stdout
+# "./scripts/print_env.sh > env.txt" - prints to file "env.txt"
+
+print_env() {
+echo "**git***"
+if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]; then
+git log --decorate -n 1
+echo "**git submodules***"
+git submodule status --recursive
+else
+echo "Not inside a git repository"
+fi
+echo
+
+echo "***OS Information***"
+cat /etc/*-release
+uname -a
+echo
+
+echo "***GPU Information***"
+nvidia-smi
+echo
+
+echo "***CPU***"
+lscpu
+echo
+
+echo "***CMake***"
+which cmake && cmake --version
+echo
+
+echo "***g++***"
+which g++ && g++ --version
+echo
+
+echo "***nvcc***"
+which nvcc && nvcc --version
+echo
+
+echo "***Python***"
+which python && python -c "import sys; print('Python {0}.{1}.{2}'.format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))"
+echo
+
+echo "***Environment Variables***"
+
+printf '%-32s: %s\n' PATH $PATH
+
+printf '%-32s: %s\n' LD_LIBRARY_PATH $LD_LIBRARY_PATH
+
+printf '%-32s: %s\n' NUMBAPRO_NVVM $NUMBAPRO_NVVM
+
+printf '%-32s: %s\n' NUMBAPRO_LIBDEVICE $NUMBAPRO_LIBDEVICE
+
+printf '%-32s: %s\n' CONDA_PREFIX $CONDA_PREFIX
+
+printf '%-32s: %s\n' PYTHON_PATH $PYTHON_PATH
+
+echo
+
+
+# Print conda packages if conda exists
+if type "conda" &> /dev/null; then
+echo '***conda packages***'
+which conda && conda list
+echo
+# Print pip packages if pip exists
+elif type "pip" &> /dev/null; then
+echo "conda not found"
+echo "***pip packages***"
+which pip && pip list
+echo
+else
+echo "conda not found"
+echo "pip not found"
+fi
+}
+
+echo "<details><summary>Click here to see environment details</summary><pre>"
+echo "     "
+print_env | while read -r line; do
+    echo "     $line"
+done
+echo "</pre></details>"


### PR DESCRIPTION
<!-- Edit PR title: "<type>[optional scope]: <short description>", see CONTRIBUTING.md for guidance -->

## Description
<!-- Provide a standalone description of changes in this PR -->
<!-- For design docs targeting docs/experimental, note this in the description -->
Follows discussion in #1255, selecting cuDF as the Bug Report template. cuDF uses a [print_env.sh](https://github.com/rapidsai/cudf/blob/main/print_env.sh) script to

### Changes to script
- Add nvidia-smi topo to output
- Add error messages for missing tools
- Add clang version check
- Remove python and conda checks
- Add Rust, Cargo, Pixi, DuckDB checks
- Add Sirius build type
- Collect `pixi info` and `pixi list` at bottom to keep other data visible

## Checklist
- [x] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
<!-- Add open issues with "Closes #issue" to close or "Refs #issue" for reference, and any relevant URLs -->
Blocks #1360
Refs #1255 