### PR TITLE
ci: update ``run-on-pr`` CI job exclusion logic

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -112,7 +112,7 @@ jobs:
         exclude:
           # On PRs, drop rows marked merge/dev-only; on merge_group/dev, match nothing.
           - build:
-              run-on-pr: ${{ fromJSON(github.event_name == 'pull_request' && 'false' || 'null') }}
+              run-on-pr: ${{ case(github.event_name == 'pull_request', false, 'no-match') }}
       fail-fast: false
     name: build (${{ matrix.build.arch }}, ${{ matrix.build.compiler }}, ${{ matrix.build.build-type }}, ${{ matrix.build.environment }}, ${{ matrix.build.cudf-channel }})
     runs-on: >-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
         exclude:
           # On PRs, drop CUDA variants marked merge/dev-only; on merge_group/dev, match nothing.
           - cuda:
-              run-on-pr: ${{ fromJSON(github.event_name == 'pull_request' && 'false' || 'null') }}
+              run-on-pr: ${{ case(github.event_name == 'pull_request', false, 'no-match') }}
       fail-fast: false
     runs-on: ${{ fromJSON(format('["self-hosted", "{0}", "cpu-xl"]', matrix.cuda.runner)) }}
     timeout-minutes: 60
@@ -118,7 +118,7 @@ jobs:
         exclude:
           # On PRs, drop CUDA variants marked merge/dev-only; on merge_group/dev, match nothing.
           - cuda:
-              run-on-pr: ${{ fromJSON(github.event_name == 'pull_request' && 'false' || 'null') }}
+              run-on-pr: ${{ case(github.event_name == 'pull_request', false, 'no-match') }}
       fail-fast: false
     runs-on: ${{ fromJSON(format('["self-hosted", "{0}", "gpu-2xt4"]', matrix.cuda.runner)) }}
     timeout-minutes: 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           cache: false
           pixi-version: v0.71.1
+          environments: ${{ matrix.cuda.pixi-environment }}
           activate-environment: ${{ matrix.cuda.pixi-environment }}
 
       - name: Configure sccache backend
@@ -132,6 +133,7 @@ jobs:
         with:
           cache: false
           pixi-version: v0.71.1
+          environments: ${{ matrix.cuda.pixi-environment }}
           activate-environment: ${{ matrix.cuda.pixi-environment }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/src/compression/simpatico_codegen/CMakeLists.txt
+++ b/src/compression/simpatico_codegen/CMakeLists.txt
@@ -44,7 +44,11 @@ elseif(CONDA_PREFIX)
       CACHE FILEPATH "nvcc from prefix")
   set(CUDA_TOOLKIT_INCLUDE
       "${CONDA_PREFIX}/targets/${CUDA_TARGET_TRIPLE}/include")
-  set(CUDA_CCCL_INCLUDE "${CUDA_TOOLKIT_INCLUDE}/cccl")
+  if(EXISTS "${CUDA_TOOLKIT_INCLUDE}/cccl")
+    set(CUDA_CCCL_INCLUDE "${CUDA_TOOLKIT_INCLUDE}/cccl")
+  else()
+    set(CUDA_CCCL_INCLUDE "${CUDA_TOOLKIT_INCLUDE}")
+  endif()
   set(_SIMPATICO_INCLUDE_DIRS
       "${CONDA_PREFIX}/include" "${CONDA_PREFIX}/include/rapids"
       "${CUDA_TOOLKIT_INCLUDE}")

--- a/src/compression/simpatico_codegen/README.md
+++ b/src/compression/simpatico_codegen/README.md
@@ -10,7 +10,7 @@ nvcomp-Cascaded, bitcomp, ANS, bitextract/bitjoin — specified via a human-read
 
 - NVIDIA GPU (Turing or newer)
 - [pixi](https://prefix.dev/) (or conda)
-- CUDA 13.x driver
+- CUDA 12.9 or CUDA 13.x
 
 ## Quick start
 
@@ -191,9 +191,10 @@ headers (`nvrtcCreateProgram`):
 
 - the two project headers (`codegen/decode/rle_block.cuh`, `codegen/stdint_shim.hpp`), embedded
   by `cmake/embed_jit_headers.cmake`;
-- the CCCL closure (`<cuda/std/...>`, `<cub/...>`) — the transitive `#include` set reachable from
-  the kernel preludes, scanned at build time and embedded by `cmake/embed_cccl_headers.cmake`
-  (so it tracks the CCCL version the extension is built against).
+- the CCCL closure (`<cuda/std/...>`, `<cub/...>`, and `<thrust/...>`) — the transitive
+  `#include` set reachable from the kernel preludes, scanned at build time and embedded by
+  `cmake/embed_cccl_headers.cmake` (so it tracks the CCCL version the extension is built
+  against).
 
 As a result the runtime JIT needs **no CCCL/CUDA headers on disk** — only the driver and the
 `libnvrtc` runtime (which the Sirius vcpkg build links statically via the `nvrtc` overlay port).

--- a/src/compression/simpatico_codegen/cmake/embed_cccl_headers.cmake
+++ b/src/compression/simpatico_codegen/cmake/embed_cccl_headers.cmake
@@ -5,12 +5,13 @@
 # -I into a CCCL tree, so a binary distribution needs only the driver + the
 # nvrtc runtime it already links. Invoked via `cmake -P`.
 #
-# Inputs (-D): CCCL_DIR  the build-time CCCL include root (contains cuda/ and
-# cub/) OUT       path of the .cpp to generate
+# Inputs (-D): CCCL_DIR  the build-time CCCL include root (contains cuda/, cub/,
+# and thrust/) OUT       path of the .cpp to generate
 #
-# The scan follows every `#include` line (both #ifdef branches) from the fixed
-# kernel-prelude roots below, so it is a safe SUPERSET of what NVRTC actually
-# reads. Recomputed at build time, so it tracks the CCCL version in use.
+# The scan follows every literal `#include` line (both #ifdef branches) from the
+# fixed kernel-prelude roots below. Dependencies reached through macro-expanded
+# includes must be seeded explicitly. Recomputed at build time, so it tracks the
+# CCCL version in use.
 
 cmake_minimum_required(VERSION 3.24)
 
@@ -19,7 +20,9 @@ if(NOT IS_DIRECTORY "${CCCL_DIR}")
     FATAL_ERROR "embed_cccl_headers: CCCL_DIR '${CCCL_DIR}' is not a directory")
 endif()
 
-# Union of the includes emitted by the encode + decode kernel preludes.
+# Union of the includes emitted by the encode + decode kernel preludes. CUDA 12
+# reaches execution_policy.h through a macro-expanded include, which the
+# literal-include scanner cannot discover, so seed it explicitly.
 set(roots
     cub/block/block_reduce.cuh
     cub/block/block_scan.cuh
@@ -27,7 +30,9 @@ set(roots
     cuda/std/cstdint
     cuda/std/cstddef
     cuda/std/climits
-    cuda/std/type_traits)
+    cuda/std/type_traits
+    thrust/system/cpp/detail/execution_policy.h
+    thrust/system/cuda/detail/execution_policy.h)
 
 set(worklist ${roots})
 set(found "")


### PR DESCRIPTION
While working on https://github.com/sirius-db/sirius/pull/1443, I noticed there's actually CI coverage for cuda 12 pixi builds but it's excluded on PRs with 

https://github.com/sirius-db/sirius/blob/e9f30e427f3ee76ae77fb4bc1471f87fd04fc1dd/.github/workflows/test.yml#L47

and this GHA `exclude:`

https://github.com/sirius-db/sirius/blob/e9f30e427f3ee76ae77fb4bc1471f87fd04fc1dd/.github/workflows/test.yml#L48-L51

meant to make it so it's not run on PRs but is run otherwise (like on the `dev` branch).

This (and other places with the same logic like `check.yml`) end up getting unintentionally skipped on non-PRs because GHA uses loose equality, where false and null both coerce to 0, so rows marked `run-on-pr: false` end up get excluded by accident. 

This PR updates things to use `'no-match'` instead of `'null'` as the fallback value instead. Unrelated, I also switched to using the `case()` function https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#case, which has the same result as the existing logic but IMO is easy to reason about (happy to stick with the existing logic if folks prefer). 