### PR TITLE
fix(config): reject negative REST request timeouts

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -321,7 +321,7 @@ and transport use one trust policy; there are no separate REST YAML controls.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `request_timeout_s` | int (seconds) | 30 | Whole-request timeout and presigned-URL TTL (0 = no limit). |
+| `request_timeout_s` | int (seconds, **>= 0**) | 30 | Whole-request timeout and presigned-URL TTL (0 = no limit; negative values are rejected). |
 | `max_connections` | int | 16 | Max concurrent in-flight connections per reactor. |
 | `chunk_size` | bytes | 8Mi | Target bytes per ranged GET (scatter/device-staging paths). |
 | `max_n_chunks` | int | 16 | Max file-adjacent segments fused into one scatter GET. |

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -179,8 +179,7 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
                                key + "' instead");
     }
   }
-  r.optional(
-    "request_timeout_s", opt.request_timeout_s, [](long value) { return value >= 0; });
+  r.optional("request_timeout_s", opt.request_timeout_s, [](long value) { return value >= 0; });
   r.optional("max_connections", opt.max_connections);
   r.optional("chunk_size", yaml::bytes(opt.chunk_size));
   r.optional("max_n_chunks", opt.max_n_chunks);

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -179,7 +179,8 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
                                key + "' instead");
     }
   }
-  r.optional("request_timeout_s", opt.request_timeout_s);
+  r.optional(
+    "request_timeout_s", opt.request_timeout_s, [](long value) { return value >= 0; });
   r.optional("max_connections", opt.max_connections);
   r.optional("chunk_size", yaml::bytes(opt.chunk_size));
   r.optional("max_n_chunks", opt.max_n_chunks);

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -285,11 +285,9 @@ TEST_CASE("sirius_config parses rest perf instrumentation flag",
   std::filesystem::remove(path, ec);
 }
 
-TEST_CASE("sirius_config rejects negative REST request timeouts",
-          "[scan_manager][config][rest]")
+TEST_CASE("sirius_config rejects negative REST request timeouts", "[scan_manager][config][rest]")
 {
-  auto const path =
-    std::filesystem::temp_directory_path() / "sirius_rest_request_timeout.yaml";
+  auto const path = std::filesystem::temp_directory_path() / "sirius_rest_request_timeout.yaml";
 
   SECTION("zero keeps the documented unlimited timeout")
   {

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -285,6 +285,45 @@ TEST_CASE("sirius_config parses rest perf instrumentation flag",
   std::filesystem::remove(path, ec);
 }
 
+TEST_CASE("sirius_config rejects negative REST request timeouts",
+          "[scan_manager][config][rest]")
+{
+  auto const path =
+    std::filesystem::temp_directory_path() / "sirius_rest_request_timeout.yaml";
+
+  SECTION("zero keeps the documented unlimited timeout")
+  {
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n"
+               "      rest:\n"
+               "        request_timeout_s: 0\n");
+
+    sirius::sirius_config cfg;
+    REQUIRE_NOTHROW(cfg.load_from_file(path));
+    CHECK(cfg.get_scan_manager_config().rest.request_timeout_s == 0);
+  }
+
+  SECTION("negative values do not silently disable the timeout")
+  {
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n"
+               "      rest:\n"
+               "        request_timeout_s: -1\n");
+
+    sirius::sirius_config cfg;
+    REQUIRE_THROWS_WITH(cfg.load_from_file(path),
+                        Catch::Contains("'rest.request_timeout_s': value out of range"));
+    CHECK(cfg.get_scan_manager_config().rest.request_timeout_s == 30);
+  }
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
 TEST_CASE("sirius_config rejects unknown rest config keys", "[scan_manager][config][rest]")
 {
   auto const path = std::filesystem::temp_directory_path() / "sirius_rest_unknown_key.yaml";


### PR DESCRIPTION
## Summary

- reject negative `sirius.executor.scan_manager.rest.request_timeout_s` values during YAML load
- preserve zero as the documented unlimited policy and every positive timeout
- prevent a negative accepted value from silently taking the same runtime branch as zero
- document the non-negative configuration contract

## Validation

### Current exact-head validation

- exact base: `4872cd3c490baf59f2591c527f8fbb6833416e0f`
- PR head: `00a51cb4a3bfa75a3e88de702c1661883e8e9526`
- tree: `12e523fbbe3c2d67dd6bcd5375d5f873680166cb`
- diff/orphan check: pass; the rebase retains only the timeout validator, its zero/negative regression, and its documentation while preserving the merged REST TLS-source and internal bounce-size changes
- `git diff --check 4872cd3c..00a51cb4`: pass
- exact clean-base patch application reproduces tree `12e523fbbe3c2d67dd6bcd5375d5f873680166cb`
- retained patch SHA-256: `08071ea74b07574a3f35df664f6ac2c5843ee9c2c8bcf04174d4917f634acc06`
- exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full runtime, and terminal aggregate checks pass
- hosted workflow [31692854270](https://github.com/sirius-db/sirius/actions/runs/31692854270): runtime job `94424623496` passed in 19m37s; aggregate job `94441018203` passed

### Historical pre-rebase validation

- independent AWS L4 release build on old base `0c5af9aee02f36d003141b432d799216f164a6c6`: pass
- `sirius_config rejects negative REST request timeouts`: pass (6 assertions / 1 test case)
- `[scan_manager][config][rest]`: pass (18 assertions / 3 test cases)
- independent test binary SHA-256: `970be50f731c533450834d1eb66c5aed8f4a26ddc47fd66e87bbb07c2ecdb3f3`
- hosted CI on old exact head `bcc1aeb17a28c1dd45f6397666be93e7cfbc1cc1`: all required jobs passed; CUDA 13 `test-run` passed in 19m57s and the terminal `test` job passed ([run 31674377116](https://github.com/sirius-db/sirius/actions/runs/31674377116))

Historical raw receipts: Foxglove commits `5fa1dc4` and `c45e6ae`, under `patches/current-dev/evidence/rest-request-timeout-0c5af9ae/aws-results/`.
