### PR TITLE
fix(config): reject negative unsigned YAML values

### DIFF
--- a/src/include/yaml_reader.hpp
+++ b/src/include/yaml_reader.hpp
@@ -204,10 +204,12 @@ template <std::integral T>
   requires(!std::is_same_v<T, bool>)
 void read_yaml(const YAML::Node& node, T& out)
 {
-  if constexpr (sizeof(T) > 4)
-    out = static_cast<T>(node.as<long long>());
-  else
-    out = static_cast<T>(node.as<int>());
+  using parsed_type = std::conditional_t<(sizeof(T) > 4), long long, int>;
+  auto const parsed = node.as<parsed_type>();
+  if constexpr (std::is_unsigned_v<T>) {
+    if (parsed < 0) { throw std::runtime_error("unsigned value must be non-negative"); }
+  }
+  out = static_cast<T>(parsed);
 }
 
 /// Wrapper that marks an integral field as accepting byte suffixes (e.g. "8Gi", "512M").

--- a/test/cpp/config/data/invalid_memory_prefetcher_num_threads_negative.yaml
+++ b/test/cpp/config/data/invalid_memory_prefetcher_num_threads_negative.yaml
@@ -1,0 +1,5 @@
+sirius:
+  executor:
+    scan_manager:
+      memory_prefetcher:
+        num_threads: -1

--- a/test/cpp/config/test_config.cpp
+++ b/test/cpp/config/test_config.cpp
@@ -24,6 +24,7 @@
 #include <exception>
 #include <optional>
 #include <stdexcept>
+#include <utility>
 #include <variant>
 
 using namespace sirius;
@@ -49,6 +50,58 @@ TEST_CASE("yaml reader basic types", "[config_opt][basic]")
   REQUIRE(int_value == 100);
   REQUIRE(double_value == Approx(6.28));
   REQUIRE(string_value == "config setter test");
+}
+
+TEST_CASE("yaml reader rejects negative unsigned values without mutation",
+          "[config_opt][basic][unsigned]")
+{
+  SECTION("unvalidated size_t accepts zero and one but rejects negative input")
+  {
+    for (auto const& [input, expected] :
+         {std::pair{"0", std::size_t{0}}, std::pair{"1", std::size_t{1}}}) {
+      CAPTURE(input);
+      auto node         = YAML::Load("value: " + std::string{input});
+      std::size_t value = 17;
+      yaml::reader r(node, "unsigned_test");
+      REQUIRE_NOTHROW(r.optional("value", value));
+      CHECK(value == expected);
+    }
+
+    auto node         = YAML::Load("value: -1");
+    std::size_t value = 17;
+    yaml::reader r(node, "unsigned_test");
+    REQUIRE_THROWS_WITH(r.optional("value", value),
+                        Catch::Contains("unsigned_test.value") &&
+                          Catch::Contains("unsigned value must be non-negative"));
+    CHECK(value == 17);
+  }
+
+  SECTION("validated size_t preserves its stricter positive policy")
+  {
+    auto const positive = yaml::greater_than<std::size_t>{0};
+
+    auto zero_node         = YAML::Load("value: 0");
+    std::size_t zero_value = 17;
+    yaml::reader zero_reader(zero_node, "unsigned_test");
+    REQUIRE_THROWS_WITH(
+      zero_reader.optional("value", zero_value, positive),
+      Catch::Contains("unsigned_test.value") && Catch::Contains("value out of range"));
+    CHECK(zero_value == 17);
+
+    auto one_node         = YAML::Load("value: 1");
+    std::size_t one_value = 17;
+    yaml::reader one_reader(one_node, "unsigned_test");
+    REQUIRE_NOTHROW(one_reader.optional("value", one_value, positive));
+    CHECK(one_value == 1);
+
+    auto negative_node         = YAML::Load("value: -1");
+    std::size_t negative_value = 17;
+    yaml::reader negative_reader(negative_node, "unsigned_test");
+    REQUIRE_THROWS_WITH(negative_reader.optional("value", negative_value, positive),
+                        Catch::Contains("unsigned_test.value") &&
+                          Catch::Contains("unsigned value must be non-negative"));
+    CHECK(negative_value == 17);
+  }
 }
 
 TEST_CASE("yaml reader optional missing field uses default", "[config_opt][optional]")

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -329,6 +329,20 @@ TEST_CASE("Sirius configuration validates MARK join build switch ratio", "[siriu
   REQUIRE(config.get_operator_params().mark_join_build_switch_ratio == Approx(0.0));
 }
 
+TEST_CASE("Sirius configuration rejects negative memory prefetcher threads", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  fs::path cfg             = fs::path(loc.file_name()).parent_path() / "data" /
+                 "invalid_memory_prefetcher_num_threads_negative.yaml";
+
+  sirius::sirius_config config;
+  auto const before = config.get_scan_manager_config().memory_prefetcher.num_threads;
+  REQUIRE_THROWS_WITH(config.load_from_file(cfg),
+                      Catch::Contains("memory_prefetcher.num_threads") &&
+                        Catch::Contains("unsigned value must be non-negative"));
+  CHECK(config.get_scan_manager_config().memory_prefetcher.num_threads == before);
+}
+
 namespace {
 
 void require_shared_operator_defaults(const sirius::operator_params& params, uint64_t batch)


### PR DESCRIPTION
## Summary

- reject negative YAML scalars before conversion to unsigned integral destinations
- preserve the destination on conversion or validation failure
- retain each field's existing zero policy and validator semantics
- add generic parser regressions plus a full `memory_prefetcher.num_threads` config-path regression

## Why

The generic integral reader currently parses through a signed temporary and
then casts to an unsigned destination before validation. A value such as `-1`
therefore becomes `SIZE_MAX`; even `greater_than<size_t>{0}` accepts it. One
concrete result is `memory_prefetcher.num_threads: -1` reaching stream/thread
allocation as an enormous count. The common reader is the smallest place to
eliminate this defect class without teaching every setting its own workaround.

## Scope

This change rejects negatives only when the destination type is unsigned
integral. Signed integers, booleans, floats, enums, durations, and byte wrappers
retain their existing overloads and behavior. Zero remains valid at the generic
layer; positive-only and nonnegative field validators still decide the local
contract.

The reader still parses unsigned values through signed intermediates, so values
above the corresponding signed maximum remain unsupported. This PR fixes the
dangerous negative-wrap defect; it does not claim full unsigned-domain parsing.

## Rebase coordination

The exact current candidate is rebased onto the protected merge of #1490. Its
only conflict was additive test placement in `test/cpp/config/test_context.cpp`.
The resolution retains #1490's full MARK-ratio YAML, DuckDB `SET`, failed-input
nonmutation, zero, and reset coverage, then adds this PR's negative unsigned
memory-prefetcher regression. The production/parser change is unchanged.

## Validation

- generic unvalidated and validated `size_t` regressions reject `-1` without mutation and preserve zero/one validator semantics
- full config regression rejects `memory_prefetcher.num_threads: -1` without mutation
- field-scoped diagnostics preserved
- independent exact-current parser, overload, and rebase-union review: CLEAR
- `git diff --check` and orphan-test validation: pass
- exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full runtime, and aggregate checks: pass
- test workflow [31705629664](https://github.com/sirius-db/sirius/actions/runs/31705629664): pass; full runtime 19m22s
- check workflow [31705629662](https://github.com/sirius-db/sirius/actions/runs/31705629662): pass

Exact base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`  
Candidate: `1f73990c55b2bd9cf4b53c5f357c45aede3e8ca6`  
Tree: `35a4f140f8e272000cc4b9171ee15afbc7365847`

The predecessor `0a393d60740e01838449eb5bacae7f1259124129`
passed hosted lint, GCC release, Clang debug, CUDA 13 release build, full CUDA
runtime, and terminal aggregate checks. Those runtime receipts are historical
and do not transfer to this rebased head.

This is complementary to #1491's byte-wrapper validation. The field-specific
positive/nonnegative policies in #1495 and #1506 remain intact and compose
cleanly.

- exact-head hosted receipt for `1f73990c55b2bd9cf4b53c5f357c45aede3e8ca6`: CUDA 13 runtime and terminal aggregate checks passed
- hosted workflow 31705629664: runtime job 94466277196 passed from 2026-08-13T13:56:40Z through 2026-08-13T14:16:02Z; aggregate job 94477655021 passed at 2026-08-13T14:16:10Z