### PR TITLE
fix(config): validate and enforce CPU affinity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,6 +665,7 @@ set(TEST_SOURCES
     test/cpp/compression/test_compression.cpp
     test/cpp/config/test_config.cpp
     test/cpp/config/test_context.cpp
+    test/cpp/config/test_cpu_affinity_config.cpp
     test/cpp/config/test_object_store_config.cpp
     test/cpp/config/test_topology_config.cpp
     test/cpp/data/test_convertible_data_batch.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -680,6 +680,7 @@ set(TEST_SOURCES
     test/cpp/compression/test_compression.cpp
     test/cpp/config/test_config.cpp
     test/cpp/config/test_context.cpp
+    test/cpp/config/test_cpu_affinity_config.cpp
     test/cpp/config/test_object_store_config.cpp
     test/cpp/config/test_topology_config.cpp
     test/cpp/creator/test_task_creator_query_state.cpp

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -272,6 +272,13 @@ hardware-derived exception described below:
 | `num_threads` | int (**> 0**) | per pool (below) | Worker threads in the pool. |
 | `cpu_affinity` | list of int | — | Cores to pin task-creator and downgrade threads. GPU pipeline affinity is derived from the selected GPU's CPU topology. |
 
+For the task-creator, downgrade, and scan-manager pools, `cpu_affinity` is one shared eligibility
+mask applied to every worker; entries are Linux logical CPU IDs, not a one-core-per-worker
+assignment. The list must be a subset of the process's currently allowed CPUs, including
+cgroup/cpuset restrictions. An omitted or empty list inherits the process mask. Sirius rejects
+invalid, unavailable, or unapplied masks rather than silently running with a different affinity.
+GPU pipeline affinity is replaced at execution with the selected GPU's topology-derived CPU mask.
+
 ### `sirius.executor.task_creator`
 
 Thread pool (default `num_threads: 1`). Task creation

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -293,17 +293,31 @@ void task_creator::start_thread_pool()
   // a paired reactivate() here, subsequent schedule() pushes silently no-op
   // and the next query's manager_loop sees an empty/inactive queue forever.
   _task_creation_queue.reactivate();
-  _bounded_pool =
-    std::make_unique<exec::bounded_thread_pool>(_config.thread_pool.num_threads,
-                                                _config.thread_pool.thread_name_prefix,
-                                                _config.thread_pool.cpu_affinity_list);
-  _manager_thread = std::thread(&task_creator::manager_loop, this);
+  try {
+    _bounded_pool =
+      std::make_unique<exec::bounded_thread_pool>(_config.thread_pool.num_threads,
+                                                  _config.thread_pool.thread_name_prefix,
+                                                  _config.thread_pool.cpu_affinity_list);
+    _manager_thread = std::thread(&task_creator::manager_loop, this);
+  } catch (...) {
+    _running = false;
+    if (_bounded_pool) { _bounded_pool->interrupt(); }
+    _task_creation_queue.interrupt();
+    if (_manager_thread.joinable()) { _manager_thread.join(); }
+    if (_bounded_pool) {
+      _bounded_pool->wait_all();
+      _bounded_pool->stop();
+      _bounded_pool.reset();
+    }
+    throw;
+  }
 }
 
 void task_creator::do_stop_thread_pool()
 {
   bool expected = true;
   if (!_running.compare_exchange_strong(expected, false)) { return; }
+  if (!_bounded_pool) { return; }
   _bounded_pool->interrupt();
   _task_creation_queue.interrupt();
   if (_manager_thread.joinable()) { _manager_thread.join(); }

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -364,17 +364,31 @@ void task_creator::start_thread_pool()
   // a paired reactivate() here, subsequent schedule() pushes silently no-op
   // and the next query's manager_loop sees an empty/inactive queue forever.
   _task_creation_queue.reactivate();
-  _bounded_pool =
-    std::make_unique<exec::bounded_thread_pool>(_config.thread_pool.num_threads,
-                                                _config.thread_pool.thread_name_prefix,
-                                                _config.thread_pool.cpu_affinity_list);
-  _manager_thread = std::thread(&task_creator::manager_loop, this);
+  try {
+    _bounded_pool =
+      std::make_unique<exec::bounded_thread_pool>(_config.thread_pool.num_threads,
+                                                  _config.thread_pool.thread_name_prefix,
+                                                  _config.thread_pool.cpu_affinity_list);
+    _manager_thread = std::thread(&task_creator::manager_loop, this);
+  } catch (...) {
+    _running = false;
+    if (_bounded_pool) { _bounded_pool->interrupt(); }
+    _task_creation_queue.interrupt();
+    if (_manager_thread.joinable()) { _manager_thread.join(); }
+    if (_bounded_pool) {
+      _bounded_pool->wait_all();
+      _bounded_pool->stop();
+      _bounded_pool.reset();
+    }
+    throw;
+  }
 }
 
 void task_creator::do_stop_thread_pool()
 {
   bool expected = true;
   if (!_running.compare_exchange_strong(expected, false)) { return; }
+  if (!_bounded_pool) { return; }
   _bounded_pool->interrupt();
   _task_creation_queue.interrupt();
   if (_manager_thread.joinable()) { _manager_thread.join(); }

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -64,46 +64,62 @@ void downgrade_executor::start()
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
 
-  // HOST/DISK tier memory_spaces return device_id == -1; passing that to
-  // rmm::cuda_device_id or cudaSetDevice fails with cudaErrorInvalidDevice.
-  // Default the stream pool to GPU 0 for non-GPU tiers and skip per-thread
-  // CUDA binding entirely (the stream is ordering metadata; host/disk work
-  // is CPU-side).
-  {
-    int device_id = 0;
-    if (_space_id.tier == cucascade::memory::Tier::GPU && _memory_space) {
-      device_id = _memory_space->get_device_id();
-    }
-    _stream_pool = std::make_unique<cucascade::memory::exclusive_stream_pool>(
-      rmm::cuda_device_id{device_id}, _config.thread_pool.num_threads);
-  }
-
-  _request_queue.reactivate();
-
-  absl::AnyInvocable<void() noexcept> per_thread_init = nullptr;
-  if (_memory_space && _space_id.tier == cucascade::memory::Tier::GPU) {
-    auto device_id  = _memory_space->get_device_id();
-    per_thread_init = [device_id]() noexcept {
-      // Pin each worker to its GPU; silent failure leaks downgrade memcpys
-      // across contexts. Lambda is noexcept, so check inline.
-      cudaError_t err = cudaSetDevice(device_id);
-      if (err != cudaSuccess) {
-        SIRIUS_LOG_ERROR("downgrade_executor per-thread init: cudaSetDevice({}) failed: {}",
-                         device_id,
-                         cudaGetErrorString(err));
+  try {
+    // HOST/DISK tier memory_spaces return device_id == -1; passing that to
+    // rmm::cuda_device_id or cudaSetDevice fails with cudaErrorInvalidDevice.
+    // Default the stream pool to GPU 0 for non-GPU tiers and skip per-thread
+    // CUDA binding entirely (the stream is ordering metadata; host/disk work
+    // is CPU-side).
+    {
+      int device_id = 0;
+      if (_space_id.tier == cucascade::memory::Tier::GPU && _memory_space) {
+        device_id = _memory_space->get_device_id();
       }
-    };
-  }
+      _stream_pool = std::make_unique<cucascade::memory::exclusive_stream_pool>(
+        rmm::cuda_device_id{device_id}, _config.thread_pool.num_threads);
+    }
 
-  _pool = std::make_unique<exec::bounded_thread_pool>(_config.thread_pool.num_threads,
-                                                      _config.thread_pool.thread_name_prefix,
-                                                      _config.thread_pool.cpu_affinity_list,
-                                                      std::move(per_thread_init));
+    _request_queue.reactivate();
 
-  _processing_thread = std::thread(&downgrade_executor::processing_loop, this);
+    absl::AnyInvocable<void() noexcept> per_thread_init = nullptr;
+    if (_memory_space && _space_id.tier == cucascade::memory::Tier::GPU) {
+      auto device_id  = _memory_space->get_device_id();
+      per_thread_init = [device_id]() noexcept {
+        // Pin each worker to its GPU; silent failure leaks downgrade memcpys
+        // across contexts. Lambda is noexcept, so check inline.
+        cudaError_t err = cudaSetDevice(device_id);
+        if (err != cudaSuccess) {
+          SIRIUS_LOG_ERROR("downgrade_executor per-thread init: cudaSetDevice({}) failed: {}",
+                           device_id,
+                           cudaGetErrorString(err));
+        }
+      };
+    }
 
-  if (_memory_space && _config.monitor_period > std::chrono::milliseconds::zero()) {
-    _monitor_thread = std::thread(&downgrade_executor::monitor_loop, this);
+    _pool = std::make_unique<exec::bounded_thread_pool>(_config.thread_pool.num_threads,
+                                                        _config.thread_pool.thread_name_prefix,
+                                                        _config.thread_pool.cpu_affinity_list,
+                                                        std::move(per_thread_init));
+
+    _processing_thread = std::thread(&downgrade_executor::processing_loop, this);
+
+    if (_memory_space && _config.monitor_period > std::chrono::milliseconds::zero()) {
+      _monitor_thread = std::thread(&downgrade_executor::monitor_loop, this);
+    }
+  } catch (...) {
+    _running = false;
+    if (_pool) { _pool->interrupt(); }
+    _request_queue.interrupt();
+    _monitor_cv.notify_one();
+    if (_monitor_thread.joinable()) { _monitor_thread.join(); }
+    if (_processing_thread.joinable()) { _processing_thread.join(); }
+    if (_pool) {
+      _pool->wait_all();
+      _pool->stop();
+      _pool.reset();
+    }
+    _stream_pool.reset();
+    throw;
   }
 }
 
@@ -112,6 +128,10 @@ void downgrade_executor::stop()
   bool expected = true;
   if (!_running.compare_exchange_strong(expected, false)) { return; }
 
+  if (!_pool) {
+    _stream_pool.reset();
+    return;
+  }
   _pool->interrupt();
   _request_queue.interrupt();
   _monitor_cv.notify_one();

--- a/src/include/exec/bounded_thread_pool.hpp
+++ b/src/include/exec/bounded_thread_pool.hpp
@@ -16,12 +16,14 @@
 
 #pragma once
 
+#include "exec/cpu_affinity.hpp"
+#include "exec/thread_pool_startup.hpp"
 #include "log/logging.hpp"
 
 #include <absl/functional/any_invocable.h>
 
 #include <condition_variable>
-#include <latch>
+#include <exception>
 #include <mutex>
 #include <queue>
 #include <string>
@@ -96,37 +98,20 @@ class bounded_thread_pool {
                                absl::AnyInvocable<void() noexcept> per_thread_init = nullptr)
     : capacity_(capacity)
   {
+    validated_cpu_affinity const affinity(cpu_ids);
     threads_.reserve(capacity);
 
-    cpu_set_t cpuset;
-    CPU_ZERO(&cpuset);
-    for (int id : cpu_ids) {
-      CPU_SET(id, &cpuset);
-    }
-
-    std::unique_ptr<std::latch> init_latch;
-    if (per_thread_init) { init_latch = std::make_unique<std::latch>(capacity); }
-
     auto* init_fn_ptr = per_thread_init ? &per_thread_init : nullptr;
-    auto* latch_ptr   = init_latch.get();
-
-    for (int i = 0; i < capacity; ++i) {
-      auto& t = threads_.emplace_back([this, init_fn_ptr, latch_ptr]() {
-        if (init_fn_ptr) {
-          (*init_fn_ptr)();
-          latch_ptr->count_down();
-        }
-        work_loop();
-      });
-      if (!name.empty()) {
-        pthread_setname_np(t.native_handle(), (name + "_" + std::to_string(i)).c_str());
-      }
-      if (!cpu_ids.empty()) {
-        pthread_setaffinity_np(t.native_handle(), sizeof(cpu_set_t), &cpuset);
-      }
-    }
-
-    if (init_latch) { init_latch->wait(); }
+    detail::start_thread_pool_workers(
+      threads_,
+      capacity,
+      name,
+      [affinity, init_fn_ptr] {
+        affinity.apply_to_current_thread();
+        if (init_fn_ptr) { (*init_fn_ptr)(); }
+      },
+      [this] { work_loop(); },
+      [this] { request_stop(); });
   }
 
   ~bounded_thread_pool() { stop(); }
@@ -183,14 +168,7 @@ class bounded_thread_pool {
    */
   void stop() noexcept
   {
-    {
-      std::lock_guard lock(mu_);
-      if (stop_requested_) { return; }
-      stop_requested_ = true;
-      interrupted_    = true;
-      cv_capacity_.notify_all();
-      cv_work_.notify_all();
-    }
+    request_stop();
     for (auto& t : threads_) {
       if (t.joinable()) { t.join(); }
     }
@@ -225,6 +203,16 @@ class bounded_thread_pool {
   }
 
  private:
+  void request_stop() noexcept
+  {
+    std::lock_guard lock(mu_);
+    if (stop_requested_) { return; }
+    stop_requested_ = true;
+    interrupted_    = true;
+    cv_capacity_.notify_all();
+    cv_work_.notify_all();
+  }
+
   // Called exclusively by the slot destructor — covers both the drop-without-dispatch
   // and post-task-completion cases.
   void release_slot()

--- a/src/include/exec/config.hpp
+++ b/src/include/exec/config.hpp
@@ -31,6 +31,11 @@ inline constexpr int default_downgrade_num_threads    = 1;
 struct thread_pool_config {
   int num_threads{0};
   std::string thread_name_prefix{"thread"};
+
+  /// Linux logical CPU IDs forming one shared eligibility mask for every worker in the pool.
+  /// An empty list inherits the constructing thread's allowed mask. Non-empty lists must be a
+  /// subset of that mask (including cgroup/cpuset constraints); IDs are not assigned one per
+  /// worker.
   std::vector<int> cpu_affinity_list;
 };
 

--- a/src/include/exec/cpu_affinity.hpp
+++ b/src/include/exec/cpu_affinity.hpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <pthread.h>
+#include <sched.h>
+
+#include <cerrno>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace sirius::exec {
+
+/**
+ * A validated CPU eligibility mask shared by every worker in a thread pool.
+ *
+ * Validation is intentionally performed on the constructing thread before any
+ * workers are created. Linux workers inherit that thread's allowed mask, so a
+ * requested CPU outside it could otherwise be silently discarded by the
+ * kernel (for example under a cgroup/cpuset constraint).
+ */
+class validated_cpu_affinity {
+ public:
+  explicit validated_cpu_affinity(const std::vector<int>& cpu_ids) : enabled_(!cpu_ids.empty())
+  {
+    CPU_ZERO(&requested_);
+    if (!enabled_) { return; }
+
+    cpu_set_t allowed;
+    CPU_ZERO(&allowed);
+    if (sched_getaffinity(0, sizeof(cpu_set_t), &allowed) != 0) {
+      throw std::system_error(errno, std::generic_category(), "sched_getaffinity failed");
+    }
+
+    for (int cpu_id : cpu_ids) {
+      if (cpu_id < 0) {
+        throw std::invalid_argument("CPU affinity ID " + std::to_string(cpu_id) +
+                                    " must be non-negative");
+      }
+      if (cpu_id >= CPU_SETSIZE) {
+        throw std::invalid_argument("CPU affinity ID " + std::to_string(cpu_id) +
+                                    " must be less than CPU_SETSIZE (" +
+                                    std::to_string(CPU_SETSIZE) + ")");
+      }
+      if (!CPU_ISSET(cpu_id, &allowed)) {
+        throw std::invalid_argument("CPU affinity ID " + std::to_string(cpu_id) +
+                                    " is not in the current process allowed CPU mask");
+      }
+      CPU_SET(cpu_id, &requested_);
+    }
+  }
+
+  [[nodiscard]] bool enabled() const noexcept { return enabled_; }
+
+  /** Apply the validated mask to the calling worker and verify the kernel readback. */
+  void apply_to_current_thread() const
+  {
+    if (!enabled_) { return; }
+
+    int const set_result = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &requested_);
+    if (set_result != 0) {
+      throw std::system_error(set_result, std::generic_category(), "pthread_setaffinity_np failed");
+    }
+
+    cpu_set_t actual;
+    CPU_ZERO(&actual);
+    int const get_result = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &actual);
+    if (get_result != 0) {
+      throw std::system_error(get_result, std::generic_category(), "pthread_getaffinity_np failed");
+    }
+
+    for (int cpu_id = 0; cpu_id < CPU_SETSIZE; ++cpu_id) {
+      if (CPU_ISSET(cpu_id, &requested_) != CPU_ISSET(cpu_id, &actual)) {
+        throw std::runtime_error("CPU affinity readback does not match the requested mask");
+      }
+    }
+  }
+
+ private:
+  cpu_set_t requested_{};
+  bool enabled_{false};
+};
+
+/** YAML-reader validator backed by the same checks used by the pool constructors. */
+struct valid_cpu_affinity {
+  bool operator()(const std::vector<int>& cpu_ids) const
+  {
+    (void)validated_cpu_affinity(cpu_ids);
+    return true;
+  }
+};
+
+}  // namespace sirius::exec

--- a/src/include/exec/thread_pool.hpp
+++ b/src/include/exec/thread_pool.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "exec/cpu_affinity.hpp"
+#include "exec/thread_pool_startup.hpp"
 #include "log/logging.hpp"
 
 #include <absl/functional/any_invocable.h>
@@ -23,7 +25,6 @@
 #include <concepts>
 #include <condition_variable>
 #include <exception>
-#include <latch>
 #include <mutex>
 #include <queue>
 #include <string>
@@ -40,48 +41,26 @@ class static_thread_pool {
                               std::vector<int> cpu_ids                            = {},
                               absl::AnyInvocable<void() noexcept> per_thread_init = nullptr)
   {
+    validated_cpu_affinity const affinity(cpu_ids);
     threads_.reserve(num_threads);
 
-    cpu_set_t cpuset;
-    CPU_ZERO(&cpuset);
-    std::for_each(
-      cpu_ids.begin(), cpu_ids.end(), [&cpuset](int cpu_id) { CPU_SET(cpu_id, &cpuset); });
-
-    std::unique_ptr<std::latch> init_latch;
-    if (per_thread_init) { init_latch = std::make_unique<std::latch>(num_threads); }
-
     auto* init_fn_ptr = per_thread_init ? &per_thread_init : nullptr;
-    auto* latch_ptr   = init_latch.get();
-
-    for (int i = 0; i < num_threads; ++i) {
-      auto& t = threads_.emplace_back([this, init_fn_ptr, latch_ptr]() {
-        if (init_fn_ptr) {
-          (*init_fn_ptr)();
-          latch_ptr->count_down();
-        }
-        work_loop();
-      });
-      if (!name.empty()) {
-        pthread_setname_np(t.native_handle(), (name + "_" + std::to_string(i)).c_str());
-      }
-      if (!cpu_ids.empty()) {
-        pthread_setaffinity_np(t.native_handle(), sizeof(cpu_set_t), &cpuset);
-      }
-    }
-
-    if (init_latch) { init_latch->wait(); }
+    detail::start_thread_pool_workers(
+      threads_,
+      num_threads,
+      name,
+      [affinity, init_fn_ptr] {
+        affinity.apply_to_current_thread();
+        if (init_fn_ptr) { (*init_fn_ptr)(); }
+      },
+      [this] { work_loop(); },
+      [this] { stop(); });
   }
 
   static_thread_pool(const static_thread_pool&)            = delete;
   static_thread_pool& operator=(const static_thread_pool&) = delete;
 
-  ~static_thread_pool()
-  {
-    stop();
-    for (auto& t : threads_) {
-      if (t.joinable()) { t.join(); }
-    }
-  }
+  ~static_thread_pool() { stop_and_join(); }
 
   void schedule(std::invocable auto&& fn)
   {
@@ -113,6 +92,14 @@ class static_thread_pool {
   }
 
  private:
+  void stop_and_join() noexcept
+  {
+    stop();
+    for (auto& t : threads_) {
+      if (t.joinable()) { t.join(); }
+    }
+  }
+
   [[nodiscard]] bool has_work_or_stopped() const { return !queue_.empty() || stop_requested_; }
 
   void work_loop()

--- a/src/include/exec/thread_pool_startup.hpp
+++ b/src/include/exec/thread_pool_startup.hpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <pthread.h>
+
+#include <exception>
+#include <latch>
+#include <memory>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace sirius::exec::detail {
+
+/**
+ * Start a pool's workers and wait until every worker has completed its startup hook.
+ *
+ * If thread creation or any startup hook fails, all workers are stopped and joined
+ * before the exception is propagated. The startup hook is therefore the safe place
+ * to apply and verify CPU affinity before the pool constructor returns.
+ */
+template <typename StartupFn, typename WorkFn, typename RequestStopFn>
+void start_thread_pool_workers(std::vector<std::thread>& threads,
+                               int count,
+                               const std::string& name,
+                               StartupFn&& startup,
+                               WorkFn&& work,
+                               RequestStopFn&& request_stop)
+{
+  std::latch startup_latch(count);
+  std::vector<std::exception_ptr> startup_errors(count);
+  auto startup_fn = std::make_shared<std::decay_t<StartupFn>>(std::forward<StartupFn>(startup));
+  auto work_fn    = std::make_shared<std::decay_t<WorkFn>>(std::forward<WorkFn>(work));
+
+  auto join_workers = [&]() noexcept {
+    request_stop();
+    for (auto& thread : threads) {
+      if (thread.joinable()) { thread.join(); }
+    }
+  };
+
+  try {
+    for (int i = 0; i < count; ++i) {
+      auto& thread =
+        threads.emplace_back([startup_fn, work_fn, &startup_latch, &startup_errors, i] {
+          bool startup_ok = true;
+          try {
+            (*startup_fn)();
+          } catch (...) {
+            startup_errors[i] = std::current_exception();
+            startup_ok        = false;
+          }
+          // count_down() may release the constructor thread, which can then
+          // destroy startup_errors immediately on the success path. Snapshot
+          // this worker's result before count_down and never touch shared
+          // startup state afterward.
+          startup_latch.count_down();
+          if (startup_ok) { (*work_fn)(); }
+        });
+      if (!name.empty()) {
+        pthread_setname_np(thread.native_handle(), (name + "_" + std::to_string(i)).c_str());
+      }
+    }
+  } catch (...) {
+    join_workers();
+    throw;
+  }
+
+  startup_latch.wait();
+  for (auto const& error : startup_errors) {
+    if (error) {
+      join_workers();
+      std::rethrow_exception(error);
+    }
+  }
+}
+
+}  // namespace sirius::exec::detail

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -63,19 +63,33 @@ void itask_executor::start()
 {
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
-  _bounded_pool = std::make_unique<exec::bounded_thread_pool>(_config.num_threads,
-                                                              _config.thread_name_prefix,
-                                                              _config.cpu_affinity_list,
-                                                              get_per_thread_init());
-  _task_queue.reactivate();
-  _manager_thread = std::thread([this] { manager_loop(); });
-  on_start();
+  try {
+    _bounded_pool = std::make_unique<exec::bounded_thread_pool>(_config.num_threads,
+                                                                _config.thread_name_prefix,
+                                                                _config.cpu_affinity_list,
+                                                                get_per_thread_init());
+    _task_queue.reactivate();
+    _manager_thread = std::thread([this] { manager_loop(); });
+    on_start();
+  } catch (...) {
+    _running = false;
+    if (_bounded_pool) { _bounded_pool->interrupt(); }
+    _task_queue.interrupt();
+    if (_manager_thread.joinable()) { _manager_thread.join(); }
+    if (_bounded_pool) {
+      _bounded_pool->wait_all();
+      _bounded_pool->stop();
+      _bounded_pool.reset();
+    }
+    throw;
+  }
 }
 
 void itask_executor::stop()
 {
   bool expected = true;
   if (!_running.compare_exchange_strong(expected, false)) { return; }
+  if (!_bounded_pool) { return; }
   _bounded_pool->interrupt();
   _task_queue.interrupt();
   on_stop();

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -67,19 +67,33 @@ void itask_executor::start()
 {
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
-  _bounded_pool = std::make_unique<exec::bounded_thread_pool>(_config.num_threads,
-                                                              _config.thread_name_prefix,
-                                                              _config.cpu_affinity_list,
-                                                              get_per_thread_init());
-  _task_queue.reactivate();
-  _manager_thread = std::thread([this] { manager_loop(); });
-  on_start();
+  try {
+    _bounded_pool = std::make_unique<exec::bounded_thread_pool>(_config.num_threads,
+                                                                _config.thread_name_prefix,
+                                                                _config.cpu_affinity_list,
+                                                                get_per_thread_init());
+    _task_queue.reactivate();
+    _manager_thread = std::thread([this] { manager_loop(); });
+    on_start();
+  } catch (...) {
+    _running = false;
+    if (_bounded_pool) { _bounded_pool->interrupt(); }
+    _task_queue.interrupt();
+    if (_manager_thread.joinable()) { _manager_thread.join(); }
+    if (_bounded_pool) {
+      _bounded_pool->wait_all();
+      _bounded_pool->stop();
+      _bounded_pool.reset();
+    }
+    throw;
+  }
 }
 
 void itask_executor::stop()
 {
   bool expected = true;
   if (!_running.compare_exchange_strong(expected, false)) { return; }
+  if (!_bounded_pool) { return; }
   _bounded_pool->interrupt();
   _task_queue.interrupt();
   on_stop();

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -144,12 +144,30 @@ void task_scheduler::schedule(std::unique_ptr<sirius::parallel::itask> task)
 
 void task_scheduler::start()
 {
+  std::vector<std::pair<int, gpu_pipeline_executor*>> executors;
+  executors.reserve(_gpu_executors.size());
+  for (auto& [device_id, gpu_exec] : _gpu_executors) {
+    executors.emplace_back(device_id, gpu_exec.get());
+  }
+  std::ranges::sort(executors, {}, &std::pair<int, gpu_pipeline_executor*>::first);
+
+  std::vector<gpu_pipeline_executor*> started;
+  started.reserve(executors.size());
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
-  for (auto& [device_id, gpu_exec] : _gpu_executors) {
-    gpu_exec->start();
+  try {
+    for (auto const& executor : executors) {
+      executor.second->start();
+      started.push_back(executor.second);
+    }
+    _management_thread = std::thread(&task_scheduler::management_eventloop, this);
+  } catch (...) {
+    _running = false;
+    for (auto* gpu_exec : started) {
+      gpu_exec->stop();
+    }
+    throw;
   }
-  _management_thread = std::thread(&task_scheduler::management_eventloop, this);
 }
 
 void task_scheduler::stop()

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -119,12 +119,30 @@ void task_scheduler::schedule(std::unique_ptr<sirius::parallel::itask> task)
 
 void task_scheduler::start()
 {
+  std::vector<std::pair<int, gpu_pipeline_executor*>> executors;
+  executors.reserve(_gpu_executors.size());
+  for (auto& [device_id, gpu_exec] : _gpu_executors) {
+    executors.emplace_back(device_id, gpu_exec.get());
+  }
+  std::ranges::sort(executors, {}, &std::pair<int, gpu_pipeline_executor*>::first);
+
+  std::vector<gpu_pipeline_executor*> started;
+  started.reserve(executors.size());
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
-  for (auto& [device_id, gpu_exec] : _gpu_executors) {
-    gpu_exec->start();
+  try {
+    for (auto const& executor : executors) {
+      executor.second->start();
+      started.push_back(executor.second);
+    }
+    _management_thread = std::thread(&task_scheduler::management_eventloop, this);
+  } catch (...) {
+    _running = false;
+    for (auto* gpu_exec : started) {
+      gpu_exec->stop();
+    }
+    throw;
   }
-  _management_thread = std::thread(&task_scheduler::management_eventloop, this);
 }
 
 void task_scheduler::stop()

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -17,6 +17,7 @@
 #include "sirius_config.hpp"
 
 #include "exec/config.hpp"
+#include "exec/cpu_affinity.hpp"
 #include "log/logging.hpp"
 #include "yaml_reader.hpp"
 
@@ -157,7 +158,7 @@ static void from_yaml(const YAML::Node& node, creator::task_creator_config& opt)
       "and currently source-first; remove this key");
   }
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{0});
-  r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
+  r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list, exec::valid_cpu_affinity{});
   r.reject_unknown();
 }
 
@@ -242,7 +243,7 @@ static void from_yaml(const YAML::Node& node, scan_manager::scan_manager_config&
 {
   yaml::reader r(node, "scan_manager");
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{2});
-  r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
+  r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list, exec::valid_cpu_affinity{});
   r.optional("use_sirius_datasource", opt.use_sirius_datasource);
   r.optional("uring_n_reactors", opt.uring_n_reactors, yaml::greater_than<std::size_t>{0});
   r.optional("rest_n_reactors", opt.rest_n_reactors, yaml::greater_than<std::size_t>{0});
@@ -349,7 +350,7 @@ static void from_yaml(const YAML::Node& node, exec::downgrade_executor_config& o
 {
   yaml::reader r(node, "downgrade");
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{0});
-  r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
+  r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list, exec::valid_cpu_affinity{});
   r.optional("monitor_period", opt.monitor_period);
   r.reject_unknown();
 }

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -17,6 +17,7 @@
 #include "sirius_config.hpp"
 
 #include "exec/config.hpp"
+#include "exec/cpu_affinity.hpp"
 #include "log/logging.hpp"
 #include "yaml_reader.hpp"
 
@@ -157,7 +158,7 @@ static void from_yaml(const YAML::Node& node, creator::task_creator_config& opt)
       "and currently source-first; remove this key");
   }
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{0});
-  r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
+  r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list, exec::valid_cpu_affinity{});
   r.reject_unknown();
 }
 
@@ -242,7 +243,7 @@ static void from_yaml(const YAML::Node& node, scan_manager::scan_manager_config&
 {
   yaml::reader r(node, "scan_manager");
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{2});
-  r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
+  r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list, exec::valid_cpu_affinity{});
   r.optional("use_sirius_datasource", opt.use_sirius_datasource);
   r.optional("uring_n_reactors", opt.uring_n_reactors, yaml::greater_than<std::size_t>{0});
   r.optional("rest_n_reactors", opt.rest_n_reactors, yaml::greater_than<std::size_t>{0});
@@ -343,7 +344,7 @@ static void from_yaml(const YAML::Node& node, exec::downgrade_executor_config& o
 {
   yaml::reader r(node, "downgrade");
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{0});
-  r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
+  r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list, exec::valid_cpu_affinity{});
   r.optional("monitor_period", opt.monitor_period);
   r.reject_unknown();
 }

--- a/test/cpp/config/test_cpu_affinity_config.cpp
+++ b/test/cpp/config/test_cpu_affinity_config.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "sirius_config.hpp"
+
+#include <sched.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct scoped_yaml {
+  scoped_yaml(std::string const& name, std::string const& text)
+    : path(std::filesystem::temp_directory_path() / name)
+  {
+    std::ofstream out(path);
+    out << text;
+    REQUIRE(out);
+  }
+
+  ~scoped_yaml()
+  {
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+  }
+
+  scoped_yaml(scoped_yaml const&)            = delete;
+  scoped_yaml& operator=(scoped_yaml const&) = delete;
+
+  std::filesystem::path path;
+};
+
+int first_allowed_cpu()
+{
+  cpu_set_t allowed;
+  CPU_ZERO(&allowed);
+  REQUIRE(sched_getaffinity(0, sizeof(cpu_set_t), &allowed) == 0);
+  for (int id = 0; id < CPU_SETSIZE; ++id) {
+    if (CPU_ISSET(id, &allowed)) { return id; }
+  }
+  FAIL("current process has no allowed CPUs");
+  return -1;
+}
+
+int first_disallowed_cpu()
+{
+  cpu_set_t allowed;
+  CPU_ZERO(&allowed);
+  REQUIRE(sched_getaffinity(0, sizeof(cpu_set_t), &allowed) == 0);
+  for (int id = 0; id < CPU_SETSIZE; ++id) {
+    if (!CPU_ISSET(id, &allowed)) { return id; }
+  }
+  return -1;
+}
+
+std::string affinity_yaml(std::string const& block, std::string const& value)
+{
+  return "sirius:\n"
+         "  executor:\n"
+         "    " +
+         block +
+         ":\n"
+         "      cpu_affinity: " +
+         value + "\n";
+}
+
+}  // namespace
+
+TEST_CASE("sirius_config accepts shared affinity masks for the three user-configurable pools",
+          "[config][cpu_affinity]")
+{
+  int const cpu = first_allowed_cpu();
+  scoped_yaml yaml("sirius_valid_cpu_affinity.yaml",
+                   "sirius:\n"
+                   "  executor:\n"
+                   "    task_creator:\n"
+                   "      cpu_affinity: [" +
+                     std::to_string(cpu) +
+                     "]\n"
+                     "    scan_manager:\n"
+                     "      cpu_affinity: [" +
+                     std::to_string(cpu) +
+                     "]\n"
+                     "    downgrade:\n"
+                     "      cpu_affinity: [" +
+                     std::to_string(cpu) + "]\n");
+
+  sirius::sirius_config config;
+  REQUIRE_NOTHROW(config.load_from_file(yaml.path));
+  CHECK(config.get_task_creator_config().thread_pool.cpu_affinity_list == std::vector<int>{cpu});
+  CHECK(config.get_scan_manager_config().thread_pool.cpu_affinity_list == std::vector<int>{cpu});
+  CHECK(config.get_downgrade_executor_config().thread_pool.cpu_affinity_list ==
+        std::vector<int>{cpu});
+}
+
+TEST_CASE("sirius_config preserves inherited affinity when lists are empty",
+          "[config][cpu_affinity]")
+{
+  scoped_yaml yaml("sirius_empty_cpu_affinity.yaml",
+                   "sirius:\n"
+                   "  executor:\n"
+                   "    task_creator: {cpu_affinity: []}\n"
+                   "    scan_manager: {cpu_affinity: []}\n"
+                   "    downgrade: {cpu_affinity: []}\n");
+
+  sirius::sirius_config config;
+  REQUIRE_NOTHROW(config.load_from_file(yaml.path));
+  CHECK(config.get_task_creator_config().thread_pool.cpu_affinity_list.empty());
+  CHECK(config.get_scan_manager_config().thread_pool.cpu_affinity_list.empty());
+  CHECK(config.get_downgrade_executor_config().thread_pool.cpu_affinity_list.empty());
+}
+
+TEST_CASE("sirius_config rejects invalid affinity on every user-configurable pool",
+          "[config][cpu_affinity]")
+{
+  auto const block =
+    GENERATE(std::string{"task_creator"}, std::string{"scan_manager"}, std::string{"downgrade"});
+  CAPTURE(block);
+
+  SECTION("negative CPU ID")
+  {
+    scoped_yaml yaml("sirius_negative_" + block + "_cpu_affinity.yaml",
+                     affinity_yaml(block, "[-1]"));
+    sirius::sirius_config config;
+    CHECK_THROWS_WITH(config.load_from_file(yaml.path), Catch::Contains("must be non-negative"));
+  }
+
+  SECTION("CPU ID at CPU_SETSIZE")
+  {
+    scoped_yaml yaml("sirius_large_" + block + "_cpu_affinity.yaml",
+                     affinity_yaml(block, "[" + std::to_string(CPU_SETSIZE) + "]"));
+    sirius::sirius_config config;
+    CHECK_THROWS_WITH(config.load_from_file(yaml.path), Catch::Contains("CPU_SETSIZE"));
+  }
+
+  SECTION("scalar instead of list")
+  {
+    scoped_yaml yaml("sirius_scalar_" + block + "_cpu_affinity.yaml",
+                     affinity_yaml(block, std::to_string(first_allowed_cpu())));
+    sirius::sirius_config config;
+    CHECK_THROWS_WITH(config.load_from_file(yaml.path), Catch::Contains("expected a sequence"));
+  }
+
+  SECTION("CPU ID outside current process allowed mask")
+  {
+    int const disallowed = first_disallowed_cpu();
+    if (disallowed < 0) {
+      WARN("current process is allowed on every CPU_SETSIZE slot; disallowed-ID case skipped");
+      return;
+    }
+    scoped_yaml yaml("sirius_disallowed_" + block + "_cpu_affinity.yaml",
+                     affinity_yaml(block, "[" + std::to_string(disallowed) + "]"));
+    sirius::sirius_config config;
+    CHECK_THROWS_WITH(config.load_from_file(yaml.path),
+                      Catch::Contains("current process allowed CPU mask"));
+  }
+}

--- a/test/cpp/creator/test_task_creator.cpp
+++ b/test/cpp/creator/test_task_creator.cpp
@@ -26,6 +26,7 @@
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 #include <duckdb/main/connection.hpp>
 #include <duckdb/main/database.hpp>
+#include <sched.h>
 
 #include <algorithm>
 #include <atomic>
@@ -158,10 +159,12 @@ class testable_task_creator : public task_creator {
   testable_task_creator(int num_threads,
                         duckdb::ClientContext& client_context,
                         task_scheduler& task_sched,
-                        sirius::memory::sirius_memory_reservation_manager& mem_res_mgr)
+                        sirius::memory::sirius_memory_reservation_manager& mem_res_mgr,
+                        std::vector<int> cpu_affinity = {})
     : task_creator(
-        creator::task_creator_config{
-          .thread_pool = {.num_threads = num_threads, .thread_name_prefix = "task_creator"}},
+        creator::task_creator_config{.thread_pool = {.num_threads        = num_threads,
+                                                     .thread_name_prefix = "task_creator",
+                                                     .cpu_affinity_list = std::move(cpu_affinity)}},
         mem_res_mgr)
   {
     this->set_client_context(client_context);
@@ -342,6 +345,21 @@ TEST_CASE("task_creator thread pool is idempotent", "[task_creator]")
 
     creator.stop_thread_pool();
   }
+}
+
+TEST_CASE("task_creator affinity startup failure leaves stop destruction and retry safe",
+          "[task_creator][cpu_affinity]")
+{
+  test_fixture fixture;
+  testable_task_creator creator(
+    1, *fixture.con.context, fixture.pipeline_exec, *fixture.memory_manager, {CPU_SETSIZE});
+
+  CHECK_THROWS_WITH(creator.start_thread_pool(), Catch::Contains("CPU_SETSIZE"));
+  CHECK_FALSE(creator.is_running());
+  CHECK_NOTHROW(creator.stop_thread_pool());
+  CHECK_THROWS_WITH(creator.start_thread_pool(), Catch::Contains("CPU_SETSIZE"));
+  CHECK_FALSE(creator.is_running());
+  CHECK_NOTHROW(creator.stop_thread_pool());
 }
 
 TEST_CASE("task_creator destructor stops thread pool", "[task_creator]")

--- a/test/cpp/creator/test_task_creator.cpp
+++ b/test/cpp/creator/test_task_creator.cpp
@@ -26,6 +26,7 @@
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 #include <duckdb/main/connection.hpp>
 #include <duckdb/main/database.hpp>
+#include <sched.h>
 
 #include <algorithm>
 #include <atomic>
@@ -159,10 +160,12 @@ class testable_task_creator : public task_creator {
                         duckdb::ClientContext& client_context,
                         task_scheduler& task_sched,
                         sirius::memory::sirius_memory_reservation_manager& mem_res_mgr,
-                        sirius::query_id_t query_id = sirius::make_query_id(1))
+                        std::vector<int> cpu_affinity = {},
+                        sirius::query_id_t query_id   = sirius::make_query_id(1))
     : task_creator(
-        creator::task_creator_config{
-          .thread_pool = {.num_threads = num_threads, .thread_name_prefix = "task_creator"}},
+        creator::task_creator_config{.thread_pool = {.num_threads        = num_threads,
+                                                     .thread_name_prefix = "task_creator",
+                                                     .cpu_affinity_list = std::move(cpu_affinity)}},
         mem_res_mgr),
       _query_id(query_id)
   {
@@ -348,6 +351,21 @@ TEST_CASE("task_creator thread pool is idempotent", "[task_creator]")
 
     creator.stop_thread_pool();
   }
+}
+
+TEST_CASE("task_creator affinity startup failure leaves stop destruction and retry safe",
+          "[task_creator][cpu_affinity]")
+{
+  test_fixture fixture;
+  testable_task_creator creator(
+    1, *fixture.con.context, fixture.pipeline_exec, *fixture.memory_manager, {CPU_SETSIZE});
+
+  CHECK_THROWS_WITH(creator.start_thread_pool(), Catch::Contains("CPU_SETSIZE"));
+  CHECK_FALSE(creator.is_running());
+  CHECK_NOTHROW(creator.stop_thread_pool());
+  CHECK_THROWS_WITH(creator.start_thread_pool(), Catch::Contains("CPU_SETSIZE"));
+  CHECK_FALSE(creator.is_running());
+  CHECK_NOTHROW(creator.stop_thread_pool());
 }
 
 TEST_CASE("task_creator destructor stops thread pool", "[task_creator]")

--- a/test/cpp/downgrade/test_downgrade_executor.cpp
+++ b/test/cpp/downgrade/test_downgrade_executor.cpp
@@ -39,6 +39,8 @@
 
 #include <rmm/cuda_stream.hpp>
 
+#include <sched.h>
+
 #include <atomic>
 #include <chrono>
 #include <memory>
@@ -151,6 +153,25 @@ TEST_CASE("Downgrade executor starts and stops cleanly", "[downgrade_executor]")
 
   REQUIRE_NOTHROW(executor.start());
   REQUIRE_NOTHROW(executor.stop());
+}
+
+TEST_CASE("Downgrade affinity startup failure leaves stop destruction and retry safe",
+          "[downgrade_executor][cpu_affinity]")
+{
+  auto mem_mgr    = make_test_memory_manager();
+  auto* gpu_space = get_gpu_space(*mem_mgr);
+  sirius::data::data_repository_manager_registry repo_registry;
+  sirius::exec::downgrade_executor_config config{
+    .thread_pool    = {.num_threads        = 1,
+                       .thread_name_prefix = "invalid_affinity",
+                       .cpu_affinity_list  = {CPU_SETSIZE}},
+    .monitor_period = std::chrono::milliseconds{0}};
+  downgrade_executor executor(config, repo_registry, GPU_SPACE_ID, gpu_space, *mem_mgr);
+
+  CHECK_THROWS_WITH(executor.start(), Catch::Contains("CPU_SETSIZE"));
+  CHECK_NOTHROW(executor.stop());
+  CHECK_THROWS_WITH(executor.start(), Catch::Contains("CPU_SETSIZE"));
+  CHECK_NOTHROW(executor.stop());
 }
 
 TEST_CASE("request_free_memory_and_wait with no repositories returns 0", "[downgrade_executor]")

--- a/test/cpp/exec/test_bounded_thread_pool.cpp
+++ b/test/cpp/exec/test_bounded_thread_pool.cpp
@@ -16,15 +16,200 @@
 
 #include "catch.hpp"
 #include "exec/bounded_thread_pool.hpp"
+#include "exec/thread_pool.hpp"
 
+#include <pthread.h>
+#include <sched.h>
+
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
 using namespace sirius::exec;
 using namespace std::chrono_literals;
+
+namespace {
+
+cpu_set_t current_cpu_mask()
+{
+  cpu_set_t mask;
+  CPU_ZERO(&mask);
+  REQUIRE(sched_getaffinity(0, sizeof(cpu_set_t), &mask) == 0);
+  return mask;
+}
+
+std::vector<int> cpu_ids_in(const cpu_set_t& mask)
+{
+  std::vector<int> ids;
+  for (int id = 0; id < CPU_SETSIZE; ++id) {
+    if (CPU_ISSET(id, &mask)) { ids.push_back(id); }
+  }
+  return ids;
+}
+
+bool masks_equal(const cpu_set_t& lhs, const cpu_set_t& rhs)
+{
+  for (int id = 0; id < CPU_SETSIZE; ++id) {
+    if (CPU_ISSET(id, &lhs) != CPU_ISSET(id, &rhs)) { return false; }
+  }
+  return true;
+}
+
+cpu_set_t mask_for(const std::vector<int>& cpu_ids)
+{
+  cpu_set_t mask;
+  CPU_ZERO(&mask);
+  for (int id : cpu_ids) {
+    CPU_SET(id, &mask);
+  }
+  return mask;
+}
+
+}  // namespace
+
+// =============================================================================
+// CPU affinity
+// =============================================================================
+
+TEST_CASE("thread pools apply one shared CPU affinity mask to every worker",
+          "[thread_pool][bounded_thread_pool][cpu_affinity]")
+{
+  auto const allowed = cpu_ids_in(current_cpu_mask());
+  REQUIRE_FALSE(allowed.empty());
+
+  std::vector<int> requested{allowed.front()};
+  if (allowed.size() > 1) { requested.push_back(allowed[1]); }
+  auto const expected = mask_for(requested);
+
+  SECTION("static_thread_pool")
+  {
+    std::atomic<int> initialized{0};
+    std::atomic<bool> exact{true};
+    static_thread_pool pool(2, "affinity", requested, [&]() noexcept {
+      cpu_set_t actual;
+      CPU_ZERO(&actual);
+      if (pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &actual) != 0 ||
+          !masks_equal(actual, expected)) {
+        exact = false;
+      }
+      initialized.fetch_add(1);
+    });
+    CHECK(initialized.load() == 2);
+    CHECK(exact.load());
+  }
+
+  SECTION("bounded_thread_pool")
+  {
+    std::atomic<int> initialized{0};
+    std::atomic<bool> exact{true};
+    bounded_thread_pool pool(2, "affinity", requested, [&]() noexcept {
+      cpu_set_t actual;
+      CPU_ZERO(&actual);
+      if (pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &actual) != 0 ||
+          !masks_equal(actual, expected)) {
+        exact = false;
+      }
+      initialized.fetch_add(1);
+    });
+    CHECK(initialized.load() == 2);
+    CHECK(exact.load());
+  }
+}
+
+TEST_CASE("empty CPU affinity inherits the constructing thread mask",
+          "[thread_pool][bounded_thread_pool][cpu_affinity]")
+{
+  auto const expected = current_cpu_mask();
+
+  SECTION("static_thread_pool")
+  {
+    std::atomic<bool> inherited{true};
+    static_thread_pool pool(1, "affinity", {}, [&]() noexcept {
+      cpu_set_t actual;
+      CPU_ZERO(&actual);
+      inherited = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &actual) == 0 &&
+                  masks_equal(actual, expected);
+    });
+    CHECK(inherited.load());
+  }
+
+  SECTION("bounded_thread_pool")
+  {
+    std::atomic<bool> inherited{true};
+    bounded_thread_pool pool(1, "affinity", {}, [&]() noexcept {
+      cpu_set_t actual;
+      CPU_ZERO(&actual);
+      inherited = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &actual) == 0 &&
+                  masks_equal(actual, expected);
+    });
+    CHECK(inherited.load());
+  }
+}
+
+TEST_CASE("thread pools reject invalid CPU affinity before creating workers",
+          "[thread_pool][bounded_thread_pool][cpu_affinity]")
+{
+  int invalid_id = -1;
+
+  SECTION("negative ID") { invalid_id = -1; }
+  SECTION("ID at CPU_SETSIZE") { invalid_id = CPU_SETSIZE; }
+  SECTION("ID outside the current allowed mask")
+  {
+    auto const allowed = current_cpu_mask();
+    invalid_id         = -1;
+    for (int id = 0; id < CPU_SETSIZE; ++id) {
+      if (!CPU_ISSET(id, &allowed)) {
+        invalid_id = id;
+        break;
+      }
+    }
+    if (invalid_id < 0) {
+      WARN("current process is allowed on every CPU_SETSIZE slot; disallowed-ID case skipped");
+      return;
+    }
+  }
+
+  CHECK_THROWS_AS(static_thread_pool(1, "invalid", {invalid_id}), std::invalid_argument);
+  CHECK_THROWS_AS(bounded_thread_pool(1, "invalid", {invalid_id}), std::invalid_argument);
+
+  // A failed construction must not leave a joinable worker behind or poison later pools.
+  CHECK_NOTHROW(static_thread_pool(1, "valid"));
+  CHECK_NOTHROW(bounded_thread_pool(1, "valid"));
+}
+
+TEST_CASE("thread pool startup propagates worker errors after joining every worker",
+          "[thread_pool][cpu_affinity][startup]")
+{
+  std::vector<std::thread> threads;
+  threads.reserve(3);
+  std::atomic<int> startup_count{0};
+  std::atomic<bool> stop{false};
+
+  CHECK_THROWS_WITH(detail::start_thread_pool_workers(
+                      threads,
+                      3,
+                      "startup",
+                      [&] {
+                        if (startup_count.fetch_add(1) == 1) {
+                          throw std::runtime_error("forced affinity startup failure");
+                        }
+                      },
+                      [&] {
+                        while (!stop.load()) {
+                          std::this_thread::yield();
+                        }
+                      },
+                      [&] { stop = true; }),
+                    "forced affinity startup failure");
+
+  CHECK(startup_count.load() == 3);
+  CHECK(std::none_of(
+    threads.begin(), threads.end(), [](auto const& thread) { return thread.joinable(); }));
+}
 
 // =============================================================================
 // Bounded concurrency

--- a/test/cpp/parallel/test_task_executor.cpp
+++ b/test/cpp/parallel/test_task_executor.cpp
@@ -21,6 +21,8 @@
 
 #include <cudf/utilities/default_stream.hpp>
 
+#include <sched.h>
+
 #include <chrono>
 #include <memory>
 #include <thread>
@@ -93,6 +95,19 @@ TEST_CASE("Executor can start and stop gracefully", "[task_executor]")
 
   REQUIRE_NOTHROW(executor.start());
   REQUIRE_NOTHROW(executor.stop());
+}
+
+TEST_CASE("Executor affinity startup failure leaves stop destruction and retry safe",
+          "[task_executor][cpu_affinity]")
+{
+  sirius::exec::thread_pool_config config{1, "invalid_affinity", {CPU_SETSIZE}};
+  dummy_task_executor executor(config);
+
+  CHECK_THROWS_WITH(executor.start(), Catch::Contains("CPU_SETSIZE"));
+  CHECK_NOTHROW(executor.stop());
+  // A poisoned _running flag would turn this retry into a silent no-op.
+  CHECK_THROWS_WITH(executor.start(), Catch::Contains("CPU_SETSIZE"));
+  CHECK_NOTHROW(executor.stop());
 }
 
 TEST_CASE("Executor executes scheduled tasks", "[task_executor]")

--- a/test/cpp/pipeline/test_task_scheduler.cpp
+++ b/test/cpp/pipeline/test_task_scheduler.cpp
@@ -26,6 +26,8 @@
 
 #include <cuda_runtime_api.h>
 
+#include <sched.h>
+
 #include <atomic>
 #include <chrono>
 #include <memory>
@@ -133,6 +135,53 @@ TEST_CASE("Task scheduler derives GPU executor affinity from topology", "[task_s
     ++visited;
   });
   REQUIRE(visited == 1);
+}
+
+TEST_CASE("Task scheduler rolls back topology-affinity startup failure",
+          "[task_scheduler][cpu_affinity]")
+{
+  // This regression needs two real executors: device 0 must start before the
+  // invalid topology mask fails device 1, so task_scheduler has something to
+  // roll back. start() orders lifecycle startup by device ID without changing
+  // the scheduler's unordered ready-device matcher. Do not construct a
+  // device-1 stream pool on a 1-GPU host.
+  int device_count = 0;
+  REQUIRE(cudaGetDeviceCount(&device_count) == cudaSuccess);
+  if (device_count < 2) {
+    WARN("Task scheduler partial-start rollback test requires >=2 GPUs; skipping");
+    return;
+  }
+
+  auto manager = initialize_memory_manager(2);
+  sirius::exec::thread_pool_config gpu_config{2};
+  cucascade::memory::system_topology_info topology;
+  topology.num_gpus = 2;
+  cpu_set_t allowed;
+  CPU_ZERO(&allowed);
+  REQUIRE(sched_getaffinity(0, sizeof(cpu_set_t), &allowed) == 0);
+  int allowed_cpu = -1;
+  for (int id = 0; id < CPU_SETSIZE; ++id) {
+    if (CPU_ISSET(id, &allowed)) {
+      allowed_cpu = id;
+      break;
+    }
+  }
+  REQUIRE(allowed_cpu >= 0);
+  for (int device_id = 0; device_id < 2; ++device_id) {
+    cucascade::memory::gpu_topology_info gpu;
+    gpu.id        = device_id;
+    gpu.numa_node = device_id;
+    gpu.cpu_cores = {device_id == 0 ? allowed_cpu : CPU_SETSIZE};
+    topology.gpus.push_back(std::move(gpu));
+  }
+
+  task_scheduler scheduler(
+    gpu_config, *manager, sirius::test::make_test_telemetry_context(), &topology);
+
+  CHECK_THROWS_WITH(scheduler.start(), Catch::Contains("CPU_SETSIZE"));
+  CHECK_NOTHROW(scheduler.stop());
+  CHECK_THROWS_WITH(scheduler.start(), Catch::Contains("CPU_SETSIZE"));
+  CHECK_NOTHROW(scheduler.stop());
 }
 
 TEST_CASE("Task scheduler executes tasks through pipeline_queue", "[task_scheduler]")


### PR DESCRIPTION
## Summary

- validate configured Linux CPU IDs against bounds and the caller's current allowed mask before creating workers
- apply the complete list as one shared eligibility mask inside every static and bounded pool worker, then require exact kernel readback
- stop and join every created worker before propagating an affinity startup error
- make current pool owners roll back cleanly when fail-closed startup rejects a mask
- document shared-mask and empty-inheritance semantics, with focused YAML, pool, and owner regressions

## Configuration contract

`cpu_affinity` remains an expert policy input for the task-creator, downgrade,
and scan-manager pools. Omitted or empty lists inherit the constructing
thread's allowed mask. Every listed CPU is an eligibility choice shared by all
workers—not a one-CPU-per-worker assignment—and must be inside the live
cgroup/cpuset-constrained process mask.

The GPU-pipeline YAML surface stays removed by merged #1494. Pipeline affinity
is derived from the selected GPU's CPU topology and passes through the same
fail-closed pool boundary.

## September 9 current-dev repair

Current `dev` added query identity to the task-creator test fixture at the same
constructor changed by this PR. The replacement keeps affinity as the fifth
parameter and query ID as the sixth, preserves query-scoped client-context
registration, and retains the original CPU-affinity behavior. Hosted lint then
identified a formatter-only layout delta; the exact generated formatting was
applied and independently re-reviewed with no semantic change.

## Exact reviewed identity

- tier: `judgment`
- exact base: `285737bc33c84d5c175c59862162b518b89fcae0`
- base tree: `8a3ac4a8c9809355bd9303ca1dc274fd6211752a`
- exact head: `88c733feee525922069b093102405c94af0d8620`
- candidate tree: `49a77d61a6a4987cae4f3e39e5755b0afb61eae3`
- cumulative binary-diff SHA-256: `3bc56020413be8a62594995c9bf0ee2f1f831bc21b0623a5763c348f3b2cc0e0`
- cumulative diff: 18 paths, 849 insertions, 128 deletions

## Author-side validation

- independent exact-head full-diff and formatter-delta review: no critical, important, or minor findings
- clean worktree, `git diff --check`, and `git show --check`: pass
- affinity, readback, partial-start rollback, retry, owner-lifecycle, and topology-derived placement regressions retained
- hosted Check `34395692616`: lint, GCC release, Clang debug, and aggregate pass
- hosted Test `34395692800`: CUDA 13 build, C++ runtime suite, TPC-H snapshot, and aggregate pass
- hosted Distribution `34395693943`: aggregate pass; CUDA distribution leaves correctly skip because distribution inputs did not change
- hosted Validate `34395690336`: title and aggregate validation pass

The replacement head is author-ready and terminal-green. Independent
maintainer approval of this exact head remains the merge gate.

### Retained predecessor evidence

The earlier Linux C++20 ASan/UBSan affinity/startup harness and previous hosted
heads remain supporting evidence for unchanged behavior; they do not replace
the current exact-head gates above.