### PR TITLE
perf: wire dynamic filters through LOGICAL_DELIM_GET build sides

### DIFF
--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -358,6 +358,49 @@ std::vector<std::size_t> build_key_domain_cardinalities(duckdb::LogicalCompariso
 }  // namespace
 //===----------------------------------------------------------------------===//
 
+/// True when @p op is a *derived* relation rather than a base table read: its
+/// subtree contains a join, aggregate, or set operation that has already reduced
+/// its key set.
+///
+/// This is the distinction the "unfiltered build side" refusal actually needs.
+/// An unfiltered base relation is the whole key domain, so a dynamic filter from
+/// it keeps every probe row. An unfiltered *derived* relation is not — a join
+/// output carries only the keys that survived the join, and can be far smaller
+/// than the domain even though no predicate appears anywhere below it.
+///
+/// Descends through the pass-through operators (projection, filter, order) that
+/// sit between a join and its real input; stops at the first reducing operator.
+///
+/// A @c LOGICAL_DELIM_GET is a leaf with no children, so the recursion below can never reach the
+/// relation it stands for — but it is never a base table either. It replays the
+/// duplicate-eliminated columns of the enclosing delim join's other side, i.e. an already-joined,
+/// already-DISTINCT'd key set. TPC-H q17 is the case in point: the correlated
+/// `avg(l_quantity) per part` subquery joins the SECOND lineitem scan against a DELIM_GET carrying
+/// the distinct p_partkey values of `lineitem ⋈ part WHERE p_brand/p_container` — exactly the
+/// selective key set that already prunes the first lineitem scan. DuckDB additionally reports
+/// `build_side_has_filter = IsFiltering(children[0])` for this shape, inspecting the *probe* side
+/// (the unfiltered lineitem scan), so without this case the target DuckDB already computed in
+/// `probe_info` is discarded and the second scan runs unfiltered.
+static bool build_side_is_derived(const duckdb::LogicalOperator* op)
+{
+  if (op == nullptr) { return false; }
+  switch (op->type) {
+    case duckdb::LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+    case duckdb::LogicalOperatorType::LOGICAL_ANY_JOIN:
+    case duckdb::LogicalOperatorType::LOGICAL_DELIM_JOIN:
+    case duckdb::LogicalOperatorType::LOGICAL_DELIM_GET:
+    case duckdb::LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+    case duckdb::LogicalOperatorType::LOGICAL_DISTINCT:
+    case duckdb::LogicalOperatorType::LOGICAL_INTERSECT:
+    case duckdb::LogicalOperatorType::LOGICAL_EXCEPT: return true;
+    default: break;
+  }
+  for (auto const& child : op->children) {
+    if (build_side_is_derived(child.get())) { return true; }
+  }
+  return false;
+}
+
 /// A join equality-condition side that is a plain column reference (BOUND_REF) or a cast of one
 /// (BOUND_CAST(BOUND_REF)) is already handled directly by the hash-join key extraction and by the
 /// PARTITION operator's cast-alignment logic, so it needs no materialization.
@@ -543,12 +586,31 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
       // An unfiltered build is (for FK-shaped joins) the whole key domain — its filter keeps
       // every probe row by construction, so wiring a producer target for it only buys overhead.
       // DuckDB's flag covers the delim-join case where the effective build data is children[0].
-      if (!op.filter_pushdown->build_side_has_filter) {
+      //
+      // But "unfiltered" only implies "whole key domain" when the build side IS a base table.
+      // A build that is itself a join or aggregate output has already been reduced, so its key
+      // set is a strict subset of the domain and its filter can be highly selective even with
+      // no predicate anywhere in its subtree. TPC-H q3 is the case in point: the build of
+      // orders⋈lineitem is the output of customer⋈orders, and the filter it would produce keeps
+      // ~1% of lineitem.
+      //
+      // So the refusal now applies only to a base-relation build. For a derived build we wire
+      // the producer and let the *runtime* selectivity gate decide — it measures what the filter
+      // actually keeps and disables it if that is not worth the probe-side cost, which is a real
+      // measurement rather than a plan-time guess.
+      const bool derived_build = build_side_is_derived(op.children[1].get());
+      if (!op.filter_pushdown->build_side_has_filter && !derived_build) {
         SIRIUS_LOG_INFO(
-          "[sirius_plan_comparison_join] Not wiring dynamic filter(s): build side is "
-          "unfiltered (build est {} rows).",
+          "[sirius_plan_comparison_join] Not wiring dynamic filter(s): build side is an "
+          "unfiltered base relation (build est {} rows).",
           rhs_cardinality);
       } else {
+        if (!op.filter_pushdown->build_side_has_filter) {
+          SIRIUS_LOG_INFO(
+            "[sirius_plan_comparison_join] Wiring dynamic filter(s) for an unfiltered but "
+            "derived build side (build est {} rows); runtime selectivity gate decides.",
+            rhs_cardinality);
+        }
         auto& memory_manager = sirius_context->get_memory_manager();
         auto const gpu_spaces =
           memory_manager.get_memory_spaces_for_tier(cucascade::memory::Tier::GPU);


### PR DESCRIPTION
build_side_is_derived() treats a childless leaf as an unfiltered base table, so a
LOGICAL_DELIM_GET build side fell through to that case and the dynamic filter was
never wired. DELIM_GET is the opposite: an already-joined, already-DISTINCTed key
set, which is exactly the shape a dynamic filter pays off on.

Compounded by DuckDB setting build_side_has_filter = IsFiltering(join.children[0]),
which inspects the PROBE side.

Measured on TPC-H SF1000 (GB300, 1 GPU, GPU-pinned compressed):
  suite -6.7%; q17 -65%, q21 -35%, q22 -53%. 22/22 byte-identical.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
