### PR TITLE
refactor(config): internalize pin compression thresholds

### DIFF
--- a/docs/super-sirius/compressed-materialization.md
+++ b/docs/super-sirius/compressed-materialization.md
@@ -385,7 +385,9 @@ compression off for the rest of the pin.
 Both compression gates (`min_batch_size_bytes` and `max_compressed_fraction`) are evaluated on the
 already-narrowed table, so they measure the batch as it will be stored. A batch that falls out of a
 gate, or that arrives after a failure has latched compression off, is stored uncompressed at the
-carrier narrowing selected for it.
+carrier narrowing selected for it. `max_compressed_fraction` must be finite and non-negative;
+values above 1 intentionally permit a compressed representation that expands relative to its
+input, which is useful when testing encodability independently of compression ratio.
 
 Known residual: a plan block with a width-explicit packed op (a `bitextract`/`bitjoin` field spec
 of a fixed total width) on an integer column narrowed to a different width still fails that

--- a/docs/super-sirius/compressed-pinning.md
+++ b/docs/super-sirius/compressed-pinning.md
@@ -15,6 +15,12 @@ at task-prepare time via the `compressed_host_representation` /
 `compressed_device_blob` → `gpu_table_representation` converters, column-parallel across
 4 fixed streams (measured strictly better than serial).
 
+The compression settings can be staged in either order before a table is pinned. They become
+active only when `pin_table_compression` is true, the plan-directory setting is non-empty, and a
+matching table plan exists. `pin_table` warns and pins uncompressed when the enable flag is true
+but the plan directory is empty; a missing table plan likewise warns and falls back. The batch-size
+and compressed-fraction settings are inert until a matching plan activates compression.
+
 ## Which tier to compress on (GB300, TPC-H SF1000, 22-query hot suite)
 
 The tier decides whether compression helps at all. Measured against a 20.74 s all-host

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -153,6 +153,23 @@ Controls the disk spill tier. Data evicted from host memory is written here. Dis
 | `capacity_bytes` | bytes | 1Ti | Maximum disk space for spill files. |
 | `downgrade_root_dirs` | string | "" | Directory path for spill files. **Must be set** to enable disk spilling. Use a fast local mount (NVMe preferred). |
 
+### Input-table compression (`sirius.compression`)
+
+These settings control optional Simpatico compression when
+`pin_table(tier=>'host')` caches input tables. Compression requires both
+`enable_pin_table_compression: true` and a matching plan in `input_plan_dir`;
+otherwise the table is pinned uncompressed.
+
+| Key | DuckDB setting | Type | Default | Description |
+|-----|----------------|------|---------|-------------|
+| `enable_pin_table_compression` | `pin_table_compression` | bool | false | Attempt planned compression while pinning input tables to host memory. |
+| `min_batch_size_bytes` | `pin_table_compression_min_batch_size_bytes` | bytes | 1Mi | Skip compression below this uncompressed batch size. `0` disables the size gate. |
+| `max_compressed_fraction` | `pin_table_compression_max_compressed_fraction` | finite double >= 0 | 0.75 | Keep a compressed representation only at or below this fraction of the original batch size. `0` retains none; values above `1` deliberately permit expansion, primarily for testing encodability. |
+| `input_plan_dir` | `pin_table_input_compression_plan_dir` | string | "" | Directory of per-table Simpatico plan files. An empty path leaves compression inactive. |
+
+The YAML loader and DuckDB `SET` surface reject negative, NaN, and infinite
+`max_compressed_fraction` values instead of silently changing retention behavior.
+
 ### How Downgrade Thresholds Work
 
 Each memory tier uses a trigger/stop threshold pair to control data eviction:

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -163,11 +163,15 @@ otherwise the table is pinned uncompressed.
 | Key | DuckDB setting | Type | Default | Description |
 |-----|----------------|------|---------|-------------|
 | `enable_pin_table_compression` | `pin_table_compression` | bool | false | Attempt planned compression while pinning input tables to host memory. |
-| `min_batch_size_bytes` | `pin_table_compression_min_batch_size_bytes` | bytes | 1Mi | Skip compression below this uncompressed batch size. `0` disables the size gate. |
-| `max_compressed_fraction` | `pin_table_compression_max_compressed_fraction` | finite double >= 0 | 0.75 | Keep a compressed representation only at or below this fraction of the original batch size. `0` retains none; values above `1` deliberately permit expansion, primarily for testing encodability. |
+| `min_batch_size_bytes` | test-only opt-in | bytes | 1Mi | Skip compression below this uncompressed batch size. `0` disables the size gate. |
+| `max_compressed_fraction` | test-only opt-in | finite double >= 0 | 0.75 | Keep a compressed representation only at or below this fraction of the original batch size. `0` retains none; values above `1` deliberately permit expansion, primarily for testing encodability. |
 | `input_plan_dir` | `pin_table_input_compression_plan_dir` | string | "" | Directory of per-table Simpatico plan files. An empty path leaves compression inactive. |
 
-The YAML loader and DuckDB `SET` surface reject negative, NaN, and infinite
+The two compression-policy values are configured through YAML rather than exposed as
+ordinary DuckDB settings. Test processes that set `SIRIUS_ENABLE_TEST_OPTIONS=1` before
+constructing a database can use the corresponding `pin_table_compression_*` settings for
+controlled mechanism tests. Other values, including `true`, do not enable that surface.
+The YAML loader and these test-only `SET` hooks reject negative, NaN, and infinite
 `max_compressed_fraction` values instead of silently changing retention behavior.
 
 ### How Downgrade Thresholds Work

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -195,6 +195,8 @@ struct compression_config {
   /// size, for the compressed form to be kept.  When the compressed header +
   /// payload exceeds this fraction of the original (i.e. compression saved too
   /// little), the compressed data is discarded and the uncompressed batch is used.
+  /// Must be finite and non-negative. Values above 1 deliberately allow compressed
+  /// representations that expand relative to the original batch.
   //  Default 0.75 (that coincides with a 1.33x compression ratio).
   double max_compressed_fraction{0.75};
 

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -27,6 +27,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <algorithm>
+#include <cmath>
 #include <exception>
 #include <limits>
 #include <stdexcept>
@@ -298,7 +299,9 @@ static void from_yaml(const YAML::Node& node, compression_config& opt)
   yaml::reader r(node, "compression");
   r.optional("enable_pin_table_compression", opt.enable_pin_table_compression);
   r.optional("min_batch_size_bytes", yaml::bytes(opt.min_batch_size_bytes));
-  r.optional("max_compressed_fraction", opt.max_compressed_fraction);
+  r.optional("max_compressed_fraction", opt.max_compressed_fraction, [](double value) {
+    return std::isfinite(value) && value >= 0.0;
+  });
   r.optional("input_plan_dir", opt.input_plan_dir);
   r.reject_unknown();
 }

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2258,6 +2258,18 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                               LogicalType::BOOLEAN,
                               Value::BOOLEAN(operator_defaults.enable_dynamic_zone_map_filter),
                               SetEnableDynamicZoneMapFilter);
+    config.AddExtensionOption(
+      "pin_table_compression_min_batch_size_bytes",
+      "TEST ONLY: override the minimum uncompressed batch size for pin_table compression",
+      LogicalType::UBIGINT,
+      Value::UBIGINT(compression_defaults.min_batch_size_bytes),
+      SetPinTableCompressionMinBatchSizeBytes);
+    config.AddExtensionOption(
+      "pin_table_compression_max_compressed_fraction",
+      "TEST ONLY: override the maximum retained compressed-to-original size fraction",
+      LogicalType::DOUBLE,
+      Value::DOUBLE(compression_defaults.max_compressed_fraction),
+      SetPinTableCompressionMaxCompressedFraction);
   }
 
   // Add in config options for special JIT implementation for regex
@@ -2403,23 +2415,6 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     LogicalType::VARCHAR,
     Value(compression_defaults.input_plan_dir),
     SetPinTableInputCompressionPlanDir);
-
-  config.AddExtensionOption(
-    "pin_table_compression_min_batch_size_bytes",
-    "Minimum uncompressed batch size in bytes below which active pin_table compression is skipped; "
-    "inert until compression is enabled and a matching plan resolves",
-    LogicalType::UBIGINT,
-    Value::UBIGINT(compression_defaults.min_batch_size_bytes),
-    SetPinTableCompressionMinBatchSizeBytes);
-
-  config.AddExtensionOption(
-    "pin_table_compression_max_compressed_fraction",
-    "Discard the compressed form and pin uncompressed when the compressed size exceeds this "
-    "finite, non-negative fraction of the batch's original size (values above 1 permit "
-    "expansion); inert until compression is enabled and a matching plan resolves",
-    LogicalType::DOUBLE,
-    Value::DOUBLE(compression_defaults.max_compressed_fraction),
-    SetPinTableCompressionMaxCompressedFraction);
 
   config.AddExtensionOption(
     "dynamic_filter_domain_coverage_threshold",

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -119,6 +119,7 @@ extern "C" int cudaProfilerStop();
 #include "io/types.hpp"                // sirius::io::sirius_ioctx
 #include "io/uring/uring_reactor.hpp"  // sirius::io::uring_io_object
 
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <string_view>
@@ -2041,10 +2042,15 @@ static void SetPinTableCompressionMaxCompressedFraction(ClientContext& context,
                                                         SetScope scope,
                                                         Value& parameter)
 {
+  const double fraction = DoubleValue::Get(parameter);
+  if (!std::isfinite(fraction) || fraction < 0.0) {
+    throw InvalidInputException(
+      "pin_table_compression_max_compressed_fraction must be finite and non-negative, got %f",
+      fraction);
+  }
   auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
   if (!sirius_ctx) { return; }
-  sirius_ctx->get_config().get_compression_config().max_compressed_fraction =
-    DoubleValue::Get(parameter);
+  sirius_ctx->get_config().get_compression_config().max_compressed_fraction = fraction;
   SIRIUS_LOG_DEBUG("Updated pin_table_compression_max_compressed_fraction");
 }
 
@@ -2409,8 +2415,8 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
   config.AddExtensionOption(
     "pin_table_compression_max_compressed_fraction",
     "Discard the compressed form and pin uncompressed when the compressed size exceeds this "
-    "fraction of the batch's original size (i.e. compression saved too little); inert until "
-    "compression is enabled and a matching plan resolves",
+    "finite, non-negative fraction of the batch's original size (values above 1 permit "
+    "expansion); inert until compression is enabled and a matching plan resolves",
     LogicalType::DOUBLE,
     Value::DOUBLE(compression_defaults.max_compressed_fraction),
     SetPinTableCompressionMaxCompressedFraction);

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1318,6 +1318,12 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
   // directory (if configured), then resolve it into a compression_pin_config. Both
   // the host and GPU pin paths compress with this when enabled.
   const auto& comp_cfg = sirius_ctx->get_config().get_compression_config();
+  if (comp_cfg.enable_pin_table_compression && comp_cfg.input_plan_dir.empty()) {
+    SIRIUS_LOG_WARN(
+      "[pin_table] '{}': pin_table_compression is enabled but "
+      "pin_table_input_compression_plan_dir is empty; pinning uncompressed",
+      data.args.name);
+  }
   const bool comp_globally_enabled =
     comp_cfg.enable_pin_table_compression && !comp_cfg.input_plan_dir.empty();
   if (comp_globally_enabled) {
@@ -2375,23 +2381,27 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     SetEnableGpuExecution);
 
   config.AddExtensionOption("pin_table_compression",
-                            "Enable Simpatico compression for pin_table(tier=>'host') chunks",
+                            "Request Simpatico compression for pin_table chunks. Takes effect only "
+                            "when pin_table_input_compression_plan_dir is non-empty and contains a "
+                            "matching table plan",
                             LogicalType::BOOLEAN,
                             Value::BOOLEAN(compression_defaults.enable_pin_table_compression),
                             SetEnablePinTableCompression);
 
   config.AddExtensionOption(
     "pin_table_input_compression_plan_dir",
-    "Directory containing per-table Simpatico plan files for pin_table(tier=>'host') compression. "
+    "Directory containing per-table Simpatico plan files for pin_table compression. "
     "Files are named '<table_name>.<ext>'; their contents are the multi-column plan DSL. "
-    "Tables with no matching file are pinned uncompressed. No effect on spill compression.",
+    "May be set before pin_table_compression is enabled. Tables with no matching file are pinned "
+    "uncompressed. No effect on spill compression.",
     LogicalType::VARCHAR,
     Value(compression_defaults.input_plan_dir),
     SetPinTableInputCompressionPlanDir);
 
   config.AddExtensionOption(
     "pin_table_compression_min_batch_size_bytes",
-    "Minimum uncompressed batch size in bytes below which pin_table compression is skipped",
+    "Minimum uncompressed batch size in bytes below which active pin_table compression is skipped; "
+    "inert until compression is enabled and a matching plan resolves",
     LogicalType::UBIGINT,
     Value::UBIGINT(compression_defaults.min_batch_size_bytes),
     SetPinTableCompressionMinBatchSizeBytes);
@@ -2399,7 +2409,8 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
   config.AddExtensionOption(
     "pin_table_compression_max_compressed_fraction",
     "Discard the compressed form and pin uncompressed when the compressed size exceeds this "
-    "fraction of the batch's original size (i.e. compression saved too little)",
+    "fraction of the batch's original size (i.e. compression saved too little); inert until "
+    "compression is enabled and a matching plan resolves",
     LogicalType::DOUBLE,
     Value::DOUBLE(compression_defaults.max_compressed_fraction),
     SetPinTableCompressionMaxCompressedFraction);

--- a/test/cpp/compression/test_compression.cpp
+++ b/test/cpp/compression/test_compression.cpp
@@ -25,6 +25,7 @@
 
 #include <catch.hpp>
 #include <compression/plan_register.hpp>
+#include <utils/log_test_utils.hpp>
 
 // standard library
 #include <string>
@@ -1697,6 +1698,30 @@ TEST_CASE("pin_table compression - no plan file for the table pins uncompressed"
   run_ok(con, "SET pin_table_compression = true;", "set compression");
   run_ok(con, "SET pin_table_compression_min_batch_size_bytes = 0;", "set min_batch");
   run_ok(con, "SET enable_compressed_materialization = true;", "set narrowing");
+
+  // Runtime settings may be staged in either order, so setting the enable flag before the plan
+  // directory is valid. The final pin must nevertheless make the inactive state visible rather
+  // than silently accepting a compression request it cannot honor.
+  {
+    sirius::test::scoped_recording_log_sink logs{"warn"};
+    auto pin_without_plan_source =
+      con.Query("CALL pin_table('" + glob + "', tier='host', name='t_noplan');");
+    require_ok(pin_without_plan_source, "pin without plan source");
+
+    std::size_t missing_plan_source_warnings = 0;
+    for (auto const& record : logs.records()) {
+      if (record.message.find("pin_table_input_compression_plan_dir is empty") !=
+          std::string::npos) {
+        ++missing_plan_source_warnings;
+        REQUIRE(record.level == sirius::log::level::warn);
+        REQUIRE(record.message.find("pinning uncompressed") != std::string::npos);
+      }
+    }
+    REQUIRE(missing_plan_source_warnings == 1);
+  }
+  REQUIRE(sirius::test::census_entry(con, "t_noplan").compressed_chunks == 0);
+  run_ok(con, "CALL unpin_table('t_noplan');", "unpin without plan source");
+
   // A plan directory holding a plan for some OTHER table: the resolver finds no plan for this
   // one, so compression never engages.
   auto plan_dir = tmp / "plans";

--- a/test/cpp/config/data/invalid_compression_fraction_infinity.yaml
+++ b/test/cpp/config/data/invalid_compression_fraction_infinity.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: .inf

--- a/test/cpp/config/data/invalid_compression_fraction_nan.yaml
+++ b/test/cpp/config/data/invalid_compression_fraction_nan.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: .nan

--- a/test/cpp/config/data/invalid_compression_fraction_negative.yaml
+++ b/test/cpp/config/data/invalid_compression_fraction_negative.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: -0.1

--- a/test/cpp/config/data/valid_compression_fraction_above_one.yaml
+++ b/test/cpp/config/data/valid_compression_fraction_above_one.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: 1.5

--- a/test/cpp/config/data/valid_compression_fraction_zero.yaml
+++ b/test/cpp/config/data/valid_compression_fraction_zero.yaml
@@ -1,0 +1,3 @@
+sirius:
+  compression:
+    max_compressed_fraction: 0

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -228,6 +228,8 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "enable_pinned_zone_map_pruning") == 0);
     REQUIRE(setting_count(con, "enable_dynamic_filter_pushdown") == 0);
     REQUIRE(setting_count(con, "enable_dynamic_zone_map_filter") == 0);
+    REQUIRE(setting_count(con, "pin_table_compression_min_batch_size_bytes") == 0);
+    REQUIRE(setting_count(con, "pin_table_compression_max_compressed_fraction") == 0);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
@@ -240,6 +242,12 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     result = con.Query("SET enable_dynamic_zone_map_filter = true");
     REQUIRE(result != nullptr);
     REQUIRE(result->HasError());
+    result = con.Query("SET pin_table_compression_min_batch_size_bytes = 0");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    result = con.Query("SET pin_table_compression_max_compressed_fraction = 0.9");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "true", 1);
@@ -250,6 +258,8 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "enable_pinned_zone_map_pruning") == 0);
     REQUIRE(setting_count(con, "enable_dynamic_filter_pushdown") == 0);
     REQUIRE(setting_count(con, "enable_dynamic_zone_map_filter") == 0);
+    REQUIRE(setting_count(con, "pin_table_compression_min_batch_size_bytes") == 0);
+    REQUIRE(setting_count(con, "pin_table_compression_max_compressed_fraction") == 0);
   }
 
   setenv("SIRIUS_ENABLE_TEST_OPTIONS", "1", 1);
@@ -260,6 +270,8 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     REQUIRE(setting_count(con, "enable_pinned_zone_map_pruning") == 1);
     REQUIRE(setting_count(con, "enable_dynamic_filter_pushdown") == 1);
     REQUIRE(setting_count(con, "enable_dynamic_zone_map_filter") == 1);
+    REQUIRE(setting_count(con, "pin_table_compression_min_batch_size_bytes") == 1);
+    REQUIRE(setting_count(con, "pin_table_compression_max_compressed_fraction") == 1);
     auto result = con.Query("SET sirius_test_inject_transparent_gpu_error = 'boom'");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
@@ -281,6 +293,25 @@ TEST_CASE("Test-only settings require explicit process opt-in",
     result = con.Query("RESET enable_dynamic_zone_map_filter");
     REQUIRE(result != nullptr);
     REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET pin_table_compression_min_batch_size_bytes = 0");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET pin_table_compression_min_batch_size_bytes");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET pin_table_compression_max_compressed_fraction = 0.9");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("RESET pin_table_compression_max_compressed_fraction");
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+    result = con.Query("SET pin_table_compression_max_compressed_fraction = -0.1");
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    REQUIRE_THAT(
+      result->GetError(),
+      Catch::Contains(
+        "pin_table_compression_max_compressed_fraction must be finite and non-negative"));
   }
 }
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -399,6 +399,37 @@ TEST_CASE("Sirius YAML rejects invalid dynamic-filter thresholds", "[sirius][con
   REQUIRE(config.get_operator_params().dynamic_filter_keep_threshold == Approx(0.0));
 }
 
+TEST_CASE("Sirius configuration rejects invalid compression retention fractions",
+          "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+  sirius::sirius_config config;
+  for (auto const* fixture : {"invalid_compression_fraction_negative.yaml",
+                              "invalid_compression_fraction_nan.yaml",
+                              "invalid_compression_fraction_infinity.yaml"}) {
+    INFO("fixture=" << fixture);
+    REQUIRE_THROWS_WITH(config.load_from_file(data_dir / fixture),
+                        Catch::Contains("max_compressed_fraction"));
+  }
+}
+
+TEST_CASE("Sirius configuration accepts intentional compression retention fraction boundaries",
+          "[sirius][config]")
+{
+  std::source_location loc    = std::source_location::current();
+  auto const data_dir         = fs::path(loc.file_name()).parent_path() / "data";
+  auto const require_fraction = [&data_dir](char const* fixture, double expected) {
+    INFO("fixture=" << fixture);
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(config.load_from_file(data_dir / fixture));
+    REQUIRE(config.get_compression_config().max_compressed_fraction == Approx(expected));
+  };
+
+  require_fraction("valid_compression_fraction_zero.yaml", 0.0);
+  require_fraction("valid_compression_fraction_above_one.yaml", 1.5);
+}
+
 namespace {
 
 void require_shared_operator_defaults(const sirius::operator_params& params, uint64_t batch)
@@ -749,6 +780,36 @@ TEST_CASE("DuckDB setting rejects negative byte values without mutation",
   REQUIRE(after->GetValue(0, 0).GetValue<uint64_t>() == expected);
 }
 
+TEST_CASE("DuckDB setting rejects invalid compression retention fractions without a Sirius context",
+          "[sirius][context][config][isolated_context]")
+{
+  finally cleanup_env{[]() { setenv("SIRIUS_DISABLE", "1", 1); }};
+  setenv("SIRIUS_DISABLE", "1", 1);
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  for (auto const* value : {"-0.1", "'NaN'", "'Infinity'"}) {
+    INFO("value=" << value);
+    auto result =
+      con.Query("SET pin_table_compression_max_compressed_fraction = " + std::string(value));
+    REQUIRE(result != nullptr);
+    REQUIRE(result->HasError());
+    REQUIRE_THAT(
+      result->GetError(),
+      Catch::Contains(
+        "pin_table_compression_max_compressed_fraction must be finite and non-negative"));
+  }
+
+  for (auto const* value : {"0", "1.5"}) {
+    INFO("value=" << value);
+    auto result =
+      con.Query("SET pin_table_compression_max_compressed_fraction = " + std::string(value));
+    REQUIRE(result != nullptr);
+    REQUIRE_FALSE(result->HasError());
+  }
+}
+
 TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
           "[sirius][context][config][isolated_context]")
 {
@@ -865,6 +926,26 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE_FALSE(reset_mark_join_ratio->HasError());
   REQUIRE(sirius_ctx->get_config().get_operator_params().mark_join_build_switch_ratio ==
           Approx(3.0));
+
+  for (auto const* value : {"-0.1", "'NaN'", "'Infinity'"}) {
+    INFO("value=" << value);
+    auto invalid_fraction =
+      con.Query("SET pin_table_compression_max_compressed_fraction = " + std::string(value));
+    REQUIRE(invalid_fraction != nullptr);
+    REQUIRE(invalid_fraction->HasError());
+    REQUIRE_THAT(
+      invalid_fraction->GetError(),
+      Catch::Contains(
+        "pin_table_compression_max_compressed_fraction must be finite and non-negative"));
+
+    auto retained =
+      con.Query("SELECT current_setting('pin_table_compression_max_compressed_fraction')::DOUBLE");
+    REQUIRE(retained != nullptr);
+    REQUIRE_FALSE(retained->HasError());
+    REQUIRE(retained->GetValue(0, 0).GetValue<double>() == Approx(0.6));
+    REQUIRE(sirius_ctx->get_config().get_compression_config().max_compressed_fraction ==
+            Approx(0.6));
+  }
 
   auto const require_ok = [&con](std::string const& sql) {
     auto result = con.Query(sql);


### PR DESCRIPTION
## Summary

- remove the two pin-compression tuning thresholds from the ordinary DuckDB session surface
- retain their YAML inputs as the internal compression-policy source of truth
- expose the DuckDB overrides only to exact mechanism tests whose process sets `SIRIUS_ENABLE_TEST_OPTIONS=1`
- document the ordinary and test-only surfaces explicitly

## Why

Foxglove screened the two thresholds across one calibration and 45 retained L4 trials. Every candidate changed the compression mechanism as the Sirius source predicts, but none earned an admissible performance gain; disabling or maximally relaxing compression materially regressed the 256 MiB path. These are useful internal policy values, not choices ordinary users should have to understand or tune.

This PR changes surface policy only. It is stacked on #1498, which separately repairs the pin-compression activation and numeric-validation behavior. While #1498 is open, this PR remains a draft and its displayed diff includes that dependency; after #1498 merges, the branch will be rebased so the review diff is the single surface-policy commit.

## Exact stacked identity

- current upstream `dev`: `e885ffea7d0541f1e3493566e2db0ed6e431106f`
- dependency #1498 head: `36a7af2470eb09b5150f5680547d761775497220`
- policy commit/head: `12f52941f288e534b8b94b6b2af0bd97e851e3a3`
- policy tree: `513e041bf67a2ba67611fc7800bb2e1e4c587f8b`
- zero-context dependency-to-head diff SHA-256: `4c94f278f60b65975857d892bd724cc111e1334b11ec3eaefa3b3d2d5f4a2460`

## Validation

- dependency #1498: hosted lint, GCC release, Clang debug, CUDA 13 build/runtime, TPC-H snapshot, and aggregate all green at its exact head (workflow 31752800591)
- `python3 scripts/check_orphan_tests.py`: pass
- `git diff --check`: pass
- recursive submodule cleanliness: pass
- changed-file pre-commit hooks: large-file, case-conflict, merge-conflict, symlink, key, EOF, line-ending, whitespace, smartquote, clang-format, codespell, and orphan-test checks pass
- repository-pinned `rumdl 0.2.44` on the changed documentation: pass
- hosted exact-head workflow 31762003238: lint, GCC release, Clang debug, and terminal Check aggregate pass
- hosted exact-head workflow 31762003302: CUDA 13 build job 94650157546 passes; runtime/TPC-H job 94650835115 passes in 19m46s; terminal Test aggregate job 94654062763 passes
- distribution and PR-title validation pass; CUDA 12/13 distribution builds are intentionally skipped by the workflow

Depends on #1498.
