### PR TITLE
ci(duckdb): set OVERRIDE_GIT_DESCRIBE to fix extension installs in CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
+# When changing the duckdb submodule, also update OVERRIDE_GIT_DESCRIBE
+# in cmake/CMakePresets.json to match the new version.
 [submodule "duckdb"]
 	path = duckdb
 	url = https://github.com/duckdb/duckdb

--- a/cmake/CMakePresets.json
+++ b/cmake/CMakePresets.json
@@ -69,7 +69,8 @@
         "CMAKE_LINKER_TYPE": "MOLD",
         "DUCKDB_EXTENSION_CONFIGS": "${sourceDir}/../extension_config.cmake",
         "EXPORT_DYNAMIC_SYMBOLS": "ON",
-        "EXTENSION_STATIC_BUILD": "ON"
+        "EXTENSION_STATIC_BUILD": "ON",
+        "OVERRIDE_GET_DESCRIBE": "v1.5.5"
       },
       "generator": "Ninja",
       "hidden": true,

--- a/cmake/CMakePresets.json
+++ b/cmake/CMakePresets.json
@@ -70,7 +70,7 @@
         "DUCKDB_EXTENSION_CONFIGS": "${sourceDir}/../extension_config.cmake",
         "EXPORT_DYNAMIC_SYMBOLS": "ON",
         "EXTENSION_STATIC_BUILD": "ON",
-        "OVERRIDE_GET_DESCRIBE": "v1.5.5"
+        "OVERRIDE_GIT_DESCRIBE": "v1.5.5"
       },
       "generator": "Ninja",
       "hidden": true,

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -9,3 +9,5 @@ as follows:
 - Bump versions in `.github/workflows`
   - `duckdb_version` input in `distribution.yml` should be set to latest tagged release
   - The reusable `sirius-db/extension-ci-tools` workflow ref and `ci_tools_version` input should be updated only when the remote CI tooling branch changes
+- Set `OVERRIDE_GIT_DESCRIBE` in `cmake/CMakePresets.json` to the current DuckDB version `vX.Y.Z`
+  - This should match the tag at the base of the branch for the submodule


### PR DESCRIPTION
<!-- Edit PR title: "<type>[optional scope]: <short description>", see CONTRIBUTING.md for guidance -->

## Description
<!-- Provide a standalone description of changes in this PR -->
<!-- For design docs targeting docs/experimental, note this in the description -->
Surfaced in #1425 our submodule and checkouts break `git describe` and prevent DuckDB extensions from installing in CI workflows. This sets a CMake preset for `OVERRIDE_GIT_DESCRIBE` with the current DuckDB version to correct this issue.

This fix is also compatible with #1407 which will move us from the upstream DuckDB to our own fork to enable new feature patches between releases.

## Checklist
- [x] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
<!-- Add open issues with "Closes #issue" to close or "Refs #issue" for reference, and any relevant URLs -->
Refs #1425 #1407 