### PR TITLE
refactor(config): keep automatic choices internal

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -407,7 +407,6 @@ individually.
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join. A build below this size is replicated to every GPU (instead of hash-partitioned) when it is tiny, or when the DuckDB-estimated probe-to-build row ratio is at least `num_gpus * 1.25`. |
 | `max_sort_partition_memory_fraction` | 0.33 | Fraction of GPU memory per sort partition when `max_sort_partition_bytes` is 0 |
 | `mark_join_build_switch_ratio` | 8.0 | For STANDARD MARK joins, build on the smaller (left) side when `right_rows >= ratio * left_rows` (0 disables) |
-| `enable_runtime_distinct_build_probe` | false | For `BUILD_PROBE` INNER/LEFT equality joins whose build-key uniqueness the planner could not prove, test distinctness at runtime (one `cudf::distinct_count` pass over the cached build, dimension-scale builds only) and take the single-pass `cudf::distinct_hash_join` instead of the general two-pass join when the keys are distinct. Temporarily off by default until a cuCollections bug fix ships in libcudf (issue #1600). |
 | `enable_dynamic_filter_pushdown` | true | Master switch for dynamic table-filter pushdown. An eligible `BUILD_PROBE` hash-join build selects a raw exact IN-list for 1–12 supported build rows, otherwise a hash IN-list if it fits the smallest probe-GPU L2 or a Bloom, for post-decode application by the probe scan. |
 | `enable_dynamic_zone_map_filter` | false | Additionally publish build-key min/max bounds. Parquet scans use them for read-time row-group pruning; duckdb-native scans apply them row-wise post-decode. Requires `enable_dynamic_filter_pushdown`; intended for clustered-keyset workloads. |
 | `dynamic_filter_domain_coverage_threshold` | 0.9 | Positive finite threshold for skipping publication when the build covers at least this fraction of the key's domain; ≥ 1.0 effectively disables the gate. |
@@ -420,6 +419,11 @@ individually.
 **Note:** `admission_bytes_per_gpu` is a parallelism dial, not a memory budget. Peak GPU residency is bounded by partition sizing (`hash_partition_bytes` and the batch settings), not by the admitted GPU count — a query on fewer GPUs processes more partitions sequentially at roughly unchanged peak memory, trading wall-clock for freed devices. Tune it against how much of the fleet a query should occupy, not against VRAM.
 
 **Note:** `max_build_hash_table_bytes` can be larger than `concat_batch_bytes`. When it is, the partition operator configures CONCAT to concatenate all batches, enabling the more efficient BUILD_PROBE join mode for larger build sides. Other joins (STANDARD, MIXED) still use `concat_batch_bytes` as the batch size threshold.
+
+Runtime distinct-build probing is an internal join policy, not a user configuration choice. It is
+temporarily disabled while the cuCollections defect tracked in #1600 remains unresolved. The
+engine retains the guarded single-pass `cudf::distinct_hash_join` path for policy-controlled use
+after that dependency is fixed.
 
 ## Telemetry
 
@@ -588,16 +592,23 @@ SET enable_compressed_materialization = false;
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `fuse_merge_pipelines` | true | Fuse eligible GROUP BY / TOP_N merges into their downstream pipeline instead of cutting a boundary (see [physical-plan-generation.md](physical-plan-generation.md) → Merge fusion) |
 | `max_sort_partition_bytes` | 0 (auto) | Max sort partition bytes |
 | `max_sort_partition_memory_fraction` | 0.33 | Auto sort-partition fraction when `max_sort_partition_bytes` is 0 |
 | `hash_partition_bytes` | Shared physical/effective GPU batch default | Hash partition target size; must be greater than zero |
-| `concat_batch_bytes` | Shared physical/effective GPU batch default | CONCAT output batch size |
 | `sort_sample_bytes` | Shared physical/effective GPU batch default | Bytes sampled before computing sort boundaries |
 | `max_build_hash_table_bytes` | 2× batch default | Max build-side hash table bytes |
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join |
 | `mark_join_build_switch_ratio` | 8.0 | STANDARD MARK join build-side switch ratio (0 disables) |
-| `enable_runtime_distinct_build_probe` | false | Runtime distinct-build test for `BUILD_PROBE` joins; promotes to the single-pass `cudf::distinct_hash_join` when the build keys prove distinct. Temporarily off by default (issue #1600) |
+
+Eligible GROUP BY and TOP_N merge pipelines are fused automatically. This is an engine-owned plan
+policy rather than a user configuration choice; see
+[Merge fusion](physical-plan-generation.md#merge-fusion).
+
+The CONCAT output-batch target is derived from effective GPU capacity. Advanced
+benchmark and test envelopes may still override `concat_batch_bytes` in YAML
+under `sirius.operator_params`, but it is not a normal session setting.
+
+Runtime distinct-build probing is also engine-owned and is temporarily disabled pending #1600.
 
 ### GPU Admission
 

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -64,7 +64,9 @@ num_partitions = max(1, ceil(total_bytes / hash_partition_bytes))
 - `src/op/sirius_physical_grouped_aggregate_merge.cpp`, `src/op/sirius_physical_top_n.cpp` — `build_pipelines()` overrides
 - `src/sirius_engine.cpp` — invokes marking after parent pointers are refreshed
 
-**Config:** `fuse_merge_pipelines` (default: true). See [physical-plan-generation.md](physical-plan-generation.md) → Merge fusion for pipeline-shape details.
+**Policy:** Sirius applies eligible merge fusion automatically. See
+[physical-plan-generation.md](physical-plan-generation.md) → Merge fusion for pipeline-shape
+details.
 
 ### Task Creator Look-Ahead (PR #1174)
 

--- a/docs/super-sirius/physical-plan-generation.md
+++ b/docs/super-sirius/physical-plan-generation.md
@@ -311,7 +311,8 @@ graph LR
 2. **Pipeline 2**: PARTITION. Repository to MERGE_GROUP_BY uses `FULL` barrier (downstream is not CONCAT — `PARTIAL` is only used when PARTITION feeds directly into CONCAT)
 3. **Pipeline 3**: MERGE_GROUP_BY. Downstream pipelines updated to use MERGE_GROUP_BY as source
 
-> With `fuse_merge_pipelines` (default on), Pipeline 3 is usually not a standalone pipeline: MERGE_GROUP_BY folds into the downstream sink's pipeline as an intermediate. See [Merge fusion](#merge-fusion) below.
+> Pipeline 3 is usually not standalone: Sirius automatically folds MERGE_GROUP_BY into the
+> downstream sink's pipeline as an intermediate. See [Merge fusion](#merge-fusion) below.
 
 ### UNGROUPED_AGGREGATE
 
@@ -333,11 +334,12 @@ graph LR
 
 MERGE_TOP_N merges local top-N results.
 
-> With `fuse_merge_pipelines` (default on), Pipeline 2 usually folds MERGE_TOP_N into the downstream sink's pipeline rather than forming its own. See [Merge fusion](#merge-fusion) below.
+> Pipeline 2 usually folds MERGE_TOP_N into the downstream sink's pipeline rather than forming its
+> own. See [Merge fusion](#merge-fusion) below.
 
 ### Merge fusion
 
-By default (`fuse_merge_pipelines = true`) an eligible `MERGE_GROUP_BY` or `MERGE_TOP_N` does **not** open its own terminal pipeline. Instead it joins its downstream sink's pipeline as an intermediate operator, removing one task launch and one repository round-trip (typically `merge → RESULT_COLLECTOR` at the query tail):
+An eligible `MERGE_GROUP_BY` or `MERGE_TOP_N` does **not** open its own terminal pipeline. Instead it joins its downstream sink's pipeline as an intermediate operator, removing one task launch and one repository round-trip (typically `merge → RESULT_COLLECTOR` at the query tail):
 
 ```mermaid
 graph LR

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -128,10 +128,11 @@ struct operator_params {
   /// disable (always use filtered_join).
   double mark_join_build_switch_ratio = config::DEFAULT_MARK_JOIN_BUILD_SWITCH_RATIO;
 
-  /// When the planner could not prove build-key uniqueness, test it at runtime (one
-  /// cudf::distinct_count pass over the build keys) and take the single-pass
-  /// cudf::distinct_hash_join instead of the two-pass general path when the keys are in fact
-  /// distinct. BUILD_PROBE mode only, INNER/LEFT equality joins with null-unequal semantics. See
+  /// Engine-owned policy: when enabled and the planner could not prove build-key uniqueness, test
+  /// it at runtime (one cudf::distinct_count pass over the build keys) and take the single-pass
+  /// cudf::distinct_hash_join when the keys are distinct. Temporarily disabled pending issue #1600.
+  /// BUILD_PROBE mode only, INNER/LEFT equality joins with null-unequal semantics. Tests retain
+  /// direct programmatic control of this field to exercise both implementations. See
   /// DEFAULT_ENABLE_RUNTIME_DISTINCT_BUILD_PROBE.
   bool enable_runtime_distinct_build_probe = config::DEFAULT_ENABLE_RUNTIME_DISTINCT_BUILD_PROBE;
 

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -921,9 +921,10 @@ bool merge_downstream_is_streaming_dead_end(const sirius::op::sirius_physical_op
 void sirius_physical_plan_generator::mark_fusable_merge_pipelines(
   duckdb::ClientContext& context, sirius::op::sirius_physical_operator& op)
 {
-  // Keep the fusion decision consistent throughout this plan traversal.
+  // Merge fusion is the engine-owned production policy. Unit tests can expose a guarded setting
+  // to exercise the unfused reference path without making that implementation detail a user knob.
   duckdb::Value setting;
-  bool fusion_enabled = true;  // matches the registered default
+  bool fusion_enabled = true;
   if (context.TryGetCurrentSetting("fuse_merge_pipelines", setting) && !setting.IsNull()) {
     fusion_enabled = setting.GetValue<bool>();
   }

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -269,7 +269,12 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
   r.optional("mark_join_build_switch_ratio",
              opt.mark_join_build_switch_ratio,
              yaml::between<double>{0.0, std::numeric_limits<double>::infinity()});
-  r.optional("enable_runtime_distinct_build_probe", opt.enable_runtime_distinct_build_probe);
+  if (r.has("enable_runtime_distinct_build_probe")) {
+    throw std::runtime_error(
+      "'sirius.operator_params.enable_runtime_distinct_build_probe': removed; runtime distinct "
+      "build probing is an internal join policy (temporarily disabled pending issue #1600); "
+      "remove this key");
+  }
   r.optional("enable_dynamic_filter_pushdown", opt.enable_dynamic_filter_pushdown);
   r.optional("enable_dynamic_zone_map_filter", opt.enable_dynamic_zone_map_filter);
   r.optional("dynamic_filter_domain_coverage_threshold",

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -124,6 +124,7 @@ extern "C" int cudaProfilerStop();
 #include <cstdlib>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 
 namespace duckdb {
 
@@ -140,6 +141,20 @@ bool test_options_enabled() noexcept
 {
   auto const* value = std::getenv("SIRIUS_ENABLE_TEST_OPTIONS");
   return value != nullptr && std::string_view{value} == "1";
+}
+
+enum class option_visibility { user, internal };
+
+template <typename... Args>
+void add_sirius_option(DBConfig& config,
+                       option_visibility visibility,
+                       const std::string& name,
+                       std::string description,
+                       Args&&... args)
+{
+  if (visibility == option_visibility::internal && !test_options_enabled()) { return; }
+  if (visibility == option_visibility::internal) { description = "TEST ONLY: " + description; }
+  config.AddExtensionOption(name, description, std::forward<Args>(args)...);
 }
 
 std::uint64_t count_narrowed_columns(
@@ -2273,7 +2288,9 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             SetEnableFallbackCheck);
 #endif
 
-  config.AddExtensionOption(
+  add_sirius_option(
+    config,
+    option_visibility::user,
     "enable_duckdb_fallback",
     "Whether to enable fallback to duckdb execution after an error is detected",
     LogicalType::BOOLEAN,
@@ -2282,44 +2299,73 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                            // fallback policy into every freshly-created database).
     SetEnableDuckdbFallback);
 
-  // Test hooks are absent from normal duckdb_settings(). The unittest harness opts in before
-  // constructing any database so fallback tests can still inject a deterministic runtime error.
-  if (test_options_enabled()) {
-    config.AddExtensionOption(
-      "sirius_test_inject_transparent_gpu_error",
-      "TEST ONLY: force transparent GPU execution to fail at runtime with this message",
-      LogicalType::VARCHAR,
-      Value(""));
-    config.AddExtensionOption(
-      "enable_pinned_zone_map_pruning",
-      "TEST ONLY: disable automatic pinned-table zone-map capture and pruning",
-      LogicalType::BOOLEAN,
-      Value::BOOLEAN(operator_defaults.enable_pinned_zone_map_pruning),
-      SetEnablePinnedZoneMapPruning);
-    config.AddExtensionOption("enable_dynamic_filter_pushdown",
-                              "TEST ONLY: disable automatic dynamic membership-filter pushdown",
-                              LogicalType::BOOLEAN,
-                              Value::BOOLEAN(operator_defaults.enable_dynamic_filter_pushdown),
-                              SetEnableDynamicFilterPushdown);
-    config.AddExtensionOption("enable_dynamic_zone_map_filter",
-                              "TEST ONLY: enable the clustered-keyset dynamic zone-map path",
-                              LogicalType::BOOLEAN,
-                              Value::BOOLEAN(operator_defaults.enable_dynamic_zone_map_filter),
-                              SetEnableDynamicZoneMapFilter);
-    config.AddExtensionOption("scan_task_batch_size",
-                              "TEST ONLY: override the internally derived scan batch target",
-                              LogicalType::UBIGINT,
-                              Value::UBIGINT(operator_defaults.scan_task_batch_size),
-                              SetDefaultScanTaskBatchSize);
-  }
+  // Keep internal policy and test hooks out of the normal duckdb_settings() surface. The
+  // unittest harness opts in before constructing a database. Centralizing visibility here keeps
+  // option registration from growing scattered environment checks.
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "sirius_test_inject_transparent_gpu_error",
+                    "force transparent GPU execution to fail at runtime with this message",
+                    LogicalType::VARCHAR,
+                    Value(""));
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "enable_pinned_zone_map_pruning",
+                    "disable automatic pinned-table zone-map capture and pruning",
+                    LogicalType::BOOLEAN,
+                    Value::BOOLEAN(operator_defaults.enable_pinned_zone_map_pruning),
+                    SetEnablePinnedZoneMapPruning);
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "enable_dynamic_filter_pushdown",
+                    "disable automatic dynamic membership-filter pushdown",
+                    LogicalType::BOOLEAN,
+                    Value::BOOLEAN(operator_defaults.enable_dynamic_filter_pushdown),
+                    SetEnableDynamicFilterPushdown);
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "enable_dynamic_zone_map_filter",
+                    "enable the clustered-keyset dynamic zone-map path",
+                    LogicalType::BOOLEAN,
+                    Value::BOOLEAN(operator_defaults.enable_dynamic_zone_map_filter),
+                    SetEnableDynamicZoneMapFilter);
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "scan_task_batch_size",
+                    "override the internally derived scan batch target",
+                    LogicalType::UBIGINT,
+                    Value::UBIGINT(operator_defaults.scan_task_batch_size),
+                    SetDefaultScanTaskBatchSize);
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "fuse_merge_pipelines",
+                    "toggle merge pipeline fusion",
+                    LogicalType::BOOLEAN,
+                    Value::BOOLEAN(true),
+                    SetFuseMergePipelines);
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "enable_runtime_distinct_build_probe",
+                    "toggle the internal runtime distinct-build probe",
+                    LogicalType::BOOLEAN,
+                    Value::BOOLEAN(operator_defaults.enable_runtime_distinct_build_probe),
+                    SetEnableRuntimeDistinctBuildProbe);
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "concat_batch_bytes",
+                    "override the internally derived CONCAT batch target",
+                    LogicalType::UBIGINT,
+                    Value::UBIGINT(operator_defaults.concat_batch_bytes),
+                    SetConcatBatchBytes);
 
   // Add in config options for special JIT implementation for regex
-  config.AddExtensionOption(
-    "enable_regex_jit_impl",
-    "Whether to use special JIT implementation for particular regex evaluation",
-    LogicalType::BOOLEAN,
-    Value::BOOLEAN(Config::ENABLE_REGEX_JIT_IMPL),
-    SetEnableRegexJitImpl);
+  add_sirius_option(config,
+                    option_visibility::user,
+                    "enable_regex_jit_impl",
+                    "Whether to use special JIT implementation for particular regex evaluation",
+                    LogicalType::BOOLEAN,
+                    Value::BOOLEAN(Config::ENABLE_REGEX_JIT_IMPL),
+                    SetEnableRegexJitImpl);
 
 #ifdef SIRIUS_ENABLE_LEGACY
   // Add in config options for modified pipeline
@@ -2329,12 +2375,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             Value::BOOLEAN(Config::MODIFIED_PIPELINE),
                             SetModifiedPipeline);
 #endif
-
-  config.AddExtensionOption("fuse_merge_pipelines",
-                            "Fuse eligible GROUP BY and TOP_N merges into downstream pipelines",
-                            LogicalType::BOOLEAN,
-                            Value::BOOLEAN(true),
-                            SetFuseMergePipelines);
 
   // Add in config option for sort partition size
   config.AddExtensionOption("max_sort_partition_bytes",
@@ -2378,12 +2418,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             Value::UBIGINT(operator_defaults.hash_partition_bytes),
                             SetHashPartitionBytes);
 
-  config.AddExtensionOption("concat_batch_bytes",
-                            "Target size for concat operator",
-                            LogicalType::UBIGINT,
-                            Value::UBIGINT(operator_defaults.concat_batch_bytes),
-                            SetConcatBatchBytes);
-
   config.AddExtensionOption("sort_sample_bytes",
                             "Target bytes to sample before computing sort partition boundaries",
                             LogicalType::UBIGINT,
@@ -2413,16 +2447,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     LogicalType::DOUBLE,
     Value::DOUBLE(operator_defaults.mark_join_build_switch_ratio),
     SetMarkJoinBuildSwitchRatio);
-
-  config.AddExtensionOption(
-    "enable_runtime_distinct_build_probe",
-    "For BUILD_PROBE hash joins whose build-key uniqueness the planner could not prove, test "
-    "distinctness at runtime (one cudf::distinct_count pass over the cached build) and take the "
-    "single-pass cudf::distinct_hash_join instead of the general two-pass join when the keys are "
-    "distinct (temporarily off by default pending a cuCollections fix; see issue #1600)",
-    LogicalType::BOOLEAN,
-    Value::BOOLEAN(operator_defaults.enable_runtime_distinct_build_probe),
-    SetEnableRuntimeDistinctBuildProbe);
 
   config.AddExtensionOption(
     "gpu_execution",

--- a/test/cpp/config/data/invalid_runtime_distinct_build_probe.yaml
+++ b/test/cpp/config/data/invalid_runtime_distinct_build_probe.yaml
@@ -1,0 +1,3 @@
+sirius:
+  operator_params:
+    enable_runtime_distinct_build_probe: false

--- a/test/cpp/config/data/setting_defaults.yaml
+++ b/test/cpp/config/data/setting_defaults.yaml
@@ -23,7 +23,6 @@ sirius:
     max_build_hash_table_bytes: 6MiB
     max_broadcast_join_size: 7MiB
     mark_join_build_switch_ratio: 3.0
-    enable_runtime_distinct_build_probe: false
     enable_dynamic_filter_pushdown: false
     enable_dynamic_zone_map_filter: true
     dynamic_filter_domain_coverage_threshold: 0.8

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -143,11 +143,10 @@ constexpr std::array<setting_assignment, 10> legacy_only_settings{{
   {"modified_pipeline", "true"},
 }};
 
-constexpr std::array<const char*, 4> super_sirius_settings{{
+constexpr std::array<const char*, 3> super_sirius_settings{{
   "expression_evaluator_strategy",
   "enable_regex_jit_impl",
   "enable_duckdb_fallback",
-  "fuse_merge_pipelines",
 }};
 }  // namespace
 
@@ -228,6 +227,9 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "enable_dynamic_filter_pushdown") == 0);
     REQUIRE(setting_count(con, "enable_dynamic_zone_map_filter") == 0);
     REQUIRE(setting_count(con, "scan_task_batch_size") == 0);
+    REQUIRE(setting_count(con, "fuse_merge_pipelines") == 0);
+    REQUIRE(setting_count(con, "enable_runtime_distinct_build_probe") == 0);
+    REQUIRE(setting_count(con, "concat_batch_bytes") == 0);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
@@ -243,6 +245,15 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     result = con.Query("SET scan_task_batch_size = 1048576");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
+    result = con.Query("SET fuse_merge_pipelines = false");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET enable_runtime_distinct_build_probe = true");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET concat_batch_bytes = 1048576");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "true", 1);
@@ -254,6 +265,9 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "enable_dynamic_filter_pushdown") == 0);
     REQUIRE(setting_count(con, "enable_dynamic_zone_map_filter") == 0);
     REQUIRE(setting_count(con, "scan_task_batch_size") == 0);
+    REQUIRE(setting_count(con, "fuse_merge_pipelines") == 0);
+    REQUIRE(setting_count(con, "enable_runtime_distinct_build_probe") == 0);
+    REQUIRE(setting_count(con, "concat_batch_bytes") == 0);
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
@@ -265,6 +279,9 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "enable_dynamic_filter_pushdown") == 1);
     REQUIRE(setting_count(con, "enable_dynamic_zone_map_filter") == 1);
     REQUIRE(setting_count(con, "scan_task_batch_size") == 1);
+    REQUIRE(setting_count(con, "fuse_merge_pipelines") == 1);
+    REQUIRE(setting_count(con, "enable_runtime_distinct_build_probe") == 1);
+    REQUIRE(setting_count(con, "concat_batch_bytes") == 1);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
@@ -292,7 +309,37 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     result = con.Query("RESET scan_task_batch_size");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET fuse_merge_pipelines = false");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET fuse_merge_pipelines");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET enable_runtime_distinct_build_probe = true");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET enable_runtime_distinct_build_probe");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET concat_batch_bytes = 1048576");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET concat_batch_bytes");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
   }
+}
+
+TEST_CASE("Sirius configuration keeps runtime distinct-build probing internal", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(
+    config.load_from_file(data_dir / "invalid_runtime_distinct_build_probe.yaml"),
+    Catch::Contains("sirius.operator_params.enable_runtime_distinct_build_probe") &&
+      Catch::Contains("removed") && Catch::Contains("remove this key"));
 }
 
 TEST_CASE("Sirius configuration loading from file with configurator",
@@ -977,7 +1024,6 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
       current_setting('pin_table_input_compression_plan_dir')::VARCHAR,
       current_setting('pin_table_compression_min_batch_size_bytes')::UBIGINT,
       current_setting('pin_table_compression_max_compressed_fraction')::DOUBLE,
-      current_setting('enable_runtime_distinct_build_probe')::BOOLEAN,
       current_setting('dynamic_filter_inlist_max_l2_fraction')::DOUBLE
   )");
   REQUIRE(settings != nullptr);
@@ -1003,8 +1049,7 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE(settings->GetValue(16, 0).GetValue<std::string>() == "/tmp/sirius-compression-plans");
   REQUIRE(settings->GetValue(17, 0).GetValue<uint64_t>() == 8 * mib);
   REQUIRE(settings->GetValue(18, 0).GetValue<double>() == Approx(0.6));
-  REQUIRE_FALSE(settings->GetValue(19, 0).GetValue<bool>());
-  REQUIRE(settings->GetValue(20, 0).GetValue<double>() == Approx(0.4));
+  REQUIRE(settings->GetValue(19, 0).GetValue<double>() == Approx(0.4));
 
   auto zero_partition = con.Query("SET hash_partition_bytes = 0");
   REQUIRE(zero_partition != nullptr);
@@ -1114,8 +1159,6 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   // RESET restores the registered default, which this context's YAML set to 0.4.
   REQUIRE(sirius_ctx->get_config().get_operator_params().dynamic_filter_inlist_max_l2_fraction ==
           Approx(0.4));
-  require_ok("SET enable_runtime_distinct_build_probe = true");
-  require_ok("RESET enable_runtime_distinct_build_probe");
   require_ok("SET pin_table_compression = false");
   require_ok("RESET pin_table_compression");
   require_ok("SET pin_table_compression_max_compressed_fraction = 0.9");
@@ -1127,8 +1170,7 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
       current_setting('max_sort_partition_memory_fraction')::DOUBLE,
       current_setting('enable_dynamic_filter_pushdown')::BOOLEAN,
       current_setting('pin_table_compression')::BOOLEAN,
-      current_setting('pin_table_compression_max_compressed_fraction')::DOUBLE,
-      current_setting('enable_runtime_distinct_build_probe')::BOOLEAN
+      current_setting('pin_table_compression_max_compressed_fraction')::DOUBLE
   )");
   REQUIRE(reset != nullptr);
   REQUIRE_FALSE(reset->HasError());
@@ -1137,13 +1179,11 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE_FALSE(reset->GetValue(2, 0).GetValue<bool>());
   REQUIRE(reset->GetValue(3, 0).GetValue<bool>());
   REQUIRE(reset->GetValue(4, 0).GetValue<double>() == Approx(0.6));
-  REQUIRE_FALSE(reset->GetValue(5, 0).GetValue<bool>());
 
   auto const& params = sirius_ctx->get_config().get_operator_params();
   REQUIRE(params.scan_task_batch_size == 1 * mib);
   REQUIRE(params.max_sort_partition_memory_fraction == Approx(0.25));
   REQUIRE_FALSE(params.enable_dynamic_filter_pushdown);
-  REQUIRE_FALSE(params.enable_runtime_distinct_build_probe);
   auto const& compression = sirius_ctx->get_config().get_compression_config();
   REQUIRE(compression.enable_pin_table_compression);
   REQUIRE(compression.max_compressed_fraction == Approx(0.6));

--- a/test/cpp/pipeline/test_merge_pipeline_fusion.cpp
+++ b/test/cpp/pipeline/test_merge_pipeline_fusion.cpp
@@ -52,8 +52,9 @@ fs::path integration_db_path()
 #endif
 }
 
-// `fuse_merge_pipelines` is a per-connection DuckDB setting (no process-global), so the toggle is
-// driven with `SET`/`RESET` on the connection the plan is generated on.
+// The unittest process explicitly enables guarded test settings before constructing a database.
+// The test-only toggle is per-connection, so drive it with `SET`/`RESET` on the connection whose
+// plan is generated.
 class fusion_flag_guard {
  public:
   fusion_flag_guard(duckdb::Connection& con, bool enabled) : con_(con)


### PR DESCRIPTION
## Review focus

**Tier:** judgment — this removes ordinary user control over three internal
execution alternatives while preserving exact test and advanced benchmark seams.

**Maintainer question:** Should merge fusion, runtime distinct-build probing,
and derived CONCAT sizing remain engine policy, with ordinary sessions unable
to discover or toggle their internal reference paths?

**Main risk:** internalization can remove a useful operational escape hatch.
The exact test-option gate and explicit advanced CONCAT YAML override remain so
the implementations stay directly testable without becoming ordinary choices.

## Summary

- keep merge-pipeline fusion enabled as engine-owned production policy
- keep runtime distinct-build probing as engine-owned join policy, currently disabled pending #1600
- keep the CONCAT batch target derived from effective GPU capacity
- remove all three from the ordinary DuckDB session-settings surface
- expose the three reference paths only when `SIRIUS_ENABLE_TEST_OPTIONS=1`
- retain the explicit CONCAT YAML override for advanced benchmark envelopes
- reject the removed YAML distinct-build key with deletion guidance

## Why one PR

All three settings expose internal execution alternatives without an ordinary user-facing selection rule. Their normal paths are already engine policy, and the engine has the plan or hardware information needed to choose them. They share the same registration boundary and exact test-option guard. The union proves once that normal sessions cannot discover or mutate these choices while all three reference paths remain directly testable.

Runtime distinct-build probing is temporarily off because the cuCollections defect tracked in #1600 can affect some key distributions. That dependency changes the current internal policy value, not the configuration-surface decision: users should not need to discover and toggle an unsafe implementation path.

This supersedes #1526 and #1530. Their YAML field-path, planner propagation, session visibility, `SET`/`RESET`, and exact-opt-in checks are retained.

## Contract

- normal processes, including `SIRIUS_ENABLE_TEST_OPTIONS=true`, cannot discover or set any of the three DuckDB options
- exact `SIRIUS_ENABLE_TEST_OPTIONS=1` exposes all three options for tests
- the removed YAML distinct-build key fails with full-path deletion guidance
- runtime distinct-build probing retains current-dev's default-off policy while #1600 is unresolved
- advanced benchmark fixtures may still override `concat_batch_bytes` in YAML
- merge fusion remains automatic-on; automatic defaults and all inactive reference implementations remain intact

## Current identity

- exact base: `cbd9516367b2d3160492c8cb0575208f1dce047c`
- exact head: `8acbb29bdbf075590bd04aac9e00967f613bbd83`
- candidate tree: `01d3b8382b0d48851ff40c18513c13cc36c9cc0c`
- full-index binary diff SHA-256: `bbe7940158b4b3d1c0c1b9360292ca80a8d3c2b3f5b724733acad49a0fee985c`
- one-commit rebase onto current `dev`; conflicts were limited to current configuration documentation, ordinary-setting registration, and configuration-test expectations

## Validation

- conflict resolution preserves current-dev GPU-admission and dynamic-filter coverage while removing the three ordinary choices
- current-dev's #1600 default-off change is retained in source, documentation, YAML-refusal behavior, and test expectations
- exact test-option coverage now toggles runtime distinct-build probing to `true`, exercising the inactive reference path rather than restating its false default
- full resolved-diff review caught and repaired one stale pre-#1600 `RESET` expectation; the test now requires the current default to remain `false`
- `python3 scripts/check_orphan_tests.py`: pass
- `git diff --check`: pass
- local conflict-marker scan across all changed source, docs, and tests: pass

- exact-head hosted Test run `32193799797`: CUDA 13 build passed; runtime job
  `95894462143` passed in 19m56s, including C++ unit tests and the TPC-H
  snapshot; terminal aggregate job `95898848048` passed
- exact-head hosted Check run `32193799872`: lint, GCC release, Clang debug,
  and terminal aggregate passed
- exact-head hosted Distribution run `32193800262`: terminal aggregate passed

Final author-readiness review at exact head `7bb37ffa2bb7` found the one-commit
unit coherent, the #1600 conflict adaptation consistent across source, docs,
and tests, the #1595 dependency explicit, and no remaining author-side repair.
The engine-policy question above is ready for maintainer review rather than an
unfinished-author-work draft condition.

## Neighboring work

- #1588 adds a separate twin-scan fusion mechanism and user-facing `fuse_twin_scans` choice. It is not silently folded into this PR: that is a separate product judgment. The branches currently conflict in shared planner/config files, so whichever lands second must rebase and preserve both decisions explicitly.
- #1595 changes BUILD_PROBE admission and currently assumes `enable_runtime_distinct_build_probe` remains an ordinary setting. The branches also conflict. This PR preserves the internalization contract; integration must adapt #1595's tests/docs to the internal field or guarded test seam rather than re-expose the user knob.


## August 19 repair receipt

Maintainer feedback on predecessor head `7bb37ffa2bb7` is addressed in rebased exact head `8acbb29bdbf075590bd04aac9e00967f613bbd83`. Internal option registration is centralized at the sole consumer; scan and CONCAT retain only their named YAML benchmark envelopes; obsolete runtime-distinct YAML fails noisily; and stale post-throw and setting-readback tests are removed. Pinned pre-commit, rumdl, the exact DuckDB AddExtensionOption compile probe, diff-check, formatting, YAML, and orphan-test validation pass. Hosted exact-head Test run `32295969393` passed, including GPU runtime job `96208613358`; Check, Distribution, lint, GCC, Clang, CUDA build, title validation, and every other non-skipped job also passed. Foxglove reviewed the complete rebased diff and resolved all maintainer threads before returning the PR to ready.
