### PR TITLE
fix(config): reject zero scan task batches

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -377,7 +377,7 @@ individually.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `scan_task_batch_size` | Shared physical/effective GPU batch default described above | Target batch size for DuckDB scan tasks |
+| `scan_task_batch_size` | Shared physical/effective GPU batch default described above | Target batch size for DuckDB scan tasks; must be greater than zero |
 | `enable_compressed_materialization` | true | Store eligible integer and fixed-point DECIMAL values in value-preserving narrower carriers when exact pin-time bounds permit it; restore native carriers at type-sensitive boundaries. |
 | `max_sort_partition_bytes` | 0 (auto) | Max bytes per sort partition. Auto = 33% of GPU memory. |
 | `hash_partition_bytes` | Shared physical/effective GPU batch default described above | Target partition size for hash joins and group-bys; must be greater than zero |
@@ -537,7 +537,7 @@ These can also be set at load via the `SIRIUS_LOG_BACKEND`, `SIRIUS_LOG_DIR`, an
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `scan_task_batch_size` | Shared physical/effective GPU batch default | Target scan batch size |
+| `scan_task_batch_size` | Shared physical/effective GPU batch default | Target scan batch size; must be greater than zero |
 | `enable_compressed_materialization` | true | Keep eligible integer and fixed-point DECIMAL values in narrower physical carriers until a native semantic boundary. |
 
 `enable_compressed_materialization` is also accepted in YAML under `sirius.operator_params`.

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -253,6 +253,9 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
 {
   yaml::reader r(node, "operator_params");
   r.optional("scan_task_batch_size", yaml::bytes(opt.scan_task_batch_size));
+  if (opt.scan_task_batch_size == 0) {
+    throw std::runtime_error("'operator_params.scan_task_batch_size': must be greater than zero");
+  }
   r.optional("max_sort_partition_bytes", yaml::bytes(opt.max_sort_partition_bytes));
   r.optional("max_sort_partition_memory_fraction",
              opt.max_sort_partition_memory_fraction,

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1855,10 +1855,12 @@ static duckdb::unique_ptr<duckdb::SiriusContext::SlotGuard> lock_operator_params
 
 static void SetDefaultScanTaskBatchSize(ClientContext& context, SetScope scope, Value& parameter)
 {
+  auto const bytes = UBigIntValue::Get(parameter);
+  if (bytes == 0) { throw InvalidInputException("scan_task_batch_size must be greater than zero"); }
   auto* params = get_operator_params(context);
   if (!params) { return; }
   auto slot                    = lock_operator_params_slot(context);
-  params->scan_task_batch_size = UBigIntValue::Get(parameter);
+  params->scan_task_batch_size = bytes;
   SIRIUS_LOG_DEBUG("Updated config SCAN_TASK_BATCH_SIZE to {}", params->scan_task_batch_size);
 }
 

--- a/test/cpp/config/data/invalid_scan_task_batch_zero.yaml
+++ b/test/cpp/config/data/invalid_scan_task_batch_zero.yaml
@@ -1,0 +1,3 @@
+sirius:
+  operator_params:
+    scan_task_batch_size: 0

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -298,6 +298,18 @@ TEST_CASE("Sirius configuration rejects zero hash partition bytes", "[sirius][co
     Catch::Contains("hash_partition_bytes") && Catch::Contains("greater than zero"));
 }
 
+TEST_CASE("Sirius configuration rejects zero scan task batch bytes", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  fs::path cfg =
+    fs::path(loc.file_name()).parent_path() / "data" / "invalid_scan_task_batch_zero.yaml";
+
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(config.load_from_file(cfg),
+                      Catch::Contains("operator_params.scan_task_batch_size") &&
+                        Catch::Contains("greater than zero"));
+}
+
 TEST_CASE("Sirius configuration rejects negative host capacity bytes", "[sirius][config]")
 {
   std::source_location loc = std::source_location::current();
@@ -634,6 +646,30 @@ TEST_CASE("DuckDB setting rejects zero hash partition bytes without a Sirius con
   REQUIRE(result->HasError());
   REQUIRE_THAT(result->GetError(),
                Catch::Contains("hash_partition_bytes must be greater than zero"));
+}
+
+TEST_CASE("DuckDB setting rejects zero scan task batch bytes without a Sirius context",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto before = con.Query("SELECT current_setting('scan_task_batch_size')::UBIGINT");
+  REQUIRE(before != nullptr);
+  REQUIRE_FALSE(before->HasError());
+  auto const expected = before->GetValue(0, 0).GetValue<uint64_t>();
+
+  auto zero = con.Query("SET scan_task_batch_size = 0");
+  REQUIRE(zero != nullptr);
+  REQUIRE(zero->HasError());
+  REQUIRE_THAT(zero->GetError(), Catch::Contains("scan_task_batch_size must be greater than zero"));
+
+  auto after = con.Query("SELECT current_setting('scan_task_batch_size')::UBIGINT");
+  REQUIRE(after != nullptr);
+  REQUIRE_FALSE(after->HasError());
+  REQUIRE(after->GetValue(0, 0).GetValue<uint64_t>() == expected);
 }
 
 TEST_CASE("DuckDB setting rejects negative byte values without mutation",


### PR DESCRIPTION
## Summary

- reject zero `scan_task_batch_size` on YAML and DuckDB runtime surfaces
- validate runtime input before Sirius-context lookup so disabled-context sessions refuse the same value
- preserve prior state on refusal and document the positive-byte contract

## Why

Zero currently has incompatible meanings across the two scan paths. The DuckDB-native coalescer explicitly treats `0` as no byte cap, producing one unbounded batch. The Parquet insert path compares every subsequent row group against the zero budget, producing one row group per batch. One accepted setting therefore selects opposite batching extremes by storage format. The derived/default value is positive and the user documentation describes a target batch size, not a format-dependent sentinel.

## Validation

- YAML regression rejects `scan_task_batch_size: 0` with the exact setting path
- isolated DuckDB regression rejects runtime zero without a Sirius context and proves the visible default is unchanged
- `python3 scripts/check_orphan_tests.py`
- `git diff --check`
- live duplicate search found no open zero-validation work for this setting
- clean independent merge trees with #1516 (`5a7797d0cab45630ce4a9669ca009ac2571e6c5e`), #1517 (`7918e91391d15a6a1842769f01826c4052ae5207`), #1519 (`29026214cd3a0943695106154384750d447c3bf5`), and #1520 (`d7c8a3bee12c5e2843f3e99e9ebca0cf9f96356a`)

Exact base: `0d7f98d9a662e9e3b47d6f7d6e2c8797d1e6572b`
Candidate: `e2d0cab113fc9161caaad65847807d9a5f3793f1`
Candidate tree: `c3c7fc2f48a1e2d1a504ce47397e1c35dfb7e428`
Zero-context source patch SHA-256: `17a0cf1cba642546365b5cacd6082338269c305eebc159de79d38d9ec6cfeb79`

Exact-head hosted CI is terminal green: lint, GCC release, Clang debug, CUDA 13 build, full C++ runtime (job 94464384943, 20m11s), and aggregate checks passed.

