### PR TITLE
fix(config): validate low-level memory spaces

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -206,23 +206,26 @@ members retain their surface defaults before the pair is validated.
 > `capacity_bytes`), and the GPU/host tiers key on `device_id` / `numa_id`.
 
 Each tier is a **YAML sequence** of space configs. Byte fields accept suffixes; fractions are `[0,1]`.
+Within a tier, `device_id`, `numa_id`, and `disk_id` must identify each space uniquely.
 
 #### `sirius.space.gpu[]` — one entry per GPU memory space
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `device_id` | int | 0 | CUDA device the space lives on. |
+| `device_id` | non-negative int | required | CUDA device the space lives on. |
 | `per_stream_reservation` | bool | false | Track reservations per CUDA stream (forced false unless set). |
 | `reservation_limit_fraction` | double [0,1] | space default | Fraction of the space that may be reserved. |
 | `downgrade_trigger_fraction` | double (0,1] | space default | Start evicting above this fraction. Must be greater than `downgrade_stop_fraction`. |
 | `downgrade_stop_fraction` | double (0,1] | space default | Stop evicting below this fraction. Must be less than `downgrade_trigger_fraction`. |
 | `memory_capacity` | bytes | space default | Absolute capacity of the space. |
 
+Every explicit `device_id` must be present in Sirius's discovered GPU topology.
+
 #### `sirius.space.host[]` — one entry per host (pinned) memory space
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `numa_id` | int | 0 | NUMA node the pinned pool is bound to. |
+| `numa_id` | int (>= -1) | -1 | NUMA node the pinned pool is bound to; -1 leaves it unbound. |
 | `reservation_limit_fraction` | double [0,1] | space default | Fraction of the space that may be reserved. |
 | `downgrade_trigger_fraction` | double (0,1] | space default | Start evicting above this fraction. Must be greater than `downgrade_stop_fraction`. |
 | `downgrade_stop_fraction` | double (0,1] | space default | Stop evicting below this fraction. Must be less than `downgrade_trigger_fraction`. |
@@ -236,7 +239,7 @@ Each tier is a **YAML sequence** of space configs. Byte fields accept suffixes; 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `disk_id` | int | 0 | Identifier for the disk space. |
-| `mount_path` | string | "" | Spill directory. |
+| `mount_path` | string | required | Non-empty spill directory. |
 | `memory_capacity` | bytes | space default | Maximum disk space for spill files. |
 
 ```yaml

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <exception>
 #include <limits>
 #include <stdexcept>
@@ -95,8 +96,8 @@ static void validate_downgrade_fractions(std::string_view scope, double trigger,
 static void from_yaml(const YAML::Node& node, cucascade::memory::gpu_memory_space_config& opt)
 {
   opt.per_stream_reservation = false;  // default to false for sirius
-  yaml::reader r(node, "gpu_memory_space");
-  r.optional("device_id", opt.device_id);
+  yaml::reader r(node, "sirius.space.gpu");
+  r.required("device_id", opt.device_id);
   r.optional("per_stream_reservation", opt.per_stream_reservation);
   r.optional(
     "reservation_limit_fraction", opt.reservation_limit_fraction, yaml::fraction<double>{});
@@ -105,13 +106,16 @@ static void from_yaml(const YAML::Node& node, cucascade::memory::gpu_memory_spac
   r.optional("downgrade_stop_fraction", opt.downgrade_stop_fraction, yaml::fraction<double>{});
   r.optional("memory_capacity", yaml::bytes(opt.memory_capacity));
   r.reject_unknown();
+  if (opt.device_id < 0) {
+    throw std::runtime_error("sirius.space.gpu: device_id must be non-negative");
+  }
   validate_downgrade_fractions(
     "sirius.space.gpu", opt.downgrade_trigger_fraction, opt.downgrade_stop_fraction);
 }
 
 static void from_yaml(const YAML::Node& node, cucascade::memory::host_memory_space_config& opt)
 {
-  yaml::reader r(node, "host_memory_space");
+  yaml::reader r(node, "sirius.space.host");
   r.optional("numa_id", opt.numa_id);
   r.optional(
     "reservation_limit_fraction", opt.reservation_limit_fraction, yaml::fraction<double>{});
@@ -123,17 +127,39 @@ static void from_yaml(const YAML::Node& node, cucascade::memory::host_memory_spa
   r.optional("pool_size", opt.pool_size);
   r.optional("initial_number_pools", opt.initial_number_pools);
   r.reject_unknown();
+  if (opt.numa_id < -1) {
+    throw std::runtime_error("sirius.space.host: numa_id must be -1 or non-negative");
+  }
   validate_downgrade_fractions(
     "sirius.space.host", opt.downgrade_trigger_fraction, opt.downgrade_stop_fraction);
 }
 
 static void from_yaml(const YAML::Node& node, cucascade::memory::disk_memory_space_config& opt)
 {
-  yaml::reader r(node, "disk_memory_space");
+  yaml::reader r(node, "sirius.space.disk");
   r.optional("disk_id", opt.disk_id);
-  r.optional("mount_path", opt.mount_paths);
+  r.required("mount_path", opt.mount_paths);
   r.optional("memory_capacity", yaml::bytes(opt.memory_capacity));
   r.reject_unknown();
+  if (opt.mount_paths.empty()) {
+    throw std::runtime_error("sirius.space.disk: mount_path must not be empty");
+  }
+}
+
+template <typename Config, typename IdOf>
+static void reject_duplicate_space_ids(std::string_view scope,
+                                       std::string_view id_name,
+                                       const std::vector<Config>& configs,
+                                       IdOf id_of)
+{
+  for (auto current = configs.begin(); current != configs.end(); ++current) {
+    for (auto prior = configs.begin(); prior != current; ++prior) {
+      if (id_of(*prior) == id_of(*current)) {
+        throw std::runtime_error(std::string(scope) + ": duplicate " + std::string(id_name) + " " +
+                                 std::to_string(id_of(*current)));
+      }
+    }
+  }
 }
 
 static void from_yaml(const YAML::Node& node, exec::thread_pool_config& opt)
@@ -679,11 +705,33 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
       sr.reject_unknown();
     }
 
+    reject_duplicate_space_ids(
+      "sirius.space.gpu", "device_id", gpu_space_configs, [](auto const& cfg) {
+        return cfg.device_id;
+      });
+    reject_duplicate_space_ids(
+      "sirius.space.host", "numa_id", host_space_configs, [](auto const& cfg) {
+        return cfg.numa_id;
+      });
+    reject_duplicate_space_ids(
+      "sirius.space.disk", "disk_id", disk_space_configs, [](auto const& cfg) {
+        return cfg.disk_id;
+      });
+
     bool const explicit_space_configured =
       !gpu_space_configs.empty() || !host_space_configs.empty() || !disk_space_configs.empty();
     if (high_level_memory_configured && explicit_space_configured) {
       throw std::runtime_error(
         "sirius.memory and non-empty sirius.space lists are mutually exclusive");
+    }
+    for (auto const& gpu : gpu_space_configs) {
+      auto const discovered = std::ranges::any_of(_hw_topology.gpus, [&](auto const& info) {
+        return static_cast<int64_t>(info.id) == static_cast<int64_t>(gpu.device_id);
+      });
+      if (!discovered) {
+        throw std::runtime_error("sirius.space.gpu: device_id " + std::to_string(gpu.device_id) +
+                                 " is not present in the discovered GPU topology");
+      }
     }
 
     r.reject_unknown();

--- a/test/cpp/config/data/invalid_space_disk_mount_path_empty.yaml
+++ b/test/cpp/config/data/invalid_space_disk_mount_path_empty.yaml
@@ -1,0 +1,6 @@
+sirius:
+  space:
+    disk:
+      - disk_id: 0
+        mount_path: ""
+        memory_capacity: 1Gi

--- a/test/cpp/config/data/invalid_space_disk_mount_path_missing.yaml
+++ b/test/cpp/config/data/invalid_space_disk_mount_path_missing.yaml
@@ -1,0 +1,5 @@
+sirius:
+  space:
+    disk:
+      - disk_id: 0
+        memory_capacity: 1Gi

--- a/test/cpp/config/data/invalid_space_disk_mount_path_null.yaml
+++ b/test/cpp/config/data/invalid_space_disk_mount_path_null.yaml
@@ -1,0 +1,6 @@
+sirius:
+  space:
+    disk:
+      - disk_id: 0
+        mount_path: null
+        memory_capacity: 1Gi

--- a/test/cpp/config/data/invalid_space_duplicate_default_host_id.yaml
+++ b/test/cpp/config/data/invalid_space_duplicate_default_host_id.yaml
@@ -1,0 +1,6 @@
+sirius:
+  space:
+    host:
+      - memory_capacity: 1Gi
+      - numa_id: -1
+        memory_capacity: 2Gi

--- a/test/cpp/config/data/invalid_space_duplicate_disk_id.yaml
+++ b/test/cpp/config/data/invalid_space_duplicate_disk_id.yaml
@@ -1,0 +1,9 @@
+sirius:
+  space:
+    disk:
+      - disk_id: 0
+        mount_path: /tmp/sirius-disk-0
+        memory_capacity: 1Gi
+      - disk_id: 0
+        mount_path: /tmp/sirius-disk-1
+        memory_capacity: 2Gi

--- a/test/cpp/config/data/invalid_space_duplicate_gpu_id.yaml
+++ b/test/cpp/config/data/invalid_space_duplicate_gpu_id.yaml
@@ -1,0 +1,7 @@
+sirius:
+  space:
+    gpu:
+      - device_id: 0
+        memory_capacity: 1Gi
+      - device_id: 0
+        memory_capacity: 2Gi

--- a/test/cpp/config/data/invalid_space_duplicate_host_id.yaml
+++ b/test/cpp/config/data/invalid_space_duplicate_host_id.yaml
@@ -1,0 +1,7 @@
+sirius:
+  space:
+    host:
+      - numa_id: 0
+        memory_capacity: 1Gi
+      - numa_id: 0
+        memory_capacity: 2Gi

--- a/test/cpp/config/data/invalid_space_gpu_device_id_missing.yaml
+++ b/test/cpp/config/data/invalid_space_gpu_device_id_missing.yaml
@@ -1,0 +1,4 @@
+sirius:
+  space:
+    gpu:
+      - memory_capacity: 1Gi

--- a/test/cpp/config/data/invalid_space_gpu_device_id_negative.yaml
+++ b/test/cpp/config/data/invalid_space_gpu_device_id_negative.yaml
@@ -1,0 +1,5 @@
+sirius:
+  space:
+    gpu:
+      - device_id: -1
+        memory_capacity: 1Gi

--- a/test/cpp/config/data/invalid_space_gpu_device_id_null.yaml
+++ b/test/cpp/config/data/invalid_space_gpu_device_id_null.yaml
@@ -1,0 +1,5 @@
+sirius:
+  space:
+    gpu:
+      - device_id: null
+        memory_capacity: 1Gi

--- a/test/cpp/config/data/invalid_space_gpu_unknown_device_id.yaml
+++ b/test/cpp/config/data/invalid_space_gpu_unknown_device_id.yaml
@@ -1,0 +1,5 @@
+sirius:
+  space:
+    gpu:
+      - device_id: 2147483647
+        memory_capacity: 1Gi

--- a/test/cpp/config/data/invalid_space_host_numa_id.yaml
+++ b/test/cpp/config/data/invalid_space_host_numa_id.yaml
@@ -1,0 +1,5 @@
+sirius:
+  space:
+    host:
+      - numa_id: -2
+        memory_capacity: 1Gi

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -692,6 +692,66 @@ TEST_CASE("Sirius configuration rejects invalid downgrade hysteresis", "[sirius]
   }
 }
 
+TEST_CASE("Sirius configuration requires a non-empty low-level disk mount path", "[sirius][config]")
+{
+  struct invalid_config {
+    const char* fixture;
+    const char* constraint;
+  };
+
+  const invalid_config cases[] = {
+    {"invalid_space_disk_mount_path_missing.yaml", "required but missing"},
+    {"invalid_space_disk_mount_path_null.yaml", "required but missing"},
+    {"invalid_space_disk_mount_path_empty.yaml", "must not be empty"},
+  };
+
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+  for (auto const& invalid : cases) {
+    INFO("fixture=" << invalid.fixture << " constraint=" << invalid.constraint);
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(config.load_from_file(data_dir / invalid.fixture),
+                        Catch::Contains("sirius.space.disk") && Catch::Contains("mount_path") &&
+                          Catch::Contains(invalid.constraint));
+  }
+}
+
+TEST_CASE("Sirius configuration requires a valid low-level GPU device id", "[sirius][config]")
+{
+  struct invalid_config {
+    const char* fixture;
+    const char* constraint;
+  };
+
+  const invalid_config cases[] = {
+    {"invalid_space_gpu_device_id_missing.yaml", "required but missing"},
+    {"invalid_space_gpu_device_id_null.yaml", "required but missing"},
+    {"invalid_space_gpu_device_id_negative.yaml", "must be non-negative"},
+  };
+
+  std::source_location loc = std::source_location::current();
+  fs::path data_dir        = fs::path(loc.file_name()).parent_path() / "data";
+
+  for (const auto& invalid : cases) {
+    INFO("fixture=" << invalid.fixture << " constraint=" << invalid.constraint);
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(config.load_from_file(data_dir / invalid.fixture),
+                        Catch::Contains("sirius.space.gpu") && Catch::Contains("device_id") &&
+                          Catch::Contains(invalid.constraint));
+  }
+}
+
+TEST_CASE("Sirius configuration rejects invalid low-level host NUMA ids", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const path =
+    fs::path(loc.file_name()).parent_path() / "data" / "invalid_space_host_numa_id.yaml";
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(config.load_from_file(path),
+                      Catch::Contains("sirius.space.host") && Catch::Contains("numa_id") &&
+                        Catch::Contains("-1 or non-negative"));
+}
+
 TEST_CASE("Sirius downgrade hysteresis accepts omitted, null, and one-sided defaults",
           "[sirius][config]")
 {
@@ -1058,6 +1118,44 @@ TEST_CASE("Sirius configuration loading from file with spaces",
   REQUIRE(manager.get_memory_spaces_for_tier(cucascade::memory::Tier::HOST).size() == 1);
   REQUIRE(manager.get_memory_spaces_for_tier(cucascade::memory::Tier::DISK).size() == 2);
   REQUIRE(manager.get_all_memory_spaces().size() == 4);
+}
+
+TEST_CASE("Sirius configuration rejects low-level GPU ids outside discovered topology",
+          "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const path =
+    fs::path(loc.file_name()).parent_path() / "data" / "invalid_space_gpu_unknown_device_id.yaml";
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(config.load_from_file(path),
+                      Catch::Contains("sirius.space.gpu") && Catch::Contains("device_id") &&
+                        Catch::Contains("not present in the discovered GPU topology"));
+}
+
+TEST_CASE("Sirius configuration rejects duplicate low-level memory-space ids", "[sirius][config]")
+{
+  struct invalid_config {
+    const char* fixture;
+    const char* scope;
+    const char* id_name;
+  };
+
+  const invalid_config cases[] = {
+    {"invalid_space_duplicate_gpu_id.yaml", "sirius.space.gpu", "device_id"},
+    {"invalid_space_duplicate_host_id.yaml", "sirius.space.host", "numa_id"},
+    {"invalid_space_duplicate_default_host_id.yaml", "sirius.space.host", "numa_id"},
+    {"invalid_space_duplicate_disk_id.yaml", "sirius.space.disk", "disk_id"},
+  };
+
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+  for (auto const& invalid : cases) {
+    INFO("fixture=" << invalid.fixture << " scope=" << invalid.scope);
+    sirius::sirius_config config;
+    REQUIRE_THROWS_WITH(config.load_from_file(data_dir / invalid.fixture),
+                        Catch::Contains(invalid.scope) && Catch::Contains("duplicate") &&
+                          Catch::Contains(invalid.id_name));
+  }
 }
 
 TEST_CASE("Sirius configuration rejects competing memory configuration paths", "[sirius][config]")


### PR DESCRIPTION
## Summary

- require every low-level GPU entry to provide a non-negative `device_id`
  that exists in discovered topology
- reject duplicate GPU `device_id`, host `numa_id`, and disk `disk_id` values,
  including collisions between omitted host IDs that resolve to `-1`
- accept only host NUMA IDs of `-1` or non-negative
- require every low-level disk entry to provide a non-empty `mount_path`

This consolidates the low-level memory-space validation family previously
split across #1540, #1541, and #1542. It does not change high-level memory
policy, default capacities, automatic topology selection, or compression
policy.

## Why

Any non-empty `sirius.space` list replaces the high-level memory-space set.
Missing or colliding identities make lookup ambiguous, an unknown GPU ID
cannot be executed, and a disk tier without a mount path cannot spill. These
are malformed low-level configurations, not tuning choices.

## Exact current-dev composition

- current base: `3e4d98cfb760c716540b8d4955a9de37d5acfa53`
- exact rebased head: `577f66f9b7d5beaf053943a9b24c0ee2327a25e2`
- candidate tree: `84823a77dec580b5714e06abf1382ba42bffb8c7`
- zero-context diff SHA-256 (`git diff --unified=0 BASE..HEAD`):
  `f53970bc3a65aa2f3df4c5b151fda03e7db7e669fe381773b1fb9124cacb6106`
- guarded force-push lease: previous remote head
  `77c45d974cad50cb91704376f0a9828d5c814d4a`

The one rebase conflict was an adjacent include addition in
`src/sirius_config.cpp`: merged #1498 requires `<cmath>` and this change
requires `<cstdint>`. The resolution retains both. Range-diff is 1:1; its only
delta is that additive include context. All five #1542 test blocks and all 12
fixtures are byte-identical to the prior head. The #1494 topology/affinity and
#1498 compression test blocks are also byte-identical to current `dev`.

## Validation

- source-contract inspection: required identities, bounds, per-tier uniqueness,
  disk path enforcement, and discovered-topology validation are present
- 12 focused invalid fixtures cover missing/null/negative/unknown GPU IDs,
  invalid host IDs, duplicate IDs including the default-host collision, and
  missing/null/empty disk paths
- scoped pre-commit suite: all applicable hooks pass
- standalone `rumdl`: changed documentation passes
- orphan-test check: pass
- `git diff --check`: pass
- no compiled Sirius test binary or `pixi` was available in the isolated
  partial clone; hosted exact-head CI is the runtime validation

Hosted validation for exact head
`577f66f9b7d5beaf053943a9b24c0ee2327a25e2` is terminal green:

- Test workflow `31916223350`: success
  - CUDA 13 build job `95088270553`: success,
    2026-08-16T00:01:57Z through 00:05:23Z
  - CUDA 13 runtime + TPC-H snapshot job `95088670516`: success,
    2026-08-16T00:05:30Z through 00:25:25Z
  - terminal aggregate job `95090923654`: success,
    2026-08-16T00:25:28Z through 00:25:31Z
- Check workflow `31916223369`: success
  - lint `95088270516`, GCC release `95088270486`, Clang debug
    `95088270532`, and terminal aggregate `95088871657`: all success
- Distribution workflow `31916223742`: success
  - distribution aggregate `95088272163`: success
  - CUDA 12/13 packaging legs `95088272493` / `95088290463`: skipped by
    workflow policy

GitHub reports the PR `MERGEABLE`; its remaining `BLOCKED` state is review
policy, with `Jedi18` requested. There are no failing or pending exact-head
Check, Test, or Distribution jobs.

## Historical receipts

- previous current-dev head `77c45d974cad50cb91704376f0a9828d5c814d4a`
  passed hosted lint, GCC, Clang, CUDA 13 build/runtime, TPC-H snapshot, and the
  terminal aggregate in workflow `31758944090`
- predecessor heads #1540 / #1541 / #1542:
  `af1c30cb8515f6605ce2223c64d22d343a5b44fc` /
  `ff29f1690b3ac70edb42221a973783f52fa1da73` /
  `b7d0b0619d5b639babf80d70c43ed0763ca31b0b`
