### PR TITLE
feat(op): streaming sink over an output repository, partitioned across N destinations (#837, #838)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,7 @@ set(EXTENSION_SOURCES
     src/op/dynamic_filter_publisher.cpp
     src/op/sirius_dynamic_filter.cpp
     src/op/sirius_physical_column_data_scan.cpp
+    src/op/sirius_physical_streaming_sink.cpp
     src/op/sirius_physical_streaming_source.cpp
     src/op/sirius_physical_concat.cpp
     src/op/sirius_physical_cte.cpp
@@ -723,6 +724,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_physical_partition.cpp
     test/cpp/operator/test_physical_projection.cpp
     test/cpp/operator/test_physical_result_collector.cpp
+    test/cpp/operator/test_physical_streaming_sink.cpp
     test/cpp/operator/test_physical_streaming_source.cpp
     test/cpp/operator/test_physical_table_scan.cpp
     test/cpp/operator/test_no_history_peak_memory_estimate.cpp
@@ -756,6 +758,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_pipeline_schedule_canonical.cpp
     test/cpp/pipeline/test_plan_printer.cpp
     test/cpp/pipeline/test_repository_wiring_materializer.cpp
+    test/cpp/pipeline/test_streaming_sink_root.cpp
     test/cpp/pipeline/test_task_scheduler.cpp
     test/cpp/scan/bench_decode_codecs.cpp
     test/cpp/scan/test_can_serve_with_columns.cpp

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -68,19 +68,34 @@ spill-visible to the downgrade executor when the caller registered that reposito
 manager) bound to the stream state (sender-aware end-of-stream, the availability classification,
 the `on_data` notification, and the producer-error plane).
 
-Key design invariants (S1–S5 are the named stream contracts defined in `exec/batch_stream.hpp`):
+Key design invariants (full S1–S5 / P1–P4 in [Streaming Sessions](streaming-sessions.md#contracts-s1-s5)):
 - Batches cross natively, in their current tier — no Arrow, no forced GPU upgrade.
 - EOS is **sender-aware**: `close_input(sender)` is idempotent per sender, and the stream ends
   only once every *expected* sender has closed. An unexpected sender id is a defined error.
 - **S1** — every batch lands in the repository before `on_data` announces it; `push()` returns
-  false once the stream is terminal, so no batch can arrive after a consumer has seen EOS.
-- **S2–S3** — a producer failure (`fail_input(error)`) fires `on_data` so a parked consumer
-  wakes to collect the rethrow; the stream never reports `END_OF_STREAM` or `drained()` while an
-  error is pending (the only exit is the rethrow).
+  false once the stream is terminal.
+- **S2** — `fail_input` wakes a parked consumer (on_data / P4 for the engine path) for the rethrow.
+- **S3** — an errored stream never reports `END_OF_STREAM` / `drained()`; exit is the rethrow.
+- **S4** — `try_pull` / task input rethrows before popping queued batches.
+- **S5** — `wait` then pull is not atomic; blocking loops must re-check.
 - `execute()` is a pure pass-through (COLUMN_DATA_SCAN shape — no GPU work).
 - `no_history_peak_memory_estimate()` returns `stats.bytes` (no extra allocation).
 
-Hint table:
+Hint state machine (contrast with `GPU_SCAN`: `READY{this} → drain blocking condvar → nullopt`):
+
+```
+WAITING{nullptr} ◄──── classify()=WAITING (open, empty)
+      │                      ▲
+      │ request dropped       │ try_pull() drains; stream still open
+      │                      │
+      └──► push() fires on_data ──► creator->schedule(head) ──► READY{this}
+                                                                      │
+                                              classify()=HAS_DATA ───┘
+                                              get_next_task_input_data() pops one batch
+                                              (or rethrows on error — S4)
+
+classify()=END_OF_STREAM ──► nullopt ──► on_end_of_stream ──► pipeline finishes
+```
 
 | Stream state | `get_next_task_hint()` |
 |---|---|
@@ -95,7 +110,8 @@ admitted between the check and the lock could be reported as end-of-stream and d
 
 **The live wake-up.** The head is scheduled once by `start_query()` and task completion only
 nominates downstream consumers, so `on_data` — fired by every successful `push()` — is the only
-thing that brings a dropped source back. It is deliberately not one-shot; the header explains why.
+thing that brings a dropped source back. It is deliberately not one-shot; `batch_stream::set_on_data`
+explains why.
 
 End-of-stream separately notifies the pipeline (`update_pipeline_status(false)`, via a weak
 pipeline reference wired in `set_pipeline`), so an empty or late-closed stream still finishes its
@@ -105,6 +121,54 @@ pipeline — and re-arms downstream consumers — even when no task is left in f
 relieves memory pressure. Sirius has no upward "stop producing" signal today (hints are only
 `READY` / `WAITING` / nothing), so the intended lever is per-fragment priority, not a bounded
 queue.
+
+### `sirius_physical_streaming_sink` — `STREAMING_SINK`
+**File:** `src/include/op/sirius_physical_streaming_sink.hpp`
+
+Terminal operator of a streaming fragment: every batch the pipeline produces is pushed into one
+`exec::batch_stream` and exposed to an external consumer via `pull()` / `wait()` / `drained()`.
+
+Where the source stands where no table exists, the sink stands where no `RESULT_COLLECTOR` exists:
+the fragment's output travels through an `exec::batch_stream` over a caller-supplied output
+repository rather than into a query result. It is shaped
+like `RESULT_COLLECTOR` (appended to `current` in `build_pipelines`, set as the meta-pipeline sink)
+so the executor places it at `operators[last]` and drives its `on_finalize_operator()` — which is
+the only route to end-of-stream for the output stream.
+
+Lifecycle:
+
+```
+sink(batch) ──► batch_stream[i].push(batch)     (per task, per destination partition)
+      │
+on_finalize_operator()                           (pipeline finish — the only EOS path)
+      │
+batch_stream[i].close(PIPELINE_SENDER)           (for every output stream i)
+      │
+consumers see END_OF_STREAM via wait(i) / drained(i)
+```
+
+Key design facts:
+- **One sender, one finalize.** The pipeline feeding this sink is its single expected sender
+  (`PIPELINE_SENDER = 0`). `on_finalize_operator()` calls `close(PIPELINE_SENDER)` on the output
+  `exec::batch_stream`, which is what makes it terminal. Without `build_pipelines` placing the sink in
+  `operators`, `on_finalize_operator()` is never called and every consumer blocked in `wait()`
+  hangs forever with no error visible.
+- **No self-nomination.** Unlike the source, the sink does not wire an `on_data` hook: its consumer
+  is an external thread blocking in `wait()`, not an engine task needing re-nomination.
+- **Native tier.** Batches are pushed in whatever tier they arrived — no Arrow, no forced GPU
+  upgrade. A queued batch stays spillable in the repository until pulled.
+- **execute() is a pass-through** (same shape as `RESULT_COLLECTOR`): it hands the batches back so
+  `publish_output()` can deliver them to `sink()`. The base implementation drops them.
+- **Partitioned variant (N destinations).** The second constructor takes N repositories and a
+  `partition_spec` (`mode`, key columns + optional casts, validated at construction).
+  `partition_mode::hash` GPU-hash-partitions each input batch and routes slice *i* into
+  `_outputs[i]`, skipping empty slices. `partition_mode::broadcast` replicates every batch to all
+  N outputs: output 0 gets the original handle, outputs 1..N−1 get independent `clone()`s with
+  fresh `batch_id`s. Each destination has its own `exec::batch_stream` and EOS reaches all of them
+  on a single `on_finalize_operator()` call. When N = 1 the spec is ignored and a native push
+  bypasses routing entirely. `no_history_peak_memory_estimate()` stays 0 for N = 1 and becomes 2×
+  the input for N > 1: hash_partition holds a reordered copy + slices; broadcast holds the
+  original + N−1 clones simultaneously.
 
 ### `sirius_physical_dummy_scan` — `DUMMY_SCAN`
 **File:** `src/include/op/sirius_physical_dummy_scan.hpp`
@@ -381,7 +445,7 @@ After pipeline finalization, `source` and `sink` are just aliases for the first 
 | Operator | Category | GPU Method |
 |----------|----------|-----------|
 | GPU_SCAN | Scan | Unified GPU scan source served by `sirius_scan_manager` via a per-format `gpu_ingestible` |
-| STREAMING_SOURCE | Scan | Exchange-input source; drains an `exec::batch_stream` (repository fed by `push()`, sender-aware EOS, producer-error plane) |
+| STREAMING_SOURCE | Scan | Exchange-input source; drains an `exec::batch_stream` |
 | DUMMY_SCAN | Scan | Generates 1 row |
 | COLUMN_DATA_SCAN | Scan | Reads ColumnDataCollection |
 | FILTER | Relational | `expression_evaluator::select()` |
@@ -406,3 +470,4 @@ After pipeline finalization, `source` and `sink` are just aliases for the first 
 | CTE | CTE | Materialize to ColumnDataCollection |
 | RESULT_COLLECTOR | Result | Final result materialization |
 | EMPTY_RESULT | Result | Empty result set |
+| STREAMING_SINK | Result | Terminal operator of a streaming fragment |

--- a/docs/super-sirius/streaming-sessions.md
+++ b/docs/super-sirius/streaming-sessions.md
@@ -1,0 +1,298 @@
+# Stream Sessions
+
+A **stream session** is the boundary object for one Sirius plan fragment in a distributed query.
+It gives the wrapper above the engine a single, id-addressed handle to feed batches into the
+fragment and collect batches out of it:
+
+```
+push(stream_id, batch)              // feed an input stream
+close_input(stream_id, sender_id)   // one remote sender is done producing
+pull(stream_id) -> optional<batch>  // collect from an output stream (non-blocking)
+wait(stream_id)                     // block until data arrives or the stream ends
+drained(stream_id) -> bool          // stream ended cleanly and nothing is left
+```
+
+Sirius itself stays **fragment-blind**: it never learns that it is distributed, which compute
+node a partition ships to, or how many nodes exist. One session models one fragment; pairing a
+leaf fragment's output id with a root fragment's input id — across sessions and nodes — is the
+wrapper's routing table, never the engine's.
+
+A session is built from three pieces:
+
+| Piece | Role |
+|---|---|
+| `STREAMING_SOURCE` operator | The fragment's input boundary — remote senders push batches in |
+| `STREAMING_SINK` operator | The fragment's output boundary — external consumers pull batches out |
+| `exec::batch_stream` | The one-directional stream primitive both operators are built on |
+
+The session (`exec::stream_session`) is the id-addressed router over these operators.
+
+## The model: the repository is the queue
+
+A `cucascade::shared_data_repository` already *is* a thread-safe queue of `data_batch`es, and it
+is what the downgrade executor sweeps for spill candidates. What it lacks is the **lifecycle** of
+a stream: who is still producing, whether "nothing right now" means *wait* or *the stream is
+over*, and how a starved consumer gets woken. So each streaming operator owns both:
+
+| Concern | Owned by |
+|---|---|
+| The queue of batches | `cucascade::shared_data_repository` |
+| End-of-stream, availability, waking | `exec::batch_stream` |
+
+Batches cross the boundary **natively**, as `cucascade::data_batch`, in whatever tier they
+currently sit. Nothing is materialized to Arrow on the way in or out, so a queued batch stays
+spillable (GPU → host → disk) right up until it is pulled, and `pull()` hands it back in its
+current tier without forcing an upgrade.
+
+There is no bounded channel and no channel-level backpressure.
+
+## `exec::batch_stream`
+
+**Files:** `src/include/exec/batch_stream.hpp`, `src/exec/batch_stream.cpp`
+
+One direction of batch flow: N declared senders push into one repository; consumers pull, poll,
+or block.
+
+```cpp
+class batch_stream {
+ public:
+  enum class availability { HAS_DATA, WAITING, END_OF_STREAM };
+
+  batch_stream(shared_ptr<shared_data_repository> repo, set<sender_id_t> expected);
+
+  // Producer
+  [[nodiscard]] bool push(shared_ptr<data_batch>);  // false once terminal
+  void close(sender_id_t);       // idempotent per sender; set-based fan-in
+  void fail(exception_ptr);      // immediate, first failure wins
+
+  // Consumer
+  shared_ptr<data_batch> try_pull();  // rethrows a pending error before popping
+  availability classify() const;
+  bool drained() const;               // clean end only
+  void wait();                        // not atomic with try_pull — loop and re-check
+
+  // Hooks (single slot; fire after unlocking; registering on an ended stream fires immediately)
+  void set_on_data(function<void()>);           // persistent — fires on every push and on fail()
+  void set_on_end_of_stream(function<void()>);
+};
+```
+
+Three behaviors are load-bearing:
+
+- **End-of-stream is a set, not a counter.** A fan-in stream fed by N remote senders is over only
+  when all N *distinct* senders have closed. A repeated close is a no-op; an unexpected sender id
+  is a defined error. A counter could not tell "both senders closed once" from "one closed twice".
+- **Push, close, and every emptiness check share one lock.** No batch is ever admitted after
+  end-of-stream, and every batch is in the repository before the wake that announces it. Hooks
+  fire after the lock is released, so a hook may safely re-enter the scheduler.
+- **`classify()` separates "not yet" from "never".** Queued data outranks terminal: EOS is never
+  reported while an accepted batch is still pullable. A pending error reads as `HAS_DATA` even
+  over an empty queue — the only way out is the rethrow from `try_pull()`, never a clean finish
+  that would let a failed query succeed silently.
+
+### Contracts S1-S5
+
+Named observable contracts cited by call sites and tests. This section is the source of truth;
+headers keep only the tokens.
+
+- **S1 — admission ordering.** `push()` puts the batch in the repository before firing `on_data`,
+  and returns false once the stream is terminal. A consumer that saw EOS can never be raced by a
+  batch that was not yet visible when `on_data` fired.
+- **S2 — poison dominates.** `fail()` ends the stream and wakes a consumer parked on `WAITING`:
+  engine paths via `on_data` (P4); external `wait()` via the condition variable. Either way the
+  only exit is the rethrow from `try_pull()`, never a quiet finish.
+- **S3 — errored is never clean.** A stream with a pending error never returns `END_OF_STREAM` or
+  `drained()`. The only exit is the rethrow from `try_pull()`.
+- **S4 — rethrow beats pop.** `try_pull()` checks the pending error before popping; batches queued
+  behind a failure are never handed to the consumer. The error is never cleared.
+- **S5 — wait-then-pop is not atomic.** `wait()` and the following `try_pull()` are two separate
+  critical sections; a blocking consumer loop must re-check after waking.
+
+### Error semantics P1–P4 (`fail`)
+
+Failure is stream-wide (no sender identity) and waits for nobody. P1–P4 are the `fail()` details;
+S2 is the stream-level name for "poison wakes / dominates".
+
+- **P1 — immediate visibility.** `pending_error()` returns it as soon as `fail()` returns.
+- **P2 — first failure wins.** Later failures and clean closes never displace the original cause.
+- **P3 — fail-fast terminal.** The stream ends at once rather than waiting for remaining senders.
+- **P4 — poison is data.** A pending error classifies as `HAS_DATA` even over an empty queue, and
+  fires `on_data` so a parked engine consumer comes back for the rethrow.
+
+| terminal? | error? | repo empty? | `classify()` |
+|---|---|---|---|
+| no | no | no | `HAS_DATA` |
+| no | no | yes | `WAITING` |
+| yes | no | no | `HAS_DATA` |
+| yes | no | yes | `END_OF_STREAM` |
+| either | yes | either | `HAS_DATA` |
+
+`wait()` blocks until `classify() != WAITING`. Engine workers never call it — it is for the
+wrapper's external threads.
+
+### Availability state machine
+
+Transitions are driven by producers (`push`, `close`, `fail`) and consumers (`try_pull`):
+
+```
+                  push()                       close(last sender) + repo empty
+WAITING ───────────────────────► HAS_DATA ──────────────────────────────────► END_OF_STREAM
+  ▲                                  │
+  └──────────────────────────────────┘
+        try_pull() drains repo; stream still open
+
+fail() (any state) ──► HAS_DATA  ──try_pull()──► rethrow
+                       ^^^^^^^^
+                       classify() cannot tell poison from data — both read HAS_DATA (P4). What
+                       the error is depends on try_pull(), which rethrows instead of popping.
+                       The stream stays in HAS_DATA — never reaches END_OF_STREAM (S3).
+```
+
+Reading S1–S5 against the diagram:
+- **S1** — `push()` deposits the batch in the repo *before* the `WAITING → HAS_DATA` transition fires; a consumer that wakes on `HAS_DATA` is guaranteed to find the batch.
+- **S2 / P4** — `fail()` drives a transition to `HAS_DATA` and fires `on_data`, so a parked engine consumer comes back and exits via the rethrow in `try_pull()`.
+- **S3** — `fail()` has no arc to `END_OF_STREAM`; the `HAS_DATA → END_OF_STREAM` arc requires no pending error.
+- **S4** — `try_pull()` checks `pending_error()` before popping; batches queued behind a failure are never handed out.
+- **S5** — `wait()` and the following `try_pull()` are separate critical sections; another consumer may traverse `HAS_DATA → WAITING` between the two calls.
+
+## `STREAMING_SOURCE` — the input boundary
+
+**Files:** `src/include/op/sirius_physical_streaming_source.hpp`,
+`src/op/sirius_physical_streaming_source.cpp`
+
+Wraps one `batch_stream` constructed with the fragment's expected sender set. Remote producers
+call `push(batch)` and `close_input(sender_id)`; the engine sees an ordinary source whose task
+hint mirrors the stream state:
+
+| Stream state | `get_next_task_hint()` |
+|---|---|
+| `HAS_DATA` | `READY{this}` |
+| `WAITING` | `WAITING_FOR_INPUT_DATA{nullptr}` |
+| `END_OF_STREAM` | `std::nullopt` |
+
+A pending producer error classifies as `HAS_DATA` even over an empty queue, so a failed stream
+answers `READY{this}` with nothing queued. That is deliberate: it is the one nomination that
+carries the failure out through `get_next_task_input_data()`'s rethrow, instead of the source
+retiring on `nullopt` and the query finishing as if it had worked.
+
+Each task pulls one batch, zero-copy, rethrowing any pending error; `execute()` is a
+pass-through.
+
+### Task-hint lifecycle
+
+Unlike `GPU_SCAN` — whose state machine is `READY{this} → drain (blocking condvar) → nullopt`
+and whose producer (`load_balancing_scan_batch_coalescer`) runs on a disjoint thread pool that
+never needs a `task_creator` slot — `STREAMING_SOURCE`'s producer is a sink task on a
+**remote fragment** (possibly a different compute node). Blocking in `get_next_task_input_data()`
+would deadlock: the 2-slot `task_creator` pool would be occupied waiting for data that can only
+arrive once the pool creates the sender's task. The source therefore never blocks; it drops the
+request and relies on `on_data` to re-nominate itself:
+
+```
+start_query() → schedule(head) once
+                      │
+                      ▼
+           ┌── classify() ──────────────────────────────────────┐
+           │                                                    │
+      WAITING                                              HAS_DATA / error
+           │                                                    │
+    WAITING{nullptr}                                      READY{this}
+    request dropped                                            │
+           │                                       get_next_task_input_data()
+           │                                       pulls one batch (or rethrows — S4)
+    push() fires on_data                                       │
+    creator->schedule(head)  ◄──── task completes ────────────┘
+    (re-enters from step ①)         (schedules consumers, not source)
+
+           │ classify() = END_OF_STREAM
+           ▼
+        nullopt → on_end_of_stream → update_pipeline_status → pipeline finishes
+```
+
+Key consequences:
+- `on_data` is **persistent** (not one-shot) — a push between fire and re-arm would otherwise be lost.
+- `schedule()` is pure enqueue (lock-free, safe from any thread) — the hook never occupies a pool slot.
+- `on_end_of_stream` is the symmetric edge for an empty or late-closed stream: `nullopt` hits the same "request dropped" path, so without this hook the pipeline would never finish.
+
+**The live re-arm.** The engine is pull-scheduled: a source that answers `WAITING` is dropped,
+and the only built-in re-nomination is task completion — so a starved stream-fed source has no
+completing task to wake it. The source therefore wires `set_on_data` (persistent, fires on every
+push) to `task_creator::schedule(head)`, which only enqueues onto a thread-safe queue and is safe
+to call from any thread. Because the hook is persistent, there is no waker to re-arm and no
+notification to miss. Separately, `set_on_end_of_stream` updates the pipeline status so that a
+stream closing with **no task in flight** (an empty stream, or a late close) still lets the
+pipeline finish and schedules its consumers.
+
+## `STREAMING_SINK` — the output boundary
+
+**Files:** `src/include/op/sirius_physical_streaming_sink.hpp`,
+`src/op/sirius_physical_streaming_sink.cpp`
+
+A pipeline-terminal operator. `sink()` pushes each output batch into an output `batch_stream`;
+the pipeline-finish hook (`on_finalize_operator()`) closes every stream, which is what makes
+`END_OF_STREAM` observable. Consumers use `pull(i)` / `wait(i)` / `drained(i)` /
+`availability(i)`. Unlike the source it registers no `on_data` hook: its consumer is an external
+thread blocking in `wait()`, not an engine task that needs re-nominating.
+
+### Lifecycle
+
+```
+pipeline executing
+    │  execute() is a pass-through; publish_output() calls sink()
+    ▼
+sink(batch) ──► batch_stream[i].push(batch)     (one per destination partition)
+    │
+    │  (repeat per task)
+    ▼
+on_finalize_operator()                          (pipeline finish — the only EOS path)
+    │
+    ▼
+batch_stream[i].close(PIPELINE_SENDER)          (for every output stream i)
+    │
+    ▼
+consumers see END_OF_STREAM via wait(i) / drained(i)
+```
+
+The sink has exactly **one sender** (`PIPELINE_SENDER`). `on_finalize_operator()` is called only
+when the sink is in the pipeline's `operators` vector — if it is reachable only through the
+`sink` member, `finalize_operator()` skips it, the streams never close, and every `wait()` caller
+blocks forever.
+
+### Partition fan-out
+
+A sink can expose **N output streams**, one per destination, each backed by its own repository.
+The routing mode is set by `partition_spec::mode`:
+
+```cpp
+enum class partition_mode { hash, broadcast };
+
+struct partition_spec {
+  partition_mode mode = partition_mode::hash;
+  std::vector<int> key_columns;                 // hashed to pick a destination (hash mode only)
+  std::vector<cudf::data_type> key_cast_types;  // per-key cast so INT32/INT64 keys agree; ignored in broadcast
+};
+```
+
+**Hash mode** — `sink()` GPU-hash-partitions each batch by the key columns (same `hash_partition`
+kernel as `PARTITION`) and pushes slice *i* into stream *i*; empty slices are skipped. A slow
+receiver's backlog accumulates in its own repository — spillable by the downgrade executor —
+without head-of-line-blocking the others.
+
+**Broadcast mode** — `sink()` replicates every batch to all N outputs. Output 0 receives the
+original handle (zero-copy); outputs 1..N−1 each receive an independent deep copy (`clone()` in
+the batch's current memory space, with a fresh `batch_id`). Clones are made before the output 0
+push so the terminal state cannot advance before copies are complete.
+
+The single-destination sink is the N = 1 case and skips both modes entirely (native push).
+
+Construction invariants:
+
+- **Hash mode, N > 1**: `key_columns` must be non-empty — silently routing every row to
+  destination 0 would corrupt a downstream shuffle rather than fail loudly.
+- **Broadcast mode**: `key_columns` must be empty — broadcast routes by replication, not hashing.
+- Output stream id, partition index, and repository correspond **positionally**; `drained(i)` and
+  `wait(i)` are independent per stream, so a slow receiver stays distinguishable from EOS.
+- All partitions share one sender (`PIPELINE_SENDER`), so pipeline finish drives all N streams to
+  EOS together.
+- *Which* compute node each partition ships to is the wrapper's routing table — the sink stays
+  oblivious to destinations.

--- a/src/exec/batch_stream.cpp
+++ b/src/exec/batch_stream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Sirius Contributors.
+ * Copyright 2026, Sirius Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ void batch_stream::fail(std::exception_ptr error)
     std::unique_lock<std::mutex> lock(_mutex);
     if (_error) { return; }  // P2 — the first failure is the cause the consumer sees
     _error = std::move(error);
-    // P4 — announced like a batch, or a consumer parked on WAITING never comes back for it.
+    // S2 / P4 — announce like a batch (on_data); wait() wakes via notify_all below.
     data_hook = _on_data;
     if (!_terminal) {
       _terminal = true;  // P3 — the stream ends now, waiting for nobody

--- a/src/include/exec/batch_stream.hpp
+++ b/src/include/exec/batch_stream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Sirius Contributors.
+ * Copyright 2026, Sirius Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,57 +28,22 @@
 
 namespace sirius::exec {
 
-/// Identity of one producer feeding a stream. A fan-in stream (N remote senders into one
-/// source) is only at end-of-stream once every expected sender has closed, so closes must
-/// dedup by identity rather than by count.
+/// Producer identity for sender-set EOS (set, not counter).
 using sender_id_t = std::uint32_t;
 
-/// One direction of batch flow: N declared senders push `data_batch`es into one
-/// `shared_data_repository`; consumers pull, poll, or block. The repository is the queue; this
-/// owns everything the repository lacks — who is still producing, whether "no batch right now"
-/// means "wait" or "the stream is over", how a starved consumer gets woken, and how a producer
-/// failure reaches the consumer.
-///
-/// The streaming source, the streaming sink, and the session all need this same pairing;
-/// written once here, each of them is left with task-protocol glue.
-///
-/// The repository is borrowed: the caller creates and registers it with the memory manager, so
-/// queued batches stay spillable. Hold the stream by `shared_ptr` — producer threads co-own it.
-///
-/// Admission, close, and every emptiness check share the one lock, which is what makes the races
-/// safe: no batch is admitted after the stream goes terminal, no queued batch is ever reported as
-/// end-of-stream, and a batch is in the repository before `on_data` announces it. The repository
-/// is touched only under that lock — except `try_pull()`'s pop, so wait-then-pop is not atomic
-/// and a blocking consumer loop must re-check after `wait()`.
-///
-/// Error semantics are P1–P4 (see `fail`). Stream-level guarantees S1–S5 (cited by call sites
-/// and tests) collect the observable contracts of each mechanism:
-/// - **S1 — admission ordering.** `push()` puts the batch in the repository before firing
-///   `on_data`, and returns false once the stream is terminal. A consumer that saw EOS can never
-///   be raced by a batch that was not yet visible when `on_data` fired.
-/// - **S2 — poison dominates.** `fail()` fires `on_data` (P4) so a consumer parked on `WAITING`
-///   wakes to collect the rethrow. The error is immediate (P1), first-wins (P2), and ends the
-///   stream at once (P3) — a starved source would otherwise never discover a producer failure.
-/// - **S3 — errored is never clean.** A stream with a pending error never returns
-///   `END_OF_STREAM` or `drained()`. The only exit is the rethrow from `try_pull()`, never the
-///   quiet success that would let a failed query finish as if it had worked.
-/// - **S4 — rethrow beats pop.** `try_pull()` checks the pending error before popping; batches
-///   queued behind a failure are never handed to the consumer.
-/// - **S5 — wait-then-pop is not atomic.** `wait()` and the following `try_pull()` are two
-///   separate critical sections; a blocking consumer loop must re-check after waking.
+/// Repository IS the queue. Owns sender-set EOS, terminal/error state, and wake hooks.
+/// Contracts: S1–S5 / P1–P4 — see docs/super-sirius/streaming-sessions.md. Borrowed repo; hold
+/// via shared_ptr. try_pull() pops outside the lock — S5: wait-then-pop is not atomic.
 class batch_stream {
  public:
-  /// What a consumer should do right now.
   enum class availability {
-    HAS_DATA,       ///< At least one batch is pullable (or an error is waiting to rethrow).
-    WAITING,        ///< Nothing available yet, but more may still arrive.
-    END_OF_STREAM,  ///< Every expected sender closed, queue empty, no error. Terminal.
+    HAS_DATA,       ///< Batch pullable, or a pending error (P4).
+    WAITING,        ///< Empty, but more may arrive.
+    END_OF_STREAM,  ///< All expected senders closed, queue empty, no error.
   };
 
   /// @param repo The queue. Must not be null.
-  /// @param expected Every sender that must `close()` before end-of-stream — `{0}` for a single
-  ///        producer, `{0 … N-1}` for an N-way fan-in. An empty set means the stream is terminal
-  ///        from construction (nothing will ever produce), a legitimate degenerate case.
+  /// @param expected Senders that must `close()` before EOS. Empty → terminal from construction.
   /// @throws sirius::invalid_input_exception when `repo` is null.
   batch_stream(std::shared_ptr<cucascade::shared_data_repository> repo,
                std::set<sender_id_t> expected);
@@ -92,88 +57,58 @@ class batch_stream {
   // Producer side — any thread
   // -----------------------------------------------------------------------
 
-  /// Insert `batch` into the repository, then fire `on_data` after unlocking.
-  /// @return false when the stream is already terminal — the batch was refused, not queued.
+  /// Push into the repository then fire on_data (S1). @return false if terminal.
   [[nodiscard]] bool push(std::shared_ptr<cucascade::data_batch> batch);
 
-  /// Record that `sender` has finished producing cleanly. Idempotent: a repeat close from the
-  /// same sender is a no-op and cannot advance a fan-in stream on its own. Once every expected
-  /// sender has closed the stream goes terminal, waking `wait()` and firing the
-  /// end-of-stream hook.
-  ///
-  /// @throws sirius::invalid_input_exception when `sender` is not in the expected set — an
-  ///         unexpected sender is a wiring bug, not something to silently count.
+  /// Sender-set EOS: idempotent per sender; terminal when all expected closed.
+  /// @throws sirius::invalid_input_exception when `sender` is not in the expected set.
   void close(sender_id_t sender);
 
-  /// A producer died: poison the stream. Failure is stream-wide, not per-sender — it carries no
-  /// identity and waits for nobody.
-  ///
-  /// - **P1 — immediate visibility.** `pending_error()` returns it as soon as this call returns.
-  /// - **P2 — the first failure wins.** Later failures and clean closes never displace the
-  ///   original cause.
-  /// - **P3 — fail-fast terminal.** The stream ends at once rather than waiting for senders that
-  ///   will never produce anything useful now.
-  /// - **P4 — poison is data.** A pending error classifies as `HAS_DATA` even over an empty
-  ///   queue, and is never `END_OF_STREAM` or `drained()`: an errored stream ends by rethrow at
-  ///   the consumer, not by a quiet clean finish. Fires `on_data` to bring a parked consumer
-  ///   back for it, as well as `on_end_of_stream`.
-  ///
-  /// @throws sirius::invalid_input_exception when `error` is null — a null failure is a bug at
-  ///         the call site, not a clean close.
+  /// Poison the stream (no sender identity). P1–P3: immediate, first-wins, fail-fast terminal.
+  /// S2 / P4: classifies as HAS_DATA, fires on_data, and notifies wait().
+  /// @throws sirius::invalid_input_exception when `error` is null.
   void fail(std::exception_ptr error);
 
   // -----------------------------------------------------------------------
   // Consumer side
   // -----------------------------------------------------------------------
 
-  /// Non-blocking: the next queued batch, or nullptr when nothing is queued.
-  /// @throws the pending error, checked before the pop, so batches queued behind a failure are
-  ///         never handed out. Every call rethrows; the error is never consumed.
+  /// Next batch, or nullptr. @throws pending error before popping (S4); error is never cleared.
   std::shared_ptr<cucascade::data_batch> try_pull();
 
-  /// What the consumer should do right now. Queued data wins over terminal, so end-of-stream is
-  /// never reported while an accepted batch is still pullable. A pending error wins over both
-  /// (P4): it reads as `HAS_DATA` so the consumer comes back and collects the rethrow.
+  /// Queued data / pending error (P4) beat EOS.
   [[nodiscard]] availability classify() const;
 
-  /// True only at a clean end: every expected sender closed, the queue empty, no pending error
-  /// (P4 — an errored stream never reports a clean end).
+  /// Clean end only: all senders closed, queue empty, no error (S3).
   [[nodiscard]] bool drained() const;
 
   /// The producer's error, or null. Never cleared once set.
   [[nodiscard]] std::exception_ptr pending_error() const;
 
-  /// Block until a batch is pullable or the stream has ended (cleanly or with an error).
-  /// For external (session / wrapper / test) threads only — never call it from a GPU worker.
+  /// Block until classify() != WAITING (S5: not atomic with try_pull — re-check after wake).
+  /// External threads only — never from a GPU worker.
   void wait();
 
   // -----------------------------------------------------------------------
-  // Hooks. Both hold one slot, and both fire after unlocking, so a callback may re-enter the
-  // stream. Neither may capture a raw pointer to anything this stream can outlive.
+  // Hooks fire after unlock; may re-enter. Do not capture raw this.
   // -----------------------------------------------------------------------
 
-  /// Fired by every successful `push()`, and by the close that records an error. A consumer that
-  /// found the queue empty has already been dropped by its driver; this is how it gets picked up
-  /// again.
+  /// Fires on every successful push() and on fail() (P4). Not one-shot: a one-shot hook would
+  /// need re-arming, and a push between fire and re-arm would go unannounced.
   void set_on_data(std::function<void()> hook);
 
-  /// Fired when the stream goes terminal. A second registration replaces the first, which then
-  /// never fires. Registering after the stream already ended fires the hook immediately,
-  /// *inside this call*, so a late-wired hook is never lost.
+  /// Replaces prior hook; if already terminal, fires immediately inside this call.
   void set_on_end_of_stream(std::function<void()> hook);
 
   // -----------------------------------------------------------------------
   // Observers (diagnostics / tests)
   // -----------------------------------------------------------------------
 
-  /// True once every expected sender has closed (or an error ended the stream), regardless of
-  /// what is still queued.
+  /// True once every expected sender has closed (or an error ended the stream).
   [[nodiscard]] bool terminal() const;
 
-  /// True when `sender` has already closed.
   [[nodiscard]] bool sender_closed(sender_id_t sender) const;
 
-  /// The queue, still owned by whoever created and registered it.
   [[nodiscard]] const std::shared_ptr<cucascade::shared_data_repository>& repository() const
   {
     return _repo;
@@ -187,7 +122,7 @@ class batch_stream {
   /// A set, not a counter: two closes from sender 0 must not stand in for senders {0, 1}.
   std::set<sender_id_t> _closed;
   bool _terminal{false};
-  /// The producer's failure, if any. First non-null wins; never cleared.
+  /// First non-null wins; never cleared.
   std::exception_ptr _error;
   std::function<void()> _on_data;
   std::function<void()> _on_end_of_stream;

--- a/src/include/op/sirius_physical_operator_type.hpp
+++ b/src/include/op/sirius_physical_operator_type.hpp
@@ -148,7 +148,8 @@ enum class SiriusPhysicalOperatorType : uint8_t {
   GPU_VALUES,
   GPU_SCAN,
   DYNAMIC_FILTER,
-  STREAMING_SOURCE
+  STREAMING_SOURCE,
+  STREAMING_SINK
 };
 
 std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type);

--- a/src/include/op/sirius_physical_streaming_sink.hpp
+++ b/src/include/op/sirius_physical_streaming_sink.hpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "exec/batch_stream.hpp"
+#include "op/sirius_physical_operator.hpp"
+
+#include <cudf/types.hpp>
+
+#include <cucascade/data/data_repository.hpp>
+
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace sirius::op {
+
+/// How a partitioned sink routes rows across its output streams. Destination nodes are the
+/// wrapper's routing table — the sink stays oblivious.
+enum class partition_mode {
+  hash,       ///< GPU-hash-partition by key_columns; key_columns must be non-empty.
+  broadcast,  ///< Replicate every batch to all N outputs; key_columns must be empty.
+};
+
+struct partition_spec {
+  partition_mode mode = partition_mode::hash;
+
+  /// Hashed to pick a destination. Must be non-empty for hash mode; must be empty for broadcast.
+  std::vector<int> key_columns;
+
+  /// Per-key cast before hashing (e.g. INT32 vs INT64). Empty = hash as-is. Ignored in broadcast.
+  std::vector<cudf::data_type> key_cast_types;
+
+  partition_spec() = default;
+
+  /// Hash-mode shorthand: partition_spec({col}, {cast}) without naming the mode.
+  partition_spec(std::vector<int> keys, std::vector<cudf::data_type> casts = {})
+    : key_columns(std::move(keys)), key_cast_types(std::move(casts))
+  {
+  }
+};
+
+/// Fragment terminal: push pipeline output into one batch_stream per destination.
+/// No on_data — consumer blocks in wait(); no channel-level backpressure.
+class sirius_physical_streaming_sink : public sirius_physical_operator {
+ public:
+  static constexpr SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::STREAMING_SINK;
+
+  /// The pipeline feeding this sink is its only sender.
+  static constexpr exec::sender_id_t PIPELINE_SENDER = 0;
+
+  /// Single-destination sink (N = 1): identity push, no partitioning.
+  /// @throws sirius::invalid_input_exception when `output_repository` is null.
+  sirius_physical_streaming_sink(
+    duckdb::vector<sirius::logical_type> types,
+    std::size_t estimated_cardinality,
+    std::shared_ptr<cucascade::shared_data_repository> output_repository);
+
+  /// N destinations: GPU-hash-partition each batch; slice i → output_repositories[i].
+  /// @throws sirius::invalid_input_exception on empty/null repos, N>1 with no keys, cast/key
+  ///         mismatch, or out-of-range key column.
+  sirius_physical_streaming_sink(
+    duckdb::vector<sirius::logical_type> types,
+    std::size_t estimated_cardinality,
+    std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repositories,
+    partition_spec spec);
+
+  bool is_sink() const override { return true; }
+
+  //! Append into operators[] (base sink path skips this). Membership required for finalize/EOS;
+  //! lands at operators.back() after is_ready() reverses.
+  void build_pipelines(pipeline::sirius_pipeline& current,
+                       pipeline::sirius_meta_pipeline& meta_pipeline) override;
+
+  // -----------------------------------------------------------------------
+  // Producer side (engine)
+  // -----------------------------------------------------------------------
+
+  /// Pass-through so sink() sees the batches; base returns empty.
+  std::unique_ptr<operator_data> execute(const operator_data& input_data,
+                                         rmm::cuda_stream_view stream) override;
+
+  /// N=1: native push. N>1: hash-partition; skip empty slices. Refused push = silent drop.
+  void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+
+  /// 0 if N==1; ~2× when partitioned (hash_partition holds reorder + slices).
+  [[nodiscard]] std::size_t no_history_peak_memory_estimate(
+    const input_stats& stats) const override;
+
+  // -----------------------------------------------------------------------
+  // Consumer side (external wrapper / session, never an engine task)
+  // -----------------------------------------------------------------------
+
+  [[nodiscard]] std::size_t num_output_streams() const { return _outputs.size(); }
+
+  /// @return nullopt means nothing now, not EOS — use drained(index).
+  /// @throws sirius::invalid_input_exception when `index` is out of range.
+  /// @throws pending producer error ahead of queued batches (S4).
+  std::optional<std::shared_ptr<cucascade::data_batch>> pull(std::size_t index = 0);
+
+  /// Block until HAS_DATA or ended (S5 with pull: re-check after wake). External threads only.
+  /// @throws sirius::invalid_input_exception when `index` is out of range.
+  void wait(std::size_t index = 0);
+
+  /// Clean end only (S3). Poisoned streams end by rethrow from pull().
+  /// @throws sirius::invalid_input_exception when `index` is out of range.
+  [[nodiscard]] bool drained(std::size_t index = 0) const;
+
+  /// @throws sirius::invalid_input_exception when `index` is out of range.
+  [[nodiscard]] exec::batch_stream::availability availability(std::size_t index = 0) const;
+
+  /// Poison every output stream (S2 / P1–P4). First failure wins. Sink has no on_data — wait()
+  /// wakes via the stream CV.
+  void fail_output(std::exception_ptr error);
+
+ protected:
+  /// Pipeline completion = sender-set EOS (PIPELINE_SENDER).
+  void on_finalize_operator() override;
+
+  /// @throws sirius::invalid_input_exception when `index` is out of range.
+  void validate_index(std::size_t index) const;
+
+  /// One stream per destination; positional with the caller's repository list.
+  std::vector<std::shared_ptr<exec::batch_stream>> _outputs;
+
+  /// Empty key_columns is valid only for N==1 (native push, no hash_partition).
+  partition_spec _spec;
+};
+
+}  // namespace sirius::op

--- a/src/include/op/sirius_physical_streaming_source.hpp
+++ b/src/include/op/sirius_physical_streaming_source.hpp
@@ -28,25 +28,13 @@
 
 namespace sirius::op {
 
-/// The plan leaf for a stream. A scan stands where the plan reads a table; this stands where
-/// there is no table at all — a fragment boundary, fed by whatever another fragment or external
-/// producer pushes in at runtime. Publishes one batch per task, in push order.
-///
-/// While a scan owns its input this source owns nothing and its senders are remote: "empty" means
-/// wait, waiting must not block an engine thread, and the stream ends only once every expected
-/// sender has closed.
-///
-/// The repository is the queue, spillable only if the caller registered it with the memory
-/// manager. `exec::batch_stream` binds it to the stream state: who is still producing, whether
-/// empty means wait or over, and how a producer failure reaches the consumer. The rest is
-/// task-protocol glue over that one stream.
+/// Plan leaf over a batch_stream. Repository IS the queue; sender-set EOS; task-protocol glue.
 class sirius_physical_streaming_source : public sirius_physical_operator {
  public:
   static constexpr SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::STREAMING_SOURCE;
 
   /// @param input_repository The queue this source drains. Must not be null.
-  /// @param expected_senders Every sender that must call `close_input` before the stream ends —
-  ///        `{0}` for a single producer, `{0 … N-1}` for an N-way fan-in.
+  /// @param expected_senders Senders that must `close_input` before EOS.
   /// @throws sirius::invalid_input_exception when `input_repository` is null.
   sirius_physical_streaming_source(
     duckdb::vector<sirius::logical_type> types,
@@ -54,36 +42,26 @@ class sirius_physical_streaming_source : public sirius_physical_operator {
     std::shared_ptr<cucascade::shared_data_repository> input_repository,
     std::set<exec::sender_id_t> expected_senders);
 
-  /// Wires the two pipeline-facing stream hooks. Both fire on a producer thread, outside the
-  /// stream's lock, and both weak-capture the pipeline rather than `this`:
-  ///
-  /// - end-of-stream → `update_pipeline_status(false)`, so a stream that ends with no task in
-  ///   flight still finishes the pipeline *and* re-arms its downstream consumers;
-  /// - on-data → `task_creator::schedule(head)`, the self-nomination described above. Without it
-  ///   a batch that arrives after the source has been dropped is never looked at.
-  ///
-  /// A stream that has *already* ended fires the first hook inside this call.
+  /// Wire EOS → update_pipeline_status(false); on_data → schedule(head) (self-nomination).
+  /// Without on_data, a WAITING source stays dropped until a task completes — which never happens.
   void set_pipeline(duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline) override;
 
   // -----------------------------------------------------------------------
-  // Producer side — called by the session / wrapper, from any thread
+  // Producer side — session / wrapper, any thread
   // -----------------------------------------------------------------------
 
-  /// Register `batch` in the input repository, then fire `on_data`.
-  /// @return false when the stream already ended and the batch was refused.
-  bool push(std::shared_ptr<cucascade::data_batch> batch);
+  /// @return false if terminal (S1). Ignoring the return silently drops the batch.
+  [[nodiscard]] bool push(std::shared_ptr<cucascade::data_batch> batch);
 
-  /// Record that `sender` has finished producing cleanly. Idempotent per sender; the stream ends
-  /// only once every expected sender has closed.
-  /// @throws sirius::invalid_input_exception when `sender` is not an expected sender.
+  /// Sender-set EOS: idempotent per sender.
+  /// @throws sirius::invalid_input_exception when `sender` is not expected.
   void close_input(exec::sender_id_t sender);
 
-  /// A producer failed: poison the input stream. It ends immediately, and the failure is
-  /// rethrown out of `get_next_task_input_data()` — never a clean end-of-stream.
+  /// Poison the input stream (S2 / P1–P4); rethrown from get_next_task_input_data(), never a
+  /// clean EOS.
   /// @throws sirius::invalid_input_exception when `error` is null.
   void fail_input(std::exception_ptr error);
 
-  /// The input stream, for the session and for diagnostics.
   [[nodiscard]] exec::batch_stream& stream() { return *_input; }
 
   // -----------------------------------------------------------------------
@@ -92,39 +70,30 @@ class sirius_physical_streaming_source : public sirius_physical_operator {
 
   bool is_source() const override { return true; }
 
-  /// `READY{this}` when a batch is queued (open or ended); `WAITING{nullptr}` when open and empty;
-  /// `nullopt` at end-of-stream. The `nullptr` producer is deliberate — there is no upstream
-  /// operator for `task_creator` to redirect the request to.
+  /// READY on HAS_DATA (incl. pending error / P4); WAITING_FOR_INPUT_DATA{nullptr} while
+  /// open+empty; nullopt only at clean EOS.
   [[nodiscard]] std::optional<task_creation_hint> get_next_task_hint() override;
 
-  /// True only at a clean end-of-stream: every expected sender closed, queue empty, no producer
-  /// error pending. Drives the task-creation guard and the port-less pipeline-finish predicate,
-  /// so an errored stream is never mistaken for a finished one — it ends by the rethrow out of
-  /// `get_next_task_input_data()`.
+  /// Clean EOS only (S3). Drives task-creation and port-less pipeline-finish.
   [[nodiscard]] bool all_ports_empty() override;
 
-  /// Non-blocking: pop one batch and wrap it in a `pipelineable_operator_data`.
-  /// Returns nullptr when nothing is queued.
-  /// @throws the producer's error, if one is pending, ahead of anything still queued.
+  /// Pop one batch. @throws pending producer error before anything queued (S4).
   std::unique_ptr<operator_data> get_next_task_input_data() override;
 
   // -----------------------------------------------------------------------
   // Execution
   // -----------------------------------------------------------------------
 
-  /// Pass-through: the sender already materialized these batches; the task only routes them
-  /// downstream.
+  /// Pass-through: batches are already materialized.
   std::unique_ptr<operator_data> execute(const operator_data& input,
                                          rmm::cuda_stream_view stream) override;
 
-  /// Pass-through allocates nothing new; return input bytes so the reservation system
-  /// does not over-reserve with the default 2× heuristic.
+  /// Pass-through: return input bytes so the default 2× heuristic does not over-reserve.
   [[nodiscard]] std::size_t no_history_peak_memory_estimate(
     const input_stats& stats) const override;
 
  private:
-  /// Shared: producer threads co-own it, so the stream they push and close through outlives
-  /// this operator exactly as the repository already did.
+  /// Shared so producer threads co-own the stream past this operator.
   std::shared_ptr<exec::batch_stream> _input;
 };
 

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -186,6 +186,10 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! Checks if the pipeline has been finished
   virtual bool is_pipeline_finished() const;
 
+  //! Query-terminal sink (RESULT_COLLECTOR or STREAMING_SINK): no downstream schedule/wiring;
+  //! completion signals execute().
+  [[nodiscard]] bool is_query_terminal() const;
+
   void mark_task_created();
   void mark_task_completed();
 
@@ -196,10 +200,8 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! Set the task_creator pointer so this pipeline can schedule downstream consumers on finish.
   void set_task_creator(sirius::creator::task_creator* tc);
 
-  //! The task_creator this pipeline schedules through, or nullptr when none is wired (tests,
-  //! or a pipeline built before the executor attached). Used by streaming sources to re-arm a
-  //! starved head from a producer thread; schedule() only touches the thread-safe creation
-  //! queue, so calling it off-thread is safe.
+  //! task_creator for schedule(), or nullptr when unwired. Streaming sources use this to
+  //! re-arm a starved head; schedule() only enqueues, so off-thread calls are safe.
   [[nodiscard]] sirius::creator::task_creator* get_task_creator() const noexcept
   {
     return _task_creator;

--- a/src/op/sirius_physical_operator_type.cpp
+++ b/src/op/sirius_physical_operator_type.cpp
@@ -115,6 +115,7 @@ std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type)
     case SiriusPhysicalOperatorType::GPU_SCAN: return "GPU_SCAN";
     case SiriusPhysicalOperatorType::DYNAMIC_FILTER: return "DYNAMIC_FILTER";
     case SiriusPhysicalOperatorType::STREAMING_SOURCE: return "STREAMING_SOURCE";
+    case SiriusPhysicalOperatorType::STREAMING_SINK: return "STREAMING_SINK";
     case SiriusPhysicalOperatorType::INVALID: break;
   }
   return "INVALID";

--- a/src/op/sirius_physical_streaming_sink.cpp
+++ b/src/op/sirius_physical_streaming_sink.cpp
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_physical_streaming_sink.hpp"
+
+#include "data/data_batch_utils.hpp"
+#include "op/partition/gpu_partition_impl.hpp"
+#include "pipeline/sirius_meta_pipeline.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "sirius/exception.hpp"
+
+#include <cucascade/data/data_batch.hpp>
+
+#include <exception>
+#include <set>
+#include <string>
+#include <utility>
+
+namespace sirius::op {
+
+namespace {
+
+/// A refused push means the output stream went terminal while this fragment was still
+/// producing — either `close()` saw every sender finish, or a peer called `fail()`. Dropping
+/// the batch would silently shorten the consumer's result, so poison the stream instead: the
+/// consumer then learns about it from `try_pull()`'s rethrow rather than by noticing rows that
+/// never arrived. `fail()` is first-failure-wins (P2), so this never displaces a real cause.
+void poison_refused_output(exec::batch_stream& output, std::size_t index)
+{
+  output.fail(std::make_exception_ptr(sirius::internal_exception(
+    "sirius_physical_streaming_sink: output stream " + std::to_string(index) +
+    " refused a batch after end-of-stream; the fragment produced data after its output closed")));
+}
+
+}  // namespace
+
+sirius_physical_streaming_sink::sirius_physical_streaming_sink(
+  duckdb::vector<sirius::logical_type> types,
+  std::size_t estimated_cardinality,
+  std::shared_ptr<cucascade::shared_data_repository> output_repository)
+  : sirius_physical_operator(
+      SiriusPhysicalOperatorType::STREAMING_SINK, std::move(types), estimated_cardinality)
+{
+  if (!output_repository) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_sink: output_repository must not be null");
+  }
+  _outputs.push_back(std::make_shared<exec::batch_stream>(
+    std::move(output_repository), std::set<exec::sender_id_t>{PIPELINE_SENDER}));
+}
+
+sirius_physical_streaming_sink::sirius_physical_streaming_sink(
+  duckdb::vector<sirius::logical_type> types,
+  std::size_t estimated_cardinality,
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repositories,
+  partition_spec spec)
+  : sirius_physical_operator(
+      SiriusPhysicalOperatorType::STREAMING_SINK, std::move(types), estimated_cardinality),
+    _spec(std::move(spec))
+{
+  if (output_repositories.empty()) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_sink: at least one output repository is required");
+  }
+  for (std::size_t i = 0; i < output_repositories.size(); ++i) {
+    if (!output_repositories[i]) {
+      throw sirius::invalid_input_exception("sirius_physical_streaming_sink: output repository " +
+                                            std::to_string(i) + " must not be null");
+    }
+  }
+  if (_spec.mode == partition_mode::hash && output_repositories.size() > 1 &&
+      _spec.key_columns.empty()) {
+    throw sirius::invalid_input_exception("sirius_physical_streaming_sink: hash mode with " +
+                                          std::to_string(output_repositories.size()) +
+                                          " destinations requires at least one key column");
+  }
+  if (_spec.mode == partition_mode::broadcast && !_spec.key_columns.empty()) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_sink: broadcast mode must have no key columns (routing is "
+      "replication, not hashing)");
+  }
+  // Fail here: bad cast list / key index is device-side UB in hash_partition.
+  if (!_spec.key_cast_types.empty() && _spec.key_cast_types.size() != _spec.key_columns.size()) {
+    throw sirius::invalid_input_exception(
+      "sirius_physical_streaming_sink: partition_spec has " +
+      std::to_string(_spec.key_cast_types.size()) + " cast types for " +
+      std::to_string(_spec.key_columns.size()) + " key columns; expected none or one per key");
+  }
+  // `this->types` — the ctor parameter of the same name has been moved from by now.
+  const auto num_columns = this->types.size();
+  for (auto key : _spec.key_columns) {
+    if (key < 0 || static_cast<std::size_t>(key) >= num_columns) {
+      throw sirius::invalid_input_exception(
+        "sirius_physical_streaming_sink: partition key column " + std::to_string(key) +
+        " is out of range for a " + std::to_string(num_columns) + "-column input");
+    }
+  }
+  for (auto& repo : output_repositories) {
+    _outputs.push_back(std::make_shared<exec::batch_stream>(
+      std::move(repo), std::set<exec::sender_id_t>{PIPELINE_SENDER}));
+  }
+}
+
+std::unique_ptr<operator_data> sirius_physical_streaming_sink::execute(
+  const operator_data& input_data, rmm::cuda_stream_view /*stream*/)
+{
+  // Match RESULT_COLLECTOR: return batches for sink().
+  return std::make_unique<pipelineable_operator_data>(
+    dynamic_cast<const pipelineable_operator_data&>(input_data).get_read_only_batches());
+}
+
+void sirius_physical_streaming_sink::sink(const operator_data& input_data,
+                                          rmm::cuda_stream_view stream)
+{
+  const auto& input = dynamic_cast<const pipelineable_operator_data&>(input_data);
+
+  if (_outputs.size() == 1) {
+    for (const auto& batch : input.get_data_batches()) {
+      if (!_outputs[0]->push(batch)) { poison_refused_output(*_outputs[0], 0); }
+    }
+    return;
+  }
+
+  if (_spec.mode == partition_mode::broadcast) {
+    // Output 0 gets the original handle (zero-copy); outputs 1..N-1 each get an independent
+    // deep copy in the batch's current memory space so destinations cannot race over one handle's
+    // residency. Clones first so output 0's push does not advance the stream's terminal state
+    // before the copies are made.
+    const auto& batches  = input.get_data_batches();
+    const auto read_only = input.get_read_only_batches();
+    for (std::size_t b = 0; b < batches.size(); ++b) {
+      for (std::size_t i = 1; i < _outputs.size(); ++i) {
+        // clone()'s probe argument defaults to a no-op, so an omitted probe silently drops the
+        // clone from quent. Bind the id and the probe together, as PARTITION does.
+        const auto clone_batch_id = sirius::get_next_batch_id();
+        auto copy                 = read_only[b].clone(
+          clone_batch_id,
+          stream,
+          telemetry::quent_data_batch_probe::create(batch_telemetry(), clone_batch_id));
+        if (!_outputs[i]->push(std::move(copy))) { poison_refused_output(*_outputs[i], i); }
+      }
+      if (!_outputs[0]->push(batches[b])) { poison_refused_output(*_outputs[0], 0); }
+    }
+    return;
+  }
+
+  const auto num_partitions = static_cast<int>(_outputs.size());
+  for (const auto& input_batch : input.get_read_only_batches()) {
+    auto* space = input_batch.get_memory_space();
+    if (space == nullptr) {
+      throw sirius::internal_exception(
+        "sirius_physical_streaming_sink: partitioned sink requires a resident input batch");
+    }
+
+    // Same kernel as PARTITION; routing only.
+    auto slices = gpu_partition_impl::hash_partition(input_batch,
+                                                     _spec.key_columns,
+                                                     _spec.key_cast_types,
+                                                     num_partitions,
+                                                     stream,
+                                                     *space,
+                                                     batch_telemetry());
+
+    for (std::size_t i = 0; i < slices.size(); ++i) {
+      // Empty partition stays WAITING until finalize.
+      if (sirius::get_cudf_table_view(*slices[i]).num_rows() == 0) { continue; }
+      if (!_outputs[i]->push(slices[i])) { poison_refused_output(*_outputs[i], i); }
+    }
+  }
+}
+
+std::size_t sirius_physical_streaming_sink::no_history_peak_memory_estimate(
+  const input_stats& stats) const
+{
+  // Single destination pushes the input handle through untouched.
+  if (_outputs.size() == 1) { return 0; }
+  // Broadcast holds the original plus one clone per extra destination, and each one stays
+  // resident until its own repository drains — so the whole fan-out is live at once, not 2×.
+  if (_spec.mode == partition_mode::broadcast) { return stats.bytes * _outputs.size(); }
+  // Hash holds hash_partition's reorder buffer alongside the slices it produces.
+  return stats.bytes * 2;
+}
+
+void sirius_physical_streaming_sink::build_pipelines(pipeline::sirius_pipeline& current,
+                                                     pipeline::sirius_meta_pipeline& meta_pipeline)
+{
+  // children[] is producers, not outputs (Volcano/DuckDB orientation): a sink consumes exactly
+  // one producing subtree.
+  if (children.size() != 1) {
+    throw sirius::internal_exception(
+      "sirius_physical_streaming_sink: expects exactly one producer child subtree");
+  }
+
+  // operators[] membership required for finalize/EOS (like RESULT_COLLECTOR).
+  auto& state = meta_pipeline.get_state();
+  state.add_pipeline_operator(current, *this);
+
+  auto& child_meta_pipeline = meta_pipeline.create_child_meta_pipeline(current, *this);
+  child_meta_pipeline.build(*children[0]);
+}
+
+void sirius_physical_streaming_sink::on_finalize_operator()
+{
+  // Pipeline completion = sender-set EOS (PIPELINE_SENDER).
+  for (auto& s : _outputs) {
+    s->close(PIPELINE_SENDER);
+  }
+}
+
+void sirius_physical_streaming_sink::validate_index(std::size_t index) const
+{
+  if (index >= _outputs.size()) {
+    throw sirius::invalid_input_exception("sirius_physical_streaming_sink: output stream index " +
+                                          std::to_string(index) + " out of range (" +
+                                          std::to_string(_outputs.size()) + " streams)");
+  }
+}
+
+std::optional<std::shared_ptr<cucascade::data_batch>> sirius_physical_streaming_sink::pull(
+  std::size_t index)
+{
+  validate_index(index);
+  auto batch = _outputs[index]->try_pull();
+  if (!batch) { return std::nullopt; }
+  return batch;
+}
+
+void sirius_physical_streaming_sink::wait(std::size_t index)
+{
+  validate_index(index);
+  _outputs[index]->wait();
+}
+
+bool sirius_physical_streaming_sink::drained(std::size_t index) const
+{
+  validate_index(index);
+  return _outputs[index]->drained();
+}
+
+exec::batch_stream::availability sirius_physical_streaming_sink::availability(
+  std::size_t index) const
+{
+  validate_index(index);
+  return _outputs[index]->classify();
+}
+
+void sirius_physical_streaming_sink::fail_output(std::exception_ptr error)
+{
+  for (auto& s : _outputs) {
+    s->fail(error);
+  }
+}
+
+}  // namespace sirius::op

--- a/src/op/sirius_physical_streaming_source.cpp
+++ b/src/op/sirius_physical_streaming_source.cpp
@@ -49,18 +49,16 @@ void sirius_physical_streaming_source::set_pipeline(
 {
   sirius_physical_operator::set_pipeline(pipeline);
 
-  // Weak, because `_pipeline` already owns it for this operator's lifetime and both callbacks
-  // fire on producer threads.
+  // Weak: callbacks run on producer threads.
   duckdb::weak_ptr<pipeline::sirius_pipeline> weak_pipeline = pipeline;
 
-  // An empty or late-closed stream finishes the pipeline with no task in flight to do it.
-  // `original_pipeline=false` so downstream consumers are re-armed as well.
+  // Empty/late-closed stream finishes with no task in flight; original_pipeline=false re-arms
+  // downstream consumers.
   _input->set_on_end_of_stream([weak_pipeline] {
     if (auto p = weak_pipeline.lock()) { p->update_pipeline_status(false); }
   });
 
-  // Self-nomination — see the class comment for why nothing else will ask this source again.
-  // schedule() just enqueues, so firing it from a producer thread is safe.
+  // Self-nomination (on_data → schedule(head)); schedule() only enqueues.
   _input->set_on_data([weak_pipeline] {
     auto p = weak_pipeline.lock();
     if (!p) { return; }
@@ -100,7 +98,6 @@ bool sirius_physical_streaming_source::all_ports_empty() { return _input->draine
 
 std::unique_ptr<operator_data> sirius_physical_streaming_source::get_next_task_input_data()
 {
-  // Rethrows a producer error: the task that asked for work carries the failure out.
   auto batch = _input->try_pull();
   if (!batch) return nullptr;
 
@@ -118,7 +115,7 @@ std::unique_ptr<operator_data> sirius_physical_streaming_source::execute(
 std::size_t sirius_physical_streaming_source::no_history_peak_memory_estimate(
   const input_stats& stats) const
 {
-  // Nothing new is allocated, so the default 2x would over-reserve under memory pressure.
+  // Pass-through: avoid default 2× reserve.
   return stats.bytes;
 }
 

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -445,11 +445,8 @@ void gpu_pipeline_executor::manager_loop()
         // which may destroy the engine and its operators. We must not schedule
         // tasks that reference those operators after signaling completion.
         bool query_complete = false;
-        if (_completion_handler && pipeline) {
-          auto sink = pipeline->get_sink();
-          if (sink && sink->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
-            query_complete = pipeline->is_pipeline_finished();
-          }
+        if (_completion_handler && pipeline && pipeline->is_query_terminal()) {
+          query_complete = pipeline->is_pipeline_finished();
         }
 
         if (!query_complete && _task_creator) {

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -337,17 +337,20 @@ bool sirius_pipeline::is_pipeline_finished() const
   return pipeline_finished.load();
 }
 
+bool sirius_pipeline::is_query_terminal() const
+{
+  auto s = get_sink();
+  if (!s) { return false; }
+  return s->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR ||
+         s->type == op::SiriusPhysicalOperatorType::STREAMING_SINK;
+}
+
 void sirius_pipeline::set_task_creator(sirius::creator::task_creator* tc) { _task_creator = tc; }
 
 void sirius_pipeline::notify_downstream_pipelines(bool original_pipeline)
 {
-  // If this pipeline's sink is the RESULT_COLLECTOR, it is the terminal
-  // pipeline of the query — there is no downstream consumer to schedule and
-  // no parent pipeline whose status needs updating. Returning early avoids
-  // racing with engine teardown after mark_completed() signals the future.
-  if (auto s = get_sink(); s && s->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
-    return;
-  }
+  // Query-terminal: no downstream; early return avoids teardown race after mark_completed().
+  if (is_query_terminal()) { return; }
 
   // Schedule output consumers via the task_creator so downstream pipelines
   // whose FULL-barrier ports are now unblocked will get tasks created.

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -284,8 +284,8 @@ void sirius_pipeline_converter::compute_repository_wiring(sirius_pipeline_build_
 
     using T = op::SiriusPhysicalOperatorType;
 
-    // RESULT_COLLECTOR is a terminal sink — nothing to emit.
-    if (sink_op->type == T::RESULT_COLLECTOR) { continue; }
+    // Query-terminal: no wiring. is_query_terminal() shared with notify_downstream / executor.
+    if (pipeline->is_query_terminal()) { continue; }
 
     // CTE fans out to its sibling `cte_scans` (parent_op alone doesn't encode them).
     // CTE_SCAN never lands in any pipeline's operators[], so consumers resolve via

--- a/test/cpp/exec/test_batch_stream.cpp
+++ b/test/cpp/exec/test_batch_stream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Sirius Contributors.
+ * Copyright 2026, Sirius Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -261,7 +261,7 @@ TEST_CASE("batch_stream BSTR-6: wait unblocks on a push and on the final close",
 }
 
 // ============================================================================
-// BSTR-7: fail() is immediate, fail-fast terminal, and first-wins (S2 / P1–P3)
+// BSTR-7: fail() is immediate, fail-fast terminal, and first-wins (P1–P3)
 // ============================================================================
 
 TEST_CASE("batch_stream BSTR-7: fail() poisons the stream at once", "[batch_stream]")
@@ -315,7 +315,7 @@ TEST_CASE("batch_stream BSTR-8: try_pull rethrows ahead of queued batches", "[ba
 }
 
 // ============================================================================
-// BSTR-9: the poison announces itself like data (S2 / P4)
+// BSTR-9: the poison announces itself like data (S2 / P4 — on_data + HAS_DATA)
 // ============================================================================
 
 TEST_CASE("batch_stream BSTR-9: fail() wakes the consumer and reads as HAS_DATA", "[batch_stream]")
@@ -490,8 +490,8 @@ TEST_CASE("batch_stream BSTR-15: push registers before it wakes", "[batch_stream
   bool seen_registered = false;
   stream->set_on_data([&, repo = repo] { seen_registered = repo->total_size() > 0; });
 
-  // Register-then-announce. A waker that ran first would schedule a task for a batch not yet
-  // in the repository, and the task's pop would come back empty.
+  // S1 — register-then-announce. An on_data hook that ran first would schedule a task for a
+  // batch not yet in the repository, and the task's pop would come back empty.
   REQUIRE(stream->push(make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32)));
   REQUIRE(seen_registered);
 }

--- a/test/cpp/operator/test_physical_streaming_sink.cpp
+++ b/test/cpp/operator/test_physical_streaming_sink.cpp
@@ -1,0 +1,837 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator_test_utils.hpp"
+
+#include <catch.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <data/data_batch_utils.hpp>
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <exec/batch_stream.hpp>
+#include <expression/ast/from_duckdb.hpp>
+#include <helper/type_conversions.hpp>
+#include <op/sirius_physical_filter.hpp>
+#include <op/sirius_physical_streaming_sink.hpp>
+#include <op/sirius_physical_streaming_source.hpp>
+#include <sirius/exception.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <set>
+#include <thread>
+#include <utility>
+#include <vector>
+
+using namespace sirius::exec;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+using namespace std::chrono_literals;
+
+namespace {
+
+using namespace sirius::test::operator_utils;
+
+using availability = batch_stream::availability;
+
+/// Single-destination sink over a fresh output repository.
+auto make_sink()
+{
+  auto repo = std::make_shared<cucascade::shared_data_repository>();
+  auto op   = std::make_unique<sirius_physical_streaming_sink>(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    repo);
+  return std::make_tuple(std::move(op), repo);
+}
+
+/// Partitioned sink over `n` fresh output repositories, routing on column 0.
+auto make_partitioned_sink(std::size_t n)
+{
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos;
+  for (std::size_t i = 0; i < n; ++i) {
+    repos.push_back(std::make_shared<cucascade::shared_data_repository>());
+  }
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  auto op = std::make_unique<sirius_physical_streaming_sink>(
+    sirius::from_duckdb_vec(types), 0, repos, partition_spec{{0}, {}});
+  return std::make_tuple(std::move(op), repos);
+}
+
+/// Broadcast sink over `n` fresh output repositories. Same column layout as the partitioned
+/// helper so the two can share row builders; broadcast takes no key columns.
+auto make_broadcast_sink(std::size_t n)
+{
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos;
+  for (std::size_t i = 0; i < n; ++i) {
+    repos.push_back(std::make_shared<cucascade::shared_data_repository>());
+  }
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  partition_spec spec;
+  spec.mode = partition_mode::broadcast;
+  auto op   = std::make_unique<sirius_physical_streaming_sink>(
+    sirius::from_duckdb_vec(types), 0, repos, spec);
+  return std::make_tuple(std::move(op), repos);
+}
+
+/// Feed one batch through the sink exactly as publish_output() would.
+void sink_one(sirius_physical_streaming_sink& op, std::shared_ptr<cucascade::data_batch> batch)
+{
+  pipelineable_operator_data data{
+    std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(batch)}};
+  op.sink(data, default_stream());
+}
+
+/// Drain output stream `index` completely, returning the (key, payload) rows it held.
+std::vector<std::pair<int64_t, int32_t>> drain_rows(sirius_physical_streaming_sink& op,
+                                                    std::size_t index)
+{
+  std::vector<std::pair<int64_t, int32_t>> rows;
+  while (auto batch = op.pull(index)) {
+    auto view = sirius::get_cudf_table_view(**batch);
+    auto keys = copy_column_to_host<int64_t>(view.column(0));
+    auto vals = copy_column_to_host<int32_t>(view.column(1));
+    REQUIRE(keys.size() == vals.size());
+    for (std::size_t i = 0; i < keys.size(); ++i) {
+      rows.emplace_back(keys[i], vals[i]);
+    }
+  }
+  return rows;
+}
+
+}  // namespace
+
+// ============================================================================
+// SNK-1: sink() publishes exactly the batches it was given, natively
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-1: sunk batches appear in the output repository in order",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr int K = 4;
+  auto [op, repo] = make_sink();
+
+  std::vector<uint64_t> pushed_ids;
+  for (int i = 0; i < K; ++i) {
+    auto batch = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    pushed_ids.push_back(batch->get_batch_id());
+    sink_one(*op, batch);
+  }
+
+  REQUIRE(repo->total_size() == K);
+
+  // Pointer identity end-to-end: the sink pushed the batch itself, not a copy or a conversion.
+  std::vector<uint64_t> pulled_ids;
+  while (auto batch = op->pull()) {
+    pulled_ids.push_back((*batch)->get_batch_id());
+  }
+  REQUIRE(pulled_ids == pushed_ids);
+  REQUIRE(repo->total_size() == 0);
+}
+
+// ============================================================================
+// SNK-2: end-of-stream is never reported while the pipeline is still running
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-2: an open sink is WAITING or HAS_DATA, never EOS",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repo] = make_sink();
+
+  // Open + empty: more output may still arrive — the consumer must not conclude EOS.
+  REQUIRE(op->availability() == availability::WAITING);
+  REQUIRE_FALSE(op->drained());
+  REQUIRE_FALSE(op->pull().has_value());
+
+  sink_one(*op, make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32));
+  REQUIRE(op->availability() == availability::HAS_DATA);
+  REQUIRE_FALSE(op->drained());
+}
+
+// ============================================================================
+// SNK-3: finalize is end-of-stream; queued output still outranks it
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-3: finalize drives EOS only once the output is drained",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repo] = make_sink();
+  sink_one(*op, make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32));
+
+  op->finalize_operator();
+
+  // Terminal, but the accepted batch is still pullable — data wins over EOS (classify()).
+  REQUIRE(op->availability() == availability::HAS_DATA);
+  REQUIRE_FALSE(op->drained());
+
+  REQUIRE(op->pull().has_value());
+  REQUIRE(op->availability() == availability::END_OF_STREAM);
+  REQUIRE(op->drained());
+  REQUIRE_FALSE(op->pull().has_value());
+}
+
+// ============================================================================
+// SNK-4: an empty fragment reaches EOS on finalize alone
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-4: a fragment that produced nothing still reaches EOS",
+          "[streaming_sink]")
+{
+  auto [op, repo] = make_sink();
+
+  REQUIRE_FALSE(op->drained());
+  op->finalize_operator();
+  REQUIRE(op->drained());
+  REQUIRE(op->availability() == availability::END_OF_STREAM);
+}
+
+// ============================================================================
+// SNK-5: no output is accepted after end-of-stream
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-5: sink after finalize poisons the stream", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repo] = make_sink();
+  op->finalize_operator();
+
+  // A late batch must not land behind a consumer that already observed END_OF_STREAM. It is
+  // still refused, but producing after the output closed is a fragment defect, so the consumer
+  // is told rather than quietly handed a short result.
+  sink_one(*op, make_numeric_batch<int32_t>(*gpu_space, {99}, cudf::type_id::INT32));
+  REQUIRE(repo->total_size() == 0);
+  // An errored stream never reports a clean end (S3); the cause surfaces from pull().
+  REQUIRE_FALSE(op->drained());
+  REQUIRE_THROWS(op->pull());
+}
+
+// ============================================================================
+// SNK-6: wait() unblocks on a sunk batch
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-6: wait unblocks when the pipeline produces", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repo] = make_sink();
+  auto batch      = make_numeric_batch<int32_t>(*gpu_space, {5}, cudf::type_id::INT32);
+  std::atomic<bool> returned{false};
+
+  std::thread consumer([&] {
+    op->wait();
+    returned = true;
+  });
+
+  std::this_thread::sleep_for(20ms);
+  REQUIRE_FALSE(returned.load());
+
+  sink_one(*op, batch);
+  consumer.join();
+
+  REQUIRE(returned.load());
+  REQUIRE(op->pull().has_value());
+}
+
+// ============================================================================
+// SNK-7: wait() unblocks on finalize of an empty stream
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-7: wait unblocks on end-of-stream", "[streaming_sink]")
+{
+  auto [op, repo] = make_sink();
+  std::atomic<bool> returned{false};
+
+  std::thread consumer([&] {
+    op->wait();
+    returned = true;
+  });
+
+  std::this_thread::sleep_for(20ms);
+  REQUIRE_FALSE(returned.load());
+
+  op->finalize_operator();
+  consumer.join();
+
+  REQUIRE(returned.load());
+  REQUIRE(op->drained());
+}
+
+// ============================================================================
+// SNK-8: construction and addressing contracts
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-8: null repository and out-of-range index are rejected",
+          "[streaming_sink]")
+{
+  auto types =
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER});
+
+  REQUIRE_THROWS_AS(sirius_physical_streaming_sink(types, 0, nullptr),
+                    sirius::invalid_input_exception);
+
+  auto [op, repo] = make_sink();
+  REQUIRE(op->num_output_streams() == 1);
+  REQUIRE(op->is_sink());
+  REQUIRE_THROWS_AS(op->pull(1), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(op->drained(1), sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// SNK-9: the memory estimate reports no additional peak
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-9: memory estimate follows the routing mode", "[streaming_sink]")
+{
+  input_stats stats;
+  stats.bytes       = 4096;
+  stats.num_batches = 2;
+
+  SECTION("single destination allocates nothing on top of the input")
+  {
+    auto [op, repo] = make_sink();
+    // The caller maxes this across the pipeline.
+    REQUIRE(op->no_history_peak_memory_estimate(stats) == 0);
+  }
+
+  SECTION("hash holds the reorder buffer alongside the slices")
+  {
+    auto [op, repos] = make_partitioned_sink(4);
+    REQUIRE(op->no_history_peak_memory_estimate(stats) == stats.bytes * 2);
+  }
+
+  SECTION("broadcast holds the original plus one clone per extra destination")
+  {
+    // All N stay resident until their own repository drains, so the peak scales with N — a
+    // flat 2× under-reserves for N > 2.
+    for (std::size_t n : {2, 3, 8}) {
+      auto [op, repos] = make_broadcast_sink(n);
+      REQUIRE(op->no_history_peak_memory_estimate(stats) == stats.bytes * n);
+    }
+  }
+}
+
+// ============================================================================
+// SNK-10: source → filter → sink round-trip over native batches.
+// ============================================================================
+
+TEST_CASE("streaming_sink SNK-10: source to filter to sink round-trips native batches",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream = default_stream();
+
+  auto source_repo = std::make_shared<cucascade::shared_data_repository>();
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  sirius_physical_streaming_source source(
+    sirius::from_duckdb_vec(types), 0, source_repo, std::set<sender_id_t>{0});
+
+  auto [sink, sink_repo] = make_sink();
+
+  // col0 = filter key (int64), col1 = int32 payload.
+  std::vector<int64_t> filter_col{1, 5, 2, 8, 3};
+  std::vector<int32_t> data_col{10, 50, 20, 80, 30};
+  auto batch =
+    make_two_column_batch<int64_t, int32_t>(*gpu_space, filter_col, data_col, cudf::type_id::INT32);
+
+  REQUIRE(source.push(batch));
+  source.close_input(0);
+
+  // FILTER: col0 > 3.
+  auto filter_expr_duck = duckdb::make_uniq<duckdb::BoundComparisonExpression>(
+    duckdb::ExpressionType::COMPARE_GREATERTHAN,
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(
+      duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), 0),
+    duckdb::make_uniq<duckdb::BoundConstantExpression>(duckdb::Value::BIGINT(3)));
+  sirius_physical_filter filter_op(
+    sirius::from_duckdb_vec(types), sirius::ast::from_duckdb(*filter_expr_duck), 0);
+
+  // Drive the fragment: source → filter → sink, one task per batch.
+  while (true) {
+    auto hint = source.get_next_task_hint();
+    if (!hint.has_value()) break;  // EOS
+    REQUIRE(hint->hint == TaskCreationHint::READY);
+
+    auto input = source.get_next_task_input_data();
+    REQUIRE(input != nullptr);
+    auto source_out = source.execute(*input, stream);
+    auto filter_out = filter_op.execute(*source_out, stream);
+    sink->sink(*filter_out, stream);
+  }
+  sink->finalize_operator();
+
+  // The consumer sees exactly the filtered rows, and then a clean end-of-stream.
+  auto out = sink->pull();
+  REQUIRE(out.has_value());
+
+  auto view       = sirius::get_cudf_table_view(**out);
+  auto res_filter = copy_column_to_host<int64_t>(view.column(0));
+  auto res_data   = copy_column_to_host<int32_t>(view.column(1));
+  REQUIRE(res_filter == std::vector<int64_t>{5, 8});
+  REQUIRE(res_data == std::vector<int32_t>{50, 80});
+
+  REQUIRE(sink->drained());
+  REQUIRE(sink->availability() == availability::END_OF_STREAM);
+}
+
+// ============================================================================
+// SINK-ERR-1: fail_output() unblocks wait() and rethrows (S2 via CV; sink has no on_data).
+// ============================================================================
+
+TEST_CASE("streaming_sink SINK-ERR-1: fail_output unblocks wait and rethrows in pull",
+          "[streaming_sink]")
+{
+  auto [op, repo] = make_sink();
+  std::atomic<bool> returned{false};
+
+  std::thread consumer([&] {
+    op->wait();
+    returned = true;
+  });
+
+  std::this_thread::sleep_for(20ms);
+  REQUIRE_FALSE(returned.load());
+
+  auto err = std::make_exception_ptr(std::runtime_error("query failed"));
+  op->fail_output(err);
+  consumer.join();
+
+  REQUIRE(returned.load());
+  // pull() rethrows the injected error — never a quiet clean end.
+  REQUIRE_THROWS_AS(op->pull(), std::runtime_error);
+}
+
+// ============================================================================
+// SINK-ERR-2: errored stream never reports clean end (S3).
+// ============================================================================
+
+TEST_CASE("streaming_sink SINK-ERR-2: errored stream never reports clean end", "[streaming_sink]")
+{
+  auto [op, repo] = make_sink();
+
+  auto err = std::make_exception_ptr(std::runtime_error("query failed"));
+  op->fail_output(err);
+
+  // A pending error reads as HAS_DATA (P4): the consumer comes back to collect the rethrow.
+  REQUIRE(op->availability() == availability::HAS_DATA);
+  // drained() stays false: the error is never consumed, so EOS is never a clean end.
+  REQUIRE_FALSE(op->drained());
+}
+
+// ============================================================================
+// PART-1: fan-out routes every row to exactly one destination, losing nothing
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-1: partitioned fan-out preserves every row exactly once",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  const std::size_t N = GENERATE(std::size_t{2}, std::size_t{3});
+  auto [op, repos]    = make_partitioned_sink(N);
+  REQUIRE(op->num_output_streams() == N);
+
+  // Three batches of distinct keys, so the union across destinations is the whole input.
+  std::vector<std::pair<int64_t, int32_t>> expected;
+  for (int b = 0; b < 3; ++b) {
+    std::vector<int64_t> keys;
+    std::vector<int32_t> vals;
+    for (int i = 0; i < 8; ++i) {
+      const auto key = static_cast<int64_t>(b * 8 + i);
+      keys.push_back(key);
+      vals.push_back(static_cast<int32_t>(key * 10));
+      expected.emplace_back(key, static_cast<int32_t>(key * 10));
+    }
+    sink_one(*op,
+             make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  }
+  op->finalize_operator();
+
+  std::vector<std::pair<int64_t, int32_t>> seen;
+  for (std::size_t i = 0; i < N; ++i) {
+    auto rows = drain_rows(*op, i);
+    seen.insert(seen.end(), rows.begin(), rows.end());
+  }
+
+  std::sort(seen.begin(), seen.end());
+  std::sort(expected.begin(), expected.end());
+  REQUIRE(seen == expected);
+}
+
+// ============================================================================
+// PART-2: equal keys are co-located — the property a shuffle actually needs
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-2: rows with the same key land on the same destination",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 3;
+  auto [op, repos]        = make_partitioned_sink(N);
+
+  // The same four keys, repeated across two separate batches (i.e. two separate tasks).
+  const std::vector<int64_t> keys{100, 200, 300, 400};
+  for (int b = 0; b < 2; ++b) {
+    std::vector<int32_t> vals(keys.size(), static_cast<int32_t>(b));
+    sink_one(*op,
+             make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  }
+  op->finalize_operator();
+
+  // Where each key ended up. Whatever the hash, a key must never appear on two destinations —
+  // otherwise a downstream MERGE_GROUP_BY on another node would see a partial group.
+  std::map<int64_t, std::size_t> destination_of;
+  for (std::size_t i = 0; i < N; ++i) {
+    for (const auto& [key, _] : drain_rows(*op, i)) {
+      auto [it, inserted] = destination_of.emplace(key, i);
+      REQUIRE(it->second == i);
+    }
+  }
+  REQUIRE(destination_of.size() == keys.size());
+}
+
+// ============================================================================
+// PART-3: a slow destination cannot head-of-line-block the others.
+// One destination that received rows stays undrained; siblings must still reach EOS.
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-3: an undrained destination does not block its siblings",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 2;
+  auto [op, repos]        = make_partitioned_sink(N);
+
+  std::vector<int64_t> keys;
+  std::vector<int32_t> vals;
+  for (int i = 0; i < 64; ++i) {
+    keys.push_back(i);
+    vals.push_back(i);
+  }
+  sink_one(*op,
+           make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  op->finalize_operator();
+
+  // Find a destination that actually received rows, and leave it untouched.
+  std::size_t slow = N;
+  for (std::size_t i = 0; i < N; ++i) {
+    if (!repos[i]->all_empty()) {
+      slow = i;
+      break;
+    }
+  }
+  REQUIRE(slow < N);
+
+  for (std::size_t i = 0; i < N; ++i) {
+    if (i == slow) continue;
+    drain_rows(*op, i);
+    // Drained independently, even though `slow` still holds a backlog.
+    REQUIRE(op->drained(i));
+    REQUIRE(op->availability(i) == availability::END_OF_STREAM);
+  }
+
+  // The slow destination is still distinguishable from EOS: terminal, but not drained.
+  REQUIRE_FALSE(op->drained(slow));
+  REQUIRE(op->availability(slow) == availability::HAS_DATA);
+
+  // And it drains cleanly whenever its consumer gets around to it.
+  drain_rows(*op, slow);
+  REQUIRE(op->drained(slow));
+}
+
+// ============================================================================
+// PART-4: finalize drives every destination to EOS together
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-4: one finalize ends all destinations", "[streaming_sink]")
+{
+  constexpr std::size_t N = 3;
+  auto [op, repos]        = make_partitioned_sink(N);
+
+  for (std::size_t i = 0; i < N; ++i) {
+    REQUIRE(op->availability(i) == availability::WAITING);
+    REQUIRE_FALSE(op->drained(i));
+  }
+
+  op->finalize_operator();
+
+  for (std::size_t i = 0; i < N; ++i) {
+    REQUIRE(op->availability(i) == availability::END_OF_STREAM);
+    REQUIRE(op->drained(i));
+  }
+}
+
+// ============================================================================
+// PART-5: wait(i) tracks its own destination
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-5: wait on one destination unblocks on its own data",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 2;
+  auto [op, repos]        = make_partitioned_sink(N);
+
+  std::vector<int64_t> keys;
+  std::vector<int32_t> vals;
+  for (int i = 0; i < 32; ++i) {
+    keys.push_back(i);
+    vals.push_back(i);
+  }
+
+  std::atomic<int> returned{0};
+  std::thread c0([&] {
+    op->wait(0);
+    returned.fetch_add(1);
+  });
+  std::thread c1([&] {
+    op->wait(1);
+    returned.fetch_add(1);
+  });
+
+  std::this_thread::sleep_for(20ms);
+  REQUIRE(returned.load() == 0);
+
+  sink_one(*op,
+           make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  op->finalize_operator();  // guarantees both waiters wake even if one partition got no rows
+
+  c0.join();
+  c1.join();
+  REQUIRE(returned.load() == 2);
+}
+
+// ============================================================================
+// PART-6: N = 1 through the partitioned constructor is the single-destination sink
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-6: a single destination bypasses partitioning", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos{
+    std::make_shared<cucascade::shared_data_repository>()};
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  // No key columns needed: with one destination there is nothing to route.
+  sirius_physical_streaming_sink op(sirius::from_duckdb_vec(types), 0, repos, partition_spec{});
+
+  const std::vector<int64_t> keys{1, 2, 3};
+  const std::vector<int32_t> vals{10, 20, 30};
+  auto batch =
+    make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32);
+  auto batch_id = batch->get_batch_id();
+  sink_one(op, batch);
+  op.finalize_operator();
+
+  // Identity preserved, exactly as the single-repository constructor: no partition, no copy.
+  auto pulled = op.pull();
+  REQUIRE(pulled.has_value());
+  REQUIRE((*pulled)->get_batch_id() == batch_id);
+  REQUIRE(op.drained());
+
+  // Nothing is allocated on this path. A partitioned sink instead pays for the reordered table
+  // and the per-partition copies, which hash_partition() holds at the same time.
+  input_stats stats;
+  stats.bytes       = 4096;
+  stats.num_batches = 1;
+  REQUIRE(op.no_history_peak_memory_estimate(stats) == 0);
+
+  auto [partitioned, repos_2] = make_partitioned_sink(2);
+  REQUIRE(partitioned->no_history_peak_memory_estimate(stats) == stats.bytes * 2);
+}
+
+// ============================================================================
+// PART-7: partitioned-sink construction contracts
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-7: destination list and spec are validated", "[streaming_sink]")
+{
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  auto sirius_types = sirius::from_duckdb_vec(types);
+  auto repo         = std::make_shared<cucascade::shared_data_repository>();
+
+  // No destinations at all.
+  REQUIRE_THROWS_AS(sirius_physical_streaming_sink(
+                      sirius_types,
+                      0,
+                      std::vector<std::shared_ptr<cucascade::shared_data_repository>>{},
+                      partition_spec{{0}, {}}),
+                    sirius::invalid_input_exception);
+
+  // A null destination.
+  REQUIRE_THROWS_AS(
+    sirius_physical_streaming_sink(
+      sirius_types,
+      0,
+      std::vector<std::shared_ptr<cucascade::shared_data_repository>>{repo, nullptr},
+      partition_spec{{0}, {}}),
+    sirius::invalid_input_exception);
+
+  // Several destinations but nothing to route by — silently sending every row to destination 0
+  // would corrupt a downstream shuffle, so this is rejected.
+  REQUIRE_THROWS_AS(
+    sirius_physical_streaming_sink(sirius_types,
+                                   0,
+                                   std::vector<std::shared_ptr<cucascade::shared_data_repository>>{
+                                     repo, std::make_shared<cucascade::shared_data_repository>()},
+                                   partition_spec{}),
+    sirius::invalid_input_exception);
+
+  // More cast types than key columns: hash_partition() reads key_columns[i] for each cast type,
+  // so the extra entry would index past the end of the key list.
+  REQUIRE_THROWS_AS(
+    sirius_physical_streaming_sink(
+      sirius_types,
+      0,
+      std::vector<std::shared_ptr<cucascade::shared_data_repository>>{
+        repo, std::make_shared<cucascade::shared_data_repository>()},
+      partition_spec{
+        {0}, {cudf::data_type{cudf::type_id::INT64}, cudf::data_type{cudf::type_id::INT64}}}),
+    sirius::invalid_input_exception);
+
+  // A key column outside the input schema, and a negative one: both would index the input table
+  // out of range inside the partition kernel.
+  REQUIRE_THROWS_AS(
+    sirius_physical_streaming_sink(sirius_types,
+                                   0,
+                                   std::vector<std::shared_ptr<cucascade::shared_data_repository>>{
+                                     repo, std::make_shared<cucascade::shared_data_repository>()},
+                                   partition_spec{{5}, {}}),
+    sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(
+    sirius_physical_streaming_sink(sirius_types,
+                                   0,
+                                   std::vector<std::shared_ptr<cucascade::shared_data_repository>>{
+                                     repo, std::make_shared<cucascade::shared_data_repository>()},
+                                   partition_spec{{-1}, {}}),
+    sirius::invalid_input_exception);
+
+  auto [op, repos] = make_partitioned_sink(2);
+  REQUIRE_THROWS_AS(op->pull(2), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(op->drained(2), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(op->availability(2), sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// PART-8: broadcast replicates instead of routing.
+// ============================================================================
+
+TEST_CASE("streaming_sink PART-8: broadcast delivers every batch to every destination",
+          "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  const std::size_t N = GENERATE(std::size_t{2}, std::size_t{3});
+  auto [op, repos]    = make_broadcast_sink(N);
+  REQUIRE(op->num_output_streams() == N);
+
+  // Unlike hash mode, the union across destinations is N copies of the input, not one.
+  std::vector<std::pair<int64_t, int32_t>> expected;
+  for (int b = 0; b < 2; ++b) {
+    std::vector<int64_t> keys;
+    std::vector<int32_t> vals;
+    for (int i = 0; i < 4; ++i) {
+      const auto key = static_cast<int64_t>(b * 4 + i);
+      keys.push_back(key);
+      vals.push_back(static_cast<int32_t>(key * 10));
+      expected.emplace_back(key, static_cast<int32_t>(key * 10));
+    }
+    sink_one(*op,
+             make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  }
+  op->finalize_operator();
+
+  std::sort(expected.begin(), expected.end());
+  for (std::size_t i = 0; i < N; ++i) {
+    auto rows = drain_rows(*op, i);
+    std::sort(rows.begin(), rows.end());
+    // Every destination sees the whole input, not a slice of it.
+    REQUIRE(rows == expected);
+  }
+}
+
+TEST_CASE("streaming_sink PART-9: broadcast clones are independent batches", "[streaming_sink]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto [op, repos] = make_broadcast_sink(3);
+
+  auto original =
+    make_two_column_batch<int64_t, int32_t>(*gpu_space, {1, 2}, {10, 20}, cudf::type_id::INT32);
+  const auto original_id = original->get_batch_id();
+  sink_one(*op, original);
+  op->finalize_operator();
+
+  std::vector<uint64_t> ids;
+  for (std::size_t i = 0; i < op->num_output_streams(); ++i) {
+    auto batch = op->pull(i);
+    REQUIRE(batch.has_value());
+    ids.push_back((*batch)->get_batch_id());
+  }
+
+  // Destination 0 forwards the original handle; the rest are clones, so no id repeats and the
+  // clones cannot race destination 0 over one handle's residency.
+  REQUIRE(ids[0] == original_id);
+  std::sort(ids.begin(), ids.end());
+  REQUIRE(std::adjacent_find(ids.begin(), ids.end()) == ids.end());
+}

--- a/test/cpp/operator/test_physical_streaming_source.cpp
+++ b/test/cpp/operator/test_physical_streaming_source.cpp
@@ -62,7 +62,7 @@ constexpr sender_id_t SOLE_SENDER = 0;
 // ============================================================================
 
 /// Producer contract: the batch goes in through the operator's own push(), so admission and the
-/// waker behave exactly as they do in production.
+/// on_data self-nomination behave exactly as they do in production.
 static void push_batch(sirius_physical_streaming_source& op,
                        std::shared_ptr<cucascade::data_batch> batch)
 {
@@ -680,9 +680,15 @@ TEST_CASE("streaming_source SRC-20: producer thread and consumer loop", "[stream
   auto [op, repo] = make_source();
 
   std::atomic<int> pushed{0};
+  // Catch2 assertions are not thread-safe, so the producer records a refusal and the main thread
+  // asserts on it after the join. A refused push here would silently drop a batch and turn the
+  // row-count check below into a false pass.
+  std::atomic<bool> refused{false};
   std::thread producer([&] {
     for (int i = 0; i < K; ++i) {
-      op->push(make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32));
+      if (!op->push(make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32))) {
+        refused.store(true, std::memory_order_release);
+      }
       pushed.fetch_add(1, std::memory_order_release);
     }
     op->close_input(SOLE_SENDER);
@@ -706,6 +712,7 @@ TEST_CASE("streaming_source SRC-20: producer thread and consumer loop", "[stream
   }
   producer.join();
 
+  REQUIRE_FALSE(refused.load(std::memory_order_acquire));
   REQUIRE(received == K);
   REQUIRE(op->all_ports_empty());
 }
@@ -814,9 +821,7 @@ TEST_CASE("streaming_source SRC-24: fan-in stream ends only after all senders cl
 }
 
 // ============================================================================
-// SRC-25: the repository is the producer's, not the operator's — destroying the
-// consumer side leaves the queue and its contents intact. This is what lets a
-// session hand the same repository to a wrapper that outlives one fragment.
+// SRC-25: repository IS the queue — destroying the operator leaves queued batches intact.
 // ============================================================================
 
 TEST_CASE("streaming_source SRC-25: the input repository outlives the operator",
@@ -840,12 +845,7 @@ TEST_CASE("streaming_source SRC-25: the input repository outlives the operator",
 
 // ============================================================================
 // BUG-1 (regression): closing an empty stream must finish a zero-task pipeline.
-//
-// These BUG-* tests exercise the real sirius_pipeline completion predicate
-// (update_pipeline_status() / is_pipeline_finished()), not just the operator's
-// own hint/all_ports_empty() methods, because the bug is in what *calls*
-// update_pipeline_status() (or rather, what fails to), not in the predicate
-// itself.
+// Exercises real sirius_pipeline completion (update_pipeline_status), not just the operator.
 // ============================================================================
 
 TEST_CASE("streaming_source BUG-1: closing an empty stream finishes a zero-task pipeline",
@@ -912,11 +912,7 @@ TEST_CASE("streaming_source BUG-2: late close after last task completed finishes
 }
 
 // ============================================================================
-// BUG-3 / BUG-4: pipeline completion must also re-arm downstream pipelines.
-// update_pipeline_status(false) makes notify_downstream_pipelines() schedule
-// this pipeline's output consumers via the task_creator; with the default
-// (true) an empty or late-closed stream finishes this pipeline but its
-// downstream pipeline never gets a task scheduled.
+// BUG-3 / BUG-4: pipeline completion must also re-arm downstream (original_pipeline=false).
 // ============================================================================
 
 TEST_CASE("streaming_source BUG-3: closing an empty stream schedules downstream consumers",
@@ -975,12 +971,7 @@ TEST_CASE("streaming_source BUG-4: late close after last task schedules downstre
 }
 
 // ============================================================================
-// REARM-1: a push after a WAITING hint re-schedules the starved source.
-//
-// This is the live edge the whole streaming source depends on. A head that
-// answers WAITING{nullptr} is dropped by the task creator, and the only
-// built-in re-nomination is task completion — which a starved stream-fed
-// source will never see. Without this the source is non-functional.
+// REARM-1: push after WAITING re-schedules the starved source (on_data self-nomination).
 // ============================================================================
 
 TEST_CASE("streaming_source REARM-1: a push after a WAITING hint re-schedules the source",
@@ -1018,18 +1009,10 @@ TEST_CASE("streaming_source REARM-1: a push after a WAITING hint re-schedules th
 }
 
 // ============================================================================
-// REARM-4: a producer's second burst is consumed after a drain.
-//
-// The task creator's drain loop is
-//     while (!all_ports_empty()) { d = get_next_task_input_data(); if (!d) break; ... }
-// — it never calls get_next_task_hint(). The head is scheduled once by start_query() and task
-// completion only nominates consumers, so if notification depended on a hint call the head
-// would go silent the moment a drain ended and every later push would be stranded.
-//
-// This drives that exact loop shape instead of hand-calling the hint.
+// REARM-2: second burst after a drain loop that never calls get_next_task_hint().
 // ============================================================================
 
-TEST_CASE("streaming_source REARM-4: a push after a drained drain loop re-schedules the source",
+TEST_CASE("streaming_source REARM-2: a push after a drained drain loop re-schedules the source",
           "[streaming_source][pipeline_completion]")
 {
   auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
@@ -1064,14 +1047,10 @@ TEST_CASE("streaming_source REARM-4: a push after a drained drain loop re-schedu
 }
 
 // ============================================================================
-// REARM-2: a push racing the WAITING hint is not lost.
-//
-// The arm predicate re-checks emptiness under the same lock push() holds while
-// it inserts, so a batch that lands between classify() and the arm turns the
-// hint into READY instead of parking on a waker that will never fire again.
+// REARM-3: push racing WAITING hint is not lost (S1 lock co-covers classify).
 // ============================================================================
 
-TEST_CASE("streaming_source REARM-2: a batch already queued turns the hint into READY",
+TEST_CASE("streaming_source REARM-3: a batch already queued turns the hint into READY",
           "[streaming_source][pipeline_completion]")
 {
   auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
@@ -1092,12 +1071,10 @@ TEST_CASE("streaming_source REARM-2: a batch already queued turns the hint into 
 }
 
 // ============================================================================
-// REARM-3: a source with no task_creator wired parks without crashing. The
-// waker resolves the creator through the pipeline at fire time, so a pipeline
-// built before the executor attached is a no-op, not a null dereference.
+// REARM-4: no task_creator wired → on_data is a no-op, not a null deref.
 // ============================================================================
 
-TEST_CASE("streaming_source REARM-3: a push with no task_creator wired is harmless",
+TEST_CASE("streaming_source REARM-4: a push with no task_creator wired is harmless",
           "[streaming_source][pipeline_completion]")
 {
   auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
@@ -1113,10 +1090,7 @@ TEST_CASE("streaming_source REARM-3: a push with no task_creator wired is harmle
 }
 
 // ============================================================================
-// SRC-26: a producer error reaches the puller as data, then as a throw.
-//
-// The failure travels the same waker → hint → pull path a batch does, because that is the only
-// path a source has: nothing else nominates a starved streaming source.
+// SRC-26: producer error reaches the puller via on_data → hint → rethrow (P4/S2).
 // ============================================================================
 
 TEST_CASE("streaming_source SRC-26: a producer error is rethrown to the puller",
@@ -1146,10 +1120,7 @@ TEST_CASE("streaming_source SRC-26: a producer error is rethrown to the puller",
 }
 
 // ============================================================================
-// SRC-27: an errored stream neither reports success nor wedges the scheduler.
-//
-// all_ports_empty() is error-aware, so a failed stream is never "empty-and-done" and the pipeline
-// cannot finish as if the query had succeeded. The drain loop still terminates — by the throw.
+// SRC-27: errored stream never finishes quietly (S3); drain loop exits by throw.
 // ============================================================================
 
 TEST_CASE("streaming_source SRC-27: an errored stream does not finish the pipeline quietly",

--- a/test/cpp/pipeline/test_streaming_sink_root.cpp
+++ b/test/cpp/pipeline/test_streaming_sink_root.cpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_physical_operator_type.hpp"
+#include "op/sirius_physical_streaming_sink.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "sirius_engine.hpp"
+
+#include <catch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <duckdb.hpp>
+#include <utils/pipeline_conversion_test_utils.hpp>
+#include <utils/sirius_test_env.hpp>
+
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+using sirius::op::sirius_physical_streaming_sink;
+using sirius::op::SiriusPhysicalOperatorType;
+using sirius::pipeline::sirius_pipeline;
+
+namespace {
+
+fs::path integration_db_path()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return fs::path(SIRIUS_PROJECT_ROOT) / "test/cpp/integration/data/duckdb/integration.duckdb";
+#else
+  return fs::path(__FILE__).parent_path().parent_path() /
+         "integration/data/duckdb/integration.duckdb";
+#endif
+}
+
+struct streaming_sink_root_fixture {
+  streaming_sink_root_fixture()
+  {
+    REQUIRE(sirius::test::g_integration_env != nullptr);
+    if (!sirius::test::g_integration_env->is_active()) {
+      sirius::test::g_integration_env->resume();
+    }
+    con = std::make_unique<duckdb::Connection>(sirius::test::g_integration_env->make_connection());
+
+    auto db_path = integration_db_path();
+    REQUIRE(fs::exists(db_path));
+    auto result =
+      con->Query("ATTACH IF NOT EXISTS '" + db_path.string() + "' AS tpch (READ_ONLY);");
+    REQUIRE(result);
+    REQUIRE_FALSE(result->HasError());
+    result = con->Query("USE tpch;");
+    REQUIRE(result);
+    REQUIRE_FALSE(result->HasError());
+  }
+
+  std::unique_ptr<duckdb::Connection> con;
+};
+
+std::vector<std::shared_ptr<cucascade::shared_data_repository>> make_repos(std::size_t n)
+{
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos;
+  repos.reserve(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    repos.push_back(std::make_shared<cucascade::shared_data_repository>());
+  }
+  return repos;
+}
+
+//! The pipeline whose `operators` contain `op`, or nullptr.
+const sirius_pipeline* pipeline_with_operator(
+  const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines,
+  const sirius::op::sirius_physical_operator& target)
+{
+  for (const auto& pipeline : pipelines) {
+    for (const auto& op : pipeline->get_operators()) {
+      if (&op.get() == &target) { return pipeline.get(); }
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+// ============================================================================
+// SINKROOT-1: a fragment plan rooted in a STREAMING_SINK initializes
+// ============================================================================
+
+TEST_CASE_METHOD(streaming_sink_root_fixture,
+                 "SINKROOT-1: a streaming-sink-rooted plan initializes",
+                 "[integration][pipeline][streaming_sink_root]")
+{
+  auto repos = make_repos(1);
+
+  sirius::test::with_initialized_streaming_fragment(
+    *con,
+    "SELECT n_regionkey FROM nation",
+    repos,
+    std::nullopt,
+    [&](sirius::sirius_engine& engine, sirius_physical_streaming_sink& sink) {
+      // "Plan-tree root" in the Volcano/DuckDB sense: the physical tree is drawn from the
+      // result, so children[] holds this operator's *producers* and get_parent_op() is its
+      // consumer. Data still runs plan-tree leaf (the scan) to plan-tree root (this sink);
+      // execution starts at the pipeline head, not here. Because the producing subtree hangs
+      // off children[], the plan generator needs none of the out-of-tree descent that
+      // RESULT_COLLECTOR requires.
+      REQUIRE(sink.type == SiriusPhysicalOperatorType::STREAMING_SINK);
+      REQUIRE(sink.children.size() == 1);        // one producer child
+      REQUIRE(sink.get_parent_op() == nullptr);  // no consumer above -> plan-tree root
+
+      // A streaming fragment never produces a QueryResult.
+      REQUIRE_FALSE(engine.has_result_collector());
+
+      REQUIRE(sink.num_output_streams() == 1);
+
+      // The pipeline must actually reach the scheduler. schedule_pipelines() walks the meta
+      // pipelines with skip=true, dropping the ROOT meta -- so a plan whose only real pipeline
+      // lands in the root meta would initialize, report the right shape, and then run zero
+      // tasks. That failure is silent: the query "completes" with an empty result.
+      REQUIRE_FALSE(engine.new_scheduled.empty());
+    });
+}
+
+// ============================================================================
+// SINKROOT-2: the sink lands in a pipeline's operators, so EOS can fire
+// ============================================================================
+
+TEST_CASE_METHOD(streaming_sink_root_fixture,
+                 "SINKROOT-2: the streaming sink reaches a pipeline's operators",
+                 "[integration][pipeline][streaming_sink_root]")
+{
+  auto repos = make_repos(1);
+
+  sirius::test::with_initialized_streaming_fragment(
+    *con,
+    "SELECT n_regionkey FROM nation",
+    repos,
+    std::nullopt,
+    [&](sirius::sirius_engine& engine, sirius_physical_streaming_sink& sink) {
+      // This is the load-bearing invariant. on_finalize_operator() -- the sink's only route to
+      // end-of-stream -- is driven by update_pipeline_status() iterating get_operators(), which
+      // returns the `operators` vector and EXCLUDES the source/sink members. If the sink is not
+      // in that vector, EOS never fires and every consumer blocked in wait() hangs forever, with
+      // no error anywhere.
+      const auto* owning = pipeline_with_operator(engine.sirius_pipelines, sink);
+      REQUIRE(owning != nullptr);
+
+      // And it is the pipeline's terminal sink, which is what tells the executor the query is
+      // complete once that pipeline finishes.
+      REQUIRE(owning->get_sink().get() == &sink);
+      REQUIRE(owning->is_query_terminal());
+    });
+}
+
+// ============================================================================
+// SINKROOT-3: a partitioned sink root exposes one output stream per destination
+// ============================================================================
+
+TEST_CASE_METHOD(streaming_sink_root_fixture,
+                 "SINKROOT-3: a partitioned sink root keeps its fan-out",
+                 "[integration][pipeline][streaming_sink_root]")
+{
+  auto repos = make_repos(3);
+
+  sirius::test::with_initialized_streaming_fragment(
+    *con,
+    "SELECT n_regionkey FROM nation",
+    repos,
+    sirius::op::partition_spec{{0}, {}},
+    [&](sirius::sirius_engine& engine, sirius_physical_streaming_sink& sink) {
+      REQUIRE(sink.num_output_streams() == 3);
+      REQUIRE(pipeline_with_operator(engine.sirius_pipelines, sink) != nullptr);
+      // Nothing has run, so every destination is empty but none has ended.
+      for (std::size_t i = 0; i < 3; ++i) {
+        REQUIRE_FALSE(sink.drained(i));
+      }
+    });
+}
+
+// ============================================================================
+// SINKROOT-4: A/B vs RESULT_COLLECTOR (FRAG-CONTROL). Same harness; only the
+// terminal operator differs. Fail here + pass there ⇒ sink fault.
+// ============================================================================
+
+TEST_CASE_METHOD(streaming_sink_root_fixture,
+                 "SINKROOT-4: a sink-rooted plan actually produces batches",
+                 "[integration][pipeline][streaming_sink_root_exec]")
+{
+  auto repos = make_repos(1);
+
+  sirius::test::with_initialized_streaming_fragment(
+    *con,
+    "SELECT a FROM (VALUES (1), (2), (3), (4), (5)) t(a)",
+    repos,
+    std::nullopt,
+    [&](sirius::sirius_engine& engine, sirius_physical_streaming_sink& sink) {
+      engine.execute();
+
+      std::size_t created = 0;
+      for (const auto& p : engine.sirius_pipelines) {
+        created += p->get_tasks_created();
+      }
+      INFO("pipelines=" << engine.sirius_pipelines.size() << " tasks_created=" << created);
+
+      // The sink holds the same repository the caller passed in.
+      REQUIRE(repos[0]->total_size() > 0);
+      REQUIRE(sink.num_output_streams() == 1);
+    });
+}

--- a/test/cpp/utils/pipeline_conversion_test_utils.cpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.cpp
@@ -22,6 +22,7 @@
 #include "pipeline/sirius_pipeline.hpp"
 #include "pipeline/sirius_pipeline_converter.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
+#include "sirius/exception.hpp"
 #include "sirius_context.hpp"
 #include "sirius_engine.hpp"
 #include "sirius_interface.hpp"
@@ -235,6 +236,78 @@ void with_initialized_engine(duckdb::Connection& con,
     sirius_engine engine(context, iface, test_query.query_id());
     engine.initialize(std::move(collector));
     consume(engine);
+
+    con.Rollback();
+  } catch (...) {
+    con.Rollback();
+    throw;
+  }
+}
+
+void with_initialized_streaming_fragment(
+  duckdb::Connection& con,
+  const std::string& query,
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repos,
+  std::optional<op::partition_spec> spec,
+  const std::function<void(sirius_engine&, op::sirius_physical_streaming_sink&)>& consume)
+{
+  auto& context = *con.context;
+
+  auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  if (!sirius_ctx) {
+    throw sirius::invalid_input_exception(
+      "with_initialized_streaming_fragment: Sirius is not registered on this connection");
+  }
+
+  // Without a partition spec the plan is rooted in a single-destination sink: no repository would
+  // index an empty vector below, and extra ones would be silently dropped rather than wired to
+  // anything. With a spec, every repository becomes a destination.
+  if (output_repos.empty() || (!spec.has_value() && output_repos.size() != 1)) {
+    throw sirius::invalid_input_exception(
+      "with_initialized_streaming_fragment: expected " +
+      std::string(spec.has_value() ? "at least 1" : "exactly 1") + " output repository, got " +
+      std::to_string(output_repos.size()));
+  }
+
+  con.BeginTransaction();
+  try {
+    // The real execution window, not scoped_test_query: consume() may execute(), and only a
+    // window begin points the task creator at this connection. Sink output repositories are
+    // never registered with the window's repository manager, so they survive finish().
+    duckdb::SiriusContext::StandaloneQueryScope window(
+      *sirius_ctx, context, "streaming_fragment_test");
+
+    extracted_plan extracted;
+    {
+      optimizer_disable_guard guard(context);
+      extracted = extract_logical_plan_sirius_order(context, query);
+    }
+
+    sirius::planner::sirius_physical_plan_generator physical_planner(context);
+    auto sirius_plan = physical_planner.create_plan(std::move(extracted.logical_plan));
+
+    // A STREAMING_SINK is a normal unary operator, unlike the RESULT_COLLECTOR, which keeps its
+    // child outside `children[]` and needs special descent in the plan generator. Attaching the
+    // subtree as children[0] is what keeps that special-casing unnecessary.
+    auto types       = sirius_plan->types;
+    auto cardinality = sirius_plan->estimated_cardinality;
+    duckdb::unique_ptr<op::sirius_physical_streaming_sink> sink;
+    if (spec.has_value()) {
+      sink = duckdb::make_uniq<op::sirius_physical_streaming_sink>(
+        std::move(types), cardinality, std::move(output_repos), std::move(*spec));
+    } else {
+      sink = duckdb::make_uniq<op::sirius_physical_streaming_sink>(
+        std::move(types), cardinality, output_repos[0]);
+    }
+    sink->children.push_back(std::move(sirius_plan));
+
+    sirius_interface iface(context);
+    sirius_engine engine(context, iface, window.query_id());
+    // The fragment owns the plan; the engine borrows it. initialize() would take ownership and
+    // destroy the sink with the engine, leaving nothing to pull from afterwards.
+    engine.initialize_internal(*sink);
+    consume(engine, *sink);
+    window.finish();
 
     con.Rollback();
   } catch (...) {

--- a/test/cpp/utils/pipeline_conversion_test_utils.hpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.hpp
@@ -16,14 +16,18 @@
 
 #pragma once
 
+#include "op/sirius_physical_streaming_sink.hpp"
 #include "query_id.hpp"
 
+#include <cucascade/data/data_repository.hpp>
 #include <duckdb/main/connection.hpp>
 
 #include <cstdint>
 #include <filesystem>
 #include <functional>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace duckdb {
 class SiriusContext;
@@ -89,6 +93,15 @@ void with_conversion_result(
 void with_initialized_engine(duckdb::Connection& con,
                              const std::string& query,
                              const std::function<void(sirius_engine&)>& consume);
+
+//! Like with_initialized_engine, but roots the plan in a STREAMING_SINK over output_repos.
+//! Caller owns the plan tree; engine borrows via initialize_internal.
+void with_initialized_streaming_fragment(
+  duckdb::Connection& con,
+  const std::string& query,
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> output_repos,
+  std::optional<op::partition_spec> spec,
+  const std::function<void(sirius_engine&, op::sirius_physical_streaming_sink&)>& consume);
 
 //! Path to the canonical TPC-H queries (`test/tpch_performance/tpch_queries/orig/`).
 std::filesystem::path tpch_queries_dir();


### PR DESCRIPTION
Implements #837 and #838. Part 1 of a three-PR stack that replaces #1432.

**What.** The output boundary of a streaming plan. Where `STREAMING_SOURCE` (landed in #1320)
stands in for a scan that has no table, `STREAMING_SINK` stands in for a result that has no
client: it writes each finished batch into one or more `cucascade::shared_data_repository`
handles, so a downstream fragment can pick them up.

**Design: the sink is a writer, not a buffer.** A regular sink accumulates a result and hands it
back at the end. This one owns no storage — each batch goes straight into a repository the caller
supplied, and the operator's only state is which destination the next batch belongs to. That is
what makes a fragment boundary cheap: nothing is copied to hand a batch across it.

**Partitioning (#838).** A sink may fan a batch out across N destinations:

- *hash* — partition on a key column set. Key types are normalized first, so two senders that
  disagree on integer width still hash to the same destination. Without that, a plan whose
  fragments were built from different sub-plans silently splits one logical key across two
  partitions.
- *broadcast* — every destination receives every batch.

**Also folded in.** The `batch_stream` / `STREAMING_SOURCE` follow-up work that accumulated after
#1320 merged: corrections to the `on_data` hook documentation, the availability state machine, and
the sender-aware EOS description. These are doc and comment changes to files #1320 already landed;
they are here rather than in their own PR because they are too small to review alone.

---

**Reviewing.** One commit. `src/op/sirius_physical_streaming_sink.cpp` and its header are the
substance; the `src/pipeline/` changes are the wiring that lets a pipeline be rooted in a sink
rather than a result collector.

**Tests.** `test_physical_streaming_sink.cpp` covers the operator directly (write, multi-batch,
per-destination independence, the error plane, hash fan-out in `PART-1..7`, and broadcast in
`PART-8/9` — every destination receives every batch, destination 0 forwards the original handle,
and the rest are independent clones with distinct batch ids). `test_streaming_sink_root.cpp`
covers a pipeline whose plan-tree root is a sink, including the partitioned cases.

**Refused pushes poison the stream.** A push is refused only once the output is terminal, which
means the fragment produced data after its own output closed. Rather than dropping the batch, the
sink fails that output so the consumer learns from `try_pull()` instead of silently receiving a
short result. `SNK-5` pins this.

---

**Stack.** This PR is the base.

| Part | PR | Branch | Scope |
|---|---|---|---|
| 1 | **#1479 (this)** | `stream/13-sink` | `STREAMING_SINK` + partitioning (#837, #838) |
| 2 | #1480 | `stream/14-session` | `exec::stream_session` (#839, addressing) |
| 3 | #1481 | `stream/15-fragment` | `streaming_fragment` + FFI (#839, execution) |

Supersedes #1432, which carried all three layers as one 17-commit PR. The three parts together
reproduce that branch exactly — verified tree-for-tree, not by inspection.
