### PR TITLE
fix(config): use one REST TLS source

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -314,11 +314,13 @@ single-GPU configurations only (logs a warning and disables itself otherwise).
 
 ### `scan_manager.rest` — REST / S3 backend (`io/rest/config.hpp`)
 
+TLS verification policy and the CA bundle are configured only under
+`scan_manager.object_store`. The REST reactor consumes those values so signing
+and transport use one trust policy; there are no separate REST YAML controls.
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `request_timeout_s` | int (seconds) | 30 | Whole-request timeout and presigned-URL TTL (0 = no limit). |
-| `ca_bundle_path` | string | "" | PEM CA bundle for TLS verification. |
-| `tls_verify` | bool | true | Verify the endpoint's TLS certificate (peer + host). |
 | `max_connections` | int | 16 | Max concurrent in-flight connections per reactor. |
 | `chunk_size` | bytes | 8Mi | Target bytes per ranged GET (scatter/device-staging paths). |
 | `max_n_chunks` | int | 16 | Max file-adjacent segments fused into one scatter GET. |
@@ -355,8 +357,8 @@ single-GPU configurations only (logs a warning and disables itself otherwise).
 | `session_token` | string | "" | STS session token for temporary credentials. |
 | `signing_mode` | enum: `presigned`, `header` | `presigned` | SigV4 form: `presigned` (auth in the URL query string) or `header` (`Authorization` + `x-amz-*` headers). Values are lowercase. |
 | `s3_transport` | enum: `auto`, `http`, `https`, `rdma` | `auto` | Transport selection. Values are lowercase; `https` is an alias for `http`. `auto` lets the backend choose from the URI scheme and endpoint. |
-| `ca_bundle_path` | string | "" | PEM CA bundle for TLS verification. |
-| `tls_verify` | bool | true | Verify the endpoint's TLS certificate. |
+| `ca_bundle_path` | string | "" | Sole YAML source for the REST endpoint's PEM CA bundle. |
+| `tls_verify` | bool | true | Sole YAML source for REST endpoint certificate verification. |
 
 ## Operator Parameters
 

--- a/src/include/yaml_reader.hpp
+++ b/src/include/yaml_reader.hpp
@@ -401,7 +401,14 @@ class reader {
   }
 
   /// Check whether a key exists in the map.
-  [[nodiscard]] bool has(const std::string& key) const { return find(key).IsDefined(); }
+  [[nodiscard]] bool has(const std::string& key) const
+  {
+    if (!node_.IsMap()) return false;
+    for (auto it = node_.begin(); it != node_.end(); ++it) {
+      if (it->first.as<std::string>() == key) return true;
+    }
+    return false;
+  }
 
   /// Check whether a key exists in the map and has a non-null value.
   [[nodiscard]] bool has_value(const std::string& key) const

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -172,9 +172,14 @@ static void from_yaml(const YAML::Node& node, sirius::io::object_store_config& o
 static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
 {
   yaml::reader r(node, "rest");
+  for (auto const* key : {"ca_bundle_path", "tls_verify"}) {
+    if (r.has(key)) {
+      throw std::runtime_error("'sirius.executor.scan_manager.rest." + std::string(key) +
+                               "': removed; configure 'sirius.executor.scan_manager.object_store." +
+                               key + "' instead");
+    }
+  }
   r.optional("request_timeout_s", opt.request_timeout_s);
-  r.optional("ca_bundle_path", opt.ca_bundle_path);
-  r.optional("tls_verify", opt.tls_verify);
   r.optional("max_connections", opt.max_connections);
   r.optional("chunk_size", yaml::bytes(opt.chunk_size));
   r.optional("max_n_chunks", opt.max_n_chunks);

--- a/test/cpp/config/test_config.cpp
+++ b/test/cpp/config/test_config.cpp
@@ -568,6 +568,16 @@ TEST_CASE("yaml reader has_value distinguishes null from scalar values", "[confi
   }
 }
 
+TEST_CASE("yaml reader has distinguishes missing, null, and scalar keys", "[config_opt][has]")
+{
+  auto node = YAML::Load("null_key: null\nscalar_key: 0");
+  yaml::reader r(node);
+
+  CHECK_FALSE(r.has("missing_key"));
+  CHECK(r.has("null_key"));
+  CHECK(r.has("scalar_key"));
+}
+
 // ================ error context ================= //
 
 TEST_CASE("yaml reader error messages include context", "[config_opt][errors]")

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -135,7 +135,9 @@ TEST_CASE("sirius_config loads object_store_config from YAML", "[object_store_co
            "        secret_key: minioadmin-secret\n"
            "        session_token: TESTSESSIONTOKEN\n"
            "        signing_mode: header\n"
-           "        s3_transport: rdma\n";
+           "        s3_transport: rdma\n"
+           "        ca_bundle_path: /tmp/test-ca.pem\n"
+           "        tls_verify: false\n";
     REQUIRE(out);
   }
 
@@ -150,6 +152,8 @@ TEST_CASE("sirius_config loads object_store_config from YAML", "[object_store_co
   CHECK(os.session_token == "TESTSESSIONTOKEN");
   CHECK(os.s3_signing_mode == object_store_config::signing_mode::header);
   CHECK(os.s3_transport == object_store_config::transport::RDMA);
+  CHECK(os.ca_bundle_path == "/tmp/test-ca.pem");
+  CHECK_FALSE(os.tls_verify);
 
   std::error_code ec;
   std::filesystem::remove(path, ec);
@@ -293,6 +297,55 @@ TEST_CASE("sirius_config rejects unknown rest config keys", "[scan_manager][conf
 
   sirius::sirius_config cfg;
   CHECK_THROWS(cfg.load_from_file(path));
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("sirius_config rejects shadowed REST TLS YAML keys",
+          "[scan_manager][config][s3][rest][tls]")
+{
+  auto check_rejected = [](std::string const& key, std::string const& value) {
+    auto const path =
+      std::filesystem::temp_directory_path() / ("sirius_shadowed_rest_" + key + ".yaml");
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n"
+               "      rest:\n"
+               "        " +
+                 key + ": " + value + "\n");
+
+    sirius::sirius_config cfg;
+    REQUIRE_THROWS_WITH(cfg.load_from_file(path),
+                        "'sirius.executor.scan_manager.rest." + key +
+                          "': removed; configure 'sirius.executor.scan_manager.object_store." +
+                          key + "' instead");
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+  };
+
+  SECTION("CA bundle") { check_rejected("ca_bundle_path", "/tmp/shadowed-ca.pem"); }
+  SECTION("TLS verification") { check_rejected("tls_verify", "false"); }
+}
+
+TEST_CASE("sirius_config still loads unrelated REST YAML fields",
+          "[scan_manager][config][s3][rest]")
+{
+  auto const path = std::filesystem::temp_directory_path() / "sirius_rest_unrelated_fields.yaml";
+  write_yaml(path,
+             "sirius:\n"
+             "  executor:\n"
+             "    scan_manager:\n"
+             "      rest:\n"
+             "        request_timeout_s: 11\n"
+             "        max_connections: 7\n");
+
+  sirius::sirius_config cfg;
+  REQUIRE_NOTHROW(cfg.load_from_file(path));
+  CHECK(cfg.get_scan_manager_config().rest.request_timeout_s == 11);
+  CHECK(cfg.get_scan_manager_config().rest.max_connections == 7);
 
   std::error_code ec;
   std::filesystem::remove(path, ec);

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -317,10 +317,10 @@ TEST_CASE("sirius_config rejects shadowed REST TLS YAML keys",
                  key + ": " + value + "\n");
 
     sirius::sirius_config cfg;
-    REQUIRE_THROWS_WITH(cfg.load_from_file(path),
-                        "'sirius.executor.scan_manager.rest." + key +
-                          "': removed; configure 'sirius.executor.scan_manager.object_store." +
-                          key + "' instead");
+    REQUIRE_THROWS_WITH(
+      cfg.load_from_file(path),
+      Catch::Contains("'sirius.executor.scan_manager.rest." + key + "': removed; configure '") &&
+        Catch::Contains("sirius.executor.scan_manager.object_store." + key + "' instead"));
 
     std::error_code ec;
     std::filesystem::remove(path, ec);


### PR DESCRIPTION
## Summary

- remove the two REST-local TLS YAML inputs that were silently overwritten before the REST reactor was constructed
- make `object_store.ca_bundle_path` and `object_store.tls_verify` the single documented TLS source
- reject the removed REST keys with their fully qualified replacements while preserving unrelated REST YAML fields
- repair `yaml::reader::has()` so missing keys no longer look present merely because the yaml-cpp sentinel is defined/null

## Validation

- independent exact-base AWS L4 release build: pass
- `[config_opt][has]`: pass (3 assertions / 1 test case)
- `[scan_manager][config][s3][rest][tls]`: pass (4 assertions / 1 test case)
- `[object_store_config]`: pass (55 assertions / 9 test cases)
- `sirius_config still loads unrelated REST YAML fields`: pass (4 assertions / 1 test case)
- independent test binary SHA-256: `4d8ac7aa0a03efd308a1db2d377bb5b86b928673b41ba708dc5a7dca5c548bad`
- hosted CUDA 13 build: pass (3m13s)
- hosted CUDA 13 full `test-run`: pass (20m12s), followed by the terminal
  `test` job: pass (5s)
- hosted GCC release build: pass (5m53s)
- hosted Clang debug build: pass (3m42s)
- hosted lint/check: pass (59s / 5s)

Exact base: `0c5af9aee02f36d003141b432d799216f164a6c6`  
Independently validated candidate: `5c2415a0122c05e05a56070484bc204b246db3e2`  
Independently validated tree: `61c16c2bcdbe0849a8e49d582f5d6203d0c168f4`

The first candidate (`0096a199`) built but failed its focused selector: one expectation omitted the public filename wrapper, and the other exposed the `reader::has()` defect. It is retained as a failed candidate and carries no PASS claim. The validated successor fixes both defects in the stricter direction.

Independent raw receipts: Foxglove commit `54b8819`, under `patches/current-dev/evidence/rest-tls-source-of-truth-0c5af9ae/aws-results/`.
