### PR TITLE
fix(config): validate dynamic filter thresholds

### DIFF
--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -273,8 +273,11 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
   r.optional("enable_dynamic_filter_pushdown", opt.enable_dynamic_filter_pushdown);
   r.optional("enable_dynamic_zone_map_filter", opt.enable_dynamic_zone_map_filter);
   r.optional("dynamic_filter_domain_coverage_threshold",
-             opt.dynamic_filter_domain_coverage_threshold);
-  r.optional("dynamic_filter_keep_threshold", opt.dynamic_filter_keep_threshold);
+             opt.dynamic_filter_domain_coverage_threshold,
+             yaml::greater_than<double>{0.0});
+  r.optional("dynamic_filter_keep_threshold",
+             opt.dynamic_filter_keep_threshold,
+             yaml::fraction<double>{});
   r.optional("enable_pinned_zone_map_pruning", opt.enable_pinned_zone_map_pruning);
   r.optional("enable_compressed_materialization", opt.enable_compressed_materialization);
   r.reject_unknown();

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -275,9 +275,8 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
   r.optional("dynamic_filter_domain_coverage_threshold",
              opt.dynamic_filter_domain_coverage_threshold,
              yaml::greater_than<double>{0.0});
-  r.optional("dynamic_filter_keep_threshold",
-             opt.dynamic_filter_keep_threshold,
-             yaml::fraction<double>{});
+  r.optional(
+    "dynamic_filter_keep_threshold", opt.dynamic_filter_keep_threshold, yaml::fraction<double>{});
   r.optional("enable_pinned_zone_map_pruning", opt.enable_pinned_zone_map_pruning);
   r.optional("enable_compressed_materialization", opt.enable_compressed_materialization);
   r.reject_unknown();

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2082,7 +2082,7 @@ static void SetDynamicFilterDomainCoverageThreshold(ClientContext& context,
   if (!params) { return; }
   auto slot              = lock_operator_params_slot(context);
   const double threshold = parameter.GetValue<double>();
-  if (threshold <= 0.0) {
+  if (!(threshold > 0.0)) {
     throw InvalidInputException("dynamic_filter_domain_coverage_threshold must be > 0.0, got %f",
                                 threshold);
   }
@@ -2097,7 +2097,7 @@ static void SetDynamicFilterKeepThreshold(ClientContext& context, SetScope scope
   if (!params) { return; }
   auto slot              = lock_operator_params_slot(context);
   const double threshold = parameter.GetValue<double>();
-  if (threshold < 0.0 || threshold > 1.0) {
+  if (!(threshold >= 0.0 && threshold <= 1.0)) {
     throw InvalidInputException("dynamic_filter_keep_threshold must be in [0.0, 1.0], got %f",
                                 threshold);
   }

--- a/test/cpp/config/data/invalid_dynamic_filter_domain_coverage_threshold.yaml
+++ b/test/cpp/config/data/invalid_dynamic_filter_domain_coverage_threshold.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    dynamic_filter_domain_coverage_threshold: 0

--- a/test/cpp/config/data/invalid_dynamic_filter_domain_coverage_threshold_nan.yaml
+++ b/test/cpp/config/data/invalid_dynamic_filter_domain_coverage_threshold_nan.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    dynamic_filter_domain_coverage_threshold: .nan

--- a/test/cpp/config/data/invalid_dynamic_filter_keep_threshold_above_one.yaml
+++ b/test/cpp/config/data/invalid_dynamic_filter_keep_threshold_above_one.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    dynamic_filter_keep_threshold: 1.1

--- a/test/cpp/config/data/invalid_dynamic_filter_keep_threshold_nan.yaml
+++ b/test/cpp/config/data/invalid_dynamic_filter_keep_threshold_nan.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    dynamic_filter_keep_threshold: .nan

--- a/test/cpp/config/data/invalid_dynamic_filter_keep_threshold_negative.yaml
+++ b/test/cpp/config/data/invalid_dynamic_filter_keep_threshold_negative.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    dynamic_filter_keep_threshold: -0.1

--- a/test/cpp/config/data/valid_dynamic_filter_threshold_boundaries.yaml
+++ b/test/cpp/config/data/valid_dynamic_filter_threshold_boundaries.yaml
@@ -1,0 +1,6 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    dynamic_filter_domain_coverage_threshold: 1.5
+    dynamic_filter_keep_threshold: 0.0

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -329,6 +329,34 @@ TEST_CASE("Sirius configuration validates MARK join build switch ratio", "[siriu
   REQUIRE(config.get_operator_params().mark_join_build_switch_ratio == Approx(0.0));
 }
 
+TEST_CASE("Sirius YAML rejects invalid dynamic-filter thresholds", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  struct invalid_config {
+    const char* fixture;
+    const char* setting;
+  };
+  const invalid_config cases[] = {
+    {"invalid_dynamic_filter_domain_coverage_threshold.yaml",
+     "dynamic_filter_domain_coverage_threshold"},
+    {"invalid_dynamic_filter_keep_threshold_negative.yaml", "dynamic_filter_keep_threshold"},
+    {"invalid_dynamic_filter_keep_threshold_above_one.yaml", "dynamic_filter_keep_threshold"},
+  };
+
+  for (auto const& invalid : cases) {
+    INFO("fixture=" << invalid.fixture << " setting=" << invalid.setting);
+    auto const path = data_dir / invalid.fixture;
+    REQUIRE(fs::is_regular_file(path));
+
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(config.load_from_file(path),
+                        Catch::Contains(invalid.setting) &&
+                          Catch::Contains("value out of range"));
+  }
+}
+
 namespace {
 
 void require_shared_operator_defaults(const sirius::operator_params& params, uint64_t batch)

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -352,8 +352,7 @@ TEST_CASE("Sirius YAML rejects invalid dynamic-filter thresholds", "[sirius][con
 
     sirius::sirius_config config;
     REQUIRE_THROWS_WITH(config.load_from_file(path),
-                        Catch::Contains(invalid.setting) &&
-                          Catch::Contains("value out of range"));
+                        Catch::Contains(invalid.setting) && Catch::Contains("value out of range"));
   }
 }
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -341,8 +341,11 @@ TEST_CASE("Sirius YAML rejects invalid dynamic-filter thresholds", "[sirius][con
   const invalid_config cases[] = {
     {"invalid_dynamic_filter_domain_coverage_threshold.yaml",
      "dynamic_filter_domain_coverage_threshold"},
+    {"invalid_dynamic_filter_domain_coverage_threshold_nan.yaml",
+     "dynamic_filter_domain_coverage_threshold"},
     {"invalid_dynamic_filter_keep_threshold_negative.yaml", "dynamic_filter_keep_threshold"},
     {"invalid_dynamic_filter_keep_threshold_above_one.yaml", "dynamic_filter_keep_threshold"},
+    {"invalid_dynamic_filter_keep_threshold_nan.yaml", "dynamic_filter_keep_threshold"},
   };
 
   for (auto const& invalid : cases) {
@@ -354,6 +357,12 @@ TEST_CASE("Sirius YAML rejects invalid dynamic-filter thresholds", "[sirius][con
     REQUIRE_THROWS_WITH(config.load_from_file(path),
                         Catch::Contains(invalid.setting) && Catch::Contains("value out of range"));
   }
+
+  sirius::sirius_config config;
+  REQUIRE_NOTHROW(
+    config.load_from_file(data_dir / "valid_dynamic_filter_threshold_boundaries.yaml"));
+  REQUIRE(config.get_operator_params().dynamic_filter_domain_coverage_threshold == Approx(1.5));
+  REQUIRE(config.get_operator_params().dynamic_filter_keep_threshold == Approx(0.0));
 }
 
 namespace {
@@ -787,6 +796,22 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE(sirius_ctx->get_config().get_operator_params().mark_join_build_switch_ratio ==
           Approx(3.0));
 
+  auto invalid_domain_threshold = con.Query("SET dynamic_filter_domain_coverage_threshold = 'NaN'");
+  REQUIRE(invalid_domain_threshold != nullptr);
+  REQUIRE(invalid_domain_threshold->HasError());
+  REQUIRE_THAT(invalid_domain_threshold->GetError(),
+               Catch::Contains("dynamic_filter_domain_coverage_threshold must be > 0.0"));
+  REQUIRE(sirius_ctx->get_config().get_operator_params().dynamic_filter_domain_coverage_threshold ==
+          Approx(0.8));
+
+  auto invalid_keep_threshold = con.Query("SET dynamic_filter_keep_threshold = 'NaN'");
+  REQUIRE(invalid_keep_threshold != nullptr);
+  REQUIRE(invalid_keep_threshold->HasError());
+  REQUIRE_THAT(invalid_keep_threshold->GetError(),
+               Catch::Contains("dynamic_filter_keep_threshold must be in [0.0, 1.0]"));
+  REQUIRE(sirius_ctx->get_config().get_operator_params().dynamic_filter_keep_threshold ==
+          Approx(0.7));
+
   auto nan_mark_join_ratio = con.Query("SET mark_join_build_switch_ratio = 'NaN'");
   REQUIRE(nan_mark_join_ratio != nullptr);
   REQUIRE(nan_mark_join_ratio->HasError());
@@ -819,6 +844,11 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   require_ok("RESET max_sort_partition_memory_fraction");
   require_ok("SET enable_dynamic_filter_pushdown = true");
   require_ok("RESET enable_dynamic_filter_pushdown");
+  require_ok("SET dynamic_filter_domain_coverage_threshold = 1.5");
+  require_ok("RESET dynamic_filter_domain_coverage_threshold");
+  require_ok("SET dynamic_filter_keep_threshold = 0.0");
+  require_ok("SET dynamic_filter_keep_threshold = 1.0");
+  require_ok("RESET dynamic_filter_keep_threshold");
   require_ok("SET enable_runtime_distinct_build_probe = true");
   require_ok("RESET enable_runtime_distinct_build_probe");
   require_ok("SET pin_table_compression = false");

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -348,17 +348,22 @@ TEST_CASE("Sirius YAML rejects invalid dynamic-filter thresholds", "[sirius][con
     {"invalid_dynamic_filter_keep_threshold_nan.yaml", "dynamic_filter_keep_threshold"},
   };
 
+  sirius::sirius_config config;
+  REQUIRE_NOTHROW(config.load_from_file(data_dir / "setting_defaults.yaml"));
+  REQUIRE(config.get_operator_params().dynamic_filter_domain_coverage_threshold == Approx(0.8));
+  REQUIRE(config.get_operator_params().dynamic_filter_keep_threshold == Approx(0.7));
+
   for (auto const& invalid : cases) {
     INFO("fixture=" << invalid.fixture << " setting=" << invalid.setting);
     auto const path = data_dir / invalid.fixture;
     REQUIRE(fs::is_regular_file(path));
 
-    sirius::sirius_config config;
     REQUIRE_THROWS_WITH(config.load_from_file(path),
                         Catch::Contains(invalid.setting) && Catch::Contains("value out of range"));
+    REQUIRE(config.get_operator_params().dynamic_filter_domain_coverage_threshold == Approx(0.8));
+    REQUIRE(config.get_operator_params().dynamic_filter_keep_threshold == Approx(0.7));
   }
 
-  sirius::sirius_config config;
   REQUIRE_NOTHROW(
     config.load_from_file(data_dir / "valid_dynamic_filter_threshold_boundaries.yaml"));
   REQUIRE(config.get_operator_params().dynamic_filter_domain_coverage_threshold == Approx(1.5));


### PR DESCRIPTION
## Summary

- validate `dynamic_filter_domain_coverage_threshold` as greater than zero in YAML
- validate `dynamic_filter_keep_threshold` as a fraction in `[0, 1]` in YAML
- reject NaN through both YAML and DuckDB `SET` without mutating the active value
- retain the documented valid boundaries: domain values above one and keep values at zero or one

## Why

The same threshold bounds were enforced through DuckDB `SET` but not through
`sirius.yaml`, so invalid file values could survive until dynamic-filter
planning or execution. The prior `SET` comparisons also admitted NaN because
every ordered comparison against NaN is false. This aligns both entry paths and
makes the existing contracts fail closed.

## Rebase coordination

This candidate is rebased onto the protected merge of #1490. The only conflict
was additive test placement in `test/cpp/config/test_context.cpp`. Its union
retains the merged negative-host-capacity and MARK-ratio tests plus this PR's
complete dynamic-filter threshold coverage. Production semantics from the
reviewed predecessor are preserved, with the additional NaN-closed `SET`
comparisons.

## Validation

- YAML rejects domain zero and NaN; accepts a domain value above one
- YAML rejects keep values below zero, above one, and NaN; accepts zero
- invalid YAML and DuckDB `SET` both preserve the prior threshold values
- DuckDB `SET` rejects NaN for both thresholds before assignment
- DuckDB `SET` accepts domain 1.5 and keep boundaries 0 and 1; RESET remains valid
- independent exact-current semantic and conflict-union review: CLEAR
- exact patch replay from current `dev` reproduces the candidate tree
- `git diff --check` and orphan-test validation: pass
- fresh exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full runtime, and terminal aggregate checks: pass
- hosted workflow [31711145481](https://github.com/sirius-db/sirius/actions/runs/31711145481): runtime job `94484972199` passed in 20m09s; aggregate job `94513537302` passed

Exact base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`  
Candidate: `8ef3ed9c67b34800b7d08dbf15a2c995a87b218b`  
Tree: `f158f5217eb29e689b7a09514df7d05ae71385c1`  
Patch SHA-256: `5dc8cac9c320b24a7dd2150b09aa606e45150b1491a2ed23e443e4df42f97dfb`

The predecessor head `ef4dffca8b6bb0faa3e161f8bdb24c3f438f6011`
passed hosted lint, GCC release, Clang debug, CUDA 13 build, full CUDA runtime,
and terminal aggregate checks. Those receipts are historical and do not
transfer to this rebased candidate.
