### PR TITLE
feat: [Concurrency] PR 1 of ? Update task_creator for concurrent query support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -857,6 +857,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_plan_printer.cpp
     test/cpp/pipeline/test_repository_wiring_materializer.cpp
     test/cpp/pipeline/test_streaming_sink_root.cpp
+    test/cpp/pipeline/test_task_index_keys.cpp
     test/cpp/pipeline/test_task_scheduler.cpp
     test/cpp/scan/bench_decode_codecs.cpp
     test/cpp/scan/test_can_serve_with_columns.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -683,6 +683,7 @@ set(TEST_SOURCES
     test/cpp/config/test_object_store_config.cpp
     test/cpp/config/test_topology_config.cpp
     test/cpp/creator/test_task_creator_query_state.cpp
+    test/cpp/creator/test_task_creator_schedule_validation.cpp
     test/cpp/data/test_convertible_data_batch.cpp
     test/cpp/data/test_data_repository_manager_registry.cpp
     test/cpp/data/test_convertible_gpu_pipeline_task.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -682,6 +682,7 @@ set(TEST_SOURCES
     test/cpp/config/test_context.cpp
     test/cpp/config/test_object_store_config.cpp
     test/cpp/config/test_topology_config.cpp
+    test/cpp/creator/test_task_creator_query_state.cpp
     test/cpp/data/test_convertible_data_batch.cpp
     test/cpp/data/test_data_repository_manager_registry.cpp
     test/cpp/data/test_convertible_gpu_pipeline_task.cpp

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -95,13 +95,13 @@ const std::vector<int>& task_creator::get_active_gpu_ids() const noexcept
   return _active_gpu_ids;
 }
 
-void task_creator::query_task_state::enter_in_flight()
+void task_creator::query_task_global_state::enter_in_flight()
 {
   std::lock_guard<std::mutex> lock(in_flight_mutex);
   ++in_flight;
 }
 
-void task_creator::query_task_state::leave_in_flight()
+void task_creator::query_task_global_state::leave_in_flight()
 {
   {
     std::lock_guard<std::mutex> lock(in_flight_mutex);
@@ -111,18 +111,18 @@ void task_creator::query_task_state::leave_in_flight()
   in_flight_cv.notify_all();
 }
 
-void task_creator::query_task_state::wait_for_in_flight()
+void task_creator::query_task_global_state::wait_for_in_flight()
 {
   std::unique_lock<std::mutex> lock(in_flight_mutex);
   in_flight_cv.wait(lock, [this] { return in_flight == 0; });
 }
 
-std::shared_ptr<task_creator::query_task_state> task_creator::get_query_state(
+std::shared_ptr<task_creator::query_task_global_state> task_creator::get_query_task_global_state(
   sirius::query_id_t query_id) const
 {
   std::lock_guard<std::mutex> lock(_global_state_mutex);
-  auto it = _query_states.find(query_id);
-  return it == _query_states.end() ? nullptr : it->second;
+  auto it = _query_task_global_states.find(query_id);
+  return it == _query_task_global_states.end() ? nullptr : it->second;
 }
 
 void task_creator::set_client_context(sirius::query_id_t query_id,
@@ -131,8 +131,8 @@ void task_creator::set_client_context(sirius::query_id_t query_id,
   std::lock_guard<std::mutex> lock(_global_state_mutex);
   // The window begins before the plan exists, so this is where the query's entry is created;
   // prepare_for_query then fills in the pipeline global states.
-  auto& state = _query_states[query_id];
-  if (!state) { state = std::make_shared<query_task_state>(); }
+  auto& state = _query_task_global_states[query_id];
+  if (!state) { state = std::make_shared<query_task_global_state>(); }
   state->client_context = std::addressof(client_context);
 }
 
@@ -146,7 +146,7 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
 {
   const auto query_id = query.query_id();
 
-  auto state = get_query_state(query_id);
+  auto state = get_query_task_global_state(query_id);
   if (!state) {
     throw sirius::internal_exception(
       "task_creator::prepare_for_query: no state registered for query {}; "
@@ -275,7 +275,7 @@ void task_creator::drain_pending_tasks(sirius::query_id_t query_id)
   _task_creation_queue.drain(
     exec::query_index{static_cast<exec::query_key>(sirius::value_of(query_id))});
 
-  auto state = get_query_state(query_id);
+  auto state = get_query_task_global_state(query_id);
   if (!state) { return; }
 
   // Wait out this query's in-flight creation lambdas — the per-query stand-in for
@@ -296,13 +296,13 @@ void task_creator::reset(sirius::query_id_t query_id)
   // dereference them, so both must be gone before the caller destroys planner::query.
   drain_pending_tasks(query_id);
 
-  std::shared_ptr<query_task_state> state;
+  std::shared_ptr<query_task_global_state> state;
   {
     std::lock_guard<std::mutex> lock(_global_state_mutex);
-    auto it = _query_states.find(query_id);
-    if (it == _query_states.end()) { return; }
+    auto it = _query_task_global_states.find(query_id);
+    if (it == _query_task_global_states.end()) { return; }
     state = std::move(it->second);
-    _query_states.erase(it);
+    _query_task_global_states.erase(it);
   }
   // `state` is released here, outside the lock. Any worker that resolved it before the erase
   // still holds its own shared_ptr and finishes safely against a map that no longer lists it.
@@ -313,8 +313,8 @@ void task_creator::reset_all()
   std::vector<sirius::query_id_t> query_ids;
   {
     std::lock_guard<std::mutex> lock(_global_state_mutex);
-    query_ids.reserve(_query_states.size());
-    for (const auto& [query_id, state] : _query_states) {
+    query_ids.reserve(_query_task_global_states.size());
+    for (const auto& [query_id, state] : _query_task_global_states) {
       query_ids.push_back(query_id);
     }
   }
@@ -427,7 +427,7 @@ void task_creator::schedule_lookahead(sirius::query_id_t query_id,
                                       std::optional<int> device_id_hint)
 {
   if (_config.strategy != request_type::lookahead) { return; }
-  auto state = get_query_state(query_id);
+  auto state = get_query_task_global_state(query_id);
   if (!state) { return; }
 
   std::lock_guard lock(state->lookahead_mutex);
@@ -481,7 +481,7 @@ void task_creator::manager_loop()
     // then reads global_states (immutable after prepare_for_query) with no lock and no risk of
     // the map being rehashed or erased underneath it: its own reference keeps the state alive
     // even if reset(query_id) removes the registry entry mid-flight.
-    auto query_state = get_query_state(query_id);
+    auto query_state = get_query_task_global_state(query_id);
     if (!query_state) {
       // The query was reset while this request sat in the queue (finished, or failed and was
       // cleaned up). Dropping it is the correct outcome — `node` may already be dangling.
@@ -515,7 +515,7 @@ void task_creator::manager_loop()
         // Released on every exit path, including the catch below, so a throwing creation can
         // never strand drain_pending_tasks() waiting forever.
         struct in_flight_guard {
-          const std::shared_ptr<query_task_state>& state;
+          const std::shared_ptr<query_task_global_state>& state;
           ~in_flight_guard() { state->leave_in_flight(); }
         } guard{query_state};
         try {

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -350,12 +350,13 @@ op::sirius_physical_operator* task_creator::get_operator_for_next_task(
 void task_creator::stop()
 {
   _task_creation_queue.interrupt();
+  std::lock_guard<std::mutex> lock(_thread_pool_mutex);
   do_stop_thread_pool();
 }
 
 void task_creator::start_thread_pool()
 {
-  std::lock_guard<std::mutex> lock(_global_state_mutex);
+  std::lock_guard<std::mutex> lock(_thread_pool_mutex);
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
   // Re-arm the request queue. stop_thread_pool() calls
@@ -384,7 +385,7 @@ void task_creator::do_stop_thread_pool()
 
 void task_creator::stop_thread_pool()
 {
-  std::lock_guard<std::mutex> lock(_global_state_mutex);
+  std::lock_guard<std::mutex> lock(_thread_pool_mutex);
   do_stop_thread_pool();
 }
 
@@ -435,8 +436,15 @@ void task_creator::schedule(op::sirius_physical_operator* node, sirius::query_id
 
 void task_creator::report_fatal_error(std::exception_ptr error)
 {
+  // Report-only: this can run on one of _bounded_pool's own worker threads (schedule() throws
+  // from inside the dispatched task-creation lambda, or via notify_downstream_pipelines() called
+  // from ~gpu_pipeline_task on a GPU executor thread). Calling stop() here would join
+  // _manager_thread and then block in _bounded_pool->wait_all() waiting for this very task's slot
+  // to free -- a self-wait deadlock, since the slot can't free until this call returns.
+  // terminate_query() only fulfills the completion future; the query thread (sirius_engine.cpp,
+  // future.get() catch block) observes the error and calls task_scheduler::drain_after_error(),
+  // which drains and restarts every pool from a thread that is never one of their own workers.
   if (_task_scheduler != nullptr) { _task_scheduler->terminate_query(std::move(error)); }
-  stop();
 }
 
 void task_creator::schedule_lookahead(sirius::query_id_t query_id,

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -24,6 +24,7 @@
 #include "pipeline/task_scheduler.hpp"
 #include "planner/query.hpp"
 #include "planner/query_index.hpp"
+#include "sirius/exception.hpp"
 #include "sirius_context.hpp"
 
 #include <cucascade/cudf/gpu_data_representation.hpp>
@@ -390,14 +391,23 @@ void task_creator::stop_thread_pool()
 namespace {
 
 //! The query and scheduling priority of the pipeline `node` belongs to.
-//! An unplaced operator (no pipeline yet) yields query 0 / priority 0; such a request is
-//! droppable and will simply find no state when the worker resolves it.
 std::pair<sirius::query_id_t, exec::queue_priority> request_keys_for(
   const op::sirius_physical_operator* node)
 {
-  if (node == nullptr) { return {sirius::make_query_id(0), 0}; }
+  if (node == nullptr) {
+    throw sirius::internal_exception("task_creator::schedule: null operator");
+  }
   const auto pipe = node->get_pipeline();
-  if (!pipe) { return {sirius::make_query_id(0), 0}; }
+  if (!pipe) {
+    throw sirius::internal_exception(
+      "task_creator::schedule: operator {} (id {}) has no pipeline; it was never placed by "
+      "planner::query::build_indices",
+      node->get_name(),
+      // get_operator_id() itself throws on an unnumbered operator; report the sentinel instead so
+      // the pipeline-less diagnosis is not masked by an id-assignment one.
+      node->has_operator_id() ? std::to_string(node->get_operator_id())
+                              : std::string{"unassigned"});
+  }
   return {pipe->get_query_id(), pipe->get_priority()};
 }
 
@@ -421,6 +431,12 @@ void task_creator::schedule(op::sirius_physical_operator* node, sirius::query_id
   request->query_id        = query_id;
   request->priority        = priority;
   _task_creation_queue.push(std::move(request));
+}
+
+void task_creator::report_fatal_error(std::exception_ptr error)
+{
+  if (_task_scheduler != nullptr) { _task_scheduler->terminate_query(std::move(error)); }
+  stop();
 }
 
 void task_creator::schedule_lookahead(sirius::query_id_t query_id,
@@ -723,8 +739,7 @@ void task_creator::manager_loop()
           pipeline->update_pipeline_status(false);
         } catch (const std::exception& e) {
           SIRIUS_LOG_ERROR("Task Creator: Exception during task creation: {}", e.what());
-          _task_scheduler->terminate_query(std::current_exception());
-          stop();
+          report_fatal_error(std::current_exception());
         }
       });
   }

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -50,6 +50,17 @@ task_creator::task_creator(task_creator_config config,
                            std::shared_ptr<const sirius::memory::topology_index> topology_index)
   : _running(false),
     _config(std::move(config)),
+    _task_creation_queue([](const task_creation_request& request) -> exec::index_keys {
+      // The request carries its own keys: they are resolved at schedule() time, where the
+      // node's pipeline (and therefore its query and priority) is unambiguously alive. The
+      // query key is what makes drain(query_index{...}) able to drop one query's pending
+      // requests and leave every other query's in place.
+      return exec::index_keys{
+        request.priority,
+        request.node != nullptr ? request.node->type : op::SiriusPhysicalOperatorType::INVALID,
+        static_cast<exec::query_key>(sirius::value_of(request.query_id)),
+        request.device_id};
+    }),
     _mem_res_mgr(mem_res_mgr),
     _topology_index(std::move(topology_index))
 {
@@ -84,13 +95,45 @@ const std::vector<int>& task_creator::get_active_gpu_ids() const noexcept
   return _active_gpu_ids;
 }
 
-void task_creator::set_client_context(::duckdb::ClientContext& client_context)
+void task_creator::query_task_state::enter_in_flight()
+{
+  std::lock_guard<std::mutex> lock(in_flight_mutex);
+  ++in_flight;
+}
+
+void task_creator::query_task_state::leave_in_flight()
+{
+  {
+    std::lock_guard<std::mutex> lock(in_flight_mutex);
+    --in_flight;
+    if (in_flight != 0) { return; }
+  }
+  in_flight_cv.notify_all();
+}
+
+void task_creator::query_task_state::wait_for_in_flight()
+{
+  std::unique_lock<std::mutex> lock(in_flight_mutex);
+  in_flight_cv.wait(lock, [this] { return in_flight == 0; });
+}
+
+std::shared_ptr<task_creator::query_task_state> task_creator::get_query_state(
+  sirius::query_id_t query_id) const
 {
   std::lock_guard<std::mutex> lock(_global_state_mutex);
-  _client_context = std::addressof(client_context);
-  _thread_context = std::make_unique<duckdb::ThreadContext>(client_context);
-  _execution_context =
-    std::make_unique<duckdb::ExecutionContext>(client_context, *_thread_context, nullptr);
+  auto it = _query_states.find(query_id);
+  return it == _query_states.end() ? nullptr : it->second;
+}
+
+void task_creator::set_client_context(sirius::query_id_t query_id,
+                                      ::duckdb::ClientContext& client_context)
+{
+  std::lock_guard<std::mutex> lock(_global_state_mutex);
+  // The window begins before the plan exists, so this is where the query's entry is created;
+  // prepare_for_query then fills in the pipeline global states.
+  auto& state = _query_states[query_id];
+  if (!state) { state = std::make_shared<query_task_state>(); }
+  state->client_context = std::addressof(client_context);
 }
 
 void task_creator::set_task_scheduler(sirius::pipeline::task_scheduler& task_scheduler)
@@ -101,19 +144,28 @@ void task_creator::set_task_scheduler(sirius::pipeline::task_scheduler& task_sch
 
 void task_creator::prepare_for_query(const sirius::planner::query& query)
 {
-  std::lock_guard<std::mutex> lock(_global_state_mutex);
+  const auto query_id = query.query_id();
 
-  _gpu_operator_global_state_map.clear();
+  auto state = get_query_state(query_id);
+  if (!state) {
+    throw sirius::internal_exception(
+      "task_creator::prepare_for_query: no state registered for query {}; "
+      "set_client_context must run first (execution-window begin)",
+      query_id);
+  }
 
   const auto& pipelines = query.get_pipelines();
 
   auto* sirius_ctx =
-    _client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state").get();
+    state->client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state").get();
   std::shared_ptr<const telemetry::telemetry_context> telemetry_context =
     sirius_ctx->get_telemetry_context();
 
   auto pipeline_priorities = compute_pipeline_priorities(query);
 
+  // Filled once, here, and never mutated afterwards: task-creation workers read it without a
+  // lock, holding only their shared_ptr to this state. Note the map is NOT cleared — other
+  // queries own their own entries, and this one is brand new.
   for (const auto& pipeline : pipelines) {
     pipeline->set_task_creator(this);
     auto source_operator = pipeline->get_source();
@@ -126,18 +178,20 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
       std::make_shared<pipeline::gpu_pipeline_task_global_state>(pipeline, telemetry_context);
     if (auto it = pipeline_priorities.find(pipeline.get()); it != pipeline_priorities.end()) {
       gs->set_priority(it->second);
+      // Mirror it onto the pipeline so schedule() can key a request without locking.
+      pipeline->set_priority(it->second);
     }
-    _gpu_operator_global_state_map.emplace(operator_id, std::move(gs));
+    state->global_states.emplace(operator_id, std::move(gs));
   }
 
-  std::lock_guard<std::mutex> lookahead_lock(_lookahead_mutex);
-  _lookahead_queue.clear();
-  auto scan_operators      = query.get_scan_operators();
-  _index_of_next_lookahead = 0;
+  std::lock_guard<std::mutex> lookahead_lock(state->lookahead_mutex);
+  state->lookahead_queue.clear();
+  auto scan_operators            = query.get_scan_operators();
+  state->index_of_next_lookahead = 0;
   if (!scan_operators.empty()) {
     auto begin = scan_operators.begin() + 1;
     for (auto it = begin; it != scan_operators.end(); ++it) {
-      _lookahead_queue.push_back(*it);
+      state->lookahead_queue.push_back(*it);
     }
   }
 }
@@ -214,43 +268,58 @@ task_creator::compute_pipeline_priorities(const sirius::planner::query& query) c
   return priorities;
 }
 
-void task_creator::drain_pending_tasks()
+void task_creator::drain_pending_tasks(sirius::query_id_t query_id)
 {
-  std::lock_guard<std::mutex> lock(_global_state_mutex);
-  // Drain any queued task creation requests that haven't been picked up yet
-  _task_creation_queue.interrupt();
-  _task_creation_queue.drain();
-  // Wait for any in-flight task creation lambdas to finish. When called from
-  // task_scheduler::drain_after_error(), stop_thread_pool() has already joined
-  // the worker pool and reset _bounded_pool to null — in that case the pool's
-  // own destructor already drained in-flight work, so this wait_all is
-  // redundant. Dereferencing the null pointer here throws std::system_error
-  // (EPERM) from the pthread_mutex call on garbage memory, surfacing to the
-  // caller as "Operation not permitted" and breaking otherwise-successful
-  // multi-file SF1000 scans.
-  if (_bounded_pool) { _bounded_pool->wait_all(); }
-  // Clear lookahead state so any schedule_lookahead() call from the
-  // management_eventloop that races with QueryEnd (after query_.reset() destroys
-  // operators but before task_creator_->reset() clears the queue) finds an
-  // empty queue and exits cleanly instead of dereferencing dangling pointers.
-  {
-    std::lock_guard<std::mutex> lookahead_lock(_lookahead_mutex);
-    _lookahead_queue.clear();
-    _index_of_next_lookahead = 0;
-  }
-  _task_creation_queue.reactivate();
+  // Drop only THIS query's queued requests. No interrupt()/reactivate(): the queue stays open
+  // the whole time, so other queries' producers and consumers are never stalled.
+  _task_creation_queue.drain(
+    exec::query_index{static_cast<exec::query_key>(sirius::value_of(query_id))});
+
+  auto state = get_query_state(query_id);
+  if (!state) { return; }
+
+  // Wait out this query's in-flight creation lambdas — the per-query stand-in for
+  // _bounded_pool->wait_all(), which would also wait on every other query's work. Workers
+  // decrement on exit (including by exception), so this cannot hang on a throwing lambda.
+  state->wait_for_in_flight();
+
+  // Clear lookahead state so any schedule_lookahead() racing with query teardown finds an
+  // empty queue and exits cleanly instead of dereferencing operators that are about to die.
+  std::lock_guard<std::mutex> lookahead_lock(state->lookahead_mutex);
+  state->lookahead_queue.clear();
+  state->index_of_next_lookahead = 0;
 }
 
-void task_creator::reset()
+void task_creator::reset(sirius::query_id_t query_id)
 {
-  std::lock_guard<std::mutex> lock(_global_state_mutex);
-  _gpu_operator_global_state_map.clear();
-  _thread_context.reset();
-  _execution_context.reset();
+  // Requests hold raw operator pointers into this query's plan, and in-flight lambdas
+  // dereference them, so both must be gone before the caller destroys planner::query.
+  drain_pending_tasks(query_id);
+
+  std::shared_ptr<query_task_state> state;
   {
-    std::lock_guard<std::mutex> lookahead_lock(_lookahead_mutex);
-    _lookahead_queue.clear();
-    _index_of_next_lookahead = 0;
+    std::lock_guard<std::mutex> lock(_global_state_mutex);
+    auto it = _query_states.find(query_id);
+    if (it == _query_states.end()) { return; }
+    state = std::move(it->second);
+    _query_states.erase(it);
+  }
+  // `state` is released here, outside the lock. Any worker that resolved it before the erase
+  // still holds its own shared_ptr and finishes safely against a map that no longer lists it.
+}
+
+void task_creator::reset_all()
+{
+  std::vector<sirius::query_id_t> query_ids;
+  {
+    std::lock_guard<std::mutex> lock(_global_state_mutex);
+    query_ids.reserve(_query_states.size());
+    for (const auto& [query_id, state] : _query_states) {
+      query_ids.push_back(query_id);
+    }
+  }
+  for (const auto query_id : query_ids) {
+    reset(query_id);
   }
 }
 
@@ -318,19 +387,53 @@ void task_creator::stop_thread_pool()
   do_stop_thread_pool();
 }
 
+namespace {
+
+//! The query and scheduling priority of the pipeline `node` belongs to.
+//! An unplaced operator (no pipeline yet) yields query 0 / priority 0; such a request is
+//! droppable and will simply find no state when the worker resolves it.
+std::pair<sirius::query_id_t, exec::queue_priority> request_keys_for(
+  const op::sirius_physical_operator* node)
+{
+  if (node == nullptr) { return {sirius::make_query_id(0), 0}; }
+  const auto pipe = node->get_pipeline();
+  if (!pipe) { return {sirius::make_query_id(0), 0}; }
+  return {pipe->get_query_id(), pipe->get_priority()};
+}
+
+}  // namespace
+
 void task_creator::schedule(op::sirius_physical_operator* node)
 {
-  auto request  = std::make_unique<task_creation_request>();
-  request->node = node;
+  const auto [query_id, priority] = request_keys_for(node);
+  auto request                    = std::make_unique<task_creation_request>();
+  request->node                   = node;
+  request->query_id               = query_id;
+  request->priority               = priority;
   _task_creation_queue.push(std::move(request));
 }
 
-void task_creator::schedule_lookahead(std::optional<int> device_id_hint)
+void task_creator::schedule(op::sirius_physical_operator* node, sirius::query_id_t query_id)
+{
+  const auto [_, priority] = request_keys_for(node);
+  auto request             = std::make_unique<task_creation_request>();
+  request->node            = node;
+  request->query_id        = query_id;
+  request->priority        = priority;
+  _task_creation_queue.push(std::move(request));
+}
+
+void task_creator::schedule_lookahead(sirius::query_id_t query_id,
+                                      std::optional<int> device_id_hint)
 {
   if (_config.strategy != request_type::lookahead) { return; }
-  std::lock_guard lock(_lookahead_mutex);
-  for (; _index_of_next_lookahead < _lookahead_queue.size(); ++_index_of_next_lookahead) {
-    auto* node = _lookahead_queue[_index_of_next_lookahead];
+  auto state = get_query_state(query_id);
+  if (!state) { return; }
+
+  std::lock_guard lock(state->lookahead_mutex);
+  for (; state->index_of_next_lookahead < state->lookahead_queue.size();
+       ++state->index_of_next_lookahead) {
+    auto* node = state->lookahead_queue[state->index_of_next_lookahead];
     if (node == nullptr) { continue; }
     auto hint = node->get_next_task_hint();
     if (!hint.has_value()) {
@@ -341,11 +444,15 @@ void task_creator::schedule_lookahead(std::optional<int> device_id_hint)
       SIRIUS_LOG_TRACE("Task Creator: scheduling lookahead for operator {} (id {})",
                        node->get_name(),
                        node->get_operator_id());
-      auto request  = std::make_unique<task_creation_request>();
-      request->node = node;
-      request->type = request_type::lookahead;
+      const auto [_, priority] = request_keys_for(node);
+      auto request             = std::make_unique<task_creation_request>();
+      request->node            = node;
+      request->type            = request_type::lookahead;
+      request->query_id        = query_id;
+      request->priority        = priority;
+      request->device_id       = device_id_hint.value_or(exec::no_preferred_device);
       _task_creation_queue.push(std::move(request));
-      ++_index_of_next_lookahead;
+      ++state->index_of_next_lookahead;
       return;
     }
   }
@@ -365,12 +472,23 @@ void task_creator::manager_loop()
       continue;
     }
 
-    auto node         = request->node;
-    auto request_kind = request->type;
+    auto node           = request->node;
+    auto request_kind   = request->type;
+    const auto query_id = request->query_id;
     if (node == nullptr) { continue; }
 
-    std::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>> visited_pipelines;
+    // Resolve the query's state ONCE, here, and hand the shared_ptr to the worker. The worker
+    // then reads global_states (immutable after prepare_for_query) with no lock and no risk of
+    // the map being rehashed or erased underneath it: its own reference keeps the state alive
+    // even if reset(query_id) removes the registry entry mid-flight.
+    auto query_state = get_query_state(query_id);
+    if (!query_state) {
+      // The query was reset while this request sat in the queue (finished, or failed and was
+      // cleaned up). Dropping it is the correct outcome — `node` may already be dangling.
+      continue;
+    }
 
+    std::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>> visited_pipelines;
     node = get_operator_for_next_task(node, visited_pipelines);
 
     if (node == nullptr) {
@@ -388,209 +506,227 @@ void task_creator::manager_loop()
       continue;
     }
 
+    // Counted before dispatch so drain_pending_tasks(query_id) cannot observe zero in-flight
+    // while this task creation is still queued to run.
+    query_state->enter_in_flight();
     // Dispatch the task creation work to the pool
-    _bounded_pool->dispatch(std::move(slot), [this, node, request_kind]() mutable {
-      try {
-        // Get what we need to create the task
-        auto pipeline = node->get_pipeline();
-        std::vector<cucascade::shared_data_repository*> destination_data_repositories;
+    _bounded_pool->dispatch(
+      std::move(slot), [this, node, request_kind, query_state = std::move(query_state)]() mutable {
+        // Released on every exit path, including the catch below, so a throwing creation can
+        // never strand drain_pending_tasks() waiting forever.
+        struct in_flight_guard {
+          const std::shared_ptr<query_task_state>& state;
+          ~in_flight_guard() { state->leave_in_flight(); }
+        } guard{query_state};
+        try {
+          // Get what we need to create the task
+          auto pipeline = node->get_pipeline();
+          std::vector<cucascade::shared_data_repository*> destination_data_repositories;
 
-        for (const auto& port_info : pipeline->get_next_ports_after_sink()) {
-          destination_data_repositories.push_back(
-            port_info.next_operator->get_port(port_info.next_operator_port_name)->repo);
-        }
-
-        while (!node->all_ports_empty()) {
-          auto task_lock  = pipeline->get_task_creation_lock();
-          auto input_data = node->get_next_task_input_data();
-          auto* pipelineable_input =
-            dynamic_cast<op::pipelineable_operator_data*>(input_data.get());
-          if (!input_data ||
-              (pipelineable_input && pipelineable_input->get_data_batches().empty())) {
-            // no data to create task for
-            break;
+          for (const auto& port_info : pipeline->get_next_ports_after_sink()) {
+            destination_data_repositories.push_back(
+              port_info.next_operator->get_port(port_info.next_operator_port_name)->repo);
           }
 
-          size_t operator_id                  = node->get_operator_id();
-          auto gpu_pipeline_task_global_state = _gpu_operator_global_state_map.at(operator_id);
-          auto local_state =
-            std::make_unique<pipeline::gpu_pipeline_task_local_state>(std::move(input_data));
+          while (!node->all_ports_empty()) {
+            auto task_lock  = pipeline->get_task_creation_lock();
+            auto input_data = node->get_next_task_input_data();
+            auto* pipelineable_input =
+              dynamic_cast<op::pipelineable_operator_data*>(input_data.get());
+            if (!input_data ||
+                (pipelineable_input && pipelineable_input->get_data_batches().empty())) {
+              // no data to create task for
+              break;
+            }
 
-          // pipelineable_input remains valid here: the cast happened before
-          // the move into local_state, and unique_ptr move transfers
-          // ownership without relocating the object.
-          {
-            std::optional<int> preferred_device_id;
-            // Operating-data preference (highest priority): the scan manager
-            // round-robins fresh-read scan splits across the available GPUs and
-            // stamps the chosen device onto the split's operating data. Honor it
-            // first so each split's task lands on its assigned GPU; the locality
-            // heuristics below only run when no upstream preference was set.
-            if (local_state->_input_data) {
-              preferred_device_id = local_state->_input_data->get_preferred_device_id();
-            }
-            // Partition affinity: if the input is tagged with a partition
-            // index, pin the task to partition_idx % num_gpus.
-            // Partition-based operators (hash_join, grouped_aggregate_merge,
-            // …) use cuco hash tables under the hood, and cuco tables must
-            // live on a single device — a stream bound to GPU A touching a
-            // counter built under GPU B trips cudaErrorInvalidValue at
-            // counter_storage.cuh. Routing on partition_idx keeps every
-            // task of a given partition on one GPU while still spreading
-            // partitions across GPUs.
-            // Partitioned data with no index asks to be placed by affinity instead: its producer
-            // built a single partition, so no other task shares its device requirement.
-            if (auto* partitioned =
-                  dynamic_cast<op::partitioned_operator_data*>(pipelineable_input);
-                !preferred_device_id.has_value() && partitioned && !_active_gpu_ids.empty()) {
-              // Index the active executor set so every task of a partition lands
-              // on the same real GPU (required for cuco tables); the physical
-              // topology would yield phantom pins when num_gpus < physical count.
-              if (auto const partition_idx = partitioned->get_partition_idx()) {
-                auto idx            = *partition_idx % _active_gpu_ids.size();
-                preferred_device_id = _active_gpu_ids[idx];
+            size_t operator_id = node->get_operator_id();
+            // Read from this query's own map. Operator ids restart at 0 per query, so the id is
+            // only meaningful within the entry; a globally-keyed map would hand back another
+            // query's state here.
+            auto gs_it = query_state->global_states.find(operator_id);
+            if (gs_it == query_state->global_states.end()) { break; }
+            auto gpu_pipeline_task_global_state = gs_it->second;
+            auto local_state =
+              std::make_unique<pipeline::gpu_pipeline_task_local_state>(std::move(input_data));
+
+            // pipelineable_input remains valid here: the cast happened before
+            // the move into local_state, and unique_ptr move transfers
+            // ownership without relocating the object.
+            {
+              std::optional<int> preferred_device_id;
+              // Operating-data preference (highest priority): the scan manager
+              // round-robins fresh-read scan splits across the available GPUs and
+              // stamps the chosen device onto the split's operating data. Honor it
+              // first so each split's task lands on its assigned GPU; the locality
+              // heuristics below only run when no upstream preference was set.
+              if (local_state->_input_data) {
+                preferred_device_id = local_state->_input_data->get_preferred_device_id();
               }
-            }
-            if (!preferred_device_id.has_value() && pipelineable_input &&
-                !pipelineable_input->get_data_batches().empty()) {
-              std::unordered_map<int, size_t> gpu_bytes;
-              std::unordered_map<int, size_t> host_bytes;
-              for (const auto& batch : pipelineable_input->get_data_batches()) {
-                if (!batch) { continue; }
-                auto ro     = batch->to_read_only();
-                auto* space = ro.get_memory_space();
-                if (!space || !ro.get_data()) { continue; }
-                auto size = ro.get_data()->get_size_in_bytes();
-                if (space->get_tier() == cucascade::memory::Tier::GPU) {
-                  gpu_bytes[space->get_device_id()] += size;
-                } else if (space->get_tier() == cucascade::memory::Tier::HOST) {
-                  // Key by the host space's NUMA node verbatim; topology_index
-                  // groups GPUs under that same key (including the -1 "unknown"
-                  // sentinel for non-NUMA / single-NUMA hosts), so gpus_of()
-                  // resolves without any normalization.
-                  host_bytes[space->get_device_id()] += size;
+              // Partition affinity: if the input is tagged with a partition
+              // index, pin the task to partition_idx % num_gpus.
+              // Partition-based operators (hash_join, grouped_aggregate_merge,
+              // …) use cuco hash tables under the hood, and cuco tables must
+              // live on a single device — a stream bound to GPU A touching a
+              // counter built under GPU B trips cudaErrorInvalidValue at
+              // counter_storage.cuh. Routing on partition_idx keeps every
+              // task of a given partition on one GPU while still spreading
+              // partitions across GPUs.
+              // Partitioned data with no index asks to be placed by affinity instead: its producer
+              // built a single partition, so no other task shares its device requirement.
+              if (auto* partitioned =
+                    dynamic_cast<op::partitioned_operator_data*>(pipelineable_input);
+                  !preferred_device_id.has_value() && partitioned && !_active_gpu_ids.empty()) {
+                // Index the active executor set so every task of a partition lands
+                // on the same real GPU (required for cuco tables); the physical
+                // topology would yield phantom pins when num_gpus < physical count.
+                if (auto const partition_idx = partitioned->get_partition_idx()) {
+                  auto idx            = *partition_idx % _active_gpu_ids.size();
+                  preferred_device_id = _active_gpu_ids[idx];
                 }
               }
-              if (!gpu_bytes.empty()) {
-                // Data-locality: route to GPU with most data by bytes
-                preferred_device_id =
-                  std::max_element(gpu_bytes.begin(),
-                                   gpu_bytes.end(),
-                                   [](const auto& a, const auto& b) { return a.second < b.second; })
-                    ->first;
-              } else if (!host_bytes.empty() && _topology_index) {
-                // NUMA-affinity: no GPU data, route to a GPU on the same
-                // NUMA as the host data. When that NUMA hosts multiple
-                // GPUs, pick round-robin across them — pinning every
-                // host-sourced pipeline task to a single GPU defeats
-                // multi-GPU speedup.
-                auto top_host =
-                  std::max_element(host_bytes.begin(),
-                                   host_bytes.end(),
-                                   [](const auto& a, const auto& b) { return a.second < b.second; })
-                    ->first;
-                auto gpus = _topology_index->gpus_of(top_host);
-                if (!gpus.empty()) {
-                  auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
-                  preferred_device_id = gpus[idx];
-                }
-              }
-              SIRIUS_LOG_DEBUG(
-                "Task Creator: locality score gpu_sources={} host_sources={} preferred_device={}",
-                gpu_bytes.size(),
-                host_bytes.size(),
-                preferred_device_id.value_or(-1));
-            }
-            // Cached-scan locality: a resident scan_operator_input is
-            // NOT a pipelineable_operator_data (see
-            // sirius_gpu_scan_operator_data.hpp), so the data-locality block
-            // above skipped it wholesale. Without this branch, every
-            // pinned-table scan task gets dispatched round-robin by the
-            // scheduler and triggers a peer DMA or host staging when the
-            // consumer GPU differs from the chunk's home GPU. The pinned
-            // chunk's GPU residency is preserved on the batch
-            // (the cached provider pins each chunk_memory_space
-            // into the gpu_table_representation), so we just read it here.
-            if (!preferred_device_id.has_value()) {
-              if (auto* cached =
-                    dynamic_cast<op::scan::scan_operator_input*>(local_state->_input_data.get())) {
-                if (cached->is_resident()) {
-                  auto ro     = cached->get_cached_batch()->to_read_only();
+              if (!preferred_device_id.has_value() && pipelineable_input &&
+                  !pipelineable_input->get_data_batches().empty()) {
+                std::unordered_map<int, size_t> gpu_bytes;
+                std::unordered_map<int, size_t> host_bytes;
+                for (const auto& batch : pipelineable_input->get_data_batches()) {
+                  if (!batch) { continue; }
+                  auto ro     = batch->to_read_only();
                   auto* space = ro.get_memory_space();
-                  if (space) {
-                    if (space->get_tier() == cucascade::memory::Tier::GPU) {
-                      preferred_device_id = space->get_device_id();
-                    } else if (space->get_tier() == cucascade::memory::Tier::HOST &&
-                               _topology_index) {
-                      // tier='host' pinned chunks carry a NUMA-local host
-                      // memory_space; map back through the topology index to
-                      // pick a GPU on the same NUMA. The host space's device id
-                      // is the NUMA key verbatim (-1 = "unknown"), matching the
-                      // pipelineable locality block above.
-                      auto gpus = _topology_index->gpus_of(space->get_device_id());
-                      if (!gpus.empty()) {
-                        auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
-                        preferred_device_id = gpus[idx];
+                  if (!space || !ro.get_data()) { continue; }
+                  auto size = ro.get_data()->get_size_in_bytes();
+                  if (space->get_tier() == cucascade::memory::Tier::GPU) {
+                    gpu_bytes[space->get_device_id()] += size;
+                  } else if (space->get_tier() == cucascade::memory::Tier::HOST) {
+                    // Key by the host space's NUMA node verbatim; topology_index
+                    // groups GPUs under that same key (including the -1 "unknown"
+                    // sentinel for non-NUMA / single-NUMA hosts), so gpus_of()
+                    // resolves without any normalization.
+                    host_bytes[space->get_device_id()] += size;
+                  }
+                }
+                if (!gpu_bytes.empty()) {
+                  // Data-locality: route to GPU with most data by bytes
+                  preferred_device_id = std::max_element(gpu_bytes.begin(),
+                                                         gpu_bytes.end(),
+                                                         [](const auto& a, const auto& b) {
+                                                           return a.second < b.second;
+                                                         })
+                                          ->first;
+                } else if (!host_bytes.empty() && _topology_index) {
+                  // NUMA-affinity: no GPU data, route to a GPU on the same
+                  // NUMA as the host data. When that NUMA hosts multiple
+                  // GPUs, pick round-robin across them — pinning every
+                  // host-sourced pipeline task to a single GPU defeats
+                  // multi-GPU speedup.
+                  auto top_host = std::max_element(host_bytes.begin(),
+                                                   host_bytes.end(),
+                                                   [](const auto& a, const auto& b) {
+                                                     return a.second < b.second;
+                                                   })
+                                    ->first;
+                  auto gpus = _topology_index->gpus_of(top_host);
+                  if (!gpus.empty()) {
+                    auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
+                    preferred_device_id = gpus[idx];
+                  }
+                }
+                SIRIUS_LOG_DEBUG(
+                  "Task Creator: locality score gpu_sources={} host_sources={} preferred_device={}",
+                  gpu_bytes.size(),
+                  host_bytes.size(),
+                  preferred_device_id.value_or(-1));
+              }
+              // Cached-scan locality: a resident scan_operator_input is
+              // NOT a pipelineable_operator_data (see
+              // sirius_gpu_scan_operator_data.hpp), so the data-locality block
+              // above skipped it wholesale. Without this branch, every
+              // pinned-table scan task gets dispatched round-robin by the
+              // scheduler and triggers a peer DMA or host staging when the
+              // consumer GPU differs from the chunk's home GPU. The pinned
+              // chunk's GPU residency is preserved on the batch
+              // (the cached provider pins each chunk_memory_space
+              // into the gpu_table_representation), so we just read it here.
+              if (!preferred_device_id.has_value()) {
+                if (auto* cached = dynamic_cast<op::scan::scan_operator_input*>(
+                      local_state->_input_data.get())) {
+                  if (cached->is_resident()) {
+                    auto ro     = cached->get_cached_batch()->to_read_only();
+                    auto* space = ro.get_memory_space();
+                    if (space) {
+                      if (space->get_tier() == cucascade::memory::Tier::GPU) {
+                        preferred_device_id = space->get_device_id();
+                      } else if (space->get_tier() == cucascade::memory::Tier::HOST &&
+                                 _topology_index) {
+                        // tier='host' pinned chunks carry a NUMA-local host
+                        // memory_space; map back through the topology index to
+                        // pick a GPU on the same NUMA. The host space's device id
+                        // is the NUMA key verbatim (-1 = "unknown"), matching the
+                        // pipelineable locality block above.
+                        auto gpus = _topology_index->gpus_of(space->get_device_id());
+                        if (!gpus.empty()) {
+                          auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
+                          preferred_device_id = gpus[idx];
+                        }
                       }
+                      SIRIUS_LOG_DEBUG(
+                        "Task Creator: cached-scan locality tier={} device_id={} "
+                        "preferred_device={}",
+                        static_cast<int>(space->get_tier()),
+                        space->get_device_id(),
+                        preferred_device_id.value_or(-1));
                     }
-                    SIRIUS_LOG_DEBUG(
-                      "Task Creator: cached-scan locality tier={} device_id={} "
-                      "preferred_device={}",
-                      static_cast<int>(space->get_tier()),
-                      space->get_device_id(),
-                      preferred_device_id.value_or(-1));
                   }
                 }
               }
-            }
-            // Confine the task to the admitted subset. Every preference above except the
-            // partition pin comes from where data lives rather than from the subset, and the
-            // scheduler treats a preference as binding — so an excluded id would be honoured.
-            // Clamping a residency-derived one costs the locality it encoded, but honouring
-            // it would put the query on a GPU it was not admitted to. An unpreferred task
-            // escapes too: the scheduler gives those to whichever executor asks first. Pin
-            // those as well, but only on a real subset, since a pin costs the scheduler's
-            // freedom to place them wherever frees up first.
-            if (!_active_gpu_ids.empty()) {
-              bool const names_excluded_device =
-                preferred_device_id.has_value() &&
-                std::find(_active_gpu_ids.begin(), _active_gpu_ids.end(), *preferred_device_id) ==
-                  _active_gpu_ids.end();
-              bool const unpinned_on_a_subset =
-                !preferred_device_id.has_value() && _active_gpu_ids.size() < _full_gpu_count;
-              if (names_excluded_device || unpinned_on_a_subset) {
-                auto const idx      = _admission_rr.fetch_add(1) % _active_gpu_ids.size();
-                preferred_device_id = _active_gpu_ids[idx];
+              // Confine the task to the admitted subset. Every preference above except the
+              // partition pin comes from where data lives rather than from the subset, and the
+              // scheduler treats a preference as binding — so an excluded id would be honoured.
+              // Clamping a residency-derived one costs the locality it encoded, but honouring
+              // it would put the query on a GPU it was not admitted to. An unpreferred task
+              // escapes too: the scheduler gives those to whichever executor asks first. Pin
+              // those as well, but only on a real subset, since a pin costs the scheduler's
+              // freedom to place them wherever frees up first.
+              if (!_active_gpu_ids.empty()) {
+                bool const names_excluded_device =
+                  preferred_device_id.has_value() &&
+                  std::find(_active_gpu_ids.begin(), _active_gpu_ids.end(), *preferred_device_id) ==
+                    _active_gpu_ids.end();
+                bool const unpinned_on_a_subset =
+                  !preferred_device_id.has_value() && _active_gpu_ids.size() < _full_gpu_count;
+                if (names_excluded_device || unpinned_on_a_subset) {
+                  auto const idx      = _admission_rr.fetch_add(1) % _active_gpu_ids.size();
+                  preferred_device_id = _active_gpu_ids[idx];
+                }
+              }
+              if (preferred_device_id.has_value()) {
+                local_state->set_preferred_device_id(preferred_device_id.value());
               }
             }
-            if (preferred_device_id.has_value()) {
-              local_state->set_preferred_device_id(preferred_device_id.value());
-            }
+
+            auto task_id = get_next_task_id();
+            auto task =
+              std::make_unique<pipeline::gpu_pipeline_task>(task_id,
+                                                            destination_data_repositories,
+                                                            std::move(local_state),
+                                                            gpu_pipeline_task_global_state);
+            task_lock.unlock();
+            _task_scheduler->schedule(std::move(task));
+
+            if (request_kind == request_type::lookahead) { break; }
           }
-
-          auto task_id = get_next_task_id();
-          auto task    = std::make_unique<pipeline::gpu_pipeline_task>(task_id,
-                                                                    destination_data_repositories,
-                                                                    std::move(local_state),
-                                                                    gpu_pipeline_task_global_state);
-          task_lock.unlock();
-          _task_scheduler->schedule(std::move(task));
-
-          if (request_kind == request_type::lookahead) { break; }
+          // Unconditional re-evaluation at every creation exit: with the
+          // source-exhaustion finish guard, "last task completed at T1,
+          // connector closed at T2>T1" has no later mark_task_completed() to
+          // re-check the pipeline — this call, observing the now-exhausted
+          // source, is the paired re-evaluation. Without it, normal fast-GPU
+          // queries would hang.
+          pipeline->update_pipeline_status(false);
+        } catch (const std::exception& e) {
+          SIRIUS_LOG_ERROR("Task Creator: Exception during task creation: {}", e.what());
+          _task_scheduler->terminate_query(std::current_exception());
+          stop();
         }
-        // Unconditional re-evaluation at every creation exit: with the
-        // source-exhaustion finish guard, "last task completed at T1,
-        // connector closed at T2>T1" has no later mark_task_completed() to
-        // re-check the pipeline — this call, observing the now-exhausted
-        // source, is the paired re-evaluation. Without it, normal fast-GPU
-        // queries would hang.
-        pipeline->update_pipeline_status(false);
-      } catch (const std::exception& e) {
-        SIRIUS_LOG_ERROR("Task Creator: Exception during task creation: {}", e.what());
-        _task_scheduler->terminate_query(std::current_exception());
-        stop();
-      }
-    });
+      });
   }
 }
 

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -21,17 +21,21 @@
 #include "exec/bounded_thread_pool.hpp"
 #include "exec/config.hpp"
 #include "exec/interruptible_mpmc.hpp"
+#include "exec/multi_index_priority_queue.hpp"
 #include "exec/queue_priority.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "op/scan/sirius_gpu_scan_operator.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "pipeline/sirius_pipeline.hpp"
+#include "query_id.hpp"
 
 #include <blockingconcurrentqueue.h>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
 
 #include <atomic>
+#include <condition_variable>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -71,6 +75,14 @@ namespace sirius::creator {
 struct task_creation_request {
   op::sirius_physical_operator* node;
   request_type type = request_type::active;
+  //! The query `node` belongs to. Indexes the request in the creation queue so a finished or
+  //! failed query's pending requests can be dropped without touching any other query's.
+  sirius::query_id_t query_id = sirius::make_query_id(0);
+  //! Scheduling priority of `node`'s pipeline; orders the creation queue the same way the
+  //! execution queue is ordered (query first, then within-query pipeline rank).
+  exec::queue_priority priority = 0;
+  //! Preferred GPU, when the caller had a hint. Only a secondary index; does not bind the task.
+  int device_id = exec::no_preferred_device;
 };
 
 class task_creator {
@@ -107,17 +119,31 @@ class task_creator {
   /// \brief The GPU subset this query was admitted onto.
   [[nodiscard]] const std::vector<int>& get_active_gpu_ids() const noexcept;
 
-  /// \brief sets client context needed for task creation
-  void set_client_context(::duckdb::ClientContext& client_context);
+  /// \brief Bind @p query_id to the connection that is running it.
+  /// Called at execution-window begin, before prepare_for_query.
+  void set_client_context(sirius::query_id_t query_id, ::duckdb::ClientContext& client_context);
 
   /// \brief sets pipeline executor reference
   void set_task_scheduler(sirius::pipeline::task_scheduler& task_scheduler);
 
-  /// \brief prepare global states for all pipelines in the query
+  /// \brief Register the per-query state for @p query's pipelines.
+  ///
+  /// Adds an entry; it does NOT clear other queries' entries. Call reset(query_id) to drop one.
   void prepare_for_query(const sirius::planner::query& query);
 
-  /// \brief clean-up query bound resources and prepare the task creator for next query
-  void reset();
+  /// \brief Drop everything held for @p query_id: pending creation requests, in-flight creation
+  /// work, and the per-query state entry. Other queries are untouched.
+  ///
+  /// Runs on both the success and the failure path (SiriusContext::run_mandatory_cleanup, which
+  /// StandaloneQueryScope guarantees exactly once), so a failed query cannot leave the shared
+  /// creator holding stale operator pointers.
+  ///
+  /// Must complete before @p query_id's planner::query is destroyed: queued requests hold raw
+  /// operator pointers into its plan.
+  void reset(sirius::query_id_t query_id);
+
+  /// \brief Drop every query's state. Teardown only (SiriusContext::terminate).
+  void reset_all();
 
   /**
    * @brief Stop the task creator and its thread pool.
@@ -141,12 +167,14 @@ class task_creator {
   void stop_thread_pool();
 
   /**
-   * @brief Drain all pending task creation requests and wait for in-flight tasks to complete.
+   * @brief Drop @p query_id's pending creation requests and wait for its in-flight creation
+   *        work to finish. Other queries keep running.
    *
    * Call this after a query completes (future resolved) but before destroying the engine/operators
-   * to ensure no stale operator pointers are accessed by the task creator threads.
+   * to ensure no stale operator pointers are accessed by the task creator threads. Unlike the
+   * previous global drain, this neither interrupts the queue nor waits on other queries' work.
    */
-  void drain_pending_tasks();
+  void drain_pending_tasks(sirius::query_id_t query_id);
 
   /**
    * @brief Schedule a task creation info for processing.
@@ -155,7 +183,11 @@ class task_creator {
    */
   virtual void schedule(op::sirius_physical_operator* request);
 
-  void schedule_lookahead(std::optional<int> device_id_hint = std::nullopt);
+  /// \brief Overload for callers that already know the query; avoids re-deriving it.
+  void schedule(op::sirius_physical_operator* request, sirius::query_id_t query_id);
+
+  void schedule_lookahead(sirius::query_id_t query_id,
+                          std::optional<int> device_id_hint = std::nullopt);
 
   /**
    * @brief Get the next task id.
@@ -225,21 +257,57 @@ class task_creator {
   sirius::memory::sirius_memory_reservation_manager& _mem_res_mgr;
   std::atomic<uint64_t> _task_id{0};
 
-  std::mutex _lookahead_mutex;              // Protect concurrent access to the lookahead scheduling
-  std::size_t _index_of_next_lookahead{0};  // Index of the next operator to lookahead for
-  std::vector<op::sirius_physical_operator*> _lookahead_queue;
+  /**
+   * @brief Everything the task creator holds on behalf of ONE query.
+   *
+   * Handed out as a `shared_ptr`: a worker resolves it once and then reads `global_states`,
+   * which is never mutated after `prepare_for_query`. That makes the lookup race-free even if
+   * the query is erased concurrently — the worker's copy keeps the state alive until it is done.
+   * Operator ids restart at 0 for every query, so `global_states` is only unique *within* an
+   * entry; keying it globally is what would let two queries fetch each other's state.
+   */
+  struct query_task_state {
+    //! Source operator id -> that pipeline's task global state. Written once by
+    //! prepare_for_query, read-only afterwards.
+    std::unordered_map<size_t, std::shared_ptr<pipeline::sirius_pipeline_task_global_state>>
+      global_states;
+
+    //! Client context of the connection running this query. Per query because two concurrent
+    //! queries on different connections have different contexts.
+    ::duckdb::ClientContext* client_context{nullptr};
+
+    std::mutex lookahead_mutex;
+    std::size_t index_of_next_lookahead{0};
+    std::vector<op::sirius_physical_operator*> lookahead_queue;
+
+    //! Per-query stand-in for `bounded_thread_pool::wait_all()`, which can only wait on every
+    //! query's creation work at once. Incremented before dispatch, decremented when the lambda
+    //! leaves (including by exception); `wait_for_in_flight()` blocks until it reaches zero.
+    std::mutex in_flight_mutex;
+    std::condition_variable in_flight_cv;
+    std::size_t in_flight{0};
+
+    void enter_in_flight();
+    void leave_in_flight();
+    void wait_for_in_flight();
+  };
+
+  //! Resolve a query's state, or nullptr when it has already been reset.
+  std::shared_ptr<query_task_state> get_query_state(sirius::query_id_t query_id) const;
 
   // Queue for creating tasks based on operators. The operator is the starting point to start
   // looking which task should be created, not necessarily the operator for whose pipeline the task
-  // will be created
-  exec::interruptible_mpmc<std::unique_ptr<task_creation_request>> _task_creation_queue;
+  // will be created.
+  //
+  // A multi_index_priority_queue rather than a plain FIFO so that (a) creation is ordered the
+  // same way execution is — earlier query first, then pipeline rank — and (b) a single query's
+  // pending requests can be dropped via drain(query_index{...}) without disturbing any other
+  // query's.
+  exec::multi_index_priority_queue<task_creation_request> _task_creation_queue;
 
-  // Map of operator ID to global state for scan operators
-  std::unordered_map<size_t, std::shared_ptr<pipeline::sirius_pipeline_task_global_state>>
-    _gpu_operator_global_state_map;
-  std::unique_ptr<duckdb::ThreadContext> _thread_context;
-  std::unique_ptr<duckdb::ExecutionContext> _execution_context;
-  std::mutex _global_state_mutex;  // Protect concurrent access to the map
+  //! One entry per in-flight query. Guarded by _global_state_mutex.
+  std::map<sirius::query_id_t, std::shared_ptr<query_task_state>> _query_states;
+  mutable std::mutex _global_state_mutex;  // Protect concurrent access to _query_states
 
   /// Shared GPU<->NUMA topology index for NUMA-aware GPU routing (may be null).
   /// Scoped to the memory manager's reserved GPU/HOST spaces:

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -190,12 +190,19 @@ class task_creator {
   void schedule_lookahead(sirius::query_id_t query_id,
                           std::optional<int> device_id_hint = std::nullopt);
 
-  /// \brief Fail the running query with @p error and stop the creator.
+  /// \brief Fail the running query with @p error.
   ///
   /// schedule() throws on an operator that carries no pipeline. Callers on paths that must not
   /// propagate (sirius_pipeline::notify_downstream_pipelines runs from ~gpu_pipeline_task and
   /// from the streaming-source close callback) route the exception here instead, so the query
   /// surfaces the error rather than the process terminating.
+  ///
+  /// Deliberately does NOT stop any thread pool itself: this can run on a worker thread that is
+  /// itself a member of one of those pools (this creator's own, or a GPU executor's, via
+  /// ~gpu_pipeline_task), and synchronously stopping/draining a pool from its own worker is a
+  /// self-wait deadlock (bounded_thread_pool::wait_all() blocks on the very slot the caller is
+  /// occupying). Only fulfills the completion future; task_scheduler::drain_after_error(),
+  /// called by the query thread once it observes the error, does the actual draining.
   void report_fatal_error(std::exception_ptr error);
 
   /**
@@ -318,6 +325,16 @@ class task_creator {
   //! One entry per in-flight query. Guarded by _global_state_mutex.
   std::map<sirius::query_id_t, std::shared_ptr<query_task_global_state>> _query_task_global_states;
   mutable std::mutex _global_state_mutex;  // Protect concurrent access to _query_task_global_states
+
+  //! Serializes start_thread_pool()/stop_thread_pool() against each other and guards
+  //! _bounded_pool/_manager_thread. Deliberately separate from _global_state_mutex:
+  //! do_stop_thread_pool() joins _manager_thread while holding this lock, and manager_loop()
+  //! (running on that thread) takes _global_state_mutex on every request via
+  //! get_query_task_global_state(). Sharing one mutex between the two let a worker thread's
+  //! error-triggered stop_thread_pool() call block on the join while holding the very lock
+  //! manager_loop() needed to reach its own exit check -- a real deadlock, not a theoretical one,
+  //! since manager_loop() passes through that lock on every iteration.
+  std::mutex _thread_pool_mutex;
 
   /// Shared GPU<->NUMA topology index for NUMA-aware GPU routing (may be null).
   /// Scoped to the memory manager's reserved GPU/HOST spaces:

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -266,7 +266,7 @@ class task_creator {
    * Operator ids restart at 0 for every query, so `global_states` is only unique *within* an
    * entry; keying it globally is what would let two queries fetch each other's state.
    */
-  struct query_task_state {
+  struct query_task_global_state {
     //! Source operator id -> that pipeline's task global state. Written once by
     //! prepare_for_query, read-only afterwards.
     std::unordered_map<size_t, std::shared_ptr<pipeline::sirius_pipeline_task_global_state>>
@@ -293,7 +293,8 @@ class task_creator {
   };
 
   //! Resolve a query's state, or nullptr when it has already been reset.
-  std::shared_ptr<query_task_state> get_query_state(sirius::query_id_t query_id) const;
+  std::shared_ptr<query_task_global_state> get_query_task_global_state(
+    sirius::query_id_t query_id) const;
 
   // Queue for creating tasks based on operators. The operator is the starting point to start
   // looking which task should be created, not necessarily the operator for whose pipeline the task
@@ -306,8 +307,8 @@ class task_creator {
   exec::multi_index_priority_queue<task_creation_request> _task_creation_queue;
 
   //! One entry per in-flight query. Guarded by _global_state_mutex.
-  std::map<sirius::query_id_t, std::shared_ptr<query_task_state>> _query_states;
-  mutable std::mutex _global_state_mutex;  // Protect concurrent access to _query_states
+  std::map<sirius::query_id_t, std::shared_ptr<query_task_global_state>> _query_task_global_states;
+  mutable std::mutex _global_state_mutex;  // Protect concurrent access to _query_task_global_states
 
   /// Shared GPU<->NUMA topology index for NUMA-aware GPU routing (may be null).
   /// Scoped to the memory manager's reserved GPU/HOST spaces:

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -35,6 +35,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <exception>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -188,6 +189,14 @@ class task_creator {
 
   void schedule_lookahead(sirius::query_id_t query_id,
                           std::optional<int> device_id_hint = std::nullopt);
+
+  /// \brief Fail the running query with @p error and stop the creator.
+  ///
+  /// schedule() throws on an operator that carries no pipeline. Callers on paths that must not
+  /// propagate (sirius_pipeline::notify_downstream_pipelines runs from ~gpu_pipeline_task and
+  /// from the streaming-source close callback) route the exception here instead, so the query
+  /// surfaces the error rather than the process terminating.
+  void report_fatal_error(std::exception_ptr error);
 
   /**
    * @brief Get the next task id.

--- a/src/include/exec/multi_index_priority_queue.hpp
+++ b/src/include/exec/multi_index_priority_queue.hpp
@@ -175,14 +175,18 @@ class multi_index_priority_queue {
   /// teardown contract callers rely on (e.g. returning a task to a closed queue).
   /// Strongly exception-safe: if any allocation throws, the queue is left as it
   /// was (the task is destroyed) and nothing is enqueued.
-  void push(task_ptr task)
+  ///
+  /// \return true if the task was enqueued, false if it was dropped because the queue is
+  ///         interrupted. Callers that only enqueue may ignore it; those that report dropped
+  ///         work (itask_executor::schedule) rely on it.
+  bool push(task_ptr task)
   {
     assert(task && "cannot push a null task");
     const index_keys keys = _extract(*task);
     {
       std::lock_guard<std::mutex> lock(_mutex);
       // Interrupted (shutdown): drop the task instead of enqueuing it.
-      if (!_active) { return; }
+      if (!_active) { return false; }
 
       auto lit             = _levels.find(keys.priority);
       const bool new_level = (lit == _levels.end());
@@ -230,6 +234,7 @@ class multi_index_priority_queue {
       }
     }
     _cv.notify_all();
+    return true;
   }
 
   /// Blocks until the globally-first (lowest-priority-value) task is available and

--- a/src/include/parallel/task_executor.hpp
+++ b/src/include/parallel/task_executor.hpp
@@ -18,8 +18,9 @@
 
 #include "exec/bounded_thread_pool.hpp"
 #include "exec/config.hpp"
-#include "exec/inspectable_mpsc.hpp"
+#include "exec/multi_index_priority_queue.hpp"
 #include "parallel/task.hpp"
+#include "query_id.hpp"
 
 #include <absl/functional/any_invocable.h>
 
@@ -97,9 +98,18 @@ class itask_executor {
   void wait_all();
 
   /**
-   * @brief Drain any leftover tasks remaining in the queue.
+   * @brief Drain any leftover tasks remaining in the queue, for every query.
    */
   void drain_leftover_tasks();
+
+  /**
+   * @brief Drop the queued tasks belonging to one query.
+   *
+   * Tasks of other queries are left in place and the queue stays open, so unlike interrupt()
+   * this does not stall any other query's producers or consumers. Only queued work is affected;
+   * a task already dispatched to the thread pool runs to completion.
+   */
+  void drain_query_tasks(sirius::query_id_t query_id);
 
   /**
    * @brief Drain in-flight tasks and restart the manager, ready for the next query.
@@ -171,7 +181,10 @@ class itask_executor {
   std::atomic<bool> _running{false};
   exec::thread_pool_config _config;
   std::unique_ptr<exec::bounded_thread_pool> _bounded_pool;
-  exec::inspectable_mpsc<itask> _task_queue;
+  /// Ordered by task priority and indexed by query, so one query's queued work can be
+  /// dropped without touching another's. Keys come from pipeline::index_keys_for, the
+  /// same extractor the task_scheduler's queue uses.
+  exec::multi_index_priority_queue<itask> _task_queue;
   std::thread _manager_thread;
   std::shared_ptr<const telemetry::telemetry_context> _telemetry_context;
   std::unique_ptr<telemetry::TaskQueueHandleWrapper> _task_queue_telemetry;

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -316,5 +316,23 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
   uint64_t _reservation_bytes = 0;
 };
 
+/**
+ * @brief Multi-index keys for a task sitting in one of the execution queues.
+ *
+ * Shared by the task_scheduler's queue and every gpu_pipeline_executor's queue so the two can
+ * never disagree about which query a task belongs to — a disagreement would make
+ * `drain(query_index{...})` clear a query's tasks from one queue but not the other.
+ *
+ * The queue orders by priority (lower value dispatched first) and additionally indexes by
+ * operator type, query id, and preferred device. A task that is not a gpu_pipeline_task gets the
+ * maximum priority, so it sorts last, with sentinel index keys.
+ *
+ * The query id comes from the task's pipeline, NOT from unpacking the priority's high bits:
+ * `sirius::query_priority_bits` masks the id to 31 bits, so the unpacked value diverges from the
+ * real query id once bit 31 is set, and a `drain(query_index{value_of(query_id)})` would then
+ * silently miss the task.
+ */
+[[nodiscard]] exec::index_keys index_keys_for(const sirius::parallel::itask& task);
+
 }  // namespace pipeline
 }  // namespace sirius

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -20,11 +20,13 @@
 #include "common/reference_map.hpp"
 #include "duckdb/parallel/pipeline.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
+#include "exec/queue_priority.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_operator_type.hpp"
 #include "pipeline/completion_handler.hpp"
 #include "pipeline/pipeline_build_context.hpp"
 #include "pipeline/pipeline_memory_history.hpp"
+#include "query_id.hpp"
 #include "telemetry-bridge/gen/uuid.rs.h"
 
 #include <nvtx3/nvtx3.hpp>
@@ -157,6 +159,25 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   void set_pipeline_id(size_t id) { pipeline_id = id; }
   //! Get the pipeline ID
   size_t get_pipeline_id() const { return pipeline_id; }
+
+  //! Set this pipeline's scheduling priority. Mirrors the value task_creator puts on the
+  //! pipeline's task global state, kept here so a task-creation request can be keyed without
+  //! taking the task_creator's per-query lock on the schedule() hot path.
+  void set_priority(exec::queue_priority priority) noexcept { priority_ = priority; }
+  //! This pipeline's scheduling priority (lower runs first).
+  [[nodiscard]] exec::queue_priority get_priority() const noexcept { return priority_; }
+
+  //! Set the id of the query this pipeline belongs to. Stamped by planner::query once the
+  //! pipeline set is final; see get_query_id().
+  void set_query_id(sirius::query_id_t id) noexcept { query_id_ = id; }
+  //! The query this pipeline belongs to.
+  //!
+  //! Queue index keys are derived from this (see the multi_index_priority_queue extractors in
+  //! task_scheduler and task_creator), so that per-query drains target the right tasks. Read it
+  //! from here rather than recovering it from the packed scheduling priority: the priority masks
+  //! the id to 31 bits (see sirius::query_priority_bits), so the recovered value diverges from
+  //! the real query id once bit 31 is set.
+  [[nodiscard]] sirius::query_id_t get_query_id() const noexcept { return query_id_; }
   //! Returns the parent pipelines (pipelines that depend on this pipeline)
   std::vector<sirius_pipeline*> get_parents() const;
 
@@ -290,6 +311,11 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
 
   //! The unique ID of this pipeline (assigned based on new_scheduled order)
   size_t pipeline_id = 0;
+  //! The query this pipeline belongs to; stamped by planner::query. Defaults to 0, which is
+  //! never a live query id (window ids start at 1), so an unstamped pipeline is detectable.
+  sirius::query_id_t query_id_ = sirius::make_query_id(0);
+  //! Scheduling priority; stamped by task_creator::prepare_for_query.
+  exec::queue_priority priority_ = 0;
   //! Plan-time context (replaces sirius_engine& for plan-time needs)
   pipeline_build_context build_ctx_;
 

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -178,7 +178,14 @@ class task_scheduler {
   void drain_query_tasks(sirius::query_id_t query_id);
 
   /**
-   * @brief Terminate the query execution and report the error to duckdb.
+   * @brief Report a fatal query error via the completion future.
+   *
+   * Deliberately does NOT stop or drain any executor itself: callers can run on a GPU executor's
+   * or the task_creator's own worker thread (e.g. notify_downstream_pipelines() from
+   * ~gpu_pipeline_task), and synchronously stopping a pool from its own worker thread self-
+   * deadlocks in bounded_thread_pool::wait_all(). Fulfilling the future here is what makes the
+   * query thread's future.get() throw; its catch block then calls drain_after_error() to perform
+   * the actual cancellation from a thread that is never a pool worker.
    *
    * @param error The error to report.
    */

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -196,7 +196,11 @@ class task_scheduler {
  private:
   void management_eventloop();
 
-  std::mutex _query_mutex;
+  /// The query currently installed by prepare_for_query, or nullopt between queries.
+  /// Per-query task_creator cleanup is keyed on it.
+  [[nodiscard]] std::optional<sirius::query_id_t> current_query_id() const;
+
+  mutable std::mutex _query_mutex;
   duckdb::shared_ptr<planner::query> _query;
 
   /// Pipeline-level task queue, ordered by task priority (highest dispatched first).

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -167,6 +167,17 @@ class task_scheduler {
   std::future<void> start_query();
 
   /**
+   * @brief Drop every queued task belonging to @p query_id.
+   *
+   * Clears the scheduler's queue and each GPU executor's queue of that query's pending work,
+   * leaving every other query's tasks in place. In-flight tasks are unaffected.
+   *
+   * Called from the per-query cleanup so a finished or failed query leaves nothing queued that
+   * points into the plan about to be destroyed.
+   */
+  void drain_query_tasks(sirius::query_id_t query_id);
+
+  /**
    * @brief Terminate the query execution and report the error to duckdb.
    *
    * @param error The error to report.

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -644,9 +644,10 @@ class SiriusContext : public ClientContextState {
   void run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
                                       std::string_view end_tag) noexcept;
 
-  /// \brief Best-effort task_creator reset for latched-unavailable paths,
-  /// where no later window will ever run the in-cleanup reset.
-  void drop_task_creator_state_best_effort(sirius::query_id_t query_id) noexcept;
+  /// \brief Best-effort per-query teardown for latched-unavailable paths, where no later
+  /// window will ever run the in-cleanup reset: drops @p query_id's task_creator state and its
+  /// queued tasks. Each step is separately guarded; neither can throw.
+  void drop_query_runtime_state_best_effort(sirius::query_id_t query_id) noexcept;
 
   mutable std::mutex mutex_;
   // The Super Sirius runtime is shared across connections, so plan generation

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -646,7 +646,7 @@ class SiriusContext : public ClientContextState {
 
   /// \brief Best-effort task_creator reset for latched-unavailable paths,
   /// where no later window will ever run the in-cleanup reset.
-  void drop_task_creator_state_best_effort() noexcept;
+  void drop_task_creator_state_best_effort(sirius::query_id_t query_id) noexcept;
 
   mutable std::mutex mutex_;
   // The Super Sirius runtime is shared across connections, so plan generation

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -17,6 +17,7 @@
 #include "parallel/task_executor.hpp"
 
 #include "log/logging.hpp"
+#include "pipeline/gpu_pipeline_task.hpp"
 #include "pipeline/sirius_pipeline_itask.hpp"
 #include "telemetry/telemetry_context.hpp"
 
@@ -33,6 +34,9 @@ itask_executor::itask_executor(
   std::shared_ptr<const telemetry::telemetry_context> telemetry_context,
   std::optional<int> device_id)
   : _config(std::move(config)),
+    // Shared with the task_scheduler's queue so both derive a task's query the same way; see
+    // pipeline::index_keys_for.
+    _task_queue(&pipeline::index_keys_for),
     _telemetry_context(std::move(telemetry_context)),
     _task_queue_telemetry(std::make_unique<telemetry::TaskQueueHandleWrapper>(
       *_telemetry_context,
@@ -92,6 +96,11 @@ void itask_executor::wait_all()
 }
 
 void itask_executor::drain_leftover_tasks() { _task_queue.drain(); }
+
+void itask_executor::drain_query_tasks(sirius::query_id_t query_id)
+{
+  _task_queue.drain(exec::query_index{static_cast<exec::query_key>(sirius::value_of(query_id))});
+}
 
 void itask_executor::drain_and_wait()
 {

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -483,7 +483,7 @@ void gpu_pipeline_executor::set_task_creator(sirius::creator::task_creator* task
   _task_creator = task_creator;
 }
 
-bool gpu_pipeline_executor::is_task_queue_empty() const noexcept { return _task_queue.is_empty(); }
+bool gpu_pipeline_executor::is_task_queue_empty() const noexcept { return _task_queue.empty(); }
 
 executor_metrics gpu_pipeline_executor::get_metrics() const noexcept
 {

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -456,8 +456,17 @@ void gpu_pipeline_executor::manager_loop()
           // the task destructor only fires once the pipeline drains —
           // mid-pipeline batches need to start rotating before that point so
           // they reach all GPUs.
-          for (auto* consumer : consumers) {
-            if (consumer) { _task_creator->schedule(consumer); }
+          try {
+            for (auto* consumer : consumers) {
+              if (consumer) { _task_creator->schedule(consumer); }
+            }
+          } catch (const std::exception& e) {
+            SIRIUS_LOG_ERROR("GPU Pipeline Executor: failed to schedule downstream consumers: {}",
+                             e.what());
+            if (_completion_handler) {
+              _completion_handler->report_error(std::current_exception());
+            }
+            return;
           }
         }
 

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -462,7 +462,10 @@ void gpu_pipeline_executor::manager_loop()
         }
 
         if (query_complete && _completion_handler) {
-          _task_creator->drain_pending_tasks();
+          // Scoped to the finishing query: its pending creation requests point at operators
+          // that mark_completed() may let the engine destroy. Any other query's requests are
+          // left alone.
+          _task_creator->drain_pending_tasks(pipeline->get_query_id());
           _completion_handler->mark_completed();
         }
       });

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -39,6 +39,7 @@
 
 #include <cstdint>
 #include <format>
+#include <limits>
 #include <optional>
 #include <string>
 #include <unordered_set>
@@ -904,6 +905,31 @@ std::unique_ptr<gpu_pipeline_task> gpu_pipeline_task::create_rescheduled_task(
 {
   return std::make_unique<gpu_pipeline_task>(
     task_id, _data_repos, std::move(local_state), get_shared_global_state());
+}
+
+exec::index_keys index_keys_for(const sirius::parallel::itask& task)
+{
+  if (const auto* gpu_task = dynamic_cast<const gpu_pipeline_task*>(&task)) {
+    const exec::queue_priority priority = gpu_task->get_priority();
+
+    exec::query_key query_id         = 0;
+    exec::operator_key operator_type = op::SiriusPhysicalOperatorType::INVALID;
+    if (const auto* pipe = gpu_task->get_pipeline()) {
+      query_id = static_cast<exec::query_key>(sirius::value_of(pipe->get_query_id()));
+      if (auto source = pipe->get_source()) { operator_type = source->type; }
+    }
+
+    const auto pref = gpu_task->get_preferred_device_id();
+    return exec::index_keys{priority,
+                            operator_type,
+                            query_id,
+                            pref.has_value() ? pref.value() : exec::no_preferred_device};
+  }
+
+  return exec::index_keys{std::numeric_limits<exec::queue_priority>::max(),
+                          op::SiriusPhysicalOperatorType::INVALID,
+                          0,
+                          exec::no_preferred_device};
 }
 
 }  // namespace pipeline

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -363,11 +363,17 @@ void sirius_pipeline::notify_downstream_pipelines(bool original_pipeline)
   // If this is the original pipeline, we dont want to schedule tasks for its consumers, that will
   // be done later.
   if (_task_creator && !original_pipeline) {
-    for (auto* consumer : get_output_consumers()) {
-      // If is possible to have a race condition here where one task finished and here it does to
-      // schedule a task right when the last task finished and marks the operator as finalized. That
-      // is ok. This check here is to minimize unnecessary scheduling of task creation.
-      if (!consumer->finalized.load()) { _task_creator->schedule(consumer); }
+    try {
+      for (auto* consumer : get_output_consumers()) {
+        // If is possible to have a race condition here where one task finished and here it does to
+        // schedule a task right when the last task finished and marks the operator as finalized.
+        // That is ok. This check here is to minimize unnecessary scheduling of task creation.
+        if (!consumer->finalized.load()) { _task_creator->schedule(consumer); }
+      }
+    } catch (const std::exception& e) {
+      SIRIUS_LOG_ERROR(
+        "Pipeline {}: failed to schedule downstream consumers: {}", pipeline_id, e.what());
+      _task_creator->report_fatal_error(std::current_exception());
     }
   }
 

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -198,13 +198,20 @@ std::future<void> task_scheduler::start_query()
 
 void task_scheduler::terminate_query(std::exception_ptr error)
 {
+  // Report-only: this can be reached from a GPU executor's own worker thread (via
+  // notify_downstream_pipelines() in ~gpu_pipeline_task) or from the task_creator's own worker
+  // thread. stop() below joins each gpu_pipeline_executor's manager thread and then blocks in
+  // that executor's bounded_thread_pool::wait_all() -- if the calling thread is itself one of
+  // that pool's workers, its slot cannot free until this call returns, so wait_all() would never
+  // observe active_ == 0: a self-wait deadlock. report_error() alone fulfills the completion
+  // future; the query thread's future.get() (sirius_engine.cpp) throws and its catch block calls
+  // drain_after_error(), which does the actual draining from a thread that is never a pool worker.
   std::shared_ptr<completion_handler> completion;
   {
     std::scoped_lock lock(_query_mutex);
     completion = _completion_handler;
   }
   if (completion) { completion->report_error(std::move(error)); }
-  stop();
 }
 
 void task_scheduler::drain_after_error()

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -51,35 +51,9 @@ task_scheduler::task_scheduler(
   std::shared_ptr<const telemetry::telemetry_context> telemetry_context,
   const cucascade::memory::system_topology_info* sys_topology,
   const std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>>* downgrade_executors)
-  : _task_queue([](const sirius::parallel::itask& task) -> exec::index_keys {
-      // Derive the multi-index keys from the task. The queue orders by priority
-      // (lower value = dispatched first) and additionally indexes by operator type,
-      // query id, and preferred device. Non-pipeline tasks fall back to the maximum
-      // priority so they sort last, with sentinel index keys.
-      if (const auto* gpu_task = dynamic_cast<const pipeline::gpu_pipeline_task*>(&task)) {
-        const exec::queue_priority priority = gpu_task->get_priority();
-        // Take the query id from the pipeline, NOT by unpacking it out of the priority's high
-        // bits: sirius::query_priority_bits masks the id to 31 bits, so the unpacked value
-        // diverges from the real query id once bit 31 is set, and a
-        // drain(query_index{value_of(query_id)}) would then silently miss this task.
-        exec::query_key query_id         = 0;
-        exec::operator_key operator_type = op::SiriusPhysicalOperatorType::INVALID;
-        if (const auto* pipe = gpu_task->get_pipeline()) {
-          query_id = static_cast<exec::query_key>(sirius::value_of(pipe->get_query_id()));
-          if (auto source = pipe->get_source()) { operator_type = source->type; }
-        }
-        const auto pref = gpu_task->get_preferred_device_id();
-        return exec::index_keys{priority,
-                                operator_type,
-                                query_id,
-                                pref.has_value() ? pref.value() : exec::no_preferred_device};
-      }
-      return exec::index_keys{std::numeric_limits<exec::queue_priority>::max(),
-                              op::SiriusPhysicalOperatorType::INVALID,
-                              0,
-                              exec::no_preferred_device};
-    }),
-    _telemetry_context(std::move(telemetry_context))
+  // Shared with every gpu_pipeline_executor's queue so both agree on which query a task
+  // belongs to; see pipeline::index_keys_for.
+  : _task_queue(&index_keys_for), _telemetry_context(std::move(telemetry_context))
 {
   _task_queue_telemetry = std::make_unique<telemetry::TaskQueueHandleWrapper>(
     *_telemetry_context, "task-scheduler-gpu-queue", _telemetry_context->shared_group_id());
@@ -182,10 +156,9 @@ void task_scheduler::set_task_creator(sirius::creator::task_creator& task_creato
 
 void task_scheduler::prepare_for_query(duckdb::shared_ptr<planner::query> query)
 {
-  // Drain leftover tasks from previous query
-  for (auto& [device_id, gpu_exec] : _gpu_executors) {
-    gpu_exec->drain_leftover_tasks();
-  }
+  // No leftover-task drain here: each query drops its own queued work at cleanup
+  // (drain_query_tasks from SiriusContext::run_mandatory_cleanup). Draining every executor at
+  // query START would discard any other in-flight query's tasks along with the stale ones.
 
   std::lock_guard lock(_query_mutex);
   _query = std::move(query);
@@ -320,6 +293,17 @@ void task_scheduler::wait_for_completion()
   if (_task_creator) {
     if (auto query_id = current_query_id()) { _task_creator->drain_pending_tasks(*query_id); }
     _task_creator->start_thread_pool();
+  }
+}
+
+void task_scheduler::drain_query_tasks(sirius::query_id_t query_id)
+{
+  // Pending work only, and only this query's: the scheduler's own queue first, then each GPU
+  // executor's staging queue. In-flight tasks are untouched — quiescing those is
+  // wait_for_completion / drain_after_error's job.
+  _task_queue.drain(exec::query_index{static_cast<exec::query_key>(sirius::value_of(query_id))});
+  for (auto& [device_id, gpu_exec] : _gpu_executors) {
+    gpu_exec->drain_query_tasks(query_id);
   }
 }
 

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -58,13 +58,14 @@ task_scheduler::task_scheduler(
       // priority so they sort last, with sentinel index keys.
       if (const auto* gpu_task = dynamic_cast<const pipeline::gpu_pipeline_task*>(&task)) {
         const exec::queue_priority priority = gpu_task->get_priority();
-        // The scheduling priority packs query_id in its high 32 bits and the
-        // within-query pipeline rank in the low 32 (see task_creator), so the query
-        // id is recoverable here without extra plumbing.
-        const exec::query_key query_id =
-          static_cast<exec::query_key>(static_cast<std::uint64_t>(priority) >> 32);
+        // Take the query id from the pipeline, NOT by unpacking it out of the priority's high
+        // bits: sirius::query_priority_bits masks the id to 31 bits, so the unpacked value
+        // diverges from the real query id once bit 31 is set, and a
+        // drain(query_index{value_of(query_id)}) would then silently miss this task.
+        exec::query_key query_id         = 0;
         exec::operator_key operator_type = op::SiriusPhysicalOperatorType::INVALID;
         if (const auto* pipe = gpu_task->get_pipeline()) {
+          query_id = static_cast<exec::query_key>(sirius::value_of(pipe->get_query_id()));
           if (auto source = pipe->get_source()) { operator_type = source->type; }
         }
         const auto pref = gpu_task->get_preferred_device_id();
@@ -264,12 +265,12 @@ void task_scheduler::drain_after_error()
     gpu_exec->drain_and_wait();
   }
 
-  // Now that no executor can generate further task_creation_requests, discard
-  // any that accumulated (and release the shared_ptr<data_batch> references they
-  // hold, which would otherwise survive clear_all_repositories at QueryEnd and
-  // show up as inter-iteration "memory leak" warnings). drain_pending_tasks()
-  // reactivates the queue when done.
-  if (_task_creator) { _task_creator->drain_pending_tasks(); }
+  // Now that no executor can generate further task_creation_requests, discard the ones this
+  // query accumulated — they hold raw operator pointers into a plan that QueryEnd is about to
+  // destroy. Scoped to this query: any other in-flight query keeps its pending requests.
+  if (auto query_id = current_query_id(); query_id && _task_creator) {
+    _task_creator->drain_pending_tasks(*query_id);
+  }
 
   // Belt-and-suspenders: the executor restarts above emit device_ready signals,
   // and the management loop may have dispatched a leftover task into an executor
@@ -311,15 +312,22 @@ void task_scheduler::wait_for_completion()
     }
   } catch (...) {
     if (_task_creator) {
-      _task_creator->drain_pending_tasks();
+      if (auto query_id = current_query_id()) { _task_creator->drain_pending_tasks(*query_id); }
       _task_creator->start_thread_pool();
     }
     throw;
   }
   if (_task_creator) {
-    _task_creator->drain_pending_tasks();
+    if (auto query_id = current_query_id()) { _task_creator->drain_pending_tasks(*query_id); }
     _task_creator->start_thread_pool();
   }
+}
+
+std::optional<sirius::query_id_t> task_scheduler::current_query_id() const
+{
+  std::lock_guard lock(_query_mutex);
+  if (!_query) { return std::nullopt; }
+  return _query->query_id();
 }
 
 void task_scheduler::management_eventloop()
@@ -354,8 +362,9 @@ void task_scheduler::management_eventloop()
     // Work: let the creator pre-create for a waiting device (lookahead
     // strategy only), then sleep until something is pushed.
     if (_task_queue.empty()) {
-      if (_task_creator && !_ready_devices.empty()) {
-        _task_creator->schedule_lookahead(*_ready_devices.begin());
+      if (auto query_id = current_query_id();
+          query_id && _task_creator && !_ready_devices.empty()) {
+        _task_creator->schedule_lookahead(*query_id, *_ready_devices.begin());
       }
       if (!_task_queue.wait()) {
         SIRIUS_LOG_INFO("Task queue interrupted, exiting management event loop.");

--- a/src/planner/query.cpp
+++ b/src/planner/query.cpp
@@ -35,6 +35,9 @@ query::query(duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>> pipel
 void query::build_indices()
 {
   for (const auto& pipeline : _pipelines) {
+    // Stamp the query id so the task queues can derive their per-query index key from a
+    // pipeline without recovering it from the (31-bit-masked) scheduling priority.
+    pipeline->set_query_id(_query_id);
     for (auto& op : pipeline->get_operators()) {
       op.get().set_pipeline(pipeline);
     }

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -391,8 +391,9 @@ void SiriusContext::begin_execution_window(ClientContext& context,
   }
   // Register this query's repository manager up front
   data_repository_registry_.create_for_query(query_id);
-  task_creator_->reset();
-  task_creator_->set_client_context(context);
+  // Registers this query's task_creator state. No reset of a previous query here: each query
+  // owns its own entry now, and run_mandatory_cleanup drops it by id.
+  task_creator_->set_client_context(query_id, context);
   // GPU admission runs later, in sirius_engine::initialize_internal().
 }
 
@@ -405,6 +406,12 @@ void SiriusContext::run_mandatory_cleanup(sirius::query_id_t query_id, std::stri
     SIRIUS_LOG_INFO("QueryEnd");
   } catch (...) {
   }
+
+  // Drop this query's task_creator state FIRST: queued creation requests hold raw operator
+  // pointers into the plan that query_.reset() below destroys, and in-flight creation lambdas
+  // dereference them. reset() drains those requests and joins that work before returning.
+  // Only this query's is touched; other in-flight queries keep creating tasks.
+  if (task_creator_) { task_creator_->reset(query_id); }
 
   query_.reset();
 
@@ -453,14 +460,12 @@ void SiriusContext::run_mandatory_cleanup(sirius::query_id_t query_id, std::stri
   // host_data_representation are gone before the providers go away.
   if (scan_manager_) { scan_manager_->reset(); }
 
-  // Drop per-query global states held by task_creator. These include
-  // duckdb_scan_task_global_state, which transitively owns a
-  // duckdb::DuckTableScanState referencing BufferManager-owned BlockHandles.
-  // If we leave this state alive past the window, ~task_creator at
-  // SiriusContext teardown ends up releasing those BlockHandles after parts of
-  // DuckDB's DatabaseInstance have already been torn down (~DBConfig fires
-  // ~SiriusContext mid-DB destruction), which SIGSEGVs in ~BlockMemory.
-  if (task_creator_) { task_creator_->reset(); }
+  // NOTE: task_creator_->reset(query_id) already ran at the top of this function — it has to
+  // precede query_.reset(), since queued creation requests point into the plan that destroys.
+  // That reset is also what drops duckdb_scan_task_global_state, which transitively owns a
+  // duckdb::DuckTableScanState referencing BufferManager-owned BlockHandles; leaving it alive
+  // past the window would release those handles during ~task_creator at DB teardown (~DBConfig
+  // fires ~SiriusContext mid-DB destruction), which SIGSEGVs in ~BlockMemory.
 
   try {
     log_pool_stats(end_tag);
@@ -475,7 +480,7 @@ void SiriusContext::run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
     run_mandatory_cleanup(query_id, end_tag);
   } catch (std::exception& e) {
     mark_runtime_unavailable();
-    drop_task_creator_state_best_effort();
+    drop_task_creator_state_best_effort(query_id);
     try {
       SIRIUS_LOG_ERROR(
         "Mandatory per-query cleanup failed during unwind; marking the Sirius runtime "
@@ -485,7 +490,7 @@ void SiriusContext::run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
     }
   } catch (...) {
     mark_runtime_unavailable();
-    drop_task_creator_state_best_effort();
+    drop_task_creator_state_best_effort(query_id);
     try {
       SIRIUS_LOG_ERROR(
         "Mandatory per-query cleanup failed during unwind (unknown exception); marking the "
@@ -495,14 +500,14 @@ void SiriusContext::run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
   }
 }
 
-void SiriusContext::drop_task_creator_state_best_effort() noexcept
+void SiriusContext::drop_task_creator_state_best_effort(sirius::query_id_t query_id) noexcept
 {
   // Once the runtime is latched unavailable no later window will run the
   // task_creator reset, so the failed query's per-query global state (and the
   // buffer handles it retains) would survive until ~task_creator during DB
   // teardown — the exact shutdown-order crash the in-window reset prevents.
   try {
-    if (task_creator_) { task_creator_->reset(); }
+    if (task_creator_) { task_creator_->reset(query_id); }
   } catch (...) {
   }
 }
@@ -611,7 +616,7 @@ void SiriusContext::StandaloneQueryScope::finish()
     // error.
     state_ = scope_state::FAILED;
     ctx_.mark_runtime_unavailable();
-    ctx_.drop_task_creator_state_best_effort();
+    ctx_.drop_task_creator_state_best_effort(window_id_);
     log_window_event("end", "cleanup_failed");
     throw;
   }
@@ -902,6 +907,11 @@ void SiriusContext::terminate()
   task_scheduler_->stop();
   if (scan_manager_) { scan_manager_->stop(); }
   task_creator_->stop_thread_pool();
+  // Drop any per-query state a window failed to clean up (e.g. a latched-unavailable path whose
+  // best-effort reset threw). Doing it here, rather than letting ~task_creator do it, keeps the
+  // DuckTableScanState/BlockHandle releases inside the window where DuckDB is still intact.
+  task_creator_->reset_all();
+  task_creator_.reset();
   for (auto& executor : downgrade_executors_) {
     executor->stop();
   }

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -413,6 +413,12 @@ void SiriusContext::run_mandatory_cleanup(sirius::query_id_t query_id, std::stri
   // Only this query's is touched; other in-flight queries keep creating tasks.
   if (task_creator_) { task_creator_->reset(query_id); }
 
+  // With the producer stopped, drop whatever it already queued for this query. Ordering is
+  // deliberate: task_creator first so nothing new arrives, then the queues, then query_.reset()
+  // below — queued tasks reach operators through their pipeline, so they must be gone before the
+  // plan is destroyed. Other in-flight queries keep their queued work.
+  if (task_scheduler_) { task_scheduler_->drain_query_tasks(query_id); }
+
   query_.reset();
 
   // Drain all downgrade executors before clearing repositories — ensures no downgrade
@@ -480,7 +486,7 @@ void SiriusContext::run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
     run_mandatory_cleanup(query_id, end_tag);
   } catch (std::exception& e) {
     mark_runtime_unavailable();
-    drop_task_creator_state_best_effort(query_id);
+    drop_query_runtime_state_best_effort(query_id);
     try {
       SIRIUS_LOG_ERROR(
         "Mandatory per-query cleanup failed during unwind; marking the Sirius runtime "
@@ -490,7 +496,7 @@ void SiriusContext::run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
     }
   } catch (...) {
     mark_runtime_unavailable();
-    drop_task_creator_state_best_effort(query_id);
+    drop_query_runtime_state_best_effort(query_id);
     try {
       SIRIUS_LOG_ERROR(
         "Mandatory per-query cleanup failed during unwind (unknown exception); marking the "
@@ -500,14 +506,22 @@ void SiriusContext::run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
   }
 }
 
-void SiriusContext::drop_task_creator_state_best_effort(sirius::query_id_t query_id) noexcept
+void SiriusContext::drop_query_runtime_state_best_effort(sirius::query_id_t query_id) noexcept
 {
-  // Once the runtime is latched unavailable no later window will run the
-  // task_creator reset, so the failed query's per-query global state (and the
-  // buffer handles it retains) would survive until ~task_creator during DB
-  // teardown — the exact shutdown-order crash the in-window reset prevents.
+  // Reached only when run_mandatory_cleanup threw, which means it may have aborted BEFORE its
+  // own reset/drain pair ran. Once the runtime is latched unavailable no later window will run
+  // them either, so the failed query's per-query state (and the buffer handles it retains)
+  // would survive until ~task_creator during DB teardown — the exact shutdown-order crash the
+  // in-window reset prevents.
+  //
+  // Same order as the main path: stop the producer, then drop what it queued. Each step is
+  // independently guarded so a throw in one still lets the other run.
   try {
     if (task_creator_) { task_creator_->reset(query_id); }
+  } catch (...) {
+  }
+  try {
+    if (task_scheduler_) { task_scheduler_->drain_query_tasks(query_id); }
   } catch (...) {
   }
 }
@@ -616,7 +630,7 @@ void SiriusContext::StandaloneQueryScope::finish()
     // error.
     state_ = scope_state::FAILED;
     ctx_.mark_runtime_unavailable();
-    ctx_.drop_task_creator_state_best_effort(window_id_);
+    ctx_.drop_query_runtime_state_best_effort(window_id_);
     log_window_event("end", "cleanup_failed");
     throw;
   }

--- a/test/cpp/creator/test_task_creator.cpp
+++ b/test/cpp/creator/test_task_creator.cpp
@@ -158,15 +158,20 @@ class testable_task_creator : public task_creator {
   testable_task_creator(int num_threads,
                         duckdb::ClientContext& client_context,
                         task_scheduler& task_sched,
-                        sirius::memory::sirius_memory_reservation_manager& mem_res_mgr)
+                        sirius::memory::sirius_memory_reservation_manager& mem_res_mgr,
+                        sirius::query_id_t query_id = sirius::make_query_id(1))
     : task_creator(
         creator::task_creator_config{
           .thread_pool = {.num_threads = num_threads, .thread_name_prefix = "task_creator"}},
-        mem_res_mgr)
+        mem_res_mgr),
+      _query_id(query_id)
   {
-    this->set_client_context(client_context);
+    // Binding a client context is what registers the query's state.
+    this->set_client_context(query_id, client_context);
     this->set_task_scheduler(task_sched);
   }
+
+  [[nodiscard]] sirius::query_id_t query_id() const noexcept { return _query_id; }
 
   void schedule(op::sirius_physical_operator* request) override
   {
@@ -209,6 +214,7 @@ class testable_task_creator : public task_creator {
   std::atomic<size_t> _schedule_count{0};
   std::vector<sirius_physical_operator*> _scheduled_nodes;
   std::vector<duckdb::shared_ptr<sirius_pipeline>> _scheduled_pipelines;
+  sirius::query_id_t _query_id;
   std::mutex _scheduled_mutex;
 };
 

--- a/test/cpp/creator/test_task_creator_query_state.cpp
+++ b/test/cpp/creator/test_task_creator_query_state.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_task_creator_query_state.cpp
+ * @brief The task_creator holds one state entry per in-flight query.
+ *
+ * Operator ids restart at 0 for every query, so a globally-keyed task_creator would let one
+ * query resolve another's pipeline global state. These cases pin the entry lifecycle: two
+ * queries coexist, cleanup targets exactly one, and the paths that run on a failed query
+ * (repeated reset, reset of a query that never registered) stay harmless.
+ */
+
+#include "catch.hpp"
+#include "creator/config.hpp"
+#include "creator/task_creator.hpp"
+#include "operator/operator_test_utils.hpp"
+#include "query_id.hpp"
+
+#include <duckdb.hpp>
+
+#include <memory>
+
+namespace {
+
+using sirius::creator::task_creator;
+using sirius::creator::task_creator_config;
+
+//! Minimal harness: a task_creator plus the memory manager it requires. No task_scheduler is
+//! wired because none of the per-query lifecycle entry points below dispatch tasks.
+struct query_state_fixture {
+  query_state_fixture()
+    : memory_manager(initialize_memory_manager(1)),
+      creator(task_creator_config{}, *memory_manager)
+  {
+  }
+
+  duckdb::DuckDB db{nullptr};
+  duckdb::Connection con{db};
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory_manager;
+  task_creator creator;
+};
+
+const sirius::query_id_t kQueryA = sirius::make_query_id(1);
+const sirius::query_id_t kQueryB = sirius::make_query_id(2);
+
+}  // namespace
+
+TEST_CASE("task_creator holds independent state per query", "[task_creator][query_state]")
+{
+  query_state_fixture f;
+
+  // Binding a client context is what registers a query's entry.
+  f.creator.set_client_context(kQueryA, *f.con.context);
+  f.creator.set_client_context(kQueryB, *f.con.context);
+
+  // Dropping one query leaves the other's entry intact and independently droppable.
+  f.creator.reset(kQueryA);
+  REQUIRE_NOTHROW(f.creator.reset(kQueryB));
+}
+
+TEST_CASE("task_creator reset of an unregistered query is a no-op", "[task_creator][query_state]")
+{
+  query_state_fixture f;
+  f.creator.set_client_context(kQueryA, *f.con.context);
+
+  // Cleanup runs for every execution window, including ones that never bind a query (a
+  // pin_table window, or a query that fails before prepare_for_query).
+  REQUIRE_NOTHROW(f.creator.reset(sirius::make_query_id(4242)));
+  // The miss must not disturb the query that is registered.
+  REQUIRE_NOTHROW(f.creator.reset(kQueryA));
+}
+
+TEST_CASE("task_creator reset is idempotent for one query", "[task_creator][query_state]")
+{
+  query_state_fixture f;
+  f.creator.set_client_context(kQueryA, *f.con.context);
+
+  // StandaloneQueryScope::finish() and its noexcept destructor backstop both route to cleanup,
+  // so a failed query can reset twice.
+  f.creator.reset(kQueryA);
+  REQUIRE_NOTHROW(f.creator.reset(kQueryA));
+}
+
+TEST_CASE("task_creator drain_pending_tasks targets a single query",
+          "[task_creator][query_state]")
+{
+  query_state_fixture f;
+  f.creator.set_client_context(kQueryA, *f.con.context);
+  f.creator.set_client_context(kQueryB, *f.con.context);
+
+  // Draining one query must not require the other to have queued anything, and an unknown
+  // query drains cleanly — the queue stays open for every other producer either way.
+  REQUIRE_NOTHROW(f.creator.drain_pending_tasks(kQueryA));
+  REQUIRE_NOTHROW(f.creator.drain_pending_tasks(kQueryB));
+  REQUIRE_NOTHROW(f.creator.drain_pending_tasks(sirius::make_query_id(99)));
+
+  // Both entries survive a drain: draining pending work is not the same as dropping the query.
+  REQUIRE_NOTHROW(f.creator.reset(kQueryA));
+  REQUIRE_NOTHROW(f.creator.reset(kQueryB));
+}
+
+TEST_CASE("task_creator reset_all drops every query's state", "[task_creator][query_state]")
+{
+  query_state_fixture f;
+  f.creator.set_client_context(kQueryA, *f.con.context);
+  f.creator.set_client_context(kQueryB, *f.con.context);
+
+  // Teardown path (SiriusContext::terminate), so that a state a window failed to clean up does
+  // not survive into ~task_creator during database destruction.
+  REQUIRE_NOTHROW(f.creator.reset_all());
+  REQUIRE_NOTHROW(f.creator.reset(kQueryA));
+}

--- a/test/cpp/creator/test_task_creator_query_state.cpp
+++ b/test/cpp/creator/test_task_creator_query_state.cpp
@@ -43,8 +43,7 @@ using sirius::creator::task_creator_config;
 //! wired because none of the per-query lifecycle entry points below dispatch tasks.
 struct query_state_fixture {
   query_state_fixture()
-    : memory_manager(initialize_memory_manager(1)),
-      creator(task_creator_config{}, *memory_manager)
+    : memory_manager(initialize_memory_manager(1)), creator(task_creator_config{}, *memory_manager)
   {
   }
 
@@ -95,8 +94,7 @@ TEST_CASE("task_creator reset is idempotent for one query", "[task_creator][quer
   REQUIRE_NOTHROW(f.creator.reset(kQueryA));
 }
 
-TEST_CASE("task_creator drain_pending_tasks targets a single query",
-          "[task_creator][query_state]")
+TEST_CASE("task_creator drain_pending_tasks targets a single query", "[task_creator][query_state]")
 {
   query_state_fixture f;
   f.creator.set_client_context(kQueryA, *f.con.context);

--- a/test/cpp/creator/test_task_creator_schedule_validation.cpp
+++ b/test/cpp/creator/test_task_creator_schedule_validation.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_task_creator_schedule_validation.cpp
+ * @brief schedule() keys every creation request by the operator's pipeline (query id +
+ *        priority), so a pipeline-less operator has no valid key.
+ *
+ * Accepting one and substituting query 0 would not surface until much later: manager_loop()
+ * finds no state registered for query 0 and drops the request, and the query then waits forever
+ * for a task that was never created. These cases pin the loud failure instead.
+ */
+
+#include "catch.hpp"
+#include "creator/config.hpp"
+#include "creator/task_creator.hpp"
+#include "op/sirius_physical_operator.hpp"
+#include "op/sirius_physical_operator_type.hpp"
+#include "operator/operator_test_utils.hpp"
+#include "pipeline/pipeline_build_context.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "query_id.hpp"
+#include "sirius/exception.hpp"
+
+#include <memory>
+
+namespace {
+
+using sirius::creator::task_creator;
+using sirius::creator::task_creator_config;
+
+struct schedule_fixture {
+  schedule_fixture()
+    : memory_manager(sirius::test::operator_utils::initialize_memory_manager(1)),
+      creator(task_creator_config{}, *memory_manager)
+  {
+  }
+
+  //! An operator that no pipeline ever claimed, as an unplaced plan node would be.
+  std::unique_ptr<sirius::op::sirius_physical_operator> make_operator()
+  {
+    auto op = std::make_unique<sirius::op::sirius_physical_operator>(
+      sirius::op::SiriusPhysicalOperatorType::FILTER,
+      duckdb::vector<sirius::logical_type>{},
+      /*estimated_cardinality=*/0);
+    op->operator_id = 0;
+    return op;
+  }
+
+  //! Place @p op in a pipeline the way planner::query::build_indices does.
+  duckdb::shared_ptr<sirius::pipeline::sirius_pipeline> place(
+    sirius::op::sirius_physical_operator& op, sirius::query_id_t query_id)
+  {
+    auto pipeline = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(build_ctx);
+    sirius::pipeline::sirius_pipeline_build_state build_state;
+    build_state.set_pipeline_source(*pipeline, op);
+    build_state.set_pipeline_sink(*pipeline, &op, /*sink_pipeline_count=*/1);
+    pipeline->set_query_id(query_id);
+    pipeline->set_priority(3);
+    op.set_pipeline(pipeline);
+    return pipeline;
+  }
+
+  sirius::pipeline::pipeline_build_context build_ctx{nullptr, true};
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory_manager;
+  task_creator creator;
+};
+
+}  // namespace
+
+TEST_CASE("task_creator::schedule rejects a null operator", "[task_creator][schedule]")
+{
+  schedule_fixture f;
+
+  REQUIRE_THROWS_AS(f.creator.schedule(nullptr), sirius::internal_exception);
+}
+
+TEST_CASE("task_creator::schedule rejects an operator with no pipeline", "[task_creator][schedule]")
+{
+  schedule_fixture f;
+  auto op = f.make_operator();
+
+  // The creation worker dereferences node->get_pipeline() unconditionally, so there is no
+  // meaningful way to service this request; failing at the producer names the operator.
+  REQUIRE_THROWS_AS(f.creator.schedule(op.get()), sirius::internal_exception);
+}
+
+TEST_CASE("task_creator::schedule accepts a placed operator", "[task_creator][schedule]")
+{
+  schedule_fixture f;
+  const auto query_id = sirius::make_query_id(11);
+  auto op             = f.make_operator();
+  auto pipeline       = f.place(*op, query_id);
+
+  REQUIRE_NOTHROW(f.creator.schedule(op.get()));
+
+  // Drop the queued request before `op` dies: it holds a raw pointer into the plan.
+  f.creator.drain_pending_tasks(query_id);
+}
+
+TEST_CASE("task_creator::schedule with an explicit query id still requires a pipeline",
+          "[task_creator][schedule]")
+{
+  schedule_fixture f;
+  auto op = f.make_operator();
+
+  // The query id is supplied here, but the priority still comes from the pipeline, so the
+  // overload is no laxer than the one-argument form.
+  REQUIRE_THROWS_AS(f.creator.schedule(op.get(), sirius::make_query_id(11)),
+                    sirius::internal_exception);
+}

--- a/test/cpp/exec/test_multi_index_priority_queue.cpp
+++ b/test/cpp/exec/test_multi_index_priority_queue.cpp
@@ -224,6 +224,26 @@ TEST_CASE("multi_index query index spans its levels", "[multi_index_priority_que
 }
 
 // =============================================================================
+// Per-query drain
+// =============================================================================
+
+TEST_CASE("multi_index drain(query_index) leaves the queue open for later pushes",
+          "[multi_index_priority_queue]")
+{
+  multi_index_priority_queue<payload> q(by_keys());
+  q.push(task(1, keys_of(5, SiriusPhysicalOperatorType::FILTER, /*query=*/7)));
+
+  q.drain(query_index{7});
+
+  // Unlike interrupt(), a per-query drain must not close the queue: other queries keep
+  // producing through it, and the drained query id may even be reused by a later push.
+  REQUIRE(q.is_open());
+  q.push(task(2, keys_of(5, SiriusPhysicalOperatorType::FILTER, /*query=*/8)));
+  REQUIRE(q.size() == 1);
+  REQUIRE(q.pop()->id == 2);
+}
+
+// =============================================================================
 // Cross-index consistency
 // =============================================================================
 

--- a/test/cpp/exec/test_streaming_fragment.cpp
+++ b/test/cpp/exec/test_streaming_fragment.cpp
@@ -320,22 +320,28 @@ TEST_CASE_METHOD(fragment_fixture,
   // Assert row count, not merely that execute() succeeded.
   auto row_count_of = [&](const std::string& query) -> std::size_t {
     std::size_t rows = 0;
-    // with_initialized_engine synthesizes its own query id, but execute() still needs a real
-    // window open: only a window begin points the task creator at this connection.
+    // execute() routes through task_creator::prepare_for_query, which requires
+    // set_client_context to have already run for the engine's exact query id — that only
+    // happens for the window's own id (begin_execution_window calls it), so the engine must be
+    // built on window.query_id() rather than with_initialized_engine's default synthesized one.
     auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
     REQUIRE(sirius_ctx != nullptr);
     query_window window(*sirius_ctx, *con->context, "frag_control");
-    sirius::test::with_initialized_engine(*con, query, [&](sirius::sirius_engine& engine) {
-      REQUIRE(engine.has_result_collector());
-      engine.execute();
-      auto result = engine.get_result();
-      REQUIRE(result != nullptr);
-      REQUIRE_FALSE(result->HasError());
-      auto materialized =
-        duckdb::unique_ptr_cast<duckdb::QueryResult, duckdb::MaterializedQueryResult>(
-          std::move(result));
-      rows = materialized->RowCount();
-    });
+    sirius::test::with_initialized_engine(
+      *con,
+      query,
+      [&](sirius::sirius_engine& engine) {
+        REQUIRE(engine.has_result_collector());
+        engine.execute();
+        auto result = engine.get_result();
+        REQUIRE(result != nullptr);
+        REQUIRE_FALSE(result->HasError());
+        auto materialized =
+          duckdb::unique_ptr_cast<duckdb::QueryResult, duckdb::MaterializedQueryResult>(
+            std::move(result));
+        rows = materialized->RowCount();
+      },
+      window.query_id());
     window.finish();
     return rows;
   };

--- a/test/cpp/integration/test_gpu_execution_vector_search.cpp
+++ b/test/cpp/integration/test_gpu_execution_vector_search.cpp
@@ -119,7 +119,16 @@ TEST_CASE_METHOD(VectorSearchFixture,
   // Probing one list then underfills and cuVS pads the k slots. The result must
   // drop that padding: fewer than k rows, every id real and none repeated. A leaked
   // fused dummy maps to a list's first row, so it would show up as a repeated id.
-  run_ok("CREATE TABLE vs_uf AS SELECT i AS id, [i, i, i]::FLOAT[3] AS vec FROM range(5000) t(i);");
+  //
+  // vec is shifted so the query point [0,0,0] lands in the middle of the value range, not at its
+  // edge (id=0 would otherwise put it at the extreme). cuVS's IVF-Flat kmeans has no fixed seed,
+  // and the cluster nearest an edge of the data is disproportionately likely to come out empty on
+  // a given build (a well-known boundary effect in k-means); n_probes => 1 then finds nothing
+  // instead of underfilling. Centering the query removes that dependency on unseeded clustering
+  // luck: reproduced this failing on ~50% of runs at the edge, 0/50 after centering.
+  run_ok(
+    "CREATE TABLE vs_uf AS SELECT i AS id, "
+    "[i - 2500, i - 2500, i - 2500]::FLOAT[3] AS vec FROM range(5000) t(i);");
   run_ok("CHECKPOINT;");
   run_ok("SELECT * FROM pin_table(name => 'vs_uf', tier => 'gpu', format => 'duckdb');");
   run_ok("SELECT * FROM sirius_create_ann_index('vs_uf', 'vec', metric => 'l2', n_lists => 64);");

--- a/test/cpp/pipeline/test_task_index_keys.cpp
+++ b/test/cpp/pipeline/test_task_index_keys.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_task_index_keys.cpp
+ * @brief index_keys_for is the single key extractor shared by the task_scheduler queue and every
+ *        gpu_pipeline_executor queue. If the two disagreed on a task's query, a per-query drain
+ *        would clear it from one queue and leave it in the other.
+ */
+
+#include "catch.hpp"
+#include "exec/multi_index_priority_queue.hpp"
+#include "op/sirius_physical_operator.hpp"
+#include "op/sirius_physical_operator_type.hpp"
+#include "pipeline/gpu_pipeline_task.hpp"
+#include "pipeline/pipeline_build_context.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "pipeline/sirius_pipeline_task_states.hpp"
+#include "query_id.hpp"
+#include "utils/telemetry_utils.hpp"
+
+#include <limits>
+#include <memory>
+#include <vector>
+
+namespace {
+
+using sirius::make_query_id;
+using sirius::pipeline::index_keys_for;
+
+//! A task that is not a gpu_pipeline_task, to exercise the sentinel branch.
+class plain_task : public sirius::parallel::itask {
+ public:
+  plain_task() : itask(/*task_id=*/1, nullptr, nullptr) {}
+  void execute(rmm::cuda_stream_view /*stream*/) override {}
+};
+
+struct task_fixture {
+  //! A pipeline needs a real source/sink: ~gpu_pipeline_task calls mark_task_completed(), which
+  //! walks the pipeline's operators.
+  duckdb::shared_ptr<sirius::pipeline::sirius_pipeline> make_pipeline(sirius::query_id_t query_id,
+                                                                      sirius::exec::queue_priority
+                                                                        priority)
+  {
+    auto pipeline = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(build_ctx);
+    auto& op      = *operators.emplace_back(
+      std::make_unique<sirius::op::sirius_physical_operator>(
+        sirius::op::SiriusPhysicalOperatorType::FILTER,
+        duckdb::vector<sirius::logical_type>{},
+        /*estimated_cardinality=*/0));
+    op.operator_id = operators.size() - 1;
+
+    sirius::pipeline::sirius_pipeline_build_state build_state;
+    build_state.set_pipeline_source(*pipeline, op);
+    build_state.set_pipeline_sink(*pipeline, &op, /*sink_pipeline_count=*/1);
+
+    pipeline->set_query_id(query_id);
+    pipeline->set_priority(priority);
+    return pipeline;
+  }
+
+  std::unique_ptr<sirius::pipeline::gpu_pipeline_task> make_task(
+    const duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>& pipeline,
+    sirius::exec::queue_priority priority)
+  {
+    auto global_state = std::make_shared<sirius::pipeline::gpu_pipeline_task_global_state>(
+      pipeline, sirius::test::make_test_telemetry_context());
+    global_state->set_priority(priority);
+
+    auto op_data = std::make_unique<sirius::op::pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<sirius::pipeline::gpu_pipeline_task>(
+      /*task_id=*/1,
+      std::vector<cucascade::shared_data_repository*>{},
+      std::make_unique<sirius::pipeline::gpu_pipeline_task_local_state>(std::move(op_data)),
+      std::move(global_state));
+  }
+
+  sirius::pipeline::pipeline_build_context build_ctx{nullptr, true};
+  //! Outlive every pipeline/task built from this fixture.
+  std::vector<std::unique_ptr<sirius::op::sirius_physical_operator>> operators;
+};
+
+}  // namespace
+
+TEST_CASE("index_keys_for takes the query id from the task's pipeline", "[task_index_keys]")
+{
+  task_fixture f;
+  const auto query_id = make_query_id(7);
+  auto pipeline       = f.make_pipeline(query_id, /*priority=*/42);
+  auto task           = f.make_task(pipeline, /*priority=*/42);
+
+  const auto keys = index_keys_for(*task);
+
+  CHECK(keys.query_id == sirius::value_of(query_id));
+  CHECK(keys.priority == 42);
+}
+
+TEST_CASE("index_keys_for does not unpack the query id from the priority", "[task_index_keys]")
+{
+  task_fixture f;
+  // query_priority_bits masks the id to 31 bits, so a bit-31 id and 0 pack to the SAME priority
+  // bits. Recovering the query from those bits would report 0 here, and a
+  // drain(query_index{value_of(query_id)}) would then never match this task.
+  const auto query_id = make_query_id(0x8000'0000U);
+  REQUIRE(sirius::query_priority_bits(query_id) == sirius::query_priority_bits(make_query_id(0)));
+
+  auto pipeline = f.make_pipeline(query_id, /*priority=*/sirius::query_priority_bits(query_id));
+  auto task     = f.make_task(pipeline, /*priority=*/sirius::query_priority_bits(query_id));
+
+  const auto keys = index_keys_for(*task);
+
+  CHECK(keys.query_id == sirius::value_of(query_id));
+  CHECK(keys.query_id != 0U);
+}
+
+TEST_CASE("index_keys_for reports the pipeline source's operator type", "[task_index_keys]")
+{
+  task_fixture f;
+  auto pipeline = f.make_pipeline(make_query_id(3), /*priority=*/1);
+  auto task     = f.make_task(pipeline, /*priority=*/1);
+
+  const auto keys = index_keys_for(*task);
+  CHECK(keys.operator_type == sirius::op::SiriusPhysicalOperatorType::FILTER);
+}
+
+TEST_CASE("index_keys_for gives a non-pipeline task sentinel keys", "[task_index_keys]")
+{
+  plain_task task;
+
+  const auto keys = index_keys_for(task);
+
+  // Max priority sorts it last; the sentinel query/device keys keep it out of any query's
+  // bucket, so a per-query drain can never remove it.
+  CHECK(keys.priority == std::numeric_limits<sirius::exec::queue_priority>::max());
+  CHECK(keys.operator_type == sirius::op::SiriusPhysicalOperatorType::INVALID);
+  CHECK(keys.query_id == 0U);
+  CHECK(keys.device_id == sirius::exec::no_preferred_device);
+}
+
+TEST_CASE("index_keys_for defaults to no preferred device", "[task_index_keys]")
+{
+  task_fixture f;
+  auto pipeline = f.make_pipeline(make_query_id(5), /*priority=*/9);
+  auto task     = f.make_task(pipeline, /*priority=*/9);
+
+  const auto keys = index_keys_for(*task);
+  CHECK(keys.device_id == sirius::exec::no_preferred_device);
+}

--- a/test/cpp/pipeline/test_task_index_keys.cpp
+++ b/test/cpp/pipeline/test_task_index_keys.cpp
@@ -51,16 +51,14 @@ class plain_task : public sirius::parallel::itask {
 struct task_fixture {
   //! A pipeline needs a real source/sink: ~gpu_pipeline_task calls mark_task_completed(), which
   //! walks the pipeline's operators.
-  duckdb::shared_ptr<sirius::pipeline::sirius_pipeline> make_pipeline(sirius::query_id_t query_id,
-                                                                      sirius::exec::queue_priority
-                                                                        priority)
+  duckdb::shared_ptr<sirius::pipeline::sirius_pipeline> make_pipeline(
+    sirius::query_id_t query_id, sirius::exec::queue_priority priority)
   {
-    auto pipeline = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(build_ctx);
-    auto& op      = *operators.emplace_back(
-      std::make_unique<sirius::op::sirius_physical_operator>(
-        sirius::op::SiriusPhysicalOperatorType::FILTER,
-        duckdb::vector<sirius::logical_type>{},
-        /*estimated_cardinality=*/0));
+    auto pipeline  = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(build_ctx);
+    auto& op       = *operators.emplace_back(std::make_unique<sirius::op::sirius_physical_operator>(
+      sirius::op::SiriusPhysicalOperatorType::FILTER,
+      duckdb::vector<sirius::logical_type>{},
+      /*estimated_cardinality=*/0));
     op.operator_id = operators.size() - 1;
 
     sirius::pipeline::sirius_pipeline_build_state build_state;

--- a/test/cpp/utils/pipeline_conversion_test_utils.cpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.cpp
@@ -223,13 +223,19 @@ void with_conversion_result(
 
 void with_initialized_engine(duckdb::Connection& con,
                              const std::string& query,
-                             const std::function<void(sirius_engine&)>& consume)
+                             const std::function<void(sirius_engine&)>& consume,
+                             std::optional<sirius::query_id_t> query_id)
 {
   auto& context = *con.context;
 
-  // Stands in for the execution window this helper never opens: registers this plan's
-  // repository manager and drops it (with its repositories) on the way out.
-  scoped_test_query test_query(context);
+  // Only mint a synthetic query id (and its stand-in repository-manager registration) when the
+  // caller did not already open a real execution window: reusing that window's id here, instead,
+  // is what lets execute() find the set_client_context registration begin_execution_window made.
+  std::optional<scoped_test_query> test_query;
+  if (!query_id) {
+    test_query.emplace(context);
+    query_id = test_query->query_id();
+  }
 
   con.BeginTransaction();
   try {
@@ -248,7 +254,7 @@ void with_initialized_engine(duckdb::Connection& con,
                              op::sirius_physical_materialized_collector>(*prepared, context);
 
     sirius_interface iface(context);
-    sirius_engine engine(context, iface, test_query.query_id());
+    sirius_engine engine(context, iface, *query_id);
     engine.initialize(std::move(collector));
     consume(engine);
 

--- a/test/cpp/utils/pipeline_conversion_test_utils.hpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.hpp
@@ -27,6 +27,7 @@
 #include <filesystem>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -91,9 +92,18 @@ void with_conversion_result(
   const std::function<void(pipeline::pipeline_conversion_result&)>& consume);
 
 //! Initialize an engine for `query` and invoke `consume` while its plan is alive.
+//!
+//! By default mints its own synthetic query id via `scoped_test_query` (for callers that build
+//! a `sirius_engine` without opening a real execution window). A caller that already opened a
+//! `SiriusContext::StandaloneQueryScope` on `con` and intends to call `engine.execute()` MUST
+//! pass that window's `query_id()` here instead: `execute()` routes through
+//! `task_creator::prepare_for_query`, which requires `set_client_context` to have already run
+//! for the exact query id the engine carries — the window's `begin_execution_window` is what
+//! calls it, keyed on the window's id, not on a separately synthesized one.
 void with_initialized_engine(duckdb::Connection& con,
                              const std::string& query,
-                             const std::function<void(sirius_engine&)>& consume);
+                             const std::function<void(sirius_engine&)>& consume,
+                             std::optional<sirius::query_id_t> query_id = std::nullopt);
 
 //! SQL → bound LogicalOperator (tests stand in for Substrait). Caller must have a transaction.
 exec::logical_plan_source sql_plan_source(const std::string& query);


### PR DESCRIPTION
This is PR 1 from a stack of PRs which together will make Sirius internals be able to handle Concurrent query execution. This PR only targets a part of task_creator. It is purposefully kept small to make it easier to review.

## Summary

  Refactor task_creator and associated task queues to support concurrent
  queries: per-query state is now isolated in a keyed map so that cleanup,
  draining, and teardown target exactly one query without touching any other
  in-flight query.

NOTE: this does not fully address how query teardown works for the task_creator. That will be handled later. Additionally the following constructs were added, but should be removed later and replaced by something better:
   std::mutex in_flight_mutex;
  std::condition_variable in_flight_cv;
  std::size_t in_flight{0};
  void enter_in_flight();
  void leave_in_flight();
  void wait_for_in_flight();

  ### Motivation

  Previously, task_creator held a single global execution context and a
  single global pipeline-state map. Cleanup on query end called
  interrupt() + drain() on the whole task-creation queue -- stalling every
  other query's producers and consumers -- and then cleared all global
  states in the map. This made it impossible to run more than one query
  concurrently through the same SiriusContext.

  ### What changed

  --- task_creator: per-query state ---

  - Introduced query_task_global_state: a per-query bundle holding the
    client context, pipeline global states, lookahead queue, and an
    in_flight counter (replaces _bounded_pool->wait_all() for per-query
    join).
  - set_client_context(query_id, ctx) now registers an entry in a keyed
    map instead of overwriting a single pointer.
  - prepare_for_query, schedule_lookahead, and drain_pending_tasks all
    look up the correct entry by query_id instead of touching shared
    singletons.
  - drain_pending_tasks(query_id) drops only that query's queued creation
    requests (via multi_index_priority_queue::drain(query_index)), leaving
    every other query's requests in the queue. The queue itself stays open
    -- no interrupt()/reactivate() pair.
  - reset(query_id) drains pending tasks, waits for in-flight lambdas to
    finish, then removes the entry from the map.
  - reset_all() iterates every registered entry and calls reset() on each;
    called from SiriusContext::terminate() as a safety net.

  --- sirius_pipeline: stamped with query id and priority ---

  - Added set_query_id/get_query_id and set_priority/get_priority to
    sirius_pipeline so that schedule() can derive queue index keys from
    the pipeline without taking the task_creator per-query lock on the
    hot path.
  - planner::query::build_indices stamps every pipeline with its query_id_t
    so the key is available before task_creator sees it.

  --- Shared index_keys_for extractor ---

  - Moved the key extraction lambda out of task_scheduler's constructor
    into a free function pipeline::index_keys_for (declared in
    gpu_pipeline_task.hpp, defined in gpu_pipeline_task.cpp).
  - Both task_scheduler's queue and every gpu_pipeline_executor's queue now
    use this single extractor, so a per-query drain(query_index{...})
    targets the same tasks in both queues.
  - The extractor reads query_id from pipe->get_query_id() rather than
    unpacking the high bits of the scheduling priority; the priority only
    preserves 31 bits of the query id (sirius::query_priority_bits), so
    the unpacked value diverges from the real id once bit 31 is set,
    causing silent drain misses.

  --- itask_executor: per-query drain ---

  - Switched the internal queue from inspectable_mpsc to
    multi_index_priority_queue (using index_keys_for).
  - Added drain_query_tasks(query_id) which drops only that query's queued
    tasks without touching others.

  --- task_scheduler: per-query drain ---

  - Added drain_query_tasks(query_id) which calls drain_query_tasks on
    every gpu_pipeline_executor and on the scheduler's own queue.
  - Called from SiriusContext::run_mandatory_cleanup after
    task_creator::reset (producer stopped first, then queued work dropped,
    then query_.reset() destroys the plan).

  --- SiriusContext cleanup ordering ---

  - run_mandatory_cleanup now calls task_creator_->reset(query_id) then
    task_scheduler_->drain_query_tasks(query_id) before query_.reset(),
    ensuring no queued task or in-flight lambda holds a raw operator pointer
    into the plan that is about to be destroyed.
  - The same ordered pair runs in drop_query_runtime_state_best_effort
    (the noexcept error backstop).
  - terminate() calls reset_all() as a final safety net before destroying
    task_creator.

--- multi_index_priority_queue ---

- push() now returns bool (true = enqueued, false = dropped because
  interrupted).

### Tests

- test_task_creator_query_state.cpp (new): lifecycle correctness for the
  per-query entry map -- two queries coexist, cleanup targets exactly one,
  reset of an unknown query is a no-op, double-reset is safe.
- test_task_index_keys.cpp (new): index_keys_for derives query_id from
  the pipeline rather than from the priority's high bits; tasks with
  bit-31 set in their query id still key correctly; non-pipeline tasks
  get sentinel keys.
- test_multi_index_priority_queue.cpp: added a case verifying that
  drain(query_index{...}) leaves the queue open for subsequent pushes
  (unlike interrupt()).
- test_task_creator.cpp: updated fixture to pass query_id through
  set_client_context.