### PR TITLE
test: reuse shared parquet fixture helpers

### DIFF
--- a/test/cpp/integration/compressed_materialization_test_common.hpp
+++ b/test/cpp/integration/compressed_materialization_test_common.hpp
@@ -26,11 +26,11 @@
 
 #include <catch.hpp>
 #include <duckdb.hpp>
+#include <utils/parquet_fixture_utils.hpp>
 #include <utils/sirius_test_env.hpp>
 
 #include <algorithm>
 #include <cstddef>
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -53,17 +53,13 @@ inline void generate_parquet(std::filesystem::path const& path,
                              std::string const& select_sql,
                              std::size_t row_group_size)
 {
-  setenv("SIRIUS_DISABLE", "1", 1);
-  {
-    duckdb::DuckDB gen_db(nullptr);
-    duckdb::Connection gen(gen_db);
-    auto r =
-      gen.Query("COPY (" + select_sql + ") TO '" + path.string() +
-                "' (FORMAT PARQUET, ROW_GROUP_SIZE " + std::to_string(row_group_size) + ");");
-    REQUIRE(r);
-    REQUIRE_FALSE(r->HasError());
-  }
-  unsetenv("SIRIUS_DISABLE");
+  sirius::test::scoped_sirius_disable disable_sirius;
+  duckdb::DuckDB gen_db(nullptr);
+  duckdb::Connection gen(gen_db);
+  auto r = gen.Query("COPY (" + select_sql + ") TO " + sirius::test::sql_literal(path.string()) +
+                     " (FORMAT PARQUET, ROW_GROUP_SIZE " + std::to_string(row_group_size) + ");");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
 }
 
 /// Operator parameters that differ between the compressed-materialization fixtures; every other

--- a/test/cpp/integration/test_gpu_execution_multi_format.cpp
+++ b/test/cpp/integration/test_gpu_execution_multi_format.cpp
@@ -30,6 +30,7 @@
 #include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <utils/parquet_fixture_utils.hpp>
 #include <utils/sirius_test_env.hpp>
 #include <utils/transparent_execution_test_utils.hpp>
 
@@ -66,19 +67,6 @@ struct sirius_config_env_guard {
   }
   ~sirius_config_env_guard() { unsetenv("SIRIUS_CONFIG_FILE"); }
 };
-
-std::string sql_string_literal(std::string const& value)
-{
-  std::string escaped;
-  escaped.reserve(value.size() + 2);
-  escaped.push_back('\'');
-  for (auto const c : value) {
-    if (c == '\'') { escaped.push_back('\''); }
-    escaped.push_back(c);
-  }
-  escaped.push_back('\'');
-  return escaped;
-}
 
 /**
  * @brief Base fixture providing compare_gpu_vs_cpu for multi-format tests.
@@ -485,7 +473,7 @@ class MultiFormatFixtureBase {
  */
 class HivePartitionDataset {
  public:
-  HivePartitionDataset()
+  HivePartitionDataset() : scratch{"hive_count_star"}, hive_dir{scratch.path()}
   {
     auto const source_root = get_project_root() / "test/cpp/integration/data/hive_partitioned";
     auto const y2024_m01   = source_root / "year=2024/month=01/data.parquet";
@@ -495,10 +483,6 @@ class HivePartitionDataset {
     REQUIRE(fs::exists(y2024_m02));
     REQUIRE(fs::exists(y2025_m01));
 
-    static std::atomic<std::uint64_t> next_fixture_id{0};
-    hive_dir = fs::temp_directory_path() /
-               ("sirius_hive_count_star_" + std::to_string(next_fixture_id.fetch_add(1)));
-    fs::remove_all(hive_dir);
     fs::create_directories(hive_dir / "h/year=2024/month=01");
     fs::create_directories(hive_dir / "h/year=2024/month=02");
     fs::create_directories(hive_dir / "h/year=2025/month=01");
@@ -528,8 +512,6 @@ class HivePartitionDataset {
     is_hive_available = true;
   }
 
-  ~HivePartitionDataset() { fs::remove_all(hive_dir); }
-
   struct watchdog_result {
     bool timed_out{false};
     duckdb::idx_t row_count{0};
@@ -540,10 +522,13 @@ class HivePartitionDataset {
 
   std::string hive_scan() const
   {
-    return "read_parquet(" + sql_string_literal(hive_path) + ", hive_partitioning=true)";
+    return "read_parquet(" + sirius::test::sql_literal(hive_path) + ", hive_partitioning=true)";
   }
 
-  std::string flat_scan() const { return "read_parquet(" + sql_string_literal(flat_path) + ")"; }
+  std::string flat_scan() const
+  {
+    return "read_parquet(" + sirius::test::sql_literal(flat_path) + ")";
+  }
 
   static std::vector<std::string> split_row(std::string const& line)
   {
@@ -687,6 +672,7 @@ class HivePartitionDataset {
     CHECK(result.rows == expected_rows);
   }
 
+  sirius::test::scratch_dir scratch;
   fs::path hive_dir;
   fs::path config_path;
   std::string hive_path;
@@ -696,17 +682,12 @@ class HivePartitionDataset {
 
 class EscapedHivePartitionDataset {
  public:
-  EscapedHivePartitionDataset()
+  EscapedHivePartitionDataset() : scratch{"hive_unescape"}, hive_dir{scratch.path()}
   {
     auto const source =
       get_project_root() /
       "test/cpp/integration/data/hive_partitioned/year=2024/month=01/data.parquet";
     REQUIRE(fs::exists(source));
-
-    static std::atomic<std::uint64_t> next_fixture_id{0};
-    hive_dir = fs::temp_directory_path() /
-               ("sirius_hive_unescape_" + std::to_string(next_fixture_id.fetch_add(1)));
-    fs::remove_all(hive_dir);
 
     copy_partition(source, hive_dir / "space/city=New%20York/data.parquet");
     copy_partition(source, hive_dir / "slash/city=Path%2FTeam/data.parquet");
@@ -716,11 +697,9 @@ class EscapedHivePartitionDataset {
     copy_partition(source, hive_dir / "plain/city=Boston/data.parquet");
   }
 
-  ~EscapedHivePartitionDataset() { fs::remove_all(hive_dir); }
-
   std::string partition_scan(fs::path const& relative_glob) const
   {
-    return "read_parquet(" + sql_string_literal((hive_dir / relative_glob).string()) +
+    return "read_parquet(" + sirius::test::sql_literal((hive_dir / relative_glob).string()) +
            ", hive_partitioning=true)";
   }
 
@@ -731,6 +710,7 @@ class EscapedHivePartitionDataset {
     fs::copy_file(source, target, fs::copy_options::overwrite_existing);
   }
 
+  sirius::test::scratch_dir scratch;
   fs::path hive_dir;
 };
 

--- a/test/cpp/integration/test_pin_table_column_order.cpp
+++ b/test/cpp/integration/test_pin_table_column_order.cpp
@@ -37,15 +37,13 @@
 
 #include <catch.hpp>
 #include <duckdb.hpp>
-#include <unistd.h>
+#include <utils/parquet_fixture_utils.hpp>
 #include <utils/sirius_test_env.hpp>
 
 #include <cstdint>
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <string>
-#include <system_error>
 
 namespace fs = std::filesystem;
 
@@ -63,39 +61,33 @@ constexpr char const* kWhere = "k >= 0 AND a < b";
 // row except the first (range 0 → a == b).
 void generate_parquet(fs::path const& path)
 {
-  setenv("SIRIUS_DISABLE", "1", 1);
-  {
-    duckdb::DuckDB gen_db(nullptr);
-    duckdb::Connection gen(gen_db);
-    auto r = gen.Query(
-      "COPY (SELECT range AS k, "
-      "             DATE '1990-01-01' + CAST(range AS INTEGER) AS a, "
-      "             DATE '1990-01-01' + CAST(range * 2 AS INTEGER) AS b "
-      "      FROM range(" +
-      std::to_string(kRows) + ")) TO '" + path.string() + "' (FORMAT PARQUET);");
-    REQUIRE(r);
-    REQUIRE_FALSE(r->HasError());
-  }
-  unsetenv("SIRIUS_DISABLE");
+  sirius::test::scoped_sirius_disable disable_sirius;
+  duckdb::DuckDB gen_db(nullptr);
+  duckdb::Connection gen(gen_db);
+  auto r = gen.Query(
+    "COPY (SELECT range AS k, "
+    "             DATE '1990-01-01' + CAST(range AS INTEGER) AS a, "
+    "             DATE '1990-01-01' + CAST(range * 2 AS INTEGER) AS b "
+    "      FROM range(" +
+    std::to_string(kRows) + ")) TO " + sirius::test::sql_literal(path.string()) +
+    " (FORMAT PARQUET);");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
 }
 
 // CPU (DuckDB, Sirius disabled) baseline for the same query — the ground truth the GPU result
 // must match.
 std::string cpu_count(fs::path const& path)
 {
-  setenv("SIRIUS_DISABLE", "1", 1);
-  std::string out;
-  {
-    duckdb::DuckDB db(nullptr);
-    duckdb::Connection con(db);
-    auto r = con.Query("SELECT count(*) FROM read_parquet('" + path.string() + "') WHERE " +
-                       std::string(kWhere) + ";");
-    REQUIRE(r);
-    REQUIRE_FALSE(r->HasError());
-    out = r->GetValue(0, 0).ToString();
-  }
-  unsetenv("SIRIUS_DISABLE");
-  return out;
+  sirius::test::scoped_sirius_disable disable_sirius;
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto r =
+    con.Query("SELECT count(*) FROM read_parquet(" + sirius::test::sql_literal(path.string()) +
+              ") WHERE " + std::string(kWhere) + ";");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
+  return r->GetValue(0, 0).ToString();
 }
 
 void write_config(fs::path const& yaml_path)
@@ -146,10 +138,8 @@ TEST_CASE("pin_table - cached scan serves columns in materialized order (column-
     sirius::test::g_integration_env_2gpu->pause();
   }
 
-  auto tmp = fs::temp_directory_path() / ("sirius-pin-colorder-" + std::to_string(::getpid()));
-  std::error_code ec;
-  fs::remove_all(tmp, ec);
-  fs::create_directories(tmp);
+  sirius::test::scratch_dir scratch{"pin_colorder"};
+  auto const& tmp = scratch.path();
 
   auto parquet_path = tmp / "kab.parquet";
   generate_parquet(parquet_path);
@@ -176,14 +166,15 @@ TEST_CASE("pin_table - cached scan serves columns in materialized order (column-
     for (auto const* tier : {"host", "gpu"}) {
       DYNAMIC_SECTION("pin tier = " << tier)
       {
-        auto pin = con.Query("CALL pin_table('" + parquet_path.string() + "', tier='" + tier +
-                             "', name='colorder', cols=['k', 'a', 'b']);");
+        auto pin = con.Query("CALL pin_table(" + sirius::test::sql_literal(parquet_path.string()) +
+                             ", tier='" + tier + "', name='colorder', cols=['k', 'a', 'b']);");
         REQUIRE(pin);
         if (pin->HasError()) { UNSCOPED_INFO("pin_table error: " << pin->GetError()); }
         REQUIRE_FALSE(pin->HasError());
 
-        auto res = con.Query("SELECT count(*) FROM read_parquet('" + parquet_path.string() +
-                             "') WHERE " + std::string(kWhere) + ";");
+        auto res = con.Query("SELECT count(*) FROM read_parquet(" +
+                             sirius::test::sql_literal(parquet_path.string()) + ") WHERE " +
+                             std::string(kWhere) + ";");
         REQUIRE(res);
         if (res->HasError()) { UNSCOPED_INFO("query error: " << res->GetError()); }
         REQUIRE_FALSE(res->HasError());  // before the fix: cuDF non-matching-operand crash
@@ -195,6 +186,4 @@ TEST_CASE("pin_table - cached scan serves columns in materialized order (column-
       }
     }
   }
-
-  fs::remove_all(tmp, ec);
 }

--- a/test/cpp/integration/test_pin_table_host_streaming.cpp
+++ b/test/cpp/integration/test_pin_table_host_streaming.cpp
@@ -37,16 +37,14 @@
 #include <cucascade/memory/memory_space.hpp>
 #include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 #include <duckdb.hpp>
-#include <unistd.h>
+#include <utils/parquet_fixture_utils.hpp>
 #include <utils/sirius_test_env.hpp>
 
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <string>
-#include <system_error>
 
 namespace fs = std::filesystem;
 
@@ -63,16 +61,13 @@ constexpr std::size_t kBatchBytes = 8ull << 20;  // 8 MiB scan batches -> ~80 ba
 // build a SiriusContext on it — the real (tiny-budget) instance is created later from the yaml.
 void generate_parquet(fs::path const& path)
 {
-  setenv("SIRIUS_DISABLE", "1", 1);
-  {
-    duckdb::DuckDB gen_db(nullptr);
-    duckdb::Connection gen(gen_db);
-    auto r = gen.Query("COPY (SELECT range AS k, range * 2 AS v FROM range(" +
-                       std::to_string(kRows) + ")) TO '" + path.string() + "' (FORMAT PARQUET);");
-    REQUIRE(r);
-    REQUIRE_FALSE(r->HasError());
-  }
-  unsetenv("SIRIUS_DISABLE");
+  sirius::test::scoped_sirius_disable disable_sirius;
+  duckdb::DuckDB gen_db(nullptr);
+  duckdb::Connection gen(gen_db);
+  auto r = gen.Query("COPY (SELECT range AS k, range * 2 AS v FROM range(" + std::to_string(kRows) +
+                     ")) TO " + sirius::test::sql_literal(path.string()) + " (FORMAT PARQUET);");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
 }
 
 // Mirror integration.yaml, but cap GPU memory well below the table size and shrink the scan
@@ -132,10 +127,8 @@ TEST_CASE("gpu_execution - pin_table host tier streams without fitting the whole
     sirius::test::g_integration_env_2gpu->pause();
   }
 
-  auto tmp = fs::temp_directory_path() / ("sirius-pin-host-stream-" + std::to_string(::getpid()));
-  std::error_code ec;
-  fs::remove_all(tmp, ec);
-  fs::create_directories(tmp);
+  sirius::test::scratch_dir scratch{"pin_host_stream"};
+  auto const& tmp = scratch.path();
 
   auto parquet_path = tmp / "wide.parquet";
   generate_parquet(parquet_path);
@@ -157,8 +150,8 @@ TEST_CASE("gpu_execution - pin_table host tier streams without fitting the whole
 
     // The view over the generated parquet is the queryable relation; the pinned cache entry is
     // keyed by the same resolved file path, so a scan of `t` is served from the host cache.
-    auto v =
-      con.Query("CREATE VIEW t AS SELECT * FROM read_parquet('" + parquet_path.string() + "');");
+    auto v = con.Query("CREATE VIEW t AS SELECT * FROM read_parquet(" +
+                       sirius::test::sql_literal(parquet_path.string()) + ");");
     REQUIRE(v);
     REQUIRE_FALSE(v->HasError());
 
@@ -177,7 +170,8 @@ TEST_CASE("gpu_execution - pin_table host tier streams without fitting the whole
     // through GPU at a time, this must succeed; materializing the whole table on GPU (the
     // pre-streaming behavior) could not fit the budget.
     auto pin_result =
-      con.Query("CALL pin_table('" + parquet_path.string() + "', tier='host', name='t');");
+      con.Query("CALL pin_table(" + sirius::test::sql_literal(parquet_path.string()) +
+                ", tier='host', name='t');");
     REQUIRE(pin_result);
     if (pin_result->HasError()) { UNSCOPED_INFO("pin_table error: " << pin_result->GetError()); }
     REQUIRE_FALSE(pin_result->HasError());
@@ -205,6 +199,4 @@ TEST_CASE("gpu_execution - pin_table host tier streams without fitting the whole
     REQUIRE(unpin_result);
     REQUIRE_FALSE(unpin_result->HasError());
   }
-
-  fs::remove_all(tmp, ec);
 }

--- a/test/cpp/integration/test_pin_table_zone_map_pruning.cpp
+++ b/test/cpp/integration/test_pin_table_zone_map_pruning.cpp
@@ -31,16 +31,14 @@
 #include <duckdb/planner/filter/constant_filter.hpp>
 #include <duckdb/planner/table_filter.hpp>
 #include <scan_manager/sirius_scan_manager.hpp>
-#include <unistd.h>
+#include <utils/parquet_fixture_utils.hpp>
 #include <utils/sirius_test_env.hpp>
 
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <string>
-#include <system_error>
 #include <utility>
 
 namespace fs = std::filesystem;
@@ -65,31 +63,25 @@ void require_ok(duckdb::unique_ptr<duckdb::MaterializedQueryResult> const& r, ch
 
 void generate_parquet(fs::path const& path)
 {
-  setenv("SIRIUS_DISABLE", "1", 1);
-  {
-    duckdb::DuckDB gen_db(nullptr);
-    duckdb::Connection gen(gen_db);
-    auto r =
-      gen.Query("COPY (SELECT range AS k, range * 2 AS v FROM range(" + std::to_string(kRows) +
-                ") ORDER BY k) TO '" + path.string() + "' (FORMAT PARQUET);");
-    REQUIRE(r);
-    REQUIRE_FALSE(r->HasError());
-  }
-  unsetenv("SIRIUS_DISABLE");
+  sirius::test::scoped_sirius_disable disable_sirius;
+  duckdb::DuckDB gen_db(nullptr);
+  duckdb::Connection gen(gen_db);
+  auto r = gen.Query("COPY (SELECT range AS k, range * 2 AS v FROM range(" + std::to_string(kRows) +
+                     ") ORDER BY k) TO " + sirius::test::sql_literal(path.string()) +
+                     " (FORMAT PARQUET);");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
 }
 
 void generate_native_db(fs::path const& db_path)
 {
-  setenv("SIRIUS_DISABLE", "1", 1);
-  {
-    duckdb::DuckDB gen_db(db_path.string().c_str());
-    duckdb::Connection gen(gen_db);
-    auto r = gen.Query("CREATE TABLE zm_native_t AS SELECT range AS k, range * 2 AS v FROM range(" +
-                       std::to_string(kRows) + ");");
-    REQUIRE(r);
-    REQUIRE_FALSE(r->HasError());
-  }
-  unsetenv("SIRIUS_DISABLE");
+  sirius::test::scoped_sirius_disable disable_sirius;
+  duckdb::DuckDB gen_db(db_path.string().c_str());
+  duckdb::Connection gen(gen_db);
+  auto r = gen.Query("CREATE TABLE zm_native_t AS SELECT range AS k, range * 2 AS v FROM range(" +
+                     std::to_string(kRows) + ");");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
 }
 
 void write_config(fs::path const& yaml_path)
@@ -230,10 +222,8 @@ TEST_CASE("gpu_execution - pinned zone maps prune clustered parquet chunks end t
 {
   pause_shared_envs();
 
-  auto tmp = fs::temp_directory_path() / ("sirius-pin-zonemap-" + std::to_string(::getpid()));
-  std::error_code ec;
-  fs::remove_all(tmp, ec);
-  fs::create_directories(tmp);
+  sirius::test::scratch_dir scratch{"pin_zonemap"};
+  auto const& tmp = scratch.path();
 
   auto parquet_path = tmp / "clustered.parquet";
   generate_parquet(parquet_path);
@@ -247,9 +237,9 @@ TEST_CASE("gpu_execution - pinned zone maps prune clustered parquet chunks end t
     auto con = local_env.make_connection();
 
     require_ok(con.Query("SET enable_duckdb_fallback = false;"), "disable fallback");
-    require_ok(
-      con.Query("CREATE VIEW t AS SELECT * FROM read_parquet('" + parquet_path.string() + "');"),
-      "create view");
+    require_ok(con.Query("CREATE VIEW t AS SELECT * FROM read_parquet(" +
+                         sirius::test::sql_literal(parquet_path.string()) + ");"),
+               "create view");
 
     auto sirius_ctx = con.context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
     REQUIRE(sirius_ctx);
@@ -257,8 +247,8 @@ TEST_CASE("gpu_execution - pinned zone maps prune clustered parquet chunks end t
     for (auto const* tier : {"host", "gpu"}) {
       DYNAMIC_SECTION("tier = " << tier)
       {
-        auto pin = con.Query("CALL pin_table('" + parquet_path.string() + "', tier='" +
-                             std::string(tier) + "', name='t');");
+        auto pin = con.Query("CALL pin_table(" + sirius::test::sql_literal(parquet_path.string()) +
+                             ", tier='" + std::string(tier) + "', name='t');");
         require_ok(pin, "pin_table");
 
         run_pruning_assertions(con, *sirius_ctx, "t", "t");
@@ -270,8 +260,8 @@ TEST_CASE("gpu_execution - pinned zone maps prune clustered parquet chunks end t
     SECTION("capture disabled at pin time yields a statless entry")
     {
       require_ok(con.Query("SET enable_pinned_zone_map_pruning = false;"), "disable before pin");
-      auto pin =
-        con.Query("CALL pin_table('" + parquet_path.string() + "', tier='gpu', name='t');");
+      auto pin = con.Query("CALL pin_table(" + sirius::test::sql_literal(parquet_path.string()) +
+                           ", tier='gpu', name='t');");
       require_ok(pin, "pin with capture disabled");
       auto const* entry_ptr = find_entry(*sirius_ctx, "t");
       REQUIRE(entry_ptr != nullptr);
@@ -290,16 +280,14 @@ TEST_CASE("gpu_execution - pinned zone maps prune clustered parquet chunks end t
 
       // ...until a re-pin: the same-name GPU re-pin takes the equal-row-count
       // merge and the statless entry adopts the fresh capture.
-      auto repin =
-        con.Query("CALL pin_table('" + parquet_path.string() + "', tier='gpu', name='t');");
+      auto repin = con.Query("CALL pin_table(" + sirius::test::sql_literal(parquet_path.string()) +
+                             ", tier='gpu', name='t');");
       require_ok(repin, "re-pin with capture enabled");
       run_pruning_assertions(con, *sirius_ctx, "t", "t");
 
       require_ok(con.Query("CALL unpin_table('t');"), "unpin");
     }
   }
-
-  fs::remove_all(tmp, ec);
 }
 
 TEST_CASE("gpu_execution - pinned zone maps prune clustered duckdb-native chunks end to end",
@@ -307,10 +295,8 @@ TEST_CASE("gpu_execution - pinned zone maps prune clustered duckdb-native chunks
 {
   pause_shared_envs();
 
-  auto tmp = fs::temp_directory_path() / ("sirius-pin-zonemap-nat-" + std::to_string(::getpid()));
-  std::error_code ec;
-  fs::remove_all(tmp, ec);
-  fs::create_directories(tmp);
+  sirius::test::scratch_dir scratch{"pin_zonemap_native"};
+  auto const& tmp = scratch.path();
 
   auto yaml_path = tmp / "pin_zonemap_native.yaml";
   write_config(yaml_path);
@@ -324,7 +310,9 @@ TEST_CASE("gpu_execution - pinned zone maps prune clustered duckdb-native chunks
     auto con = local_env.make_connection();
 
     require_ok(con.Query("SET gpu_execution = false;"), "disable gpu for setup");
-    require_ok(con.Query("ATTACH '" + db_file.string() + "' AS zm_native;"), "attach");
+    require_ok(
+      con.Query("ATTACH " + sirius::test::sql_literal(db_file.string()) + " AS zm_native;"),
+      "attach");
     require_ok(con.Query("USE zm_native;"), "use attached db");
     require_ok(con.Query("SET gpu_execution = true;"), "enable gpu");
     require_ok(con.Query("SET enable_duckdb_fallback = false;"), "disable fallback");
@@ -345,6 +333,4 @@ TEST_CASE("gpu_execution - pinned zone maps prune clustered duckdb-native chunks
       }
     }
   }
-
-  fs::remove_all(tmp, ec);
 }

--- a/test/cpp/integration/test_transparent_runtime_fallback.cpp
+++ b/test/cpp/integration/test_transparent_runtime_fallback.cpp
@@ -29,6 +29,7 @@
 #include <unistd.h>  // getpid
 #include <util/duckdb_error_message.hpp>
 #include <utils/gpu_execution_fixture.hpp>
+#include <utils/parquet_fixture_utils.hpp>
 #include <utils/sirius_test_env.hpp>
 #include <utils/transparent_execution_test_utils.hpp>
 
@@ -349,30 +350,13 @@ constexpr char kS3MixChildCase[]        = "S3 mix fallback child runner";
 constexpr char kS3MixScenarioEnv[]      = "SIRIUS_S3MIX_CHILD_SCENARIO";
 constexpr char kRuntimeFallbackBanner[] = "Error in Sirius GPU execution, fallback to DuckDB";
 
-std::string sql_literal(std::string const& value)
-{
-  std::string out;
-  out.reserve(value.size() + 2);
-  out.push_back('\'');
-  for (auto const c : value) {
-    if (c == '\'') { out.push_back('\''); }
-    out.push_back(c);
-  }
-  out.push_back('\'');
-  return out;
-}
-
 class S3MixFixture : public sirius::test::GpuExecutionFixture {
  public:
   S3MixFixture()
+    : work_dir{"s3mix"},
+      parquet_path{work_dir.path() / "nested.parquet"},
+      empty_path{work_dir.path() / "empty.parquet"}
   {
-    static std::atomic<std::uint64_t> next_id{0};
-    work_dir = fs::temp_directory_path() / ("sirius_s3mix_" + std::to_string(::getpid()) + "_" +
-                                            std::to_string(next_id.fetch_add(1)));
-    fs::create_directories(work_dir);
-    parquet_path = work_dir / "nested.parquet";
-    empty_path   = work_dir / "empty.parquet";
-
     std::string const source =
       "SELECT CAST(i - 100 AS BIGINT) AS id, "
       "CAST(i - 100 AS BIGINT) AS a, CAST(i AS BIGINT) AS b, "
@@ -382,34 +366,34 @@ class S3MixFixture : public sirius::test::GpuExecutionFixture {
       "FROM range(300) t(i)";
 
     run_ok("SET gpu_execution = false;");
-    run_ok("COPY (" + source + ") TO " + sql_literal(parquet_path.string()) + " (FORMAT PARQUET);");
+    run_ok("COPY (" + source + ") TO " + sirius::test::sql_literal(parquet_path.string()) +
+           " (FORMAT PARQUET);");
     run_ok("COPY (SELECT * FROM (" + source + ") empty_source WHERE false) TO " +
-           sql_literal(empty_path.string()) + " (FORMAT PARQUET);");
+           sirius::test::sql_literal(empty_path.string()) + " (FORMAT PARQUET);");
     run_ok("CREATE TABLE mix_native AS " + source + ";");
     run_ok("CHECKPOINT;");
 
-    auto const partition_dir = work_dir / "hive" / "part=1";
+    auto const partition_dir = work_dir.path() / "hive" / "part=1";
     fs::create_directories(partition_dir);
     fs::copy_file(
       parquet_path, partition_dir / "data.parquet", fs::copy_options::overwrite_existing);
     run_ok("SET gpu_execution = true;");
   }
 
-  ~S3MixFixture() { fs::remove_all(work_dir); }
-
   std::string parquet_scan() const
   {
-    return "read_parquet(" + sql_literal(parquet_path.string()) + ")";
+    return "read_parquet(" + sirius::test::sql_literal(parquet_path.string()) + ")";
   }
 
   std::string empty_scan() const
   {
-    return "read_parquet(" + sql_literal(empty_path.string()) + ")";
+    return "read_parquet(" + sirius::test::sql_literal(empty_path.string()) + ")";
   }
 
   std::string hive_scan() const
   {
-    return "read_parquet(" + sql_literal((work_dir / "hive" / "*" / "*.parquet").string()) +
+    return "read_parquet(" +
+           sirius::test::sql_literal((work_dir.path() / "hive" / "*" / "*.parquet").string()) +
            ", hive_partitioning=true)";
   }
 
@@ -472,7 +456,7 @@ class S3MixFixture : public sirius::test::GpuExecutionFixture {
   }
 
  private:
-  fs::path work_dir;
+  sirius::test::scratch_dir work_dir;
   fs::path parquet_path;
   fs::path empty_path;
 };
@@ -764,7 +748,8 @@ TEST_CASE_METHOD(RuntimeFallbackFixture,
     csv << "id\n1\n";
   }
 
-  auto const inner = "SELECT * FROM read_csv_auto(" + sql_literal(csv_path.string()) + ")";
+  auto const inner =
+    "SELECT * FROM read_csv_auto(" + sirius::test::sql_literal(csv_path.string()) + ")";
   std::string escaped;
   escaped.reserve(inner.size());
   for (auto const c : inner) {

--- a/test/cpp/planner/test_sirius_read_parquet_scan.cpp
+++ b/test/cpp/planner/test_sirius_read_parquet_scan.cpp
@@ -25,15 +25,13 @@
 
 #include <catch.hpp>
 #include <duckdb.hpp>
-#include <unistd.h>
+#include <utils/parquet_fixture_utils.hpp>
 #include <utils/sirius_test_env.hpp>
 
 #include <cstdint>
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <string>
-#include <system_error>
 
 namespace fs = std::filesystem;
 
@@ -45,16 +43,13 @@ constexpr std::int64_t kRows = 100'000;
 // not build a SiriusContext on it.
 void generate_parquet(fs::path const& path)
 {
-  setenv("SIRIUS_DISABLE", "1", 1);
-  {
-    duckdb::DuckDB gen_db(nullptr);
-    duckdb::Connection gen(gen_db);
-    auto r = gen.Query("COPY (SELECT range AS k, range * 2 AS v FROM range(" +
-                       std::to_string(kRows) + ")) TO '" + path.string() + "' (FORMAT PARQUET);");
-    REQUIRE(r);
-    REQUIRE_FALSE(r->HasError());
-  }
-  unsetenv("SIRIUS_DISABLE");
+  sirius::test::scoped_sirius_disable disable_sirius;
+  duckdb::DuckDB gen_db(nullptr);
+  duckdb::Connection gen(gen_db);
+  auto r = gen.Query("COPY (SELECT range AS k, range * 2 AS v FROM range(" + std::to_string(kRows) +
+                     ")) TO " + sirius::test::sql_literal(path.string()) + " (FORMAT PARQUET);");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
 }
 
 void write_config(fs::path const& yaml_path)
@@ -105,10 +100,8 @@ TEST_CASE("tree pipeline build plans sirius_read_parquet scans",
     sirius::test::g_integration_env_2gpu->pause();
   }
 
-  auto tmp = fs::temp_directory_path() / ("sirius-srp-tree-" + std::to_string(::getpid()));
-  std::error_code ec;
-  fs::remove_all(tmp, ec);
-  fs::create_directories(tmp);
+  sirius::test::scratch_dir scratch{"srp_tree"};
+  auto const& tmp = scratch.path();
 
   auto parquet_path = tmp / "kv.parquet";
   generate_parquet(parquet_path);
@@ -127,14 +120,12 @@ TEST_CASE("tree pipeline build plans sirius_read_parquet scans",
     REQUIRE(fb);
     REQUIRE_FALSE(fb->HasError());
 
-    auto res = con.Query("SELECT max(k), count(*) FROM sirius_read_parquet('" +
-                         parquet_path.string() + "');");
+    auto res = con.Query("SELECT max(k), count(*) FROM sirius_read_parquet(" +
+                         sirius::test::sql_literal(parquet_path.string()) + ");");
     REQUIRE(res);
     if (res->HasError()) { UNSCOPED_INFO("sirius_read_parquet query error: " << res->GetError()); }
     REQUIRE_FALSE(res->HasError());  // pre-fix: "Unsupported scan function: sirius_read_parquet"
     REQUIRE(res->GetValue(0, 0).GetValue<int64_t>() == kRows - 1);
     REQUIRE(res->GetValue(1, 0).GetValue<int64_t>() == kRows);
   }
-
-  fs::remove_all(tmp, ec);
 }

--- a/test/cpp/scan/test_duckdb_native_dynamic_filter_remap.cpp
+++ b/test/cpp/scan/test_duckdb_native_dynamic_filter_remap.cpp
@@ -26,16 +26,12 @@
 #include <duckdb/storage/storage_manager.hpp>
 #include <op/scan/duckdb_native_gpu_ingestible.hpp>
 #include <op/sirius_dynamic_filter.hpp>
-#include <unistd.h>
+#include <utils/parquet_fixture_utils.hpp>
 
-#include <cstdlib>
-#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-
-namespace fs = std::filesystem;
 
 using namespace sirius;
 using namespace sirius::op::scan;
@@ -67,13 +63,6 @@ duckdb::DataTable& get_storage(duckdb::Connection& con, const std::string& table
   REQUIRE(entry);
   return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
 }
-
-// Keeps the throwaway DuckDB below on the CPU path; the ingestible ctor itself never
-// needs the extension. Restores on scope exit so later tests can build Sirius envs.
-struct sirius_disable_guard {
-  sirius_disable_guard() { setenv("SIRIUS_DISABLE", "1", 1); }
-  ~sirius_disable_guard() { unsetenv("SIRIUS_DISABLE"); }
-};
 
 // The remap is channel bookkeeping, so a host-only stand-in filter suffices —
 // push_filter accepts any non-null sirius_dynamic_filter.
@@ -150,15 +139,13 @@ std::unique_ptr<duckdb_native_ingestible_table_info> make_info(
 TEST_CASE("duckdb-native ingestible installs the dynamic-filter column remap",
           "[scan][duckdb_native][dynamic_filter]")
 {
-  sirius_disable_guard disable_sirius;
+  sirius::test::scoped_sirius_disable disable_sirius;
 
   // The ingestible ctor requires a single-file block manager, so the backing table
   // must live in a file-backed database (an in-memory one cannot serve it).
-  auto tmp = fs::temp_directory_path() / ("sirius-ddbnative-remap-" + std::to_string(::getpid()));
-  std::error_code ec;
-  fs::remove_all(tmp, ec);
-  fs::create_directories(tmp);
-  auto db_file = tmp / "remap.duckdb";
+  sirius::test::scratch_dir scratch{"ddbnative_remap"};
+  auto const& tmp = scratch.path();
+  auto db_file    = tmp / "remap.duckdb";
 
   duckdb::DuckDB db(db_file.string().c_str());
   duckdb::Connection con(db);
@@ -232,6 +219,4 @@ TEST_CASE("duckdb-native ingestible installs the dynamic-filter column remap",
       make_ingestible(make_info(storage, *con.context, all_cols, {2, 0}, 2, nullptr));
     REQUIRE(ingestible);
   }
-
-  fs::remove_all(tmp, ec);
 }


### PR DESCRIPTION
Follow-up PR mentioned here https://github.com/sirius-db/sirius/pull/1419#discussion_r3730672105

## Description

Migrates existing tests to the shared utilities in `parquet_fixture_utils.hpp`.

- Replaces duplicated temporary-directory setup with `scratch_dir`
- Replaces local SQL path escaping with `sql_literal`
- Replaces manual `SIRIUS_DISABLE` handling with `scoped_sirius_disable`
- Updates `S3MixFixture`, Hive fixtures, zone-map tests, parquet scan tests, and dynamic-filter tests
- Preserves existing fixture behavior while ensuring environment variables are restored and temporary files are cleaned up safely