### PR TITLE
fix: make standard debug builds non-sanitized

### DIFF
--- a/cmake/CMakePresets.json
+++ b/cmake/CMakePresets.json
@@ -123,7 +123,9 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_CUDA_FLAGS_DEBUG": "-g -lineinfo -O0",
         "CMAKE_CXX_FLAGS_DEBUG": "-g -O0",
-        "CMAKE_C_FLAGS_DEBUG": "-g -O0"
+        "CMAKE_C_FLAGS_DEBUG": "-g -O0",
+        "ENABLE_SANITIZER": "FALSE",
+        "ENABLE_UBSAN": "0"
       },
       "displayName": "Clang Debug",
       "inherits": "base-clang",


### PR DESCRIPTION
Makes standard debug builds non-sanitized (the sanitizer flags were transitively included via duckdb configs). This allows debug builds to run certain unit tests that test memory management behaviors without crashing with OOM now.
