### PR TITLE
docs: document reviewer auto-assignment and team mention guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,20 @@ Sirius uses [CODEOWNERS](.github/CODEOWNERS) to automatically route PRs to the r
 
 Approval from any maintainer is sufficient to merge — it does not have to be the auto-assigned reviewer.
 
+The component teams can also be mentioned directly in PR comments and issues to bring the right people into a discussion without a Slack ping — useful when you need expert input on a specific area:
+
+| Team | Components |
+|------|------------|
+| `@sirius-db/sirius-core` | Planner, Executors, Operators & Expressions |
+| `@sirius-db/sirius-io` | Scan & I/O, Memory & Compression |
+| `@sirius-db/sirius-integrations` | Integrations |
+| `@sirius-db/sirius-telemetry` | Telemetry & Observability |
+| `@sirius-db/sirius-cmake` | CMake |
+| `@sirius-db/sirius-build` | CI & Build |
+| `@sirius-db/sirius-docs` | Documentation |
+| `@sirius-db/sirius-rust` | Rust |
+| `@sirius-db/sirius-python` | Python |
+
 When you open or update a PR, you will also be automatically assigned as the author. This helps maintainers track ownership and is not a request for you to review your own work.
 
 ### Commit and title convention


### PR DESCRIPTION
## Description

Documents the new CODEOWNERS-based reviewer auto-assignment system and component team `@mention` guide in CONTRIBUTING.md. Adds a new `### Reviewer assignment` section under `## Pull requests` covering:

- Reviewers are automatically assigned via CODEOWNERS teams (one per team, load balanced) — contributors don't need to request reviewers manually
- Approval from any maintainer is sufficient to merge
- PR author is automatically assigned on open/update
- Component teams can be mentioned directly in comments and issues to bring in experts without a Slack ping, with a table of all 9 teams and their coverage areas

## Checklist
- [x] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
Refs #1405