### PR TITLE
fix(concat): enforce the batching threshold in the pull path

### DIFF
--- a/docs/super-sirius/task-creator.md
+++ b/docs/super-sirius/task-creator.md
@@ -133,8 +133,8 @@ Deadlock prevention: both this and sibling partition locks are acquired in a fix
 
 | Method | Behavior |
 |--------|----------|
-| `get_next_task_hint()` | If source finished: READY if data exists. If `_concat_all`: WAITING. Otherwise: checks if any partition's accumulated bytes ≥ `_concat_batch_bytes`. |
-| `get_next_task_input_data()` | For each partition: accumulates batches until byte threshold. Returns `partitioned_operator_data` with partition index. |
+| `get_next_task_hint()` | If source finished: READY if data exists. If `_concat_all`: WAITING. Otherwise: READY only if some partition holds a complete group — accumulated bytes strictly exceed `_concat_batch_bytes` (the overflowing batch seeds the next group); a lone oversized batch is deferred until a second batch arrives or the source finishes. |
+| `get_next_task_input_data()` | Pulls the first partition with a complete group under the same policy as the hint (`plan_pull_for_partition`). Returns `partitioned_operator_data` with partition index. |
 | Why custom | Byte-threshold batching; `_concat_all` mode for LEFT/ANTI/OUTER joins requires all data before output |
 
 ### SORT_SAMPLE

--- a/src/include/op/sirius_physical_concat.hpp
+++ b/src/include/op/sirius_physical_concat.hpp
@@ -28,6 +28,12 @@
 namespace sirius {
 namespace op {
 
+//! Buffers the per-partition data batches produced upstream and releases them in groups sized to
+//! `_concat_batch_bytes` for the downstream hash or nested-loop join, so the join consumes a few
+//! large inputs instead of many small ones. Group formation follows a single policy implemented in
+//! `plan_pull_for_partition`: `get_next_task_hint` reports READY exactly when that policy would
+//! release a group, and `get_next_task_input_data` pops exactly the batches the policy selects, so
+//! task scheduling and data pulls cannot disagree.
 class sirius_physical_concat : public sirius_physical_partition_consumer_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::CONCAT;
@@ -73,6 +79,28 @@ class sirius_physical_concat : public sirius_physical_partition_consumer_operato
     const op::input_stats& stats) const override;
 
  private:
+  //! Decides which batches a pull from partition `partition_idx` of `repo` would take, without
+  //! removing anything. The policy: batches accumulate in arrival order until their cumulative size
+  //! first exceeds `_concat_batch_bytes`; the accumulated group is then released and the
+  //! overflowing batch stays behind to seed the next group. A batch that exceeds the threshold on
+  //! its own is released as a single-batch group once another batch sits behind it or
+  //! `pipeline_finished` is true. A group that never reaches the threshold is released only when
+  //! `pipeline_finished` is true (tail flush). When `_concat_all` is set the whole partition forms
+  //! one group, released only when `pipeline_finished` is true.
+  //!
+  //! Must be called with the operator mutex `lock` held. The returned plan stays valid while the
+  //! lock is held: only `get_next_task_input_data` removes batches (also under `lock`), and
+  //! concurrent producers can only append.
+  //!
+  //! @param repo The single input port's data repository
+  //! @param partition_idx The partition to plan a pull for
+  //! @param pipeline_finished Whether the source pipeline can produce no more batches
+  //! @return The batch ids to pop, in pull order, or std::nullopt if no group should form yet
+  [[nodiscard]] std::optional<std::vector<uint64_t>> plan_pull_for_partition(
+    ::cucascade::shared_data_repository& repo,
+    std::size_t partition_idx,
+    bool pipeline_finished) const;
+
   bool _is_build;
   bool _concat_all;
   uint64_t _concat_batch_bytes;

--- a/src/include/op/sirius_physical_concat.hpp
+++ b/src/include/op/sirius_physical_concat.hpp
@@ -28,12 +28,13 @@
 namespace sirius {
 namespace op {
 
-//! Buffers the per-partition data batches produced upstream and releases them in groups sized to
-//! `_concat_batch_bytes` for the downstream hash or nested-loop join, so the join consumes a few
-//! large inputs instead of many small ones. Group formation follows a single policy implemented in
-//! `plan_pull_for_partition`: `get_next_task_hint` reports READY exactly when that policy would
-//! release a group, and `get_next_task_input_data` pops exactly the batches the policy selects, so
-//! task scheduling and data pulls cannot disagree.
+/**
+ * @brief Groups partitioned input batches before a downstream join
+ *
+ * Buffers batches in arrival order for each partition and releases groups based on
+ * `_concat_batch_bytes`. `get_next_task_hint` and `get_next_task_input_data` use the same grouping
+ * policy so a ready hint always corresponds to data that can be pulled.
+ */
 class sirius_physical_concat : public sirius_physical_partition_consumer_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::CONCAT;
@@ -79,23 +80,23 @@ class sirius_physical_concat : public sirius_physical_partition_consumer_operato
     const op::input_stats& stats) const override;
 
  private:
-  //! Decides which batches a pull from partition `partition_idx` of `repo` would take, without
-  //! removing anything. The policy: batches accumulate in arrival order until their cumulative size
-  //! first exceeds `_concat_batch_bytes`; the accumulated group is then released and the
-  //! overflowing batch stays behind to seed the next group. A batch that exceeds the threshold on
-  //! its own is released as a single-batch group once another batch sits behind it or
-  //! `pipeline_finished` is true. A group that never reaches the threshold is released only when
-  //! `pipeline_finished` is true (tail flush). When `_concat_all` is set the whole partition forms
-  //! one group, released only when `pipeline_finished` is true.
-  //!
-  //! Must be called with the operator mutex `lock` held. The returned plan stays valid while the
-  //! lock is held: only `get_next_task_input_data` removes batches (also under `lock`), and
-  //! concurrent producers can only append.
-  //!
-  //! @param repo The single input port's data repository
-  //! @param partition_idx The partition to plan a pull for
-  //! @param pipeline_finished Whether the source pipeline can produce no more batches
-  //! @return The batch ids to pop, in pull order, or std::nullopt if no group should form yet
+  /**
+   * @brief Plans the next batch group for one partition without removing data
+   *
+   * A group contains the batches before the first batch that would make its cumulative size exceed
+   * `_concat_batch_bytes`; the overflowing batch remains for the next group. A batch that exceeds
+   * the threshold by itself becomes a single-batch group after another batch arrives or the source
+   * pipeline finishes. Finishing the pipeline also releases an under-threshold tail. When
+   * `_concat_all` is set, the complete partition becomes one group after the pipeline finishes.
+   *
+   * The caller must hold the operator mutex `lock`. The plan remains valid while the lock is held
+   * because consumers remove batches under the same lock and producers only append batches.
+   *
+   * @param[in] repo Repository for the operator's input port
+   * @param[in] partition_idx Partition to inspect
+   * @param[in] pipeline_finished Whether the source pipeline has finished
+   * @return Batch identifiers in pull order, or `std::nullopt` when no group is ready
+   */
   [[nodiscard]] std::optional<std::vector<uint64_t>> plan_pull_for_partition(
     ::cucascade::shared_data_repository& repo,
     std::size_t partition_idx,

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -68,6 +68,42 @@ sirius_physical_concat::sirius_physical_concat(duckdb::vector<sirius::logical_ty
   }
 }
 
+std::optional<std::vector<uint64_t>> sirius_physical_concat::plan_pull_for_partition(
+  ::cucascade::shared_data_repository& repo,
+  std::size_t partition_idx,
+  bool pipeline_finished) const
+{
+  auto batch_ids = repo.get_batch_ids(partition_idx);
+  if (batch_ids.empty()) { return std::nullopt; }
+
+  if (_concat_all) {
+    // A concat-all group is the whole partition, so it can only form once the source is done.
+    if (!pipeline_finished) { return std::nullopt; }
+    return batch_ids;
+  }
+
+  std::vector<uint64_t> group;
+  std::size_t total_batch_size = 0;
+  for (auto const batch_id : batch_ids) {
+    auto batch_idle = repo.get_data_batch_by_id(batch_id, partition_idx);
+    auto batch_ro   = batch_idle->to_read_only();
+    total_batch_size += batch_ro.get_data()->get_size_in_bytes();
+    if (total_batch_size > _concat_batch_bytes) {
+      // The accumulated group is complete; the overflowing batch seeds the next group.
+      if (!group.empty()) { return group; }
+      // The first batch alone exceeds the threshold. Release it as a single-batch group unless
+      // it is the only batch and more data may still arrive.
+      if (pipeline_finished || batch_ids.size() > 1) { return std::vector<uint64_t>{batch_id}; }
+      return std::nullopt;
+    }
+    group.push_back(batch_id);
+  }
+
+  // The whole partition fits under the threshold: keep accumulating until the source is done.
+  if (!pipeline_finished) { return std::nullopt; }
+  return group;
+}
+
 std::optional<task_creation_hint> sirius_physical_concat::get_next_task_hint()
 {
   std::lock_guard<std::mutex> lg(lock);
@@ -76,8 +112,8 @@ std::optional<task_creation_hint> sirius_physical_concat::get_next_task_hint()
     throw std::runtime_error("sirius_physical_concat: there should be only one port");
   }
 
-  auto port_ptr          = ports.begin()->second;
-  bool pipeline_finished = port_ptr->src_pipeline && port_ptr->src_pipeline->is_pipeline_finished();
+  auto const port_ptr          = ports.begin()->second;
+  bool const pipeline_finished = is_source_pipeline_finished();
 
   // If the source pipeline is done, we're ready to process whatever data remains
   if (pipeline_finished) {
@@ -85,36 +121,19 @@ std::optional<task_creation_hint> sirius_physical_concat::get_next_task_hint()
       return task_creation_hint{TaskCreationHint::READY, this};
     }
     return std::nullopt;
-  } else if (_concat_all) {
+  }
+
+  if (_concat_all) {
     // if we need to concat all then we need to wait for the pipeline to be finished
     return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA,
                               &(port_ptr->src_pipeline->get_operators()[0].get())};
   }
 
-  // Source pipeline still running — check if there is enough data to fire a task early.
-  // "Enough" means: for some partition, simulating get_next_task_input_data would pull a group
-  // of batches AND there would still be at least one batch left in that partition afterward.
-  for (size_t i = 0; i < port_ptr->repo->num_partitions(); i++) {
-    auto batch_ids          = port_ptr->repo->get_batch_ids(i);
-    size_t total_batch_size = 0;
-    size_t pulled_count     = 0;
-    for (auto& batch_id : batch_ids) {
-      auto batch_idle = port_ptr->repo->get_data_batch_by_id(batch_id, i);
-      auto batch_ro   = batch_idle->to_read_only();
-      auto batch_size = batch_ro.get_data()->get_size_in_bytes();
-      total_batch_size += batch_size;
-      if (!_concat_all && total_batch_size > _concat_batch_bytes) {
-        // This batch pushes us over the threshold — the loop would stop here.
-        // If we already accumulated batches (pulled_count > 0), the overflowing batch stays,
-        // so there is at least one batch left after the pull.
-        if (pulled_count > 0) { return task_creation_hint{TaskCreationHint::READY, this}; }
-        // If nothing was accumulated yet, the single oversized batch itself would be pulled,
-        // and remaining data is everything after it.
-        if (batch_ids.size() > 1) { return task_creation_hint{TaskCreationHint::READY, this}; }
-        break;
-      } else {
-        pulled_count++;
-      }
+  // Source pipeline still running — fire early only if some partition already holds a group
+  // that get_next_task_input_data would release.
+  for (std::size_t i = 0; i < port_ptr->repo->num_partitions(); i++) {
+    if (plan_pull_for_partition(*port_ptr->repo, i, /*pipeline_finished=*/false)) {
+      return task_creation_hint{TaskCreationHint::READY, this};
     }
   }
 
@@ -125,7 +144,6 @@ std::optional<task_creation_hint> sirius_physical_concat::get_next_task_hint()
 
 std::unique_ptr<operator_data> sirius_physical_concat::get_next_task_input_data()
 {
-  // iterate through all the partition and pull
   std::lock_guard<std::mutex> lg(lock);
 
   // assert that there is only one port
@@ -133,38 +151,19 @@ std::unique_ptr<operator_data> sirius_physical_concat::get_next_task_input_data(
     throw std::runtime_error("sirius_physical_concat: there should be only one port");
   }
 
-  auto port_ptr = ports.begin()->second;
-  for (size_t i = 0; i < port_ptr->repo->num_partitions(); i++) {
+  auto const port_ptr          = ports.begin()->second;
+  bool const pipeline_finished = is_source_pipeline_finished();
+
+  // Pull from the first partition where the group-forming policy releases a group.
+  for (std::size_t i = 0; i < port_ptr->repo->num_partitions(); i++) {
+    auto plan = plan_pull_for_partition(*port_ptr->repo, i, pipeline_finished);
+    if (!plan) { continue; }
     std::vector<std::shared_ptr<::cucascade::data_batch>> input_batch;
-    // get all the batch ids from the partition
-    auto batch_ids          = port_ptr->repo->get_batch_ids(i);
-    size_t total_batch_size = 0;
-    for (auto& batch_id : batch_ids) {
-      auto batch_idle = port_ptr->repo->get_data_batch_by_id(batch_id, i);
-      auto batch_ro   = batch_idle->to_read_only();
-      auto batch_size = batch_ro.get_data()->get_size_in_bytes();
-      total_batch_size += batch_size;
-      // Check if the batch size is already exceed the threshold
-      if (!_concat_all && total_batch_size > _concat_batch_bytes) {
-        // if the batch size is already exceed the threshold, then we need to return the batch right
-        // away
-        if (input_batch.size() == 0) {
-          // this mean that there is a batch that is bigger than the threshold, then we just output
-          // that batch right away
-          auto popped_batch = port_ptr->repo->pop_data_batch_by_id(batch_id, i);
-          input_batch.push_back(std::move(popped_batch));
-        }
-        break;
-      } else {
-        // if the batch size does not exceed the threshold, then we need to add the batch to the
-        // input batch
-        auto popped_batch = port_ptr->repo->pop_data_batch_by_id(batch_id, i);
-        input_batch.push_back(std::move(popped_batch));
-      }
+    input_batch.reserve(plan->size());
+    for (auto const batch_id : *plan) {
+      input_batch.push_back(port_ptr->repo->pop_data_batch_by_id(batch_id, i));
     }
-    if (input_batch.size() != 0) {
-      return std::make_unique<partitioned_operator_data>(std::move(input_batch), i);
-    }
+    return std::make_unique<partitioned_operator_data>(std::move(input_batch), i);
   }
   return nullptr;
 }

--- a/test/cpp/operator/test_physical_concat.cpp
+++ b/test/cpp/operator/test_physical_concat.cpp
@@ -819,6 +819,120 @@ TEST_CASE("sirius_physical_concat with concat_all defers all batches until pipel
   REQUIRE(concat_op.get_next_task_input_data() == nullptr);
 }
 
+TEST_CASE("sirius_physical_concat pulls from a later partition when earlier ones are not ready",
+          "[physical_concat]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space != nullptr);
+
+  constexpr uint64_t threshold = 1024;  // 1 KB
+
+  auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
+  sirius_physical_concat concat_op(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false,
+    threshold);
+
+  auto repo   = std::make_unique<cucascade::shared_data_repository>();
+  auto source = create_unfinished_source_pipeline();
+  attach_concat_port(concat_op, *repo, source.pipeline);
+
+  // Partition 0 holds a lone under-threshold batch: no group is ready there.
+  auto p0_batch    = make_int32_batch(*space, 100);
+  const auto p0_id = p0_batch->get_batch_id();
+  repo->add_data_batch(std::move(p0_batch), 0);
+
+  // Partition 1 holds three 400-byte batches: the third crosses the threshold, so the first two
+  // form a ready group.
+  std::vector<uint64_t> p1_ids;
+  for (int i = 0; i < 3; ++i) {
+    auto batch = make_int32_batch(*space, 100);
+    p1_ids.push_back(batch->get_batch_id());
+    repo->add_data_batch(std::move(batch), 1);
+  }
+
+  auto ready_hint = concat_op.get_next_task_hint();
+  REQUIRE(ready_hint.has_value());
+  REQUIRE(ready_hint->hint == TaskCreationHint::READY);
+  REQUIRE(ready_hint->producer == &concat_op);
+
+  // The pull must skip the not-ready partition 0 and release partition 1's group.
+  auto group = concat_op.get_next_task_input_data();
+  REQUIRE(group != nullptr);
+  const auto& group_data = dynamic_cast<const partitioned_operator_data&>(*group);
+  REQUIRE(group_data.get_partition_idx() == 1);
+  const auto& group_batches = group_data.get_data_batches();
+  REQUIRE(group_batches.size() == 2);
+  REQUIRE(group_batches[0]->get_batch_id() == p1_ids[0]);
+  REQUIRE(group_batches[1]->get_batch_id() == p1_ids[1]);
+
+  // Both partitions now hold under-threshold tails: nothing further until the source finishes.
+  REQUIRE(concat_op.get_next_task_input_data() == nullptr);
+  REQUIRE(repo->get_batch_ids(0) == std::vector<uint64_t>{p0_id});
+  REQUIRE(repo->get_batch_ids(1) == std::vector<uint64_t>{p1_ids[2]});
+
+  // Pipeline finish flushes the tails in partition order.
+  source.pipeline->set_finished(true);
+  auto tail0 = concat_op.get_next_task_input_data();
+  REQUIRE(tail0 != nullptr);
+  REQUIRE(dynamic_cast<const partitioned_operator_data&>(*tail0).get_partition_idx() == 0);
+  auto tail1 = concat_op.get_next_task_input_data();
+  REQUIRE(tail1 != nullptr);
+  REQUIRE(dynamic_cast<const partitioned_operator_data&>(*tail1).get_partition_idx() == 1);
+  REQUIRE(concat_op.get_next_task_input_data() == nullptr);
+}
+
+TEST_CASE("sirius_physical_concat keeps a batch exactly at the threshold in its group",
+          "[physical_concat]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space != nullptr);
+
+  // Size the threshold to exactly match one batch: the strict '>' comparison keeps that batch in
+  // the accumulating group instead of overflowing on its own.
+  auto exact_batch         = make_int32_batch(*space, 256);
+  const auto exact_id      = exact_batch->get_batch_id();
+  const uint64_t threshold = exact_batch->to_read_only().get_data()->get_size_in_bytes();
+
+  auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
+  sirius_physical_concat concat_op(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false,
+    threshold);
+
+  auto repo   = std::make_unique<cucascade::shared_data_repository>();
+  auto source = create_unfinished_source_pipeline();
+  attach_concat_port(concat_op, *repo, source.pipeline);
+  repo->add_data_batch(std::move(exact_batch), 0);
+
+  // Exactly at the threshold is not over it: the batch keeps accumulating.
+  REQUIRE(concat_op.get_next_task_input_data() == nullptr);
+  auto waiting_hint = concat_op.get_next_task_hint();
+  REQUIRE(waiting_hint.has_value());
+  REQUIRE(waiting_hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+
+  // The next batch overflows the group, releasing the exact-threshold batch alone.
+  auto follower          = make_int32_batch(*space, 100);
+  const auto follower_id = follower->get_batch_id();
+  repo->add_data_batch(std::move(follower), 0);
+
+  auto ready_hint = concat_op.get_next_task_hint();
+  REQUIRE(ready_hint.has_value());
+  REQUIRE(ready_hint->hint == TaskCreationHint::READY);
+
+  auto group = concat_op.get_next_task_input_data();
+  REQUIRE(group != nullptr);
+  const auto& group_batches =
+    dynamic_cast<const pipelineable_operator_data&>(*group).get_data_batches();
+  REQUIRE(group_batches.size() == 1);
+  REQUIRE(group_batches[0]->get_batch_id() == exact_id);
+  REQUIRE(repo->get_batch_ids(0) == std::vector<uint64_t>{follower_id});
+}
+
 //===----------------------------------------------------------------------===//
 // 3. Constructor tests
 //===----------------------------------------------------------------------===//

--- a/test/cpp/operator/test_physical_concat.cpp
+++ b/test/cpp/operator/test_physical_concat.cpp
@@ -25,6 +25,7 @@
 #include <op/sirius_physical_concat.hpp>
 #include <op/sirius_physical_hash_join.hpp>
 #include <op/sirius_physical_partition.hpp>
+#include <pipeline/sirius_pipeline.hpp>
 
 #include <atomic>
 #include <mutex>
@@ -136,6 +137,79 @@ memory_space* get_shared_mem_space()
 {
   static auto manager = sirius::test::operator_utils::initialize_memory_manager();
   return manager->get_memory_space(Tier::GPU, 0);
+}
+
+//===----------------------------------------------------------------------===//
+// Source-pipeline fixture for get_next_task_hint / get_next_task_input_data
+//===----------------------------------------------------------------------===//
+
+/**
+ * @brief A sirius_pipeline whose finished state the test controls, standing in for the source
+ * pipeline feeding the concat operator's input port.
+ */
+class mock_gpu_pipeline : public sirius::pipeline::sirius_pipeline {
+ public:
+  explicit mock_gpu_pipeline(const sirius::pipeline::pipeline_build_context& ctx)
+    : sirius_pipeline(ctx)
+  {
+  }
+
+  void set_finished(bool finished) { _finished = finished; }
+
+  bool is_pipeline_finished() const override { return _finished; }
+
+ private:
+  bool _finished = false;
+};
+
+/**
+ * @brief Bundles a controllable source pipeline with the upstream producer operator that
+ * get_next_task_hint reports in WAITING_FOR_INPUT_DATA hints. The producer must outlive the
+ * pipeline, which stores it by reference.
+ */
+struct source_pipeline_fixture {
+  duckdb::unique_ptr<sirius_physical_operator> upstream_producer;
+  duckdb::shared_ptr<mock_gpu_pipeline> pipeline;
+};
+
+source_pipeline_fixture create_unfinished_source_pipeline()
+{
+  source_pipeline_fixture fixture;
+  const sirius::pipeline::pipeline_build_context build_ctx{nullptr, true};
+  fixture.pipeline          = duckdb::make_shared_ptr<mock_gpu_pipeline>(build_ctx);
+  fixture.upstream_producer = duckdb::make_uniq<sirius_physical_operator>(
+    SiriusPhysicalOperatorType::PROJECTION,
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000);
+  sirius::pipeline::sirius_pipeline_build_state build_state;
+  build_state.add_pipeline_operator(*fixture.pipeline, *fixture.upstream_producer);
+  return fixture;
+}
+
+/**
+ * @brief Attach a single input port backed by @p repo to @p concat_op, optionally wired to a
+ * source pipeline.
+ */
+void attach_concat_port(sirius_physical_concat& concat_op,
+                        cucascade::shared_data_repository& repo,
+                        duckdb::shared_ptr<mock_gpu_pipeline> src_pipeline = nullptr)
+{
+  auto port           = std::make_unique<sirius_physical_operator::port>();
+  port->type          = MemoryBarrierType::FULL;
+  port->repo          = &repo;
+  port->src_pipeline  = std::move(src_pipeline);
+  port->dest_pipeline = nullptr;
+  concat_op.add_port("input", std::move(port));
+}
+
+/**
+ * @brief Create an int32 batch of @p num_rows rows (4 bytes per row).
+ */
+std::shared_ptr<data_batch> make_int32_batch(memory_space& space, std::size_t num_rows)
+{
+  std::vector<int32_t> values(num_rows);
+  std::iota(values.begin(), values.end(), 0);
+  return make_numeric_batch<int32_t>(space, values, cudf::type_id::INT32);
 }
 
 }  // namespace
@@ -543,6 +617,206 @@ TEST_CASE("sirius_physical_concat with concat_all=true ignores threshold", "[phy
   // No more batches remaining
   auto result2 = concat_op.get_next_task_input_data();
   REQUIRE(result2 == nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// Unfinished-source-pipeline gating tests
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("sirius_physical_concat defers under-threshold groups while the source pipeline runs",
+          "[physical_concat]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space != nullptr);
+
+  constexpr uint64_t threshold = 1024;  // 1 KB
+
+  auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
+  sirius_physical_concat concat_op(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false,
+    threshold);
+
+  auto repo   = std::make_unique<cucascade::shared_data_repository>();
+  auto source = create_unfinished_source_pipeline();
+  attach_concat_port(concat_op, *repo, source.pipeline);
+
+  // Two 400-byte batches accumulate below the threshold: no group forms yet.
+  auto batch_a    = make_int32_batch(*space, 100);
+  auto batch_b    = make_int32_batch(*space, 100);
+  const auto id_a = batch_a->get_batch_id();
+  const auto id_b = batch_b->get_batch_id();
+  repo->add_data_batch(std::move(batch_a), 0);
+  repo->add_data_batch(std::move(batch_b), 0);
+
+  REQUIRE(concat_op.get_next_task_input_data() == nullptr);
+  REQUIRE(repo->get_batch_ids(0).size() == 2);
+
+  auto waiting_hint = concat_op.get_next_task_hint();
+  REQUIRE(waiting_hint.has_value());
+  REQUIRE(waiting_hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+  REQUIRE(waiting_hint->producer == source.upstream_producer.get());
+
+  // A third 400-byte batch crosses the threshold: the first two form a complete group and the
+  // overflowing batch stays behind to seed the next group.
+  auto batch_c    = make_int32_batch(*space, 100);
+  const auto id_c = batch_c->get_batch_id();
+  repo->add_data_batch(std::move(batch_c), 0);
+
+  auto ready_hint = concat_op.get_next_task_hint();
+  REQUIRE(ready_hint.has_value());
+  REQUIRE(ready_hint->hint == TaskCreationHint::READY);
+  REQUIRE(ready_hint->producer == &concat_op);
+
+  auto group = concat_op.get_next_task_input_data();
+  REQUIRE(group != nullptr);
+  const auto& group_batches =
+    dynamic_cast<const pipelineable_operator_data&>(*group).get_data_batches();
+  REQUIRE(group_batches.size() == 2);
+  REQUIRE(group_batches[0]->get_batch_id() == id_a);
+  REQUIRE(group_batches[1]->get_batch_id() == id_b);
+
+  // The leftover batch is under the threshold, so it keeps accumulating.
+  REQUIRE(concat_op.get_next_task_input_data() == nullptr);
+  REQUIRE(repo->get_batch_ids(0) == std::vector<uint64_t>{id_c});
+
+  // Pipeline finish flushes the under-threshold tail.
+  source.pipeline->set_finished(true);
+  auto flush_hint = concat_op.get_next_task_hint();
+  REQUIRE(flush_hint.has_value());
+  REQUIRE(flush_hint->hint == TaskCreationHint::READY);
+
+  auto tail = concat_op.get_next_task_input_data();
+  REQUIRE(tail != nullptr);
+  const auto& tail_batches =
+    dynamic_cast<const pipelineable_operator_data&>(*tail).get_data_batches();
+  REQUIRE(tail_batches.size() == 1);
+  REQUIRE(tail_batches[0]->get_batch_id() == id_c);
+
+  REQUIRE(concat_op.get_next_task_input_data() == nullptr);
+  REQUIRE_FALSE(concat_op.get_next_task_hint().has_value());
+}
+
+TEST_CASE("sirius_physical_concat holds a lone oversized batch until more data or pipeline finish",
+          "[physical_concat]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space != nullptr);
+
+  constexpr uint64_t threshold = 1024;  // 1 KB
+
+  auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
+  sirius_physical_concat concat_op(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false,
+    threshold);
+
+  auto repo   = std::make_unique<cucascade::shared_data_repository>();
+  auto source = create_unfinished_source_pipeline();
+  attach_concat_port(concat_op, *repo, source.pipeline);
+
+  // A single 1200-byte batch exceeds the threshold on its own, but more data may still arrive
+  // behind it, so nothing is released yet.
+  auto oversized          = make_int32_batch(*space, 300);
+  const auto oversized_id = oversized->get_batch_id();
+  repo->add_data_batch(std::move(oversized), 0);
+
+  REQUIRE(concat_op.get_next_task_input_data() == nullptr);
+  REQUIRE(repo->get_batch_ids(0) == std::vector<uint64_t>{oversized_id});
+
+  auto waiting_hint = concat_op.get_next_task_hint();
+  REQUIRE(waiting_hint.has_value());
+  REQUIRE(waiting_hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+  REQUIRE(waiting_hint->producer == source.upstream_producer.get());
+
+  // A second batch behind it releases the oversized batch as a single-batch group.
+  auto small          = make_int32_batch(*space, 100);
+  const auto small_id = small->get_batch_id();
+  repo->add_data_batch(std::move(small), 0);
+
+  auto ready_hint = concat_op.get_next_task_hint();
+  REQUIRE(ready_hint.has_value());
+  REQUIRE(ready_hint->hint == TaskCreationHint::READY);
+
+  auto group = concat_op.get_next_task_input_data();
+  REQUIRE(group != nullptr);
+  const auto& group_batches =
+    dynamic_cast<const pipelineable_operator_data&>(*group).get_data_batches();
+  REQUIRE(group_batches.size() == 1);
+  REQUIRE(group_batches[0]->get_batch_id() == oversized_id);
+
+  // The remaining under-threshold batch keeps accumulating until the source is done.
+  REQUIRE(concat_op.get_next_task_input_data() == nullptr);
+  REQUIRE(repo->get_batch_ids(0) == std::vector<uint64_t>{small_id});
+
+  source.pipeline->set_finished(true);
+  auto tail = concat_op.get_next_task_input_data();
+  REQUIRE(tail != nullptr);
+  const auto& tail_batches =
+    dynamic_cast<const pipelineable_operator_data&>(*tail).get_data_batches();
+  REQUIRE(tail_batches.size() == 1);
+  REQUIRE(tail_batches[0]->get_batch_id() == small_id);
+
+  REQUIRE(concat_op.get_next_task_input_data() == nullptr);
+}
+
+TEST_CASE("sirius_physical_concat with concat_all defers all batches until pipeline finish",
+          "[physical_concat]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space != nullptr);
+
+  constexpr uint64_t threshold = 1024;  // 1 KB
+
+  // LEFT join + is_build=true -> _concat_all = true
+  auto fixture = create_test_hash_join(duckdb::JoinType::LEFT, {duckdb::LogicalType::INTEGER});
+  sirius_physical_concat concat_op(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    true,
+    threshold);
+
+  auto repo   = std::make_unique<cucascade::shared_data_repository>();
+  auto source = create_unfinished_source_pipeline();
+  attach_concat_port(concat_op, *repo, source.pipeline);
+
+  // Mix under- and over-threshold batches: the threshold plays no role with concat_all.
+  std::vector<uint64_t> expected_ids;
+  for (std::size_t num_rows : {100UL, 300UL, 100UL}) {
+    auto batch = make_int32_batch(*space, num_rows);
+    expected_ids.push_back(batch->get_batch_id());
+    repo->add_data_batch(std::move(batch), 0);
+  }
+
+  REQUIRE(concat_op.get_next_task_input_data() == nullptr);
+  REQUIRE(repo->get_batch_ids(0) == expected_ids);
+
+  auto waiting_hint = concat_op.get_next_task_hint();
+  REQUIRE(waiting_hint.has_value());
+  REQUIRE(waiting_hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+  REQUIRE(waiting_hint->producer == source.upstream_producer.get());
+
+  // Pipeline finish releases the whole partition as one group.
+  source.pipeline->set_finished(true);
+  auto ready_hint = concat_op.get_next_task_hint();
+  REQUIRE(ready_hint.has_value());
+  REQUIRE(ready_hint->hint == TaskCreationHint::READY);
+
+  auto all = concat_op.get_next_task_input_data();
+  REQUIRE(all != nullptr);
+  const auto& all_batches =
+    dynamic_cast<const pipelineable_operator_data&>(*all).get_data_batches();
+  REQUIRE(all_batches.size() == expected_ids.size());
+  for (std::size_t i = 0; i < expected_ids.size(); ++i) {
+    REQUIRE(all_batches[i]->get_batch_id() == expected_ids[i]);
+  }
+
+  REQUIRE(concat_op.get_next_task_input_data() == nullptr);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary
- CONCAT's pull path released whatever a partition held, so the task creator's drain loop (which pulls until the input is empty without re-consulting the hint) flushed under-threshold groups the hint had deliberately held back — producing runt join tasks.
- Hint and pull now share one group-forming policy (`plan_pull_for_partition`): while the source pipeline is running, a pull only releases threshold-complete groups (the overflowing batch seeds the next group); pipeline finish flushes the remainder.

## Test plan
- [x] `[physical_concat]` unit tests: 24 cases pass, incl. 3 new gating tests with a controllable source pipeline
- [x] TPC-H SF50 GPU-vs-CPU validation: 22/22 queries pass
- [x] SF50 perf A/B: neutral at the default config; join microbench with small scan batches improves ~3–8% (probe-side CONCAT outputs drop 10 → 6, runts eliminated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)