### PR TITLE
fix(config): simplify dynamic filter controls

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -390,8 +390,8 @@ individually.
 | `enable_runtime_distinct_build_probe` | true | For `BUILD_PROBE` INNER/LEFT equality joins whose build-key uniqueness the planner could not prove, test distinctness at runtime (one `cudf::distinct_count` pass over the cached build, dimension-scale builds only) and take the single-pass `cudf::distinct_hash_join` instead of the general two-pass join when the keys are distinct. |
 | `enable_dynamic_filter_pushdown` | true | Master switch for dynamic table-filter pushdown. An eligible `BUILD_PROBE` hash-join build selects a raw exact IN-list for 1–12 supported build rows, otherwise a hash IN-list if it fits the smallest probe-GPU L2 or a Bloom, for post-decode application by the probe scan. |
 | `enable_dynamic_zone_map_filter` | false | Additionally publish build-key min/max bounds. Parquet scans use them for read-time row-group pruning; duckdb-native scans apply them row-wise post-decode. Requires `enable_dynamic_filter_pushdown`; intended for clustered-keyset workloads. |
-| `dynamic_filter_domain_coverage_threshold` | 0.9 | Skip publishing a key's dynamic filters when the build covers at least this fraction of the key's domain; ≥ 1.0 effectively disables the gate. |
-| `dynamic_filter_keep_threshold` | 0.9 | Disable a probe scan's post-decode dynamic filtering once a measured split keeps more than this fraction of its rows; in [0, 1], 1.0 keeps filtering always on. |
+| `dynamic_filter_domain_coverage_threshold` | 0.9 | Positive finite threshold for skipping publication when the build covers at least this fraction of the key's domain; ≥ 1.0 effectively disables the gate. |
+| `dynamic_filter_keep_threshold` | 0.9 | Finite threshold in [0, 1] for disabling post-decode filtering once a measured split keeps more than this fraction of its rows; 1.0 keeps filtering always on. |
 | `enable_pinned_zone_map_pruning` | true | Capture per-chunk min/max statistics while pinning and use them to skip cached chunks that cannot match a scan filter. |
 
 **Note:** `max_build_hash_table_bytes` can be larger than `concat_batch_bytes`. When it is, the partition operator configures CONCAT to concatenate all batches, enabling the more efficient BUILD_PROBE join mode for larger build sides. Other joins (STANDARD, MIXED) still use `concat_batch_bytes` as the batch size threshold.
@@ -570,37 +570,38 @@ SET enable_compressed_materialization = false;
 
 ### Dynamic Filters
 
-Both settings are also accepted in YAML under `sirius.operator_params`.
+Dynamic membership-filter pushdown is automatic and enabled by default. The
+clustered-keyset zone-map path is automatic-off by default because it does not
+repay its row-level cost on scattered keys. Advanced benchmark and diagnosis
+envelopes can override either behavior in YAML under `sirius.operator_params`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `enable_dynamic_filter_pushdown` | true | Master switch for dynamic table-filter pushdown. Wires eligible `BUILD_PROBE` hash-join-build membership filters into probe scans: raw exact IN-list for 1–12 supported build rows, then a hash IN-list if it fits the smallest probe-GPU L2 or a Bloom. |
 | `enable_dynamic_zone_map_filter` | false | Additionally publish build-key min/max bounds. Parquet scans use them for read-time row-group pruning; duckdb-native scans apply them row-wise post-decode. Has no effect unless `enable_dynamic_filter_pushdown` is enabled. |
-| `dynamic_filter_domain_coverage_threshold` | 0.9 | Skip publishing a key's dynamic filters when the build covers at least this fraction of the key's domain; ≥ 1.0 effectively disables the gate. |
-| `dynamic_filter_keep_threshold` | 0.9 | Disable a probe scan's post-decode dynamic filtering once a measured split keeps more than this fraction of its rows; in [0, 1], 1.0 keeps filtering always on. |
+| `dynamic_filter_domain_coverage_threshold` | 0.9 | Positive finite threshold for skipping publication when the build covers at least this fraction of the key's domain; ≥ 1.0 effectively disables the gate. |
+| `dynamic_filter_keep_threshold` | 0.9 | Finite threshold in [0, 1] for disabling post-decode filtering once a measured split keeps more than this fraction of its rows; 1.0 keeps filtering always on. |
 
-```sql
-SET enable_dynamic_filter_pushdown = true;
-SET enable_dynamic_zone_map_filter = false;
-```
+The direct DuckDB session overrides are registered only when the process
+explicitly enables Sirius test options; they are not part of the normal user
+surface.
 
 ### Pinned Tables
 
-This setting is accepted both as a DuckDB `SET` variable and in YAML under
-`sirius.operator_params`.
+Pinned-table zone-map capture and pruning are automatic. The advanced YAML escape hatch is under
+`sirius.operator_params` for benchmark and diagnosis envelopes; it is not a normal session choice.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `enable_pinned_zone_map_pruning` | true | Capture pinned-chunk zone maps at pin time and use them to prune cached scans. |
 
-Setting this to `false` before `pin_table` avoids the extra GPU reductions and creates a
+Setting the YAML value to `false` before startup avoids the extra GPU reductions and creates a
 statless entry. Enabling it later does not add statistics to that entry; re-pin the table with
-the setting enabled. Disabling it only for a query leaves existing statistics intact. See
+the setting enabled. See
 [Pinned-table zone maps](scan.md#zone-maps) for supported types, pruning, and re-pin behavior.
 
-```sql
-SET enable_pinned_zone_map_pruning = false;
-```
+The direct DuckDB `SET` override is registered only when the process explicitly enables Sirius
+test options; it is not part of the normal user surface.
 
 ### Transparent Execution
 

--- a/docs/super-sirius/dynamic-filters.md
+++ b/docs/super-sirius/dynamic-filters.md
@@ -374,10 +374,13 @@ That sweep and the SF50/SF300 measurements below predate the raw-needle represen
 
 #### Configuration
 
-- `enable_dynamic_filter_pushdown` (bool, default **true**) — master switch; when off, the router hands out no channels so neither side wires anything and there is zero overhead. Enabled by default to wire the membership (raw/hash IN-list or Bloom) filters.
-- `enable_dynamic_zone_map_filter` (bool, default **false**, requires the master) — additionally emit a zone map. Parquet scans use it for read-time row-group pruning; duckdb-native scans apply it row-wise post-decode. Off by default: static pushdown already handles range-derivable builds and scattered keys prune nothing, so it is reserved for clustered-keyset workloads whose narrow range is runtime-determined. The publication range-coverage gate skips obviously non-pruning numeric ranges.
-- `dynamic_filter_domain_coverage_threshold` (double, default **0.9**) — skip publishing a key's filters when the build covers at least this fraction of the key's domain (rows gate and zone-map range gate); ≥ 1.0 effectively disables the gate.
-- `dynamic_filter_keep_threshold` (double, default **0.9**) — consumer-side scan gate: disable a scan's post-decode filtering once a measured split keeps more than this fraction of its rows; in [0, 1], 1.0 keeps filtering always on.
+- Dynamic membership-filter pushdown is automatic and enabled by default. When disabled through the advanced YAML benchmark/diagnosis envelope, the router hands out no channels so neither side wires anything and there is zero overhead.
+- The clustered-keyset dynamic zone-map path is automatic-off by default and requires membership pushdown. Parquet scans use it for read-time row-group pruning; duckdb-native scans apply it row-wise post-decode. Static pushdown already handles range-derivable builds and scattered keys prune nothing, so the YAML expert envelope should enable it only for clustered-keyset workloads whose narrow range is runtime-determined. The publication range-coverage gate skips obviously non-pruning numeric ranges.
+- `dynamic_filter_domain_coverage_threshold` (positive finite double, default **0.9**) — skip publishing a key's filters when the build covers at least this fraction of the key's domain (rows gate and zone-map range gate); ≥ 1.0 effectively disables the gate.
+- `dynamic_filter_keep_threshold` (finite double in [0, 1], default **0.9**) — consumer-side scan gate: disable a scan's post-decode filtering once a measured split keeps more than this fraction of its rows; 1.0 keeps filtering always on.
+
+The two mode toggles remain accepted in YAML under `sirius.operator_params`.
+Their direct DuckDB session overrides are test-only.
 
 #### Ready replicas and per-split snapshots
 

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -412,6 +412,7 @@ chunk 0 is retained as a sentinel and emptied by the GPU filter so the pipeline 
 `src/scan_manager/pinned_chunk_stats.cpp` owns the statistics and safety checks; and
 `src/scan_manager/sirius_scan_manager.cpp` builds and serves the survivor plan.
 
-**Config:** `enable_pinned_zone_map_pruning` (default: `true`) is available through YAML and
-DuckDB `SET`. It gates both capture and pruning; entries pinned while it is disabled remain
-statless until re-pinned. See [Pinned-table zone maps](scan.md#zone-maps) for limitations.
+**Config:** zone-map capture and pruning are automatic and enabled by default. The advanced YAML
+escape hatch `sirius.operator_params.enable_pinned_zone_map_pruning` gates both capture and
+pruning; entries pinned while it is disabled remain statless until re-pinned. The direct DuckDB
+session override is test-only. See [Pinned-table zone maps](scan.md#zone-maps) for limitations.

--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -238,9 +238,10 @@ States the delta cannot represent decline at plan time into the transparent CPU 
 
 ### Zone maps
 
-With `enable_pinned_zone_map_pruning` enabled (the default), `pin_table` captures per-chunk
-min/max statistics and cached scans use them to skip chunks that cannot match a pushed-down
-filter. The option is available through DuckDB `SET` and YAML under `sirius.operator_params`.
+By default, `pin_table` automatically captures per-chunk min/max statistics and cached scans use
+them to skip chunks that cannot match a pushed-down filter. An advanced YAML escape hatch,
+`sirius.operator_params.enable_pinned_zone_map_pruning`, can disable both capture and pruning for
+a benchmark or diagnosis envelope. The direct DuckDB session override is test-only.
 
 **Capture and types.** Both pin tiers run one `cudf::minmax` reduction per supported column and
 chunk before the data is stored on the GPU or converted to HOST memory. Supported types are

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -273,8 +273,10 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
   r.optional("enable_dynamic_filter_pushdown", opt.enable_dynamic_filter_pushdown);
   r.optional("enable_dynamic_zone_map_filter", opt.enable_dynamic_zone_map_filter);
   r.optional("dynamic_filter_domain_coverage_threshold",
-             opt.dynamic_filter_domain_coverage_threshold);
-  r.optional("dynamic_filter_keep_threshold", opt.dynamic_filter_keep_threshold);
+             opt.dynamic_filter_domain_coverage_threshold,
+             yaml::greater_than<double>{0.0});
+  r.optional(
+    "dynamic_filter_keep_threshold", opt.dynamic_filter_keep_threshold, yaml::fraction<double>{});
   r.optional("enable_pinned_zone_map_pruning", opt.enable_pinned_zone_map_pruning);
   r.optional("enable_compressed_materialization", opt.enable_compressed_materialization);
   r.reject_unknown();

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2082,7 +2082,7 @@ static void SetDynamicFilterDomainCoverageThreshold(ClientContext& context,
   if (!params) { return; }
   auto slot              = lock_operator_params_slot(context);
   const double threshold = parameter.GetValue<double>();
-  if (threshold <= 0.0) {
+  if (!(threshold > 0.0)) {
     throw InvalidInputException("dynamic_filter_domain_coverage_threshold must be > 0.0, got %f",
                                 threshold);
   }
@@ -2097,7 +2097,7 @@ static void SetDynamicFilterKeepThreshold(ClientContext& context, SetScope scope
   if (!params) { return; }
   auto slot              = lock_operator_params_slot(context);
   const double threshold = parameter.GetValue<double>();
-  if (threshold < 0.0 || threshold > 1.0) {
+  if (!(threshold >= 0.0 && threshold <= 1.0)) {
     throw InvalidInputException("dynamic_filter_keep_threshold must be in [0.0, 1.0], got %f",
                                 threshold);
   }
@@ -2230,6 +2230,22 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
       "TEST ONLY: force transparent GPU execution to fail at runtime with this message",
       LogicalType::VARCHAR,
       Value(""));
+    config.AddExtensionOption(
+      "enable_pinned_zone_map_pruning",
+      "TEST ONLY: disable automatic pinned-table zone-map capture and pruning",
+      LogicalType::BOOLEAN,
+      Value::BOOLEAN(operator_defaults.enable_pinned_zone_map_pruning),
+      SetEnablePinnedZoneMapPruning);
+    config.AddExtensionOption("enable_dynamic_filter_pushdown",
+                              "TEST ONLY: disable automatic dynamic membership-filter pushdown",
+                              LogicalType::BOOLEAN,
+                              Value::BOOLEAN(operator_defaults.enable_dynamic_filter_pushdown),
+                              SetEnableDynamicFilterPushdown);
+    config.AddExtensionOption("enable_dynamic_zone_map_filter",
+                              "TEST ONLY: enable the clustered-keyset dynamic zone-map path",
+                              LogicalType::BOOLEAN,
+                              Value::BOOLEAN(operator_defaults.enable_dynamic_zone_map_filter),
+                              SetEnableDynamicZoneMapFilter);
   }
 
   // Add in config options for special JIT implementation for regex
@@ -2389,25 +2405,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     SetPinTableCompressionMaxCompressedFraction);
 
   config.AddExtensionOption(
-    "enable_dynamic_filter_pushdown",
-    "Wire dynamic table-filter pushdown: an eligible BUILD_PROBE hash-join build publishes a "
-    "runtime membership filter (raw IN-list for 1-12 supported build rows; otherwise a hash "
-    "IN-list if it fits the smallest probe-GPU L2, or a Bloom) into the probe-side scan to drop "
-    "non-matching rows before the join (on by default)",
-    LogicalType::BOOLEAN,
-    Value::BOOLEAN(operator_defaults.enable_dynamic_filter_pushdown),
-    SetEnableDynamicFilterPushdown);
-
-  config.AddExtensionOption(
-    "enable_dynamic_zone_map_filter",
-    "Additionally emit a runtime zone-map (build-key min/max) at the probe scan: parquet scans use "
-    "it for read-time row-group pruning, while duckdb-native scans apply it row-wise post-decode; "
-    "requires enable_dynamic_filter_pushdown (off by default)",
-    LogicalType::BOOLEAN,
-    Value::BOOLEAN(operator_defaults.enable_dynamic_zone_map_filter),
-    SetEnableDynamicZoneMapFilter);
-
-  config.AddExtensionOption(
     "dynamic_filter_domain_coverage_threshold",
     "Skip publishing a key's dynamic filters when the hash-join build covers at least this "
     "fraction of the key's domain; >= 1.0 effectively disables the gate",
@@ -2423,15 +2420,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     LogicalType::DOUBLE,
     Value::DOUBLE(operator_defaults.dynamic_filter_keep_threshold),
     SetDynamicFilterKeepThreshold);
-
-  config.AddExtensionOption(
-    "enable_pinned_zone_map_pruning",
-    "Skip pinned-table chunks whose pin-time min/max statistics prove the scan's pushed-down "
-    "filter matches no rows; also gates the statistics capture during CALL pin_table, so a table "
-    "pinned while off carries no zone maps until re-pinned with the flag on",
-    LogicalType::BOOLEAN,
-    Value::BOOLEAN(operator_defaults.enable_pinned_zone_map_pruning),
-    SetEnablePinnedZoneMapPruning);
 
   // Default from the YAML-loaded params, so a sirius.yaml value is what connections inherit.
   config.AddExtensionOption(

--- a/test/cpp/config/data/invalid_dynamic_filter_domain_coverage_threshold.yaml
+++ b/test/cpp/config/data/invalid_dynamic_filter_domain_coverage_threshold.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    dynamic_filter_domain_coverage_threshold: 0

--- a/test/cpp/config/data/invalid_dynamic_filter_domain_coverage_threshold_nan.yaml
+++ b/test/cpp/config/data/invalid_dynamic_filter_domain_coverage_threshold_nan.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    dynamic_filter_domain_coverage_threshold: .nan

--- a/test/cpp/config/data/invalid_dynamic_filter_keep_threshold_above_one.yaml
+++ b/test/cpp/config/data/invalid_dynamic_filter_keep_threshold_above_one.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    dynamic_filter_keep_threshold: 1.1

--- a/test/cpp/config/data/invalid_dynamic_filter_keep_threshold_nan.yaml
+++ b/test/cpp/config/data/invalid_dynamic_filter_keep_threshold_nan.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    dynamic_filter_keep_threshold: .nan

--- a/test/cpp/config/data/invalid_dynamic_filter_keep_threshold_negative.yaml
+++ b/test/cpp/config/data/invalid_dynamic_filter_keep_threshold_negative.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    dynamic_filter_keep_threshold: -0.1

--- a/test/cpp/config/data/valid_dynamic_filter_threshold_boundaries.yaml
+++ b/test/cpp/config/data/valid_dynamic_filter_threshold_boundaries.yaml
@@ -1,0 +1,6 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    dynamic_filter_domain_coverage_threshold: 1.5
+    dynamic_filter_keep_threshold: 0.0

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -212,10 +212,8 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     setenv("SIRIUS_DISABLE", "1", 1);
   }};
 
-  auto setting_count = [](duckdb::Connection& con) {
-    auto result = con.Query(
-      "SELECT count(*) FROM duckdb_settings() "
-      "WHERE name = 'sirius_test_inject_transparent_gpu_error'");
+  auto setting_count = [](duckdb::Connection& con, std::string const& name) {
+    auto result = con.Query("SELECT count(*) FROM duckdb_settings() WHERE name = '" + name + "'");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
     return result->GetValue(0, 0).GetValue<int64_t>();
@@ -226,8 +224,20 @@ TEST_CASE("Test-only settings require explicit process opt-in",
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 0);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 0);
+    REQUIRE(setting_count(con, "enable_pinned_zone_map_pruning") == 0);
+    REQUIRE(setting_count(con, "enable_dynamic_filter_pushdown") == 0);
+    REQUIRE(setting_count(con, "enable_dynamic_zone_map_filter") == 0);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET enable_pinned_zone_map_pruning = false");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET enable_dynamic_filter_pushdown = false");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET enable_dynamic_zone_map_filter = true");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
   }
@@ -236,15 +246,39 @@ TEST_CASE("Test-only settings require explicit process opt-in",
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 0);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 0);
+    REQUIRE(setting_count(con, "enable_pinned_zone_map_pruning") == 0);
+    REQUIRE(setting_count(con, "enable_dynamic_filter_pushdown") == 0);
+    REQUIRE(setting_count(con, "enable_dynamic_zone_map_filter") == 0);
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
   {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);
-    REQUIRE(setting_count(con) == 1);
+    REQUIRE(setting_count(con, "sirius_test_inject_transparent_gpu_error") == 1);
+    REQUIRE(setting_count(con, "enable_pinned_zone_map_pruning") == 1);
+    REQUIRE(setting_count(con, "enable_dynamic_filter_pushdown") == 1);
+    REQUIRE(setting_count(con, "enable_dynamic_zone_map_filter") == 1);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET enable_pinned_zone_map_pruning = false");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET enable_pinned_zone_map_pruning");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET enable_dynamic_filter_pushdown = false");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET enable_dynamic_filter_pushdown");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET enable_dynamic_zone_map_filter = true");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET enable_dynamic_zone_map_filter");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
   }
@@ -327,6 +361,42 @@ TEST_CASE("Sirius configuration validates MARK join build switch ratio", "[siriu
   REQUIRE(config.get_operator_params().mark_join_build_switch_ratio == Approx(default_ratio));
   REQUIRE_NOTHROW(config.load_from_file(data_dir / "valid_mark_join_switch_zero.yaml"));
   REQUIRE(config.get_operator_params().mark_join_build_switch_ratio == Approx(0.0));
+}
+
+TEST_CASE("Sirius YAML rejects invalid dynamic-filter thresholds", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  struct invalid_config {
+    const char* fixture;
+    const char* setting;
+  };
+  const invalid_config cases[] = {
+    {"invalid_dynamic_filter_domain_coverage_threshold.yaml",
+     "dynamic_filter_domain_coverage_threshold"},
+    {"invalid_dynamic_filter_domain_coverage_threshold_nan.yaml",
+     "dynamic_filter_domain_coverage_threshold"},
+    {"invalid_dynamic_filter_keep_threshold_negative.yaml", "dynamic_filter_keep_threshold"},
+    {"invalid_dynamic_filter_keep_threshold_above_one.yaml", "dynamic_filter_keep_threshold"},
+    {"invalid_dynamic_filter_keep_threshold_nan.yaml", "dynamic_filter_keep_threshold"},
+  };
+
+  for (auto const& invalid : cases) {
+    INFO("fixture=" << invalid.fixture << " setting=" << invalid.setting);
+    auto const path = data_dir / invalid.fixture;
+    REQUIRE(fs::is_regular_file(path));
+
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(config.load_from_file(path),
+                        Catch::Contains(invalid.setting) && Catch::Contains("value out of range"));
+  }
+
+  sirius::sirius_config config;
+  REQUIRE_NOTHROW(
+    config.load_from_file(data_dir / "valid_dynamic_filter_threshold_boundaries.yaml"));
+  REQUIRE(config.get_operator_params().dynamic_filter_domain_coverage_threshold == Approx(1.5));
+  REQUIRE(config.get_operator_params().dynamic_filter_keep_threshold == Approx(0.0));
 }
 
 namespace {
@@ -760,6 +830,22 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE(sirius_ctx->get_config().get_operator_params().mark_join_build_switch_ratio ==
           Approx(3.0));
 
+  auto invalid_domain_threshold = con.Query("SET dynamic_filter_domain_coverage_threshold = 'NaN'");
+  REQUIRE(invalid_domain_threshold != nullptr);
+  REQUIRE(invalid_domain_threshold->HasError());
+  REQUIRE_THAT(invalid_domain_threshold->GetError(),
+               Catch::Contains("dynamic_filter_domain_coverage_threshold must be > 0.0"));
+  REQUIRE(sirius_ctx->get_config().get_operator_params().dynamic_filter_domain_coverage_threshold ==
+          Approx(0.8));
+
+  auto invalid_keep_threshold = con.Query("SET dynamic_filter_keep_threshold = 'NaN'");
+  REQUIRE(invalid_keep_threshold != nullptr);
+  REQUIRE(invalid_keep_threshold->HasError());
+  REQUIRE_THAT(invalid_keep_threshold->GetError(),
+               Catch::Contains("dynamic_filter_keep_threshold must be in [0.0, 1.0]"));
+  REQUIRE(sirius_ctx->get_config().get_operator_params().dynamic_filter_keep_threshold ==
+          Approx(0.7));
+
   auto nan_mark_join_ratio = con.Query("SET mark_join_build_switch_ratio = 'NaN'");
   REQUIRE(nan_mark_join_ratio != nullptr);
   REQUIRE(nan_mark_join_ratio->HasError());
@@ -792,6 +878,11 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   require_ok("RESET max_sort_partition_memory_fraction");
   require_ok("SET enable_dynamic_filter_pushdown = true");
   require_ok("RESET enable_dynamic_filter_pushdown");
+  require_ok("SET dynamic_filter_domain_coverage_threshold = 1.5");
+  require_ok("RESET dynamic_filter_domain_coverage_threshold");
+  require_ok("SET dynamic_filter_keep_threshold = 0.0");
+  require_ok("SET dynamic_filter_keep_threshold = 1.0");
+  require_ok("RESET dynamic_filter_keep_threshold");
   require_ok("SET enable_runtime_distinct_build_probe = true");
   require_ok("RESET enable_runtime_distinct_build_probe");
   require_ok("SET pin_table_compression = false");


### PR DESCRIPTION
## Summary

- remove `enable_dynamic_filter_pushdown`,
  `enable_dynamic_zone_map_filter`, and
  `enable_pinned_zone_map_pruning` from normal DuckDB sessions
- preserve their existing automatic/default behavior and YAML expert envelopes
- retain direct `SET`/`RESET` only behind exact
  `SIRIUS_ENABLE_TEST_OPTIONS=1`
- validate both dynamic-filter thresholds in YAML and DuckDB `SET`, including
  NaN refusal without mutation

This consolidates the dynamic-filter family previously split across #1535 and
#1536. It keeps the adaptive membership-filter and pinned zone-map mechanisms
automatic while preserving explicit benchmark/diagnostic YAML controls.

## Evidence and scope

Membership-filter pushdown already adapts representation and disables itself
when the first split keeps too many rows. Retained upstream evidence reported a
large warm pinned-host case and a nearly neutral cold suite; this change makes
no universal speed claim. Pinned zone-map pruning is an internal cache-history
behavior: changing it after pinning does not retroactively add statistics.

The clustered-keyset zone-map mode remains default-off and available in YAML.
The direct session duplicates are test-only; production defaults and operator
logic are unchanged.

## Exact composition and predecessor evidence

- base `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`
- consolidated head `929dcf7b38dc50c80c305a6864a6b28d85185ec6`
- consolidated tree `f19bb8bff85a0e51c711abf4de30e6c84f529dd1`
- exact binary diff SHA-256
  `1d73aa16c0cb1b24cd9d1c442f34b5f2df3c9c9155cb1bcd249b184cea7b8626`
- #1535 predecessor head/tree:
  `1280834c9146f4099440acf1c4fc24547864a619` /
  `6ddaba37f2dea6149a98fe03b3b471466a0d735f`
- #1536 predecessor head/tree:
  `fdd213703efb3f6401ee7d7b48db99324a6610da` /
  `5d49259a4978ff36f55cb91a657147145b5cc07d`

Both predecessor heads passed hosted lint, GCC release, Clang debug, CUDA 13
build, full C++ runtime, and aggregate checks. Historical workflow receipts
remain #1535 run `31716482009` and #1536 run `31725065043`; they are
predecessor evidence, not a substitute for new consolidated-head CI.

## Consolidated-head validation

- `PASS_DYNAMIC_FILTER_SOURCE_CONTRACT`: all three mode registrations occur
  only in the exact test-option block
- default-bearing `src/include/sirius_config.hpp`: byte-identical to base
- normal/non-exact absence and exact-opt-in `SET`/`RESET` regressions retained
  for all three modes
- YAML fixtures cover non-positive/non-finite domain coverage and
  out-of-range/non-finite keep thresholds; valid boundaries remain accepted
- focused pre-commit suite: all applicable hooks pass
- pinned `rumdl==0.2.44`: all four changed docs pass
- `git diff --check`: pass
- hosted CUDA-linked build/runtime: launched on this exact head; status is the
  PR check rollup

- exact-head hosted receipt for `929dcf7b38dc50c80c305a6864a6b28d85185ec6`: CUDA 13 runtime and terminal aggregate checks passed
- hosted workflow 31730946320: runtime job 94552100191 passed from 2026-08-13T18:51:39Z through 2026-08-13T19:12:11Z; aggregate job 94563227127 passed at 2026-08-13T19:12:19Z