### PR TITLE
fix(config): reject negative MARK join switch ratios

### DIFF
--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <exception>
+#include <limits>
 #include <stdexcept>
 #include <string_view>
 #include <variant>
@@ -265,7 +266,9 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
   r.optional("sort_sample_bytes", yaml::bytes(opt.sort_sample_bytes));
   r.optional("max_build_hash_table_bytes", yaml::bytes(opt.max_build_hash_table_bytes));
   r.optional("max_broadcast_join_size", yaml::bytes(opt.max_broadcast_join_size));
-  r.optional("mark_join_build_switch_ratio", opt.mark_join_build_switch_ratio);
+  r.optional("mark_join_build_switch_ratio",
+             opt.mark_join_build_switch_ratio,
+             yaml::between<double>{0.0, std::numeric_limits<double>::infinity()});
   r.optional("enable_runtime_distinct_build_probe", opt.enable_runtime_distinct_build_probe);
   r.optional("enable_dynamic_filter_pushdown", opt.enable_dynamic_filter_pushdown);
   r.optional("enable_dynamic_zone_map_filter", opt.enable_dynamic_zone_map_filter);

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1988,7 +1988,7 @@ static void SetMarkJoinBuildSwitchRatio(ClientContext& context, SetScope scope, 
   if (!params) { return; }
   auto slot          = lock_operator_params_slot(context);
   const double ratio = parameter.GetValue<double>();
-  if (ratio < 0.0) {
+  if (!(ratio >= 0.0)) {
     throw InvalidInputException("mark_join_build_switch_ratio must be >= 0.0, got %f", ratio);
   }
   params->mark_join_build_switch_ratio = ratio;

--- a/test/cpp/config/data/invalid_mark_join_switch_nan.yaml
+++ b/test/cpp/config/data/invalid_mark_join_switch_nan.yaml
@@ -1,0 +1,3 @@
+sirius:
+  operator_params:
+    mark_join_build_switch_ratio: .nan

--- a/test/cpp/config/data/invalid_mark_join_switch_negative.yaml
+++ b/test/cpp/config/data/invalid_mark_join_switch_negative.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    mark_join_build_switch_ratio: -1.0

--- a/test/cpp/config/data/valid_mark_join_switch_zero.yaml
+++ b/test/cpp/config/data/valid_mark_join_switch_zero.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    mark_join_build_switch_ratio: 0.0

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -310,6 +310,25 @@ TEST_CASE("Sirius configuration rejects negative host capacity bytes", "[sirius]
                         Catch::Contains("byte value must be non-negative"));
 }
 
+TEST_CASE("Sirius configuration validates MARK join build switch ratio", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  sirius::sirius_config config;
+  auto const default_ratio = config.get_operator_params().mark_join_build_switch_ratio;
+  REQUIRE_THROWS_WITH(
+    config.load_from_file(data_dir / "invalid_mark_join_switch_negative.yaml"),
+    Catch::Contains("mark_join_build_switch_ratio") && Catch::Contains("value out of range"));
+  REQUIRE(config.get_operator_params().mark_join_build_switch_ratio == Approx(default_ratio));
+  REQUIRE_THROWS_WITH(
+    config.load_from_file(data_dir / "invalid_mark_join_switch_nan.yaml"),
+    Catch::Contains("mark_join_build_switch_ratio") && Catch::Contains("value out of range"));
+  REQUIRE(config.get_operator_params().mark_join_build_switch_ratio == Approx(default_ratio));
+  REQUIRE_NOTHROW(config.load_from_file(data_dir / "valid_mark_join_switch_zero.yaml"));
+  REQUIRE(config.get_operator_params().mark_join_build_switch_ratio == Approx(0.0));
+}
+
 namespace {
 
 void require_shared_operator_defaults(const sirius::operator_params& params, uint64_t batch)
@@ -732,6 +751,34 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE(zero_partition != nullptr);
   REQUIRE(zero_partition->HasError());
   REQUIRE(sirius_ctx->get_config().get_operator_params().hash_partition_bytes == 3 * mib);
+
+  auto negative_mark_join_ratio = con.Query("SET mark_join_build_switch_ratio = -1.0");
+  REQUIRE(negative_mark_join_ratio != nullptr);
+  REQUIRE(negative_mark_join_ratio->HasError());
+  REQUIRE_THAT(negative_mark_join_ratio->GetError(),
+               Catch::Contains("mark_join_build_switch_ratio must be >= 0.0"));
+  REQUIRE(sirius_ctx->get_config().get_operator_params().mark_join_build_switch_ratio ==
+          Approx(3.0));
+
+  auto nan_mark_join_ratio = con.Query("SET mark_join_build_switch_ratio = 'NaN'");
+  REQUIRE(nan_mark_join_ratio != nullptr);
+  REQUIRE(nan_mark_join_ratio->HasError());
+  REQUIRE_THAT(nan_mark_join_ratio->GetError(),
+               Catch::Contains("mark_join_build_switch_ratio must be >= 0.0"));
+  REQUIRE(sirius_ctx->get_config().get_operator_params().mark_join_build_switch_ratio ==
+          Approx(3.0));
+
+  auto zero_mark_join_ratio = con.Query("SET mark_join_build_switch_ratio = 0.0");
+  REQUIRE(zero_mark_join_ratio != nullptr);
+  REQUIRE_FALSE(zero_mark_join_ratio->HasError());
+  REQUIRE(sirius_ctx->get_config().get_operator_params().mark_join_build_switch_ratio ==
+          Approx(0.0));
+
+  auto reset_mark_join_ratio = con.Query("RESET mark_join_build_switch_ratio");
+  REQUIRE(reset_mark_join_ratio != nullptr);
+  REQUIRE_FALSE(reset_mark_join_ratio->HasError());
+  REQUIRE(sirius_ctx->get_config().get_operator_params().mark_join_build_switch_ratio ==
+          Approx(3.0));
 
   auto const require_ok = [&con](std::string const& sql) {
     auto result = con.Query(sql);


### PR DESCRIPTION
## Summary

- reject negative and NaN `mark_join_build_switch_ratio` values on both YAML and DuckDB `SET` surfaces
- preserve `0` as the documented way to disable the MARK join build-side switch
- preserve the prior configured value when validation fails
- retain existing positive-infinity and negative-zero semantics; finite-only validation is not introduced here

Previously, YAML accepted negatives that silently behaved like `0`. The first
repair aligned YAML with the existing `SET ratio < 0.0` check. Maintainer review
then caught that YAML rejected NaN while `SET` accepted it because ordered
comparison with NaN is false. The setter now uses `!(ratio >= 0.0)`, matching
the YAML range validator without broadening the contract.

## Validation

- exact-base NVIDIA L4 release build and focused suites passed for the negative/zero candidate: `[sirius][config]` 290 assertions / 24 test cases; `[sirius][context][config][isolated_context]` 102 assertions / 3 test cases
- test binary SHA-256: `6d6853f13ac476bdf58874b291fcf4087599f355ced67c631b67f8c09f29adb8`
- maintainer-requested YAML `.nan` and DuckDB `SET ... = 'NaN'` regressions assert refusal and destination preservation
- current exact-head lint, Clang debug, and CUDA 13 build pass; GCC release and CUDA runtime are running/queued

Exact base: `e967464a90bbad8ce49a4b1d1c24d5038f83d1b1`  
Current candidate: `943dde68ef8318a18f38f32d40eed44955236831`  
Current tree: `7e926e2cc547349abd253c9b6490505a43d06702`
