### PR TITLE
refactor(config): keep scan sizing automatic

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -377,7 +377,7 @@ individually.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `scan_task_batch_size` | Shared physical/effective GPU batch default described above | Target batch size for DuckDB scan tasks |
+| `scan_task_batch_size` | Shared physical/effective GPU batch default described above | Target batch size for DuckDB scan tasks; must be greater than zero |
 | `enable_compressed_materialization` | true | Store eligible integer and fixed-point DECIMAL values in value-preserving narrower carriers when exact pin-time bounds permit it; restore native carriers at type-sensitive boundaries. |
 | `max_sort_partition_bytes` | 0 (auto) | Max bytes per sort partition. Auto = 33% of GPU memory. |
 | `hash_partition_bytes` | Shared physical/effective GPU batch default described above | Target partition size for hash joins and group-bys; must be greater than zero |
@@ -537,8 +537,12 @@ These can also be set at load via the `SIRIUS_LOG_BACKEND`, `SIRIUS_LOG_DIR`, an
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `scan_task_batch_size` | Shared physical/effective GPU batch default | Target scan batch size |
 | `enable_compressed_materialization` | true | Keep eligible integer and fixed-point DECIMAL values in narrower physical carriers until a native semantic boundary. |
+
+The scan-task batch target is derived from effective GPU capacity. Advanced
+benchmark and test envelopes may still override `scan_task_batch_size` in YAML
+under `sirius.operator_params`, where it must remain greater than zero, but it
+is not a normal session setting.
 
 `enable_compressed_materialization` is also accepted in YAML under `sirius.operator_params`.
 At pin time, exact per-chunk bounds select stored carriers. At query planning, a matching pinned

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -254,6 +254,9 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
 {
   yaml::reader r(node, "operator_params");
   r.optional("scan_task_batch_size", yaml::bytes(opt.scan_task_batch_size));
+  if (opt.scan_task_batch_size == 0) {
+    throw std::runtime_error("'operator_params.scan_task_batch_size': must be greater than zero");
+  }
   r.optional("max_sort_partition_bytes", yaml::bytes(opt.max_sort_partition_bytes));
   r.optional("max_sort_partition_memory_fraction",
              opt.max_sort_partition_memory_fraction,

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1855,10 +1855,12 @@ static duckdb::unique_ptr<duckdb::SiriusContext::SlotGuard> lock_operator_params
 
 static void SetDefaultScanTaskBatchSize(ClientContext& context, SetScope scope, Value& parameter)
 {
+  auto const bytes = UBigIntValue::Get(parameter);
+  if (bytes == 0) { throw InvalidInputException("scan_task_batch_size must be greater than zero"); }
   auto* params = get_operator_params(context);
   if (!params) { return; }
   auto slot                    = lock_operator_params_slot(context);
-  params->scan_task_batch_size = UBigIntValue::Get(parameter);
+  params->scan_task_batch_size = bytes;
   SIRIUS_LOG_DEBUG("Updated config SCAN_TASK_BATCH_SIZE to {}", params->scan_task_batch_size);
 }
 
@@ -2246,6 +2248,11 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                               LogicalType::BOOLEAN,
                               Value::BOOLEAN(operator_defaults.enable_dynamic_zone_map_filter),
                               SetEnableDynamicZoneMapFilter);
+    config.AddExtensionOption("scan_task_batch_size",
+                              "TEST ONLY: override the internally derived scan batch target",
+                              LogicalType::UBIGINT,
+                              Value::UBIGINT(operator_defaults.scan_task_batch_size),
+                              SetDefaultScanTaskBatchSize);
   }
 
   // Add in config options for special JIT implementation for regex
@@ -2270,14 +2277,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             LogicalType::BOOLEAN,
                             Value::BOOLEAN(true),
                             SetFuseMergePipelines);
-
-  // Add in config options for duckdb scan task
-  // Default batch size
-  config.AddExtensionOption("scan_task_batch_size",
-                            "The default batch size for a duckdb scan task",
-                            LogicalType::UBIGINT,
-                            Value::UBIGINT(operator_defaults.scan_task_batch_size),
-                            SetDefaultScanTaskBatchSize);
 
   // Add in config option for sort partition size
   config.AddExtensionOption("max_sort_partition_bytes",

--- a/test/cpp/config/data/invalid_scan_task_batch_zero.yaml
+++ b/test/cpp/config/data/invalid_scan_task_batch_zero.yaml
@@ -1,0 +1,3 @@
+sirius:
+  operator_params:
+    scan_task_batch_size: 0

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -143,12 +143,11 @@ constexpr std::array<setting_assignment, 10> legacy_only_settings{{
   {"modified_pipeline", "true"},
 }};
 
-constexpr std::array<const char*, 5> super_sirius_settings{{
+constexpr std::array<const char*, 4> super_sirius_settings{{
   "expression_evaluator_strategy",
   "enable_regex_jit_impl",
   "enable_duckdb_fallback",
   "fuse_merge_pipelines",
-  "scan_task_batch_size",
 }};
 }  // namespace
 
@@ -228,6 +227,7 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "enable_pinned_zone_map_pruning") == 0);
     REQUIRE(setting_count(con, "enable_dynamic_filter_pushdown") == 0);
     REQUIRE(setting_count(con, "enable_dynamic_zone_map_filter") == 0);
+    REQUIRE(setting_count(con, "scan_task_batch_size") == 0);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
@@ -240,6 +240,9 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     result = con.Query("SET enable_dynamic_zone_map_filter = true");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
+    result = con.Query("SET scan_task_batch_size = 1048576");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "true", 1);
@@ -250,6 +253,7 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "enable_pinned_zone_map_pruning") == 0);
     REQUIRE(setting_count(con, "enable_dynamic_filter_pushdown") == 0);
     REQUIRE(setting_count(con, "enable_dynamic_zone_map_filter") == 0);
+    REQUIRE(setting_count(con, "scan_task_batch_size") == 0);
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
@@ -260,6 +264,7 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "enable_pinned_zone_map_pruning") == 1);
     REQUIRE(setting_count(con, "enable_dynamic_filter_pushdown") == 1);
     REQUIRE(setting_count(con, "enable_dynamic_zone_map_filter") == 1);
+    REQUIRE(setting_count(con, "scan_task_batch_size") == 1);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
@@ -279,6 +284,12 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
     result = con.Query("RESET enable_dynamic_zone_map_filter");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET scan_task_batch_size = 1048576");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET scan_task_batch_size");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
   }
@@ -330,6 +341,18 @@ TEST_CASE("Sirius configuration rejects zero hash partition bytes", "[sirius][co
   REQUIRE_THROWS_WITH(
     config.load_from_file(cfg),
     Catch::Contains("hash_partition_bytes") && Catch::Contains("greater than zero"));
+}
+
+TEST_CASE("Sirius configuration rejects zero scan task batch bytes", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  fs::path cfg =
+    fs::path(loc.file_name()).parent_path() / "data" / "invalid_scan_task_batch_zero.yaml";
+
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(config.load_from_file(cfg),
+                      Catch::Contains("operator_params.scan_task_batch_size") &&
+                        Catch::Contains("greater than zero"));
 }
 
 TEST_CASE("Sirius configuration rejects negative host capacity bytes", "[sirius][config]")
@@ -723,6 +746,30 @@ TEST_CASE("DuckDB setting rejects zero hash partition bytes without a Sirius con
   REQUIRE(result->HasError());
   REQUIRE_THAT(result->GetError(),
                Catch::Contains("hash_partition_bytes must be greater than zero"));
+}
+
+TEST_CASE("DuckDB setting rejects zero scan task batch bytes without a Sirius context",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto before = con.Query("SELECT current_setting('scan_task_batch_size')::UBIGINT");
+  REQUIRE(before != nullptr);
+  REQUIRE_FALSE(before->HasError());
+  auto const expected = before->GetValue(0, 0).GetValue<uint64_t>();
+
+  auto zero = con.Query("SET scan_task_batch_size = 0");
+  REQUIRE(zero != nullptr);
+  REQUIRE(zero->HasError());
+  REQUIRE_THAT(zero->GetError(), Catch::Contains("scan_task_batch_size must be greater than zero"));
+
+  auto after = con.Query("SELECT current_setting('scan_task_batch_size')::UBIGINT");
+  REQUIRE(after != nullptr);
+  REQUIRE_FALSE(after->HasError());
+  REQUIRE(after->GetValue(0, 0).GetValue<uint64_t>() == expected);
 }
 
 TEST_CASE("DuckDB setting rejects negative byte values without mutation",


### PR DESCRIPTION
## Summary

- keep `scan_task_batch_size` automatic for ordinary DuckDB sessions
- retain the explicit YAML override for advanced benchmark envelopes and `SET`/`RESET` only behind exact `SIRIUS_ENABLE_TEST_OPTIONS=1`
- reject zero on both retained YAML and test-only session surfaces
- preserve the effective-GPU-capacity-derived default introduced by #1447

## Why one PR

This is one setting contract: ordinary users do not choose the scan batch target; Sirius derives it from effective GPU capacity. Advanced benchmark/test overrides remain possible but must be positive because clean Sirius interprets zero incompatibly across scan paths—unbounded DuckDB-native coalescing versus one Parquet row group per batch.

The exact union supersedes #1522 while retaining its YAML and disabled-context session regressions. The session validation executes before Sirius-context lookup, so the exact test surface refuses zero consistently even without a live Sirius context.

Foxglove's capped-pressure screen found that cap-relative values retained oracle-correct feasibility at 1 GiB, 512 MiB, and 256 MiB effective GPU caps (9/9 default cells). That automatic behavior replaces ordinary user tuning; it is not evidence that zero is a useful sentinel.

## Rebased identity

- base: `e885ffea7d0541f1e3493566e2db0ed6e431106f`
- head: `f4a7aa1ed971b8383da237629d6c469d3da52a1f`
- tree: `ec6956346841ed1335a36c811333c5f57cc75132`
- full-index binary diff SHA-256: `3d1d885f986bd8f247e14934dd66ad3f104efdf5d7feef817ac53ddbb92869e5`

## Validation

- rebased onto current `dev`; conflicts only shared the test-option gate and config tests with merged #1536, resolved additively so both feature families remain
- independent source/range comparison across the same five paths: semantics preserved; no legacy edits
- current-dev ancestor and recursive submodule identity/cleanliness: pass
- `python3 scripts/check_orphan_tests.py`: pass
- `git diff --check`: pass
- normal and non-exact sessions omit the setting; exact test opt-in retains `SET`/`RESET`; YAML and test-only runtime zero rejection remain covered
- pre-rebase exact-head hosted lint, GCC, Clang, CUDA 13 build/runtime: pass (workflow 31733921150)
- rebased-head hosted lint, GCC release, Clang debug, CUDA 13 build/runtime,
  TPC-H snapshot, and terminal aggregate all passed on
  `f4a7aa1ed971b8383da237629d6c469d3da52a1f`
- hosted workflow 31754904530: build job 94628495369 passed; runtime job
  94629221380 passed in 19m45s; terminal aggregate job 94632923981 passed

Supersedes #1522.
