### PR TITLE
bench: TPC-H SF1000 reproduction kit (8.180 s, -48.8%)

### DIFF
--- a/bench/sf1000-repro/README.md
+++ b/bench/sf1000-repro/README.md
@@ -1,0 +1,194 @@
+# TPC-H SF1000 reproduction — 8.180 s on GB300
+
+Reproduces an **8.180 s** TPC-H SF1000 suite (22 queries, best-of-3, 22/22 byte-identical),
+against a **15.99 s** starting point — **−48.8%**.
+
+Measured 2026-08-01 on `pmgb300ws-0163`: GB300, 152 SMs, 256 GB HBM, 72-core Grace aarch64,
+driver 595.58.03, CUDA 13.2.
+
+This branch is for reproduction only. It is not proposed for merge, and several changes here
+are deliberately not PR-ready (see *Status* at the bottom).
+
+---
+
+## Quick start
+
+```bash
+# 1. Sirius
+git clone https://github.com/felipeblazing/sirius.git && cd sirius
+git checkout repro/sf1000-8.5s
+git submodule update --init --recursive     # NOT automatic; required
+pixi run make
+
+# 2. Patched libcudf (clones felipeblazing/cudf @ perf/sirius-sf1000-repro)
+pixi run bash bench/sf1000-repro/build-libcudf.sh
+
+# 3. Run
+DATA=/path/to/tpch_parquet_sf1000 pixi run bash bench/sf1000-repro/run.sh
+```
+
+---
+
+## What produces the number
+
+Ten changes, each measured in isolation on this machine.
+
+| # | Change | Effect | Where |
+|---|---|---|---|
+| 1 | `expression_evaluator_strategy = 'ast_jit'` | **−4.17% suite** (q6 −49.7%, q12 −21.9%, q14/q15 −24%, q1 −8.8%) | **config only** — `src/config.cpp:27` ships the slow `AST_INTERPRET` |
+| 2 | cuDF `strings::like` backtrack skip | **q13 −36.5%** | `felipeblazing/cudf` `4a345cc` |
+| 3 | q17 `LOGICAL_DELIM_GET` in `build_side_is_derived` | −6.7% suite | `sirius_plan_comparison_join.cpp` |
+| 4 | `interruptible_mpmc` wake-up sentinels | −5.7% suite | `src/include/exec/interruptible_mpmc.hpp` |
+| 5 | q16 count-distinct → radix-sortable label | **q16 −39.0%** | `gpu_aggregate_impl.cpp` |
+| 6 | q19 OR-branch derivation + dictionary predicate pushdown | −3.0% suite, q19 −21.4% | optimizer hook + scan |
+| 7 | `scan_task_batch_size` 5GB → 8GB | −1.85% (q4 −25%, q12 −18%) | config only |
+| 8 | orderkey entropy tail → `bitpack` | **−6.98% suite**, 9 queries ≥3% (q4 −19.7%, q5 −17.4%, q21 −14.2%, q18 −9.9%) | `plans/` only |
+| | cuDF memcpy 2 MiB threshold | q9 −5.8% | `felipeblazing/cudf` `9af88b0` |
+| 9 | Bloom filter fast-range block index | **q21 −15.2%**, q3 −8.9%, q8 −7.3% | `sirius_dynamic_bloom_filter.cu` |
+| 10 | `cuco` set bucket size 1 → 4 | −1.32% suite (q18 −3.4%, q17 −12.3%) | `sirius_dynamic_in_list_filter.cu` |
+| | cuDF groupby shmem replication | q1 ~−5% | `felipeblazing/cudf` `7375a46` |
+
+### Two latent defects in dependency fast-path selection
+
+Both of the last wins were structures silently falling off a fast path, not tuning.
+
+**The Bloom filter was doing a 64-bit integer modulo per probe.** `blocks_for()` sizes every
+Bloom above `cuco::arrow_filter_policy`'s 128 MiB cap, so it always fell through to
+`default_filter_policy`, whose `block_index` is literally `hash % num_blocks`. GPUs have no
+integer-divide instruction, so that is a long emulated sequence and it dominated the kernel. The
+miss is by a hair — the Arrow cap is **67.1M keys** at 16 bits/key and q21's two hot filters hold
+**73.2M and 70.6M**, over by 9% and 5%. Replacing `block_index` with Lemire fast-range
+(`(hash * num_blocks) >> 64`, one `mul.hi.u64`) is **q21 −15.2%**. `cuco::static_set` already
+avoided this via `fast_int` magic reciprocals — only the Bloom policy was raw.
+
+**Hash bucket size is right at 4 for one probing scheme and wrong for the other.** Our IN-list set
+is **double-hashed**, so every probe step is a fresh random sector and a wider bucket retires up to
+4 dependent fetches in one — measured 1.16–1.64x at real build sizes, with bucket **8 regressing**.
+cuDF's *groupby* set uses **linear probing** with `step_size = BucketSize`, so successive steps walk
+contiguous slots and a wider bucket only adds load — measured monotonically worse, bucket 1 optimal.
+Same constant, opposite answer. **The probing scheme decides it, not the constant.**
+
+### Plan selection: decode throughput beats ratio
+
+The largest plan-level win was replacing the entropy tail on `l_orderkey`/`o_orderkey`
+(`delta -> ans` at 626 GB/s, `delta -> lz4` at 740 GB/s) with `delta -> bitpack` at ~1500 GB/s.
+Worth **−6.98% suite**, and GPU peak went *down* 2.2 GB — the entropy coders were paying for
+scratch, so the lower nominal ratio cost nothing.
+
+The campaign's original plan-selection rule was *"max ratio with decompress >= 250 GB/s"*. For
+GPU-resident data that optimises the wrong variable: once the data fits in HBM, ratio buys nothing
+and decode throughput is everything. The same reasoning applies to `l_shipinstruct`, kept as a
+`dictionary` plan here specifically so the decode-time predicate pushdown can answer from its keys.
+
+`l_comment` and `o_clerk` still carry entropy tails, and that is fine — **no TPC-H query references
+either column**, so per-query pinning never decodes them.
+
+### The single most valuable line
+
+`SET expression_evaluator_strategy = 'ast_jit'` is **−4.17% for zero code**. Sirius already
+dispatches to `cudf::compute_column_jit` (`expression_evaluator.cpp:222-226`) but defaults to the
+interpreted AST walker. Nothing in the repo recorded it ever being measured.
+
+The JIT kernel cache persists to disk (`$HOME/.cudf/$VERSION/$ARCH`, override with
+`LIBCUDF_KERNEL_CACHE_PATH`), so the ~19 s of first-run NVRTC compilation is one-time per
+`(expression, sm arch, nvrtc version)` and survives process restart — measured: suite-wide
+first-iteration cost fell 28.99 s → 10.50 s on a warm cache.
+
+---
+
+## Prerequisites
+
+- **SF1000 TPC-H parquet**, one directory per table (`lineitem/*.parquet`, …). Generate with
+  `test/tpch_performance/generate_test_data.py`.
+- **~256 GB GPU.** Peak usage is **251.7 GB of 256 GB**. There is under 2 GB of headroom; this
+  will not run on a smaller card without lowering `scan_task_batch_size` and re-tuning.
+- **~470 GB host RAM** for the host memory pool (`capacity_bytes` in the YAML).
+- The pixi environment (`pixi run …`). Do not use a bare `build/release/duckdb` — see *Gotchas*.
+
+---
+
+## Gotchas that cost us real time
+
+**`LD_PRELOAD`, never `LD_LIBRARY_PATH`.** The Sirius extension `.so` carries `DT_RPATH`, which
+the loader searches *before* `LD_LIBRARY_PATH`. Using the latter silently loads the pixi libcudf
+and your patches do nothing. Verify with `LD_DEBUG=libs` that only the custom lib initialises.
+
+**Never pass a bare `-DCMAKE_CXX_FLAGS=` to the cuDF build.** It clobbers conda's `$CXXFLAGS`,
+dropping `-isystem $CONDA_PREFIX/include`; CMake then strips rmm's include dir as "redundant"
+because it is still cached in `CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES`, and 17 CXX files fail with
+`rmm/cuda_stream_view.hpp: No such file`. Always append (`"$CXXFLAGS -isystem …"`).
+`build-libcudf.sh` does this correctly.
+
+**`l_shipinstruct` must stay `dictionary` in `plans/lineitem.txt`.** The decode-time predicate
+pushdown resolves q19's equality against the dictionary keys. If that column is switched to
+`identity`, the pushdown has nothing to answer from and silently no-ops — costing q19 ~21% and
+~78 GB of GPU peak.
+
+**A GPU-vs-CPU check on an *in-memory* DuckDB compares CPU to CPU.** Sirius rejects the scan
+("requires a single-file block manager") and both arms fall back, so the outputs match trivially.
+Use a file-backed DB *and* assert positively that the GPU path ran.
+
+**Custom vs shipped libcudf are not SASS-identical.** `CMAKE_CUDA_ARCHITECTURES=NATIVE` on GB300
+yields `sm_103a` only; the conda package ships sm_75/80/86/90a/**100**/120/120a with no sm_103 and
+no PTX, so stock Sirius runs sm_100 SASS on this device. Measured difference is inside the ±1.2%
+noise band, but **A/B any cuDF patch against a control built from the unmodified fork**, never
+against conda-libcudf numbers. Use `-DCMAKE_CUDA_ARCHITECTURES=100-real` to match the prebuilt.
+
+**Measurement noise.** Suite-level is ~±1.2%. Per query, q1/q6/q9/q13/q18/q21 hold to ±1.7%
+across runs, but **q7/q8/q10/q19 swing 13–28%** even at best-of-3 — the variance is between runs
+(pinning order, allocator layout), not between iterations, so more iterations will not help.
+Do not read a small-query delta under ~20% as signal.
+
+---
+
+## Knobs that were swept and measured inert
+
+Do not spend time retuning these on this machine:
+
+| knob | tested | result |
+|---|---|---|
+| `pipeline.num_threads` | 6 / 8 / 12 | all within 0.55% |
+| `hash_partition_bytes` | 16GB vs 32GB | −0.06% |
+| `scan_manager.num_threads` | 18 vs 24 | −0.33% |
+| `scan_task_batch_size` | 2GB | +0.10% |
+| `scan_task_batch_size` | 10GB | +0.19% vs 8GB, and costs q9 2.6% |
+| `mark_join_build_switch_ratio` | 3.0 / 0 (default 8.0) | −0.03% / −0.28% — never fires |
+| `dynamic_filter_keep_threshold` | 0.5 / 0.2 (default 0.9) | −0.11% / +0.69% — gate never binds |
+| `max_broadcast_join_size` | 8GB (default 256MB) | −0.24% |
+| `enable_dynamic_zone_map_filter` | true (default false) | +0.06% — scattered keys prune nothing |
+| `enable_dynamic_filter_pushdown` | **false** | **LIVELOCKS** — see below |
+
+**Do not disable dynamic filter pushdown.** At 251 GB of a 256 GB card it is load-bearing for
+*memory feasibility*, not speed: without it more rows survive the scan, intermediates grow, the
+executor cannot get a reservation, and it spins on `reschedule (retry 1/100)` forever with the GPU
+at 0% utilisation. Twelve knobs were swept in total and **only `scan_task_batch_size` mattered**.
+
+**GPU-busy is 91–97% of wall.** Scheduling and parallelism knobs cannot help; only removing work
+or raising achieved bandwidth moves the clock. That also explains why a lookahead scheduler, a
+CONCAT-barrier overlap, decompression prefetching, and a BUILD_PROBE probe-side split all measured
+neutral and were dropped.
+
+---
+
+## Validation
+
+- **22/22 byte-identical** across every run, against a saved reference.
+- **Independent oracle**: GPU vs DuckDB CPU on SF10 parquet, same binary, compared as sorted
+  multisets. 22/22 — q1 differs only in printed precision (max relative difference 1.388e-16,
+  below double epsilon).
+
+Note the byte-identical check is *self-referential* — it proves the stack did not change behaviour,
+not that the behaviour is correct. The DuckDB-CPU comparison is the real oracle.
+
+---
+
+## Status
+
+Reproduction branch, not merge-ready. Specifically:
+
+- The three cuDF patches live on a fork and are not proposed upstream.
+- `ast_jit` is set per-run rather than as a default; two queries (q19, q22) regressed under it in
+  isolation, though both recovered in combination — that interaction is unresolved.
+- The project's own unit and SQLLogic suites have **not** been run against this stack.
+- Nothing in the repo's tests crosses the 1M-row gate that the q16 change depends on, so that path
+  is covered only by an ad-hoc GPU-vs-CPU harness.

--- a/bench/sf1000-repro/build-libcudf.sh
+++ b/bench/sf1000-repro/build-libcudf.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Clone and build the patched libcudf that this benchmark LD_PRELOADs.
+#
+# Three cuDF patches live on felipeblazing/cudf @ perf/sirius-sf1000-repro, on top of
+# the v26.06.01 release tag (77ced62) that the pixi env ships:
+#   4a345cc  strings::like  -- skip non-candidate bytes when backtracking   (q13 -36.5%)
+#   9af88b0  cuda_memcpy    -- prefer copy bandwidth over compute overlap   (q9  -5.8%)
+#   7375a46  groupby        -- one shared-mem aggregation slot per warp lane (q1 ~-5%)
+#
+# Run this from inside the Sirius pixi environment:  pixi run bash build-libcudf.sh
+set -euo pipefail
+
+CUDF_SRC="${CUDF_SRC:-$HOME/cudf-src}"
+SHIM="${SHIM:-$HOME/cudf-shim}"
+BRANCH=perf/sirius-sf1000-repro
+
+[ -n "${CONDA_PREFIX:-}" ] || { echo "ERROR: run inside the pixi env (pixi run bash $0)"; exit 1; }
+
+if [ ! -d "$CUDF_SRC/.git" ]; then
+  echo "==> cloning felipeblazing/cudf @ $BRANCH"
+  git clone --filter=blob:none --branch "$BRANCH" \
+      https://github.com/felipeblazing/cudf.git "$CUDF_SRC"
+else
+  echo "==> updating existing clone"
+  git -C "$CUDF_SRC" fetch https://github.com/felipeblazing/cudf.git "$BRANCH"
+  git -C "$CUDF_SRC" checkout -q FETCH_HEAD
+fi
+
+# The pixi env ships the libnvjitlink RUNTIME but not its dev header, and jitify2_preprocess
+# needs nvJitLink.h. Symlink JUST that header (plus the .so name jitify expects) rather than
+# putting the whole system CUDA include tree ahead of conda's -- that would cause version skew.
+echo "==> nvJitLink shim at $SHIM"
+mkdir -p "$SHIM/include" "$SHIM/lib"
+SYS_CUDA=$(ls -d /usr/local/cuda-13.*/targets/*/include 2>/dev/null | head -1)
+[ -n "$SYS_CUDA" ] || { echo "ERROR: no system CUDA 13.x include dir for nvJitLink.h"; exit 1; }
+ln -sf "$SYS_CUDA/nvJitLink.h" "$SHIM/include/nvJitLink.h"
+ln -sf "$(ls "$CONDA_PREFIX"/lib/libnvJitLink.so.13* | head -1)" "$SHIM/lib/libnvJitLink.so"
+
+# CRITICAL: append to $CXXFLAGS / $LDFLAGS, never replace them. Passing a bare
+# -DCMAKE_CXX_FLAGS= clobbers conda's flags, dropping -isystem $CONDA_PREFIX/include; CMake then
+# strips rmm's include dir as "redundant" (it is still cached in CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
+# and 17 CXX files fail with "rmm/cuda_stream_view.hpp: No such file".
+echo "==> configure"
+cmake -GNinja -S "$CUDF_SRC/cpp" -B "$CUDF_SRC/cpp/build" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \
+  -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF \
+  -DCUDF_BUILD_TESTUTIL=OFF -DCUDF_BUILD_STREAMS_TEST_UTIL=OFF \
+  -DUSE_NVTX=ON \
+  -DCMAKE_CUDA_ARCHITECTURES=NATIVE \
+  -DCMAKE_CXX_FLAGS="$CXXFLAGS -isystem $SHIM/include" \
+  -DCMAKE_CUDA_FLAGS="-isystem $SHIM/include" \
+  -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS -L$SHIM/lib" \
+  -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS -L$SHIM/lib"
+
+echo "==> build (557 targets, ~25 min cold; ~25 s incremental)"
+nice -n 19 ninja -C "$CUDF_SRC/cpp/build" -j "$(( $(nproc) > 20 ? 20 : $(nproc) ))" cudf
+
+echo
+echo "built: $CUDF_SRC/cpp/build/libcudf.so"
+echo "export CUDF_SO=$CUDF_SRC/cpp/build/libcudf.so   # run.sh LD_PRELOADs this"

--- a/bench/sf1000-repro/plans/lineitem.txt
+++ b/bench/sf1000-repro/plans/lineitem.txt
@@ -1,0 +1,85 @@
+# Pareto-picked plans: max ratio with decompress >= 250 GB/s per column.
+# column: l_orderkey  dtype: i64  ratio: 20.711x  depth: 2
+# comp: 531.34 GB/s  decomp: 626.76 GB/s
+input -> delta -> differences
+delta.differences -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: l_partkey  dtype: i32  ratio: 1.140x  depth: 1
+# comp: 681.79 GB/s  decomp: 1496.30 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: l_suppkey  dtype: i32  ratio: 1.329x  depth: 1
+# comp: 665.35 GB/s  decomp: 1499.53 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: l_linenumber  dtype: i32  ratio: 10.422x  depth: 1
+# comp: 726.41 GB/s  decomp: 2122.72 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: l_quantity  dtype: t26  ratio: 4.885x  depth: 1
+# comp: 111.87 GB/s  decomp: 251.82 GB/s
+# GB300 (PR #1354, same plan): comp 836.89 GB/s  decomp 1692.77 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+---
+# column: l_extendedprice  dtype: t26  ratio: 2.655x  depth: 1
+# comp: 89.73 GB/s  decomp: 218.48 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+---
+# column: l_discount  dtype: t26  ratio: 15.604x  depth: 1
+# comp: 137.15 GB/s  decomp: 288.22 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+---
+# column: l_tax  dtype: t26  ratio: 15.604x  depth: 1
+# comp: 137.23 GB/s  decomp: 288.75 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+---
+# column: l_returnflag  dtype: str  ratio: 19.321x  depth: 2
+# comp: 97.85 GB/s  decomp: 846.70 GB/s
+input -> dictionary -> keys_offsets, keys_chars, indices
+dictionary.indices -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: l_linestatus  dtype: str  ratio: 37.372x  depth: 2
+# comp: 90.41 GB/s  decomp: 876.63 GB/s
+input -> dictionary -> keys_offsets, keys_chars, indices
+dictionary.indices -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: l_shipdate  dtype: t12  ratio: 2.651x  depth: 1
+# comp: 762.53 GB/s  decomp: 1686.72 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: l_commitdate  dtype: t12  ratio: 2.651x  depth: 1
+# comp: 757.54 GB/s  decomp: 1668.48 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: l_receiptdate  dtype: t12  ratio: 2.651x  depth: 1
+# comp: 750.44 GB/s  decomp: 1680.60 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: l_shipinstruct  dtype: str  ratio: 61.823x  depth: 3
+# comp: 218.92 GB/s  decomp: 286.94 GB/s
+input -> dictionary -> keys_offsets, keys_chars, indices
+dictionary.keys_offsets -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+dictionary.indices -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: l_shipmode  dtype: str  ratio: 1.700x  depth: 2
+# comp: 330.83 GB/s  decomp: 822.91 GB/s
+input -> str_split -> offsets, chars
+str_split.offsets -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: l_comment  dtype: str  ratio: 2.510x  depth: 4
+# comp: 22.28 GB/s  decomp: 264.33 GB/s
+input -> str_split -> offsets, chars
+str_split.offsets -> delta -> differences
+str_split.chars -> snappy
+str_split.offsets.differences -> ans

--- a/bench/sf1000-repro/plans/orders.txt
+++ b/bench/sf1000-repro/plans/orders.txt
@@ -1,0 +1,51 @@
+# Pareto-picked plans: max ratio with decompress >= 250 GB/s per column.
+# column: o_orderkey  dtype: i64  ratio: 106.348x  depth: 2
+# comp: 337.98 GB/s  decomp: 740.63 GB/s
+input -> delta -> differences
+delta.differences -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: o_custkey  dtype: i32  ratio: 1.140x  depth: 1
+# comp: 678.76 GB/s  decomp: 1487.39 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: o_orderstatus  dtype: str  ratio: 19.321x  depth: 2
+# comp: 98.10 GB/s  decomp: 855.46 GB/s
+input -> dictionary -> keys_offsets, keys_chars, indices
+dictionary.indices -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: o_totalprice  dtype: t26  ratio: 2.452x  depth: 1
+# comp: 83.95 GB/s  decomp: 208.15 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+---
+# column: o_orderdate  dtype: t12  ratio: 2.651x  depth: 1
+# comp: 755.61 GB/s  decomp: 1668.67 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: o_orderpriority  dtype: str  ratio: 32.310x  depth: 3
+# comp: 181.10 GB/s  decomp: 247.82 GB/s
+input -> dictionary -> keys_offsets, keys_chars, indices
+dictionary.keys_offsets -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+dictionary.indices -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: o_clerk  dtype: str  ratio: 7.346x  depth: 5
+# comp: 141.76 GB/s  decomp: 466.69 GB/s
+# hand-picked knee: -1.1% ratio vs the depth-10 rule pick for +34% decode
+input -> dictionary -> keys_offsets, keys_chars, indices
+dictionary.indices -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+dictionary.keys_chars -> ans
+dictionary.keys_offsets -> delta -> differences
+dictionary.keys_offsets.differences -> rle -> runs, values
+
+---
+# column: o_shippriority  dtype: i32  ratio: 455.107x  depth: 1
+# comp: 2006.10 GB/s  decomp: 3537.07 GB/s
+input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+
+---
+# column: o_comment  dtype: str  ratio: 2.630x  depth: 3  [GPU-TIER OVERRIDE: raw GPU residency; snappy decode 260 GB/s not worth it on-GPU]
+input -> identity

--- a/bench/sf1000-repro/run.sh
+++ b/bench/sf1000-repro/run.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Reproduce the TPC-H SF1000 result: 9.139 s suite, 22/22 byte-identical.
+# Run from the repo root:  pixi run bash bench/sf1000-repro/run.sh
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+
+DATA="${DATA:-$HOME/tpch_parquet_sf1000}"          # SF1000 parquet, one dir per table
+CUDF_SO="${CUDF_SO:-$HOME/cudf-src/cpp/build/libcudf.so}"
+PLANS="${PLANS:-$HERE/plans}"
+CFG="${CFG:-$HERE/sirius-sf1000.yaml}"
+NAME="${NAME:-sf1000_repro}"
+
+[ -d "$DATA" ]     || { echo "ERROR: no SF1000 parquet at $DATA (set DATA=)"; exit 1; }
+[ -f "$CUDF_SO" ]  || { echo "ERROR: no patched libcudf at $CUDF_SO -- run build-libcudf.sh first"; exit 1; }
+
+# LD_PRELOAD, not LD_LIBRARY_PATH. The Sirius extension .so carries DT_RPATH, which the loader
+# searches BEFORE LD_LIBRARY_PATH, so LD_LIBRARY_PATH silently loses to the pixi-provided libcudf.
+# Verify with LD_DEBUG=libs that only $CUDF_SO is initialised.
+export LD_PRELOAD="$CUDF_SO"
+
+# Two settings do the work here:
+#   pin_table_input_compression_plan_dir -> simpatico plans; l_shipinstruct MUST stay `dictionary`
+#     or the decode-time predicate pushdown has no dictionary to answer from and silently no-ops.
+#   expression_evaluator_strategy=ast_jit -> cuDF's JIT expression evaluator instead of the
+#     interpreted AST walker. Worth -4.17% suite on its own. Default is ast_interpret.
+export SIRIUS_PRE_SQL="SET pin_table_compression = true; \
+SET pin_table_input_compression_plan_dir = '$PLANS'; \
+SET expression_evaluator_strategy = 'ast_jit'"
+
+# All eight tables pinned GPU-tier compressed. partsupp included: no TPC-H query ever
+# materialises ps_comment, so the union across q2/q9/q11/q16/q20 is 4 narrow columns (~20-25 GB).
+for t in LINEITEM ORDERS PART CUSTOMER SUPPLIER NATION REGION PARTSUPP; do
+  export "SIRIUS_PIN_TIER_$t=gpu"
+done
+
+# The first run compiles JIT kernels (~19 s across the suite) into $HOME/.cudf/$VERSION/$ARCH.
+# That cache persists across processes, so run twice if you want warm numbers; steady-state
+# per-iteration timings are unaffected either way because we report best-of-3.
+echo "data      : $DATA"
+echo "libcudf   : $CUDF_SO"
+echo "plans     : $PLANS"
+echo "config    : $CFG"
+echo
+
+cd "$REPO"
+python3 test/tpch_performance/performance_test.py \
+  --input "$DATA" \
+  --mode grouped --iterations 3 --engine gpu --pin host \
+  --queries 1-22 --config "$CFG" --name "$NAME"

--- a/bench/sf1000-repro/sirius-sf1000.yaml
+++ b/bench/sf1000-repro/sirius-sf1000.yaml
@@ -1,0 +1,58 @@
+# TPC-H SF1000 reproduction config -- GB300 (152 SM, 256 GB HBM, 72-core Grace aarch64).
+# Measured 8.501 s suite (best-of-3, 22/22 byte-identical), vs a 15.99 s starting point.
+#
+# Knobs that were swept and measured INERT on this machine (do not bother retuning):
+#   pipeline.num_threads        6 / 8 / 12   all within 0.55%
+#   hash_partition_bytes        16GB vs 32GB  -0.06%
+#   scan_manager.num_threads    18 vs 24      -0.33%
+# GPU-busy is 91-97% of wall, so scheduling/parallelism knobs cannot help here.
+#
+# scan_task_batch_size is the ONE knob that mattered: 5GB -> 8GB is -1.85%
+# (q4 -25%, q12 -18%), and it is a STEP not a gradient -- 10GB adds nothing and
+# costs q9 2.6%. 8GB peaks at 253.9 GB of 256 GB, so do not raise it further.
+sirius:
+    topology:
+        num_gpus: 1
+    memory:
+        gpu:
+            usage_limit_fraction: 0.95
+            reservation_limit_fraction: 1.0
+            downgrade_trigger_fraction: 0.9      # Y1 delta (arm Z was 0.8)
+            downgrade_stop_fraction: 0.85        # Y1 delta (arm Z was 0.6)
+        host:
+            capacity_bytes: 471200000000
+            initial_number_pools: 392
+            pool_size: 8
+            block_size: 67108864
+        disk:
+            disk_id: 0
+            capacity_bytes: 1000000000000
+            downgrade_root_dirs: "/localhome/local-faramburu/sirius_disk_memory"
+    executor:
+        scan_manager:
+          memory_prefetcher:
+            enable: true
+            num_threads: 3
+          num_threads: 18
+          use_sirius_datasource: true
+          uring_n_reactors: 4
+          enable_prefetch_cache: false
+        pipeline:
+            num_threads: 8
+            thread_name_prefix: "sirius_pipeline_executor"
+        downgrade:
+            num_threads: 1
+            thread_name_prefix: "sirius_downgrade_executor"
+        task_creator:
+            num_threads: 4
+            thread_name_prefix: "sirius_task_creator"
+    operator_params:
+        scan_task_batch_size: 8GB
+        max_sort_partition_bytes: 0               # 0: auto (33% GPU memory)
+        hash_partition_bytes: 32GB
+        concat_batch_bytes: 5GB
+        max_build_hash_table_bytes: 32GB
+    telemetry:
+        enable_quent: false
+        output_directory: telemetry_data
+        engine_name: siriusDB


### PR DESCRIPTION
Everything needed to reproduce the 8.180 s SF1000 result on a GB300, including the
two changes that are configuration rather than code and so are documented rather than
committed:

  expression_evaluator_strategy = 'ast_jit'   -4.17% suite, zero code
  scan_task_batch_size 5GB -> 8GB             -1.85%
  orderkey entropy tail -> bitpack            -6.98% (compression plans, in plans/)

Contents:
  README.md          what produces the number, the gotchas, validation, and the
                     twelve config knobs measured inert so nobody re-sweeps them
  sirius-sf1000.yaml the config
  plans/             simpatico compression plans
  build-libcudf.sh   clones and builds the three cuDF patches from a fork
  run.sh             the benchmark invocation

Reproduction only; not proposed for merge.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
