### PR TITLE
refactor(config): simplify automatic sort sizing

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -405,7 +405,7 @@ individually.
 | `sort_sample_bytes` | Shared physical/effective GPU batch default described above | Bytes sampled before computing sort partition boundaries |
 | `max_build_hash_table_bytes` | 2× batch default | Max build-side size for BUILD_PROBE join mode |
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join. A build below this size is replicated to every GPU (instead of hash-partitioned) when it is tiny, or when the DuckDB-estimated probe-to-build row ratio is at least `num_gpus * 1.25`. |
-| `max_sort_partition_memory_fraction` | 0.33 | Fraction of GPU memory per sort partition when `max_sort_partition_bytes` is 0 |
+| `max_sort_partition_memory_fraction` | 0.33 | Fraction of GPU memory per sort partition when `max_sort_partition_bytes` is 0; must be finite and in `(0, 1]` |
 | `mark_join_build_switch_ratio` | 8.0 | For STANDARD MARK joins, build on the smaller (left) side when `right_rows >= ratio * left_rows` (0 disables) |
 | `enable_dynamic_filter_pushdown` | true | Master switch for dynamic table-filter pushdown. An eligible `BUILD_PROBE` hash-join build selects a raw exact IN-list for 1–12 supported build rows, otherwise a hash IN-list if it fits the smallest probe-GPU L2 or a Bloom, for post-decode application by the probe scan. |
 | `enable_dynamic_zone_map_filter` | false | Additionally publish build-key min/max bounds. Parquet scans use them for read-time row-group pruning; duckdb-native scans apply them row-wise post-decode. Requires `enable_dynamic_filter_pushdown`; intended for clustered-keyset workloads. |
@@ -592,10 +592,7 @@ SET enable_compressed_materialization = false;
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `max_sort_partition_bytes` | 0 (auto) | Max sort partition bytes |
-| `max_sort_partition_memory_fraction` | 0.33 | Auto sort-partition fraction when `max_sort_partition_bytes` is 0 |
 | `hash_partition_bytes` | Shared physical/effective GPU batch default | Hash partition target size; must be greater than zero |
-| `sort_sample_bytes` | Shared physical/effective GPU batch default | Bytes sampled before computing sort boundaries |
 | `max_build_hash_table_bytes` | 2× batch default | Max build-side hash table bytes |
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join |
 | `mark_join_build_switch_ratio` | 8.0 | STANDARD MARK join build-side switch ratio (0 disables) |
@@ -623,6 +620,20 @@ is YAML-only — it is read once when the GPU memory spaces are configured.
 ```sql
 SET admission_bytes_per_gpu = 34359738368;  -- 32 GiB
 ```
+
+When `max_sort_partition_bytes` is left at its automatic value, Sirius uses an
+internal 0.33 memory fraction. Advanced benchmark envelopes may override
+`max_sort_partition_memory_fraction` in YAML under `sirius.operator_params`,
+but it is not a normal session setting.
+
+The sort sample target uses the shared physical/effective GPU batch default.
+Its YAML operator parameter remains an expert benchmark envelope; the direct
+DuckDB session override is test-only.
+
+Sort partition sizing is automatic by default: `max_sort_partition_bytes: 0`
+uses `max_sort_partition_memory_fraction` of available GPU memory. The YAML
+operator parameter remains an expert escape hatch for controlled sort
+benchmarks; the direct DuckDB session override is test-only.
 
 ### Dynamic Filters
 

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -41,7 +41,10 @@ num_partitions = max(1, ceil(total_bytes / hash_partition_bytes))
 - `src/op/sirius_physical_sort_partition.cpp` — range partitioning
 - `src/op/sirius_physical_merge_sort.cpp` — multi-way merge
 
-**Config:** `max_sort_partition_bytes` (default: auto, 33% of GPU memory)
+**Config:** `max_sort_partition_bytes: 0` automatically derives the partition
+size from available GPU memory and `max_sort_partition_memory_fraction`
+(default: 0.33; valid range `(0, 1]`). The advanced YAML escape hatch remains available for a
+controlled sort benchmark. The direct DuckDB session override is test-only.
 
 ### SORT_SAMPLE Byte-Based Merge Sampling (PRs #876, #886)
 
@@ -51,7 +54,10 @@ num_partitions = max(1, ceil(total_bytes / hash_partition_bytes))
 
 **Code path:** `src/op/sirius_physical_sort_sample.cpp` — `get_next_task_input_data()`, `get_next_task_hint()`, `execute()`; `src/planner/sirius_physical_plan_generator.cpp` — wiring `sort_sample_bytes` into SORT_SAMPLE
 
-**Config:** `sort_sample_bytes` (default: 512 MB), settable via YAML and the `sort_sample_bytes` SET option
+**Config:** the sort sample target shares the hardware/effective-capacity-derived
+operator batch default. The advanced YAML escape hatch
+`sirius.operator_params.sort_sample_bytes` remains available for a controlled
+sort benchmark. The direct DuckDB session override is test-only.
 
 ### Merge Pipeline Fusion (PR #1190)
 

--- a/src/include/yaml_reader.hpp
+++ b/src/include/yaml_reader.hpp
@@ -60,6 +60,12 @@ struct fraction {
 };
 
 template <typename T>
+struct positive_fraction {
+  bool operator()(const T& v) const noexcept { return v > T{0} && v <= T{1}; }
+  static constexpr const char* description() { return "must be greater than 0.0 and at most 1.0"; }
+};
+
+template <typename T>
 struct greater_than {
   T threshold;
   bool operator()(const T& v) const noexcept { return v > threshold; }

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -265,7 +265,7 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
   r.optional("max_sort_partition_bytes", yaml::bytes(opt.max_sort_partition_bytes));
   r.optional("max_sort_partition_memory_fraction",
              opt.max_sort_partition_memory_fraction,
-             yaml::fraction<double>{});
+             yaml::positive_fraction<double>{});
   r.optional("hash_partition_bytes", yaml::bytes(opt.hash_partition_bytes));
   if (opt.hash_partition_bytes == 0) {
     throw std::runtime_error("'operator_params.hash_partition_bytes': must be greater than zero");

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1905,14 +1905,16 @@ static void SetMaxSortPartitionMemoryFraction(ClientContext& context,
                                               SetScope scope,
                                               Value& parameter)
 {
+  const double fraction = parameter.GetValue<double>();
+  if (!std::isfinite(fraction) || fraction <= 0.0 || fraction > 1.0) {
+    throw InvalidInputException(
+      "max_sort_partition_memory_fraction must be finite, greater than 0.0, and at most 1.0, got "
+      "%f",
+      fraction);
+  }
   auto* params = get_operator_params(context);
   if (!params) { return; }
-  auto slot             = lock_operator_params_slot(context);
-  const double fraction = parameter.GetValue<double>();
-  if (fraction < 0.0 || fraction > 1.0) {
-    throw InvalidInputException(
-      "max_sort_partition_memory_fraction must be between 0.0 and 1.0, got %f", fraction);
-  }
+  auto slot                                  = lock_operator_params_slot(context);
   params->max_sort_partition_memory_fraction = fraction;
   SIRIUS_LOG_DEBUG("Updated config MAX_SORT_PARTITION_MEMORY_FRACTION to {}",
                    params->max_sort_partition_memory_fraction);
@@ -2357,6 +2359,27 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                     LogicalType::UBIGINT,
                     Value::UBIGINT(operator_defaults.concat_batch_bytes),
                     SetConcatBatchBytes);
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "max_sort_partition_memory_fraction",
+                    "override the internal automatic sort-partition memory fraction",
+                    LogicalType::DOUBLE,
+                    Value::DOUBLE(operator_defaults.max_sort_partition_memory_fraction),
+                    SetMaxSortPartitionMemoryFraction);
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "sort_sample_bytes",
+                    "override the effective-capacity-derived sort sample",
+                    LogicalType::UBIGINT,
+                    Value::UBIGINT(operator_defaults.sort_sample_bytes),
+                    SetSortSampleBytes);
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "max_sort_partition_bytes",
+                    "override the automatic GPU-memory-derived sort partition size",
+                    LogicalType::UBIGINT,
+                    Value::UBIGINT(operator_defaults.max_sort_partition_bytes),
+                    SetMaxSortPartitionBytes);
 
   // Add in config options for special JIT implementation for regex
   add_sirius_option(config,
@@ -2375,20 +2398,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             Value::BOOLEAN(Config::MODIFIED_PIPELINE),
                             SetModifiedPipeline);
 #endif
-
-  // Add in config option for sort partition size
-  config.AddExtensionOption("max_sort_partition_bytes",
-                            "Maximum bytes per sort partition (0 = auto based on "
-                            "max_sort_partition_memory_fraction of GPU memory)",
-                            LogicalType::UBIGINT,
-                            Value::UBIGINT(operator_defaults.max_sort_partition_bytes),
-                            SetMaxSortPartitionBytes);
-  config.AddExtensionOption(
-    "max_sort_partition_memory_fraction",
-    "Fraction of available GPU memory per sort partition when max_sort_partition_bytes is 0",
-    LogicalType::DOUBLE,
-    Value::DOUBLE(operator_defaults.max_sort_partition_memory_fraction),
-    SetMaxSortPartitionMemoryFraction);
 
   // Logging configuration
   config.AddExtensionOption("sirius_log_backend",
@@ -2417,12 +2426,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             LogicalType::UBIGINT,
                             Value::UBIGINT(operator_defaults.hash_partition_bytes),
                             SetHashPartitionBytes);
-
-  config.AddExtensionOption("sort_sample_bytes",
-                            "Target bytes to sample before computing sort partition boundaries",
-                            LogicalType::UBIGINT,
-                            Value::UBIGINT(operator_defaults.sort_sample_bytes),
-                            SetSortSampleBytes);
 
   config.AddExtensionOption("max_build_hash_table_bytes",
                             "Maximum size a build-side table can be where it will create a "

--- a/test/cpp/config/data/invalid_sort_partition_fraction_zero.yaml
+++ b/test/cpp/config/data/invalid_sort_partition_fraction_zero.yaml
@@ -1,0 +1,5 @@
+sirius:
+  topology:
+    num_gpus: 1
+  operator_params:
+    max_sort_partition_memory_fraction: 0

--- a/test/cpp/config/test_config.cpp
+++ b/test/cpp/config/test_config.cpp
@@ -99,6 +99,52 @@ TEST_CASE("yaml reader validation with fraction", "[config_opt][conditional]")
   REQUIRE(f == 0.5);  // unchanged
 }
 
+TEST_CASE("yaml reader validation with positive fraction", "[config_opt][conditional]")
+{
+  SECTION("zero is rejected without mutation")
+  {
+    auto node = YAML::Load("f: 0");
+    double f  = 0.5;
+
+    yaml::reader r(node);
+    REQUIRE_THROWS_AS(r.optional("f", f, yaml::positive_fraction<double>{}), std::runtime_error);
+    REQUIRE(f == 0.5);
+  }
+
+  SECTION("one is accepted")
+  {
+    auto node = YAML::Load("f: 1.0");
+    double f  = 0.5;
+
+    yaml::reader r(node);
+    REQUIRE_NOTHROW(r.optional("f", f, yaml::positive_fraction<double>{}));
+    REQUIRE(f == 1.0);
+  }
+
+  SECTION("greater than one is rejected without mutation")
+  {
+    auto node = YAML::Load("f: 1.5");
+    double f  = 0.5;
+
+    yaml::reader r(node);
+    REQUIRE_THROWS_AS(r.optional("f", f, yaml::positive_fraction<double>{}), std::runtime_error);
+    REQUIRE(f == 0.5);
+  }
+
+  SECTION("non-finite values are rejected without mutation")
+  {
+    for (auto const* yaml_value : {".nan", ".inf", "-.inf"}) {
+      CAPTURE(yaml_value);
+      auto node = YAML::Load(std::string("f: ") + yaml_value);
+      double f  = 0.5;
+
+      yaml::reader r(node);
+      REQUIRE_THROWS_AS(r.optional("f", f, yaml::positive_fraction<double>{}), std::runtime_error);
+      REQUIRE(f == 0.5);
+    }
+  }
+}
+
 TEST_CASE("yaml reader byte suffix parsing", "[config_opt][bytes]")
 {
   SECTION("plain integers work with bytes()")

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -230,6 +230,9 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "fuse_merge_pipelines") == 0);
     REQUIRE(setting_count(con, "enable_runtime_distinct_build_probe") == 0);
     REQUIRE(setting_count(con, "concat_batch_bytes") == 0);
+    REQUIRE(setting_count(con, "max_sort_partition_memory_fraction") == 0);
+    REQUIRE(setting_count(con, "sort_sample_bytes") == 0);
+    REQUIRE(setting_count(con, "max_sort_partition_bytes") == 0);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
@@ -254,6 +257,15 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     result = con.Query("SET concat_batch_bytes = 1048576");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
+    result = con.Query("SET max_sort_partition_memory_fraction = 0.5");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET sort_sample_bytes = 1048576");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET max_sort_partition_bytes = 65536");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "true", 1);
@@ -268,6 +280,9 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "fuse_merge_pipelines") == 0);
     REQUIRE(setting_count(con, "enable_runtime_distinct_build_probe") == 0);
     REQUIRE(setting_count(con, "concat_batch_bytes") == 0);
+    REQUIRE(setting_count(con, "max_sort_partition_memory_fraction") == 0);
+    REQUIRE(setting_count(con, "sort_sample_bytes") == 0);
+    REQUIRE(setting_count(con, "max_sort_partition_bytes") == 0);
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
@@ -282,6 +297,9 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "fuse_merge_pipelines") == 1);
     REQUIRE(setting_count(con, "enable_runtime_distinct_build_probe") == 1);
     REQUIRE(setting_count(con, "concat_batch_bytes") == 1);
+    REQUIRE(setting_count(con, "max_sort_partition_memory_fraction") == 1);
+    REQUIRE(setting_count(con, "sort_sample_bytes") == 1);
+    REQUIRE(setting_count(con, "max_sort_partition_bytes") == 1);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
@@ -325,6 +343,24 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
     result = con.Query("RESET concat_batch_bytes");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET max_sort_partition_memory_fraction = 0.5");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET max_sort_partition_memory_fraction");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET sort_sample_bytes = 1048576");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET sort_sample_bytes");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET max_sort_partition_bytes = 65536");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET max_sort_partition_bytes");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
   }
@@ -614,6 +650,23 @@ TEST_CASE("Sirius configuration keeps task creation policy internal", "[sirius][
         Catch::Contains("removed") && Catch::Contains("remove this key"));
     CHECK(config.get_task_creator_config().priority == sirius::creator::priority_order::source);
   }
+}
+
+TEST_CASE("Sirius configuration rejects a zero automatic sort partition fraction",
+          "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const cfg =
+    fs::path(loc.file_name()).parent_path() / "data" / "invalid_sort_partition_fraction_zero.yaml";
+
+  sirius::sirius_config config;
+  auto const default_fraction = config.get_operator_params().max_sort_partition_memory_fraction;
+  REQUIRE(default_fraction == Approx(sirius::config::DEFAULT_MAX_SORT_PARTITION_MEMORY_FRACTION));
+  REQUIRE_THROWS_WITH(
+    config.load_from_file(cfg),
+    Catch::Contains("max_sort_partition_memory_fraction") && Catch::Contains("value out of range"));
+  REQUIRE(config.get_operator_params().max_sort_partition_memory_fraction ==
+          Approx(default_fraction));
 }
 
 namespace {
@@ -1061,6 +1114,24 @@ TEST_CASE("DuckDB setting rejects invalid compression retention fractions withou
   }
 }
 
+TEST_CASE(
+  "DuckDB setting rejects a zero automatic sort partition fraction without a Sirius context",
+  "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  auto result = con.Query("SET max_sort_partition_memory_fraction = 0");
+  REQUIRE(result != nullptr);
+  REQUIRE(result->HasError());
+  REQUIRE_THAT(result->GetError(),
+               Catch::Contains("max_sort_partition_memory_fraction must be finite") &&
+                 Catch::Contains("greater than 0.0"));
+}
+
 TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
           "[sirius][context][config][isolated_context]")
 {
@@ -1210,6 +1281,12 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
             Approx(0.6));
   }
 
+  auto zero_sort_fraction = con.Query("SET max_sort_partition_memory_fraction = 0");
+  REQUIRE(zero_sort_fraction != nullptr);
+  REQUIRE(zero_sort_fraction->HasError());
+  REQUIRE(sirius_ctx->get_config().get_operator_params().max_sort_partition_memory_fraction ==
+          Approx(0.25));
+
   auto const require_ok = [&con](std::string const& sql) {
     auto result = con.Query(sql);
     REQUIRE(result != nullptr);
@@ -1218,7 +1295,9 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
 
   require_ok("SET scan_task_batch_size = 99");
   require_ok("RESET scan_task_batch_size");
-  require_ok("SET max_sort_partition_memory_fraction = 0.9");
+  require_ok("SET max_sort_partition_memory_fraction = 1.0");
+  REQUIRE(sirius_ctx->get_config().get_operator_params().max_sort_partition_memory_fraction ==
+          Approx(1.0));
   require_ok("RESET max_sort_partition_memory_fraction");
   require_ok("SET enable_dynamic_filter_pushdown = true");
   require_ok("RESET enable_dynamic_filter_pushdown");


### PR DESCRIPTION
## August 20 current-dev repair (authoritative)

- tier: `judgment`
- exact base: `31043eb875c3bdbfa4b82770f2216b96dad2fa4b`
- exact head: `09cb24199043955ca49fef12e7211ce3f702724f`
- candidate tree: `5a9a372941aaa13cc183dced5d93016b76af548c`
- cumulative binary-diff SHA-256: `cd6c4f21143d17a8d5bc92c12314900ddd21a02c39b3ba0bded53fe38f77e21c`
- cumulative diff: 8 paths, 189 insertions, 33 deletions
- conflict resolution: retained both current-dev's task-creator policy regression and this PR's zero sort-fraction regression; production behavior merged without semantic conflict
- author review: complete full diff and range-diff review found only the expected test insertion-context movement
- local gates: `git fsck`, `git diff --check`, conflict-marker, YAML fixture/reference, CMake registration, positive-fraction definition/use, and internal-option visibility checks passed
- named external gate: hosted exact-head Linux/CUDA `Check`, `Test`, and `Distribution` workflows; owner Foxglove; terminal condition is every required non-skipped job passing before the PR returns to ready
- hosted status: terminal green on exact head — Check `32410131652` (lint, GCC release, Clang debug, aggregate), Test `32410131720` (CUDA 13 build, runtime job `96559574953`, aggregate), and Distribution `32410132184`; CUDA distribution leaves correctly skipped because distribution inputs did not change

The receipts below are retained as predecessor evidence and are not the authority for the current head.

## Current repair identity

- exact base: `cbd9516367b2d3160492c8cb0575208f1dce047c`
- exact head: `c469dbac5e7492a07bc9074b291a2be137e7131c`
- candidate tree: `691d3fd430cb68c1d3cce92e4aac702645f438a7`
- full-index binary diff SHA-256: `668e0196cf5e1531631b18b8f992a069f86c8b97b05417f36da67f981bfb98bf`
- current-dev conflict resolution preserves merged #1532 scan internalization and the complete sort-policy unit
- complete diff and independent cold review: clear
- clang-format, range/diff checks, and the finite `(0,1]` documentation contract: pass
- hosted exact-head Test run 32296570543 passed, including GPU runtime job 96210295627; Check, Distribution, lint, GCC, Clang, CUDA build, title validation, and every other non-skipped job passed

Foxglove has completed author-side review of this exact head and returned it to ready. The receipt below is preserved explicitly as predecessor evidence.

## Summary

- remove `sort_sample_bytes`, `sort_partition_bytes`, and `max_sort_partition_bytes` from normal DuckDB sessions
- preserve current automatic production defaults and sort behavior
- retain all three YAML values as expert diagnostic or benchmark envelopes
- retain direct `SET`/`RESET` only behind exact `SIRIUS_ENABLE_TEST_OPTIONS=1`

This removes three ordinary tuning choices without choosing new values or changing sort semantics.

## Evidence and scope

The source-derived census classified the sort-family values as internal policy controls rather than deployment choices. Automatic defaults remain authoritative; YAML stays available for bounded expert experiments. This PR changes exposure, not the numeric policy.

## August 18 predecessor identity

- exact base: `3e4d98cfb760c716540b8d4955a9de37d5acfa53`
- exact head: `e4e1796328441504f3ef8b2985ab5506b6ec76bc`
- candidate tree: `efe6993b0c8f3ebd899b7d1d7edceea48f7beed8`
- zero-context cumulative diff SHA-256: `aa89da29c9a0c6c775e7895caf08009c4bac10eb92edb67d408c5941d7c26279`
- cumulative diff: 8 paths, 184 insertions, 32 deletions

## Validation

- rebased onto current `dev` after #1494 and #1498 merged
- conflicts were adjacent test insertions in `test_context.cpp`; the additive
  resolution retains #1494 topology tests, #1498 YAML/isolated/live-context
  compression validation, and every #1537 sort-policy regression
- range-diff shows the expected insertion-context moves and one absorbed
  `#include <cmath>` now supplied by #1498; the eight-path behavioral patch is
  otherwise preserved
- automatic defaults remain `0` bytes plus `0.33` fraction; invalid fractions
  still fail before mutation, and valid/reset/YAML-backed behavior remains
  covered
- scoped pre-commit, direct `rumdl`, orphan-test detection, and
  `git diff --check` pass
- rebased exact-head hosted validation passed:
  - Check workflow `31915801295`: lint `95087295359`, GCC release
    `95087295417`, Clang debug `95087295484`, and aggregate `95087827367`
  - Distribution workflow `31915801607`: distribution `95087296417`
  - Test workflow `31915801273`: CUDA 13 build `95087334917`, runtime
    `95087678803`, and aggregate `95089852704`

### Retained predecessor hosted receipt

- pre-rebase head `f292b5e1353deef4062487f0ac17bc7e0f9c3448`:
  workflow `31754510252`, build `94627301080`, runtime `94627992637`, and
  aggregate `94631623760` passed
