### PR TITLE
fix(downgrade): wake the scheduler matcher after returning extracted pipeline tasks

### DIFF
--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -291,6 +291,7 @@ void downgrade_executor::processing_loop()
     }
 
     // === TIER 2: task_scheduler task queue ===
+    bool pipeline_tasks_extracted = false;
     if (!req->satisfied.load() && _pipeline_task_queue) {
       size_t max_tasks_to_convert = _pipeline_task_queue->size();
       size_t tasks_converted      = 0;
@@ -347,10 +348,23 @@ void downgrade_executor::processing_loop()
             }
           });
       }
+      pipeline_tasks_extracted = tasks_converted > 0;
     }
 
     // Wait for all in-flight work to finish (predicate also checked in workers)
     _pool->wait_all();
+
+    // Every task extracted above has now been pushed back into the scheduler's
+    // queue by convertible_gpu_pipeline_task's destructor (the conversion
+    // lambdas are destroyed once wait_all() returns). That push bypasses
+    // task_scheduler::schedule(), so no task_available event was emitted: if
+    // every executor drained and parked while the tasks were extracted, the
+    // management loop is blocked on its request channel and the returned tasks
+    // would never be dispatched — deadlocking the query with all workers idle.
+    // Wake the matcher explicitly.
+    if (pipeline_tasks_extracted && _pipeline_tasks_returned_notifier) {
+      _pipeline_tasks_returned_notifier();
+    }
 
     // Monitor requests are gated by has_viable_downgrade_target() and warn once per stall episode
     // in monitor_loop(); only warn here for one-shot (external) requests to avoid log spam.
@@ -503,6 +517,11 @@ void downgrade_executor::cancel_pending_requests()
       // Promise may already be fulfilled — safe to ignore
     }
   }
+}
+
+void downgrade_executor::set_pipeline_tasks_returned_notifier(std::function<void()> notifier)
+{
+  _pipeline_tasks_returned_notifier = std::move(notifier);
 }
 
 void downgrade_executor::set_pipeline_task_queue(

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -142,6 +142,21 @@ class downgrade_executor {
     sirius::exec::multi_index_priority_queue<sirius::parallel::itask>* pipeline_task_queue);
 
   /**
+   * @brief Set the callback fired after extracted pipeline tasks are returned.
+   *
+   * Tasks taken from the pipeline task queue for conversion are pushed back by
+   * convertible_gpu_pipeline_task's destructor, which bypasses
+   * task_scheduler::schedule() and therefore emits no task_available event.
+   * The scheduler's matcher must be woken explicitly or the returned tasks are
+   * never dispatched (see task_scheduler::notify_task_available()).
+   *
+   * @param notifier Callable invoked once per downgrade pass that extracted
+   *                 at least one pipeline task; must be safe to call from the
+   *                 downgrade thread for the lifetime of this executor.
+   */
+  void set_pipeline_tasks_returned_notifier(std::function<void()> notifier);
+
+  /**
    * @brief Asynchronously request a predicate-driven downgrade.
    *
    * Dispatches batch downgrades until the predicate returns true or candidates
@@ -208,6 +223,10 @@ class downgrade_executor {
   std::string _source_label;
   sirius::memory::sirius_memory_reservation_manager& _reservation_manager;
   sirius::exec::multi_index_priority_queue<sirius::parallel::itask>* _pipeline_task_queue{nullptr};
+  /// Wakes the task_scheduler's matcher after extracted tasks are pushed back
+  /// into _pipeline_task_queue (the push bypasses schedule(), so no
+  /// task_available event is emitted). See set_pipeline_tasks_returned_notifier.
+  std::function<void()> _pipeline_tasks_returned_notifier;
 };
 
 }  // namespace parallel

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -99,6 +99,20 @@ class task_scheduler {
   void schedule(std::unique_ptr<sirius::parallel::itask> task);
 
   /**
+   * @brief Wake the management event loop to re-run its task/device matcher.
+   *
+   * Emits a task_available event, exactly as schedule() does after pushing a
+   * task. Required by any path that inserts into the pipeline task queue
+   * WITHOUT going through schedule() — the downgrade executor extracts queued
+   * tasks for conversion and returns them via a direct queue push. If every
+   * executor went idle in the meantime, the ready devices are parked in the
+   * management loop and only a channel event can trigger another matcher pass;
+   * without one, the returned tasks are never dispatched and the query
+   * deadlocks with all workers idle.
+   */
+  void notify_task_available();
+
+  /**
    * @brief Starts the executor and initializes worker threads
    *
    * Initializes the thread pool and begins accepting tasks for execution.

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -135,6 +135,11 @@ void task_scheduler::schedule(std::unique_ptr<sirius::parallel::itask> task)
     });
   }
   _task_queue.push(std::move(task));
+  notify_task_available();
+}
+
+void task_scheduler::notify_task_available()
+{
   if (_self_publisher) {
     auto wake                 = std::make_unique<task_request>();
     wake->kind                = task_request_kind::task_available;
@@ -347,7 +352,11 @@ void task_scheduler::management_eventloop()
       }
     }
 
-    if (_task_queue.empty()) {
+    // _ready_devices can be empty here: a task_available event whose task was
+    // re-extracted (downgrade) before this pass arrives with no device parked,
+    // and *begin() of an empty list is UB. Lookahead exists to pre-create work
+    // for a waiting device, so skipping it when none is waiting is correct.
+    if (_task_queue.empty() && !_ready_devices.empty()) {
       if (_task_creator) { _task_creator->schedule_lookahead(*_ready_devices.begin()); }
     }
 

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -854,9 +854,15 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
     config_.get_scan_manager_config(), *memory_manager_, topology_index_);
 
   // Wire the pipeline task queue into downgrade executors now that task_scheduler_
-  // has been constructed.
+  // has been constructed. Tasks the downgrade extracts from this queue come back
+  // via a direct queue push that bypasses schedule(), so the scheduler's matcher
+  // must be woken explicitly or the returned tasks are never dispatched (query
+  // deadlock with all workers idle). The raw scheduler pointer has the same
+  // lifetime contract as the queue pointer passed alongside it.
   for (auto& executor : downgrade_executors_) {
     executor->set_pipeline_task_queue(task_scheduler_->get_pipeline_task_queue());
+    executor->set_pipeline_tasks_returned_notifier(
+      [scheduler = task_scheduler_.get()] { scheduler->notify_task_available(); });
   }
 
   // Start everything -- downgrade executors deferred until now


### PR DESCRIPTION
## Problem

A query can deadlock permanently — every worker thread idle, GPU memory held at 0% utilisation, and plenty of memory free — when the downgrade executor spills queued pipeline tasks.

`task_scheduler`'s management loop is **pull-signal**: it blocks on the task-request channel and re-runs its task/device matcher only on `device_ready` (an executor reserved a worker) or `task_available` (emitted by `schedule()` after it pushes a task). Idle devices park in `_ready_devices` until a task *arrives*.

The downgrade executor's TIER-2 pass extracts tasks from the pipeline task queue via `mutable_pop_if` to convert their input batches GPU→host, then returns them through `convertible_gpu_pipeline_task`'s RAII destructor — **a direct queue push that emits no `task_available` event**.

If every executor drains and parks while those tasks are extracted, nothing ever wakes the matcher again. The tasks sit in the queue beside parked ready-devices; the owning pipeline never reaches `tasks_created == tasks_completed`; its FULL-barrier consumer waits forever; `RESULT_COLLECTOR` never runs; `mark_completed()` never fires; and `sirius_engine::execute` blocks on the completion future indefinitely.

The extraction window is wide at scale — 9.7 GB across 2 tasks took **4.1 s** in the captured failure — so this is not a narrow race.

## Evidence

Reproduced deterministically at SF1000: TPC-H q18 with all 8 tables host-pinned (Simpatico-compressed `lineitem`/`orders`), run against a *fresh copy* of the dataset, whose I/O timing lands the downgrade window on the drain of the last runnable tasks. **Hung 7/7 before this change; completes after.**

Captured interleaving (scheduling-path logging + gdb thread dump at the freeze):

```
T+0.0s   downgrade extracts the last 2 runnable pipeline-5 tasks (4.1 s conversion)
T+1..3s  remaining tasks complete; executors drain, post device_ready, park.
         Consumer op 8 (PARTITION) dead-ends ~280x: hint=WAITING,
         all_ports_empty=false  (data present, source pipeline "not finished")
T+4.1s   downgrade returns both tasks -- silent push, no event
T+4.2s   last in-flight completion; matcher never runs again -> deadlock
```

At the freeze: 265 threads, **all** parked (185 `futex_abstimed_wait`, 71 Rust condvar, plus CUDA/idle); the only Sirius frames are `task_creator::manager_loop` (blocked on an empty request queue) and the main thread in `sirius_engine::execute -> _M_futex_wait_until`. GPU held 238 GB at **0% utilisation** with **95.7 GB free** and `total_reserved` 75.4 GB of a 254.8 GB pool — no `bad_alloc`, no `reschedule` retries. Progress stopped at pipeline 5 of 24.

## Fix

- Factor `schedule()`'s existing wake into `task_scheduler::notify_task_available()`.
- Have `downgrade_executor` invoke it once per pass that extracted pipeline tasks, after `wait_all()` guarantees the RAII returns have completed. A spurious wake is harmless — a matcher pass is idempotent.
- Wire the callback in `sirius_context` beside the existing `set_pipeline_task_queue()` call, same lifetime contract.
- Guard the matcher's lookahead against `*_ready_devices.begin()` on an empty list — pre-existing UB reachable when a `task_available` event arrives after the downgrade re-extracted the task that prompted it.

## Validation

- Minimal reproducer: hung 7/7 before, now completes in 5.64 s.
- Full SF1000 power run (host pin + Simpatico, warm-up + clean + RF1 + timed stream + RF2 + post-RF2): all phases complete; q18 ran 4x across 4 refresh states (3.05 / 3.50 / 2.44 s) where it previously hung; **Power@Size = 4,601,589**, at or above the pre-fix band, so no throughput regression.
- GPU-vs-DuckDB-CPU validation clean at the point the run was stopped (19/19 after RF1, 7/7 after RF2, 0 mismatches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)