### PR TITLE
feat: use fadvise for cache eviction instead of needing sudo, print benchmark totals

### DIFF
--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -782,6 +782,63 @@ def run_nsys_profile(
                 it += 1
 
 
+def print_runtime_summary(runtime_csv):
+    """Print a per-engine table of query runtimes with one column per iteration and a Total row."""
+    data = {}
+    iterations_seen = set()
+    with open(runtime_csv, newline="") as f:
+        for row in csv.DictReader(f):
+            eng = row["engine"]
+            qname = row["query"]
+            it = int(row["iteration"])
+            try:
+                rt = float(row["runtime_s"])
+            except (ValueError, KeyError):
+                rt = float("nan")
+            data.setdefault(eng, {}).setdefault(qname, {})[it] = rt
+            iterations_seen.add(it)
+
+    if not data:
+        return
+
+    n_iters = max(iterations_seen) + 1 if iterations_seen else 0
+    iter_labels = [f"iter{i}" for i in range(n_iters)]
+    q_w, col_w = 7, 10
+
+    def _fmt(v):
+        return f"{'nan':>{col_w}}" if math.isnan(v) else f"{v:{col_w}.4f}"
+
+    def _qnum(name):
+        try:
+            return int(name.lstrip("q"))
+        except ValueError:
+            return 0
+
+    print()
+    print("=== Runtime Summary (seconds) ===")
+    for eng in sorted(data):
+        print(f"\n[{eng}]")
+        header = f"{'Query':<{q_w}}" + "".join(f"  {lbl:>{col_w}}" for lbl in iter_labels)
+        sep = "-" * len(header)
+        print(header)
+        print(sep)
+
+        col_totals = [0.0] * n_iters
+        for qname in sorted(data[eng], key=_qnum):
+            cells = []
+            for i in range(n_iters):
+                rt = data[eng][qname].get(i, float("nan"))
+                cells.append(_fmt(rt))
+                if not math.isnan(rt):
+                    col_totals[i] += rt
+            print(f"{qname:<{q_w}}" + "".join(f"  {c}" for c in cells))
+
+        print(sep)
+        total_cells = [f"{t:{col_w}.4f}" for t in col_totals]
+        print(f"{'Total':<{q_w}}" + "".join(f"  {c}" for c in total_cells))
+    print()
+
+
 def split_sirius_log(log_dir, benchmark_dir, queries, iterations):
     """Split the combined Sirius spdlog into one log file per query.
 
@@ -1202,6 +1259,8 @@ def main():
         log("Starting validation")
         validate(benchmark_dir, queries)
         log("Validation complete")
+
+    print_runtime_summary(runtime_csv)
 
 
 if __name__ == "__main__":

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -818,7 +818,9 @@ def print_runtime_summary(runtime_csv):
     print("=== Runtime Summary (seconds) ===")
     for eng in sorted(data):
         print(f"\n[{eng}]")
-        header = f"{'Query':<{q_w}}" + "".join(f"  {lbl:>{col_w}}" for lbl in iter_labels)
+        header = f"{'Query':<{q_w}}" + "".join(
+            f"  {lbl:>{col_w}}" for lbl in iter_labels
+        )
         sep = "-" * len(header)
         print(header)
         print(sep)

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -225,21 +225,31 @@ DEFAULT_OUTPUT_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "
 PIN_COMPRESSION_PLAN_DIR = None
 
 
-def drop_os_cache():
-    """Drop OS filesystem cache. Requires passwordless sudo per CLAUDE.md."""
-    proc = subprocess.run(
-        ["sudo", "-n", "/usr/bin/tee", "/proc/sys/vm/drop_caches"],
-        input="3\n",
-        text=True,
-        capture_output=True,
-    )
-    if proc.returncode != 0:
-        raise RuntimeError(
-            "Failed to drop OS cache. Set up passwordless sudo as described "
-            f"in test/tpch_performance/CLAUDE.md (stderr: {proc.stderr.strip()})"
-        )
+def drop_os_cache(source, data_source="parquet"):
+    """Evict input dataset pages from the OS page cache via posix_fadvise(DONTNEED).
+
+    Unlike writing to /proc/sys/vm/drop_caches this requires no root/sudo — it
+    only evicts the pages belonging to the benchmark's own input files.
+    os.sync() is called first so any dirty pages are flushed before eviction.
+    """
+    if data_source == "duckdb":
+        files = [source]
     else:
-        log("OS cache dropped successfully")
+        files = []
+        for table in TPCH_TABLES:
+            files.extend(_resolve_parquet_files(source, table))
+
+    os.sync()
+    evicted = 0
+    for path in files:
+        try:
+            with open(path, "rb") as f:
+                size = os.fstat(f.fileno()).st_size
+                os.posix_fadvise(f.fileno(), 0, size, os.POSIX_FADV_DONTNEED)
+                evicted += 1
+        except OSError as e:
+            log(f"WARNING: fadvise({path}): {e}")
+    log(f"posix_fadvise(DONTNEED) applied to {evicted} file(s)")
 
 
 def _resolve_parquet_files(parquet_dir, table):
@@ -502,7 +512,7 @@ def run_isolated(
                     source, gpu_execution=use_gpu, data_source=data_source
                 )
                 try:
-                    drop_os_cache()
+                    drop_os_cache(source, data_source)
                     if pin_enabled and use_gpu:
                         log(f"  Pinning tables for q{qnum}")
                         _execute_multi(con, emit_pin(qnum, source, data_source))
@@ -1149,7 +1159,7 @@ def main():
     log(f"Runtime CSV:   {runtime_csv}")
     log(f"Log dir:       {log_dir}")
 
-    drop_os_cache()
+    drop_os_cache(source, args.data_source)
     with open(runtime_csv, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["engine", "query", "iteration", "runtime_s"])


### PR DESCRIPTION
<!-- Edit PR title: "<type>[optional scope]: <short description>", see CONTRIBUTING.md for guidance -->

## Description
Small modifications to the benchmark script, to use fadvise for removing the dataset from cache (instead of needing sudo for dropping the entire os cache), and to print an overview of the query times and totals when finished.

## Checklist
- [x] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
<!-- Add open issues with "Closes #issue" to close or "Refs #issue" for reference, and any relevant URLs -->
