### PR TITLE
feat(build): opt-in RAPIDS sccache distributed build farm support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,16 +48,28 @@ SCCACHE_DIST_CMAKE_FLAGS := \
 	-DCMAKE_C_COMPILER_LAUNCHER=$(SIRIUS_SCCACHE_DIST_BIN) \
 	-DCMAKE_CXX_COMPILER_LAUNCHER=$(SIRIUS_SCCACHE_DIST_BIN) \
 	-DCMAKE_CUDA_COMPILER_LAUNCHER=$(SIRIUS_SCCACHE_DIST_BIN)
+# Compile through the canonical pixi env's compilers (same absolute path on
+# every machine/checkout) so cache keys match across checkouts: conda's gcc
+# embeds its env path in the specs file, which sccache hashes into every key.
+ifneq ($(wildcard $(SIRIUS_SCCACHE_DIST_CANON_ENV)/bin/nvcc),)
+SCCACHE_DIST_ARCH_PREFIX := $(shell uname -m)-conda-linux-gnu
+SCCACHE_DIST_CMAKE_FLAGS += \
+	-DCMAKE_C_COMPILER=$(SIRIUS_SCCACHE_DIST_CANON_ENV)/bin/$(SCCACHE_DIST_ARCH_PREFIX)-cc \
+	-DCMAKE_CXX_COMPILER=$(SIRIUS_SCCACHE_DIST_CANON_ENV)/bin/$(SCCACHE_DIST_ARCH_PREFIX)-c++ \
+	-DCMAKE_CUDA_COMPILER=$(SIRIUS_SCCACHE_DIST_CANON_ENV)/bin/nvcc \
+	-DCMAKE_CUDA_HOST_COMPILER=$(SIRIUS_SCCACHE_DIST_CANON_ENV)/bin/$(SCCACHE_DIST_ARCH_PREFIX)-c++
+endif
 # Configure-time compiler checks should not go through the farm (rmm#2101).
 SCCACHE_DIST_CONFIGURE_ENV := SCCACHE_NO_DIST_COMPILE=1
 endif
 
-# Stamp the current dist mode so toggling it re-runs the CMake configure step
-# (which rewrites the launcher into the ninja files).
+# Stamp the current dist mode (and canonical env, which changes the compiler
+# -D flags) so toggling either re-runs the CMake configure step.
 SCCACHE_DIST_STAMP := build/.sccache_dist_mode
+SCCACHE_DIST_MODE_ID := $(SIRIUS_SCCACHE_DIST)$(if $(SIRIUS_SCCACHE_DIST_CANON_ENV),-canon)
 $(shell mkdir -p build && \
-	{ [ -f $(SCCACHE_DIST_STAMP) ] && [ "$$(cat $(SCCACHE_DIST_STAMP))" = "$(SIRIUS_SCCACHE_DIST)" ]; } \
-	|| echo $(SIRIUS_SCCACHE_DIST) > $(SCCACHE_DIST_STAMP))
+	{ [ -f $(SCCACHE_DIST_STAMP) ] && [ "$$(cat $(SCCACHE_DIST_STAMP))" = "$(SCCACHE_DIST_MODE_ID)" ]; } \
+	|| echo $(SCCACHE_DIST_MODE_ID) > $(SCCACHE_DIST_STAMP))
 CMAKE_INPUTS += $(SCCACHE_DIST_STAMP)
 
 all: release

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,39 @@ BUILD_TARGETS := $(MAIN_BUILD_TARGETS) $(TEST_BUILD_TARGET)
 	test test_release test_debug test_reldebug test_ci-release clean list-presets \
 	s3-test s3-test-large s3-tpch \
 	s3-test-aws s3-test-aws-sigv4 s3-test-aws-broker s3-bench \
-	slot-gate-test
+	slot-gate-test sccache-dist-status
 
 PRESETS_LINK := $(DUCKDB_DIR)/CMakePresets.json
 
 # Inputs that should trigger a CMake re-configure
 CMAKE_INPUTS := cmake/CMakePresets.json CMakeLists.txt extension_config.cmake $(wildcard cmake/*.cmake)
+
+# -----------------------------------------------------------------------------
+# RAPIDS sccache distributed build farm (opt-in; see docs/sccache-dist.md)
+# -----------------------------------------------------------------------------
+# `source scripts/sccache_dist_env.sh` sets SIRIUS_SCCACHE_DIST=1, which swaps
+# the CMake compiler launchers to the RAPIDS sccache fork via command-line -D
+# flags (these take precedence over the preset cache variables). When unset,
+# nothing changes and builds use the pixi-provided sccache as before.
+SIRIUS_SCCACHE_DIST ?= 0
+SIRIUS_SCCACHE_DIST_BIN ?= $(HOME)/.local/share/sirius/sccache-dist/bin/sccache
+
+ifeq ($(SIRIUS_SCCACHE_DIST),1)
+SCCACHE_DIST_CMAKE_FLAGS := \
+	-DCMAKE_C_COMPILER_LAUNCHER=$(SIRIUS_SCCACHE_DIST_BIN) \
+	-DCMAKE_CXX_COMPILER_LAUNCHER=$(SIRIUS_SCCACHE_DIST_BIN) \
+	-DCMAKE_CUDA_COMPILER_LAUNCHER=$(SIRIUS_SCCACHE_DIST_BIN)
+# Configure-time compiler checks should not go through the farm (rmm#2101).
+SCCACHE_DIST_CONFIGURE_ENV := SCCACHE_NO_DIST_COMPILE=1
+endif
+
+# Stamp the current dist mode so toggling it re-runs the CMake configure step
+# (which rewrites the launcher into the ninja files).
+SCCACHE_DIST_STAMP := build/.sccache_dist_mode
+$(shell mkdir -p build && \
+	{ [ -f $(SCCACHE_DIST_STAMP) ] && [ "$$(cat $(SCCACHE_DIST_STAMP))" = "$(SIRIUS_SCCACHE_DIST)" ]; } \
+	|| echo $(SIRIUS_SCCACHE_DIST) > $(SCCACHE_DIST_STAMP))
+CMAKE_INPUTS += $(SCCACHE_DIST_STAMP)
 
 all: release
 
@@ -41,7 +68,7 @@ $(PRESETS_LINK): cmake/CMakePresets.json
 
 # Configure step — only re-runs when cmake inputs change
 build/%/build.ninja: $(CMAKE_INPUTS) | $(PRESETS_LINK)
-	cd $(DUCKDB_DIR) && $(CMAKE) --preset $*
+	cd $(DUCKDB_DIR) && $(SCCACHE_DIST_CONFIGURE_ENV) $(CMAKE) --preset $* $(SCCACHE_DIST_CMAKE_FLAGS)
 
 release: build/release/build.ninja
 	cd $(DUCKDB_DIR) && $(CMAKE) --build --preset release --target $(BUILD_TARGETS)
@@ -110,6 +137,14 @@ clean:
 
 list-presets: $(PRESETS_LINK)
 	cd $(DUCKDB_DIR) && $(CMAKE) --list-presets
+
+# Health check for the RAPIDS sccache distributed build farm (opt-in mode).
+sccache-dist-status:
+	@if [ "$(SIRIUS_SCCACHE_DIST)" != "1" ]; then \
+	  echo "sccache-dist-status: dist mode is off - run \`source scripts/sccache_dist_env.sh\` first" >&2; \
+	  exit 1; \
+	fi
+	@$(SIRIUS_SCCACHE_DIST_BIN) --dist-status; echo; $(SIRIUS_SCCACHE_DIST_BIN) --show-stats
 
 # -----------------------------------------------------------------------------
 # S3 integration test gates

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -41,6 +41,20 @@ Alternatively, load the extension into an existing DuckDB shell:
 LOAD 'build/release/extension/sirius/sirius.duckdb_extension';
 ```
 
+### Distributed builds (optional, NVIDIA-internal)
+
+Builds can optionally be routed through the RAPIDS sccache distributed build farm and shared
+S3 compilation cache — useful for sharing build results across machines when running
+experiments. After a one-time `scripts/sccache_dist_setup.sh`, enable it per shell with:
+
+```bash
+source scripts/sccache_dist_env.sh
+pixi run make
+```
+
+Normal builds and CI are unaffected unless the mode is enabled. See
+[docs/sccache-dist.md](sccache-dist.md) for setup, health checks, and troubleshooting.
+
 ## Pre-commit
 
 Sirius uses [pre-commit](https://pre-commit.com/) hooks to enforce formatting and linting. Install the hooks after cloning so every commit is checked automatically:

--- a/docs/sccache-dist.md
+++ b/docs/sccache-dist.md
@@ -1,0 +1,109 @@
+# Distributed builds with the RAPIDS sccache build farm
+
+Sirius builds already run every compilation through [sccache](https://github.com/mozilla/sccache)
+(the pixi-provided Mozilla sccache 0.15.0, with a local disk cache). This page describes an
+**optional, opt-in** mode that instead routes compilation through the
+[RAPIDS sccache fork](https://github.com/rapidsai/sccache) and NVIDIA's RAPIDS build
+infrastructure, which adds:
+
+- a **shared S3 compilation cache** (`rapids-sccache-devs`), so object files compiled by one
+  machine (or teammate) are reused by others, and
+- a **distributed build farm** (`sccache-dist`), which offloads compile jobs to a cluster of
+  remote build servers.
+
+This is useful when running experiments across machines: the first build populates the shared
+cache, and every subsequent build of the same sources — anywhere — mostly hits it.
+
+Nothing changes unless you explicitly enable the mode: normal `pixi run make` builds, CI
+(`ci-release`/ccache and the GitHub-hosted sccache backends), and the vcpkg presets are
+untouched. The mode is enabled per shell and gated on the `SIRIUS_SCCACHE_DIST=1` environment
+variable.
+
+## Prerequisites
+
+- Membership in the **NVIDIA GitHub org** (required for the build cluster; see
+  [github-onboarding.nvidia.com](https://github-onboarding.nvidia.com/)).
+- `gh` (GitHub CLI), `curl`, and `tar` on the host.
+- `gh` authenticated with the `gist`, `repo`, `read:org`, and `read:enterprise` scopes:
+
+```bash
+gh auth login --web --scopes gist --scopes repo --scopes read:org --scopes read:enterprise
+```
+
+## One-time setup
+
+```bash
+scripts/sccache_dist_setup.sh
+```
+
+This is idempotent and:
+
+1. installs the RAPIDS sccache fork into `~/.local/share/sirius/sccache-dist/bin/sccache`
+   (override the location with `SIRIUS_SCCACHE_DIST_HOME`) — it does **not** replace the
+   pixi-provided sccache used by normal builds;
+2. checks `gh` auth and installs the `gh-nv-gha-aws` extension;
+3. mints temporary AWS credentials (12h) for the shared S3 cache into a **dedicated**
+   credentials file — your `~/.aws/credentials` and `~/.config/sccache` are never touched.
+
+The AWS credentials expire after 12 hours. Refresh them with:
+
+```bash
+scripts/sccache_dist_setup.sh --creds-only
+```
+
+## Building through the farm
+
+Enable the mode in the current shell, then build as usual:
+
+```bash
+source scripts/sccache_dist_env.sh
+pixi run make
+```
+
+`sccache_dist_env.sh` exports `SIRIUS_SCCACHE_DIST=1` plus the `SCCACHE_*` configuration
+(S3 bucket, arch-specific scheduler URL, `gh` auth token, dedicated server port 4227). The
+Makefile picks up `SIRIUS_SCCACHE_DIST=1` and passes
+`-DCMAKE_{C,CXX,CUDA}_COMPILER_LAUNCHER=<fork binary>` on the CMake configure command line,
+which overrides the launchers baked into the presets. Toggling the mode on or off is detected
+automatically and re-runs the configure step for the presets you build.
+
+`SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=true` is set, so if the farm is unreachable the build
+still succeeds by compiling locally (the shared S3 cache is still used).
+
+To go back to normal local builds, open a fresh shell (the mode is scoped to the shell that
+sourced the env file).
+
+## Health checks
+
+```bash
+pixi run make sccache-dist-status
+```
+
+This prints the farm status (`--dist-status`: number of reachable build servers and cores) and
+the cache statistics (`--show-stats`: cache hit rates, S3 backend info).
+
+## Caveats
+
+- The env file exports `AWS_SHARED_CREDENTIALS_FILE`/`AWS_PROFILE` for sccache's S3 access.
+  If you need different AWS credentials in the same shell (e.g. `make s3-test-aws`), use a
+  separate shell.
+- Dist mode also applies to the `ci-release` preset if you run it locally with the mode on
+  (its ccache launcher gets overridden). CI itself never sets `SIRIUS_SCCACHE_DIST` and is
+  unaffected.
+- Compile results are cached per architecture (`x86_64` → `amd64` scheduler, `aarch64` →
+  `arm64`), with Sirius-specific S3 key prefixes so they don't collide with RAPIDS builds.
+
+## Troubleshooting
+
+- **Auth errors / farm unreachable**: refresh the AWS creds
+  (`scripts/sccache_dist_setup.sh --creds-only`) and check `gh auth status`. If your token is
+  missing scopes:
+  `gh auth refresh --scopes gist --scopes repo --scopes read:org --scopes read:enterprise`.
+- **`gh nv-gha-aws org nvidia` fails**: NVIDIA GitHub org membership is required for the build
+  cluster — see the prerequisites above.
+- **Corrupted state**: remove the install directory and re-run setup:
+
+```bash
+rm -rf ~/.local/share/sirius/sccache-dist
+scripts/sccache_dist_setup.sh
+```

--- a/docs/sccache-dist.md
+++ b/docs/sccache-dist.md
@@ -112,6 +112,12 @@ Two things must still match for cache hits — both legitimate key inputs:
 Note: binaries built in dist mode embed an rpath to the canonical env, so keep
 `~/.local/share/sirius/sccache-dist/` around while using them.
 
+Measured cross-checkout sharing (same machine, same commit, different checkout paths):
+**~85% of C/C++ compiles hit**; whole-`nvcc` CUDA jobs and a small C/C++ tail still key
+checkout-specifically (their preprocessed output is byte-identical across checkouts, so the
+residual leak is in the sccache fork's key construction — an upstream rapidsai/sccache issue,
+not something this repo can normalize away). Same-checkout rebuilds hit ~99.8%.
+
 ## Health checks
 
 ```bash

--- a/docs/sccache-dist.md
+++ b/docs/sccache-dist.md
@@ -43,7 +43,11 @@ This is idempotent and:
    pixi-provided sccache used by normal builds;
 2. checks `gh` auth and installs the `gh-nv-gha-aws` extension;
 3. mints temporary AWS credentials (12h) for the shared S3 cache into a **dedicated**
-   credentials file — your `~/.aws/credentials` and `~/.config/sccache` are never touched.
+   credentials file — your `~/.aws/credentials` and `~/.config/sccache` are never touched;
+4. installs a **canonical pixi env** under `~/.local/share/sirius/sccache-dist/pixi/`
+   (hardlinked from the shared pixi package cache, so it is cheap). Dist-mode builds compile
+   through this env's compilers instead of the checkout-local `.pixi` env — see
+   [Why cache keys need the canonical env](#why-cache-keys-need-the-canonical-env).
 
 The AWS credentials expire after 12 hours. Refresh them with:
 
@@ -72,6 +76,36 @@ still succeeds by compiling locally (the shared S3 cache is still used).
 
 To go back to normal local builds, open a fresh shell (the mode is scoped to the shell that
 sourced the env file).
+
+## Why cache keys need the canonical env
+
+sccache's cache key includes a digest of the compiler binary *and its extra files* — for
+conda/pixi gcc that includes the `specs` file, into which conda writes the env's **absolute
+path** at install time (a link-stage `-rpath <env>/lib`). Since every checkout carries its own
+`.pixi` env, compiling with the checkout-local compilers gives every checkout (and every
+worktree, and every machine with a different checkout path) disjoint cache keys — 0% sharing,
+even for identical sources.
+
+Everything else is already path-independent: source paths, include paths, and the working
+directory are normalized out of the key (`SCCACHE_BASEDIRS` is exported by pixi activation),
+and keys are stable across sccache fork versions and dist/local compilation.
+
+The canonical env fixes the one remaining input: all dist-mode builds use compilers at the same
+absolute path (`~/.local/share/sirius/sccache-dist/pixi/.pixi/envs/default`), so the specs file
+content — and therefore the key — is identical across checkouts, worktrees, and machines
+(usernames must match for `~` to expand identically). The Makefile passes the canonical
+compilers via `-DCMAKE_{C,CXX,CUDA}_COMPILER` / `-DCMAKE_CUDA_HOST_COMPILER` only when dist
+mode is on; normal builds keep using the checkout's own env.
+
+Two things must still match for cache hits — both legitimate key inputs:
+
+- the **sources** (same commit / same file contents; unchanged files like the DuckDB submodule
+  hit regardless), and
+- the **toolchain** (same `pixi.lock`; the env script warns when the canonical env's lock has
+  drifted from the checkout's — re-run `scripts/sccache_dist_setup.sh` after lock bumps).
+
+Note: binaries built in dist mode embed an rpath to the canonical env, so keep
+`~/.local/share/sirius/sccache-dist/` around while using them.
 
 ## Health checks
 

--- a/docs/sccache-dist.md
+++ b/docs/sccache-dist.md
@@ -87,8 +87,13 @@ worktree, and every machine with a different checkout path) disjoint cache keys 
 even for identical sources.
 
 Everything else is already path-independent: source paths, include paths, and the working
-directory are normalized out of the key (`SCCACHE_BASEDIRS` is exported by pixi activation),
-and keys are stable across sccache fork versions and dist/local compilation.
+directory are normalized out of the key (`SCCACHE_BASEDIRS`, which the env script exports and
+which requires the dist server restart the env script performs — sccache reads it in the
+server process at startup), and keys are stable across sccache fork versions and dist/local
+compilation. The env script also sets `SOURCE_DATE_EPOCH=0` so `__DATE__`/`__TIME__` expand
+deterministically instead of baking the preprocessing wall-clock second into the key (duckdb's
+`pcg_extras.hpp` expands them in every TU that includes it); dist-mode binaries therefore
+report a 1970 build date.
 
 The canonical env fixes the one remaining input: all dist-mode builds use compilers at the same
 absolute path (`~/.local/share/sirius/sccache-dist/pixi/.pixi/envs/default`), so the specs file

--- a/scripts/sccache_dist_env.sh
+++ b/scripts/sccache_dist_env.sh
@@ -1,0 +1,86 @@
+# =============================================================================
+# Copyright 2025, Sirius Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+#
+# Source this file to route Sirius builds through the RAPIDS sccache
+# distributed build farm (see docs/sccache-dist.md):
+#
+#   source scripts/sccache_dist_env.sh
+#   pixi run make
+#
+# Run scripts/sccache_dist_setup.sh once first. Everything here is scoped to
+# the current shell — open a fresh shell to go back to normal local builds.
+
+if [[ "${BASH_SOURCE[0]:-}" == "$0" ]]; then
+  echo "this file must be sourced, not executed: source ${0}" >&2
+  exit 1
+fi
+
+_sirius_dist_home="${SIRIUS_SCCACHE_DIST_HOME:-$HOME/.local/share/sirius/sccache-dist}"
+_sirius_dist_bin="$_sirius_dist_home/bin/sccache"
+_sirius_dist_creds="$_sirius_dist_home/aws-credentials"
+
+if [[ ! -x "$_sirius_dist_bin" || ! -f "$_sirius_dist_creds" ]]; then
+  echo "sccache dist farm is not set up yet — run: scripts/sccache_dist_setup.sh" >&2
+  return 1
+fi
+
+if [[ -n "$(find "$_sirius_dist_creds" -mmin +720 2>/dev/null)" ]]; then
+  echo "WARNING: AWS credentials are older than 12h and have likely expired." >&2
+  echo "         Refresh with: scripts/sccache_dist_setup.sh --creds-only" >&2
+fi
+
+if ! _sirius_dist_token="$(gh auth token 2>/dev/null)"; then
+  echo "gh is not authenticated — run scripts/sccache_dist_setup.sh" >&2
+  return 1
+fi
+
+case "$(uname -m)" in
+  x86_64) _sirius_dist_arch=amd64 ;;
+  aarch64) _sirius_dist_arch=arm64 ;;
+  *)
+    echo "unsupported architecture for the sccache dist farm: $(uname -m)" >&2
+    return 1
+    ;;
+esac
+
+# Consumed by the Makefile: switches the CMake compiler launchers to the
+# RAPIDS sccache fork binary below.
+export SIRIUS_SCCACHE_DIST=1
+export SIRIUS_SCCACHE_DIST_BIN="$_sirius_dist_bin"
+
+# Dedicated server port so the fork's local server never collides with the
+# pixi-provided sccache 0.15.0 server (default port 4226) used by normal builds.
+export SCCACHE_SERVER_PORT="${SIRIUS_SCCACHE_DIST_PORT:-4227}"
+
+# Shared RAPIDS S3 compilation cache.
+export SCCACHE_BUCKET="rapids-sccache-devs"
+export SCCACHE_REGION="us-east-2"
+export SCCACHE_S3_KEY_PREFIX="sirius-${_sirius_dist_arch}"
+export SCCACHE_S3_USE_PREPROCESSOR_CACHE_MODE=true
+export SCCACHE_S3_PREPROCESSOR_CACHE_KEY_PREFIX="sirius-${_sirius_dist_arch}-preprocessor-cache"
+export AWS_SHARED_CREDENTIALS_FILE="$_sirius_dist_creds"
+export AWS_PROFILE=default
+
+# Distributed compilation cluster (arch-specific scheduler).
+export SCCACHE_DIST_SCHEDULER_URL="https://${_sirius_dist_arch}.linux.sccache.rapids.nvidia.com"
+export SCCACHE_DIST_AUTH_TYPE=token
+export SCCACHE_DIST_AUTH_TOKEN="$_sirius_dist_token"
+# Compile locally instead of failing when the farm is unreachable.
+export SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=true
+
+unset _sirius_dist_home _sirius_dist_creds _sirius_dist_token _sirius_dist_arch
+
+echo "RAPIDS sccache dist farm enabled for this shell (launcher: $_sirius_dist_bin)"
+echo "Build with: pixi run make    Check farm health with: pixi run make sccache-dist-status"
+unset _sirius_dist_bin

--- a/scripts/sccache_dist_env.sh
+++ b/scripts/sccache_dist_env.sh
@@ -59,6 +59,23 @@ esac
 export SIRIUS_SCCACHE_DIST=1
 export SIRIUS_SCCACHE_DIST_BIN="$_sirius_dist_bin"
 
+# Canonical pixi env (see setup script): compiling through compilers at this
+# fixed path — instead of the checkout-local .pixi env — is what makes cache
+# keys match across checkouts, worktrees, and machines.
+_sirius_canon_env="$_sirius_dist_home/pixi/.pixi/envs/default"
+_sirius_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -x "$_sirius_canon_env/bin/nvcc" ]]; then
+  export SIRIUS_SCCACHE_DIST_CANON_ENV="$_sirius_canon_env"
+  if ! cmp -s "$_sirius_dist_home/pixi/pixi.lock" "$_sirius_repo_root/pixi.lock"; then
+    echo "WARNING: canonical env's pixi.lock differs from this checkout's — builds may use" >&2
+    echo "         stale toolchains. Refresh with: scripts/sccache_dist_setup.sh" >&2
+  fi
+else
+  echo "WARNING: canonical pixi env not found — cache keys will be checkout-specific and" >&2
+  echo "         cross-machine cache hits will not occur. Fix with: scripts/sccache_dist_setup.sh" >&2
+fi
+unset _sirius_canon_env _sirius_repo_root
+
 # Dedicated server port so the fork's local server never collides with the
 # pixi-provided sccache 0.15.0 server (default port 4226) used by normal builds.
 export SCCACHE_SERVER_PORT="${SIRIUS_SCCACHE_DIST_PORT:-4227}"

--- a/scripts/sccache_dist_env.sh
+++ b/scripts/sccache_dist_env.sh
@@ -111,9 +111,13 @@ export SCCACHE_BASEDIRS="$_sirius_repo_root:$_sirius_repo_root/.pixi/envs/defaul
 unset _sirius_repo_root
 
 # The dist-mode server (port 4227) caches its config at startup; restart it so
-# the exports above (basedirs, S3 creds) apply to the next build. The normal
-# build's sccache server (port 4226) is unaffected.
+# the exports above (basedirs, S3 creds) apply to the next build. Start it here
+# rather than letting ninja's first parallel compile wave race to autostart it
+# (the stampede can fail with EMFILE). The normal build's sccache server
+# (port 4226) is unaffected.
+ulimit -n 4096 2>/dev/null || true
 "$_sirius_dist_bin" --stop-server >/dev/null 2>&1 || true
+"$_sirius_dist_bin" --start-server >/dev/null 2>&1 || true
 
 unset _sirius_dist_home _sirius_dist_creds _sirius_dist_token _sirius_dist_arch
 

--- a/scripts/sccache_dist_env.sh
+++ b/scripts/sccache_dist_env.sh
@@ -96,6 +96,25 @@ export SCCACHE_DIST_AUTH_TOKEN="$_sirius_dist_token"
 # Compile locally instead of failing when the farm is unreachable.
 export SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=true
 
+# Make __DATE__/__TIME__ expand deterministically (they otherwise bake the
+# preprocessing wall-clock second into cache keys via headers like duckdb's
+# pcg_extras.hpp, permanently missing across machines). Built binaries report
+# a 1970 build date in dist mode.
+export SOURCE_DATE_EPOCH=0
+
+# Strip checkout-local prefixes (sources, .pixi env) from hashed paths and
+# preprocessor output. pixi activation exports the same value inside
+# `pixi run`, but sccache reads it in the *server* process at startup — so
+# export it here too and restart the server below to make it stick.
+_sirius_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export SCCACHE_BASEDIRS="$_sirius_repo_root:$_sirius_repo_root/.pixi/envs/default"
+unset _sirius_repo_root
+
+# The dist-mode server (port 4227) caches its config at startup; restart it so
+# the exports above (basedirs, S3 creds) apply to the next build. The normal
+# build's sccache server (port 4226) is unaffected.
+"$_sirius_dist_bin" --stop-server >/dev/null 2>&1 || true
+
 unset _sirius_dist_home _sirius_dist_creds _sirius_dist_token _sirius_dist_arch
 
 echo "RAPIDS sccache dist farm enabled for this shell (launcher: $_sirius_dist_bin)"

--- a/scripts/sccache_dist_setup.sh
+++ b/scripts/sccache_dist_setup.sh
@@ -127,6 +127,30 @@ chmod 600 "$CREDS_FILE.tmp"
 mv "$CREDS_FILE.tmp" "$CREDS_FILE"
 echo "==> Wrote $CREDS_FILE"
 
+# -----------------------------------------------------------------------------
+# 5) Canonical pixi env. Cache keys include a digest of the compiler *and its
+#    specs file*; conda's gcc embeds the env's absolute path in the specs file
+#    (a link-time -rpath), so compilers from a checkout-local .pixi env poison
+#    every key. Installing one env at this fixed per-user path — identical on
+#    every machine with the same username — makes keys match across checkouts,
+#    worktrees, and machines. The Makefile points CMake at these compilers when
+#    dist mode is on.
+# -----------------------------------------------------------------------------
+if [[ "$CREDS_ONLY" == 0 ]]; then
+  command -v pixi >/dev/null || die "'pixi' is required but not on PATH"
+  REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+  CANON="$DIST_HOME/pixi"
+  mkdir -p "$CANON/scripts"
+  cp "$REPO_ROOT/pixi.toml" "$CANON/pixi.toml"
+  cp "$REPO_ROOT/pixi.lock" "$CANON/pixi.lock"
+  # Activation scripts referenced by pixi.toml (not needed for install, but
+  # keep the manifest self-consistent).
+  cp "$REPO_ROOT/scripts/pixi_activate.sh" "$REPO_ROOT/scripts/vcpkg.sh" "$CANON/scripts/" 2>/dev/null || true
+  echo "==> Installing canonical pixi env (hardlinked from the shared package cache)"
+  (cd "$CANON" && pixi install)
+  echo "==> Canonical build env ready: $CANON/.pixi/envs/default"
+fi
+
 # Stop any running dist-mode sccache server so the next build picks up the
 # fresh credentials. Normal builds use a different port (4226) and are
 # unaffected.

--- a/scripts/sccache_dist_setup.sh
+++ b/scripts/sccache_dist_setup.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Copyright 2025, Sirius Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+#
+# One-time (and credential-refresh) setup for building Sirius against the
+# RAPIDS sccache distributed build farm. See docs/sccache-dist.md.
+#
+# Everything is installed under a dedicated directory
+# (default: ~/.local/share/sirius/sccache-dist, override with
+# SIRIUS_SCCACHE_DIST_HOME). This script deliberately does NOT touch
+# ~/.aws/credentials, ~/.config/sccache, the pixi environment, or anything
+# else the normal (non-distributed) build relies on.
+#
+# Usage:
+#   scripts/sccache_dist_setup.sh               # full setup (idempotent)
+#   scripts/sccache_dist_setup.sh --creds-only  # only refresh the AWS creds (they expire after 12h)
+#   scripts/sccache_dist_setup.sh --force       # re-download the sccache fork binary
+
+set -euo pipefail
+
+DIST_HOME="${SIRIUS_SCCACHE_DIST_HOME:-$HOME/.local/share/sirius/sccache-dist}"
+DIST_BIN="$DIST_HOME/bin/sccache"
+CREDS_FILE="$DIST_HOME/aws-credentials"
+DIST_PORT="${SIRIUS_SCCACHE_DIST_PORT:-4227}"
+CREDS_DURATION=43200 # 12 hours (maximum allowed)
+
+FORCE=0
+CREDS_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=1 ;;
+    --creds-only) CREDS_ONLY=1 ;;
+    -h|--help)
+      sed -n '16,29p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $arg (try --help)" >&2
+      exit 1
+      ;;
+  esac
+done
+
+die() { echo "sccache_dist_setup: $*" >&2; exit 1; }
+
+for tool in curl tar gh; do
+  command -v "$tool" >/dev/null || die "'$tool' is required but not on PATH"
+done
+
+mkdir -p "$DIST_HOME/bin"
+
+# -----------------------------------------------------------------------------
+# 1) Install the RAPIDS sccache fork (not upstream Mozilla sccache — the fork
+#    carries the distributed-compilation features the farm requires). Kept
+#    separate from the pixi-provided sccache 0.15.0 used by normal builds.
+# -----------------------------------------------------------------------------
+if [[ "$CREDS_ONLY" == 0 ]]; then
+  if [[ -x "$DIST_BIN" && "$FORCE" == 0 ]]; then
+    echo "==> RAPIDS sccache fork already installed: $DIST_BIN ($("$DIST_BIN" --version))"
+  else
+    arch="$(uname -m)"
+    [[ "$arch" == "x86_64" || "$arch" == "aarch64" ]] || die "unsupported architecture: $arch"
+    url="https://github.com/rapidsai/sccache/releases/latest/download/sccache-${arch}-unknown-linux-musl.tar.gz"
+    echo "==> Downloading RAPIDS sccache fork: $url"
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    curl -fsSL "$url" | tar -xz -C "$tmpdir"
+    unpacked="$(find "$tmpdir" -type f -name sccache | head -n 1)"
+    [[ -n "$unpacked" ]] || die "no 'sccache' binary found in the release tarball"
+    install -m 0755 "$unpacked" "$DIST_BIN"
+    echo "==> Installed $DIST_BIN ($("$DIST_BIN" --version))"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# 2) GitHub auth — the farm authenticates with a gh token that needs the
+#    gist, repo, read:org and read:enterprise scopes, and requires membership
+#    in the NVIDIA GitHub org (see https://github-onboarding.nvidia.com/).
+# -----------------------------------------------------------------------------
+gh auth status >/dev/null 2>&1 || die "gh is not authenticated. Run:
+  gh auth login --web --scopes gist --scopes repo --scopes read:org --scopes read:enterprise"
+
+scopes="$(gh auth status 2>&1 | grep -i 'token scopes' || true)"
+for scope in gist repo read:org read:enterprise; do
+  if [[ -n "$scopes" && "$scopes" != *"'$scope'"* && "$scopes" != *" $scope"* ]]; then
+    echo "WARNING: gh token may be missing the '$scope' scope. If auth to the farm fails, re-run:" >&2
+    echo "  gh auth refresh --scopes gist --scopes repo --scopes read:org --scopes read:enterprise" >&2
+    break
+  fi
+done
+
+# -----------------------------------------------------------------------------
+# 3) gh-nv-gha-aws extension (mints the temporary AWS creds for the shared
+#    S3 cache bucket).
+# -----------------------------------------------------------------------------
+if ! gh extension list 2>/dev/null | grep -q "nv-gha-aws"; then
+  echo "==> Installing gh extension nv-gha-runners/gh-nv-gha-aws"
+  gh extension install nv-gha-runners/gh-nv-gha-aws
+fi
+
+# -----------------------------------------------------------------------------
+# 4) Temporary AWS credentials for the shared RAPIDS sccache S3 bucket.
+#    Written to a dedicated file (NOT ~/.aws/credentials);
+#    scripts/sccache_dist_env.sh points AWS_SHARED_CREDENTIALS_FILE at it.
+# -----------------------------------------------------------------------------
+echo "==> Fetching temporary AWS credentials (valid for 12h)"
+gh nv-gha-aws org nvidia \
+  --profile default \
+  --output creds-file \
+  --duration "$CREDS_DURATION" \
+  --aud sts.amazonaws.com \
+  --idp-url https://token.gha-runners.nvidia.com \
+  --role-arn arn:aws:iam::279114543810:role/nv-gha-token-sccache-devs \
+  > "$CREDS_FILE.tmp"
+chmod 600 "$CREDS_FILE.tmp"
+mv "$CREDS_FILE.tmp" "$CREDS_FILE"
+echo "==> Wrote $CREDS_FILE"
+
+# Stop any running dist-mode sccache server so the next build picks up the
+# fresh credentials. Normal builds use a different port (4226) and are
+# unaffected.
+if [[ -x "$DIST_BIN" ]]; then
+  SCCACHE_SERVER_PORT="$DIST_PORT" "$DIST_BIN" --stop-server >/dev/null 2>&1 || true
+fi
+
+cat <<EOF
+
+Setup complete. To build through the farm (per shell):
+
+  source scripts/sccache_dist_env.sh
+  pixi run make
+
+The AWS credentials expire after 12 hours; refresh them with:
+
+  scripts/sccache_dist_setup.sh --creds-only
+
+EOF


### PR DESCRIPTION
## Summary

Adds an **opt-in** path that routes Sirius compilation through the [RAPIDS sccache fork](https://github.com/rapidsai/sccache), the shared `rapids-sccache-devs` S3 cache, and NVIDIA's RAPIDS distributed build cluster — so build results are shared across machines when running experiments. Mirrors the approach in [rapidsai/rmm#2101](https://github.com/rapidsai/rmm/pull/2101).

Nothing changes unless explicitly enabled: normal `pixi run make` builds (pixi's Mozilla sccache 0.15.0), CI (GHA sccache / `ci-release` ccache), and the vcpkg presets are all untouched. The mode is gated per shell on `SIRIUS_SCCACHE_DIST=1`.

## What's included

- **`scripts/sccache_dist_setup.sh`** — one-time setup: installs the RAPIDS sccache fork side-by-side under `~/.local/share/sirius/sccache-dist/` (never replacing the pixi sccache), checks `gh` auth scopes, installs `gh-nv-gha-aws`, and mints 12h AWS creds into a dedicated file (`~/.aws/credentials` and `~/.config/sccache` are never touched). `--creds-only` refreshes expired creds.
- **`scripts/sccache_dist_env.sh`** — per-shell activation: exports `SIRIUS_SCCACHE_DIST=1` plus the `SCCACHE_*` config (S3 bucket, arch-specific scheduler URL, gh-token auth, dedicated server port 4227 to avoid clashing with the pixi sccache daemon, local-compile fallback when the farm is unreachable).
- **`Makefile`** — when `SIRIUS_SCCACHE_DIST=1`, overrides the preset compiler launchers via command-line `-D` flags and sets `SCCACHE_NO_DIST_COMPILE=1` for configure-time compiler checks; a mode stamp in `build/` re-runs configure automatically when the mode toggles. With the variable unset, generated build commands are identical to before. Adds a `make sccache-dist-status` health-check target.
- **`docs/sccache-dist.md`** (+ pointer in `DEVELOPMENT.md`) — setup, usage, caveats, troubleshooting.

## Testing (aarch64 host, arm64 scheduler)

- Cold build from a fresh worktree: all 1,283 targets, **1,709 successful distributed compiles, 0 failures, 0 S3 errors**.
- Warm rebuild after `rm -rf build`: **1m42s wall, 99.76% cache hit rate** (1,239/1,242; CUDA 100%) — this is what other machines of the same arch get once the cache is populated.
- With the mode off, `make -n` output is byte-for-byte identical to `dev`; toggling the mode on/off correctly triggers exactly one reconfigure.
- Not yet exercised: the `amd64` scheduler path (same code, different `uname -m` mapping — needs an x86_64 host).

## Notes for reviewers

- Requires NVIDIA GitHub org membership + `gh` scopes `gist, repo, read:org, read:enterprise`; external contributors are unaffected (the mode is never on by default).
- First `make` after this lands re-runs the CMake configure step once (new stamp file); nothing recompiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)