### PR TITLE
feat(starrocks): multi-fragment compute node

### DIFF
--- a/experimental/starrocks/Cargo.lock
+++ b/experimental/starrocks/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/experimental/starrocks/DEMO.md
+++ b/experimental/starrocks/DEMO.md
@@ -1,0 +1,93 @@
+# Multi-fragment demo cluster
+
+A runnable StarRocks front end + Rust compute node + Sirius engine on one host, used to exercise
+multi-fragment execution end to end against a real TPC-H Q6 query.
+
+This branch is `dev` plus the repository-backed streaming work
+([`docs/super-sirius/streaming-sessions.md`](../../docs/super-sirius/streaming-sessions.md))
+plus this multi-fragment compute node.
+
+## What this does and does not exercise
+
+The compute node coordinates fragments the way it does today: `LocalExchange` is a
+receiver-first rendezvous that buffers each sender's **fully materialized** Arrow result and
+writes it to a temporary parquet file the receiver re-scans as a `local_files` scan.
+
+The streaming primitives in this branch — `STREAMING_SOURCE`, `STREAMING_SINK`,
+`exec::streaming_fragment`, `exec::stream_session` — are **built into the engine and unit-tested,
+but not yet wired into this compute node**. The cxx-FFI boundary that reaches them
+(`sirius::ffi::Fragment`) landed in the previous part of this stack; wiring the compute node onto
+it is the next part, and it is a seam swap rather than a rewrite: each primitive replaces exactly
+one mechanism here.
+
+| Compute-node mechanism today | Streaming replacement |
+|---|---|
+| `ExchangeFile` temp parquet + `local_files` re-scan | `push(stream_id, batch)` → source repository, native |
+| `ExchangeOutput` (the whole result) | incremental native `data_batch` push |
+| `LocalExchange` rendezvous (expected sender **count**) | the streaming source's expected sender **set** + the `stream_session` registry |
+| `ExchangeKey{fragment_instance_id, node_id}` | the direction-separated input `stream_id` |
+| `per_exch_num_senders` + `exec.sender_id` | the source's expected sender set |
+| `exec.destinations` | one sink partition per destination + the wrapper's routing table |
+| `FragmentExecutor::execute → FragmentResult` (sync) | build session + submit; `push`/`pull` over cxx-FFI |
+| `ResultStore` + `fetch_data` | root `STREAMING_SINK` + `pull`/`wait`/`drained` |
+
+So: this demo proves the cluster runs the query correctly on the engine that carries the new
+primitives. It does not yet prove the query flows *through* them.
+
+## Running it
+
+Bring the cluster up (front end + compute node + engine), and leave it in the foreground:
+
+```bash
+cd experimental/starrocks
+pixi run cluster
+```
+
+In a second terminal, open a MySQL client against the front end:
+
+```bash
+cd experimental/starrocks
+pixi run client        # mysql --host 127.0.0.1 --port 9030 --user root
+```
+
+Then:
+
+```sql
+SHOW COMPUTE NODES;
+
+-- The simplest two-fragment shape: a scan+filter+project sender and a single aggregate
+-- receiver, joined by a gather exchange.
+SET new_planner_agg_stage = 1;
+
+WITH lineitem AS (
+  SELECT *
+  FROM FILES(
+    "path"="file:///home/ubuntu/git/sirius/scratch/tpch_sf1/lineitem/part.0.parquet",
+    "format"="parquet"
+  )
+)
+SELECT
+  sum(l_extendedprice * l_discount) AS revenue
+FROM lineitem
+WHERE l_shipdate >= date '1997-01-01'
+  AND l_shipdate < date '1998-01-01'
+  AND l_discount BETWEEN 0.03 - 0.01 AND 0.03 + 0.01
+  AND l_quantity < 24;
+```
+
+Point `path` at whatever TPC-H `lineitem` parquet you have.
+
+## The pre-packaged front end
+
+`cluster` depends on `fe-check`, not `fe-build`: this demo ships the front end already packaged
+under `starrocks/output/fe` so bringing the cluster up does not require a multi-hour Maven build
+of the whole StarRocks front end. `fe-check` just asserts the package is present and tells you
+what to run if it is not:
+
+```bash
+git submodule update --init --recursive experimental/starrocks/starrocks
+pixi run fe-build    # long
+```
+
+Everything else — the compute node and the Sirius engine — is built from this worktree by
+`cn-build` → `engine-build`.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/descriptor_table.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/descriptor_table.rs
@@ -245,23 +245,43 @@ impl DescriptorTable {
 
     /// Builds the Substrait schema for a StarRocks tuple.
     pub fn named_struct(&self, tuple_id: i32) -> Result<NamedStruct> {
-        let (names, types): (Vec<_>, Vec<_>) = self
-            .materialized_slot_ids(tuple_id)?
-            .into_iter()
-            .map(|slot_id| {
+        self.named_struct_for_tuples(&[tuple_id], None)
+    }
+
+    /// Builds the Substrait schema for a row layout spanning one or more tuples.
+    ///
+    /// `names` overrides descriptor names when an exchange input was materialized with the
+    /// sender fragment's output names. Types and field order always come from the receiver's
+    /// descriptor table.
+    pub(crate) fn named_struct_for_tuples(
+        &self,
+        tuple_ids: &[i32],
+        names: Option<&[String]>,
+    ) -> Result<NamedStruct> {
+        let mut descriptor_names = Vec::new();
+        let mut types = Vec::new();
+        for &tuple_id in tuple_ids {
+            for slot_id in self.materialized_slot_ids(tuple_id)? {
                 let slot = self.slot(tuple_id, slot_id)?;
-                let substrait_type =
+                descriptor_names.push(slot.output_name());
+                types.push(
                     slot.substrait_type
                         .clone()
                         .ok_or(TranslateError::MissingField {
                             context: "materialized TSlotDescriptor",
                             field: "slotType",
-                        })?;
-                Ok((slot.output_name(), substrait_type))
-            })
-            .collect::<Result<Vec<_>>>()?
-            .into_iter()
-            .unzip();
+                        })?,
+                );
+            }
+        }
+        let names = names.map_or(descriptor_names, <[String]>::to_vec);
+        if names.len() != types.len() {
+            return Err(TranslateError::descriptor(format!(
+                "row layout {tuple_ids:?} has {} fields but exchange input has {} names",
+                types.len(),
+                names.len()
+            )));
+        }
 
         Ok(NamedStruct {
             names,

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
@@ -21,6 +21,8 @@ pub(crate) struct ExprContext<'a> {
     registry: &'a mut ExtensionRegistry,
     /// Tuple ids that describe the input row visible to this expression.
     row_tuples: &'a [i32],
+    /// Synthetic StarRocks slots appended while evaluating common project expressions.
+    slot_overrides: Option<&'a std::collections::HashMap<(i32, i32), usize>>,
 }
 
 impl<'a> ExprContext<'a> {
@@ -34,6 +36,23 @@ impl<'a> ExprContext<'a> {
             desc,
             registry,
             row_tuples,
+            slot_overrides: None,
+        }
+    }
+
+    /// Creates an expression context that can resolve synthetic slots not present
+    /// in the descriptor table.
+    pub(crate) fn with_slot_overrides(
+        desc: &'a DescriptorTable,
+        registry: &'a mut ExtensionRegistry,
+        row_tuples: &'a [i32],
+        slot_overrides: &'a std::collections::HashMap<(i32, i32), usize>,
+    ) -> Self {
+        Self {
+            desc,
+            registry,
+            row_tuples,
+            slot_overrides: Some(slot_overrides),
         }
     }
 }
@@ -147,9 +166,18 @@ fn translate_slot_ref(
         context: "SLOT_REF",
         field: "slot_ref",
     })?;
-    let field =
-        ctx.desc
-            .slot_global_index(slot_ref.tuple_id, slot_ref.slot_id, ctx.row_tuples)? as i32;
+    let field = ctx
+        .slot_overrides
+        .and_then(|overrides| {
+            overrides
+                .get(&(slot_ref.tuple_id, slot_ref.slot_id))
+                .copied()
+        })
+        .map(Ok)
+        .unwrap_or_else(|| {
+            ctx.desc
+                .slot_global_index(slot_ref.tuple_id, slot_ref.slot_id, ctx.row_tuples)
+        })? as i32;
     Ok(Expression {
         rex_type: Some(expression::RexType::Selection(Box::new(FieldReference {
             reference_type: Some(field_reference::ReferenceType::DirectReference(
@@ -255,19 +283,27 @@ fn translate_decimal_literal(node: &TExprNode, children: Vec<Expression>) -> Res
             field: "decimal_literal",
         })?;
     let decimal_type = type_mapper::map_type_desc(&node.type_, true)?;
-    let Some(substrait::proto::r#type::Kind::Decimal(decimal)) = decimal_type.kind else {
-        return Err(TranslateError::malformed(
-            "DECIMAL_LITERAL has non-decimal type",
-        ));
-    };
-    let value = encode_decimal(&lit.value, decimal.scale)?;
-    Ok(literal(expression::literal::LiteralType::Decimal(
-        expression::literal::Decimal {
-            value: value.to_vec(),
-            precision: decimal.precision,
-            scale: decimal.scale,
-        },
-    )))
+    match decimal_type.kind {
+        Some(substrait::proto::r#type::Kind::Decimal(decimal)) => {
+            let value = encode_decimal(&lit.value, decimal.scale)?;
+            Ok(literal(expression::literal::LiteralType::Decimal(
+                expression::literal::Decimal {
+                    value: value.to_vec(),
+                    precision: decimal.precision,
+                    scale: decimal.scale,
+                },
+            )))
+        }
+        Some(substrait::proto::r#type::Kind::Fp64(_)) => {
+            let value = lit.value.parse::<f64>().map_err(|_| {
+                TranslateError::malformed(format!("invalid decimal literal {:?}", lit.value))
+            })?;
+            Ok(literal(expression::literal::LiteralType::Fp64(value)))
+        }
+        _ => Err(TranslateError::malformed(
+            "DECIMAL_LITERAL has non-numeric type",
+        )),
+    }
 }
 
 /// Converts a StarRocks `DATE_LITERAL` into a Substrait date literal.
@@ -346,16 +382,26 @@ fn translate_arithmetic(
         }
     };
     expect_child_count(node, &children, 2)?;
-    // Decimal-typed arithmetic is rejected for now: the StarRocks-shaped cast/width combination
-    // reliably segfaults the engine's GPU projection (see the starrocks tpch crash repro);
-    // fail with a structured error instead of taking down the compute node.
-    if is_decimal(&node.type_)? {
-        return Err(TranslateError::UnsupportedExpression {
-            node_type: node.node_type,
-            reason: "decimal arithmetic is not supported yet (crashes the engine projection)",
-        });
-    }
-    let output_type = type_mapper::map_type_desc(&node.type_, node.is_nullable.unwrap_or(true))?;
+    let decimal = is_decimal(&node.type_)?;
+    let children = if decimal {
+        children
+            .into_iter()
+            .map(|input| Expression {
+                rex_type: Some(expression::RexType::Cast(Box::new(expression::Cast {
+                    r#type: Some(type_mapper::fp64_type(true)),
+                    input: Some(Box::new(input)),
+                    failure_behavior: expression::cast::FailureBehavior::ThrowException as i32,
+                }))),
+            })
+            .collect()
+    } else {
+        children
+    };
+    let output_type = if decimal {
+        type_mapper::fp64_type(node.is_nullable.unwrap_or(true))
+    } else {
+        type_mapper::map_type_desc(&node.type_, node.is_nullable.unwrap_or(true))?
+    };
     let anchor = ctx.registry.register_function(URN_ARITHMETIC, name);
     Ok(scalar_function(anchor, children, output_type))
 }
@@ -589,6 +635,105 @@ fn integer_literal_value(expr: &Expression) -> Option<i64> {
         },
         _ => None,
     }
+}
+
+/// A StarRocks aggregate call decomposed for Substrait `AggregateRel` measures.
+pub(crate) struct AggregateCall {
+    /// Substrait/DuckDB aggregate function name.
+    pub name: String,
+    /// Translated argument expressions over the aggregation input row.
+    pub arguments: Vec<Expression>,
+    /// Whether the aggregate applies to distinct inputs.
+    pub distinct: bool,
+}
+
+/// Decomposes a StarRocks aggregate-function expression (the root of a
+/// `TAggregationNode::aggregate_functions` entry) into name, arguments, and distinct-ness.
+pub(crate) fn aggregate_call(expr: &TExpr, ctx: &mut ExprContext<'_>) -> Result<AggregateCall> {
+    let root = expr
+        .nodes
+        .first()
+        .ok_or_else(|| TranslateError::malformed("aggregate function TExpr is empty"))?;
+    let is_aggregate_root = matches!(
+        root.node_type,
+        TExprNodeType::AGG_EXPR | TExprNodeType::FUNCTION_CALL
+    ) && root.agg_expr.is_some();
+    if !is_aggregate_root {
+        return Err(TranslateError::UnsupportedExpression {
+            node_type: root.node_type,
+            reason: "aggregate function root is not an aggregate expression",
+        });
+    }
+    // One-phase aggregation only: a merge aggregate consumes partial states this translator
+    // does not model (run with `new_planner_agg_stage = 1`).
+    if root
+        .agg_expr
+        .as_ref()
+        .is_some_and(|agg_expr| agg_expr.is_merge_agg)
+    {
+        return Err(TranslateError::UnsupportedExpression {
+            node_type: root.node_type,
+            reason: "merge-phase aggregate functions are not supported (one-phase only)",
+        });
+    }
+    let function = root.fn_.as_ref().ok_or(TranslateError::MissingField {
+        context: "aggregate expression",
+        field: "fn",
+    })?;
+    // `multi_distinct_sum` is intentionally absent: the GPU grouped-aggregate path only
+    // honors DISTINCT for count and would silently overcount a distinct sum.
+    let (name, distinct) = match function.name.function_name.as_str() {
+        name @ ("sum" | "count" | "min" | "max" | "avg") => (name, false),
+        "multi_distinct_count" => ("count", true),
+        name => {
+            return Err(TranslateError::malformed(format!(
+                "unsupported StarRocks aggregate function {name:?}"
+            )));
+        }
+    };
+    // Multi-column COUNT(DISTINCT a, b) needs key packing the executor does not do here.
+    if distinct && root.num_children != 1 {
+        return Err(TranslateError::UnsupportedExpression {
+            node_type: root.node_type,
+            reason: "distinct aggregates over multiple columns are not supported",
+        });
+    }
+    let return_primitive = type_mapper::scalar_primitive(&function.ret_type)?;
+    let decimal_result = is_decimal(&function.ret_type)?;
+    // Temporal AVG has StarRocks-specific rounding semantics. Decimal SUM/AVG are lowered to FP64
+    // below because the Sirius GPU expression/aggregate path cannot consume decimal arithmetic.
+    if name == "avg" && return_primitive != TPrimitiveType::DOUBLE && !decimal_result {
+        return Err(TranslateError::UnsupportedExpression {
+            node_type: root.node_type,
+            reason: "temporal avg is not supported",
+        });
+    }
+
+    let mut cursor = ExprNodeCursor::new(&expr.nodes);
+    // Consume the root marker; its children are the aggregate arguments.
+    cursor.idx = 1;
+    let mut arguments = (0..root.num_children)
+        .map(|_| cursor.translate_next(ctx))
+        .collect::<Result<Vec<_>>>()?;
+    cursor.ensure_consumed()?;
+    if decimal_result && matches!(name, "sum" | "avg") {
+        arguments = arguments
+            .into_iter()
+            .map(|input| Expression {
+                rex_type: Some(expression::RexType::Cast(Box::new(expression::Cast {
+                    r#type: Some(type_mapper::fp64_type(true)),
+                    input: Some(Box::new(input)),
+                    failure_behavior: expression::cast::FailureBehavior::ThrowException as i32,
+                }))),
+            })
+            .collect();
+    }
+
+    Ok(AggregateCall {
+        name: name.to_string(),
+        arguments,
+        distinct,
+    })
 }
 
 /// Converts supported comparison opcodes into Substrait comparison functions.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -6,9 +6,8 @@
 //! invariants over breadth: it translates one fragment at a time, and everything
 //! outside the supported surface returns a structured [`TranslateError`] that
 //! names the offending node/type — so the next contributor knows exactly what to
-//! implement next. In particular `EXCHANGE_NODE` is rejected: a fragment is
-//! translated in isolation, and multi-fragment plans (every exchange is a
-//! fragment boundary) are a later milestone.
+//! implement next. `EXCHANGE_NODE` requires an explicit, materialized same-node
+//! input supplied by the compute-node wrapper.
 //!
 //! # Wire format: flat preorder
 //!
@@ -31,6 +30,17 @@
 //! | `HDFS_SCAN_NODE`     | `ReadRel` (named table) |
 //! | `SELECT_NODE`        | `FilterRel`        |
 //! | `PROJECT_NODE`       | `ProjectRel`       |
+//! | `AGGREGATION_NODE`   | `AggregateRel` (finalized one-phase only, `new_planner_agg_stage=1`) |
+//! | `SORT_NODE`          | `ProjectRel` (sort tuple) + `SortRel` (global row-number top-N only) |
+//! | `HASH_JOIN_NODE`     | `JoinRel` (inner/outer/left-semi/anti, incl. null-aware left anti) |
+//! | `NESTLOOP_JOIN_NODE` | inner `JoinRel` on synthetic constants (+ `FilterRel`), inner/cross only |
+//! | `EXCHANGE_NODE`      | `ReadRel` (`local_files`, with an explicit materialized input) |
+//!
+//! Node-level `conjuncts` (scan/filter predicates, HAVING, post-join filters) become a
+//! `FilterRel` over the node's output on every supported node.
+//!
+//! Any node's non-negative `limit` (plus a sort offset) becomes a `FetchRel` on top of its
+//! relation.
 //!
 //! | Expression node   | Substrait expression |
 //! |-------------------|----------------------|
@@ -44,6 +54,10 @@
 //! | `IN_PRED`         | singular-or-list (wrapped in `not` for `NOT IN`) |
 //! | `CASE_EXPR`       | if-then chain (no leading case operand) |
 //! | `FUNCTION_CALL`   | allowlisted scalar functions (`like`, `if`, `substring`, `year`, ...) |
+//!
+//! Aggregate functions (`sum`, `count`, `min`, `max`, `avg`, and the
+//! `multi_distinct_*` distinct forms) are decomposed by `expr_translator::aggregate_call` for
+//! `AggregateRel` measures; only non-merge (one-phase) aggregates are accepted.
 //!
 //! Type mapping lives in `type_mapper`. Intentional v1 omissions return
 //! [`TranslateError::UnsupportedType`]: `LARGEINT` (128-bit), `DECIMAL256` and
@@ -99,6 +113,8 @@ pub const URN_ARITHMETIC: &str = "extension:io.substrait:functions_arithmetic";
 pub const URN_STRING: &str = "extension:io.substrait:functions_string";
 /// Substrait datetime function extension URN.
 pub const URN_DATETIME: &str = "extension:io.substrait:functions_datetime";
+/// Substrait aggregate function extension URN.
+pub const URN_AGGREGATE: &str = "extension:io.substrait:functions_aggregate_generic";
 
 /// Result of translating one StarRocks plan fragment.
 pub struct TranslatedPlan {
@@ -106,6 +122,17 @@ pub struct TranslatedPlan {
     pub plan: Plan,
     /// Root output names as emitted in the Substrait plan.
     pub output_names: Vec<String>,
+}
+
+/// A fully materialized same-node input for one StarRocks exchange node.
+#[derive(Clone, Debug)]
+pub struct ExchangeInput {
+    /// Receiver `EXCHANGE_NODE` id.
+    pub node_id: i32,
+    /// Local parquet files containing the sender fragment output.
+    pub paths: Vec<String>,
+    /// Sender output names as written to those parquet files.
+    pub names: Vec<String>,
 }
 
 impl TranslatedPlan {
@@ -179,6 +206,15 @@ impl PlanTranslator {
 
     /// Translates a StarRocks execution fragment into a Substrait plan.
     pub fn translate_fragment(&self, params: &TExecPlanFragmentParams) -> Result<TranslatedPlan> {
+        self.translate_fragment_with_exchange_inputs(params, &[])
+    }
+
+    /// Translates a fragment with fully materialized inputs for its same-node exchange nodes.
+    pub fn translate_fragment_with_exchange_inputs(
+        &self,
+        params: &TExecPlanFragmentParams,
+        exchange_inputs: &[ExchangeInput],
+    ) -> Result<TranslatedPlan> {
         let fragment = params
             .fragment
             .as_ref()
@@ -200,9 +236,18 @@ impl PlanTranslator {
 
         let desc = DescriptorTable::try_from(desc_tbl)?;
         let scan_paths = ScanFilePaths::from_fragment(params, &desc)?;
+        let exchange_inputs = exchange_inputs
+            .iter()
+            .map(|input| (input.node_id, input))
+            .collect::<HashMap<_, _>>();
         let mut registry = ExtensionRegistry::new();
-        let mut translated =
-            node_translator::translate_plan(plan, &desc, &scan_paths, &mut registry)?;
+        let mut translated = node_translator::translate_plan(
+            plan,
+            &desc,
+            &scan_paths,
+            &exchange_inputs,
+            &mut registry,
+        )?;
 
         let output_names = if let Some(output_exprs) = fragment
             .output_exprs

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -1,19 +1,24 @@
 use starrocks_thrift::exprs::TExpr;
-use starrocks_thrift::plan_nodes::{TPlan, TPlanNode, TPlanNodeType};
+use starrocks_thrift::opcodes::TExprOpcode;
+use starrocks_thrift::plan_nodes::{TJoinOp, TPlan, TPlanNode, TPlanNodeType, TSortInfo};
 use substrait::proto::read_rel::local_files::FileOrFiles;
 use substrait::proto::read_rel::local_files::file_or_files::{
     FileFormat, ParquetReadOptions, PathType,
 };
 use substrait::proto::read_rel::{LocalFiles, NamedTable, ReadType};
 use substrait::proto::{
-    Expression, FilterRel, ProjectRel, ReadRel, Rel, RelCommon, rel, rel_common,
+    AggregateFunction, AggregateRel, Expression, FetchRel, FilterRel, JoinRel, ProjectRel, ReadRel,
+    Rel, RelCommon, SortField, SortRel, aggregate_rel, fetch_rel, function_argument, join_rel, rel,
+    rel_common, sort_field,
 };
 
 use crate::descriptor_table::DescriptorTable;
 use crate::error::{Result, TranslateError};
 use crate::expr_translator::{self, ExprContext, TranslateExpr};
 use crate::scan_paths::ScanFilePaths;
-use crate::{ExtensionRegistry, URN_BOOLEAN};
+use crate::{
+    ExchangeInput, ExtensionRegistry, URN_AGGREGATE, URN_ARITHMETIC, URN_BOOLEAN, URN_COMPARISON,
+};
 
 /// Partially translated relation plus the StarRocks row layout it emits.
 pub(crate) struct TranslatedRel {
@@ -44,6 +49,8 @@ struct PlanContext<'a> {
     /// scan ranges. Scans with paths emit a `local_files` read; path-less scans
     /// fall back to a named-table read.
     scan_paths: &'a ScanFilePaths,
+    /// Materialized same-node inputs keyed by receiver exchange node id.
+    exchange_inputs: &'a std::collections::HashMap<i32, &'a ExchangeInput>,
     /// Substrait extension registry shared across the whole plan.
     registry: &'a mut ExtensionRegistry,
 }
@@ -53,11 +60,13 @@ impl<'a> PlanContext<'a> {
     fn new(
         desc: &'a DescriptorTable,
         scan_paths: &'a ScanFilePaths,
+        exchange_inputs: &'a std::collections::HashMap<i32, &'a ExchangeInput>,
         registry: &'a mut ExtensionRegistry,
     ) -> Self {
         Self {
             desc,
             scan_paths,
+            exchange_inputs,
             registry,
         }
     }
@@ -65,6 +74,15 @@ impl<'a> PlanContext<'a> {
     /// Creates an expression context for an expression over `row_tuples`.
     fn expr_context<'b>(&'b mut self, row_tuples: &'b [i32]) -> ExprContext<'b> {
         ExprContext::new(self.desc, self.registry, row_tuples)
+    }
+
+    /// Creates an expression context with synthetic slot-to-column mappings.
+    fn expr_context_with_slots<'b>(
+        &'b mut self,
+        row_tuples: &'b [i32],
+        slot_overrides: &'b std::collections::HashMap<(i32, i32), usize>,
+    ) -> ExprContext<'b> {
+        ExprContext::with_slot_overrides(self.desc, self.registry, row_tuples, slot_overrides)
     }
 }
 
@@ -142,16 +160,67 @@ fn translate_plan_node(
     children: Vec<TranslatedRel>,
     ctx: &mut PlanContext<'_>,
 ) -> Result<TranslatedRel> {
-    match node.node_type {
+    let translated = match node.node_type {
         TPlanNodeType::FILE_SCAN_NODE => translate_file_scan(node, children, ctx),
         TPlanNodeType::HDFS_SCAN_NODE => translate_hdfs_scan(node, children, ctx),
         TPlanNodeType::SELECT_NODE => translate_select(node, children, ctx),
         TPlanNodeType::PROJECT_NODE => translate_project(node, children, ctx),
+        TPlanNodeType::AGGREGATION_NODE => translate_aggregation(node, children, ctx),
+        TPlanNodeType::SORT_NODE => translate_sort(node, children, ctx),
+        TPlanNodeType::HASH_JOIN_NODE => translate_hash_join(node, children, ctx),
+        TPlanNodeType::NESTLOOP_JOIN_NODE => translate_nestloop_join(node, children, ctx),
+        TPlanNodeType::EXCHANGE_NODE => translate_exchange(node, children, ctx),
         _ => Err(TranslateError::UnsupportedPlanNode {
             node_id: node.node_id,
             node_type: node.node_type,
             reason: "plan node is outside the v1 StarRocks slice",
         }),
+    }?;
+    Ok(apply_fetch(translated, node))
+}
+
+/// Wraps a relation in a Substrait fetch when the StarRocks node carries a limit or offset.
+///
+/// `TPlanNode::limit` applies to any node type; a skip offset only appears on sort and exchange
+/// payloads.
+// The deprecated plain offset/count oneof variants share wire tags with their expression
+// counterparts and are the fields DuckDB's Substrait consumer reads.
+#[allow(deprecated)]
+fn apply_fetch(input: TranslatedRel, node: &TPlanNode) -> TranslatedRel {
+    let offset = node
+        .sort_node
+        .as_ref()
+        .and_then(|sort| sort.offset)
+        .or_else(|| {
+            node.exchange_node
+                .as_ref()
+                .and_then(|exchange| exchange.offset)
+        })
+        .unwrap_or(0);
+    if node.limit < 0 && offset == 0 {
+        return input;
+    }
+    let TranslatedRel {
+        rel,
+        row_tuples,
+        output_width,
+    } = input;
+    // For an offset-only fetch, emit an explicit unlimited count: the consumer reads the plain
+    // count field without checking the oneof, and an unset count would decode as `LIMIT 0`.
+    let count = if node.limit >= 0 { node.limit } else { -1 };
+    let count_mode = Some(fetch_rel::CountMode::Count(count));
+    let offset_mode = (offset != 0).then_some(fetch_rel::OffsetMode::Offset(offset));
+    TranslatedRel {
+        rel: Rel {
+            rel_type: Some(rel::RelType::Fetch(Box::new(FetchRel {
+                input: Some(Box::new(rel)),
+                offset_mode,
+                count_mode,
+                ..Default::default()
+            }))),
+        },
+        row_tuples,
+        output_width,
     }
 }
 
@@ -246,10 +315,585 @@ pub(crate) fn translate_plan(
     plan: &TPlan,
     desc: &DescriptorTable,
     scan_paths: &ScanFilePaths,
+    exchange_inputs: &std::collections::HashMap<i32, &ExchangeInput>,
     registry: &mut ExtensionRegistry,
 ) -> Result<TranslatedRel> {
-    let mut ctx = PlanContext::new(desc, scan_paths, registry);
+    let mut ctx = PlanContext::new(desc, scan_paths, exchange_inputs, registry);
     plan.translate(&mut ctx)
+}
+
+/// Replaces a receiver exchange boundary with a read of its fully materialized sender output.
+fn translate_exchange(
+    node: &TPlanNode,
+    children: Vec<TranslatedRel>,
+    ctx: &mut PlanContext<'_>,
+) -> Result<TranslatedRel> {
+    expect_children(node, &children, 0)?;
+    let exchange = node
+        .exchange_node
+        .as_ref()
+        .ok_or(TranslateError::MissingField {
+            context: "EXCHANGE_NODE",
+            field: "exchange_node",
+        })?;
+    if exchange.input_row_tuples.is_empty() {
+        return Err(TranslateError::MissingField {
+            context: "TExchangeNode",
+            field: "input_row_tuples",
+        });
+    }
+    let input =
+        ctx.exchange_inputs
+            .get(&node.node_id)
+            .ok_or(TranslateError::UnsupportedPlanNode {
+                node_id: node.node_id,
+                node_type: node.node_type,
+                reason: "exchange node requires a materialized same-node input",
+            })?;
+    if input.paths.is_empty() {
+        return Err(TranslateError::malformed(format!(
+            "exchange node {} has no materialized input files",
+            node.node_id
+        )));
+    }
+    let schema = ctx
+        .desc
+        .named_struct_for_tuples(&exchange.input_row_tuples, Some(&input.names))?;
+    let output_width = schema
+        .r#struct
+        .as_ref()
+        .map(|structure| structure.types.len())
+        .unwrap_or(0);
+    let mut translated = TranslatedRel {
+        rel: local_files_rel(schema, &input.paths),
+        row_tuples: exchange.input_row_tuples.clone(),
+        output_width,
+    };
+    if let Some(sort_info) = &exchange.sort_info {
+        let sorts = sort_fields(sort_info, &translated, ctx)?;
+        let row_tuples = translated.row_tuples.clone();
+        translated = TranslatedRel {
+            rel: Rel {
+                rel_type: Some(rel::RelType::Sort(Box::new(SortRel {
+                    input: Some(Box::new(translated.rel)),
+                    sorts,
+                    ..Default::default()
+                }))),
+            },
+            row_tuples,
+            output_width,
+        };
+    }
+    apply_conjuncts(translated, node, ctx)
+}
+
+/// Translates a one-phase `AGGREGATION_NODE` into a Substrait aggregate relation.
+///
+/// Only finalized single-phase aggregation is supported (run StarRocks with
+/// `new_planner_agg_stage = 1`); merge/update phases would require modeling partial aggregate
+/// states. The output row layout is the aggregation output tuple, whose materialized slots are
+/// the grouping keys followed by the aggregate results (StarRocks allocates them in that order).
+fn translate_aggregation(
+    node: &TPlanNode,
+    children: Vec<TranslatedRel>,
+    ctx: &mut PlanContext<'_>,
+) -> Result<TranslatedRel> {
+    expect_children(node, &children, 1)?;
+    let child = children.into_iter().next().unwrap();
+    let agg = node.agg_node.as_ref().ok_or(TranslateError::MissingField {
+        context: "AGGREGATION_NODE",
+        field: "agg_node",
+    })?;
+    if !agg.need_finalize || agg.intermediate_tuple_id != agg.output_tuple_id {
+        return Err(TranslateError::UnsupportedPlanNode {
+            node_id: node.node_id,
+            node_type: node.node_type,
+            reason: "only finalized one-phase aggregation is supported (new_planner_agg_stage=1)",
+        });
+    }
+    let output_tuple = agg.output_tuple_id;
+
+    let grouping_exprs = agg.grouping_exprs.as_deref().unwrap_or_default();
+    let mut grouping_expressions = Vec::with_capacity(grouping_exprs.len());
+    for expr in grouping_exprs {
+        let mut expr_ctx = ctx.expr_context(&child.row_tuples);
+        grouping_expressions.push(expr.translate(&mut expr_ctx)?);
+    }
+
+    // Aggregate output types come from the output tuple's slots, which carry the grouping keys
+    // first and then one slot per aggregate function.
+    let output_slots = ctx.desc.materialized_slot_ids(output_tuple)?;
+    let output_width = output_slots.len();
+    if output_width != grouping_expressions.len() + agg.aggregate_functions.len() {
+        return Err(TranslateError::descriptor(format!(
+            "AGGREGATION_NODE {} output tuple {} has {} slots for {} keys + {} aggregates",
+            node.node_id,
+            output_tuple,
+            output_width,
+            grouping_expressions.len(),
+            agg.aggregate_functions.len()
+        )));
+    }
+
+    let mut measures = Vec::with_capacity(agg.aggregate_functions.len());
+    for (expr, slot_id) in agg
+        .aggregate_functions
+        .iter()
+        .zip(&output_slots[grouping_expressions.len()..])
+    {
+        let mut expr_ctx = ctx.expr_context(&child.row_tuples);
+        let call = expr_translator::aggregate_call(expr, &mut expr_ctx)?;
+        // The GPU ungrouped-aggregate operator rejects every distinct aggregate, so a
+        // grouping-free DISTINCT measure would translate fine and then fail at execution.
+        if call.distinct && grouping_expressions.is_empty() {
+            return Err(TranslateError::UnsupportedPlanNode {
+                node_id: node.node_id,
+                node_type: node.node_type,
+                reason: "distinct aggregates without grouping keys are not supported",
+            });
+        }
+        let output_type = ctx
+            .desc
+            .slot(output_tuple, *slot_id)?
+            .substrait_type
+            .clone()
+            .ok_or(TranslateError::MissingField {
+                context: "aggregate output slot",
+                field: "slotType",
+            })?;
+        // `count` lives in the generic aggregate extension; sum/avg/min/max are declared by
+        // the arithmetic extension.
+        let urn = if call.name == "count" {
+            URN_AGGREGATE
+        } else {
+            URN_ARITHMETIC
+        };
+        let anchor = ctx.registry.register_function(urn, &call.name);
+        measures.push(aggregate_rel::Measure {
+            measure: Some(AggregateFunction {
+                function_reference: anchor,
+                arguments: call
+                    .arguments
+                    .into_iter()
+                    .map(|expr| substrait::proto::FunctionArgument {
+                        arg_type: Some(function_argument::ArgType::Value(expr)),
+                    })
+                    .collect(),
+                output_type: Some(output_type),
+                invocation: if call.distinct {
+                    substrait::proto::aggregate_function::AggregationInvocation::Distinct as i32
+                } else {
+                    substrait::proto::aggregate_function::AggregationInvocation::All as i32
+                },
+                ..Default::default()
+            }),
+            filter: None,
+        });
+    }
+
+    let groupings = if grouping_expressions.is_empty() {
+        Vec::new()
+    } else {
+        #[allow(deprecated)]
+        let grouping = aggregate_rel::Grouping {
+            grouping_expressions: Vec::new(),
+            expression_references: (0..grouping_expressions.len() as u32).collect(),
+        };
+        vec![grouping]
+    };
+
+    let aggregated = TranslatedRel {
+        rel: Rel {
+            rel_type: Some(rel::RelType::Aggregate(Box::new(AggregateRel {
+                input: Some(Box::new(child.rel)),
+                groupings,
+                measures,
+                grouping_expressions,
+                ..Default::default()
+            }))),
+        },
+        row_tuples: vec![output_tuple],
+        output_width,
+    };
+    // Node conjuncts evaluate over the aggregation output (HAVING predicates).
+    apply_conjuncts(aggregated, node, ctx)
+}
+
+/// Translates a `SORT_NODE` into a Substrait sort (plus the fetch added by `apply_fetch` for
+/// top-N limits).
+///
+/// StarRocks sorts materialize a dedicated sort tuple first (`sort_tuple_slot_exprs`, one
+/// expression per materialized slot); the ordering expressions then reference that tuple.
+fn translate_sort(
+    node: &TPlanNode,
+    children: Vec<TranslatedRel>,
+    ctx: &mut PlanContext<'_>,
+) -> Result<TranslatedRel> {
+    expect_children(node, &children, 1)?;
+    let child = children.into_iter().next().unwrap();
+    let sort = node
+        .sort_node
+        .as_ref()
+        .ok_or(TranslateError::MissingField {
+            context: "SORT_NODE",
+            field: "sort_node",
+        })?;
+    let sort_tuple = node
+        .row_tuples
+        .first()
+        .copied()
+        .ok_or(TranslateError::MissingField {
+            context: "SORT_NODE",
+            field: "row_tuples",
+        })?;
+    // Partitioned top-N (per-partition limits) and rank-based top-N have no Substrait
+    // representation here; a global sort would silently return the wrong row set.
+    if sort
+        .partition_exprs
+        .as_ref()
+        .is_some_and(|exprs| !exprs.is_empty())
+        || sort
+            .topn_type
+            .is_some_and(|topn| topn != starrocks_thrift::plan_nodes::TTopNType::ROW_NUMBER)
+    {
+        return Err(TranslateError::UnsupportedPlanNode {
+            node_id: node.node_id,
+            node_type: node.node_type,
+            reason: "partitioned or rank-based top-N sorts are not supported",
+        });
+    }
+
+    // The resolved materialization expressions live in `TSortInfo`; the node-level field is a
+    // deprecated duplicate some senders omit.
+    let sort_tuple_slot_exprs = sort
+        .sort_info
+        .sort_tuple_slot_exprs
+        .as_ref()
+        .or(sort.sort_tuple_slot_exprs.as_ref());
+    let input = if let Some(slot_exprs) = sort_tuple_slot_exprs.filter(|exprs| !exprs.is_empty()) {
+        let expected = ctx.desc.materialized_slot_ids(sort_tuple)?.len();
+        if slot_exprs.len() != expected {
+            return Err(TranslateError::descriptor(format!(
+                "SORT_NODE {} materializes {} exprs for sort tuple {} with {} slots",
+                node.node_id,
+                slot_exprs.len(),
+                sort_tuple,
+                expected
+            )));
+        }
+        let mut expressions = Vec::with_capacity(slot_exprs.len());
+        for expr in slot_exprs {
+            let mut expr_ctx = ctx.expr_context(&child.row_tuples);
+            expressions.push(expr.translate(&mut expr_ctx)?);
+        }
+        project_rel(child, expressions, vec![sort_tuple])
+    } else {
+        child
+    };
+
+    let sorts = sort_fields(&sort.sort_info, &input, ctx)?;
+    let row_tuples = input.row_tuples.clone();
+    let output_width = input.output_width;
+    let sorted = TranslatedRel {
+        rel: Rel {
+            rel_type: Some(rel::RelType::Sort(Box::new(SortRel {
+                input: Some(Box::new(input.rel)),
+                sorts,
+                ..Default::default()
+            }))),
+        },
+        row_tuples,
+        output_width,
+    };
+    apply_conjuncts(sorted, node, ctx)
+}
+
+/// Builds Substrait sort fields from a StarRocks sort-info payload against `input`'s row layout.
+fn sort_fields(
+    sort_info: &TSortInfo,
+    input: &TranslatedRel,
+    ctx: &mut PlanContext<'_>,
+) -> Result<Vec<SortField>> {
+    let ordering = &sort_info.ordering_exprs;
+    if sort_info.is_asc_order.len() != ordering.len()
+        || sort_info.nulls_first.len() != ordering.len()
+    {
+        return Err(TranslateError::malformed(
+            "sort info direction lists do not match ordering expressions",
+        ));
+    }
+    ordering
+        .iter()
+        .zip(sort_info.is_asc_order.iter().zip(&sort_info.nulls_first))
+        .map(|(expr, (asc, nulls_first))| {
+            let mut expr_ctx = ctx.expr_context(&input.row_tuples);
+            let expr = expr.translate(&mut expr_ctx)?;
+            let direction = match (asc, nulls_first) {
+                (true, true) => sort_field::SortDirection::AscNullsFirst,
+                (true, false) => sort_field::SortDirection::AscNullsLast,
+                (false, true) => sort_field::SortDirection::DescNullsFirst,
+                (false, false) => sort_field::SortDirection::DescNullsLast,
+            };
+            Ok(SortField {
+                expr: Some(expr),
+                sort_kind: Some(sort_field::SortKind::Direction(direction as i32)),
+            })
+        })
+        .collect()
+}
+
+/// Translates a `HASH_JOIN_NODE` into a Substrait join relation.
+///
+/// StarRocks children are `[probe (left), build (right)]`; the Substrait join condition is
+/// evaluated over the concatenated left-then-right row, which is exactly how
+/// `slot_global_index` resolves slots against the combined layout.
+fn translate_hash_join(
+    node: &TPlanNode,
+    children: Vec<TranslatedRel>,
+    ctx: &mut PlanContext<'_>,
+) -> Result<TranslatedRel> {
+    expect_children(node, &children, 2)?;
+    let join = node
+        .hash_join_node
+        .as_ref()
+        .ok_or(TranslateError::MissingField {
+            context: "HASH_JOIN_NODE",
+            field: "hash_join_node",
+        })?;
+    let mut children = children.into_iter();
+    let left = children.next().unwrap();
+    let right = children.next().unwrap();
+
+    let combined_tuples = [left.row_tuples.as_slice(), right.row_tuples.as_slice()].concat();
+    let mut conditions = Vec::new();
+    let mut first_equality = None;
+    for eq in &join.eq_join_conjuncts {
+        if let Some(opcode) = eq.opcode
+            && opcode != TExprOpcode::EQ
+        {
+            return Err(TranslateError::UnsupportedPlanNode {
+                node_id: node.node_id,
+                node_type: node.node_type,
+                reason: "only plain equality join conjuncts are supported",
+            });
+        }
+        let mut expr_ctx = ctx.expr_context(&combined_tuples);
+        let left_expr = eq.left.translate(&mut expr_ctx)?;
+        let mut expr_ctx = ctx.expr_context(&combined_tuples);
+        let right_expr = eq.right.translate(&mut expr_ctx)?;
+        if first_equality.is_none() {
+            first_equality = Some((left_expr.clone(), right_expr.clone()));
+        }
+        let anchor = ctx.registry.register_function(URN_COMPARISON, "equal");
+        conditions.push(expr_translator::scalar_function(
+            anchor,
+            vec![left_expr, right_expr],
+            crate::type_mapper::bool_type(),
+        ));
+    }
+    for expr in join.other_join_conjuncts.as_deref().unwrap_or_default() {
+        let mut expr_ctx = ctx.expr_context(&combined_tuples);
+        conditions.push(expr.translate(&mut expr_ctx)?);
+    }
+    if conditions.is_empty() {
+        return Err(TranslateError::UnsupportedPlanNode {
+            node_id: node.node_id,
+            node_type: node.node_type,
+            reason: "hash join without join conjuncts",
+        });
+    }
+    let condition = and_conditions(conditions, ctx);
+
+    let (join_type, output) = match join.join_op {
+        TJoinOp::INNER_JOIN => (join_rel::JoinType::Inner, JoinOutput::Both),
+        TJoinOp::LEFT_OUTER_JOIN => (join_rel::JoinType::Left, JoinOutput::Both),
+        TJoinOp::RIGHT_OUTER_JOIN => (join_rel::JoinType::Right, JoinOutput::Both),
+        TJoinOp::FULL_OUTER_JOIN => (join_rel::JoinType::Outer, JoinOutput::Both),
+        TJoinOp::LEFT_SEMI_JOIN => (join_rel::JoinType::LeftSemi, JoinOutput::Left),
+        TJoinOp::LEFT_ANTI_JOIN => (join_rel::JoinType::Left, JoinOutput::LeftAnti),
+        TJoinOp::RIGHT_ANTI_JOIN => (join_rel::JoinType::Right, JoinOutput::RightAnti),
+        TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN => {
+            (join_rel::JoinType::LeftMark, JoinOutput::NullAwareLeftAnti)
+        }
+        _ => {
+            return Err(TranslateError::UnsupportedPlanNode {
+                node_id: node.node_id,
+                node_type: node.node_type,
+                reason: "hash join type is unsupported",
+            });
+        }
+    };
+
+    let (row_tuples, output_width) = match output {
+        JoinOutput::Left => (left.row_tuples.clone(), left.output_width),
+        JoinOutput::NullAwareLeftAnti => (left.row_tuples.clone(), left.output_width + 1),
+        _ => (
+            combined_tuples.clone(),
+            left.output_width + right.output_width,
+        ),
+    };
+
+    let joined = TranslatedRel {
+        rel: Rel {
+            rel_type: Some(rel::RelType::Join(Box::new(JoinRel {
+                left: Some(Box::new(left.rel)),
+                right: Some(Box::new(right.rel)),
+                expression: Some(Box::new(condition)),
+                r#type: join_type as i32,
+                ..Default::default()
+            }))),
+        },
+        row_tuples,
+        output_width,
+    };
+    let joined = match output {
+        JoinOutput::LeftAnti => {
+            let (_, right_key) = first_equality
+                .ok_or_else(|| TranslateError::malformed("left anti join has no equality key"))?;
+            let filtered = filter_is_null(joined, right_key, ctx);
+            emit_columns(
+                filtered,
+                (0..left.output_width as i32).collect(),
+                left.row_tuples,
+            )
+        }
+        JoinOutput::RightAnti => {
+            let (left_key, _) = first_equality
+                .ok_or_else(|| TranslateError::malformed("right anti join has no equality key"))?;
+            let filtered = filter_is_null(joined, left_key, ctx);
+            let start = left.output_width as i32;
+            let end = start + right.output_width as i32;
+            emit_columns(filtered, (start..end).collect(), right.row_tuples)
+        }
+        JoinOutput::NullAwareLeftAnti => {
+            let marker = field_selection(left.output_width as i32);
+            let not_anchor = ctx.registry.register_function(URN_BOOLEAN, "not");
+            let condition = expr_translator::scalar_function(
+                not_anchor,
+                vec![marker],
+                crate::type_mapper::bool_type(),
+            );
+            let filtered = filter_rel(joined, condition);
+            emit_columns(
+                filtered,
+                (0..left.output_width as i32).collect(),
+                left.row_tuples,
+            )
+        }
+        _ => joined,
+    };
+    // Node conjuncts are post-join predicates over the join's output row.
+    apply_conjuncts(joined, node, ctx)
+}
+
+#[derive(Clone, Copy)]
+enum JoinOutput {
+    Both,
+    Left,
+    LeftAnti,
+    RightAnti,
+    NullAwareLeftAnti,
+}
+
+/// Translates an inner/cross `NESTLOOP_JOIN_NODE` into an equality join on synthetic constants.
+/// This preserves Cartesian-product semantics without requiring a GPU cross-product operator.
+fn translate_nestloop_join(
+    node: &TPlanNode,
+    children: Vec<TranslatedRel>,
+    ctx: &mut PlanContext<'_>,
+) -> Result<TranslatedRel> {
+    expect_children(node, &children, 2)?;
+    let join = node
+        .nestloop_join_node
+        .as_ref()
+        .ok_or(TranslateError::MissingField {
+            context: "NESTLOOP_JOIN_NODE",
+            field: "nestloop_join_node",
+        })?;
+    match join.join_op {
+        None | Some(TJoinOp::CROSS_JOIN) | Some(TJoinOp::INNER_JOIN) => {}
+        Some(_) => {
+            return Err(TranslateError::UnsupportedPlanNode {
+                node_id: node.node_id,
+                node_type: node.node_type,
+                reason: "only inner/cross nested-loop joins are supported",
+            });
+        }
+    }
+    let mut children = children.into_iter();
+    let left = children.next().unwrap();
+    let right = children.next().unwrap();
+    let left_width = left.output_width;
+    let right_width = right.output_width;
+    let row_tuples = [left.row_tuples.as_slice(), right.row_tuples.as_slice()].concat();
+    let left = append_project(left, i32_literal(1));
+    let right = append_project(right, i32_literal(1));
+    let equal_anchor = ctx.registry.register_function(URN_COMPARISON, "equal");
+    let condition = expr_translator::scalar_function(
+        equal_anchor,
+        vec![
+            field_selection(left_width as i32),
+            field_selection((left.output_width + right_width) as i32),
+        ],
+        crate::type_mapper::bool_type(),
+    );
+    let joined = TranslatedRel {
+        rel: Rel {
+            rel_type: Some(rel::RelType::Join(Box::new(JoinRel {
+                left: Some(Box::new(left.rel)),
+                right: Some(Box::new(right.rel)),
+                expression: Some(Box::new(condition)),
+                r#type: join_rel::JoinType::Inner as i32,
+                ..Default::default()
+            }))),
+        },
+        row_tuples: row_tuples.clone(),
+        output_width: left.output_width + right.output_width,
+    };
+    let mut mapping = (0..left_width as i32).collect::<Vec<_>>();
+    mapping.extend(left.output_width as i32..left.output_width as i32 + right_width as i32);
+    let cross = emit_columns(joined, mapping, row_tuples);
+    let filtered = if let Some(conjuncts) = join
+        .join_conjuncts
+        .as_ref()
+        .filter(|conjuncts| !conjuncts.is_empty())
+    {
+        let mut conditions = Vec::with_capacity(conjuncts.len());
+        for expr in conjuncts {
+            let mut expr_ctx = ctx.expr_context(&cross.row_tuples);
+            conditions.push(expr.translate(&mut expr_ctx)?);
+        }
+        let condition = and_conditions(conditions, ctx);
+        let TranslatedRel {
+            rel,
+            row_tuples,
+            output_width,
+        } = cross;
+        TranslatedRel {
+            rel: Rel {
+                rel_type: Some(rel::RelType::Filter(Box::new(FilterRel {
+                    input: Some(Box::new(rel)),
+                    condition: Some(Box::new(condition)),
+                    ..Default::default()
+                }))),
+            },
+            row_tuples,
+            output_width,
+        }
+    } else {
+        cross
+    };
+    // Node conjuncts are post-join predicates over the join's output row.
+    apply_conjuncts(filtered, node, ctx)
+}
+
+/// Combines one or more boolean conditions with `and`.
+fn and_conditions(mut conditions: Vec<Expression>, ctx: &mut PlanContext<'_>) -> Expression {
+    if conditions.len() == 1 {
+        return conditions.pop().unwrap();
+    }
+    let anchor = ctx.registry.register_function(URN_BOOLEAN, "and");
+    expr_translator::scalar_function(anchor, conditions, crate::type_mapper::bool_type())
 }
 
 /// Builds a Substrait read for a StarRocks scan tuple.
@@ -266,17 +910,7 @@ fn scan_rel(desc: &DescriptorTable, tuple_id: i32, file_paths: &[String]) -> Res
             ..Default::default()
         })
     } else {
-        ReadType::LocalFiles(LocalFiles {
-            items: file_paths
-                .iter()
-                .map(|path| FileOrFiles {
-                    path_type: Some(PathType::UriFile(path.clone())),
-                    file_format: Some(FileFormat::Parquet(ParquetReadOptions {})),
-                    ..Default::default()
-                })
-                .collect(),
-            ..Default::default()
-        })
+        return Ok(local_files_rel(desc.named_struct(tuple_id)?, file_paths));
     };
     Ok(Rel {
         rel_type: Some(rel::RelType::Read(Box::new(ReadRel {
@@ -285,6 +919,27 @@ fn scan_rel(desc: &DescriptorTable, tuple_id: i32, file_paths: &[String]) -> Res
             ..Default::default()
         }))),
     })
+}
+
+/// Builds a local parquet read with an explicit schema.
+fn local_files_rel(schema: substrait::proto::NamedStruct, file_paths: &[String]) -> Rel {
+    Rel {
+        rel_type: Some(rel::RelType::Read(Box::new(ReadRel {
+            base_schema: Some(schema),
+            read_type: Some(ReadType::LocalFiles(LocalFiles {
+                items: file_paths
+                    .iter()
+                    .map(|path| FileOrFiles {
+                        path_type: Some(PathType::UriFile(path.clone())),
+                        file_format: Some(FileFormat::Parquet(ParquetReadOptions {})),
+                        ..Default::default()
+                    })
+                    .collect(),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }))),
+    }
 }
 
 /// Translates a StarRocks project node while preserving descriptor output order.
@@ -317,6 +972,19 @@ fn translate_project_node(
         node.row_tuples.clone()
     };
 
+    let output_tuple = output_tuples[0];
+    let mut input = child;
+    let mut common_slots = std::collections::HashMap::new();
+    for (&slot_id, expr) in project_node.common_slot_map.as_ref().into_iter().flatten() {
+        let expression = {
+            let mut expr_ctx = ctx.expr_context_with_slots(&input.row_tuples, &common_slots);
+            expr.translate(&mut expr_ctx)?
+        };
+        let field = input.output_width;
+        input = append_project(input, expression);
+        common_slots.insert((output_tuple, slot_id), field);
+    }
+
     let mut expressions = Vec::new();
     for &tuple_id in &output_tuples {
         for slot_id in ctx.desc.materialized_slot_ids(tuple_id)? {
@@ -326,12 +994,12 @@ fn translate_project_node(
                     node.node_id, slot_id
                 ))
             })?;
-            let mut expr_ctx = ctx.expr_context(&child.row_tuples);
+            let mut expr_ctx = ctx.expr_context_with_slots(&input.row_tuples, &common_slots);
             expressions.push(expr.translate(&mut expr_ctx)?);
         }
     }
 
-    Ok(project_rel(child, expressions, output_tuples))
+    Ok(project_rel(input, expressions, output_tuples))
 }
 
 /// Adds a root projection over explicit fragment output expressions.
@@ -344,7 +1012,8 @@ pub(crate) fn project_exprs(
     // Root projections evaluate over already-translated inputs, so there are no
     // scan nodes to resolve file paths for.
     let scan_paths = ScanFilePaths::default();
-    let mut ctx = PlanContext::new(desc, &scan_paths, registry);
+    let exchange_inputs = std::collections::HashMap::new();
+    let mut ctx = PlanContext::new(desc, &scan_paths, &exchange_inputs, registry);
     project_exprs_with_context(input, exprs, &mut ctx)
 }
 
@@ -395,6 +1064,119 @@ fn project_rel(
         row_tuples,
         output_width,
     }
+}
+
+/// Appends one expression to a relation while retaining all existing columns.
+fn append_project(input: TranslatedRel, expression: Expression) -> TranslatedRel {
+    let output_width = input.output_width + 1;
+    TranslatedRel {
+        rel: Rel {
+            rel_type: Some(rel::RelType::Project(Box::new(ProjectRel {
+                common: Some(RelCommon {
+                    emit_kind: Some(rel_common::EmitKind::Emit(rel_common::Emit {
+                        output_mapping: (0..output_width as i32).collect(),
+                    })),
+                    ..Default::default()
+                }),
+                input: Some(Box::new(input.rel)),
+                expressions: vec![expression],
+                ..Default::default()
+            }))),
+        },
+        row_tuples: input.row_tuples,
+        output_width,
+    }
+}
+
+/// Emits selected input columns without evaluating new expressions.
+fn emit_columns(
+    input: TranslatedRel,
+    output_mapping: Vec<i32>,
+    row_tuples: Vec<i32>,
+) -> TranslatedRel {
+    let output_width = output_mapping.len();
+    TranslatedRel {
+        rel: Rel {
+            rel_type: Some(rel::RelType::Project(Box::new(ProjectRel {
+                common: Some(RelCommon {
+                    emit_kind: Some(rel_common::EmitKind::Emit(rel_common::Emit {
+                        output_mapping,
+                    })),
+                    ..Default::default()
+                }),
+                input: Some(Box::new(input.rel)),
+                ..Default::default()
+            }))),
+        },
+        row_tuples,
+        output_width,
+    }
+}
+
+/// Builds a direct field selection against the current relation output.
+fn field_selection(field: i32) -> Expression {
+    use substrait::proto::expression::field_reference;
+    use substrait::proto::expression::reference_segment;
+    use substrait::proto::expression::{FieldReference, ReferenceSegment};
+
+    Expression {
+        rex_type: Some(substrait::proto::expression::RexType::Selection(Box::new(
+            FieldReference {
+                reference_type: Some(field_reference::ReferenceType::DirectReference(
+                    ReferenceSegment {
+                        reference_type: Some(reference_segment::ReferenceType::StructField(
+                            Box::new(reference_segment::StructField { field, child: None }),
+                        )),
+                    },
+                )),
+                root_type: Some(field_reference::RootType::RootReference(
+                    field_reference::RootReference {},
+                )),
+            },
+        ))),
+    }
+}
+
+/// Builds an i32 literal used as a synthetic Cartesian-product key.
+fn i32_literal(value: i32) -> Expression {
+    Expression {
+        rex_type: Some(substrait::proto::expression::RexType::Literal(
+            substrait::proto::expression::Literal {
+                literal_type: Some(substrait::proto::expression::literal::LiteralType::I32(
+                    value,
+                )),
+                ..Default::default()
+            },
+        )),
+    }
+}
+
+/// Wraps a relation in a filter without changing its row layout.
+fn filter_rel(input: TranslatedRel, condition: Expression) -> TranslatedRel {
+    let output_width = input.output_width;
+    TranslatedRel {
+        rel: Rel {
+            rel_type: Some(rel::RelType::Filter(Box::new(FilterRel {
+                input: Some(Box::new(input.rel)),
+                condition: Some(Box::new(condition)),
+                ..Default::default()
+            }))),
+        },
+        row_tuples: input.row_tuples,
+        output_width,
+    }
+}
+
+/// Filters to rows where an equality-key expression is null.
+fn filter_is_null(
+    input: TranslatedRel,
+    key: Expression,
+    ctx: &mut PlanContext<'_>,
+) -> TranslatedRel {
+    let anchor = ctx.registry.register_function(URN_COMPARISON, "is_null");
+    let condition =
+        expr_translator::scalar_function(anchor, vec![key], crate::type_mapper::bool_type());
+    filter_rel(input, condition)
 }
 
 /// Wraps a relation in a Substrait filter when the StarRocks node has conjuncts.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
@@ -20,18 +20,27 @@ use crate::error::{Result, TranslateError};
 ///
 /// Collection fails closed: only the slice that maps faithfully onto a
 /// `parquet_scan` over local files is accepted — a `FILES()` query (not a load),
-/// reading whole local parquet files whose columns are direct passthroughs to the
-/// scan tuple. Anything else (loads, byte-range splits, remote schemes, casts or
-/// other column transforms, path-derived or flexibly-mapped columns) is rejected
+/// reading local parquet files whose columns are direct passthroughs to the scan
+/// tuple. Byte-range splits assigned to one fragment are collapsed only when they
+/// collectively cover the whole file. Anything else (loads, partial files, remote
+/// schemes, casts or other column transforms, path-derived or flexibly-mapped columns) is rejected
 /// with [`TranslateError::UnsupportedScanRange`] rather than silently producing
 /// wrong results.
 #[derive(Debug, Default)]
 pub(crate) struct ScanFilePaths {
     by_node: HashMap<i32, Vec<String>>,
+    byte_ranges: HashMap<i32, HashMap<String, Vec<ByteRange>>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ByteRange {
+    start: i64,
+    size: i64,
+    file_size: Option<i64>,
 }
 
 impl ScanFilePaths {
-    /// Collects whole-file parquet paths from `params`' broker scan ranges.
+    /// Collects complete parquet paths from `params`' broker scan ranges.
     ///
     /// Ranges arrive either per node (`per_node_scan_ranges`) or, for pipeline
     /// fragments, per driver sequence (`node_to_per_driver_seq_scan_ranges`);
@@ -65,6 +74,7 @@ impl ScanFilePaths {
                 }
             }
         }
+        paths.validate_complete_files()?;
         Ok(paths)
     }
 
@@ -77,7 +87,7 @@ impl ScanFilePaths {
             .unwrap_or_default()
     }
 
-    /// Validates and appends the whole-file parquet paths in `ranges` to `node_id`.
+    /// Validates and appends parquet paths and byte ranges in `ranges` to `node_id`.
     fn add_ranges(
         &mut self,
         node_id: i32,
@@ -91,10 +101,76 @@ impl ScanFilePaths {
             Self::check_params(node_id, &broker.params, desc)?;
             for range_desc in &broker.ranges {
                 Self::check_range(node_id, range_desc)?;
-                self.by_node
+                let node_paths = self.by_node.entry(node_id).or_default();
+                if !node_paths.contains(&range_desc.path) {
+                    node_paths.push(range_desc.path.clone());
+                }
+                self.byte_ranges
                     .entry(node_id)
                     .or_default()
-                    .push(range_desc.path.clone());
+                    .entry(range_desc.path.clone())
+                    .or_default()
+                    .push(ByteRange {
+                        start: range_desc.start_offset,
+                        size: range_desc.size,
+                        file_size: range_desc.file_size,
+                    });
+            }
+        }
+        Ok(())
+    }
+
+    /// Ensures split ranges assigned to this fragment collectively cover each file exactly once.
+    fn validate_complete_files(&self) -> Result<()> {
+        for (&node_id, files) in &self.byte_ranges {
+            for (path, ranges) in files {
+                let Some(file_size) = ranges.first().and_then(|range| range.file_size) else {
+                    return Err(Self::unsupported(
+                        node_id,
+                        "scan range is missing the parquet file size",
+                    ));
+                };
+                if file_size <= 0
+                    || ranges
+                        .iter()
+                        .any(|range| range.file_size != Some(file_size))
+                {
+                    return Err(Self::unsupported(
+                        node_id,
+                        "scan ranges disagree on the parquet file size",
+                    ));
+                }
+                let mut intervals = ranges
+                    .iter()
+                    .map(|range| {
+                        let end = if range.size == -1 {
+                            file_size
+                        } else if range.size > 0 {
+                            range.start.checked_add(range.size).unwrap_or(i64::MAX)
+                        } else {
+                            -1
+                        };
+                        (range.start, end)
+                    })
+                    .collect::<Vec<_>>();
+                intervals.sort_unstable();
+                let mut covered_until = 0;
+                for (start, end) in intervals {
+                    if start < 0 || end <= start || start > covered_until {
+                        return Err(Self::unsupported(
+                            node_id,
+                            "byte-range splits do not cover the whole parquet file",
+                        ));
+                    }
+                    covered_until = covered_until.max(end);
+                }
+                if covered_until < file_size {
+                    return Err(Self::unsupported(
+                        node_id,
+                        "byte-range splits do not cover the whole parquet file",
+                    ));
+                }
+                debug_assert!(!path.is_empty());
             }
         }
         Ok(())
@@ -169,7 +245,7 @@ impl ScanFilePaths {
         Ok(())
     }
 
-    /// Rejects a single broker range outside the supported whole-file local-parquet slice.
+    /// Rejects a broker range outside the supported local-parquet slice.
     fn check_range(node_id: i32, desc: &TBrokerRangeDesc) -> Result<()> {
         if desc.format_type != TFileFormatType::FORMAT_PARQUET {
             return Err(Self::unsupported(
@@ -183,24 +259,6 @@ impl ScanFilePaths {
             return Err(Self::unsupported(
                 node_id,
                 "only broker-descriptor file scan ranges are supported",
-            ));
-        }
-        // Whole-file only: DuckDB's `local_files` reader ignores per-file byte
-        // offsets, so accept a range only when it provably covers the whole,
-        // non-empty file. A FILES() query stats each file, so require a known
-        // positive `file_size` reached by reading to EOF (`size == -1`) or by a
-        // bounded size at least that large. Unknown size, an empty file, or a
-        // bounded size short of the file are rejected rather than silently reading
-        // the wrong bytes.
-        let whole_file = desc.start_offset == 0
-            && match desc.file_size {
-                Some(file_size) => file_size > 0 && (desc.size == -1 || desc.size >= file_size),
-                None => false,
-            };
-        if !whole_file {
-            return Err(Self::unsupported(
-                node_id,
-                "byte-range split scan ranges are not supported",
             ));
         }
         // StarRocks appends path-derived columns after the physical parquet

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
@@ -23,6 +23,16 @@ pub(crate) fn bool_type() -> Type {
     }
 }
 
+/// Builds an FP64 type used to lower arithmetic Sirius cannot execute on decimal columns.
+pub(crate) fn fp64_type(nullable: bool) -> Type {
+    Type {
+        kind: Some(r#type::Kind::Fp64(r#type::Fp64 {
+            type_variation_reference: 0,
+            nullability: nullability(nullable),
+        })),
+    }
+}
+
 /// Maps a StarRocks type descriptor and slot nullability into a Substrait type.
 pub fn map_type_desc(type_desc: &TTypeDesc, nullable: bool) -> Result<Type> {
     let node = scalar_node(type_desc)?;
@@ -171,12 +181,19 @@ pub fn map_scalar_type(scalar: &TScalarType, nullable: bool) -> Result<Type> {
                     reason: "decimal precision above 38 has no safe v1 Substrait mapping",
                 });
             }
-            r#type::Kind::Decimal(r#type::Decimal {
-                precision,
-                scale: scalar.scale.unwrap_or(0),
-                type_variation_reference: 0,
-                nullability: n,
-            })
+            if precision <= 18 {
+                r#type::Kind::Decimal(r#type::Decimal {
+                    precision,
+                    scale: scalar.scale.unwrap_or(0),
+                    type_variation_reference: 0,
+                    nullability: n,
+                })
+            } else {
+                r#type::Kind::Fp64(r#type::Fp64 {
+                    type_variation_reference: 0,
+                    nullability: n,
+                })
+            }
         }
         TPrimitiveType::DECIMAL256 => {
             return Err(TranslateError::UnsupportedType {

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -1,15 +1,16 @@
 use std::collections::BTreeMap;
 
 use starrocks_plan_translator::{
-    ExtensionRegistry, PlanTranslator, TranslateError, URN_BOOLEAN, URN_COMPARISON,
+    ExchangeInput, ExtensionRegistry, PlanTranslator, TranslateError, URN_BOOLEAN, URN_COMPARISON,
     translate_fragment,
 };
 use starrocks_thrift::descriptors::{
     TDescriptorTable, TSlotDescriptor, TTableDescriptor, TTupleDescriptor,
 };
 use starrocks_thrift::exprs::{
-    TBoolLiteral, TCaseExpr, TDateLiteral, TDecimalLiteral, TExpr, TExprNode, TExprNodeType,
-    TFloatLiteral, TInPredicate, TIntLiteral, TIsNullPredicate, TSlotRef, TStringLiteral,
+    TAggregateExpr, TBoolLiteral, TCaseExpr, TDateLiteral, TDecimalLiteral, TExpr, TExprNode,
+    TExprNodeType, TFloatLiteral, TInPredicate, TIntLiteral, TIsNullPredicate, TSlotRef,
+    TStringLiteral,
 };
 use starrocks_thrift::internal_service::{
     InternalServiceVersion, TExecPlanFragmentParams, TPlanFragmentExecParams, TScanRangeParams,
@@ -17,8 +18,10 @@ use starrocks_thrift::internal_service::{
 use starrocks_thrift::opcodes::TExprOpcode;
 use starrocks_thrift::partitions::{TDataPartition, TPartitionType};
 use starrocks_thrift::plan_nodes::{
-    TBrokerRangeDesc, TBrokerScanRange, TBrokerScanRangeParams, TFileFormatType, TFileScanNode,
-    TFileScanType, TPlan, TPlanNode, TPlanNodeType, TProjectNode, TScanRange, TSelectNode,
+    TAggregationNode, TBrokerRangeDesc, TBrokerScanRange, TBrokerScanRangeParams, TEqJoinCondition,
+    TExchangeNode, TFileFormatType, TFileScanNode, TFileScanType, THashJoinNode, TJoinOp,
+    TNestLoopJoinNode, TPlan, TPlanNode, TPlanNodeType, TProjectNode, TScanRange, TSelectNode,
+    TSortInfo, TSortNode,
 };
 use starrocks_thrift::planner::TPlanFragment;
 use starrocks_thrift::types::{
@@ -663,6 +666,46 @@ fn split_broker_range_is_unsupported() {
     }
 }
 
+/// Verifies complete byte-range splits are collapsed to one whole-file local read.
+#[test]
+fn complete_split_broker_ranges_produce_one_local_file() {
+    let path = "file:///data/users.parquet";
+    let mut fragment = params_with_scan_range(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        0,
+        broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, 512, Some(1024)),
+    );
+    fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap()
+        .push(TScanRangeParams::new(
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 512, 512, Some(1024)),
+            None,
+            None,
+            None,
+        ));
+    let translated = PlanTranslator::new().translate_fragment(&fragment).unwrap();
+    let rel::RelType::Read(read) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected local read");
+    };
+    let Some(read_rel::ReadType::LocalFiles(files)) = read.read_type.as_ref() else {
+        panic!("expected local files");
+    };
+    assert_eq!(files.items.len(), 1);
+}
+
 /// Verifies a scan range delivered via the pipeline per-driver-sequence map is
 /// collected too (not just `per_node_scan_ranges`).
 #[test]
@@ -1107,6 +1150,64 @@ fn scan_project_preserves_descriptor_output_order() {
     }
 }
 
+/// Verifies hidden project expressions are appended in key order and can be
+/// referenced by visible expressions without descriptor-table slots.
+#[test]
+fn project_common_slots_are_materialized_before_visible_expressions() {
+    let mut common_slot_map = BTreeMap::new();
+    common_slot_map.insert(5, slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)));
+    let mut slot_map = BTreeMap::new();
+    slot_map.insert(3, slot_ref(5, 1, scalar_type(TPrimitiveType::BIGINT)));
+
+    let mut project = base_plan_node(1, TPlanNodeType::PROJECT_NODE, 1, vec![1]);
+    project.project_node = Some(TProjectNode::new(Some(slot_map), Some(common_slot_map)));
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None)],
+        vec![
+            slot(1, 0, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, 1, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(3, 1, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![project, scan_node(0, 0)])),
+        Some(desc),
+        None,
+    ))
+    .unwrap();
+    let rel::RelType::Project(visible) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected visible project");
+    };
+    let expression::RexType::Selection(selection) =
+        visible.expressions[0].rex_type.as_ref().unwrap()
+    else {
+        panic!("expected common-slot selection");
+    };
+    let expression::field_reference::ReferenceType::DirectReference(segment) =
+        selection.reference_type.as_ref().unwrap()
+    else {
+        panic!("expected direct field reference");
+    };
+    let expression::reference_segment::ReferenceType::StructField(field) =
+        segment.reference_type.as_ref().unwrap()
+    else {
+        panic!("expected struct field");
+    };
+    assert_eq!(field.field, 2);
+    assert!(matches!(
+        visible.input.as_ref().unwrap().rel_type.as_ref().unwrap(),
+        rel::RelType::Project(_)
+    ));
+}
+
 /// Verifies fragment output expressions add the final root projection.
 #[test]
 fn fragment_output_exprs_add_root_projection() {
@@ -1134,10 +1235,10 @@ fn fragment_output_exprs_add_root_projection() {
     }
 }
 
-/// Verifies unsupported joins return a structured unsupported-plan-node error.
+/// Verifies unsupported plan nodes return a structured unsupported-plan-node error.
 #[test]
-fn unsupported_hash_join_is_structured_error() {
-    let join = base_plan_node(9, TPlanNodeType::HASH_JOIN_NODE, 0, vec![0]);
+fn unsupported_merge_join_is_structured_error() {
+    let join = base_plan_node(9, TPlanNodeType::MERGE_JOIN_NODE, 0, vec![0]);
     let err = translate_fragment(&params(
         Some(TPlan::new(vec![join])),
         Some(base_desc()),
@@ -1150,7 +1251,7 @@ fn unsupported_hash_join_is_structured_error() {
             node_id: 9,
             node_type,
             ..
-        } if node_type == TPlanNodeType::HASH_JOIN_NODE
+        } if node_type == TPlanNodeType::MERGE_JOIN_NODE
     ));
 }
 
@@ -1999,11 +2100,424 @@ fn builtin_function(name: &str, ret_type: TTypeDesc) -> TFunction {
     )
 }
 
-/// Verifies an exchange node is still rejected: fragments are translated in isolation and
-/// multi-fragment plans are a later milestone.
+/// Builds an aggregate-function expression (`fn(child)`) in flat preorder form.
+fn aggregate_expr(name: &str, ret_type: TTypeDesc, child: Option<TExpr>) -> TExpr {
+    let num_children = child.as_ref().map(|_| 1).unwrap_or(0);
+    let mut node = base_expr_node(TExprNodeType::AGG_EXPR, ret_type.clone(), num_children);
+    node.agg_expr = Some(TAggregateExpr::new(false));
+    node.fn_ = Some(builtin_function(name, ret_type));
+    let mut nodes = vec![node];
+    if let Some(child) = child {
+        nodes.extend(child.nodes);
+    }
+    TExpr::new(nodes)
+}
+
+/// Builds a one-phase aggregation node over `output_tuple` with the given keys and aggregates.
+fn aggregation_node(
+    node_id: i32,
+    output_tuple: i32,
+    grouping: Vec<TExpr>,
+    aggregates: Vec<TExpr>,
+) -> TPlanNode {
+    let mut node = base_plan_node(
+        node_id,
+        TPlanNodeType::AGGREGATION_NODE,
+        1,
+        vec![output_tuple],
+    );
+    node.agg_node = Some(TAggregationNode::new(
+        Some(grouping),
+        aggregates,
+        output_tuple,
+        output_tuple,
+        true,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    ));
+    node
+}
+
+/// Descriptor with a scan tuple 0 (`id` BIGINT, `name` VARCHAR) and an aggregation output
+/// tuple 1 (`name` key, `total` BIGINT).
+fn agg_desc() -> TDescriptorTable {
+    desc_table(
+        vec![(0, Some(100)), (1, None)],
+        vec![
+            slot(1, 0, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, 1, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(1, 1, 0, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(2, 1, 1, "total", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    )
+}
+
+/// Verifies one-phase group-by aggregation becomes an `AggregateRel` with the grouping key and
+/// a `sum` measure, and that the output row layout switches to the aggregation output tuple.
+#[test]
+fn aggregation_translates_to_aggregate_rel() {
+    let agg = aggregation_node(
+        1,
+        1,
+        vec![slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))],
+        vec![aggregate_expr(
+            "sum",
+            scalar_type(TPrimitiveType::BIGINT),
+            Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+        )],
+    );
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![agg, scan_node(0, 0)])),
+        Some(agg_desc()),
+        None,
+    ))
+    .unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["name", "total"]);
+    let rel::RelType::Aggregate(aggregate) =
+        root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected aggregate relation");
+    };
+    assert_eq!(aggregate.grouping_expressions.len(), 1);
+    assert_eq!(aggregate.groupings.len(), 1);
+    assert_eq!(aggregate.groupings[0].expression_references, vec![0]);
+    assert_eq!(aggregate.measures.len(), 1);
+    let measure = aggregate.measures[0].measure.as_ref().unwrap();
+    assert_eq!(measure.arguments.len(), 1);
+    assert_eq!(
+        measure.invocation,
+        substrait::proto::aggregate_function::AggregationInvocation::All as i32
+    );
+    let names: Vec<_> = extension_function_names(&translated.plan);
+    assert!(names.contains(&"sum".to_string()), "{names:?}");
+}
+
+/// Verifies a distinct aggregate (StarRocks `multi_distinct_count`) becomes a distinct `count`.
+#[test]
+fn multi_distinct_count_translates_to_distinct_count() {
+    let agg = aggregation_node(
+        1,
+        1,
+        vec![slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))],
+        vec![aggregate_expr(
+            "multi_distinct_count",
+            scalar_type(TPrimitiveType::BIGINT),
+            Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+        )],
+    );
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![agg, scan_node(0, 0)])),
+        Some(agg_desc()),
+        None,
+    ))
+    .unwrap();
+
+    let root = root(&translated.plan);
+    let rel::RelType::Aggregate(aggregate) =
+        root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected aggregate relation");
+    };
+    let measure = aggregate.measures[0].measure.as_ref().unwrap();
+    assert_eq!(
+        measure.invocation,
+        substrait::proto::aggregate_function::AggregationInvocation::Distinct as i32
+    );
+    let names = extension_function_names(&translated.plan);
+    assert!(names.contains(&"count".to_string()), "{names:?}");
+}
+
+/// Verifies a merge-phase aggregate (two-phase aggregation) is rejected.
+#[test]
+fn merge_aggregation_is_rejected() {
+    let mut aggregate = aggregate_expr(
+        "sum",
+        scalar_type(TPrimitiveType::BIGINT),
+        Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+    );
+    aggregate.nodes[0].agg_expr = Some(TAggregateExpr::new(true));
+    let agg = aggregation_node(1, 1, Vec::new(), vec![aggregate]);
+    // Output tuple 1 has two slots but no grouping keys, so use a dedicated descriptor with a
+    // single aggregate output slot.
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None)],
+        vec![
+            slot(1, 0, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, 1, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(1, 1, 0, "total", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+    let err = translate_fragment(&params(
+        Some(TPlan::new(vec![agg, scan_node(0, 0)])),
+        Some(desc),
+        None,
+    ))
+    .unwrap_err();
+    assert!(matches!(err, TranslateError::UnsupportedExpression { .. }));
+}
+
+/// Verifies a top-N sort becomes project (sort tuple) + sort + fetch with the node limit.
+#[test]
+fn sort_with_limit_becomes_project_sort_fetch() {
+    let sort_info = TSortInfo::new(
+        vec![slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT))],
+        vec![true],
+        vec![false],
+        None,
+    );
+    let mut sort = base_plan_node(1, TPlanNodeType::SORT_NODE, 1, vec![1]);
+    sort.limit = 5;
+    sort.sort_node = Some(TSortNode::new(
+        sort_info,
+        true,
+        Some(0),
+        None,
+        None,
+        None,
+        None,
+        Some(vec![slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))]),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    ));
+    // Sort tuple 1 materializes only the ordering column.
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None)],
+        vec![
+            slot(1, 0, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, 1, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(1, 1, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![sort, scan_node(0, 0)])),
+        Some(desc),
+        None,
+    ))
+    .unwrap();
+
+    let root = root(&translated.plan);
+    let rel::RelType::Fetch(fetch) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected fetch relation");
+    };
+    #[allow(deprecated)]
+    {
+        assert_eq!(
+            fetch.count_mode,
+            Some(substrait::proto::fetch_rel::CountMode::Count(5))
+        );
+        assert_eq!(fetch.offset_mode, None);
+    }
+    let rel::RelType::Sort(sort) = fetch.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected sort under fetch");
+    };
+    assert_eq!(sort.sorts.len(), 1);
+    assert_eq!(
+        sort.sorts[0].sort_kind,
+        Some(substrait::proto::sort_field::SortKind::Direction(
+            substrait::proto::sort_field::SortDirection::AscNullsLast as i32
+        ))
+    );
+    let rel::RelType::Project(_) = sort.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected sort-tuple projection under sort");
+    };
+}
+
+/// Two-table descriptor for join tests: tuple 0 = users(`a`), tuple 1 = orders(`b`).
+fn join_desc() -> TDescriptorTable {
+    desc_table(
+        vec![(0, Some(100)), (1, Some(100))],
+        vec![
+            slot(1, 0, 0, "a", scalar_type(TPrimitiveType::BIGINT)),
+            slot(1, 1, 0, "b", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    )
+}
+
+/// Builds a hash-join plan node with one `left = right` equality conjunct.
+fn hash_join_node(join_op: TJoinOp) -> TPlanNode {
+    let mut join = base_plan_node(2, TPlanNodeType::HASH_JOIN_NODE, 2, vec![0, 1]);
+    join.hash_join_node = Some(THashJoinNode::new(
+        join_op,
+        vec![TEqJoinCondition::new(
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+            Some(TExprOpcode::EQ),
+        )],
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    ));
+    join
+}
+
+/// Extracts the field index from a direct struct-field reference.
+fn field_index(expr: &substrait::proto::Expression) -> i32 {
+    let expression::RexType::Selection(selection) = expr.rex_type.as_ref().unwrap() else {
+        panic!("expected field reference");
+    };
+    let expression::field_reference::ReferenceType::DirectReference(segment) =
+        selection.reference_type.as_ref().unwrap()
+    else {
+        panic!("expected direct reference");
+    };
+    let expression::reference_segment::ReferenceType::StructField(field) =
+        segment.reference_type.as_ref().unwrap()
+    else {
+        panic!("expected struct field");
+    };
+    field.field
+}
+
+/// Verifies an inner hash join becomes a Substrait join whose equality condition references the
+/// concatenated left-then-right row (right side offset by the left width).
+#[test]
+fn inner_hash_join_translates_to_join_rel() {
+    let plan = TPlan::new(vec![
+        hash_join_node(TJoinOp::INNER_JOIN),
+        scan_node(0, 0),
+        scan_node(1, 1),
+    ]);
+    let translated = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["a", "b"]);
+    let rel::RelType::Join(join) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected join relation");
+    };
+    assert_eq!(
+        join.r#type,
+        substrait::proto::join_rel::JoinType::Inner as i32
+    );
+    let expression::RexType::ScalarFunction(equal) =
+        join.expression.as_ref().unwrap().rex_type.as_ref().unwrap()
+    else {
+        panic!("expected scalar function join condition");
+    };
+    let args: Vec<_> = equal
+        .arguments
+        .iter()
+        .map(|argument| match argument.arg_type.as_ref().unwrap() {
+            substrait::proto::function_argument::ArgType::Value(value) => field_index(value),
+            other => panic!("unexpected argument {other:?}"),
+        })
+        .collect();
+    assert_eq!(args, vec![0, 1]);
+}
+
+/// Verifies a left semi join keeps only the probe-side row layout.
+#[test]
+fn left_semi_join_keeps_probe_layout() {
+    let plan = TPlan::new(vec![
+        hash_join_node(TJoinOp::LEFT_SEMI_JOIN),
+        scan_node(0, 0),
+        scan_node(1, 1),
+    ]);
+    let translated = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["a"]);
+    let rel::RelType::Join(join) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected join relation");
+    };
+    assert_eq!(
+        join.r#type,
+        substrait::proto::join_rel::JoinType::LeftSemi as i32
+    );
+}
+
+/// Verifies a cross nested-loop join becomes a filtered constant-key equality join.
+#[test]
+fn nestloop_join_translates_to_filtered_cross_rel() {
+    let mut join = base_plan_node(2, TPlanNodeType::NESTLOOP_JOIN_NODE, 2, vec![0, 1]);
+    join.nestloop_join_node = Some(TNestLoopJoinNode::new(
+        Some(TJoinOp::CROSS_JOIN),
+        None,
+        Some(vec![binary_pred(
+            TExprOpcode::LT,
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+        )]),
+        None,
+        None,
+        None,
+    ));
+    let plan = TPlan::new(vec![join, scan_node(0, 0), scan_node(1, 1)]);
+    let translated = translate_fragment(&params(Some(plan), Some(join_desc()), None)).unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["a", "b"]);
+    let rel::RelType::Filter(filter) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected filter over constant-key join");
+    };
+    let rel::RelType::Project(project) = filter.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected output projection under filter");
+    };
+    let rel::RelType::Join(join) = project.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected constant-key join under projection");
+    };
+    assert_eq!(
+        join.r#type,
+        substrait::proto::join_rel::JoinType::Inner as i32
+    );
+}
+
+/// Verifies an exchange node without a materialized input is rejected.
 #[test]
 fn exchange_node_is_rejected() {
-    let exchange = base_plan_node(1, TPlanNodeType::EXCHANGE_NODE, 0, vec![0]);
+    let mut exchange = base_plan_node(1, TPlanNodeType::EXCHANGE_NODE, 0, vec![0]);
+    exchange.exchange_node = Some(TExchangeNode::new(
+        vec![0],
+        None,
+        None,
+        Some(TPartitionType::UNPARTITIONED),
+        Some(true),
+        None,
+    ));
     let err = translate_fragment(&params(
         Some(TPlan::new(vec![exchange])),
         Some(base_desc()),
@@ -2017,6 +2531,99 @@ fn exchange_node_is_rejected() {
             ..
         }
     ));
+}
+
+/// Verifies a materialized exchange becomes the read below the receiver aggregate.
+#[test]
+fn materialized_exchange_feeds_aggregate() {
+    let mut exchange = base_plan_node(7, TPlanNodeType::EXCHANGE_NODE, 0, vec![0]);
+    exchange.exchange_node = Some(TExchangeNode::new(
+        vec![0],
+        None,
+        None,
+        Some(TPartitionType::UNPARTITIONED),
+        Some(true),
+        None,
+    ));
+    let aggregate = aggregation_node(
+        8,
+        1,
+        vec![slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))],
+        vec![aggregate_expr(
+            "sum",
+            scalar_type(TPrimitiveType::BIGINT),
+            Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+        )],
+    );
+    let translated = PlanTranslator::new()
+        .translate_fragment_with_exchange_inputs(
+            &params(
+                Some(TPlan::new(vec![aggregate, exchange])),
+                Some(agg_desc()),
+                None,
+            ),
+            &[ExchangeInput {
+                node_id: 7,
+                paths: vec!["/tmp/materialized-exchange.parquet".to_string()],
+                names: vec!["id".to_string(), "name".to_string()],
+            }],
+        )
+        .unwrap();
+
+    let root = root(&translated.plan);
+    let rel::RelType::Aggregate(aggregate) =
+        root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected aggregate receiver");
+    };
+    let rel::RelType::Read(read) = aggregate.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected materialized exchange read");
+    };
+    let Some(read_rel::ReadType::LocalFiles(files)) = read.read_type.as_ref() else {
+        panic!("expected local_files exchange input");
+    };
+    assert_eq!(files.items.len(), 1);
+    assert_eq!(read.base_schema.as_ref().unwrap().names, vec!["id", "name"]);
+}
+
+/// Verifies a merging exchange globally sorts the materialized local sender output.
+#[test]
+fn materialized_merging_exchange_becomes_sort_over_read() {
+    let sort_info = TSortInfo::new(
+        vec![slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))],
+        vec![false],
+        vec![false],
+        None,
+    );
+    let mut exchange = base_plan_node(7, TPlanNodeType::EXCHANGE_NODE, 0, vec![0]);
+    exchange.exchange_node = Some(TExchangeNode::new(
+        vec![0],
+        Some(sort_info),
+        Some(0),
+        Some(TPartitionType::UNPARTITIONED),
+        Some(true),
+        None,
+    ));
+    let translated = PlanTranslator::new()
+        .translate_fragment_with_exchange_inputs(
+            &params(Some(TPlan::new(vec![exchange])), Some(base_desc()), None),
+            &[ExchangeInput {
+                node_id: 7,
+                paths: vec!["/tmp/materialized-exchange.parquet".to_string()],
+                names: vec!["id".to_string(), "name".to_string()],
+            }],
+        )
+        .unwrap();
+
+    let root = root(&translated.plan);
+    let rel::RelType::Sort(sort) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected merging exchange sort");
+    };
+    let rel::RelType::Read(_) = sort.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected materialized exchange read under sort");
+    };
+    assert_eq!(sort.sorts.len(), 1);
 }
 
 /// Returns every extension function name declared by the plan.
@@ -2203,9 +2810,65 @@ fn case_expression_translates_to_if_then() {
     );
 }
 
-/// Verifies decimal-typed arithmetic is rejected (it crashes the engine's GPU projection).
+/// Verifies aggregation-node conjuncts (HAVING) become a filter over the aggregate output.
 #[test]
-fn decimal_arithmetic_is_rejected() {
+fn aggregation_conjuncts_become_having_filter() {
+    let mut agg = aggregation_node(
+        1,
+        1,
+        vec![slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))],
+        vec![aggregate_expr(
+            "sum",
+            scalar_type(TPrimitiveType::BIGINT),
+            Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+        )],
+    );
+    // HAVING total > 10, referencing the aggregation output tuple.
+    agg.conjuncts = Some(vec![binary_pred(
+        TExprOpcode::GT,
+        slot_ref(2, 1, scalar_type(TPrimitiveType::BIGINT)),
+        int_literal(10),
+    )]);
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![agg, scan_node(0, 0)])),
+        Some(agg_desc()),
+        None,
+    ))
+    .unwrap();
+
+    let root = root(&translated.plan);
+    let rel::RelType::Filter(filter) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected HAVING filter over the aggregate");
+    };
+    let rel::RelType::Aggregate(_) = filter.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected aggregate under the HAVING filter");
+    };
+}
+
+/// Verifies anti joins are lowered through supported outer/mark join forms.
+#[test]
+fn anti_hash_joins_are_lowered() {
+    for join_op in [
+        TJoinOp::LEFT_ANTI_JOIN,
+        TJoinOp::RIGHT_ANTI_JOIN,
+        TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN,
+    ] {
+        let plan = TPlan::new(vec![
+            hash_join_node(join_op),
+            scan_node(0, 0),
+            scan_node(1, 1),
+        ]);
+        let translated = translate_fragment(&params(Some(plan), Some(join_desc()), None))
+            .unwrap_or_else(|err| panic!("{join_op:?}: {err:?}"));
+        assert_eq!(root(&translated.plan).names.len(), 1);
+    }
+}
+
+/// Verifies decimal arithmetic is lowered to FP64 casts for the GPU expression evaluator.
+#[test]
+fn decimal_arithmetic_is_lowered_to_fp64() {
     let decimal = scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(31), Some(4));
     let mut arith = base_expr_node(TExprNodeType::ARITHMETIC_EXPR, decimal.clone(), 2);
     arith.opcode = Some(TExprOpcode::MULTIPLY);
@@ -2213,17 +2876,123 @@ fn decimal_arithmetic_is_rejected() {
     nodes.extend(slot_ref(1, 0, decimal.clone()).nodes);
     nodes.extend(slot_ref(1, 0, decimal).nodes);
 
-    let err = translate_fragment(&params(
+    let translated = translate_fragment(&params(
         Some(TPlan::new(vec![scan_node(0, 0)])),
         Some(base_desc()),
         Some(vec![TExpr::new(nodes)]),
+    ))
+    .unwrap();
+    let rel::RelType::Project(project) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected output project");
+    };
+    let expression::RexType::ScalarFunction(function) =
+        project.expressions[0].rex_type.as_ref().unwrap()
+    else {
+        panic!("expected arithmetic function");
+    };
+    assert!(function.arguments.iter().all(|argument| matches!(
+        argument.arg_type.as_ref().unwrap(),
+        substrait::proto::function_argument::ArgType::Value(substrait::proto::Expression {
+            rex_type: Some(expression::RexType::Cast(_)),
+        })
+    )));
+    assert!(matches!(
+        function
+            .output_type
+            .as_ref()
+            .unwrap()
+            .kind
+            .as_ref()
+            .unwrap(),
+        substrait::proto::r#type::Kind::Fp64(_)
+    ));
+}
+
+/// Verifies decimal AVG arguments are lowered to FP64 for GPU execution.
+#[test]
+fn decimal_avg_is_lowered_to_fp64() {
+    let decimal = scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(38), Some(8));
+    let agg = aggregation_node(
+        1,
+        1,
+        vec![slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))],
+        vec![aggregate_expr(
+            "avg",
+            decimal,
+            Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+        )],
+    );
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![agg, scan_node(0, 0)])),
+        Some(agg_desc()),
+        None,
+    ))
+    .unwrap();
+    let rel::RelType::Aggregate(aggregate) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected aggregate");
+    };
+    let argument = aggregate.measures[0].measure.as_ref().unwrap().arguments[0]
+        .arg_type
+        .as_ref()
+        .unwrap();
+    assert!(matches!(
+        argument,
+        substrait::proto::function_argument::ArgType::Value(substrait::proto::Expression {
+            rex_type: Some(expression::RexType::Cast(_)),
+        })
+    ));
+}
+
+/// Verifies partitioned top-N sorts are rejected rather than run as a global sort.
+#[test]
+fn partitioned_topn_sort_is_rejected() {
+    let sort_info = TSortInfo::new(
+        vec![slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT))],
+        vec![true],
+        vec![false],
+        Some(vec![slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))]),
+    );
+    let mut sort = base_plan_node(1, TPlanNodeType::SORT_NODE, 1, vec![1]);
+    let mut sort_node = TSortNode::new(
+        sort_info, true, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None,
+    );
+    sort_node.partition_exprs = Some(vec![slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))]);
+    sort_node.partition_limit = Some(3);
+    sort.sort_node = Some(sort_node);
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None)],
+        vec![
+            slot(1, 0, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, 1, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(1, 1, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+    let err = translate_fragment(&params(
+        Some(TPlan::new(vec![sort, scan_node(0, 0)])),
+        Some(desc),
+        None,
     ))
     .unwrap_err();
     assert!(
         matches!(
             err,
-            TranslateError::UnsupportedExpression {
-                node_type: TExprNodeType::ARITHMETIC_EXPR,
+            TranslateError::UnsupportedPlanNode {
+                node_type: TPlanNodeType::SORT_NODE,
                 ..
             }
         ),
@@ -2231,8 +3000,46 @@ fn decimal_arithmetic_is_rejected() {
     );
 }
 
-/// Verifies GPU-executor guards: non-constant LIKE patterns and non-constant substring
-/// bounds are rejected.
+/// Verifies the sort-tuple materialization is read from `TSortInfo` (the resolved field), not
+/// only from the deprecated node-level duplicate.
+#[test]
+fn sort_tuple_exprs_come_from_sort_info() {
+    let sort_info = TSortInfo::new(
+        vec![slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT))],
+        vec![true],
+        vec![false],
+        Some(vec![slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))]),
+    );
+    let mut sort = base_plan_node(1, TPlanNodeType::SORT_NODE, 1, vec![1]);
+    sort.sort_node = Some(TSortNode::new(
+        sort_info, false, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None,
+    ));
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None)],
+        vec![
+            slot(1, 0, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, 1, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(1, 1, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![sort, scan_node(0, 0)])),
+        Some(desc),
+        None,
+    ))
+    .unwrap();
+    let root = root(&translated.plan);
+    let rel::RelType::Sort(sort) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected sort relation");
+    };
+    let rel::RelType::Project(_) = sort.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected sort-tuple projection from TSortInfo exprs");
+    };
+}
+
+/// Verifies GPU-executor guards: non-constant LIKE patterns, non-constant substring bounds,
+/// bare cross joins, and ungrouped DISTINCT aggregates are rejected.
 #[test]
 fn gpu_unsupported_shapes_are_rejected() {
     // LIKE with a column pattern (not a literal).
@@ -2281,6 +3088,36 @@ fn gpu_unsupported_shapes_are_rejected() {
     .unwrap_err();
     assert!(
         matches!(err, TranslateError::UnsupportedExpression { .. }),
+        "{err:?}"
+    );
+
+    // DISTINCT aggregate without grouping keys.
+    let agg = aggregation_node(
+        1,
+        1,
+        Vec::new(),
+        vec![aggregate_expr(
+            "multi_distinct_count",
+            scalar_type(TPrimitiveType::BIGINT),
+            Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+        )],
+    );
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None)],
+        vec![
+            slot(1, 0, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, 1, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(1, 1, 0, "cnt", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+    let err = translate_fragment(&params(
+        Some(TPlan::new(vec![agg, scan_node(0, 0)])),
+        Some(desc),
+        None,
+    ))
+    .unwrap_err();
+    assert!(
+        matches!(err, TranslateError::UnsupportedPlanNode { .. }),
         "{err:?}"
     );
 }

--- a/experimental/starrocks/pixi.toml
+++ b/experimental/starrocks/pixi.toml
@@ -38,7 +38,19 @@ cn_pid="$!"
 
 wait -n "${fe_pid}" "${cn_pid}"
 '
-""",cwd = ".",depends-on = ["fe-build","cn-build"],description = "Run the local StarRocks FE and Rust CN in the foreground with logs"}
+""",cwd = ".",depends-on = ["fe-check","cn-build"],description = "Run the local StarRocks FE and Rust CN in the foreground with logs",env = {LD_LIBRARY_PATH = "../../build/release/extension/sirius"}}
+
+# This demo project ships the StarRocks FE pre-packaged under starrocks/output/fe, so `cluster`
+# does not depend on `fe-build` (a multi-hour Maven build of the whole front end). Assert the
+# package is there and point at `fe-build` if it is not.
+fe-check = {cmd = """
+bash -lc 'test -x starrocks/output/fe/bin/start_fe.sh || {
+    echo "No packaged FE at starrocks/output/fe." >&2
+    echo "Run: git submodule update --init --recursive experimental/starrocks/starrocks" >&2
+    echo "then: pixi run fe-build   (long — builds the StarRocks front end from source)" >&2
+    exit 1
+}'
+""",cwd = ".",description = "Assert the packaged StarRocks FE is present"}
 
 [feature.client.dependencies]
 # Provides the `mysql` CLI that speaks the FE's MySQL wire protocol on query_port.
@@ -61,8 +73,8 @@ engine-build = {cmd = "pixi run --manifest-path pixi.toml make",cwd = "../..",de
 # Engine-linked CN (default `sirius-engine` feature); needs the engine artifact and
 # the `engine` feature's toolchain/libs (in the default env).
 cn-build = {cmd = "cargo build --release -p sirius-starrocks-cn",depends-on = ["engine-build"],description = "Build the engine-linked StarRocks CN release binary"}
-cn-test = {cmd = "cargo test -p sirius-starrocks-cn",depends-on = ["engine-build"],description = "Run engine-linked StarRocks CN tests"}
-cn-run = {cmd = "cargo run -p sirius-starrocks-cn --",depends-on = ["engine-build"],description = "Run the engine-linked StarRocks CN with local FE defaults"}
+cn-test = {cmd = "cargo test -p sirius-starrocks-cn",depends-on = ["engine-build"],description = "Run engine-linked StarRocks CN tests",env = {LD_LIBRARY_PATH = "../../build/release/extension/sirius"}}
+cn-run = {cmd = "cargo run -p sirius-starrocks-cn --",depends-on = ["engine-build"],description = "Run the engine-linked StarRocks CN with local FE defaults",env = {LD_LIBRARY_PATH = "../../build/release/extension/sirius"}}
 
 # Pure-Rust path (no engine, build tree, or GPU). What CI runs.
 cn-test-no-engine = {cmd = "cargo test -p sirius-starrocks-cn --no-default-features",description = "Run Rust StarRocks CN tests without the embedded Sirius engine"}

--- a/experimental/starrocks/src/compute_node_service.rs
+++ b/experimental/starrocks/src/compute_node_service.rs
@@ -4,6 +4,9 @@ use std::sync::{Arc, Mutex};
 use crate::fragment_executor::FragmentExecutor;
 #[cfg(test)]
 use crate::fragment_executor::StubExecutor;
+use crate::local_exchange::{
+    ExchangeFile, ExchangeKey, ExchangeOutput, LocalExchange, ReadyFragment,
+};
 use crate::proto::starrocks::{
     PExecBatchPlanFragmentsRequest, PExecBatchPlanFragmentsResult, PExecPlanFragmentRequest,
     PExecPlanFragmentResult, PFetchDataRequest, PFetchDataResult, PGetFileSchemaRequest,
@@ -11,7 +14,7 @@ use crate::proto::starrocks::{
 };
 use crate::result_encoder::{self, ThriftBinary};
 use crate::result_store::{FragmentInstanceId, ResultStore};
-use starrocks_plan_translator::{PlanTranslator, TranslatedPlan};
+use starrocks_plan_translator::{ExchangeInput, PlanTranslator, TranslatedPlan};
 use starrocks_thrift::{
     data_sinks::{TDataSinkType, TResultSinkType},
     descriptors::TDescriptorTable,
@@ -41,7 +44,9 @@ pub(crate) struct SiriusComputeNodeService {
     /// Buffers executed-fragment results for FE `fetch_data` collection. Shared across BRPC
     /// connections so a `fetch_data` poll sees what an `exec_plan_fragment` buffered.
     results: Arc<ResultStore>,
-    /// Descriptor tables retained for StarRocks's per-query cache protocol.
+    /// Sequential same-node fragment exchange state, shared across BRPC connections.
+    exchanges: Arc<LocalExchange>,
+    /// StarRocks may send a descriptor table once per query and mark later fragments as cached.
     descriptor_tables: Arc<Mutex<HashMap<FragmentInstanceId, TDescriptorTable>>>,
 }
 
@@ -60,15 +65,16 @@ impl SiriusComputeNodeService {
             translator: PlanTranslator::new(),
             executor,
             results: Arc::new(ResultStore::default()),
+            exchanges: Arc::new(LocalExchange::default()),
             descriptor_tables: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
 
 impl PInternalService for SiriusComputeNodeService {
-    /// Handles a single FE-dispatched plan fragment thrift attachment: translate it, and for a
-    /// root RESULT_SINK fragment execute it and buffer the rows for `fetch_data`. An OK status
-    /// means the fragment was accepted (and, for a result fragment, executed and buffered).
+    /// Handles a single FE-dispatched plan fragment thrift attachment. A root fragment without an
+    /// exchange executes immediately; an exchange receiver waits for its local sender fragments.
+    /// The final rows are buffered for `fetch_data`.
     #[instrument(skip_all)]
     async fn exec_plan_fragment(
         &self,
@@ -196,19 +202,44 @@ impl SiriusComputeNodeService {
         self.process_fragment(&params)
     }
 
-    /// Translates one fragment and, when it is a supported RESULT_SINK root, executes it and
-    /// buffers the rows for later `fetch_data`. Shared by single and batch dispatch so both paths
-    /// produce fetchable results for a RESULT_SINK instance.
+    /// Processes one fragment and buffers supported RESULT_SINK rows for later `fetch_data`.
+    /// Shared by single and batch dispatch; exchange receivers are registered until their local
+    /// sender output is materialized.
     fn process_fragment(
         &self,
         params: &TExecPlanFragmentParams,
     ) -> std::result::Result<(), String> {
         let params = self.resolve_descriptor_table(params)?;
+        Self::dump_fragment(&params);
+        // Survey mode: accept every fragment so the FE dispatches (and we dump) the whole
+        // plan even when translation fails. Queries still fail at fetch_data.
+        if std::env::var_os("SIRIUS_CN_TRANSLATE_ONLY").is_some() {
+            if let Err(err) = self.translate_fragment_logged(&params) {
+                tracing::warn!(error = %err, "translate-only mode: accepting untranslatable fragment");
+            }
+            return Ok(());
+        }
+        let expected_senders = Self::receiver_exchanges(&params)?;
+        if !expected_senders.is_empty() {
+            let fragment_instance_id = Self::fragment_instance_id(&params)
+                .ok_or_else(|| "exchange receiver is missing a fragment_instance_id".to_string())?;
+            if Self::is_mysql_result_sink(&params)? {
+                self.results.reserve(fragment_instance_id);
+            }
+            let ready =
+                self.exchanges
+                    .register_receiver(fragment_instance_id, expected_senders, params)?;
+            if let Some(ready) = ready {
+                self.execute_ready_fragment(ready)?;
+            }
+            return Ok(());
+        }
+
         let translated = self.translate_fragment_logged(&params)?;
-        self.execute_and_buffer(&params, &translated)
+        self.execute_fragment(&params, translated)
     }
 
-    /// Restores descriptor tables omitted by StarRocks's per-query cache protocol.
+    /// Restores descriptor tables omitted by StarRocks's per-query descriptor cache protocol.
     fn resolve_descriptor_table(
         &self,
         params: &TExecPlanFragmentParams,
@@ -245,24 +276,163 @@ impl SiriusComputeNodeService {
         Ok(resolved)
     }
 
-    /// Executes a RESULT_SINK fragment and buffers its rows. Non-result-sink fragments (e.g. a
-    /// DATA_STREAM_SINK feeding another fragment) are translate-only. An unsupported result-sink
-    /// format or a missing fragment instance id fails loudly so integration gaps surface as an
-    /// error rather than as a silent empty result at `fetch_data`.
-    fn execute_and_buffer(
+    /// Writes the received fragment params to `$SIRIUS_CN_DUMP_FRAGMENTS/fragment-<seq>.txt`
+    /// (debug format) for offline plan analysis. No-op when the variable is unset.
+    fn dump_fragment(params: &TExecPlanFragmentParams) {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        let Ok(dir) = std::env::var("SIRIUS_CN_DUMP_FRAGMENTS") else {
+            return;
+        };
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+        let path = std::path::Path::new(&dir).join(format!("fragment-{seq:04}.txt"));
+        if let Err(err) = std::fs::write(&path, format!("{params:#?}")) {
+            tracing::warn!(error = %err, path = %path.display(), "failed to dump fragment params");
+        }
+    }
+
+    /// Executes a result fragment or materializes a data-stream sender for its local receiver.
+    fn execute_fragment(
         &self,
         params: &TExecPlanFragmentParams,
-        translated: &TranslatedPlan,
+        translated: TranslatedPlan,
     ) -> std::result::Result<(), String> {
-        if !Self::is_mysql_result_sink(params)? {
+        if Self::is_mysql_result_sink(params)? {
+            let id = Self::fragment_instance_id(params).ok_or_else(|| {
+                "RESULT_SINK fragment is missing a fragment_instance_id".to_string()
+            })?;
+            let result = self.executor.execute(&translated)?;
+            let batch = result_encoder::MysqlResultEncoder::encode(&result.batches, 0)?;
+            self.results.insert(id, batch);
             return Ok(());
         }
-        let id = Self::fragment_instance_id(params)
-            .ok_or_else(|| "RESULT_SINK fragment is missing a fragment_instance_id".to_string())?;
-        let result = self.executor.execute(translated)?;
-        let batch = result_encoder::MysqlResultEncoder::encode(&result.batches, 0)?;
-        self.results.insert(id, batch);
+
+        let Some(stream_sink) = params
+            .fragment
+            .as_ref()
+            .and_then(|fragment| fragment.output_sink.as_ref())
+            .filter(|sink| sink.type_ == TDataSinkType::DATA_STREAM_SINK)
+            .and_then(|sink| sink.stream_sink.as_ref())
+        else {
+            return Ok(());
+        };
+        if stream_sink.limit.is_some_and(|limit| limit >= 0) {
+            return Err("data stream sink limits are not supported".to_string());
+        }
+        if let Some(columns) = stream_sink
+            .output_columns
+            .as_ref()
+            .filter(|columns| !columns.is_empty())
+            && columns
+                .iter()
+                .copied()
+                .ne(0..translated.output_names.len() as i32)
+        {
+            return Err(
+                "non-identity data stream sink output_columns are not supported".to_string(),
+            );
+        }
+        let exec = params
+            .params
+            .as_ref()
+            .ok_or_else(|| "DATA_STREAM_SINK fragment is missing execution params".to_string())?;
+        let destinations = exec
+            .destinations
+            .as_ref()
+            .filter(|destinations| !destinations.is_empty())
+            .ok_or_else(|| "DATA_STREAM_SINK fragment has no destinations".to_string())?;
+        let sender_id = exec.sender_id.unwrap_or(0);
+        let result = self.executor.execute(&translated)?;
+        let output = ExchangeOutput {
+            names: translated.output_names,
+            result,
+        };
+        let mut ready_fragments = Vec::new();
+        for destination in destinations {
+            let ready = self.exchanges.push_sender(
+                ExchangeKey {
+                    fragment_instance_id: FragmentInstanceId::from(
+                        &destination.fragment_instance_id,
+                    ),
+                    node_id: stream_sink.dest_node_id,
+                },
+                sender_id,
+                output.clone(),
+            )?;
+            if let Some(ready) = ready {
+                ready_fragments.push(ready);
+            }
+        }
+        for ready in ready_fragments {
+            self.execute_ready_fragment(ready)?;
+        }
         Ok(())
+    }
+
+    /// Materializes all complete sender sets and executes the receiver as one single-shot plan.
+    fn execute_ready_fragment(&self, ready: ReadyFragment) -> std::result::Result<(), String> {
+        let files = ready
+            .inputs
+            .iter()
+            .map(|input| ExchangeFile::materialize(&input.outputs))
+            .collect::<Result<Vec<_>, _>>()?;
+        let exchange_inputs = ready
+            .inputs
+            .iter()
+            .zip(&files)
+            .map(|(input, file)| {
+                let path = file
+                    .path()
+                    .to_str()
+                    .ok_or_else(|| "exchange file path is not valid UTF-8".to_string())?
+                    .to_string();
+                Ok(ExchangeInput {
+                    node_id: input.node_id,
+                    paths: vec![path],
+                    names: file.names.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        let translated =
+            self.translate_fragment_logged_with_inputs(&ready.params, &exchange_inputs)?;
+        self.execute_fragment(&ready.params, translated)
+    }
+
+    /// Finds every exchange receiver in a fragment and each expected sender count.
+    fn receiver_exchanges(
+        params: &TExecPlanFragmentParams,
+    ) -> std::result::Result<Vec<(i32, usize)>, String> {
+        let exchange_nodes = params
+            .fragment
+            .as_ref()
+            .and_then(|fragment| fragment.plan.as_ref())
+            .map(|plan| {
+                plan.nodes
+                    .iter()
+                    .filter(|node| {
+                        node.node_type == starrocks_thrift::plan_nodes::TPlanNodeType::EXCHANGE_NODE
+                    })
+                    .map(|node| node.node_id)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        exchange_nodes
+            .into_iter()
+            .map(|node_id| {
+                let expected = params
+                    .params
+                    .as_ref()
+                    .and_then(|exec| exec.per_exch_num_senders.get(&node_id))
+                    .copied()
+                    .ok_or_else(|| {
+                        format!("EXCHANGE_NODE {node_id} is missing per_exch_num_senders")
+                    })?;
+                let expected = usize::try_from(expected).map_err(|_| {
+                    format!("EXCHANGE_NODE {node_id} has negative sender count {expected}")
+                })?;
+                Ok((node_id, expected))
+            })
+            .collect()
     }
 
     /// Deserializes a FE batch attachment and merges common params into each instance.
@@ -317,20 +487,44 @@ impl SiriusComputeNodeService {
         &self,
         params: &TExecPlanFragmentParams,
     ) -> std::result::Result<TranslatedPlan, String> {
+        self.translate_fragment_logged_with_inputs(params, &[])
+    }
+
+    fn translate_fragment_logged_with_inputs(
+        &self,
+        params: &TExecPlanFragmentParams,
+        exchange_inputs: &[ExchangeInput],
+    ) -> std::result::Result<TranslatedPlan, String> {
         let translated = self
             .translator
-            .translate_fragment(params)
+            .translate_fragment_with_exchange_inputs(params, exchange_inputs)
             .map_err(|err| err.to_string())?;
         info!(
             output_names = ?translated.output_names,
             plan = %translated.explain(),
             "translated StarRocks plan fragment"
         );
+        Self::dump_substrait(&translated);
         Ok(translated)
     }
 
+    /// Writes the translated Substrait plan bytes to `$SIRIUS_CN_DUMP_FRAGMENTS/plan-<seq>.substrait`
+    /// so a failing plan can be replayed against the engine in isolation. No-op when unset.
+    fn dump_substrait(translated: &TranslatedPlan) {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        let Ok(dir) = std::env::var("SIRIUS_CN_DUMP_FRAGMENTS") else {
+            return;
+        };
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+        let path = std::path::Path::new(&dir).join(format!("plan-{seq:04}.substrait"));
+        if let Err(err) = std::fs::write(&path, translated.to_substrait_bytes()) {
+            tracing::warn!(error = %err, path = %path.display(), "failed to dump substrait plan");
+        }
+    }
+
     /// Classifies the fragment output sink: `Ok(true)` for a MySQL text-protocol RESULT_SINK this
-    /// CN can encode, `Ok(false)` for a non-result sink (translate-only), and `Err` for a
+    /// CN can encode, `Ok(false)` for a non-result sink, and `Err` for a
     /// RESULT_SINK whose format is not supported yet (binary rows, HTTP/FILE/Arrow Flight, etc.).
     /// The encoder only emits MySQL text rows, so other result-sink formats must be rejected
     /// rather than returned in the wrong wire format.
@@ -463,15 +657,16 @@ impl SiriusComputeNodeService {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use prost::Message;
     use starrocks_thrift::{
         data::TResultBatch,
-        data_sinks::{TDataSink, TResultSink},
+        data_sinks::{TDataSink, TDataStreamSink, TPlanFragmentDestination, TResultSink},
         descriptors::{TDescriptorTable, TSlotDescriptor, TTableDescriptor, TTupleDescriptor},
         internal_service::{InternalServiceVersion, TPlanFragmentExecParams},
         partitions::{TDataPartition, TPartitionType},
-        plan_nodes::{TFileScanNode, TPlan, TPlanNode, TPlanNodeType},
+        plan_nodes::{TExchangeNode, TFileScanNode, TPlan, TPlanNode, TPlanNodeType},
         planner::TPlanFragment,
         types::{
             TPrimitiveType, TScalarType, TTableType, TTypeDesc, TTypeNode, TTypeNodeType, TUniqueId,
@@ -482,12 +677,25 @@ mod tests {
 
     use super::*;
     use crate::{
+        fragment_executor::{FragmentResult, StubExecutor},
         proto::starrocks::{
             PFetchDataRequest, PUniqueId,
             p_internal_service_brpc::{PInternalServiceRouter, SERVICE_NAME, methods},
         },
         prpc,
     };
+
+    #[derive(Debug, Default)]
+    struct CountingExecutor {
+        calls: AtomicUsize,
+    }
+
+    impl FragmentExecutor for CountingExecutor {
+        fn execute(&self, translated: &TranslatedPlan) -> Result<FragmentResult, String> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            StubExecutor.execute(translated)
+        }
+    }
 
     #[test]
     fn exec_plan_fragment_translates_supported_scan() {
@@ -695,6 +903,134 @@ mod tests {
     }
 
     #[test]
+    fn self_exchange_executes_sender_then_receiver_when_receiver_arrives_first() {
+        let executor = Arc::new(CountingExecutor::default());
+        let service = SiriusComputeNodeService::with_executor(executor.clone());
+        let query_id = TUniqueId::new(10, 1);
+        let receiver_id = TUniqueId::new(10, 2);
+
+        let mut receiver = fragment_params(Some(exchange_plan(7, 0)), Some(desc_table()));
+        receiver.fragment.as_mut().unwrap().output_sink = Some(result_sink());
+        let mut receiver_exec = exec_params(query_id.clone(), receiver_id.clone());
+        receiver_exec.per_exch_num_senders.insert(7, 1);
+        receiver.params = Some(receiver_exec);
+
+        let receiver_response = route(
+            &service,
+            methods::EXEC_PLAN_FRAGMENT,
+            PExecPlanFragmentRequest {
+                attachment_protocol: Some("binary".to_string()),
+            }
+            .encode_to_vec(),
+            serialize_binary(&receiver),
+        );
+        let receiver_response =
+            PExecPlanFragmentResult::decode(receiver_response.body.as_slice()).unwrap();
+        assert_eq!(receiver_response.status.status_code, TStatusCode::OK.0);
+        assert_eq!(executor.calls.load(Ordering::Relaxed), 0);
+
+        let waiting = route(
+            &service,
+            methods::FETCH_DATA,
+            fetch_request(receiver_id.hi, receiver_id.lo),
+            Vec::new(),
+        );
+        let waiting = PFetchDataResult::decode(waiting.body.as_slice()).unwrap();
+        assert_eq!(waiting.status.status_code, TStatusCode::OK.0);
+        assert_eq!(waiting.eos, Some(false));
+
+        let mut sender = fragment_params(Some(scan_plan(0, 0)), Some(desc_table()));
+        sender.fragment.as_mut().unwrap().output_sink = Some(data_stream_sink(7));
+        let mut sender_exec = exec_params(query_id, TUniqueId::new(10, 3));
+        sender_exec.sender_id = Some(0);
+        sender_exec.destinations = Some(vec![TPlanFragmentDestination::new(
+            receiver_id.clone(),
+            None,
+            None,
+            None,
+        )]);
+        sender.params = Some(sender_exec);
+
+        let sender_response = route(
+            &service,
+            methods::EXEC_PLAN_FRAGMENT,
+            PExecPlanFragmentRequest {
+                attachment_protocol: Some("binary".to_string()),
+            }
+            .encode_to_vec(),
+            serialize_binary(&sender),
+        );
+        let sender_response =
+            PExecPlanFragmentResult::decode(sender_response.body.as_slice()).unwrap();
+        assert_eq!(sender_response.status.status_code, TStatusCode::OK.0);
+        assert_eq!(executor.calls.load(Ordering::Relaxed), 2);
+
+        let fetched = route(
+            &service,
+            methods::FETCH_DATA,
+            fetch_request(receiver_id.hi, receiver_id.lo),
+            Vec::new(),
+        );
+        let fetched_result = PFetchDataResult::decode(fetched.body.as_slice()).unwrap();
+        assert_eq!(fetched_result.status.status_code, TStatusCode::OK.0);
+        assert_eq!(fetched_result.eos, Some(false));
+        assert!(!fetched.attachment.is_empty());
+    }
+
+    #[test]
+    fn self_exchange_executes_an_intermediate_receiver_and_reuses_cached_descriptors() {
+        let executor = Arc::new(CountingExecutor::default());
+        let service = SiriusComputeNodeService::with_executor(executor.clone());
+        let query_id = TUniqueId::new(20, 1);
+        let root_id = TUniqueId::new(20, 2);
+        let middle_id = TUniqueId::new(20, 3);
+
+        let mut root = fragment_params(Some(exchange_plan(9, 0)), Some(desc_table()));
+        root.fragment.as_mut().unwrap().output_sink = Some(result_sink());
+        let mut root_exec = exec_params(query_id.clone(), root_id.clone());
+        root_exec.per_exch_num_senders.insert(9, 1);
+        root.params = Some(root_exec);
+        assert_exec_ok(&service, &root);
+
+        let cached_desc = TDescriptorTable::new(None, Vec::new(), None, Some(true));
+        let mut middle = fragment_params(Some(exchange_plan(7, 0)), Some(cached_desc.clone()));
+        middle.fragment.as_mut().unwrap().output_sink = Some(data_stream_sink(9));
+        let mut middle_exec = exec_params(query_id.clone(), middle_id.clone());
+        middle_exec.per_exch_num_senders.insert(7, 1);
+        middle_exec.sender_id = Some(0);
+        middle_exec.destinations = Some(vec![TPlanFragmentDestination::new(
+            root_id.clone(),
+            None,
+            None,
+            None,
+        )]);
+        middle.params = Some(middle_exec);
+        assert_exec_ok(&service, &middle);
+
+        let mut leaf = fragment_params(Some(scan_plan(0, 0)), Some(cached_desc));
+        leaf.fragment.as_mut().unwrap().output_sink = Some(data_stream_sink(7));
+        let mut leaf_exec = exec_params(query_id, TUniqueId::new(20, 4));
+        leaf_exec.sender_id = Some(0);
+        leaf_exec.destinations = Some(vec![TPlanFragmentDestination::new(
+            middle_id, None, None, None,
+        )]);
+        leaf.params = Some(leaf_exec);
+        assert_exec_ok(&service, &leaf);
+
+        assert_eq!(executor.calls.load(Ordering::Relaxed), 3);
+        let fetched = route(
+            &service,
+            methods::FETCH_DATA,
+            fetch_request(root_id.hi, root_id.lo),
+            Vec::new(),
+        );
+        let fetched_result = PFetchDataResult::decode(fetched.body.as_slice()).unwrap();
+        assert_eq!(fetched_result.status.status_code, TStatusCode::OK.0);
+        assert_eq!(fetched_result.eos, Some(false));
+        assert!(!fetched.attachment.is_empty());
+    }
+
+    #[test]
     fn cached_descriptor_reference_reuses_query_descriptor_table() {
         let service = SiriusComputeNodeService::new();
         let query_id = TUniqueId::new(4, 2);
@@ -808,11 +1144,59 @@ mod tests {
             .unwrap()
     }
 
+    fn assert_exec_ok(service: &SiriusComputeNodeService, params: &TExecPlanFragmentParams) {
+        let response = route(
+            service,
+            methods::EXEC_PLAN_FRAGMENT,
+            PExecPlanFragmentRequest {
+                attachment_protocol: Some("binary".to_string()),
+            }
+            .encode_to_vec(),
+            serialize_binary(params),
+        );
+        let result = PExecPlanFragmentResult::decode(response.body.as_slice()).unwrap();
+        assert_eq!(
+            result.status.status_code,
+            TStatusCode::OK.0,
+            "{:?}",
+            result.status.error_msgs
+        );
+    }
+
     fn result_sink() -> TDataSink {
         // Only the sink type is read today (is_result_sink); the per-sink payloads stay None.
         TDataSink::new(
             TDataSinkType::RESULT_SINK,
             None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
+    fn data_stream_sink(dest_node_id: i32) -> TDataSink {
+        TDataSink::new(
+            TDataSinkType::DATA_STREAM_SINK,
+            Some(TDataStreamSink::new(
+                dest_node_id,
+                TDataPartition::new(TPartitionType::UNPARTITIONED, None, None, None),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )),
             None,
             None,
             None,
@@ -953,6 +1337,21 @@ mod tests {
     fn scan_plan(node_id: i32, tuple_id: i32) -> TPlan {
         // Build a single-node scan plan so coverage is focused on one-node fragments first.
         TPlan::new(vec![scan_node(node_id, tuple_id)])
+    }
+
+    fn exchange_plan(node_id: i32, tuple_id: i32) -> TPlan {
+        let mut exchange = scan_node(node_id, tuple_id);
+        exchange.node_type = TPlanNodeType::EXCHANGE_NODE;
+        exchange.file_scan_node = None;
+        exchange.exchange_node = Some(TExchangeNode::new(
+            vec![tuple_id],
+            None,
+            None,
+            Some(TPartitionType::UNPARTITIONED),
+            Some(true),
+            None,
+        ));
+        TPlan::new(vec![exchange])
     }
 
     fn serialize_binary<T>(value: &T) -> Vec<u8>

--- a/experimental/starrocks/src/engine.rs
+++ b/experimental/starrocks/src/engine.rs
@@ -3,21 +3,22 @@
 //! [`sirius::SiriusContext`] is `!Send`/`!Sync` and the engine serializes queries through a single
 //! process-global context, so the context is created, used, and dropped on one dedicated thread.
 //! [`SiriusEngine`] talks to that thread over channels — which are `Send`/`Sync` and carry only
-//! owned data (`Vec<u8>` in, `Vec<RecordBatch>` out) — so it satisfies `dyn FragmentExecutor:
+//! owned data (`Vec<u8>` in, `FragmentResult` out) — so it satisfies `dyn FragmentExecutor:
 //! Send + Sync` without ever moving the context across threads.
 //!
 //! The seam is synchronous (see [`FragmentExecutor`]): `execute()` blocks the caller until the
 //! engine thread returns the result. `exec_plan_fragment` runs it on a `spawn_blocking` worker, so
 //! the BRPC current-thread runtime stays free to serve `fetch_data`, connection cleanup, and
-//! shutdown cancellation while a query runs. The single-fragment limitations are elsewhere: the
-//! whole result is materialized before dispatch returns, and the single process-global context
-//! serializes queries — both lifted by the streaming evolution.
+//! shutdown cancellation while a query runs. Each fragment result is fully materialized, and the
+//! single process-global context serializes fragment execution — both lifted by the streaming
+//! evolution.
 
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::thread::JoinHandle;
 
+#[cfg(test)]
 use arrow_array::RecordBatch;
 use sirius::SiriusContext;
 use starrocks_plan_translator::TranslatedPlan;
@@ -30,7 +31,7 @@ struct ExecuteRequest {
     /// Serialized Substrait plan bytes.
     plan: Vec<u8>,
     /// Channel the engine thread sends the result (or a flattened error) back on.
-    respond: Sender<Result<Vec<RecordBatch>, String>>,
+    respond: Sender<Result<FragmentResult, String>>,
 }
 
 /// GPU-backed [`FragmentExecutor`] running plans on an embedded Sirius engine.
@@ -54,6 +55,7 @@ impl SiriusEngine {
     /// failure surfaces here, before any RPC is served. `config` is the optional Sirius YAML path
     /// (built-in defaults when `None`).
     pub fn start(config: Option<PathBuf>) -> Result<Self, String> {
+        Self::configure_duckdb_extensions()?;
         let (request_tx, request_rx) = channel::<ExecuteRequest>();
         let (ready_tx, ready_rx) = channel::<Result<(), String>>();
         let thread = std::thread::Builder::new()
@@ -69,6 +71,42 @@ impl SiriusEngine {
             Err(_) => Err("sirius-engine thread exited during bring-up".to_string()),
         }
     }
+
+    /// Points the embedded DuckDB context at the locally built extensions used by Substrait.
+    fn configure_duckdb_extensions() -> Result<(), String> {
+        let build_dir = std::env::var_os("SIRIUS_BUILD_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("../..")
+                    .join("build/release")
+            });
+        let extensions = [
+            (
+                "SIRIUS_DUCKDB_PARQUET_EXTENSION",
+                build_dir.join("extension/parquet/parquet.duckdb_extension"),
+            ),
+            (
+                "SIRIUS_DUCKDB_CORE_FUNCTIONS_EXTENSION",
+                build_dir.join("extension/core_functions/core_functions.duckdb_extension"),
+            ),
+        ];
+        for (variable, path) in extensions {
+            if std::env::var_os(variable).is_some() {
+                continue;
+            }
+            if !path.is_file() {
+                return Err(format!(
+                    "DuckDB extension for {variable} is missing at {}",
+                    path.display()
+                ));
+            }
+            // SAFETY: this runs before the engine thread and RPC servers start, so no concurrent
+            // code reads or writes these process environment variables.
+            unsafe { std::env::set_var(variable, &path) };
+        }
+        Ok(())
+    }
 }
 
 /// Engine-thread body: bring up the context, signal readiness, then serve requests until the
@@ -78,7 +116,7 @@ fn engine_thread(
     requests: Receiver<ExecuteRequest>,
     ready: Sender<Result<(), String>>,
 ) {
-    let mut context = match build_context(config) {
+    let context = match build_context(config) {
         Ok(context) => {
             // A send error means the caller is already gone; nothing to serve.
             if ready.send(Ok(())).is_err() {
@@ -99,7 +137,8 @@ fn engine_thread(
         // own Arrow C release callbacks — independent of the context. So the batches are safe to
         // send to, and drop on, the caller's thread.
         let result = context
-            .execute_substrait(&request.plan)
+            .execute_substrait_result(&request.plan)
+            .map(|result| FragmentResult::with_schema(result.schema, result.batches))
             .map_err(|err| err.to_string());
         // Ignore a send error: the waiting fragment may have been dropped/cancelled.
         let _ = request.respond.send(result);
@@ -132,10 +171,9 @@ impl FragmentExecutor for SiriusEngine {
             .ok_or_else(|| "sirius-engine is shutting down".to_string())?
             .send(request)
             .map_err(|_| "sirius-engine thread is not running".to_string())?;
-        let batches = respond_rx
+        respond_rx
             .recv()
-            .map_err(|_| "sirius-engine thread dropped the response".to_string())??;
-        Ok(FragmentResult::new(batches))
+            .map_err(|_| "sirius-engine thread dropped the response".to_string())?
     }
 }
 
@@ -168,6 +206,7 @@ mod tests {
     use parquet::arrow::ArrowWriter;
 
     use super::*;
+    use crate::local_exchange::{ExchangeFile, ExchangeOutput};
 
     /// Builds a single-file `local_files` parquet read plan with `names` as the root output
     /// names — the shape DuckDB's Substrait reader resolves to `parquet_scan(<path>)`.
@@ -275,12 +314,44 @@ mod tests {
         }
     }
 
+    /// Replays a Substrait plan dumped via `SIRIUS_CN_DUMP_FRAGMENTS` (path in
+    /// `SIRIUS_SUBSTRAIT_PLAN`) against the engine — a debug harness for diagnosing a captured
+    /// plan in isolation, outside the FE/CN loop.
+    #[test]
+    #[ignore = "debug harness: set SIRIUS_SUBSTRAIT_PLAN to a dumped plan and run with a GPU"]
+    fn engine_replays_dumped_substrait_plan() {
+        let path = std::env::var("SIRIUS_SUBSTRAIT_PLAN").expect("SIRIUS_SUBSTRAIT_PLAN not set");
+        let plan = std::fs::read(&path).expect("read dumped substrait plan");
+        let engine = SiriusEngine::start(None).expect("bring up sirius engine");
+        let (respond_tx, respond_rx) = channel();
+        engine
+            .requests
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .send(ExecuteRequest {
+                plan,
+                respond: respond_tx,
+            })
+            .unwrap();
+        let result = respond_rx
+            .recv()
+            .expect("engine response")
+            .expect("execute");
+        let rows: usize = result.batches.iter().map(RecordBatch::num_rows).sum();
+        eprintln!("plan {path} returned {rows} row(s)");
+        for batch in &result.batches {
+            eprintln!("{batch:?}");
+        }
+    }
+
     /// End-to-end: drive a `local_files` parquet plan through the engine actor and read the rows
     /// back. Exercises the dedicated-thread bring-up, the channel round-trip, and GPU execution.
     /// Requires a GPU and `LD_LIBRARY_PATH` to the built engine (like the `sirius` crate's context
     /// test); the parquet extension path is set from `SIRIUS_BUILD_DIR` (default mirrors sirius-sys).
     #[test]
-    fn engine_executes_local_files_plan() {
+    fn engine_executes_local_files_and_sequential_exchange() {
         // Point the embedded DuckDB at the locally-built parquet extension so it can bind
         // `parquet_scan`. This is the only context-constructing test in the crate, so no other
         // thread reads the environment concurrently.
@@ -318,6 +389,28 @@ mod tests {
         let result = engine.execute(&plan).expect("execute fragment on GPU");
         let total_rows: usize = result.batches.iter().map(RecordBatch::num_rows).sum();
         assert_eq!(total_rows, 3, "expected 3 rows from the parquet fixture");
+
+        // Run the same rows through the sequential exchange path: fragment one completed above,
+        // its Arrow result is materialized, and fragment two reads that file in a new single-shot
+        // GPU execution.
+        let exchange = ExchangeFile::materialize(&[ExchangeOutput {
+            names: plan.output_names.clone(),
+            result,
+        }])
+        .expect("materialize local exchange");
+        let exchanged = local_files_plan_with_base_schema(
+            exchange.path().to_str().unwrap(),
+            &[("id", false), ("name", true)],
+        );
+        let exchanged_result = engine
+            .execute(&exchanged)
+            .expect("execute exchange receiver on GPU");
+        let exchanged_rows: usize = exchanged_result
+            .batches
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum();
+        assert_eq!(exchanged_rows, 3, "exchange preserved all fragment rows");
 
         // A `base_schema` that prunes and reorders the file's columns must bind by name, not by
         // file position (exercises the Substrait reader's `local_files` projection). The fixture

--- a/experimental/starrocks/src/fragment_executor.rs
+++ b/experimental/starrocks/src/fragment_executor.rs
@@ -7,12 +7,14 @@
 use std::sync::Arc;
 
 use arrow_array::{ArrayRef, RecordBatch, StringArray};
-use arrow_schema::{DataType, Field, Schema};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use starrocks_plan_translator::TranslatedPlan;
 
 /// Output of executing one plan fragment: Arrow batches matching the fragment output schema.
 #[derive(Clone, Debug)]
 pub struct FragmentResult {
+    /// Output schema, retained even when execution produces no batches.
+    pub(crate) schema: SchemaRef,
     /// Result batches in fragment output order. Empty for a fragment with no output columns.
     pub(crate) batches: Vec<RecordBatch>,
 }
@@ -20,7 +22,16 @@ pub struct FragmentResult {
 impl FragmentResult {
     /// Builds a result from its output batches (in fragment output order).
     pub fn new(batches: Vec<RecordBatch>) -> Self {
-        Self { batches }
+        let schema = batches
+            .first()
+            .map(RecordBatch::schema)
+            .unwrap_or_else(|| Arc::new(Schema::empty()));
+        Self { schema, batches }
+    }
+
+    /// Builds a result with an explicit schema, including for empty results.
+    pub fn with_schema(schema: SchemaRef, batches: Vec<RecordBatch>) -> Self {
+        Self { schema, batches }
     }
 
     /// The result batches in fragment output order.
@@ -31,9 +42,9 @@ impl FragmentResult {
 
 /// Runs a translated fragment and returns its result batches.
 ///
-/// This is intentionally a synchronous, fully-materializing seam for the single-fragment
-/// milestone: `exec_plan_fragment` runs it to completion before returning, and `fetch_data` then
-/// drains the buffered rows.
+/// This is intentionally a synchronous, fully-materializing seam for single-shot execution.
+/// Each fragment runs to completion, and a local exchange can sequence one fragment's output into
+/// the next before `fetch_data` drains the final buffered rows.
 ///
 /// TODO(starrocks-execute): a real GPU executor should not block dispatch on full materialization.
 /// Evolve this into a streaming contract — dispatch registers a running fragment and returns after
@@ -59,6 +70,7 @@ impl FragmentExecutor for StubExecutor {
         let names = &translated.output_names;
         if names.is_empty() {
             return Ok(FragmentResult {
+                schema: Arc::new(Schema::empty()),
                 batches: Vec::new(),
             });
         }
@@ -73,6 +85,7 @@ impl FragmentExecutor for StubExecutor {
         let batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
             .map_err(|err| format!("failed to build stub result batch: {err}"))?;
         Ok(FragmentResult {
+            schema: batch.schema(),
             batches: vec![batch],
         })
     }

--- a/experimental/starrocks/src/lib.rs
+++ b/experimental/starrocks/src/lib.rs
@@ -50,6 +50,7 @@ mod compute_node_service;
 mod engine;
 mod file_schema;
 mod fragment_executor;
+mod local_exchange;
 mod proto;
 mod prpc;
 mod result_encoder;

--- a/experimental/starrocks/src/local_exchange.rs
+++ b/experimental/starrocks/src/local_exchange.rs
@@ -1,0 +1,274 @@
+//! Sequential same-node exchange for the single-shot Sirius API.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use arrow_array::RecordBatch;
+use arrow_schema::Schema;
+use parquet::arrow::ArrowWriter;
+use starrocks_thrift::internal_service::TExecPlanFragmentParams;
+
+use crate::fragment_executor::FragmentResult;
+use crate::result_store::FragmentInstanceId;
+
+/// Receiver identity used by both the stream sink and exchange node.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct ExchangeKey {
+    pub(crate) fragment_instance_id: FragmentInstanceId,
+    pub(crate) node_id: i32,
+}
+
+/// One fully materialized sender result awaiting its receiver fragment.
+#[derive(Clone, Debug)]
+pub(crate) struct ExchangeOutput {
+    pub(crate) names: Vec<String>,
+    pub(crate) result: FragmentResult,
+}
+
+/// One complete materialized input of a receiver fragment.
+#[derive(Debug)]
+pub(crate) struct ReadyExchangeInput {
+    pub(crate) node_id: i32,
+    pub(crate) outputs: Vec<ExchangeOutput>,
+}
+
+/// A receiver fragment whose exchange inputs are all ready for sequential execution.
+#[derive(Debug)]
+pub(crate) struct ReadyFragment {
+    pub(crate) params: TExecPlanFragmentParams,
+    pub(crate) inputs: Vec<ReadyExchangeInput>,
+}
+
+#[derive(Debug)]
+struct PendingReceiver {
+    params: TExecPlanFragmentParams,
+    expected_senders: HashMap<i32, usize>,
+}
+
+#[derive(Debug, Default)]
+struct ExchangeState {
+    receivers: HashMap<FragmentInstanceId, PendingReceiver>,
+    outputs: HashMap<ExchangeKey, HashMap<i32, ExchangeOutput>>,
+}
+
+/// Matches receiver-first StarRocks dispatch with later same-node sender results.
+#[derive(Debug, Default)]
+pub(crate) struct LocalExchange {
+    inner: Mutex<ExchangeState>,
+}
+
+impl LocalExchange {
+    /// Registers a receiver fragment, returning it when every exchange input is complete.
+    pub(crate) fn register_receiver(
+        &self,
+        fragment_instance_id: FragmentInstanceId,
+        expected_senders: Vec<(i32, usize)>,
+        params: TExecPlanFragmentParams,
+    ) -> Result<Option<ReadyFragment>, String> {
+        if expected_senders.is_empty() {
+            return Err("receiver fragment has no exchange inputs".to_string());
+        }
+        let mut expected_by_node = HashMap::with_capacity(expected_senders.len());
+        for (node_id, expected) in expected_senders {
+            if expected == 0 {
+                return Err(format!("exchange node {node_id} expects no senders"));
+            }
+            if expected_by_node.insert(node_id, expected).is_some() {
+                return Err(format!(
+                    "duplicate exchange node {node_id} in receiver fragment"
+                ));
+            }
+        }
+        let mut state = self.lock();
+        if state.receivers.contains_key(&fragment_instance_id) {
+            return Err(format!(
+                "duplicate receiver registration for fragment {fragment_instance_id}"
+            ));
+        }
+        state.receivers.insert(
+            fragment_instance_id,
+            PendingReceiver {
+                params,
+                expected_senders: expected_by_node,
+            },
+        );
+        Self::take_ready(&mut state, fragment_instance_id)
+    }
+
+    /// Buffers one sender output, returning the receiver when this completes its sender set.
+    pub(crate) fn push_sender(
+        &self,
+        key: ExchangeKey,
+        sender_id: i32,
+        output: ExchangeOutput,
+    ) -> Result<Option<ReadyFragment>, String> {
+        let mut state = self.lock();
+        let senders = state.outputs.entry(key).or_default();
+        if senders.contains_key(&sender_id) {
+            return Err(format!("duplicate sender {sender_id} for exchange {key:?}"));
+        }
+        senders.insert(sender_id, output);
+        Self::take_ready(&mut state, key.fragment_instance_id)
+    }
+
+    fn take_ready(
+        state: &mut ExchangeState,
+        fragment_instance_id: FragmentInstanceId,
+    ) -> Result<Option<ReadyFragment>, String> {
+        let Some(receiver) = state.receivers.get(&fragment_instance_id) else {
+            return Ok(None);
+        };
+        for (&node_id, &expected) in &receiver.expected_senders {
+            let key = ExchangeKey {
+                fragment_instance_id,
+                node_id,
+            };
+            let actual = state.outputs.get(&key).map(HashMap::len).unwrap_or(0);
+            if actual > expected {
+                return Err(format!(
+                    "exchange {key:?} received {actual} senders but expected {expected}"
+                ));
+            }
+            if actual != expected {
+                return Ok(None);
+            }
+        }
+
+        let receiver = state
+            .receivers
+            .remove(&fragment_instance_id)
+            .expect("receiver checked above");
+        let mut node_ids = receiver.expected_senders.into_keys().collect::<Vec<_>>();
+        node_ids.sort_unstable();
+        let inputs = node_ids
+            .into_iter()
+            .map(|node_id| {
+                let key = ExchangeKey {
+                    fragment_instance_id,
+                    node_id,
+                };
+                let mut senders = state.outputs.remove(&key).unwrap_or_default();
+                let mut sender_ids = senders.keys().copied().collect::<Vec<_>>();
+                sender_ids.sort_unstable();
+                let outputs = sender_ids
+                    .into_iter()
+                    .map(|sender_id| senders.remove(&sender_id).expect("sender id came from map"))
+                    .collect();
+                ReadyExchangeInput { node_id, outputs }
+            })
+            .collect();
+        Ok(Some(ReadyFragment {
+            params: receiver.params,
+            inputs,
+        }))
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, ExchangeState> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+/// Temporary parquet file used as the receiver's `local_files` exchange input.
+#[derive(Debug)]
+pub(crate) struct ExchangeFile {
+    path: PathBuf,
+    pub(crate) names: Vec<String>,
+}
+
+impl ExchangeFile {
+    /// Writes every sender batch to one parquet file in deterministic sender order.
+    pub(crate) fn materialize(outputs: &[ExchangeOutput]) -> Result<Self, String> {
+        let first = outputs
+            .first()
+            .ok_or_else(|| "cannot materialize an exchange without sender outputs".to_string())?;
+        let sender_schema = first.result.schema.clone();
+        let names = first.names.clone();
+        if sender_schema.fields().len() != names.len() {
+            return Err(format!(
+                "exchange sender produced {} schema fields but {} output names",
+                sender_schema.fields().len(),
+                names.len()
+            ));
+        }
+        for output in outputs {
+            if output.names != names {
+                return Err("exchange senders produced different output names".to_string());
+            }
+            if output.result.schema != sender_schema {
+                return Err("exchange senders produced different Arrow schemas".to_string());
+            }
+        }
+
+        // Root output names are the parquet column names consumed by the receiver's base schema.
+        // Re-label batches without copying their arrays in case the Arrow exporter chose different
+        // field names from the Substrait root.
+        let fields = sender_schema
+            .fields()
+            .iter()
+            .zip(&names)
+            .map(|(field, name)| field.as_ref().clone().with_name(name))
+            .collect::<Vec<_>>();
+        let schema = std::sync::Arc::new(Schema::new_with_metadata(
+            fields,
+            sender_schema.metadata().clone(),
+        ));
+
+        let exchange_file = Self {
+            path: Self::next_path()?,
+            names,
+        };
+        let file = std::fs::File::create(&exchange_file.path).map_err(|err| {
+            format!(
+                "failed to create exchange file {}: {err}",
+                exchange_file.path.display()
+            )
+        })?;
+        let mut writer = ArrowWriter::try_new(file, schema.clone(), None)
+            .map_err(|err| format!("failed to create exchange parquet writer: {err}"))?;
+        for output in outputs {
+            for batch in &output.result.batches {
+                let batch = RecordBatch::try_new(schema.clone(), batch.columns().to_vec())
+                    .map_err(|err| format!("failed to name exchange batch columns: {err}"))?;
+                writer
+                    .write(&batch)
+                    .map_err(|err| format!("failed to write exchange batch: {err}"))?;
+            }
+        }
+        writer
+            .close()
+            .map_err(|err| format!("failed to finish exchange parquet file: {err}"))?;
+        Ok(exchange_file)
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn next_path() -> Result<PathBuf, String> {
+        static NEXT_FILE: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join("sirius-starrocks-cn");
+        std::fs::create_dir_all(&dir).map_err(|err| {
+            format!(
+                "failed to create exchange directory {}: {err}",
+                dir.display()
+            )
+        })?;
+        let sequence = NEXT_FILE.fetch_add(1, Ordering::Relaxed);
+        Ok(dir.join(format!(
+            "exchange-{}-{sequence}.parquet",
+            std::process::id()
+        )))
+    }
+}
+
+impl Drop for ExchangeFile {
+    fn drop(&mut self) {
+        if let Err(err) = std::fs::remove_file(&self.path) {
+            tracing::warn!(path = %self.path.display(), error = %err, "failed to remove exchange file");
+        }
+    }
+}

--- a/experimental/starrocks/src/result_store.rs
+++ b/experimental/starrocks/src/result_store.rs
@@ -50,6 +50,8 @@ impl fmt::Display for FragmentInstanceId {
 /// One buffered fragment result and where the FE `fetch_data` poll is in draining it.
 #[derive(Debug)]
 enum FragmentState {
+    /// Result fragment accepted but waiting for its exchange input.
+    Waiting,
     /// Rows produced, not yet delivered.
     Pending(TResultBatch),
     /// Rows delivered; the next poll reports end-of-stream.
@@ -78,6 +80,11 @@ pub(crate) struct ResultStore {
 }
 
 impl ResultStore {
+    /// Marks an accepted result fragment whose execution is waiting on an exchange sender.
+    pub(crate) fn reserve(&self, id: FragmentInstanceId) {
+        self.lock().entry(id).or_insert(FragmentState::Waiting);
+    }
+
     /// Buffers an executed fragment's result for later `fetch_data` collection.
     pub(crate) fn insert(&self, id: FragmentInstanceId, batch: TResultBatch) {
         self.lock().insert(id, FragmentState::Pending(batch));
@@ -97,6 +104,11 @@ impl ResultStore {
         let mut guard = self.lock();
         match guard.get_mut(&id) {
             None => None,
+            Some(FragmentState::Waiting) => Some(FetchOutcome {
+                batch: None,
+                packet_seq: 0,
+                eos: false,
+            }),
             Some(state @ FragmentState::Pending(_)) => {
                 let FragmentState::Pending(batch) =
                     std::mem::replace(state, FragmentState::Drained)
@@ -165,5 +177,21 @@ mod tests {
                 .take_next(FragmentInstanceId::from_halves(9, 9))
                 .is_none()
         );
+    }
+
+    #[test]
+    fn reserved_fragment_reports_not_ready_until_rows_arrive() {
+        let store = ResultStore::default();
+        let id = FragmentInstanceId::from_halves(4, 2);
+        store.reserve(id);
+
+        let waiting = store.take_next(id).expect("reserved fragment is known");
+        assert!(!waiting.eos);
+        assert!(waiting.batch.is_none());
+
+        store.insert(id, batch(&["ready"]));
+        let ready = store.take_next(id).expect("completed fragment is known");
+        assert!(!ready.eos);
+        assert_eq!(ready.batch.unwrap().rows.len(), 1);
     }
 }


### PR DESCRIPTION
Ports integration commit `0cda6e2c`; no GitHub issue yet. Part 9 of a twelve-PR stack.

**What.** Until now the compute node executed one shape: a root RESULT_SINK fragment, everything else
translate-only. This makes it execute a plan the FE has *split* — a scan+filter sender feeding an
aggregate receiver over a gather exchange, or a three-fragment chain, all on one node. The translator
grows the nodes a split plan is made of (EXCHANGE, one-phase AGGREGATION, SORT, HASH_JOIN, NESTLOOP);
the service grows the coordination to run them in dependency order.

**Design: execute on readiness, not on arrival.** A fragment arrives when the FE dispatches it, but
its input exists only after a sibling has run — and StarRocks dispatches receivers first. So
`LocalExchange` is the single place readiness is decided.

- **`register_receiver` and `push_sender` both return `Option<ReadyFragment>` from inside the same
  lock.** Splitting "record the arrival" from "check readiness" would let a sender land between them
  and strand the receiver — a fragment that never runs and a `fetch_data` loop that polls forever.
- **An unexpected sender is a wiring bug, not something to count.** Duplicate ids are rejected and
  surplus arrivals error; a counter would fire the rendezvous early, or count a retransmit as a second
  sender and return doubled rows as a quiet success. Identity comes from the plan
  (`per_exch_num_senders`, `exec.sender_id`, `exec.destinations`), never inferred.
- **The rendezvous decides *when*; a parquet file carries *what*.** `ExchangeFile` writes each
  sender's materialized Arrow to a temp file and `translate_exchange` swaps the receiver's
  EXCHANGE_NODE for a `local_files` scan of it — forced by the model this commit inherits, where the
  engine runs one complete plan per fragment and data can only re-enter as a table. **Temporary:**
  part 10 crosses natively and deletes `ExchangeFile`.
- **`FragmentResult` carries its schema even with no batches**, or an empty sender's file fails to
  bind on the one input shape (zero rows) most likely to escape testing.

`ResultStore::reserve` and the `FragmentState::Waiting` behind it are what make receiver-first
dispatch survive the FE's polling: without them the first `fetch_data` poll hits `no buffered result
for fragment instance <id>` with `eos = true` and the query fails before any sender executes.

**Reading order.**
1. `src/local_exchange.rs` — the design note: receiver-first rendezvous, readiness under one lock.
2. `src/compute_node_service.rs` — `process_fragment` classifies each arrival,
   `execute_ready_fragment` closes the loop; plus the `SIRIUS_CN_*` debug hooks.
3. `src/result_store.rs` — `reserve` and the `Waiting` state; 28 lines.
4. `crates/starrocks-plan-translator/src/node_translator.rs` — the module comment's node table is the
   translation contract; `translate_exchange` is where the boundary becomes a scan. Supporting
   translation lives in `expr_translator.rs`, `descriptor_table.rs`, `scan_paths.rs`, `type_mapper.rs`.
5. `src/engine.rs`, `pixi.toml`, `DEMO.md` — the schema on `FragmentResult`, extension paths resolved
   at `start()`, `cluster` now depending on `fe-check`, and what the demo cluster does and does not
   prove.
6. Tests: the translator suite (pure Rust, what CI runs) covers each node and its rejection paths; the
   service tests drive the real BRPC router with a counting executor — receiver-first executes nothing
   until its sender arrives, a poll in the gap reports not-ready, a three-fragment chain runs each
   exactly once; `engine.rs` runs a materialized hop through the real engine (needs a GPU).
   `LocalExchange`'s direct rendezvous cases land in part 11.

### Stack: part 9 of 12
- **Base:** `stream/08-ffi-fragment` (#1396)
- **Depends on:** part 8 (#1396) for the FFI shape, part 7 (#1395) for the function catalog its aggregates bind
  through
