### PR TITLE
fix(config): reject inactive prefetch-cache settings

### DIFF
--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -249,10 +249,10 @@ static void from_yaml(const YAML::Node& node, scan_manager::scan_manager_config&
                                    cache_reader.has_value("dispose_after_use") ||
                                    cache_reader.has_value("min_prefetching_budget_fraction") ||
                                    cache_reader.has_value("eviction_threshold_fraction");
-    sirius::from_yaml(*n, opt.cache);
     if (!opt.enable_prefetch_cache && has_cache_setting) {
       throw std::runtime_error("scan_manager.cache: requires enable_prefetch_cache: true");
     }
+    sirius::from_yaml(*n, opt.cache);
   }
   if (auto n = r.optional_node("object_store")) sirius::from_yaml(*n, opt.object_store);
   if (auto n = r.optional_node("memory_prefetcher")) from_yaml(*n, opt.memory_prefetcher);

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -245,15 +245,13 @@ static void from_yaml(const YAML::Node& node, scan_manager::scan_manager_config&
   if (auto n = r.optional_node("rest")) sirius::from_yaml(*n, opt.rest);
   if (auto n = r.optional_node("cache")) {
     yaml::reader cache_reader(*n, "cache");
-    bool const has_cache_setting =
-      cache_reader.has_value("inflight_io_chunk_budget") ||
-      cache_reader.has_value("dispose_after_use") ||
-      cache_reader.has_value("min_prefetching_budget_fraction") ||
-      cache_reader.has_value("eviction_threshold_fraction");
+    bool const has_cache_setting = cache_reader.has_value("inflight_io_chunk_budget") ||
+                                   cache_reader.has_value("dispose_after_use") ||
+                                   cache_reader.has_value("min_prefetching_budget_fraction") ||
+                                   cache_reader.has_value("eviction_threshold_fraction");
     sirius::from_yaml(*n, opt.cache);
     if (!opt.enable_prefetch_cache && has_cache_setting) {
-      throw std::runtime_error(
-        "scan_manager.cache: requires enable_prefetch_cache: true");
+      throw std::runtime_error("scan_manager.cache: requires enable_prefetch_cache: true");
     }
   }
   if (auto n = r.optional_node("object_store")) sirius::from_yaml(*n, opt.object_store);

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -243,7 +243,19 @@ static void from_yaml(const YAML::Node& node, scan_manager::scan_manager_config&
   r.optional("enable_prefetch_cache", opt.enable_prefetch_cache);
   if (auto n = r.optional_node("local")) sirius::from_yaml(*n, opt.local);
   if (auto n = r.optional_node("rest")) sirius::from_yaml(*n, opt.rest);
-  if (auto n = r.optional_node("cache")) sirius::from_yaml(*n, opt.cache);
+  if (auto n = r.optional_node("cache")) {
+    yaml::reader cache_reader(*n, "cache");
+    bool const has_cache_setting =
+      cache_reader.has_value("inflight_io_chunk_budget") ||
+      cache_reader.has_value("dispose_after_use") ||
+      cache_reader.has_value("min_prefetching_budget_fraction") ||
+      cache_reader.has_value("eviction_threshold_fraction");
+    sirius::from_yaml(*n, opt.cache);
+    if (!opt.enable_prefetch_cache && has_cache_setting) {
+      throw std::runtime_error(
+        "scan_manager.cache: requires enable_prefetch_cache: true");
+    }
+  }
   if (auto n = r.optional_node("object_store")) sirius::from_yaml(*n, opt.object_store);
   if (auto n = r.optional_node("memory_prefetcher")) from_yaml(*n, opt.memory_prefetcher);
   r.reject_unknown();

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -257,8 +257,8 @@ TEST_CASE("sirius_config defaults chunk prewarm to enabled when YAML omits the k
 TEST_CASE("sirius_config rejects inactive prefetch cache settings",
           "[scan_manager][config][prefetching_cache]")
 {
-  for (auto const enable_line : {std::string{},
-                                 std::string{"      enable_prefetch_cache: false\n"}}) {
+  for (auto const enable_line :
+       {std::string{}, std::string{"      enable_prefetch_cache: false\n"}}) {
     auto const path = std::filesystem::temp_directory_path() /
                       (enable_line.empty() ? "sirius_cache_disabled_implicitly.yaml"
                                            : "sirius_cache_disabled_explicitly.yaml");
@@ -287,8 +287,7 @@ TEST_CASE("sirius_config treats null and empty prefetch cache blocks as absent",
                                 std::string{"      cache: {}\n"},
                                 std::string{"      cache:\n"
                                             "        inflight_io_chunk_budget: null\n"}}) {
-    auto const path =
-      std::filesystem::temp_directory_path() / "sirius_cache_inactive_absent.yaml";
+    auto const path = std::filesystem::temp_directory_path() / "sirius_cache_inactive_absent.yaml";
     write_yaml(path,
                "sirius:\n"
                "  executor:\n"
@@ -307,8 +306,7 @@ TEST_CASE("sirius_config treats null and empty prefetch cache blocks as absent",
 TEST_CASE("sirius_config accepts prefetch cache settings when enabled",
           "[scan_manager][config][prefetching_cache]")
 {
-  auto const path =
-    std::filesystem::temp_directory_path() / "sirius_cache_enabled_settings.yaml";
+  auto const path = std::filesystem::temp_directory_path() / "sirius_cache_enabled_settings.yaml";
   write_yaml(path,
              "sirius:\n"
              "  executor:\n"

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -259,24 +259,32 @@ TEST_CASE("sirius_config rejects inactive prefetch cache settings",
 {
   for (auto const enable_line :
        {std::string{}, std::string{"      enable_prefetch_cache: false\n"}}) {
-    auto const path = std::filesystem::temp_directory_path() /
-                      (enable_line.empty() ? "sirius_cache_disabled_implicitly.yaml"
-                                           : "sirius_cache_disabled_explicitly.yaml");
-    write_yaml(path,
-               "sirius:\n"
-               "  executor:\n"
-               "    scan_manager:\n" +
-                 enable_line +
-                 "      cache:\n"
-                 "        inflight_io_chunk_budget: 64\n");
+    for (auto const cache_setting : {std::string{"inflight_io_chunk_budget: 64"},
+                                     std::string{"dispose_after_use: true"},
+                                     std::string{"min_prefetching_budget_fraction: 0.1"},
+                                     std::string{"eviction_threshold_fraction: 0.7"}}) {
+      auto const path = std::filesystem::temp_directory_path() /
+                        (enable_line.empty() ? "sirius_cache_disabled_implicitly.yaml"
+                                             : "sirius_cache_disabled_explicitly.yaml");
+      write_yaml(path,
+                 "sirius:\n"
+                 "  executor:\n"
+                 "    scan_manager:\n" +
+                   enable_line + "      cache:\n        " + cache_setting + "\n");
 
-    sirius::sirius_config cfg;
-    CHECK_THROWS_WITH(cfg.load_from_file(path),
-                      Catch::Contains("scan_manager.cache") &&
-                        Catch::Contains("requires enable_prefetch_cache: true"));
+      sirius::sirius_config cfg;
+      CHECK_THROWS_WITH(cfg.load_from_file(path),
+                        Catch::Contains("scan_manager.cache") &&
+                          Catch::Contains("requires enable_prefetch_cache: true"));
+      auto const& cache = cfg.get_scan_manager_config().cache;
+      CHECK(cache.inflight_io_chunk_budget == 2048);
+      CHECK_FALSE(cache.dispose_after_use);
+      CHECK(cache.min_prefetching_budget_fraction == 0.05);
+      CHECK(cache.eviction_threshold_fraction == 0.6);
 
-    std::error_code ec;
-    std::filesystem::remove(path, ec);
+      std::error_code ec;
+      std::filesystem::remove(path, ec);
+    }
   }
 }
 

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -254,6 +254,85 @@ TEST_CASE("sirius_config defaults chunk prewarm to enabled when YAML omits the k
   std::filesystem::remove(path, ec);
 }
 
+TEST_CASE("sirius_config rejects inactive prefetch cache settings",
+          "[scan_manager][config][prefetching_cache]")
+{
+  for (auto const enable_line : {std::string{},
+                                 std::string{"      enable_prefetch_cache: false\n"}}) {
+    auto const path = std::filesystem::temp_directory_path() /
+                      (enable_line.empty() ? "sirius_cache_disabled_implicitly.yaml"
+                                           : "sirius_cache_disabled_explicitly.yaml");
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n" +
+                 enable_line +
+                 "      cache:\n"
+                 "        inflight_io_chunk_budget: 64\n");
+
+    sirius::sirius_config cfg;
+    CHECK_THROWS_WITH(cfg.load_from_file(path),
+                      Catch::Contains("scan_manager.cache") &&
+                        Catch::Contains("requires enable_prefetch_cache: true"));
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+  }
+}
+
+TEST_CASE("sirius_config treats null and empty prefetch cache blocks as absent",
+          "[scan_manager][config][prefetching_cache]")
+{
+  for (auto const cache_line : {std::string{"      cache: null\n"},
+                                std::string{"      cache: {}\n"},
+                                std::string{"      cache:\n"
+                                            "        inflight_io_chunk_budget: null\n"}}) {
+    auto const path =
+      std::filesystem::temp_directory_path() / "sirius_cache_inactive_absent.yaml";
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n" +
+                 cache_line);
+
+    sirius::sirius_config cfg;
+    REQUIRE_NOTHROW(cfg.load_from_file(path));
+    CHECK_FALSE(cfg.get_scan_manager_config().enable_prefetch_cache);
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+  }
+}
+
+TEST_CASE("sirius_config accepts prefetch cache settings when enabled",
+          "[scan_manager][config][prefetching_cache]")
+{
+  auto const path =
+    std::filesystem::temp_directory_path() / "sirius_cache_enabled_settings.yaml";
+  write_yaml(path,
+             "sirius:\n"
+             "  executor:\n"
+             "    scan_manager:\n"
+             "      enable_prefetch_cache: true\n"
+             "      cache:\n"
+             "        inflight_io_chunk_budget: 64\n"
+             "        min_prefetching_budget_fraction: 0.1\n"
+             "        eviction_threshold_fraction: 0.7\n"
+             "        dispose_after_use: true\n");
+
+  sirius::sirius_config cfg;
+  REQUIRE_NOTHROW(cfg.load_from_file(path));
+  auto const& scan = cfg.get_scan_manager_config();
+  CHECK(scan.enable_prefetch_cache);
+  CHECK(scan.cache.inflight_io_chunk_budget == 64);
+  CHECK(scan.cache.min_prefetching_budget_fraction == 0.1);
+  CHECK(scan.cache.eviction_threshold_fraction == 0.7);
+  CHECK(scan.cache.dispose_after_use);
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
 TEST_CASE("sirius_config parses rest perf instrumentation flag",
           "[scan_manager][config][s3][rest][perf]")
 {


### PR DESCRIPTION
## Summary

- Reject a non-null `scan_manager.cache` subkey when
  `enable_prefetch_cache` is false or omitted.
- Preserve absent-value behavior for a null cache block, an empty cache map,
  and null-valued subkeys.
- Reject before parsing the inert value and verify all four subkeys, so a
  refused load does not apply the ignored cache value.
- Keep the enabled path unchanged and verify readback of all four settings.

## Why

Sirius currently accepts the four cache settings even while both cache
construction sites are disabled by `enable_prefetch_cache`. The values look
valid but have no effect. Rejecting that inconsistent configuration makes the
dependency visible without selecting a new cache default or claiming the
cache should always be enabled.

## Validation

Current identity:

- base: `4872cd3c490baf59f2591c527f8fbb6833416e0f`
- head: `2b524020564329e76bbdf297f14190bbaa6b0923`
- tree: `d5c4f4bc2222d8b5100b82f30eefdc157e3a0b28`

The retained zero-context diff replays on the exact base to the exact head
tree. Exact-head lint, x64 GCC release, x64 Clang debug, CUDA 13 build, the
20-minute CUDA 13 runtime suite, distribution, title, and aggregate gates are
terminal green.

Earlier compiled L4 validation of the same activation rule passed on Sirius
`ee6b3d80` and `a4f31124`:

- clean release build: 1285/1285 actions;
- warm incremental build: 245/245 actions;
- `[scan_manager][config][prefetching_cache]`: 21/21 assertions on both;
- `[config_opt]`: 93/93 on both;
- `[object_store_config][s3][config]`: 26/26 on both;
- `[sirius][config]`: 272/272 and 277/277 respectively.

The current-head regression additionally covers every cache subkey under
implicit and explicit disablement and verifies default preservation after
refusal.

## Scope

This validates configuration dependencies only. It does not change the
prefetch-cache default or make a performance claim.
