### PR TITLE
feat(gpu): size the GPU allocation from the plan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ set(EXTENSION_SOURCES
     src/pipeline/sirius_plan_printer.cpp
     src/pipeline/task_request.cpp
     src/planner/duckdb_join_filter_candidate_adapter.cpp
+    src/planner/gpu_admission.cpp
     src/planner/query.cpp
     src/planner/query_index.cpp
     src/planner/sirius_physical_plan_generator.cpp

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -411,6 +411,10 @@ individually.
 | `dynamic_filter_domain_coverage_threshold` | 0.9 | Positive finite threshold for skipping publication when the build covers at least this fraction of the key's domain; ≥ 1.0 effectively disables the gate. |
 | `dynamic_filter_keep_threshold` | 0.9 | Finite threshold in [0, 1] for disabling post-decode filtering once a measured split keeps more than this fraction of its rows; 1.0 keeps filtering always on. |
 | `enable_pinned_zone_map_pruning` | true | Capture per-chunk min/max statistics while pinning and use them to skip cached chunks that cannot match a scan filter. |
+| `admission_bytes_per_gpu` | 0 (off) | Target projected scan-output bytes per GPU. At admission the engine estimates a query's total scan output and takes the smallest GPU subset that keeps each GPU under this figure, bounded by `topology.gpus_per_query`. `0` disables the estimate, leaving the allocation to `topology.gpus_per_query` alone. |
+| `avg_variable_column_bytes` | 32 | Per-row width assumed for variable-width columns (VARCHAR, LIST, STRUCT, ARRAY) when estimating scan output. Fixed-width columns use their real carrier width. Only consulted when `admission_bytes_per_gpu` is non-zero. |
+
+**Note:** `admission_bytes_per_gpu` is a parallelism dial, not a memory budget. Peak GPU residency is bounded by partition sizing (`hash_partition_bytes` and the batch settings), not by the admitted GPU count — a query on fewer GPUs processes more partitions sequentially at roughly unchanged peak memory, trading wall-clock for freed devices. Tune it against how much of the fleet a query should occupy, not against VRAM.
 
 **Note:** `max_build_hash_table_bytes` can be larger than `concat_batch_bytes`. When it is, the partition operator configures CONCAT to concatenate all batches, enabling the more efficient BUILD_PROBE join mode for larger build sides. Other joins (STANDARD, MIXED) still use `concat_batch_bytes` as the batch size threshold.
 
@@ -587,6 +591,20 @@ SET enable_compressed_materialization = false;
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join |
 | `mark_join_build_switch_ratio` | 8.0 | STANDARD MARK join build-side switch ratio (0 disables) |
 | `enable_runtime_distinct_build_probe` | true | Runtime distinct-build test for `BUILD_PROBE` joins; promotes to the single-pass `cudf::distinct_hash_join` when the build keys prove distinct |
+
+### GPU Admission
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `admission_bytes_per_gpu` | 0 (off) | Target projected scan-output bytes per GPU; `0` disables the estimate, leaving the allocation to `topology.gpus_per_query` |
+| `avg_variable_column_bytes` | 32 | Per-row width assumed for variable-width columns when estimating scan output; must be greater than zero |
+
+Both take effect from the next query, since admission runs per query. `topology.gpus_per_query`
+is YAML-only — it is read once when the GPU memory spaces are configured.
+
+```sql
+SET admission_bytes_per_gpu = 34359738368;  -- 32 GiB
+```
 
 ### Dynamic Filters
 

--- a/src/include/planner/gpu_admission.hpp
+++ b/src/include/planner/gpu_admission.hpp
@@ -16,10 +16,30 @@
 
 #pragma once
 
+#include "helper/logical_type.hpp"
+
+#include <algorithm>
 #include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <optional>
 #include <vector>
 
+namespace sirius::op {
+class sirius_physical_operator;
+}  // namespace sirius::op
+
 namespace sirius::planner {
+
+/**
+ * @brief Collect every GPU_SCAN operator reachable from @p node.
+ *
+ * Mirrors sirius_physical_plan_generator::set_parent_ops, the canonical full-tree descent.
+ * RESULT_COLLECTOR holds its child in `plan` and DELIM JOIN holds `join`/`distinct_root`,
+ * both outside `children[]`; missing either under-counts scans and admits too few GPUs.
+ */
+void collect_gpu_scans(const op::sirius_physical_operator& node,
+                       std::vector<const op::sirius_physical_operator*>& out);
 
 /**
  * @brief Narrow an active-GPU list to the first @p cap entries.
@@ -36,6 +56,91 @@ inline std::vector<int> apply_gpu_cap(std::vector<int> gpu_ids, int cap)
     gpu_ids.resize(static_cast<std::size_t>(cap));
   }
   return gpu_ids;
+}
+
+/**
+ * @brief Estimated GPU bytes per row for a projected column list.
+ *
+ * Fixed-width types defer to logical_type::fixed_width_byte_size(), which already tracks the
+ * cuDF carrier each one lands in. Variable-width types have no static width and cost
+ * @p avg_var_bytes.
+ *
+ * Reads *logical* types, so it misses the narrower physical carriers compressed
+ * materialization can install, over-charging those columns and biasing admission upward.
+ */
+inline uint64_t estimate_bytes_per_row(const std::vector<sirius::logical_type>& types,
+                                       uint64_t avg_var_bytes)
+{
+  constexpr auto k_max = std::numeric_limits<uint64_t>::max();
+  uint64_t total       = 0;
+  for (const auto& t : types) {
+    auto const width = t.is_fixed_width() ? uint64_t{t.fixed_width_byte_size()} : avg_var_bytes;
+    // A wide enough avg_var_bytes wraps the row width to something small, which reads as a
+    // tiny query and admits it onto one GPU. Saturate, as the scan totals do.
+    if (total > k_max - width) { return k_max; }
+    total += width;
+  }
+  return total;
+}
+
+/**
+ * @brief Add `rows * bytes_per_row` to @p running, saturating instead of wrapping.
+ *
+ * estimated_cardinality is a planner estimate with no bound, and a wrapped total would read
+ * as a small query — admitting the largest onto one GPU. Saturate and let
+ * gpu_count_for_bytes clamp to the full fleet instead.
+ */
+inline uint64_t accumulate_scan_bytes(uint64_t running, uint64_t rows, uint64_t bytes_per_row)
+{
+  constexpr auto k_max = std::numeric_limits<uint64_t>::max();
+  if (rows == 0 || bytes_per_row == 0) { return running; }
+  if (rows > k_max / bytes_per_row) { return k_max; }
+  auto const scan_bytes = rows * bytes_per_row;
+  if (running > k_max - scan_bytes) { return k_max; }
+  return running + scan_bytes;
+}
+
+/// Row count and per-row width of one scan, read off the plan.
+struct scan_estimate {
+  uint64_t rows;
+  uint64_t bytes_per_row;
+};
+
+/**
+ * @brief Total projected scan-output bytes, or nullopt when the plan cannot be sized.
+ *
+ * Zero rows is ambiguous — provably empty, or simply unestimated — and the two want
+ * opposite treatments. Sirius already reads it as "cannot size" (sirius_physical_sort_sample
+ * gates on `estimated_cardinality > 0`), so follow that: one unsized scan, or no scans at
+ * all, makes the whole estimate unavailable and admission keeps the full capped fleet
+ * rather than sizing from partial information.
+ */
+inline std::optional<uint64_t> total_scan_bytes(const std::vector<scan_estimate>& scans)
+{
+  if (scans.empty()) { return std::nullopt; }
+  uint64_t total = 0;
+  for (auto const& s : scans) {
+    if (s.rows == 0) { return std::nullopt; }
+    total = accumulate_scan_bytes(total, s.rows, s.bytes_per_row);
+  }
+  return total;
+}
+
+/**
+ * @brief Smallest GPU count that keeps @p total_bytes under @p bytes_per_gpu per GPU.
+ *
+ * Result is clamped to [1, @p n_gpus]: a query always gets at least one GPU and never
+ * more than are available. Returns @p n_gpus when @p bytes_per_gpu is 0 (estimation
+ * disabled) or when @p total_bytes is 0 (nothing to size against).
+ */
+inline int gpu_count_for_bytes(uint64_t total_bytes, uint64_t bytes_per_gpu, int n_gpus)
+{
+  if (bytes_per_gpu == 0 || total_bytes == 0 || n_gpus <= 1) { return std::max(n_gpus, 1); }
+  // 1 + (x-1)/y rather than (x+y-1)/y: the latter wraps once x nears UINT64_MAX, and a
+  // wrapped quotient narrowed to int can go negative and clamp down to a single GPU —
+  // admitting the largest queries onto the least hardware. Clamp in 64-bit before narrowing.
+  auto const required = 1ULL + (total_bytes - 1) / bytes_per_gpu;
+  return static_cast<int>(std::min<uint64_t>(required, static_cast<uint64_t>(n_gpus)));
 }
 
 }  // namespace sirius::planner

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -166,6 +166,17 @@ struct operator_params {
   /// metadata; other scans use native carriers. Logical types remain unchanged, and type-sensitive
   /// boundaries restore native carriers.
   bool enable_compressed_materialization = true;
+
+  /// Admission-time GPU allocation: target bytes of projected scan output per GPU.
+  /// At query start, the engine estimates total scan output bytes from the plan's
+  /// estimated_cardinality × per-column width, then assigns
+  /// ceil(total_bytes / admission_bytes_per_gpu) GPUs, clamped to [1, active_gpu_count].
+  /// 0 disables dynamic estimation and falls back to topology.gpus_per_query.
+  uint64_t admission_bytes_per_gpu = 0;
+
+  /// Bytes assumed per variable-width column (VARCHAR, LIST, etc.) when computing
+  /// per-row byte estimates for admission. Only used when admission_bytes_per_gpu > 0.
+  uint64_t avg_variable_column_bytes = 32;
 };
 
 struct telemetry_config {

--- a/src/planner/gpu_admission.cpp
+++ b/src/planner/gpu_admission.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "planner/gpu_admission.hpp"
+
+#include "op/sirius_physical_delim_join.hpp"
+#include "op/sirius_physical_operator.hpp"
+#include "op/sirius_physical_operator_type.hpp"
+#include "op/sirius_physical_result_collector.hpp"
+
+namespace sirius::planner {
+
+void collect_gpu_scans(const op::sirius_physical_operator& node,
+                       std::vector<const op::sirius_physical_operator*>& out)
+{
+  if (node.type == op::SiriusPhysicalOperatorType::GPU_SCAN) { out.push_back(&node); }
+
+  for (auto& child : node.children) {
+    if (child) { collect_gpu_scans(*child, out); }
+  }
+
+  if (node.type == op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN ||
+      node.type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
+    auto& delim = node.Cast<op::sirius_physical_delim_join>();
+    if (delim.join) { collect_gpu_scans(*delim.join, out); }
+    if (delim.distinct_root) { collect_gpu_scans(*delim.distinct_root, out); }
+  }
+  if (node.type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
+    auto& rc = node.Cast<op::sirius_physical_result_collector>();
+    collect_gpu_scans(rc.plan, out);
+  }
+}
+
+}  // namespace sirius::planner

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -279,6 +279,15 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
     "dynamic_filter_keep_threshold", opt.dynamic_filter_keep_threshold, yaml::fraction<double>{});
   r.optional("enable_pinned_zone_map_pruning", opt.enable_pinned_zone_map_pruning);
   r.optional("enable_compressed_materialization", opt.enable_compressed_materialization);
+  // 0 is meaningful here: it turns the estimate off and leaves sizing to gpus_per_query.
+  r.optional("admission_bytes_per_gpu", yaml::bytes(opt.admission_bytes_per_gpu));
+  r.optional("avg_variable_column_bytes", yaml::bytes(opt.avg_variable_column_bytes));
+  // 0 is not meaningful here: variable-width columns would contribute nothing to the per-row
+  // width, so a mixed schema is under-estimated and the query admitted onto too few GPUs.
+  if (opt.avg_variable_column_bytes == 0) {
+    throw std::runtime_error(
+      "'operator_params.avg_variable_column_bytes': must be greater than zero");
+  }
   r.reject_unknown();
 }
 

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -53,6 +53,45 @@ namespace sirius {
 
 namespace {
 
+/// Select the GPU subset this query is admitted with: gpus_per_query caps the fleet, and
+/// within that cap a non-zero admission_bytes_per_gpu narrows further by estimated scan
+/// bytes. With neither set, every active GPU is used.
+std::vector<int> compute_admission_gpu_ids(const op::sirius_physical_operator& plan,
+                                           std::vector<int> gpu_ids,
+                                           const sirius_config& config)
+{
+  auto const& op_params = config.get_operator_params();
+  auto const bpg        = op_params.admission_bytes_per_gpu;
+
+  gpu_ids           = planner::apply_gpu_cap(std::move(gpu_ids), config.gpus_per_query());
+  auto const n_gpus = static_cast<int>(gpu_ids.size());
+  if (bpg == 0 || n_gpus <= 1) { return gpu_ids; }
+
+  std::vector<const op::sirius_physical_operator*> scans;
+  planner::collect_gpu_scans(plan, scans);
+  std::vector<planner::scan_estimate> estimates;
+  estimates.reserve(scans.size());
+  for (auto const* scan : scans) {
+    estimates.push_back(
+      {static_cast<uint64_t>(scan->estimated_cardinality),
+       planner::estimate_bytes_per_row(scan->types, op_params.avg_variable_column_bytes)});
+  }
+
+  // nullopt means at least one scan carried no usable row estimate; admit the full capped
+  // fleet rather than size the query from what is left.
+  auto const total_bytes = planner::total_scan_bytes(estimates);
+  if (!total_bytes.has_value()) { return gpu_ids; }
+
+  auto const k = planner::gpu_count_for_bytes(*total_bytes, bpg, n_gpus);
+  SIRIUS_LOG_INFO("[gpu_alloc] estimated {} MiB over {} scan(s) -> {} of {} GPU(s)",
+                  *total_bytes / (1024 * 1024),
+                  scans.size(),
+                  k,
+                  n_gpus);
+  gpu_ids.resize(static_cast<size_t>(k));
+  return gpu_ids;
+}
+
 std::shared_ptr<const telemetry::telemetry_context> get_telemetry_context_from_client_context(
   duckdb::ClientContext& context)
 {
@@ -218,7 +257,7 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
   // matters: task_creator holds it, and create_query later reads it back for scan_manager.
   auto const full_gpu_count = gpu_ids.size();
   std::vector<int> active_gpu_ids =
-    planner::apply_gpu_cap(std::move(gpu_ids), sirius_ctx_ptr->get_config().gpus_per_query());
+    compute_admission_gpu_ids(plan, std::move(gpu_ids), sirius_ctx_ptr->get_config());
   sirius_ctx_ptr->get_task_creator().set_active_gpu_ids(active_gpu_ids, full_gpu_count);
   try {
     std::string gpu_list;

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2128,6 +2128,30 @@ static void SetEnablePinnedZoneMapPruning(ClientContext& context, SetScope scope
                    params->enable_pinned_zone_map_pruning);
 }
 
+static void SetAdmissionBytesPerGpu(ClientContext& context, SetScope scope, Value& parameter)
+{
+  auto const bytes = UBigIntValue::Get(parameter);
+  auto* params     = get_operator_params(context);
+  if (!params) { return; }
+  auto slot                       = lock_operator_params_slot(context);
+  params->admission_bytes_per_gpu = bytes;
+  SIRIUS_LOG_DEBUG("Updated config ADMISSION_BYTES_PER_GPU to {}", params->admission_bytes_per_gpu);
+}
+
+static void SetAvgVariableColumnBytes(ClientContext& context, SetScope scope, Value& parameter)
+{
+  auto const bytes = UBigIntValue::Get(parameter);
+  if (bytes == 0) {
+    throw InvalidInputException("avg_variable_column_bytes must be greater than zero");
+  }
+  auto* params = get_operator_params(context);
+  if (!params) { return; }
+  auto slot                         = lock_operator_params_slot(context);
+  params->avg_variable_column_bytes = bytes;
+  SIRIUS_LOG_DEBUG("Updated config AVG_VARIABLE_COLUMN_BYTES to {}",
+                   params->avg_variable_column_bytes);
+}
+
 static void SetEnableCompressedMaterialization(ClientContext& /*context*/,
                                                SetScope /*scope*/,
                                                Value& /*parameter*/)
@@ -2447,6 +2471,22 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     LogicalType::BOOLEAN,
     Value::BOOLEAN(operator_defaults.enable_compressed_materialization),
     SetEnableCompressedMaterialization);
+
+  config.AddExtensionOption(
+    "admission_bytes_per_gpu",
+    "Target projected scan-output bytes per GPU at admission; 0 disables the estimate and "
+    "leaves the allocation to topology.gpus_per_query",
+    LogicalType::UBIGINT,
+    Value::UBIGINT(operator_defaults.admission_bytes_per_gpu),
+    SetAdmissionBytesPerGpu);
+
+  config.AddExtensionOption(
+    "avg_variable_column_bytes",
+    "Per-row width assumed for variable-width columns (VARCHAR, LIST, STRUCT, ARRAY) when "
+    "estimating scan output at admission; must be greater than zero",
+    LogicalType::UBIGINT,
+    Value::UBIGINT(operator_defaults.avg_variable_column_bytes),
+    SetAvgVariableColumnBytes);
 }
 
 // Publish the transparent optimizer mask once at extension load, unioned

--- a/test/cpp/config/test_topology_config.cpp
+++ b/test/cpp/config/test_topology_config.cpp
@@ -95,3 +95,31 @@ TEST_CASE("sirius_config rejects a negative gpus_per_query", "[topology_config][
   sirius::sirius_config cfg;
   CHECK_THROWS(cfg.load_from_file(yaml.path));
 }
+
+TEST_CASE("sirius_config rejects a zero avg_variable_column_bytes", "[topology_config][config]")
+{
+  // Zero would make variable-width columns contribute nothing to the per-row width, so a
+  // mixed schema is under-estimated and the query admitted onto too few GPUs. Unlike
+  // admission_bytes_per_gpu, where 0 is the documented off switch, there is no reading of
+  // zero here that means anything.
+  scoped_yaml yaml("sirius_avg_var_zero.yaml",
+                   "sirius:\n"
+                   "  operator_params:\n"
+                   "    avg_variable_column_bytes: 0\n");
+
+  sirius::sirius_config cfg;
+  CHECK_THROWS(cfg.load_from_file(yaml.path));
+}
+
+TEST_CASE("sirius_config accepts a zero admission_bytes_per_gpu", "[topology_config][config]")
+{
+  // 0 is the off switch: it disables the estimate and leaves sizing to gpus_per_query.
+  scoped_yaml yaml("sirius_admission_bytes_zero.yaml",
+                   "sirius:\n"
+                   "  operator_params:\n"
+                   "    admission_bytes_per_gpu: 0\n");
+
+  sirius::sirius_config cfg;
+  REQUIRE_NOTHROW(cfg.load_from_file(yaml.path));
+  CHECK(cfg.get_operator_params().admission_bytes_per_gpu == 0);
+}

--- a/test/cpp/planner/test_gpu_admission.cpp
+++ b/test/cpp/planner/test_gpu_admission.cpp
@@ -17,9 +17,22 @@
 #include "catch.hpp"
 #include "planner/gpu_admission.hpp"
 
+#include <cstdint>
+#include <limits>
 #include <vector>
 
+using sirius::logical_type;
+using sirius::type_id;
+using sirius::planner::accumulate_scan_bytes;
 using sirius::planner::apply_gpu_cap;
+using sirius::planner::estimate_bytes_per_row;
+using sirius::planner::gpu_count_for_bytes;
+using sirius::planner::scan_estimate;
+using sirius::planner::total_scan_bytes;
+
+namespace {
+constexpr uint64_t k_avg_var = 32;
+}
 
 TEST_CASE("apply_gpu_cap with no cap admits every GPU", "[gpu_admission]")
 {
@@ -65,4 +78,196 @@ TEST_CASE("apply_gpu_cap treats a negative cap as no cap", "[gpu_admission]")
 TEST_CASE("apply_gpu_cap on an empty fleet stays empty", "[gpu_admission]")
 {
   REQUIRE(apply_gpu_cap({}, 2).empty());
+}
+
+TEST_CASE("estimate_bytes_per_row sums fixed-width carrier widths", "[admission_estimator]")
+{
+  // 1 + 2 + 4 + 8 = 15
+  const std::vector<logical_type> types{logical_type::make(type_id::TINYINT),
+                                        logical_type::make(type_id::SMALLINT),
+                                        logical_type::make(type_id::INTEGER),
+                                        logical_type::make(type_id::BIGINT)};
+  REQUIRE(estimate_bytes_per_row(types, k_avg_var) == 15);
+}
+
+TEST_CASE("estimate_bytes_per_row charges 128-bit integers their cuDF carrier width",
+          "[admission_estimator]")
+{
+  // get_cudf_type has no 128-bit integer carrier and narrows both to a 64-bit one,
+  // so they cost 8 bytes on device rather than their DuckDB width of 16.
+  REQUIRE(estimate_bytes_per_row({logical_type::make(type_id::HUGEINT)}, k_avg_var) == 8);
+  REQUIRE(estimate_bytes_per_row({logical_type::make(type_id::UHUGEINT)}, k_avg_var) == 8);
+}
+
+TEST_CASE("estimate_bytes_per_row treats unsigned types as their signed width",
+          "[admission_estimator]")
+{
+  const std::vector<logical_type> signed_types{logical_type::make(type_id::TINYINT),
+                                               logical_type::make(type_id::SMALLINT),
+                                               logical_type::make(type_id::INTEGER),
+                                               logical_type::make(type_id::BIGINT)};
+  const std::vector<logical_type> unsigned_types{logical_type::make(type_id::UTINYINT),
+                                                 logical_type::make(type_id::USMALLINT),
+                                                 logical_type::make(type_id::UINTEGER),
+                                                 logical_type::make(type_id::UBIGINT)};
+  REQUIRE(estimate_bytes_per_row(signed_types, k_avg_var) ==
+          estimate_bytes_per_row(unsigned_types, k_avg_var));
+}
+
+TEST_CASE("estimate_bytes_per_row sizes DECIMAL from its precision", "[admission_estimator]")
+{
+  // Precision selects the cuDF carrier: DECIMAL32/64/128. There is no DECIMAL16, so the
+  // narrowest precisions still cost 4 bytes.
+  REQUIRE(estimate_bytes_per_row({logical_type::make_decimal(4, 2)}, k_avg_var) == 4);
+  REQUIRE(estimate_bytes_per_row({logical_type::make_decimal(9, 2)}, k_avg_var) == 4);
+  REQUIRE(estimate_bytes_per_row({logical_type::make_decimal(18, 2)}, k_avg_var) == 8);
+  REQUIRE(estimate_bytes_per_row({logical_type::make_decimal(38, 2)}, k_avg_var) == 16);
+}
+
+TEST_CASE("estimate_bytes_per_row charges variable-width columns the configured average",
+          "[admission_estimator]")
+{
+  const std::vector<logical_type> types{logical_type::make(type_id::VARCHAR),
+                                        logical_type::make(type_id::LIST)};
+  REQUIRE(estimate_bytes_per_row(types, k_avg_var) == 2 * k_avg_var);
+  // The fallback is configurable, so the same schema scales with it.
+  REQUIRE(estimate_bytes_per_row(types, 8) == 16);
+}
+
+TEST_CASE("estimate_bytes_per_row mixes fixed and variable widths", "[admission_estimator]")
+{
+  // BIGINT(8) + VARCHAR(32) + DATE(4) = 44
+  const std::vector<logical_type> types{logical_type::make(type_id::BIGINT),
+                                        logical_type::make(type_id::VARCHAR),
+                                        logical_type::make(type_id::DATE)};
+  REQUIRE(estimate_bytes_per_row(types, k_avg_var) == 44);
+}
+
+TEST_CASE("estimate_bytes_per_row returns zero for an empty projection", "[admission_estimator]")
+{
+  REQUIRE(estimate_bytes_per_row({}, k_avg_var) == 0);
+}
+
+TEST_CASE("gpu_count_for_bytes rounds up to cover the total", "[admission_estimator]")
+{
+  constexpr uint64_t per_gpu = 100;
+  REQUIRE(gpu_count_for_bytes(100, per_gpu, 4) == 1);  // exactly one GPU's worth
+  REQUIRE(gpu_count_for_bytes(101, per_gpu, 4) == 2);  // one byte over spills to a second
+  REQUIRE(gpu_count_for_bytes(250, per_gpu, 4) == 3);
+  REQUIRE(gpu_count_for_bytes(400, per_gpu, 4) == 4);
+}
+
+TEST_CASE("gpu_count_for_bytes clamps to the available GPUs", "[admission_estimator]")
+{
+  // A query far larger than the fleet still only gets what exists.
+  REQUIRE(gpu_count_for_bytes(1'000'000, 100, 4) == 4);
+}
+
+TEST_CASE("gpu_count_for_bytes always admits at least one GPU", "[admission_estimator]")
+{
+  REQUIRE(gpu_count_for_bytes(1, 1'000'000, 4) == 1);
+}
+
+TEST_CASE("gpu_count_for_bytes falls back to the full fleet when disabled", "[admission_estimator]")
+{
+  // bytes_per_gpu == 0 means estimation is off.
+  REQUIRE(gpu_count_for_bytes(500, 0, 4) == 4);
+  // Nothing to size against.
+  REQUIRE(gpu_count_for_bytes(0, 100, 4) == 4);
+}
+
+TEST_CASE("gpu_count_for_bytes is a no-op on a single-GPU host", "[admission_estimator]")
+{
+  REQUIRE(gpu_count_for_bytes(1'000'000, 100, 1) == 1);
+}
+
+TEST_CASE("gpu_count_for_bytes survives a total near the 64-bit ceiling", "[admission_estimator]")
+{
+  // (total + per_gpu - 1) would wrap here, and a wrapped quotient narrowed to int can go
+  // negative — clamping the largest possible query down to a single GPU.
+  constexpr auto k_max = std::numeric_limits<uint64_t>::max();
+  REQUIRE(gpu_count_for_bytes(k_max, 1, 8) == 8);
+  REQUIRE(gpu_count_for_bytes(k_max, 1024, 4) == 4);
+  REQUIRE(gpu_count_for_bytes(k_max - 1, 2, 2) == 2);
+}
+
+TEST_CASE("gpu_count_for_bytes clamps a quotient wider than int", "[admission_estimator]")
+{
+  // required is ~1.8e19, far past INT_MAX; the clamp must happen in 64-bit.
+  REQUIRE(gpu_count_for_bytes(std::numeric_limits<uint64_t>::max(), 1, 3) == 3);
+}
+
+TEST_CASE("accumulate_scan_bytes sums the ordinary case", "[admission_estimator]")
+{
+  REQUIRE(accumulate_scan_bytes(0, 100, 8) == 800);
+  REQUIRE(accumulate_scan_bytes(800, 50, 4) == 1000);
+}
+
+TEST_CASE("accumulate_scan_bytes ignores empty contributions", "[admission_estimator]")
+{
+  REQUIRE(accumulate_scan_bytes(500, 0, 8) == 500);
+  REQUIRE(accumulate_scan_bytes(500, 100, 0) == 500);
+}
+
+TEST_CASE("accumulate_scan_bytes saturates instead of wrapping", "[admission_estimator]")
+{
+  constexpr auto k_max = std::numeric_limits<uint64_t>::max();
+  // A bogus cardinality must not wrap the total into a small number, which would read as a
+  // tiny query and admit it onto one GPU.
+  REQUIRE(accumulate_scan_bytes(0, k_max, 64) == k_max);
+  REQUIRE(accumulate_scan_bytes(k_max - 10, 100, 8) == k_max);
+  // Saturated totals still resolve to the full fleet downstream.
+  REQUIRE(gpu_count_for_bytes(accumulate_scan_bytes(0, k_max, 64), 1024, 4) == 4);
+}
+
+TEST_CASE("total_scan_bytes sums sized scans", "[admission_estimator]")
+{
+  const std::vector<scan_estimate> scans{{100, 8}, {50, 4}};
+  auto const total = total_scan_bytes(scans);
+  REQUIRE(total.has_value());
+  CHECK(*total == 1000);
+}
+
+TEST_CASE("total_scan_bytes reports unsized when any scan has no row estimate",
+          "[admission_estimator]")
+{
+  // Zero is ambiguous — provably empty, or simply unestimated — and Sirius reads it as
+  // "cannot size" (sirius_physical_sort_sample gates on estimated_cardinality > 0). One
+  // unsized scan makes the whole plan unsized, so a large query is never admitted onto a
+  // small subset off the back of the scans that happened to carry estimates.
+  CHECK_FALSE(total_scan_bytes({{0, 8}}).has_value());
+  CHECK_FALSE(total_scan_bytes({{1'000'000, 8}, {0, 4}}).has_value());
+  CHECK_FALSE(total_scan_bytes({{0, 4}, {1'000'000, 8}}).has_value());
+}
+
+TEST_CASE("total_scan_bytes reports unsized for a plan with no scans", "[admission_estimator]")
+{
+  CHECK_FALSE(total_scan_bytes({}).has_value());
+}
+
+TEST_CASE("total_scan_bytes saturates rather than wrapping", "[admission_estimator]")
+{
+  constexpr auto k_max = std::numeric_limits<uint64_t>::max();
+  auto const total     = total_scan_bytes({{k_max, 64}, {10, 8}});
+  REQUIRE(total.has_value());
+  CHECK(*total == k_max);
+}
+
+TEST_CASE("estimate_bytes_per_row saturates instead of wrapping", "[admission_estimator]")
+{
+  constexpr auto k_max = std::numeric_limits<uint64_t>::max();
+  const std::vector<logical_type> two_var{logical_type::make(type_id::VARCHAR),
+                                          logical_type::make(type_id::VARCHAR)};
+
+  // Two columns at 2^63+1 sum to 2^64+2, wrapping the row width to 2.
+  CHECK(estimate_bytes_per_row(two_var, (k_max / 2) + 2) == k_max);
+
+  const std::vector<logical_type> mixed{logical_type::make(type_id::BIGINT),
+                                        logical_type::make(type_id::VARCHAR)};
+  CHECK(estimate_bytes_per_row(mixed, k_max) == k_max);
+
+  // A saturated width still resolves to the full fleet downstream, not to one GPU.
+  auto const total = total_scan_bytes({{1000, k_max}});
+  REQUIRE(total.has_value());
+  CHECK(gpu_count_for_bytes(*total, 1024, 4) == 4);
 }

--- a/test/cpp/planner/test_plan_tree_shape.cpp
+++ b/test/cpp/planner/test_plan_tree_shape.cpp
@@ -37,6 +37,7 @@
 #include "op/sirius_physical_nested_loop_join.hpp"
 #include "op/sirius_physical_partition.hpp"
 #include "op/sirius_physical_projection.hpp"
+#include "planner/gpu_admission.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
 #include <cudf/types.hpp>
@@ -913,4 +914,53 @@ TEST_CASE_METHOD(plan_tree_shape_fixture,
   sirius::planner::sirius_physical_plan_generator generator(*con->context);
   CHECK_THROWS_WITH(generator.create_plan(std::move(logical)),
                     Catch::Contains("Unsupported filter predicate on column 'id'"));
+}
+
+TEST_CASE_METHOD(plan_tree_shape_fixture,
+                 "plan tree shape - admission scan walk reaches delim join subtrees",
+                 "[plan_tree_shape][gpu_admission][isolated_context]")
+{
+  // GPU admission sizes a query from its scans' estimated_cardinality, so a scan it cannot
+  // see is a scan whose bytes are not counted — under-estimating the query and admitting it
+  // onto too few GPUs. DELIM JOIN owns `join`/`distinct_root` outside `children[]`, so a walk
+  // over `children` alone misses everything inside them.
+  //
+  // Cross-check planner::collect_gpu_scans against this suite's independently written
+  // for_each_operator: the two descend the tree separately and must agree.
+  auto plan = generate_sirius_plan(
+    *con,
+    "SELECT SUM(i.qty) FROM items i, parts p WHERE p.pk = i.fk AND p.pname = 'p1' "
+    "AND i.qty < (SELECT 2 * AVG(i2.qty) FROM items i2 WHERE i2.fk = p.pk)");
+  INFO(tree_to_string(plan.get()));
+
+  REQUIRE(find_first(plan.get(), SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) != nullptr);
+
+  auto const expected = collect(plan.get(), SiriusPhysicalOperatorType::GPU_SCAN);
+  REQUIRE_FALSE(expected.empty());
+
+  std::vector<const sirius_physical_operator*> found;
+  sirius::planner::collect_gpu_scans(*plan, found);
+
+  CHECK(found.size() == expected.size());
+  for (auto const* op : expected) {
+    CHECK(std::find(found.begin(), found.end(), op) != found.end());
+  }
+}
+
+TEST_CASE_METHOD(plan_tree_shape_fixture,
+                 "plan tree shape - admission scan walk agrees on a plain join",
+                 "[plan_tree_shape][gpu_admission][isolated_context]")
+{
+  // Baseline: with no operator holding subtrees outside children[], both walks agree
+  // trivially. Guards against a descent that double-counts.
+  auto plan =
+    generate_sirius_plan(*con, "SELECT b.val FROM big_left b, small_right s WHERE b.id = s.rid");
+  INFO(tree_to_string(plan.get()));
+
+  auto const expected = collect(plan.get(), SiriusPhysicalOperatorType::GPU_SCAN);
+  REQUIRE(expected.size() == 2);
+
+  std::vector<const sirius_physical_operator*> found;
+  sirius::planner::collect_gpu_scans(*plan, found);
+  CHECK(found.size() == expected.size());
 }


### PR DESCRIPTION
## Summary

Replaces the fixed `gpus_per_query` count with an estimate derived from the query's own plan. Before any pipelines are built, the engine walks the physical plan for scan operators and sizes the allocation from their projected output.

Default behavior (`admission_bytes_per_gpu = 0`) is unchanged.

## What changed

- **Plan walk** — `collect_gpu_scans` mirrors `sirius_physical_plan_generator::set_parent_ops`, the canonical full-tree descent. Two operators keep subtrees outside `children[]`: `RESULT_COLLECTOR` (the engine-injected root) holds its child in `plan`, and `DELIM JOIN` holds `join` and `distinct_root`. `get_children()` is not sufficient — only the collector overrides it — so a walk built on it silently misses every scan inside a delim join, under-counting bytes and admitting the query onto too few GPUs. It lives in `src/planner/gpu_admission.cpp` so the header needs only a forward declaration rather than four operator headers.
- **Estimate** — total bytes = sum over scans of `estimated_cardinality × per-row width`. GPU count = `ceil(total / admission_bytes_per_gpu)`, clamped to `[1, active_gpus]`.
- **Column widths** — fixed-width types defer to `logical_type::fixed_width_byte_size()`, which already tracks the cuDF carrier each one lands in: DECIMAL follows its precision to DECIMAL32/64/128, and `HUGEINT`/`UHUGEINT` cost 8 bytes rather than 16 since cuDF has no 128-bit integer and narrows both to INT64/UINT64. Variable-width types have no static width and cost `avg_variable_column_bytes`.
- **Unsized scans** — a scan reporting zero rows is ambiguous: provably empty, or simply unestimated. Sirius already reads zero as "cannot size" (`sirius_physical_sort_sample` gates on `estimated_cardinality > 0`), so one unsized scan makes the whole estimate unavailable and admission keeps the full capped fleet, rather than sizing a possibly-large query off whichever scans happened to carry numbers. `avg_variable_column_bytes` is likewise rejected at zero, which would zero out every variable-width column.
- **Overflow** — `estimated_cardinality` is an unbounded planner estimate, so the per-scan sum saturates rather than wrapping, and the GPU count uses `1 + (total-1)/per_gpu` clamped in 64-bit before narrowing. Both guard the same failure: a wrapped total reads as a *small* query, which would admit the largest possible query onto one GPU.
- **Composition** — `topology.gpus_per_query` still applies and bounds the estimate, so the two compose as `min(estimated, cap)`.

## Config

Under `operator_params`:

```yaml
admission_bytes_per_gpu: 0      # 0 disables estimation
avg_variable_column_bytes: 32   # fallback width for VARCHAR/LIST/...
```

Both are also registered as DuckDB `SET` variables and take effect from the next query, since admission runs per query. `topology.gpus_per_query` stays YAML-only — it is read when the GPU memory spaces are configured, so a `SET` would silently not apply.

## What this knob is (and isn't)

`admission_bytes_per_gpu` is a parallelism dial, not a memory budget. Measured on 4×GB200 against TPC-H SF500, per-GPU peak memory was unchanged between a 3-GPU and a 4-GPU admission (~163–170 GiB either way, within the inter-GPU spread of a single run), because peak is bounded by partition sizing rather than by data volume divided across devices. Fewer GPUs means each processes more partitions sequentially, so the cost shows up as wall-clock: 23.16 s on 3 GPUs against 21.96 s on 4. Tune it against how much of the fleet a query should occupy, not against VRAM.

## Tests

The width calculation, the GPU-count arithmetic (including both overflow paths) and the unsized-scan rule live in `planner/gpu_admission.hpp` as pure functions, free of operator types so they can be exercised directly — 21 new cases. Two more cover the config path: `avg_variable_column_bytes` rejected at zero, `admission_bytes_per_gpu` accepted at zero as the off switch.

The plan walk is cross-checked against `test_plan_tree_shape`'s own independently written tree visitor, over a real `RIGHT_DELIM_JOIN` plan generated from SQL: both descents must find the same scans. Two separately authored walks agreeing is a stronger property than a hard-coded count, and it is the check that catches a missed subtree.

## Verification

- Full C++ suite green.
- On TPC-H SF500 Q9: estimates 129534 MiB over 6 scans and admits onto 3 of 4 GPUs, with results identical to the all-GPU run. With `gpus_per_query: 2` set alongside, the cap binds and the query admits onto 2.

## What this does NOT do

The estimate is static — it uses DuckDB's pre-execution cardinalities, not runtime measurements. It also reads *logical* types, so it misses the narrower physical carriers compressed materialization can install, over-charging those columns and biasing admission slightly upward.

Dynamic tapering (releasing GPUs mid-query as joins reduce volume) is future work and would build on the runtime estimator from the data-size-estimation branch.
