### PR TITLE
fix(s3): surface object ETags so DuckDB 1.5.5 caches S3 reads again

### DIFF
--- a/src/include/io/rest/rest_reactor.hpp
+++ b/src/include/io/rest/rest_reactor.hpp
@@ -62,6 +62,15 @@ struct footer_probe {
   std::size_t object_size{0};
   std::size_t window_lo{0};
   std::shared_ptr<const std::vector<std::uint8_t>> bytes;
+  // ETag from the verified 206, quotes preserved; empty otherwise.
+  std::string etag;
+};
+
+/// Result of a blocking HEAD: the object's size plus its ETag when the server
+/// sent one (quotes preserved, empty otherwise).
+struct head_object_result {
+  std::size_t object_size{0};
+  std::string etag;
 };
 
 // ---------------------------------------------------------------------------
@@ -271,15 +280,15 @@ class rest_reactor {
   /// Synchronous buffered host read (blocking ranged GET).  Blocks the caller.
   size_t host_read(const io_object_type& file, size_t offset, size_t size, uint8_t* dst);
 
-  /// Blocking HEAD to discover an object's size.  Used by the ioctx to build
-  /// an @c rest_io_object.  @p bucket / @p key identify the object.
-  size_t head_object_size(std::string_view bucket, std::string_view key);
+  /// Blocking HEAD to discover an object's size and ETag.  Used by the ioctx to
+  /// build an @c rest_io_object.  @p bucket / @p key identify the object.
+  head_object_result head_object_size(std::string_view bucket, std::string_view key);
 
   /// Blocking suffix-range GET of the last @p n bytes of an object, resolving
   /// the size and stashing the parquet footer in a single round-trip.  On a
   /// well-formed 206 the returned @c footer_probe carries the object size, the
-  /// window origin, and the trailing bytes; on any unusable response (200 full
-  /// body, missing / unsatisfied Content-Range) @c bytes is null so the caller
+  /// window origin, the trailing bytes, and the ETag; on any unusable response
+  /// (200 full body, missing / unsatisfied Content-Range) @c bytes is null so the caller
   /// falls back to a HEAD.  @p bucket / @p key identify the object.
   footer_probe fetch_footer_suffix(std::string_view bucket, std::string_view key, std::size_t n);
 

--- a/src/include/io/rest/rest_reactor.hpp
+++ b/src/include/io/rest/rest_reactor.hpp
@@ -86,8 +86,13 @@ struct head_object_result {
  */
 class rest_io_object : public sirius_io_object {
  public:
-  rest_io_object(std::string path, std::string bucket, std::string key, size_t size)
-    : _path(std::move(path)), _bucket(std::move(bucket)), _key(std::move(key)), _file_size(size)
+  rest_io_object(
+    std::string path, std::string bucket, std::string key, size_t size, std::string etag = {})
+    : _path(std::move(path)),
+      _bucket(std::move(bucket)),
+      _key(std::move(key)),
+      _file_size(size),
+      _etag(std::move(etag))
   {
   }
 
@@ -99,19 +104,22 @@ class rest_io_object : public sirius_io_object {
                  std::string key,
                  size_t object_size,
                  size_t window_lo,
-                 std::shared_ptr<const std::vector<std::uint8_t>> stash)
+                 std::shared_ptr<const std::vector<std::uint8_t>> stash,
+                 std::string etag = {})
     : _path(std::move(path)),
       _bucket(std::move(bucket)),
       _key(std::move(key)),
       _file_size(object_size),
       _window_lo(window_lo),
-      _stash(std::move(stash))
+      _stash(std::move(stash)),
+      _etag(std::move(etag))
   {
   }
 
   [[nodiscard]] const std::string& raw_file_cache_id() const noexcept override { return _path; }
   [[nodiscard]] const std::string& object_path() const noexcept override { return _path; }
   [[nodiscard]] size_t size() const noexcept override { return _file_size; }
+  [[nodiscard]] std::string_view validation_etag() const noexcept override { return _etag; }
 
   [[nodiscard]] const std::string& bucket() const noexcept { return _bucket; }
   [[nodiscard]] const std::string& key() const noexcept { return _key; }
@@ -133,6 +141,7 @@ class rest_io_object : public sirius_io_object {
   size_t _file_size{0};
   size_t _window_lo{0};
   std::shared_ptr<const std::vector<std::uint8_t>> _stash;
+  std::string _etag;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/include/io/s3/sirius_httpfs.hpp
+++ b/src/include/io/s3/sirius_httpfs.hpp
@@ -87,6 +87,11 @@ class sirius_httpfs : public duckdb::FileSystem {
 
   int64_t GetFileSize(duckdb::FileHandle& handle) override;
   duckdb::timestamp_t GetLastModifiedTime(duckdb::FileHandle& handle) override;
+  /// The object's ETag captured by this handle's open (HEAD or footer-probe
+  /// GET), or empty when the backend sent none.  DuckDB's external file cache
+  /// reads it once per caching handle as the validation token; an empty tag
+  /// keeps the safe (uncached) bypass.
+  std::string GetVersionTag(duckdb::FileHandle& handle) override;
 
   /// Exact key: returns @c {path} when @ref CanHandleFile. A glob pattern
   /// expands via one paginated S3 LIST (see @ref expand_glob) under four

--- a/src/include/io/types.hpp
+++ b/src/include/io/types.hpp
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace sirius::io {
@@ -92,6 +93,13 @@ class sirius_io_object : public std::enable_shared_from_this<sirius_io_object> {
   /// Total size of the underlying object, populated by the reactor at
   /// construction time and stored on the io_object thereafter.
   [[nodiscard]] virtual size_t size() const noexcept = 0;
+
+  /// Opaque validation tag associated with this open (the HTTP ETag for
+  /// object-store backends, quotes preserved); empty when unavailable.
+  /// Consumers compare it only for equality against a tag they captured
+  /// earlier; an empty tag disables validation-based caching above —
+  /// degraded performance, never wrong bytes.
+  [[nodiscard]] virtual std::string_view validation_etag() const noexcept { return {}; }
 };
 
 class sirius_io_object_metadata {

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -164,9 +164,9 @@ std::shared_ptr<sirius_io_object> rest_ioctx::create_io_object(std::string path)
   // A blocking HEAD on the caller thread (a one-time metadata round-trip) via
   // any reactor's authorizer — head_object_size uses a local easy handle and
   // does not touch worker state, so any reactor is equivalent.
-  size_t const size = _reactors.front()->head_object_size(parsed.host, parsed.path);
+  auto head = _reactors.front()->head_object_size(parsed.host, parsed.path);
   return std::make_shared<rest_io_object>(
-    std::move(path), std::move(parsed.host), std::move(parsed.path), size);
+    std::move(path), std::move(parsed.host), std::move(parsed.path), head.object_size);
 }
 
 std::shared_ptr<sirius_io_object> rest_ioctx::create_io_object(std::string path, open_hint hint)
@@ -209,9 +209,9 @@ std::shared_ptr<sirius_io_object> rest_ioctx::create_footer_probe_object(std::st
   if (!probe.bytes) {
     // Unusable suffix response (200 full body, 416, missing / "*" Content-Range):
     // fall back to a plain HEAD for the size, with no stash.
-    size_t const size = _reactors.front()->head_object_size(parsed.host, parsed.path);
+    auto head = _reactors.front()->head_object_size(parsed.host, parsed.path);
     return std::make_shared<rest_io_object>(
-      std::move(path), std::move(parsed.host), std::move(parsed.path), size);
+      std::move(path), std::move(parsed.host), std::move(parsed.path), head.object_size);
   }
   return std::make_shared<rest_io_object>(std::move(path),
                                           std::move(parsed.host),

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -165,8 +165,11 @@ std::shared_ptr<sirius_io_object> rest_ioctx::create_io_object(std::string path)
   // any reactor's authorizer — head_object_size uses a local easy handle and
   // does not touch worker state, so any reactor is equivalent.
   auto head = _reactors.front()->head_object_size(parsed.host, parsed.path);
-  return std::make_shared<rest_io_object>(
-    std::move(path), std::move(parsed.host), std::move(parsed.path), head.object_size);
+  return std::make_shared<rest_io_object>(std::move(path),
+                                          std::move(parsed.host),
+                                          std::move(parsed.path),
+                                          head.object_size,
+                                          std::move(head.etag));
 }
 
 std::shared_ptr<sirius_io_object> rest_ioctx::create_io_object(std::string path, open_hint hint)
@@ -210,15 +213,19 @@ std::shared_ptr<sirius_io_object> rest_ioctx::create_footer_probe_object(std::st
     // Unusable suffix response (200 full body, 416, missing / "*" Content-Range):
     // fall back to a plain HEAD for the size, with no stash.
     auto head = _reactors.front()->head_object_size(parsed.host, parsed.path);
-    return std::make_shared<rest_io_object>(
-      std::move(path), std::move(parsed.host), std::move(parsed.path), head.object_size);
+    return std::make_shared<rest_io_object>(std::move(path),
+                                            std::move(parsed.host),
+                                            std::move(parsed.path),
+                                            head.object_size,
+                                            std::move(head.etag));
   }
   return std::make_shared<rest_io_object>(std::move(path),
                                           std::move(parsed.host),
                                           std::move(parsed.path),
                                           probe.object_size,
                                           probe.window_lo,
-                                          probe.bytes);
+                                          probe.bytes,
+                                          std::move(probe.etag));
 }
 
 }  // namespace sirius::io::rest

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -143,10 +143,39 @@ size_t capture_header(char* buffer, size_t size, size_t nitems, void* userdata)
   return bytes;
 }
 
+/// True iff @p line is an HTTP status line ("HTTP/..."), i.e. the start of a
+/// (possibly interim) response's header block within one transfer.
+bool is_http_status_line(std::string_view line) noexcept
+{
+  return line.size() >= 5 && ascii_lower(line[0]) == 'h' && ascii_lower(line[1]) == 't' &&
+         ascii_lower(line[2]) == 't' && ascii_lower(line[3]) == 'p' && line[4] == '/';
+}
+
+/// Per-attempt capture for the blocking HEAD: Retry-After for backoff plus the
+/// object's ETag.  Separate from @c header_capture so the async data-GET path
+/// parses nothing it does not consume.  The ETag resets on every status line,
+/// so interim responses (proxy CONNECT) within one transfer leave no residue.
+struct head_capture {
+  std::string retry_after;
+  std::string etag;
+};
+
+size_t head_header_cb(char* buffer, size_t size, size_t nitems, void* userdata)
+{
+  auto* hc           = static_cast<head_capture*>(userdata);
+  size_t const bytes = size * nitems;
+  std::string_view const line(buffer, bytes);
+  if (is_http_status_line(line)) { hc->etag.clear(); }
+  if (auto v = match_header(line, "etag"); !v.empty()) { hc->etag = std::move(v); }
+  if (auto v = match_header(line, "retry-after"); !v.empty()) { hc->retry_after = std::move(v); }
+  return bytes;
+}
+
 /// Shared sink for a suffix-range footer probe: the header callback records the
-/// HTTP status (from the status line) plus Content-Range / Retry-After; the body
-/// callback consults @c status to abort a non-206 response before it streams a
-/// whole object into us.  @c HEADERDATA and @c WRITEDATA point at the same one.
+/// HTTP status (from the status line) plus Content-Range / Retry-After / ETag;
+/// the body callback consults @c status to abort a non-206 response before it
+/// streams a whole object into us.  @c HEADERDATA and @c WRITEDATA point at the
+/// same one.
 struct suffix_sink {
   std::vector<std::uint8_t> data;
   std::size_t cap{0};
@@ -154,18 +183,20 @@ struct suffix_sink {
   long status{0};
   std::string content_range;
   std::string retry_after;
+  std::string etag;
 };
 
 /// Header callback for a suffix probe: parse the status code out of the status
 /// line so the body callback can abort a non-206 early, and capture the headers
-/// the caller needs (Content-Range to verify the 206, Retry-After for backoff).
+/// the caller needs (Content-Range to verify the 206, Retry-After for backoff,
+/// ETag for the probe result).
 size_t suffix_header_cb(char* buffer, size_t size, size_t nitems, void* userdata)
 {
   auto* s            = static_cast<suffix_sink*>(userdata);
   size_t const bytes = size * nitems;
   std::string_view const line(buffer, bytes);
-  if (line.size() >= 5 && ascii_lower(line[0]) == 'h' && ascii_lower(line[1]) == 't' &&
-      ascii_lower(line[2]) == 't' && ascii_lower(line[3]) == 'p' && line[4] == '/') {
+  if (is_http_status_line(line)) {
+    s->etag.clear();
     if (auto const sp = line.find(' '); sp != std::string_view::npos) {
       long code = 0;
       for (size_t i = sp + 1; i < line.size() && line[i] >= '0' && line[i] <= '9'; ++i) {
@@ -176,6 +207,7 @@ size_t suffix_header_cb(char* buffer, size_t size, size_t nitems, void* userdata
   }
   if (auto v = match_header(line, "content-range"); !v.empty()) { s->content_range = std::move(v); }
   if (auto v = match_header(line, "retry-after"); !v.empty()) { s->retry_after = std::move(v); }
+  if (auto v = match_header(line, "etag"); !v.empty()) { s->etag = std::move(v); }
   return bytes;
 }
 
@@ -818,12 +850,12 @@ rest_perf_snapshot rest_reactor::perf_snapshot() const noexcept
   return s;
 }
 
-size_t rest_reactor::head_object_size(std::string_view bucket, std::string_view key)
+head_object_result rest_reactor::head_object_size(std::string_view bucket, std::string_view key)
 {
   s3::s3_object_ref const obj{std::string(bucket), std::string(key)};
   std::string last_error;
   for (std::size_t attempt = 0; attempt < _config.max_retry_attempts; ++attempt) {
-    header_capture hc;
+    head_capture hc;
     auto const authd =
       _ctx->authorizer()->authorize(obj, s3::s3_request_method::HEAD, presign_ttl(_config));
 
@@ -837,7 +869,7 @@ size_t rest_reactor::head_object_size(std::string_view bucket, std::string_view 
     SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_NOBODY, 1L));
     SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HTTPHEADER, hdrs.get()));
     SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_WRITEFUNCTION, &write_discard));
-    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HEADERFUNCTION, &capture_header));
+    SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HEADERFUNCTION, &head_header_cb));
     SIRIUS_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HEADERDATA, &hc));
 
     CURLcode const rc = curl_easy_perform(h.get());
@@ -852,7 +884,7 @@ size_t rest_reactor::head_object_size(std::string_view bucket, std::string_view 
         throw std::runtime_error("rest_reactor::head_object_size: missing Content-Length for " +
                                  obj.bucket + "/" + obj.key);
       }
-      return static_cast<size_t>(cl);
+      return head_object_result{static_cast<size_t>(cl), std::move(hc.etag)};
     }
 
     last_error =
@@ -1015,6 +1047,7 @@ footer_probe rest_reactor::fetch_footer_suffix(std::string_view bucket,
         probe.object_size = *total;
         probe.window_lo   = *start;
         probe.bytes       = std::make_shared<const std::vector<std::uint8_t>>(std::move(sink.data));
+        probe.etag        = std::move(sink.etag);
       }
       return probe;
     } else if (status == 200 || status == 416) {

--- a/src/io/s3/sirius_httpfs.cpp
+++ b/src/io/s3/sirius_httpfs.cpp
@@ -57,13 +57,16 @@ class sirius_httpfs_file_handle : public duckdb::FileHandle {
                             std::string path,
                             duckdb::FileOpenFlags flags,
                             std::shared_ptr<sirius::io::sirius_datasource> datasource)
-    : duckdb::FileHandle(fs, std::move(path), flags), datasource_(std::move(datasource))
+    : duckdb::FileHandle(fs, std::move(path), flags),
+      datasource_(std::move(datasource)),
+      version_tag_(datasource_->io_object().validation_etag())
   {
   }
 
   void Close() override {}
 
   std::shared_ptr<sirius::io::sirius_datasource> datasource_;
+  std::string version_tag_;
   duckdb::idx_t cursor_{0};
 };
 
@@ -323,6 +326,11 @@ int64_t sirius_httpfs::GetFileSize(duckdb::FileHandle& handle)
 duckdb::timestamp_t sirius_httpfs::GetLastModifiedTime(duckdb::FileHandle& /*handle*/)
 {
   return duckdb::timestamp_t(0);
+}
+
+std::string sirius_httpfs::GetVersionTag(duckdb::FileHandle& handle)
+{
+  return as_httpfs_handle(handle).version_tag_;
 }
 
 duckdb::vector<duckdb::OpenFileInfo> sirius_httpfs::Glob(const std::string& path,

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -255,6 +255,9 @@ struct range_fault_policy {
   bool unknown_content_range_total{false};
   bool ignore_range_with_200{false};
   bool fail_suffix_with_416{false};
+  std::string failed_get_etag;
+  std::string successful_get_etag;
+  std::string successful_head_etag;
 };
 
 struct listed_object {
@@ -362,6 +365,11 @@ class range_http_server {
   }
 
  private:
+  static void append_etag_header(std::string& response, std::string const& etag)
+  {
+    if (!etag.empty()) { response += "\r\nETag: " + etag; }
+  }
+
   struct active_get_guard {
     explicit active_get_guard(range_http_server& server) : _server(server)
     {
@@ -507,9 +515,9 @@ class range_http_server {
         send_all(fd, response);
         return;
       }
-      std::string response =
-        "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size()) +
-        "\r\nConnection: close\r\n\r\n";
+      std::string response = "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size());
+      append_etag_header(response, _fault.successful_head_etag);
+      response += "\r\nConnection: close\r\n\r\n";
       send_all(fd, response);
       return;
     }
@@ -528,9 +536,10 @@ class range_http_server {
 
     auto const get_idx = _get_count.fetch_add(1, std::memory_order_relaxed);
     if (_fault.fail_all_gets || get_idx < _fault.fail_first_gets) {
-      std::string response =
-        "HTTP/1.1 " + std::to_string(_fault.fail_status) +
-        " Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+      std::string response = "HTTP/1.1 " + std::to_string(_fault.fail_status) +
+                             " Service Unavailable\r\nContent-Length: 0";
+      append_etag_header(response, _fault.failed_get_etag);
+      response += "\r\nConnection: close\r\n\r\n";
       send_all(fd, response);
       return;
     }
@@ -545,8 +554,9 @@ class range_http_server {
       }
       if (_fault.ignore_range_with_200 && is_suffix_range(request)) {
         std::string response =
-          "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size()) +
-          "\r\nConnection: close\r\n\r\n";
+          "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size());
+        append_etag_header(response, _fault.successful_get_etag);
+        response += "\r\nConnection: close\r\n\r\n";
         send_all(fd, response);
         send_body(fd, _object.data(), _object.size());
         return;
@@ -559,14 +569,16 @@ class range_http_server {
           "\r\nContent-Range: bytes " + std::to_string(start) + "-" + std::to_string(end) + "/" +
           (_fault.unknown_content_range_total ? std::string{"*"} : std::to_string(_object.size()));
       }
+      append_etag_header(response, _fault.successful_get_etag);
       response += "\r\nConnection: close\r\n\r\n";
       send_all(fd, response);
       send_body(fd, _object.data() + start, len);
       return;
     }
 
-    std::string response = "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size()) +
-                           "\r\nConnection: close\r\n\r\n";
+    std::string response = "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size());
+    append_etag_header(response, _fault.successful_get_etag);
+    response += "\r\nConnection: close\r\n\r\n";
     send_all(fd, response);
     send_body(fd, _object.data(), _object.size());
   }
@@ -1705,12 +1717,14 @@ TEST_CASE("footer suffix probe falls back safely on unusable suffix responses",
   {
     range_fault_policy fault{};
     fault.ignore_range_with_200 = true;
+    fault.successful_get_etag   = "\"discarded-200-tag\"";
     range_http_server server(parquet, fault);
     auto ioctx      = make_direct_rest_ioctx(server.endpoint());
     auto datasource = ioctx->open_datasource("s3://footer-bucket/nation.parquet",
                                              sirius::io::open_hint::parquet_footer_probe);
     REQUIRE(datasource != nullptr);
     CHECK(datasource->size() == parquet.size());
+    CHECK(datasource->io_object().validation_etag().empty());
     CHECK(server.head_count() == 1);
     CHECK(server.get_count() == 1);
   }
@@ -1790,6 +1804,7 @@ TEST_CASE("footer suffix probe retries transient GET failures",
     range_fault_policy fault{};
     fault.fail_first_gets = 2;
     fault.fail_status     = 503;
+    fault.failed_get_etag = "\"stale-retry-tag\"";
     range_http_server server(parquet, fault);
     auto authorizer             = std::make_shared<fixed_url_authorizer>(server.endpoint());
     auto cfg                    = direct_rest_test_config();
@@ -1803,6 +1818,7 @@ TEST_CASE("footer suffix probe retries transient GET failures",
 
     CHECK(probe.object_size == parquet.size());
     CHECK(probe.window_lo == 0);
+    CHECK(probe.etag.empty());
     REQUIRE(probe.bytes != nullptr);
     CHECK(probe.bytes->size() == parquet.size());
     CHECK(server.head_count() == 0);
@@ -1871,7 +1887,9 @@ TEST_CASE("footer suffix probe retries transient GET failures",
 
   SECTION("clean 206 has no retry or terminal-failure telemetry")
   {
-    range_http_server server(parquet);
+    range_fault_policy fault{};
+    fault.successful_get_etag = "\"footer-v1\"";
+    range_http_server server(parquet, fault);
     auto authorizer             = std::make_shared<fixed_url_authorizer>(server.endpoint());
     auto cfg                    = direct_rest_test_config();
     cfg.max_retry_attempts      = 3;
@@ -1884,6 +1902,7 @@ TEST_CASE("footer suffix probe retries transient GET failures",
 
     CHECK(probe.object_size == parquet.size());
     CHECK(probe.window_lo == 0);
+    CHECK(probe.etag == "\"footer-v1\"");
     REQUIRE(probe.bytes != nullptr);
     CHECK(probe.bytes->size() == parquet.size());
     CHECK(server.head_count() == 0);
@@ -1902,8 +1921,9 @@ TEST_CASE("HEAD object-size retries update REST perf counters",
   SECTION("transient 503s are retried and the final HEAD returns the size")
   {
     range_fault_policy fault{};
-    fault.fail_first_heads = 2;
-    fault.fail_head_status = 503;
+    fault.fail_first_heads     = 2;
+    fault.fail_head_status     = 503;
+    fault.successful_head_etag = "\"head-v2\"";
     range_http_server server(payload, fault);
     auto authorizer             = std::make_shared<fixed_url_authorizer>(server.endpoint());
     auto cfg                    = direct_rest_test_config();
@@ -1913,7 +1933,9 @@ TEST_CASE("HEAD object-size retries update REST perf counters",
       cfg, std::move(authorizer), nullptr);
     sirius::io::rest::rest_reactor reactor(ctx, "head-retry-success");
 
-    CHECK(reactor.head_object_size("head-bucket", "head-success.bin") == payload.size());
+    auto const result = reactor.head_object_size("head-bucket", "head-success.bin");
+    CHECK(result.object_size == payload.size());
+    CHECK(result.etag == "\"head-v2\"");
     CHECK(server.head_count() == 3);
     CHECK(server.get_count() == 0);
     auto const perf = reactor.perf_snapshot();
@@ -1989,7 +2011,9 @@ TEST_CASE("HEAD object-size retries update REST perf counters",
       cfg, std::move(authorizer), nullptr);
     sirius::io::rest::rest_reactor reactor(ctx, "head-clean");
 
-    CHECK(reactor.head_object_size("head-bucket", "head-clean.bin") == payload.size());
+    auto const result = reactor.head_object_size("head-bucket", "head-clean.bin");
+    CHECK(result.object_size == payload.size());
+    CHECK(result.etag.empty());
     CHECK(server.head_count() == 1);
     CHECK(server.get_count() == 0);
     auto const perf = reactor.perf_snapshot();
@@ -2043,7 +2067,7 @@ TEST_CASE("REST retry logging includes object keys and stays quiet on clean requ
     scoped_log_capture logs;
     auto probe = reactor.fetch_footer_suffix("log-bucket", "clean.parquet", 1024);
     REQUIRE(probe.bytes != nullptr);
-    CHECK(reactor.head_object_size("log-bucket", "clean.parquet") == payload.size());
+    CHECK(reactor.head_object_size("log-bucket", "clean.parquet").object_size == payload.size());
 
     auto const records        = logs.records();
     auto const warning_or_bad = std::any_of(records.begin(), records.end(), [](auto const& r) {

--- a/test/cpp/io/s3/test_sirius_httpfs.cpp
+++ b/test/cpp/io/s3/test_sirius_httpfs.cpp
@@ -14,12 +14,20 @@
 #include "sirius_extension.hpp"
 #include "utils/s3_container.hpp"
 
+#include <arpa/inet.h>
 #include <duckdb.hpp>
 #include <duckdb/common/file_system.hpp>
 #include <duckdb/common/open_file_info.hpp>
+#include <duckdb/storage/buffer/buffer_handle.hpp>
+#include <duckdb/storage/caching_file_system.hpp>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
+#include <atomic>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -28,6 +36,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -116,6 +125,109 @@ std::string thrown_message(Fn&& fn)
   return {};
 }
 
+class head_http_server {
+ public:
+  explicit head_http_server(std::size_t object_size, std::string etag = {})
+    : object_size_(object_size), etag_(std::move(etag))
+  {
+    listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (listen_fd_ < 0) { throw std::runtime_error("socket failed: " + errno_message()); }
+    int one = 1;
+    if (::setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) != 0) {
+      throw std::runtime_error("setsockopt failed: " + errno_message());
+    }
+
+    sockaddr_in addr{};
+    addr.sin_family      = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port        = 0;
+    if (::bind(listen_fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+      throw std::runtime_error("bind failed: " + errno_message());
+    }
+    if (::listen(listen_fd_, 4) != 0) {
+      throw std::runtime_error("listen failed: " + errno_message());
+    }
+    socklen_t len = sizeof(addr);
+    if (::getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&addr), &len) != 0) {
+      throw std::runtime_error("getsockname failed: " + errno_message());
+    }
+    port_   = ntohs(addr.sin_port);
+    thread_ = std::thread([this] { accept_loop(); });
+  }
+
+  ~head_http_server()
+  {
+    stop_.store(true);
+    if (listen_fd_ >= 0) {
+      ::shutdown(listen_fd_, SHUT_RDWR);
+      ::close(listen_fd_);
+    }
+    if (thread_.joinable()) { thread_.join(); }
+  }
+
+  head_http_server(head_http_server const&)            = delete;
+  head_http_server& operator=(head_http_server const&) = delete;
+
+  [[nodiscard]] std::string endpoint() const { return "http://127.0.0.1:" + std::to_string(port_); }
+  [[nodiscard]] std::size_t head_count() const { return head_count_.load(); }
+
+ private:
+  static std::string errno_message() { return std::strerror(errno); }
+
+  static void send_all(int fd, std::string_view response)
+  {
+    std::size_t sent = 0;
+    while (sent < response.size()) {
+      auto const n = ::send(fd, response.data() + sent, response.size() - sent, MSG_NOSIGNAL);
+      if (n <= 0) { return; }
+      sent += static_cast<std::size_t>(n);
+    }
+  }
+
+  void accept_loop()
+  {
+    while (!stop_.load()) {
+      sockaddr_in client{};
+      socklen_t len = sizeof(client);
+      auto const fd = ::accept(listen_fd_, reinterpret_cast<sockaddr*>(&client), &len);
+      if (fd < 0) {
+        if (stop_.load()) { return; }
+        continue;
+      }
+      handle_client(fd);
+      ::close(fd);
+    }
+  }
+
+  void handle_client(int fd)
+  {
+    std::string request(4096, '\0');
+    auto const n = ::recv(fd, request.data(), request.size(), 0);
+    if (n <= 0) { return; }
+    request.resize(static_cast<std::size_t>(n));
+    if (request.rfind("HEAD ", 0) != 0) {
+      send_all(fd,
+               "HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 0\r\nConnection: "
+               "close\r\n\r\n");
+      return;
+    }
+
+    head_count_.fetch_add(1);
+    auto response = "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(object_size_);
+    if (!etag_.empty()) { response += "\r\nETag: " + etag_; }
+    response += "\r\nConnection: close\r\n\r\n";
+    send_all(fd, response);
+  }
+
+  std::size_t object_size_;
+  std::string etag_;
+  int listen_fd_{-1};
+  std::uint16_t port_{0};
+  std::atomic<bool> stop_{false};
+  std::atomic<std::size_t> head_count_{0};
+  std::thread thread_;
+};
+
 std::string read_text_file(fs::path const& path)
 {
   std::ifstream in(path);
@@ -138,7 +250,7 @@ void load_sirius_extension(duckdb::DuckDB& db)
 
 class sirius_httpfs_config_env_guard {
  public:
-  explicit sirius_httpfs_config_env_guard(s3_test_env const& env)
+  explicit sirius_httpfs_config_env_guard(s3_test_env const& env, bool perf_instrumentation = false)
   {
     if (auto* current = std::getenv("SIRIUS_CONFIG_FILE"); current != nullptr) {
       had_original_config_env_ = true;
@@ -173,6 +285,7 @@ class sirius_httpfs_config_env_guard {
            "        block_size: 1 MiB\n"
            "  executor:\n"
            "    scan_manager:\n"
+           "      enable_prefetch_cache: false\n"
            "      object_store:\n"
            "        endpoint: "
         << yaml_quote(env.endpoint)
@@ -190,6 +303,7 @@ class sirius_httpfs_config_env_guard {
            "      rest:\n"
            "        max_connections: 8\n"
            "        request_timeout_s: 30\n";
+    if (perf_instrumentation) { out << "        perf_instrumentation: true\n"; }
     out.close();
     REQUIRE(out);
 
@@ -224,7 +338,8 @@ class sirius_httpfs_config_env_guard {
 
 class sirius_httpfs_fixture {
  public:
-  explicit sirius_httpfs_fixture(s3_test_env const& env) : config_env(env), db(nullptr), con(db)
+  explicit sirius_httpfs_fixture(s3_test_env const& env, bool perf_instrumentation = false)
+    : config_env(env, perf_instrumentation), db(nullptr), con(db)
   {
     load_sirius_extension(db);
     REQUIRE(con.context->registered_state->Get<duckdb::SiriusContext>("sirius_state"));
@@ -469,6 +584,116 @@ TEST_CASE("sirius_httpfs positional reads fail on short reads and negative sizes
 
   std::vector<std::uint8_t> whole_object(static_cast<std::size_t>(size));
   CHECK_THROWS_AS(fs.Read(*handle, whole_object.data(), -1, 0), duckdb::IOException);
+}
+
+TEST_CASE("sirius_httpfs exposes S3 ETags as DuckDB version tags",
+          "[.][s3][integration][filesystem][efc]")
+{
+  SECTION("plain and glob opens preserve the quoted MinIO ETag")
+  {
+    auto env = read_s3_test_env();
+    if (skip_if_no_s3_env(env)) { return; }
+
+    sirius_httpfs_fixture fixture(*env);
+    set_gpu_execution(fixture.con, true);
+    auto& fs       = duckdb::FileSystem::GetFileSystem(*fixture.con.context);
+    auto const uri = s3_uri(env->bucket, "parquet/nation.parquet");
+
+    auto plain = fs.OpenFile(uri, duckdb::FileFlags::FILE_FLAGS_READ);
+    REQUIRE(plain != nullptr);
+    auto const plain_tag = plain->file_system.GetVersionTag(*plain);
+    REQUIRE(plain_tag.size() >= 2);
+    CHECK(plain_tag.front() == '"');
+    CHECK(plain_tag.back() == '"');
+
+    auto matches = fs.Glob(s3_uri(env->bucket, "parquet/nation*.parquet"));
+    REQUIRE(matches.size() == 1);
+    REQUIRE(matches[0].extended_info != nullptr);
+    auto glob = fs.OpenFile(matches[0], duckdb::FileFlags::FILE_FLAGS_READ);
+    REQUIRE(glob != nullptr);
+    auto const glob_tag = glob->file_system.GetVersionTag(*glob);
+    REQUIRE(glob_tag.size() >= 2);
+    CHECK(glob_tag.front() == '"');
+    CHECK(glob_tag.back() == '"');
+    CHECK(glob_tag == plain_tag);
+  }
+
+  SECTION("an ETag-free backend keeps the version tag empty")
+  {
+    head_http_server server(4096);
+    s3_test_env env{server.endpoint(), "us-east-1", "access", "secret", "bucket"};
+    sirius_httpfs_fixture fixture(env);
+    set_gpu_execution(fixture.con, true);
+    auto& fs = duckdb::FileSystem::GetFileSystem(*fixture.con.context);
+
+    auto handle = fs.OpenFile("s3://bucket/no-etag.bin", duckdb::FileFlags::FILE_FLAGS_READ);
+
+    REQUIRE(handle != nullptr);
+    CHECK(handle->GetFileSize() == 4096);
+    CHECK(handle->file_system.GetVersionTag(*handle).empty());
+    CHECK(server.head_count() == 1);
+  }
+}
+
+TEST_CASE("DuckDB external file cache invalidates an overwritten S3 range by ETag",
+          "[.][s3][integration][filesystem][efc]")
+{
+  auto env = read_s3_test_env();
+  if (skip_if_no_s3_env(env)) { return; }
+
+  constexpr std::size_t object_size = 4096;
+  constexpr std::size_t read_offset = 128;
+  constexpr std::size_t read_size   = 512;
+  std::vector<std::uint8_t> first(object_size);
+  std::vector<std::uint8_t> second(object_size);
+  for (std::size_t i = 0; i < object_size; ++i) {
+    first[i]  = static_cast<std::uint8_t>((i * 17U + 3U) & 0xffU);
+    second[i] = static_cast<std::uint8_t>((i * 29U + 11U) & 0xffU);
+  }
+
+  std::string const key = "efc/overwrite-invalidation.bin";
+  if (!sirius::test::put_s3_container_object(key, first)) {
+    SUCCEED("managed MinIO is required for the overwrite invalidation test");
+    return;
+  }
+
+  sirius_httpfs_fixture fixture(*env, /*perf_instrumentation=*/true);
+  set_gpu_execution(fixture.con, true);
+  require_query_ok(fixture.con, "SET enable_external_file_cache = true");
+  auto const uri = s3_uri(env->bucket, key);
+
+  auto routed_datasource = require_rest_datasource(fixture, uri);
+  auto* rest = dynamic_cast<sirius::io::rest::rest_ioctx*>(routed_datasource->io_ctx().get());
+  REQUIRE(rest != nullptr);
+
+  auto caching_fs        = duckdb::CachingFileSystem::Get(*fixture.con.context);
+  auto read_cached_range = [&] {
+    auto handle =
+      caching_fs.OpenFile(duckdb::OpenFileInfo{uri}, duckdb::FileFlags::FILE_FLAGS_READ);
+    duckdb::data_ptr_t data = nullptr;
+    auto pin                = handle->Read(data, read_size, read_offset);
+    REQUIRE(data != nullptr);
+    return std::vector<std::uint8_t>(data, data + read_size);
+  };
+
+  auto first_read = read_cached_range();
+  CHECK(std::equal(first_read.begin(), first_read.end(), first.begin() + read_offset));
+
+  auto cache_rows = require_query_ok(
+    fixture.con,
+    "SELECT count(*) FROM duckdb_external_file_cache() WHERE path = " + sql_quote(uri) +
+      " AND loaded AND location <= " + std::to_string(read_offset) +
+      " AND location + nr_bytes >= " + std::to_string(read_offset + read_size));
+  REQUIRE(cache_rows->RowCount() == 1);
+  CHECK(cache_rows->GetValue(0, 0).GetValue<std::int64_t>() >= 1);
+
+  REQUIRE(sirius::test::put_s3_container_object(key, second));
+  auto const before_second = rest->perf_snapshot();
+  auto second_read         = read_cached_range();
+  auto const after_second  = rest->perf_snapshot();
+
+  CHECK(after_second.chunk_get_count > before_second.chunk_get_count);
+  CHECK(std::equal(second_read.begin(), second_read.end(), second.begin() + read_offset));
 }
 
 TEST_CASE("transparent read_parquet over S3 routes through Sirius without httpfs",

--- a/test/cpp/utils/s3_container.cpp
+++ b/test/cpp/utils/s3_container.cpp
@@ -62,8 +62,10 @@ extern "C" {
 #include <ctime>
 #include <filesystem>
 #include <iostream>
+#include <memory>
 #include <mutex>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <thread>
 #include <utility>
@@ -741,6 +743,46 @@ bool ensure_s3_container_env()
     g_state = 2;  // best-effort: skip
     return false;
   }
+}
+
+bool put_s3_container_object(std::string_view key, std::span<std::uint8_t const> bytes)
+{
+  if (g_state != 1) { return false; }
+
+  auto endpoint         = env_or("SIRIUS_TEST_S3_ENDPOINT");
+  auto const scheme_end = endpoint.find("://");
+  if (scheme_end == std::string::npos) {
+    throw std::runtime_error("managed MinIO endpoint has no URI scheme");
+  }
+  auto const scheme = endpoint.substr(0, scheme_end);
+  auto authority    = endpoint.substr(scheme_end + 3);
+  if (scheme != "http" || authority.empty() || authority.find('/') != std::string::npos) {
+    throw std::runtime_error("managed MinIO object PUT requires the HTTP endpoint");
+  }
+
+  std::unique_ptr<std::FILE, decltype(&std::fclose)> body(std::tmpfile(), &std::fclose);
+  if (!body) { throw std::runtime_error("cannot create temporary S3 upload body"); }
+  auto const written = std::fwrite(bytes.data(), 1, bytes.size(), body.get());
+  if (written != bytes.size()) {
+    throw std::runtime_error("cannot write temporary S3 upload body");
+  }
+  std::rewind(body.get());
+
+  minio_instance instance;
+  instance.endpoint  = std::move(endpoint);
+  instance.authority = std::move(authority);
+  auto const bucket  = env_or("SIRIUS_TEST_S3_BUCKET", kBucket);
+  auto const code    = s3_put(instance,
+                           scheme,
+                           uri_path_for(bucket, std::string{key}),
+                           body.get(),
+                           static_cast<std::int64_t>(bytes.size()),
+                           std::nullopt);
+  if (!(code == 200 || code == 204)) {
+    throw std::runtime_error("managed MinIO object PUT failed for '" + std::string{key} +
+                             "' (HTTP " + std::to_string(code) + ")");
+  }
+  return true;
 }
 
 void shutdown_s3_container_env()

--- a/test/cpp/utils/s3_container.hpp
+++ b/test/cpp/utils/s3_container.hpp
@@ -16,6 +16,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <span>
+#include <string_view>
+
 namespace sirius::test {
 
 /**
@@ -48,6 +52,14 @@ namespace sirius::test {
  * @return true if the [s3] tests should run (env is ready), false to skip.
  */
 bool ensure_s3_container_env();
+
+/**
+ * @brief PUT a small object into the managed HTTP MinIO instance.
+ *
+ * @return false when the S3 environment is externally managed; throws on an
+ * upload failure.
+ */
+bool put_s3_container_object(std::string_view key, std::span<std::uint8_t const> bytes);
 
 /**
  * @brief Terminate the MinIO containers started by @ref ensure_s3_container_env.


### PR DESCRIPTION
## Problem

DuckDB 1.5.5 no longer caches external files without validation metadata. `sirius_httpfs` returned neither a version tag nor a usable modification time, so S3 reads bypassed DuckDB's external file cache and went back to the network.

The existing footer-bind tests exposed this as three blocking GETs per glob scan instead of zero.

## Fix

Use the S3 object's ETag as DuckDB's version tag:

- Capture the ETag from the existing HEAD and validated 206 footer-probe responses.
- Keep retry attempts isolated. A 200, 416, or invalid 206 discards the probe tag; the fallback HEAD supplies both size and tag.
- Store the ETag on `rest_io_object` and return it through `sirius_httpfs::GetVersionTag`.
- Preserve the quoted ETag. If no ETag is available, DuckDB keeps its safe uncached behavior.
- Leave `GetLastModifiedTime` unchanged.

This adds no network requests and does not touch the asynchronous column-chunk read path.

## Tests

- The existing footer-bind regression checks pass unchanged.
- Covered HEAD, suffix-probe, missing-ETag, retry, and fallback behavior.
- Verified EFC invalidation by caching a range, overwriting the object with same-size different bytes, then checking for a new backend GET and the new contents. Sirius prefetch is disabled in this test to isolate DuckDB's EFC.

## Validation

- Full Catch2: 2,317 cases, 32,706,601 assertions
- `make s3-test`: 92/92, 31,433 assertions
- `s3-test-large`: 5/5 + 3/3
- `s3-bench`: passed
- `pre-commit --all-files`: passed
- `git diff --check`: passed

## Follow-up

The reactor and `io_object` parts must be ported to cuCascade before the #1340 pin update. `sirius_httpfs::GetVersionTag` remains in Sirius.
