### PR TITLE
fix(config): reject negative log flush intervals

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -510,7 +510,7 @@ Registered in `src/sirius_extension.cpp`. These can be changed at runtime:
 | `sirius_log_backend` | `spdlog` | Log sink: `spdlog`, `duckdb`, or `noop` |
 | `sirius_log_level` | `info` | Log level: trace, debug, info, warn, error (`spdlog` only) |
 | `sirius_log_dir` | `log` | Log output directory (`spdlog` only) |
-| `sirius_log_flush_seconds` | 3 | Log flush interval in seconds (`spdlog` only) |
+| `sirius_log_flush_seconds` | 3 | Log flush interval in seconds; 0 disables periodic flushing and negative values are rejected (`spdlog` only) |
 
 - **`spdlog`** (default): writes the daily-rotated `<sirius_log_dir>/sirius.log`, honouring
   `sirius_log_level` and `sirius_log_flush_seconds`.

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1956,7 +1956,13 @@ static void SetLogDir(ClientContext& context, SetScope scope, Value& parameter)
 static void SetLogFlushSeconds(ClientContext& context, SetScope scope, Value& parameter)
 {
   throw_if_sirius_runtime_unavailable(context);
-  Config::LOG_FLUSH_SECONDS = IntegerValue::Get(parameter);
+  auto const seconds = IntegerValue::Get(parameter);
+  if (seconds < 0) {
+    throw InvalidInputException(
+      "sirius_log_flush_seconds must be non-negative; zero disables periodic flushing; got %d",
+      seconds);
+  }
+  Config::LOG_FLUSH_SECONDS = seconds;
   // The flush interval is fixed at spdlog-sink construction, so rebuild it (only
   // the spdlog backend uses it).
   if (Config::LOG_BACKEND == "spdlog") { install_configured_log_sink(context.db.get()); }
@@ -2294,7 +2300,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             Value(Config::LOG_DIR),
                             SetLogDir);
   config.AddExtensionOption("sirius_log_flush_seconds",
-                            "Interval in seconds between automatic log flushes",
+                            "Interval in seconds between automatic log flushes (0 disables)",
                             LogicalType::INTEGER,
                             Value::INTEGER(Config::LOG_FLUSH_SECONDS),
                             SetLogFlushSeconds);

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -803,9 +803,8 @@ TEST_CASE("DuckDB setting rejects negative Sirius log flush intervals without mu
   auto negative = con.Query("SET sirius_log_flush_seconds = -1");
   REQUIRE(negative != nullptr);
   REQUIRE(negative->HasError());
-  REQUIRE_THAT(
-    negative->GetError(),
-    Catch::Contains("sirius_log_flush_seconds must be non-negative; zero disables"));
+  REQUIRE_THAT(negative->GetError(),
+               Catch::Contains("sirius_log_flush_seconds must be non-negative; zero disables"));
 
   auto after_negative = con.Query("SELECT current_setting('sirius_log_flush_seconds')::INTEGER");
   REQUIRE(after_negative != nullptr);

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -780,6 +780,50 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE(compression.max_compressed_fraction == Approx(0.6));
 }
 
+TEST_CASE("DuckDB setting rejects negative Sirius log flush intervals without mutation",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  auto const previous_seconds = duckdb::Config::LOG_FLUSH_SECONDS;
+  finally restore_seconds{[&]() {
+    duckdb::Config::LOG_FLUSH_SECONDS = previous_seconds;
+    duckdb::install_configured_log_sink(nullptr);
+  }};
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto positive = con.Query("SET sirius_log_flush_seconds = 7");
+  REQUIRE(positive != nullptr);
+  REQUIRE_FALSE(positive->HasError());
+  REQUIRE(duckdb::Config::LOG_FLUSH_SECONDS == 7);
+
+  auto negative = con.Query("SET sirius_log_flush_seconds = -1");
+  REQUIRE(negative != nullptr);
+  REQUIRE(negative->HasError());
+  REQUIRE_THAT(
+    negative->GetError(),
+    Catch::Contains("sirius_log_flush_seconds must be non-negative; zero disables"));
+
+  auto after_negative = con.Query("SELECT current_setting('sirius_log_flush_seconds')::INTEGER");
+  REQUIRE(after_negative != nullptr);
+  REQUIRE_FALSE(after_negative->HasError());
+  REQUIRE(after_negative->GetValue(0, 0).GetValue<int32_t>() == 7);
+  REQUIRE(duckdb::Config::LOG_FLUSH_SECONDS == 7);
+
+  auto disabled = con.Query("SET sirius_log_flush_seconds = 0");
+  REQUIRE(disabled != nullptr);
+  REQUIRE_FALSE(disabled->HasError());
+  REQUIRE(duckdb::Config::LOG_FLUSH_SECONDS == 0);
+
+  auto after_disabled = con.Query("SELECT current_setting('sirius_log_flush_seconds')::INTEGER");
+  REQUIRE(after_disabled != nullptr);
+  REQUIRE_FALSE(after_disabled->HasError());
+  REQUIRE(after_disabled->GetValue(0, 0).GetValue<int32_t>() == 0);
+}
+
 TEST_CASE("Sirius configuration loading from file with spaces",
           "[sirius][context][isolated_context]")
 {


### PR DESCRIPTION
## Summary

- reject negative `sirius_log_flush_seconds` before mutating process-global state or rebuilding the log sink
- preserve and document `0` as the explicit periodic-flush opt-out
- prove failed input preserves both DuckDB-visible and effective process-global state

## Why

The spdlog construction path treats every value at or below zero as disabled. Clean Sirius therefore accepts `-1` as a distinct visible setting while applying the documented-zero behavior. Rejecting negatives makes the setting literal without selecting a different default.

## Validation

- focused isolated-context regression covers positive setup, negative refusal/nonmutation, and zero acceptance
- `python3 scripts/check_orphan_tests.py`
- `git diff --check`
- live duplicate search: no open issue or PR for this setting
- independent merge-tree with current open PR #1516 is clean (`51b23b0c44cfea4349eb095d1f1f41697b555b13`)
- exact-head lint, GCC release, Clang debug, CUDA 13 build, full runtime, and terminal aggregate checks pass
- hosted workflow [31701205855](https://github.com/sirius-db/sirius/actions/runs/31701205855): runtime job `94451496486` passed in 19m24s; aggregate job `94456762457` passed

Exact base: `0d7f98d9a662e9e3b47d6f7d6e2c8797d1e6572b`
Candidate: `eff5220986b014cc117116d3a97aa0b058bfd369`
Candidate tree: `7ca08297201f34257df291cbf66e35fc8798ab7b`
