### PR TITLE
perf: gather only the top k in TopN sort fallbacks

### DIFF
--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -45,6 +45,33 @@ namespace op {
 
 namespace {
 
+//! Selects the first `keep_rows` rows of `input` under the given lexicographic ordering.
+//!
+//! Sorting the keys into a permutation and gathering only the surviving rows is much cheaper than
+//! `cudf::sort_by_key` for a top-N: the sort materializes an int32 index column rather than a fully
+//! sorted copy of every payload column, and the gather touches `keep_rows` rows instead of all of
+//! them. Unlike `cudf::top_k_order` this honors SQL NULLS FIRST/LAST, so it is the fallback for
+//! nullable and multi-key orderings.
+std::unique_ptr<cudf::table> sorted_order_top_k(cudf::table_view input,
+                                                cudf::table_view keys,
+                                                std::vector<cudf::order> const& key_orders,
+                                                std::vector<cudf::null_order> const& null_orders,
+                                                cudf::size_type keep_rows,
+                                                rmm::cuda_stream_view stream,
+                                                rmm::device_async_resource_ref memory_resource)
+{
+  auto indices = cudf::sorted_order(keys, key_orders, null_orders, stream, memory_resource);
+
+  auto indices_view = indices->view();
+  if (keep_rows < indices_view.size()) {
+    // Views into `indices`, which outlives the gather below.
+    indices_view = cudf::slice(indices_view, {0, keep_rows}, stream).front();
+  }
+
+  return cudf::gather(
+    input, indices_view, cudf::out_of_bounds_policy::DONT_CHECK, stream, memory_resource);
+}
+
 std::unique_ptr<cudf::table> compute_top_n_table(
   cudf::table_view input,
   duckdb::vector<duckdb::BoundOrderByNode> const& orders,
@@ -77,15 +104,14 @@ std::unique_ptr<cudf::table> compute_top_n_table(
     if (input.column(idx).has_nulls()) {
       // cudf::top_k_order takes no null_order, so it cannot honor SQL NULLS FIRST/LAST when
       // selecting which rows are in the top k (it treats NULLs as the largest value). For a
-      // nullable key, fall back to a full sort that honors null placement, then slice the top k.
-      auto sorted = cudf::sort_by_key(
-        input, cudf::table_view({input.column(idx)}), {order}, {null_ord}, stream, memory_resource);
-      if (keep_rows == sorted->num_rows()) {
-        kept = std::move(sorted);
-      } else {
-        auto slices = cudf::slice(sorted->view(), {0, keep_rows}, stream);
-        kept        = std::make_unique<cudf::table>(slices.front(), stream, memory_resource);
-      }
+      // nullable key, fall back to a sort that honors null placement, then take the top k.
+      kept = sorted_order_top_k(input,
+                                cudf::table_view({input.column(idx)}),
+                                {order},
+                                {null_ord},
+                                keep_rows,
+                                stream,
+                                memory_resource);
     } else {
       auto indices =
         cudf::top_k_order(input.column(idx), keep_rows, order, stream, memory_resource);
@@ -100,7 +126,7 @@ std::unique_ptr<cudf::table> compute_top_n_table(
                                memory_resource);
     }
   } else {
-    // Multi-key: fall back to full sort_by_key
+    // Multi-key: cudf::top_k_order is single-column only, so sort the key tuple and take the top k.
     std::vector<cudf::column_view> key_views;
     key_views.reserve(orders.size());
     std::vector<cudf::order> key_orders;
@@ -122,16 +148,13 @@ std::unique_ptr<cudf::table> compute_top_n_table(
       null_orders.push_back(to_cudf_null_order(ord.type, ord.null_order));
     }
 
-    auto keys_table = cudf::table_view(key_views);
-    auto sorted =
-      cudf::sort_by_key(input, keys_table, key_orders, null_orders, stream, memory_resource);
-
-    if (keep_rows == sorted->num_rows()) {
-      kept = std::move(sorted);
-    } else {
-      auto slices = cudf::slice(sorted->view(), {0, keep_rows}, stream);
-      kept        = std::make_unique<cudf::table>(slices.front(), stream, memory_resource);
-    }
+    kept = sorted_order_top_k(input,
+                              cudf::table_view(key_views),
+                              key_orders,
+                              null_orders,
+                              keep_rows,
+                              stream,
+                              memory_resource);
   }
 
   return kept;


### PR DESCRIPTION
## Description

`compute_top_n_table` has three paths. The non-nullable single-key path uses `cudf::top_k_order` and gathers only `offset + limit` rows. The other two — nullable single-key and any multi-key ORDER BY — used `cudf::sort_by_key`, which materializes a **fully sorted copy of every payload column**, then sliced and copied that down to `offset + limit` rows.

On a 512 MB scan batch (`DEFAULT_SCAN_TASK_BATCH_SIZE`) with a small `LIMIT`, that sorts and gathers roughly 16M rows of full-width payload to keep a few hundred, and peaks at ~2× the input — right at the operator's default `no_history_peak_memory_estimate`.

Both paths now use a shared `sorted_order_top_k` helper:

```cpp
auto indices = cudf::sorted_order(keys, key_orders, null_orders, stream, mr);
if (keep_rows < indices->view().size()) { /* slice indices to keep_rows */ }
return cudf::gather(input, indices_view, out_of_bounds_policy::DONT_CHECK, stream, mr);
```

`cudf::sorted_order` produces an `int32` permutation over the key columns instead of a sorted table copy, and the gather touches `keep_rows` rows rather than all of them. Two full-width materializations become one narrow gather.

`sorted_order` accepts `null_precedence` per key, so NULLS FIRST/LAST placement is unchanged — that requirement is exactly why these two branches cannot use `cudf::top_k_order`, which takes no `null_order` and treats NULLs as largest. Neither `sort_by_key` nor `sorted_order` is stable, so tie ordering is unchanged as well. The non-nullable single-key branch is untouched.

No configuration changes, no behavioral changes, no public API changes.

## Checklist
- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above — n/a, no configuration changes
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md) — n/a, internal implementation detail with no documented behavior change

### Testing

No new tests. Existing coverage already exercises both rewritten branches directly — `gpu_execution TOP-N single-key places NULLs correctly for ASC and DESC` covers the nullable path, `gpu_execution TOP-N multi-key places NULLs correctly for ASC and DESC` covers the multi-key path, and `gpu_execution tpcds ORDER BY NULLS FIRST/LAST and top-N` covers both against DuckDB CPU results.

`sirius_unittest "[top_n],[order_by],[nulls]"` — 85/87 cases, 24,886,957 / 24,886,959 assertions pass.

The 2 failures are `gpu_execution - top n parquet` failing `REQUIRE(sirius_ctx != nullptr)`. These are **pre-existing and unrelated**: I stashed this change, rebuilt, and reran, and reproduced the identical 2 failures on the unmodified baseline.

`test/sql/tpch-sirius.test` was not run — this build config does not produce `build/release/test/unittest`. The C++ `[integration]` tests cover the TPC-H queries. Full build is clean and `pre-commit` passes.

### Follow-up considered and deliberately not included

A running top-N threshold (track the N-th best key across batches, filter later batches against it) was evaluated and rejected for now. On the `top_k_order` path it would add a full pass to save the cheapest step — a net regression. On these two sort paths the win is real, but this change removes most of it first, with no warm-up, no cross-task synchronization, and no tie/NULL semantics risk. Pushing that threshold down to the scan as a dynamic zone map is the larger prize, but `sirius_dynamic_filter_set` is append-only by contract and no filter channel is created for a TopN target today; `docs/super-sirius/dynamic-filters.md` lists it under speculative Phase 4 pending a concrete use case.

Separately noted, not addressed here: `LogicalTopN::dynamic_filter` is moved into the operator at `src/planner/sirius_plan_top_n.cpp:41` and never read.

## References

<!-- No related issues -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
