### PR TITLE
feat(exec): streaming fragment — plan builder, blocking runner, and Fragment FFI (#839)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,9 @@ set(EXTENSION_SOURCES
     src/exec/admission_control.cpp
     src/exec/batch_stream.cpp
     src/exec/stream_session.cpp
+    src/exec/stream_bind_catalog.cpp
+    src/exec/stream_plan_bindings.cpp
+    src/exec/streaming_fragment.cpp
     # I/O adapters (Phase 19 — io_uring + sirius_datasource)
     src/io/datasource_factory.cpp
     src/io/io_context.cpp
@@ -649,7 +652,9 @@ set(TEST_SOURCES
     test/cpp/exec/test_interruptible_mpmc.cpp
     test/cpp/exec/test_multi_index_priority_queue.cpp
     test/cpp/exec/test_semi_future.cpp
+    test/cpp/exec/test_stream_bind_catalog.cpp
     test/cpp/exec/test_stream_session.cpp
+    test/cpp/exec/test_streaming_fragment.cpp
     test/cpp/expression/test_ast_aggregate.cpp
     test/cpp/expression/test_ast_clone.cpp
     test/cpp/expression/test_ast_substitute.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -652,6 +652,7 @@ set(TEST_SOURCES
     test/cpp/exec/test_interruptible_mpmc.cpp
     test/cpp/exec/test_multi_index_priority_queue.cpp
     test/cpp/exec/test_semi_future.cpp
+    test/cpp/exec/test_sirius_ffi_fragment.cpp
     test/cpp/exec/test_stream_bind_catalog.cpp
     test/cpp/exec/test_stream_session.cpp
     test/cpp/exec/test_streaming_fragment.cpp

--- a/docs/super-sirius/README.md
+++ b/docs/super-sirius/README.md
@@ -37,6 +37,7 @@ SELECT l_returnflag, SUM(l_quantity) FROM lineitem GROUP BY l_returnflag;
 | [Scan](scan.md) | Scan subsystem: unified GPU scan operator, `gpu_ingestible` (parquet + DuckDB-native), scan manager, pinned tables, DuckDB-native decode, row-group pruning, Sirius IO layer (uring/REST/kvikio + prefetching cache) |
 | [Memory Management](memory-management.md) | cuCascade tiers, reservations, downgrade executor |
 | [Data Management](data-management.md) | Data batches, repositories, ports, barrier semantics |
+| [Streaming Sessions](streaming-sessions.md) | Fragment boundaries for distributed queries: `exec::batch_stream`, streaming source/sink, the id-addressed `stream_session`, `streaming_fragment` |
 | [Configuration](configuration.md) | sirius_config, operator_params, SET variables |
 | [Optimizations](optimizations.md) | Performance optimizations with PRs, code paths, configs |
 | [Compressed Pinning](compressed-pinning.md) | Simpatico-compressed pin_table on host/GPU tiers — which tier to compress on, plan selection vs the H2D link, GB300 SF1000 results |

--- a/docs/super-sirius/README.md
+++ b/docs/super-sirius/README.md
@@ -37,7 +37,8 @@ SELECT l_returnflag, SUM(l_quantity) FROM lineitem GROUP BY l_returnflag;
 | [Scan](scan.md) | Scan subsystem: unified GPU scan operator, `gpu_ingestible` (parquet + DuckDB-native), scan manager, pinned tables, DuckDB-native decode, row-group pruning, Sirius IO layer (uring/REST/kvikio + prefetching cache) |
 | [Memory Management](memory-management.md) | cuCascade tiers, reservations, downgrade executor |
 | [Data Management](data-management.md) | Data batches, repositories, ports, barrier semantics |
-| [Streaming Sessions](streaming-sessions.md) | Fragment boundaries for distributed queries: `exec::batch_stream`, streaming source/sink, the id-addressed `stream_session`, `streaming_fragment` |
+| [Streaming Sessions](streaming-sessions.md) | Fragment boundaries for distributed queries: `exec::batch_stream`, streaming source/sink, the id-addressed `stream_session` |
+| [Streaming Fragments](streaming-fragments.md) | Building and running one fragment: `stream_bind_catalog`, `exec::streaming_fragment`, the cross-language `sirius::ffi::Fragment`/`Context` lifecycle |
 | [Configuration](configuration.md) | sirius_config, operator_params, SET variables |
 | [Optimizations](optimizations.md) | Performance optimizations with PRs, code paths, configs |
 | [Compressed Pinning](compressed-pinning.md) | Simpatico-compressed pin_table on host/GPU tiers — which tier to compress on, plan selection vs the H2D link, GB300 SF1000 results |

--- a/docs/super-sirius/streaming-fragments.md
+++ b/docs/super-sirius/streaming-fragments.md
@@ -1,0 +1,329 @@
+# Fragments
+
+A **fragment** is one runnable piece of a (possibly multi-node) query: a bound plan, its declared
+input/output streams, and the machinery to build, run, and drain it. [Streaming
+Sessions](streaming-sessions.md) covers the low-level primitives a fragment is built on
+(`exec::batch_stream`, `STREAMING_SOURCE`/`STREAMING_SINK`, the id-addressed `exec::stream_session`
+router). This document covers the layer above: how a Substrait or DuckDB plan becomes a fragment,
+how its declared streams get a schema before the plan is even bound, and how multiple fragments —
+possibly owned by different processes — chain together via `relay_from()`.
+
+Two classes do this, at two different layers:
+
+| | `exec::streaming_fragment` | `sirius::ffi::Fragment` |
+|---|---|---|
+| **Files** | `src/include/exec/streaming_fragment.hpp`, `src/exec/streaming_fragment.cpp` | `src/include/sirius_ffi.hpp`, `src/sirius_ffi.cpp` |
+| **Caller** | C++ code already inside a live `duckdb::ClientContext` and transaction (e.g. the transparent path, `Context::execute_substrait`) | Any caller that must not include DuckDB/cuDF headers — the Rust bindings, or a standalone C++ embedder |
+| **Owns the connection?** | No — borrows the caller's `ClientContext` | Yes — brings up its own embedded `duckdb::DuckDB` + `Connection` (`Context`) |
+| **Transaction / query window** | Caller's responsibility to bracket | Manages its own, internally, across two phases (see below) |
+| **Shape** | One output-only or gather sink; `spec.plan_source` is a `LogicalOperator` factory | Declare → build → relay → run, addressable by stream id from outside the process |
+
+`sirius::ffi::Fragment` is a PIMPL wrapper around exactly one `exec::streaming_fragment` (or, for a
+result fragment, around the single-shot `sirius_interface` path) — it exists to give a
+cross-language caller everything `streaming_fragment` needs (a connection, a transaction, a query
+window, a bind catalog) without exposing any of it.
+
+## Quick path
+
+```cpp
+// exec::streaming_fragment — caller already owns the transaction/window.
+fragment_spec spec;
+spec.plan_source = my_plan_source;     // ClientContext& -> LogicalOperator
+spec.outputs     = {0};                // one output stream
+streaming_fragment frag(client, std::move(spec));
+frag.build(query_id);
+frag.run();                            // blocks
+drain(frag.session(), 0);              // pull() until drained
+```
+
+```cpp
+// sirius::ffi::Fragment — cross-language, owns everything.
+auto ctx = make_context();
+auto sender = make_fragment(*ctx);
+sender->declare_output(0);
+sender->build(substrait_plan_bytes);   // opens + closes its own setup transaction
+sender->run();                         // blocks; closes the query lifecycle
+
+auto receiver = make_fragment(*ctx);
+receiver->declare_input_column(0, "a", "BIGINT");
+receiver->build(other_plan_bytes);     // this plan reads sirius_stream_source(0) / view sirius_stream_0
+receiver->relay_from(*sender, /*source_stream_id=*/0, /*input_stream_id=*/0, /*sender_id=*/0);
+receiver->run();
+```
+
+## `stream_bind_catalog` + `sirius_stream_source` — bridging bind time and plan time
+
+**Files:** `src/include/exec/stream_bind_catalog.hpp`, `src/exec/stream_bind_catalog.cpp`,
+`src/include/exec/stream_plan_bindings.hpp`, `src/exec/stream_plan_bindings.cpp`
+
+A fragment's input streams do not exist as DuckDB tables — there is nothing in the catalog for the
+binder to look up. `sirius_stream_source(id)`, a table function, stands in for one: its **bind**
+resolves a declared stream's schema (names + types) so the binder is satisfied; its **body never
+runs** — the physical plan generator replaces every `sirius_stream_source` scan with a
+`STREAMING_SOURCE` operator before execution. A plan does not call the function directly; it reads
+`CREATE OR REPLACE VIEW main.sirius_stream_<id> AS SELECT * FROM sirius_stream_source(<id>)`, so a
+Substrait or SQL plan sees an ordinary-looking view name (`stream_view_name(id)` gives callers that
+exact string).
+
+Bind time and plan time are far apart — DuckDB binds a table function long before physical planning
+runs — so both sides need a shared place to look up a declared stream's schema. That place is
+`stream_bind_catalog`, a `duckdb::ClientContextState` registered per-connection:
+
+```cpp
+class stream_bind_catalog : public duckdb::ClientContextState {
+ public:
+  static constexpr const char* kStateKey = "sirius_stream_catalog";
+
+  void declare(stream_id_t id, stream_input_binding binding);  // overwrites same-id entry
+  void clear();                                                 // drop every declaration
+  void erase(stream_id_t id);                                   // drop one; no-op if absent
+
+  const stream_input_binding& get(stream_id_t id) const;        // @throws if undeclared
+  void set_built(stream_id_t id, op::sirius_physical_streaming_source* built);
+};
+
+// Shared by every call site that needs "the catalog on this connection, or a clear error why not".
+duckdb::shared_ptr<stream_bind_catalog> catalog_for(duckdb::ClientContext& context);
+```
+
+The round trip:
+
+```
+declare_input_column(id, name, type) × N   ── caller-side, before build() ──►  stream_bind_catalog::declare(id, ...)
+                                                                                          │
+stream_source_bind()  (DuckDB bind, resolves the CREATE VIEW's schema)  ◄── catalog_for(context)->get(id)
+                                                                                          │
+create_streaming_source_plan()  (physical planning, builds STREAMING_SOURCE)  ◄── catalog_for(context)->get(id)
+                                                                                          │
+                                                                                catalog->set_built(id, source.get())
+                                                                                          │
+streaming_fragment::build() / Fragment::build()  ── reads catalog->get(id).built ──►  session().add_source(id, *built)
+```
+
+`set_built()` is how the physical operator (created deep inside `create_plan()`, which does not
+otherwise return anything the fragment layer can see) gets back to the session that wires it up.
+
+### Contracts
+
+- **Multiple fragments may share one connection at once.** A `Context` in the FFI layer can host
+  several live `Fragment` objects — that is the whole point of `relay_from()` chaining several
+  fragments together. `clear()` drops *every* declaration on the connection and is only safe for a
+  caller that owns the whole catalog outright; a fragment that shares a connection with a peer must
+  use `erase()`, which touches only the ids it declared itself. Both `streaming_fragment` (its
+  destructor and the start of `build()`, for idempotent rebuilds) and `sirius::ffi::Fragment::Impl`
+  follow this discipline — neither ever calls `clear()`.
+- **A declared stream may be read by at most one plan leaf.** `set_built()` rejects a second bind
+  for an id that already has one, instead of silently overwriting the pointer. Without this guard,
+  a plan that reads the same declared stream twice (a self-join, or two independent scans of one
+  shared subexpression) would silently orphan the first leaf: only the *last* bind's operator ends
+  up registered with the session, so the earlier one never receives a push or a close and its
+  pipeline waits forever with no error anywhere. Fan-out reads of one declared stream are not
+  supported; if a plan genuinely needs that, feed each reader its own stream id instead.
+- **The catalog must exist before any bind can succeed.** Both the transparent (normal SQL)
+  connection path and the FFI's own embedded connection install a `stream_bind_catalog` when the
+  connection opens — `SiriusContextExtensionCallback::OnConnectionOpened` for the former,
+  `Context::Impl::bring_up()` for the latter — and remove it on close/teardown. Without this,
+  `catalog_for()` throws immediately on the first `sirius_stream_source` bind or
+  `streaming_fragment::build()` call.
+
+## `exec::streaming_fragment` — plan builder + blocking runner
+
+Owns one fragment's complete life cycle: declares inputs into the catalog, plans, constructs the
+sink, runs, and keeps the output pullable after `run()` returns.
+
+```cpp
+struct fragment_spec {
+  logical_plan_source plan_source;                    // ClientContext& -> LogicalOperator
+  std::map<stream_id_t, stream_input_spec> inputs;     // schema + expected senders per input
+  std::vector<stream_id_t> outputs;                    // positional: outputs[i] = partition i
+  std::optional<op::partition_spec> partitioning;       // absent = single destination
+};
+```
+
+**Construction validates the spec eagerly:** a plan source is required, at least one output stream
+is required (a fragment with none is not this class's job — see the FFI's *result fragment* below),
+and more than one output requires a `partitioning` mode (a bare `N`-output gather sink would leave
+`N-1` streams permanently empty with no way to tell a caller why).
+
+**`build(query_id)`** erases (not clears — see above) this fragment's own catalog ids, redeclares
+them so a rebuild after a caught, corrected failure is idempotent, runs `plan_source` to get a
+bound `LogicalOperator`, lowers it to a physical plan, and roots that plan in one
+`sirius_physical_streaming_sink`:
+
+- **Hash-key cast normalization.** When `partitioning`'s `key_cast_types` is left empty, `build()`
+  derives one per key column so independently-planned senders always hash the same logical value
+  identically — cuDF's `murmur3` hashes raw bytes, and an `INT32` sender vs. an `INT64` sender for
+  the same column would otherwise split matching keys across different partitions. `TINYINT`/
+  `SMALLINT`/`INTEGER` normalize to `INT64`; `BIGINT`/`BOOLEAN`/`VARCHAR` need no cast (`EMPTY`);
+  `DECIMAL` normalizes to `FLOAT64`; anything else throws. A key column outside the sink's own
+  column range throws before any cast is even attempted.
+- Every declared input is checked against the catalog's `built` pointer after planning: a stream
+  declared but never read by the plan throws immediately (a silent hang otherwise — nothing would
+  ever close it).
+- The engine owns the plan and the fragment owns the engine, so the sink (and its output
+  repositories) stay pullable after `run()` returns — the query window's mandatory cleanup never
+  touches them.
+
+**Member declaration order is the lifetime contract.** C++ destroys members in reverse declaration
+order, and `streaming_fragment` relies on it: repositories are declared first (so they outlive
+everything that could still be writing to or reading from them), the engine next (it owns the
+physical plan, which holds raw pointers into the operators the session also points at), and
+`_session` last — so it is torn down *first*, before the engine it borrows operator pointers from
+can go away. Reordering these members is a use-after-free waiting to happen, not a style choice.
+
+**`run()`** reuses the caller's query window rather than opening a second one (a second
+`StandaloneQueryScope` would reset the task creator and scan manager `build()` already populated,
+and the fragment would run zero tasks). On any exception from the engine, it poisons every declared
+output (`_session.fail_output(id, ...)`, swallowing secondary failures per id) **before**
+rethrowing — otherwise a peer parked in `wait()` on that stream would block forever with no error
+anywhere, the same S2/S3 hazard [Streaming Sessions](streaming-sessions.md#execbatch_stream)
+documents for `batch_stream` itself. `fail_output()` is idempotent (first failure wins), so this is
+safe to do at this layer even when a caller above it (`sirius::ffi::Fragment::run()`) also poisons
+the same outputs — see [Other contracts](#other-contracts) below.
+
+**`sink_types()`** exposes the plan root's output column types, set during `build()`. Relay steps
+use it to validate schema agreement (column count and type ids) against a target fragment's
+declared input types before any batch moves.
+
+## `sirius::ffi::Fragment` — the cross-language lifecycle
+
+**Files:** `src/include/sirius_ffi.hpp`, `src/sirius_ffi.cpp`
+
+`Context` is an RAII handle to one embedded engine: its own `duckdb::SiriusContext`, its own
+`duckdb::DuckDB` + `Connection`, and its own `stream_bind_catalog` — everything a fragment needs,
+brought up once and shared by every `Fragment` created on it via `make_fragment(context)`.
+
+`Fragment` is either an **intermediate** fragment (has declared output streams, rooted in a
+`STREAMING_SINK`, wraps one `exec::streaming_fragment`) or a **result** fragment (no declared
+outputs, executes once via `sirius_interface` and produces Arrow through `result_to_arrow()`).
+Which one a `Fragment` becomes is decided implicitly, by whether `declare_output()` was ever
+called (`is_result() == outputs.empty()`) — there is no separate constructor flag.
+
+### `build()`: two phases, two different windows
+
+```
+declare_input_column / declare_input_sender / declare_output / declare_output_broadcast / declare_output_hash_key
+                                          │
+                                          ▼
+                          ┌─── Phase 1: setup transaction ───┐
+                          │  BeginTransaction()               │
+                          │  resolve_inputs()   (type-name parsing — needs a catalog lookup)
+                          │  declare_streams()  (populate stream_bind_catalog)
+                          │  create_stream_views()  (CREATE OR REPLACE VIEW per input, real DDL)
+                          │  Commit()                          │
+                          └────────────────────────────────────┘
+                                          │
+                                          ▼
+                          ┌─── Phase 2: query window ─────────┐
+                          │  StandaloneQueryScope acquired     │
+                          │  partition-mode guard               │
+                          │  is_result() ? single-shot execute-plan path
+                          │              : construct + build() an exec::streaming_fragment
+                          └────────────────────────────────────┘
+```
+
+Phase 1 exists because parsing a DuckDB type name and creating a view both need an active
+transaction, and that transaction **must be committed before Phase 2 begins** — `StandaloneQueryScope`
+acquires the engine's single-flight lifecycle slot, and the two are sequential, not nested. This is
+also why a `Fragment::build()` failure can fall into two different states depending on *which*
+phase it fails in:
+
+- A failure during Phase 1 (a bad type name, a stream id that fails to bind at `CREATE VIEW` time)
+  leaves the transaction open — `transaction_open` was set the instant `BeginTransaction()` returned
+  and is only cleared once `Commit()` itself succeeds.
+- A failure during Phase 2 happens with the transaction already closed; only the query-window slot
+  needs releasing.
+
+`end_lifecycle()` (called from the catch blocks of both phases, and unconditionally from
+`~Fragment::Impl()`) handles both uniformly and is `noexcept`:
+
+```cpp
+void end_lifecycle() noexcept
+{
+  if (lifecycle) { lifecycle.reset(); }               // release the query-window slot, if held
+  if (transaction_open) {
+    transaction_open = false;
+    ctx.conn->Rollback();                              // NOT Commit — see below
+  }
+}
+```
+
+**Why rollback, not commit, on the failure path.** `transaction_open` is true here only because
+setup failed partway through Phase 1 — `build()` clears the flag the instant its *own* `Commit()`
+succeeds, so this branch is reachable only on the failure path, never on a success. If
+`create_stream_views()`'s per-input loop has already created some views by the time a later input
+fails to bind, those `CREATE VIEW` statements are real, uncommitted DuckDB catalog writes sitting in
+the still-open transaction. Committing here would durably persist that half-declared fragment even
+though `build()` as a whole failed; rolling back discards it, which is what "the embedded connection
+is left in a clean state on failure" actually requires. (DuckDB's own `TransactionContext::Commit()`
+and `::Rollback()` both clear the active-transaction slot before doing their real work, regardless
+of outcome — so this distinction is not about whether a *second* `BeginTransaction()` would succeed
+afterward, which it would either way. It is specifically about whether that half-declared catalog
+state survives. See commit `4431213a` for the original fix and its Copilot-review origin.)
+
+### `relay_from()` — moving batches between fragments
+
+```cpp
+std::size_t relay_from(Fragment& source, std::uint64_t source_stream_id,
+                        std::uint64_t input_stream_id, std::uint32_t sender_id);
+```
+
+Drains every batch currently on `source`'s output stream `source_stream_id`, pushes each into this
+fragment's input stream `input_stream_id`, then closes `sender_id` on it. Two preconditions are
+enforced before anything moves:
+
+- **`source` must have already `run()`.** The drain loop pulls until it gets nothing back, and
+  "nothing right now" (stream still open, just empty) is indistinguishable from "stream ended" —
+  see [`exec::batch_stream`'s S1–S5 contracts](streaming-sessions.md#execbatch_stream) for why.
+  Calling `relay_from()` before the source has run would close the input after zero batches and
+  silently truncate the result.
+- **`input_stream_id` must be a declared input on this fragment, and `source` must be an
+  intermediate fragment (not a result fragment).** A result fragment produces Arrow via
+  `result_to_arrow()`, not a relayable stream, so it is rejected explicitly rather than falling
+  through to undefined behavior.
+
+Only then does the schema check run — column count and type-id agreement between the target's
+declared types and the source's `sink_types()` — before any batch actually moves, so a mismatch
+throws instead of silently corrupting a downstream cuDF operation.
+
+### Other contracts
+
+- **A partition mode needs at least two destinations.** `declare_output_broadcast()` /
+  `declare_output_hash_key()` may be called with 0 or 1 declared outputs (they do not themselves
+  check `outputs`), but `build()` rejects that combination outright — checked once, before the
+  result/intermediate split, so it catches a 0-output result fragment the same as a 1-output
+  gather fragment. Without this, every row would go to the single destination either way while the
+  call looked like it had configured routing.
+- **`run()` poisons every declared output on failure, redundantly with `streaming_fragment::run()`.**
+  Both layers call `fail_output()` for every id in `outputs` before rethrowing; because
+  `fail_output()` is first-failure-wins, doing it at both the FFI wrapper and the core
+  `streaming_fragment` is safe, not double-poisoning in any harmful sense — it just means a direct
+  `streaming_fragment` caller (a unit test, or any future caller that bypasses the FFI) gets the
+  same protection a `Fragment` caller does.
+
+## Tests
+
+| File | Catch2 tags |
+|---|---|
+| `test/cpp/exec/test_stream_bind_catalog.cpp` | `[stream_bind_catalog]` |
+| `test/cpp/exec/test_streaming_fragment.cpp` | `[integration][streaming_fragment]`, `[integration][streaming_fragment_control]` |
+| `test/cpp/exec/test_sirius_ffi_fragment.cpp` | `[isolated_context][sirius_ffi]` |
+
+The FFI-level tests are tagged `[isolated_context]` because `sirius::ffi::Context` brings up its own
+`SiriusContext` (its own GPU memory pools) — the Catch2 listener in `test/cpp/unittest.cpp` pauses
+the shared test environments around any test with that tag so it doesn't contend with them for GPU
+memory. `sirius::ffi::Context`/`Fragment` have no raw-SQL or catalog-introspection escape hatch, so
+FFI-level tests are necessarily built around observable, public-API behavior (a failed `build()`
+throws, and a subsequent independent `Fragment` on the same `Context` can attempt its own `build()`
+right after) rather than inspecting DuckDB catalog state directly.
+
+## Not yet ported
+
+`Fragment::run()` blocks — it goes through `streaming_fragment::run()` → `sirius_engine::execute()`,
+which takes the future from `start_query()` and waits immediately. Fragments therefore run
+store-and-forward, one at a time (`relay_from(...)` orders strictly before `run()`, and only one
+fragment may sit between its own `build()` and `run()`). The `Fragment` surface exposes no
+`push`/`pull`/`wait`, so a genuinely remote sender cannot feed a fragment yet — `relay_from()` only
+moves batches that are already sitting in a *local*, already-finished source fragment's output
+repository. Non-blocking scheduling and a `push`/`pull`/`wait` FFI are tracked separately, not
+claimed here.

--- a/docs/super-sirius/streaming-sessions.md
+++ b/docs/super-sirius/streaming-sessions.md
@@ -361,3 +361,109 @@ from the **downgrade executor** instead: queued batches sit in repositories wher
 sweep can see and spill them (GPU → host → disk). Cross-fragment and cross-query pressure is a
 scheduling concern (per-fragment priority), and a future sink↔source slowness signal would be
 additive — nothing in this design forecloses it.
+
+## `exec::streaming_fragment` — plan builder + blocking runner
+
+**Files:** `src/include/exec/streaming_fragment.hpp`, `src/exec/streaming_fragment.cpp`
+
+Owns a complete fragment life cycle: declares inputs, builds the plan, constructs the sink, runs,
+and keeps the output pullable after `run()` returns.
+
+```
+fragment_spec spec = { plan_source, inputs, outputs, partitioning };
+streaming_fragment frag(context, spec);
+frag.build(query_id);   // declare → plan → create operators → register with session
+// push batches into frag.session() here if this fragment has inputs
+frag.run();             // blocks until all pipelines finish
+// pull from frag.session() until drained
+```
+
+Two lifetime decisions are load-bearing:
+
+**Repositories outlive the engine.** The fragment creates every repository before planning and
+registers none of them with `data_repository_manager_`. The query window's mandatory cleanup
+(`StandaloneQueryScope::finish()`) therefore cannot touch them. A sender's output stays in its
+repository and is still there when the receiver runs — which is what makes sequential streaming
+work without copying.
+
+**One query window, shared.** `run()` reuses the caller's `StandaloneQueryScope` rather than
+opening its own. A second scope resets the task creator and scan manager that `build()` populated;
+the fragment would then run zero tasks and return silently empty. The caller brackets `build()`
+and `run()` in one window (as `Context::execute_substrait` does for ordinary queries).
+
+**Hash key cast normalization.** When the spec carries a `partition_spec` with `key_cast_types`
+left empty, `build()` derives a cast type per key column so independently-planned senders always
+produce the same hash for the same logical value. cuDF's murmur3 hashes raw bytes, so without
+normalization an INT32 sender and an INT64 sender assign the same key to different partitions and
+groups are silently split. Rules:
+
+| Column type | Normalized cast |
+|---|---|
+| `TINYINT`, `SMALLINT`, `INTEGER` | `INT64` (canonical 64-bit) |
+| `BIGINT`, `BOOLEAN`, `VARCHAR` | `EMPTY` (hash as-is — already canonical) |
+| `DECIMAL` (any precision/scale) | `FLOAT64` |
+| anything else | throws at build time |
+
+Callers that supply their own `key_cast_types` bypass normalization.
+
+**`sink_types()` exposes the plan root's output column types** (set during `build()`; throws if
+called before `build()`). Relay steps use this to validate schema agreement — column count and
+type-id must match the target fragment's declared input types — before pulling any batches.
+Without this check, a misrouted relay silently corrupts downstream cuDF operations.
+
+**`stream_bind_catalog` bridges bind time and plan time.** DuckDB's table-function bind runs
+long before physical planning. The catalog is registered as a `ClientContextState` so
+`sirius_stream_source(id)` can resolve a schema at bind time; the physical plan generator
+re-reads the catalog at plan time to build each `STREAMING_SOURCE`.
+
+## Fragment FFI (`sirius_ffi.hpp` / `sirius_ffi.cpp`)
+
+**Files:** `src/include/sirius_ffi.hpp`, `src/sirius_ffi.cpp`
+
+A thin PIMPL layer that lets the Rust wrapper (or any C++ caller) drive multi-fragment execution
+without including any DuckDB/cuDF headers. Two public classes:
+
+**`Context`** — RAII handle to one engine instance. `execute_substrait()` runs a single-fragment
+query end-to-end. `make_context()` / `make_context_from_config()` are the factories.
+
+**`Fragment`** — one plan fragment of a multi-fragment query. Usage is strictly ordered:
+
+```
+declare_input_column / declare_input_sender   (schema of each input stream)
+declare_output / declare_output_broadcast / declare_output_hash_key
+build(substrait_plan)      ← opens the query lifecycle
+relay_from(source, ...)    ← move batches from a finished source fragment (or close_input for remote)
+run()                      ← executes; closes the lifecycle
+result_to_arrow(addr)      ← result fragments only: write Arrow stream
+```
+
+A fragment is **intermediate** (has output streams, rooted in a `STREAMING_SINK`) or a **result**
+fragment (no output streams, executes via `sirius_interface` and produces Arrow). Both kinds may
+have input streams declared and fed by other fragments.
+
+`relay_from()` validates column count and type-ids (using `sink_types()`) before moving any
+batches — a schema mismatch throws before data moves rather than reinterpreting columns silently.
+
+`stream_view_name(id)` returns `"sirius_stream_<id>"` — the DuckDB view name a Substrait plan
+must read to consume that input stream. `build()` creates the view on the embedded connection.
+
+**Not yet ported:** `export_packed` / `push_packed` / `StagingArena` — these require the
+exchange staging arena (`exchange_staging_arena`) which is a separate porting item (PRD §6).
+
+## Tests
+
+| File | Catch2 tags |
+|---|---|
+| `test/cpp/exec/test_batch_stream.cpp` | `[batch_stream]` |
+| `test/cpp/operator/test_physical_streaming_source.cpp` | `[streaming_source]`, `[streaming_source][pipeline_completion]` |
+| `test/cpp/operator/test_physical_streaming_sink.cpp` | `[streaming_sink]` |
+| `test/cpp/exec/test_stream_session.cpp` | `[stream_session]` |
+| `test/cpp/exec/test_stream_bind_catalog.cpp` | `[stream_bind_catalog]` |
+| `test/cpp/exec/test_streaming_fragment.cpp` | `[integration][streaming_fragment]`, `[integration][streaming_fragment_control]` |
+| `test/cpp/pipeline/test_streaming_sink_root.cpp` | `[integration][pipeline][streaming_sink_root]`, `[integration][pipeline][streaming_sink_root_exec]` |
+
+A `recording_task_creator` stands in for the scheduler, so the live re-arm and the `on_data`
+hook path are proven without a live executor. The `[pipeline_completion]` cases drive the real
+`sirius_pipeline` completion predicate rather than the operator in isolation, because the bugs
+they cover live in what *calls* `update_pipeline_status()`. Everything tagged `[integration]`
+needs a GPU and the real DuckDB integration database.

--- a/docs/super-sirius/streaming-sessions.md
+++ b/docs/super-sirius/streaming-sessions.md
@@ -362,93 +362,11 @@ sweep can see and spill them (GPU → host → disk). Cross-fragment and cross-q
 scheduling concern (per-fragment priority), and a future sink↔source slowness signal would be
 additive — nothing in this design forecloses it.
 
-## `exec::streaming_fragment` — plan builder + blocking runner
+## Fragments: `exec::streaming_fragment` and the FFI
 
-**Files:** `src/include/exec/streaming_fragment.hpp`, `src/exec/streaming_fragment.cpp`
-
-Owns a complete fragment life cycle: declares inputs, builds the plan, constructs the sink, runs,
-and keeps the output pullable after `run()` returns.
-
-```
-fragment_spec spec = { plan_source, inputs, outputs, partitioning };
-streaming_fragment frag(context, spec);
-frag.build(query_id);   // declare → plan → create operators → register with session
-// push batches into frag.session() here if this fragment has inputs
-frag.run();             // blocks until all pipelines finish
-// pull from frag.session() until drained
-```
-
-Two lifetime decisions are load-bearing:
-
-**Repositories outlive the engine.** The fragment creates every repository before planning and
-registers none of them with `data_repository_manager_`. The query window's mandatory cleanup
-(`StandaloneQueryScope::finish()`) therefore cannot touch them. A sender's output stays in its
-repository and is still there when the receiver runs — which is what makes sequential streaming
-work without copying.
-
-**One query window, shared.** `run()` reuses the caller's `StandaloneQueryScope` rather than
-opening its own. A second scope resets the task creator and scan manager that `build()` populated;
-the fragment would then run zero tasks and return silently empty. The caller brackets `build()`
-and `run()` in one window (as `Context::execute_substrait` does for ordinary queries).
-
-**Hash key cast normalization.** When the spec carries a `partition_spec` with `key_cast_types`
-left empty, `build()` derives a cast type per key column so independently-planned senders always
-produce the same hash for the same logical value. cuDF's murmur3 hashes raw bytes, so without
-normalization an INT32 sender and an INT64 sender assign the same key to different partitions and
-groups are silently split. Rules:
-
-| Column type | Normalized cast |
-|---|---|
-| `TINYINT`, `SMALLINT`, `INTEGER` | `INT64` (canonical 64-bit) |
-| `BIGINT`, `BOOLEAN`, `VARCHAR` | `EMPTY` (hash as-is — already canonical) |
-| `DECIMAL` (any precision/scale) | `FLOAT64` |
-| anything else | throws at build time |
-
-Callers that supply their own `key_cast_types` bypass normalization.
-
-**`sink_types()` exposes the plan root's output column types** (set during `build()`; throws if
-called before `build()`). Relay steps use this to validate schema agreement — column count and
-type-id must match the target fragment's declared input types — before pulling any batches.
-Without this check, a misrouted relay silently corrupts downstream cuDF operations.
-
-**`stream_bind_catalog` bridges bind time and plan time.** DuckDB's table-function bind runs
-long before physical planning. The catalog is registered as a `ClientContextState` so
-`sirius_stream_source(id)` can resolve a schema at bind time; the physical plan generator
-re-reads the catalog at plan time to build each `STREAMING_SOURCE`.
-
-## Fragment FFI (`sirius_ffi.hpp` / `sirius_ffi.cpp`)
-
-**Files:** `src/include/sirius_ffi.hpp`, `src/sirius_ffi.cpp`
-
-A thin PIMPL layer that lets the Rust wrapper (or any C++ caller) drive multi-fragment execution
-without including any DuckDB/cuDF headers. Two public classes:
-
-**`Context`** — RAII handle to one engine instance. `execute_substrait()` runs a single-fragment
-query end-to-end. `make_context()` / `make_context_from_config()` are the factories.
-
-**`Fragment`** — one plan fragment of a multi-fragment query. Usage is strictly ordered:
-
-```
-declare_input_column / declare_input_sender   (schema of each input stream)
-declare_output / declare_output_broadcast / declare_output_hash_key
-build(substrait_plan)      ← opens the query lifecycle
-relay_from(source, ...)    ← move batches from a finished source fragment (or close_input for remote)
-run()                      ← executes; closes the lifecycle
-result_to_arrow(addr)      ← result fragments only: write Arrow stream
-```
-
-A fragment is **intermediate** (has output streams, rooted in a `STREAMING_SINK`) or a **result**
-fragment (no output streams, executes via `sirius_interface` and produces Arrow). Both kinds may
-have input streams declared and fed by other fragments.
-
-`relay_from()` validates column count and type-ids (using `sink_types()`) before moving any
-batches — a schema mismatch throws before data moves rather than reinterpreting columns silently.
-
-`stream_view_name(id)` returns `"sirius_stream_<id>"` — the DuckDB view name a Substrait plan
-must read to consume that input stream. `build()` creates the view on the embedded connection.
-
-**Not yet ported:** `export_packed` / `push_packed` / `StagingArena` — these require the
-exchange staging arena (`exchange_staging_arena`) which is a separate porting item (PRD §6).
+The layer above these primitives — building a plan around them, bridging DuckDB bind time to
+physical-plan time via `stream_bind_catalog`, and the cross-language `sirius::ffi::Fragment`
+lifecycle — has its own document: [Streaming Fragments](streaming-fragments.md).
 
 ## Tests
 
@@ -458,9 +376,10 @@ exchange staging arena (`exchange_staging_arena`) which is a separate porting it
 | `test/cpp/operator/test_physical_streaming_source.cpp` | `[streaming_source]`, `[streaming_source][pipeline_completion]` |
 | `test/cpp/operator/test_physical_streaming_sink.cpp` | `[streaming_sink]` |
 | `test/cpp/exec/test_stream_session.cpp` | `[stream_session]` |
-| `test/cpp/exec/test_stream_bind_catalog.cpp` | `[stream_bind_catalog]` |
-| `test/cpp/exec/test_streaming_fragment.cpp` | `[integration][streaming_fragment]`, `[integration][streaming_fragment_control]` |
 | `test/cpp/pipeline/test_streaming_sink_root.cpp` | `[integration][pipeline][streaming_sink_root]`, `[integration][pipeline][streaming_sink_root_exec]` |
+
+Fragment-layer tests (`test_stream_bind_catalog.cpp`, `test_streaming_fragment.cpp`,
+`test_sirius_ffi_fragment.cpp`) are listed in [Streaming Fragments](streaming-fragments.md#tests).
 
 A `recording_task_creator` stands in for the scheduler, so the live re-arm and the `on_data`
 hook path are proven without a live executor. The `[pipeline_completion]` cases drive the real

--- a/src/exec/stream_bind_catalog.cpp
+++ b/src/exec/stream_bind_catalog.cpp
@@ -51,6 +51,12 @@ void stream_bind_catalog::clear()
   _entries.clear();
 }
 
+void stream_bind_catalog::erase(stream_id_t id)
+{
+  std::lock_guard<std::mutex> guard(_mutex);
+  _entries.erase(id);
+}
+
 bool stream_bind_catalog::contains(stream_id_t id) const
 {
   std::lock_guard<std::mutex> guard(_mutex);
@@ -92,6 +98,17 @@ std::vector<stream_id_t> stream_bind_catalog::declared_streams() const
     ids.push_back(id);
   }
   return ids;
+}
+
+duckdb::shared_ptr<stream_bind_catalog> catalog_for(duckdb::ClientContext& context)
+{
+  auto catalog = context.registered_state->Get<stream_bind_catalog>(stream_bind_catalog::kStateKey);
+  if (!catalog) {
+    throw sirius::invalid_input_exception(
+      "no stream catalog on this connection — the fragment must declare its input streams before "
+      "the plan is bound");
+  }
+  return catalog;
 }
 
 }  // namespace sirius::exec

--- a/src/exec/stream_bind_catalog.cpp
+++ b/src/exec/stream_bind_catalog.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/stream_bind_catalog.hpp"
+
+#include "sirius/exception.hpp"
+
+#include <string>
+#include <utility>
+
+namespace sirius::exec {
+
+void stream_bind_catalog::declare(stream_id_t id, stream_input_binding binding)
+{
+  if (binding.repository == nullptr) {
+    throw sirius::invalid_input_exception("stream_bind_catalog: input stream " +
+                                          std::to_string(id) +
+                                          " must be declared with a repository");
+  }
+  if (binding.names.size() != binding.types.size()) {
+    throw sirius::invalid_input_exception(
+      "stream_bind_catalog: input stream " + std::to_string(id) + " declares " +
+      std::to_string(binding.names.size()) + " column names but " +
+      std::to_string(binding.types.size()) + " types");
+  }
+  if (binding.names.empty()) {
+    throw sirius::invalid_input_exception("stream_bind_catalog: input stream " +
+                                          std::to_string(id) + " must declare at least one column");
+  }
+
+  std::lock_guard<std::mutex> guard(_mutex);
+  _entries[id] = std::move(binding);
+}
+
+void stream_bind_catalog::clear()
+{
+  std::lock_guard<std::mutex> guard(_mutex);
+  _entries.clear();
+}
+
+bool stream_bind_catalog::contains(stream_id_t id) const
+{
+  std::lock_guard<std::mutex> guard(_mutex);
+  return _entries.find(id) != _entries.end();
+}
+
+namespace {
+
+[[noreturn]] void throw_undeclared(stream_id_t id)
+{
+  throw sirius::invalid_input_exception("stream_bind_catalog: no input stream declared with id " +
+                                        std::to_string(id));
+}
+
+}  // namespace
+
+const stream_input_binding& stream_bind_catalog::get(stream_id_t id) const
+{
+  std::lock_guard<std::mutex> guard(_mutex);
+  auto it = _entries.find(id);
+  if (it == _entries.end()) { throw_undeclared(id); }
+  return it->second;
+}
+
+void stream_bind_catalog::set_built(stream_id_t id, op::sirius_physical_streaming_source* built)
+{
+  std::lock_guard<std::mutex> guard(_mutex);
+  auto it = _entries.find(id);
+  if (it == _entries.end()) { throw_undeclared(id); }
+  it->second.built = built;
+}
+
+std::vector<stream_id_t> stream_bind_catalog::declared_streams() const
+{
+  std::lock_guard<std::mutex> guard(_mutex);
+  std::vector<stream_id_t> ids;
+  ids.reserve(_entries.size());
+  for (const auto& [id, _] : _entries) {
+    ids.push_back(id);
+  }
+  return ids;
+}
+
+}  // namespace sirius::exec

--- a/src/exec/stream_bind_catalog.cpp
+++ b/src/exec/stream_bind_catalog.cpp
@@ -86,6 +86,15 @@ void stream_bind_catalog::set_built(stream_id_t id, op::sirius_physical_streamin
   std::lock_guard<std::mutex> guard(_mutex);
   auto it = _entries.find(id);
   if (it == _entries.end()) { throw_undeclared(id); }
+  if (it->second.built != nullptr) {
+    // Each declared stream backs exactly one batch_stream; a second plan leaf reading the same
+    // id (e.g. a self-join) would silently overwrite the first leaf's pointer here, so pushes
+    // and closes would never reach it and its pipeline would wait forever.
+    throw sirius::invalid_input_exception(
+      "stream_bind_catalog: input stream " + std::to_string(id) +
+      " is read by more than one operator in the same plan — fan-out reads of a single "
+      "declared stream are not supported");
+  }
   it->second.built = built;
 }
 

--- a/src/exec/stream_plan_bindings.cpp
+++ b/src/exec/stream_plan_bindings.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/stream_plan_bindings.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "helper/type_conversions.hpp"
+
+#include <stdexcept>
+
+namespace sirius::exec {
+
+namespace {
+
+/// Resolve the per-connection stream_bind_catalog, or explain why the fragment is not set up.
+duckdb::shared_ptr<stream_bind_catalog> catalog_for(duckdb::ClientContext& context)
+{
+  auto catalog = context.registered_state->Get<stream_bind_catalog>(stream_bind_catalog::kStateKey);
+  if (!catalog) {
+    throw std::runtime_error(
+      "sirius_stream_source: no stream catalog on this connection — the fragment must declare its "
+      "input streams before the plan is bound");
+  }
+  return catalog;
+}
+
+duckdb::unique_ptr<duckdb::FunctionData> stream_source_bind(
+  duckdb::ClientContext& context,
+  duckdb::TableFunctionBindInput& input,
+  duckdb::vector<duckdb::LogicalType>& return_types,
+  duckdb::vector<std::string>& names)
+{
+  if (input.inputs.size() != 1 || input.inputs[0].IsNull()) {
+    throw std::runtime_error("sirius_stream_source expects a single non-null stream id");
+  }
+  auto const stream_id = static_cast<stream_id_t>(input.inputs[0].GetValue<std::int64_t>());
+
+  // Undeclared id = bind error (not a silent empty scan).
+  auto const& binding = catalog_for(context)->get(stream_id);
+
+  names        = duckdb::vector<std::string>(binding.names.begin(), binding.names.end());
+  return_types = sirius::to_duckdb_vec(binding.types);
+  return duckdb::make_uniq<stream_source_bind_data>(stream_id);
+}
+
+/// Never runs: plan generator replaces this scan with STREAMING_SOURCE.
+void stream_source_function(duckdb::ClientContext&, duckdb::TableFunctionInput&, duckdb::DataChunk&)
+{
+  throw std::runtime_error(
+    "sirius_stream_source cannot be executed by DuckDB: it is an internal marker for a Sirius "
+    "streaming input and is only valid inside a GPU-executed fragment plan");
+}
+
+}  // namespace
+
+void register_stream_source_function(duckdb::DatabaseInstance& instance)
+{
+  auto transaction = duckdb::CatalogTransaction::GetSystemTransaction(instance);
+  auto& catalog    = duckdb::Catalog::GetSystemCatalog(instance);
+
+  duckdb::TableFunction stream_source(kStreamSourceFunctionName,
+                                      {duckdb::LogicalType::BIGINT},
+                                      stream_source_function,
+                                      stream_source_bind);
+
+  duckdb::CreateTableFunctionInfo info(stream_source);
+  // Idempotent: extension callback and explicit callers may both register.
+  info.on_conflict = duckdb::OnCreateConflict::IGNORE_ON_CONFLICT;
+  catalog.CreateTableFunction(transaction, info);
+}
+
+}  // namespace sirius::exec

--- a/src/exec/stream_plan_bindings.cpp
+++ b/src/exec/stream_plan_bindings.cpp
@@ -20,24 +20,13 @@
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "helper/type_conversions.hpp"
+#include "sirius/exception.hpp"
 
-#include <stdexcept>
+#include <string>
 
 namespace sirius::exec {
 
 namespace {
-
-/// Resolve the per-connection stream_bind_catalog, or explain why the fragment is not set up.
-duckdb::shared_ptr<stream_bind_catalog> catalog_for(duckdb::ClientContext& context)
-{
-  auto catalog = context.registered_state->Get<stream_bind_catalog>(stream_bind_catalog::kStateKey);
-  if (!catalog) {
-    throw std::runtime_error(
-      "sirius_stream_source: no stream catalog on this connection — the fragment must declare its "
-      "input streams before the plan is bound");
-  }
-  return catalog;
-}
 
 duckdb::unique_ptr<duckdb::FunctionData> stream_source_bind(
   duckdb::ClientContext& context,
@@ -46,9 +35,18 @@ duckdb::unique_ptr<duckdb::FunctionData> stream_source_bind(
   duckdb::vector<std::string>& names)
 {
   if (input.inputs.size() != 1 || input.inputs[0].IsNull()) {
-    throw std::runtime_error("sirius_stream_source expects a single non-null stream id");
+    throw sirius::invalid_input_exception(
+      "sirius_stream_source expects a single non-null stream id");
   }
-  auto const stream_id = static_cast<stream_id_t>(input.inputs[0].GetValue<std::int64_t>());
+  // SQL hands this over as a signed INT64. Reject a negative before the cast, or it wraps to a
+  // huge unsigned id and the failure surfaces as a confusing "no input stream declared with id
+  // 18446744073709551615".
+  auto const signed_id = input.inputs[0].GetValue<std::int64_t>();
+  if (signed_id < 0) {
+    throw sirius::invalid_input_exception("sirius_stream_source: stream id must not be negative (" +
+                                          std::to_string(signed_id) + ")");
+  }
+  auto const stream_id = static_cast<stream_id_t>(signed_id);
 
   // Undeclared id = bind error (not a silent empty scan).
   auto const& binding = catalog_for(context)->get(stream_id);
@@ -61,7 +59,7 @@ duckdb::unique_ptr<duckdb::FunctionData> stream_source_bind(
 /// Never runs: plan generator replaces this scan with STREAMING_SOURCE.
 void stream_source_function(duckdb::ClientContext&, duckdb::TableFunctionInput&, duckdb::DataChunk&)
 {
-  throw std::runtime_error(
+  throw sirius::invalid_input_exception(
     "sirius_stream_source cannot be executed by DuckDB: it is an internal marker for a Sirius "
     "streaming input and is only valid inside a GPU-executed fragment plan");
 }

--- a/src/exec/streaming_fragment.cpp
+++ b/src/exec/streaming_fragment.cpp
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/streaming_fragment.hpp"
+
+#include "planner/sirius_physical_plan_generator.hpp"
+#include "sirius/exception.hpp"
+#include "sirius_context.hpp"
+#include "sirius_engine.hpp"
+#include "sirius_interface.hpp"
+
+#include <cudf/types.hpp>
+
+#include <string>
+#include <utility>
+
+namespace sirius::exec {
+
+namespace {
+
+constexpr const char* kFragmentQueryLabel = "sirius_streaming_fragment";
+
+// Derive a per-key cuDF cast type so independently-planned senders always hash identically.
+// Different planners may bind the same logical column to different native widths (e.g. INT32 vs
+// INT64). cuDF's murmur3 hashes bytes, not values, so without normalization matching keys land in
+// different partitions and groups are silently split.
+//
+// Rules (mirror integration::streaming_fragment::build):
+//   TINYINT / SMALLINT / INTEGER → INT64   (all sub-64-bit integers → canonical 64-bit)
+//   BIGINT / BOOLEAN / VARCHAR   → EMPTY   (already canonical; hash as-is)
+//   DECIMAL (any precision/scale) → FLOAT64 (normalized floating representation)
+//   anything else                → throw
+cudf::data_type derive_key_cast_type(const sirius::logical_type& t)
+{
+  switch (t.id()) {
+    case sirius::type_id::TINYINT:
+    case sirius::type_id::SMALLINT:
+    case sirius::type_id::INTEGER: return cudf::data_type{cudf::type_id::INT64};
+    case sirius::type_id::BIGINT:
+    case sirius::type_id::BOOLEAN:
+    case sirius::type_id::VARCHAR: return cudf::data_type{cudf::type_id::EMPTY};
+    case sirius::type_id::DECIMAL: return cudf::data_type{cudf::type_id::FLOAT64};
+    default:
+      throw sirius::invalid_input_exception(
+        "streaming_fragment: unsupported partition key type — only integer, boolean, varchar, and "
+        "decimal columns may be used as hash partition keys");
+  }
+}
+
+// Fill partition_spec::key_cast_types when the caller left it empty.
+// No-op when the caller supplied their own cast types.
+void normalize_key_cast_types(op::partition_spec& spec,
+                              const duckdb::vector<sirius::logical_type>& output_types)
+{
+  if (!spec.key_cast_types.empty()) { return; }
+  spec.key_cast_types.reserve(spec.key_columns.size());
+  for (int key : spec.key_columns) {
+    spec.key_cast_types.push_back(derive_key_cast_type(output_types[key]));
+  }
+}
+
+duckdb::shared_ptr<stream_bind_catalog> catalog_for(duckdb::ClientContext& context)
+{
+  auto catalog = context.registered_state->Get<stream_bind_catalog>(stream_bind_catalog::kStateKey);
+  if (!catalog) {
+    throw sirius::invalid_input_exception(
+      "streaming_fragment: no stream catalog on this connection");
+  }
+  return catalog;
+}
+
+}  // namespace
+
+streaming_fragment::streaming_fragment(duckdb::ClientContext& context, fragment_spec spec)
+  : _context(context), _spec(std::move(spec))
+{
+  if (!_spec.plan_source) {
+    throw sirius::invalid_input_exception("streaming_fragment: a plan source is required");
+  }
+  if (_spec.outputs.empty()) {
+    throw sirius::invalid_input_exception(
+      "streaming_fragment: a fragment must declare at least one output stream");
+  }
+  if (_spec.outputs.size() > 1 && !_spec.partitioning.has_value()) {
+    throw sirius::invalid_input_exception(
+      "streaming_fragment: " + std::to_string(_spec.outputs.size()) +
+      " output streams need a partition spec; a gather fragment has exactly one");
+  }
+
+  // Repositories escape data_repository_manager_ cleanup so sender output outlives this fragment.
+  for (const auto& [id, _] : _spec.inputs) {
+    _input_repos[id] = std::make_shared<cucascade::shared_data_repository>();
+  }
+  for (auto id : _spec.outputs) {
+    if (_output_repos.count(id) != 0) {
+      throw sirius::invalid_input_exception("streaming_fragment: duplicate output stream id " +
+                                            std::to_string(id));
+    }
+    _output_repos[id] = std::make_shared<cucascade::shared_data_repository>();
+  }
+}
+
+streaming_fragment::~streaming_fragment()
+{
+  // Clear per-connection catalog; swallow in dtor.
+  try {
+    catalog_for(_context)->clear();
+  } catch (...) {  // NOLINT(bugprone-empty-catch)
+  }
+}
+
+void streaming_fragment::build(sirius::query_id_t query_id)
+{
+  if (_built) { throw sirius::invalid_input_exception("streaming_fragment: already built"); }
+
+  auto catalog = catalog_for(_context);
+  catalog->clear();
+
+  // Declare before planning: bind resolves schema; create_plan reads repo + senders.
+  for (const auto& [id, input] : _spec.inputs) {
+    catalog->declare(
+      id,
+      stream_input_binding{
+        input.names, input.types, _input_repos.at(id), input.expected_senders, nullptr});
+  }
+
+  auto logical_plan = _spec.plan_source(_context);
+  if (!logical_plan) {
+    throw sirius::invalid_input_exception("streaming_fragment: plan source produced no plan");
+  }
+
+  sirius::planner::sirius_physical_plan_generator generator(_context);
+  auto subtree = generator.create_plan(std::move(logical_plan));
+
+  // STREAMING_SINK is a normal unary: subtree in children[] (unlike RESULT_COLLECTOR).
+  auto types       = subtree->types;
+  auto cardinality = subtree->estimated_cardinality;
+  _sink_types      = types;  // snapshot before types is moved into the sink constructor
+
+  std::vector<std::shared_ptr<cucascade::shared_data_repository>> sink_repos;
+  sink_repos.reserve(_spec.outputs.size());
+  for (auto id : _spec.outputs) {
+    sink_repos.push_back(_output_repos.at(id));
+  }
+
+  duckdb::unique_ptr<op::sirius_physical_streaming_sink> sink;
+  if (_spec.partitioning.has_value()) {
+    normalize_key_cast_types(*_spec.partitioning, types);
+    sink = duckdb::make_uniq<op::sirius_physical_streaming_sink>(
+      std::move(types), cardinality, std::move(sink_repos), *_spec.partitioning);
+  } else {
+    sink = duckdb::make_uniq<op::sirius_physical_streaming_sink>(
+      std::move(types), cardinality, sink_repos.front());
+  }
+  sink->children.push_back(std::move(subtree));
+
+  // Engine owns the plan; fragment owns the engine so the sink stays pullable after run().
+  _iface = std::make_unique<sirius::sirius_interface>(
+    _context, std::optional<std::string>(kFragmentQueryLabel));
+  _engine = std::make_unique<sirius::sirius_engine>(_context, *_iface, query_id);
+  _engine->initialize(std::move(sink));
+
+  auto& sink_ref = _engine->sirius_physical_plan->Cast<op::sirius_physical_streaming_sink>();
+
+  _session.add_sink(_spec.outputs, sink_ref);
+  for (const auto& [id, _] : _spec.inputs) {
+    auto* built = catalog->get(id).built;
+    if (built == nullptr) {
+      // Declared but unread = hang; fail loudly.
+      throw sirius::invalid_input_exception("streaming_fragment: input stream " +
+                                            std::to_string(id) +
+                                            " was declared but the plan does not read it");
+    }
+    _session.add_source(id, *built);
+  }
+
+  _built = true;
+}
+
+void streaming_fragment::run()
+{
+  if (!_built) {
+    throw sirius::invalid_input_exception("streaming_fragment: build() must run before run()");
+  }
+
+  // Shared query window (don't open a second StandaloneQueryScope): a new window resets
+  // task_creator / scan manager that build() populated → zero tasks, empty output, no error.
+  _engine->execute();
+}
+
+const duckdb::vector<sirius::logical_type>& streaming_fragment::sink_types() const
+{
+  if (!_built) {
+    throw sirius::invalid_input_exception("streaming_fragment: sink_types() called before build()");
+  }
+  return _sink_types;
+}
+
+const std::shared_ptr<cucascade::shared_data_repository>& streaming_fragment::input_repository(
+  stream_id_t id) const
+{
+  auto it = _input_repos.find(id);
+  if (it == _input_repos.end()) {
+    throw sirius::invalid_input_exception("streaming_fragment: no input stream with id " +
+                                          std::to_string(id));
+  }
+  return it->second;
+}
+
+const std::shared_ptr<cucascade::shared_data_repository>& streaming_fragment::output_repository(
+  stream_id_t id) const
+{
+  auto it = _output_repos.find(id);
+  if (it == _output_repos.end()) {
+    throw sirius::invalid_input_exception("streaming_fragment: no output stream with id " +
+                                          std::to_string(id));
+  }
+  return it->second;
+}
+
+}  // namespace sirius::exec

--- a/src/exec/streaming_fragment.cpp
+++ b/src/exec/streaming_fragment.cpp
@@ -38,7 +38,7 @@ constexpr const char* kFragmentQueryLabel = "sirius_streaming_fragment";
 // INT64). cuDF's murmur3 hashes bytes, not values, so without normalization matching keys land in
 // different partitions and groups are silently split.
 //
-// Rules (mirror integration::streaming_fragment::build):
+// Rules:
 //   TINYINT / SMALLINT / INTEGER → INT64   (all sub-64-bit integers → canonical 64-bit)
 //   BIGINT / BOOLEAN / VARCHAR   → EMPTY   (already canonical; hash as-is)
 //   DECIMAL (any precision/scale) → FLOAT64 (normalized floating representation)
@@ -68,18 +68,15 @@ void normalize_key_cast_types(op::partition_spec& spec,
   if (!spec.key_cast_types.empty()) { return; }
   spec.key_cast_types.reserve(spec.key_columns.size());
   for (int key : spec.key_columns) {
+    // The sink validates key ranges too, but it is constructed after this runs — so an
+    // out-of-range or negative key would index output_types out of bounds first.
+    if (key < 0 || static_cast<std::size_t>(key) >= output_types.size()) {
+      throw sirius::invalid_input_exception("streaming_fragment: partition key column " +
+                                            std::to_string(key) + " is out of range for a " +
+                                            std::to_string(output_types.size()) + "-column output");
+    }
     spec.key_cast_types.push_back(derive_key_cast_type(output_types[key]));
   }
-}
-
-duckdb::shared_ptr<stream_bind_catalog> catalog_for(duckdb::ClientContext& context)
-{
-  auto catalog = context.registered_state->Get<stream_bind_catalog>(stream_bind_catalog::kStateKey);
-  if (!catalog) {
-    throw sirius::invalid_input_exception(
-      "streaming_fragment: no stream catalog on this connection");
-  }
-  return catalog;
 }
 
 }  // namespace
@@ -115,9 +112,13 @@ streaming_fragment::streaming_fragment(duckdb::ClientContext& context, fragment_
 
 streaming_fragment::~streaming_fragment()
 {
-  // Clear per-connection catalog; swallow in dtor.
+  // Drop only the ids this fragment declared. clear() would wipe the whole per-connection
+  // catalog, including a peer fragment's declarations; swallow in dtor.
   try {
-    catalog_for(_context)->clear();
+    auto catalog = catalog_for(_context);
+    for (const auto& [id, _] : _spec.inputs) {
+      catalog->erase(id);
+    }
   } catch (...) {  // NOLINT(bugprone-empty-catch)
   }
 }
@@ -127,7 +128,11 @@ void streaming_fragment::build(sirius::query_id_t query_id)
   if (_built) { throw sirius::invalid_input_exception("streaming_fragment: already built"); }
 
   auto catalog = catalog_for(_context);
-  catalog->clear();
+  // Same reason as the destructor: erase our own ids so a rebuild is idempotent without
+  // discarding declarations that belong to another fragment on this connection.
+  for (const auto& [id, _] : _spec.inputs) {
+    catalog->erase(id);
+  }
 
   // Declare before planning: bind resolves schema; create_plan reads repo + senders.
   for (const auto& [id, input] : _spec.inputs) {

--- a/src/exec/streaming_fragment.cpp
+++ b/src/exec/streaming_fragment.cpp
@@ -201,9 +201,24 @@ void streaming_fragment::run()
     throw sirius::invalid_input_exception("streaming_fragment: build() must run before run()");
   }
 
-  // Shared query window (don't open a second StandaloneQueryScope): a new window resets
-  // task_creator / scan manager that build() populated → zero tasks, empty output, no error.
-  _engine->execute();
+  try {
+    // Shared query window (don't open a second StandaloneQueryScope): a new window resets
+    // task_creator / scan manager that build() populated → zero tasks, empty output, no error.
+    _engine->execute();
+  } catch (...) {
+    // Poison every output before unwinding: otherwise the streams are neither closed nor
+    // failed, so a peer parked in wait() blocks forever with no error anywhere. fail_output is
+    // idempotent (first-failure-wins), so this stays safe even when a caller (e.g.
+    // sirius::ffi::Fragment::run()) also poisons the same outputs itself.
+    auto const cause = std::current_exception();
+    for (auto id : _spec.outputs) {
+      try {
+        _session.fail_output(id, cause);
+      } catch (...) {  // NOLINT(bugprone-empty-catch)
+      }
+    }
+    throw;
+  }
 }
 
 const duckdb::vector<sirius::logical_type>& streaming_fragment::sink_types() const

--- a/src/include/exec/stream_bind_catalog.hpp
+++ b/src/include/exec/stream_bind_catalog.hpp
@@ -42,7 +42,8 @@ struct stream_input_binding {
 };
 
 /// Per-connection declared input streams. ClientContextState so DuckDB bind can resolve schema
-/// before physical planning. One fragment per connection at a time.
+/// before physical planning. Multiple fragments may share one connection at once (e.g. chained
+/// via relay_from), each owning a disjoint set of ids — see clear() vs erase() below.
 class stream_bind_catalog : public duckdb::ClientContextState {
  public:
   static constexpr const char* kStateKey = "sirius_stream_catalog";
@@ -65,7 +66,9 @@ class stream_bind_catalog : public duckdb::ClientContextState {
   /// @throws sirius::invalid_input_exception when `id` was never declared.
   [[nodiscard]] const stream_input_binding& get(stream_id_t id) const;
 
-  /// @throws sirius::invalid_input_exception when `id` was never declared.
+  /// @throws sirius::invalid_input_exception when `id` was never declared, or when it already
+  ///         has a built operator (the same declared stream read by more than one plan leaf —
+  ///         fan-out reads of a single declared stream are not supported).
   void set_built(stream_id_t id, op::sirius_physical_streaming_source* built);
 
   [[nodiscard]] std::vector<stream_id_t> declared_streams() const;

--- a/src/include/exec/stream_bind_catalog.hpp
+++ b/src/include/exec/stream_bind_catalog.hpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "duckdb/main/client_context_state.hpp"
+#include "exec/batch_stream.hpp"
+#include "exec/stream_session.hpp"
+#include "op/sirius_physical_streaming_source.hpp"
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace sirius::exec {
+
+/// Schema + provenance for one input stream. Caller-supplied; never inferred.
+struct stream_input_binding {
+  std::vector<std::string> names;
+  duckdb::vector<sirius::logical_type> types;
+  std::shared_ptr<cucascade::shared_data_repository> repository;
+  std::set<sender_id_t> expected_senders;
+
+  /// Back-pointer into the engine-owned plan; filled during planning for session registration.
+  op::sirius_physical_streaming_source* built = nullptr;
+};
+
+/// Per-connection declared input streams. ClientContextState so DuckDB bind can resolve schema
+/// before physical planning. One fragment per connection at a time.
+class stream_bind_catalog : public duckdb::ClientContextState {
+ public:
+  static constexpr const char* kStateKey = "sirius_stream_catalog";
+
+  /// Overwrites any previous declaration for the same id.
+  /// @throws sirius::invalid_input_exception on null repository, names/types size mismatch, or
+  ///         empty names.
+  void declare(stream_id_t id, stream_input_binding binding);
+
+  void clear();
+
+  [[nodiscard]] bool contains(stream_id_t id) const;
+
+  /// @throws sirius::invalid_input_exception when `id` was never declared.
+  [[nodiscard]] const stream_input_binding& get(stream_id_t id) const;
+
+  /// @throws sirius::invalid_input_exception when `id` was never declared.
+  void set_built(stream_id_t id, op::sirius_physical_streaming_source* built);
+
+  [[nodiscard]] std::vector<stream_id_t> declared_streams() const;
+
+ private:
+  mutable std::mutex _mutex;
+  std::map<stream_id_t, stream_input_binding> _entries;
+};
+
+}  // namespace sirius::exec

--- a/src/include/exec/stream_bind_catalog.hpp
+++ b/src/include/exec/stream_bind_catalog.hpp
@@ -52,7 +52,13 @@ class stream_bind_catalog : public duckdb::ClientContextState {
   ///         empty names.
   void declare(stream_id_t id, stream_input_binding binding);
 
+  /// Drop every declaration on this connection. Only safe when the caller owns the whole
+  /// catalog; a fragment sharing a connection must use erase() so it cannot wipe a peer's ids.
   void clear();
+
+  /// Drop one declaration. No-op when `id` was never declared, so teardown paths can call it
+  /// unconditionally.
+  void erase(stream_id_t id);
 
   [[nodiscard]] bool contains(stream_id_t id) const;
 
@@ -68,5 +74,11 @@ class stream_bind_catalog : public duckdb::ClientContextState {
   mutable std::mutex _mutex;
   std::map<stream_id_t, stream_input_binding> _entries;
 };
+
+/// The catalog registered on `context`, or an error explaining that the fragment never declared
+/// its inputs. Shared by the three places that need it — the bind function, the fragment, and the
+/// plan generator — so they cannot drift on the message or the exception type.
+/// @throws sirius::invalid_input_exception when no catalog is registered on the connection.
+duckdb::shared_ptr<stream_bind_catalog> catalog_for(duckdb::ClientContext& context);
 
 }  // namespace sirius::exec

--- a/src/include/exec/stream_plan_bindings.hpp
+++ b/src/include/exec/stream_plan_bindings.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/database.hpp"
+#include "exec/stream_bind_catalog.hpp"
+
+namespace sirius::exec {
+
+inline constexpr const char* kStreamSourceFunctionName = "sirius_stream_source";
+
+/// Bind data for sirius_stream_source(stream_id). Schema comes from stream_bind_catalog.
+struct stream_source_bind_data : public duckdb::FunctionData {
+  explicit stream_source_bind_data(stream_id_t stream_id) : stream_id(stream_id) {}
+
+  stream_id_t stream_id;
+
+  duckdb::unique_ptr<duckdb::FunctionData> Copy() const override
+  {
+    return duckdb::make_uniq<stream_source_bind_data>(stream_id);
+  }
+
+  bool Equals(duckdb::FunctionData const& other_p) const override
+  {
+    auto const& other = other_p.Cast<stream_source_bind_data>();
+    return stream_id == other.stream_id;
+  }
+};
+
+/// Register sirius_stream_source(id). Bind reads stream_bind_catalog; body never runs
+/// (replaced by STREAMING_SOURCE).
+void register_stream_source_function(duckdb::DatabaseInstance& instance);
+
+}  // namespace sirius::exec

--- a/src/include/exec/streaming_fragment.hpp
+++ b/src/include/exec/streaming_fragment.hpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "exec/stream_bind_catalog.hpp"
+#include "exec/stream_session.hpp"
+#include "op/sirius_physical_streaming_sink.hpp"
+#include "query_id.hpp"
+
+#include <duckdb/main/client_context.hpp>
+#include <duckdb/planner/logical_operator.hpp>
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace sirius {
+class sirius_engine;
+class sirius_interface;
+}  // namespace sirius
+
+namespace sirius::exec {
+
+struct stream_input_spec {
+  std::vector<std::string> names;
+  duckdb::vector<sirius::logical_type> types;
+  /// Sender-set EOS: stream ends only once all have closed.
+  std::set<sender_id_t> expected_senders;
+};
+
+/// Bound, optimized DuckDB logical plan (Substrait bytes, SQL, …).
+using logical_plan_source =
+  std::function<duckdb::unique_ptr<duckdb::LogicalOperator>(duckdb::ClientContext&)>;
+
+struct fragment_spec {
+  logical_plan_source plan_source;
+  std::map<stream_id_t, stream_input_spec> inputs;
+  /// Positional: outputs[i] addresses partition i.
+  std::vector<stream_id_t> outputs;
+  /// Absent = gather (single destination, no partitioning).
+  std::optional<op::partition_spec> partitioning;
+};
+
+/// Owns repos/engine/session for one fragment.
+/// Repositories escape data_repository_manager_ cleanup (survive the query window).
+/// Engine owns the plan so the sink stays pullable after run().
+class streaming_fragment {
+ public:
+  /// Validates the spec and creates one repository per declared stream.
+  /// @throws sirius::invalid_input_exception when plan_source is unset, outputs empty, N>1
+  ///         without partitioning, or on a duplicate output id.
+  streaming_fragment(duckdb::ClientContext& context, fragment_spec spec);
+
+  /// Clears this fragment's declarations from the connection's stream_bind_catalog.
+  ~streaming_fragment();
+
+  streaming_fragment(const streaming_fragment&)            = delete;
+  streaming_fragment& operator=(const streaming_fragment&) = delete;
+
+  /// Declare inputs, lower to STREAMING_SOURCE/SINK, register with session. Separate from
+  /// run() so callers can push first.
+  /// @throws sirius::invalid_input_exception when already built, no catalog, null plan, or a
+  ///         declared input the plan never reads.
+  /// @throws whatever the plan source, binder, or plan generator raises.
+  void build(sirius::query_id_t query_id);
+
+  /// Submit and block. Shared query window (don't open a second StandaloneQueryScope between
+  /// build and run).
+  /// @throws sirius::invalid_input_exception when build() has not run.
+  /// @throws whatever the engine's execution raises.
+  void run();
+
+  [[nodiscard]] stream_session& session() { return _session; }
+
+  [[nodiscard]] sirius::sirius_engine& engine() { return *_engine; }
+
+  /// Physical output column types of the plan root (set during build()).
+  /// Used by relay steps to validate schema agreement before any data moves.
+  /// @throws sirius::invalid_input_exception when build() has not run.
+  [[nodiscard]] const duckdb::vector<sirius::logical_type>& sink_types() const;
+
+  /// @throws sirius::invalid_input_exception when `id` is not a declared input stream.
+  [[nodiscard]] const std::shared_ptr<cucascade::shared_data_repository>& input_repository(
+    stream_id_t id) const;
+
+  /// @throws sirius::invalid_input_exception when `id` is not a declared output stream.
+  [[nodiscard]] const std::shared_ptr<cucascade::shared_data_repository>& output_repository(
+    stream_id_t id) const;
+
+ private:
+  duckdb::ClientContext& _context;
+  fragment_spec _spec;
+
+  // Declaration order IS the lifetime contract (destroyed in reverse): repositories outlive
+  // the engine, the engine owns the plan, and the session (borrowing operators) is torn down first.
+  std::map<stream_id_t, std::shared_ptr<cucascade::shared_data_repository>> _input_repos;
+  std::map<stream_id_t, std::shared_ptr<cucascade::shared_data_repository>> _output_repos;
+  std::unique_ptr<sirius::sirius_interface> _iface;
+  std::unique_ptr<sirius::sirius_engine> _engine;
+  stream_session _session;
+
+  bool _built{false};
+  duckdb::vector<sirius::logical_type> _sink_types;
+};
+
+}  // namespace sirius::exec

--- a/src/include/planner/sirius_physical_plan_generator.hpp
+++ b/src/include/planner/sirius_physical_plan_generator.hpp
@@ -166,6 +166,13 @@ class sirius_physical_plan_generator {
   // &op);
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(duckdb::LogicalFilter& op);
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(duckdb::LogicalGet& op);
+
+  //! Builds the STREAMING_SOURCE a `sirius_stream_source(id)` read stands for, wired to the
+  //! repository and expected sender set the fragment declared for that id on this connection.
+  //! Records the built operator back into the catalog so the fragment can register it with its
+  //! stream_session once the plan tree owns it.
+  duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_streaming_source_plan(
+    duckdb::LogicalGet& op);
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(duckdb::LogicalLimit& op);
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(duckdb::LogicalOrder& op);
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(duckdb::LogicalTopN& op);

--- a/src/include/sirius_ffi.hpp
+++ b/src/include/sirius_ffi.hpp
@@ -114,14 +114,16 @@ class SIRIUS_FFI_EXPORT Fragment {
   /// @throws after build() or on duplicate id.
   void declare_output(std::uint64_t stream_id);
 
-  /// Every output receives the full fragment output (broadcast sink). With a single declared
-  /// output this is a no-op. Mutually exclusive with declare_output_hash_key.
-  /// @throws after build().
+  /// Every output receives the full fragment output (broadcast sink). Requires at least two
+  /// declared outputs: build() rejects a partition mode declared on 0 or 1 outputs rather than
+  /// silently ignoring it. Mutually exclusive with declare_output_hash_key.
+  /// @throws after build(), or from build() itself when fewer than two outputs are declared.
   void declare_output_broadcast();
 
   /// Declare one hash-partition key column for a multi-output sink. Call once per key in
-  /// partition-expression order. Mutually exclusive with declare_output_broadcast.
-  /// @throws after build().
+  /// partition-expression order. Requires at least two declared outputs, same as
+  /// declare_output_broadcast(). Mutually exclusive with declare_output_broadcast.
+  /// @throws after build(), or from build() itself when fewer than two outputs are declared.
   void declare_output_hash_key(std::uint32_t column_index);
 
   /// Lower and plan `substrait_plan` against the declared streams; open the query lifecycle.

--- a/src/include/sirius_ffi.hpp
+++ b/src/include/sirius_ffi.hpp
@@ -32,12 +32,15 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 #ifndef SIRIUS_FFI_EXPORT
 #define SIRIUS_FFI_EXPORT __attribute__((visibility("default")))
 #endif
 
 namespace sirius::ffi {
+
+class Fragment;
 
 /// RAII handle to a Sirius engine context.
 ///
@@ -66,27 +69,117 @@ class SIRIUS_FFI_EXPORT Context {
   /// of record batches). `out_stream_addr` is the address of a caller-owned
   /// `ArrowArrayStream` that the caller releases per the Arrow ABI. Throws on
   /// translation or execution failure.
-  ///
-  /// `plan` is the protobuf-encoded `substrait::Plan` as a byte buffer; its reads
-  /// must be resolvable by DuckDB (e.g. `local_files` parquet reads). The stream
-  /// is passed as an integer address so this public header stays free of
-  /// Arrow/DuckDB types; the Rust bindings pass the address of an
-  /// `FFI_ArrowArrayStream` they own.
   void execute_substrait(const std::string& plan, std::uintptr_t out_stream_addr);
 
  private:
-  // PIMPL: the engine handle + embedded DuckDB live in the .cpp so this public
-  // header pulls in no DuckDB/cudf/rmm types (DuckDB uses its own smart pointers).
   struct Impl;
   std::unique_ptr<Impl> impl_;
+
+  friend class Fragment;
+  friend SIRIUS_FFI_EXPORT std::unique_ptr<Fragment> make_fragment(Context& context);
 };
 
-/// Create an initialized [`Context`] configured from built-in defaults, owned by
-/// the returned `unique_ptr`.
+/// One plan fragment of a multi-fragment query, executed on this process's [`Context`].
+///
+/// A fragment is either **intermediate** (declares output streams, rooted in a streaming sink)
+/// or a **result** fragment (no output streams, produces Arrow). Both kinds may declare input
+/// streams fed by other fragments without copying.
+///
+/// Usage order: declare inputs/outputs → build → relay_from every sender → run →
+/// drain via relay_from or result_to_arrow.
+///
+/// build() opens a query lifecycle; run() closes it. Exactly one fragment may sit between its
+/// own build() and run() at a time (the engine serializes queries). A Fragment destroyed after
+/// build() but before run() closes the lifecycle itself.
+class SIRIUS_FFI_EXPORT Fragment {
+ public:
+  ~Fragment();
+
+  Fragment(const Fragment&)            = delete;
+  Fragment& operator=(const Fragment&) = delete;
+
+  /// Declare one column of input stream `stream_id` (in plan order). `type` is a DuckDB type
+  /// name (`BIGINT`, `DECIMAL(15,2)`, `DATE`, …).
+  /// @throws after build().
+  void declare_input_column(std::uint64_t stream_id,
+                            const std::string& name,
+                            const std::string& type);
+
+  /// Declare a sender that must close input stream `stream_id` before it ends. With none
+  /// declared the stream expects single sender 0.
+  /// @throws after build().
+  void declare_input_sender(std::uint64_t stream_id, std::uint32_t sender_id);
+
+  /// Declare an output stream. A fragment with no output stream is a result fragment.
+  /// @throws after build() or on duplicate id.
+  void declare_output(std::uint64_t stream_id);
+
+  /// Every output receives the full fragment output (broadcast sink). With a single declared
+  /// output this is a no-op. Mutually exclusive with declare_output_hash_key.
+  /// @throws after build().
+  void declare_output_broadcast();
+
+  /// Declare one hash-partition key column for a multi-output sink. Call once per key in
+  /// partition-expression order. Mutually exclusive with declare_output_broadcast.
+  /// @throws after build().
+  void declare_output_hash_key(std::uint32_t column_index);
+
+  /// Lower and plan `substrait_plan` against the declared streams; open the query lifecycle.
+  /// Creates a view `sirius_stream_<id>` for each declared input stream.
+  /// @throws on translation/planning failure or if already built.
+  void build(const std::string& substrait_plan);
+
+  /// Move every batch on `source`'s output stream `source_stream_id` into this fragment's
+  /// input stream `input_stream_id`, then close `sender_id` on it. Schema is validated before
+  /// any data moves. Must be called after source.run() and before this->run().
+  /// @return number of batches moved.
+  /// @throws on unknown stream id, schema mismatch, or before build().
+  std::size_t relay_from(Fragment& source,
+                         std::uint64_t source_stream_id,
+                         std::uint64_t input_stream_id,
+                         std::uint32_t sender_id);
+
+  /// Close sender `sender_id` on input stream `stream_id`. EOS mirror for remote senders
+  /// (relay_from closes its own sender). Idempotent per sender.
+  /// @throws before build() or on unknown stream/sender.
+  void close_input(std::uint64_t stream_id, std::uint32_t sender_id);
+
+  /// Execute the fragment and close the query lifecycle. Blocks until pipelines finish.
+  /// @throws before build() or on execution failure.
+  void run();
+
+  /// Write this result fragment's rows into the caller-owned ArrowArrayStream at
+  /// `out_stream_addr` (Arrow C Data Interface). Same contract as Context::execute_substrait.
+  /// @throws on an intermediate fragment or before run().
+  void result_to_arrow(std::uintptr_t out_stream_addr);
+
+  /// Batches currently parked on output stream `stream_id`. For diagnostics.
+  [[nodiscard]] std::size_t output_batch_count(std::uint64_t stream_id) const;
+
+  /// DuckDB type-name strings for each output column. Matches what declare_input_column accepts.
+  /// @throws before build() or on a result fragment.
+  [[nodiscard]] std::unique_ptr<std::vector<std::string>> output_types() const;
+
+ private:
+  struct Impl;
+  explicit Fragment(std::unique_ptr<Impl> impl);
+  std::unique_ptr<Impl> impl_;
+
+  friend SIRIUS_FFI_EXPORT std::unique_ptr<Fragment> make_fragment(Context& context);
+};
+
+/// Create a [`Context`] configured from built-in defaults.
 SIRIUS_FFI_EXPORT std::unique_ptr<Context> make_context();
 
-/// Create an initialized [`Context`] configured from the YAML file at
-/// `config_path`, owned by the returned `unique_ptr`.
+/// Create a [`Context`] configured from the YAML file at `config_path`.
 SIRIUS_FFI_EXPORT std::unique_ptr<Context> make_context_from_config(const std::string& config_path);
+
+/// Create a [`Fragment`] on `context`. The context must outlive it.
+SIRIUS_FFI_EXPORT std::unique_ptr<Fragment> make_fragment(Context& context);
+
+/// DuckDB view name a plan must read to consume input stream `stream_id`.
+/// Fragment::build() creates this view; the plan emits a read of this name where a file scan
+/// would otherwise appear.
+SIRIUS_FFI_EXPORT std::unique_ptr<std::string> stream_view_name(std::uint64_t stream_id);
 
 }  // namespace sirius::ffi

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -205,12 +205,7 @@ sirius_physical_plan_generator::create_streaming_source_plan(duckdb::LogicalGet&
     throw duckdb::InternalException("sirius_stream_source is missing its stream bind data");
   }
 
-  auto catalog = context.registered_state->Get<sirius::exec::stream_bind_catalog>(
-    sirius::exec::stream_bind_catalog::kStateKey);
-  if (!catalog) {
-    throw duckdb::InternalException(
-      "sirius_stream_source bound without a stream catalog on this connection");
-  }
+  auto catalog        = sirius::exec::catalog_for(context);
   auto const& binding = catalog->get(bind->stream_id);
 
   // Projection pushdown is off; a narrowed column list here would disagree with the binder.

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -29,6 +29,8 @@
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/local_storage.hpp"
+#include "exec/stream_bind_catalog.hpp"
+#include "exec/stream_plan_bindings.hpp"
 #include "expression/ast/from_duckdb.hpp"
 #include "expression/ast/node.hpp"
 #include "helper/numeric_narrowing.hpp"
@@ -196,6 +198,40 @@ duckdb::unique_ptr<duckdb::TableFilterSet> create_table_filter_set(
 }
 
 duckdb::unique_ptr<sirius::op::sirius_physical_operator>
+sirius_physical_plan_generator::create_streaming_source_plan(duckdb::LogicalGet& op)
+{
+  auto const* bind = dynamic_cast<sirius::exec::stream_source_bind_data const*>(op.bind_data.get());
+  if (bind == nullptr) {
+    throw duckdb::InternalException("sirius_stream_source is missing its stream bind data");
+  }
+
+  auto catalog = context.registered_state->Get<sirius::exec::stream_bind_catalog>(
+    sirius::exec::stream_bind_catalog::kStateKey);
+  if (!catalog) {
+    throw duckdb::InternalException(
+      "sirius_stream_source bound without a stream catalog on this connection");
+  }
+  auto const& binding = catalog->get(bind->stream_id);
+
+  // Projection pushdown is off; a narrowed column list here would disagree with the binder.
+  auto column_ids = op.GetColumnIds();
+  if (column_ids.size() != binding.types.size()) {
+    throw duckdb::NotImplementedException(
+      "sirius_stream_source: column projection into a stream read is not supported (stream "
+      "declares %llu columns, plan requests %llu)",
+      static_cast<unsigned long long>(binding.types.size()),
+      static_cast<unsigned long long>(column_ids.size()));
+  }
+
+  auto source = duckdb::make_uniq<sirius::op::sirius_physical_streaming_source>(
+    binding.types, op.EstimateCardinality(context), binding.repository, binding.expected_senders);
+
+  // Plan owns op; catalog.built back-pointer for session registration.
+  catalog->set_built(bind->stream_id, source.get());
+  return source;
+}
+
+duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
 {
   auto column_ids = op.GetColumnIds();
@@ -203,7 +239,11 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   // Only GPU-route known table scan functions; all others (pragma, system catalog
   // functions, etc.) must fall back to CPU.
   static const std::unordered_set<std::string> kSupportedScanFunctions = {
-    "seq_scan", "parquet_scan", "read_parquet", "sirius_read_parquet"};
+    "seq_scan",
+    "parquet_scan",
+    "read_parquet",
+    "sirius_read_parquet",
+    sirius::exec::kStreamSourceFunctionName};
   if (kSupportedScanFunctions.find(op.function.name) == kSupportedScanFunctions.end()) {
     throw duckdb::NotImplementedException("Table function '%s' is not supported in Sirius",
                                           op.function.name);
@@ -259,6 +299,11 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   if (!op.projected_input.empty()) {
     throw duckdb::InternalException(
       "LogicalGet::project_input can only be set for table-in-out functions");
+  }
+
+  // STREAMING_SOURCE leaf: fragment-declared repo + senders, not a file scan.
+  if (op.function.name == sirius::exec::kStreamSourceFunctionName) {
+    return create_streaming_source_plan(op);
   }
 
   // Plan-time probe for the duckdb-native seq_scan path: strings at/over

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -1609,9 +1609,8 @@ void SiriusContextExtensionCallback::OnConnectionOpened(ClientContext& context)
     // sirius_stream_source's bind, and any streaming_fragment built on this connection, resolve
     // declared-stream schemas through a per-connection catalog — without this, both fail
     // immediately on every normal (transparent) connection instead of just the FFI's own.
-    context.registered_state->Insert(
-      sirius::exec::stream_bind_catalog::kStateKey,
-      duckdb::make_shared_ptr<sirius::exec::stream_bind_catalog>());
+    context.registered_state->Insert(sirius::exec::stream_bind_catalog::kStateKey,
+                                     duckdb::make_shared_ptr<sirius::exec::stream_bind_catalog>());
   }
 }
 

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -25,6 +25,7 @@
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/planner.hpp"
+#include "exec/stream_bind_catalog.hpp"
 #include "log/duckdb_sink.hpp"
 #include "log/logging.hpp"
 #include "log/noop_sink.hpp"
@@ -1605,6 +1606,12 @@ void SiriusContextExtensionCallback::OnConnectionOpened(ClientContext& context)
     // capture, label, guard depths) — unlike the shared SiriusContext above.
     context.registered_state->Insert("sirius_connection_state",
                                      duckdb::make_shared_ptr<SiriusConnectionState>());
+    // sirius_stream_source's bind, and any streaming_fragment built on this connection, resolve
+    // declared-stream schemas through a per-connection catalog — without this, both fail
+    // immediately on every normal (transparent) connection instead of just the FFI's own.
+    context.registered_state->Insert(
+      sirius::exec::stream_bind_catalog::kStateKey,
+      duckdb::make_shared_ptr<sirius::exec::stream_bind_catalog>());
   }
 }
 
@@ -1614,6 +1621,7 @@ void SiriusContextExtensionCallback::OnConnectionClosed(ClientContext& context)
   // remove the context from the registered state
   context.registered_state->Remove("sirius_state");
   context.registered_state->Remove("sirius_connection_state");
+  context.registered_state->Remove(sirius::exec::stream_bind_catalog::kStateKey);
 }
 
 void SiriusContextExtensionCallback::OnExtensionLoaded(DatabaseInstance& db, const string& name)

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -89,6 +89,7 @@ extern "C" int cudaProfilerStop();
 #include "gpu_physical_plan_generator.hpp"
 #endif
 #include "duckdb/main/connection_manager.hpp"
+#include "exec/stream_plan_bindings.hpp"
 #include "helper/type_conversions.hpp"
 #include "log/logging.hpp"
 #include "op/scan/duckdb_mvcc_visibility.hpp"
@@ -1604,6 +1605,11 @@ static void SiriusSetQueryLabelFunction(ClientContext& context,
 
 void SiriusExtension::RegisterGPUFunctions(DatabaseInstance& instance)
 {
+  // A fragment plan reads each of its input streams through sirius_stream_source(id). Register
+  // it wherever Sirius is loaded, not just on the FFI's embedded DuckDB, so a fragment plan binds
+  // on the transparent path too.
+  sirius::exec::register_stream_source_function(instance);
+
   auto transaction = CatalogTransaction::GetSystemTransaction(instance);
   auto& catalog    = Catalog::GetSystemCatalog(instance);
 

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -35,21 +35,66 @@
 #include "duckdb/optimizer/optimizer.hpp"                  // duckdb::Optimizer
 #include "duckdb/parser/statement/relation_statement.hpp"  // duckdb::RelationStatement
 #include "duckdb/planner/planner.hpp"                      // duckdb::Planner
-#include "from_substrait.hpp"     // duckdb::SubstraitToDuckDB (compiled into libsirius)
-#include "parquet_extension.hpp"  // duckdb::ParquetExtension
+#include "exec/stream_bind_catalog.hpp"                    // sirius::exec::stream_bind_catalog
+#include "exec/stream_plan_bindings.hpp"  // sirius::exec::register_stream_source_function
+#include "exec/streaming_fragment.hpp"    // sirius::exec::streaming_fragment, fragment_spec
+#include "from_substrait.hpp"             // duckdb::SubstraitToDuckDB (compiled into libsirius)
+#include "helper/type_conversions.hpp"    // sirius::from_duckdb
+#include "parquet_extension.hpp"          // duckdb::ParquetExtension
 #include "planner/sirius_physical_plan_generator.hpp"  // sirius::planner::sirius_physical_plan_generator
 #include "sirius_config.hpp"                           // sirius::sirius_config
 #include "sirius_context.hpp"                          // duckdb::SiriusContext
 #include "sirius_interface.hpp"  // sirius::sirius_interface, sirius::sirius_prepared_statement_data
 
+#include <map>
+#include <set>
+
 namespace sirius::ffi {
 
 namespace {
-// ClientContextState key the GPU engine resolves its SiriusContext under.
-constexpr const char* kSiriusStateKey = "sirius_state";
-constexpr const char* kQueryLabel     = "sirius_ffi";
-// Arrow record-batch size for the exported stream; the consumer re-batches as needed.
+
+constexpr const char* kSiriusStateKey   = "sirius_state";
+constexpr const char* kQueryLabel       = "sirius_ffi";
 constexpr duckdb::idx_t kArrowBatchSize = 1u << 20;
+
+// DuckDB view name a plan uses to read input stream `id`.
+std::string stream_view_name_of(std::uint64_t id) { return "sirius_stream_" + std::to_string(id); }
+
+// Lower a Substrait plan to a bound+optimized DuckDB LogicalOperator.
+struct lowered_plan {
+  duckdb::shared_ptr<duckdb::PreparedStatementData> prepared;
+  duckdb::unique_ptr<duckdb::LogicalOperator> plan;
+};
+
+lowered_plan lower_substrait(duckdb::Connection& conn, const std::string& substrait_plan)
+{
+  auto& client = *conn.context;
+
+  duckdb::SubstraitToDuckDB transformer(conn.context, substrait_plan, /*json=*/false);
+  auto relation = transformer.TransformPlan();
+
+  duckdb::Planner planner(client);
+  planner.CreatePlan(duckdb::make_uniq<duckdb::RelationStatement>(relation));
+
+  auto prepared =
+    duckdb::make_shared_ptr<duckdb::PreparedStatementData>(duckdb::StatementType::SELECT_STATEMENT);
+  prepared->names     = planner.names;
+  prepared->types     = planner.types;
+  prepared->value_map = std::move(planner.value_map);
+
+  auto logical_plan = std::move(planner.plan);
+  if (client.config.enable_optimizer) {
+    duckdb::Optimizer optimizer(*planner.binder, client);
+    logical_plan = optimizer.Optimize(std::move(logical_plan));
+  }
+  logical_plan->ResolveOperatorTypes();
+  duckdb::ColumnBindingResolver resolver;
+  duckdb::ColumnBindingResolver::Verify(*logical_plan);
+  resolver.VisitOperator(*logical_plan);
+
+  return {std::move(prepared), std::move(logical_plan)};
+}
+
 }  // namespace
 
 // PIMPL: holds the engine + embedded DuckDB using DuckDB's own smart pointers
@@ -58,6 +103,8 @@ struct Context::Impl {
   duckdb::shared_ptr<duckdb::SiriusContext> context;
   duckdb::unique_ptr<duckdb::DuckDB> db;
   duckdb::unique_ptr<duckdb::Connection> conn;
+  //! stream_bind_catalog: also in registered_state; held here past registered_state resets.
+  duckdb::shared_ptr<sirius::exec::stream_bind_catalog> stream_catalog;
 
   void bring_up(sirius::sirius_config& config)
   {
@@ -81,6 +128,11 @@ struct Context::Impl {
     // embedded connection, mirroring OnConnectionOpened on the transparent path.
     client.registered_state->Insert("sirius_connection_state",
                                     duckdb::make_shared_ptr<duckdb::SiriusConnectionState>());
+
+    // Fragment bind path: register catalog + sirius_stream_source before any plan binds.
+    stream_catalog = duckdb::make_shared_ptr<sirius::exec::stream_bind_catalog>();
+    client.registered_state->Insert(sirius::exec::stream_bind_catalog::kStateKey, stream_catalog);
+    sirius::exec::register_stream_source_function(*db->instance);
     client.config.enable_optimizer = true;
     auto& disabled = duckdb::DBConfig::GetConfig(client).options.disabled_optimizers;
     disabled.insert(duckdb::OptimizerType::IN_CLAUSE);
@@ -125,30 +177,8 @@ void Context::execute_substrait(const std::string& plan, std::uintptr_t out_stre
   impl_->conn->BeginTransaction();
   duckdb::unique_ptr<duckdb::QueryResult> result;
   try {
-    // 1. Substrait bytes -> DuckDB Relation. DuckDB is used only for this lowering.
-    duckdb::SubstraitToDuckDB transformer(impl_->conn->context, plan, /*json=*/false);
-    auto relation = transformer.TransformPlan();
-
-    // 2. Relation -> bound + optimized DuckDB LogicalOperator (mirrors the GPU bind path:
-    //    SiriusTableFunctionData::ExtractPlan + GPUExecutionBind).
-    duckdb::Planner planner(client);
-    planner.CreatePlan(duckdb::make_uniq<duckdb::RelationStatement>(relation));
-
-    auto prepared = duckdb::make_shared_ptr<duckdb::PreparedStatementData>(
-      duckdb::StatementType::SELECT_STATEMENT);
-    prepared->names     = planner.names;
-    prepared->types     = planner.types;
-    prepared->value_map = std::move(planner.value_map);
-
-    auto logical_plan = std::move(planner.plan);
-    if (client.config.enable_optimizer) {
-      duckdb::Optimizer optimizer(*planner.binder, client);
-      logical_plan = optimizer.Optimize(std::move(logical_plan));
-    }
-    logical_plan->ResolveOperatorTypes();
-    duckdb::ColumnBindingResolver resolver;
-    duckdb::ColumnBindingResolver::Verify(*logical_plan);
-    resolver.VisitOperator(*logical_plan);
+    // 1+2. Substrait → optimized DuckDB LogicalOperator.
+    auto lowered = lower_substrait(*impl_->conn, plan);
 
     // 3. DuckDB LogicalOperator -> Sirius GPU physical plan -> execute directly
     // on the engine, inside an execution window: begin mutations and slot
@@ -159,9 +189,9 @@ void Context::execute_substrait(const std::string& plan, std::uintptr_t out_stre
     {
       duckdb::SiriusContext::StandaloneQueryScope window(*impl_->context, client, kQueryLabel);
       auto physical_plan = sirius::planner::sirius_physical_plan_generator(client).create_plan(
-        std::move(logical_plan));
+        std::move(lowered.plan));
       auto gpu_prepared = duckdb::make_shared_ptr<sirius::sirius_prepared_statement_data>(
-        std::move(prepared), std::move(physical_plan));
+        std::move(lowered.prepared), std::move(physical_plan));
 
       sirius::sirius_interface iface(client, std::optional<std::string>(kQueryLabel));
       result = iface.sirius_execute_query(
@@ -187,6 +217,392 @@ std::unique_ptr<Context> make_context() { return std::make_unique<Context>(); }
 std::unique_ptr<Context> make_context_from_config(const std::string& config_path)
 {
   return std::make_unique<Context>(config_path);
+}
+
+// ---------------------------------------------------------------------------
+// Fragment
+// ---------------------------------------------------------------------------
+
+struct Fragment::Impl {
+  explicit Impl(Context::Impl& ctx) : ctx(ctx) {}
+
+  ~Impl()
+  {
+    // If the caller dropped a Fragment between build() and run(), close the lifecycle so the
+    // engine's mutex doesn't wedge every subsequent statement on this connection.
+    end_lifecycle();
+  }
+
+  Context::Impl& ctx;
+
+  // One column declared before build(); type_name is the DuckDB type string parsed at build()
+  // time (parsing may need a catalog lookup → must be inside a transaction).
+  struct declared_input {
+    std::vector<std::string> names;
+    std::vector<std::string> type_names;
+    std::set<sirius::exec::sender_id_t> expected_senders;
+  };
+
+  std::map<sirius::exec::stream_id_t, declared_input> inputs;
+  std::vector<sirius::exec::stream_id_t> outputs;
+  bool broadcast_outputs{false};
+  std::vector<int> hash_key_columns;
+
+  // Resolved at build() time; kept for relay_from() schema validation.
+  std::map<sirius::exec::stream_id_t, sirius::exec::stream_input_spec> resolved_inputs;
+
+  // Intermediate fragment (has output streams).
+  std::unique_ptr<sirius::exec::streaming_fragment> fragment;
+
+  // Result fragment (no output streams): plan + result stored separately.
+  std::map<sirius::exec::stream_id_t, std::shared_ptr<cucascade::shared_data_repository>>
+    result_input_repos;
+  sirius::exec::stream_session result_session;
+  duckdb::shared_ptr<sirius::sirius_prepared_statement_data> result_plan;
+  duckdb::unique_ptr<duckdb::QueryResult> result;
+
+  bool built{false};
+  bool ran{false};
+  bool transaction_open{false};
+
+  // Heap-allocated because StandaloneQueryScope is non-movable. Opened in build(), closed in
+  // run() / ~Impl().
+  std::unique_ptr<duckdb::SiriusContext::StandaloneQueryScope> lifecycle;
+
+  [[nodiscard]] bool is_result() const { return outputs.empty(); }
+
+  sirius::exec::stream_session& session()
+  {
+    return fragment ? fragment->session() : result_session;
+  }
+
+  void require_not_built(const char* what) const
+  {
+    if (built) {
+      throw sirius::invalid_input_exception(std::string("Fragment: ") + what +
+                                            " must be called before build()");
+    }
+  }
+
+  std::map<sirius::exec::stream_id_t, sirius::exec::stream_input_spec> resolve_inputs() const
+  {
+    std::map<sirius::exec::stream_id_t, sirius::exec::stream_input_spec> resolved;
+    for (const auto& [id, declared] : inputs) {
+      sirius::exec::stream_input_spec spec;
+      spec.names = declared.names;
+      spec.types.reserve(declared.type_names.size());
+      for (const auto& type_name : declared.type_names) {
+        spec.types.push_back(
+          sirius::from_duckdb(duckdb::TransformStringToLogicalType(type_name, *ctx.conn->context)));
+      }
+      spec.expected_senders = declared.expected_senders;
+      if (spec.expected_senders.empty()) { spec.expected_senders.insert(0); }
+      resolved.emplace(id, std::move(spec));
+    }
+    return resolved;
+  }
+
+  // Populate the bind catalog so DuckDB can bind a view of each declared input stream.
+  // Result fragments keep the repositories here; streaming fragments let streaming_fragment
+  // redeclare with its own repos and these are dropped unused.
+  void declare_streams(
+    const std::map<sirius::exec::stream_id_t, sirius::exec::stream_input_spec>& resolved)
+  {
+    auto& catalog = *ctx.stream_catalog;
+    catalog.clear();
+    for (const auto& [id, spec] : resolved) {
+      auto repository = std::make_shared<cucascade::shared_data_repository>();
+      if (is_result()) { result_input_repos[id] = repository; }
+      catalog.declare(id,
+                      sirius::exec::stream_input_binding{
+                        spec.names, spec.types, repository, spec.expected_senders, nullptr});
+    }
+  }
+
+  // CREATE OR REPLACE VIEW sirius_stream_<id> AS SELECT * FROM sirius_stream_source(<id>)
+  // Requires an open transaction. Must happen after declare_streams (bind resolves the schema).
+  void create_stream_views()
+  {
+    for (const auto& [id, _] : inputs) {
+      const auto view_name = stream_view_name_of(id);
+      const auto sql       = "CREATE OR REPLACE VIEW main." + view_name + " AS SELECT * FROM " +
+                       std::string(sirius::exec::kStreamSourceFunctionName) + "(" +
+                       std::to_string(id) + ")";
+      auto res = ctx.conn->Query(sql);
+      if (res->HasError()) { res->ThrowError(); }
+    }
+  }
+
+  // Idempotent; called from run() and ~Impl().
+  void end_lifecycle() noexcept
+  {
+    if (lifecycle) {
+      try {
+        lifecycle.reset();
+      } catch (...) {  // NOLINT(bugprone-empty-catch)
+      }
+    }
+    if (transaction_open) {
+      transaction_open = false;
+      try {
+        ctx.conn->Commit();
+      } catch (...) {  // NOLINT(bugprone-empty-catch)
+      }
+    }
+  }
+};
+
+Fragment::Fragment(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
+
+Fragment::~Fragment() = default;
+
+void Fragment::declare_input_column(std::uint64_t stream_id,
+                                    const std::string& name,
+                                    const std::string& type)
+{
+  impl_->require_not_built("declare_input_column");
+  auto& d = impl_->inputs[stream_id];
+  d.names.push_back(name);
+  d.type_names.push_back(type);
+}
+
+void Fragment::declare_input_sender(std::uint64_t stream_id, std::uint32_t sender_id)
+{
+  impl_->require_not_built("declare_input_sender");
+  impl_->inputs[stream_id].expected_senders.insert(sender_id);
+}
+
+void Fragment::declare_output(std::uint64_t stream_id)
+{
+  impl_->require_not_built("declare_output");
+  auto& outs = impl_->outputs;
+  if (std::find(outs.begin(), outs.end(), stream_id) != outs.end()) {
+    throw sirius::invalid_input_exception("Fragment: duplicate output stream id " +
+                                          std::to_string(stream_id));
+  }
+  outs.push_back(stream_id);
+}
+
+void Fragment::declare_output_broadcast()
+{
+  impl_->require_not_built("declare_output_broadcast");
+  if (!impl_->hash_key_columns.empty()) {
+    throw sirius::invalid_input_exception(
+      "Fragment: broadcast and hash-partitioned output are mutually exclusive");
+  }
+  impl_->broadcast_outputs = true;
+}
+
+void Fragment::declare_output_hash_key(std::uint32_t column_index)
+{
+  impl_->require_not_built("declare_output_hash_key");
+  if (impl_->broadcast_outputs) {
+    throw sirius::invalid_input_exception(
+      "Fragment: broadcast and hash-partitioned output are mutually exclusive");
+  }
+  impl_->hash_key_columns.push_back(static_cast<int>(column_index));
+}
+
+void Fragment::build(const std::string& substrait_plan)
+{
+  impl_->require_not_built("build");
+
+  // Transaction must be open for: type-name parsing (catalog lookup) and CREATE VIEW.
+  // It must be committed before QueryBeginStandalone acquires the lifecycle mutex.
+  impl_->ctx.conn->BeginTransaction();
+  impl_->transaction_open = true;
+  std::map<sirius::exec::stream_id_t, sirius::exec::stream_input_spec> resolved;
+  try {
+    resolved               = impl_->resolve_inputs();
+    impl_->resolved_inputs = resolved;
+    impl_->declare_streams(resolved);
+    impl_->create_stream_views();
+    impl_->ctx.conn->Commit();
+    impl_->transaction_open = false;
+  } catch (...) {
+    impl_->end_lifecycle();
+    throw;
+  }
+
+  // Open lifecycle (StandaloneQueryScope acquires the slot and begins the window).
+  auto& client     = *impl_->ctx.conn->context;
+  impl_->lifecycle = std::make_unique<duckdb::SiriusContext::StandaloneQueryScope>(
+    *impl_->ctx.context, client, kQueryLabel);
+
+  try {
+    if (impl_->is_result()) {
+      // A result fragment takes the single-shot execution path; its leaves may be streaming
+      // sources built from the bind catalog.
+      auto lowered       = lower_substrait(*impl_->ctx.conn, substrait_plan);
+      auto physical_plan = sirius::planner::sirius_physical_plan_generator(client).create_plan(
+        std::move(lowered.plan));
+      impl_->result_plan = duckdb::make_shared_ptr<sirius::sirius_prepared_statement_data>(
+        std::move(lowered.prepared), std::move(physical_plan));
+
+      for (const auto& [id, _] : impl_->inputs) {
+        auto* built = impl_->ctx.stream_catalog->get(id).built;
+        if (built == nullptr) {
+          throw sirius::invalid_input_exception("Fragment: input stream " + std::to_string(id) +
+                                                " was declared but the plan does not read it");
+        }
+        impl_->result_session.add_source(id, *built);
+      }
+    } else {
+      sirius::exec::fragment_spec spec;
+      spec.plan_source = [plan = substrait_plan, conn = impl_->ctx.conn.get()](
+                           duckdb::ClientContext&) { return lower_substrait(*conn, plan).plan; };
+      spec.inputs  = std::move(resolved);
+      spec.outputs = impl_->outputs;
+
+      if (impl_->broadcast_outputs && impl_->outputs.size() > 1) {
+        sirius::op::partition_spec broadcast;
+        broadcast.mode    = sirius::op::partition_mode::broadcast;
+        spec.partitioning = std::move(broadcast);
+      } else if (!impl_->hash_key_columns.empty() && impl_->outputs.size() > 1) {
+        // key_cast_types left empty; streaming_fragment::build() derives them from output types.
+        sirius::op::partition_spec hash;
+        hash.mode         = sirius::op::partition_mode::hash;
+        hash.key_columns  = impl_->hash_key_columns;
+        spec.partitioning = std::move(hash);
+      }
+
+      impl_->fragment = std::make_unique<sirius::exec::streaming_fragment>(client, std::move(spec));
+      impl_->fragment->build(impl_->lifecycle->query_id());
+    }
+    impl_->built = true;
+  } catch (...) {
+    impl_->end_lifecycle();
+    throw;
+  }
+}
+
+std::size_t Fragment::relay_from(Fragment& source,
+                                 std::uint64_t source_stream_id,
+                                 std::uint64_t input_stream_id,
+                                 std::uint32_t sender_id)
+{
+  if (!impl_->built) {
+    throw sirius::invalid_input_exception("Fragment: build() must run before relay_from()");
+  }
+
+  // Schema check: fail before any data moves if column count or types disagree.
+  if (source.impl_->fragment != nullptr) {
+    if (auto it = impl_->resolved_inputs.find(input_stream_id);
+        it != impl_->resolved_inputs.end()) {
+      const auto& declared = it->second.types;
+      const auto& produced = source.impl_->fragment->sink_types();
+      if (produced.size() != declared.size()) {
+        throw sirius::invalid_input_exception(
+          "Fragment: relay into stream " + std::to_string(input_stream_id) + " expects " +
+          std::to_string(declared.size()) + " declared columns but the source sink produces " +
+          std::to_string(produced.size()));
+      }
+      for (std::size_t i = 0; i < declared.size(); ++i) {
+        if (produced[i] != declared[i]) {
+          throw sirius::invalid_input_exception(
+            "Fragment: relay into stream " + std::to_string(input_stream_id) + " column " +
+            std::to_string(i) + " is declared " + declared[i].to_string() +
+            " but the source sink produces " + produced[i].to_string());
+        }
+      }
+    }
+  }
+
+  std::size_t moved = 0;
+  while (auto batch = source.impl_->session().pull(source_stream_id)) {
+    if (!impl_->session().push(input_stream_id, *batch)) {
+      throw sirius::invalid_input_exception("Fragment: input stream " +
+                                            std::to_string(input_stream_id) +
+                                            " refused a batch; it had already ended");
+    }
+    ++moved;
+  }
+  impl_->session().close_input(input_stream_id, sender_id);
+  return moved;
+}
+
+void Fragment::close_input(std::uint64_t stream_id, std::uint32_t sender_id)
+{
+  if (!impl_->built) {
+    throw sirius::invalid_input_exception("Fragment: build() must run before close_input()");
+  }
+  impl_->session().close_input(stream_id, sender_id);
+}
+
+void Fragment::run()
+{
+  if (!impl_->built) {
+    throw sirius::invalid_input_exception("Fragment: build() must run before run()");
+  }
+  if (impl_->ran) { throw sirius::invalid_input_exception("Fragment: already run"); }
+
+  try {
+    if (impl_->is_result()) {
+      auto& client = *impl_->ctx.conn->context;
+      sirius::sirius_interface iface(client, std::optional<std::string>(kQueryLabel));
+      impl_->result = iface.sirius_execute_query(client,
+                                                 kQueryLabel,
+                                                 impl_->result_plan,
+                                                 duckdb::PendingQueryParameters{},
+                                                 impl_->lifecycle->query_id());
+    } else {
+      impl_->fragment->run();
+    }
+    impl_->ran = true;
+  } catch (...) {
+    impl_->end_lifecycle();
+    throw;
+  }
+  impl_->lifecycle->finish();
+  impl_->lifecycle.reset();
+  if (impl_->result && impl_->result->HasError()) { impl_->result->ThrowError(); }
+}
+
+void Fragment::result_to_arrow(std::uintptr_t out_stream_addr)
+{
+  if (!impl_->is_result()) {
+    throw sirius::invalid_input_exception(
+      "Fragment: result_to_arrow() is only valid on a fragment with no output streams");
+  }
+  if (!impl_->ran || !impl_->result) {
+    throw sirius::invalid_input_exception("Fragment: run() must complete before result_to_arrow()");
+  }
+  auto* wrapper =
+    new duckdb::ResultArrowArrayStreamWrapper(std::move(impl_->result), kArrowBatchSize);
+  *reinterpret_cast<ArrowArrayStream*>(out_stream_addr) = wrapper->stream;
+}
+
+std::size_t Fragment::output_batch_count(std::uint64_t stream_id) const
+{
+  if (!impl_->fragment) { return 0; }
+  return impl_->fragment->output_repository(stream_id)->total_size();
+}
+
+std::unique_ptr<std::vector<std::string>> Fragment::output_types() const
+{
+  if (!impl_->built) {
+    throw sirius::invalid_input_exception("Fragment: build() must run before output_types()");
+  }
+  if (!impl_->fragment) {
+    throw sirius::invalid_input_exception(
+      "Fragment: output_types() is only valid on an intermediate fragment with output streams");
+  }
+  auto types = std::make_unique<std::vector<std::string>>();
+  types->reserve(impl_->fragment->sink_types().size());
+  for (const auto& type : impl_->fragment->sink_types()) {
+    types->push_back(type.to_string());
+  }
+  return types;
+}
+
+std::unique_ptr<Fragment> make_fragment(Context& context)
+{
+  return std::unique_ptr<Fragment>(new Fragment(std::make_unique<Fragment::Impl>(*context.impl_)));
+}
+
+std::unique_ptr<std::string> stream_view_name(std::uint64_t stream_id)
+{
+  return std::make_unique<std::string>(stream_view_name_of(stream_id));
 }
 
 }  // namespace sirius::ffi

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -344,8 +344,11 @@ struct Fragment::Impl {
     }
     if (transaction_open) {
       transaction_open = false;
+      // Reached only when the transaction is STILL open, which by construction means setup
+      // failed — build() clears the flag the moment its own Commit() succeeds. Committing here
+      // would persist a half-declared fragment (or throw again out of a noexcept path).
       try {
-        ctx.conn->Commit();
+        ctx.conn->Rollback();
       } catch (...) {  // NOLINT(bugprone-empty-catch)
       }
     }
@@ -454,6 +457,17 @@ void Fragment::build(const std::string& substrait_plan)
       spec.inputs  = std::move(resolved);
       spec.outputs = impl_->outputs;
 
+      // A routing mode on a single destination is a caller mistake, not a no-op: every row goes
+      // to output 0 either way, so silently dropping the spec hides a fan-out that never
+      // happened. The sink applies the same rule to its own spec.
+      if (impl_->outputs.size() <= 1 &&
+          (impl_->broadcast_outputs || !impl_->hash_key_columns.empty())) {
+        throw sirius::invalid_input_exception(
+          "Fragment: a partition mode was declared but the fragment has " +
+          std::to_string(impl_->outputs.size()) +
+          " output stream(s); routing needs at least two destinations");
+      }
+
       if (impl_->broadcast_outputs && impl_->outputs.size() > 1) {
         sirius::op::partition_spec broadcast;
         broadcast.mode    = sirius::op::partition_mode::broadcast;
@@ -485,25 +499,46 @@ std::size_t Fragment::relay_from(Fragment& source,
     throw sirius::invalid_input_exception("Fragment: build() must run before relay_from()");
   }
 
+  // The drain loop below stops at the first nullopt, which means "nothing right now" as well as
+  // "ended". Before the source has run, those are indistinguishable, so relaying early would
+  // close the input after zero batches and silently truncate the result.
+  if (!source.impl_->ran) {
+    throw sirius::invalid_input_exception(
+      "Fragment: relay_from() requires the source fragment to have run — call source.run() first, "
+      "otherwise an empty stream is indistinguishable from a finished one and the input would be "
+      "closed early");
+  }
+
+  // The docs promise this throws on an unknown stream id; it used to fall through both guards
+  // and move batches unchecked.
+  auto declared_it = impl_->resolved_inputs.find(input_stream_id);
+  if (declared_it == impl_->resolved_inputs.end()) {
+    throw sirius::invalid_input_exception("Fragment: relay target input stream " +
+                                          std::to_string(input_stream_id) +
+                                          " was never declared on this fragment");
+  }
+  if (source.impl_->fragment == nullptr) {
+    throw sirius::invalid_input_exception(
+      "Fragment: relay source has no output streams — a result fragment produces Arrow via "
+      "result_to_arrow(), not a relayable stream");
+  }
+
   // Schema check: fail before any data moves if column count or types disagree.
-  if (source.impl_->fragment != nullptr) {
-    if (auto it = impl_->resolved_inputs.find(input_stream_id);
-        it != impl_->resolved_inputs.end()) {
-      const auto& declared = it->second.types;
-      const auto& produced = source.impl_->fragment->sink_types();
-      if (produced.size() != declared.size()) {
+  {
+    const auto& declared = declared_it->second.types;
+    const auto& produced = source.impl_->fragment->sink_types();
+    if (produced.size() != declared.size()) {
+      throw sirius::invalid_input_exception(
+        "Fragment: relay into stream " + std::to_string(input_stream_id) + " expects " +
+        std::to_string(declared.size()) + " declared columns but the source sink produces " +
+        std::to_string(produced.size()));
+    }
+    for (std::size_t i = 0; i < declared.size(); ++i) {
+      if (produced[i] != declared[i]) {
         throw sirius::invalid_input_exception(
-          "Fragment: relay into stream " + std::to_string(input_stream_id) + " expects " +
-          std::to_string(declared.size()) + " declared columns but the source sink produces " +
-          std::to_string(produced.size()));
-      }
-      for (std::size_t i = 0; i < declared.size(); ++i) {
-        if (produced[i] != declared[i]) {
-          throw sirius::invalid_input_exception(
-            "Fragment: relay into stream " + std::to_string(input_stream_id) + " column " +
-            std::to_string(i) + " is declared " + declared[i].to_string() +
-            " but the source sink produces " + produced[i].to_string());
-        }
+          "Fragment: relay into stream " + std::to_string(input_stream_id) + " column " +
+          std::to_string(i) + " is declared " + declared[i].to_string() +
+          " but the source sink produces " + produced[i].to_string());
       }
     }
   }
@@ -550,6 +585,17 @@ void Fragment::run()
     }
     impl_->ran = true;
   } catch (...) {
+    // Poison every output before unwinding. Without this the streams are neither closed nor
+    // failed, so a peer parked in wait() blocks forever with no error anywhere — the S2/S3
+    // hazard the design doc calls out. First-failure-wins, so this cannot mask a real cause.
+    // A result fragment has no outputs, so this is a no-op there.
+    auto const cause = std::current_exception();
+    for (auto id : impl_->outputs) {
+      try {
+        impl_->session().fail_output(id, cause);
+      } catch (...) {  // NOLINT(bugprone-empty-catch)
+      }
+    }
     impl_->end_lifecycle();
     throw;
   }

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -308,8 +308,11 @@ struct Fragment::Impl {
   void declare_streams(
     const std::map<sirius::exec::stream_id_t, sirius::exec::stream_input_spec>& resolved)
   {
+    // declare() overwrites any prior entry for the same id, so there is nothing of this
+    // fragment's own to pre-clear. Must NOT call catalog.clear() here: this catalog is shared
+    // by every Fragment on the same Context (e.g. fragments chained via relay_from), and
+    // clear() would wipe a peer fragment's still-live declarations.
     auto& catalog = *ctx.stream_catalog;
-    catalog.clear();
     for (const auto& [id, spec] : resolved) {
       auto repository = std::make_shared<cucascade::shared_data_repository>();
       if (is_result()) { result_input_repos[id] = repository; }
@@ -433,6 +436,18 @@ void Fragment::build(const std::string& substrait_plan)
     *impl_->ctx.context, client, kQueryLabel);
 
   try {
+    // A routing mode needs at least two destinations to mean anything: with 0 or 1 declared
+    // outputs every row goes to the same place either way, so accepting it here would hide a
+    // fan-out that never happened. Checked before the is_result()/else split below so it also
+    // catches a partition mode declared on a 0-output result fragment, not just a 1-output one.
+    if (impl_->outputs.size() <= 1 &&
+        (impl_->broadcast_outputs || !impl_->hash_key_columns.empty())) {
+      throw sirius::invalid_input_exception(
+        "Fragment: a partition mode was declared but the fragment has " +
+        std::to_string(impl_->outputs.size()) +
+        " output stream(s); routing needs at least two destinations");
+    }
+
     if (impl_->is_result()) {
       // A result fragment takes the single-shot execution path; its leaves may be streaming
       // sources built from the bind catalog.
@@ -456,17 +471,6 @@ void Fragment::build(const std::string& substrait_plan)
                            duckdb::ClientContext&) { return lower_substrait(*conn, plan).plan; };
       spec.inputs  = std::move(resolved);
       spec.outputs = impl_->outputs;
-
-      // A routing mode on a single destination is a caller mistake, not a no-op: every row goes
-      // to output 0 either way, so silently dropping the spec hides a fan-out that never
-      // happened. The sink applies the same rule to its own spec.
-      if (impl_->outputs.size() <= 1 &&
-          (impl_->broadcast_outputs || !impl_->hash_key_columns.empty())) {
-        throw sirius::invalid_input_exception(
-          "Fragment: a partition mode was declared but the fragment has " +
-          std::to_string(impl_->outputs.size()) +
-          " output stream(s); routing needs at least two destinations");
-      }
 
       if (impl_->broadcast_outputs && impl_->outputs.size() > 1) {
         sirius::op::partition_spec broadcast;

--- a/test/cpp/exec/test_sirius_ffi_fragment.cpp
+++ b/test/cpp/exec/test_sirius_ffi_fragment.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression coverage for Fragment::Impl::end_lifecycle() (src/sirius_ffi.cpp): a build()
+// failure while the transaction is still open must roll it back, not commit it (a7bb47e2).
+//
+// The public FFI surface links only DuckDB's substrait consumer (no substrait-plan-from-SQL
+// helper, no raw-SQL passthrough), so no test here can construct a valid Fragment or inspect
+// catalog state after a failed build(). Instead these tests use a declared column type name
+// that TransformStringToLogicalType() can never resolve, which fails build() inside
+// resolve_inputs() before `substrait_plan` is ever parsed — and check the one thing observable
+// through the public API: that end_lifecycle() leaves the connection able to start and fail a
+// second, independent Fragment cleanly.
+
+#include "sirius_ffi.hpp"
+
+#include <catch.hpp>
+#include <duckdb/common/exception/transaction_exception.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <source_location>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Small 2GB-GPU/4GB-host config shared with other [isolated_context] tests.
+fs::path isolated_memory_config_path()
+{
+  std::source_location loc = std::source_location::current();
+  return fs::path(loc.file_name()).parent_path().parent_path() / "scan" / "memory.yaml";
+}
+
+void declare_unresolvable_column(sirius::ffi::Fragment& fragment, const std::string& type_name)
+{
+  fragment.declare_input_column(0, "a", type_name);
+}
+
+// Both TransactionContext::Commit() and ::Rollback() clear current_transaction before doing any
+// work that can throw, so "does BeginTransaction() work afterward" cannot tell the old
+// commit-on-failure bug apart from the fix. What both bugs share is that a broken/skipped
+// end_lifecycle() would leave the transaction open, and the next BeginTransaction() would then
+// throw TransactionException("cannot start a transaction within a transaction") — that's the
+// one thing worth asserting against here.
+void require_build_fails_without_transaction_exception(sirius::ffi::Fragment& fragment)
+{
+  bool threw_transaction_exception = false;
+  bool threw_other                 = false;
+  try {
+    fragment.build("");
+  } catch (const duckdb::TransactionException&) {
+    threw_transaction_exception = true;
+  } catch (...) {
+    threw_other = true;
+  }
+  REQUIRE_FALSE(threw_transaction_exception);
+  REQUIRE(threw_other);
+}
+
+}  // namespace
+
+TEST_CASE("Fragment::build() failure during resolve_inputs() rolls back cleanly",
+          "[isolated_context][sirius_ffi]")
+{
+  auto context = sirius::ffi::make_context_from_config(isolated_memory_config_path().string());
+
+  auto first = sirius::ffi::make_fragment(*context);
+  declare_unresolvable_column(*first, "not_a_real_type_xyz");
+  REQUIRE_THROWS(first->build(""));
+
+  auto second = sirius::ffi::make_fragment(*context);
+  declare_unresolvable_column(*second, "also_not_a_real_type_xyz");
+  require_build_fails_without_transaction_exception(*second);
+}
+
+TEST_CASE(
+  "Fragment destroyed between a failed build() and reuse also closes the lifecycle cleanly",
+  "[isolated_context][sirius_ffi]")
+{
+  auto context = sirius::ffi::make_context_from_config(isolated_memory_config_path().string());
+
+  // Exercises ~Fragment::Impl() -> end_lifecycle() (rather than the catch-block call in
+  // build()): the failed fragment goes out of scope with no further use.
+  {
+    auto first = sirius::ffi::make_fragment(*context);
+    declare_unresolvable_column(*first, "not_a_real_type_xyz");
+    REQUIRE_THROWS(first->build(""));
+  }
+
+  auto second = sirius::ffi::make_fragment(*context);
+  declare_unresolvable_column(*second, "also_not_a_real_type_xyz");
+  require_build_fails_without_transaction_exception(*second);
+}

--- a/test/cpp/exec/test_sirius_ffi_fragment.cpp
+++ b/test/cpp/exec/test_sirius_ffi_fragment.cpp
@@ -88,9 +88,8 @@ TEST_CASE("Fragment::build() failure during resolve_inputs() rolls back cleanly"
   require_build_fails_without_transaction_exception(*second);
 }
 
-TEST_CASE(
-  "Fragment destroyed between a failed build() and reuse also closes the lifecycle cleanly",
-  "[isolated_context][sirius_ffi]")
+TEST_CASE("Fragment destroyed between a failed build() and reuse also closes the lifecycle cleanly",
+          "[isolated_context][sirius_ffi]")
 {
   auto context = sirius::ffi::make_context_from_config(isolated_memory_config_path().string());
 

--- a/test/cpp/exec/test_stream_bind_catalog.cpp
+++ b/test/cpp/exec/test_stream_bind_catalog.cpp
@@ -138,6 +138,30 @@ TEST_CASE("stream_bind_catalog CAT-5: clear drops every declaration", "[stream_b
 }
 
 // ============================================================================
+// CAT-5b: erase is scoped to one id, so fragments sharing a connection don't
+// wipe each other's declarations
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-5b: erase drops only the named stream", "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+  catalog.declare(1, make_binding());
+  catalog.declare(2, make_binding());
+
+  catalog.erase(1);
+
+  // The catalog is one ClientContextState per connection. A fragment tearing down must remove
+  // only the ids it declared — clear() here would take a peer fragment's schema with it.
+  REQUIRE_FALSE(catalog.contains(1));
+  REQUIRE(catalog.contains(2));
+  REQUIRE(catalog.declared_streams() == std::vector<stream_id_t>{2});
+
+  // Idempotent: teardown paths call it unconditionally, including after a failed build.
+  catalog.erase(1);
+  REQUIRE(catalog.declared_streams() == std::vector<stream_id_t>{2});
+}
+
+// ============================================================================
 // CAT-6: redeclaring an id replaces it rather than keeping the old schema
 // ============================================================================
 

--- a/test/cpp/exec/test_stream_bind_catalog.cpp
+++ b/test/cpp/exec/test_stream_bind_catalog.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <duckdb.hpp>
+#include <exec/stream_bind_catalog.hpp>
+#include <exec/stream_plan_bindings.hpp>
+#include <helper/type_conversions.hpp>
+#include <sirius/exception.hpp>
+
+#include <memory>
+#include <set>
+#include <vector>
+
+using namespace sirius::exec;
+
+namespace {
+
+duckdb::vector<sirius::logical_type> int_schema()
+{
+  return sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER});
+}
+
+stream_input_binding make_binding()
+{
+  return stream_input_binding{
+    {"a"}, int_schema(), std::make_shared<cucascade::shared_data_repository>(), {0}, nullptr};
+}
+
+}  // namespace
+
+// ============================================================================
+// CAT-1: a declared stream resolves to the schema it was declared with
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-1: a declared stream resolves its schema",
+          "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+  REQUIRE_FALSE(catalog.contains(7));
+
+  catalog.declare(7, make_binding());
+
+  REQUIRE(catalog.contains(7));
+  const auto& binding = catalog.get(7);
+  REQUIRE(binding.names.size() == 1);
+  REQUIRE(binding.names[0] == "a");
+  REQUIRE(binding.types.size() == 1);
+  REQUIRE(binding.repository != nullptr);
+  REQUIRE(binding.expected_senders == std::set<sender_id_t>{0});
+  // Nothing has planned yet, so no operator has been built for this id.
+  REQUIRE(binding.built == nullptr);
+}
+
+// ============================================================================
+// CAT-2: an undeclared id is a defined error, not an empty schema
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-2: an undeclared id throws", "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+  REQUIRE_THROWS_AS(catalog.get(1), sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(catalog.set_built(1, nullptr), sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// CAT-3: a malformed declaration is rejected at declare time
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-3: a malformed declaration is rejected", "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+
+  // A stream with no repository has nowhere for its senders to push.
+  auto no_repo       = make_binding();
+  no_repo.repository = nullptr;
+  REQUIRE_THROWS_AS(catalog.declare(1, std::move(no_repo)), sirius::invalid_input_exception);
+
+  // Names and types must agree — DuckDB's bind hands back both, and a mismatch would surface
+  // much later as a column-count error inside the optimizer.
+  auto mismatched = make_binding();
+  mismatched.names.emplace_back("b");
+  REQUIRE_THROWS_AS(catalog.declare(2, std::move(mismatched)), sirius::invalid_input_exception);
+
+  auto empty = make_binding();
+  empty.names.clear();
+  empty.types.clear();
+  REQUIRE_THROWS_AS(catalog.declare(3, std::move(empty)), sirius::invalid_input_exception);
+
+  REQUIRE(catalog.declared_streams().empty());
+}
+
+// ============================================================================
+// CAT-4: the plan generator's back-pointer round-trips
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-4: the built operator is recorded", "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+  catalog.declare(4, make_binding());
+
+  auto* fake = reinterpret_cast<sirius::op::sirius_physical_streaming_source*>(0x1234);
+  catalog.set_built(4, fake);
+  REQUIRE(catalog.get(4).built == fake);
+}
+
+// ============================================================================
+// CAT-5: a fragment's declarations do not leak into the next one
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-5: clear drops every declaration", "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+  catalog.declare(1, make_binding());
+  catalog.declare(2, make_binding());
+  REQUIRE(catalog.declared_streams() == std::vector<stream_id_t>{1, 2});
+
+  catalog.clear();
+
+  REQUIRE(catalog.declared_streams().empty());
+  REQUIRE_FALSE(catalog.contains(1));
+  // A reused connection must not serve a stale schema for a recycled id.
+  REQUIRE_THROWS_AS(catalog.get(1), sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// CAT-6: redeclaring an id replaces it rather than keeping the old schema
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-6: a redeclared id is replaced", "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+  catalog.declare(1, make_binding());
+  catalog.set_built(1, reinterpret_cast<sirius::op::sirius_physical_streaming_source*>(0x1234));
+
+  auto replacement  = make_binding();
+  replacement.names = {"renamed"};
+  catalog.declare(1, std::move(replacement));
+
+  REQUIRE(catalog.get(1).names[0] == "renamed");
+  // The stale back-pointer must not survive: it refers to an operator from the previous plan.
+  REQUIRE(catalog.get(1).built == nullptr);
+}
+
+// ============================================================================
+// CAT-7: a stream read binds against the declared schema, with no file behind it
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-7: sirius_stream_source binds a declared stream",
+          "[stream_bind_catalog]")
+{
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  register_stream_source_function(*db.instance);
+
+  auto catalog = duckdb::make_shared_ptr<stream_bind_catalog>();
+  con.context->registered_state->Insert(stream_bind_catalog::kStateKey, catalog);
+
+  catalog->declare(
+    0,
+    stream_input_binding{{"l_orderkey", "l_comment"},
+                         sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{
+                           duckdb::LogicalType::BIGINT, duckdb::LogicalType::VARCHAR}),
+                         std::make_shared<cucascade::shared_data_repository>(),
+                         {0},
+                         nullptr});
+
+  // Binding is the whole point: DuckDB must resolve names and types for a relation that has no
+  // file, no catalog entry and no rows behind it. A parquet URI could not do this.
+  auto prepared = con.Prepare("SELECT * FROM sirius_stream_source(0)");
+  REQUIRE_FALSE(prepared->HasError());
+
+  REQUIRE(prepared->GetNames() == duckdb::vector<std::string>{"l_orderkey", "l_comment"});
+  REQUIRE(prepared->GetTypes() == duckdb::vector<duckdb::LogicalType>{
+                                    duckdb::LogicalType::BIGINT, duckdb::LogicalType::VARCHAR});
+
+  // A projection over the stream binds too, so the fragment's plan is not limited to SELECT *.
+  auto projected = con.Prepare("SELECT l_orderkey + 1 FROM sirius_stream_source(0)");
+  REQUIRE_FALSE(projected->HasError());
+}
+
+// ============================================================================
+// CAT-8: an undeclared stream fails at bind time, not at execution
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-8: an undeclared stream is a bind error",
+          "[stream_bind_catalog]")
+{
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  register_stream_source_function(*db.instance);
+
+  auto catalog = duckdb::make_shared_ptr<stream_bind_catalog>();
+  con.context->registered_state->Insert(stream_bind_catalog::kStateKey, catalog);
+
+  // Nothing declared id 9. Failing here means a fragment referencing a stream nobody set up is
+  // caught while planning, rather than surfacing later as a plan with no source.
+  auto prepared = con.Prepare("SELECT * FROM sirius_stream_source(9)");
+  REQUIRE(prepared->HasError());
+}
+
+// ============================================================================
+// CAT-9: without a catalog on the connection the function refuses to bind
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-9: no catalog on the connection is an error",
+          "[stream_bind_catalog]")
+{
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  register_stream_source_function(*db.instance);
+
+  auto prepared = con.Prepare("SELECT * FROM sirius_stream_source(0)");
+  REQUIRE(prepared->HasError());
+}

--- a/test/cpp/exec/test_streaming_fragment.cpp
+++ b/test/cpp/exec/test_streaming_fragment.cpp
@@ -1,0 +1,510 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../operator/operator_test_utils.hpp"
+#include "exec/streaming_fragment.hpp"
+#include "helper/type_conversions.hpp"
+#include "sirius/exception.hpp"
+#include "sirius_context.hpp"
+#include "sirius_engine.hpp"
+
+#include <catch.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <data/data_batch_utils.hpp>
+#include <duckdb.hpp>
+#include <utils/pipeline_conversion_test_utils.hpp>
+#include <utils/sirius_test_env.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+using namespace sirius::exec;
+
+namespace {
+
+//! A leaf source that produces real batches without depending on duckdb-native table ingestion:
+//! the GPU_VALUES path is self-contained, so the test isolates the streaming seam rather than
+//! the scan setup.
+constexpr const char* kLeafQuery = "SELECT a FROM (VALUES (1), (2), (3), (4), (5)) t(a)";
+constexpr std::size_t kLeafRows  = 5;
+
+fs::path lineitem_parquet_path()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return fs::path(SIRIUS_PROJECT_ROOT) / "test/cpp/integration/data/parquet/lineitem.parquet";
+#else
+  return fs::path(__FILE__).parent_path().parent_path() /
+         "integration/data/parquet/lineitem.parquet";
+#endif
+}
+
+fs::path integration_db_path()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return fs::path(SIRIUS_PROJECT_ROOT) / "test/cpp/integration/data/duckdb/integration.duckdb";
+#else
+  return fs::path(__FILE__).parent_path().parent_path() /
+         "integration/data/duckdb/integration.duckdb";
+#endif
+}
+
+struct fragment_fixture {
+  fragment_fixture()
+  {
+    REQUIRE(sirius::test::g_integration_env != nullptr);
+    if (!sirius::test::g_integration_env->is_active()) {
+      sirius::test::g_integration_env->resume();
+    }
+    con = std::make_unique<duckdb::Connection>(sirius::test::g_integration_env->make_connection());
+
+    auto db_path = integration_db_path();
+    REQUIRE(fs::exists(db_path));
+    auto result =
+      con->Query("ATTACH IF NOT EXISTS '" + db_path.string() + "' AS tpch (READ_ONLY);");
+    REQUIRE(result);
+    REQUIRE_FALSE(result->HasError());
+    result = con->Query("USE tpch;");
+    REQUIRE(result);
+    REQUIRE_FALSE(result->HasError());
+
+    // sirius_stream_source's bind resolves its schema here; the transparent path does not
+    // register a catalog, so the fragment supplies one for this connection.
+    catalog = duckdb::make_shared_ptr<stream_bind_catalog>();
+    con->context->registered_state->Insert(stream_bind_catalog::kStateKey, catalog);
+  }
+
+  std::unique_ptr<duckdb::Connection> con;
+  duckdb::shared_ptr<stream_bind_catalog> catalog;
+};
+
+//! The execution window a fragment's build/run must sit inside. RAII matters here: a `REQUIRE`
+//! that fails inside a hand-bracketed window would leave the slot held and self-deadlock in the
+//! test's `Rollback`, so the scope's destructor backstop is what lets a failing assertion fail.
+//! Tests that assert on post-cleanup state call `finish()` explicitly.
+using query_window = duckdb::SiriusContext::StandaloneQueryScope;
+
+//! Every INTEGER value sitting in an output stream, draining it. Row counts alone would not
+//! catch a hop that corrupted, dropped or duplicated values.
+std::vector<std::int32_t> drain_values(streaming_fragment& fragment, stream_id_t id)
+{
+  std::vector<std::int32_t> values;
+  while (auto batch = fragment.session().pull(id)) {
+    auto view = sirius::get_cudf_table_view(**batch);
+    auto col  = sirius::test::operator_utils::copy_column_to_host<std::int32_t>(view.column(0));
+    values.insert(values.end(), col.begin(), col.end());
+  }
+  std::sort(values.begin(), values.end());
+  return values;
+}
+
+//! Total rows sitting in an output stream, draining it.
+std::size_t drain_row_count(streaming_fragment& fragment, stream_id_t id)
+{
+  std::size_t rows = 0;
+  while (auto batch = fragment.session().pull(id)) {
+    rows += static_cast<std::size_t>(sirius::get_cudf_table_view(**batch).num_rows());
+  }
+  return rows;
+}
+
+}  // namespace
+
+// ============================================================================
+// FRAG-1: a leaf fragment runs to completion and parks its output
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-1: a leaf fragment runs and its output survives the window cleanup",
+                 "[integration][streaming_fragment]")
+{
+  fragment_spec spec;
+  spec.plan_source = sirius::test::sql_plan_source(kLeafQuery);
+  spec.outputs     = {0};
+
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  con->BeginTransaction();
+  try {
+    streaming_fragment fragment(*con->context, std::move(spec));
+
+    // One window spanning build + run (shared query window).
+    query_window window(*sirius_ctx, *con->context, "frag_1");
+    fragment.build(window.query_id());
+    // Pipeline completion gate: without it run() blocks forever.
+    fragment.run();
+    window.finish();
+
+    // Separate "source never produced" from "tasks ran but sink empty".
+    std::size_t created = 0, completed = 0;
+    for (const auto& p : fragment.engine().sirius_pipelines) {
+      created += p->get_tasks_created();
+      completed += p->get_tasks_completed();
+    }
+    INFO("pipelines=" << fragment.engine().sirius_pipelines.size()
+                      << " scheduled=" << fragment.engine().new_scheduled.size()
+                      << " tasks_created=" << created << " tasks_completed=" << completed);
+    REQUIRE(created > 0);
+
+    // Repositories escape data_repository_manager_ cleanup — batches survive the window.
+    REQUIRE(fragment.output_repository(0)->total_size() > 0);
+    REQUIRE(drain_row_count(fragment, 0) == kLeafRows);
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}
+
+// ============================================================================
+// FRAG-2: two fragments chained by stream id produce the single-fragment answer
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-2: a two-fragment chain matches the equivalent single query",
+                 "[integration][streaming_fragment]")
+{
+  // The answer the chain must reproduce.
+  auto expected = con->Query(std::string("SELECT count(*) FROM (") + kLeafQuery + ") t");
+  REQUIRE_FALSE(expected->HasError());
+  auto const expected_rows = expected->GetValue(0, 0).GetValue<std::int64_t>();
+
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  con->BeginTransaction();
+  try {
+    // Sender: reads a VALUES list, writes to its output stream.
+    fragment_spec sender_spec;
+    sender_spec.plan_source = sirius::test::sql_plan_source(kLeafQuery);
+    sender_spec.outputs     = {0};
+    streaming_fragment sender(*con->context, std::move(sender_spec));
+
+    // Receiver: reads that stream instead of a table. No file, no parquet round-trip.
+    fragment_spec receiver_spec;
+    receiver_spec.plan_source =
+      sirius::test::sql_plan_source("SELECT a FROM sirius_stream_source(0)");
+    receiver_spec.inputs[0] = stream_input_spec{
+      {"a"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      {0}};
+    receiver_spec.outputs = {1};
+    streaming_fragment receiver(*con->context, std::move(receiver_spec));
+
+    // Each fragment gets its own query window, spanning its build and run. The sender's
+    // output repository is session-owned, so it survives the sender's window cleanup and is
+    // still there for the relay.
+    {
+      query_window sender_window(*sirius_ctx, *con->context, "frag_sender");
+      sender.build(sender_window.query_id());
+      sender.run();
+      sender_window.finish();
+    }
+
+    query_window receiver_window(*sirius_ctx, *con->context, "frag_receiver");
+    receiver.build(receiver_window.query_id());
+
+    // The relay the compute node will perform: pull from the sender's output stream and push
+    // into the receiver's input stream, as native batches. No Arrow, no disk.
+    std::size_t relayed_batches = 0;
+    while (auto batch = sender.session().pull(0)) {
+      REQUIRE(receiver.session().push(0, *batch));
+      ++relayed_batches;
+    }
+    REQUIRE(relayed_batches > 0);
+    receiver.session().close_input(0, 0);
+
+    receiver.run();
+    receiver_window.finish();
+
+    // Values, not just a count: the chain must deliver exactly what the sender produced.
+    auto const received = drain_values(receiver, 1);
+    REQUIRE(received.size() == static_cast<std::size_t>(expected_rows));
+    REQUIRE(received == std::vector<std::int32_t>{1, 2, 3, 4, 5});
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}
+
+// ============================================================================
+// FRAG-3: malformed specs are rejected at construction
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-3: a malformed fragment spec is rejected",
+                 "[integration][streaming_fragment]")
+{
+  auto source = sirius::test::sql_plan_source(kLeafQuery);
+
+  SECTION("no output stream")
+  {
+    fragment_spec spec;
+    spec.plan_source = source;
+    REQUIRE_THROWS_AS(streaming_fragment(*con->context, std::move(spec)),
+                      sirius::invalid_input_exception);
+  }
+
+  SECTION("fan-out without a partition spec")
+  {
+    // Two destinations without partitioning would silently broadcast; refuse instead.
+    fragment_spec spec;
+    spec.plan_source = source;
+    spec.outputs     = {0, 1};
+    REQUIRE_THROWS_AS(streaming_fragment(*con->context, std::move(spec)),
+                      sirius::invalid_input_exception);
+  }
+
+  SECTION("duplicate output id")
+  {
+    fragment_spec spec;
+    spec.plan_source  = source;
+    spec.outputs      = {0, 0};
+    spec.partitioning = sirius::op::partition_spec{{0}};
+    REQUIRE_THROWS_AS(streaming_fragment(*con->context, std::move(spec)),
+                      sirius::invalid_input_exception);
+  }
+
+  SECTION("a declared input the plan never reads")
+  {
+    fragment_spec spec;
+    spec.plan_source = source;  // reads a VALUES list, not the stream
+    spec.inputs[7]   = stream_input_spec{
+        {"a"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+        {0}};
+    spec.outputs = {0};
+
+    auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+    con->BeginTransaction();
+    streaming_fragment fragment(*con->context, std::move(spec));
+    {
+      query_window window(*sirius_ctx, *con->context, "frag_3");
+      REQUIRE_THROWS_AS(fragment.build(window.query_id()), sirius::invalid_input_exception);
+    }
+    con->Rollback();
+  }
+}
+
+// ============================================================================
+// FRAG-CONTROL: RESULT_COLLECTOR-rooted plan on the direct engine path.
+// Isolates harness failures from sink failures (pair with SINKROOT-4).
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-CONTROL: which queries actually materialize rows on the direct path",
+                 "[integration][streaming_fragment_control]")
+{
+  // Assert row count, not merely that execute() succeeded.
+  auto row_count_of = [&](const std::string& query) -> std::size_t {
+    std::size_t rows = 0;
+    // with_initialized_engine synthesizes its own query id, but execute() still needs a real
+    // window open: only a window begin points the task creator at this connection.
+    auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+    REQUIRE(sirius_ctx != nullptr);
+    query_window window(*sirius_ctx, *con->context, "frag_control");
+    sirius::test::with_initialized_engine(*con, query, [&](sirius::sirius_engine& engine) {
+      REQUIRE(engine.has_result_collector());
+      engine.execute();
+      auto result = engine.get_result();
+      REQUIRE(result != nullptr);
+      REQUIRE_FALSE(result->HasError());
+      auto materialized =
+        duckdb::unique_ptr_cast<duckdb::QueryResult, duckdb::MaterializedQueryResult>(
+          std::move(result));
+      rows = materialized->RowCount();
+    });
+    window.finish();
+    return rows;
+  };
+
+  SECTION("VALUES leaf")
+  {
+    INFO("kLeafQuery = " << kLeafQuery);
+    REQUIRE(row_count_of(kLeafQuery) == kLeafRows);
+  }
+
+  SECTION("table scan") { REQUIRE(row_count_of("SELECT n_regionkey FROM nation") == 25); }
+
+  SECTION("filtered table scan")
+  {
+    REQUIRE(row_count_of("SELECT n_nationkey FROM nation WHERE n_regionkey = 1") == 5);
+  }
+}
+
+// ============================================================================
+// FRAG-4: parquet GPU scan across a fragment boundary (real batch counts).
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-4: a parquet scan crosses a fragment boundary",
+                 "[integration][streaming_fragment]")
+{
+  auto const parquet = lineitem_parquet_path();
+  REQUIRE(fs::exists(parquet));
+
+  // Filter on l_quantity so row-group pruning does not collapse the scan. Still one batch
+  // per file; FRAG-5 covers multi-batch streams.
+  auto const leaf =
+    "SELECT l_orderkey FROM read_parquet('" + parquet.string() + "') WHERE l_quantity < 2";
+
+  auto expected = con->Query("SELECT count(*) FROM (" + leaf + ") t");
+  REQUIRE_FALSE(expected->HasError());
+  auto const expected_rows =
+    static_cast<std::size_t>(expected->GetValue(0, 0).GetValue<std::int64_t>());
+  REQUIRE(expected_rows > 0);
+
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  con->BeginTransaction();
+  try {
+    fragment_spec sender_spec;
+    sender_spec.plan_source = sirius::test::sql_plan_source(leaf);
+    sender_spec.outputs     = {0};
+    streaming_fragment sender(*con->context, std::move(sender_spec));
+
+    fragment_spec receiver_spec;
+    receiver_spec.plan_source =
+      sirius::test::sql_plan_source("SELECT l_orderkey FROM sirius_stream_source(0)");
+    receiver_spec.inputs[0] = stream_input_spec{
+      {"l_orderkey"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::BIGINT}),
+      {0}};
+    receiver_spec.outputs = {1};
+    streaming_fragment receiver(*con->context, std::move(receiver_spec));
+
+    {
+      query_window sender_window(*sirius_ctx, *con->context, "frag4_sender");
+      sender.build(sender_window.query_id());
+      sender.run();
+      sender_window.finish();
+    }
+
+    query_window receiver_window(*sirius_ctx, *con->context, "frag4_receiver");
+    receiver.build(receiver_window.query_id());
+
+    std::size_t relayed_batches = 0;
+    std::size_t relayed_rows    = 0;
+    while (auto batch = sender.session().pull(0)) {
+      relayed_rows += static_cast<std::size_t>(sirius::get_cudf_table_view(**batch).num_rows());
+      REQUIRE(receiver.session().push(0, *batch));
+      ++relayed_batches;
+    }
+    REQUIRE(relayed_batches > 0);
+    // Everything the sender produced crosses the hop; nothing is dropped in transit.
+    REQUIRE(relayed_rows == expected_rows);
+    receiver.session().close_input(0, 0);
+
+    receiver.run();
+    receiver_window.finish();
+
+    REQUIRE(drain_row_count(receiver, 1) == expected_rows);
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}
+
+// ============================================================================
+// FRAG-5: multi-batch drain. FRAG-2/4 hop one batch; two senders fill the queue here.
+// ============================================================================
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-5: a multi-batch stream drains completely",
+                 "[integration][streaming_fragment]")
+{
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  // Disjoint halves so the output identifies which batches arrived.
+  constexpr const char* kFirstHalf  = "SELECT a FROM (VALUES (1), (2), (3)) t(a)";
+  constexpr const char* kSecondHalf = "SELECT a FROM (VALUES (4), (5), (6)) t(a)";
+
+  con->BeginTransaction();
+  try {
+    auto make_sender = [&](const char* query) {
+      fragment_spec spec;
+      spec.plan_source = sirius::test::sql_plan_source(query);
+      spec.outputs     = {0};
+      return std::make_unique<streaming_fragment>(*con->context, std::move(spec));
+    };
+
+    auto first  = make_sender(kFirstHalf);
+    auto second = make_sender(kSecondHalf);
+
+    fragment_spec receiver_spec;
+    receiver_spec.plan_source =
+      sirius::test::sql_plan_source("SELECT a FROM sirius_stream_source(0)");
+    receiver_spec.inputs[0] = stream_input_spec{
+      {"a"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      {0}};
+    receiver_spec.outputs = {1};
+    streaming_fragment receiver(*con->context, std::move(receiver_spec));
+
+    for (auto* sender : {first.get(), second.get()}) {
+      query_window sender_window(*sirius_ctx, *con->context, "frag5_sender");
+      sender->build(sender_window.query_id());
+      sender->run();
+      sender_window.finish();
+    }
+
+    query_window receiver_window(*sirius_ctx, *con->context, "frag5_receiver");
+    receiver.build(receiver_window.query_id());
+
+    std::size_t relayed_batches = 0;
+    for (auto* sender : {first.get(), second.get()}) {
+      while (auto batch = sender->session().pull(0)) {
+        REQUIRE(receiver.session().push(0, *batch));
+        ++relayed_batches;
+      }
+    }
+    // Multi-batch premise: if only one batch arrives this degrades to FRAG-2.
+    REQUIRE(relayed_batches > 1);
+    receiver.session().close_input(0, 0);
+
+    receiver.run();
+    receiver_window.finish();
+
+    // INFO only: one batch per task today; coalescing would change the count.
+    std::size_t created = 0, completed = 0;
+    for (const auto& p : receiver.engine().sirius_pipelines) {
+      created += p->get_tasks_created();
+      completed += p->get_tasks_completed();
+    }
+    INFO("relayed_batches=" << relayed_batches << " receiver tasks_created=" << created
+                            << " tasks_completed=" << completed);
+
+    REQUIRE(drain_values(receiver, 1) == std::vector<std::int32_t>{1, 2, 3, 4, 5, 6});
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}

--- a/test/cpp/utils/pipeline_conversion_test_utils.cpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.cpp
@@ -256,6 +256,15 @@ void with_initialized_engine(duckdb::Connection& con,
   }
 }
 
+exec::logical_plan_source sql_plan_source(const std::string& query)
+{
+  return [query](duckdb::ClientContext& context) {
+    optimizer_disable_guard guard(context);
+    auto extracted = extract_logical_plan_sirius_order(context, query);
+    return std::move(extracted.logical_plan);
+  };
+}
+
 void with_initialized_streaming_fragment(
   duckdb::Connection& con,
   const std::string& query,

--- a/test/cpp/utils/pipeline_conversion_test_utils.hpp
+++ b/test/cpp/utils/pipeline_conversion_test_utils.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "exec/streaming_fragment.hpp"
 #include "op/sirius_physical_streaming_sink.hpp"
 #include "query_id.hpp"
 
@@ -93,6 +94,9 @@ void with_conversion_result(
 void with_initialized_engine(duckdb::Connection& con,
                              const std::string& query,
                              const std::function<void(sirius_engine&)>& consume);
+
+//! SQL → bound LogicalOperator (tests stand in for Substrait). Caller must have a transaction.
+exec::logical_plan_source sql_plan_source(const std::string& query);
 
 //! Like with_initialized_engine, but roots the plan in a STREAMING_SINK over output_repos.
 //! Caller owns the plan tree; engine borrows via initialize_internal.


### PR DESCRIPTION
Part of #839 — the execution half. Last of the three PRs that replaced #1432; **#1479 and #1480
have merged, so this now targets `dev` directly and stands alone.**

> **Not closing #839.** The issue asks for a session that "starts it on the existing task
> scheduler **without blocking**". `streaming_fragment::run()` blocks: it goes through
> `sirius_engine::execute()`, which takes the future from `start_query()` and immediately waits.
> Fragments therefore run store-and-forward, one at a time, which is why the FFI orders
> `relay_from(...) → run()` and notes that only one fragment may sit between its own `build()`
> and `run()`. The `Fragment` surface also exposes no `push`/`pull`/`wait`, so a genuinely remote
> sender cannot feed a fragment yet. Both are tracked in #1590 rather than claimed here.

**Base: #1480 (`stream/14-session`).** Review that first; this PR's diff is the third commit only.

**What.** Turns a plan plus a set of stream ids into something runnable. `streaming_fragment`
binds a logical plan against a `stream_bind_catalog`, rewrites its stream leaves to the
`batch_stream` handles the session resolves, builds the physical plan, and runs it to completion.

**Design: bind before the streams exist.** A fragment has to be constructible before its peers
have started — otherwise startup is ordered and a distributed plan deadlocks on its own topology.
`stream_bind_catalog` and `stream_plan_bindings` are what make that possible: a plan names its
inputs and outputs by id, and binding resolves those ids through the session at build time rather
than at plan time. The rewrite step is where the id-addressed world of part 2 meets the
pointer-addressed world of the operators.

**FFI.** `sirius::ffi::Fragment` exposes one fragment to Rust: `relay_from` to chain fragments,
`result_to_arrow` to pull the tail out as Arrow, and the build/run lifecycle. This is the surface
the multi-node work sits on.

---

**Reviewing.** Two commits: the original, plus a second holding the review fixes so you can see
what moved since you last looked rather than having it amended away. Suggested reading order:

1. `streaming_fragment.hpp` — the lifecycle contract
2. `stream_bind_catalog.hpp` / `stream_plan_bindings.hpp` — how a plan names streams
3. `streaming_fragment.cpp` — bind → rewrite → build → run
4. `sirius_ffi.cpp` — the Rust-facing surface

**Tests.** `test_streaming_fragment.cpp` covers build/run, relay between two fragments, the error
plane, and key-cast normalization. `test_stream_bind_catalog.cpp` covers the binding layer alone.

---

**Stack.**

| Part | PR | Branch | Scope | State |
|---|---|---|---|---|
| 1 | #1479 | `stream/13-sink` | `STREAMING_SINK` + partitioning (#837, #838) | merged |
| 2 | #1480 | `stream/14-session` | `exec::stream_session` (#839, addressing) | merged |
| 3 | **#1481 (this)** | `stream/15-fragment` | `streaming_fragment` + FFI (#839, execution) | ← on `dev` |

**This tip is tree-identical to #1432's head** on every streaming path, so #1433
(`sirius::ffi::Fragment` for Rust) rebases onto it without change. #1432 is closed as superseded.
