### PR TITLE
ci: auto-assign PR author on open and update

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,18 @@
+# .github/workflows/auto-assign.yml
+name: Auto Assign PR
+
+on:
+  pull_request_target:
+    types: [ opened, reopened, synchronize ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: toshimaru/auto-author-assign@a78a94b219445cece8ccf0d45fec60af449f212a #v3.0.3
+        with:
+          skip-users: |
+            siriusdbbot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,14 @@ When the C++ unit test job fails or times out, the workflow automatically upload
 
 ## Pull requests
 
+### Reviewer assignment
+
+Sirius uses [CODEOWNERS](.github/CODEOWNERS) to automatically route PRs to the right reviewers based on the files changed. Reviewers are assigned from component teams (e.g. `sirius-core`, `sirius-io`) — one member per team via load balancing. You do not need to manually request reviewers.
+
+Approval from any maintainer is sufficient to merge — it does not have to be the auto-assigned reviewer.
+
+When you open or update a PR, you will also be automatically assigned as the author. This helps maintainers track ownership and is not a request for you to review your own work.
+
 ### Commit and title convention
 
 Sirius squash-merges PRs, the PR titles become the commit message on merge. Commits and PR titles follow [Conventional Commits](https://www.conventionalcommits.org/) format for readability.


### PR DESCRIPTION
<!-- Edit PR title: "<type>[optional scope]: <short description>", see CONTRIBUTING.md for guidance -->

## Description
<!-- Provide a standalone description of changes in this PR -->
<!-- For design docs targeting docs/experimental, note this in the description -->
- Added CI workflow that allows us to more easily track who is assigned to a PR and can be updated at anytime by maintainers
- Updated documentation in `CONTRIBUTING.md` for this auto assignment
- Added missing documentation for #1367 in `CONTRIBUTING.md` about automated reivew assignment

## Checklist
- [x] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
<!-- Add open issues with "Closes #issue" to close or "Refs #issue" for reference, and any relevant URLs -->
Closes #1405