### PR TITLE
perf(scan): prune parquet row groups from null_count statistics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -764,6 +764,7 @@ set(TEST_SOURCES
     test/cpp/scan/test_gpu_native_decode.cpp
     test/cpp/scan/test_owning_table_view.cpp
     test/cpp/scan/test_parquet_schema_mapping.cpp
+    test/cpp/scan/test_parquet_null_count_pruning.cpp
     test/cpp/scan/test_parquet_scan_sizing.cpp
     test/cpp/scan/test_scan_schema_normalization.cpp
     test/cpp/sirius_extension/test_sirius_read_parquet_cardinality.cpp

--- a/src/include/op/scan/parquet_gpu_ingestible.hpp
+++ b/src/include/op/scan/parquet_gpu_ingestible.hpp
@@ -250,6 +250,14 @@ class parquet_file_scan_info : public scan_info {
   [[nodiscard]] std::vector<fadvise_entry> fadvise_entries() const override;
 };
 
+/// A top-level `<col> IS [NOT] NULL` conjunct, recorded so the row groups it
+/// excludes can still be pruned from the parquet null_count statistic even
+/// though cuDF's stats filter cannot evaluate the predicate itself.
+struct null_prune_predicate {
+  duckdb::idx_t batch_index;  ///< index into the scan's batch column order
+  bool expects_null;          ///< true for IS NULL, false for IS NOT NULL
+};
+
 //===----------------------------------------------------------------------===//
 // parquet_gpu_ingestible
 //===----------------------------------------------------------------------===//
@@ -335,6 +343,12 @@ class parquet_gpu_ingestible : public gpu_ingestible {
   // partially filtered, so the scan must NOT be reported ROW_FILTERED or the
   // dropped conjuncts would never be applied.
   bool _static_pushdown_is_complete = true;
+
+  // Only the simple `IS [NOT] NULL` over a bare column reference shape is
+  // recorded; anything compound is left to the post-decode filter. Empty when
+  // the predicate has no such conjunct.
+  std::vector<null_prune_predicate> _null_prune_predicates;
+
   std::vector<std::string> _file_paths;
 
   // Per-file metadata-scan cursor. next_split_provider hands out one file index

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -50,7 +50,11 @@
 // duckdb
 #include <duckdb/common/hive_partitioning.hpp>
 #include <duckdb/planner/expression/bound_conjunction_expression.hpp>
+#include <duckdb/planner/expression/bound_operator_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
 #include <duckdb/planner/expression_iterator.hpp>
+#include <duckdb/planner/filter/conjunction_filter.hpp>
+#include <duckdb/planner/filter/null_filter.hpp>
 
 // uring_reactor MUST be included last among sirius headers: liburing.h,
 // pulled in transitively, defines a BLOCK_SIZE macro that collides with the
@@ -67,6 +71,7 @@
 #include <stdexcept>
 #include <string>
 #include <system_error>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -146,6 +151,55 @@ duckdb::unique_ptr<duckdb::Expression> stats_safe_conjuncts(duckdb::Expression c
     duckdb::make_uniq<duckdb::BoundConjunctionExpression>(duckdb::ExpressionType::CONJUNCTION_AND);
   for (auto& child : kept) {
     out->children.push_back(std::move(child));
+  }
+  return out;
+}
+
+/// Every `<col> IS [NOT] NULL` filter usable for null_count row-group pruning.
+///
+/// Read from the TableFilterSet rather than from the converted expression,
+/// because convert_table_filters_to_expression DROPS a column's top-level
+/// IS_NOT_NULL before building the expression. Collecting downstream of that
+/// would leave the ordinary `WHERE v IS NOT NULL` with no pruning at all, which
+/// is the common form of the predicate.
+///
+/// Both a top-level filter and one nested in a conjunction qualify. A
+/// conjunction is an AND of per-column filters, so each null test in it must
+/// hold independently -- unlike an OR, where the other branch could still
+/// match, so those are not collected.
+std::vector<null_prune_predicate> collect_null_prune_predicates(
+  duckdb::TableFilterSet const& filters,
+  duckdb::vector<duckdb::ColumnIndex> const& column_ids,
+  std::vector<std::optional<std::size_t>> const& batch_position_by_column_id,
+  std::unordered_set<std::size_t> const& skip_primary_indices)
+{
+  std::vector<null_prune_predicate> out;
+
+  auto classify = [](duckdb::TableFilterType type) -> std::optional<bool> {
+    if (type == duckdb::TableFilterType::IS_NULL) { return true; }
+    if (type == duckdb::TableFilterType::IS_NOT_NULL) { return false; }
+    return std::nullopt;
+  };
+
+  for (auto const& [column_index, filter] : filters.filters) {
+    // Hive-partition columns are not in the parquet file, so they have no
+    // statistics to prune on.
+    if (column_index >= column_ids.size()) { continue; }
+    if (skip_primary_indices.count(column_ids[column_index].GetPrimaryIndex()) != 0) { continue; }
+    if (column_index >= batch_position_by_column_id.size()) { continue; }
+    auto const& batch_pos = batch_position_by_column_id[column_index];
+    if (!batch_pos.has_value()) { continue; }
+    auto const index = static_cast<duckdb::idx_t>(*batch_pos);
+
+    if (auto expects_null = classify(filter->filter_type)) {
+      out.push_back(null_prune_predicate{index, *expects_null});
+    } else if (filter->filter_type == duckdb::TableFilterType::CONJUNCTION_AND) {
+      for (auto const& child : filter->Cast<duckdb::ConjunctionAndFilter>().child_filters) {
+        if (auto nested = classify(child->filter_type)) {
+          out.push_back(null_prune_predicate{index, *nested});
+        }
+      }
+    }
   }
   return out;
 }
@@ -448,6 +502,14 @@ parquet_gpu_ingestible::parquet_gpu_ingestible(std::unique_ptr<parquet_ingestibl
   // Filters on hive-partition columns are dropped — those columns aren't in the
   // parquet file (DuckDB prunes them at the file-list level already).
   if (bind.table_filters && !bind.table_filters->filters.empty()) {
+    // Collected from the filters themselves, not the expression built below --
+    // see collect_null_prune_predicates. Independent of whether any part of the
+    // predicate survives into reader-side pushdown.
+    _null_prune_predicates = collect_null_prune_predicates(*bind.table_filters,
+                                                           bind.column_ids,
+                                                           _plan->batch_position_by_column_id,
+                                                           _plan->partition_primary_indices);
+
     auto duckdb_expression =
       sirius::op::convert_table_filters_to_expression(*bind.table_filters,
                                                       bind.column_ids,
@@ -712,6 +774,84 @@ std::unique_ptr<scan_info> parquet_gpu_ingestible::build_file_scan_info(
                      file_path,
                      rgs_before,
                      row_group_indices.size());
+  }
+
+  // Prune from null_count for the conjuncts cuDF could not take. `IS NULL`
+  // excludes a row group whose column has no nulls; `IS NOT NULL` excludes one
+  // that is entirely null. Both are exact, so this loses no matching rows.
+  //
+  // null_count is optional in the parquet spec — an absent value means unknown,
+  // never zero, so the row group is kept.
+  if (!_null_prune_predicates.empty() && !row_group_indices.empty()) {
+    struct resolved_predicate {
+      std::size_t chunk_index;
+      bool expects_null;
+    };
+    std::vector<resolved_predicate> resolved;
+    resolved.reserve(_null_prune_predicates.size());
+    for (auto const& pred : _null_prune_predicates) {
+      // Only a scalar top-level column qualifies. For anything nested, the leaf
+      // statistic counts repeated values or leaf-level nulls, neither of which
+      // is the top-level column's nullness -- pruning on it can drop row groups
+      // that do contain matching rows.
+      //
+      // The DECLARED type is what decides this, not the parquet encoding. A
+      // single leaf does not imply scalar (a one-field struct has one), and
+      // neither does a one-component path: legacy parquet allows a top-level
+      // REPEATED primitive, whose path is just the column name, and DuckDB
+      // surfaces that as a LIST.
+      auto const batch_index = static_cast<std::size_t>(pred.batch_index);
+      if (batch_index >= _plan->data_columns.size()) { continue; }
+      auto const primary_idx = _plan->data_columns[batch_index].primary_idx;
+      if (primary_idx >= _info->returned_types.size()) { continue; }
+      auto const& column_type = _info->returned_types[primary_idx];
+      if (column_type.id() == sirius::type_id::LIST || column_type.id() == sirius::type_id::ARRAY ||
+          column_type.id() == sirius::type_id::STRUCT) {
+        continue;
+      }
+
+      auto const leaves =
+        detail::leaf_indices_for_column(metadata, _plan->batch_column_name(pred.batch_index));
+      if (leaves.size() != 1) { continue; }
+      auto const chunk_index = leaves.front();
+      auto const& first_rg   = metadata.row_groups.front();
+      if (chunk_index >= first_rg.columns.size() ||
+          first_rg.columns[chunk_index].meta_data.path_in_schema.size() != 1) {
+        continue;
+      }
+      resolved.push_back({chunk_index, pred.expects_null});
+    }
+
+    if (!resolved.empty()) {
+      auto const rgs_before = row_group_indices.size();
+      auto kept             = decltype(row_group_indices){};
+      kept.reserve(row_group_indices.size());
+      for (auto const rg_idx : row_group_indices) {
+        auto const& rg_meta = metadata.row_groups[static_cast<std::size_t>(rg_idx)];
+        bool keep           = true;
+        for (auto const& pred : resolved) {
+          if (pred.chunk_index >= rg_meta.columns.size()) { continue; }
+          auto const& null_count =
+            rg_meta.columns[pred.chunk_index].meta_data.statistics.null_count;
+          if (!null_count.has_value()) { continue; }
+          bool const provably_empty =
+            pred.expects_null ? (*null_count == 0) : (*null_count == rg_meta.num_rows);
+          if (provably_empty) {
+            keep = false;
+            break;
+          }
+        }
+        if (keep) { kept.push_back(rg_idx); }
+      }
+      row_group_indices = std::move(kept);
+      if (row_group_indices.size() != rgs_before) {
+        SIRIUS_LOG_DEBUG(
+          "[parquet_gpu_ingestible] null_count row group pruning {}: {} -> {} row group(s)",
+          file_path,
+          rgs_before,
+          row_group_indices.size());
+      }
+    }
   }
 
   struct row_group_size_estimate {

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -805,6 +805,8 @@ std::unique_ptr<scan_info> parquet_gpu_ingestible::build_file_scan_info(
       auto const primary_idx = _plan->data_columns[batch_index].primary_idx;
       if (primary_idx >= _info->returned_types.size()) { continue; }
       auto const& column_type = _info->returned_types[primary_idx];
+      // MAP is normalized to Sirius LIST by from_duckdb(). DuckDB UNION is not
+      // supported by that conversion, so it cannot reach this scan path.
       if (column_type.id() == sirius::type_id::LIST || column_type.id() == sirius::type_id::ARRAY ||
           column_type.id() == sirius::type_id::STRUCT) {
         continue;

--- a/test/cpp/scan/test_parquet_null_count_pruning.cpp
+++ b/test/cpp/scan/test_parquet_null_count_pruning.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Row-group pruning from the parquet null_count statistic. The rule itself is
+// documented at the pruning site in parquet_gpu_ingestible.cpp.
+//
+// These assert the SURVIVING ROW-GROUP COUNT rather than query results. An
+// end-to-end query returns the same rows whether or not pruning happens -- the
+// post-decode filter sees to that -- so a correctness test cannot tell whether
+// the pruning ran at all. Driving the ingestible directly is the only way to
+// observe it.
+//
+// See the fixture for why the row groups come out the size they do.
+
+// test
+#include <catch.hpp>
+
+// sirius
+#include <io/kvikio/kvikio_context.hpp>
+#include <op/scan/parquet_gpu_ingestible.hpp>
+#include <op/scan/scan_plan.hpp>
+
+// duckdb
+#include <duckdb.hpp>
+#include <duckdb/planner/filter/null_filter.hpp>
+
+// standard library
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace fs   = std::filesystem;
+namespace scan = sirius::op::scan;
+
+namespace {
+
+/// Sets SIRIUS_DISABLE=1 for a scope and restores the prior value, so a failing
+/// REQUIRE cannot leak a changed global into later tests.
+struct scoped_sirius_disable_set {
+  scoped_sirius_disable_set()
+  {
+    if (char const* val = ::getenv("SIRIUS_DISABLE")) { _saved = val; }
+    ::setenv("SIRIUS_DISABLE", "1", 1);
+  }
+  ~scoped_sirius_disable_set()
+  {
+    if (_saved) {
+      ::setenv("SIRIUS_DISABLE", _saved->c_str(), 1);
+    } else {
+      ::unsetenv("SIRIUS_DISABLE");
+    }
+  }
+  scoped_sirius_disable_set(scoped_sirius_disable_set const&)            = delete;
+  scoped_sirius_disable_set& operator=(scoped_sirius_disable_set const&) = delete;
+
+ private:
+  std::optional<std::string> _saved;
+};
+
+/// Three row groups of 2048 rows, each with a different null shape in `v`:
+///
+///   rg 0  ids     1.. 2048  v entirely NULL
+///   rg 1  ids  2049.. 4096  v entirely non-NULL
+///   rg 2  ids  4097.. 6144  v mixed
+///
+/// So `v IS NULL` can drop exactly rg 1, and `v IS NOT NULL` exactly rg 0.
+///
+/// 2048 is not arbitrary: ROW_GROUP_SIZE is not a hard cut, since the writer
+/// flushes a whole buffered DataChunk (<= 2048 rows) as one group. Any other
+/// size yields ragged groups that do not align with the shapes above.
+class NullCountFixture {
+ public:
+  NullCountFixture()
+  {
+    static std::atomic<unsigned> ctr{0};
+    dir_ = fs::temp_directory_path() / ("sirius_null_count_" + std::to_string(::getpid()) + "_" +
+                                        std::to_string(ctr.fetch_add(1)));
+    // PID + a process-local counter repeats once PIDs are reused, and
+    // create_directories accepts an existing directory — a previous run's file
+    // would then be read instead of the one about to be written.
+    std::error_code rm_ec;
+    fs::remove_all(dir_, rm_ec);
+    fs::create_directories(dir_);
+    path_ = (dir_ / "null_count.parquet").string();
+
+    scoped_sirius_disable_set disable_guard;
+    duckdb::DuckDB db(nullptr);
+    duckdb::Connection con(db);
+    for (auto const& sql : std::vector<std::string>{
+           "CREATE TABLE nc (id INTEGER, v INTEGER)",
+           "INSERT INTO nc SELECT i,"
+           "  CASE WHEN i <= 2048 THEN NULL"
+           "       WHEN i <= 4096 THEN i"
+           "       ELSE CASE WHEN i % 2 = 0 THEN i END END"
+           "  FROM range(1, 6145) AS t(i)",
+           // ORDER BY, not incidental ordering: which rows land in which row
+           // group is the entire point of this fixture, and DuckDB is
+           // explicitly allowed to reorder a query that does not ask for an
+           // order (preserve_insertion_order is a global setting).
+           "COPY (SELECT * FROM nc ORDER BY id) TO '" + path_ +
+             "' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)",
+         }) {
+      auto r = con.Query(sql);
+      REQUIRE(r);
+      if (r->HasError()) { UNSCOPED_INFO("fixture setup error: " << r->GetError()); }
+      REQUIRE_FALSE(r->HasError());
+    }
+
+    // Verify the layout the tests below depend on. Without this the pruning
+    // assertions are unanchored: "IS NULL drops one group" means nothing unless
+    // exactly one group is known to hold no NULLs.
+    //
+    //   rg 0  ids     1..2048  all NULL      -> 2048
+    //   rg 1  ids  2049..4096  none NULL     ->    0
+    //   rg 2  ids  4097..6144  odd ids NULL  -> 1024
+    auto layout = con.Query("SELECT row_group_num_rows, stats_null_count FROM parquet_metadata('" +
+                            path_ + "') WHERE path_in_schema = 'v' ORDER BY row_group_id");
+    REQUIRE(layout);
+    REQUIRE_FALSE(layout->HasError());
+    REQUIRE(layout->RowCount() == 3);
+
+    std::vector<std::int64_t> const expected_nulls{2048, 0, 1024};
+    for (duckdb::idx_t i = 0; i < 3; i++) {
+      auto const rows = layout->GetValue(0, i).GetValue<std::int64_t>();
+      if (rows != 2048) {
+        UNSCOPED_INFO("row group " << i << " has " << rows << " rows, expected 2048");
+        REQUIRE(rows == 2048);
+      }
+      // Absent statistics would make the pruning untestable, not merely
+      // unverified — null_count is what the feature reads.
+      REQUIRE_FALSE(layout->GetValue(1, i).IsNull());
+      auto const nulls = layout->GetValue(1, i).GetValue<std::int64_t>();
+      if (nulls != expected_nulls[i]) {
+        UNSCOPED_INFO("row group " << i << " has " << nulls << " NULLs, expected "
+                                   << expected_nulls[i]);
+        REQUIRE(nulls == expected_nulls[i]);
+      }
+    }
+  }
+
+  ~NullCountFixture()
+  {
+    // Best-effort: a destructor is noexcept, so a leftover temp dir must not
+    // become a std::terminate.
+    std::error_code ec;
+    fs::remove_all(dir_, ec);
+  }
+
+  /// Scan info projecting (id, v), optionally with a null filter on `v`.
+  std::unique_ptr<scan::parquet_ingestible_table_info> make_info(
+    std::optional<bool> filter_expects_null) const
+  {
+    auto info                 = std::make_unique<scan::parquet_ingestible_table_info>();
+    info->resolved_file_paths = {path_};
+    info->names               = {"id", "v"};
+    info->returned_types.push_back(sirius::logical_type::make(sirius::type_id::INTEGER));
+    info->returned_types.push_back(sirius::logical_type::make(sirius::type_id::INTEGER));
+    info->column_ids.push_back(duckdb::ColumnIndex(0));
+    info->column_ids.push_back(duckdb::ColumnIndex(1));
+    info->scan_output_arity      = 2;
+    info->approximate_batch_size = std::size_t{1} << 30;
+
+    if (filter_expects_null) {
+      auto filters = duckdb::make_uniq<duckdb::TableFilterSet>();
+      // Column 1 is `v`; the index is into column_ids.
+      if (*filter_expects_null) {
+        filters->PushFilter(duckdb::ColumnIndex(1), duckdb::make_uniq<duckdb::IsNullFilter>());
+      } else {
+        filters->PushFilter(duckdb::ColumnIndex(1), duckdb::make_uniq<duckdb::IsNotNullFilter>());
+      }
+      info->table_filters = std::move(filters);
+    }
+    return info;
+  }
+
+  /// Row groups surviving the metadata scan for the given filter.
+  std::size_t surviving_row_groups(std::optional<bool> filter_expects_null) const
+  {
+    auto ingestible = scan::make_ingestible(make_info(filter_expects_null));
+    auto ioctx      = std::make_shared<sirius::io::kvikio_context>();
+    auto task       = ingestible->next_split_provider(
+      [ioctx](std::string_view) -> std::shared_ptr<sirius::io::sirius_ioctx> { return ioctx; });
+    REQUIRE(task);
+    auto info = task();
+    REQUIRE(info);
+    auto* file = dynamic_cast<scan::parquet_file_scan_info*>(info.get());
+    REQUIRE(file);
+    return file->row_groups.size();
+  }
+
+ protected:
+  fs::path dir_;
+  std::string path_;
+};
+
+}  // namespace
+
+// Baseline: with no filter every row group survives. Establishes that the file
+// really does have three, so the pruning counts below mean something.
+TEST_CASE_METHOD(NullCountFixture,
+                 "null_count pruning - unfiltered scan keeps every row group",
+                 "[scan][parquet][pruning][null_count]")
+{
+  REQUIRE(surviving_row_groups(std::nullopt) == 3);
+}
+
+// `v IS NULL` cannot match the all-non-NULL row group (null_count == 0).
+TEST_CASE_METHOD(NullCountFixture,
+                 "null_count pruning - IS NULL drops row groups with no nulls",
+                 "[scan][parquet][pruning][null_count]")
+{
+  CHECK(surviving_row_groups(/*filter_expects_null=*/true) == 2);
+}
+
+// `v IS NOT NULL` cannot match the wholly-NULL row group
+// (null_count == num_rows).
+//
+// A BARE filter on purpose: with no sibling comparison there is nothing for
+// cuDF's statistics filter to push, so null_count pruning is the only thing
+// that can drop a row group and the count below is evidence about it alone.
+TEST_CASE_METHOD(NullCountFixture,
+                 "null_count pruning - IS NOT NULL drops wholly-null row groups",
+                 "[scan][parquet][pruning][null_count]")
+{
+  CHECK(surviving_row_groups(/*filter_expects_null=*/false) == 2);
+}

--- a/test/cpp/scan/test_parquet_null_count_pruning.cpp
+++ b/test/cpp/scan/test_parquet_null_count_pruning.cpp
@@ -32,51 +32,22 @@
 #include <io/kvikio/kvikio_context.hpp>
 #include <op/scan/parquet_gpu_ingestible.hpp>
 #include <op/scan/scan_plan.hpp>
+#include <utils/parquet_fixture_utils.hpp>
 
 // duckdb
 #include <duckdb.hpp>
 #include <duckdb/planner/filter/null_filter.hpp>
 
 // standard library
-#include <unistd.h>
-
-#include <atomic>
 #include <cstdint>
-#include <cstdlib>
-#include <filesystem>
 #include <memory>
 #include <optional>
 #include <string>
-#include <system_error>
 #include <vector>
 
-namespace fs   = std::filesystem;
 namespace scan = sirius::op::scan;
 
 namespace {
-
-/// Sets SIRIUS_DISABLE=1 for a scope and restores the prior value, so a failing
-/// REQUIRE cannot leak a changed global into later tests.
-struct scoped_sirius_disable_set {
-  scoped_sirius_disable_set()
-  {
-    if (char const* val = ::getenv("SIRIUS_DISABLE")) { _saved = val; }
-    ::setenv("SIRIUS_DISABLE", "1", 1);
-  }
-  ~scoped_sirius_disable_set()
-  {
-    if (_saved) {
-      ::setenv("SIRIUS_DISABLE", _saved->c_str(), 1);
-    } else {
-      ::unsetenv("SIRIUS_DISABLE");
-    }
-  }
-  scoped_sirius_disable_set(scoped_sirius_disable_set const&)            = delete;
-  scoped_sirius_disable_set& operator=(scoped_sirius_disable_set const&) = delete;
-
- private:
-  std::optional<std::string> _saved;
-};
 
 /// Three row groups of 2048 rows, each with a different null shape in `v`:
 ///
@@ -93,18 +64,9 @@ class NullCountFixture {
  public:
   NullCountFixture()
   {
-    static std::atomic<unsigned> ctr{0};
-    dir_ = fs::temp_directory_path() / ("sirius_null_count_" + std::to_string(::getpid()) + "_" +
-                                        std::to_string(ctr.fetch_add(1)));
-    // PID + a process-local counter repeats once PIDs are reused, and
-    // create_directories accepts an existing directory — a previous run's file
-    // would then be read instead of the one about to be written.
-    std::error_code rm_ec;
-    fs::remove_all(dir_, rm_ec);
-    fs::create_directories(dir_);
-    path_ = (dir_ / "null_count.parquet").string();
+    path_ = dir_.file("null_count.parquet");
 
-    scoped_sirius_disable_set disable_guard;
+    sirius::test::scoped_sirius_disable disable_guard;
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
     for (auto const& sql : std::vector<std::string>{
@@ -118,8 +80,8 @@ class NullCountFixture {
            // group is the entire point of this fixture, and DuckDB is
            // explicitly allowed to reorder a query that does not ask for an
            // order (preserve_insertion_order is a global setting).
-           "COPY (SELECT * FROM nc ORDER BY id) TO '" + path_ +
-             "' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)",
+           "COPY (SELECT * FROM nc ORDER BY id) TO " + sirius::test::sql_literal(path_) +
+             " (FORMAT PARQUET, ROW_GROUP_SIZE 2048)",
          }) {
       auto r = con.Query(sql);
       REQUIRE(r);
@@ -134,8 +96,9 @@ class NullCountFixture {
     //   rg 0  ids     1..2048  all NULL      -> 2048
     //   rg 1  ids  2049..4096  none NULL     ->    0
     //   rg 2  ids  4097..6144  odd ids NULL  -> 1024
-    auto layout = con.Query("SELECT row_group_num_rows, stats_null_count FROM parquet_metadata('" +
-                            path_ + "') WHERE path_in_schema = 'v' ORDER BY row_group_id");
+    auto layout = con.Query("SELECT row_group_num_rows, stats_null_count FROM parquet_metadata(" +
+                            sirius::test::sql_literal(path_) +
+                            ") WHERE path_in_schema = 'v' ORDER BY row_group_id");
     REQUIRE(layout);
     REQUIRE_FALSE(layout->HasError());
     REQUIRE(layout->RowCount() == 3);
@@ -157,14 +120,6 @@ class NullCountFixture {
         REQUIRE(nulls == expected_nulls[i]);
       }
     }
-  }
-
-  ~NullCountFixture()
-  {
-    // Best-effort: a destructor is noexcept, so a leftover temp dir must not
-    // become a std::terminate.
-    std::error_code ec;
-    fs::remove_all(dir_, ec);
   }
 
   /// Scan info projecting (id, v), optionally with a null filter on `v`.
@@ -210,7 +165,7 @@ class NullCountFixture {
   }
 
  protected:
-  fs::path dir_;
+  sirius::test::scratch_dir dir_{"null_count"};
   std::string path_;
 };
 
@@ -230,7 +185,7 @@ TEST_CASE_METHOD(NullCountFixture,
                  "null_count pruning - IS NULL drops row groups with no nulls",
                  "[scan][parquet][pruning][null_count]")
 {
-  CHECK(surviving_row_groups(/*filter_expects_null=*/true) == 2);
+  REQUIRE(surviving_row_groups(/*filter_expects_null=*/true) == 2);
 }
 
 // `v IS NOT NULL` cannot match the wholly-NULL row group
@@ -243,5 +198,5 @@ TEST_CASE_METHOD(NullCountFixture,
                  "null_count pruning - IS NOT NULL drops wholly-null row groups",
                  "[scan][parquet][pruning][null_count]")
 {
-  CHECK(surviving_row_groups(/*filter_expects_null=*/false) == 2);
+  REQUIRE(surviving_row_groups(/*filter_expects_null=*/false) == 2);
 }

--- a/test/cpp/utils/parquet_fixture_utils.hpp
+++ b/test/cpp/utils/parquet_fixture_utils.hpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+/**
+ * @file parquet_fixture_utils.hpp
+ * @brief Shared pieces for tests that generate their own parquet files.
+ *
+ * Several test files build a scratch directory, write parquet into it with a
+ * Sirius-disabled DuckDB, and interpolate the resulting paths into SQL. Each
+ * had grown its own copy of the same three details, and the details are easy to
+ * get subtly wrong — see the notes on each below.
+ */
+
+#include <catch.hpp>
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <system_error>
+
+namespace sirius::test {
+
+/// Sets SIRIUS_DISABLE=1 for a scope, restoring whatever was there before.
+///
+/// The harness deliberately keeps SIRIUS_DISABLE=1 so untagged tests' DuckDB
+/// instances do not auto-initialize a SiriusContext (see
+/// scoped_sirius_disable_clear in test_plan_printer.cpp). Plain
+/// setenv/unsetenv therefore leaks a changed global into later tests, and a
+/// REQUIRE that throws in between skips the unset entirely. Restoring in a
+/// destructor fixes both.
+struct scoped_sirius_disable {
+  scoped_sirius_disable()
+  {
+    if (char const* value = ::getenv("SIRIUS_DISABLE")) { _saved = value; }
+    ::setenv("SIRIUS_DISABLE", "1", 1);
+  }
+  ~scoped_sirius_disable()
+  {
+    if (_saved) {
+      ::setenv("SIRIUS_DISABLE", _saved->c_str(), 1);
+    } else {
+      ::unsetenv("SIRIUS_DISABLE");
+    }
+  }
+  scoped_sirius_disable(scoped_sirius_disable const&)            = delete;
+  scoped_sirius_disable& operator=(scoped_sirius_disable const&) = delete;
+
+ private:
+  std::optional<std::string> _saved;
+};
+
+/// A single-quoted SQL literal with embedded quotes doubled.
+///
+/// Paths are interpolated into generated SQL, and a TMPDIR containing a quote
+/// is legal — it would otherwise close the literal early and break every
+/// statement built from it.
+inline std::string sql_literal(std::string const& value)
+{
+  std::string out = "'";
+  for (char const c : value) {
+    if (c == '\'') { out.push_back('\''); }
+    out.push_back(c);
+  }
+  out.push_back('\'');
+  return out;
+}
+
+/// A uniquely-named scratch directory, removed on destruction.
+///
+/// The name mixes @p tag, the pid and a process-local counter. The directory is
+/// cleared before use rather than merely created: pids are reused (pid 1 in a
+/// container makes that likely), and create_directories accepts an existing
+/// directory, so a previous run's files could otherwise be read in place of the
+/// ones about to be written.
+class scratch_dir {
+ public:
+  explicit scratch_dir(std::string const& tag)
+  {
+    static std::atomic<unsigned> counter{0};
+    _path = std::filesystem::temp_directory_path() /
+            ("sirius_test_" + tag + "_" + std::to_string(::getpid()) + "_" +
+             std::to_string(counter.fetch_add(1)));
+    std::error_code ec;
+    std::filesystem::remove_all(_path, ec);
+    std::filesystem::create_directories(_path);
+  }
+
+  /// Best-effort: a destructor is noexcept, so a directory that cannot be
+  /// removed must not become a std::terminate.
+  ~scratch_dir()
+  {
+    std::error_code ec;
+    std::filesystem::remove_all(_path, ec);
+  }
+
+  scratch_dir(scratch_dir const&)            = delete;
+  scratch_dir& operator=(scratch_dir const&) = delete;
+
+  [[nodiscard]] std::filesystem::path const& path() const noexcept { return _path; }
+
+  /// Absolute path of @p name inside the directory.
+  [[nodiscard]] std::string file(std::string const& name) const { return (_path / name).string(); }
+
+  /// @ref file as a quote-safe SQL literal.
+  [[nodiscard]] std::string file_literal(std::string const& name) const
+  {
+    return sql_literal(file(name));
+  }
+
+ private:
+  std::filesystem::path _path;
+};
+
+}  // namespace sirius::test


### PR DESCRIPTION
## Description

Follow-up to [#1417](https://github.com/sirius-db/sirius/pull/1417), which prevented null predicates from reaching cuDF’s row-group statistics filter because cuDF faults on them. Those predicates still run after decoding, but no longer contributed to row-group pruning, so queries such as `WHERE v IS NULL` read every row group.

Parquet footer statistics provide the necessary information:

- `IS NULL` cannot match when `null_count == 0`.
- `IS NOT NULL` cannot match when `null_count == num_rows`.

Sirius now applies these checks alongside cuDF’s pruning of other conjuncts. Only row groups proven unable to contain a match are skipped, so query results are unchanged.

### Safety constraints

- **Missing statistics:** `null_count` is optional. An absent value means unknown, so the row group is retained.
- **Scalar columns only:** Eligibility is determined from the declared type and validated against the Parquet leaf mapping. Nested-column leaf statistics describe repeated values or leaf-level nullness, not top-level nullness. This also excludes legacy top-level `REPEATED` primitives that DuckDB exposes as `LIST`.
- **Conjunctive predicates only:** Null tests in conjunctive positions can prune independently. Null tests inside `OR` expressions cannot, because another branch may still match.

Predicates are collected directly from `TableFilterSet`. This is necessary because `convert_table_filters_to_expression` removes top-level `IS_NOT_NULL` filters before constructing the expression; collecting afterward would miss ordinary `WHERE v IS NOT NULL` predicates.

### Testing

Result comparison alone cannot prove pruning occurred because the full predicate is still applied after decoding. The new tests therefore drive the ingestible directly and assert the surviving row-group count.

The fixture also validates its physical layout—including per-group row counts, null counts, and the presence of statistics—before testing pruning.

## Checklist

- [x] Cover changes with new or existing tests
- [x] No configuration changes
- [x] No user-facing documentation changes required

## References

Follow-up to [#1417](https://github.com/sirius-db/sirius/pull/1417).