### PR TITLE
fix(config): validate SIRIUS_DISABLE values

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -26,7 +26,12 @@ If no config file is found, Sirius initializes with built-in defaults (95% GPU m
 
 ### `SIRIUS_DISABLE`
 
-Set `SIRIUS_DISABLE=1` to prevent Super Sirius from initializing. This is **required** when using the legacy code path (`gpu_buffer_init`/`gpu_processing`), because Super Sirius claims most GPU and pinned host memory on startup, leaving insufficient memory for the legacy buffer manager. It is also useful for CPU-only benchmarks.
+Set `SIRIUS_DISABLE=1` to prevent Super Sirius from initializing. `0` explicitly
+enables initialization; other values are rejected so a misspelling cannot
+silently disable Sirius. This is **required** when using the legacy code path
+(`gpu_buffer_init`/`gpu_processing`), because Super Sirius claims most GPU and
+pinned host memory on startup, leaving insufficient memory for the legacy
+buffer manager. It is also useful for CPU-only benchmarks.
 
 ```bash
 export SIRIUS_DISABLE=1

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -703,6 +703,11 @@ class SiriusContext : public ClientContextState {
 /// null (best-effort) path never throws.
 void install_configured_log_sink(DatabaseInstance* db);
 
+/// True only when `SIRIUS_DISABLE` is exactly `1`; unset and exactly `0` enable
+/// Sirius, while every other set value is rejected before runtime
+/// initialization and optimizer-mask publication.
+bool sirius_disabled_from_environment();
+
 /// todo(amin): when duckdb is updated, we need to enable OnExtensionLoaded to support sirius
 /// extensions
 class SiriusContextExtensionCallback : public ExtensionCallback {

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -747,6 +747,11 @@ class SiriusContext : public ClientContextState {
 /// null (best-effort) path never throws.
 void install_configured_log_sink(DatabaseInstance* db);
 
+/// True only when `SIRIUS_DISABLE` is exactly `1`; unset and exactly `0` enable
+/// Sirius, while every other set value is rejected before runtime
+/// initialization and optimizer-mask publication.
+bool sirius_disabled_from_environment();
+
 /// todo(amin): when duckdb is updated, we need to enable OnExtensionLoaded to support sirius
 /// extensions
 class SiriusContextExtensionCallback : public ExtensionCallback {

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -1584,6 +1584,14 @@ void install_configured_log_sink(DatabaseInstance* db)
   }
 }
 
+bool sirius_disabled_from_environment()
+{
+  auto const* value = std::getenv("SIRIUS_DISABLE");
+  if (value == nullptr || std::string_view{value} == "0") { return false; }
+  if (std::string_view{value} == "1") { return true; }
+  throw InvalidInputException("Invalid SIRIUS_DISABLE '%s' (expected: 0 or 1)", value);
+}
+
 SiriusContextExtensionCallback::SiriusContextExtensionCallback()
 {
   if (auto* env = std::getenv("SIRIUS_LOG_BACKEND")) { Config::LOG_BACKEND = env; }
@@ -1636,7 +1644,7 @@ void SiriusContextExtensionCallback::OnExtensionLoadFail(DatabaseInstance& db,
 void SiriusContextExtensionCallback::read_config_file_if_exists()
 {
   // Check for explicit disable (used by benchmarks/tests that need pure CPU execution)
-  if (auto* val = std::getenv("SIRIUS_DISABLE"); val != nullptr && std::string(val) != "0") {
+  if (sirius_disabled_from_environment()) {
     SIRIUS_LOG_INFO("Sirius disabled via SIRIUS_DISABLE environment variable.");
     return;
   }

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -1653,6 +1653,14 @@ void install_configured_log_sink(DatabaseInstance* db)
   }
 }
 
+bool sirius_disabled_from_environment()
+{
+  auto const* value = std::getenv("SIRIUS_DISABLE");
+  if (value == nullptr || std::string_view{value} == "0") { return false; }
+  if (std::string_view{value} == "1") { return true; }
+  throw InvalidInputException("Invalid SIRIUS_DISABLE '%s' (expected: 0 or 1)", value);
+}
+
 SiriusContextExtensionCallback::SiriusContextExtensionCallback()
 {
   auto const previous_log_backend = Config::LOG_BACKEND;
@@ -1736,7 +1744,7 @@ void SiriusContextExtensionCallback::OnExtensionLoadFail(DatabaseInstance& db,
 void SiriusContextExtensionCallback::read_config_file_if_exists()
 {
   // Check for explicit disable (used by benchmarks/tests that need pure CPU execution)
-  if (auto* val = std::getenv("SIRIUS_DISABLE"); val != nullptr && std::string(val) != "0") {
+  if (sirius_disabled_from_environment()) {
     SIRIUS_LOG_INFO("Sirius disabled via SIRIUS_DISABLE environment variable.");
     return;
   }

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2627,10 +2627,7 @@ static void LoadInternal(ExtensionLoader& loader)
   // above succeeded, so a failed load leaves no mask behind. SIRIUS_DISABLE
   // means no Sirius runtime initialization and no mask publication (the
   // extension binary itself may still be loaded).
-  bool const sirius_disabled = [] {
-    auto* val = std::getenv("SIRIUS_DISABLE");
-    return val != nullptr && std::string(val) != "0";
-  }();
+  bool const sirius_disabled = sirius_disabled_from_environment();
   if (!sirius_disabled) { publish_transparent_optimizer_mask(config); }
 }
 

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -3536,10 +3536,7 @@ static void LoadInternal(ExtensionLoader& loader)
   // above succeeded, so a failed load leaves no mask behind. SIRIUS_DISABLE
   // means no Sirius runtime initialization and no mask publication (the
   // extension binary itself may still be loaded).
-  bool const sirius_disabled = [] {
-    auto* val = std::getenv("SIRIUS_DISABLE");
-    return val != nullptr && std::string(val) != "0";
-  }();
+  bool const sirius_disabled = sirius_disabled_from_environment();
   if (!sirius_disabled) { publish_transparent_optimizer_mask(config); }
 }
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -342,6 +342,33 @@ TEST_CASE("Sirius configuration keeps runtime distinct-build probing internal", 
       Catch::Contains("removed") && Catch::Contains("remove this key"));
 }
 
+TEST_CASE("SIRIUS_DISABLE accepts only explicit boolean values", "[sirius][config]")
+{
+  std::optional<std::string> previous;
+  if (auto const* value = std::getenv("SIRIUS_DISABLE")) { previous = value; }
+  finally restore_env{[previous]() {
+    if (previous) {
+      setenv("SIRIUS_DISABLE", previous->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_DISABLE");
+    }
+  }};
+
+  unsetenv("SIRIUS_DISABLE");
+  REQUIRE_FALSE(duckdb::sirius_disabled_from_environment());
+  setenv("SIRIUS_DISABLE", "0", 1);
+  REQUIRE_FALSE(duckdb::sirius_disabled_from_environment());
+  setenv("SIRIUS_DISABLE", "1", 1);
+  REQUIRE(duckdb::sirius_disabled_from_environment());
+
+  for (auto const* invalid : {"", "false", "true", "2", "yes"}) {
+    CAPTURE(invalid);
+    setenv("SIRIUS_DISABLE", invalid, 1);
+    REQUIRE_THROWS_WITH(duckdb::sirius_disabled_from_environment(),
+                        Catch::Contains("SIRIUS_DISABLE") && Catch::Contains("0 or 1"));
+  }
+}
+
 TEST_CASE("Sirius configuration loading from file with configurator",
           "[sirius][context][isolated_context]")
 {

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -611,6 +611,33 @@ TEST_CASE("Sirius startup rejects unknown environment log levels before mutation
   REQUIRE_FALSE(sirius::log::get_sink()->should_log(sirius::log::level::critical));
 }
 
+TEST_CASE("SIRIUS_DISABLE accepts only explicit boolean values", "[sirius][config]")
+{
+  std::optional<std::string> previous;
+  if (auto const* value = std::getenv("SIRIUS_DISABLE")) { previous = value; }
+  finally restore_env{[previous]() {
+    if (previous) {
+      setenv("SIRIUS_DISABLE", previous->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_DISABLE");
+    }
+  }};
+
+  unsetenv("SIRIUS_DISABLE");
+  REQUIRE_FALSE(duckdb::sirius_disabled_from_environment());
+  setenv("SIRIUS_DISABLE", "0", 1);
+  REQUIRE_FALSE(duckdb::sirius_disabled_from_environment());
+  setenv("SIRIUS_DISABLE", "1", 1);
+  REQUIRE(duckdb::sirius_disabled_from_environment());
+
+  for (auto const* invalid : {"", "false", "true", "2", "yes"}) {
+    CAPTURE(invalid);
+    setenv("SIRIUS_DISABLE", invalid, 1);
+    REQUIRE_THROWS_WITH(duckdb::sirius_disabled_from_environment(),
+                        Catch::Contains("SIRIUS_DISABLE") && Catch::Contains("0 or 1"));
+  }
+}
+
 TEST_CASE("Sirius configuration loading from file with configurator",
           "[sirius][context][isolated_context]")
 {


### PR DESCRIPTION
## Summary

- accept only explicit `SIRIUS_DISABLE=0` or `SIRIUS_DISABLE=1`
- centralize the environment interpretation used by runtime initialization and optimizer-mask publication
- reject misspellings instead of silently treating every non-`0` string as disabled

## Configuration contract

`SIRIUS_DISABLE` is a deployment policy switch, not a tuning knob. Unset and
`0` leave Sirius enabled; `1` disables it. Empty, textual booleans, other
numbers, and misspellings fail with the setting name and accepted values before
runtime initialization or optimizer-mask publication.

## September 9 current-dev repair

The prior head conflicted after merged #1519 inserted its logging rollback
regressions at the same test anchor. This replacement retains every #1519
logging test and include, then appends the unchanged `SIRIUS_DISABLE`
regression. The original five-file changed-line payload is byte-identical after
the rebase.

## Exact reviewed identity

- tier: `judgment`
- exact base: `285737bc33c84d5c175c59862162b518b89fcae0`
- base tree: `8a3ac4a8c9809355bd9303ca1dc274fd6211752a`
- exact head: `4add07a8e3865c66abe868573e9b46d1430b53ee`
- candidate tree: `3dfee4a90f2b5c6e115c0ea90089858f25dc12e6`
- cumulative binary-diff SHA-256: `39950b05cb18dde14a703d30df7adc378271fb654ec2e362719f450543262b47`
- cumulative diff: 5 paths, 48 insertions, 6 deletions

## Author-side validation

- independent exact-head full-diff review: no critical, important, or minor findings
- clean worktree, `git diff --check`, and `git show --check`: pass
- focused regression covers unset, `0`, `1`, and invalid empty, `false`, `true`, `2`, and `yes` values with exact environment restoration
- both production call sites use the same helper before their visible mutation boundaries
- hosted Check `34394470477`: lint, GCC release, Clang debug, and aggregate pass
- hosted Test `34394470184`: CUDA 13 build, runtime suite, and aggregate pass
- hosted Distribution `34394471718`: aggregate pass; CUDA distribution leaves correctly skip because distribution inputs did not change
- hosted Validate `34394467550`: title and aggregate validation pass

The replacement head is author-ready and terminal-green. Independent
maintainer approval of this exact head remains the merge gate.

### Retained predecessor evidence

Earlier exact heads also passed the hosted runtime suite. Those receipts support
the unchanged behavior but do not replace the current exact-head gates above.