### PR TITLE
refactor(config): internalize pinned zone-map pruning

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -586,21 +586,20 @@ SET enable_dynamic_zone_map_filter = false;
 
 ### Pinned Tables
 
-This setting is accepted both as a DuckDB `SET` variable and in YAML under
-`sirius.operator_params`.
+Pinned-table zone-map capture and pruning are automatic. The advanced YAML escape hatch is under
+`sirius.operator_params` for benchmark and diagnosis envelopes; it is not a normal session choice.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `enable_pinned_zone_map_pruning` | true | Capture pinned-chunk zone maps at pin time and use them to prune cached scans. |
 
-Setting this to `false` before `pin_table` avoids the extra GPU reductions and creates a
+Setting the YAML value to `false` before startup avoids the extra GPU reductions and creates a
 statless entry. Enabling it later does not add statistics to that entry; re-pin the table with
-the setting enabled. Disabling it only for a query leaves existing statistics intact. See
+the setting enabled. See
 [Pinned-table zone maps](scan.md#zone-maps) for supported types, pruning, and re-pin behavior.
 
-```sql
-SET enable_pinned_zone_map_pruning = false;
-```
+The direct DuckDB `SET` override is registered only when the process explicitly enables Sirius
+test options; it is not part of the normal user surface.
 
 ### Transparent Execution
 

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -412,6 +412,7 @@ chunk 0 is retained as a sentinel and emptied by the GPU filter so the pipeline 
 `src/scan_manager/pinned_chunk_stats.cpp` owns the statistics and safety checks; and
 `src/scan_manager/sirius_scan_manager.cpp` builds and serves the survivor plan.
 
-**Config:** `enable_pinned_zone_map_pruning` (default: `true`) is available through YAML and
-DuckDB `SET`. It gates both capture and pruning; entries pinned while it is disabled remain
-statless until re-pinned. See [Pinned-table zone maps](scan.md#zone-maps) for limitations.
+**Config:** zone-map capture and pruning are automatic and enabled by default. The advanced YAML
+escape hatch `sirius.operator_params.enable_pinned_zone_map_pruning` gates both capture and
+pruning; entries pinned while it is disabled remain statless until re-pinned. The direct DuckDB
+session override is test-only. See [Pinned-table zone maps](scan.md#zone-maps) for limitations.

--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -238,9 +238,10 @@ States the delta cannot represent decline at plan time into the transparent CPU 
 
 ### Zone maps
 
-With `enable_pinned_zone_map_pruning` enabled (the default), `pin_table` captures per-chunk
-min/max statistics and cached scans use them to skip chunks that cannot match a pushed-down
-filter. The option is available through DuckDB `SET` and YAML under `sirius.operator_params`.
+By default, `pin_table` automatically captures per-chunk min/max statistics and cached scans use
+them to skip chunks that cannot match a pushed-down filter. An advanced YAML escape hatch,
+`sirius.operator_params.enable_pinned_zone_map_pruning`, can disable both capture and pruning for
+a benchmark or diagnosis envelope. The direct DuckDB session override is test-only.
 
 **Capture and types.** Both pin tiers run one `cudf::minmax` reduction per supported column and
 chunk before the data is stored on the GPU or converted to HOST memory. Supported types are

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2230,6 +2230,12 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
       "TEST ONLY: force transparent GPU execution to fail at runtime with this message",
       LogicalType::VARCHAR,
       Value(""));
+    config.AddExtensionOption(
+      "enable_pinned_zone_map_pruning",
+      "TEST ONLY: disable automatic pinned-table zone-map capture and pruning",
+      LogicalType::BOOLEAN,
+      Value::BOOLEAN(operator_defaults.enable_pinned_zone_map_pruning),
+      SetEnablePinnedZoneMapPruning);
   }
 
   // Add in config options for special JIT implementation for regex
@@ -2423,15 +2429,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     LogicalType::DOUBLE,
     Value::DOUBLE(operator_defaults.dynamic_filter_keep_threshold),
     SetDynamicFilterKeepThreshold);
-
-  config.AddExtensionOption(
-    "enable_pinned_zone_map_pruning",
-    "Skip pinned-table chunks whose pin-time min/max statistics prove the scan's pushed-down "
-    "filter matches no rows; also gates the statistics capture during CALL pin_table, so a table "
-    "pinned while off carries no zone maps until re-pinned with the flag on",
-    LogicalType::BOOLEAN,
-    Value::BOOLEAN(operator_defaults.enable_pinned_zone_map_pruning),
-    SetEnablePinnedZoneMapPruning);
 
   // Default from the YAML-loaded params, so a sirius.yaml value is what connections inherit.
   config.AddExtensionOption(

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -212,10 +212,8 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     setenv("SIRIUS_DISABLE", "1", 1);
   }};
 
-  auto setting_count = [](duckdb::Connection& con) {
-    auto result = con.Query(
-      "SELECT count(*) FROM duckdb_settings() "
-      "WHERE name = 'sirius_test_inject_transparent_gpu_error'");
+  auto setting_count = [](duckdb::Connection& con, std::string const& name) {
+    auto result = con.Query("SELECT count(*) FROM duckdb_settings() WHERE name = '" + name + "'");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
     return result->GetValue(0, 0).GetValue<int64_t>();
@@ -226,8 +224,12 @@ TEST_CASE("Test-only settings require explicit process opt-in",
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 0);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 0);
+    REQUIRE(setting_count(con, "enable_pinned_zone_map_pruning") == 0);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET enable_pinned_zone_map_pruning = false");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
   }
@@ -236,15 +238,23 @@ TEST_CASE("Test-only settings require explicit process opt-in",
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 0);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 0);
+    REQUIRE(setting_count(con, "enable_pinned_zone_map_pruning") == 0);
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 1);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 1);
+    REQUIRE(setting_count(con, "enable_pinned_zone_map_pruning") == 1);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET enable_pinned_zone_map_pruning = false");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET enable_pinned_zone_map_pruning");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
   }


### PR DESCRIPTION
## Summary

- keep pinned-table zone-map capture/pruning automatic and enabled by default
- keep `sirius.operator_params.enable_pinned_zone_map_pruning` as the advanced YAML benchmark/diagnosis envelope
- register the direct DuckDB session override only when `SIRIUS_ENABLE_TEST_OPTIONS=1`
- prove the option is absent normally, remains absent for loose truthy opt-in values, and is available to the existing transition tests only under exact opt-in
- update the user docs to describe the smaller surface

## Why

This is an internal cache capture/serve mechanism, not a useful normal-session choice. Changing it before pinning creates a statless cached entry that stays statless until re-pinned, so exposing a mutable session knob asks users to reason about cache history.

The default and runtime behavior do not change. YAML remains available for an explicit benchmark or diagnosis envelope, and Sirius's test binary already opts into test-only settings before constructing its databases.

The merged implementation in #1154 made the feature default-on and retained oracle correctness in its end-to-end clustered-table benchmark (22/22 queries; 1.220x single-GPU and 1.058x multi-GPU suite speedups for the combined clustered-plus-pruning treatment). This PR makes no isolated performance claim; it only removes the unnecessary normal session choice.

## Validation

- pre-commit: all applicable hooks passed; the local `rumdl` wrapper alone could not start because `pixi` is not installed on the macOS host
- `rumdl==0.2.44 check` passed independently on all changed Markdown
- `git diff --check` passed
- hosted CUDA build/tests requested by this PR

- fresh exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full runtime, and terminal aggregate checks: pass
- hosted workflow [31716482009](https://github.com/sirius-db/sirius/actions/runs/31716482009): runtime job 94503737159 passed in 20m12s; aggregate job 94534354523 passed
