### PR TITLE
feat(telemetry): capture libcudf NVTX spans and serve NVTX routes

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -33,7 +33,7 @@ jobs:
       duckdb_version: v1.5.5
       ci_tools_version: sirius
       exclude_archs: "linux_amd64_musl;linux_arm64_musl;osx_amd64;osx_arm64;windows_amd64;windows_arm64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
-      extra_toolchains: "cuda;rust;protobuf"
+      extra_toolchains: "cuda;rust;protobuf;libclang"
       vcpkg_url: "https://github.com/microsoft/vcpkg.git"
       vcpkg_commit: "ffc071e0c08432c60c9b64f00334c0227667931b"
       vcpkg_binary_cache_enabled: true
@@ -57,7 +57,7 @@ jobs:
       duckdb_version: v1.5.5
       ci_tools_version: sirius
       exclude_archs: "linux_amd64_musl;linux_arm64_musl;osx_amd64;osx_arm64;windows_amd64;windows_arm64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
-      extra_toolchains: "cuda;rust;protobuf"
+      extra_toolchains: "cuda;rust;protobuf;libclang"
       vcpkg_url: "https://github.com/microsoft/vcpkg.git"
       vcpkg_commit: "ffc071e0c08432c60c9b64f00334c0227667931b"
       vcpkg_binary_cache_enabled: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -602,6 +602,14 @@ foreach(_target sirius_extension sirius_loadable_extension)
     parquet_extension
     simpatico)
 
+  # Corrosion exposes telemetry_bridge as an INTERFACE target whose concrete
+  # Rust archive is telemetry_bridge-static. Apply WHOLE_ARCHIVE to that real
+  # archive so the unreferenced NVTX static-injection shim reaches the final
+  # loadable extension instead of being dropped at the nested archive boundary.
+  set_property(
+    TARGET ${_target} PROPERTY "LINK_LIBRARY_OVERRIDE_telemetry_bridge-static"
+                               WHOLE_ARCHIVE)
+
   add_dependencies(${_target} duckdb_static)
 endforeach()
 
@@ -609,8 +617,23 @@ endforeach()
 target_link_libraries(sirius_extension PkgConfig::NUMA PkgConfig::LIBURING
                       PkgConfig::CURL OpenSSL::Crypto absl::any_invocable)
 
+# `sirius_extension` is itself an archive, so its LINK_LIBRARY_OVERRIDE does not
+# perform a final link. Carry the concrete Rust archive as a transitive
+# WHOLE_ARCHIVE item instead; DuckDB and every other final consumer then retain
+# the static NVTX pointer shim as well.
+target_link_libraries(sirius_extension
+                      "$<LINK_LIBRARY:WHOLE_ARCHIVE,telemetry_bridge-static>")
+
 target_link_libraries(sirius_loadable_extension PkgConfig::LIBURING
                       PkgConfig::CURL OpenSSL::Crypto)
+
+# NVTX's runtime injection lookup dlopens the path named by
+# NVTX_INJECTION64_PATH and resolves InitializeInjectionNvtx2 from it. Export
+# the statically embedded Quent entry point from the loadable extension so
+# Sirius can point NVTX at its own already-loaded DSO without deploying a second
+# injection library.
+target_link_options(sirius_loadable_extension PRIVATE
+                    "LINKER:--export-dynamic-symbol=InitializeInjectionNvtx2")
 
 # The sirius-sys + sirius Rust crates are built by cargo, not CMake (unlike the
 # telemetry bridge above, which CMake drives via Corrosion). Their build.rs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,6 +624,15 @@ target_link_libraries(sirius_extension PkgConfig::NUMA PkgConfig::LIBURING
 target_link_libraries(sirius_extension
                       "$<LINK_LIBRARY:WHOLE_ARCHIVE,telemetry_bridge-static>")
 
+# A statically embedded Sirius cannot give NVTX a DSO path. Its private dlopen
+# interposer maps one sentinel path to the running executable instead. Carry
+# both symbols into the final executable's dynamic symbol table so dependency
+# images such as libcudf can resolve the Quent initializer from that handle.
+target_link_options(
+  sirius_extension INTERFACE
+  "LINKER:--export-dynamic-symbol=InitializeInjectionNvtx2"
+  "LINKER:--export-dynamic-symbol=dlopen")
+
 target_link_libraries(sirius_loadable_extension PkgConfig::LIBURING
                       PkgConfig::CURL OpenSSL::Crypto)
 

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -444,6 +444,7 @@ sirius:
 | `exporter` | string | `ndjson` | Quent filesystem exporter: `ndjson`, `msgpack`, or `postcard`. |
 | `output_directory` | non-empty string | `telemetry_data` | Directory for Quent telemetry files. |
 | `engine_name` | non-empty string | `siriusDB` | Engine name reported in engine-level telemetry. |
+| `nvtx_injection_lib` | string | empty | Optional NVTX injection-library override. Normally unnecessary: a loadable Sirius uses its own DSO, while a Sirius-enabled DuckDB executable resolves the initializer from itself. `NVTX_INJECTION64_PATH` takes precedence. |
 
 Per-query labels are configured separately from YAML. They can be set with the
 `sirius_set_query_label` SQL function or inline with the `query_label` named

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -26,11 +26,23 @@ If no config file is found, Sirius initializes with built-in defaults (95% GPU m
 
 ### `SIRIUS_DISABLE`
 
-Set `SIRIUS_DISABLE=1` to prevent Super Sirius from initializing. This is **required** when using the legacy code path (`gpu_buffer_init`/`gpu_processing`), because Super Sirius claims most GPU and pinned host memory on startup, leaving insufficient memory for the legacy buffer manager. It is also useful for CPU-only benchmarks.
+`SIRIUS_DISABLE` is a process-startup kill switch for the **Super Sirius runtime**, not a query-fallback setting. Set `SIRIUS_DISABLE=1` before starting DuckDB to prevent that runtime from initializing and transparently routing queries to the GPU. The extension binary still loads and registers its SQL surface; legacy functions therefore remain available in builds that include them. Sirius also skips creating its Quent telemetry context and does not publish an automatic NVTX injection path. A caller-supplied `NVTX_INJECTION64_PATH` remains untouched.
+
+This is **required** when using the legacy code path (`gpu_buffer_init`/`gpu_processing`), because Super Sirius claims most GPU and pinned host memory on startup, leaving insufficient memory for the legacy buffer manager. It is also useful for CPU-only benchmarks. An unset value or `SIRIUS_DISABLE=0` enables normal Super Sirius initialization; any other set value disables it.
 
 ```bash
 export SIRIUS_DISABLE=1
 ```
+
+These related modes have different behavior:
+
+| Mode | Query execution | NVTX/Quent behavior |
+|------|-----------------|---------------------|
+| `SIRIUS_DISABLE=1` | Ordinary SQL runs in DuckDB; Super Sirius is never attempted | Sirius does not create its Quent context or configure automatic NVTX injection |
+| `SET gpu_execution = false` | Ordinary SQL runs in DuckDB for that connection | The process-wide Sirius runtime remains initialized and, when Quent is enabled, NVTX injection remains armed because the setting is reversible and other connections may use Sirius; DuckDB emits no NVTX events unless DuckDB or another loaded component explicitly calls NVTX |
+| Automatic CPU fallback | Sirius first rejects the GPU plan or fails during GPU execution, then DuckDB executes the CPU plan | NVTX remains active so any Sirius/libcudf work before the fallback is retained; the DuckDB portion emits events only if the executing code calls NVTX |
+
+Use `SIRIUS_DISABLE=1` for a pure DuckDB CPU baseline in a process that contains the Sirius extension. Use `SET gpu_execution = false` when the initialized Sirius runtime must remain available to turn back on later.
 
 ### Byte Suffixes
 

--- a/docs/super-sirius/quent-telemetry.md
+++ b/docs/super-sirius/quent-telemetry.md
@@ -30,6 +30,12 @@ sirius:
 | `exporter` | string | `ndjson` | Quent filesystem exporter: `ndjson`, `msgpack`, or `postcard`. |
 | `output_directory` | non-empty string | `telemetry_data` | Directory for Quent telemetry files. |
 | `engine_name` | non-empty string | `siriusDB` | Engine name reported in engine-level telemetry. |
+| `nvtx_injection_lib` | string | empty | Optional NVTX injection-library override. Normally unnecessary: a loadable Sirius uses its own DSO, while a Sirius-enabled DuckDB executable resolves the initializer from itself. `NVTX_INJECTION64_PATH` takes precedence. |
+
+Quent captures NVTX emitted by dependency images such as libcudf in both deployment modes. A
+loadable Sirius is its own injection DSO. A DuckDB executable with Sirius linked into it exports the
+same initializer and handles NVTX's private injection token inside the executable, so it does not
+ship a sidecar DSO.
 
 Load the config through the normal resolution path — usually by setting
 `SIRIUS_CONFIG_FILE=/path/to/sirius.yaml` before loading the extension. Any Sirius query run with

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -341,6 +341,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease 0.2.37",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "bitcode"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,7 +480,16 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -478,6 +507,17 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1492,6 +1532,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1537,6 +1586,16 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -1627,6 +1686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1743,16 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1735,6 +1810,78 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "nvtx-analyzer"
+version = "0.1.0"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+dependencies = [
+ "nvtx-bridge",
+ "nvtx-events",
+ "quent-events",
+ "quent-time",
+ "rustc-hash",
+ "tracing",
+]
+
+[[package]]
+name = "nvtx-bridge"
+version = "0.1.0"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+dependencies = [
+ "nvtx-events",
+ "quent-events",
+ "serde",
+]
+
+[[package]]
+name = "nvtx-events"
+version = "0.1.0"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "nvtx-injection"
+version = "0.1.0"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+dependencies = [
+ "bindgen",
+ "cc",
+ "libc",
+ "nvtx-events",
+ "thiserror",
+]
+
+[[package]]
+name = "nvtx-server"
+version = "0.1.0"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+dependencies = [
+ "axum",
+ "moka",
+ "nvtx-analyzer",
+ "nvtx-bridge",
+ "nvtx-ui",
+ "quent-events",
+ "quent-io",
+ "serde",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "nvtx-ui"
+version = "0.1.0"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+dependencies = [
+ "nvtx-analyzer",
+ "quent-time",
+ "serde",
+ "ts-rs",
 ]
 
 [[package]]
@@ -1982,7 +2129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -2003,7 +2150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -2051,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "quent-dynamic-attributes",
  "quent-events",
@@ -2068,7 +2215,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "serde",
  "serde_json",
@@ -2077,20 +2224,20 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "convert_case",
- "prettyplease 0.2.37",
+ "prettyplease 0.3.0",
  "proc-macro2",
  "quent-model",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "quent-collector-client",
  "quent-collector-proto",
@@ -2104,7 +2251,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "bitcode",
  "http",
@@ -2123,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "prost",
  "tonic",
@@ -2134,7 +2281,7 @@ dependencies = [
 [[package]]
 name = "quent-dynamic-attributes"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "serde",
  "thiserror",
@@ -2144,8 +2291,10 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
+ "quent-build-info",
+ "quent-dynamic-attributes",
  "quent-time",
  "serde",
  "uuid",
@@ -2154,12 +2303,14 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
+ "async-trait",
  "quent-build-info",
  "quent-dynamic-attributes",
  "quent-events",
  "quent-io",
+ "quent-io-callback",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2170,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "quent-io"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "async-trait",
  "http",
@@ -2185,9 +2336,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "quent-io-callback"
+version = "0.1.0"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+dependencies = [
+ "async-trait",
+ "quent-events",
+ "quent-io-types",
+ "uuid",
+]
+
+[[package]]
 name = "quent-io-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "async-trait",
  "http",
@@ -2202,7 +2364,7 @@ dependencies = [
 [[package]]
 name = "quent-io-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -2217,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "quent-io-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -2232,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "quent-io-postcard"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "async-trait",
  "postcard",
@@ -2247,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "quent-io-types"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -2259,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "quent-build-info",
  "quent-collector-client",
@@ -2277,18 +2439,18 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "quent-analyzer",
  "quent-dynamic-attributes",
@@ -2305,7 +2467,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "quent-model",
  "serde",
@@ -2315,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "axum",
  "mime_guess",
@@ -2347,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "quent-analyzer",
  "quent-dynamic-attributes",
@@ -2362,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -2373,8 +2535,9 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui-bindings"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
+ "nvtx-ui",
  "quent-query-engine-ui",
  "quent-simulator-ui",
  "quent-ui",
@@ -2384,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "quent-model",
  "uuid",
@@ -2393,7 +2556,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "serde",
  "thiserror",
@@ -2403,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca83442953cbea1c9c53560808104f6b59127"
+source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
 dependencies = [
  "quent-analyzer",
  "quent-dynamic-attributes",
@@ -2792,6 +2955,12 @@ dependencies = [
 
 [[package]]
 name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -2869,6 +3038,7 @@ dependencies = [
  "axum",
  "clap",
  "instrumentation-model",
+ "nvtx-server",
  "quent-collector",
  "quent-io",
  "quent-query-engine-server",
@@ -3209,6 +3379,8 @@ dependencies = [
  "cxx",
  "cxx-build",
  "instrumentation-model",
+ "nvtx-bridge",
+ "nvtx-injection",
  "quent-codegen",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -332,6 +332,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "better_scoped_tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,7 +583,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -773,7 +779,7 @@ dependencies = [
  "swc_eq_ignore_macros",
  "text_lines",
  "thiserror",
- "unicode-width",
+ "unicode-width 0.2.2",
  "url",
 ]
 
@@ -864,7 +870,7 @@ dependencies = [
  "indexmap",
  "rustc-hash",
  "serde",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1640,6 +1646,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive 0.15.1",
+]
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive 0.16.1",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen 0.15.1",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen 0.16.1",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,6 +1740,28 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "mime"
@@ -1815,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "nvtx-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "nvtx-bridge",
  "nvtx-events",
@@ -1828,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "nvtx-bridge"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "nvtx-events",
  "quent-events",
@@ -1838,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "nvtx-events"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "serde",
 ]
@@ -1846,19 +1940,19 @@ dependencies = [
 [[package]]
 name = "nvtx-injection"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
- "bindgen",
  "cc",
  "libc",
  "nvtx-events",
+ "nvtx-sys",
  "thiserror",
 ]
 
 [[package]]
 name = "nvtx-server"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "axum",
  "moka",
@@ -1874,9 +1968,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvtx-sys"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d27db0c4b06b35ff598e53093f6c050df4b10dbda5f397f5ee39fbc5890498"
+dependencies = [
+ "bindgen",
+ "cc",
+ "widestring",
+]
+
+[[package]]
 name = "nvtx-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "nvtx-analyzer",
  "quent-time",
@@ -2157,12 +2262,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-reflect"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b80ea363c31af2de2b92e3c07ed1156628f7838c4afb4df75ee78a37fedbd1"
+dependencies = [
+ "logos 0.16.1",
+ "miette",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
+dependencies = [
+ "logos 0.15.1",
+ "miette",
+ "prost-types",
+ "thiserror",
 ]
 
 [[package]]
@@ -2198,7 +2342,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "quent-dynamic-attributes",
  "quent-events",
@@ -2215,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "serde",
  "serde_json",
@@ -2224,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "convert_case",
  "prettyplease 0.3.0",
@@ -2237,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "quent-collector-client",
  "quent-collector-proto",
@@ -2251,7 +2395,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "bitcode",
  "http",
@@ -2270,9 +2414,10 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "prost",
+ "protox",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -2281,7 +2426,7 @@ dependencies = [
 [[package]]
 name = "quent-dynamic-attributes"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "serde",
  "thiserror",
@@ -2291,7 +2436,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "quent-build-info",
  "quent-dynamic-attributes",
@@ -2303,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "async-trait",
  "quent-build-info",
@@ -2321,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "quent-io"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "async-trait",
  "http",
@@ -2338,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "quent-io-callback"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -2349,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "quent-io-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "async-trait",
  "http",
@@ -2364,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "quent-io-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -2379,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "quent-io-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -2394,7 +2539,7 @@ dependencies = [
 [[package]]
 name = "quent-io-postcard"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "async-trait",
  "postcard",
@@ -2409,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "quent-io-types"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -2421,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "quent-build-info",
  "quent-collector-client",
@@ -2439,7 +2584,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -2450,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "quent-analyzer",
  "quent-dynamic-attributes",
@@ -2467,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "quent-model",
  "serde",
@@ -2477,8 +2622,9 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
+ "async-trait",
  "axum",
  "mime_guess",
  "moka",
@@ -2509,8 +2655,9 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
+ "async-trait",
  "quent-analyzer",
  "quent-dynamic-attributes",
  "quent-query-engine-model",
@@ -2524,7 +2671,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -2535,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui-bindings"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "nvtx-ui",
  "quent-query-engine-ui",
@@ -2547,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "quent-model",
  "uuid",
@@ -2556,7 +2703,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "serde",
  "thiserror",
@@ -2566,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7b31409cde06d855bc2d0fb937aafcb6c479f60f#7b31409cde06d855bc2d0fb937aafcb6c479f60f"
+source = "git+https://github.com/rapidsai/quent.git?rev=381e1be0425668f21b37daec0c8c2a8f0be6f017#381e1be0425668f21b37daec0c8c2a8f0be6f017"
 dependencies = [
  "quent-analyzer",
  "quent-dynamic-attributes",
@@ -3217,7 +3364,7 @@ dependencies = [
  "swc_eq_ignore_macros",
  "swc_visit",
  "tracing",
- "unicode-width",
+ "unicode-width 0.2.2",
  "url",
 ]
 
@@ -3855,6 +4002,12 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
@@ -4035,6 +4188,12 @@ checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi-util"

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -5,16 +5,16 @@ edition.workspace = true
 
 [dependencies]
 instrumentation-model = { path = "../model" }
-quent-dynamic-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
+quent-dynamic-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -5,16 +5,16 @@ edition.workspace = true
 
 [dependencies]
 instrumentation-model = { path = "../model" }
-quent-dynamic-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-dynamic-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/examples/print_resource_tree.rs
+++ b/rust/crates/telemetry/analyzer/examples/print_resource_tree.rs
@@ -70,8 +70,12 @@ fn main() {
         .parse()
         .expect("valid engine uuid");
 
-    let events = Sirius::import_events(&dir).expect("importable session dir");
-    let analyzer = SiriusUiAnalyzer::try_new(engine_id, events).expect("analyzable events");
+    let events: Vec<_> = Sirius::import_events(&dir)
+        .expect("importable session dir")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("importable events");
+    let analyzer =
+        SiriusUiAnalyzer::try_new(engine_id, events.into_iter()).expect("analyzable events");
     let model = &analyzer.model;
 
     let root_id = model.root().expect("model has a root group").id();

--- a/rust/crates/telemetry/analyzer/src/lib.rs
+++ b/rust/crates/telemetry/analyzer/src/lib.rs
@@ -171,7 +171,9 @@ impl QuentViewer for Viewer {
     fn import_events(
         dir: &std::path::Path,
     ) -> quent_model::io::ImporterResult<ViewerEventStream<Self::Analyzer>> {
-        Sirius::import_events(dir)
+        let events =
+            Sirius::import_events(dir)?.collect::<quent_model::io::ImporterResult<Vec<_>>>()?;
+        Ok(Box::new(events.into_iter()))
     }
 }
 

--- a/rust/crates/telemetry/analyzer/src/tests.rs
+++ b/rust/crates/telemetry/analyzer/src/tests.rs
@@ -60,12 +60,12 @@ fn tier_usage(resource_id: Uuid, bytes: u64) -> Option<Usage<MemoryTier>> {
     })
 }
 
-fn batch_event(id: Uuid, ts: u64, seq: u64, state: BatchPlacementTransition) -> Event<SiriusEvent> {
+fn batch_event(id: Uuid, ts: u64, seq: u16, state: BatchPlacementTransition) -> Event<SiriusEvent> {
     Event::new(id, ts, SiriusEvent::BatchPlacement(FsmEvent { seq, state }))
 }
 
 fn memory_tier_events(id: Uuid, parent: Uuid, name: &str, bytes: u64) -> Vec<Event<SiriusEvent>> {
-    let event = |ts: u64, seq: u64, state: MemoryTierTransition| {
+    let event = |ts: u64, seq: u16, state: MemoryTierTransition| {
         Event::new(id, ts, SiriusEvent::MemoryTier(FsmEvent { seq, state }))
     };
     vec![
@@ -145,7 +145,7 @@ fn fixture(with_batches: bool) -> Fixture {
     events.extend(memory_tier_events(disk_id, engine_id, "DISK", 16 << 30));
 
     // The query FSM: its first transition is the query epoch.
-    let query_event = |ts: u64, seq: u64, state: query::QueryTransition| {
+    let query_event = |ts: u64, seq: u16, state: query::QueryTransition| {
         Event::new(query_id, ts, SiriusEvent::Query(FsmEvent { seq, state }))
     };
     events.extend([
@@ -335,7 +335,7 @@ fn fixture(with_batches: bool) -> Fixture {
 /// - t=1000 exit
 fn add_working_space_task(fixture: &mut Fixture) {
     let task_id = fixture.task_1_id;
-    let task_event = |ts: u64, seq: u64, state: TaskTransition| {
+    let task_event = |ts: u64, seq: u16, state: TaskTransition| {
         Event::new(task_id, ts, SiriusEvent::Task(FsmEvent { seq, state }))
     };
     fixture.events.extend([

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -10,8 +10,10 @@ crate-type = ["staticlib"]
 [dependencies]
 cxx = "1"
 instrumentation-model = { path = "../model" }
+nvtx-bridge = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+nvtx-injection = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f", features = ["static-injection"] }
 
 [build-dependencies]
 cxx-build = "1"
 instrumentation-model = { path = "../model" }
-quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
+quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -10,10 +10,10 @@ crate-type = ["staticlib"]
 [dependencies]
 cxx = "1"
 instrumentation-model = { path = "../model" }
-nvtx-bridge = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-nvtx-injection = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f", features = ["static-injection"] }
+nvtx-bridge = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+nvtx-injection = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017", features = ["static-injection"] }
 
 [build-dependencies]
 cxx-build = "1"
 instrumentation-model = { path = "../model" }
-quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -7,13 +7,13 @@ edition.workspace = true
 collector = ["quent-model/collector"]
 
 [dependencies]
-quent-dynamic-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
+quent-dynamic-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
+quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -7,13 +7,13 @@ edition.workspace = true
 collector = ["quent-model/collector"]
 
 [dependencies]
-quent-dynamic-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-dynamic-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,15 +12,16 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model", features = ["collector"] }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-io = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
+nvtx-server = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-io = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
 
 [build-dependencies]
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "2a5ca83442953cbea1c9c53560808104f6b59127" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
 ts-rs = { version = "12", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,16 +12,16 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model", features = ["collector"] }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-nvtx-server = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-io = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+nvtx-server = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-io = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
 
 [build-dependencies]
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7b31409cde06d855bc2d0fb937aafcb6c479f60f" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "381e1be0425668f21b37daec0c8c2a8f0be6f017" }
 ts-rs = { version = "12", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/src/main.rs
+++ b/rust/crates/telemetry/server/src/main.rs
@@ -2,10 +2,11 @@ use std::{net::ToSocketAddrs, path::PathBuf};
 
 use clap::Parser;
 use instrumentation_model::{Sirius, SiriusContext};
+use nvtx_server::{import_context_events, routes as nvtx_routes};
 use quent_io::ExporterOptions;
 use quent_io::filesystem::{self, Format};
 use quent_query_engine_server::{
-    analyzer_cache::index_query_engines, analyzer_service_router, collector_service,
+    analyzer_cache::index_query_engines, analyzer_service_router_with_routes, collector_service,
     initialize_tracing,
 };
 use sirius_telemetry_analyzer::SiriusUiAnalyzer;
@@ -69,6 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let importer_output_dir = output_dir.clone();
     let lister_output_dir = output_dir.clone();
+    let nvtx_output_dir = output_dir.clone();
 
     let format = match exporter.as_str() {
         "ndjson" => Format::Ndjson,
@@ -85,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // remote source's events under that source's own context id.
     let collector = async {
         collector_service::<SiriusContext, _>(move |id| {
-            SiriusContext::try_with_id(id, Some(exporter_kind.clone())).map_err(|e| e.to_string())
+            SiriusContext::try_with_id(id, exporter_kind.clone()).map_err(|e| e.to_string())
         })?
         .serve(collector_addr)
         .await
@@ -101,16 +103,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // make up an engine instance.
     let importer = move |context_id| {
         let dir = importer_output_dir.join(format!("{context_id}"));
-        Ok(Sirius::import_events(&dir)?)
+        let events = Sirius::import_events(&dir)?.collect::<quent_io::ImporterResult<Vec<_>>>()?;
+        Ok(Box::new(events.into_iter()) as Box<dyn Iterator<Item = _>>)
     };
 
     let analyzer = async {
         axum::serve(
             TcpListener::bind(analyzer_addr).await?,
-            analyzer_service_router::<SiriusUiAnalyzer>(
+            analyzer_service_router_with_routes::<SiriusUiAnalyzer>(
                 Box::new(importer),
                 Box::new(lister),
                 cors_address,
+                nvtx_routes(Box::new(move |context_id| {
+                    import_context_events(&nvtx_output_dir, context_id)
+                })),
             )?
             .into_make_service(),
         )

--- a/scripts/pixi_activate.sh
+++ b/scripts/pixi_activate.sh
@@ -5,6 +5,10 @@ if [[ -z "${CONDA_PREFIX:-}" ]]; then
   exit 0
 fi
 
+if [[ -z "${LIBCLANG_PATH:-}" ]]; then
+  export LIBCLANG_PATH="$CONDA_PREFIX/lib"
+fi
+
 clang_cpp="$CONDA_PREFIX/bin/clang-cpp"
 clang_pp="$CONDA_PREFIX/bin/clang++"
 

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -212,6 +212,10 @@ struct telemetry_config {
   std::string exporter{"ndjson"};
   std::string output_directory{"telemetry_data"};
   std::string engine_name{"siriusDB"};
+  /// Optional override naming the NVTX injection library. When empty, the
+  /// loadable extension points NVTX at its own DSO. An NVTX_INJECTION64_PATH
+  /// already present in the environment takes precedence over both.
+  std::string nvtx_injection_lib{};
 };
 
 /// Parameters controlling Simpatico compression for pin_table(tier=>'host').

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -212,9 +212,9 @@ struct telemetry_config {
   std::string exporter{"ndjson"};
   std::string output_directory{"telemetry_data"};
   std::string engine_name{"siriusDB"};
-  /// Optional override naming the NVTX injection library. When empty, the
-  /// loadable extension points NVTX at its own DSO. An NVTX_INJECTION64_PATH
-  /// already present in the environment takes precedence over both.
+  /// Optional override naming an NVTX injection library. Normally Sirius uses
+  /// its loadable DSO or the initializer embedded in a static DuckDB host. An
+  /// NVTX_INJECTION64_PATH already in the environment takes precedence.
   std::string nvtx_injection_lib{};
 };
 

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -753,6 +753,12 @@ class SiriusContextExtensionCallback : public ExtensionCallback {
  public:
   SiriusContextExtensionCallback();
 
+  /// Finish runtime initialization after process-wide setup that must precede
+  /// the first NVTX/runtime-initialization call.
+  void initialize_context();
+
+  [[nodiscard]] bool is_disabled() const noexcept { return disabled_; }
+
   /// \brief Called when a new connection is opened.
   /// \param context The client context.
   void OnConnectionOpened(ClientContext& context) final;
@@ -783,6 +789,7 @@ class SiriusContextExtensionCallback : public ExtensionCallback {
  private:
   void read_config_file_if_exists();
 
+  bool disabled_{false};
   sirius::sirius_config config_;
   duckdb::shared_ptr<SiriusContext> context_;
 };

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -330,6 +330,7 @@ static void from_yaml(const YAML::Node& node, telemetry_config& opt)
     if (!value.empty()) return true;
     throw std::runtime_error("must not be empty");
   });
+  r.optional("nvtx_injection_lib", opt.nvtx_injection_lib);
   r.reject_unknown();
 }
 

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -1654,6 +1654,10 @@ void install_configured_log_sink(DatabaseInstance* db)
 }
 
 SiriusContextExtensionCallback::SiriusContextExtensionCallback()
+  : disabled_([] {
+      auto const* value = std::getenv("SIRIUS_DISABLE");
+      return value != nullptr && std::string_view{value} != "0";
+    }())
 {
   auto const previous_log_backend = Config::LOG_BACKEND;
   auto const previous_log_dir     = Config::LOG_DIR;
@@ -1688,6 +1692,15 @@ SiriusContextExtensionCallback::SiriusContextExtensionCallback()
     throw;
   }
   read_config_file_if_exists();
+}
+
+void SiriusContextExtensionCallback::initialize_context()
+{
+  if (disabled_ || context_) { return; }
+
+  auto context = duckdb::make_shared_ptr<SiriusContext>();
+  context->initialize(config_);
+  context_ = std::move(context);
 }
 
 void SiriusContextExtensionCallback::OnConnectionOpened(ClientContext& context)
@@ -1736,7 +1749,7 @@ void SiriusContextExtensionCallback::OnExtensionLoadFail(DatabaseInstance& db,
 void SiriusContextExtensionCallback::read_config_file_if_exists()
 {
   // Check for explicit disable (used by benchmarks/tests that need pure CPU execution)
-  if (auto* val = std::getenv("SIRIUS_DISABLE"); val != nullptr && std::string(val) != "0") {
+  if (disabled_) {
     SIRIUS_LOG_INFO("Sirius disabled via SIRIUS_DISABLE environment variable.");
     return;
   }
@@ -1768,9 +1781,6 @@ void SiriusContextExtensionCallback::read_config_file_if_exists()
       "set SIRIUS_DISABLE=1 to prevent this.");
     config_.apply_defaults();
   }
-
-  context_ = duckdb::make_shared_ptr<SiriusContext>();
-  context_->initialize(config_);
 }
 
 }  // namespace duckdb

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -111,6 +111,7 @@ extern "C" int cudaProfilerStop();
 #include "sirius_extension.hpp"
 #include "sirius_interface.hpp"
 #include "sirius_sql_rewrite.hpp"
+#include "telemetry/nvtx_injection.hpp"
 #include "util/segfault_backtrace.hpp"
 #include "vss/cuvs_index_cache.hpp"
 #include "vss/distance_metric.hpp"
@@ -161,6 +162,28 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjectionNvtx2(
 {
   return quent_InitializeInjectionNvtx2(get_export_table);
 }
+
+#ifndef DUCKDB_BUILD_LOADABLE_EXTENSION
+// NVTX v3 discovers an injector independently in each ELF image. libcudf's
+// injection pointer is local to libcudf.so and its process-global preinjection
+// lookup is compiled out, so it can only reach Quent through its dlopen path.
+// A statically linked Sirius has no DSO to name. Interpose just our private
+// sentinel and turn that request into dlopen(NULL), whose handle exposes the
+// initializer exported by the running DuckDB executable. Every other request
+// is forwarded unchanged to libc.
+extern "C" __attribute__((visibility("default"))) void* dlopen(const char* filename, int flags)
+{
+  using dlopen_fn   = void* (*)(const char*, int);
+  auto* real_dlopen = reinterpret_cast<dlopen_fn>(::dlsym(RTLD_NEXT, "dlopen"));
+  if (real_dlopen == nullptr) { return nullptr; }
+
+  if (filename != nullptr &&
+      std::string_view{filename} == sirius::telemetry::detail::static_injection_path) {
+    return real_dlopen(nullptr, flags);
+  }
+  return real_dlopen(filename, flags);
+}
+#endif
 
 namespace duckdb {
 
@@ -3500,10 +3523,11 @@ static void publish_transparent_optimizer_mask(DBConfig& config)
 ///
 /// An existing NVTX_INJECTION64_PATH remains authoritative. Otherwise, an
 /// explicit nvtx_injection_lib from the Sirius config is used. If neither is
-/// present, the loadable extension points NVTX at its own DSO: Quent's injector
-/// is statically embedded there and exported as InitializeInjectionNvtx2, so
-/// Sirius and dependency images such as libcudf attach to the same hook without
-/// requiring a separately deployed injection library or a user-supplied path.
+/// present, the loadable extension points NVTX at its own DSO. A statically
+/// linked Sirius instead uses a private dlopen token which resolves to the
+/// running executable. In both cases Quent's injector is embedded in the same
+/// image as Sirius, so dependency images such as libcudf attach to the same hook
+/// without requiring a separately deployed injection library.
 ///
 /// NVTX initialises lazily and per image, on that image's first NVTX call, so
 /// setting the variable here — after libcudf is mapped but before any NVTX call
@@ -3554,6 +3578,7 @@ static void maybe_set_nvtx_injection_path()
       return;
     }
 
+#ifdef DUCKDB_BUILD_LOADABLE_EXTENSION
     Dl_info self{};
     if (::dladdr(reinterpret_cast<void*>(&InitializeInjectionNvtx2), &self) == 0 ||
         self.dli_fname == nullptr) {
@@ -3561,13 +3586,24 @@ static void maybe_set_nvtx_injection_path()
     }
 
     auto self_path = std::filesystem::weakly_canonical(self.dli_fname);
-    // In the statically linked DuckDB target dladdr resolves to the executable,
-    // which cannot be used as an NVTX injection DSO. The built-in target already
-    // has plugin-local static injection; automatic cross-DSO discovery here is
-    // specific to the loadable extension.
     if (self_path.extension() != ".duckdb_extension") { return; }
-
     ::setenv("NVTX_INJECTION64_PATH", self_path.c_str(), /*overwrite=*/0);
+#else
+    // Probe the interposition path before publishing it. NVTX does not fall
+    // back to static injection after a dynamic lookup failure, so a broken
+    // final link must leave the environment unset.
+    auto* handle =
+      ::dlopen(sirius::telemetry::detail::static_injection_path, RTLD_LAZY | RTLD_LOCAL);
+    if (handle == nullptr) { return; }
+    auto* initializer = ::dlsym(handle, "InitializeInjectionNvtx2");
+    bool const usable = initializer == reinterpret_cast<void*>(&InitializeInjectionNvtx2);
+    ::dlclose(handle);
+    if (!usable) { return; }
+
+    ::setenv("NVTX_INJECTION64_PATH",
+             sirius::telemetry::detail::static_injection_path,
+             /*overwrite=*/0);
+#endif
   } catch (...) {
     // Silently ignore YAML parse errors in the early-init path — a diagnostic
     // would be premature here (logging is not yet configured).
@@ -3576,6 +3612,11 @@ static void maybe_set_nvtx_injection_path()
 
 static void LoadInternal(ExtensionLoader& loader)
 {
+  // libcudf is mapped before this point, but its NVTX state is still fresh
+  // because its constructors do not call NVTX. Configure discovery before any
+  // Sirius initialization can make the first NVTX call in an image.
+  maybe_set_nvtx_injection_path();
+
   sirius::util::install_segfault_backtrace_handler();
 
   auto& db     = loader.GetDatabaseInstance();
@@ -3652,14 +3693,7 @@ std::string SiriusExtension::Version() const
 
 extern "C" {
 
-DUCKDB_CPP_EXTENSION_ENTRY(sirius, loader)
-{
-  // libcudf is already mapped at this point, but its NVTX state is still fresh
-  // because its constructors do not call NVTX. Configure discovery before
-  // LoadInternal can make the first NVTX call in any image.
-  duckdb::maybe_set_nvtx_injection_path();
-  duckdb::LoadInternal(loader);
-}
+DUCKDB_CPP_EXTENSION_ENTRY(sirius, loader) { duckdb::LoadInternal(loader); }
 }
 
 #ifndef DUCKDB_EXTENSION_MAIN

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -140,7 +140,6 @@ extern "C" int cudaProfilerStop();
 #include "io/uring/uring_reactor.hpp"  // sirius::io::uring_io_object
 
 #include <dlfcn.h>
-#include <yaml-cpp/yaml.h>
 
 #include <algorithm>
 #include <cmath>
@@ -3519,15 +3518,6 @@ static void publish_transparent_optimizer_mask(DBConfig& config)
   live.swap(updated);
 }
 
-/// Whether Super Sirius runtime initialization is disabled for this process.
-/// The extension still loads and registers its surface in this mode so CPU
-/// baselines and the legacy gpu_processing path remain available.
-static bool sirius_is_disabled() noexcept
-{
-  auto const* value = std::getenv("SIRIUS_DISABLE");
-  return value != nullptr && std::string_view{value} != "0";
-}
-
 /// Configure NVTX runtime discovery before the process's first NVTX call.
 ///
 /// An existing NVTX_INJECTION64_PATH remains authoritative. Otherwise, an
@@ -3544,91 +3534,52 @@ static bool sirius_is_disabled() noexcept
 /// static constructor; should it ever do so, its image initialises during dlopen
 /// and this path becomes invisible to it. Set NVTX_INJECTION64_PATH in the
 /// environment instead if that happens.
-static void maybe_set_nvtx_injection_path()
+static void maybe_set_nvtx_injection_path(const sirius::telemetry_config& telemetry) noexcept
 {
-  if (std::getenv("NVTX_INJECTION64_PATH") != nullptr) { return; }
+  if (std::getenv("NVTX_INJECTION64_PATH") != nullptr || !telemetry.enable_quent) { return; }
 
-  // Duplicates sirius_context.cpp's get_config_file_path(); this runs before
-  // the context exists, so the config cannot be read through it.
-  std::string config_path;
-  if (const char* env = std::getenv("SIRIUS_CONFIG_FILE")) {
-    config_path = env;
-  } else {
-    namespace fs  = std::filesystem;
-    auto cwd_path = fs::current_path() / "sirius.yaml";
-    if (fs::exists(cwd_path)) {
-      config_path = cwd_path.string();
-    } else if (const char* home_dir = std::getenv("HOME")) {
-      auto home_path = fs::path(home_dir) / ".sirius" / "sirius.yaml";
-      if (fs::exists(home_path)) { config_path = home_path.string(); }
-    }
+  if (!telemetry.nvtx_injection_lib.empty()) {
+    ::setenv("NVTX_INJECTION64_PATH", telemetry.nvtx_injection_lib.c_str(), /*overwrite=*/0);
+    return;
   }
 
-  try {
-    bool enable_quent = true;
-    std::string configured_path;
-
-    if (!config_path.empty()) {
-      YAML::Node root     = YAML::LoadFile(config_path);
-      auto sirius_node    = root["sirius"];
-      auto telemetry_node = sirius_node ? sirius_node["telemetry"] : YAML::Node{};
-      if (telemetry_node) {
-        if (auto eq = telemetry_node["enable_quent"]) { enable_quent = eq.as<bool>(true); }
-        if (auto nvtx_lib = telemetry_node["nvtx_injection_lib"]; nvtx_lib && nvtx_lib.IsScalar()) {
-          configured_path = nvtx_lib.as<std::string>();
-        }
-      }
-    }
-
-    if (!enable_quent) { return; }
-
-    if (!configured_path.empty()) {
-      ::setenv("NVTX_INJECTION64_PATH", configured_path.c_str(), /*overwrite=*/0);
-      return;
-    }
-
 #ifdef DUCKDB_BUILD_LOADABLE_EXTENSION
+  try {
     Dl_info self{};
-    if (::dladdr(reinterpret_cast<void*>(&InitializeInjectionNvtx2), &self) == 0 ||
+    // Use a private function as the anchor: unlike the public NVTX initializer,
+    // its address cannot be interposed by another ELF image.
+    if (::dladdr(reinterpret_cast<void*>(&maybe_set_nvtx_injection_path), &self) == 0 ||
         self.dli_fname == nullptr) {
       return;
     }
 
-    auto self_path = std::filesystem::weakly_canonical(self.dli_fname);
-    if (self_path.extension() != ".duckdb_extension") { return; }
+    std::error_code error;
+    auto self_path = std::filesystem::canonical(self.dli_fname, error);
+    if (error) { return; }
     ::setenv("NVTX_INJECTION64_PATH", self_path.c_str(), /*overwrite=*/0);
-#else
-    // Probe the interposition path before publishing it. NVTX does not fall
-    // back to static injection after a dynamic lookup failure, so a broken
-    // final link must leave the environment unset.
-    auto* handle =
-      ::dlopen(sirius::telemetry::detail::static_injection_path, RTLD_LAZY | RTLD_LOCAL);
-    if (handle == nullptr) { return; }
-    auto* initializer = ::dlsym(handle, "InitializeInjectionNvtx2");
-    bool const usable = initializer == reinterpret_cast<void*>(&InitializeInjectionNvtx2);
-    ::dlclose(handle);
-    if (!usable) { return; }
-
-    ::setenv("NVTX_INJECTION64_PATH",
-             sirius::telemetry::detail::static_injection_path,
-             /*overwrite=*/0);
-#endif
   } catch (...) {
-    // Silently ignore YAML parse errors in the early-init path — a diagnostic
-    // would be premature here (logging is not yet configured).
+    // NVTX capture is optional; self-path discovery must not prevent Sirius
+    // from loading.
   }
+#else
+  // Probe the interposition path before publishing it. NVTX does not fall
+  // back to static injection after a dynamic lookup failure, so a broken
+  // final link must leave the environment unset.
+  auto* handle = ::dlopen(sirius::telemetry::detail::static_injection_path, RTLD_LAZY | RTLD_LOCAL);
+  if (handle == nullptr) { return; }
+  auto* initializer = ::dlsym(handle, "InitializeInjectionNvtx2");
+  bool const usable = initializer == reinterpret_cast<void*>(&InitializeInjectionNvtx2);
+  ::dlclose(handle);
+  if (!usable) { return; }
+
+  ::setenv("NVTX_INJECTION64_PATH",
+           sirius::telemetry::detail::static_injection_path,
+           /*overwrite=*/0);
+#endif
 }
 
 static void LoadInternal(ExtensionLoader& loader)
 {
-  bool const sirius_disabled = sirius_is_disabled();
-
-  // libcudf is mapped before this point, but its NVTX state is still fresh
-  // because its constructors do not call NVTX. Configure discovery before any
-  // Sirius initialization can make the first NVTX call in an image. A disabled
-  // Sirius must not publish either the DSO path or the static-host sentinel.
-  if (!sirius_disabled) { maybe_set_nvtx_injection_path(); }
-
   sirius::util::install_segfault_backtrace_handler();
 
   auto& db     = loader.GetDatabaseInstance();
@@ -3636,8 +3587,16 @@ static void LoadInternal(ExtensionLoader& loader)
 
   // SIRIUS_DISABLE means: no Sirius runtime initialization and no mask
   // publication (the extension binary itself may still be loaded).
-  auto callback      = make_shared_ptr<duckdb::SiriusContextExtensionCallback>();
-  auto* callback_ptr = callback.get();
+  auto callback              = make_shared_ptr<duckdb::SiriusContextExtensionCallback>();
+  auto* callback_ptr         = callback.get();
+  bool const sirius_disabled = callback_ptr->is_disabled();
+
+  if (!sirius_disabled) {
+    // Config loading above must remain NVTX-free. Publish discovery after its
+    // validation, but before SiriusContext can make any NVTX call.
+    maybe_set_nvtx_injection_path(callback_ptr->get_loaded_config().get_telemetry_config());
+    callback_ptr->initialize_context();
+  }
   config.GetCallbackManager().Register(std::move(callback));
 
   // The ctor already installed the db-independent backend; reinstall now that the

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -138,6 +138,9 @@ extern "C" int cudaProfilerStop();
 #include "io/types.hpp"                // sirius::io::sirius_ioctx
 #include "io/uring/uring_reactor.hpp"  // sirius::io::uring_io_object
 
+#include <dlfcn.h>
+#include <yaml-cpp/yaml.h>
+
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -147,6 +150,17 @@ extern "C" int cudaProfilerStop();
 #include <string_view>
 #include <unordered_map>
 #include <utility>
+
+// Statically embedded by telemetry_bridge. Rust archives are localized by the
+// extension link (`--exclude-libs,ALL`), so this regular C++ object supplies the
+// public NVTX entry point and forwards it into the same Quent hook state used by
+// Sirius's static-injection pointer.
+extern "C" int quent_InitializeInjectionNvtx2(void* get_export_table);
+extern "C" __attribute__((visibility("default"))) int InitializeInjectionNvtx2(
+  void* get_export_table)
+{
+  return quent_InitializeInjectionNvtx2(get_export_table);
+}
 
 namespace duckdb {
 
@@ -3482,6 +3496,84 @@ static void publish_transparent_optimizer_mask(DBConfig& config)
   live.swap(updated);
 }
 
+/// Configure NVTX runtime discovery before the process's first NVTX call.
+///
+/// An existing NVTX_INJECTION64_PATH remains authoritative. Otherwise, an
+/// explicit nvtx_injection_lib from the Sirius config is used. If neither is
+/// present, the loadable extension points NVTX at its own DSO: Quent's injector
+/// is statically embedded there and exported as InitializeInjectionNvtx2, so
+/// Sirius and dependency images such as libcudf attach to the same hook without
+/// requiring a separately deployed injection library or a user-supplied path.
+///
+/// NVTX initialises lazily and per image, on that image's first NVTX call, so
+/// setting the variable here — after libcudf is mapped but before any NVTX call
+/// — still reaches it. That holds only while libcudf makes no NVTX call from a
+/// static constructor; should it ever do so, its image initialises during dlopen
+/// and this path becomes invisible to it. Set NVTX_INJECTION64_PATH in the
+/// environment instead if that happens.
+static void maybe_set_nvtx_injection_path()
+{
+  if (std::getenv("NVTX_INJECTION64_PATH") != nullptr) { return; }
+
+  // Duplicates sirius_context.cpp's get_config_file_path(); this runs before
+  // the context exists, so the config cannot be read through it.
+  std::string config_path;
+  if (const char* env = std::getenv("SIRIUS_CONFIG_FILE")) {
+    config_path = env;
+  } else {
+    namespace fs  = std::filesystem;
+    auto cwd_path = fs::current_path() / "sirius.yaml";
+    if (fs::exists(cwd_path)) {
+      config_path = cwd_path.string();
+    } else if (const char* home_dir = std::getenv("HOME")) {
+      auto home_path = fs::path(home_dir) / ".sirius" / "sirius.yaml";
+      if (fs::exists(home_path)) { config_path = home_path.string(); }
+    }
+  }
+
+  try {
+    bool enable_quent = true;
+    std::string configured_path;
+
+    if (!config_path.empty()) {
+      YAML::Node root     = YAML::LoadFile(config_path);
+      auto sirius_node    = root["sirius"];
+      auto telemetry_node = sirius_node ? sirius_node["telemetry"] : YAML::Node{};
+      if (telemetry_node) {
+        if (auto eq = telemetry_node["enable_quent"]) { enable_quent = eq.as<bool>(true); }
+        if (auto nvtx_lib = telemetry_node["nvtx_injection_lib"]; nvtx_lib && nvtx_lib.IsScalar()) {
+          configured_path = nvtx_lib.as<std::string>();
+        }
+      }
+    }
+
+    if (!enable_quent) { return; }
+
+    if (!configured_path.empty()) {
+      ::setenv("NVTX_INJECTION64_PATH", configured_path.c_str(), /*overwrite=*/0);
+      return;
+    }
+
+    Dl_info self{};
+    if (::dladdr(reinterpret_cast<void*>(&InitializeInjectionNvtx2), &self) == 0 ||
+        self.dli_fname == nullptr) {
+      return;
+    }
+
+    auto self_path = std::filesystem::weakly_canonical(self.dli_fname);
+    // In the statically linked DuckDB target dladdr resolves to the executable,
+    // which cannot be used as an NVTX injection DSO. The built-in target already
+    // has plugin-local static injection; automatic cross-DSO discovery here is
+    // specific to the loadable extension.
+    if (self_path.extension() != ".duckdb_extension") { return; }
+
+    ::setenv("NVTX_INJECTION64_PATH", self_path.c_str(), /*overwrite=*/0);
+  } catch (...) {
+    // Silently ignore YAML parse errors in the early-init path — a diagnostic
+    // would be premature here (logging is not yet configured).
+  }
+}
+
 static void LoadInternal(ExtensionLoader& loader)
 {
   sirius::util::install_segfault_backtrace_handler();
@@ -3560,7 +3652,14 @@ std::string SiriusExtension::Version() const
 
 extern "C" {
 
-DUCKDB_CPP_EXTENSION_ENTRY(sirius, loader) { duckdb::LoadInternal(loader); }
+DUCKDB_CPP_EXTENSION_ENTRY(sirius, loader)
+{
+  // libcudf is already mapped at this point, but its NVTX state is still fresh
+  // because its constructors do not call NVTX. Configure discovery before
+  // LoadInternal can make the first NVTX call in any image.
+  duckdb::maybe_set_nvtx_injection_path();
+  duckdb::LoadInternal(loader);
+}
 }
 
 #ifndef DUCKDB_EXTENSION_MAIN

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -3519,6 +3519,15 @@ static void publish_transparent_optimizer_mask(DBConfig& config)
   live.swap(updated);
 }
 
+/// Whether Super Sirius runtime initialization is disabled for this process.
+/// The extension still loads and registers its surface in this mode so CPU
+/// baselines and the legacy gpu_processing path remain available.
+static bool sirius_is_disabled() noexcept
+{
+  auto const* value = std::getenv("SIRIUS_DISABLE");
+  return value != nullptr && std::string_view{value} != "0";
+}
+
 /// Configure NVTX runtime discovery before the process's first NVTX call.
 ///
 /// An existing NVTX_INJECTION64_PATH remains authoritative. Otherwise, an
@@ -3612,10 +3621,13 @@ static void maybe_set_nvtx_injection_path()
 
 static void LoadInternal(ExtensionLoader& loader)
 {
+  bool const sirius_disabled = sirius_is_disabled();
+
   // libcudf is mapped before this point, but its NVTX state is still fresh
   // because its constructors do not call NVTX. Configure discovery before any
-  // Sirius initialization can make the first NVTX call in an image.
-  maybe_set_nvtx_injection_path();
+  // Sirius initialization can make the first NVTX call in an image. A disabled
+  // Sirius must not publish either the DSO path or the static-host sentinel.
+  if (!sirius_disabled) { maybe_set_nvtx_injection_path(); }
 
   sirius::util::install_segfault_backtrace_handler();
 
@@ -3669,10 +3681,6 @@ static void LoadInternal(ExtensionLoader& loader)
   // above succeeded, so a failed load leaves no mask behind. SIRIUS_DISABLE
   // means no Sirius runtime initialization and no mask publication (the
   // extension binary itself may still be loaded).
-  bool const sirius_disabled = [] {
-    auto* val = std::getenv("SIRIUS_DISABLE");
-    return val != nullptr && std::string(val) != "0";
-  }();
   if (!sirius_disabled) { publish_transparent_optimizer_mask(config); }
 }
 

--- a/src/telemetry/nvtx_injection.hpp
+++ b/src/telemetry/nvtx_injection.hpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#pragma once
+
+namespace sirius::telemetry::detail {
+
+// NVTX passes this private token to dlopen. The statically linked Sirius host
+// recognizes it and returns a handle to the running executable instead.
+inline constexpr char static_injection_path[] =
+  "sirius-nvtx-static-injection-8f3fc31f-8e18-4c48-a63f-f41e538f172c";
+
+}  // namespace sirius::telemetry::detail

--- a/test/cpp/telemetry/test_telemetry_context.cpp
+++ b/test/cpp/telemetry/test_telemetry_context.cpp
@@ -16,7 +16,10 @@
 
 #include "catch.hpp"
 #include "sirius_config.hpp"
+#include "telemetry/nvtx_injection.hpp"
 #include "telemetry/telemetry_context.hpp"
+
+#include <dlfcn.h>
 
 #include <filesystem>
 #include <fstream>
@@ -26,6 +29,8 @@
 
 using namespace sirius;
 using namespace sirius::telemetry;
+
+extern "C" int InitializeInjectionNvtx2(void* get_export_table);
 
 namespace {
 
@@ -63,6 +68,15 @@ bool any_line_with_all(const std::vector<std::string>& lines,
 }
 
 }  // namespace
+
+TEST_CASE("static NVTX injection path resolves the host initializer", "[telemetry_context]")
+{
+  auto* handle = ::dlopen(sirius::telemetry::detail::static_injection_path, RTLD_LAZY | RTLD_LOCAL);
+  REQUIRE(handle != nullptr);
+  CHECK(::dlsym(handle, "InitializeInjectionNvtx2") ==
+        reinterpret_cast<void*>(&InitializeInjectionNvtx2));
+  CHECK(::dlclose(handle) == 0);
+}
 
 TEST_CASE("telemetry_context nests threads under per-GPU device groups", "[telemetry_context]")
 {

--- a/test/cpp/telemetry/test_telemetry_context.cpp
+++ b/test/cpp/telemetry/test_telemetry_context.cpp
@@ -15,14 +15,17 @@
  */
 
 #include "catch.hpp"
+#include "duckdb.hpp"
 #include "sirius_config.hpp"
 #include "telemetry/nvtx_injection.hpp"
 #include "telemetry/telemetry_context.hpp"
 
 #include <dlfcn.h>
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -33,6 +36,30 @@ using namespace sirius::telemetry;
 extern "C" int InitializeInjectionNvtx2(void* get_export_table);
 
 namespace {
+
+class scoped_env_restore {
+ public:
+  explicit scoped_env_restore(const char* name) : name_(name)
+  {
+    if (auto const* value = std::getenv(name)) { original_ = value; }
+  }
+
+  ~scoped_env_restore()
+  {
+    if (original_) {
+      ::setenv(name_.c_str(), original_->c_str(), /*overwrite=*/1);
+    } else {
+      ::unsetenv(name_.c_str());
+    }
+  }
+
+  scoped_env_restore(scoped_env_restore const&)            = delete;
+  scoped_env_restore& operator=(scoped_env_restore const&) = delete;
+
+ private:
+  std::string name_;
+  std::optional<std::string> original_;
+};
 
 std::string uuid_str(const uuid::UUID& id) { return std::string(uuid::to_string(id)); }
 
@@ -68,6 +95,21 @@ bool any_line_with_all(const std::vector<std::string>& lines,
 }
 
 }  // namespace
+
+TEST_CASE("SIRIUS_DISABLE skips automatic NVTX injection discovery",
+          "[telemetry_context][isolated_context]")
+{
+  scoped_env_restore restore_disable{"SIRIUS_DISABLE"};
+  scoped_env_restore restore_nvtx_path{"NVTX_INJECTION64_PATH"};
+  ::setenv("SIRIUS_DISABLE", "1", /*overwrite=*/1);
+  ::unsetenv("NVTX_INJECTION64_PATH");
+
+  {
+    duckdb::DuckDB db(nullptr);
+  }
+
+  CHECK(std::getenv("NVTX_INJECTION64_PATH") == nullptr);
+}
 
 TEST_CASE("static NVTX injection path resolves the host initializer", "[telemetry_context]")
 {

--- a/test/cpp/telemetry/test_telemetry_context.cpp
+++ b/test/cpp/telemetry/test_telemetry_context.cpp
@@ -17,6 +17,7 @@
 #include "catch.hpp"
 #include "duckdb.hpp"
 #include "sirius_config.hpp"
+#include "sirius_extension.hpp"
 #include "telemetry/nvtx_injection.hpp"
 #include "telemetry/telemetry_context.hpp"
 
@@ -106,6 +107,8 @@ TEST_CASE("SIRIUS_DISABLE skips automatic NVTX injection discovery",
 
   {
     duckdb::DuckDB db(nullptr);
+    duckdb::SiriusExtension extension;
+    REQUIRE(db.ExtensionIsLoaded(extension.Name()));
   }
 
   CHECK(std::getenv("NVTX_INJECTION64_PATH") == nullptr);


### PR DESCRIPTION
## Summary

- Captures Sirius, libcudf, and CCCL NVTX events in both supported deployments without a sidecar injection DSO:
  - **Vanilla DuckDB + `LOAD`** exports Quent's initializer from the Sirius extension and points NVTX at that DSO before the first NVTX call.
  - **Statically linked Sirius** exports the same initializer from DuckDB and maps a Sirius-private NVTX injection token to the running executable, while forwarding every other `dlopen` unchanged.
- Honors `SIRIUS_DISABLE` and `enable_quent: false` by skipping automatic injection; otherwise preserves configuration precedence: `NVTX_INJECTION64_PATH`, then `sirius.telemetry.nvtx_injection_lib`, then automatic discovery.
- Mounts Quent's NVTX catalog/viewport routes and pins Quent to `381e1be0`, which includes [quent#544](https://github.com/rapidsai/quent/pull/544) and the `nvtx-sys` build fix from [quent#697](https://github.com/rapidsai/quent/pull/697). Generalized schema work remains tracked by [quent#618](https://github.com/rapidsai/quent/issues/618).

## Verification

- `pixi run make`
- `pixi run make test` — 3,080 test cases and 32,833,137 assertions passed
- `pixi run pre-commit run -a`
- TPC-H SF10 Q1 produced the exact same NVTX range/count signature in both modes: 812 complete ranges across Sirius/default, libcudf, and CCCL, with zero incomplete ranges or reconstruction anomalies.