### PR TITLE
fix(scan): await async reads before freeing their source memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -712,6 +712,7 @@ set(TEST_SOURCES
     test/cpp/scan_manager/test_pin_table_multi_gpu.cpp
     test/cpp/scan_manager/test_cached_serving_hardening.cpp
     test/cpp/scan_manager/test_insert_delta_job.cpp
+    test/cpp/scan_manager/test_memory_prefetcher_accounting.cpp
     test/cpp/scan_manager/test_mvcc_mask_job.cpp
     test/cpp/scan_manager/test_pinned_chunk_stats.cpp
     test/cpp/operator/test_physical_grouped_aggregate_merge_mgpu.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -799,6 +799,7 @@ set(TEST_SOURCES
     test/cpp/scan/test_parquet_null_count_pruning.cpp
     test/cpp/scan/test_parquet_scan_sizing.cpp
     test/cpp/scan/test_scan_schema_normalization.cpp
+    test/cpp/scan/test_stream_lineage_item5.cpp
     test/cpp/sirius_extension/test_sirius_read_parquet_cardinality.cpp
     test/cpp/sql/test_sirius_sql_rewrite.cpp
     test/cpp/telemetry/test_telemetry_context.cpp

--- a/src/include/op/scan/owning_table_view.hpp
+++ b/src/include/op/scan/owning_table_view.hpp
@@ -61,14 +61,13 @@ concept no_alloc_materializable = requires(Owner& owner) {
 };
 
 /**
- * @brief An owner that tracks consumer events on the storage behind the view
+ * @brief An owner that tracks reader events on the storage behind the view
  *        (canonically @c cucascade::read_only_data_batch, whose read lock is
  *        what keeps a cached batch alive while the view is consumed).
  */
 template <typename Owner>
-concept consumer_event_recording = requires(Owner const& owner, rmm::cuda_stream_view stream) {
-  owner.record_consumer_event(stream);
-};
+concept reader_event_recording =
+  requires(Owner const& owner, rmm::cuda_stream_view stream) { owner.record_reader_event(stream); };
 
 //===----------------------------------------------------------------------===//
 // my_view
@@ -160,12 +159,9 @@ class my_view {
     return _model->materialize(_selection, stream, mr);
   }
 
-  /// Forward a consumer-event record to the type-erased owner. No-op unless the
-  /// owner is @ref consumer_event_recording.
-  void record_consumer_event(rmm::cuda_stream_view stream)
-  {
-    _model->record_consumer_event(stream);
-  }
+  /// Forward a reader-event record to the type-erased owner. No-op unless the
+  /// owner is @ref reader_event_recording.
+  void record_reader_event(rmm::cuda_stream_view stream) { _model->record_reader_event(stream); }
 
  private:
   struct owner_concept {
@@ -178,8 +174,8 @@ class my_view {
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) = 0;
 
-    /// Default no-op for owners that do not track consumer events.
-    virtual void record_consumer_event(rmm::cuda_stream_view) {}
+    /// Default no-op for owners that do not track reader events.
+    virtual void record_reader_event(rmm::cuda_stream_view) {}
   };
 
   template <typename Owner>
@@ -225,9 +221,9 @@ class my_view {
       }
     }
 
-    void record_consumer_event([[maybe_unused]] rmm::cuda_stream_view stream) override
+    void record_reader_event([[maybe_unused]] rmm::cuda_stream_view stream) override
     {
-      if constexpr (consumer_event_recording<Owner>) { _owner.record_consumer_event(stream); }
+      if constexpr (reader_event_recording<Owner>) { _owner.record_reader_event(stream); }
     }
 
     Owner _owner;
@@ -336,13 +332,17 @@ class owning_table_view {
   void select_columns(std::span<const std::size_t> positions) const;
 
   /// Record on the data owner behind the view that reads of the exposed view
-  /// have been ENQUEUED on @p stream (see data_batch::record_consumer_event).
-  /// Call after enqueuing the reads and before this handle — whose owner may
-  /// hold the read lock keeping a cached batch alive — is dropped or
-  /// reassigned, so a later reclaim of the batch is ordered after the reads.
-  /// No-op for owned-table and empty states, and for owners that do not track
-  /// consumer events. Never allocates or syncs.
-  void record_consumer_event(rmm::cuda_stream_view stream) const;
+  /// have been ENQUEUED on @p stream (see
+  /// cucascade::read_only_data_batch::record_reader_event). Call after
+  /// enqueuing the reads and before this handle — whose owner may hold the
+  /// read lock keeping a cached batch alive — is dropped or reassigned, so a
+  /// later reclaim of the batch (which must first acquire mutable access, and
+  /// therefore waits on every recorded reader event) is ordered after the
+  /// reads. No-op for owned-table and empty states, and for owners that do
+  /// not track reader events. Never syncs on success; if event registration
+  /// fails after the reads were enqueued, the owner synchronizes @p stream
+  /// before propagating the error.
+  void record_reader_event(rmm::cuda_stream_view stream) const;
 
   /// Realize a view state into an owned table. No-op if already materialized or
   /// empty. May allocate (copying path) depending on the underlying owner.

--- a/src/include/op/scan/owning_table_view.hpp
+++ b/src/include/op/scan/owning_table_view.hpp
@@ -60,6 +60,16 @@ concept no_alloc_materializable = requires(Owner& owner) {
   { (*owner).release() } -> std::same_as<std::vector<std::unique_ptr<cudf::column>>>;
 };
 
+/**
+ * @brief An owner that tracks consumer events on the storage behind the view
+ *        (canonically @c cucascade::read_only_data_batch, whose read lock is
+ *        what keeps a cached batch alive while the view is consumed).
+ */
+template <typename Owner>
+concept consumer_event_recording = requires(Owner const& owner, rmm::cuda_stream_view stream) {
+  owner.record_consumer_event(stream);
+};
+
 //===----------------------------------------------------------------------===//
 // my_view
 //===----------------------------------------------------------------------===//
@@ -150,6 +160,13 @@ class my_view {
     return _model->materialize(_selection, stream, mr);
   }
 
+  /// Forward a consumer-event record to the type-erased owner. No-op unless the
+  /// owner is @ref consumer_event_recording.
+  void record_consumer_event(rmm::cuda_stream_view stream)
+  {
+    _model->record_consumer_event(stream);
+  }
+
  private:
   struct owner_concept {
     virtual ~owner_concept() = default;
@@ -160,6 +177,9 @@ class my_view {
       std::span<const cudf::size_type> selection,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) = 0;
+
+    /// Default no-op for owners that do not track consumer events.
+    virtual void record_consumer_event(rmm::cuda_stream_view) {}
   };
 
   template <typename Owner>
@@ -203,6 +223,11 @@ class my_view {
         stream.synchronize();
         return out;
       }
+    }
+
+    void record_consumer_event([[maybe_unused]] rmm::cuda_stream_view stream) override
+    {
+      if constexpr (consumer_event_recording<Owner>) { _owner.record_consumer_event(stream); }
     }
 
     Owner _owner;
@@ -309,6 +334,15 @@ class owning_table_view {
   /// order (projection + reorder). Never allocates; demotes an owned table to a
   /// view first if necessary. Throws on out-of-range or duplicate positions.
   void select_columns(std::span<const std::size_t> positions) const;
+
+  /// Record on the data owner behind the view that reads of the exposed view
+  /// have been ENQUEUED on @p stream (see data_batch::record_consumer_event).
+  /// Call after enqueuing the reads and before this handle — whose owner may
+  /// hold the read lock keeping a cached batch alive — is dropped or
+  /// reassigned, so a later reclaim of the batch is ordered after the reads.
+  /// No-op for owned-table and empty states, and for owners that do not track
+  /// consumer events. Never allocates or syncs.
+  void record_consumer_event(rmm::cuda_stream_view stream) const;
 
   /// Realize a view state into an owned table. No-op if already materialized or
   /// empty. May allocate (copying path) depending on the underlying owner.

--- a/src/include/op/scan/owning_table_view.hpp
+++ b/src/include/op/scan/owning_table_view.hpp
@@ -60,11 +60,6 @@ concept no_alloc_materializable = requires(Owner& owner) {
   { (*owner).release() } -> std::same_as<std::vector<std::unique_ptr<cudf::column>>>;
 };
 
-/**
- * @brief An owner that tracks reader events on the storage behind the view
- *        (canonically @c cucascade::read_only_data_batch, whose read lock is
- *        what keeps a cached batch alive while the view is consumed).
- */
 template <typename Owner>
 concept reader_event_recording =
   requires(Owner const& owner, rmm::cuda_stream_view stream) { owner.record_reader_event(stream); };
@@ -159,8 +154,6 @@ class my_view {
     return _model->materialize(_selection, stream, mr);
   }
 
-  /// Forward a reader-event record to the type-erased owner. No-op unless the
-  /// owner is @ref reader_event_recording.
   void record_reader_event(rmm::cuda_stream_view stream) { _model->record_reader_event(stream); }
 
  private:
@@ -174,7 +167,6 @@ class my_view {
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) = 0;
 
-    /// Default no-op for owners that do not track reader events.
     virtual void record_reader_event(rmm::cuda_stream_view) {}
   };
 
@@ -331,17 +323,11 @@ class owning_table_view {
   /// view first if necessary. Throws on out-of-range or duplicate positions.
   void select_columns(std::span<const std::size_t> positions) const;
 
-  /// Record on the data owner behind the view that reads of the exposed view
-  /// have been ENQUEUED on @p stream (see
-  /// cucascade::read_only_data_batch::record_reader_event). Call after
-  /// enqueuing the reads and before this handle — whose owner may hold the
-  /// read lock keeping a cached batch alive — is dropped or reassigned, so a
-  /// later reclaim of the batch (which must first acquire mutable access, and
-  /// therefore waits on every recorded reader event) is ordered after the
-  /// reads. No-op for owned-table and empty states, and for owners that do
-  /// not track reader events. Never syncs on success; if event registration
-  /// fails after the reads were enqueued, the owner synchronizes @p stream
-  /// before propagating the error.
+  /// Record that reads of the exposed view have been ENQUEUED on @p stream
+  /// (see cucascade::read_only_data_batch::record_reader_event). Must be
+  /// called after enqueuing the reads and before this handle is dropped or
+  /// reassigned, so a reclaim of the backing cached batch is ordered after
+  /// them. No-op unless the owner tracks reader events.
   void record_reader_event(rmm::cuda_stream_view stream) const;
 
   /// Realize a view state into an owned table. No-op if already materialized or

--- a/src/include/op/scan/owning_table_view.hpp
+++ b/src/include/op/scan/owning_table_view.hpp
@@ -27,6 +27,8 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda_runtime_api.h>
+
 #include <algorithm>
 #include <cassert>
 #include <concepts>
@@ -59,6 +61,39 @@ template <typename Owner>
 concept no_alloc_materializable = requires(Owner& owner) {
   { (*owner).release() } -> std::same_as<std::vector<std::unique_ptr<cudf::column>>>;
 };
+
+/**
+ * @brief Await every operation enqueued on @p stream up to this call.
+ *
+ * Records a throwaway event and waits on it rather than calling
+ * @c cudaStreamSynchronize, so the wait covers exactly the work enqueued so far
+ * and not work another thread appends to the same stream afterwards.
+ *
+ * Used by the copying materialization path to close the window in which a
+ * type-erased owner — typically a @c read_only_data_batch lock on a pinned-cache
+ * chunk — is destroyed while the copy reading its memory is still in flight.
+ */
+inline void await_stream_work(rmm::cuda_stream_view stream)
+{
+  cudaEvent_t event{};
+  if (auto const status = cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+      status != cudaSuccess) {
+    throw std::runtime_error(std::string("owning_table_view: cudaEventCreateWithFlags failed: ") +
+                             cudaGetErrorString(status));
+  }
+  auto const record = cudaEventRecord(event, stream.value());
+  if (record != cudaSuccess) {
+    cudaEventDestroy(event);
+    throw std::runtime_error(std::string("owning_table_view: cudaEventRecord failed: ") +
+                             cudaGetErrorString(record));
+  }
+  auto const wait = cudaEventSynchronize(event);
+  cudaEventDestroy(event);
+  if (wait != cudaSuccess) {
+    throw std::runtime_error(std::string("owning_table_view: cudaEventSynchronize failed: ") +
+                             cudaGetErrorString(wait));
+  }
+}
 
 //===----------------------------------------------------------------------===//
 // my_view
@@ -194,7 +229,11 @@ class my_view {
       } else {
         // Generic owner: copy the selected view into a fresh table.
         std::vector<cudf::size_type> sel(selection.begin(), selection.end());
-        return std::make_unique<cudf::table>(_base_view.select(sel), stream, mr);
+        auto out = std::make_unique<cudf::table>(_base_view.select(sel), stream, mr);
+        // The caller destroys `_owner` as soon as this returns, so the copy must be
+        // complete first: `_owner` is what keeps the source memory alive.
+        await_stream_work(stream);
+        return out;
       }
     }
 

--- a/src/include/op/scan/owning_table_view.hpp
+++ b/src/include/op/scan/owning_table_view.hpp
@@ -27,8 +27,6 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda_runtime_api.h>
-
 #include <algorithm>
 #include <cassert>
 #include <concepts>
@@ -61,39 +59,6 @@ template <typename Owner>
 concept no_alloc_materializable = requires(Owner& owner) {
   { (*owner).release() } -> std::same_as<std::vector<std::unique_ptr<cudf::column>>>;
 };
-
-/**
- * @brief Await every operation enqueued on @p stream up to this call.
- *
- * Records a throwaway event and waits on it rather than calling
- * @c cudaStreamSynchronize, so the wait covers exactly the work enqueued so far
- * and not work another thread appends to the same stream afterwards.
- *
- * Used by the copying materialization path to close the window in which a
- * type-erased owner — typically a @c read_only_data_batch lock on a pinned-cache
- * chunk — is destroyed while the copy reading its memory is still in flight.
- */
-inline void await_stream_work(rmm::cuda_stream_view stream)
-{
-  cudaEvent_t event{};
-  if (auto const status = cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
-      status != cudaSuccess) {
-    throw std::runtime_error(std::string("owning_table_view: cudaEventCreateWithFlags failed: ") +
-                             cudaGetErrorString(status));
-  }
-  auto const record = cudaEventRecord(event, stream.value());
-  if (record != cudaSuccess) {
-    cudaEventDestroy(event);
-    throw std::runtime_error(std::string("owning_table_view: cudaEventRecord failed: ") +
-                             cudaGetErrorString(record));
-  }
-  auto const wait = cudaEventSynchronize(event);
-  cudaEventDestroy(event);
-  if (wait != cudaSuccess) {
-    throw std::runtime_error(std::string("owning_table_view: cudaEventSynchronize failed: ") +
-                             cudaGetErrorString(wait));
-  }
-}
 
 //===----------------------------------------------------------------------===//
 // my_view
@@ -231,8 +196,11 @@ class my_view {
         std::vector<cudf::size_type> sel(selection.begin(), selection.end());
         auto out = std::make_unique<cudf::table>(_base_view.select(sel), stream, mr);
         // The caller destroys `_owner` as soon as this returns, so the copy must be
-        // complete first: `_owner` is what keeps the source memory alive.
-        await_stream_work(stream);
+        // complete first: `_owner` is what keeps the source memory alive. Unlike the
+        // scan's carrier cast, the source here belongs to an external owner (a
+        // pinned-cache lock), so there is no buffer of ours whose deallocation
+        // stream could be rebound instead.
+        stream.synchronize();
         return out;
       }
     }

--- a/src/include/scan_manager/memory_prefetcher.hpp
+++ b/src/include/scan_manager/memory_prefetcher.hpp
@@ -57,18 +57,17 @@ namespace sirius::scan_manager {
  * conversion needs a thread to drive it. Concurrency across batches therefore
  * scales with num_threads. Each worker owns a private CUDA stream, but that
  * stream carries no copy traffic: the converter only synchronize()s it on
- * entry (a no-op — the only ops ever enqueued on it are consumer-event waits
- * from install_converted_representation, drained by that same call's tail
- * sync) and then runs all device allocation + H2D on a stream it acquires
- * internally from the target space's shared round-robin pool, exactly like
- * the scan task's own conversion path. The private stream exists as a stable
- * per-worker key for attaching the admission reservation to the allocation
- * tracker.
+ * entry (a no-op — nothing is ever enqueued on it) and then runs all device
+ * allocation + H2D on a stream it acquires internally from the target
+ * space's shared round-robin pool, exactly like the scan task's own
+ * conversion path. The private stream exists as a stable per-worker key for
+ * attaching the admission reservation to the allocation tracker.
  *
  * Races with a consumer are arbitrated by the data_batch state machine: the
  * conversion holds the exclusive (mutable) lock via try_to_mutable (skip on
- * contention), and prepare_for_processing re-checks the tier under its own
- * lock.
+ * contention, and — since the reader-event barrier — also while a recorded
+ * asynchronous reader of the batch is still in flight), and
+ * prepare_for_processing re-checks the tier under its own lock.
  *
  * Memory safety: converted batches live in connector queues, which the
  * downgrade executor does NOT scan (it walks data repositories), so

--- a/src/include/scan_manager/memory_prefetcher.hpp
+++ b/src/include/scan_manager/memory_prefetcher.hpp
@@ -20,7 +20,8 @@
 #include "scan_manager/split_connector.hpp"
 
 #include <cucascade/memory/memory_space.hpp>
-#include <cucascade/memory/stream_pool.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
 
 #include <atomic>
 #include <cstddef>
@@ -54,8 +55,13 @@ namespace sirius::scan_manager {
  * reconstructs the cudf table from the host layout, and synchronizes its
  * stream before the batch's exclusive lock can be released, so each in-flight
  * conversion needs a thread to drive it. Concurrency across batches therefore
- * scales with num_threads, each conversion on its own stream from a dedicated
- * pool.
+ * scales with num_threads. Each worker owns a private CUDA stream, but that
+ * stream carries no copy traffic: the converter only synchronize()s it on
+ * entry (a no-op — the prefetcher never enqueues work on it) and then runs
+ * all device allocation + H2D on a stream it acquires internally from the
+ * target space's shared round-robin pool, exactly like the scan task's own
+ * conversion path. The private stream exists as a stable per-worker key for
+ * attaching the admission reservation to the allocation tracker.
  *
  * Races with a consumer are arbitrated by the data_batch state machine: the
  * conversion holds the exclusive (mutable) lock via try_to_mutable (skip on
@@ -64,11 +70,17 @@ namespace sirius::scan_manager {
  *
  * Memory safety: converted batches live in connector queues, which the
  * downgrade executor does NOT scan (it walks data repositories), so
- * prefetched-but-unconsumed bytes cannot be reclaimed under pressure. The
- * headroom gate must therefore stay conservative: a batch is only converted
- * (and its GPU reservation only taken) while (available - batch_size) >=
- * min_free_fraction * max_memory, so the prefetcher backs off long before it
- * could compete with pipeline task reservations.
+ * prefetched-but-unconsumed bytes cannot be reclaimed under pressure.
+ * Admission is therefore reserve-first: a worker takes a GPU reservation for
+ * the conversion peak (charging the space's availability immediately), then
+ * checks that post-reservation availability still clears the
+ * min_free_fraction floor, releasing the reservation and backing off if it
+ * does not. Because every worker reserves before it gates, the floor check
+ * always sees all concurrent workers' in-flight admissions — the floor holds
+ * regardless of num_threads. For the conversion itself the reservation is
+ * attached to the worker thread's allocation tracker (as gpu_pipeline_task
+ * does for task work), so the conversion's device allocations draw the
+ * reservation down instead of being counted a second time on top of it.
  */
 class memory_prefetcher {
  public:
@@ -110,15 +122,14 @@ class memory_prefetcher {
   std::unique_ptr<std::atomic<bool>[]> _drain_claims;
   cucascade::memory::memory_space* _gpu_space;
 
-  /// Dedicated streams so prefetch copies never share a stream with pipeline
-  /// task work (the memory_space's shared round-robin pool would interleave
-  /// our 5GB copies with task kernels on the same stream).
-  std::unique_ptr<cucascade::memory::exclusive_stream_pool> _stream_pool;
-
   std::atomic<bool> _running{true};
   std::atomic<std::size_t> _batches_prefetched{0};
   std::atomic<std::size_t> _bytes_prefetched{0};
   /// Diagnostic gate counters (logged at stop): why sweeps stopped early.
+  /// _stops_reservation: the peak-size GPU reservation could not be admitted;
+  /// _stops_headroom: the reservation was admitted but post-reservation
+  /// availability fell below the min_free_fraction floor (reservation
+  /// released and sweep stopped).
   std::atomic<std::size_t> _stops_headroom{0};
   std::atomic<std::size_t> _stops_reservation{0};
   std::atomic<std::size_t> _skips_lock{0};

--- a/src/include/scan_manager/memory_prefetcher.hpp
+++ b/src/include/scan_manager/memory_prefetcher.hpp
@@ -55,33 +55,26 @@ namespace sirius::scan_manager {
  * reconstructs the cudf table from the host layout, and synchronizes its
  * stream before the batch's exclusive lock can be released, so each in-flight
  * conversion needs a thread to drive it. Concurrency across batches therefore
- * scales with num_threads. Each worker owns a private CUDA stream, but that
- * stream carries no copy traffic: the converter only synchronize()s it on
- * entry (a no-op — nothing is ever enqueued on it) and then runs all device
- * allocation + H2D on a stream it acquires internally from the target
- * space's shared round-robin pool, exactly like the scan task's own
- * conversion path. The private stream exists as a stable per-worker key for
- * attaching the admission reservation to the allocation tracker.
+ * scales with num_threads. Each worker's private CUDA stream carries no copy
+ * traffic (the converter allocates and copies on a pool stream it acquires
+ * internally); it exists only as a stable per-worker key for attaching the
+ * admission reservation to the allocation tracker.
  *
  * Races with a consumer are arbitrated by the data_batch state machine: the
  * conversion holds the exclusive (mutable) lock via try_to_mutable (skip on
- * contention, and — since the reader-event barrier — also while a recorded
- * asynchronous reader of the batch is still in flight), and
- * prepare_for_processing re-checks the tier under its own lock.
+ * contention), and prepare_for_processing re-checks the tier under its own
+ * lock.
  *
  * Memory safety: converted batches live in connector queues, which the
  * downgrade executor does NOT scan (it walks data repositories), so
  * prefetched-but-unconsumed bytes cannot be reclaimed under pressure.
- * Admission is therefore reserve-first: a worker takes a GPU reservation for
- * the conversion peak (charging the space's availability immediately), then
- * checks that post-reservation availability still clears the
- * min_free_fraction floor, releasing the reservation and backing off if it
- * does not. Because every worker reserves before it gates, the floor check
- * always sees all concurrent workers' in-flight admissions — the floor holds
- * regardless of num_threads. For the conversion itself the reservation is
- * attached to the worker thread's allocation tracker (as gpu_pipeline_task
- * does for task work), so the conversion's device allocations draw the
- * reservation down instead of being counted a second time on top of it.
+ * Admission must therefore reserve BEFORE gating: the worker reserves the
+ * conversion peak (charging availability immediately) and only then checks
+ * the min_free_fraction floor, so the check sees every concurrent worker's
+ * in-flight admission and the floor holds regardless of num_threads. The
+ * reservation is then attached to the worker thread's allocation tracker so
+ * the conversion's allocations draw it down instead of being counted a
+ * second time on top of it.
  */
 class memory_prefetcher {
  public:
@@ -127,10 +120,8 @@ class memory_prefetcher {
   std::atomic<std::size_t> _batches_prefetched{0};
   std::atomic<std::size_t> _bytes_prefetched{0};
   /// Diagnostic gate counters (logged at stop): why sweeps stopped early.
-  /// _stops_reservation: the peak-size GPU reservation could not be admitted;
-  /// _stops_headroom: the reservation was admitted but post-reservation
-  /// availability fell below the min_free_fraction floor (reservation
-  /// released and sweep stopped).
+  /// _stops_reservation: the peak reservation was refused; _stops_headroom:
+  /// the reservation was charged but the post-charge floor check failed.
   std::atomic<std::size_t> _stops_headroom{0};
   std::atomic<std::size_t> _stops_reservation{0};
   std::atomic<std::size_t> _skips_lock{0};

--- a/src/include/scan_manager/memory_prefetcher.hpp
+++ b/src/include/scan_manager/memory_prefetcher.hpp
@@ -19,9 +19,9 @@
 #include "scan_manager/config.hpp"
 #include "scan_manager/split_connector.hpp"
 
-#include <cucascade/memory/memory_space.hpp>
-
 #include <rmm/cuda_stream_view.hpp>
+
+#include <cucascade/memory/memory_space.hpp>
 
 #include <atomic>
 #include <cstddef>

--- a/src/include/scan_manager/memory_prefetcher.hpp
+++ b/src/include/scan_manager/memory_prefetcher.hpp
@@ -57,11 +57,13 @@ namespace sirius::scan_manager {
  * conversion needs a thread to drive it. Concurrency across batches therefore
  * scales with num_threads. Each worker owns a private CUDA stream, but that
  * stream carries no copy traffic: the converter only synchronize()s it on
- * entry (a no-op — the prefetcher never enqueues work on it) and then runs
- * all device allocation + H2D on a stream it acquires internally from the
- * target space's shared round-robin pool, exactly like the scan task's own
- * conversion path. The private stream exists as a stable per-worker key for
- * attaching the admission reservation to the allocation tracker.
+ * entry (a no-op — the only ops ever enqueued on it are consumer-event waits
+ * from install_converted_representation, drained by that same call's tail
+ * sync) and then runs all device allocation + H2D on a stream it acquires
+ * internally from the target space's shared round-robin pool, exactly like
+ * the scan task's own conversion path. The private stream exists as a stable
+ * per-worker key for attaching the admission reservation to the allocation
+ * tracker.
  *
  * Races with a consumer are arbitrated by the data_batch state machine: the
  * conversion holds the exclusive (mutable) lock via try_to_mutable (skip on

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -366,6 +366,12 @@ std::unique_ptr<cudf::table> duckdb_native_gpu_ingestible::post_filter_and_proje
       // Nothing to project away, or output_arity == 0 (count(*)) — keep all columns.
       final_table = owning_table_view{exec.select(input.table.view())};
     }
+    // The select above only ENQUEUED its reads of input.table's view on `stream`. When
+    // that view is served from a cached batch, input.table's owner holds the batch's
+    // read lock and is dropped with no stream sync of its own — the record must happen
+    // after the enqueue and before the drop so a reclaim of the batch is ordered after
+    // these in-flight reads.
+    input.table.record_consumer_event(stream);
   } else {
     final_table = std::move(input.table);
   }

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -371,7 +371,7 @@ std::unique_ptr<cudf::table> duckdb_native_gpu_ingestible::post_filter_and_proje
     // read lock and is dropped with no stream sync of its own — the record must happen
     // after the enqueue and before the drop so a reclaim of the batch is ordered after
     // these in-flight reads.
-    input.table.record_consumer_event(stream);
+    input.table.record_reader_event(stream);
   } else {
     final_table = std::move(input.table);
   }

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -366,11 +366,7 @@ std::unique_ptr<cudf::table> duckdb_native_gpu_ingestible::post_filter_and_proje
       // Nothing to project away, or output_arity == 0 (count(*)) — keep all columns.
       final_table = owning_table_view{exec.select(input.table.view())};
     }
-    // The select above only ENQUEUED its reads of input.table's view on `stream`. When
-    // that view is served from a cached batch, input.table's owner holds the batch's
-    // read lock and is dropped with no stream sync of its own — the record must happen
-    // after the enqueue and before the drop so a reclaim of the batch is ordered after
-    // these in-flight reads.
+    // The select only enqueued its reads; record before input.table's read-lock owner is dropped.
     input.table.record_reader_event(stream);
   } else {
     final_table = std::move(input.table);

--- a/src/op/scan/owning_table_view.cpp
+++ b/src/op/scan/owning_table_view.cpp
@@ -107,6 +107,15 @@ void owning_table_view::select_columns(std::span<const std::size_t> positions) c
   std::get<std::unique_ptr<detail::my_view>>(_state)->select_columns(positions);
 }
 
+void owning_table_view::record_consumer_event(rmm::cuda_stream_view stream) const
+{
+  // Only the view state can be backed by an external owner (e.g. a cached
+  // batch's read-lock accessor); an owned table has no external reclaimer.
+  if (auto* view = std::get_if<std::unique_ptr<detail::my_view>>(&_state)) {
+    (*view)->record_consumer_event(stream);
+  }
+}
+
 void owning_table_view::materialize(rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
 {
   if (auto* view = std::get_if<std::unique_ptr<detail::my_view>>(&_state)) {

--- a/src/op/scan/owning_table_view.cpp
+++ b/src/op/scan/owning_table_view.cpp
@@ -109,8 +109,6 @@ void owning_table_view::select_columns(std::span<const std::size_t> positions) c
 
 void owning_table_view::record_reader_event(rmm::cuda_stream_view stream) const
 {
-  // Only the view state can be backed by an external owner (e.g. a cached
-  // batch's read-lock accessor); an owned table has no external reclaimer.
   if (auto* view = std::get_if<std::unique_ptr<detail::my_view>>(&_state)) {
     (*view)->record_reader_event(stream);
   }

--- a/src/op/scan/owning_table_view.cpp
+++ b/src/op/scan/owning_table_view.cpp
@@ -107,12 +107,12 @@ void owning_table_view::select_columns(std::span<const std::size_t> positions) c
   std::get<std::unique_ptr<detail::my_view>>(_state)->select_columns(positions);
 }
 
-void owning_table_view::record_consumer_event(rmm::cuda_stream_view stream) const
+void owning_table_view::record_reader_event(rmm::cuda_stream_view stream) const
 {
   // Only the view state can be backed by an external owner (e.g. a cached
   // batch's read-lock accessor); an owned table has no external reclaimer.
   if (auto* view = std::get_if<std::unique_ptr<detail::my_view>>(&_state)) {
-    (*view)->record_consumer_event(stream);
+    (*view)->record_reader_event(stream);
   }
 }
 

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -1192,11 +1192,7 @@ std::unique_ptr<cudf::table> parquet_gpu_ingestible::post_filter_and_project(
     auto const data_positions = output_data_positions(*_plan);
     auto filtered             = data_positions.empty() ? exec.select(input.table.view())
                                                        : exec.select(input.table.view(), data_positions);
-    // The select above only ENQUEUED its reads of input.table's view on `stream`. When
-    // that view is served from a cached batch, input.table's owner holds the batch's
-    // read lock and the reassignment below drops it immediately — the record must
-    // happen after the enqueue and before the drop so a reclaim of the batch is
-    // ordered after these in-flight reads.
+    // The select only enqueued its reads; record before the reassignment drops the read lock.
     input.table.record_reader_event(stream);
     input = filtered_table{owning_table_view{std::move(filtered)}, filter_state::ROW_FILTERED};
     SIRIUS_LOG_DEBUG(

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -1192,6 +1192,12 @@ std::unique_ptr<cudf::table> parquet_gpu_ingestible::post_filter_and_project(
     auto const data_positions = output_data_positions(*_plan);
     auto filtered             = data_positions.empty() ? exec.select(input.table.view())
                                                        : exec.select(input.table.view(), data_positions);
+    // The select above only ENQUEUED its reads of input.table's view on `stream`. When
+    // that view is served from a cached batch, input.table's owner holds the batch's
+    // read lock and the reassignment below drops it immediately — the record must
+    // happen after the enqueue and before the drop so a reclaim of the batch is
+    // ordered after these in-flight reads.
+    input.table.record_consumer_event(stream);
     input = filtered_table{owning_table_view{std::move(filtered)}, filter_state::ROW_FILTERED};
     SIRIUS_LOG_DEBUG(
       "[parquet_gpu_ingestible::post_filter_and_project] Applied duckdb filter expression "

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -1197,7 +1197,7 @@ std::unique_ptr<cudf::table> parquet_gpu_ingestible::post_filter_and_project(
     // read lock and the reassignment below drops it immediately — the record must
     // happen after the enqueue and before the drop so a reclaim of the batch is
     // ordered after these in-flight reads.
-    input.table.record_consumer_event(stream);
+    input.table.record_reader_event(stream);
     input = filtered_table{owning_table_view{std::move(filtered)}, filter_state::ROW_FILTERED};
     SIRIUS_LOG_DEBUG(
       "[parquet_gpu_ingestible::post_filter_and_project] Applied duckdb filter expression "

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -131,13 +131,8 @@ std::unique_ptr<cudf::table> normalize_physical_schema(std::unique_ptr<cudf::tab
     auto const restoring = can_restore_to(actual, target);
     auto const narrowing = has_explicit_physical_schema && can_narrow_to(actual, target);
     if (actual == target || (!restoring && !narrowing)) { continue; }
-    // The assignment frees the source column. Its buffers may be stream-ordered
-    // on the stream that produced them (the pinned-cache upload), not on
-    // `stream`, so the free would be unordered against this still-running cast
-    // and the block could be handed to the next allocation mid-read. Rebind the
-    // source's deallocation onto `stream` so the free is enqueued behind the
-    // cast. No copy, no kernel, no host wait; the cast's column_view stays valid
-    // because rebinding relocates nothing.
+    // The source's buffers may be dealloc-bound to the pinned-cache upload stream; rebind them
+    // to `stream` so the free replacing the column queues behind the cast still reading them.
     auto casted         = cast_through_rep(columns[column_idx]->view(), target, stream, mr);
     auto source         = cudf::rebind_stream(std::move(*columns[column_idx]), stream);
     columns[column_idx] = std::move(casted);

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -30,6 +30,7 @@
 #include <sirius_context.hpp>
 
 // cudf
+#include <cudf/column/column_stream.hpp>
 #include <cudf/cudf_utils.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
@@ -130,7 +131,16 @@ std::unique_ptr<cudf::table> normalize_physical_schema(std::unique_ptr<cudf::tab
     auto const restoring = can_restore_to(actual, target);
     auto const narrowing = has_explicit_physical_schema && can_narrow_to(actual, target);
     if (actual == target || (!restoring && !narrowing)) { continue; }
-    columns[column_idx] = cast_through_rep(columns[column_idx]->view(), target, stream, mr);
+    // The assignment frees the source column. Its buffers may be stream-ordered
+    // on the stream that produced them (the pinned-cache upload), not on
+    // `stream`, so the free would be unordered against this still-running cast
+    // and the block could be handed to the next allocation mid-read. Rebind the
+    // source's deallocation onto `stream` so the free is enqueued behind the
+    // cast. No copy, no kernel, no host wait; the cast's column_view stays valid
+    // because rebinding relocates nothing.
+    auto casted         = cast_through_rep(columns[column_idx]->view(), target, stream, mr);
+    auto source         = cudf::rebind_stream(std::move(*columns[column_idx]), stream);
+    columns[column_idx] = std::move(casted);
     if (observer != nullptr) {
       if (narrowing) {
         observer->record_compressed_materialization_scan_columns_narrowed();

--- a/src/scan_manager/memory_prefetcher.cpp
+++ b/src/scan_manager/memory_prefetcher.cpp
@@ -88,15 +88,10 @@ void memory_prefetcher::worker_loop()
   // 0, and the compression converters allocate from the CURRENT device's
   // resource rather than the target space's.
   rmm::cuda_set_device_raii device_guard{rmm::cuda_device_id{_gpu_space->get_device_id()}};
-  // Private per-worker stream. No copy traffic ever runs on it: the converter
-  // only synchronize()s it on entry and does all device allocation + H2D on a
-  // stream it acquires from the GPU space's shared round-robin pool. The only
-  // ops this stream ever carries are the consumer-event waits that
-  // install_converted_representation enqueues on it, and that same call's tail
-  // sync drains them before returning — so the entry sync always sees an empty
-  // stream (a no-op). It exists as a stable per-worker key for attaching the
-  // admission reservation to the allocation tracker in sweep() (and keeps the
-  // entry sync off any pipeline stream).
+  // Private per-worker stream: it carries no copy traffic and exists as a
+  // stable per-worker key for attaching the admission reservation to the
+  // allocation tracker in sweep() — see the class doc for why the converter
+  // leaves it empty.
   rmm::cuda_stream stream{rmm::cuda_stream::flags::non_blocking};
   while (_running.load(std::memory_order_relaxed)) {
     std::size_t converted = 0;
@@ -144,8 +139,7 @@ std::size_t memory_prefetcher::sweep(rmm::cuda_stream_view stream)
     // Collisions only happen at the head of the queue, though — so instead of
     // skipping the connector entirely, convert TAIL-FIRST and leave a head
     // margin for the batches the scan will pop imminently. At most ONE worker
-    // may do this per connector: stacking prefetch parallelism on top of the
-    // scan's own conversion threads regresses short scan-bound queries.
+    // may do this per connector (see _drain_claims).
     const bool draining = connector->is_draining(_config.drain_quiet_ms);
     bool claimed        = false;
     if (draining) {
@@ -214,9 +208,7 @@ std::size_t memory_prefetcher::sweep(rmm::cuda_stream_view stream)
 
       // Reserve FIRST, then gate: the reservation charges the space's
       // availability immediately, so the floor check below already sees every
-      // concurrent worker's in-flight admission. (Gate-first would let
-      // num_threads workers pass the same headroom concurrently and overshoot
-      // the admission budget.)
+      // concurrent worker's in-flight admission (see the class doc).
       auto reservation = _gpu_space->make_reservation_or_null(peak_bytes);
       if (!reservation) {
         _stops_reservation.fetch_add(1, std::memory_order_relaxed);
@@ -224,12 +216,10 @@ std::size_t memory_prefetcher::sweep(rmm::cuda_stream_view stream)
       }
 
       // Headroom floor: never let prefetched (unreclaimable) bytes push the
-      // space below min_free_fraction of max memory. With our reservation
-      // already charged above, admitting this batch is safe iff the space
-      // still clears the floor now; otherwise back the reservation out. No
-      // room for this batch means none for the later ones either (they are at
-      // least as far from being consumed), so stop the whole sweep and retry
-      // after tasks free memory.
+      // space below min_free_fraction of max memory. No room for this batch
+      // means none for the later ones either (they are at least as far from
+      // being consumed), so back the reservation out and stop the whole sweep
+      // until tasks free memory.
       if (_gpu_space->get_available_memory() < min_free_bytes) {
         reservation.reset();
         _stops_headroom.fetch_add(1, std::memory_order_relaxed);

--- a/src/scan_manager/memory_prefetcher.cpp
+++ b/src/scan_manager/memory_prefetcher.cpp
@@ -88,10 +88,6 @@ void memory_prefetcher::worker_loop()
   // 0, and the compression converters allocate from the CURRENT device's
   // resource rather than the target space's.
   rmm::cuda_set_device_raii device_guard{rmm::cuda_device_id{_gpu_space->get_device_id()}};
-  // Private per-worker stream: it carries no copy traffic and exists as a
-  // stable per-worker key for attaching the admission reservation to the
-  // allocation tracker in sweep() — see the class doc for why the converter
-  // leaves it empty.
   rmm::cuda_stream stream{rmm::cuda_stream::flags::non_blocking};
   while (_running.load(std::memory_order_relaxed)) {
     std::size_t converted = 0;
@@ -139,7 +135,7 @@ std::size_t memory_prefetcher::sweep(rmm::cuda_stream_view stream)
     // Collisions only happen at the head of the queue, though — so instead of
     // skipping the connector entirely, convert TAIL-FIRST and leave a head
     // margin for the batches the scan will pop imminently. At most ONE worker
-    // may do this per connector (see _drain_claims).
+    // may do this per connector.
     const bool draining = connector->is_draining(_config.drain_quiet_ms);
     bool claimed        = false;
     if (draining) {
@@ -206,43 +202,21 @@ std::size_t memory_prefetcher::sweep(rmm::cuda_stream_view stream)
         continue;
       }
 
-      // Reserve FIRST, then gate: the reservation charges the space's
-      // availability immediately, so the floor check below already sees every
-      // concurrent worker's in-flight admission (see the class doc).
       auto reservation = _gpu_space->make_reservation_or_null(peak_bytes);
       if (!reservation) {
         _stops_reservation.fetch_add(1, std::memory_order_relaxed);
         return converted;
       }
 
-      // Headroom floor: never let prefetched (unreclaimable) bytes push the
-      // space below min_free_fraction of max memory. No room for this batch
-      // means none for the later ones either (they are at least as far from
-      // being consumed), so back the reservation out and stop the whole sweep
-      // until tasks free memory.
       if (_gpu_space->get_available_memory() < min_free_bytes) {
         reservation.reset();
         _stops_headroom.fetch_add(1, std::memory_order_relaxed);
         return converted;
       }
 
-      // Attach the reservation to this thread's allocation tracker (Sirius
-      // defaults to per-thread tracking; `stream` is only the API key) so the
-      // conversion's device allocations genuinely draw down the arena reserved
-      // above instead of being counted a second time on top of it — the same
-      // pattern gpu_pipeline_task::execute uses for task work. Policies stay
-      // the cucascade defaults: allocations beyond the reserved peak are
-      // tracked but not failed (the peak is an estimate), and OOM throws so we
-      // back off below — the prefetcher is opportunistic and must never
-      // trigger defragmentation or downgrades to make room for itself.
       auto* allocator = reservation->get_memory_resource_of<cucascade::memory::Tier::GPU>();
       if (allocator == nullptr ||
           !allocator->attach_reservation_to_tracker(stream, std::move(reservation))) {
-        // No reservation-aware GPU allocator, or this thread already tracks a
-        // reservation — both unexpected for a prefetch worker (we always
-        // detach below). A rejected reservation is released with its
-        // unique_ptr; skip the batch, the scan task's own conversion is the
-        // authoritative path.
         _errors_conversion.fetch_add(1, std::memory_order_relaxed);
         SIRIUS_LOG_WARN(
           "[memory_prefetcher] could not attach reservation to allocation tracker for "

--- a/src/scan_manager/memory_prefetcher.cpp
+++ b/src/scan_manager/memory_prefetcher.cpp
@@ -89,11 +89,14 @@ void memory_prefetcher::worker_loop()
   // resource rather than the target space's.
   rmm::cuda_set_device_raii device_guard{rmm::cuda_device_id{_gpu_space->get_device_id()}};
   // Private per-worker stream. No copy traffic ever runs on it: the converter
-  // only synchronize()s it on entry (a no-op — this worker never enqueues work
-  // on it) and does all device allocation + H2D on a stream it acquires from
-  // the GPU space's shared round-robin pool. It exists as a stable per-worker
-  // key for attaching the admission reservation to the allocation tracker in
-  // sweep() (and keeps the entry sync off any pipeline stream).
+  // only synchronize()s it on entry and does all device allocation + H2D on a
+  // stream it acquires from the GPU space's shared round-robin pool. The only
+  // ops this stream ever carries are the consumer-event waits that
+  // install_converted_representation enqueues on it, and that same call's tail
+  // sync drains them before returning — so the entry sync always sees an empty
+  // stream (a no-op). It exists as a stable per-worker key for attaching the
+  // admission reservation to the allocation tracker in sweep() (and keeps the
+  // entry sync off any pipeline stream).
   rmm::cuda_stream stream{rmm::cuda_stream::flags::non_blocking};
   while (_running.load(std::memory_order_relaxed)) {
     std::size_t converted = 0;

--- a/src/scan_manager/memory_prefetcher.cpp
+++ b/src/scan_manager/memory_prefetcher.cpp
@@ -21,10 +21,13 @@
 #include "log/logging.hpp"
 
 #include <rmm/cuda_device.hpp>
+#include <rmm/cuda_stream.hpp>
 #include <rmm/error.hpp>
 
+#include <absl/cleanup/cleanup.h>
 #include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
+#include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 
 #include <algorithm>
 #include <chrono>
@@ -45,8 +48,6 @@ memory_prefetcher::memory_prefetcher(memory_prefetcher_config cfg,
   for (std::size_t i = 0; i < _connectors.size(); ++i) {
     _drain_claims[i].store(false, std::memory_order_relaxed);
   }
-  _stream_pool = std::make_unique<cucascade::memory::exclusive_stream_pool>(
-    rmm::cuda_device_id{_gpu_space->get_device_id()}, _config.num_threads);
   _workers.reserve(_config.num_threads);
   for (std::size_t i = 0; i < _config.num_threads; ++i) {
     _workers.emplace_back([this] { worker_loop(); });
@@ -87,11 +88,17 @@ void memory_prefetcher::worker_loop()
   // 0, and the compression converters allocate from the CURRENT device's
   // resource rather than the target space's.
   rmm::cuda_set_device_raii device_guard{rmm::cuda_device_id{_gpu_space->get_device_id()}};
-  auto stream = _stream_pool->acquire_stream();
+  // Private per-worker stream. No copy traffic ever runs on it: the converter
+  // only synchronize()s it on entry (a no-op — this worker never enqueues work
+  // on it) and does all device allocation + H2D on a stream it acquires from
+  // the GPU space's shared round-robin pool. It exists as a stable per-worker
+  // key for attaching the admission reservation to the allocation tracker in
+  // sweep() (and keeps the entry sync off any pipeline stream).
+  rmm::cuda_stream stream{rmm::cuda_stream::flags::non_blocking};
   while (_running.load(std::memory_order_relaxed)) {
     std::size_t converted = 0;
     try {
-      converted = sweep(stream.get());
+      converted = sweep(stream.view());
     } catch (const std::exception& e) {
       SIRIUS_LOG_WARN("[memory_prefetcher] sweep error (backing off): {}", e.what());
     }
@@ -191,18 +198,6 @@ std::size_t memory_prefetcher::sweep(rmm::cuda_stream_view stream)
         peak_bytes = sirius::peak_materialization_bytes(ro->get_data());
       }
 
-      // Headroom gate: never let prefetched (unreclaimable) bytes push the
-      // space below the free floor. This also keeps the reservation below out
-      // of the executors' way: it is only attempted while the space has at
-      // least min_free_fraction headroom to spare.
-      if (_gpu_space->get_available_memory() < peak_bytes + min_free_bytes) {
-        // No room for this batch now; later batches are at least as far from
-        // being consumed, so stop the whole sweep and retry after tasks free
-        // memory.
-        _stops_headroom.fetch_add(1, std::memory_order_relaxed);
-        return converted;
-      }
-
       // Exclusive lock, skip on contention (a task is consuming this batch —
       // its own prepare_for_processing does the upload).
       auto mut = batch->try_to_mutable();
@@ -214,16 +209,60 @@ std::size_t memory_prefetcher::sweep(rmm::cuda_stream_view stream)
         continue;
       }
 
+      // Reserve FIRST, then gate: the reservation charges the space's
+      // availability immediately, so the floor check below already sees every
+      // concurrent worker's in-flight admission. (Gate-first would let
+      // num_threads workers pass the same headroom concurrently and overshoot
+      // the admission budget.)
       auto reservation = _gpu_space->make_reservation_or_null(peak_bytes);
       if (!reservation) {
         _stops_reservation.fetch_add(1, std::memory_order_relaxed);
         return converted;
       }
 
+      // Headroom floor: never let prefetched (unreclaimable) bytes push the
+      // space below min_free_fraction of max memory. With our reservation
+      // already charged above, admitting this batch is safe iff the space
+      // still clears the floor now; otherwise back the reservation out. No
+      // room for this batch means none for the later ones either (they are at
+      // least as far from being consumed), so stop the whole sweep and retry
+      // after tasks free memory.
+      if (_gpu_space->get_available_memory() < min_free_bytes) {
+        reservation.reset();
+        _stops_headroom.fetch_add(1, std::memory_order_relaxed);
+        return converted;
+      }
+
+      // Attach the reservation to this thread's allocation tracker (Sirius
+      // defaults to per-thread tracking; `stream` is only the API key) so the
+      // conversion's device allocations genuinely draw down the arena reserved
+      // above instead of being counted a second time on top of it — the same
+      // pattern gpu_pipeline_task::execute uses for task work. Policies stay
+      // the cucascade defaults: allocations beyond the reserved peak are
+      // tracked but not failed (the peak is an estimate), and OOM throws so we
+      // back off below — the prefetcher is opportunistic and must never
+      // trigger defragmentation or downgrades to make room for itself.
+      auto* allocator = reservation->get_memory_resource_of<cucascade::memory::Tier::GPU>();
+      if (allocator == nullptr ||
+          !allocator->attach_reservation_to_tracker(stream, std::move(reservation))) {
+        // No reservation-aware GPU allocator, or this thread already tracks a
+        // reservation — both unexpected for a prefetch worker (we always
+        // detach below). A rejected reservation is released with its
+        // unique_ptr; skip the batch, the scan task's own conversion is the
+        // authoritative path.
+        _errors_conversion.fetch_add(1, std::memory_order_relaxed);
+        SIRIUS_LOG_WARN(
+          "[memory_prefetcher] could not attach reservation to allocation tracker for "
+          "batch {} (skipping)",
+          mut->get_batch_id());
+        continue;
+      }
+      absl::Cleanup reservation_detacher = [allocator, stream] {
+        allocator->reset_stream_reservation(stream);
+      };
+
       try {
-        // Convert against the reservation so the conversion's device
-        // allocations draw from the arena reserved above.
-        mut->convert_to<cucascade::gpu_table_representation>(registry, *reservation, stream);
+        mut->convert_to<cucascade::gpu_table_representation>(registry, _gpu_space, stream);
       } catch (const rmm::out_of_memory&) {
         SIRIUS_LOG_DEBUG("[memory_prefetcher] OOM converting batch {}; backing off",
                          mut->get_batch_id());

--- a/test/cpp/scan/test_owning_table_view.cpp
+++ b/test/cpp/scan/test_owning_table_view.cpp
@@ -21,10 +21,14 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
+#include <rmm/cuda_stream.hpp>
+#include <rmm/device_buffer.hpp>
+
 #include <cuda_runtime_api.h>
 
 #include <catch.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <memory>
@@ -272,4 +276,116 @@ TEST_CASE("owning_table_view generic owner materializes by copy", "[owning_table
   auto result_ptrs = data_ptrs(result->view());
   REQUIRE(result_ptrs[0] != original_ptrs[0]);
   REQUIRE(result_ptrs[1] != original_ptrs[2]);
+}
+
+// Stream-ordering regression: the copying materialization path must not let the
+// caller reclaim the source memory while the copy is still in flight.
+namespace {
+
+constexpr std::int32_t kSourceByte  = 0x01;  // source fill  -> 0x01010101
+constexpr std::int32_t kPoisonByte  = 0xFF;  // reclaim fill -> 0xFFFFFFFF
+constexpr std::int32_t kSourceValue = 0x01010101;
+constexpr std::int32_t kPoisonValue = -1;
+
+// Observations recorded at the moment the owner is destroyed.
+struct reclaim_probe {
+  cudaStream_t work_stream{};
+  cudaStream_t reclaim_stream{};
+  void* source_data{};
+  std::size_t source_bytes{};
+  cudaError_t stream_status_at_reclaim{cudaSuccess};
+  bool reclaimed{false};
+};
+
+// Stands in for the pinned-cache lock: while this owner lives the source memory
+// is valid, and destroying it lets the cache overwrite that memory. Move-only so
+// only the final owner performs the reclaim.
+struct reclaiming_owner {
+  std::shared_ptr<reclaim_probe> probe;
+  std::unique_ptr<cudf::table> source;
+
+  reclaiming_owner(std::shared_ptr<reclaim_probe> p, std::unique_ptr<cudf::table> s)
+    : probe(std::move(p)), source(std::move(s))
+  {
+  }
+  reclaiming_owner(reclaiming_owner&&)                 = default;
+  reclaiming_owner& operator=(reclaiming_owner&&)      = default;
+  reclaiming_owner(reclaiming_owner const&)            = delete;
+  reclaiming_owner& operator=(reclaiming_owner const&) = delete;
+
+  ~reclaiming_owner()
+  {
+    if (probe == nullptr || source == nullptr) { return; }  // moved-from
+    probe->reclaimed                = true;
+    probe->stream_status_at_reclaim = cudaStreamQuery(probe->work_stream);
+    // Simulate the cache reusing the chunk the instant the lock drops.
+    cudaMemsetAsync(probe->source_data, kPoisonByte, probe->source_bytes, probe->reclaim_stream);
+    cudaStreamSynchronize(probe->reclaim_stream);
+  }
+};
+
+}  // namespace
+
+TEST_CASE("owning_table_view release awaits the copy before the owner reclaims memory",
+          "[owning_table_view][stream_order]")
+{
+  // Non-blocking streams: the reclaim must not be implicitly ordered against the
+  // copy by legacy-default-stream semantics.
+  rmm::cuda_stream work_stream;
+  rmm::cuda_stream reclaim_stream;
+
+  constexpr cudf::size_type kRows = 4 * 1024 * 1024;  // 16 MiB of INT32
+  auto const kSourceBytes         = static_cast<std::size_t>(kRows) * sizeof(std::int32_t);
+
+  auto source       = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                          kRows,
+                                          cudf::mask_state::UNALLOCATED,
+                                          work_stream.view());
+  auto* source_data = source->mutable_view().data<std::int32_t>();
+  cudaMemsetAsync(source_data, kSourceByte, kSourceBytes, work_stream.value());
+  work_stream.synchronize();
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(source));
+  auto source_table      = std::make_unique<cudf::table>(std::move(cols));
+  auto const source_view = source_table->view();
+
+  auto probe            = std::make_shared<reclaim_probe>();
+  probe->work_stream    = work_stream.value();
+  probe->reclaim_stream = reclaim_stream.value();
+  probe->source_data    = source_data;
+  probe->source_bytes   = kSourceBytes;
+
+  // Queue a long blocker ahead of the copy so the materializing copy is
+  // guaranteed to still be pending when release() hands back control. Without
+  // the await this makes the race deterministic rather than probabilistic.
+  constexpr std::size_t kBlockerBytes = 256UL * 1024 * 1024;
+  rmm::device_buffer blocker(kBlockerBytes, work_stream.view(), test_mr());
+  for (int i = 0; i < 8; ++i) {
+    cudaMemsetAsync(blocker.data(), 0, kBlockerBytes, work_stream.value());
+  }
+
+  // View-backed handle over a NON-no_alloc_materializable owner -> copying path.
+  owning_table_view handle{reclaiming_owner{probe, std::move(source_table)}, source_view};
+  REQUIRE(handle.n_columns() == 1);
+
+  auto result = handle.release(work_stream.view(), test_mr());
+  REQUIRE(result != nullptr);
+
+  // The owner was destroyed by release(); the copy must already have completed.
+  REQUIRE(probe->reclaimed);
+  CHECK(probe->stream_status_at_reclaim == cudaSuccess);
+
+  // The materialized copy must hold the source values, not the reclaim poison.
+  std::vector<std::int32_t> host(static_cast<std::size_t>(kRows));
+  cudaMemcpy(host.data(),
+             result->view().column(0).data<std::int32_t>(),
+             kSourceBytes,
+             cudaMemcpyDeviceToHost);
+
+  auto const poisoned = std::count(host.begin(), host.end(), kPoisonValue);
+  INFO("poisoned elements: " << poisoned << " / " << kRows);
+  REQUIRE(poisoned == 0);
+  REQUIRE(host.front() == kSourceValue);
+  REQUIRE(host.back() == kSourceValue);
 }

--- a/test/cpp/scan/test_stream_lineage_item5.cpp
+++ b/test/cpp/scan/test_stream_lineage_item5.cpp
@@ -1,0 +1,588 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Stream-lineage validation for the integrated stream-safety fixes ("item 5 is
+// unnecessary" claim):
+//
+//   - gpu_table_representation::release_table(stream) rebinds converter-produced
+//     buffers to the caller's stream (cucascade item 4), so the Sirius steal path
+//     (scan_operator_input::prepare_for_processing) frees them in the consumer
+//     stream's order instead of on the idle conversion-pool stream.
+//   - The data_batch consumer-event API (record_consumer_event / await_consumers /
+//     consumers_done) orders batch-managed reclaims (install_converted_representation,
+//     set_data) after cross-stream reads recorded by consumers.
+//
+// These tests exercise the exact hazard convert_host_fast_to_gpu used to expose:
+// converted GPU buffers are allocated on a memory-space pool stream; if their
+// eventual free retires on that idle foreign stream while a consumer stream still
+// has in-flight reads, the cudaMallocAsync pool can hand the block to the next
+// allocation mid-read (use-after-free / corruption). The "sensitivity" test
+// re-creates the pre-fix binding deliberately and proves the harness detects the
+// corruption; the fixed paths must then be deterministically clean.
+
+#include "catch.hpp"
+#include "data/data_batch_utils.hpp"
+#include "data/sirius_converter_registry.hpp"
+#include "memory/sirius_memory_reservation_manager.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_stream.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/memory/memory_space.hpp>
+#include <cucascade/memory/reservation_manager_configurator.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Fixture: single-GPU memory manager + converter registry (modeled on
+// test/cpp/pipeline/test_batch_lock_utils.cpp's batch_lock_utils_fixture).
+//===----------------------------------------------------------------------===//
+struct stream_lineage_fixture {
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> manager;
+  cucascade::memory::memory_space* gpu0  = nullptr;
+  cucascade::memory::memory_space* host0 = nullptr;
+
+  bool setup()
+  {
+    sirius::converter_registry::reset_for_testing();
+    try {
+      cucascade::memory::reservation_manager_configurator builder;
+      builder.set_number_of_gpus(1)
+        .set_gpu_usage_limit(512ULL << 20)
+        .set_reservation_fraction_per_gpu(0.75)
+        .set_per_numa_region_capacity(1ULL << 30)
+        .use_numa_id_as_host_id()
+        .track_reservation_per_stream(false)
+        .set_reservation_fraction_per_numa_region(0.75);
+      auto space_configs = builder.build();
+      manager            = std::make_unique<sirius::memory::sirius_memory_reservation_manager>(
+        std::move(space_configs));
+    } catch (const std::exception&) {
+      return false;
+    }
+    sirius::converter_registry::initialize();
+
+    auto gpu_spaces = manager->get_memory_spaces_for_tier(cucascade::memory::Tier::GPU);
+    if (gpu_spaces.empty()) { return false; }
+    gpu0             = const_cast<cucascade::memory::memory_space*>(gpu_spaces[0]);
+    auto host_spaces = manager->get_memory_spaces_for_tier(cucascade::memory::Tier::HOST);
+    if (host_spaces.empty()) { return false; }
+    host0 = const_cast<cucascade::memory::memory_space*>(host_spaces[0]);
+    return true;
+  }
+
+  ~stream_lineage_fixture()
+  {
+    if (manager) {
+      manager->shutdown();
+      sirius::converter_registry::shutdown();
+    }
+  }
+};
+
+/// INT64 column holding value(i) = seed + i, allocated from `space` on `stream`.
+/// When `with_nulls` is set, every 5th row is null (payload still written).
+std::unique_ptr<cudf::column> make_patterned_column(std::size_t num_rows,
+                                                    std::int64_t seed,
+                                                    bool with_nulls,
+                                                    cucascade::memory::memory_space& space,
+                                                    rmm::cuda_stream_view stream)
+{
+  auto mr = space.get_default_allocator();
+
+  std::vector<std::int64_t> host_vals(num_rows);
+  for (std::size_t i = 0; i < num_rows; ++i) {
+    host_vals[i] = seed + static_cast<std::int64_t>(i);
+  }
+  rmm::device_buffer data{num_rows * sizeof(std::int64_t), stream, mr};
+  cudaMemcpyAsync(data.data(),
+                  host_vals.data(),
+                  num_rows * sizeof(std::int64_t),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+
+  rmm::device_buffer mask{};
+  cudf::size_type null_count = 0;
+  if (with_nulls) {
+    std::size_t const num_words = (num_rows + 31) / 32;
+    std::vector<std::uint32_t> words(num_words, ~std::uint32_t{0});
+    for (std::size_t i = 0; i < num_rows; i += 5) {
+      words[i / 32] &= ~(std::uint32_t{1} << (i % 32));
+      ++null_count;
+    }
+    mask = rmm::device_buffer{num_words * sizeof(std::uint32_t), stream, mr};
+    cudaMemcpyAsync(mask.data(),
+                    words.data(),
+                    num_words * sizeof(std::uint32_t),
+                    cudaMemcpyHostToDevice,
+                    stream.value());
+  }
+  stream.synchronize();
+  return std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT64},
+                                        static_cast<cudf::size_type>(num_rows),
+                                        std::move(data),
+                                        std::move(mask),
+                                        null_count);
+}
+
+/// STRING column of `num_rows` four-byte strings, allocated from `space` on `stream`.
+std::unique_ptr<cudf::column> make_strings_column_patterned(
+  std::size_t num_rows, cucascade::memory::memory_space& space, rmm::cuda_stream_view stream)
+{
+  auto mr = space.get_default_allocator();
+
+  std::vector<std::int32_t> offsets(num_rows + 1);
+  std::vector<char> chars(num_rows * 4);
+  for (std::size_t i = 0; i <= num_rows; ++i) {
+    offsets[i] = static_cast<std::int32_t>(4 * i);
+  }
+  for (std::size_t i = 0; i < num_rows; ++i) {
+    char const c = static_cast<char>('a' + (i % 26));
+    chars[4 * i] = chars[4 * i + 1] = chars[4 * i + 2] = chars[4 * i + 3] = c;
+  }
+
+  rmm::device_buffer offsets_buf{offsets.size() * sizeof(std::int32_t), stream, mr};
+  cudaMemcpyAsync(offsets_buf.data(),
+                  offsets.data(),
+                  offsets.size() * sizeof(std::int32_t),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  auto offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+                                                    static_cast<cudf::size_type>(num_rows + 1),
+                                                    std::move(offsets_buf),
+                                                    rmm::device_buffer{},
+                                                    0);
+
+  rmm::device_buffer chars_buf{chars.size(), stream, mr};
+  cudaMemcpyAsync(
+    chars_buf.data(), chars.data(), chars.size(), cudaMemcpyHostToDevice, stream.value());
+  stream.synchronize();
+
+  return cudf::make_strings_column(static_cast<cudf::size_type>(num_rows),
+                                   std::move(offsets_col),
+                                   std::move(chars_buf),
+                                   0,
+                                   rmm::device_buffer{});
+}
+
+/// GPU batch spilled in place to host_data_representation (spilled-cache shape).
+/// Converting it back to gpu_table_representation goes through
+/// convert_host_fast_to_gpu, which allocates the reconstructed buffers on one of
+/// the GPU memory space's pool streams — the exact binding item 5 targeted.
+std::shared_ptr<cucascade::data_batch> make_host_batch(stream_lineage_fixture& f,
+                                                       std::size_t num_rows,
+                                                       std::int64_t seed,
+                                                       bool with_nulls,
+                                                       bool with_strings,
+                                                       rmm::cuda_stream_view stream)
+{
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(make_patterned_column(num_rows, seed, with_nulls, *f.gpu0, stream));
+  if (with_strings) { cols.push_back(make_strings_column_patterned(num_rows, *f.gpu0, stream)); }
+  auto table = std::make_unique<cudf::table>(std::move(cols));
+
+  auto batch = sirius::make_data_batch(
+    std::move(table), *f.gpu0, stream, sirius::telemetry::batch_telemetry_info{});
+  {
+    auto mut = batch->to_mutable();
+    mut.convert_to<cucascade::host_data_representation>(
+      sirius::converter_registry::get(), f.host0, stream);
+  }
+  stream.synchronize();
+  return batch;
+}
+
+/// Convert a host batch back to the GPU tier in place (convert_host_fast_to_gpu).
+void upload_to_gpu(stream_lineage_fixture& f,
+                   const std::shared_ptr<cucascade::data_batch>& batch,
+                   rmm::cuda_stream_view stream)
+{
+  auto mut = batch->to_mutable();
+  mut.convert_to<cucascade::gpu_table_representation>(
+    sirius::converter_registry::get(), f.gpu0, stream);
+}
+
+/// Mirror of the Sirius steal (sirius_gpu_scan_operator_data.cpp): release the
+/// owned table to `stream` and leave a valid empty placeholder in the batch.
+std::unique_ptr<cudf::table> steal_table(const std::shared_ptr<cucascade::data_batch>& batch,
+                                         cucascade::memory::memory_space& space,
+                                         rmm::cuda_stream_view stream)
+{
+  auto mut      = batch->to_mutable();
+  auto* gpu_rep = dynamic_cast<cucascade::gpu_table_representation*>(mut.get_data());
+  REQUIRE(gpu_rep != nullptr);
+  auto stolen = gpu_rep->release_table(stream);
+  mut.set_data(std::make_unique<cucascade::gpu_table_representation>(
+    std::make_unique<cudf::table>(), space, rmm::cuda_stream_view{}));
+  return stolen;
+}
+
+/// Enqueue ~2 GB of memset traffic on `stream` so work enqueued after it is
+/// guaranteed to still be pending when the host regains control.
+void enqueue_blockers(void* scratch, std::size_t scratch_bytes, rmm::cuda_stream_view stream)
+{
+  for (int i = 0; i < 32; ++i) {
+    cudaMemsetAsync(scratch, 0, scratch_bytes, stream.value());
+  }
+}
+
+/// Force conversion-pool churn: build small host batches and convert them to the
+/// GPU (each conversion acquires a pool stream and allocates from the async pool,
+/// grabbing any block whose free has already retired).
+void hammer_conversions(stream_lineage_fixture& f,
+                        rmm::cuda_stream_view stream,
+                        int count,
+                        std::size_t rows)
+{
+  for (int i = 0; i < count; ++i) {
+    auto hb = make_host_batch(f, rows, /*seed=*/0x5A5A5A5A + i, false, false, stream);
+    upload_to_gpu(f, hb, stream);
+    // Dropping `hb` here destroys the freshly converted representation and
+    // returns its blocks to the pool, maximizing recycling pressure.
+  }
+}
+
+constexpr std::size_t kRows       = 1u << 20;               // 1M rows -> 8 MB INT64 payload
+constexpr std::size_t kBytes      = kRows * sizeof(std::int64_t);
+constexpr std::size_t kScratchMiB = 64;
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// 1. release_table must rebind converter-produced buffers to the caller's stream
+//===----------------------------------------------------------------------===//
+TEST_CASE("release_table rebinds converted buffers (data, null mask, nested) to caller stream",
+          "[stream_lineage]")
+{
+  stream_lineage_fixture f;
+  REQUIRE(f.setup());
+
+  rmm::cuda_stream setup_stream;
+  auto batch =
+    make_host_batch(f, 4096, /*seed=*/7, /*with_nulls=*/true, /*with_strings=*/true, setup_stream);
+  upload_to_gpu(f, batch, setup_stream);
+  setup_stream.synchronize();
+
+  // Created AFTER the conversion allocated the GPU buffers, so no buffer can be
+  // "accidentally" born bound to it: any binding observed below must come from
+  // release_table's rebind.
+  rmm::cuda_stream task_stream;
+  auto stolen = steal_table(batch, *f.gpu0, task_stream.view());
+  REQUIRE(stolen != nullptr);
+  REQUIRE(stolen->num_columns() == 2);
+
+  auto cols = stolen->release();
+
+  // INT64 column: data buffer and null mask must deallocate on task_stream.
+  {
+    auto contents = cols[0]->release();
+    REQUIRE(contents.data != nullptr);
+    CHECK(contents.data->stream().value() == task_stream.value());
+    REQUIRE(contents.null_mask != nullptr);
+    REQUIRE(contents.null_mask->size() > 0);
+    CHECK(contents.null_mask->stream().value() == task_stream.value());
+  }
+
+  // STRING column (nested): chars payload and the offsets child's data buffer
+  // must both deallocate on task_stream (cudf::rebind_stream recurses).
+  {
+    auto contents = cols[1]->release();
+    REQUIRE(contents.data != nullptr);
+    REQUIRE(contents.data->size() > 0);
+    CHECK(contents.data->stream().value() == task_stream.value());
+    REQUIRE(!contents.children.empty());
+    auto offsets_contents = contents.children[0]->release();
+    REQUIRE(offsets_contents.data != nullptr);
+    CHECK(offsets_contents.data->stream().value() == task_stream.value());
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// 2. Steal-path UAF stress: mid-flight column destruction under pool churn
+//===----------------------------------------------------------------------===//
+TEST_CASE("stolen table tolerates mid-flight column destruction under conversion pressure",
+          "[stream_lineage]")
+{
+  stream_lineage_fixture f;
+  REQUIRE(f.setup());
+
+  void* scratch    = nullptr;
+  void* result_dev = nullptr;
+  REQUIRE(cudaMalloc(&scratch, kScratchMiB << 20) == cudaSuccess);
+  REQUIRE(cudaMalloc(&result_dev, kBytes) == cudaSuccess);
+
+  rmm::cuda_stream hammer_stream;
+  std::vector<std::int64_t> host_result(kRows);
+
+  for (int iter = 0; iter < 20; ++iter) {
+    std::int64_t const seed = 1000000LL * (iter + 1);
+    rmm::cuda_stream task_stream;
+
+    auto batch = make_host_batch(f, kRows, seed, false, false, task_stream.view());
+    upload_to_gpu(f, batch, task_stream.view());
+    auto stolen = steal_table(batch, *f.gpu0, task_stream.view());
+    REQUIRE(stolen != nullptr);
+
+    // Enqueue a long blocker, then the read: the D2D copy of the stolen column
+    // is guaranteed to still be pending when the host destroys the column.
+    enqueue_blockers(scratch, kScratchMiB << 20, task_stream.view());
+    void const* src = stolen->view().column(0).head();
+    cudaMemcpyAsync(result_dev, src, kBytes, cudaMemcpyDeviceToDevice, task_stream.value());
+
+    // Destroy the column mid-flight. With release_table's rebind the free is
+    // enqueued on task_stream BEHIND the read; without it (pre-fix) it would
+    // retire instantly on the idle conversion-pool stream and the block could
+    // be recycled by the conversions below while the read is still pending.
+    {
+      auto cols = stolen->release();
+      cols[0].reset();
+    }
+
+    // Hammer the conversion pool while the read is still blocked.
+    hammer_conversions(f, hammer_stream.view(), 3, kRows / 4);
+
+    cudaMemcpyAsync(
+      host_result.data(), result_dev, kBytes, cudaMemcpyDeviceToHost, task_stream.value());
+    task_stream.synchronize();
+
+    std::size_t mismatches = 0;
+    for (std::size_t i = 0; i < kRows; ++i) {
+      if (host_result[i] != seed + static_cast<std::int64_t>(i)) { ++mismatches; }
+    }
+    INFO("iteration " << iter << ": " << mismatches << " corrupted elements of " << kRows);
+    REQUIRE(mismatches == 0);
+  }
+
+  cudaFree(scratch);
+  cudaFree(result_dev);
+}
+
+//===----------------------------------------------------------------------===//
+// 3. Sensitivity check: the pre-fix binding (free on an idle foreign stream)
+//    corrupts the very read the fixed path protects.
+//===----------------------------------------------------------------------===//
+TEST_CASE("rebinding a stolen column back to an idle foreign stream reproduces pre-fix corruption",
+          "[stream_lineage]")
+{
+  stream_lineage_fixture f;
+  REQUIRE(f.setup());
+
+  void* scratch    = nullptr;
+  void* result_dev = nullptr;
+  REQUIRE(cudaMalloc(&scratch, kScratchMiB << 20) == cudaSuccess);
+  REQUIRE(cudaMalloc(&result_dev, kBytes) == cudaSuccess);
+
+  std::int64_t const seed = 42;
+  rmm::cuda_stream task_stream;
+  rmm::cuda_stream foreign_stream;  // stands in for the idle conversion-pool stream
+
+  auto batch = make_host_batch(f, kRows, seed, false, false, task_stream.view());
+  upload_to_gpu(f, batch, task_stream.view());
+  auto stolen = steal_table(batch, *f.gpu0, task_stream.view());
+
+  // Undo item 4's rebind: bind the column's buffers back to an idle foreign
+  // stream, exactly the binding release_table produced before the fix.
+  auto cols = stolen->release();
+  cols[0]   = cudf::rebind_stream(std::move(*cols[0]), foreign_stream.view());
+
+  void const* src = cols[0]->view().head();
+  enqueue_blockers(scratch, kScratchMiB << 20, task_stream.view());
+  cudaMemcpyAsync(result_dev, src, kBytes, cudaMemcpyDeviceToDevice, task_stream.value());
+
+  // Destroy mid-flight: the free retires immediately on the idle foreign stream.
+  cols[0].reset();
+
+  // The next same-stream allocation of the same size grabs the freed block and
+  // poisons it while the read above is still stuck behind the blocker.
+  rmm::device_buffer reuse{kBytes, foreign_stream.view(), f.gpu0->get_default_allocator()};
+  bool const block_reused = reuse.data() == src;
+  if (block_reused) {
+    cudaMemsetAsync(reuse.data(), 0xFF, kBytes, foreign_stream.value());
+    foreign_stream.synchronize();
+  }
+
+  std::vector<std::int64_t> host_result(kRows);
+  cudaMemcpyAsync(
+    host_result.data(), result_dev, kBytes, cudaMemcpyDeviceToHost, task_stream.value());
+  task_stream.synchronize();
+
+  std::size_t corrupted = 0;
+  for (std::size_t i = 0; i < kRows; ++i) {
+    if (host_result[i] != seed + static_cast<std::int64_t>(i)) { ++corrupted; }
+  }
+
+  if (block_reused) {
+    // The harness must be able to see the pre-fix failure mode, otherwise the
+    // clean runs in the other tests prove nothing.
+    INFO("corrupted elements with pre-fix binding: " << corrupted << " of " << kRows);
+    REQUIRE(corrupted > 0);
+  } else {
+    WARN("async pool did not recycle the freed block in place (reuse="
+         << reuse.data() << " src=" << src << ") — sensitivity check inconclusive this run");
+  }
+
+  cudaFree(scratch);
+  cudaFree(result_dev);
+}
+
+//===----------------------------------------------------------------------===//
+// 4. Consumer events order a convert_to reclaim after in-flight reads
+//===----------------------------------------------------------------------===//
+TEST_CASE("consumer events order install_converted_representation after in-flight reads",
+          "[stream_lineage]")
+{
+  stream_lineage_fixture f;
+  REQUIRE(f.setup());
+
+  void* scratch    = nullptr;
+  void* result_dev = nullptr;
+  REQUIRE(cudaMalloc(&scratch, kScratchMiB << 20) == cudaSuccess);
+  REQUIRE(cudaMalloc(&result_dev, kBytes) == cudaSuccess);
+
+  std::int64_t const seed = 77;
+  rmm::cuda_stream setup_stream;
+  rmm::cuda_stream reader_stream;
+  rmm::cuda_stream reclaim_stream;
+
+  auto batch = make_host_batch(f, kRows, seed, false, false, setup_stream.view());
+  upload_to_gpu(f, batch, setup_stream.view());
+  setup_stream.synchronize();
+
+  // Reader: enqueue a slow read of the converted buffers on its own stream and
+  // record a consumer event AFTER the reads are enqueued (the API contract).
+  {
+    auto ro         = batch->to_read_only();
+    auto view       = sirius::get_cudf_table_view(ro);
+    void const* src = view.column(0).head();
+    enqueue_blockers(scratch, kScratchMiB << 20, reader_stream.view());
+    cudaMemcpyAsync(result_dev, src, kBytes, cudaMemcpyDeviceToDevice, reader_stream.value());
+    ro.record_consumer_event(reader_stream.view());
+    REQUIRE_FALSE(batch->consumers_done());
+  }  // shared lock dropped with the read still in flight — the pre-fix hazard window
+
+  // Reclaimer: mirror the Sirius downgrade discipline (convertible_data_batch.hpp):
+  // rebind to the reclaim stream, then convert GPU -> host in place. With the
+  // consumer-event hooks, install_converted_representation must not destroy the
+  // old GPU representation until the recorded reader work has completed.
+  {
+    auto mut = batch->to_mutable();
+    mut.rebind_stream(reclaim_stream.view());
+    mut.convert_to<cucascade::host_data_representation>(
+      sirius::converter_registry::get(), f.host0, reclaim_stream.view());
+    // The reclaim host-synced behind await_consumers: the reader's recorded
+    // reads must be complete by now.
+    CHECK(cudaStreamQuery(reader_stream.value()) == cudaSuccess);
+    REQUIRE(batch->consumers_done());
+  }
+
+  // Churn the pool: if the reclaim had freed the GPU buffers early these
+  // allocations would recycle them under the (by then already finished) read.
+  hammer_conversions(f, reclaim_stream.view(), 3, kRows / 4);
+
+  std::vector<std::int64_t> host_result(kRows);
+  cudaMemcpyAsync(
+    host_result.data(), result_dev, kBytes, cudaMemcpyDeviceToHost, reader_stream.value());
+  reader_stream.synchronize();
+
+  std::size_t mismatches = 0;
+  for (std::size_t i = 0; i < kRows; ++i) {
+    if (host_result[i] != seed + static_cast<std::int64_t>(i)) { ++mismatches; }
+  }
+  INFO("corrupted elements: " << mismatches << " of " << kRows);
+  REQUIRE(mismatches == 0);
+
+  cudaFree(scratch);
+  cudaFree(result_dev);
+}
+
+//===----------------------------------------------------------------------===//
+// 5. set_data blocks on recorded consumer events before dropping the old data
+//===----------------------------------------------------------------------===//
+TEST_CASE("set_data waits for recorded consumer reads before replacing the representation",
+          "[stream_lineage]")
+{
+  stream_lineage_fixture f;
+  REQUIRE(f.setup());
+
+  void* scratch    = nullptr;
+  void* result_dev = nullptr;
+  REQUIRE(cudaMalloc(&scratch, kScratchMiB << 20) == cudaSuccess);
+  REQUIRE(cudaMalloc(&result_dev, kBytes) == cudaSuccess);
+
+  std::int64_t const seed = 99;
+  rmm::cuda_stream setup_stream;
+  rmm::cuda_stream reader_stream;
+
+  auto batch = make_host_batch(f, kRows, seed, false, false, setup_stream.view());
+  upload_to_gpu(f, batch, setup_stream.view());
+  setup_stream.synchronize();
+
+  {
+    auto ro         = batch->to_read_only();
+    auto view       = sirius::get_cudf_table_view(ro);
+    void const* src = view.column(0).head();
+    enqueue_blockers(scratch, kScratchMiB << 20, reader_stream.view());
+    cudaMemcpyAsync(result_dev, src, kBytes, cudaMemcpyDeviceToDevice, reader_stream.value());
+    ro.record_consumer_event(reader_stream.view());
+    REQUIRE_FALSE(batch->consumers_done());
+  }
+
+  // set_data destroys the old GPU representation (buffers still bound to the
+  // conversion-pool stream — no rebind happens on this path). The consumer-event
+  // hook must host-block until the reader's recorded reads complete.
+  {
+    auto mut = batch->to_mutable();
+    mut.set_data(std::make_unique<cucascade::gpu_table_representation>(
+      std::make_unique<cudf::table>(), *f.gpu0, rmm::cuda_stream_view{}));
+    CHECK(cudaStreamQuery(reader_stream.value()) == cudaSuccess);
+    REQUIRE(batch->consumers_done());
+  }
+
+  hammer_conversions(f, setup_stream.view(), 3, kRows / 4);
+
+  std::vector<std::int64_t> host_result(kRows);
+  cudaMemcpyAsync(
+    host_result.data(), result_dev, kBytes, cudaMemcpyDeviceToHost, reader_stream.value());
+  reader_stream.synchronize();
+
+  std::size_t mismatches = 0;
+  for (std::size_t i = 0; i < kRows; ++i) {
+    if (host_result[i] != seed + static_cast<std::int64_t>(i)) { ++mismatches; }
+  }
+  INFO("corrupted elements: " << mismatches << " of " << kRows);
+  REQUIRE(mismatches == 0);
+
+  cudaFree(scratch);
+  cudaFree(result_dev);
+}

--- a/test/cpp/scan/test_stream_lineage_item5.cpp
+++ b/test/cpp/scan/test_stream_lineage_item5.cpp
@@ -20,9 +20,11 @@
 //     buffers to the caller's stream, so the Sirius steal path
 //     (scan_operator_input::prepare_for_processing) frees them in the consumer
 //     stream's order instead of on the idle conversion-pool stream.
-//   - The data_batch consumer-event API (record_consumer_event / await_consumers /
-//     consumers_done) orders batch-managed reclaims (install_converted_representation,
-//     set_data) after cross-stream reads recorded by consumers.
+//   - The data_batch reader-event API (read_only_data_batch::record_reader_event)
+//     orders reclaims after cross-stream reads: mutable acquisition (to_mutable /
+//     readonly_to_mutable) host-waits for every recorded reader event before
+//     exposing the representation, and try_to_mutable declines while one is
+//     still pending.
 //
 // The hazard, reached through convert_host_fast_to_gpu: converted GPU buffers
 // are allocated on a memory-space pool stream; if their eventual free retires on
@@ -33,15 +35,15 @@
 // paths must then be deterministically clean.
 //
 // The per-buffer rebind assertions (data / null mask / nested children bound to
-// the release stream) and the set_data consumer-event sync are pinned
-// deterministically at the cucascade layer
-// (cucascade/test/cudf/test_release_table_stream.cpp and
-// cucascade/test/data/test_consumer_events.cpp). This suite covers only what
-// the Sirius layer adds: the real converter registry + memory spaces behind
-// the steal-path stress, its matched sensitivity (non-vacuity) check, the
-// production downgrade discipline through install_converted_representation,
-// and the filtered-serving record path through owning_table_view's
-// type-erased owner.
+// the release stream) and the mutable-acquisition reader-event barrier are
+// pinned deterministically at the cucascade layer
+// (cucascade/test/cudf/test_release_table_stream.cpp and the reader-event
+// cases in cucascade/test/data/test_data_batch.cpp). This suite covers only
+// what the Sirius layer adds: the real converter registry + memory spaces
+// behind the steal-path stress, its matched sensitivity (non-vacuity) check,
+// the production downgrade discipline (to_mutable + rebind + convert_to), and
+// the filtered-serving record path through owning_table_view's type-erased
+// owner.
 
 #include "catch.hpp"
 #include "data/data_batch_utils.hpp"
@@ -420,9 +422,10 @@ TEST_CASE("rebinding a stolen column back to an idle foreign stream reproduces p
 }
 
 //===----------------------------------------------------------------------===//
-// 3. Consumer events order a convert_to reclaim after in-flight reads
+// 3. Reader events make a convert reclaim's mutable acquisition wait for
+//    in-flight reads
 //===----------------------------------------------------------------------===//
-TEST_CASE("consumer events order install_converted_representation after in-flight reads",
+TEST_CASE("reader events order a convert reclaim's mutable acquisition after in-flight reads",
           "[stream_lineage]")
 {
   stream_lineage_fixture f;
@@ -443,31 +446,36 @@ TEST_CASE("consumer events order install_converted_representation after in-fligh
   setup_stream.synchronize();
 
   // Reader: enqueue a slow read of the converted buffers on its own stream and
-  // record a consumer event AFTER the reads are enqueued (the API contract).
+  // record a reader event AFTER the reads are enqueued (the API contract).
   {
     auto ro         = batch->to_read_only();
     auto view       = sirius::get_cudf_table_view(ro);
     void const* src = view.column(0).head();
     enqueue_blockers(scratch, kScratchMiB << 20, reader_stream.view());
     cudaMemcpyAsync(result_dev, src, kBytes, cudaMemcpyDeviceToDevice, reader_stream.value());
-    ro.record_consumer_event(reader_stream.view());
-    REQUIRE_FALSE(batch->consumers_done());
+    ro.record_reader_event(reader_stream.view());
   }  // shared lock dropped with the read still in flight — the pre-fix hazard window
 
+  // The recorded event must be visible as a pending reader: with the shared
+  // lock already released, only the reader-event barrier can make the
+  // non-blocking mutable path decline. This also pins that the record was not
+  // a silent no-op.
+  REQUIRE_FALSE(batch->try_to_mutable().has_value());
+
   // Reclaimer: mirror the Sirius downgrade discipline (convertible_data_batch.hpp):
-  // rebind to the reclaim stream, then convert GPU -> host in place. With the
-  // consumer-event hooks, install_converted_representation must not destroy the
-  // old GPU representation until the recorded reader work has completed.
+  // acquire mutable access, rebind to the reclaim stream, then convert GPU ->
+  // host in place. With the reader-event barrier, to_mutable must host-block
+  // until the recorded reader work has completed, so the conversion cannot
+  // destroy the old GPU representation under the in-flight read.
   {
     auto mut = batch->to_mutable();
+    // to_mutable returned, so the reader's recorded reads must be complete.
+    CHECK(cudaStreamQuery(reader_stream.value()) == cudaSuccess);
     mut.rebind_stream(reclaim_stream.view());
     mut.convert_to<cucascade::host_data_representation>(
       sirius::converter_registry::get(), f.host0, reclaim_stream.view());
-    // The reclaim host-synced behind await_consumers: the reader's recorded
-    // reads must be complete by now.
-    CHECK(cudaStreamQuery(reader_stream.value()) == cudaSuccess);
-    REQUIRE(batch->consumers_done());
   }
+  REQUIRE(batch->try_to_mutable().has_value());
 
   // Churn the pool: if the reclaim had freed the GPU buffers early these
   // allocations would recycle them under the (by then already finished) read.
@@ -500,13 +508,13 @@ TEST_CASE("consumer events order install_converted_representation after in-fligh
 //      served as an owning_table_view whose type-erased owner is the batch's
 //      read_only_data_batch (the read-lock holder).
 //   2. post_filter_and_project: a select-like read of that view is enqueued on
-//      the task stream, then owning_table_view::record_consumer_event(stream)
+//      the task stream, then owning_table_view::record_reader_event(stream)
 //      — the call this test pins — records through the type erasure.
 //   3. The owner is dropped mid-flight (parquet reassigns `input` immediately
 //      after the select), releasing the read lock with the reads pending.
-//   4. A reclaim runs through the path that now awaits consumers
-//      (install_converted_representation via convert_to).
-TEST_CASE("filtered serving records consumer events through owning_table_view before owner drop",
+//   4. A reclaim acquires mutable access, whose reader-event barrier waits
+//      for the recorded reads, then converts in place.
+TEST_CASE("filtered serving records reader events through owning_table_view before owner drop",
           "[stream_lineage]")
 {
   stream_lineage_fixture f;
@@ -539,31 +547,33 @@ TEST_CASE("filtered serving records consumer events through owning_table_view be
     enqueue_blockers(scratch, kScratchMiB << 20, task_stream.view());
     void const* src = served.view().column(0).head();
     cudaMemcpyAsync(result_dev, src, kBytes, cudaMemcpyDeviceToDevice, task_stream.value());
-    served.record_consumer_event(task_stream.view());
-
-    // Non-vacuity: the record must reach the underlying batch through the
-    // type-erased owner. If the pass-through silently no-ops (e.g. the owner
-    // concept stops matching read_only_data_batch), this fails immediately.
-    REQUIRE_FALSE(batch->consumers_done());
+    served.record_reader_event(task_stream.view());
 
     // Step 3: drop the owner mid-flight, releasing the read lock — the
     // parquet reassignment shape.
     served.drop();
   }
 
-  // Step 4: reclaim through the production downgrade discipline. With the
-  // record in place, install_converted_representation must not destroy the old
-  // GPU representation until the recorded reads have completed.
+  // Non-vacuity: the record must reach the underlying batch through the
+  // type-erased owner. The read lock is gone, so only a pending reader event
+  // can make the non-blocking mutable path decline here. If the pass-through
+  // silently no-ops (e.g. the owner concept stops matching
+  // read_only_data_batch), this fails immediately.
+  REQUIRE_FALSE(batch->try_to_mutable().has_value());
+
+  // Step 4: reclaim through the production downgrade discipline. The
+  // reader-event barrier makes to_mutable host-block until the recorded reads
+  // have completed, so the conversion cannot destroy the old GPU
+  // representation under the still-pending select.
   {
     auto mut = batch->to_mutable();
+    // to_mutable returned, so the select-like read must be complete.
+    CHECK(cudaStreamQuery(task_stream.value()) == cudaSuccess);
     mut.rebind_stream(reclaim_stream.view());
     mut.convert_to<cucascade::host_data_representation>(
       sirius::converter_registry::get(), f.host0, reclaim_stream.view());
-    // The reclaim host-synced behind await_consumers: the select-like read
-    // must be complete by now.
-    CHECK(cudaStreamQuery(task_stream.value()) == cudaSuccess);
-    REQUIRE(batch->consumers_done());
   }
+  REQUIRE(batch->try_to_mutable().has_value());
 
   // Churn the pool: had the reclaim freed the GPU buffers early, these
   // allocations would have recycled them under the still-pending read.

--- a/test/cpp/scan/test_stream_lineage_item5.cpp
+++ b/test/cpp/scan/test_stream_lineage_item5.cpp
@@ -38,13 +38,16 @@
 // (cucascade/test/cudf/test_release_table_stream.cpp and
 // cucascade/test/data/test_consumer_events.cpp). This suite covers only what
 // the Sirius layer adds: the real converter registry + memory spaces behind
-// the steal-path stress, its matched sensitivity (non-vacuity) check, and the
-// production downgrade discipline through install_converted_representation.
+// the steal-path stress, its matched sensitivity (non-vacuity) check, the
+// production downgrade discipline through install_converted_representation,
+// and the filtered-serving record path through owning_table_view's
+// type-erased owner.
 
 #include "catch.hpp"
 #include "data/data_batch_utils.hpp"
 #include "data/sirius_converter_registry.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
+#include "op/scan/owning_table_view.hpp"
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
@@ -474,6 +477,102 @@ TEST_CASE("consumer events order install_converted_representation after in-fligh
   cudaMemcpyAsync(
     host_result.data(), result_dev, kBytes, cudaMemcpyDeviceToHost, reader_stream.value());
   reader_stream.synchronize();
+
+  std::size_t mismatches = 0;
+  for (std::size_t i = 0; i < kRows; ++i) {
+    if (host_result[i] != seed + static_cast<std::int64_t>(i)) { ++mismatches; }
+  }
+  INFO("corrupted elements: " << mismatches << " of " << kRows);
+  REQUIRE(mismatches == 0);
+
+  cudaFree(scratch);
+  cudaFree(result_dev);
+}
+
+//===----------------------------------------------------------------------===//
+// 4. Filtered-serving path: the owning_table_view record reaches the batch and
+//    orders a convert reclaim after the enqueued select's reads
+//===----------------------------------------------------------------------===//
+// Replicates the exact filtered scan serving sequence — driving the real
+// ingestibles here would need full scan plans and bind data, so the test runs
+// the same steps against the same APIs the production code uses:
+//   1. gpu_ingestible::materialize_table (cached branch): the batch's view is
+//      served as an owning_table_view whose type-erased owner is the batch's
+//      read_only_data_batch (the read-lock holder).
+//   2. post_filter_and_project: a select-like read of that view is enqueued on
+//      the task stream, then owning_table_view::record_consumer_event(stream)
+//      — the call this test pins — records through the type erasure.
+//   3. The owner is dropped mid-flight (parquet reassigns `input` immediately
+//      after the select), releasing the read lock with the reads pending.
+//   4. A reclaim runs through the path that now awaits consumers
+//      (install_converted_representation via convert_to).
+TEST_CASE("filtered serving records consumer events through owning_table_view before owner drop",
+          "[stream_lineage]")
+{
+  stream_lineage_fixture f;
+  REQUIRE(f.setup());
+
+  void* scratch    = nullptr;
+  void* result_dev = nullptr;
+  REQUIRE(cudaMalloc(&scratch, kScratchMiB << 20) == cudaSuccess);
+  REQUIRE(cudaMalloc(&result_dev, kBytes) == cudaSuccess);
+
+  std::int64_t const seed = 91;
+  rmm::cuda_stream setup_stream;
+  rmm::cuda_stream task_stream;
+  rmm::cuda_stream reclaim_stream;
+
+  auto batch = make_host_batch(f, kRows, seed, false, false, setup_stream.view());
+  upload_to_gpu(f, batch, setup_stream.view());
+  setup_stream.synchronize();
+
+  {
+    // Step 1: serve the view under the read lock, owner type-erased into the
+    // owning_table_view — exactly gpu_ingestible::materialize_table.
+    auto rbatch = batch->to_read_only();
+    auto view   = sirius::get_cudf_table_view(rbatch);
+    sirius::op::scan::owning_table_view served{std::move(rbatch), view};
+
+    // Step 2: enqueue a slow select-like read of the served view on the task
+    // stream, then record — after the enqueue, while the owner still holds the
+    // read lock.
+    enqueue_blockers(scratch, kScratchMiB << 20, task_stream.view());
+    void const* src = served.view().column(0).head();
+    cudaMemcpyAsync(result_dev, src, kBytes, cudaMemcpyDeviceToDevice, task_stream.value());
+    served.record_consumer_event(task_stream.view());
+
+    // Non-vacuity: the record must reach the underlying batch through the
+    // type-erased owner. If the pass-through silently no-ops (e.g. the owner
+    // concept stops matching read_only_data_batch), this fails immediately.
+    REQUIRE_FALSE(batch->consumers_done());
+
+    // Step 3: drop the owner mid-flight, releasing the read lock — the
+    // parquet reassignment shape.
+    served.drop();
+  }
+
+  // Step 4: reclaim through the production downgrade discipline. With the
+  // record in place, install_converted_representation must not destroy the old
+  // GPU representation until the recorded reads have completed.
+  {
+    auto mut = batch->to_mutable();
+    mut.rebind_stream(reclaim_stream.view());
+    mut.convert_to<cucascade::host_data_representation>(
+      sirius::converter_registry::get(), f.host0, reclaim_stream.view());
+    // The reclaim host-synced behind await_consumers: the select-like read
+    // must be complete by now.
+    CHECK(cudaStreamQuery(task_stream.value()) == cudaSuccess);
+    REQUIRE(batch->consumers_done());
+  }
+
+  // Churn the pool: had the reclaim freed the GPU buffers early, these
+  // allocations would have recycled them under the still-pending read.
+  hammer_conversions(f, reclaim_stream.view(), 3, kRows / 4);
+
+  std::vector<std::int64_t> host_result(kRows);
+  cudaMemcpyAsync(
+    host_result.data(), result_dev, kBytes, cudaMemcpyDeviceToHost, task_stream.value());
+  task_stream.synchronize();
 
   std::size_t mismatches = 0;
   for (std::size_t i = 0; i < kRows; ++i) {

--- a/test/cpp/scan/test_stream_lineage_item5.cpp
+++ b/test/cpp/scan/test_stream_lineage_item5.cpp
@@ -32,6 +32,15 @@
 // allocation mid-read (use-after-free / corruption). The "sensitivity" test
 // re-creates the pre-fix binding deliberately and proves the harness detects the
 // corruption; the fixed paths must then be deterministically clean.
+//
+// Scope note: the per-buffer rebind assertions (data / null mask / nested
+// children bound to the release stream) and the set_data consumer-event sync
+// are pinned deterministically at the cucascade layer
+// (cucascade/test/cudf/test_release_table_stream.cpp and
+// cucascade/test/data/test_consumer_events.cpp). This suite keeps only what
+// the Sirius layer adds: the real converter registry + memory spaces behind
+// the steal-path stress, its matched sensitivity (non-vacuity) check, and the
+// production downgrade discipline through install_converted_representation.
 
 #include "catch.hpp"
 #include "data/data_batch_utils.hpp"
@@ -280,56 +289,7 @@ constexpr std::size_t kScratchMiB = 64;
 }  // namespace
 
 //===----------------------------------------------------------------------===//
-// 1. release_table must rebind converter-produced buffers to the caller's stream
-//===----------------------------------------------------------------------===//
-TEST_CASE("release_table rebinds converted buffers (data, null mask, nested) to caller stream",
-          "[stream_lineage]")
-{
-  stream_lineage_fixture f;
-  REQUIRE(f.setup());
-
-  rmm::cuda_stream setup_stream;
-  auto batch =
-    make_host_batch(f, 4096, /*seed=*/7, /*with_nulls=*/true, /*with_strings=*/true, setup_stream);
-  upload_to_gpu(f, batch, setup_stream);
-  setup_stream.synchronize();
-
-  // Created AFTER the conversion allocated the GPU buffers, so no buffer can be
-  // "accidentally" born bound to it: any binding observed below must come from
-  // release_table's rebind.
-  rmm::cuda_stream task_stream;
-  auto stolen = steal_table(batch, *f.gpu0, task_stream.view());
-  REQUIRE(stolen != nullptr);
-  REQUIRE(stolen->num_columns() == 2);
-
-  auto cols = stolen->release();
-
-  // INT64 column: data buffer and null mask must deallocate on task_stream.
-  {
-    auto contents = cols[0]->release();
-    REQUIRE(contents.data != nullptr);
-    CHECK(contents.data->stream().value() == task_stream.value());
-    REQUIRE(contents.null_mask != nullptr);
-    REQUIRE(contents.null_mask->size() > 0);
-    CHECK(contents.null_mask->stream().value() == task_stream.value());
-  }
-
-  // STRING column (nested): chars payload and the offsets child's data buffer
-  // must both deallocate on task_stream (cudf::rebind_stream recurses).
-  {
-    auto contents = cols[1]->release();
-    REQUIRE(contents.data != nullptr);
-    REQUIRE(contents.data->size() > 0);
-    CHECK(contents.data->stream().value() == task_stream.value());
-    REQUIRE(!contents.children.empty());
-    auto offsets_contents = contents.children[0]->release();
-    REQUIRE(offsets_contents.data != nullptr);
-    CHECK(offsets_contents.data->stream().value() == task_stream.value());
-  }
-}
-
-//===----------------------------------------------------------------------===//
-// 2. Steal-path UAF stress: mid-flight column destruction under pool churn
+// 1. Steal-path UAF stress: mid-flight column destruction under pool churn
 //===----------------------------------------------------------------------===//
 TEST_CASE("stolen table tolerates mid-flight column destruction under conversion pressure",
           "[stream_lineage]")
@@ -389,7 +349,7 @@ TEST_CASE("stolen table tolerates mid-flight column destruction under conversion
 }
 
 //===----------------------------------------------------------------------===//
-// 3. Sensitivity check: the pre-fix binding (free on an idle foreign stream)
+// 2. Sensitivity check: the pre-fix binding (free on an idle foreign stream)
 //    corrupts the very read the fixed path protects.
 //===----------------------------------------------------------------------===//
 TEST_CASE("rebinding a stolen column back to an idle foreign stream reproduces pre-fix corruption",
@@ -457,7 +417,7 @@ TEST_CASE("rebinding a stolen column back to an idle foreign stream reproduces p
 }
 
 //===----------------------------------------------------------------------===//
-// 4. Consumer events order a convert_to reclaim after in-flight reads
+// 3. Consumer events order a convert_to reclaim after in-flight reads
 //===----------------------------------------------------------------------===//
 TEST_CASE("consumer events order install_converted_representation after in-flight reads",
           "[stream_lineage]")
@@ -509,67 +469,6 @@ TEST_CASE("consumer events order install_converted_representation after in-fligh
   // Churn the pool: if the reclaim had freed the GPU buffers early these
   // allocations would recycle them under the (by then already finished) read.
   hammer_conversions(f, reclaim_stream.view(), 3, kRows / 4);
-
-  std::vector<std::int64_t> host_result(kRows);
-  cudaMemcpyAsync(
-    host_result.data(), result_dev, kBytes, cudaMemcpyDeviceToHost, reader_stream.value());
-  reader_stream.synchronize();
-
-  std::size_t mismatches = 0;
-  for (std::size_t i = 0; i < kRows; ++i) {
-    if (host_result[i] != seed + static_cast<std::int64_t>(i)) { ++mismatches; }
-  }
-  INFO("corrupted elements: " << mismatches << " of " << kRows);
-  REQUIRE(mismatches == 0);
-
-  cudaFree(scratch);
-  cudaFree(result_dev);
-}
-
-//===----------------------------------------------------------------------===//
-// 5. set_data blocks on recorded consumer events before dropping the old data
-//===----------------------------------------------------------------------===//
-TEST_CASE("set_data waits for recorded consumer reads before replacing the representation",
-          "[stream_lineage]")
-{
-  stream_lineage_fixture f;
-  REQUIRE(f.setup());
-
-  void* scratch    = nullptr;
-  void* result_dev = nullptr;
-  REQUIRE(cudaMalloc(&scratch, kScratchMiB << 20) == cudaSuccess);
-  REQUIRE(cudaMalloc(&result_dev, kBytes) == cudaSuccess);
-
-  std::int64_t const seed = 99;
-  rmm::cuda_stream setup_stream;
-  rmm::cuda_stream reader_stream;
-
-  auto batch = make_host_batch(f, kRows, seed, false, false, setup_stream.view());
-  upload_to_gpu(f, batch, setup_stream.view());
-  setup_stream.synchronize();
-
-  {
-    auto ro         = batch->to_read_only();
-    auto view       = sirius::get_cudf_table_view(ro);
-    void const* src = view.column(0).head();
-    enqueue_blockers(scratch, kScratchMiB << 20, reader_stream.view());
-    cudaMemcpyAsync(result_dev, src, kBytes, cudaMemcpyDeviceToDevice, reader_stream.value());
-    ro.record_consumer_event(reader_stream.view());
-    REQUIRE_FALSE(batch->consumers_done());
-  }
-
-  // set_data destroys the old GPU representation (buffers still bound to the
-  // conversion-pool stream — no rebind happens on this path). The consumer-event
-  // hook must host-block until the reader's recorded reads complete.
-  {
-    auto mut = batch->to_mutable();
-    mut.set_data(std::make_unique<cucascade::gpu_table_representation>(
-      std::make_unique<cudf::table>(), *f.gpu0, rmm::cuda_stream_view{}));
-    CHECK(cudaStreamQuery(reader_stream.value()) == cudaSuccess);
-    REQUIRE(batch->consumers_done());
-  }
-
-  hammer_conversions(f, setup_stream.view(), 3, kRows / 4);
 
   std::vector<std::int64_t> host_result(kRows);
   cudaMemcpyAsync(

--- a/test/cpp/scan/test_stream_lineage_item5.cpp
+++ b/test/cpp/scan/test_stream_lineage_item5.cpp
@@ -14,30 +14,29 @@
  * limitations under the License.
  */
 
-// Stream-lineage validation for the integrated stream-safety fixes ("item 5 is
-// unnecessary" claim):
+// Stream-lineage validation of the stream-safety fixes at the Sirius layer:
 //
 //   - gpu_table_representation::release_table(stream) rebinds converter-produced
-//     buffers to the caller's stream (cucascade item 4), so the Sirius steal path
+//     buffers to the caller's stream, so the Sirius steal path
 //     (scan_operator_input::prepare_for_processing) frees them in the consumer
 //     stream's order instead of on the idle conversion-pool stream.
 //   - The data_batch consumer-event API (record_consumer_event / await_consumers /
 //     consumers_done) orders batch-managed reclaims (install_converted_representation,
 //     set_data) after cross-stream reads recorded by consumers.
 //
-// These tests exercise the exact hazard convert_host_fast_to_gpu used to expose:
-// converted GPU buffers are allocated on a memory-space pool stream; if their
-// eventual free retires on that idle foreign stream while a consumer stream still
-// has in-flight reads, the cudaMallocAsync pool can hand the block to the next
-// allocation mid-read (use-after-free / corruption). The "sensitivity" test
-// re-creates the pre-fix binding deliberately and proves the harness detects the
-// corruption; the fixed paths must then be deterministically clean.
+// The hazard, reached through convert_host_fast_to_gpu: converted GPU buffers
+// are allocated on a memory-space pool stream; if their eventual free retires on
+// that idle foreign stream while a consumer stream still has in-flight reads,
+// the cudaMallocAsync pool can hand the block to the next allocation mid-read
+// (use-after-free / corruption). The "sensitivity" test re-creates the pre-fix
+// binding deliberately and proves the harness detects the corruption; the fixed
+// paths must then be deterministically clean.
 //
-// Scope note: the per-buffer rebind assertions (data / null mask / nested
-// children bound to the release stream) and the set_data consumer-event sync
-// are pinned deterministically at the cucascade layer
+// The per-buffer rebind assertions (data / null mask / nested children bound to
+// the release stream) and the set_data consumer-event sync are pinned
+// deterministically at the cucascade layer
 // (cucascade/test/cudf/test_release_table_stream.cpp and
-// cucascade/test/data/test_consumer_events.cpp). This suite keeps only what
+// cucascade/test/data/test_consumer_events.cpp). This suite covers only what
 // the Sirius layer adds: the real converter registry + memory spaces behind
 // the steal-path stress, its matched sensitivity (non-vacuity) check, and the
 // production downgrade discipline through install_converted_representation.
@@ -166,8 +165,9 @@ std::unique_ptr<cudf::column> make_patterned_column(std::size_t num_rows,
 }
 
 /// STRING column of `num_rows` four-byte strings, allocated from `space` on `stream`.
-std::unique_ptr<cudf::column> make_strings_column_patterned(
-  std::size_t num_rows, cucascade::memory::memory_space& space, rmm::cuda_stream_view stream)
+std::unique_ptr<cudf::column> make_strings_column_patterned(std::size_t num_rows,
+                                                            cucascade::memory::memory_space& space,
+                                                            rmm::cuda_stream_view stream)
 {
   auto mr = space.get_default_allocator();
 
@@ -208,7 +208,7 @@ std::unique_ptr<cudf::column> make_strings_column_patterned(
 /// GPU batch spilled in place to host_data_representation (spilled-cache shape).
 /// Converting it back to gpu_table_representation goes through
 /// convert_host_fast_to_gpu, which allocates the reconstructed buffers on one of
-/// the GPU memory space's pool streams — the exact binding item 5 targeted.
+/// the GPU memory space's pool streams — the binding these tests exercise.
 std::shared_ptr<cucascade::data_batch> make_host_batch(stream_lineage_fixture& f,
                                                        std::size_t num_rows,
                                                        std::int64_t seed,
@@ -282,7 +282,7 @@ void hammer_conversions(stream_lineage_fixture& f,
   }
 }
 
-constexpr std::size_t kRows       = 1u << 20;               // 1M rows -> 8 MB INT64 payload
+constexpr std::size_t kRows       = 1u << 20;  // 1M rows -> 8 MB INT64 payload
 constexpr std::size_t kBytes      = kRows * sizeof(std::int64_t);
 constexpr std::size_t kScratchMiB = 64;
 
@@ -371,8 +371,8 @@ TEST_CASE("rebinding a stolen column back to an idle foreign stream reproduces p
   upload_to_gpu(f, batch, task_stream.view());
   auto stolen = steal_table(batch, *f.gpu0, task_stream.view());
 
-  // Undo item 4's rebind: bind the column's buffers back to an idle foreign
-  // stream, exactly the binding release_table produced before the fix.
+  // Undo release_table's rebind: bind the column's buffers back to an idle
+  // foreign stream, exactly the binding release_table produced pre-fix.
   auto cols = stolen->release();
   cols[0]   = cudf::rebind_stream(std::move(*cols[0]), foreign_stream.view());
 

--- a/test/cpp/scan/test_stream_lineage_item5.cpp
+++ b/test/cpp/scan/test_stream_lineage_item5.cpp
@@ -14,37 +14,6 @@
  * limitations under the License.
  */
 
-// Stream-lineage validation of the stream-safety fixes at the Sirius layer:
-//
-//   - gpu_table_representation::release_table(stream) rebinds converter-produced
-//     buffers to the caller's stream, so the Sirius steal path
-//     (scan_operator_input::prepare_for_processing) frees them in the consumer
-//     stream's order instead of on the idle conversion-pool stream.
-//   - The data_batch reader-event API (read_only_data_batch::record_reader_event)
-//     orders reclaims after cross-stream reads: mutable acquisition (to_mutable /
-//     readonly_to_mutable) host-waits for every recorded reader event before
-//     exposing the representation, and try_to_mutable declines while one is
-//     still pending.
-//
-// The hazard, reached through convert_host_fast_to_gpu: converted GPU buffers
-// are allocated on a memory-space pool stream; if their eventual free retires on
-// that idle foreign stream while a consumer stream still has in-flight reads,
-// the cudaMallocAsync pool can hand the block to the next allocation mid-read
-// (use-after-free / corruption). The "sensitivity" test re-creates the pre-fix
-// binding deliberately and proves the harness detects the corruption; the fixed
-// paths must then be deterministically clean.
-//
-// The per-buffer rebind assertions (data / null mask / nested children bound to
-// the release stream) and the mutable-acquisition reader-event barrier are
-// pinned deterministically at the cucascade layer
-// (cucascade/test/cudf/test_release_table_stream.cpp and the reader-event
-// cases in cucascade/test/data/test_data_batch.cpp). This suite covers only
-// what the Sirius layer adds: the real converter registry + memory spaces
-// behind the steal-path stress, its matched sensitivity (non-vacuity) check,
-// the production downgrade discipline (to_mutable + rebind + convert_to), and
-// the filtered-serving record path through owning_table_view's type-erased
-// owner.
-
 #include "catch.hpp"
 #include "data/data_batch_utils.hpp"
 #include "data/sirius_converter_registry.hpp"
@@ -77,10 +46,6 @@
 
 namespace {
 
-//===----------------------------------------------------------------------===//
-// Fixture: single-GPU memory manager + converter registry (modeled on
-// test/cpp/pipeline/test_batch_lock_utils.cpp's batch_lock_utils_fixture).
-//===----------------------------------------------------------------------===//
 struct stream_lineage_fixture {
   std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> manager;
   cucascade::memory::memory_space* gpu0  = nullptr;
@@ -124,8 +89,6 @@ struct stream_lineage_fixture {
   }
 };
 
-/// INT64 column holding value(i) = seed + i, allocated from `space` on `stream`.
-/// When `with_nulls` is set, every 5th row is null (payload still written).
 std::unique_ptr<cudf::column> make_patterned_column(std::size_t num_rows,
                                                     std::int64_t seed,
                                                     bool with_nulls,
@@ -169,7 +132,6 @@ std::unique_ptr<cudf::column> make_patterned_column(std::size_t num_rows,
                                         null_count);
 }
 
-/// STRING column of `num_rows` four-byte strings, allocated from `space` on `stream`.
 std::unique_ptr<cudf::column> make_strings_column_patterned(std::size_t num_rows,
                                                             cucascade::memory::memory_space& space,
                                                             rmm::cuda_stream_view stream)
@@ -210,10 +172,8 @@ std::unique_ptr<cudf::column> make_strings_column_patterned(std::size_t num_rows
                                    rmm::device_buffer{});
 }
 
-/// GPU batch spilled in place to host_data_representation (spilled-cache shape).
-/// Converting it back to gpu_table_representation goes through
-/// convert_host_fast_to_gpu, which allocates the reconstructed buffers on one of
-/// the GPU memory space's pool streams — the binding these tests exercise.
+/// Host-resident batch; converting it back to GPU tier allocates the rebuilt
+/// buffers on a memory-space pool stream — the foreign-stream binding under test.
 std::shared_ptr<cucascade::data_batch> make_host_batch(stream_lineage_fixture& f,
                                                        std::size_t num_rows,
                                                        std::int64_t seed,
@@ -237,7 +197,6 @@ std::shared_ptr<cucascade::data_batch> make_host_batch(stream_lineage_fixture& f
   return batch;
 }
 
-/// Convert a host batch back to the GPU tier in place (convert_host_fast_to_gpu).
 void upload_to_gpu(stream_lineage_fixture& f,
                    const std::shared_ptr<cucascade::data_batch>& batch,
                    rmm::cuda_stream_view stream)
@@ -247,8 +206,7 @@ void upload_to_gpu(stream_lineage_fixture& f,
     sirius::converter_registry::get(), f.gpu0, stream);
 }
 
-/// Mirror of the Sirius steal (sirius_gpu_scan_operator_data.cpp): release the
-/// owned table to `stream` and leave a valid empty placeholder in the batch.
+/// Mirrors the production steal path (sirius_gpu_scan_operator_data.cpp).
 std::unique_ptr<cudf::table> steal_table(const std::shared_ptr<cucascade::data_batch>& batch,
                                          cucascade::memory::memory_space& space,
                                          rmm::cuda_stream_view stream)
@@ -262,8 +220,7 @@ std::unique_ptr<cudf::table> steal_table(const std::shared_ptr<cucascade::data_b
   return stolen;
 }
 
-/// Enqueue ~2 GB of memset traffic on `stream` so work enqueued after it is
-/// guaranteed to still be pending when the host regains control.
+/// Enough traffic that work enqueued after it is still pending when the host regains control.
 void enqueue_blockers(void* scratch, std::size_t scratch_bytes, rmm::cuda_stream_view stream)
 {
   for (int i = 0; i < 32; ++i) {
@@ -271,9 +228,8 @@ void enqueue_blockers(void* scratch, std::size_t scratch_bytes, rmm::cuda_stream
   }
 }
 
-/// Force conversion-pool churn: build small host batches and convert them to the
-/// GPU (each conversion acquires a pool stream and allocates from the async pool,
-/// grabbing any block whose free has already retired).
+/// Conversion-pool churn: each conversion allocates from the async pool,
+/// recycling any block whose free has already retired.
 void hammer_conversions(stream_lineage_fixture& f,
                         rmm::cuda_stream_view stream,
                         int count,
@@ -282,20 +238,15 @@ void hammer_conversions(stream_lineage_fixture& f,
   for (int i = 0; i < count; ++i) {
     auto hb = make_host_batch(f, rows, /*seed=*/0x5A5A5A5A + i, false, false, stream);
     upload_to_gpu(f, hb, stream);
-    // Dropping `hb` here destroys the freshly converted representation and
-    // returns its blocks to the pool, maximizing recycling pressure.
   }
 }
 
-constexpr std::size_t kRows       = 1u << 20;  // 1M rows -> 8 MB INT64 payload
+constexpr std::size_t kRows       = 1u << 20;
 constexpr std::size_t kBytes      = kRows * sizeof(std::int64_t);
 constexpr std::size_t kScratchMiB = 64;
 
 }  // namespace
 
-//===----------------------------------------------------------------------===//
-// 1. Steal-path UAF stress: mid-flight column destruction under pool churn
-//===----------------------------------------------------------------------===//
 TEST_CASE("stolen table tolerates mid-flight column destruction under conversion pressure",
           "[stream_lineage]")
 {
@@ -319,22 +270,17 @@ TEST_CASE("stolen table tolerates mid-flight column destruction under conversion
     auto stolen = steal_table(batch, *f.gpu0, task_stream.view());
     REQUIRE(stolen != nullptr);
 
-    // Enqueue a long blocker, then the read: the D2D copy of the stolen column
-    // is guaranteed to still be pending when the host destroys the column.
     enqueue_blockers(scratch, kScratchMiB << 20, task_stream.view());
     void const* src = stolen->view().column(0).head();
     cudaMemcpyAsync(result_dev, src, kBytes, cudaMemcpyDeviceToDevice, task_stream.value());
 
-    // Destroy the column mid-flight. With release_table's rebind the free is
-    // enqueued on task_stream BEHIND the read; without it (pre-fix) it would
-    // retire instantly on the idle conversion-pool stream and the block could
-    // be recycled by the conversions below while the read is still pending.
+    // Pre-fix, this free retired on the idle conversion-pool stream and the
+    // block could be recycled under the still-pending read.
     {
       auto cols = stolen->release();
       cols[0].reset();
     }
 
-    // Hammer the conversion pool while the read is still blocked.
     hammer_conversions(f, hammer_stream.view(), 3, kRows / 4);
 
     cudaMemcpyAsync(
@@ -353,10 +299,6 @@ TEST_CASE("stolen table tolerates mid-flight column destruction under conversion
   cudaFree(result_dev);
 }
 
-//===----------------------------------------------------------------------===//
-// 2. Sensitivity check: the pre-fix binding (free on an idle foreign stream)
-//    corrupts the very read the fixed path protects.
-//===----------------------------------------------------------------------===//
 TEST_CASE("rebinding a stolen column back to an idle foreign stream reproduces pre-fix corruption",
           "[stream_lineage]")
 {
@@ -370,14 +312,13 @@ TEST_CASE("rebinding a stolen column back to an idle foreign stream reproduces p
 
   std::int64_t const seed = 42;
   rmm::cuda_stream task_stream;
-  rmm::cuda_stream foreign_stream;  // stands in for the idle conversion-pool stream
+  rmm::cuda_stream foreign_stream;
 
   auto batch = make_host_batch(f, kRows, seed, false, false, task_stream.view());
   upload_to_gpu(f, batch, task_stream.view());
   auto stolen = steal_table(batch, *f.gpu0, task_stream.view());
 
-  // Undo release_table's rebind: bind the column's buffers back to an idle
-  // foreign stream, exactly the binding release_table produced pre-fix.
+  // Recreate the pre-fix binding: buffers bound back to an idle foreign stream.
   auto cols = stolen->release();
   cols[0]   = cudf::rebind_stream(std::move(*cols[0]), foreign_stream.view());
 
@@ -385,11 +326,10 @@ TEST_CASE("rebinding a stolen column back to an idle foreign stream reproduces p
   enqueue_blockers(scratch, kScratchMiB << 20, task_stream.view());
   cudaMemcpyAsync(result_dev, src, kBytes, cudaMemcpyDeviceToDevice, task_stream.value());
 
-  // Destroy mid-flight: the free retires immediately on the idle foreign stream.
   cols[0].reset();
 
-  // The next same-stream allocation of the same size grabs the freed block and
-  // poisons it while the read above is still stuck behind the blocker.
+  // A same-stream allocation of the same size recycles the freed block; poison
+  // it while the read above is still stuck behind the blocker.
   rmm::device_buffer reuse{kBytes, foreign_stream.view(), f.gpu0->get_default_allocator()};
   bool const block_reused = reuse.data() == src;
   if (block_reused) {
@@ -408,7 +348,7 @@ TEST_CASE("rebinding a stolen column back to an idle foreign stream reproduces p
   }
 
   if (block_reused) {
-    // The harness must be able to see the pre-fix failure mode, otherwise the
+    // Anti-vacuity: the harness must detect the pre-fix failure mode, or the
     // clean runs in the other tests prove nothing.
     INFO("corrupted elements with pre-fix binding: " << corrupted << " of " << kRows);
     REQUIRE(corrupted > 0);
@@ -421,10 +361,6 @@ TEST_CASE("rebinding a stolen column back to an idle foreign stream reproduces p
   cudaFree(result_dev);
 }
 
-//===----------------------------------------------------------------------===//
-// 3. Reader events make a convert reclaim's mutable acquisition wait for
-//    in-flight reads
-//===----------------------------------------------------------------------===//
 TEST_CASE("reader events order a convert reclaim's mutable acquisition after in-flight reads",
           "[stream_lineage]")
 {
@@ -445,8 +381,6 @@ TEST_CASE("reader events order a convert reclaim's mutable acquisition after in-
   upload_to_gpu(f, batch, setup_stream.view());
   setup_stream.synchronize();
 
-  // Reader: enqueue a slow read of the converted buffers on its own stream and
-  // record a reader event AFTER the reads are enqueued (the API contract).
   {
     auto ro         = batch->to_read_only();
     auto view       = sirius::get_cudf_table_view(ro);
@@ -454,22 +388,15 @@ TEST_CASE("reader events order a convert reclaim's mutable acquisition after in-
     enqueue_blockers(scratch, kScratchMiB << 20, reader_stream.view());
     cudaMemcpyAsync(result_dev, src, kBytes, cudaMemcpyDeviceToDevice, reader_stream.value());
     ro.record_reader_event(reader_stream.view());
-  }  // shared lock dropped with the read still in flight — the pre-fix hazard window
+  }  // read lock dropped with the read still in flight
 
-  // The recorded event must be visible as a pending reader: with the shared
-  // lock already released, only the reader-event barrier can make the
-  // non-blocking mutable path decline. This also pins that the record was not
-  // a silent no-op.
+  // Anti-vacuity: the lock is already gone, so only a pending reader event can
+  // make the non-blocking mutable path decline.
   REQUIRE_FALSE(batch->try_to_mutable().has_value());
 
-  // Reclaimer: mirror the Sirius downgrade discipline (convertible_data_batch.hpp):
-  // acquire mutable access, rebind to the reclaim stream, then convert GPU ->
-  // host in place. With the reader-event barrier, to_mutable must host-block
-  // until the recorded reader work has completed, so the conversion cannot
-  // destroy the old GPU representation under the in-flight read.
+  // The production downgrade discipline (convertible_data_batch.hpp).
   {
     auto mut = batch->to_mutable();
-    // to_mutable returned, so the reader's recorded reads must be complete.
     CHECK(cudaStreamQuery(reader_stream.value()) == cudaSuccess);
     mut.rebind_stream(reclaim_stream.view());
     mut.convert_to<cucascade::host_data_representation>(
@@ -477,8 +404,6 @@ TEST_CASE("reader events order a convert reclaim's mutable acquisition after in-
   }
   REQUIRE(batch->try_to_mutable().has_value());
 
-  // Churn the pool: if the reclaim had freed the GPU buffers early these
-  // allocations would recycle them under the (by then already finished) read.
   hammer_conversions(f, reclaim_stream.view(), 3, kRows / 4);
 
   std::vector<std::int64_t> host_result(kRows);
@@ -497,23 +422,8 @@ TEST_CASE("reader events order a convert reclaim's mutable acquisition after in-
   cudaFree(result_dev);
 }
 
-//===----------------------------------------------------------------------===//
-// 4. Filtered-serving path: the owning_table_view record reaches the batch and
-//    orders a convert reclaim after the enqueued select's reads
-//===----------------------------------------------------------------------===//
-// Replicates the exact filtered scan serving sequence — driving the real
-// ingestibles here would need full scan plans and bind data, so the test runs
-// the same steps against the same APIs the production code uses:
-//   1. gpu_ingestible::materialize_table (cached branch): the batch's view is
-//      served as an owning_table_view whose type-erased owner is the batch's
-//      read_only_data_batch (the read-lock holder).
-//   2. post_filter_and_project: a select-like read of that view is enqueued on
-//      the task stream, then owning_table_view::record_reader_event(stream)
-//      — the call this test pins — records through the type erasure.
-//   3. The owner is dropped mid-flight (parquet reassigns `input` immediately
-//      after the select), releasing the read lock with the reads pending.
-//   4. A reclaim acquires mutable access, whose reader-event barrier waits
-//      for the recorded reads, then converts in place.
+// Driving the real ingestibles would need full scan plans and bind data, so the
+// test replays the filtered serving sequence against the same APIs they use.
 TEST_CASE("filtered serving records reader events through owning_table_view before owner drop",
           "[stream_lineage]")
 {
@@ -535,39 +445,24 @@ TEST_CASE("filtered serving records reader events through owning_table_view befo
   setup_stream.synchronize();
 
   {
-    // Step 1: serve the view under the read lock, owner type-erased into the
-    // owning_table_view — exactly gpu_ingestible::materialize_table.
     auto rbatch = batch->to_read_only();
     auto view   = sirius::get_cudf_table_view(rbatch);
     sirius::op::scan::owning_table_view served{std::move(rbatch), view};
 
-    // Step 2: enqueue a slow select-like read of the served view on the task
-    // stream, then record — after the enqueue, while the owner still holds the
-    // read lock.
     enqueue_blockers(scratch, kScratchMiB << 20, task_stream.view());
     void const* src = served.view().column(0).head();
     cudaMemcpyAsync(result_dev, src, kBytes, cudaMemcpyDeviceToDevice, task_stream.value());
     served.record_reader_event(task_stream.view());
 
-    // Step 3: drop the owner mid-flight, releasing the read lock — the
-    // parquet reassignment shape.
     served.drop();
   }
 
-  // Non-vacuity: the record must reach the underlying batch through the
-  // type-erased owner. The read lock is gone, so only a pending reader event
-  // can make the non-blocking mutable path decline here. If the pass-through
-  // silently no-ops (e.g. the owner concept stops matching
-  // read_only_data_batch), this fails immediately.
+  // Anti-vacuity: the read lock is already gone, so only a reader event
+  // recorded through the type-erased owner can make this decline.
   REQUIRE_FALSE(batch->try_to_mutable().has_value());
 
-  // Step 4: reclaim through the production downgrade discipline. The
-  // reader-event barrier makes to_mutable host-block until the recorded reads
-  // have completed, so the conversion cannot destroy the old GPU
-  // representation under the still-pending select.
   {
     auto mut = batch->to_mutable();
-    // to_mutable returned, so the select-like read must be complete.
     CHECK(cudaStreamQuery(task_stream.value()) == cudaSuccess);
     mut.rebind_stream(reclaim_stream.view());
     mut.convert_to<cucascade::host_data_representation>(
@@ -575,8 +470,6 @@ TEST_CASE("filtered serving records reader events through owning_table_view befo
   }
   REQUIRE(batch->try_to_mutable().has_value());
 
-  // Churn the pool: had the reclaim freed the GPU buffers early, these
-  // allocations would have recycled them under the still-pending read.
   hammer_conversions(f, reclaim_stream.view(), 3, kRows / 4);
 
   std::vector<std::int64_t> host_result(kRows);

--- a/test/cpp/scan_manager/test_memory_prefetcher_accounting.cpp
+++ b/test/cpp/scan_manager/test_memory_prefetcher_accounting.cpp
@@ -1,0 +1,525 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Admission-accounting gates for the memory prefetcher's reserve-then-gate
+// admission path (fix 0727f820). Three defects used to be silent:
+//
+//   - gate-then-reserve overshoot: the min_free_fraction headroom gate ran
+//     BEFORE make_reservation_or_null, so num_threads workers could pass the
+//     gate concurrently against the same headroom and overshoot the admission
+//     budget by up to num_threads x (breaching the free floor that protects
+//     pipeline task reservations from unreclaimable prefetched bytes);
+//   - decorative reservation: the conversion allocated through the space's
+//     default allocator while the admission reservation sat unused, so the
+//     space was transiently charged reserved-peak + actual-allocation
+//     (double count) for every in-flight prefetch;
+//   - phantom exclusive stream pool: per-worker streams from a dedicated
+//     exclusive_stream_pool carried zero copy traffic (covered by review;
+//     the header no longer declares _stream_pool).
+//
+// Gates here: admission keeps the floor including concurrent workers'
+// in-flight reservations; the attached reservation genuinely draws down
+// during conversion (space charged the peak ONCE, never peak + actual); the
+// converted table round-trips through the per-worker-stream + tracker-attach
+// path bit-exactly; and a non-admittable reservation backs the sweep off
+// cleanly (_stops_reservation) without leaking arenas.
+//
+// The environment mirrors production accounting: Sirius configures per-THREAD
+// allocation tracking (sirius_config.cpp: per_stream_reservation = false), so
+// the builder here calls track_reservation_per_stream(false). The prefetcher's
+// tracker attach keys on the worker's private stream but the tracker resolves
+// per thread — with the cucascade-default per-STREAM tracking the conversion's
+// allocations (made on a round-robin pool stream) would bypass the arena
+// entirely.
+//
+// The diagnostic gate counters (_stops_headroom / _stops_reservation) have no
+// accessors; they are logged once by stop(), so the tests parse them out of a
+// recording log sink.
+
+#include "utils/log_test_utils.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream.hpp>
+#include <rmm/device_buffer.hpp>
+
+#include <cuda_runtime.h>
+
+#include <catch.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/memory/memory_space.hpp>
+#include <cucascade/memory/reservation_manager_configurator.hpp>
+#include <data/data_batch_utils.hpp>
+#include <data/sirius_converter_registry.hpp>
+#include <memory/sirius_memory_reservation_manager.hpp>
+#include <scan_manager/load_balancing_scan_batch_coalescer.hpp>
+#include <scan_manager/memory_prefetcher.hpp>
+#include <scan_manager/split_connector.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <regex>
+#include <stop_token>
+#include <string>
+#include <thread>
+#include <vector>
+
+using sirius::scan_manager::databatch_provider;
+using sirius::scan_manager::load_balancing_scan_batch_coalescer;
+using sirius::scan_manager::memory_prefetcher;
+using sirius::scan_manager::memory_prefetcher_config;
+using sirius::scan_manager::split_connector;
+
+namespace {
+
+constexpr std::size_t MiB = 1ull << 20;
+
+/// Per-test environment: a fresh reservation manager over a 512MB GPU space
+/// (reservation limit 384MB = 0.75 x capacity) with per-THREAD allocation
+/// tracking, matching the production Sirius configuration the prefetcher's
+/// tracker attach relies on. Fresh per test case so every case starts from an
+/// empty space and exact availability arithmetic.
+struct prefetcher_env {
+  static constexpr std::size_t gpu_capacity = 512 * MiB;
+  static constexpr double limit_ratio       = 0.75;
+
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> mgr;
+  cucascade::memory::memory_space* gpu_space;
+  cucascade::memory::memory_space* host_space;
+  rmm::cuda_stream conv_stream;  // converters need a non-default stream
+
+  prefetcher_env()
+  {
+    sirius::converter_registry::reset_for_testing();
+
+    cucascade::memory::reservation_manager_configurator builder;
+    builder.set_number_of_gpus(1)
+      .set_gpu_usage_limit(gpu_capacity)
+      .set_reservation_fraction_per_gpu(limit_ratio)
+      .set_per_numa_region_capacity(1ull << 30)
+      .use_gpu_id_as_host_id()
+      .set_reservation_fraction_per_numa_region(limit_ratio)
+      .track_reservation_per_stream(false);  // production default: per-thread tracking
+
+    auto space_configs = builder.build();
+    mgr =
+      std::make_unique<sirius::memory::sirius_memory_reservation_manager>(std::move(space_configs));
+    sirius::converter_registry::initialize();
+
+    gpu_space  = mgr->get_memory_space(cucascade::memory::Tier::GPU, 0);
+    host_space = mgr->get_memory_space(cucascade::memory::Tier::HOST, 0);
+  }
+
+  rmm::cuda_stream_view stream() { return conv_stream.view(); }
+};
+
+/// HOST-resident single-INT32-column batch of @p n_rows rows with the
+/// deterministic per-row pattern seed + 7*i — the shape a pinned scan's
+/// per-query split arrives in, which the prefetcher upgrades to GPU tier.
+/// Built GPU-first then converted down, like the pin path; the GPU staging
+/// is fully released before returning so it does not perturb availability.
+std::shared_ptr<cucascade::data_batch> make_host_batch(prefetcher_env& e,
+                                                       std::size_t n_rows,
+                                                       int32_t seed)
+{
+  auto mr     = e.gpu_space->get_default_allocator();
+  auto stream = e.stream();
+
+  std::vector<int32_t> values(n_rows);
+  for (std::size_t i = 0; i < n_rows; ++i) {
+    values[i] = seed + static_cast<int32_t>(7 * i);
+  }
+
+  auto col = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                       static_cast<cudf::size_type>(n_rows),
+                                       cudf::mask_state::UNALLOCATED,
+                                       stream,
+                                       mr);
+  cudaMemcpyAsync(col->mutable_view().data<int32_t>(),
+                  values.data(),
+                  sizeof(int32_t) * n_rows,
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  stream.synchronize();
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col));
+  cucascade::gpu_table_representation gpu_repr(
+    std::make_unique<cudf::table>(std::move(cols)), *e.gpu_space, stream);
+  auto host_repr = sirius::converter_registry::get().convert<cucascade::host_data_representation>(
+    gpu_repr, e.host_space, stream);
+  stream.synchronize();
+  return cucascade::data_batch::make(sirius::get_next_batch_id(), std::move(host_repr));
+}
+
+/// Serves its scripted batches in order, then ends the stream — the minimal
+/// provider drain_cached_provider needs to load a connector.
+struct scripted_provider final : databatch_provider {
+  std::vector<std::shared_ptr<cucascade::data_batch>> batches;
+  std::size_t served{0};
+
+  databatch_provider::batch get_next_batch() override
+  {
+    databatch_provider::batch out;
+    if (served < batches.size()) { out.data = batches[served++]; }
+    return out;
+  }
+};
+
+/// Connector pre-loaded with resident splits over @p batches (and closed —
+/// still sweepable: the prefetcher only exits once closed AND drained).
+std::shared_ptr<split_connector> make_loaded_connector(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& batches)
+{
+  auto connector = std::make_shared<split_connector>();
+  scripted_provider provider;
+  provider.batches = batches;
+  std::stop_source stop;
+  load_balancing_scan_batch_coalescer::drain_cached_provider(
+    provider, *connector, stop.get_token(), /*row_filter_pending=*/false);
+  return connector;
+}
+
+std::size_t batch_size_bytes(cucascade::data_batch& batch)
+{
+  auto ro = batch.try_to_read_only();
+  REQUIRE(ro);
+  REQUIRE(ro->get_data() != nullptr);
+  return ro->get_data()->get_size_in_bytes();
+}
+
+cucascade::memory::Tier batch_tier(cucascade::data_batch& batch)
+{
+  auto ro = batch.try_to_read_only();
+  REQUIRE(ro);
+  return ro->get_current_tier();
+}
+
+template <class Pred>
+bool wait_until(Pred&& pred, std::chrono::milliseconds timeout)
+{
+  auto const deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (pred()) { return true; }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  return pred();
+}
+
+/// The gate counters logged once by memory_prefetcher::stop() — the only
+/// surface they are readable through (no accessors on the class).
+struct stop_counters {
+  bool found{false};
+  std::size_t headroom{0};
+  std::size_t reservation{0};
+};
+
+stop_counters parse_stop_counters(const std::vector<sirius::test::recording_log_sink::record>& recs)
+{
+  static const std::regex kStops(R"(stops: headroom=(\d+) reservation=(\d+))");
+  stop_counters out;
+  for (auto it = recs.rbegin(); it != recs.rend(); ++it) {
+    if (it->message.find("[memory_prefetcher] stopping") == std::string::npos) { continue; }
+    std::smatch match;
+    if (std::regex_search(it->message, match, kStops)) {
+      out.found       = true;
+      out.headroom    = std::stoul(match[1]);
+      out.reservation = std::stoul(match[2]);
+      return out;
+    }
+  }
+  return out;
+}
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// 1. Admission floor invariant under concurrent workers
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("prefetcher admission floor holds against concurrent workers",
+          "[memory_prefetcher][scan_manager]")
+{
+  prefetcher_env e;
+  sirius::test::scoped_recording_log_sink log{"info"};
+
+  // Geometry: three 90MB host batches into a 512MB space with a 0.9 floor
+  // over the 384MB reservation limit (min_free_bytes = 345.6MB). ONE
+  // admission clears the floor (512-90 = 422 >= 345.6); TWO do not
+  // (512-180 = 332 < 345.6). The old gate-then-reserve order let all three
+  // workers pass the same headroom check concurrently (available 512 >=
+  // 90+345.6 for each of them) and convert up to 3 batches; reserve-first
+  // makes every worker's floor check see the others' in-flight reservations,
+  // so exactly one batch may ever be admitted, on every interleaving.
+  // (90MB, not more: the worst concurrent charge — one converted batch plus
+  // all three workers' probing reservations, 4 x 90 = 360MB — must stay
+  // clearly under the 384MB reservation limit so refusals are always the
+  // floor's, never the reservation's.)
+  constexpr std::size_t batch_rows = (90ull << 20) / sizeof(int32_t);  // 90MB of int32
+  constexpr double min_free_fraction{0.9};
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> batches{make_host_batch(e, batch_rows, 1),
+                                                              make_host_batch(e, batch_rows, 2),
+                                                              make_host_batch(e, batch_rows, 3)};
+  auto connector = make_loaded_connector(batches);
+
+  auto const floor_bytes =
+    static_cast<std::size_t>(min_free_fraction * e.gpu_space->get_max_memory());
+  auto const avail_before = e.gpu_space->get_available_memory();
+  auto const batch_bytes  = batch_size_bytes(*batches[0]);
+
+  // Geometry sanity: this test only means something if exactly one admission
+  // fits above the floor.
+  REQUIRE(avail_before - batch_bytes >= floor_bytes);
+  REQUIRE(avail_before - 2 * batch_bytes < floor_bytes);
+
+  memory_prefetcher_config cfg;
+  cfg.enable            = true;
+  cfg.num_threads       = 3;  // one worker per queued batch: maximal race exposure
+  cfg.min_free_fraction = min_free_fraction;
+  cfg.poll_interval_ms  = 1;
+  cfg.drain_quiet_ms    = 50;
+
+  stop_counters counters;
+  {
+    memory_prefetcher prefetcher(cfg, {connector}, e.gpu_space);
+    REQUIRE(
+      wait_until([&] { return prefetcher.batches_prefetched() >= 1; }, std::chrono::seconds(60)));
+    // Grace period: give the other two workers every chance to (incorrectly)
+    // admit on the same headroom before we look.
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    prefetcher.stop();
+
+    // The floor admits exactly one batch, no matter how the workers interleave.
+    REQUIRE(prefetcher.batches_prefetched() == 1);
+    REQUIRE(prefetcher.bytes_prefetched() <= avail_before - floor_bytes);
+    counters = parse_stop_counters(log.records());
+  }
+
+  // Steady state: the floor held, nothing reserved is left behind.
+  REQUIRE(e.gpu_space->get_available_memory() >= floor_bytes);
+  REQUIRE(e.gpu_space->get_active_reservation_count() == 0);
+
+  // Exactly one batch reached GPU tier; the other two are still host-resident.
+  std::size_t gpu_resident = 0;
+  for (auto const& batch : batches) {
+    if (batch_tier(*batch) == cucascade::memory::Tier::GPU) { ++gpu_resident; }
+  }
+  REQUIRE(gpu_resident == 1);
+
+  // Refusals took the headroom path: the peak reservation itself is always
+  // admittable in this geometry (worst concurrent charge 4x90 = 360MB, under
+  // the 384MB limit), so the workers that lost the race charged a
+  // reservation, saw the floor fail post-charge, and released it
+  // (_stops_headroom) rather than failing the reservation.
+  REQUIRE(counters.found);
+  REQUIRE(counters.headroom >= 1);
+  REQUIRE(counters.reservation == 0);
+}
+
+//===----------------------------------------------------------------------===//
+// 2. Reservation draw-down: conversion is charged once, never peak + actual
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("prefetcher conversion draws down its reservation instead of double-counting",
+          "[memory_prefetcher][scan_manager]")
+{
+  prefetcher_env e;
+
+  // One 128MB batch, floor low enough to never interfere. With the
+  // reservation attached to the worker's allocation tracker, the conversion's
+  // device allocations land inside the reserved arena: total charged stays at
+  // the 128MB peak throughout. The old decorative reservation charged
+  // peak + actual (~256MB) for the whole copy — far below the threshold the
+  // sampler enforces here.
+  constexpr std::size_t batch_rows = 32ull << 20;  // 128MB of int32
+  constexpr std::size_t slack      = 16 * MiB;     // alignment + converter temps
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> batches{make_host_batch(e, batch_rows, 11)};
+  auto connector = make_loaded_connector(batches);
+
+  auto const batch_bytes  = batch_size_bytes(*batches[0]);
+  auto const avail_before = e.gpu_space->get_available_memory();
+
+  memory_prefetcher_config cfg;
+  cfg.enable            = true;
+  cfg.num_threads       = 1;
+  cfg.min_free_fraction = 0.05;
+  cfg.poll_interval_ms  = 1;
+  cfg.drain_quiet_ms    = 50;
+
+  // Availability sampler: runs for the entire prefetcher lifetime and records
+  // the minimum. The double-count window under the old code spanned the whole
+  // H2D copy (milliseconds), so a tight loop cannot miss it; under the fix the
+  // minimum provably never goes below avail_before - peak - slack.
+  std::atomic<bool> sampling{true};
+  std::atomic<std::size_t> min_available{avail_before};
+  std::thread sampler([&] {
+    while (sampling.load(std::memory_order_relaxed)) {
+      auto const now = e.gpu_space->get_available_memory();
+      auto prev      = min_available.load(std::memory_order_relaxed);
+      while (now < prev &&
+             !min_available.compare_exchange_weak(prev, now, std::memory_order_relaxed)) {}
+    }
+  });
+
+  {
+    memory_prefetcher prefetcher(cfg, {connector}, e.gpu_space);
+    REQUIRE(
+      wait_until([&] { return prefetcher.batches_prefetched() >= 1; }, std::chrono::seconds(60)));
+    prefetcher.stop();
+    REQUIRE(prefetcher.batches_prefetched() == 1);
+    REQUIRE(prefetcher.bytes_prefetched() == batch_bytes);
+  }
+  sampling.store(false, std::memory_order_relaxed);
+  sampler.join();
+
+  // No transient double count: at no point was the space charged more than
+  // the admission peak (plus alignment/temp slack). Pre-fix this dipped to
+  // roughly avail_before - 2*batch_bytes for the whole conversion.
+  REQUIRE(min_available.load() + slack >= avail_before - batch_bytes);
+
+  // Steady state: the space is charged for the converted batch exactly once,
+  // and the reservation arena was fully detached and released.
+  auto const avail_after = e.gpu_space->get_available_memory();
+  REQUIRE(avail_before - avail_after <= batch_bytes + slack);
+  REQUIRE(avail_before - avail_after + slack >= batch_bytes);
+  REQUIRE(e.gpu_space->get_active_reservation_count() == 0);
+  REQUIRE(e.gpu_space->get_total_reserved_memory() == 0);
+}
+
+//===----------------------------------------------------------------------===//
+// 3. Data-path correctness through the per-worker-stream + tracker-attach path
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("prefetched batch converts to GPU tier bit-exactly and reads back on another stream",
+          "[memory_prefetcher][scan_manager]")
+{
+  prefetcher_env e;
+
+  constexpr std::size_t n_rows = 100'000;
+  constexpr int32_t seed       = 42;
+  std::vector<std::shared_ptr<cucascade::data_batch>> batches{make_host_batch(e, n_rows, seed)};
+  auto connector = make_loaded_connector(batches);
+  REQUIRE(batch_tier(*batches[0]) == cucascade::memory::Tier::HOST);
+
+  memory_prefetcher_config cfg;
+  cfg.enable            = true;
+  cfg.num_threads       = 1;
+  cfg.min_free_fraction = 0.05;
+  cfg.poll_interval_ms  = 1;
+  cfg.drain_quiet_ms    = 50;
+
+  {
+    memory_prefetcher prefetcher(cfg, {connector}, e.gpu_space);
+    REQUIRE(
+      wait_until([&] { return prefetcher.batches_prefetched() >= 1; }, std::chrono::seconds(60)));
+    prefetcher.stop();
+    REQUIRE(prefetcher.batches_prefetched() == 1);
+  }
+
+  // The batch was upgraded in place: GPU tier, placed in the target space.
+  auto ro = batches[0]->try_to_read_only();
+  REQUIRE(ro);
+  REQUIRE(ro->get_current_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(ro->get_data() != nullptr);
+
+  // Read the converted table back on a stream the conversion never saw —
+  // the conversion synchronized before releasing the batch lock, so the
+  // contents must be stable and bit-exact from any stream.
+  auto const view = ro->get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
+  REQUIRE(view.num_columns() == 1);
+  REQUIRE(static_cast<std::size_t>(view.num_rows()) == n_rows);
+
+  rmm::cuda_stream reader_stream;
+  std::vector<int32_t> host_values(n_rows);
+  cudaMemcpyAsync(host_values.data(),
+                  view.column(0).data<int32_t>(),
+                  sizeof(int32_t) * n_rows,
+                  cudaMemcpyDeviceToHost,
+                  reader_stream.value());
+  reader_stream.synchronize();
+
+  for (std::size_t i = 0; i < n_rows; ++i) {
+    if (host_values[i] != seed + static_cast<int32_t>(7 * i)) {
+      FAIL("row " << i << ": expected " << seed + static_cast<int32_t>(7 * i) << ", got "
+                  << host_values[i]);
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// 4. Reservation-refused back-off (_stops_reservation), no crash, no leak
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("prefetcher backs off cleanly when the peak reservation cannot be admitted",
+          "[memory_prefetcher][scan_manager]")
+{
+  prefetcher_env e;
+  sirius::test::scoped_recording_log_sink log{"info"};
+
+  // 360MB of ballast against the 384MB reservation limit: a 32MB peak
+  // reservation can never be admitted (360+32 > 384), so every sweep stops on
+  // the make_reservation_or_null path (_stops_reservation) before the floor
+  // is even consulted. The sweep must keep backing off without converting,
+  // crashing, or leaking a reservation arena.
+  constexpr std::size_t batch_rows   = 8ull << 20;  // 32MB of int32
+  constexpr std::size_t ballast_size = 360 * MiB;
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> batches{make_host_batch(e, batch_rows, 5)};
+  auto connector = make_loaded_connector(batches);
+
+  rmm::device_buffer ballast(ballast_size, e.stream(), e.gpu_space->get_default_allocator());
+  e.stream().synchronize();
+  auto const avail_before = e.gpu_space->get_available_memory();
+
+  memory_prefetcher_config cfg;
+  cfg.enable            = true;
+  cfg.num_threads       = 1;
+  cfg.min_free_fraction = 0.05;
+  cfg.poll_interval_ms  = 1;
+  cfg.drain_quiet_ms    = 50;
+
+  stop_counters counters;
+  {
+    memory_prefetcher prefetcher(cfg, {connector}, e.gpu_space);
+    // Let it sweep (and be refused) repeatedly.
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    prefetcher.stop();
+    REQUIRE(prefetcher.batches_prefetched() == 0);
+    REQUIRE(prefetcher.bytes_prefetched() == 0);
+    counters = parse_stop_counters(log.records());
+  }
+
+  // Refusals took the reservation path, never the (post-charge) headroom path.
+  REQUIRE(counters.found);
+  REQUIRE(counters.reservation >= 1);
+  REQUIRE(counters.headroom == 0);
+
+  // Nothing converted, nothing charged, nothing leaked.
+  REQUIRE(batch_tier(*batches[0]) == cucascade::memory::Tier::HOST);
+  REQUIRE(e.gpu_space->get_available_memory() == avail_before);
+  REQUIRE(e.gpu_space->get_active_reservation_count() == 0);
+}

--- a/test/cpp/scan_manager/test_memory_prefetcher_accounting.cpp
+++ b/test/cpp/scan_manager/test_memory_prefetcher_accounting.cpp
@@ -14,34 +14,6 @@
  * limitations under the License.
  */
 
-// Admission-accounting gates for the memory prefetcher's reserve-then-gate
-// admission path. Two pre-fix defects were silent:
-//
-//   - gate-then-reserve overshoot: the min_free_fraction headroom gate ran
-//     BEFORE make_reservation_or_null, so num_threads workers could pass the
-//     gate concurrently against the same headroom and overshoot the admission
-//     budget by up to num_threads x (breaching the free floor that protects
-//     pipeline task reservations from unreclaimable prefetched bytes);
-//   - decorative reservation: the conversion allocated through the space's
-//     default allocator while the admission reservation sat unused, so the
-//     space was transiently charged reserved-peak + actual-allocation
-//     (double count) for every in-flight prefetch.
-//
-// Gates here: admission keeps the floor including concurrent workers'
-// in-flight reservations; the attached reservation genuinely draws down
-// during conversion (space charged the peak ONCE, never peak + actual); the
-// converted table round-trips through the per-worker-stream + tracker-attach
-// path bit-exactly; and a non-admittable reservation backs the sweep off
-// cleanly (_stops_reservation) without leaking arenas.
-//
-// The environment mirrors production accounting: Sirius configures per-THREAD
-// allocation tracking (sirius_config.cpp: per_stream_reservation = false), so
-// the builder here calls track_reservation_per_stream(false). The prefetcher's
-// tracker attach keys on the worker's private stream but the tracker resolves
-// per thread — with the cucascade-default per-STREAM tracking the conversion's
-// allocations (made on a round-robin pool stream) would bypass the arena
-// entirely.
-
 #include "utils/log_test_utils.hpp"
 
 #include <cudf/column/column.hpp>
@@ -89,11 +61,6 @@ namespace {
 
 constexpr std::size_t MiB = 1ull << 20;
 
-/// Per-test environment: a fresh reservation manager over a 512MB GPU space
-/// (reservation limit 384MB = 0.75 x capacity) with per-THREAD allocation
-/// tracking, matching the production Sirius configuration the prefetcher's
-/// tracker attach relies on. Fresh per test case so every case starts from an
-/// empty space and exact availability arithmetic.
 struct prefetcher_env {
   static constexpr std::size_t gpu_capacity = 512 * MiB;
   static constexpr double limit_ratio       = 0.75;
@@ -114,7 +81,9 @@ struct prefetcher_env {
       .set_per_numa_region_capacity(1ull << 30)
       .use_gpu_id_as_host_id()
       .set_reservation_fraction_per_numa_region(limit_ratio)
-      .track_reservation_per_stream(false);  // production default: per-thread tracking
+      // Per-thread tracking, the production default: with per-stream tracking
+      // the conversion's allocations would bypass the attached reservation.
+      .track_reservation_per_stream(false);
 
     auto space_configs = builder.build();
     mgr =
@@ -128,11 +97,8 @@ struct prefetcher_env {
   rmm::cuda_stream_view stream() { return conv_stream.view(); }
 };
 
-/// HOST-resident single-INT32-column batch of @p n_rows rows with the
-/// deterministic per-row pattern seed + 7*i — the shape a pinned scan's
-/// per-query split arrives in, which the prefetcher upgrades to GPU tier.
-/// Built GPU-first then converted down, like the pin path; the GPU staging
-/// is fully released before returning so it does not perturb availability.
+/// Host-resident INT32 batch with pattern seed + 7*i. The GPU staging is fully
+/// released before returning so it does not perturb availability arithmetic.
 std::shared_ptr<cucascade::data_batch> make_host_batch(prefetcher_env& e,
                                                        std::size_t n_rows,
                                                        int32_t seed)
@@ -167,8 +133,6 @@ std::shared_ptr<cucascade::data_batch> make_host_batch(prefetcher_env& e,
   return cucascade::data_batch::make(sirius::get_next_batch_id(), std::move(host_repr));
 }
 
-/// Serves its scripted batches in order, then ends the stream — the minimal
-/// provider drain_cached_provider needs to load a connector.
 struct scripted_provider final : databatch_provider {
   std::vector<std::shared_ptr<cucascade::data_batch>> batches;
   std::size_t served{0};
@@ -181,8 +145,8 @@ struct scripted_provider final : databatch_provider {
   }
 };
 
-/// Connector pre-loaded with resident splits over @p batches (and closed —
-/// still sweepable: the prefetcher only exits once closed AND drained).
+/// Pre-loaded and closed — still sweepable: the prefetcher only exits once a
+/// connector is closed AND drained.
 std::shared_ptr<split_connector> make_loaded_connector(
   const std::vector<std::shared_ptr<cucascade::data_batch>>& batches)
 {
@@ -221,8 +185,7 @@ bool wait_until(Pred&& pred, std::chrono::milliseconds timeout)
   return pred();
 }
 
-/// The gate counters logged once by memory_prefetcher::stop() — the only
-/// surface they are readable through (no accessors on the class).
+/// The stop() log line is the only surface the gate counters are readable through.
 struct stop_counters {
   bool found{false};
   std::size_t headroom{0};
@@ -248,29 +211,15 @@ stop_counters parse_stop_counters(const std::vector<sirius::test::recording_log_
 
 }  // namespace
 
-//===----------------------------------------------------------------------===//
-// 1. Admission floor invariant under concurrent workers
-//===----------------------------------------------------------------------===//
-
 TEST_CASE("prefetcher admission floor holds against concurrent workers",
           "[memory_prefetcher][scan_manager]")
 {
   prefetcher_env e;
   sirius::test::scoped_recording_log_sink log{"info"};
 
-  // Geometry: three 90MB host batches into a 512MB space with a 0.9 floor
-  // over the 384MB reservation limit (min_free_bytes = 345.6MB). ONE
-  // admission clears the floor (512-90 = 422 >= 345.6); TWO do not
-  // (512-180 = 332 < 345.6). The old gate-then-reserve order let all three
-  // workers pass the same headroom check concurrently (available 512 >=
-  // 90+345.6 for each of them) and convert up to 3 batches; reserve-first
-  // makes every worker's floor check see the others' in-flight reservations,
-  // so exactly one batch may ever be admitted, on every interleaving.
-  // (90MB, not more: the worst concurrent charge — one converted batch plus
-  // all three workers' probing reservations, 4 x 90 = 360MB — must stay
-  // clearly under the 384MB reservation limit so refusals are always the
-  // floor's, never the reservation's.)
-  constexpr std::size_t batch_rows = (90ull << 20) / sizeof(int32_t);  // 90MB of int32
+  // One 90MB admission clears the 0.9 floor, two do not. Pre-fix (gate before
+  // reserve) all three workers could pass the same headroom check and convert.
+  constexpr std::size_t batch_rows = (90ull << 20) / sizeof(int32_t);
   constexpr double min_free_fraction{0.9};
 
   std::vector<std::shared_ptr<cucascade::data_batch>> batches{make_host_batch(e, batch_rows, 1),
@@ -283,8 +232,7 @@ TEST_CASE("prefetcher admission floor holds against concurrent workers",
   auto const avail_before = e.gpu_space->get_available_memory();
   auto const batch_bytes  = batch_size_bytes(*batches[0]);
 
-  // Geometry sanity: this test only means something if exactly one admission
-  // fits above the floor.
+  // Anti-vacuity: the test only means something if exactly one admission fits.
   REQUIRE(avail_before - batch_bytes >= floor_bytes);
   REQUIRE(avail_before - 2 * batch_bytes < floor_bytes);
 
@@ -300,53 +248,38 @@ TEST_CASE("prefetcher admission floor holds against concurrent workers",
     memory_prefetcher prefetcher(cfg, {connector}, e.gpu_space);
     REQUIRE(
       wait_until([&] { return prefetcher.batches_prefetched() >= 1; }, std::chrono::seconds(60)));
-    // Grace period: give the other two workers every chance to (incorrectly)
-    // admit on the same headroom before we look.
+    // Give the other two workers every chance to (incorrectly) admit on the
+    // same headroom before looking.
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
     prefetcher.stop();
 
-    // The floor admits exactly one batch, no matter how the workers interleave.
     REQUIRE(prefetcher.batches_prefetched() == 1);
     REQUIRE(prefetcher.bytes_prefetched() <= avail_before - floor_bytes);
     counters = parse_stop_counters(log.records());
   }
 
-  // Steady state: the floor held, nothing reserved is left behind.
   REQUIRE(e.gpu_space->get_available_memory() >= floor_bytes);
   REQUIRE(e.gpu_space->get_active_reservation_count() == 0);
 
-  // Exactly one batch reached GPU tier; the other two are still host-resident.
   std::size_t gpu_resident = 0;
   for (auto const& batch : batches) {
     if (batch_tier(*batch) == cucascade::memory::Tier::GPU) { ++gpu_resident; }
   }
   REQUIRE(gpu_resident == 1);
 
-  // Refusals took the headroom path: the peak reservation itself is always
-  // admittable in this geometry (worst concurrent charge 4x90 = 360MB, under
-  // the 384MB limit), so the workers that lost the race charged a
-  // reservation, saw the floor fail post-charge, and released it
-  // (_stops_headroom) rather than failing the reservation.
+  // The peak reservation is always admittable here (worst concurrent charge
+  // 4 x 90MB, under the 384MB limit), so losing workers must have stopped on
+  // the post-charge floor check, never on the reservation.
   REQUIRE(counters.found);
   REQUIRE(counters.headroom >= 1);
   REQUIRE(counters.reservation == 0);
 }
-
-//===----------------------------------------------------------------------===//
-// 2. Reservation draw-down: conversion is charged once, never peak + actual
-//===----------------------------------------------------------------------===//
 
 TEST_CASE("prefetcher conversion draws down its reservation instead of double-counting",
           "[memory_prefetcher][scan_manager]")
 {
   prefetcher_env e;
 
-  // One 128MB batch, floor low enough to never interfere. With the
-  // reservation attached to the worker's allocation tracker, the conversion's
-  // device allocations land inside the reserved arena: total charged stays at
-  // the 128MB peak throughout. The old decorative reservation charged
-  // peak + actual (~256MB) for the whole copy — far below the threshold the
-  // sampler enforces here.
   constexpr std::size_t batch_rows = 32ull << 20;  // 128MB of int32
   constexpr std::size_t slack      = 16 * MiB;     // alignment + converter temps
 
@@ -363,10 +296,8 @@ TEST_CASE("prefetcher conversion draws down its reservation instead of double-co
   cfg.poll_interval_ms  = 1;
   cfg.drain_quiet_ms    = 50;
 
-  // Availability sampler: runs for the entire prefetcher lifetime and records
-  // the minimum. The double-count window under the old code spanned the whole
-  // H2D copy (milliseconds), so a tight loop cannot miss it; under the fix the
-  // minimum provably never goes below avail_before - peak - slack.
+  // Availability sampler. The pre-fix double-count window spanned the whole
+  // H2D copy (milliseconds), so a tight sampling loop cannot miss it.
   std::atomic<bool> sampling{true};
   std::atomic<std::size_t> min_available{avail_before};
   std::thread sampler([&] {
@@ -389,23 +320,16 @@ TEST_CASE("prefetcher conversion draws down its reservation instead of double-co
   sampling.store(false, std::memory_order_relaxed);
   sampler.join();
 
-  // No transient double count: at no point was the space charged more than
-  // the admission peak (plus alignment/temp slack). Pre-fix this dipped to
-  // roughly avail_before - 2*batch_bytes for the whole conversion.
+  // Pre-fix (decorative reservation) this dipped to roughly
+  // avail_before - 2 * batch_bytes for the whole conversion.
   REQUIRE(min_available.load() + slack >= avail_before - batch_bytes);
 
-  // Steady state: the space is charged for the converted batch exactly once,
-  // and the reservation arena was fully detached and released.
   auto const avail_after = e.gpu_space->get_available_memory();
   REQUIRE(avail_before - avail_after <= batch_bytes + slack);
   REQUIRE(avail_before - avail_after + slack >= batch_bytes);
   REQUIRE(e.gpu_space->get_active_reservation_count() == 0);
   REQUIRE(e.gpu_space->get_total_reserved_memory() == 0);
 }
-
-//===----------------------------------------------------------------------===//
-// 3. Data-path correctness through the per-worker-stream + tracker-attach path
-//===----------------------------------------------------------------------===//
 
 TEST_CASE("prefetched batch converts to GPU tier bit-exactly and reads back on another stream",
           "[memory_prefetcher][scan_manager]")
@@ -433,15 +357,11 @@ TEST_CASE("prefetched batch converts to GPU tier bit-exactly and reads back on a
     REQUIRE(prefetcher.batches_prefetched() == 1);
   }
 
-  // The batch was upgraded in place: GPU tier, placed in the target space.
   auto ro = batches[0]->try_to_read_only();
   REQUIRE(ro);
   REQUIRE(ro->get_current_tier() == cucascade::memory::Tier::GPU);
   REQUIRE(ro->get_data() != nullptr);
 
-  // Read the converted table back on a stream the conversion never saw —
-  // the conversion synchronized before releasing the batch lock, so the
-  // contents must be stable and bit-exact from any stream.
   auto const view = ro->get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
   REQUIRE(view.num_columns() == 1);
   REQUIRE(static_cast<std::size_t>(view.num_rows()) == n_rows);
@@ -463,21 +383,15 @@ TEST_CASE("prefetched batch converts to GPU tier bit-exactly and reads back on a
   }
 }
 
-//===----------------------------------------------------------------------===//
-// 4. Reservation-refused back-off (_stops_reservation), no crash, no leak
-//===----------------------------------------------------------------------===//
-
 TEST_CASE("prefetcher backs off cleanly when the peak reservation cannot be admitted",
           "[memory_prefetcher][scan_manager]")
 {
   prefetcher_env e;
   sirius::test::scoped_recording_log_sink log{"info"};
 
-  // 360MB of ballast against the 384MB reservation limit: a 32MB peak
-  // reservation can never be admitted (360+32 > 384), so every sweep stops on
-  // the make_reservation_or_null path (_stops_reservation) before the floor
-  // is even consulted. The sweep must keep backing off without converting,
-  // crashing, or leaking a reservation arena.
+  // 360MB of ballast against the 384MB reservation limit: the 32MB peak
+  // reservation can never be admitted, so every sweep stops on the
+  // reservation path before the floor is even consulted.
   constexpr std::size_t batch_rows   = 8ull << 20;  // 32MB of int32
   constexpr std::size_t ballast_size = 360 * MiB;
 
@@ -506,12 +420,10 @@ TEST_CASE("prefetcher backs off cleanly when the peak reservation cannot be admi
     counters = parse_stop_counters(log.records());
   }
 
-  // Refusals took the reservation path, never the (post-charge) headroom path.
   REQUIRE(counters.found);
   REQUIRE(counters.reservation >= 1);
   REQUIRE(counters.headroom == 0);
 
-  // Nothing converted, nothing charged, nothing leaked.
   REQUIRE(batch_tier(*batches[0]) == cucascade::memory::Tier::HOST);
   REQUIRE(e.gpu_space->get_available_memory() == avail_before);
   REQUIRE(e.gpu_space->get_active_reservation_count() == 0);

--- a/test/cpp/scan_manager/test_memory_prefetcher_accounting.cpp
+++ b/test/cpp/scan_manager/test_memory_prefetcher_accounting.cpp
@@ -15,7 +15,7 @@
  */
 
 // Admission-accounting gates for the memory prefetcher's reserve-then-gate
-// admission path (fix 0727f820). Three defects used to be silent:
+// admission path. Two pre-fix defects were silent:
 //
 //   - gate-then-reserve overshoot: the min_free_fraction headroom gate ran
 //     BEFORE make_reservation_or_null, so num_threads workers could pass the
@@ -25,10 +25,7 @@
 //   - decorative reservation: the conversion allocated through the space's
 //     default allocator while the admission reservation sat unused, so the
 //     space was transiently charged reserved-peak + actual-allocation
-//     (double count) for every in-flight prefetch;
-//   - phantom exclusive stream pool: per-worker streams from a dedicated
-//     exclusive_stream_pool carried zero copy traffic (covered by review;
-//     the header no longer declares _stream_pool).
+//     (double count) for every in-flight prefetch.
 //
 // Gates here: admission keeps the floor including concurrent workers'
 // in-flight reservations; the attached reservation genuinely draws down
@@ -44,10 +41,6 @@
 // per thread — with the cucascade-default per-STREAM tracking the conversion's
 // allocations (made on a round-robin pool stream) would bypass the arena
 // entirely.
-//
-// The diagnostic gate counters (_stops_headroom / _stops_reservation) have no
-// accessors; they are logged once by stop(), so the tests parse them out of a
-// recording log sink.
 
 #include "utils/log_test_utils.hpp"
 


### PR DESCRIPTION
Needs https://github.com/NVIDIA/cuCascade/pull/184

## Bug

`cudf::cast` and the view-materializing copy are **asynchronous**, but both sites freed the source immediately after enqueuing:

```cpp
columns[i] = cudf::cast(columns[i]->view(), target, stream, mr);  // assignment frees the source
```

A pinned-cache chunk's buffers are stream-ordered on the stream that produced them, not the task stream, so the free is unordered against the still-running read and the block can be handed to the next allocation mid-copy.

Silently wrong scanned values, varying run to run. Row counts and grouping stay correct. On TPC-H SF1000 Q18 this corrupted `sum(l_quantity)`, so `HAVING sum(l_quantity) > 300` emitted 63,430 / 14,879,354 / 163,210,611 / 58,233 rows across four identical iterations.

Only reachable with `enable_compressed_materialization` (default `true`).

## Fix

**`normalize_physical_schema` (the carrier cast)** — rebind the source's deallocation onto the task stream so the free is *enqueued behind* the cast rather than racing it. No copy, no kernel, no host wait; the cast's `column_view` stays valid because rebinding relocates nothing:

```cpp
auto casted = cudf::cast(columns[i]->view(), target, stream, mr);
auto source = cudf::rebind_stream(std::move(*columns[i]), stream);
columns[i]  = std::move(casted);
```

**`owning_table_view::release()` (the view-materializing copy)** — keeps `stream.synchronize()`. There the source belongs to an external owner (a pinned-cache lock held under a read-only lock), so there is no buffer of ours whose deallocation stream could be rebound; `rebind_stream` is explicitly a no-op for that case. Closing it without a host wait needs a consumer-event API in cuCascade — the mirror of `record_writer_event`, letting a reclaimer wait on an in-flight reader — which does not exist today.

The move-based materialization path enqueues no device work and is untouched.

## Checks

New `[owning_table_view][stream_order]` test, deterministic both ways:

| | `cudaStreamQuery` at reclaim | poisoned elements |
|---|---|---|
| without the fix | `cudaErrorNotReady` | 4,194,304 / 4,194,304 |
| with the fix | `cudaSuccess` | 0 |

Full C++ suite: 2,448 passed, 1 skipped.

TPC-H SF500 pinned, per-group sums re-aggregated against the ungrouped total, 9 runs per config:

| config | before | after |
|---|---|---|
| prefetcher on | 6/8 runs wrong | 9/9 correct |
| prefetcher off | 5/8 runs wrong | 9/9 correct |

Both match the `enable_compressed_materialization=false` control.

## Note for reviewers

The cast-site rebind requires the source's *previous* stream to have no in-flight work — guaranteed today by the `stream.synchronize()` after `prepare_for_processing` at `gpu_pipeline_task.cpp:547`. That sync is currently commented as existing "to ensure the timing collected by Quent and logging for preparing the task is accurate", i.e. it reads as telemetry-only. It is load-bearing for correctness; worth re-commenting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
