### PR TITLE
refactor(config): internalize the regex specialization toggle

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -687,7 +687,6 @@ See [Compressed Pinning](compressed-pinning.md) for tier selection, plan authori
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `enable_duckdb_fallback` | true | Fall back to DuckDB CPU execution on Sirius errors. Gates both plan-time fallback (unsupported operator/type) and runtime fallback (GPU execution failure) on the transparent path, plus the legacy `CALL gpu_execution(...)` path. Set to `false` to surface Sirius errors instead of falling back. |
-| `enable_regex_jit_impl` | true | Use JIT regex implementation |
 | `like_swar_fastpath` | true | Dispatch `%lit1%lit2%...%` LIKE/NOT LIKE patterns to the SWAR digram fast-path kernel instead of `cudf::strings::like` |
 
 
@@ -695,10 +694,11 @@ See [Compressed Pinning](compressed-pinning.md) for tier selection, plan authori
 
 ### Legacy-release DuckDB settings
 
-The following settings only control the legacy `gpu_processing` path. Sirius registers them
-when built with `ENABLE_LEGACY_SIRIUS=ON`, including the `legacy-release` preset used by
-`make legacy-release`. Normal builds omit them from `duckdb_settings()` and reject attempts to
-`SET` them.
+Sirius registers the following compatibility settings when built with
+`ENABLE_LEGACY_SIRIUS=ON`, including the `legacy-release` preset used by `make legacy-release`.
+Normal builds omit them from `duckdb_settings()` and reject attempts to `SET` them. Most control
+only the legacy `gpu_processing` path; `enable_regex_jit_impl` remains available because both
+executors in a legacy build consume the same process-global value.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -711,6 +711,7 @@ when built with `ENABLE_LEGACY_SIRIUS=ON`, including the `legacy-release` preset
 | `opt_table_scan_memcpy_size` | 64 MiB | Copy chunk size used by the legacy optimized scan |
 | `print_gpu_table_max_rows` | 1000 | Maximum rows rendered by the legacy GPU-table printer |
 | `enable_fallback_check` | false | Enable legacy fallback validation |
+| `enable_regex_jit_impl` | true | Select the specialized implementation for its supported regex in a legacy build |
 | `modified_pipeline` | false | Enable legacy modified-pipeline scheduling |
 
 ### Static flags

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2599,11 +2599,17 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                     Value::UBIGINT(operator_defaults.concat_batch_bytes),
                     SetConcatBatchBytes);
 
-  // Add in config options for special JIT implementation for regex
+#ifdef SIRIUS_ENABLE_LEGACY
+  constexpr auto regex_jit_visibility = option_visibility::user;
+#else
+  constexpr auto regex_jit_visibility = option_visibility::internal;
+#endif
+  // The legacy executor retains this compatibility setting. Super Sirius keeps it available only
+  // to the explicitly opted-in differential tests that compare both implementations.
   add_sirius_option(config,
-                    option_visibility::user,
+                    regex_jit_visibility,
                     "enable_regex_jit_impl",
-                    "Whether to use special JIT implementation for particular regex evaluation",
+                    "select the specialized implementation for supported regex evaluation",
                     LogicalType::BOOLEAN,
                     Value::BOOLEAN(Config::ENABLE_REGEX_JIT_IMPL),
                     SetEnableRegexJitImpl);

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -168,9 +168,8 @@ constexpr std::array<setting_assignment, 10> legacy_only_settings{{
   {"modified_pipeline", "true"},
 }};
 
-constexpr std::array<const char*, 4> super_sirius_settings{{
+constexpr std::array<const char*, 3> super_sirius_settings{{
   "expression_evaluator_strategy",
-  "enable_regex_jit_impl",
   "enable_duckdb_fallback",
   "like_swar_fastpath",
 }};
@@ -377,6 +376,64 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     result = con.Query("RESET concat_batch_bytes");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
+  }
+}
+
+TEST_CASE("Regex implementation setting is internal outside legacy builds",
+          "[sirius][config][regex-jit-setting][isolated_context]")
+{
+  std::optional<std::string> original_test_options;
+  if (auto const* value = std::getenv("SIRIUS_ENABLE_TEST_OPTIONS")) {
+    original_test_options = value;
+  }
+  finally restore_state{[original_test_options]() {
+    if (original_test_options) {
+      setenv("SIRIUS_ENABLE_TEST_OPTIONS", original_test_options->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_ENABLE_TEST_OPTIONS");
+    }
+    setenv("SIRIUS_DISABLE", "1", 1);
+  }};
+
+  auto setting_count = [](duckdb::Connection& con) {
+    auto result =
+      con.Query("SELECT count(*) FROM duckdb_settings() WHERE name = 'enable_regex_jit_impl'");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    return result->GetValue(0, 0).GetValue<int64_t>();
+  };
+
+  setenv("SIRIUS_DISABLE", "1", 1);
+  unsetenv("SIRIUS_ENABLE_TEST_OPTIONS");
+  {
+    duckdb::DuckDB db(nullptr);
+    duckdb::Connection con(db);
+#ifdef SIRIUS_ENABLE_LEGACY
+    REQUIRE(setting_count(con) == 1);
+#else
+    REQUIRE(setting_count(con) == 0);
+    auto result = con.Query("SET enable_regex_jit_impl = false");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+#endif
+  }
+
+  setenv("SIRIUS_ENABLE_TEST_OPTIONS", "true", 1);
+  {
+    duckdb::DuckDB db(nullptr);
+    duckdb::Connection con(db);
+#ifdef SIRIUS_ENABLE_LEGACY
+    REQUIRE(setting_count(con) == 1);
+#else
+    REQUIRE(setting_count(con) == 0);
+#endif
+  }
+
+  setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
+  {
+    duckdb::DuckDB db(nullptr);
+    duckdb::Connection con(db);
+    REQUIRE(setting_count(con) == 1);
   }
 }
 

--- a/test/cpp/unittest.cpp
+++ b/test/cpp/unittest.cpp
@@ -101,7 +101,7 @@ CATCH_REGISTER_LISTENER(shared_env_listener)
 int main(int argc, char* argv[])
 {
   // Keep test-only DuckDB options out of normal Sirius builds and sessions. This process opts in
-  // before constructing the shared databases used by the runtime-fallback integration tests.
+  // before constructing the shared databases used by runtime-fallback and regex-differential tests.
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
 
   // Install the crash backtrace handler up front so it covers the whole test


### PR DESCRIPTION
## Review focus

**Tier:** judgment — configuration-surface policy only; regex behavior is
unchanged.

**Maintainer question:** Should normal Super Sirius sessions omit
`enable_regex_jit_impl`, while legacy builds and exact test opt-in retain it?

**Main risk:** this removes a production escape hatch from normal sessions. If
maintainers want that escape hatch, decline this PR without affecting the
already-merged regex correctness repair in #1410.

## Summary

- omit `enable_regex_jit_impl` from normal `duckdb_settings()` and reject
  normal `SET` attempts
- expose it only when `SIRIUS_ENABLE_TEST_OPTIONS` is exactly `1`, preserving
  deterministic differential tests
- retain it in `SIRIUS_ENABLE_LEGACY` builds because both executors in a legacy
  build consume the same process-global value
- move the documented setting into the legacy compatibility table
- preserve current `dev`'s separately added `like_swar_fastpath` surface
- test unset, non-exact `true`, exact opt-in, and legacy registration behavior

## Current-dev repair

The rebase had two additive conflicts: the configuration table and the expanded
`super_sirius_settings` test array. The resolution retains upstream's
`like_swar_fastpath` entry, removes only this toggle from the normal surface,
and makes no change under `src/legacy/`.

## Identity

- exact base: `9624f06334d41f1049088185a34d4b16e2a0e29c`
- exact head: `7af4d62dbea7ee32645b2e701f7a64bc667417c3`
- base tree: `fe3bad29a859e6480c901ade52c55725ff2de41d`
- candidate tree: `76084074300a65b635d83da9989f2c163be99c4f`
- cumulative binary-diff SHA-256: `64185c79e01034801c43029c520691e24ae9104a9b51c047d690b3d1cd5fe340`
- cumulative diff: 4 paths, 75 insertions, 11 deletions

## Author-side validation

- complete replacement diff and conflict resolution reviewed
- clean worktree, `git diff --check`, and orphan-test check pass
- exact normal Release build and focused registration selector pass on an AWS
  L4 validation host
- the separately labeled `legacy-release` validation uses the two-line #1623
  call-site repair only to make current `dev`'s pre-existing legacy baseline
  executable; that patch is not part of this PR
- the normal selector passes 11 assertions; the conditional legacy selector
  passes 9 assertions after explicitly building the current test target
- the initial legacy validator retained a target-selection failure because
  `make legacy-release` builds only the main target; its bounded retry reused
  the completed cache, built `sirius_unittest` explicitly, and passed
- retained final legacy receipt SHA-256:
  `18e6bf34af30b547d8c108e8a2925e285f2934fd2abebda367e451e7bb51fbff`
- hosted replacement-head lint, GCC release, Clang debug, C++ unit suite,
  TPC-H snapshot, validation, and distribution workflows pass

Hosted workflows: Check `32924476410`, Test `32924476328`, Distribution
`32924476860`, Validate `32924508715`. The replacement head is
author-ready and terminal-green.

## Legacy-build baseline caveat

Current `dev` itself does not canonically build the legacy regex call site:
merged #1410 changed `jit_transform_clickbench_q28_regex` to require explicit
stream and memory-resource arguments, while the legacy caller still supplies
one argument. Issue #1623 tracks that independent repair. This PR does not
modify `src/legacy/` and does not claim to fix that defect; its bounded legacy
validation applies the exact #1623 patch separately and tests only registration
policy once the baseline compiles.