### PR TITLE
refactor: remove unreachable CTE code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,9 @@ build_loadable_extension(sirius CPP ${EXTENSION_SOURCES} ${CUDA_SOURCES})
 set_target_properties(sirius_loadable_extension PROPERTIES LINKER_TYPE BFD)
 
 # Shared configuration for both extension targets
+set(SIRIUS_CLANG_CXX_WARNING_OPTIONS -Wunreachable-code -Wimplicit-fallthrough
+                                     -Wrange-loop-analysis -Wnull-dereference)
+
 foreach(_target sirius_extension sirius_loadable_extension)
   set_target_properties(
     ${_target}
@@ -483,8 +486,10 @@ foreach(_target sirius_extension sirius_loadable_extension)
   # consumers (tests/benchmarks) with --expt-extended-lambda.
   target_compile_options(
     ${_target}
-    PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-extended-lambda>
-            $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>:-Wunreachable-code>)
+    PRIVATE
+      $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-extended-lambda>
+      "$<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>:${SIRIUS_CLANG_CXX_WARNING_OPTIONS}>"
+  )
 
   if(VCPKG_BUILD)
     set_target_properties(${_target} PROPERTIES CUDA_RUNTIME_LIBRARY Static)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,7 +483,8 @@ foreach(_target sirius_extension sirius_loadable_extension)
   # consumers (tests/benchmarks) with --expt-extended-lambda.
   target_compile_options(
     ${_target}
-    PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-extended-lambda>)
+    PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-extended-lambda>
+            $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>:-Wunreachable-code>)
 
   if(VCPKG_BUILD)
     set_target_properties(${_target} PROPERTIES CUDA_RUNTIME_LIBRARY Static)

--- a/src/op/sirius_physical_column_data_scan.cpp
+++ b/src/op/sirius_physical_column_data_scan.cpp
@@ -102,10 +102,6 @@ void sirius_physical_column_data_scan::build_pipelines(
     case SiriusPhysicalOperatorType::RECURSIVE_RECURRING_CTE_SCAN:
     case SiriusPhysicalOperatorType::RECURSIVE_CTE_SCAN:
       throw not_implemented_exception("Recursive CTE scan not implemented for GPU");
-      if (!meta_pipeline.has_recursive_cte()) {
-        throw internal_exception("Recursive CTE scan found without recursive CTE node");
-      }
-      break;
     default: break;
   }
   D_ASSERT(children.empty());

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -258,15 +258,11 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
   // gpu_pipeline_task::execute_pipeline_task_round ->
   // pipelineable_operator_data::prepare_for_processing -> lock_or_prepare_batch.
   // batches[0]->get_memory_space() == target_space here.
-  cucascade::memory::memory_space* space = nullptr;
-  for (auto const& batch : input_batches) {
-    space = batch.get_memory_space();
-    break;
-  }
-  if (space == nullptr) {
+  if (input_batches.empty()) {
     return std::make_unique<pipelineable_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
+  auto* space = input_batches.front().get_memory_space();
 
   // R1 — read-only accessors held in a vector for the duration of cudf::concatenate
   // so the underlying table_views remain valid.

--- a/src/planner/sirius_plan_recursive_cte.cpp
+++ b/src/planner/sirius_plan_recursive_cte.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "duckdb/common/types/column/column_data_collection.hpp"
-#include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_cteref.hpp"
 #include "helper/type_conversions.hpp"
 #include "op/sirius_physical_column_data_scan.hpp"
@@ -46,13 +44,6 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalCTERef& op)
     }
 
     chunk_scan->collection = cte->second.get();
-    // materialized_cte->second.push_back(*chunk_scan.get())
-
-    // auto gpu_cte = gpu_recursive_cte_tables.find(op.cte_index);
-    // if (gpu_cte == gpu_recursive_cte_tables.end()) {
-    //   throw duckdb::InvalidInputException("Referenced materialized CTE does not exist.");
-    // }
-    // chunk_scan->intermediate_relation = gpu_cte->second;
 
     materialized_cte->second.push_back(*chunk_scan.get());
 
@@ -60,29 +51,6 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalCTERef& op)
   }
 
   throw duckdb::NotImplementedException("Recursive CTE is not implemented");
-
-  auto cte = recursive_cte_tables.find(op.cte_index);
-  if (cte == recursive_cte_tables.end()) {
-    throw duckdb::InvalidInputException("Referenced recursive CTE does not exist.");
-  }
-
-  // If we found a recursive CTE and we want to scan the recurring table, we search for it,
-  if (op.is_recurring) {
-    cte = recurring_cte_tables.find(op.cte_index);
-    if (cte == recurring_cte_tables.end()) {
-      throw duckdb::InvalidInputException(
-        "RECURRING can only be used with USING KEY in recursive CTE.");
-    }
-  }
-
-  auto chunk_scan = duckdb::make_uniq<sirius::op::sirius_physical_column_data_scan>(
-    sirius::from_duckdb_vec(cte->second.get()->Types()),
-    sirius::op::SiriusPhysicalOperatorType::RECURSIVE_CTE_SCAN,
-    op.estimated_cardinality,
-    op.cte_index);
-
-  chunk_scan->collection = cte->second.get();
-  return std::move(chunk_scan);
 }
 
 }  // namespace sirius::planner


### PR DESCRIPTION
## Description

Remove unreachable recursive-CTE code and enable additional low-noise Clang warnings for Sirius C++ targets.

- Delete unused recursive-CTE planning and pipeline code following unconditional “not implemented” exceptions.
- Replace a Top-N loop that always exited after its first iteration with an explicit empty-input check and `front()` access.
- Centralize Clang C++ warning options in CMake and enable these. There could be more but they require more changes:
  `-Wunreachable-code`, `-Wimplicit-fallthrough`,
  `-Wrange-loop-analysis`, and `-Wnull-dereference`.

No user-facing behavior changes: recursive CTEs remain unsupported.

## Validation

- `pixi run ninja -C build/clang-debug extension/sirius/libsirius_extension.a`

## Checklist

- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests — no runtime behavior change; validated by the Clang build
- [x] Document configuration changes in code and summarize in the description above — no runtime configuration changes
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md) — no documentation changes

## References

N/A

_Written by Codex_