### PR TITLE
fix(scan): column-aware pinned-entry lookup for split pin layouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -777,6 +777,7 @@ set(TEST_SOURCES
     test/cpp/scan_manager/test_memory_prefetcher_accounting.cpp
     test/cpp/scan_manager/test_mvcc_mask_job.cpp
     test/cpp/scan_manager/test_pinned_chunk_stats.cpp
+    test/cpp/scan_manager/test_pinned_entry_column_lookup.cpp
     test/cpp/operator/test_physical_grouped_aggregate_merge_mgpu.cpp
     test/cpp/operator/test_physical_hash_join_mgpu.cpp
     test/cpp/operator/test_physical_order_mgpu.cpp

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -131,14 +131,14 @@ class cache_entry_info {
     const op::scan::ingestible_table_info& other) const;
 
   /// Duckdb-identity check shared by can_serve_with_columns and the plan-time
-  /// MVCC guards — one matcher, so the probe and prepare can never drift.
+  /// MVCC guards — one matcher, so the probe and prepare can never disagree.
   /// False for parquet entries (empty table_name).
   [[nodiscard]] bool matches_duckdb_table(std::string_view catalog,
                                           std::string_view schema,
                                           std::string_view table) const;
 
   /// Parquet-identity check shared by can_serve_with_columns and the plan-time
-  /// residency gate — one matcher, so the probe and prepare can never drift.
+  /// residency gate — one matcher, so the probe and prepare can never disagree.
   /// Same file set irrespective of order (both sides sorted, byte-exact compare).
   /// False for duckdb entries (empty resolved_file_paths) and for an empty @p files.
   [[nodiscard]] bool matches_parquet_files(std::span<std::string const> files) const;
@@ -334,6 +334,16 @@ void validate_recorded_column_storage(sirius::pinned_column_storage_matrix const
  */
 [[nodiscard]] std::optional<cudf::data_type> pinned_column_narrow_carrier(
   pinned_entry const& entry, std::size_t entry_position, cudf::data_type native_type);
+
+/// True when every column of @p column_ids that @p entry carries still maps, in
+/// every chunk, to the pin-time native cuDF type @p returned_types declares. A
+/// column the entry lacks is skipped (coverage is checked separately) and an
+/// empty column-storage matrix passes. Shared by the plan-time MVCC guard and
+/// the lookup below.
+[[nodiscard]] bool pinned_native_types_match_columns(
+  pinned_entry const& entry,
+  duckdb::vector<duckdb::ColumnIndex> const& column_ids,
+  duckdb::vector<duckdb::LogicalType> const& returned_types);
 
 /**
  * @brief Cache-serve-time survivor plan for one cached scan.
@@ -639,10 +649,18 @@ class sirius_scan_manager {
 
   /// The pinned entry whose duckdb identity matches catalog.schema.table, or
   /// nullptr. Non-owning; obtain and read it inside one slot-scoped window, and
-  /// never hold it across a pin or unpin. First match wins if one table was
-  /// pinned under two names. Read by the plan-time MVCC guards.
+  /// never hold it across a pin or unpin. When one table is pinned under two
+  /// names with different column sets, @p requested_ids and @p returned_types
+  /// apply the plan-time guard's own two gates: prefer an entry that covers the
+  /// scan and whose pin-time native types still match, then one that only
+  /// covers, then the first identity match. Never null where one identity match
+  /// exists — that would read as an unpinned table.
   [[nodiscard]] pinned_entry const* find_pinned_entry_for_duckdb_table(
-    std::string_view catalog_name, std::string_view schema_name, std::string_view table_name) const;
+    std::string_view catalog_name,
+    std::string_view schema_name,
+    std::string_view table_name,
+    duckdb::vector<duckdb::ColumnIndex> const* requested_ids  = nullptr,
+    duckdb::vector<duckdb::LogicalType> const* returned_types = nullptr) const;
 
   /// The pinned entry whose parquet identity matches @p resolved_file_paths
   /// (cache_entry_info::matches_parquet_files), or nullptr. Non-owning; obtain

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -111,42 +111,6 @@ std::vector<cudf::data_type> scan_physical_schema(duckdb::LogicalGet& op,
   return changed ? result : std::vector<cudf::data_type>{};
 }
 
-// Plan-time counterpart of the DuckDB serve-time native-type gate. Every storage-backed projected
-// column must retain its pin-time native mapping across all chunks. Column coverage remains the
-// cache-serviceability guard's responsibility; an empty matrix passes for zero-chunk compatibility.
-[[nodiscard]] bool pinned_native_types_match_columns(
-  sirius::scan_manager::pinned_entry const& entry,
-  duckdb::vector<duckdb::ColumnIndex> const& column_ids,
-  duckdb::vector<duckdb::LogicalType> const& returned_types)
-{
-  if (entry.column_storage.empty()) { return true; }
-
-  std::unordered_map<duckdb::idx_t, std::size_t> entry_pos_by_primary;
-  entry_pos_by_primary.reserve(entry.cache_info.column_ids.size());
-  for (std::size_t i = 0; i < entry.cache_info.column_ids.size(); ++i) {
-    entry_pos_by_primary.emplace(entry.cache_info.column_ids[i].GetPrimaryIndex(), i);
-  }
-
-  for (auto const& col_idx : column_ids) {
-    if (!col_idx.HasPrimaryIndex() || col_idx.IsRowIdColumn() || col_idx.IsVirtualColumn() ||
-        col_idx.IsEmptyColumn()) {
-      continue;
-    }
-    auto const primary = col_idx.GetPrimaryIndex();
-    auto const it      = entry_pos_by_primary.find(primary);
-    if (it == entry_pos_by_primary.end()) { continue; }
-    std::optional<cudf::data_type> native;
-    if (primary < returned_types.size()) {
-      native = sirius::try_get_cudf_type(sirius::from_duckdb(returned_types[primary]));
-    }
-    if (!native) { return false; }
-    for (auto const& row : entry.column_storage) {
-      if (it->second >= row.size() || row[it->second].native != *native) { return false; }
-    }
-  }
-  return true;
-}
-
 // An OPTIONAL_FILTER is advisory and an IS_NOT_NULL is applied by the scan itself, so
 // neither contributes to the predicate convert_table_filters_to_expression builds
 // (scan_utils.cpp). This must stay in step with that skip set: probing a filter the
@@ -262,7 +226,11 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
     if (bind != nullptr && bind->table.IsDuckTable()) {
       auto& table = bind->table.Cast<duckdb::DuckTableEntry>();
       pinned      = sirius_state->get_scan_manager().find_pinned_entry_for_duckdb_table(
-        table.ParentCatalog().GetName(), table.ParentSchema().name, table.name);
+        table.ParentCatalog().GetName(),
+        table.ParentSchema().name,
+        table.name,
+        &column_ids,
+        &op.returned_types);
       // Rows beyond the pinned prefix serve as insert-delta splits, decoded fresh at native
       // width. A narrow sidecar over them would pay per-batch exact-range verification and, on
       // an out-of-range inserted value, fail the query over to the CPU fallback — so the
@@ -347,10 +315,11 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
         }
       }
 
-      // Plan and serve must classify native-type drift identically. Treat a mismatched pin as
-      // unpinned so the fresh disk path remains available.
+      // Plan and serve must judge recorded types against the scan's the same way. Treat a
+      // mismatched pin as unpinned so the fresh disk path remains available.
       if (pinned != nullptr && pinned->mvcc != nullptr &&
-          pinned_native_types_match_columns(*pinned, column_ids, op.returned_types)) {
+          sirius::scan_manager::pinned_native_types_match_columns(
+            *pinned, column_ids, op.returned_types)) {
         // Cache-or-CPU guards: while this table is MVCC-pinned, a GPU plan
         // either serves exactly from the pinned cache (DELETE keep-masks) or is
         // refused HERE, where the throw still becomes a clean CPU fallback. The

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -22,6 +22,7 @@
 #include "data/data_batch_utils.hpp"
 #include "exec/thread_pool.hpp"
 #include "helper/numeric_narrowing.hpp"
+#include "helper/type_conversions.hpp"
 #include "io/cache/prefetching_cache.hpp"
 #include "io/io_context.hpp"
 #include "io/parquet_helpers.hpp"
@@ -2461,15 +2462,61 @@ void sirius_scan_manager::visit_pinned_entries(
   }
 }
 
-pinned_entry const* sirius_scan_manager::find_pinned_entry_for_duckdb_table(
-  std::string_view catalog_name, std::string_view schema_name, std::string_view table_name) const
+bool pinned_native_types_match_columns(pinned_entry const& entry,
+                                       duckdb::vector<duckdb::ColumnIndex> const& column_ids,
+                                       duckdb::vector<duckdb::LogicalType> const& returned_types)
 {
-  for (auto const& [name, entry] : _pinned_entries) {
-    if (entry.cache_info.matches_duckdb_table(catalog_name, schema_name, table_name)) {
-      return &entry;
+  if (entry.column_storage.empty()) { return true; }
+
+  std::unordered_map<duckdb::idx_t, std::size_t> entry_pos_by_primary;
+  entry_pos_by_primary.reserve(entry.cache_info.column_ids.size());
+  for (std::size_t i = 0; i < entry.cache_info.column_ids.size(); ++i) {
+    entry_pos_by_primary.emplace(entry.cache_info.column_ids[i].GetPrimaryIndex(), i);
+  }
+
+  for (auto const& col_idx : column_ids) {
+    if (!col_idx.HasPrimaryIndex() || col_idx.IsRowIdColumn() || col_idx.IsVirtualColumn() ||
+        col_idx.IsEmptyColumn()) {
+      continue;
+    }
+    auto const primary = col_idx.GetPrimaryIndex();
+    auto const it      = entry_pos_by_primary.find(primary);
+    if (it == entry_pos_by_primary.end()) { continue; }
+    std::optional<cudf::data_type> native;
+    if (primary < returned_types.size()) {
+      native = sirius::try_get_cudf_type(sirius::from_duckdb(returned_types[primary]));
+    }
+    if (!native) { return false; }
+    for (auto const& row : entry.column_storage) {
+      if (it->second >= row.size() || row[it->second].native != *native) { return false; }
     }
   }
-  return nullptr;
+  return true;
+}
+
+pinned_entry const* sirius_scan_manager::find_pinned_entry_for_duckdb_table(
+  std::string_view catalog_name,
+  std::string_view schema_name,
+  std::string_view table_name,
+  duckdb::vector<duckdb::ColumnIndex> const* requested_ids,
+  duckdb::vector<duckdb::LogicalType> const* returned_types) const
+{
+  bool const match_columns              = requested_ids != nullptr && !requested_ids->empty();
+  pinned_entry const* identity_match    = nullptr;
+  pinned_entry const* covering_mismatch = nullptr;
+  for (auto const& [name, entry] : _pinned_entries) {
+    if (!entry.cache_info.matches_duckdb_table(catalog_name, schema_name, table_name)) { continue; }
+    if (identity_match == nullptr) { identity_match = &entry; }
+    if (!match_columns) { return &entry; }
+    if (entry.cache_info.column_projection_for(*requested_ids).empty()) { continue; }
+    // The guard reads a type-mismatched entry as unpinned, so preferring one loses a hit.
+    if (returned_types == nullptr ||
+        pinned_native_types_match_columns(entry, *requested_ids, *returned_types)) {
+      return &entry;
+    }
+    if (covering_mismatch == nullptr) { covering_mismatch = &entry; }
+  }
+  return covering_mismatch != nullptr ? covering_mismatch : identity_match;
 }
 
 pinned_entry const* sirius_scan_manager::find_pinned_entry_for_parquet_files(
@@ -2780,8 +2827,8 @@ std::optional<sirius_scan_manager::cached_assignment> sirius_scan_manager::try_m
     // Identity + serviceability gate: empty when this cache cannot serve the scan
     // (wrong format / file-set / table, or missing a requested column).
     if (entry.cache_info.can_serve_with_columns(table_info).empty()) { continue; }
-    // Check native types before strict MVCC handling so type drift is a clean cache miss rather
-    // than an MVCC error or a cache hit under the wrong type.
+    // Check native types before strict MVCC handling so a type-mismatched pin is a clean cache
+    // miss rather than an MVCC error or a hit under the wrong type.
     if (auto const* native_info =
           dynamic_cast<op::scan::duckdb_native_ingestible_table_info const*>(&table_info);
         native_info != nullptr && !pinned_native_types_match_scan(entry, *native_info)) {

--- a/test/cpp/scan_manager/test_pinned_entry_column_lookup.cpp
+++ b/test/cpp/scan_manager/test_pinned_entry_column_lookup.cpp
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// find_pinned_entry_for_duckdb_table over a split pin layout: one table pinned
+// under two names with different column sets. The coverage and type cases are
+// directed — a first-identity-match rule fails one of each pair for any
+// unordered-map iteration order.
+
+#include "memory/topology_index.hpp"
+#include "scan/test_utils.hpp"
+#include "scan_manager/sirius_scan_manager.hpp"
+
+#include <cudf/column/column_factories.hpp>
+
+#include <catch.hpp>
+#include <cucascade/memory/topology_discovery.hpp>
+#include <duckdb/common/column_index.hpp>
+#include <duckdb/common/types.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using sirius::pinned_column_storage_matrix;
+using sirius::pinned_column_storage_meta;
+using sirius::scan_manager::cache_entry_info;
+using sirius::scan_manager::pinned_entry;
+using sirius::scan_manager::scan_manager_config;
+using sirius::scan_manager::sirius_scan_manager;
+
+constexpr char const* kCatalog = "memory";
+constexpr char const* kSchema  = "main";
+constexpr char const* kTable   = "orders";
+
+cucascade::memory::system_topology_info single_gpu_topology()
+{
+  cucascade::memory::system_topology_info topology;
+  topology.num_gpus = 1;
+  cucascade::memory::gpu_topology_info gpu;
+  gpu.id        = 0;
+  gpu.numa_node = 0;
+  topology.gpus.push_back(std::move(gpu));
+  return topology;
+}
+
+std::shared_ptr<const sirius::memory::topology_index> single_gpu_index()
+{
+  return std::make_shared<sirius::memory::topology_index>(single_gpu_topology(),
+                                                          std::vector<int>{0});
+}
+
+cache_entry_info make_cache_info(std::vector<std::size_t> const& primary_indices,
+                                 std::string const& table = kTable)
+{
+  cache_entry_info info;
+  info.catalog_name = kCatalog;
+  info.schema_name  = kSchema;
+  info.table_name   = table;
+  for (auto const idx : primary_indices) {
+    info.column_ids.emplace_back(idx);
+    info.names.push_back("c" + std::to_string(idx));
+  }
+  return info;
+}
+
+duckdb::vector<duckdb::ColumnIndex> request(std::vector<std::size_t> const& primary_indices)
+{
+  duckdb::vector<duckdb::ColumnIndex> ids;
+  for (auto const idx : primary_indices) {
+    ids.emplace_back(idx);
+  }
+  return ids;
+}
+
+/// Zero-chunk pin: the lookup reads only cache_info.
+void pin_metadata_entry(sirius_scan_manager& manager,
+                        std::string const& name,
+                        std::vector<std::size_t> const& primary_indices)
+{
+  manager.insert_pinned_entry(name, make_cache_info(primary_indices), {}, {}, {}, {}, {});
+}
+
+/// 'orders' covers every column but c8; the 'main.orders' split covers {0, 1, 8}.
+struct split_pin_fixture {
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory =
+    initialize_memory_manager(1);
+  sirius_scan_manager manager{scan_manager_config{}, *memory, single_gpu_index()};
+
+  split_pin_fixture()
+  {
+    pin_metadata_entry(manager, "orders", {0, 1, 2, 3, 4, 5, 6, 7});
+    pin_metadata_entry(manager, "main.orders", {0, 1, 8});
+  }
+};
+
+bool is_wide_entry(pinned_entry const* entry)
+{
+  REQUIRE(entry != nullptr);
+  return entry->cache_info.column_ids.size() == 8u;
+}
+
+constexpr cudf::data_type kInt64{cudf::type_id::INT64};
+constexpr cudf::data_type kInt32{cudf::type_id::INT32};
+
+/// One chunk of @p n_columns INT64 columns; insert validates carriers against these.
+std::vector<std::unique_ptr<cudf::table>> one_int64_chunk(std::size_t n_columns)
+{
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  for (std::size_t i = 0; i < n_columns; ++i) {
+    columns.push_back(cudf::make_fixed_width_column(kInt64, 4));
+  }
+  std::vector<std::unique_ptr<cudf::table>> tables;
+  tables.push_back(std::make_unique<cudf::table>(std::move(columns)));
+  return tables;
+}
+
+/// Pin one INT64 chunk recording @p native as its pin-time mapping. INT32 models
+/// an entry no longer matching the INT64 the scan's BIGINT maps to.
+void pin_typed_entry(sirius_scan_manager& manager,
+                     sirius::memory::sirius_memory_reservation_manager& memory,
+                     std::string const& name,
+                     std::vector<std::size_t> const& primary_indices,
+                     cudf::data_type native)
+{
+  pinned_column_storage_matrix storage{std::vector<pinned_column_storage_meta>(
+    primary_indices.size(), pinned_column_storage_meta{kInt64, false, native})};
+  manager.insert_pinned_entry(
+    name,
+    make_cache_info(primary_indices),
+    one_int64_chunk(primary_indices.size()),
+    std::vector<cucascade::memory::memory_space*>{
+      sirius::scan_test_utils::get_space(memory, cucascade::memory::Tier::GPU)},
+    {},
+    {},
+    std::move(storage));
+}
+
+/// Both entries cover {c0, c1}; only @p matching keeps the INT64 mapping. The
+/// guard reads the other as unpinned, so preferring it loses a servable hit.
+struct type_match_fixture {
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory =
+    initialize_memory_manager(1);
+  sirius_scan_manager manager{scan_manager_config{}, *memory, single_gpu_index()};
+  duckdb::vector<duckdb::LogicalType> returned_types{duckdb::LogicalType::BIGINT,
+                                                     duckdb::LogicalType::BIGINT};
+  std::string matching_name;
+
+  explicit type_match_fixture(std::string matching) : matching_name(std::move(matching))
+  {
+    for (auto const* name : {"orders", "main.orders"}) {
+      pin_typed_entry(manager, *memory, name, {0, 1}, name == matching_name ? kInt64 : kInt32);
+    }
+  }
+
+  [[nodiscard]] static bool types_match(pinned_entry const* entry)
+  {
+    REQUIRE(entry != nullptr);
+    REQUIRE_FALSE(entry->column_storage.empty());
+    REQUIRE_FALSE(entry->column_storage.front().empty());
+    return entry->column_storage.front().front().native == kInt64;
+  }
+};
+
+}  // namespace
+
+TEST_CASE("split pin: a request only the wide entry covers lands on the wide entry",
+          "[pinned_lookup][scan_manager]")
+{
+  split_pin_fixture fixture;
+
+  auto const wide_only = request({2, 3});
+  auto const* chosen =
+    fixture.manager.find_pinned_entry_for_duckdb_table(kCatalog, kSchema, kTable, &wide_only);
+  REQUIRE(chosen != nullptr);
+  REQUIRE(is_wide_entry(chosen));
+  REQUIRE_FALSE(chosen->cache_info.column_projection_for(wide_only).empty());
+}
+
+TEST_CASE("split pin: a request only the split entry covers lands on the split entry",
+          "[pinned_lookup][scan_manager]")
+{
+  split_pin_fixture fixture;
+
+  auto const split_only = request({1, 8});
+  auto const* chosen =
+    fixture.manager.find_pinned_entry_for_duckdb_table(kCatalog, kSchema, kTable, &split_only);
+  REQUIRE(chosen != nullptr);
+  REQUIRE_FALSE(is_wide_entry(chosen));
+  REQUIRE_FALSE(chosen->cache_info.column_projection_for(split_only).empty());
+}
+
+TEST_CASE("split pin: a request both entries cover returns a serving entry",
+          "[pinned_lookup][scan_manager]")
+{
+  split_pin_fixture fixture;
+
+  // {c0, c1} is a subset of both entries; either answer is valid if it serves.
+  auto const both = request({0, 1});
+  auto const* chosen =
+    fixture.manager.find_pinned_entry_for_duckdb_table(kCatalog, kSchema, kTable, &both);
+  REQUIRE(chosen != nullptr);
+  REQUIRE_FALSE(chosen->cache_info.column_projection_for(both).empty());
+}
+
+TEST_CASE("split pin: no covering entry falls back to a non-null identity match",
+          "[pinned_lookup][scan_manager]")
+{
+  split_pin_fixture fixture;
+
+  // No entry covers {c1, c7, c8}; the guard declines the scan on the fallback.
+  auto const uncovered = request({1, 7, 8});
+  auto const* chosen =
+    fixture.manager.find_pinned_entry_for_duckdb_table(kCatalog, kSchema, kTable, &uncovered);
+  REQUIRE(chosen != nullptr);
+  REQUIRE(chosen->cache_info.table_name == kTable);
+  REQUIRE(chosen->cache_info.column_projection_for(uncovered).empty());
+
+  REQUIRE(fixture.manager.find_pinned_entry_for_duckdb_table(
+            kCatalog, kSchema, "lineitem", &uncovered) == nullptr);
+}
+
+TEST_CASE("split pin: null or empty requested ids keep the first-identity-match behavior",
+          "[pinned_lookup][scan_manager]")
+{
+  split_pin_fixture fixture;
+
+  auto const* chosen =
+    fixture.manager.find_pinned_entry_for_duckdb_table(kCatalog, kSchema, kTable, nullptr);
+  REQUIRE(chosen != nullptr);
+  REQUIRE(chosen->cache_info.table_name == kTable);
+
+  duckdb::vector<duckdb::ColumnIndex> const empty;
+  chosen = fixture.manager.find_pinned_entry_for_duckdb_table(kCatalog, kSchema, kTable, &empty);
+  REQUIRE(chosen != nullptr);
+  REQUIRE(chosen->cache_info.table_name == kTable);
+
+  // Defaulted three-argument form, as existing callers use it.
+  chosen = fixture.manager.find_pinned_entry_for_duckdb_table(kCatalog, kSchema, kTable);
+  REQUIRE(chosen != nullptr);
+}
+
+TEST_CASE("type match: a covering entry whose recorded types no longer match loses to one whose do",
+          "[pinned_lookup][scan_manager]")
+{
+  // Both assignments run, so a coverage-only rule fails one of them for any iteration order.
+  auto const matching_name = GENERATE(std::string{"orders"}, std::string{"main.orders"});
+  type_match_fixture fixture{matching_name};
+
+  auto const both    = request({0, 1});
+  auto const* chosen = fixture.manager.find_pinned_entry_for_duckdb_table(
+    kCatalog, kSchema, kTable, &both, &fixture.returned_types);
+  REQUIRE(type_match_fixture::types_match(chosen));
+}
+
+TEST_CASE("type match: when no covering entry still matches, one is returned anyway",
+          "[pinned_lookup][scan_manager]")
+{
+  auto memory = initialize_memory_manager(1);
+  sirius_scan_manager manager{scan_manager_config{}, *memory, single_gpu_index()};
+  pin_typed_entry(manager, *memory, "orders", {0, 1}, kInt32);
+  duckdb::vector<duckdb::LogicalType> const returned_types{duckdb::LogicalType::BIGINT,
+                                                           duckdb::LogicalType::BIGINT};
+
+  // nullptr here would read as an unpinned table and route to the disk-native path.
+  auto const both = request({0, 1});
+  REQUIRE(manager.find_pinned_entry_for_duckdb_table(
+            kCatalog, kSchema, kTable, &both, &returned_types) != nullptr);
+}


### PR DESCRIPTION
## Problem

`find_pinned_entry_for_duckdb_table` returned the first identity match in
`_pinned_entries` iteration order, ignoring the requested columns. Under a split
pin layout — one table pinned as two entries with different column sets — the
plan-time MVCC guard in `sirius_plan_get.cpp` could land on an entry that cannot
serve the scan, declare it unservable, and silently fall back to CPU. The serving
side (`try_match_cached_entry`) is column-aware and would have matched the other
entry, so the two disagreed.

Results stay correct, so nothing in validation flags it. Measured at SF1000
(GB300, TPC-H, split pin over `orders`): ~10 queries per pass fell back this way,
stream time 108 s instead of 11 s.

## Fix

The lookup takes the scan's `column_ids` and `returned_types` (both optional
pointers, `nullptr` default) and prefers, among identity matches:

1. an entry that covers the requested columns **and** whose recorded pin-time
   native types still equal the ones the scan declares;
2. failing that, a covering entry whose recorded types no longer match;
3. failing that, the first identity match.

Those are the same two gates the plan-time guard itself applies, so the lookup
can no longer hand the guard an entry it will reject while a usable one exists.
It never returns `nullptr` where an identity match exists — that would flip the
guard from "decline this scan" to "table is unpinned", which routes to the
MVCC-blind disk read.

`pinned_native_types_match_columns` moves out of `sirius_plan_get.cpp`'s
anonymous namespace into `sirius::scan_manager` so the guard and the lookup call
one predicate. The serve-side `pinned_native_types_match_scan` is unchanged: its
missing-column policy differs deliberately (coverage and types are one gate at
serve time, two at plan time).

With no covering entry, or when the optional arguments are omitted, behavior is
identical to before for every non-split layout. The two other callers keep the
three-argument form.

## Tests

`test/cpp/scan_manager/test_pinned_entry_column_lookup.cpp` (`[pinned_lookup]`).

Column coverage: pins the split shape as two zero-chunk entries (`orders` =
{0..7}, `main.orders` = {0,1,8}) and asserts the covering entry is chosen in each
direction, that an uncovered request falls back to a non-null identity match, and
that null/empty/defaulted ids preserve the previous behavior.

Type matching: pins two single-chunk entries that both cover {0,1}, one recording
the INT64 the scan's BIGINT maps to and one recording INT32, and asserts the
matching entry wins — run in both assignments, so a coverage-only rule fails one
of them for any iteration order. A second case asserts a non-null result when no
covering entry matches.

Verified on this branch: full suite green; reverting just the preference loop
fails the directed cases, confirming they are directed rather than incidental.

## Note for reviewers

An entry whose recorded types no longer match is treated as unpinned by the
guard, and the branch that would otherwise protect an unpinned table is the
disabled `#if 0` block pending #1160 — so a *single* such pin still reaches the
MVCC-blind disk read. That is pre-existing on `dev` and unchanged here; this PR
only stops the lookup from preferring such an entry over a usable one.