### PR TITLE
fix(config): validate positive REST counts

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -332,7 +332,7 @@ The four count limits marked below must be greater than zero.
 | `retry_backoff_base_ms` | int (ms) | 50 | Base backoff between retries. |
 | `retry_jitter_ms` | int (ms) | 50 | Random jitter added to retry backoff. |
 | `max_retry_attempts` | int (**> 0**) | 10 | Retry attempts for transient errors. |
-| `max_auth_retry_attempts` | int | 3 | Retry attempts for HTTP 403 (expired presigned URL). Kept low so a genuine AccessDenied fails fast. |
+| `max_auth_retry_attempts` | int (**> 0**) | 3 | Retry attempts for HTTP 403 (expired presigned URL). Kept low so a genuine AccessDenied fails fast. |
 | `honor_retry_after` | bool | true | Respect the server's `Retry-After` header. |
 | `perf_instrumentation` | bool | false | Record per-chunk micro-timings (chunk_get, queue_wait, ttfb, h2d) into perf counters. |
 | `footer_probe_bytes` | bytes | 512Ki | Suffix-range window for the parquet footer probe. Must cover the footer, so err large. |

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -318,19 +318,20 @@ single-GPU configurations only (logs a warning and disables itself otherwise).
 TLS verification policy and the CA bundle are configured only under
 `scan_manager.object_store`. The REST reactor consumes those values so signing
 and transport use one trust policy; there are no separate REST YAML controls.
+The four count limits marked below must be greater than zero.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `request_timeout_s` | int (seconds) | 30 | Whole-request timeout and presigned-URL TTL (0 = no limit). |
-| `max_connections` | int | 16 | Max concurrent in-flight connections per reactor. |
+| `max_connections` | int (**> 0**) | 16 | Max concurrent in-flight connections per reactor. |
 | `chunk_size` | bytes | 8Mi | Target bytes per ranged GET (scatter/device-staging paths). |
 | `max_n_chunks` | int | 16 | Max file-adjacent segments fused into one scatter GET. |
-| `max_read_split` | int | 16 | Max parallel ranged GETs for one contiguous host read (reads < 2 MiB stay a single GET). |
+| `max_read_split` | int (**> 0**) | 16 | Max parallel ranged GETs for one contiguous host read (reads < 2 MiB stay a single GET). |
 | `upkeep_interval_ms` | int (ms) | 15000 | Idle-connection keepalive interval (`curl_easy_upkeep`; 0 disables). |
 | `conn_max_age_s` | int (seconds) | 20 | Max age curl may reuse a pooled connection (`CURLOPT_MAXAGE_CONN`; 0 = curl default). |
 | `retry_backoff_base_ms` | int (ms) | 50 | Base backoff between retries. |
 | `retry_jitter_ms` | int (ms) | 50 | Random jitter added to retry backoff. |
-| `max_retry_attempts` | int | 10 | Retry attempts for transient errors. |
+| `max_retry_attempts` | int (**> 0**) | 10 | Retry attempts for transient errors. |
 | `max_auth_retry_attempts` | int | 3 | Retry attempts for HTTP 403 (expired presigned URL). Kept low so a genuine AccessDenied fails fast. |
 | `honor_retry_after` | bool | true | Respect the server's `Retry-After` header. |
 | `perf_instrumentation` | bool | false | Record per-chunk micro-timings (chunk_get, queue_wait, ttfb, h2d) into perf counters. |

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -323,7 +323,7 @@ The four count limits marked below must be greater than zero.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `request_timeout_s` | int (seconds) | 30 | Whole-request timeout and presigned-URL TTL (0 = no limit). |
-| `max_connections` | int (**> 0**) | 16 | Max concurrent in-flight connections per reactor. |
+| `max_connections` | int (**1–1024**) | 16 | Max concurrent in-flight connections per reactor. Each connection owns a slot and, when staging is active, a bounce buffer. |
 | `chunk_size` | bytes | 8Mi | Target bytes per ranged GET (scatter/device-staging paths). |
 | `max_n_chunks` | int | 16 | Max file-adjacent segments fused into one scatter GET. |
 | `max_read_split` | int (**> 0**) | 16 | Max parallel ranged GETs for one contiguous host read (reads < 2 MiB stay a single GET). |

--- a/src/include/io/rest/config.hpp
+++ b/src/include/io/rest/config.hpp
@@ -20,8 +20,23 @@
 
 #include <chrono>
 #include <cstddef>
+#include <limits>
+#include <stdexcept>
 
 namespace sirius::io::rest {
+
+// 64x the production default and 32x the largest committed integration-test
+// value. This leaves ample tuning headroom while bounding per-reactor slot,
+// curl-handle, event, and pinned-bounce allocations.
+inline constexpr std::size_t max_connection_limit = 1024;
+
+inline std::size_t checked_bounce_storage_bytes(std::size_t connections, std::size_t bytes_per_slot)
+{
+  if (connections != 0 && bytes_per_slot > std::numeric_limits<std::size_t>::max() / connections) {
+    throw std::overflow_error("rest_reactor: bounce allocation size overflow");
+  }
+  return connections * bytes_per_slot;
+}
 
 struct config {
   /// Whole-request timeout (seconds, 0 = no limit) and presigned-URL TTL.
@@ -32,7 +47,9 @@ struct config {
   std::string ca_bundle_path;
   bool tls_verify{true};
 
-  /// Max concurrent in-flight easy handles per reactor.
+  /// Max concurrent in-flight easy handles per reactor. Bounded because the
+  /// reactor allocates one slot and, when staging is active, one bounce buffer
+  /// per connection.
   std::size_t max_connections{16};
 
   /// Target maximum bytes per ranged GET for the vector / device-staging

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -469,6 +469,9 @@ rest_reactor::rest_reactor(std::shared_ptr<reactor_context> ctx, std::string_vie
   if (_config.max_connections == 0) {
     throw std::invalid_argument("rest_reactor: max_connections must be > 0");
   }
+  if (_config.max_connections > max_connection_limit) {
+    throw std::invalid_argument("rest_reactor: max_connections exceeds supported limit");
+  }
   if (_config.max_retry_attempts == 0) { _config.max_retry_attempts = 1; }
   if (_config.max_read_split == 0) { _config.max_read_split = 1; }
 
@@ -495,7 +498,7 @@ void rest_reactor::start()
     // One pinned bounce buffer per slot (1:1 with the easy-handle pool), since a
     // slot stages at most one device read at a time.
     _bounce_storage = _ctx->host_memory_resource()->allocate_multiple_blocks(
-      _config.max_connections * _bounce_slot_size);
+      checked_bounce_storage_bytes(_config.max_connections, _bounce_slot_size));
   }
 
   _worker =

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -170,6 +170,17 @@ static void from_yaml(const YAML::Node& node, sirius::io::object_store_config& o
   r.reject_unknown();
 }
 
+static void read_positive_count(yaml::reader& reader, const char* key, std::size_t& out)
+{
+  // Parse through a signed temporary so a negative YAML scalar cannot wrap to
+  // a large size_t before validation.  Missing and null values retain the
+  // struct's explicit default.
+  auto const has_value = reader.has_value(key);
+  long long value      = 1;
+  reader.optional(key, value, yaml::greater_than<long long>{0});
+  if (has_value) { out = static_cast<std::size_t>(value); }
+}
+
 static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
 {
   yaml::reader r(node, "rest");
@@ -181,15 +192,15 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
     }
   }
   r.optional("request_timeout_s", opt.request_timeout_s);
-  r.optional("max_connections", opt.max_connections);
+  read_positive_count(r, "max_connections", opt.max_connections);
   r.optional("chunk_size", yaml::bytes(opt.chunk_size));
   r.optional("max_n_chunks", opt.max_n_chunks);
-  r.optional("max_read_split", opt.max_read_split);
+  read_positive_count(r, "max_read_split", opt.max_read_split);
   r.optional("upkeep_interval_ms", opt.upkeep_interval);
   r.optional("conn_max_age_s", opt.conn_max_age);
   r.optional("retry_backoff_base_ms", opt.retry_backoff_base);
   r.optional("retry_jitter_ms", opt.retry_jitter);
-  r.optional("max_retry_attempts", opt.max_retry_attempts);
+  read_positive_count(r, "max_retry_attempts", opt.max_retry_attempts);
   r.optional("max_auth_retry_attempts", opt.max_auth_retry_attempts);
   r.optional("honor_retry_after", opt.honor_retry_after);
   r.optional("perf_instrumentation", opt.perf_instrumentation);

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -201,7 +201,7 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
   r.optional("retry_backoff_base_ms", opt.retry_backoff_base);
   r.optional("retry_jitter_ms", opt.retry_jitter);
   read_positive_count(r, "max_retry_attempts", opt.max_retry_attempts);
-  r.optional("max_auth_retry_attempts", opt.max_auth_retry_attempts);
+  read_positive_count(r, "max_auth_retry_attempts", opt.max_auth_retry_attempts);
   r.optional("honor_retry_after", opt.honor_retry_after);
   r.optional("perf_instrumentation", opt.perf_instrumentation);
   r.optional("footer_probe_bytes", yaml::bytes(opt.footer_probe_bytes));

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -170,14 +170,17 @@ static void from_yaml(const YAML::Node& node, sirius::io::object_store_config& o
   r.reject_unknown();
 }
 
-static void read_positive_count(yaml::reader& reader, const char* key, std::size_t& out)
+static void read_positive_count(yaml::reader& reader,
+                                const char* key,
+                                std::size_t& out,
+                                long long upper = std::numeric_limits<long long>::max())
 {
   // Parse through a signed temporary so a negative YAML scalar cannot wrap to
   // a large size_t before validation.  Missing and null values retain the
   // struct's explicit default.
   auto const has_value = reader.has_value(key);
   long long value      = 1;
-  reader.optional(key, value, yaml::greater_than<long long>{0});
+  reader.optional(key, value, yaml::between<long long>{1, upper});
   if (has_value) { out = static_cast<std::size_t>(value); }
 }
 
@@ -192,7 +195,10 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
     }
   }
   r.optional("request_timeout_s", opt.request_timeout_s);
-  read_positive_count(r, "max_connections", opt.max_connections);
+  read_positive_count(r,
+                      "max_connections",
+                      opt.max_connections,
+                      static_cast<long long>(sirius::io::rest::max_connection_limit));
   r.optional("chunk_size", yaml::bytes(opt.chunk_size));
   r.optional("max_n_chunks", opt.max_n_chunks);
   read_positive_count(r, "max_read_split", opt.max_read_split);

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -296,7 +296,8 @@ TEST_CASE("sirius_config validates positive REST counts", "[scan_manager][config
   auto const fields =
     std::array{count_field{"max_connections", &rest_config::max_connections},
                count_field{"max_read_split", &rest_config::max_read_split},
-               count_field{"max_retry_attempts", &rest_config::max_retry_attempts}};
+               count_field{"max_retry_attempts", &rest_config::max_retry_attempts},
+               count_field{"max_auth_retry_attempts", &rest_config::max_auth_retry_attempts}};
   auto const path = std::filesystem::temp_directory_path() / "sirius_rest_positive_count.yaml";
 
   for (auto const& field : fields) {
@@ -330,19 +331,23 @@ TEST_CASE("sirius_config validates positive REST counts", "[scan_manager][config
       CHECK(config.get_scan_manager_config().rest.*field.member == expected);
     }
 
-    DYNAMIC_SECTION(field.name << " accepts a positive override")
+    DYNAMIC_SECTION(field.name << " accepts positive overrides")
     {
-      write_yaml(path,
-                 "sirius:\n"
-                 "  executor:\n"
-                 "    scan_manager:\n"
-                 "      rest:\n"
-                 "        " +
-                   std::string(field.name) + ": 7\n");
+      for (auto const* valid : {"1", "7"}) {
+        CAPTURE(valid);
+        write_yaml(path,
+                   "sirius:\n"
+                   "  executor:\n"
+                   "    scan_manager:\n"
+                   "      rest:\n"
+                   "        " +
+                     std::string(field.name) + ": " + valid + "\n");
 
-      sirius::sirius_config config;
-      REQUIRE_NOTHROW(config.load_from_file(path));
-      CHECK(config.get_scan_manager_config().rest.*field.member == 7);
+        sirius::sirius_config config;
+        REQUIRE_NOTHROW(config.load_from_file(path));
+        CHECK(config.get_scan_manager_config().rest.*field.member ==
+              static_cast<std::size_t>(std::stoull(valid)));
+      }
     }
 
     DYNAMIC_SECTION(field.name << " rejects invalid counts without mutation")

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -23,6 +23,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <string_view>
 
 using sirius::io::enum_to_string;
 using sirius::io::object_store_config;
@@ -347,6 +348,34 @@ TEST_CASE("sirius_config validates positive REST counts", "[scan_manager][config
         REQUIRE_NOTHROW(config.load_from_file(path));
         CHECK(config.get_scan_manager_config().rest.*field.member ==
               static_cast<std::size_t>(std::stoull(valid)));
+      }
+    }
+
+    if (std::string_view{field.name} == "max_connections") {
+      DYNAMIC_SECTION(field.name << " enforces its allocation-safe upper bound")
+      {
+        for (auto const* value : {"1024", "1025"}) {
+          CAPTURE(value);
+          write_yaml(path,
+                     "sirius:\n"
+                     "  executor:\n"
+                     "    scan_manager:\n"
+                     "      rest:\n"
+                     "        max_connections: " +
+                       std::string{value} + "\n");
+
+          sirius::sirius_config config;
+          auto const before = config.get_scan_manager_config().rest.max_connections;
+          if (std::string_view{value} == "1024") {
+            REQUIRE_NOTHROW(config.load_from_file(path));
+            CHECK(config.get_scan_manager_config().rest.max_connections == 1024);
+          } else {
+            REQUIRE_THROWS_WITH(
+              config.load_from_file(path),
+              Catch::Contains("rest.max_connections") && Catch::Contains("value out of range"));
+            CHECK(config.get_scan_manager_config().rest.max_connections == before);
+          }
+        }
       }
     }
 

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -291,12 +291,12 @@ TEST_CASE("sirius_config validates positive REST counts", "[scan_manager][config
   using rest_config = sirius::io::rest::config;
   struct count_field {
     const char* name;
-    std::size_t rest_config::*member;
+    std::size_t rest_config::* member;
   };
-  auto const fields = std::array{count_field{"max_connections", &rest_config::max_connections},
-                                 count_field{"max_read_split", &rest_config::max_read_split},
-                                 count_field{"max_retry_attempts",
-                                             &rest_config::max_retry_attempts}};
+  auto const fields =
+    std::array{count_field{"max_connections", &rest_config::max_connections},
+               count_field{"max_read_split", &rest_config::max_read_split},
+               count_field{"max_retry_attempts", &rest_config::max_retry_attempts}};
   auto const path = std::filesystem::temp_directory_path() / "sirius_rest_positive_count.yaml";
 
   for (auto const& field : fields) {

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -19,6 +19,7 @@
 #include "io/rest/config.hpp"
 #include "sirius_config.hpp"
 
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -280,6 +281,93 @@ TEST_CASE("sirius_config parses rest perf instrumentation flag",
   CHECK(cfg.get_scan_manager_config().rest.footer_probe_bytes == 256UL * 1024);
   CHECK(cfg.get_scan_manager_config().rest.list_max_matches == 5);
   CHECK(cfg.get_scan_manager_config().rest.list_max_scanned == 50);
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("sirius_config validates positive REST counts", "[scan_manager][config][s3][rest]")
+{
+  using rest_config = sirius::io::rest::config;
+  struct count_field {
+    const char* name;
+    std::size_t rest_config::*member;
+  };
+  auto const fields = std::array{count_field{"max_connections", &rest_config::max_connections},
+                                 count_field{"max_read_split", &rest_config::max_read_split},
+                                 count_field{"max_retry_attempts",
+                                             &rest_config::max_retry_attempts}};
+  auto const path = std::filesystem::temp_directory_path() / "sirius_rest_positive_count.yaml";
+
+  for (auto const& field : fields) {
+    DYNAMIC_SECTION(field.name << " preserves its default when omitted")
+    {
+      write_yaml(path,
+                 "sirius:\n"
+                 "  executor:\n"
+                 "    scan_manager:\n"
+                 "      rest: {}\n");
+
+      sirius::sirius_config config;
+      auto const expected = rest_config{}.*field.member;
+      REQUIRE_NOTHROW(config.load_from_file(path));
+      CHECK(config.get_scan_manager_config().rest.*field.member == expected);
+    }
+
+    DYNAMIC_SECTION(field.name << " preserves its default when null")
+    {
+      write_yaml(path,
+                 "sirius:\n"
+                 "  executor:\n"
+                 "    scan_manager:\n"
+                 "      rest:\n"
+                 "        " +
+                   std::string(field.name) + ": null\n");
+
+      sirius::sirius_config config;
+      auto const expected = rest_config{}.*field.member;
+      REQUIRE_NOTHROW(config.load_from_file(path));
+      CHECK(config.get_scan_manager_config().rest.*field.member == expected);
+    }
+
+    DYNAMIC_SECTION(field.name << " accepts a positive override")
+    {
+      write_yaml(path,
+                 "sirius:\n"
+                 "  executor:\n"
+                 "    scan_manager:\n"
+                 "      rest:\n"
+                 "        " +
+                   std::string(field.name) + ": 7\n");
+
+      sirius::sirius_config config;
+      REQUIRE_NOTHROW(config.load_from_file(path));
+      CHECK(config.get_scan_manager_config().rest.*field.member == 7);
+    }
+
+    DYNAMIC_SECTION(field.name << " rejects invalid counts without mutation")
+    {
+      // The last value is one greater than LLONG_MAX. The signed reader must
+      // reject it rather than accepting a value that the validation temporary
+      // cannot represent.
+      for (auto const* invalid : {"0", "-1", "9223372036854775808"}) {
+        CAPTURE(invalid);
+        write_yaml(path,
+                   "sirius:\n"
+                   "  executor:\n"
+                   "    scan_manager:\n"
+                   "      rest:\n"
+                   "        " +
+                     std::string(field.name) + ": " + invalid + "\n");
+
+        sirius::sirius_config config;
+        auto const before = config.get_scan_manager_config().rest.*field.member;
+        REQUIRE_THROWS_WITH(config.load_from_file(path),
+                            Catch::Contains(std::string("rest.") + field.name));
+        CHECK(config.get_scan_manager_config().rest.*field.member == before);
+      }
+    }
+  }
 
   std::error_code ec;
   std::filesystem::remove(path, ec);

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -57,6 +57,7 @@
 #include <fstream>
 #include <future>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -777,6 +778,28 @@ sirius::io::rest::config direct_rest_test_config()
   cfg.retry_jitter            = std::chrono::milliseconds{0};
   cfg.honor_retry_after       = false;
   return cfg;
+}
+
+TEST_CASE("rest reactor rejects connection counts above the supported limit",
+          "[s3][integration][rest][config]")
+{
+  auto cfg            = direct_rest_test_config();
+  cfg.max_connections = sirius::io::rest::max_connection_limit + 1;
+  auto authorizer     = std::make_shared<fixed_url_authorizer>("http://127.0.0.1:1");
+  auto ctx            = std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(
+    cfg, std::move(authorizer), nullptr);
+
+  CHECK_THROWS_WITH(sirius::io::rest::rest_reactor(ctx, "connection-limit-test"),
+                    Catch::Contains("max_connections exceeds supported limit"));
+}
+
+TEST_CASE("rest bounce-storage sizing rejects multiplication overflow",
+          "[s3][integration][rest][config]")
+{
+  using sirius::io::rest::checked_bounce_storage_bytes;
+  CHECK(checked_bounce_storage_bytes(16, 1UL << 20) == 16UL << 20);
+  CHECK_THROWS_WITH(checked_bounce_storage_bytes(2, std::numeric_limits<std::size_t>::max()),
+                    Catch::Contains("bounce allocation size overflow"));
 }
 
 std::shared_ptr<rest_ioctx> make_direct_rest_ioctx(std::string endpoint,


### PR DESCRIPTION
## Summary

- require positive `max_connections`, `max_read_split`, `max_retry_attempts`, and `max_auth_retry_attempts` in startup YAML
- bound `max_connections` to `1..1024`, matching its per-reactor slot and optional pinned-bounce allocation cost
- check the bounce-storage multiplication before allocation
- parse through a signed temporary so negative inputs cannot wrap through `size_t`
- preserve omitted/null defaults and every valid value in each field's supported range
- document the count contract; no DuckDB `SET` options are added

`max_auth_retry_attempts` is the total-attempt bound for HTTP 403 recovery. A
value of zero already behaves like one attempt at runtime, so rejecting zero
removes an accidental alias without removing the intentional no-retry value
(`1`).

The `max_connections` ceiling is 64x the production default and 32x the
largest committed integration-test value. It keeps substantial tuning
headroom while bounding the slot, curl-handle, event, and pinned-bounce
resources allocated per reactor.

## Review follow-up

- `max_connections=1024` is accepted and `1025` is rejected without mutation
- programmatic reactor construction rejects values above the same ceiling
- bounce-storage sizing rejects `size_t` multiplication overflow before the allocator is called
- zero-valid listing caps are handled separately in #1506
- the generic negative-to-unsigned wrap class, including reactor counts, is consolidated in #1529 (predecessor #1507)
- negative byte wrappers are already repaired by merged #1491

## Validation

- focused config regression covers all four fields: omitted/null default preservation, exact readback for `1` and `7`, and rejection of `0`, `-1`, and one-past-`LLONG_MAX` without mutation
- focused max-connection regressions cover both bound values and multiplication overflow
- independent source review of the auth-retry extension: clear
- local clang-format, `git diff --check`, and orphan-test detection: pass on exact head
- exact-head hosted workflow [31713645617](https://github.com/sirius-db/sirius/actions/runs/31713645617) is terminal green: lint, GCC release, Clang debug, CUDA 13 release build, full CUDA runtime suite plus TPC-H snapshot (job `94494884488`, 20m00s), and aggregate job `94501723069` all pass
- predecessor `97969b53` also passed exact-head lint, GCC release, Clang debug, CUDA 13 release build, full CUDA runtime suite (20m09s), and terminal aggregate check before this review repair

Exact base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`  
Current candidate: `705854f3eda534940fa9af049efa7349f659c415`  
Current tree: `ace9d5d7d963b9e65a5cb3b0a201df630dcd8766`

The earlier three-field candidate `caaa1b8e71b604fde8d8313ac92be79e0f0e6c2d`
was independently built and tested on an exact-base AWS L4 release build. Its
raw receipts are retained in Foxglove commit `f6a2b8e`; those receipts do not
claim execution of the later extensions or this review repair.

