### PR TITLE
fix(config): validate and derive GPU topology

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -109,8 +109,8 @@ Sirius uses cuCascade for tiered memory management across GPU, Host (pinned), an
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `num_gpus` | int | all visible GPUs | Number of GPUs to use. Defaults to every GPU visible to topology discovery (honors `CUDA_VISIBLE_DEVICES`); `0` also means auto. Mutually exclusive with `gpu_ids`. |
-| `gpu_ids` | list of int | — | Explicit GPU device IDs. Mutually exclusive with `num_gpus`. |
+| `num_gpus` | int | all visible GPUs | Non-negative number of GPUs to use. Defaults to every GPU visible to topology discovery (honors `CUDA_VISIBLE_DEVICES`); `0` also means auto. Mutually exclusive with `gpu_ids`. |
+| `gpu_ids` | list of int | — | Non-empty list of unique, non-negative GPU device IDs. Mutually exclusive with `num_gpus`. |
 | `gpus_per_query` | int | `0` (all) | How many GPUs each query is allocated at admission time. `0` uses all active GPUs. Values exceeding the active GPU count are clamped to the full set. |
 
 ### GPU Memory (`sirius.memory.gpu`)
@@ -243,13 +243,14 @@ per-pool sub-blocks: `task_creator`, `pipeline`, `downgrade`, and `scan_manager`
 `scan_manager` sub-block is large and is documented in
 [Scan Manager & IO Configuration](#scan-manager--io-configuration) below.
 
-Every thread-pool sub-block shares three keys:
+The thread-pool sub-blocks use these common keys; pipeline affinity is the
+hardware-derived exception described below:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `num_threads` | int (**> 0**) | per pool (below) | Worker threads in the pool. |
 | `thread_name_prefix` | string | per pool | Thread name prefix for logs. |
-| `cpu_affinity` | list of int | — | Cores to pin the pool's threads to. |
+| `cpu_affinity` | list of int | — | Cores to pin task-creator and downgrade threads. GPU pipeline affinity is derived from the selected GPU's CPU topology. |
 
 ### `sirius.executor.task_creator`
 
@@ -496,8 +497,10 @@ per-pool extras.
 | `downgrade_executor` | `executor.downgrade` | 1 | `downgrade` | Data tier migration (GPU→Host) |
 | `scan_manager` | `executor.scan_manager` | remaining cores (min 4) | `scan_manager` | Scan metadata production + IO reactor management |
 
-Each pool supports optional CPU affinity lists (`cpu_affinity`) for core pinning. `num_threads`
-must be `> 0` for every pool except `scan_manager`, which requires `> 2`.
+The task-creator, downgrade, and scan-manager pools support optional CPU affinity lists
+(`cpu_affinity`) for core pinning. GPU pipeline affinity is derived per executor from the selected
+GPU's CPU topology. `num_threads` must be `> 0` for every pool except `scan_manager`, which requires
+`> 2`.
 
 ## DuckDB SET Variables
 

--- a/src/include/pipeline/gpu_pipeline_executor.hpp
+++ b/src/include/pipeline/gpu_pipeline_executor.hpp
@@ -114,6 +114,14 @@ class gpu_pipeline_executor : public sirius::parallel::itask_executor {
   [[nodiscard]] executor_metrics get_metrics() const noexcept;
 
   /**
+   * @brief Return the effective executor configuration after scheduler derivation.
+   */
+  [[nodiscard]] const exec::thread_pool_config& get_effective_config() const noexcept
+  {
+    return _config;
+  }
+
+  /**
    * @brief Set the completion handler for query completion signaling
    *
    * @param handler Pointer to the completion handler

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -140,7 +140,6 @@ static void from_yaml(const YAML::Node& node, exec::thread_pool_config& opt)
   yaml::reader r(node, "thread_pool");
   r.optional("num_threads", opt.num_threads, yaml::greater_than<int>{0});
   r.optional("thread_name_prefix", opt.thread_name_prefix);
-  r.optional("cpu_affinity", opt.cpu_affinity_list);
   r.reject_unknown();
 }
 
@@ -325,15 +324,28 @@ struct topology {
   static void from_yaml(const YAML::Node& node, topology& opt)
   {
     yaml::reader r(node, "topology");
-    // gpu_ids and num_gpus are mutually exclusive; try gpu_ids first
-    std::vector<int> ids;
-    r.optional("gpu_ids", ids);
-    if (!ids.empty()) {
+    reject_mutually_exclusive(r, "topology", "gpu_ids", "num_gpus");
+
+    if (r.has_value("gpu_ids")) {
+      std::vector<int> ids;
+      r.optional("gpu_ids", ids);
+      if (ids.empty()) {
+        throw std::runtime_error("topology.gpu_ids must contain at least one device id");
+      }
+      if (std::ranges::any_of(ids, [](int id) { return id < 0; })) {
+        throw std::runtime_error("topology.gpu_ids must contain only non-negative device ids");
+      }
+      auto sorted_ids = ids;
+      std::ranges::sort(sorted_ids);
+      if (std::ranges::adjacent_find(sorted_ids) != sorted_ids.end()) {
+        throw std::runtime_error("topology.gpu_ids must not contain duplicate device ids");
+      }
       opt.num_gpus_or_gpu_ids = std::move(ids);
     } else {
-      size_t n = 0;
+      long long n = 0;
       r.optional("num_gpus", n);
-      opt.num_gpus_or_gpu_ids = n;
+      if (n < 0) { throw std::runtime_error("topology.num_gpus must be non-negative"); }
+      opt.num_gpus_or_gpu_ids = static_cast<size_t>(n);
     }
     // greater_than{-1} is >= 0: a negative count would otherwise silently read as "use all",
     // since the admission path treats any non-positive value as unset.

--- a/test/cpp/config/data/invalid_pipeline_cpu_affinity.yaml
+++ b/test/cpp/config/data/invalid_pipeline_cpu_affinity.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    pipeline:
+      cpu_affinity: [0]

--- a/test/cpp/config/data/invalid_topology_duplicate_gpu_ids.yaml
+++ b/test/cpp/config/data/invalid_topology_duplicate_gpu_ids.yaml
@@ -1,0 +1,3 @@
+sirius:
+  topology:
+    gpu_ids: [0, 0]

--- a/test/cpp/config/data/invalid_topology_empty_gpu_ids.yaml
+++ b/test/cpp/config/data/invalid_topology_empty_gpu_ids.yaml
@@ -1,0 +1,3 @@
+sirius:
+  topology:
+    gpu_ids: []

--- a/test/cpp/config/data/invalid_topology_gpu_ids_and_num_gpus.yaml
+++ b/test/cpp/config/data/invalid_topology_gpu_ids_and_num_gpus.yaml
@@ -1,0 +1,4 @@
+sirius:
+  topology:
+    gpu_ids: [0]
+    num_gpus: 1

--- a/test/cpp/config/data/invalid_topology_negative_gpu_id.yaml
+++ b/test/cpp/config/data/invalid_topology_negative_gpu_id.yaml
@@ -1,0 +1,3 @@
+sirius:
+  topology:
+    gpu_ids: [0, -1]

--- a/test/cpp/config/data/invalid_topology_negative_num_gpus.yaml
+++ b/test/cpp/config/data/invalid_topology_negative_num_gpus.yaml
@@ -1,0 +1,3 @@
+sirius:
+  topology:
+    num_gpus: -1

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -399,6 +399,30 @@ TEST_CASE("Sirius YAML rejects invalid dynamic-filter thresholds", "[sirius][con
   REQUIRE(config.get_operator_params().dynamic_filter_keep_threshold == Approx(0.0));
 }
 
+TEST_CASE("Sirius configuration rejects invalid GPU topology selections", "[sirius][config]")
+{
+  struct invalid_config {
+    const char* fixture;
+    const char* expected;
+  };
+  const invalid_config cases[] = {
+    {"invalid_topology_empty_gpu_ids.yaml", "at least one device id"},
+    {"invalid_topology_negative_gpu_id.yaml", "only non-negative device ids"},
+    {"invalid_topology_duplicate_gpu_ids.yaml", "duplicate device ids"},
+    {"invalid_topology_gpu_ids_and_num_gpus.yaml", "mutually exclusive"},
+    {"invalid_topology_negative_num_gpus.yaml", "num_gpus must be non-negative"},
+  };
+
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+  for (auto const& invalid : cases) {
+    INFO("fixture=" << invalid.fixture);
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(config.load_from_file(data_dir / invalid.fixture),
+                        Catch::Contains("topology") && Catch::Contains(invalid.expected));
+  }
+}
+
 namespace {
 
 void require_shared_operator_defaults(const sirius::operator_params& params, uint64_t batch)
@@ -431,6 +455,13 @@ uint64_t expected_effective_batch(const sirius::sirius_config& config)
 }
 
 }  // namespace
+
+TEST_CASE("Sirius derives GPU pipeline affinity from hardware topology", "[sirius][config]")
+{
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(config.load_from_file(config_fixture("invalid_pipeline_cpu_affinity.yaml")),
+                      Catch::Contains("unknown config key: 'cpu_affinity' in thread_pool"));
+}
 
 TEST_CASE("operator batch defaults use the smallest low-level GPU capacity",
           "[sirius][config][operator_defaults]")

--- a/test/cpp/pipeline/test_task_scheduler.cpp
+++ b/test/cpp/pipeline/test_task_scheduler.cpp
@@ -110,6 +110,31 @@ TEST_CASE("Task scheduler can start and stop gracefully", "[task_scheduler]")
   REQUIRE_NOTHROW(executor.stop());
 }
 
+TEST_CASE("Task scheduler derives GPU executor affinity from topology", "[task_scheduler][config]")
+{
+  auto manager = initialize_memory_manager(1);
+  sirius::exec::thread_pool_config gpu_config{2};
+  gpu_config.cpu_affinity_list = {999};
+
+  cucascade::memory::system_topology_info topology;
+  topology.num_gpus = 1;
+  cucascade::memory::gpu_topology_info gpu;
+  gpu.id        = 0;
+  gpu.cpu_cores = {3, 7};
+  topology.gpus.push_back(std::move(gpu));
+
+  task_scheduler executor(
+    gpu_config, *manager, sirius::test::make_test_telemetry_context(), &topology);
+
+  std::size_t visited = 0;
+  executor.visit_executors([&](int device_id, auto const& gpu_executor) {
+    REQUIRE(device_id == 0);
+    REQUIRE(gpu_executor.get_effective_config().cpu_affinity_list == std::vector<int>{3, 7});
+    ++visited;
+  });
+  REQUIRE(visited == 1);
+}
+
 TEST_CASE("Task scheduler executes tasks through pipeline_queue", "[task_scheduler]")
 {
   auto manager = initialize_memory_manager(1);


### PR DESCRIPTION
## Summary

- reject empty, negative, or duplicate explicit `gpu_ids`
- reject negative `num_gpus` before unsigned conversion
- make `gpu_ids` and `num_gpus` strictly mutually exclusive by key presence
- remove `executor.pipeline.cpu_affinity` from normal YAML
- retain per-GPU topology-derived pipeline affinity and other expert affinity
  controls

## Why one PR

These changes establish one GPU-topology source of truth. Users select valid
devices through `gpu_ids` or `num_gpus`; production Sirius then derives each GPU
pipeline executor's CPU affinity from discovered topology. The removed YAML
affinity could never be honored because runtime always replaced it. This review
unit validates the input and proves the downstream derivation without changing
automatic all-visible-GPU behavior or `gpus_per_query`.

This supersedes #1503. Its stale-key rejection and topology-overrides-sentinel
regression are retained alongside #1494's complete selector fixture matrix.

## Contract

- explicit `gpu_ids` is non-empty, unique, and non-negative
- `gpu_ids` and `num_gpus` cannot both be present
- negative `num_gpus` fails before unsigned conversion; zero keeps existing
  automatic all-visible-GPU behavior
- pipeline affinity is derived from the selected GPU's topology
- task-creator, downgrade, and scan-manager affinity controls remain unchanged

## Current identity

- exact upstream `dev` base: `e885ffea7d0541f1e3493566e2db0ed6e431106f`
- exact rebased head: `45392102685f3960a6726b908d600bf9c7ed3c9e`
- candidate tree: `cd3e46be9636883a97d3da4baf037930e427815b`
- zero-context source-diff SHA-256: `9efc6e7607f2537c7ed893cafb50c441c598972eb71ed788ccc100a058f401a3`
- pre-rebase safety branch:
  `infblueocean:foxglove/safety-pr1494-pre-rebase-20260813-b9c68dcf`

The sole rebase conflict was additive in `test/cpp/config/test_context.cpp`:
upstream's dynamic-filter validation test and this PR's GPU-topology validation
test are both retained. `git range-diff` shows no behavioral change to this PR.

## Validation

- scoped pre-commit on all 11 changed files: every applicable hook passes;
  the repository Markdown wrapper alone cannot start because local `pixi` is
  unavailable
- standalone `uvx rumdl check docs/super-sirius/configuration.md`: passes
- `git diff --check`: passes
- hosted exact-head CI is fully green:
  - workflow `31756766400`: lint, GCC release, Clang debug, and terminal
    aggregate passed
  - workflow `31756766284`: CUDA 13 build job `94634088694`, full runtime job
    `94634862875` (19m24s), and terminal aggregate job `94638310083` passed

### Retained predecessor hosted receipts

- topology head `e509c1d9`: workflow `31706446045`; runtime job `94469113737`
  and aggregate job `94496337500` passed
- affinity head `35f0f368`: workflow `31727808407`; runtime job `94541962493`
  and aggregate job `94550035981` passed
