### PR TITLE
fix(config): reject zero REST chunk size

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -323,7 +323,7 @@ and transport use one trust policy; there are no separate REST YAML controls.
 |-----|------|---------|-------------|
 | `request_timeout_s` | int (seconds) | 30 | Whole-request timeout and presigned-URL TTL (0 = no limit). |
 | `max_connections` | int | 16 | Max concurrent in-flight connections per reactor. |
-| `chunk_size` | bytes | 8Mi | Target bytes per ranged GET (scatter/device-staging paths). |
+| `chunk_size` | bytes (**> 0**) | 8Mi | Target bytes per ranged GET (scatter/device-staging paths). Zero is rejected because it degenerates split reads into one-byte ranged GETs. |
 | `max_n_chunks` | int | 16 | Max file-adjacent segments fused into one scatter GET. |
 | `max_read_split` | int | 16 | Max parallel ranged GETs for one contiguous host read (reads < 2 MiB stay a single GET). |
 | `upkeep_interval_ms` | int (ms) | 15000 | Idle-connection keepalive interval (`curl_easy_upkeep`; 0 disables). |

--- a/src/include/io/rest/config.hpp
+++ b/src/include/io/rest/config.hpp
@@ -39,7 +39,8 @@ struct config {
   /// paths: file-adjacent segments are fused into one scatter GET up to this
   /// size, and an oversized segment is split into ceil(size / chunk_size)
   /// pieces.  A single contiguous host read instead splits by
-  /// @c max_read_split (see prep_host_rx_request).
+  /// @c max_read_split (see prep_host_rx_request). Must be greater than zero;
+  /// a zero YAML override is rejected during configuration loading.
   std::size_t chunk_size{8UL << 20};
 
   /// Cap on destination buffers fused into a single scatter GET (i.e. how

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -169,6 +169,17 @@ static void from_yaml(const YAML::Node& node, sirius::io::object_store_config& o
   r.reject_unknown();
 }
 
+static void read_positive_bytes(yaml::reader& reader, const char* key, std::size_t& out)
+{
+  auto const has_value = reader.has_value(key);
+  auto value           = out;
+  reader.optional(key, yaml::bytes(value));
+  if (has_value && value == 0) {
+    throw std::runtime_error("'rest." + std::string(key) + "': value must be greater than zero");
+  }
+  out = value;
+}
+
 static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
 {
   yaml::reader r(node, "rest");
@@ -181,7 +192,7 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
   }
   r.optional("request_timeout_s", opt.request_timeout_s);
   r.optional("max_connections", opt.max_connections);
-  r.optional("chunk_size", yaml::bytes(opt.chunk_size));
+  read_positive_bytes(r, "chunk_size", opt.chunk_size);
   r.optional("max_n_chunks", opt.max_n_chunks);
   r.optional("max_read_split", opt.max_read_split);
   r.optional("upkeep_interval_ms", opt.upkeep_interval);

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -285,6 +285,63 @@ TEST_CASE("sirius_config parses rest perf instrumentation flag",
   std::filesystem::remove(path, ec);
 }
 
+TEST_CASE("sirius_config requires a positive REST chunk size", "[scan_manager][config][s3][rest]")
+{
+  using rest_config = sirius::io::rest::config;
+  auto const path   = std::filesystem::temp_directory_path() / "sirius_rest_chunk_size.yaml";
+
+  for (auto const* yaml : {"      rest: {}\n", "      rest:\n        chunk_size: null\n"}) {
+    CAPTURE(yaml);
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n" +
+                 std::string(yaml));
+
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(config.load_from_file(path));
+    CHECK(config.get_scan_manager_config().rest.chunk_size == rest_config{}.chunk_size);
+  }
+
+  struct valid_case {
+    const char* yaml;
+    std::size_t expected;
+  };
+  for (auto const& value : {valid_case{"1", 1}, valid_case{"1MiB", 1UL << 20}}) {
+    CAPTURE(value.yaml);
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n"
+               "      rest:\n"
+               "        chunk_size: " +
+                 std::string(value.yaml) + "\n");
+
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(config.load_from_file(path));
+    CHECK(config.get_scan_manager_config().rest.chunk_size == value.expected);
+  }
+
+  for (auto const* invalid : {"0", "0MiB", "-1", "\"-1MiB\""}) {
+    CAPTURE(invalid);
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n"
+               "      rest:\n"
+               "        chunk_size: " +
+                 std::string(invalid) + "\n");
+
+    sirius::sirius_config config;
+    auto const before = config.get_scan_manager_config().rest.chunk_size;
+    REQUIRE_THROWS_WITH(config.load_from_file(path), Catch::Contains("rest.chunk_size"));
+    CHECK(config.get_scan_manager_config().rest.chunk_size == before);
+  }
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
 TEST_CASE("sirius_config rejects unknown rest config keys", "[scan_manager][config][rest]")
 {
   auto const path = std::filesystem::temp_directory_path() / "sirius_rest_unknown_key.yaml";


### PR DESCRIPTION
## Summary

- reject zero `scan_manager.rest.chunk_size` values during YAML load
- preserve omitted/null defaults and every positive raw or suffixed byte value
- reuse #1491's generic negative-byte rejection and validate through a temporary, so rejected input cannot mutate live config
- document the startup contract while retaining the runtime defensive clamp for programmatic configs

## Why

`chunk_size` is a target byte count for ranged GETs. It has no documented or implemented zero-as-disable policy. Clean Sirius instead coerces zero to one in `chunk_host_segments`, which can split an oversized host segment into one ranged GET per byte. Rejecting zero at the user surface removes that accidental alias without inventing a tuning minimum.

## Validation

- omitted and `null` preserve the 8 MiB default
- `1` and `1MiB` parse and read back exactly
- `0`, `0MiB`, `-1`, and `-1MiB` reject with `rest.chunk_size` diagnostics
- rejection leaves the existing value unchanged
- rebased onto merged #1491 and collapsed to one commit; negative parsing now delegates to the generic `yaml::bytes` contract while this PR adds only the field-specific nonzero rule
- exact `format-patch` replay onto the base reproduces the candidate tree
- `git diff --check` passes
- exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full runtime, and terminal aggregate checks pass
- hosted workflow [31692860146](https://github.com/sirius-db/sirius/actions/runs/31692860146): runtime job `94424648296` passed in 20m02s; aggregate job `94447223404` passed

Exact base: `4872cd3c490baf59f2591c527f8fbb6833416e0f`  
Candidate: `639e5995c29091ca43228b84711deaf9a9d93bc9`  
Tree: `5e192247aa9d70af5a9494232f9a2606e6aaf5cb`  
Patch SHA-256: `bbe09958725dfe797ecde982f57d4937950d15806c7064584567b797723433f4`
