### PR TITLE
fix(testing): gate fallback injection behind explicit test opt-in

### DIFF
--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -120,6 +120,7 @@ extern "C" int cudaProfilerStop();
 
 #include <cstdint>
 #include <cstdlib>
+#include <string_view>
 #include <unordered_map>
 
 namespace duckdb {
@@ -132,6 +133,12 @@ bool SiriusExtension::buffer_is_initialized = false;
 constexpr std::string QUERY_LABEL_PARAM_KEY = "query_label";
 
 namespace {
+
+bool test_options_enabled() noexcept
+{
+  auto const* value = std::getenv("SIRIUS_ENABLE_TEST_OPTIONS");
+  return value != nullptr && std::string_view{value} == "1";
+}
 
 std::uint64_t count_narrowed_columns(
   sirius::pinned_column_storage_matrix const& column_storage) noexcept
@@ -2183,14 +2190,15 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::operator
                            // fallback policy into every freshly-created database).
     SetEnableDuckdbFallback);
 
-  // TEST ONLY: when non-empty, transparent GPU execution fails at runtime with that
-  // message after plan generation succeeds, to exercise the CPU fallback path. No
-  // setter — the value is read via TryGetCurrentSetting in PhysicalSiriusExecution.
-  config.AddExtensionOption(
-    "sirius_test_inject_transparent_gpu_error",
-    "TEST ONLY: force transparent GPU execution to fail at runtime with this message",
-    LogicalType::VARCHAR,
-    Value(""));
+  // Test hooks are absent from normal duckdb_settings(). The unittest harness opts in before
+  // constructing any database so fallback tests can still inject a deterministic runtime error.
+  if (test_options_enabled()) {
+    config.AddExtensionOption(
+      "sirius_test_inject_transparent_gpu_error",
+      "TEST ONLY: force transparent GPU execution to fail at runtime with this message",
+      LogicalType::VARCHAR,
+      Value(""));
+  }
 
   // Add in config options for special JIT implementation for regex
   config.AddExtensionOption(

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -42,6 +42,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <set>
 #include <source_location>
 #include <string>
@@ -120,6 +121,60 @@ struct finally {
     if (func) { func(); }
   }
 };
+
+TEST_CASE("Test-only settings require explicit process opt-in",
+          "[sirius][config][test-settings][isolated_context]")
+{
+  std::optional<std::string> original_test_options;
+  if (auto const* value = std::getenv("SIRIUS_ENABLE_TEST_OPTIONS")) {
+    original_test_options = value;
+  }
+  finally restore_env{[original_test_options]() {
+    if (original_test_options) {
+      setenv("SIRIUS_ENABLE_TEST_OPTIONS", original_test_options->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_ENABLE_TEST_OPTIONS");
+    }
+    setenv("SIRIUS_DISABLE", "1", 1);
+  }};
+
+  auto setting_count = [](duckdb::Connection& con) {
+    auto result = con.Query(
+      "SELECT count(*) FROM duckdb_settings() "
+      "WHERE name = 'sirius_test_inject_transparent_gpu_error'");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    return result->GetValue(0, 0).GetValue<int64_t>();
+  };
+
+  setenv("SIRIUS_DISABLE", "1", 1);
+  unsetenv("SIRIUS_ENABLE_TEST_OPTIONS");
+  {
+    duckdb::DuckDB db(nullptr);
+    duckdb::Connection con(db);
+    REQUIRE(setting_count(con) == 0);
+    auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+  }
+
+  setenv("SIRIUS_ENABLE_TEST_OPTIONS", "true", 1);
+  {
+    duckdb::DuckDB db(nullptr);
+    duckdb::Connection con(db);
+    REQUIRE(setting_count(con) == 0);
+  }
+
+  setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
+  {
+    duckdb::DuckDB db(nullptr);
+    duckdb::Connection con(db);
+    REQUIRE(setting_count(con) == 1);
+    auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+  }
+}
 
 TEST_CASE("Sirius configuration loading from file with configurator",
           "[sirius][context][isolated_context]")

--- a/test/cpp/unittest.cpp
+++ b/test/cpp/unittest.cpp
@@ -100,6 +100,10 @@ CATCH_REGISTER_LISTENER(shared_env_listener)
 
 int main(int argc, char* argv[])
 {
+  // Keep test-only DuckDB options out of normal Sirius builds and sessions. This process opts in
+  // before constructing the shared databases used by the runtime-fallback integration tests.
+  setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
+
   // Install the crash backtrace handler up front so it covers the whole test
   // run, independent of when (or whether) the extension's LoadInternal runs.
   sirius::util::install_segfault_backtrace_handler();


### PR DESCRIPTION
## Summary

- omit `sirius_test_inject_transparent_gpu_error` from normal Sirius setting registration
- expose the injection hook only when the process explicitly sets `SIRIUS_ENABLE_TEST_OPTIONS=1`
- keep non-exact values such as `true` fail-closed
- opt the unittest process in before constructing its shared databases so runtime-fallback coverage remains intact
- directly test normal absence and `SET` rejection, non-exact absence, and exact opt-in presence

## Why

`sirius_test_inject_transparent_gpu_error` exists only to force a deterministic runtime GPU failure for transparent-fallback tests. Registering it in every normal database exposes an implementation test hook as a user-facing configuration choice. This keeps the hook available to the test harness without advertising or accepting it in production sessions.

## Validation

Validated from a clean isolated checkout based exactly on `dev` `53b1eb9891a474f63579310f6afaab9a3f24c7db`:

- `/home/ubuntu/.pixi/bin/pixi run make -j8 release` — passed all `1276/1276` actions
- `sirius_unittest "[sirius][config][test-settings][isolated_context]"` — 13 assertions in 1 test case passed
- `sirius_unittest "[transparent][fallback][integration]~[s3mix]"` — 89 assertions in 9 test cases passed

The surface test covers unset, non-exact `true`, and exact `1` process values. Both selectors exited zero on the existing AWS NVIDIA L4; no new instance was created.
