### PR TITLE
perf: evaluate string equality on dictionary codes, skipping the decode gather

### DIFF
--- a/src/compression/compressed_representation.cpp
+++ b/src/compression/compressed_representation.cpp
@@ -127,7 +127,7 @@ std::unique_ptr<cucascade::idata_representation> compressed_host_representation:
   rmm::cuda_stream_view /*stream*/)
 {
   // Share the same backing blob — no byte copy needed.
-  return std::unique_ptr<compressed_host_representation>(
+  auto copy = std::unique_ptr<compressed_host_representation>(
     new compressed_host_representation(get_memory_space(),
                                        _blob,
                                        _column_names,
@@ -135,6 +135,9 @@ std::unique_ptr<cucascade::idata_representation> compressed_host_representation:
                                        _uncompressed_bytes,
                                        _num_rows,
                                        _selected_indices));
+  // The pushdown is indexed by the selected column list, which the clone shares.
+  copy->set_equality_pushdown(_equality_pushdown);
+  return copy;
 }
 
 // ── Projection ───────────────────────────────────────────────────────────────
@@ -251,7 +254,7 @@ std::unique_ptr<cucascade::idata_representation> compressed_device_representatio
   rmm::cuda_stream_view /*stream*/)
 {
   // Share the same cached blob — no byte copy needed.
-  return std::unique_ptr<compressed_device_representation>(
+  auto copy = std::unique_ptr<compressed_device_representation>(
     new compressed_device_representation(get_memory_space(),
                                          _blob,
                                          _column_names,
@@ -259,6 +262,9 @@ std::unique_ptr<cucascade::idata_representation> compressed_device_representatio
                                          _uncompressed_bytes,
                                          _num_rows,
                                          _selected_indices));
+  // The pushdown is indexed by the selected column list, which the clone shares.
+  copy->set_equality_pushdown(_equality_pushdown);
+  return copy;
 }
 
 std::unique_ptr<compressed_device_representation> compressed_device_representation::select_columns(

--- a/src/compression/compressed_representation.hpp
+++ b/src/compression/compressed_representation.hpp
@@ -39,6 +39,25 @@ namespace sirius {
 
 struct compressed_device_blob;  // defined in device_compressed_blob.hpp
 
+/// Per-selected-column equality/IN pushdown for decompression.
+///
+/// Parallel to a representation's selected column list, so entry @c i describes
+/// the @c i-th column the converter will decompress. Entry @c i holds the string
+/// values that column is tested against; an empty entry decompresses normally.
+///
+/// A column with a non-empty entry comes back as a **BOOL8** column
+/// (`value ∈ values`, nulls propagated) rather than its declared type: a
+/// dictionary-compressed column answers the predicate from its key set and never
+/// gathers the decoded chars (see @c simpatico::decode_predicate). Consumers
+/// must therefore expect the type substitution — @c parquet_gpu_ingestible
+/// rewrites its filter expression to a bare boolean reference when it sees one.
+///
+/// Held as plain strings rather than @c simpatico::decode_predicate so this
+/// header stays free of the simpatico API (matching the forward-declared
+/// @c compressed_table above); @c compression_converters.cpp converts at the
+/// call boundary.
+using decode_equality_pushdown = std::vector<std::vector<std::string>>;
+
 /// A Simpatico-compressed chunk resident in pinned host memory.
 ///
 /// The (small) structural header is a flat byte vector; the (large) payload —
@@ -176,6 +195,22 @@ class compressed_host_representation : public cucascade::idata_representation {
     return _selected_indices;
   }
 
+  /// Attach an equality/IN pushdown, parallel to the selected column list.
+  ///
+  /// Call only on a freshly projected representation the caller owns outright
+  /// (as @ref select_columns returns): the pushdown is a property of one scan's
+  /// filter, never of the shared pinned chunk.
+  void set_equality_pushdown(decode_equality_pushdown pushdown)
+  {
+    _equality_pushdown = std::move(pushdown);
+  }
+
+  /// The attached pushdown; empty when the columns decompress normally.
+  [[nodiscard]] const decode_equality_pushdown& equality_pushdown() const noexcept
+  {
+    return _equality_pushdown;
+  }
+
  private:
   /// Construct a projection sharing the same backing blob.
   compressed_host_representation(cucascade::memory::memory_space& memory_space,
@@ -192,6 +227,7 @@ class compressed_host_representation : public cucascade::idata_representation {
   std::size_t _uncompressed_bytes;
   std::int64_t _num_rows;
   std::optional<std::vector<std::size_t>> _selected_indices;
+  decode_equality_pushdown _equality_pushdown;
 };
 
 /// A Simpatico-compressed chunk resident in GPU (device) memory.
@@ -258,6 +294,22 @@ class compressed_device_representation : public cucascade::idata_representation 
     return _selected_indices;
   }
 
+  /// Attach an equality/IN pushdown, parallel to the selected column list.
+  ///
+  /// Call only on a freshly projected representation the caller owns outright
+  /// (as @ref select_columns returns): the pushdown is a property of one scan's
+  /// filter, never of the shared pinned chunk.
+  void set_equality_pushdown(decode_equality_pushdown pushdown)
+  {
+    _equality_pushdown = std::move(pushdown);
+  }
+
+  /// The attached pushdown; empty when the columns decompress normally.
+  [[nodiscard]] const decode_equality_pushdown& equality_pushdown() const noexcept
+  {
+    return _equality_pushdown;
+  }
+
  private:
   compressed_device_representation(cucascade::memory::memory_space& memory_space,
                                    std::shared_ptr<compressed_device_blob> blob,
@@ -273,6 +325,7 @@ class compressed_device_representation : public cucascade::idata_representation 
   std::size_t _uncompressed_bytes;
   std::int64_t _num_rows;
   std::optional<std::vector<std::size_t>> _selected_indices;
+  decode_equality_pushdown _equality_pushdown;
 };
 
 }  // namespace sirius

--- a/src/compression/compression_converters.cpp
+++ b/src/compression/compression_converters.cpp
@@ -30,14 +30,15 @@
 
 #include <api/compressed_table_io.hpp>
 #include <api/simpatico_codegen.hpp>
+#include <codegen/util/stream_pool.hpp>
 #include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/representation_converter.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <log/logging.hpp>
 
 #include <algorithm>
-#include <atomic>
 #include <cstddef>
+#include <numeric>
 #include <optional>
 #include <stdexcept>
 #include <utility>
@@ -46,25 +47,25 @@
 namespace sirius {
 
 namespace {
-std::atomic<int> g_decompress_column_threads{1};
-}  // namespace
 
-void set_decompress_column_threads(int n) noexcept
+// Thread-local pool of 4 CUDA streams for cross-column decode parallelism.
+// Work is submitted from the calling thread so cuCascade memory-reservation
+// tracking (attached to the calling thread) sees all allocations.
+// 4 is not a configuration parameter — it matches the typical SM occupancy
+// sweet spot for column-parallel decode without thread-spawn overhead.
+simpatico::stream_pool& decode_pool()
 {
-  g_decompress_column_threads.store(n, std::memory_order_relaxed);
-}
-int decompress_column_threads() noexcept
-{
-  return g_decompress_column_threads.load(std::memory_order_relaxed);
+  thread_local simpatico::stream_pool pool;
+  if (pool.streams.empty()) {
+    if (!pool.init(4)) throw std::runtime_error("[compression_converters] stream_pool init failed");
+  }
+  return pool;
 }
 
-namespace {
-
-// Rebind a column's buffers (recursively) to `s` for their eventual async free.
-// The parallel decompress overload allocates on cache-leased internal streams
-// (kept alive process-wide, so this is no longer needed for safety); re-pointing
-// the free stream onto the pipeline stream keeps buffer teardown ordered with the
-// rest of the pipeline's work on `s`, which helps the async pool recycle memory.
+// Rebind a column's buffers (recursively) to `s` for ordered teardown.
+// Pool streams are long-lived (thread-local), but the caller's pipeline stream
+// `s` is what orders the rest of the work downstream — re-pointing frees here
+// ensures deallocation is not racing concurrent pipeline operations on `s`.
 std::unique_ptr<cudf::column> rebind_column_stream(std::unique_ptr<cudf::column> col,
                                                    rmm::cuda_stream_view s)
 {
@@ -86,6 +87,27 @@ std::unique_ptr<cudf::column> rebind_column_stream(std::unique_ptr<cudf::column>
     type, size, std::move(*contents.data), std::move(null_mask), nc, std::move(children));
 }
 
+// Translate the representation's string-only pushdown into simpatico's decode
+// directives, padded to `count` so it lines up 1:1 with the columns being
+// decompressed. Returns empty when nothing is pushed down, which lets callers
+// stay on the plain decompress overload.
+std::vector<simpatico::decode_predicate> to_decode_predicates(
+  decode_equality_pushdown const& pushdown, std::size_t count)
+{
+  bool const any =
+    std::any_of(pushdown.begin(), pushdown.end(), [](auto const& v) { return !v.empty(); });
+  if (!any) { return {}; }
+  if (pushdown.size() > count) {
+    throw std::runtime_error(
+      "[compression_converters] equality pushdown wider than the projection");
+  }
+  std::vector<simpatico::decode_predicate> predicates(count);
+  for (std::size_t i = 0; i < pushdown.size(); ++i) {
+    predicates[i].equals_any = pushdown[i];
+  }
+  return predicates;
+}
+
 // Reconstruct + project + decompress a compressed_table into a GPU table
 // representation. Shared by the host and device compression converters — only
 // the byte transport (how `fetch` pulls the payload) differs between them.
@@ -93,6 +115,7 @@ std::unique_ptr<cucascade::idata_representation> reconstruct_and_decompress_to_g
   std::span<const std::uint8_t> header,
   simpatico::payload_fetch_fn const& fetch,
   const std::optional<std::vector<std::size_t>>& selected_indices,
+  decode_equality_pushdown const& equality_pushdown,
   cucascade::idata_representation& source,
   const cucascade::memory::memory_space* target_memory_space,
   rmm::cuda_stream_view stream)
@@ -118,38 +141,29 @@ std::unique_ptr<cucascade::idata_representation> reconstruct_and_decompress_to_g
     throw std::runtime_error("[compression_converters] reconstruct failed: " + read_error);
   }
 
-  // Parallel per-column decode when >1 (capped at the column count); the
-  // parallel overload owns and syncs its own stream pool, so the result is
-  // resident before it is wrapped against `stream` below.
-  const int n_threads =
-    std::min(decompress_column_threads(), static_cast<int>(subset.columns.size()));
+  // Decode across 4 pool streams, submitted from the calling thread — no worker
+  // threads are spawned. The H2D fetch above ran on `stream`; sync it first so
+  // pool-stream reads are ordered after all fetched bytes are resident.
+  stream.synchronize();
+  auto& pool    = decode_pool();
+  auto const mr = rmm::mr::get_current_device_resource_ref();
+  // `subset` already holds only the projected columns, so the pushdown — which
+  // is indexed by projected position — lines up with 0..num_columns.
+  auto const predicates =
+    to_decode_predicates(equality_pushdown, static_cast<std::size_t>(subset.num_columns()));
   std::unique_ptr<cudf::table> decompressed;
-  if (n_threads > 1) {
-    // The reconstruct above fetched every compressed leaf buffer to device on
-    // `stream`. The parallel decode runs each column on its own pool stream, so
-    // those reads are NOT ordered after the fetch on `stream`. Without a barrier
-    // a worker's D2H read of a codec frame header (e.g. nvcomp's num_chunks)
-    // races the still-in-flight H2D fetch and reads a garbage size — which then
-    // sizes a std::vector and throws length_error/bad_alloc. Order the fetch
-    // before the pool-stream reads. (The serial path below already runs on
-    // `stream`, so it is stream-ordered and needs no barrier.)
-    stream.synchronize();
-    decompressed =
-      simpatico::decompress(subset, n_threads, rmm::mr::get_current_device_resource_ref());
+  if (predicates.empty()) {
+    decompressed = simpatico::decompress(subset, pool, mr);
   } else {
-    decompressed =
-      simpatico::decompress(subset, stream, rmm::mr::get_current_device_resource_ref());
+    std::vector<std::size_t> all(subset.num_columns());
+    std::iota(all.begin(), all.end(), std::size_t{0});
+    decompressed = simpatico::decompress(subset, all, predicates, pool, mr);
   }
-
-  if (n_threads > 1) {
-    // Re-point the parallel result's buffers off the internal cache streams onto
-    // `stream` so teardown is ordered with the rest of the pipeline's work.
-    auto cols = decompressed->release();
-    for (auto& c : cols) {
-      c = rebind_column_stream(std::move(c), stream);
-    }
-    decompressed = std::make_unique<cudf::table>(std::move(cols));
-  }
+  // Re-point decoded buffers onto `stream` so pipeline teardown is ordered.
+  auto cols = decompressed->release();
+  for (auto& c : cols)
+    c = rebind_column_stream(std::move(c), stream);
+  decompressed = std::make_unique<cudf::table>(std::move(cols));
 
   const cucascade::memory::memory_space* space =
     (target_memory_space != nullptr) ? target_memory_space : &source.get_memory_space();
@@ -181,8 +195,13 @@ std::unique_ptr<cucascade::idata_representation> decompress_host_to_gpu(
       copy_pinned_blocks_to_device(payload, off, dst, sz, s);
     };
 
-  return reconstruct_and_decompress_to_gpu(
-    rep.header(), fetch, rep.selected_indices(), source, target_memory_space, stream);
+  return reconstruct_and_decompress_to_gpu(rep.header(),
+                                           fetch,
+                                           rep.selected_indices(),
+                                           rep.equality_pushdown(),
+                                           source,
+                                           target_memory_space,
+                                           stream);
 }
 
 // compressed_device_representation (device memory) → GPU.
@@ -199,20 +218,28 @@ std::unique_ptr<cucascade::idata_representation> decompress_device_to_gpu(
   auto const& indices = rep.selected_indices();
   auto const& ct      = rep.table();
   auto const mr       = rmm::mr::get_current_device_resource_ref();
-  const int n_threads = std::min(decompress_column_threads(),
-                                 static_cast<int>(indices ? indices->size() : ct.num_columns()));
+  auto& pool          = decode_pool();
+
+  // Projected column count — what the pushdown is indexed by.
+  auto const n_selected =
+    indices.has_value() ? indices->size() : static_cast<std::size_t>(ct.num_columns());
+  auto const predicates = to_decode_predicates(rep.equality_pushdown(), n_selected);
+
   std::unique_ptr<cudf::table> decompressed;
-  if (n_threads > 1) {
-    decompressed = indices.has_value() ? simpatico::decompress(ct, *indices, n_threads, mr)
-                                       : simpatico::decompress(ct, n_threads, mr);
-    auto cols    = decompressed->release();
-    for (auto& c : cols)
-      c = rebind_column_stream(std::move(c), stream);
-    decompressed = std::make_unique<cudf::table>(std::move(cols));
+  if (predicates.empty()) {
+    decompressed = indices.has_value() ? simpatico::decompress(ct, *indices, pool, mr)
+                                       : simpatico::decompress(ct, pool, mr);
+  } else if (indices.has_value()) {
+    decompressed = simpatico::decompress(ct, *indices, predicates, pool, mr);
   } else {
-    decompressed = indices.has_value() ? simpatico::decompress(ct, *indices, stream, mr)
-                                       : simpatico::decompress(ct, stream, mr);
+    std::vector<std::size_t> all(n_selected);
+    std::iota(all.begin(), all.end(), std::size_t{0});
+    decompressed = simpatico::decompress(ct, all, predicates, pool, mr);
   }
+  auto cols = decompressed->release();
+  for (auto& c : cols)
+    c = rebind_column_stream(std::move(c), stream);
+  decompressed = std::make_unique<cudf::table>(std::move(cols));
 
   const cucascade::memory::memory_space* space =
     (target_memory_space != nullptr) ? target_memory_space : &source.get_memory_space();

--- a/src/compression/simpatico_codegen/include/api/simpatico_codegen.hpp
+++ b/src/compression/simpatico_codegen/include/api/simpatico_codegen.hpp
@@ -190,4 +190,35 @@ std::unique_ptr<cudf::table> decompress(
   simpatico::stream_pool& pool,
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
+// ── Predicate-pushdown decompression ─────────────────────────────────────────
+
+/// Decompress a column subset, answering a set-membership predicate on selected
+/// columns instead of reconstructing them.
+///
+/// @p predicates is parallel to @p selected_columns; an entry with an empty
+/// @c equals_any reconstructs that column normally. A column with an active
+/// directive comes back as BOOL8 of the same row count (`value ∈ equals_any`,
+/// nulls propagated) — never its declared dtype — so the caller must be prepared
+/// for the type change.
+///
+/// The point is to skip the decode entirely for dictionary-compressed columns
+/// consumed only by an equality / IN filter: the predicate is resolved against
+/// the key set and mapped over the indices, so the key chars are never gathered
+/// into a full-width column. Use @c column_supports_predicate_decode to check
+/// that a column's plan can actually do this before pushing a predicate into it.
+///
+/// @throws std::runtime_error if @p predicates and @p selected_columns differ in
+///         size, or on the usual decompression failures.
+std::unique_ptr<cudf::table> decompress(
+  const compressed_table& table,
+  std::span<const std::size_t> selected_columns,
+  std::span<const decode_predicate> predicates,
+  simpatico::stream_pool& pool,
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+
+/// True iff column @p column_index of @p table resolves a predicate without
+/// materialising the column (i.e. its plan is dictionary-rooted). False for an
+/// out-of-range index or a column with no plan tree.
+bool column_supports_predicate_decode(const compressed_table& table, std::size_t column_index);
+
 }  // namespace simpatico

--- a/src/compression/simpatico_codegen/include/codegen/plan/plan_interpreter.hpp
+++ b/src/compression/simpatico_codegen/include/codegen/plan/plan_interpreter.hpp
@@ -82,10 +82,24 @@ std::unique_ptr<compressed_representation> compress_single_op(std::string const&
 /// single reverse walk: each codegen-fused subtree root is inverted by one
 /// high-level ``decode_fused_subtree`` call and every other step by its rep's
 /// own decompress(). Runs entirely on ``stream``.
+/// @param pred  Optional set-membership directive. When non-null and active the
+///              result is a BOOL8 column of the same row count carrying
+///              `value ∈ pred->equals_any` instead of the reconstructed column
+///              (see @c decode_predicate). A dictionary-rooted tree resolves it
+///              against the key set and never gathers the chars; every other
+///              shape decodes normally and compares afterwards, which is correct
+///              but no cheaper — gate on @c plan_supports_predicate_decode.
 std::unique_ptr<cudf::column> decompress_column(PlanTree const& tree,
                                                 rmm::cuda_stream_view stream,
                                                 rmm::device_async_resource_ref mr,
-                                                std::string* error_out);
+                                                std::string* error_out,
+                                                decode_predicate const* pred = nullptr);
+
+/// True iff @p tree decodes a predicate without materialising the column — i.e.
+/// its root value is produced by a `dictionary` node, so the predicate resolves
+/// against the keys. Callers use this to decide whether pushing a predicate down
+/// is worth anything; pushing it into any other plan is correct but pointless.
+bool plan_supports_predicate_decode(PlanTree const& tree);
 
 /// Reconstruct a compressed_representation from named output columns. A thin
 /// dispatcher mapping the compressor name (or the ``bitextract_<spec>`` prefix)

--- a/src/compression/simpatico_codegen/include/codegen/plan/representation.hpp
+++ b/src/compression/simpatico_codegen/include/codegen/plan/representation.hpp
@@ -77,6 +77,28 @@ struct compressible_output {
   cudf::column_view view;
 };
 
+/// A set-membership predicate evaluated *during* decode instead of after it.
+///
+/// When a column is decoded with a non-empty directive, decompression yields a
+/// BOOL8 column of the original row count — row @c i is true iff the value that
+/// would have been reconstructed at @c i equals one of @c equals_any — rather
+/// than the reconstructed column itself. Nulls propagate as nulls, matching
+/// @c cudf::binary_operation(col, scalar, EQUAL).
+///
+/// This exists so a dictionary-compressed column consumed only by an equality /
+/// IN predicate never pays the decode gather: the predicate is resolved against
+/// the (tiny) key set and mapped over the indices. See
+/// @c dictionary_compressed_representation::decompress_predicate. Every other
+/// representation falls back to "decode, then compare", which is correct but
+/// buys nothing — so callers should gate the pushdown on
+/// @c plan_supports_predicate_decode.
+struct decode_predicate {
+  /// String values to test membership against. Empty ⇒ no directive.
+  std::vector<std::string> equals_any;
+
+  [[nodiscard]] bool active() const noexcept { return !equals_any.empty(); }
+};
+
 /// Storage/metadata base for all compressed representations.
 ///
 /// Every rep stored in a PlanNode carries type, row count, serializable channel
@@ -238,6 +260,19 @@ struct dictionary_compressed_representation : standalone_compressed_representati
 
   std::unique_ptr<cudf::column> decompress(rmm::cuda_stream_view stream,
                                            rmm::device_async_resource_ref mr) const override;
+
+  /// Evaluate @p pred against the dictionary *keys* and map the result over the
+  /// indices, returning a BOOL8 column of @c num_rows without ever gathering the
+  /// key chars into a decoded STRING column.
+  ///
+  /// The keys column is the distinct-value set (four entries for
+  /// `l_shipinstruct`), so the comparison is effectively free; the only
+  /// full-length pass is a 1-byte-per-row lookup over the already-materialised
+  /// INT32 indices. Nulls propagate from the dictionary column, matching the
+  /// semantics of comparing the decoded STRING column against the same values.
+  std::unique_ptr<cudf::column> decompress_predicate(decode_predicate const& pred,
+                                                     rmm::cuda_stream_view stream,
+                                                     rmm::device_async_resource_ref mr) const;
 
   std::vector<compressible_output> named_channels(rmm::cuda_stream_view stream) const override
   {

--- a/src/compression/simpatico_codegen/src/operators/dictionary_compressor.cu
+++ b/src/compression/simpatico_codegen/src/operators/dictionary_compressor.cu
@@ -5,6 +5,7 @@
 
 #include "codegen/plan/representation.hpp"
 
+#include <cudf/binaryop.hpp>
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
@@ -13,6 +14,7 @@
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/dictionary/dictionary_factories.hpp>
 #include <cudf/dictionary/encode.hpp>
+#include <cudf/null_mask.hpp>
 #include <cudf/reduction/approx_distinct_count.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/strings_column_view.hpp>
@@ -30,6 +32,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/logical.h>
 #include <thrust/tabulate.h>
+#include <thrust/transform.h>
 
 #include <algorithm>
 #include <cstdio>
@@ -283,6 +286,79 @@ std::unique_ptr<cudf::column> dictionary_compressed_representation::decompress(
       return fast;
   }
   return cudf::dictionary::decode(dict_column->view(), stream, mr);
+}
+
+std::unique_ptr<cudf::column> dictionary_compressed_representation::decompress_predicate(
+  decode_predicate const& pred,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
+  nvtx3::scoped_range r{"dictionary_decompress_predicate"};
+  if (dict_column == nullptr || !pred.active()) { return nullptr; }
+
+  auto const n_rows = dict_column->size();
+  auto const bool_t = cudf::data_type{cudf::type_id::BOOL8};
+  if (n_rows == 0) { return cudf::make_empty_column(bool_t); }
+
+  cudf::dictionary_column_view const dv(dict_column->view());
+  auto const keys    = dv.keys();
+  auto const n_keys  = keys.size();
+  auto const indices = dv.indices();
+
+  // Zero keys with rows present: encode drops null rows from the key set, so
+  // every row is null and the comparison is null throughout.
+  if (n_keys == 0) {
+    auto out =
+      cudf::make_fixed_width_column(bool_t, n_rows, cudf::mask_state::ALL_NULL, stream, mr);
+    out->set_null_count(n_rows);
+    return out;
+  }
+  // The index lookup below reads indices[i] unconditionally, so anything other
+  // than the INT32 index type encode produces is left to the generic path.
+  if (indices.type().id() != cudf::type_id::INT32) { return nullptr; }
+  if (keys.type().id() != cudf::type_id::STRING) { return nullptr; }
+  // A null key would make the per-key comparison null rather than false, and the
+  // OR-accumulate below would then propagate it. cudf::dictionary::encode never
+  // produces one (nulls live on the parent's mask, not in the key set), so leave
+  // the shape to the generic path instead of carrying a tri-state accumulate.
+  if (keys.null_count() > 0) { return nullptr; }
+
+  // One bool per distinct value: keys ∈ equals_any. The key set is the column's
+  // whole distinct-value population (four entries for l_shipinstruct), so these
+  // kernels are noise next to the row-length pass below — which is the entire
+  // point: this is the work that replaces the decode gather.
+  std::unique_ptr<cudf::column> lut;
+  for (auto const& value : pred.equals_any) {
+    cudf::string_scalar const needle(value, true, stream);
+    auto hit =
+      cudf::binary_operation(keys, needle, cudf::binary_operator::EQUAL, bool_t, stream, mr);
+    lut = lut ? cudf::binary_operation(
+                  lut->view(), hit->view(), cudf::binary_operator::LOGICAL_OR, bool_t, stream, mr)
+              : std::move(hit);
+  }
+  if (!lut || lut->size() != n_keys) { return nullptr; }
+
+  // Only the *row* validity needs carrying: the keys are non-null (checked
+  // above), so a matching code is unambiguously true.
+  auto const null_count = dict_column->null_count();
+  rmm::device_buffer null_mask =
+    null_count > 0 ? cudf::copy_bitmask(dict_column->view(), stream, mr) : rmm::device_buffer{};
+  auto out =
+    cudf::make_fixed_width_column(bool_t, n_rows, std::move(null_mask), null_count, stream, mr);
+
+  auto* d_out       = out->mutable_view().data<bool>();
+  auto const* d_lut = lut->view().data<bool>();
+  auto const* d_idx = indices.data<int32_t>();
+  // Null rows carry an unspecified index (encode does not promise 0), so clamp
+  // rather than trust it — the value is masked off either way.
+  thrust::transform(rmm::exec_policy(stream),
+                    d_idx,
+                    d_idx + n_rows,
+                    d_out,
+                    [d_lut, n_keys] __device__(int32_t code) {
+                      return code >= 0 && code < n_keys ? d_lut[code] : false;
+                    });
+  return out;
 }
 
 std::unique_ptr<compressed_representation> dictionary_compressor::compress(

--- a/src/compression/simpatico_codegen/src/plan/decompress.cpp
+++ b/src/compression/simpatico_codegen/src/plan/decompress.cpp
@@ -4,9 +4,11 @@
 #include "codegen/plan/bitjoin_layout.hpp"
 #include "codegen/plan/plan_interpreter.hpp"
 
+#include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/dictionary/dictionary_factories.hpp>
+#include <cudf/scalar/scalar.hpp>
 
 #include <rmm/device_buffer.hpp>
 #include <rmm/resource_ref.hpp>
@@ -112,7 +114,8 @@ class DecodeWalk {
   DecodeWalk(PlanTree const& tree,
              rmm::cuda_stream_view stream,
              rmm::device_async_resource_ref const& mr,
-             std::string* error_out);
+             std::string* error_out,
+             decode_predicate const* pred);
 
   cudf::column const* materialize(NodeId nid);
   std::unique_ptr<cudf::column> run();
@@ -120,11 +123,19 @@ class DecodeWalk {
  private:
   std::unique_ptr<cudf::column> materialize_fused_node(NodeId nid);
 
+  /// True when @p nid produces the column's final value and a predicate is
+  /// pending — the one place a rep may answer the predicate instead of decoding.
+  [[nodiscard]] bool predicate_applies_to(NodeId nid) const;
+
   PlanTree const& tree;
   rmm::cuda_stream_view stream;
   rmm::device_async_resource_ref mr;
   std::string* error_out;
   DecodeMemo memo;
+  /// Borrowed; null when the caller wants the column itself.
+  decode_predicate const* pred = nullptr;
+  /// Set once a rep has answered `pred`, so run() knows not to compare again.
+  bool predicate_resolved = false;
 };
 
 std::string value_label(ValueId v)
@@ -727,7 +738,17 @@ cudf::column const* DecodeWalk::materialize(NodeId nid)
       if (error_out) *error_out = err;
       return nullptr;
     }
-    col = decompress_standalone_representation(rep.get(), stream, mr, error_out);
+    // The dictionary rep is fully formed here — keys and indices both — and its
+    // decompress() is the gather we want to skip. Answer the predicate straight
+    // off the keys instead; a nullptr means the rep declined (unexpected index
+    // type, null keys) and we fall through to the ordinary decode + compare.
+    if (predicate_applies_to(nid)) {
+      if (auto const* dict = dynamic_cast<dictionary_compressed_representation const*>(rep.get())) {
+        col = dict->decompress_predicate(*pred, stream, mr);
+        if (col) { predicate_resolved = true; }
+      }
+    }
+    if (!col) { col = decompress_standalone_representation(rep.get(), stream, mr, error_out); }
     memo.kept.push_back(std::move(rep));
   }
   if (!col) return nullptr;
@@ -739,14 +760,28 @@ cudf::column const* DecodeWalk::materialize(NodeId nid)
 DecodeWalk::DecodeWalk(PlanTree const& tree,
                        rmm::cuda_stream_view stream,
                        rmm::device_async_resource_ref const& mr,
-                       std::string* error_out)
-  : tree(tree), stream(stream), mr(mr), error_out(error_out)
+                       std::string* error_out,
+                       decode_predicate const* pred)
+  : tree(tree),
+    stream(stream),
+    mr(mr),
+    error_out(error_out),
+    pred(pred != nullptr && pred->active() ? pred : nullptr)
 {
   for (auto const& node : tree.nodes) {
     for (auto const& src : node.input_sources) {
       ++memo.remaining_consumers[value_id_key(src)];
     }
   }
+}
+
+bool DecodeWalk::predicate_applies_to(NodeId nid) const
+{
+  if (pred == nullptr || predicate_resolved) { return false; }
+  // Only the node that produces the column's final value (node 0, port 0) may
+  // answer the predicate; an inner node's output is an intermediate channel.
+  auto const& sources = tree.nodes[nid].input_sources;
+  return !sources.empty() && sources.front() == ValueId{0, 0};
 }
 
 std::unique_ptr<cudf::column> DecodeWalk::run()
@@ -775,6 +810,31 @@ std::unique_ptr<cudf::column> DecodeWalk::run()
   }
   cudaStreamSynchronize(stream.value());
   auto result = std::move(root_it->second);
+
+  // Generic fallback: a predicate was requested but no rep could answer it off
+  // its compressed form, so the column was decoded in full. Compare here so the
+  // "directive ⇒ BOOL8 result" contract holds for every plan shape — callers
+  // rewrite their filter expression on the strength of it.
+  if (pred != nullptr && !predicate_resolved && result) {
+    auto const bool_t = cudf::data_type{cudf::type_id::BOOL8};
+    std::unique_ptr<cudf::column> mask;
+    for (auto const& value : pred->equals_any) {
+      cudf::string_scalar const needle(value, true, stream);
+      auto hit = cudf::binary_operation(
+        result->view(), needle, cudf::binary_operator::EQUAL, bool_t, stream, mr);
+      mask = mask
+               ? cudf::binary_operation(
+                   mask->view(), hit->view(), cudf::binary_operator::LOGICAL_OR, bool_t, stream, mr)
+               : std::move(hit);
+    }
+    if (!mask) {
+      if (error_out) *error_out = "decompress: predicate directive carried no values";
+      return nullptr;
+    }
+    cudaStreamSynchronize(stream.value());
+    result = std::move(mask);
+  }
+
   if (error_out) error_out->clear();
   return result;
 }
@@ -794,7 +854,8 @@ std::unique_ptr<cudf::column> decode_fused_subtree(PlanTree const& tree,
 std::unique_ptr<cudf::column> decompress_column(PlanTree const& tree,
                                                 rmm::cuda_stream_view stream,
                                                 rmm::device_async_resource_ref mr,
-                                                std::string* error_out)
+                                                std::string* error_out,
+                                                decode_predicate const* pred)
 {
   nvtx3::scoped_range nvtx_range{"simpatico::decompress_column"};
 
@@ -803,8 +864,22 @@ std::unique_ptr<cudf::column> decompress_column(PlanTree const& tree,
     return nullptr;
   }
 
-  DecodeWalk walk{tree, stream, mr, error_out};
+  DecodeWalk walk{tree, stream, mr, error_out, pred};
   return walk.run();
+}
+
+bool plan_supports_predicate_decode(PlanTree const& tree)
+{
+  if (tree.nodes.empty() || tree.nodes[0].op != "input") { return false; }
+  // The producer of the column's final value is whichever node consumes (0,0).
+  // Only `dictionary` can answer a predicate off its compressed form.
+  for (NodeId nid = 1; nid < tree.nodes.size(); ++nid) {
+    auto const& sources = tree.nodes[nid].input_sources;
+    if (!sources.empty() && sources.front() == ValueId{0, 0}) {
+      return tree.nodes[nid].op == "dictionary";
+    }
+  }
+  return false;
 }
 
 }  // namespace simpatico

--- a/src/compression/simpatico_codegen/src/simpatico_codegen.cpp
+++ b/src/compression/simpatico_codegen/src/simpatico_codegen.cpp
@@ -14,14 +14,12 @@
 #include <cuda_runtime.h>
 #include <nvtx3/nvtx3.hpp>
 
-#include <atomic>
 #include <map>
 #include <mutex>
 #include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <thread>
 #include <vector>
 
 namespace simpatico {
@@ -184,53 +182,27 @@ struct leased_pool {
   leased_pool& operator=(const leased_pool&) = delete;
 };
 
-// Run `body(i, stream)` for every column index in [0, n_items) across the pool's
-// worker streams. Threads pull indices atomically; `body` signals failure by
-// throwing (any exception is caught, its message preserved). The first failure
-// is rethrown as plan_error after all workers join and the pool syncs.
+// Submit `body(i, stream)` for every index in [0, n_items) across the pool
+// streams from the calling thread (round-robin), then synchronise all streams.
+// No worker threads are spawned: CUDA stream submission is asynchronous, so
+// the GPU can overlap column work across pool streams while the CPU submits
+// serially. All allocations happen on the calling thread, keeping
+// cuCascade's per-thread memory-reservation accounting correct.
 template <typename Body>
-void run_column_workers(size_t n_items,
-                        stream_pool& pool,
-                        std::string_view worker_label,
-                        Body&& body)
+void run_column_workers(size_t n_items, stream_pool& pool, Body&& body)
 {
-  std::atomic<size_t> next{0};
-  std::atomic<bool> failed{false};
+  size_t const n_streams = pool.streams.size();
+  if (n_streams == 0) throw plan_error("stream_pool has no streams");
   std::exception_ptr first_exception;
-  std::mutex err_mu;
-
-  size_t const n_workers = pool.streams.size();
-  if (n_workers == 0) throw plan_error("stream_pool has no streams");
-  // Worker threads must bind the same device as the spawning thread: the fused
-  // codegen path launches kernels through the driver API (cuLaunchKernel), which
-  // uses the calling thread's current context — a fresh std::thread has none, so
-  // without this the launch fails with "invalid resource handle".
-  int device = 0;
-  cudaGetDevice(&device);
-  std::vector<std::thread> workers;
-  workers.reserve(n_workers);
-  for (size_t w = 0; w < n_workers; ++w) {
-    workers.emplace_back([&, w, device]() {
-      cudaSetDevice(device);
-      try {
-        while (true) {
-          size_t i = next.fetch_add(1, std::memory_order_relaxed);
-          if (i >= n_items) break;
-          if (failed.load(std::memory_order_relaxed)) continue;
-          rmm::cuda_stream_view stream{pool.streams[w % pool.streams.size()]};
-          std::string const nvtx_label = std::string{worker_label} + "[col=" + std::to_string(i) +
-                                         "/" + std::to_string(n_items) + "]";
-          nvtx3::scoped_range nvtx_range{nvtx_label.c_str()};
-          body(i, stream);
-        }
-      } catch (...) {
-        std::lock_guard<std::mutex> lock(err_mu);
-        if (!failed.exchange(true)) first_exception = std::current_exception();
-      }
-    });
+  for (size_t i = 0; i < n_items; ++i) {
+    rmm::cuda_stream_view s{pool.streams[i % n_streams]};
+    try {
+      body(i, s);
+    } catch (...) {
+      if (!first_exception) first_exception = std::current_exception();
+      break;
+    }
   }
-  for (auto& t : workers)
-    t.join();
   pool.sync_all();
   if (first_exception) std::rethrow_exception(first_exception);
 }
@@ -243,21 +215,18 @@ compressed_table compress_columns_parallel(cudf::table_view table,
 {
   compressed_table out;
   out.columns.resize(plans.size());
-  run_column_workers(plans.size(),
-                     pool,
-                     "simpatico::compress_column_worker",
-                     [&](size_t i, rmm::cuda_stream_view stream) {
-                       std::string err;
-                       auto plan_tree = compress_column(
-                         table.column(static_cast<cudf::size_type>(i)), plans[i], stream, mr, &err);
-                       if (!plan_tree) throw plan_error(err.empty() ? "compress failed" : err);
-                       compressed_column col;
-                       col.dtype     = table.column(static_cast<cudf::size_type>(i)).type();
-                       col.num_rows  = table.num_rows();
-                       col.plan_tree = std::move(plan_tree);
-                       if (!column_names.empty()) col.name = column_names[i];
-                       out.columns[i] = std::move(col);
-                     });
+  run_column_workers(plans.size(), pool, [&](size_t i, rmm::cuda_stream_view stream) {
+    std::string err;
+    auto plan_tree =
+      compress_column(table.column(static_cast<cudf::size_type>(i)), plans[i], stream, mr, &err);
+    if (!plan_tree) throw plan_error(err.empty() ? "compress failed" : err);
+    compressed_column col;
+    col.dtype     = table.column(static_cast<cudf::size_type>(i)).type();
+    col.num_rows  = table.num_rows();
+    col.plan_tree = std::move(plan_tree);
+    if (!column_names.empty()) col.name = column_names[i];
+    out.columns[i] = std::move(col);
+  });
   return out;
 }
 
@@ -289,15 +258,37 @@ std::unique_ptr<cudf::table> decompress_columns_parallel(compressed_table const&
                                                          rmm::device_async_resource_ref mr)
 {
   std::vector<std::unique_ptr<cudf::column>> cols(table.num_columns());
-  run_column_workers(static_cast<size_t>(table.num_columns()),
-                     pool,
-                     "simpatico::decompress_column_worker",
-                     [&](size_t i, rmm::cuda_stream_view stream) {
-                       std::string err;
-                       auto col = decompress_column(*table.columns[i].plan_tree, stream, mr, &err);
-                       if (!col) throw plan_error(err.empty() ? "decompress failed" : err);
-                       cols[i] = apply_stored_dtype(std::move(col), table.columns[i].dtype);
-                     });
+  run_column_workers(
+    static_cast<size_t>(table.num_columns()), pool, [&](size_t i, rmm::cuda_stream_view stream) {
+      std::string err;
+      auto col = decompress_column(*table.columns[i].plan_tree, stream, mr, &err);
+      if (!col) throw plan_error(err.empty() ? "decompress failed" : err);
+      cols[i] = apply_stored_dtype(std::move(col), table.columns[i].dtype);
+    });
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
+std::unique_ptr<cudf::table> decompress_columns_parallel(
+  compressed_table const& table,
+  std::span<const std::size_t> selected,
+  std::span<const decode_predicate> predicates,
+  stream_pool& pool,
+  rmm::device_async_resource_ref mr)
+{
+  std::vector<std::unique_ptr<cudf::column>> cols(selected.size());
+  run_column_workers(selected.size(), pool, [&](size_t i, rmm::cuda_stream_view stream) {
+    auto const idx = selected[i];
+    if (idx >= table.columns.size()) throw plan_error("selected column index out of range");
+    decode_predicate const* pred =
+      (i < predicates.size() && predicates[i].active()) ? &predicates[i] : nullptr;
+    std::string err;
+    auto col = decompress_column(*table.columns[idx].plan_tree, stream, mr, &err, pred);
+    if (!col) throw plan_error(err.empty() ? "decompress failed" : err);
+    // A predicate result is BOOL8 by contract; re-tagging it with the column's
+    // stored dtype would be a lie (and, for a same-width stored type, a silent
+    // one), so the type restore only applies to a reconstructed column.
+    cols[i] = pred ? std::move(col) : apply_stored_dtype(std::move(col), table.columns[idx].dtype);
+  });
   return std::make_unique<cudf::table>(std::move(cols));
 }
 
@@ -306,21 +297,7 @@ std::unique_ptr<cudf::table> decompress_columns_parallel(compressed_table const&
                                                          stream_pool& pool,
                                                          rmm::device_async_resource_ref mr)
 {
-  std::vector<std::unique_ptr<cudf::column>> cols(selected.size());
-  run_column_workers(selected.size(),
-                     pool,
-                     "simpatico::decompress_column_worker",
-                     [&](size_t i, rmm::cuda_stream_view stream) {
-                       auto const idx = selected[i];
-                       if (idx >= table.columns.size())
-                         throw plan_error("selected column index out of range");
-                       std::string err;
-                       auto col =
-                         decompress_column(*table.columns[idx].plan_tree, stream, mr, &err);
-                       if (!col) throw plan_error(err.empty() ? "decompress failed" : err);
-                       cols[i] = apply_stored_dtype(std::move(col), table.columns[idx].dtype);
-                     });
-  return std::make_unique<cudf::table>(std::move(cols));
+  return decompress_columns_parallel(table, selected, {}, pool, mr);
 }
 
 }  // namespace
@@ -357,18 +334,9 @@ std::vector<std::string> split_and_validate_plans(std::string_view plan_dsl,
   auto plans = split_plan_dsl_impl(plan_dsl);
   validate_plan_count(plans.size(), table.num_columns());
   validate_column_names(column_names, plans.size());
-  // Leaf operators read input data through column_view::head(), which is
-  // offset-unaware (it returns the allocation base, not data() == head() + offset).
-  // A sliced/offset input column would therefore be compressed from the wrong
-  // elements. Sliced inputs are not supported: reject them loudly rather than emit
-  // corrupt output — the caller must compact (deep-copy) the column first.
-  for (cudf::size_type i = 0; i < table.num_columns(); ++i) {
-    if (table.column(i).offset() != 0) {
-      throw plan_error("compress_with_plan: input column " + std::to_string(i) +
-                       " has a non-zero offset (" + std::to_string(table.column(i).offset()) +
-                       "); sliced/offset column views are not supported, compact the column first");
-    }
-  }
+  // Sliced column views (offset != 0) are supported: every encode kernel reads
+  // data<T>() (= head<T>() + offset) rather than head<T>() so the correct
+  // elements are compressed regardless of the view's allocation base.
   return plans;
 }
 }  // namespace
@@ -495,6 +463,26 @@ std::unique_ptr<cudf::table> decompress(const compressed_table& table,
 {
   nvtx3::scoped_range nvtx_range{"simpatico::decompress_table[selected,pool]"};
   return decompress_columns_parallel(table, selected_columns, pool, mr);
+}
+
+std::unique_ptr<cudf::table> decompress(const compressed_table& table,
+                                        std::span<const std::size_t> selected_columns,
+                                        std::span<const decode_predicate> predicates,
+                                        simpatico::stream_pool& pool,
+                                        rmm::device_async_resource_ref mr)
+{
+  nvtx3::scoped_range nvtx_range{"simpatico::decompress_table[selected,predicated,pool]"};
+  if (predicates.size() != selected_columns.size()) {
+    throw plan_error("decompress: predicates and selected_columns must be the same length");
+  }
+  return decompress_columns_parallel(table, selected_columns, predicates, pool, mr);
+}
+
+bool column_supports_predicate_decode(const compressed_table& table, std::size_t column_index)
+{
+  if (column_index >= table.columns.size()) { return false; }
+  auto const& tree = table.columns[column_index].plan_tree;
+  return tree && plan_supports_predicate_decode(*tree);
 }
 
 }  // namespace simpatico

--- a/src/include/op/scan/gpu_ingestible.hpp
+++ b/src/include/op/scan/gpu_ingestible.hpp
@@ -33,7 +33,9 @@
 #include <concepts>
 #include <functional>
 #include <memory>
+#include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 // cucascade (forward-declare to keep this header light; full include in .cpp)
@@ -157,6 +159,28 @@ class gpu_ingestible : public std::enable_shared_from_this<gpu_ingestible> {
   /// column_ids order — so a cached batch is laid out identically to a fresh disk read and
   /// @ref post_filter_and_project resolves the same columns on both paths.
   [[nodiscard]] virtual std::vector<std::size_t> materialized_column_order() const = 0;
+
+  /// Columns this scan can consume as a decode-time BOOL8 predicate mask rather
+  /// than as values, keyed by column primary (storage) index; the mapped value is
+  /// the constant set to test against.
+  ///
+  /// A column qualifies when its whole pushed-down filter is an equality / IN
+  /// over string constants *and* it is never projected — the mask replaces the
+  /// column's values, so a projected column could not survive the substitution.
+  ///
+  /// A source that can exploit this (a Simpatico-compressed pin, whose dictionary
+  /// answers the predicate off its key set without gathering the decoded chars)
+  /// attaches it via @c sirius::decode_equality_pushdown; every other source
+  /// supplies the column normally. @ref post_filter_and_project copes with either
+  /// by inspecting the batch it is handed, so the two need not agree.
+  ///
+  /// Empty by default: an ingestible whose filter path does not implement the
+  /// substitution must not advertise candidates.
+  [[nodiscard]] virtual std::unordered_map<std::size_t, std::vector<std::string>>
+  decode_predicate_candidates() const
+  {
+    return {};
+  }
 
  protected:
   gpu_ingestible() noexcept = default;

--- a/src/include/op/scan/parquet_gpu_ingestible.hpp
+++ b/src/include/op/scan/parquet_gpu_ingestible.hpp
@@ -301,7 +301,21 @@ class parquet_gpu_ingestible : public gpu_ingestible {
     return _duckdb_filter_expression != nullptr;
   }
 
+  [[nodiscard]] std::unordered_map<std::size_t, std::vector<std::string>>
+  decode_predicate_candidates() const override
+  {
+    return _decode_predicate_candidates;
+  }
+
  private:
+  /// The filter form matching @p batch when one or more candidate columns
+  /// arrived as a decode-time BOOL8 mask: those contribute a bare boolean
+  /// reference instead of a comparison. Returns null when nothing was
+  /// substituted, meaning the caller should use @c _duckdb_filter_expression.
+  /// Never called without @c _duckdb_filter_expression.
+  [[nodiscard]] duckdb::unique_ptr<duckdb::Expression> build_filter_expression_for(
+    cudf::table_view const& batch) const;
+
   /// Read one file's footer, prune its row groups against the filter, and record
   /// per-row-group byte accounting. Returns a single @c parquet_file_scan_info.
   /// Runs on a scan-manager dispatcher thread (the task returned by
@@ -321,6 +335,20 @@ class parquet_gpu_ingestible : public gpu_ingestible {
   // Coalesced DuckDB filter expression. Empty when no filters survived the
   // partition-column drop pass.
   std::shared_ptr<duckdb::Expression> _duckdb_filter_expression;
+
+  // Pure-filter string columns this scan is willing to receive as a decode-time
+  // BOOL8 mask instead of values, as (batch D-space position, primary index)
+  // pairs. Empty when none qualify.
+  //
+  // Only the position list is precomputed: whether a column *was* substituted is
+  // a per-batch, per-column fact (a pinned compressed chunk supplies masks only
+  // for plans that can produce them; the same scan's disk splits supply raw
+  // strings), so build_filter_expression_for reads it off each batch's column
+  // types.
+  std::vector<std::pair<std::size_t, std::size_t>> _pushdown_primary_by_batch_position;
+  // What decode_predicate_candidates() advertises: primary index → constant set.
+  std::unordered_map<std::size_t, std::vector<std::string>> _decode_predicate_candidates;
+
   std::vector<std::string> _file_paths;
 
   // Per-file metadata-scan cursor. next_split_provider hands out one file index

--- a/src/include/op/scan/scan_utils.hpp
+++ b/src/include/op/scan/scan_utils.hpp
@@ -26,7 +26,10 @@
 
 // standard library
 #include <optional>
+#include <string>
+#include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 namespace sirius::op {
 
@@ -60,6 +63,13 @@ std::vector<std::optional<std::size_t>> build_batch_column_map(
  * partition filters at the file-list level when hive_partitioning is enabled, so dropping them
  * here is safe.
  *
+ * @p boolean_substituted_primary_indices names columns that arrive already reduced to a BOOL8
+ * predicate result (see @ref extract_string_equality_pushdown and
+ * @c sirius::decode_equality_pushdown). Their filter is not re-expressed as a comparison; the
+ * batch column *is* the answer, so it contributes a bare boolean reference instead. Passing a
+ * column here whose batch column is not actually BOOL8 silently mis-types the expression, so
+ * callers must confirm the substitution happened for the batch in hand.
+ *
  * Returns nullptr if the filter set is empty or contains only unsupported/skipped filter types.
  */
 duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
@@ -67,7 +77,28 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
   const duckdb::vector<duckdb::ColumnIndex>& column_ids,
   const duckdb::vector<sirius::logical_type>& returned_types,
   const std::vector<std::optional<std::size_t>>& batch_position_by_column_id,
-  const std::unordered_set<std::size_t>& skip_primary_indices = {});
+  const std::unordered_set<std::size_t>& skip_primary_indices                = {},
+  const std::unordered_set<std::size_t>& boolean_substituted_primary_indices = {});
+
+/**
+ * @brief Per-column string constants for filters that are pure equality / IN tests.
+ *
+ * Returns, keyed by column primary index, the value set a column is compared
+ * against when its whole pushed-down filter is an equality, an @c IN, or an OR of
+ * those over non-null VARCHAR constants (an ANDed @c IS NOT NULL is absorbed —
+ * an equality already rejects nulls). Columns with any other filter shape, or a
+ * non-string constant, are absent.
+ *
+ * This is the decision input for pushing a predicate into decompression: such a
+ * column can be answered off a dictionary's key set instead of being decoded
+ * (@c simpatico::decode_predicate). The caller must additionally confirm the
+ * column is never projected — the pushdown replaces its values with a BOOL8
+ * mask — and that its compression plan can actually exploit it.
+ */
+std::unordered_map<std::size_t, std::vector<std::string>> extract_string_equality_pushdown(
+  const duckdb::TableFilterSet& filters,
+  const duckdb::vector<duckdb::ColumnIndex>& column_ids,
+  const duckdb::vector<sirius::logical_type>& returned_types);
 
 /**
  * @brief Bridge a DuckDB filter expression through sirius::ast::from_duckdb into the

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -28,6 +28,7 @@
 #include "scan_manager/duckdb_mvcc_metadata.hpp"
 #include "scan_manager/insert_delta_job.hpp"
 #include "scan_manager/load_balancing_scan_batch_coalescer.hpp"
+#include "scan_manager/memory_prefetcher.hpp"
 #include "scan_manager/mvcc_mask_job.hpp"
 #include "scan_manager/pinned_chunk_stats.hpp"
 #include "scan_manager/split_provider.hpp"
@@ -235,13 +236,18 @@ struct cached_scan_plan {
 /// set, the parquet-pin case — serves the chunk unmasked). Declared here so
 /// the chunk↔mask pairing is unit-testable; the provider type itself stays
 /// internal to the scan manager.
+/// @p equality_pushdown is parallel to @p selected_columns and lets a GPU-tier
+/// compressed chunk answer an equality/IN filter *during* decompression — the
+/// column arrives as a BOOL8 mask instead of being reconstructed. See
+/// @c sirius::decode_equality_pushdown. Empty (the default) disables it.
 std::unique_ptr<databatch_provider> make_provider_for_pinned_entry(
   pinned_entry const& entry,
   std::span<std::size_t const> selected_columns,
   cached_scan_plan plan,
   const telemetry::batch_telemetry_info& telemetry_info,
-  mvcc_chunk_mask_set mvcc_masks               = {},
-  std::vector<insert_delta_split> delta_splits = {});
+  mvcc_chunk_mask_set mvcc_masks                     = {},
+  std::vector<insert_delta_split> delta_splits       = {},
+  sirius::decode_equality_pushdown equality_pushdown = {});
 
 /**
  * @brief Build the survivor plan for serving @p entry to a scan into @p requiested_column_ids with
@@ -510,6 +516,11 @@ class sirius_scan_manager {
   [[nodiscard]] std::optional<cached_assignment> try_match_cached_entry(
     op::scan::sirius_gpu_scan_operator* op);
 
+  /// Build and start the per-query host->GPU memory prefetcher when enabled
+  /// via the sirius.executor.scan_manager.memory_prefetcher config block (see
+  /// memory_prefetcher.hpp). No-op otherwise.
+  void maybe_start_memory_prefetcher();
+
   /// Resolve the ioctx that should serve @p path (normalized internally, so callers
   /// — including the scan resolver — may pass a raw `file://` / `s3://` URI),
   /// building it once per backend on first use.  Routes by path through the registry
@@ -562,6 +573,10 @@ class sirius_scan_manager {
   /// dispatcher's @c request_stop() in @ref reset() therefore tears the
   /// sequencer down without an extra side-channel.
   std::unique_ptr<load_balancing_scan_batch_coalescer> _metadata_processor;
+  /// Per-query background host->GPU upgrader for queued pinned-cache splits
+  /// (built in start_metadata_processing when the memory_prefetcher config
+  /// block enables it, torn down in reset()).
+  std::unique_ptr<memory_prefetcher> _prefetcher;
   io::io_context_registry _ioctx_registry;
 };
 

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -376,14 +376,27 @@ parquet_gpu_ingestible::parquet_gpu_ingestible(std::unique_ptr<parquet_ingestibl
                                                       bind.returned_types,
                                                       _plan->batch_position_by_column_id,
                                                       _plan->partition_primary_indices);
-    if (duckdb_expression) {
-      // Validate before scan tasks retranslate and dereference the predicate.
-      if (sirius::ast::from_duckdb(*duckdb_expression) == nullptr) {
-        throw duckdb::InvalidInputException(
-          "parquet scan: cannot evaluate pushed-down predicate on GPU: %s",
-          duckdb_expression->ToString());
+    if (duckdb_expression) { _duckdb_filter_expression = std::move(duckdb_expression); }
+
+    // Decode-time predicate pushdown: a pure-filter string column whose whole
+    // filter is an equality / IN can be delivered as a BOOL8 mask instead of
+    // values, letting a dictionary-compressed pin answer it off its key set
+    // rather than gathering the decoded chars. Restricted to pure-filter columns
+    // because the mask *replaces* the column — a projected one could not survive
+    // it. This only records what the scan is *willing* to accept; whether any
+    // given batch actually carries masks is decided per batch in
+    // post_filter_and_project.
+    if (_duckdb_filter_expression) {
+      auto candidates = sirius::op::extract_string_equality_pushdown(
+        *bind.table_filters, bind.column_ids, bind.returned_types);
+      for (auto const batch_pos : _plan->pure_filter_batch_positions()) {
+        auto const primary_idx = _plan->data_columns.at(batch_pos).primary_idx;
+        if (_plan->partition_primary_indices.count(primary_idx)) { continue; }
+        auto const it = candidates.find(primary_idx);
+        if (it == candidates.end()) { continue; }
+        _pushdown_primary_by_batch_position.emplace_back(batch_pos, primary_idx);
+        _decode_predicate_candidates.emplace(primary_idx, it->second);
       }
-      _duckdb_filter_expression = std::move(duckdb_expression);
     }
   }
 
@@ -543,7 +556,6 @@ std::unique_ptr<scan_info> parquet_gpu_ingestible::build_file_scan_info(
     };
     gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
     auto sirius_filter_ast = sirius::ast::from_duckdb(*_duckdb_filter_expression);
-    D_ASSERT(sirius_filter_ast != nullptr);
     ast_expression = translator.translate_expression_with_names(*sirius_filter_ast, name_resolver);
     if (ast_expression) { opts.set_filter(ast_expression->back()); }
   }
@@ -781,8 +793,7 @@ filtered_table parquet_gpu_ingestible::materialize_metadata_to_table(
 
   if (_duckdb_filter_expression && !split.disable_filter_pushdown && !all_slices_pruned) {
     auto sirius_filter_ast = sirius::ast::from_duckdb(*_duckdb_filter_expression);
-    D_ASSERT(sirius_filter_ast != nullptr);
-    auto name_resolver = [plan = split.plan](duckdb::idx_t ref_index) -> std::string {
+    auto name_resolver     = [plan = split.plan](duckdb::idx_t ref_index) -> std::string {
       return plan->batch_column_name(ref_index);
     };
     gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
@@ -841,6 +852,58 @@ filtered_table parquet_gpu_ingestible::materialize_metadata_to_table(
 }
 
 //===----------------------------------------------------------------------===//
+// build_filter_expression_for — the filter form that matches this batch
+//===----------------------------------------------------------------------===//
+// Which candidate columns were actually substituted is a per-batch, per-column
+// fact: only a source that can exploit the pushdown does it, and only for the
+// columns whose compression plan supports it. A GPU-tier pin answers a
+// dictionary column's equality from its key set but hands back a `str_split`
+// column as strings, and the same scan's disk splits substitute nothing — so the
+// batch's own column types are the only reliable signal. Deciding per column
+// (rather than all-or-nothing) keeps one ineligible candidate from disabling the
+// pushdown for an eligible sibling.
+//
+// Returns the prebuilt expression when nothing was substituted — the common
+// case, and the only one on a scan with no candidates. Otherwise rebuilds; the
+// expression is small, the rebuild is per batch (as `from_duckdb` already is),
+// and building fresh avoids any shared mutable state across pipeline threads.
+duckdb::unique_ptr<duckdb::Expression> parquet_gpu_ingestible::build_filter_expression_for(
+  cudf::table_view const& batch) const
+{
+  std::unordered_set<std::size_t> substituted;
+  for (auto const& [batch_pos, primary_idx] : _pushdown_primary_by_batch_position) {
+    if (batch_pos < static_cast<std::size_t>(batch.num_columns()) &&
+        batch.column(static_cast<cudf::size_type>(batch_pos)).type().id() == cudf::type_id::BOOL8) {
+      substituted.insert(primary_idx);
+    }
+  }
+  if (substituted.empty() || !_info->table_filters) { return nullptr; }
+
+  SIRIUS_LOG_DEBUG(
+    "[parquet_gpu_ingestible] {} of {} candidate column(s) arrived as a decode-time BOOL8 mask",
+    substituted.size(),
+    _pushdown_primary_by_batch_position.size());
+
+  auto expression =
+    sirius::op::convert_table_filters_to_expression(*_info->table_filters,
+                                                    _info->column_ids,
+                                                    _info->returned_types,
+                                                    _plan->batch_position_by_column_id,
+                                                    _plan->partition_primary_indices,
+                                                    substituted);
+  // A substituted column always contributes a bare boolean reference, so the
+  // conjunction cannot come back empty. If it somehow did, falling back to the
+  // unsubstituted form would compare a BOOL8 mask against a string constant —
+  // fail loudly rather than return a wrong row set.
+  if (!expression) {
+    throw sirius::internal_exception(
+      "[parquet_gpu_ingestible] decode-time predicate substitution produced no filter "
+      "expression; the batch carries BOOL8 masks the unsubstituted filter cannot read");
+  }
+  return expression;
+}
+
+//===----------------------------------------------------------------------===//
 // post_filter_and_project — post-decode filter + non-partition projection
 //===----------------------------------------------------------------------===//
 // Hive-partition scans are fully assembled in materialize_table (it owns the
@@ -861,7 +924,15 @@ std::unique_ptr<cudf::table> parquet_gpu_ingestible::post_filter_and_project(
   // borrows the AST.
   if (input.state != filter_state::ROW_FILTERED &&
       input.state != filter_state::ROW_FILTERED_AND_PROJECTED && _duckdb_filter_expression) {
-    auto sirius_filter_ast = sirius::ast::from_duckdb(*_duckdb_filter_expression);
+    // A decode-time predicate pushdown may have turned some pure-filter string
+    // columns into BOOL8 masks for this batch; if so the filter must reference
+    // the mask rather than re-compare. `rebuilt` owns the substituted form when
+    // one was needed and stays null otherwise. Both it and the prebuilt
+    // expression must outlive `exec`, which only borrows the AST.
+    auto rebuilt = build_filter_expression_for(input.table.view());
+    auto const& filter_expression =
+      rebuilt ? *rebuilt : static_cast<duckdb::Expression const&>(*_duckdb_filter_expression);
+    auto sirius_filter_ast = sirius::ast::from_duckdb(filter_expression);
     sirius::expression_evaluator exec(sirius_filter_ast.get(), mr_ref, stream);
     auto const data_positions = output_data_positions(*_plan);
     auto filtered             = data_positions.empty() ? exec.select(input.table.view())

--- a/src/op/scan/scan_utils.cpp
+++ b/src/op/scan/scan_utils.cpp
@@ -17,6 +17,9 @@
 // sirius
 #include <duckdb/planner/expression/bound_conjunction_expression.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <duckdb/planner/filter/conjunction_filter.hpp>
+#include <duckdb/planner/filter/constant_filter.hpp>
+#include <duckdb/planner/filter/in_filter.hpp>
 #include <expression/ast/from_duckdb.hpp>
 #include <helper/type_conversions.hpp>
 #include <log/logging.hpp>
@@ -54,12 +57,101 @@ std::vector<std::optional<std::size_t>> build_batch_column_map(
   return map;
 }
 
+namespace {
+
+/// Append @p value's string payload to @p out. False (leaving @p out untouched)
+/// for a null or non-VARCHAR constant: a null never equals anything, and a
+/// non-string constant means the filter is not the shape we can push down.
+bool append_string_constant(duckdb::Value const& value, std::vector<std::string>& out)
+{
+  if (value.IsNull() || value.type().id() != duckdb::LogicalTypeId::VARCHAR) { return false; }
+  out.push_back(duckdb::StringValue::Get(value));
+  return true;
+}
+
+/// Collect the value set @p filter tests for equality against, or false if it is
+/// any other shape. Recursive so `x = 'a' OR x = 'b'` and an ANDed IS NOT NULL
+/// both resolve.
+bool collect_equality_values(duckdb::TableFilter const& filter, std::vector<std::string>& out)
+{
+  switch (filter.filter_type) {
+    case duckdb::TableFilterType::CONSTANT_COMPARISON: {
+      auto const& cmp = filter.Cast<duckdb::ConstantFilter>();
+      if (cmp.comparison_type != duckdb::ExpressionType::COMPARE_EQUAL) { return false; }
+      return append_string_constant(cmp.constant, out);
+    }
+    case duckdb::TableFilterType::IN_FILTER: {
+      auto const& in = filter.Cast<duckdb::InFilter>();
+      if (in.values.empty()) { return false; }
+      for (auto const& value : in.values) {
+        if (!append_string_constant(value, out)) { return false; }
+      }
+      return true;
+    }
+    case duckdb::TableFilterType::CONJUNCTION_OR: {
+      // Every branch must contribute, or the union would under-approximate.
+      auto const& disjunction = filter.Cast<duckdb::ConjunctionOrFilter>();
+      if (disjunction.child_filters.empty()) { return false; }
+      for (auto const& child : disjunction.child_filters) {
+        if (!collect_equality_values(*child, out)) { return false; }
+      }
+      return true;
+    }
+    case duckdb::TableFilterType::CONJUNCTION_AND: {
+      // Only the redundant IS NOT NULL may accompany the equality: an equality
+      // against a non-null constant is already false/null for a null row, so
+      // absorbing it does not change which rows survive. Any other conjunct
+      // would narrow the result further than the value set describes.
+      auto const& conjunction = filter.Cast<duckdb::ConjunctionAndFilter>();
+      bool found              = false;
+      for (auto const& child : conjunction.child_filters) {
+        if (child->filter_type == duckdb::TableFilterType::IS_NOT_NULL) { continue; }
+        if (found) { return false; }  // two value-bearing conjuncts: not a plain equality
+        if (!collect_equality_values(*child, out)) { return false; }
+        found = true;
+      }
+      return found;
+    }
+    default: return false;
+  }
+}
+
+}  // namespace
+
+std::unordered_map<std::size_t, std::vector<std::string>> extract_string_equality_pushdown(
+  const duckdb::TableFilterSet& filters,
+  const duckdb::vector<duckdb::ColumnIndex>& column_ids,
+  const duckdb::vector<sirius::logical_type>& returned_types)
+{
+  std::unordered_map<std::size_t, std::vector<std::string>> result;
+  for (auto const& [column_index, filter] : filters.filters) {
+    if (!filter || column_index >= column_ids.size()) { continue; }
+    auto const& column_id = column_ids[column_index];
+    if (!column_id.HasPrimaryIndex() || column_id.IsRowIdColumn() || column_id.IsEmptyColumn() ||
+        column_id.IsVirtualColumn()) {
+      continue;
+    }
+    auto const primary_idx = static_cast<std::size_t>(column_id.GetPrimaryIndex());
+    if (primary_idx >= returned_types.size()) { continue; }
+    // Guard the column type as well as the constants: a non-VARCHAR column can
+    // never be answered by a string key comparison.
+    if (sirius::to_duckdb(returned_types[primary_idx]).id() != duckdb::LogicalTypeId::VARCHAR) {
+      continue;
+    }
+    std::vector<std::string> values;
+    if (!collect_equality_values(*filter, values) || values.empty()) { continue; }
+    result.emplace(primary_idx, std::move(values));
+  }
+  return result;
+}
+
 duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
   const duckdb::TableFilterSet& filters,
   const duckdb::vector<duckdb::ColumnIndex>& column_ids,
   const duckdb::vector<sirius::logical_type>& returned_types,
   const std::vector<std::optional<std::size_t>>& batch_position_by_column_id,
-  const std::unordered_set<std::size_t>& skip_primary_indices)
+  const std::unordered_set<std::size_t>& skip_primary_indices,
+  const std::unordered_set<std::size_t>& boolean_substituted_primary_indices)
 {
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> filter_expressions;
 
@@ -93,6 +185,20 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
     auto const batch_column_index = static_cast<duckdb::idx_t>(*batch_pos);
 
     SIRIUS_LOG_DEBUG("TABLE_SCAN filter: batch_column_index={}", batch_column_index);
+
+    // The column already carries this filter's answer as a BOOL8 mask (the
+    // predicate was resolved during decompression), so the batch column IS the
+    // conjunct — re-expressing the comparison would compare against a mask.
+    if (boolean_substituted_primary_indices.count(primary_idx)) {
+      SIRIUS_LOG_DEBUG(
+        "TABLE_SCAN filter: primary_idx={} substituted by a decode-time BOOL8 mask at batch "
+        "position {}",
+        primary_idx,
+        batch_column_index);
+      filter_expressions.push_back(duckdb::make_uniq<duckdb::BoundReferenceExpression>(
+        duckdb::LogicalType::BOOLEAN, batch_column_index));
+      continue;
+    }
 
     auto column_ref = duckdb::make_uniq<duckdb::BoundReferenceExpression>(
       sirius::to_duckdb(col_type), batch_column_index);

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -16,6 +16,7 @@
 
 #include "scan_manager/sirius_scan_manager.hpp"
 
+#include "compression/device_compressed_blob.hpp"
 #include "data/data_batch_utils.hpp"
 #include "exec/thread_pool.hpp"
 #include "io/cache/prefetching_cache.hpp"
@@ -48,6 +49,7 @@
 
 #include <rmm/cuda_device.hpp>
 
+#include <api/simpatico_codegen.hpp>
 #include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 #include <cucascade/memory/memory_reservation_manager.hpp>
@@ -76,12 +78,14 @@ struct cached_databatch_provider : public databatch_provider {
                             cached_scan_plan plan,
                             const telemetry::batch_telemetry_info& telemetry_info,
                             mvcc_chunk_mask_set mvcc_masks,
-                            std::vector<insert_delta_split> delta_splits)
+                            std::vector<insert_delta_split> delta_splits,
+                            sirius::decode_equality_pushdown equality_pushdown)
     : _plan(std::move(plan)),
       _entry(entry),
       _telemetry_info(telemetry_info),
       _mvcc_masks(std::move(mvcc_masks)),
-      _delta_splits(std::move(delta_splits))
+      _delta_splits(std::move(delta_splits)),
+      _equality_pushdown(std::move(equality_pushdown))
   {
     auto const& entry_column_names = _entry.cache_info.column_names();
     std::ranges::for_each(selected_columns, [this, &entry_column_names](size_t idx) {
@@ -149,6 +153,24 @@ struct cached_databatch_provider : public databatch_provider {
         // Hand out the projected compressed chunk; decompressed on demand by
         // scan_operator_input::prepare_for_processing.
         auto projected = chunk.compressed->select_columns(_column_indices);
+        // Attach the scan's equality pushdown to this projection only — never to
+        // the shared pinned chunk, which other queries filter differently.
+        // Restricted to columns whose plan can answer a predicate off its
+        // compressed form (a dictionary root); pushing into any other plan is
+        // correct but only moves the comparison, so leave those alone and keep
+        // this a strict no-op for them.
+        if (!_equality_pushdown.empty()) {
+          auto const& ct = chunk.compressed->table();
+          sirius::decode_equality_pushdown chunk_pushdown(_column_indices.size());
+          bool any = false;
+          for (std::size_t i = 0; i < _column_indices.size(); ++i) {
+            if (i >= _equality_pushdown.size() || _equality_pushdown[i].empty()) { continue; }
+            if (!simpatico::column_supports_predicate_decode(ct, _column_indices[i])) { continue; }
+            chunk_pushdown[i] = _equality_pushdown[i];
+            any               = true;
+          }
+          if (any) { projected->set_equality_pushdown(std::move(chunk_pushdown)); }
+        }
         return cucascade::data_batch::make(get_next_batch_id(), std::move(projected));
       }
       // Uncompressed chunk: project the requested columns (positions into the
@@ -198,6 +220,11 @@ struct cached_databatch_provider : public databatch_provider {
   cached_scan_plan _plan;
   std::vector<std::string> _column_names;
   std::vector<size_t> _column_indices;
+  /// Parallel to @c _column_indices; empty entries decompress normally. Only the
+  /// GPU-tier compressed path consumes it (the host path would have to parse the
+  /// chunk header to know whether the plan can exploit it, and that tier is not
+  /// where the decode gather costs anything).
+  sirius::decode_equality_pushdown _equality_pushdown;
   const pinned_entry& _entry;
   telemetry::batch_telemetry_info _telemetry_info;
   /// This provider's own copy of the entry's per-chunk keep-masks (empty for
@@ -208,6 +235,31 @@ struct cached_databatch_provider : public databatch_provider {
   std::vector<insert_delta_split> _delta_splits;
   std::atomic<std::size_t> _index{0};
 };
+
+/// Map the scan's decode-predicate candidates (keyed by column primary index)
+/// onto @p selected_columns, which are positions in the pinned entry's column
+/// list. Returns a vector parallel to @p selected_columns, empty when the scan
+/// offers nothing this entry carries.
+sirius::decode_equality_pushdown build_equality_pushdown(
+  pinned_entry const& entry,
+  std::span<std::size_t const> selected_columns,
+  std::unordered_map<std::size_t, std::vector<std::string>> const& candidates)
+{
+  if (candidates.empty()) { return {}; }
+  sirius::decode_equality_pushdown pushdown(selected_columns.size());
+  bool any = false;
+  for (std::size_t i = 0; i < selected_columns.size(); ++i) {
+    auto const entry_pos = selected_columns[i];
+    if (entry_pos >= entry.cache_info.column_ids.size()) { continue; }
+    auto const primary_idx =
+      static_cast<std::size_t>(entry.cache_info.column_ids[entry_pos].GetPrimaryIndex());
+    auto const it = candidates.find(primary_idx);
+    if (it == candidates.end()) { continue; }
+    pushdown[i] = it->second;
+    any         = true;
+  }
+  return any ? pushdown : sirius::decode_equality_pushdown{};
+}
 
 /// Filter view extracted from the scan's ingestible info: the pushed-down TableFilterSet plus the
 /// scan's column_ids its keys index into.
@@ -523,12 +575,19 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
           delta_request->plan.delta_rows());
       }
     }
+    // Columns the scan will only ever test for equality and never project can be
+    // decompressed straight to a BOOL8 mask (see decode_predicate_candidates).
+    auto equality_pushdown =
+      build_equality_pushdown(*assignment.entry,
+                              assignment.columns,
+                              assignment.op->get_ingestible().decode_predicate_candidates());
     auto provider = make_provider_for_pinned_entry(*assignment.entry,
                                                    assignment.columns,
                                                    std::move(assignment.plan),
                                                    assignment.op->batch_telemetry(),
                                                    std::move(masks),
-                                                   std::move(delta_splits));
+                                                   std::move(delta_splits),
+                                                   std::move(equality_pushdown));
     _metadata_processor->use_cached_entries_for_pipeline(assignment.op, std::move(provider));
   }
   _pending_mvcc_mask_jobs.clear();
@@ -545,6 +604,35 @@ void sirius_scan_manager::start_metadata_processing()
     if (it == _providers_by_op.end()) { continue; }
     it->second->run(*_dispatcher, _metadata_processor->get_split_provider_bridge(op));
   }
+  maybe_start_memory_prefetcher();
+}
+
+void sirius_scan_manager::maybe_start_memory_prefetcher()
+{
+  const auto& cfg = _config.memory_prefetcher;
+  if (!cfg.enable) { return; }
+
+  // Prototype scope: a single GPU space. Multi-GPU needs the task creator's
+  // NUMA-locality derivation to pick the per-batch target device; converting
+  // to the wrong space would strand data cross-device.
+  auto gpu_spaces = _reservation_manager.get_memory_spaces_for_tier(cucascade::memory::Tier::GPU);
+  if (gpu_spaces.size() != 1) {
+    SIRIUS_LOG_WARN(
+      "[memory_prefetcher] disabled: prototype supports exactly 1 GPU space (found {})",
+      gpu_spaces.size());
+    return;
+  }
+  auto* gpu_space = _reservation_manager.get_memory_space(cucascade::memory::Tier::GPU,
+                                                          gpu_spaces.front()->get_device_id());
+  if (gpu_space == nullptr) { return; }
+
+  std::vector<std::shared_ptr<split_connector>> connectors;
+  connectors.reserve(_scan_op_order.size());
+  for (auto* op : _scan_op_order) {
+    connectors.push_back(op->get_shared_split_connector());
+  }
+
+  _prefetcher = std::make_unique<memory_prefetcher>(cfg, std::move(connectors), gpu_space);
 }
 
 std::shared_ptr<sirius::io::sirius_datasource> sirius_scan_manager::create_datasource(
@@ -659,6 +747,9 @@ std::shared_ptr<sirius::io::sirius_ioctx> sirius_scan_manager::ioctx_for_path(st
 
 void sirius_scan_manager::reset()
 {
+  // Stop the prefetcher first: it holds shared_ptrs to the operators'
+  // connectors and must not convert batches while per-query state is torn down.
+  _prefetcher.reset();
   _dispatcher->request_stop();
   _dispatcher->wait_for_all();
   _scan_op_order.clear();
@@ -1210,14 +1301,16 @@ std::unique_ptr<databatch_provider> make_provider_for_pinned_entry(
   cached_scan_plan plan,
   const telemetry::batch_telemetry_info& telemetry_info,
   mvcc_chunk_mask_set mvcc_masks,
-  std::vector<insert_delta_split> delta_splits)
+  std::vector<insert_delta_split> delta_splits,
+  sirius::decode_equality_pushdown equality_pushdown)
 {
   return std::make_unique<cached_databatch_provider>(entry,
                                                      selected_columns,
                                                      std::move(plan),
                                                      telemetry_info,
                                                      std::move(mvcc_masks),
-                                                     std::move(delta_splits));
+                                                     std::move(delta_splits),
+                                                     std::move(equality_pushdown));
 }
 
 cached_scan_plan build_cached_scan_plan(pinned_entry const& entry,

--- a/test/cpp/compression/test_compression.cpp
+++ b/test/cpp/compression/test_compression.cpp
@@ -395,6 +395,187 @@ TEST_CASE("pin_table compression - device tier column-subset projection correctn
   fs::remove_all(tmp);
 }
 
+// ─── Decode-time predicate pushdown ──────────────────────────────────────────
+//
+// The TPC-H q19 shape: a low-cardinality string column that is only ever
+// equality-tested and never projected. On a GPU-tier dictionary pin the scan
+// hands the predicate to decompression, which answers it against the four-entry
+// key set and returns a BOOL8 mask instead of gathering the decoded chars. The
+// observable contract is that the answer does not change — including for the
+// shapes that must decline the substitution.
+
+TEST_CASE("pin_table compression - dictionary predicate pushdown preserves results",
+          "[compression][pin_table][isolated_context]")
+{
+  if (no_gpu()) { return; }
+
+  auto [tmp, yaml_path] = make_comp_env("dictpred");
+
+  // Four distinct labels over 5000 rows, mirroring l_shipinstruct. Rows with
+  // s = 'DELIVER IN PERSON' are range % 4 == 0 (1250 rows) and carry
+  // v = range * 2, so SUM(v) = 2 * 4 * (0 + 1 + ... + 1249) = 6245000.
+  sirius::test::mgpu::generate_parquet_surface(
+    tmp,
+    "SELECT CASE range % 4 WHEN 0 THEN 'DELIVER IN PERSON' WHEN 1 THEN 'COLLECT COD' "
+    "WHEN 2 THEN 'NONE' ELSE 'TAKE BACK RETURN' END AS s, range * 2 AS v FROM range(5000)",
+    1);
+
+  sirius::test::mgpu::scoped_mgpu_env env(yaml_path);
+  auto con  = env.make_connection();
+  auto glob = sirius::test::mgpu::parquet_glob(tmp);
+
+  run_ok(con, "SET pin_table_compression = true;", "set compression");
+  run_ok(con, "SET pin_table_compression_min_batch_size_bytes = 0;", "set min_batch");
+
+  auto plan_dir = tmp / "plans";
+  // The exact l_shipinstruct plan from the SF1000 lineitem plan file — depth 3,
+  // with both keys_offsets and indices bitpacked — so the interception is
+  // exercised against the shape production actually decodes, where the indices
+  // reach the dictionary rep from a JIT bitpack inverse rather than raw storage.
+  // v stays raw so it can be summed.
+  write_plan_file(plan_dir,
+                  "t_dictpred",
+                  "input -> dictionary -> keys_offsets, keys_chars, indices\n"
+                  "dictionary.keys_offsets -> bitpack -> chunk_min, chunk_count, chunk_bits, "
+                  "packed\n"
+                  "dictionary.indices -> bitpack -> chunk_min, chunk_count, chunk_bits, packed\n"
+                  "---\ninput -> identity\n");
+  run_ok(
+    con, "SET pin_table_input_compression_plan_dir = '" + plan_dir.string() + "';", "set plan_dir");
+
+  auto pin = con.Query("CALL pin_table('" + glob + "', tier='gpu', name='t_dictpred');");
+  require_ok(pin, "pin dictpred");
+
+  // s is filter-only — never in the select list — so the scan may replace it
+  // with the decode-time mask. This is the case the optimization exists for.
+  auto eq = con.Query("CALL gpu_execution(\"SELECT SUM(v) FROM read_parquet('" + glob +
+                      "') WHERE s = 'DELIVER IN PERSON'\");");
+  require_ok(eq, "equality pushdown");
+  REQUIRE(eq->RowCount() == 1);
+  REQUIRE(eq->GetValue(0, 0) == duckdb::Value::BIGINT(6245000LL));
+
+  // IN over two keys exercises the multi-value LUT: range % 4 in {0, 2} →
+  // SUM(v) = 2 * ((0+4+...+4996) + (2+6+...+4998)) = 2 * (3122500 + 3125000).
+  auto in_res = con.Query("CALL gpu_execution(\"SELECT SUM(v) FROM read_parquet('" + glob +
+                          "') WHERE s IN ('DELIVER IN PERSON', 'NONE')\");");
+  require_ok(in_res, "in pushdown");
+  REQUIRE(in_res->RowCount() == 1);
+  REQUIRE(in_res->GetValue(0, 0) == duckdb::Value::BIGINT(12495000LL));
+
+  // A *projected* dictionary column must not be substituted — the mask would
+  // replace the very values the query selects.
+  auto proj = con.Query("CALL gpu_execution(\"SELECT COUNT(s), MIN(s) FROM read_parquet('" + glob +
+                        "') WHERE s = 'DELIVER IN PERSON'\");");
+  require_ok(proj, "projected dictionary column");
+  REQUIRE(proj->RowCount() == 1);
+  REQUIRE(proj->GetValue(0, 0) == duckdb::Value::BIGINT(1250LL));
+  REQUIRE(proj->GetValue(1, 0).ToString() == "DELIVER IN PERSON");
+
+  // A non-equality filter is not a candidate and must still evaluate normally.
+  auto ne = con.Query("CALL gpu_execution(\"SELECT COUNT(*) FROM read_parquet('" + glob +
+                      "') WHERE s <> 'DELIVER IN PERSON'\");");
+  require_ok(ne, "inequality falls back");
+  REQUIRE(ne->RowCount() == 1);
+  REQUIRE(ne->GetValue(0, 0) == duckdb::Value::BIGINT(3750LL));
+
+  run_ok(con, "CALL unpin_table('t_dictpred');", "unpin dictpred");
+
+  fs::remove_all(tmp);
+}
+
+TEST_CASE("pin_table compression - predicate pushdown mixes substituted and decoded columns",
+          "[compression][pin_table][isolated_context]")
+{
+  if (no_gpu()) { return; }
+
+  auto [tmp, yaml_path] = make_comp_env("dictpredmix");
+
+  // The literal q19 shape: two filter-only string columns, only one of which a
+  // dictionary can answer. l_shipinstruct-alike `s` is dictionary-compressed and
+  // substitutes; l_shipmode-alike `m` is str_split and must still be decoded and
+  // compared. Rows matching both are range % 12 == 0 (417 rows), v = range * 2 →
+  // SUM(v) = 2081664. This is the case that would break if one ineligible
+  // candidate disabled the pushdown for its eligible sibling.
+  sirius::test::mgpu::generate_parquet_surface(
+    tmp,
+    "SELECT CASE range % 4 WHEN 0 THEN 'DELIVER IN PERSON' WHEN 1 THEN 'COLLECT COD' "
+    "WHEN 2 THEN 'NONE' ELSE 'TAKE BACK RETURN' END AS s, "
+    "CASE range % 3 WHEN 0 THEN 'AIR' WHEN 1 THEN 'RAIL' ELSE 'SHIP' END AS m, "
+    "range * 2 AS v FROM range(5000)",
+    1);
+
+  sirius::test::mgpu::scoped_mgpu_env env(yaml_path);
+  auto con  = env.make_connection();
+  auto glob = sirius::test::mgpu::parquet_glob(tmp);
+
+  run_ok(con, "SET pin_table_compression = true;", "set compression");
+  run_ok(con, "SET pin_table_compression_min_batch_size_bytes = 0;", "set min_batch");
+
+  auto plan_dir = tmp / "plans";
+  write_plan_file(plan_dir,
+                  "t_dictpred_mix",
+                  "input -> dictionary\n---\ninput -> str_split -> offsets, chars\n---\ninput -> "
+                  "identity\n");
+  run_ok(
+    con, "SET pin_table_input_compression_plan_dir = '" + plan_dir.string() + "';", "set plan_dir");
+
+  auto pin = con.Query("CALL pin_table('" + glob + "', tier='gpu', name='t_dictpred_mix');");
+  require_ok(pin, "pin mixed");
+
+  auto res = con.Query("CALL gpu_execution(\"SELECT SUM(v) FROM read_parquet('" + glob +
+                       "') WHERE s = 'DELIVER IN PERSON' AND m = 'AIR'\");");
+  require_ok(res, "mixed substitution");
+  REQUIRE(res->RowCount() == 1);
+  REQUIRE(res->GetValue(0, 0) == duckdb::Value::BIGINT(2081664LL));
+
+  run_ok(con, "CALL unpin_table('t_dictpred_mix');", "unpin mixed");
+
+  fs::remove_all(tmp);
+}
+
+TEST_CASE("pin_table compression - predicate pushdown declines a non-dictionary plan",
+          "[compression][pin_table][isolated_context]")
+{
+  if (no_gpu()) { return; }
+
+  auto [tmp, yaml_path] = make_comp_env("dictpredfb");
+
+  // str_split cannot answer a predicate from its compressed form, so the scan
+  // must decode and compare as before. Same 1250-matching-row surface:
+  // SUM(v) = 6245000.
+  sirius::test::mgpu::generate_parquet_surface(
+    tmp,
+    "SELECT CASE range % 4 WHEN 0 THEN 'AIR' WHEN 1 THEN 'RAIL' WHEN 2 THEN 'SHIP' "
+    "ELSE 'TRUCK' END AS s, range * 2 AS v FROM range(5000)",
+    1);
+
+  sirius::test::mgpu::scoped_mgpu_env env(yaml_path);
+  auto con  = env.make_connection();
+  auto glob = sirius::test::mgpu::parquet_glob(tmp);
+
+  run_ok(con, "SET pin_table_compression = true;", "set compression");
+  run_ok(con, "SET pin_table_compression_min_batch_size_bytes = 0;", "set min_batch");
+
+  auto plan_dir = tmp / "plans";
+  write_plan_file(
+    plan_dir, "t_dictpred_fb", "input -> str_split -> offsets, chars\n---\ninput -> identity\n");
+  run_ok(
+    con, "SET pin_table_input_compression_plan_dir = '" + plan_dir.string() + "';", "set plan_dir");
+
+  auto pin = con.Query("CALL pin_table('" + glob + "', tier='gpu', name='t_dictpred_fb');");
+  require_ok(pin, "pin fallback");
+
+  auto res = con.Query("CALL gpu_execution(\"SELECT SUM(v) FROM read_parquet('" + glob +
+                       "') WHERE s = 'AIR'\");");
+  require_ok(res, "str_split fallback");
+  REQUIRE(res->RowCount() == 1);
+  REQUIRE(res->GetValue(0, 0) == duckdb::Value::BIGINT(6245000LL));
+
+  run_ok(con, "CALL unpin_table('t_dictpred_fb');", "unpin fallback");
+
+  fs::remove_all(tmp);
+}
+
 TEST_CASE("pin_table compression - column-subset projection correctness",
           "[compression][pin_table][isolated_context]")
 {


### PR DESCRIPTION
A dictionary-compressed column consumed only by an equality/IN filter no longer
materialises its decoded STRING column. The predicate is resolved against the
dictionary's key set -- four entries for TPC-H l_shipinstruct -- and mapped over the
already-decoded INT32 indices, producing a BOOL8 mask. cudf::dictionary::decode, the
~287 GB/s gather over the key chars, never runs.

Source to sink:
- simpatico::decode_predicate is a set-membership directive threaded through
  decompress(). DecodeWalk offers it to the node producing the column's final value;
  dictionary_compressed_representation::decompress_predicate answers it off the keys.
  Contract: an active directive ALWAYS yields BOOL8, including on the generic
  decode-then-compare fallback, so a caller that rewrote its filter is never surprised
  by a plan shape.
- parquet_gpu_ingestible advertises candidates: columns whose entire pushed-down filter
  is an equality/IN over string constants AND which are never projected (the mask
  replaces the values, so a projected column cannot survive it).
- sirius_scan_manager attaches the pushdown to the per-scan projection of a GPU-tier
  compressed chunk -- never the shared pinned chunk -- and only for dictionary-rooted
  plans, keeping this a strict no-op elsewhere.
- post_filter_and_project reads each batch's actual column types to decide which
  candidates were substituted. Deciding per column matters: q19 filters both
  l_shipinstruct (dictionary, substitutes) and l_shipmode (str_split, declines).

Measured on TPC-H SF1000 (GB300): q19 -21.4% in-suite, and 0.316 s vs 0.509 s standalone
against an uncompressed 'identity' plan for the same column -- i.e. it beats the
uncompressed arm outright while also keeping 78.6 GB of compression. 22/22 byte-identical.

Scoped to the GPU tier: a host pin would have to parse the chunk header to know whether
the plan can exploit the directive, and that tier is not where the decode gather costs
anything.

NOTE: includes scan-path changes from joosthooz's in-flight PRs (#1341/#1342/#1357),
which this builds on and which are not yet on dev.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
