### PR TITLE
test(perf): make the thread sweep isolated and fail-closed

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Test thread sweep harness
+        run: bash test/tpch_performance/test_sweep_threads.sh
+
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           cache: false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,7 +31,17 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Test thread sweep harness
-        run: bash test/tpch_performance/test_sweep_threads.sh
+        run: |
+          set -o pipefail
+          bash test/tpch_performance/test_sweep_threads.sh 2>&1 | tee /tmp/harness.log
+
+      - name: Surface thread sweep harness errors
+        if: failure()
+        run: |
+          echo '## Thread sweep harness errors' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/harness.log >> "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:

--- a/test/tpch_performance/CLAUDE.md
+++ b/test/tpch_performance/CLAUDE.md
@@ -249,13 +249,13 @@ export SIRIUS_CONFIG_FILE=$(pwd)/test/cpp/integration/integration.yaml
 
 ### Thread configuration sweep
 
-`sweep_threads.sh` runs Sirius-only across multiple thread configurations (pipeline, scan, task_creator threads) to find optimal settings. Modifies `integration.yaml` during the run and restores baseline when done.
+`sweep_threads.sh` runs Sirius-only across multiple thread configurations (pipeline, scan, task_creator threads) to find optimal settings. It writes each configuration to a temporary file exported through `SIRIUS_CONFIG_FILE`; the tracked `integration.yaml` is never modified.
 
 ```bash
 bash test/tpch_performance/sweep_threads.sh
 ```
 
-Results are saved to `benchmark_results_thread_sweep/` as CSV files per configuration.
+Results are saved as one CSV per configuration under a unique timestamped directory in `benchmark_results_thread_sweep/`. Set `SWEEP_OUTPUT_DIR` to use an explicit run directory.
 
 ### Legacy shell runners
 

--- a/test/tpch_performance/sweep_threads.sh
+++ b/test/tpch_performance/sweep_threads.sh
@@ -1,41 +1,118 @@
 #!/usr/bin/env bash
-# =============================================================================
-# Thread sweep benchmark: Sirius-only on 2M RG parquet
+# Thread sweep benchmark: Sirius-only on 2M RG parquet.
 #
-# Runs the Sirius queries with different thread configurations to find
-# the optimal settings. Only runs Sirius (no DuckDB).
-# =============================================================================
-set -uo pipefail
+# The functions are intentionally sourceable so the configuration rendering and
+# failure behavior can be tested without a GPU or DuckDB build.
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-DUCKDB="$PROJECT_DIR/build/release/duckdb"
-QUERY_DIR="$PROJECT_DIR/test/tpch_performance/tpch_queries/orig"
-CONFIG_FILE="$PROJECT_DIR/test/cpp/integration/integration.yaml"
+DUCKDB="${SWEEP_DUCKDB:-$PROJECT_DIR/build/release/duckdb}"
+QUERY_DIR="${SWEEP_QUERY_DIR:-$PROJECT_DIR/test/tpch_performance/tpch_queries/orig}"
+SF="${SWEEP_SF:-100_rg2m}"
+PARQUET_DIR="${SWEEP_PARQUET_DIR:-$PROJECT_DIR/test_datasets/tpch_parquet_sf${SF}}"
+if [ -n "${SWEEP_OUTPUT_DIR:-}" ]; then
+    OUTPUT_DIR="$SWEEP_OUTPUT_DIR"
+else
+    OUTPUT_DIR="$PROJECT_DIR/benchmark_results_thread_sweep/run_$(date +%Y%m%d-%H%M%S)-$$"
+fi
 
-export SIRIUS_CONFIG_FILE="$CONFIG_FILE"
-
-SF="100_rg2m"
-QUERIES=(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 22)
-PARQUET_DIR="$PROJECT_DIR/test_datasets/tpch_parquet_sf${SF}"
-OUTPUT_DIR="$PROJECT_DIR/benchmark_results_thread_sweep"
-mkdir -p "$OUTPUT_DIR"
-
-# Build view SQL
+read -r -a QUERIES <<< "${SWEEP_QUERIES:-1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 22}"
 TPCH_TABLES=(customer lineitem nation orders part partsupp region supplier)
+LABELS=(
+    "baseline_p8_s4_t4"
+    "pipeline_p4_s4_t4"
+    "pipeline_p12_s4_t4"
+    "pipeline_p16_s4_t4"
+    "scan_p8_s3_t4"
+    "scan_p8_s8_t4"
+    "taskcreator_p8_s4_t2"
+    "taskcreator_p8_s4_t8"
+)
+SHORT_NAMES=(
+    "p8/s4/t4"
+    "p4/s4/t4"
+    "p12/s4/t4"
+    "p16/s4/t4"
+    "p8/s3/t4"
+    "p8/s8/t4"
+    "p8/s4/t2"
+    "p8/s4/t8"
+)
+
+CONFIG_FILE=""
+CURRENT_SQL=""
+CURRENT_CSV=""
 VIEW_SQL=""
-for T in "${TPCH_TABLES[@]}"; do
-    FILES=()
-    for f in "$PARQUET_DIR/${T}.parquet" "$PARQUET_DIR/${T}_"*.parquet; do
-        [ -f "$f" ] && FILES+=("'$f'")
+
+die() {
+    echo "ERROR: $*" >&2
+    return 1
+}
+
+cleanup() {
+    if [ -n "$CURRENT_SQL" ] && [ -f "$CURRENT_SQL" ]; then
+        rm -f "$CURRENT_SQL"
+    fi
+    if [ -n "$CURRENT_CSV" ] && [ -f "$CURRENT_CSV" ]; then
+        rm -f "$CURRENT_CSV"
+    fi
+    if [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ]; then
+        rm -f "$CONFIG_FILE"
+    fi
+}
+
+require_positive_integer() {
+    local name=$1 value=$2
+    case "$value" in
+        ''|*[!0-9]*) die "$name must be a positive integer, got '$value'"; return 1 ;;
+        0) die "$name must be a positive integer, got '0'"; return 1 ;;
+    esac
+}
+
+validate_config_values() {
+    local pipeline=$1 scan=$2 task_creator=$3
+    require_positive_integer "pipeline threads" "$pipeline" || return 1
+    require_positive_integer "scan threads" "$scan" || return 1
+    require_positive_integer "task creator threads" "$task_creator" || return 1
+    if [ "$scan" -lt 3 ]; then
+        die "scan threads must be at least 3, got '$scan'"
+        return 1
+    fi
+}
+
+create_temp_config() {
+    CONFIG_FILE="$(mktemp "${TMPDIR:-/tmp}/sirius_thread_sweep.yaml.XXXXXX")"
+    export SIRIUS_CONFIG_FILE="$CONFIG_FILE"
+}
+
+build_view_sql() {
+    local table file_list
+    local -a files
+    VIEW_SQL=""
+    for table in "${TPCH_TABLES[@]}"; do
+        files=()
+        for file in "$PARQUET_DIR/${table}.parquet" "$PARQUET_DIR/${table}_"*.parquet; do
+            [ -f "$file" ] && files+=("'$file'")
+        done
+        if [ "${#files[@]}" -eq 0 ]; then
+            die "no parquet files found for table '$table' under $PARQUET_DIR"
+            return 1
+        fi
+        file_list=$(IFS=,; echo "${files[*]}")
+        VIEW_SQL+="CREATE VIEW ${table} AS SELECT * FROM read_parquet([${file_list}]);"$'\n'
     done
-    FILE_LIST=$(IFS=,; echo "${FILES[*]}")
-    VIEW_SQL+="CREATE VIEW ${T} AS SELECT * FROM read_parquet([${FILE_LIST}]);"$'\n'
-done
+}
 
 # update_config <pipeline> <scan> <task_creator>
 update_config() {
     local pipeline=$1 scan=$2 task_creator=$3
+    validate_config_values "$pipeline" "$scan" "$task_creator" || return 1
+    if [ -z "$CONFIG_FILE" ]; then
+        die "temporary config has not been created"
+        return 1
+    fi
+
     cat > "$CONFIG_FILE" << EOF
 sirius:
   topology:
@@ -52,6 +129,8 @@ sirius:
   executor:
     pipeline:
       num_threads: ${pipeline}
+    scan_manager:
+      num_threads: ${scan}
     task_creator:
       num_threads: ${task_creator}
     downgrade:
@@ -63,6 +142,9 @@ EOF
 run_sirius_sweep() {
     local label=$1 pipeline=$2 scan=$3 task_creator=$4
     local csv="$OUTPUT_DIR/${label}.csv"
+    local partial_csv="${csv}.partial"
+    local query_file output timing cold warm
+    local -a times
 
     update_config "$pipeline" "$scan" "$task_creator"
 
@@ -70,124 +152,125 @@ run_sirius_sweep() {
     echo "============================================================"
     echo "  $label: pipeline=$pipeline scan=$scan task_creator=$task_creator"
     echo "============================================================"
-
-    echo "query,cold,warm" > "$csv"
+    CURRENT_CSV="$partial_csv"
+    echo "query,cold,warm" > "$partial_csv"
 
     for q in "${QUERIES[@]}"; do
-        QUERY_FILE="$QUERY_DIR/q${q}.sql"
-        [ ! -f "$QUERY_FILE" ] && continue
+        query_file="$QUERY_DIR/q${q}.sql"
+        if [ ! -f "$query_file" ]; then
+            die "query file not found: $query_file"
+            return 1
+        fi
 
-        TEMP_SQL=$(mktemp /tmp/tpch_sweep_q${q}_XXXXXX.sql)
+        CURRENT_SQL=$(mktemp "${TMPDIR:-/tmp}/tpch_sweep_q${q}.sql.XXXXXX")
         {
             printf '%s\n' "$VIEW_SQL"
             echo ".timer on"
-            cat "$QUERY_FILE"
-            cat "$QUERY_FILE"
-        } > "$TEMP_SQL"
+            cat "$query_file"
+            cat "$query_file"
+        } > "$CURRENT_SQL"
 
-        OUTPUT=$("$DUCKDB" -f "$TEMP_SQL" 2>&1)
-        rm -f "$TEMP_SQL"
+        if ! output=$("$DUCKDB" -f "$CURRENT_SQL" 2>&1); then
+            echo "$output" >&2
+            die "DuckDB failed for $label query $q"
+            return 1
+        fi
+        rm -f "$CURRENT_SQL"
+        CURRENT_SQL=""
 
-        readarray -t TIMES < <(echo "$OUTPUT" | grep -oP 'Run Time \(s\): real \K[0-9]+\.[0-9]+')
-        cold="${TIMES[0]:-N/A}"
-        warm="${TIMES[1]:-N/A}"
+        times=()
+        while IFS= read -r timing; do
+            times+=("$timing")
+        done < <(printf '%s\n' "$output" | sed -nE 's/.*Run Time \(s\): real ([0-9]+([.][0-9]+)?).*/\1/p')
+        if [ "${#times[@]}" -ne 2 ]; then
+            echo "$output" >&2
+            die "expected exactly two DuckDB timer values for $label query $q, found ${#times[@]}"
+            return 1
+        fi
+
+        cold=${times[0]}
+        warm=${times[1]}
         echo "  Q${q}: cold=${cold}s warm=${warm}s"
-        echo "${q},${cold},${warm}" >> "$csv"
+        echo "${q},${cold},${warm}" >> "$partial_csv"
     done
+
+    mv "$partial_csv" "$csv"
+    CURRENT_CSV=""
 }
 
-echo "============================================================"
-echo "  Thread Sweep Benchmark (SF${SF}, Sirius-only)"
-echo "============================================================"
+run_all_sweeps() {
+    run_sirius_sweep "baseline_p8_s4_t4" 8 4 4
+    run_sirius_sweep "pipeline_p4_s4_t4" 4 4 4
+    run_sirius_sweep "pipeline_p12_s4_t4" 12 4 4
+    run_sirius_sweep "pipeline_p16_s4_t4" 16 4 4
+    run_sirius_sweep "scan_p8_s3_t4" 8 3 4
+    run_sirius_sweep "scan_p8_s8_t4" 8 8 4
+    run_sirius_sweep "taskcreator_p8_s4_t2" 8 4 2
+    run_sirius_sweep "taskcreator_p8_s4_t8" 8 4 8
+}
 
-# Baseline: pipeline=8, scan=4, task_creator=4
-run_sirius_sweep "baseline_p8_s4_t4" 8 4 4
+print_summary() {
+    local name label csv val total q
+    echo ""
+    echo "============================================================"
+    echo "  Thread Sweep Summary (Sirius cold times)"
+    echo "============================================================"
+    echo ""
 
-# Vary pipeline threads (scan=4, task_creator=4)
-run_sirius_sweep "pipeline_p4_s4_t4" 4 4 4
-run_sirius_sweep "pipeline_p12_s4_t4" 12 4 4
-run_sirius_sweep "pipeline_p16_s4_t4" 16 4 4
-
-# Vary scan threads (pipeline=8, task_creator=4)
-run_sirius_sweep "scan_p8_s2_t4" 8 2 4
-run_sirius_sweep "scan_p8_s8_t4" 8 8 4
-
-# Vary task creator threads (pipeline=8, scan=4)
-run_sirius_sweep "taskcreator_p8_s4_t2" 8 4 2
-run_sirius_sweep "taskcreator_p8_s4_t8" 8 4 8
-
-# Restore baseline config
-update_config 8 4 4
-
-# ---- Print comparison table ----
-echo ""
-echo "============================================================"
-echo "  Thread Sweep Summary (Sirius cold times)"
-echo "============================================================"
-echo ""
-
-LABELS=(
-    "baseline_p8_s4_t4"
-    "pipeline_p4_s4_t4"
-    "pipeline_p12_s4_t4"
-    "pipeline_p16_s4_t4"
-    "scan_p8_s2_t4"
-    "scan_p8_s8_t4"
-    "taskcreator_p8_s4_t2"
-    "taskcreator_p8_s4_t8"
-)
-SHORT_NAMES=(
-    "p8/s4/t4"
-    "p4/s4/t4"
-    "p12/s4/t4"
-    "p16/s4/t4"
-    "p8/s2/t4"
-    "p8/s8/t4"
-    "p8/s4/t2"
-    "p8/s4/t8"
-)
-
-# Header
-printf "%-5s" "Query"
-for name in "${SHORT_NAMES[@]}"; do
-    printf " | %11s" "$name"
-done
-echo ""
-
-printf "%-5s" "-----"
-for name in "${SHORT_NAMES[@]}"; do
-    printf "-+-%-11s" "-----------"
-done
-echo ""
-
-# Data rows
-for q in "${QUERIES[@]}"; do
-    printf "%-5s" "Q${q}"
-    for label in "${LABELS[@]}"; do
-        csv="$OUTPUT_DIR/${label}.csv"
-        val=$(grep "^${q}," "$csv" 2>/dev/null | cut -d, -f2)
-        if [ -n "$val" ] && [ "$val" != "N/A" ]; then
-            printf " | %10ss" "$val"
-        else
-            printf " | %11s" "N/A"
-        fi
+    printf "%-5s" "Query"
+    for name in "${SHORT_NAMES[@]}"; do
+        printf " | %11s" "$name"
     done
     echo ""
-done
 
-# Totals
-printf "%-5s" "TOTAL"
-for label in "${LABELS[@]}"; do
-    csv="$OUTPUT_DIR/${label}.csv"
-    total=$(tail -n +2 "$csv" 2>/dev/null | cut -d, -f2 | grep -v N/A | paste -sd+ | bc 2>/dev/null || echo "N/A")
-    if [ -n "$total" ] && [ "$total" != "N/A" ]; then
-        printf " | %10ss" "$(printf '%.1f' "$total")"
-    else
-        printf " | %11s" "N/A"
-    fi
-done
-echo ""
+    printf "%-5s" "-----"
+    for name in "${SHORT_NAMES[@]}"; do
+        printf -- "-+-%-11s" "-----------"
+    done
+    echo ""
 
-echo ""
-echo "CSVs saved to: $OUTPUT_DIR/"
-echo "============================================================"
+    for q in "${QUERIES[@]}"; do
+        printf "%-5s" "Q${q}"
+        for label in "${LABELS[@]}"; do
+            csv="$OUTPUT_DIR/${label}.csv"
+            val=$(awk -F, -v query="$q" '$1 == query { print $2 }' "$csv")
+            printf " | %10ss" "$val"
+        done
+        echo ""
+    done
+
+    printf "%-5s" "TOTAL"
+    for label in "${LABELS[@]}"; do
+        csv="$OUTPUT_DIR/${label}.csv"
+        total=$(awk -F, 'NR > 1 { sum += $2 } END { printf "%.1f", sum }' "$csv")
+        printf " | %10ss" "$total"
+    done
+    echo ""
+}
+
+main() {
+    [ -x "$DUCKDB" ] || { die "DuckDB binary is not executable: $DUCKDB"; return 1; }
+    [ -d "$QUERY_DIR" ] || { die "query directory not found: $QUERY_DIR"; return 1; }
+    [ -d "$PARQUET_DIR" ] || { die "parquet directory not found: $PARQUET_DIR"; return 1; }
+
+    mkdir -p "$OUTPUT_DIR"
+    create_temp_config
+    trap cleanup EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    build_view_sql
+
+    echo "============================================================"
+    echo "  Thread Sweep Benchmark (SF${SF}, Sirius-only)"
+    echo "============================================================"
+    run_all_sweeps
+    print_summary
+
+    echo ""
+    echo "CSVs saved to: $OUTPUT_DIR/"
+    echo "============================================================"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/test/tpch_performance/test_sweep_threads.sh
+++ b/test/tpch_performance/test_sweep_threads.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SWEEP_SCRIPT="$SCRIPT_DIR/sweep_threads.sh"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/sirius_sweep_test.XXXXXX")
+
+cleanup() {
+    rm -rf -- "$TMP_ROOT"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+QUERY_DIR="$TMP_ROOT/queries"
+PARQUET_DIR="$TMP_ROOT/parquet"
+OUTPUT_DIR="$TMP_ROOT/output"
+CAPTURE_FILE="$TMP_ROOT/configurations.txt"
+CONFIG_PATHS="$TMP_ROOT/config_paths.txt"
+FAKE_DUCKDB="$TMP_ROOT/duckdb"
+mkdir -p "$QUERY_DIR" "$PARQUET_DIR"
+printf 'SELECT 1;\n' > "$QUERY_DIR/q1.sql"
+
+for table in customer lineitem nation orders part partsupp region supplier; do
+    : > "$PARQUET_DIR/${table}.parquet"
+done
+
+cat > "$FAKE_DUCKDB" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${SWEEP_FAKE_FAIL:-0}" = "1" ]; then
+    echo "synthetic DuckDB failure" >&2
+    exit 42
+fi
+
+read_threads() {
+    local section=$1
+    awk -v wanted="$section" '
+        $1 == wanted ":" { active = 1; next }
+        active && $1 == "num_threads:" { print $2; exit }
+        active && $1 ~ /:$/ { exit 1 }
+    ' "$SIRIUS_CONFIG_FILE"
+}
+
+pipeline=$(read_threads pipeline)
+scan=$(read_threads scan_manager)
+task_creator=$(read_threads task_creator)
+printf '%s/%s/%s\n' "$pipeline" "$scan" "$task_creator" >> "$SWEEP_CAPTURE_FILE"
+printf '%s\n' "$SIRIUS_CONFIG_FILE" >> "$SWEEP_CONFIG_PATHS"
+printf 'Run Time (s): real 1.25 user 0.00 sys 0.00\n'
+printf 'Run Time (s): real 0.75 user 0.00 sys 0.00\n'
+EOF
+chmod +x "$FAKE_DUCKDB"
+
+INTEGRATION_CONFIG="$PROJECT_DIR/test/cpp/integration/integration.yaml"
+INTEGRATION_COPY="$TMP_ROOT/integration.yaml"
+cp "$INTEGRATION_CONFIG" "$INTEGRATION_COPY"
+
+SWEEP_DUCKDB="$FAKE_DUCKDB" \
+SWEEP_QUERY_DIR="$QUERY_DIR" \
+SWEEP_PARQUET_DIR="$PARQUET_DIR" \
+SWEEP_OUTPUT_DIR="$OUTPUT_DIR" \
+SWEEP_QUERIES=1 \
+SWEEP_CAPTURE_FILE="$CAPTURE_FILE" \
+SWEEP_CONFIG_PATHS="$CONFIG_PATHS" \
+bash "$SWEEP_SCRIPT" > "$TMP_ROOT/success.log"
+
+cat > "$TMP_ROOT/expected_configurations.txt" <<'EOF'
+8/4/4
+4/4/4
+12/4/4
+16/4/4
+8/3/4
+8/8/4
+8/4/2
+8/4/8
+EOF
+diff -u "$TMP_ROOT/expected_configurations.txt" "$CAPTURE_FILE"
+
+CONFIG_PATH=$(head -n 1 "$CONFIG_PATHS")
+[ -n "$CONFIG_PATH" ]
+[ "${CONFIG_PATH#*XXXXXX}" = "$CONFIG_PATH" ]
+[ "$(sort -u "$CONFIG_PATHS" | wc -l | tr -d ' ')" = "1" ]
+[ ! -e "$CONFIG_PATH" ]
+cmp "$INTEGRATION_COPY" "$INTEGRATION_CONFIG"
+
+# The config parser requires scan_manager.num_threads > 2.
+(
+    # shellcheck source=sweep_threads.sh
+    source "$SWEEP_SCRIPT"
+    CONFIG_FILE="$TMP_ROOT/invalid.yaml"
+    if update_config 8 2 4 > "$TMP_ROOT/invalid.out" 2>&1; then
+        echo "scan thread validation unexpectedly accepted 2" >&2
+        exit 1
+    fi
+)
+grep -q "scan threads must be at least 3" "$TMP_ROOT/invalid.out"
+
+if SWEEP_DUCKDB="$FAKE_DUCKDB" \
+    SWEEP_QUERY_DIR="$QUERY_DIR" \
+    SWEEP_PARQUET_DIR="$PARQUET_DIR" \
+    SWEEP_OUTPUT_DIR="$TMP_ROOT/failure-output" \
+    SWEEP_QUERIES=1 \
+    SWEEP_CAPTURE_FILE="$TMP_ROOT/failure-configurations.txt" \
+    SWEEP_CONFIG_PATHS="$TMP_ROOT/failure-config-paths.txt" \
+    SWEEP_FAKE_FAIL=1 \
+    bash "$SWEEP_SCRIPT" > "$TMP_ROOT/failure.log" 2>&1; then
+    echo "DuckDB failure unexpectedly returned success" >&2
+    exit 1
+fi
+grep -q "DuckDB failed for baseline_p8_s4_t4 query 1" "$TMP_ROOT/failure.log"
+[ ! -e "$TMP_ROOT/failure-output/baseline_p8_s4_t4.csv" ]
+[ ! -e "$TMP_ROOT/failure-output/baseline_p8_s4_t4.csv.partial" ]
+if grep -q "N/A" "$TMP_ROOT/failure.log"; then
+    echo "failure path emitted misleading N/A timing evidence" >&2
+    exit 1
+fi
+cmp "$INTEGRATION_COPY" "$INTEGRATION_CONFIG"
+
+echo "thread sweep harness tests passed"


### PR DESCRIPTION
## Problem

The thread-sweep runner rewrites the tracked integration configuration, publishes results into a shared directory, and can continue after missing queries, failed DuckDB executions, or missing timer output. A failed sweep can therefore leave repository state behind or publish incomplete timings as evidence.

The scan-thread parameter is also accepted by the runner but not written into the generated configuration, so the existing scan sweep does not actually vary scan threads.

## Changes

- Render every sweep configuration into a temporary file selected through `SIRIUS_CONFIG_FILE`; never modify the tracked integration YAML.
- Write `scan_manager.num_threads` and replace the invalid two-thread scan cell with the minimum accepted value of three.
- Validate all thread counts and required inputs before running.
- Fail on missing queries, DuckDB errors, or anything other than exactly two timer values.
- Write each CSV through a `.partial` file and publish it only after the configuration completes.
- Use a unique timestamped output directory by default, with explicit path overrides for automation.
- Remove the runner’s dependencies on GNU `grep -P`, `readarray`, and `bc`.
- Add a CPU-only shell regression covering all eight configurations, temporary-file isolation and cleanup, invalid scan-thread rejection, tracked-config preservation, and DuckDB failure behavior.
- Run that regression as the dependency-free first step of the `Check` workflow.
- Update the performance-test documentation to describe the isolated configuration and output behavior.

## Validation

Based on Sirius `dev` at `53b1eb9891a474f63579310f6afaab9a3f24c7db`.

```text
git diff --check
bash -n test/tpch_performance/sweep_threads.sh
bash -n test/tpch_performance/test_sweep_threads.sh
bash test/tpch_performance/test_sweep_threads.sh
  -> thread sweep harness tests passed
```

The updated `check.yml` also parses successfully as YAML. The regenerated full-index diff matches the reviewed patch at SHA-256 `3194b4270f2bebe4048ef884359125d6e898af5dc89c2361faa139af3f74fe2a`.

## Scope

This is harness reliability work. It does not run a GPU benchmark, select thread values, or change any Sirius runtime default. Full lint and build checks remain for PR CI.
