### PR TITLE
fix(config): validate and preserve logging state

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -539,9 +539,9 @@ Registered in `src/sirius_extension.cpp`. These can be changed at runtime:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `sirius_log_backend` | `spdlog` | Log sink: `spdlog`, `duckdb`, or `noop` |
-| `sirius_log_level` | `info` | Log level: trace, debug, info, warn, error (`spdlog` only) |
+| `sirius_log_level` | `info` | Log level: trace, debug, info, warn, error, critical, off (`spdlog` only) |
 | `sirius_log_dir` | `log` | Log output directory (`spdlog` only) |
-| `sirius_log_flush_seconds` | 3 | Log flush interval in seconds (`spdlog` only) |
+| `sirius_log_flush_seconds` | 3 | Log flush interval in seconds; 0 disables periodic flushing and negative values are rejected (`spdlog` only) |
 
 - **`spdlog`** (default): writes the daily-rotated `<sirius_log_dir>/sirius.log`, honouring
   `sirius_log_level` and `sirius_log_flush_seconds`.

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -1586,13 +1586,38 @@ void install_configured_log_sink(DatabaseInstance* db)
 
 SiriusContextExtensionCallback::SiriusContextExtensionCallback()
 {
-  if (auto* env = std::getenv("SIRIUS_LOG_BACKEND")) { Config::LOG_BACKEND = env; }
-  if (auto* env = std::getenv("SIRIUS_LOG_DIR")) { Config::LOG_DIR = env; }
-  if (auto* env = std::getenv("SIRIUS_LOG_LEVEL")) { Config::LOG_LEVEL = env; }
+  auto const previous_log_backend = Config::LOG_BACKEND;
+  auto const previous_log_dir     = Config::LOG_DIR;
+  auto const previous_log_level   = Config::LOG_LEVEL;
+  auto* backend_env               = std::getenv("SIRIUS_LOG_BACKEND");
+  auto* log_dir_env               = std::getenv("SIRIUS_LOG_DIR");
+  auto* level_env                 = std::getenv("SIRIUS_LOG_LEVEL");
+  if (backend_env) {
+    std::string_view const backend{backend_env};
+    if (backend != "duckdb" && backend != "spdlog" && backend != "noop") {
+      throw InvalidInputException(
+        "SIRIUS_LOG_BACKEND must be one of: duckdb, spdlog, noop; got '%s'", backend_env);
+    }
+  }
+  if (level_env && !sirius::log::string_to_enum(level_env)) {
+    throw InvalidInputException(
+      "SIRIUS_LOG_LEVEL must be one of: trace, debug, info, warn, error, critical, off; got '%s'",
+      level_env);
+  }
+  if (backend_env) { Config::LOG_BACKEND = backend_env; }
+  if (log_dir_env) { Config::LOG_DIR = log_dir_env; }
+  if (level_env) { Config::LOG_LEVEL = level_env; }
   // Install now (no db yet) so spdlog/noop capture the logs emitted by
   // read_config_file_if_exists() below; the duckdb backend needs a db (installed
   // later).
-  install_configured_log_sink(nullptr);
+  try {
+    install_configured_log_sink(nullptr);
+  } catch (...) {
+    Config::LOG_BACKEND = previous_log_backend;
+    Config::LOG_DIR     = previous_log_dir;
+    Config::LOG_LEVEL   = previous_log_level;
+    throw;
+  }
   read_config_file_if_exists();
 }
 

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -1589,9 +1589,9 @@ SiriusContextExtensionCallback::SiriusContextExtensionCallback()
   auto const previous_log_backend = Config::LOG_BACKEND;
   auto const previous_log_dir     = Config::LOG_DIR;
   auto const previous_log_level   = Config::LOG_LEVEL;
-  auto* backend_env               = std::getenv("SIRIUS_LOG_BACKEND");
-  auto* log_dir_env               = std::getenv("SIRIUS_LOG_DIR");
-  auto* level_env                 = std::getenv("SIRIUS_LOG_LEVEL");
+  auto const* backend_env         = std::getenv("SIRIUS_LOG_BACKEND");
+  auto const* log_dir_env         = std::getenv("SIRIUS_LOG_DIR");
+  auto const* level_env           = std::getenv("SIRIUS_LOG_LEVEL");
   if (backend_env) {
     std::string_view const backend{backend_env};
     if (backend != "duckdb" && backend != "spdlog" && backend != "noop") {

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1955,37 +1955,58 @@ static void SetLogBackend(ClientContext& context, SetScope scope, Value& paramet
     throw InvalidInputException("Unknown sirius_log_backend '%s' (expected: duckdb, spdlog, noop)",
                                 backend);
   }
-  Config::LOG_BACKEND = std::move(backend);
-  install_configured_log_sink(context.db.get());
+  auto const previous_backend = Config::LOG_BACKEND;
+  Config::LOG_BACKEND         = std::move(backend);
+  try {
+    install_configured_log_sink(context.db.get());
+  } catch (...) {
+    Config::LOG_BACKEND = previous_backend;
+    throw;
+  }
   SIRIUS_LOG_DEBUG("Updated config LOG_BACKEND to {}", Config::LOG_BACKEND);
 }
 
 static void SetLogLevel(ClientContext& context, SetScope scope, Value& parameter)
 {
   throw_if_sirius_runtime_unavailable(context);
-  Config::LOG_LEVEL = StringValue::Get(parameter);
-  // Only re-targets the current sink; no rebuild (a no-op for the duckdb backend).
-  auto parsed_level = sirius::log::string_to_enum(Config::LOG_LEVEL);
-  sirius::log::get_sink()->set_level(parsed_level.value_or(sirius::log::level::info));
+  auto level_name   = StringValue::Get(parameter);
+  auto parsed_level = sirius::log::string_to_enum(level_name);
   if (!parsed_level) {
-    SIRIUS_LOG_WARN("Unknown log level '{}', defaulting to info", Config::LOG_LEVEL);
+    throw InvalidInputException(
+      "sirius_log_level must be one of: trace, debug, info, warn, error, critical, off; got '%s'",
+      level_name);
   }
+  Config::LOG_LEVEL = std::move(level_name);
+  // Only re-targets the current sink; no rebuild (a no-op for the duckdb backend).
+  sirius::log::get_sink()->set_level(*parsed_level);
   SIRIUS_LOG_DEBUG("Updated config LOG_LEVEL to {}", Config::LOG_LEVEL);
 }
 
 static void SetLogDir(ClientContext& context, SetScope scope, Value& parameter)
 {
   throw_if_sirius_runtime_unavailable(context);
-  Config::LOG_DIR = StringValue::Get(parameter);
+  auto const previous_log_dir = Config::LOG_DIR;
+  Config::LOG_DIR             = StringValue::Get(parameter);
   // log_dir only affects the spdlog backend; rebuild it when that one is active.
-  if (Config::LOG_BACKEND == "spdlog") { install_configured_log_sink(context.db.get()); }
+  try {
+    if (Config::LOG_BACKEND == "spdlog") { install_configured_log_sink(context.db.get()); }
+  } catch (...) {
+    Config::LOG_DIR = previous_log_dir;
+    throw;
+  }
   SIRIUS_LOG_DEBUG("Updated config LOG_DIR to {}", Config::LOG_DIR);
 }
 
 static void SetLogFlushSeconds(ClientContext& context, SetScope scope, Value& parameter)
 {
   throw_if_sirius_runtime_unavailable(context);
-  Config::LOG_FLUSH_SECONDS = IntegerValue::Get(parameter);
+  auto const seconds = IntegerValue::Get(parameter);
+  if (seconds < 0) {
+    throw InvalidInputException(
+      "sirius_log_flush_seconds must be non-negative; zero disables periodic flushing; got %d",
+      seconds);
+  }
+  Config::LOG_FLUSH_SECONDS = seconds;
   // The flush interval is fixed at spdlog-sink construction, so rebuild it (only
   // the spdlog backend uses it).
   if (Config::LOG_BACKEND == "spdlog") { install_configured_log_sink(context.db.get()); }
@@ -2407,7 +2428,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             Value(Config::LOG_DIR),
                             SetLogDir);
   config.AddExtensionOption("sirius_log_flush_seconds",
-                            "Interval in seconds between automatic log flushes",
+                            "Interval in seconds between automatic log flushes (0 disables)",
                             LogicalType::INTEGER,
                             Value::INTEGER(Config::LOG_FLUSH_SECONDS),
                             SetLogFlushSeconds);

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2006,10 +2006,16 @@ static void SetLogFlushSeconds(ClientContext& context, SetScope scope, Value& pa
       "sirius_log_flush_seconds must be non-negative; zero disables periodic flushing; got %d",
       seconds);
   }
-  Config::LOG_FLUSH_SECONDS = seconds;
+  auto const previous_flush_seconds = Config::LOG_FLUSH_SECONDS;
+  Config::LOG_FLUSH_SECONDS         = seconds;
   // The flush interval is fixed at spdlog-sink construction, so rebuild it (only
   // the spdlog backend uses it).
-  if (Config::LOG_BACKEND == "spdlog") { install_configured_log_sink(context.db.get()); }
+  try {
+    if (Config::LOG_BACKEND == "spdlog") { install_configured_log_sink(context.db.get()); }
+  } catch (...) {
+    Config::LOG_FLUSH_SECONDS = previous_flush_seconds;
+    throw;
+  }
   SIRIUS_LOG_DEBUG("Updated config LOG_FLUSH_SECONDS to {}", Config::LOG_FLUSH_SECONDS);
 }
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -51,6 +51,7 @@
 #include <set>
 #include <source_location>
 #include <string>
+#include <system_error>
 #include <vector>
 
 namespace {
@@ -359,7 +360,8 @@ TEST_CASE("DuckDB setting preserves the Sirius log backend when sink constructio
     duckdb::Config::LOG_BACKEND = previous_backend;
     duckdb::Config::LOG_DIR     = previous_log_dir;
     sirius::log::set_sink(previous_sink);
-    fs::remove_all(test_root);
+    std::error_code cleanup_error;
+    fs::remove_all(test_root, cleanup_error);
   }};
 
   fs::remove_all(test_root);
@@ -1437,7 +1439,8 @@ TEST_CASE("DuckDB setting preserves the Sirius log directory when sink construct
     duckdb::Config::LOG_BACKEND = previous_backend;
     duckdb::Config::LOG_DIR     = previous_log_dir;
     sirius::log::set_sink(previous_sink);
-    fs::remove_all(test_root);
+    std::error_code cleanup_error;
+    fs::remove_all(test_root, cleanup_error);
   }};
 
   fs::remove_all(test_root);
@@ -1511,7 +1514,8 @@ TEST_CASE("Sirius startup preserves logging settings when sink construction fail
     } else {
       unsetenv("SIRIUS_DISABLE");
     }
-    fs::remove_all(test_root);
+    std::error_code cleanup_error;
+    fs::remove_all(test_root, cleanup_error);
   }};
 
   fs::remove_all(test_root);
@@ -1583,6 +1587,64 @@ TEST_CASE("DuckDB setting rejects negative Sirius log flush intervals without mu
   REQUIRE(after_disabled != nullptr);
   REQUIRE_FALSE(after_disabled->HasError());
   REQUIRE(after_disabled->GetValue(0, 0).GetValue<int32_t>() == 0);
+}
+
+TEST_CASE("DuckDB setting preserves the Sirius log flush interval when sink construction fails",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  auto const previous_backend       = duckdb::Config::LOG_BACKEND;
+  auto const previous_log_dir       = duckdb::Config::LOG_DIR;
+  auto const previous_flush_seconds = duckdb::Config::LOG_FLUSH_SECONDS;
+  auto const previous_sink          = sirius::log::get_sink();
+  auto const test_root              = fs::temp_directory_path() / "sirius-log-flush-rollback-test";
+  finally restore_logging{[&]() {
+    duckdb::Config::LOG_BACKEND       = previous_backend;
+    duckdb::Config::LOG_DIR           = previous_log_dir;
+    duckdb::Config::LOG_FLUSH_SECONDS = previous_flush_seconds;
+    sirius::log::set_sink(previous_sink);
+    std::error_code cleanup_error;
+    fs::remove_all(test_root, cleanup_error);
+  }};
+
+  fs::remove_all(test_root);
+  fs::create_directories(test_root);
+  auto const valid_dir = test_root / "valid";
+  auto const blocker   = test_root / "not-a-directory";
+  std::ofstream(blocker) << "file";
+  auto const invalid_dir = blocker / "child";
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto noop = con.Query("SET sirius_log_backend = 'noop'");
+  REQUIRE(noop != nullptr);
+  REQUIRE_FALSE(noop->HasError());
+  auto set_valid_dir = con.Query("SET sirius_log_dir = '" + valid_dir.string() + "'");
+  REQUIRE(set_valid_dir != nullptr);
+  REQUIRE_FALSE(set_valid_dir->HasError());
+  auto spdlog = con.Query("SET sirius_log_backend = 'spdlog'");
+  REQUIRE(spdlog != nullptr);
+  REQUIRE_FALSE(spdlog->HasError());
+  auto positive = con.Query("SET sirius_log_flush_seconds = 7");
+  REQUIRE(positive != nullptr);
+  REQUIRE_FALSE(positive->HasError());
+  REQUIRE(duckdb::Config::LOG_FLUSH_SECONDS == 7);
+  auto const valid_sink = sirius::log::get_sink();
+
+  duckdb::Config::LOG_DIR = invalid_dir.string();
+  auto invalid            = con.Query("SET sirius_log_flush_seconds = 11");
+  REQUIRE(invalid != nullptr);
+  REQUIRE(invalid->HasError());
+
+  auto after_invalid = con.Query("SELECT current_setting('sirius_log_flush_seconds')::INTEGER");
+  REQUIRE(after_invalid != nullptr);
+  REQUIRE_FALSE(after_invalid->HasError());
+  REQUIRE(after_invalid->GetValue(0, 0).GetValue<int32_t>() == 7);
+  REQUIRE(duckdb::Config::LOG_FLUSH_SECONDS == 7);
+  REQUIRE(sirius::log::get_sink() == valid_sink);
 }
 
 TEST_CASE("Sirius configuration loading from file with spaces",

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -15,7 +15,10 @@
  */
 
 #include "catch.hpp"
+#include "log/level.hpp"
+#include "log/sink.hpp"
 #include "sirius_context.hpp"
+#include "utils/log_test_utils.hpp"
 
 #include <cudf/contiguous_split.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -340,6 +343,192 @@ TEST_CASE("Sirius configuration keeps runtime distinct-build probing internal", 
     config.load_from_file(data_dir / "invalid_runtime_distinct_build_probe.yaml"),
     Catch::Contains("sirius.operator_params.enable_runtime_distinct_build_probe") &&
       Catch::Contains("removed") && Catch::Contains("remove this key"));
+}
+
+TEST_CASE("DuckDB setting preserves the Sirius log backend when sink construction fails",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  auto const previous_backend = duckdb::Config::LOG_BACKEND;
+  auto const previous_log_dir = duckdb::Config::LOG_DIR;
+  auto const previous_sink    = sirius::log::get_sink();
+  auto const test_root        = fs::temp_directory_path() / "sirius-log-backend-rollback-test";
+  finally restore_logging{[&]() {
+    duckdb::Config::LOG_BACKEND = previous_backend;
+    duckdb::Config::LOG_DIR     = previous_log_dir;
+    sirius::log::set_sink(previous_sink);
+    fs::remove_all(test_root);
+  }};
+
+  fs::remove_all(test_root);
+  fs::create_directories(test_root);
+  auto const blocker = test_root / "not-a-directory";
+  std::ofstream(blocker) << "file";
+  auto const invalid_dir = blocker / "child";
+  auto const valid_dir   = test_root / "valid";
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto noop = con.Query("SET sirius_log_backend = 'noop'");
+  REQUIRE(noop != nullptr);
+  REQUIRE_FALSE(noop->HasError());
+  auto const noop_sink = sirius::log::get_sink();
+
+  auto stage_invalid_dir = con.Query("SET sirius_log_dir = '" + invalid_dir.string() + "'");
+  REQUIRE(stage_invalid_dir != nullptr);
+  REQUIRE_FALSE(stage_invalid_dir->HasError());
+
+  auto invalid_spdlog = con.Query("SET sirius_log_backend = 'spdlog'");
+  REQUIRE(invalid_spdlog != nullptr);
+  REQUIRE(invalid_spdlog->HasError());
+
+  auto after_invalid = con.Query("SELECT current_setting('sirius_log_backend')::VARCHAR");
+  REQUIRE(after_invalid != nullptr);
+  REQUIRE_FALSE(after_invalid->HasError());
+  REQUIRE(after_invalid->GetValue(0, 0).GetValue<std::string>() == "noop");
+  REQUIRE(duckdb::Config::LOG_BACKEND == "noop");
+  REQUIRE(sirius::log::get_sink() == noop_sink);
+
+  auto repair_dir = con.Query("SET sirius_log_dir = '" + valid_dir.string() + "'");
+  REQUIRE(repair_dir != nullptr);
+  REQUIRE_FALSE(repair_dir->HasError());
+
+  auto valid_spdlog = con.Query("SET sirius_log_backend = 'spdlog'");
+  REQUIRE(valid_spdlog != nullptr);
+  REQUIRE_FALSE(valid_spdlog->HasError());
+  REQUIRE(duckdb::Config::LOG_BACKEND == "spdlog");
+}
+
+TEST_CASE("Sirius startup rejects unknown environment log backends before mutation",
+          "[sirius][context][config][isolated_context]")
+{
+  auto const previous_backend = duckdb::Config::LOG_BACKEND;
+  auto const previous_sink    = sirius::log::get_sink();
+  std::optional<std::string> previous_env_backend;
+  if (auto const* value = std::getenv("SIRIUS_LOG_BACKEND")) { previous_env_backend = value; }
+  finally restore_logging{[&]() {
+    duckdb::Config::LOG_BACKEND = previous_backend;
+    sirius::log::set_sink(previous_sink);
+    if (previous_env_backend) {
+      setenv("SIRIUS_LOG_BACKEND", previous_env_backend->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_LOG_BACKEND");
+    }
+    setenv("SIRIUS_DISABLE", "1", 1);
+  }};
+
+  setenv("SIRIUS_DISABLE", "1", 1);
+  duckdb::Config::LOG_BACKEND = "noop";
+  setenv("SIRIUS_LOG_BACKEND", "syslog", 1);
+
+  REQUIRE_THROWS_WITH(
+    duckdb::SiriusContextExtensionCallback{},
+    Catch::Contains("SIRIUS_LOG_BACKEND must be one of: duckdb, spdlog, noop; got 'syslog'"));
+  REQUIRE(duckdb::Config::LOG_BACKEND == "noop");
+
+  setenv("SIRIUS_LOG_BACKEND", "duckdb", 1);
+  duckdb::SiriusContextExtensionCallback valid_callback;
+  REQUIRE(duckdb::Config::LOG_BACKEND == "duckdb");
+}
+
+TEST_CASE("DuckDB setting rejects unknown Sirius log levels without mutation",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  sirius::test::scoped_recording_log_sink scoped_sink;
+  auto const previous_level = duckdb::Config::LOG_LEVEL;
+  finally restore_level{[&]() { duckdb::Config::LOG_LEVEL = previous_level; }};
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto warn = con.Query("SET sirius_log_level = 'warn'");
+  REQUIRE(warn != nullptr);
+  REQUIRE_FALSE(warn->HasError());
+  REQUIRE(duckdb::Config::LOG_LEVEL == "warn");
+  REQUIRE_FALSE(sirius::log::get_sink()->should_log(sirius::log::level::info));
+  REQUIRE(sirius::log::get_sink()->should_log(sirius::log::level::warn));
+
+  auto invalid = con.Query("SET sirius_log_level = 'verbose'");
+  REQUIRE(invalid != nullptr);
+  REQUIRE(invalid->HasError());
+  REQUIRE_THAT(
+    invalid->GetError(),
+    Catch::Contains(
+      "sirius_log_level must be one of: trace, debug, info, warn, error, critical, off"));
+
+  auto after_invalid = con.Query("SELECT current_setting('sirius_log_level')::VARCHAR");
+  REQUIRE(after_invalid != nullptr);
+  REQUIRE_FALSE(after_invalid->HasError());
+  REQUIRE(after_invalid->GetValue(0, 0).GetValue<std::string>() == "warn");
+  REQUIRE(duckdb::Config::LOG_LEVEL == "warn");
+  REQUIRE_FALSE(sirius::log::get_sink()->should_log(sirius::log::level::info));
+  REQUIRE(sirius::log::get_sink()->should_log(sirius::log::level::warn));
+
+  auto critical = con.Query("SET sirius_log_level = 'critical'");
+  REQUIRE(critical != nullptr);
+  REQUIRE_FALSE(critical->HasError());
+  REQUIRE(duckdb::Config::LOG_LEVEL == "critical");
+  REQUIRE_FALSE(sirius::log::get_sink()->should_log(sirius::log::level::error));
+  REQUIRE(sirius::log::get_sink()->should_log(sirius::log::level::critical));
+
+  auto off = con.Query("SET sirius_log_level = 'off'");
+  REQUIRE(off != nullptr);
+  REQUIRE_FALSE(off->HasError());
+  REQUIRE(duckdb::Config::LOG_LEVEL == "off");
+  REQUIRE_FALSE(sirius::log::get_sink()->should_log(sirius::log::level::critical));
+}
+
+TEST_CASE("Sirius startup rejects unknown environment log levels before mutation",
+          "[sirius][context][config][isolated_context]")
+{
+  auto const previous_level   = duckdb::Config::LOG_LEVEL;
+  auto const previous_backend = duckdb::Config::LOG_BACKEND;
+  auto const previous_sink    = sirius::log::get_sink();
+  std::optional<std::string> previous_env_level;
+  std::optional<std::string> previous_env_backend;
+  if (auto const* value = std::getenv("SIRIUS_LOG_LEVEL")) { previous_env_level = value; }
+  if (auto const* value = std::getenv("SIRIUS_LOG_BACKEND")) { previous_env_backend = value; }
+  finally restore_logging{[&]() {
+    duckdb::Config::LOG_LEVEL   = previous_level;
+    duckdb::Config::LOG_BACKEND = previous_backend;
+    sirius::log::set_sink(previous_sink);
+    if (previous_env_level) {
+      setenv("SIRIUS_LOG_LEVEL", previous_env_level->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_LOG_LEVEL");
+    }
+    if (previous_env_backend) {
+      setenv("SIRIUS_LOG_BACKEND", previous_env_backend->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_LOG_BACKEND");
+    }
+    setenv("SIRIUS_DISABLE", "1", 1);
+  }};
+
+  setenv("SIRIUS_DISABLE", "1", 1);
+  setenv("SIRIUS_LOG_BACKEND", "noop", 1);
+  duckdb::Config::LOG_LEVEL = "warn";
+  setenv("SIRIUS_LOG_LEVEL", "verbose", 1);
+
+  REQUIRE_THROWS_WITH(
+    duckdb::SiriusContextExtensionCallback{},
+    Catch::Contains(
+      "SIRIUS_LOG_LEVEL must be one of: trace, debug, info, warn, error, critical, off; got "
+      "'verbose'"));
+  REQUIRE(duckdb::Config::LOG_LEVEL == "warn");
+  REQUIRE(duckdb::Config::LOG_BACKEND == previous_backend);
+
+  setenv("SIRIUS_LOG_LEVEL", "critical", 1);
+  duckdb::SiriusContextExtensionCallback valid_callback;
+  REQUIRE(duckdb::Config::LOG_LEVEL == "critical");
+  REQUIRE(duckdb::Config::LOG_BACKEND == "noop");
+  REQUIRE_FALSE(sirius::log::get_sink()->should_log(sirius::log::level::critical));
 }
 
 TEST_CASE("Sirius configuration loading from file with configurator",
@@ -1232,6 +1421,168 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   auto const& compression = sirius_ctx->get_config().get_compression_config();
   REQUIRE(compression.enable_pin_table_compression);
   REQUIRE(compression.max_compressed_fraction == Approx(0.6));
+}
+
+TEST_CASE("DuckDB setting preserves the Sirius log directory when sink construction fails",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  auto const previous_backend = duckdb::Config::LOG_BACKEND;
+  auto const previous_log_dir = duckdb::Config::LOG_DIR;
+  auto const previous_sink    = sirius::log::get_sink();
+  auto const test_root        = fs::temp_directory_path() / "sirius-log-dir-rollback-test";
+  finally restore_logging{[&]() {
+    duckdb::Config::LOG_BACKEND = previous_backend;
+    duckdb::Config::LOG_DIR     = previous_log_dir;
+    sirius::log::set_sink(previous_sink);
+    fs::remove_all(test_root);
+  }};
+
+  fs::remove_all(test_root);
+  fs::create_directories(test_root);
+  auto const valid_dir = test_root / "valid";
+  auto const blocker   = test_root / "not-a-directory";
+  std::ofstream(blocker) << "file";
+  auto const invalid_dir = blocker / "child";
+
+  duckdb::Config::LOG_BACKEND = "spdlog";
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto valid = con.Query("SET sirius_log_dir = '" + valid_dir.string() + "'");
+  REQUIRE(valid != nullptr);
+  REQUIRE_FALSE(valid->HasError());
+  REQUIRE(duckdb::Config::LOG_DIR == valid_dir.string());
+  auto const valid_sink = sirius::log::get_sink();
+
+  auto invalid = con.Query("SET sirius_log_dir = '" + invalid_dir.string() + "'");
+  REQUIRE(invalid != nullptr);
+  REQUIRE(invalid->HasError());
+
+  auto after_invalid = con.Query("SELECT current_setting('sirius_log_dir')::VARCHAR");
+  REQUIRE(after_invalid != nullptr);
+  REQUIRE_FALSE(after_invalid->HasError());
+  REQUIRE(after_invalid->GetValue(0, 0).GetValue<std::string>() == valid_dir.string());
+  REQUIRE(duckdb::Config::LOG_DIR == valid_dir.string());
+  REQUIRE(sirius::log::get_sink() == valid_sink);
+}
+
+TEST_CASE("Sirius startup preserves logging settings when sink construction fails",
+          "[sirius][context][config][isolated_context]")
+{
+  auto const previous_backend = duckdb::Config::LOG_BACKEND;
+  auto const previous_log_dir = duckdb::Config::LOG_DIR;
+  auto const previous_level   = duckdb::Config::LOG_LEVEL;
+  auto const previous_sink    = sirius::log::get_sink();
+  std::optional<std::string> previous_env_backend;
+  std::optional<std::string> previous_env_log_dir;
+  std::optional<std::string> previous_env_level;
+  std::optional<std::string> previous_env_disable;
+  if (auto const* value = std::getenv("SIRIUS_LOG_BACKEND")) { previous_env_backend = value; }
+  if (auto const* value = std::getenv("SIRIUS_LOG_DIR")) { previous_env_log_dir = value; }
+  if (auto const* value = std::getenv("SIRIUS_LOG_LEVEL")) { previous_env_level = value; }
+  if (auto const* value = std::getenv("SIRIUS_DISABLE")) { previous_env_disable = value; }
+
+  auto const test_root = fs::temp_directory_path() / "sirius-startup-log-dir-rollback-test";
+  finally restore_logging{[&]() {
+    duckdb::Config::LOG_BACKEND = previous_backend;
+    duckdb::Config::LOG_DIR     = previous_log_dir;
+    duckdb::Config::LOG_LEVEL   = previous_level;
+    sirius::log::set_sink(previous_sink);
+    if (previous_env_backend) {
+      setenv("SIRIUS_LOG_BACKEND", previous_env_backend->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_LOG_BACKEND");
+    }
+    if (previous_env_log_dir) {
+      setenv("SIRIUS_LOG_DIR", previous_env_log_dir->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_LOG_DIR");
+    }
+    if (previous_env_level) {
+      setenv("SIRIUS_LOG_LEVEL", previous_env_level->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_LOG_LEVEL");
+    }
+    if (previous_env_disable) {
+      setenv("SIRIUS_DISABLE", previous_env_disable->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_DISABLE");
+    }
+    fs::remove_all(test_root);
+  }};
+
+  fs::remove_all(test_root);
+  fs::create_directories(test_root);
+  auto const valid_dir = test_root / "valid";
+  auto const blocker   = test_root / "not-a-directory";
+  std::ofstream(blocker) << "file";
+  auto const invalid_dir = blocker / "child";
+
+  duckdb::Config::LOG_BACKEND = "noop";
+  duckdb::Config::LOG_DIR     = valid_dir.string();
+  duckdb::Config::LOG_LEVEL   = "warn";
+  setenv("SIRIUS_LOG_BACKEND", "spdlog", 1);
+  setenv("SIRIUS_LOG_DIR", invalid_dir.string().c_str(), 1);
+  setenv("SIRIUS_LOG_LEVEL", "debug", 1);
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  REQUIRE_THROWS(duckdb::SiriusContextExtensionCallback{});
+  REQUIRE(duckdb::Config::LOG_BACKEND == "noop");
+  REQUIRE(duckdb::Config::LOG_DIR == valid_dir.string());
+  REQUIRE(duckdb::Config::LOG_LEVEL == "warn");
+  REQUIRE(sirius::log::get_sink() == previous_sink);
+
+  setenv("SIRIUS_LOG_DIR", valid_dir.string().c_str(), 1);
+  duckdb::SiriusContextExtensionCallback valid_callback;
+  REQUIRE(duckdb::Config::LOG_BACKEND == "spdlog");
+  REQUIRE(duckdb::Config::LOG_DIR == valid_dir.string());
+  REQUIRE(duckdb::Config::LOG_LEVEL == "debug");
+}
+
+TEST_CASE("DuckDB setting rejects negative Sirius log flush intervals without mutation",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  auto const previous_seconds = duckdb::Config::LOG_FLUSH_SECONDS;
+  finally restore_seconds{[&]() {
+    duckdb::Config::LOG_FLUSH_SECONDS = previous_seconds;
+    duckdb::install_configured_log_sink(nullptr);
+  }};
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto positive = con.Query("SET sirius_log_flush_seconds = 7");
+  REQUIRE(positive != nullptr);
+  REQUIRE_FALSE(positive->HasError());
+  REQUIRE(duckdb::Config::LOG_FLUSH_SECONDS == 7);
+
+  auto negative = con.Query("SET sirius_log_flush_seconds = -1");
+  REQUIRE(negative != nullptr);
+  REQUIRE(negative->HasError());
+  REQUIRE_THAT(negative->GetError(),
+               Catch::Contains("sirius_log_flush_seconds must be non-negative; zero disables"));
+
+  auto after_negative = con.Query("SELECT current_setting('sirius_log_flush_seconds')::INTEGER");
+  REQUIRE(after_negative != nullptr);
+  REQUIRE_FALSE(after_negative->HasError());
+  REQUIRE(after_negative->GetValue(0, 0).GetValue<int32_t>() == 7);
+  REQUIRE(duckdb::Config::LOG_FLUSH_SECONDS == 7);
+
+  auto disabled = con.Query("SET sirius_log_flush_seconds = 0");
+  REQUIRE(disabled != nullptr);
+  REQUIRE_FALSE(disabled->HasError());
+  REQUIRE(duckdb::Config::LOG_FLUSH_SECONDS == 0);
+
+  auto after_disabled = con.Query("SELECT current_setting('sirius_log_flush_seconds')::INTEGER");
+  REQUIRE(after_disabled != nullptr);
+  REQUIRE_FALSE(after_disabled->HasError());
+  REQUIRE(after_disabled->GetValue(0, 0).GetValue<int32_t>() == 0);
 }
 
 TEST_CASE("Sirius configuration loading from file with spaces",


### PR DESCRIPTION
## What changes for users

When Sirius rebuilds an spdlog sink after a logging-setting change, a failed
rebuild must not leave the reported configuration describing a sink that never
became active. This PR now restores the prior flush interval when that rebuild
fails, matching its existing rollback behavior for backend and directory
changes.

Users still choose the supported logging backend, directory, level, and flush
interval. Sirius owns validation and the transactional sink replacement. A
focused regression forces the deterministic invalid-directory failure and
checks that both the previous current_setting value and the exact active sink
remain unchanged. The evidence boundary is that deterministic construction
failure; this does not claim recovery from arbitrary external filesystem
failures after a sink is installed.

## Summary

- reject unsupported startup and runtime logging backend/level values before mutation
- preserve the active backend, directory, sink, and startup logging tuple when replacement sink construction fails
- restore LOG_FLUSH_SECONDS when spdlog sink reconstruction fails
- reject negative sirius_log_flush_seconds while preserving 0 as the explicit periodic-flush opt-out
- consolidate the adjacent logging validation formerly carried by #1516 into the rollback transaction already reviewed here

## Contract

Runtime backend changes accept only duckdb, spdlog, or noop; runtime level
changes accept only trace, debug, info, warn, error, critical, or off. Rejected
names leave visible and effective logging state unchanged. Runtime directory,
backend, and flush-interval transitions restore their prior process-global
value when sink construction fails, and startup restores the complete
backend/directory/level tuple. Flush intervals must be non-negative; 0 disables
periodic flushing.

## Why one PR

Validation and rollback touch the same startup tuple, setters, and
isolated-context regressions. Keeping them together makes the invariant
reviewable in one place: validate before mutation, then restore the prior
coupled state if the external sink transition fails. This supersedes #1516;
#1517 and #1520 were already consolidated into those two predecessor heads.

## Current public identity

- prior reviewed public head: 6afa3b389ba4309fb30f5dd281fc65b0ff9e2783
- replacement head: 2373ed62af7324d7744682b20ebbe481f9715ec2
- candidate tree: c81c11e0851bbc75a335edfa0a986c005b954b9a
- three-path review-repair diff SHA-256:
  67a00f054e528488863a4adf60e469336f268d8d1feaeca9e4dc1ba7d5cda1a8
- current Sirius dev observed during repair:
  de71900686ddcfab66812c3f29c12f848f7c8f2e; GitHub reports the replacement
  head mergeable

## Review repair

- restores LOG_FLUSH_SECONDS on any install_configured_log_sink throw and rethrows
- adds a focused invalid-directory regression that verifies the prior
  DuckDB-visible value, process-global value, and exact sink identity
- changes the three environment pointers to auto const*
- uses non-throwing std::filesystem::remove_all overloads in the affected
  failure-test teardown paths

## Validation

- complete replacement diff independently cold-reviewed; no submodule or unrelated-source drift
- targeted repository pre-commit hooks pass, including clang-format, codespell,
  and orphan-test validation
- explicit scripts/check_orphan_tests.py, git diff --check, and git show --check pass
- native C++ execution was unavailable on the Apple-arm64 author host without
  the Sirius Pixi/CUDA environment
- replacement exact-head hosted CI passes: Check 32994600965, Test
  32994601203, Distribution 32994602370, and Validate 32994766298

### Retained predecessor hosted receipts

- rollback head 19e58e4e6d57b93d1ec2e7a2ab0f75f180052c2c: workflow
  31726205775; CUDA 13 runtime job 94536097118 and terminal aggregate job
  94545844935 passed
- validation head a3dfe9e218c816b834de81e75579d08e629a6eea: workflow
  31726952876; CUDA 13 runtime job 94540138947 and terminal aggregate job
  94551660464 passed

### Retained failed-head repair receipt

- first consolidated head 8429111bfa225f5d9ae17b088b4b9ee35d5f6c15 omitted
  the validation predecessor's utils/log_test_utils.hpp include while retaining
  its scoped_recording_log_sink regression
- exact-head workflows 31732638303 and 31732638391 failed compilation at
  test/cpp/config/test_context.cpp:350
- repaired head deb2902807c19c8bbabde9f8b87c4073819116a8: workflow
  31733223327; runtime job 94559525138 and aggregate job 94566061275 passed
- the failed predecessor remains separately retained and receives no terminal credit

### Retained pre-review current-dev receipt

- head 6afa3b389ba4309fb30f5dd281fc65b0ff9e2783: hosted lint, GCC, Clang,
  CUDA 13 build/runtime, TPC-H snapshot, and terminal aggregate passed
- Check 32350078769, Test 32350078679, Distribution 32350079434