### PR TITLE
perf: replace the Bloom filter's modulo block index with Lemire fast-range

### DIFF
--- a/docs/super-sirius/dynamic-filters.md
+++ b/docs/super-sirius/dynamic-filters.md
@@ -344,7 +344,7 @@ The zone-map captures only the build keys' `[min,max]` range, which is useless f
 
 - **`sirius_dynamic_small_in_list_filter`** — exact membership for 1–12 null-free INT32/INT64 build rows, counting duplicates. Each successfully materialized device-local replica owns a raw snapshot of the build values (the *needles*), and one CUB bulk kernel compares every probe value with every needle. It has no hash build, slot array, or reserved empty-key sentinel.
 - **`sirius_dynamic_in_list_filter`** — hash-based membership via a persistent `cuco::static_set`, with a device kernel probing its read-only set reference. It is exact for representable set keys and conservatively passes cuCO's reserved empty-key value, so it remains a safe join-filter superset.
-- **`sirius_dynamic_bloom_filter`** — a `cuco::bloom_filter` (PIMPL'd in a `.cu`; INT32/INT64 keys), a few bits/key, for large builds where the hash IN-list is too big. False positives only let extra rows through — harmless, because the join is authoritative; no false negatives means a true match is never dropped.
+- **`sirius_dynamic_bloom_filter`** — a `cuco::bloom_filter` (PIMPL'd in a `.cu`; INT32/INT64 keys) at 16 bits/key under Sirius's own fingerprint policy (see [Fingerprint policy](#fingerprint-policy--why-neither-cuco-stock-policy-is-used)), for large builds where the hash IN-list is too big. False positives only let extra rows through — harmless, because the join is authoritative; no false negatives means a true match is never dropped.
 
 **Producer policy** (`dynamic_filter_publisher::publish`). The master switch `enable_dynamic_filter_pushdown` emits at most one **membership filter** per key, in this order:
 
@@ -400,6 +400,47 @@ Bloom filters are runtime-only — there is no AST node that evaluates "is this 
 A channel may carry both a zone map for the reader and a Bloom for the post-decode operator. Each becomes visible only after its device replicas are ready. A direct target normally sees both; a transitive target can safely observe either one or both at its per-split checkpoints because the filters are optional conjuncts and the join remains authoritative.
 
 **Build heuristic: raw exact list, then L2-sized hash set, then Bloom (implemented).** The producer first handles 1–12 null-free INT32/INT64 build rows with a linear scan over raw needles. For larger supported columns, it queries the active GPUs' L2 sizes (`cudaDeviceGetAttribute(cudaDevAttrL2CacheSize)`) and selects the hash IN-list only if its set fits the smallest L2; otherwise it uses the smaller Bloom, even if that bitset also spills L2. This L2 decision subsumed the original fixed row-count hash/Bloom cutover.
+
+#### Fingerprint policy — why neither cuco stock policy is used
+
+The filter is a `cuco::bloom_filter` at a fixed 16 bits/key over 256-bit (32-byte, i.e. one memory
+sector) blocks. cuCollections ships two policies and Sirius uses neither:
+
+- `cuco::arrow_filter_policy` maps the hash to a block with a cheap multiply-shift but hard-caps
+  the filter at Arrow's 128 MiB (2²² blocks ⇒ 67.1M keys at 16 bits/key). Every Bloom the publisher
+  emits at SF1000 is larger than that, so it was never selected.
+- `cuco::default_filter_policy` has no cap but computes `hash % num_blocks`. GPUs have no integer
+  divide, so a 64-bit modulo by a runtime value is a long emulated instruction sequence. It — not
+  the random gather — dominates the probe kernel.
+
+`sirius_bloom_policy` (in `src/cuda/sirius_dynamic_bloom_filter.cu`) keeps the uncapped sizing and
+`default_filter_policy`'s exact hash and fingerprint layout, and replaces only the block index with
+Lemire fast-range, `(hash * num_blocks) >> 64`, one `mul.hi.u64`. One policy now covers every size,
+so the replica variant carries two alternatives (one per key width) instead of four.
+
+Measured on GB300 (152 SM, 115.5 MiB L2, 7.16 TB/s) at TPC-H SF1000 q21's real probe shape —
+389M clustered `l_orderkey` probes per split, `contains_async` only:
+
+| build keys | filter | `hash % n` | fast-range | |
+|---|---|---|---|---|
+| 73.2M (q21 `l1` key set) | 139.7 MB | 5.06 ms | 2.34 ms | 2.16× |
+| 730.8M (q21 `orders` F key set) | 1393.9 MB | 5.21 ms | 2.73 ms | 1.91× |
+
+Filter *size* is not the lever, which is directly falsifiable and was falsified: a 69.8 MB filter
+small enough to live entirely in L2 still took 4.93 ms with the modulo against 2.18 ms with
+fast-range. Cutting bits/key is likewise not worth it — 8 bits/key bought 1.07× on the probe while
+raising the false-positive rate from 0.11% to 2.86%, which on a 6-billion-row scan means ~170M
+extra rows handed to the downstream join. Note the asymmetry that hid this: `cuco::static_set`,
+backing the hash IN-list, already avoids the divide via `cuco::utility::fast_int` magic-number
+reciprocals, so the IN-list never showed the symptom.
+
+Fast-range preserves the no-false-negative contract: it is a deterministic uniform map of a 64-bit
+hash onto `[0, num_blocks)` applied identically on `add` and `contains`, so an inserted key always
+tests positive. Only the false-positive *set* can move, which is harmless because the join stays
+authoritative — and it moved in the right direction, because fast-range consumes the high hash bits
+while the fingerprint consumes the low 40, whereas the modulo drew both from the low bits. At the
+73.2M-key shape the measured keep ratio fell from 5.002% to 4.878% against a 4.77% true-match rate,
+roughly halving the false-positive rate at identical footprint.
 
 ### 1.4 IN-list representations (raw needles + hash set)
 

--- a/src/cuda/sirius_dynamic_bloom_filter.cu
+++ b/src/cuda/sirius_dynamic_bloom_filter.cu
@@ -24,7 +24,9 @@
 #include <cuco/bloom_filter_policies.cuh>
 #include <cuco/hash_functions.cuh>
 #include <cuda/sirius_rmm_cuco_allocator.cuh>
+#include <cuda/std/bit>
 #include <cuda/std/cstddef>
+#include <cuda/std/limits>
 #include <cuda/stream_ref>
 
 #include <cucascade/memory/memory_space.hpp>
@@ -60,29 +62,104 @@ std::size_t blocks_for(std::size_t num_keys)
 
 using bloom_alloc = sirius::rmm_cuco_allocator<cuda::std::byte>;
 
+/**
+ * @brief Fingerprint policy for Sirius's dynamic Bloom filters.
+ *
+ * Byte-for-byte identical to @c cuco::default_filter_policy<xxhash_64<KeyT>,uint32_t,8> in hash
+ * function, block geometry (8 x 32-bit words = one 256-bit block = one 32-byte memory sector) and
+ * fingerprint layout (its default @c pattern_bits==words_per_block, i.e. exactly one bit per word).
+ * The @b only difference is @ref block_index.
+ *
+ * cuCollections offers two stock policies and neither is right here:
+ *   - @c arrow_filter_policy maps the hash with a cheap multiply-shift, but hard-caps the filter at
+ *     Arrow's 128 MiB (2^22 blocks). Every Bloom the publisher actually emits at SF1000 is larger
+ *     than that (q21's are 2^22.13, 2^22.19 and 2^25.4 blocks), so it is never selected.
+ *   - @c default_filter_policy has no cap but computes @c hash % num_blocks. NVIDIA GPUs have no
+ *     integer-divide instruction and a 64-bit modulo by a runtime value is a long emulated
+ *     sequence, which makes it -- not the random gather -- the probe kernel's bottleneck.
+ *
+ * This policy keeps the uncapped sizing and replaces the modulo with Lemire fast-range: one
+ * @c mul.hi.u64. Measured on GB300 (152 SM, 115.5 MiB L2) at TPC-H SF1000 q21's real probe shape
+ * (389M clustered @c l_orderkey probes, @c contains_async):
+ * | build keys | filter    | @c hash%n | fast-range |       |
+ * |------------|-----------|-----------|------------|-------|
+ * | 73.2M      |  139.7 MB |   5.06 ms |    2.34 ms | 2.16x |
+ * | 730.8M     | 1393.9 MB |   5.21 ms |    2.73 ms | 1.91x |
+ *
+ * That the modulo dominates rather than the gather is directly falsifiable and was falsified: a
+ * 69.8 MB filter, small enough to sit entirely in L2, still ran at 4.93 ms with the modulo versus
+ * 2.18 ms with fast-range. Filter size is not the lever; the block-index arithmetic is.
+ *
+ * @note Correctness. Fast-range is a deterministic, uniform map of a 64-bit hash onto
+ *       @c [0,num_blocks) -- @c (hash*num_blocks)>>64 is @c <num_blocks for any @c hash<2^64 -- and
+ *       is applied identically on @c add and @c contains, so the no-false-negative contract is
+ *       preserved: a key that was inserted always tests positive. Only the false-positive @a set
+ *       can differ, which is harmless because the join remains authoritative. Measured, it is a
+ *       slight improvement: fast-range consumes the @a high hash bits while the fingerprint
+ *       consumes the low 40, whereas the modulo draws both from the low bits; at the 73.2M-key
+ *       shape the observed keep ratio fell from 5.002% to 4.878% against a 4.77% true-match rate,
+ *       i.e. the false-positive rate roughly halved at identical footprint.
+ */
 template <class KeyT>
-using arrow_policy = cuco::arrow_filter_policy<KeyT>;
-template <class KeyT>
-using default_policy = cuco::default_filter_policy<cuco::xxhash_64<KeyT>, std::uint32_t, 8>;
+class sirius_bloom_policy {
+ public:
+  using hasher             = cuco::xxhash_64<KeyT>;
+  using word_type          = std::uint32_t;
+  using hash_argument_type = typename hasher::argument_type;
+  using hash_result_type   = decltype(std::declval<hasher>()(std::declval<hash_argument_type>()));
 
-template <class KeyT, class Policy>
-using bloom_filter_for = cuco::
-  bloom_filter<KeyT, cuco::extent<std::size_t>, cuda::thread_scope_device, Policy, bloom_alloc>;
+  static constexpr std::uint32_t words_per_block = 8;
+
+ private:
+  static constexpr std::uint32_t word_bits = cuda::std::numeric_limits<word_type>::digits;
+  /// Bits of hash consumed per fingerprint bit (5 for a 32-bit word).
+  static constexpr std::uint32_t bit_index_width = cuda::std::bit_width(word_bits - 1);
+  static constexpr word_type bit_index_mask      = (word_type{1} << bit_index_width) - 1;
+
+  static_assert(words_per_block * bit_index_width <=
+                  cuda::std::numeric_limits<hash_result_type>::digits,
+                "hash is too narrow to supply one fingerprint bit per word");
+
+ public:
+  __device__ constexpr hash_result_type hash(hash_argument_type const& key) const
+  {
+    return hash_(key);
+  }
+
+  /// Lemire fast-range in place of `hash % num_blocks`: one 64x64->high multiply.
+  template <class Extent>
+  [[nodiscard]] __device__ constexpr Extent block_index(hash_result_type hash,
+                                                        Extent num_blocks) const
+  {
+    auto const wide = static_cast<__uint128_t>(static_cast<std::uint64_t>(hash)) *
+                      static_cast<__uint128_t>(static_cast<std::uint64_t>(num_blocks));
+    return static_cast<Extent>(static_cast<std::uint64_t>(wide >> 64));
+  }
+
+  /// One fingerprint bit per word, drawn from a disjoint `bit_index_width`-wide hash field.
+  [[nodiscard]] __device__ constexpr word_type word_pattern(hash_result_type hash,
+                                                            std::uint32_t word_index) const
+  {
+    return word_type{1} << ((hash >> (word_index * bit_index_width)) & bit_index_mask);
+  }
+
+ private:
+  hasher hash_{};
+};
 
 template <class KeyT>
-using arrow_bloom = bloom_filter_for<KeyT, arrow_policy<KeyT>>;
-
-template <class KeyT>
-using standard_bloom = bloom_filter_for<KeyT, default_policy<KeyT>>;
+using sirius_bloom = cuco::bloom_filter<KeyT,
+                                        cuco::extent<std::size_t>,
+                                        cuda::thread_scope_device,
+                                        sirius_bloom_policy<KeyT>,
+                                        bloom_alloc>;
 
 template <class Filter>
 using bloom_owner = std::unique_ptr<Filter>;
 
-// The four legal key-width/policy combinations. A live replica owns exactly one alternative.
-using bloom_storage = std::variant<bloom_owner<arrow_bloom<std::int32_t>>,
-                                   bloom_owner<standard_bloom<std::int32_t>>,
-                                   bloom_owner<arrow_bloom<std::int64_t>>,
-                                   bloom_owner<standard_bloom<std::int64_t>>>;
+// The two legal key widths. A live replica owns exactly one alternative.
+using bloom_storage =
+  std::variant<bloom_owner<sirius_bloom<std::int32_t>>, bloom_owner<sirius_bloom<std::int64_t>>>;
 
 template <class Filter>
 bloom_owner<Filter> make_bloom(std::size_t num_blocks,
@@ -173,12 +250,10 @@ std::unique_ptr<bloom_replica> build_bloom_replica(int device_id,
                                                    rmm::device_async_resource_ref mr,
                                                    cuda::stream_ref stream)
 {
-  if (num_blocks <= arrow_policy<KeyT>::max_filter_blocks) {
-    return std::make_unique<bloom_replica>(
-      device_id, build_bloom<arrow_bloom<KeyT>>(keys, num_blocks, mr, stream));
-  }
+  // One policy for every size: unlike cuco's stock pair there is no cap to fall off, so there is
+  // no size-dependent branch and no second filter type to carry through the replica variant.
   return std::make_unique<bloom_replica>(
-    device_id, build_bloom<standard_bloom<KeyT>>(keys, num_blocks, mr, stream));
+    device_id, build_bloom<sirius_bloom<KeyT>>(keys, num_blocks, mr, stream));
 }
 }  // namespace
 


### PR DESCRIPTION
blocks_for() sizes every Bloom above cuco::arrow_filter_policy's 128 MiB / 2^22-block
cap, so build_bloom_replica always fell through to cuco::default_filter_policy, whose
block_index is literally 'hash mod num_blocks'. GPUs have no integer-divide
instruction, so a 64-bit modulo by a runtime value is a long emulated sequence and it
dominated the probe kernel.

The miss is by a hair: the Arrow cap is 67.1M keys at 16 bits/key, and TPC-H q21's two
hot filters hold 73.2M and 70.6M -- over by 9% and 5%.

sirius_bloom_policy is identical to default_filter_policy<xxhash_64,uint32,8> in hash,
block geometry and fingerprint layout; only block_index changes, to
(hash * num_blocks) >> 64 -- one mul.hi.u64. Being uncapped, one policy now covers all
sizes, so the size-dependent branch is gone. kTargetBitsPerKey and estimated_bytes()
are untouched, so hash-set-vs-Bloom selection is bit-identical.

cuco::static_set already avoided this divide via cuco::utility::fast_int magic
reciprocals -- only the Bloom policy was raw, which is why the IN-list never showed
the symptom.

No false negatives: fast-range is a deterministic uniform map applied identically on
add and contains, so the filter stays a conjunctive superset and the join stays
authoritative. The false-positive set moved favourably -- fast-range takes the high
hash bits while the fingerprint takes the low 40, where the modulo drew both from the
low bits. Keep ratio 5.002% -> 4.878% against a 4.77% true-match rate.

Measured on TPC-H SF1000 (GB300): q21 -15.2%, q3 -8.9%, q8 -7.3%, suite -2.49%.
22/22 byte-identical. Zero-false-negative verified for INT32/INT64 at 1/12/1e3/1e6/
3e7/7.3e7 keys including 0, -1, INT_MIN, INT_MAX; 99 [dynamic_filter] tests pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
