### PR TITLE
fix(config): validate and simplify prefetch controls

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -323,8 +323,13 @@ single-GPU configurations only (logs a warning and disables itself otherwise).
 | `enable` | bool | false | Master switch for the prefetcher. |
 | `num_threads` | int (**> 0**) | 2 | Prefetch worker threads; each drives one in-flight batch conversion on its own stream. |
 | `min_free_fraction` | double [0,1] | 0.4 | Keep at least this fraction of the GPU space free after each prefetch; conversions (and their reservations) are only attempted above this floor. |
-| `poll_interval_ms` | int (**> 0**) | 2 | Worker sweep interval while waiting for headroom / new splits. |
-| `drain_quiet_ms` | int (ms) | 100 | A connector counts as actively draining (and is skipped) until this long passes since its last pop. Must exceed the scan's inter-pop interval. |
+
+`num_threads` and `min_free_fraction` are active only when `enable: true`; configuration loading
+rejects non-null overrides while the prefetcher is disabled.
+
+Worker polling and connector-drain timing are internal scheduling policy. The
+former `poll_interval_ms` and `drain_quiet_ms` keys have been removed;
+configurations that still contain either key must delete it.
 
 ### `scan_manager.local` — io_uring backend (`io/uring/config.hpp`)
 
@@ -363,8 +368,8 @@ and transport use one trust policy; there are no separate REST YAML controls.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `inflight_io_chunk_budget` | int (**> 0**) | 2048 | Max in-flight IO chunks (enforced by admission control). |
-| `eviction_threshold_fraction` | double [0,1] | 0.6 | Start evicting when the pool fills to this fraction. |
-| `min_prefetching_budget_fraction` | double [0,1] | 0.05 | Floor of the budget reserved for prefetching. |
+| `eviction_threshold_fraction` | double [0,1] | 0.6 | Start evicting when the pool fills to this fraction. Must be at least `min_prefetching_budget_fraction`. |
+| `min_prefetching_budget_fraction` | double [0,1] | 0.05 | Floor of the budget reserved for prefetching. Must not exceed `eviction_threshold_fraction`. |
 | `dispose_after_use` | bool | false | Discard chunks immediately after use. |
 
 ### `scan_manager.object_store` — S3 credentials & endpoint (`io/object_store_config.hpp`)

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -306,7 +306,7 @@ The `sirius.executor.scan_manager` block configures the scan-metadata thread poo
 | `use_sirius_datasource` | bool | true | Route reads through the Sirius `io_uring` datasource. When false, the kvikio fallback is used (single-GPU only; multi-GPU requires the Sirius datasource). |
 | `uring_n_reactors` | int (**> 0**) | 1 | Number of io_uring reactor threads for local-disk reads. |
 | `rest_n_reactors` | int (**> 0**) | 2 | Number of REST reactor threads for object-store (`s3://`) reads. |
-| `enable_prefetch_cache` | bool | false | Attach the pinned-memory prefetching cache in front of the backend. |
+| `enable_prefetch_cache` | bool | false | Attach the pinned-memory prefetching cache in front of the backend. Supported only with one configured GPU; configuration loading rejects it for multiple GPUs because that path can return incorrect results. |
 
 Five optional nested sub-configs tune the individual backends, caches, and the memory prefetcher:
 

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -428,7 +428,9 @@ If translation fails, filtering falls back to `expression_evaluator` on the deco
 - `src/io/io_context.cpp` — `sirius_ioctx` cache integration and coverage policy
 - `src/include/exec/semi_future.hpp` — async I/O completion primitive
 
-**Config:** `enable_prefetch_cache` and the `cache` sub-config under `executor.scan_manager`
+**Config:** `enable_prefetch_cache` and the `cache` sub-config under `executor.scan_manager`.
+The prefetch cache is currently supported only with exactly one configured GPU;
+configuration loading rejects an enabled cache for multi-GPU execution.
 
 ### Load-Balanced Scan Batch Coalescing (PR #997)
 

--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -484,7 +484,7 @@ Separately from the prefetching cache, the ioctx always exposes a `metadata_stor
 - **Background threads.** A preparation thread, a prefetch thread, and an evictor thread (each a `std::jthread` driven by a blocking queue) handle queued inserts, IO dispatch, and reclamation. IO completion callbacks run on a small dedicated dispatcher pool.
 - **Admission control.** In-flight prefetch IO is bounded by an `exec::admission_control` budget sized in chunks (`cache::config::inflight_io_chunk_budget`). An oversized request is granted the full budget when nothing else is outstanding, so it makes progress instead of waiting forever.
 - **Evictor as backpressure.** When the buffer pool can't satisfy a load, the worker posts an eviction request and blocks until the evictor returns enough chunks; pool exhaustion is never a silent failure. Eviction walks LRU candidates using a per-chunk `chunk_lifecycle` score (query-tick aging plus insert/consume counts), so never-consumed entries are not evicted first.
-- **Multi-GPU safe.** Device reads carry the caller's device id; the reactor sets the device before the H2D copy, and pinned chunks are portable across CUDA contexts.
+- **Single-GPU envelope.** Configuration rejects `enable_prefetch_cache: true` when more than one GPU memory space is configured. The current cache read path is only supported for single-GPU execution.
 
 ### Constants
 

--- a/src/include/scan_manager/config.hpp
+++ b/src/include/scan_manager/config.hpp
@@ -60,11 +60,11 @@ struct memory_prefetcher_config {
   /// the reservation for a batch is only attempted above this floor, so the
   /// prefetcher backs off well before competing with pipeline reservations.
   double min_free_fraction{0.4};
-  /// Worker sweep interval while waiting for headroom / new splits.
+  /// Internal worker sweep interval while waiting for headroom / new splits.
   std::size_t poll_interval_ms{2};
   /// A connector is considered actively draining (and skipped) until this
-  /// long has passed since its last pop. Must exceed the scan's inter-pop
-  /// interval (~10-40ms per 5GB batch) or sweeps race the scan.
+  /// long has passed since its last pop. This internal policy must exceed the
+  /// scan's inter-pop interval (~10-40ms per 5GB batch) or sweeps race the scan.
   std::size_t drain_quiet_ms{100};
 };
 

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -298,6 +298,11 @@ struct sirius_config {
   /// the override takes effect. Called from the end of @ref load_from_file.
   void enforce_sirius_datasource_for_multi_gpu();
 
+  /// Reject the prefetch cache when more than one GPU memory space is configured.
+  /// The cache's current read path is only correct for single-GPU execution.
+  /// Called from the end of @ref load_from_file after memory spaces are resolved.
+  void validate_prefetch_cache_for_gpu_count() const;
+
   cucascade::memory::system_topology_info _hw_topology{.num_gpus = 1};
   int _gpus_per_query = 0;
   std::vector<cucascade::memory::memory_space_config> _memory_space_configs;

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -777,6 +777,7 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
     if (operator_node) { sirius::from_yaml(*operator_node, resolved_operator_params); }
     _operator_params = std::move(resolved_operator_params);
 
+    validate_prefetch_cache_for_gpu_count();
     enforce_sirius_datasource_for_multi_gpu();
 
   } catch (const std::exception& e) {
@@ -797,6 +798,19 @@ void sirius_config::enforce_sirius_datasource_for_multi_gpu()
       "use_sirius_datasource to true.",
       num_gpus);
     _scan_manager_config.use_sirius_datasource = true;
+  }
+}
+
+void sirius_config::validate_prefetch_cache_for_gpu_count() const
+{
+  size_t const num_gpus = std::ranges::count_if(_memory_space_configs, [](auto const& space) {
+    return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space);
+  });
+  if (num_gpus > 1 && _scan_manager_config.enable_prefetch_cache) {
+    throw std::runtime_error(
+      "sirius.executor.scan_manager.enable_prefetch_cache: true is not supported with multiple "
+      "configured GPUs because the cache can return incorrect results; disable the prefetch cache "
+      "or configure exactly one GPU");
   }
 }
 

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -216,17 +216,32 @@ static void from_yaml(const YAML::Node& node, sirius::io::cache::config& opt)
              yaml::fraction<double>{});
   r.optional(
     "eviction_threshold_fraction", opt.eviction_threshold_fraction, yaml::fraction<double>{});
+  if (opt.min_prefetching_budget_fraction > opt.eviction_threshold_fraction) {
+    throw std::runtime_error(
+      "'sirius.executor.scan_manager.cache.min_prefetching_budget_fraction': must be less than "
+      "or equal to eviction_threshold_fraction");
+  }
   r.reject_unknown();
 }
 
 static void from_yaml(const YAML::Node& node, scan_manager::memory_prefetcher_config& opt)
 {
   yaml::reader r(node, "memory_prefetcher");
+  if (r.has("poll_interval_ms") || r.has("drain_quiet_ms")) {
+    throw std::runtime_error(
+      "'sirius.executor.scan_manager.memory_prefetcher.poll_interval_ms' and "
+      "'sirius.executor.scan_manager.memory_prefetcher.drain_quiet_ms': removed; worker timing "
+      "policy is internal; remove these keys");
+  }
   r.optional("enable", opt.enable);
+  bool const has_dependent_setting = r.has_value("num_threads") || r.has_value("min_free_fraction");
+  if (!opt.enable && has_dependent_setting) {
+    throw std::runtime_error(
+      "sirius.executor.scan_manager.memory_prefetcher: num_threads and min_free_fraction require "
+      "enable: true");
+  }
   r.optional("num_threads", opt.num_threads, yaml::greater_than<std::size_t>{0});
   r.optional("min_free_fraction", opt.min_free_fraction, yaml::fraction<double>{});
-  r.optional("poll_interval_ms", opt.poll_interval_ms, yaml::greater_than<std::size_t>{0});
-  r.optional("drain_quiet_ms", opt.drain_quiet_ms);
   r.reject_unknown();
 }
 
@@ -241,7 +256,17 @@ static void from_yaml(const YAML::Node& node, scan_manager::scan_manager_config&
   r.optional("enable_prefetch_cache", opt.enable_prefetch_cache);
   if (auto n = r.optional_node("local")) sirius::from_yaml(*n, opt.local);
   if (auto n = r.optional_node("rest")) sirius::from_yaml(*n, opt.rest);
-  if (auto n = r.optional_node("cache")) sirius::from_yaml(*n, opt.cache);
+  if (auto n = r.optional_node("cache")) {
+    yaml::reader cache_reader(*n, "cache");
+    bool const has_cache_setting = cache_reader.has_value("inflight_io_chunk_budget") ||
+                                   cache_reader.has_value("dispose_after_use") ||
+                                   cache_reader.has_value("min_prefetching_budget_fraction") ||
+                                   cache_reader.has_value("eviction_threshold_fraction");
+    if (!opt.enable_prefetch_cache && has_cache_setting) {
+      throw std::runtime_error("scan_manager.cache: requires enable_prefetch_cache: true");
+    }
+    sirius::from_yaml(*n, opt.cache);
+  }
   if (auto n = r.optional_node("object_store")) sirius::from_yaml(*n, opt.object_store);
   if (auto n = r.optional_node("memory_prefetcher")) from_yaml(*n, opt.memory_prefetcher);
   r.reject_unknown();

--- a/test/cpp/config/data/invalid_cache_fraction_order.yaml
+++ b/test/cpp/config/data/invalid_cache_fraction_order.yaml
@@ -1,0 +1,9 @@
+sirius:
+  topology:
+    num_gpus: 1
+  executor:
+    scan_manager:
+      enable_prefetch_cache: true
+      cache:
+        min_prefetching_budget_fraction: 0.8
+        eviction_threshold_fraction: 0.6

--- a/test/cpp/config/data/invalid_memory_prefetcher_drain_quiet.yaml
+++ b/test/cpp/config/data/invalid_memory_prefetcher_drain_quiet.yaml
@@ -1,0 +1,5 @@
+sirius:
+  executor:
+    scan_manager:
+      memory_prefetcher:
+        drain_quiet_ms: 200

--- a/test/cpp/config/data/invalid_memory_prefetcher_poll_interval.yaml
+++ b/test/cpp/config/data/invalid_memory_prefetcher_poll_interval.yaml
@@ -1,0 +1,5 @@
+sirius:
+  executor:
+    scan_manager:
+      memory_prefetcher:
+        poll_interval_ms: 5

--- a/test/cpp/config/data/valid_cache_equal_fractions.yaml
+++ b/test/cpp/config/data/valid_cache_equal_fractions.yaml
@@ -1,0 +1,9 @@
+sirius:
+  topology:
+    num_gpus: 1
+  executor:
+    scan_manager:
+      enable_prefetch_cache: true
+      cache:
+        min_prefetching_budget_fraction: 0.6
+        eviction_threshold_fraction: 0.6

--- a/test/cpp/config/data/valid_memory_prefetcher_timing_omitted.yaml
+++ b/test/cpp/config/data/valid_memory_prefetcher_timing_omitted.yaml
@@ -1,0 +1,5 @@
+sirius:
+  executor:
+    scan_manager:
+      memory_prefetcher:
+        enable: false

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -454,6 +454,107 @@ TEST_CASE("Sirius configuration rejects empty telemetry destination and identity
   }
 }
 
+TEST_CASE("Sirius configuration rejects a cache reservation floor above its eviction threshold",
+          "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  sirius::sirius_config rejected;
+  REQUIRE_THROWS_WITH(rejected.load_from_file(data_dir / "invalid_cache_fraction_order.yaml"),
+                      Catch::Contains("scan_manager.cache.min_prefetching_budget_fraction") &&
+                        Catch::Contains("less than or equal to eviction_threshold_fraction"));
+
+  sirius::sirius_config equal;
+  REQUIRE_NOTHROW(equal.load_from_file(data_dir / "valid_cache_equal_fractions.yaml"));
+  auto const& cache = equal.get_scan_manager_config().cache;
+  REQUIRE(cache.min_prefetching_budget_fraction == 0.6);
+  REQUIRE(cache.eviction_threshold_fraction == 0.6);
+}
+
+TEST_CASE("Sirius configuration keeps memory prefetcher timing internal", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  for (auto const& [file, key] : std::initializer_list<std::pair<char const*, char const*>>{
+         {"invalid_memory_prefetcher_poll_interval.yaml", "poll_interval_ms"},
+         {"invalid_memory_prefetcher_drain_quiet.yaml", "drain_quiet_ms"}}) {
+    CAPTURE(file, key);
+    sirius::sirius_config rejected;
+    REQUIRE_THROWS_WITH(rejected.load_from_file(data_dir / file),
+                        Catch::Contains("scan_manager.memory_prefetcher") && Catch::Contains(key) &&
+                          Catch::Contains("removed") && Catch::Contains("remove these keys"));
+  }
+
+  sirius::sirius_config omitted;
+  REQUIRE_NOTHROW(omitted.load_from_file(data_dir / "valid_memory_prefetcher_timing_omitted.yaml"));
+  auto const& prefetcher = omitted.get_scan_manager_config().memory_prefetcher;
+  CHECK(prefetcher.poll_interval_ms == 2);
+  CHECK(prefetcher.drain_quiet_ms == 100);
+}
+
+TEST_CASE("Sirius configuration rejects inactive memory prefetcher settings", "[sirius][config]")
+{
+  struct inactive_setting {
+    const char* name;
+    const char* value;
+  };
+  const inactive_setting cases[] = {
+    {"num_threads", "3"},
+    {"min_free_fraction", "0.25"},
+  };
+
+  for (auto const enable : {"", "        enable: false\n"}) {
+    for (auto const& setting : cases) {
+      DYNAMIC_SECTION((enable[0] == '\0' ? "implicit" : "explicit") << "." << setting.name)
+      {
+        auto const path =
+          fs::temp_directory_path() /
+          (std::string("sirius_inactive_memory_prefetcher_") + setting.name + ".yaml");
+        finally cleanup{[path]() {
+          std::error_code ec;
+          fs::remove(path, ec);
+        }};
+        {
+          std::ofstream out(path);
+          REQUIRE(out);
+          out << "sirius:\n  executor:\n    scan_manager:\n      memory_prefetcher:\n"
+              << enable << "        " << setting.name << ": " << setting.value << "\n";
+        }
+
+        sirius::sirius_config config;
+        REQUIRE_THROWS_WITH(config.load_from_file(path),
+                            Catch::Contains("sirius.executor.scan_manager.memory_prefetcher") &&
+                              Catch::Contains("require enable: true"));
+      }
+    }
+  }
+}
+
+TEST_CASE("Sirius configuration accepts memory prefetcher settings when enabled",
+          "[sirius][config]")
+{
+  auto const path = fs::temp_directory_path() / "sirius_active_memory_prefetcher.yaml";
+  finally cleanup{[path]() {
+    std::error_code ec;
+    fs::remove(path, ec);
+  }};
+  {
+    std::ofstream out(path);
+    REQUIRE(out);
+    out << "sirius:\n  executor:\n    scan_manager:\n      memory_prefetcher:\n"
+           "        enable: true\n        num_threads: 3\n        min_free_fraction: 0.25\n";
+  }
+
+  sirius::sirius_config config;
+  REQUIRE_NOTHROW(config.load_from_file(path));
+  auto const& prefetcher = config.get_scan_manager_config().memory_prefetcher;
+  REQUIRE(prefetcher.enable);
+  REQUIRE(prefetcher.num_threads == 3);
+  REQUIRE(prefetcher.min_free_fraction == Approx(0.25));
+}
+
 TEST_CASE("Sirius configuration rejects negative host capacity bytes", "[sirius][config]")
 {
   std::source_location loc = std::source_location::current();

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -317,6 +317,8 @@ TEST_CASE("sirius_config accepts prefetch cache settings when enabled",
   auto const path = std::filesystem::temp_directory_path() / "sirius_cache_enabled_settings.yaml";
   write_yaml(path,
              "sirius:\n"
+             "  topology:\n"
+             "    num_gpus: 1\n"
              "  executor:\n"
              "    scan_manager:\n"
              "      enable_prefetch_cache: true\n"

--- a/test/cpp/config/test_object_store_config.cpp
+++ b/test/cpp/config/test_object_store_config.cpp
@@ -254,6 +254,91 @@ TEST_CASE("sirius_config defaults chunk prewarm to enabled when YAML omits the k
   std::filesystem::remove(path, ec);
 }
 
+TEST_CASE("sirius_config rejects inactive prefetch cache settings",
+          "[scan_manager][config][prefetching_cache]")
+{
+  for (auto const enable_line :
+       {std::string{}, std::string{"      enable_prefetch_cache: false\n"}}) {
+    for (auto const cache_setting : {std::string{"inflight_io_chunk_budget: 64"},
+                                     std::string{"dispose_after_use: true"},
+                                     std::string{"min_prefetching_budget_fraction: 0.1"},
+                                     std::string{"eviction_threshold_fraction: 0.7"}}) {
+      auto const path = std::filesystem::temp_directory_path() /
+                        (enable_line.empty() ? "sirius_cache_disabled_implicitly.yaml"
+                                             : "sirius_cache_disabled_explicitly.yaml");
+      write_yaml(path,
+                 "sirius:\n"
+                 "  executor:\n"
+                 "    scan_manager:\n" +
+                   enable_line + "      cache:\n        " + cache_setting + "\n");
+
+      sirius::sirius_config cfg;
+      CHECK_THROWS_WITH(cfg.load_from_file(path),
+                        Catch::Contains("scan_manager.cache") &&
+                          Catch::Contains("requires enable_prefetch_cache: true"));
+      auto const& cache = cfg.get_scan_manager_config().cache;
+      CHECK(cache.inflight_io_chunk_budget == 2048);
+      CHECK_FALSE(cache.dispose_after_use);
+      CHECK(cache.min_prefetching_budget_fraction == 0.05);
+      CHECK(cache.eviction_threshold_fraction == 0.6);
+
+      std::error_code ec;
+      std::filesystem::remove(path, ec);
+    }
+  }
+}
+
+TEST_CASE("sirius_config treats null and empty prefetch cache blocks as absent",
+          "[scan_manager][config][prefetching_cache]")
+{
+  for (auto const cache_line : {std::string{"      cache: null\n"},
+                                std::string{"      cache: {}\n"},
+                                std::string{"      cache:\n"
+                                            "        inflight_io_chunk_budget: null\n"}}) {
+    auto const path = std::filesystem::temp_directory_path() / "sirius_cache_inactive_absent.yaml";
+    write_yaml(path,
+               "sirius:\n"
+               "  executor:\n"
+               "    scan_manager:\n" +
+                 cache_line);
+
+    sirius::sirius_config cfg;
+    REQUIRE_NOTHROW(cfg.load_from_file(path));
+    CHECK_FALSE(cfg.get_scan_manager_config().enable_prefetch_cache);
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+  }
+}
+
+TEST_CASE("sirius_config accepts prefetch cache settings when enabled",
+          "[scan_manager][config][prefetching_cache]")
+{
+  auto const path = std::filesystem::temp_directory_path() / "sirius_cache_enabled_settings.yaml";
+  write_yaml(path,
+             "sirius:\n"
+             "  executor:\n"
+             "    scan_manager:\n"
+             "      enable_prefetch_cache: true\n"
+             "      cache:\n"
+             "        inflight_io_chunk_budget: 64\n"
+             "        min_prefetching_budget_fraction: 0.1\n"
+             "        eviction_threshold_fraction: 0.7\n"
+             "        dispose_after_use: true\n");
+
+  sirius::sirius_config cfg;
+  REQUIRE_NOTHROW(cfg.load_from_file(path));
+  auto const& scan = cfg.get_scan_manager_config();
+  CHECK(scan.enable_prefetch_cache);
+  CHECK(scan.cache.inflight_io_chunk_budget == 64);
+  CHECK(scan.cache.min_prefetching_budget_fraction == 0.1);
+  CHECK(scan.cache.eviction_threshold_fraction == 0.7);
+  CHECK(scan.cache.dispose_after_use);
+
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
 TEST_CASE("sirius_config parses rest perf instrumentation flag",
           "[scan_manager][config][s3][rest][perf]")
 {

--- a/test/cpp/config/test_topology_config.cpp
+++ b/test/cpp/config/test_topology_config.cpp
@@ -123,3 +123,57 @@ TEST_CASE("sirius_config accepts a zero admission_bytes_per_gpu", "[topology_con
   REQUIRE_NOTHROW(cfg.load_from_file(yaml.path));
   CHECK(cfg.get_operator_params().admission_bytes_per_gpu == 0);
 }
+
+TEST_CASE("sirius_config restricts the prefetch cache to one GPU",
+          "[topology_config][config][prefetching_cache]")
+{
+  SECTION("one GPU accepts an enabled cache")
+  {
+    scoped_yaml yaml("sirius_prefetch_cache_one_gpu.yaml",
+                     "sirius:\n"
+                     "  topology:\n"
+                     "    num_gpus: 1\n"
+                     "  executor:\n"
+                     "    scan_manager:\n"
+                     "      enable_prefetch_cache: true\n");
+
+    sirius::sirius_config cfg;
+    REQUIRE_NOTHROW(cfg.load_from_file(yaml.path));
+  }
+
+  SECTION("multiple GPUs accept the default disabled cache")
+  {
+    scoped_yaml yaml("sirius_prefetch_cache_multi_gpu_disabled.yaml",
+                     "sirius:\n"
+                     "  space:\n"
+                     "    gpu:\n"
+                     "      - device_id: 0\n"
+                     "        memory_capacity: 512MiB\n"
+                     "      - device_id: 1\n"
+                     "        memory_capacity: 512MiB\n");
+
+    sirius::sirius_config cfg;
+    REQUIRE_NOTHROW(cfg.load_from_file(yaml.path));
+  }
+
+  SECTION("multiple GPUs reject an enabled cache")
+  {
+    scoped_yaml yaml("sirius_prefetch_cache_multi_gpu_enabled.yaml",
+                     "sirius:\n"
+                     "  space:\n"
+                     "    gpu:\n"
+                     "      - device_id: 0\n"
+                     "        memory_capacity: 512MiB\n"
+                     "      - device_id: 1\n"
+                     "        memory_capacity: 512MiB\n"
+                     "  executor:\n"
+                     "    scan_manager:\n"
+                     "      enable_prefetch_cache: true\n");
+
+    sirius::sirius_config cfg;
+    REQUIRE_THROWS_WITH(cfg.load_from_file(yaml.path),
+                        Catch::Contains("enable_prefetch_cache") &&
+                          Catch::Contains("multiple configured GPUs") &&
+                          Catch::Contains("incorrect results"));
+  }
+}


### PR DESCRIPTION
## Current repair identity

- exact base: `cbd9516367b2d3160492c8cb0575208f1dce047c`
- exact head: `c5ae05c03d488341ed32df589c1a0840500172a3`
- candidate tree: `984d9fa0333d3e09a51bc6f2da53153274bba4ef`
- full-index binary diff SHA-256: `7dfac65d012b5a14e84997a2494e87abcca2e7d4ee5295ac443fcbebe65a1ad6`
- current-dev conflict resolution preserves merged #1532 scan internalization and the complete prefetch validation unit
- complete diff and independent cold review: clear
- diff, clang-format, rumdl, YAML-fixture, test-registration, and single-GPU documentation consistency checks: pass
- hosted exact-head Test run 32296818402 passed, including GPU runtime job 96211865477; Check, Distribution, lint, GCC, Clang, CUDA build, title validation, and every other non-skipped job passed

Foxglove has completed author-side review of this exact head and returned it to ready. The receipt below is preserved explicitly as predecessor evidence.

## Review focus

**Tier:** judgment — this changes the accepted configuration envelope by
refusing a known-incorrect multi-GPU prefetch-cache topology.

**Maintainer question:** Is load-time refusal the right containment for the
known multi-GPU wrong-result path while #1312 remains open, or is there a
topology-safe cache implementation constraint this guard should encode instead?

**Main risk:** the guard intentionally rejects a configuration previously
accepted by the loader; that configuration is retained only when the cache is
disabled because the enabled path is known to return wrong results.

## Summary

- reject non-null cache controls while `enable_prefetch_cache` is false or omitted
- reject a cache reservation floor above its eviction threshold, retaining equality
- remove memory-prefetcher polling and drain timing from YAML; keep the existing internal policy
- reject memory-prefetcher overrides unless that prefetcher is enabled
- reject `enable_prefetch_cache: true` when more than one GPU is configured
- preserve null/empty cache blocks and every supported enabled-path readback

## Why one PR

The cache and memory prefetcher are adjacent scan-manager prefetch components. This PR gives them one load-time contract: dependent settings require their named component, contradictory budgets fail, worker timing stays internal, and the prefetch cache is restricted to its known-correct single-GPU path.

The topology guard mitigates the silent wrong-result configuration reported in #1312. It deliberately does **not** close #1312: the underlying multi-GPU cache defect remains. A load-time refusal is safer than silently disabling the requested cache or allowing a configuration known to produce incorrect results.

This supersedes #1531 and retains the complete cache activation contract formerly carried by #1488.

## Contract

- implicit or explicit disablement rejects non-null dependent settings
- null and empty cache blocks remain equivalent to omission
- enabled components accept and read back their remaining controls
- cache budget floor must be less than or equal to its eviction threshold
- removed memory-prefetcher timing keys fail with deletion guidance
- omitted timing retains the existing 2 ms polling and 100 ms drain policy
- one configured GPU may enable the prefetch cache
- multiple configured GPUs may run with the cache disabled, but enabling it fails with corrective guidance

## August 18 predecessor identity

- exact base: `34311516f1233c1f4aca4d16b0a7bf190fa197f9`
- exact head: `d5765f1820e1ac125bf8180eadef44d35381fcf7`
- candidate tree: `0d2fedb6542d018244b19fec5b1b4e27bd736cca`
- full-index binary diff SHA-256: `3b1023c0af8d14ee914f49251b796cc92d8449203fd1f4787b14daafda0dc87a`
- clean two-commit rebase onto current `dev`; the only conflict was additive test placement in `test_topology_config.cpp`

## Validation

- conflict resolution retains current-dev topology validation and the complete one-GPU/multi-GPU prefetch-cache regression
- range-diff preserves the production/source patch; only the topology-test insertion context moved
- live comparison with #1588 and #1595 found shared aggregate config files but no prefetch/cache semantic delta to consolidate or resolve
- `python3 scripts/check_orphan_tests.py`: pass
- `git diff --check`: pass
- local conflict-marker scan across the changed source, docs, and config tests: pass
- new hardware-independent topology regression covers: one GPU + cache enabled; two GPUs + cache disabled; two GPUs + cache enabled and rejected
- adjacent config selectors cover topology, scan-manager activation, object-store cache use, and full Sirius config loading
- exact-head hosted Test run `32193359123`: CUDA 13 build passed; runtime job `95893704932` passed in 20m27s, including C++ unit tests and the TPC-H snapshot; terminal aggregate job `95898222615` passed
- exact-head hosted Check run `32193359054`: lint, GCC release, Clang debug, and terminal aggregate passed
- exact-head hosted Distribution run `32193359694`: terminal aggregate passed

Final author-readiness review at exact head `d5765f1820e` found the two-commit
unit coherent, the conflict resolution faithful, the dependency current, and
no remaining author-side repair. The judgment question above is ready for
maintainer review rather than an unfinished-author-work draft condition.
