### PR TITLE
fix(aggregate): retain grouped CUDA error context

### DIFF
--- a/src/op/aggregate/gpu_aggregate_impl.cpp
+++ b/src/op/aggregate/gpu_aggregate_impl.cpp
@@ -29,9 +29,10 @@
 #include <cudf/transform.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
-#include <thrust/system/system_error.h>
 
 #include <rmm/error.hpp>
+
+#include <thrust/system/system_error.h>
 
 #include <algorithm>
 #include <new>
@@ -364,7 +365,7 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
       throw;
     }
   }();
-  auto output_cols    = groupby_result.first->release();
+  auto output_cols = groupby_result.first->release();
 
   // Expand the single label key back into the original group key columns. The groupby emits
   // one row per distinct label, so this gather runs at group cardinality, not input rows.

--- a/src/op/aggregate/gpu_aggregate_impl.cpp
+++ b/src/op/aggregate/gpu_aggregate_impl.cpp
@@ -29,6 +29,7 @@
 #include <cudf/transform.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
+#include <thrust/system/system_error.h>
 
 #include <rmm/error.hpp>
 
@@ -341,7 +342,28 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
   }
 
   // Call cudf groupby and populate output columns
-  auto groupby_result = grpby_obj.aggregate(requests, stream, mr);
+  auto groupby_result = [&]() {
+    try {
+      return grpby_obj.aggregate(requests, stream, mr);
+    } catch (const thrust::system_error& cuda_err) {
+      // The task executor can retry selected transient launch failures, but at
+      // that layer the failing cuDF phase and grouped-aggregate shape have
+      // already been lost. Preserve enough context here to distinguish the
+      // COLLECT_SET sorted-groupby path from the other aggregate paths without
+      // changing the exception type or recovery behavior.
+      SIRIUS_LOG_WARN(
+        "local_grouped_agg: cudf groupby aggregate threw CUDA/Thrust error [{}] {} "
+        "(rows={}, group_columns={}, requests={}, collect_set={}, label_keys={})",
+        cuda_err.code().value(),
+        cuda_err.what(),
+        input_table.num_rows(),
+        group_cols.size(),
+        requests.size(),
+        has_collect_set,
+        use_label_keys);
+      throw;
+    }
+  }();
   auto output_cols    = groupby_result.first->release();
 
   // Expand the single label key back into the original group key columns. The groupby emits


### PR DESCRIPTION
> **Tier:** `judgment` — diagnostics change; retry and recovery behavior do not.
>
> **Operator effect:** When grouped GPU aggregation throws a CUDA/Thrust error,
> Sirius records which aggregate path failed and the input shape before
> rethrowing the same exception.
>
> **Question for @sirius-db/sirius-core:** Is
> `gpu_aggregate_impl::local_grouped_aggregate()` the right ownership boundary
> for this context, or should it be emitted at the task-level retry boundary?
>
> **Known limit:** The recovered GB300 failure has not reproduced under a
> controlled test. The warning path therefore remains dynamically unexercised;
> current validation covers formatting, builds, the full hosted runtime suite,
> grouped-aggregate success behavior, and source-level preservation of the
> exception.

## Why

Issue #1567 retained correct Q16 results after CUDA launch errors, but the
task-level warning had already lost the failing cuDF phase and aggregate shape.
This change adds that missing context without changing retry policy.

## Change

- catch `thrust::system_error` only around `groupby::aggregate`;
- log the CUDA code/message, row and request counts, and the
  `COLLECT_SET`/label-key path flags;
- bare-rethrow the original exception.

## Validation — exact replacement head

- repair base: `dev` `96d3773810cf762bd2be95c39c093dd1411566dc`;
- head: `97816bb5c3213d4beb503ef5d7dd8813bca3b673`;
- tree: `b49ef46dd4c8c3b5f2e838f84f5ba91d9286c612`;
- cumulative binary-diff SHA-256:
  `d59a44bd43418fd2cdbe7af1a3902bb580d87f662284283e68dfded994bff317`;
- `git diff --check origin/dev..HEAD`: pass;
- pinned pre-commit hooks on
  `src/op/aggregate/gpu_aggregate_impl.cpp`: pass, including
  `clang-format`, `codespell`, conflict detection, and secret detection;
- complete replacement diff independently reviewed: pass;
- hosted Validate workflow `33112349116`: pass;
- hosted Check workflow `33112351741`: pass, including lint, GCC release,
  Clang debug, Rust bindings, and vcpkg build checks;
- hosted Test workflow `33112351594`: pass, including CUDA 13 build, C++ unit
  tests, late-materialization checks, and the TPC-H performance snapshot;
- hosted Distribution workflow `33112352376`: pass; the CUDA 12/13 package
  leaves were conditionally skipped by the workflow.

The earlier L4 build, aggregate tests, and 3/3 oracle-equal SF100 Q16 runs were
performed on superseded head `282d6cbda320b3ff47feb2e3cb3c9327f4eb5ea8`.
They remain historical motivation/success-path evidence, not validation of the
replacement head.

## Evidence boundary

The warning/rethrow path remains dynamically unexercised. No configuration
surface, fallback rule, retry condition, or recovery policy changes.

The replacement head is author-ready. It now awaits independent maintainer
judgment on the diagnostic ownership boundary above.

Refs #1567