### PR TITLE
fix(config): define IO configuration contracts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,6 +632,7 @@ set(TEST_SOURCES
     test/cpp/compression/test_compression.cpp
     test/cpp/config/test_config.cpp
     test/cpp/config/test_context.cpp
+    test/cpp/config/test_local_io_config.cpp
     test/cpp/config/test_object_store_config.cpp
     test/cpp/config/test_topology_config.cpp
     test/cpp/data/test_convertible_data_batch.cpp

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Running TPC-H on 1TB data, Sirius accelerates DuckDB by 5x on DGX Station (GB300
 - NVIDIA Turing or newer, with compute capability 7.5+.
 - CUDA 13.x (driver 580.65.06 or newer) or CUDA 12.x (driver 525.60.13 or newer).
 - `io_uring` enabled at runtime (`CONFIG_IO_URING`, `kernel.io_uring_disabled=0` recommended). Containers must allow `io_uring_setup`, `io_uring_enter`, and `io_uring_register`.
-- Local Parquet files should be on a filesystem/block device that supports direct I/O (`O_DIRECT`).
+- Local Parquet files should be on a filesystem/block device that supports direct I/O (`O_DIRECT`). This remains a requirement when `scan_manager.local.use_odirect` is `false`, because the local backend still opens an `O_DIRECT` handle even though requests use the buffered handle.
 
 ### Build Requirements
 

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -328,8 +328,8 @@ single-GPU configurations only (logs a warning and disables itself otherwise).
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `use_odirect` | bool | true | Use `O_DIRECT` for local-disk reads. |
-| `max_n_chunks` | int | 1 | Max contiguous file segments fused into one vectored read. |
+| `use_odirect` | bool | true | Prefer `O_DIRECT` for compatible local-disk reads; `false` forces buffered reads but does not waive the backend's `O_DIRECT` filesystem requirement because both handles are still opened. |
+| `max_n_chunks` | int (**> 0**) | 1 | Max contiguous file segments fused into one vectored read; zero is rejected because every request contains at least one segment. |
 
 ### `scan_manager.rest` — REST / S3 backend (`io/rest/config.hpp`)
 
@@ -342,7 +342,7 @@ and transport use one trust policy; there are no separate REST YAML controls.
 | `request_timeout_s` | int (seconds) | 30 | Whole-request timeout and presigned-URL TTL (0 = no limit). |
 | `max_connections` | int | 16 | Max concurrent in-flight connections per reactor. |
 | `chunk_size` | bytes | 8Mi | Target bytes per ranged GET (scatter/device-staging paths). |
-| `max_n_chunks` | int | 16 | Max file-adjacent segments fused into one scatter GET. |
+| `max_n_chunks` | int (**> 0**) | 16 | Max file-adjacent segments fused into one scatter GET; zero is rejected because every request contains at least one segment. |
 | `max_read_split` | int | 16 | Max parallel ranged GETs for one contiguous host read (reads < 2 MiB stay a single GET). |
 | `upkeep_interval_ms` | int (ms) | 15000 | Idle-connection keepalive interval (`curl_easy_upkeep`; 0 disables). |
 | `conn_max_age_s` | int (seconds) | 20 | Max age curl may reuse a pooled connection (`CURLOPT_MAXAGE_CONN`; 0 = curl default). |
@@ -352,7 +352,7 @@ and transport use one trust policy; there are no separate REST YAML controls.
 | `max_auth_retry_attempts` | int | 3 | Retry attempts for HTTP 403 (expired presigned URL). Kept low so a genuine AccessDenied fails fast. |
 | `honor_retry_after` | bool | true | Respect the server's `Retry-After` header. |
 | `perf_instrumentation` | bool | false | Record per-chunk micro-timings (chunk_get, queue_wait, ttfb, h2d) into perf counters. |
-| `footer_probe_bytes` | bytes | 512Ki | Suffix-range window for the parquet footer probe. Must cover the footer, so err large. |
+| `footer_probe_bytes` | bytes (**>= 0**) | 512Ki | Suffix-range window for the parquet footer probe. Zero disables the suffix GET and uses HEAD; positive values should cover the footer, so err large. |
 | `list_max_matches` | int | 100000 | Cap on files a glob/listing may accumulate (throws "narrow the glob prefix", never truncates). |
 | `list_max_scanned` | int | 1000000 | Cap on objects a LIST sweep may scan across pages (throws, never truncates). |
 

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -339,7 +339,7 @@ and transport use one trust policy; there are no separate REST YAML controls.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `request_timeout_s` | int (seconds) | 30 | Whole-request timeout and presigned-URL TTL (0 = no limit). |
+| `request_timeout_s` | int (seconds, **>= 0**) | 30 | Whole-request curl deadline (0 = no limit) and presigned-URL TTL input (60-second signing headroom, 300-second fallback at zero, capped at S3's seven-day maximum); negative values are rejected. |
 | `max_connections` | int | 16 | Max concurrent in-flight connections per reactor. |
 | `chunk_size` | bytes | 8Mi | Target bytes per ranged GET (scatter/device-staging paths). |
 | `max_n_chunks` | int (**> 0**) | 16 | Max file-adjacent segments fused into one scatter GET; zero is rejected because every request contains at least one segment. |

--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -430,7 +430,7 @@ Both authorizers use path-style URLs and support temporary credentials. The sess
 
 **Configuration.** `object_store_config` supplies the endpoint, region, static credentials, optional session token, signing mode, and TLS settings. The built-in factory does not search environment variables, AWS profiles, or IMDS. A custom authorizer can implement those sources. If the endpoint, region, or static keys are missing, the factory returns no REST ioctx and the S3 read fails.
 
-Connection limits, request sizing, footer-probe size, retry budgets, keepalive, and LIST caps live in `rest::config`; the defaults are defined in `io/rest/config.hpp`. `request_timeout_s` is also used as the lifetime of a presigned URL. Async data requests retry transient curl and HTTP failures, with a separate bounded retry for HTTP 403. Control requests treat HTTP 403 as terminal.
+Connection limits, request sizing, footer-probe size, retry budgets, keepalive, and LIST caps live in `rest::config`; the defaults are defined in `io/rest/config.hpp`. `request_timeout_s` also informs the presigned-URL lifetime, with signing headroom and S3's seven-day cap applied separately. Async data requests retry transient curl and HTTP failures, with a separate bounded retry for HTTP 403. Control requests treat HTTP 403 as terminal.
 
 `rest_ioctx::perf_snapshot()` reports aggregate request, retry, byte, queue-wait, and H2D metrics across its reactors. Detailed timing is enabled with `perf_instrumentation`.
 

--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -467,7 +467,7 @@ Separately from the prefetching cache, the ioctx always exposes a `metadata_stor
 | chunk size | `buffer_pool::chunk_size()` (FSMR block size) | Cache / bounce chunk granularity; sourced from the pinned `fixed_size_host_memory_resource`'s block size rather than a compile-time constant. |
 | `inflight_io_chunk_budget` (2048) | `io/cache/config.hpp` | In-flight prefetch IO budget, in chunks, enforced by `admission_control`. |
 | `eviction_threshold_fraction` / `min_prefetching_budget_fraction` | `io/cache/config.hpp` | When the pool starts evicting and the floor reserved for prefetching. |
-| `bounce_size` / `max_n_chunks` / `use_odirect` | `io/uring/config.hpp` | Per-reactor uring tunables: bounce-slot size, max contiguous segments fused into one `readv`, and the buffered-vs-`O_DIRECT` toggle. |
+| `bounce_size` / `max_n_chunks` / `use_odirect` | `io/uring/config.hpp` | Per-reactor uring tunables: bounce-slot size, max contiguous segments fused into one `readv`, and the request-mode selector (`false` forces buffered reads, but the backend still opens both buffered and `O_DIRECT` handles). |
 | `chunk_size` / `max_read_split` / `max_connections` / retry policy | `io/rest/config.hpp` | Per-reactor REST tunables (see [S3 / Object-Store Backend](#s3--object-store-backend)). |
 
 ## Complete Scan Flow

--- a/src/include/io/rest/config.hpp
+++ b/src/include/io/rest/config.hpp
@@ -101,7 +101,8 @@ struct config {
   /// one-time bind transfer (~10 ms on a high-bandwidth link).  The 512 KiB
   /// default covers files up to ~1.4 GB in one GET (the common range); raise it
   /// for multi-GB single files, lower it for many-tiny-file / low-bandwidth
-  /// workloads.
+  /// workloads.  Zero explicitly disables the suffix probe and uses the
+  /// ordinary HEAD-plus-read path.
   std::size_t footer_probe_bytes{512UL << 10};  // 512 KiB
 
   /// S3 LIST / glob safety caps (both throw "narrow the glob prefix", never

--- a/src/include/io/rest/config.hpp
+++ b/src/include/io/rest/config.hpp
@@ -24,7 +24,9 @@
 namespace sirius::io::rest {
 
 struct config {
-  /// Whole-request timeout (seconds, 0 = no limit) and presigned-URL TTL.
+  /// Whole-request curl deadline (seconds, 0 = no limit). Also informs the
+  /// presigned-URL TTL with 60 seconds of headroom; zero uses a 300-second
+  /// fallback and positive values are capped at S3's seven-day maximum.
   long request_timeout_s{30};
 
   /// TLS: optional CA bundle path; when @c tls_verify is false, peer/host

--- a/src/include/io/rest/curl_handle.hpp
+++ b/src/include/io/rest/curl_handle.hpp
@@ -225,10 +225,11 @@ class global_curl_context {
  *
  * Sets HTTP/2, the shared DNS/TLS/cookie (and optionally connection) cache, TCP
  * tuning (NODELAY, keepalive), @c NOSIGNAL (required for multithreaded use),
- * receive buffer size, connect/transfer timeouts, disabled redirect following
+ * receive buffer size, connect timeout, disabled redirect following
  * (presigned URLs cannot survive a redirect — see the .cpp), connection
  * max-age, DNS cache timeout, and the @c curl_easy_upkeep interval.
- * Per-request options (URL, Range, write/header callbacks, TLS verification)
+ * Per-request options (URL, Range, write/header callbacks, TLS verification,
+ * whole-transfer timeout)
  * are set by the reactor at submit time.
  *
  * @param handle            the easy handle to configure.

--- a/src/include/io/uring/config.hpp
+++ b/src/include/io/uring/config.hpp
@@ -22,9 +22,12 @@ namespace sirius::io::uring {
 
 struct config {
   std::size_t bounce_size{1UL << 20};
-  /// When false, every prep path except the BYO-device-buffer read
-  /// (prep_device_rx_request) reads through the buffered (page-cache) file
-  /// handle instead of the O_DIRECT one.  Defaults to O_DIRECT.
+  /// Select the file handle used by local read requests.  When true, aligned
+  /// requests use the O_DIRECT handle and incompatible requests fall back to
+  /// the buffered (page-cache) handle; false forces every request through the
+  /// buffered handle.  This is a request-mode switch, not a deployment-mode
+  /// switch: create_io_object still opens both handles, so the filesystem must
+  /// support O_DIRECT in either mode.  Defaults to true.
   bool use_odirect{true};
 
   // max number of contiguous segments to fuse into one readv SQE.  The

--- a/src/io/rest/curl_handle.cpp
+++ b/src/io/rest/curl_handle.cpp
@@ -26,7 +26,6 @@ namespace {
 // 16 KiB to cut write-callback round trips on multi-MiB ranged GETs.
 constexpr long kRecvBufferSize     = 128L * 1024L;
 constexpr long kConnectTimeoutMs   = 5'000L;
-constexpr long kTransferTimeoutMs  = 30'000L;
 constexpr long kDnsCacheTimeoutSec = 600L;
 
 // curl_global_init must run exactly once per process, before any handle is
@@ -130,10 +129,10 @@ void configure_easy_handle(CURL* handle,
   SIRIUS_CURL_CHECK(curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 0L));
   SIRIUS_CURL_CHECK(curl_easy_setopt(handle, CURLOPT_BUFFERSIZE, kRecvBufferSize));
 
-  // Default timeouts; the reactor may override the whole-transfer timeout per
-  // request based on its configuration.
+  // Connection establishment has a fixed safety timeout. The reactor applies
+  // the configured whole-transfer timeout to every request, including zero to
+  // clear the deadline.
   SIRIUS_CURL_CHECK(curl_easy_setopt(handle, CURLOPT_CONNECTTIMEOUT_MS, kConnectTimeoutMs));
-  SIRIUS_CURL_CHECK(curl_easy_setopt(handle, CURLOPT_TIMEOUT_MS, kTransferTimeoutMs));
 
   // Minimum gap between curl_easy_upkeep PINGs per connection (the reactor
   // drives the actual upkeep calls on an idle timer).

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -977,6 +977,8 @@ footer_probe rest_reactor::fetch_footer_suffix(std::string_view bucket,
                                                std::size_t n)
 {
   footer_probe probe;
+  // Zero is the explicit opt-out: issue no suffix GET and let the caller use
+  // the ordinary HEAD-plus-read path.
   if (n == 0) { return probe; }
 
   s3::s3_object_ref const obj{std::string(bucket), std::string(key)};

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -266,7 +266,13 @@ bool is_retriable_curl(CURLcode rc) noexcept
 /// window.
 std::chrono::seconds presign_ttl(const config& cfg) noexcept
 {
-  long const base = cfg.request_timeout_s > 0 ? cfg.request_timeout_s + 60 : 300;
+  constexpr long kFallbackSec      = 300;
+  constexpr long kHeadroomSec      = 60;
+  constexpr long kMaxPresignTtlSec = 7 * 24 * 60 * 60;
+  constexpr long kMaxBaseSec       = kMaxPresignTtlSec - kHeadroomSec;
+  long const base                  = cfg.request_timeout_s > 0
+                                       ? std::min(cfg.request_timeout_s, kMaxBaseSec) + kHeadroomSec
+                                       : kFallbackSec;
   return std::chrono::seconds{base};
 }
 
@@ -280,9 +286,9 @@ void apply_request_opts(CURL* h, const config& cfg)
     SIRIUS_CURL_CHECK(curl_easy_setopt(h, CURLOPT_SSL_VERIFYPEER, 0L));
     SIRIUS_CURL_CHECK(curl_easy_setopt(h, CURLOPT_SSL_VERIFYHOST, 0L));
   }
-  if (cfg.request_timeout_s > 0) {
-    SIRIUS_CURL_CHECK(curl_easy_setopt(h, CURLOPT_TIMEOUT, cfg.request_timeout_s));
-  }
+  // libcurl defines zero as no whole-transfer deadline. Apply it explicitly so
+  // a reused handle cannot retain an earlier positive timeout.
+  SIRIUS_CURL_CHECK(curl_easy_setopt(h, CURLOPT_TIMEOUT, cfg.request_timeout_s));
 }
 
 /// Build a header list from the authorizer's headers (empty in presigned mode)

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -183,7 +183,10 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
   r.optional("request_timeout_s", opt.request_timeout_s);
   r.optional("max_connections", opt.max_connections);
   r.optional("chunk_size", yaml::bytes(opt.chunk_size));
-  r.optional("max_n_chunks", opt.max_n_chunks);
+  auto const has_max_n_chunks = r.has_value("max_n_chunks");
+  long long max_n_chunks      = 1;
+  r.optional("max_n_chunks", max_n_chunks, yaml::greater_than<long long>{0});
+  if (has_max_n_chunks) { opt.max_n_chunks = static_cast<std::size_t>(max_n_chunks); }
   r.optional("max_read_split", opt.max_read_split);
   r.optional("upkeep_interval_ms", opt.upkeep_interval);
   r.optional("conn_max_age_s", opt.conn_max_age);
@@ -203,7 +206,10 @@ static void from_yaml(const YAML::Node& node, sirius::io::uring::config& opt)
 {
   yaml::reader r(node, "local");
   r.optional("use_odirect", opt.use_odirect);
-  r.optional("max_n_chunks", opt.max_n_chunks);
+  auto const has_max_n_chunks = r.has_value("max_n_chunks");
+  long long max_n_chunks      = 1;
+  r.optional("max_n_chunks", max_n_chunks, yaml::greater_than<long long>{0});
+  if (has_max_n_chunks) { opt.max_n_chunks = static_cast<std::size_t>(max_n_chunks); }
   r.reject_unknown();
 }
 

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -180,7 +180,7 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
                                key + "' instead");
     }
   }
-  r.optional("request_timeout_s", opt.request_timeout_s);
+  r.optional("request_timeout_s", opt.request_timeout_s, yaml::greater_than<long>{-1});
   r.optional("max_connections", opt.max_connections);
   r.optional("chunk_size", yaml::bytes(opt.chunk_size));
   auto const has_max_n_chunks = r.has_value("max_n_chunks");

--- a/test/cpp/config/test_local_io_config.cpp
+++ b/test/cpp/config/test_local_io_config.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "sirius_config.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace {
+
+struct scoped_yaml {
+  scoped_yaml(std::string const& name, bool use_odirect)
+    : path(std::filesystem::temp_directory_path() / name)
+  {
+    std::ofstream out(path);
+    out << "sirius:\n"
+           "  executor:\n"
+           "    scan_manager:\n"
+           "      local:\n"
+           "        use_odirect: "
+        << (use_odirect ? "true\n" : "false\n");
+    REQUIRE(out);
+  }
+
+  ~scoped_yaml()
+  {
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+  }
+
+  scoped_yaml(scoped_yaml const&)            = delete;
+  scoped_yaml& operator=(scoped_yaml const&) = delete;
+
+  std::filesystem::path path;
+};
+
+}  // namespace
+
+TEST_CASE("sirius_config preserves explicit local use_odirect modes",
+          "[scan_manager][config][local]")
+{
+  for (bool const expected : {false, true}) {
+    INFO("use_odirect=" << std::boolalpha << expected);
+    scoped_yaml yaml(expected ? "sirius_use_odirect_true.yaml" : "sirius_use_odirect_false.yaml",
+                     expected);
+
+    sirius::sirius_config cfg;
+    REQUIRE_NOTHROW(cfg.load_from_file(yaml.path));
+    CHECK(cfg.get_scan_manager_config().local.use_odirect == expected);
+  }
+}

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -285,6 +285,43 @@ TEST_CASE("sirius_config parses rest perf instrumentation flag",
   std::filesystem::remove(path, ec);
 }
 
+TEST_CASE("sirius_config rejects negative REST request timeouts", "[scan_manager][config][rest]")
+{
+  auto const path = std::filesystem::temp_directory_path() / "sirius_rest_request_timeout.yaml";
+
+  SECTION("zero keeps the documented unlimited timeout")
+  {
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n"
+               "      rest:\n"
+               "        request_timeout_s: 0\n");
+
+    sirius::sirius_config cfg;
+    REQUIRE_NOTHROW(cfg.load_from_file(path));
+    CHECK(cfg.get_scan_manager_config().rest.request_timeout_s == 0);
+  }
+
+  SECTION("negative values do not silently disable the timeout")
+  {
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n"
+               "      rest:\n"
+               "        request_timeout_s: -1\n");
+
+    sirius::sirius_config cfg;
+    REQUIRE_THROWS_WITH(cfg.load_from_file(path),
+                        Catch::Contains("'rest.request_timeout_s': value out of range"));
+    CHECK(cfg.get_scan_manager_config().rest.request_timeout_s == 30);
+  }
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
 TEST_CASE("sirius_config preserves the zero footer-probe opt-out",
           "[scan_manager][config][s3][rest][footerbind]")
 {

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -285,6 +285,40 @@ TEST_CASE("sirius_config parses rest perf instrumentation flag",
   std::filesystem::remove(path, ec);
 }
 
+TEST_CASE("sirius_config preserves the zero footer-probe opt-out",
+          "[scan_manager][config][s3][rest][footerbind]")
+{
+  auto const path  = std::filesystem::temp_directory_path() / "sirius_rest_footer_probe.yaml";
+  auto write_value = [&](std::string const& value) {
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n"
+               "      rest:\n"
+               "        footer_probe_bytes: " +
+                 value + "\n");
+  };
+
+  sirius::sirius_config cfg;
+  write_value("256KiB");
+  REQUIRE_NOTHROW(cfg.load_from_file(path));
+  REQUIRE(cfg.get_scan_manager_config().rest.footer_probe_bytes == 256UL * 1024);
+
+  write_value("0");
+  REQUIRE_NOTHROW(cfg.load_from_file(path));
+  CHECK(cfg.get_scan_manager_config().rest.footer_probe_bytes == 0);
+
+  for (auto const* invalid : {"-1", "-1KiB"}) {
+    CAPTURE(invalid);
+    write_value(invalid);
+    REQUIRE_THROWS_WITH(cfg.load_from_file(path), Catch::Contains("rest.footer_probe_bytes"));
+    CHECK(cfg.get_scan_manager_config().rest.footer_probe_bytes == 0);
+  }
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
 TEST_CASE("sirius_config rejects unknown rest config keys", "[scan_manager][config][rest]")
 {
   auto const path = std::filesystem::temp_directory_path() / "sirius_rest_unknown_key.yaml";
@@ -368,4 +402,61 @@ TEST_CASE("sirius_config keeps REST bounce sizing internal", "[scan_manager][con
 
   std::error_code ec;
   std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("sirius_config rejects zero fused-chunk limits", "[scan_manager][config]")
+{
+  auto read_value = [](sirius::sirius_config const& cfg, std::string const& surface) {
+    return surface == "rest" ? cfg.get_scan_manager_config().rest.max_n_chunks
+                             : cfg.get_scan_manager_config().local.max_n_chunks;
+  };
+  auto write_value =
+    [](std::filesystem::path const& path, std::string const& surface, std::string const& value) {
+      auto const body = value == "<omitted>" ? "      " + surface + ": {}\n"
+                                             : "      " + surface +
+                                                 ":\n"
+                                                 "        max_n_chunks: " +
+                                                 value + "\n";
+      write_yaml(path,
+                 "sirius:\n"
+                 "  executor:\n"
+                 "    scan_manager:\n" +
+                   body);
+    };
+  auto check_surface = [&](std::string const& surface, std::size_t expected_default) {
+    auto const path =
+      std::filesystem::temp_directory_path() / ("sirius_zero_" + surface + "_max_n_chunks.yaml");
+
+    for (auto const* value : {"<omitted>", "null"}) {
+      write_value(path, surface, value);
+      sirius::sirius_config cfg;
+      REQUIRE_NOTHROW(cfg.load_from_file(path));
+      CHECK(read_value(cfg, surface) == expected_default);
+    }
+
+    for (auto const* value : {"1", "7"}) {
+      write_value(path, surface, value);
+      sirius::sirius_config cfg;
+      REQUIRE_NOTHROW(cfg.load_from_file(path));
+      CHECK(read_value(cfg, surface) == static_cast<std::size_t>(std::stoull(value)));
+    }
+
+    for (auto const* invalid : {"0", "-1", "9223372036854775808"}) {
+      CAPTURE(surface, invalid);
+      sirius::sirius_config cfg;
+      write_value(path, surface, "7");
+      REQUIRE_NOTHROW(cfg.load_from_file(path));
+      REQUIRE(read_value(cfg, surface) == 7);
+
+      write_value(path, surface, invalid);
+      REQUIRE_THROWS_WITH(cfg.load_from_file(path), Catch::Contains(surface + ".max_n_chunks"));
+      CHECK(read_value(cfg, surface) == 7);
+    }
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+  };
+
+  SECTION("REST scatter GET") { check_surface("rest", 16); }
+  SECTION("local vectored read") { check_surface("local", 1); }
 }

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -57,6 +57,7 @@
 #include <fstream>
 #include <future>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -283,8 +284,9 @@ class fixed_url_authorizer final : public sirius::io::s3::s3_request_authorizer 
 
   sirius::io::s3::s3_authorized_request authorize(sirius::io::s3::s3_object_ref const& obj,
                                                   sirius::io::s3::s3_request_method /*method*/,
-                                                  std::chrono::seconds /*timeout*/) override
+                                                  std::chrono::seconds timeout) override
   {
+    _last_timeout_sec.store(timeout.count(), std::memory_order_relaxed);
     return {_endpoint + "/" + obj.bucket + "/" + obj.key, {}};
   }
 
@@ -295,8 +297,14 @@ class fixed_url_authorizer final : public sirius::io::s3::s3_request_authorizer 
     return {_endpoint + "/" + std::string{bucket} + "?" + std::string{canonical_query}, {}};
   }
 
+  [[nodiscard]] std::chrono::seconds last_timeout() const noexcept
+  {
+    return std::chrono::seconds{_last_timeout_sec.load(std::memory_order_relaxed)};
+  }
+
  private:
   std::string _endpoint;
+  std::atomic<std::chrono::seconds::rep> _last_timeout_sec{0};
 };
 
 class range_http_server {
@@ -2346,6 +2354,72 @@ TEST_CASE("rest_ioctx retries transient fake-server failures and reports termina
     std::array<std::uint8_t, 128> got{};
     CHECK_THROWS(datasource->host_read(0, got.size(), got.data()));
     CHECK(server.get_count() >= 2);
+  }
+}
+
+TEST_CASE("rest_ioctx applies the configured whole-request timeout",
+          "[s3][integration][rest][timeout]")
+{
+  auto payload = deterministic_payload(64 * 1024);
+
+  SECTION("a positive timeout aborts a slower response")
+  {
+    range_fault_policy fault{};
+    fault.response_delay = 1500ms;
+    range_http_server server(payload, fault);
+    auto cfg               = direct_rest_test_config();
+    cfg.request_timeout_s  = 1;
+    cfg.max_retry_attempts = 1;
+    auto ioctx             = make_direct_rest_ioctx(server.endpoint(), cfg);
+    auto datasource        = ioctx->open_datasource("s3://timeout-bucket/object.bin",
+                                             static_cast<std::uint64_t>(payload.size()));
+    std::array<std::uint8_t, 128> got{};
+    auto const started = std::chrono::steady_clock::now();
+    CHECK_THROWS(datasource->host_read(0, got.size(), got.data()));
+    auto const elapsed = std::chrono::steady_clock::now() - started;
+    CHECK(elapsed < fault.response_delay);
+    CHECK(server.peak_active_gets() == 1);
+  }
+
+  SECTION("zero clears the whole-transfer deadline")
+  {
+    range_fault_policy fault{};
+    fault.response_delay = 1200ms;
+    range_http_server server(payload, fault);
+    auto cfg               = direct_rest_test_config();
+    cfg.request_timeout_s  = 0;
+    cfg.max_retry_attempts = 1;
+    auto ioctx             = make_direct_rest_ioctx(server.endpoint(), cfg);
+    auto datasource        = ioctx->open_datasource("s3://timeout-bucket/object.bin",
+                                             static_cast<std::uint64_t>(payload.size()));
+    std::array<std::uint8_t, 128> got{};
+    REQUIRE(datasource->host_read(0, got.size(), got.data()) == got.size());
+    require_bytes_equal(got, std::span<std::uint8_t const>(payload.data(), got.size()));
+  }
+}
+
+TEST_CASE("rest_reactor bounds the presigned URL lifetime", "[s3][integration][rest][timeout]")
+{
+  auto payload = deterministic_payload(64 * 1024);
+  range_http_server server(payload);
+
+  for (auto const [configured, expected] :
+       {std::pair{0L, 300L},
+        std::pair{1L, 61L},
+        std::pair{std::numeric_limits<long>::max(), 7L * 24 * 60 * 60}}) {
+    CAPTURE(configured, expected);
+    auto authorizer        = std::make_shared<fixed_url_authorizer>(server.endpoint());
+    auto cfg               = direct_rest_test_config();
+    cfg.request_timeout_s  = configured;
+    cfg.max_retry_attempts = 1;
+    auto ctx =
+      std::make_shared<sirius::io::rest::rest_reactor::reactor_context>(cfg, authorizer, nullptr);
+    sirius::io::rest::rest_reactor reactor(ctx, "presign-ttl-test");
+    reactor.start();
+
+    auto const head = reactor.head_object_size("timeout-bucket", "object.bin");
+    CHECK(head.object_size == payload.size());
+    CHECK(authorizer->last_timeout() == std::chrono::seconds{expected});
   }
 }
 

--- a/test/cpp/io/rest/test_rest_ioctx_integration.cpp
+++ b/test/cpp/io/rest/test_rest_ioctx_integration.cpp
@@ -1548,6 +1548,32 @@ TEST_CASE("footer probe open uses the configured suffix window",
   auto const footer_len = static_cast<std::size_t>(parquet_footer_len(parquet));
   auto const footer_off = parquet.size() - 8 - footer_len;
 
+  SECTION("zero disables the suffix GET and keeps ordinary reads correct")
+  {
+    range_http_server server(parquet);
+    auto cfg               = direct_rest_test_config();
+    cfg.footer_probe_bytes = 0;
+    auto ioctx             = make_direct_rest_ioctx(server.endpoint(), cfg);
+    auto datasource        = ioctx->open_datasource("s3://footer-bucket/nation.parquet",
+                                             sirius::io::open_hint::parquet_footer_probe);
+    auto const* rest_object =
+      dynamic_cast<sirius::io::rest::rest_io_object const*>(&datasource->io_object());
+
+    REQUIRE(rest_object != nullptr);
+    CHECK(datasource->size() == parquet.size());
+    CHECK(rest_object->stash() == nullptr);
+    CHECK(server.head_count() == 1);
+    CHECK(server.get_count() == 0);
+
+    std::array<std::uint8_t, 8> trailer{};
+    REQUIRE(datasource->host_read(
+              parquet.size() - trailer.size(), trailer.size(), trailer.data()) == trailer.size());
+    require_bytes_equal(trailer,
+                        std::span<std::uint8_t const>(parquet.data() + parquet.size() - 8, 8));
+    CHECK(server.head_count() == 1);
+    CHECK(server.get_count() == 1);
+  }
+
   SECTION("tiny configured window misses the footer body and re-GETs it")
   {
     std::size_t constexpr suffix_bytes = 8;


### PR DESCRIPTION
## Review question

Should `request_timeout_s: 0` explicitly disable libcurl's whole-transfer deadline while presigned URLs remain bounded (300-second fallback at zero, 60-second headroom for positive values, seven-day S3 maximum)? The previous implementation documented `0 = no limit` but silently retained a generic 30-second curl timeout.

This is judgment-bearing because removing that hidden deadline can permit an intentionally unlimited request to remain hung. Please push back if Sirius wants a bounded policy instead; negative values should still be rejected rather than acting as an undocumented alias.

## Summary

- reject zero REST and local `max_n_chunks` values that Sirius cannot honor
- define `footer_probe_bytes: 0` as the suffix-probe opt-out using HEAD plus ordinary reads
- define `use_odirect: false` as forced buffered reads without waiving the backend's current O_DIRECT-open requirement
- reject negative `request_timeout_s`
- make documented `request_timeout_s: 0` real by clearing libcurl's hidden 30-second transfer timeout
- add 60 seconds of signing headroom without overflow and cap SigV4 TTL at S3's seven-day maximum
- preserve every shipped default and positive curl deadline

## Why one PR

These settings define boundary values for the same REST and local IO surfaces. Zero selects an existing path for the footer probe and request deadline, but is incoherent for either chunk-count maximum. A negative request timeout previously followed the non-positive path silently. The hidden generic curl timeout also made the documented zero contract false.

This PR makes those existing contracts executable without choosing a new IO architecture or tuning value. It supersedes #1512 and retains the earlier #1513/#1514 IO-contract union.

## Contract

- omitted/null and positive chunk limits preserve current behavior
- zero, negative, and signed-overflow chunk limits fail without mutation
- zero footer probe emits no suffix GET and falls back to HEAD plus ordinary reads
- `use_odirect: false` selects buffered reads under the backend's current open requirements
- request timeout: omitted keeps 30 seconds, positive values remain curl deadlines, `0` clears the curl deadline, negatives fail without mutation
- signing TTL: zero maps to 300 seconds; positive values receive 60 seconds of headroom and saturate at 604800 seconds

## Current identity

- exact base: `3e4d98cfb760c716540b8d4955a9de37d5acfa53`
- exact head: `7ca3768e5a4ce206d7efd60954e2da12afd8edfb`
- base tree: `32f681ebd0ad17bbd942988dfc57e010c46412a2`
- candidate tree: `afa777945c89e95bb68290d444fe770ceea4332a`
- zero-context source-diff SHA-256: `c8f2f479237e5990d65a8a527b9fa5db26de9cd2afca9a5722eba7b0271c525d`
- cumulative diff: 13 paths, 342 insertions, 27 deletions
- clean two-commit rebase onto current `dev`

## Validation

- focused YAML regression: zero accepted/read back, negative rejected without mutating the 30-second default, positive 11 preserved
- focused fake-server regression: a 1-second deadline aborts a 1.5-second response; zero permits a slower response to complete
- focused signing regression: `0 -> 300`, `1 -> 61`, and `LONG_MAX -> 604800`
- retained IO boundary tests cover null/omitted/positive/zero/negative/overflow chunk counts, footer opt-out, buffered reads, and path selection
- `git diff --check` passes at the exact head
- exact-head hosted validation is terminal green: Check workflow `31923497755`, Test workflow `31923497904`, and Distribution workflow `31923498178` passed their applicable gates

Earlier hosted receipts belong only to predecessor heads and are not execution evidence for this candidate. Internal review superseded `81659f1c` after finding the hidden 30-second curl deadline, superseded `cbbf01a2` after finding the SigV4 seven-day boundary, and superseded `b272a5ad` after hosted lint supplied the repo-pinned clang-format diff.

## Bounded follow-up

The shared `sigv4::presign_url` primitive still accepts caller-provided TTLs above seven days. This PR keeps every REST-reactor call valid; hardening the shared primitive is deliberately left as a separate mechanical patch.

