### PR TITLE
fix(config): simplify memory prefetcher controls

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -303,8 +303,10 @@ single-GPU configurations only (logs a warning and disables itself otherwise).
 | `enable` | bool | false | Master switch for the prefetcher. |
 | `num_threads` | int (**> 0**) | 2 | Prefetch worker threads; each drives one in-flight batch conversion on its own stream. |
 | `min_free_fraction` | double [0,1] | 0.4 | Keep at least this fraction of the GPU space free after each prefetch; conversions (and their reservations) are only attempted above this floor. |
-| `poll_interval_ms` | int (**> 0**) | 2 | Worker sweep interval while waiting for headroom / new splits. |
-| `drain_quiet_ms` | int (ms) | 100 | A connector counts as actively draining (and is skipped) until this long passes since its last pop. Must exceed the scan's inter-pop interval. |
+
+Worker polling and connector-drain timing are internal scheduling policy. The
+former `poll_interval_ms` and `drain_quiet_ms` keys have been removed;
+configurations that still contain either key must delete it.
 
 ### `scan_manager.local` — io_uring backend (`io/uring/config.hpp`)
 

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -304,6 +304,9 @@ single-GPU configurations only (logs a warning and disables itself otherwise).
 | `num_threads` | int (**> 0**) | 2 | Prefetch worker threads; each drives one in-flight batch conversion on its own stream. |
 | `min_free_fraction` | double [0,1] | 0.4 | Keep at least this fraction of the GPU space free after each prefetch; conversions (and their reservations) are only attempted above this floor. |
 
+`num_threads` and `min_free_fraction` are active only when `enable: true`; configuration loading
+rejects non-null overrides while the prefetcher is disabled.
+
 Worker polling and connector-drain timing are internal scheduling policy. The
 former `poll_interval_ms` and `drain_quiet_ms` keys have been removed;
 configurations that still contain either key must delete it.

--- a/src/include/scan_manager/config.hpp
+++ b/src/include/scan_manager/config.hpp
@@ -60,11 +60,11 @@ struct memory_prefetcher_config {
   /// the reservation for a batch is only attempted above this floor, so the
   /// prefetcher backs off well before competing with pipeline reservations.
   double min_free_fraction{0.4};
-  /// Worker sweep interval while waiting for headroom / new splits.
+  /// Internal worker sweep interval while waiting for headroom / new splits.
   std::size_t poll_interval_ms{2};
   /// A connector is considered actively draining (and skipped) until this
-  /// long has passed since its last pop. Must exceed the scan's inter-pop
-  /// interval (~10-40ms per 5GB batch) or sweeps race the scan.
+  /// long has passed since its last pop. This internal policy must exceed the
+  /// scan's inter-pop interval (~10-40ms per 5GB batch) or sweeps race the scan.
   std::size_t drain_quiet_ms{100};
 };
 

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -231,6 +231,12 @@ static void from_yaml(const YAML::Node& node, scan_manager::memory_prefetcher_co
       "policy is internal; remove these keys");
   }
   r.optional("enable", opt.enable);
+  bool const has_dependent_setting = r.has_value("num_threads") || r.has_value("min_free_fraction");
+  if (!opt.enable && has_dependent_setting) {
+    throw std::runtime_error(
+      "sirius.executor.scan_manager.memory_prefetcher: num_threads and min_free_fraction require "
+      "enable: true");
+  }
   r.optional("num_threads", opt.num_threads, yaml::greater_than<std::size_t>{0});
   r.optional("min_free_fraction", opt.min_free_fraction, yaml::fraction<double>{});
   r.reject_unknown();

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -224,11 +224,15 @@ static void from_yaml(const YAML::Node& node, sirius::io::cache::config& opt)
 static void from_yaml(const YAML::Node& node, scan_manager::memory_prefetcher_config& opt)
 {
   yaml::reader r(node, "memory_prefetcher");
+  if (r.has("poll_interval_ms") || r.has("drain_quiet_ms")) {
+    throw std::runtime_error(
+      "'sirius.executor.scan_manager.memory_prefetcher.poll_interval_ms' and "
+      "'sirius.executor.scan_manager.memory_prefetcher.drain_quiet_ms': removed; worker timing "
+      "policy is internal; remove these keys");
+  }
   r.optional("enable", opt.enable);
   r.optional("num_threads", opt.num_threads, yaml::greater_than<std::size_t>{0});
   r.optional("min_free_fraction", opt.min_free_fraction, yaml::fraction<double>{});
-  r.optional("poll_interval_ms", opt.poll_interval_ms, yaml::greater_than<std::size_t>{0});
-  r.optional("drain_quiet_ms", opt.drain_quiet_ms);
   r.reject_unknown();
 }
 

--- a/test/cpp/config/data/invalid_memory_prefetcher_drain_quiet.yaml
+++ b/test/cpp/config/data/invalid_memory_prefetcher_drain_quiet.yaml
@@ -1,0 +1,5 @@
+sirius:
+  executor:
+    scan_manager:
+      memory_prefetcher:
+        drain_quiet_ms: 200

--- a/test/cpp/config/data/invalid_memory_prefetcher_poll_interval.yaml
+++ b/test/cpp/config/data/invalid_memory_prefetcher_poll_interval.yaml
@@ -1,0 +1,5 @@
+sirius:
+  executor:
+    scan_manager:
+      memory_prefetcher:
+        poll_interval_ms: 5

--- a/test/cpp/config/data/valid_memory_prefetcher_timing_omitted.yaml
+++ b/test/cpp/config/data/valid_memory_prefetcher_timing_omitted.yaml
@@ -1,0 +1,5 @@
+sirius:
+  executor:
+    scan_manager:
+      memory_prefetcher:
+        enable: false

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -320,6 +320,67 @@ TEST_CASE("Sirius configuration keeps memory prefetcher timing internal", "[siri
   CHECK(prefetcher.drain_quiet_ms == 100);
 }
 
+TEST_CASE("Sirius configuration rejects inactive memory prefetcher settings", "[sirius][config]")
+{
+  struct inactive_setting {
+    const char* name;
+    const char* value;
+  };
+  const inactive_setting cases[] = {
+    {"num_threads", "3"},
+    {"min_free_fraction", "0.25"},
+  };
+
+  for (auto const enable : {"", "        enable: false\n"}) {
+    for (auto const& setting : cases) {
+      DYNAMIC_SECTION((enable[0] == '\0' ? "implicit" : "explicit") << "." << setting.name)
+      {
+        auto const path =
+          fs::temp_directory_path() /
+          (std::string("sirius_inactive_memory_prefetcher_") + setting.name + ".yaml");
+        finally cleanup{[path]() {
+          std::error_code ec;
+          fs::remove(path, ec);
+        }};
+        {
+          std::ofstream out(path);
+          REQUIRE(out);
+          out << "sirius:\n  executor:\n    scan_manager:\n      memory_prefetcher:\n"
+              << enable << "        " << setting.name << ": " << setting.value << "\n";
+        }
+
+        sirius::sirius_config config;
+        REQUIRE_THROWS_WITH(config.load_from_file(path),
+                            Catch::Contains("sirius.executor.scan_manager.memory_prefetcher") &&
+                              Catch::Contains("require enable: true"));
+      }
+    }
+  }
+}
+
+TEST_CASE("Sirius configuration accepts memory prefetcher settings when enabled",
+          "[sirius][config]")
+{
+  auto const path = fs::temp_directory_path() / "sirius_active_memory_prefetcher.yaml";
+  finally cleanup{[path]() {
+    std::error_code ec;
+    fs::remove(path, ec);
+  }};
+  {
+    std::ofstream out(path);
+    REQUIRE(out);
+    out << "sirius:\n  executor:\n    scan_manager:\n      memory_prefetcher:\n"
+           "        enable: true\n        num_threads: 3\n        min_free_fraction: 0.25\n";
+  }
+
+  sirius::sirius_config config;
+  REQUIRE_NOTHROW(config.load_from_file(path));
+  auto const& prefetcher = config.get_scan_manager_config().memory_prefetcher;
+  REQUIRE(prefetcher.enable);
+  REQUIRE(prefetcher.num_threads == 3);
+  REQUIRE(prefetcher.min_free_fraction == Approx(0.25));
+}
+
 TEST_CASE("Sirius configuration rejects negative host capacity bytes", "[sirius][config]")
 {
   std::source_location loc = std::source_location::current();

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -298,6 +298,28 @@ TEST_CASE("Sirius configuration rejects zero hash partition bytes", "[sirius][co
     Catch::Contains("hash_partition_bytes") && Catch::Contains("greater than zero"));
 }
 
+TEST_CASE("Sirius configuration keeps memory prefetcher timing internal", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  for (auto const& [file, key] : std::initializer_list<std::pair<char const*, char const*>>{
+         {"invalid_memory_prefetcher_poll_interval.yaml", "poll_interval_ms"},
+         {"invalid_memory_prefetcher_drain_quiet.yaml", "drain_quiet_ms"}}) {
+    CAPTURE(file, key);
+    sirius::sirius_config rejected;
+    REQUIRE_THROWS_WITH(rejected.load_from_file(data_dir / file),
+                        Catch::Contains("scan_manager.memory_prefetcher") && Catch::Contains(key) &&
+                          Catch::Contains("removed") && Catch::Contains("remove these keys"));
+  }
+
+  sirius::sirius_config omitted;
+  REQUIRE_NOTHROW(omitted.load_from_file(data_dir / "valid_memory_prefetcher_timing_omitted.yaml"));
+  auto const& prefetcher = omitted.get_scan_manager_config().memory_prefetcher;
+  CHECK(prefetcher.poll_interval_ms == 2);
+  CHECK(prefetcher.drain_quiet_ms == 100);
+}
+
 TEST_CASE("Sirius configuration rejects negative host capacity bytes", "[sirius][config]")
 {
   std::source_location loc = std::source_location::current();


### PR DESCRIPTION
## Summary

- remove `memory_prefetcher.poll_interval_ms` and `memory_prefetcher.drain_quiet_ms` from YAML
- retain the existing internal 2 ms polling and 100 ms connector-drain policy
- reject `num_threads` and `min_free_fraction` overrides unless the prefetcher is enabled
- preserve `enable`, `num_threads`, and `min_free_fraction` as the operator-facing activation policy

## Why

Polling and drain-quiet values govern internal worker scheduling, not a user decision with a workload-backed selection rule. In particular, the drain-quiet interval must stay above the scan inter-pop interval for correct scheduling behavior.

The remaining controls only affect an active memory prefetcher. Accepting them while `enable` is false or omitted makes a valid-looking configuration silently inert. The loader now fails with a path-specific correction instead.

## Validation

- exact base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`
- exact head: `971ad3356b02baf82438f66134dc25c547b3bbc6`
- candidate tree: `829cec755b2af284cd145194588562a2ac853fee`
- zero-context patch SHA-256: `7f5825d4b68f3ce7a5dd1bc75a0a0c0c300df78784efe2ac648a2d9473aaeabe`
- `git diff --check`
- pre-commit hooks pass for all changed files (repository rumdl wrapper unavailable locally; rumdl 0.2.44 run directly and passed)
- focused regressions reject each removed timing key independently and prove omission retains the internal defaults
- focused regressions cover implicit-disabled, explicit-disabled, and enabled dependent-setting configurations
- prior head `b1010b0b` passed hosted lint, GCC release, Clang debug, CUDA 13 build, distribution, check, PR-title, full runtime, and terminal aggregate checks; exact-head hosted checks are running

- fresh exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full runtime, and terminal aggregate checks: pass
- hosted workflow 31724596002: runtime job 94530700163 passed in 20m36s; aggregate job 94540183594 passed
