### PR TITLE
fix(aggregate): record AVG local accumulator schema

### DIFF
--- a/src/include/op/sirius_physical_ungrouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate.hpp
@@ -44,6 +44,10 @@ class sirius_physical_ungrouped_aggregate : public sirius_physical_operator {
   //! The aggregates that have to be computed
   duckdb::vector<std::unique_ptr<sirius::ast::node>> aggregates;
 
+  //! Schema emitted by the per-task partial aggregate. AVG expands to SUM + COUNT here; the
+  //! MERGE_AGGREGATE above this operator collapses those carriers to the declared SQL schema.
+  [[nodiscard]] duckdb::vector<sirius::logical_type> get_local_output_types() const;
+
   bool is_source() const override { return true; }
 
  public:

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -277,7 +277,15 @@ std::unique_ptr<cudf::column> make_avg_column(const cudf::column_view& sum_view,
 duckdb::vector<sirius::logical_type> sirius_physical_ungrouped_aggregate::get_local_output_types()
   const
 {
-  auto layout = build_aggregate_layout(aggregates);
+  aggregate_layout layout;
+  try {
+    layout = build_aggregate_layout(aggregates);
+  } catch (const not_implemented_exception&) {
+    // Keep unsupported aggregates on their established runtime-fallback path. Their local output
+    // is never consumed, so retaining the declared schema here avoids turning a runtime fallback
+    // into an earlier planning refusal merely to describe an output that will not be produced.
+    return types;
+  }
   duckdb::vector<sirius::logical_type> local_types;
   local_types.reserve(layout.local_types.size());
   for (auto const& type : layout.local_types) {

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -192,14 +192,23 @@ aggregate_layout build_aggregate_layout(
         layout.merge_kinds.push_back(cudf::aggregation::Kind::MAX);
         layout.merge_nth_index.push_back(std::nullopt);
         break;
-      case sirius::aggregate_id::avg:
+      case sirius::aggregate_id::avg: {
         if (children.empty()) {
           throw not_implemented_exception("avg() without arguments not supported");
         }
         spec.kind          = aggregate_kind::AVG;
         spec.input_idx     = child_ref_index();
         spec.local_sum_idx = local_idx++;
-        layout.local_types.push_back(agg_return_type);
+        // AVG's local carrier is the input type, not AVG's final return type. Execution widens
+        // signed 8/16/32-bit inputs to INT64 before reducing so partial sums merge without a
+        // cross-type reduction; keep the declared local schema on the same rule.
+        auto local_sum_type = sirius::to_duckdb(children[0]->return_type());
+        if (local_sum_type.id() == duckdb::LogicalTypeId::TINYINT ||
+            local_sum_type.id() == duckdb::LogicalTypeId::SMALLINT ||
+            local_sum_type.id() == duckdb::LogicalTypeId::INTEGER) {
+          local_sum_type = duckdb::LogicalType::BIGINT;
+        }
+        layout.local_types.push_back(std::move(local_sum_type));
         layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
         layout.merge_nth_index.push_back(std::nullopt);
         spec.local_count_idx = local_idx++;
@@ -208,6 +217,7 @@ aggregate_layout build_aggregate_layout(
         layout.merge_nth_index.push_back(std::nullopt);
         layout.has_avg = true;
         break;
+      }
       case sirius::aggregate_id::first:
         spec.kind          = aggregate_kind::FIRST;
         spec.input_idx     = child_ref_index();
@@ -263,6 +273,18 @@ std::unique_ptr<cudf::column> make_avg_column(const cudf::column_view& sum_view,
 }
 
 }  // namespace
+
+duckdb::vector<sirius::logical_type> sirius_physical_ungrouped_aggregate::get_local_output_types()
+  const
+{
+  auto layout = build_aggregate_layout(aggregates);
+  duckdb::vector<sirius::logical_type> local_types;
+  local_types.reserve(layout.local_types.size());
+  for (auto const& type : layout.local_types) {
+    local_types.push_back(sirius::from_duckdb(type));
+  }
+  return local_types;
+}
 
 std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -461,6 +461,11 @@ void wrap_ungrouped_aggregate(duckdb::unique_ptr<sirius::op::sirius_physical_ope
     auto* ungrouped_ptr = ungrouped_op.get();
     auto merge          = duckdb::make_uniq<sirius::op::sirius_physical_ungrouped_aggregate_merge>(
       &ungrouped_ptr->Cast<sirius::op::sirius_physical_ungrouped_aggregate>());
+    // MERGE_AGGREGATE keeps the final SQL schema copied above. The child emits per-task
+    // accumulator carriers instead: AVG is SUM + COUNT, so its runtime width is larger than the
+    // final width. Recording that schema on the child keeps task-level output validation exact.
+    ungrouped_ptr->types = ungrouped_ptr->Cast<sirius::op::sirius_physical_ungrouped_aggregate>()
+                             .get_local_output_types();
     merge->children.push_back(std::move(ungrouped_op));
     return merge;
   });

--- a/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
+++ b/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
@@ -271,7 +271,8 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate resolves AVG in merge",
                    int32_t,
                    int64_t,
                    float,
-                   double)
+                   double,
+                   decimal64_tag)
 {
   using Traits = gpu_type_traits<TestType>;
 
@@ -289,21 +290,27 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate resolves AVG in merge",
   std::vector<typename Traits::type> batch2_vals(vals.begin() + 2, vals.begin() + 4);
 
   std::shared_ptr<data_batch> b1, b2;
-  b1 = make_numeric_batch<typename Traits::type>(*space, batch1_vals, Traits::cudf_type);
-  b2 = make_numeric_batch<typename Traits::type>(*space, batch2_vals, Traits::cudf_type);
+  if constexpr (Traits::is_decimal) {
+    b1 = make_decimal64_batch(*space, batch1_vals, Traits::scale);
+    b2 = make_decimal64_batch(*space, batch2_vals, Traits::scale);
+  } else {
+    b1 = make_numeric_batch<typename Traits::type>(*space, batch1_vals, Traits::cudf_type);
+    b2 = make_numeric_batch<typename Traits::type>(*space, batch2_vals, Traits::cudf_type);
+  }
 
   auto make_avg_aggregates = [&](duckdb::vector<duckdb::LogicalType>& ret_types) {
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> aggregates;
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
     children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
+    auto return_type =
+      Traits::is_decimal ? Traits::logical_type() : LogicalType(duckdb::LogicalTypeId::DOUBLE);
     aggregates.push_back(make_uniq<BoundAggregateExpression>(
-      MakeDummyAggregate(
-        "avg", {Traits::logical_type()}, LogicalType(duckdb::LogicalTypeId::DOUBLE)),
+      MakeDummyAggregate("avg", {Traits::logical_type()}, return_type),
       std::move(children),
       nullptr,
       nullptr,
       AggregateType::NON_DISTINCT));
-    ret_types.push_back(LogicalType(duckdb::LogicalTypeId::DOUBLE));
+    ret_types.push_back(return_type);
     return aggregates;
   };
 
@@ -346,11 +353,22 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate resolves AVG in merge",
   REQUIRE(view.num_columns() == 1);
   REQUIRE(view.num_rows() == 1);
 
-  auto avg_out        = copy_column_to_host<double>(view.column(0));
-  double expected_sum = 0.0;
-  for (auto v : vals) {
-    expected_sum += static_cast<double>(v);
+  if constexpr (Traits::is_decimal) {
+    REQUIRE(view.column(0).type() == cudf::data_type{cudf::type_id::DECIMAL64, Traits::scale});
+    auto avg_out                       = copy_column_to_host<typename Traits::type>(view.column(0));
+    typename Traits::type expected_sum = 0;
+    for (auto v : vals) {
+      expected_sum += v;
+    }
+    // The sample values divide exactly in their fixed-point representation.
+    REQUIRE(avg_out[0] == expected_sum / static_cast<typename Traits::type>(vals.size()));
+  } else {
+    auto avg_out        = copy_column_to_host<double>(view.column(0));
+    double expected_sum = 0.0;
+    for (auto v : vals) {
+      expected_sum += static_cast<double>(v);
+    }
+    double expected_avg = expected_sum / static_cast<double>(vals.size());
+    REQUIRE(avg_out[0] == Approx(expected_avg));
   }
-  double expected_avg = expected_sum / static_cast<double>(vals.size());
-  REQUIRE(avg_out[0] == Approx(expected_avg));
 }

--- a/test/cpp/planner/test_plan_tree_shape.cpp
+++ b/test/cpp/planner/test_plan_tree_shape.cpp
@@ -326,6 +326,8 @@ struct plan_tree_shape_fixture {
       "(9,27),(10,30),(11,33),(12,36),(13,39),(14,42),(15,45),(16,48),(17,51),(18,54),(19,57)");
     con->Query("CREATE TABLE small_right (rid INTEGER, other INTEGER)");
     con->Query("INSERT INTO small_right VALUES (0, 0), (1, 1)");
+    con->Query("CREATE TABLE decimal_values (amount DECIMAL(15,2))");
+    con->Query("INSERT INTO decimal_values VALUES (1.00), (2.50), (3.75)");
 
     // parts/items reproduce TPC-H q17's RIGHT_DELIM_JOIN: the filter on the correlated
     // table keeps the deliminator from rewriting the correlated aggregate into a plain
@@ -448,6 +450,41 @@ TEST_CASE_METHOD(plan_tree_shape_fixture,
     REQUIRE(merge != nullptr);
     REQUIRE(merge->children.size() == 1);
     CHECK(merge->children[0]->type == SiriusPhysicalOperatorType::UNGROUPED_AGGREGATE);
+  }
+
+  SECTION("AVG records its two-column local accumulator schema below MERGE_AGGREGATE")
+  {
+    auto plan = generate_sirius_plan(*con, "SELECT avg(val) FROM big_left");
+    INFO(tree_to_string(plan.get()));
+
+    auto* merge = find_first(plan.get(), SiriusPhysicalOperatorType::MERGE_AGGREGATE);
+    REQUIRE(merge != nullptr);
+    REQUIRE(merge->get_types().size() == 1);
+    REQUIRE(merge->children.size() == 1);
+
+    auto* local = merge->children[0].get();
+    REQUIRE(local->type == SiriusPhysicalOperatorType::UNGROUPED_AGGREGATE);
+    duckdb::vector<sirius::logical_type> const expected_local_types{
+      sirius::logical_type::make(sirius::type_id::BIGINT),
+      sirius::logical_type::make(sirius::type_id::BIGINT)};
+    CHECK(local->get_types() == expected_local_types);
+  }
+
+  SECTION("AVG preserves its DECIMAL local sum carrier below MERGE_AGGREGATE")
+  {
+    auto plan = generate_sirius_plan(*con, "SELECT avg(amount) FROM decimal_values");
+    INFO(tree_to_string(plan.get()));
+
+    auto* merge = find_first(plan.get(), SiriusPhysicalOperatorType::MERGE_AGGREGATE);
+    REQUIRE(merge != nullptr);
+    REQUIRE(merge->get_types().size() == 1);
+    REQUIRE(merge->children.size() == 1);
+
+    auto* local = merge->children[0].get();
+    REQUIRE(local->type == SiriusPhysicalOperatorType::UNGROUPED_AGGREGATE);
+    REQUIRE(local->get_types().size() == 2);
+    CHECK(local->get_types()[0] == sirius::logical_type::make_decimal(15, 2));
+    CHECK(local->get_types()[1].id() == sirius::type_id::BIGINT);
   }
 }
 


### PR DESCRIPTION
## Summary

- record the local two-column AVG accumulator schema below `MERGE_AGGREGATE`
- keep the local sum carrier aligned with execution, including integer widening and DECIMAL preservation
- add planner coverage for integer and DECIMAL AVG plus a DECIMAL64 execution case

## Why

The ungrouped aggregate child emits partial AVG state as `SUM + COUNT`, while the merge operator exposes the final one-column SQL schema. The planner previously copied the final schema onto the local child, so task-level validation compared a two-column runtime batch with a one-column declaration.

## Validation

Validated on Sirius `f107ba88f1d473223169d6d2d9dd0c9e3bf75af0` using an NVIDIA L4:

- affected Release build completed successfully
- planner selector: 33 assertions in 1 test case
- AVG execution wildcard: 26 assertions in 5 test cases
- the five executed template instances were exactly `int32_t`, `int64_t`, `float`, `double`, and `decimal64_tag`
- `clang-format` 20.1.4 was idempotent; focused codespell and orphan-test checks passed

## Validation history

The first implementation attempt exposed two compile defects before any result was accepted: a case-local variable crossed switch labels, and a `std::vector` was passed to a helper requiring `duckdb::vector`. This revision braces the AVG case and performs the type conversion explicitly. A later selector used an exact Catch2 name and matched zero template instances; that run was rejected. The final wildcard run enumerated and executed all five instances above, including DECIMAL64.
