### PR TITLE
perf(planner): eager aggregation pushdown below equi-joins (TPC-H q13)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,7 @@ set(EXTENSION_SOURCES
     src/planner/duckdb_join_filter_candidate_adapter.cpp
     src/planner/query.cpp
     src/planner/query_index.cpp
+    src/planner/eager_agg_pushdown_plan_pass.cpp
     src/planner/sirius_physical_plan_generator.cpp
     src/planner/sirius_plan_aggregate.cpp
     src/planner/sirius_plan_column_data_get.cpp
@@ -670,6 +671,7 @@ set(TEST_SOURCES
     test/cpp/integration/test_gpu_execution_allnull_scan.cpp
     test/cpp/integration/test_gpu_execution_array.cpp
     test/cpp/integration/test_gpu_execution_dynamic_filter_native.cpp
+    test/cpp/integration/test_gpu_execution_eager_agg.cpp
     test/cpp/integration/test_gpu_execution_filter_nulls.cpp
     test/cpp/integration/test_gpu_execution_join_nulls.cpp
     test/cpp/integration/test_gpu_execution_locality.cpp
@@ -748,6 +750,7 @@ set(TEST_SOURCES
     test/cpp/planner/test_distinct_hash_join_detection.cpp
     test/cpp/planner/test_duckdb_join_filter_candidate_adapter.cpp
     test/cpp/planner/test_dynamic_filter_router.cpp
+    test/cpp/planner/test_eager_agg_pushdown.cpp
     test/cpp/planner/test_join_expression_key.cpp
     test/cpp/planner/test_plan_tree_shape.cpp
     test/cpp/planner/test_projection_fold.cpp

--- a/src/include/planner/eager_agg_pushdown_plan_pass.hpp
+++ b/src/include/planner/eager_agg_pushdown_plan_pass.hpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <duckdb/common/unique_ptr.hpp>
+
+#include <cstdint>
+
+namespace duckdb {
+class ClientContext;
+class LogicalOperator;
+}  // namespace duckdb
+
+namespace sirius::planner {
+
+/// Eager aggregation pushdown (Yan & Larson): when a grouped aggregate sits
+/// directly on an equi-join and every aggregate input comes from one join side,
+/// pre-aggregate that side by its join keys below the join and combine the
+/// partial results above it. The join then consumes one row per distinct key
+/// instead of one row per input row (TPC-H q13: the customer⋈orders join input
+/// shrinks from |filtered orders| rows to |distinct custkeys| partial counts).
+///
+/// Returns a REWRITTEN COPY of @p plan when at least one provable candidate was
+/// found and rewritten, nullptr otherwise. @p plan itself is never modified, so
+/// the caller can fall back to it if the rewritten plan fails any later
+/// planning stage (see sirius_physical_plan_generator::create_plan).
+///
+/// Correctness gates (all provable at plan time, fail closed — see the .cpp
+/// header comment for the full soundness argument):
+///   - single grouping set, no GROUPING() calls, groups are plain column refs
+///     that do not touch the pushed side;
+///   - every aggregate is a single-column-ref COUNT / SUM / SUM_NO_OVERFLOW /
+///     MIN / MAX without DISTINCT / FILTER / ORDER BY, and every aggregate
+///     input comes from the pushed side;
+///   - the join is a plain comparison join (INNER, or LEFT/RIGHT pushing into
+///     the non-preserved side) whose conditions are all `=` with a plain
+///     column ref on the pushed side and no residual predicate;
+///   - COUNT's 0-vs-NULL mismatch on outer joins is repaired with a
+///     COALESCE(combined, 0) projection above the aggregate, and any
+///     combine-type widening (SUM over BIGINT partials returns HUGEINT) is
+///     cast back so the plan's output schema is byte-identical.
+///
+/// Benefit gate (heuristic only — never affects correctness): the rewrite is
+/// applied only when the non-pushed side is a bare, unfiltered table scan
+/// (modulo projections), i.e. the join is not expected to discard most of the
+/// pushed side's rows. When optimizer cardinality estimates are present on the
+/// join they refine this decision (estimated join output must be at least
+/// SIRIUS_EAGER_AGG_MIN_RATIO — default 0.5 — of the pushed side's input).
+///
+/// Environment switches (read per call, so tests can A/B in-process):
+///   SIRIUS_EAGER_AGG_PUSHDOWN=0   kill switch, pass never fires
+///   SIRIUS_EAGER_AGG_FORCE=1      bypass the BENEFIT gate (correctness gates
+///                                 always apply)
+///   SIRIUS_EAGER_AGG_MIN_RATIO=x  estimate-ratio threshold (default 0.5)
+[[nodiscard]] duckdb::unique_ptr<duckdb::LogicalOperator> try_eager_aggregation_pushdown(
+  duckdb::LogicalOperator& plan, duckdb::ClientContext& context);
+
+/// Process-wide count of applied rewrites; lets tests assert the pass actually
+/// fired (a silently-refused rewrite would make GPU-vs-CPU tests vacuous).
+[[nodiscard]] std::uint64_t eager_agg_pushdown_applied_count();
+
+}  // namespace sirius::planner

--- a/src/include/planner/eager_agg_pushdown_plan_pass.hpp
+++ b/src/include/planner/eager_agg_pushdown_plan_pass.hpp
@@ -41,6 +41,10 @@ namespace sirius::planner {
 ///
 /// Correctness gates (all provable at plan time, fail closed — see the .cpp
 /// header comment for the full soundness argument):
+///   - the aggregate sits on the join directly or through ONE pure
+///     pass-through projection (every slot a plain column ref — DuckDB's
+///     column pruning inserts one on some shapes); references are traced
+///     through it;
 ///   - single grouping set, no GROUPING() calls, groups are plain column refs
 ///     that do not touch the pushed side;
 ///   - every aggregate is a single-column-ref COUNT / SUM / SUM_NO_OVERFLOW /

--- a/src/include/planner/sirius_physical_plan_generator.hpp
+++ b/src/include/planner/sirius_physical_plan_generator.hpp
@@ -114,7 +114,9 @@ class sirius_physical_plan_generator {
   get_or_create_dynamic_filter_channel(duckdb::DynamicTableFilterSet const* key);
 
   //! Creates a plan from the logical operator. This involves resolving column bindings and
-  //! generating physical operator nodes.
+  //! generating physical operator nodes. Attempts the eager-aggregation-pushdown logical
+  //! rewrite first; if the rewritten copy fails any later planning stage, planning is retried
+  //! with the untouched original plan (fail closed).
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(
     duckdb::unique_ptr<duckdb::LogicalOperator> logical);
 
@@ -131,6 +133,12 @@ class sirius_physical_plan_generator {
     sirius::op::sirius_physical_operator& op);
 
  protected:
+  //! The actual planning stages (type resolution, column binding, physical operator
+  //! generation, plan passes). create_plan() runs these on the eager-agg-rewritten copy
+  //! first and again on the original plan if that attempt throws.
+  duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan_stages(
+    duckdb::unique_ptr<duckdb::LogicalOperator> logical);
+
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(duckdb::LogicalOperator& op);
 
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(

--- a/src/planner/eager_agg_pushdown_plan_pass.cpp
+++ b/src/planner/eager_agg_pushdown_plan_pass.cpp
@@ -83,6 +83,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -164,14 +165,39 @@ bool non_pushed_side_is_bare_scan(const duckdb::LogicalOperator& side)
 struct match_info {
   duckdb::LogicalAggregate* aggregate = nullptr;
   duckdb::LogicalComparisonJoin* join = nullptr;
+  /// Pure pass-through projection between aggregate and join, when present
+  /// (DuckDB's column pruning inserts one on some shapes, e.g. INNER joins).
+  duckdb::LogicalProjection* projection = nullptr;
   /// Which join child is the pushed (pre-aggregated) side.
   duckdb::idx_t pushed_slot = 0;
+  /// Table indexes produced by the pushed side.
+  std::unordered_set<duckdb::idx_t> pushed_tables;
   /// Per upper aggregate: combine function name ("sum"/"min"/"max").
   std::vector<const char*> combine_names;
   /// Per upper aggregate: repair 0-vs-NULL for unmatched preserved rows
   /// (COUNT under an outer join).
   std::vector<bool> needs_zero_fill;
 };
+
+/// Resolve @p expr (a reference in the aggregate) through the optional
+/// pass-through projection to the column ref the JOIN emits. Returns nullptr
+/// when the shape is out of contract (not a plain column ref at either level).
+const duckdb::BoundColumnRefExpression* trace_to_join_output(
+  const duckdb::Expression& expr, const duckdb::LogicalProjection* projection)
+{
+  if (expr.GetExpressionClass() != duckdb::ExpressionClass::BOUND_COLUMN_REF) { return nullptr; }
+  auto& colref = expr.Cast<duckdb::BoundColumnRefExpression>();
+  if (projection == nullptr) { return &colref; }
+  // With a projection in between, every aggregate-level reference must be one
+  // of its outputs.
+  if (colref.binding.table_index != projection->table_index ||
+      colref.binding.column_index >= projection->expressions.size()) {
+    return nullptr;
+  }
+  auto& below = *projection->expressions[colref.binding.column_index];
+  if (below.GetExpressionClass() != duckdb::ExpressionClass::BOUND_COLUMN_REF) { return nullptr; }
+  return &below.Cast<duckdb::BoundColumnRefExpression>();
+}
 
 /// Match @p op against the pushdown pattern. Purely read-only; returns
 /// std::nullopt (refusal) unless every correctness gate and the benefit gate
@@ -192,12 +218,22 @@ std::optional<match_info> match_candidate(duckdb::LogicalOperator& op)
     return std::nullopt;
   }
 
-  // --- child must be a plain comparison join ---
-  if (aggregate.children.size() != 1 ||
-      aggregate.children[0]->type != duckdb::LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
-    return std::nullopt;
+  // --- child must be a plain comparison join, optionally through ONE pure
+  // pass-through projection (every slot a plain column ref) ---
+  if (aggregate.children.size() != 1) { return std::nullopt; }
+  match_info info;
+  duckdb::LogicalOperator* below = aggregate.children[0].get();
+  if (below->type == duckdb::LogicalOperatorType::LOGICAL_PROJECTION) {
+    info.projection = &below->Cast<duckdb::LogicalProjection>();
+    for (auto& slot : info.projection->expressions) {
+      if (slot->GetExpressionClass() != duckdb::ExpressionClass::BOUND_COLUMN_REF) {
+        return std::nullopt;
+      }
+    }
+    below = info.projection->children[0].get();
   }
-  auto& join = aggregate.children[0]->Cast<duckdb::LogicalComparisonJoin>();
+  if (below->type != duckdb::LogicalOperatorType::LOGICAL_COMPARISON_JOIN) { return std::nullopt; }
+  auto& join = below->Cast<duckdb::LogicalComparisonJoin>();
   if (join.join_type != duckdb::JoinType::INNER && join.join_type != duckdb::JoinType::LEFT &&
       join.join_type != duckdb::JoinType::RIGHT) {
     return std::nullopt;
@@ -212,7 +248,6 @@ std::optional<match_info> match_candidate(duckdb::LogicalOperator& op)
   // --- every aggregate is a decomposable single-column-ref over ONE side ---
   bool args_in_left  = false;
   bool args_in_right = false;
-  match_info info;
   for (auto& expr : aggregate.expressions) {
     if (expr->GetExpressionClass() != duckdb::ExpressionClass::BOUND_AGGREGATE) {
       return std::nullopt;
@@ -223,12 +258,10 @@ std::optional<match_info> match_candidate(duckdb::LogicalOperator& op)
     }
     const char* combine = combine_function_name(aggr.function.name);
     if (combine == nullptr) { return std::nullopt; }
-    if (aggr.children.size() != 1 ||
-        aggr.children[0]->GetExpressionClass() != duckdb::ExpressionClass::BOUND_COLUMN_REF) {
-      return std::nullopt;
-    }
-    auto table_index =
-      aggr.children[0]->Cast<duckdb::BoundColumnRefExpression>().binding.table_index;
+    if (aggr.children.size() != 1) { return std::nullopt; }
+    auto* traced = trace_to_join_output(*aggr.children[0], info.projection);
+    if (traced == nullptr) { return std::nullopt; }
+    auto table_index = traced->binding.table_index;
     if (left_tables.count(table_index) != 0) {
       args_in_left = true;
     } else if (right_tables.count(table_index) != 0) {
@@ -248,15 +281,14 @@ std::optional<match_info> match_candidate(duckdb::LogicalOperator& op)
   if (join.join_type == duckdb::JoinType::LEFT && info.pushed_slot != 1) { return std::nullopt; }
   if (join.join_type == duckdb::JoinType::RIGHT && info.pushed_slot != 0) { return std::nullopt; }
 
-  const auto& pushed_tables = info.pushed_slot == 0 ? left_tables : right_tables;
+  info.pushed_tables        = info.pushed_slot == 0 ? left_tables : right_tables;
+  const auto& pushed_tables = info.pushed_tables;
 
   // --- group keys must not touch the pushed side ---
   for (auto& group : aggregate.groups) {
-    if (group->GetExpressionClass() != duckdb::ExpressionClass::BOUND_COLUMN_REF) {
-      return std::nullopt;
-    }
-    auto table_index = group->Cast<duckdb::BoundColumnRefExpression>().binding.table_index;
-    if (pushed_tables.count(table_index) != 0) { return std::nullopt; }
+    auto* traced = trace_to_join_output(*group, info.projection);
+    if (traced == nullptr) { return std::nullopt; }
+    if (pushed_tables.count(traced->binding.table_index) != 0) { return std::nullopt; }
   }
 
   // --- join conditions: all `=`, pushed side is a plain column ref ---
@@ -348,10 +380,16 @@ void apply_rewrite(duckdb::unique_ptr<duckdb::LogicalOperator>& op_ref,
   auto const num_aggregates    = aggregate.expressions.size();
 
   // --- lower aggregate: GROUP BY the pushed side's join keys, computing the
-  // original aggregates (their column refs already bind below the join) ---
+  // original aggregates with their inputs re-traced to below-join bindings
+  // (identical bindings when no pass-through projection sits in between) ---
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> lower_aggregates;
   for (auto& expr : aggregate.expressions) {
-    lower_aggregates.push_back(expr->Copy());
+    auto lower_expr        = expr->Copy();
+    auto& lower_aggr       = lower_expr->Cast<duckdb::BoundAggregateExpression>();
+    auto* traced           = trace_to_join_output(*lower_aggr.children[0], info.projection);
+    lower_aggr.children[0] = make_column_ref(
+      traced->return_type, traced->binding.table_index, traced->binding.column_index);
+    lower_aggregates.push_back(std::move(lower_expr));
   }
   auto lower = duckdb::make_uniq<duckdb::LogicalAggregate>(
     lower_group_index, lower_aggr_index, std::move(lower_aggregates));
@@ -386,11 +424,44 @@ void apply_rewrite(duckdb::unique_ptr<duckdb::LogicalOperator>& op_ref,
 
   // --- upper aggregate combines the partials ---
   std::vector<duckdb::LogicalType> original_types;
+  original_types.reserve(num_aggregates);
+  for (auto& expr : aggregate.expressions) {
+    original_types.push_back(expr->return_type);
+  }
+
+  // With a pass-through projection in between, route the partials through it:
+  // keep its non-pushed-side slots (remapping the group keys that use them),
+  // drop the pushed-side slots (their join columns no longer exist — every one
+  // of them was only consumed as an aggregate input), and append one slot per
+  // partial for the upper aggregate to combine.
+  auto partial_table         = lower_aggr_index;
+  duckdb::idx_t partial_base = 0;
+  if (info.projection != nullptr) {
+    auto& projection = *info.projection;
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> kept_slots;
+    std::unordered_map<duckdb::idx_t, duckdb::idx_t> slot_remap;
+    for (duckdb::idx_t s = 0; s < projection.expressions.size(); s++) {
+      auto& slot_ref = projection.expressions[s]->Cast<duckdb::BoundColumnRefExpression>();
+      if (info.pushed_tables.count(slot_ref.binding.table_index) != 0) { continue; }
+      slot_remap[s] = kept_slots.size();
+      kept_slots.push_back(std::move(projection.expressions[s]));
+    }
+    partial_base = kept_slots.size();
+    for (duckdb::idx_t i = 0; i < num_aggregates; i++) {
+      kept_slots.push_back(make_column_ref(original_types[i], lower_aggr_index, i));
+    }
+    projection.expressions = std::move(kept_slots);
+    partial_table          = projection.table_index;
+    for (auto& group : aggregate.groups) {
+      auto& group_ref                = group->Cast<duckdb::BoundColumnRefExpression>();
+      group_ref.binding.column_index = slot_remap.at(group_ref.binding.column_index);
+    }
+  }
+
   bool needs_projection = false;
   for (duckdb::idx_t i = 0; i < num_aggregates; i++) {
-    auto& expr = aggregate.expressions[i];
-    original_types.push_back(expr->return_type);
-    auto partial_ref = make_column_ref(expr->return_type, lower_aggr_index, i);
+    auto& expr       = aggregate.expressions[i];
+    auto partial_ref = make_column_ref(original_types[i], partial_table, partial_base + i);
     auto combined = bind_combine_aggregate(context, info.combine_names[i], std::move(partial_ref));
     combined->SetAlias(expr->GetAlias());
     needs_projection =

--- a/src/planner/eager_agg_pushdown_plan_pass.cpp
+++ b/src/planner/eager_agg_pushdown_plan_pass.cpp
@@ -1,0 +1,530 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Eager aggregation pushdown (Yan & Larson, "Eager Aggregation and Lazy
+//! Aggregation", VLDB 1995).
+//!
+//! Pattern (q13 shape; DuckDB flips `customer LEFT JOIN orders` into
+//! `orders RIGHT JOIN customer`, so the pushed side may be either child):
+//!
+//!     AGGREGATE g=[keys from S], a=[AGG(col from R), ...]        (upper, A)
+//!       COMPARISON_JOIN INNER/LEFT/RIGHT on R.k1=S.e1 AND ...    (J)
+//!         [R: pushed side]      [S: preserved / non-pushed side]
+//!
+//! becomes
+//!
+//!     PROJECTION [groups..., CAST(COALESCE(combined, 0))...]     (PX, only
+//!       AGGREGATE g=[keys from S], a=[SUM(partial), ...]          when needed)
+//!         COMPARISON_JOIN on AGG_R.k1=S.e1 AND ...
+//!           AGGREGATE g=[R.k1,...], a=[AGG(col), ...]            (lower)
+//!             [R]
+//!           [S]
+//!
+//! Soundness: every R row that joins a given S row carries the same join-key
+//! tuple, so all of them land in exactly one lower-aggregate group and their
+//! contribution to any upper group is combined losslessly — COUNT partials
+//! combine by SUM, SUM partials by SUM, MIN/MAX by MIN/MAX. This holds for any
+//! join multiplicity (an S key matching n R rows contributes the same combined
+//! value once instead of n addends; duplicated S rows duplicate the partial
+//! exactly as they duplicated the base rows). NULL join keys on R form a lower
+//! group whose key never satisfies `=`, exactly as the underlying rows never
+//! joined. For LEFT/RIGHT joins the preserved side's unmatched rows see one
+//! NULL partial: SUM/MIN/MAX over them yields NULL exactly as over the original
+//! NULL-extended rows, while COUNT would have yielded 0 — repaired by a
+//! COALESCE(combined, 0) in PX. COUNT partials are never NULL (COUNT >= 0), so
+//! matched groups need no repair.
+//!
+//! Everything above the join that referenced R must be rewritten or refused:
+//! the upper aggregate's inputs are rewritten to the partials, the join
+//! conditions' R sides are rewritten to the lower aggregate's keys, and the
+//! matcher refuses any other reference to R (group keys, residual predicates,
+//! non-column-ref condition sides). The caller additionally retries physical
+//! planning with the untouched original plan if the rewritten copy fails any
+//! later stage, so an unsupported rewritten shape costs only the optimization.
+
+#include "planner/eager_agg_pushdown_plan_pass.hpp"
+
+#include "log/logging.hpp"
+#include "transparent/sirius_optimizer_extension.hpp"
+
+#include <duckdb/catalog/catalog.hpp>
+#include <duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp>
+#include <duckdb/common/enums/expression_type.hpp>
+#include <duckdb/common/enums/join_type.hpp>
+#include <duckdb/function/function_binder.hpp>
+#include <duckdb/optimizer/column_binding_replacer.hpp>
+#include <duckdb/planner/expression/bound_aggregate_expression.hpp>
+#include <duckdb/planner/expression/bound_cast_expression.hpp>
+#include <duckdb/planner/expression/bound_columnref_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_operator_expression.hpp>
+#include <duckdb/planner/operator/logical_aggregate.hpp>
+#include <duckdb/planner/operator/logical_comparison_join.hpp>
+#include <duckdb/planner/operator/logical_get.hpp>
+#include <duckdb/planner/operator/logical_projection.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdlib>
+#include <exception>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+namespace sirius::planner {
+
+namespace {
+
+std::atomic<std::uint64_t> g_applied_count{0};
+
+// ---------------------------------------------------------------------------
+// Environment gates (read per use so tests can flip them in-process)
+// ---------------------------------------------------------------------------
+
+bool pass_enabled()
+{
+  const char* v = std::getenv("SIRIUS_EAGER_AGG_PUSHDOWN");
+  return v == nullptr || std::string_view{v} != "0";
+}
+
+bool benefit_gate_bypassed()
+{
+  const char* v = std::getenv("SIRIUS_EAGER_AGG_FORCE");
+  return v != nullptr && std::string_view{v} == "1";
+}
+
+double min_join_to_input_ratio()
+{
+  if (const char* v = std::getenv("SIRIUS_EAGER_AGG_MIN_RATIO")) {
+    try {
+      return std::stod(v);
+    } catch (std::exception&) {  // NOLINT(bugprone-empty-catch)
+      // fall through to the default on a malformed value
+    }
+  }
+  return 0.5;
+}
+
+// ---------------------------------------------------------------------------
+// Matching
+// ---------------------------------------------------------------------------
+
+/// Combine function applied above the join for each pushable aggregate, or
+/// nullptr when the aggregate is not decomposable this way. COUNT partials are
+/// non-NULL counts, so they combine by SUM like SUM partials do.
+const char* combine_function_name(const std::string& name)
+{
+  if (name == "count" || name == "sum" || name == "sum_no_overflow") { return "sum"; }
+  if (name == "min") { return "min"; }
+  if (name == "max") { return "max"; }
+  return nullptr;
+}
+
+std::unordered_set<duckdb::idx_t> output_table_indexes(duckdb::LogicalOperator& op)
+{
+  std::unordered_set<duckdb::idx_t> out;
+  for (auto& binding : op.GetColumnBindings()) {
+    out.insert(binding.table_index);
+  }
+  return out;
+}
+
+/// The heuristic benefit gate: push only when the non-pushed side is a bare,
+/// unfiltered table scan (modulo projections). Then the join is not expected
+/// to discard most pushed-side rows, so the pre-aggregation's reduction
+/// carries through to the join (q13: customer is a bare scan). A filtered or
+/// composite non-pushed side (q18: a semi-join-reduced orders subtree) means
+/// the join itself is selective and pre-aggregating the full pushed side would
+/// mostly compute groups the join throws away.
+bool non_pushed_side_is_bare_scan(const duckdb::LogicalOperator& side)
+{
+  const duckdb::LogicalOperator* node = &side;
+  while (node->type == duckdb::LogicalOperatorType::LOGICAL_PROJECTION) {
+    node = node->children[0].get();
+  }
+  if (node->type != duckdb::LogicalOperatorType::LOGICAL_GET) { return false; }
+  return node->Cast<duckdb::LogicalGet>().table_filters.filters.empty();
+}
+
+struct match_info {
+  duckdb::LogicalAggregate* aggregate = nullptr;
+  duckdb::LogicalComparisonJoin* join = nullptr;
+  /// Which join child is the pushed (pre-aggregated) side.
+  duckdb::idx_t pushed_slot = 0;
+  /// Per upper aggregate: combine function name ("sum"/"min"/"max").
+  std::vector<const char*> combine_names;
+  /// Per upper aggregate: repair 0-vs-NULL for unmatched preserved rows
+  /// (COUNT under an outer join).
+  std::vector<bool> needs_zero_fill;
+};
+
+/// Match @p op against the pushdown pattern. Purely read-only; returns
+/// std::nullopt (refusal) unless every correctness gate and the benefit gate
+/// hold.
+std::optional<match_info> match_candidate(duckdb::LogicalOperator& op)
+{
+  if (op.type != duckdb::LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
+    return std::nullopt;
+  }
+  auto& aggregate = op.Cast<duckdb::LogicalAggregate>();
+
+  // --- upper aggregate shape ---
+  // Exactly one plain grouping set over all group columns; no GROUPING() calls.
+  if (!aggregate.grouping_functions.empty()) { return std::nullopt; }
+  if (aggregate.groups.empty() || aggregate.expressions.empty()) { return std::nullopt; }
+  if (aggregate.grouping_sets.size() != 1 ||
+      aggregate.grouping_sets[0].size() != aggregate.groups.size()) {
+    return std::nullopt;
+  }
+
+  // --- child must be a plain comparison join ---
+  if (aggregate.children.size() != 1 ||
+      aggregate.children[0]->type != duckdb::LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+    return std::nullopt;
+  }
+  auto& join = aggregate.children[0]->Cast<duckdb::LogicalComparisonJoin>();
+  if (join.join_type != duckdb::JoinType::INNER && join.join_type != duckdb::JoinType::LEFT &&
+      join.join_type != duckdb::JoinType::RIGHT) {
+    return std::nullopt;
+  }
+  if (join.predicate || !join.duplicate_eliminated_columns.empty() || join.conditions.empty()) {
+    return std::nullopt;
+  }
+
+  auto left_tables  = output_table_indexes(*join.children[0]);
+  auto right_tables = output_table_indexes(*join.children[1]);
+
+  // --- every aggregate is a decomposable single-column-ref over ONE side ---
+  bool args_in_left  = false;
+  bool args_in_right = false;
+  match_info info;
+  for (auto& expr : aggregate.expressions) {
+    if (expr->GetExpressionClass() != duckdb::ExpressionClass::BOUND_AGGREGATE) {
+      return std::nullopt;
+    }
+    auto& aggr = expr->Cast<duckdb::BoundAggregateExpression>();
+    if (aggr.IsDistinct() || aggr.filter || (aggr.order_bys && !aggr.order_bys->orders.empty())) {
+      return std::nullopt;
+    }
+    const char* combine = combine_function_name(aggr.function.name);
+    if (combine == nullptr) { return std::nullopt; }
+    if (aggr.children.size() != 1 ||
+        aggr.children[0]->GetExpressionClass() != duckdb::ExpressionClass::BOUND_COLUMN_REF) {
+      return std::nullopt;
+    }
+    auto table_index =
+      aggr.children[0]->Cast<duckdb::BoundColumnRefExpression>().binding.table_index;
+    if (left_tables.count(table_index) != 0) {
+      args_in_left = true;
+    } else if (right_tables.count(table_index) != 0) {
+      args_in_right = true;
+    } else {
+      return std::nullopt;  // outer / lateral reference — not this join's column
+    }
+    info.combine_names.push_back(combine);
+    info.needs_zero_fill.push_back(std::string_view{aggr.function.name} == "count" &&
+                                   join.join_type != duckdb::JoinType::INNER);
+  }
+  if (args_in_left == args_in_right) { return std::nullopt; }  // both sides or neither
+  info.pushed_slot = args_in_left ? 0 : 1;
+
+  // The pushed side must not be the preserved side of an outer join: preserved
+  // rows must reach the upper aggregate once each, not once per group.
+  if (join.join_type == duckdb::JoinType::LEFT && info.pushed_slot != 1) { return std::nullopt; }
+  if (join.join_type == duckdb::JoinType::RIGHT && info.pushed_slot != 0) { return std::nullopt; }
+
+  const auto& pushed_tables = info.pushed_slot == 0 ? left_tables : right_tables;
+
+  // --- group keys must not touch the pushed side ---
+  for (auto& group : aggregate.groups) {
+    if (group->GetExpressionClass() != duckdb::ExpressionClass::BOUND_COLUMN_REF) {
+      return std::nullopt;
+    }
+    auto table_index = group->Cast<duckdb::BoundColumnRefExpression>().binding.table_index;
+    if (pushed_tables.count(table_index) != 0) { return std::nullopt; }
+  }
+
+  // --- join conditions: all `=`, pushed side is a plain column ref ---
+  for (auto& cond : join.conditions) {
+    if (cond.comparison != duckdb::ExpressionType::COMPARE_EQUAL) { return std::nullopt; }
+    auto& pushed_expr = info.pushed_slot == 0 ? cond.left : cond.right;
+    if (pushed_expr->GetExpressionClass() != duckdb::ExpressionClass::BOUND_COLUMN_REF) {
+      return std::nullopt;
+    }
+    auto table_index = pushed_expr->Cast<duckdb::BoundColumnRefExpression>().binding.table_index;
+    if (pushed_tables.count(table_index) == 0) { return std::nullopt; }
+  }
+
+  // --- benefit gate (heuristic; never affects correctness) ---
+  if (!benefit_gate_bypassed()) {
+    auto& pushed_child = *join.children[info.pushed_slot];
+    if (join.has_estimated_cardinality && pushed_child.has_estimated_cardinality &&
+        pushed_child.estimated_cardinality > 0) {
+      // Optimizer estimates survive on directly-planned paths (they are lost
+      // by LogicalOperator::Copy on the transparent capture path): the join
+      // must keep most of the pushed side's rows for the reduction to pay.
+      auto ratio = static_cast<double>(join.estimated_cardinality) /
+                   static_cast<double>(pushed_child.estimated_cardinality);
+      if (ratio < min_join_to_input_ratio()) { return std::nullopt; }
+    } else if (!non_pushed_side_is_bare_scan(*join.children[1 - info.pushed_slot])) {
+      return std::nullopt;
+    }
+  }
+
+  info.aggregate = &aggregate;
+  info.join      = &join;
+  return info;
+}
+
+// ---------------------------------------------------------------------------
+// Rewriting
+// ---------------------------------------------------------------------------
+
+duckdb::idx_t max_table_index(const duckdb::LogicalOperator& op)
+{
+  duckdb::idx_t max_index = 0;
+  for (auto index : op.GetTableIndex()) {
+    max_index = std::max(max_index, index);
+  }
+  for (auto& child : op.children) {
+    max_index = std::max(max_index, max_table_index(*child));
+  }
+  return max_index;
+}
+
+duckdb::unique_ptr<duckdb::BoundColumnRefExpression> make_column_ref(
+  const duckdb::LogicalType& type, duckdb::idx_t table_index, duckdb::idx_t column_index)
+{
+  return duckdb::make_uniq<duckdb::BoundColumnRefExpression>(
+    type, duckdb::ColumnBinding(table_index, column_index));
+}
+
+/// Bind `name(child)` against the system catalog, mirroring how DuckDB's own
+/// optimizer rewrites bind replacement aggregates (sum_rewriter.cpp).
+duckdb::unique_ptr<duckdb::Expression> bind_combine_aggregate(
+  duckdb::ClientContext& context, const char* name, duckdb::unique_ptr<duckdb::Expression> child)
+{
+  duckdb::QueryErrorContext error_context;
+  auto& entry = duckdb::Catalog::GetEntry<duckdb::AggregateFunctionCatalogEntry>(
+    context, SYSTEM_CATALOG, DEFAULT_SCHEMA, name, error_context);
+  auto function = entry.functions.GetFunctionByArguments(context, {child->return_type});
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+  children.push_back(std::move(child));
+  duckdb::FunctionBinder binder(context);
+  return binder.BindAggregateFunction(std::move(function), std::move(children));
+}
+
+/// Apply the rewrite for a matched candidate. @p op_ref owns the upper
+/// aggregate; it is replaced with a fix-up projection when one is needed.
+/// @p root is the plan root, used to remap bindings above the new projection.
+void apply_rewrite(duckdb::unique_ptr<duckdb::LogicalOperator>& op_ref,
+                   duckdb::unique_ptr<duckdb::LogicalOperator>& root,
+                   const match_info& info,
+                   duckdb::ClientContext& context)
+{
+  auto& aggregate = *info.aggregate;
+  auto& join      = *info.join;
+
+  auto next_index              = max_table_index(*root) + 1;
+  auto const lower_group_index = next_index++;
+  auto const lower_aggr_index  = next_index++;
+  auto const projection_index  = next_index++;
+  auto const num_groups        = aggregate.groups.size();
+  auto const num_aggregates    = aggregate.expressions.size();
+
+  // --- lower aggregate: GROUP BY the pushed side's join keys, computing the
+  // original aggregates (their column refs already bind below the join) ---
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> lower_aggregates;
+  for (auto& expr : aggregate.expressions) {
+    lower_aggregates.push_back(expr->Copy());
+  }
+  auto lower = duckdb::make_uniq<duckdb::LogicalAggregate>(
+    lower_group_index, lower_aggr_index, std::move(lower_aggregates));
+  duckdb::GroupingSet grouping_set;
+  for (duckdb::idx_t k = 0; k < join.conditions.size(); k++) {
+    auto& cond        = join.conditions[k];
+    auto& pushed_expr = info.pushed_slot == 0 ? cond.left : cond.right;
+    lower->groups.push_back(pushed_expr->Copy());
+    grouping_set.insert(k);
+  }
+  lower->grouping_sets.push_back(std::move(grouping_set));
+  auto& pushed_child = join.children[info.pushed_slot];
+  // Upper bound; only pinned when the child actually carries an estimate —
+  // pinning 0 would freeze EstimateCardinality's later bottom-up recomputation.
+  if (pushed_child->has_estimated_cardinality) {
+    lower->SetEstimatedCardinality(pushed_child->estimated_cardinality);
+  }
+  lower->children.push_back(std::move(pushed_child));
+  pushed_child = std::move(lower);
+
+  // --- join now reads the lower aggregate's keys on the pushed side; its
+  // former per-row output no longer exists, so drop any pushed-side projection
+  // map (the new output is exactly keys + partials, all of them consumed) ---
+  for (duckdb::idx_t k = 0; k < join.conditions.size(); k++) {
+    auto& cond        = join.conditions[k];
+    auto& pushed_expr = info.pushed_slot == 0 ? cond.left : cond.right;
+    pushed_expr       = make_column_ref(pushed_expr->return_type, lower_group_index, k);
+  }
+  auto& pushed_projection_map =
+    info.pushed_slot == 0 ? join.left_projection_map : join.right_projection_map;
+  pushed_projection_map.clear();
+
+  // --- upper aggregate combines the partials ---
+  std::vector<duckdb::LogicalType> original_types;
+  bool needs_projection = false;
+  for (duckdb::idx_t i = 0; i < num_aggregates; i++) {
+    auto& expr = aggregate.expressions[i];
+    original_types.push_back(expr->return_type);
+    auto partial_ref = make_column_ref(expr->return_type, lower_aggr_index, i);
+    auto combined = bind_combine_aggregate(context, info.combine_names[i], std::move(partial_ref));
+    combined->SetAlias(expr->GetAlias());
+    needs_projection =
+      needs_projection || info.needs_zero_fill[i] || combined->return_type != original_types[i];
+    expr = std::move(combined);
+  }
+
+  if (!needs_projection) {
+    g_applied_count.fetch_add(1, std::memory_order_relaxed);
+    SIRIUS_LOG_INFO("Eager aggregation pushdown applied ({} keys, {} aggregates)",
+                    join.conditions.size(),
+                    num_aggregates);
+    return;
+  }
+
+  // --- fix-up projection: restore COUNT's 0 for unmatched preserved rows and
+  // the original output types, keeping the plan's schema byte-identical ---
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> projection_exprs;
+  for (duckdb::idx_t g = 0; g < num_groups; g++) {
+    projection_exprs.push_back(
+      make_column_ref(aggregate.groups[g]->return_type, aggregate.group_index, g));
+  }
+  for (duckdb::idx_t i = 0; i < num_aggregates; i++) {
+    auto const& combined_type = aggregate.expressions[i]->return_type;
+    duckdb::unique_ptr<duckdb::Expression> expr =
+      make_column_ref(combined_type, aggregate.aggregate_index, i);
+    if (info.needs_zero_fill[i]) {
+      auto coalesce = duckdb::make_uniq<duckdb::BoundOperatorExpression>(
+        duckdb::ExpressionType::OPERATOR_COALESCE, combined_type);
+      coalesce->children.push_back(std::move(expr));
+      coalesce->children.push_back(duckdb::make_uniq<duckdb::BoundConstantExpression>(
+        duckdb::Value::Numeric(combined_type, 0)));
+      expr = std::move(coalesce);
+    }
+    expr = duckdb::BoundCastExpression::AddCastToType(context, std::move(expr), original_types[i]);
+    projection_exprs.push_back(std::move(expr));
+  }
+
+  auto projection =
+    duckdb::make_uniq<duckdb::LogicalProjection>(projection_index, std::move(projection_exprs));
+  if (aggregate.has_estimated_cardinality) {
+    projection->SetEstimatedCardinality(aggregate.estimated_cardinality);
+  }
+
+  duckdb::ColumnBindingReplacer replacer;
+  for (duckdb::idx_t g = 0; g < num_groups; g++) {
+    replacer.replacement_bindings.emplace_back(duckdb::ColumnBinding(aggregate.group_index, g),
+                                               duckdb::ColumnBinding(projection_index, g));
+  }
+  for (duckdb::idx_t i = 0; i < num_aggregates; i++) {
+    replacer.replacement_bindings.emplace_back(
+      duckdb::ColumnBinding(aggregate.aggregate_index, i),
+      duckdb::ColumnBinding(projection_index, num_groups + i));
+  }
+
+  projection->children.push_back(std::move(op_ref));
+  op_ref = std::move(projection);
+
+  // Remap every reference above the aggregate to the projection's outputs. The
+  // stop operator keeps the projection's own expressions (which legitimately
+  // reference the aggregate) untouched; nothing below the aggregate can see
+  // its bindings.
+  replacer.stop_operator = op_ref.get();
+  replacer.VisitOperator(*root);
+
+  g_applied_count.fetch_add(1, std::memory_order_relaxed);
+  SIRIUS_LOG_INFO(
+    "Eager aggregation pushdown applied ({} keys, {} aggregates, with fix-up projection)",
+    join.conditions.size(),
+    num_aggregates);
+}
+
+/// Bottom-up rewrite walk. Children first, so nested candidates are handled
+/// before their ancestors; each node is visited exactly once, so a rewritten
+/// aggregate (which still matches the pattern textually) is never re-pushed.
+void visit(duckdb::unique_ptr<duckdb::LogicalOperator>& op_ref,
+           duckdb::unique_ptr<duckdb::LogicalOperator>& root,
+           duckdb::ClientContext& context,
+           int& applied)
+{
+  for (auto& child : op_ref->children) {
+    visit(child, root, context, applied);
+  }
+  if (auto info = match_candidate(*op_ref)) {
+    apply_rewrite(op_ref, root, *info, context);
+    applied++;
+  }
+}
+
+bool contains_candidate(duckdb::LogicalOperator& op)
+{
+  if (match_candidate(op)) { return true; }
+  for (auto& child : op.children) {
+    if (contains_candidate(*child)) { return true; }
+  }
+  return false;
+}
+
+}  // namespace
+
+duckdb::unique_ptr<duckdb::LogicalOperator> try_eager_aggregation_pushdown(
+  duckdb::LogicalOperator& plan, duckdb::ClientContext& context)
+{
+  if (!pass_enabled()) { return nullptr; }
+
+  // Cheap read-only scan first: the copy below is only paid when a provable
+  // candidate exists (on TPC-H that is q13 alone).
+  if (!contains_candidate(plan)) { return nullptr; }
+
+  duckdb::unique_ptr<duckdb::LogicalOperator> copy;
+  try {
+    // Preserves dynamic-filter metadata exactly like the transparent capture
+    // path; a plan whose scans cannot be copied is simply not rewritten.
+    copy = sirius::transparent::copy_logical_plan(plan, context);
+  } catch (std::exception& e) {
+    SIRIUS_LOG_DEBUG("Eager aggregation pushdown: plan not copyable, skipping: {}", e.what());
+    return nullptr;
+  }
+
+  int applied = 0;
+  try {
+    visit(copy, copy, context, applied);
+  } catch (std::exception& e) {
+    // E.g. no matching combine overload in the catalog. Fail closed.
+    SIRIUS_LOG_DEBUG("Eager aggregation pushdown: rewrite failed, skipping: {}", e.what());
+    return nullptr;
+  }
+  if (applied == 0) { return nullptr; }
+  return copy;
+}
+
+std::uint64_t eager_agg_pushdown_applied_count()
+{
+  return g_applied_count.load(std::memory_order_relaxed);
+}
+
+}  // namespace sirius::planner

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -59,6 +59,7 @@
 #include "op/sirius_physical_top_n_merge.hpp"
 #include "op/sirius_physical_ungrouped_aggregate.hpp"
 #include "op/sirius_physical_ungrouped_aggregate_merge.hpp"
+#include "planner/eager_agg_pushdown_plan_pass.hpp"
 #include "planner/sirius_plan_compressed_schema.hpp"
 #include "planner/sirius_plan_projection_utils.hpp"
 #include "sirius_config.hpp"
@@ -1019,26 +1020,80 @@ bool sirius_physical_plan_generator::preserve_insertion_order(
   return preserve_insertion_order(context, plan);
 }
 
+namespace {
+
+/// Exception-safe StartPhase/EndPhase pairing: create_plan_stages can throw
+/// between the two (that is how unsupported plans decline GPU execution), and
+/// the eager-aggregation retry below runs the stages a second time — an
+/// unbalanced phase from the first attempt would corrupt the profiler state.
+struct profiler_phase_guard {
+  profiler_phase_guard(duckdb::QueryProfiler& profiler, duckdb::MetricType metric)
+    : _profiler(profiler)
+  {
+    _profiler.StartPhase(metric);
+  }
+  ~profiler_phase_guard() { end(); }
+  void end()
+  {
+    if (!_ended) {
+      _ended = true;
+      _profiler.EndPhase();
+    }
+  }
+  profiler_phase_guard(const profiler_phase_guard&)            = delete;
+  profiler_phase_guard& operator=(const profiler_phase_guard&) = delete;
+
+ private:
+  duckdb::QueryProfiler& _profiler;
+  bool _ended = false;
+};
+
+}  // namespace
+
 duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::unique_ptr<duckdb::LogicalOperator> op)
+{
+  // Eager aggregation pushdown (Yan & Larson) — a logical-level rewrite, so it
+  // runs before type/binding resolution. Fail closed twice over: the matcher
+  // only fires on shapes it can prove (see eager_agg_pushdown_plan_pass.cpp),
+  // the rewrite is applied to a COPY, and if the rewritten plan fails ANY
+  // later planning stage we fall back to the untouched original — the query
+  // then behaves exactly as if the pass did not exist.
+  if (auto rewritten = planner::try_eager_aggregation_pushdown(*op, context)) {
+    try {
+      return create_plan_stages(std::move(rewritten));
+    } catch (std::exception& e) {
+      SIRIUS_LOG_INFO(
+        "Eager aggregation pushdown: rewritten plan failed physical planning ({}); "
+        "retrying with the original plan",
+        e.what());
+    }
+  }
+  return create_plan_stages(std::move(op));
+}
+
+duckdb::unique_ptr<sirius::op::sirius_physical_operator>
+sirius_physical_plan_generator::create_plan_stages(duckdb::unique_ptr<duckdb::LogicalOperator> op)
 {
   auto& profiler = duckdb::QueryProfiler::Get(context);
 
   // Resolve the types of each operator.
-  profiler.StartPhase(duckdb::MetricType::PHYSICAL_PLANNER_RESOLVE_TYPES);
-  op->ResolveOperatorTypes();
-  profiler.EndPhase();
+  {
+    profiler_phase_guard phase(profiler, duckdb::MetricType::PHYSICAL_PLANNER_RESOLVE_TYPES);
+    op->ResolveOperatorTypes();
+  }
 
   // Resolve the column references.
-  profiler.StartPhase(duckdb::MetricType::PHYSICAL_PLANNER_COLUMN_BINDING);
-  duckdb::ColumnBindingResolver resolver;
-  resolver.VisitOperator(*op);
-  profiler.EndPhase();
+  {
+    profiler_phase_guard phase(profiler, duckdb::MetricType::PHYSICAL_PLANNER_COLUMN_BINDING);
+    duckdb::ColumnBindingResolver resolver;
+    resolver.VisitOperator(*op);
+  }
 
   // then create the main physical plan
-  profiler.StartPhase(duckdb::MetricType::PHYSICAL_PLANNER_CREATE_PLAN);
+  profiler_phase_guard create_phase(profiler, duckdb::MetricType::PHYSICAL_PLANNER_CREATE_PLAN);
   auto plan = create_plan(*op);
-  profiler.EndPhase();
+  create_phase.end();
 
   plan = fold_adjacent_projections(std::move(plan));
   if (compressed_materialization_active(context)) {

--- a/test/cpp/integration/test_gpu_execution_eager_agg.cpp
+++ b/test/cpp/integration/test_gpu_execution_eager_agg.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_gpu_execution_eager_agg.cpp
+ * @brief End-to-end GPU-vs-CPU correctness for the eager-aggregation-pushdown
+ *        pass (src/planner/eager_agg_pushdown_plan_pass.cpp) on the transparent
+ *        execution path — the path where the rewrite actually runs in
+ *        production. Each "fires" case additionally asserts the pass really
+ *        fired (via its applied counter), so a silently-refused rewrite cannot
+ *        make these tests vacuous; each "refused" case asserts the counter did
+ *        NOT move and the results are still correct.
+ *
+ * The data is built so every NULL/no-match edge of the rewrite is exercised:
+ * customers with zero orders (COUNT must be 0, not NULL, under LEFT/RIGHT
+ * joins), NULL join keys on the pushed side (rows that never match), NULLs in
+ * the aggregated column (COUNT skips them, SUM/MIN/MAX ignore them), duplicate
+ * keys on BOTH sides (N:M multiplicity), and an empty pushed side.
+ */
+
+#include "planner/eager_agg_pushdown_plan_pass.hpp"
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <utils/gpu_execution_fixture.hpp>
+
+#include <cstdlib>
+#include <string>
+
+namespace {
+
+/// RAII environment variable override.
+struct scoped_env {
+  scoped_env(const char* name, const char* value) : _name(name) { setenv(name, value, 1); }
+  ~scoped_env() { unsetenv(_name); }
+  scoped_env(const scoped_env&)            = delete;
+  scoped_env& operator=(const scoped_env&) = delete;
+
+ private:
+  const char* _name;
+};
+
+class EagerAggFixture : public sirius::test::GpuExecutionFixture {
+ public:
+  EagerAggFixture()
+  {
+    // cust: c_id 4 is duplicated (N:M multiplicity through the join); c_id 5
+    // and 6 have no orders (LEFT/RIGHT no-match rows -> COUNT 0 / SUM NULL).
+    run_ok("CREATE TABLE cust (c_id INTEGER, c_grp INTEGER);");
+    run_ok("INSERT INTO cust VALUES (1, 1), (2, 0), (3, 1), (4, 0), (4, 0), (5, 1), (6, 0);");
+    // ord: duplicate join keys (three rows for c_id 1), a NULL join key (never
+    // matches), NULLs in o_val (COUNT counts non-NULLs only), negatives for
+    // MIN/MAX, and o_grp for multi-key joins.
+    run_ok("CREATE TABLE ord (o_cid INTEGER, o_grp INTEGER, o_key INTEGER, o_val INTEGER);");
+    run_ok(
+      "INSERT INTO ord VALUES "
+      "(1, 1, 100, 10), (1, 1, 101, NULL), (1, 0, 102, -7), "
+      "(2, 0, 103, 20), (2, 0, 104, 20), "
+      "(3, 1, 105, NULL), "
+      "(4, 0, 106, -1), (4, 1, 107, 42), "
+      "(NULL, 1, 108, 99);");
+    // ordempty: an empty pushed side.
+    run_ok("CREATE TABLE ordempty (o_cid INTEGER, o_key INTEGER);");
+    run_ok("CHECKPOINT;");
+  }
+
+  /// compare_gpu_vs_cpu, requiring that the pass fired during the GPU planning
+  /// (the CPU run disables transparent execution and never plans on Sirius).
+  void compare_fired(const std::string& query)
+  {
+    auto before = sirius::planner::eager_agg_pushdown_applied_count();
+    compare_gpu_vs_cpu(query);
+    auto after = sirius::planner::eager_agg_pushdown_applied_count();
+    CHECK(after > before);
+  }
+
+  /// compare_gpu_vs_cpu, requiring that the pass did NOT fire.
+  void compare_refused(const std::string& query)
+  {
+    auto before = sirius::planner::eager_agg_pushdown_applied_count();
+    compare_gpu_vs_cpu(query);
+    auto after = sirius::planner::eager_agg_pushdown_applied_count();
+    CHECK(after == before);
+  }
+};
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// Fired shapes: rewritten GPU plan must match the CPU results exactly
+//===----------------------------------------------------------------------===//
+
+TEST_CASE_METHOD(EagerAggFixture,
+                 "gpu_execution eager agg pushdown - LEFT join grouped COUNT (q13 shape)",
+                 "[integration][gpu_execution][eager_agg]")
+{
+  // Customers 5/6 have no orders: COUNT must be 0 (COALESCE repair), not NULL.
+  // Customer 3's only order has o_val NULL: count(o_val) = 0 for a MATCHED row.
+  compare_fired(
+    "SELECT c_id, count(o_key), count(o_val) FROM cust LEFT JOIN ord ON c_id = o_cid "
+    "GROUP BY c_id");
+}
+
+TEST_CASE_METHOD(EagerAggFixture,
+                 "gpu_execution eager agg pushdown - RIGHT join (DuckDB's flipped q13 plan)",
+                 "[integration][gpu_execution][eager_agg]")
+{
+  compare_fired("SELECT c_id, count(o_key) FROM ord RIGHT JOIN cust ON o_cid = c_id GROUP BY c_id");
+}
+
+TEST_CASE_METHOD(EagerAggFixture,
+                 "gpu_execution eager agg pushdown - INNER join COUNT and SUM",
+                 "[integration][gpu_execution][eager_agg]")
+{
+  compare_fired(
+    "SELECT c_id, count(o_key), sum(o_val) FROM cust JOIN ord ON c_id = o_cid GROUP BY c_id");
+}
+
+TEST_CASE_METHOD(EagerAggFixture,
+                 "gpu_execution eager agg pushdown - LEFT join SUM/MIN/MAX keep NULL semantics",
+                 "[integration][gpu_execution][eager_agg]")
+{
+  // Unmatched customers must stay NULL for SUM/MIN/MAX (no COALESCE), and
+  // customer 3 (only NULL o_val) must also be NULL.
+  compare_fired(
+    "SELECT c_id, sum(o_val), min(o_val), max(o_val) FROM cust LEFT JOIN ord ON c_id = o_cid "
+    "GROUP BY c_id");
+}
+
+TEST_CASE_METHOD(EagerAggFixture,
+                 "gpu_execution eager agg pushdown - multi-key equi join",
+                 "[integration][gpu_execution][eager_agg]")
+{
+  compare_fired(
+    "SELECT c_id, count(o_key) FROM cust LEFT JOIN ord ON c_id = o_cid AND c_grp = o_grp "
+    "GROUP BY c_id");
+}
+
+TEST_CASE_METHOD(EagerAggFixture,
+                 "gpu_execution eager agg pushdown - full q13 shape (second GROUP BY over counts)",
+                 "[integration][gpu_execution][eager_agg]")
+{
+  compare_fired(
+    "SELECT c_count, count(*) AS custdist FROM ("
+    "  SELECT c_id, count(o_key) AS c_count FROM cust LEFT JOIN ord ON c_id = o_cid "
+    "  GROUP BY c_id) GROUP BY c_count");
+}
+
+TEST_CASE_METHOD(EagerAggFixture,
+                 "gpu_execution eager agg pushdown - empty pushed side yields COUNT 0 everywhere",
+                 "[integration][gpu_execution][eager_agg]")
+{
+  compare_fired(
+    "SELECT c_id, count(o_key) FROM cust LEFT JOIN ordempty ON c_id = o_cid GROUP BY c_id");
+}
+
+TEST_CASE_METHOD(EagerAggFixture,
+                 "gpu_execution eager agg pushdown - forced pushdown on a filtered preserved side",
+                 "[integration][gpu_execution][eager_agg]")
+{
+  // The default benefit gate refuses a filtered non-pushed side; FORCE bypasses
+  // only the benefit heuristic, so the result must still be exact.
+  scoped_env force("SIRIUS_EAGER_AGG_FORCE", "1");
+  compare_fired(
+    "SELECT c_id, count(o_key) FROM cust LEFT JOIN ord ON c_id = o_cid WHERE c_grp = 1 "
+    "GROUP BY c_id");
+}
+
+//===----------------------------------------------------------------------===//
+// Refused shapes: pass must not fire, results must still be correct
+//===----------------------------------------------------------------------===//
+
+TEST_CASE_METHOD(EagerAggFixture,
+                 "gpu_execution eager agg pushdown - refusals stay refused and correct",
+                 "[integration][gpu_execution][eager_agg]")
+{
+  SECTION("count(*) counts join rows")
+  {
+    compare_refused("SELECT c_id, count(*) FROM cust LEFT JOIN ord ON c_id = o_cid GROUP BY c_id");
+  }
+  SECTION("avg is not decomposed")
+  {
+    compare_refused("SELECT c_id, avg(o_val) FROM cust JOIN ord ON c_id = o_cid GROUP BY c_id");
+  }
+  SECTION("DISTINCT aggregate")
+  {
+    compare_refused(
+      "SELECT c_id, count(DISTINCT o_grp) FROM cust JOIN ord ON c_id = o_cid GROUP BY c_id");
+  }
+  SECTION("group key on the pushed side")
+  {
+    compare_refused("SELECT o_grp, count(o_key) FROM cust JOIN ord ON c_id = o_cid GROUP BY o_grp");
+  }
+  SECTION("aggregates over both sides")
+  {
+    compare_refused(
+      "SELECT c_id, count(o_key), sum(c_grp) FROM cust JOIN ord ON c_id = o_cid GROUP BY c_id");
+  }
+  SECTION("filtered preserved side fails the default benefit gate")
+  {
+    compare_refused(
+      "SELECT c_id, count(o_key) FROM cust LEFT JOIN ord ON c_id = o_cid WHERE c_grp = 1 "
+      "GROUP BY c_id");
+  }
+}
+
+TEST_CASE_METHOD(EagerAggFixture,
+                 "gpu_execution eager agg pushdown - kill switch",
+                 "[integration][gpu_execution][eager_agg]")
+{
+  scoped_env off("SIRIUS_EAGER_AGG_PUSHDOWN", "0");
+  compare_refused(
+    "SELECT c_id, count(o_key) FROM cust LEFT JOIN ord ON c_id = o_cid GROUP BY c_id");
+}

--- a/test/cpp/integration/test_gpu_execution_eager_agg.cpp
+++ b/test/cpp/integration/test_gpu_execution_eager_agg.cpp
@@ -58,12 +58,16 @@ class EagerAggFixture : public sirius::test::GpuExecutionFixture {
   EagerAggFixture()
   {
     // cust: c_id 4 is duplicated (N:M multiplicity through the join); c_id 5
-    // and 6 have no orders (LEFT/RIGHT no-match rows -> COUNT 0 / SUM NULL).
+    // has no orders (LEFT/RIGHT no-match rows -> COUNT 0 / SUM NULL).
     run_ok("CREATE TABLE cust (c_id INTEGER, c_grp INTEGER);");
     run_ok("INSERT INTO cust VALUES (1, 1), (2, 0), (3, 1), (4, 0), (4, 0), (5, 1), (6, 0);");
     // ord: duplicate join keys (three rows for c_id 1), a NULL join key (never
     // matches), NULLs in o_val (COUNT counts non-NULLs only), negatives for
-    // MIN/MAX, and o_grp for multi-key joins.
+    // MIN/MAX, and o_grp for multi-key joins. o_cid spans cust's full c_id
+    // domain [1, 6] on purpose: a narrower domain would let DuckDB's
+    // statistics propagation derive a c_id range filter on the cust scan,
+    // and the benefit gate (correctly) refuses non-bare preserved sides —
+    // which would mask the organic INNER fire path this file exercises.
     run_ok("CREATE TABLE ord (o_cid INTEGER, o_grp INTEGER, o_key INTEGER, o_val INTEGER);");
     run_ok(
       "INSERT INTO ord VALUES "
@@ -71,6 +75,7 @@ class EagerAggFixture : public sirius::test::GpuExecutionFixture {
       "(2, 0, 103, 20), (2, 0, 104, 20), "
       "(3, 1, 105, NULL), "
       "(4, 0, 106, -1), (4, 1, 107, 42), "
+      "(6, 0, 109, NULL), (6, 1, 110, -3), "
       "(NULL, 1, 108, 99);");
     // ordempty: an empty pushed side.
     run_ok("CREATE TABLE ordempty (o_cid INTEGER, o_key INTEGER);");
@@ -107,7 +112,7 @@ TEST_CASE_METHOD(EagerAggFixture,
                  "gpu_execution eager agg pushdown - LEFT join grouped COUNT (q13 shape)",
                  "[integration][gpu_execution][eager_agg]")
 {
-  // Customers 5/6 have no orders: COUNT must be 0 (COALESCE repair), not NULL.
+  // Customer 5 has no orders: COUNT must be 0 (COALESCE repair), not NULL.
   // Customer 3's only order has o_val NULL: count(o_val) = 0 for a MATCHED row.
   compare_fired(
     "SELECT c_id, count(o_key), count(o_val) FROM cust LEFT JOIN ord ON c_id = o_cid "
@@ -125,8 +130,12 @@ TEST_CASE_METHOD(EagerAggFixture,
                  "gpu_execution eager agg pushdown - INNER join COUNT and SUM",
                  "[integration][gpu_execution][eager_agg]")
 {
+  // COUNT over o_val (nullable), not o_key: under an INNER join DuckDB's
+  // optimizer rewrites COUNT of a provably non-NULL column into count_star(),
+  // which the matcher refuses by design (no argument to push). A nullable
+  // argument keeps the plain count(col) shape this test exercises.
   compare_fired(
-    "SELECT c_id, count(o_key), sum(o_val) FROM cust JOIN ord ON c_id = o_cid GROUP BY c_id");
+    "SELECT c_id, count(o_val), sum(o_val) FROM cust JOIN ord ON c_id = o_cid GROUP BY c_id");
 }
 
 TEST_CASE_METHOD(EagerAggFixture,

--- a/test/cpp/planner/test_eager_agg_pushdown.cpp
+++ b/test/cpp/planner/test_eager_agg_pushdown.cpp
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_eager_agg_pushdown.cpp
+ * @brief Plan-shape tests for the eager-aggregation-pushdown pass
+ *        (src/planner/eager_agg_pushdown_plan_pass.cpp).
+ *
+ * The pass runs at the head of sirius_physical_plan_generator::create_plan on
+ * the (unresolved) optimized logical plan, so these tests hand create_plan the
+ * optimizer output directly — exactly what the transparent execution path
+ * captures. A fired rewrite shows up as one extra HASH_GROUP_BY that lives
+ * BELOW the HASH_JOIN; every refusal case must keep the plan's aggregate count
+ * unchanged. GPU-vs-CPU result equality is covered separately by
+ * test/cpp/integration/test_gpu_execution_eager_agg.cpp.
+ */
+
+#include "op/sirius_physical_operator.hpp"
+#include "planner/sirius_physical_plan_generator.hpp"
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/main/config.hpp>
+#include <duckdb/optimizer/optimizer.hpp>
+#include <duckdb/parser/parser.hpp>
+#include <duckdb/planner/planner.hpp>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace duckdb;
+
+using sirius::op::sirius_physical_operator;
+using sirius::op::SiriusPhysicalOperatorType;
+
+namespace {
+
+/// RAII environment variable override.
+struct scoped_env {
+  scoped_env(const char* name, const char* value) : _name(name) { setenv(name, value, 1); }
+  ~scoped_env() { unsetenv(_name); }
+  scoped_env(const scoped_env&)            = delete;
+  scoped_env& operator=(const scoped_env&) = delete;
+
+ private:
+  const char* _name;
+};
+
+class scoped_temp_db_path {
+ public:
+  scoped_temp_db_path()
+  {
+    char tmpl[] = "/tmp/sirius_eager_agg_pushdown_XXXXXX";
+    int fd      = ::mkstemp(tmpl);
+    REQUIRE(fd >= 0);
+    ::close(fd);
+    ::unlink(tmpl);
+    _path = tmpl;
+  }
+
+  ~scoped_temp_db_path()
+  {
+    if (!_path.empty()) {
+      std::remove(_path.c_str());
+      std::remove((_path + ".wal").c_str());
+    }
+  }
+
+  scoped_temp_db_path(const scoped_temp_db_path&)            = delete;
+  scoped_temp_db_path& operator=(const scoped_temp_db_path&) = delete;
+
+  const std::string& path() const { return _path; }
+
+ private:
+  std::string _path;
+};
+
+/// Parse + bind + optimize, then hand the UNRESOLVED optimized plan to
+/// create_plan — the same shape the transparent capture path provides (the
+/// eager-agg pass matches bound column refs, which ColumnBindingResolver would
+/// have rewritten away; create_plan resolves them itself).
+duckdb::unique_ptr<sirius_physical_operator> generate_sirius_plan(Connection& con,
+                                                                  const std::string& query)
+{
+  auto& context = *con.context;
+
+  con.Query("BEGIN TRANSACTION");
+  duckdb::unique_ptr<sirius_physical_operator> result;
+  try {
+    Parser parser(context.GetParserOptions());
+    parser.ParseQuery(query);
+    REQUIRE(parser.statements.size() == 1);
+
+    Planner planner(context);
+    planner.CreatePlan(std::move(parser.statements[0]));
+    REQUIRE(planner.plan);
+
+    Optimizer optimizer(*planner.binder, context);
+    auto plan = optimizer.Optimize(std::move(planner.plan));
+
+    sirius::planner::sirius_physical_plan_generator gen(context);
+    result = gen.create_plan(std::move(plan));
+  } catch (...) {
+    con.Query("ROLLBACK");
+    throw;
+  }
+  con.Query("COMMIT");
+  return result;
+}
+
+template <typename Fn>
+void for_each_operator(sirius_physical_operator* root, const Fn& fn)
+{
+  if (!root) { return; }
+  fn(root);
+  for (auto& child : root->children) {
+    for_each_operator(child.get(), fn);
+  }
+}
+
+std::size_t count_ops(sirius_physical_operator* root, SiriusPhysicalOperatorType type)
+{
+  std::size_t count = 0;
+  for_each_operator(root, [&](sirius_physical_operator* op) {
+    if (op->type == type) { count++; }
+  });
+  return count;
+}
+
+sirius_physical_operator* find_first(sirius_physical_operator* root,
+                                     SiriusPhysicalOperatorType type)
+{
+  sirius_physical_operator* found = nullptr;
+  for_each_operator(root, [&](sirius_physical_operator* op) {
+    if (found == nullptr && op->type == type) { found = op; }
+  });
+  return found;
+}
+
+void tree_to_string(sirius_physical_operator* root, int depth, std::ostringstream& out)
+{
+  if (!root) { return; }
+  out << std::string(static_cast<size_t>(depth) * 2, ' ')
+      << sirius::op::SiriusPhysicalOperatorToString(root->type) << "\n";
+  for (auto& child : root->children) {
+    tree_to_string(child.get(), depth + 1, out);
+  }
+}
+
+std::string tree_to_string(sirius_physical_operator* root)
+{
+  std::ostringstream out;
+  tree_to_string(root, 0, out);
+  return out.str();
+}
+
+struct eager_agg_pushdown_fixture {
+  eager_agg_pushdown_fixture()
+  {
+    auto cfg = std::filesystem::path(SIRIUS_PROJECT_ROOT) / "test" / "cpp" / "config" / "data" /
+               "minimal.yaml";
+    setenv("SIRIUS_CONFIG_FILE", cfg.string().c_str(), 1);
+    unsetenv("SIRIUS_DISABLE");
+    db = std::make_unique<DuckDB>(_db_path.path());
+    setenv("SIRIUS_DISABLE", "1", 1);
+    con = std::make_unique<Connection>(*db);
+
+    // cust is the preserved / non-pushed side (bare, unfiltered scan); ord is
+    // the pushed side with duplicate keys so the pre-aggregation actually
+    // reduces rows.
+    con->Query("CREATE TABLE cust (c_id INTEGER, c_grp INTEGER)");
+    con->Query("INSERT INTO cust SELECT range, range % 2 FROM range(20)");
+    con->Query("CREATE TABLE ord (o_cid INTEGER, o_grp INTEGER, o_key INTEGER, o_val INTEGER)");
+    con->Query("INSERT INTO ord SELECT range % 10, range % 2, range, range * 3 FROM range(200)");
+  }
+
+  ~eager_agg_pushdown_fixture() { unsetenv("SIRIUS_CONFIG_FILE"); }
+
+  /// A fired rewrite adds exactly one grouped aggregate, and it must sit below
+  /// the join.
+  void require_fired(const std::string& query, std::size_t baseline_aggregates = 1)
+  {
+    auto plan = generate_sirius_plan(*con, query);
+    INFO(tree_to_string(plan.get()));
+    CHECK(count_ops(plan.get(), SiriusPhysicalOperatorType::HASH_GROUP_BY) ==
+          baseline_aggregates + 1);
+    auto* join = find_first(plan.get(), SiriusPhysicalOperatorType::HASH_JOIN);
+    REQUIRE(join != nullptr);
+    std::size_t below_join = 0;
+    for (auto& child : join->children) {
+      below_join += count_ops(child.get(), SiriusPhysicalOperatorType::HASH_GROUP_BY);
+    }
+    CHECK(below_join == 1);
+  }
+
+  void require_refused(const std::string& query, std::size_t baseline_aggregates = 1)
+  {
+    auto plan = generate_sirius_plan(*con, query);
+    INFO(tree_to_string(plan.get()));
+    CHECK(count_ops(plan.get(), SiriusPhysicalOperatorType::HASH_GROUP_BY) == baseline_aggregates);
+  }
+
+  // Declared before db/con so the backing file outlives the database.
+  scoped_temp_db_path _db_path;
+  std::unique_ptr<DuckDB> db;
+  std::unique_ptr<Connection> con;
+};
+
+constexpr const char* kQ13Inner =
+  "SELECT c_id, count(o_key) FROM cust LEFT JOIN ord ON c_id = o_cid GROUP BY c_id";
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// Fired shapes
+//===----------------------------------------------------------------------===//
+
+TEST_CASE_METHOD(eager_agg_pushdown_fixture,
+                 "eager agg pushdown - fires on the q13 shape (LEFT join + grouped COUNT)",
+                 "[eager_agg_pushdown][isolated_context]")
+{
+  scoped_env ratio("SIRIUS_EAGER_AGG_MIN_RATIO", "0");
+  require_fired(kQ13Inner);
+}
+
+TEST_CASE_METHOD(eager_agg_pushdown_fixture,
+                 "eager agg pushdown - fires with a RIGHT join (DuckDB's flipped q13 plan)",
+                 "[eager_agg_pushdown][isolated_context]")
+{
+  scoped_env ratio("SIRIUS_EAGER_AGG_MIN_RATIO", "0");
+  require_fired("SELECT c_id, count(o_key) FROM ord RIGHT JOIN cust ON o_cid = c_id GROUP BY c_id");
+}
+
+TEST_CASE_METHOD(eager_agg_pushdown_fixture,
+                 "eager agg pushdown - fires on INNER joins and SUM/MIN/MAX",
+                 "[eager_agg_pushdown][isolated_context]")
+{
+  scoped_env ratio("SIRIUS_EAGER_AGG_MIN_RATIO", "0");
+  require_fired(
+    "SELECT c_id, sum(o_val), min(o_val), max(o_val) FROM cust JOIN ord ON c_id = o_cid "
+    "GROUP BY c_id");
+}
+
+TEST_CASE_METHOD(eager_agg_pushdown_fixture,
+                 "eager agg pushdown - fires on multi-key equi joins",
+                 "[eager_agg_pushdown][isolated_context]")
+{
+  scoped_env ratio("SIRIUS_EAGER_AGG_MIN_RATIO", "0");
+  require_fired(
+    "SELECT c_id, count(o_key) FROM cust LEFT JOIN ord ON c_id = o_cid AND c_grp = o_grp "
+    "GROUP BY c_id");
+}
+
+TEST_CASE_METHOD(eager_agg_pushdown_fixture,
+                 "eager agg pushdown - fires on the full q13 (nested second GROUP BY)",
+                 "[eager_agg_pushdown][isolated_context]")
+{
+  scoped_env ratio("SIRIUS_EAGER_AGG_MIN_RATIO", "0");
+  // Two aggregates in the baseline plan (inner per-customer count + outer
+  // histogram); the rewrite adds a third below the join.
+  require_fired(
+    "SELECT c_count, count(*) FROM ("
+    "  SELECT c_id, count(o_key) AS c_count FROM cust LEFT JOIN ord ON c_id = o_cid "
+    "  GROUP BY c_id) GROUP BY c_count",
+    /*baseline_aggregates=*/2);
+}
+
+//===----------------------------------------------------------------------===//
+// Refused shapes (correctness gates)
+//===----------------------------------------------------------------------===//
+
+TEST_CASE_METHOD(eager_agg_pushdown_fixture,
+                 "eager agg pushdown - refuses non-decomposable or decorated aggregates",
+                 "[eager_agg_pushdown][isolated_context]")
+{
+  scoped_env ratio("SIRIUS_EAGER_AGG_MIN_RATIO", "0");
+  SECTION("count(*) counts join rows, not pushed-side rows")
+  {
+    require_refused("SELECT c_id, count(*) FROM cust LEFT JOIN ord ON c_id = o_cid GROUP BY c_id");
+  }
+  SECTION("avg is not in the decomposable set")
+  {
+    require_refused(
+      "SELECT c_id, avg(o_val) FROM cust LEFT JOIN ord ON c_id = o_cid GROUP BY c_id");
+  }
+  SECTION("DISTINCT aggregates")
+  {
+    require_refused(
+      "SELECT c_id, count(DISTINCT o_key) FROM cust LEFT JOIN ord ON c_id = o_cid GROUP BY c_id");
+  }
+  SECTION("FILTER clauses")
+  {
+    require_refused(
+      "SELECT c_id, count(o_key) FILTER (WHERE o_val > 30) FROM cust LEFT JOIN ord "
+      "ON c_id = o_cid GROUP BY c_id");
+  }
+  SECTION("aggregate over an expression, not a plain column")
+  {
+    // o_val + o_grp (two columns) so DuckDB's SumRewriter cannot reduce it to
+    // sum(col) + C*count(col), which WOULD be a legitimately pushable shape.
+    require_refused(
+      "SELECT c_id, sum(o_val + o_grp) FROM cust JOIN ord ON c_id = o_cid GROUP BY c_id");
+  }
+}
+
+TEST_CASE_METHOD(eager_agg_pushdown_fixture,
+                 "eager agg pushdown - refuses when references would escape the pushed side",
+                 "[eager_agg_pushdown][isolated_context]")
+{
+  scoped_env ratio("SIRIUS_EAGER_AGG_MIN_RATIO", "0");
+  SECTION("group key on the pushed side")
+  {
+    require_refused("SELECT o_grp, count(o_key) FROM cust JOIN ord ON c_id = o_cid GROUP BY o_grp");
+  }
+  SECTION("aggregates over both sides")
+  {
+    require_refused(
+      "SELECT c_id, count(o_key), sum(c_grp) FROM cust JOIN ord ON c_id = o_cid GROUP BY c_id");
+  }
+}
+
+TEST_CASE_METHOD(eager_agg_pushdown_fixture,
+                 "eager agg pushdown - refuses unsupported join shapes",
+                 "[eager_agg_pushdown][isolated_context]")
+{
+  scoped_env ratio("SIRIUS_EAGER_AGG_MIN_RATIO", "0");
+  SECTION("FULL OUTER join")
+  {
+    require_refused(
+      "SELECT c_id, count(o_key) FROM cust FULL JOIN ord ON c_id = o_cid GROUP BY c_id");
+  }
+  SECTION("mixed equality + inequality conditions")
+  {
+    require_refused(
+      "SELECT c_id, count(o_key) FROM cust JOIN ord ON c_id = o_cid AND c_grp < o_grp "
+      "GROUP BY c_id");
+  }
+  SECTION("pushed-side join key is an expression")
+  {
+    require_refused(
+      "SELECT c_id, count(o_key) FROM cust JOIN ord ON c_id = o_cid + 1 GROUP BY c_id");
+  }
+}
+
+TEST_CASE_METHOD(eager_agg_pushdown_fixture,
+                 "eager agg pushdown - refuses ungrouped aggregates",
+                 "[eager_agg_pushdown][isolated_context]")
+{
+  scoped_env ratio("SIRIUS_EAGER_AGG_MIN_RATIO", "0");
+  auto plan =
+    generate_sirius_plan(*con, "SELECT count(o_key) FROM cust LEFT JOIN ord ON c_id = o_cid");
+  INFO(tree_to_string(plan.get()));
+  CHECK(count_ops(plan.get(), SiriusPhysicalOperatorType::HASH_GROUP_BY) == 0);
+}
+
+//===----------------------------------------------------------------------===//
+// Benefit gate + kill switch
+//===----------------------------------------------------------------------===//
+
+TEST_CASE_METHOD(eager_agg_pushdown_fixture,
+                 "eager agg pushdown - estimate ratio gate is honored",
+                 "[eager_agg_pushdown][isolated_context]")
+{
+  // Plans generated directly (not via the transparent capture copy) carry
+  // optimizer cardinality estimates, so the ratio branch decides. An
+  // unattainable threshold must refuse the otherwise-provable q13 shape.
+  scoped_env ratio("SIRIUS_EAGER_AGG_MIN_RATIO", "1000000000");
+  require_refused(kQ13Inner);
+}
+
+TEST_CASE_METHOD(eager_agg_pushdown_fixture,
+                 "eager agg pushdown - kill switch disables the pass",
+                 "[eager_agg_pushdown][isolated_context]")
+{
+  scoped_env ratio("SIRIUS_EAGER_AGG_MIN_RATIO", "0");
+  scoped_env off("SIRIUS_EAGER_AGG_PUSHDOWN", "0");
+  require_refused(kQ13Inner);
+}

--- a/test/cpp/planner/test_eager_agg_pushdown.cpp
+++ b/test/cpp/planner/test_eager_agg_pushdown.cpp
@@ -186,11 +186,15 @@ struct eager_agg_pushdown_fixture {
 
     // cust is the preserved / non-pushed side (bare, unfiltered scan); ord is
     // the pushed side with duplicate keys so the pre-aggregation actually
-    // reduces rows.
+    // reduces rows. o_cid spans cust's full c_id domain [0, 19] on purpose: a
+    // narrower domain would let DuckDB's statistics propagation derive a c_id
+    // range filter on the cust scan, and the benefit gate (correctly) refuses
+    // non-bare preserved sides — which would mask the organic fire shapes
+    // this file asserts on.
     con->Query("CREATE TABLE cust (c_id INTEGER, c_grp INTEGER)");
     con->Query("INSERT INTO cust SELECT range, range % 2 FROM range(20)");
     con->Query("CREATE TABLE ord (o_cid INTEGER, o_grp INTEGER, o_key INTEGER, o_val INTEGER)");
-    con->Query("INSERT INTO ord SELECT range % 10, range % 2, range, range * 3 FROM range(200)");
+    con->Query("INSERT INTO ord SELECT range % 20, range % 2, range, range * 3 FROM range(200)");
   }
 
   ~eager_agg_pushdown_fixture() { unsetenv("SIRIUS_CONFIG_FILE"); }


### PR DESCRIPTION
# perf(planner): eager aggregation pushdown below equi-joins (TPC-H q13)

**Branch:** `pr/eager-agg-pushdown` → base: **`dev`** (standalone — applies, builds, and the full unit suite is green on current `dev`).

## What

Yan & Larson eager/lazy aggregation as a Sirius logical plan pass: when a grouped aggregate sits on an equi-join (directly, or through one pure column-ref pass-through projection) and every aggregate input comes from one join side, pre-aggregate that side by its join keys below the join and combine the partials above it. q13's customer–orders join then consumes ~100M partial counts instead of ~1.48B filtered order rows (the join phase was 47% of q13 at SF1000; the regroup it replaces costs 71.7 ms in the same profile).

DuckDB's optimizer does not perform this rewrite (verified on v1.5.5: the optimized q13 plan keeps the aggregate above the join), so it lands as a Sirius-side transform at the head of `create_plan`, on the captured copy only — CPU plans are untouched.

## Correctness gates (fail closed, all provable at plan time)

- single grouping set, no `GROUPING()`, plain column-ref group keys that never touch the pushed side;
- aggregates are single-column-ref `COUNT`/`SUM`/`SUM_NO_OVERFLOW`/`MIN`/`MAX`, no DISTINCT/FILTER/ORDER BY, all args from the pushed side;
- plain comparison join, INNER or LEFT/RIGHT pushing into the non-preserved side, all conditions `=` with a column-ref pushed side, no residual predicate;
- COUNT's 0-vs-NULL repair under outer joins via COALESCE, and combine-type widening (`SUM(BIGINT)`→`HUGEINT`) cast back, so the output schema is byte-identical;
- if the rewritten copy fails ANY later planning stage, `create_plan` retries with the untouched original plan.

**Benefit gate** (heuristic only, never affects correctness): the non-pushed side must be a bare unfiltered scan — q18's structurally-matching aggregate (SUM over a semi-join-reduced side) is refused; pre-aggregating 6B unfiltered lineitem rows for a tiny join would be a large regression. When optimizer estimates are present (directly-planned paths) an estimated join-output/pushed-input ratio ≥ 0.5 refines the decision. Env: `SIRIUS_EAGER_AGG_PUSHDOWN=0` kill switch, `SIRIUS_EAGER_AGG_FORCE=1` gate bypass, `SIRIUS_EAGER_AGG_MIN_RATIO` threshold; all read per use for in-process A/B.

## Measured (SF1000, GB300)

- **q13 −9.7%**; suite-neutral otherwise.
- Fire-set audit at SF0.1: **exactly q13 fires across all 22 TPC-H queries**; GPU results equal CPU on all 22 (q1 differs only in last-digit float noise, pass not involved).

## Adaptation notes (dev rebase, honest)

Authored on the wave-4 experiment stack (2 commits: base pass + tracing through one pure column-ref projection, the shape DuckDB's column pruning inserts on some INNER joins). Adapted to `dev` with the pass logic **byte-identical**; the only conflicts were context (a `late_mat_plan_pass` sibling registration in CMakeLists and its `#include`, dropped — that lineage belongs to #1409).

A third commit repairs two tests that could not pass as written — **verified by rebuilding the original experiment branch: they failed identically there**, so this is not an adaptation regression:

1. Both INNER fire-shape fixtures gave the pushed side a key domain strictly narrower than the preserved side's. Under an INNER join, DuckDB's statistics propagation derives a range filter on the preserved-side scan, and the benefit gate (correctly, by design) refuses non-bare preserved sides. The `MIN_RATIO=0` escape the tests relied on is unreachable on the path they exercise: `LogicalOperator::Copy` drops optimizer cardinality estimates, so the ratio branch never sees them on the capture-path copy the pass rewrites. Fixed by making the pushed side's key domain span the preserved side's exactly (no filter derived; the documented heuristic fires organically). LEFT/RIGHT shapes never hit this — an outer join cannot filter its preserved side.
2. The integration INNER test counted a provably non-NULL column, which DuckDB rewrites into `count_star()` under INNER joins — a zero-argument aggregate the matcher refuses by design. It now counts the nullable column, keeping the plain `count(col)` shape the test means to exercise.

Reviewers may reasonably ask whether the pass should preserve estimates across its own copy (restoring the ratio gate on capture paths); that would change production gating for q13 and was deliberately NOT done here — logic is exactly as measured.

## Tests

- `test/cpp/planner/test_eager_agg_pushdown.cpp` (`[eager_agg_pushdown]`): plan-shape suite — fires (q13 LEFT, flipped RIGHT, INNER, multi-key, nested second GROUP BY) and the full refusal matrix (decorated/non-decomposable aggregates, escaping references, unsupported join shapes, ungrouped aggregates, ratio gate, kill switch).
- `test/cpp/integration/test_gpu_execution_eager_agg.cpp` (`[eager_agg]`): GPU-vs-CPU equivalence covering no-match rows, NULL keys, NULL aggregate inputs, N:M multiplicity, empty pushed side, forced pushdown on a filtered preserved side, and every refusal class.
- Run on this branch (current `dev` base): own tags 21/21 green (695 assertions); **full unit suite 2468/2469 passed, 1 skipped, 0 failed** (32.3M assertions; the known `[!mayfail]` null-safe MARK join limitation is unrelated and pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
