### PR TITLE
docs(config): define footer probe opt-out

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -334,7 +334,7 @@ and transport use one trust policy; there are no separate REST YAML controls.
 | `max_auth_retry_attempts` | int | 3 | Retry attempts for HTTP 403 (expired presigned URL). Kept low so a genuine AccessDenied fails fast. |
 | `honor_retry_after` | bool | true | Respect the server's `Retry-After` header. |
 | `perf_instrumentation` | bool | false | Record per-chunk micro-timings (chunk_get, queue_wait, ttfb, h2d) into perf counters. |
-| `footer_probe_bytes` | bytes | 512Ki | Suffix-range window for the parquet footer probe. Must cover the footer, so err large. |
+| `footer_probe_bytes` | bytes (**>= 0**) | 512Ki | Suffix-range window for the parquet footer probe. Zero disables the suffix GET and uses HEAD; positive values should cover the footer, so err large. |
 | `list_max_matches` | int | 100000 | Cap on files a glob/listing may accumulate (throws "narrow the glob prefix", never truncates). |
 | `list_max_scanned` | int | 1000000 | Cap on objects a LIST sweep may scan across pages (throws, never truncates). |
 

--- a/src/include/io/rest/config.hpp
+++ b/src/include/io/rest/config.hpp
@@ -101,7 +101,8 @@ struct config {
   /// one-time bind transfer (~10 ms on a high-bandwidth link).  The 512 KiB
   /// default covers files up to ~1.4 GB in one GET (the common range); raise it
   /// for multi-GB single files, lower it for many-tiny-file / low-bandwidth
-  /// workloads.
+  /// workloads.  Zero explicitly disables the suffix probe and uses the
+  /// ordinary HEAD-plus-read path.
   std::size_t footer_probe_bytes{512UL << 10};  // 512 KiB
 
   /// S3 LIST / glob safety caps (both throw "narrow the glob prefix", never

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -977,6 +977,8 @@ footer_probe rest_reactor::fetch_footer_suffix(std::string_view bucket,
                                                std::size_t n)
 {
   footer_probe probe;
+  // Zero is the explicit opt-out: issue no suffix GET and let the caller use
+  // the ordinary HEAD-plus-read path.
   if (n == 0) { return probe; }
 
   s3::s3_object_ref const obj{std::string(bucket), std::string(key)};

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -288,7 +288,7 @@ TEST_CASE("sirius_config parses rest perf instrumentation flag",
 TEST_CASE("sirius_config preserves the zero footer-probe opt-out",
           "[scan_manager][config][s3][rest][footerbind]")
 {
-  auto const path = std::filesystem::temp_directory_path() / "sirius_rest_footer_probe.yaml";
+  auto const path  = std::filesystem::temp_directory_path() / "sirius_rest_footer_probe.yaml";
   auto write_value = [&](std::string const& value) {
     write_yaml(path,
                "sirius:\n"

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -285,6 +285,40 @@ TEST_CASE("sirius_config parses rest perf instrumentation flag",
   std::filesystem::remove(path, ec);
 }
 
+TEST_CASE("sirius_config preserves the zero footer-probe opt-out",
+          "[scan_manager][config][s3][rest][footerbind]")
+{
+  auto const path = std::filesystem::temp_directory_path() / "sirius_rest_footer_probe.yaml";
+  auto write_value = [&](std::string const& value) {
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n"
+               "      rest:\n"
+               "        footer_probe_bytes: " +
+                 value + "\n");
+  };
+
+  sirius::sirius_config cfg;
+  write_value("256KiB");
+  REQUIRE_NOTHROW(cfg.load_from_file(path));
+  REQUIRE(cfg.get_scan_manager_config().rest.footer_probe_bytes == 256UL * 1024);
+
+  write_value("0");
+  REQUIRE_NOTHROW(cfg.load_from_file(path));
+  CHECK(cfg.get_scan_manager_config().rest.footer_probe_bytes == 0);
+
+  for (auto const* invalid : {"-1", "-1KiB"}) {
+    CAPTURE(invalid);
+    write_value(invalid);
+    REQUIRE_THROWS_WITH(cfg.load_from_file(path), Catch::Contains("rest.footer_probe_bytes"));
+    CHECK(cfg.get_scan_manager_config().rest.footer_probe_bytes == 0);
+  }
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
 TEST_CASE("sirius_config rejects unknown rest config keys", "[scan_manager][config][rest]")
 {
   auto const path = std::filesystem::temp_directory_path() / "sirius_rest_unknown_key.yaml";

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -1548,6 +1548,32 @@ TEST_CASE("footer probe open uses the configured suffix window",
   auto const footer_len = static_cast<std::size_t>(parquet_footer_len(parquet));
   auto const footer_off = parquet.size() - 8 - footer_len;
 
+  SECTION("zero disables the suffix GET and keeps ordinary reads correct")
+  {
+    range_http_server server(parquet);
+    auto cfg               = direct_rest_test_config();
+    cfg.footer_probe_bytes = 0;
+    auto ioctx             = make_direct_rest_ioctx(server.endpoint(), cfg);
+    auto datasource        = ioctx->open_datasource("s3://footer-bucket/nation.parquet",
+                                             sirius::io::open_hint::parquet_footer_probe);
+    auto const* rest_object =
+      dynamic_cast<sirius::io::rest::rest_io_object const*>(&datasource->io_object());
+
+    REQUIRE(rest_object != nullptr);
+    CHECK(datasource->size() == parquet.size());
+    CHECK(rest_object->stash() == nullptr);
+    CHECK(server.head_count() == 1);
+    CHECK(server.get_count() == 0);
+
+    std::array<std::uint8_t, 8> trailer{};
+    REQUIRE(datasource->host_read(
+              parquet.size() - trailer.size(), trailer.size(), trailer.data()) == trailer.size());
+    require_bytes_equal(trailer,
+                        std::span<std::uint8_t const>(parquet.data() + parquet.size() - 8, 8));
+    CHECK(server.head_count() == 1);
+    CHECK(server.get_count() == 1);
+  }
+
   SECTION("tiny configured window misses the footer body and re-GETs it")
   {
     std::size_t constexpr suffix_bytes = 8;


### PR DESCRIPTION
## Summary

- document `scan_manager.rest.footer_probe_bytes: 0` as the supported suffix-probe opt-out
- lock the existing no-suffix-GET / HEAD fallback behavior end to end
- verify negative bare and suffixed inputs fail without mutating the selected zero policy

## Why

Zero already has a coherent implementation: `fetch_footer_suffix` returns before constructing a `Range: bytes=-N` request; the caller performs HEAD and creates a stashless object; later reads use ordinary GETs. This is useful deployment policy for many tiny files or constrained links, but it was undocumented. The smallest configuration improvement is to name and test the existing escape hatch, not reject it.

## Validation

- config selector: 12 assertions, pass on exact candidate
- REST footer integration selector: 61 assertions, pass on exact candidate
- config test covers positive seed, zero readback, `-1`/`-1KiB` field-scoped refusal, and zero preservation
- REST integration proves zero emits one HEAD and no GET at open; a trailer read is oracle-correct and emits the first GET
- hosted lint, GCC release, and Clang debug checks: pass
- `git diff --check`: pass
- exact base: `0d7f98d9a662e9e3b47d6f7d6e2c8797d1e6572b`
- candidate: `3b0fa1c1ab5c106bf1818c7be2a78c9c11a1270d`
- tree: `ea1128def00a55fd1fbeae50a1d35d735a025521`
- zero-context patch SHA-256: `a045d2a11ff66afc9abff0739e7e01225c3e77a7d1f938d7e32e79fb02443642`

Independent review is clear. The initial lint run found one clang-format spacing edit; the current candidate applies that exact formatter repair.

- exact-head hosted receipt for `3b0fa1c1ab5c106bf1818c7be2a78c9c11a1270d`: CUDA 13 runtime and terminal aggregate checks passed
- hosted workflow 31695219911: runtime job 94432177546 passed from 2026-08-13T12:23:09Z through 2026-08-13T12:42:37Z; aggregate job 94450935549 passed at 2026-08-13T12:42:47Z