### PR TITLE
fix(config): validate low-level GPU device ids

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -194,7 +194,7 @@ Each tier is a **YAML sequence** of space configs. Byte fields accept suffixes; 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `device_id` | int | 0 | CUDA device the space lives on. |
+| `device_id` | non-negative int | required | CUDA device the space lives on. |
 | `per_stream_reservation` | bool | false | Track reservations per CUDA stream (forced false unless set). |
 | `reservation_limit_fraction` | double [0,1] | space default | Fraction of the space that may be reserved. |
 | `downgrade_trigger_fraction` | double (0,1] | space default | Start evicting above this fraction. Must be greater than `downgrade_stop_fraction`. |

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -201,6 +201,8 @@ Each tier is a **YAML sequence** of space configs. Byte fields accept suffixes; 
 | `downgrade_stop_fraction` | double (0,1] | space default | Stop evicting below this fraction. Must be less than `downgrade_trigger_fraction`. |
 | `memory_capacity` | bytes | space default | Absolute capacity of the space. |
 
+Every explicit `device_id` must be present in Sirius's discovered GPU topology.
+
 #### `sirius.space.host[]` — one entry per host (pinned) memory space
 
 | Key | Type | Default | Description |

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -94,8 +94,8 @@ static void validate_downgrade_fractions(std::string_view scope, double trigger,
 static void from_yaml(const YAML::Node& node, cucascade::memory::gpu_memory_space_config& opt)
 {
   opt.per_stream_reservation = false;  // default to false for sirius
-  yaml::reader r(node, "gpu_memory_space");
-  r.optional("device_id", opt.device_id);
+  yaml::reader r(node, "sirius.space.gpu");
+  r.required("device_id", opt.device_id);
   r.optional("per_stream_reservation", opt.per_stream_reservation);
   r.optional(
     "reservation_limit_fraction", opt.reservation_limit_fraction, yaml::fraction<double>{});
@@ -104,6 +104,9 @@ static void from_yaml(const YAML::Node& node, cucascade::memory::gpu_memory_spac
   r.optional("downgrade_stop_fraction", opt.downgrade_stop_fraction, yaml::fraction<double>{});
   r.optional("memory_capacity", yaml::bytes(opt.memory_capacity));
   r.reject_unknown();
+  if (opt.device_id < 0) {
+    throw std::runtime_error("sirius.space.gpu: device_id must be non-negative");
+  }
   validate_downgrade_fractions(
     "sirius.space.gpu", opt.downgrade_trigger_fraction, opt.downgrade_stop_fraction);
 }

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -27,6 +27,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <exception>
 #include <limits>
 #include <stdexcept>
@@ -670,6 +671,15 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
     if (high_level_memory_configured && explicit_space_configured) {
       throw std::runtime_error(
         "sirius.memory and non-empty sirius.space lists are mutually exclusive");
+    }
+    for (auto const& gpu : gpu_space_configs) {
+      auto const discovered = std::ranges::any_of(_hw_topology.gpus, [&](auto const& info) {
+        return static_cast<int64_t>(info.id) == static_cast<int64_t>(gpu.device_id);
+      });
+      if (!discovered) {
+        throw std::runtime_error("sirius.space.gpu: device_id " + std::to_string(gpu.device_id) +
+                                 " is not present in the discovered GPU topology");
+      }
     }
 
     r.reject_unknown();

--- a/test/cpp/config/data/invalid_space_gpu_device_id_missing.yaml
+++ b/test/cpp/config/data/invalid_space_gpu_device_id_missing.yaml
@@ -1,0 +1,4 @@
+sirius:
+  space:
+    gpu:
+      - memory_capacity: 1Gi

--- a/test/cpp/config/data/invalid_space_gpu_device_id_negative.yaml
+++ b/test/cpp/config/data/invalid_space_gpu_device_id_negative.yaml
@@ -1,0 +1,5 @@
+sirius:
+  space:
+    gpu:
+      - device_id: -1
+        memory_capacity: 1Gi

--- a/test/cpp/config/data/invalid_space_gpu_device_id_null.yaml
+++ b/test/cpp/config/data/invalid_space_gpu_device_id_null.yaml
@@ -1,0 +1,5 @@
+sirius:
+  space:
+    gpu:
+      - device_id: null
+        memory_capacity: 1Gi

--- a/test/cpp/config/data/invalid_space_gpu_unknown_device_id.yaml
+++ b/test/cpp/config/data/invalid_space_gpu_unknown_device_id.yaml
@@ -1,0 +1,5 @@
+sirius:
+  space:
+    gpu:
+      - device_id: 2147483647
+        memory_capacity: 1Gi

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -881,6 +881,18 @@ TEST_CASE("Sirius configuration loading from file with spaces",
   REQUIRE(manager.get_all_memory_spaces().size() == 4);
 }
 
+TEST_CASE("Sirius configuration rejects low-level GPU ids outside discovered topology",
+          "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const path =
+    fs::path(loc.file_name()).parent_path() / "data" / "invalid_space_gpu_unknown_device_id.yaml";
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(config.load_from_file(path),
+                      Catch::Contains("sirius.space.gpu") && Catch::Contains("device_id") &&
+                        Catch::Contains("not present in the discovered GPU topology"));
+}
+
 TEST_CASE("Sirius configuration rejects competing memory configuration paths", "[sirius][config]")
 {
   std::source_location loc = std::source_location::current();

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -560,6 +560,30 @@ TEST_CASE("Sirius configuration rejects invalid downgrade hysteresis", "[sirius]
   }
 }
 
+TEST_CASE("Sirius configuration requires a valid low-level GPU device id", "[sirius][config]")
+{
+  struct invalid_config {
+    const char* fixture;
+    const char* constraint;
+  };
+
+  const invalid_config cases[] = {
+    {"invalid_space_gpu_device_id_missing.yaml", "required but missing"},
+    {"invalid_space_gpu_device_id_null.yaml", "required but missing"},
+    {"invalid_space_gpu_device_id_negative.yaml", "must be non-negative"},
+  };
+
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+  for (auto const& invalid : cases) {
+    INFO("fixture=" << invalid.fixture << " constraint=" << invalid.constraint);
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(config.load_from_file(data_dir / invalid.fixture),
+                        Catch::Contains("sirius.space.gpu") && Catch::Contains("device_id") &&
+                          Catch::Contains(invalid.constraint));
+  }
+}
+
 TEST_CASE("Sirius downgrade hysteresis accepts omitted, null, and one-sided defaults",
           "[sirius][config]")
 {


### PR DESCRIPTION
## Summary

- require each expert `sirius.space.gpu[]` entry to select a CUDA device explicitly
- reject negative low-level GPU device IDs during YAML loading
- reject IDs absent from Sirius's discovered GPU topology before allocator construction
- document the complete explicit-ID contract and add omitted/null/negative/unknown regressions

## Why

The low-level `sirius.space.*` surface remains an intentional expert replacement API. Its `gpu_memory_space_config` default is `-1`, however, and the low-level path copies entries directly into allocator construction, where `memory_space` passes `device_id` to `rmm::cuda_set_device_raii`. Omitted, negative, and non-negative-but-unavailable IDs therefore survive configuration loading and fail later as CUDA-device errors. This moves the complete device-selection invariant to the user-facing configuration boundary without changing high-level topology selection.

## Validation

- regression fixtures cover omitted, null, negative, and deterministically unavailable `device_id`
- existing `spaces.yaml` remains the positive explicit discovered-device path
- applicable pre-commit hooks pass (repository rumdl hook cannot launch locally because `pixi` is unavailable)
- direct `rumdl 0.2.44` passes
- `git diff --check` passes

Base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`

- fresh exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full runtime, and terminal aggregate checks: pass
- hosted workflow 31723114178: runtime job 94525886838 passed in 20m55s; aggregate job 94538376690 passed
