### PR TITLE
fix: two GPU use-after-free races — batch read-lock lifetime and error-path teardown

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,132 @@
+# fix: GPU use-after-free — device memory released while kernels still read it (scan read-lock lifetime + error-path teardown)
+
+## Problem
+
+Two independent instances of one defect class — **device memory released for
+reuse while kernels still read it** — corrupted or wedged roughly **50% of
+concurrent multi-stream workloads** (staged-refresh TPC-H throughput runs at
+SF1000). Because the corruption lands in whatever pool memory gets rebound
+next, one defect showed four faces:
+
+1. `cudaErrorIllegalAddress` surfacing at the victim query's next stream sync
+   (observed at `gpu_decode_strings.cu:240` — an innocent bystander).
+2. Negative-size (2^64−N) allocations in HASH_JOIN/CONCAT — the signature of
+   scribbled, non-monotonic string offsets reaching size subtraction.
+3. Silent never-terminating kernels at full power — a cuco open-addressing
+   insert livelocks when its row comparator reads memory mutating under it.
+4. Garbage VARCHAR bytes with valid geometry — client-side
+   `Invalid unicode (byte sequence mismatch)` errors.
+
+Sequential runs were almost always clean: the freed region must be rebound
+quickly by concurrent work for the stale read to become garbage, which is why
+this presented as a flaky, concurrency-only corruption.
+
+## Root cause
+
+### Instance 1 (primary): the scan drops the cached-batch read-lock while its kernels still read the batch
+
+The resident-scan path wraps the cached batch's read-only accessor (the batch
+READ LOCK) in an `owning_table_view`, then enqueues the kernels that read the
+batch — the filter gather and the view→table `release()` copy in
+`post_filter_and_project`, plus normalization work in the scan's `execute()` —
+and destroyed the owner (dropping the lock) before any of that work completed:
+inside `post_filter_and_project` on some paths (the duckdb-native no-filter
+path moves the owner into a local; parquet re-assigns `input` right after
+enqueueing the gather), or at `execute()` exit — both ahead of
+`run_one_operator`'s post-execute sync.
+
+The moment the lock drops, the downgrade executor's `try_to_mutable` succeeds
+and, under memory pressure, evicts the batch GPU→HOST and **frees its device
+buffers while the scan's kernels still read them**; the async pool rebinds the
+region to concurrent work. The keep-mask branches of
+`gpu_ingestible::materialize_table` already synchronized for exactly this
+hazard — the non-mask paths lacked the same discipline.
+
+**Fix:** synchronize the stream before every owner-death point — the end of
+both `post_filter_and_project` implementations and the end of the scan
+`execute()` (the latter is nearly free: `run_one_operator` syncs the same
+stream immediately after).
+
+### Instance 2: query-abort teardown races the aborted query's still-running kernels
+
+A pipeline task that throws out of `gpu_pipeline_task::execute()` (e.g.
+`rmm::out_of_memory` inside a cudf call) unwinds with its kernels still
+enqueued on `exc_stream`. In `gpu_pipeline_executor`'s worker lambda:
+
+- the `task_reschedule_exception` handler synced `exc_stream` — but only
+  *after* an early `return` taken when the completion handler was already in
+  an error state (the exact path taken when a sibling task's fail-fast had
+  already errored the query), and
+- the generic `catch (std::exception&)` / `catch (...)` paths never synced.
+
+On those unsynced exits the task (and the reschedule exception, which owns the
+task's input batches) is destroyed. Its buffers are freed *stream-ordered on
+the streams that allocated them* — long-idle upstream streams — so the async
+pool considers the memory immediately reusable while `exc_stream`'s orphaned
+kernels still read/write it. `drain_after_error()` only joins host lambdas;
+`QueryEnd` then frees the whole query's device memory the same way. One abort
+poisons many concurrent victims.
+
+**Fix:** quiesce `exc_stream` on every abnormal exit of the worker lambda
+before any owner of device memory is destroyed — the sync is hoisted to the
+top of the reschedule handler (now covering the has-error early return and the
+failed-cast return) and added to both generic catches (sync failures from
+sticky CUDA errors are logged, never thrown). Belt-and-suspenders: a
+device-scoped `cudaDeviceSynchronize` per GPU executor in
+`task_scheduler::drain_after_error()` (error path only) so QueryEnd can never
+free device memory with pending kernels even through a throw path the handlers
+miss.
+
+## Verification
+
+Forensics and verification were run on the SF1000 staged-refresh concurrent
+throughput stack where the corruption reproduced (~50% incidence):
+
+- **Deterministic repro via poison-on-free.** An env-gated diagnostic
+  (`SIRIUS_POISON_FREES=1`) enqueues a stream-ordered 0xEE fill over every
+  freed device region before the free, converting use-after-free reads from
+  timing-dependent stale-but-intact data into deterministic garbage.
+  Pre-fix: **3/3 runs wedged**, always within the *sequential* phases —
+  proving a freed-while-still-read buffer in the normal warm serve path, no
+  query abort required. Post-fix: **3/3 poison-armed sequential trials
+  clean** (full power coverage, zero corruption events) plus **1/1
+  poison-armed full concurrent run clean**, including seven genuine OOM→CPU
+  fallbacks — i.e. the error-path teardown executed seven times at maximum
+  use-after-free sensitivity and corrupted nothing.
+- **GPU core dump naming the livelocked kernel.** A user-triggered core dump
+  (`CUDA_ENABLE_USER_TRIGGERED_COREDUMP`) at a pre-fix wedge showed exactly
+  one active kernel: `cuco::detail::open_addressing_ns::insert_if_n<...,
+  cudf::detail::primitive_keys_fn<rhs_index_type>...>` — the cudf
+  `distinct_hash_join` build insert over 200 M rows, livelocked because its
+  row comparator read memory mutating under it (dangling build-input views
+  into an evicted batch). This ties face 3 to the same defect.
+- **Regression test** (`test/cpp/pipeline/test_gpu_pipeline_executor.cpp`,
+  tag `[gpu_pipeline_executor]`): a task enqueues slow stream-ordered work
+  and throws (a) `oom_reschedule_exception` with the completion handler
+  pre-errored — the exact regressed path — and (b) a generic exception; the
+  task destructor records whether it ran while stream work was still pending.
+  Fails on the pre-fix code, passes with the fix.
+- **Clean scored production runs:** with the fixes (poison off, decode/ASCII
+  guards armed as canaries), 3/3 full SF1000 power+throughput runs completed
+  with zero corruption events (QphH 7,211,669 / 7,365,117 / 7,044,510).
+
+**Known residual (honest status):** one post-fix production run wedged
+silently with a different signature (low-occupancy ~254 W spin vs the 480 W
+distinct-build wedges), zero errors. The poison-deterministic instance and the
+teardown instance are gone, but the bug *class* is reduced, not proven extinct
+at production timing — poison slows the engine ~3.5×, which can shift a narrow
+race out of its window. A follow-up hunt with the coredump pipe armed is the
+next step; it does not block this fix.
+
+## Note for reviewers
+
+The poison-on-free diagnostic used for the deterministic repro is intentionally
+kept out of this PR (it taxes every free). It lives on the cucascade branch
+`diag/poison-on-free` if you want to reproduce the verification.
+
+## Performance
+
+The added syncs are on paths that were already followed by a sync
+(`run_one_operator` syncs the operator stream right after `execute()`), on
+error-only paths, or replace an unsynchronized owner-death that was simply
+wrong. No measurable cost in the scored SF1000 runs above.

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -381,7 +381,18 @@ std::unique_ptr<cudf::table> duckdb_native_gpu_ingestible::post_filter_and_proje
     final_table.select_columns(selected_cols);
   }
 
-  return final_table.release(stream, mr_ref);
+  auto out = final_table.release(stream, mr_ref);
+  // Quiesce BEFORE `final_table` (which may own the moved-in input view's
+  // owner — for a resident scan, the cached batch's read-lock accessor) is
+  // destroyed. release()'s view->table materialization and the filter gather
+  // above are still enqueued on `stream`; dropping the read lock while they
+  // run lets the downgrade executor evict the source batch and free its
+  // device memory mid-read, so the pool rebinds it to concurrent work — the
+  // staged-refresh corruption (garbage VARCHAR bytes / non-monotonic offsets
+  // / never-terminating kernels downstream). Same discipline as the
+  // keep-mask branches in gpu_ingestible::materialize_table.
+  stream.synchronize();
+  return out;
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -1192,7 +1192,15 @@ std::unique_ptr<cudf::table> parquet_gpu_ingestible::post_filter_and_project(
     auto const data_positions = output_data_positions(*_plan);
     auto filtered             = data_positions.empty() ? exec.select(input.table.view())
                                                        : exec.select(input.table.view(), data_positions);
+    // Keep the pre-filter view's owner (for a resident scan, the cached
+    // batch's read-lock accessor) alive until the filter gather completes:
+    // destroying it re-assigns `input` below, dropping the read lock while
+    // the gather still reads the batch — the downgrade executor can then
+    // evict the batch and free its device memory mid-read (the
+    // staged-refresh corruption).
+    auto previous = std::move(input.table);
     input = filtered_table{owning_table_view{std::move(filtered)}, filter_state::ROW_FILTERED};
+    stream.synchronize();
     SIRIUS_LOG_DEBUG(
       "[parquet_gpu_ingestible::post_filter_and_project] Applied duckdb filter expression "
       "post-decode.");
@@ -1206,7 +1214,15 @@ std::unique_ptr<cudf::table> parquet_gpu_ingestible::post_filter_and_project(
     assemble_scan_output(*_plan, std::move(input.table), /*partition_values=*/{}, stream);
   SIRIUS_LOG_DEBUG(
     "[parquet_gpu_ingestible::post_filter_and_project] Assembled scan output to plan layout.");
-  return assembled.release(stream, mr_ref);
+  auto out = assembled.release(stream, mr_ref);
+  // Quiesce BEFORE `assembled` (owner of the moved-in input view — for a
+  // resident scan, the cached batch's read-lock accessor) is destroyed:
+  // release()'s view->table materialization is still enqueued on `stream`,
+  // and dropping the read lock mid-copy lets the downgrade executor free the
+  // source batch's device memory under the copy (the staged-refresh
+  // corruption).
+  stream.synchronize();
+  return out;
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -249,6 +249,16 @@ std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::execute(
   auto batch =
     sirius::make_data_batch(std::move(output_table), *mem_space, stream, batch_telemetry());
   std::vector<std::shared_ptr<::cucascade::data_batch>> batches{std::move(batch)};
+  // Quiesce BEFORE this function's locals are destroyed: `materialized_table`
+  // may still own the source view's owner (for a resident scan, the cached
+  // batch's read-lock accessor), and the ROW_FILTERED_AND_PROJECTED release
+  // above and the carrier-normalization casts are still enqueued on `stream`.
+  // Dropping the read lock while those kernels read the batch lets the
+  // downgrade executor evict it and free its device memory mid-read (the
+  // staged-refresh corruption).
+  // Nearly free: run_one_operator synchronizes this stream immediately after
+  // execute() returns anyway.
+  stream.synchronize();
   return std::make_unique<pipelineable_operator_data>(std::move(batches));
 }
 

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -305,10 +305,41 @@ void gpu_pipeline_executor::manager_loop()
        exc_stream = std::move(exc_stream),
        consumers  = std::move(output_consumers),
        pipeline]() mutable {
+        // Quiesce exc_stream on EVERY abnormal exit BEFORE any object that
+        // owns device memory (the task, a reschedule exception's intermediate
+        // data) is destroyed. execute()'s throw paths unwind with kernels /
+        // copies still enqueued on exc_stream; destroying those owners frees
+        // their buffers stream-ordered on OTHER (already idle) streams, so
+        // the async pool can rebind the memory to concurrent queries while
+        // this stream's orphaned kernels still read/write it. That was the
+        // staged-refresh throughput corruption: one aborted query's orphaned
+        // kernels scribbled pool memory reused by concurrent queries —
+        // surfacing as cudaErrorIllegalAddress at the victims' next sync,
+        // negative-size (2^64-N) allocations from non-monotonic string
+        // offsets, garbage VARCHAR bytes (client-side "Invalid unicode"),
+        // and never-terminating kernels.
+        auto quiesce_exc_stream = [&exc_stream](char const* why) noexcept {
+          try {
+            exc_stream->synchronize();
+          } catch (const std::exception& sync_err) {
+            SIRIUS_LOG_ERROR("GPU Pipeline Executor: exc_stream synchronize failed during {}: {}",
+                             why,
+                             sync_err.what());
+          } catch (...) {
+            SIRIUS_LOG_ERROR("GPU Pipeline Executor: exc_stream synchronize failed during {}", why);
+          }
+        };
         try {
           task->execute(exc_stream);
           _tasks_executed.fetch_add(1, std::memory_order_relaxed);
         } catch (task_reschedule_exception& ex) {
+          // Sync FIRST: `ex` owns the task's input batches, and every return
+          // below destroys `task` (and possibly `ex`) — no device buffer may
+          // be freed while this stream still has the throwing operator's work
+          // in flight. The error-state early return below previously skipped
+          // the sync entirely; that gap is what let an abandoned query leak
+          // running kernels into QueryEnd's memory teardown.
+          quiesce_exc_stream("reschedule handling");
           if (_completion_handler && _completion_handler->has_error()) {
             // If the completion handler is already in an error state, then we can just return and
             // not try to reschedule
@@ -324,8 +355,8 @@ void gpu_pipeline_executor::manager_loop()
             return;
           }
 
-          // Sync the stream to ensure all memory is released before the reschedule.
-          exc_stream->synchronize();
+          // (exc_stream already quiesced at the top of this handler, so all
+          // task memory is released before the reschedule.)
 
           // Determine retry count and original task ID for this rescheduled attempt.
           auto* cur_local = dynamic_cast<gpu_pipeline_task_local_state*>(gpu_task->local_state());
@@ -421,11 +452,16 @@ void gpu_pipeline_executor::manager_loop()
           return;
         } catch (const std::exception& e) {
           SIRIUS_LOG_ERROR("GPU Pipeline Executor: Exception during task execution: {}", e.what());
+          // Quiesce before `task` (destroyed at lambda exit) releases its
+          // device buffers — same freed-while-pending hazard as the
+          // reschedule path above.
+          quiesce_exc_stream("task-failure teardown");
           if (_task_creator) { _task_creator->stop(); }
           if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
           return;
         } catch (...) {
           SIRIUS_LOG_ERROR("GPU Pipeline Executor: unknown error during task execution");
+          quiesce_exc_stream("task-failure teardown");
           if (_task_creator) { _task_creator->stop(); }
           if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
           return;

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -30,6 +30,10 @@
 #include "planner/query.hpp"
 #include "telemetry/telemetry_context.hpp"
 
+#include <rmm/cuda_device.hpp>
+
+#include <cuda_runtime_api.h>
+
 #include <cucascade/memory/common.hpp>
 #include <cucascade/memory/memory_reservation.hpp>
 #include <cucascade/memory/memory_space.hpp>
@@ -254,6 +258,24 @@ void task_scheduler::drain_after_error()
   // tasks to finish, then restart the manager for the next query.
   for (auto& [device_id, gpu_exec] : _gpu_executors) {
     gpu_exec->drain_and_wait();
+    // Belt-and-suspenders for the device-side teardown hazard: drain_and_wait
+    // only joins the HOST lambdas. A task that threw may have unwound with
+    // kernels still enqueued on its exc_stream (the executor's catch handlers
+    // quiesce that stream, but this guards any throw path they miss). The
+    // caller rethrows right after this drain and QueryEnd then frees every
+    // device buffer the query owned — if any of the query's kernels were
+    // still running, the async pool would rebind that memory to concurrent
+    // queries mid-kernel (the staged-refresh corruption). Quiesce the whole
+    // device before letting the teardown free anything. Error path only, so
+    // the (bounded) wait on unrelated streams is acceptable.
+    rmm::cuda_set_device_raii device_guard{rmm::cuda_device_id{device_id}};
+    if (auto const sync_err = cudaDeviceSynchronize(); sync_err != cudaSuccess) {
+      SIRIUS_LOG_ERROR(
+        "task_scheduler::drain_after_error: cudaDeviceSynchronize on GPU {} failed: [{}] {}",
+        device_id,
+        static_cast<int>(sync_err),
+        cudaGetErrorString(sync_err));
+    }
   }
 
   // Now that no executor can generate further task_creation_requests, discard

--- a/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
@@ -17,12 +17,16 @@
 #include "catch.hpp"
 #include "exec/channel.hpp"
 #include "exec/config.hpp"
+#include "pipeline/completion_handler.hpp"
 #include "pipeline/gpu_pipeline_executor.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
+#include "pipeline/oom_reschedule_exception.hpp"
 #include "pipeline/sirius_pipeline_task_states.hpp"
 #include "pipeline/task_request.hpp"
 #include "scan/test_utils.hpp"
 #include "utils/telemetry_utils.hpp"
+
+#include <cuda_runtime_api.h>
 
 #include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 
@@ -245,4 +249,172 @@ TEST_CASE("GPU pipeline executor schedules GPU tasks directly (push-model)",
       REQUIRE(consumed_bytes >= kReservationBytes);
     }
   }
+}
+
+namespace {
+
+// Shared observation state for the teardown-quiesce regression test below.
+struct teardown_probe {
+  std::atomic<bool> stream_work_done{false};         // set by the stream-ordered host func
+  std::atomic<bool> destroyed_while_pending{false};  // task destroyed before stream quiesced
+  std::atomic<bool> task_destroyed{false};
+};
+
+// Stream-ordered "pending work": blocks the stream for a while, then flips the
+// flag. Anything that destroys task-owned device state before this has run is
+// exactly the freed-while-pending teardown hazard.
+void CUDART_CB slow_stream_work(void* userdata)
+{
+  auto* probe = static_cast<teardown_probe*>(userdata);
+  std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  probe->stream_work_done.store(true, std::memory_order_release);
+}
+
+// A task that enqueues slow stream-ordered work and then throws, emulating an
+// operator OOM that unwinds with kernels still in flight on exc_stream.
+class throwing_pipeline_task : public sirius::pipeline::gpu_pipeline_task {
+ public:
+  enum class failure_mode { reschedule_exception, generic_exception };
+
+  throwing_pipeline_task(uint64_t task_id,
+                         std::unique_ptr<test_gpu_pipeline_task_local_state> local_state,
+                         std::shared_ptr<test_gpu_pipeline_task_global_state> global_state,
+                         std::shared_ptr<teardown_probe> probe,
+                         failure_mode mode)
+    : gpu_pipeline_task(task_id,
+                        std::vector<cucascade::shared_data_repository*>{},
+                        std::move(local_state),
+                        std::move(global_state)),
+      _probe(std::move(probe)),
+      _mode(mode)
+  {
+  }
+
+  ~throwing_pipeline_task() override
+  {
+    // REGRESSION GUARD for the staged-refresh corruption: the executor must
+    // quiesce exc_stream on every abnormal exit BEFORE the task (and the
+    // device memory it owns) is destroyed. If this destructor runs while the
+    // stream still has our enqueued work pending, freed buffers could be
+    // rebound by the async pool to concurrent queries mid-kernel.
+    _probe->destroyed_while_pending.store(!_probe->stream_work_done.load(std::memory_order_acquire),
+                                          std::memory_order_release);
+    _probe->task_destroyed.store(true, std::memory_order_release);
+  }
+
+  void execute(rmm::cuda_stream_view stream) override
+  {
+    auto err = cudaLaunchHostFunc(stream.value(), slow_stream_work, _probe.get());
+    if (err != cudaSuccess) {
+      // Never leave the probe unresolvable: report and finish "quiesced".
+      _probe->stream_work_done.store(true, std::memory_order_release);
+      throw std::runtime_error("cudaLaunchHostFunc failed in throwing_pipeline_task");
+    }
+    if (_mode == failure_mode::reschedule_exception) {
+      throw sirius::pipeline::oom_reschedule_exception(
+        nullptr, 0, "test-injected OOM with stream work in flight");
+    }
+    throw std::runtime_error("test-injected failure with stream work in flight");
+  }
+
+  sirius::pipeline::reservation_size_info get_estimated_reservation_size_info(
+    const cucascade::memory::memory_space* /*target_space*/) const override
+  {
+    sirius::pipeline::reservation_size_info info;
+    info.reservation_size = kReservationBytes;
+    return info;
+  }
+
+  std::vector<sirius::op::sirius_physical_operator*> get_output_consumers() override { return {}; }
+
+ private:
+  std::shared_ptr<teardown_probe> _probe;
+  failure_mode _mode;
+};
+
+}  // namespace
+
+// Regression test for the staged-refresh delta-serving corruption (concurrent
+// throughput): a task that threw out of execute() was destroyed — and with it
+// the exception's input batches — while its enqueued kernels were still
+// running on exc_stream. In particular, the reschedule handler's
+// has_error early return skipped the stream sync entirely. The async pool
+// then rebound the freed device memory to concurrent queries while the
+// orphaned kernels still read/wrote it, surfacing as illegal addresses,
+// negative-size (2^64-N) allocations from scribbled string offsets, garbage
+// VARCHAR bytes ("Invalid unicode" at the client), and never-terminating
+// kernels. The executor must quiesce exc_stream before any teardown.
+TEST_CASE("GPU pipeline executor quiesces the task stream before teardown on error paths",
+          "[gpu_pipeline_executor]")
+{
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> manager;
+  try {
+    cucascade::memory::reservation_manager_configurator builder;
+    builder.set_number_of_gpus(1)
+      .set_gpu_usage_limit(256 * 1024 * 1024)
+      .set_reservation_fraction_per_gpu(0.75)
+      .set_per_numa_region_capacity(1 * 1024 * 1024 * 1024)
+      .use_gpu_id_as_host_id()
+      .track_reservation_per_stream(false)
+      .set_reservation_fraction_per_numa_region(0.75);
+    auto space_configs = builder.build();
+    manager =
+      std::make_unique<sirius::memory::sirius_memory_reservation_manager>(std::move(space_configs));
+  } catch (const std::exception& e) {
+    WARN("Skipping test due to insufficient GPUs: " << e.what());
+    return;
+  }
+
+  auto* mem_space = manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  if (!mem_space) {
+    WARN("Skipping test because no GPU memory space is available.");
+    return;
+  }
+
+  sirius::exec::channel<std::unique_ptr<sirius::pipeline::task_request>> request_channel;
+  auto request_publisher = request_channel.make_publisher();
+
+  sirius::exec::thread_pool_config config;
+  config.num_threads        = 2;
+  config.thread_name_prefix = "gpu-pipeline-teardown-test";
+
+  sirius::pipeline::gpu_pipeline_executor executor(config,
+                                                   mem_space,
+                                                   std::move(request_publisher),
+                                                   nullptr,
+                                                   sirius::test::make_test_telemetry_context());
+
+  // Pre-error the completion handler: this drives the reschedule handler's
+  // has_error early return — the exact path that used to skip the sync.
+  sirius::pipeline::completion_handler handler;
+  handler.report_error("pre-set error state (test)");
+  executor.set_completion_handler(&handler);
+
+  executor.start();
+
+  auto const run_one = [&](throwing_pipeline_task::failure_mode mode, uint64_t task_id) {
+    auto probe        = std::make_shared<teardown_probe>();
+    auto global_state = std::make_shared<test_gpu_pipeline_task_global_state>();
+    auto local_state  = std::make_unique<test_gpu_pipeline_task_local_state>(
+      std::make_unique<sirius::op::pipelineable_operator_data>(
+        std::vector<std::shared_ptr<cucascade::data_batch>>{}));
+    executor.schedule(std::make_unique<throwing_pipeline_task>(
+      task_id, std::move(local_state), global_state, probe, mode));
+
+    auto const start_time = std::chrono::steady_clock::now();
+    while (!probe->task_destroyed.load(std::memory_order_acquire)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      if (std::chrono::steady_clock::now() - start_time > std::chrono::seconds(20)) {
+        FAIL("Timed out waiting for the throwing task to be destroyed.");
+      }
+    }
+    INFO("failure mode " << static_cast<int>(mode));
+    REQUIRE_FALSE(probe->destroyed_while_pending.load(std::memory_order_acquire));
+  };
+
+  run_one(throwing_pipeline_task::failure_mode::reschedule_exception, 1);
+  run_one(throwing_pipeline_task::failure_mode::generic_exception, 2);
+
+  executor.stop();
+  request_channel.close();
 }


### PR DESCRIPTION
# fix: GPU use-after-free — device memory released while kernels still read it (scan read-lock lifetime + error-path teardown)

## Problem

Two independent instances of one defect class — **device memory released for
reuse while kernels still read it** — corrupted or wedged roughly **50% of
concurrent multi-stream workloads** (staged-refresh TPC-H throughput runs at
SF1000). Because the corruption lands in whatever pool memory gets rebound
next, one defect showed four faces:

1. `cudaErrorIllegalAddress` surfacing at the victim query's next stream sync
   (observed at `gpu_decode_strings.cu:240` — an innocent bystander).
2. Negative-size (2^64−N) allocations in HASH_JOIN/CONCAT — the signature of
   scribbled, non-monotonic string offsets reaching size subtraction.
3. Silent never-terminating kernels at full power — a cuco open-addressing
   insert livelocks when its row comparator reads memory mutating under it.
4. Garbage VARCHAR bytes with valid geometry — client-side
   `Invalid unicode (byte sequence mismatch)` errors.

Sequential runs were almost always clean: the freed region must be rebound
quickly by concurrent work for the stale read to become garbage, which is why
this presented as a flaky, concurrency-only corruption.

## Root cause

### Instance 1 (primary): the scan drops the cached-batch read-lock while its kernels still read the batch

The resident-scan path wraps the cached batch's read-only accessor (the batch
READ LOCK) in an `owning_table_view`, then enqueues the kernels that read the
batch — the filter gather and the view→table `release()` copy in
`post_filter_and_project`, plus normalization work in the scan's `execute()` —
and destroyed the owner (dropping the lock) before any of that work completed:
inside `post_filter_and_project` on some paths (the duckdb-native no-filter
path moves the owner into a local; parquet re-assigns `input` right after
enqueueing the gather), or at `execute()` exit — both ahead of
`run_one_operator`'s post-execute sync.

The moment the lock drops, the downgrade executor's `try_to_mutable` succeeds
and, under memory pressure, evicts the batch GPU→HOST and **frees its device
buffers while the scan's kernels still read them**; the async pool rebinds the
region to concurrent work. The keep-mask branches of
`gpu_ingestible::materialize_table` already synchronized for exactly this
hazard — the non-mask paths lacked the same discipline.

**Fix:** synchronize the stream before every owner-death point — the end of
both `post_filter_and_project` implementations and the end of the scan
`execute()` (the latter is nearly free: `run_one_operator` syncs the same
stream immediately after).

### Instance 2: query-abort teardown races the aborted query's still-running kernels

A pipeline task that throws out of `gpu_pipeline_task::execute()` (e.g.
`rmm::out_of_memory` inside a cudf call) unwinds with its kernels still
enqueued on `exc_stream`. In `gpu_pipeline_executor`'s worker lambda:

- the `task_reschedule_exception` handler synced `exc_stream` — but only
  *after* an early `return` taken when the completion handler was already in
  an error state (the exact path taken when a sibling task's fail-fast had
  already errored the query), and
- the generic `catch (std::exception&)` / `catch (...)` paths never synced.

On those unsynced exits the task (and the reschedule exception, which owns the
task's input batches) is destroyed. Its buffers are freed *stream-ordered on
the streams that allocated them* — long-idle upstream streams — so the async
pool considers the memory immediately reusable while `exc_stream`'s orphaned
kernels still read/write it. `drain_after_error()` only joins host lambdas;
`QueryEnd` then frees the whole query's device memory the same way. One abort
poisons many concurrent victims.

**Fix:** quiesce `exc_stream` on every abnormal exit of the worker lambda
before any owner of device memory is destroyed — the sync is hoisted to the
top of the reschedule handler (now covering the has-error early return and the
failed-cast return) and added to both generic catches (sync failures from
sticky CUDA errors are logged, never thrown). Belt-and-suspenders: a
device-scoped `cudaDeviceSynchronize` per GPU executor in
`task_scheduler::drain_after_error()` (error path only) so QueryEnd can never
free device memory with pending kernels even through a throw path the handlers
miss.

## Verification

Forensics and verification were run on the SF1000 staged-refresh concurrent
throughput stack where the corruption reproduced (~50% incidence):

- **Deterministic repro via poison-on-free.** An env-gated diagnostic
  (`SIRIUS_POISON_FREES=1`) enqueues a stream-ordered 0xEE fill over every
  freed device region before the free, converting use-after-free reads from
  timing-dependent stale-but-intact data into deterministic garbage.
  Pre-fix: **3/3 runs wedged**, always within the *sequential* phases —
  proving a freed-while-still-read buffer in the normal warm serve path, no
  query abort required. Post-fix: **3/3 poison-armed sequential trials
  clean** (full power coverage, zero corruption events) plus **1/1
  poison-armed full concurrent run clean**, including seven genuine OOM→CPU
  fallbacks — i.e. the error-path teardown executed seven times at maximum
  use-after-free sensitivity and corrupted nothing.
- **GPU core dump naming the livelocked kernel.** A user-triggered core dump
  (`CUDA_ENABLE_USER_TRIGGERED_COREDUMP`) at a pre-fix wedge showed exactly
  one active kernel: `cuco::detail::open_addressing_ns::insert_if_n<...,
  cudf::detail::primitive_keys_fn<rhs_index_type>...>` — the cudf
  `distinct_hash_join` build insert over 200 M rows, livelocked because its
  row comparator read memory mutating under it (dangling build-input views
  into an evicted batch). This ties face 3 to the same defect.
- **Regression test** (`test/cpp/pipeline/test_gpu_pipeline_executor.cpp`,
  tag `[gpu_pipeline_executor]`): a task enqueues slow stream-ordered work
  and throws (a) `oom_reschedule_exception` with the completion handler
  pre-errored — the exact regressed path — and (b) a generic exception; the
  task destructor records whether it ran while stream work was still pending.
  Fails on the pre-fix code, passes with the fix.
- **Clean scored production runs:** with the fixes (poison off, decode/ASCII
  guards armed as canaries), 3/3 full SF1000 power+throughput runs completed
  with zero corruption events (QphH 7,211,669 / 7,365,117 / 7,044,510).

**Known residual (honest status):** one post-fix production run wedged
silently with a different signature (low-occupancy ~254 W spin vs the 480 W
distinct-build wedges), zero errors. The poison-deterministic instance and the
teardown instance are gone, but the bug *class* is reduced, not proven extinct
at production timing — poison slows the engine ~3.5×, which can shift a narrow
race out of its window. A follow-up hunt with the coredump pipe armed is the
next step; it does not block this fix.

## Note for reviewers

The poison-on-free diagnostic used for the deterministic repro is intentionally
kept out of this PR (it taxes every free). It lives on the cucascade branch
`diag/poison-on-free` if you want to reproduce the verification.

## Performance

The added syncs are on paths that were already followed by a sync
(`run_one_operator` syncs the operator stream right after `execute()`), on
error-only paths, or replace an unsynchronized owner-death that was simply
wrong. No measurable cost in the scored SF1000 runs above.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
