### PR TITLE
fix(config): reject partial object-store activation

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -349,6 +349,12 @@ and transport use one trust policy; there are no separate REST YAML controls.
 
 ### `scan_manager.object_store` — S3 credentials & endpoint (`io/object_store_config.hpp`)
 
+The endpoint, region, access key, and secret key form one activation unit. An
+empty quartet leaves the REST object-store backend disabled. If any member is
+configured, all four are required; partial configurations are rejected while
+loading the file instead of disabling REST later. The session token and TLS,
+transport, or signing choices do not activate the backend by themselves.
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `endpoint` | string | "" | S3 endpoint URL. |

--- a/src/include/io/object_store_config.hpp
+++ b/src/include/io/object_store_config.hpp
@@ -22,10 +22,10 @@
 
 namespace sirius::io {
 
-/// Inert configuration carrier for remote object-store backends.
-/// PR1 only exposes the POD fields and enum/string helpers; runtime plumbing and
-/// backend consumption live in the integration/backend PRs.
-/// Empty strings are valid and mean "no value configured".
+/// Configuration carrier for remote object-store backends.
+/// An empty endpoint/region/static-key quartet means "no object store
+/// configured". Once any quartet member is supplied through YAML, all four
+/// members are required together; ancillary policy fields remain dormant.
 struct object_store_config {
   std::string endpoint;
   std::string region;

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -156,17 +156,37 @@ static void from_yaml(const YAML::Node& node, creator::task_creator_config& opt)
 
 static void from_yaml(const YAML::Node& node, sirius::io::object_store_config& opt)
 {
+  auto candidate = opt;
   yaml::reader r(node, "object_store");
-  r.optional("endpoint", opt.endpoint);
-  r.optional("region", opt.region);
-  r.optional("access_key", opt.access_key);
-  r.optional("secret_key", opt.secret_key);
-  r.optional("session_token", opt.session_token);
-  r.optional("s3_transport", opt.s3_transport);
-  r.optional("signing_mode", opt.s3_signing_mode);
-  r.optional("ca_bundle_path", opt.ca_bundle_path);
-  r.optional("tls_verify", opt.tls_verify);
+  r.optional("endpoint", candidate.endpoint);
+  r.optional("region", candidate.region);
+  r.optional("access_key", candidate.access_key);
+  r.optional("secret_key", candidate.secret_key);
+  r.optional("session_token", candidate.session_token);
+  r.optional("s3_transport", candidate.s3_transport);
+  r.optional("signing_mode", candidate.s3_signing_mode);
+  r.optional("ca_bundle_path", candidate.ca_bundle_path);
+  r.optional("tls_verify", candidate.tls_verify);
   r.reject_unknown();
+
+  auto const any_required = !candidate.endpoint.empty() || !candidate.region.empty() ||
+                            !candidate.access_key.empty() || !candidate.secret_key.empty();
+  if (any_required) {
+    std::vector<std::string_view> missing;
+    if (candidate.endpoint.empty()) { missing.emplace_back("endpoint"); }
+    if (candidate.region.empty()) { missing.emplace_back("region"); }
+    if (candidate.access_key.empty()) { missing.emplace_back("access_key"); }
+    if (candidate.secret_key.empty()) { missing.emplace_back("secret_key"); }
+    if (!missing.empty()) {
+      std::string message =
+        "'sirius.executor.scan_manager.object_store': incomplete activation; missing";
+      for (auto const field : missing) {
+        message += " " + std::string(field);
+      }
+      throw std::runtime_error(message);
+    }
+  }
+  opt = std::move(candidate);
 }
 
 static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -159,6 +159,147 @@ TEST_CASE("sirius_config loads object_store_config from YAML", "[object_store_co
   std::filesystem::remove(path, ec);
 }
 
+TEST_CASE("sirius_config accepts an empty object_store block", "[object_store_config][s3][config]")
+{
+  auto const path = std::filesystem::temp_directory_path() / "sirius_empty_object_store.yaml";
+  write_yaml(path,
+             "sirius:\n"
+             "  executor:\n"
+             "    scan_manager:\n"
+             "      object_store: {}\n");
+
+  sirius::sirius_config cfg;
+  REQUIRE_NOTHROW(cfg.load_from_file(path));
+
+  auto const& os = cfg.get_scan_manager_config().object_store;
+  CHECK(os.endpoint.empty());
+  CHECK(os.region.empty());
+  CHECK(os.access_key.empty());
+  CHECK(os.secret_key.empty());
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("sirius_config keeps ancillary object_store policy dormant",
+          "[object_store_config][s3][config]")
+{
+  auto const path =
+    std::filesystem::temp_directory_path() / "sirius_dormant_object_store_policy.yaml";
+  write_yaml(path,
+             "sirius:\n"
+             "  executor:\n"
+             "    scan_manager:\n"
+             "      object_store:\n"
+             "        session_token: dormant-session-token\n"
+             "        signing_mode: header\n"
+             "        s3_transport: rdma\n"
+             "        ca_bundle_path: /tmp/dormant-ca.pem\n"
+             "        tls_verify: false\n");
+
+  sirius::sirius_config cfg;
+  REQUIRE_NOTHROW(cfg.load_from_file(path));
+
+  auto const& os = cfg.get_scan_manager_config().object_store;
+  CHECK(os.endpoint.empty());
+  CHECK(os.region.empty());
+  CHECK(os.access_key.empty());
+  CHECK(os.secret_key.empty());
+  CHECK(os.session_token == "dormant-session-token");
+  CHECK(os.s3_signing_mode == object_store_config::signing_mode::header);
+  CHECK(os.s3_transport == object_store_config::transport::RDMA);
+  CHECK(os.ca_bundle_path == "/tmp/dormant-ca.pem");
+  CHECK_FALSE(os.tls_verify);
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("sirius_config rejects partial object_store activation",
+          "[object_store_config][s3][config]")
+{
+  auto const check_rejected =
+    [](std::string const& name, std::string const& fields, std::string const& missing_fields) {
+      auto const path =
+        std::filesystem::temp_directory_path() / ("sirius_partial_object_store_" + name + ".yaml");
+      write_yaml(path,
+                 "sirius:\n"
+                 "  executor:\n"
+                 "    scan_manager:\n"
+                 "      object_store:\n" +
+                   fields);
+
+      sirius::sirius_config cfg;
+      REQUIRE_THROWS_WITH(
+        cfg.load_from_file(path),
+        Catch::Contains(
+          "'sirius.executor.scan_manager.object_store': incomplete activation; missing " +
+          missing_fields));
+      auto const& os = cfg.get_scan_manager_config().object_store;
+      CHECK(os.endpoint.empty());
+      CHECK(os.region.empty());
+      CHECK(os.access_key.empty());
+      CHECK(os.secret_key.empty());
+      CHECK(os.session_token.empty());
+
+      std::error_code ec;
+      std::filesystem::remove(path, ec);
+    };
+
+  SECTION("endpoint without the remaining required fields")
+  {
+    check_rejected("endpoint_only",
+                   "        endpoint: https://s3.example.com\n",
+                   "region access_key secret_key");
+  }
+  SECTION("region without the remaining required fields")
+  {
+    check_rejected("region_only", "        region: us-east-1\n", "endpoint access_key secret_key");
+  }
+  SECTION("access key without the remaining required fields")
+  {
+    check_rejected(
+      "access_key_only", "        access_key: example-access-key\n", "endpoint region secret_key");
+  }
+  SECTION("secret key without the remaining required fields")
+  {
+    check_rejected(
+      "secret_key_only", "        secret_key: example-secret-key\n", "endpoint region access_key");
+  }
+  SECTION("endpoint omitted from an otherwise complete activation")
+  {
+    check_rejected("missing_endpoint",
+                   "        region: us-east-1\n"
+                   "        access_key: example-access-key\n"
+                   "        secret_key: example-secret-key\n",
+                   "endpoint");
+  }
+  SECTION("region omitted from an otherwise complete activation")
+  {
+    check_rejected("missing_region",
+                   "        endpoint: https://s3.example.com\n"
+                   "        access_key: example-access-key\n"
+                   "        secret_key: example-secret-key\n",
+                   "region");
+  }
+  SECTION("access key omitted from an otherwise complete activation")
+  {
+    check_rejected("missing_access_key",
+                   "        endpoint: https://s3.example.com\n"
+                   "        region: us-east-1\n"
+                   "        secret_key: example-secret-key\n",
+                   "access_key");
+  }
+  SECTION("secret key omitted from an otherwise complete activation")
+  {
+    check_rejected("missing_secret_key",
+                   "        endpoint: https://s3.example.com\n"
+                   "        region: us-east-1\n"
+                   "        access_key: example-access-key\n",
+                   "secret_key");
+  }
+}
+
 TEST_CASE("sirius_config loads presigned object_store_config signing mode from YAML",
           "[object_store_config][s3][config]")
 {


### PR DESCRIPTION
## What changed

- Keep an empty `scan_manager.object_store` block disabled.
- Once any member of the built-in REST backend quartet is supplied, require all four: `endpoint`, `region`, `access_key`, and `secret_key`.
- Reject incomplete activation during YAML load instead of accepting it and later disabling REST.
- List the exact missing quartet members and leave the previous config value unchanged after refusal.
- Document the all-or-none contract.

## Validation

- Focused config tests cover the empty block, both complete long-lived and temporary credentials, each required field alone, and each required field omitted from an otherwise complete activation.
- An explicit dormant-policy test proves `session_token`, signing, transport, CA, and TLS options alone remain accepted without activating the backend.
- `git diff --check` passes and changed C++ files are clang-formatted.
- Exact patch replay onto the rebased base reproduces the candidate tree.
- Exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full runtime, and terminal aggregate checks pass.
- Hosted workflow [31692800790](https://github.com/sirius-db/sirius/actions/runs/31692800790): runtime job `94424479329` passed in 20m00s; aggregate job `94430838875` passed.

This is intentionally YAML-scoped: ancillary session/transport/TLS/signing options alone do not activate the object store, and `session_token` remains optional once the required quartet is complete.

Exact identity: base `4872cd3c490baf59f2591c527f8fbb6833416e0f`, candidate `7c055b398dd8e31e6abe6118d771780c8b8cf173`, tree `2940753a5a1d18f961cbc9d3c9d01af888ab7501`.
