### PR TITLE
fix(config): reject invalid YAML quantities

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -291,7 +291,7 @@ Thread pool (default `num_threads: 1`) plus:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `monitor_period` | int (ms) | 10 | Period of the memory-pressure monitor loop. Set to `0` to disable the monitor loop entirely. |
+| `monitor_period` | duration (**>= 0**) | 10ms | Period of the memory-pressure monitor loop. Set to `0` to disable the monitor loop entirely; negative durations are rejected. |
 
 ## Scan Manager & IO Configuration
 

--- a/src/include/yaml_reader.hpp
+++ b/src/include/yaml_reader.hpp
@@ -18,10 +18,13 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include <cctype>
 #include <chrono>
+#include <cmath>
 #include <concepts>
 #include <cstdint>
 #include <filesystem>
+#include <limits>
 #include <optional>
 #include <set>
 #include <stdexcept>
@@ -96,7 +99,13 @@ inline std::uint64_t parse_bytes(std::string_view sv)
 
   if (pos == 0) { throw std::runtime_error("invalid byte value: '" + std::string(sv) + "'"); }
 
-  double number = std::stod(std::string(sv.substr(0, pos)));
+  auto const numeric = std::string(sv.substr(0, pos));
+  std::size_t consumed{};
+  long double number = std::stold(numeric, &consumed);
+  if (consumed != numeric.size()) {
+    throw std::runtime_error("invalid byte value: '" + std::string(sv) + "'");
+  }
+  if (!std::isfinite(number)) { throw std::runtime_error("byte value must be finite"); }
   if (number < 0) { throw std::runtime_error("byte value must be non-negative"); }
   auto suffix = sv.substr(pos);
 
@@ -105,24 +114,39 @@ inline std::uint64_t parse_bytes(std::string_view sv)
     suffix.remove_prefix(1);
   }
 
-  if (suffix.empty() || suffix == "B" || suffix == "b") {
-    return static_cast<std::uint64_t>(number);
+  std::string normalized_suffix;
+  normalized_suffix.reserve(suffix.size());
+  for (char c : suffix) {
+    normalized_suffix.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
   }
 
-  // Determine if binary (Ki, Mi, Gi, Ti, KiB, MiB, GiB, TiB) or decimal (K, KB, M, MB, ...)
-  char unit   = static_cast<char>(std::toupper(static_cast<unsigned char>(suffix[0])));
-  bool binary = (suffix.size() >= 2 && suffix[1] == 'i');
-
-  std::uint64_t base = binary ? 1024ULL : 1000ULL;
-  std::uint64_t multiplier;
-  switch (unit) {
-    case 'K': multiplier = base; break;
-    case 'M': multiplier = base * base; break;
-    case 'G': multiplier = base * base * base; break;
-    case 'T': multiplier = base * base * base * base; break;
-    default: throw std::runtime_error("unknown byte suffix: '" + std::string(suffix) + "'");
+  std::uint64_t multiplier = 1;
+  if (normalized_suffix.empty() || normalized_suffix == "b") {
+    multiplier = 1;
+  } else if (normalized_suffix == "k" || normalized_suffix == "kb") {
+    multiplier = 1000ULL;
+  } else if (normalized_suffix == "m" || normalized_suffix == "mb") {
+    multiplier = 1000ULL * 1000;
+  } else if (normalized_suffix == "g" || normalized_suffix == "gb") {
+    multiplier = 1000ULL * 1000 * 1000;
+  } else if (normalized_suffix == "t" || normalized_suffix == "tb") {
+    multiplier = 1000ULL * 1000 * 1000 * 1000;
+  } else if (normalized_suffix == "ki" || normalized_suffix == "kib") {
+    multiplier = 1024ULL;
+  } else if (normalized_suffix == "mi" || normalized_suffix == "mib") {
+    multiplier = 1024ULL * 1024;
+  } else if (normalized_suffix == "gi" || normalized_suffix == "gib") {
+    multiplier = 1024ULL * 1024 * 1024;
+  } else if (normalized_suffix == "ti" || normalized_suffix == "tib") {
+    multiplier = 1024ULL * 1024 * 1024 * 1024;
+  } else {
+    throw std::runtime_error("unknown byte suffix: '" + std::string(suffix) + "'");
   }
 
+  if (number > static_cast<long double>(std::numeric_limits<std::uint64_t>::max()) /
+                 static_cast<long double>(multiplier)) {
+    throw std::runtime_error("byte value is too large");
+  }
   return static_cast<std::uint64_t>(number * static_cast<double>(multiplier));
 }
 
@@ -155,8 +179,14 @@ inline std::chrono::nanoseconds parse_duration(std::string_view sv)
 
   if (pos == 0) { throw std::runtime_error("invalid time value: '" + std::string(sv) + "'"); }
 
-  double number = std::stod(std::string(sv.substr(0, pos)));
-  auto suffix   = sv.substr(pos);
+  auto const numeric = std::string(sv.substr(0, pos));
+  std::size_t consumed{};
+  long double number = std::stold(numeric, &consumed);
+  if (consumed != numeric.size()) {
+    throw std::runtime_error("invalid time value: '" + std::string(sv) + "'");
+  }
+  if (!std::isfinite(number)) { throw std::runtime_error("time value must be finite"); }
+  auto suffix = sv.substr(pos);
 
   // Strip leading whitespace from suffix
   while (!suffix.empty() && suffix[0] == ' ') {
@@ -173,7 +203,15 @@ inline std::chrono::nanoseconds parse_duration(std::string_view sv)
   // Scale the (possibly fractional) count by the chrono literal for the unit,
   // then round down to whole nanoseconds.
   auto scale = [number](auto literal_unit) {
-    return std::chrono::duration_cast<std::chrono::nanoseconds>(number * literal_unit);
+    auto const nanoseconds_value =
+      std::chrono::duration_cast<std::chrono::duration<long double, std::nano>>(number *
+                                                                                literal_unit)
+        .count();
+    if (nanoseconds_value < static_cast<long double>(std::chrono::nanoseconds::min().count()) ||
+        nanoseconds_value > static_cast<long double>(std::chrono::nanoseconds::max().count())) {
+      throw std::runtime_error("time value is out of range");
+    }
+    return std::chrono::nanoseconds{static_cast<std::chrono::nanoseconds::rep>(nanoseconds_value)};
   };
 
   if (unit == "ns" || unit == "nsec") { return scale(1ns); }
@@ -204,10 +242,12 @@ template <std::integral T>
   requires(!std::is_same_v<T, bool>)
 void read_yaml(const YAML::Node& node, T& out)
 {
-  if constexpr (sizeof(T) > 4)
-    out = static_cast<T>(node.as<long long>());
-  else
-    out = static_cast<T>(node.as<int>());
+  using parsed_type = std::conditional_t<(sizeof(T) > 4), long long, int>;
+  auto const parsed = node.as<parsed_type>();
+  if constexpr (std::is_unsigned_v<T>) {
+    if (parsed < 0) { throw std::runtime_error("unsigned value must be non-negative"); }
+  }
+  out = static_cast<T>(parsed);
 }
 
 /// Wrapper that marks an integral field as accepting byte suffixes (e.g. "8Gi", "512M").
@@ -289,6 +329,38 @@ void read_yaml(const YAML::Node& node, std::chrono::duration<Rep, Period>& out)
     out = target{node.as<Rep>()};
   } catch (const YAML::BadConversion&) {
     out = std::chrono::duration_cast<target>(parse_duration(node.as<std::string>()));
+  }
+}
+
+/// Wrapper that rejects negative durations before casting to the target resolution.
+/// This avoids a negative sub-unit value (for example, -1us into milliseconds)
+/// truncating to zero before validation.
+template <typename Duration>
+struct non_negative_duration_value {
+  Duration& ref;
+};
+
+template <typename Rep, typename Period>
+non_negative_duration_value<std::chrono::duration<Rep, Period>> non_negative_duration(
+  std::chrono::duration<Rep, Period>& value)
+{
+  return {value};
+}
+
+template <typename Rep, typename Period>
+void read_yaml(const YAML::Node& node,
+               non_negative_duration_value<std::chrono::duration<Rep, Period>>& out)
+{
+  using target = std::chrono::duration<Rep, Period>;
+  try {
+    auto const count = node.as<Rep>();
+    if (count < Rep{0}) { throw std::runtime_error("duration must be non-negative"); }
+    out.ref = target{count};
+  } catch (const YAML::BadConversion&) {
+    auto const scalar = node.as<std::string>();
+    auto const parsed = parse_duration(scalar);
+    if (std::stod(scalar) < 0.0) { throw std::runtime_error("duration must be non-negative"); }
+    out.ref = std::chrono::duration_cast<target>(parsed);
   }
 }
 

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -344,7 +344,7 @@ static void from_yaml(const YAML::Node& node, exec::downgrade_executor_config& o
   yaml::reader r(node, "downgrade");
   r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{0});
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
-  r.optional("monitor_period", opt.monitor_period);
+  r.optional("monitor_period", yaml::non_negative_duration(opt.monitor_period));
   r.reject_unknown();
 }
 

--- a/test/cpp/config/data/invalid_downgrade_monitor_period_negative.yaml
+++ b/test/cpp/config/data/invalid_downgrade_monitor_period_negative.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      monitor_period: -1

--- a/test/cpp/config/data/invalid_downgrade_monitor_period_negative_fractional.yaml
+++ b/test/cpp/config/data/invalid_downgrade_monitor_period_negative_fractional.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      monitor_period: -0.5ms

--- a/test/cpp/config/data/invalid_downgrade_monitor_period_negative_submillisecond.yaml
+++ b/test/cpp/config/data/invalid_downgrade_monitor_period_negative_submillisecond.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      monitor_period: -1us

--- a/test/cpp/config/data/invalid_downgrade_monitor_period_negative_suffix.yaml
+++ b/test/cpp/config/data/invalid_downgrade_monitor_period_negative_suffix.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      monitor_period: -1ms

--- a/test/cpp/config/data/invalid_memory_prefetcher_num_threads_negative.yaml
+++ b/test/cpp/config/data/invalid_memory_prefetcher_num_threads_negative.yaml
@@ -1,0 +1,5 @@
+sirius:
+  executor:
+    scan_manager:
+      memory_prefetcher:
+        num_threads: -1

--- a/test/cpp/config/data/valid_downgrade_monitor_period_positive.yaml
+++ b/test/cpp/config/data/valid_downgrade_monitor_period_positive.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      monitor_period: 25ms

--- a/test/cpp/config/data/valid_downgrade_monitor_period_zero.yaml
+++ b/test/cpp/config/data/valid_downgrade_monitor_period_zero.yaml
@@ -1,0 +1,4 @@
+sirius:
+  executor:
+    downgrade:
+      monitor_period: 0

--- a/test/cpp/config/test_config.cpp
+++ b/test/cpp/config/test_config.cpp
@@ -24,6 +24,7 @@
 #include <exception>
 #include <optional>
 #include <stdexcept>
+#include <utility>
 #include <variant>
 
 using namespace sirius;
@@ -49,6 +50,58 @@ TEST_CASE("yaml reader basic types", "[config_opt][basic]")
   REQUIRE(int_value == 100);
   REQUIRE(double_value == Approx(6.28));
   REQUIRE(string_value == "config setter test");
+}
+
+TEST_CASE("yaml reader rejects negative unsigned values without mutation",
+          "[config_opt][basic][unsigned]")
+{
+  SECTION("unvalidated size_t accepts zero and one but rejects negative input")
+  {
+    for (auto const& [input, expected] :
+         {std::pair{"0", std::size_t{0}}, std::pair{"1", std::size_t{1}}}) {
+      CAPTURE(input);
+      auto node         = YAML::Load("value: " + std::string{input});
+      std::size_t value = 17;
+      yaml::reader r(node, "unsigned_test");
+      REQUIRE_NOTHROW(r.optional("value", value));
+      CHECK(value == expected);
+    }
+
+    auto node         = YAML::Load("value: -1");
+    std::size_t value = 17;
+    yaml::reader r(node, "unsigned_test");
+    REQUIRE_THROWS_WITH(r.optional("value", value),
+                        Catch::Contains("unsigned_test.value") &&
+                          Catch::Contains("unsigned value must be non-negative"));
+    CHECK(value == 17);
+  }
+
+  SECTION("validated size_t preserves its stricter positive policy")
+  {
+    auto const positive = yaml::greater_than<std::size_t>{0};
+
+    auto zero_node         = YAML::Load("value: 0");
+    std::size_t zero_value = 17;
+    yaml::reader zero_reader(zero_node, "unsigned_test");
+    REQUIRE_THROWS_WITH(
+      zero_reader.optional("value", zero_value, positive),
+      Catch::Contains("unsigned_test.value") && Catch::Contains("value out of range"));
+    CHECK(zero_value == 17);
+
+    auto one_node         = YAML::Load("value: 1");
+    std::size_t one_value = 17;
+    yaml::reader one_reader(one_node, "unsigned_test");
+    REQUIRE_NOTHROW(one_reader.optional("value", one_value, positive));
+    CHECK(one_value == 1);
+
+    auto negative_node         = YAML::Load("value: -1");
+    std::size_t negative_value = 17;
+    yaml::reader negative_reader(negative_node, "unsigned_test");
+    REQUIRE_THROWS_WITH(negative_reader.optional("value", negative_value, positive),
+                        Catch::Contains("unsigned_test.value") &&
+                          Catch::Contains("unsigned value must be non-negative"));
+    CHECK(negative_value == 17);
+  }
 }
 
 TEST_CASE("yaml reader optional missing field uses default", "[config_opt][optional]")
@@ -227,6 +280,36 @@ bi: "1.5Gi")");
     yaml::reader r(node);
     REQUIRE_THROWS_AS(r.optional("size", size), std::runtime_error);
   }
+
+  SECTION("suffix trailing text is rejected without mutation")
+  {
+    auto node          = YAML::Load(R"(size: "8GiBextra")");
+    std::uint64_t size = 4096;
+    yaml::reader r(node);
+    REQUIRE_THROWS_WITH(r.optional("size", yaml::bytes(size)),
+                        Catch::Contains("unknown byte suffix"));
+    REQUIRE(size == 4096);
+  }
+
+  SECTION("malformed numeric text is rejected without mutation")
+  {
+    auto node          = YAML::Load(R"(size: "1.5.2GiB")");
+    std::uint64_t size = 4096;
+    yaml::reader r(node);
+    REQUIRE_THROWS_WITH(r.optional("size", yaml::bytes(size)),
+                        Catch::Contains("invalid byte value"));
+    REQUIRE(size == 4096);
+  }
+
+  SECTION("byte values reject overflow without mutation")
+  {
+    auto node          = YAML::Load(R"(size: "18446744073709551616B")");
+    std::uint64_t size = 4096;
+    yaml::reader r(node);
+    REQUIRE_THROWS_WITH(r.optional("size", yaml::bytes(size)),
+                        Catch::Contains("byte value is too large"));
+    REQUIRE(size == 4096);
+  }
 }
 
 TEST_CASE("parse_duration time suffix parsing", "[config_opt][duration]")
@@ -285,6 +368,17 @@ TEST_CASE("parse_duration time suffix parsing", "[config_opt][duration]")
   {
     REQUIRE_THROWS_AS(yaml::parse_duration("10years"), std::runtime_error);
   }
+
+  SECTION("malformed numeric text is rejected")
+  {
+    REQUIRE_THROWS_WITH(yaml::parse_duration("1.5.2s"), Catch::Contains("invalid time value"));
+  }
+
+  SECTION("overflow is rejected")
+  {
+    REQUIRE_THROWS_WITH(yaml::parse_duration("1000000000000h"),
+                        Catch::Contains("time value is out of range"));
+  }
 }
 
 TEST_CASE("yaml reader duration parsing", "[config_opt][duration]")
@@ -338,6 +432,43 @@ TEST_CASE("yaml reader duration parsing", "[config_opt][duration]")
     yaml::reader r2(node);
     r2.optional("period", s_period);
     REQUIRE(s_period == 10s);
+  }
+
+  SECTION("malformed duration leaves the configured value untouched")
+  {
+    auto node = YAML::Load(R"(period: "1.5.2s")");
+    std::chrono::milliseconds period{10};
+    yaml::reader r(node);
+    REQUIRE_THROWS_WITH(r.optional("period", period), Catch::Contains("invalid time value"));
+    REQUIRE(period == 10ms);
+  }
+}
+
+TEST_CASE("yaml reader non-negative duration parsing", "[config_opt][duration]")
+{
+  using namespace std::chrono_literals;
+
+  SECTION("rejects a negative value before target-resolution truncation")
+  {
+    auto node = YAML::Load(R"(period: "-1us")");
+    std::chrono::milliseconds period{10};
+    yaml::reader r(node);
+    REQUIRE_THROWS_WITH(r.optional("period", yaml::non_negative_duration(period)),
+                        Catch::Contains("duration must be non-negative"));
+    REQUIRE(period == 10ms);
+  }
+
+  SECTION("preserves zero and positive duration semantics")
+  {
+    auto node = YAML::Load(R"(zero: 0
+positive: "25ms")");
+    std::chrono::milliseconds zero{10};
+    std::chrono::milliseconds positive{0};
+    yaml::reader r(node);
+    r.optional("zero", yaml::non_negative_duration(zero));
+    r.optional("positive", yaml::non_negative_duration(positive));
+    REQUIRE(zero == 0ms);
+    REQUIRE(positive == 25ms);
   }
 }
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -39,6 +39,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>  // for setenv/putenv
 #include <filesystem>
@@ -616,6 +617,20 @@ TEST_CASE("Sirius configuration keeps task creation policy internal", "[sirius][
   }
 }
 
+TEST_CASE("Sirius configuration rejects negative memory prefetcher threads", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  fs::path cfg             = fs::path(loc.file_name()).parent_path() / "data" /
+                 "invalid_memory_prefetcher_num_threads_negative.yaml";
+
+  sirius::sirius_config config;
+  auto const before = config.get_scan_manager_config().memory_prefetcher.num_threads;
+  REQUIRE_THROWS_WITH(config.load_from_file(cfg),
+                      Catch::Contains("memory_prefetcher.num_threads") &&
+                        Catch::Contains("unsigned value must be non-negative"));
+  CHECK(config.get_scan_manager_config().memory_prefetcher.num_threads == before);
+}
+
 namespace {
 
 void require_shared_operator_defaults(const sirius::operator_params& params, uint64_t batch)
@@ -906,6 +921,45 @@ TEST_CASE("Sirius high-level GPU config keeps per-stream tracking internal", "[s
   REQUIRE_THROWS_WITH(
     config.load_from_file(config_fixture("invalid_memory_gpu_per_stream_reservation.yaml")),
     Catch::Contains("unknown config key: 'track_per_stream_reservation' in memory.gpu"));
+}
+
+TEST_CASE("Sirius downgrade monitor period rejects negatives and preserves zero disable",
+          "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  for (auto const* fixture : {"invalid_downgrade_monitor_period_negative.yaml",
+                              "invalid_downgrade_monitor_period_negative_suffix.yaml",
+                              "invalid_downgrade_monitor_period_negative_submillisecond.yaml",
+                              "invalid_downgrade_monitor_period_negative_fractional.yaml"}) {
+    INFO("fixture=" << fixture);
+    auto const path = data_dir / fixture;
+    REQUIRE(fs::is_regular_file(path));
+
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(
+      config.load_from_file(path),
+      Catch::Contains("downgrade.monitor_period") && Catch::Contains("non-negative"));
+  }
+
+  struct valid_config {
+    const char* fixture;
+    std::chrono::milliseconds expected;
+  };
+  for (auto const& valid : {
+         valid_config{"valid_downgrade_monitor_period_zero.yaml", std::chrono::milliseconds{0}},
+         valid_config{"valid_downgrade_monitor_period_positive.yaml",
+                      std::chrono::milliseconds{25}},
+       }) {
+    INFO("fixture=" << valid.fixture);
+    auto const path = data_dir / valid.fixture;
+    REQUIRE(fs::is_regular_file(path));
+
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(config.load_from_file(path));
+    REQUIRE(config.get_downgrade_executor_config().monitor_period == valid.expected);
+  }
 }
 
 TEST_CASE("Sirius configuration rejects conflicting memory budget forms", "[sirius][config]")


### PR DESCRIPTION
## August 20 current-dev repair (authoritative)

- tier: `judgment`
- exact base: `31043eb875c3bdbfa4b82770f2216b96dad2fa4b`
- exact head: `2c3fa5fbb3b58fdc78cca46ac7129081f2359bad`
- candidate tree: `3791fdadaa8e3749e902dd4b5b27b53b48766450`
- cumulative binary-diff SHA-256: `e29c58adbc5ab889fa27b1a8134cc1917c1c7d14d8a6b2b140bfa18517228118`
- cumulative diff: 12 paths, 310 insertions, 24 deletions
- conflict resolution: retained both current-dev's task-creator policy regression and this PR's negative memory-prefetcher thread regression; the shared YAML parser unit replayed unchanged
- author review: complete full diff and range-diff review found only the expected adjacent test insertion-context movement
- local gates: `git diff --check`, conflict-marker, seven YAML fixture parses, fixture-reference, and source-contract checks passed
- named external gate: hosted exact-head Linux/CUDA `Check`, `Test`, and `Distribution` workflows; owner Foxglove; terminal condition is every required non-skipped job passing before the PR returns to ready
- hosted status: terminal green on exact head — Check `32410133773` (lint, GCC release, Clang debug, aggregate), Test `32410133744` (CUDA 13 build, runtime job `96559706226`, aggregate), and Distribution `32410134387`; CUDA distribution leaves correctly skipped because distribution inputs did not change

The receipts below are retained as predecessor evidence and are not the authority for the current head.

> **Tier:** `judgment` — this changes the accepted YAML input grammar at the shared reader boundary.  
> **Review question for @sirius-db/sirius-core:** Should byte and duration tokens be exact and representable, unsigned fields reject negative scalars before conversion, and `downgrade.monitor_period` reject negative durations before resolution narrowing while preserving its `0` opt-out?  
> **Behavior delta:** Inputs such as `8GiBextra`, `1.5.2s`, overflowing quantities, `-1` into `size_t`, and negative sub-resolution monitor periods now fail before mutating the destination; documented suffixes and existing field-specific zero policies remain accepted.  
> **Main risk:** The shared-reader blast radius reaches every byte, duration, and integral consumer: previously tolerated legacy spellings or edge-range values may now fail, while generic unsigned values above the corresponding signed maximum remain intentionally unsupported.

## Summary

- require byte-valued YAML settings to use an exact supported suffix and complete numeric token
- require complete numeric tokens for duration quantities
- reject byte and duration overflow before narrowing
- reject negative YAML scalars before conversion to unsigned integral destinations
- reject negative durations before target-resolution conversion can truncate them to zero
- preserve destinations on parse or validation failure while retaining each field's existing zero policy

## Why one PR

The three predecessor changes repair one YAML quantity boundary. Malformed byte/duration text and overflow could be silently narrowed, signed negative scalars could wrap into unsigned fields, and negative sub-resolution durations could truncate to zero before validation. The common invariant is: consume the exact input, prove it fits the destination domain, then mutate.

This supersedes #1507 and #1508. Their field-path regressions are retained alongside the byte/duration parser regressions. `downgrade.monitor_period: 0` remains the intentional monitor opt-out; only negative values are rejected.

## Scope

- documented byte and duration suffixes remain case-insensitive
- plain bytes, SI/IEC quantities, time aliases, fractional quantities, and field-specific validators retain their prior contracts
- signed integers, booleans, floats, and enums retain their existing overloads
- generic unsigned integral parsing still uses a signed intermediate, so values above the corresponding signed maximum remain unsupported; this candidate rejects dangerous negative wrap but does not claim full unsigned-domain parsing

## Rebased identity

- exact base: `ab3603ca73b527486e087143d4aa6b565f562d96`
- exact head: `6a29729bc89cd246efca39897210aee516fd61e8`
- candidate tree: `9484b763c0df7435f261d6b4f89c4b79600c0982`
- cumulative binary-diff SHA-256: `4f6f547a1cbe4920d85b1ac000581e38aa9863a6f99d51b2c1ca37155f21094f`
- cumulative diff: 12 paths, 310 insertions, 24 deletions

## Validation

- rebased onto current `dev` after #1499 merged
- the sole conflict was adjacent insertion in `test_context.cpp`; the
  resolution retains #1499's internal per-stream setting rejection and
  #1529's complete negative/zero/positive monitor-period matrix
- range-diff differences are context from #1499's thread-prefix
  internalization plus that test insertion; the YAML reader, quantity
  validators, fixtures, and assertions replay unchanged
- scoped pre-commit, direct pinned `rumdl`, orphan-test detection, and
  `git diff --check` pass
- all required hosted checks are terminal green on exact head `6a29729b`, with
  CUDA 12/13 distribution leaves correctly skipped; Test workflow
  `32097642996` passed its CUDA 13 build and full runtime suite
- retained pre-rebase hosted validation was terminal green:
  - Check workflow `31915776894`: lint `95087234134`, GCC release
    `95087234157`, Clang debug `95087234181`, aggregate `95087747053`
  - Test workflow `31915776886`: CUDA 13 build `95087234264`, runtime
    `95087569660`, aggregate `95089711493`
  - Distribution workflow `31915777318`: gate `95087235803` passed; CUDA
    distribution jobs were correctly skipped because distribution inputs
    did not change

### Retained predecessor hosted receipts

- pre-rebase head `cd893b2df3e7378ddbd8c1ac0e27e40bae4d76b0`:
  workflow `31755353244`, runtime `94630488672` passed
- earlier exact head: workflow `31734482910` passed hosted lint, GCC, Clang,
  and CUDA 13 build/runtime

Supersedes #1507 and #1508.
