### PR TITLE
perf(concat): lock-free readiness hint and taskless single-batch forwarding

### DIFF
--- a/src/include/op/sirius_physical_concat.hpp
+++ b/src/include/op/sirius_physical_concat.hpp
@@ -25,6 +25,8 @@
 #include "op/sirius_physical_top_n.hpp"
 #include "sirius_config.hpp"
 
+#include <unordered_map>
+
 namespace sirius {
 namespace op {
 
@@ -56,9 +58,24 @@ class sirius_physical_concat : public sirius_physical_partition_consumer_operato
     return _downstream_join;
   }
 
+  //! Answers READY/WAITING from the per-partition push-time totals (`_input_totals`), so the task
+  //! creator's manager thread never touches a buffered `data_batch` lock. Once the source pipeline
+  //! finishes, READY is decided from repository emptiness alone, independent of the totals.
   std::optional<task_creation_hint> get_next_task_hint() override;
 
+  //! Forms the next input group with the greedy size-threshold walk over partitions. A group of
+  //! exactly one batch is not wrapped in a task when sink wiring exists: since execute is an
+  //! identity for one batch, the batch is pushed directly to the downstream consumers via their
+  //! `push_data_batch_partitioned` (the same publication path `sink` uses) and the walk continues.
   std::unique_ptr<operator_data> get_next_task_input_data() override;
+
+  //! Measures the batch's size and records it in the per-partition totals before delegating to the
+  //! base implementation, which publishes the batch into the input repository. This override is
+  //! the accounting entry point: `get_next_task_hint` answers from the totals, so producers must
+  //! push through it (the upstream PARTITION sink dispatches here through the virtual).
+  void push_data_batch_partitioned(std::string_view port_id,
+                                   std::shared_ptr<::cucascade::data_batch> batch,
+                                   std::size_t partition_idx) override;
 
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
@@ -73,11 +90,31 @@ class sirius_physical_concat : public sirius_physical_partition_consumer_operato
     const op::input_stats& stats) const override;
 
  private:
+  //! Running byte/batch totals over one input partition's currently buffered batches.
+  struct partition_totals {
+    uint64_t bytes    = 0;
+    std::size_t count = 0;
+  };
+
+  //! Pop `batch_id` from `repo` and subtract its ledgered push-time size from the partition's
+  //! totals. Requires `lock` to be held. Batches that entered the repository without going through
+  //! `push_data_batch_partitioned` have no ledger entry and leave the totals untouched.
+  std::shared_ptr<::cucascade::data_batch> pop_and_account(
+    ::cucascade::shared_data_repository& repo, uint64_t batch_id, std::size_t partition_idx);
+
   bool _is_build;
   bool _concat_all;
   uint64_t _concat_batch_bytes;
   //! Non-owning. Captured at construction from the `downstream_join` ctor argument.
   sirius_physical_operator* _downstream_join = nullptr;
+  //! Per-partition totals, indexed by partition and grown on push. Guarded by `lock`. Sizes are
+  //! snapshotted at push time, so they can drift from live sizes while a batch idles (downgrade
+  //! converts batches in place); the drift is bounded to the currently buffered batches and
+  //! self-heals on pop — acceptable for a batching heuristic.
+  std::vector<partition_totals> _input_totals;
+  //! Push-time size of every currently buffered batch, keyed by batch id, so pops subtract exactly
+  //! what the push added even when a batch's live size changed while idle. Guarded by `lock`.
+  std::unordered_map<uint64_t, uint64_t> _pushed_batch_bytes;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_concat.hpp
+++ b/src/include/op/sirius_physical_concat.hpp
@@ -67,6 +67,10 @@ class sirius_physical_concat : public sirius_physical_partition_consumer_operato
   //! exactly one batch is not wrapped in a task when sink wiring exists: since execute is an
   //! identity for one batch, the batch is pushed directly to the downstream consumers via their
   //! `push_data_batch_partitioned` (the same publication path `sink` uses) and the walk continues.
+  //! Group sizes come from the push-time ledger, never a live batch lock. Contract: pipeline-wired
+  //! callers hold the pipeline's get_task_creation_lock() (see sirius_pipeline.hpp) across the
+  //! call — the forward's in-flight batch is in no repository, hidden from finish evaluation only
+  //! by that lock.
   std::unique_ptr<operator_data> get_next_task_input_data() override;
 
   //! Measures the batch's size and records it in the per-partition totals before delegating to the
@@ -101,6 +105,14 @@ class sirius_physical_concat : public sirius_physical_partition_consumer_operato
   //! `push_data_batch_partitioned` have no ledger entry and leave the totals untouched.
   std::shared_ptr<::cucascade::data_batch> pop_and_account(
     ::cucascade::shared_data_repository& repo, uint64_t batch_id, std::size_t partition_idx);
+
+  //! Requires `lock`. Push-time size from the ledger — the walk must never take a batch lock (a
+  //! downgrade conversion may hold it; see get_next_task_hint). Unledgered batches (direct
+  //! repository inserts in tests; broadcast's duplicate ids never reach sizing, as broadcast
+  //! implies concat_all) fall back to a live, possibly blocking, measurement.
+  [[nodiscard]] uint64_t buffered_batch_size(::cucascade::shared_data_repository& repo,
+                                             uint64_t batch_id,
+                                             std::size_t partition_idx) const;
 
   bool _is_build;
   bool _concat_all;

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -210,6 +210,7 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! (port data pop, partition claim, etc.) and the task constructor that calls
   //! mark_task_created(), so that update_pipeline_status() cannot observe an
   //! empty-port / balanced-counter state while a task is mid-creation.
+  //! Also serializes concat's taskless forward (pop -> downstream push) against finish evaluation.
   [[nodiscard]] std::unique_lock<std::mutex> get_task_creation_lock();
 
   [[nodiscard]] uuid::UUID pipeline_uuid() const { return _pipeline_uuid; }

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -16,12 +16,16 @@
 
 #include "op/sirius_physical_concat.hpp"
 
+#include "creator/task_creator.hpp"
 #include "data/data_batch_utils.hpp"
+#include "log/logging.hpp"
 #include "op/merge/gpu_merge_impl.hpp"
 #include "op/sirius_physical_hash_join.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 
 #include <nvtx3/nvtx3.hpp>
+
+#include <algorithm>
 
 namespace sirius {
 namespace op {
@@ -76,45 +80,32 @@ std::optional<task_creation_hint> sirius_physical_concat::get_next_task_hint()
     throw std::runtime_error("sirius_physical_concat: there should be only one port");
   }
 
-  auto port_ptr          = ports.begin()->second;
-  bool pipeline_finished = port_ptr->src_pipeline && port_ptr->src_pipeline->is_pipeline_finished();
+  auto port_ptr = ports.begin()->second;
 
-  // If the source pipeline is done, we're ready to process whatever data remains
-  if (pipeline_finished) {
+  // If the source pipeline is done, we're ready to process whatever data remains. This check reads
+  // only the repository's own bookkeeping (never a batch lock), keeping the residual flush — and
+  // with it deadlock-freedom — independent of the totals. The base helper treats a port without a
+  // src_pipeline as finished, so unwired ports resolve here instead of dereferencing null below.
+  if (is_source_pipeline_finished()) {
     if (port_ptr->repo->total_size() > 0) {
       return task_creation_hint{TaskCreationHint::READY, this};
     }
     return std::nullopt;
-  } else if (_concat_all) {
+  }
+  if (_concat_all) {
     // if we need to concat all then we need to wait for the pipeline to be finished
     return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA,
                               &(port_ptr->src_pipeline->get_operators()[0].get())};
   }
 
-  // Source pipeline still running — check if there is enough data to fire a task early.
-  // "Enough" means: for some partition, simulating get_next_task_input_data would pull a group
-  // of batches AND there would still be at least one batch left in that partition afterward.
-  for (size_t i = 0; i < port_ptr->repo->num_partitions(); i++) {
-    auto batch_ids          = port_ptr->repo->get_batch_ids(i);
-    size_t total_batch_size = 0;
-    size_t pulled_count     = 0;
-    for (auto& batch_id : batch_ids) {
-      auto batch_idle = port_ptr->repo->get_data_batch_by_id(batch_id, i);
-      auto batch_ro   = batch_idle->to_read_only();
-      auto batch_size = batch_ro.get_data()->get_size_in_bytes();
-      total_batch_size += batch_size;
-      if (!_concat_all && total_batch_size > _concat_batch_bytes) {
-        // This batch pushes us over the threshold — the loop would stop here.
-        // If we already accumulated batches (pulled_count > 0), the overflowing batch stays,
-        // so there is at least one batch left after the pull.
-        if (pulled_count > 0) { return task_creation_hint{TaskCreationHint::READY, this}; }
-        // If nothing was accumulated yet, the single oversized batch itself would be pulled,
-        // and remaining data is everything after it.
-        if (batch_ids.size() > 1) { return task_creation_hint{TaskCreationHint::READY, this}; }
-        break;
-      } else {
-        pulled_count++;
-      }
+  // Source pipeline still running — fire early once a partition has buffered more than the
+  // batching threshold across at least two batches. A lone oversized batch keeps WAITING: it
+  // either gains a groupmate or is flushed once the source finishes. Answered from the push-time
+  // totals, so this runs without touching any data_batch lock (this is polled on the task
+  // creator's single manager thread, which must not block behind a downgrade's exclusive lock).
+  for (const auto& totals : _input_totals) {
+    if (totals.bytes > _concat_batch_bytes && totals.count >= 2) {
+      return task_creation_hint{TaskCreationHint::READY, this};
     }
   }
 
@@ -123,50 +114,149 @@ std::optional<task_creation_hint> sirius_physical_concat::get_next_task_hint()
                             &(port_ptr->src_pipeline->get_operators()[0].get())};
 }
 
+void sirius_physical_concat::push_data_batch_partitioned(
+  std::string_view port_id,
+  std::shared_ptr<::cucascade::data_batch> batch,
+  std::size_t partition_idx)
+{
+  if (batch) {
+    // Measure outside `lock`: to_read_only can block behind a downgrade's exclusive lock, and a
+    // blocked push (a worker thread) must not hold the mutex the manager-thread hint needs.
+    const uint64_t batch_size = batch->to_read_only().get_data()->get_size_in_bytes();
+    std::lock_guard<std::mutex> lg(lock);
+    if (_input_totals.size() <= partition_idx) { _input_totals.resize(partition_idx + 1); }
+    _pushed_batch_bytes[batch->get_batch_id()] = batch_size;
+    _input_totals[partition_idx].bytes += batch_size;
+    _input_totals[partition_idx].count += 1;
+  }
+  // Delegate outside `lock`: the base's telemetry publish also takes the batch's shared lock,
+  // which must never be acquired under the mutex the hint needs. Accounting before the repository
+  // insert guarantees every poppable batch already has its ledger entry; the transient window
+  // where the totals include a batch that is not yet poppable is within the documented drift
+  // heuristic (the pull remains authoritative for what is actually popped).
+  sirius_physical_partition_consumer_operator::push_data_batch_partitioned(
+    port_id, std::move(batch), partition_idx);
+}
+
+std::shared_ptr<::cucascade::data_batch> sirius_physical_concat::pop_and_account(
+  ::cucascade::shared_data_repository& repo, uint64_t batch_id, std::size_t partition_idx)
+{
+  auto popped = repo.pop_data_batch_by_id(batch_id, partition_idx);
+  auto ledger = _pushed_batch_bytes.find(batch_id);
+  if (ledger != _pushed_batch_bytes.end()) {
+    auto& totals = _input_totals[partition_idx];
+    totals.bytes -= ledger->second;
+    totals.count -= 1;
+    _pushed_batch_bytes.erase(ledger);
+  } else {
+    // Production wiring always enters through push_data_batch_partitioned; an unledgered pop
+    // means something bypassed the accounting (tests that insert straight into the repository).
+    SIRIUS_LOG_DEBUG("sirius_physical_concat: popped batch {} has no push-time ledger entry",
+                     batch_id);
+  }
+  return popped;
+}
+
 std::unique_ptr<operator_data> sirius_physical_concat::get_next_task_input_data()
 {
-  // iterate through all the partition and pull
-  std::lock_guard<std::mutex> lg(lock);
+  std::unique_ptr<operator_data> task_input;
+  bool forwarded = false;
 
-  // assert that there is only one port
-  if (ports.size() != 1) {
-    throw std::runtime_error("sirius_physical_concat: there should be only one port");
-  }
+  // Each pass forms one group; a single-batch group with sink wiring is forwarded downstream
+  // without a task (execute is an identity for it) and the walk repeats. Every forward removes a
+  // batch from the repository, so the loop terminates.
+  while (true) {
+    std::shared_ptr<::cucascade::data_batch> single_batch;
+    std::size_t single_partition_idx = 0;
+    {
+      // iterate through all the partition and pull
+      std::lock_guard<std::mutex> lg(lock);
 
-  auto port_ptr = ports.begin()->second;
-  for (size_t i = 0; i < port_ptr->repo->num_partitions(); i++) {
-    std::vector<std::shared_ptr<::cucascade::data_batch>> input_batch;
-    // get all the batch ids from the partition
-    auto batch_ids          = port_ptr->repo->get_batch_ids(i);
-    size_t total_batch_size = 0;
-    for (auto& batch_id : batch_ids) {
-      auto batch_idle = port_ptr->repo->get_data_batch_by_id(batch_id, i);
-      auto batch_ro   = batch_idle->to_read_only();
-      auto batch_size = batch_ro.get_data()->get_size_in_bytes();
-      total_batch_size += batch_size;
-      // Check if the batch size is already exceed the threshold
-      if (!_concat_all && total_batch_size > _concat_batch_bytes) {
-        // if the batch size is already exceed the threshold, then we need to return the batch right
-        // away
-        if (input_batch.size() == 0) {
-          // this mean that there is a batch that is bigger than the threshold, then we just output
-          // that batch right away
-          auto popped_batch = port_ptr->repo->pop_data_batch_by_id(batch_id, i);
-          input_batch.push_back(std::move(popped_batch));
+      // assert that there is only one port
+      if (ports.size() != 1) {
+        throw std::runtime_error("sirius_physical_concat: there should be only one port");
+      }
+
+      auto port_ptr = ports.begin()->second;
+      for (size_t i = 0; i < port_ptr->repo->num_partitions(); i++) {
+        std::vector<std::shared_ptr<::cucascade::data_batch>> input_batch;
+        // get all the batch ids from the partition
+        auto batch_ids          = port_ptr->repo->get_batch_ids(i);
+        size_t total_batch_size = 0;
+        for (auto& batch_id : batch_ids) {
+          auto batch_idle = port_ptr->repo->get_data_batch_by_id(batch_id, i);
+          auto batch_ro   = batch_idle->to_read_only();
+          auto batch_size = batch_ro.get_data()->get_size_in_bytes();
+          total_batch_size += batch_size;
+          // Check if the batch size is already exceed the threshold
+          if (!_concat_all && total_batch_size > _concat_batch_bytes) {
+            // if the batch size is already exceed the threshold, then we need to return the batch
+            // right away
+            if (input_batch.size() == 0) {
+              // this mean that there is a batch that is bigger than the threshold, then we just
+              // output that batch right away
+              input_batch.push_back(pop_and_account(*port_ptr->repo, batch_id, i));
+            }
+            break;
+          } else {
+            // if the batch size does not exceed the threshold, then we need to add the batch to
+            // the input batch
+            input_batch.push_back(pop_and_account(*port_ptr->repo, batch_id, i));
+          }
         }
-        break;
-      } else {
-        // if the batch size does not exceed the threshold, then we need to add the batch to the
-        // input batch
-        auto popped_batch = port_ptr->repo->pop_data_batch_by_id(batch_id, i);
-        input_batch.push_back(std::move(popped_batch));
+        if (input_batch.size() != 0) {
+          if (input_batch.size() == 1 && !next_port_after_sink.empty()) {
+            single_batch         = std::move(input_batch[0]);
+            single_partition_idx = i;
+          } else {
+            task_input = std::make_unique<partitioned_operator_data>(std::move(input_batch), i);
+          }
+          break;
+        }
       }
     }
-    if (input_batch.size() != 0) {
-      return std::make_unique<partitioned_operator_data>(std::move(input_batch), i);
+    if (!single_batch) { break; }
+
+    // Forward the single batch outside `lock`: it is exclusively ours (popped, in no repository),
+    // and the downstream push must not run under this operator's mutex. Pushing through
+    // push_data_batch_partitioned matches sink(): telemetry publish, partition tagging, and any
+    // consumer-side hooks (e.g. the hash join's build-port dynamic-filter publish) all fire.
+    for (auto& next_port_info : next_port_after_sink) {
+      auto partition_consumer_op =
+        dynamic_cast<sirius_physical_partition_consumer_operator*>(next_port_info.next_operator);
+      if (partition_consumer_op) {
+        partition_consumer_op->push_data_batch_partitioned(
+          next_port_info.next_operator_port_name, single_batch, single_partition_idx);
+      } else {
+        throw std::runtime_error(
+          "sirius_physical_concat::get_next_task_input_data(): Next operator is not a partition "
+          "consumer operator: " +
+          SiriusPhysicalOperatorToString(next_port_info.next_operator->type));
+      }
+    }
+    forwarded = true;
+  }
+
+  if (forwarded) {
+    // A forward creates no task, so the executor's per-task consumer ping never fires; re-arm the
+    // downstream consumers here. schedule() only touches the task creator's thread-safe creation
+    // queue, so calling it from this (creator worker) thread is safe; a redundant ping is
+    // harmless.
+    auto pipeline      = get_pipeline();
+    auto* task_creator = pipeline ? pipeline->get_task_creator() : nullptr;
+    if (task_creator) {
+      std::vector<sirius_physical_operator*> pinged;
+      for (auto& next_port_info : next_port_after_sink) {
+        auto* consumer = next_port_info.next_operator;
+        if (std::find(pinged.begin(), pinged.end(), consumer) == pinged.end()) {
+          pinged.push_back(consumer);
+          task_creator->schedule(consumer);
+        }
+      }
     }
   }
-  return nullptr;
+
+  return task_input;
 }
 
 std::unique_ptr<operator_data> sirius_physical_concat::execute(const operator_data& input_data,

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -17,7 +17,6 @@
 #include "op/sirius_physical_concat.hpp"
 
 #include "creator/task_creator.hpp"
-#include "data/data_batch_utils.hpp"
 #include "log/logging.hpp"
 #include "op/merge/gpu_merge_impl.hpp"
 #include "op/sirius_physical_hash_join.hpp"
@@ -82,10 +81,7 @@ std::optional<task_creation_hint> sirius_physical_concat::get_next_task_hint()
 
   auto port_ptr = ports.begin()->second;
 
-  // If the source pipeline is done, we're ready to process whatever data remains. This check reads
-  // only the repository's own bookkeeping (never a batch lock), keeping the residual flush — and
-  // with it deadlock-freedom — independent of the totals. The base helper treats a port without a
-  // src_pipeline as finished, so unwired ports resolve here instead of dereferencing null below.
+  // If the source pipeline is done, we're ready to process whatever data remains.
   if (is_source_pipeline_finished()) {
     if (port_ptr->repo->total_size() > 0) {
       return task_creation_hint{TaskCreationHint::READY, this};
@@ -100,9 +96,7 @@ std::optional<task_creation_hint> sirius_physical_concat::get_next_task_hint()
 
   // Source pipeline still running — fire early once a partition has buffered more than the
   // batching threshold across at least two batches. A lone oversized batch keeps WAITING: it
-  // either gains a groupmate or is flushed once the source finishes. Answered from the push-time
-  // totals, so this runs without touching any data_batch lock (this is polled on the task
-  // creator's single manager thread, which must not block behind a downgrade's exclusive lock).
+  // either gains a groupmate or is flushed once the source finishes.
   for (const auto& totals : _input_totals) {
     if (totals.bytes > _concat_batch_bytes && totals.count >= 2) {
       return task_creation_hint{TaskCreationHint::READY, this};
@@ -120,20 +114,18 @@ void sirius_physical_concat::push_data_batch_partitioned(
   std::size_t partition_idx)
 {
   if (batch) {
-    // Measure outside `lock`: to_read_only can block behind a downgrade's exclusive lock, and a
-    // blocked push (a worker thread) must not hold the mutex the manager-thread hint needs.
-    const uint64_t batch_size = batch->to_read_only().get_data()->get_size_in_bytes();
+    // Measured before taking `lock`: to_read_only() can wait out a downgrade's exclusive batch
+    // lock, and the manager-thread hint blocks on `lock`.
+    auto const batch_size = batch->to_read_only().get_data()->get_size_in_bytes();
     std::lock_guard<std::mutex> lg(lock);
     if (_input_totals.size() <= partition_idx) { _input_totals.resize(partition_idx + 1); }
     _pushed_batch_bytes[batch->get_batch_id()] = batch_size;
     _input_totals[partition_idx].bytes += batch_size;
     _input_totals[partition_idx].count += 1;
   }
-  // Delegate outside `lock`: the base's telemetry publish also takes the batch's shared lock,
-  // which must never be acquired under the mutex the hint needs. Accounting before the repository
-  // insert guarantees every poppable batch already has its ledger entry; the transient window
-  // where the totals include a batch that is not yet poppable is within the documented drift
-  // heuristic (the pull remains authoritative for what is actually popped).
+  // Delegated after releasing `lock` for the same reason: the base's telemetry publish takes the
+  // batch's shared lock. Ledger-then-insert ordering keeps every poppable batch ledgered; the
+  // reverse window (counted but not yet poppable) only makes the hint transiently optimistic.
   sirius_physical_partition_consumer_operator::push_data_batch_partitioned(
     port_id, std::move(batch), partition_idx);
 }
@@ -149,12 +141,26 @@ std::shared_ptr<::cucascade::data_batch> sirius_physical_concat::pop_and_account
     totals.count -= 1;
     _pushed_batch_bytes.erase(ledger);
   } else {
-    // Production wiring always enters through push_data_batch_partitioned; an unledgered pop
-    // means something bypassed the accounting (tests that insert straight into the repository).
+    // Unledgered: tests that insert straight into the repository, or broadcast build slots (the
+    // sink deposits one id into every slot; the ledger keys by id). Broadcast implies concat_all,
+    // which consults neither the totals nor buffered_batch_size.
     SIRIUS_LOG_DEBUG("sirius_physical_concat: popped batch {} has no push-time ledger entry",
                      batch_id);
   }
   return popped;
+}
+
+uint64_t sirius_physical_concat::buffered_batch_size(::cucascade::shared_data_repository& repo,
+                                                     uint64_t batch_id,
+                                                     std::size_t partition_idx) const
+{
+  if (auto ledger = _pushed_batch_bytes.find(batch_id); ledger != _pushed_batch_bytes.end()) {
+    return ledger->second;
+  }
+  return repo.get_data_batch_by_id(batch_id, partition_idx)
+    ->to_read_only()
+    .get_data()
+    ->get_size_in_bytes();
 }
 
 std::unique_ptr<operator_data> sirius_physical_concat::get_next_task_input_data()
@@ -165,44 +171,36 @@ std::unique_ptr<operator_data> sirius_physical_concat::get_next_task_input_data(
   // Each pass forms one group; a single-batch group with sink wiring is forwarded downstream
   // without a task (execute is an identity for it) and the walk repeats. Every forward removes a
   // batch from the repository, so the loop terminates.
+  // Contract: pipeline-wired callers hold get_task_creation_lock() — the forward's in-flight batch
+  // is in no repository, and only that lock hides the gap from finish evaluation.
   while (true) {
     std::shared_ptr<::cucascade::data_batch> single_batch;
     std::size_t single_partition_idx = 0;
     {
-      // iterate through all the partition and pull
       std::lock_guard<std::mutex> lg(lock);
 
-      // assert that there is only one port
       if (ports.size() != 1) {
         throw std::runtime_error("sirius_physical_concat: there should be only one port");
       }
 
       auto port_ptr = ports.begin()->second;
-      for (size_t i = 0; i < port_ptr->repo->num_partitions(); i++) {
+      for (std::size_t i = 0; i < port_ptr->repo->num_partitions(); i++) {
         std::vector<std::shared_ptr<::cucascade::data_batch>> input_batch;
-        // get all the batch ids from the partition
-        auto batch_ids          = port_ptr->repo->get_batch_ids(i);
-        size_t total_batch_size = 0;
+        auto batch_ids               = port_ptr->repo->get_batch_ids(i);
+        std::size_t total_batch_size = 0;
         for (auto& batch_id : batch_ids) {
-          auto batch_idle = port_ptr->repo->get_data_batch_by_id(batch_id, i);
-          auto batch_ro   = batch_idle->to_read_only();
-          auto batch_size = batch_ro.get_data()->get_size_in_bytes();
-          total_batch_size += batch_size;
-          // Check if the batch size is already exceed the threshold
-          if (!_concat_all && total_batch_size > _concat_batch_bytes) {
-            // if the batch size is already exceed the threshold, then we need to return the batch
-            // right away
-            if (input_batch.size() == 0) {
-              // this mean that there is a batch that is bigger than the threshold, then we just
-              // output that batch right away
-              input_batch.push_back(pop_and_account(*port_ptr->repo, batch_id, i));
+          // Sizes are push-time snapshots; _concat_all needs none.
+          if (!_concat_all) {
+            total_batch_size += buffered_batch_size(*port_ptr->repo, batch_id, i);
+            if (total_batch_size > _concat_batch_bytes) {
+              // An oversized head goes alone; otherwise the group closes and `batch_id` stays.
+              if (input_batch.empty()) {
+                input_batch.push_back(pop_and_account(*port_ptr->repo, batch_id, i));
+              }
+              break;
             }
-            break;
-          } else {
-            // if the batch size does not exceed the threshold, then we need to add the batch to
-            // the input batch
-            input_batch.push_back(pop_and_account(*port_ptr->repo, batch_id, i));
           }
+          input_batch.push_back(pop_and_account(*port_ptr->repo, batch_id, i));
         }
         if (input_batch.size() != 0) {
           if (input_batch.size() == 1 && !next_port_after_sink.empty()) {
@@ -214,14 +212,10 @@ std::unique_ptr<operator_data> sirius_physical_concat::get_next_task_input_data(
           break;
         }
       }
-    }
+    }  // end lock
     if (!single_batch) { break; }
 
-    // Forward the single batch outside `lock`: it is exclusively ours (popped, in no repository),
-    // and the downstream push must not run under this operator's mutex. Pushing through
-    // push_data_batch_partitioned matches sink(): telemetry publish, partition tagging, and any
-    // consumer-side hooks (e.g. the hash join's build-port dynamic-filter publish) all fire.
-    for (auto& next_port_info : next_port_after_sink) {
+    for (auto const& next_port_info : next_port_after_sink) {
       auto partition_consumer_op =
         dynamic_cast<sirius_physical_partition_consumer_operator*>(next_port_info.next_operator);
       if (partition_consumer_op) {

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -674,6 +674,8 @@ cross_schedule_orphan next_cross_schedule_orphan(std::vector<partition_cross_sch
                                                  bool probe_finished,
                                                  bool build_finished)
 {
+  // Flags were latched before the ids were snapshotted (refresh_cross_schedule); only that read
+  // order makes an empty opposite side final.
   if (!(probe_finished && build_finished)) { return {}; }
   for (std::size_t p = 0; p < cross.size(); ++p) {
     auto& c = cross[p];
@@ -922,6 +924,8 @@ void sirius_physical_hash_join::discard_build_only_slots_if_probe_complete()
   // Only once the probe upstream is finished do we know no further probe data can arrive for any
   // slot. Broadcast replicates the build table to every slot, but the probe side is unpartitioned,
   // so slots on GPUs that saw no probe rows get build data that will never be probed.
+  // Latch read before the slot snapshot below: pushes that preceded the finish latch (incl.
+  // concat's taskless forward) are then visible to it — reordering strands batches.
   bool const probe_finished =
     probe_port->src_pipeline && probe_port->src_pipeline->is_pipeline_finished();
 
@@ -1099,6 +1103,8 @@ std::pair<bool, bool> sirius_physical_hash_join::refresh_cross_schedule()
   std::size_t const num_partitions = probe_port->repo->num_partitions();
   if (_cross.size() < num_partitions) { _cross.resize(num_partitions); }
 
+  // Latch reads before the repo re-poll below: pushes that preceded a finish latch (incl.
+  // concat's taskless forward) are then visible, so an empty side is truly final.
   bool const probe_finished =
     probe_port->src_pipeline && probe_port->src_pipeline->is_pipeline_finished();
   bool const build_finished =

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -291,6 +291,9 @@ std::optional<task_creation_hint> sirius_physical_operator::get_next_task_hint()
 {
   if (ports.empty()) { return std::nullopt; }
 
+  // Finished-latch reads precede the repo-size reads below: a batch in flight between pop and
+  // downstream push (concat's taskless forward) then resolves to WAITING. A poll straddling the
+  // landing can still return a transient nullopt; the forward's schedule() ping re-polls.
   // look at the input ports and see if there are any unfinished hard barriers
   auto unfinished_barrier = std::find_if(_ports_list.begin(), _ports_list.end(), [](const auto& p) {
     return p->type == MemoryBarrierType::FULL && p->src_pipeline &&

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -334,6 +334,7 @@ bool sirius_pipeline::is_pipeline_finished() const
 {
   // todo (amin): there is a potential race condition between scan executor and gpu pipeline
   // executor
+  // Monotonic latch: sole store under _status_mutex (update_pipeline_status); true is final.
   return pipeline_finished.load();
 }
 
@@ -408,6 +409,8 @@ void sirius_pipeline::update_pipeline_status(bool original_pipeline)
       // scan source, all_ports_empty() is split_connector::is_closed() (closed
       // AND drained); port-less sources are trivially exhausted. limit_exhausted
       // keeps its early exit: it finishes without draining the source.
+      // Each finished latch below is read before its paired emptiness check: pre-latch pushes
+      // (concat's taskless forward) stay visible to it — reordering strands batches.
       bool source_exhausted =
         !source || (source->is_source_pipeline_finished() && source->all_ports_empty());
       if (limit_exhausted || (source_exhausted && first_node->is_source_pipeline_finished() &&

--- a/test/cpp/operator/test_physical_concat.cpp
+++ b/test/cpp/operator/test_physical_concat.cpp
@@ -25,8 +25,11 @@
 #include <op/sirius_physical_concat.hpp>
 #include <op/sirius_physical_hash_join.hpp>
 #include <op/sirius_physical_partition.hpp>
+#include <pipeline/sirius_pipeline.hpp>
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <mutex>
 #include <numeric>
 #include <set>
@@ -136,6 +139,144 @@ memory_space* get_shared_mem_space()
 {
   static auto manager = sirius::test::operator_utils::initialize_memory_manager();
   return manager->get_memory_space(Tier::GPU, 0);
+}
+
+//===----------------------------------------------------------------------===//
+// Hint / forward fixtures
+//===----------------------------------------------------------------------===//
+
+/**
+ * @brief Pipeline stub with a settable is_pipeline_finished(), standing in for the concat's
+ * source pipeline in hint and forward tests.
+ */
+class mock_gpu_pipeline : public sirius::pipeline::sirius_pipeline {
+ public:
+  explicit mock_gpu_pipeline(const sirius::pipeline::pipeline_build_context& ctx)
+    : sirius_pipeline(ctx), _finished(false)
+  {
+  }
+
+  void set_finished(bool finished) { _finished = finished; }
+
+  bool is_pipeline_finished() const override { return _finished; }
+
+ private:
+  bool _finished;
+};
+
+/**
+ * @brief Attach an "input" port backed by @p repo, optionally sourced from @p src_pipeline.
+ */
+void attach_input_port(sirius_physical_operator& op,
+                       cucascade::shared_data_repository& repo,
+                       duckdb::shared_ptr<sirius::pipeline::sirius_pipeline> src_pipeline = nullptr)
+{
+  auto port           = std::make_unique<sirius_physical_operator::port>();
+  port->type          = MemoryBarrierType::FULL;
+  port->repo          = &repo;
+  port->src_pipeline  = std::move(src_pipeline);
+  port->dest_pipeline = nullptr;
+  op.add_port("input", std::move(port));
+}
+
+//! Whether a rig's concat has a source pipeline and, if so, whether it reports finished.
+enum class source_state { none, running, finished };
+
+/**
+ * @brief Everything a hint/forward test needs: the concat under test with its "input" port and
+ * repository attached, plus (unless source_state::none) a mock source pipeline whose first
+ * operator is the producer the WAITING hint must name. `repo` is declared before `op` so it
+ * outlives the operator whose port holds a raw pointer to it.
+ */
+struct concat_test_rig {
+  hash_join_test_fixture join;
+  std::unique_ptr<cucascade::shared_data_repository> repo;
+  std::unique_ptr<sirius_physical_concat> op;
+  duckdb::shared_ptr<mock_gpu_pipeline> src_pipeline;
+  duckdb::unique_ptr<sirius_physical_operator> upstream_producer;
+};
+
+concat_test_rig make_concat_rig(uint64_t threshold,
+                                source_state source        = source_state::running,
+                                duckdb::JoinType join_type = duckdb::JoinType::INNER,
+                                bool is_build              = false)
+{
+  concat_test_rig rig;
+  rig.join = create_test_hash_join(join_type, {duckdb::LogicalType::INTEGER});
+  rig.op   = std::make_unique<sirius_physical_concat>(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    rig.join.hash_join.get(),
+    is_build,
+    threshold);
+  rig.repo = std::make_unique<cucascade::shared_data_repository>();
+  if (source != source_state::none) {
+    const sirius::pipeline::pipeline_build_context build_ctx{nullptr, true};
+    rig.src_pipeline = duckdb::make_shared_ptr<mock_gpu_pipeline>(build_ctx);
+    rig.src_pipeline->set_finished(source == source_state::finished);
+    rig.upstream_producer = duckdb::make_uniq<sirius_physical_operator>(
+      SiriusPhysicalOperatorType::PROJECTION,
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      1000);
+    sirius::pipeline::sirius_pipeline_build_state build_state;
+    build_state.add_pipeline_operator(*rig.src_pipeline, *rig.upstream_producer);
+  }
+  attach_input_port(*rig.op, *rig.repo, rig.src_pipeline);
+  return rig;
+}
+
+/**
+ * @brief A downstream partition consumer wired as a forward target, owning its "input" port repo.
+ * `repo` is declared before `op` so it outlives the operator whose port points at it.
+ */
+struct downstream_rig {
+  hash_join_test_fixture join;
+  std::unique_ptr<cucascade::shared_data_repository> repo;
+  std::unique_ptr<sirius_physical_concat> op;
+};
+
+downstream_rig make_downstream_rig()
+{
+  downstream_rig rig;
+  rig.join = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
+  rig.op   = std::make_unique<sirius_physical_concat>(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    rig.join.hash_join.get(),
+    false);
+  rig.repo = std::make_unique<cucascade::shared_data_repository>();
+  attach_input_port(*rig.op, *rig.repo);
+  return rig;
+}
+
+std::shared_ptr<data_batch> make_int_batch(std::size_t num_rows)
+{
+  std::vector<int32_t> values(num_rows);
+  std::iota(values.begin(), values.end(), 0);
+  return make_numeric_batch<int32_t>(*get_shared_mem_space(), values, cudf::type_id::INT32);
+}
+
+uint64_t batch_bytes(const std::shared_ptr<data_batch>& batch)
+{
+  return batch->to_read_only().get_data()->get_size_in_bytes();
+}
+
+//! Batch ids of @p data in group order.
+std::vector<uint64_t> group_batch_ids(const operator_data& data)
+{
+  std::vector<uint64_t> ids;
+  for (auto& batch : dynamic_cast<const pipelineable_operator_data&>(data).get_data_batches()) {
+    ids.push_back(batch->get_batch_id());
+  }
+  return ids;
+}
+
+//! Deref-safe hint accessor: fails the test instead of dereferencing a nullopt hint.
+TaskCreationHint require_hint(sirius_physical_concat& op)
+{
+  auto hint = op.get_next_task_hint();
+  REQUIRE(hint.has_value());
+  return hint->hint;
 }
 
 }  // namespace
@@ -897,4 +1038,406 @@ TEST_CASE("sirius_physical_concat execute is thread-safe with independent stream
     auto out_table = sirius::get_cudf_table_view(*thread_outputs[t][0]);
     REQUIRE(static_cast<std::size_t>(out_table.num_rows()) == rows_per_batch * batches_per_thread);
   }
+}
+
+//===----------------------------------------------------------------------===//
+// 5. get_next_task_hint totals tests
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("sirius_physical_concat hint fires exactly on the totals predicate", "[physical_concat]")
+{
+  REQUIRE(get_shared_mem_space() != nullptr);
+
+  auto first                 = make_int_batch(256);
+  auto second                = make_int_batch(256);
+  const uint64_t small_bytes = batch_bytes(first);
+  REQUIRE(small_bytes > 1);
+  // Exact-boundary thresholds below assume identically sized batches.
+  REQUIRE(batch_bytes(second) == small_bytes);
+
+  SECTION("lone oversized batch waits for a groupmate")
+  {
+    auto rig = make_concat_rig(small_bytes - 1);
+    rig.op->push_data_batch_partitioned("input", first, 0);
+    auto hint = rig.op->get_next_task_hint();
+    REQUIRE(hint.has_value());
+    REQUIRE(hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+    REQUIRE(hint->producer == rig.upstream_producer.get());
+  }
+
+  SECTION("oversized batch plus a second batch fires")
+  {
+    auto rig = make_concat_rig(small_bytes - 1);
+    rig.op->push_data_batch_partitioned("input", first, 0);
+    rig.op->push_data_batch_partitioned("input", second, 0);
+    auto hint = rig.op->get_next_task_hint();
+    REQUIRE(hint.has_value());
+    REQUIRE(hint->hint == TaskCreationHint::READY);
+    REQUIRE(hint->producer == rig.op.get());
+  }
+
+  SECTION("two batches under the threshold wait")
+  {
+    auto rig = make_concat_rig(2 * small_bytes + 1);
+    rig.op->push_data_batch_partitioned("input", first, 0);
+    rig.op->push_data_batch_partitioned("input", second, 0);
+    auto hint = rig.op->get_next_task_hint();
+    REQUIRE(hint.has_value());
+    REQUIRE(hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+    REQUIRE(hint->producer == rig.upstream_producer.get());
+  }
+
+  SECTION("two batches exactly at the threshold wait (strict >)")
+  {
+    auto rig = make_concat_rig(2 * small_bytes);
+    rig.op->push_data_batch_partitioned("input", first, 0);
+    rig.op->push_data_batch_partitioned("input", second, 0);
+    auto hint = rig.op->get_next_task_hint();
+    REQUIRE(hint.has_value());
+    REQUIRE(hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+  }
+
+  SECTION("two batches over the threshold fire")
+  {
+    auto rig = make_concat_rig(2 * small_bytes - 1);
+    rig.op->push_data_batch_partitioned("input", first, 0);
+    rig.op->push_data_batch_partitioned("input", second, 0);
+    auto hint = rig.op->get_next_task_hint();
+    REQUIRE(hint.has_value());
+    REQUIRE(hint->hint == TaskCreationHint::READY);
+    REQUIRE(hint->producer == rig.op.get());
+  }
+
+  SECTION("concat_all waits regardless of buffered size")
+  {
+    auto rig = make_concat_rig(small_bytes - 1);
+    rig.op->set_concat_all(true);
+    rig.op->push_data_batch_partitioned("input", first, 0);
+    rig.op->push_data_batch_partitioned("input", second, 0);
+    auto hint = rig.op->get_next_task_hint();
+    REQUIRE(hint.has_value());
+    REQUIRE(hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+    REQUIRE(hint->producer == rig.upstream_producer.get());
+  }
+}
+
+TEST_CASE("sirius_physical_concat totals stay consistent across push, pull, and flush",
+          "[physical_concat]")
+{
+  REQUIRE(get_shared_mem_space() != nullptr);
+
+  auto big                   = make_int_batch(1024);
+  auto small_0               = make_int_batch(256);
+  auto small_1               = make_int_batch(256);
+  auto small_2               = make_int_batch(256);
+  const uint64_t small_bytes = batch_bytes(small_0);
+  REQUIRE(batch_bytes(small_1) == small_bytes);
+  REQUIRE(batch_bytes(small_2) == small_bytes);
+  // small < threshold < 2 * small < big
+  const uint64_t threshold = small_bytes + small_bytes / 2;
+  REQUIRE(batch_bytes(big) > threshold);
+
+  auto rig = make_concat_rig(threshold);
+
+  // Lone oversized batch: over the threshold but count == 1 -> WAITING.
+  rig.op->push_data_batch_partitioned("input", big, 0);
+  REQUIRE(require_hint(*rig.op) == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+
+  // A groupmate arrives -> partition 0 fires.
+  rig.op->push_data_batch_partitioned("input", small_0, 0);
+  REQUIRE(require_hint(*rig.op) == TaskCreationHint::READY);
+
+  // A batch on another partition does not disturb partition 0's READY.
+  rig.op->push_data_batch_partitioned("input", small_1, 1);
+  REQUIRE(require_hint(*rig.op) == TaskCreationHint::READY);
+
+  // Pull 1: the oversized head is popped alone; small_0 stays behind.
+  auto pull_1 = rig.op->get_next_task_input_data();
+  REQUIRE(pull_1 != nullptr);
+  REQUIRE(group_batch_ids(*pull_1) == std::vector<uint64_t>{big->get_batch_id()});
+  REQUIRE(dynamic_cast<const partitioned_operator_data&>(*pull_1).get_partition_idx() == 0);
+  REQUIRE(require_hint(*rig.op) == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+
+  // Partition 1 crosses the threshold with two batches -> READY.
+  rig.op->push_data_batch_partitioned("input", small_2, 1);
+  REQUIRE(require_hint(*rig.op) == TaskCreationHint::READY);
+
+  // Pull 2: partition 0's residual runt goes first; partition 1 still fires.
+  auto pull_2 = rig.op->get_next_task_input_data();
+  REQUIRE(pull_2 != nullptr);
+  REQUIRE(group_batch_ids(*pull_2) == std::vector<uint64_t>{small_0->get_batch_id()});
+  REQUIRE(require_hint(*rig.op) == TaskCreationHint::READY);
+
+  // Pull 3: partition 1's greedy prefix stops before the batch that crosses the threshold.
+  auto pull_3 = rig.op->get_next_task_input_data();
+  REQUIRE(pull_3 != nullptr);
+  REQUIRE(group_batch_ids(*pull_3) == std::vector<uint64_t>{small_1->get_batch_id()});
+  REQUIRE(require_hint(*rig.op) == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+
+  // Residual flush: READY on a nonempty repo, nullopt once drained.
+  rig.src_pipeline->set_finished(true);
+  REQUIRE(require_hint(*rig.op) == TaskCreationHint::READY);
+  auto pull_4 = rig.op->get_next_task_input_data();
+  REQUIRE(pull_4 != nullptr);
+  REQUIRE(group_batch_ids(*pull_4) == std::vector<uint64_t>{small_2->get_batch_id()});
+  REQUIRE_FALSE(rig.op->get_next_task_hint().has_value());
+}
+
+TEST_CASE("sirius_physical_concat hint treats a port without a source pipeline as finished",
+          "[physical_concat]")
+{
+  REQUIRE(get_shared_mem_space() != nullptr);
+
+  auto rig   = make_concat_rig(1024, source_state::none);
+  auto batch = make_int_batch(64);
+  rig.op->push_data_batch_partitioned("input", batch, 0);
+
+  auto hint = rig.op->get_next_task_hint();
+  REQUIRE(hint.has_value());
+  REQUIRE(hint->hint == TaskCreationHint::READY);
+  REQUIRE(hint->producer == rig.op.get());
+
+  REQUIRE(rig.op->get_next_task_input_data() != nullptr);
+  REQUIRE_FALSE(rig.op->get_next_task_hint().has_value());
+}
+
+TEST_CASE("sirius_physical_concat hint returns while a buffered batch is exclusively locked",
+          "[physical_concat]")
+{
+  REQUIRE(get_shared_mem_space() != nullptr);
+
+  auto big_0               = make_int_batch(1024);
+  auto big_1               = make_int_batch(1024);
+  const uint64_t big_bytes = batch_bytes(big_0);
+
+  auto rig = make_concat_rig(big_bytes - 1);
+  rig.op->push_data_batch_partitioned("input", big_0, 0);
+  rig.op->push_data_batch_partitioned("input", big_1, 0);
+
+  // A helper thread holds big_0's exclusive lock, standing in for the downgrade executor
+  // converting an idle buffered batch in place.
+  std::mutex sync_mutex;
+  std::condition_variable sync_cv;
+  bool lock_held         = false;
+  bool release_requested = false;
+  std::thread lock_holder([&] {
+    auto exclusive = big_0->to_mutable();
+    {
+      std::lock_guard<std::mutex> lg(sync_mutex);
+      lock_held = true;
+    }
+    sync_cv.notify_all();
+    {
+      std::unique_lock<std::mutex> ul(sync_mutex);
+      sync_cv.wait(ul, [&] { return release_requested; });
+    }
+    auto idle = cucascade::data_batch::to_idle(std::move(exclusive));
+  });
+  {
+    std::unique_lock<std::mutex> ul(sync_mutex);
+    sync_cv.wait(ul, [&] { return lock_held; });
+  }
+
+  // Watchdog: run the hint on its own thread and bound the wait, so a hint that blocks on the
+  // batch lock fails the test instead of hanging the suite.
+  std::optional<sirius::op::task_creation_hint> hint;
+  bool hint_done = false;
+  std::thread hint_runner([&] {
+    auto result = rig.op->get_next_task_hint();
+    {
+      std::lock_guard<std::mutex> lg(sync_mutex);
+      hint      = result;
+      hint_done = true;
+    }
+    sync_cv.notify_all();
+  });
+
+  bool completed_in_time = false;
+  {
+    std::unique_lock<std::mutex> ul(sync_mutex);
+    completed_in_time = sync_cv.wait_for(ul, std::chrono::seconds(10), [&] { return hint_done; });
+  }
+
+  // Release the exclusive lock before any assertion so a blocked hint unblocks and both threads
+  // join even when the test fails.
+  {
+    std::lock_guard<std::mutex> lg(sync_mutex);
+    release_requested = true;
+  }
+  sync_cv.notify_all();
+  lock_holder.join();
+  hint_runner.join();
+
+  REQUIRE(completed_in_time);
+  REQUIRE(hint.has_value());
+  REQUIRE(hint->hint == TaskCreationHint::READY);
+  REQUIRE(hint->producer == rig.op.get());
+}
+
+//===----------------------------------------------------------------------===//
+// 6. Single-batch forward tests
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("sirius_physical_concat forwards a single-batch group downstream without a task",
+          "[physical_concat]")
+{
+  REQUIRE(get_shared_mem_space() != nullptr);
+
+  auto rig        = make_concat_rig(1024, source_state::finished);
+  auto downstream = make_downstream_rig();
+  rig.op->add_next_port_after_sink({downstream.op.get(), "input"});
+
+  auto batch = make_int_batch(64);
+  rig.op->push_data_batch_partitioned("input", batch, 2);
+
+  REQUIRE(rig.op->get_next_task_input_data() == nullptr);
+  REQUIRE(rig.repo->total_size() == 0);
+
+  // The forward preserves the partition index and moves the very same batch object.
+  REQUIRE(downstream.repo->get_batch_ids(2) == std::vector<uint64_t>{batch->get_batch_id()});
+  auto forwarded = downstream.repo->pop_data_batch_by_id(batch->get_batch_id(), 2);
+  REQUIRE(forwarded.get() == batch.get());
+}
+
+TEST_CASE("sirius_physical_concat returns multi-batch groups as task input with wiring present",
+          "[physical_concat]")
+{
+  REQUIRE(get_shared_mem_space() != nullptr);
+
+  auto batch_0               = make_int_batch(256);
+  auto batch_1               = make_int_batch(256);
+  auto batch_2               = make_int_batch(256);
+  const uint64_t small_bytes = batch_bytes(batch_0);
+  REQUIRE(batch_bytes(batch_1) == small_bytes);
+  REQUIRE(batch_bytes(batch_2) == small_bytes);
+
+  // Two batches fit exactly; the third crosses the threshold and stays behind.
+  auto rig        = make_concat_rig(2 * small_bytes);
+  auto downstream = make_downstream_rig();
+  rig.op->add_next_port_after_sink({downstream.op.get(), "input"});
+
+  rig.op->push_data_batch_partitioned("input", batch_0, 0);
+  rig.op->push_data_batch_partitioned("input", batch_1, 0);
+  rig.op->push_data_batch_partitioned("input", batch_2, 0);
+
+  auto result = rig.op->get_next_task_input_data();
+  REQUIRE(result != nullptr);
+  REQUIRE(group_batch_ids(*result) ==
+          std::vector<uint64_t>{batch_0->get_batch_id(), batch_1->get_batch_id()});
+  REQUIRE(dynamic_cast<const partitioned_operator_data&>(*result).get_partition_idx() == 0);
+
+  // The multi-batch group takes the task path: nothing was forwarded, the leftover remains.
+  REQUIRE(downstream.repo->total_size() == 0);
+  REQUIRE(rig.repo->get_batch_ids(0) == std::vector<uint64_t>{batch_2->get_batch_id()});
+}
+
+TEST_CASE("sirius_physical_concat drains singles by forwarding and returns the first multi group",
+          "[physical_concat]")
+{
+  REQUIRE(get_shared_mem_space() != nullptr);
+
+  auto lone                  = make_int_batch(256);
+  auto pair_0                = make_int_batch(256);
+  auto pair_1                = make_int_batch(256);
+  const uint64_t small_bytes = batch_bytes(lone);
+
+  auto rig        = make_concat_rig(3 * small_bytes, source_state::finished);
+  auto downstream = make_downstream_rig();
+  rig.op->add_next_port_after_sink({downstream.op.get(), "input"});
+
+  rig.op->push_data_batch_partitioned("input", lone, 0);
+  rig.op->push_data_batch_partitioned("input", pair_0, 1);
+  rig.op->push_data_batch_partitioned("input", pair_1, 1);
+
+  // One call: partition 0's single is forwarded, partition 1's pair comes back as task input.
+  auto result = rig.op->get_next_task_input_data();
+  REQUIRE(result != nullptr);
+  REQUIRE(group_batch_ids(*result) ==
+          std::vector<uint64_t>{pair_0->get_batch_id(), pair_1->get_batch_id()});
+  REQUIRE(dynamic_cast<const partitioned_operator_data&>(*result).get_partition_idx() == 1);
+  REQUIRE(downstream.repo->get_batch_ids(0) == std::vector<uint64_t>{lone->get_batch_id()});
+
+  // Drained: the hint reports nothing left and further pulls forward nothing new.
+  REQUIRE_FALSE(rig.op->get_next_task_hint().has_value());
+  REQUIRE(rig.op->get_next_task_input_data() == nullptr);
+  REQUIRE(downstream.repo->total_size() == 1);
+}
+
+TEST_CASE("sirius_physical_concat returns a single-batch group as task input without sink wiring",
+          "[physical_concat]")
+{
+  REQUIRE(get_shared_mem_space() != nullptr);
+
+  auto rig   = make_concat_rig(1024, source_state::finished);
+  auto batch = make_int_batch(64);
+  rig.op->push_data_batch_partitioned("input", batch, 0);
+
+  auto result = rig.op->get_next_task_input_data();
+  REQUIRE(result != nullptr);
+  auto& group = dynamic_cast<const partitioned_operator_data&>(*result);
+  REQUIRE(group.get_data_batches().size() == 1);
+  REQUIRE(group.get_data_batches()[0].get() == batch.get());
+  REQUIRE(group.get_partition_idx() == 0);
+}
+
+TEST_CASE("sirius_physical_concat with concat_all forwards a lone batch at pipeline finish",
+          "[physical_concat]")
+{
+  REQUIRE(get_shared_mem_space() != nullptr);
+
+  // LEFT join + is_build=true -> _concat_all = true.
+  auto rig =
+    make_concat_rig(1024, source_state::finished, duckdb::JoinType::LEFT, /*is_build=*/true);
+  auto downstream = make_downstream_rig();
+  rig.op->add_next_port_after_sink({downstream.op.get(), "input"});
+
+  auto batch = make_int_batch(64);
+  rig.op->push_data_batch_partitioned("input", batch, 0);
+
+  REQUIRE(rig.op->get_next_task_input_data() == nullptr);
+  auto forwarded = downstream.repo->pop_data_batch_by_id(batch->get_batch_id(), 0);
+  REQUIRE(forwarded.get() == batch.get());
+}
+
+TEST_CASE("sirius_physical_concat totals stay balanced after forwards", "[physical_concat]")
+{
+  REQUIRE(get_shared_mem_space() != nullptr);
+
+  auto batch_0               = make_int_batch(256);
+  auto batch_1               = make_int_batch(256);
+  auto batch_2               = make_int_batch(256);
+  auto batch_3               = make_int_batch(256);
+  auto batch_4               = make_int_batch(256);
+  const uint64_t small_bytes = batch_bytes(batch_0);
+  REQUIRE(small_bytes > 1);
+  for (const auto& batch : {batch_1, batch_2, batch_3, batch_4}) {
+    REQUIRE(batch_bytes(batch) == small_bytes);
+  }
+
+  auto rig        = make_concat_rig(2 * small_bytes - 1);
+  auto downstream = make_downstream_rig();
+  rig.op->add_next_port_after_sink({downstream.op.get(), "input"});
+
+  // A runt single is forwarded rather than returned.
+  rig.op->push_data_batch_partitioned("input", batch_0, 0);
+  REQUIRE(require_hint(*rig.op) == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+  REQUIRE(rig.op->get_next_task_input_data() == nullptr);
+  REQUIRE(downstream.repo->total_size() == 1);
+
+  // The predicate fires exactly as before the forward.
+  rig.op->push_data_batch_partitioned("input", batch_1, 0);
+  REQUIRE(require_hint(*rig.op) == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+  rig.op->push_data_batch_partitioned("input", batch_2, 0);
+  REQUIRE(require_hint(*rig.op) == TaskCreationHint::READY);
+
+  // The greedy walk splits the pair into two singles; both forward, none returns.
+  REQUIRE(rig.op->get_next_task_input_data() == nullptr);
+  REQUIRE(downstream.repo->total_size() == 3);
+  REQUIRE(rig.repo->total_size() == 0);
+
+  // No drift: a fresh pair fires the predicate exactly at the same boundary.
+  rig.op->push_data_batch_partitioned("input", batch_3, 0);
+  REQUIRE(require_hint(*rig.op) == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+  rig.op->push_data_batch_partitioned("input", batch_4, 0);
+  REQUIRE(require_hint(*rig.op) == TaskCreationHint::READY);
 }

--- a/test/cpp/operator/test_physical_concat.cpp
+++ b/test/cpp/operator/test_physical_concat.cpp
@@ -1274,6 +1274,85 @@ TEST_CASE("sirius_physical_concat hint returns while a buffered batch is exclusi
   REQUIRE(hint->producer == rig.op.get());
 }
 
+TEST_CASE("sirius_physical_concat pull returns while a buffered batch is exclusively locked",
+          "[physical_concat]")
+{
+  REQUIRE(get_shared_mem_space() != nullptr);
+
+  auto small_0 = make_int_batch(64);
+  auto small_1 = make_int_batch(64);
+  auto big     = make_int_batch(1024);
+
+  // Threshold admits exactly the two smalls; the walk must then consult big's size — from the
+  // ledger, not the batch — and leave it buffered.
+  auto rig = make_concat_rig(batch_bytes(small_0) + batch_bytes(small_1));
+  rig.op->push_data_batch_partitioned("input", small_0, 0);
+  rig.op->push_data_batch_partitioned("input", small_1, 0);
+  rig.op->push_data_batch_partitioned("input", big, 0);
+
+  // A helper thread holds big's exclusive lock, standing in for the downgrade executor converting
+  // an idle buffered batch in place.
+  std::mutex sync_mutex;
+  std::condition_variable sync_cv;
+  bool lock_held         = false;
+  bool release_requested = false;
+  std::thread lock_holder([&] {
+    auto exclusive = big->to_mutable();
+    {
+      std::lock_guard<std::mutex> lg(sync_mutex);
+      lock_held = true;
+    }
+    sync_cv.notify_all();
+    {
+      std::unique_lock<std::mutex> ul(sync_mutex);
+      sync_cv.wait(ul, [&] { return release_requested; });
+    }
+    auto idle = cucascade::data_batch::to_idle(std::move(exclusive));
+  });
+  {
+    std::unique_lock<std::mutex> ul(sync_mutex);
+    sync_cv.wait(ul, [&] { return lock_held; });
+  }
+
+  // Watchdog: run the pull on its own thread and bound the wait, so a walk that blocks on the
+  // batch lock fails the test instead of hanging the suite.
+  std::unique_ptr<operator_data> pulled;
+  bool pull_done = false;
+  std::thread pull_runner([&] {
+    auto result = rig.op->get_next_task_input_data();
+    {
+      std::lock_guard<std::mutex> lg(sync_mutex);
+      pulled    = std::move(result);
+      pull_done = true;
+    }
+    sync_cv.notify_all();
+  });
+
+  bool completed_in_time = false;
+  {
+    std::unique_lock<std::mutex> ul(sync_mutex);
+    completed_in_time = sync_cv.wait_for(ul, std::chrono::seconds(10), [&] { return pull_done; });
+  }
+
+  // Release the exclusive lock before any assertion so a blocked pull unblocks and both threads
+  // join even when the test fails.
+  {
+    std::lock_guard<std::mutex> lg(sync_mutex);
+    release_requested = true;
+  }
+  sync_cv.notify_all();
+  lock_holder.join();
+  pull_runner.join();
+
+  REQUIRE(completed_in_time);
+  REQUIRE(pulled != nullptr);
+  REQUIRE(group_batch_ids(*pulled) ==
+          std::vector<uint64_t>{small_0->get_batch_id(), small_1->get_batch_id()});
+  REQUIRE(dynamic_cast<const partitioned_operator_data&>(*pulled).get_partition_idx() == 0);
+  // The locked batch stayed behind, untouched.
+  REQUIRE(rig.repo->get_batch_ids(0) == std::vector<uint64_t>{big->get_batch_id()});
+}
+
 //===----------------------------------------------------------------------===//
 // 6. Single-batch forward tests
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Two CONCAT improvements.

**The readiness check no longer touches batch locks.** Deciding whether enough input has buffered used to walk every buffered batch and briefly lock each one, on every poll, on the single thread that creates tasks for the whole engine — so a batch in the middle of being spilled to host memory could stall task creation everywhere. The operator now keeps per-partition running totals, updated as batches arrive and leave, and the check answers from those. It fires once a partition holds more than the batching threshold across at least two batches; the flush at pipeline finish is unchanged.

**Single-batch groups skip the task machinery.** When a group is exactly one batch there is nothing to concatenate, so the batch is handed directly to the downstream operator instead of running a GPU task — saving a memory reservation and two stream synchronizations per group.

No plan or result changes. TPC-H SF50 runtimes are unchanged within noise (the gain is stall immunity and fewer tasks — 42 → 33 concat tasks in a small-batch stress run); 22/22 result validation against DuckDB passes.

Related: #1576 touches the pull side of the same operator; the two are independent and compose in either order.