### PR TITLE
feat(pipeline): runtime data size estimation API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,7 @@ set(EXTENSION_SOURCES
     src/pipeline/sirius_meta_pipeline.cpp
     src/pipeline/sirius_pipeline.cpp
     src/pipeline/sirius_pipeline_converter.cpp
+    src/pipeline/data_size_estimator.cpp
     src/pipeline/repository_wiring_materializer.cpp
     src/pipeline/sirius_plan_printer.cpp
     src/pipeline/task_request.cpp
@@ -807,6 +808,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_gpu_pipeline_executor.cpp
     test/cpp/pipeline/test_oom_reschedule.cpp
     test/cpp/pipeline/test_pipeline_memory_history.cpp
+    test/cpp/pipeline/test_data_size_estimator.cpp
     test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
     test/cpp/pipeline/test_gpu_pipeline_disk_readback.cpp
     test/cpp/pipeline/test_get_next_ports_after_sink.cpp

--- a/docs/super-sirius/README.md
+++ b/docs/super-sirius/README.md
@@ -39,6 +39,7 @@ SELECT l_returnflag, SUM(l_quantity) FROM lineitem GROUP BY l_returnflag;
 | [Data Management](data-management.md) | Data batches, repositories, ports, barrier semantics |
 | [Streaming Sessions](streaming-sessions.md) | Fragment boundaries for distributed queries: `exec::batch_stream`, streaming source/sink, the id-addressed `stream_session` |
 | [Streaming Fragments](streaming-fragments.md) | Building and running one fragment: `stream_bind_catalog`, `exec::streaming_fragment`, the cross-language `sirius::ffi::Fragment`/`Context` lifecycle |
+| [Data Size Estimation](data-size-estimation.md) | Runtime projection of the total bytes that will reach an operator's input port |
 | [Configuration](configuration.md) | sirius_config, operator_params, SET variables |
 | [Optimizations](optimizations.md) | Performance optimizations with PRs, code paths, configs |
 | [Compressed Pinning](compressed-pinning.md) | Simpatico-compressed pin_table on host/GPU tiers — which tier to compress on, plan selection vs the H2D link, GB300 SF1000 results |

--- a/docs/super-sirius/data-size-estimation.md
+++ b/docs/super-sirius/data-size-estimation.md
@@ -1,0 +1,289 @@
+# Runtime Data Size Estimation
+
+**Files:** `src/include/pipeline/data_size_estimator.hpp`, `src/pipeline/data_size_estimator.cpp`
+
+An API that projects how many bytes will *ultimately* arrive at an operator's input port, by
+chaining upstream pipelines' measured input→output ratios back to the first pipeline that has
+finished (or to a source that knows its own total).
+
+Implements [issue #1283](https://github.com/sirius-db/sirius/issues/1283).
+
+## The API
+
+```cpp
+std::optional<data_size_estimate> estimate_port_total_input_bytes(
+    op::sirius_physical_operator& op, std::string_view port_id, size_estimate_options = {});
+
+std::optional<data_size_estimate> estimate_pipeline_total_output_bytes(
+    pipeline::sirius_pipeline& p, size_estimate_options = {});
+```
+
+The number is a **total for the whole query**, not a so-far figure: it answers *"how many bytes
+will this port have received once its producer is done?"*.
+
+`estimate_pipeline_total_output_bytes` resolves in four cases, in the order tried:
+
+| # | condition | result |
+|---|-----------|--------|
+| 1 | pipeline finished | its recorded output total, `exact = true`; a pipeline that finished having never created a task emitted exactly 0, while one whose tasks all recorded nothing is `nullopt` |
+| 2 | several input ports (fan-in) | follow the source's nominated primary port, scaled by `output total / consumed primary bytes`; `nullopt` if it nominates none |
+| 3 | source has no input ports (a leaf) | `total_source_input_bytes × ratio`, or `total_source_output_bytes` unscaled |
+| 4 | exactly one input port | recurse into the producer, then apply this pipeline's ratio |
+
+`estimate_port_total_input_bytes` resolves the port's `src_pipeline` and delegates. It returns
+`nullopt` for a missing port, a dependency-only port (null repo), or a port with no producer.
+
+### The result
+
+```cpp
+struct data_size_estimate {
+  std::size_t bytes;           // projected total
+  bool        exact;           // measured, not projected — anchored on a finished pipeline
+  std::size_t hops;            // pipelines traversed; ratio error compounds per hop
+  std::size_t ratio_samples;   // completed tasks behind the weakest ratio in the chain
+  bool        planner_derived; // the anchor was a planner guess, not a measurement
+};
+```
+
+`exact`, `ratio_samples` and `planner_derived` are the confidence signals to gate on when a
+decision is expensive to reverse — a projection built from a handful of completed tasks is far
+weaker than one built from hundreds, and one resting on a planner guess is weaker still.
+
+**The chaining is measurement-derived**, and any unknown link yields `nullopt` rather than a guess.
+The estimator core never consults planner cardinality: every ratio comes from completed tasks, and
+every anchor from a source that measured its own total.
+
+There is exactly one exception, at the leaf. `GPU_SCAN::total_source_output_bytes()` projects
+DuckDB's `estimated_cardinality × measured bytes/row`, and is consulted only while split discovery
+is still open — once it closes, the measured `total_source_input_bytes()` takes over. An estimate
+resting on it is never `exact`, and sets `planner_derived`.
+
+`planner_derived` is a distinct field rather than a reading of `ratio_samples == 0`, because that
+zero does not survive the walk. It means "no measured ratio was applied", which is true of the
+anchor's own pipeline but stops being true one hop later: `weaker_sample_count` treats zero as
+"nothing recorded yet" rather than as a minimum, so the first downstream pipeline with a trusted
+ratio replaces it with its own count. Reading provenance off the zero would therefore report it
+correctly only when the scan pipeline *is* the pipeline being asked about. `planner_derived` is
+sticky instead — set at the anchor, carried through every ratio application and every fan-in hop.
+
+`ratio_samples == 0` is ambiguous for a second reason, independent of the above. With
+`assume_unit_ratio` on, a substituted unit ratio passes the upstream sample count through untouched
+(it has no measured support of its own to report), so a chain of substitutions above a *measured*
+anchor also arrives at zero. Read `ratio_samples == 0` as "no measured ratio backs this" — never as
+"planner-derived", which is what `planner_derived` is for.
+
+The corollary of the rest being measurement-derived is that this API **cannot answer before the
+query has started running**; it has no pre-execution mode.
+
+## Where the numbers come from
+
+**The pipeline ratio.** Every completed GPU task already records `{input_basis, peak_memory,
+output_bytes}` into its pipeline's history. `history_totals` accumulates alongside the 64-entry
+ring buffer and is never evicted, so it stays accurate on pipelines that run more tasks than the
+ring holds. It keeps two sets of terms, because the ratio and the output total have different
+admission rules:
+
+- **ratio terms** need a basis in pipeline-input units, so they take only tasks with a nonzero
+  basis that were not resumed mid-pipeline after a reschedule (a resumed task restarted from
+  intermediate data, which is a different quantity and would inflate the ratio).
+- **output terms** take every successful task, including zero-basis ones — a scan split with no
+  a-priori size estimate still emits bytes, and a finished pipeline's total must not depend on
+  whether its inputs happened to be measurable.
+
+Tasks that OOM'd record no output and are in neither: they consumed input and produced nothing.
+
+**Leaf source totals.** Two virtuals on `sirius_physical_operator`, both defaulting to `nullopt`
+(the correct answer for `STREAMING_SOURCE`, whose total is genuinely unknowable):
+
+| operator | `total_source_input_bytes` | `total_source_output_bytes` |
+|----------|---------------------------|-----------------------------|
+| `GPU_SCAN` | Σ split bytes, once split discovery closes | `max(estimated_cardinality × bytes/row, bytes emitted so far)` |
+| `GPU_VALUES` | exact, known at plan time | — |
+
+Both exist because the quantities live in different coordinate systems.
+`scan_info::estimated_bytes()` is **pre**-filter, and the pipeline ratio's denominator is that same
+pre-filter number — so the ratio already encodes filter selectivity. `estimated_cardinality` is
+**post**-filter, so scaling it by the ratio would count selectivity twice. Hence
+`total_source_output_bytes` is used unscaled.
+
+For `GPU_SCAN` the total is tallied in `split_connector::push_split` — the choke point every split
+passes through — and `is_discovery_complete()` reports when the tally is final. That is distinct
+from the pre-existing `is_closed()`, which means *closed and drained*.
+
+`total_source_output_bytes` is the one planner-derived number anywhere in the chain: its row count
+comes from DuckDB's `estimated_cardinality`, not from measurement. It is consulted only while split
+discovery is open, and only the bytes/row factor is measured. An estimate resting on it is never
+`exact` and always reports `planner_derived`.
+
+That row count has no lower bound and is not tied to reality: it is a pre-execution guess at a
+post-filter cardinality, so it can sit below the rows the scan has *already* emitted, and DuckDB
+forces it to exactly zero whenever the base table cardinality reads zero — which an absent or stale
+stat on a non-empty table will do. Left alone, the leaf would then report a whole-query total below
+an observed partial, or zero, and every downstream hop would multiply that out. So the projection is
+floored at the bytes already emitted: a measured partial is a hard lower bound on a total, and
+`max(estimated_cardinality × bytes/row, emitted_bytes)` is the weakest correct statement available.
+Returning `nullopt` instead would also be sound but discards a usable bound.
+
+## Fan-in
+
+A `HASH_JOIN` heads its own pipeline with `"build"` and `"default"` ports. The estimator follows
+only the volume-driving side, which the operator nominates:
+
+```cpp
+virtual std::optional<std::string_view> primary_input_port() const;        // "default" on a join
+virtual std::optional<std::size_t>      consumed_primary_input_bytes() const;
+```
+
+### Which side to follow
+
+The nominated port must be the side still *arriving* — that is the axis the extrapolation runs
+along. INNER/LEFT/SEMI/ANTI/MARK qualify: `refresh_cross_schedule` folds the build to one whole
+batch and streams the probe. RIGHT/RIGHT_SEMI/RIGHT_ANTI invert it, pinning the probe whole and
+streaming the build, and OUTER pins both — so those nominate nothing. With the probe closed,
+`consumed` is final from the first pairing while output climbs with each build pairing, so the ratio
+would collapse to "bytes emitted so far" and under-report the unpaired build, worst when the build
+dwarfs the probe. Following the build side would be predictive for RIGHT-family, but needs
+build-byte accounting the join does not keep.
+
+### The denominator
+
+The recorded `input_basis` cannot serve: a STANDARD join pairs each probe batch with every build
+batch and *borrows* rather than pops, so the same bytes enter `input_basis` once per pairing and its
+sum is a cross product, not an input volume. The join therefore counts probe bytes itself, as they
+enter a task rather than as they land in the port — which would measure arrival, not consumption.
+
+Bytes are **weighted by pairing progress** rather than charged whole at first sighting. Output
+accrues once per completed pairing, so a batch through 1 of B pairings has emitted 1/B of what it
+finally will; charging its full size up front completes the denominator while the numerator is 1/B
+of the way there, and the ratio reads low by a factor unbounded in B — untouched by the sample
+floor, which counts tasks rather than pairings. `pairing_weighted_probe_bytes` sums
+`bytes x (pairings done / build batches)`, putting both terms at the same fraction of the way
+through. This is INNER-specific in practice: every other join type pins the build side whole,
+leaving B = 1 and nothing to weight.
+
+Batches with no such multiplicity — BUILD_PROBE pops, and cross-schedule orphans whose opposite side
+finished empty — are counted whole in a separate accumulator. The two sets are disjoint, so the
+reported total is their sum.
+
+#### Known bias: the weighting assumes output accrues evenly across build batches
+
+**This is an open defect, not a solved problem.** The weighting is unbiased only if each build batch
+contributes an equal share of a probe batch's output. It does not, in general, and when it does not
+the ratio reads **high** — the unsafe direction, and the one the mechanisms below are supposed to
+rule out.
+
+`next_cross_schedule_pair` hands out the first unscheduled pair in `(partition, probe, build)` order,
+so partition 0's grid is fully scheduled before partition 1 gets anything, and within a partition
+probe batch 0 sweeps all B build batches before probe batch 1 starts. At the moment the fan-in gate
+opens — `min_fan_in_ratio_samples` completed pairings, 16 by default — the denominator therefore
+carries weight for only the first probe batch or two, while the numerator is the pipeline's *whole*
+output. If matches concentrate in the early build batches, output is already near its final value
+while the denominator reads `bytes(p0) × 16/B`, overstating the ratio by roughly **B/16** for
+B ≥ 16 — unbounded in B. The floor does bound it by that factor of 16, so it is not useless here,
+just far weaker than its own rationale (below) claims.
+
+The floor is weaker than its sample count suggests for a second reason: with B ≥ 16, those 16
+samples are 16 pairings *of a single probe batch*, so in probe-batch terms the ratio rests on n = 1.
+That is exactly the unrepresentative-sample case the floor exists to exclude. Partition skew
+compounds it, since the whole probe side is extrapolated from partition 0's opening batches.
+
+The bias is transient — it vanishes once every probe batch is fully paired, because the denominator
+is then the true total probe bytes — but it is largest early, which is when consumers ask.
+
+Neither available fix is cheap. Restricting the ratio to fully-paired probe batches would remove the
+bias outright, but the join records output per *task*, not per probe batch, so the numerator cannot
+be narrowed to match. Gating on pairing completeness instead of task count would work, at the cost
+of withholding the estimate until near the end of the join. Until one lands, treat a fan-in estimate
+as an upper-biased figure under build or partition skew.
+
+### Keeping the error one-directional
+
+An estimate that reads low costs a consumer some headroom; one that reads high can leave it
+under-provisioned. Three mechanisms exist to keep the error on the low side — bounding the *races
+and read orders* below, not the modelling bias documented just above, which they do not address.
+
+*Read order.* The two terms live on different objects and cannot be read atomically, so the
+numerator is sampled before the denominator. `consumed` advances at task *creation* and
+`output_bytes` at *completion*, both monotonically, so reading output first leaves the denominator a
+superset of the numerator's tasks. The opposite order lets a task both created and completed between
+the two reads contribute output with no matching input.
+
+*Publish order.* The weighted total is republished after a pairing is claimed, never before:
+`refresh_cross_schedule` runs ahead of the increment, so its store alone would leave the new
+pairing's weight unpublished while the task it hands out is already free to record output. The claim
+republishes for itself; the store in `refresh_cross_schedule` covers only the polls that claim
+nothing. Both are no-ops until the build side finishes — the predicate
+`consumed_primary_input_bytes()` gates on — which also keeps the walk off the streaming phase, as
+the discard sweep beside it already does.
+
+*Late sizes.* `execute()` cannot republish (the weights need `_cross`, hence `op_state_mutex`), and
+scheduler polling is event-driven, so it may never run again after the last task is handed out. A
+size learned in the drain tail is therefore carried in a separate accumulator at its **full** size
+rather than its pairing fraction: over-counting the denominator biases the ratio low. A publish
+folds it into the weights and clears the carry.
+
+### Recording sizes
+
+`record_probe_batch_bytes` is the only writer of the size map, so the "paired or counted whole,
+never both" split holds by construction. It skips ids already counted whole, which is what keeps an
+orphan task from disturbing the totals: the scheduler has already counted the survivor, and the
+synthesized empty opposite handed to the same task is not a probe batch at all.
+
+The claim-time read is non-blocking, since it runs under the join's state lock and a resident batch
+may be exclusively locked by a concurrent conversion; a lost race is retried at the batch's next
+pairing. A batch paired only once has no next pairing, so `execute()` records again off the accessor
+it has already materialized with a blocking read. Sizes come from
+`get_uncompressed_data_size_in_bytes()`: `get_size_in_bytes()` is representation-dependent, so the
+same rows would contribute different numbers depending on tier — and on whether a lock race was
+lost — and would not match the units `input_basis` counts.
+
+That accounting takes `_probe_bytes_mutex`, never `op_state_mutex`: `execute()` updates it while
+holding a batch lock, and two scheduler paths (the cross-schedule orphan and the broadcast slot
+cleanup) block on a batch lock while holding `op_state_mutex`, so sharing it would invert the order
+against a queued writer — spill readback blocks, where the downgrade's `try_to_mutable` does not.
+It is the innermost lock: nothing waits on a batch lock or `op_state_mutex` while holding it.
+
+### Sample floors
+
+`size_estimate_options` carries two floors, below which a measured ratio is not trusted:
+
+- `min_ratio_samples` (4) — single-input. That ratio accrues both terms on task completion and is
+  unbiased at any count; the floor only rules out one unrepresentative batch.
+- `min_fan_in_ratio_samples` (16) — fan-in. That ratio divides a completion-accrued numerator by a
+  denominator advancing at task *start*, so it reads low by roughly
+  `in_flight / (samples + in_flight)`. More samples shrink a systematic bias, which is why this
+  floor is far higher — and why it is a **hard gate**: below it there is no estimate even under
+  `assume_unit_ratio`. A unit ratio is a reasonable stand-in for a single-input pipeline
+  (assume pass-through), but a join can multiply or divide its input volume by orders of
+  magnitude, so 1:1 carries no information there.
+
+There is deliberately no task-count correction for in-flight tasks: `consumed` does not advance
+once per task, so the completed fraction of tasks does not map onto the consumed fraction of bytes.
+
+The in-flight skew described above is not the only bias on the fan-in ratio, and `16` does not
+bound the other one. See [the known bias](#known-bias-the-weighting-assumes-output-accrues-evenly-across-build-batches):
+under build or partition skew the pairing weighting pushes the ratio high by roughly `B/16`, in the
+opposite direction to the in-flight effect and not necessarily smaller than it.
+
+## Coverage
+
+| category | operators |
+|----------|-----------|
+| anchors | `GPU_SCAN`; `GPU_VALUES` (also covers `COLUMN_DATA_SCAN`, `DUMMY_SCAN`, `EMPTY_RESULT`, rewritten to it at plan generation); any finished pipeline |
+| pass-through (recurse) | any single-ingress pipeline — `FILTER`, `PROJECTION`, `LIMIT`, sorts, aggregates, `CONCAT`, `PARTITION` |
+| fan-in | `HASH_JOIN` (INNER/LEFT/SEMI/ANTI/MARK) |
+| dead ends (`nullopt`) | `STREAMING_SOURCE` (by design); `TABLE_SCAN`; `NESTED_LOOP_JOIN`, delim joins, `CTE`, `HASH_JOIN` RIGHT-family and OUTER (no nominated primary) |
+
+Because the estimator works at pipeline granularity, single-input operators need no per-operator
+model: a pipeline's ratio is measured end-to-end, so whatever a projection or filter does to byte
+volume is captured automatically. The cost is attribution — a bad ratio cannot be traced to one
+operator.
+
+`NESTED_LOOP_JOIN` uses the same port names and could take the identical fan-in treatment; leaving
+it unnominated preserves fall-back-to-waiting behaviour.
+
+## Consumers
+
+None in-tree yet. The API is exercised by `test/cpp/pipeline/test_data_size_estimator.cpp` against
+a synthetic pipeline DAG, which covers each terminating case, the sample floors, overflow, and the
+fan-in rules above.

--- a/docs/super-sirius/data-size-estimation.md
+++ b/docs/super-sirius/data-size-estimation.md
@@ -26,8 +26,9 @@ will this port have received once its producer is done?"*.
 | # | condition | result |
 |---|-----------|--------|
 | 1 | pipeline finished | its recorded output total, `exact = true`; a pipeline that finished having never created a task emitted exactly 0, while one whose tasks all recorded nothing is `nullopt` |
+| — | output capped (a row limit) | `nullopt` — see [capped pipelines](#capped-pipelines) |
 | 2 | several input ports (fan-in) | follow the source's nominated primary port, scaled by `output total / consumed primary bytes`; `nullopt` if it nominates none |
-| 3 | source has no input ports (a leaf) | `total_source_input_bytes × ratio`, or `total_source_output_bytes` unscaled |
+| 3 | source has no input ports (a leaf) | `total_source_input_bytes × ratio`, or — only when the source is the pipeline's sole operator — `total_source_output_bytes` unscaled |
 | 4 | exactly one input port | recurse into the producer, then apply this pipeline's ratio |
 
 `estimate_port_total_input_bytes` resolves the port's `src_pipeline` and delegates. It returns
@@ -106,6 +107,15 @@ pre-filter number — so the ratio already encodes filter selectivity. `estimate
 **post**-filter, so scaling it by the ratio would count selectivity twice. Hence
 `total_source_output_bytes` is used unscaled.
 
+That only works when the source is the pipeline's **only** operator, which for a GPU_SCAN holds
+just when its tree parent is a `PARTITION`. Otherwise `FILTER`, `PROJECTION`, `LIMIT` or
+`DYNAMIC_FILTER` sit in the same pipeline, the scan's output stops being the pipeline's output, and
+neither option is available: unscaled ignores those operators, while the pipeline ratio cannot
+bridge the gap because its denominator is the pre-filter input rather than the scan's output. The
+estimator checks `source == sink` — `get_operators()` runs source through sink, so a lone operator
+is both — and returns `nullopt` when anything follows. The measured `total_source_input_bytes` path
+has no such restriction: its ratio is the pipeline's own, end to end.
+
 For `GPU_SCAN` the total is tallied in `split_connector::push_split` — the choke point every split
 passes through — and `is_discovery_complete()` reports when the tally is final. That is distinct
 from the pre-existing `is_closed()`, which means *closed and drained*.
@@ -123,6 +133,32 @@ an observed partial, or zero, and every downstream hop would multiply that out. 
 floored at the bytes already emitted: a measured partial is a hard lower bound on a total, and
 `max(estimated_cardinality × bytes/row, emitted_bytes)` is the weakest correct statement available.
 Returning `nullopt` instead would also be sound but discards a usable bound.
+
+## Capped pipelines
+
+Everything above models a pipeline as a linear map: output grows in proportion to input, so a
+measured ratio extrapolates. A row limit breaks that. `STREAMING_LIMIT` makes output
+`min(k, input × selectivity)` — saturating, not linear — so past the cap more input yields no more
+output, and a ratio measured before the cap binds projects a total the pipeline will never reach.
+The error is worst exactly where the operator is most useful: `SELECT * FROM huge LIMIT 10`.
+
+It compounds. `sirius_pipeline::update_pipeline_status` treats `is_limit_exhausted()` as grounds to
+finish early *without draining the source*, so the pipeline stops consuming while
+`total_source_input_bytes` still reports the whole table. The scan itself is never told to stop —
+no split is skipped and the split connector is only ever closed by its producer — but those splits
+no longer flow through a pipeline that has already finished.
+
+So a pipeline containing an operator whose `caps_pipeline_output()` is true gets no estimate at all
+while it is unfinished, in any of the four cases. Once it *is* finished, case 1 answers from the
+recorded total and is unaffected. The check is a virtual on the operator rather than a type test,
+and is deliberately distinct from the existing `is_limit_exhausted()`: the cap bounds the eventual
+total from the start, whether or not it has bound yet.
+
+This is a hard stop rather than a bound because bounding needs the limit in *bytes*, and the limit
+is a row count while the history records only bytes. `LIMIT_PERCENT` would need no treatment (a
+percentage is multiplicative) but Sirius rejects it at planning. `TOP_N` is a sink heading its own
+pipeline, so it caps what that pipeline's *consumer* sees rather than what this one emits, and it
+does not set the flag.
 
 ## Fan-in
 
@@ -172,9 +208,9 @@ contributes an equal share of a probe batch's output. It does not, in general, a
 the ratio reads **high** — the unsafe direction, and the one the mechanisms below are supposed to
 rule out.
 
-`next_cross_schedule_pair` hands out the first unscheduled pair in `(partition, probe, build)` order,
-so partition 0's grid is fully scheduled before partition 1 gets anything, and within a partition
-probe batch 0 sweeps all B build batches before probe batch 1 starts. At the moment the fan-in gate
+`next_cross_schedule_pair` hands out the first unscheduled pair in `(partition, probe, build)`
+order, so partition 0's grid is fully scheduled before partition 1 gets anything, and within a
+partition probe batch 0 sweeps all B build batches before probe batch 1 starts. At the fan-in gate
 opens — `min_fan_in_ratio_samples` completed pairings, 16 by default — the denominator therefore
 carries weight for only the first probe batch or two, while the numerator is the pipeline's *whole*
 output. If matches concentrate in the early build batches, output is already near its final value
@@ -270,14 +306,15 @@ opposite direction to the in-flight effect and not necessarily smaller than it.
 | category | operators |
 |----------|-----------|
 | anchors | `GPU_SCAN`; `GPU_VALUES` (also covers `COLUMN_DATA_SCAN`, `DUMMY_SCAN`, `EMPTY_RESULT`, rewritten to it at plan generation); any finished pipeline |
-| pass-through (recurse) | any single-ingress pipeline — `FILTER`, `PROJECTION`, `LIMIT`, sorts, aggregates, `CONCAT`, `PARTITION` |
+| pass-through (recurse) | any single-ingress pipeline — `FILTER`, `PROJECTION`, sorts, aggregates, `CONCAT`, `PARTITION` |
 | fan-in | `HASH_JOIN` (INNER/LEFT/SEMI/ANTI/MARK) |
-| dead ends (`nullopt`) | `STREAMING_SOURCE` (by design); `TABLE_SCAN`; `NESTED_LOOP_JOIN`, delim joins, `CTE`, `HASH_JOIN` RIGHT-family and OUTER (no nominated primary) |
+| dead ends (`nullopt`) | `STREAMING_SOURCE` (by design); `TABLE_SCAN`; `NESTED_LOOP_JOIN`, delim joins, `CTE`, `HASH_JOIN` RIGHT-family and OUTER (no nominated primary); any unfinished pipeline holding a `STREAMING_LIMIT` |
 
 Because the estimator works at pipeline granularity, single-input operators need no per-operator
 model: a pipeline's ratio is measured end-to-end, so whatever a projection or filter does to byte
 volume is captured automatically. The cost is attribution — a bad ratio cannot be traced to one
-operator.
+operator. The exception is an operator that breaks proportionality rather than merely scaling it,
+which is why `STREAMING_LIMIT` has to opt out by hand — see [capped pipelines](#capped-pipelines).
 
 `NESTED_LOOP_JOIN` uses the same port names and could take the identical fan-in treatment; leaving
 it unnominated preserves fall-back-to-waiting behaviour.

--- a/docs/super-sirius/data-size-estimation.md
+++ b/docs/super-sirius/data-size-estimation.md
@@ -196,30 +196,34 @@ batch and *borrows* rather than pops, so the same bytes enter `input_basis` once
 sum is a cross product, not an input volume. The join therefore counts probe bytes itself, as they
 enter a task rather than as they land in the port — which would measure arrival, not consumption.
 
-Bytes are **weighted by pairing progress** rather than charged whole at first sighting. Output
-accrues once per completed pairing, so a batch through 1 of B pairings has emitted 1/B of what it
-finally will; charging its full size up front completes the denominator while the numerator is 1/B
-of the way there, and the ratio reads low by a factor unbounded in B — untouched by the sample
-floor, which counts tasks rather than pairings. `pairing_weighted_probe_bytes` sums
-`bytes x (pairings done / build batches)`, putting both terms at the same fraction of the way
-through. This is INNER-specific in practice: every other join type pins the build side whole,
-leaving B = 1 and nothing to weight.
+In BUILD_PROBE — the only mode that publishes a denominator — each probe batch is popped exactly
+once, so the count is a plain running total: `note_probe_bytes_counted` adds each popped batch's
+bytes to `_whole_probe_bytes`, deduplicated by batch id so an OOM-rescheduled task re-entering
+`execute()` with the same batch counts nothing new. Cross-schedule orphans (a surviving batch whose
+opposite side finished empty) are counted the same way.
 
-Batches with no such multiplicity — BUILD_PROBE pops, and cross-schedule orphans whose opposite side
-finished empty — are counted whole in a separate accumulator. The two sets are disjoint, so the
-reported total is their sum.
+A STANDARD or MIXED_JOIN cross schedule has no such clean count: it borrows each probe batch once
+per build batch, so its bytes would have to be **weighted by pairing progress** (a batch through 1
+of B pairings has emitted 1/B of what it finally will), and that weighting is biased under skew —
+the next section. The estimate is withheld for those modes, and the operator-side weighted
+bookkeeping (the per-batch size map, the pairing-weight publication, and the late-size carry) has
+been removed with it. `pairing_weighted_probe_bytes` survives, with its unit tests, as the
+reference arithmetic for the eventual fix.
 
-#### Known bias: the weighting assumes output accrues evenly across build batches
+#### Why STANDARD and MIXED_JOIN are not estimated
 
-**This is an open defect, not a solved problem.** The weighting is unbiased only if each build batch
-contributes an equal share of a probe batch's output. It does not, in general, and when it does not
-the ratio reads **high** — the unsafe direction, and the one the mechanisms below are supposed to
-rule out.
+**The pairing weighting has an unsolved bias, so the estimate is withheld for those modes.**
+`consumed_primary_input_bytes()` answers only in BUILD_PROBE mode, where each probe batch is popped
+exactly once and `consumed` is a plain running total with no weighting to bias. The weighting is
+unbiased only if each build batch contributes an equal share of a probe batch's output. It does not,
+in general, and when it does not the ratio reads **high** — the unsafe direction, and the one the
+mechanisms below are supposed to rule out. The rest of this section records why, so the gate is not
+lifted without fixing it.
 
 `next_cross_schedule_pair` hands out the first unscheduled pair in `(partition, probe, build)`
 order, so partition 0's grid is fully scheduled before partition 1 gets anything, and within a
-partition probe batch 0 sweeps all B build batches before probe batch 1 starts. At the fan-in gate
-opens — `min_fan_in_ratio_samples` completed pairings, 16 by default — the denominator therefore
+partition probe batch 0 sweeps all B build batches before probe batch 1 starts. When the fan-in
+gate opens — `min_fan_in_ratio_samples` completed pairings, 16 by default — the denominator would
 carries weight for only the first probe batch or two, while the numerator is the pipeline's *whole*
 output. If matches concentrate in the early build batches, output is already near its final value
 while the denominator reads `bytes(p0) × 16/B`, overstating the ratio by roughly **B/16** for
@@ -237,49 +241,36 @@ is then the true total probe bytes — but it is largest early, which is when co
 Neither available fix is cheap. Restricting the ratio to fully-paired probe batches would remove the
 bias outright, but the join records output per *task*, not per probe batch, so the numerator cannot
 be narrowed to match. Gating on pairing completeness instead of task count would work, at the cost
-of withholding the estimate until near the end of the join. Until one lands, treat a fan-in estimate
-as an upper-biased figure under build or partition skew.
+of withholding the estimate until near the end of the join. Until one lands, STANDARD and
+MIXED_JOIN report no consumed total at all, and the weighted bookkeeping is removed rather than
+maintained inert. Lifting the gate therefore means restoring, from git history: the size map and
+its recorders, the publish-after-claim ordering, the late-size carry, and the `execute()` backstop
+for a batch whose only pairing loses the non-blocking size read.
 
 ### Keeping the error one-directional
 
 An estimate that reads low costs a consumer some headroom; one that reads high can leave it
-under-provisioned. Three mechanisms exist to keep the error on the low side — bounding the *races
-and read orders* below, not the modelling bias documented just above, which they do not address.
+under-provisioned. One mechanism keeps race error on the low side (it does not address the
+modelling bias documented above):
 
 *Read order.* The two terms live on different objects and cannot be read atomically, so the
-numerator is sampled before the denominator. `consumed` advances at task *creation* and
-`output_bytes` at *completion*, both monotonically, so reading output first leaves the denominator a
-superset of the numerator's tasks. The opposite order lets a task both created and completed between
-the two reads contribute output with no matching input.
+numerator is sampled before the denominator. `consumed` advances when a task takes its probe batch
+and `output_bytes` at *completion*, both monotonically, so reading output first leaves the
+denominator a superset of the numerator's tasks. The opposite order lets a task that both took its
+batch and completed between the two reads contribute output with no matching input.
 
-*Publish order.* The weighted total is republished after a pairing is claimed, never before:
-`refresh_cross_schedule` runs ahead of the increment, so its store alone would leave the new
-pairing's weight unpublished while the task it hands out is already free to record output. The claim
-republishes for itself; the store in `refresh_cross_schedule` covers only the polls that claim
-nothing. Both are no-ops until the build side finishes — the predicate
-`consumed_primary_input_bytes()` gates on — which also keeps the walk off the streaming phase, as
-the discard sweep beside it already does.
-
-*Late sizes.* `execute()` cannot republish (the weights need `_cross`, hence `op_state_mutex`), and
-scheduler polling is event-driven, so it may never run again after the last task is handed out. A
-size learned in the drain tail is therefore carried in a separate accumulator at its **full** size
-rather than its pairing fraction: over-counting the denominator biases the ratio low. A publish
-folds it into the weights and clears the carry.
+The removed weighted path needed two more — publish-after-claim ordering and a full-size carry for
+sizes learned too late to weight — recorded in git history with the machinery, to return with it.
 
 ### Recording sizes
 
-`record_probe_batch_bytes` is the only writer of the size map, so the "paired or counted whole,
-never both" split holds by construction. It skips ids already counted whole, which is what keeps an
-orphan task from disturbing the totals: the scheduler has already counted the survivor, and the
-synthesized empty opposite handed to the same task is not a probe batch at all.
-
-The claim-time read is non-blocking, since it runs under the join's state lock and a resident batch
-may be exclusively locked by a concurrent conversion; a lost race is retried at the batch's next
-pairing. A batch paired only once has no next pairing, so `execute()` records again off the accessor
-it has already materialized with a blocking read. Sizes come from
+`note_probe_bytes_counted` is the only writer: each popped probe batch's bytes enter
+`_whole_probe_bytes` once, keyed by batch id in `_counted_probe_batch_ids`, so an OOM-rescheduled
+task re-entering `execute()` with the same batch — or an orphan already counted by the scheduler —
+adds nothing. Sizes come from
 `get_uncompressed_data_size_in_bytes()`: `get_size_in_bytes()` is representation-dependent, so the
-same rows would contribute different numbers depending on tier — and on whether a lock race was
-lost — and would not match the units `input_basis` counts.
+same rows would contribute different numbers depending on tier, and would not match the units
+`input_basis` counts.
 
 That accounting takes `_probe_bytes_mutex`, never `op_state_mutex`: `execute()` updates it while
 holding a batch lock, and two scheduler paths (the cross-schedule orphan and the broadcast slot
@@ -305,7 +296,7 @@ There is deliberately no task-count correction for in-flight tasks: `consumed` d
 once per task, so the completed fraction of tasks does not map onto the consumed fraction of bytes.
 
 The in-flight skew described above is not the only bias on the fan-in ratio, and `16` does not
-bound the other one. See [the known bias](#known-bias-the-weighting-assumes-output-accrues-evenly-across-build-batches):
+bound the other one. See [why STANDARD and MIXED_JOIN are not estimated](#why-standard-and-mixed_join-are-not-estimated):
 under build or partition skew the pairing weighting pushes the ratio high by roughly `B/16`, in the
 opposite direction to the in-flight effect and not necessarily smaller than it.
 
@@ -315,8 +306,8 @@ opposite direction to the in-flight effect and not necessarily smaller than it.
 |----------|-----------|
 | anchors | `GPU_SCAN`; `GPU_VALUES` (also covers `COLUMN_DATA_SCAN`, `DUMMY_SCAN`, `EMPTY_RESULT`, rewritten to it at plan generation); any finished pipeline |
 | pass-through (recurse) | any single-ingress pipeline — `FILTER`, `PROJECTION`, sorts, aggregates, `CONCAT`, `PARTITION` |
-| fan-in | `HASH_JOIN` (INNER/LEFT/SEMI/ANTI/MARK) |
-| dead ends (`nullopt`) | `STREAMING_SOURCE` (by design); `TABLE_SCAN`; `NESTED_LOOP_JOIN`, delim joins, `CTE`, `HASH_JOIN` RIGHT-family and OUTER (no nominated primary); any unfinished pipeline holding a `STREAMING_LIMIT` |
+| fan-in | `HASH_JOIN` (INNER/LEFT/SEMI/ANTI/MARK) in **BUILD_PROBE mode only** |
+| dead ends (`nullopt`) | `STREAMING_SOURCE` (by design); `TABLE_SCAN`; `NESTED_LOOP_JOIN`, delim joins, `CTE`, `HASH_JOIN` RIGHT-family and OUTER (no nominated primary); any unfinished pipeline holding a `STREAMING_LIMIT`; `HASH_JOIN` in STANDARD or MIXED_JOIN mode |
 
 Because the estimator works at pipeline granularity, single-input operators need no per-operator
 model: a pipeline's ratio is measured end-to-end, so whatever a projection or filter does to byte

--- a/docs/super-sirius/data-size-estimation.md
+++ b/docs/super-sirius/data-size-estimation.md
@@ -284,21 +284,25 @@ It is the innermost lock: nothing waits on a batch lock or `op_state_mutex` whil
 
 - `min_ratio_samples` (4) — single-input. That ratio accrues both terms on task completion and is
   unbiased at any count; the floor only rules out one unrepresentative batch.
-- `min_fan_in_ratio_samples` (16) — fan-in. That ratio divides a completion-accrued numerator by a
-  denominator advancing at task *start*, so it reads low by roughly
-  `in_flight / (samples + in_flight)`. More samples shrink a systematic bias, which is why this
-  floor is far higher — and why it is a **hard gate**: below it there is no estimate even under
-  `assume_unit_ratio`. A unit ratio is a reasonable stand-in for a single-input pipeline
-  (assume pass-through), but a join can multiply or divide its input volume by orders of
-  magnitude, so 1:1 carries no information there.
+- `min_fan_in_ratio_samples` (16) — fan-in. A join can multiply or divide its input volume by
+  orders of magnitude, so a handful of completed tasks is no evidence of its ratio — and this
+  floor is a **hard gate**: below it there is no estimate even under `assume_unit_ratio`, because
+  1:1 carries no information for a join. Zero completed outputs are never estimable, whatever the
+  floor is configured to.
 
-There is deliberately no task-count correction for in-flight tasks: `consumed` does not advance
-once per task, so the completed fraction of tasks does not map onto the consumed fraction of bytes.
+The fan-in ratio is additionally taken only from **bracketed quiescent snapshots**. Probe bytes
+enter `consumed` when a task starts while its output lands at completion, so any task active while
+the terms are read can drive the ratio toward zero — the skew is byte-weighted, so no task-count
+floor bounds it, and a completed-task-fraction correction cannot either (`consumed` does not
+advance once per task). The task counters are therefore read before the terms and re-read after:
+equal and unchanged means no task started or completed at any point in between — unchanged, not
+merely equal, since a task starting *and* completing mid-read would leave them equal while its
+bytes sit in `consumed` with no matching output. Both terms then cover exactly the same tasks.
 
-The in-flight skew described above is not the only bias on the fan-in ratio, and `16` does not
-bound the other one. See [why STANDARD and MIXED_JOIN are not estimated](#why-standard-and-mixed_join-are-not-estimated):
-under build or partition skew the pairing weighting pushes the ratio high by roughly `B/16`, in the
-opposite direction to the in-flight effect and not necessarily smaller than it.
+The in-flight skew was never the fan-in ratio's only bias, and quiescence does not address the
+other one. See [why STANDARD and MIXED_JOIN are not estimated](#why-standard-and-mixed_join-are-not-estimated):
+under build or partition skew the pairing weighting pushes the ratio high by roughly `B/16`, which
+is why those modes are withheld outright.
 
 ## Coverage
 

--- a/docs/super-sirius/data-size-estimation.md
+++ b/docs/super-sirius/data-size-estimation.md
@@ -40,7 +40,7 @@ will this port have received once its producer is done?"*.
 struct data_size_estimate {
   std::size_t bytes;           // projected whole-query total
   bool        exact;           // no learned ratio was applied
-  std::size_t hops;            // producer pipelines traversed
+  std::size_t hops;            // ratios applied; error compounds per hop
   std::size_t ratio_samples;   // tasks backing the weakest measured ratio
   bool        planner_derived; // anchored on planner cardinality
 };

--- a/docs/super-sirius/data-size-estimation.md
+++ b/docs/super-sirius/data-size-estimation.md
@@ -38,11 +38,11 @@ will this port have received once its producer is done?"*.
 
 ```cpp
 struct data_size_estimate {
-  std::size_t bytes;           // projected total
-  bool        exact;           // measured, not projected — anchored on a finished pipeline
-  std::size_t hops;            // pipelines traversed; ratio error compounds per hop
-  std::size_t ratio_samples;   // completed tasks behind the weakest ratio in the chain
-  bool        planner_derived; // the anchor was a planner guess, not a measurement
+  std::size_t bytes;           // projected whole-query total
+  bool        exact;           // no learned ratio was applied
+  std::size_t hops;            // producer pipelines traversed
+  std::size_t ratio_samples;   // tasks backing the weakest measured ratio
+  bool        planner_derived; // anchored on planner cardinality
 };
 ```
 

--- a/docs/super-sirius/data-size-estimation.md
+++ b/docs/super-sirius/data-size-estimation.md
@@ -98,7 +98,7 @@ Tasks that OOM'd record no output and are in neither: they consumed input and pr
 
 | operator | `total_source_input_bytes` | `total_source_output_bytes` |
 |----------|---------------------------|-----------------------------|
-| `GPU_SCAN` | Σ split bytes, once split discovery closes | `max(estimated_cardinality × bytes/row, bytes emitted so far)` |
+| `GPU_SCAN` | Σ split bytes, once split discovery closes and if every split was sized | `max(estimated_cardinality × bytes/row, bytes emitted so far)` |
 | `GPU_VALUES` | exact, known at plan time | — |
 
 Both exist because the quantities live in different coordinate systems.
@@ -119,6 +119,14 @@ has no such restriction: its ratio is the pipeline's own, end to end.
 For `GPU_SCAN` the total is tallied in `split_connector::push_split` — the choke point every split
 passes through — and `is_discovery_complete()` reports when the tally is final. That is distinct
 from the pre-existing `is_closed()`, which means *closed and drained*.
+
+`scan_info::estimated_bytes()` returns 0 for a split with no a-priori estimate, and that zero is a
+gap rather than a measurement. Such a split adds nothing to the tally, and `pipeline_memory_history`
+also excludes zero-basis tasks from the ratio — so its bytes are missing from *both* terms, and the
+projection silently omits whatever it emits instead of approximating it. When no split carries an
+estimate the tally is exactly 0, which under `assume_unit_ratio` would scale to a confident total of
+zero. So `push_split` latches `has_unsized_splits()` and the scan returns `nullopt` when it is set:
+a partial sum must not be presented as a complete total.
 
 `total_source_output_bytes` is the one planner-derived number anywhere in the chain: its row count
 comes from DuckDB's `estimated_cardinality`, not from measurement. It is consulted only while split

--- a/src/include/op/scan/sirius_gpu_scan_operator.hpp
+++ b/src/include/op/scan/sirius_gpu_scan_operator.hpp
@@ -141,6 +141,10 @@ class sirius_gpu_scan_operator : public sirius_physical_operator {
   /// closes; there is deliberately no partial-discovery extrapolation, because the split
   /// provider claims every metadata unit up front and a claim-based progress fraction would
   /// saturate while the byte tally is still near zero.
+  ///
+  /// Also nullopt if any split reported no a-priori estimate. Such a split adds 0 to the tally
+  /// and is excluded from the ratio, so its output is absent from both sides rather than
+  /// approximated — the sum would be a partial total presented as a complete one.
   [[nodiscard]] std::optional<std::size_t> total_source_input_bytes() const override;
 
   /// `pipeline::project_source_output_bytes` over the per-batch counters below: the planner's

--- a/src/include/op/scan/sirius_gpu_scan_operator.hpp
+++ b/src/include/op/scan/sirius_gpu_scan_operator.hpp
@@ -135,22 +135,13 @@ class sirius_gpu_scan_operator : public sirius_physical_operator {
   [[nodiscard]] static std::size_t resident_carrier_conversion_peak_memory_estimate(
     const op::input_stats& stats) noexcept;
 
-  /// Σ `scan_info::estimated_bytes()` over every split pushed into this operator's connector —
-  /// the same quantity `pipeline_memory_history` records as a scan task's `input_basis`, so the
-  /// estimator may scale it by the pipeline's learned ratio. nullopt until split discovery
-  /// closes; there is deliberately no partial-discovery extrapolation, because the split
-  /// provider claims every metadata unit up front and a claim-based progress fraction would
-  /// saturate while the byte tally is still near zero.
-  ///
-  /// Also nullopt if any split reported no a-priori estimate. Such a split adds 0 to the tally
-  /// and is excluded from the ratio, so its output is absent from both sides rather than
-  /// approximated — the sum would be a partial total presented as a complete one.
+  /// Whole-query sum of `scan_info::estimated_bytes()` for all pushed splits, in scan-task
+  /// `input_basis` units.
+  /// Returns nullopt until discovery closes or if any split lacks an a-priori estimate.
   [[nodiscard]] std::optional<std::size_t> total_source_input_bytes() const override;
 
-  /// `pipeline::project_source_output_bytes` over the per-batch counters below: the planner's
-  /// `estimated_cardinality` scaled by measured bytes/row, floored at the bytes already emitted
-  /// (see that function for why the floor is load-bearing). Both factors are post-filter, so the
-  /// estimator uses this unscaled. nullopt until a batch with rows has been emitted.
+  /// @ref pipeline::project_source_output_bytes: planner cardinality times measured post-filter
+  /// bytes/row, floored at emitted bytes. Returns nullopt before measurement; used unscaled.
   [[nodiscard]] std::optional<std::size_t> total_source_output_bytes() const override;
 
   /**
@@ -199,10 +190,7 @@ class sirius_gpu_scan_operator : public sirius_physical_operator {
   duckdb::SiriusContext* _compressed_materialization_observer;
   /// Native cuDF carrier for each logical output column, in output order.
   std::vector<cudf::data_type> _native_physical_types;
-  /// Running post-filter output totals, accumulated per batch in execute(). Only meaningful as
-  /// a pair — their quotient is the bytes-per-row factor — so they are published together under
-  /// one mutex rather than as two atomics, which would let a reader divide a row count by a byte
-  /// total that excludes those rows.
+  /// Post-filter totals, locked together to provide a consistent bytes/row sample.
   mutable std::mutex _emitted_mutex;
   std::size_t _emitted_bytes{0};
   std::size_t _emitted_rows{0};

--- a/src/include/op/scan/sirius_gpu_scan_operator.hpp
+++ b/src/include/op/scan/sirius_gpu_scan_operator.hpp
@@ -26,7 +26,9 @@
 
 // standard library
 #include <atomic>
+#include <cstddef>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <vector>
 
@@ -133,6 +135,20 @@ class sirius_gpu_scan_operator : public sirius_physical_operator {
   [[nodiscard]] static std::size_t resident_carrier_conversion_peak_memory_estimate(
     const op::input_stats& stats) noexcept;
 
+  /// Σ `scan_info::estimated_bytes()` over every split pushed into this operator's connector —
+  /// the same quantity `pipeline_memory_history` records as a scan task's `input_basis`, so the
+  /// estimator may scale it by the pipeline's learned ratio. nullopt until split discovery
+  /// closes; there is deliberately no partial-discovery extrapolation, because the split
+  /// provider claims every metadata unit up front and a claim-based progress fraction would
+  /// saturate while the byte tally is still near zero.
+  [[nodiscard]] std::optional<std::size_t> total_source_input_bytes() const override;
+
+  /// `pipeline::project_source_output_bytes` over the per-batch counters below: the planner's
+  /// `estimated_cardinality` scaled by measured bytes/row, floored at the bytes already emitted
+  /// (see that function for why the floor is load-bearing). Both factors are post-filter, so the
+  /// estimator uses this unscaled. nullopt until a batch with rows has been emitted.
+  [[nodiscard]] std::optional<std::size_t> total_source_output_bytes() const override;
+
   /**
    * @brief Returns the complete carrier schema used to normalize scan output
    *
@@ -179,6 +195,13 @@ class sirius_gpu_scan_operator : public sirius_physical_operator {
   duckdb::SiriusContext* _compressed_materialization_observer;
   /// Native cuDF carrier for each logical output column, in output order.
   std::vector<cudf::data_type> _native_physical_types;
+  /// Running post-filter output totals, accumulated per batch in execute(). Only meaningful as
+  /// a pair — their quotient is the bytes-per-row factor — so they are published together under
+  /// one mutex rather than as two atomics, which would let a reader divide a row count by a byte
+  /// total that excludes those rows.
+  mutable std::mutex _emitted_mutex;
+  std::size_t _emitted_bytes{0};
+  std::size_t _emitted_rows{0};
 };
 
 }  // namespace sirius::op::scan

--- a/src/include/op/sirius_physical_gpu_values.hpp
+++ b/src/include/op/sirius_physical_gpu_values.hpp
@@ -127,14 +127,8 @@ class sirius_physical_gpu_values : public sirius_physical_operator {
   [[nodiscard]] std::size_t no_history_peak_memory_estimate(
     const input_stats& stats) const override;
 
-  /**
-   * @brief Exact total input basis: this source is single-shot, so its one task input is the
-   *        whole thing, known from plan time.
-   *
-   * The anchor is immediate; an estimate resting on it is not. The leaf case scales it by the
-   * pipeline ratio, which single-shot caps at one sample — below the default min_ratio_samples,
-   * so an estimate here needs assume_unit_ratio.
-   */
+  /// Exact whole-query input basis, known at plan time. This single-shot source yields at most
+  /// one ratio sample, so default estimation requires `assume_unit_ratio`.
   [[nodiscard]] std::optional<std::size_t> total_source_input_bytes() const override
   {
     return estimated_source_bytes();

--- a/src/include/op/sirius_physical_gpu_values.hpp
+++ b/src/include/op/sirius_physical_gpu_values.hpp
@@ -128,6 +128,19 @@ class sirius_physical_gpu_values : public sirius_physical_operator {
     const input_stats& stats) const override;
 
   /**
+   * @brief Exact total input basis: this source is single-shot, so its one task input is the
+   *        whole thing, known from plan time.
+   *
+   * The anchor is immediate; an estimate resting on it is not. The leaf case scales it by the
+   * pipeline ratio, which single-shot caps at one sample — below the default min_ratio_samples,
+   * so an estimate here needs assume_unit_ratio.
+   */
+  [[nodiscard]] std::optional<std::size_t> total_source_input_bytes() const override
+  {
+    return estimated_source_bytes();
+  }
+
+  /**
    * @brief Viability gate: throw for output types the host→device conversion
    *        cannot represent faithfully, triggering DuckDB CPU fallback.
    *

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -420,7 +420,8 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
 
   bool is_all_inequality_join = true;
 
-  HASH_JOIN_MODE _join_mode            = HASH_JOIN_MODE::STANDARD;
+  // Atomic: the size estimator polls probe_bytes_are_unweighted() without op_state_mutex.
+  std::atomic<HASH_JOIN_MODE> _join_mode{HASH_JOIN_MODE::STANDARD};
   uint64_t _max_build_hash_table_bytes = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES;
   // Maximum build-side bytes eligible for a broadcast join (see get_partition_strategy). Set from
   // operator_params at construction.

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -194,12 +194,8 @@ struct cross_schedule_pair {
 [[nodiscard]] std::vector<cross_schedule_discard> collect_cross_schedule_discards(
   std::vector<partition_cross_schedule>& cross, bool probe_finished, bool build_finished);
 
-/// Sum over probe batches of `bytes x (pairings done / build batches)` — the size estimator's
-/// denominator. Output accrues once per pairing, so charging a batch whole at its first pairing
-/// would leave the ratio low by the build batch count until the last one lands; weighting puts
-/// both terms at the same fraction of the way through. A partition with no build batch yet
-/// contributes nothing, having nothing to be a fraction of; those reach the total whole, once,
-/// via the orphan path.
+/// Size-estimator denominator: sum `probe bytes * completed pairings / build batches`.
+/// Partitions without build batches contribute zero; orphan probe batches are counted separately.
 [[nodiscard]] std::size_t pairing_weighted_probe_bytes(
   std::vector<partition_cross_schedule> const& cross,
   std::unordered_map<uint64_t, std::size_t> const& probe_bytes);
@@ -382,54 +378,34 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
 
-  /// The probe side, but only where it is the side still streaming — the estimator extrapolates
-  /// along the nominated port, so a port already at its final volume carries no prediction.
-  /// INNER/LEFT/SEMI/ANTI/MARK fold the build whole and stream the probe, which is that axis.
-  /// RIGHT-family inverts it (refresh_cross_schedule pins the *probe* whole and streams the build)
-  /// and OUTER pins both, so they nominate nothing: with the probe closed, `consumed` is final
-  /// from the first pairing while output keeps climbing, and the ratio would collapse to "bytes
-  /// emitted so far" — blind to the unpaired build, worst when the build dwarfs the probe.
-  /// Following the build side would be predictive for RIGHT-family but needs build-byte accounting
-  /// this operator does not keep. See sirius_physical_operator::primary_input_port.
+  /// Nominates the streaming probe port for INNER/LEFT/SEMI/ANTI/MARK joins. Returns nullopt for
+  /// RIGHT-family and OUTER joins, which would require build-byte accounting. See
+  /// sirius_physical_operator::primary_input_port.
   [[nodiscard]] std::optional<std::string_view> primary_input_port() const override
   {
     if (is_right_family() || join_type == duckdb::JoinType::OUTER) { return std::nullopt; }
     return std::string_view{"default"};
   }
 
-  /// Probe bytes consumed so far: batches taken whole, plus the cross schedule's pairing-weighted
-  /// share (see @ref pairing_weighted_probe_bytes). Withheld until the build side is whole, since
-  /// the weights divide by a build batch count that is still growing before then.
-  /// Out of line: the predicate needs sirius_pipeline complete.
+  /// Whole-counted plus @ref pairing_weighted_probe_bytes probe bytes. Returns nullopt until the
+  /// build side is complete. Defined out of line because that check needs `sirius_pipeline`.
   [[nodiscard]] std::optional<std::size_t> consumed_primary_input_bytes() const override;
 
  protected:
-  /// Record @p batch's size in @ref _probe_batch_bytes for the cross schedule to weight, once per
-  /// distinct batch. Idempotent, so call it at every sighting rather than identifying the first:
-  /// the size read is non-blocking and a later sighting retries a lost one. Build bytes are never
-  /// recorded; null batches ignored. Only for sites that see a batch repeatedly — where it is seen
-  /// once, a lost read is unrecoverable, so use note_probe_bytes_counted instead.
+  /// Idempotently record a probe batch for pairing weights. The non-blocking size read may be
+  /// retried at later sightings; use note_probe_bytes_counted for single-sighting paths.
   void note_probe_bytes(const std::shared_ptr<cucascade::data_batch>& batch);
 
-  /// Recompute @ref _weighted_probe_bytes from the current schedule. Call after a pairing is
-  /// claimed, never before: a stale total lets the task's output reach the numerator while its
-  /// weight is still missing from the denominator, inflating the ratio. No-op until @p
-  /// build_finished — the same predicate consumed_primary_input_bytes() gates on, so nothing can
-  /// read it before then and the walk stays off the streaming phase. Caller holds op_state_mutex.
+  /// Publish current pairing weights after a pairing is claimed, preventing output from preceding
+  /// its denominator. No-op until @p build_finished. Caller holds `op_state_mutex`.
   void publish_weighted_probe_bytes(bool build_finished);
 
-  /// Add @p bytes to @ref _whole_probe_bytes, once per distinct batch — for a batch consumed
-  /// exactly once, with no pairing fraction to weight. The caller has already read the size off its
-  /// own accessor, so this takes no batch lock and cannot lose. Takes @ref _probe_bytes_mutex
-  /// itself, so it is safe to call while holding a batch lock.
+  /// Count @p bytes once for an unweighted probe batch. Takes @ref _probe_bytes_mutex but no batch
+  /// lock, so callers may hold a batch lock.
   void note_probe_bytes_counted(uint64_t batch_id, std::size_t bytes);
 
-  /// Record @p bytes as @p batch_id's size for the cross schedule to weight, once per batch, and
-  /// carry it in @ref _unpublished_probe_bytes until a publish folds it into the weights. The
-  /// single place that writes @ref _probe_batch_bytes, so the "paired or counted whole, never
-  /// both" split holds by construction: a batch already counted whole is skipped, which is what
-  /// keeps an orphan task — whose probe survivor the scheduler has already counted, and whose
-  /// synthesized empty opposite is not a probe batch at all — from disturbing the totals.
+  /// Record a weighted probe batch once and carry its full size in
+  /// @ref _unpublished_probe_bytes until publication. Skips batches already counted whole.
   void record_probe_batch_bytes(uint64_t batch_id, std::size_t bytes);
 
   // double get_progress(duckdb::ClientContext &context, duckdb::GlobalSourceState &gstate) const
@@ -461,38 +437,23 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   // Guarded by op_state_mutex.
   bool _build_not_whole_reported = false;
 
-  // Probe bytes for batches consumed exactly once, with no pairing multiplicity to discount:
-  // BUILD_PROBE pops and cross-schedule orphans. Relaxed ordering: the derived value is an
-  // estimate and readers tolerate a slightly stale count.
+  // Whole-counted BUILD_PROBE and orphan bytes. Relaxed reads may be slightly stale.
   std::atomic<std::size_t> _whole_probe_bytes{0};
 
-  // The STANDARD / MIXED_JOIN cross schedule's share, republished by refresh_cross_schedule
-  // because a batch's weight rises with every pairing. See pairing_weighted_probe_bytes.
+  // Published STANDARD/MIXED_JOIN share; updated as pairing weights increase.
   std::atomic<std::size_t> _weighted_probe_bytes{0};
 
-  // Dedup for _whole_probe_bytes, so repeated sightings of a batch count once. Guarded by
-  // _probe_bytes_mutex below, not op_state_mutex: execute() updates this while holding a batch
-  // lock, and taking op_state_mutex there would invert the order (see that member).
+  // Deduplicates _whole_probe_bytes. Guarded by _probe_bytes_mutex.
   std::unordered_set<uint64_t> _counted_probe_batch_ids;
 
-  // Sizes recorded since the last publish. execute() cannot republish (that needs _cross under
-  // op_state_mutex, which it must not take), and scheduler polling is event-driven, so it may
-  // never run again — a batch recorded by the drain tail's last task would otherwise sit out of
-  // the denominator for good. Adding its FULL size here instead of its pairing fraction
-  // deliberately over-counts the denominator, which biases the ratio low: the direction the whole
-  // design already errs in. publish_weighted_probe_bytes folds these into the weights and clears
-  // it.
+  // Full sizes awaiting publication. execute() cannot take op_state_mutex to recompute weights,
+  // and no later scheduler poll is guaranteed; full-size carry biases the ratio low, not high.
   std::atomic<std::size_t> _unpublished_probe_bytes{0};
 
-  // Size of every probe batch the cross schedule has seen, keyed by batch id — the weights are
-  // applied to these. Disjoint from _counted_probe_batch_ids: a batch is either paired (here) or
-  // consumed whole (there), never both.
+  // Probe sizes for pairing weights; disjoint from _counted_probe_batch_ids.
   //
-  // Deliberately NOT op_state_mutex: execute() records here while holding a batch's shared lock,
-  // and the scheduler blocks on a batch lock while holding op_state_mutex (the orphan path), so
-  // reusing it would invert the order against a queued writer (spill readback takes a blocking
-  // exclusive lock; the downgrade's try_to_mutable does not). Innermost lock: op_state_mutex ->
-  // _probe_bytes_mutex, and nothing waits on a batch lock while holding it.
+  // Lock order: op_state_mutex -> _probe_bytes_mutex. execute() may take this mutex while holding
+  // a batch lock; nothing may wait on a batch lock or op_state_mutex while holding it.
   std::mutex _probe_bytes_mutex;
   std::unordered_map<uint64_t, std::size_t> _probe_batch_bytes;
 

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -194,8 +194,10 @@ struct cross_schedule_pair {
 [[nodiscard]] std::vector<cross_schedule_discard> collect_cross_schedule_discards(
   std::vector<partition_cross_schedule>& cross, bool probe_finished, bool build_finished);
 
-/// Size-estimator denominator: sum `probe bytes * completed pairings / build batches`.
-/// Partitions without build batches contribute zero; orphan probe batches are counted separately.
+/// Reference arithmetic for a pairing-weighted probe-byte denominator: sum
+/// `probe bytes * completed pairings / build batches`. Unused — the STANDARD/MIXED estimate is
+/// withheld — but kept with its tests for the eventual fix. See
+/// data-size-estimation.md#why-standard-and-mixed_join-are-not-estimated.
 [[nodiscard]] std::size_t pairing_weighted_probe_bytes(
   std::vector<partition_cross_schedule> const& cross,
   std::unordered_map<uint64_t, std::size_t> const& probe_bytes);
@@ -387,26 +389,23 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
     return std::string_view{"default"};
   }
 
-  /// Whole-counted plus @ref pairing_weighted_probe_bytes probe bytes. Returns nullopt until the
-  /// build side is complete. Defined out of line because that check needs `sirius_pipeline`.
+  /// True only in BUILD_PROBE, where each probe batch is popped exactly once and `consumed` is
+  /// a plain running total. A cross schedule would need pairing weights, which read high under
+  /// skew, so the estimate is withheld there. See
+  /// data-size-estimation.md#why-standard-and-mixed_join-are-not-estimated.
+  [[nodiscard]] bool probe_bytes_are_unweighted() const
+  {
+    return _join_mode == HASH_JOIN_MODE::BUILD_PROBE;
+  }
+
+  /// Whole-counted probe bytes, or nullopt until the build side is complete — and always nullopt
+  /// unless @ref probe_bytes_are_unweighted. Out of line because the check needs `sirius_pipeline`.
   [[nodiscard]] std::optional<std::size_t> consumed_primary_input_bytes() const override;
 
  protected:
-  /// Idempotently record a probe batch for pairing weights. The non-blocking size read may be
-  /// retried at later sightings; use note_probe_bytes_counted for single-sighting paths.
-  void note_probe_bytes(const std::shared_ptr<cucascade::data_batch>& batch);
-
-  /// Publish current pairing weights after a pairing is claimed, preventing output from preceding
-  /// its denominator. No-op until @p build_finished. Caller holds `op_state_mutex`.
-  void publish_weighted_probe_bytes(bool build_finished);
-
-  /// Count @p bytes once for an unweighted probe batch. Takes @ref _probe_bytes_mutex but no batch
+  /// Count @p bytes once for a popped probe batch. Takes @ref _probe_bytes_mutex but no batch
   /// lock, so callers may hold a batch lock.
   void note_probe_bytes_counted(uint64_t batch_id, std::size_t bytes);
-
-  /// Record a weighted probe batch once and carry its full size in
-  /// @ref _unpublished_probe_bytes until publication. Skips batches already counted whole.
-  void record_probe_batch_bytes(uint64_t batch_id, std::size_t bytes);
 
   // double get_progress(duckdb::ClientContext &context, duckdb::GlobalSourceState &gstate) const
   // override;
@@ -440,22 +439,12 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   // Whole-counted BUILD_PROBE and orphan bytes. Relaxed reads may be slightly stale.
   std::atomic<std::size_t> _whole_probe_bytes{0};
 
-  // Published STANDARD/MIXED_JOIN share; updated as pairing weights increase.
-  std::atomic<std::size_t> _weighted_probe_bytes{0};
-
   // Deduplicates _whole_probe_bytes. Guarded by _probe_bytes_mutex.
   std::unordered_set<uint64_t> _counted_probe_batch_ids;
 
-  // Full sizes awaiting publication. execute() cannot take op_state_mutex to recompute weights,
-  // and no later scheduler poll is guaranteed; full-size carry biases the ratio low, not high.
-  std::atomic<std::size_t> _unpublished_probe_bytes{0};
-
-  // Probe sizes for pairing weights; disjoint from _counted_probe_batch_ids.
-  //
   // Lock order: op_state_mutex -> _probe_bytes_mutex. execute() may take this mutex while holding
   // a batch lock; nothing may wait on a batch lock or op_state_mutex while holding it.
   std::mutex _probe_bytes_mutex;
-  std::unordered_map<uint64_t, std::size_t> _probe_batch_bytes;
 
   // Whether any build-side join key column contains a NULL. Used exclusively for MARK join
   // three-valued logic. Sentinel -1 = unset, 0 = false, 1 = true. Join-wide (not per-partition)

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -42,6 +42,7 @@
 #include <memory>
 #include <optional>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -192,6 +193,16 @@ struct cross_schedule_pair {
 /// >= 1 batch), and symmetrically for build batches. Idempotent.
 [[nodiscard]] std::vector<cross_schedule_discard> collect_cross_schedule_discards(
   std::vector<partition_cross_schedule>& cross, bool probe_finished, bool build_finished);
+
+/// Sum over probe batches of `bytes x (pairings done / build batches)` — the size estimator's
+/// denominator. Output accrues once per pairing, so charging a batch whole at its first pairing
+/// would leave the ratio low by the build batch count until the last one lands; weighting puts
+/// both terms at the same fraction of the way through. A partition with no build batch yet
+/// contributes nothing, having nothing to be a fraction of; those reach the total whole, once,
+/// via the orphan path.
+[[nodiscard]] std::size_t pairing_weighted_probe_bytes(
+  std::vector<partition_cross_schedule> const& cross,
+  std::unordered_map<uint64_t, std::size_t> const& probe_bytes);
 
 /// Find and claim the next unscheduled (probe,build) pair across partitions, marking it scheduled
 /// and bumping the paired counts. If none is schedulable now, reports whether to wait on the build
@@ -371,7 +382,56 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
 
+  /// The probe side, but only where it is the side still streaming — the estimator extrapolates
+  /// along the nominated port, so a port already at its final volume carries no prediction.
+  /// INNER/LEFT/SEMI/ANTI/MARK fold the build whole and stream the probe, which is that axis.
+  /// RIGHT-family inverts it (refresh_cross_schedule pins the *probe* whole and streams the build)
+  /// and OUTER pins both, so they nominate nothing: with the probe closed, `consumed` is final
+  /// from the first pairing while output keeps climbing, and the ratio would collapse to "bytes
+  /// emitted so far" — blind to the unpaired build, worst when the build dwarfs the probe.
+  /// Following the build side would be predictive for RIGHT-family but needs build-byte accounting
+  /// this operator does not keep. See sirius_physical_operator::primary_input_port.
+  [[nodiscard]] std::optional<std::string_view> primary_input_port() const override
+  {
+    if (is_right_family() || join_type == duckdb::JoinType::OUTER) { return std::nullopt; }
+    return std::string_view{"default"};
+  }
+
+  /// Probe bytes consumed so far: batches taken whole, plus the cross schedule's pairing-weighted
+  /// share (see @ref pairing_weighted_probe_bytes). Withheld until the build side is whole, since
+  /// the weights divide by a build batch count that is still growing before then.
+  /// Out of line: the predicate needs sirius_pipeline complete.
+  [[nodiscard]] std::optional<std::size_t> consumed_primary_input_bytes() const override;
+
  protected:
+  /// Record @p batch's size in @ref _probe_batch_bytes for the cross schedule to weight, once per
+  /// distinct batch. Idempotent, so call it at every sighting rather than identifying the first:
+  /// the size read is non-blocking and a later sighting retries a lost one. Build bytes are never
+  /// recorded; null batches ignored. Only for sites that see a batch repeatedly — where it is seen
+  /// once, a lost read is unrecoverable, so use note_probe_bytes_counted instead.
+  void note_probe_bytes(const std::shared_ptr<cucascade::data_batch>& batch);
+
+  /// Recompute @ref _weighted_probe_bytes from the current schedule. Call after a pairing is
+  /// claimed, never before: a stale total lets the task's output reach the numerator while its
+  /// weight is still missing from the denominator, inflating the ratio. No-op until @p
+  /// build_finished — the same predicate consumed_primary_input_bytes() gates on, so nothing can
+  /// read it before then and the walk stays off the streaming phase. Caller holds op_state_mutex.
+  void publish_weighted_probe_bytes(bool build_finished);
+
+  /// Add @p bytes to @ref _whole_probe_bytes, once per distinct batch — for a batch consumed
+  /// exactly once, with no pairing fraction to weight. The caller has already read the size off its
+  /// own accessor, so this takes no batch lock and cannot lose. Takes @ref _probe_bytes_mutex
+  /// itself, so it is safe to call while holding a batch lock.
+  void note_probe_bytes_counted(uint64_t batch_id, std::size_t bytes);
+
+  /// Record @p bytes as @p batch_id's size for the cross schedule to weight, once per batch, and
+  /// carry it in @ref _unpublished_probe_bytes until a publish folds it into the weights. The
+  /// single place that writes @ref _probe_batch_bytes, so the "paired or counted whole, never
+  /// both" split holds by construction: a batch already counted whole is skipped, which is what
+  /// keeps an orphan task — whose probe survivor the scheduler has already counted, and whose
+  /// synthesized empty opposite is not a probe batch at all — from disturbing the totals.
+  void record_probe_batch_bytes(uint64_t batch_id, std::size_t bytes);
+
   // double get_progress(duckdb::ClientContext &context, duckdb::GlobalSourceState &gstate) const
   // override;
 
@@ -400,6 +460,41 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
 
   // Guarded by op_state_mutex.
   bool _build_not_whole_reported = false;
+
+  // Probe bytes for batches consumed exactly once, with no pairing multiplicity to discount:
+  // BUILD_PROBE pops and cross-schedule orphans. Relaxed ordering: the derived value is an
+  // estimate and readers tolerate a slightly stale count.
+  std::atomic<std::size_t> _whole_probe_bytes{0};
+
+  // The STANDARD / MIXED_JOIN cross schedule's share, republished by refresh_cross_schedule
+  // because a batch's weight rises with every pairing. See pairing_weighted_probe_bytes.
+  std::atomic<std::size_t> _weighted_probe_bytes{0};
+
+  // Dedup for _whole_probe_bytes, so repeated sightings of a batch count once. Guarded by
+  // _probe_bytes_mutex below, not op_state_mutex: execute() updates this while holding a batch
+  // lock, and taking op_state_mutex there would invert the order (see that member).
+  std::unordered_set<uint64_t> _counted_probe_batch_ids;
+
+  // Sizes recorded since the last publish. execute() cannot republish (that needs _cross under
+  // op_state_mutex, which it must not take), and scheduler polling is event-driven, so it may
+  // never run again — a batch recorded by the drain tail's last task would otherwise sit out of
+  // the denominator for good. Adding its FULL size here instead of its pairing fraction
+  // deliberately over-counts the denominator, which biases the ratio low: the direction the whole
+  // design already errs in. publish_weighted_probe_bytes folds these into the weights and clears
+  // it.
+  std::atomic<std::size_t> _unpublished_probe_bytes{0};
+
+  // Size of every probe batch the cross schedule has seen, keyed by batch id — the weights are
+  // applied to these. Disjoint from _counted_probe_batch_ids: a batch is either paired (here) or
+  // consumed whole (there), never both.
+  //
+  // Deliberately NOT op_state_mutex: execute() records here while holding a batch's shared lock,
+  // and the scheduler blocks on a batch lock while holding op_state_mutex (the orphan path), so
+  // reusing it would invert the order against a queued writer (spill readback takes a blocking
+  // exclusive lock; the downgrade's try_to_mutable does not). Innermost lock: op_state_mutex ->
+  // _probe_bytes_mutex, and nothing waits on a batch lock while holding it.
+  std::mutex _probe_bytes_mutex;
+  std::unordered_map<uint64_t, std::size_t> _probe_batch_bytes;
 
   // Whether any build-side join key column contains a NULL. Used exclusively for MARK join
   // three-valued logic. Sentinel -1 = unset, 0 = false, 1 = true. Join-wide (not per-partition)

--- a/src/include/op/sirius_physical_limit.hpp
+++ b/src/include/op/sirius_physical_limit.hpp
@@ -49,6 +49,8 @@ class sirius_physical_streaming_limit : public sirius_physical_operator {
     return _limit_exhausted.load(std::memory_order_acquire);
   }
 
+  [[nodiscard]] bool caps_pipeline_output() const override { return true; }
+
  private:
   // Shared atomic state for coordinating limit/offset across concurrent tasks.
   // Each task atomically claims rows to skip (offset) or produce (limit).

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -683,6 +683,9 @@ class sirius_physical_operator {
   port* get_port(std::string_view port_id);
   //! Get all ports from the operator
   std::vector<std::string_view> get_port_ids();
+  //! Ports in ownership order. Allocation-free, and reaches each port without the per-name
+  //! map lookup get_port_ids() implies.
+  [[nodiscard]] const std::list<std::unique_ptr<port>>& get_ports() const { return _ports_list; }
   //! Check if the source pipeline is finished
   bool is_source_pipeline_finished();
   //! Returns true if any FULL-barrier port has src_pipeline == src

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -546,45 +546,29 @@ class sirius_physical_operator {
     return sirius::OrderPreservationType::INSERTION_ORDER;
   }
 
-  // Hooks for the data size estimator (`pipeline/data_size_estimator.hpp`). All four default to
-  // nullopt, meaning "this operator cannot answer", which makes the estimator report no estimate
-  // — the correct outcome for STREAMING_SOURCE, CTE and delim-join wiring. See
+  // Data-size estimator hooks. nullopt means unavailable; see
   // docs/super-sirius/data-size-estimation.md.
 
-  /// Total bytes this leaf source will feed its pipeline over the whole query, in the same units
-  /// as `pipeline_memory_history::input_basis`, so the estimator may scale it by the pipeline's
-  /// learned input->output ratio.
+  /// Whole-query leaf input in `pipeline_memory_history::input_basis` units.
   [[nodiscard]] virtual std::optional<std::size_t> total_source_input_bytes() const
   {
     return std::nullopt;
   }
 
-  /// Total bytes this leaf source will *emit*, consulted only when @ref total_source_input_bytes
-  /// is nullopt. Already an output quantity, so the estimator does NOT apply the pipeline ratio:
-  /// that ratio's denominator is pre-filter, and scaling a post-filter figure by it would count
-  /// filter selectivity twice.
-  ///
-  /// An override projecting from a planner estimate must floor its answer at whatever it has
-  /// already emitted: this is a *total*, so a value below an observed partial is provably wrong.
-  /// Results built on this hook are always marked `planner_derived`.
+  /// Whole-query leaf output, used unscaled only when @ref total_source_input_bytes is nullopt.
+  /// Planner-based overrides must floor totals at emitted bytes; results are `planner_derived`.
   [[nodiscard]] virtual std::optional<std::size_t> total_source_output_bytes() const
   {
     return std::nullopt;
   }
 
-  /// For a fan-in operator, the port carrying the volume-driving input — a hash join nominates
-  /// its probe port, since the build side is consumed once into a hash table. Tells the
-  /// estimator which upstream to follow. Must be paired with @ref consumed_primary_input_bytes.
+  /// Fan-in port that drives output volume. Must pair with @ref consumed_primary_input_bytes.
   [[nodiscard]] virtual std::optional<std::string_view> primary_input_port() const
   {
     return std::nullopt;
   }
 
-  /// Bytes *processed* from @ref primary_input_port, counted once per distinct batch. Both
-  /// halves are load-bearing: count on first entry into a task, not on arrival in the port, or
-  /// the ratio reads far too low while input is still streaming; and once per batch, because a
-  /// STANDARD join re-pairs each probe batch against every build batch, which is exactly why
-  /// `input_basis` cannot serve here (its sum is a cross product, not an input volume).
+  /// Bytes processed from @ref primary_input_port, counted at task entry once per distinct batch.
   [[nodiscard]] virtual std::optional<std::size_t> consumed_primary_input_bytes() const
   {
     return std::nullopt;
@@ -692,13 +676,10 @@ class sirius_physical_operator {
   void push_data_batch(std::string_view port_id, std::shared_ptr<::cucascade::data_batch> batch);
   //! Add a port to the operator
   void add_port(std::string_view port_id, std::unique_ptr<port> p);
-  //! Get a port from the operator
-  //! Look up a port, or nullptr when this operator has no port by that name. Prefer this over
-  //! @ref get_port wherever a missing port is an ordinary outcome rather than a bug — get_port
-  //! throws, and a throw escaping a scheduling path (get_next_task_hint) is not recoverable.
+  //! Look up a port, or nullptr if absent. Use @ref get_port when absence is an error.
   [[nodiscard]] port* try_get_port(std::string_view port_id);
   [[nodiscard]] const port* try_get_port(std::string_view port_id) const;
-  //! As @ref try_get_port, but throws when the name is unknown.
+  //! Look up a port; throws if absent.
   port* get_port(std::string_view port_id);
   //! Get all ports from the operator
   std::vector<std::string_view> get_port_ids();
@@ -727,10 +708,8 @@ class sirius_physical_operator {
   /// \brief check if this operator has exhausted its limit, allowing the pipeline to finish early
   virtual bool is_limit_exhausted() const { return false; }
 
-  /// \brief whether this operator caps its pipeline's output independently of how much input
-  /// arrives — a row limit. Unlike @ref is_limit_exhausted this is true from the start, since the
-  /// cap bounds the eventual total whether or not it has bound yet. The data size estimator
-  /// refuses to extrapolate a ratio through such a pipeline.
+  /// \brief Whether this operator caps pipeline output regardless of input volume.
+  /// True before the cap binds; the data-size estimator will not extrapolate through it.
   [[nodiscard]] virtual bool caps_pipeline_output() const { return false; }
 
   //! Get the input batch

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -546,6 +546,50 @@ class sirius_physical_operator {
     return sirius::OrderPreservationType::INSERTION_ORDER;
   }
 
+  // Hooks for the data size estimator (`pipeline/data_size_estimator.hpp`). All four default to
+  // nullopt, meaning "this operator cannot answer", which makes the estimator report no estimate
+  // — the correct outcome for STREAMING_SOURCE, CTE and delim-join wiring. See
+  // docs/super-sirius/data-size-estimation.md.
+
+  /// Total bytes this leaf source will feed its pipeline over the whole query, in the same units
+  /// as `pipeline_memory_history::input_basis`, so the estimator may scale it by the pipeline's
+  /// learned input->output ratio.
+  [[nodiscard]] virtual std::optional<std::size_t> total_source_input_bytes() const
+  {
+    return std::nullopt;
+  }
+
+  /// Total bytes this leaf source will *emit*, consulted only when @ref total_source_input_bytes
+  /// is nullopt. Already an output quantity, so the estimator does NOT apply the pipeline ratio:
+  /// that ratio's denominator is pre-filter, and scaling a post-filter figure by it would count
+  /// filter selectivity twice.
+  ///
+  /// An override projecting from a planner estimate must floor its answer at whatever it has
+  /// already emitted: this is a *total*, so a value below an observed partial is provably wrong.
+  /// Results built on this hook are always marked `planner_derived`.
+  [[nodiscard]] virtual std::optional<std::size_t> total_source_output_bytes() const
+  {
+    return std::nullopt;
+  }
+
+  /// For a fan-in operator, the port carrying the volume-driving input — a hash join nominates
+  /// its probe port, since the build side is consumed once into a hash table. Tells the
+  /// estimator which upstream to follow. Must be paired with @ref consumed_primary_input_bytes.
+  [[nodiscard]] virtual std::optional<std::string_view> primary_input_port() const
+  {
+    return std::nullopt;
+  }
+
+  /// Bytes *processed* from @ref primary_input_port, counted once per distinct batch. Both
+  /// halves are load-bearing: count on first entry into a task, not on arrival in the port, or
+  /// the ratio reads far too low while input is still streaming; and once per batch, because a
+  /// STANDARD join re-pairs each probe batch against every build batch, which is exactly why
+  /// `input_basis` cannot serve here (its sum is a cross product, not an input volume).
+  [[nodiscard]] virtual std::optional<std::size_t> consumed_primary_input_bytes() const
+  {
+    return std::nullopt;
+  }
+
  public:
   // Sink interface
   virtual void sink(const operator_data& input_data, rmm::cuda_stream_view stream);
@@ -649,6 +693,12 @@ class sirius_physical_operator {
   //! Add a port to the operator
   void add_port(std::string_view port_id, std::unique_ptr<port> p);
   //! Get a port from the operator
+  //! Look up a port, or nullptr when this operator has no port by that name. Prefer this over
+  //! @ref get_port wherever a missing port is an ordinary outcome rather than a bug — get_port
+  //! throws, and a throw escaping a scheduling path (get_next_task_hint) is not recoverable.
+  [[nodiscard]] port* try_get_port(std::string_view port_id);
+  [[nodiscard]] const port* try_get_port(std::string_view port_id) const;
+  //! As @ref try_get_port, but throws when the name is unknown.
   port* get_port(std::string_view port_id);
   //! Get all ports from the operator
   std::vector<std::string_view> get_port_ids();

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -727,6 +727,12 @@ class sirius_physical_operator {
   /// \brief check if this operator has exhausted its limit, allowing the pipeline to finish early
   virtual bool is_limit_exhausted() const { return false; }
 
+  /// \brief whether this operator caps its pipeline's output independently of how much input
+  /// arrives — a row limit. Unlike @ref is_limit_exhausted this is true from the start, since the
+  /// cap bounds the eventual total whether or not it has bound yet. The data size estimator
+  /// refuses to extrapolate a ratio through such a pipeline.
+  [[nodiscard]] virtual bool caps_pipeline_output() const { return false; }
+
   //! Get the input batch
   virtual std::unique_ptr<operator_data> get_next_task_input_data();
 

--- a/src/include/pipeline/data_size_estimator.hpp
+++ b/src/include/pipeline/data_size_estimator.hpp
@@ -104,9 +104,7 @@ struct size_estimate_options {
 /**
  * @brief `bytes * ratio`, or nullopt if the product would not survive narrowing to std::size_t.
  *
- * Shared with the source hooks that feed the estimator. Narrowing an out-of-range double is UB,
- * and on x86-64 yields a huge positive value rather than anything obviously wrong — an unguarded
- * cast turns "we cannot answer" into a confident exabyte-scale total.
+ * Shared with the source hooks that feed the estimator.
  */
 [[nodiscard]] std::optional<std::size_t> scale_bytes_checked(std::size_t bytes, double ratio);
 

--- a/src/include/pipeline/data_size_estimator.hpp
+++ b/src/include/pipeline/data_size_estimator.hpp
@@ -37,7 +37,9 @@ struct data_size_estimate {
   std::size_t bytes = 0;
   /// True when anchored on an exact total with no learned ratio applied.
   bool exact = false;
-  /// Pipelines traversed; ratio error compounds per hop.
+  /// Ratios applied between the anchor and this answer; error compounds per hop, and exact
+  /// implies zero. Distinct from the recursion depth @ref size_estimate_options::max_hops
+  /// bounds — a leaf applies its own ratio without recursing.
   std::size_t hops = 0;
   /// Completed tasks behind the weakest measured ratio; zero means no measured ratio applies.
   std::size_t ratio_samples = 0;

--- a/src/include/pipeline/data_size_estimator.hpp
+++ b/src/include/pipeline/data_size_estimator.hpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string_view>
+
+namespace sirius {
+namespace op {
+class sirius_physical_operator;
+}  // namespace op
+
+namespace pipeline {
+
+class sirius_pipeline;
+
+/**
+ * @brief Projected total bytes that will flow through a point in the plan.
+ *
+ * A total for the whole query, not a so-far figure: "how many bytes will this port have
+ * received once its producer is done?". See docs/super-sirius/data-size-estimation.md.
+ */
+struct data_size_estimate {
+  std::size_t bytes = 0;
+  /// Measured rather than projected: the walk anchored on a finished pipeline or an exactly
+  /// known source total, with no learned ratio applied anywhere along the chain.
+  bool exact = false;
+  /// Pipelines traversed. Diagnostic — ratio error compounds per hop.
+  std::size_t hops = 0;
+  /// Completed tasks behind the *weakest measured* ratio in the chain. Separates "we sampled too
+  /// early" from "the model is wrong" when an estimate misses. Zero means no measured ratio backs
+  /// the result: an exact estimate, or — under @ref size_estimate_options::assume_unit_ratio — a
+  /// chain that substituted 1:1 at every link. @ref exact separates the two.
+  std::size_t ratio_samples = 0;
+  /// The walk anchored on a planner guess rather than a measurement — in practice
+  /// `GPU_SCAN::total_source_output_bytes()`, built from DuckDB's `estimated_cardinality`.
+  /// Sticky: every estimate chained on top of such an anchor inherits it. Not inferable from
+  /// `ratio_samples == 0`, which holds only for the anchor's own pipeline — one downstream hop
+  /// with a trusted ratio overwrites that zero (see weaker_sample_count in the .cpp).
+  bool planner_derived = false;
+};
+
+/// Tuning for a single estimation call.
+struct size_estimate_options {
+  /// Use a 1:1 ratio where the measured one is unusable, instead of returning nullopt. Never
+  /// marks the result exact. Applies to *pipeline* ratios only: 1:1 reads as "assume
+  /// pass-through", which a join — free to multiply or divide its input volume — cannot claim.
+  bool assume_unit_ratio = false;
+  /// Recursion guard against pathological plan depth, and defensively against graph cycles.
+  std::size_t max_hops = 16;
+  /// Sample floor for a single-input pipeline ratio. Below it the ratio is treated as absent, so
+  /// @ref assume_unit_ratio still applies.
+  std::size_t min_ratio_samples = 4;
+  /// Sample floor for a fan-in ratio. Far higher, because that ratio is systematically biased low
+  /// while tasks are in flight where a single-input one is merely noisy — and a **hard gate**:
+  /// nullopt below it even under @ref assume_unit_ratio. See data-size-estimation.md#fan-in.
+  std::size_t min_fan_in_ratio_samples = 16;
+};
+
+/**
+ * @brief Project the total bytes arriving at @p op's @p port_id input port.
+ *
+ * @return nullopt for a missing port, a dependency-only port (null repo), a port with no
+ *         producer, or when the upstream walk cannot produce an estimate.
+ */
+[[nodiscard]] std::optional<data_size_estimate> estimate_port_total_input_bytes(
+  op::sirius_physical_operator& op, std::string_view port_id, size_estimate_options options = {});
+
+/**
+ * @brief Project the total bytes @p pipeline will emit over the whole query.
+ *
+ * Walks upstream to the first known total, then chains each intervening pipeline's measured
+ * output/input ratio back down. Four terminating cases, in the order the implementation tries
+ * them (see data_size_estimator.cpp for why each is shaped as it is):
+ *
+ *  1. finished pipeline — its recorded output total, exactly;
+ *  2. fan-in — follow only the source's nominated primary port;
+ *  3. leaf — anchor on the source's own total;
+ *  4. single producer — recurse, then apply this pipeline's ratio.
+ *
+ * @return nullopt whenever any link in the chain is unknown.
+ */
+[[nodiscard]] std::optional<data_size_estimate> estimate_pipeline_total_output_bytes(
+  sirius_pipeline& pipeline, size_estimate_options options = {});
+
+/**
+ * @brief `bytes * ratio`, or nullopt if the product would not survive narrowing to std::size_t.
+ *
+ * Shared with the source hooks that feed the estimator. Narrowing an out-of-range double is UB,
+ * and on x86-64 yields a huge positive value rather than anything obviously wrong — an unguarded
+ * cast turns "we cannot answer" into a confident exabyte-scale total.
+ */
+[[nodiscard]] std::optional<std::size_t> scale_bytes_checked(std::size_t bytes, double ratio);
+
+/**
+ * @brief A leaf source's whole-query output total, projected from a planner row estimate and
+ *        floored at what it has already emitted.
+ *
+ * `estimated_cardinality x (emitted_bytes / emitted_rows)`, then `max(..., emitted_bytes)`.
+ * Backs `total_source_output_bytes()` on scan-like sources.
+ *
+ * The floor is not defensive rounding. A planner cardinality is a pre-execution guess at a
+ * post-filter row count, unbounded below and routinely under the rows already produced; DuckDB
+ * pins it to exactly zero whenever the base table cardinality reads zero, which a stale or absent
+ * stat on a non-empty table will do. Unfloored, a leaf anchor could report zero and every
+ * downstream hop would multiply it out to a zero whole-query total.
+ *
+ * @return nullopt when no batch has been measured yet (either count zero), or when the product
+ *         would not survive narrowing.
+ */
+[[nodiscard]] std::optional<std::size_t> project_source_output_bytes(
+  std::size_t estimated_cardinality, std::size_t emitted_rows, std::size_t emitted_bytes);
+
+}  // namespace pipeline
+}  // namespace sirius

--- a/src/include/pipeline/data_size_estimator.hpp
+++ b/src/include/pipeline/data_size_estimator.hpp
@@ -30,45 +30,31 @@ namespace pipeline {
 class sirius_pipeline;
 
 /**
- * @brief Projected total bytes that will flow through a point in the plan.
- *
- * A total for the whole query, not a so-far figure: "how many bytes will this port have
- * received once its producer is done?". See docs/super-sirius/data-size-estimation.md.
+ * @brief Projected whole-query byte total, not bytes seen so far.
+ * @see docs/super-sirius/data-size-estimation.md
  */
 struct data_size_estimate {
   std::size_t bytes = 0;
-  /// Measured rather than projected: the walk anchored on a finished pipeline or an exactly
-  /// known source total, with no learned ratio applied anywhere along the chain.
+  /// True when anchored on an exact total with no learned ratio applied.
   bool exact = false;
-  /// Pipelines traversed. Diagnostic — ratio error compounds per hop.
+  /// Pipelines traversed; ratio error compounds per hop.
   std::size_t hops = 0;
-  /// Completed tasks behind the *weakest measured* ratio in the chain. Separates "we sampled too
-  /// early" from "the model is wrong" when an estimate misses. Zero means no measured ratio backs
-  /// the result: an exact estimate, or — under @ref size_estimate_options::assume_unit_ratio — a
-  /// chain that substituted 1:1 at every link. @ref exact separates the two.
+  /// Completed tasks behind the weakest measured ratio; zero means no measured ratio applies.
   std::size_t ratio_samples = 0;
-  /// The walk anchored on a planner guess rather than a measurement — in practice
-  /// `GPU_SCAN::total_source_output_bytes()`, built from DuckDB's `estimated_cardinality`.
-  /// Sticky: every estimate chained on top of such an anchor inherits it. Not inferable from
-  /// `ratio_samples == 0`, which holds only for the anchor's own pipeline — one downstream hop
-  /// with a trusted ratio overwrites that zero (see weaker_sample_count in the .cpp).
+  /// True when anchored on a planner estimate. Sticky and independent of @ref ratio_samples.
   bool planner_derived = false;
 };
 
 /// Tuning for a single estimation call.
 struct size_estimate_options {
-  /// Use a 1:1 ratio where the measured one is unusable, instead of returning nullopt. Never
-  /// marks the result exact. Applies to *pipeline* ratios only: 1:1 reads as "assume
-  /// pass-through", which a join — free to multiply or divide its input volume — cannot claim.
+  /// Substitute 1:1 for unavailable pipeline ratios; never applies to fan-in or marks exact.
   bool assume_unit_ratio = false;
-  /// Recursion guard against pathological plan depth, and defensively against graph cycles.
+  /// Recursion and cycle guard.
   std::size_t max_hops = 16;
-  /// Sample floor for a single-input pipeline ratio. Below it the ratio is treated as absent, so
-  /// @ref assume_unit_ratio still applies.
+  /// Minimum samples for a single-input ratio; @ref assume_unit_ratio may replace weaker ratios.
   std::size_t min_ratio_samples = 4;
-  /// Sample floor for a fan-in ratio. Far higher, because that ratio is systematically biased low
-  /// while tasks are in flight where a single-input one is merely noisy — and a **hard gate**:
-  /// nullopt below it even under @ref assume_unit_ratio. See data-size-estimation.md#fan-in.
+  /// Hard fan-in sample floor; returns nullopt below it even with @ref assume_unit_ratio.
+  /// See docs/super-sirius/data-size-estimation.md#fan-in.
   std::size_t min_fan_in_ratio_samples = 16;
 };
 
@@ -84,19 +70,14 @@ struct size_estimate_options {
 /**
  * @brief Project the total bytes @p pipeline will emit over the whole query.
  *
- * Walks upstream to the first known total, then chains each intervening pipeline's measured
- * output/input ratio back down. Four terminating cases, in the order the implementation tries
- * them (see data_size_estimator.cpp for why each is shaped as it is):
+ * Walks upstream to a known total, then applies intervening output/input ratios:
  *
- *  1. finished pipeline — its recorded output total, exactly;
- *  2. fan-in — follow only the source's nominated primary port;
- *  3. leaf — anchor on the source's own total;
- *  4. single producer — recurse, then apply this pipeline's ratio.
+ *  1. finished pipeline: exact recorded output;
+ *  2. fan-in: nominated primary port;
+ *  3. leaf: source total;
+ *  4. single producer: recurse and scale.
  *
- * An unfinished pipeline holding an operator that caps its output by row count (a LIMIT) short
- * circuits to nullopt ahead of 2-4: no ratio extrapolates through a cap.
- *
- * @return nullopt whenever any link in the chain is unknown.
+ * @return nullopt for an unknown link or an unfinished output-capped pipeline.
  */
 [[nodiscard]] std::optional<data_size_estimate> estimate_pipeline_total_output_bytes(
   sirius_pipeline& pipeline, size_estimate_options options = {});
@@ -113,16 +94,8 @@ struct size_estimate_options {
  *        floored at what it has already emitted.
  *
  * `estimated_cardinality x (emitted_bytes / emitted_rows)`, then `max(..., emitted_bytes)`.
- * Backs `total_source_output_bytes()` on scan-like sources.
  *
- * The floor is not defensive rounding. A planner cardinality is a pre-execution guess at a
- * post-filter row count, unbounded below and routinely under the rows already produced; DuckDB
- * pins it to exactly zero whenever the base table cardinality reads zero, which a stale or absent
- * stat on a non-empty table will do. Unfloored, a leaf anchor could report zero and every
- * downstream hop would multiply it out to a zero whole-query total.
- *
- * @return nullopt when no batch has been measured yet (either count zero), or when the product
- *         would not survive narrowing.
+ * @return nullopt when either measured count is zero or the product cannot narrow to size_t.
  */
 [[nodiscard]] std::optional<std::size_t> project_source_output_bytes(
   std::size_t estimated_cardinality, std::size_t emitted_rows, std::size_t emitted_bytes);

--- a/src/include/pipeline/data_size_estimator.hpp
+++ b/src/include/pipeline/data_size_estimator.hpp
@@ -93,6 +93,9 @@ struct size_estimate_options {
  *  3. leaf — anchor on the source's own total;
  *  4. single producer — recurse, then apply this pipeline's ratio.
  *
+ * An unfinished pipeline holding an operator that caps its output by row count (a LIMIT) short
+ * circuits to nullopt ahead of 2-4: no ratio extrapolates through a cap.
+ *
  * @return nullopt whenever any link in the chain is unknown.
  */
 [[nodiscard]] std::optional<data_size_estimate> estimate_pipeline_total_output_bytes(

--- a/src/include/pipeline/pipeline_memory_history.hpp
+++ b/src/include/pipeline/pipeline_memory_history.hpp
@@ -36,40 +36,27 @@ struct task_memory_record {
   std::size_t estimated_bytes;              ///< Pre-history estimation basis
   std::size_t peak_memory_bytes;            ///< Actual peak allocated bytes during execution
   std::optional<std::size_t> output_bytes;  ///< Total output data size (nullopt if task OOM'd)
-  /// Whether @ref estimated_bytes is in pipeline-input units, and so may contribute to the
-  /// aggregate ratio. False for a task resumed mid-pipeline after an OOM/CUDA reschedule: its
-  /// basis is the intermediate data it restarted from, which is a different quantity. Such a
-  /// record is still valid for @ref estimate_peak_memory, which is per-task.
+  /// Whether @ref estimated_bytes is in pipeline-input units. False for mid-pipeline resumes;
+  /// they remain valid for per-task @ref estimate_peak_memory.
   bool ratio_eligible = true;
 };
 
 /**
- * @brief Running totals over the successful tasks a pipeline has completed.
+ * @brief Non-evicting totals over successful pipeline tasks.
  *
- * Unlike the ring buffer these are monotonic and never evicted, so they stay
- * accurate for pipelines that run more than kMaxRecords tasks.
- *
- * Two sets of terms, because the estimator asks two questions with different
- * admission rules: what ratio does this pipeline have (needs a basis and an
- * output that describe the same task), and how much has it emitted in total
- * (needs every task that produced anything). Conflating them lets a pipeline
- * with unmeasurable inputs under-report its output.
+ * Ratio terms require matching usable input and output; output terms include every successful
+ * task. Keeping them separate prevents unsized inputs from reducing the emitted total.
  */
 struct history_totals {
-  /// Ratio terms — only tasks whose basis is a usable pipeline-input quantity, i.e. nonzero and
-  /// ratio-eligible. A pairing of input and output is meaningless without both.
+  /// Tasks with nonzero, ratio-eligible input and recorded output.
   std::size_t ratio_input_bytes  = 0;
   std::size_t ratio_output_bytes = 0;
   std::size_t ratio_records      = 0;
-  /// Output terms — EVERY successful task, including those whose basis was zero (a scan split
-  /// with no a-priori size estimate) or mid-pipeline. A pipeline's total emitted bytes must not
-  /// depend on whether its inputs happened to be measurable.
+  /// Every task with recorded output, including zero-basis and resumed tasks.
   std::size_t output_bytes   = 0;
   std::size_t output_records = 0;
 
-  /// Aggregate output/input ratio over the ratio-eligible tasks, or nullopt when none has been
-  /// recorded. Deliberately an aggregate rather than the proximity-weighted scheme
-  /// estimate_peak_memory() uses: this projects a total, it does not size one task.
+  /// Aggregate ratio over eligible tasks, or nullopt without usable input.
   [[nodiscard]] std::optional<double> ratio() const
   {
     if (ratio_records == 0 || ratio_input_bytes == 0) { return std::nullopt; }
@@ -83,9 +70,7 @@ struct history_totals {
  * Stores a bounded ring buffer of recent task_memory_records and provides
  * an estimation function that uses historical ratios to predict peak memory
  * consumption for a new task given its estimation basis.
- *
- * Separately maintains unbounded @ref history_totals so the pipeline's
- * aggregate input->output ratio survives ring-buffer eviction.
+ * Also maintains @ref history_totals beyond ring-buffer eviction.
  */
 class pipeline_memory_history {
  public:
@@ -101,22 +86,19 @@ class pipeline_memory_history {
   void record(task_memory_record rec)
   {
     std::lock_guard<std::mutex> lock(_mutex);
-    // A failed (OOM'd) task carries no output_bytes; it contributes to neither total.
+    // OOM'd tasks have no output and contribute to neither total.
     if (rec.output_bytes.has_value()) {
-      // Emitted bytes count regardless of whether the basis was usable, so a finished pipeline's
-      // output total is complete even when some tasks had no a-priori size estimate.
+      // Output totals include every successful task.
       _totals.output_bytes += *rec.output_bytes;
       _totals.output_records++;
-      // The ratio additionally needs a basis in pipeline-input units: nonzero, and not a
-      // mid-pipeline resume (see task_memory_record::ratio_eligible).
+      // Ratio totals additionally require a usable pipeline-input basis.
       if (rec.estimated_bytes > 0 && rec.ratio_eligible) {
         _totals.ratio_input_bytes += rec.estimated_bytes;
         _totals.ratio_output_bytes += *rec.output_bytes;
         _totals.ratio_records++;
       }
     }
-    // The ring feeds estimate_peak_memory, which divides by estimated_bytes — a zero-basis record
-    // is unusable there and is skipped, as it always has been.
+    // estimate_peak_memory divides by the basis, so zero-basis records skip the ring.
     if (rec.estimated_bytes == 0) { return; }
     if (_records.size() < kMaxRecords) {
       _records.push_back(rec);
@@ -211,9 +193,7 @@ class pipeline_memory_history {
     return _records.size();
   }
 
-  /**
-   * @brief Unbounded running totals over every successful task (see @ref history_totals).
-   */
+  /// Non-evicting totals over successful tasks.
   [[nodiscard]] history_totals totals() const
   {
     std::lock_guard<std::mutex> lock(_mutex);

--- a/src/include/pipeline/pipeline_memory_history.hpp
+++ b/src/include/pipeline/pipeline_memory_history.hpp
@@ -36,6 +36,45 @@ struct task_memory_record {
   std::size_t estimated_bytes;              ///< Pre-history estimation basis
   std::size_t peak_memory_bytes;            ///< Actual peak allocated bytes during execution
   std::optional<std::size_t> output_bytes;  ///< Total output data size (nullopt if task OOM'd)
+  /// Whether @ref estimated_bytes is in pipeline-input units, and so may contribute to the
+  /// aggregate ratio. False for a task resumed mid-pipeline after an OOM/CUDA reschedule: its
+  /// basis is the intermediate data it restarted from, which is a different quantity. Such a
+  /// record is still valid for @ref estimate_peak_memory, which is per-task.
+  bool ratio_eligible = true;
+};
+
+/**
+ * @brief Running totals over the successful tasks a pipeline has completed.
+ *
+ * Unlike the ring buffer these are monotonic and never evicted, so they stay
+ * accurate for pipelines that run more than kMaxRecords tasks.
+ *
+ * Two sets of terms, because the estimator asks two questions with different
+ * admission rules: what ratio does this pipeline have (needs a basis and an
+ * output that describe the same task), and how much has it emitted in total
+ * (needs every task that produced anything). Conflating them lets a pipeline
+ * with unmeasurable inputs under-report its output.
+ */
+struct history_totals {
+  /// Ratio terms — only tasks whose basis is a usable pipeline-input quantity, i.e. nonzero and
+  /// ratio-eligible. A pairing of input and output is meaningless without both.
+  std::size_t ratio_input_bytes  = 0;
+  std::size_t ratio_output_bytes = 0;
+  std::size_t ratio_records      = 0;
+  /// Output terms — EVERY successful task, including those whose basis was zero (a scan split
+  /// with no a-priori size estimate) or mid-pipeline. A pipeline's total emitted bytes must not
+  /// depend on whether its inputs happened to be measurable.
+  std::size_t output_bytes   = 0;
+  std::size_t output_records = 0;
+
+  /// Aggregate output/input ratio over the ratio-eligible tasks, or nullopt when none has been
+  /// recorded. Deliberately an aggregate rather than the proximity-weighted scheme
+  /// estimate_peak_memory() uses: this projects a total, it does not size one task.
+  [[nodiscard]] std::optional<double> ratio() const
+  {
+    if (ratio_records == 0 || ratio_input_bytes == 0) { return std::nullopt; }
+    return static_cast<double>(ratio_output_bytes) / static_cast<double>(ratio_input_bytes);
+  }
 };
 
 /**
@@ -44,6 +83,9 @@ struct task_memory_record {
  * Stores a bounded ring buffer of recent task_memory_records and provides
  * an estimation function that uses historical ratios to predict peak memory
  * consumption for a new task given its estimation basis.
+ *
+ * Separately maintains unbounded @ref history_totals so the pipeline's
+ * aggregate input->output ratio survives ring-buffer eviction.
  */
 class pipeline_memory_history {
  public:
@@ -58,8 +100,24 @@ class pipeline_memory_history {
    */
   void record(task_memory_record rec)
   {
-    if (rec.estimated_bytes == 0) { return; }
     std::lock_guard<std::mutex> lock(_mutex);
+    // A failed (OOM'd) task carries no output_bytes; it contributes to neither total.
+    if (rec.output_bytes.has_value()) {
+      // Emitted bytes count regardless of whether the basis was usable, so a finished pipeline's
+      // output total is complete even when some tasks had no a-priori size estimate.
+      _totals.output_bytes += *rec.output_bytes;
+      _totals.output_records++;
+      // The ratio additionally needs a basis in pipeline-input units: nonzero, and not a
+      // mid-pipeline resume (see task_memory_record::ratio_eligible).
+      if (rec.estimated_bytes > 0 && rec.ratio_eligible) {
+        _totals.ratio_input_bytes += rec.estimated_bytes;
+        _totals.ratio_output_bytes += *rec.output_bytes;
+        _totals.ratio_records++;
+      }
+    }
+    // The ring feeds estimate_peak_memory, which divides by estimated_bytes — a zero-basis record
+    // is unusable there and is skipped, as it always has been.
+    if (rec.estimated_bytes == 0) { return; }
     if (_records.size() < kMaxRecords) {
       _records.push_back(rec);
     } else {
@@ -153,12 +211,22 @@ class pipeline_memory_history {
     return _records.size();
   }
 
+  /**
+   * @brief Unbounded running totals over every successful task (see @ref history_totals).
+   */
+  [[nodiscard]] history_totals totals() const
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _totals;
+  }
+
  private:
   static constexpr std::size_t kMaxRecords = 64;
 
   mutable std::mutex _mutex;
   std::vector<task_memory_record> _records;
   std::size_t _write_pos = 0;
+  history_totals _totals;
 };
 
 }  // namespace sirius::pipeline

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -217,11 +217,8 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
 
   [[nodiscard]] uuid::UUID pipeline_uuid() const { return _pipeline_uuid; }
 
-  //! Historical memory/size metrics for this pipeline's completed tasks. Recorded by
-  //! gpu_pipeline_task via sirius_pipeline_task_global_state::get_memory_history() (which
-  //! delegates here), and read by the data size estimator, which needs to reach a producer
-  //! pipeline's input->output ratio through `port::src_pipeline` — a path that has no access
-  //! to the task_creator-owned global states.
+  //! Completed-task memory and size history, owned here so upstream estimators can access it
+  //! through `port::src_pipeline`.
   [[nodiscard]] pipeline_memory_history& get_memory_history() noexcept { return _memory_history; }
   [[nodiscard]] const pipeline_memory_history& get_memory_history() const noexcept
   {
@@ -287,7 +284,7 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   std::atomic<std::size_t> tasks_created   = 0;
   std::atomic<std::size_t> tasks_completed = 0;
 
-  //! Historical memory metrics for this pipeline's tasks (see get_memory_history).
+  //! Completed-task history; see get_memory_history().
   pipeline_memory_history _memory_history;
 
   //! NVTX process-wide range tracking the pipeline's active lifetime

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -23,6 +23,7 @@
 #include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_operator_type.hpp"
 #include "pipeline/pipeline_build_context.hpp"
+#include "pipeline/pipeline_memory_history.hpp"
 #include "telemetry-bridge/gen/uuid.rs.h"
 
 #include <nvtx3/nvtx3.hpp>
@@ -216,6 +217,17 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
 
   [[nodiscard]] uuid::UUID pipeline_uuid() const { return _pipeline_uuid; }
 
+  //! Historical memory/size metrics for this pipeline's completed tasks. Recorded by
+  //! gpu_pipeline_task via sirius_pipeline_task_global_state::get_memory_history() (which
+  //! delegates here), and read by the data size estimator, which needs to reach a producer
+  //! pipeline's input->output ratio through `port::src_pipeline` — a path that has no access
+  //! to the task_creator-owned global states.
+  [[nodiscard]] pipeline_memory_history& get_memory_history() noexcept { return _memory_history; }
+  [[nodiscard]] const pipeline_memory_history& get_memory_history() const noexcept
+  {
+    return _memory_history;
+  }
+
   //! The SiriusContext-wide telemetry context carried in this pipeline's build
   //! context (set at convert time in sirius_engine). Operators read it via
   //! sirius_physical_operator::get_telemetry_context() to build data_batch probes.
@@ -274,6 +286,9 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
 
   std::atomic<std::size_t> tasks_created   = 0;
   std::atomic<std::size_t> tasks_completed = 0;
+
+  //! Historical memory metrics for this pipeline's tasks (see get_memory_history).
+  pipeline_memory_history _memory_history;
 
   //! NVTX process-wide range tracking the pipeline's active lifetime
   std::atomic<bool> _nvtx_range_started{false};

--- a/src/include/pipeline/sirius_pipeline_task_states.hpp
+++ b/src/include/pipeline/sirius_pipeline_task_states.hpp
@@ -97,9 +97,22 @@ class sirius_pipeline_task_global_state : public sirius::parallel::itask_global_
    *
    * Used to record and query historical memory consumption patterns so that
    * future tasks can make better reservation estimates.
+   *
+   * The history is owned by the pipeline itself, not by this global state, so that the
+   * data size estimator can reach a producer pipeline's ratio through `port::src_pipeline`
+   * without going through the task_creator. There is exactly one global state per pipeline
+   * (task_creator::prepare_for_query), so this delegation preserves the previous 1:1
+   * lifetime. Falls back to a per-state history for the test paths that construct a global
+   * state with a null pipeline.
    */
-  pipeline_memory_history& get_memory_history() { return _memory_history; }
-  const pipeline_memory_history& get_memory_history() const { return _memory_history; }
+  pipeline_memory_history& get_memory_history()
+  {
+    return _pipeline ? _pipeline->get_memory_history() : _detached_memory_history;
+  }
+  const pipeline_memory_history& get_memory_history() const
+  {
+    return _pipeline ? _pipeline->get_memory_history() : _detached_memory_history;
+  }
 
   /**
    * @brief Set the preferred GPU device ID for this pipeline's tasks.
@@ -133,9 +146,11 @@ class sirius_pipeline_task_global_state : public sirius::parallel::itask_global_
 
  private:
   duckdb::shared_ptr<sirius_pipeline> _pipeline;  ///< Shared pointer to the GPU pipeline to execute
-  pipeline_memory_history _memory_history;        ///< Historical memory metrics for estimation
-  std::optional<int> _preferred_device_id;        ///< Pipeline-level preferred GPU device
-  exec::queue_priority _priority{0};              ///< Pipeline-level scheduling priority
+  /// Stand-in history used only when @c _pipeline is null (tests that construct a global
+  /// state without a pipeline). The real history lives on sirius_pipeline.
+  pipeline_memory_history _detached_memory_history;
+  std::optional<int> _preferred_device_id;  ///< Pipeline-level preferred GPU device
+  exec::queue_priority _priority{0};        ///< Pipeline-level scheduling priority
   std::shared_ptr<const telemetry::telemetry_context>
     _telemetry_context;  ///< SiriusContext telemetry
 };

--- a/src/include/pipeline/sirius_pipeline_task_states.hpp
+++ b/src/include/pipeline/sirius_pipeline_task_states.hpp
@@ -97,13 +97,7 @@ class sirius_pipeline_task_global_state : public sirius::parallel::itask_global_
    *
    * Used to record and query historical memory consumption patterns so that
    * future tasks can make better reservation estimates.
-   *
-   * The history is owned by the pipeline itself, not by this global state, so that the
-   * data size estimator can reach a producer pipeline's ratio through `port::src_pipeline`
-   * without going through the task_creator. There is exactly one global state per pipeline
-   * (task_creator::prepare_for_query), so this delegation preserves the previous 1:1
-   * lifetime. Falls back to a per-state history for the test paths that construct a global
-   * state with a null pipeline.
+   * Delegates to the pipeline-owned history; uses detached history when tests provide no pipeline.
    */
   pipeline_memory_history& get_memory_history()
   {
@@ -146,8 +140,7 @@ class sirius_pipeline_task_global_state : public sirius::parallel::itask_global_
 
  private:
   duckdb::shared_ptr<sirius_pipeline> _pipeline;  ///< Shared pointer to the GPU pipeline to execute
-  /// Stand-in history used only when @c _pipeline is null (tests that construct a global
-  /// state without a pipeline). The real history lives on sirius_pipeline.
+  /// Test fallback when @c _pipeline is null.
   pipeline_memory_history _detached_memory_history;
   std::optional<int> _preferred_device_id;  ///< Pipeline-level preferred GPU device
   exec::queue_priority _priority{0};        ///< Pipeline-level scheduling priority

--- a/src/include/scan_manager/split_connector.hpp
+++ b/src/include/scan_manager/split_connector.hpp
@@ -107,6 +107,14 @@ class split_connector : public std::enable_shared_from_this<split_connector> {
   /// prefetch threads grabbing exclusive locks would serialize them.
   [[nodiscard]] bool is_draining(std::size_t quiet_ms) const;
 
+  /// \brief True once close() has been called — i.e. @ref discovered_bytes is now the scan's
+  ///        complete total. Distinct from @ref is_closed, which means closed AND drained.
+  [[nodiscard]] bool is_discovery_complete() const;
+
+  /// \brief Σ `get_estimated_size_in_bytes()` over every split pushed so far. Monotonic, so
+  ///        consumers draining the queue do not reduce it; a lower bound until discovery closes.
+  [[nodiscard]] std::size_t discovered_bytes() const;
+
  private:
   friend class load_balancing_scan_batch_coalescer;
 
@@ -122,6 +130,9 @@ class split_connector : public std::enable_shared_from_this<split_connector> {
   std::exception_ptr _exception;
   /// steady_clock ms timestamp of the last get_next_split() pop (0 = never).
   std::atomic<std::int64_t> _last_pop_ms{0};
+  /// Monotonic discovery total: accumulated in push_split, never decremented when a
+  /// consumer pops. See @ref discovered_bytes.
+  std::size_t _discovered_bytes{0};
 };
 
 }  // namespace sirius::scan_manager

--- a/src/include/scan_manager/split_connector.hpp
+++ b/src/include/scan_manager/split_connector.hpp
@@ -112,8 +112,14 @@ class split_connector : public std::enable_shared_from_this<split_connector> {
   [[nodiscard]] bool is_discovery_complete() const;
 
   /// \brief Σ `get_estimated_size_in_bytes()` over every split pushed so far. Monotonic, so
-  ///        consumers draining the queue do not reduce it; a lower bound until discovery closes.
+  ///        consumers draining the queue do not reduce it; a lower bound until discovery closes,
+  ///        and a complete total only when @ref has_unsized_splits is false.
   [[nodiscard]] std::size_t discovered_bytes() const;
+
+  /// \brief Whether any split reported no a-priori size estimate. Such a split adds 0 to
+  ///        @ref discovered_bytes while still emitting rows, so the sum omits its contribution
+  ///        rather than merely approximating it.
+  [[nodiscard]] bool has_unsized_splits() const;
 
  private:
   friend class load_balancing_scan_batch_coalescer;
@@ -133,6 +139,8 @@ class split_connector : public std::enable_shared_from_this<split_connector> {
   /// Monotonic discovery total: accumulated in push_split, never decremented when a
   /// consumer pops. See @ref discovered_bytes.
   std::size_t _discovered_bytes{0};
+  /// Latched once any split reports a zero size estimate. See @ref has_unsized_splits.
+  bool _has_unsized_splits{false};
 };
 
 }  // namespace sirius::scan_manager

--- a/src/include/scan_manager/split_connector.hpp
+++ b/src/include/scan_manager/split_connector.hpp
@@ -107,18 +107,14 @@ class split_connector : public std::enable_shared_from_this<split_connector> {
   /// prefetch threads grabbing exclusive locks would serialize them.
   [[nodiscard]] bool is_draining(std::size_t quiet_ms) const;
 
-  /// \brief True once close() has been called — i.e. @ref discovered_bytes is now the scan's
-  ///        complete total. Distinct from @ref is_closed, which means closed AND drained.
+  /// \brief True after close(); unlike @ref is_closed, does not require the queue to be drained.
   [[nodiscard]] bool is_discovery_complete() const;
 
-  /// \brief Σ `get_estimated_size_in_bytes()` over every split pushed so far. Monotonic, so
-  ///        consumers draining the queue do not reduce it; a lower bound until discovery closes,
-  ///        and a complete total only when @ref has_unsized_splits is false.
+  /// \brief Monotonic sum of `get_estimated_size_in_bytes()` for all pushed splits.
+  /// Complete after discovery only if @ref has_unsized_splits is false.
   [[nodiscard]] std::size_t discovered_bytes() const;
 
-  /// \brief Whether any split reported no a-priori size estimate. Such a split adds 0 to
-  ///        @ref discovered_bytes while still emitting rows, so the sum omits its contribution
-  ///        rather than merely approximating it.
+  /// \brief Whether any split lacked an a-priori size estimate and contributed zero.
   [[nodiscard]] bool has_unsized_splits() const;
 
  private:
@@ -136,10 +132,9 @@ class split_connector : public std::enable_shared_from_this<split_connector> {
   std::exception_ptr _exception;
   /// steady_clock ms timestamp of the last get_next_split() pop (0 = never).
   std::atomic<std::int64_t> _last_pop_ms{0};
-  /// Monotonic discovery total: accumulated in push_split, never decremented when a
-  /// consumer pops. See @ref discovered_bytes.
+  /// Monotonic total; consumers never decrement it.
   std::size_t _discovered_bytes{0};
-  /// Latched once any split reports a zero size estimate. See @ref has_unsized_splits.
+  /// Latched when a split reports no size estimate.
   bool _has_unsized_splits{false};
 };
 

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -263,9 +263,7 @@ bool sirius_gpu_scan_operator::all_ports_empty() { return _split_connector->is_c
 std::optional<std::size_t> sirius_gpu_scan_operator::total_source_input_bytes() const
 {
   if (!_split_connector->is_discovery_complete()) { return std::nullopt; }
-  // A split with no a-priori estimate contributes 0 to the tally and is excluded from the
-  // pipeline ratio, yet still emits rows — so the sum omits its output rather than approximating
-  // it, and reads exactly 0 when no split had an estimate at all. Neither is a total.
+  // An unsized split may still emit rows, so discovered bytes are not a total.
   if (_split_connector->has_unsized_splits()) { return std::nullopt; }
   return _split_connector->discovered_bytes();
 }
@@ -376,10 +374,8 @@ std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::execute(
     }
   }
 
-  // Feed the bytes-per-row factor behind total_source_output_bytes(). Read both from the table
-  // while we still own it: for an owned table the batch's get_size_in_bytes() is exactly
-  // alloc_size(), so locking the batch afterwards would buy the same number at the cost of a
-  // shared lock. Rows and bytes are only meaningful as a pair, so publish them in one update.
+  // Read the size before moving the table into a batch to avoid locking the batch. Publish rows
+  // and bytes together because they form one sample.
   auto const emitted_rows  = static_cast<std::size_t>(output_table->num_rows());
   auto const emitted_bytes = output_table->alloc_size();
   {

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -26,6 +26,7 @@
 #include <op/scan/sirius_gpu_scan_operator.hpp>
 #include <op/scan/sirius_gpu_scan_operator_data.hpp>
 #include <op/sirius_physical_operator.hpp>
+#include <pipeline/data_size_estimator.hpp>
 #include <scan_manager/split_connector.hpp>
 #include <sirius/exception.hpp>
 #include <sirius_context.hpp>
@@ -47,6 +48,7 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -258,6 +260,24 @@ std::optional<task_creation_hint> sirius_gpu_scan_operator::get_next_task_hint()
 
 bool sirius_gpu_scan_operator::all_ports_empty() { return _split_connector->is_closed(); }
 
+std::optional<std::size_t> sirius_gpu_scan_operator::total_source_input_bytes() const
+{
+  if (!_split_connector->is_discovery_complete()) { return std::nullopt; }
+  return _split_connector->discovered_bytes();
+}
+
+std::optional<std::size_t> sirius_gpu_scan_operator::total_source_output_bytes() const
+{
+  std::size_t rows  = 0;
+  std::size_t bytes = 0;
+  {
+    std::lock_guard<std::mutex> guard(_emitted_mutex);
+    rows  = _emitted_rows;
+    bytes = _emitted_bytes;
+  }
+  return pipeline::project_source_output_bytes(estimated_cardinality, rows, bytes);
+}
+
 std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::get_next_task_input_data()
 {
   auto next = _split_connector->get_next_split();
@@ -351,6 +371,19 @@ std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::execute(
                                                mem_space->get_default_allocator());
     }
   }
+
+  // Feed the bytes-per-row factor behind total_source_output_bytes(). Read both from the table
+  // while we still own it: for an owned table the batch's get_size_in_bytes() is exactly
+  // alloc_size(), so locking the batch afterwards would buy the same number at the cost of a
+  // shared lock. Rows and bytes are only meaningful as a pair, so publish them in one update.
+  auto const emitted_rows  = static_cast<std::size_t>(output_table->num_rows());
+  auto const emitted_bytes = output_table->alloc_size();
+  {
+    std::lock_guard<std::mutex> guard(_emitted_mutex);
+    _emitted_rows += emitted_rows;
+    _emitted_bytes += emitted_bytes;
+  }
+
   auto batch =
     sirius::make_data_batch(std::move(output_table), *mem_space, stream, batch_telemetry());
   std::vector<std::shared_ptr<::cucascade::data_batch>> batches{std::move(batch)};

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -263,6 +263,10 @@ bool sirius_gpu_scan_operator::all_ports_empty() { return _split_connector->is_c
 std::optional<std::size_t> sirius_gpu_scan_operator::total_source_input_bytes() const
 {
   if (!_split_connector->is_discovery_complete()) { return std::nullopt; }
+  // A split with no a-priori estimate contributes 0 to the tally and is excluded from the
+  // pipeline ratio, yet still emits rows — so the sum omits its output rather than approximating
+  // it, and reads exactly 0 when no split had an estimate at all. Neither is a total.
+  if (_split_connector->has_unsized_splits()) { return std::nullopt; }
   return _split_connector->discovered_bytes();
 }
 

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -378,14 +378,16 @@ std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::execute(
   // and bytes together because they form one sample.
   auto const emitted_rows  = static_cast<std::size_t>(output_table->num_rows());
   auto const emitted_bytes = output_table->alloc_size();
+
+  auto batch =
+    sirius::make_data_batch(std::move(output_table), *mem_space, stream, batch_telemetry());
+  // Published only after make_data_batch succeeds: an OOM there reschedules the task into
+  // re-running the same split, and these bytes floor total_source_output_bytes().
   {
     std::lock_guard<std::mutex> guard(_emitted_mutex);
     _emitted_rows += emitted_rows;
     _emitted_bytes += emitted_bytes;
   }
-
-  auto batch =
-    sirius::make_data_batch(std::move(output_table), *mem_space, stream, batch_telemetry());
   std::vector<std::shared_ptr<::cucascade::data_batch>> batches{std::move(batch)};
   return std::make_unique<pipelineable_operator_data>(std::move(batches));
 }

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -674,14 +674,13 @@ std::size_t pairing_weighted_probe_bytes(
   std::size_t weighted = 0;
   for (auto const& c : cross) {
     auto const builds = c.build_ids.size();
-    if (builds == 0) { continue; }  // nothing to be a fraction of
+    if (builds == 0) { continue; }
     auto const n = std::min(c.probe_ids.size(), c.probe_paired_count.size());
     for (std::size_t i = 0; i < n; ++i) {
       auto const it = probe_bytes.find(c.probe_ids[i]);
-      // No size recorded: the non-blocking read lost its race; a later pairing retries it.
+      // A failed non-blocking size read is retried on a later pairing.
       if (it == probe_bytes.end()) { continue; }
-      // Multiply before dividing to keep the truncation at the end. k <= B and both are batch
-      // counts, so the product cannot overflow for any realistic batch size.
+      // Multiply first to minimize truncation.
       weighted += it->second * c.probe_paired_count[i] / builds;
     }
   }
@@ -856,40 +855,35 @@ partition_strategy compute_hash_join_partition_strategy(uint64_t total_bytes,
 
 std::optional<std::size_t> sirius_physical_hash_join::consumed_primary_input_bytes() const
 {
-  // Read the predicate rather than latching it. The port map is immutable after repository
-  // wiring, so this is a lock-free lookup plus an atomic load, and a cached flag would lag the
-  // poll that observed the build finishing — leaving the drain phase reporting nullopt.
+  // Read live completion state so drain-phase polls cannot observe a stale latch.
   auto const* build = try_get_port("build");
   if (build == nullptr || !build->src_pipeline || !build->src_pipeline->is_pipeline_finished()) {
     return std::nullopt;
   }
-  // Unpublished BEFORE weighted: a publish between the two reads then shows the same bytes in
-  // both, over-counting the denominator and biasing the ratio low. The other order could drop
-  // them from both and inflate it. See _unpublished_probe_bytes.
+  // Read unpublished bytes first. A concurrent publish may then double-count bytes, conservatively
+  // biasing the ratio low; the reverse order could omit them and inflate it.
   auto const unpublished = _unpublished_probe_bytes.load(std::memory_order_acquire);
-  // A batch is either paired or consumed whole, never both, so the totals sum cleanly.
+  // Each batch is counted either by pairing weight or in full.
   return _whole_probe_bytes.load(std::memory_order_relaxed) +
          _weighted_probe_bytes.load(std::memory_order_relaxed) + unpublished;
 }
 
 void sirius_physical_hash_join::publish_weighted_probe_bytes(bool build_finished)
 {
-  // Unreadable until the build side finishes, so skip the walk while probe batches stream in.
+  // Pairing weights are stable only after the build side finishes.
   if (!build_finished) { return; }
-  // op_state_mutex (held by the caller) -> _probe_bytes_mutex, and nothing here waits on a batch
-  // lock, so the nesting cannot form a cycle.
+  // Lock order: op_state_mutex (caller) -> _probe_bytes_mutex. This path takes no batch lock.
   std::lock_guard<std::mutex> lg(_probe_bytes_mutex);
   _weighted_probe_bytes.store(pairing_weighted_probe_bytes(_cross, _probe_batch_bytes),
                               std::memory_order_relaxed);
-  // Released after the store above, so a reader that sees zero here also sees the new weights.
+  // Release after publishing weights so readers that see zero also see the new value.
   _unpublished_probe_bytes.store(0, std::memory_order_release);
 }
 
 void sirius_physical_hash_join::record_probe_batch_bytes(uint64_t batch_id, std::size_t bytes)
 {
   std::lock_guard<std::mutex> lg(_probe_bytes_mutex);
-  // Already counted whole — an orphan survivor, or a BUILD_PROBE pop. Weighting it too would
-  // count it twice.
+  // Batches counted in full must not also contribute pairing weight.
   if (_counted_probe_batch_ids.contains(batch_id)) { return; }
   if (_probe_batch_bytes.try_emplace(batch_id, bytes).second) {
     _unpublished_probe_bytes.fetch_add(bytes, std::memory_order_release);
@@ -911,11 +905,8 @@ void sirius_physical_hash_join::note_probe_bytes(
     std::lock_guard<std::mutex> lg(_probe_bytes_mutex);
     if (_probe_batch_bytes.contains(batch->get_batch_id())) { return; }
   }
-  // Non-blocking because this runs under op_state_mutex: a concurrent downgrade holds the batch's
-  // exclusive lock for a whole tier conversion, and blocking would stall every task-creation call
-  // on this join for the duration (memory_prefetcher.cpp documents the same hazard). Losing the
-  // race just leaves the size unrecorded; the batch's next pairing retries it, and execute()
-  // backstops the batch that has no next pairing.
+  // Do not block under op_state_mutex while a downgrade holds the batch lock. A later pairing
+  // retries a missed read, and execute() handles batches with no later pairing.
   auto ro = batch->try_to_read_only();
   if (!ro || ro->get_data() == nullptr) { return; }
   auto const bytes = ro->get_data()->get_uncompressed_data_size_in_bytes();
@@ -1183,8 +1174,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
     std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
     input_batch.push_back(probe_port->repo->pop_next_data_batch(p));
     input_batch.push_back(build_port->repo->pop_next_data_batch(p));
-    // Probe bytes are counted in execute(), off a blocking accessor: this pop is the batch's only
-    // sighting, so a non-blocking read here could lose it to a downgrade for good.
+    // Count in execute() with a blocking accessor because this batch is not observed after pop.
     _partition_build_states[p].build_state.store(BUILD_HASH_TABLE_STATE::SCHEDULED,
                                                  std::memory_order_release);
     // Every task of partition p (this build+first-probe and all later probe-only tasks) shares the
@@ -1202,7 +1192,6 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
     std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
     auto batch = probe_port->repo->pop_next_data_batch(p);
     if (batch) {
-      // Counted in execute(), as above.
       input_batch.push_back(std::move(batch));
     } else {
       SIRIUS_LOG_WARN(
@@ -1306,7 +1295,6 @@ std::pair<bool, bool> sirius_physical_hash_join::refresh_cross_schedule()
     }
   }
 
-  // Covers polls that claim no pair; a claim republishes for itself, after its increment.
   publish_weighted_probe_bytes(build_finished);
   return {probe_finished, build_finished};
 }
@@ -1349,14 +1337,10 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
         std::to_string(step.partition) + " of operator " + std::to_string(this->get_operator_id()));
     }
 
-    // Every pairing, not just the first: note_probe_bytes dedups by batch id, and its size read
-    // is non-blocking, so a later pairing retries a batch whose first attempt lost the try-lock.
-    // execute() backstops the batch that has no later pairing.
+    // Retry the non-blocking size read at every pairing; batch-id dedup prevents double counting.
     note_probe_bytes(probe_batch);
 
-    // next_cross_schedule_pair has now bumped this batch's paired count, which the store inside
-    // refresh_cross_schedule ran too early to see. Republishing before the task is handed out
-    // below keeps the denominator ahead of the numerator.
+    // Republish after the paired-count increment so the denominator leads task output.
     publish_weighted_probe_bytes(finished.second);
 
     std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
@@ -1391,10 +1375,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
     {
       auto present_ro = present_batch->to_read_only();
       ms              = present_ro.get_memory_space();
-      // An orphaned probe batch is consumed here without ever being paired, so no later sighting
-      // exists to retry a missed count. Count it from this accessor — already being taken for the
-      // memory space — rather than through note_probe_bytes, whose non-blocking read could lose
-      // the batch outright.
+      // An orphaned probe has no later retry, so count it through this blocking accessor.
       if (!orphan.present_is_build) {
         if (auto const* data = present_ro.get_data(); data != nullptr) {
           note_probe_bytes_counted(present_batch->get_batch_id(),
@@ -1806,12 +1787,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
   cudf::table_view left_full, right_full;
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_indices, right_indices;
 
-  // Cross-schedule backstop, off an accessor already materialized with a blocking read: the size
-  // read at claim time is non-blocking, and a batch paired only once (every join type but INNER
-  // pins the build whole) has no later pairing to retry on, so a lost race would drop it from the
-  // denominator for good. Runs before the task records output, so the denominator still leads;
-  // ids the schedule does not track are inert. Takes _probe_bytes_mutex and NOT op_state_mutex —
-  // see the member declaration. The next refresh republishes.
+  // Backstop a failed claim-time read through this blocking accessor. Record before task output so
+  // the denominator leads; take only _probe_bytes_mutex to preserve lock order.
   if (_join_mode != HASH_JOIN_MODE::BUILD_PROBE && !input_batches.empty()) {
     if (auto const* probe_data = input_batches[0].get_data(); probe_data != nullptr) {
       auto const probe_id    = input_batches[0].get_batch_id();
@@ -1845,14 +1822,9 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
     }
     auto& slot = _partition_build_states[partition];
 
-    // Count the probe batch ([0] in both shapes: SCHEDULED probe+build, BUILT probe-only) here
-    // rather than at pop time, where BUILD_PROBE sees it once and a lost try-lock under-counts it
-    // for good. This accessor was already materialized with a blocking to_read_only() for the join
-    // itself, so the size read cannot lose. Dedup still applies: an OOM-rescheduled task re-enters
-    // execute() with the same batch (create_rescheduled_task) and would otherwise count it twice.
-    // note_probe_bytes_counted takes only _probe_bytes_mutex: we hold batch locks here, and the
-    // broadcast slot cleanup blocks on a batch lock under op_state_mutex, so taking that one here
-    // would invert the order.
+    // BUILD_PROBE sees each popped probe once, so count it through this blocking accessor. Dedup
+    // handles OOM rescheduling. Take only _probe_bytes_mutex to avoid inverting the batch-lock /
+    // op_state_mutex order used by broadcast cleanup.
     if (!input_batches.empty()) {
       if (auto const* probe_data = input_batches[0].get_data(); probe_data != nullptr) {
         note_probe_bytes_counted(input_batches[0].get_batch_id(),

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -855,39 +855,14 @@ partition_strategy compute_hash_join_partition_strategy(uint64_t total_bytes,
 
 std::optional<std::size_t> sirius_physical_hash_join::consumed_primary_input_bytes() const
 {
+  // Only the unweighted BUILD_PROBE count is published; see probe_bytes_are_unweighted().
+  if (!probe_bytes_are_unweighted()) { return std::nullopt; }
   // Read live completion state so drain-phase polls cannot observe a stale latch.
   auto const* build = try_get_port("build");
   if (build == nullptr || !build->src_pipeline || !build->src_pipeline->is_pipeline_finished()) {
     return std::nullopt;
   }
-  // Read unpublished bytes first. A concurrent publish may then double-count bytes, conservatively
-  // biasing the ratio low; the reverse order could omit them and inflate it.
-  auto const unpublished = _unpublished_probe_bytes.load(std::memory_order_acquire);
-  // Each batch is counted either by pairing weight or in full.
-  return _whole_probe_bytes.load(std::memory_order_relaxed) +
-         _weighted_probe_bytes.load(std::memory_order_relaxed) + unpublished;
-}
-
-void sirius_physical_hash_join::publish_weighted_probe_bytes(bool build_finished)
-{
-  // Pairing weights are stable only after the build side finishes.
-  if (!build_finished) { return; }
-  // Lock order: op_state_mutex (caller) -> _probe_bytes_mutex. This path takes no batch lock.
-  std::lock_guard<std::mutex> lg(_probe_bytes_mutex);
-  _weighted_probe_bytes.store(pairing_weighted_probe_bytes(_cross, _probe_batch_bytes),
-                              std::memory_order_relaxed);
-  // Release after publishing weights so readers that see zero also see the new value.
-  _unpublished_probe_bytes.store(0, std::memory_order_release);
-}
-
-void sirius_physical_hash_join::record_probe_batch_bytes(uint64_t batch_id, std::size_t bytes)
-{
-  std::lock_guard<std::mutex> lg(_probe_bytes_mutex);
-  // Batches counted in full must not also contribute pairing weight.
-  if (_counted_probe_batch_ids.contains(batch_id)) { return; }
-  if (_probe_batch_bytes.try_emplace(batch_id, bytes).second) {
-    _unpublished_probe_bytes.fetch_add(bytes, std::memory_order_release);
-  }
+  return _whole_probe_bytes.load(std::memory_order_relaxed);
 }
 
 void sirius_physical_hash_join::note_probe_bytes_counted(uint64_t batch_id, std::size_t bytes)
@@ -895,22 +870,6 @@ void sirius_physical_hash_join::note_probe_bytes_counted(uint64_t batch_id, std:
   std::lock_guard<std::mutex> lg(_probe_bytes_mutex);
   if (!_counted_probe_batch_ids.insert(batch_id).second) { return; }
   _whole_probe_bytes.fetch_add(bytes, std::memory_order_relaxed);
-}
-
-void sirius_physical_hash_join::note_probe_bytes(
-  const std::shared_ptr<cucascade::data_batch>& batch)
-{
-  if (!batch) { return; }
-  {
-    std::lock_guard<std::mutex> lg(_probe_bytes_mutex);
-    if (_probe_batch_bytes.contains(batch->get_batch_id())) { return; }
-  }
-  // Do not block under op_state_mutex while a downgrade holds the batch lock. A later pairing
-  // retries a missed read, and execute() handles batches with no later pairing.
-  auto ro = batch->try_to_read_only();
-  if (!ro || ro->get_data() == nullptr) { return; }
-  auto const bytes = ro->get_data()->get_uncompressed_data_size_in_bytes();
-  record_probe_batch_bytes(batch->get_batch_id(), bytes);
 }
 
 partition_strategy sirius_physical_hash_join::get_partition_strategy(
@@ -1295,7 +1254,6 @@ std::pair<bool, bool> sirius_physical_hash_join::refresh_cross_schedule()
     }
   }
 
-  publish_weighted_probe_bytes(build_finished);
   return {probe_finished, build_finished};
 }
 
@@ -1336,12 +1294,6 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
         "batches for a newly-scheduled pair in partition " +
         std::to_string(step.partition) + " of operator " + std::to_string(this->get_operator_id()));
     }
-
-    // Retry the non-blocking size read at every pairing; batch-id dedup prevents double counting.
-    note_probe_bytes(probe_batch);
-
-    // Republish after the paired-count increment so the denominator leads task output.
-    publish_weighted_probe_bytes(finished.second);
 
     std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
     input_batch.reserve(2);
@@ -1786,16 +1738,6 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
 
   cudf::table_view left_full, right_full;
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_indices, right_indices;
-
-  // Backstop a failed claim-time read through this blocking accessor. Record before task output so
-  // the denominator leads; take only _probe_bytes_mutex to preserve lock order.
-  if (_join_mode != HASH_JOIN_MODE::BUILD_PROBE && !input_batches.empty()) {
-    if (auto const* probe_data = input_batches[0].get_data(); probe_data != nullptr) {
-      auto const probe_id    = input_batches[0].get_batch_id();
-      auto const probe_bytes = probe_data->get_uncompressed_data_size_in_bytes();
-      record_probe_batch_bytes(probe_id, probe_bytes);
-    }
-  }
 
   if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
     // Each partition owns one hash table. The incoming batch is tagged with its partition index

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -69,6 +69,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace sirius {
@@ -666,6 +667,27 @@ std::vector<cross_schedule_discard> collect_cross_schedule_discards(
   return discards;
 }
 
+std::size_t pairing_weighted_probe_bytes(
+  std::vector<partition_cross_schedule> const& cross,
+  std::unordered_map<uint64_t, std::size_t> const& probe_bytes)
+{
+  std::size_t weighted = 0;
+  for (auto const& c : cross) {
+    auto const builds = c.build_ids.size();
+    if (builds == 0) { continue; }  // nothing to be a fraction of
+    auto const n = std::min(c.probe_ids.size(), c.probe_paired_count.size());
+    for (std::size_t i = 0; i < n; ++i) {
+      auto const it = probe_bytes.find(c.probe_ids[i]);
+      // No size recorded: the non-blocking read lost its race; a later pairing retries it.
+      if (it == probe_bytes.end()) { continue; }
+      // Multiply before dividing to keep the truncation at the end. k <= B and both are batch
+      // counts, so the product cannot overflow for any realistic batch size.
+      weighted += it->second * c.probe_paired_count[i] / builds;
+    }
+  }
+  return weighted;
+}
+
 cross_schedule_pair next_cross_schedule_pair(std::vector<partition_cross_schedule>& cross,
                                              bool probe_finished,
                                              bool build_finished)
@@ -830,6 +852,74 @@ partition_strategy compute_hash_join_partition_strategy(uint64_t total_bytes,
                              : (is_mark && num_gpus <= 1) ? 1
                                                           : natural;
   return {num_partitions, broadcast, build_probe};
+}
+
+std::optional<std::size_t> sirius_physical_hash_join::consumed_primary_input_bytes() const
+{
+  // Read the predicate rather than latching it. The port map is immutable after repository
+  // wiring, so this is a lock-free lookup plus an atomic load, and a cached flag would lag the
+  // poll that observed the build finishing — leaving the drain phase reporting nullopt.
+  auto const* build = try_get_port("build");
+  if (build == nullptr || !build->src_pipeline || !build->src_pipeline->is_pipeline_finished()) {
+    return std::nullopt;
+  }
+  // Unpublished BEFORE weighted: a publish between the two reads then shows the same bytes in
+  // both, over-counting the denominator and biasing the ratio low. The other order could drop
+  // them from both and inflate it. See _unpublished_probe_bytes.
+  auto const unpublished = _unpublished_probe_bytes.load(std::memory_order_acquire);
+  // A batch is either paired or consumed whole, never both, so the totals sum cleanly.
+  return _whole_probe_bytes.load(std::memory_order_relaxed) +
+         _weighted_probe_bytes.load(std::memory_order_relaxed) + unpublished;
+}
+
+void sirius_physical_hash_join::publish_weighted_probe_bytes(bool build_finished)
+{
+  // Unreadable until the build side finishes, so skip the walk while probe batches stream in.
+  if (!build_finished) { return; }
+  // op_state_mutex (held by the caller) -> _probe_bytes_mutex, and nothing here waits on a batch
+  // lock, so the nesting cannot form a cycle.
+  std::lock_guard<std::mutex> lg(_probe_bytes_mutex);
+  _weighted_probe_bytes.store(pairing_weighted_probe_bytes(_cross, _probe_batch_bytes),
+                              std::memory_order_relaxed);
+  // Released after the store above, so a reader that sees zero here also sees the new weights.
+  _unpublished_probe_bytes.store(0, std::memory_order_release);
+}
+
+void sirius_physical_hash_join::record_probe_batch_bytes(uint64_t batch_id, std::size_t bytes)
+{
+  std::lock_guard<std::mutex> lg(_probe_bytes_mutex);
+  // Already counted whole — an orphan survivor, or a BUILD_PROBE pop. Weighting it too would
+  // count it twice.
+  if (_counted_probe_batch_ids.contains(batch_id)) { return; }
+  if (_probe_batch_bytes.try_emplace(batch_id, bytes).second) {
+    _unpublished_probe_bytes.fetch_add(bytes, std::memory_order_release);
+  }
+}
+
+void sirius_physical_hash_join::note_probe_bytes_counted(uint64_t batch_id, std::size_t bytes)
+{
+  std::lock_guard<std::mutex> lg(_probe_bytes_mutex);
+  if (!_counted_probe_batch_ids.insert(batch_id).second) { return; }
+  _whole_probe_bytes.fetch_add(bytes, std::memory_order_relaxed);
+}
+
+void sirius_physical_hash_join::note_probe_bytes(
+  const std::shared_ptr<cucascade::data_batch>& batch)
+{
+  if (!batch) { return; }
+  {
+    std::lock_guard<std::mutex> lg(_probe_bytes_mutex);
+    if (_probe_batch_bytes.contains(batch->get_batch_id())) { return; }
+  }
+  // Non-blocking because this runs under op_state_mutex: a concurrent downgrade holds the batch's
+  // exclusive lock for a whole tier conversion, and blocking would stall every task-creation call
+  // on this join for the duration (memory_prefetcher.cpp documents the same hazard). Losing the
+  // race just leaves the size unrecorded; the batch's next pairing retries it, and execute()
+  // backstops the batch that has no next pairing.
+  auto ro = batch->try_to_read_only();
+  if (!ro || ro->get_data() == nullptr) { return; }
+  auto const bytes = ro->get_data()->get_uncompressed_data_size_in_bytes();
+  record_probe_batch_bytes(batch->get_batch_id(), bytes);
 }
 
 partition_strategy sirius_physical_hash_join::get_partition_strategy(
@@ -1093,6 +1183,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
     std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
     input_batch.push_back(probe_port->repo->pop_next_data_batch(p));
     input_batch.push_back(build_port->repo->pop_next_data_batch(p));
+    // Probe bytes are counted in execute(), off a blocking accessor: this pop is the batch's only
+    // sighting, so a non-blocking read here could lose it to a downgrade for good.
     _partition_build_states[p].build_state.store(BUILD_HASH_TABLE_STATE::SCHEDULED,
                                                  std::memory_order_release);
     // Every task of partition p (this build+first-probe and all later probe-only tasks) shares the
@@ -1110,6 +1202,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
     std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
     auto batch = probe_port->repo->pop_next_data_batch(p);
     if (batch) {
+      // Counted in execute(), as above.
       input_batch.push_back(std::move(batch));
     } else {
       SIRIUS_LOG_WARN(
@@ -1212,6 +1305,9 @@ std::pair<bool, bool> sirius_physical_hash_join::refresh_cross_schedule()
       port->repo->pop_data_batch_by_id(d.batch_id, d.partition);
     }
   }
+
+  // Covers polls that claim no pair; a claim republishes for itself, after its increment.
+  publish_weighted_probe_bytes(build_finished);
   return {probe_finished, build_finished};
 }
 
@@ -1253,6 +1349,16 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
         std::to_string(step.partition) + " of operator " + std::to_string(this->get_operator_id()));
     }
 
+    // Every pairing, not just the first: note_probe_bytes dedups by batch id, and its size read
+    // is non-blocking, so a later pairing retries a batch whose first attempt lost the try-lock.
+    // execute() backstops the batch that has no later pairing.
+    note_probe_bytes(probe_batch);
+
+    // next_cross_schedule_pair has now bumped this batch's paired count, which the store inside
+    // refresh_cross_schedule ran too early to see. Republishing before the task is handed out
+    // below keeps the denominator ahead of the numerator.
+    publish_weighted_probe_bytes(finished.second);
+
     std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
     input_batch.reserve(2);
     input_batch.push_back(std::move(probe_batch));  // [0] = probe / "default" / left
@@ -1285,6 +1391,16 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
     {
       auto present_ro = present_batch->to_read_only();
       ms              = present_ro.get_memory_space();
+      // An orphaned probe batch is consumed here without ever being paired, so no later sighting
+      // exists to retry a missed count. Count it from this accessor — already being taken for the
+      // memory space — rather than through note_probe_bytes, whose non-blocking read could lose
+      // the batch outright.
+      if (!orphan.present_is_build) {
+        if (auto const* data = present_ro.get_data(); data != nullptr) {
+          note_probe_bytes_counted(present_batch->get_batch_id(),
+                                   data->get_uncompressed_data_size_in_bytes());
+        }
+      }
     }
     if (!ms) {
       throw std::runtime_error(
@@ -1690,6 +1806,20 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
   cudf::table_view left_full, right_full;
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_indices, right_indices;
 
+  // Cross-schedule backstop, off an accessor already materialized with a blocking read: the size
+  // read at claim time is non-blocking, and a batch paired only once (every join type but INNER
+  // pins the build whole) has no later pairing to retry on, so a lost race would drop it from the
+  // denominator for good. Runs before the task records output, so the denominator still leads;
+  // ids the schedule does not track are inert. Takes _probe_bytes_mutex and NOT op_state_mutex —
+  // see the member declaration. The next refresh republishes.
+  if (_join_mode != HASH_JOIN_MODE::BUILD_PROBE && !input_batches.empty()) {
+    if (auto const* probe_data = input_batches[0].get_data(); probe_data != nullptr) {
+      auto const probe_id    = input_batches[0].get_batch_id();
+      auto const probe_bytes = probe_data->get_uncompressed_data_size_in_bytes();
+      record_probe_batch_bytes(probe_id, probe_bytes);
+    }
+  }
+
   if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
     // Each partition owns one hash table. The incoming batch is tagged with its partition index
     // (get_next_task_input_data_for_build_probe), which selects the per-partition slot; the
@@ -1714,6 +1844,21 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         std::to_string(this->get_operator_id()));
     }
     auto& slot = _partition_build_states[partition];
+
+    // Count the probe batch ([0] in both shapes: SCHEDULED probe+build, BUILT probe-only) here
+    // rather than at pop time, where BUILD_PROBE sees it once and a lost try-lock under-counts it
+    // for good. This accessor was already materialized with a blocking to_read_only() for the join
+    // itself, so the size read cannot lose. Dedup still applies: an OOM-rescheduled task re-enters
+    // execute() with the same batch (create_rescheduled_task) and would otherwise count it twice.
+    // note_probe_bytes_counted takes only _probe_bytes_mutex: we hold batch locks here, and the
+    // broadcast slot cleanup blocks on a batch lock under op_state_mutex, so taking that one here
+    // would invert the order.
+    if (!input_batches.empty()) {
+      if (auto const* probe_data = input_batches[0].get_data(); probe_data != nullptr) {
+        note_probe_bytes_counted(input_batches[0].get_batch_id(),
+                                 probe_data->get_uncompressed_data_size_in_bytes());
+      }
+    }
 
     if (slot.build_state.load(std::memory_order_acquire) == BUILD_HASH_TABLE_STATE::SCHEDULED) {
       if (input_batches.size() != 2) {

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -231,18 +231,28 @@ void sirius_physical_operator::add_port(std::string_view port_id, std::unique_pt
   ports[std::string(port_id)] = raw;
 }
 
-sirius_physical_operator::port* sirius_physical_operator::get_port(std::string_view port_id)
+sirius_physical_operator::port* sirius_physical_operator::try_get_port(std::string_view port_id)
 {
   auto it = ports.find(std::string(port_id));
-  if (it == ports.end()) {
-    std::string ports_string = "";
-    for (auto& [port_name, port_ptr] : ports) {
-      ports_string += port_name + ", ";
-    }
-    throw internal_exception("Port " + std::string(port_id) + " not found in operator " +
-                             get_name() + " existing ports are: " + ports_string);
+  return it == ports.end() ? nullptr : it->second;
+}
+
+const sirius_physical_operator::port* sirius_physical_operator::try_get_port(
+  std::string_view port_id) const
+{
+  auto it = ports.find(std::string(port_id));
+  return it == ports.end() ? nullptr : it->second;
+}
+
+sirius_physical_operator::port* sirius_physical_operator::get_port(std::string_view port_id)
+{
+  if (auto* found = try_get_port(port_id); found != nullptr) { return found; }
+  std::string ports_string = "";
+  for (auto& [port_name, port_ptr] : ports) {
+    ports_string += port_name + ", ";
   }
-  return it->second;
+  throw internal_exception("Port " + std::string(port_id) + " not found in operator " + get_name() +
+                           " existing ports are: " + ports_string);
 }
 
 void sirius_physical_operator::sink(const operator_data& output_data, rmm::cuda_stream_view stream)

--- a/src/pipeline/data_size_estimator.cpp
+++ b/src/pipeline/data_size_estimator.cpp
@@ -29,12 +29,17 @@ namespace pipeline {
 
 namespace {
 
+// A port carries bytes only with a repository behind it and a pipeline producing into it.
+bool carries_data(const op::sirius_physical_operator::port* p)
+{
+  return p != nullptr && p->repo != nullptr && p->src_pipeline;
+}
+
 op::sirius_physical_operator::port* resolve_data_port(op::sirius_physical_operator& op,
                                                       std::string_view id)
 {
   auto* p = op.try_get_port(id);
-  if (p == nullptr || p->repo == nullptr || !p->src_pipeline) { return nullptr; }
-  return p;
+  return carries_data(p) ? p : nullptr;
 }
 
 struct producer_scan {
@@ -52,9 +57,9 @@ producer_scan scan_producer_pipelines(sirius_pipeline& pipeline)
   auto collect_from = [&](op::sirius_physical_operator* candidate) {
     if (candidate == nullptr) { return; }
     result.output_capped |= candidate->caps_pipeline_output();
-    for (auto port_id : candidate->get_port_ids()) {
-      auto* p = resolve_data_port(*candidate, port_id);
-      if (p == nullptr) { continue; }
+    for (auto const& owned : candidate->get_ports()) {
+      auto* p = owned.get();
+      if (!carries_data(p)) { continue; }
       if (std::find(seen.begin(), seen.end(), p) != seen.end()) { continue; }
       seen.push_back(p);
       if (result.count == 0) { result.first = p->src_pipeline.get(); }
@@ -93,9 +98,12 @@ std::optional<data_size_estimate> apply_pipeline_ratio(const history_totals& tot
   auto const scaled = scale_bytes_checked(input.bytes, trust_measured ? *totals.ratio() : 1.0);
   if (!scaled.has_value()) { return std::nullopt; }
   return data_size_estimate{
-    .bytes = *scaled,
+    // Floor at the bytes already emitted: the ratio is measured over eligible tasks only, so
+    // output from zero-basis and resumed tasks is invisible to it.
+    .bytes = std::max(*scaled, totals.output_bytes),
     .exact = false,
-    .hops  = input.hops,
+    // One more ratio now stands between the anchor and this answer.
+    .hops = input.hops + 1,
     // A substituted unit ratio contributes no measured support.
     .ratio_samples = trust_measured ? weaker_sample_count(input.ratio_samples, totals.ratio_records)
                                     : input.ratio_samples,
@@ -117,12 +125,12 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
     if (totals.output_records == 0) {
       // No tasks means exact empty output; created tasks with no records lost measurement.
       if (pipeline.get_tasks_created() != 0) { return std::nullopt; }
-      return data_size_estimate{.bytes = 0, .exact = true, .hops = hops};
+      return data_size_estimate{.bytes = 0, .exact = true, .hops = 0};
     }
     return data_size_estimate{
       .bytes = totals.output_bytes,
       .exact = true,
-      .hops  = hops,
+      .hops  = 0,
     };
   }
 
@@ -159,9 +167,11 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
     auto const scaled = scale_bytes_checked(upstream->bytes, ratio);
     if (!scaled.has_value()) { return std::nullopt; }
     return data_size_estimate{
-      .bytes           = *scaled,
+      // Floored as above: consumed primary bytes are deliberately over-counted, so the projection
+      // can fall below the bytes already emitted.
+      .bytes           = std::max(*scaled, totals.output_bytes),
       .exact           = false,
-      .hops            = upstream->hops,
+      .hops            = upstream->hops + 1,
       .ratio_samples   = weaker_sample_count(upstream->ratio_samples, totals.output_records),
       .planner_derived = upstream->planner_derived,
     };
@@ -175,7 +185,7 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
     if (auto input_bytes = source->total_source_input_bytes()) {
       return apply_pipeline_ratio(
         pipeline.get_memory_history().totals(),
-        data_size_estimate{.bytes = *input_bytes, .exact = true, .hops = hops},
+        data_size_estimate{.bytes = *input_bytes, .exact = true, .hops = 0},
         options);
     }
     // A source-output estimate is also the pipeline output only for a lone source. Scaling it
@@ -183,8 +193,13 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
     if (pipeline.get_sink().get() == source) {
       // GPU scan cardinality projection is planner-derived.
       if (auto output_bytes = source->total_source_output_bytes()) {
-        return data_size_estimate{
-          .bytes = *output_bytes, .exact = false, .hops = hops, .planner_derived = true};
+        // The source floors this at its own emitted bytes; the pipeline's recorded output is a
+        // second, independently measured lower bound on the same total.
+        auto const totals = pipeline.get_memory_history().totals();
+        return data_size_estimate{.bytes           = std::max(*output_bytes, totals.output_bytes),
+                                  .exact           = false,
+                                  .hops            = 0,
+                                  .planner_derived = true};
       }
     }
     return std::nullopt;

--- a/src/pipeline/data_size_estimator.cpp
+++ b/src/pipeline/data_size_estimator.cpp
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "pipeline/data_size_estimator.hpp"
+
+#include "op/sirius_physical_operator.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+namespace sirius {
+namespace pipeline {
+
+namespace {
+
+/// The port @p id on @p op if it carries data from a producer, else nullptr. Folds the three
+/// conditions every caller here needs: the name must exist (get_port throws, and a throw escaping
+/// into get_next_task_hint is not recoverable), the port must carry bytes rather than being a
+/// dependency-only edge (null repo), and it must have a producing pipeline to walk into.
+op::sirius_physical_operator::port* resolve_data_port(op::sirius_physical_operator& op,
+                                                      std::string_view id)
+{
+  auto* p = op.try_get_port(id);
+  if (p == nullptr || p->repo == nullptr || !p->src_pipeline) { return nullptr; }
+  return p;
+}
+
+/// How many distinct data-carrying producer pipelines feed a pipeline, and (when there is
+/// exactly one) which. See @ref scan_producer_pipelines.
+struct producer_scan {
+  std::size_t count      = 0;
+  sirius_pipeline* first = nullptr;
+};
+
+/**
+ * @brief Count the data-carrying ports feeding @p pipeline and identify the first producer.
+ *
+ * Mirrors sirius_pipeline::get_ingress_ports_info, which returns the producer *operator* where
+ * we need the producer *pipeline*. `operators` spans source through sink after is_ready(), so
+ * walking it reaches build-side ports on the sink too. Dependency-only ports (null repo) and
+ * ports with no producer carry no bytes and are skipped.
+ *
+ * Deduplication by port pointer is load-bearing: `operators` normally already contains the
+ * source and sink, so without it every port is seen twice and a single-input pipeline reads as
+ * a fan-in. A reserved vector rather than a hash set because this runs on every task-creation
+ * poll until a projection latches, and port counts are single digits.
+ */
+producer_scan scan_producer_pipelines(sirius_pipeline& pipeline)
+{
+  producer_scan result;
+  std::vector<const op::sirius_physical_operator::port*> seen;
+  seen.reserve(4);
+
+  auto collect_from = [&](op::sirius_physical_operator* candidate) {
+    if (candidate == nullptr) { return; }
+    for (auto port_id : candidate->get_port_ids()) {
+      auto* p = resolve_data_port(*candidate, port_id);
+      if (p == nullptr) { continue; }
+      if (std::find(seen.begin(), seen.end(), p) != seen.end()) { continue; }
+      seen.push_back(p);
+      if (result.count == 0) { result.first = p->src_pipeline.get(); }
+      result.count++;
+    }
+  };
+
+  for (auto& op_ref : pipeline.get_operators()) {
+    collect_from(&op_ref.get());
+  }
+  // Sink-only pipelines leave `operators` empty; source/sink are still set.
+  collect_from(pipeline.get_source().get());
+  collect_from(pipeline.get_sink().get());
+
+  return result;
+}
+
+/// The weaker of two sample counts, treating 0 as "no ratio applied yet" rather than as a
+/// minimum. Keeps @ref data_size_estimate::ratio_samples reporting the least-supported ratio in
+/// the chain.
+std::size_t weaker_sample_count(std::size_t so_far, std::size_t candidate)
+{
+  return so_far == 0 ? candidate : std::min(so_far, candidate);
+}
+
+/// Whether @p totals has enough support for its measured ratio to be used. Too few completed
+/// tasks is treated exactly as "no ratio yet": the number exists but one or two batches are not
+/// evidence that it describes the pipeline, and the consumer latches the first estimate it is
+/// given rather than refining it later. See size_estimate_options::min_ratio_samples.
+bool ratio_is_trusted(const history_totals& totals, const size_estimate_options& options)
+{
+  return totals.ratio_records >= options.min_ratio_samples && totals.ratio().has_value();
+}
+
+/// Scale @p input by the pipeline ratio in @p totals. Takes the snapshot rather than the pipeline
+/// so callers that already needed it (to decide whether recursing is worthwhile) do not lock the
+/// history a second time.
+std::optional<data_size_estimate> apply_pipeline_ratio(const history_totals& totals,
+                                                       data_size_estimate input,
+                                                       const size_estimate_options& options)
+{
+  bool const trust_measured = ratio_is_trusted(totals, options);
+  if (!trust_measured && !options.assume_unit_ratio) { return std::nullopt; }
+
+  auto const scaled = scale_bytes_checked(input.bytes, trust_measured ? *totals.ratio() : 1.0);
+  if (!scaled.has_value()) { return std::nullopt; }
+  return data_size_estimate{
+    .bytes = *scaled,
+    // A learned ratio is a projection, never a measurement.
+    .exact = false,
+    .hops  = input.hops,
+    // A substituted unit ratio carries no measured support, so it neither adds to nor weakens
+    // the chain's: pass the upstream count through rather than overwriting it, which would
+    // discard a real measurement made further up.
+    .ratio_samples = trust_measured ? weaker_sample_count(input.ratio_samples, totals.ratio_records)
+                                    : input.ratio_samples,
+    // Applying a measured ratio does not launder a planner guess out of the chain. This is the
+    // hop where ratio_samples stops being able to carry the provenance, hence the separate flag.
+    .planner_derived = input.planner_derived,
+  };
+}
+
+std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pipeline,
+                                                             const size_estimate_options& options,
+                                                             std::size_t hops)
+{
+  if (hops > options.max_hops) { return std::nullopt; }
+
+  // 1. Finished pipeline: its recorded output total is the exact answer. Safe to read because
+  //    pipeline_finished is only set once tasks_created == tasks_completed, and each task
+  //    records its output before mark_task_completed() runs in its destructor.
+  //
+  //    Keyed on output_records, not the ratio terms: a task with no a-priori size estimate has
+  //    a zero basis and cannot inform a ratio, but its emitted bytes are still part of this
+  //    pipeline's total. Reporting only the ratio-eligible tasks' output would under-count while
+  //    still claiming exact.
+  //
+  //    With no record at all, the task count separates two lookalikes: a pipeline that finished
+  //    having never created a task had nothing to measure and emitted exactly zero (an empty
+  //    scan), while one whose tasks all recorded nothing lost the measurement and yields nullopt.
+  //    Finishing needs the source exhausted, not just the counters balanced, so 0 == 0 here means
+  //    drained rather than not yet started.
+  if (pipeline.is_pipeline_finished()) {
+    auto const totals = pipeline.get_memory_history().totals();
+    if (totals.output_records == 0) {
+      if (pipeline.get_tasks_created() != 0) { return std::nullopt; }
+      return data_size_estimate{.bytes = 0, .exact = true, .hops = hops};
+    }
+    return data_size_estimate{
+      .bytes = totals.output_bytes,
+      .exact = true,
+      .hops  = hops,
+    };
+  }
+
+  auto const producers = scan_producer_pipelines(pipeline);
+
+  // 2. Fan-in: follow only the source's nominated primary input.
+  //
+  //    The recorded input_basis is unusable here: a STANDARD join pairs each probe batch with
+  //    every build batch and borrows rather than pops, so the same bytes enter input_basis once
+  //    per pairing and its sum is a cross product, not an input volume. Ask the operator for
+  //    probe bytes counted once per batch instead, and divide the pipeline's output total by
+  //    that. An operator nominating no primary port (CTE, delim-join wiring) yields nullopt.
+  if (producers.count > 1) {
+    auto* source = pipeline.get_source().get();
+    if (source == nullptr) { return std::nullopt; }
+
+    auto const port_name = source->primary_input_port();
+    if (!port_name.has_value()) { return std::nullopt; }
+
+    // Numerator before denominator, and keep it that way: `consumed` advances at task creation,
+    // output_bytes at completion, and both only grow, so reading output first guarantees every
+    // task in it is also in the `consumed` read below. The other order lets a task created and
+    // completed between the two reads contribute output with no matching input, inflating the
+    // ratio; this way the residual error is always low, which is the direction the in-flight bias
+    // already points. See min_fan_in_ratio_samples and data-size-estimation.md.
+    auto const totals = pipeline.get_memory_history().totals();
+    if (totals.output_records < options.min_fan_in_ratio_samples) { return std::nullopt; }
+
+    auto const consumed = source->consumed_primary_input_bytes();
+    if (!consumed.has_value() || *consumed == 0) { return std::nullopt; }
+
+    // A bad nomination is "no estimate", not an error: the name comes from an operator override.
+    auto* p = resolve_data_port(*source, *port_name);
+    if (p == nullptr) { return std::nullopt; }
+
+    auto upstream = estimate_output_bytes_impl(*p->src_pipeline, options, hops + 1);
+    if (!upstream.has_value()) { return std::nullopt; }
+
+    // The residual in-flight bias is bounded by min_fan_in_ratio_samples above, not corrected
+    // here: task counts cannot be used to discount it, because `consumed` does not advance once
+    // per task. See data-size-estimation.md.
+    auto const ratio  = static_cast<double>(totals.output_bytes) / static_cast<double>(*consumed);
+    auto const scaled = scale_bytes_checked(upstream->bytes, ratio);
+    if (!scaled.has_value()) { return std::nullopt; }
+    return data_size_estimate{
+      .bytes           = *scaled,
+      .exact           = false,
+      .hops            = upstream->hops,
+      .ratio_samples   = weaker_sample_count(upstream->ratio_samples, totals.output_records),
+      .planner_derived = upstream->planner_derived,
+    };
+  }
+
+  // 3. Leaf: anchor on what the source operator knows about its own total.
+  if (producers.count == 0) {
+    auto* source = pipeline.get_source().get();
+    if (source == nullptr) { return std::nullopt; }
+
+    if (auto input_bytes = source->total_source_input_bytes()) {
+      return apply_pipeline_ratio(
+        pipeline.get_memory_history().totals(),
+        data_size_estimate{.bytes = *input_bytes, .exact = true, .hops = hops},
+        options);
+    }
+    // Already an output quantity — returned as-is. Scaling it by the pipeline ratio (which is
+    // derived from pre-filter input bytes) would double-count filter selectivity.
+    // The one planner-derived number in the design (GPU_SCAN's estimated_cardinality projection),
+    // so this is where the provenance flag originates.
+    if (auto output_bytes = source->total_source_output_bytes()) {
+      return data_size_estimate{
+        .bytes = *output_bytes, .exact = false, .hops = hops, .planner_derived = true};
+    }
+    return std::nullopt;
+  }
+
+  // 4. Single producer: recurse, then scale by this pipeline's ratio.
+  //
+  //    Check our own ratio first. Without it the whole multi-hop walk runs and is then thrown
+  //    away whenever the ratio would be rejected — a cost paid on every task-creation poll early
+  //    in a query, which is exactly when no pipeline has enough samples yet. The fan-in branch
+  //    gates the same way.
+  if (producers.first == nullptr) { return std::nullopt; }
+  auto const totals = pipeline.get_memory_history().totals();
+  if (!ratio_is_trusted(totals, options) && !options.assume_unit_ratio) { return std::nullopt; }
+
+  auto upstream = estimate_output_bytes_impl(*producers.first, options, hops + 1);
+  if (!upstream.has_value()) { return std::nullopt; }
+  return apply_pipeline_ratio(totals, *upstream, options);
+}
+
+}  // namespace
+
+std::optional<std::size_t> scale_bytes_checked(std::size_t bytes, double ratio)
+{
+  if (!std::isfinite(ratio) || ratio < 0.0) { return std::nullopt; }
+  double const scaled = static_cast<double>(bytes) * ratio;
+  if (!std::isfinite(scaled) || scaled < 0.0) { return std::nullopt; }
+  // llround is UB outside the integral type's range; cap at what a byte count can represent.
+  constexpr double kMaxBytes = 9.0e18;  // comfortably inside both int64 and size_t
+  if (scaled > kMaxBytes) { return std::nullopt; }
+  return static_cast<std::size_t>(std::llround(scaled));
+}
+
+std::optional<std::size_t> project_source_output_bytes(std::size_t estimated_cardinality,
+                                                       std::size_t emitted_rows,
+                                                       std::size_t emitted_bytes)
+{
+  // Nothing measured yet: there is no bytes/row factor, and no floor either.
+  if (emitted_rows == 0 || emitted_bytes == 0) { return std::nullopt; }
+  auto const bytes_per_row = static_cast<double>(emitted_bytes) / static_cast<double>(emitted_rows);
+  auto const projected     = scale_bytes_checked(estimated_cardinality, bytes_per_row);
+  if (!projected.has_value()) { return std::nullopt; }
+  // Bytes already emitted are a hard lower bound on the total. See the header for why this fires
+  // in practice rather than only in principle.
+  return std::max(*projected, emitted_bytes);
+}
+
+std::optional<data_size_estimate> estimate_pipeline_total_output_bytes(
+  sirius_pipeline& pipeline, size_estimate_options options)
+{
+  return estimate_output_bytes_impl(pipeline, options, /*hops=*/0);
+}
+
+std::optional<data_size_estimate> estimate_port_total_input_bytes(op::sirius_physical_operator& op,
+                                                                  std::string_view port_id,
+                                                                  size_estimate_options options)
+{
+  auto* p = resolve_data_port(op, port_id);
+  if (p == nullptr) { return std::nullopt; }
+  return estimate_pipeline_total_output_bytes(*p->src_pipeline, options);
+}
+
+}  // namespace pipeline
+}  // namespace sirius

--- a/src/pipeline/data_size_estimator.cpp
+++ b/src/pipeline/data_size_estimator.cpp
@@ -148,13 +148,30 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
     auto const port_name = source->primary_input_port();
     if (!port_name.has_value()) { return std::nullopt; }
 
-    // Read output before consumed input. A concurrent task can then only bias the ratio low;
-    // reversing the order could omit its input while including its output.
+    // Probe bytes enter `consumed` when a task starts but its output lands only at completion,
+    // so any task active while the two terms are read can drive the ratio toward zero — a
+    // byte-weighted skew no task-count floor bounds. Bracket the reads with the task counters:
+    // equal before and unchanged after means no task ran at any point in between, so both terms
+    // cover exactly the same tasks.
+    auto const completed_before = pipeline.get_tasks_completed();
+    auto const created_before   = pipeline.get_tasks_created();
+    if (completed_before != created_before) { return std::nullopt; }
+
     auto const totals = pipeline.get_memory_history().totals();
-    if (totals.output_records < options.min_fan_in_ratio_samples) { return std::nullopt; }
+    // Never estimable with zero completed outputs, whatever the configured floor.
+    if (totals.output_records == 0 || totals.output_records < options.min_fan_in_ratio_samples) {
+      return std::nullopt;
+    }
 
     auto const consumed = source->consumed_primary_input_bytes();
     if (!consumed.has_value() || *consumed == 0) { return std::nullopt; }
+
+    // Unchanged, not merely equal: a task that started and completed mid-read would leave the
+    // counters equal while its bytes sit in `consumed` with no matching output in `totals`.
+    if (pipeline.get_tasks_completed() != completed_before ||
+        pipeline.get_tasks_created() != created_before) {
+      return std::nullopt;
+    }
 
     auto* p = resolve_data_port(*source, *port_name);
     if (p == nullptr) { return std::nullopt; }
@@ -162,7 +179,6 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
     auto upstream = estimate_output_bytes_impl(*p->src_pipeline, options, hops + 1);
     if (!upstream.has_value()) { return std::nullopt; }
 
-    // The sample threshold bounds the conservative in-flight bias.
     auto const ratio  = static_cast<double>(totals.output_bytes) / static_cast<double>(*consumed);
     auto const scaled = scale_bytes_checked(upstream->bytes, ratio);
     if (!scaled.has_value()) { return std::nullopt; }

--- a/src/pipeline/data_size_estimator.cpp
+++ b/src/pipeline/data_size_estimator.cpp
@@ -29,10 +29,6 @@ namespace pipeline {
 
 namespace {
 
-/// The port @p id on @p op if it carries data from a producer, else nullptr. Folds the three
-/// conditions every caller here needs: the name must exist (get_port throws, and a throw escaping
-/// into get_next_task_hint is not recoverable), the port must carry bytes rather than being a
-/// dependency-only edge (null repo), and it must have a producing pipeline to walk into.
 op::sirius_physical_operator::port* resolve_data_port(op::sirius_physical_operator& op,
                                                       std::string_view id)
 {
@@ -41,27 +37,12 @@ op::sirius_physical_operator::port* resolve_data_port(op::sirius_physical_operat
   return p;
 }
 
-/// How many distinct data-carrying producer pipelines feed a pipeline, and (when there is
-/// exactly one) which. Also reports whether any operator caps the pipeline's output, since that
-/// falls out of the same walk. See @ref scan_producer_pipelines.
 struct producer_scan {
   std::size_t count      = 0;
   sirius_pipeline* first = nullptr;
   bool output_capped     = false;
 };
 
-/**
- * @brief Count the data-carrying ports feeding @p pipeline and identify the first producer.
- *
- * Mirrors sirius_pipeline::get_ingress_ports_info, which returns the producer *operator* where
- * we need the producer *pipeline*. `operators` spans source through sink after is_ready(), so
- * walking it reaches build-side ports on the sink too. Dependency-only ports (null repo) and
- * ports with no producer carry no bytes and are skipped.
- *
- * Deduplication by port pointer is load-bearing: `operators` normally already contains the
- * source and sink, so without it every port is seen twice and a single-input pipeline reads as
- * a fan-in.
- */
 producer_scan scan_producer_pipelines(sirius_pipeline& pipeline)
 {
   producer_scan result;
@@ -70,7 +51,6 @@ producer_scan scan_producer_pipelines(sirius_pipeline& pipeline)
 
   auto collect_from = [&](op::sirius_physical_operator* candidate) {
     if (candidate == nullptr) { return; }
-    // Idempotent, so unlike the port count this needs no dedup against a second visit.
     result.output_capped |= candidate->caps_pipeline_output();
     for (auto port_id : candidate->get_port_ids()) {
       auto* p = resolve_data_port(*candidate, port_id);
@@ -85,33 +65,24 @@ producer_scan scan_producer_pipelines(sirius_pipeline& pipeline)
   for (auto& op_ref : pipeline.get_operators()) {
     collect_from(&op_ref.get());
   }
-  // Sink-only pipelines leave `operators` empty; source/sink are still set.
+  // Source and sink may also appear in get_operators(); port-pointer dedup prevents false fan-in.
   collect_from(pipeline.get_source().get());
   collect_from(pipeline.get_sink().get());
 
   return result;
 }
 
-/// The weaker of two sample counts, treating 0 as "no ratio applied yet" rather than as a
-/// minimum. Keeps @ref data_size_estimate::ratio_samples reporting the least-supported ratio in
-/// the chain.
+// Zero means no ratio has been applied yet.
 std::size_t weaker_sample_count(std::size_t so_far, std::size_t candidate)
 {
   return so_far == 0 ? candidate : std::min(so_far, candidate);
 }
 
-/// Whether @p totals has enough support for its measured ratio to be used. Too few completed
-/// tasks is treated exactly as "no ratio yet": the number exists but one or two batches are not
-/// evidence that it describes the pipeline, and the consumer latches the first estimate it is
-/// given rather than refining it later. See size_estimate_options::min_ratio_samples.
 bool ratio_is_trusted(const history_totals& totals, const size_estimate_options& options)
 {
   return totals.ratio_records >= options.min_ratio_samples && totals.ratio().has_value();
 }
 
-/// Scale @p input by the pipeline ratio in @p totals. Takes the snapshot rather than the pipeline
-/// so callers that already needed it (to decide whether recursing is worthwhile) do not lock the
-/// history a second time.
 std::optional<data_size_estimate> apply_pipeline_ratio(const history_totals& totals,
                                                        data_size_estimate input,
                                                        const size_estimate_options& options)
@@ -123,16 +94,12 @@ std::optional<data_size_estimate> apply_pipeline_ratio(const history_totals& tot
   if (!scaled.has_value()) { return std::nullopt; }
   return data_size_estimate{
     .bytes = *scaled,
-    // A learned ratio is a projection, never a measurement.
     .exact = false,
     .hops  = input.hops,
-    // A substituted unit ratio carries no measured support, so it neither adds to nor weakens
-    // the chain's: pass the upstream count through rather than overwriting it, which would
-    // discard a real measurement made further up.
+    // A substituted unit ratio contributes no measured support.
     .ratio_samples = trust_measured ? weaker_sample_count(input.ratio_samples, totals.ratio_records)
                                     : input.ratio_samples,
-    // Applying a measured ratio does not launder a planner guess out of the chain. This is the
-    // hop where ratio_samples stops being able to carry the provenance, hence the separate flag.
+    // Preserve planner-derived provenance through measured ratios.
     .planner_derived = input.planner_derived,
   };
 }
@@ -143,23 +110,12 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
 {
   if (hops > options.max_hops) { return std::nullopt; }
 
-  // 1. Finished pipeline: its recorded output total is the exact answer. Safe to read because
-  //    pipeline_finished is only set once tasks_created == tasks_completed, and each task
-  //    records its output before mark_task_completed() runs in its destructor.
-  //
-  //    Keyed on output_records, not the ratio terms: a task with no a-priori size estimate has
-  //    a zero basis and cannot inform a ratio, but its emitted bytes are still part of this
-  //    pipeline's total. Reporting only the ratio-eligible tasks' output would under-count while
-  //    still claiming exact.
-  //
-  //    With no record at all, the task count separates two lookalikes: a pipeline that finished
-  //    having never created a task had nothing to measure and emitted exactly zero (an empty
-  //    scan), while one whose tasks all recorded nothing lost the measurement and yields nullopt.
-  //    Finishing needs the source exhausted, not just the counters balanced, so 0 == 0 here means
-  //    drained rather than not yet started.
+  // Finished implies every task recorded output before completion. Use all output records, not
+  // only ratio-eligible records, because zero-basis tasks may still emit bytes.
   if (pipeline.is_pipeline_finished()) {
     auto const totals = pipeline.get_memory_history().totals();
     if (totals.output_records == 0) {
+      // No tasks means exact empty output; created tasks with no records lost measurement.
       if (pipeline.get_tasks_created() != 0) { return std::nullopt; }
       return data_size_estimate{.bytes = 0, .exact = true, .hops = hops};
     }
@@ -172,18 +128,11 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
 
   auto const producers = scan_producer_pipelines(pipeline);
 
-  // A row limit caps output independently of input, so no measured ratio extrapolates through
-  // this pipeline: output stops growing once the cap binds, and the pipeline may then finish
-  // without its source draining. Only the finished case above can answer for it.
+  // A capped pipeline may stop before draining its source, so only a finished total is valid.
   if (producers.output_capped) { return std::nullopt; }
 
-  // 2. Fan-in: follow only the source's nominated primary input.
-  //
-  //    The recorded input_basis is unusable here: a STANDARD join pairs each probe batch with
-  //    every build batch and borrows rather than pops, so the same bytes enter input_basis once
-  //    per pairing and its sum is a cross product, not an input volume. Ask the operator for
-  //    probe bytes counted once per batch instead, and divide the pipeline's output total by
-  //    that. An operator nominating no primary port (CTE, delim-join wiring) yields nullopt.
+  // Fan-in: use the nominated primary input. A join's task-level input basis repeats borrowed
+  // batches across pairings and is not an input volume.
   if (producers.count > 1) {
     auto* source = pipeline.get_source().get();
     if (source == nullptr) { return std::nullopt; }
@@ -191,28 +140,21 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
     auto const port_name = source->primary_input_port();
     if (!port_name.has_value()) { return std::nullopt; }
 
-    // Numerator before denominator, and keep it that way: `consumed` advances at task creation,
-    // output_bytes at completion, and both only grow, so reading output first guarantees every
-    // task in it is also in the `consumed` read below. The other order lets a task created and
-    // completed between the two reads contribute output with no matching input, inflating the
-    // ratio; this way the residual error is always low, which is the direction the in-flight bias
-    // already points. See min_fan_in_ratio_samples and data-size-estimation.md.
+    // Read output before consumed input. A concurrent task can then only bias the ratio low;
+    // reversing the order could omit its input while including its output.
     auto const totals = pipeline.get_memory_history().totals();
     if (totals.output_records < options.min_fan_in_ratio_samples) { return std::nullopt; }
 
     auto const consumed = source->consumed_primary_input_bytes();
     if (!consumed.has_value() || *consumed == 0) { return std::nullopt; }
 
-    // A bad nomination is "no estimate", not an error: the name comes from an operator override.
     auto* p = resolve_data_port(*source, *port_name);
     if (p == nullptr) { return std::nullopt; }
 
     auto upstream = estimate_output_bytes_impl(*p->src_pipeline, options, hops + 1);
     if (!upstream.has_value()) { return std::nullopt; }
 
-    // The residual in-flight bias is bounded by min_fan_in_ratio_samples above, not corrected
-    // here: task counts cannot be used to discount it, because `consumed` does not advance once
-    // per task. See data-size-estimation.md.
+    // The sample threshold bounds the conservative in-flight bias.
     auto const ratio  = static_cast<double>(totals.output_bytes) / static_cast<double>(*consumed);
     auto const scaled = scale_bytes_checked(upstream->bytes, ratio);
     if (!scaled.has_value()) { return std::nullopt; }
@@ -225,7 +167,7 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
     };
   }
 
-  // 3. Leaf: anchor on what the source operator knows about its own total.
+  // Leaf: anchor on the source's total.
   if (producers.count == 0) {
     auto* source = pipeline.get_source().get();
     if (source == nullptr) { return std::nullopt; }
@@ -236,15 +178,10 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
         data_size_estimate{.bytes = *input_bytes, .exact = true, .hops = hops},
         options);
     }
-    // An output quantity for the *source*, which is the pipeline's output only when nothing
-    // follows it — get_operators() runs source..sink, so source == sink means a lone operator.
-    // With a FILTER, PROJECTION or DYNAMIC_FILTER in between there is no way to bridge the gap:
-    // the pipeline ratio's denominator is pre-filter input bytes, so scaling by it would count
-    // the scan's pushdown selectivity twice, and returning it unscaled would ignore the
-    // downstream operators entirely.
+    // A source-output estimate is also the pipeline output only for a lone source. Scaling it
+    // through downstream operators would double-count scan pushdown selectivity.
     if (pipeline.get_sink().get() == source) {
-      // GPU_SCAN's estimated_cardinality projection, the one planner-derived number in the
-      // design, so this is where the provenance flag originates.
+      // GPU scan cardinality projection is planner-derived.
       if (auto output_bytes = source->total_source_output_bytes()) {
         return data_size_estimate{
           .bytes = *output_bytes, .exact = false, .hops = hops, .planner_derived = true};
@@ -253,12 +190,7 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
     return std::nullopt;
   }
 
-  // 4. Single producer: recurse, then scale by this pipeline's ratio.
-  //
-  //    Check our own ratio first. Without it the whole multi-hop walk runs and is then thrown
-  //    away whenever the ratio would be rejected — a cost paid on every task-creation poll early
-  //    in a query, which is exactly when no pipeline has enough samples yet. The fan-in branch
-  //    gates the same way.
+  // Single producer: reject an unsupported local ratio before recursing.
   if (producers.first == nullptr) { return std::nullopt; }
   auto const totals = pipeline.get_memory_history().totals();
   if (!ratio_is_trusted(totals, options) && !options.assume_unit_ratio) { return std::nullopt; }
@@ -275,8 +207,8 @@ std::optional<std::size_t> scale_bytes_checked(std::size_t bytes, double ratio)
   if (!std::isfinite(ratio) || ratio < 0.0) { return std::nullopt; }
   double const scaled = static_cast<double>(bytes) * ratio;
   if (!std::isfinite(scaled) || scaled < 0.0) { return std::nullopt; }
-  // llround is UB outside the integral type's range; cap at what a byte count can represent.
-  constexpr double kMaxBytes = 9.0e18;  // comfortably inside both int64 and size_t
+  // llround is undefined outside the integral type's range.
+  constexpr double kMaxBytes = 9.0e18;  // Within int64_t and size_t.
   if (scaled > kMaxBytes) { return std::nullopt; }
   return static_cast<std::size_t>(std::llround(scaled));
 }
@@ -285,13 +217,11 @@ std::optional<std::size_t> project_source_output_bytes(std::size_t estimated_car
                                                        std::size_t emitted_rows,
                                                        std::size_t emitted_bytes)
 {
-  // Nothing measured yet: there is no bytes/row factor, and no floor either.
   if (emitted_rows == 0 || emitted_bytes == 0) { return std::nullopt; }
   auto const bytes_per_row = static_cast<double>(emitted_bytes) / static_cast<double>(emitted_rows);
   auto const projected     = scale_bytes_checked(estimated_cardinality, bytes_per_row);
   if (!projected.has_value()) { return std::nullopt; }
-  // Bytes already emitted are a hard lower bound on the total. See the header for why this fires
-  // in practice rather than only in principle.
+  // Emitted bytes are a hard lower bound on the total.
   return std::max(*projected, emitted_bytes);
 }
 

--- a/src/pipeline/data_size_estimator.cpp
+++ b/src/pipeline/data_size_estimator.cpp
@@ -42,10 +42,12 @@ op::sirius_physical_operator::port* resolve_data_port(op::sirius_physical_operat
 }
 
 /// How many distinct data-carrying producer pipelines feed a pipeline, and (when there is
-/// exactly one) which. See @ref scan_producer_pipelines.
+/// exactly one) which. Also reports whether any operator caps the pipeline's output, since that
+/// falls out of the same walk. See @ref scan_producer_pipelines.
 struct producer_scan {
   std::size_t count      = 0;
   sirius_pipeline* first = nullptr;
+  bool output_capped     = false;
 };
 
 /**
@@ -69,6 +71,8 @@ producer_scan scan_producer_pipelines(sirius_pipeline& pipeline)
 
   auto collect_from = [&](op::sirius_physical_operator* candidate) {
     if (candidate == nullptr) { return; }
+    // Idempotent, so unlike the port count this needs no dedup against a second visit.
+    result.output_capped |= candidate->caps_pipeline_output();
     for (auto port_id : candidate->get_port_ids()) {
       auto* p = resolve_data_port(*candidate, port_id);
       if (p == nullptr) { continue; }
@@ -169,6 +173,11 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
 
   auto const producers = scan_producer_pipelines(pipeline);
 
+  // A row limit caps output independently of input, so no measured ratio extrapolates through
+  // this pipeline: output stops growing once the cap binds, and the pipeline may then finish
+  // without its source draining. Only the finished case above can answer for it.
+  if (producers.output_capped) { return std::nullopt; }
+
   // 2. Fan-in: follow only the source's nominated primary input.
   //
   //    The recorded input_basis is unusable here: a STANDARD join pairs each probe batch with
@@ -228,13 +237,19 @@ std::optional<data_size_estimate> estimate_output_bytes_impl(sirius_pipeline& pi
         data_size_estimate{.bytes = *input_bytes, .exact = true, .hops = hops},
         options);
     }
-    // Already an output quantity — returned as-is. Scaling it by the pipeline ratio (which is
-    // derived from pre-filter input bytes) would double-count filter selectivity.
-    // The one planner-derived number in the design (GPU_SCAN's estimated_cardinality projection),
-    // so this is where the provenance flag originates.
-    if (auto output_bytes = source->total_source_output_bytes()) {
-      return data_size_estimate{
-        .bytes = *output_bytes, .exact = false, .hops = hops, .planner_derived = true};
+    // An output quantity for the *source*, which is the pipeline's output only when nothing
+    // follows it — get_operators() runs source..sink, so source == sink means a lone operator.
+    // With a FILTER, PROJECTION or DYNAMIC_FILTER in between there is no way to bridge the gap:
+    // the pipeline ratio's denominator is pre-filter input bytes, so scaling by it would count
+    // the scan's pushdown selectivity twice, and returning it unscaled would ignore the
+    // downstream operators entirely.
+    if (pipeline.get_sink().get() == source) {
+      // GPU_SCAN's estimated_cardinality projection, the one planner-derived number in the
+      // design, so this is where the provenance flag originates.
+      if (auto output_bytes = source->total_source_output_bytes()) {
+        return data_size_estimate{
+          .bytes = *output_bytes, .exact = false, .hops = hops, .planner_derived = true};
+      }
     }
     return std::nullopt;
   }

--- a/src/pipeline/data_size_estimator.cpp
+++ b/src/pipeline/data_size_estimator.cpp
@@ -60,8 +60,7 @@ struct producer_scan {
  *
  * Deduplication by port pointer is load-bearing: `operators` normally already contains the
  * source and sink, so without it every port is seen twice and a single-input pipeline reads as
- * a fan-in. A reserved vector rather than a hash set because this runs on every task-creation
- * poll until a projection latches, and port counts are single digits.
+ * a fan-in.
  */
 producer_scan scan_producer_pipelines(sirius_pipeline& pipeline)
 {

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -624,7 +624,12 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
       }
     }
     auto& global = _global_state->cast<gpu_pipeline_task_global_state>();
-    global.get_memory_history().record({input_basis, peak_bytes, output_bytes});
+    // A task resumed mid-pipeline restarted from intermediate data, so its input_basis is not in
+    // pipeline-input units and must not feed the aggregate ratio (it still informs per-task peak
+    // estimation). The prepare_for_processing OOM path rethrows the ORIGINAL input at index 0 and
+    // stays eligible.
+    bool const ratio_eligible = local_state._start_operator_index == 0;
+    global.get_memory_history().record({input_basis, peak_bytes, output_bytes, ratio_eligible});
     SIRIUS_LOG_TRACE(
       "[GPU:{}] Pipeline {}: memory history record - task={}, input_basis={}, output_bytes={}, "
       "reservation_bytes={}, peak_bytes={}, peak_bytes_to_materialize_input={}",

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -624,10 +624,8 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
       }
     }
     auto& global = _global_state->cast<gpu_pipeline_task_global_state>();
-    // A task resumed mid-pipeline restarted from intermediate data, so its input_basis is not in
-    // pipeline-input units and must not feed the aggregate ratio (it still informs per-task peak
-    // estimation). The prepare_for_processing OOM path rethrows the ORIGINAL input at index 0 and
-    // stays eligible.
+    // Mid-pipeline retries use intermediate input units and must not affect the aggregate ratio.
+    // An OOM before processing restarts at index 0 with the original input and remains eligible.
     bool const ratio_eligible = local_state._start_operator_index == 0;
     global.get_memory_history().record({input_basis, peak_bytes, output_bytes, ratio_eligible});
     SIRIUS_LOG_TRACE(

--- a/src/scan_manager/split_connector.cpp
+++ b/src/scan_manager/split_connector.cpp
@@ -34,6 +34,9 @@ void split_connector::push_split(std::unique_ptr<op::operator_data> split)
   {
     std::lock_guard<std::mutex> lock(_mutex);
     assert(!_closed && "push_split after close() is forbidden");
+    // Accumulate before the move: this is the one choke point every split passes through,
+    // so it is where the scan's total input basis is tallied for the data size estimator.
+    _discovered_bytes += split->get_estimated_size_in_bytes();
     _splits.push_back(std::move(split));
   }
   _cv.notify_one();
@@ -104,6 +107,18 @@ std::vector<std::shared_ptr<::cucascade::data_batch>> split_connector::peek_resi
     }
   }
   return batches;
+}
+
+bool split_connector::is_discovery_complete() const
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  return _closed;
+}
+
+std::size_t split_connector::discovered_bytes() const
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  return _discovered_bytes;
 }
 
 }  // namespace sirius::scan_manager

--- a/src/scan_manager/split_connector.cpp
+++ b/src/scan_manager/split_connector.cpp
@@ -31,11 +31,13 @@ split_connector::~split_connector() = default;
 void split_connector::push_split(std::unique_ptr<op::operator_data> split)
 {
   assert(split != nullptr && "push_split requires a non-null split");
+  // Sized before the lock: a cached-batch split reads its size through the blocking
+  // to_read_only(), which waits on a downgrade — under _mutex that stalls every consumer pop.
+  auto const split_bytes = split->get_estimated_size_in_bytes();
   {
     std::lock_guard<std::mutex> lock(_mutex);
     assert(!_closed && "push_split after close() is forbidden");
     // A zero estimate means unknown, not empty; latch it so the total remains conservative.
-    auto const split_bytes = split->get_estimated_size_in_bytes();
     _discovered_bytes += split_bytes;
     _has_unsized_splits = _has_unsized_splits || split_bytes == 0;
     _splits.push_back(std::move(split));

--- a/src/scan_manager/split_connector.cpp
+++ b/src/scan_manager/split_connector.cpp
@@ -34,10 +34,7 @@ void split_connector::push_split(std::unique_ptr<op::operator_data> split)
   {
     std::lock_guard<std::mutex> lock(_mutex);
     assert(!_closed && "push_split after close() is forbidden");
-    // Accumulate before the move: this is the one choke point every split passes through,
-    // so it is where the scan's total input basis is tallied for the data size estimator.
-    // A zero here is "no a-priori estimate", not "no data", so it is latched rather than
-    // silently folded into the sum.
+    // A zero estimate means unknown, not empty; latch it so the total remains conservative.
     auto const split_bytes = split->get_estimated_size_in_bytes();
     _discovered_bytes += split_bytes;
     _has_unsized_splits = _has_unsized_splits || split_bytes == 0;

--- a/src/scan_manager/split_connector.cpp
+++ b/src/scan_manager/split_connector.cpp
@@ -36,7 +36,11 @@ void split_connector::push_split(std::unique_ptr<op::operator_data> split)
     assert(!_closed && "push_split after close() is forbidden");
     // Accumulate before the move: this is the one choke point every split passes through,
     // so it is where the scan's total input basis is tallied for the data size estimator.
-    _discovered_bytes += split->get_estimated_size_in_bytes();
+    // A zero here is "no a-priori estimate", not "no data", so it is latched rather than
+    // silently folded into the sum.
+    auto const split_bytes = split->get_estimated_size_in_bytes();
+    _discovered_bytes += split_bytes;
+    _has_unsized_splits = _has_unsized_splits || split_bytes == 0;
     _splits.push_back(std::move(split));
   }
   _cv.notify_one();
@@ -119,6 +123,12 @@ std::size_t split_connector::discovered_bytes() const
 {
   std::lock_guard<std::mutex> lock(_mutex);
   return _discovered_bytes;
+}
+
+bool split_connector::has_unsized_splits() const
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  return _has_unsized_splits;
 }
 
 }  // namespace sirius::scan_manager

--- a/test/cpp/operator/test_build_probe_scheduling.cpp
+++ b/test/cpp/operator/test_build_probe_scheduling.cpp
@@ -31,11 +31,14 @@
 #include "helper/type_conversions.hpp"
 #include "op/sirius_physical_hash_join.hpp"
 #include "op/sirius_physical_partition.hpp"
+#include "pipeline/pipeline_build_context.hpp"
+#include "pipeline/sirius_pipeline.hpp"
 
 #include <catch.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
 #include <duckdb/planner/operator/logical_comparison_join.hpp>
 
+#include <memory>
 #include <stdexcept>
 #include <string_view>
 
@@ -595,6 +598,27 @@ TEST_CASE("broadcast_slots_to_discard - a DESTROYED slot is not rediscarded", "[
 
 namespace {
 
+// Exposes the protected mode knob and byte recorder so BUILD_PROBE accounting is testable
+// without a wired pipeline graph.
+struct exposed_hash_join : sirius::op::sirius_physical_hash_join {
+  using sirius_physical_hash_join::note_probe_bytes_counted;
+  using sirius_physical_hash_join::sirius_physical_hash_join;
+
+  void set_build_probe_mode() { _join_mode = sirius::op::HASH_JOIN_MODE::BUILD_PROBE; }
+};
+
+/// Pipeline whose finished state is set directly.
+struct finishable_pipeline : sirius::pipeline::sirius_pipeline {
+  explicit finishable_pipeline(const sirius::pipeline::pipeline_build_context& ctx)
+    : sirius_pipeline(ctx)
+  {
+  }
+
+  [[nodiscard]] bool is_pipeline_finished() const override { return finished; }
+
+  bool finished = false;
+};
+
 // LogicalComparisonJoin must outlive hash_join, which references op.types.
 struct nomination_fixture {
   duckdb::unique_ptr<duckdb::LogicalComparisonJoin> logical_join;
@@ -621,7 +645,7 @@ nomination_fixture make_join(duckdb::JoinType join_type)
   cond.comparison = duckdb::ExpressionType::COMPARE_EQUAL;
   conditions.push_back(std::move(cond));
 
-  f.hash_join = duckdb::make_uniq<sirius::op::sirius_physical_hash_join>(
+  f.hash_join = duckdb::make_uniq<exposed_hash_join>(
     *f.logical_join,
     make_child(),
     make_child(),
@@ -663,4 +687,47 @@ TEST_CASE("primary_input_port - build-streaming joins nominate nothing",
     INFO("join type: " << duckdb::JoinTypeToString(jt));
     REQUIRE_FALSE(f.hash_join->primary_input_port().has_value());
   }
+}
+
+TEST_CASE("probe bytes are only unweighted in BUILD_PROBE mode",
+          "[hash_join][size_estimation][unit]")
+{
+  // Only BUILD_PROBE, which pops each probe batch exactly once, reports a consumed total; a
+  // cross schedule would need pairing weights, which are biased under skew.
+  auto f = make_join(duckdb::JoinType::INNER);
+  CHECK_FALSE(f.hash_join->probe_bytes_are_unweighted());
+  // consumed_primary_input_bytes() gates on the same predicate before anything else.
+  CHECK_FALSE(f.hash_join->consumed_primary_input_bytes().has_value());
+}
+
+TEST_CASE("BUILD_PROBE byte accounting - accumulation, dedup, and the build-finished gate",
+          "[hash_join][size_estimation][unit]")
+{
+  auto f  = make_join(duckdb::JoinType::INNER);
+  auto* j = static_cast<exposed_hash_join*>(f.hash_join.get());
+  j->set_build_probe_mode();
+  REQUIRE(j->probe_bytes_are_unweighted());
+
+  // Without a build port the accessor cannot know the build side finished.
+  CHECK_FALSE(j->consumed_primary_input_bytes().has_value());
+
+  sirius::pipeline::pipeline_build_context ctx{nullptr, true};
+  auto build_pipeline = duckdb::make_shared_ptr<finishable_pipeline>(ctx);
+  auto port           = std::make_unique<sirius::op::sirius_physical_operator::port>();
+  port->src_pipeline  = build_pipeline;
+  j->add_port("build", std::move(port));
+
+  // Bytes recorded while the build side is still open are withheld...
+  j->note_probe_bytes_counted(7, 1000);
+  j->note_probe_bytes_counted(8, 500);
+  CHECK_FALSE(j->consumed_primary_input_bytes().has_value());
+
+  // ...and reported once it finishes.
+  build_pipeline->finished = true;
+  CHECK(j->consumed_primary_input_bytes() == std::size_t{1500});
+
+  // An OOM-rescheduled task re-enters execute() with the same batch id; the dedup counts it once,
+  // whatever size the retry reads.
+  j->note_probe_bytes_counted(7, 999999);
+  CHECK(j->consumed_primary_input_bytes() == std::size_t{1500});
 }

--- a/test/cpp/operator/test_build_probe_scheduling.cpp
+++ b/test/cpp/operator/test_build_probe_scheduling.cpp
@@ -27,12 +27,17 @@
 // (interleaved per-partition build/probe sequencing) deterministically. The
 // end-to-end multi-GPU behavior is covered by the [mgpu] integration tests.
 
+#include "expression/join_condition.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_hash_join.hpp"
 #include "op/sirius_physical_partition.hpp"
 
 #include <catch.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <duckdb/planner/operator/logical_comparison_join.hpp>
 
 #include <stdexcept>
+#include <string_view>
 
 using sirius::op::broadcast_slots_to_discard;
 using sirius::op::BUILD_HASH_TABLE_STATE;
@@ -582,4 +587,84 @@ TEST_CASE("broadcast_slots_to_discard - a DESTROYED slot is not rediscarded", "[
     },
     /*probe_finished=*/true);
   REQUIRE(d == std::vector<std::size_t>{1});
+}
+
+//===----------------------------------------------------------------------===//
+// primary_input_port — which side the size estimator may extrapolate along
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+// A bare hash join of a given type: single-INTEGER children joined on col0, no pipelines, no GPU.
+// The LogicalComparisonJoin must outlive the join, which holds op.types by reference.
+struct nomination_fixture {
+  duckdb::unique_ptr<duckdb::LogicalComparisonJoin> logical_join;
+  duckdb::unique_ptr<sirius::op::sirius_physical_hash_join> hash_join;
+};
+
+nomination_fixture make_join(duckdb::JoinType join_type)
+{
+  nomination_fixture f;
+  f.logical_join        = duckdb::make_uniq<duckdb::LogicalComparisonJoin>(join_type);
+  f.logical_join->types = {duckdb::LogicalType::INTEGER, duckdb::LogicalType::INTEGER};
+
+  auto make_child = [] {
+    return duckdb::make_uniq<sirius::op::sirius_physical_operator>(
+      sirius::op::SiriusPhysicalOperatorType::PROJECTION,
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      0);
+  };
+
+  duckdb::vector<duckdb::JoinCondition> conditions;
+  duckdb::JoinCondition cond;
+  cond.left  = duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
+  cond.right = duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
+  cond.comparison = duckdb::ExpressionType::COMPARE_EQUAL;
+  conditions.push_back(std::move(cond));
+
+  f.hash_join = duckdb::make_uniq<sirius::op::sirius_physical_hash_join>(
+    *f.logical_join,
+    make_child(),
+    make_child(),
+    sirius::wrap_join_conditions(std::move(conditions)),
+    join_type,
+    duckdb::vector<duckdb::idx_t>{},
+    duckdb::vector<duckdb::idx_t>{},
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{}),
+    1000,
+    nullptr);
+  return f;
+}
+
+}  // namespace
+
+TEST_CASE("primary_input_port - probe-streaming joins nominate the probe side",
+          "[hash_join][size_estimation][unit]")
+{
+  // These fold the build to one whole batch and stream the probe, so probe volume is the open
+  // axis the estimator's ratio extrapolates along.
+  for (auto const jt : {duckdb::JoinType::INNER,
+                        duckdb::JoinType::LEFT,
+                        duckdb::JoinType::SEMI,
+                        duckdb::JoinType::ANTI,
+                        duckdb::JoinType::MARK}) {
+    auto f = make_join(jt);
+    INFO("join type: " << duckdb::JoinTypeToString(jt));
+    REQUIRE(f.hash_join->primary_input_port() == std::string_view{"default"});
+  }
+}
+
+TEST_CASE("primary_input_port - build-streaming joins nominate nothing",
+          "[hash_join][size_estimation][unit]")
+{
+  // RIGHT-family pins the probe whole and streams the build; OUTER pins both. With no open axis
+  // to extrapolate along, nominating nothing yields no estimate instead of an under-estimate.
+  for (auto const jt : {duckdb::JoinType::RIGHT,
+                        duckdb::JoinType::RIGHT_SEMI,
+                        duckdb::JoinType::RIGHT_ANTI,
+                        duckdb::JoinType::OUTER}) {
+    auto f = make_join(jt);
+    INFO("join type: " << duckdb::JoinTypeToString(jt));
+    REQUIRE_FALSE(f.hash_join->primary_input_port().has_value());
+  }
 }

--- a/test/cpp/operator/test_build_probe_scheduling.cpp
+++ b/test/cpp/operator/test_build_probe_scheduling.cpp
@@ -595,8 +595,7 @@ TEST_CASE("broadcast_slots_to_discard - a DESTROYED slot is not rediscarded", "[
 
 namespace {
 
-// A bare hash join of a given type: single-INTEGER children joined on col0, no pipelines, no GPU.
-// The LogicalComparisonJoin must outlive the join, which holds op.types by reference.
+// LogicalComparisonJoin must outlive hash_join, which references op.types.
 struct nomination_fixture {
   duckdb::unique_ptr<duckdb::LogicalComparisonJoin> logical_join;
   duckdb::unique_ptr<sirius::op::sirius_physical_hash_join> hash_join;
@@ -640,8 +639,7 @@ nomination_fixture make_join(duckdb::JoinType join_type)
 TEST_CASE("primary_input_port - probe-streaming joins nominate the probe side",
           "[hash_join][size_estimation][unit]")
 {
-  // These fold the build to one whole batch and stream the probe, so probe volume is the open
-  // axis the estimator's ratio extrapolates along.
+  // Probe volume is the estimator's open axis for these joins.
   for (auto const jt : {duckdb::JoinType::INNER,
                         duckdb::JoinType::LEFT,
                         duckdb::JoinType::SEMI,
@@ -656,8 +654,7 @@ TEST_CASE("primary_input_port - probe-streaming joins nominate the probe side",
 TEST_CASE("primary_input_port - build-streaming joins nominate nothing",
           "[hash_join][size_estimation][unit]")
 {
-  // RIGHT-family pins the probe whole and streams the build; OUTER pins both. With no open axis
-  // to extrapolate along, nominating nothing yields no estimate instead of an under-estimate.
+  // These joins have no probe-side axis the estimator can safely extrapolate.
   for (auto const jt : {duckdb::JoinType::RIGHT,
                         duckdb::JoinType::RIGHT_SEMI,
                         duckdb::JoinType::RIGHT_ANTI,

--- a/test/cpp/operator/test_build_probe_scheduling.cpp
+++ b/test/cpp/operator/test_build_probe_scheduling.cpp
@@ -631,8 +631,7 @@ nomination_fixture make_join(duckdb::JoinType join_type)
     duckdb::vector<duckdb::idx_t>{},
     duckdb::vector<duckdb::idx_t>{},
     sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{}),
-    1000,
-    nullptr);
+    1000);
   return f;
 }
 

--- a/test/cpp/operator/test_cross_schedule.cpp
+++ b/test/cpp/operator/test_cross_schedule.cpp
@@ -324,6 +324,43 @@ TEST_CASE("pairing-weighted probe bytes ignore a partition with no build batch y
   CHECK(pairing_weighted_probe_bytes(cross, bytes) == 0);
 }
 
+TEST_CASE("pairing-weighted probe bytes read far below the probe volume mid-sweep",
+          "[cross_schedule][size_estimation]")
+{
+  // Why STANDARD / MIXED_JOIN withhold the fan-in estimate: next_cross_schedule_pair sweeps one
+  // probe batch across every build batch before starting the next, so at the 16-pairing sample
+  // gate the denominator holds 16% of one batch's bytes while the numerator may already be near
+  // its final value — the ratio overstates by the same factor.
+  std::vector<uint64_t> builds;
+  builds.reserve(100);
+  for (uint64_t i = 0; i < 100; ++i) {
+    builds.push_back(10 + i);
+  }
+  std::vector<partition_cross_schedule> cross{make_partition({1}, builds)};
+  std::unordered_map<uint64_t, std::size_t> bytes{{1, 1000}};
+
+  cross[0].probe_paired_count[0] = 16;
+  CHECK(pairing_weighted_probe_bytes(cross, bytes) == 160);
+  // The gap closes only when the sweep completes, which is the end of the join.
+  cross[0].probe_paired_count[0] = 100;
+  CHECK(pairing_weighted_probe_bytes(cross, bytes) == 1000);
+}
+
+TEST_CASE("pairing-weighted probe bytes lag the probe side while later batches wait",
+          "[cross_schedule][size_estimation]")
+{
+  // The same sweep order leaves later probe batches at zero weight, so the denominator describes
+  // the opening batches rather than the probe side as a whole.
+  std::vector<partition_cross_schedule> cross{make_partition({1, 2, 3}, {10, 11})};
+  std::unordered_map<uint64_t, std::size_t> bytes{{1, 900}, {2, 900}, {3, 900}};
+  cross[0].probe_paired_count[0] = 2;  // swept
+  cross[0].probe_paired_count[1] = 1;  // mid-sweep
+  cross[0].probe_paired_count[2] = 0;  // untouched
+
+  // 900 + 450 + 0 against 2700 bytes actually queued.
+  CHECK(pairing_weighted_probe_bytes(cross, bytes) == 1350);
+}
+
 TEST_CASE("pairing-weighted probe bytes skip a batch whose size was never recorded",
           "[cross_schedule][size_estimation]")
 {

--- a/test/cpp/operator/test_cross_schedule.cpp
+++ b/test/cpp/operator/test_cross_schedule.cpp
@@ -289,8 +289,7 @@ TEST_CASE("orphan path does nothing when both sides are empty", "[cross_schedule
 TEST_CASE("pairing-weighted probe bytes track how far through its pairings a batch is",
           "[cross_schedule][size_estimation]")
 {
-  // One probe batch of 1000 bytes against 4 build batches: charging the full 1000 up front would
-  // make the ratio read a quarter of true until the last pairing lands.
+  // Weighting by completed pairings prevents early ratios from reading artificially low.
   std::vector<partition_cross_schedule> cross{make_partition({7}, {10, 11, 12, 13})};
   std::unordered_map<uint64_t, std::size_t> bytes{{7, 1000}};
 
@@ -299,7 +298,6 @@ TEST_CASE("pairing-weighted probe bytes track how far through its pairings a bat
   CHECK(pairing_weighted_probe_bytes(cross, bytes) == 250);
   cross[0].probe_paired_count[0] = 2;
   CHECK(pairing_weighted_probe_bytes(cross, bytes) == 500);
-  // Fully paired: worth exactly its own size.
   cross[0].probe_paired_count[0] = 4;
   CHECK(pairing_weighted_probe_bytes(cross, bytes) == 1000);
 }
@@ -310,9 +308,9 @@ TEST_CASE("pairing-weighted probe bytes sum across batches and partitions",
   std::vector<partition_cross_schedule> cross{make_partition({1, 2}, {10, 11}),
                                               make_partition({3}, {20, 21, 22, 23})};
   std::unordered_map<uint64_t, std::size_t> bytes{{1, 800}, {2, 400}, {3, 1000}};
-  cross[0].probe_paired_count[0] = 2;  // 800 x 2/2 = 800
-  cross[0].probe_paired_count[1] = 1;  // 400 x 1/2 = 200
-  cross[1].probe_paired_count[0] = 3;  // 1000 x 3/4 = 750
+  cross[0].probe_paired_count[0] = 2;
+  cross[0].probe_paired_count[1] = 1;
+  cross[1].probe_paired_count[0] = 3;
 
   CHECK(pairing_weighted_probe_bytes(cross, bytes) == 1750);
 }
@@ -320,7 +318,6 @@ TEST_CASE("pairing-weighted probe bytes sum across batches and partitions",
 TEST_CASE("pairing-weighted probe bytes ignore a partition with no build batch yet",
           "[cross_schedule][size_estimation]")
 {
-  // Nothing to be a fraction of; such a batch reaches the total whole via the orphan path.
   std::vector<partition_cross_schedule> cross{make_partition({1}, {})};
   std::unordered_map<uint64_t, std::size_t> bytes{{1, 500}};
 
@@ -330,10 +327,9 @@ TEST_CASE("pairing-weighted probe bytes ignore a partition with no build batch y
 TEST_CASE("pairing-weighted probe bytes skip a batch whose size was never recorded",
           "[cross_schedule][size_estimation]")
 {
-  // The non-blocking size read lost its race; the batch contributes once a later pairing records
-  // it.
+  // Simulate a non-blocking size read that could not acquire the batch lock.
   std::vector<partition_cross_schedule> cross{make_partition({1, 2}, {10})};
-  std::unordered_map<uint64_t, std::size_t> bytes{{1, 600}};  // no entry for batch 2
+  std::unordered_map<uint64_t, std::size_t> bytes{{1, 600}};
   cross[0].probe_paired_count[0] = 1;
   cross[0].probe_paired_count[1] = 1;
 

--- a/test/cpp/operator/test_cross_schedule.cpp
+++ b/test/cpp/operator/test_cross_schedule.cpp
@@ -32,7 +32,9 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
+#include <unordered_map>
 #include <vector>
 
 using sirius::op::collect_cross_schedule_discards;
@@ -42,6 +44,7 @@ using sirius::op::cross_schedule_orphan;
 using sirius::op::has_pending_cross_orphan;
 using sirius::op::next_cross_schedule_orphan;
 using sirius::op::next_cross_schedule_pair;
+using sirius::op::pairing_weighted_probe_bytes;
 using sirius::op::partition_cross_schedule;
 using sirius::op::peek_cross_schedule_kind;
 
@@ -277,4 +280,62 @@ TEST_CASE("orphan path does nothing when both sides are empty", "[cross_schedule
   REQUIRE_FALSE(has_pending_cross_orphan(cross, true, true));
   REQUIRE_FALSE(next_cross_schedule_orphan(cross, true, true).found);
   REQUIRE(peek_cross_schedule_kind(cross, true, true) == cross_schedule_kind::done);
+}
+
+//===----------------------------------------------------------------------===//
+// pairing_weighted_probe_bytes — the size estimator's denominator
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("pairing-weighted probe bytes track how far through its pairings a batch is",
+          "[cross_schedule][size_estimation]")
+{
+  // One probe batch of 1000 bytes against 4 build batches: charging the full 1000 up front would
+  // make the ratio read a quarter of true until the last pairing lands.
+  std::vector<partition_cross_schedule> cross{make_partition({7}, {10, 11, 12, 13})};
+  std::unordered_map<uint64_t, std::size_t> bytes{{7, 1000}};
+
+  CHECK(pairing_weighted_probe_bytes(cross, bytes) == 0);
+  cross[0].probe_paired_count[0] = 1;
+  CHECK(pairing_weighted_probe_bytes(cross, bytes) == 250);
+  cross[0].probe_paired_count[0] = 2;
+  CHECK(pairing_weighted_probe_bytes(cross, bytes) == 500);
+  // Fully paired: worth exactly its own size.
+  cross[0].probe_paired_count[0] = 4;
+  CHECK(pairing_weighted_probe_bytes(cross, bytes) == 1000);
+}
+
+TEST_CASE("pairing-weighted probe bytes sum across batches and partitions",
+          "[cross_schedule][size_estimation]")
+{
+  std::vector<partition_cross_schedule> cross{make_partition({1, 2}, {10, 11}),
+                                              make_partition({3}, {20, 21, 22, 23})};
+  std::unordered_map<uint64_t, std::size_t> bytes{{1, 800}, {2, 400}, {3, 1000}};
+  cross[0].probe_paired_count[0] = 2;  // 800 x 2/2 = 800
+  cross[0].probe_paired_count[1] = 1;  // 400 x 1/2 = 200
+  cross[1].probe_paired_count[0] = 3;  // 1000 x 3/4 = 750
+
+  CHECK(pairing_weighted_probe_bytes(cross, bytes) == 1750);
+}
+
+TEST_CASE("pairing-weighted probe bytes ignore a partition with no build batch yet",
+          "[cross_schedule][size_estimation]")
+{
+  // Nothing to be a fraction of; such a batch reaches the total whole via the orphan path.
+  std::vector<partition_cross_schedule> cross{make_partition({1}, {})};
+  std::unordered_map<uint64_t, std::size_t> bytes{{1, 500}};
+
+  CHECK(pairing_weighted_probe_bytes(cross, bytes) == 0);
+}
+
+TEST_CASE("pairing-weighted probe bytes skip a batch whose size was never recorded",
+          "[cross_schedule][size_estimation]")
+{
+  // The non-blocking size read lost its race; the batch contributes once a later pairing records
+  // it.
+  std::vector<partition_cross_schedule> cross{make_partition({1, 2}, {10})};
+  std::unordered_map<uint64_t, std::size_t> bytes{{1, 600}};  // no entry for batch 2
+  cross[0].probe_paired_count[0] = 1;
+  cross[0].probe_paired_count[1] = 1;
+
+  CHECK(pairing_weighted_probe_bytes(cross, bytes) == 600);
 }

--- a/test/cpp/pipeline/test_data_size_estimator.cpp
+++ b/test/cpp/pipeline/test_data_size_estimator.cpp
@@ -1,0 +1,855 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "pipeline/data_size_estimator.hpp"
+#include "pipeline/pipeline_build_context.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+
+#include <cucascade/data/data_repository.hpp>
+
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+using sirius::op::MemoryBarrierType;
+using sirius::op::sirius_physical_operator;
+using sirius::op::SiriusPhysicalOperatorType;
+using sirius::pipeline::estimate_pipeline_total_output_bytes;
+using sirius::pipeline::estimate_port_total_input_bytes;
+using sirius::pipeline::pipeline_build_context;
+using sirius::pipeline::sirius_pipeline;
+using sirius::pipeline::sirius_pipeline_build_state;
+using sirius::pipeline::size_estimate_options;
+using sirius::pipeline::task_memory_record;
+
+namespace {
+
+constexpr std::size_t kMiB = 1024ull * 1024ull;
+
+/// Leaf-source stand-in whose two "what is my total?" answers are set per test.
+struct test_source_operator : sirius_physical_operator {
+  test_source_operator() : sirius_physical_operator(SiriusPhysicalOperatorType::PROJECTION, {}, 0)
+  {
+  }
+
+  [[nodiscard]] std::optional<std::size_t> total_source_input_bytes() const override
+  {
+    return input_total;
+  }
+  [[nodiscard]] std::optional<std::size_t> total_source_output_bytes() const override
+  {
+    return output_total;
+  }
+
+  // Fan-in nomination: which port carries the primary (probe-equivalent) input, and how many
+  // bytes have been taken from it. Both unset by default, matching every non-join operator.
+  [[nodiscard]] std::optional<std::string_view> primary_input_port() const override
+  {
+    if (primary_port.empty()) { return std::nullopt; }
+    return std::string_view{primary_port};
+  }
+  [[nodiscard]] std::optional<std::size_t> consumed_primary_input_bytes() const override
+  {
+    // Lets a test observe *when* the denominator is sampled relative to the numerator, by running
+    // side effects at exactly that instant. Unset in every other test.
+    if (on_consumed_read) { on_consumed_read(); }
+    return consumed_primary;
+  }
+
+  std::optional<std::size_t> input_total;
+  std::optional<std::size_t> output_total;
+  std::string primary_port;  ///< empty = nominates none
+  std::optional<std::size_t> consumed_primary;
+  /// Fires as the denominator is read. See the numerator/denominator ordering test.
+  std::function<void()> on_consumed_read;
+};
+
+/// Pipeline whose finished state is set directly, instead of being driven through the task
+/// counters that update_pipeline_status() normally maintains.
+struct test_pipeline : sirius_pipeline {
+  explicit test_pipeline(const pipeline_build_context& ctx) : sirius_pipeline(ctx) {}
+
+  [[nodiscard]] bool is_pipeline_finished() const override { return finished; }
+
+  bool finished = false;
+};
+
+/// Builds a chain/DAG of single-operator pipelines wired through data-carrying ports, mirroring
+/// how the planner wires real pipelines. Each pipeline's operator doubles as source and sink.
+class estimator_dag {
+ public:
+  /// Add a pipeline and return it. `source` is the operator standing in for its leaf source.
+  test_pipeline& add()
+  {
+    auto pipeline = duckdb::make_shared_ptr<test_pipeline>(_ctx);
+    auto op       = std::make_unique<test_source_operator>();
+    op->set_pipeline(pipeline);
+    _bs.set_pipeline_source(*pipeline, *op);
+    _bs.set_pipeline_sink(*pipeline, sirius::optional_ptr<sirius_physical_operator>(op.get()), 0);
+    auto& ref = *pipeline;
+    _ops.push_back(std::move(op));
+    _pipelines.push_back(std::move(pipeline));
+    return ref;
+  }
+
+  /// Wire a data-flow edge from -> to. `with_repo=false` models a dependency-only port.
+  void connect(test_pipeline& from,
+               test_pipeline& to,
+               MemoryBarrierType barrier    = MemoryBarrierType::FULL,
+               bool with_repo               = true,
+               const std::string& port_name = "")
+  {
+    auto* consumer_op = to.get_source().get();
+    auto* producer_op = from.get_sink().get();
+
+    _names.push_back(port_name.empty() ? "e" + std::to_string(_names.size()) : port_name);
+    std::string_view name = _names.back();
+
+    auto port  = std::make_unique<sirius_physical_operator::port>();
+    port->type = barrier;
+    if (with_repo) {
+      _repos.push_back(std::make_unique<cucascade::shared_data_repository>());
+      port->repo = _repos.back().get();
+    } else {
+      port->repo = nullptr;
+    }
+    port->src_pipeline  = shared_for(from);
+    port->dest_pipeline = shared_for(to);
+    consumer_op->add_port(name, std::move(port));
+
+    producer_op->add_next_port_after_sink(
+      sirius_physical_operator::next_port_info{consumer_op, name, uuid::now_v7()});
+  }
+
+  /// The operator standing in as `pipeline`'s leaf source.
+  static test_source_operator& source_of(test_pipeline& pipeline)
+  {
+    return static_cast<test_source_operator&>(*pipeline.get_source());
+  }
+
+ private:
+  duckdb::shared_ptr<sirius_pipeline> shared_for(test_pipeline& pipeline) const
+  {
+    for (const auto& p : _pipelines) {
+      if (p.get() == &pipeline) { return p; }
+    }
+    return nullptr;
+  }
+
+  pipeline_build_context _ctx{nullptr, true};
+  sirius_pipeline_build_state _bs;
+  std::vector<std::unique_ptr<test_source_operator>> _ops;
+  std::vector<std::unique_ptr<cucascade::shared_data_repository>> _repos;
+  std::deque<std::string> _names;  // stable storage backing the port-name string_views
+  std::vector<duckdb::shared_ptr<sirius_pipeline>> _pipelines;
+};
+
+/// Record one completed task on `pipeline`.
+void record_task(test_pipeline& pipeline, std::size_t in_bytes, std::size_t out_bytes)
+{
+  pipeline.get_memory_history().record(task_memory_record{in_bytes, in_bytes * 2, out_bytes});
+}
+
+/// Give `pipeline` a measured output/input ratio backed by `samples` completed tasks.
+///
+/// Defaults to exactly what size_estimate_options::min_ratio_samples requires, so a pipeline
+/// set up this way has a ratio the estimator will trust; cases that are *about* the sample
+/// count pass it explicitly. The bytes are split evenly across the samples, so the aggregate
+/// ratio is `out_bytes / in_bytes` regardless of the count (every value here is a multiple of
+/// kMiB, which divides exactly).
+void record_ratio(test_pipeline& pipeline,
+                  std::size_t in_bytes,
+                  std::size_t out_bytes,
+                  std::size_t samples = size_estimate_options{}.min_ratio_samples)
+{
+  for (std::size_t i = 0; i < samples; ++i) {
+    record_task(pipeline, in_bytes / samples, out_bytes / samples);
+  }
+}
+
+}  // namespace
+
+TEST_CASE("data_size_estimator: a finished pipeline reports its exact recorded output",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer = dag.add();
+  record_ratio(producer, 100 * kMiB, 40 * kMiB);
+  record_ratio(producer, 100 * kMiB, 60 * kMiB);
+  producer.finished = true;
+
+  auto est = estimate_pipeline_total_output_bytes(producer);
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 100 * kMiB);
+  CHECK(est->exact);
+  CHECK(est->hops == 0);
+}
+
+TEST_CASE("data_size_estimator: a finished pipeline whose tasks recorded nothing is unknown",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer    = dag.add();
+  producer.finished = true;
+  // Tasks ran and none recorded output — every one OOM'd. Measurement was attempted and lost, so
+  // reporting 0 would size a large input onto a single partition.
+  producer.mark_task_created();
+  producer.mark_task_created();
+
+  CHECK_FALSE(estimate_pipeline_total_output_bytes(producer).has_value());
+}
+
+TEST_CASE("data_size_estimator: a finished pipeline that never created a task is exactly zero",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer    = dag.add();
+  producer.finished = true;
+  // An empty scan: nothing to measure rather than a measurement that failed. Finishing requires
+  // source exhaustion, not just balanced counters, so zero tasks means drained.
+
+  auto est = estimate_pipeline_total_output_bytes(producer);
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 0);
+  CHECK(est->exact);
+  CHECK(est->hops == 0);
+}
+
+TEST_CASE("data_size_estimator: a finished pipeline counts output from zero-basis tasks",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer = dag.add();
+  // A scan split with no a-priori size estimate reports a zero basis. Its output is still part
+  // of the pipeline's total; omitting it would under-count while still claiming exact.
+  record_task(producer, 100 * kMiB, 40 * kMiB);
+  record_task(producer, 0, 60 * kMiB);
+  producer.finished = true;
+
+  auto est = estimate_pipeline_total_output_bytes(producer);
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 100 * kMiB);
+  CHECK(est->exact);
+}
+
+TEST_CASE("data_size_estimator: a finished pipeline that emitted nothing reports zero, exactly",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer = dag.add();
+  // Distinct from "no evidence": tasks ran and succeeded, they just produced no rows.
+  record_task(producer, 100 * kMiB, 0);
+  producer.finished = true;
+
+  auto est = estimate_pipeline_total_output_bytes(producer);
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 0);
+  CHECK(est->exact);
+}
+
+TEST_CASE("data_size_estimator: an unfinished leaf scales its known total by the measured ratio",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer = dag.add();
+  // The source will feed 1 GiB; the pipeline has so far turned 100 MiB of input into 25 MiB.
+  estimator_dag::source_of(producer).input_total = 1024 * kMiB;
+  record_ratio(producer, 100 * kMiB, 25 * kMiB);
+
+  auto est = estimate_pipeline_total_output_bytes(producer);
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 256 * kMiB);
+  // A learned ratio is a projection even though the leaf total is known exactly.
+  CHECK_FALSE(est->exact);
+}
+
+TEST_CASE("data_size_estimator: no ratio yet means no estimate, unless unit ratio is allowed",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer                                 = dag.add();
+  estimator_dag::source_of(producer).input_total = 512 * kMiB;
+  // No task has completed, so the pipeline has no measured input->output ratio.
+
+  CHECK_FALSE(estimate_pipeline_total_output_bytes(producer).has_value());
+
+  auto est = estimate_pipeline_total_output_bytes(producer,
+                                                  size_estimate_options{
+                                                    .assume_unit_ratio = true,
+                                                  });
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 512 * kMiB);
+  CHECK_FALSE(est->exact);
+}
+
+TEST_CASE("data_size_estimator: a substituted unit ratio claims no measured support",
+          "[data_size_estimator][estimation]")
+{
+  auto const min_samples = size_estimate_options{}.min_ratio_samples;
+  REQUIRE(min_samples > 1);
+
+  estimator_dag dag;
+  auto& scan = dag.add();
+  auto& mid  = dag.add();
+  dag.connect(scan, mid);
+
+  estimator_dag::source_of(scan).input_total = 1024 * kMiB;
+  record_ratio(scan, 100 * kMiB, 100 * kMiB, /*samples=*/8);  // well-supported, ratio 1.0
+  // `mid` has a ratio, but from too few tasks to trust, so 1:1 is substituted for it.
+  record_task(mid, 100 * kMiB, 50 * kMiB);
+
+  auto est = estimate_pipeline_total_output_bytes(mid,
+                                                  size_estimate_options{
+                                                    .assume_unit_ratio = true,
+                                                  });
+  REQUIRE(est.has_value());
+  // The substituted link must not be credited with mid's 1 under-floor record...
+  CHECK(est->ratio_samples != 1);
+  // ...nor zero out the scan's genuine support, which 0 would also confuse with "exact".
+  CHECK(est->ratio_samples == 8);
+  CHECK_FALSE(est->exact);
+  // Substituting 1.0 for mid leaves the scan's 1.0-scaled total unchanged.
+  CHECK(est->bytes == 1024 * kMiB);
+}
+
+TEST_CASE("data_size_estimator: a single-input ratio from too few tasks is not trusted",
+          "[data_size_estimator][estimation]")
+{
+  auto const min_samples = size_estimate_options{}.min_ratio_samples;
+  REQUIRE(min_samples > 1);  // otherwise this case asserts nothing
+
+  estimator_dag dag;
+  auto& producer                                 = dag.add();
+  estimator_dag::source_of(producer).input_total = 1024 * kMiB;
+
+  // One task short of the floor. The ratio exists and is arithmetically usable, but a filter
+  // over clustered data can make a single batch's selectivity nothing like the table's — and
+  // the consumer latches the first estimate it gets, so an unlucky sample is never corrected.
+  for (std::size_t i = 0; i < min_samples - 1; ++i) {
+    record_task(producer, 100 * kMiB, 25 * kMiB);
+  }
+  CHECK_FALSE(estimate_pipeline_total_output_bytes(producer).has_value());
+
+  // An untrusted ratio is treated exactly as no ratio, so the unit-ratio escape still applies
+  // and yields the unscaled source total.
+  auto assumed = estimate_pipeline_total_output_bytes(producer,
+                                                      size_estimate_options{
+                                                        .assume_unit_ratio = true,
+                                                      });
+  REQUIRE(assumed.has_value());
+  CHECK(assumed->bytes == 1024 * kMiB);
+  CHECK_FALSE(assumed->exact);
+
+  // The floor is a knob, not a constant: on the very same history, a caller willing to act on
+  // thinner evidence lowers it and gets the measured ratio applied (1 GiB x 0.25).
+  auto lowered = estimate_pipeline_total_output_bytes(producer,
+                                                      size_estimate_options{
+                                                        .min_ratio_samples = 1,
+                                                      });
+  REQUIRE(lowered.has_value());
+  CHECK(lowered->bytes == 256 * kMiB);
+
+  // One more task clears the default floor, and the same answer arrives without the override.
+  record_task(producer, 100 * kMiB, 25 * kMiB);
+  auto est = estimate_pipeline_total_output_bytes(producer);
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 256 * kMiB);
+  CHECK(est->ratio_samples == min_samples);
+}
+
+TEST_CASE("data_size_estimator: a source that knows nothing yields no estimate",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer = dag.add();
+  record_ratio(producer, 100 * kMiB, 50 * kMiB);
+  // Both source totals stay nullopt — this is the streaming-source case.
+
+  CHECK_FALSE(estimate_pipeline_total_output_bytes(producer).has_value());
+  // A unit ratio does not invent a total that the source cannot supply.
+  CHECK_FALSE(estimate_pipeline_total_output_bytes(producer,
+                                                   size_estimate_options{
+                                                     .assume_unit_ratio = true,
+                                                   })
+                .has_value());
+}
+
+TEST_CASE("data_size_estimator: an output-level source total bypasses the pipeline ratio",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer = dag.add();
+  // Only the post-filter output total is known (the scan's cardinality fallback).
+  estimator_dag::source_of(producer).output_total = 300 * kMiB;
+  // A ratio exists but must NOT be applied: it is derived from pre-filter input bytes, so
+  // using it here would count filter selectivity twice.
+  record_ratio(producer, 100 * kMiB, 10 * kMiB);
+
+  auto est = estimate_pipeline_total_output_bytes(producer);
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 300 * kMiB);
+  CHECK_FALSE(est->exact);
+  CHECK(est->planner_derived);  // the output-level total is the scan's cardinality projection
+}
+
+TEST_CASE("data_size_estimator: a cardinality projection never falls below bytes emitted",
+          "[data_size_estimator][estimation]")
+{
+  using sirius::pipeline::project_source_output_bytes;
+
+  // 10 rows / 1000 bytes measured so far -> 100 bytes per row.
+  constexpr std::size_t kRows  = 10;
+  constexpr std::size_t kBytes = 1000;
+
+  SECTION("a cardinality above what is emitted projects normally")
+  {
+    CHECK(project_source_output_bytes(50, kRows, kBytes) == 5000);
+  }
+
+  SECTION("a cardinality below the rows already emitted is floored at the observed bytes")
+  {
+    // The planner said 4 rows; 10 have already come out. 400 would be a whole-query total below
+    // an observed partial, which is provably wrong whatever the planner thinks.
+    CHECK(project_source_output_bytes(4, kRows, kBytes) == kBytes);
+  }
+
+  SECTION("a zero cardinality does not claim the scan emits nothing")
+  {
+    // Reachable: DuckDB zeroes the estimate outright on a zero base-table stat. Unfloored this
+    // returns 0 rather than nullopt, which a leaf anchor would multiply out across the chain.
+    CHECK(project_source_output_bytes(0, kRows, kBytes) == kBytes);
+  }
+
+  SECTION("no measurement yet yields no projection")
+  {
+    CHECK_FALSE(project_source_output_bytes(1000, 0, 0).has_value());
+    CHECK_FALSE(project_source_output_bytes(1000, kRows, 0).has_value());
+    CHECK_FALSE(project_source_output_bytes(1000, 0, kBytes).has_value());
+  }
+
+  SECTION("an unrepresentable product yields no projection rather than a wrapped one")
+  {
+    CHECK_FALSE(
+      project_source_output_bytes(std::numeric_limits<std::size_t>::max(), 1, kBytes).has_value());
+  }
+}
+
+TEST_CASE("data_size_estimator: a measured anchor is not marked planner-derived",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer                                 = dag.add();
+  estimator_dag::source_of(producer).input_total = 1024 * kMiB;
+  record_ratio(producer, 100 * kMiB, 50 * kMiB);
+
+  auto est = estimate_pipeline_total_output_bytes(producer);
+  REQUIRE(est.has_value());
+  CHECK_FALSE(est->planner_derived);
+}
+
+TEST_CASE("data_size_estimator: planner provenance survives a downstream ratio",
+          "[data_size_estimator][estimation]")
+{
+  // The regression the flag exists for: one hop is enough to overwrite the anchor's zero, leaving
+  // the estimate indistinguishable from a fully measured chain.
+  estimator_dag dag;
+  auto& scan = dag.add();
+  auto& mid  = dag.add();
+  dag.connect(scan, mid);
+
+  estimator_dag::source_of(scan).output_total = 300 * kMiB;
+  record_ratio(mid, 100 * kMiB, 50 * kMiB);  // ratio 0.5, backed by min_ratio_samples tasks
+
+  auto est = estimate_pipeline_total_output_bytes(mid);
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 150 * kMiB);
+  CHECK_FALSE(est->exact);
+  // mid's genuine support is reported, exactly as before — the zero is gone...
+  CHECK(est->ratio_samples == size_estimate_options{}.min_ratio_samples);
+  // ...so this is the only surviving signal that part of the number is a planner guess.
+  CHECK(est->planner_derived);
+}
+
+TEST_CASE("data_size_estimator: ratios compose along a multi-hop chain",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& scan     = dag.add();
+  auto& mid      = dag.add();
+  auto& consumer = dag.add();
+  dag.connect(scan, mid);
+  dag.connect(mid, consumer);
+
+  estimator_dag::source_of(scan).input_total = 1024 * kMiB;
+  record_ratio(scan, 100 * kMiB, 50 * kMiB);  // ratio 0.5  -> 512 MiB leaves the scan
+  record_ratio(mid, 100 * kMiB, 25 * kMiB);   // ratio 0.25 -> 128 MiB leaves mid
+
+  auto& consumer_op = *consumer.get_source();
+  auto est = estimate_port_total_input_bytes(consumer_op, consumer_op.get_port_ids().front());
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 128 * kMiB);
+  CHECK_FALSE(est->exact);
+  CHECK(est->hops == 1);  // consumer's port -> mid (hop 0) -> scan (hop 1)
+}
+
+TEST_CASE("data_size_estimator: the walk stops at the first finished pipeline",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& scan     = dag.add();
+  auto& mid      = dag.add();
+  auto& consumer = dag.add();
+  dag.connect(scan, mid);
+  dag.connect(mid, consumer);
+
+  // mid is done, so its recorded output total is authoritative and the scan is never consulted
+  // (deliberately left with no source total, which would otherwise abort the walk).
+  record_ratio(mid, 100 * kMiB, 200 * kMiB);
+  mid.finished = true;
+
+  auto& consumer_op = *consumer.get_source();
+  auto est = estimate_port_total_input_bytes(consumer_op, consumer_op.get_port_ids().front());
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 200 * kMiB);
+  CHECK(est->exact);
+  CHECK(est->hops == 0);
+}
+
+namespace {
+
+/// A `probe -> join <- build`, `join -> consumer` shape. Returns the consumer's only port name
+/// so callers can estimate through it.
+struct fan_in_dag {
+  estimator_dag dag;
+  test_pipeline* probe    = nullptr;
+  test_pipeline* build    = nullptr;
+  test_pipeline* join     = nullptr;
+  test_pipeline* consumer = nullptr;
+
+  fan_in_dag()
+  {
+    probe    = &dag.add();
+    build    = &dag.add();
+    join     = &dag.add();
+    consumer = &dag.add();
+    dag.connect(*probe, *join, MemoryBarrierType::PARTIAL, true, "default");
+    dag.connect(*build, *join, MemoryBarrierType::FULL, true, "build");
+    dag.connect(*join, *consumer);
+  }
+
+  /// Record exactly `n` completed tasks on the join pipeline so it clears
+  /// size_estimate_options::min_fan_in_ratio_samples. The ratio is unaffected by the count.
+  /// Uses record_task rather than record_ratio so `n` means n tasks, not n groups of them.
+  void record_join_ratio(std::size_t in_bytes, std::size_t out_bytes, std::size_t n = 16)
+  {
+    for (std::size_t i = 0; i < n; ++i) {
+      record_task(*join, in_bytes / n, out_bytes / n);
+    }
+  }
+
+  /// Drive the join pipeline's task counters. The estimator must ignore these entirely — see
+  /// the "does not correct its ratio from task counts" case for why.
+  void set_join_task_counters(std::size_t created, std::size_t completed)
+  {
+    for (std::size_t i = 0; i < created; ++i) {
+      join->mark_task_created();
+    }
+    for (std::size_t i = 0; i < completed; ++i) {
+      join->mark_task_completed();
+    }
+  }
+
+  /// Probe side projects 1 GiB; build side is deliberately given a wildly different total so a
+  /// test can prove it is not consulted.
+  void give_both_sides_totals()
+  {
+    estimator_dag::source_of(*probe).input_total = 1024 * kMiB;
+    record_ratio(*probe, 100 * kMiB, 100 * kMiB);  // ratio 1.0 -> 1 GiB leaves the probe side
+    estimator_dag::source_of(*build).input_total = 1 * kMiB;
+    record_ratio(*build, 100 * kMiB, 100 * kMiB);
+  }
+
+  std::optional<sirius::pipeline::data_size_estimate> estimate()
+  {
+    auto& op = *consumer->get_source();
+    return estimate_port_total_input_bytes(op, op.get_port_ids().front());
+  }
+};
+
+}  // namespace
+
+TEST_CASE("data_size_estimator: a fan-in that nominates no primary port yields no estimate",
+          "[data_size_estimator][estimation][fan_in]")
+{
+  fan_in_dag f;
+  f.give_both_sides_totals();
+  f.record_join_ratio(100 * kMiB, 50 * kMiB);
+  estimator_dag::source_of(*f.join).consumed_primary = 100 * kMiB;
+  // primary_port left empty — this is the CTE / delim-join case, which must still bail out.
+
+  CHECK_FALSE(f.estimate().has_value());
+}
+
+TEST_CASE("data_size_estimator: a fan-in with no consumed primary bytes yields no estimate",
+          "[data_size_estimator][estimation][fan_in]")
+{
+  fan_in_dag f;
+  f.give_both_sides_totals();
+  f.record_join_ratio(100 * kMiB, 50 * kMiB);
+  estimator_dag::source_of(*f.join).primary_port = "default";
+  // No probe batch taken yet, so there is nothing to form a ratio against.
+  estimator_dag::source_of(*f.join).consumed_primary = 0;
+
+  CHECK_FALSE(f.estimate().has_value());
+}
+
+TEST_CASE("data_size_estimator: a fan-in scales the primary upstream by output-per-primary-byte",
+          "[data_size_estimator][estimation][fan_in]")
+{
+  fan_in_dag f;
+  f.give_both_sides_totals();
+  // The join pipeline has emitted 50 MiB while taking 200 MiB of probe input: ratio 0.25.
+  // Note the ratio comes from consumed_primary, NOT from the recorded input_basis — that is
+  // the whole point, since a STANDARD join's input_basis double-counts re-paired batches.
+  f.record_join_ratio(999 * kMiB, 50 * kMiB);  // input_basis deliberately bogus
+  estimator_dag::source_of(*f.join).primary_port     = "default";
+  estimator_dag::source_of(*f.join).consumed_primary = 200 * kMiB;
+
+  auto est = f.estimate();
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 256 * kMiB);  // 1 GiB (probe projection) x 0.25
+  CHECK_FALSE(est->exact);
+  CHECK(est->hops == 1);              // consumer -> join (0) -> probe side (1)
+  CHECK_FALSE(est->planner_derived);  // both sides anchored on measured split totals
+}
+
+TEST_CASE("data_size_estimator: planner provenance survives a fan-in hop",
+          "[data_size_estimator][estimation][fan_in]")
+{
+  fan_in_dag f;
+  // Probe side anchors on the scan's cardinality projection rather than a measured split total.
+  // The build side is never walked, so it needs no total of its own.
+  estimator_dag::source_of(*f.probe).output_total = 1024 * kMiB;
+  f.record_join_ratio(999 * kMiB, 50 * kMiB);
+  estimator_dag::source_of(*f.join).primary_port     = "default";
+  estimator_dag::source_of(*f.join).consumed_primary = 200 * kMiB;
+
+  auto est = f.estimate();
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 256 * kMiB);  // 1 GiB (probe projection) x 0.25
+  // The sample count reads as well-supported while the anchor beneath it is still a guess —
+  // the pair a consumer has to be able to tell apart.
+  CHECK(est->ratio_samples == size_estimate_options{}.min_fan_in_ratio_samples);
+  CHECK(est->planner_derived);
+}
+
+TEST_CASE("data_size_estimator: a fan-in samples its numerator before its denominator",
+          "[data_size_estimator][estimation][fan_in]")
+{
+  // The terms cannot be read atomically, so the read order decides which way a task landing
+  // between them skews the ratio. Reading output first keeps the error low rather than inflated.
+  fan_in_dag f;
+  f.give_both_sides_totals();
+  f.record_join_ratio(999 * kMiB, 50 * kMiB);
+  auto& src            = estimator_dag::source_of(*f.join);
+  src.primary_port     = "default";
+  src.consumed_primary = 200 * kMiB;
+
+  // Stand in for a task both created and completed between the two reads: 50 MiB of output lands
+  // at the instant the denominator is sampled, with no matching input in `consumed`. Read second,
+  // the numerator would take it and the ratio would go 0.25 -> 0.5; read first, it cannot.
+  bool fired           = false;
+  src.on_consumed_read = [&] {
+    if (fired) { return; }  // fire once, whatever the estimator's call pattern
+    fired = true;
+    record_task(*f.join, 0, 50 * kMiB);
+  };
+
+  auto est = f.estimate();
+  REQUIRE(fired);  // the hook must actually have run, or this test proves nothing
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 256 * kMiB);  // unchanged by the interleaved task
+}
+
+TEST_CASE("data_size_estimator: a fan-in with too few completed tasks yields no estimate",
+          "[data_size_estimator][estimation][fan_in]")
+{
+  fan_in_dag f;
+  f.give_both_sides_totals();
+  estimator_dag::source_of(*f.join).primary_port     = "default";
+  estimator_dag::source_of(*f.join).consumed_primary = 200 * kMiB;
+
+  // A fan-in ratio divides a completion-accrued numerator by a live denominator, so it reads
+  // low while tasks are in flight — and worst at the first opportunity to sample it. One
+  // completed task is not enough evidence.
+  f.record_join_ratio(100 * kMiB, 50 * kMiB, /*n=*/1);
+  CHECK_FALSE(f.estimate().has_value());
+
+  // The fan-in floor is a hard gate: unlike the single-input floor, assume_unit_ratio does not
+  // substitute 1:1 here, because a join can multiply or divide its input volume by orders of
+  // magnitude and a unit ratio would be a fabricated answer rather than a neutral one.
+  {
+    auto& op = *f.consumer->get_source();
+    CHECK_FALSE(estimate_port_total_input_bytes(op,
+                                                op.get_port_ids().front(),
+                                                size_estimate_options{
+                                                  .assume_unit_ratio = true,
+                                                })
+                  .has_value());
+  }
+
+  // Clearing the threshold unblocks it. (The reported sample count is the weakest link in the
+  // chain, not the join's own — see the next case.)
+  f.record_join_ratio(100 * kMiB, 50 * kMiB, /*n=*/16);
+  CHECK(f.estimate().has_value());
+}
+
+TEST_CASE("data_size_estimator: a fan-in does not correct its ratio from task counts",
+          "[data_size_estimator][estimation][fan_in]")
+{
+  fan_in_dag f;
+  f.give_both_sides_totals();  // probe side projects 1 GiB
+  f.record_join_ratio(100 * kMiB, 50 * kMiB);
+  estimator_dag::source_of(*f.join).primary_port     = "default";
+  estimator_dag::source_of(*f.join).consumed_primary = 200 * kMiB;
+
+  auto const before = f.estimate();
+  REQUIRE(before.has_value());
+  CHECK(before->bytes == 256 * kMiB);  // 1 GiB x (50/200)
+
+  // An earlier version scaled the denominator by completed/created to discount tasks still in
+  // flight. That is only valid if every task consumes an equal share of `consumed`, and a join's
+  // do not: `consumed` advances on a probe batch's FIRST pairing, so with B build batches only
+  // one task in B moves it at all. Leaving tasks in flight must not move the projection.
+  f.set_join_task_counters(/*created=*/25, /*completed=*/20);
+  auto const after = f.estimate();
+  REQUIRE(after.has_value());
+  CHECK(after->bytes == before->bytes);
+}
+
+TEST_CASE("data_size_estimator: a projection that would overflow is reported as unknown",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& scan = dag.add();
+
+  // A near-maximal input paired with an expanding ratio: the product does not fit in a byte
+  // count. Report nothing rather than a wrapped total that would then size a partition count.
+  estimator_dag::source_of(scan).input_total = std::numeric_limits<std::size_t>::max();
+  record_ratio(scan, 1 * kMiB, 1024 * kMiB);
+
+  CHECK_FALSE(estimate_pipeline_total_output_bytes(scan).has_value());
+
+  // The same input with a ratio that keeps the product in range is still answered.
+  estimator_dag::source_of(scan).input_total = 1024 * kMiB;
+  CHECK(estimate_pipeline_total_output_bytes(scan).has_value());
+}
+
+TEST_CASE("data_size_estimator: ratio_samples reports the weakest ratio in the chain",
+          "[data_size_estimator][estimation][fan_in]")
+{
+  fan_in_dag f;
+  f.give_both_sides_totals();  // probe side gets exactly min_ratio_samples records
+  f.record_join_ratio(100 * kMiB, 50 * kMiB, /*n=*/40);
+  estimator_dag::source_of(*f.join).primary_port     = "default";
+  estimator_dag::source_of(*f.join).consumed_primary = 200 * kMiB;
+
+  auto est = f.estimate();
+  REQUIRE(est.has_value());
+  // The join has 40 samples but the probe pipeline has only the bare minimum — the chain is
+  // only as trustworthy as its weakest link.
+  CHECK(est->ratio_samples == size_estimate_options{}.min_ratio_samples);
+}
+
+TEST_CASE("data_size_estimator: a fan-in ignores the non-primary side entirely",
+          "[data_size_estimator][estimation][fan_in]")
+{
+  fan_in_dag f;
+  f.give_both_sides_totals();
+  f.record_join_ratio(100 * kMiB, 50 * kMiB);
+  estimator_dag::source_of(*f.join).primary_port     = "default";
+  estimator_dag::source_of(*f.join).consumed_primary = 200 * kMiB;
+
+  auto const before = f.estimate();
+  REQUIRE(before.has_value());
+
+  // Move the build side dramatically; the projection must not budge.
+  estimator_dag::source_of(*f.build).input_total = 4096 * kMiB;
+  record_ratio(*f.build, 100 * kMiB, 800 * kMiB);
+
+  auto const after = f.estimate();
+  REQUIRE(after.has_value());
+  CHECK(after->bytes == before->bytes);
+}
+
+TEST_CASE("data_size_estimator: a fan-in whose primary upstream is unknown yields no estimate",
+          "[data_size_estimator][estimation][fan_in]")
+{
+  fan_in_dag f;
+  // Build side is fully knowable; probe side is not (its source knows no total). The strict
+  // fallback means we report nothing rather than substituting the side we happen to know.
+  estimator_dag::source_of(*f.build).input_total = 1 * kMiB;
+  record_ratio(*f.build, 100 * kMiB, 100 * kMiB);
+  f.record_join_ratio(100 * kMiB, 50 * kMiB);
+  estimator_dag::source_of(*f.join).primary_port     = "default";
+  estimator_dag::source_of(*f.join).consumed_primary = 200 * kMiB;
+
+  CHECK_FALSE(f.estimate().has_value());
+}
+
+TEST_CASE("data_size_estimator: max_hops bounds the upstream walk",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& scan = dag.add();
+  auto& a    = dag.add();
+  auto& b    = dag.add();
+  dag.connect(scan, a);
+  dag.connect(a, b);
+
+  estimator_dag::source_of(scan).input_total = 100 * kMiB;
+  record_ratio(scan, 100 * kMiB, 100 * kMiB);
+  record_ratio(a, 100 * kMiB, 100 * kMiB);
+  record_ratio(b, 100 * kMiB, 100 * kMiB);
+
+  CHECK(estimate_pipeline_total_output_bytes(b, size_estimate_options{.max_hops = 2}).has_value());
+  CHECK_FALSE(
+    estimate_pipeline_total_output_bytes(b, size_estimate_options{.max_hops = 1}).has_value());
+}
+
+TEST_CASE("data_size_estimator: unknown and dependency-only ports yield no estimate",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer = dag.add();
+  auto& consumer = dag.add();
+  // A dependency-only edge: no repository, so no bytes ever flow through it.
+  dag.connect(producer, consumer, MemoryBarrierType::FULL, /*with_repo=*/false);
+
+  producer.finished = true;
+  record_ratio(producer, 100 * kMiB, 100 * kMiB);
+
+  auto& consumer_op = *consumer.get_source();
+  CHECK_FALSE(estimate_port_total_input_bytes(consumer_op, "no_such_port").has_value());
+  CHECK_FALSE(
+    estimate_port_total_input_bytes(consumer_op, consumer_op.get_port_ids().front()).has_value());
+}

--- a/test/cpp/pipeline/test_data_size_estimator.cpp
+++ b/test/cpp/pipeline/test_data_size_estimator.cpp
@@ -75,10 +75,13 @@ struct test_source_operator : sirius_physical_operator {
     return consumed_primary;
   }
 
+  [[nodiscard]] bool caps_pipeline_output() const override { return caps_output; }
+
   std::optional<std::size_t> input_total;
   std::optional<std::size_t> output_total;
   std::string primary_port;  ///< empty = nominates none
   std::optional<std::size_t> consumed_primary;
+  bool caps_output = false;  ///< stands in for a LIMIT in the pipeline
   /// Fires as the denominator is read. See the numerator/denominator ordering test.
   std::function<void()> on_consumed_read;
 };
@@ -144,6 +147,18 @@ class estimator_dag {
   static test_source_operator& source_of(test_pipeline& pipeline)
   {
     return static_cast<test_source_operator&>(*pipeline.get_source());
+  }
+
+  /// Give `pipeline` a sink distinct from its source, modelling a scan pipeline that also holds
+  /// a FILTER or PROJECTION. add() otherwise makes one operator serve as both ends.
+  test_source_operator& add_distinct_sink(test_pipeline& pipeline)
+  {
+    auto op = std::make_unique<test_source_operator>();
+    op->set_pipeline(shared_for(pipeline));
+    _bs.set_pipeline_sink(pipeline, sirius::optional_ptr<sirius_physical_operator>(op.get()), 0);
+    auto& ref = *op;
+    _ops.push_back(std::move(op));
+    return ref;
   }
 
  private:
@@ -409,6 +424,77 @@ TEST_CASE("data_size_estimator: an output-level source total bypasses the pipeli
   CHECK(est->bytes == 300 * kMiB);
   CHECK_FALSE(est->exact);
   CHECK(est->planner_derived);  // the output-level total is the scan's cardinality projection
+}
+
+TEST_CASE("data_size_estimator: an output-level source total is unusable when operators follow it",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer                                  = dag.add();
+  estimator_dag::source_of(producer).output_total = 300 * kMiB;
+  record_ratio(producer, 100 * kMiB, 10 * kMiB);
+  // A FILTER or PROJECTION now sits between source and sink, so the source's output is no longer
+  // the pipeline's. Returning it unscaled would ignore that operator; scaling it by the ratio
+  // would count the scan's pushdown selectivity twice. Neither is an answer.
+  dag.add_distinct_sink(producer);
+
+  CHECK_FALSE(estimate_pipeline_total_output_bytes(producer).has_value());
+}
+
+TEST_CASE("data_size_estimator: a capped pipeline is not extrapolated while unfinished",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer                                 = dag.add();
+  estimator_dag::source_of(producer).input_total = 1024 * kMiB;
+  record_ratio(producer, 100 * kMiB, 50 * kMiB);
+
+  auto before = estimate_pipeline_total_output_bytes(producer);
+  REQUIRE(before.has_value());
+  CHECK(before->bytes == 512 * kMiB);
+
+  // A LIMIT bounds output by a row count, so the pipeline stops emitting once the cap binds and
+  // may finish without its source draining. Projecting the whole source total through the ratio
+  // would overshoot by however much of the table the limit spares.
+  estimator_dag::source_of(producer).caps_output = true;
+  CHECK_FALSE(estimate_pipeline_total_output_bytes(producer).has_value());
+  // A cap is not a missing ratio, so the unit-ratio escape does not apply either.
+  CHECK_FALSE(estimate_pipeline_total_output_bytes(producer,
+                                                   size_estimate_options{
+                                                     .assume_unit_ratio = true,
+                                                   })
+                .has_value());
+}
+
+TEST_CASE("data_size_estimator: a finished capped pipeline still reports its measured output",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer                                 = dag.add();
+  estimator_dag::source_of(producer).caps_output = true;
+  record_ratio(producer, 100 * kMiB, 10 * kMiB);
+  producer.finished = true;
+
+  auto est = estimate_pipeline_total_output_bytes(producer);
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 10 * kMiB);
+  CHECK(est->exact);
+}
+
+TEST_CASE("data_size_estimator: a cap anywhere in the chain stops the walk",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& scan = dag.add();
+  auto& mid  = dag.add();
+  dag.connect(scan, mid);
+
+  estimator_dag::source_of(scan).input_total = 1024 * kMiB;
+  record_ratio(scan, 100 * kMiB, 100 * kMiB);
+  record_ratio(mid, 100 * kMiB, 50 * kMiB);
+  estimator_dag::source_of(mid).caps_output = true;
+
+  CHECK_FALSE(estimate_pipeline_total_output_bytes(mid).has_value());
 }
 
 TEST_CASE("data_size_estimator: a cardinality projection never falls below bytes emitted",

--- a/test/cpp/pipeline/test_data_size_estimator.cpp
+++ b/test/cpp/pipeline/test_data_size_estimator.cpp
@@ -272,6 +272,8 @@ TEST_CASE("data_size_estimator: an unfinished leaf scales its known total by the
   REQUIRE(est.has_value());
   CHECK(est->bytes == 256 * kMiB);
   CHECK_FALSE(est->exact);
+  // A leaf applies its own ratio without recursing, so the count is 1 at zero recursion depth.
+  CHECK(est->hops == 1);
 }
 
 TEST_CASE("data_size_estimator: no ratio yet means no estimate, unless unit ratio is allowed",
@@ -524,6 +526,26 @@ TEST_CASE("data_size_estimator: planner provenance survives a downstream ratio",
   CHECK(est->planner_derived);
 }
 
+TEST_CASE("data_size_estimator: a projection never falls below the bytes already emitted",
+          "[data_size_estimator][estimation]")
+{
+  estimator_dag dag;
+  auto& producer                                 = dag.add();
+  estimator_dag::source_of(producer).input_total = 500 * kMiB;
+
+  // Ratio-eligible tasks: 400 MiB in, 40 MiB out, so the measured ratio is 0.1.
+  record_ratio(producer, 400 * kMiB, 40 * kMiB);
+  // Zero-basis tasks emit real bytes but cannot inform a ratio, so the projection is blind to
+  // them however accurate the upstream total is.
+  record_task(producer, 0, 200 * kMiB);
+
+  // 500 MiB x 0.1 = 50 MiB, which is less than the 240 MiB already emitted.
+  auto est = estimate_pipeline_total_output_bytes(producer);
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 240 * kMiB);
+  CHECK_FALSE(est->exact);
+}
+
 TEST_CASE("data_size_estimator: ratios compose along a multi-hop chain",
           "[data_size_estimator][estimation]")
 {
@@ -543,7 +565,8 @@ TEST_CASE("data_size_estimator: ratios compose along a multi-hop chain",
   REQUIRE(est.has_value());
   CHECK(est->bytes == 128 * kMiB);
   CHECK_FALSE(est->exact);
-  CHECK(est->hops == 1);
+  // scan's own ratio, then mid's.
+  CHECK(est->hops == 2);
 }
 
 TEST_CASE("data_size_estimator: the walk stops at the first finished pipeline",
@@ -661,8 +684,29 @@ TEST_CASE("data_size_estimator: a fan-in scales the primary upstream by output-p
   REQUIRE(est.has_value());
   CHECK(est->bytes == 256 * kMiB);
   CHECK_FALSE(est->exact);
-  CHECK(est->hops == 1);
+  // probe side's ratio, then the join's.
+  CHECK(est->hops == 2);
   CHECK_FALSE(est->planner_derived);
+}
+
+TEST_CASE("data_size_estimator: a fan-in projection never falls below the bytes already emitted",
+          "[data_size_estimator][estimation][fan_in]")
+{
+  fan_in_dag f;
+  // Probe projects 8 MiB and has emitted only 4, so its own floor does not bind and the join
+  // scales a genuinely small upstream.
+  estimator_dag::source_of(*f.probe).input_total = 8 * kMiB;
+  record_ratio(*f.probe, 4 * kMiB, 4 * kMiB);
+  // Consumed primary bytes are deliberately over-counted, so the ratio can read far below the
+  // join's true expansion: 8 MiB x (64/512) = 1 MiB, against 64 MiB already emitted.
+  f.record_join_ratio(999 * kMiB, 64 * kMiB);
+  estimator_dag::source_of(*f.join).primary_port     = "default";
+  estimator_dag::source_of(*f.join).consumed_primary = 512 * kMiB;
+
+  auto est = f.estimate();
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 64 * kMiB);
+  CHECK_FALSE(est->exact);
 }
 
 TEST_CASE("data_size_estimator: planner provenance survives a fan-in hop",

--- a/test/cpp/pipeline/test_data_size_estimator.cpp
+++ b/test/cpp/pipeline/test_data_size_estimator.cpp
@@ -777,7 +777,7 @@ TEST_CASE("data_size_estimator: a fan-in with too few completed tasks yields no 
   CHECK(f.estimate().has_value());
 }
 
-TEST_CASE("data_size_estimator: a fan-in does not correct its ratio from task counts",
+TEST_CASE("data_size_estimator: a fan-in is withheld while probe tasks are in flight",
           "[data_size_estimator][estimation][fan_in]")
 {
   fan_in_dag f;
@@ -786,16 +786,66 @@ TEST_CASE("data_size_estimator: a fan-in does not correct its ratio from task co
   estimator_dag::source_of(*f.join).primary_port     = "default";
   estimator_dag::source_of(*f.join).consumed_primary = 200 * kMiB;
 
-  auto const before = f.estimate();
-  REQUIRE(before.has_value());
-  CHECK(before->bytes == 256 * kMiB);
+  auto const quiescent = f.estimate();
+  REQUIRE(quiescent.has_value());
+  CHECK(quiescent->bytes == 256 * kMiB);
 
-  // Regression: join tasks consume unequal shares because only a probe's first pairing advances
-  // the denominator, so task completion counts must not scale it.
+  // One enormous in-flight task could hold the ratio near zero however many small tasks have
+  // completed, so in-flight snapshots are withheld rather than sample-floored.
   f.set_join_task_counters(/*created=*/25, /*completed=*/20);
+  CHECK_FALSE(f.estimate().has_value());
+
+  // Quiescent again: the totals cover the same tasks and the estimate returns.
+  f.set_join_task_counters(/*created=*/0, /*completed=*/5);
   auto const after = f.estimate();
   REQUIRE(after.has_value());
-  CHECK(after->bytes == before->bytes);
+  CHECK(after->bytes == quiescent->bytes);
+}
+
+TEST_CASE("data_size_estimator: a fan-in rejects a task racing the ratio reads",
+          "[data_size_estimator][estimation][fan_in]")
+{
+  fan_in_dag f;
+  f.give_both_sides_totals();
+  f.record_join_ratio(100 * kMiB, 50 * kMiB);
+  auto& src            = estimator_dag::source_of(*f.join);
+  src.primary_port     = "default";
+  src.consumed_primary = 200 * kMiB;
+
+  // A task starts and completes while `consumed` is read: the counters end equal, so only a
+  // comparison against the pre-read snapshot can catch it.
+  bool fired           = false;
+  src.on_consumed_read = [&] {
+    if (fired) { return; }
+    fired = true;
+    f.join->mark_task_created();
+    f.join->mark_task_completed();
+  };
+  CHECK_FALSE(f.estimate().has_value());
+  REQUIRE(fired);
+
+  // Quiescent and stable again: the estimate returns.
+  auto est = f.estimate();
+  REQUIRE(est.has_value());
+  CHECK(est->bytes == 256 * kMiB);
+}
+
+TEST_CASE("data_size_estimator: a zero fan-in floor still requires completed output",
+          "[data_size_estimator][estimation][fan_in]")
+{
+  fan_in_dag f;
+  f.give_both_sides_totals();
+  estimator_dag::source_of(*f.join).primary_port     = "default";
+  estimator_dag::source_of(*f.join).consumed_primary = 200 * kMiB;
+
+  // No join task has completed; a zero floor must not turn 0 / consumed into a confident zero.
+  auto& op = *f.consumer->get_source();
+  CHECK_FALSE(estimate_port_total_input_bytes(op,
+                                              op.get_port_ids().front(),
+                                              size_estimate_options{
+                                                .min_fan_in_ratio_samples = 0,
+                                              })
+                .has_value());
 }
 
 TEST_CASE("data_size_estimator: a projection that would overflow is reported as unknown",

--- a/test/cpp/pipeline/test_data_size_estimator.cpp
+++ b/test/cpp/pipeline/test_data_size_estimator.cpp
@@ -45,7 +45,6 @@ namespace {
 
 constexpr std::size_t kMiB = 1024ull * 1024ull;
 
-/// Leaf-source stand-in whose two "what is my total?" answers are set per test.
 struct test_source_operator : sirius_physical_operator {
   test_source_operator() : sirius_physical_operator(SiriusPhysicalOperatorType::PROJECTION, {}, 0)
   {
@@ -60,8 +59,7 @@ struct test_source_operator : sirius_physical_operator {
     return output_total;
   }
 
-  // Fan-in nomination: which port carries the primary (probe-equivalent) input, and how many
-  // bytes have been taken from it. Both unset by default, matching every non-join operator.
+  // Fan-in primary input and the bytes consumed from it.
   [[nodiscard]] std::optional<std::string_view> primary_input_port() const override
   {
     if (primary_port.empty()) { return std::nullopt; }
@@ -69,8 +67,7 @@ struct test_source_operator : sirius_physical_operator {
   }
   [[nodiscard]] std::optional<std::size_t> consumed_primary_input_bytes() const override
   {
-    // Lets a test observe *when* the denominator is sampled relative to the numerator, by running
-    // side effects at exactly that instant. Unset in every other test.
+    // The hook simulates a task completing between estimator reads.
     if (on_consumed_read) { on_consumed_read(); }
     return consumed_primary;
   }
@@ -79,15 +76,13 @@ struct test_source_operator : sirius_physical_operator {
 
   std::optional<std::size_t> input_total;
   std::optional<std::size_t> output_total;
-  std::string primary_port;  ///< empty = nominates none
+  std::string primary_port;
   std::optional<std::size_t> consumed_primary;
-  bool caps_output = false;  ///< stands in for a LIMIT in the pipeline
-  /// Fires as the denominator is read. See the numerator/denominator ordering test.
+  bool caps_output = false;
   std::function<void()> on_consumed_read;
 };
 
-/// Pipeline whose finished state is set directly, instead of being driven through the task
-/// counters that update_pipeline_status() normally maintains.
+/// Pipeline with a directly controlled finished state.
 struct test_pipeline : sirius_pipeline {
   explicit test_pipeline(const pipeline_build_context& ctx) : sirius_pipeline(ctx) {}
 
@@ -96,11 +91,9 @@ struct test_pipeline : sirius_pipeline {
   bool finished = false;
 };
 
-/// Builds a chain/DAG of single-operator pipelines wired through data-carrying ports, mirroring
-/// how the planner wires real pipelines. Each pipeline's operator doubles as source and sink.
+/// Builds test pipeline DAGs with one operator per pipeline by default.
 class estimator_dag {
  public:
-  /// Add a pipeline and return it. `source` is the operator standing in for its leaf source.
   test_pipeline& add()
   {
     auto pipeline = duckdb::make_shared_ptr<test_pipeline>(_ctx);
@@ -114,7 +107,7 @@ class estimator_dag {
     return ref;
   }
 
-  /// Wire a data-flow edge from -> to. `with_repo=false` models a dependency-only port.
+  /// `with_repo=false` creates a dependency-only port.
   void connect(test_pipeline& from,
                test_pipeline& to,
                MemoryBarrierType barrier    = MemoryBarrierType::FULL,
@@ -143,14 +136,12 @@ class estimator_dag {
       sirius_physical_operator::next_port_info{consumer_op, name, uuid::now_v7()});
   }
 
-  /// The operator standing in as `pipeline`'s leaf source.
   static test_source_operator& source_of(test_pipeline& pipeline)
   {
     return static_cast<test_source_operator&>(*pipeline.get_source());
   }
 
-  /// Give `pipeline` a sink distinct from its source, modelling a scan pipeline that also holds
-  /// a FILTER or PROJECTION. add() otherwise makes one operator serve as both ends.
+  /// Models a pipeline with an operator after its source.
   test_source_operator& add_distinct_sink(test_pipeline& pipeline)
   {
     auto op = std::make_unique<test_source_operator>();
@@ -178,19 +169,12 @@ class estimator_dag {
   std::vector<duckdb::shared_ptr<sirius_pipeline>> _pipelines;
 };
 
-/// Record one completed task on `pipeline`.
 void record_task(test_pipeline& pipeline, std::size_t in_bytes, std::size_t out_bytes)
 {
   pipeline.get_memory_history().record(task_memory_record{in_bytes, in_bytes * 2, out_bytes});
 }
 
-/// Give `pipeline` a measured output/input ratio backed by `samples` completed tasks.
-///
-/// Defaults to exactly what size_estimate_options::min_ratio_samples requires, so a pipeline
-/// set up this way has a ratio the estimator will trust; cases that are *about* the sample
-/// count pass it explicitly. The bytes are split evenly across the samples, so the aggregate
-/// ratio is `out_bytes / in_bytes` regardless of the count (every value here is a multiple of
-/// kMiB, which divides exactly).
+/// Records an aggregate output/input ratio with enough samples to be trusted by default.
 void record_ratio(test_pipeline& pipeline,
                   std::size_t in_bytes,
                   std::size_t out_bytes,
@@ -225,8 +209,7 @@ TEST_CASE("data_size_estimator: a finished pipeline whose tasks recorded nothing
   estimator_dag dag;
   auto& producer    = dag.add();
   producer.finished = true;
-  // Tasks ran and none recorded output — every one OOM'd. Measurement was attempted and lost, so
-  // reporting 0 would size a large input onto a single partition.
+  // Treat failed measurement as unknown, not as zero output.
   producer.mark_task_created();
   producer.mark_task_created();
 
@@ -239,8 +222,7 @@ TEST_CASE("data_size_estimator: a finished pipeline that never created a task is
   estimator_dag dag;
   auto& producer    = dag.add();
   producer.finished = true;
-  // An empty scan: nothing to measure rather than a measurement that failed. Finishing requires
-  // source exhaustion, not just balanced counters, so zero tasks means drained.
+  // A finished pipeline with no tasks has drained without producing output.
 
   auto est = estimate_pipeline_total_output_bytes(producer);
   REQUIRE(est.has_value());
@@ -254,8 +236,6 @@ TEST_CASE("data_size_estimator: a finished pipeline counts output from zero-basi
 {
   estimator_dag dag;
   auto& producer = dag.add();
-  // A scan split with no a-priori size estimate reports a zero basis. Its output is still part
-  // of the pipeline's total; omitting it would under-count while still claiming exact.
   record_task(producer, 100 * kMiB, 40 * kMiB);
   record_task(producer, 0, 60 * kMiB);
   producer.finished = true;
@@ -271,7 +251,6 @@ TEST_CASE("data_size_estimator: a finished pipeline that emitted nothing reports
 {
   estimator_dag dag;
   auto& producer = dag.add();
-  // Distinct from "no evidence": tasks ran and succeeded, they just produced no rows.
   record_task(producer, 100 * kMiB, 0);
   producer.finished = true;
 
@@ -285,15 +264,13 @@ TEST_CASE("data_size_estimator: an unfinished leaf scales its known total by the
           "[data_size_estimator][estimation]")
 {
   estimator_dag dag;
-  auto& producer = dag.add();
-  // The source will feed 1 GiB; the pipeline has so far turned 100 MiB of input into 25 MiB.
+  auto& producer                                 = dag.add();
   estimator_dag::source_of(producer).input_total = 1024 * kMiB;
   record_ratio(producer, 100 * kMiB, 25 * kMiB);
 
   auto est = estimate_pipeline_total_output_bytes(producer);
   REQUIRE(est.has_value());
   CHECK(est->bytes == 256 * kMiB);
-  // A learned ratio is a projection even though the leaf total is known exactly.
   CHECK_FALSE(est->exact);
 }
 
@@ -303,7 +280,6 @@ TEST_CASE("data_size_estimator: no ratio yet means no estimate, unless unit rati
   estimator_dag dag;
   auto& producer                                 = dag.add();
   estimator_dag::source_of(producer).input_total = 512 * kMiB;
-  // No task has completed, so the pipeline has no measured input->output ratio.
 
   CHECK_FALSE(estimate_pipeline_total_output_bytes(producer).has_value());
 
@@ -328,8 +304,7 @@ TEST_CASE("data_size_estimator: a substituted unit ratio claims no measured supp
   dag.connect(scan, mid);
 
   estimator_dag::source_of(scan).input_total = 1024 * kMiB;
-  record_ratio(scan, 100 * kMiB, 100 * kMiB, /*samples=*/8);  // well-supported, ratio 1.0
-  // `mid` has a ratio, but from too few tasks to trust, so 1:1 is substituted for it.
+  record_ratio(scan, 100 * kMiB, 100 * kMiB, /*samples=*/8);
   record_task(mid, 100 * kMiB, 50 * kMiB);
 
   auto est = estimate_pipeline_total_output_bytes(mid,
@@ -337,12 +312,9 @@ TEST_CASE("data_size_estimator: a substituted unit ratio claims no measured supp
                                                     .assume_unit_ratio = true,
                                                   });
   REQUIRE(est.has_value());
-  // The substituted link must not be credited with mid's 1 under-floor record...
   CHECK(est->ratio_samples != 1);
-  // ...nor zero out the scan's genuine support, which 0 would also confuse with "exact".
   CHECK(est->ratio_samples == 8);
   CHECK_FALSE(est->exact);
-  // Substituting 1.0 for mid leaves the scan's 1.0-scaled total unchanged.
   CHECK(est->bytes == 1024 * kMiB);
 }
 
@@ -350,22 +322,18 @@ TEST_CASE("data_size_estimator: a single-input ratio from too few tasks is not t
           "[data_size_estimator][estimation]")
 {
   auto const min_samples = size_estimate_options{}.min_ratio_samples;
-  REQUIRE(min_samples > 1);  // otherwise this case asserts nothing
+  REQUIRE(min_samples > 1);
 
   estimator_dag dag;
   auto& producer                                 = dag.add();
   estimator_dag::source_of(producer).input_total = 1024 * kMiB;
 
-  // One task short of the floor. The ratio exists and is arithmetically usable, but a filter
-  // over clustered data can make a single batch's selectivity nothing like the table's — and
-  // the consumer latches the first estimate it gets, so an unlucky sample is never corrected.
+  // A single batch may not represent selectivity over clustered data.
   for (std::size_t i = 0; i < min_samples - 1; ++i) {
     record_task(producer, 100 * kMiB, 25 * kMiB);
   }
   CHECK_FALSE(estimate_pipeline_total_output_bytes(producer).has_value());
 
-  // An untrusted ratio is treated exactly as no ratio, so the unit-ratio escape still applies
-  // and yields the unscaled source total.
   auto assumed = estimate_pipeline_total_output_bytes(producer,
                                                       size_estimate_options{
                                                         .assume_unit_ratio = true,
@@ -374,8 +342,6 @@ TEST_CASE("data_size_estimator: a single-input ratio from too few tasks is not t
   CHECK(assumed->bytes == 1024 * kMiB);
   CHECK_FALSE(assumed->exact);
 
-  // The floor is a knob, not a constant: on the very same history, a caller willing to act on
-  // thinner evidence lowers it and gets the measured ratio applied (1 GiB x 0.25).
   auto lowered = estimate_pipeline_total_output_bytes(producer,
                                                       size_estimate_options{
                                                         .min_ratio_samples = 1,
@@ -383,7 +349,6 @@ TEST_CASE("data_size_estimator: a single-input ratio from too few tasks is not t
   REQUIRE(lowered.has_value());
   CHECK(lowered->bytes == 256 * kMiB);
 
-  // One more task clears the default floor, and the same answer arrives without the override.
   record_task(producer, 100 * kMiB, 25 * kMiB);
   auto est = estimate_pipeline_total_output_bytes(producer);
   REQUIRE(est.has_value());
@@ -397,10 +362,8 @@ TEST_CASE("data_size_estimator: a source that knows nothing yields no estimate",
   estimator_dag dag;
   auto& producer = dag.add();
   record_ratio(producer, 100 * kMiB, 50 * kMiB);
-  // Both source totals stay nullopt — this is the streaming-source case.
 
   CHECK_FALSE(estimate_pipeline_total_output_bytes(producer).has_value());
-  // A unit ratio does not invent a total that the source cannot supply.
   CHECK_FALSE(estimate_pipeline_total_output_bytes(producer,
                                                    size_estimate_options{
                                                      .assume_unit_ratio = true,
@@ -412,18 +375,16 @@ TEST_CASE("data_size_estimator: an output-level source total bypasses the pipeli
           "[data_size_estimator][estimation]")
 {
   estimator_dag dag;
-  auto& producer = dag.add();
-  // Only the post-filter output total is known (the scan's cardinality fallback).
+  auto& producer                                  = dag.add();
   estimator_dag::source_of(producer).output_total = 300 * kMiB;
-  // A ratio exists but must NOT be applied: it is derived from pre-filter input bytes, so
-  // using it here would count filter selectivity twice.
+  // Applying the pre-filter ratio would count selectivity twice.
   record_ratio(producer, 100 * kMiB, 10 * kMiB);
 
   auto est = estimate_pipeline_total_output_bytes(producer);
   REQUIRE(est.has_value());
   CHECK(est->bytes == 300 * kMiB);
   CHECK_FALSE(est->exact);
-  CHECK(est->planner_derived);  // the output-level total is the scan's cardinality projection
+  CHECK(est->planner_derived);
 }
 
 TEST_CASE("data_size_estimator: an output-level source total is unusable when operators follow it",
@@ -433,9 +394,7 @@ TEST_CASE("data_size_estimator: an output-level source total is unusable when op
   auto& producer                                  = dag.add();
   estimator_dag::source_of(producer).output_total = 300 * kMiB;
   record_ratio(producer, 100 * kMiB, 10 * kMiB);
-  // A FILTER or PROJECTION now sits between source and sink, so the source's output is no longer
-  // the pipeline's. Returning it unscaled would ignore that operator; scaling it by the ratio
-  // would count the scan's pushdown selectivity twice. Neither is an answer.
+  // The source total cannot represent output after another operator.
   dag.add_distinct_sink(producer);
 
   CHECK_FALSE(estimate_pipeline_total_output_bytes(producer).has_value());
@@ -453,12 +412,9 @@ TEST_CASE("data_size_estimator: a capped pipeline is not extrapolated while unfi
   REQUIRE(before.has_value());
   CHECK(before->bytes == 512 * kMiB);
 
-  // A LIMIT bounds output by a row count, so the pipeline stops emitting once the cap binds and
-  // may finish without its source draining. Projecting the whole source total through the ratio
-  // would overshoot by however much of the table the limit spares.
+  // A capped pipeline may finish without draining its source.
   estimator_dag::source_of(producer).caps_output = true;
   CHECK_FALSE(estimate_pipeline_total_output_bytes(producer).has_value());
-  // A cap is not a missing ratio, so the unit-ratio escape does not apply either.
   CHECK_FALSE(estimate_pipeline_total_output_bytes(producer,
                                                    size_estimate_options{
                                                      .assume_unit_ratio = true,
@@ -502,7 +458,6 @@ TEST_CASE("data_size_estimator: a cardinality projection never falls below bytes
 {
   using sirius::pipeline::project_source_output_bytes;
 
-  // 10 rows / 1000 bytes measured so far -> 100 bytes per row.
   constexpr std::size_t kRows  = 10;
   constexpr std::size_t kBytes = 1000;
 
@@ -513,15 +468,12 @@ TEST_CASE("data_size_estimator: a cardinality projection never falls below bytes
 
   SECTION("a cardinality below the rows already emitted is floored at the observed bytes")
   {
-    // The planner said 4 rows; 10 have already come out. 400 would be a whole-query total below
-    // an observed partial, which is provably wrong whatever the planner thinks.
     CHECK(project_source_output_bytes(4, kRows, kBytes) == kBytes);
   }
 
   SECTION("a zero cardinality does not claim the scan emits nothing")
   {
-    // Reachable: DuckDB zeroes the estimate outright on a zero base-table stat. Unfloored this
-    // returns 0 rather than nullopt, which a leaf anchor would multiply out across the chain.
+    // DuckDB can report zero cardinality for a nonempty scan.
     CHECK(project_source_output_bytes(0, kRows, kBytes) == kBytes);
   }
 
@@ -555,23 +507,20 @@ TEST_CASE("data_size_estimator: a measured anchor is not marked planner-derived"
 TEST_CASE("data_size_estimator: planner provenance survives a downstream ratio",
           "[data_size_estimator][estimation]")
 {
-  // The regression the flag exists for: one hop is enough to overwrite the anchor's zero, leaving
-  // the estimate indistinguishable from a fully measured chain.
+  // Regression: downstream ratios must preserve planner-derived provenance.
   estimator_dag dag;
   auto& scan = dag.add();
   auto& mid  = dag.add();
   dag.connect(scan, mid);
 
   estimator_dag::source_of(scan).output_total = 300 * kMiB;
-  record_ratio(mid, 100 * kMiB, 50 * kMiB);  // ratio 0.5, backed by min_ratio_samples tasks
+  record_ratio(mid, 100 * kMiB, 50 * kMiB);
 
   auto est = estimate_pipeline_total_output_bytes(mid);
   REQUIRE(est.has_value());
   CHECK(est->bytes == 150 * kMiB);
   CHECK_FALSE(est->exact);
-  // mid's genuine support is reported, exactly as before — the zero is gone...
   CHECK(est->ratio_samples == size_estimate_options{}.min_ratio_samples);
-  // ...so this is the only surviving signal that part of the number is a planner guess.
   CHECK(est->planner_derived);
 }
 
@@ -586,15 +535,15 @@ TEST_CASE("data_size_estimator: ratios compose along a multi-hop chain",
   dag.connect(mid, consumer);
 
   estimator_dag::source_of(scan).input_total = 1024 * kMiB;
-  record_ratio(scan, 100 * kMiB, 50 * kMiB);  // ratio 0.5  -> 512 MiB leaves the scan
-  record_ratio(mid, 100 * kMiB, 25 * kMiB);   // ratio 0.25 -> 128 MiB leaves mid
+  record_ratio(scan, 100 * kMiB, 50 * kMiB);
+  record_ratio(mid, 100 * kMiB, 25 * kMiB);
 
   auto& consumer_op = *consumer.get_source();
   auto est = estimate_port_total_input_bytes(consumer_op, consumer_op.get_port_ids().front());
   REQUIRE(est.has_value());
   CHECK(est->bytes == 128 * kMiB);
   CHECK_FALSE(est->exact);
-  CHECK(est->hops == 1);  // consumer's port -> mid (hop 0) -> scan (hop 1)
+  CHECK(est->hops == 1);
 }
 
 TEST_CASE("data_size_estimator: the walk stops at the first finished pipeline",
@@ -607,8 +556,7 @@ TEST_CASE("data_size_estimator: the walk stops at the first finished pipeline",
   dag.connect(scan, mid);
   dag.connect(mid, consumer);
 
-  // mid is done, so its recorded output total is authoritative and the scan is never consulted
-  // (deliberately left with no source total, which would otherwise abort the walk).
+  // Leaving scan unknown verifies that the walk stops at finished mid.
   record_ratio(mid, 100 * kMiB, 200 * kMiB);
   mid.finished = true;
 
@@ -622,8 +570,7 @@ TEST_CASE("data_size_estimator: the walk stops at the first finished pipeline",
 
 namespace {
 
-/// A `probe -> join <- build`, `join -> consumer` shape. Returns the consumer's only port name
-/// so callers can estimate through it.
+/// A `probe -> join <- build`, `join -> consumer` test DAG.
 struct fan_in_dag {
   estimator_dag dag;
   test_pipeline* probe    = nullptr;
@@ -642,9 +589,7 @@ struct fan_in_dag {
     dag.connect(*join, *consumer);
   }
 
-  /// Record exactly `n` completed tasks on the join pipeline so it clears
-  /// size_estimate_options::min_fan_in_ratio_samples. The ratio is unaffected by the count.
-  /// Uses record_task rather than record_ratio so `n` means n tasks, not n groups of them.
+  /// Records the join ratio across exactly `n` tasks.
   void record_join_ratio(std::size_t in_bytes, std::size_t out_bytes, std::size_t n = 16)
   {
     for (std::size_t i = 0; i < n; ++i) {
@@ -652,8 +597,6 @@ struct fan_in_dag {
     }
   }
 
-  /// Drive the join pipeline's task counters. The estimator must ignore these entirely — see
-  /// the "does not correct its ratio from task counts" case for why.
   void set_join_task_counters(std::size_t created, std::size_t completed)
   {
     for (std::size_t i = 0; i < created; ++i) {
@@ -664,12 +607,10 @@ struct fan_in_dag {
     }
   }
 
-  /// Probe side projects 1 GiB; build side is deliberately given a wildly different total so a
-  /// test can prove it is not consulted.
   void give_both_sides_totals()
   {
     estimator_dag::source_of(*probe).input_total = 1024 * kMiB;
-    record_ratio(*probe, 100 * kMiB, 100 * kMiB);  // ratio 1.0 -> 1 GiB leaves the probe side
+    record_ratio(*probe, 100 * kMiB, 100 * kMiB);
     estimator_dag::source_of(*build).input_total = 1 * kMiB;
     record_ratio(*build, 100 * kMiB, 100 * kMiB);
   }
@@ -690,7 +631,6 @@ TEST_CASE("data_size_estimator: a fan-in that nominates no primary port yields n
   f.give_both_sides_totals();
   f.record_join_ratio(100 * kMiB, 50 * kMiB);
   estimator_dag::source_of(*f.join).consumed_primary = 100 * kMiB;
-  // primary_port left empty — this is the CTE / delim-join case, which must still bail out.
 
   CHECK_FALSE(f.estimate().has_value());
 }
@@ -701,8 +641,7 @@ TEST_CASE("data_size_estimator: a fan-in with no consumed primary bytes yields n
   fan_in_dag f;
   f.give_both_sides_totals();
   f.record_join_ratio(100 * kMiB, 50 * kMiB);
-  estimator_dag::source_of(*f.join).primary_port = "default";
-  // No probe batch taken yet, so there is nothing to form a ratio against.
+  estimator_dag::source_of(*f.join).primary_port     = "default";
   estimator_dag::source_of(*f.join).consumed_primary = 0;
 
   CHECK_FALSE(f.estimate().has_value());
@@ -713,27 +652,23 @@ TEST_CASE("data_size_estimator: a fan-in scales the primary upstream by output-p
 {
   fan_in_dag f;
   f.give_both_sides_totals();
-  // The join pipeline has emitted 50 MiB while taking 200 MiB of probe input: ratio 0.25.
-  // Note the ratio comes from consumed_primary, NOT from the recorded input_basis — that is
-  // the whole point, since a STANDARD join's input_basis double-counts re-paired batches.
-  f.record_join_ratio(999 * kMiB, 50 * kMiB);  // input_basis deliberately bogus
+  // STANDARD joins must use consumed primary bytes, not re-paired input basis.
+  f.record_join_ratio(999 * kMiB, 50 * kMiB);
   estimator_dag::source_of(*f.join).primary_port     = "default";
   estimator_dag::source_of(*f.join).consumed_primary = 200 * kMiB;
 
   auto est = f.estimate();
   REQUIRE(est.has_value());
-  CHECK(est->bytes == 256 * kMiB);  // 1 GiB (probe projection) x 0.25
+  CHECK(est->bytes == 256 * kMiB);
   CHECK_FALSE(est->exact);
-  CHECK(est->hops == 1);              // consumer -> join (0) -> probe side (1)
-  CHECK_FALSE(est->planner_derived);  // both sides anchored on measured split totals
+  CHECK(est->hops == 1);
+  CHECK_FALSE(est->planner_derived);
 }
 
 TEST_CASE("data_size_estimator: planner provenance survives a fan-in hop",
           "[data_size_estimator][estimation][fan_in]")
 {
   fan_in_dag f;
-  // Probe side anchors on the scan's cardinality projection rather than a measured split total.
-  // The build side is never walked, so it needs no total of its own.
   estimator_dag::source_of(*f.probe).output_total = 1024 * kMiB;
   f.record_join_ratio(999 * kMiB, 50 * kMiB);
   estimator_dag::source_of(*f.join).primary_port     = "default";
@@ -741,9 +676,7 @@ TEST_CASE("data_size_estimator: planner provenance survives a fan-in hop",
 
   auto est = f.estimate();
   REQUIRE(est.has_value());
-  CHECK(est->bytes == 256 * kMiB);  // 1 GiB (probe projection) x 0.25
-  // The sample count reads as well-supported while the anchor beneath it is still a guess —
-  // the pair a consumer has to be able to tell apart.
+  CHECK(est->bytes == 256 * kMiB);
   CHECK(est->ratio_samples == size_estimate_options{}.min_fan_in_ratio_samples);
   CHECK(est->planner_derived);
 }
@@ -751,8 +684,7 @@ TEST_CASE("data_size_estimator: planner provenance survives a fan-in hop",
 TEST_CASE("data_size_estimator: a fan-in samples its numerator before its denominator",
           "[data_size_estimator][estimation][fan_in]")
 {
-  // The terms cannot be read atomically, so the read order decides which way a task landing
-  // between them skews the ratio. Reading output first keeps the error low rather than inflated.
+  // Reading output first prevents an interleaved completion from inflating the ratio.
   fan_in_dag f;
   f.give_both_sides_totals();
   f.record_join_ratio(999 * kMiB, 50 * kMiB);
@@ -760,20 +692,18 @@ TEST_CASE("data_size_estimator: a fan-in samples its numerator before its denomi
   src.primary_port     = "default";
   src.consumed_primary = 200 * kMiB;
 
-  // Stand in for a task both created and completed between the two reads: 50 MiB of output lands
-  // at the instant the denominator is sampled, with no matching input in `consumed`. Read second,
-  // the numerator would take it and the ratio would go 0.25 -> 0.5; read first, it cannot.
+  // Simulate a task completing when the denominator is sampled.
   bool fired           = false;
   src.on_consumed_read = [&] {
-    if (fired) { return; }  // fire once, whatever the estimator's call pattern
+    if (fired) { return; }
     fired = true;
     record_task(*f.join, 0, 50 * kMiB);
   };
 
   auto est = f.estimate();
-  REQUIRE(fired);  // the hook must actually have run, or this test proves nothing
+  REQUIRE(fired);  // Ensure the simulated race occurred.
   REQUIRE(est.has_value());
-  CHECK(est->bytes == 256 * kMiB);  // unchanged by the interleaved task
+  CHECK(est->bytes == 256 * kMiB);
 }
 
 TEST_CASE("data_size_estimator: a fan-in with too few completed tasks yields no estimate",
@@ -784,15 +714,11 @@ TEST_CASE("data_size_estimator: a fan-in with too few completed tasks yields no 
   estimator_dag::source_of(*f.join).primary_port     = "default";
   estimator_dag::source_of(*f.join).consumed_primary = 200 * kMiB;
 
-  // A fan-in ratio divides a completion-accrued numerator by a live denominator, so it reads
-  // low while tasks are in flight — and worst at the first opportunity to sample it. One
-  // completed task is not enough evidence.
+  // In-flight tasks can temporarily depress the fan-in ratio.
   f.record_join_ratio(100 * kMiB, 50 * kMiB, /*n=*/1);
   CHECK_FALSE(f.estimate().has_value());
 
-  // The fan-in floor is a hard gate: unlike the single-input floor, assume_unit_ratio does not
-  // substitute 1:1 here, because a join can multiply or divide its input volume by orders of
-  // magnitude and a unit ratio would be a fabricated answer rather than a neutral one.
+  // A unit ratio is unsafe for joins that may greatly change data volume.
   {
     auto& op = *f.consumer->get_source();
     CHECK_FALSE(estimate_port_total_input_bytes(op,
@@ -803,8 +729,6 @@ TEST_CASE("data_size_estimator: a fan-in with too few completed tasks yields no 
                   .has_value());
   }
 
-  // Clearing the threshold unblocks it. (The reported sample count is the weakest link in the
-  // chain, not the join's own — see the next case.)
   f.record_join_ratio(100 * kMiB, 50 * kMiB, /*n=*/16);
   CHECK(f.estimate().has_value());
 }
@@ -813,19 +737,17 @@ TEST_CASE("data_size_estimator: a fan-in does not correct its ratio from task co
           "[data_size_estimator][estimation][fan_in]")
 {
   fan_in_dag f;
-  f.give_both_sides_totals();  // probe side projects 1 GiB
+  f.give_both_sides_totals();
   f.record_join_ratio(100 * kMiB, 50 * kMiB);
   estimator_dag::source_of(*f.join).primary_port     = "default";
   estimator_dag::source_of(*f.join).consumed_primary = 200 * kMiB;
 
   auto const before = f.estimate();
   REQUIRE(before.has_value());
-  CHECK(before->bytes == 256 * kMiB);  // 1 GiB x (50/200)
+  CHECK(before->bytes == 256 * kMiB);
 
-  // An earlier version scaled the denominator by completed/created to discount tasks still in
-  // flight. That is only valid if every task consumes an equal share of `consumed`, and a join's
-  // do not: `consumed` advances on a probe batch's FIRST pairing, so with B build batches only
-  // one task in B moves it at all. Leaving tasks in flight must not move the projection.
+  // Regression: join tasks consume unequal shares because only a probe's first pairing advances
+  // the denominator, so task completion counts must not scale it.
   f.set_join_task_counters(/*created=*/25, /*completed=*/20);
   auto const after = f.estimate();
   REQUIRE(after.has_value());
@@ -838,14 +760,11 @@ TEST_CASE("data_size_estimator: a projection that would overflow is reported as 
   estimator_dag dag;
   auto& scan = dag.add();
 
-  // A near-maximal input paired with an expanding ratio: the product does not fit in a byte
-  // count. Report nothing rather than a wrapped total that would then size a partition count.
   estimator_dag::source_of(scan).input_total = std::numeric_limits<std::size_t>::max();
   record_ratio(scan, 1 * kMiB, 1024 * kMiB);
 
   CHECK_FALSE(estimate_pipeline_total_output_bytes(scan).has_value());
 
-  // The same input with a ratio that keeps the product in range is still answered.
   estimator_dag::source_of(scan).input_total = 1024 * kMiB;
   CHECK(estimate_pipeline_total_output_bytes(scan).has_value());
 }
@@ -854,15 +773,13 @@ TEST_CASE("data_size_estimator: ratio_samples reports the weakest ratio in the c
           "[data_size_estimator][estimation][fan_in]")
 {
   fan_in_dag f;
-  f.give_both_sides_totals();  // probe side gets exactly min_ratio_samples records
+  f.give_both_sides_totals();
   f.record_join_ratio(100 * kMiB, 50 * kMiB, /*n=*/40);
   estimator_dag::source_of(*f.join).primary_port     = "default";
   estimator_dag::source_of(*f.join).consumed_primary = 200 * kMiB;
 
   auto est = f.estimate();
   REQUIRE(est.has_value());
-  // The join has 40 samples but the probe pipeline has only the bare minimum — the chain is
-  // only as trustworthy as its weakest link.
   CHECK(est->ratio_samples == size_estimate_options{}.min_ratio_samples);
 }
 
@@ -878,7 +795,6 @@ TEST_CASE("data_size_estimator: a fan-in ignores the non-primary side entirely",
   auto const before = f.estimate();
   REQUIRE(before.has_value());
 
-  // Move the build side dramatically; the projection must not budge.
   estimator_dag::source_of(*f.build).input_total = 4096 * kMiB;
   record_ratio(*f.build, 100 * kMiB, 800 * kMiB);
 
@@ -891,8 +807,6 @@ TEST_CASE("data_size_estimator: a fan-in whose primary upstream is unknown yield
           "[data_size_estimator][estimation][fan_in]")
 {
   fan_in_dag f;
-  // Build side is fully knowable; probe side is not (its source knows no total). The strict
-  // fallback means we report nothing rather than substituting the side we happen to know.
   estimator_dag::source_of(*f.build).input_total = 1 * kMiB;
   record_ratio(*f.build, 100 * kMiB, 100 * kMiB);
   f.record_join_ratio(100 * kMiB, 50 * kMiB);
@@ -928,7 +842,6 @@ TEST_CASE("data_size_estimator: unknown and dependency-only ports yield no estim
   estimator_dag dag;
   auto& producer = dag.add();
   auto& consumer = dag.add();
-  // A dependency-only edge: no repository, so no bytes ever flow through it.
   dag.connect(producer, consumer, MemoryBarrierType::FULL, /*with_repo=*/false);
 
   producer.finished = true;

--- a/test/cpp/pipeline/test_pipeline_memory_history.cpp
+++ b/test/cpp/pipeline/test_pipeline_memory_history.cpp
@@ -77,13 +77,24 @@ TEST_CASE("pipeline_memory_history skips records with zero estimated_bytes",
 {
   pipeline_memory_history history;
 
-  history.record({0, 500, 300});    // Should be skipped
+  history.record({0, 500, 300});    // Skipped by the ring: peak estimation divides by the basis
   history.record({100, 300, 200});  // ratio = 3.0
 
   auto estimate = history.estimate_peak_memory(100);
   REQUIRE(estimate.has_value());
   // Only the second record contributes: 100 * 3.0 = 300
   REQUIRE(*estimate == 300);
+
+  // ...but its emitted bytes still count toward the pipeline's output total, which must not
+  // depend on whether a task's input happened to be measurable.
+  REQUIRE(history.totals().output_records == 2);
+  REQUIRE(history.totals().output_bytes == 500);
+  // The ratio ignores it: a zero basis cannot be paired with an output.
+  REQUIRE(history.totals().ratio_records == 1);
+  REQUIRE(history.totals().ratio_input_bytes == 100);
+  auto ratio = history.totals().ratio();
+  REQUIRE(ratio.has_value());
+  REQUIRE(*ratio == Approx(2.0));
 }
 
 TEST_CASE("pipeline_memory_history ring buffer evicts oldest records",
@@ -140,4 +151,97 @@ TEST_CASE("pipeline_memory_history is thread-safe for concurrent recording",
   auto estimate = history.estimate_peak_memory(200);
   REQUIRE(estimate.has_value());
   REQUIRE(*estimate > 0);
+
+  // Every record is counted in the running totals, unlike the capped ring buffer.
+  REQUIRE(history.totals().ratio_records ==
+          static_cast<std::size_t>(num_threads) * static_cast<std::size_t>(records_per_thread));
+}
+
+TEST_CASE("pipeline_memory_history has no output/input ratio without records",
+          "[pipeline_memory_history][ratio]")
+{
+  pipeline_memory_history history;
+  REQUIRE_FALSE(history.totals().ratio().has_value());
+  REQUIRE(history.totals().output_bytes == 0);
+}
+
+TEST_CASE("pipeline_memory_history aggregates the output/input ratio over all records",
+          "[pipeline_memory_history][ratio]")
+{
+  pipeline_memory_history history;
+
+  history.record({100, 200, 60});
+  history.record({300, 600, 140});
+
+  // Aggregate, not per-record: 200 out of 400 in.
+  auto ratio = history.totals().ratio();
+  REQUIRE(ratio.has_value());
+  REQUIRE(*ratio == Approx(0.5));
+
+  REQUIRE(history.totals().output_bytes == 200);
+  REQUIRE(history.totals().ratio_input_bytes == 400);
+  REQUIRE(history.totals().ratio_records == 2);
+}
+
+TEST_CASE("pipeline_memory_history totals survive ring-buffer eviction",
+          "[pipeline_memory_history][ratio][ring_buffer]")
+{
+  pipeline_memory_history history;
+
+  // 200 records is well past the 64-entry ring, so a totals implementation backed by the ring
+  // would lose most of this.
+  for (std::size_t i = 0; i < 200; ++i) {
+    history.record({100, 200, 25});
+  }
+
+  REQUIRE(history.size() == 64);
+  REQUIRE(history.totals().ratio_records == 200);
+  REQUIRE(history.totals().output_bytes == std::size_t{200} * 25);
+
+  auto ratio = history.totals().ratio();
+  REQUIRE(ratio.has_value());
+  REQUIRE(*ratio == Approx(0.25));
+}
+
+TEST_CASE("pipeline_memory_history excludes failed tasks from the output/input ratio",
+          "[pipeline_memory_history][ratio]")
+{
+  pipeline_memory_history history;
+
+  history.record({100, 200, 50});
+  // A task that OOM'd produced no output; counting its input would drag the ratio down.
+  history.record_on_failure(400, 900);
+
+  auto ratio = history.totals().ratio();
+  REQUIRE(ratio.has_value());
+  REQUIRE(*ratio == Approx(0.5));
+  REQUIRE(history.totals().ratio_records == 1);
+  REQUIRE(history.totals().ratio_input_bytes == 100);
+}
+
+TEST_CASE("pipeline_memory_history excludes resumed tasks from the output/input ratio",
+          "[pipeline_memory_history][ratio]")
+{
+  pipeline_memory_history history;
+
+  history.record({100, 200, 50});
+  // A task resumed mid-pipeline after a reschedule: its basis is the intermediate data it
+  // restarted from, not pipeline input, so mixing it in would inflate the ratio. It still
+  // belongs in the ring, which feeds per-task peak estimation.
+  history.record({10, 200, 50, /*ratio_eligible=*/false});
+
+  REQUIRE(history.size() == 2);
+
+  // The ratio takes only the first: pairing 50 output with a 10-byte intermediate basis would
+  // report 5.0 for a pipeline that actually halves its input.
+  auto ratio = history.totals().ratio();
+  REQUIRE(ratio.has_value());
+  REQUIRE(*ratio == Approx(0.5));
+  REQUIRE(history.totals().ratio_records == 1);
+  REQUIRE(history.totals().ratio_input_bytes == 100);
+
+  // The output total takes both: a resumed task's basis is unusable, but the bytes it emitted
+  // are still the pipeline's output and must not vanish from a finished pipeline's total.
+  REQUIRE(history.totals().output_records == 2);
+  REQUIRE(history.totals().output_bytes == 100);
 }

--- a/test/cpp/pipeline/test_pipeline_memory_history.cpp
+++ b/test/cpp/pipeline/test_pipeline_memory_history.cpp
@@ -85,11 +85,8 @@ TEST_CASE("pipeline_memory_history skips records with zero estimated_bytes",
   // Only the second record contributes: 100 * 3.0 = 300
   REQUIRE(*estimate == 300);
 
-  // ...but its emitted bytes still count toward the pipeline's output total, which must not
-  // depend on whether a task's input happened to be measurable.
   REQUIRE(history.totals().output_records == 2);
   REQUIRE(history.totals().output_bytes == 500);
-  // The ratio ignores it: a zero basis cannot be paired with an output.
   REQUIRE(history.totals().ratio_records == 1);
   REQUIRE(history.totals().ratio_input_bytes == 100);
   auto ratio = history.totals().ratio();
@@ -152,7 +149,7 @@ TEST_CASE("pipeline_memory_history is thread-safe for concurrent recording",
   REQUIRE(estimate.has_value());
   REQUIRE(*estimate > 0);
 
-  // Every record is counted in the running totals, unlike the capped ring buffer.
+  // Running totals are not capped by the ring buffer.
   REQUIRE(history.totals().ratio_records ==
           static_cast<std::size_t>(num_threads) * static_cast<std::size_t>(records_per_thread));
 }
@@ -173,7 +170,6 @@ TEST_CASE("pipeline_memory_history aggregates the output/input ratio over all re
   history.record({100, 200, 60});
   history.record({300, 600, 140});
 
-  // Aggregate, not per-record: 200 out of 400 in.
   auto ratio = history.totals().ratio();
   REQUIRE(ratio.has_value());
   REQUIRE(*ratio == Approx(0.5));
@@ -188,8 +184,6 @@ TEST_CASE("pipeline_memory_history totals survive ring-buffer eviction",
 {
   pipeline_memory_history history;
 
-  // 200 records is well past the 64-entry ring, so a totals implementation backed by the ring
-  // would lose most of this.
   for (std::size_t i = 0; i < 200; ++i) {
     history.record({100, 200, 25});
   }
@@ -209,7 +203,6 @@ TEST_CASE("pipeline_memory_history excludes failed tasks from the output/input r
   pipeline_memory_history history;
 
   history.record({100, 200, 50});
-  // A task that OOM'd produced no output; counting its input would drag the ratio down.
   history.record_on_failure(400, 900);
 
   auto ratio = history.totals().ratio();
@@ -225,23 +218,18 @@ TEST_CASE("pipeline_memory_history excludes resumed tasks from the output/input 
   pipeline_memory_history history;
 
   history.record({100, 200, 50});
-  // A task resumed mid-pipeline after a reschedule: its basis is the intermediate data it
-  // restarted from, not pipeline input, so mixing it in would inflate the ratio. It still
-  // belongs in the ring, which feeds per-task peak estimation.
+  // A resumed task's intermediate input is not a valid pipeline ratio basis.
   history.record({10, 200, 50, /*ratio_eligible=*/false});
 
   REQUIRE(history.size() == 2);
 
-  // The ratio takes only the first: pairing 50 output with a 10-byte intermediate basis would
-  // report 5.0 for a pipeline that actually halves its input.
   auto ratio = history.totals().ratio();
   REQUIRE(ratio.has_value());
   REQUIRE(*ratio == Approx(0.5));
   REQUIRE(history.totals().ratio_records == 1);
   REQUIRE(history.totals().ratio_input_bytes == 100);
 
-  // The output total takes both: a resumed task's basis is unusable, but the bytes it emitted
-  // are still the pipeline's output and must not vanish from a finished pipeline's total.
+  // Resumed-task output still contributes to the pipeline total.
   REQUIRE(history.totals().output_records == 2);
   REQUIRE(history.totals().output_bytes == 100);
 }


### PR DESCRIPTION
## Description

Adds a runtime estimator that answers: **"how many bytes will ultimately arrive at this
operator's input port over the whole query?"** — the API issue #1283 asks for. Today,
decisions like a join's partition count are made from the build side and planner guesses
only; this API lets downstream operators size themselves from what the query has actually
done so far.

Two free functions over the pipeline graph (no engine state):

- `estimate_port_total_input_bytes(op, port_id)` — projected total for one input port
- `estimate_pipeline_total_output_bytes(pipeline)` — projected total a pipeline will emit

**How an estimate is formed** — walk upstream to the first known total, then chain each
pipeline's measured output/input ratio back down. Four terminating cases:

1. **Finished pipeline** — its recorded output total, reported `exact`
2. **Fan-in (join)** — follow only the source's nominated primary (probe) port, scaled by
   output-per-probe-byte; joins that stream the build instead (RIGHT-family, OUTER) nominate none and get no estimate
3. **Leaf** — anchor on the source's own total (scan split discovery, VALUES plan size)
4. **Single producer** — recurse, then apply this pipeline's learned ratio

**Design stance:** the chaining is measurement-derived — every ratio comes from completed
tasks, and any unknown link yields `nullopt` rather than a guess (opt-in
`assume_unit_ratio` relaxes this for single-input pipelines only). There is exactly one
planner-derived number: the scan's output-side anchor (`estimated_cardinality × measured
bytes/row`), used only while split discovery is open and identifiable via the result's
diagnostics. Corollary: the API cannot answer before a query starts running — there is no
pre-execution mode.

**Supporting changes:**

- `pipeline_memory_history` gains monotonic totals that survive ring-buffer eviction, split
  into *ratio terms* (tasks with a usable pipeline-input basis) and *output terms* (every
  successful task) — so zero-basis scan splits still count toward a finished pipeline's
  total, and tasks resumed mid-pipeline after an OOM/CUDA reschedule can't skew the ratio
  with intermediate-data units
- Four operator hooks on `sirius_physical_operator`, all defaulting to "cannot answer";
  implemented by `GPU_SCAN`, `GPU_VALUES` (leaf totals) and `HASH_JOIN` (probe-side
  nomination + probe-byte counting, weighted by how far through its pairings each batch is so the ratio holds mid-run rather than only once the join drains)
- `split_connector` tallies discovered bytes, making a scan's total knowable before it drains
- `try_get_port` (const + non-const): non-throwing port lookup; `get_port` delegates to it

**Consumers:** none in-tree yet. The first — sizing the group-by partition count from a
projected total, turning that hard barrier into a partial one — follows in a stacked PR.
Expected next: join partition/broadcast strategy and per-query GPU memory tapering.

Start reviewing at `docs/super-sirius/data-size-estimation.md`, which covers the mechanism,
the fan-in bias and its sample floor, and every limitation called out above.

## Checklist
- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests — 36 unit cases drive the arithmetic
      against a synthetic pipeline DAG and the join's probe accounting (`[data_size_estimator]`, `[pipeline_memory_history]`, `[size_estimation]`)
- [x] Document configuration changes in code and summarize in the description above — none
      (this PR adds no settings; tuning lives in per-call `size_estimate_options`)
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md) — new
      `docs/super-sirius/data-size-estimation.md`, indexed in the Super Sirius README

## References
Refs #1283 (the API half; the issue's partition-sizing consumer lands in the stacked
follow-up PR)
