### PR TITLE
fix(config): reject negative downgrade monitor periods

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -269,7 +269,7 @@ Thread pool (default `num_threads: 1`, prefix `downgrade`) plus:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `monitor_period` | int (ms) | 10 | Period of the memory-pressure monitor loop. Set to `0` to disable the monitor loop entirely. |
+| `monitor_period` | duration (**>= 0**) | 10ms | Period of the memory-pressure monitor loop. Set to `0` to disable the monitor loop entirely; negative durations are rejected. |
 
 ## Scan Manager & IO Configuration
 

--- a/src/include/yaml_reader.hpp
+++ b/src/include/yaml_reader.hpp
@@ -278,6 +278,38 @@ void read_yaml(const YAML::Node& node, std::chrono::duration<Rep, Period>& out)
   }
 }
 
+/// Wrapper that rejects negative durations before casting to the target resolution.
+/// This avoids a negative sub-unit value (for example, -1us into milliseconds)
+/// truncating to zero before validation.
+template <typename Duration>
+struct non_negative_duration_value {
+  Duration& ref;
+};
+
+template <typename Rep, typename Period>
+non_negative_duration_value<std::chrono::duration<Rep, Period>> non_negative_duration(
+  std::chrono::duration<Rep, Period>& value)
+{
+  return {value};
+}
+
+template <typename Rep, typename Period>
+void read_yaml(const YAML::Node& node,
+               non_negative_duration_value<std::chrono::duration<Rep, Period>>& out)
+{
+  using target = std::chrono::duration<Rep, Period>;
+  try {
+    auto const count = node.as<Rep>();
+    if (count < Rep{0}) { throw std::runtime_error("duration must be non-negative"); }
+    out.ref = target{count};
+  } catch (const YAML::BadConversion&) {
+    auto const scalar = node.as<std::string>();
+    auto const parsed = parse_duration(scalar);
+    if (std::stod(scalar) < 0.0) { throw std::runtime_error("duration must be non-negative"); }
+    out.ref = std::chrono::duration_cast<target>(parsed);
+  }
+}
+
 template <StringEnum T>
 void read_yaml(const YAML::Node& node, T& out)
 {

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -304,7 +304,7 @@ static void from_yaml(const YAML::Node& node, exec::downgrade_executor_config& o
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{0});
   r.optional("thread_name_prefix", opt.thread_pool.thread_name_prefix);
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
-  r.optional("monitor_period", opt.monitor_period);
+  r.optional("monitor_period", yaml::non_negative_duration(opt.monitor_period));
   r.reject_unknown();
 }
 

--- a/test/cpp/config/data/invalid_downgrade_monitor_period_negative.yaml
+++ b/test/cpp/config/data/invalid_downgrade_monitor_period_negative.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      monitor_period: -1

--- a/test/cpp/config/data/invalid_downgrade_monitor_period_negative_fractional.yaml
+++ b/test/cpp/config/data/invalid_downgrade_monitor_period_negative_fractional.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      monitor_period: -0.5ms

--- a/test/cpp/config/data/invalid_downgrade_monitor_period_negative_submillisecond.yaml
+++ b/test/cpp/config/data/invalid_downgrade_monitor_period_negative_submillisecond.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      monitor_period: -1us

--- a/test/cpp/config/data/invalid_downgrade_monitor_period_negative_suffix.yaml
+++ b/test/cpp/config/data/invalid_downgrade_monitor_period_negative_suffix.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      monitor_period: -1ms

--- a/test/cpp/config/data/valid_downgrade_monitor_period_positive.yaml
+++ b/test/cpp/config/data/valid_downgrade_monitor_period_positive.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      monitor_period: 25ms

--- a/test/cpp/config/data/valid_downgrade_monitor_period_zero.yaml
+++ b/test/cpp/config/data/valid_downgrade_monitor_period_zero.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      monitor_period: 0

--- a/test/cpp/config/test_config.cpp
+++ b/test/cpp/config/test_config.cpp
@@ -287,6 +287,34 @@ TEST_CASE("yaml reader duration parsing", "[config_opt][duration]")
   }
 }
 
+TEST_CASE("yaml reader non-negative duration parsing", "[config_opt][duration]")
+{
+  using namespace std::chrono_literals;
+
+  SECTION("rejects a negative value before target-resolution truncation")
+  {
+    auto node = YAML::Load(R"(period: "-1us")");
+    std::chrono::milliseconds period{10};
+    yaml::reader r(node);
+    REQUIRE_THROWS_WITH(r.optional("period", yaml::non_negative_duration(period)),
+                        Catch::Contains("duration must be non-negative"));
+    REQUIRE(period == 10ms);
+  }
+
+  SECTION("preserves zero and positive duration semantics")
+  {
+    auto node = YAML::Load(R"(zero: 0
+positive: "25ms")");
+    std::chrono::milliseconds zero{10};
+    std::chrono::milliseconds positive{0};
+    yaml::reader r(node);
+    r.optional("zero", yaml::non_negative_duration(zero));
+    r.optional("positive", yaml::non_negative_duration(positive));
+    REQUIRE(zero == 0ms);
+    REQUIRE(positive == 25ms);
+  }
+}
+
 TEST_CASE("yaml reader arrays", "[config_opt][array]")
 {
   auto node = YAML::Load(R"(

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -39,6 +39,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>  // for setenv/putenv
 #include <filesystem>
@@ -546,6 +547,45 @@ TEST_CASE("Sirius downgrade hysteresis accepts omitted, null, and one-sided defa
 
     sirius::sirius_config config;
     REQUIRE_NOTHROW(config.load_from_file(path));
+  }
+}
+
+TEST_CASE("Sirius downgrade monitor period rejects negatives and preserves zero disable",
+          "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  for (auto const* fixture : {"invalid_downgrade_monitor_period_negative.yaml",
+                              "invalid_downgrade_monitor_period_negative_suffix.yaml",
+                              "invalid_downgrade_monitor_period_negative_submillisecond.yaml",
+                              "invalid_downgrade_monitor_period_negative_fractional.yaml"}) {
+    INFO("fixture=" << fixture);
+    auto const path = data_dir / fixture;
+    REQUIRE(fs::is_regular_file(path));
+
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(
+      config.load_from_file(path),
+      Catch::Contains("downgrade.monitor_period") && Catch::Contains("non-negative"));
+  }
+
+  struct valid_config {
+    const char* fixture;
+    std::chrono::milliseconds expected;
+  };
+  for (auto const& valid : {
+         valid_config{"valid_downgrade_monitor_period_zero.yaml", std::chrono::milliseconds{0}},
+         valid_config{"valid_downgrade_monitor_period_positive.yaml",
+                      std::chrono::milliseconds{25}},
+       }) {
+    INFO("fixture=" << valid.fixture);
+    auto const path = data_dir / valid.fixture;
+    REQUIRE(fs::is_regular_file(path));
+
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(config.load_from_file(path));
+    REQUIRE(config.get_downgrade_executor_config().monitor_period == valid.expected);
   }
 }
 


### PR DESCRIPTION
## Summary
- reject negative `sirius.executor.downgrade.monitor_period` values before target-resolution conversion
- preserve `0` as the intentional monitor-loop disable value and positive durations unchanged
- document the non-negative contract

## Why
`downgrade_executor::start()` starts the pressure monitor only when `monitor_period > 0`. Previously the YAML path accepted negative durations, so a typo such as `-1ms` silently disabled automatic downgrade recovery exactly like the intentional `0` setting. Validation must happen before conversion to milliseconds: supported values such as `-1us` and `-0.5ms` otherwise truncate to `0ms` and evade a post-conversion check.

## Tests
- config-path fixtures reject bare `-1`, `-1ms`, `-1us`, and `-0.5ms`
- config-path fixtures accept and read back `0` and `25ms`
- direct reader regression proves sub-millisecond refusal happens before truncation and leaves the destination unchanged
- `python3 scripts/check_orphan_tests.py`
- YAML fixture parse + `git diff --check`
- hosted exact-head lint, GCC release, Clang debug, CUDA 13 release build, full C++ runtime suite, dataset preparation, TPC-H snapshot, artifact upload, and aggregate check passed
- CUDA runtime job: 20m12s; C++ unit-test step: 18m53s

Exact base: `54c7d02864efc42c28987bcdb0896626a7bb371f`
Candidate: `c4b48153af995b38db002d3bc137b45991ce001a`
Tree: `2bc7e9111fd5d1dab7dd0d1bbb23fe8b78be57f4`

- exact-head hosted receipt for `c4b48153af995b38db002d3bc137b45991ce001a`: CUDA 13 runtime and terminal aggregate checks passed
- hosted workflow 31689001799: runtime job 94412744234 passed from 2026-08-13T10:19:25Z through 2026-08-13T10:39:37Z; aggregate job 94421389286 passed at 2026-08-13T10:39:47Z