### PR TITLE
fix(config): validate memory policy inputs

### DIFF
--- a/bench/sf1000-repro/sirius-sf1000.yaml
+++ b/bench/sf1000-repro/sirius-sf1000.yaml
@@ -25,7 +25,6 @@ sirius:
             pool_size: 8
             block_size: 67108864
         disk:
-            disk_id: 0
             capacity_bytes: 1000000000000
             downgrade_root_dirs: "/localhome/local-faramburu/sirius_disk_memory"
     executor:

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -78,7 +78,7 @@ sirius:
       downgrade_trigger_fraction: 0.8
       downgrade_stop_fraction: 0.6
     host: { capacity_bytes: 25GB, initial_number_pools: 50, pool_size: 512, block_size: 1048576 }
-    disk: { disk_id: 0, capacity_bytes: 1000000000000, downgrade_root_dirs: "/tmp/sirius_disk_memory" }
+    disk: { capacity_bytes: 1000000000000, downgrade_root_dirs: "/tmp/sirius_disk_memory" }
   executor:
     scan_manager: { num_threads: 4, use_sirius_datasource: true, uring_n_reactors: 1, enable_prefetch_cache: false }
     pipeline:     { num_threads: 4 }
@@ -119,10 +119,10 @@ Controls how much GPU VRAM Sirius claims and when it starts evicting data to hos
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `usage_limit_fraction` | double | 0.95 | Fraction of total VRAM to use as Sirius's GPU memory capacity. The remaining 5% is left for the CUDA runtime, cuDF temporaries, and other GPU consumers. Mutually exclusive with `usage_limit_bytes`; configuration loading rejects both when both values are non-null. |
-| `usage_limit_bytes` | bytes | — | Absolute VRAM limit. Mutually exclusive with `usage_limit_fraction`; configuration loading rejects both when both values are non-null. |
-| `reservation_limit_fraction` | double | 1.0 | Fraction of the GPU capacity (set by `usage_limit_*`) that can be reserved by pipeline tasks. Reservations are acquired before task execution and prevent overcommit. Mutually exclusive with `reservation_limit_bytes`; configuration loading rejects both when both values are non-null. |
-| `reservation_limit_bytes` | bytes | — | Absolute reservation limit. Mutually exclusive with `reservation_limit_fraction`; configuration loading rejects both when both values are non-null. |
+| `usage_limit_fraction` | double (0,1] | 0.95 | Fraction of total VRAM to use as Sirius's GPU memory capacity. The remaining 5% is left for the CUDA runtime, cuDF temporaries, and other GPU consumers. Mutually exclusive with `usage_limit_bytes`; configuration loading rejects both when both values are non-null. |
+| `usage_limit_bytes` | bytes > 0 | — | Absolute VRAM limit. Mutually exclusive with `usage_limit_fraction`; configuration loading rejects both when both values are non-null. |
+| `reservation_limit_fraction` | double (0,1] | 1.0 | Fraction of the GPU capacity (set by `usage_limit_*`) that can be reserved by pipeline tasks. Reservations are acquired before task execution and prevent overcommit. Mutually exclusive with `reservation_limit_bytes`; configuration loading rejects both when both values are non-null. |
+| `reservation_limit_bytes` | bytes | — | Absolute reservation limit against each GPU's resolved effective capacity. Must not exceed that capacity. Mutually exclusive with `reservation_limit_fraction`; configuration loading rejects both when both values are non-null. |
 | `downgrade_trigger_fraction` | double (0,1] | 0.8 | Start evicting GPU-resident data to host when reserved memory exceeds this fraction of capacity. Must be greater than `downgrade_stop_fraction`. |
 | `downgrade_stop_fraction` | double (0,1] | 0.6 | Stop evicting when reserved memory drops to this fraction of capacity. Must be less than `downgrade_trigger_fraction`; configuration loading rejects an invalid pair. |
 | `track_per_stream_reservation` | bool | false | Track memory reservations per CUDA stream instead of globally. Useful for debugging per-task memory usage. |
@@ -134,14 +134,16 @@ Controls pinned host memory pools. One pool group is created per NUMA node (auto
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `capacity_fraction` | double (0,1] | 0.9 | Pinned host memory capacity as a fraction of **each backing NUMA node's total RAM** (read from `/sys/devices/system/node/node<id>/meminfo`). Mutually exclusive with `capacity_bytes`; configuration loading rejects both when both values are non-null. Initialization fails if a node's capacity cannot be determined. |
-| `capacity_bytes` | bytes | — | Pinned host memory capacity **per NUMA node** as absolute bytes, allocated with `cudaMallocHost`. Mutually exclusive with `capacity_fraction`; configuration loading rejects both when both values are non-null. |
-| `reservation_limit_fraction` | double | 1.0 | Fraction of host capacity that can be reserved. Mutually exclusive with `reservation_limit_bytes`; configuration loading rejects both when both values are non-null. |
-| `reservation_limit_bytes` | bytes | — | Absolute reservation limit. Mutually exclusive with `reservation_limit_fraction`; configuration loading rejects both when both values are non-null. |
+| `capacity_bytes` | bytes > 0 | — | Pinned host memory capacity **per NUMA node** as absolute bytes, allocated with `cudaMallocHost`. Mutually exclusive with `capacity_fraction`; configuration loading rejects both when both values are non-null. |
+| `reservation_limit_fraction` | double (0,1] | 1.0 | Fraction of host capacity that can be reserved. Mutually exclusive with `reservation_limit_bytes`; configuration loading rejects both when both values are non-null. |
+| `reservation_limit_bytes` | bytes | — | Absolute reservation limit against each resolved NUMA-space capacity. Must not exceed that capacity. Mutually exclusive with `reservation_limit_fraction`; configuration loading rejects both when both values are non-null. |
 | `downgrade_trigger_fraction` | double (0,1] | 0.9 | Start evicting host-resident data to disk when reserved memory exceeds this fraction. Must be greater than `downgrade_stop_fraction`. Eviction also requires a configured `downgrade_root_dirs`; without one the downgrade executor logs a warning and skips. |
 | `downgrade_stop_fraction` | double (0,1] | 0.8 | Stop evicting when reserved memory drops to this fraction. Must be less than `downgrade_trigger_fraction`; configuration loading rejects an invalid pair. |
-| `block_size` | bytes | 1Mi | Size of each allocation block in the pool. Larger blocks reduce allocation overhead but waste memory on small allocations. |
-| `pool_size` | int | 128 | Number of blocks per pool. Total pool capacity = `block_size × pool_size`. |
-| `initial_number_pools` | int | 4 | Number of pools pre-allocated at startup. Additional pools are created on demand. Initial host footprint = `block_size × pool_size × initial_number_pools`. |
+| `block_size` | bytes (**> 0**) | 1Mi | Size of each allocation block in the pool. Larger blocks reduce allocation overhead but waste memory on small allocations. |
+| `pool_size` | int (**> 0**) | 128 | Number of blocks per pool. Total pool capacity = `block_size × pool_size`. |
+| `initial_number_pools` | int (**> 0**) | 4 | Number of pools pre-allocated at startup. Additional pools are created on demand. Initial host footprint = `block_size × pool_size × initial_number_pools`. |
+
+The initial host footprint must not exceed the resolved capacity of each host space.
 
 ### Disk Memory (`sirius.memory.disk`)
 
@@ -149,8 +151,7 @@ Controls the disk spill tier. Data evicted from host memory is written here. Dis
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `disk_id` | int | 0 | Identifier for the disk space. |
-| `capacity_bytes` | bytes | 1Ti | Maximum disk space for spill files. |
+| `capacity_bytes` | bytes | 1Ti | Maximum disk space for spill files. An explicitly positive capacity requires a non-empty `downgrade_root_dirs`; `0` remains an explicit spill-tier opt-out. |
 | `downgrade_root_dirs` | string | "" | Directory path for spill files. **Must be set** to enable disk spilling. Use a fast local mount (NVMe preferred). |
 
 ### How Downgrade Thresholds Work
@@ -210,9 +211,12 @@ Each tier is a **YAML sequence** of space configs. Byte fields accept suffixes; 
 | `downgrade_trigger_fraction` | double (0,1] | space default | Start evicting above this fraction. Must be greater than `downgrade_stop_fraction`. |
 | `downgrade_stop_fraction` | double (0,1] | space default | Stop evicting below this fraction. Must be less than `downgrade_trigger_fraction`. |
 | `memory_capacity` | bytes | space default | Absolute capacity of the space. |
-| `block_size` | bytes | pool default | Allocation block size. |
-| `pool_size` | int | pool default | Blocks per pool. |
-| `initial_number_pools` | int | pool default | Pools pre-allocated at startup. |
+| `block_size` | bytes (**> 0**) | pool default | Allocation block size. |
+| `pool_size` | int (**> 0**) | pool default | Blocks per pool. |
+| `initial_number_pools` | int (**> 0**) | pool default | Pools pre-allocated at startup. |
+
+For every low-level host space with a non-zero `memory_capacity`, the initial pool footprint
+must fit within that capacity.
 
 #### `sirius.space.disk[]` — one entry per disk spill space
 

--- a/src/include/yaml_reader.hpp
+++ b/src/include/yaml_reader.hpp
@@ -60,6 +60,12 @@ struct fraction {
 };
 
 template <typename T>
+struct positive_fraction {
+  bool operator()(const T& v) const noexcept { return v > T{0} && v <= T{1}; }
+  static constexpr const char* description() { return "must be greater than 0.0 and at most 1.0"; }
+};
+
+template <typename T>
 struct greater_than {
   T threshold;
   bool operator()(const T& v) const noexcept { return v > threshold; }

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -91,6 +91,49 @@ static void validate_downgrade_fractions(std::string_view scope, double trigger,
   }
 }
 
+static void reject_zero_bytes(std::string_view scope,
+                              std::string_view field,
+                              const std::optional<std::uint64_t>& value)
+{
+  if (value && *value == 0) {
+    throw std::runtime_error(std::string(scope) + "." + std::string(field) +
+                             ": must be greater than zero");
+  }
+}
+
+static void validate_host_pool_features(std::string_view scope,
+                                        std::size_t block_size,
+                                        std::size_t pool_size,
+                                        std::size_t initial_number_pools)
+{
+  auto require_positive = [scope](std::string_view field, std::size_t value) {
+    if (value == 0) {
+      throw std::runtime_error(std::string(scope) + "." + std::string(field) +
+                               ": must be greater than zero");
+    }
+  };
+  require_positive("block_size", block_size);
+  require_positive("pool_size", pool_size);
+  require_positive("initial_number_pools", initial_number_pools);
+}
+
+static void validate_host_pool_capacity(std::string_view scope,
+                                        const cucascade::memory::host_memory_space_config& config)
+{
+  // The low-level replacement API retains memory_capacity == 0 semantics. For every
+  // bounded host space, however, the pool constructor preallocates the complete initial
+  // footprint from its upstream allocator before logical reservations begin.
+  if (config.memory_capacity == 0) { return; }
+  auto const pool_fits  = config.block_size <= config.memory_capacity / config.pool_size;
+  auto const pool_bytes = pool_fits ? config.block_size * config.pool_size : 0;
+  auto const initial_fits =
+    pool_fits && config.initial_number_pools <= config.memory_capacity / pool_bytes;
+  if (!initial_fits) {
+    throw std::runtime_error(std::string(scope) +
+                             ": initial host pool footprint exceeds memory capacity");
+  }
+}
+
 static void from_yaml(const YAML::Node& node, cucascade::memory::gpu_memory_space_config& opt)
 {
   opt.per_stream_reservation = false;  // default to false for sirius
@@ -122,6 +165,8 @@ static void from_yaml(const YAML::Node& node, cucascade::memory::host_memory_spa
   r.optional("pool_size", opt.pool_size);
   r.optional("initial_number_pools", opt.initial_number_pools);
   r.reject_unknown();
+  validate_host_pool_features(
+    "sirius.space.host", opt.block_size, opt.pool_size, opt.initial_number_pools);
   validate_downgrade_fractions(
     "sirius.space.host", opt.downgrade_trigger_fraction, opt.downgrade_stop_fraction);
 }
@@ -366,7 +411,8 @@ struct gpu_mem_config {
     double usage_frac = 0.95;
     reject_mutually_exclusive(r, "memory.gpu", "usage_limit_bytes", "usage_limit_fraction");
     r.optional("usage_limit_bytes", yaml::bytes(usage_bytes));
-    r.optional("usage_limit_fraction", usage_frac, yaml::fraction<double>{});
+    reject_zero_bytes("sirius.memory.gpu", "usage_limit_bytes", usage_bytes);
+    r.optional("usage_limit_fraction", usage_frac, yaml::positive_fraction<double>{});
     opt.usage_limit = usage_bytes ? std::variant<double, std::uint64_t>{*usage_bytes}
                                   : std::variant<double, std::uint64_t>{usage_frac};
     // reservation_limit: fraction or absolute bytes
@@ -375,7 +421,7 @@ struct gpu_mem_config {
     reject_mutually_exclusive(
       r, "memory.gpu", "reservation_limit_bytes", "reservation_limit_fraction");
     r.optional("reservation_limit_bytes", yaml::bytes(res_bytes));
-    r.optional("reservation_limit_fraction", res_frac, yaml::fraction<double>{});
+    r.optional("reservation_limit_fraction", res_frac, yaml::positive_fraction<double>{});
     opt.reservation_limit = res_bytes ? std::variant<double, std::uint64_t>{*res_bytes}
                                       : std::variant<double, std::uint64_t>{res_frac};
     r.optional(
@@ -385,6 +431,12 @@ struct gpu_mem_config {
     r.reject_unknown();
     validate_downgrade_fractions(
       "sirius.memory.gpu", opt.downgrade_trigger_fraction, opt.downgrade_stop_fraction);
+  }
+
+  [[nodiscard]] std::optional<std::uint64_t> absolute_reservation_limit() const
+  {
+    if (auto const* bytes = std::get_if<std::uint64_t>(&reservation_limit)) { return *bytes; }
+    return std::nullopt;
   }
 
   void setup_configurator(cucascade::memory::reservation_manager_configurator& builder) const
@@ -397,7 +449,9 @@ struct gpu_mem_config {
     if (std::holds_alternative<double>(reservation_limit)) {
       builder.set_reservation_fraction_per_gpu(std::get<double>(reservation_limit));
     } else {
-      builder.set_reservation_limit_per_gpu(std::get<std::uint64_t>(reservation_limit));
+      // Apply absolute bytes against each resolved effective capacity below. cuCascade's
+      // absolute GPU setter converts against physical capacity before applying the usage cap.
+      builder.set_reservation_fraction_per_gpu(1.0);
     }
     builder.set_downgrade_fractions_per_gpu(downgrade_trigger_fraction, downgrade_stop_fraction);
     builder.track_reservation_per_stream(track_per_stream_reservation);
@@ -424,6 +478,7 @@ struct host_mem_config {
     std::optional<double> cap_frac;
     reject_mutually_exclusive(r, "memory.host", "capacity_bytes", "capacity_fraction");
     r.optional("capacity_bytes", yaml::bytes(cap_bytes));
+    reject_zero_bytes("sirius.memory.host", "capacity_bytes", cap_bytes);
     r.optional("capacity_fraction", cap_frac);
     if (cap_frac && !(*cap_frac > 0.0 && *cap_frac <= 1.0)) {
       throw std::runtime_error("memory.host.capacity_fraction: must be in (0.0, 1.0], got " +
@@ -439,7 +494,7 @@ struct host_mem_config {
     reject_mutually_exclusive(
       r, "memory.host", "reservation_limit_bytes", "reservation_limit_fraction");
     r.optional("reservation_limit_bytes", yaml::bytes(res_bytes));
-    r.optional("reservation_limit_fraction", res_frac, yaml::fraction<double>{});
+    r.optional("reservation_limit_fraction", res_frac, yaml::positive_fraction<double>{});
     opt.reservation_limit = res_bytes ? std::variant<double, std::uint64_t>{*res_bytes}
                                       : std::variant<double, std::uint64_t>{res_frac};
     r.optional(
@@ -449,8 +504,16 @@ struct host_mem_config {
     r.optional("pool_size", opt.pool_size);
     r.optional("initial_number_pools", opt.initial_number_pools);
     r.reject_unknown();
+    validate_host_pool_features(
+      "sirius.memory.host", opt.block_size, opt.pool_size, opt.initial_number_pools);
     validate_downgrade_fractions(
       "sirius.memory.host", opt.downgrade_trigger_fraction, opt.downgrade_stop_fraction);
+  }
+
+  [[nodiscard]] std::optional<std::uint64_t> absolute_reservation_limit() const
+  {
+    if (auto const* bytes = std::get_if<std::uint64_t>(&reservation_limit)) { return *bytes; }
+    return std::nullopt;
   }
 
   void setup_configurator(cucascade::memory::reservation_manager_configurator& builder) const
@@ -464,7 +527,9 @@ struct host_mem_config {
     if (std::holds_alternative<double>(reservation_limit)) {
       builder.set_reservation_fraction_per_numa_region(std::get<double>(reservation_limit));
     } else {
-      builder.set_reservation_limit_per_numa_region(std::get<std::uint64_t>(reservation_limit));
+      // Apply absolute bytes against each resolved NUMA-space capacity below so invalid user
+      // input is reported as a configuration error instead of relying on a builder assertion.
+      builder.set_reservation_fraction_per_numa_region(1.0);
     }
     builder.set_downgrade_fractions_per_numa_region(downgrade_trigger_fraction,
                                                     downgrade_stop_fraction);
@@ -485,23 +550,33 @@ struct host_mem_config {
 };
 
 struct disk_mem_config {
-  int id{0};
   std::size_t capacity_bytes{1024UL << 30};  // 1TB
   std::string downgrade_root_dirs;
 
   static void from_yaml(const YAML::Node& node, disk_mem_config& opt)
   {
     yaml::reader r(node, "memory.disk");
-    r.optional("disk_id", opt.id);
+    if (r.has("disk_id")) {
+      throw std::runtime_error(
+        "'sirius.memory.disk.disk_id': removed; the single high-level disk space uses internal "
+        "ID 0; remove this key or use 'sirius.space.disk[]' for explicit multi-space IDs");
+    }
     r.optional("capacity_bytes", yaml::bytes(opt.capacity_bytes));
     r.optional("downgrade_root_dirs", opt.downgrade_root_dirs);
     r.reject_unknown();
+    if (r.has_value("capacity_bytes") && opt.capacity_bytes > 0 &&
+        opt.downgrade_root_dirs.empty()) {
+      throw std::runtime_error(
+        "sirius.memory.disk.capacity_bytes: inactive without a non-empty "
+        "sirius.memory.disk.downgrade_root_dirs; configure the spill directory or remove "
+        "capacity_bytes");
+    }
   }
 
   void setup_configurator(cucascade::memory::reservation_manager_configurator& builder) const
   {
     if (downgrade_root_dirs.empty() || capacity_bytes == 0) { return; }
-    builder.set_disk_mounting_point(id, capacity_bytes, downgrade_root_dirs);
+    builder.set_disk_mounting_point(0, capacity_bytes, downgrade_root_dirs);
   }
 };
 
@@ -700,6 +775,37 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
       host_cfg.setup_configurator(builder);
       disk_cfg.setup_configurator(builder);
       _memory_space_configs = builder.build(_hw_topology);
+
+      auto apply_absolute_limit =
+        [](std::string_view scope, std::string_view field, std::uint64_t bytes, auto& config) {
+          if (bytes > config.memory_capacity) {
+            throw std::runtime_error(std::string(scope) + "." + std::string(field) +
+                                     ": must not exceed resolved memory capacity " +
+                                     std::to_string(config.memory_capacity));
+          }
+          config.reservation_limit_fraction =
+            config.memory_capacity == 0
+              ? 0.0
+              : static_cast<double>(bytes) / static_cast<double>(config.memory_capacity);
+        };
+      for (auto& space : _memory_space_configs) {
+        if (auto* gpu = std::get_if<cucascade::memory::gpu_memory_space_config>(&space)) {
+          if (auto const bytes = gpu_cfg.absolute_reservation_limit()) {
+            apply_absolute_limit("sirius.memory.gpu", "reservation_limit_bytes", *bytes, *gpu);
+          }
+        } else if (auto* host = std::get_if<cucascade::memory::host_memory_space_config>(&space)) {
+          if (auto const bytes = host_cfg.absolute_reservation_limit()) {
+            apply_absolute_limit("sirius.memory.host", "reservation_limit_bytes", *bytes, *host);
+          }
+        }
+      }
+    }
+
+    for (auto const& space : _memory_space_configs) {
+      if (auto const* host = std::get_if<cucascade::memory::host_memory_space_config>(&space)) {
+        validate_host_pool_capacity(using_configurator ? "sirius.memory.host" : "sirius.space.host",
+                                    *host);
+      }
     }
 
     bool const explicit_low_level_gpu_capacity =

--- a/test/cpp/config/data/configurator.yaml
+++ b/test/cpp/config/data/configurator.yaml
@@ -10,11 +10,11 @@ sirius:
       track_per_stream_reservation: false
     host:
       capacity_bytes: 160000000
+      initial_number_pools: 1
       reservation_limit_fraction: 0.9
       downgrade_trigger_fraction: 0.8
       downgrade_stop_fraction: 0.7
     disk:
-      disk_id: 0
       capacity_bytes: 1000000000
       downgrade_root_dirs: "/tmp/sirius_disk_memory"
   executor:

--- a/test/cpp/config/data/effective_operator_defaults_high_level.yaml
+++ b/test/cpp/config/data/effective_operator_defaults_high_level.yaml
@@ -6,3 +6,4 @@ sirius:
       usage_limit_bytes: 256MiB
     host:
       capacity_bytes: 256MiB
+      initial_number_pools: 1

--- a/test/cpp/config/data/effective_operator_defaults_uncapped.yaml
+++ b/test/cpp/config/data/effective_operator_defaults_uncapped.yaml
@@ -6,3 +6,4 @@ sirius:
       reservation_limit_fraction: 1.0
     host:
       capacity_bytes: 256MiB
+      initial_number_pools: 1

--- a/test/cpp/config/data/invalid_memory_disk_capacity_without_root.yaml
+++ b/test/cpp/config/data/invalid_memory_disk_capacity_without_root.yaml
@@ -1,0 +1,4 @@
+sirius:
+  memory:
+    disk:
+      capacity_bytes: 1Gi

--- a/test/cpp/config/data/invalid_memory_disk_id.yaml
+++ b/test/cpp/config/data/invalid_memory_disk_id.yaml
@@ -1,0 +1,6 @@
+sirius:
+  memory:
+    disk:
+      disk_id: 7
+      capacity_bytes: 1Gi
+      downgrade_root_dirs: /tmp/sirius-disk

--- a/test/cpp/config/data/minimal.yaml
+++ b/test/cpp/config/data/minimal.yaml
@@ -6,8 +6,8 @@ sirius:
       usage_limit_fraction: 0.25
     host:
       capacity_bytes: 160000000
+      initial_number_pools: 1
     disk:
-      disk_id: 0
       capacity_bytes: 1000000000
       downgrade_root_dirs: "/tmp/sirius_disk_memory"
   executor:

--- a/test/cpp/config/data/setting_defaults.yaml
+++ b/test/cpp/config/data/setting_defaults.yaml
@@ -9,6 +9,7 @@ sirius:
       downgrade_stop_fraction: 0.02
     host:
       capacity_bytes: 160000000
+      initial_number_pools: 1
   executor:
     downgrade:
       num_threads: 1

--- a/test/cpp/config/data/valid_memory_disk_zero_optout.yaml
+++ b/test/cpp/config/data/valid_memory_disk_zero_optout.yaml
@@ -1,0 +1,4 @@
+sirius:
+  memory:
+    disk:
+      capacity_bytes: 0

--- a/test/cpp/config/test_config.cpp
+++ b/test/cpp/config/test_config.cpp
@@ -99,6 +99,29 @@ TEST_CASE("yaml reader validation with fraction", "[config_opt][conditional]")
   REQUIRE(f == 0.5);  // unchanged
 }
 
+TEST_CASE("yaml reader validation with positive fraction", "[config_opt][conditional]")
+{
+  SECTION("zero is rejected")
+  {
+    auto node = YAML::Load("f: 0.0");
+    double f  = 0.5;
+
+    yaml::reader r(node);
+    REQUIRE_THROWS_AS(r.optional("f", f, yaml::positive_fraction<double>{}), std::runtime_error);
+    REQUIRE(f == 0.5);
+  }
+
+  SECTION("one is accepted")
+  {
+    auto node = YAML::Load("f: 1.0");
+    double f  = 0.5;
+
+    yaml::reader r(node);
+    REQUIRE_NOTHROW(r.optional("f", f, yaml::positive_fraction<double>{}));
+    REQUIRE(f == 1.0);
+  }
+}
+
 TEST_CASE("yaml reader byte suffix parsing", "[config_opt][bytes]")
 {
   SECTION("plain integers work with bytes()")

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -313,11 +313,42 @@ TEST_CASE("Sirius configuration loading from file with configurator",
   REQUIRE(manager.get_memory_spaces_for_tier(cucascade::memory::Tier::GPU).size() == 1);
   REQUIRE(manager.get_memory_spaces_for_tier(cucascade::memory::Tier::HOST).size() == 1);
   REQUIRE(manager.get_memory_spaces_for_tier(cucascade::memory::Tier::DISK).size() == 1);
+  REQUIRE(
+    manager.get_memory_spaces_for_tier(cucascade::memory::Tier::DISK).front()->get_device_id() ==
+    0);
 
   auto const& telemetry = sirius_ctx->get_config().get_telemetry_config();
   REQUIRE_FALSE(telemetry.enable_quent);
   REQUIRE(telemetry.output_directory == "/tmp/sirius_telemetry_config_test");
   REQUIRE(telemetry.engine_name == "sirius_config_test");
+}
+
+TEST_CASE("Sirius keeps the high-level disk space id internal", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const path =
+    fs::path(loc.file_name()).parent_path() / "data" / "invalid_memory_disk_id.yaml";
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(config.load_from_file(path),
+                      Catch::Contains("sirius.memory.disk.disk_id") && Catch::Contains("removed") &&
+                        Catch::Contains("sirius.space.disk"));
+}
+
+TEST_CASE("Sirius rejects an inactive high-level disk capacity", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(
+    config.load_from_file(data_dir / "invalid_memory_disk_capacity_without_root.yaml"),
+    Catch::Contains("sirius.memory.disk.capacity_bytes") && Catch::Contains("inactive") &&
+      Catch::Contains("downgrade_root_dirs"));
+
+  REQUIRE_NOTHROW(config.load_from_file(data_dir / "valid_memory_disk_zero_optout.yaml"));
+  auto const& spaces = config.get_memory_space_configs();
+  REQUIRE(std::ranges::none_of(spaces, [](auto const& space) {
+    return std::holds_alternative<cucascade::memory::disk_memory_space_config>(space);
+  }));
 }
 
 TEST_CASE("Sirius configuration rejects zero hash partition bytes", "[sirius][config]")
@@ -696,6 +727,218 @@ TEST_CASE("Sirius configuration accepts one form of each memory budget", "[siriu
 
   sirius::sirius_config config;
   REQUIRE_NOTHROW(config.load_from_file(cfg));
+}
+
+TEST_CASE("Sirius applies absolute reservation limits to effective capacities", "[sirius][config]")
+{
+  constexpr std::size_t mib = 1024ULL * 1024;
+  auto const path           = fs::temp_directory_path() / "sirius_absolute_reservation_limits.yaml";
+  finally cleanup{[path]() {
+    std::error_code ec;
+    fs::remove(path, ec);
+  }};
+  {
+    std::ofstream out(path);
+    REQUIRE(out);
+    out << "sirius:\n  memory:\n    gpu:\n      usage_limit_bytes: 1Gi\n"
+           "      reservation_limit_bytes: 256Mi\n    host:\n      capacity_bytes: 1Gi\n"
+           "      reservation_limit_bytes: 256Mi\n";
+  }
+
+  sirius::sirius_config config;
+  REQUIRE_NOTHROW(config.load_from_file(path));
+  bool saw_gpu  = false;
+  bool saw_host = false;
+  for (auto const& space : config.get_memory_space_configs()) {
+    if (auto const* gpu = std::get_if<cucascade::memory::gpu_memory_space_config>(&space)) {
+      saw_gpu = true;
+      REQUIRE(gpu->reservation_limit() == 256 * mib);
+    } else if (auto const* host =
+                 std::get_if<cucascade::memory::host_memory_space_config>(&space)) {
+      saw_host = true;
+      REQUIRE(host->reservation_limit() == 256 * mib);
+    }
+  }
+  REQUIRE(saw_gpu);
+  REQUIRE(saw_host);
+}
+
+TEST_CASE("Sirius rejects absolute reservation limits above effective capacity", "[sirius][config]")
+{
+  struct invalid_limit {
+    const char* tier;
+    const char* yaml;
+  };
+  const invalid_limit cases[] = {
+    {"gpu",
+     "sirius:\n  memory:\n    gpu:\n      usage_limit_bytes: 1Gi\n"
+     "      reservation_limit_bytes: 2Gi\n"},
+    {"host",
+     "sirius:\n  memory:\n    host:\n      capacity_bytes: 1Gi\n"
+     "      reservation_limit_bytes: 2Gi\n"},
+  };
+  for (auto const& test : cases) {
+    DYNAMIC_SECTION(test.tier)
+    {
+      auto const path = fs::temp_directory_path() /
+                        (std::string("sirius_absolute_reservation_") + test.tier + ".yaml");
+      finally cleanup{[path]() {
+        std::error_code ec;
+        fs::remove(path, ec);
+      }};
+      {
+        std::ofstream out(path);
+        REQUIRE(out);
+        out << test.yaml;
+      }
+
+      sirius::sirius_config config;
+      REQUIRE_THROWS_WITH(
+        config.load_from_file(path),
+        Catch::Contains(std::string("sirius.memory.") + test.tier + ".reservation_limit_bytes") &&
+          Catch::Contains("must not exceed resolved memory capacity"));
+    }
+  }
+}
+
+TEST_CASE("Sirius configuration rejects zero host pool dimensions", "[sirius][config]")
+{
+  struct zero_case {
+    const char* surface;
+    const char* field;
+  };
+  constexpr std::array cases{
+    zero_case{"memory", "block_size"},
+    zero_case{"memory", "pool_size"},
+    zero_case{"memory", "initial_number_pools"},
+    zero_case{"space", "block_size"},
+    zero_case{"space", "pool_size"},
+    zero_case{"space", "initial_number_pools"},
+  };
+
+  for (auto const& test : cases) {
+    DYNAMIC_SECTION(test.surface << ".host." << test.field)
+    {
+      auto const path = fs::temp_directory_path() / (std::string("sirius_zero_host_") +
+                                                     test.surface + "_" + test.field + ".yaml");
+      finally cleanup{[path]() {
+        std::error_code ec;
+        fs::remove(path, ec);
+      }};
+      {
+        std::ofstream out(path);
+        REQUIRE(out);
+        if (std::string_view{test.surface} == "memory") {
+          out << "sirius:\n  memory:\n    host:\n      " << test.field << ": 0\n";
+        } else {
+          out << "sirius:\n  space:\n    host:\n      - " << test.field << ": 0\n";
+        }
+      }
+
+      sirius::sirius_config config;
+      REQUIRE_THROWS_WITH(
+        config.load_from_file(path),
+        Catch::Contains(std::string("sirius.") + test.surface + ".host." + test.field) &&
+          Catch::Contains("greater than zero"));
+    }
+  }
+}
+
+TEST_CASE("Sirius configuration keeps initial host pools within capacity", "[sirius][config]")
+{
+  struct invalid_pool {
+    const char* name;
+    const char* yaml;
+    const char* scope;
+  };
+  const invalid_pool cases[] = {
+    {"high_level",
+     "sirius:\n  memory:\n    host:\n      capacity_bytes: 1Mi\n",
+     "sirius.memory.host"},
+    {"low_level",
+     "sirius:\n  space:\n    host:\n      - numa_id: -1\n        memory_capacity: 1Mi\n",
+     "sirius.space.host"},
+    {"overflow",
+     "sirius:\n  space:\n    host:\n      - numa_id: -1\n        memory_capacity: 1Gi\n"
+     "        block_size: 9223372036854775808\n        pool_size: 2\n"
+     "        initial_number_pools: 1\n",
+     "sirius.space.host"},
+  };
+
+  for (auto const& test : cases) {
+    DYNAMIC_SECTION(test.name)
+    {
+      auto const path = fs::temp_directory_path() /
+                        (std::string("sirius_host_pool_capacity_") + test.name + ".yaml");
+      finally cleanup{[path]() {
+        std::error_code ec;
+        fs::remove(path, ec);
+      }};
+      {
+        std::ofstream out(path);
+        REQUIRE(out);
+        out << test.yaml;
+      }
+
+      sirius::sirius_config config;
+      REQUIRE_THROWS_WITH(config.load_from_file(path),
+                          Catch::Contains(test.scope) && Catch::Contains("initial host pool") &&
+                            Catch::Contains("exceeds memory capacity"));
+    }
+  }
+}
+
+TEST_CASE("Sirius configuration rejects zero high-level memory budgets", "[sirius][config]")
+{
+  struct invalid_budget {
+    const char* name;
+    const char* yaml;
+    const char* field;
+    const char* message;
+  };
+  const invalid_budget cases[] = {
+    {"gpu_usage_bytes",
+     "sirius:\n  memory:\n    gpu:\n      usage_limit_bytes: 0\n",
+     "usage_limit_bytes",
+     "greater than zero"},
+    {"gpu_usage",
+     "sirius:\n  memory:\n    gpu:\n      usage_limit_fraction: 0\n",
+     "usage_limit_fraction",
+     "value out of range"},
+    {"gpu_reservation",
+     "sirius:\n  memory:\n    gpu:\n      reservation_limit_fraction: 0\n",
+     "reservation_limit_fraction",
+     "value out of range"},
+    {"host_capacity_bytes",
+     "sirius:\n  memory:\n    host:\n      capacity_bytes: 0\n",
+     "capacity_bytes",
+     "greater than zero"},
+    {"host_reservation",
+     "sirius:\n  memory:\n    host:\n      reservation_limit_fraction: 0\n",
+     "reservation_limit_fraction",
+     "value out of range"},
+  };
+
+  for (auto const& test : cases) {
+    DYNAMIC_SECTION(test.name)
+    {
+      auto const path =
+        fs::temp_directory_path() / (std::string("sirius_zero_fraction_") + test.name + ".yaml");
+      finally cleanup{[path]() {
+        std::error_code ec;
+        fs::remove(path, ec);
+      }};
+      {
+        std::ofstream out(path);
+        out << test.yaml;
+        REQUIRE(out);
+      }
+
+      sirius::sirius_config config;
+      REQUIRE_THROWS_WITH(config.load_from_file(path),
+                          Catch::Contains(test.field) && Catch::Contains(test.message));
+    }
+  }
 }
 
 TEST_CASE("Sirius configuration treats null memory budget forms as absent", "[sirius][config]")


### PR DESCRIPTION
## Summary

- reject zero host pool dimensions and zero high-level GPU/host capacities or fractions
- bound the initial host-pool footprint by each resolved non-zero host-space capacity with overflow-safe arithmetic
- honor absolute GPU/host reservation bytes against resolved effective space capacity and reject values that cannot fit
- remove the high-level single-disk `disk_id` choice and use internal ID 0
- reject positive high-level spill capacity without a spill directory, while retaining `capacity_bytes: 0` as the explicit spill opt-out
- preserve explicit IDs on expert low-level `sirius.space.disk[]`

## Why one PR

These are the shared allocator-safety and high-level `sirius.memory` source-of-truth rules. Capacity and reservation values must mean the bytes users state; pool preallocation must fit the resolved capacity; and the one high-level disk tier should express spill path/capacity policy rather than an internal identity. Low-level host-pool dimensions receive the same safety checks; low-level multi-space identities and topology remain separate in #1542.

This supersedes #1545 and preserves its single-disk/partial-activation regressions alongside the allocator budget contract.

## Contract

- high-level capacity and fraction fields that construct memory tiers are positive; intentional reservation/disk zero opt-outs remain accepted
- initial host-pool bytes fit each non-zero effective host capacity
- absolute reservations are applied literally after effective capacity resolution and cannot exceed it
- the single high-level disk tier always uses internal ID 0
- positive spill capacity requires a spill directory; zero capacity disables the tier
- low-level host-pool dimensions are positive and bounded; low-level space identities remain the separate #1542 contract

## Identity

- exact base: `e885ffea7d0541f1e3493566e2db0ed6e431106f`
- exact consolidated head: `dc8bbce33177a381ddaa12182126f0e44832064b`
- base tree: `df560dabe752232176201ed43bbaaa9c91be5805`
- candidate tree: `70621cf77dd11764d9764c451403bc19de8383cb`
- zero-context source-diff SHA-256: `a10d8e51374b93f517890b6a7401d54c9ede0527d3b520ace3a2a1ac99c06b75`
- prior #1511 head: `fc975c4ae07694d287400bc11512620fc1e73e7e`
- #1545 predecessor: `d3ac266b35639c6ada5994d82d25344668e2f1c0`

## Validation

- clean conflict-free rebase; `git range-diff` reports the single commit as patch-equivalent
- the rebase removes unrelated upstream drift from the hosted PR diff; exact patch is 14 paths, 425 insertions, 27 deletions
- orphan-test detection and `git diff --check` pass
- hosted exact-head checks passed: lint, GCC release, Clang debug, CUDA 13 build, full runtime, and terminal aggregate

### Retained predecessor hosted receipts

- prior #1511 head `f6c511429940a1d5e5ddef72a4279c8666594a3b`: workflow `31728016316`, runtime job `94542094345`, aggregate job `94557435248`; all passed
- #1545 head `d3ac266b35639c6ada5994d82d25344668e2f1c0`: workflow `31723993656`, runtime job `94528692203`, aggregate job `94540105396`; all passed

Those receipts remain predecessor evidence and are not relabeled as execution of the consolidated head. The previous exact consolidated head `fc975c4ae07694d287400bc11512620fc1e73e7e` also passed workflow `31739756563`.

- exact-head hosted receipt for `dc8bbce33177a381ddaa12182126f0e44832064b`: workflow `31758693293`; runtime job `94640834821` passed from `2026-08-14T00:55:52Z` through `2026-08-14T01:15:52Z`; terminal aggregate job `94644301794` passed at `2026-08-14T01:16:03Z`
