### PR TITLE
fix(aggregate): record COUNT DISTINCT local schema

### DIFF
--- a/src/include/op/sirius_physical_grouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate.hpp
@@ -96,8 +96,7 @@ class sirius_physical_grouped_aggregate : public sirius_physical_operator {
 
   //! Runtime schema of the local COUNT(DISTINCT) accumulator. The local aggregate and PARTITION
   //! carry LIST sets; MERGE_GROUP_BY later converts those sets to the declared BIGINT count.
-  [[nodiscard]] duckdb::vector<sirius::logical_type>
-  get_count_distinct_local_output_types() const;
+  [[nodiscard]] duckdb::vector<sirius::logical_type> get_count_distinct_local_output_types() const;
 
   // Source interface
   bool is_source() const override { return true; }

--- a/src/include/op/sirius_physical_grouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate.hpp
@@ -94,6 +94,11 @@ class sirius_physical_grouped_aggregate : public sirius_physical_operator {
     return indices;
   }
 
+  //! Runtime schema of the local COUNT(DISTINCT) accumulator. The local aggregate and PARTITION
+  //! carry LIST sets; MERGE_GROUP_BY later converts those sets to the declared BIGINT count.
+  [[nodiscard]] duckdb::vector<sirius::logical_type>
+  get_count_distinct_local_output_types() const;
+
   // Source interface
   bool is_source() const override { return true; }
 

--- a/src/op/sirius_physical_grouped_aggregate.cpp
+++ b/src/op/sirius_physical_grouped_aggregate.cpp
@@ -72,6 +72,25 @@ sirius_physical_grouped_aggregate::sirius_physical_grouped_aggregate(
   has_count_distinct                = cudf_defs.has_count_distinct;
 }
 
+duckdb::vector<sirius::logical_type>
+sirius_physical_grouped_aggregate::get_count_distinct_local_output_types() const
+{
+  auto const aggregate_offset = group_idx.size();
+  if (!has_count_distinct || has_avg || types.size() != aggregate_offset + aggregate_slots.size()) {
+    throw std::runtime_error(
+      "COUNT(DISTINCT) local schema requires a non-AVG one-slot-per-aggregate layout");
+  }
+
+  auto local_types = types;
+  for (size_t slot_idx = 0; slot_idx < aggregate_slots.size(); ++slot_idx) {
+    if (aggregate_slots[slot_idx].is_count_distinct) {
+      local_types[aggregate_offset + slot_idx] =
+        sirius::logical_type::make(sirius::type_id::LIST);
+    }
+  }
+  return local_types;
+}
+
 std::unique_ptr<operator_data> sirius_physical_grouped_aggregate::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {

--- a/src/op/sirius_physical_grouped_aggregate.cpp
+++ b/src/op/sirius_physical_grouped_aggregate.cpp
@@ -84,8 +84,7 @@ sirius_physical_grouped_aggregate::get_count_distinct_local_output_types() const
   auto local_types = types;
   for (size_t slot_idx = 0; slot_idx < aggregate_slots.size(); ++slot_idx) {
     if (aggregate_slots[slot_idx].is_count_distinct) {
-      local_types[aggregate_offset + slot_idx] =
-        sirius::logical_type::make(sirius::type_id::LIST);
+      local_types[aggregate_offset + slot_idx] = sirius::logical_type::make(sirius::type_id::LIST);
     }
   }
   return local_types;

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -428,6 +428,23 @@ void wrap_hash_group_by(duckdb::unique_ptr<sirius::op::sirius_physical_operator>
   wrap_above(slot, [&](duckdb::unique_ptr<sirius::op::sirius_physical_operator> hgb_op) {
     auto* hgb_ptr = hgb_op.get();
 
+    // Construct the merge while the child still carries the final SQL schema. COUNT(DISTINCT)
+    // emits LIST sets locally and only becomes BIGINT after merge post-processing.
+    auto merge = duckdb::make_uniq<sirius::op::sirius_physical_grouped_aggregate_merge>(
+      &hgb_ptr->Cast<sirius::op::sirius_physical_grouped_aggregate>(),
+      op_params.hash_partition_bytes);
+    if (hgb_ptr->has_physical_overrides()) {
+      merge->set_physical_types(hgb_ptr->get_physical_types());
+    }
+
+    auto& grouped = hgb_ptr->Cast<sirius::op::sirius_physical_grouped_aggregate>();
+    bool const has_supported_count_distinct_layout =
+      grouped.has_count_distinct && !grouped.has_avg && !hgb_ptr->has_physical_overrides() &&
+      hgb_ptr->types.size() == grouped.group_idx.size() + grouped.aggregate_slots.size();
+    if (has_supported_count_distinct_layout) {
+      hgb_ptr->types = grouped.get_count_distinct_local_output_types();
+    }
+
     auto partition =
       duckdb::make_uniq<sirius::op::sirius_physical_partition>(hgb_ptr->types,
                                                                hgb_ptr->estimated_cardinality,
@@ -440,12 +457,6 @@ void wrap_hash_group_by(duckdb::unique_ptr<sirius::op::sirius_physical_operator>
     }
     partition->children.push_back(std::move(hgb_op));
 
-    auto merge = duckdb::make_uniq<sirius::op::sirius_physical_grouped_aggregate_merge>(
-      &hgb_ptr->Cast<sirius::op::sirius_physical_grouped_aggregate>(),
-      op_params.hash_partition_bytes);
-    if (hgb_ptr->has_physical_overrides()) {
-      merge->set_physical_types(hgb_ptr->get_physical_types());
-    }
     // The partition's downstream sizing consumer is the merge (key_source hgb only supplies keys).
     partition_ptr->set_downstream_consumer_op(merge.get());
     merge->children.push_back(std::move(partition));

--- a/test/cpp/planner/test_plan_tree_shape.cpp
+++ b/test/cpp/planner/test_plan_tree_shape.cpp
@@ -439,6 +439,30 @@ TEST_CASE_METHOD(plan_tree_shape_fixture,
     CHECK(partition->children[0]->type == SiriusPhysicalOperatorType::HASH_GROUP_BY);
   }
 
+  SECTION("COUNT(DISTINCT) records LIST locally and BIGINT after merge")
+  {
+    auto plan =
+      generate_sirius_plan(*con, "SELECT val, count(DISTINCT id) FROM big_left GROUP BY val");
+    INFO(tree_to_string(plan.get()));
+
+    auto* merge = find_first(plan.get(), SiriusPhysicalOperatorType::MERGE_GROUP_BY);
+    REQUIRE(merge != nullptr);
+    REQUIRE(merge->get_types().size() == 2);
+    CHECK(merge->get_types()[1].id() == sirius::type_id::BIGINT);
+    REQUIRE(merge->children.size() == 1);
+
+    auto* partition = merge->children[0].get();
+    REQUIRE(partition->type == SiriusPhysicalOperatorType::PARTITION);
+    REQUIRE(partition->get_types().size() == 2);
+    CHECK(partition->get_types()[1].id() == sirius::type_id::LIST);
+    REQUIRE(partition->children.size() == 1);
+
+    auto* local = partition->children[0].get();
+    REQUIRE(local->type == SiriusPhysicalOperatorType::HASH_GROUP_BY);
+    REQUIRE(local->get_types().size() == 2);
+    CHECK(local->get_types()[1].id() == sirius::type_id::LIST);
+  }
+
   SECTION("ungrouped aggregate gains MERGE_AGGREGATE with no PARTITION")
   {
     auto plan = generate_sirius_plan(*con, "SELECT sum(val) FROM big_left");


### PR DESCRIPTION
## Description

Fix the datatype diagnostics reported by TPC-H Q16 for `HASH_GROUP_BY` and its pass-through `PARTITION` stage.

`COUNT(DISTINCT)` lowers to a local `COLLECT_SET`, so those stages carry LIST values. `MERGE_GROUP_BY` later counts the set elements and returns the declared BIGINT result. This change constructs the merge while the final SQL schema is still present, then records LIST only on the supported local one-slot-per-aggregate COUNT(DISTINCT) shape and its partition.

AVG mixtures, grouping-function layouts, and physical-sidecar shapes retain their existing behavior instead of guessing an intermediate schema.

## Validation

- Sirius `dev` base: `f107ba88f1d473223169d6d2d9dd0c9e3bf75af0`
- Clean isolated NVIDIA L4 release build: 1,285/1,285 actions completed
- Focused planner selector: 29/29 assertions passed
- Stored source diff SHA-256: `dc464a7291444bd392274decb7333cd8932891ca4de1d656bea4d78bc15b59ee`
- Clean-base apply, reverse-apply, and `git diff --check` passed

## Checklist

- [x] Read `CONTRIBUTING.md`
- [x] Covered the repair with a focused planner regression
- [x] No Sirius configuration option changes
- [x] No user-facing documentation change required

## References

Closes #1475