### PR TITLE
perf(aggregate): hash-based label assignment for the COLLECT_SET group-key encode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -761,6 +761,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_build_probe_scheduling.cpp
     test/cpp/operator/test_cross_schedule.cpp
     test/cpp/operator/aggregate/test_gpu_merge_impl.cpp
+    test/cpp/operator/aggregate/test_hash_encode.cpp
     test/cpp/operator/aggregate/test_physical_grouped_aggregate.cpp
     test/cpp/operator/aggregate/test_physical_grouped_aggregate_count_distinct.cpp
     test/cpp/operator/aggregate/test_physical_grouped_aggregate_merge.cpp

--- a/src/include/op/aggregate/gpu_aggregate_impl.hpp
+++ b/src/include/op/aggregate/gpu_aggregate_impl.hpp
@@ -91,6 +91,33 @@ class gpu_aggregate_impl {
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space,
     const telemetry::batch_telemetry_info& telemetry_info = {});
+
+  /**
+   * @brief Hash-based drop-in replacement for `cudf::encode`.
+   *
+   * Returns exactly what `cudf::encode(keys)` returns: the distinct rows of `keys` in
+   * ascending lexicographic order (NULLs last, per column), plus one INT32 index per input
+   * row into that distinct table (`distinct[indices[i]] == keys[i]`). Row identity follows
+   * `null_equality::EQUAL` / `nan_equality::ALL_EQUAL`, matching both `cudf::encode` and
+   * cudf's sorted groupby under `null_policy::INCLUDE`.
+   *
+   * The difference is the cost model: `cudf::encode` assigns indices with a per-row
+   * `lower_bound` binary search driven by a lexicographic row comparator
+   * (O(N log G) comparator calls of random access over every key column — 119 ms for
+   * 59M rows x 3 columns in TPC-H q16), whereas this implementation assigns them with one
+   * hash-table probe per row (`cudf::distinct` + a sort at *distinct* cardinality +
+   * `cudf::distinct_hash_join::left_join`), which is ~5-10x cheaper for string-heavy keys.
+   *
+   * @param keys Table of group key columns to encode. Nested (LIST/STRUCT) key columns are
+   *        not supported (the label-encode caller gates them off; cudf throws on the
+   *        unsupported ones).
+   * @param stream CUDA stream used for device memory operations and kernel launches.
+   * @param mr Device memory resource used to allocate the returned table/column.
+   *
+   * @return {distinct key rows in sorted order, per-row INT32 index into them}.
+   */
+  static std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::column>> hash_encode(
+    const cudf::table_view& keys, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);
 };
 
 }  // namespace op

--- a/src/op/aggregate/gpu_aggregate_impl.cpp
+++ b/src/op/aggregate/gpu_aggregate_impl.cpp
@@ -24,13 +24,16 @@
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/dictionary/encode.hpp>
 #include <cudf/reduction/approx_distinct_count.hpp>
+#include <cudf/stream_compaction.hpp>
 #include <cudf/strings/strings_column_view.hpp>
-#include <cudf/transform.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 
+#include <rmm/device_uvector.hpp>
+
 #include <algorithm>
 #include <new>
+#include <numeric>
 
 namespace sirius {
 namespace op {
@@ -117,6 +120,70 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_ungrouped_aggre
   return make_data_batch(std::move(output_table), memory_space, stream, telemetry_info);
 }
 
+std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::column>>
+gpu_aggregate_impl::hash_encode(const cudf::table_view& keys,
+                                rmm::cuda_stream_view stream,
+                                rmm::device_async_resource_ref mr)
+{
+  if (keys.num_columns() == 0) {
+    throw std::runtime_error("hash_encode: keys table must have at least one column");
+  }
+
+  // 1. Distinct rows via hash (unordered). Row identity: NULL == NULL, NaN == NaN --
+  //    identical to `cudf::encode` and to cudf's sorted groupby under
+  //    `null_policy::INCLUDE`.
+  std::vector<cudf::size_type> all_columns(keys.num_columns());
+  std::iota(all_columns.begin(), all_columns.end(), 0);
+  auto distinct_keys = cudf::distinct(keys,
+                                      all_columns,
+                                      cudf::duplicate_keep_option::KEEP_ANY,
+                                      cudf::null_equality::EQUAL,
+                                      cudf::nan_equality::ALL_EQUAL,
+                                      stream,
+                                      mr);
+
+  // 2. Sort the distinct rows -- this runs at *group* cardinality, not input rows.
+  //    Ascending with NULLs last matches `cudf::encode`'s output ordering exactly. No
+  //    stability concern: the rows are distinct, so there are no ties.
+  auto const sort_order =
+    cudf::sorted_order(distinct_keys->view(),
+                       /*column_order=*/{},
+                       std::vector<cudf::null_order>(keys.num_columns(), cudf::null_order::AFTER),
+                       stream,
+                       mr);
+  auto sorted_keys = cudf::gather(
+    distinct_keys->view(), sort_order->view(), cudf::out_of_bounds_policy::DONT_CHECK, stream, mr);
+  distinct_keys.reset();
+
+  // 3. Assign each input row its index into `sorted_keys` with one hash probe per row.
+  //    `left_join` on a distinct build table returns exactly one build index per probe row,
+  //    in probe-row order -- precisely the label column, no scatter needed.
+  cudf::distinct_hash_join key_to_label(
+    sorted_keys->view(), cudf::null_equality::EQUAL, /*load_factor=*/0.5, stream);
+  auto labels = key_to_label.left_join(keys, stream, mr);
+  auto label_col =
+    std::make_unique<cudf::column>(std::move(*labels), rmm::device_buffer{}, /*null_count=*/0);
+
+  // 4. Every probe row is present in the build table by construction (same rows, same
+  //    NULL/NaN equality), so every label must be a valid index. Verify with one cheap
+  //    min-reduce: an unmatched row would carry the negative `JoinNoMatch` sentinel and
+  //    silently corrupt the post-aggregate key gather.
+  if (keys.num_rows() > 0) {
+    auto min_label  = cudf::reduce(label_col->view(),
+                                  *cudf::make_min_aggregation<cudf::reduce_aggregation>(),
+                                  label_col->view().type(),
+                                  stream,
+                                  mr);
+    auto& typed_min = static_cast<cudf::numeric_scalar<cudf::size_type>&>(*min_label);
+    if (!typed_min.is_valid(stream) || typed_min.value(stream) < 0) {
+      throw std::runtime_error(
+        "hash_encode: probe row missing from its own distinct set (join sentinel in labels)");
+    }
+  }
+
+  return {std::move(sorted_keys), std::move(label_col)};
+}
+
 std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggregate(
   const cucascade::read_only_data_batch& input,
   const std::vector<int>& group_idx,
@@ -153,23 +220,32 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
   // fixed-width, null-free column is dispatched to `sorted_order_radix`
   // (`cub::DeviceRadixSort`), which is a handful of fully coalesced passes.
   //
-  // So we collapse the whole key table into one dense INT32 label with `cudf::encode` and
-  // group by that instead. `cudf::encode` returns the distinct key rows in sorted order plus
-  // the per-row index into them, so the label ordering is exactly the lexicographic ordering
-  // of the original key tuples -- group identity and group ordering are both preserved. The
-  // original key columns are recovered after the aggregate with a gather at group cardinality.
+  // So we collapse the whole key table into one dense INT32 label with `hash_encode` (a
+  // hash-based drop-in for `cudf::encode` -- see below) and group by that instead. It returns
+  // the distinct key rows in sorted order plus the per-row index into them, so the label
+  // ordering is exactly the lexicographic ordering of the original key tuples -- group
+  // identity and group ordering are both preserved. The original key columns are recovered
+  // after the aggregate with a gather at group cardinality.
   //
-  // NULL semantics are preserved: `cudf::encode` builds the distinct set with
-  // `null_equality::EQUAL` / `nan_equality::ALL_EQUAL` and searches it with
-  // `null_order::AFTER`, which is precisely what the sorted groupby helper does for
+  // Why not `cudf::encode` itself: it assigns the per-row index with a `thrust::lower_bound`
+  // binary search over the sorted distinct rows, driven by a generic lexicographic row
+  // comparator -- O(N log G) comparator calls of *random* access over every key column. On
+  // TPC-H q16 (59.4M rows x [p_brand, p_type, p_size], G~18k) that single kernel is 118.8 ms,
+  // 41% of the query. `hash_encode` computes the same mapping with one hash-table probe per
+  // row (~10-25 ms at that scale): `cudf::distinct` (hash-based), a sort at *distinct*
+  // cardinality only, then `cudf::distinct_hash_join::left_join` to look up each row's index.
+  //
+  // NULL semantics are preserved: the distinct set is built with `null_equality::EQUAL` /
+  // `nan_equality::ALL_EQUAL` and sorted with `null_order::AFTER`, which is precisely what
+  // `cudf::encode` produces and what the sorted groupby helper does for
   // `null_policy::INCLUDE`. A key tuple containing NULL therefore gets its own label and
   // becomes its own group, exactly as before.
   //
   // Only worth it when the sort actually dominates, so gate on a large input; and pointless
   // when the key table is already a single radix-sortable column.
   //
-  // The gate on group cardinality matters most: `cudf::encode` is distinct + a sort of the
-  // *distinct* rows + a binary search per input row. That is a large win when the groups are
+  // The gate on group cardinality matters most: the encode is distinct + a sort of the
+  // *distinct* rows + a hash probe per input row. That is a large win when the groups are
   // few, but for a high-cardinality key (say COUNT(DISTINCT ...) grouped by an order key) the
   // distinct-key sort is as big as the sort we are trying to avoid, and we would come out
   // behind. An HLL estimate over the key rows is ~O(1) memory and one cheap pass, so use it to
@@ -215,7 +291,7 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
           input_table.num_rows(),
           ratio);
       } else {
-        auto encoded     = cudf::encode(keys_view, stream, mr);
+        auto encoded     = hash_encode(keys_view, stream, mr);
         label_key_values = std::move(encoded.first);
         label_col        = std::move(encoded.second);
         SIRIUS_LOG_DEBUG(

--- a/test/cpp/operator/aggregate/test_hash_encode.cpp
+++ b/test/cpp/operator/aggregate/test_hash_encode.cpp
@@ -1,0 +1,491 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for gpu_aggregate_impl::hash_encode -- the hash-based drop-in replacement for
+// cudf::encode used by the COLLECT_SET (COUNT DISTINCT) label-encode group-by path.
+//
+// The oracle for most tests is cudf::encode itself: for any input, hash_encode must
+// produce the exact same (sorted distinct rows, per-row label) pair. Scenarios:
+//
+//   1. q16-shaped multi-column string+int keys with heavy duplication.
+//   2. NULL key rows: NULL == NULL forms one group, sorted last.
+//   3. NaN key rows: NaN == NaN collapses to a single label.
+//   4. Empty input, single row, all-rows-identical.
+//   5. Large-cardinality randomized differential (exercises hash-table collision
+//      handling inside cudf::distinct / distinct_hash_join) including the
+//      all-rows-distinct extreme.
+//   6. End-to-end: COUNT DISTINCT through local_grouped_aggregate at the label-encode
+//      gate scale (>= 2^20 rows, low group cardinality) so the hash_encode path runs
+//      inside the real operator and the post-aggregate key recovery is validated.
+
+#include "../operator_test_utils.hpp"
+#include "data/data_batch_utils.hpp"
+#include "op/aggregate/gpu_aggregate_impl.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/transform.hpp>
+
+#include <catch.hpp>
+
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <random>
+#include <string>
+#include <tuple>
+#include <vector>
+
+using namespace sirius;
+using namespace sirius::op;
+using namespace sirius::test::operator_utils;
+using namespace cucascade;
+using namespace cucascade::memory;
+
+namespace {
+
+memory_space* get_shared_mem_space()
+{
+  static auto manager = sirius::test::operator_utils::initialize_memory_manager();
+  return manager->get_memory_space(Tier::GPU, 0);
+}
+
+template <typename T>
+std::unique_ptr<cudf::column> make_numeric_column_from(const std::vector<T>& values,
+                                                       cudf::type_id type_id,
+                                                       rmm::cuda_stream_view stream,
+                                                       rmm::device_async_resource_ref mr)
+{
+  auto col = cudf::make_numeric_column(cudf::data_type{type_id},
+                                       static_cast<cudf::size_type>(values.size()),
+                                       cudf::mask_state::UNALLOCATED,
+                                       stream,
+                                       mr);
+  if (!values.empty()) {
+    cudaMemcpyAsync(col->mutable_view().data<T>(),
+                    values.data(),
+                    values.size() * sizeof(T),
+                    cudaMemcpyHostToDevice,
+                    stream.value());
+  }
+  stream.synchronize();
+  return col;
+}
+
+/// Apply a validity vector (true == valid) as a null mask onto an existing column.
+void apply_validity(cudf::column& col,
+                    const std::vector<bool>& valid,
+                    rmm::cuda_stream_view stream,
+                    rmm::device_async_resource_ref mr)
+{
+  REQUIRE(static_cast<std::size_t>(col.size()) == valid.size());
+  auto const mask_bytes =
+    cudf::bitmask_allocation_size_bytes(static_cast<cudf::size_type>(valid.size()));
+  std::vector<cudf::bitmask_type> words(mask_bytes / sizeof(cudf::bitmask_type), 0);
+  cudf::size_type null_count = 0;
+  for (std::size_t i = 0; i < valid.size(); ++i) {
+    if (valid[i]) {
+      words[i / 32] |= (cudf::bitmask_type{1} << (i % 32));
+    } else {
+      ++null_count;
+    }
+  }
+  rmm::device_buffer mask(mask_bytes, stream, mr);
+  cudaMemcpyAsync(mask.data(), words.data(), mask_bytes, cudaMemcpyHostToDevice, stream.value());
+  stream.synchronize();
+  col.set_null_mask(std::move(mask), null_count);
+}
+
+/// Value-level equality of two columns, on host. NaN == NaN. Null rows must line up
+/// (values under null rows are not compared).
+void expect_columns_equal(const cudf::column_view& actual, const cudf::column_view& expected)
+{
+  REQUIRE(actual.type().id() == expected.type().id());
+  REQUIRE(actual.size() == expected.size());
+  auto const actual_valid   = copy_validity_to_host(actual);
+  auto const expected_valid = copy_validity_to_host(expected);
+  REQUIRE(actual_valid == expected_valid);
+
+  auto compare = [&](auto tag) {
+    using T                  = decltype(tag);
+    auto const actual_host   = copy_column_to_host<T>(actual);
+    auto const expected_host = copy_column_to_host<T>(expected);
+    std::size_t mismatches   = 0;
+    std::size_t first        = 0;
+    for (std::size_t i = 0; i < actual_host.size(); ++i) {
+      if (!actual_valid[i]) { continue; }
+      if constexpr (std::is_floating_point_v<T>) {
+        if (std::isnan(actual_host[i]) && std::isnan(expected_host[i])) { continue; }
+      }
+      if (actual_host[i] != expected_host[i]) {
+        if (mismatches == 0) { first = i; }
+        ++mismatches;
+      }
+    }
+    INFO("mismatching rows: " << mismatches << ", first at row " << first);
+    REQUIRE(mismatches == 0);
+  };
+
+  switch (actual.type().id()) {
+    case cudf::type_id::INT32: compare(int32_t{}); break;
+    case cudf::type_id::INT64: compare(int64_t{}); break;
+    case cudf::type_id::FLOAT64: compare(double{}); break;
+    case cudf::type_id::STRING: compare(std::string{}); break;
+    default: FAIL("expect_columns_equal: unhandled type in test helper");
+  }
+}
+
+/// Differential oracle: hash_encode(keys) must equal cudf::encode(keys) exactly.
+void expect_matches_cudf_encode(const cudf::table_view& keys,
+                                rmm::cuda_stream_view stream,
+                                rmm::device_async_resource_ref mr)
+{
+  auto [actual_keys, actual_labels]     = gpu_aggregate_impl::hash_encode(keys, stream, mr);
+  auto [expected_keys, expected_labels] = cudf::encode(keys, stream, mr);
+  stream.synchronize();
+
+  REQUIRE(actual_keys->num_columns() == expected_keys->num_columns());
+  REQUIRE(actual_keys->num_rows() == expected_keys->num_rows());
+  for (cudf::size_type c = 0; c < actual_keys->num_columns(); ++c) {
+    INFO("distinct-keys column " << c);
+    expect_columns_equal(actual_keys->view().column(c), expected_keys->view().column(c));
+  }
+  expect_columns_equal(actual_labels->view(), expected_labels->view());
+}
+
+}  // namespace
+
+TEST_CASE("hash_encode: q16-shaped string keys with duplicates", "[hash_encode]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+  auto stream = default_stream();
+  auto mr     = get_resource_ref(*space);
+
+  // Unsorted input with heavy duplication, mixed string lengths, and an empty string.
+  std::vector<std::string> brand = {"Brand#34",
+                                    "Brand#12",
+                                    "Brand#34",
+                                    "Brand#12",
+                                    "Brand#34",
+                                    "Brand#12",
+                                    "",
+                                    "Brand#34",
+                                    "Brand#3",
+                                    ""};
+  std::vector<std::string> type  = {"ECONOMY BRUSHED",
+                                    "STANDARD POLISHED",
+                                    "ECONOMY BRUSHED",
+                                    "STANDARD POLISHED",
+                                    "PROMO PLATED",
+                                    "STANDARD POLISHED",
+                                    "ECONOMY BRUSHED",
+                                    "ECONOMY BRUSHED",
+                                    "ECONOMY BRUSHED",
+                                    "ECONOMY BRUSHED"};
+  std::vector<int32_t> size      = {9, 14, 9, 14, 9, 23, 9, 9, 9, 9};
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(make_string_column(brand, stream, mr));
+  cols.push_back(make_string_column(type, stream, mr));
+  cols.push_back(make_numeric_column_from(size, cudf::type_id::INT32, stream, mr));
+  cudf::table keys(std::move(cols));
+
+  expect_matches_cudf_encode(keys.view(), stream, mr);
+
+  // Hand-checked semantics: 6 distinct tuples; identical tuples share a label; the
+  // label dereferences back to the original tuple.
+  auto [distinct, labels] = gpu_aggregate_impl::hash_encode(keys.view(), stream, mr);
+  stream.synchronize();
+  REQUIRE(distinct->num_rows() == 6);
+  auto const label_host = copy_column_to_host<int32_t>(labels->view());
+  auto const brand_host = copy_column_to_host<std::string>(distinct->view().column(0));
+  auto const type_host  = copy_column_to_host<std::string>(distinct->view().column(1));
+  auto const size_host  = copy_column_to_host<int32_t>(distinct->view().column(2));
+  REQUIRE(label_host.size() == brand.size());
+  REQUIRE(label_host[0] == label_host[2]);  // duplicate tuples -> same label
+  REQUIRE(label_host[0] != label_host[4]);  // row 4 differs in type only -> new label
+  for (std::size_t i = 0; i < label_host.size(); ++i) {
+    INFO("row " << i);
+    auto const l = label_host[i];
+    REQUIRE(l >= 0);
+    REQUIRE(l < 6);
+    REQUIRE(brand_host[l] == brand[i]);
+    REQUIRE(type_host[l] == type[i]);
+    REQUIRE(size_host[l] == size[i]);
+  }
+  // Distinct rows come back lexicographically sorted.
+  for (std::size_t i = 1; i < brand_host.size(); ++i) {
+    auto const prev = std::tie(brand_host[i - 1], type_host[i - 1], size_host[i - 1]);
+    auto const cur  = std::tie(brand_host[i], type_host[i], size_host[i]);
+    REQUIRE(prev < cur);
+  }
+}
+
+TEST_CASE("hash_encode: NULL keys form their own group, sorted last", "[hash_encode]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+  auto stream = default_stream();
+  auto mr     = get_resource_ref(*space);
+
+  std::vector<std::string> str_vals = {"x", "y", "x", "IGNORED", "y", "IGNORED", "x"};
+  std::vector<bool> str_valid       = {true, true, true, false, true, false, true};
+  std::vector<int32_t> int_vals     = {1, 2, 1, 5, 2, 5, 0 /* IGNORED */};
+  std::vector<bool> int_valid       = {true, true, true, true, true, true, false};
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(make_string_column(str_vals, stream, mr));
+  apply_validity(*cols.back(), str_valid, stream, mr);
+  cols.push_back(make_numeric_column_from(int_vals, cudf::type_id::INT32, stream, mr));
+  apply_validity(*cols.back(), int_valid, stream, mr);
+  cudf::table keys(std::move(cols));
+
+  expect_matches_cudf_encode(keys.view(), stream, mr);
+
+  auto [distinct, labels] = gpu_aggregate_impl::hash_encode(keys.view(), stream, mr);
+  stream.synchronize();
+  // Distinct tuples: ("x",1), ("y",2), (NULL,5), ("x",NULL) -> 4 groups; the two
+  // (NULL,5) rows must share one label (NULL == NULL).
+  REQUIRE(distinct->num_rows() == 4);
+  auto const label_host = copy_column_to_host<int32_t>(labels->view());
+  REQUIRE(label_host[3] == label_host[5]);
+  REQUIRE(label_host[0] == label_host[2]);
+  REQUIRE(label_host[1] == label_host[4]);
+  // NULL sorts after valid values within each column (null_order::AFTER): the
+  // string-NULL group must come after every valid-string group.
+  auto const distinct_str_valid = copy_validity_to_host(distinct->view().column(0));
+  REQUIRE_FALSE(distinct_str_valid.back());
+}
+
+TEST_CASE("hash_encode: NaN keys collapse to one label", "[hash_encode]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+  auto stream = default_stream();
+  auto mr     = get_resource_ref(*space);
+
+  auto const nan           = std::numeric_limits<double>::quiet_NaN();
+  std::vector<double> vals = {1.5, nan, 2.5, nan, 1.5, nan};
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(make_numeric_column_from(vals, cudf::type_id::FLOAT64, stream, mr));
+  cudf::table keys(std::move(cols));
+
+  expect_matches_cudf_encode(keys.view(), stream, mr);
+
+  auto [distinct, labels] = gpu_aggregate_impl::hash_encode(keys.view(), stream, mr);
+  stream.synchronize();
+  REQUIRE(distinct->num_rows() == 3);  // {1.5, 2.5, NaN}
+  auto const label_host = copy_column_to_host<int32_t>(labels->view());
+  REQUIRE(label_host[1] == label_host[3]);
+  REQUIRE(label_host[1] == label_host[5]);
+  REQUIRE(label_host[0] == label_host[4]);
+  REQUIRE(label_host[0] != label_host[1]);
+}
+
+TEST_CASE("hash_encode: empty input, single row, all rows identical", "[hash_encode]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+  auto stream = default_stream();
+  auto mr     = get_resource_ref(*space);
+
+  SECTION("empty input")
+  {
+    std::vector<std::unique_ptr<cudf::column>> cols;
+    cols.push_back(make_string_column({}, stream, mr));
+    cols.push_back(make_numeric_column_from<int32_t>({}, cudf::type_id::INT32, stream, mr));
+    cudf::table keys(std::move(cols));
+
+    auto [distinct, labels] = gpu_aggregate_impl::hash_encode(keys.view(), stream, mr);
+    stream.synchronize();
+    REQUIRE(distinct->num_rows() == 0);
+    REQUIRE(labels->size() == 0);
+    REQUIRE(labels->type().id() == cudf::type_id::INT32);
+  }
+
+  SECTION("single row")
+  {
+    std::vector<std::unique_ptr<cudf::column>> cols;
+    cols.push_back(make_string_column({"only"}, stream, mr));
+    cudf::table keys(std::move(cols));
+    expect_matches_cudf_encode(keys.view(), stream, mr);
+  }
+
+  SECTION("all rows identical")
+  {
+    std::vector<std::string> vals(1000, "same");
+    std::vector<std::unique_ptr<cudf::column>> cols;
+    cols.push_back(make_string_column(vals, stream, mr));
+    cudf::table keys(std::move(cols));
+
+    expect_matches_cudf_encode(keys.view(), stream, mr);
+    auto [distinct, labels] = gpu_aggregate_impl::hash_encode(keys.view(), stream, mr);
+    stream.synchronize();
+    REQUIRE(distinct->num_rows() == 1);
+    auto const label_host = copy_column_to_host<int32_t>(labels->view());
+    REQUIRE(std::all_of(label_host.begin(), label_host.end(), [](int32_t l) { return l == 0; }));
+  }
+
+  SECTION("no key columns is rejected")
+  {
+    cudf::table_view empty_keys{std::vector<cudf::column_view>{}};
+    REQUIRE_THROWS_AS(gpu_aggregate_impl::hash_encode(empty_keys, stream, mr), std::runtime_error);
+  }
+}
+
+TEST_CASE("hash_encode: large-cardinality randomized differential", "[hash_encode]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+  auto stream = default_stream();
+  auto mr     = get_resource_ref(*space);
+
+  std::mt19937_64 rng(0xC0FFEE);
+
+  SECTION("~50% distinct: heavy collision territory")
+  {
+    constexpr int n = 200000;
+    std::uniform_int_distribution<int64_t> dist(0, n / 2);
+    std::vector<int64_t> a(n), b(n);
+    for (int i = 0; i < n; ++i) {
+      a[i] = dist(rng);
+      b[i] = dist(rng) % 37;  // second column adds tuple structure
+    }
+    std::vector<std::unique_ptr<cudf::column>> cols;
+    cols.push_back(make_numeric_column_from(a, cudf::type_id::INT64, stream, mr));
+    cols.push_back(make_numeric_column_from(b, cudf::type_id::INT64, stream, mr));
+    cudf::table keys(std::move(cols));
+    expect_matches_cudf_encode(keys.view(), stream, mr);
+  }
+
+  SECTION("all rows distinct: G == N extreme")
+  {
+    constexpr int n = 100000;
+    std::vector<int64_t> a(n);
+    for (int i = 0; i < n; ++i) {
+      a[i] = i;
+    }
+    std::shuffle(a.begin(), a.end(), rng);
+    std::vector<std::unique_ptr<cudf::column>> cols;
+    cols.push_back(make_numeric_column_from(a, cudf::type_id::INT64, stream, mr));
+    cudf::table keys(std::move(cols));
+    expect_matches_cudf_encode(keys.view(), stream, mr);
+  }
+
+  SECTION("random strings with duplicates")
+  {
+    constexpr int n = 50000;
+    std::uniform_int_distribution<int> pick(0, 999);
+    std::vector<std::string> s(n);
+    for (int i = 0; i < n; ++i) {
+      s[i] = "key_" + std::to_string(pick(rng));
+    }
+    std::vector<std::unique_ptr<cudf::column>> cols;
+    cols.push_back(make_string_column(s, stream, mr));
+    cudf::table keys(std::move(cols));
+    expect_matches_cudf_encode(keys.view(), stream, mr);
+  }
+}
+
+// ===========================================================================
+// End-to-end: COUNT DISTINCT through local_grouped_aggregate at the label-encode gate
+// scale. 1.1M rows (>= 2^20 gate), 100 distinct (brand, type, size) tuples
+// (ratio 100/1.1M << 0.01 gate) so the hash_encode label path runs inside the real
+// operator. value = i % 7 with group(i) = i % 100 puts all 7 values in every group.
+// ===========================================================================
+TEST_CASE("hash_encode: COUNT DISTINCT label path end-to-end at gate scale",
+          "[hash_encode][physical_grouped_aggregate_count_distinct]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+  auto stream = default_stream();
+  auto mr     = get_resource_ref(*space);
+
+  constexpr int num_rows = 1'100'000;
+  static_assert(num_rows >= (1 << 20));
+
+  std::vector<std::string> brand(num_rows), type(num_rows);
+  std::vector<int32_t> size_col(num_rows), value(num_rows);
+  for (int i = 0; i < num_rows; ++i) {
+    brand[i]    = "Brand#" + std::to_string(i % 20);
+    type[i]     = "TYPE " + std::to_string(i % 25);
+    size_col[i] = i % 20;
+    value[i]    = i % 7;
+  }
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(make_string_column(brand, stream, mr));
+  cols.push_back(make_string_column(type, stream, mr));
+  cols.push_back(make_numeric_column_from(size_col, cudf::type_id::INT32, stream, mr));
+  cols.push_back(make_numeric_column_from(value, cudf::type_id::INT32, stream, mr));
+  auto table = std::make_unique<cudf::table>(std::move(cols));
+
+  auto gpu_repr =
+    std::make_unique<cucascade::gpu_table_representation>(std::move(table), *space, stream);
+  auto batch = cucascade::data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
+
+  auto out_batch = gpu_aggregate_impl::local_grouped_aggregate(
+    batch->to_read_only(),
+    /*group_idx=*/{0, 1, 2},
+    /*aggregates=*/{cudf::aggregation::Kind::COLLECT_SET},
+    /*aggregate_idx=*/{3},
+    /*aggregate_struct_col_indices=*/{},
+    stream,
+    *space);
+  REQUIRE(out_batch);
+
+  auto ro         = out_batch->to_read_only();
+  auto const view = sirius::get_cudf_table_view(ro);
+  REQUIRE(view.num_columns() == 4);
+  // group(i) = i % 100 (lcm of 20, 25, 20), so exactly 100 groups.
+  REQUIRE(view.num_rows() == 100);
+
+  auto const out_brand = copy_column_to_host<std::string>(view.column(0));
+  auto const out_type  = copy_column_to_host<std::string>(view.column(1));
+  auto const out_size  = copy_column_to_host<int32_t>(view.column(2));
+
+  // Reconstruct each group's key tuple and check it is one of the expected tuples,
+  // each appearing exactly once.
+  std::vector<std::tuple<std::string, std::string, int32_t>> actual_tuples, expected_tuples;
+  for (int g = 0; g < 100; ++g) {
+    expected_tuples.emplace_back(
+      "Brand#" + std::to_string(g % 20), "TYPE " + std::to_string(g % 25), g % 20);
+  }
+  for (int r = 0; r < 100; ++r) {
+    actual_tuples.emplace_back(out_brand[r], out_type[r], out_size[r]);
+  }
+  std::sort(expected_tuples.begin(), expected_tuples.end());
+  std::sort(actual_tuples.begin(), actual_tuples.end());
+  REQUIRE(actual_tuples == expected_tuples);
+
+  // Every group must have collected exactly the 7 distinct values {0..6}.
+  cudf::lists_column_view lists(view.column(3));
+  auto const offsets = copy_column_to_host<int32_t>(lists.offsets());
+  auto const child   = copy_column_to_host<int32_t>(lists.child());
+  REQUIRE(offsets.size() == 101);
+  for (int g = 0; g < 100; ++g) {
+    INFO("group " << g);
+    REQUIRE(offsets[g + 1] - offsets[g] == 7);
+    std::vector<int32_t> got(child.begin() + offsets[g], child.begin() + offsets[g + 1]);
+    std::sort(got.begin(), got.end());
+    REQUIRE(got == std::vector<int32_t>({0, 1, 2, 3, 4, 5, 6}));
+  }
+}


### PR DESCRIPTION
# perf(aggregate): hash-based label assignment for the COLLECT_SET group-key encode

## Summary

Replaces `cudf::encode` with a hash-based drop-in (`hash_encode`) in the sorted-groupby
COUNT(DISTINCT) label-encode path of `gpu_aggregate_impl::local_grouped_aggregate`.
TPC-H q16 at SF1000: **-38% phase-stable**; full suite **~-1.2%** (q16 is essentially all
of it). Output is **bit-identical** to `cudf::encode`.

## Mechanism

The COUNT(DISTINCT) sorted-groupby path collapses multi-column group keys into one
radix-sortable INT32 label via `cudf::encode`, whose per-row index assignment is a
`thrust::lower_bound` binary search driven by a lexicographic row comparator:
O(N log G) comparator calls of random access over every key column. On TPC-H SF1000 q16
(59.4M rows x [p_brand, p_type, p_size], G~18k) that single kernel measured 118.8 ms —
41% of the query.

`hash_encode` produces exactly what `cudf::encode` produces, at hash-probe cost:

1. `cudf::distinct` — hash-based distinct set (NULL==NULL / NaN==NaN, identical row
   identity to `cudf::encode` and to cudf's sorted groupby under `null_policy::INCLUDE`);
2. sort at **distinct** cardinality only (ascending, NULLs last — the exact
   `cudf::encode` output ordering; no stability concern, distinct rows have no ties);
3. `cudf::distinct_hash_join::left_join` — one hash probe per input row returns each
   row's index into the sorted distinct table, in probe-row order (no scatter needed);
4. a min-reduce guard: an unmatched probe row would carry the negative `JoinNoMatch`
   sentinel and silently corrupt the post-aggregate key gather, so fail loudly (the
   caller's existing multi-column-key fallback path remains intact).

The existing gates are unchanged: only large inputs, only multi-column / non-radix keys,
and only when the HLL group-cardinality estimate says label-encoding wins.

## Measured (GB300, SF1000, master DB read-only, host-tier compressed pins)

- Single-query A/B, 7 reps, median of last 6: **q16 0.2883 s → 0.2155 s (-25.3%)**;
  27,840-row result byte-identical to the baseline binary.
- Full varied power-only run vs `tpch_power_20260813_102701` baseline:
  **q16 0.312 s → 0.193 s power pass (-38.1%)**, phase-stable at 0.192–0.193 s across
  clean/power/postrf2 (-105..-119 ms each).
- Suite: clean pass **-1.27%**, postrf2 **-1.14%** (q16 is ~all of it); the power pass
  was polluted by q9's known RF1-delta spill-cliff trip (+146 ms — the COLLECT_SET-gated
  path cannot touch q9).

## Correctness evidence

- Output contract is differential-tested against `cudf::encode` as the oracle
  (`test/cpp/operator/aggregate/test_hash_encode.cpp`, tag `[hash_encode]`):
  q16-shaped string keys with duplicates, NULL groups sorted last, NaN collapse,
  empty/single-row/all-identical inputs, and a 200k-row randomized large-cardinality
  differential including the all-distinct case.
- End-to-end COUNT DISTINCT run through `local_grouped_aggregate` at the 2^20-row
  label-encode gate scale, validating group-key recovery and per-group sets.
- Benchmark output byte-identical to the baseline binary at SF1000.

## Knobs

None added. The change is inside the existing label-encode path and keeps its gates
(input-size gate, non-radix multi-column key gate, HLL cardinality-ratio gate). The
runtime `JoinNoMatch` min-reduce check throws into the pre-existing non-label fallback
rather than producing wrong results.

## Files

- `src/op/aggregate/gpu_aggregate_impl.cpp` — `hash_encode` + call-site swap
- `src/include/op/aggregate/gpu_aggregate_impl.hpp` — declaration + contract docs
- `test/cpp/operator/aggregate/test_hash_encode.cpp` — new differential tests
- `CMakeLists.txt` — register the test source


🤖 Generated with [Claude Code](https://claude.com/claude-code)
