### PR TITLE
perf(join): runtime distinct-build probe for BUILD_PROBE hash joins

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -375,6 +375,7 @@ batch default**. Each can still be overridden individually.
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join. A build below this size is replicated to every GPU (instead of hash-partitioned) when it is tiny, or when the DuckDB-estimated probe-to-build row ratio is at least `num_gpus * 1.25`. |
 | `max_sort_partition_memory_fraction` | 0.33 | Fraction of GPU memory per sort partition when `max_sort_partition_bytes` is 0 |
 | `mark_join_build_switch_ratio` | 8.0 | For STANDARD MARK joins, build on the smaller (left) side when `right_rows >= ratio * left_rows` (0 disables) |
+| `enable_runtime_distinct_build_probe` | true | For `BUILD_PROBE` INNER/LEFT equality joins whose build-key uniqueness the planner could not prove, test distinctness at runtime (one `cudf::distinct_count` pass over the cached build, dimension-scale builds only) and take the single-pass `cudf::distinct_hash_join` instead of the general two-pass join when the keys are distinct. |
 | `enable_dynamic_filter_pushdown` | true | Master switch for dynamic table-filter pushdown. An eligible `BUILD_PROBE` hash-join build selects a raw exact IN-list for 1–12 supported build rows, otherwise a hash IN-list if it fits the smallest probe-GPU L2 or a Bloom, for post-decode application by the probe scan. |
 | `enable_dynamic_zone_map_filter` | false | Additionally publish build-key min/max bounds. Parquet scans use them for read-time row-group pruning; duckdb-native scans apply them row-wise post-decode. Requires `enable_dynamic_filter_pushdown`; intended for clustered-keyset workloads. |
 | `dynamic_filter_domain_coverage_threshold` | 0.9 | Skip publishing a key's dynamic filters when the build covers at least this fraction of the key's domain; ≥ 1.0 effectively disables the gate. |
@@ -566,6 +567,7 @@ SET enable_compressed_materialization = false;
 | `max_build_hash_table_bytes` | 2× batch default | Max build-side hash table bytes |
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join |
 | `mark_join_build_switch_ratio` | 8.0 | STANDARD MARK join build-side switch ratio (0 disables) |
+| `enable_runtime_distinct_build_probe` | true | Runtime distinct-build test for `BUILD_PROBE` joins; promotes to the single-pass `cudf::distinct_hash_join` when the build keys prove distinct |
 
 ### Dynamic Filters
 

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -288,6 +288,13 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
 
   mutable bool unique_probe_keys = false;
 
+  //! When the planner could not *prove* build-key uniqueness, test it at runtime instead (one hash
+  //! pass over the build keys) and, if the keys are in fact distinct, take the single-pass
+  //! cudf::distinct_hash_join path rather than the general two-pass multiset path. Proving
+  //! uniqueness statically needs a declared PRIMARY KEY on a catalog table. Set from
+  //! operator_params at planning time.
+  bool runtime_distinct_build_probe = config::DEFAULT_ENABLE_RUNTIME_DISTINCT_BUILD_PROBE;
+
   //! Row-count ratio gate for switching STANDARD-mode MARK joins to cudf::mark_join (build on the
   //! left/output side) instead of filtered_join (build on the right side). Switch when
   //! right_rows >= ratio * left_rows; 0 disables. Set from operator_params at planning time.

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -72,6 +72,15 @@ constexpr double DEFAULT_MAX_SORT_PARTITION_MEMORY_FRACTION = 0.33;
 /// disable (always use filtered_join).
 constexpr double DEFAULT_MARK_JOIN_BUILD_SWITCH_RATIO = 8.0;
 
+/// Test build-key uniqueness at runtime when the planner could not prove it statically.
+///
+/// cudf's general hash join probes twice — a count pass to size the output, then a retrieve pass —
+/// while cudf::distinct_hash_join probes once, because a distinct build bounds the output by the
+/// probe row count. Sirius already implements both, but the distinct path is gated on a *proof* of
+/// uniqueness, which only a declared PRIMARY KEY on a catalog table can supply. The runtime test is
+/// one cudf::distinct_count pass over the build keys, taken only in BUILD_PROBE mode.
+constexpr bool DEFAULT_ENABLE_RUNTIME_DISTINCT_BUILD_PROBE = true;
+
 }  // namespace config
 
 /// Parameters controlling operator-level resource sizing.
@@ -113,6 +122,13 @@ struct operator_params {
   /// L4 in the issue #510 microbenchmark, defaulted higher to stay conservative). Set to 0 to
   /// disable (always use filtered_join).
   double mark_join_build_switch_ratio = config::DEFAULT_MARK_JOIN_BUILD_SWITCH_RATIO;
+
+  /// When the planner could not prove build-key uniqueness, test it at runtime (one
+  /// cudf::distinct_count pass over the build keys) and take the single-pass
+  /// cudf::distinct_hash_join instead of the two-pass general path when the keys are in fact
+  /// distinct. BUILD_PROBE mode only, INNER/LEFT equality joins with null-unequal semantics. See
+  /// DEFAULT_ENABLE_RUNTIME_DISTINCT_BUILD_PROBE.
+  bool enable_runtime_distinct_build_probe = config::DEFAULT_ENABLE_RUNTIME_DISTINCT_BUILD_PROBE;
 
   /// Wire dynamic table-filter pushdown: an eligible BUILD_PROBE hash-join build publishes a raw
   /// exact IN-list for 1..12 supported build rows, otherwise a hash IN-list if it fits the smallest

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -1468,9 +1468,14 @@ static constexpr cudf::size_type k_max_distinct_count_rows =
   std::numeric_limits<cudf::size_type>::max() / 2;
 
 /// @brief Largest build the runtime distinctness test is allowed to probe at all. Heuristic
-/// limitation
+/// limitation.
 static constexpr cudf::size_type k_max_distinct_probe_rows = 128 * 1024 * 1024;
 static_assert(k_max_distinct_probe_rows <= k_max_distinct_count_rows);
+
+/// @brief Number of rows with which to sample the keys cheaply for a quick refutation of
+/// non-distinctness. The static set for the sample will fit in the L2 cache for recent
+/// architectures at 16MB.
+static constexpr cudf::size_type k_distinct_refute_sample_rows = 1024 * 1024;
 
 /// @brief Exact runtime test that the build keys hold no duplicate rows.
 /// @note Reads a count back to the host, so it synchronizes the stream.
@@ -1482,6 +1487,13 @@ static bool build_keys_are_distinct(cudf::table_view const& build_keys,
   if (num_rows == 1) { return true; }
   if (build_keys.num_columns() == 0 || num_rows <= 0 || num_rows > k_max_distinct_probe_rows) {
     return false;
+  }
+  // Guard the full uniqueness test on a sample.
+  if (num_rows > 4 * k_distinct_refute_sample_rows) {
+    auto const prefix = cudf::slice(build_keys, {0, k_distinct_refute_sample_rows}, stream).front();
+    if (cudf::distinct_count(prefix, nulls_equal, stream) != k_distinct_refute_sample_rows) {
+      return false;
+    }
   }
   return cudf::distinct_count(build_keys, nulls_equal, stream) == num_rows;
 }

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -26,6 +26,7 @@
 #include "cudf/join/mixed_join.hpp"
 #include "cudf/null_mask.hpp"
 #include "cudf/reduction.hpp"
+#include "cudf/reduction/distinct_count.hpp"
 #include "cudf/table/table_view.hpp"
 #include "cudf/transform.hpp"
 #include "cudf/types.hpp"
@@ -1462,6 +1463,29 @@ static bool table_has_any_null(cudf::table_view const& keys)
   return std::ranges::any_of(keys, [](auto const& col) { return col.null_count() > 0; });
 }
 
+/// @brief Largest build cudf::distinct_count can answer for. Hard limitation.
+static constexpr cudf::size_type k_max_distinct_count_rows =
+  std::numeric_limits<cudf::size_type>::max() / 2;
+
+/// @brief Largest build the runtime distinctness test is allowed to probe at all. Heuristic
+/// limitation
+static constexpr cudf::size_type k_max_distinct_probe_rows = 128 * 1024 * 1024;
+static_assert(k_max_distinct_probe_rows <= k_max_distinct_count_rows);
+
+/// @brief Exact runtime test that the build keys hold no duplicate rows.
+/// @note Reads a count back to the host, so it synchronizes the stream.
+static bool build_keys_are_distinct(cudf::table_view const& build_keys,
+                                    cudf::null_equality nulls_equal,
+                                    rmm::cuda_stream_view stream)
+{
+  auto const num_rows = build_keys.num_rows();
+  if (num_rows == 1) { return true; }
+  if (build_keys.num_columns() == 0 || num_rows <= 0 || num_rows > k_max_distinct_probe_rows) {
+    return false;
+  }
+  return cudf::distinct_count(build_keys, nulls_equal, stream) == num_rows;
+}
+
 /// @brief Thread-safe check-and-set for the join-wide _build_has_null sentinel.
 ///
 /// Sentinel encoding: -1 = unset, 0 = false, 1 = true.
@@ -1661,17 +1685,17 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
           SIRIUS_LOG_DEBUG("sirius_physical_hash_join id {}: using filtered_join (BUILD_PROBE {})",
                            this->get_operator_id(),
                            duckdb::JoinTypeToString(join_type));
-        } else if (unique_build_keys &&
-                   (join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT)) {
-          // The planner only sets unique_build_keys for pure-equal joins (the
-          // build-uniqueness gate in sirius_plan_comparison_join excludes
-          // not_distinct_from), so compare_nulls() is UNEQUAL here -- the
-          // distinct_hash_join path is never asked to be null-safe.
+        } else if ((join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT) &&
+                   (unique_build_keys ||
+                    (runtime_distinct_build_probe &&
+                     compare_nulls() == cudf::null_equality::UNEQUAL &&
+                     build_keys_are_distinct(build_keys, compare_nulls(), stream)))) {
           slot.distinct_hash_table =
             std::make_unique<cudf::distinct_hash_join>(build_keys, compare_nulls(), 0.5, stream);
           SIRIUS_LOG_DEBUG(
-            "sirius_physical_hash_join id {}: using distinct_hash_join (BUILD_PROBE)",
-            this->get_operator_id());
+            "sirius_physical_hash_join id {}: using distinct_hash_join (BUILD_PROBE, {})",
+            this->get_operator_id(),
+            unique_build_keys ? "proven unique" : "runtime-distinct");
         } else {
           slot.hash_table = std::make_unique<cudf::hash_join>(build_keys, compare_nulls(), stream);
         }

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -693,9 +693,10 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
       std::move(filter_plan),
       op_params.hash_partition_bytes,
       op_params.max_broadcast_join_size);
-    auto& hj                        = join->Cast<sirius::op::sirius_physical_hash_join>();
-    hj.join_stats                   = std::move(op.join_stats);
-    hj.mark_join_build_switch_ratio = op_params.mark_join_build_switch_ratio;
+    auto& hj                         = join->Cast<sirius::op::sirius_physical_hash_join>();
+    hj.join_stats                    = std::move(op.join_stats);
+    hj.mark_join_build_switch_ratio  = op_params.mark_join_build_switch_ratio;
+    hj.runtime_distinct_build_probe  = op_params.enable_runtime_distinct_build_probe;
 
     // --- Detect build-side key uniqueness ---
     // Gate: only for pure equal conditions (not_distinct_from needs null_equality::EQUAL).

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -693,10 +693,10 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
       std::move(filter_plan),
       op_params.hash_partition_bytes,
       op_params.max_broadcast_join_size);
-    auto& hj                         = join->Cast<sirius::op::sirius_physical_hash_join>();
-    hj.join_stats                    = std::move(op.join_stats);
-    hj.mark_join_build_switch_ratio  = op_params.mark_join_build_switch_ratio;
-    hj.runtime_distinct_build_probe  = op_params.enable_runtime_distinct_build_probe;
+    auto& hj                        = join->Cast<sirius::op::sirius_physical_hash_join>();
+    hj.join_stats                   = std::move(op.join_stats);
+    hj.mark_join_build_switch_ratio = op_params.mark_join_build_switch_ratio;
+    hj.runtime_distinct_build_probe = op_params.enable_runtime_distinct_build_probe;
 
     // --- Detect build-side key uniqueness ---
     // Gate: only for pure equal conditions (not_distinct_from needs null_equality::EQUAL).

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -230,6 +230,7 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
   r.optional("max_build_hash_table_bytes", yaml::bytes(opt.max_build_hash_table_bytes));
   r.optional("max_broadcast_join_size", yaml::bytes(opt.max_broadcast_join_size));
   r.optional("mark_join_build_switch_ratio", opt.mark_join_build_switch_ratio);
+  r.optional("enable_runtime_distinct_build_probe", opt.enable_runtime_distinct_build_probe);
   r.optional("enable_dynamic_filter_pushdown", opt.enable_dynamic_filter_pushdown);
   r.optional("enable_dynamic_zone_map_filter", opt.enable_dynamic_zone_map_filter);
   r.optional("dynamic_filter_domain_coverage_threshold",

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2036,6 +2036,18 @@ static void SetPinTableCompressionMaxCompressedFraction(ClientContext& context,
   SIRIUS_LOG_DEBUG("Updated pin_table_compression_max_compressed_fraction");
 }
 
+static void SetEnableRuntimeDistinctBuildProbe(ClientContext& context,
+                                               SetScope scope,
+                                               Value& parameter)
+{
+  auto* params = get_operator_params(context);
+  if (!params) { return; }
+  auto slot                                   = lock_operator_params_slot(context);
+  params->enable_runtime_distinct_build_probe = BooleanValue::Get(parameter);
+  SIRIUS_LOG_DEBUG("Updated config ENABLE_RUNTIME_DISTINCT_BUILD_PROBE to {}",
+                   params->enable_runtime_distinct_build_probe);
+}
+
 static void SetEnableDynamicFilterPushdown(ClientContext& context, SetScope scope, Value& parameter)
 {
   auto* params = get_operator_params(context);
@@ -2316,6 +2328,16 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     LogicalType::DOUBLE,
     Value::DOUBLE(operator_defaults.mark_join_build_switch_ratio),
     SetMarkJoinBuildSwitchRatio);
+
+  config.AddExtensionOption(
+    "enable_runtime_distinct_build_probe",
+    "For BUILD_PROBE hash joins whose build-key uniqueness the planner could not prove, test "
+    "distinctness at runtime (one cudf::distinct_count pass over the cached build) and take the "
+    "single-pass cudf::distinct_hash_join instead of the general two-pass join when the keys are "
+    "distinct (on by default)",
+    LogicalType::BOOLEAN,
+    Value::BOOLEAN(operator_defaults.enable_runtime_distinct_build_probe),
+    SetEnableRuntimeDistinctBuildProbe);
 
   config.AddExtensionOption(
     "gpu_execution",

--- a/test/cpp/config/data/setting_defaults.yaml
+++ b/test/cpp/config/data/setting_defaults.yaml
@@ -23,6 +23,7 @@ sirius:
     max_build_hash_table_bytes: 6MiB
     max_broadcast_join_size: 7MiB
     mark_join_build_switch_ratio: 3.0
+    enable_runtime_distinct_build_probe: false
     enable_dynamic_filter_pushdown: false
     enable_dynamic_zone_map_filter: true
     dynamic_filter_domain_coverage_threshold: 0.8

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -280,7 +280,8 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
       current_setting('pin_table_compression')::BOOLEAN,
       current_setting('pin_table_input_compression_plan_dir')::VARCHAR,
       current_setting('pin_table_compression_min_batch_size_bytes')::UBIGINT,
-      current_setting('pin_table_compression_max_compressed_fraction')::DOUBLE
+      current_setting('pin_table_compression_max_compressed_fraction')::DOUBLE,
+      current_setting('enable_runtime_distinct_build_probe')::BOOLEAN
   )");
   REQUIRE(settings != nullptr);
   REQUIRE_FALSE(settings->HasError());
@@ -305,6 +306,7 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE(settings->GetValue(16, 0).GetValue<std::string>() == "/tmp/sirius-compression-plans");
   REQUIRE(settings->GetValue(17, 0).GetValue<uint64_t>() == 8 * mib);
   REQUIRE(settings->GetValue(18, 0).GetValue<double>() == Approx(0.6));
+  REQUIRE_FALSE(settings->GetValue(19, 0).GetValue<bool>());
 
   auto zero_partition = con.Query("SET hash_partition_bytes = 0");
   REQUIRE(zero_partition != nullptr);
@@ -323,6 +325,8 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   require_ok("RESET max_sort_partition_memory_fraction");
   require_ok("SET enable_dynamic_filter_pushdown = true");
   require_ok("RESET enable_dynamic_filter_pushdown");
+  require_ok("SET enable_runtime_distinct_build_probe = true");
+  require_ok("RESET enable_runtime_distinct_build_probe");
   require_ok("SET pin_table_compression = false");
   require_ok("RESET pin_table_compression");
   require_ok("SET pin_table_compression_max_compressed_fraction = 0.9");
@@ -334,7 +338,8 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
       current_setting('max_sort_partition_memory_fraction')::DOUBLE,
       current_setting('enable_dynamic_filter_pushdown')::BOOLEAN,
       current_setting('pin_table_compression')::BOOLEAN,
-      current_setting('pin_table_compression_max_compressed_fraction')::DOUBLE
+      current_setting('pin_table_compression_max_compressed_fraction')::DOUBLE,
+      current_setting('enable_runtime_distinct_build_probe')::BOOLEAN
   )");
   REQUIRE(reset != nullptr);
   REQUIRE_FALSE(reset->HasError());
@@ -343,11 +348,13 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE_FALSE(reset->GetValue(2, 0).GetValue<bool>());
   REQUIRE(reset->GetValue(3, 0).GetValue<bool>());
   REQUIRE(reset->GetValue(4, 0).GetValue<double>() == Approx(0.6));
+  REQUIRE_FALSE(reset->GetValue(5, 0).GetValue<bool>());
 
   auto const& params = sirius_ctx->get_config().get_operator_params();
   REQUIRE(params.scan_task_batch_size == 1 * mib);
   REQUIRE(params.max_sort_partition_memory_fraction == Approx(0.25));
   REQUIRE_FALSE(params.enable_dynamic_filter_pushdown);
+  REQUIRE_FALSE(params.enable_runtime_distinct_build_probe);
   auto const& compression = sirius_ctx->get_config().get_compression_config();
   REQUIRE(compression.enable_pin_table_compression);
   REQUIRE(compression.max_compressed_fraction == Approx(0.6));


### PR DESCRIPTION
Performance:
TPC-H SF1000 (GB300, best-of-3, measured stacked on the #1371 perf branch under its reproduction config): 22-query suite (-4.8%); q11 -48%, q9 -18%, q5 -13%, q4 -7%, q3 -6%, q10 -3%; no per-query regression above run-to-run noise; results byte-identical across 7 consecutive suite runs. Behind enable_runtime_distinct_build_probe (default on).

## Description
cudf's general hash_join probes twice (a count pass to size the output, then a retrieve pass) while cudf::distinct_hash_join probes once, but the single-pass path was gated on a planner proof of build-key uniqueness -- a declared PRIMARY KEY, which costs an ART index -- memory and insert/update/delete cost. Test distinctness at runtime instead: one cudf::distinct_count pass over the cached build, in BUILD_PROBE mode only, where a single test amortises across every probe batch. 

## Checklist
- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md