### PR TITLE
docs(exec): streaming-sessions.md documents batch_stream, not its ancestor

### DIFF
--- a/docs/super-sirius/README.md
+++ b/docs/super-sirius/README.md
@@ -37,6 +37,7 @@ SELECT l_returnflag, SUM(l_quantity) FROM lineitem GROUP BY l_returnflag;
 | [Scan](scan.md) | Scan subsystem: unified GPU scan operator, `gpu_ingestible` (parquet + DuckDB-native), scan manager, pinned tables, DuckDB-native decode, row-group pruning, Sirius IO layer (uring/REST/kvikio + prefetching cache) |
 | [Memory Management](memory-management.md) | cuCascade tiers, reservations, downgrade executor |
 | [Data Management](data-management.md) | Data batches, repositories, ports, barrier semantics |
+| [Streaming Sessions](streaming-sessions.md) | Fragment boundaries for distributed queries: `exec::batch_stream`, streaming source/sink, the id-addressed `stream_session`, `streaming_fragment` |
 | [Configuration](configuration.md) | sirius_config, operator_params, SET variables |
 | [Optimizations](optimizations.md) | Performance optimizations with PRs, code paths, configs |
 | [Multi-GPU Architecture](multi-gpu-architecture.md) | How Sirius executes SQL across every GPU on a node — tiers, pin tables, SCHED-RR, cross-GPU transfers, downgrade, concurrency invariants |


### PR DESCRIPTION
Documents #836–#839. Docs only. Part 6 of a twelve-PR stack (parts 1–5 are #1320–#1324).

**What.** `docs/super-sirius/streaming-sessions.md` still described `stream_lifecycle`, an ancestor
that no longer exists; the code it explains is now `exec::batch_stream` and the two operators built on
it. This rewrites the doc around what shipped in parts 1–5 and adds the README index row that makes
it reachable — without that row the doc is orphaned, since the project instructions send readers to
the README's reading order before touching Super Sirius code.

**Design: one difference drives everything.** The doc is organized around the fact the code is: the
repository is already the queue; `batch_stream` owns only what the repository lacks — who is still
producing, whether empty means *wait* or *over*, waking, and the error plane.

- **The contract labels are the code's, verbatim.** P1–P4 as `batch_stream.hpp` declares them and the
  `BSTR-*` tests cite them; S1–S5 cited at the API sketch and at each mechanism they constrain. A
  paraphrase would drift the moment the header changes.
- **Every mechanism states the failure it prevents** — set-not-counter EOS (a repeat close standing
  in for a missing sender), the persistent `on_data` re-arm (a batch arriving after the source was
  dropped), the sink's `execute()` pass-through (a pipeline that "succeeds" with an empty output
  stream). Wait-then-pull non-atomicity keeps its sharp-edge callout (S5).
- **No duplication with `operators.md`.** That file keeps the operator-registry view; this one owns
  the cross-cutting story — stream, session, fragment, the worked distributed-GROUP-BY example, the
  no-backpressure bet, the `exchange_channel` migration table.
- **No forward links into later parts.** The FFI boundary, non-blocking `run()`, and bit-exact
  StarRocks hashing are listed under "Not here yet" as plain text — nothing links to a PR that does
  not exist on this branch.

Re-verifying every claim against the headers on this branch caught one drift: the test table listed
one tag per file, but a case in `test_streaming_fragment.cpp` runs under `[streaming_fragment_control]`
and one in `test_streaming_sink_root.cpp` under `[streaming_sink_root_exec]` — running only the listed
tag would silently skip them. The table now names both.

**Reading order.**
1. `docs/super-sirius/streaming-sessions.md` — the whole change; sections follow the data (stream →
   source → sink → session → fragment → worked example → scoped-out list → test map).
2. `docs/super-sirius/README.md` — 1 line, the index row.

### Stack: part 6 of 12
- **Base:** `stream/05-plan` (#1324)
- **Depends on:** #1324 (part 5), transitively #1323 / #1322 / #1321 / #1320
