### PR TITLE
feat(telemetry): sticky per-connection session labels for query grouping

### DIFF
--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -150,6 +150,20 @@ class SiriusConnectionState : public ClientContextState {
     return label;
   }
 
+  /// Sets the telemetry query-group label for subsequent queries on this connection.
+  ///
+  /// The label remains active until replaced.
+  /// An empty label restores the default session group.
+  void set_session_label(std::string label)
+  {
+    if (label.empty()) {
+      session_label_.reset();
+    } else {
+      session_label_ = std::move(label);
+    }
+  }
+  [[nodiscard]] const std::optional<std::string>& session_label() const { return session_label_; }
+
   void enter_internal_query() noexcept
   {
     internal_query_depth_.fetch_add(1, std::memory_order_relaxed);
@@ -185,6 +199,8 @@ class SiriusConnectionState : public ClientContextState {
   /// Label set by `sirius_set_query_label`, consumed by the next
   /// sirius_interface construction on this connection.
   std::optional<std::string> pending_query_label_;
+  /// Sticky label set by `sirius_set_session_label`; never consumed.
+  std::optional<std::string> session_label_;
   std::atomic<int> internal_query_depth_{0};
   std::atomic<int> cpu_fallback_depth_{0};
   std::optional<std::shared_lock<std::shared_mutex>> pinned_update_guard_;

--- a/src/include/sirius_interface.hpp
+++ b/src/include/sirius_interface.hpp
@@ -65,11 +65,14 @@ struct sirius_active_query_context {
 class sirius_interface {
  public:
   sirius_interface(duckdb::ClientContext& client_context,
-                   std::optional<std::string> query_label = std::nullopt);
+                   std::optional<std::string> query_label   = std::nullopt,
+                   std::optional<std::string> session_label = std::nullopt);
   //! The client context
   duckdb::ClientContext& client_context;
   //! Optional label for this query's telemetry instance name
   std::optional<std::string> query_label;
+  //! Optional sticky per-connection label selecting the telemetry query group
+  std::optional<std::string> session_label;
   //! The currently active query context
   duckdb::unique_ptr<sirius_active_query_context> sirius_active_query;
   //! The current query progress

--- a/src/include/telemetry/telemetry_context.hpp
+++ b/src/include/telemetry/telemetry_context.hpp
@@ -71,6 +71,10 @@ class telemetry_context {
   [[nodiscard]] const uuid::UUID& worker_id() const { return worker_uuid_; }
   /// The single, session-scoped query group that every query in this context is reported under.
   [[nodiscard]] const uuid::UUID& query_group_id() const { return query_group_uuid_; }
+  /// The `{engine}-{session_label}` query group, declared on first use; empty or
+  /// nullopt falls back to the default session-scoped group. Thread-safe.
+  [[nodiscard]] uuid::UUID query_group_id_for(
+    const std::optional<std::string>& session_label) const;
   /// The `gpu-N` device group for `device_id`; falls back to the engine group
   /// (with a warning) when the device was not declared at creation time.
   [[nodiscard]] const uuid::UUID& gpu_device_group_id(int device_id) const;
@@ -103,6 +107,9 @@ class telemetry_context {
   uuid::UUID worker_uuid_;
   uuid::UUID query_group_uuid_;
   uuid::UUID shared_group_uuid_;
+  std::string engine_name_;
+  mutable std::mutex labeled_groups_mutex_;
+  mutable std::map<std::string, uuid::UUID> labeled_group_ids_;
   std::map<int, gpu_device_group_ids> gpu_group_ids_;
   rust::Box<quent::Context> context_;
   rust::Box<quent::engine::EngineObserver> engine_observer_;

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -116,15 +116,13 @@ sirius_engine::sirius_engine(duckdb::ClientContext& context,
     sirius_iface(sirius_iface),
     query_id_(query_id),
     telemetry_context_(get_telemetry_context_from_client_context(this->context)),
-    query_handle_(
-      quent::query::create(telemetry_context_->context(),
-                           quent::query::Init{
-                             .instance_name  = sirius_iface.query_label.value_or("unnamed_query"),
-                             .query_group_id = telemetry_context_->query_group_id(),
-                           }))
+    query_handle_(quent::query::create(
+      telemetry_context_->context(),
+      quent::query::Init{
+        .instance_name  = sirius_iface.query_label.value_or("unnamed_query"),
+        .query_group_id = telemetry_context_->query_group_id_for(sirius_iface.session_label),
+      }))
 {
-  // The query group is session-scoped and owned by telemetry_context; every query in this
-  // context is reported under it (see telemetry_context::query_group_id).
 }
 
 sirius_engine::~sirius_engine() { query_handle_->exit(); }

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -680,8 +680,10 @@ void SiriusExtension::GPUExecutionFunction(ClientContext& context,
   if (gstate.finished) { return; }
 
   if (!gstate.res) {
-    auto start      = std::chrono::high_resolution_clock::now();
-    auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
+    auto conn_state    = get_sirius_connection_state(context);
+    auto session_label = conn_state ? conn_state->session_label() : std::optional<std::string>{};
+    auto start         = std::chrono::high_resolution_clock::now();
+    auto sirius_ctx    = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
     ErrorData gpu_error;
     bool gpu_failed                = false;
     bool runtime_unavailable_error = false;
@@ -711,8 +713,9 @@ void SiriusExtension::GPUExecutionFunction(ClientContext& context,
         auto gpu_prepared = make_shared_ptr<::sirius::sirius_prepared_statement_data>(
           std::move(prepared), std::move(sirius_physical_plan));
 
-        gstate.sirius_iface = make_uniq<::sirius::sirius_interface>(context, data.query_label);
-        gstate.res          = gstate.sirius_iface->sirius_execute_query(
+        gstate.sirius_iface =
+          make_uniq<::sirius::sirius_interface>(context, data.query_label, session_label);
+        gstate.res = gstate.sirius_iface->sirius_execute_query(
           context, data.query, gpu_prepared, {}, window->query_id());
         if (gstate.res->HasError()) {
           gpu_error = gstate.res->GetErrorObject();
@@ -1888,6 +1891,39 @@ static void SiriusVectorSearchFunction(ClientContext& context,
   state.reader->get_next_chunk(output);
 }
 
+// sirius_set_session_label('<label>'): sticky per-connection telemetry query
+// group; '' reverts to the default session group.
+static unique_ptr<FunctionData> SiriusSetSessionLabelBind(ClientContext& context,
+                                                          TableFunctionBindInput& input,
+                                                          vector<LogicalType>& return_types,
+                                                          vector<string>& names)
+{
+  if (input.inputs.empty() || input.inputs[0].IsNull()) {
+    throw BinderException("sirius_set_session_label requires a non-NULL VARCHAR argument");
+  }
+  auto result   = make_uniq<SiriusSetQueryLabelData>();
+  result->label = input.inputs[0].ToString();
+  return_types.push_back(LogicalType::BOOLEAN);
+  names.push_back("ok");
+  return std::move(result);
+}
+
+static void SiriusSetSessionLabelFunction(ClientContext& context,
+                                          TableFunctionInput& data_p,
+                                          DataChunk& output)
+{
+  auto& data = data_p.bind_data->CastNoConst<SiriusSetQueryLabelData>();
+  if (data.finished) { return; }
+
+  if (auto conn_state = get_sirius_connection_state(context)) {
+    conn_state->set_session_label(data.label);
+  }
+
+  output.SetCardinality(1);
+  output.SetValue(0, 0, Value::BOOLEAN(true));
+  data.finished = true;
+}
+
 void SiriusExtension::RegisterGPUFunctions(DatabaseInstance& instance)
 {
   // A fragment plan reads each of its input streams through sirius_stream_source(id). Register
@@ -1942,6 +1978,13 @@ void SiriusExtension::RegisterGPUFunctions(DatabaseInstance& instance)
                                 SiriusSetQueryLabelBind);
   CreateTableFunctionInfo set_query_label_info(set_query_label);
   catalog.CreateTableFunction(transaction, set_query_label_info);
+
+  TableFunction set_session_label("sirius_set_session_label",
+                                  {LogicalType::VARCHAR},
+                                  SiriusSetSessionLabelFunction,
+                                  SiriusSetSessionLabelBind);
+  CreateTableFunctionInfo set_session_label_info(set_session_label);
+  catalog.CreateTableFunction(transaction, set_session_label_info);
 
   // Profiler control functions for nsys --capture-range=cudaProfilerApi
   TableFunction profiler_start(

--- a/src/sirius_interface.cpp
+++ b/src/sirius_interface.cpp
@@ -40,8 +40,11 @@ void bind_prepared_statement_parameters(duckdb::PreparedStatementData& statement
 }
 
 sirius_interface::sirius_interface(duckdb::ClientContext& client_context,
-                                   std::optional<std::string> query_label)
-  : client_context(client_context), query_label(std::move(query_label)) {};
+                                   std::optional<std::string> query_label,
+                                   std::optional<std::string> session_label)
+  : client_context(client_context),
+    query_label(std::move(query_label)),
+    session_label(std::move(session_label)) {};
 
 void sirius_interface::sirius_process_error(duckdb::ErrorData& error,
                                             const duckdb::string& query) const

--- a/src/telemetry/telemetry_context.cpp
+++ b/src/telemetry/telemetry_context.cpp
@@ -51,6 +51,7 @@ telemetry_context::telemetry_context(const sirius::telemetry_config& config,
     worker_uuid_(uuid::now_v7()),
     query_group_uuid_(uuid::now_v7()),
     shared_group_uuid_(uuid::now_v7()),
+    engine_name_(config.engine_name),
     context_(quent::create_context([&config] {
       if (!config.enable_quent) { return quent::ExporterOptions::none(); }
       if (config.exporter == "ndjson") {
@@ -136,6 +137,25 @@ telemetry_context::telemetry_context(const sirius::telemetry_config& config,
   SIRIUS_LOG_INFO("Telemetry context initialized (engine={}, {} GPU device group(s))",
                   config.engine_name,
                   gpu_group_ids_.size());
+}
+
+uuid::UUID telemetry_context::query_group_id_for(
+  const std::optional<std::string>& session_label) const
+{
+  if (!session_label.has_value() || session_label->empty()) { return query_group_uuid_; }
+  const std::lock_guard lock(labeled_groups_mutex_);
+  auto it = labeled_group_ids_.find(*session_label);
+  if (it == labeled_group_ids_.end()) {
+    auto group_uuid = uuid::now_v7();
+    query_group_observer_->declaration(
+      group_uuid,
+      quent::query_group::Declaration{
+        .instance_name = std::format("{}-{}", engine_name_, *session_label),
+        .engine_id     = engine_uuid_,
+      });
+    it = labeled_group_ids_.emplace(*session_label, std::move(group_uuid)).first;
+  }
+  return it->second;
 }
 
 const uuid::UUID& telemetry_context::gpu_device_group_id(int device_id) const

--- a/src/transparent/physical_sirius_execution.cpp
+++ b/src/transparent/physical_sirius_execution.cpp
@@ -131,7 +131,9 @@ duckdb::unique_ptr<duckdb::GlobalSourceState> PhysicalSiriusExecution::GetGlobal
   auto conn_state = duckdb::get_sirius_connection_state(context);
   auto query_label =
     conn_state ? conn_state->take_pending_query_label() : std::optional<std::string>{};
-  state->iface = duckdb::make_uniq<sirius::sirius_interface>(context, std::move(query_label));
+  auto session_label = conn_state ? conn_state->session_label() : std::optional<std::string>{};
+  state->iface       = duckdb::make_uniq<sirius::sirius_interface>(
+    context, std::move(query_label), std::move(session_label));
   state->sirius_context = sirius_ctx.get();
   return std::move(state);
 }


### PR DESCRIPTION
## Problem

Every query in a process reports under one telemetry query group,
`{engine}-session-{pid}`. A benchmark's warmup, power, and throughput-stream
phases all collapse into that single bucket.

## Change

`CALL sirius_set_session_label('<label>')` sets a sticky per-connection label;
every subsequent query reports under the query group `{engine}-{label}`,
declared on first use. `''` reverts to the default session group. Unlike
`sirius_set_query_label`, the label is not consumed per query.

The label rides on `sirius_interface` (new defaulted third constructor arg) and
selects the group via `telemetry_context::query_group_id_for`. Both interface
construction sites are covered — the `gpu_execution` table function and the
transparent interception path, which is the one plain SQL takes by default.

```sql
CALL sirius_set_session_label('power');
-- ... queries land in '{engine}-power' ...
CALL sirius_set_session_label('');  -- back to the default group
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)