### PR TITLE
refactor(config): internalize metadata parse chunk

### DIFF
--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -324,13 +324,11 @@ If translation fails, filtering falls back to `expression_evaluator` on the deco
 **Mechanism:** The walk is structured for minimal, parallel, typed metadata access with statistics pruning:
 1. **Projected-column-only, typed walk (#868, #936):** `walk_duckdb_native_row_group_range()` walks the DuckDB segment trees directly for only the projected columns, reading typed `block_id` / compression / row counts / validity-child / max-string-length per segment instead of calling `GetColumnSegmentInfo` and re-parsing strings.
 2. **Stats pruning (#900):** `prepare_duckdb_native_walk()` evaluates DuckDB's own `TableFilter::CheckStatistics` against each row group's per-column statistics and drops any row group a pushed-down filter proves `FILTER_ALWAYS_FALSE` before it is staged, copied to the GPU, or decoded; an all-pruned table routes to DuckDB CPU up front.
-3. **Parallel range walk + early decode (#895):** `prepare_duckdb_native_walk()` runs as a cheap serial pre-step (partition stats, type-viability gate, row-group count) with no per-segment I/O; the row groups are sliced into ranges of `SIRIUS_METADATA_PARSE_CHUNK` groups, and the scan-manager pool walks the ranges in parallel so cold segment reads for different ranges overlap. The batch coalescer packs parsed ranges into cap-sized batches that decode while later ranges are still being parsed.
+3. **Parallel range walk + early decode (#895):** `prepare_duckdb_native_walk()` runs as a cheap serial pre-step (partition stats, type-viability gate, row-group count) with no per-segment I/O; the row groups are sliced into fixed internal ranges of eight groups, and the scan-manager pool walks the ranges in parallel so cold segment reads for different ranges overlap. The batch coalescer packs parsed ranges into cap-sized batches that decode while later ranges are still being parsed.
 
 **Code path:**
 - `src/op/scan/duckdb_native_metadata.cpp` — `prepare_duckdb_native_walk()`, `walk_duckdb_native_row_group_range()`, `mark_row_groups_pruned_by_filter_stats()`
 - `src/op/scan/duckdb_native_gpu_ingestible.cpp` — parse-range slicing, per-range walk thunks, and the `duckdb_native_batch_coalescer`
-
-**Config:** `SIRIUS_METADATA_PARSE_CHUNK` (row groups per parallel parse range, default 8)
 
 ### DuckDB-Native Async Coalesced Reads (PR #849)
 

--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -91,7 +91,7 @@ There is no factory class. Each implementation provides a free `make_ingestible(
 
 ### DuckDB-native ingestible
 
-`duckdb_native_gpu_ingestible` (`duckdb_native_gpu_ingestible.{hpp,cpp}`) prepares a serial walk plan in its constructor (`prepare_duckdb_native_walk`: partition statistics, projected-type viability gate, and filter-stat row-group pruning — a non-viable query throws to trigger CPU fallback before any per-segment IO). It slices the table's row groups into fixed-size parse ranges (`SIRIUS_METADATA_PARSE_CHUNK`, default 8). `next_split_provider` hands out one range per claim; each metadata task walks that range and emits a `duckdb_native_scan_info`. `materialize_metadata_to_table` decodes the range's storage segments into a `cudf::table` (always `UNFILTERED`); filter evaluation and projection to output arity happen in `post_filter_and_project`.
+`duckdb_native_gpu_ingestible` (`duckdb_native_gpu_ingestible.{hpp,cpp}`) prepares a serial walk plan in its constructor (`prepare_duckdb_native_walk`: partition statistics, projected-type viability gate, and filter-stat row-group pruning — a non-viable query throws to trigger CPU fallback before any per-segment IO). It slices the table's row groups into fixed internal ranges of eight groups. `next_split_provider` hands out one range per claim; each metadata task walks that range and emits a `duckdb_native_scan_info`. `materialize_metadata_to_table` decodes the range's storage segments into a `cudf::table` (always `UNFILTERED`); filter evaluation and projection to output arity happen in `post_filter_and_project`.
 
 ## owning_table_view
 
@@ -317,7 +317,7 @@ The result is a `duckdb_native_walk_plan` carrying per-row-group row starts/coun
 
 ### Phase 2 — `walk_duckdb_native_row_group_range()` (concurrent)
 
-The row-group range `[0, n_row_groups)` is sliced into fixed-size parse chunks (default 8 row groups, `SIRIUS_METADATA_PARSE_CHUNK`), and each chunk is walked independently on a scan-manager thread. For each surviving row group in its range, a range walk:
+The row-group range `[0, n_row_groups)` is sliced into fixed internal chunks of eight row groups, and each chunk is walked independently on a scan-manager thread. For each surviving row group in its range, a range walk:
 
 - Walks each projected column's **typed segment trees** directly — reading `block_id`, block offset, compression enum, per-segment row counts, the validity child's segments, and (for varchar) the per-segment max-string-length stat as typed fields. It does not build or re-parse the per-segment string blobs that DuckDB's generic `GetColumnSegmentInfo` would produce.
 - Refuses on the first unsupported segment codec or an absent/over-threshold varchar stat, partially filling the range (which the caller then discards in favor of CPU fallback).

--- a/src/include/op/scan/duckdb_native_metadata.hpp
+++ b/src/include/op/scan/duckdb_native_metadata.hpp
@@ -214,9 +214,9 @@ struct duckdb_native_row_group_range {
 duckdb_native_row_group_range walk_duckdb_native_row_group_range(
   const duckdb_native_walk_plan& plan, std::size_t rg_begin, std::size_t rg_end);
 
-/// @brief Row groups per parallel-walk task unit (env `SIRIUS_METADATA_PARSE_CHUNK`,
-/// default 8). Shared by the metadata parse fan-out and the MVCC mask job so both
-/// slice row-group work into the same task granularity.
+/// @brief Row groups per parallel-walk task unit (fixed internally at 8).
+/// Shared by the metadata parse fan-out and the MVCC mask job so both slice
+/// row-group work into the same task granularity.
 std::size_t metadata_parse_chunk();
 
 }  // namespace sirius::op::scan

--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -44,7 +44,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
-#include <cstdlib>
 #include <limits>
 #include <optional>
 #include <string>
@@ -55,14 +54,9 @@ namespace sirius::op::scan {
 
 std::size_t metadata_parse_chunk()
 {
-  constexpr std::size_t kDefaultParseChunk = 8;
-  if (const char* env = std::getenv("SIRIUS_METADATA_PARSE_CHUNK")) {
-    try {
-      if (const auto v = std::stoull(env); v > 0) return static_cast<std::size_t>(v);
-    } catch (...) { /* fall through to default */
-    }
-  }
-  return kDefaultParseChunk;
+  // This is an internal scheduling granularity, not a user tuning surface.
+  constexpr std::size_t kParseChunk = 8;
+  return kParseChunk;
 }
 
 namespace {

--- a/test/cpp/scan_manager/test_insert_delta_job.cpp
+++ b/test/cpp/scan_manager/test_insert_delta_job.cpp
@@ -34,6 +34,7 @@
 #include <io/sirius_datasource.hpp>
 #include <memory/topology_index.hpp>
 #include <op/scan/duckdb_native_gpu_ingestible.hpp>
+#include <op/scan/duckdb_native_metadata.hpp>
 #include <scan_manager/insert_delta_job.hpp>
 #include <unistd.h>
 
@@ -432,19 +433,24 @@ TEST_CASE("insert-delta job: blockless-only splits carry no datasource",
 TEST_CASE("insert-delta job: a delta spanning multiple capture ranges merges in order",
           "[insert_delta_job][scan_manager]")
 {
-  // One row group per capture range so the delta below spans several
-  // dispatcher tasks.
+  // The former environment override must not change the fixed internal
+  // scheduling granularity.
   setenv("SIRIUS_METADATA_PARSE_CHUNK", "1", 1);
   struct chunk_env_restore {
     ~chunk_env_restore() { unsetenv("SIRIUS_METADATA_PARSE_CHUNK"); }
   } restore;
+  REQUIRE(sirius::op::scan::metadata_parse_chunk() == 8);
 
+  // Use enough row groups to span multiple fixed internal capture ranges.
+  constexpr std::size_t delta_rows = 1'250'000;
   job_test_db tdb;
   exec_ok(*tdb.con, "SET threads TO 1");
   exec_ok(*tdb.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(10000)");
   exec_ok(*tdb.con, "CHECKPOINT");
-  exec_ok(*tdb.con, "INSERT INTO t SELECT (10000+range)::INTEGER FROM range(250000)");
-  exec_ok(*tdb.con, "INSERT INTO t VALUES (260000)");
+  exec_ok(
+    *tdb.con,
+    "INSERT INTO t SELECT (10000+range)::INTEGER FROM range(" + std::to_string(delta_rows) + ")");
+  exec_ok(*tdb.con, "INSERT INTO t VALUES (" + std::to_string(10000 + delta_rows) + ")");
 
   exec_ok(*tdb.con, "BEGIN TRANSACTION");
   auto& storage = resolve_storage(*tdb.con, "t");
@@ -454,7 +460,7 @@ TEST_CASE("insert-delta job: a delta spanning multiple capture ranges merges in 
   run(requests);
 
   auto const& request = requests[0];
-  REQUIRE(request.plan.row_groups.size() >= 3);
+  REQUIRE(request.plan.row_groups.size() > sirius::op::scan::metadata_parse_chunk());
 
   // Row-group order, contiguous boundaries, and filled columns survive the
   // parallel merge.
@@ -468,13 +474,13 @@ TEST_CASE("insert-delta job: a delta spanning multiple capture ranges merges in 
     expected_start += rg.row_count;
     plan_rows += rg.row_count;
   }
-  REQUIRE(plan_rows == 250001);
+  REQUIRE(plan_rows == delta_rows + 1);
 
   std::size_t bundle_rows = 0;
   for (auto const& b : request.bundles) {
     bundle_rows += b.total_rows;
   }
-  REQUIRE(bundle_rows == 250001);
+  REQUIRE(bundle_rows == delta_rows + 1);
   exec_ok(*tdb.con, "ROLLBACK");
 }
 


### PR DESCRIPTION
## Summary

- remove the `SIRIUS_METADATA_PARSE_CHUNK` environment override
- keep shared scan, insert-delta, and MVCC scheduling ranges at the existing internal value of eight row groups
- document the value as an implementation detail, not a deployment choice

## Why

This value is granularity shared by three internal schedulers. It does not express deployment policy, hardware capacity, correctness, or a stable endpoint contract, so exposing it asks operators to coordinate a choice Sirius owns.

## Identity

- base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`
- head: `bfdaa33bf45a32e7cdf8b1ad59441c7aaa072fe1`
- tree: `745b5ebaa95c45c31807878b1f3453e6571cbdb2`
- zero-context source-diff SHA-256: `ed102c2d5677542dbc605a90310fc238d30bc48884e35bcbd1c0b873e02aa274`

## Validation

- exact-current five-file diff; production change removes only the environment parser and fixes the internal value at its prior default
- `python3 scripts/check_orphan_tests.py`: pass
- `git diff --check`: pass
- regression sets the former environment variable to `1`, proves the effective value remains `8`, crosses multiple real row-group ranges, and verifies ordered plan/bundle row counts
- predecessor exact-head hosted lint, GCC, Clang, CUDA 13 build/runtime passed
- current exact-head hosted checks are the final acceptance path

- exact-head hosted receipt for `bfdaa33bf45a32e7cdf8b1ad59441c7aaa072fe1`: CUDA 13 runtime and terminal aggregate checks passed
- hosted workflow 31728186624: runtime job 94542678439 passed from 2026-08-13T18:52:14Z through 2026-08-13T19:12:39Z; aggregate job 94563353889 passed at 2026-08-13T19:12:46Z