### PR TITLE
refactor(config): keep build-hash admission internal

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -563,10 +563,14 @@ SET enable_compressed_materialization = false;
 | `hash_partition_bytes` | Shared physical/effective GPU batch default | Hash partition target size; must be greater than zero |
 | `concat_batch_bytes` | Shared physical/effective GPU batch default | CONCAT output batch size |
 | `sort_sample_bytes` | Shared physical/effective GPU batch default | Bytes sampled before computing sort boundaries |
-| `max_build_hash_table_bytes` | 2× batch default | Max build-side hash table bytes |
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join |
 | `mark_join_build_switch_ratio` | 8.0 | STANDARD MARK join build-side switch ratio (0 disables) |
 | `enable_runtime_distinct_build_probe` | true | Runtime distinct-build test for `BUILD_PROBE` joins; promotes to the single-pass `cudf::distinct_hash_join` when the build keys prove distinct |
+
+The BUILD_PROBE admission threshold is derived as twice the effective-capacity
+batch default. Advanced diagnostic and benchmark envelopes may still override
+`max_build_hash_table_bytes` in YAML under `sirius.operator_params`, but it is
+not a normal session setting.
 
 ### Dynamic Filters
 

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2230,6 +2230,11 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
       "TEST ONLY: force transparent GPU execution to fail at runtime with this message",
       LogicalType::VARCHAR,
       Value(""));
+    config.AddExtensionOption("max_build_hash_table_bytes",
+                              "TEST ONLY: override the internally derived BUILD_PROBE threshold",
+                              LogicalType::UBIGINT,
+                              Value::UBIGINT(operator_defaults.max_build_hash_table_bytes),
+                              SetMaxBuildHashTableBytes);
   }
 
   // Add in config options for special JIT implementation for regex
@@ -2316,13 +2321,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             LogicalType::UBIGINT,
                             Value::UBIGINT(operator_defaults.sort_sample_bytes),
                             SetSortSampleBytes);
-
-  config.AddExtensionOption("max_build_hash_table_bytes",
-                            "Maximum size a build-side table can be where it will create a "
-                            "reusable hash table for hash joins (i.e. BUILD_PROBE mode)",
-                            LogicalType::UBIGINT,
-                            Value::UBIGINT(operator_defaults.max_build_hash_table_bytes),
-                            SetMaxBuildHashTableBytes);
 
   config.AddExtensionOption("max_broadcast_join_size",
                             "Maximum build-side size in bytes for a broadcast join, where the "

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -212,10 +212,8 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     setenv("SIRIUS_DISABLE", "1", 1);
   }};
 
-  auto setting_count = [](duckdb::Connection& con) {
-    auto result = con.Query(
-      "SELECT count(*) FROM duckdb_settings() "
-      "WHERE name = 'sirius_test_inject_transparent_gpu_error'");
+  auto setting_count = [](duckdb::Connection& con, std::string const& name) {
+    auto result = con.Query("SELECT count(*) FROM duckdb_settings() WHERE name = '" + name + "'");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
     return result->GetValue(0, 0).GetValue<int64_t>();
@@ -226,8 +224,12 @@ TEST_CASE("Test-only settings require explicit process opt-in",
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 0);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 0);
+    REQUIRE(setting_count(con, "max_build_hash_table_bytes") == 0);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET max_build_hash_table_bytes = 1048576");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
   }
@@ -236,15 +238,23 @@ TEST_CASE("Test-only settings require explicit process opt-in",
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 0);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 0);
+    REQUIRE(setting_count(con, "max_build_hash_table_bytes") == 0);
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 1);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 1);
+    REQUIRE(setting_count(con, "max_build_hash_table_bytes") == 1);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET max_build_hash_table_bytes = 1048576");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET max_build_hash_table_bytes");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
   }


### PR DESCRIPTION
## Summary

- remove `max_build_hash_table_bytes` from the normal DuckDB session surface
- keep its effective-capacity-derived production default
- retain the normal YAML key as an explicit expert diagnostic and benchmark envelope
- retain direct `SET`/`RESET` only behind exact `SIRIUS_ENABLE_TEST_OPTIONS=1`

This removes an ordinary tuning choice without deleting the mechanism or its
expert escape hatch. The threshold remains twice the effective-capacity batch
default in normal operation.

## Evidence and scope

Foxglove's predeclared 30-cell capped-pressure ladder crossed the calibrated
BUILD_PROBE admission boundary exactly in every cell, with all results
oracle-correct. The maximum admissible median-runtime effect was 3.45%, below
the 10% materiality gate. A prior timeout was followed by 20 exact-cell
reproductions with zero recurrence. The bounded verdict is therefore: omit the
setting from the normal single-GPU session surface on this tested path, retain
it as an expert YAML diagnostic, and do not infer a new universal number.

Open PR #1342 repairs how this threshold controls BUILD_PROBE at real scale. It
is behaviorally complementary rather than a duplicate: this PR does not alter
eligibility or the numeric threshold, and keeps the YAML envelope needed for
that work.

## Validation

- exact base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`
- exact head: `f18370e075e59f7e8bb004f5712688004054e10b`
- tree: `f74c8f0fb63fed20be68e3328e5260708a6baa19`
- `git diff --check`: pass
- focused pre-commit hooks: pass for large files, case conflicts, merge
  conflicts, symlinks, private keys, EOF/whitespace, smart quotes,
  clang-format, codespell, and orphan-test detection
- pinned `rumdl==0.2.44` check: pass (run directly because local `pixi` is
  unavailable)
- regression proves normal and non-exact opt-in sessions do not register or
  accept `max_build_hash_table_bytes`
- regression proves exact test opt-in retains `SET`/`RESET`
- duplicate search found only behaviorally complementary #1342

Hosted CUDA-linked execution is left to this PR's CI. The configuration
regression is CPU-only but the Sirius unit binary is CUDA-linked.

## Composition note

The exact composition with open PRs #1522, #1523, #1526, #1530, and #1532
retains zero-value scan validation and all five internal policies with their
test-only controls. The precomputed composition is commit
`8a878b42f11c03ac60ec418c207d2554d6c8fe07`, tree
`a2c2a3f12036b3d1beb82febe159562fe1705509`; focused hooks and pinned Markdown
validation pass on that tree.

- exact-head hosted receipt for `f18370e075e59f7e8bb004f5712688004054e10b`: CUDA 13 runtime and terminal aggregate checks passed
- hosted workflow 31712788959: runtime job 94490980536 passed from 2026-08-13T17:09:33Z through 2026-08-13T17:29:40Z; aggregate job 94534327221 passed at 2026-08-13T17:29:46Z