### PR TITLE
refactor(config): simplify automatic join sizing

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -594,10 +594,7 @@ SET enable_compressed_materialization = false;
 |----------|---------|-------------|
 | `max_sort_partition_bytes` | 0 (auto) | Max sort partition bytes |
 | `max_sort_partition_memory_fraction` | 0.33 | Auto sort-partition fraction when `max_sort_partition_bytes` is 0 |
-| `hash_partition_bytes` | Shared physical/effective GPU batch default | Hash partition target size; must be greater than zero |
 | `sort_sample_bytes` | Shared physical/effective GPU batch default | Bytes sampled before computing sort boundaries |
-| `max_build_hash_table_bytes` | 2× batch default | Max build-side hash table bytes |
-| `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join |
 | `mark_join_build_switch_ratio` | 8.0 | STANDARD MARK join build-side switch ratio (0 disables) |
 
 Eligible GROUP BY and TOP_N merge pipelines are fused automatically. This is an engine-owned plan
@@ -623,6 +620,19 @@ is YAML-only — it is read once when the GPU memory spaces are configured.
 ```sql
 SET admission_bytes_per_gpu = 34359738368;  -- 32 GiB
 ```
+
+The BUILD_PROBE admission threshold is derived as twice the effective-capacity
+batch default. Advanced diagnostic and benchmark envelopes may still override
+`max_build_hash_table_bytes` in YAML under `sirius.operator_params`, but it is
+not a normal session setting.
+
+Hash partition sizing uses the shared physical/effective GPU batch default.
+Its YAML operator parameter remains an expert benchmark envelope; the direct
+DuckDB session override is test-only.
+
+The multi-GPU broadcast-join size threshold defaults to 256 MiB. Its YAML
+operator parameter remains an expert multi-GPU calibration envelope; the
+direct DuckDB session override is test-only.
 
 ### Dynamic Filters
 

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -16,7 +16,11 @@ num_partitions = max(1, ceil(total_bytes / hash_partition_bytes))
 
 **Code path:** `src/op/sirius_physical_partition.cpp` — `determine_num_partitions()`
 
-**Config:** `hash_partition_bytes` (default: 512 MB)
+**Config:** the hash partition target uses the shared
+physical/effective-capacity-derived operator batch default. The advanced YAML
+escape hatch `sirius.operator_params.hash_partition_bytes` remains available
+for a controlled partition benchmark. The direct DuckDB session override is
+test-only.
 
 ### Drain and Restart Task Creator (PR #479)
 
@@ -95,7 +99,7 @@ In BUILD_PROBE mode, each partition's first task builds a `cudf::hash_join` hash
 
 **Code path:** `src/op/sirius_physical_hash_join.cpp` — `compute_hash_join_partition_strategy()`, `get_partition_strategy()`; `src/op/sirius_physical_partition.cpp` — broadcast slot routing
 
-**Config:** `max_build_hash_table_bytes` (default: 500 MB)
+**Config:** `max_build_hash_table_bytes` (default: 2× the shared physical/effective GPU batch default)
 
 ### COUNT DISTINCT Optimization (PR #414)
 
@@ -139,7 +143,7 @@ Only applies to INNER and LEFT joins with pure equality conditions (excludes IS 
 
 **Code path:** `src/creator/task_creator.cpp` — `manager_loop()`, `src/pipeline/task_scheduler.cpp` — `schedule_next_scan_tasks()`
 
-**Config:** `max_build_hash_table_bytes` (default: 500 MB) — now independent from `concat_batch_bytes`, enabling larger build sides in BUILD_PROBE mode without affecting other joins.
+**Config:** `max_build_hash_table_bytes` (default: 2× the shared physical/effective GPU batch default). Its advanced YAML override remains independent from `concat_batch_bytes`, enabling a larger BUILD_PROBE envelope without changing CONCAT behavior.
 
 ### Zero-Copy Projection Passthrough (PR #991)
 

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2357,6 +2357,27 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                     LogicalType::UBIGINT,
                     Value::UBIGINT(operator_defaults.concat_batch_bytes),
                     SetConcatBatchBytes);
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "max_build_hash_table_bytes",
+                    "override the internally derived BUILD_PROBE threshold",
+                    LogicalType::UBIGINT,
+                    Value::UBIGINT(operator_defaults.max_build_hash_table_bytes),
+                    SetMaxBuildHashTableBytes);
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "hash_partition_bytes",
+                    "override the effective-capacity-derived hash partition size",
+                    LogicalType::UBIGINT,
+                    Value::UBIGINT(operator_defaults.hash_partition_bytes),
+                    SetHashPartitionBytes);
+  add_sirius_option(config,
+                    option_visibility::internal,
+                    "max_broadcast_join_size",
+                    "override the multi-GPU broadcast-join size threshold",
+                    LogicalType::UBIGINT,
+                    Value::UBIGINT(operator_defaults.max_broadcast_join_size),
+                    SetMaxBroadcastJoinSize);
 
   // Add in config options for special JIT implementation for regex
   add_sirius_option(config,
@@ -2412,32 +2433,11 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             Value::INTEGER(Config::LOG_FLUSH_SECONDS),
                             SetLogFlushSeconds);
 
-  config.AddExtensionOption("hash_partition_bytes",
-                            "Target size in bytes per hash partition",
-                            LogicalType::UBIGINT,
-                            Value::UBIGINT(operator_defaults.hash_partition_bytes),
-                            SetHashPartitionBytes);
-
   config.AddExtensionOption("sort_sample_bytes",
                             "Target bytes to sample before computing sort partition boundaries",
                             LogicalType::UBIGINT,
                             Value::UBIGINT(operator_defaults.sort_sample_bytes),
                             SetSortSampleBytes);
-
-  config.AddExtensionOption("max_build_hash_table_bytes",
-                            "Maximum size a build-side table can be where it will create a "
-                            "reusable hash table for hash joins (i.e. BUILD_PROBE mode)",
-                            LogicalType::UBIGINT,
-                            Value::UBIGINT(operator_defaults.max_build_hash_table_bytes),
-                            SetMaxBuildHashTableBytes);
-
-  config.AddExtensionOption("max_broadcast_join_size",
-                            "Maximum build-side size in bytes for a broadcast join, where the "
-                            "(small) build table is replicated to every GPU instead of "
-                            "hash-partitioned across GPUs",
-                            LogicalType::UBIGINT,
-                            Value::UBIGINT(operator_defaults.max_broadcast_join_size),
-                            SetMaxBroadcastJoinSize);
 
   config.AddExtensionOption(
     "mark_join_build_switch_ratio",

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -230,7 +230,19 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "fuse_merge_pipelines") == 0);
     REQUIRE(setting_count(con, "enable_runtime_distinct_build_probe") == 0);
     REQUIRE(setting_count(con, "concat_batch_bytes") == 0);
+    REQUIRE(setting_count(con, "max_build_hash_table_bytes") == 0);
+    REQUIRE(setting_count(con, "hash_partition_bytes") == 0);
+    REQUIRE(setting_count(con, "max_broadcast_join_size") == 0);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET max_build_hash_table_bytes = 1048576");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET hash_partition_bytes = 1048576");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET max_broadcast_join_size = 1048576");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
     result = con.Query("SET enable_pinned_zone_map_pruning = false");
@@ -268,6 +280,9 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "fuse_merge_pipelines") == 0);
     REQUIRE(setting_count(con, "enable_runtime_distinct_build_probe") == 0);
     REQUIRE(setting_count(con, "concat_batch_bytes") == 0);
+    REQUIRE(setting_count(con, "max_build_hash_table_bytes") == 0);
+    REQUIRE(setting_count(con, "hash_partition_bytes") == 0);
+    REQUIRE(setting_count(con, "max_broadcast_join_size") == 0);
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
@@ -282,7 +297,28 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "fuse_merge_pipelines") == 1);
     REQUIRE(setting_count(con, "enable_runtime_distinct_build_probe") == 1);
     REQUIRE(setting_count(con, "concat_batch_bytes") == 1);
+    REQUIRE(setting_count(con, "max_build_hash_table_bytes") == 1);
+    REQUIRE(setting_count(con, "hash_partition_bytes") == 1);
+    REQUIRE(setting_count(con, "max_broadcast_join_size") == 1);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET max_build_hash_table_bytes = 1048576");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET max_build_hash_table_bytes");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET hash_partition_bytes = 1048576");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET hash_partition_bytes");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET max_broadcast_join_size = 1048576");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET max_broadcast_join_size");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
     result = con.Query("SET enable_pinned_zone_map_pruning = false");


### PR DESCRIPTION
## Current repair identity

- exact base: `cbd9516367b2d3160492c8cb0575208f1dce047c`
- exact head: `b37fff0509dbb90f631675b46418620c383044ff`
- candidate tree: `fe7f0ad86bc57f97e9fe6452a0f54f65492213c6`
- full-index binary diff SHA-256: `086a9beedbf54d930c51d4ea8ab11b044939e76ec181aca1c726ef4a59ed8554`
- current-dev conflict resolution preserves merged #1532 scan internalization and the complete join-sizing surface unit
- complete diff and independent cold review: clear
- clang-format, range/diff checks, and both effective-capacity-derived default documentation checks: pass
- hosted exact-head Test run 32296594344 passed, including GPU runtime job 96210320065; Check, Distribution, lint, GCC, Clang, CUDA build, title validation, and every other non-skipped job passed

Foxglove has completed author-side review of this exact head and returned it to ready. The receipt below is preserved explicitly as predecessor evidence.

## Review focus

**Tier:** judgment — configuration-surface policy; join behavior and numeric
defaults are unchanged by this PR.

**Maintainer question:** Should automatic join sizing remain available through
expert YAML/test envelopes while disappearing from ordinary DuckDB sessions?

**Main risk:** existing scripts that directly `SET` these implementation
controls must use the retained YAML envelope or exact test opt-in instead.

## Summary

- remove `max_build_hash_table_bytes`, `hash_partition_bytes`, and
  `max_broadcast_join_size` from normal DuckDB sessions
- preserve their current automatic production defaults and join behavior
- retain all three YAML operator parameters as expert diagnostic, benchmark,
  or multi-GPU calibration envelopes
- retain direct `SET`/`RESET` only behind exact
  `SIRIUS_ENABLE_TEST_OPTIONS=1`

This removes three ordinary tuning choices without choosing a new number or
changing BUILD_PROBE, partition-count, or broadcast-eligibility semantics.

## Relationship to #1595

#1595 is a separate behavioral repair: it changes BUILD_PROBE admission from
one payload bound to independent estimated-table and resident-payload bounds,
changes the `max_build_hash_table_bytes` meaning/default, and introduces
`max_build_probe_resident_bytes`. This PR changes only who may directly set the
existing controls; the two product judgments should remain independently
reviewable.

The clean sequence is this surface-policy PR first, then #1595 rebased onto it.
During that rebase, #1595's new `max_build_probe_resident_bytes` must either
follow this policy (expert YAML plus exact test opt-in, not a normal session
choice) or explicitly justify why that new engine-owned capacity bound is a
user decision. If #1595 lands first instead, return this PR to draft and rebase
it to include the new control before offering the surface-policy unit again.

No code change is needed on this head because
`max_build_probe_resident_bytes` does not exist in current `dev`; importing
#1595's unmerged behavior into this PR would combine two independent product
judgments and duplicate its repair work.

## Evidence and scope

The 30-cell capped-pressure ladder crossed the BUILD_PROBE admission boundary
exactly with a maximum admissible median-runtime effect of 3.45%, below its 10%
gate. The hash-partition screen forced source-predicted partition counts across
0.5x, 1x, and 2x pressure; smaller targets did not produce relief and one
2x-pressure repetition lost feasibility. Those bounded findings support
omitting the ordinary controls, not a universal numeric optimum.

The 256 MiB broadcast threshold remains a multi-GPU calibration question.
Existing pure-decision tests retain its size, ratio, GPU-scaling, join-family,
and forced-MARK boundary coverage. Its YAML envelope remains available.

## August 18 predecessor identity

- recorded base: `e885ffea7d0541f1e3493566e2db0ed6e431106f`
- exact head: `2d740f805644fbfdfcdaeec28743a8e5e87ab43f`
- tree: `85f5aaa01633d0fcf901237b9b2dcc7ec5d7b52a`
- `git diff --binary --full-index BASE...HEAD` SHA-256:
  `204fa55b7cbd04f90e3a445069001a88817c3d31c54ae298fd7adab4da5465b3`
- live `dev` during final author review:
  `34311516f1233c1f4aca4d16b0a7bf190fa197f9`; GitHub reports the PR
  mergeable, so no base-only churn was introduced

## August 18 predecessor validation and author readiness

- complete exact-head four-path diff reread: coherent surface-policy unit
- live same-boundary search and full #1595 comparison: relationship and
  sequence recorded above
- no reviews or unresolved review threads
- `python3 scripts/check_orphan_tests.py`: pass on the candidate receipt
- `git diff --check`: pass on the candidate receipt
- exact-head required checks are terminal green:
  - Check workflow `31753992658`
  - Distribution workflow `31753993276`
  - Test workflow `31753992674` (CUDA 13 build/runtime, TPC-H snapshot, and
    terminal aggregate)

Foxglove's final author-side review was recorded under active actor
`abelatnvidia` against exact unchanged head
`2d740f805644fbfdfcdaeec28743a8e5e87ab43f` on 2026-08-18. Review priority is
tracked separately from this author-readiness state.

Supersedes the narrower predecessor #1533.
