### PR TITLE
fix(config): validate low-level GPU topology

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -201,6 +201,8 @@ Each tier is a **YAML sequence** of space configs. Byte fields accept suffixes; 
 | `downgrade_stop_fraction` | double (0,1] | space default | Stop evicting below this fraction. Must be less than `downgrade_trigger_fraction`. |
 | `memory_capacity` | bytes | space default | Absolute capacity of the space. |
 
+Every explicit `device_id` must be present in Sirius's discovered GPU topology.
+
 #### `sirius.space.host[]` — one entry per host (pinned) memory space
 
 | Key | Type | Default | Description |

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -27,6 +27,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <exception>
 #include <limits>
 #include <stdexcept>
@@ -667,6 +668,15 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
     if (high_level_memory_configured && explicit_space_configured) {
       throw std::runtime_error(
         "sirius.memory and non-empty sirius.space lists are mutually exclusive");
+    }
+    for (auto const& gpu : gpu_space_configs) {
+      auto const discovered = std::ranges::any_of(_hw_topology.gpus, [&](auto const& info) {
+        return static_cast<int64_t>(info.id) == static_cast<int64_t>(gpu.device_id);
+      });
+      if (!discovered) {
+        throw std::runtime_error("sirius.space.gpu: device_id " + std::to_string(gpu.device_id) +
+                                 " is not present in the discovered GPU topology");
+      }
     }
 
     r.reject_unknown();

--- a/test/cpp/config/data/invalid_space_gpu_unknown_device_id.yaml
+++ b/test/cpp/config/data/invalid_space_gpu_unknown_device_id.yaml
@@ -1,0 +1,5 @@
+sirius:
+  space:
+    gpu:
+      - device_id: 2147483647
+        memory_capacity: 1Gi

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -857,6 +857,18 @@ TEST_CASE("Sirius configuration loading from file with spaces",
   REQUIRE(manager.get_all_memory_spaces().size() == 4);
 }
 
+TEST_CASE("Sirius configuration rejects low-level GPU ids outside discovered topology",
+          "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const path =
+    fs::path(loc.file_name()).parent_path() / "data" / "invalid_space_gpu_unknown_device_id.yaml";
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(config.load_from_file(path),
+                      Catch::Contains("sirius.space.gpu") && Catch::Contains("device_id") &&
+                        Catch::Contains("not present in the discovered GPU topology"));
+}
+
 TEST_CASE("Sirius configuration rejects competing memory configuration paths", "[sirius][config]")
 {
   std::source_location loc = std::source_location::current();


### PR DESCRIPTION
## Summary

- reject expert `sirius.space.gpu[]` device IDs absent from discovered topology
- report the invalid field and ID during configuration loading
- document that explicit low-level IDs must refer to discovered GPUs

## Why

High-level `sirius.topology` selections are resolved against topology by the configurator, but the low-level replacement path copies `gpu_memory_space_config` entries directly into allocator construction. A non-negative but unavailable `device_id` therefore survives configuration loading and only fails when the GPU memory space calls RMM/CUDA. This gives the expert path the same fail-early hardware identity boundary without changing its replacement semantics.

## Validation

- regression uses `INT_MAX` as a deterministically absent GPU ID
- existing `spaces.yaml` remains the positive discovered-device path
- applicable pre-commit hooks pass (repository rumdl hook cannot launch locally because `pixi` is unavailable)
- direct `rumdl 0.2.44` passes
- `git diff --check` passes

Base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`