### PR TITLE
refactor(config): keep executor thread labels internal

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -243,17 +243,16 @@ per-pool sub-blocks: `task_creator`, `pipeline`, `downgrade`, and `scan_manager`
 `scan_manager` sub-block is large and is documented in
 [Scan Manager & IO Configuration](#scan-manager--io-configuration) below.
 
-Every thread-pool sub-block shares three keys:
+Every thread-pool sub-block shares two keys:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `num_threads` | int (**> 0**) | per pool (below) | Worker threads in the pool. |
-| `thread_name_prefix` | string | per pool | Thread name prefix for logs. |
 | `cpu_affinity` | list of int | — | Cores to pin the pool's threads to. |
 
 ### `sirius.executor.task_creator`
 
-Thread pool (default `num_threads: 1`, prefix `task_creator`) plus:
+Thread pool (default `num_threads: 1`) plus:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -262,11 +261,11 @@ Thread pool (default `num_threads: 1`, prefix `task_creator`) plus:
 
 ### `sirius.executor.pipeline`
 
-Thread pool only (default `num_threads: 4`, prefix `gpu_pipeline`). No extra keys.
+Thread pool only (default `num_threads: 4`). No extra keys.
 
 ### `sirius.executor.downgrade`
 
-Thread pool (default `num_threads: 1`, prefix `downgrade`) plus:
+Thread pool (default `num_threads: 1`) plus:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -281,7 +280,6 @@ The `sirius.executor.scan_manager` block configures the scan-metadata thread poo
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `num_threads` | int (**> 2**) | remaining cores (min 4) | Threads in the scan-manager pool that run metadata tasks. Defaults to every core left after the other default pools (1 downgrade + 1 task_creator + 4 pipeline + 1 uring reactor), with a floor of 4. Rejected unless strictly greater than 2 (i.e. minimum 3). |
-| `thread_name_prefix` | string | `scan_manager` | Thread name prefix for logs. |
 | `cpu_affinity` | list of int | — | Cores to pin scan-manager threads to. |
 | `use_sirius_datasource` | bool | true | Route reads through the Sirius `io_uring` datasource. When false, the kvikio fallback is used (single-GPU only; multi-GPU requires the Sirius datasource). |
 | `uring_n_reactors` | int (**> 0**) | 1 | Number of io_uring reactor threads for local-disk reads. |

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -139,7 +139,6 @@ static void from_yaml(const YAML::Node& node, exec::thread_pool_config& opt)
 {
   yaml::reader r(node, "thread_pool");
   r.optional("num_threads", opt.num_threads, yaml::greater_than<int>{0});
-  r.optional("thread_name_prefix", opt.thread_name_prefix);
   r.optional("cpu_affinity", opt.cpu_affinity_list);
   r.reject_unknown();
 }
@@ -148,7 +147,6 @@ static void from_yaml(const YAML::Node& node, creator::task_creator_config& opt)
 {
   yaml::reader r(node, "task_creator");
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{0});
-  r.optional("thread_name_prefix", opt.thread_pool.thread_name_prefix);
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
   r.optional("strategy", opt.strategy);
   r.optional("priority_order", opt.priority);
@@ -236,7 +234,6 @@ static void from_yaml(const YAML::Node& node, scan_manager::scan_manager_config&
 {
   yaml::reader r(node, "scan_manager");
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{2});
-  r.optional("thread_name_prefix", opt.thread_pool.thread_name_prefix);
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
   r.optional("use_sirius_datasource", opt.use_sirius_datasource);
   r.optional("uring_n_reactors", opt.uring_n_reactors, yaml::greater_than<std::size_t>{0});
@@ -305,7 +302,6 @@ static void from_yaml(const YAML::Node& node, exec::downgrade_executor_config& o
 {
   yaml::reader r(node, "downgrade");
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{0});
-  r.optional("thread_name_prefix", opt.thread_pool.thread_name_prefix);
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
   r.optional("monitor_period", opt.monitor_period);
   r.reject_unknown();

--- a/test/cpp/config/data/configurator.yaml
+++ b/test/cpp/config/data/configurator.yaml
@@ -20,10 +20,8 @@ sirius:
   executor:
     pipeline:
       num_threads: 4
-      thread_name_prefix: "sirius_pipeline_executor"
     downgrade:
       num_threads: 1
-      thread_name_prefix: "sirius_downgrade_executor"
       monitor_period: 10ms
   telemetry:
     enable_quent: false

--- a/test/cpp/config/data/invalid_downgrade_thread_name_prefix.yaml
+++ b/test/cpp/config/data/invalid_downgrade_thread_name_prefix.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      thread_name_prefix: custom_downgrade

--- a/test/cpp/config/data/invalid_pipeline_thread_name_prefix.yaml
+++ b/test/cpp/config/data/invalid_pipeline_thread_name_prefix.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    pipeline:
+      thread_name_prefix: custom_pipeline

--- a/test/cpp/config/data/invalid_scan_manager_thread_name_prefix.yaml
+++ b/test/cpp/config/data/invalid_scan_manager_thread_name_prefix.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    scan_manager:
+      thread_name_prefix: custom_scan_manager

--- a/test/cpp/config/data/invalid_task_creator_thread_name_prefix.yaml
+++ b/test/cpp/config/data/invalid_task_creator_thread_name_prefix.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    task_creator:
+      thread_name_prefix: custom_task_creator

--- a/test/cpp/config/data/minimal.yaml
+++ b/test/cpp/config/data/minimal.yaml
@@ -13,8 +13,6 @@ sirius:
   executor:
     pipeline:
       num_threads: 4
-      thread_name_prefix: "sirius_pipeline_executor"
     downgrade:
       num_threads: 1
-      thread_name_prefix: "sirius_downgrade_executor"
       monitor_period: 10ms

--- a/test/cpp/config/data/spaces.yaml
+++ b/test/cpp/config/data/spaces.yaml
@@ -24,8 +24,6 @@ sirius:
   executor:
     pipeline:
       num_threads: 4
-      thread_name_prefix: "sirius_pipeline_executor"
     downgrade:
       num_threads: 1
-      thread_name_prefix: "sirius_downgrade_executor"
       monitor_period: 10ms

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -391,6 +391,32 @@ TEST_CASE("operator batch defaults use an explicit high-level GPU usage fraction
   config.load_from_file(config_fixture("minimal.yaml"));
 
   require_shared_operator_defaults(config.get_operator_params(), expected_effective_batch(config));
+  REQUIRE(config.get_task_creator_config().thread_pool.thread_name_prefix == "task_creator");
+  REQUIRE(config.get_gpu_pipeline_executor_config().thread_name_prefix == "gpu_pipeline");
+  REQUIRE(config.get_downgrade_executor_config().thread_pool.thread_name_prefix == "downgrade");
+  REQUIRE(config.get_scan_manager_config().thread_pool.thread_name_prefix == "scan_manager");
+}
+
+TEST_CASE("Sirius keeps executor thread-name prefixes internal", "[sirius][config]")
+{
+  struct invalid_prefix {
+    const char* fixture;
+    const char* context;
+  };
+  constexpr std::array cases{
+    invalid_prefix{"invalid_task_creator_thread_name_prefix.yaml", "task_creator"},
+    invalid_prefix{"invalid_pipeline_thread_name_prefix.yaml", "thread_pool"},
+    invalid_prefix{"invalid_downgrade_thread_name_prefix.yaml", "downgrade"},
+    invalid_prefix{"invalid_scan_manager_thread_name_prefix.yaml", "scan_manager"},
+  };
+
+  for (auto const& test : cases) {
+    INFO("fixture=" << test.fixture);
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(
+      config.load_from_file(config_fixture(test.fixture)),
+      Catch::Contains("unknown config key: 'thread_name_prefix'") && Catch::Contains(test.context));
+  }
 }
 
 TEST_CASE("explicit operator batch values override effective-capacity defaults",


### PR DESCRIPTION
## Summary

- remove four executor `thread_name_prefix` choices from normal YAML
- preserve internal/programmatic fields and their exact stable defaults
- make stale explicit values fail at configuration load
- assert resolved task-creator, pipeline, downgrade, and scan-manager labels

## Why

These strings do not control scheduling, capacity, affinity, or execution. Their runtime consumers use them only as OS-thread names and Quent `instance_name` labels. Letting each deployment rename them adds four choices while making diagnostics less stable. UUID-backed telemetry identity remains unchanged.

## Identity

- base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`
- head: `62e48601658ad9304c2c6573d78bdeed3e3e537f`
- tree: `e76b0ead77a744586d0c5bc3f29537f8cf328b1b`
- zero-context source-diff SHA-256: `8be5534a1e5af242fa96427ec415d486d8320b6e02cf12809ece1cacd17c5bb5`

## Validation

- exact-current ten-file diff; production change removes only four YAML readers
- `python3 scripts/check_orphan_tests.py`: pass
- `git diff --check`: pass
- minimal config asserts all four stable labels
- each removed path has contextual unknown-key rejection coverage
- predecessor exact-head hosted lint, GCC, Clang, CUDA 13 build/runtime passed
- current exact-head hosted checks are the final acceptance path

- exact-head hosted receipt for `62e48601658ad9304c2c6573d78bdeed3e3e537f`: CUDA 13 runtime and terminal aggregate checks passed
- hosted workflow 31727988334: runtime job 94542038414 passed from 2026-08-13T18:51:55Z through 2026-08-13T19:12:20Z; aggregate job 94563271595 passed at 2026-08-13T19:12:29Z