### PR TITLE
fix(config): validate pin compression controls

### DIFF
--- a/docs/super-sirius/compressed-materialization.md
+++ b/docs/super-sirius/compressed-materialization.md
@@ -385,7 +385,9 @@ compression off for the rest of the pin.
 Both compression gates (`min_batch_size_bytes` and `max_compressed_fraction`) are evaluated on the
 already-narrowed table, so they measure the batch as it will be stored. A batch that falls out of a
 gate, or that arrives after a failure has latched compression off, is stored uncompressed at the
-carrier narrowing selected for it.
+carrier narrowing selected for it. `max_compressed_fraction` must be finite and non-negative;
+values above 1 intentionally permit a compressed representation that expands relative to its
+input, which is useful when testing encodability independently of compression ratio.
 
 Known residual: a plan block with a width-explicit packed op (a `bitextract`/`bitjoin` field spec
 of a fixed total width) on an integer column narrowed to a different width still fails that

--- a/docs/super-sirius/compressed-pinning.md
+++ b/docs/super-sirius/compressed-pinning.md
@@ -15,6 +15,12 @@ at task-prepare time via the `compressed_host_representation` /
 `compressed_device_blob` → `gpu_table_representation` converters, column-parallel across
 4 fixed streams (measured strictly better than serial).
 
+The compression settings can be staged in either order before a table is pinned. They become
+active only when `pin_table_compression` is true, the plan-directory setting is non-empty, and a
+matching table plan exists. `pin_table` warns and pins uncompressed when the enable flag is true
+but the plan directory is empty; a missing table plan likewise warns and falls back. The batch-size
+and compressed-fraction settings are inert until a matching plan activates compression.
+
 ## Which tier to compress on (GB300, TPC-H SF1000, 22-query hot suite)
 
 The tier decides whether compression helps at all. Measured against a 20.74 s all-host

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -153,6 +153,23 @@ Controls the disk spill tier. Data evicted from host memory is written here. Dis
 | `capacity_bytes` | bytes | 1Ti | Maximum disk space for spill files. |
 | `downgrade_root_dirs` | string | "" | Directory path for spill files. **Must be set** to enable disk spilling. Use a fast local mount (NVMe preferred). |
 
+### Input-table compression (`sirius.compression`)
+
+These settings control optional Simpatico compression when
+`pin_table(tier=>'host')` caches input tables. Compression requires both
+`enable_pin_table_compression: true` and a matching plan in `input_plan_dir`;
+otherwise the table is pinned uncompressed.
+
+| Key | DuckDB setting | Type | Default | Description |
+|-----|----------------|------|---------|-------------|
+| `enable_pin_table_compression` | `pin_table_compression` | bool | false | Attempt planned compression while pinning input tables to host memory. |
+| `min_batch_size_bytes` | `pin_table_compression_min_batch_size_bytes` | bytes | 1Mi | Skip compression below this uncompressed batch size. `0` disables the size gate. |
+| `max_compressed_fraction` | `pin_table_compression_max_compressed_fraction` | finite double >= 0 | 0.75 | Keep a compressed representation only at or below this fraction of the original batch size. `0` retains none; values above `1` deliberately permit expansion, primarily for testing encodability. |
+| `input_plan_dir` | `pin_table_input_compression_plan_dir` | string | "" | Directory of per-table Simpatico plan files. An empty path leaves compression inactive. |
+
+The YAML loader and DuckDB `SET` surface reject negative, NaN, and infinite
+`max_compressed_fraction` values instead of silently changing retention behavior.
+
 ### How Downgrade Thresholds Work
 
 Each memory tier uses a trigger/stop threshold pair to control data eviction:

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -195,6 +195,8 @@ struct compression_config {
   /// size, for the compressed form to be kept.  When the compressed header +
   /// payload exceeds this fraction of the original (i.e. compression saved too
   /// little), the compressed data is discarded and the uncompressed batch is used.
+  /// Must be finite and non-negative. Values above 1 deliberately allow compressed
+  /// representations that expand relative to the original batch.
   //  Default 0.75 (that coincides with a 1.33x compression ratio).
   double max_compressed_fraction{0.75};
 

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -27,6 +27,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <algorithm>
+#include <cmath>
 #include <exception>
 #include <limits>
 #include <stdexcept>
@@ -297,7 +298,9 @@ static void from_yaml(const YAML::Node& node, compression_config& opt)
   yaml::reader r(node, "compression");
   r.optional("enable_pin_table_compression", opt.enable_pin_table_compression);
   r.optional("min_batch_size_bytes", yaml::bytes(opt.min_batch_size_bytes));
-  r.optional("max_compressed_fraction", opt.max_compressed_fraction);
+  r.optional("max_compressed_fraction", opt.max_compressed_fraction, [](double value) {
+    return std::isfinite(value) && value >= 0.0;
+  });
   r.optional("input_plan_dir", opt.input_plan_dir);
   r.reject_unknown();
 }

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -119,6 +119,7 @@ extern "C" int cudaProfilerStop();
 #include "io/types.hpp"                // sirius::io::sirius_ioctx
 #include "io/uring/uring_reactor.hpp"  // sirius::io::uring_io_object
 
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <string_view>
@@ -2041,10 +2042,15 @@ static void SetPinTableCompressionMaxCompressedFraction(ClientContext& context,
                                                         SetScope scope,
                                                         Value& parameter)
 {
+  const double fraction = DoubleValue::Get(parameter);
+  if (!std::isfinite(fraction) || fraction < 0.0) {
+    throw InvalidInputException(
+      "pin_table_compression_max_compressed_fraction must be finite and non-negative, got %f",
+      fraction);
+  }
   auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
   if (!sirius_ctx) { return; }
-  sirius_ctx->get_config().get_compression_config().max_compressed_fraction =
-    DoubleValue::Get(parameter);
+  sirius_ctx->get_config().get_compression_config().max_compressed_fraction = fraction;
   SIRIUS_LOG_DEBUG("Updated pin_table_compression_max_compressed_fraction");
 }
 
@@ -2409,8 +2415,8 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
   config.AddExtensionOption(
     "pin_table_compression_max_compressed_fraction",
     "Discard the compressed form and pin uncompressed when the compressed size exceeds this "
-    "fraction of the batch's original size (i.e. compression saved too little); inert until "
-    "compression is enabled and a matching plan resolves",
+    "finite, non-negative fraction of the batch's original size (values above 1 permit "
+    "expansion); inert until compression is enabled and a matching plan resolves",
     LogicalType::DOUBLE,
     Value::DOUBLE(compression_defaults.max_compressed_fraction),
     SetPinTableCompressionMaxCompressedFraction);

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1318,6 +1318,12 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
   // directory (if configured), then resolve it into a compression_pin_config. Both
   // the host and GPU pin paths compress with this when enabled.
   const auto& comp_cfg = sirius_ctx->get_config().get_compression_config();
+  if (comp_cfg.enable_pin_table_compression && comp_cfg.input_plan_dir.empty()) {
+    SIRIUS_LOG_WARN(
+      "[pin_table] '{}': pin_table_compression is enabled but "
+      "pin_table_input_compression_plan_dir is empty; pinning uncompressed",
+      data.args.name);
+  }
   const bool comp_globally_enabled =
     comp_cfg.enable_pin_table_compression && !comp_cfg.input_plan_dir.empty();
   if (comp_globally_enabled) {
@@ -2375,23 +2381,27 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     SetEnableGpuExecution);
 
   config.AddExtensionOption("pin_table_compression",
-                            "Enable Simpatico compression for pin_table(tier=>'host') chunks",
+                            "Request Simpatico compression for pin_table chunks. Takes effect only "
+                            "when pin_table_input_compression_plan_dir is non-empty and contains a "
+                            "matching table plan",
                             LogicalType::BOOLEAN,
                             Value::BOOLEAN(compression_defaults.enable_pin_table_compression),
                             SetEnablePinTableCompression);
 
   config.AddExtensionOption(
     "pin_table_input_compression_plan_dir",
-    "Directory containing per-table Simpatico plan files for pin_table(tier=>'host') compression. "
+    "Directory containing per-table Simpatico plan files for pin_table compression. "
     "Files are named '<table_name>.<ext>'; their contents are the multi-column plan DSL. "
-    "Tables with no matching file are pinned uncompressed. No effect on spill compression.",
+    "May be set before pin_table_compression is enabled. Tables with no matching file are pinned "
+    "uncompressed. No effect on spill compression.",
     LogicalType::VARCHAR,
     Value(compression_defaults.input_plan_dir),
     SetPinTableInputCompressionPlanDir);
 
   config.AddExtensionOption(
     "pin_table_compression_min_batch_size_bytes",
-    "Minimum uncompressed batch size in bytes below which pin_table compression is skipped",
+    "Minimum uncompressed batch size in bytes below which active pin_table compression is skipped; "
+    "inert until compression is enabled and a matching plan resolves",
     LogicalType::UBIGINT,
     Value::UBIGINT(compression_defaults.min_batch_size_bytes),
     SetPinTableCompressionMinBatchSizeBytes);
@@ -2399,7 +2409,8 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
   config.AddExtensionOption(
     "pin_table_compression_max_compressed_fraction",
     "Discard the compressed form and pin uncompressed when the compressed size exceeds this "
-    "fraction of the batch's original size (i.e. compression saved too little)",
+    "fraction of the batch's original size (i.e. compression saved too little); inert until "
+    "compression is enabled and a matching plan resolves",
     LogicalType::DOUBLE,
     Value::DOUBLE(compression_defaults.max_compressed_fraction),
     SetPinTableCompressionMaxCompressedFraction);

--- a/test/cpp/compression/test_compression.cpp
+++ b/test/cpp/compression/test_compression.cpp
@@ -25,6 +25,7 @@
 
 #include <catch.hpp>
 #include <compression/plan_register.hpp>
+#include <utils/log_test_utils.hpp>
 
 // standard library
 #include <string>
@@ -1697,6 +1698,30 @@ TEST_CASE("pin_table compression - no plan file for the table pins uncompressed"
   run_ok(con, "SET pin_table_compression = true;", "set compression");
   run_ok(con, "SET pin_table_compression_min_batch_size_bytes = 0;", "set min_batch");
   run_ok(con, "SET enable_compressed_materialization = true;", "set narrowing");
+
+  // Runtime settings may be staged in either order, so setting the enable flag before the plan
+  // directory is valid. The final pin must nevertheless make the inactive state visible rather
+  // than silently accepting a compression request it cannot honor.
+  {
+    sirius::test::scoped_recording_log_sink logs{"warn"};
+    auto pin_without_plan_source =
+      con.Query("CALL pin_table('" + glob + "', tier='host', name='t_noplan');");
+    require_ok(pin_without_plan_source, "pin without plan source");
+
+    std::size_t missing_plan_source_warnings = 0;
+    for (auto const& record : logs.records()) {
+      if (record.message.find("pin_table_input_compression_plan_dir is empty") !=
+          std::string::npos) {
+        ++missing_plan_source_warnings;
+        REQUIRE(record.level == sirius::log::level::warn);
+        REQUIRE(record.message.find("pinning uncompressed") != std::string::npos);
+      }
+    }
+    REQUIRE(missing_plan_source_warnings == 1);
+  }
+  REQUIRE(sirius::test::census_entry(con, "t_noplan").compressed_chunks == 0);
+  run_ok(con, "CALL unpin_table('t_noplan');", "unpin without plan source");
+
   // A plan directory holding a plan for some OTHER table: the resolver finds no plan for this
   // one, so compression never engages.
   auto plan_dir = tmp / "plans";

--- a/test/cpp/config/data/invalid_compression_fraction_infinity.yaml
+++ b/test/cpp/config/data/invalid_compression_fraction_infinity.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: .inf

--- a/test/cpp/config/data/invalid_compression_fraction_nan.yaml
+++ b/test/cpp/config/data/invalid_compression_fraction_nan.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: .nan

--- a/test/cpp/config/data/invalid_compression_fraction_negative.yaml
+++ b/test/cpp/config/data/invalid_compression_fraction_negative.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: -0.1

--- a/test/cpp/config/data/valid_compression_fraction_above_one.yaml
+++ b/test/cpp/config/data/valid_compression_fraction_above_one.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: 1.5

--- a/test/cpp/config/data/valid_compression_fraction_zero.yaml
+++ b/test/cpp/config/data/valid_compression_fraction_zero.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: 0

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -423,6 +423,37 @@ TEST_CASE("Sirius configuration rejects invalid GPU topology selections", "[siri
   }
 }
 
+TEST_CASE("Sirius configuration rejects invalid compression retention fractions",
+          "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+  sirius::sirius_config config;
+  for (auto const* fixture : {"invalid_compression_fraction_negative.yaml",
+                              "invalid_compression_fraction_nan.yaml",
+                              "invalid_compression_fraction_infinity.yaml"}) {
+    INFO("fixture=" << fixture);
+    REQUIRE_THROWS_WITH(config.load_from_file(data_dir / fixture),
+                        Catch::Contains("max_compressed_fraction"));
+  }
+}
+
+TEST_CASE("Sirius configuration accepts intentional compression retention fraction boundaries",
+          "[sirius][config]")
+{
+  std::source_location loc    = std::source_location::current();
+  auto const data_dir         = fs::path(loc.file_name()).parent_path() / "data";
+  auto const require_fraction = [&data_dir](char const* fixture, double expected) {
+    INFO("fixture=" << fixture);
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(config.load_from_file(data_dir / fixture));
+    REQUIRE(config.get_compression_config().max_compressed_fraction == Approx(expected));
+  };
+
+  require_fraction("valid_compression_fraction_zero.yaml", 0.0);
+  require_fraction("valid_compression_fraction_above_one.yaml", 1.5);
+}
+
 namespace {
 
 void require_shared_operator_defaults(const sirius::operator_params& params, uint64_t batch)
@@ -780,6 +811,36 @@ TEST_CASE("DuckDB setting rejects negative byte values without mutation",
   REQUIRE(after->GetValue(0, 0).GetValue<uint64_t>() == expected);
 }
 
+TEST_CASE("DuckDB setting rejects invalid compression retention fractions without a Sirius context",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  for (auto const* value : {"-0.1", "'NaN'", "'Infinity'"}) {
+    INFO("value=" << value);
+    auto result =
+      con.Query("SET pin_table_compression_max_compressed_fraction = " + std::string(value));
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    REQUIRE_THAT(
+      result->GetError(),
+      Catch::Contains(
+        "pin_table_compression_max_compressed_fraction must be finite and non-negative"));
+  }
+
+  for (auto const* value : {"0", "1.5"}) {
+    INFO("value=" << value);
+    auto result =
+      con.Query("SET pin_table_compression_max_compressed_fraction = " + std::string(value));
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+  }
+}
+
 TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
           "[sirius][context][config][isolated_context]")
 {
@@ -896,6 +957,26 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE_FALSE(reset_mark_join_ratio->HasError());
   REQUIRE(sirius_ctx->get_config().get_operator_params().mark_join_build_switch_ratio ==
           Approx(3.0));
+
+  for (auto const* value : {"-0.1", "'NaN'", "'Infinity'"}) {
+    INFO("value=" << value);
+    auto invalid_fraction =
+      con.Query("SET pin_table_compression_max_compressed_fraction = " + std::string(value));
+    REQUIRE(invalid_fraction != nullptr);
+    REQUIRE(invalid_fraction->HasError());
+    REQUIRE_THAT(
+      invalid_fraction->GetError(),
+      Catch::Contains(
+        "pin_table_compression_max_compressed_fraction must be finite and non-negative"));
+
+    auto retained =
+      con.Query("SELECT current_setting('pin_table_compression_max_compressed_fraction')::DOUBLE");
+    REQUIRE(retained != nullptr);
+    REQUIRE_FALSE(retained->HasError());
+    REQUIRE(retained->GetValue(0, 0).GetValue<double>() == Approx(0.6));
+    REQUIRE(sirius_ctx->get_config().get_compression_config().max_compressed_fraction ==
+            Approx(0.6));
+  }
 
   auto const require_ok = [&con](std::string const& sql) {
     auto result = con.Query(sql);


### PR DESCRIPTION
## Summary

- warn once at the `CALL pin_table` consumption boundary when compression is enabled without a plan directory and the table therefore pins uncompressed
- preserve either-order staging of the enable flag, plan directory, and child thresholds
- reject negative, NaN, and infinite compression-retention fractions at YAML load and DuckDB `SET`, before mutation
- preserve intentional `0` and finite values above `1` used by encodability tests
- consolidate the adjacent #1504 validation into one pin-compression review unit

## Why

The four visible settings describe one activation contract: compression requires both the enable flag and a matching plan, and its thresholds are inert until then. Previously the missing-plan case was silent, while malformed retention fractions could silently reject every compressed result or admit unbounded expansion. This candidate surfaces the inactive configuration without introducing an ordering trap and validates the only malformed numeric domain.

## Screen evidence

Foxglove subsequently screened both threshold settings at the exact pre-rebase Sirius head on an NVIDIA L4: one calibration plus 45 trials, all oracle-correct and contract-complete. Every candidate changed the compression mechanism as source predicts, but none produced an admissible gain; disabling or maximally relaxing compression regressed the 256 MiB path materially. The bounded verdict is to keep the current defaults on the tested path. A separate follow-up may reduce the ordinary user-facing surface; it is intentionally not mixed into this behavioral-repair PR.

## Rebased identity

- exact base: `e3e37aec4b19bd3959c87d24c4e3f60bfb8b046b`
- exact head: `35b7bd553be8db08962da8ac914629f2fc4852ee`
- candidate tree: `32f681ebd0ad17bbd942988dfc57e010c46412a2`
- zero-context cumulative diff SHA-256: `399bd760b48e03f14bcfff23de0b25ce517a45ad51bcd43911735f8d9ab9efeb`
- cumulative diff: 13 paths, 177 insertions, 9 deletions

## Validation

- rebased onto current `dev` after #1494 merged
- range-diff: the first commit is patch-identical; the second differs only by
  placing its unchanged compression tests after #1494's new topology tests
- the sole conflict retains both #1494's topology validation coverage and this
  PR's compression-fraction coverage
- repository pre-commit hooks pass for all changed files except the disposable
  clone's missing `pixi` wrapper; the identical `rumdl` checks pass directly
- orphan-test check, YAML checks, clang-format, codespell, and `git diff --check`
  pass
- predecessor head `36a7af2470eb09b5150f5680547d761775497220`
  passed hosted lint, GCC release, Clang debug, CUDA 13 build/runtime, TPC-H
  snapshot, and terminal aggregate (Test workflow `31752800591`, runtime job
  `94622914746`, aggregate job `94626571866`)
- rebased exact-head validation is terminal green:
  - Check workflow `31913366196`: lint `95081626431`, GCC release
    `95081626444`, Clang debug `95081626438`, aggregate `95082157123`
  - Test workflow `31913366067`: CUDA 13 build `95081626199`, runtime
    `95081980871`, aggregate `95084051266`
  - Distribution workflow `31913366459`: gate `95081627443` passed; CUDA
    distribution jobs were correctly skipped because distribution inputs did
    not change

Supersedes #1504.
