### PR TITLE
feat(duckdb): backport enable_optimistic_write setting from duckdb#24194

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "duckdb"]
 	path = duckdb
-	url = https://github.com/duckdb/duckdb
-	branch = main
+	url = https://github.com/sirius-db/duckdb
+	branch = v1.5.5-patches
 	ignore = dirty
 [submodule "substrait"]
 	path = substrait


### PR DESCRIPTION
<!-- Edit PR title: "<type>[optional scope]: <short description>", see CONTRIBUTING.md for guidance -->

## Description
<!-- Provide a standalone description of changes in this PR -->
<!-- For design docs targeting docs/experimental, note this in the description -->
Switches our `/duckdb` submodule from `duckdb/duckdb` with branch `main` pointing to `v1.5.5` release tag to `v1.5.5-patches` branch of `sirius-db/duckdb` to enable backporting of duckdb#24194. This feature is not released, so this is our way of being able to test this new feature in development builds.

⚠️ **THIS FEATURE WILL NOT WORK OUTSIDE OF DEV**
The patched DuckDB we are using will only be availble in development as we need to build it from source. Those running Sirius using the pre-built DuckDB packages with `pixi` will not see this feature. If this is needed we will need to build the patched versions of DuckDB and update `pixi` to use them instead of `conda-forge`

✅ Distribution [workflow](https://github.com/sirius-db/sirius/actions/runs/30939939982) passed, testing this change

## Checklist
- [x] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
<!-- Add open issues with "Closes #issue" to close or "Refs #issue" for reference, and any relevant URLs -->
