### PR TITLE
refactor(config): keep scheduling choices internal

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -278,8 +278,11 @@ Thread pool (default `num_threads: 1`) plus:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `strategy` | enum: `active`, `lookahead` | `active` | Most speculative request type the task creator may use. `active` is demand-driven only; `lookahead` additionally warms up not-yet-activated scans one task at a time. Values are lowercase. |
 | `priority_order` | enum: `source`, `sink` | `source` | Order in which the task creator prioritizes tasks within a duckdb pipeline. `source` closer to source has higher priority; `sink` closer to sink has higher priority. Values are lowercase. |
+
+Task creation policy is internal and currently demand-driven. The former
+`sirius.executor.task_creator.strategy` key has been removed; configurations that still contain it
+must delete the key.
 
 ### `sirius.executor.pipeline`
 

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -274,15 +274,12 @@ hardware-derived exception described below:
 
 ### `sirius.executor.task_creator`
 
-Thread pool (default `num_threads: 1`) plus:
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `priority_order` | enum: `source`, `sink` | `source` | Order in which the task creator prioritizes tasks within a duckdb pipeline. `source` closer to source has higher priority; `sink` closer to sink has higher priority. Values are lowercase. |
-
-Task creation policy is internal and currently demand-driven. The former
-`sirius.executor.task_creator.strategy` key has been removed; configurations that still contain it
-must delete the key.
+Thread pool (default `num_threads: 1`). Task creation
+policy and within-branch priority are internal: Sirius currently creates tasks
+on demand and prioritizes source-side pipelines first. The former
+`sirius.executor.task_creator.strategy` and
+`sirius.executor.task_creator.priority_order` keys have been removed;
+configurations that still contain either key must delete it.
 
 ### `sirius.executor.pipeline`
 

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -363,13 +363,11 @@ If translation fails, filtering falls back to `expression_evaluator` on the deco
 **Mechanism:** The walk is structured for minimal, parallel, typed metadata access with statistics pruning:
 1. **Projected-column-only, typed walk (#868, #936):** `walk_duckdb_native_row_group_range()` walks the DuckDB segment trees directly for only the projected columns, reading typed `block_id` / compression / row counts / validity-child / max-string-length per segment instead of calling `GetColumnSegmentInfo` and re-parsing strings.
 2. **Stats pruning (#900):** `prepare_duckdb_native_walk()` evaluates DuckDB's own `TableFilter::CheckStatistics` against each row group's per-column statistics and drops any row group a pushed-down filter proves `FILTER_ALWAYS_FALSE` before it is staged, copied to the GPU, or decoded; an all-pruned table routes to DuckDB CPU up front.
-3. **Parallel range walk + early decode (#895):** `prepare_duckdb_native_walk()` runs as a cheap serial pre-step (partition stats, type-viability gate, row-group count) with no per-segment I/O; the row groups are sliced into ranges of `SIRIUS_METADATA_PARSE_CHUNK` groups, and the scan-manager pool walks the ranges in parallel so cold segment reads for different ranges overlap. The batch coalescer packs parsed ranges into cap-sized batches that decode while later ranges are still being parsed.
+3. **Parallel range walk + early decode (#895):** `prepare_duckdb_native_walk()` runs as a cheap serial pre-step (partition stats, type-viability gate, row-group count) with no per-segment I/O; the row groups are sliced into fixed internal ranges of eight groups, and the scan-manager pool walks the ranges in parallel so cold segment reads for different ranges overlap. The batch coalescer packs parsed ranges into cap-sized batches that decode while later ranges are still being parsed.
 
 **Code path:**
 - `src/op/scan/duckdb_native_metadata.cpp` — `prepare_duckdb_native_walk()`, `walk_duckdb_native_row_group_range()`, `mark_row_groups_pruned_by_filter_stats()`
 - `src/op/scan/duckdb_native_gpu_ingestible.cpp` — parse-range slicing, per-range walk thunks, and the `duckdb_native_batch_coalescer`
-
-**Config:** `SIRIUS_METADATA_PARSE_CHUNK` (row groups per parallel parse range, default 8)
 
 ### DuckDB-Native Async Coalesced Reads (PR #849)
 

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -70,11 +70,12 @@ num_partitions = max(1, ceil(total_bytes / hash_partition_bytes))
 
 **Motivation:** With demand-driven (`active`) task creation, a drained task queue leaves GPU workers idle even when not-yet-activated scans could already be producing work.
 
-**Mechanism:** The task creator keeps a `_lookahead_queue` of candidate operators (built at query start from the plan's scan operators after the first, cleared on drain/restart). When the task scheduler finds its task queue empty, it calls `schedule_lookahead(device_hint)`, which — only under `strategy: lookahead` — emits one speculative request for the next not-yet-activated operator, warming scans up one task at a time. The manager loop creates a single task per look-ahead request rather than draining the source. See [task-creator.md](task-creator.md).
+**Mechanism:** The task creator retains a `_lookahead_queue` of candidate operators (built at query start from the plan's scan operators after the first, cleared on drain/restart). When an engine-controlled policy selects the internal `request_type::lookahead` primitive and the task scheduler finds its task queue empty, `schedule_lookahead(device_hint)` emits one speculative request for the next not-yet-activated operator, warming scans up one task at a time. The manager loop creates a single task per look-ahead request rather than draining the source. See [task-creator.md](task-creator.md).
 
 **Code path:** `src/creator/task_creator.cpp` — `schedule_lookahead()`; `src/pipeline/task_scheduler.cpp` — empty-queue trigger; `src/include/creator/config.hpp` — `request_type`
 
-**Config:** `executor.task_creator.strategy` (`active` default, `lookahead` opt-in) — see [configuration.md](configuration.md).
+**Policy:** internal. The current shipped policy is active and demand-driven;
+look-ahead is not a user-selectable YAML setting.
 
 ## Operator-Level Optimizations
 

--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -91,7 +91,7 @@ There is no factory class. Each implementation provides a free `make_ingestible(
 
 ### DuckDB-native ingestible
 
-`duckdb_native_gpu_ingestible` (`duckdb_native_gpu_ingestible.{hpp,cpp}`) prepares a serial walk plan in its constructor (`prepare_duckdb_native_walk`: partition statistics, projected-type viability gate, and filter-stat row-group pruning — a non-viable query throws to trigger CPU fallback before any per-segment IO). It slices the table's row groups into fixed-size parse ranges (`SIRIUS_METADATA_PARSE_CHUNK`, default 8). `next_split_provider` hands out one range per claim; each metadata task walks that range and emits a `duckdb_native_scan_info`. `materialize_metadata_to_table` decodes the range's storage segments into a `cudf::table` (always `UNFILTERED`); filter evaluation and projection to output arity happen in `post_filter_and_project`.
+`duckdb_native_gpu_ingestible` (`duckdb_native_gpu_ingestible.{hpp,cpp}`) prepares a serial walk plan in its constructor (`prepare_duckdb_native_walk`: partition statistics, projected-type viability gate, and filter-stat row-group pruning — a non-viable query throws to trigger CPU fallback before any per-segment IO). It slices the table's row groups into fixed internal ranges of eight groups. `next_split_provider` hands out one range per claim; each metadata task walks that range and emits a `duckdb_native_scan_info`. `materialize_metadata_to_table` decodes the range's storage segments into a `cudf::table` (always `UNFILTERED`); filter evaluation and projection to output arity happen in `post_filter_and_project`.
 
 ## owning_table_view
 
@@ -335,7 +335,7 @@ The result is a `duckdb_native_walk_plan` carrying per-row-group row starts/coun
 
 ### Phase 2 — `walk_duckdb_native_row_group_range()` (concurrent)
 
-The row-group range `[0, n_row_groups)` is sliced into fixed-size parse chunks (default 8 row groups, `SIRIUS_METADATA_PARSE_CHUNK`), and each chunk is walked independently on a scan-manager thread. For each surviving row group in its range, a range walk:
+The row-group range `[0, n_row_groups)` is sliced into fixed internal chunks of eight row groups, and each chunk is walked independently on a scan-manager thread. For each surviving row group in its range, a range walk:
 
 - Walks each projected column's **typed segment trees** directly — reading `block_id`, block offset, compression enum, per-segment row counts, the validity child's segments, and (for varchar) the per-segment max-string-length stat as typed fields. It does not build or re-parse the per-segment string blobs that DuckDB's generic `GetColumnSegmentInfo` would produce.
 - Refuses on the first unsupported segment codec or an absent/over-threshold varchar stat, partially filling the range (which the caller then discards in favor of CPU fallback).

--- a/docs/super-sirius/task-creator.md
+++ b/docs/super-sirius/task-creator.md
@@ -8,8 +8,10 @@ This document covers the task creation subsystem: how the system decides when an
 
 The `task_creator` is a multi-threaded component that converts operator scheduling requests into concrete scan or GPU pipeline tasks. It maintains global state maps for each operator type and uses a hint-chain recursion to find the deepest ready operator.
 
-Task creation policy is internal and currently demand-driven. The engine retains its lookahead
-primitive for policy-controlled use, but users do not select it through YAML.
+Task creation policy is internal and currently demand-driven, with source-side
+pipelines prioritized first within each branch. The engine retains its
+lookahead and reverse-priority primitives for policy-controlled use, but users
+do not select either through YAML.
 
 ## Core Flow
 
@@ -217,7 +219,7 @@ The `mark_task_created()` call before data popping prevents a race condition whe
 
 **Files:** `src/include/creator/config.hpp`, `src/creator/task_creator.cpp`
 
-The task creator is constructed with a `task_creator_config` whose `strategy` is `request_type::active` (default, purely demand-driven) or `request_type::lookahead`. Under `lookahead`, `prepare_for_query` seeds a `_lookahead_queue` with the plan's scan operators after the first. When the task scheduler's management loop finds its task queue empty, it calls `schedule_lookahead(device_hint)`: the creator walks the queue from `_index_of_next_lookahead`, skips finished pipelines, and pushes one request tagged `request_type::lookahead` for the next not-yet-activated operator. A look-ahead request creates a **single** task (the manager loop breaks instead of draining the source), so speculation warms a scan up without committing its full memory footprint. Look-ahead state is cleared by `drain_pending_tasks()` and `reset()` so no dangling operator pointers survive `QueryEnd`. The knob is `executor.task_creator.strategy` — see [configuration.md](configuration.md).
+The task creator is constructed with a `task_creator_config` whose internal `strategy` is `request_type::active` (the current shipped, purely demand-driven policy) or `request_type::lookahead`. Under `lookahead`, `prepare_for_query` seeds a `_lookahead_queue` with the plan's scan operators after the first. When the task scheduler's management loop finds its task queue empty, it calls `schedule_lookahead(device_hint)`: the creator walks the queue from `_index_of_next_lookahead`, skips finished pipelines, and pushes one request tagged `request_type::lookahead` for the next not-yet-activated operator. A look-ahead request creates a **single** task (the manager loop breaks instead of draining the source), so speculation warms a scan up without committing its full memory footprint. Look-ahead state is cleared by `drain_pending_tasks()` and `reset()` so no dangling operator pointers survive `QueryEnd`. This primitive is retained for engine-controlled policy; it is not exposed through YAML.
 
 ## Device Assignment for GPU Tasks
 

--- a/docs/super-sirius/task-creator.md
+++ b/docs/super-sirius/task-creator.md
@@ -8,6 +8,9 @@ This document covers the task creation subsystem: how the system decides when an
 
 The `task_creator` is a multi-threaded component that converts operator scheduling requests into concrete scan or GPU pipeline tasks. It maintains global state maps for each operator type and uses a hint-chain recursion to find the deepest ready operator.
 
+Task creation policy is internal and currently demand-driven. The engine retains its lookahead
+primitive for policy-controlled use, but users do not select it through YAML.
+
 ## Core Flow
 
 ```

--- a/src/include/creator/config.hpp
+++ b/src/include/creator/config.hpp
@@ -100,8 +100,9 @@ struct task_creator_config {
   /// (demand-driven only); lookahead remains available to engine-controlled policy.
   request_type strategy{request_type::active};
 
-  /// Within-branch scheduling priority direction, consumed by compute_pipeline_priorities.
-  /// source keeps plan order (head/scan first); sink reverses it.
+  /// Internal within-branch scheduling priority, consumed by compute_pipeline_priorities.
+  /// The current engine policy keeps plan order (head/scan first); sink remains available to a
+  /// future engine-controlled policy.
   priority_order priority{priority_order::source};
 };
 

--- a/src/include/creator/config.hpp
+++ b/src/include/creator/config.hpp
@@ -91,14 +91,13 @@ inline bool enum_to_string(priority_order order, std::string& s)
 inline constexpr int default_task_creator_num_threads = 1;
 
 /// Configuration for the task creator.
-/// Embeds the thread pool config plus the task creation strategy.
+/// Embeds the thread pool config plus internal scheduling policy.
 struct task_creator_config {
   exec::thread_pool_config thread_pool{.num_threads        = default_task_creator_num_threads,
                                        .thread_name_prefix = "task_creator"};
 
-  /// The most speculative request type the task creator is allowed to use when
-  /// servicing scheduling requests: active (demand-driven only) or lookahead
-  /// (additionally warm up not-yet-activated scans one task at a time).
+  /// Internal policy for servicing scheduling requests. The current default is active
+  /// (demand-driven only); lookahead remains available to engine-controlled policy.
   request_type strategy{request_type::active};
 
   /// Within-branch scheduling priority direction, consumed by compute_pipeline_priorities.

--- a/src/include/op/scan/duckdb_native_metadata.hpp
+++ b/src/include/op/scan/duckdb_native_metadata.hpp
@@ -214,9 +214,9 @@ struct duckdb_native_row_group_range {
 duckdb_native_row_group_range walk_duckdb_native_row_group_range(
   const duckdb_native_walk_plan& plan, std::size_t rg_begin, std::size_t rg_end);
 
-/// @brief Row groups per parallel-walk task unit (env `SIRIUS_METADATA_PARSE_CHUNK`,
-/// default 8). Shared by the metadata parse fan-out and the MVCC mask job so both
-/// slice row-group work into the same task granularity.
+/// @brief Row groups per parallel-walk task unit (fixed internally at 8).
+/// Shared by the metadata parse fan-out and the MVCC mask job so both slice
+/// row-group work into the same task granularity.
 std::size_t metadata_parse_chunk();
 
 }  // namespace sirius::op::scan

--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -44,7 +44,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
-#include <cstdlib>
 #include <limits>
 #include <optional>
 #include <string>
@@ -55,14 +54,9 @@ namespace sirius::op::scan {
 
 std::size_t metadata_parse_chunk()
 {
-  constexpr std::size_t kDefaultParseChunk = 8;
-  if (const char* env = std::getenv("SIRIUS_METADATA_PARSE_CHUNK")) {
-    try {
-      if (const auto v = std::stoull(env); v > 0) return static_cast<std::size_t>(v);
-    } catch (...) { /* fall through to default */
-    }
-  }
-  return kDefaultParseChunk;
+  // This is an internal scheduling granularity, not a user tuning surface.
+  constexpr std::size_t kParseChunk = 8;
+  return kParseChunk;
 }
 
 namespace {

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -146,9 +146,13 @@ static void from_yaml(const YAML::Node& node, exec::thread_pool_config& opt)
 static void from_yaml(const YAML::Node& node, creator::task_creator_config& opt)
 {
   yaml::reader r(node, "task_creator");
+  if (r.has("strategy")) {
+    throw std::runtime_error(
+      "'sirius.executor.task_creator.strategy': removed; task creation policy is internal and "
+      "currently demand-driven; remove this key");
+  }
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{0});
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
-  r.optional("strategy", opt.strategy);
   r.optional("priority_order", opt.priority);
   r.reject_unknown();
 }

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -151,9 +151,13 @@ static void from_yaml(const YAML::Node& node, creator::task_creator_config& opt)
       "'sirius.executor.task_creator.strategy': removed; task creation policy is internal and "
       "currently demand-driven; remove this key");
   }
+  if (r.has("priority_order")) {
+    throw std::runtime_error(
+      "'sirius.executor.task_creator.priority_order': removed; scheduling priority is internal "
+      "and currently source-first; remove this key");
+  }
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{0});
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
-  r.optional("priority_order", opt.priority);
   r.reject_unknown();
 }
 

--- a/test/cpp/config/data/invalid_task_creator_priority_order.yaml
+++ b/test/cpp/config/data/invalid_task_creator_priority_order.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    task_creator:
+      priority_order: sink

--- a/test/cpp/config/data/invalid_task_creator_strategy.yaml
+++ b/test/cpp/config/data/invalid_task_creator_strategy.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    task_creator:
+      strategy: lookahead

--- a/test/cpp/config/data/valid_task_creator_strategy_omitted.yaml
+++ b/test/cpp/config/data/valid_task_creator_strategy_omitted.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    task_creator:
+      num_threads: 1

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -468,7 +468,7 @@ TEST_CASE("Sirius configuration accepts intentional compression retention fracti
   require_fraction("valid_compression_fraction_above_one.yaml", 1.5);
 }
 
-TEST_CASE("Sirius configuration keeps task creation strategy internal", "[sirius][config]")
+TEST_CASE("Sirius configuration keeps task creation policy internal", "[sirius][config]")
 {
   std::source_location loc = std::source_location::current();
   auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
@@ -487,6 +487,17 @@ TEST_CASE("Sirius configuration keeps task creation strategy internal", "[sirius
     sirius::sirius_config config;
     REQUIRE_NOTHROW(config.load_from_file(data_dir / "valid_task_creator_strategy_omitted.yaml"));
     CHECK(config.get_task_creator_config().strategy == sirius::creator::request_type::active);
+    CHECK(config.get_task_creator_config().priority == sirius::creator::priority_order::source);
+  }
+
+  SECTION("explicit priority order is rejected with removal guidance")
+  {
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(
+      config.load_from_file(data_dir / "invalid_task_creator_priority_order.yaml"),
+      Catch::Contains("sirius.executor.task_creator.priority_order") &&
+        Catch::Contains("removed") && Catch::Contains("remove this key"));
+    CHECK(config.get_task_creator_config().priority == sirius::creator::priority_order::source);
   }
 }
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -468,6 +468,28 @@ TEST_CASE("Sirius configuration accepts intentional compression retention fracti
   require_fraction("valid_compression_fraction_above_one.yaml", 1.5);
 }
 
+TEST_CASE("Sirius configuration keeps task creation strategy internal", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  SECTION("explicit strategy is rejected with removal guidance")
+  {
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(config.load_from_file(data_dir / "invalid_task_creator_strategy.yaml"),
+                        Catch::Contains("sirius.executor.task_creator.strategy") &&
+                          Catch::Contains("removed") && Catch::Contains("remove this key"));
+    CHECK(config.get_task_creator_config().strategy == sirius::creator::request_type::active);
+  }
+
+  SECTION("omitted strategy retains the active demand-driven default")
+  {
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(config.load_from_file(data_dir / "valid_task_creator_strategy_omitted.yaml"));
+    CHECK(config.get_task_creator_config().strategy == sirius::creator::request_type::active);
+  }
+}
+
 namespace {
 
 void require_shared_operator_defaults(const sirius::operator_params& params, uint64_t batch)

--- a/test/cpp/scan_manager/test_insert_delta_job.cpp
+++ b/test/cpp/scan_manager/test_insert_delta_job.cpp
@@ -34,6 +34,7 @@
 #include <io/sirius_datasource.hpp>
 #include <memory/topology_index.hpp>
 #include <op/scan/duckdb_native_gpu_ingestible.hpp>
+#include <op/scan/duckdb_native_metadata.hpp>
 #include <scan_manager/insert_delta_job.hpp>
 #include <unistd.h>
 
@@ -432,19 +433,24 @@ TEST_CASE("insert-delta job: blockless-only splits carry no datasource",
 TEST_CASE("insert-delta job: a delta spanning multiple capture ranges merges in order",
           "[insert_delta_job][scan_manager]")
 {
-  // One row group per capture range so the delta below spans several
-  // dispatcher tasks.
+  // The former environment override must not change the fixed internal
+  // scheduling granularity.
   setenv("SIRIUS_METADATA_PARSE_CHUNK", "1", 1);
   struct chunk_env_restore {
     ~chunk_env_restore() { unsetenv("SIRIUS_METADATA_PARSE_CHUNK"); }
   } restore;
+  REQUIRE(sirius::op::scan::metadata_parse_chunk() == 8);
 
+  // Use enough row groups to span multiple fixed internal capture ranges.
+  constexpr std::size_t delta_rows = 1'250'000;
   job_test_db tdb;
   exec_ok(*tdb.con, "SET threads TO 1");
   exec_ok(*tdb.con, "CREATE TABLE t AS SELECT range::INTEGER AS k FROM range(10000)");
   exec_ok(*tdb.con, "CHECKPOINT");
-  exec_ok(*tdb.con, "INSERT INTO t SELECT (10000+range)::INTEGER FROM range(250000)");
-  exec_ok(*tdb.con, "INSERT INTO t VALUES (260000)");
+  exec_ok(
+    *tdb.con,
+    "INSERT INTO t SELECT (10000+range)::INTEGER FROM range(" + std::to_string(delta_rows) + ")");
+  exec_ok(*tdb.con, "INSERT INTO t VALUES (" + std::to_string(10000 + delta_rows) + ")");
 
   exec_ok(*tdb.con, "BEGIN TRANSACTION");
   auto& storage = resolve_storage(*tdb.con, "t");
@@ -454,7 +460,7 @@ TEST_CASE("insert-delta job: a delta spanning multiple capture ranges merges in 
   run(requests);
 
   auto const& request = requests[0];
-  REQUIRE(request.plan.row_groups.size() >= 3);
+  REQUIRE(request.plan.row_groups.size() > sirius::op::scan::metadata_parse_chunk());
 
   // Row-group order, contiguous boundaries, and filled columns survive the
   // parallel merge.
@@ -468,13 +474,13 @@ TEST_CASE("insert-delta job: a delta spanning multiple capture ranges merges in 
     expected_start += rg.row_count;
     plan_rows += rg.row_count;
   }
-  REQUIRE(plan_rows == 250001);
+  REQUIRE(plan_rows == delta_rows + 1);
 
   std::size_t bundle_rows = 0;
   for (auto const& b : request.bundles) {
     bundle_rows += b.total_rows;
   }
-  REQUIRE(bundle_rows == 250001);
+  REQUIRE(bundle_rows == delta_rows + 1);
   exec_ok(*tdb.con, "ROLLBACK");
 }
 


### PR DESCRIPTION
## Summary

- remove the experimental `sirius.executor.task_creator.strategy` YAML choice while retaining the active, demand-driven policy
- remove `sirius.executor.task_creator.priority_order` while retaining the source-first policy and the internal reverse primitive
- remove the `SIRIUS_METADATA_PARSE_CHUNK` environment override while keeping scan, insert-delta, and MVCC metadata ranges at eight row groups
- preserve the internal implementation primitives and real-path regressions

## Why one PR

These three settings expose internal scheduling choices without a stable deployment or workload selection rule. Task creation is engine policy; metadata parse granularity is shared by three internal schedulers. Keeping the existing policies internal removes coordination work from operators without changing a performance value or selecting a new architecture.

This supersedes #1502 and #1561. Their multi-range regression, ordered plan/bundle checks, task-priority deletion checks, and retained internal primitives are folded into this single review surface.

## Contract

- stale `strategy` and `priority_order` YAML keys fail with full-path deletion guidance
- omission retains active task creation and source-first priority
- `SIRIUS_METADATA_PARSE_CHUNK` no longer changes effective granularity
- shared metadata scheduling remains eight row groups per range
- active/lookahead, source/sink, and range-splitting primitives remain internal

## Coordination

- draft #1364 and #1369 do not overlap this patch's files; their task-creator implementations can continue to consume the retained internal request and priority primitives
- draft #1476 overlaps configuration documentation and parsing mechanically, but does not depend on restoring any removed user-facing scheduling key

## Rebased identity

- exact base: `34311516f1233c1f4aca4d16b0a7bf190fa197f9`
- exact head: `bf9c82ff7de728666134c408f54198784c511ac9`
- candidate tree: `1aa413ba2fe741ac09ddaa424708571111c1a68a`
- zero-context cumulative diff SHA-256: `b7604f803b0d17c0da94205d962b7cec51eb9c3f319d88125aeeef6f14d2d4ec`
- cumulative diff: 13 paths, 98 insertions, 41 deletions
- task-strategy predecessor: `173434e2e8e50e8dd6a41c96e501f9d54e0c0123`
- metadata-range predecessor from #1502: `bfdaa33bf45a32e7cdf8b1ad59441c7aaa072fe1`

## Validation

- rebased onto `dev` `34311516f1233c1f4aca4d16b0a7bf190fa197f9`
- the sole manual conflict was documentation adjacent to upstream's removal of `thread_name_prefix`; the resolution keeps that key absent and describes only the internal task policy
- range-diff preserves the two original behavior commits; source changes are limited to expected live-context movement around the removed `thread_name_prefix`
- cold review found and removed stale opt-in language in `optimizations.md` and `task-creator.md`; a repository-wide documentation search now leaves only the intentional removed-key migration notice
- orphan-test detection and `git diff --check` pass on the exact head
- hosted validation for the exact head is terminal green:
  - Check workflow `32194391799`: lint `95895311735`, GCC release `95895311832`, Clang debug `95895311835`, aggregate `95896552043`
  - Test workflow `32194391907`: CUDA 13 build `95895392366`, runtime `95896133435`, aggregate `95900573033`
  - Distribution workflow `32194392471`: gate `95895315132` passed; CUDA distribution jobs were correctly skipped because distribution inputs did not change

### Retained hosted receipts

- prior rebased head `f17c9decd91d970a8d327bef8058d8cbaa009988`: Check workflow `31915739364`, Test workflow `31915739377`, and Distribution workflow `31915739661` passed
- predecessor `78c09ddd2b932c9da9d0513466ad7771ae0c98e9`: Validate `31846057853`, Check `31846058468`, Test `31846058495`, runtime `94913278575`, and Distribution `31846058839` passed

Supersedes #1502 and #1561.
