### PR TITLE
fix(config): reject zero sort memory fraction

### DIFF
--- a/src/include/yaml_reader.hpp
+++ b/src/include/yaml_reader.hpp
@@ -60,6 +60,12 @@ struct fraction {
 };
 
 template <typename T>
+struct positive_fraction {
+  bool operator()(const T& v) const noexcept { return v > T{0} && v <= T{1}; }
+  static constexpr const char* description() { return "must be greater than 0.0 and at most 1.0"; }
+};
+
+template <typename T>
 struct greater_than {
   T threshold;
   bool operator()(const T& v) const noexcept { return v > threshold; }

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -257,7 +257,7 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
   r.optional("max_sort_partition_bytes", yaml::bytes(opt.max_sort_partition_bytes));
   r.optional("max_sort_partition_memory_fraction",
              opt.max_sort_partition_memory_fraction,
-             yaml::fraction<double>{});
+             yaml::positive_fraction<double>{});
   r.optional("hash_partition_bytes", yaml::bytes(opt.hash_partition_bytes));
   if (opt.hash_partition_bytes == 0) {
     throw std::runtime_error("'operator_params.hash_partition_bytes': must be greater than zero");

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -119,6 +119,7 @@ extern "C" int cudaProfilerStop();
 #include "io/types.hpp"                // sirius::io::sirius_ioctx
 #include "io/uring/uring_reactor.hpp"  // sirius::io::uring_io_object
 
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <string_view>
@@ -1876,14 +1877,16 @@ static void SetMaxSortPartitionMemoryFraction(ClientContext& context,
                                               SetScope scope,
                                               Value& parameter)
 {
+  const double fraction = parameter.GetValue<double>();
+  if (!std::isfinite(fraction) || fraction <= 0.0 || fraction > 1.0) {
+    throw InvalidInputException(
+      "max_sort_partition_memory_fraction must be finite, greater than 0.0, and at most 1.0, got "
+      "%f",
+      fraction);
+  }
   auto* params = get_operator_params(context);
   if (!params) { return; }
-  auto slot             = lock_operator_params_slot(context);
-  const double fraction = parameter.GetValue<double>();
-  if (fraction < 0.0 || fraction > 1.0) {
-    throw InvalidInputException(
-      "max_sort_partition_memory_fraction must be between 0.0 and 1.0, got %f", fraction);
-  }
+  auto slot                                  = lock_operator_params_slot(context);
   params->max_sort_partition_memory_fraction = fraction;
   SIRIUS_LOG_DEBUG("Updated config MAX_SORT_PARTITION_MEMORY_FRACTION to {}",
                    params->max_sort_partition_memory_fraction);

--- a/test/cpp/config/data/invalid_sort_partition_fraction_zero.yaml
+++ b/test/cpp/config/data/invalid_sort_partition_fraction_zero.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    max_sort_partition_memory_fraction: 0

--- a/test/cpp/config/test_config.cpp
+++ b/test/cpp/config/test_config.cpp
@@ -99,6 +99,52 @@ TEST_CASE("yaml reader validation with fraction", "[config_opt][conditional]")
   REQUIRE(f == 0.5);  // unchanged
 }
 
+TEST_CASE("yaml reader validation with positive fraction", "[config_opt][conditional]")
+{
+  SECTION("zero is rejected without mutation")
+  {
+    auto node = YAML::Load("f: 0");
+    double f  = 0.5;
+
+    yaml::reader r(node);
+    REQUIRE_THROWS_AS(r.optional("f", f, yaml::positive_fraction<double>{}), std::runtime_error);
+    REQUIRE(f == 0.5);
+  }
+
+  SECTION("one is accepted")
+  {
+    auto node = YAML::Load("f: 1.0");
+    double f  = 0.5;
+
+    yaml::reader r(node);
+    REQUIRE_NOTHROW(r.optional("f", f, yaml::positive_fraction<double>{}));
+    REQUIRE(f == 1.0);
+  }
+
+  SECTION("greater than one is rejected without mutation")
+  {
+    auto node = YAML::Load("f: 1.5");
+    double f  = 0.5;
+
+    yaml::reader r(node);
+    REQUIRE_THROWS_AS(r.optional("f", f, yaml::positive_fraction<double>{}), std::runtime_error);
+    REQUIRE(f == 0.5);
+  }
+
+  SECTION("non-finite values are rejected without mutation")
+  {
+    for (auto const* yaml_value : {".nan", ".inf", "-.inf"}) {
+      CAPTURE(yaml_value);
+      auto node = YAML::Load(std::string("f: ") + yaml_value);
+      double f  = 0.5;
+
+      yaml::reader r(node);
+      REQUIRE_THROWS_AS(r.optional("f", f, yaml::positive_fraction<double>{}), std::runtime_error);
+      REQUIRE(f == 0.5);
+    }
+  }
+}
+
 TEST_CASE("yaml reader byte suffix parsing", "[config_opt][bytes]")
 {
   SECTION("plain integers work with bytes()")

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -329,6 +329,23 @@ TEST_CASE("Sirius configuration validates MARK join build switch ratio", "[siriu
   REQUIRE(config.get_operator_params().mark_join_build_switch_ratio == Approx(0.0));
 }
 
+TEST_CASE("Sirius configuration rejects a zero automatic sort partition fraction",
+          "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const cfg =
+    fs::path(loc.file_name()).parent_path() / "data" / "invalid_sort_partition_fraction_zero.yaml";
+
+  sirius::sirius_config config;
+  auto const default_fraction = config.get_operator_params().max_sort_partition_memory_fraction;
+  REQUIRE(default_fraction == Approx(sirius::config::DEFAULT_MAX_SORT_PARTITION_MEMORY_FRACTION));
+  REQUIRE_THROWS_WITH(
+    config.load_from_file(cfg),
+    Catch::Contains("max_sort_partition_memory_fraction") && Catch::Contains("value out of range"));
+  REQUIRE(config.get_operator_params().max_sort_partition_memory_fraction ==
+          Approx(default_fraction));
+}
+
 namespace {
 
 void require_shared_operator_defaults(const sirius::operator_params& params, uint64_t batch)
@@ -679,6 +696,24 @@ TEST_CASE("DuckDB setting rejects negative byte values without mutation",
   REQUIRE(after->GetValue(0, 0).GetValue<uint64_t>() == expected);
 }
 
+TEST_CASE(
+  "DuckDB setting rejects a zero automatic sort partition fraction without a Sirius context",
+  "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto result = con.Query("SET max_sort_partition_memory_fraction = 0");
+  REQUIRE(result != nullptr);
+  REQUIRE(result->HasError());
+  REQUIRE_THAT(result->GetError(),
+               Catch::Contains("max_sort_partition_memory_fraction must be finite") &&
+                 Catch::Contains("greater than 0.0"));
+}
+
 TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
           "[sirius][context][config][isolated_context]")
 {
@@ -780,6 +815,12 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE(sirius_ctx->get_config().get_operator_params().mark_join_build_switch_ratio ==
           Approx(3.0));
 
+  auto zero_sort_fraction = con.Query("SET max_sort_partition_memory_fraction = 0");
+  REQUIRE(zero_sort_fraction != nullptr);
+  REQUIRE(zero_sort_fraction->HasError());
+  REQUIRE(sirius_ctx->get_config().get_operator_params().max_sort_partition_memory_fraction ==
+          Approx(0.25));
+
   auto const require_ok = [&con](std::string const& sql) {
     auto result = con.Query(sql);
     REQUIRE(result != nullptr);
@@ -788,7 +829,9 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
 
   require_ok("SET scan_task_batch_size = 99");
   require_ok("RESET scan_task_batch_size");
-  require_ok("SET max_sort_partition_memory_fraction = 0.9");
+  require_ok("SET max_sort_partition_memory_fraction = 1.0");
+  REQUIRE(sirius_ctx->get_config().get_operator_params().max_sort_partition_memory_fraction ==
+          Approx(1.0));
   require_ok("RESET max_sort_partition_memory_fraction");
   require_ok("SET enable_dynamic_filter_pushdown = true");
   require_ok("RESET enable_dynamic_filter_pushdown");


### PR DESCRIPTION
## Summary

- require a finite `0 < max_sort_partition_memory_fraction <= 1` in YAML and DuckDB `SET`
- validate `SET` before Sirius-context lookup so disabled-context sessions refuse the same invalid value
- preserve defaults on refusal and cover zero, one, greater-than-one, NaN, and infinity boundaries

## Current-dev rebase

Rebased onto Sirius dev `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`,
which includes merged Foxglove PR #1490. The only conflicts were additive test
placement in `test/cpp/config/test_context.cpp`; the resolution retains the
current-dev host-capacity, negative-byte, and MARK-join regressions alongside
this patch's positive-fraction regressions. Production, YAML-reader, and
`test_config` changes applied cleanly.

## Validation

- current rebased head: `git diff --check` pass
- current rebased head: `python3 scripts/check_orphan_tests.py` pass
- exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full C++ runtime, and aggregate checks: pass
- test workflow run `31703966746`: pass; CUDA runtime 19m59s
- check workflow run `31703966794`: pass
- previous head `622deac2` completed hosted CUDA 13 runtime and exact AWS L4 focused selectors, retained as historical evidence only

Exact base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`  
Exact head: `86341a35d62bea03e57f4579fc0259a1cf28fa98`  
Exact tree: `08eeabba66e5a1f94cf43aeaa8a7c534c18b7cf7`

- exact-head hosted receipt for `86341a35d62bea03e57f4579fc0259a1cf28fa98`: CUDA 13 runtime and terminal aggregate checks passed
- hosted workflow 31703966746: runtime job 94460712576 passed from 2026-08-13T13:26:57Z through 2026-08-13T13:46:56Z; aggregate job 94468884502 passed at 2026-08-13T13:47:03Z