### PR TITLE
fix(config): validate telemetry output contract

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -435,8 +435,8 @@ sirius:
 |-----|------|---------|-------------|
 | `enable_quent` | bool | true | Emit Quent telemetry using the configured exporter. When false, telemetry uses the noop exporter. |
 | `exporter` | string | `ndjson` | Quent filesystem exporter: `ndjson`, `msgpack`, or `postcard`. |
-| `output_directory` | string | `telemetry_data` | Directory for Quent telemetry files. |
-| `engine_name` | string | `siriusDB` | Engine name reported in engine-level telemetry. |
+| `output_directory` | non-empty string | `telemetry_data` | Directory for Quent telemetry files. |
+| `engine_name` | non-empty string | `siriusDB` | Engine name reported in engine-level telemetry. |
 
 Per-query labels are configured separately from YAML. They can be set with the
 `sirius_set_query_label` SQL function or inline with the `query_label` named

--- a/docs/super-sirius/quent-telemetry.md
+++ b/docs/super-sirius/quent-telemetry.md
@@ -28,8 +28,8 @@ sirius:
 |-----|------|---------|-------------|
 | `enable_quent` | bool | `true` | Emit Quent telemetry using the configured exporter. When `false`, telemetry uses the no-op exporter and nothing is written. |
 | `exporter` | string | `ndjson` | Quent filesystem exporter: `ndjson`, `msgpack`, or `postcard`. |
-| `output_directory` | string | `telemetry_data` | Directory for Quent telemetry files. |
-| `engine_name` | string | `siriusDB` | Engine name reported in engine-level telemetry. |
+| `output_directory` | non-empty string | `telemetry_data` | Directory for Quent telemetry files. |
+| `engine_name` | non-empty string | `siriusDB` | Engine name reported in engine-level telemetry. |
 
 Load the config through the normal resolution path — usually by setting
 `SIRIUS_CONFIG_FILE=/path/to/sirius.yaml` before loading the extension. Any Sirius query run with

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -300,6 +300,9 @@ static void from_yaml(const YAML::Node& node, telemetry_config& opt)
   r.optional("enable_quent", opt.enable_quent);
   r.optional("enable_batch_events", opt.enable_batch_events);
   r.optional("exporter", opt.exporter);
+  if (opt.exporter != "ndjson" && opt.exporter != "msgpack" && opt.exporter != "postcard") {
+    throw std::runtime_error("'telemetry.exporter': must be one of ndjson, msgpack, postcard");
+  }
   r.optional("output_directory", opt.output_directory);
   r.optional("engine_name", opt.engine_name);
   r.reject_unknown();

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -299,18 +299,18 @@ static void from_yaml(const YAML::Node& node, telemetry_config& opt)
   yaml::reader r(node, "telemetry");
   r.optional("enable_quent", opt.enable_quent);
   r.optional("enable_batch_events", opt.enable_batch_events);
-  r.optional("exporter", opt.exporter);
-  if (opt.exporter != "ndjson" && opt.exporter != "msgpack" && opt.exporter != "postcard") {
-    throw std::runtime_error("'telemetry.exporter': must be one of ndjson, msgpack, postcard");
-  }
-  r.optional("output_directory", opt.output_directory);
-  if (opt.output_directory.empty()) {
-    throw std::runtime_error("'telemetry.output_directory': must not be empty");
-  }
-  r.optional("engine_name", opt.engine_name);
-  if (opt.engine_name.empty()) {
-    throw std::runtime_error("'telemetry.engine_name': must not be empty");
-  }
+  r.optional("exporter", opt.exporter, [](std::string const& value) {
+    if (value == "ndjson" || value == "msgpack" || value == "postcard") return true;
+    throw std::runtime_error("must be one of ndjson, msgpack, postcard");
+  });
+  r.optional("output_directory", opt.output_directory, [](std::string const& value) {
+    if (!value.empty()) return true;
+    throw std::runtime_error("must not be empty");
+  });
+  r.optional("engine_name", opt.engine_name, [](std::string const& value) {
+    if (!value.empty()) return true;
+    throw std::runtime_error("must not be empty");
+  });
   r.reject_unknown();
 }
 

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -304,7 +304,13 @@ static void from_yaml(const YAML::Node& node, telemetry_config& opt)
     throw std::runtime_error("'telemetry.exporter': must be one of ndjson, msgpack, postcard");
   }
   r.optional("output_directory", opt.output_directory);
+  if (opt.output_directory.empty()) {
+    throw std::runtime_error("'telemetry.output_directory': must not be empty");
+  }
   r.optional("engine_name", opt.engine_name);
+  if (opt.engine_name.empty()) {
+    throw std::runtime_error("'telemetry.engine_name': must not be empty");
+  }
   r.reject_unknown();
 }
 

--- a/test/cpp/config/data/invalid_telemetry_engine_name_empty.yaml
+++ b/test/cpp/config/data/invalid_telemetry_engine_name_empty.yaml
@@ -1,0 +1,4 @@
+sirius:
+  telemetry:
+    enable_quent: false
+    engine_name: ""

--- a/test/cpp/config/data/invalid_telemetry_exporter.yaml
+++ b/test/cpp/config/data/invalid_telemetry_exporter.yaml
@@ -1,0 +1,4 @@
+sirius:
+  telemetry:
+    enable_quent: false
+    exporter: json

--- a/test/cpp/config/data/invalid_telemetry_output_directory_empty.yaml
+++ b/test/cpp/config/data/invalid_telemetry_output_directory_empty.yaml
@@ -1,0 +1,4 @@
+sirius:
+  telemetry:
+    enable_quent: false
+    output_directory: ""

--- a/test/cpp/config/data/valid_telemetry_exporter_msgpack.yaml
+++ b/test/cpp/config/data/valid_telemetry_exporter_msgpack.yaml
@@ -1,0 +1,4 @@
+sirius:
+  telemetry:
+    enable_quent: false
+    exporter: msgpack

--- a/test/cpp/config/data/valid_telemetry_exporter_ndjson.yaml
+++ b/test/cpp/config/data/valid_telemetry_exporter_ndjson.yaml
@@ -1,0 +1,4 @@
+sirius:
+  telemetry:
+    enable_quent: false
+    exporter: ndjson

--- a/test/cpp/config/data/valid_telemetry_exporter_postcard.yaml
+++ b/test/cpp/config/data/valid_telemetry_exporter_postcard.yaml
@@ -1,0 +1,4 @@
+sirius:
+  telemetry:
+    enable_quent: false
+    exporter: postcard

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -369,9 +369,11 @@ TEST_CASE("Sirius configuration validates telemetry exporters before initializat
   auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
   auto const invalid       = data_dir / "invalid_telemetry_exporter.yaml";
   sirius::sirius_config rejected;
+  auto const default_exporter = rejected.get_telemetry_config().exporter;
   REQUIRE_THROWS_WITH(
     rejected.load_from_file(invalid),
     Catch::Contains("telemetry.exporter") && Catch::Contains("ndjson, msgpack, postcard"));
+  REQUIRE(rejected.get_telemetry_config().exporter == default_exporter);
 
   for (auto const& [exporter, fixture] : std::array<std::pair<const char*, const char*>, 3>{{
          {"ndjson", "valid_telemetry_exporter_ndjson.yaml"},
@@ -395,9 +397,13 @@ TEST_CASE("Sirius configuration rejects empty telemetry destination and identity
          {"engine_name", "invalid_telemetry_engine_name_empty.yaml"},
        }}) {
     sirius::sirius_config config;
+    auto const default_output_directory = config.get_telemetry_config().output_directory;
+    auto const default_engine_name      = config.get_telemetry_config().engine_name;
     REQUIRE_THROWS_WITH(
       config.load_from_file(data_dir / fixture),
       Catch::Contains("telemetry." + std::string(field)) && Catch::Contains("must not be empty"));
+    REQUIRE(config.get_telemetry_config().output_directory == default_output_directory);
+    REQUIRE(config.get_telemetry_config().engine_name == default_engine_name);
   }
 }
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -362,6 +362,28 @@ TEST_CASE("Sirius configuration rejects zero scan task batch bytes", "[sirius][c
                         Catch::Contains("greater than zero"));
 }
 
+TEST_CASE("Sirius configuration validates telemetry exporters before initialization",
+          "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+  auto const invalid       = data_dir / "invalid_telemetry_exporter.yaml";
+  sirius::sirius_config rejected;
+  REQUIRE_THROWS_WITH(
+    rejected.load_from_file(invalid),
+    Catch::Contains("telemetry.exporter") && Catch::Contains("ndjson, msgpack, postcard"));
+
+  for (auto const& [exporter, fixture] : std::array<std::pair<const char*, const char*>, 3>{{
+         {"ndjson", "valid_telemetry_exporter_ndjson.yaml"},
+         {"msgpack", "valid_telemetry_exporter_msgpack.yaml"},
+         {"postcard", "valid_telemetry_exporter_postcard.yaml"},
+       }}) {
+    sirius::sirius_config accepted;
+    REQUIRE_NOTHROW(accepted.load_from_file(data_dir / fixture));
+    REQUIRE(accepted.get_telemetry_config().exporter == exporter);
+  }
+}
+
 TEST_CASE("Sirius configuration rejects negative host capacity bytes", "[sirius][config]")
 {
   std::source_location loc = std::source_location::current();

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -384,6 +384,23 @@ TEST_CASE("Sirius configuration validates telemetry exporters before initializat
   }
 }
 
+TEST_CASE("Sirius configuration rejects empty telemetry destination and identity",
+          "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  for (auto const& [field, fixture] : std::array<std::pair<const char*, const char*>, 2>{{
+         {"output_directory", "invalid_telemetry_output_directory_empty.yaml"},
+         {"engine_name", "invalid_telemetry_engine_name_empty.yaml"},
+       }}) {
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(
+      config.load_from_file(data_dir / fixture),
+      Catch::Contains("telemetry." + std::string(field)) && Catch::Contains("must not be empty"));
+  }
+}
+
 TEST_CASE("Sirius configuration rejects negative host capacity bytes", "[sirius][config]")
 {
   std::source_location loc = std::source_location::current();


### PR DESCRIPTION
## Summary

- validate `sirius.telemetry.exporter` while reading YAML rather than during runtime initialization
- accept exactly the three implemented/documented exporters: `ndjson`, `msgpack`, and `postcard`
- reject empty `output_directory` and `engine_name` values before exporter/session construction
- apply the contract even when telemetry is disabled, so dormant typos and unusable values cannot remain accepted configuration

Defaults and telemetry behavior are unchanged. Paths are not required to exist at config-load time; this only rejects the empty destination and empty emitted identity.

## Why

The YAML reader accepted any exporter string, but `telemetry_context` recognizes only three values and otherwise threw after Sirius context initialization was underway. It also passed `output_directory` directly to Quent exporter construction and used `engine_name` as the engine, instance, and session-group identity without rejecting empty strings.

Configuration loading is the correct boundary for these finite requirements. A disabled telemetry block is still configuration: rejecting invalid dormant values prevents a typo from being silently staged until telemetry is later enabled.

Open-head refresh found no competing telemetry destination/identity validation owner; these fields extend the existing exporter-validation unit rather than creating a second PR.

## Validation

- focused config regression proves invalid `json` is rejected with telemetry disabled
- focused config regression loads and reads back all three accepted exporters with telemetry disabled
- focused fixtures prove empty `output_directory` and `engine_name` are rejected with telemetry disabled and field-specific messages
- focused pre-commit hooks: pass
- pinned `rumdl==0.2.44`: pass on both changed telemetry docs
- `git diff --check`: pass
- current base: `cbd9516367b2d3160492c8cb0575208f1dce047c`
- exact rebased head: `59c310e97533a9ecab40181d731f93da2d4c28da`
- candidate tree: `b4ec3f5750369969bb640f71ac0ea41b181bcd70`
- zero-context source-diff SHA-256: `eb272342001e6259c7e12647e8757320d2ac8582e3d6e99c46dc0e8e557a85a4`
- rebase is exact 2:2 by range-diff with no conflicts; the hosted receipt below remains pre-rebase evidence

The predecessor exporter-only head `6cc3b0ca` passed hosted lint, GCC release, Clang debug, CUDA 13 build, distribution, check, PR-title, full runtime, and aggregate checks. Hosted validation of the expanded exact head is left to this PR's refreshed CI.

- fresh exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full runtime, and terminal aggregate checks: pass
- hosted workflow 31719912513: runtime job 94515025137 passed in 22m08s; aggregate job 94542530198 passed



## Current-dev hosted receipt

- exact rebased head `73dace7b81342ed5011638787388baee00da0095`: hosted lint, GCC, Clang, CUDA 13 build/runtime, TPC-H snapshot, and terminal aggregate all passed
- workflow `31758608890`; build job `94639867426`; runtime job `94640579664` passed in 20m10s; aggregate job `94643894220` passed


## August 19 repair receipt

The ordering concern on predecessor head `73dace7b8134` is addressed in rebased exact head `59c310e97533a9ecab40181d731f93da2d4c28da`. Each telemetry value is parsed into a temporary, validated through the YAML reader validator overload, and assigned only on success; new assertions prove rejected values do not mutate target fields. The rebase preserves the upstream scan-sizing test. Diff-check and pinned formatting pass, and the maintainer thread is resolved. Hosted exact-head Test run `32295747766` passed, including GPU runtime job `96208071448`; Check, Distribution, lint, GCC, Clang, CUDA build, title validation, and every other non-skipped job also passed. Foxglove reviewed the complete rebased diff before returning the PR to ready.
