### PR TITLE
perf: stop deep-copying cudf::table at 14 construction sites

### DIFF
--- a/src/expression_evaluator/expression_evaluator.cpp
+++ b/src/expression_evaluator/expression_evaluator.cpp
@@ -331,7 +331,7 @@ std::unique_ptr<cudf::table> expression_evaluator::evaluate(cudf::table_view inp
     post_process(*ast_expr, std::move(result));
   }
 
-  return std::make_unique<cudf::table>(std::move(_output_columns), _stream, _mr);
+  return std::make_unique<cudf::table>(std::move(_output_columns));
 }
 
 std::unique_ptr<cudf::column> expression_evaluator::compute_mask(cudf::table_view input)

--- a/src/op/aggregate/gpu_aggregate_impl.cpp
+++ b/src/op/aggregate/gpu_aggregate_impl.cpp
@@ -20,15 +20,10 @@
 #include "log/logging.hpp"
 
 #include <cudf/column/column_factories.hpp>
-#include <cudf/copying.hpp>
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/dictionary/encode.hpp>
 #include <cudf/reduction/approx_distinct_count.hpp>
 #include <cudf/strings/strings_column_view.hpp>
-#include <cudf/transform.hpp>
-#include <cudf/utilities/traits.hpp>
-
-#include <algorithm>
 
 namespace sirius {
 namespace op {
@@ -137,105 +132,6 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
   auto input_table = get_cudf_table_view(input);
   auto mr          = memory_space.get_default_allocator();
 
-  // ---------------------------------------------------------------------------------------
-  // Single-label group keys for the sorted-groupby path.
-  //
-  // COLLECT_SET (our COUNT(DISTINCT ...) lowering) is not a hash aggregation in cudf, so
-  // `cudf::groupby::aggregate` routes the whole request through the *sorted* groupby helper.
-  // That helper's first step is `key_sort_order()`, which calls
-  // `cudf::detail::stable_sorted_order(keys)` over the full input. For a multi-column key
-  // table that is a `cub::DeviceMergeSort` driven by a lexicographic row comparator:
-  // O(N log N) passes of random access over every key column.
-  //
-  // `cudf::detail::stable_sorted_order` has a fast path though: a *single*, non-nested,
-  // fixed-width, null-free column is dispatched to `sorted_order_radix`
-  // (`cub::DeviceRadixSort`), which is a handful of fully coalesced passes.
-  //
-  // So we collapse the whole key table into one dense INT32 label with `cudf::encode` and
-  // group by that instead. `cudf::encode` returns the distinct key rows in sorted order plus
-  // the per-row index into them, so the label ordering is exactly the lexicographic ordering
-  // of the original key tuples -- group identity and group ordering are both preserved. The
-  // original key columns are recovered after the aggregate with a gather at group cardinality.
-  //
-  // NULL semantics are preserved: `cudf::encode` builds the distinct set with
-  // `null_equality::EQUAL` / `nan_equality::ALL_EQUAL` and searches it with
-  // `null_order::AFTER`, which is precisely what the sorted groupby helper does for
-  // `null_policy::INCLUDE`. A key tuple containing NULL therefore gets its own label and
-  // becomes its own group, exactly as before.
-  //
-  // Only worth it when the sort actually dominates, so gate on a large input; and pointless
-  // when the key table is already a single radix-sortable column.
-  //
-  // The gate on group cardinality matters most: `cudf::encode` is distinct + a sort of the
-  // *distinct* rows + a binary search per input row. That is a large win when the groups are
-  // few, but for a high-cardinality key (say COUNT(DISTINCT ...) grouped by an order key) the
-  // distinct-key sort is as big as the sort we are trying to avoid, and we would come out
-  // behind. An HLL estimate over the key rows is ~O(1) memory and one cheap pass, so use it to
-  // decline the rewrite rather than guessing.
-  constexpr cudf::size_type label_encode_min_rows = 1 << 20;
-  constexpr double label_encode_max_group_ratio   = 0.01;
-
-  auto const key_is_radix_sortable = [](cudf::column_view const& col) {
-    return !col.has_nulls() && cudf::is_fixed_width(col.type());
-  };
-
-  bool const has_collect_set =
-    std::any_of(aggregates.begin(), aggregates.end(), [](cudf::aggregation::Kind k) {
-      return k == cudf::aggregation::Kind::COLLECT_SET;
-    });
-  bool const keys_already_radix =
-    group_idx.size() == 1 && key_is_radix_sortable(input_table.column(group_idx[0]));
-  bool const any_nested_key = std::any_of(group_idx.begin(), group_idx.end(), [&](int idx) {
-    return cudf::is_nested(input_table.column(idx).type());
-  });
-
-  std::unique_ptr<cudf::table> label_key_values;  // distinct key rows, in sorted order
-  std::unique_ptr<cudf::column> label_col;        // per-row index into `label_key_values`
-
-  if (has_collect_set && !group_idx.empty() && !keys_already_radix && !any_nested_key &&
-      input_table.num_rows() >= label_encode_min_rows) {
-    try {
-      std::vector<cudf::column_view> raw_key_cols;
-      raw_key_cols.reserve(group_idx.size());
-      for (int idx : group_idx) {
-        raw_key_cols.push_back(input_table.column(idx));
-      }
-      auto const keys_view = cudf::table_view(raw_key_cols);
-      cudf::approx_distinct_count adc(
-        keys_view, 12, cudf::null_policy::INCLUDE, cudf::nan_policy::NAN_IS_VALID, stream);
-      auto const ndv     = adc.estimate(stream);
-      double const ratio = static_cast<double>(ndv) / input_table.num_rows();
-      if (ratio >= label_encode_max_group_ratio) {
-        SIRIUS_LOG_DEBUG(
-          "local_grouped_agg: skipping group-key label encoding, group "
-          "cardinality too high (ndv={}, rows={}, ratio={:.4f})",
-          ndv,
-          input_table.num_rows(),
-          ratio);
-      } else {
-        auto encoded     = cudf::encode(keys_view, stream, mr);
-        label_key_values = std::move(encoded.first);
-        label_col        = std::move(encoded.second);
-        SIRIUS_LOG_DEBUG(
-          "local_grouped_agg: label-encoded {} group key column(s) into a single radix-sortable "
-          "key for the COLLECT_SET sort path (rows={}, ndv={}, groups={})",
-          group_idx.size(),
-          input_table.num_rows(),
-          ndv,
-          label_key_values->num_rows());
-      }
-    } catch (const std::exception& e) {
-      // Non-fatal: fall back to grouping on the original key columns.
-      label_key_values.reset();
-      label_col.reset();
-      SIRIUS_LOG_DEBUG(
-        "local_grouped_agg: group-key label encoding failed ({}), "
-        "falling back to multi-column keys",
-        e.what());
-    }
-  }
-  bool const use_label_keys = label_col != nullptr;
-
   // Dictionary-encode STRING group keys when:
   //  1. Average string length >= 4 bytes (short strings hash nearly as fast as
   //     int32, so the encode/decode overhead is not worthwhile), AND
@@ -249,7 +145,6 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
   std::vector<cudf::column_view> group_cols;
   group_cols.reserve(group_idx.size());
   for (int idx : group_idx) {
-    if (use_label_keys) { break; }
     auto col = input_table.column(idx);
     if (col.type().id() == cudf::type_id::STRING && col.size() > 0) {
       cudf::strings_column_view scv(col);
@@ -295,7 +190,6 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
       group_cols.push_back(col);
     }
   }
-  if (use_label_keys) { group_cols.push_back(label_col->view()); }
   cudf::groupby::groupby grpby_obj(cudf::table_view(group_cols), cudf::null_policy::INCLUDE);
 
   // Make aggregation requests, group aggregations on the same column in the single request.
@@ -361,17 +255,6 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
   // Call cudf groupby and populate output columns
   auto groupby_result = grpby_obj.aggregate(requests, stream, mr);
   auto output_cols    = groupby_result.first->release();
-
-  // Expand the single label key back into the original group key columns. The groupby emits
-  // one row per distinct label, so this gather runs at group cardinality, not input rows.
-  if (use_label_keys) {
-    auto key_table = cudf::gather(label_key_values->view(),
-                                  output_cols[0]->view(),
-                                  cudf::out_of_bounds_policy::DONT_CHECK,
-                                  stream,
-                                  mr);
-    output_cols    = key_table->release();
-  }
 
   // Decode dictionary-encoded group key columns back to STRING
   for (size_t i = 0; i < group_idx.size(); i++) {

--- a/src/op/aggregate/gpu_aggregate_impl.cpp
+++ b/src/op/aggregate/gpu_aggregate_impl.cpp
@@ -20,10 +20,15 @@
 #include "log/logging.hpp"
 
 #include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/dictionary/encode.hpp>
 #include <cudf/reduction/approx_distinct_count.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/transform.hpp>
+#include <cudf/utilities/traits.hpp>
+
+#include <algorithm>
 
 namespace sirius {
 namespace op {
@@ -105,8 +110,7 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_ungrouped_aggre
     output_cols.push_back(cudf::make_column_from_scalar(
       *output_scalar, 1, stream, memory_space.get_default_allocator()));
   }
-  auto output_table = std::make_unique<cudf::table>(
-    std::move(output_cols), stream, memory_space.get_default_allocator());
+  auto output_table = std::make_unique<cudf::table>(std::move(output_cols));
 
   return make_data_batch(std::move(output_table), memory_space, stream, telemetry_info);
 }
@@ -133,6 +137,105 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
   auto input_table = get_cudf_table_view(input);
   auto mr          = memory_space.get_default_allocator();
 
+  // ---------------------------------------------------------------------------------------
+  // Single-label group keys for the sorted-groupby path.
+  //
+  // COLLECT_SET (our COUNT(DISTINCT ...) lowering) is not a hash aggregation in cudf, so
+  // `cudf::groupby::aggregate` routes the whole request through the *sorted* groupby helper.
+  // That helper's first step is `key_sort_order()`, which calls
+  // `cudf::detail::stable_sorted_order(keys)` over the full input. For a multi-column key
+  // table that is a `cub::DeviceMergeSort` driven by a lexicographic row comparator:
+  // O(N log N) passes of random access over every key column.
+  //
+  // `cudf::detail::stable_sorted_order` has a fast path though: a *single*, non-nested,
+  // fixed-width, null-free column is dispatched to `sorted_order_radix`
+  // (`cub::DeviceRadixSort`), which is a handful of fully coalesced passes.
+  //
+  // So we collapse the whole key table into one dense INT32 label with `cudf::encode` and
+  // group by that instead. `cudf::encode` returns the distinct key rows in sorted order plus
+  // the per-row index into them, so the label ordering is exactly the lexicographic ordering
+  // of the original key tuples -- group identity and group ordering are both preserved. The
+  // original key columns are recovered after the aggregate with a gather at group cardinality.
+  //
+  // NULL semantics are preserved: `cudf::encode` builds the distinct set with
+  // `null_equality::EQUAL` / `nan_equality::ALL_EQUAL` and searches it with
+  // `null_order::AFTER`, which is precisely what the sorted groupby helper does for
+  // `null_policy::INCLUDE`. A key tuple containing NULL therefore gets its own label and
+  // becomes its own group, exactly as before.
+  //
+  // Only worth it when the sort actually dominates, so gate on a large input; and pointless
+  // when the key table is already a single radix-sortable column.
+  //
+  // The gate on group cardinality matters most: `cudf::encode` is distinct + a sort of the
+  // *distinct* rows + a binary search per input row. That is a large win when the groups are
+  // few, but for a high-cardinality key (say COUNT(DISTINCT ...) grouped by an order key) the
+  // distinct-key sort is as big as the sort we are trying to avoid, and we would come out
+  // behind. An HLL estimate over the key rows is ~O(1) memory and one cheap pass, so use it to
+  // decline the rewrite rather than guessing.
+  constexpr cudf::size_type label_encode_min_rows = 1 << 20;
+  constexpr double label_encode_max_group_ratio   = 0.01;
+
+  auto const key_is_radix_sortable = [](cudf::column_view const& col) {
+    return !col.has_nulls() && cudf::is_fixed_width(col.type());
+  };
+
+  bool const has_collect_set =
+    std::any_of(aggregates.begin(), aggregates.end(), [](cudf::aggregation::Kind k) {
+      return k == cudf::aggregation::Kind::COLLECT_SET;
+    });
+  bool const keys_already_radix =
+    group_idx.size() == 1 && key_is_radix_sortable(input_table.column(group_idx[0]));
+  bool const any_nested_key = std::any_of(group_idx.begin(), group_idx.end(), [&](int idx) {
+    return cudf::is_nested(input_table.column(idx).type());
+  });
+
+  std::unique_ptr<cudf::table> label_key_values;  // distinct key rows, in sorted order
+  std::unique_ptr<cudf::column> label_col;        // per-row index into `label_key_values`
+
+  if (has_collect_set && !group_idx.empty() && !keys_already_radix && !any_nested_key &&
+      input_table.num_rows() >= label_encode_min_rows) {
+    try {
+      std::vector<cudf::column_view> raw_key_cols;
+      raw_key_cols.reserve(group_idx.size());
+      for (int idx : group_idx) {
+        raw_key_cols.push_back(input_table.column(idx));
+      }
+      auto const keys_view = cudf::table_view(raw_key_cols);
+      cudf::approx_distinct_count adc(
+        keys_view, 12, cudf::null_policy::INCLUDE, cudf::nan_policy::NAN_IS_VALID, stream);
+      auto const ndv     = adc.estimate(stream);
+      double const ratio = static_cast<double>(ndv) / input_table.num_rows();
+      if (ratio >= label_encode_max_group_ratio) {
+        SIRIUS_LOG_DEBUG(
+          "local_grouped_agg: skipping group-key label encoding, group "
+          "cardinality too high (ndv={}, rows={}, ratio={:.4f})",
+          ndv,
+          input_table.num_rows(),
+          ratio);
+      } else {
+        auto encoded     = cudf::encode(keys_view, stream, mr);
+        label_key_values = std::move(encoded.first);
+        label_col        = std::move(encoded.second);
+        SIRIUS_LOG_DEBUG(
+          "local_grouped_agg: label-encoded {} group key column(s) into a single radix-sortable "
+          "key for the COLLECT_SET sort path (rows={}, ndv={}, groups={})",
+          group_idx.size(),
+          input_table.num_rows(),
+          ndv,
+          label_key_values->num_rows());
+      }
+    } catch (const std::exception& e) {
+      // Non-fatal: fall back to grouping on the original key columns.
+      label_key_values.reset();
+      label_col.reset();
+      SIRIUS_LOG_DEBUG(
+        "local_grouped_agg: group-key label encoding failed ({}), "
+        "falling back to multi-column keys",
+        e.what());
+    }
+  }
+  bool const use_label_keys = label_col != nullptr;
+
   // Dictionary-encode STRING group keys when:
   //  1. Average string length >= 4 bytes (short strings hash nearly as fast as
   //     int32, so the encode/decode overhead is not worthwhile), AND
@@ -146,6 +249,7 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
   std::vector<cudf::column_view> group_cols;
   group_cols.reserve(group_idx.size());
   for (int idx : group_idx) {
+    if (use_label_keys) { break; }
     auto col = input_table.column(idx);
     if (col.type().id() == cudf::type_id::STRING && col.size() > 0) {
       cudf::strings_column_view scv(col);
@@ -191,6 +295,7 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
       group_cols.push_back(col);
     }
   }
+  if (use_label_keys) { group_cols.push_back(label_col->view()); }
   cudf::groupby::groupby grpby_obj(cudf::table_view(group_cols), cudf::null_policy::INCLUDE);
 
   // Make aggregation requests, group aggregations on the same column in the single request.
@@ -257,6 +362,17 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
   auto groupby_result = grpby_obj.aggregate(requests, stream, mr);
   auto output_cols    = groupby_result.first->release();
 
+  // Expand the single label key back into the original group key columns. The groupby emits
+  // one row per distinct label, so this gather runs at group cardinality, not input rows.
+  if (use_label_keys) {
+    auto key_table = cudf::gather(label_key_values->view(),
+                                  output_cols[0]->view(),
+                                  cudf::out_of_bounds_policy::DONT_CHECK,
+                                  stream,
+                                  mr);
+    output_cols    = key_table->release();
+  }
+
   // Decode dictionary-encoded group key columns back to STRING
   for (size_t i = 0; i < group_idx.size(); i++) {
     if (output_cols[i]->type().id() == cudf::type_id::DICTIONARY32) {
@@ -313,8 +429,7 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
   }
 
   // Create the output data batch
-  auto output_table = std::make_unique<cudf::table>(
-    std::move(output_cols), stream, memory_space.get_default_allocator());
+  auto output_table = std::make_unique<cudf::table>(std::move(output_cols));
   return make_data_batch(std::move(output_table), memory_space, stream, telemetry_info);
 }
 

--- a/src/op/merge/gpu_merge_impl.cpp
+++ b/src/op/merge/gpu_merge_impl.cpp
@@ -147,8 +147,7 @@ std::shared_ptr<cucascade::data_batch> gpu_merge_impl::merge_ungrouped_aggregate
     output_cudf_cols.push_back(cudf::make_column_from_scalar(
       *output_scalar, 1, stream, memory_space.get_default_allocator()));
   }
-  auto output_cudf_table = std::make_unique<cudf::table>(
-    std::move(output_cudf_cols), stream, memory_space.get_default_allocator());
+  auto output_cudf_table = std::make_unique<cudf::table>(std::move(output_cudf_cols));
 
   // Create output data batch.
   return make_data_batch(std::move(output_cudf_table), memory_space, stream, telemetry_info);
@@ -295,8 +294,7 @@ std::shared_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregate(
   }
 
   // Create the output data batch
-  auto output_table = std::make_unique<cudf::table>(
-    std::move(output_cols), stream, memory_space.get_default_allocator());
+  auto output_table = std::make_unique<cudf::table>(std::move(output_cols));
   return make_data_batch(std::move(output_table), memory_space, stream, telemetry_info);
 }
 

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -300,7 +300,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
     }
   }
 
-  auto output_table = std::make_unique<cudf::table>(std::move(output_cols), stream, mr);
+  auto output_table = std::make_unique<cudf::table>(std::move(output_cols));
   auto result = sirius::make_data_batch(std::move(output_table), *space, stream, batch_telemetry());
   return std::make_unique<pipelineable_operator_data>(
     std::vector<std::shared_ptr<::cucascade::data_batch>>{result});

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -681,30 +681,40 @@ partition_strategy compute_hash_join_partition_strategy(uint64_t total_bytes,
   bool const is_full_outer = join_type == duckdb::JoinType::OUTER;
   uint64_t const small     = partition_small_table_bytes(num_gpus);
 
-  // Broadcast candidacy. MARK multi-GPU is forced broadcast (build_has_null must be globally
-  // consistent); otherwise a build is a candidate when it is below the small-table threshold, OR
-  // below max_broadcast_join_size while the probe side is large relative to the build (replicating
-  // the build avoids shuffling a much larger probe across GPUs).
-  bool const broadcast_candidate =
-    is_mark ? num_gpus > 1
-            : (total_bytes < small ||
-               (total_bytes < max_broadcast_join_size &&
-                estimated_probe_to_build_ratio >= static_cast<double>(num_gpus) * 1.25));
+  // Phase 1 — broadcast candidacy and the partition count we propose to the eligibility check.
+  //   MARK multi-GPU: forced broadcast (build_has_null must be globally consistent).
+  //   MARK single-GPU: clamped to one partition (may still enter BUILD_PROBE below).
+  //   Otherwise: a build is a broadcast candidate when it is below the small-table threshold, OR
+  //   below max_broadcast_join_size while the probe side is large relative to the build (so
+  //   replicating the build avoids shuffling a much larger probe across GPUs).
+  bool broadcast_candidate = false;
+  int proposed             = natural;
+  if (is_mark && num_gpus > 1) {
+    broadcast_candidate = true;
+    proposed            = num_gpus;
+  } else if (is_mark) {
+    broadcast_candidate = false;
+    proposed            = 1;
+  } else {
+    broadcast_candidate = total_bytes < small ||
+                          (total_bytes < max_broadcast_join_size &&
+                           estimated_probe_to_build_ratio >= static_cast<double>(num_gpus) * 1.25);
+    proposed = broadcast_candidate ? num_gpus : natural;
+  }
 
-  // BUILD_PROBE eligibility. MARK/SEMI/ANTI are eligible (persistent filtered_join built on the
-  // right, reused across streamed left probe batches); RIGHT_SEMI/RIGHT_ANTI/RIGHT and full OUTER
-  // emit build-side output and stay on the STANDARD path.
-  //
-  // Evaluated at the count BUILD_PROBE would run with — one build table per GPU, capped at
-  // `natural` — not at the natural count: `hash_partition_bytes` targets a streaming batch size
-  // and must not veto `max_build_hash_table_bytes`, which is what sizes the folded hash table.
-  // A broadcast join charges the FULL build to every GPU; a hash-partitioned build charges the
-  // per-GPU average.
-  int const build_probe_partitions = std::max(1, std::min(natural, num_gpus));
-  uint64_t const per_gpu_build_bytes =
-    broadcast_candidate ? total_bytes : total_bytes / static_cast<uint64_t>(build_probe_partitions);
-  bool build_probe = per_gpu_build_bytes < max_build_hash_table_bytes && build_foldable &&
-                     !is_right_family && !is_mixed && !is_full_outer;
+  // Phase 2 — BUILD_PROBE eligibility at `proposed`. MARK/SEMI/ANTI are eligible (persistent
+  // filtered_join built on the right, reused across streamed left probe batches). RIGHT_SEMI/
+  // RIGHT_ANTI/RIGHT and full OUTER emit build-side output and would need cross-batch (and, on
+  // multi-GPU, cross-partition/cross-GPU) accumulation of unmatched build rows, so they stay on the
+  // STANDARD path. A broadcast join charges the FULL build to every GPU; a hash-partitioned build
+  // charges the per-partition average.
+  bool build_probe = false;
+  if (proposed <= num_gpus) {
+    uint64_t const per_gpu_build_bytes =
+      broadcast_candidate ? total_bytes : total_bytes / static_cast<uint64_t>(proposed);
+    build_probe = per_gpu_build_bytes < max_build_hash_table_bytes && build_foldable &&
+                  !is_right_family && !is_mixed && !is_full_outer;
+  }
 
   // A MARK join must always run in BUILD_PROBE mode. It needs the entire build side resident to
   // compute the global build_has_null sentinel and the per-probe-row marks, and on multi-GPU it is
@@ -715,12 +725,9 @@ partition_strategy compute_hash_join_partition_strategy(uint64_t total_bytes,
 
   bool const broadcast = broadcast_candidate && build_probe;
 
-  // BUILD_PROBE runs at the count its eligibility was measured at; MARK single-GPU is clamped to
-  // one partition; broadcast takes num_gpus; everything else the natural count.
-  int const num_partitions = broadcast                    ? num_gpus
-                             : build_probe                ? build_probe_partitions
-                             : (is_mark && num_gpus <= 1) ? 1
-                                                          : natural;
+  // MARK single-GPU is clamped to one partition regardless of the natural count; every other case
+  // takes num_gpus when broadcasting and the natural count otherwise.
+  int const num_partitions = broadcast ? num_gpus : ((is_mark && num_gpus <= 1) ? 1 : natural);
   return {num_partitions, broadcast, build_probe};
 }
 
@@ -799,18 +806,6 @@ bool sirius_physical_hash_join::is_build_probe_mode()
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
   return _join_mode == HASH_JOIN_MODE::BUILD_PROBE;
-}
-
-bool sirius_physical_hash_join::publishes_dynamic_filters() const
-{
-  // Both are fixed at construction, so this needs no lock.
-  return filter_pushdown != nullptr && _dynamic_filter_plan.enabled();
-}
-
-void sirius_physical_hash_join::set_build_arrives_whole(bool arrives_whole)
-{
-  std::lock_guard<std::mutex> lg(op_state_mutex);
-  _build_arrives_whole = arrives_whole;
 }
 
 std::vector<build_probe_slot_view> sirius_physical_hash_join::snapshot_build_probe_slots()
@@ -1980,40 +1975,21 @@ void sirius_physical_hash_join::push_data_batch_partitioned(
 {
   //===----------Dynamic Table Filters----------===//
   // Build-side dynamic-filter publish: the moment the (single, concat-folded) build batch arrives,
-  // compute and publish the filter from the build keys.
-  //
-  // The publisher is one-shot, so the batch it claims must carry the WHOLE build side — a filter
-  // built from part of the key set would drop probe rows that do in fact join. The upstream
-  // PARTITION knows whether that holds (a single-partition or broadcast build, folded to one batch
-  // by a concat_all build-side CONCAT) and reports it at sizing time through
-  // `set_build_arrives_whole`. The join mode is deliberately not part of the condition: a
-  // single-partition STANDARD / MIXED_JOIN build publishes on the same terms as BUILD_PROBE.
+  // compute and publish the filter from the build keys. This is gated to the two BUILD_PROBE shapes
+  // where a single partition's build batch covers the whole build side, so the one-shot publisher
+  // and its single-GPU reduction emit a complete filter:
+  //   - Single partition (`size() == 1`)
+  //   - Broadcast (`_broadcast`)
   std::optional<::cucascade::read_only_data_batch> build_ro;
   if (port_id == "build" && batch) {
-    bool claim              = false;
-    bool wired_but_unusable = false;
-    HASH_JOIN_MODE mode     = HASH_JOIN_MODE::STANDARD;
+    bool claim = false;
     {
       std::scoped_lock lg(op_state_mutex);
-      const bool open = _dynamic_filter_publication_state.load(std::memory_order_acquire) ==
-                        dynamic_filter_publication_state::OPEN;
-      const bool wired = filter_pushdown && _dynamic_filter_plan.enabled();
-      claim            = open && wired && _build_arrives_whole;
-
-      // A join that has a filter plan and is still open but cannot use the one-shot publisher
-      // silently publishes nothing — say so.
-      wired_but_unusable = open && wired && !claim;
-      mode               = _join_mode;
-    }
-    if (wired_but_unusable) {
-      SIRIUS_LOG_DEBUG(
-        "[sirius_physical_hash_join] dynamic filter NOT published (id={}): mode={}; the build does "
-        "not arrive as a single batch covering the whole build side (multi-partition, or no "
-        "concat-folded build — see this join's partition strategy log line)",
-        get_operator_id(),
-        mode == HASH_JOIN_MODE::BUILD_PROBE  ? "BUILD_PROBE"
-        : mode == HASH_JOIN_MODE::MIXED_JOIN ? "MIXED_JOIN"
-                                             : "STANDARD");
+      claim = _dynamic_filter_publication_state.load(std::memory_order_acquire) ==
+                dynamic_filter_publication_state::OPEN &&
+              _join_mode == HASH_JOIN_MODE::BUILD_PROBE &&
+              (_partition_build_states.size() == 1 || _broadcast) && filter_pushdown &&
+              _dynamic_filter_plan.enabled();
     }
     if (claim) { build_ro.emplace(batch->to_read_only()); }
   }

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -681,40 +681,30 @@ partition_strategy compute_hash_join_partition_strategy(uint64_t total_bytes,
   bool const is_full_outer = join_type == duckdb::JoinType::OUTER;
   uint64_t const small     = partition_small_table_bytes(num_gpus);
 
-  // Phase 1 — broadcast candidacy and the partition count we propose to the eligibility check.
-  //   MARK multi-GPU: forced broadcast (build_has_null must be globally consistent).
-  //   MARK single-GPU: clamped to one partition (may still enter BUILD_PROBE below).
-  //   Otherwise: a build is a broadcast candidate when it is below the small-table threshold, OR
-  //   below max_broadcast_join_size while the probe side is large relative to the build (so
-  //   replicating the build avoids shuffling a much larger probe across GPUs).
-  bool broadcast_candidate = false;
-  int proposed             = natural;
-  if (is_mark && num_gpus > 1) {
-    broadcast_candidate = true;
-    proposed            = num_gpus;
-  } else if (is_mark) {
-    broadcast_candidate = false;
-    proposed            = 1;
-  } else {
-    broadcast_candidate = total_bytes < small ||
-                          (total_bytes < max_broadcast_join_size &&
-                           estimated_probe_to_build_ratio >= static_cast<double>(num_gpus) * 1.25);
-    proposed = broadcast_candidate ? num_gpus : natural;
-  }
+  // Broadcast candidacy. MARK multi-GPU is forced broadcast (build_has_null must be globally
+  // consistent); otherwise a build is a candidate when it is below the small-table threshold, OR
+  // below max_broadcast_join_size while the probe side is large relative to the build (replicating
+  // the build avoids shuffling a much larger probe across GPUs).
+  bool const broadcast_candidate =
+    is_mark ? num_gpus > 1
+            : (total_bytes < small ||
+               (total_bytes < max_broadcast_join_size &&
+                estimated_probe_to_build_ratio >= static_cast<double>(num_gpus) * 1.25));
 
-  // Phase 2 — BUILD_PROBE eligibility at `proposed`. MARK/SEMI/ANTI are eligible (persistent
-  // filtered_join built on the right, reused across streamed left probe batches). RIGHT_SEMI/
-  // RIGHT_ANTI/RIGHT and full OUTER emit build-side output and would need cross-batch (and, on
-  // multi-GPU, cross-partition/cross-GPU) accumulation of unmatched build rows, so they stay on the
-  // STANDARD path. A broadcast join charges the FULL build to every GPU; a hash-partitioned build
-  // charges the per-partition average.
-  bool build_probe = false;
-  if (proposed <= num_gpus) {
-    uint64_t const per_gpu_build_bytes =
-      broadcast_candidate ? total_bytes : total_bytes / static_cast<uint64_t>(proposed);
-    build_probe = per_gpu_build_bytes < max_build_hash_table_bytes && build_foldable &&
-                  !is_right_family && !is_mixed && !is_full_outer;
-  }
+  // BUILD_PROBE eligibility. MARK/SEMI/ANTI are eligible (persistent filtered_join built on the
+  // right, reused across streamed left probe batches); RIGHT_SEMI/RIGHT_ANTI/RIGHT and full OUTER
+  // emit build-side output and stay on the STANDARD path.
+  //
+  // Evaluated at the count BUILD_PROBE would run with — one build table per GPU, capped at
+  // `natural` — not at the natural count: `hash_partition_bytes` targets a streaming batch size
+  // and must not veto `max_build_hash_table_bytes`, which is what sizes the folded hash table.
+  // A broadcast join charges the FULL build to every GPU; a hash-partitioned build charges the
+  // per-GPU average.
+  int const build_probe_partitions = std::max(1, std::min(natural, num_gpus));
+  uint64_t const per_gpu_build_bytes =
+    broadcast_candidate ? total_bytes : total_bytes / static_cast<uint64_t>(build_probe_partitions);
+  bool build_probe = per_gpu_build_bytes < max_build_hash_table_bytes && build_foldable &&
+                     !is_right_family && !is_mixed && !is_full_outer;
 
   // A MARK join must always run in BUILD_PROBE mode. It needs the entire build side resident to
   // compute the global build_has_null sentinel and the per-probe-row marks, and on multi-GPU it is
@@ -725,9 +715,12 @@ partition_strategy compute_hash_join_partition_strategy(uint64_t total_bytes,
 
   bool const broadcast = broadcast_candidate && build_probe;
 
-  // MARK single-GPU is clamped to one partition regardless of the natural count; every other case
-  // takes num_gpus when broadcasting and the natural count otherwise.
-  int const num_partitions = broadcast ? num_gpus : ((is_mark && num_gpus <= 1) ? 1 : natural);
+  // BUILD_PROBE runs at the count its eligibility was measured at; MARK single-GPU is clamped to
+  // one partition; broadcast takes num_gpus; everything else the natural count.
+  int const num_partitions = broadcast                    ? num_gpus
+                             : build_probe                ? build_probe_partitions
+                             : (is_mark && num_gpus <= 1) ? 1
+                                                          : natural;
   return {num_partitions, broadcast, build_probe};
 }
 
@@ -806,6 +799,18 @@ bool sirius_physical_hash_join::is_build_probe_mode()
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
   return _join_mode == HASH_JOIN_MODE::BUILD_PROBE;
+}
+
+bool sirius_physical_hash_join::publishes_dynamic_filters() const
+{
+  // Both are fixed at construction, so this needs no lock.
+  return filter_pushdown != nullptr && _dynamic_filter_plan.enabled();
+}
+
+void sirius_physical_hash_join::set_build_arrives_whole(bool arrives_whole)
+{
+  std::lock_guard<std::mutex> lg(op_state_mutex);
+  _build_arrives_whole = arrives_whole;
 }
 
 std::vector<build_probe_slot_view> sirius_physical_hash_join::snapshot_build_probe_slots()
@@ -1334,7 +1339,7 @@ static std::unique_ptr<operator_data> gather_join_output(
     }
   }
 
-  auto output_cudf_table = std::make_unique<cudf::table>(std::move(out_cols), stream);
+  auto output_cudf_table = std::make_unique<cudf::table>(std::move(out_cols));
   return std::make_unique<pipelineable_operator_data>(
     std::vector<std::shared_ptr<::cucascade::data_batch>>{
       make_data_batch(std::move(output_cudf_table), memory_space, stream, telemetry_info)});
@@ -1376,7 +1381,7 @@ static std::unique_ptr<operator_data> gather_distinct_left_join_output(
     out_cols.push_back(std::move(col));
   }
 
-  auto output_cudf_table = std::make_unique<cudf::table>(std::move(out_cols), stream);
+  auto output_cudf_table = std::make_unique<cudf::table>(std::move(out_cols));
   return std::make_unique<pipelineable_operator_data>(
     std::vector<std::shared_ptr<::cucascade::data_batch>>{
       make_data_batch(std::move(output_cudf_table), memory_space, stream, telemetry_info)});
@@ -1500,7 +1505,7 @@ static std::unique_ptr<operator_data> resolve_mark_join_result(
   if (null_count > 0) { mark_column->set_null_mask(std::move(null_mask), null_count); }
 
   mark_out_cols.push_back(std::move(mark_column));
-  auto output_cudf_table = std::make_unique<cudf::table>(std::move(mark_out_cols), stream);
+  auto output_cudf_table = std::make_unique<cudf::table>(std::move(mark_out_cols));
   return std::make_unique<pipelineable_operator_data>(
     std::vector<std::shared_ptr<::cucascade::data_batch>>{make_data_batch(
       std::move(output_cudf_table), *left_batch.get_memory_space(), stream, telemetry_info)});
@@ -1975,21 +1980,40 @@ void sirius_physical_hash_join::push_data_batch_partitioned(
 {
   //===----------Dynamic Table Filters----------===//
   // Build-side dynamic-filter publish: the moment the (single, concat-folded) build batch arrives,
-  // compute and publish the filter from the build keys. This is gated to the two BUILD_PROBE shapes
-  // where a single partition's build batch covers the whole build side, so the one-shot publisher
-  // and its single-GPU reduction emit a complete filter:
-  //   - Single partition (`size() == 1`)
-  //   - Broadcast (`_broadcast`)
+  // compute and publish the filter from the build keys.
+  //
+  // The publisher is one-shot, so the batch it claims must carry the WHOLE build side — a filter
+  // built from part of the key set would drop probe rows that do in fact join. The upstream
+  // PARTITION knows whether that holds (a single-partition or broadcast build, folded to one batch
+  // by a concat_all build-side CONCAT) and reports it at sizing time through
+  // `set_build_arrives_whole`. The join mode is deliberately not part of the condition: a
+  // single-partition STANDARD / MIXED_JOIN build publishes on the same terms as BUILD_PROBE.
   std::optional<::cucascade::read_only_data_batch> build_ro;
   if (port_id == "build" && batch) {
-    bool claim = false;
+    bool claim              = false;
+    bool wired_but_unusable = false;
+    HASH_JOIN_MODE mode     = HASH_JOIN_MODE::STANDARD;
     {
       std::scoped_lock lg(op_state_mutex);
-      claim = _dynamic_filter_publication_state.load(std::memory_order_acquire) ==
-                dynamic_filter_publication_state::OPEN &&
-              _join_mode == HASH_JOIN_MODE::BUILD_PROBE &&
-              (_partition_build_states.size() == 1 || _broadcast) && filter_pushdown &&
-              _dynamic_filter_plan.enabled();
+      const bool open = _dynamic_filter_publication_state.load(std::memory_order_acquire) ==
+                        dynamic_filter_publication_state::OPEN;
+      const bool wired = filter_pushdown && _dynamic_filter_plan.enabled();
+      claim            = open && wired && _build_arrives_whole;
+
+      // A join that has a filter plan and is still open but cannot use the one-shot publisher
+      // silently publishes nothing — say so.
+      wired_but_unusable = open && wired && !claim;
+      mode               = _join_mode;
+    }
+    if (wired_but_unusable) {
+      SIRIUS_LOG_DEBUG(
+        "[sirius_physical_hash_join] dynamic filter NOT published (id={}): mode={}; the build does "
+        "not arrive as a single batch covering the whole build side (multi-partition, or no "
+        "concat-folded build — see this join's partition strategy log line)",
+        get_operator_id(),
+        mode == HASH_JOIN_MODE::BUILD_PROBE  ? "BUILD_PROBE"
+        : mode == HASH_JOIN_MODE::MIXED_JOIN ? "MIXED_JOIN"
+                                             : "STANDARD");
     }
     if (claim) { build_ro.emplace(batch->to_read_only()); }
   }

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -463,7 +463,7 @@ static std::unique_ptr<operator_data> resolve_mark_join_result(
 
   out_cols.push_back(std::move(mark_column));
 
-  auto output_table = std::make_unique<cudf::table>(std::move(out_cols), stream);
+  auto output_table = std::make_unique<cudf::table>(std::move(out_cols));
   return std::make_unique<pipelineable_operator_data>(
     std::vector<std::shared_ptr<cucascade::data_batch>>{
       make_data_batch(std::move(output_table), space, stream, telemetry_info)});
@@ -564,7 +564,7 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::emit_one_side_e
   for (std::size_t idx : right_output_col_idxs) {
     if (idx < right_released.size()) { out_cols.push_back(std::move(right_released[idx])); }
   }
-  auto result_table = std::make_unique<cudf::table>(std::move(out_cols), stream, mr);
+  auto result_table = std::make_unique<cudf::table>(std::move(out_cols));
   return std::make_unique<pipelineable_operator_data>(
     std::vector<std::shared_ptr<cucascade::data_batch>>{
       make_data_batch(std::move(result_table), space, stream, batch_telemetry())});
@@ -632,7 +632,7 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
         out_cols.push_back(std::move(left_released[left_n + idx]));
       }
     }
-    result_table = std::make_unique<cudf::table>(std::move(out_cols), stream, mr);
+    result_table = std::make_unique<cudf::table>(std::move(out_cols));
   } else {
     // Resolve column indices and target types so AST predicate operands match (cudf requires
     // matching types). Columns used in conditions may be cast to the expression return type.
@@ -895,7 +895,7 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
     for (std::size_t idx : right_output_col_idxs) {
       if (idx < right_released.size()) { out_cols.push_back(std::move(right_released[idx])); }
     }
-    result_table = std::make_unique<cudf::table>(std::move(out_cols), stream, mr);
+    result_table = std::make_unique<cudf::table>(std::move(out_cols));
   }
 
   SIRIUS_LOG_DEBUG("Pipeline {}: nested loop join, 1 output batches", pipeline_id);

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -390,7 +390,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
       }
     }
 
-    auto out_table = std::make_unique<cudf::table>(std::move(cols), stream);
+    auto out_table = std::make_unique<cudf::table>(std::move(cols));
     // STREAM-LINEAGE: cudf::table ctor + cudf::make_column_from_scalar wrote
     // on `stream`; the constructor records the writer event for downstream
     // cross-device readers.


### PR DESCRIPTION
cudf exports no (vector&&, stream, mr) table constructor, so a three-argument call
builds an implicit temporary from the vector and then binds
explicit table(table const&, stream, mr) -- a full deep copy of data we already own.
Dropping stream/mr selects the move constructor.

Measured on TPC-H SF1000 (GB300): suite -0.8%, 22/22 byte-identical.

Deliberately NOT changed: the six sites where table(table_view, stream, mr) is the
intended materialisation -- top_n.cpp:87,133,289,303, sort_partition.cpp:148 and
host_keep_mask.cpp:80.

NOTE: sirius_physical_hash_join.cpp here also carries joosthooz's in-flight
#1341/#1342 changes, which are not yet on dev.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
