### PR TITLE
refactor: derive GPU pipeline affinity from topology

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -243,13 +243,14 @@ per-pool sub-blocks: `task_creator`, `pipeline`, `downgrade`, and `scan_manager`
 `scan_manager` sub-block is large and is documented in
 [Scan Manager & IO Configuration](#scan-manager--io-configuration) below.
 
-Every thread-pool sub-block shares three keys:
+The thread-pool sub-blocks use these common keys; pipeline affinity is the
+hardware-derived exception described below:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `num_threads` | int (**> 0**) | per pool (below) | Worker threads in the pool. |
 | `thread_name_prefix` | string | per pool | Thread name prefix for logs. |
-| `cpu_affinity` | list of int | — | Cores to pin the pool's threads to. |
+| `cpu_affinity` | list of int | — | Cores to pin task-creator and downgrade threads. GPU pipeline affinity is derived from the selected GPU's CPU topology. |
 
 ### `sirius.executor.task_creator`
 
@@ -496,8 +497,10 @@ per-pool extras.
 | `downgrade_executor` | `executor.downgrade` | 1 | `downgrade` | Data tier migration (GPU→Host) |
 | `scan_manager` | `executor.scan_manager` | remaining cores (min 4) | `scan_manager` | Scan metadata production + IO reactor management |
 
-Each pool supports optional CPU affinity lists (`cpu_affinity`) for core pinning. `num_threads`
-must be `> 0` for every pool except `scan_manager`, which requires `> 2`.
+The task-creator, downgrade, and scan-manager pools support optional CPU affinity lists
+(`cpu_affinity`) for core pinning. GPU pipeline affinity is derived per executor from the selected
+GPU's CPU topology. `num_threads` must be `> 0` for every pool except `scan_manager`, which requires
+`> 2`.
 
 ## DuckDB SET Variables
 

--- a/src/include/pipeline/gpu_pipeline_executor.hpp
+++ b/src/include/pipeline/gpu_pipeline_executor.hpp
@@ -114,6 +114,14 @@ class gpu_pipeline_executor : public sirius::parallel::itask_executor {
   [[nodiscard]] executor_metrics get_metrics() const noexcept;
 
   /**
+   * @brief Return the effective executor configuration after scheduler derivation.
+   */
+  [[nodiscard]] const exec::thread_pool_config& get_effective_config() const noexcept
+  {
+    return _config;
+  }
+
+  /**
    * @brief Set the completion handler for query completion signaling
    *
    * @param handler Pointer to the completion handler

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -140,7 +140,6 @@ static void from_yaml(const YAML::Node& node, exec::thread_pool_config& opt)
   yaml::reader r(node, "thread_pool");
   r.optional("num_threads", opt.num_threads, yaml::greater_than<int>{0});
   r.optional("thread_name_prefix", opt.thread_name_prefix);
-  r.optional("cpu_affinity", opt.cpu_affinity_list);
   r.reject_unknown();
 }
 

--- a/test/cpp/config/data/invalid_pipeline_cpu_affinity.yaml
+++ b/test/cpp/config/data/invalid_pipeline_cpu_affinity.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    pipeline:
+      cpu_affinity: [0]

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -362,6 +362,13 @@ uint64_t expected_effective_batch(const sirius::sirius_config& config)
 
 }  // namespace
 
+TEST_CASE("Sirius derives GPU pipeline affinity from hardware topology", "[sirius][config]")
+{
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(config.load_from_file(config_fixture("invalid_pipeline_cpu_affinity.yaml")),
+                      Catch::Contains("unknown config key: 'cpu_affinity' in thread_pool"));
+}
+
 TEST_CASE("operator batch defaults use the smallest low-level GPU capacity",
           "[sirius][config][operator_defaults]")
 {

--- a/test/cpp/pipeline/test_task_scheduler.cpp
+++ b/test/cpp/pipeline/test_task_scheduler.cpp
@@ -110,6 +110,31 @@ TEST_CASE("Task scheduler can start and stop gracefully", "[task_scheduler]")
   REQUIRE_NOTHROW(executor.stop());
 }
 
+TEST_CASE("Task scheduler derives GPU executor affinity from topology", "[task_scheduler][config]")
+{
+  auto manager = initialize_memory_manager(1);
+  sirius::exec::thread_pool_config gpu_config{2};
+  gpu_config.cpu_affinity_list = {999};
+
+  cucascade::memory::system_topology_info topology;
+  topology.num_gpus = 1;
+  cucascade::memory::gpu_topology_info gpu;
+  gpu.id        = 0;
+  gpu.cpu_cores = {3, 7};
+  topology.gpus.push_back(std::move(gpu));
+
+  task_scheduler executor(
+    gpu_config, *manager, sirius::test::make_test_telemetry_context(), &topology);
+
+  std::size_t visited = 0;
+  executor.visit_executors([&](int device_id, auto const& gpu_executor) {
+    REQUIRE(device_id == 0);
+    REQUIRE(gpu_executor.get_effective_config().cpu_affinity_list == std::vector<int>{3, 7});
+    ++visited;
+  });
+  REQUIRE(visited == 1);
+}
+
 TEST_CASE("Task scheduler executes tasks through pipeline_queue", "[task_scheduler]")
 {
   auto manager = initialize_memory_manager(1);


### PR DESCRIPTION
## Summary

- remove `executor.pipeline.cpu_affinity` from normal YAML
- retain the internal/programmatic field and existing per-GPU topology derivation
- leave task-creator, downgrade, and scan-manager affinity controls unchanged
- reject stale pipeline affinity input at configuration load

## Why

Production Sirius cannot honor this YAML choice. `SiriusContext` always passes discovered topology to `task_scheduler`; for each GPU executor, the scheduler copies the parsed configuration and replaces its affinity list with that GPU topology’s CPU cores before construction. This removes one apparent choice and makes documented behavior match effective behavior.

## Coordination

#1518 validates and enforces the remaining expert affinity masks plus the programmatically derived pipeline mask at the pool boundary. It remains a separate review unit because its worker-startup contract is materially broader.

## Identity

- base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`
- head: `35f0f3683b5d140f6457a1a21bea4b81ebada59c`
- tree: `2099dcee4c1f98d3cd996c2ae682bdf3dd551e79`
- zero-context source-diff SHA-256: `b25d9b0a37b6e756e17458de0b76cb914b9ef07378e26467d5d3556fe8518639`

## Validation

- exact-current six-file diff; production change removes only the pipeline YAML key and adds a read-only effective-config accessor used by the regression
- `python3 scripts/check_orphan_tests.py`: pass
- `git diff --check`: pass
- stale YAML key rejection and topology-overrides-sentinel regression included
- predecessor exact-head hosted lint, GCC, Clang, CUDA 13 build/runtime passed
- current exact-head hosted checks are the final acceptance path

- exact-head hosted receipt for `35f0f3683b5d140f6457a1a21bea4b81ebada59c`: CUDA 13 runtime and terminal aggregate checks passed
- hosted workflow 31727808407: runtime job 94541962493 passed from 2026-08-13T18:05:14Z through 2026-08-13T18:25:36Z; aggregate job 94550035981 passed at 2026-08-13T18:25:46Z