### PR TITLE
test(exec): adversarial coverage for the streaming boundary

### DIFF
--- a/experimental/starrocks/src/local_exchange.rs
+++ b/experimental/starrocks/src/local_exchange.rs
@@ -172,3 +172,217 @@ impl LocalExchange {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use starrocks_thrift::internal_service::InternalServiceVersion;
+
+    use super::*;
+
+    fn fiid(n: i64) -> FragmentInstanceId {
+        FragmentInstanceId::from_halves(0, n)
+    }
+
+    fn params() -> TExecPlanFragmentParams {
+        TExecPlanFragmentParams::new(
+            InternalServiceVersion::V1,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
+    fn output(receiver: FragmentInstanceId, node_id: i32, sender_id: i32) -> SenderOutput {
+        SenderOutput {
+            names: vec!["a".to_string()],
+            slot: SenderSlot {
+                fragment_instance_id: receiver,
+                node_id,
+                sender_id,
+            },
+        }
+    }
+
+    fn key(receiver: FragmentInstanceId, node_id: i32) -> ExchangeKey {
+        ExchangeKey {
+            fragment_instance_id: receiver,
+            node_id,
+        }
+    }
+
+    #[test]
+    fn a_receiver_completes_when_its_last_sender_arrives() {
+        let exchange = LocalExchange::default();
+        let receiver = fiid(1);
+
+        assert!(
+            exchange
+                .register_receiver(receiver, vec![(7, 2)], params())
+                .unwrap()
+                .is_none(),
+            "no sender has produced yet"
+        );
+        assert!(
+            exchange
+                .push_sender(key(receiver, 7), 0, output(receiver, 7, 0))
+                .unwrap()
+                .is_none(),
+            "one of two senders is not a complete set"
+        );
+
+        let ready = exchange
+            .push_sender(key(receiver, 7), 1, output(receiver, 7, 1))
+            .unwrap()
+            .expect("second sender completes the set");
+        assert_eq!(ready.inputs.len(), 1);
+        assert_eq!(ready.inputs[0].node_id, 7);
+        assert_eq!(ready.inputs[0].outputs.len(), 2);
+    }
+
+    #[test]
+    fn senders_that_arrive_first_park_until_the_receiver_registers() {
+        let exchange = LocalExchange::default();
+        let receiver = fiid(2);
+
+        // StarRocks dispatches receiver-first, but nothing guarantees the CN observes that
+        // order; a sender completing before registration must park, not vanish.
+        assert!(
+            exchange
+                .push_sender(key(receiver, 3), 0, output(receiver, 3, 0))
+                .unwrap()
+                .is_none()
+        );
+
+        let ready = exchange
+            .register_receiver(receiver, vec![(3, 1)], params())
+            .unwrap()
+            .expect("registration finds the parked sender");
+        assert_eq!(ready.inputs[0].outputs[0].slot.sender_id, 0);
+    }
+
+    #[test]
+    fn a_duplicate_sender_id_is_rejected_not_counted() {
+        let exchange = LocalExchange::default();
+        let receiver = fiid(3);
+
+        exchange
+            .register_receiver(receiver, vec![(5, 2)], params())
+            .unwrap();
+        exchange
+            .push_sender(key(receiver, 5), 0, output(receiver, 5, 0))
+            .unwrap();
+
+        // A retransmit counted as a second sender would mark the set complete and run the
+        // receiver with half its input missing.
+        let err = exchange
+            .push_sender(key(receiver, 5), 0, output(receiver, 5, 0))
+            .unwrap_err();
+        assert!(err.contains("duplicate sender"), "{err}");
+    }
+
+    #[test]
+    fn malformed_receiver_registrations_are_rejected() {
+        let exchange = LocalExchange::default();
+
+        let err = exchange
+            .register_receiver(fiid(4), vec![], params())
+            .unwrap_err();
+        assert!(err.contains("no exchange inputs"), "{err}");
+
+        let err = exchange
+            .register_receiver(fiid(4), vec![(1, 0)], params())
+            .unwrap_err();
+        assert!(err.contains("expects no senders"), "{err}");
+
+        let err = exchange
+            .register_receiver(fiid(4), vec![(1, 1), (1, 2)], params())
+            .unwrap_err();
+        assert!(err.contains("duplicate exchange node"), "{err}");
+
+        exchange
+            .register_receiver(fiid(4), vec![(1, 1)], params())
+            .unwrap();
+        let err = exchange
+            .register_receiver(fiid(4), vec![(2, 1)], params())
+            .unwrap_err();
+        assert!(err.contains("duplicate receiver"), "{err}");
+    }
+
+    #[test]
+    fn more_senders_than_expected_is_an_error_not_a_ready_fragment() {
+        let exchange = LocalExchange::default();
+        let receiver = fiid(5);
+
+        // A second exchange (node 8) keeps the receiver pending, so the surplus on node 9 is
+        // observed rather than the exact match consuming the receiver first.
+        exchange
+            .register_receiver(receiver, vec![(9, 2), (8, 1)], params())
+            .unwrap();
+        exchange
+            .push_sender(key(receiver, 9), 0, output(receiver, 9, 0))
+            .unwrap();
+        exchange
+            .push_sender(key(receiver, 9), 1, output(receiver, 9, 1))
+            .unwrap();
+        // Readiness is exact-match: the surplus sender means the plan and the dispatch
+        // disagree about the world, and running anyway would silently drop its output.
+        let err = exchange
+            .push_sender(key(receiver, 9), 2, output(receiver, 9, 2))
+            .unwrap_err();
+        assert!(err.contains("expected 2"), "{err}");
+    }
+
+    #[test]
+    fn ready_inputs_and_outputs_come_back_sorted() {
+        let exchange = LocalExchange::default();
+        let receiver = fiid(6);
+
+        exchange
+            .register_receiver(receiver, vec![(11, 2), (4, 1)], params())
+            .unwrap();
+        // Arrival order scrambled on purpose: readiness must not depend on it, and the
+        // returned order must be deterministic for the sequential executor.
+        exchange
+            .push_sender(key(receiver, 11), 1, output(receiver, 11, 1))
+            .unwrap();
+        exchange
+            .push_sender(key(receiver, 4), 0, output(receiver, 4, 0))
+            .unwrap();
+        let ready = exchange
+            .push_sender(key(receiver, 11), 0, output(receiver, 11, 0))
+            .unwrap()
+            .expect("all sender sets complete");
+
+        let node_ids: Vec<i32> = ready.inputs.iter().map(|input| input.node_id).collect();
+        assert_eq!(node_ids, vec![4, 11]);
+        let sender_ids: Vec<i32> = ready.inputs[1]
+            .outputs
+            .iter()
+            .map(|output| output.slot.sender_id)
+            .collect();
+        assert_eq!(sender_ids, vec![0, 1]);
+    }
+}

--- a/test/cpp/exec/test_streaming_fragment.cpp
+++ b/test/cpp/exec/test_streaming_fragment.cpp
@@ -30,9 +30,12 @@
 #include <utils/sirius_test_env.hpp>
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
+#include <thread>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -529,6 +532,243 @@ TEST_CASE_METHOD(fragment_fixture,
     // Every value from every batch: a receiver that ran one task and stopped would return the
     // first batch's rows and look like a plausible partial success.
     REQUIRE(drain_values(receiver, 1) == std::vector<std::int32_t>{1, 2, 3, 4, 5, 6});
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}
+
+namespace {
+
+//! Joins on every exit path. A test that throws past a live producer thread would terminate();
+//! this keeps the failure a failure instead of an abort.
+struct thread_joiner {
+  std::thread& t;
+  ~thread_joiner()
+  {
+    if (t.joinable()) { t.join(); }
+  }
+};
+
+//! Build and run `query` as a sender fragment inside its own window, then hand back everything
+//! it parked. The staged batches are how the live-producer and fan-in tests get real GPU batches
+//! without touching the memory manager directly.
+std::vector<std::shared_ptr<cucascade::data_batch>> staged_batches_of(
+  duckdb::Connection& con, duckdb::SiriusContext& sirius_ctx, const char* query)
+{
+  fragment_spec spec;
+  spec.plan_source = sirius::test::sql_plan_source(query);
+  spec.outputs     = {0};
+  streaming_fragment sender(*con.context, std::move(spec));
+
+  query_window window(sirius_ctx, *con.context, "frag_stage_sender");
+  sender.build(window.query_id());
+  sender.run();
+  window.finish();
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> staged;
+  while (auto batch = sender.session().pull(0)) {
+    staged.push_back(*batch);
+  }
+  return staged;
+}
+
+}  // namespace
+
+// ============================================================================
+// FRAG-6: a live producer pushes while run() executes.
+//
+// Every earlier FRAG case pre-fills and closes the stream before run(); a
+// concurrent compute node does neither. This is the first fragment-level
+// exercise of the source's persistent on_data hook under a real pipeline:
+// run() starts against an open, EMPTY stream, the pipeline parks, and each
+// push must re-nominate the source or run() never returns.
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-6: a producer pushing during run() is drained to the last value",
+                 "[integration][streaming_fragment]")
+{
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  con->BeginTransaction();
+  try {
+    // Disjoint halves again (cf. FRAG-5): two staged batches, so at least one push lands while
+    // the pipeline is already parked, not merely before the first task.
+    auto staged = staged_batches_of(*con, *sirius_ctx, "SELECT a FROM (VALUES (1), (2), (3)) t(a)");
+    auto second = staged_batches_of(*con, *sirius_ctx, "SELECT a FROM (VALUES (4), (5), (6)) t(a)");
+    staged.insert(staged.end(), second.begin(), second.end());
+    REQUIRE(staged.size() >= 2);
+
+    fragment_spec receiver_spec;
+    receiver_spec.plan_source =
+      sirius::test::sql_plan_source("SELECT a FROM sirius_stream_source(0)");
+    receiver_spec.inputs[0] = stream_input_spec{
+      {"a"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      {0}};
+    receiver_spec.outputs = {1};
+    streaming_fragment receiver(*con->context, std::move(receiver_spec));
+
+    query_window receiver_window(*sirius_ctx, *con->context, "frag6_receiver");
+    receiver.build(receiver_window.query_id());
+
+    // Catch2 assertions are not thread-safe; the producer records refusals and the main thread
+    // asserts after the join.
+    std::atomic<bool> push_refused{false};
+    std::thread producer([&] {
+      for (const auto& batch : staged) {
+        // Long enough for run() to start, drain what exists, and park between pushes.
+        std::this_thread::sleep_for(std::chrono::milliseconds(30));
+        if (!receiver.session().push(0, batch)) { push_refused.store(true); }
+      }
+      receiver.session().close_input(0, 0);
+    });
+    thread_joiner join_producer{producer};
+
+    // Blocks until the stream ends -- which only happens if every live push re-armed the
+    // pipeline and the producer's close was seen. A lost wake-up hangs here, not later.
+    receiver.run();
+    producer.join();
+    receiver_window.finish();
+
+    REQUIRE_FALSE(push_refused.load());
+    REQUIRE(drain_values(receiver, 1) == std::vector<std::int32_t>{1, 2, 3, 4, 5, 6});
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}
+
+// ============================================================================
+// FRAG-7: fan-in with two DISTINCT sender ids, and the duplicate-close attack.
+//
+// FRAG-5 pushed two senders' batches under one sender id and one close. This
+// is the property the sender *set* exists for: with senders {0, 1}, a repeated
+// close from sender 0 must not end the stream -- a plain counter would, and
+// the rows sender 1 had not yet pushed would silently never arrive.
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-7: a duplicated close from one sender cannot end a fan-in stream",
+                 "[integration][streaming_fragment]")
+{
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  con->BeginTransaction();
+  try {
+    auto first  = staged_batches_of(*con, *sirius_ctx, "SELECT a FROM (VALUES (1), (2), (3)) t(a)");
+    auto second = staged_batches_of(*con, *sirius_ctx, "SELECT a FROM (VALUES (4), (5), (6)) t(a)");
+    REQUIRE_FALSE(first.empty());
+    REQUIRE_FALSE(second.empty());
+
+    fragment_spec receiver_spec;
+    receiver_spec.plan_source =
+      sirius::test::sql_plan_source("SELECT a FROM sirius_stream_source(0)");
+    receiver_spec.inputs[0] = stream_input_spec{
+      {"a"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      {0, 1}};
+    receiver_spec.outputs = {1};
+    streaming_fragment receiver(*con->context, std::move(receiver_spec));
+
+    query_window receiver_window(*sirius_ctx, *con->context, "frag7_receiver");
+    receiver.build(receiver_window.query_id());
+
+    for (const auto& batch : first) {
+      REQUIRE(receiver.session().push(0, batch));
+    }
+    receiver.session().close_input(0, 0);
+    // The attack: close sender 0 again. Idempotent per identity -- if this advanced the stream,
+    // the push below would be refused and sender 1's rows would be lost.
+    REQUIRE_NOTHROW(receiver.session().close_input(0, 0));
+
+    for (const auto& batch : second) {
+      // Still open: only sender 1's close may end it.
+      REQUIRE(receiver.session().push(0, batch));
+    }
+    receiver.session().close_input(0, 1);
+
+    receiver.run();
+    receiver_window.finish();
+
+    REQUIRE(drain_values(receiver, 1) == std::vector<std::int32_t>{1, 2, 3, 4, 5, 6});
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}
+
+// ============================================================================
+// FRAG-8: a fragment whose plan reads TWO stream inputs.
+//
+// task_scheduler::start_query() kicks off only scans.front(), so the second
+// STREAMING_SOURCE is reached the way the probe side of any join is: when
+// the pipeline it depends on finishes, notify_downstream_pipelines()
+// schedules the blocked consumer, and get_operator_for_next_task() walks the
+// consumer's WAITING_FOR_INPUT_DATA hints back to this source; batches
+// arriving after that re-nominate it through the on_data hook. (The
+// task creator's lookahead queue also holds scans.begin()+1, but feeds tasks
+// only under the non-default lookahead strategy -- this test runs the
+// notification chain.) Pins that a two-stream plan actually drains both:
+// the shape a shuffle-consuming fragment will have.
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-8: a fragment reading two stream inputs drains both",
+                 "[integration][streaming_fragment]")
+{
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  con->BeginTransaction();
+  try {
+    auto left  = staged_batches_of(*con, *sirius_ctx, "SELECT a FROM (VALUES (1), (2), (3)) t(a)");
+    auto right = staged_batches_of(*con, *sirius_ctx, "SELECT b FROM (VALUES (2), (3), (4)) t(b)");
+    REQUIRE_FALSE(left.empty());
+    REQUIRE_FALSE(right.empty());
+
+    fragment_spec receiver_spec;
+    receiver_spec.plan_source = sirius::test::sql_plan_source(
+      "SELECT s0.a FROM sirius_stream_source(0) s0 JOIN sirius_stream_source(1) s1 "
+      "ON s0.a = s1.b");
+    receiver_spec.inputs[0] = stream_input_spec{
+      {"a"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      {0}};
+    receiver_spec.inputs[1] = stream_input_spec{
+      {"b"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      {0}};
+    receiver_spec.outputs = {2};
+    streaming_fragment receiver(*con->context, std::move(receiver_spec));
+
+    query_window receiver_window(*sirius_ctx, *con->context, "frag8_receiver");
+    receiver.build(receiver_window.query_id());
+
+    for (const auto& batch : left) {
+      REQUIRE(receiver.session().push(0, batch));
+    }
+    receiver.session().close_input(0, 0);
+    for (const auto& batch : right) {
+      REQUIRE(receiver.session().push(1, batch));
+    }
+    receiver.session().close_input(1, 0);
+
+    receiver.run();
+    receiver_window.finish();
+
+    // The join's answer identifies which streams were read: {2, 3} requires values from BOTH
+    // sides. A starved second source would hang run() or produce an empty (or one-sided) result.
+    REQUIRE(drain_values(receiver, 2) == std::vector<std::int32_t>{2, 3});
 
     con->Rollback();
   } catch (...) {

--- a/test/cpp/operator/test_physical_streaming_sink.cpp
+++ b/test/cpp/operator/test_physical_streaming_sink.cpp
@@ -760,3 +760,45 @@ TEST_CASE("streaming_sink PART-7: destination list and spec are validated", "[st
   REQUIRE_THROWS_AS(op->drained(2), sirius::invalid_input_exception);
   REQUIRE_THROWS_AS(op->availability(2), sirius::invalid_input_exception);
 }
+
+// ============================================================================
+// PART-8: a batch arriving after end-of-stream is refused on every partition
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-8: a partitioned push after end-of-stream publishes nothing",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 2;
+  auto [op, repos]        = make_partitioned_sink(N);
+
+  const std::vector<int64_t> keys{1, 2, 3, 4};
+  const std::vector<int32_t> vals{10, 20, 30, 40};
+  sink_one(*op,
+           make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  op->finalize_operator();
+
+  // Drain to a clean end on every partition first, so anything appearing below is unambiguously
+  // the late batch.
+  std::size_t drained_rows = 0;
+  for (std::size_t i = 0; i < N; ++i) {
+    drained_rows += drain_rows(*op, i).size();
+    REQUIRE(op->drained(i));
+  }
+  REQUIRE(drained_rows == keys.size());
+
+  // The late arrival. Same disaster class as SINK-ERR on the single path: rows that vanish
+  // behind a consumer that already saw end-of-stream would make a partial shuffle look like a
+  // clean one. The sink must refuse the slices (and warn), never publish them.
+  sink_one(*op,
+           make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+
+  for (std::size_t i = 0; i < N; ++i) {
+    REQUIRE(op->availability(i) == availability::END_OF_STREAM);
+    REQUIRE(op->drained(i));
+    REQUIRE_FALSE(op->pull(i).has_value());
+  }
+}


### PR DESCRIPTION
New work, not a port — the integration branch never wrote these tests either. Part 11 of a twelve-PR
stack.

**What.** Four gaps this stack inherited: the live-producer path was never exercised (every fragment
test pre-filled and closed its stream before `run()`), fan-in was untested at fragment level,
`LocalExchange` had zero direct tests, and the K=2 receiver risk (`start_query()` schedules only
`scans.front()` — would a plan with two stream inputs starve the second?) was unverified. All four are
retired here, plus one log-only fix the last of them pins.

**Design: the signature failure is silent success.** A crash names itself; a lost batch produces a
smaller correct-looking answer. Every case is built so the failure it hunts cannot pass — assertions
are exact values, never counts (`drain_values` compares the full sorted vector, so a dropped,
duplicated, or corrupted batch fails on content where a row count could still balance).

- **FRAG-6 overlaps the producer with `run()` for real.** A thread pushes staged GPU batches 30 ms
  apart while the main thread sits inside `run()` — the first exercise of the persistent `on_data`
  re-arm under the real driver. A lost wake-up hangs the test rather than passing it; a mid-run
  refusal is recorded and asserted after the join.
- **FRAG-7 attacks the sender set with a duplicate close.** Senders `{0, 1}`, sender 0 closes twice,
  *then* sender 1's rows are pushed. A close-counter would have ended the stream at the second close
  and refused those pushes — a fan-in "completing" with one sender's rows silently gone.
- **FRAG-8 makes starvation unfakeable.** Two stream inputs feed a join whose answer, `{2, 3}`, is the
  intersection of the two sides; a starved second source either hangs `run()` or fails the assertion.
- **The LocalExchange surplus-sender case is staged so the error is observable** — a second exchange
  node keeps the receiver pending, otherwise the completing sender consumes it before the surplus
  arrives. The other five cover both arrival orders, duplicate-sender rejection, malformed
  registrations, and deterministic ready-set ordering.

**The K=2 risk did not materialize; no scheduler change was needed.** A non-front source is reached
the way any join's probe side already is — the finishing pipeline's `notify_downstream_pipelines()`
schedules the blocked consumer, `get_operator_for_next_task()` walks its WAITING hints back to the
ready source, and later batches re-nominate it through `on_data`. FRAG-8's header comment is the
engine-side record of that chain.

**The fix that rides along.** The partitioned sink dropped `[[nodiscard]] push()`'s return on its
slices. On N = 1 a refused push is warned about; on N > 1 it vanished — a partition that went terminal
early turns into rows that silently never arrive, with nothing in the log. Log-only, pinned by PART-8.

**Reading order.**
1. `test/cpp/exec/test_streaming_fragment.cpp` — FRAG-6/7/8; `staged_batches_of` is how the tests get
   real GPU batches to push, `thread_joiner` keeps a failing assertion a failure rather than a
   `terminate()`.
2. `experimental/starrocks/src/local_exchange.rs` — six rendezvous tests, pure Rust, no GPU.
3. `src/op/sirius_physical_streaming_sink.cpp` — the fix; 8 lines including a comment naming the
   failure.
4. `test/cpp/operator/test_physical_streaming_sink.cpp` — PART-8.

The C++ cases need a GPU; the Rust cases run under `cargo test --no-default-features`, which is what
CI has. FRAG-6 is timing-shaped in the benign direction only: if the producer finishes before `run()`
parks, it degrades toward FRAG-2's pre-filled shape and still verifies values — it can under-stress
the re-arm property, never false-pass it.

### Stack: part 11 of 12
- **Base:** `stream/10-native-crossing` (#1398)
- **Depends on:** part 10 (#1398) for `LocalExchange` in its post-crossing shape; #1324 / #1322 for the code
  under test
