### PR TITLE
refactor(config): simplify high-level disk policy

### DIFF
--- a/bench/sf1000-repro/sirius-sf1000.yaml
+++ b/bench/sf1000-repro/sirius-sf1000.yaml
@@ -25,7 +25,6 @@ sirius:
             pool_size: 8
             block_size: 67108864
         disk:
-            disk_id: 0
             capacity_bytes: 1000000000000
             downgrade_root_dirs: "/localhome/local-faramburu/sirius_disk_memory"
     executor:

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -78,7 +78,7 @@ sirius:
       downgrade_trigger_fraction: 0.8
       downgrade_stop_fraction: 0.6
     host: { capacity_bytes: 25GB, initial_number_pools: 50, pool_size: 512, block_size: 1048576 }
-    disk: { disk_id: 0, capacity_bytes: 1000000000000, downgrade_root_dirs: "/tmp/sirius_disk_memory" }
+    disk: { capacity_bytes: 1000000000000, downgrade_root_dirs: "/tmp/sirius_disk_memory" }
   executor:
     scan_manager: { num_threads: 4, use_sirius_datasource: true, uring_n_reactors: 1, enable_prefetch_cache: false }
     pipeline:     { num_threads: 4 }
@@ -149,8 +149,7 @@ Controls the disk spill tier. Data evicted from host memory is written here. Dis
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `disk_id` | int | 0 | Identifier for the disk space. |
-| `capacity_bytes` | bytes | 1Ti | Maximum disk space for spill files. |
+| `capacity_bytes` | bytes | 1Ti | Maximum disk space for spill files. An explicitly positive capacity requires a non-empty `downgrade_root_dirs`; `0` remains an explicit spill-tier opt-out. |
 | `downgrade_root_dirs` | string | "" | Directory path for spill files. **Must be set** to enable disk spilling. Use a fast local mount (NVMe preferred). |
 
 ### How Downgrade Thresholds Work

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -483,23 +483,33 @@ struct host_mem_config {
 };
 
 struct disk_mem_config {
-  int id{0};
   std::size_t capacity_bytes{1024UL << 30};  // 1TB
   std::string downgrade_root_dirs;
 
   static void from_yaml(const YAML::Node& node, disk_mem_config& opt)
   {
     yaml::reader r(node, "memory.disk");
-    r.optional("disk_id", opt.id);
+    if (r.has("disk_id")) {
+      throw std::runtime_error(
+        "'sirius.memory.disk.disk_id': removed; the single high-level disk space uses internal "
+        "ID 0; remove this key or use 'sirius.space.disk[]' for explicit multi-space IDs");
+    }
     r.optional("capacity_bytes", yaml::bytes(opt.capacity_bytes));
     r.optional("downgrade_root_dirs", opt.downgrade_root_dirs);
     r.reject_unknown();
+    if (r.has_value("capacity_bytes") && opt.capacity_bytes > 0 &&
+        opt.downgrade_root_dirs.empty()) {
+      throw std::runtime_error(
+        "sirius.memory.disk.capacity_bytes: inactive without a non-empty "
+        "sirius.memory.disk.downgrade_root_dirs; configure the spill directory or remove "
+        "capacity_bytes");
+    }
   }
 
   void setup_configurator(cucascade::memory::reservation_manager_configurator& builder) const
   {
     if (downgrade_root_dirs.empty() || capacity_bytes == 0) { return; }
-    builder.set_disk_mounting_point(id, capacity_bytes, downgrade_root_dirs);
+    builder.set_disk_mounting_point(0, capacity_bytes, downgrade_root_dirs);
   }
 };
 

--- a/test/cpp/config/data/configurator.yaml
+++ b/test/cpp/config/data/configurator.yaml
@@ -14,7 +14,6 @@ sirius:
       downgrade_trigger_fraction: 0.8
       downgrade_stop_fraction: 0.7
     disk:
-      disk_id: 0
       capacity_bytes: 1000000000
       downgrade_root_dirs: "/tmp/sirius_disk_memory"
   executor:

--- a/test/cpp/config/data/invalid_memory_disk_capacity_without_root.yaml
+++ b/test/cpp/config/data/invalid_memory_disk_capacity_without_root.yaml
@@ -1,0 +1,4 @@
+sirius:
+  memory:
+    disk:
+      capacity_bytes: 1Gi

--- a/test/cpp/config/data/invalid_memory_disk_id.yaml
+++ b/test/cpp/config/data/invalid_memory_disk_id.yaml
@@ -1,0 +1,6 @@
+sirius:
+  memory:
+    disk:
+      disk_id: 7
+      capacity_bytes: 1Gi
+      downgrade_root_dirs: /tmp/sirius-disk

--- a/test/cpp/config/data/minimal.yaml
+++ b/test/cpp/config/data/minimal.yaml
@@ -7,7 +7,6 @@ sirius:
     host:
       capacity_bytes: 160000000
     disk:
-      disk_id: 0
       capacity_bytes: 1000000000
       downgrade_root_dirs: "/tmp/sirius_disk_memory"
   executor:

--- a/test/cpp/config/data/valid_memory_disk_zero_optout.yaml
+++ b/test/cpp/config/data/valid_memory_disk_zero_optout.yaml
@@ -1,0 +1,4 @@
+sirius:
+  memory:
+    disk:
+      capacity_bytes: 0

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -279,11 +279,42 @@ TEST_CASE("Sirius configuration loading from file with configurator",
   REQUIRE(manager.get_memory_spaces_for_tier(cucascade::memory::Tier::GPU).size() == 1);
   REQUIRE(manager.get_memory_spaces_for_tier(cucascade::memory::Tier::HOST).size() == 1);
   REQUIRE(manager.get_memory_spaces_for_tier(cucascade::memory::Tier::DISK).size() == 1);
+  REQUIRE(
+    manager.get_memory_spaces_for_tier(cucascade::memory::Tier::DISK).front()->get_device_id() ==
+    0);
 
   auto const& telemetry = sirius_ctx->get_config().get_telemetry_config();
   REQUIRE_FALSE(telemetry.enable_quent);
   REQUIRE(telemetry.output_directory == "/tmp/sirius_telemetry_config_test");
   REQUIRE(telemetry.engine_name == "sirius_config_test");
+}
+
+TEST_CASE("Sirius keeps the high-level disk space id internal", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const path =
+    fs::path(loc.file_name()).parent_path() / "data" / "invalid_memory_disk_id.yaml";
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(config.load_from_file(path),
+                      Catch::Contains("sirius.memory.disk.disk_id") && Catch::Contains("removed") &&
+                        Catch::Contains("sirius.space.disk"));
+}
+
+TEST_CASE("Sirius rejects an inactive high-level disk capacity", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+  sirius::sirius_config config;
+  REQUIRE_THROWS_WITH(
+    config.load_from_file(data_dir / "invalid_memory_disk_capacity_without_root.yaml"),
+    Catch::Contains("sirius.memory.disk.capacity_bytes") && Catch::Contains("inactive") &&
+      Catch::Contains("downgrade_root_dirs"));
+
+  REQUIRE_NOTHROW(config.load_from_file(data_dir / "valid_memory_disk_zero_optout.yaml"));
+  auto const& spaces = config.get_memory_space_configs();
+  REQUIRE(std::ranges::none_of(spaces, [](auto const& space) {
+    return std::holds_alternative<cucascade::memory::disk_memory_space_config>(space);
+  }));
 }
 
 TEST_CASE("Sirius configuration rejects zero hash partition bytes", "[sirius][config]")


### PR DESCRIPTION
## Summary

- remove `sirius.memory.disk.disk_id` from the normal high-level configuration path and fix the single high-level disk tier to internal ID 0
- reject an explicitly positive spill capacity when no spill directory activates it
- preserve `capacity_bytes: 0` as the explicit high-level spill-tier opt-out
- retain explicit IDs on expert `sirius.space.disk[]`, where multiple disk spaces make identity meaningful
- update the shipped config examples and SF1000 reproduction config

## Why

High-level `sirius.memory.disk` can construct at most one disk space. Its `disk_id` only renamed the internal `memory_space_id`; it did not choose a device, path, capacity, or recovery policy. Requiring users to choose that implementation key added configuration surface without expressing intent.

The same high-level block previously accepted `capacity_bytes` by itself and silently skipped constructing the disk tier because `downgrade_root_dirs` was empty. That partial configuration now fails at YAML load with an actionable message instead of looking active while doing nothing.

The low-level replacement API still supports multiple disk spaces and keeps explicit IDs.

## Validation

- configurator integration asserts the high-level disk space uses internal ID 0
- stale high-level `disk_id` fixture checks removal and low-level replacement guidance
- positive-capacity-without-directory fixture checks inactive-setting rejection
- zero-capacity fixture proves the explicit opt-out remains accepted and produces no disk space
- existing low-level `spaces.yaml` continues to cover IDs 0 and 1
- applicable pre-commit hooks pass (repository rumdl hook cannot launch locally because `pixi` is unavailable)
- direct `rumdl 0.2.44` passes
- `git diff --check` passes

Base: `e64b8ad79ea3cee50149d7e3039dbbb92ed291a9`

- fresh exact-head hosted lint, GCC release, Clang debug, CUDA 13 build, full runtime, and terminal aggregate checks: pass
- hosted workflow 31723993656: runtime job 94528692203 passed in 20m20s; aggregate job 94540105396 passed
