### PR TITLE
fix(config): require disk spill mount paths

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -219,7 +219,7 @@ Each tier is a **YAML sequence** of space configs. Byte fields accept suffixes; 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `disk_id` | int | 0 | Identifier for the disk space. |
-| `mount_path` | string | "" | Spill directory. |
+| `mount_path` | string | required | Non-empty spill directory. |
 | `memory_capacity` | bytes | space default | Maximum disk space for spill files. |
 
 ```yaml

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -128,11 +128,14 @@ static void from_yaml(const YAML::Node& node, cucascade::memory::host_memory_spa
 
 static void from_yaml(const YAML::Node& node, cucascade::memory::disk_memory_space_config& opt)
 {
-  yaml::reader r(node, "disk_memory_space");
+  yaml::reader r(node, "sirius.space.disk");
   r.optional("disk_id", opt.disk_id);
-  r.optional("mount_path", opt.mount_paths);
+  r.required("mount_path", opt.mount_paths);
   r.optional("memory_capacity", yaml::bytes(opt.memory_capacity));
   r.reject_unknown();
+  if (opt.mount_paths.empty()) {
+    throw std::runtime_error("sirius.space.disk: mount_path must not be empty");
+  }
 }
 
 static void from_yaml(const YAML::Node& node, exec::thread_pool_config& opt)

--- a/test/cpp/config/data/invalid_space_disk_mount_path_empty.yaml
+++ b/test/cpp/config/data/invalid_space_disk_mount_path_empty.yaml
@@ -1,0 +1,6 @@
+sirius:
+  space:
+    disk:
+      - disk_id: 0
+        mount_path: ""
+        memory_capacity: 1Gi

--- a/test/cpp/config/data/invalid_space_disk_mount_path_missing.yaml
+++ b/test/cpp/config/data/invalid_space_disk_mount_path_missing.yaml
@@ -1,0 +1,5 @@
+sirius:
+  space:
+    disk:
+      - disk_id: 0
+        memory_capacity: 1Gi

--- a/test/cpp/config/data/invalid_space_disk_mount_path_null.yaml
+++ b/test/cpp/config/data/invalid_space_disk_mount_path_null.yaml
@@ -1,0 +1,6 @@
+sirius:
+  space:
+    disk:
+      - disk_id: 0
+        mount_path: null
+        memory_capacity: 1Gi

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -560,6 +560,30 @@ TEST_CASE("Sirius configuration rejects invalid downgrade hysteresis", "[sirius]
   }
 }
 
+TEST_CASE("Sirius configuration requires a non-empty low-level disk mount path", "[sirius][config]")
+{
+  struct invalid_config {
+    const char* fixture;
+    const char* constraint;
+  };
+
+  const invalid_config cases[] = {
+    {"invalid_space_disk_mount_path_missing.yaml", "required but missing"},
+    {"invalid_space_disk_mount_path_null.yaml", "required but missing"},
+    {"invalid_space_disk_mount_path_empty.yaml", "must not be empty"},
+  };
+
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+  for (auto const& invalid : cases) {
+    INFO("fixture=" << invalid.fixture << " constraint=" << invalid.constraint);
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(config.load_from_file(data_dir / invalid.fixture),
+                        Catch::Contains("sirius.space.disk") && Catch::Contains("mount_path") &&
+                          Catch::Contains(invalid.constraint));
+  }
+}
+
 TEST_CASE("Sirius downgrade hysteresis accepts omitted, null, and one-sided defaults",
           "[sirius][config]")
 {


### PR DESCRIPTION
## Summary

- reject low-level `sirius.space.disk[]` entries that omit or null `mount_path` during YAML loading
- reject an explicitly empty mount path before allocator construction
- document the spill path as required and non-empty

## Why

The low-level `sirius.space.*` surface is an intentional expert replacement API, so this leaves the surface intact. A disk-space entry is nevertheless unusable without a mount path: `cucascade::memory::memory_space` already throws for an empty path, but the YAML loader currently accepts the invalid state and defers the error until allocator construction. This moves the existing invariant to the user-facing configuration boundary.

## Validation

- regression fixtures cover omitted, null, and empty `mount_path`
- the existing `spaces.yaml` configuration test remains the positive path
- applicable pre-commit hooks pass (the repository rumdl hook could not launch because local `pixi` is unavailable)
- direct `rumdl 0.2.44` passes
- `git diff --check` passes

Base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`
- fresh exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full runtime, and terminal aggregate checks: pass
- hosted workflow [31722321301](https://github.com/sirius-db/sirius/actions/runs/31722321301): runtime job `94523031030` passed in 20m07s; aggregate job `94533693742` passed

