### PR TITLE
refactor(config): keep distinct-build probing internal

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -387,7 +387,6 @@ individually.
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join. A build below this size is replicated to every GPU (instead of hash-partitioned) when it is tiny, or when the DuckDB-estimated probe-to-build row ratio is at least `num_gpus * 1.25`. |
 | `max_sort_partition_memory_fraction` | 0.33 | Fraction of GPU memory per sort partition when `max_sort_partition_bytes` is 0 |
 | `mark_join_build_switch_ratio` | 8.0 | For STANDARD MARK joins, build on the smaller (left) side when `right_rows >= ratio * left_rows` (0 disables) |
-| `enable_runtime_distinct_build_probe` | true | For `BUILD_PROBE` INNER/LEFT equality joins whose build-key uniqueness the planner could not prove, test distinctness at runtime (one `cudf::distinct_count` pass over the cached build, dimension-scale builds only) and take the single-pass `cudf::distinct_hash_join` instead of the general two-pass join when the keys are distinct. |
 | `enable_dynamic_filter_pushdown` | true | Master switch for dynamic table-filter pushdown. An eligible `BUILD_PROBE` hash-join build selects a raw exact IN-list for 1–12 supported build rows, otherwise a hash IN-list if it fits the smallest probe-GPU L2 or a Bloom, for post-decode application by the probe scan. |
 | `enable_dynamic_zone_map_filter` | false | Additionally publish build-key min/max bounds. Parquet scans use them for read-time row-group pruning; duckdb-native scans apply them row-wise post-decode. Requires `enable_dynamic_filter_pushdown`; intended for clustered-keyset workloads. |
 | `dynamic_filter_domain_coverage_threshold` | 0.9 | Skip publishing a key's dynamic filters when the build covers at least this fraction of the key's domain; ≥ 1.0 effectively disables the gate. |
@@ -395,6 +394,11 @@ individually.
 | `enable_pinned_zone_map_pruning` | true | Capture per-chunk min/max statistics while pinning and use them to skip cached chunks that cannot match a scan filter. |
 
 **Note:** `max_build_hash_table_bytes` can be larger than `concat_batch_bytes`. When it is, the partition operator configures CONCAT to concatenate all batches, enabling the more efficient BUILD_PROBE join mode for larger build sides. Other joins (STANDARD, MIXED) still use `concat_batch_bytes` as the batch size threshold.
+
+For eligible `BUILD_PROBE` INNER/LEFT equality joins whose build-key uniqueness the planner could
+not prove, Sirius automatically tests distinctness at runtime and uses the single-pass
+`cudf::distinct_hash_join` when the keys are distinct. This is an internal join policy, not a user
+configuration choice.
 
 ## Telemetry
 
@@ -566,8 +570,6 @@ SET enable_compressed_materialization = false;
 | `max_build_hash_table_bytes` | 2× batch default | Max build-side hash table bytes |
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join |
 | `mark_join_build_switch_ratio` | 8.0 | STANDARD MARK join build-side switch ratio (0 disables) |
-| `enable_runtime_distinct_build_probe` | true | Runtime distinct-build test for `BUILD_PROBE` joins; promotes to the single-pass `cudf::distinct_hash_join` when the build keys prove distinct |
-
 ### Dynamic Filters
 
 Both settings are also accepted in YAML under `sirius.operator_params`.

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -125,10 +125,11 @@ struct operator_params {
   /// disable (always use filtered_join).
   double mark_join_build_switch_ratio = config::DEFAULT_MARK_JOIN_BUILD_SWITCH_RATIO;
 
-  /// When the planner could not prove build-key uniqueness, test it at runtime (one
-  /// cudf::distinct_count pass over the build keys) and take the single-pass
-  /// cudf::distinct_hash_join instead of the two-pass general path when the keys are in fact
-  /// distinct. BUILD_PROBE mode only, INNER/LEFT equality joins with null-unequal semantics. See
+  /// Engine-owned policy: when the planner could not prove build-key uniqueness, test it at runtime
+  /// (one cudf::distinct_count pass over the build keys) and take the single-pass
+  /// cudf::distinct_hash_join when the keys are distinct. BUILD_PROBE mode only, INNER/LEFT
+  /// equality joins with null-unequal semantics. Tests retain direct programmatic control of this
+  /// field to exercise the general two-pass reference path. See
   /// DEFAULT_ENABLE_RUNTIME_DISTINCT_BUILD_PROBE.
   bool enable_runtime_distinct_build_probe = config::DEFAULT_ENABLE_RUNTIME_DISTINCT_BUILD_PROBE;
 

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -269,7 +269,11 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
   r.optional("mark_join_build_switch_ratio",
              opt.mark_join_build_switch_ratio,
              yaml::between<double>{0.0, std::numeric_limits<double>::infinity()});
-  r.optional("enable_runtime_distinct_build_probe", opt.enable_runtime_distinct_build_probe);
+  if (r.has("enable_runtime_distinct_build_probe")) {
+    throw std::runtime_error(
+      "'sirius.operator_params.enable_runtime_distinct_build_probe': removed; runtime distinct "
+      "build probing is an internal join policy and is enabled automatically; remove this key");
+  }
   r.optional("enable_dynamic_filter_pushdown", opt.enable_dynamic_filter_pushdown);
   r.optional("enable_dynamic_zone_map_filter", opt.enable_dynamic_zone_map_filter);
   r.optional("dynamic_filter_domain_coverage_threshold",

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2230,6 +2230,11 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
       "TEST ONLY: force transparent GPU execution to fail at runtime with this message",
       LogicalType::VARCHAR,
       Value(""));
+    config.AddExtensionOption("enable_runtime_distinct_build_probe",
+                              "TEST ONLY: toggle the internal runtime distinct-build probe",
+                              LogicalType::BOOLEAN,
+                              Value::BOOLEAN(operator_defaults.enable_runtime_distinct_build_probe),
+                              SetEnableRuntimeDistinctBuildProbe);
   }
 
   // Add in config options for special JIT implementation for regex
@@ -2340,16 +2345,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     LogicalType::DOUBLE,
     Value::DOUBLE(operator_defaults.mark_join_build_switch_ratio),
     SetMarkJoinBuildSwitchRatio);
-
-  config.AddExtensionOption(
-    "enable_runtime_distinct_build_probe",
-    "For BUILD_PROBE hash joins whose build-key uniqueness the planner could not prove, test "
-    "distinctness at runtime (one cudf::distinct_count pass over the cached build) and take the "
-    "single-pass cudf::distinct_hash_join instead of the general two-pass join when the keys are "
-    "distinct (on by default)",
-    LogicalType::BOOLEAN,
-    Value::BOOLEAN(operator_defaults.enable_runtime_distinct_build_probe),
-    SetEnableRuntimeDistinctBuildProbe);
 
   config.AddExtensionOption(
     "gpu_execution",

--- a/test/cpp/config/data/invalid_runtime_distinct_build_probe.yaml
+++ b/test/cpp/config/data/invalid_runtime_distinct_build_probe.yaml
@@ -1,0 +1,3 @@
+sirius:
+  operator_params:
+    enable_runtime_distinct_build_probe: false

--- a/test/cpp/config/data/setting_defaults.yaml
+++ b/test/cpp/config/data/setting_defaults.yaml
@@ -23,7 +23,6 @@ sirius:
     max_build_hash_table_bytes: 6MiB
     max_broadcast_join_size: 7MiB
     mark_join_build_switch_ratio: 3.0
-    enable_runtime_distinct_build_probe: false
     enable_dynamic_filter_pushdown: false
     enable_dynamic_zone_map_filter: true
     dynamic_filter_domain_coverage_threshold: 0.8

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -212,10 +212,8 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     setenv("SIRIUS_DISABLE", "1", 1);
   }};
 
-  auto setting_count = [](duckdb::Connection& con) {
-    auto result = con.Query(
-      "SELECT count(*) FROM duckdb_settings() "
-      "WHERE name = 'sirius_test_inject_transparent_gpu_error'");
+  auto setting_count = [](duckdb::Connection& con, std::string const& name) {
+    auto result = con.Query("SELECT count(*) FROM duckdb_settings() WHERE name = '" + name + "'");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
     return result->GetValue(0, 0).GetValue<int64_t>();
@@ -226,8 +224,12 @@ TEST_CASE("Test-only settings require explicit process opt-in",
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 0);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 0);
+    REQUIRE(setting_count(con, "enable_runtime_distinct_build_probe") == 0);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET enable_runtime_distinct_build_probe = false");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
   }
@@ -236,18 +238,36 @@ TEST_CASE("Test-only settings require explicit process opt-in",
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 0);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 0);
+    REQUIRE(setting_count(con, "enable_runtime_distinct_build_probe") == 0);
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 1);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 1);
+    REQUIRE(setting_count(con, "enable_runtime_distinct_build_probe") == 1);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET enable_runtime_distinct_build_probe = false");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
   }
+}
+
+TEST_CASE("Sirius configuration keeps runtime distinct-build probing internal", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(
+    config.load_from_file(data_dir / "invalid_runtime_distinct_build_probe.yaml"),
+    Catch::Contains("sirius.operator_params.enable_runtime_distinct_build_probe") &&
+      Catch::Contains("removed") && Catch::Contains("remove this key"));
+  CHECK(config.get_operator_params().enable_runtime_distinct_build_probe);
 }
 
 TEST_CASE("Sirius configuration loading from file with configurator",
@@ -745,7 +765,7 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE(settings->GetValue(16, 0).GetValue<std::string>() == "/tmp/sirius-compression-plans");
   REQUIRE(settings->GetValue(17, 0).GetValue<uint64_t>() == 8 * mib);
   REQUIRE(settings->GetValue(18, 0).GetValue<double>() == Approx(0.6));
-  REQUIRE_FALSE(settings->GetValue(19, 0).GetValue<bool>());
+  REQUIRE(settings->GetValue(19, 0).GetValue<bool>());
 
   auto zero_partition = con.Query("SET hash_partition_bytes = 0");
   REQUIRE(zero_partition != nullptr);
@@ -792,7 +812,7 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   require_ok("RESET max_sort_partition_memory_fraction");
   require_ok("SET enable_dynamic_filter_pushdown = true");
   require_ok("RESET enable_dynamic_filter_pushdown");
-  require_ok("SET enable_runtime_distinct_build_probe = true");
+  require_ok("SET enable_runtime_distinct_build_probe = false");
   require_ok("RESET enable_runtime_distinct_build_probe");
   require_ok("SET pin_table_compression = false");
   require_ok("RESET pin_table_compression");
@@ -815,13 +835,13 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE_FALSE(reset->GetValue(2, 0).GetValue<bool>());
   REQUIRE(reset->GetValue(3, 0).GetValue<bool>());
   REQUIRE(reset->GetValue(4, 0).GetValue<double>() == Approx(0.6));
-  REQUIRE_FALSE(reset->GetValue(5, 0).GetValue<bool>());
+  REQUIRE(reset->GetValue(5, 0).GetValue<bool>());
 
   auto const& params = sirius_ctx->get_config().get_operator_params();
   REQUIRE(params.scan_task_batch_size == 1 * mib);
   REQUIRE(params.max_sort_partition_memory_fraction == Approx(0.25));
   REQUIRE_FALSE(params.enable_dynamic_filter_pushdown);
-  REQUIRE_FALSE(params.enable_runtime_distinct_build_probe);
+  REQUIRE(params.enable_runtime_distinct_build_probe);
   auto const& compression = sirius_ctx->get_config().get_compression_config();
   REQUIRE(compression.enable_pin_table_compression);
   REQUIRE(compression.max_compressed_fraction == Approx(0.6));


### PR DESCRIPTION
## Summary

- keep runtime distinct-build probing enabled as an engine-owned join policy
- reject the removed YAML key with its full path and deletion guidance
- expose the general two-pass reference path only when `SIRIUS_ENABLE_TEST_OPTIONS=1`
- preserve the internal field, planner propagation, and runtime false path for tests

## Why

`enable_runtime_distinct_build_probe` selects between internal BUILD_PROBE implementations and already defaults on. Sirius can prove distinctness from the actual build keys at runtime; users have no better workload rule for disabling that proof. Keeping the switch public asks them to select an implementation path the engine can own.

## Validation

- repository pre-commit hooks on every changed file: PASS
- `git diff --check`: PASS
- explicit YAML key rejects with full-path removal guidance and leaves the internal default enabled
- normal and non-exact-opt-in processes cannot discover or set the DuckDB option; exact test opt-in can set/reset it
- exact zero-context replay reproduces candidate tree and reverses to the base tree
- duplicate search: no open issue or PR for this setting
- exact composition with #1523 resolved and pre-commit-clean at tree `c9bb796d1cc4ec29fab1653388a3d4072b9c0b7b`

Hosted CUDA-linked tests will execute the config regression and retain the existing internal join-path coverage.

## Identity

- base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`
- head: `6e2ee85ea15b6a7304e90071169f3d5f04929b99`
- tree: `1ed675dc395ec1bd37c2208d68e72888468e03e8`

- exact-head hosted receipt for `6e2ee85ea15b6a7304e90071169f3d5f04929b99`: CUDA 13 runtime and terminal aggregate checks passed
- hosted workflow 31707971632: runtime job 94474358746 passed from 2026-08-13T16:31:32Z through 2026-08-13T16:50:54Z; aggregate job 94523470997 passed at 2026-08-13T16:51:04Z