### PR TITLE
build: Fix ``simpatico_codegen`` cccl cmake for CUDA 12

### DIFF
--- a/src/compression/simpatico_codegen/CMakeLists.txt
+++ b/src/compression/simpatico_codegen/CMakeLists.txt
@@ -44,7 +44,11 @@ elseif(CONDA_PREFIX)
       CACHE FILEPATH "nvcc from prefix")
   set(CUDA_TOOLKIT_INCLUDE
       "${CONDA_PREFIX}/targets/${CUDA_TARGET_TRIPLE}/include")
-  set(CUDA_CCCL_INCLUDE "${CUDA_TOOLKIT_INCLUDE}/cccl")
+  if(EXISTS "${CUDA_TOOLKIT_INCLUDE}/cccl")
+    set(CUDA_CCCL_INCLUDE "${CUDA_TOOLKIT_INCLUDE}/cccl")
+  else()
+    set(CUDA_CCCL_INCLUDE "${CUDA_TOOLKIT_INCLUDE}")
+  endif()
   set(_SIMPATICO_INCLUDE_DIRS
       "${CONDA_PREFIX}/include" "${CONDA_PREFIX}/include/rapids"
       "${CUDA_TOOLKIT_INCLUDE}")


### PR DESCRIPTION
I was attempting to build the latest `dev` branch of sirius on CUDA 12 but ran into this compilation error

```
CMake Error at /home/shadeform/sirius/src/compression/simpatico_codegen/cmake/embed_cccl_headers.cmake:18 (message):
  embed_cccl_headers: CCCL_DIR
  '/home/shadeform/sirius/.pixi/envs/cuda12/targets/x86_64-linux/include/cccl'
  is not a directory
```


<details>
<summary>Full traceback:</summary>

```
cd duckdb && cmake --preset release
-- Found Python3: /home/shadeform/sirius/.pixi/envs/cuda12/bin/python3.14 (found version "3.14.6") found components: Interpreter
-- The C compiler identification is GNU 14.3.0
-- The CXX compiler identification is GNU 14.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /home/shadeform/sirius/.pixi/envs/cuda12/bin/x86_64-conda-linux-gnu-cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /home/shadeform/sirius/.pixi/envs/cuda12/bin/x86_64-conda-linux-gnu-c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Found Git: /usr/bin/git (found version "2.43.0")
fatal: No names found, cannot describe anything.
CMake Warning at CMakeLists.txt:372 (message):
  git is available (at /usr/bin/git) but has failed to execute 'describe
  --tags --long', likely due to shallow clone.  Consider providing explicit
  OVERRIDE_GIT_DESCRIBE or clone with tags.  Continuing with dummy version
  v0.0.1


-- GIT_COMMIT_HASH has length 8 different than the expected 10
-- git hash d8cdaa33, version v0.0.1, extension folder v0.0.1
-- Build workers: compile= link_release=4 link_non_release=2
-- Extensions will be deployed to: /home/shadeform/sirius/build/release/repository
-- Load extension 'sirius' from '/home/shadeform/sirius' @ dev
-- Load extension 'core_functions' from '/home/shadeform/sirius/duckdb/extensions' @ v0.0.1
-- Load extension 'parquet' from '/home/shadeform/sirius/duckdb/extensions' @ v0.0.1
CMake Warning at extension/extension_build_tools.cmake:597 (message):
  Extension 'sirius' has a vcpkg.json, but build was not run with VCPKG.  If
  build fails, check out VCPKG build instructions in
  'duckdb/extension/README.md' or try manually installing the dependencies in
  /home/shadeform/sirius/vcpkg.json
Call Stack (most recent call first):
  CMakeLists.txt:834 (include)


-- The CUDA compiler identification is NVIDIA 12.9.86 with host compiler GNU 14.3.0
-- Detecting CUDA compiler ABI info
-- Detecting CUDA compiler ABI info - done
-- Check for working CUDA compiler: /home/shadeform/sirius/.pixi/envs/cuda12/bin/nvcc - skipped
-- Detecting CUDA compile features
-- Detecting CUDA compile features - done
-- Found CUDAToolkit: /home/shadeform/sirius/.pixi/envs/cuda12/targets/x86_64-linux/include (found version "12.9.86")
-- Found rapids_logger: /home/shadeform/sirius/.pixi/envs/cuda12/lib/cmake/rapids_logger/rapids_logger-config.cmake (found version "0.2.3")
-- Finding CCCL components: Thrust;CUB;libcudacxx
-- Finding CCCL components: Thrust;CUB;libcudacxx
-- Found Thrust: /home/shadeform/sirius/.pixi/envs/cuda12/lib/rapids/cmake/thrust/thrust-config.cmake (found suitable exact version "3.4.0.0")
-- Found CUB: /home/shadeform/sirius/.pixi/envs/cuda12/lib/rapids/cmake/cub/cub-config.cmake (found suitable exact version "3.4.0.0")
-- Found libcudacxx: /home/shadeform/sirius/.pixi/envs/cuda12/lib/rapids/cmake/libcudacxx/libcudacxx-config.cmake (found suitable exact version "3.4.0.0")
-- Found CCCL: /home/shadeform/sirius/.pixi/envs/cuda12/lib/rapids/cmake/cccl/cccl-config.cmake (found version "3.4.0.0")
-- Finding CCCL components: Thrust;CUB;libcudacxx
-- Finding CCCL components: Thrust;CUB;libcudacxx
-- Finding CCCL components: Thrust;CUB;libcudacxx
-- Found rmm: /home/shadeform/sirius/.pixi/envs/cuda12/lib/cmake/rmm/rmm-config.cmake (found version "26.06.0")
-- Found cudf: /home/shadeform/sirius/.pixi/envs/cuda12/lib/cmake/cudf/cudf-config.cmake (found version "26.06.01")
-- Found PkgConfig: /home/shadeform/sirius/.pixi/envs/cuda12/bin/pkg-config (found version "0.29.2")
-- Found OpenSSL: /home/shadeform/sirius/.pixi/envs/cuda12/lib/libcrypto.so (found version "3.6.3")
-- Found ZLIB: /home/shadeform/sirius/.pixi/envs/cuda12/lib/libz.so (found version "1.3.2")
-- Checking for module 'numa'
--   Found numa, version 2.0.18
-- Checking for module 'liburing'
--   Found liburing, version 2.14
-- Checking for module 'libcurl'
--   Found libcurl, version 8.21.0
-- Finding CCCL components: Thrust;CUB;libcudacxx
-- Finding CCCL components: Thrust;CUB;libcudacxx
-- Finding CCCL components: Thrust;CUB;libcudacxx
-- Found Numa: /home/shadeform/sirius/.pixi/envs/cuda12/lib/libnuma.so
Cloning into 'corrosion-src'...
HEAD is now at 1499b14 Prepare v0.6.1 release (#656)
-- Rust Target: x86_64-unknown-linux-gnu
-- Determining required link libraries for target x86_64-unknown-linux-gnu
-- Required static libs for target x86_64-unknown-linux-gnu: gcc_s;util;rt;pthread;m;dl;c
-- Required link flags for target x86_64-unknown-linux-gnu:
-- Found Rust: /home/shadeform/sirius/.pixi/envs/cuda12/bin/rustc (found version "1.96.0")
Cloning into 'testcontainers_native_src-src'...
HEAD is now at d6929da Merge pull request #73 from mplumleeUNH/patch-1
-- Legacy Sirius code path (gpu_processing) is DISABLED
-- Sirius: redirected CUDA::nvml_static from /home/shadeform/sirius/.pixi/envs/cuda12/targets/x86_64-linux/lib/stubs/libnvidia-ml.a to /home/shadeform/sirius/.pixi/envs/cuda12/targets/x86_64-linux/lib/stubs/libnvidia-ml.so
-- Stream check library will not be built (runtime loading will gracefully fail)
-- Extensions linked into DuckDB: [sirius, core_functions, parquet]
-- Tests loaded for extensions: [sirius]
-- Configuring done (9.1s)
-- Generating done (0.4s)
-- Build files have been written to: /home/shadeform/sirius/build/release
cd duckdb && cmake --build --preset release --target duckdb duckdb_local_extension_repo
[0/1103] cd /home/shadeform/sirius/rust/crates/telemetry/bridge && /home/shadeform/sirius/.pixi/envs/cuda12/bin/cmake -E env CARGO_TARGET_X8.../telemetry/bridge/Cargo.toml --target-dir /home/shadeform/sirius/build/release/cargo/bridge_ef1e0 --release -- -Cdefault-linker-libraries=yes
   Compiling proc-macro2 v1.0.107
   Compiling unicode-ident v1.0.24
   Compiling quote v1.0.47
   Compiling libc v0.2.189
   Compiling serde_core v1.0.229
   Compiling bytes v1.12.1
   Compiling serde v1.0.229
   Compiling getrandom v0.4.3
   Compiling thiserror v2.0.19
   Compiling once_cell v1.21.4
   Compiling hashbrown v0.17.1
   Compiling equivalent v1.0.2
   Compiling memchr v2.8.3
   Compiling httparse v1.10.1
   Compiling anyhow v1.0.104
   Compiling cfg-if v1.0.4
   Compiling either v1.17.0
   Compiling pin-project-lite v0.2.17
   Compiling bitflags v2.13.1
   Compiling itoa v1.0.18
   Compiling prettyplease v0.2.37
   Compiling rustix v1.1.4
   Compiling pulldown-cmark v0.13.4
   Compiling linux-raw-sys v0.12.1
   Compiling foldhash v0.1.5
   Compiling regex-syntax v0.8.11
   Compiling unicase v2.9.0
   Compiling zmij v1.0.23
   Compiling hashbrown v0.15.5
   Compiling fixedbitset v0.5.7
   Compiling fastrand v2.5.0
   Compiling itertools v0.14.0
   Compiling log v0.4.33
   Compiling multimap v0.10.1
   Compiling futures-core v0.3.33
   Compiling heck v0.5.0
   Compiling serde_json v1.0.151
   Compiling autocfg v1.5.1
   Compiling tracing-core v0.1.36
   Compiling slab v0.4.12
   Compiling futures-sink v0.3.33
   Compiling quent-build-info v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling tower-service v0.3.3
   Compiling futures-task v0.3.33
   Compiling http v1.5.0
   Compiling indexmap v2.14.0
   Compiling futures-util v0.3.33
   Compiling fnv v1.0.7
   Compiling num-traits v0.2.19
   Compiling atomic-waker v1.1.2
   Compiling try-lock v0.2.5
   Compiling futures-channel v0.3.33
   Compiling want v0.3.1
   Compiling smallvec v1.15.2
   Compiling httpdate v1.0.3
   Compiling sync_wrapper v1.0.2
   Compiling tower-layer v0.3.3
   Compiling quent-io v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling mime v0.3.17
   Compiling percent-encoding v2.3.2
   Compiling matchit v0.8.4
   Compiling syn v3.0.3
   Compiling syn v2.0.119
   Compiling base64 v0.22.1
   Compiling petgraph v0.8.3
   Compiling http-body v1.1.0
   Compiling mio v1.2.2
   Compiling socket2 v0.6.5
   Compiling regex-automata v0.4.16
   Compiling pulldown-cmark-to-cmark v22.0.0
   Compiling http-body-util v0.1.4
   Compiling axum-core v0.5.6
   Compiling unicode-segmentation v1.13.3
   Compiling bytemuck v1.25.2
   Compiling tempfile v3.27.0
   Compiling convert_case v0.11.0
   Compiling find-msvc-tools v0.1.9
   Compiling shlex v2.0.1
   Compiling cc v1.4.0
   Compiling scratch v1.0.9
   Compiling unicode-width v0.2.2
   Compiling cxxbridge-flags v1.0.198
   Compiling uuid v1.24.0
   Compiling termcolor v1.4.1
   Compiling foldhash v0.2.0
   Compiling rmp v0.8.15
   Compiling codespan-reporting v0.13.1
   Compiling regex v1.13.1
   Compiling link-cplusplus v1.0.12
   Compiling cxx v1.0.198
   Compiling cxx-build v1.0.198
   Compiling tokio-macros v2.7.2
   Compiling serde_derive v1.0.229
   Compiling thiserror-impl v2.0.19
   Compiling async-trait v0.1.91
   Compiling cxxbridge-macro v1.0.198
   Compiling tokio v1.53.1
   Compiling tracing-attributes v0.1.31
   Compiling prost-derive v0.14.4
   Compiling pin-project-internal v1.1.13
   Compiling bitcode_derive v0.6.9
   Compiling quent-model-macros v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling tonic-build v0.14.6
   Compiling quent-time v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling cobs v0.3.0
   Compiling pin-project v1.1.13
   Compiling tracing v0.1.44
   Compiling prost v0.14.4
   Compiling prost-types v0.14.4
   Compiling quent-events v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling bitcode v0.6.9
   Compiling postcard v1.1.3
   Compiling rmp-serde v1.3.1
   Compiling quent-dynamic-attributes v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling quent-io-types v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling prost-build v0.14.4
   Compiling instrumentation-model v0.1.0 (/home/shadeform/sirius/rust/crates/telemetry/model)
   Compiling tonic-prost-build v0.14.6
   Compiling quent-collector-proto v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling tokio-util v0.7.19
   Compiling tokio-stream v0.1.19
   Compiling quent-io-ndjson v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling quent-io-msgpack v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling quent-io-postcard v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling h2 v0.4.15
   Compiling tower v0.5.3
   Compiling axum v0.8.9
   Compiling hyper v1.11.0
   Compiling hyper-util v0.1.20
   Compiling hyper-timeout v0.5.2
   Compiling tonic v0.14.6
   Compiling tonic-prost v0.14.6
   Compiling quent-collector-client v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling quent-io-collector v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling quent-instrumentation v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling quent-model v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling quent-query-engine-model v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling quent-stdlib v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling quent-codegen v0.1.0 (https://github.com/rapidsai/quent.git?rev=2a5ca83442953cbea1c9c53560808104f6b59127#2a5ca834)
   Compiling telemetry-bridge v0.1.0 (/home/shadeform/sirius/rust/crates/telemetry/bridge)
warning: telemetry-bridge@0.1.0: model component `operator` is a C++ reserved keyword — C++ namespace will be `operator_`
    Finished `release` profile [optimized] target(s) in 29.98s
[2/1103] Scanning + embedding CCCL JIT header closure into /home/shadeform/sirius/build/release/simpatico_codegen/generated/codegen/jit/cccl_embedded_headers.cpp
FAILED: [code=1] simpatico_codegen/generated/codegen/jit/cccl_embedded_headers.cpp /home/shadeform/sirius/build/release/simpatico_codegen/generated/codegen/jit/cccl_embedded_headers.cpp
cd /home/shadeform/sirius/build/release/simpatico_codegen && /home/shadeform/sirius/.pixi/envs/cuda12/bin/cmake -DCCCL_DIR=/home/shadeform/sirius/.pixi/envs/cuda12/targets/x86_64-linux/include/cccl -DOUT=/home/shadeform/sirius/build/release/simpatico_codegen/generated/codegen/jit/cccl_embedded_headers.cpp -P /home/shadeform/sirius/src/compression/simpatico_codegen/cmake/embed_cccl_headers.cmake
CMake Error at /home/shadeform/sirius/src/compression/simpatico_codegen/cmake/embed_cccl_headers.cmake:18 (message):
  embed_cccl_headers: CCCL_DIR
  '/home/shadeform/sirius/.pixi/envs/cuda12/targets/x86_64-linux/include/cccl'
  is not a directory


[26/1103] Building CXX object cucascade/CMakeFiles/cucascade_objects.dir/src/memory/reservation_manager_configurator.cpp.o
ninja: build stopped: subcommand failed.
make: *** [Makefile:47: release] Error 1
```

</details>

Here's the problem and fix description from Codex:

> CUDA 12 and CUDA 13 Pixi packages use different CCCL header layouts. The build hard-coded ${CUDA_TOOLKIT_INCLUDE}/cccl, which exists for CUDA 13 but not CUDA 12, where CCCL headers are installed directly under ${CUDA_TOOLKIT_INCLUDE}. This caused the CCCL embedding step to fail.
> 
> The fix detects whether the cccl subdirectory exists and otherwise falls back to the toolkit include directory, supporting both layouts.