### PR TITLE
fix(config): validate low-level host NUMA ids

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -205,7 +205,7 @@ Each tier is a **YAML sequence** of space configs. Byte fields accept suffixes; 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `numa_id` | int | 0 | NUMA node the pinned pool is bound to. |
+| `numa_id` | int (>= -1) | -1 | NUMA node the pinned pool is bound to; -1 leaves it unbound. |
 | `reservation_limit_fraction` | double [0,1] | space default | Fraction of the space that may be reserved. |
 | `downgrade_trigger_fraction` | double (0,1] | space default | Start evicting above this fraction. Must be greater than `downgrade_stop_fraction`. |
 | `downgrade_stop_fraction` | double (0,1] | space default | Stop evicting below this fraction. Must be less than `downgrade_trigger_fraction`. |

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -110,7 +110,7 @@ static void from_yaml(const YAML::Node& node, cucascade::memory::gpu_memory_spac
 
 static void from_yaml(const YAML::Node& node, cucascade::memory::host_memory_space_config& opt)
 {
-  yaml::reader r(node, "host_memory_space");
+  yaml::reader r(node, "sirius.space.host");
   r.optional("numa_id", opt.numa_id);
   r.optional(
     "reservation_limit_fraction", opt.reservation_limit_fraction, yaml::fraction<double>{});
@@ -122,6 +122,9 @@ static void from_yaml(const YAML::Node& node, cucascade::memory::host_memory_spa
   r.optional("pool_size", opt.pool_size);
   r.optional("initial_number_pools", opt.initial_number_pools);
   r.reject_unknown();
+  if (opt.numa_id < -1) {
+    throw std::runtime_error("sirius.space.host: numa_id must be -1 or non-negative");
+  }
   validate_downgrade_fractions(
     "sirius.space.host", opt.downgrade_trigger_fraction, opt.downgrade_stop_fraction);
 }

--- a/test/cpp/config/data/invalid_space_host_numa_id.yaml
+++ b/test/cpp/config/data/invalid_space_host_numa_id.yaml
@@ -1,0 +1,5 @@
+sirius:
+  space:
+    host:
+      - numa_id: -2
+        memory_capacity: 1Gi

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -560,6 +560,17 @@ TEST_CASE("Sirius configuration rejects invalid downgrade hysteresis", "[sirius]
   }
 }
 
+TEST_CASE("Sirius configuration rejects invalid low-level host NUMA ids", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const path =
+    fs::path(loc.file_name()).parent_path() / "data" / "invalid_space_host_numa_id.yaml";
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(config.load_from_file(path),
+                      Catch::Contains("sirius.space.host") && Catch::Contains("numa_id") &&
+                        Catch::Contains("-1 or non-negative"));
+}
+
 TEST_CASE("Sirius downgrade hysteresis accepts omitted, null, and one-sided defaults",
           "[sirius][config]")
 {


### PR DESCRIPTION
## Summary

- reject low-level `sirius.space.host[].numa_id` values below the supported `-1` sentinel
- document the actual `-1` default and its unbound-host-allocation meaning
- retain omitted and explicit `-1` behavior

## Why

The expert `sirius.space.host[]` replacement API defaults `numa_id` to `-1`. cuCascade handles exactly that value as the unbound path using `cudaHostAlloc`; every other value is passed to `numa_alloc_onnode`. Values below `-1` currently survive YAML loading and reach libnuma as node IDs. This validates the existing two-state contract at the configuration boundary without removing the intentional `-1` escape hatch.

## Validation

- regression fixture rejects `numa_id: -2` with the low-level field named in the error
- existing `spaces.yaml` remains the positive explicit `-1` path
- applicable pre-commit hooks pass (repository rumdl hook cannot launch locally because `pixi` is unavailable)
- direct `rumdl 0.2.44` passes
- `git diff --check` passes

Base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`