### PR TITLE
fix(config): reject negative YAML byte values

### DIFF
--- a/src/include/yaml_reader.hpp
+++ b/src/include/yaml_reader.hpp
@@ -22,6 +22,7 @@
 #include <concepts>
 #include <cstdint>
 #include <filesystem>
+#include <optional>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -96,7 +97,8 @@ inline std::uint64_t parse_bytes(std::string_view sv)
   if (pos == 0) { throw std::runtime_error("invalid byte value: '" + std::string(sv) + "'"); }
 
   double number = std::stod(std::string(sv.substr(0, pos)));
-  auto suffix   = sv.substr(pos);
+  if (number < 0) { throw std::runtime_error("byte value must be non-negative"); }
+  auto suffix = sv.substr(pos);
 
   // Strip leading whitespace from suffix
   while (!suffix.empty() && suffix[0] == ' ') {
@@ -224,14 +226,21 @@ bytes_value<T> bytes(T& v)
 template <std::integral T>
 void read_yaml(const YAML::Node& node, bytes_value<T>& out)
 {
+  T val{};
   try {
-    if constexpr (sizeof(T) > 4)
-      out.ref = static_cast<T>(node.as<long long>());
-    else
-      out.ref = static_cast<T>(node.as<int>());
+    if constexpr (sizeof(T) > 4) {
+      auto const parsed = node.as<long long>();
+      if (parsed < 0) { throw std::runtime_error("byte value must be non-negative"); }
+      val = static_cast<T>(parsed);
+    } else {
+      auto const parsed = node.as<int>();
+      if (parsed < 0) { throw std::runtime_error("byte value must be non-negative"); }
+      val = static_cast<T>(parsed);
+    }
   } catch (const YAML::BadConversion&) {
-    out.ref = static_cast<T>(parse_bytes(node.as<std::string>()));
+    val = static_cast<T>(parse_bytes(node.as<std::string>()));
   }
+  out.ref = val;
 }
 
 /// Wrapper for optional byte values.
@@ -251,10 +260,15 @@ void read_yaml(const YAML::Node& node, optional_bytes_value<T>& out)
 {
   T val{};
   try {
-    if constexpr (sizeof(T) > 4)
-      val = static_cast<T>(node.as<long long>());
-    else
-      val = static_cast<T>(node.as<int>());
+    if constexpr (sizeof(T) > 4) {
+      auto const parsed = node.as<long long>();
+      if (parsed < 0) { throw std::runtime_error("byte value must be non-negative"); }
+      val = static_cast<T>(parsed);
+    } else {
+      auto const parsed = node.as<int>();
+      if (parsed < 0) { throw std::runtime_error("byte value must be non-negative"); }
+      val = static_cast<T>(parsed);
+    }
   } catch (const YAML::BadConversion&) {
     val = static_cast<T>(parse_bytes(node.as<std::string>()));
   }

--- a/test/cpp/config/data/invalid_memory_host_capacity_negative.yaml
+++ b/test/cpp/config/data/invalid_memory_host_capacity_negative.yaml
@@ -1,0 +1,4 @@
+sirius:
+  memory:
+    host:
+      capacity_bytes: -1

--- a/test/cpp/config/test_config.cpp
+++ b/test/cpp/config/test_config.cpp
@@ -158,6 +158,60 @@ bi: "1.5Gi")");
     REQUIRE(bi == static_cast<std::uint64_t>(1.5 * 1024 * 1024 * 1024));
   }
 
+  SECTION("required byte values reject negative integers without mutation")
+  {
+    auto node          = YAML::Load("size: -1");
+    std::uint64_t size = 4096;
+    yaml::reader r(node);
+    REQUIRE_THROWS_WITH(r.required("size", yaml::bytes(size)),
+                        Catch::Contains("byte value must be non-negative"));
+    REQUIRE(size == 4096);
+  }
+
+  SECTION("required byte values reject negative suffixed strings without mutation")
+  {
+    auto node          = YAML::Load(R"(size: "-1GiB")");
+    std::uint64_t size = 4096;
+    yaml::reader r(node);
+    REQUIRE_THROWS_WITH(r.required("size", yaml::bytes(size)),
+                        Catch::Contains("byte value must be non-negative"));
+    REQUIRE(size == 4096);
+  }
+
+  SECTION("optional byte values reject negative integers without mutation")
+  {
+    auto node                         = YAML::Load("size: -1");
+    std::optional<std::uint64_t> size = 4096;
+    yaml::reader r(node);
+    REQUIRE_THROWS_WITH(r.optional("size", yaml::bytes(size)),
+                        Catch::Contains("byte value must be non-negative"));
+    REQUIRE(size == 4096);
+  }
+
+  SECTION("optional byte values reject negative suffixed strings without mutation")
+  {
+    auto node                         = YAML::Load(R"(size: "-1GiB")");
+    std::optional<std::uint64_t> size = 4096;
+    yaml::reader r(node);
+    REQUIRE_THROWS_WITH(r.optional("size", yaml::bytes(size)),
+                        Catch::Contains("byte value must be non-negative"));
+    REQUIRE(size == 4096);
+  }
+
+  SECTION("zero byte values remain valid")
+  {
+    auto node                                  = YAML::Load("size: 0");
+    std::uint64_t size                         = 4096;
+    std::optional<std::uint64_t> optional_size = 4096;
+    yaml::reader r(node);
+    r.required("size", yaml::bytes(size));
+    REQUIRE(size == 0);
+
+    yaml::reader optional_reader(node);
+    optional_reader.optional("size", yaml::bytes(optional_size));
+    REQUIRE(optional_size == 0);
+  }
+
   SECTION("string suffix on plain integer field is rejected")
   {
     auto node = YAML::Load(R"(count: "4Ki")");

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -298,6 +298,18 @@ TEST_CASE("Sirius configuration rejects zero hash partition bytes", "[sirius][co
     Catch::Contains("hash_partition_bytes") && Catch::Contains("greater than zero"));
 }
 
+TEST_CASE("Sirius configuration rejects negative host capacity bytes", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  fs::path cfg =
+    fs::path(loc.file_name()).parent_path() / "data" / "invalid_memory_host_capacity_negative.yaml";
+
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(config.load_from_file(cfg),
+                      Catch::Contains("memory.host.capacity_bytes") &&
+                        Catch::Contains("byte value must be non-negative"));
+}
+
 namespace {
 
 void require_shared_operator_defaults(const sirius::operator_params& params, uint64_t batch)
@@ -622,6 +634,30 @@ TEST_CASE("DuckDB setting rejects zero hash partition bytes without a Sirius con
   REQUIRE(result->HasError());
   REQUIRE_THAT(result->GetError(),
                Catch::Contains("hash_partition_bytes must be greater than zero"));
+}
+
+TEST_CASE("DuckDB setting rejects negative byte values without mutation",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto before = con.Query("SELECT current_setting('scan_task_batch_size')::UBIGINT");
+  REQUIRE(before != nullptr);
+  REQUIRE_FALSE(before->HasError());
+  auto const expected = before->GetValue(0, 0).GetValue<uint64_t>();
+
+  auto negative = con.Query("SET scan_task_batch_size = -1");
+  REQUIRE(negative != nullptr);
+  REQUIRE(negative->HasError());
+
+  auto after = con.Query("SELECT current_setting('scan_task_batch_size')::UBIGINT");
+  REQUIRE(after != nullptr);
+  REQUIRE_FALSE(after->HasError());
+  REQUIRE(after->GetValue(0, 0).GetValue<uint64_t>() == expected);
 }
 
 TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",


### PR DESCRIPTION
## Summary

- reject negative plain and suffixed YAML byte values before unsigned conversion
- preserve zero and leave required/optional destinations unchanged on refusal
- cover parser, full `sirius.memory.host.capacity_bytes`, and DuckDB `SET` parity paths

## Validation

- full applicable pre-commit suite: pass
- clean CUDA 13 release build: 1286/1286 actions
- `[config_opt]`: 103 assertions in 18 test cases
- `[sirius][config]`: 285 assertions in 25 test cases
- `[sirius][context][config][isolated_context]`: 99 assertions in 4 test cases
- test binary SHA-256: `8657aa04034758261f4f1b59a986203ea9dabbee4a6c3eb0b25105c43d310789`

Exact tested head: `070b7e174f702d624643592365f8c7dadb6e3e3f`.