### PR TITLE
ci: use prefix for sccache

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -156,8 +156,10 @@ jobs:
             echo "SCCACHE_BUCKET UNDEFINED -> GitHub Runner, Enable GHA sccache"
             echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
           fi
+          # Use 'sirius' prefix for sccache and vcpkg caches
+          echo "SCCACHE_S3_KEY_PREFIX=sirius" >> $GITHUB_ENV
           if [[ -n "${VCPKG_BUCKET}" ]]; then
-            echo "VCPKG_BINARY_SOURCES=clear;x-aws,s3://${VCPKG_BUCKET}/,readwrite" >> $GITHUB_ENV
+            echo "VCPKG_BINARY_SOURCES=clear;x-aws,s3://${VCPKG_BUCKET}/sirius/,readwrite" >> $GITHUB_ENV
           fi
 
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,8 @@ jobs:
             echo "SCCACHE_BUCKET UNDEFINED -> GitHub Runner, Enable GHA sccache"
             echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
           fi
+          # Use 'sirius' prefix for sccache cache
+          echo "SCCACHE_S3_KEY_PREFIX=sirius" >> $GITHUB_ENV
 
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 


### PR DESCRIPTION
<!-- Edit PR title: "<type>[optional scope]: <short description>", see CONTRIBUTING.md for guidance -->

## Description
<!-- Provide a standalone description of changes in this PR -->
<!-- For design docs targeting docs/experimental, note this in the description -->
In order to support multiple sirius-db repos using the same runners we need to add a prefix so sccache puts its files in a subfolder. This prevents contamination and allows us to fine-tune retention policies in our S3 bucket per repo

## Verification
- [x] S3 buckets show `sirius` prefixes for `sccache` and `vcpkg`
- [x] Successful Distribution [workflow](https://github.com/sirius-db/sirius/actions/runs/31534590207)
- [x] Successful full run of modified Check [workflow](https://github.com/sirius-db/sirius/actions/runs/31219253226) (running all variants on PR for testing)
  - This also generated the `vcpkg` cache during this test

## Backend changes
- [x] Copy `sccache` at S3 bucket root to `sirius/` pre-fix to seed jobs

## Checklist
- [x] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
<!-- Add open issues with "Closes #issue" to close or "Refs #issue" for reference, and any relevant URLs -->
