### PR TITLE
[Concurrency] BIG WIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ tools/log_analyzer/__pycache__/
 tools/log_analyzer/metrics/__pycache__/
 test/tpch_performance/__pycache__/
 test/tpch_performance/output/
+
+# Core dumps (debugging concurrency crashes writes these into the repo root)
+core
+core.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -662,6 +662,7 @@ set(TEST_SOURCES
     test/cpp/scan_manager/test_s3_routing_cutover.cpp
     test/cpp/scan_manager/test_pin_table_multi_gpu.cpp
     test/cpp/scan_manager/test_cached_serving_hardening.cpp
+    test/cpp/scan_manager/test_scan_manager_query_state.cpp
     test/cpp/scan_manager/test_insert_delta_job.cpp
     test/cpp/scan_manager/test_mvcc_mask_job.cpp
     test/cpp/scan_manager/test_pinned_chunk_stats.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -722,6 +722,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_pipeline_schedule_canonical.cpp
     test/cpp/pipeline/test_plan_printer.cpp
     test/cpp/pipeline/test_repository_wiring_materializer.cpp
+    test/cpp/pipeline/test_task_index_keys.cpp
     test/cpp/pipeline/test_task_scheduler.cpp
     test/cpp/scan/bench_decode_codecs.cpp
     test/cpp/scan/test_can_serve_with_columns.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -609,6 +609,7 @@ set(TEST_SOURCES
     test/cpp/exec/test_inspectable_mpsc.cpp
     test/cpp/exec/test_interruptible_mpmc.cpp
     test/cpp/exec/test_multi_index_priority_queue.cpp
+    test/cpp/exec/test_query_lifecycle_registry.cpp
     test/cpp/exec/test_semi_future.cpp
     test/cpp/expression/test_ast_aggregate.cpp
     test/cpp/expression/test_ast_clone.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,6 +597,7 @@ set(TEST_SOURCES
     test/cpp/config/test_config.cpp
     test/cpp/config/test_context.cpp
     test/cpp/config/test_object_store_config.cpp
+    test/cpp/creator/test_task_creator_query_state.cpp
     test/cpp/data/test_convertible_data_batch.cpp
     test/cpp/data/test_data_repository_manager_registry.cpp
     test/cpp/data/test_convertible_gpu_pipeline_task.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -720,6 +720,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_partition_build_pipelines.cpp
     test/cpp/pipeline/test_pipeline_dynamic_filter_native_shape.cpp
     test/cpp/pipeline/test_pipeline_schedule_canonical.cpp
+    test/cpp/pipeline/test_per_query_completion_handler.cpp
     test/cpp/pipeline/test_plan_printer.cpp
     test/cpp/pipeline/test_repository_wiring_materializer.cpp
     test/cpp/pipeline/test_task_index_keys.cpp

--- a/docs/concurrency/00-issue-register.md
+++ b/docs/concurrency/00-issue-register.md
@@ -1,0 +1,177 @@
+# Concurrent Query Execution — Consolidated Issue Register
+
+**Branch:** `concurrency2` (`a35be838`) · **Baseline:** `dev`
+**Scope:** everything needed before `SiriusContext::query_lifecycle_mutex_` can be replaced by an
+admission queue. `src/legacy/` is out of scope.
+
+This is the single source of truth for the remaining work. Every plan option in this directory
+closes **all** of these issues; they differ only in *mechanism* and *ordering*.
+
+---
+
+## 0. Where we actually are
+
+The last six commits converted the per-query **data** plumbing:
+
+| Already done — do not redo | Commit |
+|---|---|
+| `task_creator::query_task_global_state` map keyed by `query_id_t`; per-query in-flight counter; `reset(query_id)` / `drain_pending_tasks(query_id)` | `a8002e38` |
+| `pipeline::index_keys_for` as the one key extractor; executor queues → `multi_index_priority_queue` with `query_index`; `drain(query_index)` | `59e0df9e` |
+| `completion_handler` moved onto `sirius_pipeline_task_global_state`; `task_scheduler::_query` deleted | `49dc8421` |
+| `SiriusContext::query_` deleted; `planner::query` owned by `sirius_engine`; `completion_handler_` outlives the engine | `f0883cee` |
+| `query_scan_manager_state` with its own `scoped_dispatcher`; pin table → `shared_ptr<pinned_entry>` | `cecfcfe5` |
+
+What was **not** converted is the per-query **control** plumbing. Every teardown, drain, wait,
+validate and error path is still a process-wide stop-the-world, and each is invoked once per
+query. `query_lifecycle_mutex_` is the only thing keeping them from firing.
+
+Two consequences worth stating plainly:
+
+1. **The feature is currently unreachable.** `_query_task_global_states` and `_query_states` can
+   never hold more than one live entry via SQL, so none of the new per-query code has ever run
+   under real concurrency.
+2. **Some issues are live today**, not latent — the downgrade monitor thread and the GPU manager
+   loops are not slot-gated. These are marked **LIVE**.
+
+---
+
+## Group A — Cross-query blast radius
+
+A per-query event tears down a shared subsystem. These are the loudest bugs and the first to fire.
+
+| ID | Severity | Issue | Location |
+|---|---|---|---|
+| **A1** | Critical | `task_scheduler::terminate_query()` reports to the right handler and then calls `stop()` — closes the request channel, joins the management thread, stops **every** GPU executor. Nothing ever calls `start()` again. One query's creation error hangs every other query and every future query in the process. | `src/pipeline/task_scheduler.cpp:171-176` |
+| **A2** | Critical | The creation-worker catch calls `stop()` **from inside its own pool worker**. `do_stop_thread_pool()` → `_bounded_pool->wait_all()` blocks until `active_ == 0`, but the caller *is* an active slot. Guaranteed self-deadlock; if it got past, `_bounded_pool.reset()` joins the calling thread with itself inside a `noexcept` function. | `src/creator/task_creator.cpp:688-693` → `:363-373` |
+| **A3** | Critical | GPU task exception → `_task_creator->stop()`, interrupting the shared creation queue and tearing down the shared pool. Every other query's `schedule()` push then silently returns false. The `completion->report_error` on the next line already fails the correct query. | `src/pipeline/gpu_pipeline_executor.cpp:427, 432` |
+| **A4** | Critical | Four `break`s in `manager_loop` (reservation failure, downgrade cancelled, post-downgrade reservation failure, local-state cast failure) exit the `while (_running)` loop permanently. `_running` stays `true`, nothing restarts it, that GPU stops dispatching for **all** queries, and the popped task is dropped with no error. | `src/pipeline/gpu_pipeline_executor.cpp:196, 239, 261, 295` |
+| **A5** | Critical | `wait_for_completion(query_id)` is per-query in name only: `_task_creator->stop_thread_pool()` halts creation for all queries; `_task_queue.size() != 0 → throw` sees **every** query's tasks, so A fails because B has work queued; `gpu_exec->wait_and_validate_empty()` interrupts and waits across all queries. | `src/pipeline/task_scheduler.cpp:234, 237, 250` |
+| **A6** | Critical | `drain_after_error(query_id)` likewise: `_task_queue.drain()` **unfiltered** (twice), `gpu_exec->drain_and_wait()` for all devices, plus a global `stop_thread_pool()`/`start_thread_pool()` pair. One query's error destroys every other query's queued work → they hang with no error. | `src/pipeline/task_scheduler.cpp:197, 201, 205-207, 218, 220` |
+| **A7** | Critical **LIVE** | `run_mandatory_cleanup` calls `executor->drain()` on **every** downgrade executor on **every** query end. `drain()` calls `cancel_pending_requests()`, which sets an exception on every queued promise — including query B's, whose GPU manager thread is blocked in `request_downgrade(...).get()`. B's manager thread then takes the `break` at `:239` (A4) and that GPU dies. | `src/sirius_context.cpp:322-324` → `src/downgrade/downgrade_executor.cpp:129-142, 496-506` |
+| **A8** | High | `batch_telemetry_registry::on_query_end()` takes no query id. It consumes every live placement across all 16 shards as `reason=query_end` and then `impl_->ports.clear()`. Query A's end silently truncates query B's telemetry for the rest of B's life. | `src/sirius_context.cpp:331` → `src/telemetry/batch_telemetry.cpp:475-497` |
+| **A9** | High | `multi_index_priority_queue::push` returns `false` and destroys the item when interrupted. `task_creator::schedule`/`schedule_lookahead` and `task_scheduler::schedule` all **discard** the return. Every interrupt window in A3/A5/A6 therefore loses work with zero trace — a dropped task is a pipeline that never finishes, i.e. a silent hang. | `src/creator/task_creator.cpp:404, 414, 456`; `src/pipeline/task_scheduler.cpp:112` |
+| **A10** | Critical | `manager_loop` has no try/catch but throws (`internal_exception` at `:139`) and calls throwing APIs (`make_reservation`, `acquire_stream`, telemetry). It is a `std::thread` entry function — an escaping exception aborts the process. `:139` is specifically reachable when a stale/foreign task reaches a device queue, i.e. exactly what multi-query drain bugs produce. | `src/pipeline/gpu_pipeline_executor.cpp:95-478` |
+
+---
+
+## Group B — Lifetime, ownership, use-after-free
+
+| ID | Severity | Issue | Location |
+|---|---|---|---|
+| **B1** | Critical **LIVE** | **TIER-2 downgrade resurrects a drained task.** `mutable_pop_if` removes a task from the shared scheduler queue into a processing-thread local; ownership then crosses a *blocking* `_pool->reserve()` and a full H2D/D2H conversion; `~convertible_gpu_pipeline_task` pushes it **back**. If the query's `drain_query_tasks(q)` ran in that window, the task returns after the drain. Two distinct faults follow: the re-push runs `index_keys_for` → `pipe->get_source()->type` on an **already-destroyed plan** (B5), and the resurrected task holds raw `data_repository*` into a manager about to be erased. | `src/downgrade/downgrade_executor.cpp:297-314`; `src/include/data/convertible_gpu_pipeline_task.hpp:86-89` |
+| **B2** | Critical **LIVE** | `downgrade_executor::drain()` **restarts the processing thread** as its last act (`_pool->resume(); _request_queue.reactivate(); _processing_thread = std::thread(...)`). Quiescence therefore expires *before* `erase(query_id)` runs 20 lines later. The monitor thread (~10 ms period, never stopped by `drain()`) reliably refills the queue. With >1 executor, executor[0] restarts while executor[1] is still draining. | `src/downgrade/downgrade_executor.cpp:138-141` vs `src/sirius_context.cpp:323` / `:345` |
+| **B3** | High **LIVE** | TIER-1 sweep holds raw `shared_data_repository*` from `manager->get_repositories()` across a blocking `reserve()`. The `shared_ptr<manager>` protects the *manager*, not the repositories inside it — `erase()` → `clear_all_repositories()` destroys the `unique_ptr`s. The registry header states this precondition explicitly; nothing enforces it. | `src/downgrade/downgrade_executor.cpp:223-236`; `src/include/data/data_repository_manager_registry.hpp:124-142` |
+| **B4** | High | `gpu_pipeline_task::_data_repos` is `vector<shared_data_repository*>` carried across every queue hop and re-copied on the OOM reschedule path (which includes a 50 ms sleep). Any task alive when its manager is erased UAFs in `publish_output`. | `src/include/pipeline/gpu_pipeline_task.hpp:276`; `src/pipeline/gpu_pipeline_executor.cpp:404-423` |
+| **B5** | High | **The plan is destroyed before the drains.** `cleanup_internal` → `sirius_active_query.reset()` destroys `sirius_engine` and therefore `sirius_owned_plan`; only *then* does `window->finish()` run `run_mandatory_cleanup`. `sirius_pipeline::source`/`operators`/`sink` are non-owning refs into that freed plan, and the pipeline outlives it (held by `shared_ptr` from the task global state). `~gpu_pipeline_task` → `mark_task_completed()` → `notify_downstream_pipelines()` dereferences all of them. The code acknowledges the inversion in a comment. | `src/sirius_interface.cpp:124` vs `src/sirius_context.cpp:314-318`; `src/include/pipeline/sirius_pipeline.hpp:243-247` |
+| **B6** | Critical | `terminate()` does `task_scheduler_.reset()` **before** stopping the downgrade executors and the creator pool. Each downgrade executor holds `_pipeline_task_queue` = a raw pointer into the destroyed `task_scheduler::_task_queue` and dereferences it in `processing_loop`; creator lambdas hold `_task_scheduler`. | `src/sirius_context.cpp:817-828`; `src/include/downgrade/downgrade_executor.hpp:210` |
+| **B7** | High | `SiriusContext` member declaration order makes `task_scheduler_` destroy *after* `task_creator_` and `downgrade_executors_`, but `task_scheduler` holds raw pointers to both. Reachable when `initialize()` throws after `task_scheduler_` is constructed (`is_initialized_` stays false, so `~SiriusContext` skips `terminate()`). | `src/include/sirius_context.hpp:621-624` |
+| **B8** | High | `drop_query_runtime_state_best_effort` resets the creator, scheduler queues and scan manager but **never erases the repository registry**. A failed cleanup therefore leaks the query's manager and every batch in it (GPU memory never returned) until `terminate()`, and the downgrade executors keep sweeping it on every monitor cycle forever. | `src/sirius_context.cpp:404-430` |
+| **B9** | Medium | `data_repository_manager::get_repository()` returns a **reference into the map** and is the only method in the class that does not take `_mutex`. A concurrent `add_new_repository` rehash or `clear_all_repositories` races it. | `cucascade/include/cucascade/data/data_repository_manager.hpp:155-158` |
+| **B10** | Medium | `~SiriusContext() noexcept` calls `terminate()`, which starts with `throw_if_not_initialized()` and goes on to `reset_all()` / `registry.clear()` / `memory_manager_->shutdown()`. Any throw → `std::terminate` during DB teardown. | `src/sirius_context.cpp:134-137` |
+| **B11** | High | `prefetching_cache` unlocks the map mutex and *then* uses the iterator (`lk.unlock(); ...; return *it->second;`). A concurrent insert rehashes `_file_cache` and the reader touches a freed bucket. Element pointers are stable; iterators are not. Single-query runs first-touch everything in one prepare, so this only becomes routine with two queries opening different files. | `src/io/cache/prefetching_cache.cpp:311-322, 385-390` |
+
+---
+
+## Group C — Deadlock and lock ordering
+
+| ID | Severity | Issue | Location |
+|---|---|---|---|
+| **C1** | Critical | `stop_thread_pool()` holds `_global_state_mutex` across `_manager_thread.join()`; the manager thread calls `get_query_task_global_state()`, which takes **the same mutex**. Manager blocks on the mutex, stopper blocks in `join()` holding it. Reachable on **every query completion** (`wait_for_completion` → `stop_thread_pool`), and far likelier with a second query keeping the creation queue non-empty. | `src/creator/task_creator.cpp:375-379` → `:369`, vs `:486` → `:112` |
+| **C2** | High | `task_creator::stop()` does **not** take `_global_state_mutex` while `stop_thread_pool()`/`start_thread_pool()` do. A worker calling `stop()` can be inside `do_stop_thread_pool()` while the DuckDB thread — seeing the `_running` CAS already false — returns immediately and calls `start_thread_pool()`, reassigning `_bounded_pool` and `_manager_thread` under the other thread. | `src/creator/task_creator.cpp:340-344` vs `:346-361`, `:375-379` |
+| **C3** | Critical | `k_max_concurrent_queries = 1`, and the scan pool is sized `num_threads + k_max_concurrent_queries`. Each query parks one **blocking** coalescer sequencer in `queue.wait_dequeue`, unblocked only by that query's own split tasks on the same pool. At Q ≥ pool size this is a hard deadlock. Exceeding the cap currently only emits `SIRIUS_LOG_WARN`. The header carries its own `TODO: … RAISE IT`. | `src/include/scan_manager/sirius_scan_manager.hpp:284-292`; `src/scan_manager/sirius_scan_manager.cpp:272-280, 596-610` |
+| **C4** | High | There is exactly **one** manager thread per GPU, and it performs both a blocking `make_reservation` and a blocking downgrade `.get()` while holding a reserved pool slot. One query's memory-hungry task blocks every other query's dispatch to that GPU. If the memory that would be released requires a downstream task to be dispatched, it livelocks; only the `IDLE` fallback in cucascade prevents a hard hang in the all-quiet case. | `src/pipeline/gpu_pipeline_executor.cpp:187, 234`; `cucascade/src/memory/memory_space.cpp:258-268` |
+
+---
+
+## Group D — Gaps in the per-query tracking that already exists
+
+| ID | Severity | Issue | Location |
+|---|---|---|---|
+| **D1** | High | `get_operator_for_next_task(node)` runs on the manager thread **before** `enter_in_flight()` and recursively calls `node->get_next_task_hint()`. `drain_pending_tasks(Q)` can see `in_flight == 0` and return while that dereference is in progress — a hole in the exact invariant the mechanism exists to provide. | `src/creator/task_creator.cpp:493` vs `:499` |
+| **D2** | High | The creation queue's key extractor dereferences `request.node->type` **at push time**, inside the queue mutex. A `schedule()` racing teardown reads a freed operator. Not covered by the in-flight counter. | `src/creator/task_creator.cpp:58-62` |
+| **D3** | Medium | `schedule_lookahead` hard-codes `_query_task_global_states.begin()` — only the *oldest* query ever gets lookahead, so every newer query starts cold. It also dereferences operators under only `lookahead_mutex`, uncounted by the in-flight tracker. Carries its own TODO. | `src/creator/task_creator.cpp:419-459` |
+| **D4** | Medium | `if (_task_queue.empty()) { schedule_lookahead(*_ready_devices.begin()); }` — `_ready_devices` can be empty when woken by a `task_available` event. B1's extraction window makes `_task_queue.empty()` return true while a task is temporarily held by a downgrade worker, so concurrency makes this reachable routinely. | `src/pipeline/task_scheduler.cpp:309-313` |
+| **D5** | High | `runtime_unavailable_` is a process-wide permanent latch set by *one* query's cleanup failure. Defensible when only one query can be mid-cleanup; with N queries one unlucky query poisons N−1 healthy ones and every future query. It conflates "this query's state is corrupt" with "the shared runtime is corrupt". | `src/include/sirius_context.hpp:575`; `src/sirius_context.cpp:335-338` |
+| **D6** | Medium | `_monitor_request_enqueued` latches `true` and is cleared **only** inside `processing_loop`. `cancel_pending_requests()` eats queued monitor requests without resetting it, and the push returns `false` when interrupted. Any `drain()` that races the monitor leaves the flag stuck → **automatic memory-pressure downgrade for that space is dead for the rest of the process**, and every later query OOMs instead of spilling. | `src/downgrade/downgrade_executor.cpp:456, 473-474, 496-506` |
+
+---
+
+## Group E — Shared mutable configuration
+
+| ID | Severity | Issue | Location |
+|---|---|---|---|
+| **E1** | High | `operator_params` is one plain non-atomic struct per `DatabaseInstance`, written by ~20 `SET` callbacks and read mid-plan and mid-execution. The **only** thing serializing those writes is the slot this project removes. Semantics are already wrong today: B's `SET scan_task_batch_size` silently changes A's next query. | `src/include/sirius_config.hpp:245`; `src/sirius_extension.cpp:1788-1794` and 20 setters; readers `src/sirius_engine.cpp:211`, `src/planner/sirius_physical_plan_generator.cpp:83` |
+| **E2** | High | `duckdb::Config` process-wide static variables written by `SET` callbacks with **no** guard at all. `EXPRESSION_EVALUATOR_STRATEGY` is read as a **default argument** on every `expression_evaluator` construction, so B's `SET` can change strategy between two operators of A's plan. The `LOG_*` `std::string`s are worse — concurrent reassign/read is a torn read or UAF on the string buffer. | `src/include/config.hpp:30-77`; writers `src/sirius_extension.cpp:1638-1758, 1859-1894` |
+| **E3** | High | Five compression-config setters write `get_config().get_compression_config()` with **no slot**, inconsistent with their `operator_params` neighbours. The reader (`PinTableFunction`) does hold a window and passes the `std::string` straight into `fs::directory_iterator`. | `src/sirius_extension.cpp:1942-1983` vs `:1287-1337` |
+| **E4** | High | `PhysicalSiriusExecution::logical_plan_` is `mutable` and `reset()` from a `const` source method. DuckDB shares one prepared `PhysicalOperator` across executions and calls `GetDataInternal` `const` precisely because it assumes re-entrancy. Two concurrent `EXECUTE`s of the same transparent prepared statement → one thread dereferences while the other destroys. | `src/include/transparent/physical_sirius_execution.hpp:74`; `src/transparent/physical_sirius_execution.cpp:198, 202` |
+| **E5** | Medium | `plan_register::global()` check-then-act across three separate critical sections, keyed by bare table name with no catalog/schema. Two connections pinning same-named tables in different ATTACHed DBs both miss, both write, and the loser pins with the other database's plan DSL. | `src/sirius_extension.cpp:1293, 1301, 1317` |
+| **E6** | Medium | `get_target_ctas()` uses `static int cached_device = -1; static uint32_t cached = 0;` with a non-atomic check-then-use — the only genuine mutable function-local static in the operator/CUDA layer. Two queries race both words; on multi-GPU the pair can tear and return the other device's CTA count. | `src/include/cuda/scan/strings/common.cuh:150-158` |
+| **E7** | Medium | `SiriusTableFunctionData::original_config` saves/restores `ClientConfig` on **shared bind data**. Two concurrent executions of one `gpu_execution(...)` prepared statement clobber each other's saved config, leaving a connection with `enable_optimizer` permanently flipped. | `src/sirius_extension.cpp:247, 252, 266` |
+
+---
+
+## Group F — Fairness and performance under concurrency
+
+These do not corrupt anything, but concurrency is the point — a correct engine that serializes is not a win.
+
+| ID | Severity | Issue | Location |
+|---|---|---|---|
+| **F1** | High | `query_id` is packed into the **high** bits of the scheduling priority and the queue pops lowest-first, so **every** task of query 1 outranks **every** task of query 2. Query 2 runs only when query 1 has nothing dispatchable; if query 1 waits on memory only query 2 could release, it livelocks. | `src/include/query_id.hpp:66-69`; `src/creator/task_creator.cpp:256-260` |
+| **F2** | Medium | The plan-time `SlotGuard` makes plan generation mutually exclusive with *execution*. Planning is CPU-only and needs only a read view of the pin table, which `_pinned_entries_mutex` + `shared_ptr<pinned_entry>` now provide. Today query A executing blocks query B from even being planned. The cheapest lock to narrow. | `src/sirius_context.cpp:1236` |
+| **F3** | Medium | Prefetch-cache query epoch is one global `_ticker`; scoring is newest-wins, so B's `prepare_for_query` demotes every chunk A prefetched-but-not-yet-read to eviction tier 0. Documented as a KNOWN GAP, not fixed. Related: `chunk_lifecycle::on_request` resets A's counters when B touches the same chunk. | `src/include/io/cache/prefetching_cache.hpp:228`; `src/io/cache/prefetching_cache.cpp:659`; `src/include/io/cache/types.hpp:368-370, 407-412` |
+| **F4** | Medium | One `_preparation_thread`, one `_prefetch_thread`, one `_evictor_thread`, one process-wide `_rate_limiter` with no query dimension. Strict FIFO: query A's 20k chunk requests fully block query B's first prefetch. | `src/include/io/cache/prefetching_cache.hpp:251-262`; `src/exec/admission_control.cpp` |
+| **F5** | Medium | The pin/unpin guard rejects on `use_count() > 1`, but the extra reference comes from an **all-entries** snapshot. Query A anywhere inside `try_match_cached_entry` holds a ref to *every* pinned entry, so connection B's `PIN` on a completely unrelated table spuriously fails. | `src/scan_manager/sirius_scan_manager.cpp:1002-1007, 1272-1276, 1482-1491` |
+| **F6** | Medium | Sizing reads whole-device/whole-host free memory: sort partition count from `get_available_memory()`, result-collector host space from `max_element` over free bytes then an unreserved `make_reservation_or_null`. Two concurrent sorts each size to a fraction of the *same* free bytes and overshoot; two collectors pick the same host space and one gets `nullptr`. | `src/op/sirius_physical_sort_sample.cpp:266`; `src/op/sirius_physical_result_collector.cpp:160-193` |
+| **F7** | Medium | `cudaDeviceSynchronize()` in the dynamic-filter publish fallback blocks **all** of query B's kernels on every stream. Plus default-stream work in the orphan-pairing path, parquet footer read, and string decode — the build does not enable per-thread default stream, so the legacy default stream implicitly synchronizes with every blocking stream on the device. | `src/op/sirius_physical_hash_join.cpp:2023, 1183`; `src/op/scan/parquet_gpu_ingestible.cpp:461` |
+| **F8** | Medium | Downgrade is strictly serial (one request at a time, ending in `_pool->wait_all()`), and TIER 2 sizes its budget from the whole shared queue and pops **other queries'** ready tasks. Defensible — memory pressure is global — but it is a throughput cliff and it briefly removes a co-tenant's dispatchable work. | `src/downgrade/downgrade_executor.cpp:144-398` |
+| **F9** | Medium | Shared blocking primitives with no query dimension that will become the next bottleneck once the slot is gone: cucascade's `memory_reservation_manager::_wait_cv` (blocks when no space can satisfy a reservation) and `exclusive_stream_pool::_cv` (blocks when all streams are checked out). | `cucascade/include/cucascade/memory/memory_reservation_manager.hpp:276-277`; `cucascade/include/cucascade/memory/stream_pool.hpp:99-100` |
+
+---
+
+## Group G — Test infrastructure
+
+| ID | Severity | Issue |
+|---|---|---|
+| **G1** | Critical | **No reusable concurrency harness exists.** All four new branch tests (`test_task_creator_query_state.cpp`, `test_scan_manager_query_state.cpp`, `test_per_query_completion_handler.cpp`, `test_task_index_keys.cpp`) are **single-threaded** — they prove state *partitioning*, not race-freedom. `test_scan_manager_query_state.cpp:181` is literally titled *"concurrent queries do not collide on operator id"* and spawns zero threads. |
+| **G2** | High | The only multi-threaded multi-connection code lives in an anonymous namespace inside `test/cpp/integration/test_query_lifecycle_slot.cpp` (start gate, `async_query_result`, `scoped_blocking_window_log_sink`, `held_window_threads` — ~200 lines). Nothing in `test/cpp/utils/` spawns a thread. Mainstream fixtures (`GpuExecutionFixture`, `GPUExecutionFixtureBase`) hold **one** connection and have no `make_connection()`. |
+| **G3** | High | The harness actively **forbids** parallel tests: `shared_env_listener` and `scoped_mgpu_env`'s ctor *pause* (destroy the `DuckDB` instance of) every other env before each test. |
+| **G4** | Medium | `test_query_lifecycle_slot.cpp` exists to prove **serialization** — e.g. `run_ac2_gpu_single_flight` asserts the second query *waits on the slot*. These assertions need to be re-expressed against the new semantics, not deleted. |
+| **G5** | Medium | `run_ac13_concurrent_logging` is fully implemented (`:1919-2045`) and dispatchable (`:2082`) but **no `TEST_CASE` invokes it**. |
+| **G6** | Low | `test/cpp/integration/test_transparent_execution.cpp:304-366` asserts the *old* whole-query serialization semantics (`REQUIRE(is_query_lifecycle_active())`, `REQUIRE(second_elapsed >= 150ms)`). It is orphaned (not in `CMakeLists.txt`, listed in `orphan_test_allowlist.txt:13`) and uses a nonexistent `pg_sleep()`. Dead — but it is the **only** file with a fixture-level `make_connection()`, so it is the natural salvage point. |
+| **G7** | Medium | Zero SQLLogic concurrency (`concurrentloop` appears nowhere). No TPC-H/TPC-DS query is ever run concurrently with another. |
+
+---
+
+## Group H — Dead code, drift, and hygiene
+
+| ID | Issue | Location |
+|---|---|---|
+| **H1** | `task_creator::_client_context` — uninitialized raw pointer, not in the ctor init list, never read. Superseded by the per-query `query_task_global_state::client_context`. A trap waiting for someone to "fix" it by reading it. | `src/include/creator/task_creator.hpp:240` |
+| **H2** | `sirius_engine::wait_for_query_finish()` + `query_finish_mutex` / `query_finish_cv` / `query_finished` — **no definition, no caller**. Delete before someone turns them into a global barrier. | `src/include/sirius_engine.hpp:102-108` |
+| **H3** | `task_completion_message_queue` — never instantiated. | `src/include/task_completion.hpp:108, 111` |
+| **H4** | `SiriusContext::mutable std::mutex mutex_` — **never locked anywhere**. | `src/include/sirius_context.hpp:560` |
+| **H5** | `exec::inspectable_mpsc` — orphaned; referenced only by its own test and a stale comment. | `src/include/exec/inspectable_mpsc.hpp` |
+| **H6** | `task_creator::schedule(node, query_id)` — zero callers. | `src/include/creator/task_creator.hpp:180` |
+| **H7** | `task_creation_request::device_id` — set only by `schedule_lookahead`; the queue is only ever `pop()`ed, never `try_pop_from(gpu_index{})`. | `src/include/creator/task_creator.hpp:72` |
+| **H8** | Query ids wrap at 2³² and the priority packing masks to **31 bits**. A wrapped id collides with a live query → `create_for_query` throws "already registered"; at 2³¹ the priority ordering silently inverts. | `src/include/sirius_context.hpp:579`; `src/include/query_id.hpp:66` |
+| **H9** | Doc drift: five files describe deleted APIs (`pipeline-execution.md:296`, `architecture-overview.md:130`, `task-creator.md:31,239`, `scan.md:16,158`, `optimizations.md:25`). No doc exists for the new per-query model. Dangling doxygen: `/// \brief Get the current query.` now sits above `get_config()` (`sirius_context.hpp:498`). Header comment claims `std::map` above an `unordered_map` (`task_scheduler.hpp:216-219`). |
+| **H10** | Misleading aliases: `using shared_data_repository = data_repository;` and `shared_data_repository_manager` imply shared ownership where there is none — in exactly the area under discussion. | `cucascade/.../data_repository.hpp:319`, `data_repository_manager.hpp:251` |
+| **H11** | Dead APIs in cucascade: `data_repository_manager::for_each_repository` (zero callers). Dead test accessor `testable_task_creator::query_id()`. Uninitialized members `sirius_physical_table_scan::physical_table_scan` / `column_size` / `mask_size`. | various |
+
+---
+
+## Dependency notes for planning
+
+A few hard ordering constraints that every option must respect:
+
+1. **C3 (scan pool sizing) gates every end-to-end concurrent test.** Nothing can be validated at
+   Q > 1 until the pool is sized for it.
+2. **A4 must be fixed before A7**, or fixing the downgrade drain just relocates the hang.
+3. **B5 (plan lifetime) is upstream of B1's second fault.** Gating the TIER-2 re-push stops the
+   resurrection, but any surviving task still dereferences a dead plan on its completion path.
+4. **C1 must be fixed before A5/A6 are exercised**, because both call `stop_thread_pool()` today.
+5. **A9 is a diagnosability multiplier** — until push failures are loud, every other bug in
+   Group A presents as an unexplained hang. Worth landing early even though it fixes nothing.
+6. **G1/G2 gate confidence in everything else.** Without a harness, no fix in this register can be
+   demonstrated to work; the four existing "query_state" tests would all still pass with every
+   Group A bug present.

--- a/docs/concurrency/99-execution-summary.md
+++ b/docs/concurrency/99-execution-summary.md
@@ -1,0 +1,218 @@
+# Concurrent Query Execution — Execution Summary
+
+What was built, what was not, and what to do next.
+
+**Branch:** `concurrency3` (base `a35be838`) · **10 commits** · 32 files, +3142 / −239
+**Validation:** full C++ suite (2255 cases, ~32.5M assertions) green, 3 consecutive runs per step
+**Not pushed.** Nothing here has been reviewed or merged.
+
+> **Branch note:** this work is on `concurrency3`, not `concurrency2`. The branch was switched
+> before the first commit. `concurrency2` still points at the base commit `a35be838`.
+
+---
+
+## 1. Where the project stands
+
+The [issue register](00-issue-register.md) listed 44 issues. **23 are closed.** The single-flight
+mutex is still in place, so Sirius still executes one query at a time — but the control plumbing
+behind it is now per-query rather than process-wide, which was the actual blocker.
+
+| Group | Closed | Remaining |
+|---|---|---|
+| A — cross-query blast radius | A1 A2 A3 A4 A5 A9 A10 | A6 (partial), A7, A8 |
+| B — lifetime / use-after-free | B6 B7 B8 B10 B11 | B1 B2 B3 B4 B5 B9 |
+| C — deadlock | C1 C2 C3 | C4 |
+| D — tracking gaps | D1 D2 D3 D4 | D5 D6 |
+| E — shared config | — | E1–E7 |
+| F — fairness / perf | F1 (policy), F4 (withdrawn) | F2 F3 F5 F6 F7 F8 F9 |
+| G — test infra | — | G1–G7 |
+| H — hygiene | H4 H8(partial) H10 | rest |
+
+### Commits
+
+| Commit | Step | Closes |
+|---|---|---|
+| `f966ae00` | 1 — stop per-query failures killing shared subsystems | A1, A3, A4, A10, A2(half) |
+| `c19f480e` | 2 — per-query lifecycle gate + the C1 deadlock it exposed | C1, C2 |
+| `7bdf050e` | 3 — per-query completion and error paths | A5, D4, A6(partial) |
+| `8a09bebc` | — crash handler bounded (unplanned, see §3) | — |
+| `5d93da7f` | 4 — in-flight coverage and lookahead | D1, D2, D3, A2(half) |
+| `6d22cb6b` | 5 — query-aware thread pool with per-query waits | A6 (success path) |
+| `48c114bc` | 8+11 — shutdown ordering, failed-cleanup leak, loud drops | A9, B6, B7, B8, B10 |
+| `a9a85ed4` | 9+12 (partial) — prefetch-cache UAF, real `max_concurrent_queries` | B11, C3 |
+| `ff33f389`, `e5078162` | plan-doc corrections | — |
+
+### The two mechanisms everything else hangs off
+
+**`exec::query_lifecycle_registry`** (`src/include/exec/query_lifecycle_registry.hpp`) — a per-query
+`open → quiescing → closed` gate consulted at six enqueue points, including
+`~convertible_gpu_pipeline_task`'s TIER-2 re-push. It replaces "interrupt the shared queue", which
+refused *every* query's pushes at once. An unknown query id **accepts** work on purpose: a missed
+`open_query()` would otherwise silently stop a query from scheduling, i.e. a hang — the exact
+failure class the gate exists to remove.
+
+**Query-aware `bounded_thread_pool`** — slots carry an optional `query_id` via `slot::attach()`,
+applied once the task's query is known rather than at `reserve()`. That distinction is load-bearing:
+every manager loop reserves a slot and *then* blocks in `pop()`, so an idle manager holds a slot
+forever and `wait_all()` can never return. Untagged slots are invisible to per-query waits, which is
+what makes `wait_for_query(q)` / `drain_and_wait(q)` usable at all.
+
+---
+
+## 2. What was attempted and backed out
+
+**Steps 6 + 7 — shared-ownership repositories and deleting the global downgrade drain.**
+
+Implemented in full, then reverted. The work is preserved in named stashes, not discarded:
+
+```
+cucascade/   stash@{0}  step6-cucascade-shared-ptr-repositories
+sirius/      stash@{0}  step6b-7-sirius-side
+```
+
+**Symptom:** deterministic `SIGSEGV` at the 6th test (`pin_table compression - result equality vs
+uncompressed pin`), 3/3 runs and in isolation, in
+`sirius_physical_ungrouped_aggregate_merge::get_next_task_input_data()` on a `task_creator` pool
+worker. Faulting instruction `mov 0x8(%rcx),%rdi`; the source line is
+`ports.begin()->second->repo->pop_next_data_batch()`.
+
+**Ruled out:** not pre-existing (verified by stashing both halves and rebuilding at step 5); not an
+unhooked virtual override (nothing derives from `data_repository`); not an out-of-range partition
+(`pop_next_data_batch` range-checks and throws).
+
+**Still open**, in suspicion order:
+1. `get_repository()` returning `shared_ptr` **by value** while `materialize_repository_wiring` takes
+   `.get()` on the temporary — the one lifetime change on the exact pointer that crashes.
+2. The manager's `add_data_batch` moving per-repository calls outside `_mutex`.
+3. `close()` leaving `_data_batches` size 0 rather than one empty partition, changing
+   `num_partitions()` for anything reading it after close.
+
+**Consequence:** the global `executor->drain()` is still in `run_mandatory_cleanup`. It remains the
+worst cross-query serialization point — every query end cancels every other query's pending spills
+and stops/joins/restarts each downgrade executor's processing thread.
+
+---
+
+## 3. Things found along the way that were not in the plan
+
+**The crash handler turned every crash into an unkillable spin** (`8a09bebc`).
+`segfault_handler` called `backtrace_symbols()`, which goes through `_dl_addr()` and takes the
+dynamic loader lock; `__cxa_demangle()` and the log flush allocate. If the crash happened while any
+thread held the loader, malloc-arena or logging lock, none of those *fail* — they spin forever. A
+dead process then looks alive: 100% CPU, no output, survives SIGTERM.
+
+This is worth calling out because it **cost roughly an hour of misdiagnosis**. It disguised an
+ordinary `task_creator` deadlock as a live spinning process, and every symptom (running thread,
+`wchan=0`, all other threads idle) pointed the wrong way. The handler is now bounded by a 10s
+`SIGALRM` covering the whole handler, and emits the async-signal-safe `backtrace_symbols_fd()` output
+*first* so a usable stack survives even if the pretty path blocks. It found the step-5 pool bug
+within minutes of landing.
+
+**The plan's own dependency note was violated, and it bit immediately.** The register said *"C1 must
+be fixed before A5/A6 are exercised, because both call `stop_thread_pool()` today"* — and C1 was
+scheduled for step 4 while step 1 made those paths live. Step 1 removed the `stop()` calls that used
+to pre-stop the creator, so `drain_after_error → stop_thread_pool()` began racing a live manager
+thread and deadlocked ~3 of 8 full-suite runs. C1/C2 were pulled forward into step 2.
+
+Generalizable lesson, now recorded in the plan: **any step that stops pre-stopping a subsystem makes
+that subsystem's lifecycle races live in the same commit.**
+
+**A 9.4 GB core dump was accidentally committed** by a `git add -A` during debugging, taking `.git`
+to 3.2 GB. Caught before pushing; the commit was rewritten, the blob garbage-collected, and
+`core`/`core.*` added to `.gitignore`.
+
+---
+
+## 4. Known gaps in what *was* delivered
+
+Stated explicitly so they are not mistaken for finished work.
+
+**A6 is only partly closed.** `wait_and_drain_query` (the error path) still brackets its work in
+`quiesce_manager()`/`resume_manager()`, which interrupts the shared queue and can drop a co-tenant's
+**in-transit** task. The success path no longer does. The bracket cannot simply be removed — a
+failing query can still have tasks the manager may pop at any moment, and between `pop()` and
+`slot::attach()` a task belongs to neither the queue nor the per-query count. Joining the manager is
+what closes that window, and the caller's next act is destroying the plan.
+
+**The concurrency test harness does not exist.** Every test added here is either single-threaded or
+exercises one subsystem with synthetic query ids. Nothing runs two *queries* end to end. The four
+pre-existing "query_state" tests would still pass with most of the original register bugs present.
+
+**One unexplained intermittent failure**: `query lifecycle slot is released for an unconsumed result`
+→ "watchdog child exited abnormally", seen once in ~16 runs and not reproduced in follow-ups. It is a
+forked-child test, and the `DISABLE_SIRIUS_SIGNAL_HANDLER=1` debugging harness changes how a crashing
+child dies, so it may be an artifact of that.
+
+**A separate pre-existing issue**: running only `[integration]` reproducibly fails
+`test_pin_table_mvcc_foundation.cpp:201` (`probe.counts.size() >= 2` yields 1), while the same test
+passes in full-suite runs. Order-dependent test isolation, unrelated to this work.
+
+---
+
+## 5. Recommended next steps, in order
+
+### 1. Land the concurrency harness before any more engine work (G1–G3)
+Everything above was validated at N=1. The per-query code has still **never run under real
+concurrency**, so the confidence from "2255 tests green" is narrower than it looks. Salvage the
+primitives trapped in `test_query_lifecycle_slot.cpp`'s anonymous namespace (start gate,
+`async_query_result`, `scoped_blocking_window_log_sink`) into `test/cpp/utils/`, and let a test opt
+out of `shared_env_listener`'s env-pausing.
+
+Cheap and high-value: `concurrentloop` already works in the vendored DuckDB, and
+`ParallelExecuteLoop` constructs a **new `Connection` per parallel iteration** on its own thread
+against the shared `DatabaseInstance` — exactly the shape needed.
+
+### 2. Finish steps 6+7 with one instrumentation point
+Do **not** resume by re-reading the diff. Add a temporary print of `ports.size()` and
+`repo == nullptr` immediately before the deref in `get_next_task_input_data`. That single data point
+separates all three hypotheses in §2; none of the black-box debugging did. Then unstash.
+
+This matters more than its position suggests: **FIFO fairness depends on spilling working**, because
+the livelock case is an older query blocked on memory only a newer query could release by finishing.
+Steps 6/7 are what make the downgrade path per-query.
+
+### 3. Close the error-path window (A6 remainder)
+Have the manager publish its in-hand task's query *before* the task leaves the queue's lock — e.g. a
+per-query "in-hand" counter incremented under the pop, so `pop()`-to-`attach()` is covered. Then
+`wait_and_drain_query` can drop its quiesce bracket like the success path did.
+
+### 4. Per-query batch telemetry (A8)
+`batch_telemetry_registry::on_query_end()` takes no query id: it consumes every live placement across
+all 16 shards and clears `impl_->ports`, so one query's end silently truncates every co-tenant's
+telemetry. Add `query_id` to placements and ports, re-key `ports` on the existing
+`port::source_port_uuid` instead of a raw `data_repository*` (a key is not an owner — address
+recycling silently matches stale entries), and add an `on_query_end(query_id)` overload.
+
+### 5. Head-of-line blocking (C4)
+One manager thread per GPU performs a blocking `make_reservation` *and* a blocking downgrade `.get()`
+while holding a reserved slot, so one query's memory-hungry task blocks every other query's dispatch
+to that GPU. At the 3–7 target this is the throughput ceiling. Move reservation acquisition into the
+dispatched job, or `make_reservation_or_null` + requeue-with-backoff.
+
+### 6. Shared mutable config (E1–E7) — required before removing the mutex
+`operator_params` is one non-atomic struct per `DatabaseInstance` written by ~20 `SET` callbacks and
+read mid-plan and mid-execution; **the slot is the only thing serializing those writes today**. The
+`Config::` static variables have no guard at all, and `EXPRESSION_EVALUATOR_STRATEGY` is read as a *default
+argument* on every `expression_evaluator` construction — so one connection's `SET` can change
+strategy between two operators of another connection's plan. Move both into per-`ClientContext`
+settings and snapshot into the plan at window begin.
+
+### 7. Only then: raise `max_concurrent_queries` and remove the single-flight mutex
+The knob and the pool sizing are in place. Raise it, run the harness from step 1 under ASan and TSan,
+and expect to find things — 23 issues closed is not 44.
+
+---
+
+## 6. Practical notes for whoever picks this up
+
+- **`DISABLE_SIRIUS_SIGNAL_HANDLER=1`** gives real core dumps fast. Documented in
+  `docs/super-sirius/debugging.md`. Invaluable for this work.
+- **Put `timeout` *inside* `pixi run`**, not outside — `timeout -s ABRT 600 pixi run ...` signals
+  pixi's wrapper and you get a useless Rust backtrace. `pixi run bash -c 'exec timeout -s ABRT ...'`
+  signals the test binary.
+- **A full suite run is ~345s.** Anything much longer is a hang, not slowness. Watch the
+  `[N/2255]` progress counter, and never pipe it to `tail` while diagnosing — `tail` emits nothing
+  until its input closes, which makes a live run look identical to a dead one. That mistake cost
+  real time here.
+- **Validate every step with ≥3 consecutive full-suite runs.** Two of the bugs in this work appeared
+  in roughly 1 run in 3.

--- a/docs/concurrency/README.md
+++ b/docs/concurrency/README.md
@@ -1,0 +1,192 @@
+# Concurrent Query Execution — Plan
+
+Getting Sirius from "per-query data structures exist" to "N queries actually run together".
+
+| Document | Purpose |
+|---|---|
+| [00-issue-register.md](00-issue-register.md) | **Read first.** Every remaining issue, with severity, file:line, and failure scenario. All options close all of it. |
+| [**option-d-recommended.md**](option-d-recommended.md) | **The plan to execute.** B's step ordering with C's two structural changes folded in, after the scoping answers. |
+| [option-a-surgical.md](option-a-surgical.md) | Fix each site in place with the narrowest change. No new abstractions. |
+| [option-b-unified-gate.md](option-b-unified-gate.md) | One lifecycle gate + query-aware thread pool. Implements the `drain_and_wait(query_id)` idea. |
+| [option-c-structural.md](option-c-structural.md) | Option B plus shared-ownership repositories, plan lifetime inversion, and fairness. |
+
+A, B and C are kept as the reasoning trail — the trade-offs behind each decision in D are argued
+there, and A or B remain the fallbacks if the `cucascade` change or the appetite for step 6 changes.
+
+---
+
+## Where the branch stands
+
+The last six commits converted the per-query **data** plumbing — repository registry, task-creator
+state, scan-manager state, completion handlers, query-indexed queues. That work is sound and none
+of the options redo it.
+
+What was not converted is the per-query **control** plumbing. Every teardown, drain, wait, validate
+and error path is still a process-wide stop-the-world, invoked once per query.
+`SiriusContext::query_lifecycle_mutex_` is the only thing keeping them from firing.
+
+Two facts that shape all three plans:
+
+- **The new per-query code has never run under concurrency.** All four new tests are
+  single-threaded — `test_scan_manager_query_state.cpp:181` is titled *"concurrent queries do not
+  collide on operator id"* and spawns zero threads. They prove state *partitioning*, not
+  race-freedom.
+- **Not everything is latent.** The downgrade monitor thread and the GPU manager loops are not
+  slot-gated, so a handful of issues (B1, B2, B3, A7) are live on `dev` today.
+
+## The 44 issues at a glance
+
+| Group | Count | Theme |
+|---|---|---|
+| A — Cross-query blast radius | 10 | A per-query event stops a shared subsystem. 6 Critical. |
+| B — Lifetime / use-after-free | 11 | Raw borrows outliving their owners; teardown ordering. |
+| C — Deadlock | 4 | Lock-order inversion in `task_creator`; scan pool sized for one query. |
+| D — Gaps in existing per-query tracking | 6 | The in-flight counter has a hole; lookahead serves only the oldest query. |
+| E — Shared mutable config | 7 | `operator_params` and `Config::` static variables raced by `SET`. |
+| F — Fairness / performance | 9 | Strict head-of-line blocking; global downgrade drain; shared prefetch pipeline. |
+| G — Test infrastructure | 7 | No concurrency harness exists. |
+| H — Dead code / drift | 11 | Uninitialized dead pointers, orphaned APIs, five drifted docs. |
+
+Four issues are worth naming because they drive the choice between options:
+
+- **A7 + B2 (live).** `run_mandatory_cleanup` drains *every* downgrade executor on *every* query
+  end, cancelling other queries' pending spills — and `drain()` **restarts the processing thread as
+  its last act**, so quiescence expires before `erase(query_id)` runs 20 lines later.
+- **B1 (live).** TIER-2 downgrade pops a task off the shared queue into a processing-thread local,
+  carries it across a *blocking* `reserve()` and a full conversion, then `~convertible_gpu_pipeline_task`
+  pushes it **back** — potentially after that query's drain already ran.
+- **B5.** The plan is destroyed *before* the drains. Pipelines hold non-owning references into it
+  and outlive it. The code acknowledges this in a comment.
+- **C1.** `stop_thread_pool()` holds `_global_state_mutex` across `_manager_thread.join()` while the
+  manager thread needs that same mutex. Reachable on **every query completion**.
+
+## Comparing the options
+
+|  | A — Surgical | B — Unified gate | C — Structural |
+|---|---|---|---|
+| Steps | 12 (A12 splits → ~17) | 12 (B12 splits → ~17) | 15 (C15 splits → ~20) |
+| Net LOC | ~1,400 | ~1,700 | ~2,600 |
+| New files in `src/` | 0 | 2 | 3 |
+| Touches `cucascade` | no | no | **yes** |
+| Touches `bounded_thread_pool` | no | **yes** | **yes** |
+| `data_repository` ownership | `unique_ptr` + raw borrows | `unique_ptr` + raw borrows | `shared_ptr` + eager `close()` |
+| Teardown correctness rests on | a specific 6-step order | a gate (order-insensitive) | types (hazard unrepresentable) |
+| Global downgrade drain | made per-query | made per-query | **deleted** |
+| Plan vs cleanup order | fixed | fixed | **inverted** |
+| Fairness (F1) | last step | last step | **before enablement** |
+| First step that closes a Critical | 3 | 3 | 3 |
+| Steps before 2 queries run together | 11 | 11 | 14 |
+| Revertibility | high — every step independent | medium — B5→B6 is a fixed chain | low — C8/C9/C10 interlock |
+
+All three share the same first three steps: harness + admission knob + scan pool sizing → make
+dropped work loud → delete the three rogue `stop()` calls and convert the four `break`s. That is
+where the highest-severity items are, and none of it is architecture-dependent — so it can start
+immediately regardless of which option is chosen.
+
+## Recommendation
+
+**Option B**, with two amendments borrowed from C.
+
+The reasoning:
+
+- **A's cost is not its size, it's the twelve independent mechanisms.** Correctness of teardown
+  would rest on an implicit six-step ordering in `run_mandatory_cleanup` plus a `closing` flag plus
+  an in-flight counter plus a post-`reserve()` re-check. Nothing enforces any of it, and at N=1
+  every test still passes if someone reorders it. For a system that already has *four* thread pools
+  and *seven* enqueue points, one gate that every enqueue consults is worth its foundation cost.
+- **B's `drain_and_wait(query_id)` is your idea, and the survey says it works** — 4 production
+  `dispatch` sites, 4 `reserve` sites — **but only paired with the gate.** On its own it cannot see
+  the TIER-2 window, because during it no job exists yet: the task is owned by a processing-thread
+  local across a blocking `reserve()`. The gate covers that window; the pool covers everything
+  already dispatched. Neither alone is sufficient, which is why they are one option and not two.
+- **C's C8+C9 are genuinely valuable** — deleting the global downgrade drain rather than narrowing
+  it is the difference between "concurrency works" and "concurrency works under memory pressure",
+  which is the workload that matters. But C8 modifies the ownership model of the object every
+  operator reads and writes through, **in a submodule**, and its bad failure mode is silently
+  incomplete results rather than a crash. That is a lot to take on in the same project that is also
+  removing the single-flight gate.
+
+**Amendment to B:** fold in C8+C9 (shared-ownership repositories with `close()`, and deleting the
+global downgrade drain). C13's fairness work is **not** needed — see the FIFO decision above.
+
+### Revised after the scoping answers
+
+The original write-up put C8+C9 as a follow-on rather than folding them in, on the grounds that
+modifying the ownership model of the object every operator reads and writes through — in a
+submodule — was too much to take on alongside removing the single-flight gate. Three of those
+concerns turned out to be smaller than assumed:
+
+- The cucascade surface is **two Sirius call sites, zero internal cucascade callers, and no
+  subclasses** — not a sprawling refactor.
+- The "silently incomplete results" failure mode is closed by change #3 in
+  [the scope table](option-c-structural.md#cucascade-change-scope) — `add_data_batch` returns a
+  status rather than silently accepting on a closed repository.
+- At 3–7 concurrent queries, the global downgrade drain is no longer a tolerable tax. Every query
+  end currently quiesces *every* downgrade executor on *every* memory space, and query ends become
+  ~7× more frequent. C9 deletes it outright; B only narrows it to per-query.
+
+So the recommendation is **Option B's step order, with C8/C9 inserted after B7 and C13 before
+enablement** — which is, in practice, Option C. Take the sequencing discipline from B (harness and
+the three rogue `stop()` deletions ship in the first three steps, before any foundation work) and
+the structural changes from C.
+
+The one part of C to still treat as optional is **C10's engine-ownership move**. Option B's step B9
+already fixes the same bug (B5) by reordering destruction; C10 additionally makes
+`StandaloneQueryScope` own the engine, which touches all five entry points and DuckDB's
+`GlobalSourceState` interaction. Take the reorder; defer the ownership move unless the reorder
+proves fragile.
+
+If appetite for the submodule change disappears, **Option B unmodified** remains correct — you
+keep the downgrade tax and per-query drain instead of deletion. **Option A** is still defensible
+if the priority is landing something quickly with maximum per-step revertibility, but at 3–7
+queries its twelve independent teardown mechanisms are the wrong trade.
+
+## Answered scoping questions
+
+### 1. Target concurrency: **3–7**, with **FIFO query order** as the fairness policy
+
+The FIFO decision does most of the work here. `query_id` is already packed into the high bits of
+the priority and the queue pops lowest-first — that *is* FIFO, so:
+
+- **F1 is reclassified from defect to policy.** Oldest-first is defensible for a memory-constrained
+  GPU engine: it drains queries rather than making partial progress on all of them, which bounds
+  peak memory. No round-robin dispatch, no separate fairness index, **no fairness step**.
+- **F4 is withdrawn.** A single FIFO prefetch pipeline is *consistent* with FIFO query order —
+  query 7's prefetch queueing behind queries 1–6 is the chosen policy, not a bug.
+- **What survives is small**: `schedule_lookahead` unconditionally serving
+  `_query_task_global_states.begin()` is still wrong, not because oldest-first is wrong but because
+  it will serve a finished-but-not-yet-reset query and touch a dead plan. Two-line fix, folded into
+  step 4.
+- **C4 stays** — the single per-GPU manager thread blocking on `make_reservation` and on the
+  downgrade `.get()` stops *dispatch* entirely, so a newer query can't run even a task needing no
+  new memory. Gets its own step.
+
+One dependency worth stating: **FIFO is safe provided spilling works.** The livelock case is an
+older query blocked on memory only a newer query would release by finishing. Steps 6–7 (shared
+ownership + per-query downgrade) are therefore load-bearing for the fairness policy, not just for
+teardown.
+
+Scan pool sizing is comfortable: `num_threads` defaults to 8, so `num_threads + 7` takes the pool
+from 9 to 15 threads. H8 (32-bit id wrap) stays low priority at this concurrency.
+
+### 2. `cucascade` scope — **more than the pointer swap**
+
+See [the cucascade scope section in Option C](option-c-structural.md#cucascade-change-scope). Short
+version: the pointer swap is the easy half and it is the half that does not work on its own.
+`close()` is the essential addition. Total surface is small — **zero** internal cucascade callers,
+**two** Sirius production call sites, and `data_repository` has **no subclasses**.
+
+### 3. Concurrent SQLLogic: **in scope, and the runner already exists**
+
+The vendored DuckDB fully supports `concurrentloop` / `concurrentforeach`
+(`duckdb/test/sqlite/sqllogic_parser.cpp:250`, `sqllogic_test_runner.cpp:1059`). Critically,
+`ParallelExecuteLoop` constructs **a new `Connection` per parallel iteration** on its own
+`std::thread` against the shared `DatabaseInstance` — i.e. exactly the shape needed: separate
+connections, real threads, one shared `SiriusContext`.
+
+Constraints to design around: nested parallel loops are rejected, and every command in the body
+must return true from `SupportsConcurrent()`. So the runner is free; the work is authoring the
+`.test` files and confirming Sirius's `ClientContext`-registered state behaves under the
+per-iteration connections. This lands in step 11/14 (enablement) of whichever option is chosen and
+replaces part of the bespoke C++ harness work — the C++ harness is still needed for the
+subsystem-level tests in earlier steps, which have no SQL surface.

--- a/docs/concurrency/README.md
+++ b/docs/concurrency/README.md
@@ -5,7 +5,8 @@ Getting Sirius from "per-query data structures exist" to "N queries actually run
 | Document | Purpose |
 |---|---|
 | [00-issue-register.md](00-issue-register.md) | **Read first.** Every remaining issue, with severity, file:line, and failure scenario. All options close all of it. |
-| [**option-d-recommended.md**](option-d-recommended.md) | **The plan to execute.** B's step ordering with C's two structural changes folded in, after the scoping answers. |
+| [**99-execution-summary.md**](99-execution-summary.md) | **Start here for current state.** What was built, what was backed out, and the recommended next steps. |
+| [option-d-recommended.md](option-d-recommended.md) | The plan that was executed. Annotated in place where reality diverged from it. |
 | [option-a-surgical.md](option-a-surgical.md) | Fix each site in place with the narrowest change. No new abstractions. |
 | [option-b-unified-gate.md](option-b-unified-gate.md) | One lifecycle gate + query-aware thread pool. Implements the `drain_and_wait(query_id)` idea. |
 | [option-c-structural.md](option-c-structural.md) | Option B plus shared-ownership repositories, plan lifetime inversion, and fairness. |

--- a/docs/concurrency/option-a-surgical.md
+++ b/docs/concurrency/option-a-surgical.md
@@ -1,0 +1,271 @@
+# Option A — Surgical
+
+> **Philosophy:** no new abstractions. Every issue in [the register](00-issue-register.md) is fixed
+> at its own call site with the narrowest possible change, using the per-query APIs that **already
+> exist** (`drain_query_tasks(query_id)`, `drain(query_index{})`, `size(query_index{})`,
+> `drain_pending_tasks(query_id)`, `reset(query_id)`). Correctness of teardown rests on a
+> **quiescence proof**: at the moment a query's repositories are erased, no thread holds a borrowed
+> pointer into them, because every producer was stopped first and stays stopped.
+
+**Shape:** 12 steps · ~1,400 LOC net · 0 new files in `src/` (2 in `test/`)
+**Keeps:** `unique_ptr<data_repository>`, raw `data_repository*`, `enter/leave/wait_for_in_flight`,
+`bounded_thread_pool` unchanged.
+
+---
+
+## Step-by-step
+
+### A1 — Concurrency harness + admission knob + scan pool sizing
+**Closes:** G1, G2, G3, C3, H4 · **Enables:** everything downstream
+
+- New `test/cpp/utils/concurrent_query_harness.hpp`: N connections from `shared_test_env`, a
+  release-gate start barrier, per-thread result/exception capture, deadline watchdog. Salvage the
+  primitives currently trapped in `test_query_lifecycle_slot.cpp`'s anonymous namespace
+  (`wait_for_workers`, `async_query_result`, `scoped_blocking_window_log_sink`) — move them here
+  and have that file include it, so there is one implementation.
+- Relax `shared_env_listener` / `scoped_mgpu_env` so a test can opt out of env-pausing (G3).
+- Promote `k_max_concurrent_queries` to a real `scan_manager_config::max_concurrent_queries`,
+  parsed in `sirius_config.cpp::from_yaml`, **default 1**. Pool stays `num_threads + N`.
+  Make `sirius_scan_manager.cpp:597` reject rather than warn.
+- Add `sirius_config::max_concurrent_queries` (**default 1**) and turn
+  `acquire_query_lifecycle_slot` from a `std::mutex` into a counting semaphore of that size.
+  At 1 the behaviour is bit-identical to today, including the same-thread-reacquire error.
+- Delete the never-locked `SiriusContext::mutex_`.
+
+**Tests:** harness self-test; existing `test_query_lifecycle_slot.cpp` suite unchanged and green at
+N=1. One `[.]`-hidden `[concurrency]` test at N=2 that will be un-hidden by step A11.
+
+---
+
+### A2 — Make dropped work loud
+**Closes:** A9
+
+Check the `bool` from every `push()`; on a drop for a still-live query, `report_error` on that
+query's completion handler instead of silently destroying the task. Add a `SIRIUS_LOG_ERROR` with
+the query id at each site.
+
+> Fixes nothing on its own. Landed second because until it exists, **every** bug in Group A
+> presents as an unexplained hang and the remaining steps are much harder to debug.
+
+**Tests:** unit test that an interrupted queue's dropped task surfaces as a query error.
+
+---
+
+### A3 — Stop per-query failures from killing shared subsystems
+**Closes:** A1, A3, A4, A10, and the global-halt half of A2
+
+- `terminate_query`: delete the `stop()`. Report to the handler, then `drain_query_tasks(query_id)`.
+- Creation-worker catch (`task_creator.cpp:692`): delete the `stop()`.
+- GPU executor catch (`:427`, `:432`): delete `_task_creator->stop()`. `completion->report_error`
+  on the next line already fails the correct query.
+- All four `break`s in `manager_loop` → report to *that task's* handler, then `continue`.
+  Only channel/queue closure may break the loop.
+- Wrap the `manager_loop` body in try/catch so a throw cannot abort the process.
+
+**Tests:** inject a creation exception and a task exception; assert the scheduler and creator are
+still running and a second query completes normally.
+
+---
+
+### A4 — Fix the creator's lock ordering and in-flight coverage
+**Closes:** C1, C2, D1, D2, and the self-deadlock half of A2
+
+- Split `_global_state_mutex` from a new `_lifecycle_mutex`; never hold either across
+  `_manager_thread.join()`.
+- `stop()` takes the same lifecycle mutex as `stop_thread_pool()`/`start_thread_pool()`.
+- Forbid `stop()` from a pool worker (assert + post a stop request instead).
+- Move `enter_in_flight()` to immediately after the successful `get_query_task_global_state`
+  lookup, so the manager thread's own `get_operator_for_next_task(node)` dereference is inside
+  the counted region. Release on every early-`continue`.
+- Cover the key extractor's `request.node->type` dereference the same way.
+
+**Tests:** a targeted test that `drain_pending_tasks(Q)` returning implies no thread is
+dereferencing Q's operators; a stop/start hammer test.
+
+---
+
+### A5 — Per-query completion and error paths
+**Closes:** A5, A6, D4
+
+- `wait_for_completion(query_id)`: `_task_queue.size(query_index{q})`,
+  `gpu_exec->wait_and_validate_empty(query_id)`, and **delete** the
+  `stop_thread_pool()`/`start_thread_pool()` pair — per-query in-flight accounting replaces it.
+- `drain_after_error(query_id)`: `_task_queue.drain(query_index{q})` in both places,
+  `gpu_exec->drain_query_tasks(query_id)` instead of `drain_and_wait()`, same pool-cycle deletion.
+- New `itask_executor::wait_and_validate_empty(query_id)`; reserve the global `drain_and_wait()`
+  for `stop()`/teardown only. Add the missing null-pool guard.
+- Guard `*_ready_devices.begin()`.
+
+**Tests:** query A completes while query B has queued tasks — A must not throw and B must not lose
+work. Same for A erroring.
+
+---
+
+### A6 — Per-query downgrade
+**Closes:** A7, B2, D6
+
+- `downgrade_request` gains a `query_id`. `drain(query_id)` cancels only that query's requests.
+- Split `drain()` into `quiesce()` / `resume()` so the caller controls when the executor re-arms —
+  the current unconditional restart is what makes quiescence expire before `erase()`.
+- Add the `_running` guard (`drain()` after `stop()` currently null-derefs and leaks a joinable
+  thread).
+- Reset `_monitor_request_enqueued` via RAII on the request and on a failed push.
+- `data_repository_manager_registry::get_all()` returns `{query_id, manager}` pairs so the sweep
+  can attribute candidates.
+
+**Tests:** query A's cleanup must not cancel query B's pending downgrade; monitor latch survives a
+drain.
+
+---
+
+### A7 — Close the repository lifetime hole by quiescence
+**Closes:** B1, B3, B4, B9
+
+The heart of Option A. No shared ownership — instead, make the "nobody holds a borrowed pointer"
+precondition **enforced** rather than documented:
+
+- Add a per-query `closing` flag to `data_repository_manager_registry`. `get_all()` skips closing
+  queries, so the sweep can never *start* on a dying query.
+- The TIER-1 and TIER-2 candidate paths re-check `closing` **after** the blocking
+  `_pool->reserve()` returns, beside the existing `req->satisfied` re-check. This is what closes
+  B1's extraction window, which pool-level accounting cannot see (no job exists yet).
+- Gate `~convertible_gpu_pipeline_task`'s re-push on `closing`: drop the task instead of
+  resurrecting it.
+- Reorder `run_mandatory_cleanup` to: **mark closing → downgrade `quiesce(q)` → creator `reset(q)`
+  → scheduler/executor drains(q) → repo erase → scan reset → downgrade `resume()`**.
+  The current order (queue drain *before* downgrade drain) is precisely what makes B1 fire.
+- Take `_mutex` in `cucascade::data_repository_manager::get_repository`.
+
+**Tests:** a stress test that hammers TIER-2 downgrade against a query ending — under ASan and TSan.
+
+---
+
+### A8 — Plan lifetime
+**Closes:** B5, B8
+
+- Move the drains so the plan outlives them. Preferred: `StandaloneQueryScope` takes ownership of
+  the engine, and `finish()` orders drain → repo erase → **then** engine destruction. Fallback:
+  move the drain into `cleanup_internal` before `sirius_active_query.reset()`.
+- Add the guarded `data_repository_registry_.erase(query_id)` that
+  `drop_query_runtime_state_best_effort` is missing.
+
+**Tests:** force `get_result()` to throw (the path that currently destroys the plan with no drain
+having run) and assert clean teardown under ASan.
+
+---
+
+### A9 — Shutdown ordering
+**Closes:** B6, B7, B10
+
+- `terminate()`: stop the creator, scan manager and downgrade executors (or null their
+  `_pipeline_task_queue`) **before** `task_scheduler_.reset()`. Null `task_scheduler::_task_creator`
+  and `gpu_pipeline_executor::_downgrade_executor` in the respective `stop()`s.
+- Declare `task_scheduler_` **last** in `SiriusContext` so it is destroyed first, or add a
+  last-declared RAII shutdown sentinel running an idempotent `terminate()`.
+- Wrap the `terminate()` call in `~SiriusContext` in try/catch + log.
+
+**Tests:** a test that `initialize()` throwing after `task_scheduler_` is constructed tears down
+cleanly under ASan.
+
+---
+
+### A10 — Per-query telemetry and prefetch-cache safety
+**Closes:** A8, B11
+
+- Add `query_id` to `batch_telemetry_registry`'s placements and ports; `on_query_end(query_id)`
+  filters both loops. Re-key `ports` on the existing `port::source_port_uuid` instead of a raw
+  `data_repository*` (address recycling silently matches a stale entry).
+- `prefetching_cache`: copy `file_entry*` out under the lock and drop the iterator before
+  unlocking. Element pointers are stable; iterators are not.
+
+---
+
+### A11 — Turn concurrency on and prove it
+**Closes:** the validation half of G1, plus G4, G5, G7
+
+- Raise the default `max_concurrent_queries` above 1.
+- Un-hide the `[concurrency]` suite; re-express `test_query_lifecycle_slot.cpp`'s
+  serialization assertions against the new semantics (G4); wire up `run_ac13_concurrent_logging`.
+- Add a concurrent TPC-H test (two different queries, and the same query twice) and a
+  `concurrentloop` SQLLogic file.
+- Run the whole suite under ASan and TSan.
+
+> **This is the step where unknown-unknowns surface.** Budget for it accordingly; it is the one
+> step in this plan whose size cannot be estimated from the register.
+
+---
+
+### A12 — Fairness, config safety, and hygiene
+**Closes:** D3, D5, E1–E7, F1–F9, H1–H3, H5–H11
+
+Largely independent of each other; can be split into several commits or parallelised.
+
+- **Fairness (F1):** make the query bits a fairness index — round-robin across live queries at
+  dispatch — instead of a strict priority prefix. Rotate `schedule_lookahead` across live queries
+  (D3).
+- **Config (E1–E3, E7):** move `operator_params` and the `Config::` static variables into per-`ClientContext`
+  settings (the pattern already used for `enable_duckdb_fallback`), snapshotting by value into the
+  plan at window begin. Guard the `LOG_*` trio, which is genuinely process-wide. Make
+  `original_config` a stack-local RAII.
+- **E4:** `logical_plan_` → `shared_ptr<const LogicalOperator>` + an atomic
+  `copy_unsupported_` latch.
+- **E5, E6:** resolve-or-insert under one `unique_lock`, keyed on `(catalog, schema, table)`;
+  atomic packed pair or per-device `call_once`.
+- **D5:** split `runtime_unavailable_` into "this query is corrupt" (fail that query) vs "the
+  shared runtime is corrupt" (latch).
+- **F2:** narrow the plan-time `SlotGuard` to a shared read of the pin registry.
+- **F3–F9:** live prefetch-epoch set; fair-share credit on `admission_control`; per-entry reader
+  count replacing the `use_count() > 1` heuristic; reservation-driven sizing; remove
+  `cudaDeviceSynchronize` and default-stream work.
+- **H:** delete H1–H7 and H11; widen `query_id_t` to 64-bit and stop packing it into the signed
+  priority (H8); rewrite the five drifted docs and add a per-query-model doc (H9); rename the
+  lying `shared_data_repository` aliases (H10).
+
+---
+
+## Pros
+
+- **Smallest total diff and the smallest diff per step.** Every commit is reviewable in isolation
+  by someone who knows only the file it touches.
+- **No shared primitive is destabilised.** `bounded_thread_pool` is used by four subsystems; not
+  touching it means a mistake there cannot take out task creation, GPU dispatch and downgrade at
+  once.
+- **Uses machinery that already exists and is already tested.** `drain(query_index{})`,
+  `size(query_index{})` and `drain_query_tasks(query_id)` all landed in the last six commits.
+  Steps A5 and A6 are largely "call the overload that is already there".
+- **Lowest risk of a bad revert.** Any single step can be reverted without stranding the others.
+- **Memory release stays deterministic.** `erase(query_id)` remains the exact point where a
+  query's GPU memory returns, so the `log_pool_stats` leak signature
+  (`QueryEnd allocated != QueryBegin allocated`) keeps working — that check is how leaks are
+  currently caught.
+- **Preserves the leaked-batch diagnostic.** `clear_all_repositories()`'s un-consumed batch report
+  is how you learn "operator X didn't drain port Y"; nothing here makes a crash into a silent leak.
+
+## Cons
+
+- **Twelve mechanisms instead of one invariant.** The `closing` flag (A7), the in-flight counter
+  (A4), the per-query queue index (A5), the per-query downgrade drain (A6) and the cleanup ordering
+  (A7) each independently guarantee a piece of teardown. There is no single place to look to
+  answer "is it safe to erase this query's repositories?", and no compiler help — the argument has
+  to be re-made by hand at every new call site.
+- **Quiescence is order-sensitive, and the order is load-bearing but implicit.** A7 pins a specific
+  six-step sequence in `run_mandatory_cleanup`. A future contributor reordering it reintroduces B1
+  with no test failure at N=1.
+- **A7's re-check-after-reserve is subtle** and easy to regress. It exists because the candidate is
+  owned by a processing-thread *local* across a blocking call — a window no pool-level or
+  counter-level accounting can observe.
+- **`enter_in_flight`/`leave_in_flight`/`wait_for_in_flight` survives** as a one-off in
+  `task_creator`, with no equivalent for the GPU executor or downgrade pools. Those two get
+  correctness from ordering alone.
+- **Step A11 is a cliff.** Eleven steps of unvalidated refactoring land before two queries actually
+  run together. The harness exists from step A1, but only at N=1 until A11.
+- **Step A12 is enormous** and will want splitting into 4–6 commits, which makes the real step
+  count closer to 17.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| A7's ordering silently regresses | Add a debug assertion in `erase(query_id)` that the query is `closing` and all producers are quiesced |
+| A11 surfaces issues not in the register | Land A2 (loud drops) first; run TSan from A5 onward, not only at A11 |
+| A12 sprawls | Split it up front; F-group items are independently shippable and can land in parallel |

--- a/docs/concurrency/option-b-unified-gate.md
+++ b/docs/concurrency/option-b-unified-gate.md
@@ -1,0 +1,254 @@
+# Option B — Unified Lifecycle Gate + Query-Aware Thread Pool
+
+> **Philosophy:** one invariant instead of twelve. Introduce a single per-query lifecycle authority
+> (`open → quiescing → closed`) that **every** enqueue point consults, and teach
+> `exec::bounded_thread_pool` to tag jobs with a `query_id` so it can offer
+> `drain_and_wait(query_id)`. Once both exist, teardown becomes *idempotent and order-insensitive*:
+> work cannot walk back across a drain, so the remaining per-query conversions are mechanical.
+
+This is the option that implements your `drain_and_wait(query_id)` idea — **paired with the gate
+that makes it correct**. On its own, `drain_and_wait` is a barrier that work walks straight back
+across (see [B1 in the register](00-issue-register.md#group-b--lifetime-ownership-use-after-free)).
+
+**Shape:** 12 steps · ~1,700 LOC net · 2 new files in `src/`
+**Keeps:** `unique_ptr<data_repository>` (adds `close()` semantics), plan-before-cleanup ordering
+fixed but not inverted.
+
+---
+
+## The two new mechanisms
+
+### 1. `query_lifecycle_registry` — the gate
+
+```
+open  ──► quiescing ──► closed
+        (drains run)   (erase safe)
+```
+
+Owned by `SiriusContext`, keyed by `query_id_t`. Every enqueue point checks it and no-ops when the
+query is not `open`:
+
+| Enqueue point | File |
+|---|---|
+| `task_creator::schedule` / `schedule_lookahead` | `src/creator/task_creator.cpp:397, 407, 456` |
+| `task_scheduler::schedule` | `src/pipeline/task_scheduler.cpp:112` |
+| `itask_executor::schedule` | `src/parallel/task_executor.cpp:61` |
+| **`~convertible_gpu_pipeline_task`** (the TIER-2 re-push) | `src/include/data/convertible_gpu_pipeline_task.hpp:88` |
+| `gpu_pipeline_executor`'s OOM reschedule | `src/pipeline/gpu_pipeline_executor.cpp:423` |
+| `bounded_thread_pool::dispatch(query_id, ...)` | new |
+| downgrade candidate acquisition (post-`reserve()` re-check) | `src/downgrade/downgrade_executor.cpp:306` |
+
+**There is already a working precedent in the tree**: `exec::scoped_dispatcher` layered over a
+shared `static_thread_pool`, one per query, where `request_stop()` clears pending work and makes
+subsequent `enqueue()` a **silent no-op**, plus `wait_for_all()`. That is exactly "drain + gate",
+and it is the design to copy.
+
+### 2. Query-aware `bounded_thread_pool`
+
+- Tag at `reserve(query_id)` — **not** at `dispatch` — so the manager thread's pre-dispatch
+  dereference (register D1) falls inside the counted region. Where the query is unknown until
+  after `pop()`, use `slot::attach(query_id)`.
+- `work_queue_` becomes a `std::list` plus a `query_id → iterator` index so queued work is
+  removable by key; erasing a queued item must release its slot.
+- Per-query active counter + CV → `drain_and_wait(query_id)`.
+- **Replaces** `enter_in_flight` / `leave_in_flight` / `wait_for_in_flight` entirely, and gives the
+  GPU executor and downgrade pools the same guarantee `task_creator` has today.
+
+**Feasibility notes from the call-site survey** — 4 `dispatch` sites, 4 `reserve` sites in
+production, ~12 in tests:
+
+| Site | `reserve` | `dispatch` | Query id available? |
+|---|---|---|---|
+| `task_creator::manager_loop` | `task_creator.cpp:466` | `:501` | yes (`request->query_id`) |
+| `gpu_pipeline_executor::manager_loop` | `gpu_pipeline_executor.cpp:105` | `:306` | yes (`pipeline->get_query_id()`) |
+| downgrade TIER 1 | `downgrade_executor.cpp:238` | `:251` | **no** — needs `get_all()` to return `{query_id, manager}` |
+| downgrade TIER 2 | `:306` | `:314` | derivable, but type-erased — needs `query_id()` on `convertible_data` |
+
+One prerequisite: **`task_creator` currently destroys and recreates its pool on every query
+completion** (`stop_thread_pool`/`start_thread_pool` from `wait_for_completion` and
+`drain_after_error`). Any per-query state stored in the pool evaporates there, so that cycle must
+go first — which is also the fix for register C1.
+
+---
+
+## Step-by-step
+
+### B1 — Concurrency harness + admission knob + scan pool sizing
+**Closes:** G1, G2, G3, C3, H4
+
+Identical to [Option A step A1](option-a-surgical.md#a1--concurrency-harness--admission-knob--scan-pool-sizing).
+Harness, `max_concurrent_queries` config (default 1), semaphore slot, `mutex_` deleted.
+
+---
+
+### B2 — Make dropped work loud
+**Closes:** A9
+
+Identical to Option A step A2. Lands early for the same reason: until push failures are loud, every
+Group A bug is an unexplained hang.
+
+---
+
+### B3 — Stop per-query failures from killing shared subsystems
+**Closes:** A1, A3, A4, A10, global-halt half of A2
+
+Identical to Option A step A3. Delete the three rogue `stop()` calls, convert the four `break`s to
+report-and-`continue`, wrap `manager_loop` in try/catch.
+
+> Deliberately kept ahead of the new mechanisms: these are pure deletions, they are the highest
+> severity items in the register, and they make the gate's job smaller.
+
+---
+
+### B4 — Introduce `query_lifecycle_registry` (gate only, no behaviour change)
+**Closes:** nothing yet — foundation
+
+- New `src/include/exec/query_lifecycle_registry.hpp` + `.cpp`.
+- `SiriusContext` owns it; `begin_execution_window` opens a query,
+  `run_mandatory_cleanup` moves it `open → quiescing → closed`.
+- Wire the **check** into all seven enqueue points listed above, but with the registry always
+  reporting `open` for live queries — so this step is a no-op at runtime and provably safe.
+
+**Tests:** unit tests for the state machine; a test that enqueue after `quiescing` is a no-op.
+
+---
+
+### B5 — Remove the creator's stop/start-per-query cycle; fix its lock ordering
+**Closes:** C1, C2, D1, D2, self-deadlock half of A2 · **Prerequisite for B6**
+
+- Delete `stop_thread_pool()`/`start_thread_pool()` from `wait_for_completion` and
+  `drain_after_error` — the gate (B4) now does what the interrupt was doing, without touching a
+  shared pool.
+- Split the lifecycle mutex from `_global_state_mutex`; never hold either across `join()`.
+- Forbid `stop()` from a pool worker.
+- Move `enter_in_flight()` before `get_operator_for_next_task(node)`; cover the key extractor.
+
+---
+
+### B6 — Query-aware `bounded_thread_pool` + `drain_and_wait(query_id)`
+**Closes:** replaces `enter/leave/wait_for_in_flight`; foundation for B7/B8
+
+- `reserve(query_id)` / `slot::attach(query_id)`; `std::list`-backed work queue with a per-query
+  index; per-query active counter + CV; `drain_and_wait(query_id)`; `close(q)`/`reopen(q)`.
+- Convert all four production call sites; delete `task_creator`'s bespoke in-flight members and
+  route `drain_pending_tasks(query_id)` through the pool.
+- `data_repository_manager_registry::get_all()` → `{query_id, manager}` pairs.
+- `convertible_data` gains a `query_id()` virtual.
+
+**Tests:** extend `test_bounded_thread_pool.cpp` with per-query drain semantics — including that
+`drain_and_wait(A)` does not wait on B's work, and that a queued-then-drained item releases its slot.
+
+---
+
+### B7 — Per-query completion and error paths
+**Closes:** A5, A6, D4
+
+Now mechanical, because the gate makes drains idempotent:
+
+- `wait_for_completion(query_id)` → `size(query_index{q})`, `wait_and_validate_empty(query_id)`,
+  no pool cycling.
+- `drain_after_error(query_id)` → `drain(query_index{q})`, `drain_query_tasks(query_id)`.
+- Guard `*_ready_devices.begin()`.
+
+---
+
+### B8 — Per-query downgrade
+**Closes:** A7, B1, B2, B3, D6
+
+The payoff step — the gate and the pool together close the race that neither closes alone:
+
+- `downgrade_request` gains a `query_id`; `drain(query_id)` cancels only that query's requests.
+- Split `drain()` into `quiesce()`/`resume()`; add the `_running` guard; RAII-reset
+  `_monitor_request_enqueued`.
+- **The TIER-2 window closes twice over:** the gate refuses `~convertible_gpu_pipeline_task`'s
+  re-push for a non-`open` query, *and* the post-`reserve()` re-check refuses to dispatch a
+  candidate whose query has left `open`. The gate handles the processing-thread-local window that
+  pool accounting cannot see; `drain_and_wait(q)` handles everything already dispatched.
+- TIER-1 sweep skips non-`open` queries.
+
+**Tests:** the TIER-2 resurrection stress test from the register, under ASan and TSan.
+
+---
+
+### B9 — Repository teardown, plan lifetime, shutdown ordering
+**Closes:** B4, B5, B6, B7, B8, B9, B10
+
+- `run_mandatory_cleanup` becomes: `gate.quiesce(q)` → `drain_and_wait(q)` on all four pools →
+  per-query queue drains → repo erase → `gate.close(q)`. Because the gate makes every drain
+  idempotent, **this sequence is no longer order-sensitive** — the key structural difference
+  from Option A.
+- Move engine/plan destruction after `run_mandatory_cleanup`.
+- `drop_query_runtime_state_best_effort` erases the repository registry.
+- `terminate()` stops producers before `task_scheduler_.reset()`; fix member declaration order;
+  try/catch in `~SiriusContext`.
+- Take `_mutex` in `get_repository`.
+
+---
+
+### B10 — Per-query telemetry and prefetch-cache safety
+**Closes:** A8, B11
+
+Identical to Option A step A10.
+
+---
+
+### B11 — Turn concurrency on and prove it
+**Closes:** validation half of G1, G4, G5, G7
+
+Identical to Option A step A11 — but arriving with a single invariant to reason about when
+something does go wrong, and with `drain_and_wait(query_id)` available as a debugging primitive.
+
+---
+
+### B12 — Fairness, config safety, and hygiene
+**Closes:** D3, D5, E1–E7, F1–F9, H1–H3, H5–H11
+
+Identical to Option A step A12. Split into 4–6 commits.
+
+---
+
+## Pros
+
+- **One invariant, one place to look.** "Is it safe to erase this query's repositories?" has a
+  single answer: the gate says `closed` and every pool reports `drain_and_wait(q)` complete. New
+  call sites inherit the guarantee instead of re-deriving it.
+- **Teardown becomes order-insensitive.** Option A's correctness depends on a specific six-step
+  sequence in `run_mandatory_cleanup`. Here, a gated enqueue point cannot re-arm work after a
+  drain regardless of ordering, so a future reorder is not a latent UAF.
+- **Implements your `drain_and_wait(query_id)` idea properly.** It uniformly replaces
+  `enter/leave/wait_for_in_flight` and extends the same guarantee to the GPU executor and
+  downgrade pools, which have nothing equivalent today.
+- **Tagging at `reserve()` fixes register D1 for free** — the manager-thread dereference that the
+  current in-flight counter misses.
+- **Copies a design that already works in this tree.** `scoped_dispatcher`'s "after `request_stop()`,
+  enqueue is a silent no-op" is the same shape, already shipped and already tested.
+- **Better debugging story.** `drain_and_wait(q)` plus gate state is directly inspectable when a
+  query hangs; Option A gives you four separate mechanisms to inspect.
+
+## Cons
+
+- **Touches a primitive shared by four subsystems.** A bug in `bounded_thread_pool` takes out task
+  creation, GPU dispatch and downgrade simultaneously. Step B6 needs disproportionate review and
+  test attention relative to its LOC.
+- **Two foundation steps (B4, B6) deliver no user-visible fix.** B4 is deliberately a runtime
+  no-op. That is uncomfortable if the project gets cut short — Option A's steps each close real
+  bugs from step 3 onward.
+- **The gate is only as good as its coverage.** A missed enqueue point is a silent hole, and the
+  compiler will not find it. Needs an explicit audit (and ideally a debug assertion in `push()`
+  that the query is `open`).
+- **`std::list` + index in the work queue** is more machinery than the current `std::queue`, with
+  slot-release bookkeeping on the erase path that must be exactly right.
+- **Ordering constraint:** B5 must precede B6 (the pool cannot hold per-query state while it is
+  destroyed and recreated every query), which makes the middle of the plan a fixed sequence rather
+  than parallelisable work.
+- **Still does not fix the register's structural items.** `unique_ptr<data_repository>` with raw
+  borrows survives; correctness still rests on quiescence, just centrally enforced quiescence.
+  The global `executor->drain()` can be made per-query but not *deleted*.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| A missed gate check | Debug-build assertion in every `push()`/`dispatch()` that the query is `open`; grep audit as a checklist item in B4's review |
+| B6 destabilises all four subsystems at once | Land B6 behind the N=1 default so production behaviour is unchanged until B11; extend `test_bounded_thread_pool.cpp` before converting call sites |
+| B4/B6 deliver nothing shippable | Sequence B1–B3 first (harness + the three rogue `stop()` deletions) so real value lands before the foundation work |

--- a/docs/concurrency/option-c-structural.md
+++ b/docs/concurrency/option-c-structural.md
@@ -1,0 +1,272 @@
+# Option C — Structural
+
+> **Philosophy:** remove whole *classes* of bug rather than instances. Everything in
+> [Option B](option-b-unified-gate.md), plus three structural changes that make the remaining
+> hazards unrepresentable: shared ownership of repositories with **eager content release**, plan
+> lifetime inverted so the plan outlives every drain, and per-query fairness so concurrency
+> actually pays.
+
+The test: after Option C, can a new contributor introduce a teardown UAF by writing ordinary code?
+Under A and B the answer is yes (miss an ordering, miss a gate check). Under C the dangerous
+pointer types no longer exist.
+
+**Shape:** 15 steps · ~2,600 LOC net · 3 new files in `src/`, changes in `cucascade/`
+**Changes:** `shared_ptr<data_repository>` + `close()`, plan destroyed after cleanup, round-robin
+fairness, config moved to per-connection.
+
+---
+
+## The three structural changes
+
+### 1. Shared ownership with eager content release
+
+The register's verdict on plain `shared_ptr<data_repository>` is **"partially — worth doing, but
+not the fix on its own"**, and it has a real cost: one straggler task keeping one repository alive
+keeps **every un-consumed batch in it** alive, and those batches hold GPU memory. That would move
+memory release from a deterministic point (`erase(query_id)`) to "whenever the last borrower drops",
+which is unbounded on the OOM-reschedule path — and it would break the `log_pool_stats` leak
+signature (`QueryEnd allocated != QueryBegin allocated`) that leak detection currently relies on.
+
+So Option C **splits object lifetime from content lifetime**:
+
+```cpp
+// shared ownership of the OBJECT — no dangling, ever
+std::map<operator_port_key, std::shared_ptr<data_repository>> _repositories;
+
+// deterministic release of the CONTENTS
+void data_repository::close();   // takes _mutex, clears _data_batches (GPU memory back NOW),
+                                 // sets _closed; later add_data_batch() is a no-op returning
+                                 // "dropped" so a straggler's publish is observable, not silent
+```
+
+`registry.erase(query_id)` calls `close()` on every repository — **still reporting leaked batch
+counts, preserving the diagnostic** — then drops the map entry. Repository *objects* die lazily;
+repository *memory* dies eagerly. This is what lets the global `executor->drain()` at
+`sirius_context.cpp:322-324` be **deleted** rather than merely made per-query.
+
+Also in scope: `gpu_pipeline_task::_data_repos` and `convertible_data_batch_provider::_repo`
+become `shared_ptr`; `port::repo` stays raw (the plan dies first, so shared ownership there would
+extend lifetime *backwards*); `batch_telemetry_registry::ports` re-keys on the existing
+`port::source_port_uuid` (a key is not an owner — address recycling silently matches stale entries).
+
+`data_batch` itself needs **no change**: it is already `shared_ptr` throughout, non-owning
+references are `weak_ptr` or by-id, and there are zero raw `data_batch*` in `src/`.
+
+#### cucascade change scope
+
+The blast radius is much smaller than "modifying a submodule" suggests:
+
+- **Zero internal cucascade callers** of `get_repository` / `get_repositories` — only the class
+  itself and its own test file (`cucascade/test/data/test_data_repository_manager.cpp`, ~20 sites,
+  all mechanical `auto& repo =` → `auto repo =`).
+- **Two Sirius production call sites**: `src/pipeline/repository_wiring_materializer.cpp:71` and
+  `src/downgrade/downgrade_executor.cpp:226`.
+- **`data_repository` has no subclasses**, so changing virtual signatures is safe.
+
+Five changes, of which the pointer swap is only the first:
+
+| # | Change | Why |
+|---|---|---|
+| 1 | `_repositories`: `unique_ptr` → `shared_ptr`. `get_repository()` returns `shared_ptr` **by value under `_mutex`**; `get_repositories()` → `vector<shared_ptr>`. | Removes the dangling borrow. Also fixes register **B9** for free — `get_repository` today returns a reference into the map and is the *only* method in the class that takes no lock. |
+| 2 | **`data_repository::close()`** — take `_mutex`, clear `_data_batches`, set `_closed`. | **The essential part.** `_data_batches` is `vector<vector<shared_ptr<data_batch>>>`; dropping it is what returns GPU memory. Without this, shared ownership means one straggler task keeps *every* un-consumed batch alive and memory release becomes non-deterministic. |
+| 3 | `add_data_batch` returns a status instead of `void` when closed. | Without it, a straggler's publish is a silent no-op — memory-safe but **wrong results**, which is worse than the crash it replaces. Currently `virtual void` with no overrides, so this is safe to change. |
+| 4 | `clear_all_repositories()` → `close()` each (still counting leaked batches) then drop entries. | Preserves the leaked-batch diagnostic, which is how "operator X didn't drain port Y" is currently detected. |
+| 5 | `data_repository_manager::add_data_batch` uses `_repositories.at(...)`, which throws `std::out_of_range` once the entry is erased. | Needs a graceful "dropped" path rather than an exception on a teardown race. |
+
+Optional hygiene while in there: delete `for_each_repository` (zero callers) and rename the
+`shared_data_repository` / `shared_data_repository_manager` aliases (register H10), which claim
+shared ownership where there is none — in exactly this code.
+
+**Effort:** ~150 LOC production + mechanical test updates on the cucascade side; ~80 LOC on the
+Sirius side across the two call sites and the registry. The cucascade half is independently
+shippable — land it, bump the submodule, then land the Sirius half.
+
+### 2. Plan lifetime inversion
+
+Today `cleanup_internal` destroys `sirius_engine` — and therefore `sirius_owned_plan` — *before*
+`run_mandatory_cleanup` runs. Every `sirius_pipeline` holds non-owning refs into that freed plan
+(`optional_ptr` source/sink, `reference_wrapper` operators) and outlives it via the task global
+state. `~gpu_pipeline_task` → `mark_task_completed()` → `notify_downstream_pipelines()` walks all
+of them; so does `index_keys_for` from inside `drain_query_tasks`. The code acknowledges this in a
+comment ("stop touching a plan that has died").
+
+Option C makes `StandaloneQueryScope` own the engine, so `finish()` orders: drain → repo erase →
+**then** engine destruction. After this, "a pipeline referencing a dead plan" is not a state the
+system can reach, and the whole `drain_query_tasks`-must-not-run-completion-side-effects problem
+evaporates.
+
+### 3. Fairness
+
+`query_id` is currently packed into the **high** bits of the priority and the queue pops
+lowest-first, so every task of query 1 outranks every task of query 2. Query 2 runs only when
+query 1 has nothing dispatchable — and if query 1 is blocked on memory that only query 2 could
+release by finishing, it livelocks. Option C makes the query bits a **fairness index**
+(round-robin across live queries at dispatch) rather than a priority prefix, and widens
+`query_id_t` to 64-bit so it stops being packed into a signed 31-bit field at all.
+
+---
+
+## Step-by-step
+
+### C1 — Concurrency harness + admission knob + scan pool sizing
+**Closes:** G1, G2, G3, C3, H4 · Same as Option A step A1.
+
+### C2 — Make dropped work loud
+**Closes:** A9 · Same as Option A step A2.
+
+### C3 — Stop per-query failures from killing shared subsystems
+**Closes:** A1, A3, A4, A10, global-halt half of A2 · Same as Option A step A3.
+
+### C4 — Introduce `query_lifecycle_registry` (gate only)
+**Closes:** foundation · Same as Option B step B4.
+
+### C5 — Remove the creator's stop/start cycle; fix lock ordering
+**Closes:** C1, C2, D1, D2, self-deadlock half of A2 · Same as Option B step B5.
+
+### C6 — Query-aware `bounded_thread_pool` + `drain_and_wait(query_id)`
+**Closes:** replaces `enter/leave/wait_for_in_flight` · Same as Option B step B6.
+
+### C7 — Per-query completion and error paths
+**Closes:** A5, A6, D4 · Same as Option B step B7.
+
+---
+
+### C8 — Shared-ownership repositories with `close()` *(new to Option C)*
+**Closes:** B3, B4, B9, H10 · **Prerequisite for C9's deletion**
+
+- `cucascade`: `_repositories` → `map<key, shared_ptr<data_repository>>`; `get_repository()`
+  returns `shared_ptr` **by value under `_mutex`** (which also fixes B9 for free);
+  `get_repositories()` → `vector<shared_ptr<...>>`; delete the zero-caller `for_each_repository`.
+- Add `data_repository::close()` as described above.
+- `registry.erase(query_id)` → `close()` every repository (still counting leaked batches) then
+  drop the entry.
+- `gpu_pipeline_task::_data_repos` and `convertible_data_batch_provider::_repo` → `shared_ptr`.
+- Rename the `shared_data_repository` / `shared_data_repository_manager` aliases, which currently
+  claim shared ownership where there was none.
+
+**Tests:** a straggler task publishing into a closed repository must be observable (dropped +
+logged), not a crash and not a silent leak. Assert `log_pool_stats` returns to baseline at
+`QueryEnd` — i.e. that eager `close()` really did release the GPU memory.
+
+---
+
+### C9 — Delete the global downgrade drain *(new to Option C)*
+**Closes:** A7, B1, B2, D6, F8
+
+With C8 in place the downgrade executor can no longer dangle, so the worst cross-query
+serialization point in the system goes away entirely rather than being narrowed:
+
+- **Delete** `for (auto& executor : downgrade_executors_) executor->drain();` from
+  `run_mandatory_cleanup`.
+- `downgrade_request` gains a `query_id`; the sweep skips non-`open` queries; `_running` guard;
+  RAII-reset `_monitor_request_enqueued`.
+- TIER-2 re-push is gated (never resurrects) *and* harmless if it did (shared ownership).
+- Optionally lift the strict `_pool->wait_all()` serialization (F8).
+
+> This is the step that makes concurrency actually *concurrent* under memory pressure. Under
+> Options A and B, every query end still quiesces every downgrade executor.
+
+---
+
+### C10 — Plan lifetime inversion *(new to Option C)*
+**Closes:** B5, B8
+
+- `StandaloneQueryScope` takes ownership of the engine; `finish()` orders drain → repo erase →
+  engine destruction.
+- `drop_query_runtime_state_best_effort` erases the repository registry.
+- With the plan outliving the drains, remove the defensive machinery that existed only to cope
+  with the inversion (the `drain_after_error` comment block explaining why the creator must stay
+  interrupted across executor drains describes a hazard that no longer exists).
+
+**Tests:** force `get_result()` to throw — the path that today destroys the plan with no drain
+having run — and assert clean teardown under ASan.
+
+---
+
+### C11 — Shutdown ordering
+**Closes:** B6, B7, B10 · Same as Option A step A9.
+
+### C12 — Per-query telemetry and prefetch-cache safety
+**Closes:** A8, B11 · Same as Option A step A10.
+
+---
+
+### C13 — Fairness *(new to Option C — promoted ahead of enablement)*
+**Closes:** F1, D3, H8
+
+- Widen `query_id_t` to 64-bit; stop packing it into the signed priority; make it a separate
+  fairness index level.
+- Round-robin across live queries at dispatch in `management_eventloop`.
+- Rotate `schedule_lookahead` across live queries.
+
+> Deliberately **before** enablement, unlike Options A and B. Turning on concurrency with strict
+> query-id-first priority means the first thing the new concurrent tests measure is head-of-line
+> blocking, and a livelock (query 1 blocked on memory only query 2 can release) reads as a hang —
+> which is exactly the failure mode you would otherwise be trying to debug.
+
+---
+
+### C14 — Turn concurrency on and prove it
+**Closes:** validation half of G1, G4, G5, G7
+
+As Option A step A11, plus: concurrent TPC-H at scale under memory pressure (the case C9 and C13
+were built for), and a fairness assertion (a short query behind a long query completes in bounded
+time).
+
+---
+
+### C15 — Config safety and hygiene
+**Closes:** D5, E1–E7, F2–F7, F9, H1–H3, H5–H7, H9, H11
+
+Same content as Option A step A12 minus the fairness items (done in C13) and the alias rename
+(done in C8). Split into 4–6 commits.
+
+---
+
+## Pros
+
+- **The dangerous pointer types stop existing.** After C8 and C10 there is no raw
+  `data_repository*` crossing a queue hop and no pipeline referencing a dead plan. A new
+  contributor cannot reintroduce those bugs by writing ordinary code — which is not true under
+  A or B.
+- **Deletes the worst serialization point rather than narrowing it.** C9 removes the global
+  downgrade drain outright. Under A and B, every query end still quiesces every downgrade executor
+  on every memory space — a permanent tax on exactly the workload (concurrent + memory-pressured)
+  that this project exists to enable.
+- **Solves your `shared_ptr` question without its downside.** Eager `close()` keeps memory release
+  deterministic, keeps the `log_pool_stats` leak signature working, and keeps the leaked-batch
+  diagnostic — the three real objections to a plain `shared_ptr` conversion.
+- **Turns silent failures into observable ones.** A straggler publishing into a closed repository
+  is logged and counted rather than being a memory-safe-but-wrong no-op (or a crash).
+- **Fairness lands before enablement**, so the first concurrent test results are interpretable.
+- **Best foundation for removing the mutex.** The follow-on project (admission queue instead of
+  single-flight) is mostly configuration after C14; under A or B there is more to re-verify.
+
+## Cons
+
+- **Largest and longest.** ~2,600 LOC across 15 steps, with C15 realistically splitting into 4–6
+  more. Roughly 1.8× Option A.
+- **Modifies the `cucascade` submodule** (`data_repository`, `data_repository_manager`). Separate
+  review, separate CI, possible coordination with other cucascade consumers — and a submodule bump
+  in the middle of the plan.
+- **C8 is the highest-consequence single step in any option.** It changes the ownership model of
+  the object every operator reads and writes through, in a submodule. If `close()` semantics are
+  wrong, the failure mode is "query silently produces incomplete results", which is worse than a
+  crash.
+- **C10 changes who owns the engine**, touching all five entry points that construct a
+  `StandaloneQueryScope` (`physical_sirius_execution.cpp`, `sirius_extension.cpp` ×2,
+  `sirius_ffi.cpp`) and DuckDB's `GlobalSourceState` interaction. Real risk of subtle result-lifetime
+  regressions on the streaming/pending paths — which is precisely what
+  `test_query_lifecycle_slot.cpp` was written to catch, so at least it is covered.
+- **Value arrives latest.** Nine steps before anything structurally new lands, and C8–C10 are three
+  large consecutive steps with no user-visible change until C14.
+- **Hardest to revert.** C8 and C10 are not independently revertible once C9 depends on them.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| C8's `close()` semantics wrong → silent wrong results | Make `add_data_batch` on a closed repository return an explicit "dropped" status that the caller *must* handle; assert-fail in debug builds; add a result-correctness test with a forced straggler |
+| cucascade submodule coordination | Land the cucascade half as its own PR first, bump the submodule, then land the Sirius half — C8 splits cleanly in two |
+| C10 regresses result lifetime on streaming/pending paths | `test_query_lifecycle_slot.cpp` already covers abandoned streaming and pending results; run it under ASan before and after |
+| Three large consecutive steps (C8–C10) with no visible payoff | Sequence C1–C7 first — identical to Option B, so real fixes ship for seven steps before the structural work begins |

--- a/docs/concurrency/option-d-recommended.md
+++ b/docs/concurrency/option-d-recommended.md
@@ -218,6 +218,47 @@ a queued-then-drained item must release its slot. Convert call sites only after 
 
 ---
 
+> ### ⚠ ATTEMPTED AND BACKED OUT — steps 6 and 7 are NOT in the branch
+>
+> Implemented in full, then reverted. The work is preserved in two named stashes:
+> `step6-cucascade-shared-ptr-repositories` (in `cucascade/`) and `step6b-7-sirius-side`
+> (in the Sirius repo).
+>
+> **Symptom.** Deterministic `SIGSEGV`, 3/3 full-suite runs and also in isolation, at
+> `test/cpp/integration` case *"pin_table compression - result equality vs uncompressed pin"* —
+> the 6th test, so it fails almost immediately.
+>
+> **Where.** `sirius::op::sirius_physical_ungrouped_aggregate_merge::get_next_task_input_data()`,
+> on a `task_creator` pool worker inside the creation lambda. Faulting instruction is
+> `mov 0x8(%rcx),%rdi` with `rax = rbx = 0`. The line is
+> `ports.begin()->second->repo->pop_next_data_batch()`, so the candidates are an empty `ports` map
+> (`begin()` == `end()`) or a null/dangling `repo`.
+>
+> **Ruled out during investigation:**
+> - Not pre-existing — the same test passes at the step-5 commit, verified by stashing both halves
+>   and rebuilding.
+> - Not a silently-unhooked virtual override: nothing derives from `data_repository`, so changing
+>   `add_data_batch`'s return type broke no override (and would not have compiled if it had).
+> - Not `pop_next_data_batch` indexing an emptied partition vector: it range-checks and throws.
+>
+> **Not yet ruled out** (in rough order of suspicion):
+> 1. `get_repository()` now returns `shared_ptr` **by value**; `materialize_repository_wiring` does
+>    `.get()` on that temporary. The map still holds a reference so the raw pointer should stay
+>    valid — but this is the one lifetime change on the exact pointer that crashes.
+> 2. The manager's `add_data_batch` moving the per-repository calls **outside** `_mutex`.
+> 3. `close()` leaving `_data_batches` empty (size 0) rather than "one empty partition", which
+>    changes `num_partitions()` for any code that reads it after close.
+>
+> **Recommended next move:** instrument `get_next_task_input_data` to report `ports.size()` and
+> `repo == nullptr` before the deref — that single data point distinguishes all three hypotheses,
+> and none of the black-box debugging did.
+>
+> The plan's own risk table called this out: *"C8 is the highest-consequence single step in any
+> option ... its bad failure mode is silently incomplete results"*, with the contingency
+> *"if cucascade coordination stalls, proceed with the narrowed (per-query) downgrade drain and
+> revisit"*. That is what happened, and that is the state the branch is in: the downgrade drain in
+> `run_mandatory_cleanup` is still the global one.
+
 ### Step 6 — cucascade: shared-ownership repositories with `close()`
 **Closes:** B3, B4, B9, H10 · **two commits: 6a cucascade PR + submodule bump, 6b Sirius side**
 

--- a/docs/concurrency/option-d-recommended.md
+++ b/docs/concurrency/option-d-recommended.md
@@ -180,7 +180,17 @@ stop/start hammer test.
 Only safe now: step 3 removed the stop/start-per-query cycle that would otherwise destroy and
 recreate the pool — and any per-query state in it — on every completion.
 
-> **Carried over from step 3 — A6 is only partly closed.** `wait_and_validate_empty(query_id)` and
+> **RESOLVED IN STEP 5 (success path).** `wait_and_validate_empty(query_id)` now uses
+> `bounded_thread_pool::wait_for_query(query_id)` with no quiesce bracket, so a successful query
+> completion no longer interrupts the shared queue and can no longer drop a co-tenant's in-transit
+> task. `wait_and_drain_query(query_id)` (the ERROR path) deliberately keeps the bracket: a failing
+> query can still have tasks the manager may pop at any moment, and there is a window between
+> `pop()` and `slot::attach()` where a task belongs to neither the queue nor the per-query count.
+> Joining the manager is what closes it, and the caller's next act is to destroy the plan, so
+> "almost certainly quiesced" is not good enough there. Closing that last window needs the manager
+> to publish its in-hand task's query before leaving the queue's lock — noted as follow-up work.
+>
+> **Original note, kept for context — A6 was only partly closed in step 3.** `wait_and_validate_empty(query_id)` and
 > `wait_and_drain_query(query_id)` still bracket their work in `quiesce_manager()` /
 > `resume_manager()`, because `manager_loop()` reserves a pool slot and then blocks in `pop()`: an
 > idle manager holds an active slot forever, so `wait_all()` cannot return until the manager is

--- a/docs/concurrency/option-d-recommended.md
+++ b/docs/concurrency/option-d-recommended.md
@@ -180,6 +180,17 @@ stop/start hammer test.
 Only safe now: step 3 removed the stop/start-per-query cycle that would otherwise destroy and
 recreate the pool — and any per-query state in it — on every completion.
 
+> **Carried over from step 3 — A6 is only partly closed.** `wait_and_validate_empty(query_id)` and
+> `wait_and_drain_query(query_id)` still bracket their work in `quiesce_manager()` /
+> `resume_manager()`, because `manager_loop()` reserves a pool slot and then blocks in `pop()`: an
+> idle manager holds an active slot forever, so `wait_all()` cannot return until the manager is
+> interrupted and joined. That interrupt makes `push()` return false for the duration, so a
+> co-tenant task **in transit** from the scheduler to a device queue can still be dropped. Step 3
+> removed the whole-queue drain that destroyed co-tenants' *queued* work; this step must remove the
+> in-transit drop by making the in-flight wait per-query, after which
+> `test_task_scheduler.cpp`'s "wait_for_completion validates only its own query's queue" should
+> regain the liveness assertion currently documented-but-not-asserted there.
+
 - Tag at `reserve(query_id)`, **not** `dispatch` — that is what puts the manager thread's
   pre-dispatch dereference inside the counted region. Where the query is unknown until after
   `pop()`, use `slot::attach(query_id)`.

--- a/docs/concurrency/option-d-recommended.md
+++ b/docs/concurrency/option-d-recommended.md
@@ -1,0 +1,425 @@
+# Option D — Recommended (consolidated)
+
+> **This is the plan to execute.** It takes [Option B](option-b-unified-gate.md)'s gate +
+> query-aware-pool mechanism and [Option C](option-c-structural.md)'s two structural changes, and
+> orders them so the gate is load-bearing from step 2 rather than arriving as scaffolding.
+
+**Scope decisions this plan is built on:**
+
+| Decision | Consequence |
+|---|---|
+| Target concurrency **3–7** | Scan pool sized `num_threads + N`; head-of-line blocking on the per-GPU manager thread gets its own step |
+| **Fairness = FIFO query order** (oldest query wins) | Register F1 is a *policy*, not a bug. No fairness step. See [below](#fairness-is-fifo-and-that-collapses-two-steps) |
+| `cucascade` can take a PR | Shared-ownership repositories with `close()` are in scope; the global downgrade drain gets **deleted**, not narrowed |
+| Concurrent SQLLogic in scope | The vendored runner already supports it; enablement uses it |
+
+**Shape:** 14 steps (step 14 splits into 4–6 commits) · ~2,000 LOC net · 2 new files in `src/` ·
+one `cucascade` PR + submodule bump.
+
+Every step is one commit and leaves `pixi run make test` green.
+
+---
+
+## Ordering rationale
+
+**The gate goes second and does real work immediately.** An earlier draft had it as a deliberate
+runtime no-op — wire the checks, keep reporting `open`, prove nothing changed. That was
+over-cautious and gave nothing to look at. Instead, step 2 wires it live and step 3 immediately
+cashes it in: `drain_after_error`'s own comment explains that it interrupts the *shared* creation
+queue precisely so that late `schedule()` calls from completion callbacks return false and get
+dropped. The gate does exactly that, **per query, without touching a shared queue** — so the global
+`stop_thread_pool()`/`interrupt()` pair can be deleted. That deletion is the gate's first visible
+payoff, and it defuses register C1 as a side effect.
+
+**Step 1 stays ahead of it** because it is pure deletion — three rogue `stop()` calls and four
+`break`s — needing no new machinery and closing four Criticals. If the project stopped after one
+commit, the bugs where a single query's failure hangs the whole engine would already be gone.
+
+**Two things moved late.** The test harness (was step 1) is unusable until enablement — at
+`max_concurrent_queries = 1` it can only re-prove serialization, which `test_query_lifecycle_slot.cpp`
+already does. And the push-drop check (was step 2) is *better* late: before the gate, "push returned
+false" cannot be distinguished from an intended teardown drop, so the check would have been a log
+line. After the gate it becomes a real invariant — *any* push-false for a query the gate says is
+`open` is a bug — and can `report_error` rather than just warn.
+
+### Fairness is FIFO, and that collapses two steps
+
+`query_id` is packed into the high bits of the scheduling priority and the queue pops lowest-first,
+so every task of the older query outranks every task of a newer one. That **is** FIFO query order.
+With FIFO accepted as the policy, register F1 stops being a defect:
+
+- **F1's starvation is the policy.** Oldest-first is a defensible choice for a memory-constrained
+  GPU engine — it drains queries rather than making partial progress on all of them, which bounds
+  peak memory. No round-robin dispatch, no separate fairness index. The dedicated fairness step
+  disappears.
+- **F4 (single FIFO prefetch pipeline) stops being an issue.** One preparation thread, one prefetch
+  thread, one rate limiter, strict FIFO — query 7's prefetch queueing behind queries 1–6 is
+  precisely the chosen policy. Dropped from the plan.
+- **What survives is small and moves into other steps.** `schedule_lookahead` taking
+  `_query_task_global_states.begin()` unconditionally is still a bug — not because oldest-first is
+  wrong, but because it will happily serve a query that is finished-but-not-yet-reset, touching
+  operators of a dead plan. That becomes a two-line fix in step 4 (skip non-`open` queries, then
+  take the oldest). The 31-bit priority mask and 32-bit id wrap (H8) become standalone hygiene.
+
+> **One dependency to state explicitly.** FIFO is safe *provided the downgrade path works*. The
+> livelock case is an older query blocked on memory that only a newer query could release by
+> finishing — under FIFO the newer query never gets dispatched. The escape hatch is spilling, which
+> means **steps 6 and 7 are load-bearing for the fairness policy**, not just for teardown
+> correctness. If step 7 slips, revisit this.
+
+---
+
+## Steps
+
+### Step 1 — Stop per-query failures from killing shared subsystems
+**Closes:** A1, A3, A4, A10, global-halt half of A2
+
+Pure deletion. No new abstractions, highest severity in the register.
+
+- `task_scheduler::terminate_query` (`task_scheduler.cpp:174`): delete the `stop()`. Report to the
+  handler, then `drain_query_tasks(query_id)`. Today one query's creation error stops every GPU
+  executor and nothing ever calls `start()` again.
+- Creation-worker catch (`task_creator.cpp:692`): delete the `stop()`.
+- GPU executor catch (`gpu_pipeline_executor.cpp:427, 432`): delete `_task_creator->stop()` —
+  `completion->report_error` on the next line already fails the correct query.
+- All four `break`s (`:196, 239, 261, 295`) → report to *that task's* handler, then `continue`.
+  Only channel/queue closure may break the loop.
+- Wrap the `manager_loop` body in try/catch — it is a `std::thread` entry function that throws
+  (`internal_exception` at `:139`) and calls throwing APIs, so an escape aborts the process.
+
+**Tests:** inject a creation exception and a task exception; assert the scheduler and creator are
+still running and a subsequent query completes normally.
+
+---
+
+### Step 2 — `query_lifecycle_registry`, wired live
+**Closes:** foundation — but observable from day one
+
+New `src/include/exec/query_lifecycle_registry.hpp` + `.cpp`. States `open → quiescing → closed`,
+keyed by `query_id_t`, owned by `SiriusContext`. `begin_execution_window` opens;
+`run_mandatory_cleanup` moves to `quiescing`, then `closed` after the drains.
+
+Wire the check **live** into all seven enqueue points — a non-`open` query's enqueue becomes a
+silent no-op:
+
+| Enqueue point | File |
+|---|---|
+| `task_creator::schedule` / `schedule_lookahead` | `task_creator.cpp:397, 407, 456` |
+| `task_scheduler::schedule` | `task_scheduler.cpp:112` |
+| `itask_executor::schedule` | `task_executor.cpp:61` |
+| **`~convertible_gpu_pipeline_task`** (the TIER-2 re-push) | `convertible_gpu_pipeline_task.hpp:88` |
+| OOM reschedule | `gpu_pipeline_executor.cpp:423` |
+| downgrade candidate, re-checked after `reserve()` | `downgrade_executor.cpp:306` |
+| `bounded_thread_pool::dispatch` | added in step 5 |
+
+Copy `exec::scoped_dispatcher`'s shape — after `request_stop()`, `enqueue()` is a silent no-op plus
+`wait_for_all()`. That pattern is already shipped and tested in this tree.
+
+**Tests — this is the "see it in action" step.** After `quiesce(A)`, a `schedule()` from a
+completion callback for A is refused while B's still succeeds; a TIER-2 re-push for a quiescing
+query is dropped instead of resurrecting the task. Add a debug-build assertion in
+`push()`/`dispatch()` that the query is `open`, so a missed call site fails loudly rather than
+silently.
+
+---
+
+### Step 3 — Delete the global interrupts; make completion and error paths per-query
+**Closes:** A5, A6, D4 · defuses C1 from the per-query paths
+
+The gate's first payoff. `drain_after_error`'s comment block explains that it interrupts the shared
+creation queue so late pushes from completion callbacks are dropped — step 2 now does that per
+query, so the shared interrupt is redundant.
+
+- Delete `_task_creator->stop_thread_pool()` / `start_thread_pool()` from `wait_for_completion`
+  (`:234, 255, 261`) and `drain_after_error` (`:197, 220`).
+- `wait_for_completion(query_id)`: `_task_queue.size(query_index{q})` instead of the global
+  `size()` (today query A throws *"task queue not empty"* because query B has work queued);
+  `gpu_exec->wait_and_validate_empty(query_id)`.
+- `drain_after_error(query_id)`: `_task_queue.drain(query_index{q})` in both places;
+  `gpu_exec->drain_query_tasks(query_id)` instead of the unfiltered `drain_and_wait()`.
+- New `itask_executor::wait_and_validate_empty(query_id)`; reserve the global `drain_and_wait()`
+  for teardown. Add the missing null-pool guard it lacks but `drain_and_wait` has.
+- Guard `*_ready_devices.begin()` against an empty vector.
+
+**Tests:** query A completes while B has queued tasks — A must not throw, B must not lose work.
+Same for A erroring.
+
+---
+
+### Step 4 — Creator lock ordering, in-flight coverage, lookahead
+**Closes:** C1, C2, D1, D2, D3, self-deadlock half of A2 · **prerequisite for step 5**
+
+- Split the lifecycle mutex from `_global_state_mutex`; never hold either across
+  `_manager_thread.join()`. Today `stop_thread_pool()` holds `_global_state_mutex` across the join
+  while the manager thread needs that same mutex — a deadlock reachable on every query completion
+  until step 3 removed the caller, and still reachable from `terminate()`.
+- Forbid `stop()` from a pool worker (assert; post a stop request). `stop()` currently bypasses
+  `_global_state_mutex` entirely while `start`/`stop_thread_pool` take it.
+- Move `enter_in_flight()` to immediately after the `get_query_task_global_state` lookup, so the
+  manager thread's own `get_operator_for_next_task(node)` dereference is inside the counted region.
+  Release on every early `continue`. Cover the key extractor's `request.node->type` dereference the
+  same way.
+- `schedule_lookahead`: skip non-`open` queries, then take the oldest — preserving FIFO while no
+  longer serving a query whose plan is gone.
+
+**Tests:** `drain_pending_tasks(Q)` returning implies no thread is dereferencing Q's operators;
+stop/start hammer test.
+
+---
+
+### Step 5 — Query-aware `bounded_thread_pool` + `drain_and_wait(query_id)`
+**Closes:** replaces `enter/leave/wait_for_in_flight`; foundation for step 7
+
+Only safe now: step 3 removed the stop/start-per-query cycle that would otherwise destroy and
+recreate the pool — and any per-query state in it — on every completion.
+
+- Tag at `reserve(query_id)`, **not** `dispatch` — that is what puts the manager thread's
+  pre-dispatch dereference inside the counted region. Where the query is unknown until after
+  `pop()`, use `slot::attach(query_id)`.
+- `work_queue_`: `std::queue` → `std::list` + a `query_id → iterator` index so queued work is
+  removable by key; erasing a queued item must release its slot.
+- Per-query active counter + CV → `drain_and_wait(query_id)`; `close(q)`/`reopen(q)`.
+- Convert the four production call sites (`task_creator.cpp:466/501`,
+  `gpu_pipeline_executor.cpp:105/306`, downgrade TIER 1 `:238/251`, TIER 2 `:306/314`).
+- `data_repository_manager_registry::get_all()` → `{query_id, manager}` pairs (TIER 1 has no query
+  id today); `convertible_data` gains a `query_id()` virtual (TIER 2 is type-erased).
+- Delete `task_creator`'s bespoke in-flight members.
+
+**Tests:** extend `test_bounded_thread_pool.cpp` — `drain_and_wait(A)` must not wait on B's work;
+a queued-then-drained item must release its slot. Convert call sites only after these pass.
+
+---
+
+### Step 6 — cucascade: shared-ownership repositories with `close()`
+**Closes:** B3, B4, B9, H10 · **two commits: 6a cucascade PR + submodule bump, 6b Sirius side**
+
+Surface is small: **zero** internal cucascade callers of `get_repository`/`get_repositories`,
+**two** Sirius production call sites, and `data_repository` has **no subclasses**.
+
+| # | Change |
+|---|---|
+| 1 | `_repositories`: `unique_ptr` → `shared_ptr`; `get_repository()` returns by value **under `_mutex`** — it takes no lock today, the only method in the class that doesn't (fixes B9); `get_repositories()` → `vector<shared_ptr>` |
+| 2 | **`data_repository::close()`** — take `_mutex`, clear `_data_batches`, set `_closed`. This is what keeps GPU memory release *eager* while object lifetime goes lazy |
+| 3 | `add_data_batch` returns a status when closed instead of `void` — otherwise a straggler's publish is a silent no-op, i.e. wrong results, which is worse than the crash it replaces |
+| 4 | `clear_all_repositories()` → `close()` each, still counting leaked batches (preserves the drain diagnostic) |
+| 5 | `manager::add_data_batch`'s `_repositories.at(...)` → graceful "dropped" path instead of `std::out_of_range` |
+
+Plus: delete `for_each_repository` (zero callers), rename the `shared_data_repository` aliases.
+Sirius side is `repository_wiring_materializer.cpp:71` and `downgrade_executor.cpp:226` plus the
+registry; `port::repo` stays raw (the plan dies first, so shared ownership there extends lifetime
+backwards).
+
+**Tests:** a straggler publishing into a closed repository is observable, not a crash and not a
+silent leak. Assert `log_pool_stats` returns to baseline at `QueryEnd` — i.e. that eager `close()`
+really released the GPU memory.
+
+---
+
+### Step 7 — Delete the global downgrade drain
+**Closes:** A7, B1, B2, D6, F8
+
+With step 6 in place the downgrade executor cannot dangle, so the worst cross-query serialization
+point goes away rather than being narrowed. At 3–7 queries this matters ~7× more than it does today.
+
+- **Delete** `for (auto& executor : downgrade_executors_) executor->drain();` from
+  `run_mandatory_cleanup`. Today it cancels *every* query's pending spills on *every* query end.
+- `downgrade_request` gains a `query_id`; `drain(query_id)` cancels only that query's requests. Add
+  the `_running` guard — `drain()` after `stop()` currently null-derefs and leaves a joinable thread.
+  RAII-reset `_monitor_request_enqueued` on the request and on a failed push (it latches `true`
+  forever today, killing automatic spilling for the rest of the process).
+- The TIER-2 window closes three ways over: the gate (step 2) refuses the re-push, the
+  post-`reserve()` re-check refuses to dispatch a candidate whose query left `open`, and shared
+  ownership (step 6) makes it harmless if either were missed.
+- TIER-1 sweep skips non-`open` queries.
+- Lift the strict `_pool->wait_all()` serialization (F8).
+
+**Tests:** TIER-2 resurrection stress test under ASan and TSan. Note this is reproducible
+**single-query** — the downgrade monitor thread is not slot-gated, so it needs no concurrency
+infrastructure.
+
+---
+
+### Step 8 — Repository teardown, plan lifetime, shutdown ordering
+**Closes:** B5, B6, B7, B8, B10
+
+- `run_mandatory_cleanup` becomes `gate.quiesce(q)` → `drain_and_wait(q)` on all pools → per-query
+  queue drains → repo erase → `gate.close(q)`. Because the gate makes drains idempotent, this
+  sequence is **no longer order-sensitive** — the key structural difference from a
+  quiescence-only approach.
+- Move engine/plan destruction after `run_mandatory_cleanup` (the reorder, not Option C's
+  engine-ownership move). Today the plan is destroyed first and pipelines hold non-owning refs
+  into it.
+- `drop_query_runtime_state_best_effort` erases the repository registry — it currently doesn't, so
+  a failed cleanup leaks the manager and all its GPU memory until `terminate()`.
+- `terminate()`: stop creator/scan/downgrade **before** `task_scheduler_.reset()`; null
+  `task_scheduler::_task_creator` and `gpu_pipeline_executor::_downgrade_executor` in the
+  respective `stop()`s.
+- Declare `task_scheduler_` last in `SiriusContext` (destroyed first); try/catch in
+  `~SiriusContext`, which is `noexcept` but calls a throwing `terminate()`.
+
+**Tests:** force `get_result()` to throw — the path that today destroys the plan with no drain
+having run — and assert clean teardown under ASan. Test `initialize()` throwing after
+`task_scheduler_` is constructed.
+
+---
+
+### Step 9 — Per-query telemetry and prefetch-cache safety
+**Closes:** A8, B11
+
+- `batch_telemetry_registry`: add `query_id` to placements and ports; `on_query_end(query_id)`
+  filters both loops. Re-key `ports` on the existing `port::source_port_uuid` instead of a raw
+  `data_repository*` — a key is not an owner, and address recycling silently matches stale entries.
+- `prefetching_cache`: copy `file_entry*` out under the lock and drop the iterator before
+  unlocking (`:311-322`, `:385-390`). Element pointers are stable; iterators are not.
+
+---
+
+### Step 10 — Head-of-line blocking on the per-GPU manager thread
+**Closes:** C4
+
+There is exactly one manager thread per GPU, and it performs a blocking `make_reservation` *and* a
+blocking downgrade `.get()` while holding a reserved pool slot. Under FIFO this is partly intended
+— the older query should win — but it stops *dispatch* entirely, so a newer query cannot run even a
+task that needs no new memory.
+
+Move reservation acquisition into the dispatched job, or `make_reservation_or_null` +
+requeue-with-backoff.
+
+> F4 (single FIFO prefetch pipeline) was originally paired here and is **dropped** — a FIFO prefetch
+> queue is consistent with FIFO query order.
+
+---
+
+### Step 11 — Push-drop invariant
+**Closes:** A9
+
+Now a real invariant rather than scaffolding. `multi_index_priority_queue::push` returns false for
+exactly one reason — `_active == false`, set only by `interrupt()`. After steps 1, 3 and 7, the
+remaining `interrupt()` callers are genuine teardown. So:
+
+- **Any push-false for a query the gate reports as `open` is a bug** → `report_error` on that
+  query's completion handler.
+- A push-false for a `quiescing`/`closed` query is the documented teardown contract → debug log
+  only. (`~convertible_gpu_pipeline_task` returning a task to a closed queue is *intended*; a
+  blanket error would fire spuriously.)
+- Sites: `task_creator.cpp:404, 414, 456`; `task_scheduler.cpp:112`.
+  `itask_executor::schedule:61-63` already logs and is the precedent.
+
+Landing this before enablement means that when concurrency is switched on, lost work surfaces as an
+error instead of a hang.
+
+---
+
+### Step 12 — Harness, admission knob, scan pool sizing
+**Closes:** G1 (infra), G2, G3, G6, C3, H4
+
+Everything here is an enablement prerequisite — none of it changes behaviour at N=1, which is why
+it sits here rather than at the front.
+
+- `test/cpp/utils/concurrent_query_harness.hpp`: N connections, release-gate start barrier,
+  per-thread result/exception capture, deadline watchdog. Salvage the primitives from
+  `test_query_lifecycle_slot.cpp`'s anonymous namespace (`wait_for_workers`, `async_query_result`,
+  `scoped_blocking_window_log_sink`, `held_window_threads`) and the fixture-level
+  `make_connection()` from the orphaned `test_transparent_execution.cpp`, then drop that file from
+  the allowlist.
+- Let a test opt out of `shared_env_listener` / `scoped_mgpu_env` env-pausing.
+- Promote `k_max_concurrent_queries` → `scan_manager_config::max_concurrent_queries`, yaml-parsed,
+  **default 1**, pool `num_threads + N`. Reject rather than warn past the cap. At 7 the pool goes
+  9 → 15 threads.
+- Add `sirius_config::max_concurrent_queries` (**default 1**); turn `acquire_query_lifecycle_slot`
+  into a counting semaphore of that size. At 1 the behaviour is bit-identical to today, including
+  the same-thread-reacquire error.
+- Delete the never-locked `SiriusContext::mutex_`.
+
+---
+
+### Step 13 — Turn concurrency on and prove it
+**Closes:** G1 (validation), G4, G5, G7; verifies F1
+
+- Raise the default `max_concurrent_queries` above 1.
+- Un-hide the `[concurrency]` suite; re-express `test_query_lifecycle_slot.cpp`'s serialization
+  assertions against the new semantics; wire up the implemented-but-never-invoked
+  `run_ac13_concurrent_logging`.
+- **Concurrent SQLLogic:** the vendored runner supports `concurrentloop`/`concurrentforeach`, and
+  `ParallelExecuteLoop` constructs a **new `Connection` per parallel iteration** on its own thread
+  against the shared `DatabaseInstance` — exactly the shape needed. Constraints: nested parallel
+  loops are rejected, and every command in the body must return true from `SupportsConcurrent()`.
+  Add a concurrent TPC-H `.test`.
+- Concurrent TPC-H at scale under memory pressure — the case steps 6, 7 and 10 were built for.
+- **Assert FIFO holds:** an older query's tasks are dispatched ahead of a newer query's, and a
+  newer query still completes (no permanent starvation once the older one drains).
+- Full suite under ASan and TSan.
+
+> **This is where unknown-unknowns surface** — the one step whose size cannot be estimated from the
+> register. Budget accordingly. Step 11 is what makes it tractable.
+
+---
+
+### Step 14 — Config safety and hygiene
+**Closes:** D5, E1–E7, F2, F3, F5, F6, F7, F9, H1, H2, H3, H5, H6, H7, H8, H9, H11
+**Split into 4–6 commits; largely parallelisable and independent of the 6→7→8 chain.**
+
+- **Config (E1–E3, E7):** move `operator_params` and the `Config::` static variables into per-`ClientContext`
+  settings (the pattern already used for `enable_duckdb_fallback`), snapshotting by value into the
+  plan at window begin. Guard the genuinely process-wide `LOG_*` trio. Make `original_config` a
+  stack-local RAII.
+- **E4:** `logical_plan_` → `shared_ptr<const LogicalOperator>` + an atomic `copy_unsupported_` latch.
+- **E5, E6:** resolve-or-insert under one `unique_lock` keyed on `(catalog, schema, table)`; atomic
+  packed pair or per-device `call_once` for `get_target_ctas`.
+- **D5:** split `runtime_unavailable_` into "this query is corrupt" vs "the shared runtime is
+  corrupt" — today one query's cleanup failure permanently disables GPU execution process-wide.
+- **F2:** narrow the plan-time `SlotGuard` to a shared read of the pin registry.
+- **F3, F5, F6, F7, F9:** live prefetch-epoch set; per-entry reader count replacing the
+  `use_count() > 1` heuristic; reservation-driven sizing; remove `cudaDeviceSynchronize` and
+  default-stream work; per-query dimension on the cucascade reservation/stream waits.
+- **H8:** widen `query_id_t` to 64-bit, or keep 32-bit and document the wrap — the priority packing
+  masks to 31 bits, so ordering silently inverts at 2³¹ and ids collide with live queries at 2³².
+  With FIFO retained, the packing stays; only its robustness needs deciding.
+- **H:** delete H1, H2, H3, H5, H6, H7, H11; rewrite the five drifted docs and add a doc for the
+  per-query model (H9).
+
+---
+
+## Issue coverage
+
+Every issue in [the register](00-issue-register.md) is closed exactly once. F4 is
+**withdrawn** — a FIFO prefetch pipeline is consistent with FIFO query order — and F1 is reclassified
+from defect to policy, verified in step 13.
+
+| Group | Issue → step |
+|---|---|
+| A | A1·1 A2·1,4 A3·1 A4·1 A5·3 A6·3 A7·7 A8·9 A9·11 A10·1 |
+| B | B1·7 B2·7 B3·6 B4·6 B5·8 B6·8 B7·8 B8·8 B9·6 B10·8 B11·9 |
+| C | C1·3,4 C2·4 C3·12 C4·10 |
+| D | D1·4 D2·4 D3·4 D4·3 D5·14 D6·7 |
+| E | E1–E7·14 |
+| F | F1·policy (verified 13) · F2·14 F3·14 F4·withdrawn F5·14 F6·14 F7·14 F8·7 F9·14 |
+| G | G1·12,13 G2·12 G3·12 G4·13 G5·13 G6·12 G7·13 |
+| H | H1–H3·14 H4·12 H5–H9·14 H10·6 H11·14 |
+
+## Critical path
+
+```
+1 ─► 2 ─► 3 ─► 4 ─► 5 ─► 6 ─► 7 ─► 8 ─► 10 ─► 11 ─► 12 ─► 13
+          ▲     └── 4 before 5: the pool can't hold per-query state while
+          │        the stop/start cycle recreates it
+          │
+          └── 2 before 3: the gate is what replaces the global interrupt
+                          6 before 7: deletion needs shared ownership
+
+     9 ──┘  (independent)              14 ── (independent, splits)
+```
+
+Steps 9 and 14 are off the critical path and can be pulled forward or parallelised. Step 6a
+(cucascade) can start any time and lands on its own cadence.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| A missed gate check in step 2 | Debug-build assertion in every `push()`/`dispatch()` that the query is `open`; grep audit as a review checklist item. Step 11 turns the same condition into a runtime error |
+| Step 5 destabilises four subsystems at once | Lands behind the N=1 default, so production behaviour is unchanged until step 13; extend `test_bounded_thread_pool.cpp` **before** converting call sites |
+| Step 6's `close()` semantics wrong → silent wrong results | `add_data_batch` on a closed repository returns a status the caller must handle; assert-fail in debug; result-correctness test with a forced straggler |
+| cucascade coordination stalls | 6a is independently shippable; if it slips, steps 7–13 proceed with a *narrowed* (per-query) downgrade drain and step 7 is revisited later |
+| FIFO livelock: older query blocked on memory only a newer query would release | Depends on spilling, i.e. steps 6–7. If step 7 slips, re-evaluate the fairness policy |
+| Step 13 surfaces issues not in the register | Step 11 (loud drops) is why this is tractable; run TSan from step 3 onward, not only at 13 |

--- a/docs/concurrency/option-d-recommended.md
+++ b/docs/concurrency/option-d-recommended.md
@@ -92,8 +92,17 @@ still running and a subsequent query completes normally.
 
 ---
 
-### Step 2 — `query_lifecycle_registry`, wired live
-**Closes:** foundation — but observable from day one
+> **Executed note (step 1 → step 2 reordering).** Step 1 deleted the `stop()` calls that used to
+> pre-stop the task_creator, which made `drain_after_error → stop_thread_pool()` race a *live*
+> manager thread and exposed the C1 deadlock — intermittently hanging the full suite in ~3 of 8
+> runs. This plan's own dependency note said *"C1 must be fixed before A5/A6 are exercised, because
+> both call `stop_thread_pool()` today"*, and scheduling C1 for step 4 violated it. **C1 and C2 were
+> therefore pulled forward into step 2 and are no longer part of step 4.** The lesson generalizes:
+> any step that stops pre-stopping a subsystem makes that subsystem's lifecycle races live in the
+> same commit.
+
+### Step 2 — `query_lifecycle_registry`, wired live (+ C1/C2 pulled forward)
+**Closes:** C1, C2 — plus the gate that steps 3 and 7 build on
 
 New `src/include/exec/query_lifecycle_registry.hpp` + `.cpp`. States `open → quiescing → closed`,
 keyed by `query_id_t`, owned by `SiriusContext`. `begin_execution_window` opens;
@@ -146,15 +155,13 @@ Same for A erroring.
 
 ---
 
-### Step 4 — Creator lock ordering, in-flight coverage, lookahead
-**Closes:** C1, C2, D1, D2, D3, self-deadlock half of A2 · **prerequisite for step 5**
+### Step 4 — In-flight coverage and lookahead
+**Closes:** D1, D2, D3, self-deadlock half of A2 · **prerequisite for step 5**
 
-- Split the lifecycle mutex from `_global_state_mutex`; never hold either across
-  `_manager_thread.join()`. Today `stop_thread_pool()` holds `_global_state_mutex` across the join
-  while the manager thread needs that same mutex — a deadlock reachable on every query completion
-  until step 3 removed the caller, and still reachable from `terminate()`.
-- Forbid `stop()` from a pool worker (assert; post a stop request). `stop()` currently bypasses
-  `_global_state_mutex` entirely while `start`/`stop_thread_pool` take it.
+> C1 and C2 (the `_global_state_mutex`-across-`join()` deadlock and the unlocked `stop()`) moved to
+> step 2 — see the note above. `_pool_lifecycle_mutex` already exists.
+
+- Forbid `stop()` from a pool worker (assert; post a stop request).
 - Move `enter_in_flight()` to immediately after the `get_query_task_global_state` lookup, so the
   manager thread's own `get_operator_for_next_task(node)` dereference is inside the counted region.
   Release on every early `continue`. Cover the key extractor's `request.node->type` dereference the
@@ -390,7 +397,7 @@ from defect to policy, verified in step 13.
 |---|---|
 | A | A1·1 A2·1,4 A3·1 A4·1 A5·3 A6·3 A7·7 A8·9 A9·11 A10·1 |
 | B | B1·7 B2·7 B3·6 B4·6 B5·8 B6·8 B7·8 B8·8 B9·6 B10·8 B11·9 |
-| C | C1·3,4 C2·4 C3·12 C4·10 |
+| C | C1·2 C2·2 C3·12 C4·10 |
 | D | D1·4 D2·4 D3·4 D4·3 D5·14 D6·7 |
 | E | E1–E7·14 |
 | F | F1·policy (verified 13) · F2·14 F3·14 F4·withdrawn F5·14 F6·14 F7·14 F8·7 F9·14 |

--- a/docs/super-sirius/pipeline-execution.md
+++ b/docs/super-sirius/pipeline-execution.md
@@ -125,7 +125,7 @@ int target_device_id = _gpu_executors.begin()->first;
 
 That `begin()` is hash-bucket-ordered — but for any single process it returns the *same* GPU on every call. Every preference-less source-pipeline task (metadata scan, parquet scan with no locality hint) piled onto whichever GPU happened to live in the first hash bucket. The implicit-and-undocumented contract was: "default GPU is `_gpu_executors.begin()->first`."
 
-**Phase 14 SCHED-RR change.** Phase 14 replaced the `unordered_map` with a `std::map<int, std::unique_ptr<gpu_pipeline_executor>>` (deterministic ascending-by-`device_id` iteration), added `std::atomic<size_t> _no_pref_rr_counter{0}`, and inserted a round-robin walk in `management_eventloop` that distributes preference-less tasks across all configured GPUs. Source-pipeline tasks now genuinely land on multiple GPUs within a single query — exactly what an N-GPU configuration is supposed to deliver.
+**Phase 14 SCHED-RR change.** Phase 14 made preference-less dispatch distribute across all configured GPUs instead of piling onto whichever executor happened to sit in the first hash bucket. Source-pipeline tasks now genuinely land on multiple GPUs within a single query — exactly what an N-GPU configuration is supposed to deliver. (The original implementation used a round-robin counter; it has since been replaced by the pull-signal matcher described below.)
 
 **The hazard this exposes.** Several operators read `valid_batches[0]->get_memory_space()` (or an equivalent expression on a single input batch) as the authoritative target memory space, then perform their concat/merge/sort directly on that space. Pre-Phase-14, this was *accidentally* safe — every batch in the input vector was already on the implicit "default GPU" because every upstream task was dispatched to that same default. Under SCHED-RR, that accident is gone. If an operator reads `batches[0]->get_memory_space()` without a guarantee that *all* batches in the input vector are colocated on that space, it can silently produce wrong results, mis-allocate, or skip data on the other GPU.
 
@@ -222,50 +222,31 @@ If the batch is already on `target_space`, it is locked in place. If it is on a 
 
 ### The SCHED-RR distribution policy
 
-The contract above is necessary because the scheduler distributes preference-less tasks across multiple GPUs. The distribution policy itself lives in three places.
+The contract above is necessary because the scheduler distributes preference-less tasks across multiple GPUs.
 
-**Storage: deterministic ordering.** `src/include/pipeline/task_scheduler.hpp:224-228`:
-
-```cpp
-/// device_id -> GPU executor. std::map (not unordered_map) so iteration
-/// order is deterministic (ascending by device_id) — keeps preference-less
-/// task dispatch reproducible across runs.
-std::map<int, std::unique_ptr<gpu_pipeline_executor>> _gpu_executors;
-std::atomic<size_t> _no_pref_rr_counter{0};
-```
-
-`std::map` gives an ascending-by-`device_id` iteration order, which makes `_gpu_executors.begin()` deterministic instead of hash-bucket-dependent and makes `std::advance(it, idx)` walk a fixed sequence.
-
-**Per-query reset.** `src/pipeline/task_scheduler.cpp:156-160`, inside `task_scheduler::prepare_for_query`:
+**Pull-signal matching.** Distribution is demand-driven rather than counter-driven. A
+`gpu_pipeline_executor`'s manager loop reserves a worker slot and then publishes a `device_ready`
+signal; `task_scheduler::management_eventloop` matches each ready device against the task queue:
 
 ```cpp
-// Reset SCHED-RR counter so the round-robin walk is reproducible across
-// iterations of the same query (cache=table_gpu warm path keys cache
-// entries by device_id; without this reset the second iteration's source
-// tasks would assign to a different GPU and miss the cache entries).
-_no_pref_rr_counter.store(0, std::memory_order_relaxed);
-```
-
-The reset is mandatory for `cache=table_gpu` warm-path correctness. Without it, iteration `N+1` of the same query would dispatch preference-less source tasks to a different starting GPU than iteration `N`, missing the per-device cache populated on iteration `N`. Phase 13 follow-up #17 scale-up test is the regression gate that locks this behavior in.
-
-**Per-task round-robin walk.** `src/pipeline/task_scheduler.cpp:259-265`, inside `management_eventloop`:
-
-```cpp
-if (!have_pref && _gpu_executors.size() > 1) {
-  auto idx = _no_pref_rr_counter.fetch_add(1, std::memory_order_relaxed) %
-             _gpu_executors.size();
-  auto it = _gpu_executors.begin();
-  std::advance(it, idx);
-  target_device_id = it->first;
+// Exact preference match first: the highest-priority task preferring this device.
+task = _task_queue.try_pop_from(exec::gpu_index{device_id}).value_or(nullptr);
+if (!task) {
+  // Otherwise any task with no preference.
+  task = _task_queue.try_pop_from(exec::gpu_index{exec::no_preferred_device}).value_or(nullptr);
 }
 ```
 
-The walk is gated on `!have_pref && _gpu_executors.size() > 1` so two configurations stay untouched:
+Preference-less tasks live in the `no_preferred_device` bucket of the
+`multi_index_priority_queue`, so the GPU that serves one is simply whichever executor signalled
+ready first. That is self-balancing — a GPU that finishes its work sooner asks for more sooner —
+and it needs no shared counter, which is what makes it safe when several queries are in flight.
 
-- **1-GPU configurations.** The single executor is always picked by the line just above this block (`int target_device_id = _gpu_executors.begin()->first;`).
-- **Preference-bearing tasks.** `SCHED-01/02/04` tasks (data-locality-bearing, e.g. downstream pipeline tasks consuming a specific repository) keep their `preferred_device_id` and skip the round-robin walk entirely. Locality is preserved.
+Tasks that *do* carry a `preferred_device_id` (`SCHED-01/02/04`, e.g. downstream pipeline tasks
+consuming a specific repository) only ever match their own device, so locality is preserved.
+Single-GPU configurations are unaffected: there is one executor, so every ready signal comes from
+it.
 
-Only *preference-less* source-pipeline tasks (metadata scans, parquet scans with no upstream locality) round-robin across GPUs.
 
 ### Migration note (Phase 14)
 
@@ -279,7 +260,7 @@ Three pieces of evidence corroborate that the contract holds for every currently
 
 - **Phase 14 ship-validation** — `[mgpu]` 12/13 PASS, `[TPC-H][parquet]` 22/22 PASS, `[integration][TPC-H]` 48/48 PASS (71608 assertions). The single `[mgpu]` fail is the Phase-12-territory `physical_order - small sort stays single-GPU` `vector::_M_range_check`, fixed on `fix/order-small-sort-rangecheck` and unrelated to operator colocation.
 - **Phase 15 Wave 1 audit** — All 11 operator sites that read `valid_batches[0]->get_memory_space()` (or equivalent) are classified `SAFE` based on upstream-trace through `gpu_pipeline_task::execute -> pipelineable_operator_data::prepare_for_processing -> lock_or_prepare_batch`. See [`.planning/phases/15-mgpu-operator-colocation-audit/15-AUDIT-LOG.md`](../../.planning/phases/15-mgpu-operator-colocation-audit/15-AUDIT-LOG.md) for the per-site classification table and justification.
-- **Phase 15 Wave 2 stress test** — `test/cpp/operator/test_mgpu_stress.cpp` exercises five representative `[mgpu]` queries under 100 distinct `_no_pref_rr_counter` starting offsets (500 inner runs, 77053 assertions), each asserting CPU baseline match via `require_gpu_matches_cpu`. PASS in 86.6s on `2 × RTX 6000 Ada`. Catches hash-bucket-order-dependent bugs and any latent off-by-one that a counter-always-starts-at-0 test would mask.
+- **Phase 15 Wave 2 stress test** — `test/cpp/operator/test_mgpu_stress.cpp` exercises five representative `[mgpu]` queries over 100 iterations (500 inner runs, 77053 assertions), each asserting CPU baseline match via `require_gpu_matches_cpu`. PASS in 86.6s on `2 × RTX 6000 Ada`. Because the serving GPU is decided by which executor signals ready first, repeating each query this many times samples both assignments and catches an operator that is only correct on one of them.
 
 ### For new operator authors
 

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -84,13 +84,13 @@ task_creator::task_creator(task_creator_config config,
 
 task_creator::~task_creator() { stop(); }
 
-void task_creator::query_task_state::enter_in_flight()
+void task_creator::query_task_global_state::enter_in_flight()
 {
   std::lock_guard<std::mutex> lock(in_flight_mutex);
   ++in_flight;
 }
 
-void task_creator::query_task_state::leave_in_flight()
+void task_creator::query_task_global_state::leave_in_flight()
 {
   {
     std::lock_guard<std::mutex> lock(in_flight_mutex);
@@ -100,18 +100,18 @@ void task_creator::query_task_state::leave_in_flight()
   in_flight_cv.notify_all();
 }
 
-void task_creator::query_task_state::wait_for_in_flight()
+void task_creator::query_task_global_state::wait_for_in_flight()
 {
   std::unique_lock<std::mutex> lock(in_flight_mutex);
   in_flight_cv.wait(lock, [this] { return in_flight == 0; });
 }
 
-std::shared_ptr<task_creator::query_task_state> task_creator::get_query_state(
+std::shared_ptr<task_creator::query_task_global_state> task_creator::get_query_task_global_state(
   sirius::query_id_t query_id) const
 {
   std::lock_guard<std::mutex> lock(_global_state_mutex);
-  auto it = _query_states.find(query_id);
-  return it == _query_states.end() ? nullptr : it->second;
+  auto it = _query_task_global_states.find(query_id);
+  return it == _query_task_global_states.end() ? nullptr : it->second;
 }
 
 void task_creator::set_client_context(sirius::query_id_t query_id,
@@ -120,8 +120,8 @@ void task_creator::set_client_context(sirius::query_id_t query_id,
   std::lock_guard<std::mutex> lock(_global_state_mutex);
   // The window begins before the plan exists, so this is where the query's entry is created;
   // prepare_for_query then fills in the pipeline global states.
-  auto& state = _query_states[query_id];
-  if (!state) { state = std::make_shared<query_task_state>(); }
+  auto& state = _query_task_global_states[query_id];
+  if (!state) { state = std::make_shared<query_task_global_state>(); }
   state->client_context = std::addressof(client_context);
 }
 
@@ -135,7 +135,7 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
 {
   const auto query_id = query.query_id();
 
-  auto state = get_query_state(query_id);
+  auto state = get_query_task_global_state(query_id);
   if (!state) {
     throw sirius::internal_exception(
       "task_creator::prepare_for_query: no state registered for query {}; "
@@ -264,7 +264,7 @@ void task_creator::drain_pending_tasks(sirius::query_id_t query_id)
   _task_creation_queue.drain(
     exec::query_index{static_cast<exec::query_key>(sirius::value_of(query_id))});
 
-  auto state = get_query_state(query_id);
+  auto state = get_query_task_global_state(query_id);
   if (!state) { return; }
 
   // Wait out this query's in-flight creation lambdas — the per-query stand-in for
@@ -285,13 +285,13 @@ void task_creator::reset(sirius::query_id_t query_id)
   // dereference them, so both must be gone before the caller destroys planner::query.
   drain_pending_tasks(query_id);
 
-  std::shared_ptr<query_task_state> state;
+  std::shared_ptr<query_task_global_state> state;
   {
     std::lock_guard<std::mutex> lock(_global_state_mutex);
-    auto it = _query_states.find(query_id);
-    if (it == _query_states.end()) { return; }
+    auto it = _query_task_global_states.find(query_id);
+    if (it == _query_task_global_states.end()) { return; }
     state = std::move(it->second);
-    _query_states.erase(it);
+    _query_task_global_states.erase(it);
   }
   // `state` is released here, outside the lock. Any worker that resolved it before the erase
   // still holds its own shared_ptr and finishes safely against a map that no longer lists it.
@@ -302,8 +302,8 @@ void task_creator::reset_all()
   std::vector<sirius::query_id_t> query_ids;
   {
     std::lock_guard<std::mutex> lock(_global_state_mutex);
-    query_ids.reserve(_query_states.size());
-    for (const auto& [query_id, state] : _query_states) {
+    query_ids.reserve(_query_task_global_states.size());
+    for (const auto& [query_id, state] : _query_task_global_states) {
       query_ids.push_back(query_id);
     }
   }
@@ -414,7 +414,7 @@ void task_creator::schedule_lookahead(sirius::query_id_t query_id,
                                       std::optional<int> device_id_hint)
 {
   if (_config.strategy != request_type::lookahead) { return; }
-  auto state = get_query_state(query_id);
+  auto state = get_query_task_global_state(query_id);
   if (!state) { return; }
 
   std::lock_guard lock(state->lookahead_mutex);
@@ -468,7 +468,7 @@ void task_creator::manager_loop()
     // then reads global_states (immutable after prepare_for_query) with no lock and no risk of
     // the map being rehashed or erased underneath it: its own reference keeps the state alive
     // even if reset(query_id) removes the registry entry mid-flight.
-    auto query_state = get_query_state(query_id);
+    auto query_state = get_query_task_global_state(query_id);
     if (!query_state) {
       // The query was reset while this request sat in the queue (finished, or failed and was
       // cleaned up). Dropping it is the correct outcome — `node` may already be dangling.
@@ -488,7 +488,7 @@ void task_creator::manager_loop()
         // Released on every exit path, including the catch below, so a throwing creation can
         // never strand drain_pending_tasks() waiting forever.
         struct in_flight_guard {
-          const std::shared_ptr<query_task_state>& state;
+          const std::shared_ptr<query_task_global_state>& state;
           ~in_flight_guard() { state->leave_in_flight(); }
         } guard{query_state};
         try {

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -86,28 +86,6 @@ task_creator::task_creator(task_creator_config config,
 
 task_creator::~task_creator() { stop(); }
 
-void task_creator::query_task_global_state::enter_in_flight()
-{
-  std::lock_guard<std::mutex> lock(in_flight_mutex);
-  ++in_flight;
-}
-
-void task_creator::query_task_global_state::leave_in_flight()
-{
-  {
-    std::lock_guard<std::mutex> lock(in_flight_mutex);
-    --in_flight;
-    if (in_flight != 0) { return; }
-  }
-  in_flight_cv.notify_all();
-}
-
-void task_creator::query_task_global_state::wait_for_in_flight()
-{
-  std::unique_lock<std::mutex> lock(in_flight_mutex);
-  in_flight_cv.wait(lock, [this] { return in_flight == 0; });
-}
-
 std::shared_ptr<task_creator::query_task_global_state> task_creator::get_query_task_global_state(
   sirius::query_id_t query_id) const
 {
@@ -273,10 +251,12 @@ void task_creator::drain_pending_tasks(sirius::query_id_t query_id)
   auto state = get_query_task_global_state(query_id);
   if (!state) { return; }
 
-  // Wait out this query's in-flight creation lambdas — the per-query stand-in for
-  // _bounded_pool->wait_all(), which would also wait on every other query's work. Workers
-  // decrement on exit (including by exception), so this cannot hang on a throwing lambda.
-  state->wait_for_in_flight();
+  // Wait out this query's in-flight creation work. The pool tracks it per query via the slot
+  // attached in manager_loop, so this waits on THIS query only — never on a co-tenant's lambda,
+  // and never on the manager thread's own idle reservation, which carries no query. Slots are
+  // released by RAII on every exit path including an exception, so a throwing creation lambda
+  // cannot strand this wait.
+  if (_bounded_pool) { _bounded_pool->drain_and_wait(query_id); }
 
   // Clear lookahead state so any schedule_lookahead() racing with query teardown finds an
   // empty queue and exits cleanly instead of dereferencing operators that are about to die.
@@ -535,42 +515,28 @@ void task_creator::manager_loop()
       continue;
     }
 
-    // Enter the counted region BEFORE touching `node` again.
+    // Attribute the slot to this query BEFORE touching `node` again.
     //
     // get_operator_for_next_task() dereferences the operator (recursively, via
-    // get_next_task_hint()) on THIS thread. Counting only from just before dispatch left that
-    // dereference outside the window, so drain_pending_tasks(query_id) could observe
-    // in_flight == 0 and return while the manager thread was still walking the query's operators
-    // — a hole in the exact invariant the counter exists to provide, and the caller's next act is
-    // to let the plan be destroyed.
+    // get_next_task_hint()) on THIS thread. Attaching only just before dispatch would leave that
+    // dereference outside the counted region, so drain_pending_tasks(query_id) could return while
+    // the manager was still walking the query's operators — and the caller's next act is to let
+    // the plan be destroyed.
     //
-    // Released here on every early exit; on the dispatch path ownership passes to the worker's
-    // in_flight_guard, so the count is entered once and left once.
-    query_state->enter_in_flight();
-    bool dispatched = false;
-    struct manager_in_flight_guard {
-      const std::shared_ptr<query_task_global_state>& state;
-      const bool& dispatched;
-      ~manager_in_flight_guard()
-      {
-        if (!dispatched) { state->leave_in_flight(); }
-      }
-    } manager_guard{query_state, dispatched};
+    // The slot's own RAII covers every exit: an early `continue` below destroys it and decrements
+    // the query's count; the dispatch path moves it into the worker, which releases it when the
+    // creation lambda returns. Entered once, left once, with no separate bookkeeping to keep in
+    // sync. (Attribution cannot happen at reserve() time: the manager reserves before it knows
+    // which query it will serve, and an idle manager must not be counted against anyone.)
+    slot.attach(query_id);
 
     node = get_operator_for_next_task(node);
 
     if (node == nullptr) { continue; }
 
-    dispatched = true;
     // Dispatch the task creation work to the pool
     _bounded_pool->dispatch(
       std::move(slot), [this, node, request_kind, query_state = std::move(query_state)]() mutable {
-        // Released on every exit path, including the catch below, so a throwing creation can
-        // never strand drain_pending_tasks() waiting forever.
-        struct in_flight_guard {
-          const std::shared_ptr<query_task_global_state>& state;
-          ~in_flight_guard() { state->leave_in_flight(); }
-        } guard{query_state};
         // Scoped marker so task_creator::stop() can assert it is never called from here.
         struct worker_marker {
           worker_marker() { t_in_creation_worker = true; }

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -339,13 +339,17 @@ op::sirius_physical_operator* task_creator::get_operator_for_next_task(
 
 void task_creator::stop()
 {
+  // Takes the same mutex as start/stop_thread_pool. Without it, a stop() racing a
+  // start_thread_pool() could reassign _bounded_pool and _manager_thread while the other thread
+  // was inside do_stop_thread_pool() joining them.
+  std::lock_guard<std::mutex> lock(_pool_lifecycle_mutex);
   _task_creation_queue.interrupt();
   do_stop_thread_pool();
 }
 
 void task_creator::start_thread_pool()
 {
-  std::lock_guard<std::mutex> lock(_global_state_mutex);
+  std::lock_guard<std::mutex> lock(_pool_lifecycle_mutex);
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
   // Re-arm the request queue. stop_thread_pool() calls
@@ -374,7 +378,7 @@ void task_creator::do_stop_thread_pool()
 
 void task_creator::stop_thread_pool()
 {
-  std::lock_guard<std::mutex> lock(_global_state_mutex);
+  std::lock_guard<std::mutex> lock(_pool_lifecycle_mutex);
   do_stop_thread_pool();
 }
 
@@ -397,21 +401,33 @@ std::pair<sirius::query_id_t, exec::queue_priority> request_keys_for(
 void task_creator::schedule(op::sirius_physical_operator* node)
 {
   const auto [query_id, priority] = request_keys_for(node);
-  auto request                    = std::make_unique<task_creation_request>();
-  request->node                   = node;
-  request->query_id               = query_id;
-  request->priority               = priority;
+  // Most calls here come from a completion callback (notify_downstream_pipelines, or the GPU
+  // executor scheduling a finished task's consumers). If the query is tearing down, `node` points
+  // into a plan that is about to be destroyed and a drain has very likely already passed this
+  // queue — so refuse rather than enqueue. Previously this was achieved by interrupting the
+  // queue, which refused EVERY query's pushes at once.
+  if (!accepts_work(query_id)) { return; }
+  auto request      = std::make_unique<task_creation_request>();
+  request->node     = node;
+  request->query_id = query_id;
+  request->priority = priority;
   _task_creation_queue.push(std::move(request));
 }
 
 void task_creator::schedule(op::sirius_physical_operator* node, sirius::query_id_t query_id)
 {
+  if (!accepts_work(query_id)) { return; }
   const auto [_, priority] = request_keys_for(node);
   auto request             = std::make_unique<task_creation_request>();
   request->node            = node;
   request->query_id        = query_id;
   request->priority        = priority;
   _task_creation_queue.push(std::move(request));
+}
+
+bool task_creator::accepts_work(sirius::query_id_t query_id) const noexcept
+{
+  return _query_lifecycle == nullptr || _query_lifecycle->accepts_work(query_id);
 }
 
 void task_creator::schedule_lookahead(std::optional<int> device_id_hint)
@@ -431,6 +447,9 @@ void task_creator::schedule_lookahead(std::optional<int> device_id_hint)
     state    = it->second;
   }
   if (!state) { return; }
+  // The oldest entry can be a query that has finished and is mid-cleanup but whose state has not
+  // been dropped yet. Warming it up would dereference operators of a plan that is already gone.
+  if (!accepts_work(query_id)) { return; }
 
   std::lock_guard lock(state->lookahead_mutex);
   for (; state->index_of_next_lookahead < state->lookahead_queue.size();

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -131,7 +131,8 @@ void task_creator::set_task_scheduler(sirius::pipeline::task_scheduler& task_sch
   _task_scheduler = &task_scheduler;
 }
 
-void task_creator::prepare_for_query(const sirius::planner::query& query)
+void task_creator::prepare_for_query(const sirius::planner::query& query,
+                                     std::shared_ptr<pipeline::completion_handler> handler)
 {
   const auto query_id = query.query_id();
 
@@ -150,6 +151,8 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
   std::shared_ptr<const telemetry::telemetry_context> telemetry_context =
     sirius_ctx->get_telemetry_context();
 
+  state->completion_handler = handler;
+
   auto pipeline_priorities = compute_pipeline_priorities(query);
 
   // Filled once, here, and never mutated afterwards: task-creation workers read it without a
@@ -165,6 +168,7 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
     size_t operator_id = source_operator->get_operator_id();
     auto gs =
       std::make_shared<pipeline::gpu_pipeline_task_global_state>(pipeline, telemetry_context);
+    gs->set_completion_handler(handler);
     if (auto it = pipeline_priorities.find(pipeline.get()); it != pipeline_priorities.end()) {
       gs->set_priority(it->second);
       // Mirror it onto the pipeline so schedule() can key a request without locking.
@@ -410,11 +414,22 @@ void task_creator::schedule(op::sirius_physical_operator* node, sirius::query_id
   _task_creation_queue.push(std::move(request));
 }
 
-void task_creator::schedule_lookahead(sirius::query_id_t query_id,
-                                      std::optional<int> device_id_hint)
+void task_creator::schedule_lookahead(std::optional<int> device_id_hint)
 {
   if (_config.strategy != request_type::lookahead) { return; }
-  auto state = get_query_task_global_state(query_id);
+
+  // Select the first query, which is the implicit FIFO priority.
+  // TODO: Will want to revisit this, to have lookahead be able to schedule lookahead for the
+  // following query as well if needed.
+  sirius::query_id_t query_id{};
+  std::shared_ptr<query_task_global_state> state;
+  {
+    std::lock_guard<std::mutex> lock(_global_state_mutex);
+    if (_query_task_global_states.empty()) { return; }
+    auto it  = _query_task_global_states.begin();
+    query_id = it->first;
+    state    = it->second;
+  }
   if (!state) { return; }
 
   std::lock_guard lock(state->lookahead_mutex);
@@ -672,7 +687,8 @@ void task_creator::manager_loop()
           pipeline->update_pipeline_status(false);
         } catch (const std::exception& e) {
           SIRIUS_LOG_ERROR("Task Creator: Exception during task creation: {}", e.what());
-          _task_scheduler->terminate_query(std::current_exception());
+          _task_scheduler->terminate_query(query_state->completion_handler,
+                                           std::current_exception());
           stop();
         }
       });

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -33,6 +33,7 @@
 #include <duckdb/parallel/thread_context.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <limits>
 #include <mutex>
 #include <optional>
@@ -51,15 +52,16 @@ task_creator::task_creator(task_creator_config config,
   : _running(false),
     _config(std::move(config)),
     _task_creation_queue([](const task_creation_request& request) -> exec::index_keys {
-      // The request carries its own keys: they are resolved at schedule() time, where the
-      // node's pipeline (and therefore its query and priority) is unambiguously alive. The
-      // query key is what makes drain(query_index{...}) able to drop one query's pending
-      // requests and leave every other query's in place.
-      return exec::index_keys{
-        request.priority,
-        request.node != nullptr ? request.node->type : op::SiriusPhysicalOperatorType::INVALID,
-        static_cast<exec::query_key>(sirius::value_of(request.query_id)),
-        request.device_id};
+      // The request carries ALL of its own keys, resolved at schedule() time where the node's
+      // pipeline (and therefore its query, priority and type) is unambiguously alive. Nothing
+      // here dereferences `node`: this runs inside the queue mutex on every push, and reading a
+      // freed operator there would corrupt the index of a queue every query shares. The query key
+      // is what makes drain(query_index{...}) able to drop one query's pending requests and leave
+      // every other query's in place.
+      return exec::index_keys{request.priority,
+                              request.operator_type,
+                              static_cast<exec::query_key>(sirius::value_of(request.query_id)),
+                              request.device_id};
     }),
     _mem_res_mgr(mem_res_mgr),
     _topology_index(std::move(topology_index))
@@ -337,8 +339,24 @@ op::sirius_physical_operator* task_creator::get_operator_for_next_task(
   return nullptr;
 }
 
+namespace {
+//! Set for the duration of a creation-worker lambda, so stop() can assert it is not being called
+//! from inside its own pool (see task_creator::stop).
+thread_local bool t_in_creation_worker = false;
+}  // namespace
+
+bool task_creator::is_pool_worker_thread() { return t_in_creation_worker; }
+
 void task_creator::stop()
 {
+  // Calling this from a creation worker is a guaranteed self-deadlock: do_stop_thread_pool()
+  // calls _bounded_pool->wait_all(), which blocks until active_ == 0, but the calling worker IS
+  // an active slot. If it somehow got past, _bounded_pool.reset() would join the calling thread
+  // with itself inside a noexcept function. The rogue call sites that did this are gone; assert
+  // so a new one is caught in a debug build rather than hanging CI.
+  assert(!is_pool_worker_thread() &&
+         "task_creator::stop() must not be called from one of its own pool workers");
+
   // Takes the same mutex as start/stop_thread_pool. Without it, a stop() racing a
   // start_thread_pool() could reassign _bounded_pool and _manager_thread while the other thread
   // was inside do_stop_thread_pool() joining them.
@@ -407,10 +425,11 @@ void task_creator::schedule(op::sirius_physical_operator* node)
   // queue — so refuse rather than enqueue. Previously this was achieved by interrupting the
   // queue, which refused EVERY query's pushes at once.
   if (!accepts_work(query_id)) { return; }
-  auto request      = std::make_unique<task_creation_request>();
-  request->node     = node;
-  request->query_id = query_id;
-  request->priority = priority;
+  auto request           = std::make_unique<task_creation_request>();
+  request->node          = node;
+  request->query_id      = query_id;
+  request->priority      = priority;
+  request->operator_type = node->type;
   _task_creation_queue.push(std::move(request));
 }
 
@@ -422,6 +441,7 @@ void task_creator::schedule(op::sirius_physical_operator* node, sirius::query_id
   request->node            = node;
   request->query_id        = query_id;
   request->priority        = priority;
+  request->operator_type   = node->type;
   _task_creation_queue.push(std::move(request));
 }
 
@@ -441,15 +461,20 @@ void task_creator::schedule_lookahead(std::optional<int> device_id_hint)
   std::shared_ptr<query_task_global_state> state;
   {
     std::lock_guard<std::mutex> lock(_global_state_mutex);
-    if (_query_task_global_states.empty()) { return; }
-    auto it  = _query_task_global_states.begin();
-    query_id = it->first;
-    state    = it->second;
+    // Oldest-first, matching the FIFO scheduling policy — but SKIPPING queries that are no longer
+    // accepting work rather than giving up on the first one. The oldest entry is routinely a
+    // query that has finished and is mid-cleanup but whose state has not been dropped yet:
+    // warming it up would dereference operators of a plan that is already gone, and bailing out
+    // entirely would starve every younger query of lookahead for the whole cleanup window.
+    for (auto& [id, candidate] : _query_task_global_states) {
+      if (candidate && accepts_work(id)) {
+        query_id = id;
+        state    = candidate;
+        break;
+      }
+    }
   }
   if (!state) { return; }
-  // The oldest entry can be a query that has finished and is mid-cleanup but whose state has not
-  // been dropped yet. Warming it up would dereference operators of a plan that is already gone.
-  if (!accepts_work(query_id)) { return; }
 
   std::lock_guard lock(state->lookahead_mutex);
   for (; state->index_of_next_lookahead < state->lookahead_queue.size();
@@ -472,6 +497,7 @@ void task_creator::schedule_lookahead(std::optional<int> device_id_hint)
       request->query_id        = query_id;
       request->priority        = priority;
       request->device_id       = device_id_hint.value_or(exec::no_preferred_device);
+      request->operator_type   = node->type;
       _task_creation_queue.push(std::move(request));
       ++state->index_of_next_lookahead;
       return;
@@ -509,13 +535,33 @@ void task_creator::manager_loop()
       continue;
     }
 
+    // Enter the counted region BEFORE touching `node` again.
+    //
+    // get_operator_for_next_task() dereferences the operator (recursively, via
+    // get_next_task_hint()) on THIS thread. Counting only from just before dispatch left that
+    // dereference outside the window, so drain_pending_tasks(query_id) could observe
+    // in_flight == 0 and return while the manager thread was still walking the query's operators
+    // — a hole in the exact invariant the counter exists to provide, and the caller's next act is
+    // to let the plan be destroyed.
+    //
+    // Released here on every early exit; on the dispatch path ownership passes to the worker's
+    // in_flight_guard, so the count is entered once and left once.
+    query_state->enter_in_flight();
+    bool dispatched = false;
+    struct manager_in_flight_guard {
+      const std::shared_ptr<query_task_global_state>& state;
+      const bool& dispatched;
+      ~manager_in_flight_guard()
+      {
+        if (!dispatched) { state->leave_in_flight(); }
+      }
+    } manager_guard{query_state, dispatched};
+
     node = get_operator_for_next_task(node);
 
     if (node == nullptr) { continue; }
 
-    // Counted before dispatch so drain_pending_tasks(query_id) cannot observe zero in-flight
-    // while this task creation is still queued to run.
-    query_state->enter_in_flight();
+    dispatched = true;
     // Dispatch the task creation work to the pool
     _bounded_pool->dispatch(
       std::move(slot), [this, node, request_kind, query_state = std::move(query_state)]() mutable {
@@ -525,6 +571,11 @@ void task_creator::manager_loop()
           const std::shared_ptr<query_task_global_state>& state;
           ~in_flight_guard() { state->leave_in_flight(); }
         } guard{query_state};
+        // Scoped marker so task_creator::stop() can assert it is never called from here.
+        struct worker_marker {
+          worker_marker() { t_in_creation_worker = true; }
+          ~worker_marker() { t_in_creation_worker = false; }
+        } marker;
         try {
           // Get what we need to create the task
           auto pipeline = node->get_pipeline();

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -410,7 +410,7 @@ void task_creator::schedule(op::sirius_physical_operator* node)
   request->query_id      = query_id;
   request->priority      = priority;
   request->operator_type = node->type;
-  _task_creation_queue.push(std::move(request));
+  report_if_dropped(_task_creation_queue.push(std::move(request)), query_id);
 }
 
 void task_creator::schedule(op::sirius_physical_operator* node, sirius::query_id_t query_id)
@@ -422,7 +422,28 @@ void task_creator::schedule(op::sirius_physical_operator* node, sirius::query_id
   request->query_id        = query_id;
   request->priority        = priority;
   request->operator_type   = node->type;
-  _task_creation_queue.push(std::move(request));
+  report_if_dropped(_task_creation_queue.push(std::move(request)), query_id);
+}
+
+void task_creator::report_if_dropped(bool pushed, sirius::query_id_t query_id) const
+{
+  if (pushed) { return; }
+  // multi_index_priority_queue::push returns false for exactly one reason: the queue is
+  // interrupted, i.e. shutting down. For a query the gate still reports as accepting work that is
+  // a genuine loss -- the request is destroyed, its pipeline never gets its task, and the query
+  // waits on a completion that can never arrive. Silence here is what turned every dropped-work
+  // bug in this subsystem into an unexplained hang.
+  //
+  // For a quiescing/closed query the drop is the documented teardown contract, not a bug.
+  if (accepts_work(query_id)) {
+    SIRIUS_LOG_ERROR(
+      "task_creator: creation request for query {} was DROPPED by an interrupted queue while the "
+      "query was still accepting work; that query will not receive the task it was waiting for",
+      query_id);
+  } else {
+    SIRIUS_LOG_DEBUG("task_creator: dropped a creation request for tearing-down query {}",
+                     query_id);
+  }
 }
 
 bool task_creator::accepts_work(sirius::query_id_t query_id) const noexcept
@@ -478,7 +499,7 @@ void task_creator::schedule_lookahead(std::optional<int> device_id_hint)
       request->priority        = priority;
       request->device_id       = device_id_hint.value_or(exec::no_preferred_device);
       request->operator_type   = node->type;
-      _task_creation_queue.push(std::move(request));
+      report_if_dropped(_task_creation_queue.push(std::move(request)), query_id);
       ++state->index_of_next_lookahead;
       return;
     }

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -50,6 +50,17 @@ task_creator::task_creator(task_creator_config config,
                            std::shared_ptr<const sirius::memory::topology_index> topology_index)
   : _running(false),
     _config(std::move(config)),
+    _task_creation_queue([](const task_creation_request& request) -> exec::index_keys {
+      // The request carries its own keys: they are resolved at schedule() time, where the
+      // node's pipeline (and therefore its query and priority) is unambiguously alive. The
+      // query key is what makes drain(query_index{...}) able to drop one query's pending
+      // requests and leave every other query's in place.
+      return exec::index_keys{
+        request.priority,
+        request.node != nullptr ? request.node->type : op::SiriusPhysicalOperatorType::INVALID,
+        static_cast<exec::query_key>(sirius::value_of(request.query_id)),
+        request.device_id};
+    }),
     _mem_res_mgr(mem_res_mgr),
     _topology_index(std::move(topology_index))
 {
@@ -73,13 +84,45 @@ task_creator::task_creator(task_creator_config config,
 
 task_creator::~task_creator() { stop(); }
 
-void task_creator::set_client_context(::duckdb::ClientContext& client_context)
+void task_creator::query_task_state::enter_in_flight()
+{
+  std::lock_guard<std::mutex> lock(in_flight_mutex);
+  ++in_flight;
+}
+
+void task_creator::query_task_state::leave_in_flight()
+{
+  {
+    std::lock_guard<std::mutex> lock(in_flight_mutex);
+    --in_flight;
+    if (in_flight != 0) { return; }
+  }
+  in_flight_cv.notify_all();
+}
+
+void task_creator::query_task_state::wait_for_in_flight()
+{
+  std::unique_lock<std::mutex> lock(in_flight_mutex);
+  in_flight_cv.wait(lock, [this] { return in_flight == 0; });
+}
+
+std::shared_ptr<task_creator::query_task_state> task_creator::get_query_state(
+  sirius::query_id_t query_id) const
 {
   std::lock_guard<std::mutex> lock(_global_state_mutex);
-  _client_context = std::addressof(client_context);
-  _thread_context = std::make_unique<duckdb::ThreadContext>(client_context);
-  _execution_context =
-    std::make_unique<duckdb::ExecutionContext>(client_context, *_thread_context, nullptr);
+  auto it = _query_states.find(query_id);
+  return it == _query_states.end() ? nullptr : it->second;
+}
+
+void task_creator::set_client_context(sirius::query_id_t query_id,
+                                      ::duckdb::ClientContext& client_context)
+{
+  std::lock_guard<std::mutex> lock(_global_state_mutex);
+  // The window begins before the plan exists, so this is where the query's entry is created;
+  // prepare_for_query then fills in the pipeline global states.
+  auto& state = _query_states[query_id];
+  if (!state) { state = std::make_shared<query_task_state>(); }
+  state->client_context = std::addressof(client_context);
 }
 
 void task_creator::set_task_scheduler(sirius::pipeline::task_scheduler& task_scheduler)
@@ -90,19 +133,28 @@ void task_creator::set_task_scheduler(sirius::pipeline::task_scheduler& task_sch
 
 void task_creator::prepare_for_query(const sirius::planner::query& query)
 {
-  std::lock_guard<std::mutex> lock(_global_state_mutex);
+  const auto query_id = query.query_id();
 
-  _gpu_operator_global_state_map.clear();
+  auto state = get_query_state(query_id);
+  if (!state) {
+    throw sirius::internal_exception(
+      "task_creator::prepare_for_query: no state registered for query {}; "
+      "set_client_context must run first (execution-window begin)",
+      query_id);
+  }
 
   const auto& pipelines = query.get_pipelines();
 
   auto* sirius_ctx =
-    _client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state").get();
+    state->client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state").get();
   std::shared_ptr<const telemetry::telemetry_context> telemetry_context =
     sirius_ctx->get_telemetry_context();
 
   auto pipeline_priorities = compute_pipeline_priorities(query);
 
+  // Filled once, here, and never mutated afterwards: task-creation workers read it without a
+  // lock, holding only their shared_ptr to this state. Note the map is NOT cleared — other
+  // queries own their own entries, and this one is brand new.
   for (const auto& pipeline : pipelines) {
     pipeline->set_task_creator(this);
     auto source_operator = pipeline->get_source();
@@ -115,18 +167,20 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
       std::make_shared<pipeline::gpu_pipeline_task_global_state>(pipeline, telemetry_context);
     if (auto it = pipeline_priorities.find(pipeline.get()); it != pipeline_priorities.end()) {
       gs->set_priority(it->second);
+      // Mirror it onto the pipeline so schedule() can key a request without locking.
+      pipeline->set_priority(it->second);
     }
-    _gpu_operator_global_state_map.emplace(operator_id, std::move(gs));
+    state->global_states.emplace(operator_id, std::move(gs));
   }
 
-  std::lock_guard<std::mutex> lookahead_lock(_lookahead_mutex);
-  _lookahead_queue.clear();
-  auto scan_operators      = query.get_scan_operators();
-  _index_of_next_lookahead = 0;
+  std::lock_guard<std::mutex> lookahead_lock(state->lookahead_mutex);
+  state->lookahead_queue.clear();
+  auto scan_operators            = query.get_scan_operators();
+  state->index_of_next_lookahead = 0;
   if (!scan_operators.empty()) {
     auto begin = scan_operators.begin() + 1;
     for (auto it = begin; it != scan_operators.end(); ++it) {
-      _lookahead_queue.push_back(*it);
+      state->lookahead_queue.push_back(*it);
     }
   }
 }
@@ -203,43 +257,58 @@ task_creator::compute_pipeline_priorities(const sirius::planner::query& query) c
   return priorities;
 }
 
-void task_creator::drain_pending_tasks()
+void task_creator::drain_pending_tasks(sirius::query_id_t query_id)
 {
-  std::lock_guard<std::mutex> lock(_global_state_mutex);
-  // Drain any queued task creation requests that haven't been picked up yet
-  _task_creation_queue.interrupt();
-  _task_creation_queue.drain();
-  // Wait for any in-flight task creation lambdas to finish. When called from
-  // task_scheduler::drain_after_error(), stop_thread_pool() has already joined
-  // the worker pool and reset _bounded_pool to null — in that case the pool's
-  // own destructor already drained in-flight work, so this wait_all is
-  // redundant. Dereferencing the null pointer here throws std::system_error
-  // (EPERM) from the pthread_mutex call on garbage memory, surfacing to the
-  // caller as "Operation not permitted" and breaking otherwise-successful
-  // multi-file SF1000 scans.
-  if (_bounded_pool) { _bounded_pool->wait_all(); }
-  // Clear lookahead state so any schedule_lookahead() call from the
-  // management_eventloop that races with QueryEnd (after query_.reset() destroys
-  // operators but before task_creator_->reset() clears the queue) finds an
-  // empty queue and exits cleanly instead of dereferencing dangling pointers.
-  {
-    std::lock_guard<std::mutex> lookahead_lock(_lookahead_mutex);
-    _lookahead_queue.clear();
-    _index_of_next_lookahead = 0;
-  }
-  _task_creation_queue.reactivate();
+  // Drop only THIS query's queued requests. No interrupt()/reactivate(): the queue stays open
+  // the whole time, so other queries' producers and consumers are never stalled.
+  _task_creation_queue.drain(
+    exec::query_index{static_cast<exec::query_key>(sirius::value_of(query_id))});
+
+  auto state = get_query_state(query_id);
+  if (!state) { return; }
+
+  // Wait out this query's in-flight creation lambdas — the per-query stand-in for
+  // _bounded_pool->wait_all(), which would also wait on every other query's work. Workers
+  // decrement on exit (including by exception), so this cannot hang on a throwing lambda.
+  state->wait_for_in_flight();
+
+  // Clear lookahead state so any schedule_lookahead() racing with query teardown finds an
+  // empty queue and exits cleanly instead of dereferencing operators that are about to die.
+  std::lock_guard<std::mutex> lookahead_lock(state->lookahead_mutex);
+  state->lookahead_queue.clear();
+  state->index_of_next_lookahead = 0;
 }
 
-void task_creator::reset()
+void task_creator::reset(sirius::query_id_t query_id)
 {
-  std::lock_guard<std::mutex> lock(_global_state_mutex);
-  _gpu_operator_global_state_map.clear();
-  _thread_context.reset();
-  _execution_context.reset();
+  // Requests hold raw operator pointers into this query's plan, and in-flight lambdas
+  // dereference them, so both must be gone before the caller destroys planner::query.
+  drain_pending_tasks(query_id);
+
+  std::shared_ptr<query_task_state> state;
   {
-    std::lock_guard<std::mutex> lookahead_lock(_lookahead_mutex);
-    _lookahead_queue.clear();
-    _index_of_next_lookahead = 0;
+    std::lock_guard<std::mutex> lock(_global_state_mutex);
+    auto it = _query_states.find(query_id);
+    if (it == _query_states.end()) { return; }
+    state = std::move(it->second);
+    _query_states.erase(it);
+  }
+  // `state` is released here, outside the lock. Any worker that resolved it before the erase
+  // still holds its own shared_ptr and finishes safely against a map that no longer lists it.
+}
+
+void task_creator::reset_all()
+{
+  std::vector<sirius::query_id_t> query_ids;
+  {
+    std::lock_guard<std::mutex> lock(_global_state_mutex);
+    query_ids.reserve(_query_states.size());
+    for (const auto& [query_id, state] : _query_states) {
+      query_ids.push_back(query_id);
+    }
+  }
+  for (const auto query_id : query_ids) {
+    reset(query_id);
   }
 }
 
@@ -305,19 +374,53 @@ void task_creator::stop_thread_pool()
   do_stop_thread_pool();
 }
 
+namespace {
+
+//! The query and scheduling priority of the pipeline `node` belongs to.
+//! An unplaced operator (no pipeline yet) yields query 0 / priority 0; such a request is
+//! droppable and will simply find no state when the worker resolves it.
+std::pair<sirius::query_id_t, exec::queue_priority> request_keys_for(
+  const op::sirius_physical_operator* node)
+{
+  if (node == nullptr) { return {sirius::make_query_id(0), 0}; }
+  const auto pipe = node->get_pipeline();
+  if (!pipe) { return {sirius::make_query_id(0), 0}; }
+  return {pipe->get_query_id(), pipe->get_priority()};
+}
+
+}  // namespace
+
 void task_creator::schedule(op::sirius_physical_operator* node)
 {
-  auto request  = std::make_unique<task_creation_request>();
-  request->node = node;
+  const auto [query_id, priority] = request_keys_for(node);
+  auto request                    = std::make_unique<task_creation_request>();
+  request->node                   = node;
+  request->query_id               = query_id;
+  request->priority               = priority;
   _task_creation_queue.push(std::move(request));
 }
 
-void task_creator::schedule_lookahead(std::optional<int> device_id_hint)
+void task_creator::schedule(op::sirius_physical_operator* node, sirius::query_id_t query_id)
+{
+  const auto [_, priority] = request_keys_for(node);
+  auto request             = std::make_unique<task_creation_request>();
+  request->node            = node;
+  request->query_id        = query_id;
+  request->priority        = priority;
+  _task_creation_queue.push(std::move(request));
+}
+
+void task_creator::schedule_lookahead(sirius::query_id_t query_id,
+                                      std::optional<int> device_id_hint)
 {
   if (_config.strategy != request_type::lookahead) { return; }
-  std::lock_guard lock(_lookahead_mutex);
-  for (; _index_of_next_lookahead < _lookahead_queue.size(); ++_index_of_next_lookahead) {
-    auto* node = _lookahead_queue[_index_of_next_lookahead];
+  auto state = get_query_state(query_id);
+  if (!state) { return; }
+
+  std::lock_guard lock(state->lookahead_mutex);
+  for (; state->index_of_next_lookahead < state->lookahead_queue.size();
+       ++state->index_of_next_lookahead) {
+    auto* node = state->lookahead_queue[state->index_of_next_lookahead];
     if (node == nullptr) { continue; }
     auto hint = node->get_next_task_hint();
     if (!hint.has_value()) {
@@ -328,11 +431,15 @@ void task_creator::schedule_lookahead(std::optional<int> device_id_hint)
       SIRIUS_LOG_TRACE("Task Creator: scheduling lookahead for operator {} (id {})",
                        node->get_name(),
                        node->get_operator_id());
-      auto request  = std::make_unique<task_creation_request>();
-      request->node = node;
-      request->type = request_type::lookahead;
+      const auto [_, priority] = request_keys_for(node);
+      auto request             = std::make_unique<task_creation_request>();
+      request->node            = node;
+      request->type            = request_type::lookahead;
+      request->query_id        = query_id;
+      request->priority        = priority;
+      request->device_id       = device_id_hint.value_or(exec::no_preferred_device);
       _task_creation_queue.push(std::move(request));
-      ++_index_of_next_lookahead;
+      ++state->index_of_next_lookahead;
       return;
     }
   }
@@ -352,193 +459,223 @@ void task_creator::manager_loop()
       continue;
     }
 
-    auto node         = request->node;
-    auto request_kind = request->type;
+    auto node           = request->node;
+    auto request_kind   = request->type;
+    const auto query_id = request->query_id;
     if (node == nullptr) { continue; }
+
+    // Resolve the query's state ONCE, here, and hand the shared_ptr to the worker. The worker
+    // then reads global_states (immutable after prepare_for_query) with no lock and no risk of
+    // the map being rehashed or erased underneath it: its own reference keeps the state alive
+    // even if reset(query_id) removes the registry entry mid-flight.
+    auto query_state = get_query_state(query_id);
+    if (!query_state) {
+      // The query was reset while this request sat in the queue (finished, or failed and was
+      // cleaned up). Dropping it is the correct outcome — `node` may already be dangling.
+      continue;
+    }
 
     node = get_operator_for_next_task(node);
 
     if (node == nullptr) { continue; }
 
+    // Counted before dispatch so drain_pending_tasks(query_id) cannot observe zero in-flight
+    // while this task creation is still queued to run.
+    query_state->enter_in_flight();
     // Dispatch the task creation work to the pool
-    _bounded_pool->dispatch(std::move(slot), [this, node, request_kind]() mutable {
-      try {
-        // Get what we need to create the task
-        auto pipeline = node->get_pipeline();
-        std::vector<cucascade::shared_data_repository*> destination_data_repositories;
+    _bounded_pool->dispatch(
+      std::move(slot), [this, node, request_kind, query_state = std::move(query_state)]() mutable {
+        // Released on every exit path, including the catch below, so a throwing creation can
+        // never strand drain_pending_tasks() waiting forever.
+        struct in_flight_guard {
+          const std::shared_ptr<query_task_state>& state;
+          ~in_flight_guard() { state->leave_in_flight(); }
+        } guard{query_state};
+        try {
+          // Get what we need to create the task
+          auto pipeline = node->get_pipeline();
+          std::vector<cucascade::shared_data_repository*> destination_data_repositories;
 
-        for (const auto& port_info : pipeline->get_next_ports_after_sink()) {
-          destination_data_repositories.push_back(
-            port_info.next_operator->get_port(port_info.next_operator_port_name)->repo);
-        }
-
-        while (!node->all_ports_empty()) {
-          auto task_lock  = pipeline->get_task_creation_lock();
-          auto input_data = node->get_next_task_input_data();
-          auto* pipelineable_input =
-            dynamic_cast<op::pipelineable_operator_data*>(input_data.get());
-          if (!input_data ||
-              (pipelineable_input && pipelineable_input->get_data_batches().empty())) {
-            // no data to create task for
-            break;
+          for (const auto& port_info : pipeline->get_next_ports_after_sink()) {
+            destination_data_repositories.push_back(
+              port_info.next_operator->get_port(port_info.next_operator_port_name)->repo);
           }
 
-          size_t operator_id                  = node->get_operator_id();
-          auto gpu_pipeline_task_global_state = _gpu_operator_global_state_map.at(operator_id);
-          auto local_state =
-            std::make_unique<pipeline::gpu_pipeline_task_local_state>(std::move(input_data));
+          while (!node->all_ports_empty()) {
+            auto task_lock  = pipeline->get_task_creation_lock();
+            auto input_data = node->get_next_task_input_data();
+            auto* pipelineable_input =
+              dynamic_cast<op::pipelineable_operator_data*>(input_data.get());
+            if (!input_data ||
+                (pipelineable_input && pipelineable_input->get_data_batches().empty())) {
+              // no data to create task for
+              break;
+            }
 
-          // pipelineable_input remains valid here: the cast happened before
-          // the move into local_state, and unique_ptr move transfers
-          // ownership without relocating the object.
-          {
-            std::optional<int> preferred_device_id;
-            // Operating-data preference (highest priority): the scan manager
-            // round-robins fresh-read scan splits across the available GPUs and
-            // stamps the chosen device onto the split's operating data. Honor it
-            // first so each split's task lands on its assigned GPU; the locality
-            // heuristics below only run when no upstream preference was set.
-            if (local_state->_input_data) {
-              preferred_device_id = local_state->_input_data->get_preferred_device_id();
-            }
-            // Partition affinity: if the input is tagged with a partition
-            // index, pin the task to partition_idx % num_gpus.
-            // Partition-based operators (hash_join, grouped_aggregate_merge,
-            // …) use cuco hash tables under the hood, and cuco tables must
-            // live on a single device — a stream bound to GPU A touching a
-            // counter built under GPU B trips cudaErrorInvalidValue at
-            // counter_storage.cuh. Routing on partition_idx keeps every
-            // task of a given partition on one GPU while still spreading
-            // partitions across GPUs.
-            if (auto* partitioned =
-                  dynamic_cast<op::partitioned_operator_data*>(pipelineable_input);
-                !preferred_device_id.has_value() && partitioned && !_active_gpu_ids.empty()) {
-              // Index the active executor set so every task of a partition lands
-              // on the same real GPU (required for cuco tables); the physical
-              // topology would yield phantom pins when num_gpus < physical count.
-              auto idx            = partitioned->get_partition_idx() % _active_gpu_ids.size();
-              preferred_device_id = _active_gpu_ids[idx];
-            }
-            if (!preferred_device_id.has_value() && pipelineable_input &&
-                !pipelineable_input->get_data_batches().empty()) {
-              std::unordered_map<int, size_t> gpu_bytes;
-              std::unordered_map<int, size_t> host_bytes;
-              for (const auto& batch : pipelineable_input->get_data_batches()) {
-                if (!batch) { continue; }
-                auto ro     = batch->to_read_only();
-                auto* space = ro.get_memory_space();
-                if (!space || !ro.get_data()) { continue; }
-                auto size = ro.get_data()->get_size_in_bytes();
-                if (space->get_tier() == cucascade::memory::Tier::GPU) {
-                  gpu_bytes[space->get_device_id()] += size;
-                } else if (space->get_tier() == cucascade::memory::Tier::HOST) {
-                  // Key by the host space's NUMA node verbatim; topology_index
-                  // groups GPUs under that same key (including the -1 "unknown"
-                  // sentinel for non-NUMA / single-NUMA hosts), so gpus_of()
-                  // resolves without any normalization.
-                  host_bytes[space->get_device_id()] += size;
-                }
+            size_t operator_id = node->get_operator_id();
+            // Read from this query's own map. Operator ids restart at 0 per query, so the id is
+            // only meaningful within the entry; a globally-keyed map would hand back another
+            // query's state here.
+            auto gs_it = query_state->global_states.find(operator_id);
+            if (gs_it == query_state->global_states.end()) { break; }
+            auto gpu_pipeline_task_global_state = gs_it->second;
+            auto local_state =
+              std::make_unique<pipeline::gpu_pipeline_task_local_state>(std::move(input_data));
+
+            // pipelineable_input remains valid here: the cast happened before
+            // the move into local_state, and unique_ptr move transfers
+            // ownership without relocating the object.
+            {
+              std::optional<int> preferred_device_id;
+              // Operating-data preference (highest priority): the scan manager
+              // round-robins fresh-read scan splits across the available GPUs and
+              // stamps the chosen device onto the split's operating data. Honor it
+              // first so each split's task lands on its assigned GPU; the locality
+              // heuristics below only run when no upstream preference was set.
+              if (local_state->_input_data) {
+                preferred_device_id = local_state->_input_data->get_preferred_device_id();
               }
-              if (!gpu_bytes.empty()) {
-                // Data-locality: route to GPU with most data by bytes
-                preferred_device_id =
-                  std::max_element(gpu_bytes.begin(),
-                                   gpu_bytes.end(),
-                                   [](const auto& a, const auto& b) { return a.second < b.second; })
-                    ->first;
-              } else if (!host_bytes.empty() && _topology_index) {
-                // NUMA-affinity: no GPU data, route to a GPU on the same
-                // NUMA as the host data. When that NUMA hosts multiple
-                // GPUs, pick round-robin across them — pinning every
-                // host-sourced pipeline task to a single GPU defeats
-                // multi-GPU speedup.
-                auto top_host =
-                  std::max_element(host_bytes.begin(),
-                                   host_bytes.end(),
-                                   [](const auto& a, const auto& b) { return a.second < b.second; })
-                    ->first;
-                auto gpus = _topology_index->gpus_of(top_host);
-                if (!gpus.empty()) {
-                  auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
-                  preferred_device_id = gpus[idx];
-                }
+              // Partition affinity: if the input is tagged with a partition
+              // index, pin the task to partition_idx % num_gpus.
+              // Partition-based operators (hash_join, grouped_aggregate_merge,
+              // …) use cuco hash tables under the hood, and cuco tables must
+              // live on a single device — a stream bound to GPU A touching a
+              // counter built under GPU B trips cudaErrorInvalidValue at
+              // counter_storage.cuh. Routing on partition_idx keeps every
+              // task of a given partition on one GPU while still spreading
+              // partitions across GPUs.
+              if (auto* partitioned =
+                    dynamic_cast<op::partitioned_operator_data*>(pipelineable_input);
+                  !preferred_device_id.has_value() && partitioned && !_active_gpu_ids.empty()) {
+                // Index the active executor set so every task of a partition lands
+                // on the same real GPU (required for cuco tables); the physical
+                // topology would yield phantom pins when num_gpus < physical count.
+                auto idx            = partitioned->get_partition_idx() % _active_gpu_ids.size();
+                preferred_device_id = _active_gpu_ids[idx];
               }
-              SIRIUS_LOG_DEBUG(
-                "Task Creator: locality score gpu_sources={} host_sources={} preferred_device={}",
-                gpu_bytes.size(),
-                host_bytes.size(),
-                preferred_device_id.value_or(-1));
-            }
-            // Cached-scan locality: a resident scan_operator_input is
-            // NOT a pipelineable_operator_data (see
-            // sirius_gpu_scan_operator_data.hpp), so the data-locality block
-            // above skipped it wholesale. Without this branch, every
-            // pinned-table scan task gets dispatched round-robin by the
-            // scheduler and triggers a peer DMA or host staging when the
-            // consumer GPU differs from the chunk's home GPU. The pinned
-            // chunk's GPU residency is preserved on the batch
-            // (the cached provider pins each chunk_memory_space
-            // into the gpu_table_representation), so we just read it here.
-            if (!preferred_device_id.has_value()) {
-              if (auto* cached =
-                    dynamic_cast<op::scan::scan_operator_input*>(local_state->_input_data.get())) {
-                if (cached->is_resident()) {
-                  auto ro     = cached->get_cached_batch()->to_read_only();
+              if (!preferred_device_id.has_value() && pipelineable_input &&
+                  !pipelineable_input->get_data_batches().empty()) {
+                std::unordered_map<int, size_t> gpu_bytes;
+                std::unordered_map<int, size_t> host_bytes;
+                for (const auto& batch : pipelineable_input->get_data_batches()) {
+                  if (!batch) { continue; }
+                  auto ro     = batch->to_read_only();
                   auto* space = ro.get_memory_space();
-                  if (space) {
-                    if (space->get_tier() == cucascade::memory::Tier::GPU) {
-                      preferred_device_id = space->get_device_id();
-                    } else if (space->get_tier() == cucascade::memory::Tier::HOST &&
-                               _topology_index) {
-                      // tier='host' pinned chunks carry a NUMA-local host
-                      // memory_space; map back through the topology index to
-                      // pick a GPU on the same NUMA. The host space's device id
-                      // is the NUMA key verbatim (-1 = "unknown"), matching the
-                      // pipelineable locality block above.
-                      auto gpus = _topology_index->gpus_of(space->get_device_id());
-                      if (!gpus.empty()) {
-                        auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
-                        preferred_device_id = gpus[idx];
+                  if (!space || !ro.get_data()) { continue; }
+                  auto size = ro.get_data()->get_size_in_bytes();
+                  if (space->get_tier() == cucascade::memory::Tier::GPU) {
+                    gpu_bytes[space->get_device_id()] += size;
+                  } else if (space->get_tier() == cucascade::memory::Tier::HOST) {
+                    // Key by the host space's NUMA node verbatim; topology_index
+                    // groups GPUs under that same key (including the -1 "unknown"
+                    // sentinel for non-NUMA / single-NUMA hosts), so gpus_of()
+                    // resolves without any normalization.
+                    host_bytes[space->get_device_id()] += size;
+                  }
+                }
+                if (!gpu_bytes.empty()) {
+                  // Data-locality: route to GPU with most data by bytes
+                  preferred_device_id = std::max_element(gpu_bytes.begin(),
+                                                         gpu_bytes.end(),
+                                                         [](const auto& a, const auto& b) {
+                                                           return a.second < b.second;
+                                                         })
+                                          ->first;
+                } else if (!host_bytes.empty() && _topology_index) {
+                  // NUMA-affinity: no GPU data, route to a GPU on the same
+                  // NUMA as the host data. When that NUMA hosts multiple
+                  // GPUs, pick round-robin across them — pinning every
+                  // host-sourced pipeline task to a single GPU defeats
+                  // multi-GPU speedup.
+                  auto top_host = std::max_element(host_bytes.begin(),
+                                                   host_bytes.end(),
+                                                   [](const auto& a, const auto& b) {
+                                                     return a.second < b.second;
+                                                   })
+                                    ->first;
+                  auto gpus = _topology_index->gpus_of(top_host);
+                  if (!gpus.empty()) {
+                    auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
+                    preferred_device_id = gpus[idx];
+                  }
+                }
+                SIRIUS_LOG_DEBUG(
+                  "Task Creator: locality score gpu_sources={} host_sources={} preferred_device={}",
+                  gpu_bytes.size(),
+                  host_bytes.size(),
+                  preferred_device_id.value_or(-1));
+              }
+              // Cached-scan locality: a resident scan_operator_input is
+              // NOT a pipelineable_operator_data (see
+              // sirius_gpu_scan_operator_data.hpp), so the data-locality block
+              // above skipped it wholesale. Without this branch, every
+              // pinned-table scan task gets dispatched round-robin by the
+              // scheduler and triggers a peer DMA or host staging when the
+              // consumer GPU differs from the chunk's home GPU. The pinned
+              // chunk's GPU residency is preserved on the batch
+              // (the cached provider pins each chunk_memory_space
+              // into the gpu_table_representation), so we just read it here.
+              if (!preferred_device_id.has_value()) {
+                if (auto* cached = dynamic_cast<op::scan::scan_operator_input*>(
+                      local_state->_input_data.get())) {
+                  if (cached->is_resident()) {
+                    auto ro     = cached->get_cached_batch()->to_read_only();
+                    auto* space = ro.get_memory_space();
+                    if (space) {
+                      if (space->get_tier() == cucascade::memory::Tier::GPU) {
+                        preferred_device_id = space->get_device_id();
+                      } else if (space->get_tier() == cucascade::memory::Tier::HOST &&
+                                 _topology_index) {
+                        // tier='host' pinned chunks carry a NUMA-local host
+                        // memory_space; map back through the topology index to
+                        // pick a GPU on the same NUMA. The host space's device id
+                        // is the NUMA key verbatim (-1 = "unknown"), matching the
+                        // pipelineable locality block above.
+                        auto gpus = _topology_index->gpus_of(space->get_device_id());
+                        if (!gpus.empty()) {
+                          auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
+                          preferred_device_id = gpus[idx];
+                        }
                       }
+                      SIRIUS_LOG_DEBUG(
+                        "Task Creator: cached-scan locality tier={} device_id={} "
+                        "preferred_device={}",
+                        static_cast<int>(space->get_tier()),
+                        space->get_device_id(),
+                        preferred_device_id.value_or(-1));
                     }
-                    SIRIUS_LOG_DEBUG(
-                      "Task Creator: cached-scan locality tier={} device_id={} "
-                      "preferred_device={}",
-                      static_cast<int>(space->get_tier()),
-                      space->get_device_id(),
-                      preferred_device_id.value_or(-1));
                   }
                 }
               }
+              if (preferred_device_id.has_value()) {
+                local_state->set_preferred_device_id(preferred_device_id.value());
+              }
             }
-            if (preferred_device_id.has_value()) {
-              local_state->set_preferred_device_id(preferred_device_id.value());
-            }
+
+            auto task_id = get_next_task_id();
+            auto task =
+              std::make_unique<pipeline::gpu_pipeline_task>(task_id,
+                                                            destination_data_repositories,
+                                                            std::move(local_state),
+                                                            gpu_pipeline_task_global_state);
+            task_lock.unlock();
+            _task_scheduler->schedule(std::move(task));
+
+            if (request_kind == request_type::lookahead) { break; }
           }
-
-          auto task_id = get_next_task_id();
-          auto task    = std::make_unique<pipeline::gpu_pipeline_task>(task_id,
-                                                                    destination_data_repositories,
-                                                                    std::move(local_state),
-                                                                    gpu_pipeline_task_global_state);
-          task_lock.unlock();
-          _task_scheduler->schedule(std::move(task));
-
-          if (request_kind == request_type::lookahead) { break; }
+          // Unconditional re-evaluation at every creation exit: with the
+          // source-exhaustion finish guard, "last task completed at T1,
+          // connector closed at T2>T1" has no later mark_task_completed() to
+          // re-check the pipeline — this call, observing the now-exhausted
+          // source, is the paired re-evaluation. Without it, normal fast-GPU
+          // queries would hang.
+          pipeline->update_pipeline_status(false);
+        } catch (const std::exception& e) {
+          SIRIUS_LOG_ERROR("Task Creator: Exception during task creation: {}", e.what());
+          _task_scheduler->terminate_query(std::current_exception());
+          stop();
         }
-        // Unconditional re-evaluation at every creation exit: with the
-        // source-exhaustion finish guard, "last task completed at T1,
-        // connector closed at T2>T1" has no later mark_task_completed() to
-        // re-check the pipeline — this call, observing the now-exhausted
-        // source, is the paired re-evaluation. Without it, normal fast-GPU
-        // queries would hang.
-        pipeline->update_pipeline_status(false);
-      } catch (const std::exception& e) {
-        SIRIUS_LOG_ERROR("Task Creator: Exception during task creation: {}", e.what());
-        _task_scheduler->terminate_query(std::current_exception());
-        stop();
-      }
-    });
+      });
   }
 }
 

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -686,10 +686,14 @@ void task_creator::manager_loop()
           // queries would hang.
           pipeline->update_pipeline_status(false);
         } catch (const std::exception& e) {
+          // Fail only this query. The stop() that used to follow ran on a task_creator pool
+          // worker and called _bounded_pool->wait_all(), which blocks until active_ == 0 — but
+          // this thread IS an active slot, so it deadlocked outright; and had it got past,
+          // _bounded_pool.reset() would have joined this thread with itself inside a noexcept
+          // function. It also tore down task creation for every other in-flight query.
           SIRIUS_LOG_ERROR("Task Creator: Exception during task creation: {}", e.what());
           _task_scheduler->terminate_query(query_state->completion_handler,
                                            std::current_exception());
-          stop();
         }
       });
   }

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -294,7 +294,10 @@ void downgrade_executor::processing_loop()
     if (!req->satisfied.load() && _pipeline_task_queue) {
       size_t max_tasks_to_convert = _pipeline_task_queue->size();
       size_t tasks_converted      = 0;
-      convertible_gpu_pipeline_task_provider pipeline_provider(*_pipeline_task_queue);
+      // The gate travels with the provider: each wrapper it hands out consults it before its RAII
+      // re-push, so a task extracted here cannot land back in the queue after its query's drain.
+      convertible_gpu_pipeline_task_provider pipeline_provider(*_pipeline_task_queue,
+                                                               _query_lifecycle);
       while (!req->satisfied.load() && tasks_converted < max_tasks_to_convert) {
         auto candidate =
           pipeline_provider.get_next_convertible(source_space, /*front_to_back=*/false);

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -21,17 +21,21 @@
 #include "exec/bounded_thread_pool.hpp"
 #include "exec/config.hpp"
 #include "exec/interruptible_mpmc.hpp"
+#include "exec/multi_index_priority_queue.hpp"
 #include "exec/queue_priority.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "op/scan/sirius_gpu_scan_operator.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "pipeline/sirius_pipeline.hpp"
+#include "query_id.hpp"
 
 #include <blockingconcurrentqueue.h>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
 
 #include <atomic>
+#include <condition_variable>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -70,6 +74,14 @@ namespace sirius::creator {
 struct task_creation_request {
   op::sirius_physical_operator* node;
   request_type type = request_type::active;
+  //! The query `node` belongs to. Indexes the request in the creation queue so a finished or
+  //! failed query's pending requests can be dropped without touching any other query's.
+  sirius::query_id_t query_id = sirius::make_query_id(0);
+  //! Scheduling priority of `node`'s pipeline; orders the creation queue the same way the
+  //! execution queue is ordered (query first, then within-query pipeline rank).
+  exec::queue_priority priority = 0;
+  //! Preferred GPU, when the caller had a hint. Only a secondary index; does not bind the task.
+  int device_id = exec::no_preferred_device;
 };
 
 class task_creator {
@@ -96,17 +108,31 @@ class task_creator {
   task_creator(task_creator&&)                 = delete;
   task_creator& operator=(task_creator&&)      = delete;
 
-  /// \brief sets client context needed for task creation
-  void set_client_context(::duckdb::ClientContext& client_context);
+  /// \brief Bind @p query_id to the connection that is running it.
+  /// Called at execution-window begin, before prepare_for_query.
+  void set_client_context(sirius::query_id_t query_id, ::duckdb::ClientContext& client_context);
 
   /// \brief sets pipeline executor reference
   void set_task_scheduler(sirius::pipeline::task_scheduler& task_scheduler);
 
-  /// \brief prepare global states for all pipelines in the query
+  /// \brief Register the per-query state for @p query's pipelines.
+  ///
+  /// Adds an entry; it does NOT clear other queries' entries. Call reset(query_id) to drop one.
   void prepare_for_query(const sirius::planner::query& query);
 
-  /// \brief clean-up query bound resources and prepare the task creator for next query
-  void reset();
+  /// \brief Drop everything held for @p query_id: pending creation requests, in-flight creation
+  /// work, and the per-query state entry. Other queries are untouched.
+  ///
+  /// Runs on both the success and the failure path (SiriusContext::run_mandatory_cleanup, which
+  /// StandaloneQueryScope guarantees exactly once), so a failed query cannot leave the shared
+  /// creator holding stale operator pointers.
+  ///
+  /// Must complete before @p query_id's planner::query is destroyed: queued requests hold raw
+  /// operator pointers into its plan.
+  void reset(sirius::query_id_t query_id);
+
+  /// \brief Drop every query's state. Teardown only (SiriusContext::terminate).
+  void reset_all();
 
   /**
    * @brief Stop the task creator and its thread pool.
@@ -130,12 +156,14 @@ class task_creator {
   void stop_thread_pool();
 
   /**
-   * @brief Drain all pending task creation requests and wait for in-flight tasks to complete.
+   * @brief Drop @p query_id's pending creation requests and wait for its in-flight creation
+   *        work to finish. Other queries keep running.
    *
    * Call this after a query completes (future resolved) but before destroying the engine/operators
-   * to ensure no stale operator pointers are accessed by the task creator threads.
+   * to ensure no stale operator pointers are accessed by the task creator threads. Unlike the
+   * previous global drain, this neither interrupts the queue nor waits on other queries' work.
    */
-  void drain_pending_tasks();
+  void drain_pending_tasks(sirius::query_id_t query_id);
 
   /**
    * @brief Schedule a task creation info for processing.
@@ -144,7 +172,11 @@ class task_creator {
    */
   virtual void schedule(op::sirius_physical_operator* request);
 
-  void schedule_lookahead(std::optional<int> device_id_hint = std::nullopt);
+  /// \brief Overload for callers that already know the query; avoids re-deriving it.
+  void schedule(op::sirius_physical_operator* request, sirius::query_id_t query_id);
+
+  void schedule_lookahead(sirius::query_id_t query_id,
+                          std::optional<int> device_id_hint = std::nullopt);
 
   /**
    * @brief Get the next task id.
@@ -205,21 +237,57 @@ class task_creator {
   sirius::memory::sirius_memory_reservation_manager& _mem_res_mgr;
   std::atomic<uint64_t> _task_id{0};
 
-  std::mutex _lookahead_mutex;              // Protect concurrent access to the lookahead scheduling
-  std::size_t _index_of_next_lookahead{0};  // Index of the next operator to lookahead for
-  std::vector<op::sirius_physical_operator*> _lookahead_queue;
+  /**
+   * @brief Everything the task creator holds on behalf of ONE query.
+   *
+   * Handed out as a `shared_ptr`: a worker resolves it once and then reads `global_states`,
+   * which is never mutated after `prepare_for_query`. That makes the lookup race-free even if
+   * the query is erased concurrently — the worker's copy keeps the state alive until it is done.
+   * Operator ids restart at 0 for every query, so `global_states` is only unique *within* an
+   * entry; keying it globally is what would let two queries fetch each other's state.
+   */
+  struct query_task_state {
+    //! Source operator id -> that pipeline's task global state. Written once by
+    //! prepare_for_query, read-only afterwards.
+    std::unordered_map<size_t, std::shared_ptr<pipeline::sirius_pipeline_task_global_state>>
+      global_states;
+
+    //! Client context of the connection running this query. Per query because two concurrent
+    //! queries on different connections have different contexts.
+    ::duckdb::ClientContext* client_context{nullptr};
+
+    std::mutex lookahead_mutex;
+    std::size_t index_of_next_lookahead{0};
+    std::vector<op::sirius_physical_operator*> lookahead_queue;
+
+    //! Per-query stand-in for `bounded_thread_pool::wait_all()`, which can only wait on every
+    //! query's creation work at once. Incremented before dispatch, decremented when the lambda
+    //! leaves (including by exception); `wait_for_in_flight()` blocks until it reaches zero.
+    std::mutex in_flight_mutex;
+    std::condition_variable in_flight_cv;
+    std::size_t in_flight{0};
+
+    void enter_in_flight();
+    void leave_in_flight();
+    void wait_for_in_flight();
+  };
+
+  //! Resolve a query's state, or nullptr when it has already been reset.
+  std::shared_ptr<query_task_state> get_query_state(sirius::query_id_t query_id) const;
 
   // Queue for creating tasks based on operators. The operator is the starting point to start
   // looking which task should be created, not necessarily the operator for whose pipeline the task
-  // will be created
-  exec::interruptible_mpmc<std::unique_ptr<task_creation_request>> _task_creation_queue;
+  // will be created.
+  //
+  // A multi_index_priority_queue rather than a plain FIFO so that (a) creation is ordered the
+  // same way execution is — earlier query first, then pipeline rank — and (b) a single query's
+  // pending requests can be dropped via drain(query_index{...}) without disturbing any other
+  // query's.
+  exec::multi_index_priority_queue<task_creation_request> _task_creation_queue;
 
-  // Map of operator ID to global state for scan operators
-  std::unordered_map<size_t, std::shared_ptr<pipeline::sirius_pipeline_task_global_state>>
-    _gpu_operator_global_state_map;
-  std::unique_ptr<duckdb::ThreadContext> _thread_context;
-  std::unique_ptr<duckdb::ExecutionContext> _execution_context;
-  std::mutex _global_state_mutex;  // Protect concurrent access to the map
+  //! One entry per in-flight query. Guarded by _global_state_mutex.
+  std::map<sirius::query_id_t, std::shared_ptr<query_task_state>> _query_states;
+  mutable std::mutex _global_state_mutex;  // Protect concurrent access to _query_states
 
   /// Shared GPU<->NUMA topology index for NUMA-aware GPU routing (may be null).
   /// Scoped to the memory manager's reserved GPU/HOST spaces:

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -82,6 +82,13 @@ struct task_creation_request {
   //! Scheduling priority of `node`'s pipeline; orders the creation queue the same way the
   //! execution queue is ordered (query first, then within-query pipeline rank).
   exec::queue_priority priority = 0;
+  //! `node`'s operator type, captured at schedule() time.
+  //!
+  //! Stored rather than read back off `node` so the queue's key extractor — which runs inside the
+  //! queue mutex on every push — dereferences no operator. A schedule() racing its query's
+  //! teardown would otherwise read a freed operator while holding that mutex, and unlike the
+  //! other keys this one had no reason to be resolved late.
+  op::SiriusPhysicalOperatorType operator_type = op::SiriusPhysicalOperatorType::INVALID;
   //! Preferred GPU, when the caller had a hint. Only a secondary index; does not bind the task.
   int device_id = exec::no_preferred_device;
 };
@@ -222,6 +229,11 @@ class task_creator {
    * True when no registry is bound (the unit-test default), preserving pre-gate behaviour.
    */
   [[nodiscard]] bool accepts_work(sirius::query_id_t query_id) const noexcept;
+
+  /// \brief Whether the calling thread is one of this creator's task-creation pool workers.
+  /// Used only to assert that stop() is never called from inside its own pool, which would
+  /// self-deadlock in wait_all(). See task_creator::stop.
+  [[nodiscard]] static bool is_pool_worker_thread();
 
   /**
    * @brief Stop the worker thread pool.

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -22,6 +22,7 @@
 #include "exec/config.hpp"
 #include "exec/interruptible_mpmc.hpp"
 #include "exec/multi_index_priority_queue.hpp"
+#include "exec/query_lifecycle_registry.hpp"
 #include "exec/queue_priority.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "op/scan/sirius_gpu_scan_operator.hpp"
@@ -116,6 +117,15 @@ class task_creator {
   /// \brief sets pipeline executor reference
   void set_task_scheduler(sirius::pipeline::task_scheduler& task_scheduler);
 
+  /// \brief Bind the per-query lifecycle gate consulted before every enqueue.
+  ///
+  /// Without one (the default, and what most unit tests use) every query is treated as accepting
+  /// work, i.e. the pre-gate behaviour.
+  void set_query_lifecycle_registry(sirius::exec::query_lifecycle_registry* registry) noexcept
+  {
+    _query_lifecycle = registry;
+  }
+
   /// \brief Register the per-query state for @p query's pipelines.
   ///
   /// Adds an entry; it does NOT clear other queries' entries. Call reset(query_id) to drop one.
@@ -207,6 +217,13 @@ class task_creator {
 
  protected:
   /**
+   * @brief Whether the lifecycle gate still accepts work for @p query_id.
+   *
+   * True when no registry is bound (the unit-test default), preserving pre-gate behaviour.
+   */
+  [[nodiscard]] bool accepts_work(sirius::query_id_t query_id) const noexcept;
+
+  /**
    * @brief Stop the worker thread pool.
    *
    * Stops all worker threads and waits for them to finish. This method is
@@ -239,6 +256,8 @@ class task_creator {
   std::thread _manager_thread;
   ::duckdb::ClientContext* _client_context;
   sirius::pipeline::task_scheduler* _task_scheduler{nullptr};
+  /// Non-owning; owned by SiriusContext and outlives this creator. Null in unit tests.
+  sirius::exec::query_lifecycle_registry* _query_lifecycle{nullptr};
   sirius::memory::sirius_memory_reservation_manager& _mem_res_mgr;
   std::atomic<uint64_t> _task_id{0};
 
@@ -298,6 +317,17 @@ class task_creator {
   //! One entry per in-flight query. Guarded by _global_state_mutex.
   std::map<sirius::query_id_t, std::shared_ptr<query_task_global_state>> _query_task_global_states;
   mutable std::mutex _global_state_mutex;  // Protect concurrent access to _query_task_global_states
+  /// Serializes pool/manager-thread lifecycle (start_thread_pool / stop_thread_pool / stop).
+  ///
+  /// Deliberately NOT _global_state_mutex. do_stop_thread_pool() joins _manager_thread, and
+  /// manager_loop() takes _global_state_mutex on every request via get_query_task_global_state().
+  /// Holding that mutex across the join therefore deadlocked: the stopper waited for the manager
+  /// thread while holding the very mutex the manager thread needed to finish its iteration. It
+  /// fires whenever a query takes the error path (drain_after_error -> stop_thread_pool) while the
+  /// creator is still running. The two mutexes guard disjoint state -- this one covers
+  /// _bounded_pool / _manager_thread / _running, the other covers _query_task_global_states and
+  /// _task_scheduler -- so splitting them removes the cycle rather than papering over it.
+  std::mutex _pool_lifecycle_mutex;
 
   /// Shared GPU<->NUMA topology index for NUMA-aware GPU routing (may be null).
   /// Scoped to the memory manager's reserved GPU/HOST spaces:

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -26,6 +26,7 @@
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "op/scan/sirius_gpu_scan_operator.hpp"
 #include "op/sirius_physical_operator.hpp"
+#include "pipeline/completion_handler.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 #include "query_id.hpp"
 
@@ -118,7 +119,10 @@ class task_creator {
   /// \brief Register the per-query state for @p query's pipelines.
   ///
   /// Adds an entry; it does NOT clear other queries' entries. Call reset(query_id) to drop one.
-  void prepare_for_query(const sirius::planner::query& query);
+  ///
+  /// \param handler The query's completion signal
+  void prepare_for_query(const sirius::planner::query& query,
+                         std::shared_ptr<pipeline::completion_handler> handler);
 
   /// \brief Drop everything held for @p query_id: pending creation requests, in-flight creation
   /// work, and the per-query state entry. Other queries are untouched.
@@ -175,8 +179,9 @@ class task_creator {
   /// \brief Overload for callers that already know the query; avoids re-deriving it.
   void schedule(op::sirius_physical_operator* request, sirius::query_id_t query_id);
 
-  void schedule_lookahead(sirius::query_id_t query_id,
-                          std::optional<int> device_id_hint = std::nullopt);
+  /// \brief Warm up one not-yet-activated scan of the oldest live query.
+  /// No-op when no query is registered.
+  void schedule_lookahead(std::optional<int> device_id_hint = std::nullopt);
 
   /**
    * @brief Get the next task id.
@@ -255,6 +260,10 @@ class task_creator {
     //! Client context of the connection running this query. Per query because two concurrent
     //! queries on different connections have different contexts.
     ::duckdb::ClientContext* client_context{nullptr};
+
+    //! This query's completion signal, for the creation-failure path (which has this state in
+    //! scope but no task). Same handler every pipeline's global state carries.
+    std::shared_ptr<pipeline::completion_handler> completion_handler;
 
     std::mutex lookahead_mutex;
     std::size_t index_of_next_lookahead{0};

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -300,16 +300,9 @@ class task_creator {
     std::size_t index_of_next_lookahead{0};
     std::vector<op::sirius_physical_operator*> lookahead_queue;
 
-    //! Per-query stand-in for `bounded_thread_pool::wait_all()`, which can only wait on every
-    //! query's creation work at once. Incremented before dispatch, decremented when the lambda
-    //! leaves (including by exception); `wait_for_in_flight()` blocks until it reaches zero.
-    std::mutex in_flight_mutex;
-    std::condition_variable in_flight_cv;
-    std::size_t in_flight{0};
-
-    void enter_in_flight();
-    void leave_in_flight();
-    void wait_for_in_flight();
+    // (In-flight creation work is tracked by the pool itself, keyed by the query the slot is
+    // attached to; see bounded_thread_pool::drain_and_wait. The bespoke counter that used to live
+    // here duplicated that accounting and had to be kept in sync by hand across every exit path.)
   };
 
   //! Resolve a query's state, or nullptr when it has already been reset.

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -230,6 +230,10 @@ class task_creator {
    */
   [[nodiscard]] bool accepts_work(sirius::query_id_t query_id) const noexcept;
 
+  /// \brief Log loudly when a push was refused for a query that is still accepting work.
+  /// A refused push destroys the request, so a live query silently loses a task it is waiting on.
+  void report_if_dropped(bool pushed, sirius::query_id_t query_id) const;
+
   /// \brief Whether the calling thread is one of this creator's task-creation pool workers.
   /// Used only to assert that stop() is never called from inside its own pool, which would
   /// self-deadlock in wait_all(). See task_creator::stop.

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -246,7 +246,7 @@ class task_creator {
    * Operator ids restart at 0 for every query, so `global_states` is only unique *within* an
    * entry; keying it globally is what would let two queries fetch each other's state.
    */
-  struct query_task_state {
+  struct query_task_global_state {
     //! Source operator id -> that pipeline's task global state. Written once by
     //! prepare_for_query, read-only afterwards.
     std::unordered_map<size_t, std::shared_ptr<pipeline::sirius_pipeline_task_global_state>>
@@ -273,7 +273,8 @@ class task_creator {
   };
 
   //! Resolve a query's state, or nullptr when it has already been reset.
-  std::shared_ptr<query_task_state> get_query_state(sirius::query_id_t query_id) const;
+  std::shared_ptr<query_task_global_state> get_query_task_global_state(
+    sirius::query_id_t query_id) const;
 
   // Queue for creating tasks based on operators. The operator is the starting point to start
   // looking which task should be created, not necessarily the operator for whose pipeline the task
@@ -286,8 +287,8 @@ class task_creator {
   exec::multi_index_priority_queue<task_creation_request> _task_creation_queue;
 
   //! One entry per in-flight query. Guarded by _global_state_mutex.
-  std::map<sirius::query_id_t, std::shared_ptr<query_task_state>> _query_states;
-  mutable std::mutex _global_state_mutex;  // Protect concurrent access to _query_states
+  std::map<sirius::query_id_t, std::shared_ptr<query_task_global_state>> _query_task_global_states;
+  mutable std::mutex _global_state_mutex;  // Protect concurrent access to _query_task_global_states
 
   /// Shared GPU<->NUMA topology index for NUMA-aware GPU routing (may be null).
   /// Scoped to the memory manager's reserved GPU/HOST spaces:

--- a/src/include/data/convertible_gpu_pipeline_task.hpp
+++ b/src/include/data/convertible_gpu_pipeline_task.hpp
@@ -20,6 +20,7 @@
 #include "data/convertible_data_batch.hpp"
 #include "data/sirius_converter_registry.hpp"
 #include "exec/multi_index_priority_queue.hpp"
+#include "exec/query_lifecycle_registry.hpp"
 #include "log/logging.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "parallel/task.hpp"
@@ -65,8 +66,9 @@ class convertible_gpu_pipeline_task : public convertible_data {
    */
   convertible_gpu_pipeline_task(
     std::unique_ptr<sirius::parallel::itask> task,
-    sirius::exec::multi_index_priority_queue<sirius::parallel::itask>& queue)
-    : _task(std::move(task)), _queue(queue)
+    sirius::exec::multi_index_priority_queue<sirius::parallel::itask>& queue,
+    sirius::exec::query_lifecycle_registry* query_lifecycle = nullptr)
+    : _task(std::move(task)), _queue(queue), _query_lifecycle(query_lifecycle)
   {
   }
 
@@ -82,10 +84,23 @@ class convertible_gpu_pipeline_task : public convertible_data {
    * If the task has been moved-from (nullptr), does nothing.
    * Pushes the task back to the queue; if the queue is closed (shutdown),
    * the task is destroyed -- this is expected during query teardown.
+   *
+   * The lifecycle gate is what makes that "expected during query teardown" actually hold. TIER-2
+   * downgrade pops a task off the shared scheduler queue into a processing-thread local, carries
+   * it across a *blocking* pool reserve() and a full host/device conversion, and only then gets
+   * here. That window easily outlives the owning query's drain, so an ungated push resurrects a
+   * task after its query was cleaned up: the push itself runs the key extractor over a plan that
+   * has already been destroyed, and the resurrected task holds raw repository pointers into a
+   * manager that is about to be erased.
    */
   ~convertible_gpu_pipeline_task() override
   {
-    if (_task) { (void)_queue.push(std::move(_task)); }
+    if (!_task) { return; }
+    if (_query_lifecycle != nullptr && !_query_lifecycle->accepts_work(sirius::make_query_id(
+                                         sirius::pipeline::index_keys_for(*_task).query_id))) {
+      return;  // query is tearing down; drop instead of resurrecting
+    }
+    (void)_queue.push(std::move(_task));
   }
 
   /**
@@ -210,6 +225,8 @@ class convertible_gpu_pipeline_task : public convertible_data {
 
   std::unique_ptr<sirius::parallel::itask> _task;
   sirius::exec::multi_index_priority_queue<sirius::parallel::itask>& _queue;
+  /// Non-owning; owned by SiriusContext. Null in unit tests, which restores the ungated push.
+  sirius::exec::query_lifecycle_registry* _query_lifecycle{nullptr};
 };
 
 /**
@@ -228,8 +245,9 @@ class convertible_gpu_pipeline_task_provider : public convertible_data_provider 
    * @param queue The task queue to search (non-owning reference).
    */
   explicit convertible_gpu_pipeline_task_provider(
-    sirius::exec::multi_index_priority_queue<sirius::parallel::itask>& queue)
-    : _queue(queue)
+    sirius::exec::multi_index_priority_queue<sirius::parallel::itask>& queue,
+    sirius::exec::query_lifecycle_registry* query_lifecycle = nullptr)
+    : _queue(queue), _query_lifecycle(query_lifecycle)
   {
   }
 
@@ -254,7 +272,8 @@ class convertible_gpu_pipeline_task_provider : public convertible_data_provider 
       [space](sirius::parallel::itask& t) { return has_matching_batches(t, space); },
       front_to_back);
     if (!task) { return nullptr; }
-    return std::make_unique<convertible_gpu_pipeline_task>(std::move(*task), _queue);
+    return std::make_unique<convertible_gpu_pipeline_task>(
+      std::move(*task), _queue, _query_lifecycle);
   }
 
   /**
@@ -283,7 +302,8 @@ class convertible_gpu_pipeline_task_provider : public convertible_data_provider 
         [space](sirius::parallel::itask& t) { return has_matching_batches(t, space); },
         front_to_back);
       if (!task) { break; }
-      results.push_back(std::make_unique<convertible_gpu_pipeline_task>(std::move(*task), _queue));
+      results.push_back(std::make_unique<convertible_gpu_pipeline_task>(
+        std::move(*task), _queue, _query_lifecycle));
     }
     return results;
   }
@@ -318,6 +338,9 @@ class convertible_gpu_pipeline_task_provider : public convertible_data_provider 
   }
 
   sirius::exec::multi_index_priority_queue<sirius::parallel::itask>& _queue;
+  /// Non-owning; owned by SiriusContext. Forwarded to each wrapper so its RAII re-push is
+  /// refused once the owning query starts tearing down.
+  sirius::exec::query_lifecycle_registry* _query_lifecycle{nullptr};
 };
 
 }  // namespace sirius

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -21,6 +21,7 @@
 #include "exec/config.hpp"
 #include "exec/interruptible_mpmc.hpp"
 #include "exec/multi_index_priority_queue.hpp"
+#include "exec/query_lifecycle_registry.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "parallel/task.hpp"
 
@@ -142,6 +143,18 @@ class downgrade_executor {
     sirius::exec::multi_index_priority_queue<sirius::parallel::itask>* pipeline_task_queue);
 
   /**
+   * @brief Bind the per-query lifecycle gate.
+   *
+   * Forwarded to every convertible_gpu_pipeline_task the TIER-2 sweep creates, so a task
+   * extracted from the shared queue is dropped rather than re-pushed once its query starts
+   * tearing down. Without one (the unit-test default) the re-push is ungated, as before.
+   */
+  void set_query_lifecycle_registry(sirius::exec::query_lifecycle_registry* registry) noexcept
+  {
+    _query_lifecycle = registry;
+  }
+
+  /**
    * @brief Asynchronously request a predicate-driven downgrade.
    *
    * Dispatches batch downgrades until the predicate returns true or candidates
@@ -208,6 +221,8 @@ class downgrade_executor {
   std::string _source_label;
   sirius::memory::sirius_memory_reservation_manager& _reservation_manager;
   sirius::exec::multi_index_priority_queue<sirius::parallel::itask>* _pipeline_task_queue{nullptr};
+  /// Non-owning; owned by SiriusContext and outlives this executor. Null in unit tests.
+  sirius::exec::query_lifecycle_registry* _query_lifecycle{nullptr};
 };
 
 }  // namespace parallel

--- a/src/include/exec/bounded_thread_pool.hpp
+++ b/src/include/exec/bounded_thread_pool.hpp
@@ -17,13 +17,16 @@
 #pragma once
 
 #include "log/logging.hpp"
+#include "query_id.hpp"
 
 #include <absl/functional/any_invocable.h>
 
 #include <condition_variable>
 #include <latch>
+#include <list>
+#include <map>
 #include <mutex>
-#include <queue>
+#include <optional>
 #include <string>
 #include <thread>
 #include <utility>
@@ -61,14 +64,20 @@ class bounded_thread_pool {
    public:
     explicit slot(bounded_thread_pool* pool = nullptr) noexcept : pool_(pool) {}
 
-    slot(slot&& other) noexcept : pool_(other.pool_) { other.pool_ = nullptr; }
+    slot(slot&& other) noexcept : pool_(other.pool_), query_(other.query_)
+    {
+      other.pool_ = nullptr;
+      other.query_.reset();
+    }
 
     slot& operator=(slot&& other) noexcept
     {
       if (this != &other) {
         release();
         pool_       = other.pool_;
+        query_      = other.query_;
         other.pool_ = nullptr;
+        other.query_.reset();
       }
       return *this;
     }
@@ -81,13 +90,39 @@ class bounded_thread_pool {
     [[nodiscard]] bool is_valid() const noexcept { return pool_ != nullptr; }
     explicit operator bool() const noexcept { return is_valid(); }
 
+    /**
+     * @brief Attribute this slot to @p query_id, so drain_and_wait(query_id) waits for it.
+     *
+     * Deliberately separate from reserve(). Every manager loop in this codebase reserves a slot
+     * and THEN blocks waiting for a task, so the query is not known at reserve() time — and an
+     * idle manager must not be counted against any query, or drain_and_wait() would block until
+     * that manager happened to receive work. Attribution therefore happens once the task has been
+     * popped and its query is known.
+     *
+     * Idempotent; a slot can only be attached once.
+     */
+    void attach(sirius::query_id_t query_id)
+    {
+      if (pool_ == nullptr || query_.has_value()) { return; }
+      query_ = query_id;
+      pool_->attach_slot(query_id);
+    }
+
+    /// \brief The query this slot is attributed to, or nullopt while untagged.
+    [[nodiscard]] std::optional<sirius::query_id_t> query() const noexcept { return query_; }
+
    private:
     void release()
     {
-      if (auto* p = std::exchange(pool_, nullptr); p != nullptr) { p->release_slot(); }
+      if (auto* p = std::exchange(pool_, nullptr); p != nullptr) {
+        const auto q = query_;
+        query_.reset();
+        p->release_slot(q);
+      }
     }
 
     bounded_thread_pool* pool_{nullptr};
+    std::optional<sirius::query_id_t> query_{};
   };
 
   explicit bounded_thread_pool(int capacity,
@@ -205,34 +240,122 @@ class bounded_thread_pool {
   void dispatch(slot&& s, absl::AnyInvocable<void()> fn)
   {
     if (not s) { return; }
+    const auto query = s.query();
     {
       std::lock_guard lock(mu_);
-      work_queue_.push([s = std::move(s), fn = std::move(fn)]() mutable noexcept {
-        try {
-          fn();
-        } catch (const std::exception& e) {
-          SIRIUS_LOG_ERROR("Exception in bounded_thread_pool task: {}", e.what());
-        } catch (...) {
-          SIRIUS_LOG_ERROR("Unknown exception in bounded_thread_pool task");
-        }
-        // Destroy before slot is released upon lambda exit.
-        fn = nullptr;
-        // When slot, s, goes out of scope, release_slot is automatically
-        // invoked, clearing the path for another task to pick up that slot.
-      });
+      work_queue_.push_back(
+        work_item{query, [s = std::move(s), fn = std::move(fn)]() mutable noexcept {
+                    try {
+                      fn();
+                    } catch (const std::exception& e) {
+                      SIRIUS_LOG_ERROR("Exception in bounded_thread_pool task: {}", e.what());
+                    } catch (...) {
+                      SIRIUS_LOG_ERROR("Unknown exception in bounded_thread_pool task");
+                    }
+                    // Destroy before slot is released upon lambda exit.
+                    fn = nullptr;
+                    // When slot, s, goes out of scope, release_slot is automatically
+                    // invoked, clearing the path for another task to pick up that slot.
+                  }});
     }
     cv_work_.notify_one();
   }
 
- private:
-  // Called exclusively by the slot destructor — covers both the drop-without-dispatch
-  // and post-task-completion cases.
-  void release_slot()
+  /**
+   * @brief Wait until @p query_id has no work left — queued or running — without dropping any.
+   *
+   * A slot is attached before it is dispatched, so the per-query count covers queued-but-unstarted
+   * work as well as work in progress; waiting for it to reach zero therefore means every task of
+   * this query has actually RUN. That is what the success path needs: dropping there would
+   * silently discard work the query legitimately scheduled.
+   *
+   * Untagged slots (an idle manager holding a reservation) are ignored, so this returns while
+   * other queries — and the manager itself — carry on. wait_all() cannot: it waits for
+   * active_ == 0, which a parked manager makes unreachable.
+   */
+  void wait_for_query(sirius::query_id_t query_id)
   {
+    std::unique_lock lock(mu_);
+    cv_query_idle_.wait(lock, [&] {
+      auto it = active_by_query_.find(query_id);
+      return it == active_by_query_.end() || it->second == 0;
+    });
+  }
+
+  /**
+   * @brief Drop @p query_id's queued work and wait for its running work to finish.
+   *
+   * The per-query counterpart of wait_all(). Untagged slots — notably a manager thread parked in
+   * its own queue's pop() while holding a reservation — are ignored, which is precisely why this
+   * can return while other queries keep running. wait_all() cannot: it waits for active_ == 0,
+   * which an idle manager makes unreachable.
+   *
+   * Queued items are moved out under the lock and destroyed after releasing it: destroying a work
+   * item runs ~slot, which re-enters release_slot() and would deadlock on a held mutex.
+   */
+  void drain_and_wait(sirius::query_id_t query_id)
+  {
+    std::list<work_item> dropped;
+    {
+      std::lock_guard lock(mu_);
+      for (auto it = work_queue_.begin(); it != work_queue_.end();) {
+        if (it->query == query_id) {
+          auto next = std::next(it);
+          dropped.splice(dropped.end(), work_queue_, it);
+          it = next;
+        } else {
+          ++it;
+        }
+      }
+    }
+    dropped.clear();  // releases the dropped items' slots, outside the lock
+
+    std::unique_lock lock(mu_);
+    cv_query_idle_.wait(lock, [&] {
+      auto it = active_by_query_.find(query_id);
+      return it == active_by_query_.end() || it->second == 0;
+    });
+  }
+
+  /// \brief Number of running slots attributed to @p query_id. Test/diagnostic aid.
+  [[nodiscard]] int active_for_query(sirius::query_id_t query_id)
+  {
+    std::lock_guard lock(mu_);
+    auto it = active_by_query_.find(query_id);
+    return it == active_by_query_.end() ? 0 : it->second;
+  }
+
+ private:
+  /// One unit of dispatched work plus the query it is attributed to (nullopt when untagged).
+  struct work_item {
+    std::optional<sirius::query_id_t> query;
+    absl::AnyInvocable<void() noexcept> fn;
+  };
+
+  // Called by slot::attach() once the query behind a reservation is known.
+  void attach_slot(sirius::query_id_t query_id)
+  {
+    std::lock_guard lock(mu_);
+    ++active_by_query_[query_id];
+  }
+
+  // Called exclusively by the slot destructor — covers both the drop-without-dispatch
+  // and post-task-completion cases. @p query is the slot's attribution, if it had one.
+  void release_slot(std::optional<sirius::query_id_t> query)
+  {
+    bool query_idle = false;
     {
       std::lock_guard lock(mu_);
       --active_;
+      if (query.has_value()) {
+        auto it = active_by_query_.find(*query);
+        if (it != active_by_query_.end() && --it->second <= 0) {
+          active_by_query_.erase(it);
+          query_idle = true;
+        }
+      }
     }
+    if (query_idle) { cv_query_idle_.notify_all(); }
     cv_capacity_.notify_one();
     cv_idle_.notify_all();
   }
@@ -245,8 +368,8 @@ class bounded_thread_pool {
         std::unique_lock lock(mu_);
         cv_work_.wait(lock, [&] { return !work_queue_.empty() || stop_requested_; });
         if (stop_requested_ && work_queue_.empty()) { break; }
-        fn = std::move(work_queue_.front());
-        work_queue_.pop();
+        fn = std::move(work_queue_.front().fn);
+        work_queue_.pop_front();
       }
       if (fn == nullptr) { break; }
       fn();
@@ -254,16 +377,21 @@ class bounded_thread_pool {
   }
 
   std::mutex mu_;
-  std::condition_variable cv_capacity_;  // reserve() waits here when at capacity
-  std::condition_variable cv_idle_;      // wait_all() waits here
-  std::condition_variable cv_work_;      // worker threads wait here for work
+  std::condition_variable cv_capacity_;    // reserve() waits here when at capacity
+  std::condition_variable cv_idle_;        // wait_all() waits here
+  std::condition_variable cv_work_;        // worker threads wait here for work
+  std::condition_variable cv_query_idle_;  // drain_and_wait(query_id) waits here
 
   int active_{0};
   const int capacity_;
   bool interrupted_{false};
   bool stop_requested_{false};
 
-  std::queue<absl::AnyInvocable<void() noexcept>> work_queue_;
+  /// std::list, not std::queue: drain_and_wait(query_id) must remove one query's items from the
+  /// middle without disturbing the ordering of everyone else's.
+  std::list<work_item> work_queue_;
+  /// Running slots per query. Absent key == zero; untagged slots are not represented at all.
+  std::map<sirius::query_id_t, int> active_by_query_;
   std::vector<std::thread> threads_;
 };
 

--- a/src/include/exec/multi_index_priority_queue.hpp
+++ b/src/include/exec/multi_index_priority_queue.hpp
@@ -173,14 +173,18 @@ class multi_index_priority_queue {
   /// teardown contract callers rely on (e.g. returning a task to a closed queue).
   /// Strongly exception-safe: if any allocation throws, the queue is left as it
   /// was (the task is destroyed) and nothing is enqueued.
-  void push(task_ptr task)
+  ///
+  /// \return true if the task was enqueued, false if it was dropped because the queue is
+  ///         interrupted. Callers that only enqueue may ignore it; those that report dropped
+  ///         work (itask_executor::schedule) rely on it.
+  bool push(task_ptr task)
   {
     assert(task && "cannot push a null task");
     const index_keys keys = _extract(*task);
     {
       std::lock_guard<std::mutex> lock(_mutex);
       // Interrupted (shutdown): drop the task instead of enqueuing it.
-      if (!_active) { return; }
+      if (!_active) { return false; }
 
       auto lit             = _levels.find(keys.priority);
       const bool new_level = (lit == _levels.end());
@@ -228,6 +232,7 @@ class multi_index_priority_queue {
       }
     }
     _cv.notify_one();
+    return true;
   }
 
   /// Blocks until the globally-first (lowest-priority-value) task is available and

--- a/src/include/exec/query_lifecycle_registry.hpp
+++ b/src/include/exec/query_lifecycle_registry.hpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "query_id.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <mutex>
+#include <optional>
+
+namespace sirius::exec {
+
+/// \brief Where a query is in its lifecycle, from the point of view of "may work be enqueued?".
+enum class query_lifecycle_state : std::uint8_t {
+  /// Normal execution: every enqueue point accepts work for this query.
+  open,
+  /// Teardown has begun and the drains are running. Enqueues are refused so that work cannot be
+  /// added back behind a drain that already passed.
+  quiescing,
+};
+
+/**
+ * @brief The single authority on whether work may still be enqueued for a query.
+ *
+ * Sirius has four thread pools and seven places that enqueue work, several of which fire from
+ * *completion callbacks* — a finishing task schedules its downstream consumers, and a downgraded
+ * task pushes itself back onto the scheduler queue. During teardown those late enqueues must be
+ * refused, or a drain that already ran leaves work behind pointing at a plan that is about to be
+ * destroyed.
+ *
+ * Historically that was achieved by interrupting the *shared* queues (`multi_index_priority_queue
+ * ::interrupt()`), which refuses pushes for every query at once — see the comment block in
+ * `task_scheduler::drain_after_error`. This registry does the same thing per query, so one
+ * query's teardown no longer silently eats another query's work.
+ *
+ * ### Semantics
+ *
+ * - `open_query()` at the start of an execution window, `quiesce()` at the start of its cleanup,
+ *   `close()` once the drains are done.
+ * - An **unknown** query id is treated as accepting work. This is deliberate: the failure mode of
+ *   a missed `open_query()` would otherwise be a query that silently never schedules anything,
+ *   i.e. a hang, which is exactly the class of bug this registry exists to remove. Components
+ *   constructed without a registry (most unit tests) behave as they did before.
+ * - `accepts_work()` is therefore "not known to be tearing down" rather than "known to be live".
+ *
+ * Thread-safe. Every method takes the mutex for a map lookup only; nothing is called with it held.
+ */
+class query_lifecycle_registry {
+ public:
+  query_lifecycle_registry()  = default;
+  ~query_lifecycle_registry() = default;
+
+  query_lifecycle_registry(const query_lifecycle_registry&)            = delete;
+  query_lifecycle_registry& operator=(const query_lifecycle_registry&) = delete;
+  query_lifecycle_registry(query_lifecycle_registry&&)                 = delete;
+  query_lifecycle_registry& operator=(query_lifecycle_registry&&)      = delete;
+
+  /**
+   * @brief Register @p query_id as accepting work.
+   *
+   * Called once per execution window, before anything can be scheduled. Idempotent: re-opening an
+   * already-open query is a no-op, and re-opening a quiescing one returns it to `open` (which no
+   * production path does — window ids are monotonic).
+   */
+  void open_query(sirius::query_id_t query_id)
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _states[query_id] = query_lifecycle_state::open;
+  }
+
+  /**
+   * @brief Refuse further work for @p query_id.
+   *
+   * Called at the top of the query's cleanup, before any drain runs, so that a drain cannot be
+   * outrun by a completion callback enqueuing behind it. Idempotent, and a no-op for a query that
+   * was never opened.
+   */
+  void quiesce(sirius::query_id_t query_id)
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    auto it = _states.find(query_id);
+    if (it != _states.end()) { it->second = query_lifecycle_state::quiescing; }
+  }
+
+  /**
+   * @brief Forget @p query_id entirely; its window is over.
+   *
+   * Called after the drains complete. The entry is erased rather than kept as a tombstone, so the
+   * map stays bounded by the number of in-flight queries rather than growing for the life of the
+   * process. Work arriving after this point is by definition work that no drain will ever see;
+   * preventing *that* is the job of the per-query pool drains and shared repository ownership,
+   * not of this registry.
+   */
+  void close(sirius::query_id_t query_id)
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _states.erase(query_id);
+  }
+
+  /**
+   * @brief Whether work may still be enqueued for @p query_id.
+   *
+   * @return false only when @p query_id is registered and quiescing. Unknown ids return true; see
+   *         the class docs for why that direction is the safe one.
+   */
+  [[nodiscard]] bool accepts_work(sirius::query_id_t query_id) const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    auto it = _states.find(query_id);
+    return it == _states.end() || it->second == query_lifecycle_state::open;
+  }
+
+  /// \brief The recorded state of @p query_id, or nullopt if it is not registered.
+  [[nodiscard]] std::optional<query_lifecycle_state> state(sirius::query_id_t query_id) const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    auto it = _states.find(query_id);
+    return it == _states.end() ? std::nullopt : std::optional{it->second};
+  }
+
+  /// \brief Number of registered (open or quiescing) queries.
+  [[nodiscard]] std::size_t size() const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _states.size();
+  }
+
+  /// \brief Drop every entry. Teardown only.
+  void clear()
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _states.clear();
+  }
+
+ private:
+  mutable std::mutex _mutex;
+  /// std::map rather than unordered_map: entries are bounded by in-flight query count (a handful),
+  /// so ordered lookup is fine and iteration order stays deterministic for debugging.
+  std::map<sirius::query_id_t, query_lifecycle_state> _states;
+};
+
+}  // namespace sirius::exec

--- a/src/include/parallel/task_executor.hpp
+++ b/src/include/parallel/task_executor.hpp
@@ -19,6 +19,7 @@
 #include "exec/bounded_thread_pool.hpp"
 #include "exec/config.hpp"
 #include "exec/multi_index_priority_queue.hpp"
+#include "exec/query_lifecycle_registry.hpp"
 #include "parallel/task.hpp"
 #include "query_id.hpp"
 
@@ -70,8 +71,22 @@ class itask_executor {
 
   /**
    * @brief Schedule a task for execution.
+   *
+   * A no-op when the lifecycle gate reports that the task's query is tearing down: the OOM
+   * reschedule path re-enters here from a worker thread long after a drain may have passed.
    */
   void schedule(std::unique_ptr<itask> task);
+
+  /**
+   * @brief Bind the per-query lifecycle gate consulted before enqueuing.
+   *
+   * Without one (the default, and what most unit tests use) every query is treated as accepting
+   * work, i.e. the pre-gate behaviour.
+   */
+  void set_query_lifecycle_registry(exec::query_lifecycle_registry* registry) noexcept
+  {
+    _query_lifecycle = registry;
+  }
 
   /**
    * @brief Start the executor: creates the thread pool and manager thread.
@@ -185,6 +200,8 @@ class itask_executor {
   /// dropped without touching another's. Keys come from pipeline::index_keys_for, the
   /// same extractor the task_scheduler's queue uses.
   exec::multi_index_priority_queue<itask> _task_queue;
+  /// Non-owning; owned by SiriusContext and outlives this executor. Null in unit tests.
+  exec::query_lifecycle_registry* _query_lifecycle{nullptr};
   std::thread _manager_thread;
   std::shared_ptr<const telemetry::telemetry_context> _telemetry_context;
   std::unique_ptr<telemetry::TaskQueueHandleWrapper> _task_queue_telemetry;

--- a/src/include/parallel/task_executor.hpp
+++ b/src/include/parallel/task_executor.hpp
@@ -18,8 +18,9 @@
 
 #include "exec/bounded_thread_pool.hpp"
 #include "exec/config.hpp"
-#include "exec/inspectable_mpsc.hpp"
+#include "exec/multi_index_priority_queue.hpp"
 #include "parallel/task.hpp"
+#include "query_id.hpp"
 
 #include <absl/functional/any_invocable.h>
 
@@ -97,9 +98,18 @@ class itask_executor {
   void wait_all();
 
   /**
-   * @brief Drain any leftover tasks remaining in the queue.
+   * @brief Drain any leftover tasks remaining in the queue, for every query.
    */
   void drain_leftover_tasks();
+
+  /**
+   * @brief Drop the queued tasks belonging to one query.
+   *
+   * Tasks of other queries are left in place and the queue stays open, so unlike interrupt()
+   * this does not stall any other query's producers or consumers. Only queued work is affected;
+   * a task already dispatched to the thread pool runs to completion.
+   */
+  void drain_query_tasks(sirius::query_id_t query_id);
 
   /**
    * @brief Drain in-flight tasks and restart the manager, ready for the next query.
@@ -171,7 +181,10 @@ class itask_executor {
   std::atomic<bool> _running{false};
   exec::thread_pool_config _config;
   std::unique_ptr<exec::bounded_thread_pool> _bounded_pool;
-  exec::inspectable_mpsc<itask> _task_queue;
+  /// Ordered by task priority and indexed by query, so one query's queued work can be
+  /// dropped without touching another's. Keys come from pipeline::index_keys_for, the
+  /// same extractor the task_scheduler's queue uses.
+  exec::multi_index_priority_queue<itask> _task_queue;
   std::thread _manager_thread;
   std::shared_ptr<const telemetry::telemetry_context> _telemetry_context;
   std::unique_ptr<telemetry::TaskQueueHandleWrapper> _task_queue_telemetry;

--- a/src/include/parallel/task_executor.hpp
+++ b/src/include/parallel/task_executor.hpp
@@ -136,19 +136,50 @@ class itask_executor {
   void drain_and_wait();
 
   /**
-   * @brief Like drain_and_wait(), but VALIDATES the queue is empty instead of
-   * draining it.
+   * @brief Wait for in-flight work, then assert @p query_id has nothing queued here.
    *
-   * Stops the kiosk and interrupts the queue so the manager exits, waits for all
-   * in-flight thread-pool tasks, then — instead of draining — checks that the
-   * task queue is empty. If it is not, logs an error and throws: a non-empty queue
-   * at query completion means tasks were still scheduled when we declared the query
-   * done. Re-enables the queue/pool and restarts the manager thread either way
-   * (the throw happens after the executor is left in a restartable state).
+   * The success-path counterpart of wait_and_drain_query(). A non-empty queue for @p query_id at
+   * completion means tasks were still being scheduled when the query was declared done, so this
+   * throws rather than draining, which would hide the bug.
+   *
+   * Unlike the whole-executor version it replaced, this neither interrupts the shared queue nor
+   * stops and restarts the manager thread — both of which dropped co-tenant queries' queued work
+   * and stalled their producers on every completion. It also no longer validates the *whole*
+   * queue, which made one query fail because another had work legitimately queued.
+   *
+   * The in-flight wait is still whole-pool; per-query in-flight accounting arrives with the
+   * query-aware bounded_thread_pool. Waiting on a co-tenant's task is a stall, not a correctness
+   * problem.
    */
-  void wait_and_validate_empty();
+  void wait_and_validate_empty(sirius::query_id_t query_id);
+
+  /**
+   * @brief Wait for in-flight work, then drop @p query_id's queued tasks.
+   *
+   * The error-path counterpart of wait_and_validate_empty(). Waiting first guarantees no thread is
+   * still executing a task that references the failing query's plan before the caller lets that
+   * plan be destroyed.
+   */
+  void wait_and_drain_query(sirius::query_id_t query_id);
 
  protected:
+  /**
+   * @brief Stop the manager thread and wait for all in-flight pool work.
+   *
+   * Releasing the manager's pool slot is a PRECONDITION for wait_all(), not an optimization:
+   * manager_loop() reserves a slot and then blocks in pop(), so an idle manager holds an active
+   * slot forever and wait_all() (which waits for active_ == 0) would never return.
+   *
+   * Cost, and why it is temporary: interrupting the queue makes push() return false for the
+   * duration, so a co-tenant query's task in transit from the scheduler can be dropped here. The
+   * query-aware bounded_thread_pool removes the need for this bracket by making the in-flight
+   * wait per-query.
+   */
+  void quiesce_manager();
+
+  /// \brief Re-arm the pool and queue and restart the manager thread after quiesce_manager().
+  void resume_manager();
+
   /**
    * @brief Main dispatch loop — must be implemented by each subclass.
    *

--- a/src/include/pipeline/gpu_pipeline_executor.hpp
+++ b/src/include/pipeline/gpu_pipeline_executor.hpp
@@ -40,6 +40,7 @@ class downgrade_executor;
 
 namespace sirius::telemetry {
 class telemetry_context;
+struct TaskManagerLoopThreadHandleWrapper;
 }  // namespace sirius::telemetry
 
 namespace sirius {
@@ -127,6 +128,26 @@ class gpu_pipeline_executor : public sirius::parallel::itask_executor {
    * @throws std::bad_cast if the task is not of type gpu_pipeline_task
    */
   gpu_pipeline_task* cast_to_gpu_pipeline_task(sirius::parallel::itask* task);
+
+  /**
+   * @brief Prepare and dispatch one popped task: reservation, downgrade-on-shortfall, local-state
+   *        wiring, then hand-off to the bounded pool.
+   *
+   * Split out of manager_loop() so a failure here is contained to @p pipeline_task's query. Every
+   * failure path reports to that task's own completion handler and returns; none of them may stop
+   * the manager thread, which serves every in-flight query on this device. noexcept because
+   * manager_loop() is a std::thread entry function — an escaping exception would be
+   * std::terminate, not a query failure.
+   *
+   * @param pipeline_task The task popped from this executor's queue. Consumed.
+   * @param slot The reserved pool slot. Consumed by dispatch, or released on any early return.
+   * @param manager_thread_telemetry This manager thread's telemetry handle, for resource
+   * attribution.
+   */
+  void process_task(
+    std::unique_ptr<sirius::parallel::itask> pipeline_task,
+    exec::bounded_thread_pool::slot slot,
+    telemetry::TaskManagerLoopThreadHandleWrapper& manager_thread_telemetry) noexcept;
 
   cucascade::memory::exclusive_stream_pool _stream_pool;
   exec::publisher<std::unique_ptr<task_request>> _task_request_publisher;

--- a/src/include/pipeline/gpu_pipeline_executor.hpp
+++ b/src/include/pipeline/gpu_pipeline_executor.hpp
@@ -113,13 +113,6 @@ class gpu_pipeline_executor : public sirius::parallel::itask_executor {
    */
   [[nodiscard]] executor_metrics get_metrics() const noexcept;
 
-  /**
-   * @brief Set the completion handler for query completion signaling
-   *
-   * @param handler Pointer to the completion handler
-   */
-  void set_completion_handler(completion_handler* handler) noexcept;
-
  protected:
   void manager_loop() override;
 
@@ -140,7 +133,6 @@ class gpu_pipeline_executor : public sirius::parallel::itask_executor {
   cucascade::memory::memory_space* _memory_space;
   sirius::parallel::downgrade_executor* _downgrade_executor{nullptr};
   sirius::creator::task_creator* _task_creator{nullptr};
-  completion_handler* _completion_handler{nullptr};
   std::atomic<size_t> _tasks_executed{0};
 };
 

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -185,6 +185,21 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
   }
 
   /**
+   * @brief The completion handler of the query this task belongs to.
+   *
+   * Carried on the shared global state, so every executor site holding a task can report that
+   * query's completion or failure without consulting any shared "current query" state. Returns
+   * null when no global state is attached (tests).
+   */
+  [[nodiscard]] std::shared_ptr<completion_handler> get_completion_handler() const
+  {
+    if (auto gs = std::dynamic_pointer_cast<const gpu_pipeline_task_global_state>(_global_state)) {
+      return gs->get_completion_handler();
+    }
+    return nullptr;
+  }
+
+  /**
    * @brief Get the GPU pipeline associated with this task
    *
    * @return const duckdb::sirius_pipeline* Pointer to the GPU pipeline

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -274,5 +274,23 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
   uint64_t _reservation_bytes = 0;
 };
 
+/**
+ * @brief Multi-index keys for a task sitting in one of the execution queues.
+ *
+ * Shared by the task_scheduler's queue and every gpu_pipeline_executor's queue so the two can
+ * never disagree about which query a task belongs to — a disagreement would make
+ * `drain(query_index{...})` clear a query's tasks from one queue but not the other.
+ *
+ * The queue orders by priority (lower value dispatched first) and additionally indexes by
+ * operator type, query id, and preferred device. A task that is not a gpu_pipeline_task gets the
+ * maximum priority, so it sorts last, with sentinel index keys.
+ *
+ * The query id comes from the task's pipeline, NOT from unpacking the priority's high bits:
+ * `sirius::query_priority_bits` masks the id to 31 bits, so the unpacked value diverges from the
+ * real query id once bit 31 is set, and a `drain(query_index{value_of(query_id)})` would then
+ * silently miss the task.
+ */
+[[nodiscard]] exec::index_keys index_keys_for(const sirius::parallel::itask& task);
+
 }  // namespace pipeline
 }  // namespace sirius

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -20,9 +20,11 @@
 #include "common/reference_map.hpp"
 #include "duckdb/parallel/pipeline.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
+#include "exec/queue_priority.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_operator_type.hpp"
 #include "pipeline/pipeline_build_context.hpp"
+#include "query_id.hpp"
 #include "telemetry-bridge/gen/uuid.rs.h"
 
 #include <nvtx3/nvtx3.hpp>
@@ -154,6 +156,25 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   void set_pipeline_id(size_t id) { pipeline_id = id; }
   //! Get the pipeline ID
   size_t get_pipeline_id() const { return pipeline_id; }
+
+  //! Set this pipeline's scheduling priority. Mirrors the value task_creator puts on the
+  //! pipeline's task global state, kept here so a task-creation request can be keyed without
+  //! taking the task_creator's per-query lock on the schedule() hot path.
+  void set_priority(exec::queue_priority priority) noexcept { priority_ = priority; }
+  //! This pipeline's scheduling priority (lower runs first).
+  [[nodiscard]] exec::queue_priority get_priority() const noexcept { return priority_; }
+
+  //! Set the id of the query this pipeline belongs to. Stamped by planner::query once the
+  //! pipeline set is final; see get_query_id().
+  void set_query_id(sirius::query_id_t id) noexcept { query_id_ = id; }
+  //! The query this pipeline belongs to.
+  //!
+  //! Queue index keys are derived from this (see the multi_index_priority_queue extractors in
+  //! task_scheduler and task_creator), so that per-query drains target the right tasks. Read it
+  //! from here rather than recovering it from the packed scheduling priority: the priority masks
+  //! the id to 31 bits (see sirius::query_priority_bits), so the recovered value diverges from
+  //! the real query id once bit 31 is set.
+  [[nodiscard]] sirius::query_id_t get_query_id() const noexcept { return query_id_; }
   //! Returns the parent pipelines (pipelines that depend on this pipeline)
   std::vector<sirius_pipeline*> get_parents() const;
 
@@ -250,6 +271,11 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
 
   //! The unique ID of this pipeline (assigned based on new_scheduled order)
   size_t pipeline_id = 0;
+  //! The query this pipeline belongs to; stamped by planner::query. Defaults to 0, which is
+  //! never a live query id (window ids start at 1), so an unstamped pipeline is detectable.
+  sirius::query_id_t query_id_ = sirius::make_query_id(0);
+  //! Scheduling priority; stamped by task_creator::prepare_for_query.
+  exec::queue_priority priority_ = 0;
   //! Plan-time context (replaces sirius_engine& for plan-time needs)
   pipeline_build_context build_ctx_;
 

--- a/src/include/pipeline/sirius_pipeline_task_states.hpp
+++ b/src/include/pipeline/sirius_pipeline_task_states.hpp
@@ -18,6 +18,7 @@
 
 #include "exec/queue_priority.hpp"
 #include "parallel/task.hpp"
+#include "pipeline/completion_handler.hpp"
 #include "pipeline/pipeline_memory_history.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 
@@ -131,6 +132,32 @@ class sirius_pipeline_task_global_state : public sirius::parallel::itask_global_
    */
   [[nodiscard]] exec::queue_priority get_priority() const { return _priority; }
 
+  /**
+   * @brief Set the completion handler of the query this pipeline belongs to.
+   *
+   * Assigned once per query by task_creator::prepare_for_query(). Every pipeline of a query
+   * shares the one handler its sirius_engine owns.
+   */
+  void set_completion_handler(std::shared_ptr<completion_handler> handler)
+  {
+    _completion_handler = std::move(handler);
+  }
+
+  /**
+   * @brief The completion handler to report this query's completion or failure to.
+   *
+   * Held by shared_ptr, not by raw pointer, because the owning sirius_engine is destroyed while
+   * the query is being torn down (fetch_result_internal runs before run_mandatory_cleanup drains
+   * the queues). A task still unwinding after that point must be able to report safely, so the
+   * handler stays alive as long as any task referencing this state does.
+   *
+   * Null only for states built outside a query (tests).
+   */
+  [[nodiscard]] const std::shared_ptr<completion_handler>& get_completion_handler() const
+  {
+    return _completion_handler;
+  }
+
  private:
   duckdb::shared_ptr<sirius_pipeline> _pipeline;  ///< Shared pointer to the GPU pipeline to execute
   pipeline_memory_history _memory_history;        ///< Historical memory metrics for estimation
@@ -138,6 +165,8 @@ class sirius_pipeline_task_global_state : public sirius::parallel::itask_global_
   exec::queue_priority _priority{0};              ///< Pipeline-level scheduling priority
   std::shared_ptr<const telemetry::telemetry_context>
     _telemetry_context;  ///< SiriusContext telemetry
+  /// The owning query's completion handler; see get_completion_handler().
+  std::shared_ptr<completion_handler> _completion_handler;
 };
 
 /**

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -167,8 +167,12 @@ class task_scheduler {
   void drain_query_tasks(sirius::query_id_t query_id);
 
   /**
-   * @brief Terminate the query execution and report the error to duckdb.
+   * @brief Fail one query by reporting @p error to its own completion handler.
    *
+   * Touches no shared subsystem: other in-flight queries keep running. The caller's query is
+   * unwound by sirius_engine::execute, whose future.get() catch runs drain_after_error(query_id).
+   *
+   * @param handler The failing query's completion handler.
    * @param error The error to report.
    */
   void terminate_query(const std::shared_ptr<completion_handler>& handler,

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -19,6 +19,7 @@
 #include "exec/channel.hpp"
 #include "exec/config.hpp"
 #include "exec/multi_index_priority_queue.hpp"
+#include "exec/query_lifecycle_registry.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "parallel/task.hpp"
 #include "pipeline/completion_handler.hpp"
@@ -179,6 +180,14 @@ class task_scheduler {
                        std::exception_ptr error);
 
   /**
+   * @brief Bind the per-query lifecycle gate, propagating it to every GPU executor.
+   *
+   * Without one (the default, and what most unit tests use) every query is treated as accepting
+   * work, i.e. the pre-gate behaviour.
+   */
+  void set_query_lifecycle_registry(sirius::exec::query_lifecycle_registry* registry);
+
+  /**
    * @brief Drain all in-flight tasks after a query error.
    *
    * Drains the top-level task queue and waits for each GPU executor to finish
@@ -222,6 +231,8 @@ class task_scheduler {
   /// task dispatch reproducible across runs.
   std::unordered_map<int, std::unique_ptr<gpu_pipeline_executor>> _gpu_executors;
   sirius::creator::task_creator* _task_creator{nullptr};
+  /// Non-owning; owned by SiriusContext and outlives this scheduler. Null in unit tests.
+  sirius::exec::query_lifecycle_registry* _query_lifecycle{nullptr};
   std::shared_ptr<const telemetry::telemetry_context> _telemetry_context;
   std::unique_ptr<telemetry::TaskQueueHandleWrapper> _task_queue_telemetry;
 };

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -167,6 +167,17 @@ class task_scheduler {
   std::future<void> start_query();
 
   /**
+   * @brief Drop every queued task belonging to @p query_id.
+   *
+   * Clears the scheduler's queue and each GPU executor's queue of that query's pending work,
+   * leaving every other query's tasks in place. In-flight tasks are unaffected.
+   *
+   * Called from the per-query cleanup so a finished or failed query leaves nothing queued that
+   * points into the plan about to be destroyed.
+   */
+  void drain_query_tasks(sirius::query_id_t query_id);
+
+  /**
    * @brief Terminate the query execution and report the error to duckdb.
    *
    * @param error The error to report.

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -215,7 +215,11 @@ class task_scheduler {
  private:
   void management_eventloop();
 
-  std::mutex _query_mutex;
+  /// The query currently installed by prepare_for_query, or nullopt between queries.
+  /// Per-query task_creator cleanup is keyed on it.
+  [[nodiscard]] std::optional<sirius::query_id_t> current_query_id() const;
+
+  mutable std::mutex _query_mutex;
   duckdb::shared_ptr<planner::query> _query;
 
   /// Pipeline-level task queue, ordered by task priority (highest dispatched first).

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -146,25 +146,14 @@ class task_scheduler {
   }
 
   /**
-   * @brief Prepare scheduler state for a query.
+   * @brief Kick off query execution by scheduling its first scan.
    *
-   * Drains tasks left by the previous query, installs the new query and completion handler,
-   * and resets per-query scheduler state.
+   * Completion is signalled through the query's own completion_handler, which its sirius_engine
+   * owns and already holds the future for, so nothing is returned here.
    *
-   * @param query Query whose tasks will be scheduled
+   * @param query The query to start; must have at least one schedulable scan source.
    */
-  void prepare_for_query(duckdb::shared_ptr<planner::query> query);
-
-  /**
-   * @brief Start query execution and return a future for completion.
-   *
-   * Sets up the completion handler and returns a future that will be satisfied
-   * when the query completes or errors. Note: prepare_for_query must be called
-   * before this method.
-   *
-   * @return A future that will be satisfied when the query completes.
-   */
-  std::future<void> start_query();
+  void start_query(const planner::query& query);
 
   /**
    * @brief Drop every queued task belonging to @p query_id.
@@ -182,7 +171,8 @@ class task_scheduler {
    *
    * @param error The error to report.
    */
-  void terminate_query(std::exception_ptr error);
+  void terminate_query(const std::shared_ptr<completion_handler>& handler,
+                       std::exception_ptr error);
 
   /**
    * @brief Drain all in-flight tasks after a query error.
@@ -193,7 +183,7 @@ class task_scheduler {
    * tasks.  Each GPU executor's manager thread is restarted so the executor is
    * ready for the next query.
    */
-  void drain_after_error();
+  void drain_after_error(sirius::query_id_t query_id);
 
   /**
    * @brief This function interrupts executors and waits for all in-flight tasks to complete.
@@ -202,36 +192,10 @@ class task_scheduler {
    * the plan.
    * @throws std::runtime_error if any tasks are still in flight.
    */
-  void wait_for_completion();
-
-  // for testing/stress only — see Doxygen below.
-  /**
-   * @brief Inject an initial value into the round-robin counter.
-   *
-   * For testing/stress only. Intended to verify that the round-robin
-   * distribution path (and the per-task-device contract documented in
-   * `docs/super-sirius/pipeline-execution.md`) is correct under arbitrary
-   * counter starting offsets — catches hash-bucket-order dependent bugs and
-   * off-by-one drift that a counter starting at 0 each query might mask.
-   *
-   * Must be called AFTER `prepare_for_query` (which resets the counter
-   * to 0) but BEFORE the first task is dispatched into
-   * `management_eventloop`. Concurrent calls are safe (atomic store).
-   */
-  void set_no_pref_rr_counter_for_testing(size_t value) noexcept
-  {
-    _no_pref_rr_counter.store(value, std::memory_order_relaxed);
-  }
+  void wait_for_completion(sirius::query_id_t query_id);
 
  private:
   void management_eventloop();
-
-  /// The query currently installed by prepare_for_query, or nullopt between queries.
-  /// Per-query task_creator cleanup is keyed on it.
-  [[nodiscard]] std::optional<sirius::query_id_t> current_query_id() const;
-
-  mutable std::mutex _query_mutex;
-  duckdb::shared_ptr<planner::query> _query;
 
   /// Pipeline-level task queue, ordered by task priority (highest dispatched first).
   exec::multi_index_priority_queue<sirius::parallel::itask> _task_queue;
@@ -253,13 +217,7 @@ class task_scheduler {
   /// order is deterministic (ascending by device_id) — keeps preference-less
   /// task dispatch reproducible across runs.
   std::unordered_map<int, std::unique_ptr<gpu_pipeline_executor>> _gpu_executors;
-  /// Deprecated as of pull-signal restoration: no-preference distribution now
-  /// arises from which executor sends a device_ready signal first, not from a
-  /// counter. Field retained for source compat with set_no_pref_rr_counter_for_testing.
-  std::atomic<size_t> _no_pref_rr_counter{0};
-
   sirius::creator::task_creator* _task_creator{nullptr};
-  std::unique_ptr<completion_handler> _completion_handler;
   std::shared_ptr<const telemetry::telemetry_context> _telemetry_context;
   std::unique_ptr<telemetry::TaskQueueHandleWrapper> _task_queue_telemetry;
 };

--- a/src/include/scan_manager/config.hpp
+++ b/src/include/scan_manager/config.hpp
@@ -43,6 +43,20 @@ struct scan_manager_config {
   exec::thread_pool_config thread_pool{.num_threads = 8, .thread_name_prefix = "scan_manager"};
   bool use_sirius_datasource{true};
 
+  /**
+   * @brief Maximum queries that may hold scan state at once. Sizes the scan thread pool.
+   *
+   * Each query's coalescer sequencer task BLOCKS (worker_loop -> process_provider_inputs ->
+   * queue.wait_dequeue) and is unblocked only by that query's own split_provider tasks, which run
+   * on the SAME pool. With Q concurrent queries, Q threads are parked in sequencers at all times,
+   * so the pool must be sized num_threads + max_concurrent_queries or Q queries consume the entire
+   * working budget and deadlock by starvation.
+   *
+   * Default 1 keeps the pool exactly the size it was before per-query scan state landed, so
+   * existing single-query deployments are unaffected. RAISE THIS before enabling real concurrency.
+   */
+  int max_concurrent_queries{1};
+
   /// Number of uring reactor worker threads for the local-disk IO path.
   std::size_t uring_n_reactors{1};
 

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -289,7 +289,9 @@ struct parquet_bind_result {
 /// parsed alongside thread_pool.num_threads in sirius_config.cpp's from_yaml, and RAISE IT
 /// before enabling more than a couple of concurrent queries. Nothing else should read this
 /// constant once it moves.
-inline constexpr int k_max_concurrent_queries = 1;
+/// Deprecated compile-time bound, kept only as the default for
+/// scan_manager_config::max_concurrent_queries. Read the config value, not this.
+inline constexpr int k_default_max_concurrent_queries = 1;
 
 /**
  * @brief Manages scan-side preparation for a query.

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -50,6 +50,7 @@ class fixed_size_host_memory_resource;
 
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -235,8 +236,13 @@ struct cached_scan_plan {
 /// set, the parquet-pin case — serves the chunk unmasked). Declared here so
 /// the chunk↔mask pairing is unit-testable; the provider type itself stays
 /// internal to the scan manager.
+///
+/// The provider CO-OWNS @p entry for its whole life: it reads the entry's chunks on every
+/// get_next_batch, and with concurrent queries another connection may unpin (or replace)
+/// the entry mid-scan. Shared ownership is what keeps that from dangling — an unpin drops
+/// the scan manager's map slot, and the data dies only once the last serving provider does.
 std::unique_ptr<databatch_provider> make_provider_for_pinned_entry(
-  pinned_entry const& entry,
+  std::shared_ptr<pinned_entry const> entry,
   std::span<std::size_t const> selected_columns,
   cached_scan_plan plan,
   const telemetry::batch_telemetry_info& telemetry_info,
@@ -267,11 +273,30 @@ struct parquet_bind_result {
   std::size_t total_num_rows{0};
 };
 
+/// Number of concurrent queries the scan manager sizes its thread pool for.
+///
+/// Each query's coalescer runs exactly ONE sequencer task that BLOCKS in
+/// queue.wait_dequeue, and is unblocked only by that query's own split_provider tasks
+/// running on the same pool. So every concurrent query needs a parked thread on top of the
+/// working budget. With Q concurrent queries and a pool of size P, Q >= P is a hard
+/// deadlock: every thread parked in a sequencer, none left to feed them.
+///
+/// Left at 1 so the pool stays exactly the size it was before per-query state landed
+/// (num_threads + 1, the old single-sequencer allowance) — this makes the concurrency
+/// refactor behaviorally neutral for existing single-query runs.
+///
+/// TODO: promote to a real option on @ref scan_manager_config (scan_manager/config.hpp),
+/// parsed alongside thread_pool.num_threads in sirius_config.cpp's from_yaml, and RAISE IT
+/// before enabling more than a couple of concurrent queries. Nothing else should read this
+/// constant once it moves.
+inline constexpr int k_max_concurrent_queries = 1;
+
 /**
  * @brief Manages scan-side preparation for a query.
  *
- * The scan manager owns a configurable-size thread pool and is given a chance
- * to set up per-scan state before a query runs (via prepare_for_query).
+ * The scan manager owns a configurable-size thread pool shared by every query, and holds
+ * per-query scan state keyed by query id (see @c query_scan_manager_state) so concurrent
+ * queries prepare, run and tear down independently.
  */
 class sirius_scan_manager {
  public:
@@ -312,6 +337,10 @@ class sirius_scan_manager {
   /// arrive or the connector is closed, so no separate wake-up channel is
   /// needed.
   ///
+  /// Registers a NEW per-query state entry keyed by @p query 's id; it does NOT touch any
+  /// other query's entry. Call reset(query_id) when the query finishes. A query with no GPU
+  /// scan operators registers nothing, so its reset is a harmless no-op.
+  ///
   /// @param query                           The query whose scan operators must be prepared.
   /// @param enable_pinned_zone_map_pruning  Per-query snapshot of the serve-side pruning flag (the
   ///                                        manager's _config is a construction-time copy, so SET
@@ -320,9 +349,19 @@ class sirius_scan_manager {
   ///                                        the survivor plan.
   void prepare_for_query(const sirius::planner::query& query, bool enable_pinned_zone_map_pruning);
 
-  /// \brief Clear the providers map and join the driver thread if it is
-  ///        still running.
-  void reset();
+  /// \brief Drop everything held for @p query_id: stop and join its scan work, then destroy
+  ///        its providers and coalescer. Other queries are untouched. No-op for an unknown id.
+  ///
+  /// Blocking — waits out this query's in-flight reads. The wait happens OUTSIDE the state
+  /// mutex, so another connection's prepare_for_query is never parked behind it.
+  void reset(sirius::query_id_t query_id);
+
+  /// \brief Drop every query's state. Teardown only (stop(), the destructor, and the
+  ///        failed-query backstop).
+  void reset_all();
+
+  /// \brief Number of queries currently registered. Observability and tests.
+  [[nodiscard]] std::size_t num_active_queries() const noexcept;
 
   /// \brief Start the worker thread pool. Idempotent.
   void start();
@@ -445,15 +484,19 @@ class sirius_scan_manager {
   /// \brief Remove the pinned entry for @p name. No-op if absent.
   void remove_pinned_entry(const std::string& name);
 
+  /// Visit every pinned entry under the pin-table lock. The visitor runs WHILE the lock is
+  /// held, so it must be quick and must not call back into the scan manager. The reference
+  /// it receives is only guaranteed for the duration of the call — a visitor that stashes
+  /// the address for later use is racing any concurrent unpin.
   void visit_pinned_entries(
     const std::function<bool(std::string_view, const pinned_entry&)>& visitor) const;
 
-  /// The pinned entry whose duckdb identity matches catalog.schema.table, or
-  /// nullptr. Non-owning; valid only until the next pin/unpin — the same
-  /// single-threaded query-lifecycle discipline as visit_pinned_entries.
-  /// First match wins if one table was pinned under two names. Read by the
-  /// plan-time MVCC guards.
-  [[nodiscard]] pinned_entry const* find_pinned_entry_for_duckdb_table(
+  /// The pinned entry whose duckdb identity matches catalog.schema.table, or nullptr.
+  /// OWNING: the returned shared_ptr keeps the entry alive for as long as the caller holds
+  /// it, so a concurrent unpin on another connection cannot pull it out from under the
+  /// plan-time MVCC guards that read it. First match wins if one table was pinned under two
+  /// names.
+  [[nodiscard]] std::shared_ptr<const pinned_entry> find_pinned_entry_for_duckdb_table(
     std::string_view catalog_name, std::string_view schema_name, std::string_view table_name) const;
 
   parquet_bind_result describe_parquet(std::string const& uri);
@@ -485,17 +528,86 @@ class sirius_scan_manager {
   [[nodiscard]] std::size_t s3_list_max_matches(std::string const& s3_uri);
 
  private:
-  /// \brief Run providers sequentially: start each, wait on its future, advance.
-  void start_metadata_processing();
+  /**
+   * @brief Everything the scan manager holds on behalf of ONE query.
+   *
+   * Handed out as a `shared_ptr` keyed by query id: a caller resolves it under the state
+   * mutex and uses it outside, so an erase racing a reader cannot pull the state out from
+   * under them. The manager's shared members (ioctxs, registry, pinned entries, thread pool)
+   * stay outside — they are process-wide and outlive every query. What lives here is exactly
+   * what the old global `reset()` used to wipe, and wiping it globally is what made
+   * finishing query A tear down query B's scan work.
+   *
+   * Operator ids restart at 0 for every query, so `metadata_processor`'s slot map (keyed by
+   * `scan_op->get_operator_id()`) is unique only *within* an entry; one shared coalescer
+   * would let two queries' scans collide on the same slot.
+   *
+   * Member order is teardown order: `dispatcher` is declared LAST so it is destroyed FIRST,
+   * while the coalescer and providers its tasks captured are still alive. The destructor's
+   * `drain()` makes that safe even if a member is later added below it.
+   */
+  struct query_scan_manager_state {
+    ~query_scan_manager_state() { drain(); }
+
+    query_scan_manager_state()                                           = default;
+    query_scan_manager_state(const query_scan_manager_state&)            = delete;
+    query_scan_manager_state& operator=(const query_scan_manager_state&) = delete;
+    query_scan_manager_state(query_scan_manager_state&&)                 = delete;
+    query_scan_manager_state& operator=(query_scan_manager_state&&)      = delete;
+
+    //! Stop and join every task this query put on the shared pool. Idempotent, and safe to
+    //! call outside the state mutex — it can block for as long as an in-flight read.
+    void drain() noexcept;
+
+    //! One scan operator and the disk-reading provider built for it (null when the operator
+    //! matched a pinned entry and is served from the cache instead). A vector rather than a
+    //! map plus a parallel order vector: the only traversal is registration order, and one
+    //! container makes the "already registered" guard cover cache-matched operators too.
+    struct scan_entry {
+      op::scan::sirius_gpu_scan_operator* op{nullptr};
+      std::unique_ptr<split_provider> provider;  ///< null for a cache-served operator
+    };
+    std::vector<scan_entry> scans;
+
+    //! Per-query snapshot of the serve-side pruning flag; the manager's _config is a
+    //! construction-time copy, so SET changes arrive per query via prepare_for_query.
+    bool pruning_enabled{true};
+
+    //! One mask computation per distinct pinned entry matched by THIS query (recorded by
+    //! try_match_cached_entry, deduped by entry name); run block-in-prepare, then copied
+    //! into each provider and cleared. Per-query by nature: two queries over the same entry
+    //! see different MVCC snapshots and each needs its own masks.
+    std::vector<mvcc_mask_job_request> pending_mvcc_mask_jobs;
+
+    //! One insert-delta job per distinct pinned entry matched by this query, with the same
+    //! dedup and lifecycle as the mask jobs above.
+    std::vector<insert_delta_job_request> pending_insert_delta_jobs;
+
+    //! This query's sequencer for opportunistic fadvise calls; gets one pipeline slot per
+    //! scan. Its slot map is keyed by operator id, which restarts at 0 per query.
+    std::unique_ptr<load_balancing_scan_batch_coalescer> metadata_processor;
+
+    //! This query's scope for every scan task it puts on the SHARED pool. request_stop()
+    //! here stops only this query's work; the pool and every other query keep running.
+    std::unique_ptr<exec::scoped_dispatcher> dispatcher;
+  };
+
+  /// \brief Run @p state 's providers sequentially: start each, wait on its future, advance.
+  void start_metadata_processing(query_scan_manager_state& state);
+
+  //! Resolve a query's state, or nullptr when it has already been reset.
+  [[nodiscard]] std::shared_ptr<query_scan_manager_state> get_query_state(
+    sirius::query_id_t query_id) const;
 
   /// One matched (scan op ← pinned entry) pairing from the cache-match pass.
   /// Provider construction is deferred to after run_mvcc_mask_jobs so each
-  /// provider takes its own copy of the entry's completed mask set; the entry
-  /// pointer stays valid for the whole prepare (pin/unpin is
-  /// query-lifecycle-serialized).
+  /// provider takes its own copy of the entry's completed mask set. The
+  /// assignment SHARES OWNERSHIP of the entry across that gap: the mask and
+  /// insert-delta jobs block for as long as their IO takes, and with concurrent
+  /// queries another connection may unpin in that window.
   struct cached_assignment {
     op::scan::sirius_gpu_scan_operator* op{nullptr};
-    pinned_entry const* entry{nullptr};
+    std::shared_ptr<pinned_entry const> entry;
     std::vector<std::size_t> columns;  ///< selected columns, materialized order
     std::string entry_name;            ///< handoff key into _pending_mvcc_mask_jobs
     cached_scan_plan plan;             ///< zone-map survivor plan, moved into the provider
@@ -507,8 +619,13 @@ class sirius_scan_manager {
   ///        returns the assignment for the post-mask-run provider handoff.
   ///        Returns nullopt on a miss (the caller then builds the
   ///        disk-reading split_provider for this operator).
+  ///
+  ///        Mask and insert-delta jobs are queued into @p state, and @p state 's
+  ///        pruning_enabled decides whether the survivor plan applies zone-map filters. The
+  ///        dedup is therefore per-query, which is the point: two concurrent queries over
+  ///        the same pinned entry each queue their own job and take their own mask copies.
   [[nodiscard]] std::optional<cached_assignment> try_match_cached_entry(
-    op::scan::sirius_gpu_scan_operator* op);
+    op::scan::sirius_gpu_scan_operator* op, query_scan_manager_state& state);
 
   /// Resolve the ioctx that should serve @p path (normalized internally, so callers
   /// — including the scan resolver — may pass a raw `file://` / `s3://` URI),
@@ -523,7 +640,6 @@ class sirius_scan_manager {
   /// the GPU id set fed to the round-robin scan-balancing strategy.
   std::shared_ptr<const sirius::memory::topology_index> _topology_index;
   exec::static_thread_pool _thread_pool;
-  std::unique_ptr<exec::scoped_dispatcher> _dispatcher;
   std::shared_ptr<sirius::io::sirius_ioctx> _io_ctx;
   /// Lazily-built per-backend ioctxs for path-routed datasources (e.g. an s3://
   /// rest_ioctx alongside the local uring/kvikio `_io_ctx`).  Built exactly once
@@ -535,33 +651,23 @@ class sirius_scan_manager {
   std::mutex _routed_io_ctxs_mtx;
   std::unordered_map<sirius::io::io_context_type, std::shared_ptr<sirius::io::sirius_ioctx>>
     _routed_io_ctxs;
-  std::unordered_map<op::scan::sirius_gpu_scan_operator*, std::unique_ptr<split_provider>>
-    _providers_by_op;
-  std::vector<op::scan::sirius_gpu_scan_operator*> _scan_op_order;
-  std::unordered_map<std::string, pinned_entry> _pinned_entries;
-  bool _pruning_enabled{true};
+  /// The pin table. Shared across every query and outliving all of them, so entries are
+  /// held by shared_ptr rather than by value: a matched scan takes a reference for its
+  /// whole duration, and an unpin from another connection drops only the map slot, leaving
+  /// the data alive until the last serving provider releases it.
+  std::unordered_map<std::string, std::shared_ptr<pinned_entry>> _pinned_entries;
+  /// Guards the STRUCTURE of _pinned_entries (lookup/insert/erase) only, never the serving
+  /// of an entry — shared ownership covers that. Held only for map manipulation and the
+  /// snapshot in try_match_cached_entry, never across match/validate/plan work, so
+  /// concurrent prepares do not serialize behind each other.
+  mutable std::mutex _pinned_entries_mutex;
 
-  /// One mask computation per distinct pinned entry matched this query
-  /// (recorded by try_match_cached_entry, deduped by entry name); executed
-  /// block-in-prepare by run_mvcc_mask_jobs, after which the provider handoff
-  /// copies each completed set out and the vector is cleared (also cleared in
-  /// reset() for the prepare-threw case).
-  std::vector<mvcc_mask_job_request> _pending_mvcc_mask_jobs;
+  //! One entry per in-flight query. Guarded by _query_states_mutex; the shared_ptr is
+  //! resolved under the lock and used outside it, so an erase racing a reader cannot pull
+  //! the state out from under them.
+  std::map<sirius::query_id_t, std::shared_ptr<query_scan_manager_state>> _query_states;
+  mutable std::mutex _query_states_mutex;
 
-  /// One insert-delta job per distinct pinned entry matched this query, with
-  /// the same dedup and lifecycle as the mask jobs above. Later operators
-  /// union their columns into the pending request. The job no-ops when the
-  /// table has no rows beyond the pinned prefix.
-  std::vector<insert_delta_job_request> _pending_insert_delta_jobs;
-
-  /// Per-query sequencer for opportunistic fadvise calls.  Built fresh
-  /// in @ref prepare_for_query, gets one @c pipeline_slot per scan,
-  /// registered before the pinned-cache match.  The
-  /// sequencer task is enqueued on the
-  /// per-query @c _dispatcher, which injects its own stop_token; the
-  /// dispatcher's @c request_stop() in @ref reset() therefore tears the
-  /// sequencer down without an extra side-channel.
-  std::unique_ptr<load_balancing_scan_batch_coalescer> _metadata_processor;
   io::io_context_registry _ioctx_registry;
 };
 

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -486,15 +486,16 @@ class SiriusContext : public ClientContextState {
   /// \param handler The query's completion signal, owned by its sirius_engine. Stamped onto
   ///        every pipeline's task global state so tasks can report without any shared
   ///        "current query" handler.
-  void create_query(duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>> pipelines,
-                    sirius::query_id_t query_id,
-                    std::shared_ptr<sirius::pipeline::completion_handler> handler,
-                    sirius::telemetry::query_telemetry_info telemetry_info);
+  /// \return The constructed query. Ownership belongs to the caller (sirius_engine): the query
+  ///         is an index over that engine's plan, so outliving the plan would leave its cached
+  ///         operator pointers dangling for no benefit.
+  [[nodiscard]] duckdb::shared_ptr<sirius::planner::query> create_query(
+    duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>> pipelines,
+    sirius::query_id_t query_id,
+    std::shared_ptr<sirius::pipeline::completion_handler> handler,
+    sirius::telemetry::query_telemetry_info telemetry_info);
 
   /// \brief Get the current query.
-  [[nodiscard]] duckdb::shared_ptr<sirius::planner::query> get_query();
-  [[nodiscard]] duckdb::shared_ptr<const sirius::planner::query> get_query() const;
-
   /// \brief Get the current Sirius configuration (const).
   [[nodiscard]] const sirius::sirius_config& get_config() const noexcept { return config_; }
 
@@ -621,7 +622,6 @@ class SiriusContext : public ClientContextState {
   std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>> downgrade_executors_;
   std::unique_ptr<sirius::creator::task_creator> task_creator_;
   std::unique_ptr<sirius::scan_manager::sirius_scan_manager> scan_manager_;
-  duckdb::shared_ptr<sirius::planner::query> query_;
 
   std::atomic<uint64_t> transparent_rebind_success_count_{0};
   std::atomic<uint64_t> transparent_fallback_count_{0};

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -549,7 +549,7 @@ class SiriusContext : public ClientContextState {
 
   /// \brief Best-effort task_creator reset for latched-unavailable paths,
   /// where no later window will ever run the in-cleanup reset.
-  void drop_task_creator_state_best_effort() noexcept;
+  void drop_task_creator_state_best_effort(sirius::query_id_t query_id) noexcept;
 
   mutable std::mutex mutex_;
   // The Super Sirius runtime is shared across connections, so plan generation

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -19,6 +19,7 @@
 #include "creator/task_creator.hpp"
 #include "data/data_repository_manager_registry.hpp"
 #include "downgrade/downgrade_executor.hpp"
+#include "exec/query_lifecycle_registry.hpp"
 #include "memory/resource_ref_utils.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "pipeline/sirius_pipeline.hpp"
@@ -441,6 +442,12 @@ class SiriusContext : public ClientContextState {
   /// \brief The registry itself, for subsystems that hold a long-lived binding to it.
   [[nodiscard]] sirius::data::data_repository_manager_registry& get_data_repository_registry();
 
+  /// \brief The per-query enqueue gate, for tests and for subsystems that consult it directly.
+  [[nodiscard]] sirius::exec::query_lifecycle_registry& get_query_lifecycle_registry() noexcept
+  {
+    return query_lifecycle_;
+  }
+
   [[nodiscard]] sirius::pipeline::task_scheduler& get_task_scheduler();
   [[nodiscard]] const sirius::pipeline::task_scheduler& get_task_scheduler() const;
 
@@ -618,6 +625,11 @@ class SiriusContext : public ClientContextState {
   std::shared_ptr<const sirius::telemetry::telemetry_context> telemetry_context_;
   /// One data repository manager per in-flight query, keyed by query_id.
   sirius::data::data_repository_manager_registry data_repository_registry_;
+  /// Per-query "may work still be enqueued?" gate, consulted by every enqueue point in the
+  /// engine. Opened at window begin, quiesced at the top of the query's cleanup so the drains
+  /// below it cannot be outrun by a completion callback, and closed once they finish. Declared
+  /// before the subsystems that hold a pointer to it so it is destroyed after them.
+  sirius::exec::query_lifecycle_registry query_lifecycle_;
   std::unique_ptr<sirius::pipeline::task_scheduler> task_scheduler_;
   std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>> downgrade_executors_;
   std::unique_ptr<sirius::creator::task_creator> task_creator_;

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -630,6 +630,18 @@ class SiriusContext : public ClientContextState {
   /// below it cannot be outrun by a completion callback, and closed once they finish. Declared
   /// before the subsystems that hold a pointer to it so it is destroyed after them.
   sirius::exec::query_lifecycle_registry query_lifecycle_;
+  // Declaration order is destruction order reversed, and it is load-bearing here.
+  //
+  // task_scheduler is declared LAST so it is destroyed FIRST is wrong — it must be destroyed
+  // *after* everything that holds a pointer into it. Each downgrade_executor holds a raw pointer
+  // to task_scheduler::_task_queue, the task_creator's lambdas hold task_scheduler*, and
+  // ~task_scheduler joins a management thread that calls into task_creator. terminate() stops all
+  // of them in the right order explicitly; this ordering is the backstop for the path where
+  // terminate() never runs — initialize() throwing after task_scheduler_ is constructed leaves
+  // is_initialized_ false, so ~SiriusContext skips terminate() entirely and only these
+  // declarations decide the order.
+  //
+  // Destroyed: scan_manager_ -> task_creator_ -> downgrade_executors_ -> task_scheduler_.
   std::unique_ptr<sirius::pipeline::task_scheduler> task_scheduler_;
   std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>> downgrade_executors_;
   std::unique_ptr<sirius::creator::task_creator> task_creator_;

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -483,8 +483,12 @@ class SiriusContext : public ClientContextState {
   /// \brief Start a query with its pipelines.
   /// \param pipelines The ordered pipelines for the query.
   /// \param telemetry_info Info useful for emitting identifiable telemetry.
+  /// \param handler The query's completion signal, owned by its sirius_engine. Stamped onto
+  ///        every pipeline's task global state so tasks can report without any shared
+  ///        "current query" handler.
   void create_query(duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>> pipelines,
                     sirius::query_id_t query_id,
+                    std::shared_ptr<sirius::pipeline::completion_handler> handler,
                     sirius::telemetry::query_telemetry_info telemetry_info);
 
   /// \brief Get the current query.

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -547,9 +547,10 @@ class SiriusContext : public ClientContextState {
   void run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
                                       std::string_view end_tag) noexcept;
 
-  /// \brief Best-effort task_creator reset for latched-unavailable paths,
-  /// where no later window will ever run the in-cleanup reset.
-  void drop_task_creator_state_best_effort(sirius::query_id_t query_id) noexcept;
+  /// \brief Best-effort per-query teardown for latched-unavailable paths, where no later
+  /// window will ever run the in-cleanup reset: drops @p query_id's task_creator state and its
+  /// queued tasks. Each step is separately guarded; neither can throw.
+  void drop_query_runtime_state_best_effort(sirius::query_id_t query_id) noexcept;
 
   mutable std::mutex mutex_;
   // The Super Sirius runtime is shared across connections, so plan generation

--- a/src/include/sirius_engine.hpp
+++ b/src/include/sirius_engine.hpp
@@ -28,6 +28,7 @@
 #include "pipeline/pipeline_build_context.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
+#include "planner/query.hpp"
 #include "telemetry-bridge/gen/query.rs.h"
 #include "telemetry-bridge/gen/uuid.rs.h"
 #include "telemetry/telemetry_context.hpp"
@@ -108,6 +109,11 @@ class sirius_engine {
 
  private:
   sirius::query_id_t query_id_;
+  /// The planner query for this execution: the pipeline set plus the operator->pipeline and
+  /// scan-operator indices built over `sirius_owned_plan`. Owned here because it indexes this
+  /// engine's plan — outliving the plan would leave its cached operator pointers dangling with
+  /// nothing to gain.
+  duckdb::shared_ptr<planner::query> query_;
   /// This query's completion signal, created in execute() and shared with every task through
   /// its pipeline's global state. shared_ptr because this engine is destroyed (in
   /// sirius_interface::cleanup_internal) before the query's cleanup drains the task queues, so a

--- a/src/include/sirius_engine.hpp
+++ b/src/include/sirius_engine.hpp
@@ -24,6 +24,7 @@
 #include "duckdb/execution/task_error_manager.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_result_collector.hpp"
+#include "pipeline/completion_handler.hpp"
 #include "pipeline/pipeline_build_context.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
@@ -107,6 +108,11 @@ class sirius_engine {
 
  private:
   sirius::query_id_t query_id_;
+  /// This query's completion signal, created in execute() and shared with every task through
+  /// its pipeline's global state. shared_ptr because this engine is destroyed (in
+  /// sirius_interface::cleanup_internal) before the query's cleanup drains the task queues, so a
+  /// task still unwinding must be able to report without touching freed memory.
+  std::shared_ptr<pipeline::completion_handler> completion_handler_;
   std::shared_ptr<const telemetry::telemetry_context> telemetry_context_;
   rust::Box<quent::query::QueryHandle> query_handle_;
 };

--- a/src/io/cache/prefetching_cache.cpp
+++ b/src/io/cache/prefetching_cache.cpp
@@ -306,18 +306,25 @@ prefetching_cache::file_entry& prefetching_cache::get_or_create_file_entry(
   const sirius_io_object& obj)
 {
   const auto& key = obj.raw_file_cache_id();
-  std::shared_lock lk(_map_mtx);
-  auto it = _file_cache.find(key);
-  if (it == _file_cache.end()) {
-    lk.unlock();
-    std::unique_lock ulk(_map_mtx);
-    auto [new_it, inserted] = _file_cache.try_emplace(key, std::make_unique<file_entry>());
-    it                      = new_it;
-    if (inserted) {
-      it->second->file_size = obj.size();
-      it->second->io_obj    = obj.shared_from_this();
-      it->second->chunks.reserve((obj.size() + _chunk_size - 1) / _chunk_size);
-    }
+  // Capture the ENTRY POINTER while a lock is held, never the iterator. The insert branch below
+  // scopes its unique_lock to the `if`, so returning `*it->second` dereferenced an iterator with
+  // no lock held at all — and a concurrent insert of a different file rehashes _file_cache and
+  // invalidates it. The pointed-to file_entry is heap-allocated and stable across a rehash; only
+  // iterators and references into the map are not. Single-query runs first-touch every file in one
+  // prepare, which is why this only becomes reachable once two queries open different files.
+  file_entry* entry = nullptr;
+  {
+    std::shared_lock lk(_map_mtx);
+    if (auto it = _file_cache.find(key); it != _file_cache.end()) { entry = it->second.get(); }
+  }
+  if (entry != nullptr) { return *entry; }
+
+  std::unique_lock ulk(_map_mtx);
+  auto [it, inserted] = _file_cache.try_emplace(key, std::make_unique<file_entry>());
+  if (inserted) {
+    it->second->file_size = obj.size();
+    it->second->io_obj    = obj.shared_from_this();
+    it->second->chunks.reserve((obj.size() + _chunk_size - 1) / _chunk_size);
   }
   return *it->second;
 }
@@ -382,11 +389,20 @@ bool prefetching_cache::host_read_from_cache_only(const sirius_io_object& obj,
     }
   }
   if (chunks.empty()) {
-    std::shared_lock lk(_map_mtx);
-    auto it = _file_cache.find(obj.raw_file_cache_id());
-    if (it != _file_cache.end()) {
-      lk.unlock();
-      chunks = it->second->fetch_chunks(offset, size, coverage_policy::full, _chunk_size);
+    // Same rule as get_or_create_file_entry: take the entry pointer out under the lock, then drop
+    // the lock. `it` was being dereferenced after lk.unlock(), so a concurrent insert rehashing
+    // _file_cache invalidated it mid-call. fetch_chunks is deliberately called unlocked (it does
+    // its own locking and can be slow), which is why the pointer — stable across rehash — is what
+    // has to be carried across.
+    file_entry* entry = nullptr;
+    {
+      std::shared_lock lk(_map_mtx);
+      if (auto it = _file_cache.find(obj.raw_file_cache_id()); it != _file_cache.end()) {
+        entry = it->second.get();
+      }
+    }
+    if (entry != nullptr) {
+      chunks = entry->fetch_chunks(offset, size, coverage_policy::full, _chunk_size);
     }
   }
 

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -143,35 +143,71 @@ void itask_executor::drain_and_wait()
   _manager_thread = std::thread([this] { manager_loop(); });
 }
 
-void itask_executor::wait_and_validate_empty()
+void itask_executor::quiesce_manager()
 {
-  // Same quiescing as drain_and_wait(): interrupt the pool + queue so the manager
-  // exits, join it, and wait for all in-flight thread-pool tasks to finish.
+  // Releasing the manager thread's pool slot is a PRECONDITION for wait_all(), not an
+  // optimization. manager_loop() calls reserve() and then blocks in _task_queue.pop(), so an idle
+  // manager permanently holds an active slot; wait_all() waits for active_ == 0 and would never
+  // return. interrupt() makes reserve() hand back an invalid slot and pop() return nullptr, which
+  // is what lets the loop exit and the join succeed.
   _bounded_pool->interrupt();
   _task_queue.interrupt();
   if (_manager_thread.joinable()) { _manager_thread.join(); }
   _bounded_pool->wait_all();
+}
 
-  // Instead of draining, VALIDATE the queue is empty. A non-empty queue here means
-  // tasks were still scheduled on this executor when the query was declared complete.
-  const std::size_t remaining = _task_queue.size();
-
-  // Re-enable the pool/queue and restart the manager so the executor is left in a
-  // usable state for the next query, whether or not validation passes.
+void itask_executor::resume_manager()
+{
   _bounded_pool->resume();
   _task_queue.reactivate();
   _manager_thread = std::thread([this] { manager_loop(); });
+}
+
+void itask_executor::wait_and_validate_empty(sirius::query_id_t query_id)
+{
+  // Never started (or already stopped): nothing dispatched, nothing to validate. drain_and_wait()
+  // has always had this guard; the whole-executor variant this replaced did not, and
+  // null-dereferenced when a query failed before any work reached this executor.
+  if (!_bounded_pool) { return; }
+
+  quiesce_manager();
+  // Only THIS query's tasks must be gone. The previous version validated the WHOLE queue, so a
+  // query completing normally threw because a co-tenant had work legitimately queued.
+  const std::size_t remaining =
+    _task_queue.size(exec::query_index{static_cast<exec::query_key>(sirius::value_of(query_id))});
+  resume_manager();
 
   if (remaining != 0) {
     SIRIUS_LOG_ERROR(
-      "itask_executor::wait_and_validate_empty: task queue NOT empty at query completion — "
+      "itask_executor::wait_and_validate_empty: task queue NOT empty for query {} at completion — "
       "{} task(s) still queued; tasks were still being scheduled when the query was marked "
       "complete",
+      query_id,
       remaining);
     throw std::runtime_error(
       "task_executor: task queue not empty at query completion (" + std::to_string(remaining) +
       " task(s) remaining) — premature completion while work was still scheduled");
   }
+}
+
+void itask_executor::wait_and_drain_query(sirius::query_id_t query_id)
+{
+  // Error-path counterpart of wait_and_validate_empty: let in-flight work finish so no thread is
+  // still touching the failing query's plan, then drop that query's queued tasks.
+  //
+  // The quiesce/resume bracket is still whole-executor — see quiesce_manager() for why wait_all()
+  // requires it. What changed is the drain in the middle: drain_and_wait() cleared the ENTIRE
+  // queue here, destroying every co-tenant query's queued work and leaving those queries waiting
+  // on completions that could never arrive. Now only the failing query's tasks are dropped. The
+  // remaining cost is a brief stall of co-tenants across the bracket, which the query-aware
+  // bounded_thread_pool removes by making the in-flight wait per-query.
+  if (!_bounded_pool) {
+    drain_query_tasks(query_id);
+    return;
+  }
+  quiesce_manager();
+  drain_query_tasks(query_id);
+  resume_manager();
 }
 
 }  // namespace parallel

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -170,12 +170,21 @@ void itask_executor::wait_and_validate_empty(sirius::query_id_t query_id)
   // null-dereferenced when a query failed before any work reached this executor.
   if (!_bounded_pool) { return; }
 
-  quiesce_manager();
-  // Only THIS query's tasks must be gone. The previous version validated the WHOLE queue, so a
-  // query completing normally threw because a co-tenant had work legitimately queued.
+  // Per-query wait, no quiesce bracket. This is the success path: the query's completion handler
+  // has already fired, so nothing of this query remains to be popped and the pop-to-attach window
+  // that the error path must worry about cannot occur here. Untagged slots (a manager parked in
+  // pop()) are ignored by drain_and_wait, which is exactly what lets this return without stopping
+  // the executor -- and therefore without interrupting the shared queue and dropping a co-tenant's
+  // in-transit task, which the previous bracket did on EVERY successful completion.
+  // wait_for_query, NOT drain_and_wait: this is the success path, so the query's remaining work
+  // must be allowed to RUN. Dropping it here would silently discard tasks the query legitimately
+  // scheduled and then report success.
+  _bounded_pool->wait_for_query(query_id);
+
+  // Only THIS query's tasks must be gone. The original validated the WHOLE queue, so a query
+  // completing normally threw because a co-tenant had work legitimately queued.
   const std::size_t remaining =
     _task_queue.size(exec::query_index{static_cast<exec::query_key>(sirius::value_of(query_id))});
-  resume_manager();
 
   if (remaining != 0) {
     SIRIUS_LOG_ERROR(
@@ -195,12 +204,17 @@ void itask_executor::wait_and_drain_query(sirius::query_id_t query_id)
   // Error-path counterpart of wait_and_validate_empty: let in-flight work finish so no thread is
   // still touching the failing query's plan, then drop that query's queued tasks.
   //
-  // The quiesce/resume bracket is still whole-executor — see quiesce_manager() for why wait_all()
-  // requires it. What changed is the drain in the middle: drain_and_wait() cleared the ENTIRE
-  // queue here, destroying every co-tenant query's queued work and leaving those queries waiting
-  // on completions that could never arrive. Now only the failing query's tasks are dropped. The
-  // remaining cost is a brief stall of co-tenants across the bracket, which the query-aware
-  // bounded_thread_pool removes by making the in-flight wait per-query.
+  // This one KEEPS the quiesce bracket, deliberately. Unlike the success path, a failing query can
+  // still have tasks sitting in the queue that the manager is free to pop at any moment, and there
+  // is a window between pop() and slot::attach() where the task belongs to neither the queue nor
+  // the per-query slot count. Joining the manager is what closes it: after that, no task can be
+  // in-hand. The caller's next act is to let the plan be destroyed, so "almost certainly quiesced"
+  // is not good enough here.
+  //
+  // What did change: the drain in the middle is per-query. The original cleared the ENTIRE queue,
+  // destroying every co-tenant's queued work and leaving those queries waiting on completions that
+  // could never arrive. The residual cost is that co-tenant pushes are refused across the bracket
+  // — on the error path only, not on every successful completion as before.
   if (!_bounded_pool) {
     drain_query_tasks(query_id);
     return;

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -17,6 +17,7 @@
 #include "parallel/task_executor.hpp"
 
 #include "log/logging.hpp"
+#include "pipeline/gpu_pipeline_task.hpp"
 #include "pipeline/sirius_pipeline_itask.hpp"
 #include "telemetry/telemetry_context.hpp"
 
@@ -33,6 +34,9 @@ itask_executor::itask_executor(
   std::shared_ptr<const telemetry::telemetry_context> telemetry_context,
   std::optional<int> device_id)
   : _config(std::move(config)),
+    // Shared with the task_scheduler's queue so both derive a task's query the same way; see
+    // pipeline::index_keys_for.
+    _task_queue(&pipeline::index_keys_for),
     _telemetry_context(std::move(telemetry_context)),
     _task_queue_telemetry(std::make_unique<telemetry::TaskQueueHandleWrapper>(
       *_telemetry_context,
@@ -92,6 +96,11 @@ void itask_executor::wait_all()
 }
 
 void itask_executor::drain_leftover_tasks() { _task_queue.drain(); }
+
+void itask_executor::drain_query_tasks(sirius::query_id_t query_id)
+{
+  _task_queue.drain(exec::query_index{static_cast<exec::query_key>(sirius::value_of(query_id))});
+}
 
 void itask_executor::drain_and_wait()
 {

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -51,6 +51,12 @@ itask_executor::~itask_executor() { stop(); }
 void itask_executor::schedule(std::unique_ptr<itask> task)
 {
   if (task) {
+    // The OOM reschedule path re-enters here from a pool worker after a 50 ms backoff, so a
+    // drain for this query may already have passed. Refuse rather than re-arm work behind it.
+    if (_query_lifecycle != nullptr && !_query_lifecycle->accepts_work(sirius::make_query_id(
+                                         pipeline::index_keys_for(*task).query_id))) {
+      return;
+    }
     if (auto* pipeline_task = dynamic_cast<pipeline::sirius_pipeline_itask*>(task.get())) {
       pipeline_task->telemetry_handle().queued({
         .queue_resource_id      = _task_queue_telemetry->handle->uuid(),

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -131,12 +131,13 @@ void gpu_pipeline_executor::manager_loop()
     }
     auto* gpu_task = cast_to_gpu_pipeline_task(pipeline_task.get());
     if (!gpu_task) {
+      // Only gpu_pipeline_tasks are ever scheduled onto a GPU executor, so this is a
+      // programming error rather than a query failure. There is no pipeline here and therefore
+      // no query whose completion handler could own the error; reporting it to some arbitrary
+      // in-flight query would fail the wrong one. Fail the engine loudly instead.
       SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to cast pipeline task to gpu_pipeline_task");
-      if (_completion_handler) {
-        _completion_handler->report_error(
-          "GPU Pipeline Executor: Failed to cast pipeline task to gpu_pipeline_task");
-      }
-      break;
+      throw sirius::internal_exception(
+        "GPU Pipeline Executor: a non-gpu_pipeline_task reached the GPU executor queue");
     }
     // Pass this executor's memory space so cross-space inputs (host/disk tiers and GPU data on
     // another device, which prepare clones into this space) are counted in the reservation.
@@ -187,8 +188,8 @@ void gpu_pipeline_executor::manager_loop()
     if (!reservation) {
       SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to acquire memory reservation for task {}",
                        gpu_task->get_task_id());
-      if (_completion_handler) {
-        _completion_handler->report_error(
+      if (auto handler = gpu_task->get_completion_handler()) {
+        handler->report_error(
           "GPU Pipeline Executor: Failed to acquire memory reservation for task " +
           std::to_string(gpu_task->get_task_id()));
       }
@@ -251,8 +252,8 @@ void gpu_pipeline_executor::manager_loop()
           "downgrade for task {} (freed {} bytes)",
           gpu_task->get_task_id(),
           freed);
-        if (_completion_handler) {
-          _completion_handler->report_error(
+        if (auto handler = gpu_task->get_completion_handler()) {
+          handler->report_error(
             "GPU Pipeline Executor: Failed to acquire memory reservation "
             "after downgrade for task " +
             std::to_string(gpu_task->get_task_id()));
@@ -287,10 +288,9 @@ void gpu_pipeline_executor::manager_loop()
     } else {
       SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to cast local state for task {}",
                        gpu_task->get_task_id());
-      if (_completion_handler) {
-        _completion_handler->report_error(
-          "GPU Pipeline Executor: Failed to cast local state for task " +
-          std::to_string(gpu_task->get_task_id()));
+      if (auto handler = gpu_task->get_completion_handler()) {
+        handler->report_error("GPU Pipeline Executor: Failed to cast local state for task " +
+                              std::to_string(gpu_task->get_task_id()));
       }
       break;
     }
@@ -298,28 +298,31 @@ void gpu_pipeline_executor::manager_loop()
     auto* pipeline        = gpu_task->get_pipeline();
     auto exc_stream       = _stream_pool.acquire_stream(
       cucascade::memory::exclusive_stream_pool::stream_acquire_policy::GROW);
+    // Resolved once here: every report below belongs to THIS task's query, so a failure or
+    // completion can never land on another in-flight query's promise. The shared_ptr also keeps
+    // the handler alive past the owning sirius_engine, which is destroyed before query cleanup
+    // drains the queues.
+    auto completion = gpu_task->get_completion_handler();
     _bounded_pool->dispatch(
       std::move(slot),
       [this,
        task       = std::move(pipeline_task),
        exc_stream = std::move(exc_stream),
        consumers  = std::move(output_consumers),
+       completion = std::move(completion),
        pipeline]() mutable {
         try {
           task->execute(exc_stream);
           _tasks_executed.fetch_add(1, std::memory_order_relaxed);
         } catch (task_reschedule_exception& ex) {
-          if (_completion_handler && _completion_handler->has_error()) {
-            // If the completion handler is already in an error state, then we can just return and
-            // not try to reschedule
-            return;
-          }
+          // Only THIS query's error state suppresses the reschedule. Previously one query's
+          // failure silently stopped every other query's tasks from rescheduling.
+          if (completion && completion->has_error()) { return; }
           auto* gpu_task = cast_to_gpu_pipeline_task(task.get());
           if (!gpu_task) {
             SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to cast task for reschedule");
-            if (_completion_handler) {
-              _completion_handler->report_error(
-                "GPU Pipeline Executor: Failed to cast task for reschedule");
+            if (completion) {
+              completion->report_error("GPU Pipeline Executor: Failed to cast task for reschedule");
             }
             return;
           }
@@ -355,8 +358,8 @@ void gpu_pipeline_executor::manager_loop()
               MAX_RETRIES,
               ex.get_resume_operator_index(),
               ex.what());
-            if (_completion_handler) {
-              _completion_handler->report_error(std::make_exception_ptr(std::runtime_error(
+            if (completion) {
+              completion->report_error(std::make_exception_ptr(std::runtime_error(
                 "GPU pipeline task exceeded maximum retry limit (" + std::to_string(MAX_RETRIES) +
                 ") for original task " + std::to_string(orig_task_id) + ": " + ex.what())));
             }
@@ -422,12 +425,12 @@ void gpu_pipeline_executor::manager_loop()
         } catch (const std::exception& e) {
           SIRIUS_LOG_ERROR("GPU Pipeline Executor: Exception during task execution: {}", e.what());
           if (_task_creator) { _task_creator->stop(); }
-          if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
+          if (completion) { completion->report_error(std::current_exception()); }
           return;
         } catch (...) {
           SIRIUS_LOG_ERROR("GPU Pipeline Executor: unknown error during task execution");
           if (_task_creator) { _task_creator->stop(); }
-          if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
+          if (completion) { completion->report_error(std::current_exception()); }
           return;
         }
         if (auto* pipeline_task = dynamic_cast<sirius_pipeline_itask*>(task.get())) {
@@ -445,7 +448,7 @@ void gpu_pipeline_executor::manager_loop()
         // which may destroy the engine and its operators. We must not schedule
         // tasks that reference those operators after signaling completion.
         bool query_complete = false;
-        if (_completion_handler && pipeline) {
+        if (completion && pipeline) {
           auto sink = pipeline->get_sink();
           if (sink && sink->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
             query_complete = pipeline->is_pipeline_finished();
@@ -463,12 +466,12 @@ void gpu_pipeline_executor::manager_loop()
           }
         }
 
-        if (query_complete && _completion_handler) {
+        if (query_complete && completion) {
           // Scoped to the finishing query: its pending creation requests point at operators
           // that mark_completed() may let the engine destroy. Any other query's requests are
           // left alone.
           _task_creator->drain_pending_tasks(pipeline->get_query_id());
-          _completion_handler->mark_completed();
+          completion->mark_completed();
         }
       });
   }
@@ -490,11 +493,6 @@ bool gpu_pipeline_executor::is_task_queue_empty() const noexcept { return _task_
 executor_metrics gpu_pipeline_executor::get_metrics() const noexcept
 {
   return {_tasks_executed.load(std::memory_order_relaxed)};
-}
-
-void gpu_pipeline_executor::set_completion_handler(completion_handler* handler) noexcept
-{
-  _completion_handler = handler;
 }
 
 }  // namespace pipeline

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -464,7 +464,10 @@ void gpu_pipeline_executor::manager_loop()
         }
 
         if (query_complete && _completion_handler) {
-          _task_creator->drain_pending_tasks();
+          // Scoped to the finishing query: its pending creation requests point at operators
+          // that mark_completed() may let the engine destroy. Any other query's requests are
+          // left alone.
+          _task_creator->drain_pending_tasks(pipeline->get_query_id());
           _completion_handler->mark_completed();
         }
       });

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -485,7 +485,7 @@ void gpu_pipeline_executor::set_task_creator(sirius::creator::task_creator* task
   _task_creator = task_creator;
 }
 
-bool gpu_pipeline_executor::is_task_queue_empty() const noexcept { return _task_queue.is_empty(); }
+bool gpu_pipeline_executor::is_task_queue_empty() const noexcept { return _task_queue.empty(); }
 
 executor_metrics gpu_pipeline_executor::get_metrics() const noexcept
 {

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -155,6 +155,11 @@ void gpu_pipeline_executor::process_task(
       return;
     }
     iteration_completion = gpu_task->get_completion_handler();
+    // Attribute the reserved slot now that the task's query is known, so
+    // drain_and_wait(query_id) covers this execution. Not done at reserve() time: the manager
+    // parks in pop() holding the slot before any task exists, and counting that against a query
+    // would make its drain wait for work that may never arrive.
+    if (auto const* pipe = gpu_task->get_pipeline()) { slot.attach(pipe->get_query_id()); }
     // Pass this executor's memory space so cross-space inputs (host/disk tiers and GPU data on
     // another device, which prepare clones into this space) are counted in the reservation.
     auto reservation_info = gpu_task->get_estimated_reservation_size_info(_memory_space);

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -129,16 +129,32 @@ void gpu_pipeline_executor::manager_loop()
       SIRIUS_LOG_INFO("GPU Pipeline Executor: task queue interrupted, stopping manager loop");
       break;
     }
+    // Everything past this point is per-task and must not be able to stop the manager thread:
+    // it serves every in-flight query on this device.
+    process_task(std::move(pipeline_task), std::move(slot), manager_thread_telemetry);
+  }
+}
+
+void gpu_pipeline_executor::process_task(
+  std::unique_ptr<parallel::itask> pipeline_task,
+  exec::bounded_thread_pool::slot slot,
+  telemetry::TaskManagerLoopThreadHandleWrapper& manager_thread_telemetry) noexcept
+{
+  // Resolved as soon as the task is known so every failure path below — including an unexpected
+  // throw — fails THIS task's query rather than the engine.
+  std::shared_ptr<completion_handler> iteration_completion;
+  try {
     auto* gpu_task = cast_to_gpu_pipeline_task(pipeline_task.get());
     if (!gpu_task) {
       // Only gpu_pipeline_tasks are ever scheduled onto a GPU executor, so this is a
       // programming error rather than a query failure. There is no pipeline here and therefore
       // no query whose completion handler could own the error; reporting it to some arbitrary
-      // in-flight query would fail the wrong one. Fail the engine loudly instead.
+      // in-flight query would fail the wrong one. Drop it loudly instead: this used to throw,
+      // which escaped manager_loop (a std::thread entry function) and aborted the process.
       SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to cast pipeline task to gpu_pipeline_task");
-      throw sirius::internal_exception(
-        "GPU Pipeline Executor: a non-gpu_pipeline_task reached the GPU executor queue");
+      return;
     }
+    iteration_completion = gpu_task->get_completion_handler();
     // Pass this executor's memory space so cross-space inputs (host/disk tiers and GPU data on
     // another device, which prepare clones into this space) are counted in the reservation.
     auto reservation_info = gpu_task->get_estimated_reservation_size_info(_memory_space);
@@ -193,7 +209,7 @@ void gpu_pipeline_executor::manager_loop()
           "GPU Pipeline Executor: Failed to acquire memory reservation for task " +
           std::to_string(gpu_task->get_task_id()));
       }
-      break;
+      return;
     } else if (reservation->size() < bytes_needs && _downgrade_executor) {
       size_t shortfall    = bytes_needs - reservation->size();
       size_t partial_size = reservation->size();
@@ -233,10 +249,18 @@ void gpu_pipeline_executor::manager_loop()
             })
             .get();
       } catch (const std::exception& e) {
+        // The downgrade executor cancelled this request (its queue was drained). This task cannot
+        // get its reservation, so fail its query — previously this broke the manager loop, which
+        // killed this GPU for every other in-flight query and left them hanging forever.
         SIRIUS_LOG_INFO("GPU Pipeline Executor: downgrade request cancelled for task {}: {}",
                         gpu_task->get_task_id(),
                         e.what());
-        break;
+        if (iteration_completion) {
+          iteration_completion->report_error(
+            "GPU Pipeline Executor: downgrade request cancelled for task " +
+            std::to_string(gpu_task->get_task_id()) + ": " + e.what());
+        }
+        return;
       }
 
       if (new_reservation) {
@@ -258,7 +282,7 @@ void gpu_pipeline_executor::manager_loop()
             "after downgrade for task " +
             std::to_string(gpu_task->get_task_id()));
         }
-        break;
+        return;
       }
       if (reservation->size() < bytes_needs) {
         SIRIUS_LOG_WARN(
@@ -292,17 +316,18 @@ void gpu_pipeline_executor::manager_loop()
         handler->report_error("GPU Pipeline Executor: Failed to cast local state for task " +
                               std::to_string(gpu_task->get_task_id()));
       }
-      break;
+      return;
     }
     auto output_consumers = gpu_task->get_output_consumers();
     auto* pipeline        = gpu_task->get_pipeline();
     auto exc_stream       = _stream_pool.acquire_stream(
       cucascade::memory::exclusive_stream_pool::stream_acquire_policy::GROW);
-    // Resolved once here: every report below belongs to THIS task's query, so a failure or
-    // completion can never land on another in-flight query's promise. The shared_ptr also keeps
-    // the handler alive past the owning sirius_engine, which is destroyed before query cleanup
-    // drains the queues.
-    auto completion = gpu_task->get_completion_handler();
+    // Resolved once at the top of this function: every report below belongs to THIS task's query,
+    // so a failure or completion can never land on another in-flight query's promise. The
+    // shared_ptr also keeps the handler alive past the owning sirius_engine, which is destroyed
+    // before query cleanup drains the queues. Copied (not moved) into the lambda so the catch
+    // blocks below still have it if dispatch itself throws.
+    auto completion = iteration_completion;
     _bounded_pool->dispatch(
       std::move(slot),
       [this,
@@ -423,13 +448,14 @@ void gpu_pipeline_executor::manager_loop()
           this->schedule(std::move(new_task));
           return;
         } catch (const std::exception& e) {
+          // Report to THIS task's query only. This used to also call _task_creator->stop(), which
+          // interrupted the shared creation queue and tore down the shared pool — silently
+          // stalling every other in-flight query because one query's operator threw.
           SIRIUS_LOG_ERROR("GPU Pipeline Executor: Exception during task execution: {}", e.what());
-          if (_task_creator) { _task_creator->stop(); }
           if (completion) { completion->report_error(std::current_exception()); }
           return;
         } catch (...) {
           SIRIUS_LOG_ERROR("GPU Pipeline Executor: unknown error during task execution");
-          if (_task_creator) { _task_creator->stop(); }
           if (completion) { completion->report_error(std::current_exception()); }
           return;
         }
@@ -474,6 +500,21 @@ void gpu_pipeline_executor::manager_loop()
           completion->mark_completed();
         }
       });
+  } catch (const std::exception& e) {
+    // Reservation, stream acquisition and telemetry can all throw. Before this catch existed the
+    // throw escaped manager_loop's thread function and aborted the whole process.
+    SIRIUS_LOG_ERROR("GPU Pipeline Executor: Exception while preparing task for dispatch: {}",
+                     e.what());
+    try {
+      if (iteration_completion) { iteration_completion->report_error(std::current_exception()); }
+    } catch (...) {  // reporting must never take down the manager thread
+    }
+  } catch (...) {
+    SIRIUS_LOG_ERROR("GPU Pipeline Executor: unknown error while preparing task for dispatch");
+    try {
+      if (iteration_completion) { iteration_completion->report_error(std::current_exception()); }
+    } catch (...) {
+    }
   }
 }
 

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -36,6 +36,7 @@
 
 #include <cstdint>
 #include <format>
+#include <limits>
 #include <optional>
 #include <string>
 #include <unordered_set>
@@ -713,6 +714,31 @@ std::unique_ptr<gpu_pipeline_task> gpu_pipeline_task::create_rescheduled_task(
 {
   return std::make_unique<gpu_pipeline_task>(
     task_id, _data_repos, std::move(local_state), get_shared_global_state());
+}
+
+exec::index_keys index_keys_for(const sirius::parallel::itask& task)
+{
+  if (const auto* gpu_task = dynamic_cast<const gpu_pipeline_task*>(&task)) {
+    const exec::queue_priority priority = gpu_task->get_priority();
+
+    exec::query_key query_id         = 0;
+    exec::operator_key operator_type = op::SiriusPhysicalOperatorType::INVALID;
+    if (const auto* pipe = gpu_task->get_pipeline()) {
+      query_id = static_cast<exec::query_key>(sirius::value_of(pipe->get_query_id()));
+      if (auto source = pipe->get_source()) { operator_type = source->type; }
+    }
+
+    const auto pref = gpu_task->get_preferred_device_id();
+    return exec::index_keys{priority,
+                            operator_type,
+                            query_id,
+                            pref.has_value() ? pref.value() : exec::no_preferred_device};
+  }
+
+  return exec::index_keys{std::numeric_limits<exec::queue_priority>::max(),
+                          op::SiriusPhysicalOperatorType::INVALID,
+                          0,
+                          exec::no_preferred_device};
 }
 
 }  // namespace pipeline

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -202,48 +202,39 @@ void task_scheduler::terminate_query(const std::shared_ptr<completion_handler>& 
 
 void task_scheduler::drain_after_error(sirius::query_id_t query_id)
 {
-  SIRIUS_LOG_INFO("task_scheduler: draining after error");
-  // Teardown ordering is load-bearing. The scan/gpu executor drains below run
-  // in-flight tasks to completion, and a completing task schedules its
-  // downstream consumers via task_creator::schedule() (gpu_pipeline_executor and
-  // duckdb_scan_executor both do this). Each such request holds a raw
-  // sirius_physical_operator* owned by the engine, which is destroyed the moment
-  // execute() returns. If the task_creator is live (or restarted) while those
-  // requests are still in flight, its manager_loop dereferences a freed operator
-  // in get_operator_for_next_task() — a use-after-free that crashes intermittently
-  // under multi-partition sort with many in-flight pipeline tasks.
+  SIRIUS_LOG_INFO("task_scheduler: draining after error for query {}", query_id);
+  // Teardown ordering is load-bearing. The executor drains below run in-flight tasks to
+  // completion, and a completing task schedules its downstream consumers via
+  // task_creator::schedule(). Each such request holds a raw sirius_physical_operator* owned by
+  // the engine, which is destroyed the moment execute() returns. If those requests are processed
+  // after the plan dies, manager_loop dereferences a freed operator in
+  // get_operator_for_next_task() — a use-after-free seen under multi-partition sort with many
+  // in-flight pipeline tasks.
   //
-  // So: stop the task_creator FIRST and keep its queue interrupted across the
-  // executor drains. With the queue interrupted, schedule() pushes from
-  // completion callbacks return false and the requests (and their dangling
-  // operator pointers) are dropped instead of processed. Only AFTER every
-  // executor has quiesced do we drain the creation queue and restart the
-  // creator for the next query.
-  if (_task_creator) { _task_creator->stop_thread_pool(); }
+  // This used to be achieved by stopping the shared task_creator and keeping its queue
+  // interrupted across the drains, so that late schedule() pushes returned false. That worked but
+  // was process-wide: it halted task creation for EVERY in-flight query and dropped their queued
+  // requests too. The lifecycle gate does the same job scoped to one query — from here on,
+  // schedule() for this query is refused while every other query keeps producing.
+  if (_query_lifecycle != nullptr) { _query_lifecycle->quiesce(query_id); }
 
-  // Drain the top-level task queue so management_eventloop doesn't dispatch
-  // stale tasks from the failed query.
-  _task_queue.drain();
+  // Drop this query's queued work so management_eventloop cannot dispatch a stale task from it.
+  _task_queue.drain(exec::query_index{static_cast<exec::query_key>(sirius::value_of(query_id))});
 
-  // Interrupt each GPU executor's manager loop, wait for in-flight thread-pool
-  // tasks to finish, then restart the manager for the next query.
+  // Let in-flight tasks finish, then drop whatever this query still has staged per device.
   for (auto& [device_id, gpu_exec] : _gpu_executors) {
-    gpu_exec->drain_and_wait();
+    gpu_exec->wait_and_drain_query(query_id);
   }
 
-  // Now that no executor can generate further task_creation_requests, discard the ones this
-  // query accumulated — they hold raw operator pointers into a plan that QueryEnd is about to
-  // destroy. Scoped to this query: any other in-flight query keeps its pending requests.
+  // Discard the creation requests this query accumulated — they hold raw operator pointers into a
+  // plan that QueryEnd is about to destroy. Other queries keep their pending requests.
   if (_task_creator) { _task_creator->drain_pending_tasks(query_id); }
 
-  // Belt-and-suspenders: the executor restarts above emit device_ready signals,
-  // and the management loop may have dispatched a leftover task into an executor
-  // queue between the two drains. Clear the top-level queue once more so the
-  // next query starts from empty.
-  _task_queue.drain();
+  // A task completing during the drains above can have handed one more task to the scheduler
+  // queue before the gate refused its successor, so sweep this query once more.
+  _task_queue.drain(exec::query_index{static_cast<exec::query_key>(sirius::value_of(query_id))});
 
-  if (_task_creator) { _task_creator->start_thread_pool(); }
-  SIRIUS_LOG_INFO("task_scheduler: DONE draining after error");
+  SIRIUS_LOG_INFO("task_scheduler: DONE draining after error for query {}", query_id);
 }
 
 void task_scheduler::wait_for_completion(sirius::query_id_t query_id)
@@ -253,38 +244,36 @@ void task_scheduler::wait_for_completion(sirius::query_id_t query_id)
   // throw if not — a non-empty queue means tasks were still being scheduled when we
   // declared the query done.
   //
-  // Halt the producer (task_creator) first so the checks are not racing new task
-  // creation. The task_creator is always restarted afterwards (even on throw) so the
-  // next query can run.
-  if (_task_creator) { _task_creator->stop_thread_pool(); }
+  // Halt this query's producers so the checks are not racing its own task creation. This used to
+  // be _task_creator->stop_thread_pool(), which tore down the SHARED creation pool and interrupted
+  // the shared queue — halting every other in-flight query, and dropping their queued requests,
+  // on every successful completion. The gate does it for one query.
+  if (_query_lifecycle != nullptr) { _query_lifecycle->quiesce(query_id); }
+  const exec::query_index this_query{static_cast<exec::query_key>(sirius::value_of(query_id))};
   try {
-    // The task_scheduler's pipeline task queue must be empty.
-    if (const std::size_t remaining = _task_queue.size(); remaining != 0) {
+    // Only THIS query's tasks must be gone. The old check used the whole-queue size(), so query A
+    // completing normally threw "task queue not empty" because query B had work queued.
+    if (const std::size_t remaining = _task_queue.size(this_query); remaining != 0) {
       SIRIUS_LOG_ERROR(
-        "task_scheduler::wait_for_completion: pipeline _task_queue NOT empty at query "
+        "task_scheduler::wait_for_completion: pipeline _task_queue NOT empty for query {} at "
         "completion — {} task(s) still queued; work was still scheduled when the query was "
         "marked complete",
+        query_id,
         remaining);
       throw std::runtime_error(
         "task_scheduler: pipeline task queue not empty at query completion (" +
         std::to_string(remaining) + " task(s) remaining)");
     }
 
-    // Each executor must finish its in-flight tasks and then have an empty queue.
+    // Each executor must finish its in-flight tasks and then have none of this query's queued.
     for (auto& [device_id, gpu_exec] : _gpu_executors) {
-      gpu_exec->wait_and_validate_empty();
+      gpu_exec->wait_and_validate_empty(query_id);
     }
   } catch (...) {
-    if (_task_creator) {
-      _task_creator->drain_pending_tasks(query_id);
-      _task_creator->start_thread_pool();
-    }
+    if (_task_creator) { _task_creator->drain_pending_tasks(query_id); }
     throw;
   }
-  if (_task_creator) {
-    _task_creator->drain_pending_tasks(query_id);
-    _task_creator->start_thread_pool();
-  }
+  if (_task_creator) { _task_creator->drain_pending_tasks(query_id); }
 }
 
 void task_scheduler::drain_query_tasks(sirius::query_id_t query_id)
@@ -331,7 +320,10 @@ void task_scheduler::management_eventloop()
       }
     }
 
-    if (_task_queue.empty()) {
+    // _ready_devices can be empty here: this loop also wakes on task_available events, which carry
+    // no device, and a per-query drain can empty _task_queue between the push and this check.
+    // Dereferencing begin() on an empty vector is UB — it used to yield a garbage device id.
+    if (_task_queue.empty() && !_ready_devices.empty()) {
       // No query id: the task_creator picks the oldest live query itself, since this loop has
       // none to inherit.
       if (_task_creator) { _task_creator->schedule_lookahead(*_ready_devices.begin()); }

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -116,7 +116,22 @@ void task_scheduler::schedule(std::unique_ptr<sirius::parallel::itask> task)
       .queue_capacity_entries = 1,
     });
   }
-  _task_queue.push(std::move(task));
+  // Read before the move: reporting a drop needs the query, and `task` is gone after push().
+  const auto pushed_query =
+    task ? sirius::make_query_id(index_keys_for(*task).query_id) : sirius::make_query_id(0);
+  if (!_task_queue.push(std::move(task))) {
+    // push returns false only when the queue is interrupted. If the gate still reports this query
+    // as accepting work, the task is destroyed and its query waits forever on a completion that
+    // cannot arrive -- the silent-drop failure mode behind several "query just hangs" reports.
+    if (_query_lifecycle == nullptr || _query_lifecycle->accepts_work(pushed_query)) {
+      SIRIUS_LOG_ERROR(
+        "task_scheduler: task for query {} was DROPPED by an interrupted queue while the query was "
+        "still accepting work; that query will not complete",
+        pushed_query);
+    } else {
+      SIRIUS_LOG_DEBUG("task_scheduler: dropped a task for tearing-down query {}", pushed_query);
+    }
+  }
   if (_self_publisher) {
     auto wake                 = std::make_unique<task_request>();
     wake->kind                = task_request_kind::task_available;

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -51,35 +51,9 @@ task_scheduler::task_scheduler(
   std::shared_ptr<const telemetry::telemetry_context> telemetry_context,
   const cucascade::memory::system_topology_info* sys_topology,
   const std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>>* downgrade_executors)
-  : _task_queue([](const sirius::parallel::itask& task) -> exec::index_keys {
-      // Derive the multi-index keys from the task. The queue orders by priority
-      // (lower value = dispatched first) and additionally indexes by operator type,
-      // query id, and preferred device. Non-pipeline tasks fall back to the maximum
-      // priority so they sort last, with sentinel index keys.
-      if (const auto* gpu_task = dynamic_cast<const pipeline::gpu_pipeline_task*>(&task)) {
-        const exec::queue_priority priority = gpu_task->get_priority();
-        // Take the query id from the pipeline, NOT by unpacking it out of the priority's high
-        // bits: sirius::query_priority_bits masks the id to 31 bits, so the unpacked value
-        // diverges from the real query id once bit 31 is set, and a
-        // drain(query_index{value_of(query_id)}) would then silently miss this task.
-        exec::query_key query_id         = 0;
-        exec::operator_key operator_type = op::SiriusPhysicalOperatorType::INVALID;
-        if (const auto* pipe = gpu_task->get_pipeline()) {
-          query_id = static_cast<exec::query_key>(sirius::value_of(pipe->get_query_id()));
-          if (auto source = pipe->get_source()) { operator_type = source->type; }
-        }
-        const auto pref = gpu_task->get_preferred_device_id();
-        return exec::index_keys{priority,
-                                operator_type,
-                                query_id,
-                                pref.has_value() ? pref.value() : exec::no_preferred_device};
-      }
-      return exec::index_keys{std::numeric_limits<exec::queue_priority>::max(),
-                              op::SiriusPhysicalOperatorType::INVALID,
-                              0,
-                              exec::no_preferred_device};
-    }),
-    _telemetry_context(std::move(telemetry_context))
+  // Shared with every gpu_pipeline_executor's queue so both agree on which query a task
+  // belongs to; see pipeline::index_keys_for.
+  : _task_queue(&index_keys_for), _telemetry_context(std::move(telemetry_context))
 {
   _task_queue_telemetry = std::make_unique<telemetry::TaskQueueHandleWrapper>(
     *_telemetry_context, "task-scheduler-gpu-queue", _telemetry_context->shared_group_id());
@@ -182,10 +156,9 @@ void task_scheduler::set_task_creator(sirius::creator::task_creator& task_creato
 
 void task_scheduler::prepare_for_query(duckdb::shared_ptr<planner::query> query)
 {
-  // Drain leftover tasks from previous query
-  for (auto& [device_id, gpu_exec] : _gpu_executors) {
-    gpu_exec->drain_leftover_tasks();
-  }
+  // No leftover-task drain here: each query drops its own queued work at cleanup
+  // (drain_query_tasks from SiriusContext::run_mandatory_cleanup). Draining every executor at
+  // query START would discard any other in-flight query's tasks along with the stale ones.
 
   std::lock_guard lock(_query_mutex);
   _query = std::move(query);
@@ -312,6 +285,17 @@ void task_scheduler::wait_for_completion()
   if (_task_creator) {
     if (auto query_id = current_query_id()) { _task_creator->drain_pending_tasks(*query_id); }
     _task_creator->start_thread_pool();
+  }
+}
+
+void task_scheduler::drain_query_tasks(sirius::query_id_t query_id)
+{
+  // Pending work only, and only this query's: the scheduler's own queue first, then each GPU
+  // executor's staging queue. In-flight tasks are untouched — quiescing those is
+  // wait_for_completion / drain_after_error's job.
+  _task_queue.drain(exec::query_index{static_cast<exec::query_key>(sirius::value_of(query_id))});
+  for (auto& [device_id, gpu_exec] : _gpu_executors) {
+    gpu_exec->drain_query_tasks(query_id);
   }
 }
 

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -171,8 +171,15 @@ void task_scheduler::start_query(const planner::query& query)
 void task_scheduler::terminate_query(const std::shared_ptr<completion_handler>& handler,
                                      std::exception_ptr error)
 {
+  // Report to THIS query's handler and nothing else. This used to also call stop(), which closed
+  // the request channel, joined the management thread and stopped every GPU executor — for all
+  // queries — with no path that ever calls start() again. One query's creation error therefore
+  // hung every other in-flight query and every subsequent query in the process.
+  //
+  // No drain here: report_error wakes sirius_engine::execute's future.get(), whose catch runs
+  // drain_after_error(query_id) on the engine thread. Draining from here would re-enter the
+  // queues from inside a task_creator pool worker.
   if (handler) { handler->report_error(std::move(error)); }
-  stop();
 }
 
 void task_scheduler::drain_after_error(sirius::query_id_t query_id)

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -154,33 +154,9 @@ void task_scheduler::set_task_creator(sirius::creator::task_creator& task_creato
   }
 }
 
-void task_scheduler::prepare_for_query(duckdb::shared_ptr<planner::query> query)
+void task_scheduler::start_query(const planner::query& query)
 {
-  // No leftover-task drain here: each query drops its own queued work at cleanup
-  // (drain_query_tasks from SiriusContext::run_mandatory_cleanup). Draining every executor at
-  // query START would discard any other in-flight query's tasks along with the stale ones.
-
-  std::lock_guard lock(_query_mutex);
-  _query = std::move(query);
-
-  _completion_handler = std::make_unique<completion_handler>();
-
-  // Set completion handler on all executors
-  for (auto& [device_id, gpu_exec] : _gpu_executors) {
-    gpu_exec->set_completion_handler(_completion_handler.get());
-  }
-
-  // Reset the round-robin counter so the walk is reproducible across
-  // iterations of the same query (cache=table_gpu warm path keys cache
-  // entries by device_id; without this reset the second iteration's source
-  // tasks would assign to a different GPU and miss the cache entries).
-  _no_pref_rr_counter.store(0, std::memory_order_relaxed);
-}
-
-std::future<void> task_scheduler::start_query()
-{
-  std::scoped_lock lock(_query_mutex);
-  const auto& scans = _query->get_scan_operators();
+  const auto& scans = query.get_scan_operators();
 
   // A query with no schedulable scan can never complete. Plan generation should have
   // rejected it, so fail loudly instead of dereferencing an empty vector.
@@ -188,18 +164,18 @@ std::future<void> task_scheduler::start_query()
     throw std::runtime_error("task_scheduler: query has no schedulable scan sources");
   }
 
+  // The caller already holds the future from its own completion handler.
   _task_creator->schedule(scans.front());
-
-  return _completion_handler->get_awaitable();
 }
 
-void task_scheduler::terminate_query(std::exception_ptr error)
+void task_scheduler::terminate_query(const std::shared_ptr<completion_handler>& handler,
+                                     std::exception_ptr error)
 {
-  _completion_handler->report_error(std::move(error));
+  if (handler) { handler->report_error(std::move(error)); }
   stop();
 }
 
-void task_scheduler::drain_after_error()
+void task_scheduler::drain_after_error(sirius::query_id_t query_id)
 {
   SIRIUS_LOG_INFO("task_scheduler: draining after error");
   // Teardown ordering is load-bearing. The scan/gpu executor drains below run
@@ -233,9 +209,7 @@ void task_scheduler::drain_after_error()
   // Now that no executor can generate further task_creation_requests, discard the ones this
   // query accumulated — they hold raw operator pointers into a plan that QueryEnd is about to
   // destroy. Scoped to this query: any other in-flight query keeps its pending requests.
-  if (auto query_id = current_query_id(); query_id && _task_creator) {
-    _task_creator->drain_pending_tasks(*query_id);
-  }
+  if (_task_creator) { _task_creator->drain_pending_tasks(query_id); }
 
   // Belt-and-suspenders: the executor restarts above emit device_ready signals,
   // and the management loop may have dispatched a leftover task into an executor
@@ -247,7 +221,7 @@ void task_scheduler::drain_after_error()
   SIRIUS_LOG_INFO("task_scheduler: DONE draining after error");
 }
 
-void task_scheduler::wait_for_completion()
+void task_scheduler::wait_for_completion(sirius::query_id_t query_id)
 {
   // Once the query has signaled completion, NOTHING should still be queued. Rather
   // than drain (which would hide the bug), validate that every queue is empty and
@@ -277,13 +251,13 @@ void task_scheduler::wait_for_completion()
     }
   } catch (...) {
     if (_task_creator) {
-      if (auto query_id = current_query_id()) { _task_creator->drain_pending_tasks(*query_id); }
+      _task_creator->drain_pending_tasks(query_id);
       _task_creator->start_thread_pool();
     }
     throw;
   }
   if (_task_creator) {
-    if (auto query_id = current_query_id()) { _task_creator->drain_pending_tasks(*query_id); }
+    _task_creator->drain_pending_tasks(query_id);
     _task_creator->start_thread_pool();
   }
 }
@@ -297,13 +271,6 @@ void task_scheduler::drain_query_tasks(sirius::query_id_t query_id)
   for (auto& [device_id, gpu_exec] : _gpu_executors) {
     gpu_exec->drain_query_tasks(query_id);
   }
-}
-
-std::optional<sirius::query_id_t> task_scheduler::current_query_id() const
-{
-  std::lock_guard lock(_query_mutex);
-  if (!_query) { return std::nullopt; }
-  return _query->query_id();
 }
 
 void task_scheduler::management_eventloop()
@@ -340,9 +307,9 @@ void task_scheduler::management_eventloop()
     }
 
     if (_task_queue.empty()) {
-      if (auto query_id = current_query_id(); query_id && _task_creator) {
-        _task_creator->schedule_lookahead(*query_id, *_ready_devices.begin());
-      }
+      // No query id: the task_creator picks the oldest live query itself, since this loop has
+      // none to inherit.
+      if (_task_creator) { _task_creator->schedule_lookahead(*_ready_devices.begin()); }
     }
 
     // Matcher: for each ready device, try to find a dispatchable task.
@@ -362,7 +329,8 @@ void task_scheduler::management_eventloop()
       // (lowest value) task preferring exactly this device.
       task = _task_queue.try_pop_from(exec::gpu_index{device_id}).value_or(nullptr);
       if (!task) {
-        // pick a task with no preference (any device will do). The round-robin counter
+        // Pick a task with no preference (any device will do). Which GPU gets it is decided by
+        // whichever executor signalled ready first, not by any counter.
         task =
           _task_queue.try_pop_from(exec::gpu_index{exec::no_preferred_device}).value_or(nullptr);
       }

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -58,13 +58,14 @@ task_scheduler::task_scheduler(
       // priority so they sort last, with sentinel index keys.
       if (const auto* gpu_task = dynamic_cast<const pipeline::gpu_pipeline_task*>(&task)) {
         const exec::queue_priority priority = gpu_task->get_priority();
-        // The scheduling priority packs query_id in its high 32 bits and the
-        // within-query pipeline rank in the low 32 (see task_creator), so the query
-        // id is recoverable here without extra plumbing.
-        const exec::query_key query_id =
-          static_cast<exec::query_key>(static_cast<std::uint64_t>(priority) >> 32);
+        // Take the query id from the pipeline, NOT by unpacking it out of the priority's high
+        // bits: sirius::query_priority_bits masks the id to 31 bits, so the unpacked value
+        // diverges from the real query id once bit 31 is set, and a
+        // drain(query_index{value_of(query_id)}) would then silently miss this task.
+        exec::query_key query_id         = 0;
         exec::operator_key operator_type = op::SiriusPhysicalOperatorType::INVALID;
         if (const auto* pipe = gpu_task->get_pipeline()) {
+          query_id = static_cast<exec::query_key>(sirius::value_of(pipe->get_query_id()));
           if (auto source = pipe->get_source()) { operator_type = source->type; }
         }
         const auto pref = gpu_task->get_preferred_device_id();
@@ -256,12 +257,12 @@ void task_scheduler::drain_after_error()
     gpu_exec->drain_and_wait();
   }
 
-  // Now that no executor can generate further task_creation_requests, discard
-  // any that accumulated (and release the shared_ptr<data_batch> references they
-  // hold, which would otherwise survive clear_all_repositories at QueryEnd and
-  // show up as inter-iteration "memory leak" warnings). drain_pending_tasks()
-  // reactivates the queue when done.
-  if (_task_creator) { _task_creator->drain_pending_tasks(); }
+  // Now that no executor can generate further task_creation_requests, discard the ones this
+  // query accumulated — they hold raw operator pointers into a plan that QueryEnd is about to
+  // destroy. Scoped to this query: any other in-flight query keeps its pending requests.
+  if (auto query_id = current_query_id(); query_id && _task_creator) {
+    _task_creator->drain_pending_tasks(*query_id);
+  }
 
   // Belt-and-suspenders: the executor restarts above emit device_ready signals,
   // and the management loop may have dispatched a leftover task into an executor
@@ -303,15 +304,22 @@ void task_scheduler::wait_for_completion()
     }
   } catch (...) {
     if (_task_creator) {
-      _task_creator->drain_pending_tasks();
+      if (auto query_id = current_query_id()) { _task_creator->drain_pending_tasks(*query_id); }
       _task_creator->start_thread_pool();
     }
     throw;
   }
   if (_task_creator) {
-    _task_creator->drain_pending_tasks();
+    if (auto query_id = current_query_id()) { _task_creator->drain_pending_tasks(*query_id); }
     _task_creator->start_thread_pool();
   }
+}
+
+std::optional<sirius::query_id_t> task_scheduler::current_query_id() const
+{
+  std::lock_guard lock(_query_mutex);
+  if (!_query) { return std::nullopt; }
+  return _query->query_id();
 }
 
 void task_scheduler::management_eventloop()
@@ -348,7 +356,9 @@ void task_scheduler::management_eventloop()
     }
 
     if (_task_queue.empty()) {
-      if (_task_creator) { _task_creator->schedule_lookahead(*_ready_devices.begin()); }
+      if (auto query_id = current_query_id(); query_id && _task_creator) {
+        _task_creator->schedule_lookahead(*query_id, *_ready_devices.begin());
+      }
     }
 
     // Matcher: for each ready device, try to find a dispatchable task.

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -103,6 +103,13 @@ task_scheduler::~task_scheduler() { stop(); }
 
 void task_scheduler::schedule(std::unique_ptr<sirius::parallel::itask> task)
 {
+  // Refuse work for a query that is tearing down. A task creation worker can land here after
+  // that query's queue drain already ran, and the task would then sit in the shared queue holding
+  // raw repository pointers into a manager about to be erased.
+  if (_query_lifecycle != nullptr && task &&
+      !_query_lifecycle->accepts_work(sirius::make_query_id(index_keys_for(*task).query_id))) {
+    return;
+  }
   if (auto* pipeline_task = dynamic_cast<sirius_pipeline_itask*>(task.get())) {
     pipeline_task->telemetry_handle().queued({
       .queue_resource_id      = _task_queue_telemetry->handle->uuid(),
@@ -151,6 +158,17 @@ void task_scheduler::set_task_creator(sirius::creator::task_creator& task_creato
 
   for (auto& [device_id, gpu_exec] : _gpu_executors) {
     gpu_exec->set_task_creator(_task_creator);
+  }
+}
+
+void task_scheduler::set_query_lifecycle_registry(sirius::exec::query_lifecycle_registry* registry)
+{
+  _query_lifecycle = registry;
+
+  // Propagated so each device queue refuses a dying query's tasks too — notably the OOM
+  // reschedule, which re-enters itask_executor::schedule from a worker thread.
+  for (auto& [device_id, gpu_exec] : _gpu_executors) {
+    gpu_exec->set_query_lifecycle_registry(registry);
   }
 }
 

--- a/src/planner/query.cpp
+++ b/src/planner/query.cpp
@@ -35,6 +35,9 @@ query::query(duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>> pipel
 void query::build_indices()
 {
   for (const auto& pipeline : _pipelines) {
+    // Stamp the query id so the task queues can derive their per-query index key from a
+    // pipeline without recovering it from the (31-bit-masked) scheduling priority.
+    pipeline->set_query_id(_query_id);
     for (auto& op : pipeline->get_operators()) {
       op.get().set_pipeline(pipeline);
     }

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -155,7 +155,9 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
         }
       }
 
-      sirius::scan_manager::pinned_entry const* entry = nullptr;
+      // Owning: holds the entry alive across the guards below, so a concurrent UNPIN on
+      // another connection cannot invalidate it mid-check.
+      std::shared_ptr<const sirius::scan_manager::pinned_entry> entry;
       if (context.registered_state) {
         if (auto sirius_state =
               context.registered_state->Get<duckdb::SiriusContext>("sirius_state")) {

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -269,13 +269,14 @@ sirius_scan_manager::sirius_scan_manager(
   : _config(config),
     _reservation_manager(reservation_manager),
     _topology_index(std::move(topology_index)),
-    // num_threads + k_max_concurrent_queries, not num_threads + 1: each query's coalescer
+    // num_threads + max_concurrent_queries, not num_threads + 1: each query's coalescer
     // sequencer task BLOCKS (worker_loop -> process_provider_inputs -> queue.wait_dequeue)
     // and is unblocked only by that query's own split_provider tasks, which run on this same
     // pool. With Q concurrent queries, Q threads are parked in sequencers at all times, so
     // sizing for a single sequencer would let Q queries consume the entire working budget
-    // and deadlock by starvation. See k_max_concurrent_queries for the bound and its TODO.
-    _thread_pool(_config.thread_pool.num_threads + k_max_concurrent_queries,
+    // and deadlock by starvation. The bound is now a real config option, so raising concurrency
+    // and resizing the pool are the same knob.
+    _thread_pool(_config.thread_pool.num_threads + config.max_concurrent_queries,
                  _config.thread_pool.thread_name_prefix,
                  _config.thread_pool.cpu_affinity_list),
     _ioctx_registry(config, reservation_manager)
@@ -594,19 +595,20 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
   // locally and never leaves a half-built entry visible to reset() or a concurrent prepare.
   {
     std::lock_guard lk{_query_states_mutex};
-    if (_query_states.size() >= static_cast<std::size_t>(k_max_concurrent_queries)) {
-      // The pool is sized for k_max_concurrent_queries parked sequencers; past that, each
+    if (_query_states.size() >= static_cast<std::size_t>(_config.max_concurrent_queries)) {
+      // The pool is sized for max_concurrent_queries parked sequencers; past that, each
       // extra query eats into the working budget and at pool size it deadlocks outright.
       // Loud rather than silent, so the missing config option reports itself the first time
-      // real concurrency is exercised. See k_max_concurrent_queries.
+      // real concurrency is exercised.
       SIRIUS_LOG_WARN(
         "[sirius_scan_manager::prepare_for_query] registering query {} brings the live query "
         "count to {}, above the {} the scan thread pool is sized for; scan throughput will "
-        "degrade and {} concurrent queries would deadlock. Raise k_max_concurrent_queries.",
+        "degrade and {} concurrent queries would deadlock. Raise "
+        "scan_manager.max_concurrent_queries.",
         query_id,
         _query_states.size() + 1,
-        k_max_concurrent_queries,
-        _thread_pool.num_threads() + k_max_concurrent_queries);
+        _config.max_concurrent_queries,
+        _thread_pool.num_threads() + _config.max_concurrent_queries);
     }
     _query_states.emplace(query_id, state);
   }

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -71,14 +71,25 @@ namespace sirius::scan_manager {
 namespace {
 
 struct cached_databatch_provider : public databatch_provider {
-  cached_databatch_provider(pinned_entry const& entry,
+  /// Dereference the owned entry, refusing a null. The reference member below binds to the
+  /// result, so a null here would be an unnoticed UB rather than a loud failure.
+  static pinned_entry const& deref_or_throw(std::shared_ptr<pinned_entry const> const& entry)
+  {
+    if (!entry) {
+      throw std::invalid_argument("[cached_databatch_provider] pinned entry must be non-null");
+    }
+    return *entry;
+  }
+
+  cached_databatch_provider(std::shared_ptr<pinned_entry const> entry,
                             std::span<std::size_t const> selected_columns,
                             cached_scan_plan plan,
                             const telemetry::batch_telemetry_info& telemetry_info,
                             mvcc_chunk_mask_set mvcc_masks,
                             std::vector<insert_delta_split> delta_splits)
     : _plan(std::move(plan)),
-      _entry(entry),
+      _entry_owner(std::move(entry)),
+      _entry(deref_or_throw(_entry_owner)),
       _telemetry_info(telemetry_info),
       _mvcc_masks(std::move(mvcc_masks)),
       _delta_splits(std::move(delta_splits))
@@ -198,6 +209,10 @@ struct cached_databatch_provider : public databatch_provider {
   cached_scan_plan _plan;
   std::vector<std::string> _column_names;
   std::vector<size_t> _column_indices;
+  /// Shared ownership of the served entry, keeping it alive for this provider's whole life.
+  /// A concurrent unpin drops the scan manager's map slot but not the data underneath us.
+  /// MUST stay declared before _entry, which binds to it.
+  std::shared_ptr<pinned_entry const> _entry_owner;
   const pinned_entry& _entry;
   telemetry::batch_telemetry_info _telemetry_info;
   /// This provider's own copy of the entry's per-chunk keep-masks (empty for
@@ -254,11 +269,15 @@ sirius_scan_manager::sirius_scan_manager(
   : _config(config),
     _reservation_manager(reservation_manager),
     _topology_index(std::move(topology_index)),
-    _thread_pool(_config.thread_pool.num_threads + 1,
+    // num_threads + k_max_concurrent_queries, not num_threads + 1: each query's coalescer
+    // sequencer task BLOCKS (worker_loop -> process_provider_inputs -> queue.wait_dequeue)
+    // and is unblocked only by that query's own split_provider tasks, which run on this same
+    // pool. With Q concurrent queries, Q threads are parked in sequencers at all times, so
+    // sizing for a single sequencer would let Q queries consume the entire working budget
+    // and deadlock by starvation. See k_max_concurrent_queries for the bound and its TODO.
+    _thread_pool(_config.thread_pool.num_threads + k_max_concurrent_queries,
                  _config.thread_pool.thread_name_prefix,
                  _config.thread_pool.cpu_affinity_list),
-    _dispatcher(
-      std::make_unique<exec::scoped_dispatcher>(_thread_pool, _thread_pool.num_threads())),
     _ioctx_registry(config, reservation_manager)
 {
   if (!_topology_index) {
@@ -384,9 +403,32 @@ parquet_bind_result sirius_scan_manager::describe_parquet(std::string const& uri
 void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
                                             bool enable_pinned_zone_map_pruning)
 {
-  _pruning_enabled = enable_pinned_zone_map_pruning;
-  reset();
+  auto const query_id = query.query_id();
 
+  // No global reset here. It used to be how the previous query's state was dropped; with
+  // concurrent queries that would tear down whatever is still running. Each query's state is
+  // dropped by its own reset(query_id) at window cleanup.
+  //
+  // A duplicate id means the previous window's cleanup never ran (a failed query on a
+  // latched-unavailable runtime). Drain and replace it rather than leaking a live dispatcher.
+  if (get_query_state(query_id) != nullptr) {
+    SIRIUS_LOG_WARN(
+      "[sirius_scan_manager::prepare_for_query] query {} was already registered; its cleanup "
+      "never ran. Draining and replacing the stale state.",
+      query_id);
+    reset(query_id);
+  }
+
+  // KNOWN GAP under concurrent queries: the prefetch cache's query epoch is a single GLOBAL
+  // generation counter (prefetching_cache::_ticker, bumped in
+  // prefetching_cache::prepare_for_query, src/io/cache/prefetching_cache.cpp).
+  // chunk_lifecycle::eviction_tier(query_tick) (src/include/io/cache/types.hpp) scores every
+  // chunk whose tick is older than the newest as tier 0 — evict first — so a second query
+  // starting here demotes all of the first query's prefetched-but-unconsumed chunks to the
+  // front of the eviction order. Performance only, never correctness: mark_evicting()
+  // succeeds only at pin == 0, so a chunk a live reader holds cannot be reclaimed; the query
+  // just re-reads on a miss. The fix belongs in prefetching_cache (track the set of live
+  // epochs rather than newest-wins), not here.
   if (_io_ctx && _io_ctx->cache()) {
     SIRIUS_LOG_INFO("[sirius_scan_manager] cache summary: {}", _io_ctx->cache()->summary());
     _io_ctx->cache()->prepare_for_query(query);
@@ -395,7 +437,7 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
   // Routed ioctxs (e.g. the restful context serving s3://) are built lazily and
   // reused across queries; advance their caches to this query too, or a routed
   // cache's epoch freezes at build time and a later query serves the prior
-  // query's cached chunks as current.
+  // query's cached chunks as current. Same global-epoch caveat as above.
   {
     std::lock_guard lk{_routed_io_ctxs_mtx};
     for (auto& [type, io_ctx] : _routed_io_ctxs) {
@@ -407,22 +449,33 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
   auto round_robin =
     std::make_shared<round_robin_strategy>(std::vector<int>(gpu_ids.begin(), gpu_ids.end()));
 
-  _metadata_processor = std::make_unique<load_balancing_scan_batch_coalescer>();
+  auto state             = std::make_shared<query_scan_manager_state>();
+  state->pruning_enabled = enable_pinned_zone_map_pruning;
+  // Deliberately NOT divided by the query count: a lone query must still be able to use the
+  // whole pool. Oversubscription across concurrent queries is absorbed by the dispatcher's
+  // pending queue and the pool, not by a per-query cap.
+  state->dispatcher =
+    std::make_unique<exec::scoped_dispatcher>(_thread_pool, _thread_pool.num_threads());
+  state->metadata_processor = std::make_unique<load_balancing_scan_batch_coalescer>();
 
   std::vector<cached_assignment> cached_assignments;
   for (auto const& scan_op : query.get_scan_operators()) {
     if (scan_op->type != ::sirius::op::SiriusPhysicalOperatorType::GPU_SCAN) { continue; }
     auto* op = &scan_op->Cast<op::scan::sirius_gpu_scan_operator>();
-    if (_providers_by_op.find(op) != _providers_by_op.end()) { continue; }
-    _metadata_processor->register_pipeline(op, round_robin);
+    // One container for cached and disk-read scans alike, so this guard covers both. The old
+    // providers-map guard missed cache-matched operators (they were recorded only in the
+    // order vector), which would have let a repeated operator register its coalescer slot
+    // twice and clobber itself.
+    if (std::ranges::any_of(state->scans, [op](auto const& s) { return s.op == op; })) { continue; }
+    state->metadata_processor->register_pipeline(op, round_robin);
     // On a pinned-cache hit the coalescer serves this operator from a cached
     // batch_provider (process_cached_entries); skip the disk-reading
     // split_provider entirely so no read is issued for the cached scan. The
     // provider itself is built after the mask jobs run (below), so it can
     // take a copy of the entry's finished mask set.
-    if (auto assignment = try_match_cached_entry(op)) {
+    if (auto assignment = try_match_cached_entry(op, *state)) {
       cached_assignments.push_back(std::move(*assignment));
-      _scan_op_order.push_back(op);
+      state->scans.push_back({op, nullptr});
       continue;
     }
     auto provider = std::make_unique<split_provider>(
@@ -435,13 +488,15 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
         }
         return io_ctx;
       });
-    _providers_by_op.emplace(op, std::move(provider));
-    _scan_op_order.push_back(op);
+    state->scans.push_back({op, std::move(provider)});
   }
 
-  if (_scan_op_order.empty()) {
+  if (state->scans.empty()) {
     SIRIUS_LOG_WARN(
       "[sirius_scan_manager::prepare_for_query] no GPU scan operators found in query");
+    // Deliberately NOT registered: there is nothing to tear down, so the matching
+    // reset(query_id) at window cleanup is a harmless no-op. `state` dies here, draining a
+    // dispatcher that never received work.
     return;
   }
 
@@ -451,17 +506,17 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
   // every scan op). The dispatcher is fresh and otherwise idle here. Errors
   // are loud: past the plan-time gate there is no CPU fallback, and the
   // alternative to failing is serving rows a concurrent DELETE removed.
-  if (!_pending_mvcc_mask_jobs.empty()) {
+  if (!state->pending_mvcc_mask_jobs.empty()) {
     run_mvcc_mask_jobs(
-      _pending_mvcc_mask_jobs, *_dispatcher, _reservation_manager, *_topology_index);
+      state->pending_mvcc_mask_jobs, *state->dispatcher, _reservation_manager, *_topology_index);
   }
   // Insert-delta jobs block in prepare for the same reason: staging and
   // masks must be finished before serving starts. No-op when no pinned
   // table has rows beyond its prefix.
-  if (!_pending_insert_delta_jobs.empty()) {
+  if (!state->pending_insert_delta_jobs.empty()) {
     std::vector<int> const delta_gpu_ids(gpu_ids.begin(), gpu_ids.end());
-    run_insert_delta_jobs(_pending_insert_delta_jobs,
-                          *_dispatcher,
+    run_insert_delta_jobs(state->pending_insert_delta_jobs,
+                          *state->dispatcher,
                           _reservation_manager,
                           *_topology_index,
                           delta_gpu_ids);
@@ -478,9 +533,9 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
     std::vector<insert_delta_split> delta_splits;
     if (assignment.entry->mvcc != nullptr) {
       auto request = std::ranges::find_if(
-        _pending_mvcc_mask_jobs,
+        state->pending_mvcc_mask_jobs,
         [&](mvcc_mask_job_request const& r) { return r.entry_name == assignment.entry_name; });
-      if (request == _pending_mvcc_mask_jobs.end()) {
+      if (request == state->pending_mvcc_mask_jobs.end()) {
         throw std::runtime_error(
           "[sirius_scan_manager::prepare_for_query] no mask job was queued for mvcc-pinned "
           "entry '" +
@@ -489,9 +544,10 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
       masks = request->masks;
 
       auto delta_request = std::ranges::find_if(
-        _pending_insert_delta_jobs,
+        state->pending_insert_delta_jobs,
         [&](insert_delta_job_request const& r) { return r.entry_name == assignment.entry_name; });
-      if (delta_request != _pending_insert_delta_jobs.end() && !delta_request->bundles.empty()) {
+      if (delta_request != state->pending_insert_delta_jobs.end() &&
+          !delta_request->bundles.empty()) {
         auto const* duckdb_info =
           dynamic_cast<op::scan::duckdb_native_ingestible_table_info const*>(
             &assignment.op->get_ingestible().table_info());
@@ -523,27 +579,50 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
           delta_request->plan.delta_rows());
       }
     }
-    auto provider = make_provider_for_pinned_entry(*assignment.entry,
+    auto provider = make_provider_for_pinned_entry(assignment.entry,
                                                    assignment.columns,
                                                    std::move(assignment.plan),
                                                    assignment.op->batch_telemetry(),
                                                    std::move(masks),
                                                    std::move(delta_splits));
-    _metadata_processor->use_cached_entries_for_pipeline(assignment.op, std::move(provider));
+    state->metadata_processor->use_cached_entries_for_pipeline(assignment.op, std::move(provider));
   }
-  _pending_mvcc_mask_jobs.clear();
-  _pending_insert_delta_jobs.clear();
+  state->pending_mvcc_mask_jobs.clear();
+  state->pending_insert_delta_jobs.clear();
 
-  start_metadata_processing();
+  // Publish only once the state is fully built: a prepare that threw above destroys `state`
+  // locally and never leaves a half-built entry visible to reset() or a concurrent prepare.
+  {
+    std::lock_guard lk{_query_states_mutex};
+    if (_query_states.size() >= static_cast<std::size_t>(k_max_concurrent_queries)) {
+      // The pool is sized for k_max_concurrent_queries parked sequencers; past that, each
+      // extra query eats into the working budget and at pool size it deadlocks outright.
+      // Loud rather than silent, so the missing config option reports itself the first time
+      // real concurrency is exercised. See k_max_concurrent_queries.
+      SIRIUS_LOG_WARN(
+        "[sirius_scan_manager::prepare_for_query] registering query {} brings the live query "
+        "count to {}, above the {} the scan thread pool is sized for; scan throughput will "
+        "degrade and {} concurrent queries would deadlock. Raise k_max_concurrent_queries.",
+        query_id,
+        _query_states.size() + 1,
+        k_max_concurrent_queries,
+        _thread_pool.num_threads() + k_max_concurrent_queries);
+    }
+    _query_states.emplace(query_id, state);
+  }
+
+  start_metadata_processing(*state);
 }
 
-void sirius_scan_manager::start_metadata_processing()
+void sirius_scan_manager::start_metadata_processing(query_scan_manager_state& state)
 {
-  _metadata_processor->spawn_workers(*_dispatcher);
-  for (auto* op : _scan_op_order) {
-    auto it = _providers_by_op.find(op);
-    if (it == _providers_by_op.end()) { continue; }
-    it->second->run(*_dispatcher, _metadata_processor->get_split_provider_bridge(op));
+  state.metadata_processor->spawn_workers(*state.dispatcher);
+  for (auto& scan : state.scans) {
+    // Null provider: the operator matched a pinned entry, and the coalescer already holds
+    // its cached databatch_provider (use_cached_entries_for_pipeline above).
+    if (!scan.provider) { continue; }
+    scan.provider->run(*state.dispatcher,
+                       state.metadata_processor->get_split_provider_bridge(scan.op));
   }
 }
 
@@ -657,23 +736,71 @@ std::shared_ptr<sirius::io::sirius_ioctx> sirius_scan_manager::ioctx_for_path(st
   return it->second;
 }
 
-void sirius_scan_manager::reset()
+void sirius_scan_manager::query_scan_manager_state::drain() noexcept
 {
-  _dispatcher->request_stop();
-  _dispatcher->wait_for_all();
-  _scan_op_order.clear();
-  _providers_by_op.clear();
-  _pending_mvcc_mask_jobs.clear();
-  _pending_insert_delta_jobs.clear();
-  _metadata_processor.reset();
-  _dispatcher = std::make_unique<exec::scoped_dispatcher>(_thread_pool, _thread_pool.num_threads());
+  if (!dispatcher) { return; }
+  dispatcher->request_stop();
+  dispatcher->wait_for_all();
+}
+
+std::shared_ptr<sirius_scan_manager::query_scan_manager_state> sirius_scan_manager::get_query_state(
+  sirius::query_id_t query_id) const
+{
+  std::lock_guard lk{_query_states_mutex};
+  auto it = _query_states.find(query_id);
+  return it == _query_states.end() ? nullptr : it->second;
+}
+
+void sirius_scan_manager::reset(sirius::query_id_t query_id)
+{
+  std::shared_ptr<query_scan_manager_state> state;
+  {
+    std::lock_guard lk{_query_states_mutex};
+    auto it = _query_states.find(query_id);
+    if (it == _query_states.end()) { return; }  // already reset, or never registered
+    state = std::move(it->second);
+    _query_states.erase(it);
+  }
+  // Outside the lock on purpose: draining waits out this query's in-flight reads, which can
+  // take as long as the slowest outstanding IO. Holding _query_states_mutex across it would
+  // park another connection's prepare_for_query behind this query's teardown.
+  //
+  // Order matters: stop and join FIRST, then let `state` die. The sequencer task captures the
+  // coalescer by `this` and the split tasks captured the providers, so destroying either with
+  // a task still running is a use-after-free (scoped_dispatcher's dtor asserts on it).
+  // ~query_scan_manager_state then runs: dispatcher (already idle) first, then the coalescer,
+  // then the providers.
+  state->drain();
+}
+
+void sirius_scan_manager::reset_all()
+{
+  std::vector<sirius::query_id_t> query_ids;
+  {
+    std::lock_guard lk{_query_states_mutex};
+    query_ids.reserve(_query_states.size());
+    for (auto const& [query_id, state] : _query_states) {
+      query_ids.push_back(query_id);
+    }
+  }
+  for (auto const query_id : query_ids) {
+    reset(query_id);
+  }
+}
+
+std::size_t sirius_scan_manager::num_active_queries() const noexcept
+{
+  std::lock_guard lk{_query_states_mutex};
+  return _query_states.size();
 }
 
 void sirius_scan_manager::start() {}
 
 void sirius_scan_manager::stop()
 {
-  reset();
+  // Every query's scan work must be off the pool before the pool stops: a sequencer parked on
+  // a dequeue that will never be satisfied would otherwise never return.
+  reset_all();
   _thread_pool.stop();
 }
 
@@ -865,12 +992,31 @@ void sirius_scan_manager::insert_pinned_entry(
       name);
   }
 
+  std::lock_guard pin_lk{_pinned_entries_mutex};
+
   auto existing_it = _pinned_entries.find(name);
   if (existing_it != _pinned_entries.end()) {
     // Same-row-count merge only applies when the completeness contracts match.
     // Mixing a full pin with a partial pin produces an entry whose columns came
     // from different row coverage — drop and rebuild instead.
-    if (existing_it->second.num_rows == new_num_rows) {
+    if (existing_it->second->num_rows == new_num_rows) {
+      // The merge below mutates the existing entry IN PLACE, and appending a column rehashes
+      // data_batches_by_column while a cached provider may be calling .at() on it. Shared
+      // ownership tells us whether that can happen: use_count() == 1 means only this map holds
+      // the entry, so nobody is serving it. We hold _pinned_entries_mutex, and the only way to
+      // acquire a new reference is through try_match_cached_entry / find_pinned_entry_for_
+      // duckdb_table, both of which take that same lock — so no sharer can appear underneath
+      // this check. A sharer *releasing* concurrently only makes us over-reject, never
+      // under-accept, which is the safe direction.
+      //
+      // The replace path below needs no such guard: erasing the map slot leaves any serving
+      // provider reading its own shared_ptr, which is exactly what shared ownership buys.
+      if (existing_it->second.use_count() > 1) {
+        throw std::runtime_error(
+          "[sirius_scan_manager::insert_pinned_entry] cannot re-pin '" + name +
+          "': a query is currently reading the pinned entry. Retry once it completes, or UNPIN "
+          "and pin again (an unpin is safe mid-query).");
+      }
       // A merge is only valid when the new pin reproduces the existing batch
       // boundaries and placement. The round-robin counter restarts at chunk 0
       // per pin_table call, and chunks at index i across all columns share a
@@ -878,7 +1024,7 @@ void sirius_scan_manager::insert_pinned_entry(
       // boundaries depend on the projected column set, so a re-pin can slice
       // the same files differently. Reject any mismatch loudly rather than
       // silently aliasing.
-      auto& entry = existing_it->second;
+      auto& entry = *existing_it->second;
       if (entry.chunk_memory_spaces.size() != chunk_memory_spaces.size()) {
         throw std::runtime_error(
           "[sirius_scan_manager::insert_pinned_entry] merge mismatch — "
@@ -1020,7 +1166,7 @@ void sirius_scan_manager::insert_pinned_entry(
     }
   }
 
-  _pinned_entries[name] = std::move(entry);
+  _pinned_entries[name] = std::make_shared<pinned_entry>(std::move(entry));
 }
 
 namespace {
@@ -1083,7 +1229,10 @@ void sirius_scan_manager::insert_pinned_entry_host(
   entry.host_chunks  = std::move(host_chunks);
   entry.zone_maps    = std::move(pin_zone_maps);
 
-  _pinned_entries[name] = std::move(entry);
+  // Replace, never mutate: a query already serving the old entry holds its own shared_ptr and
+  // keeps reading it to completion. Only the map slot is swapped here.
+  std::lock_guard pin_lk{_pinned_entries_mutex};
+  _pinned_entries[name] = std::make_shared<pinned_entry>(std::move(entry));
 }
 
 void sirius_scan_manager::insert_pinned_entry_device(const std::string& name,
@@ -1112,38 +1261,53 @@ void sirius_scan_manager::insert_pinned_entry_device(const std::string& name,
                    entry.device_chunks.size(),
                    new_num_rows);
 
-  _pinned_entries[name] = std::move(entry);
+  // Replace, never mutate — see insert_pinned_entry_host.
+  std::lock_guard pin_lk{_pinned_entries_mutex};
+  _pinned_entries[name] = std::make_shared<pinned_entry>(std::move(entry));
 }
 
 void sirius_scan_manager::attach_mvcc_metadata(const std::string& name,
                                                duckdb_mvcc_metadata metadata)
 {
+  std::lock_guard pin_lk{_pinned_entries_mutex};
   auto it = _pinned_entries.find(name);
   if (it == _pinned_entries.end()) {
     throw std::invalid_argument("[attach_mvcc_metadata] no pinned entry named '" + name + "'");
   }
-  it->second.mvcc = std::make_unique<duckdb_mvcc_metadata>(std::move(metadata));
+  // In-place mutation of a live entry, same hazard (and same guard) as the re-pin merge in
+  // insert_pinned_entry. In practice this always fires on an entry the caller's own insert
+  // just installed, so use_count() is 1 and the guard never trips.
+  if (it->second.use_count() > 1) {
+    throw std::runtime_error("[attach_mvcc_metadata] cannot attach MVCC metadata to '" + name +
+                             "': a query is currently reading the pinned entry");
+  }
+  it->second->mvcc = std::make_unique<duckdb_mvcc_metadata>(std::move(metadata));
 }
 
 void sirius_scan_manager::remove_pinned_entry(const std::string& name)
 {
+  // Safe mid-query by construction: dropping the map slot only releases this map's reference.
+  // A query serving the entry holds its own, so its data outlives the unpin.
+  std::lock_guard pin_lk{_pinned_entries_mutex};
   _pinned_entries.erase(name);
 }
 
 void sirius_scan_manager::visit_pinned_entries(
   const std::function<bool(std::string_view, const pinned_entry&)>& visitor) const
 {
+  std::lock_guard pin_lk{_pinned_entries_mutex};
   for (auto const& [name, entry] : _pinned_entries) {
-    if (!visitor(name, entry)) { break; }
+    if (!visitor(name, *entry)) { break; }
   }
 }
 
-pinned_entry const* sirius_scan_manager::find_pinned_entry_for_duckdb_table(
+std::shared_ptr<const pinned_entry> sirius_scan_manager::find_pinned_entry_for_duckdb_table(
   std::string_view catalog_name, std::string_view schema_name, std::string_view table_name) const
 {
+  std::lock_guard pin_lk{_pinned_entries_mutex};
   for (auto const& [name, entry] : _pinned_entries) {
-    if (entry.cache_info.matches_duckdb_table(catalog_name, schema_name, table_name)) {
-      return &entry;
+    if (entry->cache_info.matches_duckdb_table(catalog_name, schema_name, table_name)) {
+      return entry;
     }
   }
   return nullptr;
@@ -1205,14 +1369,14 @@ void validate_pinned_entry_for_serving(pinned_entry const& entry,
 }
 
 std::unique_ptr<databatch_provider> make_provider_for_pinned_entry(
-  pinned_entry const& entry,
+  std::shared_ptr<pinned_entry const> entry,
   std::span<std::size_t const> selected_columns,
   cached_scan_plan plan,
   const telemetry::batch_telemetry_info& telemetry_info,
   mvcc_chunk_mask_set mvcc_masks,
   std::vector<insert_delta_split> delta_splits)
 {
-  return std::make_unique<cached_databatch_provider>(entry,
+  return std::make_unique<cached_databatch_provider>(std::move(entry),
                                                      selected_columns,
                                                      std::move(plan),
                                                      telemetry_info,
@@ -1308,11 +1472,26 @@ cached_scan_plan build_cached_scan_plan(pinned_entry const& entry,
 }
 
 std::optional<sirius_scan_manager::cached_assignment> sirius_scan_manager::try_match_cached_entry(
-  op::scan::sirius_gpu_scan_operator* op)
+  op::scan::sirius_gpu_scan_operator* op, query_scan_manager_state& state)
 {
   const auto& table_info = op->get_ingestible().table_info();
 
-  for (auto const& [pinned_name, entry] : _pinned_entries) {
+  // Snapshot the pin table, then match outside the lock. Each snapshotted shared_ptr also
+  // pins the entry for the rest of this match, so a concurrent unpin cannot invalidate an
+  // entry mid-match — and the matching below (can_serve_with_columns, validate, zone-map plan
+  // building, the MVCC branch) is slow enough that holding _pinned_entries_mutex across it
+  // would serialize every concurrent query's prepare against every other's.
+  std::vector<std::pair<std::string, std::shared_ptr<pinned_entry const>>> snapshot;
+  {
+    std::lock_guard pin_lk{_pinned_entries_mutex};
+    snapshot.reserve(_pinned_entries.size());
+    for (auto const& [pinned_name, entry] : _pinned_entries) {
+      snapshot.emplace_back(pinned_name, entry);
+    }
+  }
+
+  for (auto const& [pinned_name, entry_ptr] : snapshot) {
+    auto const& entry = *entry_ptr;
     // Identity + serviceability gate: empty when this cache cannot serve the scan
     // (wrong format / file-set / table, or missing a requested column).
     if (entry.cache_info.can_serve_with_columns(table_info).empty()) { continue; }
@@ -1338,7 +1517,7 @@ std::optional<sirius_scan_manager::cached_assignment> sirius_scan_manager::try_m
       validate_pinned_entry_for_serving(entry, cols);
       // Zone-map survivor plan
       auto const filter_view =
-        _pruning_enabled ? extract_scan_filters(table_info) : scan_filter_view{};
+        state.pruning_enabled ? extract_scan_filters(table_info) : scan_filter_view{};
       auto plan = build_cached_scan_plan(entry, filter_view.table_filters, filter_view.column_ids);
       auto const total_chunks = plan.survivor_chunk_indices.size() + plan.pruned;
       if (plan.pruned > 0) {
@@ -1393,7 +1572,7 @@ std::optional<sirius_scan_manager::cached_assignment> sirius_scan_manager::try_m
         // entry (e.g. a self-join) shares the pending job's completed set at
         // handoff instead of re-running the capture+fill walk.
         auto const already_pending = std::ranges::any_of(
-          _pending_mvcc_mask_jobs,
+          state.pending_mvcc_mask_jobs,
           [&](mvcc_mask_job_request const& r) { return r.entry_name == pinned_name; });
         if (already_pending) {
           SIRIUS_LOG_INFO(
@@ -1426,7 +1605,7 @@ std::optional<sirius_scan_manager::cached_assignment> sirius_scan_manager::try_m
           }
           request.chunk_spaces = std::move(chunk_spaces);
           request.entry_name   = pinned_name;
-          _pending_mvcc_mask_jobs.push_back(std::move(request));
+          state.pending_mvcc_mask_jobs.push_back(std::move(request));
         }
 
         // One insert-delta job per entry per query, deduped like the mask
@@ -1435,17 +1614,17 @@ std::optional<sirius_scan_manager::cached_assignment> sirius_scan_manager::try_m
         // columns in so the staging covers every requester; per-operator
         // splits are cut at handoff.
         auto delta_request = std::ranges::find_if(
-          _pending_insert_delta_jobs,
+          state.pending_insert_delta_jobs,
           [&](insert_delta_job_request const& r) { return r.entry_name == pinned_name; });
-        if (delta_request == _pending_insert_delta_jobs.end()) {
+        if (delta_request == state.pending_insert_delta_jobs.end()) {
           insert_delta_job_request request;
           request.storage                = duckdb_info->storage;
           request.context                = duckdb_info->context;
           request.n_cache                = entry.mvcc->n_cache();
           request.approximate_batch_size = duckdb_info->approximate_batch_size;
           request.entry_name             = pinned_name;
-          _pending_insert_delta_jobs.push_back(std::move(request));
-          delta_request = std::prev(_pending_insert_delta_jobs.end());
+          state.pending_insert_delta_jobs.push_back(std::move(request));
+          delta_request = std::prev(state.pending_insert_delta_jobs.end());
         }
         for (std::size_t ci = 0; ci < duckdb_info->projected_cols.size(); ++ci) {
           auto const& pc = duckdb_info->projected_cols[ci];
@@ -1462,7 +1641,7 @@ std::optional<sirius_scan_manager::cached_assignment> sirius_scan_manager::try_m
       SIRIUS_LOG_INFO("[sirius_scan_manager] assigned pinned entry '{}' to operator '{}'",
                       pinned_name,
                       op->get_operator_id());
-      return cached_assignment{op, &entry, std::move(cols), pinned_name, std::move(plan)};
+      return cached_assignment{op, entry_ptr, std::move(cols), pinned_name, std::move(plan)};
     } catch (std::exception const& e) {
       if (mvcc_strict) {
         throw std::runtime_error("[sirius_scan_manager] mvcc-pinned entry '" + pinned_name +

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -161,6 +161,9 @@ static void from_yaml(const YAML::Node& node, scan_manager::scan_manager_config&
   r.optional("thread_name_prefix", opt.thread_pool.thread_name_prefix);
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
   r.optional("use_sirius_datasource", opt.use_sirius_datasource);
+  // Sizes the scan thread pool (num_threads + this). Each concurrent query parks one blocking
+  // coalescer sequencer on that pool, so raising concurrency without raising this deadlocks.
+  r.optional("max_concurrent_queries", opt.max_concurrent_queries, yaml::greater_than<int>{0});
   r.optional("uring_n_reactors", opt.uring_n_reactors, yaml::greater_than<std::size_t>{0});
   r.optional("rest_n_reactors", opt.rest_n_reactors, yaml::greater_than<std::size_t>{0});
   r.optional("enable_prefetch_cache", opt.enable_prefetch_cache);

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -968,13 +968,13 @@ std::shared_ptr<const sirius::telemetry::telemetry_context> SiriusContext::get_t
 void SiriusContext::create_query(
   duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>> pipelines,
   sirius::query_id_t query_id,
+  std::shared_ptr<sirius::pipeline::completion_handler> handler,
   sirius::telemetry::query_telemetry_info telemetry_info)
 {
   throw_if_not_initialized();
   query_ = duckdb::make_shared_ptr<sirius::planner::query>(
     std::move(pipelines), telemetry_context_->context(), query_id, telemetry_info);
-  task_scheduler_->prepare_for_query(query_);
-  task_creator_->prepare_for_query(*query_);
+  task_creator_->prepare_for_query(*query_, std::move(handler));
   scan_manager_->prepare_for_query(*query_,
                                    config_.get_operator_params().enable_pinned_zone_map_pruning);
 }

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -357,10 +357,10 @@ void SiriusContext::run_mandatory_cleanup(sirius::query_id_t query_id, std::stri
     }
   }
 
-  // Drop scan-manager providers for this query. Repositories are already
-  // cleared above, so downstream data_batches that referenced sliced
-  // host_data_representation are gone before the providers go away.
-  if (scan_manager_) { scan_manager_->reset(); }
+  // Drop THIS query's scan-manager providers; any other in-flight query keeps scanning.
+  // Repositories are already cleared above, so downstream data_batches that referenced
+  // sliced host_data_representation are gone before the providers go away.
+  if (scan_manager_) { scan_manager_->reset(query_id); }
 
   // NOTE: task_creator_->reset(query_id) already ran at the top of this function. That reset is
   // what drops duckdb_scan_task_global_state, which transitively owns a
@@ -417,6 +417,14 @@ void SiriusContext::drop_query_runtime_state_best_effort(sirius::query_id_t quer
   }
   try {
     if (task_scheduler_) { task_scheduler_->drain_query_tasks(query_id); }
+  } catch (...) {
+  }
+  // The scan manager needs the same backstop. prepare_for_query no longer performs a global
+  // reset (it would tear down concurrently-running queries), so nothing else will ever drop
+  // this query's scan state: without this, a failed query leaks its dispatcher, coalescer and
+  // split providers until terminate().
+  try {
+    if (scan_manager_) { scan_manager_->reset(query_id); }
   } catch (...) {
   }
 }

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -287,8 +287,9 @@ void SiriusContext::begin_execution_window(ClientContext& context,
   }
   // Register this query's repository manager up front
   data_repository_registry_.create_for_query(query_id);
-  task_creator_->reset();
-  task_creator_->set_client_context(context);
+  // Registers this query's task_creator state. No reset of a previous query here: each query
+  // owns its own entry now, and run_mandatory_cleanup drops it by id.
+  task_creator_->set_client_context(query_id, context);
 }
 
 void SiriusContext::run_mandatory_cleanup(sirius::query_id_t query_id, std::string_view end_tag)
@@ -300,6 +301,12 @@ void SiriusContext::run_mandatory_cleanup(sirius::query_id_t query_id, std::stri
     SIRIUS_LOG_INFO("QueryEnd");
   } catch (...) {
   }
+
+  // Drop this query's task_creator state FIRST: queued creation requests hold raw operator
+  // pointers into the plan that query_.reset() below destroys, and in-flight creation lambdas
+  // dereference them. reset() drains those requests and joins that work before returning.
+  // Only this query's is touched; other in-flight queries keep creating tasks.
+  if (task_creator_) { task_creator_->reset(query_id); }
 
   query_.reset();
 
@@ -348,14 +355,12 @@ void SiriusContext::run_mandatory_cleanup(sirius::query_id_t query_id, std::stri
   // host_data_representation are gone before the providers go away.
   if (scan_manager_) { scan_manager_->reset(); }
 
-  // Drop per-query global states held by task_creator. These include
-  // duckdb_scan_task_global_state, which transitively owns a
-  // duckdb::DuckTableScanState referencing BufferManager-owned BlockHandles.
-  // If we leave this state alive past the window, ~task_creator at
-  // SiriusContext teardown ends up releasing those BlockHandles after parts of
-  // DuckDB's DatabaseInstance have already been torn down (~DBConfig fires
-  // ~SiriusContext mid-DB destruction), which SIGSEGVs in ~BlockMemory.
-  if (task_creator_) { task_creator_->reset(); }
+  // NOTE: task_creator_->reset(query_id) already ran at the top of this function — it has to
+  // precede query_.reset(), since queued creation requests point into the plan that destroys.
+  // That reset is also what drops duckdb_scan_task_global_state, which transitively owns a
+  // duckdb::DuckTableScanState referencing BufferManager-owned BlockHandles; leaving it alive
+  // past the window would release those handles during ~task_creator at DB teardown (~DBConfig
+  // fires ~SiriusContext mid-DB destruction), which SIGSEGVs in ~BlockMemory.
 
   try {
     log_pool_stats(end_tag);
@@ -370,7 +375,7 @@ void SiriusContext::run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
     run_mandatory_cleanup(query_id, end_tag);
   } catch (std::exception& e) {
     mark_runtime_unavailable();
-    drop_task_creator_state_best_effort();
+    drop_task_creator_state_best_effort(query_id);
     try {
       SIRIUS_LOG_ERROR(
         "Mandatory per-query cleanup failed during unwind; marking the Sirius runtime "
@@ -380,7 +385,7 @@ void SiriusContext::run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
     }
   } catch (...) {
     mark_runtime_unavailable();
-    drop_task_creator_state_best_effort();
+    drop_task_creator_state_best_effort(query_id);
     try {
       SIRIUS_LOG_ERROR(
         "Mandatory per-query cleanup failed during unwind (unknown exception); marking the "
@@ -390,14 +395,14 @@ void SiriusContext::run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
   }
 }
 
-void SiriusContext::drop_task_creator_state_best_effort() noexcept
+void SiriusContext::drop_task_creator_state_best_effort(sirius::query_id_t query_id) noexcept
 {
   // Once the runtime is latched unavailable no later window will run the
   // task_creator reset, so the failed query's per-query global state (and the
   // buffer handles it retains) would survive until ~task_creator during DB
   // teardown — the exact shutdown-order crash the in-window reset prevents.
   try {
-    if (task_creator_) { task_creator_->reset(); }
+    if (task_creator_) { task_creator_->reset(query_id); }
   } catch (...) {
   }
 }
@@ -506,7 +511,7 @@ void SiriusContext::StandaloneQueryScope::finish()
     // error.
     state_ = scope_state::FAILED;
     ctx_.mark_runtime_unavailable();
-    ctx_.drop_task_creator_state_best_effort();
+    ctx_.drop_task_creator_state_best_effort(window_id_);
     log_window_event("end", "cleanup_failed");
     throw;
   }
@@ -791,6 +796,10 @@ void SiriusContext::terminate()
   task_scheduler_.reset();
   if (scan_manager_) { scan_manager_->stop(); }
   task_creator_->stop_thread_pool();
+  // Drop any per-query state a window failed to clean up (e.g. a latched-unavailable path whose
+  // best-effort reset threw). Doing it here, rather than letting ~task_creator do it, keeps the
+  // DuckTableScanState/BlockHandle releases inside the window where DuckDB is still intact.
+  task_creator_->reset_all();
   task_creator_.reset();
   for (auto& executor : downgrade_executors_) {
     executor->stop();

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -308,6 +308,12 @@ void SiriusContext::run_mandatory_cleanup(sirius::query_id_t query_id, std::stri
   // Only this query's is touched; other in-flight queries keep creating tasks.
   if (task_creator_) { task_creator_->reset(query_id); }
 
+  // With the producer stopped, drop whatever it already queued for this query. Ordering is
+  // deliberate: task_creator first so nothing new arrives, then the queues, then query_.reset()
+  // below — queued tasks reach operators through their pipeline, so they must be gone before the
+  // plan is destroyed. Other in-flight queries keep their queued work.
+  if (task_scheduler_) { task_scheduler_->drain_query_tasks(query_id); }
+
   query_.reset();
 
   // Drain all downgrade executors before clearing repositories — ensures no downgrade
@@ -375,7 +381,7 @@ void SiriusContext::run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
     run_mandatory_cleanup(query_id, end_tag);
   } catch (std::exception& e) {
     mark_runtime_unavailable();
-    drop_task_creator_state_best_effort(query_id);
+    drop_query_runtime_state_best_effort(query_id);
     try {
       SIRIUS_LOG_ERROR(
         "Mandatory per-query cleanup failed during unwind; marking the Sirius runtime "
@@ -385,7 +391,7 @@ void SiriusContext::run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
     }
   } catch (...) {
     mark_runtime_unavailable();
-    drop_task_creator_state_best_effort(query_id);
+    drop_query_runtime_state_best_effort(query_id);
     try {
       SIRIUS_LOG_ERROR(
         "Mandatory per-query cleanup failed during unwind (unknown exception); marking the "
@@ -395,14 +401,22 @@ void SiriusContext::run_mandatory_cleanup_backstop(sirius::query_id_t query_id,
   }
 }
 
-void SiriusContext::drop_task_creator_state_best_effort(sirius::query_id_t query_id) noexcept
+void SiriusContext::drop_query_runtime_state_best_effort(sirius::query_id_t query_id) noexcept
 {
-  // Once the runtime is latched unavailable no later window will run the
-  // task_creator reset, so the failed query's per-query global state (and the
-  // buffer handles it retains) would survive until ~task_creator during DB
-  // teardown — the exact shutdown-order crash the in-window reset prevents.
+  // Reached only when run_mandatory_cleanup threw, which means it may have aborted BEFORE its
+  // own reset/drain pair ran. Once the runtime is latched unavailable no later window will run
+  // them either, so the failed query's per-query state (and the buffer handles it retains)
+  // would survive until ~task_creator during DB teardown — the exact shutdown-order crash the
+  // in-window reset prevents.
+  //
+  // Same order as the main path: stop the producer, then drop what it queued. Each step is
+  // independently guarded so a throw in one still lets the other run.
   try {
     if (task_creator_) { task_creator_->reset(query_id); }
+  } catch (...) {
+  }
+  try {
+    if (task_scheduler_) { task_scheduler_->drain_query_tasks(query_id); }
   } catch (...) {
   }
 }
@@ -511,7 +525,7 @@ void SiriusContext::StandaloneQueryScope::finish()
     // error.
     state_ = scope_state::FAILED;
     ctx_.mark_runtime_unavailable();
-    ctx_.drop_task_creator_state_best_effort(window_id_);
+    ctx_.drop_query_runtime_state_best_effort(window_id_);
     log_window_event("end", "cleanup_failed");
     throw;
   }

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -303,18 +303,19 @@ void SiriusContext::run_mandatory_cleanup(sirius::query_id_t query_id, std::stri
   }
 
   // Drop this query's task_creator state FIRST: queued creation requests hold raw operator
-  // pointers into the plan that query_.reset() below destroys, and in-flight creation lambdas
-  // dereference them. reset() drains those requests and joins that work before returning.
-  // Only this query's is touched; other in-flight queries keep creating tasks.
+  // pointers, and in-flight creation lambdas dereference them. reset() drains those requests and
+  // joins that work before returning. Only this query's is touched; other in-flight queries keep
+  // creating tasks.
+  //
+  // Note the plan those pointers target is ALREADY gone by the time this runs: sirius_engine
+  // owns sirius_owned_plan and is destroyed in sirius_interface::cleanup_internal, which runs
+  // before this window's finish(). So this is not "clean up before the plan dies" — it is
+  // "stop touching a plan that has died".
   if (task_creator_) { task_creator_->reset(query_id); }
 
-  // With the producer stopped, drop whatever it already queued for this query. Ordering is
-  // deliberate: task_creator first so nothing new arrives, then the queues, then query_.reset()
-  // below — queued tasks reach operators through their pipeline, so they must be gone before the
-  // plan is destroyed. Other in-flight queries keep their queued work.
+  // With the producer stopped, drop whatever it already queued for this query, for the same
+  // reason. Other in-flight queries keep their queued work.
   if (task_scheduler_) { task_scheduler_->drain_query_tasks(query_id); }
-
-  query_.reset();
 
   // Drain all downgrade executors before clearing repositories — ensures no downgrade
   // tasks hold shared_ptr<data_batch> references to batches we're about to destroy.
@@ -361,9 +362,8 @@ void SiriusContext::run_mandatory_cleanup(sirius::query_id_t query_id, std::stri
   // host_data_representation are gone before the providers go away.
   if (scan_manager_) { scan_manager_->reset(); }
 
-  // NOTE: task_creator_->reset(query_id) already ran at the top of this function — it has to
-  // precede query_.reset(), since queued creation requests point into the plan that destroys.
-  // That reset is also what drops duckdb_scan_task_global_state, which transitively owns a
+  // NOTE: task_creator_->reset(query_id) already ran at the top of this function. That reset is
+  // what drops duckdb_scan_task_global_state, which transitively owns a
   // duckdb::DuckTableScanState referencing BufferManager-owned BlockHandles; leaving it alive
   // past the window would release those handles during ~task_creator at DB teardown (~DBConfig
   // fires ~SiriusContext mid-DB destruction), which SIGSEGVs in ~BlockMemory.
@@ -965,30 +965,22 @@ std::shared_ptr<const sirius::telemetry::telemetry_context> SiriusContext::get_t
   return telemetry_context_;
 }
 
-void SiriusContext::create_query(
+duckdb::shared_ptr<sirius::planner::query> SiriusContext::create_query(
   duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>> pipelines,
   sirius::query_id_t query_id,
   std::shared_ptr<sirius::pipeline::completion_handler> handler,
   sirius::telemetry::query_telemetry_info telemetry_info)
 {
   throw_if_not_initialized();
-  query_ = duckdb::make_shared_ptr<sirius::planner::query>(
+  auto query = duckdb::make_shared_ptr<sirius::planner::query>(
     std::move(pipelines), telemetry_context_->context(), query_id, telemetry_info);
-  task_creator_->prepare_for_query(*query_, std::move(handler));
-  scan_manager_->prepare_for_query(*query_,
+  // Pushed down to the subsystems that need it; neither retains the query itself (they extract
+  // pipelines and raw operator pointers, both owned by the caller's plan). Returned rather than
+  // stored so ownership sits with the sirius_engine, whose plan the query indexes.
+  task_creator_->prepare_for_query(*query, std::move(handler));
+  scan_manager_->prepare_for_query(*query,
                                    config_.get_operator_params().enable_pinned_zone_map_pruning);
-}
-
-duckdb::shared_ptr<sirius::planner::query> SiriusContext::get_query()
-{
-  throw_if_not_initialized();
-  return query_;
-}
-
-duckdb::shared_ptr<const sirius::planner::query> SiriusContext::get_query() const
-{
-  throw_if_not_initialized();
-  return query_;
+  return query;
 }
 
 bool SiriusContext::is_query_lifecycle_active() const noexcept

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -133,7 +133,24 @@ SiriusContext::SiriusContext() = default;
 
 SiriusContext::~SiriusContext() noexcept
 {
-  if (is_initialized_) { terminate(); }
+  // terminate() can throw — it opens with throw_if_not_initialized() and goes on to reset_all(),
+  // registry.clear() and memory_manager_->shutdown(). Letting that escape a noexcept destructor is
+  // std::terminate, and this runs mid-DB-destruction (~DBConfig fires ~SiriusContext), where a
+  // clean-enough teardown plus a log line is far better than aborting the process.
+  if (!is_initialized_) { return; }
+  try {
+    terminate();
+  } catch (const std::exception& e) {
+    try {
+      SIRIUS_LOG_ERROR("SiriusContext teardown failed (ignored, process is exiting): {}", e.what());
+    } catch (...) {
+    }
+  } catch (...) {
+    try {
+      SIRIUS_LOG_ERROR("SiriusContext teardown failed (ignored, process is exiting)");
+    } catch (...) {
+    }
+  }
 }
 
 // Log host and GPU memory pool stats at a labeled point.
@@ -443,6 +460,25 @@ void SiriusContext::drop_query_runtime_state_best_effort(sirius::query_id_t quer
   // split providers until terminate().
   try {
     if (scan_manager_) { scan_manager_->reset(query_id); }
+  } catch (...) {
+  }
+  // Drop this query's repositories. run_mandatory_cleanup does this on the normal path, but this
+  // function runs precisely when that threw part-way — and once the runtime is latched
+  // unavailable no later window will ever run it. Without this the failed query's manager, and
+  // every batch still in it, survived until terminate(): its GPU/host memory was never returned,
+  // and the downgrade executors kept sweeping it on every monitor cycle for the life of the
+  // process. Guarded like every other step here so one failure cannot stop the others.
+  try {
+    auto leaked = data_repository_registry_.erase(query_id);
+    for (auto const& info : leaked) {
+      SIRIUS_LOG_WARN(
+        "drop_query_runtime_state_best_effort: query {} operator {} port '{}' still had {} "
+        "un-consumed data batch(es) (memory leak).",
+        query_id,
+        info.operator_id,
+        info.port_id,
+        info.count);
+    }
   } catch (...) {
   }
   // The window is over either way; drop the gate entry so it does not accumulate.
@@ -846,18 +882,28 @@ void SiriusContext::terminate()
 {
   throw_if_not_initialized();
 
+  // Stop every producer and every borrower BEFORE destroying the task_scheduler.
+  //
+  // task_scheduler_.reset() used to run second, while the downgrade executors and the creator pool
+  // were still live. Each downgrade executor holds _pipeline_task_queue — a raw pointer into
+  // task_scheduler::_task_queue — and dereferences it in processing_loop; creation lambdas hold
+  // _task_scheduler and call schedule() on it. A monitor request or an in-flight creation landing
+  // in that window dereferenced a freed queue at DB teardown.
   task_scheduler_->stop();
-  task_scheduler_.reset();
   if (scan_manager_) { scan_manager_->stop(); }
   task_creator_->stop_thread_pool();
+  for (auto& executor : downgrade_executors_) {
+    executor->stop();
+  }
+  // Only now is nothing left holding a pointer into the scheduler.
+  task_scheduler_.reset();
   // Drop any per-query state a window failed to clean up (e.g. a latched-unavailable path whose
   // best-effort reset threw). Doing it here, rather than letting ~task_creator do it, keeps the
   // DuckTableScanState/BlockHandle releases inside the window where DuckDB is still intact.
   task_creator_->reset_all();
   task_creator_.reset();
-  for (auto& executor : downgrade_executors_) {
-    executor->stop();
-  }
+  // Already stopped above, before task_scheduler_ was destroyed; stop() is idempotent, so this is
+  // only here to keep the destruction of the executors themselves adjacent to their clear().
   downgrade_executors_.clear();
   sirius::telemetry::batch_telemetry_registry::instance().uninstall();
   telemetry_context_.reset();

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -285,6 +285,9 @@ void SiriusContext::begin_execution_window(ClientContext& context,
     SIRIUS_LOG_INFO("QueryBegin: {}", window_label);
   } catch (...) {  // best-effort observability
   }
+  // Open the enqueue gate before anything can schedule. Every producer consults it, so this must
+  // precede repository/task_creator registration.
+  query_lifecycle_.open_query(query_id);
   // Register this query's repository manager up front
   data_repository_registry_.create_for_query(query_id);
   // Registers this query's task_creator state. No reset of a previous query here: each query
@@ -301,6 +304,13 @@ void SiriusContext::run_mandatory_cleanup(sirius::query_id_t query_id, std::stri
     SIRIUS_LOG_INFO("QueryEnd");
   } catch (...) {
   }
+
+  // Close the enqueue gate BEFORE any drain runs. Every producer consults it, so from here on a
+  // completion callback for this query — notify_downstream_pipelines, the GPU executor scheduling
+  // a finished task's consumers, an OOM reschedule, or a TIER-2 downgrade returning a task it
+  // extracted — is refused instead of adding work behind a drain that already passed. Scoped to
+  // this query: other in-flight queries keep scheduling normally.
+  query_lifecycle_.quiesce(query_id);
 
   // Drop this query's task_creator state FIRST: queued creation requests hold raw operator
   // pointers, and in-flight creation lambdas dereference them. reset() drains those requests and
@@ -368,6 +378,10 @@ void SiriusContext::run_mandatory_cleanup(sirius::query_id_t query_id, std::stri
   // past the window would release those handles during ~task_creator at DB teardown (~DBConfig
   // fires ~SiriusContext mid-DB destruction), which SIGSEGVs in ~BlockMemory.
 
+  // Every drain has run; the window is over, so forget the query rather than leaving a tombstone
+  // that would grow the map for the life of the process.
+  query_lifecycle_.close(query_id);
+
   try {
     log_pool_stats(end_tag);
   } catch (...) {  // best-effort observability
@@ -409,8 +423,12 @@ void SiriusContext::drop_query_runtime_state_best_effort(sirius::query_id_t quer
   // would survive until ~task_creator during DB teardown — the exact shutdown-order crash the
   // in-window reset prevents.
   //
-  // Same order as the main path: stop the producer, then drop what it queued. Each step is
-  // independently guarded so a throw in one still lets the other run.
+  // Same order as the main path: shut the gate, stop the producer, then drop what it queued. Each
+  // step is independently guarded so a throw in one still lets the others run.
+  try {
+    query_lifecycle_.quiesce(query_id);
+  } catch (...) {
+  }
   try {
     if (task_creator_) { task_creator_->reset(query_id); }
   } catch (...) {
@@ -425,6 +443,11 @@ void SiriusContext::drop_query_runtime_state_best_effort(sirius::query_id_t quer
   // split providers until terminate().
   try {
     if (scan_manager_) { scan_manager_->reset(query_id); }
+  } catch (...) {
+  }
+  // The window is over either way; drop the gate entry so it does not accumulate.
+  try {
+    query_lifecycle_.close(query_id);
   } catch (...) {
   }
 }
@@ -790,6 +813,15 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
   task_creator_->set_task_scheduler(*task_scheduler_);
   task_scheduler_->set_task_creator(*task_creator_);
 
+  // Bind the per-query enqueue gate to every producer. From here on, a query that has entered
+  // cleanup cannot have work added behind a drain that already passed — previously this was only
+  // achievable by interrupting the shared queues, which refused every query's pushes at once.
+  task_creator_->set_query_lifecycle_registry(&query_lifecycle_);
+  task_scheduler_->set_query_lifecycle_registry(&query_lifecycle_);
+  for (auto& executor : downgrade_executors_) {
+    executor->set_query_lifecycle_registry(&query_lifecycle_);
+  }
+
   scan_manager_ = std::make_unique<sirius::scan_manager::sirius_scan_manager>(
     config_.get_scan_manager_config(), *memory_manager_, topology_index_);
 
@@ -847,6 +879,7 @@ void SiriusContext::terminate()
   // downgrade executors (the only other holders of a manager reference) were stopped above, so
   // no borrower can outlive this.
   data_repository_registry_.clear();
+  query_lifecycle_.clear();
 
   // Restore the previous cuDF pinned memory resource and threshold before destroying the
   // slab allocator — cuDF holds a non-owning reference and would dangle after reset().

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -91,6 +91,8 @@ sirius_engine::~sirius_engine() { query_handle_->exit(); }
 
 void sirius_engine::reset()
 {
+  // Before the plan: the query indexes it, so it must not outlive a plan swap.
+  query_.reset();
   sirius_physical_plan = nullptr;
   sirius_owned_plan.reset();
   sirius_root_pipelines.clear();
@@ -155,16 +157,16 @@ void sirius_engine::execute()
   completion_handler_ = std::make_shared<pipeline::completion_handler>();
   auto future         = completion_handler_->get_awaitable();
 
-  // Create the query with the pipelines
-  sirius_ctx->create_query(std::move(new_scheduled),
-                           query_id_,
-                           completion_handler_,
-                           telemetry::query_telemetry_info{
-                             .telemetry_query_id = telemetry_uuid,
-                             .worker_id          = telemetry_context_->worker_id(),
-                             .query_id           = query_id_,
-                           });
-  sirius_ctx->get_task_scheduler().start_query(*sirius_ctx->get_query());
+  // Create the query with the pipelines. It is owned here, alongside the plan it indexes.
+  query_ = sirius_ctx->create_query(std::move(new_scheduled),
+                                    query_id_,
+                                    completion_handler_,
+                                    telemetry::query_telemetry_info{
+                                      .telemetry_query_id = telemetry_uuid,
+                                      .worker_id          = telemetry_context_->worker_id(),
+                                      .query_id           = query_id_,
+                                    });
+  sirius_ctx->get_task_scheduler().start_query(*query_);
   try {
     future.get();
     sirius_ctx->get_task_scheduler().wait_for_completion(query_id_);
@@ -184,8 +186,8 @@ void sirius_engine::execute()
 
   // All tasks completed — operators and pipelines are still alive here.
   // Warn about any intermediate operators that were never finalized.
-  if (auto query = sirius_ctx->get_query()) {
-    for (const auto& pipeline : query->get_pipelines()) {
+  if (query_) {
+    for (const auto& pipeline : query_->get_pipelines()) {
       for (const auto& op_ref : pipeline->get_operators()) {
         const auto& op = op_ref.get();
         if (!op.finalized.load()) {

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -150,29 +150,35 @@ void sirius_engine::execute()
                   telemetry_uuid.high_bits,
                   telemetry_uuid.low_bits);
 
+  // This query's completion signal. Owned here, shared down to every task via its pipeline's
+  // global state, so no cross-query subsystem holds a "current query" handler.
+  completion_handler_ = std::make_shared<pipeline::completion_handler>();
+  auto future         = completion_handler_->get_awaitable();
+
   // Create the query with the pipelines
   sirius_ctx->create_query(std::move(new_scheduled),
                            query_id_,
+                           completion_handler_,
                            telemetry::query_telemetry_info{
                              .telemetry_query_id = telemetry_uuid,
                              .worker_id          = telemetry_context_->worker_id(),
                              .query_id           = query_id_,
                            });
-  auto future = sirius_ctx->get_task_scheduler().start_query();
+  sirius_ctx->get_task_scheduler().start_query(*sirius_ctx->get_query());
   try {
     future.get();
-    sirius_ctx->get_task_scheduler().wait_for_completion();
+    sirius_ctx->get_task_scheduler().wait_for_completion(query_id_);
   } catch (const std::exception& e) {
     SIRIUS_LOG_ERROR("Error executing query: {}", e.what());
     // Drain all in-flight GPU tasks before returning.  QueryEnd() will call
     // clear_all_repositories() immediately after execute() throws; without
     // this drain, tasks still running in the thread pool hold raw pointers to
     // those repositories and cause a use-after-free / heap corruption.
-    sirius_ctx->get_task_scheduler().drain_after_error();
+    sirius_ctx->get_task_scheduler().drain_after_error(query_id_);
     throw;
   } catch (...) {
     SIRIUS_LOG_ERROR("Unknown error executing query");
-    sirius_ctx->get_task_scheduler().drain_after_error();
+    sirius_ctx->get_task_scheduler().drain_after_error(query_id_);
     throw;
   }
 

--- a/src/util/segfault_backtrace_handler.cpp
+++ b/src/util/segfault_backtrace_handler.cpp
@@ -77,22 +77,39 @@ static void write_backtrace_line(int fd, int frame_no, const char* raw_line)
   write(fd, "\n", 1);
 }
 
-// Best-effort flush of the global logger so the most recent log lines reach
-// disk before we terminate. This is NOT async-signal-safe: the sink takes
-// a mutex and may allocate, so if the crash happened while a thread held the
-// logging mutex (or inside the allocator) the flush could deadlock. We bound
-// that risk with alarm(): SIGALRM's default disposition terminates the
-// process, so a hung flush kills us within the deadline instead of hanging the
-// crash handler forever. alarm() and signal() are themselves signal-safe.
-static void flush_logs_best_effort()
+/// Hard deadline for the WHOLE handler, armed on entry. See arm_handler_deadline().
+constexpr unsigned kHandlerDeadlineSeconds = 10;
+
+// Bound every unsafe step in this handler with a wall-clock deadline.
+//
+// Only backtrace() and backtrace_symbols_fd() are async-signal-safe. backtrace_symbols(),
+// abi::__cxa_demangle() and the log flush all allocate and take locks — backtrace_symbols() goes
+// through _dl_addr(), which takes the dynamic loader lock. If the crash happened while any thread
+// held the loader lock, the malloc arena lock, or the logging mutex, those calls do not fail:
+// they spin or block forever. The process then looks alive (100% CPU, no output) instead of dead,
+// which is strictly worse than crashing — it hides the crash, survives SIGTERM, and cannot be
+// attached to once the parent has moved on.
+//
+// That is not hypothetical: it turned an ordinary deadlock in this codebase into an
+// unkillable spin that took an hour to diagnose, because every symptom pointed at a live process.
+//
+// SIGALRM's default disposition terminates, so this converts "hangs forever" into "dies within
+// kHandlerDeadlineSeconds". alarm() and signal() are themselves async-signal-safe.
+static void arm_handler_deadline()
 {
   signal(SIGALRM, SIG_DFL);  // ensure default (terminate) disposition
-  alarm(3);                  // hard deadline for the log + flush below
+  alarm(kHandlerDeadlineSeconds);
+}
+
+// Best-effort flush of the global logger so the most recent log lines reach disk before we
+// terminate. NOT async-signal-safe (the sink takes a mutex and may allocate); covered by the
+// handler-wide deadline armed in arm_handler_deadline(), so this must NOT cancel the alarm.
+static void flush_logs_best_effort()
+{
   SIRIUS_LOG_WARN("SIRIUS signal handler triggered, flushing logs");
-  // get_sink() never returns null; the flush itself is the risky part, bounded
-  // by the alarm above and by the handler's re-entrancy guard.
+  // get_sink() never returns null; the flush itself is the risky part, bounded by the
+  // handler-wide deadline and by the handler's re-entrancy guard.
   sirius::log::get_sink()->flush();
-  alarm(0);  // flush returned in time; cancel the deadline
 }
 
 static const char* signal_name(int sig)
@@ -117,6 +134,9 @@ static void segfault_handler(int sig)
   if (handling) { _exit(1); }
   handling = 1;
 
+  // Everything below this line is bounded. Nothing here may hang the process.
+  arm_handler_deadline();
+
   std::array<void*, kBacktraceMaxFrames> frames{};
   int n = backtrace(frames.data(), kBacktraceMaxFrames);
   if (n <= 0) {
@@ -124,15 +144,28 @@ static void segfault_handler(int sig)
     _exit(1);
   }
 
+  long tid          = static_cast<long>(syscall(SYS_gettid));
+  const char* sname = signal_name(sig);
+
+  // Emit the async-signal-safe form FIRST. backtrace_symbols_fd() writes straight to the fd with
+  // no allocation and no loader lock, so this reaches stderr even if the demangled pass below
+  // blocks and the deadline has to kill us. Un-demangled frames are far less readable, but a raw
+  // backtrace beats the silence that a hung handler produces.
+  {
+    const char* raw_header = "\n*** ";
+    write(STDERR_FILENO, raw_header, __builtin_strlen(raw_header));
+    write(STDERR_FILENO, sname, strlen(sname));
+    const char* raw_suffix = " — raw frames (async-signal-safe) ***\n";
+    write(STDERR_FILENO, raw_suffix, __builtin_strlen(raw_suffix));
+    backtrace_symbols_fd(frames.data(), n, STDERR_FILENO);
+  }
+
+  // From here on the output is nicer but the calls are not signal-safe.
   char** symbols = backtrace_symbols(frames.data(), n);
   if (!symbols) {
-    backtrace_symbols_fd(frames.data(), n, STDERR_FILENO);
     flush_logs_best_effort();
     _exit(1);
   }
-
-  long tid          = static_cast<long>(syscall(SYS_gettid));
-  const char* sname = signal_name(sig);
 
   auto write_header = [sname](int fd) {
     const char* suffix = " — backtrace from faulting thread ***\n";

--- a/test/cpp/creator/test_task_creator.cpp
+++ b/test/cpp/creator/test_task_creator.cpp
@@ -155,14 +155,19 @@ class testable_task_creator : public task_creator {
   testable_task_creator(int num_threads,
                         duckdb::ClientContext& client_context,
                         task_scheduler& task_sched,
-                        sirius::memory::sirius_memory_reservation_manager& mem_res_mgr)
+                        sirius::memory::sirius_memory_reservation_manager& mem_res_mgr,
+                        sirius::query_id_t query_id = sirius::make_query_id(1))
     : task_creator(
         exec::thread_pool_config{.num_threads = num_threads, .thread_name_prefix = "task_creator"},
-        mem_res_mgr)
+        mem_res_mgr),
+      _query_id(query_id)
   {
-    this->set_client_context(client_context);
+    // Binding a client context is what registers the query's state.
+    this->set_client_context(query_id, client_context);
     this->set_task_scheduler(task_sched);
   }
+
+  [[nodiscard]] sirius::query_id_t query_id() const noexcept { return _query_id; }
 
   void schedule(op::sirius_physical_operator* request) override
   {
@@ -205,6 +210,7 @@ class testable_task_creator : public task_creator {
   std::atomic<size_t> _schedule_count{0};
   std::vector<sirius_physical_operator*> _scheduled_nodes;
   std::vector<duckdb::shared_ptr<sirius_pipeline>> _scheduled_pipelines;
+  sirius::query_id_t _query_id;
   std::mutex _scheduled_mutex;
 };
 

--- a/test/cpp/creator/test_task_creator_query_state.cpp
+++ b/test/cpp/creator/test_task_creator_query_state.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_task_creator_query_state.cpp
+ * @brief The task_creator holds one state entry per in-flight query.
+ *
+ * Operator ids restart at 0 for every query, so a globally-keyed task_creator would let one
+ * query resolve another's pipeline global state. These cases pin the entry lifecycle: two
+ * queries coexist, cleanup targets exactly one, and the paths that run on a failed query
+ * (repeated reset, reset of a query that never registered) stay harmless.
+ */
+
+#include "catch.hpp"
+#include "creator/config.hpp"
+#include "creator/task_creator.hpp"
+#include "operator/operator_test_utils.hpp"
+#include "query_id.hpp"
+
+#include <duckdb.hpp>
+
+#include <memory>
+
+namespace {
+
+using sirius::creator::task_creator;
+using sirius::creator::task_creator_config;
+
+//! Minimal harness: a task_creator plus the memory manager it requires. No task_scheduler is
+//! wired because none of the per-query lifecycle entry points below dispatch tasks.
+struct query_state_fixture {
+  query_state_fixture()
+    : memory_manager(initialize_memory_manager(1)),
+      creator(task_creator_config{}, *memory_manager)
+  {
+  }
+
+  duckdb::DuckDB db{nullptr};
+  duckdb::Connection con{db};
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory_manager;
+  task_creator creator;
+};
+
+const sirius::query_id_t kQueryA = sirius::make_query_id(1);
+const sirius::query_id_t kQueryB = sirius::make_query_id(2);
+
+}  // namespace
+
+TEST_CASE("task_creator holds independent state per query", "[task_creator][query_state]")
+{
+  query_state_fixture f;
+
+  // Binding a client context is what registers a query's entry.
+  f.creator.set_client_context(kQueryA, *f.con.context);
+  f.creator.set_client_context(kQueryB, *f.con.context);
+
+  // Dropping one query leaves the other's entry intact and independently droppable.
+  f.creator.reset(kQueryA);
+  REQUIRE_NOTHROW(f.creator.reset(kQueryB));
+}
+
+TEST_CASE("task_creator reset of an unregistered query is a no-op", "[task_creator][query_state]")
+{
+  query_state_fixture f;
+  f.creator.set_client_context(kQueryA, *f.con.context);
+
+  // Cleanup runs for every execution window, including ones that never bind a query (a
+  // pin_table window, or a query that fails before prepare_for_query).
+  REQUIRE_NOTHROW(f.creator.reset(sirius::make_query_id(4242)));
+  // The miss must not disturb the query that is registered.
+  REQUIRE_NOTHROW(f.creator.reset(kQueryA));
+}
+
+TEST_CASE("task_creator reset is idempotent for one query", "[task_creator][query_state]")
+{
+  query_state_fixture f;
+  f.creator.set_client_context(kQueryA, *f.con.context);
+
+  // StandaloneQueryScope::finish() and its noexcept destructor backstop both route to cleanup,
+  // so a failed query can reset twice.
+  f.creator.reset(kQueryA);
+  REQUIRE_NOTHROW(f.creator.reset(kQueryA));
+}
+
+TEST_CASE("task_creator drain_pending_tasks targets a single query",
+          "[task_creator][query_state]")
+{
+  query_state_fixture f;
+  f.creator.set_client_context(kQueryA, *f.con.context);
+  f.creator.set_client_context(kQueryB, *f.con.context);
+
+  // Draining one query must not require the other to have queued anything, and an unknown
+  // query drains cleanly — the queue stays open for every other producer either way.
+  REQUIRE_NOTHROW(f.creator.drain_pending_tasks(kQueryA));
+  REQUIRE_NOTHROW(f.creator.drain_pending_tasks(kQueryB));
+  REQUIRE_NOTHROW(f.creator.drain_pending_tasks(sirius::make_query_id(99)));
+
+  // Both entries survive a drain: draining pending work is not the same as dropping the query.
+  REQUIRE_NOTHROW(f.creator.reset(kQueryA));
+  REQUIRE_NOTHROW(f.creator.reset(kQueryB));
+}
+
+TEST_CASE("task_creator reset_all drops every query's state", "[task_creator][query_state]")
+{
+  query_state_fixture f;
+  f.creator.set_client_context(kQueryA, *f.con.context);
+  f.creator.set_client_context(kQueryB, *f.con.context);
+
+  // Teardown path (SiriusContext::terminate), so that a state a window failed to clean up does
+  // not survive into ~task_creator during database destruction.
+  REQUIRE_NOTHROW(f.creator.reset_all());
+  REQUIRE_NOTHROW(f.creator.reset(kQueryA));
+}

--- a/test/cpp/creator/test_task_creator_query_state.cpp
+++ b/test/cpp/creator/test_task_creator_query_state.cpp
@@ -43,8 +43,7 @@ using sirius::creator::task_creator_config;
 //! wired because none of the per-query lifecycle entry points below dispatch tasks.
 struct query_state_fixture {
   query_state_fixture()
-    : memory_manager(initialize_memory_manager(1)),
-      creator(task_creator_config{}, *memory_manager)
+    : memory_manager(initialize_memory_manager(1)), creator(task_creator_config{}, *memory_manager)
   {
   }
 
@@ -95,8 +94,7 @@ TEST_CASE("task_creator reset is idempotent for one query", "[task_creator][quer
   REQUIRE_NOTHROW(f.creator.reset(kQueryA));
 }
 
-TEST_CASE("task_creator drain_pending_tasks targets a single query",
-          "[task_creator][query_state]")
+TEST_CASE("task_creator drain_pending_tasks targets a single query", "[task_creator][query_state]")
 {
   query_state_fixture f;
   f.creator.set_client_context(kQueryA, *f.con.context);

--- a/test/cpp/exec/test_bounded_thread_pool.cpp
+++ b/test/cpp/exec/test_bounded_thread_pool.cpp
@@ -16,6 +16,7 @@
 
 #include "catch.hpp"
 #include "exec/bounded_thread_pool.hpp"
+#include "query_id.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -344,4 +345,120 @@ TEST_CASE("bounded_thread_pool concurrent producers all tasks execute", "[bounde
 
   pool.wait_all();
   REQUIRE(counter.load() == num_threads * tasks_each);
+}
+
+//===----------------------------------------------------------------------===//
+// Per-query accounting: wait_for_query / drain_and_wait
+//===----------------------------------------------------------------------===//
+
+namespace {
+//! Releases a blocking task on every exit path, so a failed REQUIRE cannot leave a worker spinning
+//! and hang the pool destructor's join().
+struct release_on_exit {
+  std::atomic<bool>& flag;
+  ~release_on_exit() { flag.store(true, std::memory_order_release); }
+};
+}  // namespace
+
+TEST_CASE("wait_for_query runs the query's work and ignores other queries",
+          "[bounded_thread_pool][concurrency]")
+{
+  bounded_thread_pool pool(4, "test");
+  const auto qa = sirius::make_query_id(1);
+  const auto qb = sirius::make_query_id(2);
+
+  std::atomic<bool> release_b{false};
+  release_on_exit guard{release_b};
+  std::atomic<int> a_done{0};
+
+  // B blocks until told otherwise. If wait_for_query(A) waited on the whole pool it would hang
+  // here -- tracking per query is exactly what makes it return.
+  {
+    auto sb = pool.reserve();
+    sb.attach(qb);
+    pool.dispatch(std::move(sb), [&] {
+      while (!release_b.load(std::memory_order_acquire)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+    });
+  }
+
+  for (int i = 0; i < 3; ++i) {
+    auto sa = pool.reserve();
+    sa.attach(qa);
+    pool.dispatch(std::move(sa), [&] { a_done.fetch_add(1, std::memory_order_relaxed); });
+  }
+
+  pool.wait_for_query(qa);
+  // RUN, not dropped: the success path must never discard work the query scheduled.
+  REQUIRE(a_done.load() == 3);
+  REQUIRE(pool.active_for_query(qa) == 0);
+  REQUIRE(pool.active_for_query(qb) == 1);  // B untouched
+
+  release_b.store(true, std::memory_order_release);
+  pool.wait_all();
+}
+
+TEST_CASE("an untagged reservation does not block a per-query wait",
+          "[bounded_thread_pool][concurrency]")
+{
+  // The load-bearing case. Every manager loop in Sirius reserves a slot and THEN blocks waiting
+  // for a task, so a slot with no query is permanently held whenever a manager is idle. wait_all()
+  // can never return in that state; the per-query waits must, or query teardown deadlocks -- which
+  // is exactly how removing the manager-quiesce bracket broke the suite.
+  bounded_thread_pool pool(4, "test");
+  const auto q = sirius::make_query_id(7);
+
+  auto parked = pool.reserve();  // untagged, held for the whole test
+  REQUIRE(parked.is_valid());
+
+  std::atomic<int> ran{0};
+  {
+    auto s = pool.reserve();
+    s.attach(q);
+    pool.dispatch(std::move(s), [&] { ran.fetch_add(1, std::memory_order_relaxed); });
+  }
+
+  pool.wait_for_query(q);  // must not hang despite `parked` still being held
+  REQUIRE(ran.load() == 1);
+  REQUIRE(pool.active_for_query(q) == 0);
+}
+
+TEST_CASE("drain_and_wait discards the query's queued work", "[bounded_thread_pool][concurrency]")
+{
+  // The error-path counterpart: queued work is dropped rather than run, because its query is
+  // failing and its plan is about to be destroyed. Single worker, held by a blocker, so everything
+  // dispatched behind it is still queued when the drain runs.
+  bounded_thread_pool pool(1, "test");
+  const auto q = sirius::make_query_id(3);
+
+  std::atomic<bool> release{false};
+  release_on_exit guard{release};
+  std::atomic<int> ran{0};
+
+  auto blocker = pool.reserve();
+  pool.dispatch(std::move(blocker), [&] {
+    while (!release.load(std::memory_order_acquire)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  });
+
+  // Capacity is 1 and taken, so reserve() would block here; dispatch from another thread.
+  std::atomic<int> dispatched{0};
+  std::thread producer([&] {
+    for (int i = 0; i < 2; ++i) {
+      auto s = pool.reserve();
+      if (!s) { return; }
+      s.attach(q);
+      pool.dispatch(std::move(s), [&] { ran.fetch_add(1, std::memory_order_relaxed); });
+      dispatched.fetch_add(1, std::memory_order_relaxed);
+    }
+  });
+
+  release.store(true, std::memory_order_release);
+  producer.join();
+  pool.drain_and_wait(q);
+  REQUIRE(pool.active_for_query(q) == 0);
+  REQUIRE(ran.load() <= dispatched.load());  // some may have run before the drain; none may leak
+  pool.wait_all();
 }

--- a/test/cpp/exec/test_multi_index_priority_queue.cpp
+++ b/test/cpp/exec/test_multi_index_priority_queue.cpp
@@ -224,6 +224,26 @@ TEST_CASE("multi_index query index spans its levels", "[multi_index_priority_que
 }
 
 // =============================================================================
+// Per-query drain
+// =============================================================================
+
+TEST_CASE("multi_index drain(query_index) leaves the queue open for later pushes",
+          "[multi_index_priority_queue]")
+{
+  multi_index_priority_queue<payload> q(by_keys());
+  q.push(task(1, keys_of(5, SiriusPhysicalOperatorType::FILTER, /*query=*/7)));
+
+  q.drain(query_index{7});
+
+  // Unlike interrupt(), a per-query drain must not close the queue: other queries keep
+  // producing through it, and the drained query id may even be reused by a later push.
+  REQUIRE(q.is_open());
+  q.push(task(2, keys_of(5, SiriusPhysicalOperatorType::FILTER, /*query=*/8)));
+  REQUIRE(q.size() == 1);
+  REQUIRE(q.pop()->id == 2);
+}
+
+// =============================================================================
 // Cross-index consistency
 // =============================================================================
 

--- a/test/cpp/exec/test_query_lifecycle_registry.cpp
+++ b/test/cpp/exec/test_query_lifecycle_registry.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "exec/query_lifecycle_registry.hpp"
+#include "query_id.hpp"
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+using sirius::make_query_id;
+using sirius::exec::query_lifecycle_registry;
+using sirius::exec::query_lifecycle_state;
+
+TEST_CASE("an unknown query accepts work", "[query_lifecycle_gate][concurrency]")
+{
+  // Deliberate direction: a missed open_query() must not silently stop a query from scheduling
+  // anything, which would present as a hang. Components with no registry bound behave as before.
+  query_lifecycle_registry registry;
+  REQUIRE(registry.accepts_work(make_query_id(7)));
+  REQUIRE_FALSE(registry.state(make_query_id(7)).has_value());
+  REQUIRE(registry.size() == 0);
+}
+
+TEST_CASE("open -> quiescing -> closed", "[query_lifecycle_gate][concurrency]")
+{
+  query_lifecycle_registry registry;
+  const auto q = make_query_id(1);
+
+  registry.open_query(q);
+  REQUIRE(registry.accepts_work(q));
+  REQUIRE(registry.state(q) == query_lifecycle_state::open);
+  REQUIRE(registry.size() == 1);
+
+  registry.quiesce(q);
+  REQUIRE_FALSE(registry.accepts_work(q));
+  REQUIRE(registry.state(q) == query_lifecycle_state::quiescing);
+
+  registry.close(q);
+  REQUIRE_FALSE(registry.state(q).has_value());
+  REQUIRE(registry.size() == 0);
+}
+
+TEST_CASE("quiescing one query leaves every other query accepting work",
+          "[query_lifecycle_gate][concurrency]")
+{
+  // The whole point of the gate: teardown of one query must not refuse another query's work, the
+  // way interrupting a shared queue does.
+  query_lifecycle_registry registry;
+  const auto a = make_query_id(1);
+  const auto b = make_query_id(2);
+  const auto c = make_query_id(3);
+
+  registry.open_query(a);
+  registry.open_query(b);
+  registry.open_query(c);
+
+  registry.quiesce(b);
+
+  REQUIRE(registry.accepts_work(a));
+  REQUIRE_FALSE(registry.accepts_work(b));
+  REQUIRE(registry.accepts_work(c));
+
+  registry.close(b);
+  REQUIRE(registry.accepts_work(a));
+  REQUIRE(registry.accepts_work(c));
+  REQUIRE(registry.size() == 2);
+}
+
+TEST_CASE("quiesce and close are idempotent and safe on unknown queries",
+          "[query_lifecycle_gate][concurrency]")
+{
+  query_lifecycle_registry registry;
+  const auto q       = make_query_id(1);
+  const auto unknown = make_query_id(99);
+
+  // Cleanup can run twice on a failed query (finish() then the destructor backstop), and the
+  // best-effort teardown path quiesces a query that may never have opened.
+  REQUIRE_NOTHROW(registry.quiesce(unknown));
+  REQUIRE_NOTHROW(registry.close(unknown));
+  REQUIRE(registry.accepts_work(unknown));
+
+  registry.open_query(q);
+  registry.quiesce(q);
+  registry.quiesce(q);
+  REQUIRE(registry.state(q) == query_lifecycle_state::quiescing);
+  registry.close(q);
+  REQUIRE_NOTHROW(registry.close(q));
+  REQUIRE(registry.size() == 0);
+}
+
+TEST_CASE("a quiesce is visible to every reader once it returns",
+          "[query_lifecycle_gate][concurrency]")
+{
+  // Producers call accepts_work() from pool workers while the cleanup thread quiesces. Readers
+  // may legitimately observe either state before the quiesce lands, but once it has returned no
+  // reader may still see the query as accepting work.
+  query_lifecycle_registry registry;
+  const auto gated  = make_query_id(1);
+  const auto other  = make_query_id(2);
+  constexpr int kNr = 4;
+
+  registry.open_query(gated);
+  registry.open_query(other);
+
+  std::atomic<bool> stop{false};
+  std::atomic<bool> quiesced{false};
+  std::atomic<int> accepted_after_quiesce{0};
+  std::atomic<int> other_refused{0};
+
+  std::vector<std::thread> readers;
+  readers.reserve(kNr);
+  for (int i = 0; i < kNr; ++i) {
+    readers.emplace_back([&] {
+      while (!stop.load(std::memory_order_acquire)) {
+        const bool seen_quiesced = quiesced.load(std::memory_order_acquire);
+        if (registry.accepts_work(gated) && seen_quiesced) {
+          accepted_after_quiesce.fetch_add(1, std::memory_order_relaxed);
+        }
+        // The unrelated query must never be refused, no matter what the gated one is doing.
+        if (!registry.accepts_work(other)) {
+          other_refused.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    });
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  registry.quiesce(gated);
+  quiesced.store(true, std::memory_order_release);
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  stop.store(true, std::memory_order_release);
+  for (auto& t : readers) {
+    t.join();
+  }
+
+  REQUIRE(accepted_after_quiesce.load() == 0);
+  REQUIRE(other_refused.load() == 0);
+}

--- a/test/cpp/operator/mgpu_test_utils.hpp
+++ b/test/cpp/operator/mgpu_test_utils.hpp
@@ -183,10 +183,9 @@ class scoped_mgpu_env {
    * @brief Test-only accessor for the underlying task_scheduler.
    *
    * Returns a non-owning reference to the task_scheduler instance owned
-   * by the SiriusContext that this fixture wraps. Intended for tests
-   * that need to call test-only mutators (e.g.,
-   * `set_no_pref_rr_counter_for_testing`) between query setup and
-   * execution. Lifetime: the returned reference is valid for the
+   * by the SiriusContext that this fixture wraps. Intended for tests that
+   * need to reach the scheduler between query setup and execution.
+   * Lifetime: the returned reference is valid for the
    * lifetime of the scoped_mgpu_env instance (the SiriusContext is
    * shared across every connection opened against this env via the
    * extension callback's `OnConnectionOpened`).

--- a/test/cpp/operator/test_mgpu_stress.cpp
+++ b/test/cpp/operator/test_mgpu_stress.cpp
@@ -15,9 +15,8 @@
  */
 
 /*
- * Phase 15 stress test — varies the SCHED-RR counter starting offset
- * across 100 iterations and runs 5 pre-bound representative [mgpu]
- * test queries at each offset, asserting CPU baseline match.
+ * Phase 15 stress test — runs 5 pre-bound representative [mgpu] test queries
+ * across 100 iterations, asserting CPU baseline match on every run.
  *
  * SPEC DEVIATION (documented per 15-CONTEXT.md acceptance criterion 2):
  * CONTEXT calls for "100 iterations x all [mgpu] tests" (~1300 runs).
@@ -63,14 +62,13 @@
  *       Audit sites: end-to-end TPC-H plan (top_n via TopN, ungrouped_aggregate
  *       via aggregate). Uses /datasets/tpch_parquet_sf1/lineitem.parquet.
  *
- * Catches: hash-bucket-order dependent bugs, off-by-one drift in the
- * round-robin walk, latent assumptions that the counter always starts
- * at 0. See .planning/phases/15-mgpu-operator-colocation-audit/15-CONTEXT.md
- * acceptance criterion 2.
+ * Catches: hash-bucket-order dependent bugs and any latent assumption that
+ * preference-less tasks always land on the same GPU. Dispatch order is decided
+ * by whichever executor signals device_ready first, so repeating each query
+ * many times samples different orderings.
  */
 
 #include "mgpu_test_utils.hpp"
-#include "pipeline/task_scheduler.hpp"  // for set_no_pref_rr_counter_for_testing
 
 #include <cuda_runtime.h>
 
@@ -103,38 +101,17 @@ fs::path make_tmp_dir(std::string const& tag)
 }  // namespace
 
 // ---------------------------------------------------------------------------
-// Stress test: 100 counter-offset iterations x 5 pre-bound [mgpu] queries.
-// Each query has its parquet surface generated ONCE before the iteration
-// loop (data doesn't change with the counter offset; only the SCHED-RR
-// dispatch order does). Inside each iteration we set the counter offset
-// AFTER prepare_for_query (which would reset to 0) but BEFORE the first
-// task dispatch. The current Connection-based approach achieves this by
-// setting the counter BEFORE the gpu_execution call: prepare_for_query
-// runs as part of gpu_execution and resets to 0, then management_eventloop
-// reads the counter on first dispatch — so we re-set the counter on every
-// inner-loop iteration via the test-only setter.
+// Stress test: 100 iterations x 5 pre-bound [mgpu] queries, each compared
+// against its CPU baseline. Each query's parquet surface is generated ONCE
+// before the iteration loop; only the dispatch order varies between runs.
 //
-// Audit observation: prepare_for_query resets _no_pref_rr_counter to 0
-// at the start of every query (verified in Phase 14-01 SUMMARY line 138:
-// "Per-query reset in prepare_for_query: Required for cache=table_gpu
-// correctness ... iteration N+1 must dispatch the same preference-less
-// task to the same GPU as iteration N"). This makes the canonical
-// counter-injection path the test-only setter — a no-op warm-up cannot
-// persist counter state across query iterations.
-//
-// To inject `iter` into the counter at the right moment, we call the
-// setter immediately before `require_gpu_matches_cpu`. The setter races
-// with the per-query reset inside prepare_for_query, but only if the
-// management thread reaches the round-robin block before our setter's
-// store; in practice prepare_for_query runs synchronously in the calling
-// thread before any task dispatch, so our setter (also called from the
-// test thread, AFTER gpu_execution returns the prepared query) lands
-// before management_eventloop fires. Even if a race did occur the test
-// would still exercise SCHED-RR correctness with whatever offset wins;
-// the goal is offset DIVERSITY across iterations, not exact `iter` match.
+// Preference-less tasks are distributed by whichever GPU executor signals
+// device_ready first, so the GPU that serves a given task is not fixed across
+// iterations. Repeating each query many times is what samples those orderings
+// and catches an operator that only happens to be correct on one assignment.
 // ---------------------------------------------------------------------------
 
-TEST_CASE("mgpu_stress - SCHED-RR counter offset rotation",
+TEST_CASE("mgpu_stress - repeated multi-GPU dispatch matches CPU",
           "[mgpu_stress][mgpu][operator-mgpu][gpu_execution]")
 {
   if (!require_two_gpus()) return;
@@ -294,27 +271,19 @@ TEST_CASE("mgpu_stress - SCHED-RR counter offset rotation",
       "ORDER BY l_returnflag, l_linestatus");
   }
 
-  // 100 outer offsets — sweeps the counter through values that cover both
-  // even/odd, modulo-2 boundary, and large-modulo-N edge cases. With 2
-  // GPUs, offsets {0..99} mod 2 covers both GPUs as the "first preference-
-  // less task" device equally.
+  // 100 outer iterations. Which GPU serves the first preference-less task is
+  // decided by whichever executor signals device_ready first, so repeating the
+  // run this many times exercises both assignments rather than pinning one.
   static constexpr size_t kIterations = 100;
 
-  // Open the env + connection once. The connection persists across all
-  // iterations; only the counter offset changes. This mirrors the
-  // followup-17 stress TEST_CASE (kIterations=3 reusing one connection).
+  // Open the env + connection once; the connection persists across all
+  // iterations. This mirrors the followup-17 stress TEST_CASE (kIterations=3
+  // reusing one connection).
   scoped_mgpu_env env(yaml);
-  auto con    = env.make_connection();
-  auto& sched = env.get_task_scheduler(con);
+  auto con = env.make_connection();
 
   for (size_t iter = 0; iter < kIterations; ++iter) {
     for (size_t qi = 0; qi < kQueries.size(); ++qi) {
-      // Inject the iteration-specific offset. prepare_for_query resets
-      // the counter to 0 at the start of every gpu_execution; setting it
-      // here right before the call lands the test value before the first
-      // dispatch — see header comment for the race rationale.
-      sched.set_no_pref_rr_counter_for_testing(iter);
-
       INFO("iter=" << iter << " query=" << qi);
       require_gpu_matches_cpu(con, kQueries[qi]);
     }

--- a/test/cpp/pipeline/test_oom_reschedule.cpp
+++ b/test/cpp/pipeline/test_oom_reschedule.cpp
@@ -79,7 +79,10 @@ struct oom_test_fixture {
   cucascade::memory::memory_space* mem_space = nullptr;
   sirius::exec::channel<std::unique_ptr<sirius::pipeline::task_request>> request_channel;
   std::unique_ptr<sirius::pipeline::gpu_pipeline_executor> executor;
-  sirius::pipeline::completion_handler completion;
+  // The query's completion signal now travels on the task's global state rather than on
+  // the executor, so it is shared with whatever global state the test builds.
+  std::shared_ptr<sirius::pipeline::completion_handler> completion =
+    std::make_shared<sirius::pipeline::completion_handler>();
 
   // Returns false if setup failed (no GPU available) — caller should WARN and return.
   bool setup(int num_threads, const std::string& thread_name_prefix)
@@ -115,7 +118,6 @@ struct oom_test_fixture {
       std::move(request_publisher),
       nullptr,
       sirius::test::make_test_telemetry_context());
-    executor->set_completion_handler(&completion);
     return true;
   }
 };
@@ -364,6 +366,7 @@ TEST_CASE("GPU pipeline executor reschedules tasks on OOM", "[gpu_pipeline_execu
   }
 
   auto global_state = std::make_shared<oom_test_global_state>();
+  global_state->set_completion_handler(f.completion);
 
   const int num_tasks = 3;
   std::atomic<int> dispatched{0};
@@ -453,6 +456,7 @@ TEST_CASE("GPU pipeline executor fails after max OOM retries",
   }
 
   auto global_state = std::make_shared<oom_test_global_state>();
+  global_state->set_completion_handler(f.completion);
 
   const int num_small = 5;
   const int num_xl    = 3;
@@ -487,7 +491,7 @@ TEST_CASE("GPU pipeline executor fails after max OOM retries",
   //--------------------------------------------------------------------------
   auto start_time = std::chrono::steady_clock::now();
   auto timeout    = std::chrono::seconds(60);
-  while (!f.completion.has_error()) {
+  while (!f.completion->has_error()) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     if (std::chrono::steady_clock::now() - start_time > timeout) {
       f.executor->stop();
@@ -522,7 +526,7 @@ TEST_CASE("GPU pipeline executor fails after max OOM retries",
   REQUIRE(global_state->completed_count.load(std::memory_order_relaxed) == num_small);
 
   // The completion handler should be in an error state from exceeding max retries.
-  REQUIRE(f.completion.has_error());
+  REQUIRE(f.completion->has_error());
 
   // XL tasks should have OOM'd many times (at least 10 for the one that hit the limit).
   REQUIRE(global_state->oom_count.load(std::memory_order_relaxed) >= 10);

--- a/test/cpp/pipeline/test_per_query_completion_handler.cpp
+++ b/test/cpp/pipeline/test_per_query_completion_handler.cpp
@@ -42,8 +42,7 @@ using sirius::pipeline::sirius_pipeline_task_global_state;
 
 //! A global state carrying its query's handler, as task_creator::prepare_for_query builds it.
 std::shared_ptr<sirius_pipeline_task_global_state> make_global_state(
-  const sirius::pipeline::pipeline_build_context& ctx,
-  std::shared_ptr<completion_handler> handler)
+  const sirius::pipeline::pipeline_build_context& ctx, std::shared_ptr<completion_handler> handler)
 {
   auto pipeline = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(ctx);
   auto gs       = std::make_shared<sirius_pipeline_task_global_state>(

--- a/test/cpp/pipeline/test_per_query_completion_handler.cpp
+++ b/test/cpp/pipeline/test_per_query_completion_handler.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_per_query_completion_handler.cpp
+ * @brief A query's completion handler travels on its tasks' global state.
+ *
+ * It used to live on task_scheduler and be pushed into every executor, so a second query
+ * overwrote the first's: query A's completion signalled B's promise, and A's failure poisoned B.
+ * These cases pin the isolation that replaces it, plus the lifetime property that lets the
+ * owning sirius_engine be destroyed while tasks are still unwinding.
+ */
+
+#include "catch.hpp"
+#include "pipeline/completion_handler.hpp"
+#include "pipeline/pipeline_build_context.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "pipeline/sirius_pipeline_task_states.hpp"
+#include "utils/telemetry_utils.hpp"
+
+#include <chrono>
+#include <future>
+#include <memory>
+
+namespace {
+
+using sirius::pipeline::completion_handler;
+using sirius::pipeline::sirius_pipeline_task_global_state;
+
+//! A global state carrying its query's handler, as task_creator::prepare_for_query builds it.
+std::shared_ptr<sirius_pipeline_task_global_state> make_global_state(
+  const sirius::pipeline::pipeline_build_context& ctx,
+  std::shared_ptr<completion_handler> handler)
+{
+  auto pipeline = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(ctx);
+  auto gs       = std::make_shared<sirius_pipeline_task_global_state>(
+    pipeline, sirius::test::make_test_telemetry_context());
+  gs->set_completion_handler(std::move(handler));
+  return gs;
+}
+
+bool is_ready(std::future<void>& f)
+{
+  return f.wait_for(std::chrono::seconds{0}) == std::future_status::ready;
+}
+
+}  // namespace
+
+TEST_CASE("completing one query leaves another query's future unset",
+          "[completion_handler][per_query]")
+{
+  sirius::pipeline::pipeline_build_context ctx{nullptr, true};
+  auto handler_a = std::make_shared<completion_handler>();
+  auto handler_b = std::make_shared<completion_handler>();
+  auto future_a  = handler_a->get_awaitable();
+  auto future_b  = handler_b->get_awaitable();
+
+  auto gs_a = make_global_state(ctx, handler_a);
+  auto gs_b = make_global_state(ctx, handler_b);
+
+  // Query A finishes. With a single scheduler-wide handler this would have satisfied whichever
+  // query happened to be installed last.
+  gs_a->get_completion_handler()->mark_completed();
+
+  REQUIRE(is_ready(future_a));
+  CHECK_FALSE(is_ready(future_b));
+  future_a.get();  // no throw
+}
+
+TEST_CASE("one query's failure does not poison another's handler",
+          "[completion_handler][per_query]")
+{
+  sirius::pipeline::pipeline_build_context ctx{nullptr, true};
+  auto handler_a = std::make_shared<completion_handler>();
+  auto handler_b = std::make_shared<completion_handler>();
+  auto future_b  = handler_b->get_awaitable();
+
+  auto gs_a = make_global_state(ctx, handler_a);
+  auto gs_b = make_global_state(ctx, handler_b);
+
+  gs_a->get_completion_handler()->report_error("query A failed");
+
+  CHECK(handler_a->has_error());
+  // B stays clean. The executor's reschedule path consults has_error() to decide whether to
+  // abandon a task, so a shared handler made A's failure silently stop B's rescheduling.
+  CHECK_FALSE(handler_b->has_error());
+  CHECK_FALSE(is_ready(future_b));
+}
+
+TEST_CASE("the handler outlives the engine-side reference", "[completion_handler][per_query]")
+{
+  sirius::pipeline::pipeline_build_context ctx{nullptr, true};
+  auto handler = std::make_shared<completion_handler>();
+  auto future  = handler->get_awaitable();
+  auto gs      = make_global_state(ctx, handler);
+
+  // sirius_engine is destroyed in cleanup_internal, BEFORE run_mandatory_cleanup drains the
+  // queues — so dropping the owning reference must not invalidate the handler a still-unwinding
+  // task holds through its global state. A raw pointer here would dangle.
+  std::weak_ptr<completion_handler> observer = handler;
+  handler.reset();
+  REQUIRE_FALSE(observer.expired());
+
+  gs->get_completion_handler()->report_error("late failure after the engine went away");
+  CHECK(is_ready(future));
+  CHECK_THROWS(future.get());
+
+  // Released only when the last task-side reference goes.
+  gs.reset();
+  CHECK(observer.expired());
+}
+
+TEST_CASE("every pipeline of one query shares its handler", "[completion_handler][per_query]")
+{
+  sirius::pipeline::pipeline_build_context ctx{nullptr, true};
+  auto handler = std::make_shared<completion_handler>();
+
+  // prepare_for_query stamps the same handler onto each pipeline's global state, so whichever
+  // pipeline's task reports, it reaches the one promise the engine is waiting on.
+  auto gs_first  = make_global_state(ctx, handler);
+  auto gs_second = make_global_state(ctx, handler);
+
+  CHECK(gs_first->get_completion_handler().get() == gs_second->get_completion_handler().get());
+  CHECK(gs_first->get_completion_handler().get() == handler.get());
+}
+
+TEST_CASE("a global state built without a query carries no handler",
+          "[completion_handler][per_query]")
+{
+  sirius::pipeline::pipeline_build_context ctx{nullptr, true};
+  auto pipeline = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(ctx);
+  sirius_pipeline_task_global_state gs(pipeline, sirius::test::make_test_telemetry_context());
+
+  // Reporting sites are all null-guarded, so a state built outside a query (tests) is inert
+  // rather than a crash.
+  CHECK(gs.get_completion_handler() == nullptr);
+}

--- a/test/cpp/pipeline/test_task_index_keys.cpp
+++ b/test/cpp/pipeline/test_task_index_keys.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_task_index_keys.cpp
+ * @brief index_keys_for is the single key extractor shared by the task_scheduler queue and every
+ *        gpu_pipeline_executor queue. If the two disagreed on a task's query, a per-query drain
+ *        would clear it from one queue and leave it in the other.
+ */
+
+#include "catch.hpp"
+#include "exec/multi_index_priority_queue.hpp"
+#include "op/sirius_physical_operator.hpp"
+#include "op/sirius_physical_operator_type.hpp"
+#include "pipeline/gpu_pipeline_task.hpp"
+#include "pipeline/pipeline_build_context.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "pipeline/sirius_pipeline_task_states.hpp"
+#include "query_id.hpp"
+#include "utils/telemetry_utils.hpp"
+
+#include <limits>
+#include <memory>
+#include <vector>
+
+namespace {
+
+using sirius::make_query_id;
+using sirius::pipeline::index_keys_for;
+
+//! A task that is not a gpu_pipeline_task, to exercise the sentinel branch.
+class plain_task : public sirius::parallel::itask {
+ public:
+  plain_task() : itask(/*task_id=*/1, nullptr, nullptr) {}
+  void execute(rmm::cuda_stream_view /*stream*/) override {}
+};
+
+struct task_fixture {
+  //! A pipeline needs a real source/sink: ~gpu_pipeline_task calls mark_task_completed(), which
+  //! walks the pipeline's operators.
+  duckdb::shared_ptr<sirius::pipeline::sirius_pipeline> make_pipeline(sirius::query_id_t query_id,
+                                                                      sirius::exec::queue_priority
+                                                                        priority)
+  {
+    auto pipeline = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(build_ctx);
+    auto& op      = *operators.emplace_back(
+      std::make_unique<sirius::op::sirius_physical_operator>(
+        sirius::op::SiriusPhysicalOperatorType::FILTER,
+        duckdb::vector<sirius::logical_type>{},
+        /*estimated_cardinality=*/0));
+    op.operator_id = operators.size() - 1;
+
+    sirius::pipeline::sirius_pipeline_build_state build_state;
+    build_state.set_pipeline_source(*pipeline, op);
+    build_state.set_pipeline_sink(*pipeline, &op, /*sink_pipeline_count=*/1);
+
+    pipeline->set_query_id(query_id);
+    pipeline->set_priority(priority);
+    return pipeline;
+  }
+
+  std::unique_ptr<sirius::pipeline::gpu_pipeline_task> make_task(
+    const duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>& pipeline,
+    sirius::exec::queue_priority priority)
+  {
+    auto global_state = std::make_shared<sirius::pipeline::gpu_pipeline_task_global_state>(
+      pipeline, sirius::test::make_test_telemetry_context());
+    global_state->set_priority(priority);
+
+    auto op_data = std::make_unique<sirius::op::pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<sirius::pipeline::gpu_pipeline_task>(
+      /*task_id=*/1,
+      std::vector<cucascade::shared_data_repository*>{},
+      std::make_unique<sirius::pipeline::gpu_pipeline_task_local_state>(std::move(op_data)),
+      std::move(global_state));
+  }
+
+  sirius::pipeline::pipeline_build_context build_ctx{nullptr, true};
+  //! Outlive every pipeline/task built from this fixture.
+  std::vector<std::unique_ptr<sirius::op::sirius_physical_operator>> operators;
+};
+
+}  // namespace
+
+TEST_CASE("index_keys_for takes the query id from the task's pipeline", "[task_index_keys]")
+{
+  task_fixture f;
+  const auto query_id = make_query_id(7);
+  auto pipeline       = f.make_pipeline(query_id, /*priority=*/42);
+  auto task           = f.make_task(pipeline, /*priority=*/42);
+
+  const auto keys = index_keys_for(*task);
+
+  CHECK(keys.query_id == sirius::value_of(query_id));
+  CHECK(keys.priority == 42);
+}
+
+TEST_CASE("index_keys_for does not unpack the query id from the priority", "[task_index_keys]")
+{
+  task_fixture f;
+  // query_priority_bits masks the id to 31 bits, so a bit-31 id and 0 pack to the SAME priority
+  // bits. Recovering the query from those bits would report 0 here, and a
+  // drain(query_index{value_of(query_id)}) would then never match this task.
+  const auto query_id = make_query_id(0x8000'0000U);
+  REQUIRE(sirius::query_priority_bits(query_id) == sirius::query_priority_bits(make_query_id(0)));
+
+  auto pipeline = f.make_pipeline(query_id, /*priority=*/sirius::query_priority_bits(query_id));
+  auto task     = f.make_task(pipeline, /*priority=*/sirius::query_priority_bits(query_id));
+
+  const auto keys = index_keys_for(*task);
+
+  CHECK(keys.query_id == sirius::value_of(query_id));
+  CHECK(keys.query_id != 0U);
+}
+
+TEST_CASE("index_keys_for reports the pipeline source's operator type", "[task_index_keys]")
+{
+  task_fixture f;
+  auto pipeline = f.make_pipeline(make_query_id(3), /*priority=*/1);
+  auto task     = f.make_task(pipeline, /*priority=*/1);
+
+  const auto keys = index_keys_for(*task);
+  CHECK(keys.operator_type == sirius::op::SiriusPhysicalOperatorType::FILTER);
+}
+
+TEST_CASE("index_keys_for gives a non-pipeline task sentinel keys", "[task_index_keys]")
+{
+  plain_task task;
+
+  const auto keys = index_keys_for(task);
+
+  // Max priority sorts it last; the sentinel query/device keys keep it out of any query's
+  // bucket, so a per-query drain can never remove it.
+  CHECK(keys.priority == std::numeric_limits<sirius::exec::queue_priority>::max());
+  CHECK(keys.operator_type == sirius::op::SiriusPhysicalOperatorType::INVALID);
+  CHECK(keys.query_id == 0U);
+  CHECK(keys.device_id == sirius::exec::no_preferred_device);
+}
+
+TEST_CASE("index_keys_for defaults to no preferred device", "[task_index_keys]")
+{
+  task_fixture f;
+  auto pipeline = f.make_pipeline(make_query_id(5), /*priority=*/9);
+  auto task     = f.make_task(pipeline, /*priority=*/9);
+
+  const auto keys = index_keys_for(*task);
+  CHECK(keys.device_id == sirius::exec::no_preferred_device);
+}

--- a/test/cpp/pipeline/test_task_index_keys.cpp
+++ b/test/cpp/pipeline/test_task_index_keys.cpp
@@ -51,16 +51,14 @@ class plain_task : public sirius::parallel::itask {
 struct task_fixture {
   //! A pipeline needs a real source/sink: ~gpu_pipeline_task calls mark_task_completed(), which
   //! walks the pipeline's operators.
-  duckdb::shared_ptr<sirius::pipeline::sirius_pipeline> make_pipeline(sirius::query_id_t query_id,
-                                                                      sirius::exec::queue_priority
-                                                                        priority)
+  duckdb::shared_ptr<sirius::pipeline::sirius_pipeline> make_pipeline(
+    sirius::query_id_t query_id, sirius::exec::queue_priority priority)
   {
-    auto pipeline = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(build_ctx);
-    auto& op      = *operators.emplace_back(
-      std::make_unique<sirius::op::sirius_physical_operator>(
-        sirius::op::SiriusPhysicalOperatorType::FILTER,
-        duckdb::vector<sirius::logical_type>{},
-        /*estimated_cardinality=*/0));
+    auto pipeline  = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(build_ctx);
+    auto& op       = *operators.emplace_back(std::make_unique<sirius::op::sirius_physical_operator>(
+      sirius::op::SiriusPhysicalOperatorType::FILTER,
+      duckdb::vector<sirius::logical_type>{},
+      /*estimated_cardinality=*/0));
     op.operator_id = operators.size() - 1;
 
     sirius::pipeline::sirius_pipeline_build_state build_state;

--- a/test/cpp/pipeline/test_task_scheduler.cpp
+++ b/test/cpp/pipeline/test_task_scheduler.cpp
@@ -16,6 +16,7 @@
 
 #include "catch.hpp"
 #include "exec/config.hpp"
+#include "pipeline/completion_handler.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
 #include "pipeline/task_scheduler.hpp"
 #include "scan/test_utils.hpp"
@@ -27,8 +28,10 @@
 
 #include <atomic>
 #include <chrono>
+#include <exception>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 
 using namespace sirius::pipeline;
@@ -137,6 +140,53 @@ TEST_CASE("Task scheduler executes tasks through pipeline_queue", "[task_schedul
     }
   }
 
+  REQUIRE(global_state->executed_count.load() == num_tasks);
+
+  executor.stop();
+}
+
+TEST_CASE("terminate_query fails only its own query and leaves the scheduler running",
+          "[task_scheduler][concurrency]")
+{
+  // Regression for the "one query's failure hangs the whole engine" class of bug:
+  // terminate_query used to call stop(), which closed the request channel, joined the management
+  // thread and stopped every GPU executor -- for ALL queries -- with no path that ever calls
+  // start() again. Any other in-flight query was left waiting on a completion that could never
+  // arrive, as was every subsequent query in the process.
+  auto manager = initialize_memory_manager(1);
+  sirius::exec::thread_pool_config gpu_config{2};
+  task_scheduler executor(gpu_config, *manager, sirius::test::make_test_telemetry_context());
+
+  executor.start();
+
+  // Query A fails.
+  auto handler_a = std::make_shared<completion_handler>();
+  auto future_a  = handler_a->get_awaitable();
+  executor.terminate_query(handler_a,
+                           std::make_exception_ptr(std::runtime_error("query A creation failed")));
+
+  // A -- and only A -- is failed.
+  REQUIRE_THROWS_AS(future_a.get(), std::runtime_error);
+
+  // The scheduler must still dispatch work. Before the fix this hung until the 10s timeout
+  // because the management thread and every GPU executor were already stopped.
+  auto global_state = std::make_shared<mock_gpu_pipeline_task_global_state>();
+
+  const int num_tasks = 5;
+  for (int i = 0; i < num_tasks; ++i) {
+    auto local_state = std::make_unique<mock_gpu_pipeline_task_local_state>(i, 0);
+    auto task = std::make_unique<mock_gpu_pipeline_task>(i, std::move(local_state), global_state);
+    executor.schedule(std::move(task));
+  }
+
+  auto start_time = std::chrono::steady_clock::now();
+  auto timeout    = std::chrono::seconds(10);
+  while (global_state->executed_count.load(std::memory_order_relaxed) < num_tasks) {
+    std::this_thread::sleep_for(10ms);
+    if (std::chrono::steady_clock::now() - start_time > timeout) {
+      FAIL("scheduler stopped dispatching after terminate_query on an unrelated query");
+    }
+  }
   REQUIRE(global_state->executed_count.load() == num_tasks);
 
   executor.stop();

--- a/test/cpp/pipeline/test_task_scheduler.cpp
+++ b/test/cpp/pipeline/test_task_scheduler.cpp
@@ -247,6 +247,51 @@ TEST_CASE("the lifecycle gate refuses scheduling for a quiescing query",
   executor.stop();
 }
 
+TEST_CASE("wait_for_completion validates only its own query's queue",
+          "[task_scheduler][query_lifecycle_gate][concurrency]")
+{
+  // Regression for A5: wait_for_completion used the whole-queue size(), so query A completing
+  // normally threw "pipeline task queue not empty at query completion" purely because query B had
+  // work legitimately queued. It also called _task_creator->stop_thread_pool(), tearing down the
+  // SHARED creation pool on every successful completion.
+  auto manager = initialize_memory_manager(1);
+  sirius::exec::thread_pool_config gpu_config{2};
+  sirius::exec::query_lifecycle_registry lifecycle;
+  task_scheduler executor(gpu_config, *manager, sirius::test::make_test_telemetry_context());
+  executor.set_query_lifecycle_registry(&lifecycle);
+
+  // Mock tasks carry no pipeline, so index_keys_for() reports them as query 0. Completing a
+  // DIFFERENT query id must ignore them entirely.
+  const auto other_query      = sirius::make_query_id(0);
+  const auto completing_query = sirius::make_query_id(42);
+  lifecycle.open_query(other_query);
+  lifecycle.open_query(completing_query);
+
+  auto global_state = std::make_shared<mock_gpu_pipeline_task_global_state>();
+  executor.start();
+
+  // Park work belonging to `other_query` in the scheduler queue by keeping every device busy.
+  for (int i = 0; i < 8; ++i) {
+    auto local_state = std::make_unique<mock_gpu_pipeline_task_local_state>(i, 0);
+    executor.schedule(
+      std::make_unique<mock_gpu_pipeline_task>(i, std::move(local_state), global_state));
+  }
+
+  // The assertion this test exists for: completing an unrelated query must not throw because a
+  // co-tenant has work queued. Before the per-query size() check, this threw
+  // "pipeline task queue not empty at query completion" every time.
+  REQUIRE_NOTHROW(executor.wait_for_completion(completing_query));
+
+  // NOT asserted here: that every co-tenant task still runs. wait_and_validate_empty() must
+  // release the manager thread's pool slot before wait_all() can return (see
+  // itask_executor::quiesce_manager), and that interrupt makes push() return false for the
+  // duration — so a co-tenant task in transit from the scheduler to a device queue can still be
+  // dropped. Step 3 removes the *whole-queue* drain that used to destroy co-tenants' queued work
+  // outright; eliminating the in-transit drop needs per-query in-flight accounting from the
+  // query-aware bounded_thread_pool, at which point this test should gain a liveness assertion.
+  executor.stop();
+}
+
 TEST_CASE("Task queue handles empty queue gracefully", "[pipeline_queue]")
 {
   auto manager = initialize_memory_manager(1);

--- a/test/cpp/pipeline/test_task_scheduler.cpp
+++ b/test/cpp/pipeline/test_task_scheduler.cpp
@@ -16,9 +16,11 @@
 
 #include "catch.hpp"
 #include "exec/config.hpp"
+#include "exec/query_lifecycle_registry.hpp"
 #include "pipeline/completion_handler.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
 #include "pipeline/task_scheduler.hpp"
+#include "query_id.hpp"
 #include "scan/test_utils.hpp"
 #include "utils/telemetry_utils.hpp"
 
@@ -187,6 +189,59 @@ TEST_CASE("terminate_query fails only its own query and leaves the scheduler run
       FAIL("scheduler stopped dispatching after terminate_query on an unrelated query");
     }
   }
+  REQUIRE(global_state->executed_count.load() == num_tasks);
+
+  executor.stop();
+}
+
+TEST_CASE("the lifecycle gate refuses scheduling for a quiescing query",
+          "[task_scheduler][query_lifecycle_gate][concurrency]")
+{
+  // Wiring check for the gate: task_scheduler::schedule must consult it. A task creation worker
+  // can land in schedule() after this query's queue drain already ran, and the task would then
+  // sit in the shared queue holding raw repository pointers into a manager about to be erased.
+  auto manager = initialize_memory_manager(1);
+  sirius::exec::thread_pool_config gpu_config{2};
+  // Declared BEFORE the scheduler so it is destroyed AFTER it: the scheduler and every GPU
+  // executor hold a raw pointer to the gate, and ~task_scheduler still runs stop().
+  sirius::exec::query_lifecycle_registry lifecycle;
+  task_scheduler executor(gpu_config, *manager, sirius::test::make_test_telemetry_context());
+  executor.set_query_lifecycle_registry(&lifecycle);
+
+  // Mock tasks carry no pipeline, so index_keys_for() reports them as query 0.
+  const auto mock_query = sirius::make_query_id(0);
+  lifecycle.open_query(mock_query);
+
+  auto global_state = std::make_shared<mock_gpu_pipeline_task_global_state>();
+  executor.start();
+
+  auto schedule_batch = [&](int count, int id_base) {
+    for (int i = 0; i < count; ++i) {
+      auto local_state = std::make_unique<mock_gpu_pipeline_task_local_state>(id_base + i, 0);
+      auto task =
+        std::make_unique<mock_gpu_pipeline_task>(id_base + i, std::move(local_state), global_state);
+      executor.schedule(std::move(task));
+    }
+  };
+
+  // Open: work flows.
+  const int num_tasks = 5;
+  schedule_batch(num_tasks, 0);
+
+  auto start_time = std::chrono::steady_clock::now();
+  while (global_state->executed_count.load(std::memory_order_relaxed) < num_tasks) {
+    std::this_thread::sleep_for(10ms);
+    if (std::chrono::steady_clock::now() - start_time > std::chrono::seconds(10)) {
+      FAIL("tasks did not execute while the query was open");
+    }
+  }
+  REQUIRE(global_state->executed_count.load() == num_tasks);
+
+  // Quiescing: further work is dropped rather than enqueued.
+  lifecycle.quiesce(mock_query);
+  schedule_batch(num_tasks, 100);
+
+  std::this_thread::sleep_for(200ms);
   REQUIRE(global_state->executed_count.load() == num_tasks);
 
   executor.stop();

--- a/test/cpp/scan_manager/test_cached_serving_hardening.cpp
+++ b/test/cpp/scan_manager/test_cached_serving_hardening.cpp
@@ -336,8 +336,11 @@ TEST_CASE("drain_cached_provider forwards the mvcc keep-mask and filter flag ont
 
 TEST_CASE("cached provider pairs chunk i with mask-set slot i", "[cached_serving][scan_manager]")
 {
-  auto& e    = env();
-  auto entry = make_gpu_entry(*e.gpu_space, 3, 4);
+  auto& e = env();
+  // shared_ptr because the provider co-owns the entry it serves — see
+  // make_provider_for_pinned_entry.
+  auto entry =
+    std::make_shared<sirius::scan_manager::pinned_entry>(make_gpu_entry(*e.gpu_space, 3, 4));
   std::vector<std::size_t> cols{0, 1, 2};
 
   SECTION("with a mask set")

--- a/test/cpp/scan_manager/test_s3_routing_cutover.cpp
+++ b/test/cpp/scan_manager/test_s3_routing_cutover.cpp
@@ -254,10 +254,9 @@ sirius::io::ioctx_resolver make_datasource_resolver(sirius_scan_manager& manager
   };
 }
 
-sirius::planner::query make_empty_query()
+sirius::planner::query make_empty_query(sirius::query_id_t query_id = sirius::make_query_id(1))
 {
-  auto tctx           = sirius::test::make_test_telemetry_context();
-  const auto query_id = sirius::make_query_id(1);
+  auto tctx = sirius::test::make_test_telemetry_context();
   sirius::telemetry::query_telemetry_info tinfo{tctx->engine_id(), tctx->worker_id(), query_id};
   return sirius::planner::query(
     duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>>{},
@@ -645,14 +644,18 @@ TEST_CASE("scan_manager re-primes routed S3 cache on every query",
   REQUIRE(default_cache != nullptr);
   REQUIRE(default_cache->query_epoch() == 0);
 
-  auto q = make_empty_query();
-  // The query intentionally has no scan operators: routed caches must still
+  // The queries intentionally have no scan operators: routed caches must still
   // advance once per query, matching the default ioctx's query-wide refresh.
-  manager.prepare_for_query(q, true);
+  // Distinct query ids because per-query state is keyed by id — the epoch bump is per
+  // prepare_for_query call, and using one id twice would exercise the stale-state replacement
+  // path rather than the two-queries case this gate is about.
+  auto q1 = make_empty_query(sirius::make_query_id(1));
+  manager.prepare_for_query(q1, true);
   REQUIRE(routed_cache->query_epoch() == 1);
   REQUIRE(default_cache->query_epoch() == 1);
 
-  manager.prepare_for_query(q, true);
+  auto q2 = make_empty_query(sirius::make_query_id(2));
+  manager.prepare_for_query(q2, true);
   REQUIRE(routed_cache->query_epoch() == 2);
   REQUIRE(default_cache->query_epoch() == 2);
 }

--- a/test/cpp/scan_manager/test_scan_manager_query_state.cpp
+++ b/test/cpp/scan_manager/test_scan_manager_query_state.cpp
@@ -76,10 +76,10 @@ sirius::scan_manager::scan_manager_config make_local_config()
 
 std::unique_ptr<scan::parquet_ingestible_table_info> make_table_info(std::string const& file)
 {
-  auto info = std::make_unique<scan::parquet_ingestible_table_info>();
-  info->resolved_file_paths = {(project_root() / "test/cpp/integration/data/parquet" / file)
-                                 .string()};
-  info->names               = {"c0"};
+  auto info                 = std::make_unique<scan::parquet_ingestible_table_info>();
+  info->resolved_file_paths = {
+    (project_root() / "test/cpp/integration/data/parquet" / file).string()};
+  info->names = {"c0"};
   info->returned_types.push_back(sirius::logical_type::make(sirius::type_id::INTEGER));
   info->column_ids.push_back(duckdb::ColumnIndex(0));
   info->scan_output_arity = 1;
@@ -226,8 +226,7 @@ TEST_CASE("concurrent queries do not collide on operator id", "[scan_manager][qu
   REQUIRE(manager.num_active_queries() == 0);
 }
 
-TEST_CASE("reset is a no-op for unknown and already-reset queries",
-          "[scan_manager][query_state]")
+TEST_CASE("reset is a no-op for unknown and already-reset queries", "[scan_manager][query_state]")
 {
   fixture f;
   sirius_scan_manager manager{make_local_config(), *f.memory, f.topology};
@@ -272,8 +271,8 @@ TEST_CASE("a query with no GPU scan operators registers nothing", "[scan_manager
   fixture f;
   sirius_scan_manager manager{make_local_config(), *f.memory, f.topology};
 
-  auto tctx               = sirius::test::make_test_telemetry_context();
-  auto const query_id     = sirius::make_query_id(7);
+  auto tctx           = sirius::test::make_test_telemetry_context();
+  auto const query_id = sirius::make_query_id(7);
   sirius::telemetry::query_telemetry_info tinfo{tctx->engine_id(), tctx->worker_id(), query_id};
   sirius::planner::query empty{
     duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>>{},

--- a/test/cpp/scan_manager/test_scan_manager_query_state.cpp
+++ b/test/cpp/scan_manager/test_scan_manager_query_state.cpp
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Per-query scan state (sirius_scan_manager::query_scan_manager_state).
+//
+// The scan manager used to keep one query's worth of state in bare members, with reset()
+// wiping all of it. Two things broke the moment two queries could overlap:
+//
+//   - the dispatcher was shared, so finishing query A called request_stop() on the dispatcher
+//     running query B's scans — B's sequencer died and its split_connector closed mid-scan,
+//     which the consumer reads as end-of-stream (silent truncation, not an error);
+//   - the coalescer was shared and its slot map is keyed by scan_op->get_operator_id(), and
+//     operator ids restart at 0 for every query — so two queries' first scan operators
+//     collided on one slot and each could be fed the other's splits.
+//
+// These gates pin both, plus the lifecycle arithmetic (register / reset / reset_all and the
+// no-op paths) that sirius_context's cleanup and failure backstop depend on.
+
+#include "catch.hpp"
+#include "memory/topology_index.hpp"
+#include "op/scan/parquet_gpu_ingestible.hpp"
+#include "op/scan/sirius_gpu_scan_operator.hpp"
+#include "op/scan/sirius_gpu_scan_operator_data.hpp"
+#include "pipeline/repository_wiring.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "planner/query.hpp"
+#include "scan/test_utils.hpp"
+#include "scan_manager/sirius_scan_manager.hpp"
+#include "scan_manager/split_connector.hpp"
+#include "utils/telemetry_utils.hpp"
+
+#include <cucascade/memory/topology_discovery.hpp>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+namespace scan = sirius::op::scan;
+using sirius::scan_manager::sirius_scan_manager;
+
+std::filesystem::path project_root()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return std::filesystem::path{SIRIUS_PROJECT_ROOT};
+#else
+  return std::filesystem::current_path();
+#endif
+}
+
+/// Local-file scan config: no S3 backend, no prefetch cache, one worker. The pool the manager
+/// builds is num_threads + k_max_concurrent_queries, which is what the two-query gates lean on.
+sirius::scan_manager::scan_manager_config make_local_config()
+{
+  sirius::scan_manager::scan_manager_config cfg;
+  cfg.thread_pool.num_threads = 2;
+  cfg.uring_n_reactors        = 1;
+  cfg.enable_prefetch_cache   = false;
+  return cfg;
+}
+
+std::unique_ptr<scan::parquet_ingestible_table_info> make_table_info(std::string const& file)
+{
+  auto info = std::make_unique<scan::parquet_ingestible_table_info>();
+  info->resolved_file_paths = {(project_root() / "test/cpp/integration/data/parquet" / file)
+                                 .string()};
+  info->names               = {"c0"};
+  info->returned_types.push_back(sirius::logical_type::make(sirius::type_id::INTEGER));
+  info->column_ids.push_back(duckdb::ColumnIndex(0));
+  info->scan_output_arity = 1;
+  return info;
+}
+
+/// One query, one pipeline, one GPU scan operator over @p file. Operator ids are assigned per
+/// query (restarting at 0), which is exactly the collision the coalescer slot map used to hit.
+struct query_context {
+  duckdb::shared_ptr<sirius::pipeline::sirius_pipeline> pipeline;
+  std::unique_ptr<scan::sirius_gpu_scan_operator> scan_op;
+  std::shared_ptr<const sirius::telemetry::telemetry_context> tctx;
+  duckdb::shared_ptr<sirius::planner::query> query;
+};
+
+query_context make_query(sirius::query_id_t query_id, std::string const& file)
+{
+  query_context ctx;
+  const sirius::pipeline::pipeline_build_context build_ctx{nullptr, true};
+  ctx.pipeline = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(build_ctx);
+  ctx.pipeline->set_pipeline_id(1);
+  ctx.pipeline->set_query_id(query_id);
+
+  auto ingestible = scan::make_ingestible(make_table_info(file));
+  ctx.scan_op     = std::make_unique<scan::sirius_gpu_scan_operator>(
+    duckdb::vector<sirius::logical_type>{sirius::logical_type::make(sirius::type_id::INTEGER)},
+    0,
+    std::move(ingestible));
+
+  sirius::pipeline::sirius_pipeline_build_state build_state;
+  build_state.set_pipeline_source(*ctx.pipeline, *ctx.scan_op);
+  // Also register it as a pipeline operator: query::build_indices only calls set_pipeline() on
+  // operators in get_operators(), and the coalescer's register_pipeline dereferences
+  // scan_op->get_pipeline() to read the pipeline id. assign_operator_ids walks the same list.
+  build_state.add_pipeline_operator(*ctx.pipeline, *ctx.scan_op);
+
+  duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>> pipelines{ctx.pipeline};
+  sirius::pipeline::assign_operator_ids(pipelines);
+
+  ctx.tctx = sirius::test::make_test_telemetry_context();
+  sirius::telemetry::query_telemetry_info tinfo{
+    ctx.tctx->engine_id(), ctx.tctx->worker_id(), query_id};
+  ctx.query = duckdb::make_shared_ptr<sirius::planner::query>(
+    pipelines, ctx.tctx->context(), query_id, tinfo);
+  return ctx;
+}
+
+cucascade::memory::system_topology_info single_gpu_topology()
+{
+  cucascade::memory::system_topology_info topology;
+  topology.num_gpus = 1;
+  cucascade::memory::gpu_topology_info gpu;
+  gpu.id        = 0;
+  gpu.numa_node = 0;
+  topology.gpus.push_back(std::move(gpu));
+  return topology;
+}
+
+struct fixture {
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory =
+    initialize_memory_manager(1);
+  std::shared_ptr<const sirius::memory::topology_index> topology =
+    std::make_shared<sirius::memory::topology_index>(single_gpu_topology(), std::vector<int>{0});
+};
+
+}  // namespace
+
+TEST_CASE("two queries register independently and reset drops only one",
+          "[scan_manager][query_state]")
+{
+  fixture f;
+  sirius_scan_manager manager{make_local_config(), *f.memory, f.topology};
+
+  auto a = make_query(sirius::make_query_id(1), "nation.parquet");
+  auto b = make_query(sirius::make_query_id(2), "supplier.parquet");
+
+  manager.prepare_for_query(*a.query, /*enable_pinned_zone_map_pruning=*/true);
+  REQUIRE(manager.num_active_queries() == 1);
+  manager.prepare_for_query(*b.query, /*enable_pinned_zone_map_pruning=*/true);
+  REQUIRE(manager.num_active_queries() == 2);
+
+  // The gate: tearing down A must not touch B. Before per-query dispatchers this called
+  // request_stop() on the one dispatcher driving both, killing B's sequencer.
+  manager.reset(a.query->query_id());
+  REQUIRE(manager.num_active_queries() == 1);
+
+  // B is still live and still serving: its connector yields its splits and closes normally
+  // (a closed-by-A connector would have ended the stream with no splits at all).
+  std::size_t b_splits = 0;
+  while (auto split = b.scan_op->get_split_connector().get_next_split()) {
+    ++b_splits;
+  }
+  REQUIRE(b_splits > 0);
+
+  manager.reset(b.query->query_id());
+  REQUIRE(manager.num_active_queries() == 0);
+}
+
+TEST_CASE("concurrent queries do not collide on operator id", "[scan_manager][query_state]")
+{
+  fixture f;
+  sirius_scan_manager manager{make_local_config(), *f.memory, f.topology};
+
+  // Both scan operators are id 0 — ids restart per query. A shared coalescer keys its slot map
+  // by that id, so one query's splits would land in the other's slot.
+  auto a = make_query(sirius::make_query_id(1), "nation.parquet");
+  auto b = make_query(sirius::make_query_id(2), "supplier.parquet");
+  REQUIRE(a.scan_op->get_operator_id() == b.scan_op->get_operator_id());
+
+  manager.prepare_for_query(*a.query, true);
+  manager.prepare_for_query(*b.query, true);
+
+  // Each operator receives splits for ITS OWN file, not the other's. The coalescer emits
+  // parquet_split_info (row-group slices, possibly spanning files), not the per-file
+  // parquet_file_scan_info the pre-coalescer metadata pass produces.
+  auto drain_paths = [](scan::sirius_gpu_scan_operator& op) {
+    std::vector<std::string> paths;
+    while (auto split = op.get_split_connector().get_next_split()) {
+      auto* input = dynamic_cast<scan::scan_operator_input*>(split->get());
+      if (input == nullptr || !input->has_scan_metadata()) { continue; }
+      auto const* split_info =
+        dynamic_cast<scan::parquet_split_info const*>(&input->get_scan_info());
+      if (split_info == nullptr) { continue; }
+      for (auto const& slice : split_info->rg_slices) {
+        paths.push_back(slice.file_path);
+      }
+    }
+    return paths;
+  };
+
+  auto a_paths = drain_paths(*a.scan_op);
+  auto b_paths = drain_paths(*b.scan_op);
+
+  REQUIRE_FALSE(a_paths.empty());
+  REQUIRE_FALSE(b_paths.empty());
+  for (auto const& p : a_paths) {
+    REQUIRE(p.find("nation.parquet") != std::string::npos);
+  }
+  for (auto const& p : b_paths) {
+    REQUIRE(p.find("supplier.parquet") != std::string::npos);
+  }
+
+  manager.reset_all();
+  REQUIRE(manager.num_active_queries() == 0);
+}
+
+TEST_CASE("reset is a no-op for unknown and already-reset queries",
+          "[scan_manager][query_state]")
+{
+  fixture f;
+  sirius_scan_manager manager{make_local_config(), *f.memory, f.topology};
+
+  // Never prepared: sirius_context's failure backstop calls reset(query_id) unconditionally,
+  // so an unknown id has to be harmless.
+  REQUIRE_NOTHROW(manager.reset(sirius::make_query_id(99)));
+  REQUIRE(manager.num_active_queries() == 0);
+
+  auto a = make_query(sirius::make_query_id(1), "nation.parquet");
+  manager.prepare_for_query(*a.query, true);
+  REQUIRE(manager.num_active_queries() == 1);
+
+  manager.reset(a.query->query_id());
+  // Double reset: run_mandatory_cleanup and drop_query_runtime_state_best_effort can both
+  // fire for the same query on the failure path.
+  REQUIRE_NOTHROW(manager.reset(a.query->query_id()));
+  REQUIRE(manager.num_active_queries() == 0);
+}
+
+TEST_CASE("reset_all drops every query and stop() still returns", "[scan_manager][query_state]")
+{
+  fixture f;
+  sirius_scan_manager manager{make_local_config(), *f.memory, f.topology};
+
+  auto a = make_query(sirius::make_query_id(1), "nation.parquet");
+  auto b = make_query(sirius::make_query_id(2), "supplier.parquet");
+  manager.prepare_for_query(*a.query, true);
+  manager.prepare_for_query(*b.query, true);
+  REQUIRE(manager.num_active_queries() == 2);
+
+  manager.reset_all();
+  REQUIRE(manager.num_active_queries() == 0);
+
+  // stop() drains again then stops the pool; a sequencer left parked on a dequeue that will
+  // never be satisfied would hang here.
+  REQUIRE_NOTHROW(manager.stop());
+}
+
+TEST_CASE("a query with no GPU scan operators registers nothing", "[scan_manager][query_state]")
+{
+  fixture f;
+  sirius_scan_manager manager{make_local_config(), *f.memory, f.topology};
+
+  auto tctx               = sirius::test::make_test_telemetry_context();
+  auto const query_id     = sirius::make_query_id(7);
+  sirius::telemetry::query_telemetry_info tinfo{tctx->engine_id(), tctx->worker_id(), query_id};
+  sirius::planner::query empty{
+    duckdb::vector<duckdb::shared_ptr<sirius::pipeline::sirius_pipeline>>{},
+    tctx->context(),
+    query_id,
+    tinfo};
+
+  manager.prepare_for_query(empty, true);
+  // Nothing to tear down, so nothing is registered and the matching reset is a no-op.
+  REQUIRE(manager.num_active_queries() == 0);
+  REQUIRE_NOTHROW(manager.reset(query_id));
+}


### PR DESCRIPTION
This PR is built on top of the work of the stack of Concurrency PRs (it goes on top of https://github.com/sirius-db/sirius/pull/1364 , https://github.com/sirius-db/sirius/pull/1365, https://github.com/sirius-db/sirius/pull/1366 and  https://github.com/sirius-db/sirius/pull/1369). BUT, these previous PRs have a couple extra commits, so this would need to be rebased.
This work was one massive multi-step Claude session. https://github.com/sirius-db/sirius/pull/1369 actually was the beginning of that session and holds Steps 1 and 2. The rest of the session went basically unsupervised. I have not really been able to look through everything here. This will need more oversight and more work will still be needed after this. 
Each commit here should build independently and all tests should pass. 

# Concurrent query execution: per-query control plumbing (steps 3-12)

Continues the work of making Sirius internals safe for concurrent queries.
The single-flight mutex (`SiriusContext::query_lifecycle_mutex_`) is still in
place, so Sirius still executes one query at a time. What changes here is the
control plumbing behind it: teardown, drains, waits, validation and error paths
were process-wide stop-the-world operations invoked once per query, and they are
now scoped to the query that triggered them.

Range: `ff33f389..b38e6e3f` (9 commits), 20 files, +1071 / -225.

The steps referred to are from docs/concurrency/option-d-recommended.md

Validation: full C++ suite (2255 cases, ~32.5M assertions) run 3 consecutive
times per step, all green. Single-GPU host, so multi-GPU cases self-skip.

---

## Commit by commit

### 1. `ff33f389` docs(concurrency): record C1/C2 pull-forward into step 2

Docs only.

Step 1 deleted the `stop()` calls that used to pre-stop the `task_creator`. That
made `drain_after_error -> stop_thread_pool()` race a live manager thread and
exposed the C1 deadlock: `stop_thread_pool()` held `_global_state_mutex` across
`_manager_thread.join()`, while `manager_loop()` needs that same mutex in
`get_query_task_global_state()`. It hung the full suite in roughly 3 of 8 runs.

The plan's own dependency note said "C1 must be fixed before A5/A6 are
exercised, because both call `stop_thread_pool()` today", and scheduling C1 for
step 4 violated it. C1 and C2 were pulled forward into step 2 and are recorded
there. The generalizable lesson is also recorded: any step that stops
pre-stopping a subsystem makes that subsystem's lifecycle races live in the same
commit.

Files: `docs/concurrency/option-d-recommended.md`

### 2. `7bdf050e` concurrency step 3: per-query completion and error paths

`wait_for_completion` and `drain_after_error` took a `query_id` but their bodies
were process-wide.

- Producer halt: both called `_task_creator->stop_thread_pool()`, tearing down
  the SHARED creation pool and interrupting the shared creation queue on every
  completion and every error. Replaced with the lifecycle gate's
  `quiesce(query_id)`.
- Queue validation: `wait_for_completion` checked the WHOLE queue size, so query
  A completing normally threw "pipeline task queue not empty at query
  completion" because query B had work legitimately queued. Now
  `size(query_index{A})`, with a matching
  `itask_executor::wait_and_validate_empty(query_id)`.
- Queue draining: `drain_after_error` called the unindexed `_task_queue.drain()`
  twice plus `gpu_exec->drain_and_wait()`, destroying every co-tenant query's
  queued tasks and leaving those queries waiting on completions that could never
  arrive. Now `drain(query_index{})` and a new
  `wait_and_drain_query(query_id)`.
- Guards `*_ready_devices.begin()`, which dereferenced an empty vector when the
  management loop woke on a `task_available` event with no ready device.

Known gap carried forward at this point: the in-flight wait still brackets in
`quiesce_manager()`/`resume_manager()`. That bracket is not optional -
`manager_loop()` reserves a pool slot and then blocks in `pop()`, so an idle
manager holds an active slot forever and `wait_all()` (which waits for
`active_ == 0`) never returns. Removing it deadlocked the suite at test 5 in 4
of 4 runs. Because interrupting makes `push()` return false for the duration, a
co-tenant task in transit could still be dropped.

Closes register A5, D4; A6 partially.

Files: `src/include/parallel/task_executor.hpp`, `src/parallel/task_executor.cpp`,
`src/pipeline/task_scheduler.cpp`, `test/cpp/pipeline/test_task_scheduler.cpp`,
`docs/concurrency/option-d-recommended.md`

### 3. `8a09bebc` fix(util): bound the crash handler so a segfault dies instead of spinning

Not in the original plan. Added because it actively obstructed debugging the
rest of this work.

`segfault_handler()` armed a deadline only around the log flush, leaving the
dangerous work unbounded. Only `backtrace()` and `backtrace_symbols_fd()` are
async-signal-safe; `backtrace_symbols()` goes through `_dl_addr()`, which takes
the dynamic loader lock, and `__cxa_demangle()` plus the log flush allocate. If
the crash happens while any thread holds the loader lock, the malloc arena lock
or the logging mutex, none of those calls fail - they spin forever. The process
then looks alive rather than dead: 100% CPU, no output, unresponsive to SIGTERM.

This disguised an ordinary `task_creator` deadlock as a live spinning process
and cost about an hour of misdiagnosis, because every symptom (running thread,
`wchan=0`, other threads idle) pointed at a live process.

Two changes:
- `arm_handler_deadline()` now fires on handler entry and covers everything, so
  a blocked symbolization or flush terminates the process within 10s.
  `flush_logs_best_effort()` no longer manages or cancels the alarm.
- The async-signal-safe backtrace is emitted FIRST via `backtrace_symbols_fd()`,
  so a usable stack reaches stderr even if the demangled pass blocks.

Verified by reproducing the original failure mode (SIGABRT delivered mid-run
with the handler enabled). Before: spun until force-killed, no output. After:
raw frames plus the demangled backtrace, process exits about 1s after the
signal.

Files: `src/util/segfault_backtrace_handler.cpp`

### 4. `5d93da7f` concurrency step 4: close the in-flight tracking holes and unstarve lookahead

- D1: `get_operator_for_next_task()` dereferences the operator recursively, via
  `get_next_task_hint()`, on the manager thread; `enter_in_flight()` ran after
  it. So `drain_pending_tasks(query_id)` could observe `in_flight == 0` and
  return while the manager was still walking that query's operator graph - and
  the caller's next act is to let the plan be destroyed. The counted region now
  opens before that dereference.
- D2: the creation queue's key extractor read `request.node->type` at push time,
  inside the queue mutex, on a queue every query shares. A `schedule()` racing
  its query's teardown would read a freed operator while holding that mutex. The
  operator type is now captured at `schedule()` time into the request, like
  `priority` and `query_id` already were.
- D3: lookahead returned on the first non-open entry instead of skipping it.
  Since the map is ordered oldest-first and the oldest entry is routinely a
  finished-but-not-yet-reset query, that suppressed lookahead for every younger
  query for the whole cleanup window. It now skips to the oldest query that is
  actually accepting work, preserving FIFO.
- A2 (self-deadlock half): `stop()` from one of its own pool workers is now an
  assert, backed by a thread_local marker. `do_stop_thread_pool()` calls
  `wait_all()`, which blocks until `active_ == 0`, but the calling worker IS an
  active slot.

Closes register D1, D2, D3, and the self-deadlock half of A2.

Files: `src/creator/task_creator.cpp`, `src/include/creator/task_creator.hpp`

### 5. `6d22cb6b` concurrency step 5: query-aware thread pool with per-query waits

`bounded_thread_pool` now tracks work per query, so teardown can wait for one
query without stopping the executor - closing the gap step 3 had to carry.

Slots gain an optional query attribution via `slot::attach(query_id)`, applied
once the task's query is known rather than at `reserve()` time. That distinction
is load-bearing: every manager loop reserves a slot and THEN blocks in `pop()`,
so an idle manager holds a slot indefinitely. Counting it against a query would
make that query's wait block until the manager happened to receive work, and
counting it globally is why `wait_all()` cannot be used at all. Untagged slots
are therefore invisible to the per-query waits, and a test pins exactly that.

Two operations, because the two callers need different things:

- `wait_for_query(q)` - waits until q has nothing queued or running, running
  everything it finds. The SUCCESS path. Since `attach()` precedes `dispatch()`,
  the per-query count already covers queued-but-unstarted work, so reaching zero
  means every task actually ran.
- `drain_and_wait(q)` - discards q's queued work, then waits for what is already
  running. The ERROR path, where the query is failing and its plan is about to
  be destroyed.

Wiring `wait_and_validate_empty()` to `drain_and_wait()` was a bug caught by
these tests: on the success path it would have silently discarded work the query
legitimately scheduled and then reported success.

`wait_and_validate_empty(query_id)` now uses `wait_for_query` with no quiesce
bracket, so a successful completion no longer interrupts the shared queue.
`wait_and_drain_query` (error path) keeps the bracket deliberately: a failing
query can still have tasks the manager may pop at any moment, and between
`pop()` and `attach()` a task belongs to neither the queue nor the count.

`task_creator`'s bespoke in-flight counter is deleted in favour of the pool's.
`work_queue_` becomes `std::list` so `drain_and_wait` can remove one query's
items from the middle; dropped items are spliced out under the lock and
destroyed after releasing it, because destroying a work item runs `~slot`, which
re-enters `release_slot()` and would deadlock on a held mutex.

Closes the A6 remainder on the success path.

Files: `src/include/exec/bounded_thread_pool.hpp`, `src/creator/task_creator.cpp`,
`src/include/creator/task_creator.hpp`, `src/parallel/task_executor.cpp`,
`src/pipeline/gpu_pipeline_executor.cpp`,
`test/cpp/exec/test_bounded_thread_pool.cpp`,
`docs/concurrency/option-d-recommended.md`

### 6. `e5078162` docs(concurrency): record steps 6+7 as attempted and backed out

Docs only. No code from steps 6 or 7 is in this branch.

Steps 6 and 7 (shared-ownership `data_repository` with `close()`, and deleting
the global downgrade drain) were implemented in full and then reverted, on a
deterministic SIGSEGV at the 6th test ("pin_table compression - result equality
vs uncompressed pin") in
`sirius_physical_ungrouped_aggregate_merge::get_next_task_input_data()`, on a
`task_creator` pool worker. Faulting instruction `mov 0x8(%rcx),%rdi`; the
source line is `ports.begin()->second->repo->pop_next_data_batch()`.

Ruled out: not pre-existing (verified by stashing both halves and rebuilding at
step 5); not an unhooked virtual override (nothing derives from
`data_repository`); not an out-of-range partition (`pop_next_data_batch`
range-checks and throws).

The work is preserved in named stashes rather than discarded:
- `cucascade/` stash: `step6-cucascade-shared-ptr-repositories`
- sirius stash: `step6b-7-sirius-side`

Consequence: the global `executor->drain()` is still in
`run_mandatory_cleanup`.

Files: `docs/concurrency/option-d-recommended.md`

### 7. `48c114bc` concurrency steps 8+11: shutdown ordering, failed-cleanup leak, loud drops

- B6 shutdown ordering: `terminate()` destroyed `task_scheduler_` second, while
  the downgrade executors and the creation pool were still live. Each downgrade
  executor holds `_pipeline_task_queue`, a raw pointer into
  `task_scheduler::_task_queue`, and dereferences it in `processing_loop`;
  creation lambdas hold `_task_scheduler`. A monitor request or an in-flight
  creation landing in that window dereferenced a freed queue at DB teardown.
  Every producer and borrower is now stopped first.
- B7 declaration order: documented as the backstop for the one path where
  `terminate()` never runs - `initialize()` throwing after `task_scheduler_` is
  constructed leaves `is_initialized_` false, so `~SiriusContext` skips
  `terminate()` and only the member order decides who dies first.
- B10 destructor: `~SiriusContext` is noexcept but called a `terminate()` that
  opens with `throw_if_not_initialized()` and goes on to `reset_all()`,
  `registry.clear()` and `memory_manager_->shutdown()`. Any throw was
  `std::terminate`, during `~DBConfig`-triggered destruction. Now caught and
  logged.
- B8 failed-cleanup leak: `drop_query_runtime_state_best_effort` never erased the
  repository registry. It runs precisely when `run_mandatory_cleanup` threw
  part-way, and once the runtime is latched unavailable no later window runs the
  erase either - so the failed query's manager and every batch in it survived
  until `terminate()`: GPU/host memory never returned, and the downgrade
  executors kept sweeping it every monitor cycle for the life of the process.
- A9 loud drops: `multi_index_priority_queue::push` returns false for exactly one
  reason - the queue is interrupted - and `task_creator::schedule`,
  `schedule_lookahead` and `task_scheduler::schedule` all discarded it. A refused
  push destroys the request, so a live query silently loses a task it is waiting
  on; that silence is what turned every dropped-work bug in this subsystem into
  an unexplained hang. The lifecycle gate makes the check precise: a drop for a
  query the gate still reports as accepting work is an ERROR, while a drop for a
  quiescing query is the documented teardown contract and stays at DEBUG.

Closes register A9, B6, B7, B8, B10.

Files: `src/sirius_context.cpp`, `src/include/sirius_context.hpp`,
`src/creator/task_creator.cpp`, `src/include/creator/task_creator.hpp`,
`src/pipeline/task_scheduler.cpp`

### 8. `a9a85ed4` concurrency steps 9+12 (partial): prefetch-cache UAF, real max_concurrent_queries

- B11 prefetch cache: two sites dereferenced a `_file_cache` iterator after
  releasing the lock. `get_or_create_file_entry` scoped its `unique_lock` to the
  `if` block, so `return *it->second` ran with NO lock held; the other site
  called `lk.unlock()` explicitly and then used `it`. Either way a concurrent
  insert of a DIFFERENT file rehashes the map and invalidates the iterator. Both
  now carry the `file_entry*` out under the lock: the entry is heap-allocated and
  stable across a rehash, only iterators and references into the map are not.
  `fetch_chunks` is still called unlocked, deliberately, which is exactly why the
  pointer rather than the iterator is what crosses. Reachable only with
  concurrency: a single query first-touches every file in one prepare.
- C3 scan-manager bound: `k_max_concurrent_queries` was a compile-time constant
  of 1 carrying a TODO. It is now
  `scan_manager_config::max_concurrent_queries`, parsed from YAML as
  `scan_manager.max_concurrent_queries`, still defaulting to 1 so existing
  single-query deployments are byte-identical. It sizes the scan thread pool as
  `num_threads + max_concurrent_queries`, which is the constraint that matters:
  each query parks one BLOCKING coalescer sequencer on that pool, unblocked only
  by that query's own split tasks running on the same pool, so raising
  concurrency without resizing the pool deadlocks by starvation.

Step 9's per-query batch telemetry (A8) and step 12's concurrency harness are
NOT included.

Closes register B11, C3.

Files: `src/io/cache/prefetching_cache.cpp`,
`src/include/scan_manager/config.hpp`,
`src/include/scan_manager/sirius_scan_manager.hpp`,
`src/scan_manager/sirius_scan_manager.cpp`, `src/sirius_config.cpp`

### 9. `b38e6e3f` docs(concurrency): execution summary and recommended next steps

Docs only. Adds `docs/concurrency/99-execution-summary.md`: what was built, what
was backed out and why, known gaps in what was delivered, and ordered next
steps. Also records three things found that were not in the plan (the crash
handler, the violated dependency note, and a 9.4 GB core dump accidentally
committed during debugging and scrubbed before push).

Files: `docs/concurrency/99-execution-summary.md`, `docs/concurrency/README.md`

---

## What is still left to do

23 of the 44 issues in `docs/concurrency/00-issue-register.md` are closed across
the whole branch. Sirius still runs one query at a time; the single-flight mutex
has not been touched. The items below are in the order they should be tackled.

### 1. Build the concurrency test harness (register G1-G3) - do this first

Everything on this branch was validated at N=1. The per-query code has still
never run under real concurrency, so "2255 tests green" is narrower assurance
than it looks. Every test added here is single-threaded or exercises one
subsystem with synthetic query ids; nothing runs two QUERIES end to end.

Salvage the primitives currently trapped in
`test/cpp/integration/test_query_lifecycle_slot.cpp`'s anonymous namespace
(start gate, `async_query_result`, `scoped_blocking_window_log_sink`) into
`test/cpp/utils/`, and let a test opt out of `shared_env_listener`'s
env-pausing. `concurrentloop` already works in the vendored DuckDB and
`ParallelExecuteLoop` constructs a new `Connection` per parallel iteration on
its own thread against the shared `DatabaseInstance`, which is exactly the shape
needed.

### 2. Finish steps 6+7 (register B1, B2, B3, B4, B9, A7, D6, F8)

Do NOT resume by re-reading the diff. Add a temporary print of `ports.size()`
and `repo == nullptr` immediately before the deref in
`get_next_task_input_data`. That single data point separates the three remaining
hypotheses; none of the black-box debugging did. Then unstash
`step6-cucascade-shared-ptr-repositories` and `step6b-7-sirius-side`.

Remaining hypotheses, in suspicion order:
1. `get_repository()` returning `shared_ptr` BY VALUE while
   `materialize_repository_wiring` takes `.get()` on the temporary - the one
   lifetime change on the exact pointer that crashes.
2. The manager's `add_data_batch` moving per-repository calls outside `_mutex`.
3. `close()` leaving `_data_batches` size 0 rather than one empty partition,
   changing `num_partitions()` for anything reading it after close.

This matters more than its position suggests: FIFO fairness depends on spilling
working, because the livelock case is an older query blocked on memory that only
a newer query could release by finishing. Steps 6/7 are what make the downgrade
path per-query. Until then the global `executor->drain()` remains in
`run_mandatory_cleanup` and is the worst cross-query serialization point.

### 3. Close the error-path window (A6 remainder)

`wait_and_drain_query` still brackets in `quiesce_manager()`/`resume_manager()`,
which interrupts the shared queue and can drop a co-tenant's in-transit task.
The bracket cannot simply be deleted - see step 3 above. Fix: have the manager
publish its in-hand task's query BEFORE the task leaves the queue's lock, e.g. a
per-query "in-hand" counter incremented under the pop, so the `pop()`-to-
`attach()` window is covered. Then the error path can drop the bracket like the
success path did.

### 4. Per-query batch telemetry (A8)

`batch_telemetry_registry::on_query_end()` takes no query id: it consumes every
live placement across all 16 shards and clears `impl_->ports`, so one query's end
silently truncates every co-tenant's telemetry. Add `query_id` to placements and
ports, re-key `ports` on the existing `port::source_port_uuid` instead of a raw
`data_repository*` (a key is not an owner - address recycling silently matches
stale entries), and add an `on_query_end(query_id)` overload.

### 5. Head-of-line blocking (C4)

One manager thread per GPU performs a blocking `make_reservation` AND a blocking
downgrade `.get()` while holding a reserved slot, so one query's memory-hungry
task blocks every other query's dispatch to that GPU. At the 3-7 concurrency
target this is the throughput ceiling. Move reservation acquisition into the
dispatched job, or use `make_reservation_or_null` plus requeue-with-backoff.

### 6. Shared mutable configuration (E1-E7) - required before removing the mutex

`operator_params` is one non-atomic struct per `DatabaseInstance`, written by
about 20 `SET` callbacks and read mid-plan and mid-execution. The single-flight
slot is the ONLY thing serializing those writes today. The `duckdb::Config`
static variables have no guard at all, and `EXPRESSION_EVALUATOR_STRATEGY` is
read as a default argument on every `expression_evaluator` construction, so one
connection's `SET` can change strategy between two operators of another
connection's plan. Move both into per-`ClientContext` settings and snapshot into
the plan at window begin. Also here: `PhysicalSiriusExecution::logical_plan_` is
`mutable` and `reset()` from a `const` source method (E4), and
`plan_register::global()` is a check-then-act keyed on a bare table name (E5).

### 7. Remaining fairness and performance items (F2, F3, F5, F6, F7, F9)

Narrow the plan-time `SlotGuard`; live prefetch-epoch set instead of a single
global ticker; replace the `use_count() > 1` pin guard with a per-entry reader
count; reservation-driven sizing in sort and result-collector; remove
`cudaDeviceSynchronize` and default-stream work from the hash-join dynamic-filter
publish; give the cucascade reservation and stream waits a per-query dimension.

### 8. Then raise the cap and remove the single-flight mutex

`scan_manager.max_concurrent_queries` and the pool sizing are in place. Raise it,
run the harness from item 1 under ASan and TSan, and expect to find more - 23
issues closed is not 44.

### Known loose ends not covered above

- One unexplained intermittent failure: "query lifecycle slot is released for an
  unconsumed result" -> "watchdog child exited abnormally", seen once in about 16
  runs and not reproduced in follow-ups. It is a forked-child test, and the
  `DISABLE_SIRIUS_SIGNAL_HANDLER=1` debugging harness changes how a crashing
  child dies, so it may be an artifact of that.
- Pre-existing and unrelated: running only `[integration]` reproducibly fails
  `test/cpp/integration/test_pin_table_mvcc_foundation.cpp:201`
  (`probe.counts.size() >= 2` yields 1), while the same test passes in
  full-suite runs. Order-dependent test isolation.
- Hygiene (register H): dead members `task_creator::_client_context`,
  `sirius_engine::wait_for_query_finish` and friends, `task_completion.hpp`,
  orphaned `exec::inspectable_mpsc`, the dead `schedule(node, query_id)`
  overload, `task_creation_request::device_id`; the 32-bit query id wrap and
  31-bit priority mask (H8); and five drifted docs under `docs/super-sirius/`
  that still describe deleted APIs.

## Testing notes for reviewers

- Full suite: `pixi run build/release/extension/sirius/test/cpp/sirius_unittest`.
  A healthy run is about 345s on a single-GPU host. Anything much longer is a
  hang, not slowness.
- Do not pipe the run to `tail` while diagnosing - `tail` emits nothing until its
  input closes, which makes a live run look identical to a dead one.
- `DISABLE_SIRIUS_SIGNAL_HANDLER=1` gives real core dumps fast (see
  `docs/super-sirius/debugging.md`).
- Put `timeout` INSIDE `pixi run`, not outside: `timeout -s ABRT 600 pixi run ...`
  signals pixi's wrapper and yields a useless Rust backtrace. Use
  `pixi run bash -c 'exec timeout -s ABRT 600 <binary>'`.
- Validate with at least 3 consecutive full-suite runs. Two of the bugs fixed in
  this branch appeared in roughly 1 run in 3.


