### PR TITLE
fix(config): reject ambiguous memory budget forms

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -118,10 +118,10 @@ Controls how much GPU VRAM Sirius claims and when it starts evicting data to hos
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `usage_limit_fraction` | double | 0.95 | Fraction of total VRAM to use as Sirius's GPU memory capacity. The remaining 5% is left for the CUDA runtime, cuDF temporaries, and other GPU consumers. |
-| `usage_limit_bytes` | bytes | — | Absolute VRAM limit. Mutually exclusive with `usage_limit_fraction`. |
-| `reservation_limit_fraction` | double | 1.0 | Fraction of the GPU capacity (set by `usage_limit_*`) that can be reserved by pipeline tasks. Reservations are acquired before task execution and prevent overcommit. |
-| `reservation_limit_bytes` | bytes | — | Absolute reservation limit. Mutually exclusive with `reservation_limit_fraction`. |
+| `usage_limit_fraction` | double | 0.95 | Fraction of total VRAM to use as Sirius's GPU memory capacity. The remaining 5% is left for the CUDA runtime, cuDF temporaries, and other GPU consumers. Mutually exclusive with `usage_limit_bytes`; configuration loading rejects both when both values are non-null. |
+| `usage_limit_bytes` | bytes | — | Absolute VRAM limit. Mutually exclusive with `usage_limit_fraction`; configuration loading rejects both when both values are non-null. |
+| `reservation_limit_fraction` | double | 1.0 | Fraction of the GPU capacity (set by `usage_limit_*`) that can be reserved by pipeline tasks. Reservations are acquired before task execution and prevent overcommit. Mutually exclusive with `reservation_limit_bytes`; configuration loading rejects both when both values are non-null. |
+| `reservation_limit_bytes` | bytes | — | Absolute reservation limit. Mutually exclusive with `reservation_limit_fraction`; configuration loading rejects both when both values are non-null. |
 | `downgrade_trigger_fraction` | double | 0.8 | Start evicting GPU-resident data to host when reserved memory exceeds this fraction of capacity. |
 | `downgrade_stop_fraction` | double | 0.6 | Stop evicting when reserved memory drops to this fraction of capacity. The gap between trigger and stop prevents oscillation. |
 | `track_per_stream_reservation` | bool | false | Track memory reservations per CUDA stream instead of globally. Useful for debugging per-task memory usage. |
@@ -132,10 +132,10 @@ Controls pinned host memory pools. One pool group is created per NUMA node (auto
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `capacity_fraction` | double (0,1] | 0.9 | Pinned host memory capacity as a fraction of **each backing NUMA node's total RAM** (read from `/sys/devices/system/node/node<id>/meminfo`). Mutually exclusive with `capacity_bytes`, which wins if both are set. Initialization fails if a node's capacity cannot be determined. |
-| `capacity_bytes` | bytes | — | Pinned host memory capacity **per NUMA node** as absolute bytes, allocated with `cudaMallocHost`. Mutually exclusive with `capacity_fraction`. |
-| `reservation_limit_fraction` | double | 1.0 | Fraction of host capacity that can be reserved. |
-| `reservation_limit_bytes` | bytes | — | Absolute reservation limit. Mutually exclusive with `reservation_limit_fraction`. |
+| `capacity_fraction` | double (0,1] | 0.9 | Pinned host memory capacity as a fraction of **each backing NUMA node's total RAM** (read from `/sys/devices/system/node/node<id>/meminfo`). Mutually exclusive with `capacity_bytes`; configuration loading rejects both when both values are non-null. Initialization fails if a node's capacity cannot be determined. |
+| `capacity_bytes` | bytes | — | Pinned host memory capacity **per NUMA node** as absolute bytes, allocated with `cudaMallocHost`. Mutually exclusive with `capacity_fraction`; configuration loading rejects both when both values are non-null. |
+| `reservation_limit_fraction` | double | 1.0 | Fraction of host capacity that can be reserved. Mutually exclusive with `reservation_limit_bytes`; configuration loading rejects both when both values are non-null. |
+| `reservation_limit_bytes` | bytes | — | Absolute reservation limit. Mutually exclusive with `reservation_limit_fraction`; configuration loading rejects both when both values are non-null. |
 | `downgrade_trigger_fraction` | double | 0.9 | Start evicting host-resident data to disk when reserved memory exceeds this fraction. Eviction also requires a configured `downgrade_root_dirs`; without one the downgrade executor logs a warning and skips. |
 | `downgrade_stop_fraction` | double | 0.8 | Stop evicting when reserved memory drops to this fraction. |
 | `block_size` | bytes | 1Mi | Size of each allocation block in the pool. Larger blocks reduce allocation overhead but waste memory on small allocations. |

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -60,6 +60,19 @@ uint64_t derived_default_batch_size()
 
 }  // namespace config
 
+static void reject_mutually_exclusive(yaml::reader& reader,
+                                      const char* context,
+                                      const char* first,
+                                      const char* second)
+{
+  auto const first_value  = reader.optional_node(first);
+  auto const second_value = reader.optional_node(second);
+  if (first_value && second_value) {
+    throw std::runtime_error(std::string(context) + ": '" + first + "' and '" + second +
+                             "' are mutually exclusive");
+  }
+}
+
 // ================ from_yaml for external types ================= //
 
 static void from_yaml(const YAML::Node& node, cucascade::memory::gpu_memory_space_config& opt)
@@ -304,6 +317,7 @@ struct gpu_mem_config {
     // usage_limit: fraction (double) or absolute bytes — mutually exclusive keys
     std::optional<std::uint64_t> usage_bytes;
     double usage_frac = 0.95;
+    reject_mutually_exclusive(r, "memory.gpu", "usage_limit_bytes", "usage_limit_fraction");
     r.optional("usage_limit_bytes", yaml::bytes(usage_bytes));
     r.optional("usage_limit_fraction", usage_frac, yaml::fraction<double>{});
     opt.usage_limit = usage_bytes ? std::variant<double, std::uint64_t>{*usage_bytes}
@@ -311,6 +325,8 @@ struct gpu_mem_config {
     // reservation_limit: fraction or absolute bytes
     std::optional<std::uint64_t> res_bytes;
     double res_frac = 1.0;
+    reject_mutually_exclusive(
+      r, "memory.gpu", "reservation_limit_bytes", "reservation_limit_fraction");
     r.optional("reservation_limit_bytes", yaml::bytes(res_bytes));
     r.optional("reservation_limit_fraction", res_frac, yaml::fraction<double>{});
     opt.reservation_limit = res_bytes ? std::variant<double, std::uint64_t>{*res_bytes}
@@ -357,6 +373,7 @@ struct host_mem_config {
     // capacity: fraction of node RAM (double) or absolute bytes per node — mutually exclusive keys
     std::optional<std::uint64_t> cap_bytes;
     std::optional<double> cap_frac;
+    reject_mutually_exclusive(r, "memory.host", "capacity_bytes", "capacity_fraction");
     r.optional("capacity_bytes", yaml::bytes(cap_bytes));
     r.optional("capacity_fraction", cap_frac);
     if (cap_frac && !(*cap_frac > 0.0 && *cap_frac <= 1.0)) {
@@ -370,6 +387,8 @@ struct host_mem_config {
     }
     std::optional<std::uint64_t> res_bytes;
     double res_frac = 1.0;
+    reject_mutually_exclusive(
+      r, "memory.host", "reservation_limit_bytes", "reservation_limit_fraction");
     r.optional("reservation_limit_bytes", yaml::bytes(res_bytes));
     r.optional("reservation_limit_fraction", res_frac, yaml::fraction<double>{});
     opt.reservation_limit = res_bytes ? std::variant<double, std::uint64_t>{*res_bytes}

--- a/test/cpp/config/data/invalid_memory_gpu_reservation_limit_both.yaml
+++ b/test/cpp/config/data/invalid_memory_gpu_reservation_limit_both.yaml
@@ -1,0 +1,5 @@
+sirius:
+  memory:
+    gpu:
+      reservation_limit_bytes: 512 MiB
+      reservation_limit_fraction: 0.5

--- a/test/cpp/config/data/invalid_memory_gpu_usage_limit_both.yaml
+++ b/test/cpp/config/data/invalid_memory_gpu_usage_limit_both.yaml
@@ -1,0 +1,5 @@
+sirius:
+  memory:
+    gpu:
+      usage_limit_bytes: 1 GiB
+      usage_limit_fraction: 0.5

--- a/test/cpp/config/data/invalid_memory_host_capacity_both.yaml
+++ b/test/cpp/config/data/invalid_memory_host_capacity_both.yaml
@@ -1,0 +1,5 @@
+sirius:
+  memory:
+    host:
+      capacity_bytes: 8 GiB
+      capacity_fraction: 0.5

--- a/test/cpp/config/data/invalid_memory_host_reservation_limit_both.yaml
+++ b/test/cpp/config/data/invalid_memory_host_reservation_limit_both.yaml
@@ -1,0 +1,5 @@
+sirius:
+  memory:
+    host:
+      reservation_limit_bytes: 4 GiB
+      reservation_limit_fraction: 0.5

--- a/test/cpp/config/data/valid_memory_budget_null_alternates.yaml
+++ b/test/cpp/config/data/valid_memory_budget_null_alternates.yaml
@@ -1,0 +1,12 @@
+sirius:
+  memory:
+    gpu:
+      usage_limit_bytes: null
+      usage_limit_fraction: 0.5
+      reservation_limit_bytes: 512 MiB
+      reservation_limit_fraction: null
+    host:
+      capacity_bytes: null
+      capacity_fraction: 0.5
+      reservation_limit_bytes: 4 GiB
+      reservation_limit_fraction: null

--- a/test/cpp/config/data/valid_memory_budget_single_forms.yaml
+++ b/test/cpp/config/data/valid_memory_budget_single_forms.yaml
@@ -1,0 +1,8 @@
+sirius:
+  memory:
+    gpu:
+      usage_limit_bytes: 1 GiB
+      reservation_limit_fraction: 0.5
+    host:
+      capacity_fraction: 0.5
+      reservation_limit_bytes: 4 GiB

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -169,6 +169,64 @@ TEST_CASE("Sirius configuration rejects zero hash partition bytes", "[sirius][co
     Catch::Contains("hash_partition_bytes") && Catch::Contains("greater than zero"));
 }
 
+TEST_CASE("Sirius configuration rejects conflicting memory budget forms", "[sirius][config]")
+{
+  struct invalid_config {
+    const char* filename;
+    const char* context;
+    const char* first;
+    const char* second;
+  };
+  const invalid_config cases[] = {
+    {"invalid_memory_gpu_usage_limit_both.yaml",
+     "memory.gpu",
+     "usage_limit_bytes",
+     "usage_limit_fraction"},
+    {"invalid_memory_gpu_reservation_limit_both.yaml",
+     "memory.gpu",
+     "reservation_limit_bytes",
+     "reservation_limit_fraction"},
+    {"invalid_memory_host_capacity_both.yaml",
+     "memory.host",
+     "capacity_bytes",
+     "capacity_fraction"},
+    {"invalid_memory_host_reservation_limit_both.yaml",
+     "memory.host",
+     "reservation_limit_bytes",
+     "reservation_limit_fraction"},
+  };
+
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+  for (auto const& test : cases) {
+    INFO(test.filename);
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(config.load_from_file(data_dir / test.filename),
+                        Catch::Contains(test.context) && Catch::Contains(test.first) &&
+                          Catch::Contains(test.second) && Catch::Contains("mutually exclusive"));
+  }
+}
+
+TEST_CASE("Sirius configuration accepts one form of each memory budget", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const cfg =
+    fs::path(loc.file_name()).parent_path() / "data" / "valid_memory_budget_single_forms.yaml";
+
+  sirius::sirius_config config;
+  REQUIRE_NOTHROW(config.load_from_file(cfg));
+}
+
+TEST_CASE("Sirius configuration treats null memory budget forms as absent", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const cfg =
+    fs::path(loc.file_name()).parent_path() / "data" / "valid_memory_budget_null_alternates.yaml";
+
+  sirius::sirius_config config;
+  REQUIRE_NOTHROW(config.load_from_file(cfg));
+}
+
 TEST_CASE("DuckDB setting rejects zero hash partition bytes without a Sirius context",
           "[sirius][context][config][isolated_context]")
 {


### PR DESCRIPTION
## Summary

- reject simultaneous non-null byte and fraction forms for the high-level GPU usage, GPU reservation, host capacity, and host reservation budgets
- preserve the existing YAML convention that an explicit `null` is absent
- update the configuration reference so it no longer documents silent byte precedence
- add focused rejection and preservation fixtures

## Why

The source described these key pairs as mutually exclusive but previously parsed both and silently preferred the byte form. A configuration could therefore state two different budgets while giving the user no direct indication that one had been ignored. Rejecting the ambiguity makes the active budget explicit without changing valid single-form or omitted defaults.

## Validation

Source-level validation:

- clang-format dry-run with warnings as errors
- `git diff --check`
- clean-base apply and reverse-apply checks
- YAML fixture parse and test-registration checks
- independent source review against Sirius `dev` `4d88a0fed6782d37c9753aa1179cbe9f47816d5a`

Compiled validation at exact PR head `ec2143a433089cd0d618acf512312151c5b8ed9f`:

- isolated `sirius_unittest` build completed all 929 actions
- `Sirius configuration rejects conflicting memory budget forms`: 4/4 assertions passed
- `Sirius configuration accepts one form of each memory budget`: 1/1 assertion passed
- `Sirius configuration treats null memory budget forms as absent`: 1/1 assertion passed
- recursive submodules matched their pins and the source tree was clean before and after
