### PR TITLE
perf(join): prove DELIM_GET build-side uniqueness — skip the count pass on unique build keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -722,6 +722,7 @@ set(TEST_SOURCES
     test/cpp/integration/test_gpu_execution_tpcds_nulls.cpp
     test/cpp/integration/test_gpu_execution_tpch.cpp
     test/cpp/integration/test_gpu_execution_tpch_mgpu_audit.cpp
+    test/cpp/integration/test_gpu_execution_unique_join.cpp
     test/cpp/integration/test_gpu_execution_vector_search.cpp
     test/cpp/integration/test_pin_table_host_streaming.cpp
     test/cpp/integration/test_pin_table_merge_columns.cpp

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -23,6 +23,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
+#include "duckdb/planner/operator/logical_delim_get.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
@@ -117,6 +118,21 @@ static std::unordered_set<duckdb::idx_t> prove_unique_columns(duckdb::LogicalOpe
       if (aggr.grouping_sets.size() > 1 || aggr.groups.empty()) { return {}; }
       std::unordered_set<duckdb::idx_t> unique_set;
       for (duckdb::idx_t i = 0; i < aggr.groups.size(); i++) {
+        unique_set.insert(i);
+      }
+      return unique_set;
+    }
+
+    case duckdb::LogicalOperatorType::LOGICAL_DELIM_GET: {
+      // A delim scan replays the enclosing delim join's duplicate-eliminated chunk, which
+      // Sirius materializes with a grouped aggregate over ALL delim columns
+      // (plan_delim_join builds the DISTINCT; wrap_delim_distinct globalizes it via
+      // PARTITION_DISTINCT → DISTINCT_MERGE), so the full row set is unique by
+      // construction — under EQUAL null semantics too, since GROUP BY collapses NULL keys
+      // into one group. Only the complete column set is a key; a subset can repeat.
+      auto& delim_get = op.Cast<duckdb::LogicalDelimGet>();
+      std::unordered_set<duckdb::idx_t> unique_set;
+      for (duckdb::idx_t i = 0; i < delim_get.chunk_types.size(); i++) {
         unique_set.insert(i);
       }
       return unique_set;

--- a/test/cpp/integration/test_gpu_execution_unique_join.cpp
+++ b/test/cpp/integration/test_gpu_execution_unique_join.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// GPU-vs-CPU correctness for the unique-build-key (distinct_hash_join) fast path,
+// including the DELIM_GET structural uniqueness proof (the TPC-H q2/q22 shape).
+// A wrong uniqueness proof drops matches, so the GPU result diverges from CPU.
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <utils/gpu_execution_fixture.hpp>
+
+#include <string>
+
+namespace {
+
+class UniqueJoinFixture : public sirius::test::GpuExecutionFixture {
+ public:
+  UniqueJoinFixture()
+  {
+    // On toy tables the deliminator rewrites the delim join away, and
+    // compressed_materialization wraps GROUP BY keys in __internal_compress_integral_*
+    // calls the GPU translator rejects. Disabling both preserves the plan shape under
+    // test; it applies to the GPU and CPU passes alike, so comparisons stay fair.
+    run_ok("SET disabled_optimizers='deliminator,compressed_materialization';");
+
+    run_ok("CREATE TABLE dim (id INTEGER PRIMARY KEY, name VARCHAR);");
+    run_ok("INSERT INTO dim VALUES (1,'a'),(2,'b'),(3,'c'),(4,'d');");
+
+    // Duplicate keys, NULL keys, and keys with no build match (5).
+    run_ok("CREATE TABLE fact (k INTEGER, grp INTEGER, v INTEGER);");
+    run_ok(
+      "INSERT INTO fact VALUES"
+      " (1, 1, 10), (1, 1, 30), (2, 1, 20), (2, 2, 5), (3, 2, 50), (NULL, 2, 7),"
+      " (5, 3, 100), (1, 3, 1), (2, 3, 2), (3, 3, 3), (NULL, 3, 4), (4, 1, 8),"
+      " (4, 2, 9), (1, 2, 11), (2, 1, 12), (3, 1, 13), (5, NULL, 60), (NULL, NULL, 70);");
+
+    // Much larger than fact's deduplicated key set, so the DELIM_GET stays the build
+    // side of the NOT EXISTS re-join.
+    run_ok("CREATE TABLE big (okey INTEGER, k INTEGER);");
+    run_ok("INSERT INTO big SELECT i, i % 4 FROM range(3000) t(i);");
+
+    // Non-unique build side: the uniqueness gate must refuse it.
+    run_ok("CREATE TABLE dup_build (k INTEGER, tag VARCHAR);");
+    run_ok("INSERT INTO dup_build VALUES (1,'x'),(1,'y'),(2,'z'),(NULL,'n');");
+
+    run_ok("CREATE TABLE empty_fact (k INTEGER, grp INTEGER, v INTEGER);");
+
+    run_ok("CHECKPOINT;");
+  }
+
+  ~UniqueJoinFixture()
+  {
+    // The connection is shared across tests, so restore the optimizer set. Plain Query
+    // (not run_ok) — never assert during unwinding.
+    if (con) { con->Query("SET disabled_optimizers='';"); }
+  }
+};
+
+}  // namespace
+
+TEST_CASE_METHOD(UniqueJoinFixture,
+                 "gpu_execution unique-build INNER join on a PK build side",
+                 "[integration][gpu_execution][join][unique_build_keys]")
+{
+  compare_gpu_vs_cpu("SELECT f.k, f.v, d.name FROM fact f JOIN dim d ON f.k = d.id");
+}
+
+TEST_CASE_METHOD(UniqueJoinFixture,
+                 "gpu_execution unique-build LEFT join NULL-pads through the distinct path",
+                 "[integration][gpu_execution][join][unique_build_keys]")
+{
+  // Takes distinct_hash_join::left_join; NULL-key and unmatched probe rows must NULL-pad.
+  compare_gpu_vs_cpu("SELECT f.k, f.v, d.name FROM fact f LEFT JOIN dim d ON f.k = d.id");
+}
+
+TEST_CASE_METHOD(UniqueJoinFixture,
+                 "gpu_execution unique-build join with an empty probe side",
+                 "[integration][gpu_execution][join][unique_build_keys]")
+{
+  compare_gpu_vs_cpu("SELECT f.k, d.name FROM empty_fact f JOIN dim d ON f.k = d.id");
+}
+
+TEST_CASE_METHOD(UniqueJoinFixture,
+                 "gpu_execution delim-shaped NOT EXISTS (q22 DELIM_GET build)",
+                 "[integration][gpu_execution][join][unique_build_keys]")
+{
+  // Decorrelates into a DELIM_JOIN whose inner re-join probes big against a DELIM_GET
+  // of dedup'd fact.k keys (one of them NULL) — the proof this change adds.
+  compare_gpu_vs_cpu(
+    "SELECT f.k, f.grp, f.v FROM fact f "
+    "WHERE f.v > 3 AND NOT EXISTS (SELECT 1 FROM big o WHERE o.k = f.k)");
+}
+
+TEST_CASE_METHOD(UniqueJoinFixture,
+                 "gpu_execution delim-shaped NOT EXISTS over an empty table",
+                 "[integration][gpu_execution][join][unique_build_keys]")
+{
+  compare_gpu_vs_cpu(
+    "SELECT f.k, f.grp, f.v FROM empty_fact f "
+    "WHERE f.v > 3 AND NOT EXISTS (SELECT 1 FROM big o WHERE o.k = f.k)");
+}
+
+TEST_CASE_METHOD(UniqueJoinFixture,
+                 "gpu_execution non-unique build keys preserve match multiplicity",
+                 "[integration][gpu_execution][join][unique_build_keys]")
+{
+  // dup_build has two k=1 rows: every k=1 probe row must appear twice. Had the gate
+  // wrongly claimed this build, the distinct path would drop one of the two matches.
+  compare_gpu_vs_cpu("SELECT f.k, f.v, b.tag FROM fact f JOIN dup_build b ON f.k = b.k");
+}
+
+TEST_CASE_METHOD(UniqueJoinFixture,
+                 "gpu_execution GROUP BY build side through the distinct path",
+                 "[integration][gpu_execution][join][unique_build_keys]")
+{
+  // Aggregate output is unique on its group keys — the pre-existing proof.
+  compare_gpu_vs_cpu(
+    "SELECT f.k, f.v, agg.cnt FROM fact f "
+    "JOIN (SELECT grp, COUNT(*) AS cnt FROM fact GROUP BY grp) agg ON f.k = agg.grp");
+}

--- a/test/cpp/planner/test_distinct_hash_join_detection.cpp
+++ b/test/cpp/planner/test_distinct_hash_join_detection.cpp
@@ -20,6 +20,7 @@
  *        build-side keys are proven unique at plan construction time.
  */
 
+#include "op/sirius_physical_delim_join.hpp"
 #include "op/sirius_physical_hash_join.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
@@ -32,9 +33,11 @@
 #include <duckdb/planner/planner.hpp>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
+#include <vector>
 
 using namespace duckdb;
 
@@ -77,11 +80,14 @@ duckdb::unique_ptr<sirius::op::sirius_physical_operator> generate_sirius_plan(
 {
   auto& context = *con.context;
 
-  // Disable optimizers that can interfere with plan structure
+  // Disable optimizers that can interfere with plan structure. DELIMINATOR is disabled so
+  // correlated-subquery tests keep their DELIM_JOIN / DELIM_GET shape, which it would
+  // otherwise rewrite away on toy tables; a no-op for the other tests.
   auto original_disabled = DBConfig::GetConfig(context).options.disabled_optimizers;
   auto& disabled         = DBConfig::GetConfig(context).options.disabled_optimizers;
   disabled.insert(OptimizerType::IN_CLAUSE);
   disabled.insert(OptimizerType::COMPRESSED_MATERIALIZATION);
+  disabled.insert(OptimizerType::DELIMINATOR);
 
   con.Query("BEGIN TRANSACTION");
 
@@ -140,6 +146,50 @@ sirius::op::sirius_physical_hash_join* find_hash_join(sirius::op::sirius_physica
   return nullptr;
 }
 
+/// Collect every hash join in the tree, recursing into a DELIM JOIN's internal `join` and
+/// `distinct_root` subtrees, which live outside `children[]`.
+void collect_hash_joins(sirius::op::sirius_physical_operator* root,
+                        std::vector<sirius::op::sirius_physical_hash_join*>& out)
+{
+  if (!root) { return; }
+  if (root->type == sirius::op::SiriusPhysicalOperatorType::HASH_JOIN) {
+    out.push_back(&root->Cast<sirius::op::sirius_physical_hash_join>());
+  }
+  if (root->type == sirius::op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN ||
+      root->type == sirius::op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
+    auto& delim = root->Cast<sirius::op::sirius_physical_delim_join>();
+    collect_hash_joins(delim.join.get(), out);
+    collect_hash_joins(delim.distinct_root.get(), out);
+  }
+  for (auto& child : root->children) {
+    collect_hash_joins(child.get(), out);
+  }
+}
+
+/// True when @p root's subtree contains a DELIM_SCAN (the physical form of LOGICAL_DELIM_GET).
+bool subtree_has_delim_scan(sirius::op::sirius_physical_operator* root)
+{
+  if (!root) { return false; }
+  if (root->type == sirius::op::SiriusPhysicalOperatorType::DELIM_SCAN) { return true; }
+  return std::any_of(root->children.begin(), root->children.end(), [](auto& c) {
+    return subtree_has_delim_scan(c.get());
+  });
+}
+
+/// A hash join's build side is children[1]; the probe side is children[0].
+bool builds_on_delim_scan(sirius::op::sirius_physical_hash_join* hj)
+{
+  REQUIRE(hj->children.size() == 2);
+  return subtree_has_delim_scan(hj->children[1].get());
+}
+
+bool touches_delim_scan(sirius::op::sirius_physical_hash_join* hj)
+{
+  REQUIRE(hj->children.size() == 2);
+  return subtree_has_delim_scan(hj->children[0].get()) ||
+         subtree_has_delim_scan(hj->children[1].get());
+}
+
 /// Shared fixture: one DuckDB + config for all distinct_hash_join tests.
 struct distinct_hash_join_fixture {
   distinct_hash_join_fixture()
@@ -184,6 +234,13 @@ struct distinct_hash_join_fixture {
     con->Query(
       "INSERT INTO probe VALUES (1,1),(1,2),(2,1),(2,2),(3,1),(3,2),(4,1),(4,2),"
       "(5,1),(5,2),(6,1),(6,2),(7,1),(7,2),(8,1),(8,2),(9,1),(9,2),(10,1),(10,2)");
+
+    // delim_fact drives a correlated NOT EXISTS that decorrelates into a DELIM_GET build
+    // side. delim_big is much larger so the DELIM_GET stays the build side.
+    con->Query("CREATE TABLE delim_fact (k INTEGER, grp INTEGER, v INTEGER)");
+    con->Query("INSERT INTO delim_fact SELECT i % 7, (i % 4) + 1, i FROM range(40) t(i)");
+    con->Query("CREATE TABLE delim_big (okey INTEGER, k INTEGER)");
+    con->Query("INSERT INTO delim_big SELECT i, i % 9 FROM range(3000) t(i)");
   }
 
   ~distinct_hash_join_fixture() { unsetenv("SIRIUS_CONFIG_FILE"); }
@@ -371,6 +428,68 @@ TEST_CASE_METHOD(distinct_hash_join_fixture,
   auto* hj = find_hash_join(plan.get());
   REQUIRE(hj);
   CHECK_FALSE(hj->unique_build_keys);
+}
+
+// ---------------------------------------------------------------------------
+// DELIM_GET uniqueness (duplicate-eliminated delim scans)
+// ---------------------------------------------------------------------------
+
+TEST_CASE_METHOD(distinct_hash_join_fixture,
+                 "distinct_hash_join - DELIM_GET build side enables unique_build_keys",
+                 "[distinct_hash_join][isolated_context]")
+{
+  // Decorrelates into a DELIM_JOIN whose inner re-join probes delim_big against a
+  // DELIM_GET replaying the duplicate-eliminated k keys — the TPC-H q22 shape.
+  auto plan = generate_sirius_plan(
+    *con,
+    "SELECT f.grp, f.v FROM delim_fact f "
+    "WHERE f.v > 3 AND NOT EXISTS (SELECT 1 FROM delim_big o WHERE o.k = f.k)");
+  REQUIRE(plan);
+
+  std::vector<sirius::op::sirius_physical_hash_join*> joins;
+  collect_hash_joins(plan.get(), joins);
+
+  // Exactly one join builds on the DELIM_GET, and that is the one that must be claimed.
+  // (The DELIM_JOIN's own join probes the delim scan and carries an IS NOT DISTINCT FROM
+  // condition, so the pure-equal gate leaves it un-marked.)
+  auto delim_builds = std::count_if(joins.begin(), joins.end(), builds_on_delim_scan);
+  REQUIRE(delim_builds == 1);
+  for (auto* hj : joins) {
+    if (builds_on_delim_scan(hj)) { CHECK(hj->unique_build_keys); }
+  }
+}
+
+TEST_CASE_METHOD(distinct_hash_join_fixture,
+                 "distinct_hash_join - non-unique build still refused alongside DELIM_GET",
+                 "[distinct_hash_join][isolated_context]")
+{
+  // Same delim shape, but the outer query also joins the non-unique delim_fact build.
+  auto plan = generate_sirius_plan(
+    *con,
+    "SELECT p.x FROM probe p JOIN delim_fact f ON p.x = f.grp "
+    "WHERE f.v > 3 AND NOT EXISTS (SELECT 1 FROM delim_big o WHERE o.k = f.k)");
+  REQUIRE(plan);
+
+  std::vector<sirius::op::sirius_physical_hash_join*> joins;
+  collect_hash_joins(plan.get(), joins);
+
+  // Assert per join rather than over the plan as a whole: the DELIM_GET build is claimed,
+  // and the plain probe ⋈ delim_fact join (no delim scan on either side, so it builds over
+  // raw duplicated rows) is refused. A whole-plan "not every join is unique" would pass
+  // even if the wrong join were the refused one.
+  auto delim_builds = std::count_if(joins.begin(), joins.end(), builds_on_delim_scan);
+  REQUIRE(delim_builds == 1);
+
+  bool saw_plain_join = false;
+  for (auto* hj : joins) {
+    if (builds_on_delim_scan(hj)) {
+      CHECK(hj->unique_build_keys);
+    } else if (!touches_delim_scan(hj)) {
+      saw_plain_join = true;
+      CHECK_FALSE(hj->unique_build_keys);
+    }
+  }
+  REQUIRE(saw_plain_join);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# perf(join): prove DELIM_GET build-side uniqueness — q2/q22 count-pass skip

## Summary

Teaches the planner's build-key uniqueness proof (`prove_unique_columns`) that a
`LOGICAL_DELIM_GET` build side is unique by construction, so the hottest PK-shaped
TPC-H joins take the single-pass `cudf::distinct_hash_join` fast path at plan time.
Measured at SF1000: **q22 -24%, q2 -9%**, results **byte-identical**.

The production change is 16 lines in one planner file.

## Mechanism

The distinct_hash_join fast path (#558) skips cudf `hash_join`'s cuco count pass, but
its plan-time uniqueness proof only knew PRIMARY KEY constraints and GROUP BY outputs.
The TPC-H benchmark schema declares no PKs, so the proof never fired on the SF1000
suite's hottest PK-shaped joins: q2's partsupp ⋈ delim part keys and q22's orders ⋈
delim cust keys both walk the probe twice (count + retrieve) purely to size the output.

This adds a `LOGICAL_DELIM_GET` case to `prove_unique_columns`: a delim scan replays the
enclosing delim join's duplicate-eliminated chunk, which Sirius materializes with a
grouped aggregate over ALL delim columns (globalized by PARTITION_DISTINCT →
DISTINCT_MERGE), so the full output row set is unique by construction — under EQUAL and
UNEQUAL null semantics alike (GROUP BY collapses NULL keys into a single group). Only
the complete column set is claimed; subsets stay refused.

### Relation to #1466 (runtime distinct-build probe)

Complementary, not overlapping. #1466 tests build distinctness at runtime, in
BUILD_PROBE mode only, at the cost of a `cudf::distinct_count` pass (plus a
host-synchronizing readback) per cached build, and it caps out at 128M build rows.
The plan-time DELIM_GET proof (a) also fires in STANDARD mode (q22's shape), (b) skips
the runtime distinct-count pass and its stream sync entirely, and (c) has no build-size
cap. The measured numbers below predate #1466 on the measurement branch; on dev the q2
BUILD_PROBE share may partially overlap with #1466's runtime win, while the STANDARD-mode
and count-pass-avoidance components remain additive.

## Measured (GB300, SF1000)

- **q22 -24%**, **q2 -9%**, results byte-identical to baseline.
- Evidence trail (`tpch_power_20260812_014959_sf1000_s7`): q2 Pipeline 22 join_retrieve
  35.5 ms (29% of q2); q22 count kernel 13.9 ms; both builds are delim-deduplicated key
  sets that the old proof could not claim.

## Correctness evidence

A wrong uniqueness proof would *silently drop matches* (distinct_hash_join retrieves at
most one build row per probe row), so the change ships with two test layers:

- **Plan-time detection** (`test/cpp/planner/test_distinct_hash_join_detection.cpp`,
  tags `[distinct_hash_join][isolated_context]`): the DELIM_GET shape is claimed, and a
  non-unique build alongside it stays refused — asserted per-join by discriminating on
  whether the build side contains a DELIM_SCAN, not by a whole-plan "not all unique".
- **Integration** (`test/cpp/integration/test_gpu_execution_unique_join.cpp`, tags
  `[integration][gpu_execution][join][unique_build_keys]`): GPU-vs-CPU comparison over
  the delim / PK / GROUP BY / non-unique paths, including LEFT joins, empty builds, NULL
  keys, and duplicate probe keys. A wrong proof drops rows, so the GPU result diverges
  from DuckDB's and the comparison fails.

Dropped matches are exactly what the GPU-vs-CPU comparison detects, so it carries the
correctness argument directly — no runtime instrumentation ships to make that work.

An earlier revision of this PR added a `SIRIUS_VERIFY_UNIQUE_BUILD_KEYS=1` device
recount guard in `sirius_physical_hash_join`. It was used during bring-up to validate
the full TPC-H suite (green with the guard enabled) and has been removed: being env-gated
and off by default, it contributed a `getenv` per hash-table build, two exported symbols,
and two cudf/rmm includes in a widely-included header while detecting nothing in any
build anyone actually runs. Its unit tests asserted that `cudf::distinct_count` counts
distinct values, which is cudf's contract rather than this change's.

### Test results

- `[distinct_hash_join]` — 12 cases, 80 assertions, green
- `[unique_build_keys]` — 7 cases, 449 assertions, green
- `[hash_join]` — 37 cases, 172 assertions, green
- `[gpu_execution]` — 690 cases, 689 passed, 1 skipped, 0 failed

Negative control: temporarily removing the `LOGICAL_DELIM_GET` case fails both plan-time
tests. Worth noting because the earlier revision's whole-plan `CHECK_FALSE(all_unique)`
*passed* under that same control — with no proof firing, "not every join is unique" is
trivially true — so it could not have caught the regression it was written for.

## Files

- `src/planner/sirius_plan_comparison_join.cpp` — `LOGICAL_DELIM_GET` case in
  `prove_unique_columns` (the entire production change)
- `test/cpp/integration/test_gpu_execution_unique_join.cpp` — new
- `test/cpp/planner/test_distinct_hash_join_detection.cpp` — extended
- `CMakeLists.txt` — register the new test source

🤖 Generated with [Claude Code](https://claude.com/claude-code)