### PR TITLE
refactor(config): keep sort memory fraction internal

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -559,7 +559,6 @@ SET enable_compressed_materialization = false;
 |----------|---------|-------------|
 | `fuse_merge_pipelines` | true | Fuse eligible GROUP BY / TOP_N merges into their downstream pipeline instead of cutting a boundary (see [physical-plan-generation.md](physical-plan-generation.md) → Merge fusion) |
 | `max_sort_partition_bytes` | 0 (auto) | Max sort partition bytes |
-| `max_sort_partition_memory_fraction` | 0.33 | Auto sort-partition fraction when `max_sort_partition_bytes` is 0 |
 | `hash_partition_bytes` | Shared physical/effective GPU batch default | Hash partition target size; must be greater than zero |
 | `concat_batch_bytes` | Shared physical/effective GPU batch default | CONCAT output batch size |
 | `sort_sample_bytes` | Shared physical/effective GPU batch default | Bytes sampled before computing sort boundaries |
@@ -567,6 +566,11 @@ SET enable_compressed_materialization = false;
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join |
 | `mark_join_build_switch_ratio` | 8.0 | STANDARD MARK join build-side switch ratio (0 disables) |
 | `enable_runtime_distinct_build_probe` | true | Runtime distinct-build test for `BUILD_PROBE` joins; promotes to the single-pass `cudf::distinct_hash_join` when the build keys prove distinct |
+
+When `max_sort_partition_bytes` is left at its automatic value, Sirius uses an
+internal 0.33 memory fraction. Advanced benchmark envelopes may override
+`max_sort_partition_memory_fraction` in YAML under `sirius.operator_params`,
+but it is not a normal session setting.
 
 ### Dynamic Filters
 

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2230,6 +2230,12 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
       "TEST ONLY: force transparent GPU execution to fail at runtime with this message",
       LogicalType::VARCHAR,
       Value(""));
+    config.AddExtensionOption(
+      "max_sort_partition_memory_fraction",
+      "TEST ONLY: override the internal automatic sort-partition memory fraction",
+      LogicalType::DOUBLE,
+      Value::DOUBLE(operator_defaults.max_sort_partition_memory_fraction),
+      SetMaxSortPartitionMemoryFraction);
   }
 
   // Add in config options for special JIT implementation for regex
@@ -2270,13 +2276,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             LogicalType::UBIGINT,
                             Value::UBIGINT(operator_defaults.max_sort_partition_bytes),
                             SetMaxSortPartitionBytes);
-  config.AddExtensionOption(
-    "max_sort_partition_memory_fraction",
-    "Fraction of available GPU memory per sort partition when max_sort_partition_bytes is 0",
-    LogicalType::DOUBLE,
-    Value::DOUBLE(operator_defaults.max_sort_partition_memory_fraction),
-    SetMaxSortPartitionMemoryFraction);
-
   // Logging configuration
   config.AddExtensionOption("sirius_log_backend",
                             "Logging backend for Sirius (duckdb, spdlog, noop)",

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -212,10 +212,8 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     setenv("SIRIUS_DISABLE", "1", 1);
   }};
 
-  auto setting_count = [](duckdb::Connection& con) {
-    auto result = con.Query(
-      "SELECT count(*) FROM duckdb_settings() "
-      "WHERE name = 'sirius_test_inject_transparent_gpu_error'");
+  auto setting_count = [](duckdb::Connection& con, std::string const& name) {
+    auto result = con.Query("SELECT count(*) FROM duckdb_settings() WHERE name = '" + name + "'");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
     return result->GetValue(0, 0).GetValue<int64_t>();
@@ -226,8 +224,12 @@ TEST_CASE("Test-only settings require explicit process opt-in",
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 0);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 0);
+    REQUIRE(setting_count(con, "max_sort_partition_memory_fraction") == 0);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET max_sort_partition_memory_fraction = 0.5");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
   }
@@ -236,15 +238,23 @@ TEST_CASE("Test-only settings require explicit process opt-in",
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 0);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 0);
+    REQUIRE(setting_count(con, "max_sort_partition_memory_fraction") == 0);
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 1);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 1);
+    REQUIRE(setting_count(con, "max_sort_partition_memory_fraction") == 1);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET max_sort_partition_memory_fraction = 0.5");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET max_sort_partition_memory_fraction");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
   }
@@ -684,6 +694,7 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
 {
   finally cleanup_env{[]() {
     unsetenv("SIRIUS_CONFIG_FILE");
+    unsetenv("SIRIUS_ENABLE_TEST_OPTIONS");
     setenv("SIRIUS_DISABLE", "1", 1);
   }};
 
@@ -691,6 +702,7 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   fs::path cfg = fs::path(loc.file_name()).parent_path() / "data" / "setting_defaults.yaml";
 
   unsetenv("SIRIUS_DISABLE");
+  setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
   setenv("SIRIUS_CONFIG_FILE", cfg.string().c_str(), 1);
 
   duckdb::DuckDB db(nullptr);

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -694,7 +694,6 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
 {
   finally cleanup_env{[]() {
     unsetenv("SIRIUS_CONFIG_FILE");
-    unsetenv("SIRIUS_ENABLE_TEST_OPTIONS");
     setenv("SIRIUS_DISABLE", "1", 1);
   }};
 
@@ -702,7 +701,6 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   fs::path cfg = fs::path(loc.file_name()).parent_path() / "data" / "setting_defaults.yaml";
 
   unsetenv("SIRIUS_DISABLE");
-  setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
   setenv("SIRIUS_CONFIG_FILE", cfg.string().c_str(), 1);
 
   duckdb::DuckDB db(nullptr);


### PR DESCRIPTION
## Summary

- remove `max_sort_partition_memory_fraction` from normal DuckDB sessions
- keep the existing internal 0.33 automatic-sort policy unchanged
- retain the normal YAML key as an explicit expert benchmark envelope
- retain direct `SET`/`RESET` only behind exact `SIRIUS_ENABLE_TEST_OPTIONS=1`

This is a surface simplification, not a new performance claim or numeric-default
change. Ordinary users can leave `max_sort_partition_bytes=0` and get the same
automatic behavior; controlled sort experiments can still supply the fraction
in YAML.

## Validation

- exact base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`
- exact head: `80094b6e7f2d2cd261b229698abf2ae6262ca880`
- exact tree: `26be694a08b1f436b915a4c49ab2e1a256341c7b`
- `git diff --check`: pass
- focused pre-commit hooks: pass for source hygiene, clang-format, codespell,
  and orphan-test detection
- pinned `rumdl==0.2.44` check: pass (run directly because local `pixi` is
  unavailable)
- regression proves normal and non-exact opt-in sessions do not register or
  accept the setting; exact test opt-in retains `SET`/`RESET`
- duplicate search found only complementary validation PR #1492
- fresh exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full
  runtime, and terminal aggregate checks: pass
- hosted workflow [31716976615](https://github.com/sirius-db/sirius/actions/runs/31716976615): runtime job `94505151331` passed in 19m33s; aggregate job `94516393721` passed

The first hosted runtime run (`31713564845`, job `94493551466`) found an owned
test-scope bug after 1,312 passing cases: this PR's YAML-default regression had
set and then unconditionally unset the process-global test-option opt-in, so a
later runtime-fallback fixture could not register its injection setting. The
follow-up commit removes both redundant mutations; `sirius_unittest` already
sets the exact opt-in before constructing databases. The terminal run above is
the repaired head and supersedes that failed attempt.

## Composition notes

PR #1492 tightens the same setter/YAML validation. The positive validation
remains on the retained YAML and exact test-only surfaces.

The pre-repair head was audited pairwise against all 36 other open
Foxglove-authored PR heads touching shared configuration files: 31 merged
without textual conflict, while adjacent internalization PRs #1523, #1526,
#1530, #1532, and #1533 required the already-precomputed stack resolution. The
two-line repair touches only test-local environment cleanup. The historical
pre-repair composition hashes remain scoped to `185d6b4`; the repaired exact
head is `80094b6e`.
