### PR TITLE
fix(config): validate logging controls

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -508,7 +508,7 @@ Registered in `src/sirius_extension.cpp`. These can be changed at runtime:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `sirius_log_backend` | `spdlog` | Log sink: `spdlog`, `duckdb`, or `noop` |
-| `sirius_log_level` | `info` | Log level: trace, debug, info, warn, error (`spdlog` only) |
+| `sirius_log_level` | `info` | Log level: trace, debug, info, warn, error, critical, off (`spdlog` only) |
 | `sirius_log_dir` | `log` | Log output directory (`spdlog` only) |
 | `sirius_log_flush_seconds` | 3 | Log flush interval in seconds (`spdlog` only) |
 

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -510,7 +510,7 @@ Registered in `src/sirius_extension.cpp`. These can be changed at runtime:
 | `sirius_log_backend` | `spdlog` | Log sink: `spdlog`, `duckdb`, or `noop` |
 | `sirius_log_level` | `info` | Log level: trace, debug, info, warn, error, critical, off (`spdlog` only) |
 | `sirius_log_dir` | `log` | Log output directory (`spdlog` only) |
-| `sirius_log_flush_seconds` | 3 | Log flush interval in seconds (`spdlog` only) |
+| `sirius_log_flush_seconds` | 3 | Log flush interval in seconds; 0 disables periodic flushing and negative values are rejected (`spdlog` only) |
 
 - **`spdlog`** (default): writes the daily-rotated `<sirius_log_dir>/sirius.log`, honouring
   `sirius_log_level` and `sirius_log_flush_seconds`.

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -1586,9 +1586,17 @@ void install_configured_log_sink(DatabaseInstance* db)
 
 SiriusContextExtensionCallback::SiriusContextExtensionCallback()
 {
-  if (auto* env = std::getenv("SIRIUS_LOG_BACKEND")) { Config::LOG_BACKEND = env; }
-  if (auto* env = std::getenv("SIRIUS_LOG_DIR")) { Config::LOG_DIR = env; }
-  if (auto* env = std::getenv("SIRIUS_LOG_LEVEL")) { Config::LOG_LEVEL = env; }
+  auto* backend_env = std::getenv("SIRIUS_LOG_BACKEND");
+  auto* log_dir_env = std::getenv("SIRIUS_LOG_DIR");
+  auto* level_env   = std::getenv("SIRIUS_LOG_LEVEL");
+  if (level_env && !sirius::log::string_to_enum(level_env)) {
+    throw InvalidInputException(
+      "SIRIUS_LOG_LEVEL must be one of: trace, debug, info, warn, error, critical, off; got '%s'",
+      level_env);
+  }
+  if (backend_env) { Config::LOG_BACKEND = backend_env; }
+  if (log_dir_env) { Config::LOG_DIR = log_dir_env; }
+  if (level_env) { Config::LOG_LEVEL = level_env; }
   // Install now (no db yet) so spdlog/noop capture the logs emitted by
   // read_config_file_if_exists() below; the duckdb backend needs a db (installed
   // later).

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1959,7 +1959,13 @@ static void SetLogDir(ClientContext& context, SetScope scope, Value& parameter)
 static void SetLogFlushSeconds(ClientContext& context, SetScope scope, Value& parameter)
 {
   throw_if_sirius_runtime_unavailable(context);
-  Config::LOG_FLUSH_SECONDS = IntegerValue::Get(parameter);
+  auto const seconds = IntegerValue::Get(parameter);
+  if (seconds < 0) {
+    throw InvalidInputException(
+      "sirius_log_flush_seconds must be non-negative; zero disables periodic flushing; got %d",
+      seconds);
+  }
+  Config::LOG_FLUSH_SECONDS = seconds;
   // The flush interval is fixed at spdlog-sink construction, so rebuild it (only
   // the spdlog backend uses it).
   if (Config::LOG_BACKEND == "spdlog") { install_configured_log_sink(context.db.get()); }
@@ -2297,7 +2303,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             Value(Config::LOG_DIR),
                             SetLogDir);
   config.AddExtensionOption("sirius_log_flush_seconds",
-                            "Interval in seconds between automatic log flushes",
+                            "Interval in seconds between automatic log flushes (0 disables)",
                             LogicalType::INTEGER,
                             Value::INTEGER(Config::LOG_FLUSH_SECONDS),
                             SetLogFlushSeconds);

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1934,13 +1934,16 @@ static void SetLogBackend(ClientContext& context, SetScope scope, Value& paramet
 static void SetLogLevel(ClientContext& context, SetScope scope, Value& parameter)
 {
   throw_if_sirius_runtime_unavailable(context);
-  Config::LOG_LEVEL = StringValue::Get(parameter);
-  // Only re-targets the current sink; no rebuild (a no-op for the duckdb backend).
-  auto parsed_level = sirius::log::string_to_enum(Config::LOG_LEVEL);
-  sirius::log::get_sink()->set_level(parsed_level.value_or(sirius::log::level::info));
+  auto level_name   = StringValue::Get(parameter);
+  auto parsed_level = sirius::log::string_to_enum(level_name);
   if (!parsed_level) {
-    SIRIUS_LOG_WARN("Unknown log level '{}', defaulting to info", Config::LOG_LEVEL);
+    throw InvalidInputException(
+      "sirius_log_level must be one of: trace, debug, info, warn, error, critical, off; got '%s'",
+      level_name);
   }
+  Config::LOG_LEVEL = std::move(level_name);
+  // Only re-targets the current sink; no rebuild (a no-op for the duckdb backend).
+  sirius::log::get_sink()->set_level(*parsed_level);
   SIRIUS_LOG_DEBUG("Updated config LOG_LEVEL to {}", Config::LOG_LEVEL);
 }
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -704,9 +704,10 @@ TEST_CASE("DuckDB setting rejects unknown Sirius log levels without mutation",
   auto invalid = con.Query("SET sirius_log_level = 'verbose'");
   REQUIRE(invalid != nullptr);
   REQUIRE(invalid->HasError());
-  REQUIRE_THAT(invalid->GetError(),
-               Catch::Contains(
-                 "sirius_log_level must be one of: trace, debug, info, warn, error, critical, off"));
+  REQUIRE_THAT(
+    invalid->GetError(),
+    Catch::Contains(
+      "sirius_log_level must be one of: trace, debug, info, warn, error, critical, off"));
 
   auto after_invalid = con.Query("SELECT current_setting('sirius_log_level')::VARCHAR");
   REQUIRE(after_invalid != nullptr);

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -15,7 +15,9 @@
  */
 
 #include "catch.hpp"
+#include "log/level.hpp"
 #include "sirius_context.hpp"
+#include "utils/log_test_utils.hpp"
 
 #include <cudf/contiguous_split.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -677,6 +679,55 @@ TEST_CASE("DuckDB setting rejects negative byte values without mutation",
   REQUIRE(after != nullptr);
   REQUIRE_FALSE(after->HasError());
   REQUIRE(after->GetValue(0, 0).GetValue<uint64_t>() == expected);
+}
+
+TEST_CASE("DuckDB setting rejects unknown Sirius log levels without mutation",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  sirius::test::scoped_recording_log_sink scoped_sink;
+  auto const previous_level = duckdb::Config::LOG_LEVEL;
+  finally restore_level{[&]() { duckdb::Config::LOG_LEVEL = previous_level; }};
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto warn = con.Query("SET sirius_log_level = 'warn'");
+  REQUIRE(warn != nullptr);
+  REQUIRE_FALSE(warn->HasError());
+  REQUIRE(duckdb::Config::LOG_LEVEL == "warn");
+  REQUIRE_FALSE(scoped_sink.sink().should_log(sirius::log::level::info));
+  REQUIRE(scoped_sink.sink().should_log(sirius::log::level::warn));
+
+  auto invalid = con.Query("SET sirius_log_level = 'verbose'");
+  REQUIRE(invalid != nullptr);
+  REQUIRE(invalid->HasError());
+  REQUIRE_THAT(invalid->GetError(),
+               Catch::Contains(
+                 "sirius_log_level must be one of: trace, debug, info, warn, error, critical, off"));
+
+  auto after_invalid = con.Query("SELECT current_setting('sirius_log_level')::VARCHAR");
+  REQUIRE(after_invalid != nullptr);
+  REQUIRE_FALSE(after_invalid->HasError());
+  REQUIRE(after_invalid->GetValue(0, 0).GetValue<std::string>() == "warn");
+  REQUIRE(duckdb::Config::LOG_LEVEL == "warn");
+  REQUIRE_FALSE(scoped_sink.sink().should_log(sirius::log::level::info));
+  REQUIRE(scoped_sink.sink().should_log(sirius::log::level::warn));
+
+  auto critical = con.Query("SET sirius_log_level = 'critical'");
+  REQUIRE(critical != nullptr);
+  REQUIRE_FALSE(critical->HasError());
+  REQUIRE(duckdb::Config::LOG_LEVEL == "critical");
+  REQUIRE_FALSE(scoped_sink.sink().should_log(sirius::log::level::error));
+  REQUIRE(scoped_sink.sink().should_log(sirius::log::level::critical));
+
+  auto off = con.Query("SET sirius_log_level = 'off'");
+  REQUIRE(off != nullptr);
+  REQUIRE_FALSE(off->HasError());
+  REQUIRE(duckdb::Config::LOG_LEVEL == "off");
+  REQUIRE_FALSE(scoped_sink.sink().should_log(sirius::log::level::critical));
 }
 
 TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -926,6 +926,50 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE(compression.max_compressed_fraction == Approx(0.6));
 }
 
+TEST_CASE("DuckDB setting rejects negative Sirius log flush intervals without mutation",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  auto const previous_seconds = duckdb::Config::LOG_FLUSH_SECONDS;
+  finally restore_seconds{[&]() {
+    duckdb::Config::LOG_FLUSH_SECONDS = previous_seconds;
+    duckdb::install_configured_log_sink(nullptr);
+  }};
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto positive = con.Query("SET sirius_log_flush_seconds = 7");
+  REQUIRE(positive != nullptr);
+  REQUIRE_FALSE(positive->HasError());
+  REQUIRE(duckdb::Config::LOG_FLUSH_SECONDS == 7);
+
+  auto negative = con.Query("SET sirius_log_flush_seconds = -1");
+  REQUIRE(negative != nullptr);
+  REQUIRE(negative->HasError());
+  REQUIRE_THAT(
+    negative->GetError(),
+    Catch::Contains("sirius_log_flush_seconds must be non-negative; zero disables"));
+
+  auto after_negative = con.Query("SELECT current_setting('sirius_log_flush_seconds')::INTEGER");
+  REQUIRE(after_negative != nullptr);
+  REQUIRE_FALSE(after_negative->HasError());
+  REQUIRE(after_negative->GetValue(0, 0).GetValue<int32_t>() == 7);
+  REQUIRE(duckdb::Config::LOG_FLUSH_SECONDS == 7);
+
+  auto disabled = con.Query("SET sirius_log_flush_seconds = 0");
+  REQUIRE(disabled != nullptr);
+  REQUIRE_FALSE(disabled->HasError());
+  REQUIRE(duckdb::Config::LOG_FLUSH_SECONDS == 0);
+
+  auto after_disabled = con.Query("SELECT current_setting('sirius_log_flush_seconds')::INTEGER");
+  REQUIRE(after_disabled != nullptr);
+  REQUIRE_FALSE(after_disabled->HasError());
+  REQUIRE(after_disabled->GetValue(0, 0).GetValue<int32_t>() == 0);
+}
+
 TEST_CASE("Sirius configuration loading from file with spaces",
           "[sirius][context][isolated_context]")
 {

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -731,6 +731,53 @@ TEST_CASE("DuckDB setting rejects unknown Sirius log levels without mutation",
   REQUIRE_FALSE(sirius::log::get_sink()->should_log(sirius::log::level::critical));
 }
 
+TEST_CASE("Sirius startup rejects unknown environment log levels before mutation",
+          "[sirius][context][config][isolated_context]")
+{
+  auto const previous_level   = duckdb::Config::LOG_LEVEL;
+  auto const previous_backend = duckdb::Config::LOG_BACKEND;
+  auto const previous_sink    = sirius::log::get_sink();
+  std::optional<std::string> previous_env_level;
+  std::optional<std::string> previous_env_backend;
+  if (auto const* value = std::getenv("SIRIUS_LOG_LEVEL")) { previous_env_level = value; }
+  if (auto const* value = std::getenv("SIRIUS_LOG_BACKEND")) { previous_env_backend = value; }
+  finally restore_logging{[&]() {
+    duckdb::Config::LOG_LEVEL   = previous_level;
+    duckdb::Config::LOG_BACKEND = previous_backend;
+    sirius::log::set_sink(previous_sink);
+    if (previous_env_level) {
+      setenv("SIRIUS_LOG_LEVEL", previous_env_level->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_LOG_LEVEL");
+    }
+    if (previous_env_backend) {
+      setenv("SIRIUS_LOG_BACKEND", previous_env_backend->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_LOG_BACKEND");
+    }
+    setenv("SIRIUS_DISABLE", "1", 1);
+  }};
+
+  setenv("SIRIUS_DISABLE", "1", 1);
+  setenv("SIRIUS_LOG_BACKEND", "noop", 1);
+  duckdb::Config::LOG_LEVEL = "warn";
+  setenv("SIRIUS_LOG_LEVEL", "verbose", 1);
+
+  REQUIRE_THROWS_WITH(
+    duckdb::SiriusContextExtensionCallback{},
+    Catch::Contains(
+      "SIRIUS_LOG_LEVEL must be one of: trace, debug, info, warn, error, critical, off; got "
+      "'verbose'"));
+  REQUIRE(duckdb::Config::LOG_LEVEL == "warn");
+  REQUIRE(duckdb::Config::LOG_BACKEND == previous_backend);
+
+  setenv("SIRIUS_LOG_LEVEL", "critical", 1);
+  duckdb::SiriusContextExtensionCallback valid_callback;
+  REQUIRE(duckdb::Config::LOG_LEVEL == "critical");
+  REQUIRE(duckdb::Config::LOG_BACKEND == "noop");
+  REQUIRE_FALSE(sirius::log::get_sink()->should_log(sirius::log::level::critical));
+}
+
 TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
           "[sirius][context][config][isolated_context]")
 {

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -698,8 +698,8 @@ TEST_CASE("DuckDB setting rejects unknown Sirius log levels without mutation",
   REQUIRE(warn != nullptr);
   REQUIRE_FALSE(warn->HasError());
   REQUIRE(duckdb::Config::LOG_LEVEL == "warn");
-  REQUIRE_FALSE(scoped_sink.sink().should_log(sirius::log::level::info));
-  REQUIRE(scoped_sink.sink().should_log(sirius::log::level::warn));
+  REQUIRE_FALSE(sirius::log::get_sink()->should_log(sirius::log::level::info));
+  REQUIRE(sirius::log::get_sink()->should_log(sirius::log::level::warn));
 
   auto invalid = con.Query("SET sirius_log_level = 'verbose'");
   REQUIRE(invalid != nullptr);
@@ -714,21 +714,21 @@ TEST_CASE("DuckDB setting rejects unknown Sirius log levels without mutation",
   REQUIRE_FALSE(after_invalid->HasError());
   REQUIRE(after_invalid->GetValue(0, 0).GetValue<std::string>() == "warn");
   REQUIRE(duckdb::Config::LOG_LEVEL == "warn");
-  REQUIRE_FALSE(scoped_sink.sink().should_log(sirius::log::level::info));
-  REQUIRE(scoped_sink.sink().should_log(sirius::log::level::warn));
+  REQUIRE_FALSE(sirius::log::get_sink()->should_log(sirius::log::level::info));
+  REQUIRE(sirius::log::get_sink()->should_log(sirius::log::level::warn));
 
   auto critical = con.Query("SET sirius_log_level = 'critical'");
   REQUIRE(critical != nullptr);
   REQUIRE_FALSE(critical->HasError());
   REQUIRE(duckdb::Config::LOG_LEVEL == "critical");
-  REQUIRE_FALSE(scoped_sink.sink().should_log(sirius::log::level::error));
-  REQUIRE(scoped_sink.sink().should_log(sirius::log::level::critical));
+  REQUIRE_FALSE(sirius::log::get_sink()->should_log(sirius::log::level::error));
+  REQUIRE(sirius::log::get_sink()->should_log(sirius::log::level::critical));
 
   auto off = con.Query("SET sirius_log_level = 'off'");
   REQUIRE(off != nullptr);
   REQUIRE_FALSE(off->HasError());
   REQUIRE(duckdb::Config::LOG_LEVEL == "off");
-  REQUIRE_FALSE(scoped_sink.sink().should_log(sirius::log::level::critical));
+  REQUIRE_FALSE(sirius::log::get_sink()->should_log(sirius::log::level::critical));
 }
 
 TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -949,9 +949,8 @@ TEST_CASE("DuckDB setting rejects negative Sirius log flush intervals without mu
   auto negative = con.Query("SET sirius_log_flush_seconds = -1");
   REQUIRE(negative != nullptr);
   REQUIRE(negative->HasError());
-  REQUIRE_THAT(
-    negative->GetError(),
-    Catch::Contains("sirius_log_flush_seconds must be non-negative; zero disables"));
+  REQUIRE_THAT(negative->GetError(),
+               Catch::Contains("sirius_log_flush_seconds must be non-negative; zero disables"));
 
   auto after_negative = con.Query("SELECT current_setting('sirius_log_flush_seconds')::INTEGER");
   REQUIRE(after_negative != nullptr);


### PR DESCRIPTION
## Summary

- reject unknown `sirius_log_level` and `SIRIUS_LOG_LEVEL` values before mutation
- document and accept the full supported level set, including `critical` and `off`
- reject negative `sirius_log_flush_seconds` while preserving `0` as the explicit periodic-flush opt-out
- consolidate the adjacent #1517 flush validation into one logging-controls review unit

## Contract

Runtime and startup log-level validation accept only `trace`, `debug`, `info`, `warn`, `error`, `critical`, or `off`. Rejected values leave the visible setting, process-global value, and active sink behavior unchanged. Flush intervals must be non-negative; `0` disables periodic flushing.

## Identity

- base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`
- head: `a3dfe9e218c816b834de81e75579d08e629a6eea`
- tree: `bc31566b7cd7dc89e5299c31898fdc48ef1db7cd`
- zero-context source-diff SHA-256: `01d7ead8d4a9592cd6646ff7f8cd10e97f244e88a20dbe9f1e23ad0180356665`

## Validation

- exact current-base four-file diff; no unrelated source changes
- `python3 scripts/check_orphan_tests.py` passes
- `git diff --check` passes
- focused runtime/startup and nonmutation regressions included
- hosted lint, GCC, Clang, CUDA 13 build/runtime are the compiled acceptance path

Supersedes #1517.

- exact-head hosted receipt for `a3dfe9e218c816b834de81e75579d08e629a6eea`: CUDA 13 runtime and terminal aggregate checks passed
- hosted workflow 31726952876: runtime job 94540138947 passed from 2026-08-13T18:10:42Z through 2026-08-13T18:31:05Z; aggregate job 94551660464 passed at 2026-08-13T18:31:12Z