### PR TITLE
fix(config): reject zero fused-chunk limits

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -311,7 +311,7 @@ single-GPU configurations only (logs a warning and disables itself otherwise).
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `use_odirect` | bool | true | Use `O_DIRECT` for local-disk reads. |
-| `max_n_chunks` | int | 1 | Max contiguous file segments fused into one vectored read. |
+| `max_n_chunks` | int (**> 0**) | 1 | Max contiguous file segments fused into one vectored read; zero is rejected because every request contains at least one segment. |
 
 ### `scan_manager.rest` — REST / S3 backend (`io/rest/config.hpp`)
 
@@ -324,7 +324,7 @@ and transport use one trust policy; there are no separate REST YAML controls.
 | `request_timeout_s` | int (seconds) | 30 | Whole-request timeout and presigned-URL TTL (0 = no limit). |
 | `max_connections` | int | 16 | Max concurrent in-flight connections per reactor. |
 | `chunk_size` | bytes | 8Mi | Target bytes per ranged GET (scatter/device-staging paths). |
-| `max_n_chunks` | int | 16 | Max file-adjacent segments fused into one scatter GET. |
+| `max_n_chunks` | int (**> 0**) | 16 | Max file-adjacent segments fused into one scatter GET; zero is rejected because every request contains at least one segment. |
 | `max_read_split` | int | 16 | Max parallel ranged GETs for one contiguous host read (reads < 2 MiB stay a single GET). |
 | `upkeep_interval_ms` | int (ms) | 15000 | Idle-connection keepalive interval (`curl_easy_upkeep`; 0 disables). |
 | `conn_max_age_s` | int (seconds) | 20 | Max age curl may reuse a pooled connection (`CURLOPT_MAXAGE_CONN`; 0 = curl default). |

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -182,7 +182,10 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
   r.optional("request_timeout_s", opt.request_timeout_s);
   r.optional("max_connections", opt.max_connections);
   r.optional("chunk_size", yaml::bytes(opt.chunk_size));
-  r.optional("max_n_chunks", opt.max_n_chunks);
+  auto const has_max_n_chunks = r.has_value("max_n_chunks");
+  long long max_n_chunks      = 1;
+  r.optional("max_n_chunks", max_n_chunks, yaml::greater_than<long long>{0});
+  if (has_max_n_chunks) { opt.max_n_chunks = static_cast<std::size_t>(max_n_chunks); }
   r.optional("max_read_split", opt.max_read_split);
   r.optional("upkeep_interval_ms", opt.upkeep_interval);
   r.optional("conn_max_age_s", opt.conn_max_age);
@@ -202,7 +205,10 @@ static void from_yaml(const YAML::Node& node, sirius::io::uring::config& opt)
 {
   yaml::reader r(node, "local");
   r.optional("use_odirect", opt.use_odirect);
-  r.optional("max_n_chunks", opt.max_n_chunks);
+  auto const has_max_n_chunks = r.has_value("max_n_chunks");
+  long long max_n_chunks      = 1;
+  r.optional("max_n_chunks", max_n_chunks, yaml::greater_than<long long>{0});
+  if (has_max_n_chunks) { opt.max_n_chunks = static_cast<std::size_t>(max_n_chunks); }
   r.reject_unknown();
 }
 

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -376,22 +376,22 @@ TEST_CASE("sirius_config rejects zero fused-chunk limits", "[scan_manager][confi
     return surface == "rest" ? cfg.get_scan_manager_config().rest.max_n_chunks
                              : cfg.get_scan_manager_config().local.max_n_chunks;
   };
-  auto write_value = [](std::filesystem::path const& path,
-                        std::string const& surface,
-                        std::string const& value) {
-    auto const body = value == "<omitted>" ? "      " + surface + ": {}\n"
-                                            : "      " + surface + ":\n"
-                                                "        max_n_chunks: " +
-                                                value + "\n";
-    write_yaml(path,
-               "sirius:\n"
-               "  executor:\n"
-               "    scan_manager:\n" +
-                 body);
-  };
+  auto write_value =
+    [](std::filesystem::path const& path, std::string const& surface, std::string const& value) {
+      auto const body = value == "<omitted>" ? "      " + surface + ": {}\n"
+                                             : "      " + surface +
+                                                 ":\n"
+                                                 "        max_n_chunks: " +
+                                                 value + "\n";
+      write_yaml(path,
+                 "sirius:\n"
+                 "  executor:\n"
+                 "    scan_manager:\n" +
+                   body);
+    };
   auto check_surface = [&](std::string const& surface, std::size_t expected_default) {
-    auto const path = std::filesystem::temp_directory_path() /
-                      ("sirius_zero_" + surface + "_max_n_chunks.yaml");
+    auto const path =
+      std::filesystem::temp_directory_path() / ("sirius_zero_" + surface + "_max_n_chunks.yaml");
 
     for (auto const* value : {"<omitted>", "null"}) {
       write_value(path, surface, value);
@@ -415,8 +415,7 @@ TEST_CASE("sirius_config rejects zero fused-chunk limits", "[scan_manager][confi
       REQUIRE(read_value(cfg, surface) == 7);
 
       write_value(path, surface, invalid);
-      REQUIRE_THROWS_WITH(cfg.load_from_file(path),
-                          Catch::Contains(surface + ".max_n_chunks"));
+      REQUIRE_THROWS_WITH(cfg.load_from_file(path), Catch::Contains(surface + ".max_n_chunks"));
       CHECK(read_value(cfg, surface) == 7);
     }
 

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -369,3 +369,61 @@ TEST_CASE("sirius_config keeps REST bounce sizing internal", "[scan_manager][con
   std::error_code ec;
   std::filesystem::remove(path, ec);
 }
+
+TEST_CASE("sirius_config rejects zero fused-chunk limits", "[scan_manager][config]")
+{
+  auto read_value = [](sirius::sirius_config const& cfg, std::string const& surface) {
+    return surface == "rest" ? cfg.get_scan_manager_config().rest.max_n_chunks
+                             : cfg.get_scan_manager_config().local.max_n_chunks;
+  };
+  auto write_value = [](std::filesystem::path const& path,
+                        std::string const& surface,
+                        std::string const& value) {
+    auto const body = value == "<omitted>" ? "      " + surface + ": {}\n"
+                                            : "      " + surface + ":\n"
+                                                "        max_n_chunks: " +
+                                                value + "\n";
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n" +
+                 body);
+  };
+  auto check_surface = [&](std::string const& surface, std::size_t expected_default) {
+    auto const path = std::filesystem::temp_directory_path() /
+                      ("sirius_zero_" + surface + "_max_n_chunks.yaml");
+
+    for (auto const* value : {"<omitted>", "null"}) {
+      write_value(path, surface, value);
+      sirius::sirius_config cfg;
+      REQUIRE_NOTHROW(cfg.load_from_file(path));
+      CHECK(read_value(cfg, surface) == expected_default);
+    }
+
+    for (auto const* value : {"1", "7"}) {
+      write_value(path, surface, value);
+      sirius::sirius_config cfg;
+      REQUIRE_NOTHROW(cfg.load_from_file(path));
+      CHECK(read_value(cfg, surface) == static_cast<std::size_t>(std::stoull(value)));
+    }
+
+    for (auto const* invalid : {"0", "-1", "9223372036854775808"}) {
+      CAPTURE(surface, invalid);
+      sirius::sirius_config cfg;
+      write_value(path, surface, "7");
+      REQUIRE_NOTHROW(cfg.load_from_file(path));
+      REQUIRE(read_value(cfg, surface) == 7);
+
+      write_value(path, surface, invalid);
+      REQUIRE_THROWS_WITH(cfg.load_from_file(path),
+                          Catch::Contains(surface + ".max_n_chunks"));
+      CHECK(read_value(cfg, surface) == 7);
+    }
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+  };
+
+  SECTION("REST scatter GET") { check_surface("rest", 16); }
+  SECTION("local vectored read") { check_surface("local", 1); }
+}


### PR DESCRIPTION
## Summary

- reject `scan_manager.rest.max_n_chunks: 0` at YAML load instead of silently clamping it to one buffer per ranged GET
- reject `scan_manager.local.max_n_chunks: 0` instead of silently disabling contiguous-segment fusion
- preserve omitted/null defaults, every positive value, and destination state after refusal

## Why

Both fields describe a maximum number of chunks. Zero currently has no literal implementation: the REST path applies `std::max(max_n_chunks, 1)`, while the local path simply cannot extend a group and behaves like one. Accepting zero therefore gives users a configuration Sirius does not actually honor. Rejecting it at the source surface makes the behavior explicit without selecting a new default or tuning policy.

## Validation

- exact base: `0d7f98d9a662e9e3b47d6f7d6e2c8797d1e6572b`
- candidate: `094d41d71b1695e8154e096d0d6acdfa0c4b495b`
- candidate tree: `182b009df7a9bef2473b02f7897843a380f2f6b7`
- retained patch SHA-256: `3e286986b780f3b05f33f92b6703afb90d0ec5f0de160048ba96c74a9c6b7c92`
- regression covers both surfaces; omitted/null preserve defaults, positive values round-trip, and zero, negative, and signed-overflow values are refused without mutation
- rebased over live `dev`; first expanded-test lint exposed only `clang-format`, repaired exactly in the candidate's second commit
- exact-current AWS L4 focused selector: pass, 60 assertions / 1 test case; CI artifact SHA-256 `1b06f075a134d15a936de87b72df007ebd19b03bbfb1b26b88e7fafa4e80f0f9`; test binary SHA-256 `43d211718ec41a04aa52b7cb5989a127acdfa6234d90dd0954ccaaf595c1ed6f`
- exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full runtime, and terminal aggregate checks pass
- hosted workflow [31694165577](https://github.com/sirius-db/sirius/actions/runs/31694165577): runtime job `94428753529` passed in 20m02s; aggregate job `94451076969` passed

The signed temporary parse closes unsigned-wraparound ambiguity before assigning the existing `size_t` destinations. The patch changes no default and makes no performance recommendation.
