### PR TITLE
fix(config): validate compression retention fractions

### DIFF
--- a/docs/super-sirius/compressed-materialization.md
+++ b/docs/super-sirius/compressed-materialization.md
@@ -385,7 +385,9 @@ compression off for the rest of the pin.
 Both compression gates (`min_batch_size_bytes` and `max_compressed_fraction`) are evaluated on the
 already-narrowed table, so they measure the batch as it will be stored. A batch that falls out of a
 gate, or that arrives after a failure has latched compression off, is stored uncompressed at the
-carrier narrowing selected for it.
+carrier narrowing selected for it. `max_compressed_fraction` must be finite and non-negative;
+values above 1 intentionally permit a compressed representation that expands relative to its
+input, which is useful when testing encodability independently of compression ratio.
 
 Known residual: a plan block with a width-explicit packed op (a `bitextract`/`bitjoin` field spec
 of a fixed total width) on an integer column narrowed to a different width still fails that

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -153,6 +153,23 @@ Controls the disk spill tier. Data evicted from host memory is written here. Dis
 | `capacity_bytes` | bytes | 1Ti | Maximum disk space for spill files. |
 | `downgrade_root_dirs` | string | "" | Directory path for spill files. **Must be set** to enable disk spilling. Use a fast local mount (NVMe preferred). |
 
+### Input-table compression (`sirius.compression`)
+
+These settings control optional Simpatico compression when
+`pin_table(tier=>'host')` caches input tables. Compression requires both
+`enable_pin_table_compression: true` and a matching plan in `input_plan_dir`;
+otherwise the table is pinned uncompressed.
+
+| Key | DuckDB setting | Type | Default | Description |
+|-----|----------------|------|---------|-------------|
+| `enable_pin_table_compression` | `pin_table_compression` | bool | false | Attempt planned compression while pinning input tables to host memory. |
+| `min_batch_size_bytes` | `pin_table_compression_min_batch_size_bytes` | bytes | 1Mi | Skip compression below this uncompressed batch size. `0` disables the size gate. |
+| `max_compressed_fraction` | `pin_table_compression_max_compressed_fraction` | finite double >= 0 | 0.75 | Keep a compressed representation only at or below this fraction of the original batch size. `0` retains none; values above `1` deliberately permit expansion, primarily for testing encodability. |
+| `input_plan_dir` | `pin_table_input_compression_plan_dir` | string | "" | Directory of per-table Simpatico plan files. An empty path leaves compression inactive. |
+
+The YAML loader and DuckDB `SET` surface reject negative, NaN, and infinite
+`max_compressed_fraction` values instead of silently changing retention behavior.
+
 ### How Downgrade Thresholds Work
 
 Each memory tier uses a trigger/stop threshold pair to control data eviction:

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -195,6 +195,8 @@ struct compression_config {
   /// size, for the compressed form to be kept.  When the compressed header +
   /// payload exceeds this fraction of the original (i.e. compression saved too
   /// little), the compressed data is discarded and the uncompressed batch is used.
+  /// Must be finite and non-negative. Values above 1 deliberately allow compressed
+  /// representations that expand relative to the original batch.
   //  Default 0.75 (that coincides with a 1.33x compression ratio).
   double max_compressed_fraction{0.75};
 

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -27,6 +27,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <algorithm>
+#include <cmath>
 #include <exception>
 #include <limits>
 #include <stdexcept>
@@ -296,7 +297,9 @@ static void from_yaml(const YAML::Node& node, compression_config& opt)
   yaml::reader r(node, "compression");
   r.optional("enable_pin_table_compression", opt.enable_pin_table_compression);
   r.optional("min_batch_size_bytes", yaml::bytes(opt.min_batch_size_bytes));
-  r.optional("max_compressed_fraction", opt.max_compressed_fraction);
+  r.optional("max_compressed_fraction", opt.max_compressed_fraction, [](double value) {
+    return std::isfinite(value) && value >= 0.0;
+  });
   r.optional("input_plan_dir", opt.input_plan_dir);
   r.reject_unknown();
 }

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -119,6 +119,7 @@ extern "C" int cudaProfilerStop();
 #include "io/types.hpp"                // sirius::io::sirius_ioctx
 #include "io/uring/uring_reactor.hpp"  // sirius::io::uring_io_object
 
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <string_view>
@@ -2035,10 +2036,15 @@ static void SetPinTableCompressionMaxCompressedFraction(ClientContext& context,
                                                         SetScope scope,
                                                         Value& parameter)
 {
+  const double fraction = DoubleValue::Get(parameter);
+  if (!std::isfinite(fraction) || fraction < 0.0) {
+    throw InvalidInputException(
+      "pin_table_compression_max_compressed_fraction must be finite and non-negative, got %f",
+      fraction);
+  }
   auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
   if (!sirius_ctx) { return; }
-  sirius_ctx->get_config().get_compression_config().max_compressed_fraction =
-    DoubleValue::Get(parameter);
+  sirius_ctx->get_config().get_compression_config().max_compressed_fraction = fraction;
   SIRIUS_LOG_DEBUG("Updated pin_table_compression_max_compressed_fraction");
 }
 
@@ -2383,7 +2389,8 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
   config.AddExtensionOption(
     "pin_table_compression_max_compressed_fraction",
     "Discard the compressed form and pin uncompressed when the compressed size exceeds this "
-    "fraction of the batch's original size (i.e. compression saved too little)",
+    "finite, non-negative fraction of the batch's original size (values above 1 permit "
+    "expansion)",
     LogicalType::DOUBLE,
     Value::DOUBLE(compression_defaults.max_compressed_fraction),
     SetPinTableCompressionMaxCompressedFraction);

--- a/test/cpp/config/data/invalid_compression_fraction_infinity.yaml
+++ b/test/cpp/config/data/invalid_compression_fraction_infinity.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: .inf

--- a/test/cpp/config/data/invalid_compression_fraction_nan.yaml
+++ b/test/cpp/config/data/invalid_compression_fraction_nan.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: .nan

--- a/test/cpp/config/data/invalid_compression_fraction_negative.yaml
+++ b/test/cpp/config/data/invalid_compression_fraction_negative.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: -0.1

--- a/test/cpp/config/data/valid_compression_fraction_above_one.yaml
+++ b/test/cpp/config/data/valid_compression_fraction_above_one.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: 1.5

--- a/test/cpp/config/data/valid_compression_fraction_zero.yaml
+++ b/test/cpp/config/data/valid_compression_fraction_zero.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: 0

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -329,6 +329,37 @@ TEST_CASE("Sirius configuration validates MARK join build switch ratio", "[siriu
   REQUIRE(config.get_operator_params().mark_join_build_switch_ratio == Approx(0.0));
 }
 
+TEST_CASE("Sirius configuration rejects invalid compression retention fractions",
+          "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+  sirius::sirius_config config;
+  for (auto const* fixture : {"invalid_compression_fraction_negative.yaml",
+                              "invalid_compression_fraction_nan.yaml",
+                              "invalid_compression_fraction_infinity.yaml"}) {
+    INFO("fixture=" << fixture);
+    REQUIRE_THROWS_WITH(config.load_from_file(data_dir / fixture),
+                        Catch::Contains("max_compressed_fraction"));
+  }
+}
+
+TEST_CASE("Sirius configuration accepts intentional compression retention fraction boundaries",
+          "[sirius][config]")
+{
+  std::source_location loc    = std::source_location::current();
+  auto const data_dir         = fs::path(loc.file_name()).parent_path() / "data";
+  auto const require_fraction = [&data_dir](char const* fixture, double expected) {
+    INFO("fixture=" << fixture);
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(config.load_from_file(data_dir / fixture));
+    REQUIRE(config.get_compression_config().max_compressed_fraction == Approx(expected));
+  };
+
+  require_fraction("valid_compression_fraction_zero.yaml", 0.0);
+  require_fraction("valid_compression_fraction_above_one.yaml", 1.5);
+}
+
 namespace {
 
 void require_shared_operator_defaults(const sirius::operator_params& params, uint64_t batch)
@@ -679,6 +710,36 @@ TEST_CASE("DuckDB setting rejects negative byte values without mutation",
   REQUIRE(after->GetValue(0, 0).GetValue<uint64_t>() == expected);
 }
 
+TEST_CASE("DuckDB setting rejects invalid compression retention fractions without a Sirius context",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  for (auto const* value : {"-0.1", "'NaN'", "'Infinity'"}) {
+    INFO("value=" << value);
+    auto result =
+      con.Query("SET pin_table_compression_max_compressed_fraction = " + std::string(value));
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    REQUIRE_THAT(
+      result->GetError(),
+      Catch::Contains(
+        "pin_table_compression_max_compressed_fraction must be finite and non-negative"));
+  }
+
+  for (auto const* value : {"0", "1.5"}) {
+    INFO("value=" << value);
+    auto result =
+      con.Query("SET pin_table_compression_max_compressed_fraction = " + std::string(value));
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+  }
+}
+
 TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
           "[sirius][context][config][isolated_context]")
 {
@@ -779,6 +840,26 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE_FALSE(reset_mark_join_ratio->HasError());
   REQUIRE(sirius_ctx->get_config().get_operator_params().mark_join_build_switch_ratio ==
           Approx(3.0));
+
+  for (auto const* value : {"-0.1", "'NaN'", "'Infinity'"}) {
+    INFO("value=" << value);
+    auto invalid_fraction =
+      con.Query("SET pin_table_compression_max_compressed_fraction = " + std::string(value));
+    REQUIRE(invalid_fraction != nullptr);
+    REQUIRE(invalid_fraction->HasError());
+    REQUIRE_THAT(
+      invalid_fraction->GetError(),
+      Catch::Contains(
+        "pin_table_compression_max_compressed_fraction must be finite and non-negative"));
+
+    auto retained =
+      con.Query("SELECT current_setting('pin_table_compression_max_compressed_fraction')::DOUBLE");
+    REQUIRE(retained != nullptr);
+    REQUIRE_FALSE(retained->HasError());
+    REQUIRE(retained->GetValue(0, 0).GetValue<double>() == Approx(0.6));
+    REQUIRE(sirius_ctx->get_config().get_compression_config().max_compressed_fraction ==
+            Approx(0.6));
+  }
 
   auto const require_ok = [&con](std::string const& sql) {
     auto result = con.Query(sql);


### PR DESCRIPTION
## Summary

- reject negative, NaN, and infinite `max_compressed_fraction` values at both YAML load and DuckDB `SET`
- preserve intentional `0` and values above `1` semantics used by compression encodability tests
- document the input-table compression YAML and DuckDB surfaces

## Why

The retention gate compares the compressed footprint against
`original_size * max_compressed_fraction`. A negative value silently rejects
every nonempty compressed representation, while NaN or positive infinity can
retain arbitrary expansion. These are invalid configurations, not useful
tuning choices. Values above `1` remain supported because existing Sirius tests
deliberately use `1.5` to test encodability independently of compression ratio.

## Rebase coordination

The exact current candidate is rebased onto the protected merge of #1490. Its
two conflicts were additive placements in
`test/cpp/config/test_context.cpp`. The resolution retains #1490's complete
MARK-ratio YAML, DuckDB `SET`, failed-input nonmutation, zero, and reset
coverage, and retains this PR's complete compression YAML boundary and DuckDB
`SET`/nonmutation coverage. Production and documentation semantics are
unchanged from the reviewed predecessor.

## Validation

- YAML regressions reject negative, `.nan`, and `.inf`
- YAML regressions accept and read back `0` and `1.5`
- DuckDB regressions reject `-0.1`, `NaN`, and `Infinity` before context mutation
- live-context regression proves rejected values leave both `current_setting` and Sirius config unchanged
- independent exact-current semantic and additive-union review: CLEAR
- exact mail-patch replay, `git diff --check`, and orphan-test validation: pass
- exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full C++ runtime, and aggregate checks: pass
- test workflow run `31706090116`: pass; CUDA runtime 19m41s
- check workflow run `31706090368`: pass

Exact base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`  
Candidate: `a0e9e58d0c566be1095ebb89483e8928e300539c`  
Tree: `c4c3012b958f94d07cd1825a575861c81fb1f0e8`  
Patch SHA-256: `c12c1e9a4811bc6c9e5dd63f3108ff24481f83b190fe8d07951ed40a03dde970`

The predecessor `66c1db78a6ebbd8898a0ad8c9d9fef040a64e899`
passed hosted lint, GCC release, Clang debug, CUDA 13 build, full runtime, and
terminal aggregate checks. Those receipts are historical and do not transfer
to this rebased head.
