### PR TITLE
feat(starrocks): cross the fragment boundary as native batches

### DIFF
--- a/experimental/starrocks/DEMO.md
+++ b/experimental/starrocks/DEMO.md
@@ -7,32 +7,42 @@ This branch is `dev` plus the repository-backed streaming work
 ([`docs/super-sirius/streaming-sessions.md`](../../docs/super-sirius/streaming-sessions.md))
 plus this multi-fragment compute node.
 
-## What this does and does not exercise
+## What this exercises
 
-The compute node coordinates fragments the way it does today: `LocalExchange` is a
-receiver-first rendezvous that buffers each sender's **fully materialized** Arrow result and
-writes it to a temporary parquet file the receiver re-scans as a `local_files` scan.
+**A fragment's output crosses the exchange boundary as native `cucascade::data_batch` handles.**
+It is never converted to Arrow, never written to a file, and never copied: the sender's rows stay
+in GPU memory, parked in the engine's output repository, and the receiver's `STREAMING_SOURCE`
+takes them from there. Each mechanism the earlier compute node used to relay data has been
+replaced by the streaming primitive it was staged for:
 
-The streaming primitives in this branch — `STREAMING_SOURCE`, `STREAMING_SINK`,
-`exec::streaming_fragment`, `exec::stream_session` — are **built into the engine and unit-tested,
-but not yet wired into this compute node**. The cxx-FFI boundary that reaches them
-(`sirius::ffi::Fragment`) landed in the previous part of this stack; wiring the compute node onto
-it is the next part, and it is a seam swap rather than a rewrite: each primitive replaces exactly
-one mechanism here.
-
-| Compute-node mechanism today | Streaming replacement |
+| Was | Is |
 |---|---|
-| `ExchangeFile` temp parquet + `local_files` re-scan | `push(stream_id, batch)` → source repository, native |
-| `ExchangeOutput` (the whole result) | incremental native `data_batch` push |
-| `LocalExchange` rendezvous (expected sender **count**) | the streaming source's expected sender **set** + the `stream_session` registry |
-| `ExchangeKey{fragment_instance_id, node_id}` | the direction-separated input `stream_id` |
-| `per_exch_num_senders` + `exec.sender_id` | the source's expected sender set |
-| `exec.destinations` | one sink partition per destination + the wrapper's routing table |
-| `FragmentExecutor::execute → FragmentResult` (sync) | build session + submit; `push`/`pull` over cxx-FFI |
-| `ResultStore` + `fetch_data` | root `STREAMING_SINK` + `pull`/`wait`/`drained` |
+| `ExchangeFile` temp parquet + `local_files` re-scan | `Fragment::relay_from` — a pointer move between two live fragments |
+| `ExchangeOutput` (a whole materialized Arrow result) | native `data_batch` handles, parked on the GPU |
+| The receiver's `EXCHANGE_NODE` lowered to a file read | lowered to a read of `sirius_stream_<node_id>` |
+| `FragmentExecutor::execute → FragmentResult` per fragment | `FragmentExecutor::run`; only a *result* fragment produces Arrow |
+| `LocalExchange` buffering sender data | `LocalExchange` tracking only *which* senders have produced |
 
-So: this demo proves the cluster runs the query correctly on the engine that carries the new
-primitives. It does not yet prove the query flows *through* them.
+`ExchangeFile` is deleted, which is what makes a correct answer evidence rather than coincidence:
+with the temp-parquet path physically gone, the rows can only have crossed as native batches.
+`grep -r ExchangeFile experimental/` finds nothing but this file, and no file appears under
+`$TMPDIR/sirius-starrocks-cn` during a run.
+
+The CN logs each boundary it crosses:
+
+```
+INFO sirius_starrocks_cn::engine: relayed native batches across a fragment boundary
+     stream_id=2 sender_id=0 batches=1
+```
+
+### What it does not exercise yet
+
+- **One destination per sender.** A gather exchange only. Fan-out needs the partitioned sink
+  (#838); a sender with several destinations is refused rather than silently under-delivering.
+- **Sequential fragments.** The engine serializes queries, so a sender runs to completion before
+  its receiver starts. Concurrency needs per-query lifecycle isolation.
+- **A pre-filled stream.** Senders finish before the receiver is built, so the live producer path
+  — a push arriving while the receiver runs — is still untested here.
 
 ## Running it
 
@@ -75,7 +85,25 @@ WHERE l_shipdate >= date '1997-01-01'
   AND l_quantity < 24;
 ```
 
-Point `path` at whatever TPC-H `lineitem` parquet you have.
+Point `path` at whatever TPC-H `lineitem` parquet you have. On TPC-H SF1 that query returns
+
+```
+revenue
+61567694.95019999
+```
+
+which matches DuckDB on CPU over the same file (`61567694.9502`).
+
+A `GROUP BY` is worth running too — it plans two exchanges rather than one, so the CN logs two
+boundary crossings for a single query:
+
+```sql
+WITH lineitem AS (SELECT * FROM FILES(
+  "path"="file:///home/ubuntu/git/sirius/scratch/tpch_sf1/lineitem/part.0.parquet",
+  "format"="parquet"))
+SELECT l_returnflag, count(*) AS n, sum(l_quantity) AS qty
+FROM lineitem GROUP BY l_returnflag ORDER BY l_returnflag;
+```
 
 ## The pre-packaged front end
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -122,17 +122,40 @@ pub struct TranslatedPlan {
     pub plan: Plan,
     /// Root output names as emitted in the Substrait plan.
     pub output_names: Vec<String>,
+    /// One entry per exchange node lowered to a stream read. The caller declares these on the
+    /// engine before handing it the plan — a stream has no file to infer a schema from.
+    pub stream_inputs: Vec<StreamInputSchema>,
 }
 
-/// A fully materialized same-node input for one StarRocks exchange node.
+/// A same-node input stream bound to one StarRocks exchange node.
 #[derive(Clone, Debug)]
 pub struct ExchangeInput {
     /// Receiver `EXCHANGE_NODE` id.
     pub node_id: i32,
-    /// Local parquet files containing the sender fragment output.
-    pub paths: Vec<String>,
-    /// Sender output names as written to those parquet files.
+    /// Name of the engine view this exchange's input stream is read through.
+    pub stream_view: String,
+    /// Sender output names, which become the stream's column names.
     pub names: Vec<String>,
+}
+
+/// The schema one exchange's input stream must be declared with, as the plan reads it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StreamInputSchema {
+    /// Receiver `EXCHANGE_NODE` id, which is also the engine-side stream id.
+    pub node_id: i32,
+    /// Name of the engine view the plan reads this stream through.
+    pub stream_view: String,
+    /// Columns in plan order.
+    pub columns: Vec<StreamInputColumn>,
+}
+
+/// One column of a declared input stream.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StreamInputColumn {
+    /// Column name, matching the read's base schema.
+    pub name: String,
+    /// DuckDB type name the engine parses when declaring the stream.
+    pub ty: String,
 }
 
 impl TranslatedPlan {
@@ -241,7 +264,7 @@ impl PlanTranslator {
             .map(|input| (input.node_id, input))
             .collect::<HashMap<_, _>>();
         let mut registry = ExtensionRegistry::new();
-        let mut translated = node_translator::translate_plan(
+        let (mut translated, stream_inputs) = node_translator::translate_plan(
             plan,
             &desc,
             &scan_paths,
@@ -291,6 +314,7 @@ impl PlanTranslator {
         Ok(TranslatedPlan {
             plan: substrait_plan,
             output_names,
+            stream_inputs,
         })
     }
 }

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -17,7 +17,8 @@ use crate::error::{Result, TranslateError};
 use crate::expr_translator::{self, ExprContext, TranslateExpr};
 use crate::scan_paths::ScanFilePaths;
 use crate::{
-    ExchangeInput, ExtensionRegistry, URN_AGGREGATE, URN_ARITHMETIC, URN_BOOLEAN, URN_COMPARISON,
+    ExchangeInput, ExtensionRegistry, StreamInputColumn, StreamInputSchema, URN_AGGREGATE,
+    URN_ARITHMETIC, URN_BOOLEAN, URN_COMPARISON,
 };
 
 /// Partially translated relation plus the StarRocks row layout it emits.
@@ -49,10 +50,13 @@ struct PlanContext<'a> {
     /// scan ranges. Scans with paths emit a `local_files` read; path-less scans
     /// fall back to a named-table read.
     scan_paths: &'a ScanFilePaths,
-    /// Materialized same-node inputs keyed by receiver exchange node id.
+    /// Same-node input streams keyed by receiver exchange node id.
     exchange_inputs: &'a std::collections::HashMap<i32, &'a ExchangeInput>,
     /// Substrait extension registry shared across the whole plan.
     registry: &'a mut ExtensionRegistry,
+    /// Schema of every exchange lowered to a stream read, in translation order. The caller has to
+    /// declare these on the engine before the plan can bind.
+    stream_inputs: Vec<StreamInputSchema>,
 }
 
 impl<'a> PlanContext<'a> {
@@ -68,6 +72,7 @@ impl<'a> PlanContext<'a> {
             scan_paths,
             exchange_inputs,
             registry,
+            stream_inputs: Vec::new(),
         }
     }
 
@@ -317,12 +322,19 @@ pub(crate) fn translate_plan(
     scan_paths: &ScanFilePaths,
     exchange_inputs: &std::collections::HashMap<i32, &ExchangeInput>,
     registry: &mut ExtensionRegistry,
-) -> Result<TranslatedRel> {
+) -> Result<(TranslatedRel, Vec<StreamInputSchema>)> {
     let mut ctx = PlanContext::new(desc, scan_paths, exchange_inputs, registry);
-    plan.translate(&mut ctx)
+    let translated = plan.translate(&mut ctx)?;
+    Ok((translated, std::mem::take(&mut ctx.stream_inputs)))
 }
 
-/// Replaces a receiver exchange boundary with a read of its fully materialized sender output.
+/// Replaces a receiver exchange boundary with a read of the sender's output **stream**.
+///
+/// The sender's rows are already on the GPU, parked in the engine as native batches. So the read
+/// resolves to the engine's stream view rather than to a file: nothing is materialized, nothing
+/// is re-parsed, and the boundary costs a pointer move. The schema the read declares is also
+/// recorded on the context, because the engine has no file to infer it from and the fragment must
+/// declare the same one.
 fn translate_exchange(
     node: &TPlanNode,
     children: Vec<TranslatedRel>,
@@ -348,14 +360,8 @@ fn translate_exchange(
             .ok_or(TranslateError::UnsupportedPlanNode {
                 node_id: node.node_id,
                 node_type: node.node_type,
-                reason: "exchange node requires a materialized same-node input",
+                reason: "exchange node requires a bound same-node input stream",
             })?;
-    if input.paths.is_empty() {
-        return Err(TranslateError::malformed(format!(
-            "exchange node {} has no materialized input files",
-            node.node_id
-        )));
-    }
     let schema = ctx
         .desc
         .named_struct_for_tuples(&exchange.input_row_tuples, Some(&input.names))?;
@@ -364,8 +370,33 @@ fn translate_exchange(
         .as_ref()
         .map(|structure| structure.types.len())
         .unwrap_or(0);
+
+    let columns = schema
+        .names
+        .iter()
+        .cloned()
+        .zip(
+            schema
+                .r#struct
+                .as_ref()
+                .map(|structure| structure.types.as_slice())
+                .unwrap_or_default(),
+        )
+        .map(|(name, ty)| {
+            Ok(StreamInputColumn {
+                name,
+                ty: crate::type_mapper::duckdb_type_name(ty)?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    ctx.stream_inputs.push(StreamInputSchema {
+        node_id: node.node_id,
+        stream_view: input.stream_view.clone(),
+        columns,
+    });
+
     let mut translated = TranslatedRel {
-        rel: local_files_rel(schema, &input.paths),
+        rel: stream_read_rel(schema, &input.stream_view),
         row_tuples: exchange.input_row_tuples.clone(),
         output_width,
     };
@@ -919,6 +950,23 @@ fn scan_rel(desc: &DescriptorTable, tuple_id: i32, file_paths: &[String]) -> Res
             ..Default::default()
         }))),
     })
+}
+
+/// Builds a read of an engine stream view with an explicit schema.
+///
+/// The view is a named table as far as Substrait is concerned; the engine defines it as a read of
+/// the corresponding input stream, so the plan never names a file.
+fn stream_read_rel(schema: substrait::proto::NamedStruct, stream_view: &str) -> Rel {
+    Rel {
+        rel_type: Some(rel::RelType::Read(Box::new(ReadRel {
+            base_schema: Some(schema),
+            read_type: Some(ReadType::NamedTable(NamedTable {
+                names: vec![stream_view.to_string()],
+                ..Default::default()
+            })),
+            ..Default::default()
+        }))),
+    }
 }
 
 /// Builds a local parquet read with an explicit schema.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
@@ -33,6 +33,45 @@ pub(crate) fn fp64_type(nullable: bool) -> Type {
     }
 }
 
+/// Renders a Substrait type as the DuckDB type name the engine parses when a fragment declares
+/// an input stream's schema.
+///
+/// A stream has no file to probe, so the engine cannot infer the schema; it is declared. Deriving
+/// the declaration from the very `Type` the plan's read carries is what keeps the two from
+/// drifting — the alternative, a second StarRocks-to-DuckDB mapping, would be a silent
+/// wrong-results bug the first time the two disagreed.
+pub fn duckdb_type_name(ty: &Type) -> Result<String> {
+    let kind = ty
+        .kind
+        .as_ref()
+        .ok_or_else(|| TranslateError::malformed("stream input column has no type"))?;
+    let name = match kind {
+        r#type::Kind::Bool(_) => "BOOLEAN".to_string(),
+        r#type::Kind::I8(_) => "TINYINT".to_string(),
+        r#type::Kind::I16(_) => "SMALLINT".to_string(),
+        r#type::Kind::I32(_) => "INTEGER".to_string(),
+        r#type::Kind::I64(_) => "BIGINT".to_string(),
+        r#type::Kind::Fp32(_) => "FLOAT".to_string(),
+        r#type::Kind::Fp64(_) => "DOUBLE".to_string(),
+        // DuckDB's CHAR is an alias of VARCHAR, so the declared length carries no information.
+        r#type::Kind::FixedChar(_) | r#type::Kind::Varchar(_) | r#type::Kind::String(_) => {
+            "VARCHAR".to_string()
+        }
+        r#type::Kind::Binary(_) | r#type::Kind::FixedBinary(_) => "BLOB".to_string(),
+        r#type::Kind::Date(_) => "DATE".to_string(),
+        r#type::Kind::PrecisionTimestamp(_) => "TIMESTAMP".to_string(),
+        r#type::Kind::Decimal(decimal) => {
+            format!("DECIMAL({},{})", decimal.precision, decimal.scale)
+        }
+        _ => {
+            return Err(TranslateError::malformed(
+                "stream input column type has no DuckDB name",
+            ));
+        }
+    };
+    Ok(name)
+}
+
 /// Maps a StarRocks type descriptor and slot nullability into a Substrait type.
 pub fn map_type_desc(type_desc: &TTypeDesc, nullable: bool) -> Result<Type> {
     let node = scalar_node(type_desc)?;

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -2506,7 +2506,7 @@ fn nestloop_join_translates_to_filtered_cross_rel() {
     );
 }
 
-/// Verifies an exchange node without a materialized input is rejected.
+/// Verifies an exchange node with no bound input stream is rejected.
 #[test]
 fn exchange_node_is_rejected() {
     let mut exchange = base_plan_node(1, TPlanNodeType::EXCHANGE_NODE, 0, vec![0]);
@@ -2533,9 +2533,11 @@ fn exchange_node_is_rejected() {
     ));
 }
 
-/// Verifies a materialized exchange becomes the read below the receiver aggregate.
+/// Verifies a bound exchange becomes a stream read below the receiver aggregate -- and that no
+/// file appears anywhere in the plan, which is what makes the boundary native rather than a
+/// parquet round-trip.
 #[test]
-fn materialized_exchange_feeds_aggregate() {
+fn bound_exchange_feeds_aggregate_from_a_stream() {
     let mut exchange = base_plan_node(7, TPlanNodeType::EXCHANGE_NODE, 0, vec![0]);
     exchange.exchange_node = Some(TExchangeNode::new(
         vec![0],
@@ -2564,7 +2566,7 @@ fn materialized_exchange_feeds_aggregate() {
             ),
             &[ExchangeInput {
                 node_id: 7,
-                paths: vec!["/tmp/materialized-exchange.parquet".to_string()],
+                stream_view: "sirius_stream_7".to_string(),
                 names: vec!["id".to_string(), "name".to_string()],
             }],
         )
@@ -2578,18 +2580,32 @@ fn materialized_exchange_feeds_aggregate() {
     };
     let rel::RelType::Read(read) = aggregate.input.as_ref().unwrap().rel_type.as_ref().unwrap()
     else {
-        panic!("expected materialized exchange read");
+        panic!("expected exchange read");
     };
-    let Some(read_rel::ReadType::LocalFiles(files)) = read.read_type.as_ref() else {
-        panic!("expected local_files exchange input");
+    let Some(read_rel::ReadType::NamedTable(table)) = read.read_type.as_ref() else {
+        panic!("expected a stream read for the exchange input");
     };
-    assert_eq!(files.items.len(), 1);
+    assert_eq!(table.names, vec!["sirius_stream_7"]);
     assert_eq!(read.base_schema.as_ref().unwrap().names, vec!["id", "name"]);
+
+    // The declaration the engine needs, derived from the same schema the read carries.
+    assert_eq!(translated.stream_inputs.len(), 1);
+    let stream = &translated.stream_inputs[0];
+    assert_eq!(stream.node_id, 7);
+    assert_eq!(stream.stream_view, "sirius_stream_7");
+    assert_eq!(
+        stream
+            .columns
+            .iter()
+            .map(|column| (column.name.as_str(), column.ty.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("id", "BIGINT"), ("name", "VARCHAR")]
+    );
 }
 
-/// Verifies a merging exchange globally sorts the materialized local sender output.
+/// Verifies a merging exchange globally sorts the local sender output it streams in.
 #[test]
-fn materialized_merging_exchange_becomes_sort_over_read() {
+fn merging_exchange_becomes_sort_over_stream_read() {
     let sort_info = TSortInfo::new(
         vec![slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))],
         vec![false],
@@ -2610,7 +2626,7 @@ fn materialized_merging_exchange_becomes_sort_over_read() {
             &params(Some(TPlan::new(vec![exchange])), Some(base_desc()), None),
             &[ExchangeInput {
                 node_id: 7,
-                paths: vec!["/tmp/materialized-exchange.parquet".to_string()],
+                stream_view: "sirius_stream_7".to_string(),
                 names: vec!["id".to_string(), "name".to_string()],
             }],
         )
@@ -2620,9 +2636,16 @@ fn materialized_merging_exchange_becomes_sort_over_read() {
     let rel::RelType::Sort(sort) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
         panic!("expected merging exchange sort");
     };
-    let rel::RelType::Read(_) = sort.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
-        panic!("expected materialized exchange read under sort");
+    let rel::RelType::Read(read) = sort.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected an exchange read under the sort");
     };
+    assert!(
+        matches!(
+            read.read_type.as_ref(),
+            Some(read_rel::ReadType::NamedTable(_))
+        ),
+        "a merging exchange must stream its input too, not re-scan a file"
+    );
     assert_eq!(sort.sorts.len(), 1);
 }
 

--- a/experimental/starrocks/src/compute_node_service.rs
+++ b/experimental/starrocks/src/compute_node_service.rs
@@ -1,12 +1,10 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use crate::fragment_executor::FragmentExecutor;
 #[cfg(test)]
 use crate::fragment_executor::StubExecutor;
-use crate::local_exchange::{
-    ExchangeFile, ExchangeKey, ExchangeOutput, LocalExchange, ReadyFragment,
-};
+use crate::fragment_executor::{FragmentExecutor, FragmentRun, SenderSlot};
+use crate::local_exchange::{ExchangeKey, LocalExchange, ReadyFragment, SenderOutput};
 use crate::proto::starrocks::{
     PExecBatchPlanFragmentsRequest, PExecBatchPlanFragmentsResult, PExecPlanFragmentRequest,
     PExecPlanFragmentResult, PFetchDataRequest, PFetchDataResult, PGetFileSchemaRequest,
@@ -29,6 +27,23 @@ use thrift::{
     transport::TBufferChannel,
 };
 use tracing::{info, instrument};
+
+/// Name of the engine view an exchange's input stream is read through.
+///
+/// With the engine linked this is the engine's own definition, so the name the plan reads and the
+/// name the engine creates cannot drift. The no-engine build — a translation-only test path where
+/// no view is ever created — mirrors the format, and `stream_view_name_matches_the_engine` pins
+/// the two together whenever the engine is present.
+fn sirius_stream_view_name(stream_id: u64) -> String {
+    #[cfg(feature = "sirius-engine")]
+    {
+        sirius::stream_view_name(stream_id)
+    }
+    #[cfg(not(feature = "sirius-engine"))]
+    {
+        format!("sirius_stream_{stream_id}")
+    }
+}
 
 /// Sirius compute-node implementation of StarRocks PInternalService.
 ///
@@ -291,17 +306,35 @@ impl SiriusComputeNodeService {
         }
     }
 
-    /// Executes a result fragment or materializes a data-stream sender for its local receiver.
+    /// Executes a fragment that reads no exchange input.
     fn execute_fragment(
         &self,
         params: &TExecPlanFragmentParams,
         translated: TranslatedPlan,
     ) -> std::result::Result<(), String> {
+        self.execute_fragment_with_inputs(params, translated, Vec::new())
+    }
+
+    /// Executes a result fragment, or runs a data-stream sender and parks its output on the GPU
+    /// for its local receiver. `inputs` names the parked sender outputs this fragment consumes.
+    fn execute_fragment_with_inputs(
+        &self,
+        params: &TExecPlanFragmentParams,
+        translated: TranslatedPlan,
+        inputs: Vec<(i32, Vec<SenderSlot>)>,
+    ) -> std::result::Result<(), String> {
         if Self::is_mysql_result_sink(params)? {
             let id = Self::fragment_instance_id(params).ok_or_else(|| {
                 "RESULT_SINK fragment is missing a fragment_instance_id".to_string()
             })?;
-            let result = self.executor.execute(&translated)?;
+            let result = self
+                .executor
+                .run(FragmentRun {
+                    plan: &translated,
+                    inputs: inputs.clone(),
+                    output: None,
+                })?
+                .ok_or_else(|| "result fragment returned no rows".to_string())?;
             let batch = result_encoder::MysqlResultEncoder::encode(&result.batches, 0)?;
             self.results.insert(id, batch);
             return Ok(());
@@ -342,60 +375,86 @@ impl SiriusComputeNodeService {
             .filter(|destinations| !destinations.is_empty())
             .ok_or_else(|| "DATA_STREAM_SINK fragment has no destinations".to_string())?;
         let sender_id = exec.sender_id.unwrap_or(0);
-        let result = self.executor.execute(&translated)?;
-        let output = ExchangeOutput {
-            names: translated.output_names,
-            result,
-        };
-        let mut ready_fragments = Vec::new();
-        for destination in destinations {
-            let ready = self.exchanges.push_sender(
-                ExchangeKey {
-                    fragment_instance_id: FragmentInstanceId::from(
-                        &destination.fragment_instance_id,
-                    ),
-                    node_id: stream_sink.dest_node_id,
-                },
-                sender_id,
-                output.clone(),
-            )?;
-            if let Some(ready) = ready {
-                ready_fragments.push(ready);
-            }
+        // One destination only: relaying a stream to N receivers means each batch is claimed by
+        // one of them, so a broadcast needs the partitioned sink (#838), not a loop here. Refusing
+        // is the honest answer — the alternative silently gives every receiver but one no rows.
+        if destinations.len() > 1 {
+            return Err(format!(
+                "a data stream sink with {} destinations needs partitioned streaming",
+                destinations.len()
+            ));
         }
-        for ready in ready_fragments {
+        let destination = &destinations[0];
+        let slot = SenderSlot {
+            fragment_instance_id: FragmentInstanceId::from(&destination.fragment_instance_id),
+            node_id: stream_sink.dest_node_id,
+            sender_id,
+        };
+
+        // The sender's rows stay on the GPU, parked under `slot` as native batches; only the
+        // rendezvous bookkeeping — which sender produced, and its output names — comes back here.
+        self.executor.run(FragmentRun {
+            plan: &translated,
+            inputs,
+            output: Some(slot),
+        })?;
+
+        let ready = self.exchanges.push_sender(
+            ExchangeKey {
+                fragment_instance_id: slot.fragment_instance_id,
+                node_id: slot.node_id,
+            },
+            sender_id,
+            SenderOutput {
+                names: translated.output_names,
+                slot,
+            },
+        )?;
+        if let Some(ready) = ready {
             self.execute_ready_fragment(ready)?;
         }
         Ok(())
     }
 
-    /// Materializes all complete sender sets and executes the receiver as one single-shot plan.
+    /// Translates a receiver whose sender set is complete, binding each exchange to the input
+    /// stream its senders parked into, and runs it.
     fn execute_ready_fragment(&self, ready: ReadyFragment) -> std::result::Result<(), String> {
-        let files = ready
-            .inputs
-            .iter()
-            .map(|input| ExchangeFile::materialize(&input.outputs))
-            .collect::<Result<Vec<_>, _>>()?;
         let exchange_inputs = ready
             .inputs
             .iter()
-            .zip(&files)
-            .map(|(input, file)| {
-                let path = file
-                    .path()
-                    .to_str()
-                    .ok_or_else(|| "exchange file path is not valid UTF-8".to_string())?
-                    .to_string();
+            .map(|input| {
+                let names = input
+                    .outputs
+                    .first()
+                    .map(|output| output.names.clone())
+                    .ok_or_else(|| {
+                        format!("exchange node {} has no sender output", input.node_id)
+                    })?;
+                if input.outputs.iter().any(|output| output.names != names) {
+                    return Err("exchange senders produced different output names".to_string());
+                }
+                let stream_id = u64::try_from(input.node_id)
+                    .map_err(|_| format!("negative exchange node id {}", input.node_id))?;
                 Ok(ExchangeInput {
                     node_id: input.node_id,
-                    paths: vec![path],
-                    names: file.names.clone(),
+                    stream_view: sirius_stream_view_name(stream_id),
+                    names,
                 })
             })
             .collect::<Result<Vec<_>, String>>()?;
+        let inputs = ready
+            .inputs
+            .iter()
+            .map(|input| {
+                (
+                    input.node_id,
+                    input.outputs.iter().map(|output| output.slot).collect(),
+                )
+            })
+            .collect();
         let translated =
             self.translate_fragment_logged_with_inputs(&ready.params, &exchange_inputs)?;
-        self.execute_fragment(&ready.params, translated)
+        self.execute_fragment_with_inputs(&ready.params, translated, inputs)
     }
 
     /// Finds every exchange receiver in a fragment and each expected sender count.
@@ -691,9 +750,23 @@ mod tests {
     }
 
     impl FragmentExecutor for CountingExecutor {
-        fn execute(&self, translated: &TranslatedPlan) -> Result<FragmentResult, String> {
+        fn run(&self, run: FragmentRun<'_>) -> Result<Option<FragmentResult>, String> {
             self.calls.fetch_add(1, Ordering::Relaxed);
-            StubExecutor.execute(translated)
+            StubExecutor.run(run)
+        }
+    }
+
+    /// The plan names the view; the engine creates it. If the two ever disagree the receiver's
+    /// read binds to nothing and the query fails at plan time, so pin them together here rather
+    /// than discovering it in a cluster run.
+    #[cfg(feature = "sirius-engine")]
+    #[test]
+    fn stream_view_name_matches_the_engine() {
+        for stream_id in [0, 1, 7, 4096] {
+            assert_eq!(
+                sirius_stream_view_name(stream_id),
+                sirius::stream_view_name(stream_id)
+            );
         }
     }
 

--- a/experimental/starrocks/src/engine.rs
+++ b/experimental/starrocks/src/engine.rs
@@ -3,16 +3,17 @@
 //! [`sirius::SiriusContext`] is `!Send`/`!Sync` and the engine serializes queries through a single
 //! process-global context, so the context is created, used, and dropped on one dedicated thread.
 //! [`SiriusEngine`] talks to that thread over channels — which are `Send`/`Sync` and carry only
-//! owned data (`Vec<u8>` in, `FragmentResult` out) — so it satisfies `dyn FragmentExecutor:
+//! owned data (see [`ExecuteRequest`]; owned Arrow out) — so it satisfies `dyn FragmentExecutor:
 //! Send + Sync` without ever moving the context across threads.
 //!
-//! The seam is synchronous (see [`FragmentExecutor`]): `execute()` blocks the caller until the
-//! engine thread returns the result. `exec_plan_fragment` runs it on a `spawn_blocking` worker, so
-//! the BRPC current-thread runtime stays free to serve `fetch_data`, connection cleanup, and
-//! shutdown cancellation while a query runs. Each fragment result is fully materialized, and the
-//! single process-global context serializes fragment execution — both lifted by the streaming
-//! evolution.
+//! The seam is synchronous (see [`FragmentExecutor`]): `run()` blocks the caller until the
+//! engine thread answers. `exec_plan_fragment` runs it on a `spawn_blocking` worker, so the BRPC
+//! current-thread runtime stays free to serve `fetch_data`, connection cleanup, and shutdown
+//! cancellation while a query runs. Only a *result* fragment materializes Arrow; a sender's
+//! output stays parked on this thread as native batches. The process-global context still
+//! serializes fragment execution — lifted once per-query lifecycle isolation lands.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::sync::mpsc::{Receiver, Sender, channel};
@@ -21,17 +22,31 @@ use std::thread::JoinHandle;
 #[cfg(test)]
 use arrow_array::RecordBatch;
 use sirius::SiriusContext;
-use starrocks_plan_translator::TranslatedPlan;
+use starrocks_plan_translator::StreamInputSchema;
 use tracing::info;
 
-use crate::fragment_executor::{FragmentExecutor, FragmentResult};
+use crate::fragment_executor::{FragmentExecutor, FragmentResult, FragmentRun, SenderSlot};
 
-/// One execution request handed to the engine thread.
+/// Output stream id an intermediate fragment sinks into. One per fragment: a gather exchange has
+/// a single destination, and fan-out needs the partitioned sink (#838), not more ids here.
+const SENDER_OUTPUT_STREAM: u64 = 0;
+
+/// One fragment execution handed to the engine thread.
+///
+/// Owned data only: the `sirius::Fragment`s themselves never leave that thread, so what crosses
+/// the channel is the plan, the schema of each declared stream, and the slots naming which parked
+/// sender outputs to relay in.
 struct ExecuteRequest {
     /// Serialized Substrait plan bytes.
     plan: Vec<u8>,
+    /// Schema of every exchange this plan reads as a stream.
+    stream_inputs: Vec<StreamInputSchema>,
+    /// Parked sender outputs to relay in, keyed by receiver exchange node id.
+    inputs: Vec<(i32, Vec<SenderSlot>)>,
+    /// Set for a sender fragment: park the output under this slot instead of returning rows.
+    output: Option<SenderSlot>,
     /// Channel the engine thread sends the result (or a flattened error) back on.
-    respond: Sender<Result<FragmentResult, String>>,
+    respond: Sender<Result<Option<FragmentResult>, String>>,
 }
 
 /// GPU-backed [`FragmentExecutor`] running plans on an embedded Sirius engine.
@@ -129,21 +144,140 @@ fn engine_thread(
             return;
         }
     };
+
+    // Sender fragments whose output is parked on the GPU, waiting for their receiver to be
+    // dispatched. Declared after `context` so it is dropped *first*: on the C++ side a fragment
+    // holds pointers into the context it ran on, and a fragment outliving its context is
+    // use-after-free. The `Fragment<'_>` borrow turns that drop order into something the borrow
+    // checker rejects at compile time rather than a convention a refactor could silently break.
+    let mut parked: HashMap<SenderSlot, sirius::Fragment<'_>> = HashMap::new();
+
     info!("sirius-engine thread ready");
     // One query at a time until the handle (and its sender) is dropped.
     while let Ok(request) = requests.recv() {
-        // `execute_substrait` drains the Arrow stream and drops the context-referencing wrapper
-        // here, on the engine thread, returning owned batches whose buffers are released via their
-        // own Arrow C release callbacks — independent of the context. So the batches are safe to
-        // send to, and drop on, the caller's thread.
-        let result = context
-            .execute_substrait_result(&request.plan)
-            .map(|result| FragmentResult::with_schema(result.schema, result.batches))
-            .map_err(|err| err.to_string());
+        let result = run_fragment(&context, &mut parked, &request);
+        if result.is_err() {
+            // A failed query leaves its parked senders unreachable — the receiver that would have
+            // consumed them is the thing that just failed. Dropping them releases the GPU memory
+            // their batches hold rather than leaking it for the process's lifetime.
+            parked.clear();
+        }
         // Ignore a send error: the waiting fragment may have been dropped/cancelled.
         let _ = request.respond.send(result);
     }
+    // Fragments must be gone before the context they borrow.
+    drop(parked);
     info!("sirius-engine thread shutting down");
+}
+
+/// Runs one fragment on the engine thread: declare its input streams, relay every parked sender
+/// into them as native batches, execute, then either park the output or return the rows.
+fn run_fragment<'ctx>(
+    context: &'ctx SiriusContext,
+    parked: &mut HashMap<SenderSlot, sirius::Fragment<'ctx>>,
+    request: &ExecuteRequest,
+) -> Result<Option<FragmentResult>, String> {
+    let mut fragment = context
+        .fragment()
+        .map_err(|err| format!("failed to create fragment: {err}"))?;
+
+    for schema in &request.stream_inputs {
+        let stream_id = stream_id_of(schema.node_id)?;
+        for column in &schema.columns {
+            fragment
+                .declare_input_column(stream_id, &column.name, &column.ty)
+                .map_err(|err| {
+                    format!(
+                        "failed to declare column {} of stream {stream_id}: {err}",
+                        column.name
+                    )
+                })?;
+        }
+        let senders = request
+            .inputs
+            .iter()
+            .find(|(node_id, _)| *node_id == schema.node_id)
+            .map(|(_, senders)| senders.as_slice())
+            .unwrap_or_default();
+        if senders.is_empty() {
+            return Err(format!(
+                "exchange node {} is read as a stream but no sender output is parked for it",
+                schema.node_id
+            ));
+        }
+        for slot in senders {
+            let sender_id = u32::try_from(slot.sender_id)
+                .map_err(|_| format!("negative sender id {}", slot.sender_id))?;
+            fragment
+                .declare_input_sender(stream_id, sender_id)
+                .map_err(|err| format!("failed to declare sender on stream {stream_id}: {err}"))?;
+        }
+    }
+
+    // An intermediate fragment sinks into its own output stream 0; a result fragment declares no
+    // output stream at all and produces Arrow instead.
+    if request.output.is_some() {
+        fragment
+            .declare_output(SENDER_OUTPUT_STREAM)
+            .map_err(|err| format!("failed to declare the fragment output stream: {err}"))?;
+    }
+
+    fragment
+        .build(&request.plan)
+        .map_err(|err| format!("failed to plan fragment: {err}"))?;
+
+    // The fragment boundary itself: each sender's batches move into this fragment's input stream
+    // as native handles. Nothing is converted, written, or copied.
+    for schema in &request.stream_inputs {
+        let stream_id = stream_id_of(schema.node_id)?;
+        let senders = request
+            .inputs
+            .iter()
+            .find(|(node_id, _)| *node_id == schema.node_id)
+            .map(|(_, senders)| senders.as_slice())
+            .unwrap_or_default();
+        for slot in senders {
+            let mut sender = parked
+                .remove(slot)
+                .ok_or_else(|| format!("no parked sender output for {slot:?}"))?;
+            let sender_id = u32::try_from(slot.sender_id)
+                .map_err(|_| format!("negative sender id {}", slot.sender_id))?;
+            let moved = fragment
+                .relay_from(&mut sender, SENDER_OUTPUT_STREAM, stream_id, sender_id)
+                .map_err(|err| format!("failed to relay sender {sender_id}: {err}"))?;
+            info!(
+                stream_id,
+                sender_id,
+                batches = moved,
+                "relayed native batches across a fragment boundary"
+            );
+        }
+    }
+
+    fragment
+        .run()
+        .map_err(|err| format!("failed to execute fragment: {err}"))?;
+
+    match request.output {
+        Some(slot) => {
+            parked.insert(slot, fragment);
+            Ok(None)
+        }
+        // `into_arrow` drains the stream and drops the context-referencing wrapper here, on the
+        // engine thread, returning owned batches whose buffers are released via their own Arrow C
+        // release callbacks — independent of the context. So they are safe to send to, and drop
+        // on, the caller's thread.
+        None => fragment
+            .into_arrow()
+            .map(|result| Some(FragmentResult::new(result.batches)))
+            .map_err(|err| err.to_string()),
+    }
+}
+
+/// Engine-side stream id for a receiver exchange node. The node id addresses the stream, so the
+/// two sides of a boundary agree without a separate allocation table.
+fn stream_id_of(node_id: i32) -> Result<u64, String> {
+    u64::try_from(node_id).map_err(|_| format!("negative exchange node id {node_id}"))
 }
 
 /// Brings up a [`SiriusContext`] from an optional config path (built-in defaults when `None`).
@@ -158,10 +292,13 @@ fn build_context(config: Option<PathBuf>) -> Result<SiriusContext, String> {
 }
 
 impl FragmentExecutor for SiriusEngine {
-    fn execute(&self, translated: &TranslatedPlan) -> Result<FragmentResult, String> {
+    fn run(&self, run: FragmentRun<'_>) -> Result<Option<FragmentResult>, String> {
         let (respond_tx, respond_rx) = channel();
         let request = ExecuteRequest {
-            plan: translated.to_substrait_bytes(),
+            plan: run.plan.to_substrait_bytes(),
+            stream_inputs: run.plan.stream_inputs.clone(),
+            inputs: run.inputs,
+            output: run.output,
             respond: respond_tx,
         };
         self.requests
@@ -205,8 +342,10 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use parquet::arrow::ArrowWriter;
 
+    use starrocks_plan_translator::TranslatedPlan;
+
     use super::*;
-    use crate::local_exchange::{ExchangeFile, ExchangeOutput};
+    use crate::result_store::FragmentInstanceId;
 
     /// Builds a single-file `local_files` parquet read plan with `names` as the root output
     /// names — the shape DuckDB's Substrait reader resolves to `parquet_scan(<path>)`.
@@ -243,7 +382,90 @@ mod tests {
         TranslatedPlan {
             plan,
             output_names: names,
+            stream_inputs: Vec::new(),
         }
+    }
+
+    /// A plan that reads one input stream through the engine's stream view, plus the declaration
+    /// the engine needs for it. `columns` is `(name, is_string)` in output order.
+    fn stream_plan(node_id: i32, columns: &[(&str, bool)]) -> TranslatedPlan {
+        use starrocks_plan_translator::{StreamInputColumn, StreamInputSchema};
+        use substrait::proto::read_rel::{NamedTable, ReadType};
+        use substrait::proto::{
+            NamedStruct, Plan, PlanRel, ReadRel, Rel, RelRoot, Type, plan_rel, rel, r#type,
+        };
+
+        let view = sirius::stream_view_name(node_id as u64);
+        let names: Vec<String> = columns.iter().map(|(name, _)| name.to_string()).collect();
+        let types: Vec<Type> = columns
+            .iter()
+            .map(|(_, is_string)| {
+                let kind = if *is_string {
+                    r#type::Kind::String(r#type::String {
+                        type_variation_reference: 0,
+                        nullability: r#type::Nullability::Nullable as i32,
+                    })
+                } else {
+                    r#type::Kind::I64(r#type::I64 {
+                        type_variation_reference: 0,
+                        nullability: r#type::Nullability::Nullable as i32,
+                    })
+                };
+                Type { kind: Some(kind) }
+            })
+            .collect();
+        let read = Rel {
+            rel_type: Some(rel::RelType::Read(Box::new(ReadRel {
+                base_schema: Some(NamedStruct {
+                    names: names.clone(),
+                    r#struct: Some(r#type::Struct {
+                        types,
+                        type_variation_reference: 0,
+                        nullability: r#type::Nullability::Required as i32,
+                    }),
+                }),
+                read_type: Some(ReadType::NamedTable(NamedTable {
+                    names: vec![view.clone()],
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }))),
+        };
+        TranslatedPlan {
+            plan: Plan {
+                relations: vec![PlanRel {
+                    rel_type: Some(plan_rel::RelType::Root(RelRoot {
+                        input: Some(read),
+                        names: names.clone(),
+                    })),
+                }],
+                ..Default::default()
+            },
+            output_names: names.clone(),
+            stream_inputs: vec![StreamInputSchema {
+                node_id,
+                stream_view: view,
+                columns: columns
+                    .iter()
+                    .map(|(name, is_string)| StreamInputColumn {
+                        name: name.to_string(),
+                        ty: if *is_string { "VARCHAR" } else { "BIGINT" }.to_string(),
+                    })
+                    .collect(),
+            }],
+        }
+    }
+
+    /// Runs a result fragment (no output slot) and returns its rows.
+    fn run_result(engine: &SiriusEngine, plan: &TranslatedPlan) -> FragmentResult {
+        engine
+            .run(FragmentRun {
+                plan,
+                inputs: Vec::new(),
+                output: None,
+            })
+            .expect("execute fragment on GPU")
+            .expect("a result fragment returns rows")
     }
 
     /// Like [`local_files_plan`] but declares a `base_schema` (names + types) on the read — the
@@ -311,6 +533,7 @@ mod tests {
         TranslatedPlan {
             plan,
             output_names: names,
+            stream_inputs: Vec::new(),
         }
     }
 
@@ -332,13 +555,17 @@ mod tests {
             .unwrap()
             .send(ExecuteRequest {
                 plan,
+                stream_inputs: Vec::new(),
+                inputs: Vec::new(),
+                output: None,
                 respond: respond_tx,
             })
             .unwrap();
         let result = respond_rx
             .recv()
             .expect("engine response")
-            .expect("execute");
+            .expect("execute")
+            .expect("a result fragment returns rows");
         let rows: usize = result.batches.iter().map(RecordBatch::num_rows).sum();
         eprintln!("plan {path} returned {rows} row(s)");
         for batch in &result.batches {
@@ -386,31 +613,50 @@ mod tests {
         );
 
         let engine = SiriusEngine::start(None).expect("bring up sirius engine");
-        let result = engine.execute(&plan).expect("execute fragment on GPU");
+        let result = run_result(&engine, &plan);
         let total_rows: usize = result.batches.iter().map(RecordBatch::num_rows).sum();
         assert_eq!(total_rows, 3, "expected 3 rows from the parquet fixture");
 
-        // Run the same rows through the sequential exchange path: fragment one completed above,
-        // its Arrow result is materialized, and fragment two reads that file in a new single-shot
-        // GPU execution.
-        let exchange = ExchangeFile::materialize(&[ExchangeOutput {
-            names: plan.output_names.clone(),
-            result,
-        }])
-        .expect("materialize local exchange");
-        let exchanged = local_files_plan_with_base_schema(
-            exchange.path().to_str().unwrap(),
-            &[("id", false), ("name", true)],
+        // The fragment boundary, over native batches: the sender's rows park on the GPU under
+        // `slot`, and the receiver reads them through its input stream. Nothing is written to
+        // disk and nothing becomes Arrow in between -- the only Arrow here is the receiver's own
+        // result, at the very end.
+        const EXCHANGE_NODE: i32 = 7;
+        let slot = SenderSlot {
+            fragment_instance_id: FragmentInstanceId::from_halves(1, 2),
+            node_id: EXCHANGE_NODE,
+            sender_id: 0,
+        };
+        assert!(
+            engine
+                .run(FragmentRun {
+                    plan: &plan,
+                    inputs: Vec::new(),
+                    output: Some(slot),
+                })
+                .expect("run the sender fragment")
+                .is_none(),
+            "a sender fragment parks its output instead of returning rows"
         );
+
+        let receiver = stream_plan(EXCHANGE_NODE, &[("id", false), ("name", true)]);
         let exchanged_result = engine
-            .execute(&exchanged)
-            .expect("execute exchange receiver on GPU");
+            .run(FragmentRun {
+                plan: &receiver,
+                inputs: vec![(EXCHANGE_NODE, vec![slot])],
+                output: None,
+            })
+            .expect("execute exchange receiver on GPU")
+            .expect("a result fragment returns rows");
         let exchanged_rows: usize = exchanged_result
             .batches
             .iter()
             .map(RecordBatch::num_rows)
             .sum();
-        assert_eq!(exchanged_rows, 3, "exchange preserved all fragment rows");
+        assert_eq!(
+            exchanged_rows, 3,
+            "the fragment boundary preserved every row"
+        );
 
         // A `base_schema` that prunes and reorders the file's columns must bind by name, not by
         // file position (exercises the Substrait reader's `local_files` projection). The fixture
@@ -442,9 +688,7 @@ mod tests {
             cols_path.to_str().unwrap(),
             &[("name", true), ("id", false)],
         );
-        let result = engine
-            .execute(&pruned)
-            .expect("execute pruned fragment on GPU");
+        let result = run_result(&engine, &pruned);
         let batch = result
             .batches
             .iter()

--- a/experimental/starrocks/src/fragment_executor.rs
+++ b/experimental/starrocks/src/fragment_executor.rs
@@ -7,14 +7,17 @@
 use std::sync::Arc;
 
 use arrow_array::{ArrayRef, RecordBatch, StringArray};
-use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_schema::{DataType, Field, Schema};
 use starrocks_plan_translator::TranslatedPlan;
 
+use crate::result_store::FragmentInstanceId;
+
 /// Output of executing one plan fragment: Arrow batches matching the fragment output schema.
+///
+/// Only a *result* fragment produces one. An intermediate fragment's output never becomes Arrow —
+/// it stays on the GPU as native batches for the fragment that consumes it.
 #[derive(Clone, Debug)]
 pub struct FragmentResult {
-    /// Output schema, retained even when execution produces no batches.
-    pub(crate) schema: SchemaRef,
     /// Result batches in fragment output order. Empty for a fragment with no output columns.
     pub(crate) batches: Vec<RecordBatch>,
 }
@@ -22,16 +25,7 @@ pub struct FragmentResult {
 impl FragmentResult {
     /// Builds a result from its output batches (in fragment output order).
     pub fn new(batches: Vec<RecordBatch>) -> Self {
-        let schema = batches
-            .first()
-            .map(RecordBatch::schema)
-            .unwrap_or_else(|| Arc::new(Schema::empty()));
-        Self { schema, batches }
-    }
-
-    /// Builds a result with an explicit schema, including for empty results.
-    pub fn with_schema(schema: SchemaRef, batches: Vec<RecordBatch>) -> Self {
-        Self { schema, batches }
+        Self { batches }
     }
 
     /// The result batches in fragment output order.
@@ -40,20 +34,44 @@ impl FragmentResult {
     }
 }
 
-/// Runs a translated fragment and returns its result batches.
+/// Where one sender fragment's output is parked until its receiver runs.
 ///
-/// This is intentionally a synchronous, fully-materializing seam for single-shot execution.
-/// Each fragment runs to completion, and a local exchange can sequence one fragment's output into
-/// the next before `fetch_data` drains the final buffered rows.
+/// Keyed by the *receiver* it feeds, because that is what the rendezvous looks it up by: a sender
+/// is addressed by the exchange it produces into, not by its own identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SenderSlot {
+    /// Receiver fragment instance the output is destined for.
+    pub fragment_instance_id: FragmentInstanceId,
+    /// Receiver `EXCHANGE_NODE` id, which is also the engine-side stream id.
+    pub node_id: i32,
+    /// Sender ordinal within that exchange's sender set.
+    pub sender_id: i32,
+}
+
+/// One fragment to run: the plan, where its exchange inputs come from, and where its output goes.
+#[derive(Debug)]
+pub struct FragmentRun<'a> {
+    /// Translated plan, including the schema of every exchange lowered to a stream read.
+    pub plan: &'a TranslatedPlan,
+    /// Parked sender outputs to relay into this fragment, keyed by receiver exchange node id.
+    pub inputs: Vec<(i32, Vec<SenderSlot>)>,
+    /// Set for a sender fragment: its output parks under this slot instead of returning rows.
+    pub output: Option<SenderSlot>,
+}
+
+/// Runs a translated fragment, either parking its output for a downstream fragment or returning
+/// its rows.
 ///
-/// TODO(starrocks-execute): a real GPU executor should not block dispatch on full materialization.
-/// Evolve this into a streaming contract — dispatch registers a running fragment and returns after
-/// startup, the executor pushes Arrow batches (e.g. via an Arrow C stream) into a bounded channel
-/// the `ResultStore` drains, and execution is cancellable from `cancel_plan_fragment`. Large/slow
-/// result queries then stream through `fetch_data` instead of risking dispatch-time timeout/OOM.
+/// The seam is synchronous and one fragment at a time: the engine serializes queries, and a
+/// sender's output is parked on the GPU — as native batches, not Arrow — until its receiver is
+/// dispatched. A sender's rows therefore never leave the device between fragments.
+///
+/// TODO(starrocks-execute): dispatch still blocks until a fragment completes. Concurrency needs
+/// per-query lifecycle isolation in the engine; until then `run` is called from a blocking worker
+/// so the BRPC runtime stays responsive.
 pub trait FragmentExecutor: std::fmt::Debug + Send + Sync {
-    /// Executes `translated` and returns its Arrow result batches.
-    fn execute(&self, translated: &TranslatedPlan) -> Result<FragmentResult, String>;
+    /// Runs `run`. Returns rows only for a fragment with no `output` slot — a result fragment.
+    fn run(&self, run: FragmentRun<'_>) -> Result<Option<FragmentResult>, String>;
 }
 
 /// Placeholder executor that fabricates one row so the result path works without a GPU.
@@ -61,6 +79,17 @@ pub trait FragmentExecutor: std::fmt::Debug + Send + Sync {
 pub struct StubExecutor;
 
 impl FragmentExecutor for StubExecutor {
+    fn run(&self, run: FragmentRun<'_>) -> Result<Option<FragmentResult>, String> {
+        // A stub sender parks nothing; the rendezvous only needs it to succeed.
+        if run.output.is_some() {
+            return Ok(None);
+        }
+        self.execute(run.plan).map(Some)
+    }
+}
+
+impl StubExecutor {
+    /// One placeholder row per output column, so the FE→client path works without a GPU.
     fn execute(&self, translated: &TranslatedPlan) -> Result<FragmentResult, String> {
         // TODO(starrocks-execute): replace with a SiriusExecutor that hands
         // `translated.to_substrait_bytes()` to the embedded Sirius engine, executes it on the
@@ -70,7 +99,6 @@ impl FragmentExecutor for StubExecutor {
         let names = &translated.output_names;
         if names.is_empty() {
             return Ok(FragmentResult {
-                schema: Arc::new(Schema::empty()),
                 batches: Vec::new(),
             });
         }
@@ -85,7 +113,6 @@ impl FragmentExecutor for StubExecutor {
         let batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
             .map_err(|err| format!("failed to build stub result batch: {err}"))?;
         Ok(FragmentResult {
-            schema: batch.schema(),
             batches: vec![batch],
         })
     }
@@ -99,6 +126,7 @@ mod tests {
         TranslatedPlan {
             plan: Default::default(),
             output_names: names.iter().map(|name| name.to_string()).collect(),
+            stream_inputs: Vec::new(),
         }
     }
 

--- a/experimental/starrocks/src/local_exchange.rs
+++ b/experimental/starrocks/src/local_exchange.rs
@@ -1,16 +1,15 @@
-//! Sequential same-node exchange for the single-shot Sirius API.
+//! Sequential same-node exchange rendezvous.
+//!
+//! The exchange matches StarRocks' receiver-first dispatch with the senders that arrive later. It
+//! carries no data: a sender's rows stay on the GPU, parked in the engine as native batches, and
+//! what is tracked here is only which senders have produced and where their output sits.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicU64, Ordering};
 
-use arrow_array::RecordBatch;
-use arrow_schema::Schema;
-use parquet::arrow::ArrowWriter;
 use starrocks_thrift::internal_service::TExecPlanFragmentParams;
 
-use crate::fragment_executor::FragmentResult;
+use crate::fragment_executor::SenderSlot;
 use crate::result_store::FragmentInstanceId;
 
 /// Receiver identity used by both the stream sink and exchange node.
@@ -20,18 +19,20 @@ pub(crate) struct ExchangeKey {
     pub(crate) node_id: i32,
 }
 
-/// One fully materialized sender result awaiting its receiver fragment.
+/// One sender that has produced, and where the engine parked its output.
 #[derive(Clone, Debug)]
-pub(crate) struct ExchangeOutput {
+pub(crate) struct SenderOutput {
+    /// Sender output names, which become the input stream's column names.
     pub(crate) names: Vec<String>,
-    pub(crate) result: FragmentResult,
+    /// Where the engine parked this sender's batches.
+    pub(crate) slot: SenderSlot,
 }
 
-/// One complete materialized input of a receiver fragment.
+/// One exchange input of a receiver fragment whose sender set is complete.
 #[derive(Debug)]
 pub(crate) struct ReadyExchangeInput {
     pub(crate) node_id: i32,
-    pub(crate) outputs: Vec<ExchangeOutput>,
+    pub(crate) outputs: Vec<SenderOutput>,
 }
 
 /// A receiver fragment whose exchange inputs are all ready for sequential execution.
@@ -50,7 +51,7 @@ struct PendingReceiver {
 #[derive(Debug, Default)]
 struct ExchangeState {
     receivers: HashMap<FragmentInstanceId, PendingReceiver>,
-    outputs: HashMap<ExchangeKey, HashMap<i32, ExchangeOutput>>,
+    outputs: HashMap<ExchangeKey, HashMap<i32, SenderOutput>>,
 }
 
 /// Matches receiver-first StarRocks dispatch with later same-node sender results.
@@ -97,12 +98,12 @@ impl LocalExchange {
         Self::take_ready(&mut state, fragment_instance_id)
     }
 
-    /// Buffers one sender output, returning the receiver when this completes its sender set.
+    /// Records one sender as produced, returning the receiver when this completes its sender set.
     pub(crate) fn push_sender(
         &self,
         key: ExchangeKey,
         sender_id: i32,
-        output: ExchangeOutput,
+        output: SenderOutput,
     ) -> Result<Option<ReadyFragment>, String> {
         let mut state = self.lock();
         let senders = state.outputs.entry(key).or_default();
@@ -169,106 +170,5 @@ impl LocalExchange {
         self.inner
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
-}
-
-/// Temporary parquet file used as the receiver's `local_files` exchange input.
-#[derive(Debug)]
-pub(crate) struct ExchangeFile {
-    path: PathBuf,
-    pub(crate) names: Vec<String>,
-}
-
-impl ExchangeFile {
-    /// Writes every sender batch to one parquet file in deterministic sender order.
-    pub(crate) fn materialize(outputs: &[ExchangeOutput]) -> Result<Self, String> {
-        let first = outputs
-            .first()
-            .ok_or_else(|| "cannot materialize an exchange without sender outputs".to_string())?;
-        let sender_schema = first.result.schema.clone();
-        let names = first.names.clone();
-        if sender_schema.fields().len() != names.len() {
-            return Err(format!(
-                "exchange sender produced {} schema fields but {} output names",
-                sender_schema.fields().len(),
-                names.len()
-            ));
-        }
-        for output in outputs {
-            if output.names != names {
-                return Err("exchange senders produced different output names".to_string());
-            }
-            if output.result.schema != sender_schema {
-                return Err("exchange senders produced different Arrow schemas".to_string());
-            }
-        }
-
-        // Root output names are the parquet column names consumed by the receiver's base schema.
-        // Re-label batches without copying their arrays in case the Arrow exporter chose different
-        // field names from the Substrait root.
-        let fields = sender_schema
-            .fields()
-            .iter()
-            .zip(&names)
-            .map(|(field, name)| field.as_ref().clone().with_name(name))
-            .collect::<Vec<_>>();
-        let schema = std::sync::Arc::new(Schema::new_with_metadata(
-            fields,
-            sender_schema.metadata().clone(),
-        ));
-
-        let exchange_file = Self {
-            path: Self::next_path()?,
-            names,
-        };
-        let file = std::fs::File::create(&exchange_file.path).map_err(|err| {
-            format!(
-                "failed to create exchange file {}: {err}",
-                exchange_file.path.display()
-            )
-        })?;
-        let mut writer = ArrowWriter::try_new(file, schema.clone(), None)
-            .map_err(|err| format!("failed to create exchange parquet writer: {err}"))?;
-        for output in outputs {
-            for batch in &output.result.batches {
-                let batch = RecordBatch::try_new(schema.clone(), batch.columns().to_vec())
-                    .map_err(|err| format!("failed to name exchange batch columns: {err}"))?;
-                writer
-                    .write(&batch)
-                    .map_err(|err| format!("failed to write exchange batch: {err}"))?;
-            }
-        }
-        writer
-            .close()
-            .map_err(|err| format!("failed to finish exchange parquet file: {err}"))?;
-        Ok(exchange_file)
-    }
-
-    pub(crate) fn path(&self) -> &Path {
-        &self.path
-    }
-
-    fn next_path() -> Result<PathBuf, String> {
-        static NEXT_FILE: AtomicU64 = AtomicU64::new(0);
-        let dir = std::env::temp_dir().join("sirius-starrocks-cn");
-        std::fs::create_dir_all(&dir).map_err(|err| {
-            format!(
-                "failed to create exchange directory {}: {err}",
-                dir.display()
-            )
-        })?;
-        let sequence = NEXT_FILE.fetch_add(1, Ordering::Relaxed);
-        Ok(dir.join(format!(
-            "exchange-{}-{sequence}.parquet",
-            std::process::id()
-        )))
-    }
-}
-
-impl Drop for ExchangeFile {
-    fn drop(&mut self) {
-        if let Err(err) = std::fs::remove_file(&self.path) {
-            tracing::warn!(path = %self.path.display(), error = %err, "failed to remove exchange file");
-        }
     }
 }

--- a/experimental/starrocks/src/result_store.rs
+++ b/experimental/starrocks/src/result_store.rs
@@ -20,7 +20,7 @@ use crate::proto::starrocks::PUniqueId;
 /// `fetch_data`). It is held here as a [`Uuid`] so the two wire forms compare
 /// equal and logs render the canonical hyphenated form instead of `hi-lo`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct FragmentInstanceId(Uuid);
+pub struct FragmentInstanceId(Uuid);
 
 impl FragmentInstanceId {
     /// Packs the `hi`/`lo` 64-bit halves of a StarRocks unique id into a [`Uuid`].


### PR DESCRIPTION
Ports integration commits `c14acfd4` (issues E/F of the integration triage) and `4d35e780`; no GitHub
issue yet. Part 10 of a twelve-PR stack.

**What.** Part 9 crossed the fragment boundary by materializing: the sender's result became Arrow,
went to a temp parquet file, and the receiver re-scanned it. This makes the boundary a pointer move —
rows stay in GPU memory as `cucascade::data_batch` handles, parked in the engine, and the receiver
reads them through the part-8 `ffi::Fragment` (`declare`, `build`, `relay_from`, `run`), with Arrow
only at the MySQL edge. `ExchangeFile` is **deleted**, which is what makes the change falsifiable:
with the temp-parquet code gone, a correct TPC-H Q6 on the demo cluster is evidence the rows crossed
natively.

**Design: the crossing no longer produces an artifact.** A parquet file did four jobs for free — it
named itself, described its own schema, could be read by any thread, and outlived its producer. Each
mechanism here is one of those, done explicitly.

- **Identity: the stream id *is* the exchange node id.** Both sides read it out of the same plan, so
  there is no allocation table to disagree over — an id-minting scheme invites a receiver waiting
  forever on a stream its sender parked under a different number.
- **Schema: declared from the very `substrait::Type` the read carries.** A second StarRocks→DuckDB
  type mapping in the compute node would be a silent wrong-results bug the first time the two
  disagreed.
- **Residence: parked batches live where the context lives.** `SiriusContext` is `!Send`, so the
  parked map is a local of the engine thread, declared after the context so it drops first — the
  `Fragment<'_>` borrow makes that ordering a compile error, not a convention. A failed query clears
  the map rather than leaking GPU memory for the process's lifetime.
- **Lifetime: a sender returns `None`.** Its output parks under its `SenderSlot` instead of coming
  back as rows; returning a materialized result would silently reintroduce the Arrow round-trip this
  commit deletes.
- **Sharing: more than one destination is refused.** Each parked batch is claimed by exactly one
  receiver (`relay_from` moves it), so broadcast needs the partitioned sink (#1322) — looping would
  hand every receiver but one zero rows, a wrong answer rather than an error.

The receiver's plan binds `sirius_stream_<node_id>` only because part 8 creates a view of that exact
name, so the compute node delegates to the engine's `sirius::stream_view_name` and
`stream_view_name_matches_the_engine` pins the two together; drift would surface as a catalog error in
a cluster run, long after the sender had executed. Two refusals carry over unchanged: multi-destination
senders, and two-phase aggregation in the translator (issue G).

**Reading order.**
1. `src/engine.rs` — the crossing: `run_fragment` declares, relays, runs, then parks or returns; the
   parked map's drop-order comment is the lifetime story.
2. `crates/starrocks-plan-translator/src/node_translator.rs` — `translate_exchange` lowers
   EXCHANGE_NODE to `stream_read_rel` and records the declaration; `type_mapper.rs` renders the type
   names, `lib.rs` carries `StreamInputSchema` and a view name in place of file paths.
3. `src/fragment_executor.rs` — `SenderSlot`, `FragmentRun`, `run → Option<FragmentResult>`.
4. `src/compute_node_service.rs`, `src/local_exchange.rs` — the one-destination refusal, the view-name
   pinning, and the `ExchangeFile` deletion; `DEMO.md` now claims the crossing it performs, and
   `streaming-sessions.md` retires the "expected sender population" not-here-yet item.
5. Tests: the translator suite asserts the exchange becomes a NamedTable read, that the declaration
   derives from the read's own schema, and that no file appears anywhere in the plan; the engine test
   (`engine_executes_local_files_and_sequential_exchange`, needs a GPU) asserts a sender parks (`run`
   returns `None`) and the receiver streams every row back out.

### Stack: part 10 of 12
- **Base:** `stream/09-cn-multifragment` (#1397)
- **Depends on:** part 9 (#1397) for the compute node it reshapes, part 8 (#1396) for the `ffi::Fragment` surface
