### PR TITLE
fix(regex): make specialized URL replacement equivalent to libcudf

### DIFF
--- a/src/expression_evaluator/regex/regex_playground.cpp
+++ b/src/expression_evaluator/regex/regex_playground.cpp
@@ -16,12 +16,37 @@
 
 #include "expression_evaluator/regex/regex_playground.hpp"
 
+#include <cudf/reduction.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/strings/find.hpp>
+#include <cudf/strings/regex/regex_program.hpp>
+#include <cudf/strings/replace_re.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+
 namespace sirius {
 namespace regex {
 
 std::unique_ptr<cudf::column> regex_playground::jit_transform_clickbench_q28_regex(
-  const cudf::column_view& input)
+  const cudf::column_view& input, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
 {
+  // libcudf's $ anchor matches before one final LF. Replacing that match retains the unmatched LF,
+  // which a string-view transform cannot synthesize after extracting a non-contiguous domain.
+  // Route the whole batch through the generic implementation when any row ends in LF.
+  auto final_newline_rows = cudf::strings::ends_with(
+    cudf::strings_column_view(input), cudf::string_scalar("\n", true, stream, mr), stream, mr);
+  auto any_final_newline = cudf::reduce(final_newline_rows->view(),
+                                        *cudf::make_any_aggregation<cudf::reduce_aggregation>(),
+                                        cudf::data_type{cudf::type_id::BOOL8},
+                                        stream,
+                                        mr);
+  auto const& any_final_newline_scalar =
+    static_cast<cudf::scalar_type_t<bool> const&>(*any_final_newline);
+  if (any_final_newline_scalar.is_valid(stream) && any_final_newline_scalar.value(stream)) {
+    auto regex_prog = cudf::strings::regex_program::create(R"(^https?://(?:www\.)?([^/]+)/.*$)");
+    return cudf::strings::replace_with_backrefs(
+      cudf::strings_column_view(input), *regex_prog, R"(\1)", stream, mr);
+  }
+
   auto udf = R"***(
 __device__ void extract_domain(cuda::std::optional<cudf::string_view>* out, cuda::std::optional<cudf::string_view> const url_opt) {
     // Skip null
@@ -50,7 +75,9 @@ __device__ void extract_domain(cuda::std::optional<cudf::string_view>* out, cuda
     next = next.substr(3, next.length() - 3);
 
     // For "(?:www\.)?"
-    if (next.length() >= 4 && next[0] == 'w' && next[1] == 'w' && next[2] == 'w' && next[3] == '.') {
+    // Only consume the optional prefix when the required ([^/]+) group will remain non-empty.
+    // Otherwise the generic regex engine backtracks and captures "www." as the host.
+    if (next.length() > 4 && next[0] == 'w' && next[1] == 'w' && next[2] == 'w' && next[3] == '.' && next[4] != '/') {
         next = next.substr(4, next.length() - 4);
     }
 
@@ -66,12 +93,14 @@ __device__ void extract_domain(cuda::std::optional<cudf::string_view>* out, cuda
     }
     *out = next.substr(0, pos);
 
-    // For "/.*", a newline ('\n') will trigger mismatch
+    // For "/.*", an internal newline triggers a mismatch. A final newline is handled by the
+    // batch-level generic fallback above because libcudf's $ anchor preserves it.
     next = next.substr(pos + 1, next.length() - pos - 1);
     if (next.find('\n') != cudf::string_view::npos) {
         *out = url;
         return;
     }
+
 }
 )***";
 
@@ -81,7 +110,11 @@ __device__ void extract_domain(cuda::std::optional<cudf::string_view>* out, cuda
                                   cudf::data_type{cudf::type_id::STRING},
                                   cudf::udf_source_type::CUDA,
                                   std::nullopt,
-                                  cudf::null_aware::YES);
+                                  cudf::null_aware::YES,
+                                  std::nullopt,
+                                  cudf::output_nullability::PRESERVE,
+                                  stream,
+                                  mr);
 }
 
 }  // namespace regex

--- a/src/expression_evaluator/specializations/function.cpp
+++ b/src/expression_evaluator/specializations/function.cpp
@@ -363,16 +363,15 @@ evaluate_result expression_evaluator::evaluate(sirius::ast::function_call const&
 
     auto const& pattern_str = std::get<std::string>(args[1]->get<sirius::ast::constant>().payload);
     auto const& replace_str = std::get<std::string>(args[2]->get<sirius::ast::constant>().payload);
-    auto regex_prog         = cudf::strings::regex_program::create(std::string_view(pattern_str));
-
     auto const has_backrefs = std::regex_search(replace_str, std::regex(R"(\\[0-9])"));
     if (has_backrefs) {
       if (duckdb::Config::ENABLE_REGEX_JIT_IMPL) {
         if (pattern_str == R"(^https?://(?:www\.)?([^/]+)/.*$)" && replace_str == R"(\1)") {
           return ::sirius::regex::regex_playground::jit_transform_clickbench_q28_regex(
-            input.get_column_view());
+            input.get_column_view(), _stream, _mr);
         }
       }
+      auto regex_prog = cudf::strings::regex_program::create(std::string_view(pattern_str));
       return cudf::strings::replace_with_backrefs(
         cudf::strings_column_view(input.get_column_view()),
         *regex_prog,
@@ -380,6 +379,7 @@ evaluate_result expression_evaluator::evaluate(sirius::ast::function_call const&
         _stream,
         _mr);
     } else {
+      auto regex_prog = cudf::strings::regex_program::create(std::string_view(pattern_str));
       return cudf::strings::replace_re(cudf::strings_column_view(input.get_column_view()),
                                        *regex_prog,
                                        cudf::string_scalar(replace_str, true, _stream, _mr),

--- a/src/include/expression_evaluator/regex/regex_playground.hpp
+++ b/src/include/expression_evaluator/regex/regex_playground.hpp
@@ -21,6 +21,7 @@
 #include <cudf/transform.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
 
 namespace sirius {
 namespace regex {
@@ -28,7 +29,9 @@ namespace regex {
 class regex_playground {
  public:
   static std::unique_ptr<cudf::column> jit_transform_clickbench_q28_regex(
-    const cudf::column_view& input);
+    const cudf::column_view& input,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr);
 };
 
 }  // namespace regex

--- a/test/cpp/integration/test_transparent_runtime_fallback.cpp
+++ b/test/cpp/integration/test_transparent_runtime_fallback.cpp
@@ -21,6 +21,7 @@
 // failure, distinct from a plan-time (create_plan) fallback.
 
 #include <catch.hpp>
+#include <config.hpp>
 #include <duckdb.hpp>
 #include <duckdb/main/client_context.hpp>
 #include <fcntl.h>
@@ -183,6 +184,105 @@ class RuntimeFallbackFixture {
 };
 
 }  // namespace
+
+TEST_CASE_METHOD(RuntimeFallbackFixture,
+                 "transparent execution: specialized regex matches generic implementation",
+                 "[transparent][integration][regex-jit-differential]")
+{
+  struct regex_jit_restore_guard {
+    bool original;
+    ~regex_jit_restore_guard() { duckdb::Config::ENABLE_REGEX_JIT_IMPL = original; }
+  } restore_regex_jit{duckdb::Config::ENABLE_REGEX_JIT_IMPL};
+
+  create_table(R"SQL(
+    CREATE TABLE test_regex_jit_equivalence AS
+    SELECT * FROM (VALUES
+      (1,  'http://www.example.com/a'),
+      (2,  'https://sub.example.org/a/b?x=1'),
+      (3,  'http://www.example.com/'),
+      (4,  'https://www.www.example.com/path'),
+      (5,  'https://münich.example/über'),
+      (6,  'https://example.com'),
+      (7,  'ftp://example.com/path'),
+      (8,  'HTTPS://example.com/path'),
+      (9,  'http:///missing-host'),
+      (10, ''),
+      (11, NULL),
+      (12, 'http://www./x'),
+      (13, 'http://www.//x'),
+      (14, 'https://newline.example/' || chr(10) || 'tail'),
+      (15, 'http://a' || chr(10) || 'b/x')
+    ) AS cases(id, url)
+  )SQL");
+
+  create_table(R"SQL(
+    CREATE TABLE test_regex_jit_final_newline_fallback AS
+    SELECT * FROM (VALUES
+      (1, 'http://a/x' || chr(10))
+    ) AS cases(id, url)
+  )SQL");
+
+  auto run_with_specialized_regex = [this](bool enabled, std::string const& table) {
+    auto setting =
+      con->Query(std::string{"SET enable_regex_jit_impl = "} + (enabled ? "true" : "false"));
+    REQUIRE(setting != nullptr);
+    REQUIRE_FALSE(setting->HasError());
+    REQUIRE(duckdb::Config::ENABLE_REGEX_JIT_IMPL == enabled);
+
+    auto const before = sirius::test::get_transparent_execution_stats(*con);
+    auto query        = std::string{R"SQL(
+      SELECT regexp_replace(url, '^https?://(?:www\.)?([^/]+)/.*$', '\1') AS domain
+      FROM )SQL"} +
+                 table + R"SQL(
+      ORDER BY id
+    )SQL";
+    auto result = con->Query(query);
+    REQUIRE(result != nullptr);
+    if (result->HasError()) {
+      UNSCOPED_INFO("regex differential query failed: " << result->GetError());
+    }
+    REQUIRE_FALSE(result->HasError());
+    auto const after = sirius::test::get_transparent_execution_stats(*con);
+    sirius::test::require_transparent_execution_delta(before, after, 1, 0, 1);
+
+    std::vector<std::string> rows;
+    rows.reserve(result->RowCount());
+    for (duckdb::idx_t row = 0; row < result->RowCount(); ++row) {
+      rows.push_back(result->GetValue(0, row).ToString());
+    }
+    return rows;
+  };
+
+  auto const generic     = run_with_specialized_regex(false, "test_regex_jit_equivalence");
+  auto const specialized = run_with_specialized_regex(true, "test_regex_jit_equivalence");
+  REQUIRE(specialized == generic);
+
+  std::vector<std::string> const expected{
+    "example.com",
+    "sub.example.org",
+    "example.com",
+    "www.example.com",
+    "münich.example",
+    "https://example.com",
+    "ftp://example.com/path",
+    "HTTPS://example.com/path",
+    "http:///missing-host",
+    "",
+    "NULL",
+    "www.",
+    "www.",
+    "https://newline.example/\ntail",
+    "a\nb",
+  };
+  REQUIRE(specialized == expected);
+
+  auto const generic_final_newline =
+    run_with_specialized_regex(false, "test_regex_jit_final_newline_fallback");
+  auto const specialized_final_newline =
+    run_with_specialized_regex(true, "test_regex_jit_final_newline_fallback");
+  REQUIRE(specialized_final_newline == generic_final_newline);
+  REQUIRE(specialized_final_newline == std::vector<std::string>{"a\n"});
+}
 
 // A GPU failure at runtime completes the query on CPU and is counted as a runtime
 // fallback. Without injection the same query runs on the GPU.


### PR DESCRIPTION
## Description

The specialized implementation of ClickBench Q28's URL replacement diverged
from libcudf in two edge cases: it consumed the optional `www.` prefix when the
required host capture would otherwise be empty, and it did not preserve
libcudf's final-newline behavior for the `$` anchor.

This change:

- propagates the expression evaluator's CUDA stream and memory resource through
  the specialized path;
- delays generic regex-program construction until the generic branch is used;
- preserves a non-empty host capture when handling the optional `www.` prefix;
- routes final-newline batches through libcudf so replacement semantics remain
  equivalent; and
- adds a generic-versus-specialized differential test covering valid URLs,
  non-matches, nulls, Unicode, prefix backtracking, internal newlines, and final
  newlines.

This PR contains Super-Sirius behavioral correctness and test changes only. It
does not modify legacy Sirius, setting registration, documentation, test opt-in
policy, or the visibility of `enable_regex_jit_impl`.

Validation on the existing NVIDIA L4:

- Sirius `release` build: passed;
- `[transparent][integration][regex-jit-differential]`: 1 test case and all 51
  assertions passed;
- clean apply and `git diff --check`: passed; and
- the four-file change applied cleanly to live `dev` at
  `53b1eb9891a474f63579310f6afaab9a3f24c7db` (one unrelated S3 commit after the
  tested base).

This makes no performance claim.

## Checklist

- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description
      above (not applicable: no configuration changes)
- [x] Update human and agent documentation (not applicable: no user-facing
      configuration or workflow change)

## References

No linked issue.
