### PR TITLE
Support compressing nullable columns

### DIFF
--- a/src/compression/simpatico_codegen/CMakeLists.txt
+++ b/src/compression/simpatico_codegen/CMakeLists.txt
@@ -147,6 +147,7 @@ add_library(
   src/plan/operator_registry.cpp
   src/plan/representation_factory.cpp
   src/plan/bitjoin_layout.cpp
+  src/plan/validity.cpp
   src/plan/compress.cpp
   src/plan/decompress.cpp
   src/util/stream_pool.cpp

--- a/src/compression/simpatico_codegen/include/api/compressed_table_io.hpp
+++ b/src/compression/simpatico_codegen/include/api/compressed_table_io.hpp
@@ -16,6 +16,9 @@
 //       name_len (uint16 LE) + name bytes   [0 = no name]
 //       dtype_tag (uint8)                   [decoded column type]
 //       num_rows (int64 LE)
+//       validity_kind (uint8)               [0=all_valid 1=all_null 2=mask]
+//         if kind != all_valid: null_count (int64 LE)
+//         if kind == mask:      mask_size_bytes (uint64 LE) + payload_offset (uint64 LE)
 //       num_nodes (uint16 LE)
 //       per node:
 //         op_len (uint16 LE) + op bytes

--- a/src/compression/simpatico_codegen/include/codegen/plan/plan_tree.hpp
+++ b/src/compression/simpatico_codegen/include/codegen/plan/plan_tree.hpp
@@ -6,6 +6,7 @@
 #include "codegen/plan/operator_registry.hpp"  // ChannelId
 #include "codegen/plan/plan_dsl.hpp"
 #include "codegen/plan/representation.hpp"
+#include "codegen/plan/validity.hpp"
 
 #include <cudf/types.hpp>
 
@@ -113,6 +114,13 @@ struct PlanNode {
 
 struct PlanTree {
   std::vector<PlanNode> nodes;
+
+  // The column's validity, detached from the dataflow the nodes describe.
+  // compress_column strips it off the input before the walk and decompress_column
+  // reattaches it after, so no node -- and no plan DSL -- ever refers to it.
+  // Default-constructed (all_valid) for a column with no nulls, which costs
+  // nothing to carry.
+  validity_sidecar validity;
 };
 
 std::optional<PlanTree> plan_tree_from_dsl(std::string_view dsl, std::string* error_out = nullptr);

--- a/src/compression/simpatico_codegen/include/codegen/plan/representation.hpp
+++ b/src/compression/simpatico_codegen/include/codegen/plan/representation.hpp
@@ -7,7 +7,6 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
-#include <cudf/null_mask.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -99,21 +98,16 @@ struct compressed_representation {
 
   /// Canonical channel enumeration: this rep's named output channels, in manifest/wire order.
   /// Generic implementation: driven by channels_ + op_info(kind()).channels from the registry.
-  /// Subclasses with variable-arity or lazy synthesis (dictionary, bitextract) override this.
+  /// Subclasses with lazy synthesis (dictionary, bitextract) override this.
   virtual std::vector<compressible_output> named_channels(rmm::cuda_stream_view) const
   {
     auto const& names = op_info(kind()).channels;
     std::vector<compressible_output> out;
     out.reserve(channels_.size());
     for (size_t i = 0; i < channels_.size() && i < names.size(); ++i)
-      if (channels_[i]) out.push_back({names[i], channels_[i]->view()});
+      out.push_back({names[i], channels_[i]->view()});
     return out;
   }
-
-  /// Channels that MUST be routed by the plan, else the driver errors -- preventing silent data
-  /// loss. Default: none. str_split returns {"null_mask"} for a nullable input so a plan can never
-  /// silently drop validity.
-  virtual std::vector<std::string> required_channels() const { return {}; }
 
   /// SAFETY invariant: a representation owns everything it exposes — all
   /// compressors create new data during compression, and the original user
@@ -202,7 +196,7 @@ struct identity_compressor : compressor {
 /// Dictionary format: stores the encoded dictionary column and a copy of keys chars.
 /// In modern cuDF, chars are not accessible as a column_view, so we copy them into a UINT8 column.
 struct dictionary_compressed_representation : standalone_compressed_representation {
-  // Accepts the (keys_offsets, keys_chars, indices[, null_mask]) form.
+  // Accepts the (keys_offsets, keys_chars, indices) form.
   static std::unique_ptr<compressed_representation> from_outputs(
     std::vector<std::string> const& output_names,
     std::vector<std::unique_ptr<cudf::column>> outputs,
@@ -218,11 +212,6 @@ struct dictionary_compressed_representation : standalone_compressed_representati
   // an all-null column yields zero keys). See named_channels().
   mutable std::unique_ptr<cudf::column> keys_offsets_synth;
   mutable std::unique_ptr<cudf::column> indices_synth;
-  // Lazily copied validity bitmask bytes (UINT8), exposed as the optional
-  // "null_mask" channel (and marked required) so a nullable column's validity
-  // survives every channel-based path: .hpln IO and decomposed plans rebuild
-  // via from_outputs, which cannot see the mask carried on the stored columns.
-  mutable std::unique_ptr<cudf::column> null_mask_copy;
 
   // Constant key byte-width, measured lazily at first decompress (0 = variable, -1 = unmeasured).
   mutable std::int64_t constant_key_width = -1;
@@ -243,8 +232,9 @@ struct dictionary_compressed_representation : standalone_compressed_representati
   {
     std::vector<compressible_output> outputs;
 
-    // Expose keys_offsets, keys_chars, indices and — for a nullable column —
-    // null_mask.
+    // Expose keys_offsets, keys_chars and indices. Validity is never among them:
+    // compress_column strips it into the plan tree's sidecar, so the column this
+    // rep was built from is null-free by construction.
     auto dict_view            = dict_column->view();
     bool const childless_dict = dict_column->num_children() == 0;  // zero-row compress
     bool const childless_keys =  // encode of an all-null column: zero keys, no offsets child
@@ -308,35 +298,10 @@ struct dictionary_compressed_representation : standalone_compressed_representati
         {"indices", get_dictionary_child_view(dict_view, dictionary_view_kind::Indices)});
     }
 
-    if (dict_column->null_count() > 0) {
-      ensure_null_mask_copy(dict_view, stream);
-      outputs.push_back({"null_mask", null_mask_copy->view()});
-    }
     return outputs;
   }
 
-  std::vector<std::string> required_channels() const override
-  {
-    if (dict_column && dict_column->null_count() > 0) return {"null_mask"};
-    return {};
-  }
-
   OpId kind() const override { return OpId::Dictionary; }
-
- private:
-  // Copy `source`'s validity bitmask into the owned UINT8 null_mask_copy
-  // column (no-op if already built).
-  void ensure_null_mask_copy(cudf::column_view const& source, rmm::cuda_stream_view stream) const
-  {
-    if (null_mask_copy) return;
-    auto mr                 = rmm::mr::get_current_device_resource_ref();
-    rmm::device_buffer bits = cudf::copy_bitmask(source, stream, mr);
-    auto const mask_bytes =
-      static_cast<cudf::size_type>(cudf::bitmask_allocation_size_bytes(source.size()));
-    null_mask_copy = std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT8}, mask_bytes, std::move(bits), rmm::device_buffer{}, 0);
-    cudaStreamSynchronize(stream.value());
-  }
 };
 
 /// Dictionary compressor: STRING column only. Encodes via cudf dictionary encode; stores the
@@ -348,16 +313,14 @@ struct dictionary_compressor : compressor {
 };
 
 // -----------------------------------------------------------------------------
-// str_split: decompose a STRING column into {offsets, chars, null_mask} channels.
+// str_split: decompose a STRING column into {offsets, chars} channels.
 // Structural (non-codegen) operator -- byte compression is delegated to the
 // channel codecs (offsets -> delta -> bitpack; chars -> lz4). Modeled on the
 // ALP rep (dedicated struct + from_outputs); decode reassembles via
-// cudf::make_strings_column. Conditional arity: a non-null column exposes
-// {offsets, chars}; a nullable column also exposes null_mask, which is marked
-// required() so the driver errors if the plan fails to route it.
+// cudf::make_strings_column. Validity is not among the channels: it is stripped
+// into the plan tree's sidecar before the walk, so the input is always null-free.
 // -----------------------------------------------------------------------------
-// channels_[0] = offsets (INT32 or INT64), channels_[1] = chars (UINT8/UINT32/UINT64),
-// channels_[2] = null_mask (UINT8 bitmask bytes, only present when nullable).
+// channels_[0] = offsets (INT32 or INT64), channels_[1] = chars (UINT8/UINT32/UINT64).
 // decompress() copies channels into make_strings_column; channels_ is left intact.
 struct str_split_compressed_representation : standalone_compressed_representation {
   static std::unique_ptr<compressed_representation> from_outputs(
@@ -369,23 +332,15 @@ struct str_split_compressed_representation : standalone_compressed_representatio
 
   str_split_compressed_representation(cudf::size_type n_rows,
                                       std::unique_ptr<cudf::column> offsets,
-                                      std::unique_ptr<cudf::column> chars,
-                                      std::unique_ptr<cudf::column> null_mask)
+                                      std::unique_ptr<cudf::column> chars)
     : standalone_compressed_representation(cudf::data_type{cudf::type_id::STRING}, n_rows)
   {
     channels_.push_back(std::move(offsets));
     channels_.push_back(std::move(chars));
-    if (null_mask) channels_.push_back(std::move(null_mask));
   }
 
   std::unique_ptr<cudf::column> decompress(rmm::cuda_stream_view stream,
                                            rmm::device_async_resource_ref mr) const override;
-
-  std::vector<std::string> required_channels() const override
-  {
-    if (channels_.size() > 2 && channels_[2]) return {"null_mask"};
-    return {};
-  }
 
   OpId kind() const override { return OpId::StrSplit; }
 };

--- a/src/compression/simpatico_codegen/include/codegen/plan/validity.hpp
+++ b/src/compression/simpatico_codegen/include/codegen/plan/validity.hpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Transparent validity handling.
+//
+// Nulls are stripped off a column before the compress walk and reattached after
+// the decode walk, so the plan DSL never mentions validity and no operator ever
+// sees a nullable input. The stripped bitmask rides along as a sidecar on the
+// column's PlanTree (see plan_tree.hpp) rather than as a routed channel.
+//
+// Two shapes cost nothing to carry and are special-cased:
+//   * no nulls  -- no sidecar, no allocation, no copy; the input view is passed
+//                  through untouched, so an all-valid column is byte-for-byte
+//                  the same work it was before validity was supported at all.
+//   * all nulls -- the bitmask is a constant, so only the kind is recorded; it
+//                  is regenerated on decode and occupies no payload bytes.
+
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cstdint>
+
+namespace simpatico {
+
+/// How a column's validity is carried alongside its compression plan.
+/// Serialized as a uint8 in the .hpln header -- do not renumber.
+enum class validity_kind : std::uint8_t {
+  all_valid = 0,  ///< No nulls. Nothing stored.
+  all_null  = 1,  ///< Every row null. Nothing stored; the mask is regenerated on decode.
+  mask      = 2,  ///< Mixed. `mask` holds the bitmask bytes for rows [0, size).
+};
+
+/// A column's validity, detached from its data.
+struct validity_sidecar {
+  validity_kind kind      = validity_kind::all_valid;
+  std::int64_t null_count = 0;
+  /// Bitmask bytes, populated iff kind == mask. Always rebased so bit i
+  /// describes row i of the logical column, whatever the source view's offset.
+  rmm::device_buffer mask;
+
+  /// True when there is nothing to reattach (the common, all-valid case).
+  bool empty() const { return kind == validity_kind::all_valid; }
+};
+
+/// Detach @p input's validity into @p out and return the same column with its
+/// null mask dropped.
+///
+/// The returned view keeps @p input's offset and children, so it is exactly what
+/// the walk would have received had the column never been nullable -- no
+/// operator behaviour changes. It borrows @p input's data, so @p input must
+/// outlive it.
+cudf::column_view strip_validity(cudf::column_view input,
+                                 validity_sidecar& out,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::device_async_resource_ref mr);
+
+/// Reattach @p v to a freshly decoded column. A no-op when @p v is all_valid.
+/// @p v is not consumed: a PlanTree can be decoded more than once, so the mask
+/// is copied rather than moved.
+void attach_validity(cudf::column& col,
+                     validity_sidecar const& v,
+                     rmm::cuda_stream_view stream,
+                     rmm::device_async_resource_ref mr);
+
+}  // namespace simpatico

--- a/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
+++ b/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
@@ -317,7 +317,60 @@ static std::unique_ptr<compressed_representation> rep_from_leaf_desc(
     std::string(cname), names, std::move(cols), stream, mr, err, ld.meta);
 }
 
-static constexpr std::uint8_t kVersion = 10;
+// v11 added the per-column validity sidecar record (see push_validity).
+static constexpr std::uint8_t kVersion = 11;
+
+// Per-column validity record, written right after num_rows:
+//
+//   kind (uint8)                        [validity_kind]
+//   if kind != all_valid: null_count (int64 LE)
+//   if kind == mask:      size_bytes (uint64 LE) + payload_offset (uint64 LE)
+//
+// An all-valid column costs exactly one byte, and an all-null one costs nine
+// with no payload at all -- only a genuinely mixed column pays for a bitmask.
+// The mask is appended to the payload region like any leaf buffer, so callers
+// that stage the payload themselves need no special case for it.
+static void push_validity(std::vector<std::uint8_t>& hdr,
+                          validity_sidecar const& v,
+                          std::vector<payload_buffer_ref>& out_buffers,
+                          std::uint64_t& payload_offset)
+{
+  push_le(hdr, static_cast<std::uint8_t>(v.kind));
+  if (v.kind == validity_kind::all_valid) return;
+
+  push_le(hdr, v.null_count);
+  if (v.kind != validity_kind::mask) return;
+
+  auto const size_bytes = static_cast<std::uint64_t>(v.mask.size());
+  push_le(hdr, size_bytes);
+  push_le(hdr, payload_offset);
+  out_buffers.push_back(payload_buffer_ref{payload_offset, v.mask.data(), size_bytes, size_bytes});
+  payload_offset += size_bytes;
+}
+
+// Parsed form of the record above; the mask bytes are pulled from the payload
+// later (reconstruct_from_records), like every leaf buffer.
+struct ValidityRecord {
+  validity_kind kind           = validity_kind::all_valid;
+  std::int64_t null_count      = 0;
+  std::uint64_t size_bytes     = 0;
+  std::uint64_t payload_offset = 0;
+};
+
+// Inverse of push_validity. Returns false on a truncated or unknown record.
+static bool read_validity(Reader& r, ValidityRecord& v)
+{
+  std::uint8_t k;
+  if (!r.read_le(k)) return false;
+  if (k > static_cast<std::uint8_t>(validity_kind::mask)) return false;
+  v.kind = static_cast<validity_kind>(k);
+  if (v.kind == validity_kind::all_valid) return true;
+
+  if (!r.read_le(v.null_count)) return false;
+  if (v.kind != validity_kind::mask) return true;
+
+  return r.read_le(v.size_bytes) && r.read_le(v.payload_offset);
+}
 
 // Serialize one node's structure (op, bitjoin params, edges, output names).
 // Other ops carry their params in the op name, so only bitjoin needs attrs.
@@ -407,6 +460,7 @@ struct ColRecord {
   std::uint8_t dtype_tag = 0;
   std::int32_t scale     = 0;  // fixed-point scale for the column dtype (0 otherwise)
   std::int64_t num_rows  = 0;
+  ValidityRecord validity;
   PlanTree tree;
   std::vector<leaf_desc> leaf_descs;
   std::vector<std::vector<std::uint64_t>> buf_offsets;  // [leaf][buffer] -> payload offset
@@ -444,6 +498,7 @@ static bool parse_hpln_header(Reader& r, std::vector<ColRecord>& out, std::strin
     if (!r.read_le(cr.dtype_tag)) return bad("truncated col dtype");
     if (!r.read_le(cr.scale)) return bad("truncated col scale");
     if (!r.read_le(cr.num_rows)) return bad("truncated col num_rows");
+    if (!read_validity(r, cr.validity)) return bad("truncated/unknown col validity");
 
     std::uint16_t nn;
     if (!r.read_le(nn)) return bad("truncated num_nodes");
@@ -527,6 +582,17 @@ static compressed_table reconstruct_from_records(std::vector<ColRecord>& recs,
     auto plan_tree = std::make_unique<PlanTree>();
     *plan_tree     = std::move(cr.tree);
     auto& nodes    = plan_tree->nodes;
+
+    // Rebuild the validity sidecar. all_valid and all_null carry no payload, so
+    // only a mixed column costs a fetch here.
+    auto& validity      = plan_tree->validity;
+    validity.kind       = cr.validity.kind;
+    validity.null_count = cr.validity.null_count;
+    if (validity.kind == validity_kind::mask) {
+      auto const sz = static_cast<std::size_t>(cr.validity.size_bytes);
+      validity.mask = rmm::device_buffer(sz, stream, mr);
+      if (sz > 0) fetch(cr.validity.payload_offset, sz, validity.mask.data(), stream);
+    }
 
     for (std::size_t li = 0; li < cr.leaf_descs.size(); ++li) {
       auto const& ld    = cr.leaf_descs[li];
@@ -629,17 +695,22 @@ compressed_table read_compressed_table(std::string const& path,
 
   // Bounds-check every buffer up front so a truncated file is reported here
   // rather than faulting mid-copy, then copy each buffer straight to device.
+  auto in_payload = [&](std::uint64_t off, std::size_t sz) {
+    // Subtraction form: `off + sz` could overflow for a corrupt/hostile file's
+    // huge declared offset and wrap below payload_total, passing the check and
+    // then faulting in fetch(). Compare against the remaining space instead so
+    // it can never overflow.
+    return sz == 0 || (off <= payload_total && sz <= payload_total - off);
+  };
   for (auto const& cr : col_records) {
+    if (cr.validity.kind == validity_kind::mask &&
+        !in_payload(cr.validity.payload_offset, static_cast<std::size_t>(cr.validity.size_bytes)))
+      return fail("payload out of bounds");
     for (std::size_t li = 0; li < cr.leaf_descs.size(); ++li) {
       for (std::size_t bi = 0; bi < cr.leaf_descs[li].buffers.size(); ++bi) {
         std::size_t sz = static_cast<std::size_t>(cr.leaf_descs[li].buffers[bi].size_bytes);
         std::uint64_t const off = cr.buf_offsets[li][bi];
-        // Subtraction form: `off + sz` could overflow for a corrupt/hostile
-        // file's huge declared offset and wrap below payload_total, passing the
-        // check and then faulting in fetch(). Compare against the remaining space
-        // instead so it can never overflow.
-        if (sz > 0 && (off > payload_total || sz > payload_total - off))
-          return fail("payload out of bounds");
+        if (!in_payload(off, sz)) return fail("payload out of bounds");
       }
     }
   }
@@ -766,6 +837,10 @@ std::string build_compressed_table_header(compressed_table const& table,
     // Structural plan tree (identical layout to the file header, so the same
     // parser reconstructs it): the node array is the source of truth on read.
     PlanTree const& tree = col.plan_tree ? *col.plan_tree : kEmptyTree;
+
+    // Validity rides beside the tree, not inside it: it is not a leaf and has no
+    // node, so it is written here rather than through describe().
+    push_validity(hdr, tree.validity, out_buffers, payload_offset);
     push_le(hdr, static_cast<std::uint16_t>(tree.nodes.size()));
     for (auto const& node : tree.nodes)
       push_node(hdr, node);

--- a/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
+++ b/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
@@ -414,7 +414,7 @@ const char* dtype_to_cxx(const char* dtype)
   // the original float type_id so cudf reinterprets the bits correctly.
   if (s == "float32") return "int32_t";
   if (s == "float64") return "int64_t";
-  // Byte types (string sub-channels: chars, null_mask, keys_chars) map to the
+  // Byte types (string sub-channels: chars, keys_chars) map to the
   // SIGNED int8_t: zigzag's shift = elem_size*8-1 relies on sign-extension.
   // The output column retains the original UINT8 type_id.
   if (s == "uint8" || s == "uint8_t" || s == "int8" || s == "int8_t") return "int8_t";

--- a/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
+++ b/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
@@ -13,6 +13,7 @@
 #include "codegen/plan/operator_registry.hpp"  // is_terminal_compressor
 #include "codegen/plan/plan_interpreter.hpp"
 #include "codegen/plan/representation.hpp"
+#include "codegen/plan/validity.hpp"
 
 #include <cudf/copying.hpp>
 #include <cudf/strings/strings_column_view.hpp>
@@ -461,6 +462,14 @@ exploration_result explore_column_compression(cudf::column_view input,
                                               rmm::cuda_stream_view stream,
                                               rmm::device_async_resource_ref mr)
 {
+  // Explore the column as compress_column will actually see it. The BFS calls
+  // compress_single_op directly, bypassing the plan walk's strip, so without
+  // this a nullable column would be scored on data the real compress pass never
+  // feeds its operators. The sidecar is discarded — exploration only ranks how
+  // the values compress.
+  validity_sidecar explored_validity;
+  input = strip_validity(input, explored_validity, stream, mr);
+
   size_t const full_size = column_size_bytes_ex(input, stream);
 
   // Head-prefix of `input` (rows). Strings are materialized — a zero-copy slice

--- a/src/compression/simpatico_codegen/src/operators/str_split_compressor.cu
+++ b/src/compression/simpatico_codegen/src/operators/str_split_compressor.cu
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// str_split: decompose STRING into {offsets, chars, null_mask}; reassemble via
-// make_strings_column on decode. Structural operator.
+// str_split: decompose STRING into {offsets, chars}; reassemble via
+// make_strings_column on decode. Structural operator. Validity never reaches
+// here: compress_column strips it into the plan tree's sidecar beforehand.
 
 #include "codegen/plan/bitjoin_layout.hpp"  // copy_column_view
 #include "codegen/plan/representation.hpp"
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/null_mask.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
 
@@ -22,9 +22,8 @@ namespace simpatico {
 std::unique_ptr<cudf::column> str_split_compressed_representation::decompress(
   rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const
 {
-  auto& offsets   = channels_[0];
-  auto& chars     = channels_[1];
-  auto* null_mask = channels_.size() > 2 ? channels_[2].get() : nullptr;
+  auto& offsets = channels_[0];
+  auto& chars   = channels_[1];
   if (num_rows == 0 || !offsets) {
     return cudf::make_empty_column(cudf::data_type(cudf::type_id::STRING));
   }
@@ -33,20 +32,12 @@ std::unique_ptr<cudf::column> str_split_compressed_representation::decompress(
                            static_cast<std::size_t>(cudf::size_of(chars->type()));
   rmm::device_buffer chars_buf(chars->view().head<void>(), chars_bytes, stream, mr);
 
-  cudf::size_type nc = 0;
-  rmm::device_buffer mask_buf(0, stream, mr);
-  if (null_mask) {
-    auto const* bits =
-      reinterpret_cast<cudf::bitmask_type const*>(null_mask->view().data<std::uint8_t>());
-    nc = cudf::null_count(bits, 0, num_rows, stream);
-    if (nc > 0) {
-      mask_buf = rmm::device_buffer(
-        null_mask->view().head<void>(), static_cast<std::size_t>(null_mask->size()), stream, mr);
-    }
-  }
   auto offsets_copy = std::make_unique<cudf::column>(*offsets, stream, mr);
-  return cudf::make_strings_column(
-    num_rows, std::move(offsets_copy), std::move(chars_buf), nc, std::move(mask_buf));
+  return cudf::make_strings_column(num_rows,
+                                   std::move(offsets_copy),
+                                   std::move(chars_buf),
+                                   /*null_count=*/0,
+                                   rmm::device_buffer(0, stream, mr));
 }
 
 std::unique_ptr<compressed_representation> str_split_compressor::compress(
@@ -70,7 +61,7 @@ std::unique_ptr<compressed_representation> str_split_compressor::compress(
       cudf::data_type{cudf::type_id::UINT8}, 0, cudf::mask_state::UNALLOCATED, stream, mr);
     cudaStreamSynchronize(stream.value());
     return std::make_unique<str_split_compressed_representation>(
-      0, std::move(offsets), std::move(chars), nullptr);
+      0, std::move(offsets), std::move(chars));
   }
 
   std::unique_ptr<cudf::column>
@@ -78,8 +69,8 @@ std::unique_ptr<compressed_representation> str_split_compressor::compress(
   cudf::column_view src = column_to_compress;
   // Normalize any sliced view to an owned compact copy: a non-zero offset
   // needs rebasing, and a head-slice (offset 0, size < parent) still views the
-  // parent's full offsets child, so the emitted channels would be mutually
-  // inconsistent (offsets/chars parent-sized, null_mask slice-sized).
+  // parent's full offsets child, so the emitted channels would be sized off the
+  // parent rather than the slice.
   if (column_to_compress.offset() != 0 ||
       cudf::strings_column_view(column_to_compress).offsets().size() !=
         column_to_compress.size() + 1) {
@@ -123,19 +114,10 @@ std::unique_ptr<compressed_representation> str_split_compressor::compress(
     }
   }
 
-  // null_mask: owned UINT8 bitmask bytes, copied only if the column has nulls.
-  // A non-null column gets NO mask channel (2-channel str_split).
-  std::unique_ptr<cudf::column> null_mask;
-  if (src.null_count() > 0) {
-    rmm::device_buffer mbuf = cudf::copy_bitmask(src, stream, mr);
-    auto const mbytes       = static_cast<cudf::size_type>(cudf::bitmask_allocation_size_bytes(n));
-    null_mask               = std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT8}, mbytes, std::move(mbuf), rmm::device_buffer{}, 0);
-  }
   cudaStreamSynchronize(stream.value());
 
   return std::make_unique<str_split_compressed_representation>(
-    n, std::move(offsets), std::move(chars), std::move(null_mask));
+    n, std::move(offsets), std::move(chars));
 }
 
 }  // namespace simpatico

--- a/src/compression/simpatico_codegen/src/plan/compress.cpp
+++ b/src/compression/simpatico_codegen/src/plan/compress.cpp
@@ -19,6 +19,7 @@
 #include "codegen/plan/plan_interpreter.hpp"
 #include "codegen/plan/plan_tree.hpp"
 #include "codegen/plan/representation.hpp"
+#include "codegen/plan/validity.hpp"
 
 #include <cudf/column/column_factories.hpp>
 
@@ -106,14 +107,6 @@ bool is_keys_chars_path(std::string const& path)
 {
   return path.find("keys_chars") != std::string::npos;
 }
-
-// Ops that carry a nullable input's validity through to decode (via a null_mask
-// channel their representation marks required(), see representation.hpp). Every
-// other compressor operates on the packed data buffer only and would silently
-// drop the validity bitmask, surfacing garbage under the null slots on decode.
-// The walk fails closed for those (see emit_path) until numeric ops learn to
-// route validity themselves.
-bool op_handles_nulls(std::string const& op) { return op == "str_split" || op == "dictionary"; }
 
 std::unique_ptr<cudf::column> copy_identity_leaf(cudf::column_view const& view,
                                                  std::string const& path,
@@ -238,20 +231,18 @@ void CompressWalk::emit_path(ValueId v)
   }
   visited[n] = true;
 
-  // Fail closed on nullable input to an op that can't carry validity, rather
-  // than silently dropping the null mask. Intermediate channels are null-free by
-  // construction, so checking each op's input view is sufficient; only the root
-  // leaf column can legitimately carry nulls.
-  if (!op_handles_nulls(node.op)) {
-    for (auto const& src : node.input_sources) {
-      auto const src_it = columns.find(src);
-      if (src_it != columns.end() && src_it->second.null_count() > 0) {
-        set_error("compressor '" + node.op +
-                  "' does not support nullable input (validity would be dropped); "
-                  "route the column through a null-aware op (str_split/dictionary) "
-                  "or drop nulls upstream");
-        return;
-      }
+  // Backstop: no op can see a nullable input, because compress_column strips the
+  // column's validity into the tree's sidecar before the walk and intermediate
+  // channels are null-free by construction. No compressor carries a validity
+  // bitmask, so fail closed rather than silently drop one if that invariant is
+  // ever broken.
+  for (auto const& src : node.input_sources) {
+    auto const src_it = columns.find(src);
+    if (src_it != columns.end() && src_it->second.null_count() > 0) {
+      set_error("compressor '" + node.op +
+                "' received a nullable input (validity would be dropped); validity "
+                "should have been stripped into the plan tree's sidecar before the walk");
+      return;
     }
   }
 
@@ -522,25 +513,6 @@ void CompressWalk::emit_generic_node(NodeId n, cudf::column_view col)
   for (auto const& output : outputs)
     output_by_name.emplace(output.name, output.view);
 
-  // Guard: every channel the rep marks required must be routed by the plan, or
-  // data (e.g. a nullable column's validity via str_split's null_mask) would be
-  // silently dropped. Runs only when some outputs are declared (a bare terminal
-  // `input -> str_split` stored the whole rep above and is safe).
-  for (auto const& req : repr->required_channels()) {
-    bool declared = false;
-    for (auto const& out_name : node.output_names) {
-      if (req == out_name) {
-        declared = true;
-        break;
-      }
-    }
-    if (!declared) {
-      set_error("compressor '" + node.op + "' requires output '" + req +
-                "' to be routed by the plan (nullable input)");
-      return;
-    }
-  }
-
   size_t pending = 0;
   std::vector<ValueId> to_recurse;
   // The rep's owner key is this node's own representative output value {n,0} —
@@ -614,6 +586,12 @@ std::unique_ptr<PlanTree> compress_column(cudf::column_view input,
   }
   PlanTree& tree = *plan_tree;
 
+  // Detach validity before anything else looks at the column. Everything below
+  // this line -- the walk, every operator, the JIT-fused subtrees -- sees a
+  // null-free column, which is why no plan has to route a mask and no compressor
+  // has to know what one is. An all-valid input passes through untouched.
+  cudf::column_view values = strip_validity(input, tree.validity, stream, mr);
+
   // consumer_by_input[V] = the node that consumes the value produced at V,
   // derived structurally from each node's input_sources (the (node, port) each
   // input comes from). First-consumer-wins, matching parse_plan_dsl. Every value
@@ -634,7 +612,7 @@ std::unique_ptr<PlanTree> compress_column(cudf::column_view input,
   // case (a raw-passthrough or boundary channel with a downstream consumer)
   // uniformly — so there is no separate fast path to maintain here.
   ValueColumnMap columns;
-  columns.emplace(ValueId{0, 0}, input);  // the column input is value (node 0, port 0)
+  columns.emplace(ValueId{0, 0}, values);  // the column input is value (node 0, port 0)
   std::unordered_map<ValueId, std::unique_ptr<compressed_representation>, ValueIdHash>
     reprs_by_input;
   std::vector<bool> visited(tree.nodes.size(), false);

--- a/src/compression/simpatico_codegen/src/plan/decompress.cpp
+++ b/src/compression/simpatico_codegen/src/plan/decompress.cpp
@@ -3,6 +3,7 @@
 #include "codegen/codegen_bridge.hpp"
 #include "codegen/plan/bitjoin_layout.hpp"
 #include "codegen/plan/plan_interpreter.hpp"
+#include "codegen/plan/validity.hpp"
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
@@ -804,7 +805,13 @@ std::unique_ptr<cudf::column> decompress_column(PlanTree const& tree,
   }
 
   DecodeWalk walk{tree, stream, mr, error_out};
-  return walk.run();
+  auto col = walk.run();
+  if (!col) return nullptr;
+
+  // Reattach the validity the compress side detached. The walk itself decodes a
+  // null-free column, so this is the only place the mask re-enters the picture.
+  attach_validity(*col, tree.validity, stream, mr);
+  return col;
 }
 
 }  // namespace simpatico

--- a/src/compression/simpatico_codegen/src/plan/operator_registry.cpp
+++ b/src/compression/simpatico_codegen/src/plan/operator_registry.cpp
@@ -56,9 +56,7 @@ std::vector<OperatorInfo> const& operator_registry()
     {OpId::Bitextract,     "bitextract",      {},                                                                     true,  false, true,  false},
     {OpId::Identity,       "identity",        {"data"},                                                               false, false, false, false},
     {OpId::NvcompCascaded, "nvcomp_cascaded", {"output"},                                                             false, false, false, false},
-    // 2 or 3 channels: offsets, chars[, null_mask]. null_mask is optional (present only when
-    // nullable); the generic named_channels() skips nullptr slots so arity is correct at runtime.
-    {OpId::StrSplit,       "str_split",       {"offsets", "chars", "null_mask"},                                     true,  false, true,  false},
+    {OpId::StrSplit,       "str_split",       {"offsets", "chars"},                                                   true,  false, true,  false},
   };
   // clang-format on
   return kTable;

--- a/src/compression/simpatico_codegen/src/plan/representation_factory.cpp
+++ b/src/compression/simpatico_codegen/src/plan/representation_factory.cpp
@@ -17,7 +17,6 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/dictionary/dictionary_factories.hpp>
-#include <cudf/null_mask.hpp>
 
 #include <rmm/device_buffer.hpp>
 #include <rmm/resource_ref.hpp>
@@ -125,36 +124,6 @@ std::unique_ptr<compressed_representation> identity_compressed_representation::f
   return std::make_unique<identity_compressed_representation>(std::move(outputs[0]));
 }
 
-namespace {
-
-// Reads a "null_mask" channel column (UINT8 bitmask bytes, as emitted by
-// dictionary/str_split named_channels) into a device_buffer + null count over
-// `num_rows` rows. Returns false and sets *error_out on a malformed channel.
-bool take_null_mask_channel(std::unique_ptr<cudf::column> mask_col,
-                            cudf::size_type num_rows,
-                            rmm::device_buffer* mask_out,
-                            cudf::size_type* null_count_out,
-                            rmm::cuda_stream_view stream,
-                            std::string* error_out)
-{
-  if (mask_col->type().id() != cudf::type_id::UINT8) {
-    if (error_out) *error_out = "dictionary null_mask must be UINT8";
-    return false;
-  }
-  if (static_cast<std::size_t>(mask_col->size()) < cudf::bitmask_allocation_size_bytes(num_rows)) {
-    if (error_out) *error_out = "dictionary null_mask is shorter than the row count requires";
-    return false;
-  }
-  auto const* bits =
-    reinterpret_cast<cudf::bitmask_type const*>(mask_col->view().data<std::uint8_t>());
-  *null_count_out = num_rows > 0 ? cudf::null_count(bits, 0, num_rows, stream) : 0;
-  auto contents   = mask_col->release();
-  *mask_out       = std::move(*contents.data);
-  return true;
-}
-
-}  // namespace
-
 std::unique_ptr<compressed_representation> dictionary_compressed_representation::from_outputs(
   std::vector<std::string> const& output_names,
   std::vector<std::unique_ptr<cudf::column>> outputs,
@@ -166,17 +135,10 @@ std::unique_ptr<compressed_representation> dictionary_compressed_representation:
     if (error_out) *error_out = "dictionary: output_names / outputs size mismatch";
     return nullptr;
   }
-  // Accepts a trailing optional "null_mask" channel (UINT8 bitmask bytes of the
-  // decoded column) — reattached below so validity survives channel-based
-  // round-trips (.hpln IO and decomposed plans).
-  bool const has_mask = !output_names.empty() && output_names.back() == "null_mask";
-
-  // keys_offsets, keys_chars, indices (+ null_mask).
-  if (outputs.size() != (has_mask ? 4u : 3u) || output_names[0] != "keys_offsets" ||
+  if (outputs.size() != 3u || output_names[0] != "keys_offsets" ||
       output_names[1] != "keys_chars" || output_names[2] != "indices") {
     if (error_out) {
-      *error_out =
-        "dictionary outputs must be named 'keys_offsets, keys_chars, indices[, null_mask]'";
+      *error_out = "dictionary outputs must be named 'keys_offsets, keys_chars, indices'";
     }
     return nullptr;
   }
@@ -188,14 +150,6 @@ std::unique_ptr<compressed_representation> dictionary_compressed_representation:
   cudf::size_type num_keys    = num_offsets > 0 ? static_cast<cudf::size_type>(num_offsets - 1) : 0;
   if (keys_chars->type().id() != cudf::type_id::UINT8) {
     if (error_out) *error_out = "dictionary keys_chars must be UINT8";
-    return nullptr;
-  }
-
-  rmm::device_buffer mask(0, stream, mr);
-  cudf::size_type null_count = 0;
-  if (has_mask &&
-      !take_null_mask_channel(
-        std::move(outputs[3]), indices->size(), &mask, &null_count, stream, error_out)) {
     return nullptr;
   }
 
@@ -212,10 +166,7 @@ std::unique_ptr<compressed_representation> dictionary_compressed_representation:
                                                 rmm::device_buffer(0, stream, mr));
 
   auto dict_col =
-    null_count > 0
-      ? cudf::make_dictionary_column(
-          std::move(keys_strings), std::move(indices), std::move(mask), null_count)
-      : cudf::make_dictionary_column(std::move(keys_strings), std::move(indices), stream, mr);
+    cudf::make_dictionary_column(std::move(keys_strings), std::move(indices), stream, mr);
   // Indices, keys, and chars are then obtained as views from this column via
   // get_dictionary_child_view(dict_col->view(), ...) / dictionary_column_view.
   return std::make_unique<dictionary_compressed_representation>(std::move(dict_col));
@@ -378,20 +329,16 @@ std::unique_ptr<compressed_representation> str_split_compressed_representation::
   rmm::device_async_resource_ref,
   std::string* error_out)
 {
-  // Variable arity: {offsets, chars} or {offsets, chars, null_mask}.
-  bool const has_mask = outputs.size() == 3;
-  if (outputs.size() != 2 && outputs.size() != 3) {
-    if (error_out) *error_out = "str_split expects 2 (offsets, chars) or 3 (+ null_mask) outputs";
+  if (outputs.size() != 2) {
+    if (error_out) *error_out = "str_split expects 2 outputs (offsets, chars)";
     return nullptr;
   }
-  if (output_names[0] != "offsets" || output_names[1] != "chars" ||
-      (has_mask && output_names[2] != "null_mask")) {
-    if (error_out) *error_out = "str_split outputs must be 'offsets, chars[, null_mask]'";
+  if (output_names[0] != "offsets" || output_names[1] != "chars") {
+    if (error_out) *error_out = "str_split outputs must be 'offsets, chars'";
     return nullptr;
   }
   auto offsets       = std::move(outputs[0]);
   auto chars         = std::move(outputs[1]);
-  auto null_mask     = has_mask ? std::move(outputs[2]) : nullptr;
   auto const off_tid = offsets->type().id();
   if (off_tid != cudf::type_id::INT32 && off_tid != cudf::type_id::INT64) {
     if (error_out) *error_out = "str_split offsets must be INT32 or INT64";
@@ -402,13 +349,13 @@ std::unique_ptr<compressed_representation> str_split_compressed_representation::
   auto const chars_tid = chars->type().id();
   bool const chars_ok  = chars_tid == cudf::type_id::UINT8 || chars_tid == cudf::type_id::UINT32 ||
                         chars_tid == cudf::type_id::UINT64;
-  if (!chars_ok || (null_mask && null_mask->type().id() != cudf::type_id::UINT8)) {
-    if (error_out) *error_out = "str_split chars must be UINT8/UINT32/UINT64, null_mask UINT8";
+  if (!chars_ok) {
+    if (error_out) *error_out = "str_split chars must be UINT8/UINT32/UINT64";
     return nullptr;
   }
   cudf::size_type const n = offsets->size() > 0 ? offsets->size() - 1 : 0;
   return std::make_unique<str_split_compressed_representation>(
-    n, std::move(offsets), std::move(chars), std::move(null_mask));
+    n, std::move(offsets), std::move(chars));
 }
 
 std::unique_ptr<compressed_representation> bitextract_compressed_representation::from_outputs(

--- a/src/compression/simpatico_codegen/src/plan/validity.cpp
+++ b/src/compression/simpatico_codegen/src/plan/validity.cpp
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// strip_validity / attach_validity: the two ends of the transparent null path.
+// See validity.hpp for the contract.
+
+#include "codegen/plan/validity.hpp"
+
+#include <cudf/null_mask.hpp>
+
+#include <vector>
+
+namespace simpatico {
+
+cudf::column_view strip_validity(cudf::column_view input,
+                                 validity_sidecar& out,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::device_async_resource_ref mr)
+{
+  auto const n     = input.size();
+  auto const nulls = input.null_count();
+
+  // Fast path: nothing to carry. No allocation, no copy, no kernel -- the view
+  // reaches the walk exactly as it arrived. An all-valid column pays nothing for
+  // nullability support, including in the .hpln header (see push_validity).
+  if (nulls == 0 || n == 0) {
+    out = validity_sidecar{};
+    return input;
+  }
+
+  if (nulls == n) {
+    // Fast path: every row is null, so the bitmask is a constant. Record the
+    // kind alone -- nothing is copied here and nothing is serialized later;
+    // attach_validity regenerates the mask from the row count.
+    out.kind       = validity_kind::all_null;
+    out.null_count = n;
+    out.mask       = rmm::device_buffer{};
+  } else {
+    // copy_bitmask rebases a sliced view's mask to start at row 0, so the
+    // sidecar always describes rows [0, size) of the logical column regardless
+    // of input.offset().
+    out.kind       = validity_kind::mask;
+    out.null_count = nulls;
+    out.mask       = cudf::copy_bitmask(input, stream, mr);
+  }
+
+  // The same column with its validity buffer dropped. Offset and children are
+  // preserved, so stripping is behaviourally neutral: every operator sees what
+  // it would have seen had the column arrived all-valid.
+  std::vector<cudf::column_view> children;
+  children.reserve(static_cast<std::size_t>(input.num_children()));
+  for (cudf::size_type i = 0; i < input.num_children(); ++i) {
+    children.push_back(input.child(i));
+  }
+  return cudf::column_view(input.type(),
+                           n,
+                           input.head<void>(),
+                           /*null_mask=*/nullptr,
+                           /*null_count=*/0,
+                           input.offset(),
+                           children);
+}
+
+void attach_validity(cudf::column& col,
+                     validity_sidecar const& v,
+                     rmm::cuda_stream_view stream,
+                     rmm::device_async_resource_ref mr)
+{
+  switch (v.kind) {
+    case validity_kind::all_valid: return;
+
+    case validity_kind::all_null:
+      col.set_null_mask(cudf::create_null_mask(col.size(), cudf::mask_state::ALL_NULL, stream, mr),
+                        col.size());
+      return;
+
+    case validity_kind::mask:
+      // Copied, not moved: decompress_column takes the tree by const reference
+      // and the same tree may be decoded repeatedly (e.g. a pinned chunk served
+      // to several queries).
+      col.set_null_mask(rmm::device_buffer(v.mask.data(), v.mask.size(), stream, mr),
+                        static_cast<cudf::size_type>(v.null_count));
+      return;
+  }
+}
+
+}  // namespace simpatico

--- a/src/compression/simpatico_codegen/tests/test_compress_with_plan_roundtrip.cpp
+++ b/src/compression/simpatico_codegen/tests/test_compress_with_plan_roundtrip.cpp
@@ -797,10 +797,11 @@ int main()
     }
 
     {
-      // str_split: decompose STRING into offsets/chars[/null_mask], compress each
-      // channel independently (offsets -> delta -> bitpack fused; chars -> lz4),
-      // reassemble via make_strings_column. Conditional arity: a non-null column
-      // uses a 2-channel plan; a nullable column MUST route null_mask (guarded).
+      // str_split: decompose STRING into offsets/chars, compress each channel
+      // independently (offsets -> delta -> bitpack fused; chars -> lz4),
+      // reassemble via make_strings_column. Validity never reaches str_split --
+      // compress_column strips it into the tree's sidecar -- so ONE 2-channel
+      // plan serves nullable and non-nullable columns alike.
       // NOTE the nested path str_split.offsets.differences (offsets is non-root).
       auto stream                   = cudf::get_default_stream();
       std::vector<std::string> vals = {
@@ -815,28 +816,32 @@ int main()
       roundtrip_once(t->view(), dsl2, 1, "str_split");
       roundtrip_once(t->view(), dsl2, 2, "str_split_mt");
 
-      // Nullable: 3-channel plan carries the mask (null_mask declared on line 1).
-      std::string const dsl3 =
-        "input -> str_split -> offsets, chars, null_mask\n"
-        "str_split.offsets -> delta -> differences\n"
-        "str_split.offsets.differences -> bitpack\n"
-        "str_split.chars -> lz4\n"
-        "str_split.null_mask -> identity\n";
+      // The SAME plan on a nullable column: the mask rides the tree's sidecar, so
+      // the plan needs no null_mask leg and the walk is identical to the
+      // non-nullable case above.
       std::vector<bool> valid = {true, false, true, true, false, true, true, false};  // 3 nulls
       auto tn                 = make_strings_table(vals, valid, stream);
-      auto ct                 = roundtrip_once(tn->view(), dsl3, 1, "str_split_nulls");
+      auto ct                 = roundtrip_once(tn->view(), dsl2, 1, "str_split_nulls");
       // strings_equal ignores validity, so assert null preservation explicitly.
       auto decoded = decompress(ct, stream, rmm::mr::get_current_device_resource_ref());
       expect(decoded->view().column(0).null_count() == 3, "str_split_nulls: null_count preserved");
+      expect(validity_equal(tn->view().column(0), decoded->view().column(0)),
+             "str_split_nulls: null positions preserved");
+      expect(ct.columns[0].plan_tree->validity.kind == simpatico::validity_kind::mask,
+             "str_split_nulls: sidecar carries a mask");
 
-      // Guard: nullable column + 2-channel plan must ERROR, not drop nulls silently.
-      bool threw = false;
+      // A plan that still declares null_mask must ERROR: str_split no longer
+      // produces that channel, and silently ignoring a declared output would
+      // hide plan typos.
+      std::string const dsl_mask = dsl2 + "str_split.null_mask -> identity\n";
+      bool threw                 = false;
       try {
-        compress_with_plan(tn->view(), dsl2, stream, rmm::mr::get_current_device_resource_ref());
+        compress_with_plan(
+          tn->view(), dsl_mask, stream, rmm::mr::get_current_device_resource_ref());
       } catch (std::runtime_error const&) {
         threw = true;
       }
-      expect(threw, "str_split: nullable input without null_mask must throw");
+      expect(threw, "str_split: a plan routing null_mask must throw");
     }
 
     {
@@ -901,9 +906,9 @@ int main()
     }
 
     {
-      // Nullable STRING through the byte codecs must be REJECTED (the payload
-      // carries no mask), and a decomposed dictionary plan that fails to
-      // route null_mask must error rather than silently drop validity.
+      // STRING through the raw byte codecs is still rejected -- but on dtype
+      // grounds ("only fixed-width columns supported; use str_split"), which has
+      // nothing to do with validity and applies equally to a non-null column.
       auto stream = cudf::get_default_stream();
       auto mr     = rmm::mr::get_current_device_resource_ref();
       auto tn     = make_strings_table({"a", "b"}, {true, false}, stream);
@@ -914,24 +919,21 @@ int main()
         } catch (std::exception const&) {
           threw = true;
         }
-        expect(threw, "nullable STRING through ans/bitcomp must throw");
+        expect(threw, "STRING through ans/bitcomp must throw (not fixed-width)");
       }
-      bool threw = false;
-      try {
-        compress_with_plan(
-          tn->view(), "input -> dictionary -> keys_offsets, keys_chars, indices\n", stream, mr);
-      } catch (std::exception const&) {
-        threw = true;
-      }
-      expect(threw, "nullable decomposed dictionary without null_mask must throw");
+      // A decomposed dictionary plan no longer has to route null_mask.
+      auto ctd = compress_with_plan(
+        tn->view(), "input -> dictionary -> keys_offsets, keys_chars, indices\n", stream, mr);
+      auto decd = decompress(ctd, stream, mr);
+      expect(validity_equal(tn->view().column(0), decd->view().column(0)),
+             "nullable decomposed dictionary preserves validity");
     }
 
     {
-      // Nullable NUMERIC input through a non-null-aware op must be REJECTED,
-      // not silently stripped of validity. No numeric op carries a null_mask
-      // channel, so both the fused codegen path (delta -> bitpack) and the
-      // generic byte codecs (ans) must fail closed rather than decode garbage
-      // under the null slots.
+      // Nullable NUMERIC input. No numeric op carries a null_mask channel, so
+      // every one of these used to fail closed; with validity stripped into the
+      // sidecar they all round-trip, through both the fused codegen path
+      // (delta / bitpack) and the generic byte codecs (ans).
       auto stream = cudf::get_default_stream();
       auto mr     = rmm::mr::get_current_device_resource_ref();
       // Build a nullable INT32 column (offset 0, one null at row 5) directly so
@@ -945,43 +947,72 @@ int main()
                      host.data(),
                      host.size() * sizeof(std::int32_t),
                      cudaMemcpyHostToDevice) != cudaSuccess)
-        throw std::runtime_error("nullable numeric guard: cudaMemcpy failed");
+        throw std::runtime_error("nullable numeric: cudaMemcpy failed");
       cudf::set_null_mask(col->mutable_view().null_mask(), 5, 6, /*valid=*/false, stream);
       col->set_null_count(1);
       cudf::table_view nullable_tbl({col->view()});
-      expect(col->null_count() == 1, "nullable numeric guard: input has one null");
+      expect(col->null_count() == 1, "nullable numeric: input has one null");
       for (char const* plan :
            {"input -> delta -> differences\n", "input -> ans\n", "input -> bitpack\n"}) {
-        bool threw = false;
-        try {
-          compress_with_plan(nullable_tbl, plan, stream, mr);
-        } catch (std::exception const&) {
-          threw = true;
-        }
-        expect(threw, "nullable numeric input through a non-null-aware op must throw");
+        auto ct = compress_with_plan(nullable_tbl, plan, stream, mr);
+        expect(ct.columns[0].plan_tree->validity.kind == simpatico::validity_kind::mask,
+               "nullable numeric: sidecar carries a mask");
+        auto dec = decompress(ct, stream, mr);
+        // columns_equal compares the payload bytes AND validity, so a roundtrip
+        // that moved or lost the null fails here.
+        expect(columns_equal(nullable_tbl.column(0), dec->view().column(0)),
+               "nullable numeric roundtrip preserves data and validity");
       }
     }
 
     {
-      // Nullable decomposed dictionary WITH the null_mask channel routed:
-      // validity must survive the from_outputs rebuild.
+      // Validity fast paths. An all-valid column must carry no sidecar at all
+      // (byte-identical to the pre-sidecar behaviour), and an all-null column
+      // must record only the kind -- no bitmask is copied or serialized.
+      auto stream = cudf::get_default_stream();
+      auto mr     = rmm::mr::get_current_device_resource_ref();
+
+      auto plain = make_int32_table(1, 256, 7);
+      auto ctv   = compress_with_plan(plain->view(), "input -> delta -> differences\n", stream, mr);
+      expect(ctv.columns[0].plan_tree->validity.kind == simpatico::validity_kind::all_valid,
+             "all-valid column carries no sidecar");
+      expect(ctv.columns[0].plan_tree->validity.mask.size() == 0,
+             "all-valid column allocates no mask");
+
+      auto all_null = cudf::make_numeric_column(
+        cudf::data_type{cudf::type_id::INT32}, 32, cudf::mask_state::ALL_NULL, stream, mr);
+      all_null->set_null_count(32);
+      cudf::table_view an_tbl({all_null->view()});
+      auto cta = compress_with_plan(an_tbl, "input -> delta -> differences\n", stream, mr);
+      expect(cta.columns[0].plan_tree->validity.kind == simpatico::validity_kind::all_null,
+             "all-null column takes the all_null fast path");
+      expect(cta.columns[0].plan_tree->validity.mask.size() == 0,
+             "all-null column stores no bitmask");
+      auto deca = decompress(cta, stream, mr);
+      expect(deca->view().column(0).null_count() == 32, "all-null column decodes back to all-null");
+    }
+
+    {
+      // Nullable decomposed dictionary: validity must survive the from_outputs
+      // rebuild, carried by the sidecar rather than a routed channel.
       auto stream             = cudf::get_default_stream();
       std::vector<bool> valid = {true, false, true, true};
       auto tn                 = make_strings_table({"apple", "", "cherry", "apple"}, valid, stream);
       auto ct                 = roundtrip_once(tn->view(),
-                               "input -> dictionary -> keys_offsets, keys_chars, indices, "
-                                               "null_mask\n"
-                                               "dictionary.indices -> bitpack\n"
-                                               "dictionary.null_mask -> identity\n",
+                               "input -> dictionary -> keys_offsets, keys_chars, indices\n"
+                                               "dictionary.indices -> bitpack\n",
                                1,
                                "dictionary_decomposed_nulls");
       auto decoded            = decompress(ct, stream, rmm::mr::get_current_device_resource_ref());
       expect(decoded->view().column(0).null_count() == 1, "dictionary_decomposed_nulls: count");
+      expect(validity_equal(tn->view().column(0), decoded->view().column(0)),
+             "dictionary_decomposed_nulls: positions");
     }
 
     {
-      // u8 codegen on string sub-channels: RLE on the (mostly 0xFF) null_mask
-      // bytes and a fused delta->bitpack cascade on the chars bytes.
+      // u8 codegen on string sub-channels: a fused delta->bitpack cascade on the
+      // offsets and lz4 on the chars bytes, with a sparse null pattern riding the
+      // sidecar alongside.
       auto stream = cudf::get_default_stream();
       std::vector<std::string> v64;
       std::vector<bool> b64;
@@ -991,15 +1022,16 @@ int main()
       }
       auto tn      = make_strings_table(v64, b64, stream);
       auto ct      = roundtrip_once(tn->view(),
-                               "input -> str_split -> offsets, chars, null_mask\n"
+                               "input -> str_split -> offsets, chars\n"
                                     "str_split.offsets -> delta -> differences\n"
                                     "str_split.offsets.differences -> bitpack\n"
-                                    "str_split.chars -> lz4\n"
-                                    "str_split.null_mask -> rle -> runs, values\n",
+                                    "str_split.chars -> lz4\n",
                                1,
-                               "str_split_null_mask_rle_u8");
+                               "str_split_sparse_nulls_u8");
       auto decoded = decompress(ct, stream, rmm::mr::get_current_device_resource_ref());
-      expect(decoded->view().column(0).null_count() == 2, "str_split_null_mask_rle_u8: count");
+      expect(decoded->view().column(0).null_count() == 2, "str_split_sparse_nulls_u8: count");
+      expect(validity_equal(tn->view().column(0), decoded->view().column(0)),
+             "str_split_sparse_nulls_u8: positions");
 
       std::vector<std::string> vals8 = {"aa", "bb", "cc", "aa", "dd", "bb", "ee", "aa"};
       auto t8                        = make_strings_table(vals8, {}, stream);

--- a/src/compression/simpatico_codegen/tests/test_compressed_table_io.cpp
+++ b/src/compression/simpatico_codegen/tests/test_compressed_table_io.cpp
@@ -639,6 +639,49 @@ void test_str_split_plan_shapes_roundtrip()
   memory_roundtrip("str_split_bare_terminal_mem", addr_tbl->view(), bare_dsl);
 }
 
+// Validity survives both serialization paths. The sidecar is not a leaf, so it
+// travels in its own per-column header record rather than through describe() --
+// this covers the file path, the pinned in-memory path, and the two fast paths
+// that write no payload bytes at all.
+void test_validity_sidecar_roundtrip()
+{
+  auto stream = cudf::get_default_stream();
+  auto mr     = rmm::mr::get_current_device_resource_ref();
+
+  // Mixed validity: a real bitmask is written to the payload region.
+  auto mixed = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT32}, 128, cudf::mask_state::ALL_VALID, stream, mr);
+  std::vector<std::int32_t> host(128);
+  for (int r = 0; r < 128; ++r)
+    host[static_cast<std::size_t>(r)] = static_cast<std::int32_t>((r * 31 + 7) % 5000);
+  if (cudaMemcpy(mixed->mutable_view().head<std::int32_t>(),
+                 host.data(),
+                 host.size() * sizeof(std::int32_t),
+                 cudaMemcpyHostToDevice) != cudaSuccess)
+    throw std::runtime_error("validity_sidecar: cudaMemcpy failed");
+  cudf::set_null_mask(mixed->mutable_view().null_mask(), 3, 4, /*valid=*/false, stream);
+  cudf::set_null_mask(mixed->mutable_view().null_mask(), 70, 96, /*valid=*/false, stream);
+  mixed->set_null_count(27);
+  cudf::table_view mixed_tbl({mixed->view()});
+  io_roundtrip("validity_mixed", mixed_tbl, "input -> delta -> differences\n");
+  memory_roundtrip("validity_mixed_mem", mixed_tbl, "input -> delta -> differences\n");
+
+  // All null: nothing is written to the payload, so this also checks that the
+  // reader rebuilds the mask from the kind alone.
+  auto all_null = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT32}, 64, cudf::mask_state::ALL_NULL, stream, mr);
+  all_null->set_null_count(64);
+  cudf::table_view an_tbl({all_null->view()});
+  io_roundtrip("validity_all_null", an_tbl, "input -> delta -> differences\n");
+  memory_roundtrip("validity_all_null_mem", an_tbl, "input -> delta -> differences\n");
+
+  // Nullable STRING through str_split, where validity used to be a routed channel.
+  std::vector<bool> valid = {true, false, true, true, false, true};
+  auto strs = make_strings_table({"alpha", "", "gamma", "delta", "x", "zeta"}, valid, stream);
+  io_roundtrip("validity_strings", strs->view(), "input -> str_split\n");
+  memory_roundtrip("validity_strings_mem", strs->view(), "input -> str_split\n");
+}
+
 }  // namespace
 
 int main()
@@ -674,6 +717,7 @@ int main()
     {"error_bad_version", test_error_bad_version},
     {"identity_string_roundtrip", test_identity_string_roundtrip},
     {"str_split_plan_shapes", test_str_split_plan_shapes_roundtrip},
+    {"validity_sidecar", test_validity_sidecar_roundtrip},
   };
 
   int failures = 0;


### PR DESCRIPTION
Adds transparent support for a null bitmask in a compressed batch representation. It is stored as a sidecar, so none of the compression code itself sees this data. The tradeoff here is that we can also not apply any compression to it. For that, we would have to make it an explicit channel and probably also an explicit operator to split that channel out. 

The code for handling nulls in str_split and dictionary, as well as the plumbing to make that work, is removed.
There are fastpaths for all nulls and zero nulls.
I'm not sure I'm happy with this approach, I think it adds a bit too much code, I'm open to opinions/suggestions.

Fixes #1308 