### PR TITLE
feat(exec): stream_session, the id-addressed streaming router (#839)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,7 @@ set(EXTENSION_SOURCES
     # Execution primitives (slot-based backpressure / completion tracking)
     src/exec/admission_control.cpp
     src/exec/batch_stream.cpp
+    src/exec/stream_session.cpp
     # I/O adapters (Phase 19 — io_uring + sirius_datasource)
     src/io/datasource_factory.cpp
     src/io/io_context.cpp
@@ -648,6 +649,7 @@ set(TEST_SOURCES
     test/cpp/exec/test_interruptible_mpmc.cpp
     test/cpp/exec/test_multi_index_priority_queue.cpp
     test/cpp/exec/test_semi_future.cpp
+    test/cpp/exec/test_stream_session.cpp
     test/cpp/expression/test_ast_aggregate.cpp
     test/cpp/expression/test_ast_clone.cpp
     test/cpp/expression/test_ast_substitute.cpp

--- a/docs/super-sirius/streaming-sessions.md
+++ b/docs/super-sirius/streaming-sessions.md
@@ -44,7 +44,8 @@ currently sit. Nothing is materialized to Arrow on the way in or out, so a queue
 spillable (GPU → host → disk) right up until it is pulled, and `pull()` hands it back in its
 current tier without forcing an upgrade.
 
-There is no bounded channel and no channel-level backpressure.
+There is no bounded channel and no channel-level backpressure; see
+[No backpressure](#no-backpressure).
 
 ## `exec::batch_stream`
 
@@ -256,7 +257,7 @@ consumers see END_OF_STREAM via wait(i) / drained(i)
 The sink has exactly **one sender** (`PIPELINE_SENDER`). `on_finalize_operator()` is called only
 when the sink is in the pipeline's `operators` vector — if it is reachable only through the
 `sink` member, `finalize_operator()` skips it, the streams never close, and every `wait()` caller
-blocks forever.
+blocks forever (see the gotcha in [exec::stream_session](#execstream_session--the-id-addressed-router)).
 
 ### Partition fan-out
 
@@ -296,3 +297,67 @@ Construction invariants:
   EOS together.
 - *Which* compute node each partition ships to is the wrapper's routing table — the sink stays
   oblivious to destinations.
+
+## `exec::stream_session` — the id-addressed router
+
+**Files:** `src/include/exec/stream_session.hpp`, `src/exec/stream_session.cpp`
+
+```
+push(stream_id, batch)              // → source.push
+close_input(stream_id, sender_id)   // → source.close_input(sender)
+fail_input(stream_id, error)        // → source.fail_input(error)   — poison an input stream
+pull(stream_id) -> optional         // → sink.pull(partition)
+wait(stream_id)                     // → sink.wait(partition)
+drained(stream_id) -> bool          // → sink.drained(partition)
+fail_output(stream_id, error)       // → sink.fail_output(error)    — poison all sink partitions
+```
+
+- Stream ids are **session-local** and **direction-separated** — two independent namespaces:
+  `push`/`close_input` resolve input streams (sources); `pull`/`wait`/`drained` resolve output
+  streams (sink partitions). A partitioned sink registers N ids, one per destination. An unknown
+  id is a defined error.
+- The session holds **no repositories** — it forwards to the operators, which own the queues. It
+  builds no plan, submits nothing to the scheduler, and owns no teardown; it wraps
+  already-instantiated operators.
+- A **leaf**-fragment session registers only sink ids (a session with no input streams is
+  legitimate); a **root**-fragment session registers a source id plus sink ids.
+
+> **Gotcha for plan-launcher work.** The sink is the pipeline **tail**, and it must be a member of
+> that pipeline's `operators` vector — being the pipeline's `sink` member is not enough. Pipeline
+> finish calls `finalize_operator()` on `get_operators()`, which returns `operators` and excludes
+> the `source`/`sink` members, so *membership* is what fires end-of-stream, not position. A sink
+> reachable only through the `sink` member never sees `on_finalize_operator()`, the streams never
+> close, and every consumer blocks in `wait()` forever with no error anywhere. The sink is
+> appended first and lands at `operators.back()` once `is_ready()` reverses the vector. A plan
+> launcher must key on that structure rather than on `is_source()`.
+
+## Worked example: distributed GROUP BY
+
+The flagship case composes entirely from the pieces above — no extra operator, no new mechanism.
+The front end emits two fragment shapes:
+
+```
+Leaf fragment (every node, over its shard)    Root fragment (every node, owns one key range)
+  partitioned STREAMING_SINK                    STREAMING_SINK (N = 1)
+  └─ HASH_GROUP_BY  (partial)                   └─ MERGE_GROUP_BY (final)
+     └─ GPU_SCAN                                   └─ STREAMING_SOURCE
+                                                      (expected = {0 … N-1})
+```
+
+The shuffle in the middle becomes the leaf sink's N per-destination streams, the wrapper's
+transport hop, and the root source's sender-aware fan-in. The aggregate algebra is unchanged
+(`SUM→SUM`, `COUNT→SUM` of partial counts, `AVG` carrying `(sum, cnt)`) — distributed GROUP BY is
+a data-movement and lifecycle problem, which is exactly the seam these pieces fill.
+
+The leaf session's EOS comes from its scan finishing (pipeline finish → close), not from any
+`close_input`. The root session's source reaches EOS only after all N distinct senders close — a
+repeated close from one sender cannot terminate it early.
+
+## No backpressure
+
+Streams never infer pressure from queue depth, and the engine has no "slow down" task hint — so
+the streaming layer deliberately carries no channel-level backpressure. Pressure relief comes
+from the **downgrade executor** instead: queued batches sit in repositories where the memory
+sweep can see and spill them (GPU → host → disk). Cross-fragment and cross-query pressure is a
+scheduling concern (per-fragment priority), and a future sink↔source slowness signal would be
+additive — nothing in this design forecloses it.

--- a/src/exec/stream_session.cpp
+++ b/src/exec/stream_session.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/stream_session.hpp"
+
+#include "sirius/exception.hpp"
+
+#include <set>
+#include <string>
+#include <utility>
+
+namespace sirius::exec {
+
+void stream_session::add_source(stream_id_t id, op::sirius_physical_streaming_source& source)
+{
+  if (!_sources.emplace(id, &source).second) {
+    throw sirius::invalid_input_exception("stream_session: input stream " + std::to_string(id) +
+                                          " is already registered");
+  }
+}
+
+void stream_session::add_sink(std::vector<stream_id_t> ids,
+                              op::sirius_physical_streaming_sink& sink)
+{
+  if (ids.size() != sink.num_output_streams()) {
+    throw sirius::invalid_input_exception(
+      "stream_session: sink exposes " + std::to_string(sink.num_output_streams()) +
+      " output streams but " + std::to_string(ids.size()) + " ids were given");
+  }
+
+  // Validate every id before inserting any. Throwing mid-insert would leave the partitions
+  // already registered behind in the map, so a caller that catches and retries would then trip
+  // over its own leftovers as spurious duplicates.
+  std::set<stream_id_t> incoming;
+  for (auto id : ids) {
+    if (_sinks.find(id) != _sinks.end()) {
+      throw sirius::invalid_input_exception("stream_session: output stream " + std::to_string(id) +
+                                            " is already registered");
+    }
+    if (!incoming.insert(id).second) {
+      throw sirius::invalid_input_exception("stream_session: output stream " + std::to_string(id) +
+                                            " appears more than once in the same registration");
+    }
+  }
+
+  // Positional by contract: ids[i] ↔ sink partition i ↔ output repository i.
+  for (std::size_t partition = 0; partition < ids.size(); ++partition) {
+    _sinks.emplace(ids[partition], sink_output{&sink, partition});
+  }
+}
+
+std::vector<stream_id_t> stream_session::input_streams() const
+{
+  std::vector<stream_id_t> ids;
+  ids.reserve(_sources.size());
+  for (const auto& [id, _] : _sources) {
+    ids.push_back(id);
+  }
+  return ids;
+}
+
+std::vector<stream_id_t> stream_session::output_streams() const
+{
+  std::vector<stream_id_t> ids;
+  ids.reserve(_sinks.size());
+  for (const auto& [id, _] : _sinks) {
+    ids.push_back(id);
+  }
+  return ids;
+}
+
+op::sirius_physical_streaming_source& stream_session::resolve_source(stream_id_t id) const
+{
+  auto it = _sources.find(id);
+  if (it == _sources.end()) {
+    throw sirius::invalid_input_exception("stream_session: no input stream with id " +
+                                          std::to_string(id));
+  }
+  return *it->second;
+}
+
+const stream_session::sink_output& stream_session::resolve_sink(stream_id_t id) const
+{
+  auto it = _sinks.find(id);
+  if (it == _sinks.end()) {
+    throw sirius::invalid_input_exception("stream_session: no output stream with id " +
+                                          std::to_string(id));
+  }
+  return it->second;
+}
+
+bool stream_session::push(stream_id_t id, std::shared_ptr<cucascade::data_batch> batch)
+{
+  return resolve_source(id).push(std::move(batch));
+}
+
+void stream_session::close_input(stream_id_t id, sender_id_t sender)
+{
+  resolve_source(id).close_input(sender);
+}
+
+void stream_session::fail_input(stream_id_t id, std::exception_ptr error)
+{
+  resolve_source(id).fail_input(std::move(error));
+}
+
+std::optional<std::shared_ptr<cucascade::data_batch>> stream_session::pull(stream_id_t id)
+{
+  const auto& out = resolve_sink(id);
+  return out.sink->pull(out.partition);
+}
+
+void stream_session::wait(stream_id_t id)
+{
+  const auto& out = resolve_sink(id);
+  out.sink->wait(out.partition);
+}
+
+bool stream_session::drained(stream_id_t id) const
+{
+  const auto& out = resolve_sink(id);
+  return out.sink->drained(out.partition);
+}
+
+void stream_session::fail_output(stream_id_t id, std::exception_ptr error)
+{
+  // fail_output poisons all partitions of the sink (one pipeline = one sender).
+  resolve_sink(id).sink->fail_output(std::move(error));
+}
+
+}  // namespace sirius::exec

--- a/src/include/exec/stream_session.hpp
+++ b/src/include/exec/stream_session.hpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "exec/batch_stream.hpp"
+#include "op/sirius_physical_streaming_sink.hpp"
+#include "op/sirius_physical_streaming_source.hpp"
+
+#include <cstdint>
+#include <exception>
+#include <map>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace sirius::exec {
+
+/// Direction-separated id namespaces: push/close = input; pull/wait/drained = output.
+using stream_id_t = std::uint64_t;
+
+/// Id → operator router for one fragment. Non-owning; plan must outlive the session.
+///
+/// Registration is build-time only and single-shot: every id is registered exactly once while
+/// the fragment is being built, and registering one twice is an error rather than a no-op. The
+/// session is a lookup table, not a factory — it never creates a stream on resolve, and an
+/// unknown id throws rather than materializing one. Both halves matter: a fragment that resolves
+/// an id it never registered has a plan/binding bug, and silently creating a stream there would
+/// route its data into a queue no peer is holding.
+///
+/// Registration is not thread-safe. Forwarded verbs are as thread-safe as batch_stream + the
+/// repository.
+class stream_session {
+ public:
+  stream_session()                                     = default;
+  stream_session(stream_session&&) noexcept            = default;
+  stream_session& operator=(stream_session&&) noexcept = default;
+  stream_session(const stream_session&)                = delete;
+  stream_session& operator=(const stream_session&)     = delete;
+
+  // -----------------------------------------------------------------------
+  // Registration (build time)
+  // -----------------------------------------------------------------------
+
+  /// @throws sirius::invalid_input_exception on a duplicate input id.
+  void add_source(stream_id_t id, op::sirius_physical_streaming_source& source);
+
+  /// ids[i] ↔ sink partition i ↔ repository i. All-or-nothing: every id is validated before
+  /// any is inserted, so a rejected registration leaves the session exactly as it was.
+  /// @throws sirius::invalid_input_exception if `ids` does not match the sink's output count,
+  ///         names an already-registered id, or repeats an id within the same call.
+  void add_sink(std::vector<stream_id_t> ids, op::sirius_physical_streaming_sink& sink);
+
+  /// Empty for a leaf fragment.
+  [[nodiscard]] std::vector<stream_id_t> input_streams() const;
+
+  [[nodiscard]] std::vector<stream_id_t> output_streams() const;
+
+  // -----------------------------------------------------------------------
+  // Producer side — input streams
+  // -----------------------------------------------------------------------
+
+  /// @return false if terminal. @throws on unknown input id.
+  bool push(stream_id_t id, std::shared_ptr<cucascade::data_batch> batch);
+
+  /// Sender-set EOS. @throws on unknown input id or unexpected sender.
+  void close_input(stream_id_t id, sender_id_t sender);
+
+  /// Poison an input stream (S2/P1–P4). Rethrown from the engine's next pull on that stream.
+  /// @throws on unknown input id.
+  void fail_input(stream_id_t id, std::exception_ptr error);
+
+  // -----------------------------------------------------------------------
+  // Consumer side — output streams
+  // -----------------------------------------------------------------------
+
+  /// nullopt = nothing now, not EOS — use drained(id). @throws on unknown output id or poison.
+  std::optional<std::shared_ptr<cucascade::data_batch>> pull(stream_id_t id);
+
+  /// External threads only. @throws on unknown output id.
+  void wait(stream_id_t id);
+
+  /// @throws on unknown output id.
+  [[nodiscard]] bool drained(stream_id_t id) const;
+
+  /// Poison an output stream (S2/P1–P4). Wakes consumers blocked in wait(); rethrown from pull().
+  /// Poisons all partitions of the sink that owns the given id.
+  /// @throws on unknown output id.
+  void fail_output(stream_id_t id, std::exception_ptr error);
+
+ private:
+  struct sink_output {
+    op::sirius_physical_streaming_sink* sink;
+    std::size_t partition;
+  };
+
+  [[nodiscard]] op::sirius_physical_streaming_source& resolve_source(stream_id_t id) const;
+  [[nodiscard]] const sink_output& resolve_sink(stream_id_t id) const;
+
+  std::map<stream_id_t, op::sirius_physical_streaming_source*> _sources;
+  std::map<stream_id_t, sink_output> _sinks;
+};
+
+}  // namespace sirius::exec

--- a/test/cpp/exec/test_stream_session.cpp
+++ b/test/cpp/exec/test_stream_session.cpp
@@ -1,0 +1,480 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../operator/operator_test_utils.hpp"
+
+#include <catch.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <data/data_batch_utils.hpp>
+#include <exec/stream_session.hpp>
+#include <helper/type_conversions.hpp>
+#include <sirius/exception.hpp>
+
+#include <memory>
+#include <set>
+#include <vector>
+
+using namespace sirius::exec;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+
+namespace {
+
+using namespace sirius::test::operator_utils;
+
+/// A streaming source plus the repository behind it, so a test can inspect where a routed push
+/// actually landed.
+struct source_fixture {
+  std::shared_ptr<sirius_physical_streaming_source> source;
+  std::shared_ptr<cucascade::shared_data_repository> repo;
+};
+
+source_fixture make_source(std::set<sender_id_t> expected = {0})
+{
+  auto repo   = std::make_shared<cucascade::shared_data_repository>();
+  auto source = std::make_shared<sirius_physical_streaming_source>(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    repo,
+    std::move(expected));
+  return {std::move(source), std::move(repo)};
+}
+
+struct sink_fixture {
+  std::shared_ptr<sirius_physical_streaming_sink> sink;
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos;
+};
+
+/// Single-destination sink (INTEGER payload, no partitioning).
+sink_fixture make_sink()
+{
+  auto repo = std::make_shared<cucascade::shared_data_repository>();
+  auto sink = std::make_shared<sirius_physical_streaming_sink>(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    repo);
+  return {std::move(sink), {std::move(repo)}};
+}
+
+/// Partitioned sink over `n` destinations, routing on column 0 of a (BIGINT, INTEGER) schema.
+sink_fixture make_partitioned_sink(std::size_t n)
+{
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> repos;
+  for (std::size_t i = 0; i < n; ++i) {
+    repos.push_back(std::make_shared<cucascade::shared_data_repository>());
+  }
+  duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType::BIGINT,
+                                            duckdb::LogicalType::INTEGER};
+  auto sink = std::make_shared<sirius_physical_streaming_sink>(
+    sirius::from_duckdb_vec(types), 0, repos, partition_spec{{0}});
+  return {std::move(sink), std::move(repos)};
+}
+
+/// Feed one batch through a sink exactly as publish_output() would.
+void sink_one(sirius_physical_streaming_sink& sink, std::shared_ptr<cucascade::data_batch> batch)
+{
+  pipelineable_operator_data data{
+    std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(batch)}};
+  sink.sink(data, default_stream());
+}
+
+}  // namespace
+
+// ============================================================================
+// SESS-1: registration is reflected in the two id namespaces
+// ============================================================================
+
+TEST_CASE("stream_session SESS-1: input and output ids are separate namespaces", "[stream_session]")
+{
+  auto in  = make_source();
+  auto out = make_sink();
+
+  stream_session session;
+  // Deliberately the same numeric id on both sides: direction, not the number, disambiguates.
+  session.add_source(7, *in.source);
+  session.add_sink({7}, *out.sink);
+
+  REQUIRE(session.input_streams() == std::vector<stream_id_t>{7});
+  REQUIRE(session.output_streams() == std::vector<stream_id_t>{7});
+}
+
+// ============================================================================
+// SESS-2: push routes to the addressed source, and only that one
+// ============================================================================
+
+TEST_CASE("stream_session SESS-2: push reaches only the addressed source", "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto a = make_source();
+  auto b = make_source();
+
+  stream_session session;
+  session.add_source(10, *a.source);
+  session.add_source(20, *b.source);
+
+  REQUIRE(session.push(10, make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32)));
+  REQUIRE(a.repo->total_size() == 1);
+  REQUIRE(b.repo->total_size() == 0);
+
+  REQUIRE(session.push(20, make_numeric_batch<int32_t>(*gpu_space, {2}, cudf::type_id::INT32)));
+  REQUIRE(a.repo->total_size() == 1);
+  REQUIRE(b.repo->total_size() == 1);
+}
+
+// ============================================================================
+// SESS-3: close_input marks one sender of one stream
+// ============================================================================
+
+TEST_CASE("stream_session SESS-3: close_input is scoped to its stream and sender",
+          "[stream_session]")
+{
+  auto a = make_source({0, 1});
+  auto b = make_source({0});
+
+  stream_session session;
+  session.add_source(10, *a.source);
+  session.add_source(20, *b.source);
+
+  session.close_input(10, 0);
+  REQUIRE(a.source->stream().sender_closed(0));
+  REQUIRE_FALSE(a.source->stream().terminal());  // still waiting on sender 1
+  REQUIRE_FALSE(b.source->stream().terminal());  // untouched
+
+  session.close_input(20, 0);
+  REQUIRE(b.source->stream().terminal());
+  REQUIRE_FALSE(a.source->stream().terminal());
+}
+
+// ============================================================================
+// SESS-4: pull / wait / drained read only the addressed output stream
+// ============================================================================
+
+TEST_CASE("stream_session SESS-4: output calls resolve to one sink partition", "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto a = make_sink();
+  auto b = make_sink();
+
+  stream_session session;
+  session.add_sink({100}, *a.sink);
+  session.add_sink({200}, *b.sink);
+
+  auto batch    = make_numeric_batch<int32_t>(*gpu_space, {42}, cudf::type_id::INT32);
+  auto batch_id = batch->get_batch_id();
+  sink_one(*a.sink, batch);
+
+  REQUIRE_FALSE(session.pull(200).has_value());
+  auto pulled = session.pull(100);
+  REQUIRE(pulled.has_value());
+  REQUIRE((*pulled)->get_batch_id() == batch_id);
+
+  a.sink->finalize_operator();
+  REQUIRE(session.drained(100));
+  REQUIRE_FALSE(session.drained(200));
+}
+
+// ============================================================================
+// SESS-5: a partitioned sink registers one id per destination, positionally
+// ============================================================================
+
+TEST_CASE("stream_session SESS-5: each sink partition gets its own stream id", "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 3;
+  auto out                = make_partitioned_sink(N);
+
+  stream_session session;
+  const std::vector<stream_id_t> ids{300, 301, 302};
+  session.add_sink(ids, *out.sink);
+  REQUIRE(session.output_streams() == ids);
+
+  std::vector<int64_t> keys;
+  std::vector<int32_t> vals;
+  for (int i = 0; i < 32; ++i) {
+    keys.push_back(i);
+    vals.push_back(i);
+  }
+  sink_one(*out.sink,
+           make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+  out.sink->finalize_operator();
+
+  // ids[i] must address repository i and nothing else.
+  for (std::size_t i = 0; i < N; ++i) {
+    const bool repo_has_data = !out.repos[i]->all_empty();
+    REQUIRE(session.drained(ids[i]) == !repo_has_data);
+    REQUIRE(session.pull(ids[i]).has_value() == repo_has_data);
+  }
+}
+
+// ============================================================================
+// SESS-6: an unknown id is a defined error on every verb
+// ============================================================================
+
+TEST_CASE("stream_session SESS-6: unknown ids are rejected", "[stream_session]")
+{
+  auto in  = make_source();
+  auto out = make_sink();
+
+  stream_session session;
+  session.add_source(1, *in.source);
+  session.add_sink({2}, *out.sink);
+
+  REQUIRE_THROWS_AS(session.push(99, nullptr), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(session.close_input(99, 0), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(session.pull(99), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(session.wait(99), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(session.drained(99), sirius::invalid_input_exception);
+
+  // An output id is not usable as an input id, and vice versa — the namespaces do not leak.
+  REQUIRE_THROWS_AS(session.push(2, nullptr), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(session.pull(1), sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// SESS-7: registration contracts
+// ============================================================================
+
+TEST_CASE("stream_session SESS-7: registration is validated", "[stream_session]")
+{
+  auto in    = make_source();
+  auto other = make_source();
+  auto out   = make_partitioned_sink(2);
+  auto spare = make_sink();
+
+  stream_session session;
+  session.add_source(1, *in.source);
+
+  // A duplicate id must be rejected rather than silently rebinding the stream to another
+  // operator. (Registration takes a reference, so a null operator is not expressible.)
+  REQUIRE_THROWS_AS(session.add_source(1, *other.source), sirius::invalid_input_exception);
+
+  // One id per destination — an id list that does not match the sink's fan-out would silently
+  // leave a partition unaddressable.
+  REQUIRE_THROWS_AS(session.add_sink({10}, *out.sink), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(session.add_sink({10, 11, 12}, *out.sink), sirius::invalid_input_exception);
+
+  session.add_sink({10, 11}, *out.sink);
+  REQUIRE_THROWS_AS(session.add_sink({11}, *spare.sink), sirius::invalid_input_exception);
+
+  // An id repeated inside one call is rejected too — otherwise the second occurrence would
+  // silently win and one partition would be unreachable.
+  auto twice = make_partitioned_sink(2);
+  REQUIRE_THROWS_AS(session.add_sink({20, 20}, *twice.sink), sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// SESS-7b: a rejected add_sink leaves the session untouched
+// ============================================================================
+
+TEST_CASE("stream_session SESS-7b: a rejected registration inserts nothing", "[stream_session]")
+{
+  auto first  = make_sink();
+  auto second = make_partitioned_sink(3);
+
+  stream_session session;
+  session.add_sink({10}, *first.sink);
+
+  // Ids are validated before any is inserted, so the good ids ahead of the clash (30, 31) must
+  // not be left behind. A partial insert would make a caller that catches and retries trip over
+  // its own leftovers as duplicates.
+  REQUIRE_THROWS_AS(session.add_sink({30, 31, 10}, *second.sink), sirius::invalid_input_exception);
+
+  REQUIRE(session.output_streams() == std::vector<stream_id_t>{10});
+
+  // ... and the ids from the failed call are still free to use.
+  session.add_sink({30, 31, 32}, *second.sink);
+  REQUIRE(session.output_streams() == std::vector<stream_id_t>{10, 30, 31, 32});
+}
+
+// ============================================================================
+// SESS-8: a source → sink fragment driven entirely by stream id
+// ============================================================================
+
+TEST_CASE("stream_session SESS-8: a fragment round-trips native batches by id", "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream = default_stream();
+  auto in     = make_source();
+  auto out    = make_sink();
+
+  stream_session session;
+  session.add_source(1, *in.source);
+  session.add_sink({2}, *out.sink);
+
+  constexpr int K = 3;
+  std::vector<uint64_t> pushed_ids;
+  for (int i = 0; i < K; ++i) {
+    auto batch = make_numeric_batch<int32_t>(*gpu_space, {i}, cudf::type_id::INT32);
+    pushed_ids.push_back(batch->get_batch_id());
+    REQUIRE(session.push(1, batch));
+  }
+  session.close_input(1, 0);
+
+  // Drive the fragment: source → sink, one task per batch, exactly as the executor would.
+  while (auto hint = in.source->get_next_task_hint()) {
+    REQUIRE(hint->hint == TaskCreationHint::READY);
+    auto input = in.source->get_next_task_input_data();
+    REQUIRE(input != nullptr);
+    auto produced = in.source->execute(*input, stream);
+    out.sink->sink(*produced, stream);
+  }
+  out.sink->finalize_operator();
+
+  std::vector<uint64_t> pulled_ids;
+  while (auto batch = session.pull(2)) {
+    pulled_ids.push_back((*batch)->get_batch_id());
+  }
+  REQUIRE(pulled_ids == pushed_ids);
+  REQUIRE(session.drained(2));
+}
+
+// ============================================================================
+// SESS-9: leaf-fragment shape — partitioned sink, no source. EOS from scan finish.
+// ============================================================================
+
+TEST_CASE("stream_session SESS-9: a leaf fragment registers only output streams",
+          "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  constexpr std::size_t N = 2;
+  auto out                = make_partitioned_sink(N);
+
+  stream_session session;
+  const std::vector<stream_id_t> ids{500, 501};
+  session.add_sink(ids, *out.sink);
+
+  REQUIRE(session.input_streams().empty());
+  REQUIRE(session.output_streams() == ids);
+
+  std::vector<int64_t> keys;
+  std::vector<int32_t> vals;
+  for (int i = 0; i < 16; ++i) {
+    keys.push_back(i);
+    vals.push_back(i * 2);
+  }
+  sink_one(*out.sink,
+           make_two_column_batch<int64_t, int32_t>(*gpu_space, keys, vals, cudf::type_id::INT32));
+
+  // Still producing: no destination may report EOS yet.
+  for (auto id : ids) {
+    REQUIRE_FALSE(session.drained(id));
+  }
+
+  out.sink->finalize_operator();
+
+  int total_rows = 0;
+  for (auto id : ids) {
+    while (auto batch = session.pull(id)) {
+      total_rows += sirius::get_cudf_table_view(**batch).num_rows();
+    }
+    REQUIRE(session.drained(id));
+  }
+  REQUIRE(total_rows == static_cast<int>(keys.size()));
+}
+
+// ============================================================================
+// SESS-10: root-fragment shape — fan-in source, N senders. Sender-set EOS.
+// ============================================================================
+
+TEST_CASE("stream_session SESS-10: a root fragment ends only after every sender closes",
+          "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  auto stream = default_stream();
+  auto in     = make_source({0, 1});
+  auto out    = make_sink();
+
+  stream_session session;
+  session.add_source(600, *in.source);
+  session.add_sink({601}, *out.sink);
+
+  // Sender 0 delivers and closes; sender 1 is still going.
+  REQUIRE(session.push(600, make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32)));
+  session.close_input(600, 0);
+
+  // A duplicate close from sender 0 must not stand in for sender 1 — the failure mode a bare
+  // counter would have, and one that would truncate the root's input.
+  session.close_input(600, 0);
+  REQUIRE_FALSE(in.source->all_ports_empty());
+
+  REQUIRE(session.push(600, make_numeric_batch<int32_t>(*gpu_space, {2}, cudf::type_id::INT32)));
+  session.close_input(600, 1);
+
+  int received = 0;
+  while (auto hint = in.source->get_next_task_hint()) {
+    REQUIRE(hint->hint == TaskCreationHint::READY);
+    auto input = in.source->get_next_task_input_data();
+    REQUIRE(input != nullptr);
+    auto produced = in.source->execute(*input, stream);
+    out.sink->sink(*produced, stream);
+    ++received;
+  }
+  out.sink->finalize_operator();
+
+  REQUIRE(received == 2);
+  REQUIRE(in.source->all_ports_empty());
+
+  int pulled = 0;
+  while (session.pull(601)) {
+    ++pulled;
+  }
+  REQUIRE(pulled == 2);
+  REQUIRE(session.drained(601));
+}
+
+// ============================================================================
+// SESS-11: the session is move-only, and moves keep its routing intact
+// ============================================================================
+
+TEST_CASE("stream_session SESS-11: a moved session still routes", "[stream_session]")
+{
+  auto mem_mgr    = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space = mem_mgr->get_memory_space(Tier::GPU, 0);
+  REQUIRE(gpu_space != nullptr);
+
+  static_assert(!std::is_copy_constructible_v<stream_session>);
+  static_assert(std::is_move_constructible_v<stream_session>);
+
+  auto in = make_source();
+
+  stream_session original;
+  original.add_source(1, *in.source);
+
+  stream_session moved{std::move(original)};
+  REQUIRE(moved.input_streams() == std::vector<stream_id_t>{1});
+  REQUIRE(moved.push(1, make_numeric_batch<int32_t>(*gpu_space, {1}, cudf::type_id::INT32)));
+  REQUIRE(in.repo->total_size() == 1);
+}


### PR DESCRIPTION
Part of #839 — the addressing half. Part 2 of a three-PR stack that replaces #1432.

**Base: #1479 (`stream/13-sink`).** Review that first; this PR's diff is the second commit only.

**What.** A fragment does not know which `batch_stream` a peer will push into — it knows an *id*.
`exec::stream_session` is the lookup table that turns one into the other: streams are registered
under a `(query, stream)` id and resolved by any participant, so a sender and a receiver that
never share a pointer still meet on the same queue.

**Design: a lookup table, not a factory.** Every id this fragment can name is registered once
while the fragment is built, and resolution is pure lookup — an unknown id throws rather than
creating a stream on the spot. That is the single decision the rest of the type follows from.

Creating on resolve would be the more forgiving choice, and it is the wrong one here: a fragment
that resolves an id it never registered has a plan or binding bug, and quietly materializing a
stream would route its data into a queue no peer is holding — a hang at the far end instead of an
error at the near one. Registering the same id twice is an error for the same reason. Ordering
between fragments is handled by the layer above (part 3's bind catalog), not by making this type
tolerant.

**Failure travels by id too.** `fail_input` / `fail_output` put a stream into the error state, so
a peer blocked on it wakes with the producer's actual error rather than hanging until a timeout.
Without this, the only observable form of a remote failure is a stall.

---

**Reviewing.** One commit, one type. `stream_session.hpp` is the contract; the `.cpp` is mostly
locking and the id→stream map.

**Tests.** `test_stream_session.cpp` covers the id namespaces, routing to the addressed
source/sink partition, rejection of unknown and duplicate ids, the error verbs, EOS across
multiple senders, and move semantics. `SESS-7b` pins the all-or-nothing registration guarantee:
a rejected `add_sink` must leave the session exactly as it was.

**Not here.** Nothing constructs a session yet — part 3 wires it into `streaming_fragment`. This
PR is deliberately reviewable as a standalone data structure.

---

**Stack.**

| Part | PR | Branch | Scope |
|---|---|---|---|
| 1 | #1479 | `stream/13-sink` | `STREAMING_SINK` + partitioning (#837, #838) |
| 2 | **#1480 (this)** | `stream/14-session` | `exec::stream_session` (#839, addressing) |
| 3 | #1481 | `stream/15-fragment` | `streaming_fragment` + FFI (#839, execution) |

#839 is closed by part 3, which adds the half that executes.
