### PR TITLE
fix(config): reject incomplete object-store credentials

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -360,6 +360,12 @@ and transport use one trust policy; there are no separate REST YAML controls.
 | `ca_bundle_path` | string | "" | Sole YAML source for the REST endpoint's PEM CA bundle. |
 | `tls_verify` | bool | true | Sole YAML source for REST endpoint certificate verification. |
 
+The endpoint, region, access key, and secret key form one activation unit. An
+empty quartet leaves the REST object-store backend disabled. If any member is
+configured, all four are required; partial configurations are rejected while
+loading the file instead of disabling REST later. The session token and TLS or
+signing choices do not activate the backend by themselves.
+
 ## Operator Parameters
 
 **File:** `src/include/sirius_config.hpp` — `operator_params` struct

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -167,6 +167,23 @@ static void from_yaml(const YAML::Node& node, sirius::io::object_store_config& o
   r.optional("ca_bundle_path", opt.ca_bundle_path);
   r.optional("tls_verify", opt.tls_verify);
   r.reject_unknown();
+
+  auto const any_required = !opt.endpoint.empty() || !opt.region.empty() ||
+                            !opt.access_key.empty() || !opt.secret_key.empty();
+  if (!any_required) { return; }
+
+  std::vector<std::string_view> missing;
+  if (opt.endpoint.empty()) { missing.emplace_back("endpoint"); }
+  if (opt.region.empty()) { missing.emplace_back("region"); }
+  if (opt.access_key.empty()) { missing.emplace_back("access_key"); }
+  if (opt.secret_key.empty()) { missing.emplace_back("secret_key"); }
+  if (!missing.empty()) {
+    std::string message = "object_store: incomplete configuration; missing";
+    for (auto const field : missing) {
+      message += " " + std::string(field);
+    }
+    throw std::runtime_error(message);
+  }
 }
 
 static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -187,6 +187,86 @@ TEST_CASE("sirius_config loads presigned object_store_config signing mode from Y
   std::filesystem::remove(path, ec);
 }
 
+TEST_CASE("sirius_config rejects incomplete object_store activation quartets",
+          "[object_store_config][s3][config]")
+{
+  struct invalid_config {
+    const char* name;
+    const char* fields;
+    const char* missing;
+  };
+  for (auto const& invalid : {
+         invalid_config{"endpoint_only", "        endpoint: https://s3.example.com\n", "region"},
+         invalid_config{"missing_endpoint",
+                        "        region: us-east-1\n"
+                        "        access_key: access\n"
+                        "        secret_key: secret\n",
+                        "endpoint"},
+         invalid_config{"missing_region",
+                        "        endpoint: https://s3.example.com\n"
+                        "        access_key: access\n"
+                        "        secret_key: secret\n",
+                        "region"},
+         invalid_config{"missing_access_key",
+                        "        endpoint: https://s3.example.com\n"
+                        "        region: us-east-1\n"
+                        "        secret_key: secret\n",
+                        "access_key"},
+         invalid_config{"missing_secret_key",
+                        "        endpoint: https://s3.example.com\n"
+                        "        region: us-east-1\n"
+                        "        access_key: access\n",
+                        "secret_key"},
+       }) {
+    INFO("case=" << invalid.name);
+    auto const path = std::filesystem::temp_directory_path() /
+                      ("sirius_object_store_" + std::string(invalid.name) + ".yaml");
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n"
+               "      object_store:\n" +
+                 std::string(invalid.fields));
+
+    sirius::sirius_config cfg;
+    REQUIRE_THROWS_WITH(cfg.load_from_file(path),
+                        Catch::Contains("object_store: incomplete configuration") &&
+                          Catch::Contains(invalid.missing));
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+  }
+}
+
+TEST_CASE("sirius_config keeps an empty object_store quartet disabled",
+          "[object_store_config][s3][config]")
+{
+  auto const path =
+    std::filesystem::temp_directory_path() / "sirius_object_store_disabled_tls_policy.yaml";
+  write_yaml(path,
+             "sirius:\n"
+             "  executor:\n"
+             "    scan_manager:\n"
+             "      object_store:\n"
+             "        session_token: dormant-token\n"
+             "        ca_bundle_path: /tmp/dormant-ca.pem\n"
+             "        tls_verify: false\n");
+
+  sirius::sirius_config cfg;
+  REQUIRE_NOTHROW(cfg.load_from_file(path));
+  auto const& os = cfg.get_scan_manager_config().object_store;
+  CHECK(os.endpoint.empty());
+  CHECK(os.region.empty());
+  CHECK(os.access_key.empty());
+  CHECK(os.secret_key.empty());
+  CHECK(os.session_token == "dormant-token");
+  CHECK(os.ca_bundle_path == "/tmp/dormant-ca.pem");
+  CHECK_FALSE(os.tls_verify);
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
 TEST_CASE("sirius_config rejects unknown object_store_config signing modes",
           "[object_store_config][s3][config]")
 {


### PR DESCRIPTION
## Summary

- treat endpoint, region, access_key, and secret_key as one object-store activation unit
- reject partial activation during configuration loading instead of silently disabling REST later
- keep the all-empty quartet disabled, including when dormant session/TLS policy fields are present
- document the activation contract

## Why

The runtime object-store authorizer already returns null when any member of this quartet is empty. That turns a typo or omitted credential into a warning and a disabled REST backend. The built-in factory does not recover the missing value from environment variables, AWS profiles, or IMDS, so the configuration cannot become usable later. Rejecting the partial file at load time gives the operator a specific missing-field error.

## Validation

- xcrun clang-format 21 on changed C++ files
- git diff --check
- python3 scripts/check_orphan_tests.py
- focused configuration fixtures cover every single missing member plus the disabled all-empty case
- full build and runtime tests delegated to upstream CI because this macOS host has no Sirius CUDA toolchain