### PR TITLE
refactor(config): derive REST bounce sizing internally

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -325,7 +325,6 @@ and transport use one trust policy; there are no separate REST YAML controls.
 | `chunk_size` | bytes | 8Mi | Target bytes per ranged GET (scatter/device-staging paths). |
 | `max_n_chunks` | int | 16 | Max file-adjacent segments fused into one scatter GET. |
 | `max_read_split` | int | 16 | Max parallel ranged GETs for one contiguous host read (reads < 2 MiB stay a single GET). |
-| `bounce_block_size` | bytes | 0 | Bounce-slot size for the reactor-staged device path (0 disables that path; normally set from the staging resource at runtime). |
 | `upkeep_interval_ms` | int (ms) | 15000 | Idle-connection keepalive interval (`curl_easy_upkeep`; 0 disables). |
 | `conn_max_age_s` | int (seconds) | 20 | Max age curl may reuse a pooled connection (`CURLOPT_MAXAGE_CONN`; 0 = curl default). |
 | `retry_backoff_base_ms` | int (ms) | 50 | Base backoff between retries. |

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -184,7 +184,6 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
   r.optional("chunk_size", yaml::bytes(opt.chunk_size));
   r.optional("max_n_chunks", opt.max_n_chunks);
   r.optional("max_read_split", opt.max_read_split);
-  r.optional("bounce_block_size", yaml::bytes(opt.bounce_block_size));
   r.optional("upkeep_interval_ms", opt.upkeep_interval);
   r.optional("conn_max_age_s", opt.conn_max_age);
   r.optional("retry_backoff_base_ms", opt.retry_backoff_base);

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -350,3 +350,22 @@ TEST_CASE("sirius_config still loads unrelated REST YAML fields",
   std::error_code ec;
   std::filesystem::remove(path, ec);
 }
+
+TEST_CASE("sirius_config keeps REST bounce sizing internal", "[scan_manager][config][rest]")
+{
+  auto const path = std::filesystem::temp_directory_path() / "sirius_rest_bounce_size.yaml";
+  write_yaml(path,
+             "sirius:\n"
+             "  executor:\n"
+             "    scan_manager:\n"
+             "      rest:\n"
+             "        bounce_block_size: 4MiB\n");
+
+  sirius::sirius_config cfg;
+  REQUIRE_THROWS_WITH(cfg.load_from_file(path),
+                      Catch::Contains("unknown config key: 'bounce_block_size' in rest"));
+  CHECK(cfg.get_scan_manager_config().rest.bounce_block_size == 0);
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}


### PR DESCRIPTION
## Summary

- remove `scan_manager.rest.bounce_block_size` from the user-facing YAML surface
- retain the internal field and derive it from the live host staging resource
- make stale explicit values fail at config load instead of appearing effective

## Why

The parsed YAML value cannot reach execution. REST construction copies the
configuration and unconditionally replaces `bounce_block_size` with the live
host memory resource's block size, or zero when no host resource exists. The
two runtime uses consume that replacement. Exposing the field therefore adds a
choice without granting control.

This is intentionally separate from the pending REST TLS source-of-truth work:
both remove adjacent reader/docs rows, but one concerns derived resource sizing
and the other concerns shadowed trust policy. Whichever lands second can rebase
the small adjacent hunk.

## Validation

- exact clean-base apply/reverse replay: pass
- reproduced candidate tree: `f127e98c2c29ebac22e885cb850bd6b0494c4afb`
- source and artifact `git diff --check`: pass
- focused config regression requires the old key to fail as unknown and keeps
  the internal pre-derivation default at zero
- hosted CUDA 13 build: pass (3m20s)
- hosted CUDA 13 full `test-run`: pass (20m11s), followed by the terminal
  `test` job: pass (5s)
- hosted GCC release build: pass (5m50s)
- hosted Clang debug build: pass (3m39s)
- hosted lint/check: pass (54s / 4s)

Exact base: `0c5af9aee02f36d003141b432d799216f164a6c6`  
Candidate: `c46aa2664579affb6bb723abf1846855841b7985`  
Candidate tree: `f127e98c2c29ebac22e885cb850bd6b0494c4afb`

Foxglove source proof: commit `0dc69f9`, under
`patches/current-dev/evidence/rest-bounce-size-derivation-0c5af9ae/`.
