### PR TITLE
fix(config): reject negative REST durations

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -325,10 +325,10 @@ and transport use one trust policy; there are no separate REST YAML controls.
 | `chunk_size` | bytes | 8Mi | Target bytes per ranged GET (scatter/device-staging paths). |
 | `max_n_chunks` | int | 16 | Max file-adjacent segments fused into one scatter GET. |
 | `max_read_split` | int | 16 | Max parallel ranged GETs for one contiguous host read (reads < 2 MiB stay a single GET). |
-| `upkeep_interval_ms` | int (ms) | 15000 | Idle-connection keepalive interval (`curl_easy_upkeep`; 0 disables). |
-| `conn_max_age_s` | int (seconds) | 20 | Max age curl may reuse a pooled connection (`CURLOPT_MAXAGE_CONN`; 0 = curl default). |
-| `retry_backoff_base_ms` | int (ms) | 50 | Base backoff between retries. |
-| `retry_jitter_ms` | int (ms) | 50 | Random jitter added to retry backoff. |
+| `upkeep_interval_ms` | duration (**>= 0**) | 15s | Idle-connection keepalive interval (`curl_easy_upkeep`; 0 disables). Bare numbers are milliseconds; duration suffixes are accepted. |
+| `conn_max_age_s` | duration (**>= 0**) | 20s | Max age curl may reuse a pooled connection (`CURLOPT_MAXAGE_CONN`; 0 = curl default). Bare numbers are seconds; duration suffixes are accepted. |
+| `retry_backoff_base_ms` | duration (**>= 0**) | 50ms | Base backoff between retries. Bare numbers are milliseconds; duration suffixes are accepted. |
+| `retry_jitter_ms` | duration (**>= 0**) | 50ms | Random jitter added to retry backoff. Bare numbers are milliseconds; duration suffixes are accepted. |
 | `max_retry_attempts` | int | 10 | Retry attempts for transient errors. |
 | `max_auth_retry_attempts` | int | 3 | Retry attempts for HTTP 403 (expired presigned URL). Kept low so a genuine AccessDenied fails fast. |
 | `honor_retry_after` | bool | true | Respect the server's `Retry-After` header. |

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -184,10 +184,10 @@ static void from_yaml(const YAML::Node& node, sirius::io::rest::config& opt)
   r.optional("chunk_size", yaml::bytes(opt.chunk_size));
   r.optional("max_n_chunks", opt.max_n_chunks);
   r.optional("max_read_split", opt.max_read_split);
-  r.optional("upkeep_interval_ms", opt.upkeep_interval);
-  r.optional("conn_max_age_s", opt.conn_max_age);
-  r.optional("retry_backoff_base_ms", opt.retry_backoff_base);
-  r.optional("retry_jitter_ms", opt.retry_jitter);
+  r.optional("upkeep_interval_ms", yaml::non_negative_duration(opt.upkeep_interval));
+  r.optional("conn_max_age_s", yaml::non_negative_duration(opt.conn_max_age));
+  r.optional("retry_backoff_base_ms", yaml::non_negative_duration(opt.retry_backoff_base));
+  r.optional("retry_jitter_ms", yaml::non_negative_duration(opt.retry_jitter));
   r.optional("max_retry_attempts", opt.max_retry_attempts);
   r.optional("max_auth_retry_attempts", opt.max_auth_retry_attempts);
   r.optional("honor_retry_after", opt.honor_retry_after);

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -19,9 +19,13 @@
 #include "io/rest/config.hpp"
 #include "sirius_config.hpp"
 
+#include <array>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <string_view>
+#include <utility>
 
 using sirius::io::enum_to_string;
 using sirius::io::object_store_config;
@@ -349,6 +353,96 @@ TEST_CASE("sirius_config still loads unrelated REST YAML fields",
 
   std::error_code ec;
   std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("sirius_config rejects negative REST durations and preserves zero",
+          "[scan_manager][config][rest]")
+{
+  using namespace std::chrono_literals;
+
+  struct duration_field {
+    const char* name;
+    std::chrono::milliseconds default_value;
+    std::chrono::milliseconds bare_seven;
+    const char* negative_native;
+    const char* negative_subresolution;
+  };
+  constexpr std::array fields{
+    duration_field{"upkeep_interval_ms", 15s, 7ms, "-1ms", "-1us"},
+    duration_field{"conn_max_age_s", 20s, 7s, "-1s", "-1ms"},
+    duration_field{"retry_backoff_base_ms", 50ms, 7ms, "-1ms", "-1us"},
+    duration_field{"retry_jitter_ms", 50ms, 7ms, "-1ms", "-1us"},
+  };
+
+  auto read_value = [](sirius::sirius_config const& cfg,
+                       std::string_view name) -> std::chrono::milliseconds {
+    auto const& rest = cfg.get_scan_manager_config().rest;
+    if (name == "upkeep_interval_ms") { return rest.upkeep_interval; }
+    if (name == "conn_max_age_s") {
+      return std::chrono::duration_cast<std::chrono::milliseconds>(rest.conn_max_age);
+    }
+    if (name == "retry_backoff_base_ms") { return rest.retry_backoff_base; }
+    return rest.retry_jitter;
+  };
+
+  auto write_value =
+    [](std::filesystem::path const& path, std::string_view name, std::string_view value) {
+      std::string body =
+        "sirius:\n"
+        "  executor:\n"
+        "    scan_manager:\n"
+        "      rest:";
+      if (value == "<omitted>") {
+        body += " {}\n";
+      } else {
+        body += "\n        " + std::string(name) + ": " + std::string(value) + "\n";
+      }
+      write_yaml(path, body);
+    };
+
+  for (auto const& field : fields) {
+    INFO("field=" << field.name);
+    auto const path = std::filesystem::temp_directory_path() /
+                      ("sirius_rest_duration_" + std::string(field.name) + ".yaml");
+
+    for (auto const* value : {"<omitted>", "null"}) {
+      INFO("value=" << value);
+      write_value(path, field.name, value);
+      sirius::sirius_config cfg;
+      REQUIRE_NOTHROW(cfg.load_from_file(path));
+      CHECK(read_value(cfg, field.name) == field.default_value);
+    }
+
+    for (auto const& [value, expected] :
+         std::array<std::pair<const char*, std::chrono::milliseconds>, 3>{
+           std::pair{"0", 0ms},
+           std::pair{"7", field.bare_seven},
+           std::pair{"\"2s\"", 2s},
+         }) {
+      INFO("value=" << value);
+      write_value(path, field.name, value);
+      sirius::sirius_config cfg;
+      REQUIRE_NOTHROW(cfg.load_from_file(path));
+      CHECK(read_value(cfg, field.name) == expected);
+    }
+
+    sirius::sirius_config cfg;
+    write_value(path, field.name, "7");
+    REQUIRE_NOTHROW(cfg.load_from_file(path));
+    REQUIRE(read_value(cfg, field.name) == field.bare_seven);
+
+    for (auto const* value : {"-1", field.negative_native, field.negative_subresolution}) {
+      INFO("value=" << value);
+      write_value(path, field.name, value);
+      REQUIRE_THROWS_WITH(cfg.load_from_file(path),
+                          Catch::Contains("rest." + std::string(field.name)) &&
+                            Catch::Contains("duration must be non-negative"));
+      CHECK(read_value(cfg, field.name) == field.bare_seven);
+    }
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+  }
 }
 
 TEST_CASE("sirius_config keeps REST bounce sizing internal", "[scan_manager][config][rest]")


### PR DESCRIPTION
## Summary

- reject negative `upkeep_interval_ms`, `conn_max_age_s`, `retry_backoff_base_ms`, and `retry_jitter_ms` values before duration-resolution conversion
- preserve each field's intentional zero behavior
- document bare-number units and supported duration suffixes
- cover omitted/null defaults, zero, bare and suffixed positives, and negative refusal without mutation

## Why

All four values currently accept negative bare and suffixed YAML values. Those values silently collapse into zero-like runtime behavior: upkeep and connection-age controls are skipped by `> 0` guards, negative jitter disables jitter, and negative backoff makes retries immediately due rather than backing off.

This branch was intentionally stacked on predecessor #1508, whose `yaml::non_negative_duration` wrapper is now consolidated in #1529. That wrapper checks the sign before converting to the target resolution, so a value such as `-1us` cannot truncate to `0ms` and evade validation. The merge diff after #1508 is limited to the four REST consumers, documentation, and focused tests.

## Semantics retained

- upkeep `0`: disable upkeep
- connection max age `0`: use curl's default
- retry base `0`: no fixed backoff
- retry jitter `0`: no random jitter

## Validation

- focused selector: 108 assertions, pass on exact candidate
- historical dependency/base: #1508 head `c4b48153af995b38db002d3bc137b45991ce001a`; current dependency owner: #1529
- candidate: `66d965f2d6f129e5a13f5ed1ed301ec56f9d80ba`
- tree: `dc9afdf895b9568e251c747ed8effdce0d7d4bf8`
- clang-format 20.1.4, codespell, whitespace, EOF, orphan-test, and `git diff --check`: pass
- fresh exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, distribution, check, PR-title, full runtime, and terminal aggregate checks pass on the exact stacked head
- test workflow `31696230243` passed; runtime job `94435359145` ran from `2026-08-13T12:43:15Z` through `2026-08-13T13:03:15Z` (20m00s), including C++ unit tests and the TPC-H snapshot; terminal aggregate job `94456486837` passed

The exact stacked candidate is execution-complete. It remains dependent on that duration wrapper and must rebase onto #1529 or its merge after upstream #1340 lands; this receipt does not imply standalone merge readiness against `dev`.

## Residual

This patch validates the lower bound only. It does not claim to fix the generic duration parser's out-of-range positive suffixed conversion or bound exponential backoff/jitter arithmetic; those require a separate upper-bound contract.

