### PR TITLE
fix(config): derive scan-manager threads from live pools

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -302,7 +302,6 @@ The `sirius.executor.scan_manager` block configures the scan-metadata thread poo
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `num_threads` | int (**3..INT_MAX-1**) | remaining cores (min 4) | Configured metadata workers in the scan-manager pool. The pool also owns one internal worker. When omitted, Sirius derives the configured count after parsing the other executor and memory settings: hardware concurrency minus that internal worker, every configured downgrade executor (one per GPU and HOST space), every pipeline executor (one per GPU), the task-creator pool, and the io_uring pool, with a floor of 4. An explicit value is preserved when the constructor's internal-worker addition remains representable. |
-| `thread_name_prefix` | string | `scan_manager` | Thread name prefix for logs. |
 | `cpu_affinity` | list of int | — | Cores to pin scan-manager threads to. |
 | `use_sirius_datasource` | bool | true | Route reads through the Sirius `io_uring` datasource. When false, the kvikio fallback is used (single-GPU only; multi-GPU requires the Sirius datasource). |
 | `uring_n_reactors` | int (**> 0**) | 1 | Number of io_uring reactor threads for local-disk reads. |

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -301,7 +301,7 @@ The `sirius.executor.scan_manager` block configures the scan-metadata thread poo
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `num_threads` | int (**> 2**) | remaining cores (min 4) | Configured metadata workers in the scan-manager pool. The pool also owns one internal worker. When omitted, Sirius derives the configured count after parsing the other executor and memory settings: hardware concurrency minus that internal worker, every configured downgrade executor (one per GPU and HOST space), every pipeline executor (one per GPU), the task-creator pool, and the io_uring pool, with a floor of 4. An explicit value is preserved. Rejected unless strictly greater than 2 (i.e. minimum 3). |
+| `num_threads` | int (**3..INT_MAX-1**) | remaining cores (min 4) | Configured metadata workers in the scan-manager pool. The pool also owns one internal worker. When omitted, Sirius derives the configured count after parsing the other executor and memory settings: hardware concurrency minus that internal worker, every configured downgrade executor (one per GPU and HOST space), every pipeline executor (one per GPU), the task-creator pool, and the io_uring pool, with a floor of 4. An explicit value is preserved when the constructor's internal-worker addition remains representable. |
 | `thread_name_prefix` | string | `scan_manager` | Thread name prefix for logs. |
 | `cpu_affinity` | list of int | — | Cores to pin scan-manager threads to. |
 | `use_sirius_datasource` | bool | true | Route reads through the Sirius `io_uring` datasource. When false, the kvikio fallback is used (single-GPU only; multi-GPU requires the Sirius datasource). |

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -301,7 +301,7 @@ The `sirius.executor.scan_manager` block configures the scan-metadata thread poo
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `num_threads` | int (**> 2**) | remaining cores (min 4) | Threads in the scan-manager pool that run metadata tasks. When omitted, Sirius derives this after parsing the other executor and memory settings: hardware concurrency minus every configured downgrade executor (one per GPU and HOST space), every pipeline executor (one per GPU), the task-creator pool, and the io_uring pool, with a floor of 4. An explicit value is preserved. Rejected unless strictly greater than 2 (i.e. minimum 3). |
+| `num_threads` | int (**> 2**) | remaining cores (min 4) | Configured metadata workers in the scan-manager pool. The pool also owns one internal worker. When omitted, Sirius derives the configured count after parsing the other executor and memory settings: hardware concurrency minus that internal worker, every configured downgrade executor (one per GPU and HOST space), every pipeline executor (one per GPU), the task-creator pool, and the io_uring pool, with a floor of 4. An explicit value is preserved. Rejected unless strictly greater than 2 (i.e. minimum 3). |
 | `thread_name_prefix` | string | `scan_manager` | Thread name prefix for logs. |
 | `cpu_affinity` | list of int | — | Cores to pin scan-manager threads to. |
 | `use_sirius_datasource` | bool | true | Route reads through the Sirius `io_uring` datasource. When false, the kvikio fallback is used (single-GPU only; multi-GPU requires the Sirius datasource). |

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -301,7 +301,8 @@ The `sirius.executor.scan_manager` block configures the scan-metadata thread poo
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `num_threads` | int (**> 2**) | remaining cores (min 4) | Threads in the scan-manager pool that run metadata tasks. Defaults to every core left after the other default pools (1 downgrade + 1 task_creator + 4 pipeline + 1 uring reactor), with a floor of 4. Rejected unless strictly greater than 2 (i.e. minimum 3). |
+| `num_threads` | int (**> 2**) | remaining cores (min 4) | Threads in the scan-manager pool that run metadata tasks. When omitted, Sirius derives this after parsing the other executor and memory settings: hardware concurrency minus every configured downgrade executor (one per GPU and HOST space), every pipeline executor (one per GPU), the task-creator pool, and the io_uring pool, with a floor of 4. An explicit value is preserved. Rejected unless strictly greater than 2 (i.e. minimum 3). |
+| `thread_name_prefix` | string | `scan_manager` | Thread name prefix for logs. |
 | `cpu_affinity` | list of int | — | Cores to pin scan-manager threads to. |
 | `use_sirius_datasource` | bool | true | Route reads through the Sirius `io_uring` datasource. When false, the kvikio fallback is used (single-GPU only; multi-GPU requires the Sirius datasource). |
 | `uring_n_reactors` | int (**> 0**) | 1 | Number of io_uring reactor threads for local-disk reads. |

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -301,7 +301,7 @@ The `sirius.executor.scan_manager` block configures the scan-metadata thread poo
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `num_threads` | int (**3..INT_MAX-1**) | remaining cores (min 4) | Configured metadata workers in the scan-manager pool. The pool also owns one internal worker. When omitted, Sirius derives the configured count after parsing the other executor and memory settings: hardware concurrency minus that internal worker, every configured downgrade executor (one per GPU and HOST space), every pipeline executor (one per GPU), the task-creator pool, and the io_uring pool, with a floor of 4. An explicit value is preserved when the constructor's internal-worker addition remains representable. |
+| `num_threads` | int (**3..INT_MAX-1**) | remaining cores (min 4) | Configured metadata workers in the scan-manager pool. The pool also owns one internal worker. When omitted, Sirius derives the configured count after parsing the other executor and memory settings: hardware concurrency minus that internal worker, every configured downgrade executor (one per GPU and HOST space), every pipeline executor (one per GPU), the task-creator pool, and active io_uring reactor workers. The reactor count is zero when the single-GPU KvikIO fallback is selected. The derived count has a floor of 4. An explicit value is preserved when the constructor's internal-worker addition remains representable. |
 | `cpu_affinity` | list of int | — | Cores to pin scan-manager threads to. |
 | `use_sirius_datasource` | bool | true | Route reads through the Sirius `io_uring` datasource. When false, the kvikio fallback is used (single-GPU only; multi-GPU requires the Sirius datasource). |
 | `uring_n_reactors` | int (**> 0**) | 1 | Number of io_uring reactor threads for local-disk reads. |
@@ -531,7 +531,7 @@ per-pool extras.
 The task-creator, downgrade, and scan-manager pools support optional CPU affinity lists
 (`cpu_affinity`) for core pinning. GPU pipeline affinity is derived per executor from the selected
 GPU's CPU topology. `num_threads` must be `> 0` for every pool except `scan_manager`, which requires
-`> 2`.
+`3..INT_MAX-1`.
 
 ## DuckDB SET Variables
 

--- a/src/include/scan_manager/config.hpp
+++ b/src/include/scan_manager/config.hpp
@@ -25,6 +25,7 @@
 #include "io/uring/config.hpp"
 
 #include <algorithm>
+#include <limits>
 #include <thread>
 
 namespace sirius::scan_manager {
@@ -32,14 +33,48 @@ namespace sirius::scan_manager {
 /// Default uring reactor count; counted in the scan-manager sizing budget below.
 inline constexpr std::size_t default_uring_n_reactors = 1;
 
-/// Default scan-manager pool size: every core left after the other default pools
-/// (downgrade, task_creator, pipeline, uring reactor), never below 4.
+/// Scan-manager pool size from the live sibling-pool configuration: every core left after the
+/// per-space downgrade, task-creator, per-GPU pipeline, and io_uring pools, never below 4.
+[[nodiscard]] inline int derived_scan_manager_num_threads(unsigned hardware_threads,
+                                                          std::size_t downgrade_threads,
+                                                          std::size_t downgrade_executors,
+                                                          std::size_t task_creator_threads,
+                                                          std::size_t pipeline_threads,
+                                                          std::size_t pipeline_executors,
+                                                          std::size_t uring_reactors)
+{
+  std::size_t remaining = hardware_threads;
+  auto subtract_product = [&remaining](std::size_t threads, std::size_t executors) {
+    if (threads != 0 && executors > remaining / threads) {
+      remaining = 0;
+    } else {
+      auto const reserved = threads * executors;
+      remaining           = reserved >= remaining ? 0 : remaining - reserved;
+    }
+  };
+  auto subtract = [&remaining](std::size_t reserved) {
+    remaining = reserved >= remaining ? 0 : remaining - reserved;
+  };
+
+  subtract_product(downgrade_threads, downgrade_executors);
+  subtract(task_creator_threads);
+  subtract_product(pipeline_threads, pipeline_executors);
+  subtract(uring_reactors);
+
+  remaining = std::clamp<std::size_t>(remaining, 4, std::numeric_limits<int>::max());
+  return static_cast<int>(remaining);
+}
+
+/// Default scan-manager pool size derived from the default sibling pools.
 [[nodiscard]] inline int default_scan_manager_num_threads()
 {
-  constexpr int reserved =
-    exec::default_downgrade_num_threads + creator::default_task_creator_num_threads +
-    exec::default_gpu_pipeline_num_threads + static_cast<int>(default_uring_n_reactors);
-  return std::max(4, static_cast<int>(std::thread::hardware_concurrency()) - reserved);
+  return derived_scan_manager_num_threads(std::thread::hardware_concurrency(),
+                                          exec::default_downgrade_num_threads,
+                                          1,
+                                          creator::default_task_creator_num_threads,
+                                          exec::default_gpu_pipeline_num_threads,
+                                          1,
+                                          default_uring_n_reactors);
 }
 
 /**

--- a/src/include/scan_manager/config.hpp
+++ b/src/include/scan_manager/config.hpp
@@ -33,8 +33,12 @@ namespace sirius::scan_manager {
 /// Default uring reactor count; counted in the scan-manager sizing budget below.
 inline constexpr std::size_t default_uring_n_reactors = 1;
 
+/// Extra worker added by sirius_scan_manager beyond the configured scan-manager count.
+inline constexpr int scan_manager_internal_worker_count = 1;
+
 /// Scan-manager pool size from the live sibling-pool configuration: every core left after the
-/// per-space downgrade, task-creator, per-GPU pipeline, and io_uring pools, never below 4.
+/// internal scan-manager worker, per-space downgrade, task-creator, per-GPU pipeline, and io_uring
+/// pools, never below 4.
 [[nodiscard]] inline int derived_scan_manager_num_threads(unsigned hardware_threads,
                                                           std::size_t downgrade_threads,
                                                           std::size_t downgrade_executors,
@@ -56,6 +60,7 @@ inline constexpr std::size_t default_uring_n_reactors = 1;
     remaining = reserved >= remaining ? 0 : remaining - reserved;
   };
 
+  subtract(scan_manager_internal_worker_count);
   subtract_product(downgrade_threads, downgrade_executors);
   subtract(task_creator_threads);
   subtract_product(pipeline_threads, pipeline_executors);

--- a/src/include/scan_manager/config.hpp
+++ b/src/include/scan_manager/config.hpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <stdexcept>
 #include <thread>
 
 namespace sirius::scan_manager {
@@ -35,6 +36,20 @@ inline constexpr std::size_t default_uring_n_reactors = 1;
 
 /// Extra worker added by sirius_scan_manager beyond the configured scan-manager count.
 inline constexpr int scan_manager_internal_worker_count = 1;
+
+/// Largest configured count whose constructor-time internal-worker addition is representable.
+inline constexpr int max_scan_manager_num_threads =
+  std::numeric_limits<int>::max() - scan_manager_internal_worker_count;
+
+/// Total scan-manager pool size, checked here as well as at the YAML boundary because callers can
+/// install a scan_manager_config programmatically.
+[[nodiscard]] inline int scan_manager_pool_num_threads(int configured_threads)
+{
+  if (configured_threads > max_scan_manager_num_threads) {
+    throw std::out_of_range("scan-manager thread count exceeds the constructible maximum");
+  }
+  return configured_threads + scan_manager_internal_worker_count;
+}
 
 /// Scan-manager pool size from the live sibling-pool configuration: every core left after the
 /// internal scan-manager worker, per-space downgrade, task-creator, per-GPU pipeline, and io_uring
@@ -66,7 +81,7 @@ inline constexpr int scan_manager_internal_worker_count = 1;
   subtract_product(pipeline_threads, pipeline_executors);
   subtract(uring_reactors);
 
-  remaining = std::clamp<std::size_t>(remaining, 4, std::numeric_limits<int>::max());
+  remaining = std::clamp<std::size_t>(remaining, 4, max_scan_manager_num_threads);
   return static_cast<int>(remaining);
 }
 

--- a/src/include/scan_manager/config.hpp
+++ b/src/include/scan_manager/config.hpp
@@ -51,6 +51,13 @@ inline constexpr int max_scan_manager_num_threads =
   return configured_threads + scan_manager_internal_worker_count;
 }
 
+/// Configured reactor workers that are active for the selected local-data-source backend.
+[[nodiscard]] constexpr std::size_t active_uring_reactor_count(
+  bool use_sirius_datasource, std::size_t configured_reactors) noexcept
+{
+  return use_sirius_datasource ? configured_reactors : 0;
+}
+
 /// Scan-manager pool size from the live sibling-pool configuration: every core left after the
 /// internal scan-manager worker, per-space downgrade, task-creator, per-GPU pipeline, and io_uring
 /// pools, never below 4.

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -493,7 +493,7 @@ sirius_scan_manager::sirius_scan_manager(
   : _config(config),
     _reservation_manager(reservation_manager),
     _topology_index(std::move(topology_index)),
-    _thread_pool(_config.thread_pool.num_threads + 1,
+    _thread_pool(_config.thread_pool.num_threads + scan_manager_internal_worker_count,
                  _config.thread_pool.thread_name_prefix,
                  _config.thread_pool.cpu_affinity_list),
     _dispatcher(

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -493,7 +493,7 @@ sirius_scan_manager::sirius_scan_manager(
   : _config(config),
     _reservation_manager(reservation_manager),
     _topology_index(std::move(topology_index)),
-    _thread_pool(_config.thread_pool.num_threads + scan_manager_internal_worker_count,
+    _thread_pool(scan_manager_pool_num_threads(_config.thread_pool.num_threads),
                  _config.thread_pool.thread_name_prefix,
                  _config.thread_pool.cpu_affinity_list),
     _dispatcher(

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -1265,7 +1265,7 @@ sirius_scan_manager::sirius_scan_manager(
   : _config(config),
     _reservation_manager(reservation_manager),
     _topology_index(std::move(topology_index)),
-    _thread_pool(_config.thread_pool.num_threads + 1,
+    _thread_pool(_config.thread_pool.num_threads + scan_manager_internal_worker_count,
                  _config.thread_pool.thread_name_prefix,
                  _config.thread_pool.cpu_affinity_list),
     _dispatcher(

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -1265,7 +1265,7 @@ sirius_scan_manager::sirius_scan_manager(
   : _config(config),
     _reservation_manager(reservation_manager),
     _topology_index(std::move(topology_index)),
-    _thread_pool(_config.thread_pool.num_threads + scan_manager_internal_worker_count,
+    _thread_pool(scan_manager_pool_num_threads(_config.thread_pool.num_threads),
                  _config.thread_pool.thread_name_prefix,
                  _config.thread_pool.cpu_affinity_list),
     _dispatcher(

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -600,6 +600,40 @@ operator_params operator_defaults_for(
   return params;
 }
 
+std::size_t downgrade_executor_count_for(
+  const std::vector<cucascade::memory::memory_space_config>& memory_space_configs)
+{
+  return std::ranges::count_if(memory_space_configs, [](auto const& space) {
+    return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space) ||
+           std::holds_alternative<cucascade::memory::host_memory_space_config>(space);
+  });
+}
+
+std::size_t pipeline_executor_count_for(
+  const std::vector<cucascade::memory::memory_space_config>& memory_space_configs)
+{
+  return std::ranges::count_if(memory_space_configs, [](auto const& space) {
+    return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space);
+  });
+}
+
+int derived_scan_manager_threads_for(
+  const std::vector<cucascade::memory::memory_space_config>& memory_space_configs,
+  const exec::downgrade_executor_config& downgrade,
+  const creator::task_creator_config& task_creator,
+  const exec::thread_pool_config& pipeline,
+  const scan_manager::scan_manager_config& scan_manager)
+{
+  return scan_manager::derived_scan_manager_num_threads(
+    std::thread::hardware_concurrency(),
+    downgrade.thread_pool.num_threads,
+    downgrade_executor_count_for(memory_space_configs),
+    task_creator.thread_pool.num_threads,
+    pipeline.num_threads,
+    pipeline_executor_count_for(memory_space_configs),
+    scan_manager.uring_n_reactors);
+}
+
 }  // namespace
 
 // ================ sirius_config ================= //
@@ -625,7 +659,13 @@ void sirius_config::apply_defaults()
   host_cfg.setup_configurator(builder);
   disk_cfg.setup_configurator(builder);
   _memory_space_configs = builder.build(_hw_topology);
-  _operator_params      = operator_params{};
+  _scan_manager_config.thread_pool.num_threads =
+    derived_scan_manager_threads_for(_memory_space_configs,
+                                     _downgrade_executor_config,
+                                     _task_creator_config,
+                                     _gpu_pipeline_executor_config,
+                                     _scan_manager_config);
+  _operator_params = operator_params{};
 }
 
 void sirius_config::load_from_file(const std::filesystem::path& config_path)
@@ -678,16 +718,21 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
       mr.reject_unknown();
     }
 
-    // Executors
+    // Executors. If scan_manager.num_threads is omitted, resolve it after all sibling pools so
+    // their explicit sizes reduce the same hardware concurrency budget instead of silently
+    // oversubscribing it.
+    bool scan_manager_num_threads_explicit = false;
     if (auto exec_node = r.optional_node("executor")) {
       yaml::reader er(*exec_node, "sirius.executor");
       if (auto n = er.optional_node("task_creator")) from_yaml(*n, _task_creator_config);
-      if (auto n = er.optional_node("scan_manager")) from_yaml(*n, _scan_manager_config);
+      if (auto n = er.optional_node("scan_manager")) {
+        scan_manager_num_threads_explicit = yaml::reader{*n}.has_value("num_threads");
+        from_yaml(*n, _scan_manager_config);
+      }
       if (auto n = er.optional_node("pipeline")) from_yaml(*n, _gpu_pipeline_executor_config);
       if (auto n = er.optional_node("downgrade")) from_yaml(*n, _downgrade_executor_config);
       er.reject_unknown();
     }
-
     // Preserve the node until memory-space capacities are resolved below. Explicit
     // values are applied after capacity-derived defaults so they always win.
     auto operator_node = r.optional_node("operator_params");
@@ -747,6 +792,15 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
       host_cfg.setup_configurator(builder);
       disk_cfg.setup_configurator(builder);
       _memory_space_configs = builder.build(_hw_topology);
+    }
+
+    if (!scan_manager_num_threads_explicit) {
+      _scan_manager_config.thread_pool.num_threads =
+        derived_scan_manager_threads_for(_memory_space_configs,
+                                         _downgrade_executor_config,
+                                         _task_creator_config,
+                                         _gpu_pipeline_executor_config,
+                                         _scan_manager_config);
     }
 
     bool const explicit_low_level_gpu_capacity =

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -244,7 +244,6 @@ static void from_yaml(const YAML::Node& node, scan_manager::scan_manager_config&
   r.optional("num_threads",
              opt.thread_pool.num_threads,
              yaml::between<int>{3, scan_manager::max_scan_manager_num_threads});
-  r.optional("thread_name_prefix", opt.thread_pool.thread_name_prefix);
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
   r.optional("use_sirius_datasource", opt.use_sirius_datasource);
   r.optional("uring_n_reactors", opt.uring_n_reactors, yaml::greater_than<std::size_t>{0});

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -241,7 +241,10 @@ static void from_yaml(const YAML::Node& node, scan_manager::memory_prefetcher_co
 static void from_yaml(const YAML::Node& node, scan_manager::scan_manager_config& opt)
 {
   yaml::reader r(node, "scan_manager");
-  r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{2});
+  r.optional("num_threads",
+             opt.thread_pool.num_threads,
+             yaml::between<int>{3, scan_manager::max_scan_manager_num_threads});
+  r.optional("thread_name_prefix", opt.thread_pool.thread_name_prefix);
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
   r.optional("use_sirius_datasource", opt.use_sirius_datasource);
   r.optional("uring_n_reactors", opt.uring_n_reactors, yaml::greater_than<std::size_t>{0});

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -639,7 +639,8 @@ int derived_scan_manager_threads_for(
     task_creator.thread_pool.num_threads,
     pipeline.num_threads,
     pipeline_executor_count_for(memory_space_configs),
-    scan_manager.uring_n_reactors);
+    scan_manager::active_uring_reactor_count(scan_manager.use_sirius_datasource,
+                                             scan_manager.uring_n_reactors));
 }
 
 }  // namespace
@@ -802,6 +803,8 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
       _memory_space_configs = builder.build(_hw_topology);
     }
 
+    enforce_sirius_datasource_for_multi_gpu();
+
     if (!scan_manager_num_threads_explicit) {
       _scan_manager_config.thread_pool.num_threads =
         derived_scan_manager_threads_for(_memory_space_configs,
@@ -821,8 +824,6 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
       operator_defaults_for(_memory_space_configs, use_effective_gpu_capacity);
     if (operator_node) { sirius::from_yaml(*operator_node, resolved_operator_params); }
     _operator_params = std::move(resolved_operator_params);
-
-    enforce_sirius_datasource_for_multi_gpu();
 
   } catch (const std::exception& e) {
     throw std::runtime_error("Failed to load config from " + config_path.string() + ": " +

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -606,6 +606,40 @@ operator_params operator_defaults_for(
   return params;
 }
 
+std::size_t downgrade_executor_count_for(
+  const std::vector<cucascade::memory::memory_space_config>& memory_space_configs)
+{
+  return std::ranges::count_if(memory_space_configs, [](auto const& space) {
+    return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space) ||
+           std::holds_alternative<cucascade::memory::host_memory_space_config>(space);
+  });
+}
+
+std::size_t pipeline_executor_count_for(
+  const std::vector<cucascade::memory::memory_space_config>& memory_space_configs)
+{
+  return std::ranges::count_if(memory_space_configs, [](auto const& space) {
+    return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space);
+  });
+}
+
+int derived_scan_manager_threads_for(
+  const std::vector<cucascade::memory::memory_space_config>& memory_space_configs,
+  const exec::downgrade_executor_config& downgrade,
+  const creator::task_creator_config& task_creator,
+  const exec::thread_pool_config& pipeline,
+  const scan_manager::scan_manager_config& scan_manager)
+{
+  return scan_manager::derived_scan_manager_num_threads(
+    std::thread::hardware_concurrency(),
+    downgrade.thread_pool.num_threads,
+    downgrade_executor_count_for(memory_space_configs),
+    task_creator.thread_pool.num_threads,
+    pipeline.num_threads,
+    pipeline_executor_count_for(memory_space_configs),
+    scan_manager.uring_n_reactors);
+}
+
 }  // namespace
 
 // ================ sirius_config ================= //
@@ -631,7 +665,13 @@ void sirius_config::apply_defaults()
   host_cfg.setup_configurator(builder);
   disk_cfg.setup_configurator(builder);
   _memory_space_configs = builder.build(_hw_topology);
-  _operator_params      = operator_params{};
+  _scan_manager_config.thread_pool.num_threads =
+    derived_scan_manager_threads_for(_memory_space_configs,
+                                     _downgrade_executor_config,
+                                     _task_creator_config,
+                                     _gpu_pipeline_executor_config,
+                                     _scan_manager_config);
+  _operator_params = operator_params{};
 }
 
 void sirius_config::load_from_file(const std::filesystem::path& config_path)
@@ -684,16 +724,21 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
       mr.reject_unknown();
     }
 
-    // Executors
+    // Executors. If scan_manager.num_threads is omitted, resolve it after all sibling pools so
+    // their explicit sizes reduce the same hardware concurrency budget instead of silently
+    // oversubscribing it.
+    bool scan_manager_num_threads_explicit = false;
     if (auto exec_node = r.optional_node("executor")) {
       yaml::reader er(*exec_node, "sirius.executor");
       if (auto n = er.optional_node("task_creator")) from_yaml(*n, _task_creator_config);
-      if (auto n = er.optional_node("scan_manager")) from_yaml(*n, _scan_manager_config);
+      if (auto n = er.optional_node("scan_manager")) {
+        scan_manager_num_threads_explicit = yaml::reader{*n}.has_value("num_threads");
+        from_yaml(*n, _scan_manager_config);
+      }
       if (auto n = er.optional_node("pipeline")) from_yaml(*n, _gpu_pipeline_executor_config);
       if (auto n = er.optional_node("downgrade")) from_yaml(*n, _downgrade_executor_config);
       er.reject_unknown();
     }
-
     // Preserve the node until memory-space capacities are resolved below. Explicit
     // values are applied after capacity-derived defaults so they always win.
     auto operator_node = r.optional_node("operator_params");
@@ -753,6 +798,15 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
       host_cfg.setup_configurator(builder);
       disk_cfg.setup_configurator(builder);
       _memory_space_configs = builder.build(_hw_topology);
+    }
+
+    if (!scan_manager_num_threads_explicit) {
+      _scan_manager_config.thread_pool.num_threads =
+        derived_scan_manager_threads_for(_memory_space_configs,
+                                         _downgrade_executor_config,
+                                         _task_creator_config,
+                                         _gpu_pipeline_executor_config,
+                                         _scan_manager_config);
     }
 
     bool const explicit_low_level_gpu_capacity =

--- a/test/cpp/config/data/executor_scan_threads_derived.yaml
+++ b/test/cpp/config/data/executor_scan_threads_derived.yaml
@@ -1,0 +1,17 @@
+sirius:
+  space:
+    gpu:
+      - device_id: 0
+        memory_capacity: 1GiB
+    host:
+      - numa_id: -1
+        memory_capacity: 1GiB
+  executor:
+    task_creator:
+      num_threads: 4
+    pipeline:
+      num_threads: 3
+    downgrade:
+      num_threads: 2
+    scan_manager:
+      uring_n_reactors: 2

--- a/test/cpp/config/data/executor_scan_threads_derived_kvikio.yaml
+++ b/test/cpp/config/data/executor_scan_threads_derived_kvikio.yaml
@@ -3,8 +3,6 @@ sirius:
     gpu:
       - device_id: 0
         memory_capacity: 1GiB
-      - device_id: 1
-        memory_capacity: 1GiB
     host:
       - numa_id: -1
         memory_capacity: 1GiB

--- a/test/cpp/config/data/executor_scan_threads_derived_multi_gpu.yaml
+++ b/test/cpp/config/data/executor_scan_threads_derived_multi_gpu.yaml
@@ -1,0 +1,19 @@
+sirius:
+  space:
+    gpu:
+      - device_id: 0
+        memory_capacity: 1GiB
+      - device_id: 1
+        memory_capacity: 1GiB
+    host:
+      - numa_id: -1
+        memory_capacity: 1GiB
+  executor:
+    task_creator:
+      num_threads: 4
+    pipeline:
+      num_threads: 3
+    downgrade:
+      num_threads: 2
+    scan_manager:
+      uring_n_reactors: 2

--- a/test/cpp/config/data/executor_scan_threads_explicit.yaml
+++ b/test/cpp/config/data/executor_scan_threads_explicit.yaml
@@ -1,0 +1,18 @@
+sirius:
+  space:
+    gpu:
+      - device_id: 0
+        memory_capacity: 1GiB
+    host:
+      - numa_id: -1
+        memory_capacity: 1GiB
+  executor:
+    task_creator:
+      num_threads: 4
+    pipeline:
+      num_threads: 3
+    downgrade:
+      num_threads: 2
+    scan_manager:
+      num_threads: 7
+      uring_n_reactors: 2

--- a/test/cpp/config/data/executor_scan_threads_safe_max.yaml
+++ b/test/cpp/config/data/executor_scan_threads_safe_max.yaml
@@ -1,0 +1,11 @@
+sirius:
+  space:
+    gpu:
+      - device_id: 0
+        memory_capacity: 1GiB
+    host:
+      - numa_id: -1
+        memory_capacity: 1GiB
+  executor:
+    scan_manager:
+      num_threads: 2147483646

--- a/test/cpp/config/data/executor_scan_threads_unsafe_max.yaml
+++ b/test/cpp/config/data/executor_scan_threads_unsafe_max.yaml
@@ -1,0 +1,11 @@
+sirius:
+  space:
+    gpu:
+      - device_id: 0
+        memory_capacity: 1GiB
+    host:
+      - numa_id: -1
+        memory_capacity: 1GiB
+  executor:
+    scan_manager:
+      num_threads: 2147483647

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -44,10 +44,12 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <set>
 #include <source_location>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -613,6 +615,88 @@ TEST_CASE("Sirius configuration keeps task creation policy internal", "[sirius][
       Catch::Contains("sirius.executor.task_creator.priority_order") &&
         Catch::Contains("removed") && Catch::Contains("remove this key"));
     CHECK(config.get_task_creator_config().priority == sirius::creator::priority_order::source);
+  }
+}
+
+TEST_CASE("Sirius derives scan-manager threads from configured sibling pools", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 1, 2, 1, 4, 1, 1) == 24);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 2, 4, 3, 1, 2) == 19);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 2, 2) == 14);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 1, 2) == 17);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(64, 1, 3, 1, 4, 2, 1) == 51);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(0, 2, 2, 4, 3, 1, 2) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(4, 2, 2, 4, 3, 1, 2) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          32, 1, 2, 1, 4, 1, std::numeric_limits<std::size_t>::max()) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          32, std::numeric_limits<std::size_t>::max(), 2, 1, 4, 1, 1) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          32, 1, std::numeric_limits<std::size_t>::max(), 1, 4, 1, 1) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          32, 1, 2, 1, std::numeric_limits<std::size_t>::max(), 2, 1) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          32, 1, 2, 1, 4, std::numeric_limits<std::size_t>::max(), 1) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          32, 1, 2, std::numeric_limits<std::size_t>::max(), 4, 1, 1) == 4);
+
+  SECTION("zero-configuration defaults use the resolved memory spaces")
+  {
+    sirius::sirius_config config;
+    config.apply_defaults();
+    auto const downgrade_executor_count =
+      std::ranges::count_if(config.get_memory_space_configs(), [](auto const& space) {
+        return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space) ||
+               std::holds_alternative<cucascade::memory::host_memory_space_config>(space);
+      });
+    auto const expected = sirius::scan_manager::derived_scan_manager_num_threads(
+      std::thread::hardware_concurrency(),
+      config.get_downgrade_executor_config().thread_pool.num_threads,
+      downgrade_executor_count,
+      config.get_task_creator_config().thread_pool.num_threads,
+      config.get_gpu_pipeline_executor_config().num_threads,
+      std::ranges::count_if(
+        config.get_memory_space_configs(),
+        [](auto const& space) {
+          return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space);
+        }),
+      config.get_scan_manager_config().uring_n_reactors);
+    CHECK(config.get_scan_manager_config().thread_pool.num_threads == expected);
+  }
+
+  SECTION("omitted scan-manager size uses the configured sibling sizes")
+  {
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(config.load_from_file(data_dir / "executor_scan_threads_derived.yaml"));
+    auto const downgrade_executor_count =
+      std::ranges::count_if(config.get_memory_space_configs(), [](auto const& space) {
+        return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space) ||
+               std::holds_alternative<cucascade::memory::host_memory_space_config>(space);
+      });
+    auto const expected = sirius::scan_manager::derived_scan_manager_num_threads(
+      std::thread::hardware_concurrency(), 2, downgrade_executor_count, 4, 3, 1, 2);
+    CHECK(downgrade_executor_count == 2);
+    CHECK(config.get_scan_manager_config().thread_pool.num_threads == expected);
+  }
+
+  SECTION("multi-GPU plus host counts every downgrade executor")
+  {
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(
+      config.load_from_file(data_dir / "executor_scan_threads_derived_multi_gpu.yaml"));
+    auto const expected = sirius::scan_manager::derived_scan_manager_num_threads(
+      std::thread::hardware_concurrency(), 2, 3, 4, 3, 2, 2);
+    CHECK(config.get_scan_manager_config().thread_pool.num_threads == expected);
+  }
+
+  SECTION("explicit scan-manager size remains authoritative")
+  {
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(config.load_from_file(data_dir / "executor_scan_threads_explicit.yaml"));
+    CHECK(config.get_scan_manager_config().thread_pool.num_threads == 7);
   }
 }
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -632,7 +632,15 @@ TEST_CASE("Sirius derives scan-manager threads from configured sibling pools", "
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(7, 1, 1, 1, 1, 1, 0) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
           std::numeric_limits<unsigned>::max(), 0, 0, 0, 0, 0, 0) ==
-        std::numeric_limits<int>::max());
+        sirius::scan_manager::max_scan_manager_num_threads);
+  STATIC_REQUIRE(sirius::scan_manager::max_scan_manager_num_threads +
+                   sirius::scan_manager::scan_manager_internal_worker_count ==
+                 std::numeric_limits<int>::max());
+  CHECK(sirius::scan_manager::scan_manager_pool_num_threads(
+          sirius::scan_manager::max_scan_manager_num_threads) == std::numeric_limits<int>::max());
+  CHECK_THROWS_AS(
+    sirius::scan_manager::scan_manager_pool_num_threads(std::numeric_limits<int>::max()),
+    std::out_of_range);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(0, 2, 2, 4, 3, 1, 2) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(4, 2, 2, 4, 3, 1, 2) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
@@ -728,6 +736,18 @@ TEST_CASE("Sirius derives scan-manager threads from configured sibling pools", "
     sirius::sirius_config config;
     REQUIRE_NOTHROW(config.load_from_file(data_dir / "executor_scan_threads_explicit.yaml"));
     CHECK(config.get_scan_manager_config().thread_pool.num_threads == 7);
+  }
+
+  SECTION("explicit scan-manager size preserves constructor addition")
+  {
+    sirius::sirius_config safe;
+    REQUIRE_NOTHROW(safe.load_from_file(data_dir / "executor_scan_threads_safe_max.yaml"));
+    CHECK(safe.get_scan_manager_config().thread_pool.num_threads ==
+          sirius::scan_manager::max_scan_manager_num_threads);
+
+    sirius::sirius_config unsafe;
+    REQUIRE_THROWS_WITH(unsafe.load_from_file(data_dir / "executor_scan_threads_unsafe_max.yaml"),
+                        Catch::Contains("num_threads") && Catch::Contains("value out of range"));
   }
 }
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -623,11 +623,16 @@ TEST_CASE("Sirius derives scan-manager threads from configured sibling pools", "
   std::source_location loc = std::source_location::current();
   auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
 
-  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 1, 2, 1, 4, 1, 1) == 24);
-  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 2, 4, 3, 1, 2) == 19);
-  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 2, 2) == 14);
-  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 1, 2) == 17);
-  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(64, 1, 3, 1, 4, 2, 1) == 51);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 1, 2, 1, 4, 1, 1) == 23);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 2, 4, 3, 1, 2) == 18);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 2, 2) == 13);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 1, 2) == 16);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(64, 1, 3, 1, 4, 2, 1) == 50);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(8, 1, 1, 1, 1, 1, 0) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(7, 1, 1, 1, 1, 1, 0) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          std::numeric_limits<unsigned>::max(), 0, 0, 0, 0, 0, 0) ==
+        std::numeric_limits<int>::max());
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(0, 2, 2, 4, 3, 1, 2) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(4, 2, 2, 4, 3, 1, 2) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
@@ -642,6 +647,32 @@ TEST_CASE("Sirius derives scan-manager threads from configured sibling pools", "
           32, 1, 2, 1, 4, std::numeric_limits<std::size_t>::max(), 1) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
           32, 1, 2, std::numeric_limits<std::size_t>::max(), 4, 1, 1) == 4);
+
+  auto check_exact_cpu_envelope = [](unsigned hardware_threads,
+                                     std::size_t downgrade_threads,
+                                     std::size_t downgrade_executors,
+                                     std::size_t task_creator_threads,
+                                     std::size_t pipeline_threads,
+                                     std::size_t pipeline_executors,
+                                     std::size_t uring_reactors) {
+    auto const scan_threads =
+      sirius::scan_manager::derived_scan_manager_num_threads(hardware_threads,
+                                                             downgrade_threads,
+                                                             downgrade_executors,
+                                                             task_creator_threads,
+                                                             pipeline_threads,
+                                                             pipeline_executors,
+                                                             uring_reactors);
+    auto const total_workers = static_cast<std::size_t>(scan_threads) +
+                               sirius::scan_manager::scan_manager_internal_worker_count +
+                               downgrade_threads * downgrade_executors + task_creator_threads +
+                               pipeline_threads * pipeline_executors + uring_reactors;
+    CHECK(total_workers == hardware_threads);
+  };
+  check_exact_cpu_envelope(32, 1, 2, 1, 4, 1, 1);
+  check_exact_cpu_envelope(32, 2, 2, 4, 3, 1, 2);
+  check_exact_cpu_envelope(32, 2, 3, 4, 3, 2, 2);
+  check_exact_cpu_envelope(64, 1, 3, 1, 4, 2, 1);
 
   SECTION("zero-configuration defaults use the resolved memory spaces")
   {

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -897,6 +897,9 @@ TEST_CASE("Sirius derives scan-manager threads from configured sibling pools", "
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 2, 2) == 13);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 1, 2) == 16);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(64, 1, 3, 1, 4, 2, 1) == 50);
+  CHECK(sirius::scan_manager::active_uring_reactor_count(false, 2) == 0);
+  CHECK(sirius::scan_manager::active_uring_reactor_count(true, 2) == 2);
+  CHECK(sirius::scan_manager::active_uring_reactor_count(true, 4096) == 4096);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(8, 1, 1, 1, 1, 1, 0) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(7, 1, 1, 1, 1, 1, 0) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
@@ -990,6 +993,16 @@ TEST_CASE("Sirius derives scan-manager threads from configured sibling pools", "
     CHECK(config.get_scan_manager_config().thread_pool.num_threads == expected);
   }
 
+  SECTION("single-GPU KvikIO does not reserve inactive uring reactors")
+  {
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(config.load_from_file(data_dir / "executor_scan_threads_derived_kvikio.yaml"));
+    auto const expected = sirius::scan_manager::derived_scan_manager_num_threads(
+      std::thread::hardware_concurrency(), 2, 2, 4, 3, 1, 0);
+    CHECK_FALSE(config.get_scan_manager_config().use_sirius_datasource);
+    CHECK(config.get_scan_manager_config().thread_pool.num_threads == expected);
+  }
+
   SECTION("multi-GPU plus host counts every downgrade executor")
   {
     sirius::sirius_config config;
@@ -997,6 +1010,7 @@ TEST_CASE("Sirius derives scan-manager threads from configured sibling pools", "
       config.load_from_file(data_dir / "executor_scan_threads_derived_multi_gpu.yaml"));
     auto const expected = sirius::scan_manager::derived_scan_manager_num_threads(
       std::thread::hardware_concurrency(), 2, 3, 4, 3, 2, 2);
+    CHECK(config.get_scan_manager_config().use_sirius_datasource);
     CHECK(config.get_scan_manager_config().thread_pool.num_threads == expected);
   }
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -47,11 +47,13 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <set>
 #include <source_location>
 #include <string>
 #include <system_error>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -882,6 +884,88 @@ TEST_CASE("Sirius configuration keeps task creation policy internal", "[sirius][
       Catch::Contains("sirius.executor.task_creator.priority_order") &&
         Catch::Contains("removed") && Catch::Contains("remove this key"));
     CHECK(config.get_task_creator_config().priority == sirius::creator::priority_order::source);
+  }
+}
+
+TEST_CASE("Sirius derives scan-manager threads from configured sibling pools", "[sirius][config]")
+{
+  std::source_location loc = std::source_location::current();
+  auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
+
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 1, 2, 1, 4, 1, 1) == 24);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 2, 4, 3, 1, 2) == 19);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 2, 2) == 14);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 1, 2) == 17);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(64, 1, 3, 1, 4, 2, 1) == 51);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(0, 2, 2, 4, 3, 1, 2) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(4, 2, 2, 4, 3, 1, 2) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          32, 1, 2, 1, 4, 1, std::numeric_limits<std::size_t>::max()) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          32, std::numeric_limits<std::size_t>::max(), 2, 1, 4, 1, 1) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          32, 1, std::numeric_limits<std::size_t>::max(), 1, 4, 1, 1) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          32, 1, 2, 1, std::numeric_limits<std::size_t>::max(), 2, 1) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          32, 1, 2, 1, 4, std::numeric_limits<std::size_t>::max(), 1) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          32, 1, 2, std::numeric_limits<std::size_t>::max(), 4, 1, 1) == 4);
+
+  SECTION("zero-configuration defaults use the resolved memory spaces")
+  {
+    sirius::sirius_config config;
+    config.apply_defaults();
+    auto const downgrade_executor_count =
+      std::ranges::count_if(config.get_memory_space_configs(), [](auto const& space) {
+        return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space) ||
+               std::holds_alternative<cucascade::memory::host_memory_space_config>(space);
+      });
+    auto const expected = sirius::scan_manager::derived_scan_manager_num_threads(
+      std::thread::hardware_concurrency(),
+      config.get_downgrade_executor_config().thread_pool.num_threads,
+      downgrade_executor_count,
+      config.get_task_creator_config().thread_pool.num_threads,
+      config.get_gpu_pipeline_executor_config().num_threads,
+      std::ranges::count_if(
+        config.get_memory_space_configs(),
+        [](auto const& space) {
+          return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space);
+        }),
+      config.get_scan_manager_config().uring_n_reactors);
+    CHECK(config.get_scan_manager_config().thread_pool.num_threads == expected);
+  }
+
+  SECTION("omitted scan-manager size uses the configured sibling sizes")
+  {
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(config.load_from_file(data_dir / "executor_scan_threads_derived.yaml"));
+    auto const downgrade_executor_count =
+      std::ranges::count_if(config.get_memory_space_configs(), [](auto const& space) {
+        return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space) ||
+               std::holds_alternative<cucascade::memory::host_memory_space_config>(space);
+      });
+    auto const expected = sirius::scan_manager::derived_scan_manager_num_threads(
+      std::thread::hardware_concurrency(), 2, downgrade_executor_count, 4, 3, 1, 2);
+    CHECK(downgrade_executor_count == 2);
+    CHECK(config.get_scan_manager_config().thread_pool.num_threads == expected);
+  }
+
+  SECTION("multi-GPU plus host counts every downgrade executor")
+  {
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(
+      config.load_from_file(data_dir / "executor_scan_threads_derived_multi_gpu.yaml"));
+    auto const expected = sirius::scan_manager::derived_scan_manager_num_threads(
+      std::thread::hardware_concurrency(), 2, 3, 4, 3, 2, 2);
+    CHECK(config.get_scan_manager_config().thread_pool.num_threads == expected);
+  }
+
+  SECTION("explicit scan-manager size remains authoritative")
+  {
+    sirius::sirius_config config;
+    REQUIRE_NOTHROW(config.load_from_file(data_dir / "executor_scan_threads_explicit.yaml"));
+    CHECK(config.get_scan_manager_config().thread_pool.num_threads == 7);
   }
 }
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -892,11 +892,16 @@ TEST_CASE("Sirius derives scan-manager threads from configured sibling pools", "
   std::source_location loc = std::source_location::current();
   auto const data_dir      = fs::path(loc.file_name()).parent_path() / "data";
 
-  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 1, 2, 1, 4, 1, 1) == 24);
-  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 2, 4, 3, 1, 2) == 19);
-  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 2, 2) == 14);
-  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 1, 2) == 17);
-  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(64, 1, 3, 1, 4, 2, 1) == 51);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 1, 2, 1, 4, 1, 1) == 23);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 2, 4, 3, 1, 2) == 18);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 2, 2) == 13);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(32, 2, 3, 4, 3, 1, 2) == 16);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(64, 1, 3, 1, 4, 2, 1) == 50);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(8, 1, 1, 1, 1, 1, 0) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(7, 1, 1, 1, 1, 1, 0) == 4);
+  CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
+          std::numeric_limits<unsigned>::max(), 0, 0, 0, 0, 0, 0) ==
+        std::numeric_limits<int>::max());
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(0, 2, 2, 4, 3, 1, 2) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(4, 2, 2, 4, 3, 1, 2) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
@@ -911,6 +916,32 @@ TEST_CASE("Sirius derives scan-manager threads from configured sibling pools", "
           32, 1, 2, 1, 4, std::numeric_limits<std::size_t>::max(), 1) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
           32, 1, 2, std::numeric_limits<std::size_t>::max(), 4, 1, 1) == 4);
+
+  auto check_exact_cpu_envelope = [](unsigned hardware_threads,
+                                     std::size_t downgrade_threads,
+                                     std::size_t downgrade_executors,
+                                     std::size_t task_creator_threads,
+                                     std::size_t pipeline_threads,
+                                     std::size_t pipeline_executors,
+                                     std::size_t uring_reactors) {
+    auto const scan_threads =
+      sirius::scan_manager::derived_scan_manager_num_threads(hardware_threads,
+                                                             downgrade_threads,
+                                                             downgrade_executors,
+                                                             task_creator_threads,
+                                                             pipeline_threads,
+                                                             pipeline_executors,
+                                                             uring_reactors);
+    auto const total_workers = static_cast<std::size_t>(scan_threads) +
+                               sirius::scan_manager::scan_manager_internal_worker_count +
+                               downgrade_threads * downgrade_executors + task_creator_threads +
+                               pipeline_threads * pipeline_executors + uring_reactors;
+    CHECK(total_workers == hardware_threads);
+  };
+  check_exact_cpu_envelope(32, 1, 2, 1, 4, 1, 1);
+  check_exact_cpu_envelope(32, 2, 2, 4, 3, 1, 2);
+  check_exact_cpu_envelope(32, 2, 3, 4, 3, 2, 2);
+  check_exact_cpu_envelope(64, 1, 3, 1, 4, 2, 1);
 
   SECTION("zero-configuration defaults use the resolved memory spaces")
   {

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -901,7 +901,15 @@ TEST_CASE("Sirius derives scan-manager threads from configured sibling pools", "
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(7, 1, 1, 1, 1, 1, 0) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
           std::numeric_limits<unsigned>::max(), 0, 0, 0, 0, 0, 0) ==
-        std::numeric_limits<int>::max());
+        sirius::scan_manager::max_scan_manager_num_threads);
+  STATIC_REQUIRE(sirius::scan_manager::max_scan_manager_num_threads +
+                   sirius::scan_manager::scan_manager_internal_worker_count ==
+                 std::numeric_limits<int>::max());
+  CHECK(sirius::scan_manager::scan_manager_pool_num_threads(
+          sirius::scan_manager::max_scan_manager_num_threads) == std::numeric_limits<int>::max());
+  CHECK_THROWS_AS(
+    sirius::scan_manager::scan_manager_pool_num_threads(std::numeric_limits<int>::max()),
+    std::out_of_range);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(0, 2, 2, 4, 3, 1, 2) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(4, 2, 2, 4, 3, 1, 2) == 4);
   CHECK(sirius::scan_manager::derived_scan_manager_num_threads(
@@ -997,6 +1005,18 @@ TEST_CASE("Sirius derives scan-manager threads from configured sibling pools", "
     sirius::sirius_config config;
     REQUIRE_NOTHROW(config.load_from_file(data_dir / "executor_scan_threads_explicit.yaml"));
     CHECK(config.get_scan_manager_config().thread_pool.num_threads == 7);
+  }
+
+  SECTION("explicit scan-manager size preserves constructor addition")
+  {
+    sirius::sirius_config safe;
+    REQUIRE_NOTHROW(safe.load_from_file(data_dir / "executor_scan_threads_safe_max.yaml"));
+    CHECK(safe.get_scan_manager_config().thread_pool.num_threads ==
+          sirius::scan_manager::max_scan_manager_num_threads);
+
+    sirius::sirius_config unsafe;
+    REQUIRE_THROWS_WITH(unsafe.load_from_file(data_dir / "executor_scan_threads_unsafe_max.yaml"),
+                        Catch::Contains("num_threads") && Catch::Contains("value out of range"));
   }
 }
 


### PR DESCRIPTION
## Decision

> **Tier:** `judgment` — hardware-derived executor default and construction bound.  
> **Review question for @sirius-db/sirius-core:** Does this resolved-pool budget match Sirius ownership: one pipeline pool per GPU, one downgrade pool per GPU and HOST space, task creator, only active io_uring reactors, and the scan manager's internal worker, while retaining the floor of four?  
> **Behavior delta:** An omitted `scan_manager.num_threads` derives after memory, executor, and effective datasource settings resolve; explicit values remain authoritative through `INT_MAX - 1`.  
> **Main risk:** The floor intentionally permits oversubscription on very small hosts, and retained performance evidence is single-GPU.

## Summary

- derive an omitted `sirius.executor.scan_manager.num_threads` from resolved live pools
- count one pipeline pool per GPU and one downgrade pool per GPU and HOST space
- budget task-creator, active io_uring, and the scan manager's internal worker
- preserve explicit values while preventing constructor-time `+1` overflow
- keep the internal scan-manager label out of the YAML surface

## September 9 current-dev repair

The rebase conflict was one include insertion shared with merged #1519; the
replacement retains both #1519's `<system_error>` and this PR's `<thread>`.
Independent full-diff review also found that the original series budgeted
configured io_uring reactors even when single-GPU KvikIO left them inactive.
The replacement now resolves multi-GPU datasource coercion before derivation,
budgets zero inactive reactors for retained KvikIO, and covers the selector
with deterministic and end-to-end configuration regressions.

## Exact reviewed identity

- exact base: `285737bc33c84d5c175c59862162b518b89fcae0`
- base tree: `8a3ac4a8c9809355bd9303ca1dc274fd6211752a`
- exact head: `2463842b93a269684efb028244bed78060543042`
- candidate tree: `c6e25929cae8ebbdd70e524a86236d00a092cd0d`
- cumulative binary-diff SHA-256: `47acb68bce16bf3db04865cfdc34e906e4947e7a6cdebb860e0f42e979a180a0`
- cumulative diff: 11 paths, 379 insertions, 16 deletions

## Author-side validation

- independent exact-head full-diff review: no critical, important, or minor findings
- original four commits range-map one-to-one; only the additive include context differs
- clean worktree, `git diff --check`, `git show --check`, and C++20 header syntax check: pass
- pinned host-compatible pre-commit hooks, including clang-format, YAML, codespell, and orphan-test detection: pass
- hosted Check `34396881586`: lint, GCC release, Clang debug, and aggregate pass
- hosted Test `34396881532`: CUDA 13 build, C++ runtime suite, TPC-H snapshot, and aggregate pass
- hosted Distribution `34396883034`: aggregate pass; CUDA distribution leaves correctly skip because distribution inputs did not change
- hosted Validate `34396877914`: title and aggregate validation pass

The replacement head is author-ready and terminal-green. Independent
maintainer approval of this exact head remains the merge gate.

### Retained predecessor evidence

The prior exact heads passed their hosted suites. A supplemental 16-CPU H100
screen at predecessor head `bdfbbe5e` completed all 36 SF100 Q1/Q6/Q12 trials
oracle-correct; derived count 7 was not displaced by explicit 4, 8, or the old
derived count 9. Those receipts support the unchanged sizing behavior but do
not replace the current exact-head gates above.