### PR TITLE
refactor(config): keep diagnostic controls internal

### DIFF
--- a/bench/sf1000-repro/sirius-sf1000.yaml
+++ b/bench/sf1000-repro/sirius-sf1000.yaml
@@ -39,13 +39,10 @@ sirius:
           enable_prefetch_cache: false
         pipeline:
             num_threads: 8
-            thread_name_prefix: "sirius_pipeline_executor"
         downgrade:
             num_threads: 1
-            thread_name_prefix: "sirius_downgrade_executor"
         task_creator:
             num_threads: 4
-            thread_name_prefix: "sirius_task_creator"
     operator_params:
         scan_task_batch_size: 8GB
         max_sort_partition_bytes: 0               # 0: auto (33% GPU memory)

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -125,7 +125,10 @@ Controls how much GPU VRAM Sirius claims and when it starts evicting data to hos
 | `reservation_limit_bytes` | bytes | — | Absolute reservation limit. Mutually exclusive with `reservation_limit_fraction`; configuration loading rejects both when both values are non-null. |
 | `downgrade_trigger_fraction` | double (0,1] | 0.8 | Start evicting GPU-resident data to host when reserved memory exceeds this fraction of capacity. Must be greater than `downgrade_stop_fraction`. |
 | `downgrade_stop_fraction` | double (0,1] | 0.6 | Stop evicting when reserved memory drops to this fraction of capacity. Must be less than `downgrade_trigger_fraction`; configuration loading rejects an invalid pair. |
-| `track_per_stream_reservation` | bool | false | Track memory reservations per CUDA stream instead of globally. Useful for debugging per-task memory usage. |
+
+The high-level GPU path keeps per-stream reservation tracking off. The
+diagnostic control remains available only through the explicit low-level
+`sirius.space.gpu[].per_stream_reservation` replacement surface.
 
 ### Host Memory (`sirius.memory.host`)
 
@@ -249,12 +252,11 @@ hardware-derived exception described below:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `num_threads` | int (**> 0**) | per pool (below) | Worker threads in the pool. |
-| `thread_name_prefix` | string | per pool | Thread name prefix for logs. |
 | `cpu_affinity` | list of int | — | Cores to pin task-creator and downgrade threads. GPU pipeline affinity is derived from the selected GPU's CPU topology. |
 
 ### `sirius.executor.task_creator`
 
-Thread pool (default `num_threads: 1`, prefix `task_creator`) plus:
+Thread pool (default `num_threads: 1`) plus:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -263,11 +265,11 @@ Thread pool (default `num_threads: 1`, prefix `task_creator`) plus:
 
 ### `sirius.executor.pipeline`
 
-Thread pool only (default `num_threads: 4`, prefix `gpu_pipeline`). No extra keys.
+Thread pool only (default `num_threads: 4`). No extra keys.
 
 ### `sirius.executor.downgrade`
 
-Thread pool (default `num_threads: 1`, prefix `downgrade`) plus:
+Thread pool (default `num_threads: 1`) plus:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -282,7 +284,6 @@ The `sirius.executor.scan_manager` block configures the scan-metadata thread poo
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `num_threads` | int (**> 2**) | remaining cores (min 4) | Threads in the scan-manager pool that run metadata tasks. Defaults to every core left after the other default pools (1 downgrade + 1 task_creator + 4 pipeline + 1 uring reactor), with a floor of 4. Rejected unless strictly greater than 2 (i.e. minimum 3). |
-| `thread_name_prefix` | string | `scan_manager` | Thread name prefix for logs. |
 | `cpu_affinity` | list of int | — | Cores to pin scan-manager threads to. |
 | `use_sirius_datasource` | bool | true | Route reads through the Sirius `io_uring` datasource. When false, the kvikio fallback is used (single-GPU only; multi-GPU requires the Sirius datasource). |
 | `uring_n_reactors` | int (**> 0**) | 1 | Number of io_uring reactor threads for local-disk reads. |

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -139,7 +139,6 @@ static void from_yaml(const YAML::Node& node, exec::thread_pool_config& opt)
 {
   yaml::reader r(node, "thread_pool");
   r.optional("num_threads", opt.num_threads, yaml::greater_than<int>{0});
-  r.optional("thread_name_prefix", opt.thread_name_prefix);
   r.reject_unknown();
 }
 
@@ -147,7 +146,6 @@ static void from_yaml(const YAML::Node& node, creator::task_creator_config& opt)
 {
   yaml::reader r(node, "task_creator");
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{0});
-  r.optional("thread_name_prefix", opt.thread_pool.thread_name_prefix);
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
   r.optional("strategy", opt.strategy);
   r.optional("priority_order", opt.priority);
@@ -235,7 +233,6 @@ static void from_yaml(const YAML::Node& node, scan_manager::scan_manager_config&
 {
   yaml::reader r(node, "scan_manager");
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{2});
-  r.optional("thread_name_prefix", opt.thread_pool.thread_name_prefix);
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
   r.optional("use_sirius_datasource", opt.use_sirius_datasource);
   r.optional("uring_n_reactors", opt.uring_n_reactors, yaml::greater_than<std::size_t>{0});
@@ -306,7 +303,6 @@ static void from_yaml(const YAML::Node& node, exec::downgrade_executor_config& o
 {
   yaml::reader r(node, "downgrade");
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{0});
-  r.optional("thread_name_prefix", opt.thread_pool.thread_name_prefix);
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
   r.optional("monitor_period", opt.monitor_period);
   r.reject_unknown();
@@ -367,11 +363,9 @@ struct gpu_mem_config {
   std::variant<double, std::uint64_t> reservation_limit{1.0};
   double downgrade_trigger_fraction{0.8};
   double downgrade_stop_fraction{0.6};
-  bool track_per_stream_reservation{false};
 
   static void from_yaml(const YAML::Node& node, gpu_mem_config& opt)
   {
-    opt.track_per_stream_reservation = false;
     yaml::reader r(node, "memory.gpu");
     // usage_limit: fraction (double) or absolute bytes — mutually exclusive keys
     std::optional<std::uint64_t> usage_bytes;
@@ -393,7 +387,6 @@ struct gpu_mem_config {
     r.optional(
       "downgrade_trigger_fraction", opt.downgrade_trigger_fraction, yaml::fraction<double>{});
     r.optional("downgrade_stop_fraction", opt.downgrade_stop_fraction, yaml::fraction<double>{});
-    r.optional("track_per_stream_reservation", opt.track_per_stream_reservation);
     r.reject_unknown();
     validate_downgrade_fractions(
       "sirius.memory.gpu", opt.downgrade_trigger_fraction, opt.downgrade_stop_fraction);
@@ -412,7 +405,9 @@ struct gpu_mem_config {
       builder.set_reservation_limit_per_gpu(std::get<std::uint64_t>(reservation_limit));
     }
     builder.set_downgrade_fractions_per_gpu(downgrade_trigger_fraction, downgrade_stop_fraction);
-    builder.track_reservation_per_stream(track_per_stream_reservation);
+    // Keep the high-level path on Sirius's default. The low-level
+    // space.gpu[] replacement surface retains the diagnostic per-stream control.
+    builder.track_reservation_per_stream(false);
   }
 };
 

--- a/test/cpp/config/data/configurator.yaml
+++ b/test/cpp/config/data/configurator.yaml
@@ -7,7 +7,6 @@ sirius:
       reservation_limit_fraction: 0.04
       downgrade_trigger_fraction: 0.04
       downgrade_stop_fraction: 0.02
-      track_per_stream_reservation: false
     host:
       capacity_bytes: 160000000
       reservation_limit_fraction: 0.9
@@ -20,10 +19,8 @@ sirius:
   executor:
     pipeline:
       num_threads: 4
-      thread_name_prefix: "sirius_pipeline_executor"
     downgrade:
       num_threads: 1
-      thread_name_prefix: "sirius_downgrade_executor"
       monitor_period: 10ms
   telemetry:
     enable_quent: false

--- a/test/cpp/config/data/invalid_downgrade_thread_name_prefix.yaml
+++ b/test/cpp/config/data/invalid_downgrade_thread_name_prefix.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      thread_name_prefix: custom_downgrade

--- a/test/cpp/config/data/invalid_memory_gpu_per_stream_reservation.yaml
+++ b/test/cpp/config/data/invalid_memory_gpu_per_stream_reservation.yaml
@@ -1,0 +1,4 @@
+sirius:
+  memory:
+    gpu:
+      track_per_stream_reservation: true

--- a/test/cpp/config/data/invalid_pipeline_thread_name_prefix.yaml
+++ b/test/cpp/config/data/invalid_pipeline_thread_name_prefix.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    pipeline:
+      thread_name_prefix: custom_pipeline

--- a/test/cpp/config/data/invalid_scan_manager_thread_name_prefix.yaml
+++ b/test/cpp/config/data/invalid_scan_manager_thread_name_prefix.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    scan_manager:
+      thread_name_prefix: custom_scan_manager

--- a/test/cpp/config/data/invalid_task_creator_thread_name_prefix.yaml
+++ b/test/cpp/config/data/invalid_task_creator_thread_name_prefix.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    task_creator:
+      thread_name_prefix: custom_task_creator

--- a/test/cpp/config/data/minimal.yaml
+++ b/test/cpp/config/data/minimal.yaml
@@ -13,8 +13,6 @@ sirius:
   executor:
     pipeline:
       num_threads: 4
-      thread_name_prefix: "sirius_pipeline_executor"
     downgrade:
       num_threads: 1
-      thread_name_prefix: "sirius_downgrade_executor"
       monitor_period: 10ms

--- a/test/cpp/config/data/spaces.yaml
+++ b/test/cpp/config/data/spaces.yaml
@@ -2,7 +2,7 @@ sirius:
   space:
     gpu:
       - device_id: 0
-        per_stream_reservation: false
+        per_stream_reservation: true
         reservation_limit_fraction: 0.9
         downgrade_trigger_fraction: 0.8
         downgrade_stop_fraction: 0.7
@@ -24,8 +24,6 @@ sirius:
   executor:
     pipeline:
       num_threads: 4
-      thread_name_prefix: "sirius_pipeline_executor"
     downgrade:
       num_threads: 1
-      thread_name_prefix: "sirius_downgrade_executor"
       monitor_period: 10ms

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -314,6 +314,13 @@ TEST_CASE("Sirius configuration loading from file with configurator",
   REQUIRE(manager.get_memory_spaces_for_tier(cucascade::memory::Tier::HOST).size() == 1);
   REQUIRE(manager.get_memory_spaces_for_tier(cucascade::memory::Tier::DISK).size() == 1);
 
+  auto const& spaces = sirius_ctx->get_config().get_memory_space_configs();
+  auto const gpu     = std::ranges::find_if(spaces, [](auto const& space) {
+    return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space);
+  });
+  REQUIRE(gpu != spaces.end());
+  REQUIRE_FALSE(std::get<cucascade::memory::gpu_memory_space_config>(*gpu).per_stream_reservation);
+
   auto const& telemetry = sirius_ctx->get_config().get_telemetry_config();
   REQUIRE_FALSE(telemetry.enable_quent);
   REQUIRE(telemetry.output_directory == "/tmp/sirius_telemetry_config_test");
@@ -492,6 +499,32 @@ TEST_CASE("operator batch defaults use an explicit high-level GPU usage fraction
   config.load_from_file(config_fixture("minimal.yaml"));
 
   require_shared_operator_defaults(config.get_operator_params(), expected_effective_batch(config));
+  REQUIRE(config.get_task_creator_config().thread_pool.thread_name_prefix == "task_creator");
+  REQUIRE(config.get_gpu_pipeline_executor_config().thread_name_prefix == "gpu_pipeline");
+  REQUIRE(config.get_downgrade_executor_config().thread_pool.thread_name_prefix == "downgrade");
+  REQUIRE(config.get_scan_manager_config().thread_pool.thread_name_prefix == "scan_manager");
+}
+
+TEST_CASE("Sirius keeps executor thread-name prefixes internal", "[sirius][config]")
+{
+  struct invalid_prefix {
+    const char* fixture;
+    const char* context;
+  };
+  constexpr std::array cases{
+    invalid_prefix{"invalid_task_creator_thread_name_prefix.yaml", "task_creator"},
+    invalid_prefix{"invalid_pipeline_thread_name_prefix.yaml", "thread_pool"},
+    invalid_prefix{"invalid_downgrade_thread_name_prefix.yaml", "downgrade"},
+    invalid_prefix{"invalid_scan_manager_thread_name_prefix.yaml", "scan_manager"},
+  };
+
+  for (auto const& test : cases) {
+    INFO("fixture=" << test.fixture);
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(
+      config.load_from_file(config_fixture(test.fixture)),
+      Catch::Contains("unknown config key: 'thread_name_prefix'") && Catch::Contains(test.context));
+  }
 }
 
 TEST_CASE("explicit operator batch values override effective-capacity defaults",
@@ -679,6 +712,14 @@ TEST_CASE("Sirius downgrade hysteresis accepts omitted, null, and one-sided defa
     sirius::sirius_config config;
     REQUIRE_NOTHROW(config.load_from_file(path));
   }
+}
+
+TEST_CASE("Sirius high-level GPU config keeps per-stream tracking internal", "[sirius][config]")
+{
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(
+    config.load_from_file(config_fixture("invalid_memory_gpu_per_stream_reservation.yaml")),
+    Catch::Contains("unknown config key: 'track_per_stream_reservation' in memory.gpu"));
 }
 
 TEST_CASE("Sirius configuration rejects conflicting memory budget forms", "[sirius][config]")
@@ -977,6 +1018,13 @@ TEST_CASE("Sirius configuration loading from file with spaces",
   REQUIRE(manager.get_memory_spaces_for_tier(cucascade::memory::Tier::HOST).size() == 1);
   REQUIRE(manager.get_memory_spaces_for_tier(cucascade::memory::Tier::DISK).size() == 2);
   REQUIRE(manager.get_all_memory_spaces().size() == 4);
+
+  auto const& spaces = sirius_ctx->get_config().get_memory_space_configs();
+  auto const gpu     = std::ranges::find_if(spaces, [](auto const& space) {
+    return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space);
+  });
+  REQUIRE(gpu != spaces.end());
+  REQUIRE(std::get<cucascade::memory::gpu_memory_space_config>(*gpu).per_stream_reservation);
 }
 
 TEST_CASE("Sirius configuration rejects competing memory configuration paths", "[sirius][config]")


### PR DESCRIPTION
## Summary

- remove high-level `memory.gpu.track_per_stream_reservation` from YAML
- preserve explicit low-level per-space reservation accounting for diagnostics
- remove four executor `thread_name_prefix` choices from normal YAML
- keep stable internal labels and UUID-backed telemetry identity unchanged
- reject every stale removed path with contextual configuration errors

## Why one PR

These five settings are diagnostic controls, not workload policy. Per-stream
reservation accounting changes debugging detail and remains available through
the explicit low-level space model. Thread-label strings rename OS threads and
Quent instances without changing scheduling, capacity, affinity, or execution.
Keeping stable labels engine-owned makes diagnostics comparable while removing
ordinary choices users cannot tune productively.

This supersedes #1501. Its four field-path regressions and resolved-label checks
are retained alongside #1499's high-level/low-level reservation boundary.

## Contract

- high-level GPU memory policy fixes per-stream reservation tracking off
- explicit low-level `space.gpu[].per_stream_reservation` remains available
- task-creator, pipeline, downgrade, and scan-manager labels retain exact stable
  defaults
- pipeline affinity remains hardware-derived from selected GPU topology; the
  removed YAML `cpu_affinity` path from merged #1494 is not restored
- all five removed high-level paths fail at configuration load
- UUID-backed telemetry identity is unchanged

## Rebased identity

- exact base: `e3e37aec4b19bd3959c87d24c4e3f60bfb8b046b`
- exact head: `ca0acc7742c8704df8cb6e840b59e8f34653ea23`
- candidate tree: `9c814aa42346a6d0cbdc4a647c237189f738c3e6`
- zero-context cumulative diff SHA-256: `c628c6d69124b674fd4b36af759e8cea242cae49334f3f52bb9848a41a4e44c9`
- cumulative diff: 12 paths, 79 insertions, 25 deletions
- reservation predecessor: `caebd91dc366b597f079d863e725edabeff44bcd`
- thread-label predecessor from #1501: `62e48601658ad9304c2c6573d78bdeed3e3e537f`

## Validation

- rebased onto current `dev` after #1494 merged
- range-diff: the SF1000 migration repair remains patch-identical; the first
  commit changes only where required to preserve #1494's topology-derived
  pipeline affinity while also removing the thread-name choice
- the resolved generic pipeline parser accepts only `num_threads`; independent
  tests reject both stale `cpu_affinity` and `thread_name_prefix` keys
- scoped affinity remains available for task-creator, downgrade, and
  scan-manager pools
- all scoped pre-commit hooks pass, including YAML, clang-format, codespell,
  orphan-test detection, and merge-conflict detection
- direct `rumdl` and `git diff --check` pass
- rebased exact-head hosted validation passed on
  `ca0acc7742c8704df8cb6e840b59e8f34653ea23`: Check workflow `31914932966`
  (terminal job `95085813434`), Test workflow `31914932997` (CUDA 13 runtime
  job `95085639542`, terminal job `95087611695`), and Distribution workflow
  `31914933231` (terminal job `95085279456`) all completed successfully

### Retained predecessor hosted receipts

- repaired pre-rebase head `e2d0351`: Check workflow `31843774186`, Test
  workflow `31843774166`, Distribution workflow `31843774689`, CUDA 13 runtime
  `94906839964`, and aggregate `94911037143` passed
- reservation head `caebd91d`: workflow `31728356820`; runtime job
  `94543280504` and aggregate job `94561723117` passed
- thread-label head `62e48601`: workflow `31727988334`; runtime job
  `94542038414` and aggregate job `94563271595` passed
- pre-repair consolidated head
  `3cf4054c67db7efc7fba481d89747e9e96d68667`: workflow `31758628953`;
  runtime job `94640655154` and terminal aggregate job `94643964144` passed
