### PR TITLE
fix(delim-join): scope runtime schema validation

### DIFF
--- a/src/include/op/sirius_physical_delim_join.hpp
+++ b/src/include/op/sirius_physical_delim_join.hpp
@@ -62,6 +62,13 @@ class sirius_physical_delim_join : public sirius_physical_operator {
 
   bool is_sink() const override { return true; }
 
+  //! DELIM_JOIN execute() forwards its pipeline input unchanged. `types` describes the logical
+  //! join result produced by the internal join subtree, not those pass-through batches.
+  [[nodiscard]] bool declared_output_schema_is_runtime_schema() const noexcept override
+  {
+    return false;
+  }
+
   sirius::OrderPreservationType source_order() const override
   {
     return sirius::OrderPreservationType::NO_ORDER;

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -429,6 +429,15 @@ class sirius_physical_operator {
   //! Return a vector of the types that will be returned by this operator
   const duckdb::vector<sirius::logical_type>& get_types() const { return types; }
 
+  //! Whether `get_types()` describes the batches returned directly by execute(). Most operators
+  //! materialize their declared logical schema. Structural pass-through stages may instead carry
+  //! a different runtime schema; those operators must opt out so the task-level diagnostic does
+  //! not compare unrelated schemas.
+  [[nodiscard]] virtual bool declared_output_schema_is_runtime_schema() const noexcept
+  {
+    return true;
+  }
+
   //! Return the optional physical output schema. Empty means the native schema derived from
   //! get_types().
   [[nodiscard]] const std::vector<cudf::data_type>& get_physical_types() const noexcept

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -50,6 +50,7 @@ void validate_operator_output_types(const op::operator_data* data,
                                     const op::sirius_physical_operator& op)
 {
   if (data == nullptr) { return; }
+  if (!op.declared_output_schema_is_runtime_schema()) { return; }
   auto* pipelineable_data = dynamic_cast<const op::pipelineable_operator_data*>(data);
   if (pipelineable_data == nullptr) { return; }
   const auto& expected_types = op.get_types();
@@ -71,8 +72,6 @@ void validate_operator_output_types(const op::operator_data* data,
     if (!batch) { continue; }
     cudf::table_view tbl = get_cudf_table_view(*batch);
     if (static_cast<size_t>(tbl.num_columns()) != expected_types.size()) {
-      // bobbi (todo): delim join will return this warning for now, but there is no bug here, so we
-      // can ignore it. we can do something about this after gtc
       SIRIUS_LOG_WARN(
         "gpu_pipeline_task: operator '{}' (id={}) output batch {} column count mismatch: got "
         "{}, expected {}",

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -24,6 +24,7 @@
 #include <duckdb.hpp>
 #include <duckdb/common/enums/optimizer_type.hpp>
 #include <duckdb/main/config.hpp>
+#include <utils/log_test_utils.hpp>
 #include <utils/sirius_test_env.hpp>
 #include <utils/tpch_queries.hpp>
 #include <utils/transparent_execution_test_utils.hpp>
@@ -4415,7 +4416,12 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - TPC-H Query 20 parquet",
                  "[integration][gpu_execution][parquet][TPC-H][Q20]")
 {
+  sirius::test::scoped_recording_log_sink logs{"warn"};
   RUN_TPCH_MGPU(sirius::test::kTpchQ20);
+  for (auto const& record : logs.records()) {
+    CHECK(record.message.find("RIGHT_DELIM_JOIN") == std::string::npos);
+    CHECK(record.message.find("output batch") == std::string::npos);
+  }
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,

--- a/test/cpp/planner/test_plan_tree_shape.cpp
+++ b/test/cpp/planner/test_plan_tree_shape.cpp
@@ -361,6 +361,7 @@ TEST_CASE_METHOD(plan_tree_shape_fixture,
   REQUIRE(!gpu_scans.empty());
   for (auto* scan : gpu_scans) {
     CHECK(scan->children.empty());
+    CHECK(scan->declared_output_schema_is_runtime_schema());
   }
 }
 
@@ -786,6 +787,7 @@ TEST_CASE_METHOD(plan_tree_shape_fixture,
     gen.insert_gpu_pipeline_operators(plan);
 
     auto& delim_ref = plan->Cast<sirius::op::sirius_physical_delim_join>();
+    CHECK_FALSE(delim_ref.declared_output_schema_is_runtime_schema());
     REQUIRE(delim_ref.distinct_root);
     auto* merge = delim_ref.distinct_root.get();
     REQUIRE(merge->type == SiriusPhysicalOperatorType::MERGE_GROUP_BY);


### PR DESCRIPTION
## Description

Fix the false TPC-H Q20 `RIGHT_DELIM_JOIN` datatype diagnostic while keeping runtime output-schema validation enabled by default.

Both LEFT and RIGHT delimiter `execute()` implementations forward their pipeline input batches unchanged, while the delimiter node's declared `types` describe the logical result of its internal join subtree. Comparing those unrelated schemas produces a misleading warning.

This change adds an explicit runtime-schema contract to physical operators. It defaults to enabled for materializing operators and opts out only the common delimiter pass-through class. It does not alter query output, scheduling, fallback, or the schemas declared by ordinary operators.

Tests cover the shared LEFT/RIGHT delimiter contract, retain a default-on assertion for `GPU_SCAN`, and run exact TPC-H Q20 Parquet while requiring the delimiter/output-batch warning to be absent.

## Validation

- Sirius `dev` base: `f107ba88f1d473223169d6d2d9dd0c9e3bf75af0`
- Clean isolated NVIDIA L4 release build: 1,285/1,285 actions completed
- Focused planner selector: 24/24 assertions passed
- Exact TPC-H Q20 Parquet selector: 124/124 assertions passed
- Validated source patch SHA-256: `f6d7bf9518858528b8c42f7f266a20425c1523c95b5e9f6610001796ba711341`
- The PR adds only the repository formatter's include-order normalization to those validated bytes
- clang-format 20.1.4, focused codespell, orphan-test check, and `git diff --check` passed

## Checklist

- [x] Read `CONTRIBUTING.md`
- [x] Added focused planner and integration regressions
- [x] No Sirius configuration option changes
- [x] No user-facing documentation change required
