### PR TITLE
feat(ffi): a plan fragment reachable from Rust

### DIFF
--- a/docs/super-sirius/streaming-sessions.md
+++ b/docs/super-sirius/streaming-sessions.md
@@ -258,6 +258,12 @@ long before physical planning. The catalog is registered as a `ClientContextStat
 `sirius_stream_source(id)` can resolve a schema at bind time; the physical plan generator
 re-reads the catalog at plan time to build each `STREAMING_SOURCE`.
 
+`sirius::ffi::Fragment` (`src/include/sirius_ffi.hpp`, `src/sirius_ffi.cpp`) is the cxx-FFI
+wrapper over this substrate: a Rust caller declares inputs and outputs, builds a Substrait plan
+against them (each input read through a `sirius_stream_<id>` view), relays each sender in, and
+runs, with engine exceptions crossing the bridge as `Result`. No batch type crosses cxx —
+`relay_from` moves batches entirely inside C++, and Arrow appears only at a result fragment.
+
 ## Tests
 
 | File | Catch2 tag |

--- a/rust/crates/sirius-sys/src/lib.rs
+++ b/rust/crates/sirius-sys/src/lib.rs
@@ -55,7 +55,72 @@ mod ffi {
             plan: &CxxString,
             out_stream_addr: usize,
         ) -> Result<()>;
+
+        /// One plan fragment of a multi-fragment query. Either declares output
+        /// streams (an intermediate fragment, whose results park as native GPU
+        /// batches that outlive its own query) or none (a result fragment,
+        /// which produces Arrow).
+        type Fragment;
+
+        /// Create a [`Fragment`] on `context`, which must outlive it.
+        fn make_fragment(context: Pin<&mut Context>) -> Result<UniquePtr<Fragment>>;
+
+        /// Name of the view a plan reads to consume input stream `stream_id` —
+        /// the single definition of the convention, so a front end emitting the
+        /// read and the engine creating the view cannot drift apart.
+        fn stream_view_name(stream_id: u64) -> UniquePtr<CxxString>;
+
+        /// Declare one column of an input stream, in plan order. `ty` is a
+        /// DuckDB type name; a stream has no file to probe.
+        fn declare_input_column(
+            self: Pin<&mut Fragment>,
+            stream_id: u64,
+            name: &CxxString,
+            ty: &CxxString,
+        ) -> Result<()>;
+
+        /// Declare a sender that must close this input stream before it ends.
+        fn declare_input_sender(
+            self: Pin<&mut Fragment>,
+            stream_id: u64,
+            sender_id: u32,
+        ) -> Result<()>;
+
+        /// Declare an output stream. A fragment with none is a result fragment.
+        fn declare_output(self: Pin<&mut Fragment>, stream_id: u64) -> Result<()>;
+
+        /// Plan `substrait_plan` against the declared streams and open the
+        /// fragment's query lifecycle.
+        fn build(self: Pin<&mut Fragment>, substrait_plan: &CxxString) -> Result<()>;
+
+        /// Move every batch parked on `source`'s output stream into this
+        /// fragment's input stream as native handles — no Arrow, no file, no
+        /// copy — then close `sender_id`. Returns the number of batches moved.
+        fn relay_from(
+            self: Pin<&mut Fragment>,
+            source: Pin<&mut Fragment>,
+            source_stream_id: u64,
+            input_stream_id: u64,
+            sender_id: u32,
+        ) -> Result<usize>;
+
+        /// Execute the fragment and close its query lifecycle.
+        fn run(self: Pin<&mut Fragment>) -> Result<()>;
+
+        /// Write a result fragment's rows into the caller-owned
+        /// `ArrowArrayStream` at `out_stream_addr`.
+        ///
+        /// # Safety
+        /// `out_stream_addr` must be the address of a valid, writable
+        /// `ArrowArrayStream` that outlives this call.
+        unsafe fn result_to_arrow(self: Pin<&mut Fragment>, out_stream_addr: usize) -> Result<()>;
+
+        /// Batches currently parked on an output stream — the evidence that a
+        /// fragment boundary carried native batches rather than nothing.
+        fn output_batch_count(self: &Fragment, stream_id: u64) -> Result<usize>;
     }
 }
 
-pub use ffi::{Context, make_context, make_context_from_config};
+pub use ffi::{
+    Context, Fragment, make_context, make_context_from_config, make_fragment, stream_view_name,
+};

--- a/rust/crates/sirius/src/lib.rs
+++ b/rust/crates/sirius/src/lib.rs
@@ -8,6 +8,8 @@
 //! Sirius library: constructing a [`SiriusContext`] from defaults or a YAML
 //! config file. More of the API surface is added in later PRs.
 
+use std::cell::RefCell;
+use std::marker::PhantomData;
 use std::path::Path;
 
 use arrow_array::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
@@ -29,7 +31,13 @@ use cxx::{Exception, UniquePtr, let_cxx_string};
 /// is not yet supported (enforcement is a follow-up).
 pub struct SiriusContext {
     // RAII handle owning the C++ engine context for its lifetime.
-    inner: UniquePtr<sirius_sys::Context>,
+    //
+    // Behind a `RefCell` because every call into C++ needs `Pin<&mut Context>` while a
+    // [`Fragment`] only borrows the context immutably: several fragments of one query are alive
+    // at once (senders parked, waiting for their receiver), and a `&mut self` factory would allow
+    // exactly one. The borrow is taken and released within each call, and the context is neither
+    // `Send` nor `Sync`, so there is no cross-thread aliasing to worry about.
+    inner: RefCell<UniquePtr<sirius_sys::Context>>,
 }
 
 /// Fully materialized output of one Substrait execution.
@@ -45,7 +53,7 @@ impl SiriusContext {
     /// built-in defaults.
     pub fn new() -> Result<Self, Exception> {
         Ok(Self {
-            inner: sirius_sys::make_context()?,
+            inner: RefCell::new(sirius_sys::make_context()?),
         })
     }
 
@@ -56,7 +64,19 @@ impl SiriusContext {
         // one from the (lossy) UTF-8 form of the platform path.
         let_cxx_string!(config_path = path.to_string_lossy().as_ref());
         Ok(Self {
-            inner: sirius_sys::make_context_from_config(&config_path)?,
+            inner: RefCell::new(sirius_sys::make_context_from_config(&config_path)?),
+        })
+    }
+
+    /// Start a new [`Fragment`] on this context.
+    ///
+    /// The returned fragment borrows the context, so the compiler enforces the one lifetime rule
+    /// the C++ side cannot: a fragment must not outlive the engine it runs on.
+    pub fn fragment(&self) -> Result<Fragment<'_>, Exception> {
+        let mut context = self.inner.borrow_mut();
+        Ok(Fragment {
+            inner: sirius_sys::make_fragment(context.pin_mut())?,
+            _context: PhantomData,
         })
     }
 
@@ -71,15 +91,12 @@ impl SiriusContext {
     /// Arrow stream converts each batch using this context's client state, so the
     /// stream is drained while the context is alive; the returned batches own
     /// their buffers and are independent of the context's lifetime.
-    pub fn execute_substrait(&mut self, plan: &[u8]) -> Result<Vec<RecordBatch>, SiriusError> {
+    pub fn execute_substrait(&self, plan: &[u8]) -> Result<Vec<RecordBatch>, SiriusError> {
         Ok(self.execute_substrait_result(plan)?.batches)
     }
 
     /// Execute a serialized Substrait plan and retain its Arrow schema for empty results.
-    pub fn execute_substrait_result(
-        &mut self,
-        plan: &[u8],
-    ) -> Result<SubstraitResult, SiriusError> {
+    pub fn execute_substrait_result(&self, plan: &[u8]) -> Result<SubstraitResult, SiriusError> {
         // The engine writes a self-owning Arrow C Data Interface stream into
         // `stream`; the FFI takes its address as an integer (a `uintptr_t`).
         let mut stream = FFI_ArrowArrayStream::empty();
@@ -89,17 +106,136 @@ impl SiriusContext {
         // `FFI_ArrowArrayStream` owned by this stack frame for the call's duration.
         unsafe {
             self.inner
+                .borrow_mut()
                 .pin_mut()
                 .execute_substrait(&plan, out_stream_addr)
                 .map_err(SiriusError::Engine)?;
         }
         // Drain fully while `self` is alive (conversion dereferences the context).
-        let reader = ArrowArrayStreamReader::try_new(stream).map_err(SiriusError::Arrow)?;
-        let schema = reader.schema();
-        let batches = reader
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(SiriusError::Arrow)?;
-        Ok(SubstraitResult { schema, batches })
+        collect_arrow_stream(stream)
+    }
+}
+
+/// Drains a filled Arrow C Data Interface stream into owned batches, retaining the schema.
+fn collect_arrow_stream(stream: FFI_ArrowArrayStream) -> Result<SubstraitResult, SiriusError> {
+    let reader = ArrowArrayStreamReader::try_new(stream).map_err(SiriusError::Arrow)?;
+    let schema = reader.schema();
+    let batches = reader
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(SiriusError::Arrow)?;
+    Ok(SubstraitResult { schema, batches })
+}
+
+/// The name of the view a plan must read to consume input stream `stream_id`.
+///
+/// A front end emits a read of this name where it would otherwise emit a file scan; the engine
+/// creates the view when the fragment is built. Both sides call this, so the convention has one
+/// definition.
+pub fn stream_view_name(stream_id: u64) -> String {
+    sirius_sys::stream_view_name(stream_id)
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// One plan fragment of a multi-fragment query.
+///
+/// A fragment declaring one or more **output streams** is rooted in a streaming sink: its results
+/// stay on the GPU as native batches that outlive its own query, ready for a downstream fragment
+/// to take with [`Fragment::relay_from`]. A fragment declaring **none** is a result fragment and
+/// produces Arrow via [`Fragment::into_arrow`].
+///
+/// Calls are ordered: declare, [`build`](Fragment::build), relay from every sender,
+/// [`run`](Fragment::run), then drain. `build` opens a query lifecycle on the shared engine that
+/// `run` closes, so one fragment at a time may sit between the two — dropping a built-but-unrun
+/// fragment closes the lifecycle for you.
+pub struct Fragment<'ctx> {
+    inner: UniquePtr<sirius_sys::Fragment>,
+    /// Ties the fragment's lifetime to the context that made it.
+    _context: PhantomData<&'ctx SiriusContext>,
+}
+
+impl Fragment<'_> {
+    /// Declare one column of input stream `stream_id`, in plan order. `ty` is a DuckDB type name
+    /// (`BIGINT`, `DECIMAL(15,2)`, `DATE`, …).
+    pub fn declare_input_column(
+        &mut self,
+        stream_id: u64,
+        name: &str,
+        ty: &str,
+    ) -> Result<(), Exception> {
+        let_cxx_string!(name = name);
+        let_cxx_string!(ty = ty);
+        self.inner
+            .pin_mut()
+            .declare_input_column(stream_id, &name, &ty)
+    }
+
+    /// Declare a sender that must close input stream `stream_id` before it ends. With none
+    /// declared the stream expects the single sender `0`.
+    pub fn declare_input_sender(
+        &mut self,
+        stream_id: u64,
+        sender_id: u32,
+    ) -> Result<(), Exception> {
+        self.inner
+            .pin_mut()
+            .declare_input_sender(stream_id, sender_id)
+    }
+
+    /// Declare an output stream. A fragment with no output stream is a result fragment.
+    pub fn declare_output(&mut self, stream_id: u64) -> Result<(), Exception> {
+        self.inner.pin_mut().declare_output(stream_id)
+    }
+
+    /// Plan `substrait_plan` against the declared streams and open the fragment's query lifecycle.
+    pub fn build(&mut self, substrait_plan: &[u8]) -> Result<(), Exception> {
+        let_cxx_string!(plan = substrait_plan);
+        self.inner.pin_mut().build(&plan)
+    }
+
+    /// Move every batch parked on `source`'s output stream into this fragment's input stream —
+    /// as native GPU batch handles, with no Arrow and no file in between — then close `sender_id`.
+    ///
+    /// Returns the number of batches moved. `source` must have finished [`run`](Fragment::run).
+    pub fn relay_from(
+        &mut self,
+        source: &mut Fragment<'_>,
+        source_stream_id: u64,
+        input_stream_id: u64,
+        sender_id: u32,
+    ) -> Result<usize, Exception> {
+        self.inner.pin_mut().relay_from(
+            source.inner.pin_mut(),
+            source_stream_id,
+            input_stream_id,
+            sender_id,
+        )
+    }
+
+    /// Execute the fragment and close its query lifecycle. Blocks until its pipelines finish.
+    pub fn run(&mut self) -> Result<(), Exception> {
+        self.inner.pin_mut().run()
+    }
+
+    /// Collect a result fragment's rows over the Arrow C Data Interface.
+    pub fn into_arrow(&mut self) -> Result<SubstraitResult, SiriusError> {
+        let mut stream = FFI_ArrowArrayStream::empty();
+        let out_stream_addr = std::ptr::addr_of_mut!(stream) as usize;
+        // SAFETY: `out_stream_addr` is the address of `stream`, a live, writable
+        // `FFI_ArrowArrayStream` owned by this stack frame for the call's duration.
+        unsafe {
+            self.inner
+                .pin_mut()
+                .result_to_arrow(out_stream_addr)
+                .map_err(SiriusError::Engine)?;
+        }
+        collect_arrow_stream(stream)
+    }
+
+    /// Batches currently parked on output stream `stream_id`. A result fragment reports 0 for
+    /// every id — it parks nothing by definition.
+    pub fn output_batch_count(&self, stream_id: u64) -> Result<usize, Exception> {
+        self.inner.output_batch_count(stream_id)
     }
 }
 
@@ -239,7 +375,7 @@ mod tests {
         // Execute twice on one context to verify standalone query state is reset,
         // then drop it before inspecting the returned owned results.
         let results = {
-            let mut ctx = SiriusContext::new().expect("bring up sirius context");
+            let ctx = SiriusContext::new().expect("bring up sirius context");
             vec![
                 ctx.execute_substrait_result(&plan)
                     .expect("execute first substrait plan"),

--- a/src/include/sirius_ffi.hpp
+++ b/src/include/sirius_ffi.hpp
@@ -39,6 +39,15 @@
 
 namespace sirius::ffi {
 
+class Fragment;
+
+namespace detail {
+/// Engine handle + embedded DuckDB behind a [`Context`]. Defined in the .cpp so this public
+/// header pulls in no DuckDB/cudf/rmm types; named here (rather than nested and private) because
+/// a `Fragment` runs on the same connection and has to reach it.
+struct context_state;
+}  // namespace detail
+
 /// RAII handle to a Sirius engine context.
 ///
 /// Constructing a `Context` brings up an initialized engine (a
@@ -75,10 +84,93 @@ class SIRIUS_FFI_EXPORT Context {
   void execute_substrait(const std::string& plan, std::uintptr_t out_stream_addr);
 
  private:
-  // PIMPL: the engine handle + embedded DuckDB live in the .cpp so this public
-  // header pulls in no DuckDB/cudf/rmm types (DuckDB uses its own smart pointers).
+  // PIMPL: see detail::context_state.
+  std::unique_ptr<detail::context_state> impl_;
+
+  friend class Fragment;
+  friend SIRIUS_FFI_EXPORT std::unique_ptr<Fragment> make_fragment(Context& context);
+};
+
+/// One plan fragment of a multi-fragment query, executed on this process's [`Context`].
+///
+/// A fragment is either **intermediate** — it declares one or more output streams and is rooted in
+/// a streaming sink, parking its results as native `cucascade::data_batch`es that outlive its own
+/// query — or a **result** fragment, which declares none and produces Arrow for the caller.
+/// Both kinds may declare input streams, which is how one fragment's output becomes another's
+/// input without Arrow, parquet, or a copy.
+///
+/// Usage is strictly ordered: declare inputs and outputs, `build`, `relay_from` every sender,
+/// `run`, then either drain via a downstream fragment's `relay_from` or `result_to_arrow`.
+///
+/// `build()` opens a query lifecycle on the shared context and `run()` closes it, so exactly one
+/// fragment may sit between its own `build` and `run` at a time — the engine serializes queries
+/// anyway. A `Fragment` destroyed after `build()` but before `run()` closes the lifecycle itself.
+///
+/// The `Context` must outlive every `Fragment` made from it.
+class SIRIUS_FFI_EXPORT Fragment {
+ public:
+  ~Fragment();
+
+  Fragment(const Fragment&)            = delete;
+  Fragment& operator=(const Fragment&) = delete;
+
+  /// Declare one column of input stream `stream_id`, in plan order. `type` is a DuckDB type name
+  /// (`BIGINT`, `DECIMAL(15,2)`, `DATE`, …) — a stream has no file to probe, so the front end's
+  /// descriptor table is the only schema source.
+  /// @throws after `build()`, or on an unparsable type name.
+  void declare_input_column(std::uint64_t stream_id,
+                            const std::string& name,
+                            const std::string& type);
+
+  /// Declare a sender that must close input stream `stream_id` before it ends. With none
+  /// declared, the stream expects the single sender `0`.
+  /// @throws after `build()`.
+  void declare_input_sender(std::uint64_t stream_id, std::uint32_t sender_id);
+
+  /// Declare an output stream. A fragment with no output stream is a result fragment.
+  /// @throws after `build()`, or on a duplicate id.
+  void declare_output(std::uint64_t stream_id);
+
+  /// Plan `substrait_plan` against the declared streams and open this fragment's query lifecycle.
+  /// Reads of a declared input stream must name the view `sirius_stream_<id>`, which this call
+  /// creates.
+  /// @throws on a translation or planning failure, or if already built.
+  void build(const std::string& substrait_plan);
+
+  /// Move every batch parked on `source`'s output stream `source_stream_id` into this fragment's
+  /// input stream `input_stream_id`, then close `sender_id` on it.
+  ///
+  /// The batches move as native handles: no Arrow, no file, no copy. `source` must have finished
+  /// `run()`; its output survives its own lifecycle, which is what makes the sequential relay
+  /// legal.
+  /// @return the number of batches moved.
+  /// @throws when either stream id is unknown, or before `build()`.
+  std::size_t relay_from(Fragment& source,
+                         std::uint64_t source_stream_id,
+                         std::uint64_t input_stream_id,
+                         std::uint32_t sender_id);
+
+  /// Execute the fragment and close its query lifecycle. Blocks until its pipelines finish.
+  /// @throws before `build()`, or on an execution failure.
+  void run();
+
+  /// Write this result fragment's rows into the caller-owned `ArrowArrayStream` at
+  /// `out_stream_addr`, per the Arrow C Data Interface — the same contract as
+  /// `Context::execute_substrait`.
+  /// @throws on an intermediate fragment, or before `run()`.
+  void result_to_arrow(std::uintptr_t out_stream_addr);
+
+  /// Batches currently parked on output stream `stream_id`. Diagnostics: it is how a caller
+  /// confirms a fragment boundary carried native batches rather than nothing. A result fragment
+  /// reports 0 for every id — it parks nothing by definition.
+  [[nodiscard]] std::size_t output_batch_count(std::uint64_t stream_id) const;
+
+ private:
   struct Impl;
+  explicit Fragment(std::unique_ptr<Impl> impl);
   std::unique_ptr<Impl> impl_;
+
+  friend SIRIUS_FFI_EXPORT std::unique_ptr<Fragment> make_fragment(Context& context);
 };
 
 /// Create an initialized [`Context`] configured from built-in defaults, owned by
@@ -88,5 +180,15 @@ SIRIUS_FFI_EXPORT std::unique_ptr<Context> make_context();
 /// Create an initialized [`Context`] configured from the YAML file at
 /// `config_path`, owned by the returned `unique_ptr`.
 SIRIUS_FFI_EXPORT std::unique_ptr<Context> make_context_from_config(const std::string& config_path);
+
+/// Create a [`Fragment`] on `context`. The context must outlive it.
+SIRIUS_FFI_EXPORT std::unique_ptr<Fragment> make_fragment(Context& context);
+
+/// Name of the view a plan must read to consume input stream `stream_id`. `Fragment::build`
+/// creates it; a front end emits a read of this name where it would otherwise emit a file scan.
+///
+/// Returned by `unique_ptr` so the cxx bridge can bind it directly — the convention has to have
+/// exactly one definition, and that is only true if both languages read it from here.
+SIRIUS_FFI_EXPORT std::unique_ptr<std::string> stream_view_name(std::uint64_t stream_id);
 
 }  // namespace sirius::ffi

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -36,13 +36,20 @@
 #include "duckdb/planner/planner.hpp"                      // duckdb::Planner
 #include "exec/stream_bind_catalog.hpp"                    // sirius::exec::stream_bind_catalog
 #include "exec/stream_plan_bindings.hpp"  // sirius::exec::register_stream_source_function
+#include "exec/streaming_fragment.hpp"    // sirius::exec::streaming_fragment
 #include "from_substrait.hpp"             // duckdb::SubstraitToDuckDB (compiled into libsirius)
+#include "helper/type_conversions.hpp"    // sirius::from_duckdb
 #include "planner/sirius_physical_plan_generator.hpp"  // sirius::planner::sirius_physical_plan_generator
+#include "sirius/exception.hpp"                        // sirius::invalid_input_exception
 #include "sirius_config.hpp"                           // sirius::sirius_config
 #include "sirius_context.hpp"                          // duckdb::SiriusContext
 #include "sirius_interface.hpp"  // sirius::sirius_interface, sirius::sirius_prepared_statement_data
 
-#include <cstdlib>  // std::getenv
+#include <algorithm>  // std::find
+#include <cstdlib>    // std::getenv
+#include <map>
+#include <optional>
+#include <vector>
 
 namespace sirius::ffi {
 
@@ -52,11 +59,50 @@ constexpr const char* kSiriusStateKey = "sirius_state";
 constexpr const char* kQueryLabel     = "sirius_ffi";
 // Arrow record-batch size for the exported stream; the consumer re-batches as needed.
 constexpr duckdb::idx_t kArrowBatchSize = 1u << 20;
+
+/// A Substrait plan lowered to the pair the Sirius planner needs: a bound, optimized DuckDB
+/// logical plan and the statement metadata that travels with it.
+struct lowered_plan {
+  duckdb::unique_ptr<duckdb::LogicalOperator> plan;
+  duckdb::shared_ptr<duckdb::PreparedStatementData> prepared;
+};
+
+/// Substrait bytes -> bound + optimized DuckDB `LogicalOperator`. DuckDB is used only for this
+/// lowering; execution runs on the Sirius engine. Shared by the single-shot path and by
+/// `Fragment`, which needs the same lowering with its input streams declared first.
+lowered_plan lower_substrait(duckdb::Connection& conn, const std::string& plan_bytes)
+{
+  auto& client = *conn.context;
+
+  duckdb::SubstraitToDuckDB transformer(conn.context, plan_bytes, /*json=*/false);
+  auto relation = transformer.TransformPlan();
+
+  duckdb::Planner planner(client);
+  planner.CreatePlan(duckdb::make_uniq<duckdb::RelationStatement>(relation));
+
+  auto prepared =
+    duckdb::make_shared_ptr<duckdb::PreparedStatementData>(duckdb::StatementType::SELECT_STATEMENT);
+  prepared->names     = planner.names;
+  prepared->types     = planner.types;
+  prepared->value_map = std::move(planner.value_map);
+
+  auto logical_plan = std::move(planner.plan);
+  if (client.config.enable_optimizer) {
+    duckdb::Optimizer optimizer(*planner.binder, client);
+    logical_plan = optimizer.Optimize(std::move(logical_plan));
+  }
+  logical_plan->ResolveOperatorTypes();
+  duckdb::ColumnBindingResolver resolver;
+  duckdb::ColumnBindingResolver::Verify(*logical_plan);
+  resolver.VisitOperator(*logical_plan);
+
+  return lowered_plan{std::move(logical_plan), std::move(prepared)};
+}
 }  // namespace
 
 // PIMPL: holds the engine + embedded DuckDB using DuckDB's own smart pointers
 // (duckdb::shared_ptr, so the SiriusContext can register as a ClientContextState).
-struct Context::Impl {
+struct detail::context_state {
   duckdb::shared_ptr<duckdb::SiriusContext> context;
   duckdb::unique_ptr<duckdb::DuckDB> db;
   duckdb::unique_ptr<duckdb::Connection> conn;
@@ -130,14 +176,14 @@ struct Context::Impl {
   }
 };
 
-Context::Context() : impl_(std::make_unique<Impl>())
+Context::Context() : impl_(std::make_unique<detail::context_state>())
 {
   sirius::sirius_config config;
   config.apply_defaults();  // populate default GPU/host/disk memory spaces
   impl_->bring_up(config);
 }
 
-Context::Context(const std::string& config_path) : impl_(std::make_unique<Impl>())
+Context::Context(const std::string& config_path) : impl_(std::make_unique<detail::context_state>())
 {
   sirius::sirius_config config;
   config.load_from_file(config_path);  // throws on a missing/invalid config file
@@ -160,30 +206,9 @@ void Context::execute_substrait(const std::string& plan, std::uintptr_t out_stre
   impl_->conn->BeginTransaction();
   duckdb::unique_ptr<duckdb::QueryResult> result;
   try {
-    // 1. Substrait bytes -> DuckDB Relation. DuckDB is used only for this lowering.
-    duckdb::SubstraitToDuckDB transformer(impl_->conn->context, plan, /*json=*/false);
-    auto relation = transformer.TransformPlan();
-
-    // 2. Relation -> bound + optimized DuckDB LogicalOperator (mirrors the GPU bind path:
-    //    SiriusTableFunctionData::ExtractPlan + GPUExecutionBind).
-    duckdb::Planner planner(client);
-    planner.CreatePlan(duckdb::make_uniq<duckdb::RelationStatement>(relation));
-
-    auto prepared = duckdb::make_shared_ptr<duckdb::PreparedStatementData>(
-      duckdb::StatementType::SELECT_STATEMENT);
-    prepared->names     = planner.names;
-    prepared->types     = planner.types;
-    prepared->value_map = std::move(planner.value_map);
-
-    auto logical_plan = std::move(planner.plan);
-    if (client.config.enable_optimizer) {
-      duckdb::Optimizer optimizer(*planner.binder, client);
-      logical_plan = optimizer.Optimize(std::move(logical_plan));
-    }
-    logical_plan->ResolveOperatorTypes();
-    duckdb::ColumnBindingResolver resolver;
-    duckdb::ColumnBindingResolver::Verify(*logical_plan);
-    resolver.VisitOperator(*logical_plan);
+    // 1./2. Substrait bytes -> bound + optimized DuckDB LogicalOperator (mirrors the GPU bind
+    //       path: SiriusTableFunctionData::ExtractPlan + GPUExecutionBind).
+    auto lowered = lower_substrait(*impl_->conn, plan);
 
     // 3. DuckDB LogicalOperator -> Sirius GPU physical plan -> execute directly
     // on the engine, inside an execution window: begin mutations and slot
@@ -194,9 +219,9 @@ void Context::execute_substrait(const std::string& plan, std::uintptr_t out_stre
     {
       duckdb::SiriusContext::StandaloneQueryScope window(*impl_->context, client, kQueryLabel);
       auto physical_plan = sirius::planner::sirius_physical_plan_generator(client).create_plan(
-        std::move(logical_plan));
+        std::move(lowered.plan));
       auto gpu_prepared = duckdb::make_shared_ptr<sirius::sirius_prepared_statement_data>(
-        std::move(prepared), std::move(physical_plan));
+        std::move(lowered.prepared), std::move(physical_plan));
 
       sirius::sirius_interface iface(client, std::optional<std::string>(kQueryLabel));
       result = iface.sirius_execute_query(
@@ -217,11 +242,359 @@ void Context::execute_substrait(const std::string& plan, std::uintptr_t out_stre
   *reinterpret_cast<ArrowArrayStream*>(out_stream_addr) = wrapper->stream;
 }
 
+namespace {
+std::string stream_view_name_of(std::uint64_t stream_id)
+{
+  return "sirius_stream_" + std::to_string(stream_id);
+}
+}  // namespace
+
+std::unique_ptr<std::string> stream_view_name(std::uint64_t stream_id)
+{
+  return std::make_unique<std::string>(stream_view_name_of(stream_id));
+}
+
+// ---------------------------------------------------------------------------
+// Fragment
+// ---------------------------------------------------------------------------
+
+struct Fragment::Impl {
+  explicit Impl(detail::context_state& ctx) : ctx(ctx) {}
+
+  ~Impl()
+  {
+    // A fragment dropped between build() and run() still holds the context's execution window.
+    // Abandoning it here keeps a failed fragment from wedging every later statement on this
+    // connection — the failure mode is a silent deadlock, so it must not depend on the caller
+    // remembering to run().
+    abandon_lifecycle();
+  }
+
+  detail::context_state& ctx;
+
+  /// One input stream as the caller declared it. The column types are kept as DuckDB type
+  /// *names* and parsed in build(): parsing needs an active transaction (it may resolve a
+  /// user-defined type through the catalog), and a declaration happens before there is one.
+  struct declared_input {
+    std::vector<std::string> names;
+    std::vector<std::string> type_names;
+    std::set<sirius::exec::sender_id_t> expected_senders;
+  };
+
+  //! Declared before build(); the map is what the bind catalog is populated from.
+  std::map<sirius::exec::stream_id_t, declared_input> inputs;
+  std::vector<sirius::exec::stream_id_t> outputs;
+
+  //! Intermediate fragment: a streaming sink root, owning its own repositories and session.
+  std::unique_ptr<sirius::exec::streaming_fragment> fragment;
+
+  //! Result fragment: a RESULT_COLLECTOR root. The input repositories, the session borrowing the
+  //! built sources out of the plan, and the plan itself all have to outlive build().
+  std::map<sirius::exec::stream_id_t, std::shared_ptr<cucascade::shared_data_repository>>
+    result_input_repos;
+  sirius::exec::stream_session result_session;
+  duckdb::shared_ptr<sirius::sirius_prepared_statement_data> result_plan;
+  duckdb::unique_ptr<duckdb::QueryResult> result;
+
+  //! The fragment's execution window, open from build() to run(). The scope's noexcept
+  //! destructor is the backstop for every path that never reaches a clean finish().
+  std::optional<duckdb::SiriusContext::StandaloneQueryScope> window;
+
+  bool built{false};
+  bool ran{false};
+  bool transaction_open{false};
+
+  [[nodiscard]] bool is_result() const { return outputs.empty(); }
+
+  sirius::exec::stream_session& session()
+  {
+    return fragment ? fragment->session() : result_session;
+  }
+
+  void begin_transaction()
+  {
+    ctx.conn->BeginTransaction();
+    transaction_open = true;
+  }
+
+  void begin_lifecycle() { window.emplace(*ctx.context, *ctx.conn->context, kQueryLabel); }
+
+  //! Clean close: mandatory per-query cleanup, then commit. Either may throw — the fragment
+  //! then errors, exactly as execute_substrait() errors when its window fails to finish.
+  //! Ordering is load-bearing: finish() releases the execution slot before Commit() runs an
+  //! ordinary statement that re-takes the query-lifecycle mutex on this same thread.
+  void end_lifecycle()
+  {
+    if (window) {
+      window->finish();
+      window.reset();
+    }
+    if (transaction_open) {
+      transaction_open = false;
+      ctx.conn->Commit();
+    }
+  }
+
+  //! Failure/abandon close: never throws, so it can run from catch blocks and from ~Impl. The
+  //! scope destructor attempts the mandatory cleanup once and always releases the slot; the
+  //! transaction rolls back, mirroring execute_substrait()'s error path.
+  void abandon_lifecycle() noexcept
+  {
+    window.reset();
+    if (transaction_open) {
+      transaction_open = false;
+      try {
+        ctx.conn->Rollback();
+      } catch (...) {  // NOLINT(bugprone-empty-catch)
+      }
+    }
+  }
+
+  void require_not_built(const char* what) const
+  {
+    if (built) {
+      throw sirius::invalid_input_exception(std::string("Fragment: ") + what +
+                                            " must be called before build()");
+    }
+  }
+
+  //! Resolves each declared stream to a `stream_input_spec`, parsing its column type names.
+  //! Requires an open transaction.
+  std::map<sirius::exec::stream_id_t, sirius::exec::stream_input_spec> resolve_inputs() const
+  {
+    std::map<sirius::exec::stream_id_t, sirius::exec::stream_input_spec> resolved;
+    for (const auto& [id, declared] : inputs) {
+      sirius::exec::stream_input_spec spec;
+      spec.names = declared.names;
+      spec.types.reserve(declared.type_names.size());
+      for (const auto& type_name : declared.type_names) {
+        spec.types.push_back(
+          sirius::from_duckdb(duckdb::TransformStringToLogicalType(type_name, *ctx.conn->context)));
+      }
+      spec.expected_senders = declared.expected_senders;
+      // A stream with no declared sender expects the single sender 0, which is the gather case.
+      if (spec.expected_senders.empty()) { spec.expected_senders.insert(0); }
+      resolved.emplace(id, std::move(spec));
+    }
+    return resolved;
+  }
+
+  //! Creates the view each declared stream is read through. Runs *before* the execution window
+  //! opens, because creating a view is an ordinary DuckDB statement and an ordinary statement
+  //! takes the query-lifecycle mutex the window holds — and *after* the streams are declared,
+  //! because DuckDB binds a view's body at CREATE time, which resolves the stream's schema out
+  //! of the bind catalog.
+  void create_stream_views()
+  {
+    for (const auto& [id, _] : inputs) {
+      auto view   = stream_view_name_of(id);
+      auto create = ctx.conn->Query("CREATE OR REPLACE VIEW main." + view + " AS SELECT * FROM " +
+                                    std::string(sirius::exec::kStreamSourceFunctionName) + "(" +
+                                    std::to_string(id) + ")");
+      if (create->HasError()) { create->ThrowError(); }
+    }
+  }
+
+  //! Declares every input stream on the connection's bind catalog, with a repository this
+  //! fragment owns.
+  //!
+  //! Both paths need the declaration before the view is created. The result path then keeps these
+  //! repositories, because nothing else creates them; on the streaming path
+  //! streaming_fragment::build() clears the catalog and redeclares the same schemas against its
+  //! own repositories, and these are dropped unused.
+  void declare_streams(
+    const std::map<sirius::exec::stream_id_t, sirius::exec::stream_input_spec>& resolved)
+  {
+    auto& catalog = *ctx.stream_catalog;
+    catalog.clear();
+    for (const auto& [id, spec] : resolved) {
+      auto repository = std::make_shared<cucascade::shared_data_repository>();
+      if (is_result()) { result_input_repos[id] = repository; }
+      catalog.declare(id,
+                      sirius::exec::stream_input_binding{
+                        spec.names, spec.types, repository, spec.expected_senders, nullptr});
+    }
+  }
+};
+
+Fragment::Fragment(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
+
+Fragment::~Fragment() = default;
+
+void Fragment::declare_input_column(std::uint64_t stream_id,
+                                    const std::string& name,
+                                    const std::string& type)
+{
+  impl_->require_not_built("declare_input_column");
+  auto& declared = impl_->inputs[stream_id];
+  declared.names.push_back(name);
+  declared.type_names.push_back(type);
+}
+
+void Fragment::declare_input_sender(std::uint64_t stream_id, std::uint32_t sender_id)
+{
+  impl_->require_not_built("declare_input_sender");
+  impl_->inputs[stream_id].expected_senders.insert(sender_id);
+}
+
+void Fragment::declare_output(std::uint64_t stream_id)
+{
+  impl_->require_not_built("declare_output");
+  auto& outputs = impl_->outputs;
+  if (std::find(outputs.begin(), outputs.end(), stream_id) != outputs.end()) {
+    throw sirius::invalid_input_exception("Fragment: duplicate output stream id " +
+                                          std::to_string(stream_id));
+  }
+  outputs.push_back(stream_id);
+}
+
+void Fragment::build(const std::string& substrait_plan)
+{
+  impl_->require_not_built("build");
+
+  // Ordering matters three ways: parsing a type name and creating a view are ordinary statements
+  // that need a transaction, an ordinary statement also takes the query-lifecycle mutex (so both
+  // must precede the execution window), and the window must then span planning and execution,
+  // as streaming_fragment::run() requires.
+  impl_->begin_transaction();
+  std::map<sirius::exec::stream_id_t, sirius::exec::stream_input_spec> resolved;
+  try {
+    resolved = impl_->resolve_inputs();
+    impl_->declare_streams(resolved);
+    impl_->create_stream_views();
+  } catch (...) {
+    impl_->abandon_lifecycle();
+    throw;
+  }
+  impl_->begin_lifecycle();
+
+  try {
+    auto& client = *impl_->ctx.conn->context;
+    if (impl_->is_result()) {
+      // A result fragment takes the ordinary single-shot path; the only difference is that its
+      // leaves may be streaming sources, which the plan generator built from the bind catalog.
+      auto lowered       = lower_substrait(*impl_->ctx.conn, substrait_plan);
+      auto physical_plan = sirius::planner::sirius_physical_plan_generator(client).create_plan(
+        std::move(lowered.plan));
+      impl_->result_plan = duckdb::make_shared_ptr<sirius::sirius_prepared_statement_data>(
+        std::move(lowered.prepared), std::move(physical_plan));
+
+      for (const auto& [id, _] : impl_->inputs) {
+        auto* built = impl_->ctx.stream_catalog->get(id).built;
+        if (built == nullptr) {
+          throw sirius::invalid_input_exception("Fragment: input stream " + std::to_string(id) +
+                                                " was declared but the plan does not read it");
+        }
+        impl_->result_session.add_source(id, *built);
+      }
+    } else {
+      sirius::exec::fragment_spec spec;
+      // The raw connection borrow is safe: streaming_fragment invokes plan_source only inside
+      // build() below, and the connection outlives the fragment anyway (a Context must outlive
+      // every Fragment made from it — the class contract).
+      spec.plan_source = [plan = substrait_plan, conn = impl_->ctx.conn.get()](
+                           duckdb::ClientContext&) { return lower_substrait(*conn, plan).plan; };
+      spec.inputs     = std::move(resolved);
+      spec.outputs    = impl_->outputs;
+      impl_->fragment = std::make_unique<sirius::exec::streaming_fragment>(client, std::move(spec));
+      // streaming_fragment declares its own inputs on the catalog from the spec; the views
+      // created above are what the plan reads them through. It registers its engine under the
+      // caller's window, which is why build() takes this window's query id.
+      impl_->fragment->build(impl_->window->query_id());
+    }
+    impl_->built = true;
+  } catch (...) {
+    impl_->abandon_lifecycle();
+    throw;
+  }
+}
+
+std::size_t Fragment::relay_from(Fragment& source,
+                                 std::uint64_t source_stream_id,
+                                 std::uint64_t input_stream_id,
+                                 std::uint32_t sender_id)
+{
+  if (!impl_->built) {
+    throw sirius::invalid_input_exception("Fragment: build() must run before relay_from()");
+  }
+  std::size_t moved = 0;
+  while (auto batch = source.impl_->session().pull(source_stream_id)) {
+    if (!impl_->session().push(input_stream_id, *batch)) {
+      throw sirius::invalid_input_exception(
+        "Fragment: input stream " + std::to_string(input_stream_id) +
+        " refused a batch from sender " + std::to_string(sender_id) + "; it had already ended");
+    }
+    ++moved;
+  }
+  impl_->session().close_input(input_stream_id, sender_id);
+  return moved;
+}
+
+void Fragment::run()
+{
+  if (!impl_->built) {
+    throw sirius::invalid_input_exception("Fragment: build() must run before run()");
+  }
+  if (impl_->ran) { throw sirius::invalid_input_exception("Fragment: already run"); }
+
+  try {
+    if (impl_->is_result()) {
+      auto& client = *impl_->ctx.conn->context;
+      sirius::sirius_interface iface(client, std::optional<std::string>(kQueryLabel));
+      impl_->result = iface.sirius_execute_query(client,
+                                                 kQueryLabel,
+                                                 impl_->result_plan,
+                                                 duckdb::PendingQueryParameters{},
+                                                 impl_->window->query_id());
+    } else {
+      impl_->fragment->run();
+    }
+    impl_->ran = true;
+    impl_->end_lifecycle();
+  } catch (...) {
+    impl_->abandon_lifecycle();
+    throw;
+  }
+  if (impl_->result && impl_->result->HasError()) { impl_->result->ThrowError(); }
+}
+
+void Fragment::result_to_arrow(std::uintptr_t out_stream_addr)
+{
+  if (!impl_->is_result()) {
+    throw sirius::invalid_input_exception(
+      "Fragment: result_to_arrow() is only valid on a fragment with no output stream");
+  }
+  if (!impl_->ran || !impl_->result) {
+    throw sirius::invalid_input_exception("Fragment: run() must complete before result_to_arrow()");
+  }
+  // Same self-owning stream contract as execute_substrait() step 4: the stream's `release`
+  // callback deletes the heap wrapper. The move makes this one-shot — the guard above rejects a
+  // second call because the fragment no longer holds a result.
+  auto* wrapper =
+    new duckdb::ResultArrowArrayStreamWrapper(std::move(impl_->result), kArrowBatchSize);
+  *reinterpret_cast<ArrowArrayStream*>(out_stream_addr) = wrapper->stream;
+}
+
+std::size_t Fragment::output_batch_count(std::uint64_t stream_id) const
+{
+  // Deliberate: a result fragment parks nothing, so 0 is the true count for every id — but it
+  // also means an unknown stream id on a result fragment reads as "empty" rather than throwing.
+  // Kept as the integration surface the compute node already calls; tightening the unknown-id
+  // case to a throw is a follow-up for when the CN side lands and can absorb the change.
+  if (!impl_->fragment) { return 0; }
+  return impl_->fragment->output_repository(stream_id)->total_size();
+}
+
 std::unique_ptr<Context> make_context() { return std::make_unique<Context>(); }
 
 std::unique_ptr<Context> make_context_from_config(const std::string& config_path)
 {
   return std::make_unique<Context>(config_path);
+}
+
+std::unique_ptr<Fragment> make_fragment(Context& context)
+{
+  return std::unique_ptr<Fragment>(new Fragment(std::make_unique<Fragment::Impl>(*context.impl_)));
 }
 
 }  // namespace sirius::ffi


### PR DESCRIPTION
Ports integration commit `e2377b23` (issue D of the integration triage); no GitHub issue yet. Part 8
of a twelve-PR stack.

**What.** `Context::execute_substrait` runs a whole query; `sirius::ffi::Fragment` runs one hop of
one. It is the cxx surface over `exec::streaming_fragment` — declare the input streams, build a
Substrait plan against them, relay each sender in, run. A fragment with output streams is rooted in a
streaming sink and parks native batches that outlive its own query; one without is a result fragment
(RESULT_COLLECTOR root) and produces Arrow.

**Design: no batch type crosses cxx.** A batch is a live tiered object under the memory manager's
sweep; crossing a language boundary would need an owner on the other side and a shared representation.
Only ids, names, and plan bytes cross.

- **`relay_from(source, from_id, to_id, sender_id)` moves batches inside C++.** A `DataBatch` handle
  over the bridge would hand Rust an object whose spillability the engine can no longer manage.
- **Arrow appears only at a result fragment.** Materializing per hop would pay a serialize-and-copy
  each time and pin every intermediate off the spill path.
- **An input stream is read through a view**, `sirius_stream_<id>`, so a front end emits an ordinary
  NamedTable read and the vendored substrait extension needs no change. `stream_view_name` is bound
  over the bridge so the convention has one definition; two copies drift into a missing-table error.
- **`Fragment<'ctx>` borrows the context**, so a fragment cannot outlive its engine. The context sits
  behind a `RefCell` because several fragments of one query are alive at once — a `&mut self` factory
  would allow exactly one.

Two deliberate deviations from the reference: the port holds a `std::optional<StandaloneQueryScope>`
so the abandon path **rolls back** (the original committed on every path, including failure), with the
noexcept destructor as backstop — the failure mode is a silent connection deadlock; and `finish()`
runs inside the try, so a failed mandatory cleanup errors the fragment instead of being swallowed.
`build()` threads the scope's id into `streaming_fragment::build(query_id)`, the caller-owned-window
contract from #1324.

**The view is what makes it bind.** Without the `CREATE OR REPLACE VIEW main.sirius_stream_<id>` loop
in `Fragment::build`, the first dispatched fragment dies with `Catalog Error: Table with name
sirius_stream_<id> does not exist!`. Its placement is load-bearing three ways (see the `build()`
comment): type parsing and view creation need a transaction, an ordinary statement takes the
query-lifecycle mutex, and DuckDB binds a view's body at CREATE time — so views come after the streams
are declared.

**Reading order.**
1. `src/include/sirius_ffi.hpp` — the `Fragment` class comment is the design note.
2. `src/sirius_ffi.cpp` — `lower_substrait()` extracted so both paths share one lowering; then
   `build()`'s ordering comment, `end_lifecycle` vs `abandon_lifecycle`, the destructor backstop.
3. `rust/crates/sirius-sys/src/lib.rs`, `rust/crates/sirius/src/lib.rs` — the bridge, then
   `Fragment<'ctx>`, the `RefCell` comment, `into_arrow()`.
4. `docs/super-sirius/streaming-sessions.md` — 8 lines; the "Not here yet" item this delivers moves
   into the `streaming_fragment` section.
5. Tests: the three cargo tests in `rust/crates/sirius` (need a GPU) cover this commit's changes to
   the shared path — two back-to-back `execute_substrait` runs through the extracted
   `lower_substrait()` and the now-`RefCell`'d context, plus the cxx exception round-trip. Fragment
   behavior is covered engine-side by FRAG-1…5 in `test/cpp/exec/test_streaming_fragment.cpp`.

### Stack: part 8 of 12
- **Base:** `stream/07-ffi-corefunctions` (#1395)
- **Depends on:** part 7 (#1395), transitively #1324
