### PR TITLE
refactor(config): keep concat sizing out of sessions

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -561,12 +561,15 @@ SET enable_compressed_materialization = false;
 | `max_sort_partition_bytes` | 0 (auto) | Max sort partition bytes |
 | `max_sort_partition_memory_fraction` | 0.33 | Auto sort-partition fraction when `max_sort_partition_bytes` is 0 |
 | `hash_partition_bytes` | Shared physical/effective GPU batch default | Hash partition target size; must be greater than zero |
-| `concat_batch_bytes` | Shared physical/effective GPU batch default | CONCAT output batch size |
 | `sort_sample_bytes` | Shared physical/effective GPU batch default | Bytes sampled before computing sort boundaries |
 | `max_build_hash_table_bytes` | 2× batch default | Max build-side hash table bytes |
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join |
 | `mark_join_build_switch_ratio` | 8.0 | STANDARD MARK join build-side switch ratio (0 disables) |
 | `enable_runtime_distinct_build_probe` | true | Runtime distinct-build test for `BUILD_PROBE` joins; promotes to the single-pass `cudf::distinct_hash_join` when the build keys prove distinct |
+
+The CONCAT output-batch target is derived from effective GPU capacity. Advanced
+benchmark and test envelopes may still override `concat_batch_bytes` in YAML
+under `sirius.operator_params`, but it is not a normal session setting.
 
 ### Dynamic Filters
 

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2230,6 +2230,11 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
       "TEST ONLY: force transparent GPU execution to fail at runtime with this message",
       LogicalType::VARCHAR,
       Value(""));
+    config.AddExtensionOption("concat_batch_bytes",
+                              "TEST ONLY: override the internally derived CONCAT batch target",
+                              LogicalType::UBIGINT,
+                              Value::UBIGINT(operator_defaults.concat_batch_bytes),
+                              SetConcatBatchBytes);
   }
 
   // Add in config options for special JIT implementation for regex
@@ -2304,12 +2309,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             LogicalType::UBIGINT,
                             Value::UBIGINT(operator_defaults.hash_partition_bytes),
                             SetHashPartitionBytes);
-
-  config.AddExtensionOption("concat_batch_bytes",
-                            "Target size for concat operator",
-                            LogicalType::UBIGINT,
-                            Value::UBIGINT(operator_defaults.concat_batch_bytes),
-                            SetConcatBatchBytes);
 
   config.AddExtensionOption("sort_sample_bytes",
                             "Target bytes to sample before computing sort partition boundaries",

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -212,10 +212,8 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     setenv("SIRIUS_DISABLE", "1", 1);
   }};
 
-  auto setting_count = [](duckdb::Connection& con) {
-    auto result = con.Query(
-      "SELECT count(*) FROM duckdb_settings() "
-      "WHERE name = 'sirius_test_inject_transparent_gpu_error'");
+  auto setting_count = [](duckdb::Connection& con, std::string const& name) {
+    auto result = con.Query("SELECT count(*) FROM duckdb_settings() WHERE name = '" + name + "'");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
     return result->GetValue(0, 0).GetValue<int64_t>();
@@ -226,8 +224,12 @@ TEST_CASE("Test-only settings require explicit process opt-in",
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 0);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 0);
+    REQUIRE(setting_count(con, "concat_batch_bytes") == 0);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET concat_batch_bytes = 1048576");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
   }
@@ -236,15 +238,23 @@ TEST_CASE("Test-only settings require explicit process opt-in",
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 0);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 0);
+    REQUIRE(setting_count(con, "concat_batch_bytes") == 0);
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 1);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 1);
+    REQUIRE(setting_count(con, "concat_batch_bytes") == 1);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET concat_batch_bytes = 1048576");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET concat_batch_bytes");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
   }


### PR DESCRIPTION
## Summary

- remove `concat_batch_bytes` from the normal DuckDB session-settings surface
- keep the effective-GPU-capacity-derived default introduced by #1447
- retain the explicit YAML override for advanced benchmark envelopes
- retain `SET`/`RESET` only behind the exact `SIRIUS_ENABLE_TEST_OPTIONS=1` test opt-in

This makes the ordinary session behavior automatic without deleting the
advanced YAML escape hatch used by controlled benchmark fixtures. A user no
longer sees a session knob whose normal value is already derived from the
effective GPU capacity.

## Validation

- exact base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`
- exact head: `4e2b93a0cff09014165b77caaff9df50e24ec27b`
- tree: `4694519f8de8a4eaa3a5d0d873aa2fdf6a2100e4`
- `git diff --check`: pass
- focused pre-commit hooks: pass for large files, case conflicts, merge
  conflicts, symlinks, private keys, EOF/whitespace, smart quotes,
  clang-format, codespell, and orphan-test detection
- pinned `rumdl==0.2.44` check: pass (run directly because local `pixi` is
  unavailable)
- regression proves normal and non-exact opt-in sessions do not register or
  accept `concat_batch_bytes`
- regression proves the exact test opt-in retains `SET`/`RESET`
- duplicate search: no open Sirius issue or PR for this session-surface change

Hosted CUDA-linked execution is left to this PR's CI. The configuration
regression is CPU-only but the Sirius unit binary is CUDA-linked.

## Composition note

Open PRs #1523 and #1526 add adjacent test-only settings in the same guarded
registration block. The combined resolution keeps all three internal policies
and their test-only toggles. It is precomputed at commit
`5492e91b956bd11fcc9f68912f29e323c3ecb954`, tree
`c5ad404b6c705e37beee76d383f367b1d385c465`; focused hooks pass on that
composition as well.

- exact-head hosted receipt for `4e2b93a0cff09014165b77caaff9df50e24ec27b`: CUDA 13 runtime and terminal aggregate checks passed
- hosted workflow 31710250025: runtime job 94482450431 passed from 2026-08-13T15:31:04Z through 2026-08-13T15:50:50Z; aggregate job 94506140756 passed at 2026-08-13T15:51:00Z