### PR TITLE
fix(config): honor loaded YAML defaults and reject zero hash partitions

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -352,7 +352,7 @@ batch default**. Each can still be overridden individually.
 | `scan_task_batch_size` | 2.5% of GPU mem (512 MiB – 5 GiB) | Target batch size for DuckDB scan tasks |
 | `enable_compressed_materialization` | true | Store eligible integer and fixed-point DECIMAL values in value-preserving narrower carriers when exact pin-time bounds permit it; restore native carriers at type-sensitive boundaries. |
 | `max_sort_partition_bytes` | 0 (auto) | Max bytes per sort partition. Auto = 33% of GPU memory. |
-| `hash_partition_bytes` | 2.5% of GPU mem (512 MiB – 5 GiB) | Target partition size for hash joins and group-bys |
+| `hash_partition_bytes` | 2.5% of GPU mem (512 MiB – 5 GiB) | Target partition size for hash joins and group-bys; must be greater than zero |
 | `concat_batch_bytes` | 2.5% of GPU mem (512 MiB – 5 GiB) | Target output batch size for CONCAT operator |
 | `sort_sample_bytes` | 2.5% of GPU mem (512 MiB – 5 GiB) | Bytes sampled before computing sort partition boundaries |
 | `max_build_hash_table_bytes` | 2× batch default | Max build-side size for BUILD_PROBE join mode |
@@ -544,7 +544,7 @@ SET enable_compressed_materialization = false;
 | `fuse_merge_pipelines` | true | Fuse eligible GROUP BY / TOP_N merges into their downstream pipeline instead of cutting a boundary (see [physical-plan-generation.md](physical-plan-generation.md) → Merge fusion) |
 | `max_sort_partition_bytes` | 0 (auto) | Max sort partition bytes |
 | `max_sort_partition_memory_fraction` | 0.33 | Auto sort-partition fraction when `max_sort_partition_bytes` is 0 |
-| `hash_partition_bytes` | 2.5% of GPU mem (512 MiB – 5 GiB) | Hash partition target size |
+| `hash_partition_bytes` | 2.5% of GPU mem (512 MiB – 5 GiB) | Hash partition target size; must be greater than zero |
 | `concat_batch_bytes` | 2.5% of GPU mem (512 MiB – 5 GiB) | CONCAT output batch size |
 | `sort_sample_bytes` | 2.5% of GPU mem (512 MiB – 5 GiB) | Bytes sampled before computing sort boundaries |
 | `max_build_hash_table_bytes` | 2× batch default | Max build-side hash table bytes |

--- a/src/include/op/sirius_physical_partition_consumer_operator.hpp
+++ b/src/include/op/sirius_physical_partition_consumer_operator.hpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <stdexcept>
 
 namespace sirius {
 namespace op {
@@ -65,6 +66,9 @@ struct partition_strategy {
                                                 uint64_t hash_partition_bytes,
                                                 int num_gpus)
 {
+  if (hash_partition_bytes == 0) {
+    throw std::invalid_argument("hash_partition_bytes must be greater than zero");
+  }
   int num_partitions =
     static_cast<int>(std::max(uint64_t{1},
                               total_bytes / hash_partition_bytes +

--- a/src/include/sirius_extension.hpp
+++ b/src/include/sirius_extension.hpp
@@ -25,7 +25,7 @@
 #include <utility>
 
 namespace sirius {
-struct operator_params;
+struct sirius_config;
 }  // namespace sirius
 
 namespace duckdb {
@@ -73,7 +73,7 @@ class SiriusExtension : public Extension {
   /// Register Sirius's extension options. @p defaults supplies the registered default for every
   /// option DuckDB stores per connection, so a sirius.yaml value reaches those connections as
   /// their inherited starting point instead of being shadowed by the compiled default.
-  static void InitialGPUConfigs(DBConfig& db, const sirius::operator_params& defaults);
+  static void InitialGPUConfigs(DBConfig& db, const sirius::sirius_config& defaults);
   static void RegisterGPUFunctions(DatabaseInstance& catalog);
 #ifdef SIRIUS_ENABLE_LEGACY
   static void GPUProcessingSubstraitFunction(ClientContext& context,

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -210,6 +210,9 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
              opt.max_sort_partition_memory_fraction,
              yaml::fraction<double>{});
   r.optional("hash_partition_bytes", yaml::bytes(opt.hash_partition_bytes));
+  if (opt.hash_partition_bytes == 0) {
+    throw std::runtime_error("'operator_params.hash_partition_bytes': must be greater than zero");
+  }
   r.optional("concat_batch_bytes", yaml::bytes(opt.concat_batch_bytes));
   r.optional("sort_sample_bytes", yaml::bytes(opt.sort_sample_bytes));
   r.optional("max_build_hash_table_bytes", yaml::bytes(opt.max_build_hash_table_bytes));

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1873,10 +1873,12 @@ static void SetMaxSortPartitionMemoryFraction(ClientContext& context,
 
 static void SetHashPartitionBytes(ClientContext& context, SetScope scope, Value& parameter)
 {
+  auto const bytes = UBigIntValue::Get(parameter);
+  if (bytes == 0) { throw InvalidInputException("hash_partition_bytes must be greater than zero"); }
   auto* params = get_operator_params(context);
   if (!params) { return; }
   auto slot                    = lock_operator_params_slot(context);
-  params->hash_partition_bytes = UBigIntValue::Get(parameter);
+  params->hash_partition_bytes = bytes;
   SIRIUS_LOG_DEBUG("Updated config HASH_PARTITION_BYTES to {}", params->hash_partition_bytes);
 }
 
@@ -2096,8 +2098,11 @@ static void SetEnableCompressedMaterialization(ClientContext& /*context*/,
   // current_setting still reported the old value.
 }
 
-void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator_params& defaults)
+void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_config& defaults)
 {
+  auto const& operator_defaults    = defaults.get_operator_params();
+  auto const& compression_defaults = defaults.get_compression_config();
+
   // Add in config option for gpu buffer manager
   config.AddExtensionOption("use_pin_memory",
                             "Whether or not the buffer manager is initialized with pinned memory",
@@ -2218,7 +2223,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
   config.AddExtensionOption("scan_task_batch_size",
                             "The default batch size for a duckdb scan task",
                             LogicalType::UBIGINT,
-                            Value::UBIGINT(sirius::operator_params{}.scan_task_batch_size),
+                            Value::UBIGINT(operator_defaults.scan_task_batch_size),
                             SetDefaultScanTaskBatchSize);
 
   // Add in config option for sort partition size
@@ -2226,13 +2231,13 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
                             "Maximum bytes per sort partition (0 = auto based on "
                             "max_sort_partition_memory_fraction of GPU memory)",
                             LogicalType::UBIGINT,
-                            Value::UBIGINT(sirius::operator_params{}.max_sort_partition_bytes),
+                            Value::UBIGINT(operator_defaults.max_sort_partition_bytes),
                             SetMaxSortPartitionBytes);
   config.AddExtensionOption(
     "max_sort_partition_memory_fraction",
     "Fraction of available GPU memory per sort partition when max_sort_partition_bytes is 0",
     LogicalType::DOUBLE,
-    Value::DOUBLE(sirius::operator_params{}.max_sort_partition_memory_fraction),
+    Value::DOUBLE(operator_defaults.max_sort_partition_memory_fraction),
     SetMaxSortPartitionMemoryFraction);
 
   // Logging configuration
@@ -2260,26 +2265,26 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
   config.AddExtensionOption("hash_partition_bytes",
                             "Target size in bytes per hash partition",
                             LogicalType::UBIGINT,
-                            Value::UBIGINT(sirius::operator_params{}.hash_partition_bytes),
+                            Value::UBIGINT(operator_defaults.hash_partition_bytes),
                             SetHashPartitionBytes);
 
   config.AddExtensionOption("concat_batch_bytes",
                             "Target size for concat operator",
                             LogicalType::UBIGINT,
-                            Value::UBIGINT(sirius::operator_params{}.concat_batch_bytes),
+                            Value::UBIGINT(operator_defaults.concat_batch_bytes),
                             SetConcatBatchBytes);
 
   config.AddExtensionOption("sort_sample_bytes",
                             "Target bytes to sample before computing sort partition boundaries",
                             LogicalType::UBIGINT,
-                            Value::UBIGINT(sirius::operator_params{}.sort_sample_bytes),
+                            Value::UBIGINT(operator_defaults.sort_sample_bytes),
                             SetSortSampleBytes);
 
   config.AddExtensionOption("max_build_hash_table_bytes",
                             "Maximum size a build-side table can be where it will create a "
                             "reusable hash table for hash joins (i.e. BUILD_PROBE mode)",
                             LogicalType::UBIGINT,
-                            Value::UBIGINT(sirius::operator_params{}.max_build_hash_table_bytes),
+                            Value::UBIGINT(operator_defaults.max_build_hash_table_bytes),
                             SetMaxBuildHashTableBytes);
 
   config.AddExtensionOption("max_broadcast_join_size",
@@ -2287,7 +2292,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
                             "(small) build table is replicated to every GPU instead of "
                             "hash-partitioned across GPUs",
                             LogicalType::UBIGINT,
-                            Value::UBIGINT(sirius::operator_params{}.max_broadcast_join_size),
+                            Value::UBIGINT(operator_defaults.max_broadcast_join_size),
                             SetMaxBroadcastJoinSize);
 
   config.AddExtensionOption(
@@ -2296,7 +2301,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
     "right (probe) side has at least this many times more rows than the left side (0 disables). "
     "Hardware-dependent — recalibrate per GPU.",
     LogicalType::DOUBLE,
-    Value::DOUBLE(sirius::operator_params{}.mark_join_build_switch_ratio),
+    Value::DOUBLE(operator_defaults.mark_join_build_switch_ratio),
     SetMarkJoinBuildSwitchRatio);
 
   config.AddExtensionOption(
@@ -2309,7 +2314,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
   config.AddExtensionOption("pin_table_compression",
                             "Enable Simpatico compression for pin_table(tier=>'host') chunks",
                             LogicalType::BOOLEAN,
-                            Value::BOOLEAN(false),
+                            Value::BOOLEAN(compression_defaults.enable_pin_table_compression),
                             SetEnablePinTableCompression);
 
   config.AddExtensionOption(
@@ -2318,14 +2323,14 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
     "Files are named '<table_name>.<ext>'; their contents are the multi-column plan DSL. "
     "Tables with no matching file are pinned uncompressed. No effect on spill compression.",
     LogicalType::VARCHAR,
-    Value(std::string{}),
+    Value(compression_defaults.input_plan_dir),
     SetPinTableInputCompressionPlanDir);
 
   config.AddExtensionOption(
     "pin_table_compression_min_batch_size_bytes",
     "Minimum uncompressed batch size in bytes below which pin_table compression is skipped",
     LogicalType::UBIGINT,
-    Value::UBIGINT(1ULL * 1024 * 1024),
+    Value::UBIGINT(compression_defaults.min_batch_size_bytes),
     SetPinTableCompressionMinBatchSizeBytes);
 
   config.AddExtensionOption(
@@ -2333,7 +2338,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
     "Discard the compressed form and pin uncompressed when the compressed size exceeds this "
     "fraction of the batch's original size (i.e. compression saved too little)",
     LogicalType::DOUBLE,
-    Value::DOUBLE(0.95),
+    Value::DOUBLE(compression_defaults.max_compressed_fraction),
     SetPinTableCompressionMaxCompressedFraction);
 
   config.AddExtensionOption(
@@ -2343,7 +2348,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
     "IN-list if it fits the smallest probe-GPU L2, or a Bloom) into the probe-side scan to drop "
     "non-matching rows before the join (on by default)",
     LogicalType::BOOLEAN,
-    Value::BOOLEAN(sirius::operator_params{}.enable_dynamic_filter_pushdown),
+    Value::BOOLEAN(operator_defaults.enable_dynamic_filter_pushdown),
     SetEnableDynamicFilterPushdown);
 
   config.AddExtensionOption(
@@ -2352,7 +2357,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
     "it for read-time row-group pruning, while duckdb-native scans apply it row-wise post-decode; "
     "requires enable_dynamic_filter_pushdown (off by default)",
     LogicalType::BOOLEAN,
-    Value::BOOLEAN(sirius::operator_params{}.enable_dynamic_zone_map_filter),
+    Value::BOOLEAN(operator_defaults.enable_dynamic_zone_map_filter),
     SetEnableDynamicZoneMapFilter);
 
   config.AddExtensionOption(
@@ -2360,7 +2365,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
     "Skip publishing a key's dynamic filters when the hash-join build covers at least this "
     "fraction of the key's domain; >= 1.0 effectively disables the gate",
     LogicalType::DOUBLE,
-    Value::DOUBLE(sirius::operator_params{}.dynamic_filter_domain_coverage_threshold),
+    Value::DOUBLE(operator_defaults.dynamic_filter_domain_coverage_threshold),
     SetDynamicFilterDomainCoverageThreshold);
 
   config.AddExtensionOption(
@@ -2369,7 +2374,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
     "this fraction of its rows (too unselective to repay the mask kernel); in [0.0, 1.0], 1.0 "
     "keeps filtering always on",
     LogicalType::DOUBLE,
-    Value::DOUBLE(sirius::operator_params{}.dynamic_filter_keep_threshold),
+    Value::DOUBLE(operator_defaults.dynamic_filter_keep_threshold),
     SetDynamicFilterKeepThreshold);
 
   config.AddExtensionOption(
@@ -2378,7 +2383,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
     "filter matches no rows; also gates the statistics capture during CALL pin_table, so a table "
     "pinned while off carries no zone maps until re-pinned with the flag on",
     LogicalType::BOOLEAN,
-    Value::BOOLEAN(sirius::operator_params{}.enable_pinned_zone_map_pruning),
+    Value::BOOLEAN(operator_defaults.enable_pinned_zone_map_pruning),
     SetEnablePinnedZoneMapPruning);
 
   // Default from the YAML-loaded params, so a sirius.yaml value is what connections inherit.
@@ -2388,7 +2393,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
     "carriers selected from exact pin-time bounds; restore native carriers at type-sensitive "
     "boundaries (on by default)",
     LogicalType::BOOLEAN,
-    Value::BOOLEAN(defaults.enable_compressed_materialization),
+    Value::BOOLEAN(operator_defaults.enable_compressed_materialization),
     SetEnableCompressedMaterialization);
 }
 
@@ -2443,8 +2448,7 @@ static void LoadInternal(ExtensionLoader& loader)
   sirius::converter_registry::initialize();
   // The callback constructor above already read sirius.yaml, so its params are the defaults the
   // per-connection options register with.
-  SiriusExtension::InitialGPUConfigs(config,
-                                     callback_ptr->get_loaded_config().get_operator_params());
+  SiriusExtension::InitialGPUConfigs(config, callback_ptr->get_loaded_config());
   SiriusExtension::RegisterGPUFunctions(db);
 
   // Register the s3:// FileSystem so DuckDB's native read_parquet('s3://') binds

--- a/test/cpp/config/data/invalid_hash_partition_zero.yaml
+++ b/test/cpp/config/data/invalid_hash_partition_zero.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    hash_partition_bytes: 0

--- a/test/cpp/config/data/setting_defaults.yaml
+++ b/test/cpp/config/data/setting_defaults.yaml
@@ -1,0 +1,38 @@
+sirius:
+  topology:
+    num_gpus: 1
+  memory:
+    gpu:
+      usage_limit_fraction: 0.05
+      reservation_limit_fraction: 0.04
+      downgrade_trigger_fraction: 0.04
+      downgrade_stop_fraction: 0.02
+    host:
+      capacity_bytes: 160000000
+  executor:
+    downgrade:
+      num_threads: 1
+      monitor_period: 10ms
+  operator_params:
+    scan_task_batch_size: 1MiB
+    max_sort_partition_bytes: 2MiB
+    max_sort_partition_memory_fraction: 0.25
+    hash_partition_bytes: 3MiB
+    concat_batch_bytes: 4MiB
+    sort_sample_bytes: 5MiB
+    max_build_hash_table_bytes: 6MiB
+    max_broadcast_join_size: 7MiB
+    mark_join_build_switch_ratio: 3.0
+    enable_dynamic_filter_pushdown: false
+    enable_dynamic_zone_map_filter: true
+    dynamic_filter_domain_coverage_threshold: 0.8
+    dynamic_filter_keep_threshold: 0.7
+    enable_pinned_zone_map_pruning: false
+    enable_compressed_materialization: false
+  compression:
+    enable_pin_table_compression: true
+    min_batch_size_bytes: 8MiB
+    max_compressed_fraction: 0.6
+    input_plan_dir: /tmp/sirius-compression-plans
+  telemetry:
+    enable_quent: false

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -157,6 +157,147 @@ TEST_CASE("Sirius configuration loading from file with configurator",
   REQUIRE(telemetry.engine_name == "sirius_config_test");
 }
 
+TEST_CASE("Sirius configuration rejects zero hash partition bytes", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  fs::path cfg =
+    fs::path(loc.file_name()).parent_path() / "data" / "invalid_hash_partition_zero.yaml";
+
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(
+    config.load_from_file(cfg),
+    Catch::Contains("hash_partition_bytes") && Catch::Contains("greater than zero"));
+}
+
+TEST_CASE("DuckDB setting rejects zero hash partition bytes without a Sirius context",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto result = con.Query("SET hash_partition_bytes = 0");
+  REQUIRE(result != nullptr);
+  REQUIRE(result->HasError());
+  REQUIRE_THAT(result->GetError(),
+               Catch::Contains("hash_partition_bytes must be greater than zero"));
+}
+
+TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() {
+    unsetenv("SIRIUS_CONFIG_FILE");
+    setenv("SIRIUS_DISABLE", "1", 1);
+  }};
+
+  std::source_location loc = std::source_location::current();
+  fs::path cfg = fs::path(loc.file_name()).parent_path() / "data" / "setting_defaults.yaml";
+
+  unsetenv("SIRIUS_DISABLE");
+  setenv("SIRIUS_CONFIG_FILE", cfg.string().c_str(), 1);
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto sirius_ctx = con.context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  auto settings = con.Query(R"(
+    SELECT
+      current_setting('scan_task_batch_size')::UBIGINT,
+      current_setting('max_sort_partition_bytes')::UBIGINT,
+      current_setting('max_sort_partition_memory_fraction')::DOUBLE,
+      current_setting('hash_partition_bytes')::UBIGINT,
+      current_setting('concat_batch_bytes')::UBIGINT,
+      current_setting('sort_sample_bytes')::UBIGINT,
+      current_setting('max_build_hash_table_bytes')::UBIGINT,
+      current_setting('max_broadcast_join_size')::UBIGINT,
+      current_setting('mark_join_build_switch_ratio')::DOUBLE,
+      current_setting('enable_dynamic_filter_pushdown')::BOOLEAN,
+      current_setting('enable_dynamic_zone_map_filter')::BOOLEAN,
+      current_setting('dynamic_filter_domain_coverage_threshold')::DOUBLE,
+      current_setting('dynamic_filter_keep_threshold')::DOUBLE,
+      current_setting('enable_pinned_zone_map_pruning')::BOOLEAN,
+      current_setting('enable_compressed_materialization')::BOOLEAN,
+      current_setting('pin_table_compression')::BOOLEAN,
+      current_setting('pin_table_input_compression_plan_dir')::VARCHAR,
+      current_setting('pin_table_compression_min_batch_size_bytes')::UBIGINT,
+      current_setting('pin_table_compression_max_compressed_fraction')::DOUBLE
+  )");
+  REQUIRE(settings != nullptr);
+  REQUIRE_FALSE(settings->HasError());
+
+  constexpr uint64_t mib = 1024ULL * 1024;
+  REQUIRE(settings->GetValue(0, 0).GetValue<uint64_t>() == 1 * mib);
+  REQUIRE(settings->GetValue(1, 0).GetValue<uint64_t>() == 2 * mib);
+  REQUIRE(settings->GetValue(2, 0).GetValue<double>() == Approx(0.25));
+  REQUIRE(settings->GetValue(3, 0).GetValue<uint64_t>() == 3 * mib);
+  REQUIRE(settings->GetValue(4, 0).GetValue<uint64_t>() == 4 * mib);
+  REQUIRE(settings->GetValue(5, 0).GetValue<uint64_t>() == 5 * mib);
+  REQUIRE(settings->GetValue(6, 0).GetValue<uint64_t>() == 6 * mib);
+  REQUIRE(settings->GetValue(7, 0).GetValue<uint64_t>() == 7 * mib);
+  REQUIRE(settings->GetValue(8, 0).GetValue<double>() == Approx(3.0));
+  REQUIRE_FALSE(settings->GetValue(9, 0).GetValue<bool>());
+  REQUIRE(settings->GetValue(10, 0).GetValue<bool>());
+  REQUIRE(settings->GetValue(11, 0).GetValue<double>() == Approx(0.8));
+  REQUIRE(settings->GetValue(12, 0).GetValue<double>() == Approx(0.7));
+  REQUIRE_FALSE(settings->GetValue(13, 0).GetValue<bool>());
+  REQUIRE_FALSE(settings->GetValue(14, 0).GetValue<bool>());
+  REQUIRE(settings->GetValue(15, 0).GetValue<bool>());
+  REQUIRE(settings->GetValue(16, 0).GetValue<std::string>() == "/tmp/sirius-compression-plans");
+  REQUIRE(settings->GetValue(17, 0).GetValue<uint64_t>() == 8 * mib);
+  REQUIRE(settings->GetValue(18, 0).GetValue<double>() == Approx(0.6));
+
+  auto zero_partition = con.Query("SET hash_partition_bytes = 0");
+  REQUIRE(zero_partition != nullptr);
+  REQUIRE(zero_partition->HasError());
+  REQUIRE(sirius_ctx->get_config().get_operator_params().hash_partition_bytes == 3 * mib);
+
+  auto const require_ok = [&con](std::string const& sql) {
+    auto result = con.Query(sql);
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+  };
+
+  require_ok("SET scan_task_batch_size = 99");
+  require_ok("RESET scan_task_batch_size");
+  require_ok("SET max_sort_partition_memory_fraction = 0.9");
+  require_ok("RESET max_sort_partition_memory_fraction");
+  require_ok("SET enable_dynamic_filter_pushdown = true");
+  require_ok("RESET enable_dynamic_filter_pushdown");
+  require_ok("SET pin_table_compression = false");
+  require_ok("RESET pin_table_compression");
+  require_ok("SET pin_table_compression_max_compressed_fraction = 0.9");
+  require_ok("RESET pin_table_compression_max_compressed_fraction");
+
+  auto reset = con.Query(R"(
+    SELECT
+      current_setting('scan_task_batch_size')::UBIGINT,
+      current_setting('max_sort_partition_memory_fraction')::DOUBLE,
+      current_setting('enable_dynamic_filter_pushdown')::BOOLEAN,
+      current_setting('pin_table_compression')::BOOLEAN,
+      current_setting('pin_table_compression_max_compressed_fraction')::DOUBLE
+  )");
+  REQUIRE(reset != nullptr);
+  REQUIRE_FALSE(reset->HasError());
+  REQUIRE(reset->GetValue(0, 0).GetValue<uint64_t>() == 1 * mib);
+  REQUIRE(reset->GetValue(1, 0).GetValue<double>() == Approx(0.25));
+  REQUIRE_FALSE(reset->GetValue(2, 0).GetValue<bool>());
+  REQUIRE(reset->GetValue(3, 0).GetValue<bool>());
+  REQUIRE(reset->GetValue(4, 0).GetValue<double>() == Approx(0.6));
+
+  auto const& params = sirius_ctx->get_config().get_operator_params();
+  REQUIRE(params.scan_task_batch_size == 1 * mib);
+  REQUIRE(params.max_sort_partition_memory_fraction == Approx(0.25));
+  REQUIRE_FALSE(params.enable_dynamic_filter_pushdown);
+  auto const& compression = sirius_ctx->get_config().get_compression_config();
+  REQUIRE(compression.enable_pin_table_compression);
+  REQUIRE(compression.max_compressed_fraction == Approx(0.6));
+}
+
 TEST_CASE("Sirius configuration loading from file with spaces",
           "[sirius][context][isolated_context]")
 {

--- a/test/cpp/operator/test_build_probe_scheduling.cpp
+++ b/test/cpp/operator/test_build_probe_scheduling.cpp
@@ -108,6 +108,19 @@ TEST_CASE("compute_hash_join_partition_strategy - single-GPU small foldable inne
   REQUIRE(s.build_probe);
 }
 
+TEST_CASE("compute_hash_join_partition_strategy rejects a zero partition target",
+          "[hash_join][build_probe][unit][config]")
+{
+  REQUIRE_THROWS_AS(strategy(k100MB,
+                             /*is_build_side=*/true,
+                             /*build_foldable=*/true,
+                             /*num_gpus=*/1,
+                             duckdb::JoinType::INNER,
+                             HASH_JOIN_MODE::STANDARD,
+                             /*hash_partition_bytes=*/0),
+                    std::invalid_argument);
+}
+
 TEST_CASE("compute_hash_join_partition_strategy - single-GPU large build splits and stays STANDARD",
           "[hash_join][build_probe][unit]")
 {


### PR DESCRIPTION
## Summary

- register DuckDB extension defaults from the Sirius operator and compression configuration already loaded from YAML
- preserve current hardware-derived and clamped defaults when YAML omits those values
- reject `hash_partition_bytes == 0` at YAML validation, DuckDB `SET`, and partition-strategy boundaries
- add direct reset, inheritance, invalid-YAML, and strategy-guard tests

## Why

The YAML loader accepts operator and compression defaults, but DuckDB setting registration currently substitutes compile-time constants. A later `RESET` can therefore discard the loaded configuration. Separately, a zero hash-partition target is not a usable configuration and reaches arithmetic that requires a positive partition size. This makes the loaded YAML the registered source of truth and rejects zero at each reachable boundary.

## Validation

Validated from a clean checkout based exactly on `dev` `53b1eb9891a474f63579310f6afaab9a3f24c7db`:

- `/home/ubuntu/.pixi/bin/pixi run make -j8 release` — passed all `1276/1276` actions
- `sirius_unittest "Sirius configuration rejects zero hash partition bytes"` — 1 assertion in 1 test case passed
- `sirius_unittest "DuckDB setting rejects zero hash partition bytes without a Sirius context"` — 3 assertions in 1 test case passed
- `sirius_unittest "YAML-backed operator and compression settings are DuckDB defaults"` — 57 assertions in 1 test case passed
- `sirius_unittest "[hash_join][build_probe][unit][config]"` — 1 assertion in 1 test case passed
