### PR TITLE
fix: guard empty _ready_devices in the lookahead hint

### DIFF
--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <limits>
 #include <mutex>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -347,8 +348,14 @@ void task_scheduler::management_eventloop()
       }
     }
 
-    if (_task_queue.empty()) {
-      if (_task_creator) { _task_creator->schedule_lookahead(*_ready_devices.begin()); }
+    // `_ready_devices` is legitimately empty here: it only records device_ready requests whose
+    // `is_scan` is false, so a loop iteration that saw none leaves it so. The hint is optional
+    // (schedule_lookahead defaults it to nullopt), so pass nothing rather than dereferencing
+    // begin() on an empty vector.
+    if (_task_queue.empty() && _task_creator) {
+      _task_creator->schedule_lookahead(_ready_devices.empty()
+                                          ? std::nullopt
+                                          : std::optional<int>{_ready_devices.front()});
     }
 
     // Matcher: for each ready device, try to find a dispatchable task.


### PR DESCRIPTION
management_eventloop dereferenced *_ready_devices.begin() unconditionally. The
vector is legitimately empty whenever a loop iteration saw no non-scan device_ready
request, so this is UB on a live path. schedule_lookahead already takes
std::optional<int> defaulted to nullopt, so pass nothing instead.

The dereference happens at the call site, before schedule_lookahead can early-return,
so it is reachable regardless of the task_creator strategy setting.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
