### PR TITLE
fix(config): preserve log backend on sink errors

### DIFF
--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -1586,7 +1586,14 @@ void install_configured_log_sink(DatabaseInstance* db)
 
 SiriusContextExtensionCallback::SiriusContextExtensionCallback()
 {
-  if (auto* env = std::getenv("SIRIUS_LOG_BACKEND")) { Config::LOG_BACKEND = env; }
+  if (auto* env = std::getenv("SIRIUS_LOG_BACKEND")) {
+    std::string_view const backend{env};
+    if (backend != "duckdb" && backend != "spdlog" && backend != "noop") {
+      throw InvalidInputException(
+        "SIRIUS_LOG_BACKEND must be one of: duckdb, spdlog, noop; got '%s'", env);
+    }
+    Config::LOG_BACKEND = env;
+  }
   if (auto* env = std::getenv("SIRIUS_LOG_DIR")) { Config::LOG_DIR = env; }
   if (auto* env = std::getenv("SIRIUS_LOG_LEVEL")) { Config::LOG_LEVEL = env; }
   // Install now (no db yet) so spdlog/noop capture the logs emitted by

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1926,8 +1926,14 @@ static void SetLogBackend(ClientContext& context, SetScope scope, Value& paramet
     throw InvalidInputException("Unknown sirius_log_backend '%s' (expected: duckdb, spdlog, noop)",
                                 backend);
   }
-  Config::LOG_BACKEND = std::move(backend);
-  install_configured_log_sink(context.db.get());
+  auto const previous_backend = Config::LOG_BACKEND;
+  Config::LOG_BACKEND         = std::move(backend);
+  try {
+    install_configured_log_sink(context.db.get());
+  } catch (...) {
+    Config::LOG_BACKEND = previous_backend;
+    throw;
+  }
   SIRIUS_LOG_DEBUG("Updated config LOG_BACKEND to {}", Config::LOG_BACKEND);
 }
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "catch.hpp"
+#include "log/sink.hpp"
 #include "sirius_context.hpp"
 
 #include <cudf/contiguous_split.hpp>
@@ -248,6 +249,63 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
   }
+}
+
+TEST_CASE("DuckDB setting preserves the Sirius log backend when sink construction fails",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  auto const previous_backend = duckdb::Config::LOG_BACKEND;
+  auto const previous_log_dir = duckdb::Config::LOG_DIR;
+  auto const previous_sink    = sirius::log::get_sink();
+  auto const test_root        = fs::temp_directory_path() / "sirius-log-backend-rollback-test";
+  finally restore_logging{[&]() {
+    duckdb::Config::LOG_BACKEND = previous_backend;
+    duckdb::Config::LOG_DIR     = previous_log_dir;
+    sirius::log::set_sink(previous_sink);
+    fs::remove_all(test_root);
+  }};
+
+  fs::remove_all(test_root);
+  fs::create_directories(test_root);
+  auto const blocker = test_root / "not-a-directory";
+  std::ofstream(blocker) << "file";
+  auto const invalid_dir = blocker / "child";
+  auto const valid_dir   = test_root / "valid";
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto noop = con.Query("SET sirius_log_backend = 'noop'");
+  REQUIRE(noop != nullptr);
+  REQUIRE_FALSE(noop->HasError());
+  auto const noop_sink = sirius::log::get_sink();
+
+  auto stage_invalid_dir = con.Query("SET sirius_log_dir = '" + invalid_dir.string() + "'");
+  REQUIRE(stage_invalid_dir != nullptr);
+  REQUIRE_FALSE(stage_invalid_dir->HasError());
+
+  auto invalid_spdlog = con.Query("SET sirius_log_backend = 'spdlog'");
+  REQUIRE(invalid_spdlog != nullptr);
+  REQUIRE(invalid_spdlog->HasError());
+
+  auto after_invalid = con.Query("SELECT current_setting('sirius_log_backend')::VARCHAR");
+  REQUIRE(after_invalid != nullptr);
+  REQUIRE_FALSE(after_invalid->HasError());
+  REQUIRE(after_invalid->GetValue(0, 0).GetValue<std::string>() == "noop");
+  REQUIRE(duckdb::Config::LOG_BACKEND == "noop");
+  REQUIRE(sirius::log::get_sink() == noop_sink);
+
+  auto repair_dir = con.Query("SET sirius_log_dir = '" + valid_dir.string() + "'");
+  REQUIRE(repair_dir != nullptr);
+  REQUIRE_FALSE(repair_dir->HasError());
+
+  auto valid_spdlog = con.Query("SET sirius_log_backend = 'spdlog'");
+  REQUIRE(valid_spdlog != nullptr);
+  REQUIRE_FALSE(valid_spdlog->HasError());
+  REQUIRE(duckdb::Config::LOG_BACKEND == "spdlog");
 }
 
 TEST_CASE("Sirius configuration loading from file with configurator",

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -308,6 +308,38 @@ TEST_CASE("DuckDB setting preserves the Sirius log backend when sink constructio
   REQUIRE(duckdb::Config::LOG_BACKEND == "spdlog");
 }
 
+TEST_CASE("Sirius startup rejects unknown environment log backends before mutation",
+          "[sirius][context][config][isolated_context]")
+{
+  auto const previous_backend = duckdb::Config::LOG_BACKEND;
+  auto const previous_sink    = sirius::log::get_sink();
+  std::optional<std::string> previous_env_backend;
+  if (auto const* value = std::getenv("SIRIUS_LOG_BACKEND")) { previous_env_backend = value; }
+  finally restore_logging{[&]() {
+    duckdb::Config::LOG_BACKEND = previous_backend;
+    sirius::log::set_sink(previous_sink);
+    if (previous_env_backend) {
+      setenv("SIRIUS_LOG_BACKEND", previous_env_backend->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_LOG_BACKEND");
+    }
+    setenv("SIRIUS_DISABLE", "1", 1);
+  }};
+
+  setenv("SIRIUS_DISABLE", "1", 1);
+  duckdb::Config::LOG_BACKEND = "noop";
+  setenv("SIRIUS_LOG_BACKEND", "syslog", 1);
+
+  REQUIRE_THROWS_WITH(
+    duckdb::SiriusContextExtensionCallback{},
+    Catch::Contains("SIRIUS_LOG_BACKEND must be one of: duckdb, spdlog, noop; got 'syslog'"));
+  REQUIRE(duckdb::Config::LOG_BACKEND == "noop");
+
+  setenv("SIRIUS_LOG_BACKEND", "duckdb", 1);
+  duckdb::SiriusContextExtensionCallback valid_callback;
+  REQUIRE(duckdb::Config::LOG_BACKEND == "duckdb");
+}
+
 TEST_CASE("Sirius configuration loading from file with configurator",
           "[sirius][context][isolated_context]")
 {


### PR DESCRIPTION
## Summary

- restore the prior process-global `sirius_log_backend` when installing its replacement sink fails
- preserve DuckDB-visible and process-global state on the deterministic invalid-directory construction failure
- prove the failed transition remains recoverable after correcting the staged log directory
- reject unsupported startup `SIRIUS_LOG_BACKEND` values before process-global mutation

## Why

While the `noop` backend is active, `sirius_log_dir` may legitimately stage a path without constructing a file sink. Switching to `spdlog` assigns `Config::LOG_BACKEND` before trying that path. If construction rejects it, DuckDB reports the backend `SET` as failed and keeps the visible value at `noop`, but Sirius currently retains `spdlog` internally. At startup, an unknown environment value is also assigned and only rejected later when a DatabaseInstance exists, poisoning process-global state across a retry.

## Validation

- focused isolated-context regression stages an invalid directory under `noop`, requires the `spdlog` transition to fail, and proves visible/effective backend nonmutation
- the same regression corrects the directory and proves the subsequent `spdlog` transition succeeds
- startup constructor regression proves exact unknown-environment failure/nonmutation and valid `duckdb` application
- `python3 scripts/check_orphan_tests.py`
- `git diff --check`
- clean independent merge trees with #1517 (`01dff114f8c0eb4c015f32baf871116d19de1c99`), #1519 (`9d740aebcb0d36d41d492a9d811e42202d66936d`), and #1522 (`4bf74ed20194fcfad4cda6a0774f5b49121e457b`)
- #1516 now validates the neighboring startup log-level environment value in the same constructor and adds independent tests in the same file; the combined resolution is the union of the two validation blocks and test cases
- fresh exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, distribution, check, PR-title, full runtime, and terminal aggregate checks pass
- test workflow `31704934195` passed at the exact candidate; runtime job `94464053089` ran from `2026-08-13T14:56:41Z` through `2026-08-13T15:16:04Z` (19m23s), including C++ unit tests and the TPC-H snapshot; terminal aggregate job `94495565907` passed

This claim is scoped to the concrete invalid-directory sink-construction path; it does not claim every hypothetical exception in spdlog's global setup is strongly transactional.

Exact base: `0d7f98d9a662e9e3b47d6f7d6e2c8797d1e6572b`
Candidate: `c9ed92d4c6427ba817741da0394213091de13c9c`
Candidate tree: `4bae1faf666f0c129477f8973669883677c94a4f`
Zero-context source patch SHA-256: `cdbba82b50612532923d6acf61e7fd1ec783ba2540fcedb6f804d58249972066`
