### PR TITLE
fix(gpu): derive planning and peer access from configured GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -741,6 +741,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_get_next_ports_after_sink.cpp
     test/cpp/pipeline/test_merge_pipeline_fusion.cpp
     test/cpp/pipeline/test_partition_build_pipelines.cpp
+    test/cpp/pipeline/test_pipeline_build_context.cpp
     test/cpp/pipeline/test_pipeline_dynamic_filter_native_shape.cpp
     test/cpp/pipeline/test_pipeline_schedule_canonical.cpp
     test/cpp/pipeline/test_plan_printer.cpp

--- a/docs/super-sirius/multi-gpu-architecture.md
+++ b/docs/super-sirius/multi-gpu-architecture.md
@@ -18,7 +18,9 @@ LOAD 'sirius.duckdb_extension';
 SELECT l_returnflag, SUM(l_quantity) FROM lineitem GROUP BY l_returnflag;
 ```
 
-The engine assumes a single process pinning all visible GPUs (`CUDA_VISIBLE_DEVICES` controls which GPUs Sirius can use). There is no notion of distributed multi-node execution in this codebase.
+The engine assumes a single process pinning the configured subset of visible GPUs
+(`CUDA_VISIBLE_DEVICES` bounds which GPUs Sirius can use; `sirius.topology` selects from that
+set). There is no notion of distributed multi-node execution in this codebase.
 
 ## Tier Hierarchy
 
@@ -238,7 +240,9 @@ After a downgrade frees enough space, the rescheduled task retries. The reservat
 
 - **Consumer-grade GPUs (e.g., RTX 6000 Ada Generation)** may advertise P2P peer access via `cudaDeviceCanAccessPeer` but silently fail actual DMA transfers. The empirical probe (`probe_peer_dma_works`) catches this at startup and routes affected pairs through host-staging.
 - **NUMA topology discovery** runs at startup. The `topology_discovery` component reads `/sys/class/drm/card*/device/numa_node` (and equivalents) to determine each GPU's NUMA node, then pairs each GPU with its NUMA-local host region. Without this, host-tier downgrade traffic crosses the NUMA boundary, halving effective bandwidth.
-- **`CUDA_VISIBLE_DEVICES`** is the canonical way to scope which GPUs Sirius uses. Setting it to `0` runs the engine in single-GPU mode (no distribution, no cross-GPU transfers); setting it to `0,1` enables full multi-GPU.
+- **`CUDA_VISIBLE_DEVICES`** scopes which GPUs Sirius may use. With the automatic topology
+  default, `CUDA_VISIBLE_DEVICES=0,1` enables both visible GPUs. Set `sirius.topology.num_gpus` to
+  use only a prefix of that visible set, or use `gpu_ids` to select a non-prefix subset.
 - **Single-process scope.** Sirius runs as a single OS process. Multi-process / multi-node execution is out of scope; the user is responsible for partitioning at a higher layer if needed.
 
 ## Key Source Files

--- a/src/include/pipeline/pipeline_build_context.hpp
+++ b/src/include/pipeline/pipeline_build_context.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <memory>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -39,20 +40,36 @@ class pipeline_build_context {
   //!        probes.
   //! @param preserve_insertion_order Whether query results must preserve
   //!        insertion order (from DuckDB's PreserveInsertionOrderSetting).
-  //! @param num_gpus Number of GPUs available for partition-floor heuristics.
+  //! @param num_gpus Number of GPUs available for partition-floor heuristics when constructing a
+  //!        context without an engine (primarily unit tests).
   //!        Enables sirius_pipeline_converter::configure_partition_min_partitions
   //!        to ensure big partition-consuming operators (hash_join,
   //!        merge_group_by) get at least num_gpus partitions to spread work.
   explicit pipeline_build_context(
     std::shared_ptr<const telemetry::telemetry_context> telemetry_context,
-    bool preserve_insertion_order   = true,
-    int num_gpus                    = 1,
-    std::vector<int> active_gpu_ids = {})
+    bool preserve_insertion_order = true,
+    int num_gpus                  = 1)
     : _telemetry_context(std::move(telemetry_context)),
       _preserve_insertion_order(preserve_insertion_order),
-      _num_gpus(num_gpus),
+      _num_gpus(num_gpus)
+  {
+  }
+
+  //! Construct an engine-backed context from the configured GPU set. The GPU count is derived
+  //! from the same ids used for execution routing, so planning cannot accidentally use the raw
+  //! hardware count when the Sirius config selected a subset of visible GPUs.
+  pipeline_build_context(std::shared_ptr<const telemetry::telemetry_context> telemetry_context,
+                         bool preserve_insertion_order,
+                         std::vector<int> active_gpu_ids)
+    : _telemetry_context(std::move(telemetry_context)),
+      _preserve_insertion_order(preserve_insertion_order),
       _active_gpu_ids(std::move(active_gpu_ids))
   {
+    if (_active_gpu_ids.empty()) {
+      throw std::invalid_argument(
+        "pipeline_build_context requires at least one configured GPU device id");
+    }
+    _num_gpus = static_cast<int>(_active_gpu_ids.size());
   }
 
   [[nodiscard]] bool preserve_insertion_order() const { return _preserve_insertion_order; }
@@ -61,7 +78,7 @@ class pipeline_build_context {
 
   //! Sorted, deduped device ids of the GPUs the query runs on — the same list task_creator routes
   //! partitions across. Used by broadcast join partitioning to map a probe batch's residence GPU
-  //! back to its partition slot. Empty when built without an engine (tests / single-GPU).
+  //! back to its partition slot. Empty only when built through the engine-free test constructor.
   [[nodiscard]] const std::vector<int>& active_gpu_ids() const { return _active_gpu_ids; }
 
   [[nodiscard]] const std::shared_ptr<const telemetry::telemetry_context>& telemetry_context() const

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -480,7 +480,7 @@ void sirius_pipeline_converter::link_join_partition_siblings()
 
 void sirius_pipeline_converter::configure_partition_min_partitions()
 {
-  // Pull num_gpus from the build context (populated from sirius_engine's hardware topology at
+  // Pull num_gpus from the build context (derived from sirius_engine's configured GPU set at
   // convert time). Single-GPU runs keep the consumer default of 1 (no-op). For multi-GPU we hand
   // num_gpus to each partition's downstream sizing consumer, which derives the partition floor and
   // small-table threshold internally (see natural_num_partitions / partition_small_table_bytes) and

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -57,6 +57,7 @@
 #include <sys/resource.h>
 #include <unistd.h>  // for isatty/fileno
 
+#include <algorithm>
 #include <cctype>
 #include <chrono>
 #include <cstddef>
@@ -535,8 +536,9 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
   config_ = config;
   // Validate the cached topology before any downstream construction so a stub
   // topology fails loudly rather than producing zero-GPU executors silently.
-  // get_hw_topology() is the only authorised source of GPU/NUMA counts —
-  // never call raw CUDA/NUMA device-enumeration APIs directly elsewhere.
+  // get_hw_topology() is the only authorised source of physical GPU/NUMA discovery — never call
+  // raw CUDA/NUMA device-enumeration APIs directly elsewhere. Configured execution GPU ids come
+  // from the memory manager built below.
   auto const& topo = config_.get_hw_topology();
   if (topo.num_gpus == 0) {
     throw std::runtime_error(
@@ -557,17 +559,18 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
 
   // Declare one telemetry device group per GPU so thread/queue telemetry can
   // nest under its device instead of piling up flat under the engine. The GPU
-  // memory space configs already reflect the configured topology.num_gpus /
-  // topology.gpu_ids selection, unlike the raw hardware topology.
-  std::vector<int> telemetry_gpu_ids;
-  for (auto const& space_config : config_.get_memory_space_configs()) {
-    if (auto const* gpu_config =
-          std::get_if<cucascade::memory::gpu_memory_space_config>(&space_config)) {
-      telemetry_gpu_ids.push_back(gpu_config->device_id);
-    }
+  // memory manager already reflects the configured topology.num_gpus / topology.gpu_ids
+  // selection, unlike the raw hardware topology.
+  std::vector<int> active_gpu_ids;
+  for (auto const* gpu_space :
+       memory_manager_->get_memory_spaces_for_tier(cucascade::memory::Tier::GPU)) {
+    if (gpu_space != nullptr) { active_gpu_ids.push_back(gpu_space->get_device_id()); }
   }
+  std::sort(active_gpu_ids.begin(), active_gpu_ids.end());
+  active_gpu_ids.erase(std::unique(active_gpu_ids.begin(), active_gpu_ids.end()),
+                       active_gpu_ids.end());
   telemetry_context_ = sirius::telemetry::telemetry_context::create(
-    config_.get_telemetry_config(), memory_manager_.get(), telemetry_gpu_ids);
+    config_.get_telemetry_config(), memory_manager_.get(), active_gpu_ids);
 
   if (config_.get_telemetry_config().enable_quent &&
       config_.get_telemetry_config().enable_batch_events) {
@@ -612,49 +615,48 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
   topology_index_ = std::make_shared<const sirius::memory::topology_index>(
     config_.get_hw_topology(), *memory_manager_);
 
-  // Enable P2P peer access for every available GPU pair.
+  // Enable P2P peer access for every configured GPU pair.
   // cucascade::convert_gpu_to_gpu calls cudaMemcpyPeerAsync on every GPU->GPU
   // conversion. For that call to bypass host staging, peer access must be
   // enabled ONCE at init for every (src, dst) pair the host supports.
   // Non-fatal failure mode: SIRIUS_LOG_ERROR and continue — host-staged fallback
   // in cucascade's converter is a correct alternate path.
   {
-    auto const& mgpu06_topo = config_.get_hw_topology();
-    if (mgpu06_topo.num_gpus >= 2) {
-      peer_access_enabled_pairs_.reserve(static_cast<size_t>(mgpu06_topo.num_gpus) *
-                                         (mgpu06_topo.num_gpus - 1));
-      for (unsigned i = 0; i < mgpu06_topo.num_gpus; ++i) {
-        rmm::cuda_set_device_raii guard_i{rmm::cuda_device_id{static_cast<int>(i)}};
-        for (unsigned j = 0; j < mgpu06_topo.num_gpus; ++j) {
-          if (i == j) continue;
+    if (active_gpu_ids.size() >= 2) {
+      peer_access_enabled_pairs_.reserve(active_gpu_ids.size() * (active_gpu_ids.size() - 1));
+      for (int source_device : active_gpu_ids) {
+        rmm::cuda_set_device_raii guard_i{rmm::cuda_device_id{source_device}};
+        for (int target_device : active_gpu_ids) {
+          if (source_device == target_device) continue;
           int can_access = 0;
           cudaError_t probe_err =
-            cudaDeviceCanAccessPeer(&can_access, static_cast<int>(i), static_cast<int>(j));
+            cudaDeviceCanAccessPeer(&can_access, source_device, target_device);
           if (probe_err != cudaSuccess) {
             SIRIUS_LOG_ERROR("SiriusContext: cudaDeviceCanAccessPeer({},{}) failed: {}",
-                             i,
-                             j,
+                             source_device,
+                             target_device,
                              cudaGetErrorString(probe_err));
             continue;
           }
           if (can_access == 0) {
-            SIRIUS_LOG_INFO(
-              "SiriusContext: no P2P access {} -> {} -- falling back to host staging", i, j);
+            SIRIUS_LOG_INFO("SiriusContext: no P2P access {} -> {} -- falling back to host staging",
+                            source_device,
+                            target_device);
             continue;
           }
-          cudaError_t enable_err = cudaDeviceEnablePeerAccess(static_cast<int>(j), 0);
+          cudaError_t enable_err = cudaDeviceEnablePeerAccess(target_device, 0);
           // Always consume sticky error state — cudaErrorPeerAccessAlreadyEnabled
           // (and any other non-fatal condition) persists in the runtime until
           // cudaGetLastError() is called, which would make the NEXT CUDA API
           // call fail spuriously in unrelated code (e.g., thrust::exclusive_scan).
           (void)cudaGetLastError();
           if (enable_err == cudaSuccess || enable_err == cudaErrorPeerAccessAlreadyEnabled) {
-            peer_access_enabled_pairs_.emplace(static_cast<int>(i), static_cast<int>(j));
-            SIRIUS_LOG_INFO("SiriusContext: P2P enabled {} -> {}", i, j);
+            peer_access_enabled_pairs_.emplace(source_device, target_device);
+            SIRIUS_LOG_INFO("SiriusContext: P2P enabled {} -> {}", source_device, target_device);
           } else {
             SIRIUS_LOG_ERROR("SiriusContext: cudaDeviceEnablePeerAccess({}) from ctx {} failed: {}",
-                             j,
-                             i,
+                             target_device,
+                             source_device,
                              cudaGetErrorString(enable_err));
           }
         }
@@ -662,8 +664,8 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
     } else {
       SIRIUS_LOG_INFO(
         "SiriusContext: skipping peer-access enable loop (num_gpus={}); "
-        "single-GPU host has no pairs to enable",
-        mgpu06_topo.num_gpus);
+        "configured GPU set has no pairs to enable",
+        active_gpu_ids.size());
     }
   }
 

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -220,7 +220,6 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
   const pipeline::pipeline_build_context build_ctx{
     sirius_ctx_ptr->get_telemetry_context(),
     duckdb::Settings::Get<duckdb::PreserveInsertionOrderSetting>(context),
-    static_cast<int>(sirius_ctx_ptr->get_config().get_hw_topology().gpus.size()),
     std::move(active_gpu_ids)};
 
   // The collector is added after planning, so refresh parent pointers before marking fusion.

--- a/test/cpp/pipeline/test_pipeline_build_context.cpp
+++ b/test/cpp/pipeline/test_pipeline_build_context.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "pipeline/pipeline_build_context.hpp"
+
+#include <stdexcept>
+#include <vector>
+
+TEST_CASE("Engine pipeline context derives GPU count from configured device ids",
+          "[sirius][pipeline][config]")
+{
+  std::vector<int> configured_gpu_ids{1, 3};
+  sirius::pipeline::pipeline_build_context context{nullptr, true, std::move(configured_gpu_ids)};
+
+  REQUIRE(context.num_gpus() == 2);
+  REQUIRE(context.active_gpu_ids() == std::vector<int>{1, 3});
+}
+
+TEST_CASE("Engine pipeline context rejects an empty configured GPU set",
+          "[sirius][pipeline][config]")
+{
+  REQUIRE_THROWS_AS(sirius::pipeline::pipeline_build_context(nullptr, true, std::vector<int>{}),
+                    std::invalid_argument);
+}
+
+TEST_CASE("Pipeline context retains explicit GPU counts for engine-free tests",
+          "[sirius][pipeline][config]")
+{
+  sirius::pipeline::pipeline_build_context context{nullptr, true, 3};
+
+  REQUIRE(context.num_gpus() == 3);
+  REQUIRE(context.active_gpu_ids().empty());
+}

--- a/test/cpp/utils/pipeline_conversion_test_utils.cpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.cpp
@@ -37,9 +37,11 @@
 #include <duckdb/parser/parser.hpp>
 #include <duckdb/planner/planner.hpp>
 
+#include <algorithm>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
+#include <vector>
 
 namespace sirius::test {
 
@@ -179,11 +181,21 @@ void with_conversion_result(
     }
     const auto& op_params = sirius_ctx_ptr->get_config().get_operator_params();
 
-    // Null telemetry context: no engine, per the pipeline_build_context ctor contract.
+    std::vector<int> active_gpu_ids;
+    for (auto const* space : sirius_ctx_ptr->get_memory_manager().get_memory_spaces_for_tier(
+           cucascade::memory::Tier::GPU)) {
+      if (space != nullptr) { active_gpu_ids.push_back(space->get_device_id()); }
+    }
+    std::sort(active_gpu_ids.begin(), active_gpu_ids.end());
+    active_gpu_ids.erase(std::unique(active_gpu_ids.begin(), active_gpu_ids.end()),
+                         active_gpu_ids.end());
+
+    // Null telemetry context: no engine, but derive planning width from the same configured GPU
+    // spaces as production so multi-visible-GPU hosts do not inflate single-GPU test plans.
     pipeline::pipeline_build_context build_ctx(
       /*telemetry_context=*/nullptr,
       duckdb::Settings::Get<duckdb::PreserveInsertionOrderSetting>(context),
-      static_cast<int>(sirius_ctx_ptr->get_config().get_hw_topology().gpus.size()));
+      std::move(active_gpu_ids));
 
     pipeline::sirius_pipeline_build_state state;
     auto root_pipeline =


### PR DESCRIPTION
## Summary

- derive planning width and active device IDs from the GPU memory spaces configured in the Sirius memory manager
- use the same configured device set for pipeline slots, telemetry groups, and peer-access enablement
- reject an empty engine-backed configured set while retaining explicit GPU counts for engine-free tests
- document visibility and configured activation as distinct concepts

## Why

Sirius can expose more GPUs through CUDA than the configured memory manager activates. Planning and peer-access setup currently use visible topology, so inactive devices can inflate pipeline width and introduce unnecessary peer-access requirements. This aligns those consumers with the configured source of truth.

## Validation

Validated from a clean checkout based exactly on `dev` `53b1eb9891a474f63579310f6afaab9a3f24c7db`:

- `/home/ubuntu/.pixi/bin/pixi run make -j8 release` — passed all `1277/1277` actions
- `sirius_unittest "[sirius][pipeline][config]"` — 5 assertions in 3 test cases passed
- `sirius_unittest "[integration][pipeline][partition_build]"` — 99 assertions in 3 test cases passed

## Scope

Validation ran on one NVIDIA L4. It proves the current-dev build, configured-set logic, and existing single-GPU selectors; it does not claim real configured-subset or peer-access behavior on a host with two or more GPUs. That remains the explicit multi-GPU follow-up.
