### PR TITLE
feat(ffi): load core_functions into the embedded DuckDB

### DIFF
--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -73,22 +73,25 @@ struct Context::Impl {
     // path needs. Idempotent; the transparent path does this at extension load.
     sirius::converter_registry::initialize();
 
-    // Lowering a Substrait `local_files` read produces a `parquet_scan`, so the
-    // embedded DuckDB must have the parquet extension to bind it. Dev stopgap until
-    // parquet is linked into the engine: ONLY when SIRIUS_DUCKDB_PARQUET_EXTENSION
-    // points at a (locally-built, unsigned) parquet extension do we opt into
-    // unsigned loading and load it. Absent the env var, no unsigned loading is
-    // enabled — the default trust boundary is unchanged.
+    // The embedded DuckDB ships without the two extensions this path binds against: parquet
+    // (a Substrait local_files read lowers to parquet_scan) and core_functions (scalar and
+    // aggregate bindings resolve against it — without it the first aggregating plan fails to
+    // bind: Scalar Function with name "sum" is not in the catalog). Dev stopgap until both are
+    // linked into the engine: each loads only when its env var points at a locally-built copy,
+    // and unsigned loading is opted into only when at least one is configured — absent both,
+    // the default trust boundary is unchanged.
     duckdb::DBConfig db_config;
-    const char* parquet_ext = std::getenv("SIRIUS_DUCKDB_PARQUET_EXTENSION");
-    if (parquet_ext != nullptr) {
+    const char* parquet_ext        = std::getenv("SIRIUS_DUCKDB_PARQUET_EXTENSION");
+    const char* core_functions_ext = std::getenv("SIRIUS_DUCKDB_CORE_FUNCTIONS_EXTENSION");
+    if (parquet_ext != nullptr || core_functions_ext != nullptr) {
       db_config.SetOptionByName("allow_unsigned_extensions", duckdb::Value::BOOLEAN(true));
     }
     db   = duckdb::make_uniq<duckdb::DuckDB>(nullptr, &db_config);
     conn = duckdb::make_uniq<duckdb::Connection>(*db);
-    if (parquet_ext != nullptr) {
+    for (const char* extension : {core_functions_ext, parquet_ext}) {
+      if (extension == nullptr) { continue; }
       // Escape single quotes so the path can't break out of the SQL string literal.
-      std::string escaped(parquet_ext);
+      std::string escaped(extension);
       for (std::size_t pos = escaped.find('\''); pos != std::string::npos;
            pos             = escaped.find('\'', pos + 2)) {
         escaped.replace(pos, 1, "''");


### PR DESCRIPTION
Ports integration commit `c2783171`; no tracking issue. Part 7 of a twelve-PR stack.

**What.** The FFI's embedded DuckDB already loads parquet this way, gated behind
`SIRIUS_DUCKDB_PARQUET_EXTENSION`, because a Substrait `local_files` read lowers to `parquet_scan`.
This is the same move for the function catalog: Substrait scalar and aggregate bindings resolve by
name, and those names live in `core_functions`, which the embedded DuckDB does not ship with.

**Design: a catalog lookup, not a link-time symbol.** The only question is whether `core_functions` is
in the catalog before the first plan binds. Without it the first aggregating fragment a compute node
dispatches fails at plan time with `Scalar Function with name "sum" is not in the catalog`, before any
GPU work runs.

- **`SIRIUS_DUCKDB_CORE_FUNCTIONS_EXTENSION` mirrors the parquet variable.** Both are the same dev
  stopgap until the extensions are linked in; a hardcoded path would break every environment that
  builds DuckDB extensions elsewhere.
- **Unsigned loading is opted into only when a variable is configured.** An unconditional
  `allow_unsigned_extensions` would widen the trust boundary for embeddings that load nothing.
- **The two loads share one loop and one quote-escaping site.** Duplicating the parquet block would
  mean two places to get SQL-literal escaping right; a path containing `'` must not break out of the
  `LOAD '...'` string at either.

**Reading order.**
1. `src/sirius_ffi.cpp` — one hunk in `Context::Impl::bring_up`; the comment above the load loop is
   the design note.

No direct tests: a missing `core_functions` fails the first bound plan loudly, never silently, and
every FFI test downstream exercises it. End-to-end coverage of the aggregate path arrives in parts
9–10.

### Stack: part 7 of 12
- **Base:** `stream/06-doc-fix` (#1394)
- **Depends on:** part 6 (#1394) for stacking order only; functionally nothing above `dev`
