### PR TITLE
test: skip global environments in child runners (WIP)

### DIFF
--- a/test/cpp/integration/test_gpu_execution_multi_format.cpp
+++ b/test/cpp/integration/test_gpu_execution_multi_format.cpp
@@ -30,6 +30,7 @@
 #include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <utils/child_runner.hpp>
 #include <utils/sirius_test_env.hpp>
 #include <utils/transparent_execution_test_utils.hpp>
 
@@ -642,6 +643,7 @@ class HivePartitionDataset {
       ::setenv("SIRIUS_HIVE_WATCHDOG_OUTPUT", output_path.string().c_str(), 1);
       ::setenv("SIRIUS_HIVE_WATCHDOG_CONFIG", config_path.string().c_str(), 1);
       ::setenv("SIRIUS_CONFIG_FILE", config_path.string().c_str(), 1);
+      if (!sirius::test::mark_child_runner()) { ::_exit(127); }
       ::execl("/proc/self/exe",
               "sirius_unittest",
               "gpu_execution hive partition watchdog child runner",
@@ -743,6 +745,10 @@ class GPUExecutionEscapedHivePartitionFixture : public MultiFormatFixtureBase,
 TEST_CASE("gpu_execution hive partition watchdog child runner",
           "[.][gpu_execution][hive_partition][watchdog_child]")
 {
+  REQUIRE(sirius::test::g_shared_env == nullptr);
+  REQUIRE(sirius::test::g_integration_env == nullptr);
+  REQUIRE(sirius::test::g_integration_env_2gpu == nullptr);
+
   auto const* query      = std::getenv("SIRIUS_HIVE_WATCHDOG_QUERY");
   auto const* output_raw = std::getenv("SIRIUS_HIVE_WATCHDOG_OUTPUT");
   if (query == nullptr || output_raw == nullptr) { return; }
@@ -757,9 +763,8 @@ TEST_CASE("gpu_execution hive partition watchdog child runner",
     std::unique_ptr<duckdb::Connection> con;
     if (out.error.empty()) {
       config_guard = std::make_unique<sirius_config_env_guard>(config_raw);
-      unsetenv("SIRIUS_DISABLE");
-      db  = std::make_unique<duckdb::DuckDB>(nullptr);
-      con = std::make_unique<duckdb::Connection>(*db);
+      db           = std::make_unique<duckdb::DuckDB>(nullptr);
+      con          = std::make_unique<duckdb::Connection>(*db);
     }
 
     auto set_gpu = out.error.empty() ? con->Query("SET gpu_execution = true;") : nullptr;

--- a/test/cpp/integration/test_query_lifecycle_slot.cpp
+++ b/test/cpp/integration/test_query_lifecycle_slot.cpp
@@ -41,6 +41,8 @@
 #include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <utils/child_runner.hpp>
+#include <utils/sirius_test_env.hpp>
 #include <utils/transparent_execution_test_utils.hpp>
 
 #include <algorithm>
@@ -2098,6 +2100,10 @@ slot_watchdog_result run_scenario(std::string const& variant,
 // standard gate; runs only when selected by its exact name.
 TEST_CASE(kChildRunnerCase, "[.][query_lifecycle][watchdog_child]")
 {
+  REQUIRE(sirius::test::g_shared_env == nullptr);
+  REQUIRE(sirius::test::g_integration_env == nullptr);
+  REQUIRE(sirius::test::g_integration_env_2gpu == nullptr);
+
   auto const* variant_raw = std::getenv(kEnvVariant);
   auto const* output_raw  = std::getenv(kEnvOutput);
   auto const* config_raw  = std::getenv(kEnvConfig);
@@ -2108,7 +2114,6 @@ TEST_CASE(kChildRunnerCase, "[.][query_lifecycle][watchdog_child]")
     out.error = "watchdog child missing config path";
   } else {
     ::setenv("SIRIUS_CONFIG_FILE", config_raw, 1);
-    ::unsetenv("SIRIUS_DISABLE");
     auto const output_path = fs::path(output_raw);
     auto const database_path =
       output_path.parent_path() / ("scenario_" + std::string(variant_raw) + ".duckdb");
@@ -2155,6 +2160,7 @@ class QueryLifecycleSlotFixture {
         ::setenv("SIRIUS_LOG_DIR", log_dir.string().c_str(), 1);
         ::setenv("SIRIUS_LOG_LEVEL", "debug", 1);
       }
+      if (!sirius::test::mark_child_runner()) { ::_exit(127); }
       // A child that inherited a live CUDA context must re-exec before running an
       // engine query, so re-invoke the unit-test binary for the child-runner case.
       ::execl("/proc/self/exe", "sirius_unittest", kChildRunnerCase, static_cast<char*>(nullptr));

--- a/test/cpp/integration/test_transparent_runtime_fallback.cpp
+++ b/test/cpp/integration/test_transparent_runtime_fallback.cpp
@@ -28,6 +28,7 @@
 #include <sys/wait.h>
 #include <unistd.h>  // getpid
 #include <util/duckdb_error_message.hpp>
+#include <utils/child_runner.hpp>
 #include <utils/gpu_execution_fixture.hpp>
 #include <utils/sirius_test_env.hpp>
 #include <utils/transparent_execution_test_utils.hpp>
@@ -565,13 +566,17 @@ child_result run_s3mix_child(std::string const& scenario, std::chrono::seconds t
   }
   child_argv.push_back(nullptr);
 
-  auto const scenario_prefix = std::string{kS3MixScenarioEnv} + "=";
+  auto const scenario_prefix     = std::string{kS3MixScenarioEnv} + "=";
+  auto const child_runner_prefix = std::string{sirius::test::child_runner_env} + "=";
   std::vector<std::string> child_environment;
   for (auto entry = environ; entry != nullptr && *entry != nullptr; ++entry) {
     std::string value{*entry};
-    if (value.rfind(scenario_prefix, 0) != 0) { child_environment.push_back(std::move(value)); }
+    if (value.rfind(scenario_prefix, 0) != 0 && value.rfind(child_runner_prefix, 0) != 0) {
+      child_environment.push_back(std::move(value));
+    }
   }
   child_environment.push_back(scenario_prefix + scenario);
+  child_environment.push_back(child_runner_prefix + sirius::test::child_runner_env_value);
 
   std::vector<char*> child_envp;
   child_envp.reserve(child_environment.size() + 1);
@@ -650,6 +655,10 @@ void require_s3mix_child_survives(std::string const& scenario,
 
 TEST_CASE("S3 mix fallback child runner", "[.][transparent][integration][s3mix_child]")
 {
+  REQUIRE(sirius::test::g_shared_env == nullptr);
+  REQUIRE(sirius::test::g_integration_env == nullptr);
+  REQUIRE(sirius::test::g_integration_env_2gpu == nullptr);
+
   auto const* scenario = std::getenv(kS3MixScenarioEnv);
   if (scenario == nullptr) { return; }
   run_s3mix_scenario(scenario);

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -23,6 +23,7 @@
 #include "memory/topology_index.hpp"
 #include "scan/test_utils.hpp"
 #include "scan_manager/sirius_scan_manager.hpp"
+#include "utils/child_runner.hpp"
 #include "utils/s3_container.hpp"
 #include "utils/sirius_test_env.hpp"
 
@@ -824,6 +825,7 @@ list_watchdog_result run_list_watchdog(range_http_server const& server,
   auto const pid = ::fork();
   REQUIRE(pid >= 0);
   if (pid == 0) {
+    if (!sirius::test::mark_child_runner()) { ::_exit(127); }
     ::execl("/proc/self/exe",
             "sirius_unittest",
             "rest LIST loop watchdog child runner",
@@ -888,6 +890,10 @@ TEST_CASE("rest_ioctx lists S3 objects with sizes and follows encoded continuati
 
 TEST_CASE("rest LIST loop watchdog child runner", "[.][rest][list][watchdog_child]")
 {
+  REQUIRE(sirius::test::g_shared_env == nullptr);
+  REQUIRE(sirius::test::g_integration_env == nullptr);
+  REQUIRE(sirius::test::g_integration_env_2gpu == nullptr);
+
   auto const* endpoint = std::getenv("SIRIUS_TEST_REST_LIST_WATCHDOG_ENDPOINT");
   if (endpoint == nullptr) { return; }
 

--- a/test/cpp/unittest.cpp
+++ b/test/cpp/unittest.cpp
@@ -21,6 +21,7 @@
 #include "log/logging.hpp"
 #include "log/spdlog_owning_sink.hpp"
 #include "util/segfault_backtrace.hpp"
+#include "utils/child_runner.hpp"
 #include "utils/s3_container.hpp"
 #include "utils/sirius_test_env.hpp"
 
@@ -120,31 +121,38 @@ int main(int argc, char* argv[])
   // by the listener for tests with the matching tag. This avoids GPU memory
   // conflicts with operator tests that use their own memory managers.
   // Only one environment can be active at a time.
-  auto scan_config_path =
-    std::filesystem::path(SIRIUS_PROJECT_ROOT) / "test" / "cpp" / "scan" / "memory.yaml";
-  sirius::test::shared_test_env scan_env(scan_config_path);
-  scan_env.pause();
-  sirius::test::g_shared_env = &scan_env;
-
-  auto integration_config_path = std::filesystem::path(SIRIUS_PROJECT_ROOT) / "test" / "cpp" /
-                                 "integration" / "integration.yaml";
-  sirius::test::shared_test_env integration_env(integration_config_path);
-  integration_env.pause();
-  sirius::test::g_integration_env = &integration_env;
-
-  // 2-GPU integration env (TEST-01/02 v1.2). Starts paused; TEST_CASE bodies
-  // that parameterize on num_gpus via GENERATE(1, 2) pick this env up via
-  // sirius::test::acquire_integration_env_for(2) and call resume()/pause()
-  // around each call to compare_gpu_vs_cpu.
-  auto integration_config_2gpu_path = std::filesystem::path(SIRIUS_PROJECT_ROOT) / "test" / "cpp" /
-                                      "integration" / "integration-2gpu.yaml";
-  int _dev_count = 0;
-  cudaGetDeviceCount(&_dev_count);
+  // Re-executed watchdog children create their own state and leave these holders empty.
+  std::optional<sirius::test::shared_test_env> scan_env_holder;
+  std::optional<sirius::test::shared_test_env> integration_env_holder;
   std::optional<sirius::test::shared_test_env> integration_env_2gpu_holder;
-  if (_dev_count >= 2) {
-    integration_env_2gpu_holder.emplace(integration_config_2gpu_path);
-    integration_env_2gpu_holder->pause();
-    sirius::test::g_integration_env_2gpu = &(*integration_env_2gpu_holder);
+  if (sirius::test::is_child_runner()) {
+    ::unsetenv("SIRIUS_DISABLE");
+  } else {
+    auto scan_config_path =
+      std::filesystem::path(SIRIUS_PROJECT_ROOT) / "test" / "cpp" / "scan" / "memory.yaml";
+    scan_env_holder.emplace(scan_config_path);
+    scan_env_holder->pause();
+    sirius::test::g_shared_env = &(*scan_env_holder);
+
+    auto integration_config_path = std::filesystem::path(SIRIUS_PROJECT_ROOT) / "test" / "cpp" /
+                                   "integration" / "integration.yaml";
+    integration_env_holder.emplace(integration_config_path);
+    integration_env_holder->pause();
+    sirius::test::g_integration_env = &(*integration_env_holder);
+
+    // 2-GPU integration env (TEST-01/02 v1.2). Starts paused; TEST_CASE bodies
+    // that parameterize on num_gpus via GENERATE(1, 2) pick this env up via
+    // sirius::test::acquire_integration_env_for(2) and call resume()/pause()
+    // around each call to compare_gpu_vs_cpu.
+    auto integration_config_2gpu_path = std::filesystem::path(SIRIUS_PROJECT_ROOT) / "test" /
+                                        "cpp" / "integration" / "integration-2gpu.yaml";
+    int _dev_count = 0;
+    cudaGetDeviceCount(&_dev_count);
+    if (_dev_count >= 2) {
+      integration_env_2gpu_holder.emplace(integration_config_2gpu_path);
+      integration_env_2gpu_holder->pause();
+      sirius::test::g_integration_env_2gpu = &(*integration_env_2gpu_holder);
+    }
   }
 
   // Bring up the S3 test backend (MinIO via testcontainers) once, when the [s3]

--- a/test/cpp/utils/child_runner.hpp
+++ b/test/cpp/utils/child_runner.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdlib>
+#include <string_view>
+
+namespace sirius::test {
+
+inline constexpr char child_runner_env[]       = "SIRIUS_INTERNAL_CHILD_RUNNER";
+inline constexpr char child_runner_env_value[] = "1";
+
+inline bool is_child_runner()
+{
+  auto const* value = std::getenv(child_runner_env);
+  return value != nullptr && std::string_view{value} == child_runner_env_value;
+}
+
+inline bool mark_child_runner()
+{
+  return ::setenv(child_runner_env, child_runner_env_value, 1) == 0;
+}
+
+}  // namespace sirius::test

--- a/test/cpp/utils/sirius_test_env.hpp
+++ b/test/cpp/utils/sirius_test_env.hpp
@@ -92,8 +92,9 @@ class shared_test_env {
 /**
  * @brief Non-owning pointer to the shared test environment.
  *
- * Managed by main() in unittest.cpp. Non-null for the entire test run.
- * Check is_active() before using — it may be temporarily paused for isolated tests.
+ * Managed by main() in unittest.cpp. Non-null during ordinary test runs and null
+ * for marked child runners. Check is_active() before using — it may be temporarily
+ * paused for isolated tests.
  */
 extern shared_test_env* g_shared_env;
 extern shared_test_env* g_integration_env;


### PR DESCRIPTION
## Description

Watchdog tests re-execute the unit-test binary to run isolated hidden child cases. These children previously initialized and paused every global Sirius test environment before Catch2 selected the requested case.

This change:

- marks only forked child-runner processes before `exec`;
- preserves the marker in the S3 watchdog's explicit `execve` environment;
- bypasses shared, one-GPU, and two-GPU environment initialization and device discovery for marked children;
- leaves all global environment pointers null and verifies that invariant in each child case;
- clears inherited `SIRIUS_DISABLE` centrally so child-local DuckDB instances initialize Sirius normally.

Representative direct child startup decreased from a median of 2.157 seconds to 0.270 seconds, an 87.5% reduction.

## Testing

- `pixi run make`
- All changed-file pre-commit hooks
- Both REST watchdog parent tests
- All 18 `[s3mix]` tests
- Hive partition watchdog parent, including all four child executions
- All 11 non-hidden `[slot_leak]` parent tests
- Representative normal `[shared_context]` and `[integration]` tests
- Post-review smoke tests covering each child-runner family

CUDA reported fewer than two GPUs, so aggregate two-GPU runtime and live two-GPU environment verification could not be performed.

## Checklist

- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above — not applicable; no configuration options changed
- [x] Update human and agent documentation — test-harness pointer documentation was updated; no user-facing documentation changes are required

_Written by Codex._