### PR TITLE
fix(config): reject negative REST listing caps

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -333,8 +333,8 @@ single-GPU configurations only (logs a warning and disables itself otherwise).
 | `honor_retry_after` | bool | true | Respect the server's `Retry-After` header. |
 | `perf_instrumentation` | bool | false | Record per-chunk micro-timings (chunk_get, queue_wait, ttfb, h2d) into perf counters. |
 | `footer_probe_bytes` | bytes | 512Ki | Suffix-range window for the parquet footer probe. Must cover the footer, so err large. |
-| `list_max_matches` | int | 100000 | Cap on files a glob/listing may accumulate (throws "narrow the glob prefix", never truncates). |
-| `list_max_scanned` | int | 1000000 | Cap on objects a LIST sweep may scan across pages (throws, never truncates). |
+| `list_max_matches` | int (**>= 0**) | 100000 | Cap on files a glob/listing may accumulate (throws "narrow the glob prefix", never truncates). Zero allows only an empty result. |
+| `list_max_scanned` | int (**>= 0**) | 1000000 | Cap on objects a LIST sweep may scan across pages (throws, never truncates). Zero allows only an empty listing. |
 
 ### `scan_manager.cache` — prefetching cache (`io/cache/config.hpp`)
 

--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -416,7 +416,7 @@ S3 has no direct-to-device transport in this backend. Reads into arbitrary devic
 
 **LIST and glob expansion.** `sirius_httpfs` expands S3 globs with paginated `ListObjectsV2` requests. It sends the longest static directory prefix to S3, then applies the remaining pattern locally. `*`, `?`, and `[...]` match within one path segment; a segment equal to `**` can cross directories. Bucket wildcards are rejected.
 
-Pages are processed as they arrive, so listing memory is bounded by one page plus the matches retained for DuckDB. `list_max_scanned` limits inspected objects and `list_max_matches` limits retained matches. Reaching either limit raises an error instead of returning an incomplete file list. Results are sorted by URI, and LIST metadata lets globbed parquet files use the footer-probe open without a separate HEAD.
+Pages are processed as they arrive, so listing memory is bounded by one page plus the matches retained for DuckDB. `list_max_scanned` limits inspected objects and `list_max_matches` limits retained matches. Both caps are non-negative; zero permits only an empty listing or result. Reaching either limit raises an error instead of returning an incomplete file list. Results are sorted by URI, and LIST metadata lets globbed parquet files use the footer-probe open without a separate HEAD.
 
 **Authorization.** `s3_request_authorizer` signs each request attempt and returns the request URL and headers. LIST uses the separate `authorize_list` entry point, which custom authorizers must implement if they support glob expansion.
 

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -75,6 +75,17 @@ static void reject_mutually_exclusive(yaml::reader& reader,
   }
 }
 
+static void read_nonnegative_count(yaml::reader& reader, const char* key, std::size_t& out)
+{
+  // Parse through a signed temporary so a negative YAML scalar cannot wrap to
+  // a large size_t before validation. Missing and null values retain the
+  // struct's explicit default.
+  auto const has_value = reader.has_value(key);
+  long long value      = 0;
+  reader.optional(key, value, yaml::greater_than<long long>{-1});
+  if (has_value) { out = static_cast<std::size_t>(value); }
+}
+
 // ================ from_yaml for external types ================= //
 
 static void validate_downgrade_fractions(std::string_view scope, double trigger, double stop)
@@ -189,8 +200,8 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
   r.optional("honor_retry_after", opt.honor_retry_after);
   r.optional("perf_instrumentation", opt.perf_instrumentation);
   r.optional("footer_probe_bytes", yaml::bytes(opt.footer_probe_bytes));
-  r.optional("list_max_matches", opt.list_max_matches);
-  r.optional("list_max_scanned", opt.list_max_scanned);
+  read_nonnegative_count(r, "list_max_matches", opt.list_max_matches);
+  read_nonnegative_count(r, "list_max_scanned", opt.list_max_scanned);
   r.reject_unknown();
 }
 

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -19,6 +19,7 @@
 #include "io/rest/config.hpp"
 #include "sirius_config.hpp"
 
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -245,6 +246,86 @@ TEST_CASE("sirius_config defaults chunk prewarm to enabled when YAML omits the k
 
   sirius::sirius_config cfg;
   cfg.load_from_file(path);
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("sirius_config validates non-negative REST listing caps",
+          "[scan_manager][config][s3][rest]")
+{
+  using rest_config = sirius::io::rest::config;
+  struct cap_field {
+    const char* name;
+    std::size_t rest_config::* member;
+  };
+  auto const fields = std::array{cap_field{"list_max_matches", &rest_config::list_max_matches},
+                                 cap_field{"list_max_scanned", &rest_config::list_max_scanned}};
+  auto const path   = std::filesystem::temp_directory_path() / "sirius_rest_listing_caps.yaml";
+
+  for (auto const& field : fields) {
+    DYNAMIC_SECTION(field.name << " preserves its default when omitted or null")
+    {
+      for (auto const* yaml : {"      rest: {}\n", "      rest:\n        FIELD: null\n"}) {
+        auto text = std::string{yaml};
+        if (auto const pos = text.find("FIELD"); pos != std::string::npos) {
+          text.replace(pos, 5, field.name);
+        }
+        write_yaml(path,
+                   "sirius:\n"
+                   "  executor:\n"
+                   "    scan_manager:\n" +
+                     text);
+
+        sirius::sirius_config config;
+        auto const expected = rest_config{}.*field.member;
+        REQUIRE_NOTHROW(config.load_from_file(path));
+        CHECK(config.get_scan_manager_config().rest.*field.member == expected);
+      }
+    }
+
+    DYNAMIC_SECTION(field.name << " accepts zero and positive caps")
+    {
+      for (auto const* valid : {"0", "7"}) {
+        CAPTURE(valid);
+        write_yaml(path,
+                   "sirius:\n"
+                   "  executor:\n"
+                   "    scan_manager:\n"
+                   "      rest:\n"
+                   "        " +
+                     std::string(field.name) + ": " + valid + "\n");
+
+        sirius::sirius_config config;
+        REQUIRE_NOTHROW(config.load_from_file(path));
+        CHECK(config.get_scan_manager_config().rest.*field.member ==
+              static_cast<std::size_t>(std::stoull(valid)));
+      }
+    }
+
+    DYNAMIC_SECTION(field.name << " rejects signed underflow without mutation")
+    {
+      // The last value is one greater than LLONG_MAX. Parsing through a signed
+      // temporary must reject both directions rather than wrapping either into
+      // the size_t safety cap.
+      for (auto const* invalid : {"-1", "9223372036854775808"}) {
+        CAPTURE(invalid);
+        write_yaml(path,
+                   "sirius:\n"
+                   "  executor:\n"
+                   "    scan_manager:\n"
+                   "      rest:\n"
+                   "        " +
+                     std::string(field.name) + ": " + invalid + "\n");
+
+        sirius::sirius_config config;
+        auto const before = config.get_scan_manager_config().rest.*field.member;
+        REQUIRE_THROWS_WITH(config.load_from_file(path),
+                            Catch::Contains(std::string("rest.") + field.name));
+        CHECK(config.get_scan_manager_config().rest.*field.member == before);
+      }
+    }
+  }
 
   std::error_code ec;
   std::filesystem::remove(path, ec);


### PR DESCRIPTION
## Summary

- reject negative and signed-overflow values for `list_max_matches` and `list_max_scanned`
- parse through a signed temporary before assigning to `size_t`
- preserve omitted/null defaults, positive caps, and intentional zero-as-fail-closed behavior
- document exact zero semantics for empty listings and empty matched results

## Why

These settings are hard listing safety rails. Clean Sirius parses `-1` and casts it to `size_t`, silently turning it into `SIZE_MAX` and effectively disabling the cap. Zero is different and intentionally useful: it permits an empty listing/result but rejects the first scanned object or match. The smallest sound contract is therefore non-negative, not positive.

## Validation

- table-driven regression covers both fields
- omitted/null preserve defaults; `0` and `7` read back exactly
- `-1` and one-past-`LLONG_MAX` reject with field-scoped diagnostics
- rejection does not mutate the destination field
- hosted exact-head lint, GCC release, Clang debug, CUDA 13 build, full runtime suite, and terminal aggregate test pass
- audited against current dev `4872cd3`: #1491 changes the generic byte parser and additive `test_context` coverage, while this PR uses signed count parsing in `sirius_config.cpp`; the current merge tree is conflict-free, so the already-green head is intentionally not churned

Exact authored base: `0c5af9aee02f36d003141b432d799216f164a6c6`  
Current audited dev: `4872cd3c490baf59f2591c527f8fbb6833416e0f`  
Candidate: `03f8ae845f0937c02236cea7bc20f719f5076db1`  
Candidate tree: `593939e8134013d332f6d15d82bd4eabe28677b7`  
Current merge tree: `ee42896e2c8bb3316d0ba362c5314839bbde69af`  
Patch SHA-256: `1c1caf75e721e102161103aecd5c736a898227a286815425c9be2a74d481f591`

- exact-head hosted receipt for `03f8ae845f0937c02236cea7bc20f719f5076db1`: CUDA 13 runtime and terminal aggregate checks passed
- hosted workflow 31682521086: runtime job 94391815241 passed from 2026-08-13T08:36:10Z through 2026-08-13T08:55:52Z; aggregate job 94396546596 passed at 2026-08-13T08:56:03Z