### PR TITLE
perf(expression): cascade cheap conjuncts ahead of expensive filter predicates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,6 +659,7 @@ set(TEST_SOURCES
     test/cpp/expression/test_value.cpp
     test/cpp/expression_evaluator/test_expression_evaluator.cpp
     test/cpp/expression_evaluator/test_expression_evaluator_ast_equivalence.cpp
+    test/cpp/expression_evaluator/test_filter_cascade.cpp
     test/cpp/expression_evaluator/test_gpu_expression_translator.cpp
     test/cpp/expression_evaluator/test_nonduckdb_frontend_proof.cpp
     test/cpp/helper/test_cudf_utils.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ set(EXTENSION_SOURCES
     src/expression_evaluator/expression_evaluator_strategy.cpp
     src/expression_evaluator/ast_op_counter.cpp
     src/expression_evaluator/expression_evaluator.cpp
+    src/expression_evaluator/filter_cascade.cpp
     src/expression_evaluator/gpu_expression_translator.cpp
     src/expression_evaluator/regex/regex_playground.cpp
     src/expression_evaluator/specializations/between.cpp

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -529,9 +529,16 @@ These can also be set at load via the `SIRIUS_LOG_BACKEND`, `SIRIUS_LOG_DIR`, an
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `expression_evaluator_strategy` | `ast_interpret` | Expression evaluator strategy: `materialize`, `ast_interpret`, or `ast_jit` |
+| `filter_cascade_cheap_conjuncts` | `true` | Evaluate cheap fixed-width conjuncts of a filter's top-level AND first; run the expensive (string-carried) residual only on surviving rows |
+| `filter_cascade_min_rows` | `1048576` | Minimum batch rows before the filter cascade engages (below this, kernel-launch latency dominates any saving) |
+| `filter_cascade_max_pass_rate` | `0.75` | Highest cheap-prefilter pass rate at which survivors are gathered before the residual; above it the two masks are combined without a gather. Domain [0, 1] |
 
 `expression_executor_strategy` remains registered as a deprecated compatibility alias for
 `expression_evaluator_strategy`; new configuration should use the evaluator name.
+
+The three `filter_cascade_*` knobs govern the filter cascade in
+`expression_evaluator::select()`; see
+[expression-executor.md](expression-executor.md) → Filter cascade in select().
 
 ### Scan
 

--- a/docs/super-sirius/expression-executor.md
+++ b/docs/super-sirius/expression-executor.md
@@ -110,6 +110,35 @@ The strategy is a DuckDB SET variable registered in `src/sirius_extension.cpp`:
 SET expression_evaluator_strategy = 'ast_jit';   -- or 'ast_interpret', 'materialize'
 ```
 
+## Filter cascade in select()
+
+**Files:** `src/expression_evaluator/filter_cascade.cpp`, `src/include/expression_evaluator/filter_cascade_internal.hpp`
+
+`select()` — the universal filter route used by `sirius_physical_filter`, `sirius_physical_table_scan`, and the scan ingestibles' predicate pushdown — can split a filter whose predicate is a top-level AND mixing cheap fixed-width conjuncts with expensive (string-carried) ones: it evaluates the cheap group first and runs the expensive residual only on rows surviving that prefilter. On TPC-H q19's part scan this avoids most of a 116-register JIT string kernel's work. The cascade is an internal execution strategy: callers see the exact same signature, result contract, and byte-identical rows.
+
+Per `select()` call (one knob snapshot at entry):
+
+1. Refuse (`not_applicable`, monolithic path) unless `filter_cascade_cheap_conjuncts` is set, the batch has at least `filter_cascade_min_rows` rows, the single predicate's root is a top-level AND, the classifier splits its children into non-empty cheap and expensive groups, and the survivor gather is *in scope*: every input column is in the union of `output_indices` and the columns referenced by the expensive residual. An out-of-scope gather refuses outright — a cascade that may never gather only adds launches and a sync over the monolithic kernel.
+2. Evaluate the cheap group's mask; count survivors via `cudf::bools_to_mask` (one 4-byte device-to-host sync).
+3. Zero survivors → `short_circuited`: return `cudf::empty_like` of the projection without running the residual.
+4. Pass rate ≤ `filter_cascade_max_pass_rate` → `cascaded`: gather survivors with `cudf::apply_boolean_mask`, evaluate the residual on them, apply its mask.
+5. Otherwise → `combined_masks`: evaluate the residual over all rows and Kleene-AND the two masks (the cheap mask is a sunk cost at this point; ANDing beats recomputing the monolithic predicate).
+
+The classifier (`sirius::detail::is_cheap_prefilter_conjunct`) marks a conjunct cheap iff every node in its subtree is an elementwise, fixed-width-carried operation:
+
+| `ast::node` alternative | Cheap when |
+|---|---|
+| `reference` | column index in bounds and the *runtime carrier* satisfies `cudf::is_fixed_width` (a decode-time predicate substitution's BOOL8 mask reference classifies cheap) |
+| `constant` | not VARCHAR |
+| `comparison`, `between`, `in_list` | all operands cheap |
+| `conjunction` (AND or OR) | non-empty and all children cheap |
+| `unary_op` | NOT / IS NULL / IS NOT NULL over a cheap child |
+| `cast`, `case_expr`, `coalesce`, `function_call`, `aggregate`, any future alternative | never (deliberately conservative default arm) |
+
+Correctness is Kleene partition invariance: a top-level AND selects a row iff every partition of its conjuncts evaluates to TRUE for it, so any split — including the mask AND and the short-circuit — produces the identical row set, and misclassification can only move cost, never change results.
+
+The knobs are documented in [configuration.md](configuration.md) → Expression Evaluation; the break-even reasoning behind the defaults lives in `src/config.cpp`.
+
 ## Supported Expression Types
 
 | Expression Type | Sirius AST alternative | Example |
@@ -198,6 +227,8 @@ This is used by `sirius_physical_hash_join` in MIXED_JOIN mode to pass the condi
 |------|---------|
 | `src/include/expression_evaluator/expression_evaluator.hpp` | Main evaluator class |
 | `src/expression_evaluator/expression_evaluator.cpp` | Driver: strategy dispatch, AST tree management, temp lifetimes |
+| `src/expression_evaluator/filter_cascade.cpp` | Cheap-conjunct filter cascade policy for `select()` (classifier + `try_select_cascade`) |
+| `src/include/expression_evaluator/filter_cascade_internal.hpp` | `sirius::detail::is_cheap_prefilter_conjunct` classifier contract (exposed for tests) |
 | `src/expression_evaluator/specializations/*.cpp` | Per-Sirius-AST-alternative dispatch (comparison, case, function, …) |
 | `src/include/expression_evaluator/expression_evaluator_strategy.hpp` | `expression_evaluator_strategy` enum + string conversions |
 | `src/include/expression_evaluator/ast_supported_types.hpp` | AST-eligible cast targets and functions (`supported_ast_cast_types`, `supported_ast_functions`) |

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -27,6 +27,18 @@ bool Config::USE_CUDF_EXPR = true;
 sirius::expression_evaluator_strategy Config::EXPRESSION_EVALUATOR_STRATEGY =
   sirius::expression_evaluator_strategy::AST_INTERPRET;
 
+bool Config::FILTER_CASCADE_CHEAP_CONJUNCTS = true;
+// Below ~1M rows a predicate kernel is launch-latency-bound (tens of microseconds) while the
+// cascade adds a handful of launches plus a 4-byte device-to-host count sync of the same order,
+// so the crossover sits near this size; above it the saving scales with rows and the overhead
+// stays fixed.
+uint64_t Config::FILTER_CASCADE_MIN_ROWS = 1ULL << 20;
+// Break-even between gathering survivors before the residual (~55 ps per surviving row for a
+// ~50 B row at the ~890 GB/s device-to-device gather rate) and the residual string evaluation
+// the gather avoids (~180 ps per dropped row, measured JIT string-compare rate):
+// 55*s = 180*(1-s) -> s ~ 0.77, rounded down.
+double Config::FILTER_CASCADE_MAX_PASS_RATE = 0.75;
+
 bool Config::USE_CUSTOM_TOP_N = true;
 
 bool Config::USE_OPT_TABLE_SCAN                  = true;

--- a/src/expression_evaluator/expression_evaluator.cpp
+++ b/src/expression_evaluator/expression_evaluator.cpp
@@ -36,6 +36,7 @@
 // standard library
 #include <memory>
 #include <numeric>
+#include <utility>
 #include <variant>
 
 namespace {
@@ -333,15 +334,23 @@ std::unique_ptr<cudf::table> expression_evaluator::select(
       "[expression_evaluator] select(): output_indices must be non-empty; use the "
       "all-columns select() overload for count(*)-style filters with no output columns");
   }
-  auto mask = compute_mask(input);
-  return cudf::apply_boolean_mask(
-    input.select(output_indices.begin(), output_indices.end()), mask->view(), _stream, _mr);
+  return select_impl(input, output_indices);
 }
 
 std::unique_ptr<cudf::table> expression_evaluator::select(cudf::table_view input)
 {
+  return select_impl(input, {});
+}
+
+std::unique_ptr<cudf::table> expression_evaluator::select_impl(
+  cudf::table_view input, std::span<cudf::size_type const> output_indices)
+{
+  _last_filter_cascade_decision = filter_cascade_decision::not_applicable;
+  if (auto cascaded = try_select_cascade(input, output_indices)) { return std::move(*cascaded); }
   auto mask = compute_mask(input);
-  return cudf::apply_boolean_mask(input, mask->view(), _stream, _mr);
+  auto const projected =
+    output_indices.empty() ? input : input.select(output_indices.begin(), output_indices.end());
+  return cudf::apply_boolean_mask(projected, mask->view(), _stream, _mr);
 }
 
 evaluate_result expression_evaluator::evaluate(sirius::ast::aggregate const& /*expr*/,

--- a/src/expression_evaluator/filter_cascade.cpp
+++ b/src/expression_evaluator/filter_cascade.cpp
@@ -146,6 +146,10 @@ std::optional<std::unique_ptr<cudf::table>> expression_evaluator::try_select_cas
 
   std::vector<ast::node const*> cheap;
   std::vector<ast::node const*> expensive;
+  // This split cannot change three-valued outcomes: a Kleene conjunction is TRUE iff every
+  // operand is TRUE, so AND(cheap) then AND(expensive) keeps exactly the rows AND(all children)
+  // keeps (full argument in the file header). Classification only decides where each conjunct's
+  // cost lands.
   for (auto const& child : conj.children) {
     if (!child) { return std::nullopt; }  // malformed AST: let the ordinary path report it
     (detail::is_cheap_prefilter_conjunct(*child, input) ? cheap : expensive).push_back(child.get());

--- a/src/expression_evaluator/filter_cascade.cpp
+++ b/src/expression_evaluator/filter_cascade.cpp
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Cheap-conjunct filter cascade policy for sirius::expression_evaluator::select().
+//
+// This translation unit holds the policy of the cascade — the conjunct classifier and the
+// decision procedure in try_select_cascade — following the house pattern of defining one class's
+// concern-specific members across dedicated files (see specializations/*.cpp). All mechanism
+// (compute_mask, cudf::apply_boolean_mask, cudf::bools_to_mask, NULL_LOGICAL_AND) is the
+// existing evaluator/cuDF machinery, reused unmodified; expression_evaluator.cpp keeps the
+// baseline select path.
+//
+// Correctness rests on Kleene partition invariance: for a top-level AND with children C and any
+// partition C = A + B, AND(C) is TRUE for a row iff AND(A) and AND(B) are both TRUE, because
+// Kleene AND is associative/commutative and a Kleene conjunction is TRUE iff all operands are
+// TRUE (a NULL or FALSE anywhere makes it non-TRUE). cudf::apply_boolean_mask keeps exactly the
+// valid-and-TRUE rows and NULL_LOGICAL_AND is Kleene AND (matching the lowering in
+// specializations/conjunction.cpp), so every route below — cascaded, combined_masks,
+// short_circuited, and the caller's monolithic fallback — produces the identical row set. In
+// particular, a row where the cheap group evaluates to NULL is correctly dropped before the
+// residual ever runs (TRUE AND NULL != TRUE), and a row where the cheap group is TRUE but the
+// residual is NULL is dropped by the residual stage; the cascade therefore needs no
+// null-handling code of its own.
+
+// sirius
+#include <config.hpp>
+#include <expression/ast/node.hpp>   // sirius::ast::node alternatives
+#include <expression/ast/utils.hpp>  // sirius::ast::clone, sirius::ast::visit_references
+#include <expression_evaluator/expression_evaluator.hpp>
+#include <expression_evaluator/filter_cascade_internal.hpp>
+#include <log/logging.hpp>
+
+// cudf
+#include <cudf/binaryop.hpp>
+#include <cudf/copying.hpp>  // cudf::empty_like
+#include <cudf/stream_compaction.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/transform.hpp>  // cudf::bools_to_mask
+#include <cudf/types.hpp>
+#include <cudf/utilities/traits.hpp>  // cudf::is_fixed_width
+
+// standard library
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace sirius::detail {
+
+// Contract and the deliberate non-exhaustiveness of the visitor's default arm are documented on
+// the declaration in filter_cascade_internal.hpp.
+bool is_cheap_prefilter_conjunct(sirius::ast::node const& n, cudf::table_view const& input)
+{
+  namespace ast = sirius::ast;
+  return std::visit(
+    [&](auto const& alt) -> bool {
+      using T = std::decay_t<decltype(alt)>;
+      if constexpr (std::is_same_v<T, ast::reference>) {
+        if (alt.column_index >= static_cast<uint32_t>(input.num_columns())) { return false; }
+        return cudf::is_fixed_width(
+          input.column(static_cast<cudf::size_type>(alt.column_index)).type());
+      } else if constexpr (std::is_same_v<T, ast::constant>) {
+        // Literals are free; only string payloads (which can only pair with string-carried
+        // operands) mark a conjunct expensive.
+        return !alt.return_type().is_varchar();
+      } else if constexpr (std::is_same_v<T, ast::comparison>) {
+        return alt.left && alt.right && is_cheap_prefilter_conjunct(*alt.left, input) &&
+               is_cheap_prefilter_conjunct(*alt.right, input);
+      } else if constexpr (std::is_same_v<T, ast::between>) {
+        return alt.input && alt.lower && alt.upper &&
+               is_cheap_prefilter_conjunct(*alt.input, input) &&
+               is_cheap_prefilter_conjunct(*alt.lower, input) &&
+               is_cheap_prefilter_conjunct(*alt.upper, input);
+      } else if constexpr (std::is_same_v<T, ast::conjunction>) {
+        // A nested AND or OR of fixed-width comparisons is still elementwise.
+        return !alt.children.empty() &&
+               std::all_of(alt.children.begin(), alt.children.end(), [&](auto const& child) {
+                 return child && is_cheap_prefilter_conjunct(*child, input);
+               });
+      } else if constexpr (std::is_same_v<T, ast::in_list>) {
+        return alt.probe && is_cheap_prefilter_conjunct(*alt.probe, input) &&
+               std::all_of(alt.values.begin(), alt.values.end(), [&](auto const& value) {
+                 return value && is_cheap_prefilter_conjunct(*value, input);
+               });
+      } else if constexpr (std::is_same_v<T, ast::unary_op>) {
+        switch (alt.op) {
+          case ast::unary_op::kind::op_not:
+          case ast::unary_op::kind::op_is_null:
+          case ast::unary_op::kind::op_is_not_null:
+            return alt.child && is_cheap_prefilter_conjunct(*alt.child, input);
+          default: return false;
+        }
+      } else {
+        // cast, case_expr, coalesce, function_call, aggregate, and any future alternative.
+        return false;
+      }
+    },
+    n.v);
+}
+
+}  // namespace sirius::detail
+
+namespace sirius {
+
+// Sub-evaluators produce, per row, the same value a monolithic evaluation would: every
+// specialization's lowering decisions (restored-reference casts, narrow-domain comparisons)
+// depend only on the conjunct's own operands and carrier types, never on sibling conjuncts.
+// Future specializations must preserve this context-free property; the byte-equivalence tests in
+// test_filter_cascade.cpp are its regression net.
+std::optional<std::unique_ptr<cudf::table>> expression_evaluator::try_select_cascade(
+  cudf::table_view input, std::span<cudf::size_type const> output_indices)
+{
+  namespace ast = sirius::ast;
+  // One coherent knob snapshot per call: the SET handlers write these globals from other
+  // connections, and the branch taken must match what any log line reports.
+  if (!duckdb::Config::FILTER_CASCADE_CHEAP_CONJUNCTS) { return std::nullopt; }
+  auto const min_rows      = duckdb::Config::FILTER_CASCADE_MIN_ROWS;
+  auto const max_pass_rate = duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE;
+  auto const num_rows      = input.num_rows();
+  if (num_rows <= 0 || static_cast<std::uint64_t>(num_rows) < min_rows) { return std::nullopt; }
+  if (_ast_expressions.size() != 1 || _ast_expressions[0] == nullptr) { return std::nullopt; }
+  auto const& root = *_ast_expressions[0];
+  if (!root.holds<ast::conjunction>()) { return std::nullopt; }
+  auto const& conj = root.get<ast::conjunction>();
+  if (conj.op != ast::conjunction::kind::op_and) { return std::nullopt; }
+
+  std::vector<ast::node const*> cheap;
+  std::vector<ast::node const*> expensive;
+  for (auto const& child : conj.children) {
+    if (!child) { return std::nullopt; }  // malformed AST: let the ordinary path report it
+    (detail::is_cheap_prefilter_conjunct(*child, input) ? cheap : expensive).push_back(child.get());
+  }
+  if (cheap.empty() || expensive.empty()) { return std::nullopt; }
+
+  // Gather-scope guard: the cascaded branch gathers `input` wholesale, which is acceptable only
+  // when that is shape-equivalent to what the monolithic path materializes anyway. Under a
+  // projection that drops a column the expensive residual never reads, the gather would
+  // materialize up to pass_rate x (its bytes) of pure peak-memory waste on memory-tight scans —
+  // and a cascade that may never gather has negative expected value versus the single monolithic
+  // kernel (extra launches plus a host sync for no possible win), so refuse outright rather than
+  // salvage. The needed set is output_indices union referenced(expensive residual); it
+  // deliberately excludes cheap-only references — a column read only by the cheap group is dead
+  // after the prefilter, so gathering it is waste too.
+  if (!output_indices.empty()) {
+    std::vector<bool> needed(static_cast<std::size_t>(input.num_columns()), false);
+    for (auto const output_index : output_indices) {
+      if (output_index >= 0 && output_index < input.num_columns()) {
+        needed[static_cast<std::size_t>(output_index)] = true;
+      }
+    }
+    for (auto const* conjunct : expensive) {
+      ast::visit_references(*conjunct, [&](ast::reference const& ref) {
+        if (ref.column_index < static_cast<uint32_t>(input.num_columns())) {
+          needed[ref.column_index] = true;
+        }
+      });
+    }
+    if (!std::all_of(needed.begin(), needed.end(), [](bool used) { return used; })) {
+      return std::nullopt;
+    }
+  }
+
+  // From here the cascade is committed: once the cheap mask and its survivor count exist, every
+  // outcome below is cheaper than restarting on the monolithic path.
+
+  // A single conjunct is borrowed in place (owned by the operator's expression, alive across
+  // this call); a multi-conjunct group needs an owning AND wrapper, so its members are
+  // deep-cloned (predicate trees are tiny — a few host allocations against a multi-million-row
+  // kernel).
+  auto make_group = [](std::vector<ast::node const*> const& parts)
+    -> std::pair<ast::node const*, std::unique_ptr<ast::node>> {
+    if (parts.size() == 1) { return {parts.front(), nullptr}; }
+    ast::conjunction group;
+    group.op = ast::conjunction::kind::op_and;
+    group.children.reserve(parts.size());
+    for (auto const* part : parts) {
+      group.children.push_back(ast::clone(*part));
+    }
+    auto owned      = std::make_unique<ast::node>(std::move(group));
+    auto const* ptr = owned.get();
+    return {ptr, std::move(owned)};
+  };
+
+  auto const [cheap_root, cheap_owned] = make_group(cheap);
+  expression_evaluator cheap_evaluator(cheap_root, _mr, _stream, _strategy, _min_ast_size);
+  auto cheap_mask = cheap_evaluator.compute_mask(input);
+
+  // Survivor count: bools_to_mask reports how many entries are false-or-null, which is exactly
+  // the set apply_boolean_mask would drop, so passed = num_rows - dropped. The transient bitmask
+  // (num_rows/8 bytes) is discarded immediately. The count is the cascade's one host-blocking
+  // 4-byte device-to-host sync — the price of the adaptive decision.
+  cudf::size_type dropped = 0;
+  {
+    auto const mask_and_count = cudf::bools_to_mask(cheap_mask->view(), _stream, _mr);
+    dropped                   = mask_and_count.second;
+  }
+  auto const passed    = num_rows - dropped;
+  auto const pass_rate = static_cast<double>(passed) / static_cast<double>(num_rows);
+
+  // The engaged path is the hottest filter route in the engine, so per-batch detail stays at
+  // DEBUG; one INFO line per process on first engagement keeps activation evidence in every
+  // run's log without per-batch volume.
+  static std::atomic<bool> activation_logged{false};
+  if (!activation_logged.exchange(true, std::memory_order_relaxed)) {
+    SIRIUS_LOG_INFO(
+      "[expression_evaluator] filter cascade engaged (first activation in this process): "
+      "{} of {} rows (rate {:.3f}) pass the cheap prefilter ({} cheap / {} expensive "
+      "conjuncts); per-batch decisions log at debug level",
+      passed,
+      num_rows,
+      pass_rate,
+      cheap.size(),
+      expensive.size());
+  }
+
+  auto project = [&](cudf::table_view t) {
+    return output_indices.empty() ? t : t.select(output_indices.begin(), output_indices.end());
+  };
+
+  if (passed == 0) {
+    // Nothing survives the cheap prefilter, so skipping the residual is legal (a non-TRUE cheap
+    // group already makes the whole AND non-TRUE). cudf::empty_like matches the zero-row
+    // structure apply_boolean_mask itself returns for empty inputs.
+    _last_filter_cascade_decision = filter_cascade_decision::short_circuited;
+    SIRIUS_LOG_DEBUG(
+      "[expression_evaluator] filter cascade: cheap prefilter dropped all {} rows "
+      "({} cheap / {} expensive conjuncts)",
+      num_rows,
+      cheap.size(),
+      expensive.size());
+    return cudf::empty_like(project(input));
+  }
+
+  auto const [residual_root, residual_owned] = make_group(expensive);
+  expression_evaluator residual_evaluator(residual_root, _mr, _stream, _strategy, _min_ast_size);
+
+  if (pass_rate <= max_pass_rate) {
+    // Selective prefilter: compact once, then run the expensive residual only on survivors.
+    // apply_boolean_mask is a stable compaction and two stacked stable compactions compose to a
+    // stable compaction, so output order equals input order equals the monolithic path's order.
+    _last_filter_cascade_decision = filter_cascade_decision::cascaded;
+    SIRIUS_LOG_DEBUG(
+      "[expression_evaluator] filter cascade: {} of {} rows (rate {:.3f}) pass the cheap "
+      "prefilter ({} cheap / {} expensive conjuncts); evaluating the residual on survivors",
+      passed,
+      num_rows,
+      pass_rate,
+      cheap.size(),
+      expensive.size());
+    auto const survivors = cudf::apply_boolean_mask(input, cheap_mask->view(), _stream, _mr);
+    cheap_mask.reset();
+    auto const residual_mask = residual_evaluator.compute_mask(survivors->view());
+    return cudf::apply_boolean_mask(
+      project(survivors->view()), residual_mask->view(), _stream, _mr);
+  }
+
+  // The prefilter is too unselective for the gather to pay for itself. The cheap mask is a sunk
+  // cost at this point, so ANDing it with the residual mask (Kleene, matching the conjunction
+  // lowering) is strictly cheaper than recomputing the monolithic predicate. Same row set either
+  // way.
+  _last_filter_cascade_decision = filter_cascade_decision::combined_masks;
+  SIRIUS_LOG_DEBUG(
+    "[expression_evaluator] filter cascade: {} of {} rows (rate {:.3f}) pass the cheap "
+    "prefilter ({} cheap / {} expensive conjuncts); pass rate above "
+    "filter_cascade_max_pass_rate, combining masks without a gather",
+    passed,
+    num_rows,
+    pass_rate,
+    cheap.size(),
+    expensive.size());
+  auto const residual_mask = residual_evaluator.compute_mask(input);
+  auto const combined      = cudf::binary_operation(cheap_mask->view(),
+                                               residual_mask->view(),
+                                               cudf::binary_operator::NULL_LOGICAL_AND,
+                                               cudf::data_type{cudf::type_id::BOOL8},
+                                               _stream,
+                                               _mr);
+  return cudf::apply_boolean_mask(project(input), combined->view(), _stream, _mr);
+}
+
+}  // namespace sirius

--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -40,6 +40,18 @@ struct Config {
   static ::sirius::expression_evaluator_strategy
     EXPRESSION_EVALUATOR_STRATEGY;  // expression_evaluator_strategy
 
+  // Cheap-conjunct filter cascade in sirius::expression_evaluator::select(): split a filter's
+  // top-level AND into cheap fixed-width prefilter conjuncts and an expensive (string-carried /
+  // AST-breaker) residual, evaluate the cheap group first, and run the residual only on rows
+  // surviving the prefilter.
+  static bool FILTER_CASCADE_CHEAP_CONJUNCTS;  // filter_cascade_cheap_conjuncts
+  // Minimum input rows before the cascade engages; below this, kernel-launch latency dominates
+  // the possible saving and the monolithic single-kernel path wins.
+  static uint64_t FILTER_CASCADE_MIN_ROWS;  // filter_cascade_min_rows
+  // Highest cheap-prefilter pass rate at which survivors are gathered before the residual runs;
+  // above it the residual is evaluated in place and the two masks are ANDed (no gather).
+  static double FILTER_CASCADE_MAX_PASS_RATE;  // filter_cascade_max_pass_rate
+
   // For gpu physical top-N
   static bool USE_CUSTOM_TOP_N;  // use_custom_top_n
 

--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -43,13 +43,22 @@ struct Config {
   // Cheap-conjunct filter cascade in sirius::expression_evaluator::select(): split a filter's
   // top-level AND into cheap fixed-width prefilter conjuncts and an expensive (string-carried /
   // AST-breaker) residual, evaluate the cheap group first, and run the residual only on rows
-  // surviving the prefilter.
+  // surviving the prefilter. Defaults to true. Results are identical either way (any split of a
+  // conjunction selects the same rows under Kleene AND), so enabling trades a few extra kernel
+  // launches plus one 4-byte device-to-host sync for skipping expensive residual work on
+  // filtered-out rows; false always takes the monolithic single-mask path.
   static bool FILTER_CASCADE_CHEAP_CONJUNCTS;  // filter_cascade_cheap_conjuncts
   // Minimum input rows before the cascade engages; below this, kernel-launch latency dominates
-  // the possible saving and the monolithic single-kernel path wins.
+  // the possible saving and the monolithic single-kernel path wins. Any uint64; defaults to
+  // 1 << 20 (~1M rows, the estimated crossover — see config.cpp). Raising it trades cascade wins
+  // on mid-size batches for immunity to the fixed per-call overhead; 0 engages on every
+  // non-empty batch.
   static uint64_t FILTER_CASCADE_MIN_ROWS;  // filter_cascade_min_rows
   // Highest cheap-prefilter pass rate at which survivors are gathered before the residual runs;
-  // above it the residual is evaluated in place and the two masks are ANDed (no gather).
+  // above it the residual is evaluated in place and the two masks are ANDed (no gather). Domain
+  // [0, 1], enforced by the SET handler; defaults to 0.75 (the gather-vs-residual break-even —
+  // see config.cpp). 0 never gathers (always combine masks), 1 always gathers; raising it trades
+  // gather bytes on unselective prefilters for residual work saved on the rows they do drop.
   static double FILTER_CASCADE_MAX_PASS_RATE;  // filter_cascade_max_pass_rate
 
   // For gpu physical top-N

--- a/src/include/expression_evaluator/expression_evaluator.hpp
+++ b/src/include/expression_evaluator/expression_evaluator.hpp
@@ -358,6 +358,32 @@ class expression_evaluator {
     return _narrow_domain_comparison_count;
   }
 
+  /**
+   * @brief Which path the most recent select() took through the cheap-conjunct filter cascade.
+   *
+   * The cascade (see Config::FILTER_CASCADE_CHEAP_CONJUNCTS) splits a top-level AND into cheap
+   * fixed-width prefilter conjuncts and an expensive residual: `cascaded` means the residual ran
+   * only on gathered prefilter survivors, `combined_masks` means the prefilter was too
+   * unselective to justify the gather so the residual ran in place and the masks were ANDed,
+   * `short_circuited` means the prefilter dropped every row and the residual never ran, and
+   * `not_applicable` means the cascade did not engage (disabled, below the row threshold, the
+   * predicate is not an AND mixing both conjunct classes, or the survivor gather is out of scope
+   * for the caller's projection).
+   */
+  enum class filter_cascade_decision : std::uint8_t {
+    not_applicable,
+    cascaded,
+    combined_masks,
+    short_circuited,
+  };
+
+  /// The filter-cascade path taken by the most recent select(). Exposed for
+  /// observability/testing.
+  [[nodiscard]] filter_cascade_decision last_filter_cascade_decision_for_testing() const noexcept
+  {
+    return _last_filter_cascade_decision;
+  }
+
  private:
   std::vector<sirius::ast::node const*> _ast_expressions;  ///< The AST expressions to evaluate
   expression_evaluator_strategy _strategy;  ///< The strategy to use for expression evaluation
@@ -391,10 +417,31 @@ class expression_evaluator {
   std::vector<restored_reference_cache_entry> _restored_reference_cache;
   std::size_t _restored_reference_cast_count{0};   ///< For observability/testing
   std::size_t _narrow_domain_comparison_count{0};  ///< For observability/testing
+  filter_cascade_decision _last_filter_cascade_decision{
+    filter_cascade_decision::not_applicable};  ///< For observability/testing
 
   // Evaluate the executor's single boolean predicate over @p input and return the resulting
   // mask column (the sole column of evaluate()'s output). Shared by both select() overloads.
   std::unique_ptr<cudf::column> compute_mask(cudf::table_view input);
+
+  // Shared body of both select() overloads; an empty @p output_indices means all columns.
+  std::unique_ptr<cudf::table> select_impl(cudf::table_view input,
+                                           std::span<cudf::size_type const> output_indices);
+
+  // Cheap-conjunct filter cascade (Config::FILTER_CASCADE_CHEAP_CONJUNCTS), defined in
+  // filter_cascade.cpp: when the predicate is a top-level AND mixing cheap fixed-width conjuncts
+  // with expensive (string-carried or AST-breaking) ones, the batch clears
+  // Config::FILTER_CASCADE_MIN_ROWS, and the survivor gather is in scope — every input column is
+  // projected or referenced by the expensive residual — evaluate the cheap conjuncts first and
+  // run the expensive residual only on surviving rows. The gather happens when the prefilter
+  // pass rate is at most Config::FILTER_CASCADE_MAX_PASS_RATE (see config.cpp for the break-even
+  // reasoning); above that the residual runs over all rows and the two masks are ANDed. Any
+  // split of a conjunction selects the same rows under Kleene AND, so this is purely a
+  // performance decision. Returns nullopt when the cascade does not apply (including an
+  // out-of-scope gather, where splitting could never beat the monolithic kernel); the caller
+  // then falls through to the monolithic single-mask path.
+  std::optional<std::unique_ptr<cudf::table>> try_select_cascade(
+    cudf::table_view input, std::span<cudf::size_type const> output_indices);
 
   // Execute the AST tree rooted at the given expression reference and return the result as a
   // column.

--- a/src/include/expression_evaluator/filter_cascade_internal.hpp
+++ b/src/include/expression_evaluator/filter_cascade_internal.hpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Internal declaration shared between filter_cascade.cpp and its unit tests, following the
+// gpu_expression_translator_internal.hpp precedent: the classifier is an implementation detail
+// of sirius::expression_evaluator::try_select_cascade, exposed here so tests can exercise each
+// classification arm directly.
+
+// sirius
+#include <expression/ast/node.hpp>  // sirius::ast::node
+
+// cudf
+#include <cudf/table/table_view.hpp>
+
+namespace sirius::detail {
+
+/**
+ * @brief Returns true when the conjunct rooted at @p n is cheap-prefilter material for the filter
+ * cascade in sirius::expression_evaluator::select().
+ *
+ * A conjunct is cheap iff every node in its subtree is an elementwise, fixed-width-carried
+ * operation: a reference whose column index is in bounds for @p input and whose *runtime carrier*
+ * satisfies cudf::is_fixed_width, a non-VARCHAR constant, or a comparison / BETWEEN / IN-list /
+ * nested conjunction (AND or OR) / NOT / IS NULL / IS NOT NULL over cheap operands. Everything
+ * else — string-carried references, string literals, CAST, CASE, COALESCE, TRY, function calls,
+ * aggregates — is expensive: real per-row cost and/or an AST-breaking lowering.
+ *
+ * The runtime carrier decides because cost lives in the materialized column, not the declared
+ * type: under compressed materialization a reference's declared type and physical carrier differ,
+ * and decode-time predicate substitution turns a string filter into a BOOL8 mask reference —
+ * fixed-width, hence cheap. cudf::is_fixed_width is false for exactly the expensive carriers
+ * (STRING, LIST, STRUCT, DICTIONARY32, EMPTY), so the single cuDF trait is the whole type policy.
+ *
+ * Misclassification cannot change results: a conjunction selects the same rows under any
+ * partition of its children (Kleene AND is associative/commutative and cudf::apply_boolean_mask
+ * keeps only valid-and-TRUE rows), so classification only moves cost between the prefilter and
+ * the residual. The safe default direction is *expensive* — a conjunct wrongly classified
+ * expensive merely fails to prefilter, while one wrongly classified cheap drags real per-row cost
+ * into the stage that runs on all rows. The visitor's default arm therefore returns false, and —
+ * unlike ast::clone / ast::visit_references, which static_assert exhaustiveness because omission
+ * there is a correctness bug — this classifier deliberately does not force handling of new
+ * ast::node alternatives: they land in the residual automatically. Conservative arms (e.g. a
+ * fixed-width cast is elementwise-cheap in principle) are only widened with measured evidence.
+ */
+[[nodiscard]] bool is_cheap_prefilter_conjunct(sirius::ast::node const& n,
+                                               cudf::table_view const& input);
+
+}  // namespace sirius::detail

--- a/src/include/expression_evaluator/filter_cascade_internal.hpp
+++ b/src/include/expression_evaluator/filter_cascade_internal.hpp
@@ -30,8 +30,8 @@
 namespace sirius::detail {
 
 /**
- * @brief Returns true when the conjunct rooted at @p n is cheap-prefilter material for the filter
- * cascade in sirius::expression_evaluator::select().
+ * @brief Classifies one conjunct of a filter's top-level AND as cheap-prefilter material for the
+ * filter cascade in sirius::expression_evaluator::select()
  *
  * A conjunct is cheap iff every node in its subtree is an elementwise, fixed-width-carried
  * operation: a reference whose column index is in bounds for @p input and whose *runtime carrier*
@@ -56,6 +56,12 @@ namespace sirius::detail {
  * there is a correctness bug — this classifier deliberately does not force handling of new
  * ast::node alternatives: they land in the residual automatically. Conservative arms (e.g. a
  * fixed-width cast is elementwise-cheap in principle) are only widened with measured evidence.
+ *
+ * @param n     Root of the conjunct's AST subtree
+ * @param input Table the filter runs over; supplies each ast::reference's bounds check and
+ *              runtime carrier type
+ * @return true when the conjunct belongs in the cheap prefilter group, false when it belongs in
+ * the expensive residual
  */
 [[nodiscard]] bool is_cheap_prefilter_conjunct(sirius::ast::node const& n,
                                                cudf::table_view const& input);

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1748,6 +1748,34 @@ static void SetExpressionExecutorStrategyDeprecated(ClientContext& context,
   ApplyExpressionEvaluatorStrategy(StringValue::Get(parameter));
 }
 
+static void SetFilterCascadeCheapConjuncts(ClientContext& context, SetScope scope, Value& parameter)
+{
+  throw_if_sirius_runtime_unavailable(context);
+  Config::FILTER_CASCADE_CHEAP_CONJUNCTS = BooleanValue::Get(parameter);
+  SIRIUS_LOG_DEBUG("Updated config FILTER_CASCADE_CHEAP_CONJUNCTS to {}",
+                   Config::FILTER_CASCADE_CHEAP_CONJUNCTS);
+}
+
+static void SetFilterCascadeMinRows(ClientContext& context, SetScope scope, Value& parameter)
+{
+  throw_if_sirius_runtime_unavailable(context);
+  Config::FILTER_CASCADE_MIN_ROWS = UBigIntValue::Get(parameter);
+  SIRIUS_LOG_DEBUG("Updated config FILTER_CASCADE_MIN_ROWS to {}", Config::FILTER_CASCADE_MIN_ROWS);
+}
+
+static void SetFilterCascadeMaxPassRate(ClientContext& context, SetScope scope, Value& parameter)
+{
+  throw_if_sirius_runtime_unavailable(context);
+  auto const rate = DoubleValue::Get(parameter);
+  // Negated form rejects NaN as well as out-of-range values.
+  if (!(rate >= 0.0 && rate <= 1.0)) {
+    throw InvalidInputException("filter_cascade_max_pass_rate must be in [0, 1], got %f", rate);
+  }
+  Config::FILTER_CASCADE_MAX_PASS_RATE = rate;
+  SIRIUS_LOG_DEBUG("Updated config FILTER_CASCADE_MAX_PASS_RATE to {}",
+                   Config::FILTER_CASCADE_MAX_PASS_RATE);
+}
+
 #ifdef SIRIUS_ENABLE_LEGACY
 static void SetUseCustomTopN(ClientContext& context, SetScope scope, Value& parameter)
 {
@@ -2172,6 +2200,29 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     LogicalType::VARCHAR,
     Value(std::string(sirius::strategy_to_string(Config::EXPRESSION_EVALUATOR_STRATEGY))),
     SetExpressionExecutorStrategyDeprecated);
+
+  config.AddExtensionOption(
+    "filter_cascade_cheap_conjuncts",
+    "Evaluate cheap fixed-width conjuncts of a filter's top-level AND first and run the "
+    "expensive (string / AST-breaker) residual only on surviving rows",
+    LogicalType::BOOLEAN,
+    Value::BOOLEAN(Config::FILTER_CASCADE_CHEAP_CONJUNCTS),
+    SetFilterCascadeCheapConjuncts);
+
+  config.AddExtensionOption("filter_cascade_min_rows",
+                            "Minimum input rows before the filter cascade engages (below this, "
+                            "kernel-launch latency dominates the possible saving)",
+                            LogicalType::UBIGINT,
+                            Value::UBIGINT(Config::FILTER_CASCADE_MIN_ROWS),
+                            SetFilterCascadeMinRows);
+
+  config.AddExtensionOption(
+    "filter_cascade_max_pass_rate",
+    "Highest cheap-prefilter pass rate at which the cascade gathers survivors before the "
+    "expensive residual; above it the residual runs over all rows and the masks are combined",
+    LogicalType::DOUBLE,
+    Value::DOUBLE(Config::FILTER_CASCADE_MAX_PASS_RATE),
+    SetFilterCascadeMaxPassRate);
 
 #ifdef SIRIUS_ENABLE_LEGACY
   // Add in config option for top-N

--- a/test/cpp/expression_evaluator/test_filter_cascade.cpp
+++ b/test/cpp/expression_evaluator/test_filter_cascade.cpp
@@ -1,0 +1,834 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for the cheap-conjunct filter cascade in expression_evaluator::select().
+//
+// The cascade splits a top-level AND into cheap fixed-width prefilter conjuncts
+// and an expensive (string-carried) residual, evaluates the cheap group first,
+// and runs the residual only on surviving rows when the prefilter is selective
+// enough. These tests assert two things for every decision branch:
+//   1. the decision taken (via last_filter_cascade_decision_for_testing), and
+//   2. byte-identical results against the monolithic single-mask path
+//      (cascade disabled), including under NULLs and Kleene AND semantics.
+// The conjunct classifier is additionally exercised arm-by-arm through
+// filter_cascade_internal.hpp.
+//
+// Config knobs are process-global; config_guard saves/restores them so these
+// tests cannot leak thresholds into other test files.
+
+// test
+#include "ast_test_support.hpp"
+
+#include <catch.hpp>
+
+// sirius
+#include <config.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/memory/reservation_manager_configurator.hpp>
+#include <data/sirius_converter_registry.hpp>
+#include <expression/ast/node.hpp>
+#include <expression/value.hpp>
+#include <expression_evaluator/expression_evaluator.hpp>
+#include <expression_evaluator/filter_cascade_internal.hpp>
+#include <helper/logical_type.hpp>
+#include <memory/sirius_memory_reservation_manager.hpp>
+
+// test utils
+#include <operator/operator_type_traits.hpp>
+#include <utils/data_utils.hpp>
+
+// cudf
+#include <cudf/column/column_factories.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+#include <cuda_runtime_api.h>
+
+// standard library
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace cucascade;
+using namespace cucascade::memory;
+using namespace sirius::expr_test;
+
+namespace {
+
+namespace test_utils = ::sirius::test::operator_utils;
+
+using memory_mgr = ::sirius::memory::sirius_memory_reservation_manager;
+using decision   = ::sirius::expression_evaluator::filter_cascade_decision;
+
+std::unique_ptr<memory_mgr> initialize_memory_manager()
+{
+  ::sirius::converter_registry::reset_for_testing();
+  reservation_manager_configurator builder;
+  auto constexpr gpu_capacity  = 256ull << 20;  // 256MB
+  auto constexpr host_capacity = 512ull << 20;  // 512MB
+  auto constexpr limit_ratio   = 0.75;
+  builder.set_number_of_gpus(1)
+    .set_gpu_usage_limit(gpu_capacity)
+    .set_reservation_fraction_per_gpu(limit_ratio)
+    .set_per_numa_region_capacity(host_capacity)
+    .use_gpu_id_as_host_id()
+    .set_reservation_fraction_per_numa_region(limit_ratio);
+  auto configs = builder.build();
+  auto manager = std::make_unique<memory_mgr>(std::move(configs));
+  ::sirius::converter_registry::initialize();
+  return manager;
+}
+
+memory_space* get_default_gpu_space()
+{
+  static auto manager = initialize_memory_manager();
+  return const_cast<memory_space*>(manager->get_memory_space(Tier::GPU, 0));
+}
+
+rmm::device_async_resource_ref get_resource_ref(memory_space& space)
+{
+  return space.get_default_allocator();
+}
+
+/// Save/restore the cascade Config knobs around each test.
+struct config_guard {
+  bool enabled           = duckdb::Config::FILTER_CASCADE_CHEAP_CONJUNCTS;
+  std::uint64_t min_rows = duckdb::Config::FILTER_CASCADE_MIN_ROWS;
+  double max_pass_rate   = duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE;
+  ~config_guard()
+  {
+    duckdb::Config::FILTER_CASCADE_CHEAP_CONJUNCTS = enabled;
+    duckdb::Config::FILTER_CASCADE_MIN_ROWS        = min_rows;
+    duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE   = max_pass_rate;
+  }
+};
+
+/// Null out exactly the given rows of @p col (explicit rows, not stride coincidence).
+void set_nulls_at(cudf::column& col,
+                  std::vector<cudf::size_type> const& rows,
+                  rmm::cuda_stream_view stream,
+                  rmm::device_async_resource_ref mr)
+{
+  auto mask      = cudf::create_null_mask(col.size(), cudf::mask_state::ALL_VALID, stream, mr);
+  auto* mask_ptr = static_cast<cudf::bitmask_type*>(mask.data());
+  for (auto const row : rows) {
+    cudf::set_null_mask(mask_ptr, row, row + 1, false, stream);
+  }
+  col.set_null_mask(std::move(mask), static_cast<cudf::size_type>(rows.size()));
+}
+
+/// What make_mixed_table appends after its two predicate columns.
+enum class extra_column : std::uint8_t {
+  none,
+  string_payload,  ///< col2 STRING "payload-<i>" — expensive to gather, referenced by nothing
+  int_payload,     ///< col2 INT32 — fixed-width, referenceable by a cheap conjunct
+};
+
+/// Input fixture: col0 INT32 = 0..n-1 (optionally with nulls), col1 STRING cycling
+/// {"AIR", "TRUCK", "MAIL", "SHIP"} (optionally with nulls), plus an optional payload column
+/// that no test predicate's residual references — the column the gather-scope guard must not
+/// gather.
+std::unique_ptr<cudf::table> make_mixed_table(memory_space& space,
+                                              cudf::size_type n,
+                                              bool with_nulls,
+                                              extra_column extra = extra_column::none)
+{
+  auto mr     = get_resource_ref(space);
+  auto stream = cudf::get_default_stream();
+
+  std::vector<int32_t> ints(n);
+  std::vector<std::string> strs(n);
+  static std::vector<std::string> const kModes{"AIR", "TRUCK", "MAIL", "SHIP"};
+  for (cudf::size_type i = 0; i < n; ++i) {
+    ints[i] = i;
+    strs[i] = kModes[i % kModes.size()];
+  }
+
+  auto int_col =
+    ::sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(ints, stream, mr);
+  auto str_col =
+    ::sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<test_utils::string_tag>>(
+      strs, stream, mr);
+
+  if (with_nulls) {
+    // Null out every 7th int row and every 5th string row (offset so the sets differ).
+    auto strided_rows = [n](cudf::size_type stride, cudf::size_type offset) {
+      std::vector<cudf::size_type> rows;
+      for (cudf::size_type i = offset; i < n; i += stride) {
+        rows.push_back(i);
+      }
+      return rows;
+    };
+    set_nulls_at(*int_col, strided_rows(7, 3), stream, mr);
+    set_nulls_at(*str_col, strided_rows(5, 1), stream, mr);
+  }
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(int_col));
+  cols.push_back(std::move(str_col));
+  if (extra == extra_column::string_payload) {
+    std::vector<std::string> payload(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      payload[i] = "payload-" + std::to_string(i);
+    }
+    cols.push_back(
+      ::sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<test_utils::string_tag>>(
+        payload, stream, mr));
+  } else if (extra == extra_column::int_payload) {
+    std::vector<int32_t> payload(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      payload[i] = n - i;
+    }
+    cols.push_back(::sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
+      payload, stream, mr));
+  }
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
+/// AND[col0 < int_bound (cheap), col1 = 'AIR' (expensive)].
+std::unique_ptr<ast_node> make_mixed_and(int32_t int_bound)
+{
+  std::vector<std::unique_ptr<ast_node>> conjuncts;
+  conjuncts.push_back(
+    make_cmp(sirius::comparison_type::lt,
+             make_ref_typed(0, sirius::logical_type::make(sirius::type_id::INTEGER)),
+             make_int_const(int_bound)));
+  conjuncts.push_back(
+    make_cmp(sirius::comparison_type::equal,
+             make_ref_typed(1, sirius::logical_type::make(sirius::type_id::VARCHAR)),
+             make_str_const("AIR")));
+  return make_conj(sirius::ast::conjunction::kind::op_and, std::move(conjuncts));
+}
+
+struct select_run {
+  std::unique_ptr<cudf::table> result;
+  decision taken;
+};
+
+select_run run_select(memory_space& space,
+                      ast_node const& expr,
+                      cudf::table_view input,
+                      ::sirius::expression_evaluator_strategy strategy,
+                      std::vector<cudf::size_type> const& output_indices = {})
+{
+  ::sirius::expression_evaluator evaluator(
+    expr, get_resource_ref(space), cudf::get_default_stream(), strategy);
+  auto result =
+    output_indices.empty() ? evaluator.select(input) : evaluator.select(input, output_indices);
+  return {std::move(result), evaluator.last_filter_cascade_decision_for_testing()};
+}
+
+/// Assert two tables (already on GPU) are element-identical, including validity.
+void expect_tables_equal(cudf::table_view lhs, cudf::table_view rhs)
+{
+  REQUIRE(lhs.num_columns() == rhs.num_columns());
+  REQUIRE(lhs.num_rows() == rhs.num_rows());
+  for (cudf::size_type c = 0; c < lhs.num_columns(); ++c) {
+    auto const& l = lhs.column(c);
+    auto const& r = rhs.column(c);
+    REQUIRE(l.type().id() == r.type().id());
+    REQUIRE(copy_valids_to_host(l) == copy_valids_to_host(r));
+    if (l.type().id() == cudf::type_id::STRING) {
+      REQUIRE(copy_string_column_to_host(l) == copy_string_column_to_host(r));
+    } else {
+      REQUIRE(copy_column_to_host<int32_t>(l) == copy_column_to_host<int32_t>(r));
+    }
+  }
+}
+
+/// Run @p expr twice — cascade enabled then disabled — asserting the enabled run takes
+/// @p expected and both results are byte-identical. Returns the enabled run for extra checks.
+select_run expect_decision_and_baseline_equality(
+  memory_space& space,
+  ast_node const& expr,
+  cudf::table_view input,
+  ::sirius::expression_evaluator_strategy strategy,
+  decision expected,
+  std::vector<cudf::size_type> const& output_indices = {})
+{
+  duckdb::Config::FILTER_CASCADE_CHEAP_CONJUNCTS = true;
+  auto enabled = run_select(space, expr, input, strategy, output_indices);
+  REQUIRE(enabled.taken == expected);
+
+  duckdb::Config::FILTER_CASCADE_CHEAP_CONJUNCTS = false;
+  auto baseline = run_select(space, expr, input, strategy, output_indices);
+  REQUIRE(baseline.taken == decision::not_applicable);
+  expect_tables_equal(baseline.result->view(), enabled.result->view());
+
+  duckdb::Config::FILTER_CASCADE_CHEAP_CONJUNCTS = true;
+  return enabled;
+}
+
+struct mat_strategy {
+  static constexpr auto value = ::sirius::expression_evaluator_strategy::MATERIALIZE;
+};
+struct ast_interpret_strategy {
+  static constexpr auto value = ::sirius::expression_evaluator_strategy::AST_INTERPRET;
+};
+struct ast_jit_strategy {
+  static constexpr auto value = ::sirius::expression_evaluator_strategy::AST_JIT;
+};
+
+constexpr auto kInterpret = ::sirius::expression_evaluator_strategy::AST_INTERPRET;
+
+}  // namespace
+
+TEMPLATE_TEST_CASE("filter cascade selects the same rows as the monolithic path",
+                   "[expression_evaluator][filter_cascade]",
+                   mat_strategy,
+                   ast_interpret_strategy,
+                   ast_jit_strategy)
+{
+  constexpr auto strategy = TestType::value;
+  auto* space             = get_default_gpu_space();
+  config_guard guard;
+
+  duckdb::Config::FILTER_CASCADE_MIN_ROWS      = 1;
+  duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 0.75;
+
+  for (bool with_nulls : {false, true}) {
+    auto input = make_mixed_table(*space, 1000, with_nulls);
+    // col0 < 300 passes 30% -> below the 0.75 pass-rate cap -> cascaded.
+    auto expr = make_mixed_and(300);
+
+    auto cascaded = expect_decision_and_baseline_equality(
+      *space, *expr, input->view(), strategy, decision::cascaded);
+    REQUIRE(cascaded.result->num_rows() > 0);
+  }
+}
+
+TEST_CASE("filter cascade honors output_indices projection",
+          "[expression_evaluator][filter_cascade]")
+{
+  auto* space = get_default_gpu_space();
+  config_guard guard;
+
+  duckdb::Config::FILTER_CASCADE_MIN_ROWS      = 1;
+  duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 0.75;
+
+  auto input = make_mixed_table(*space, 1000, /*with_nulls=*/true);
+  auto expr  = make_mixed_and(300);
+  std::vector<cudf::size_type> const project_int_only{0};
+
+  auto cascaded = expect_decision_and_baseline_equality(
+    *space, *expr, input->view(), kInterpret, decision::cascaded, project_int_only);
+  REQUIRE(cascaded.result->num_columns() == 1);
+}
+
+TEMPLATE_TEST_CASE("unselective cheap prefilter combines masks without a gather",
+                   "[expression_evaluator][filter_cascade]",
+                   mat_strategy,
+                   ast_interpret_strategy,
+                   ast_jit_strategy)
+{
+  constexpr auto strategy = TestType::value;
+  auto* space             = get_default_gpu_space();
+  config_guard guard;
+
+  duckdb::Config::FILTER_CASCADE_MIN_ROWS      = 1;
+  duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 0.75;
+
+  auto input = make_mixed_table(*space, 1000, /*with_nulls=*/true);
+  // col0 < 990 passes ~99% -> above the 0.75 cap -> combined_masks.
+  auto expr = make_mixed_and(990);
+
+  expect_decision_and_baseline_equality(
+    *space, *expr, input->view(), strategy, decision::combined_masks);
+}
+
+TEMPLATE_TEST_CASE("cheap prefilter that drops every row short-circuits the residual",
+                   "[expression_evaluator][filter_cascade]",
+                   mat_strategy,
+                   ast_interpret_strategy,
+                   ast_jit_strategy)
+{
+  constexpr auto strategy = TestType::value;
+  auto* space             = get_default_gpu_space();
+  config_guard guard;
+
+  duckdb::Config::FILTER_CASCADE_MIN_ROWS      = 1;
+  duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 0.75;
+
+  auto input = make_mixed_table(*space, 1000, /*with_nulls=*/false);
+  auto expr  = make_mixed_and(-1);  // col0 < -1 passes nothing
+
+  auto run = expect_decision_and_baseline_equality(
+    *space, *expr, input->view(), strategy, decision::short_circuited);
+  REQUIRE(run.result->num_rows() == 0);
+  REQUIRE(run.result->num_columns() == 2);
+  REQUIRE(run.result->view().column(1).type().id() == cudf::type_id::STRING);
+}
+
+TEST_CASE("short-circuit under projection synthesizes a typed empty table",
+          "[expression_evaluator][filter_cascade]")
+{
+  auto* space = get_default_gpu_space();
+  config_guard guard;
+
+  duckdb::Config::FILTER_CASCADE_MIN_ROWS      = 1;
+  duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 0.75;
+
+  auto input = make_mixed_table(*space, 1000, /*with_nulls=*/false);
+  auto expr  = make_mixed_and(-1);  // col0 < -1 passes nothing
+  std::vector<cudf::size_type> const project_int_only{0};
+
+  // The one place a projected empty table is synthesized (empty_like of the projection) rather
+  // than gathered.
+  auto run = expect_decision_and_baseline_equality(
+    *space, *expr, input->view(), kInterpret, decision::short_circuited, project_int_only);
+  REQUIRE(run.result->num_rows() == 0);
+  REQUIRE(run.result->num_columns() == 1);
+  REQUIRE(run.result->view().column(0).type().id() == cudf::type_id::INT32);
+}
+
+TEST_CASE("cascade does not engage without a mixed AND or above min rows",
+          "[expression_evaluator][filter_cascade]")
+{
+  auto* space = get_default_gpu_space();
+  config_guard guard;
+
+  duckdb::Config::FILTER_CASCADE_CHEAP_CONJUNCTS = true;
+  duckdb::Config::FILTER_CASCADE_MIN_ROWS        = 1;
+  duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE   = 0.75;
+
+  auto input = make_mixed_table(*space, 1000, /*with_nulls=*/false);
+
+  SECTION("all-cheap conjunction")
+  {
+    std::vector<std::unique_ptr<ast_node>> conjuncts;
+    conjuncts.push_back(make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(300)));
+    conjuncts.push_back(make_cmp(sirius::comparison_type::ge, make_ref(0), make_int_const(10)));
+    auto expr = make_conj(sirius::ast::conjunction::kind::op_and, std::move(conjuncts));
+    auto run  = run_select(*space, *expr, input->view(), kInterpret);
+    REQUIRE(run.taken == decision::not_applicable);
+  }
+
+  SECTION("OR root")
+  {
+    std::vector<std::unique_ptr<ast_node>> disjuncts;
+    disjuncts.push_back(make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(300)));
+    disjuncts.push_back(
+      make_cmp(sirius::comparison_type::equal,
+               make_ref_typed(1, sirius::logical_type::make(sirius::type_id::VARCHAR)),
+               make_str_const("AIR")));
+    auto expr = make_conj(sirius::ast::conjunction::kind::op_or, std::move(disjuncts));
+    auto run  = run_select(*space, *expr, input->view(), kInterpret);
+    REQUIRE(run.taken == decision::not_applicable);
+  }
+
+  SECTION("below min rows")
+  {
+    duckdb::Config::FILTER_CASCADE_MIN_ROWS = 100000;
+    auto expr                               = make_mixed_and(300);
+    auto run                                = run_select(*space, *expr, input->view(), kInterpret);
+    REQUIRE(run.taken == decision::not_applicable);
+  }
+
+  SECTION("disabled by knob")
+  {
+    duckdb::Config::FILTER_CASCADE_CHEAP_CONJUNCTS = false;
+    auto expr                                      = make_mixed_and(300);
+    auto run = run_select(*space, *expr, input->view(), kInterpret);
+    REQUIRE(run.taken == decision::not_applicable);
+  }
+}
+
+TEST_CASE("empty input refuses the cascade without throwing",
+          "[expression_evaluator][filter_cascade]")
+{
+  auto* space = get_default_gpu_space();
+  config_guard guard;
+
+  duckdb::Config::FILTER_CASCADE_CHEAP_CONJUNCTS = true;
+  // A zero-row batch must refuse on the num_rows > 0 guard even when the row floor is 0.
+  duckdb::Config::FILTER_CASCADE_MIN_ROWS      = 0;
+  duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 0.75;
+
+  auto input = make_mixed_table(*space, 0, /*with_nulls=*/false);
+  auto expr  = make_mixed_and(300);
+
+  auto run = run_select(*space, *expr, input->view(), kInterpret);
+  REQUIRE(run.taken == decision::not_applicable);
+  REQUIRE(run.result->num_rows() == 0);
+  REQUIRE(run.result->num_columns() == 2);
+}
+
+TEST_CASE("min rows boundary: equal row count engages, one fewer refuses",
+          "[expression_evaluator][filter_cascade]")
+{
+  auto* space = get_default_gpu_space();
+  config_guard guard;
+
+  duckdb::Config::FILTER_CASCADE_MIN_ROWS      = 1000;
+  duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 0.75;
+
+  auto expr = make_mixed_and(300);
+
+  SECTION("num_rows == min_rows engages")
+  {
+    auto input = make_mixed_table(*space, 1000, /*with_nulls=*/false);
+    expect_decision_and_baseline_equality(
+      *space, *expr, input->view(), kInterpret, decision::cascaded);
+  }
+
+  SECTION("num_rows == min_rows - 1 refuses")
+  {
+    auto input = make_mixed_table(*space, 999, /*with_nulls=*/false);
+    duckdb::Config::FILTER_CASCADE_CHEAP_CONJUNCTS = true;
+    auto run = run_select(*space, *expr, input->view(), kInterpret);
+    REQUIRE(run.taken == decision::not_applicable);
+  }
+}
+
+TEST_CASE("pass rate exactly at the knob gathers; one row above combines masks",
+          "[expression_evaluator][filter_cascade]")
+{
+  auto* space = get_default_gpu_space();
+  config_guard guard;
+
+  duckdb::Config::FILTER_CASCADE_MIN_ROWS      = 1;
+  duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 0.75;
+
+  // No nulls, n = 1000: col0 < bound passes exactly `bound` rows.
+  auto input = make_mixed_table(*space, 1000, /*with_nulls=*/false);
+
+  SECTION("passed = 750 -> rate exactly 0.750 -> cascaded (comparison is inclusive)")
+  {
+    auto expr = make_mixed_and(750);
+    expect_decision_and_baseline_equality(
+      *space, *expr, input->view(), kInterpret, decision::cascaded);
+  }
+
+  SECTION("passed = 751 -> rate 0.751 -> combined_masks")
+  {
+    auto expr = make_mixed_and(751);
+    expect_decision_and_baseline_equality(
+      *space, *expr, input->view(), kInterpret, decision::combined_masks);
+  }
+}
+
+TEST_CASE("all-pass prefilter and the pass-rate knob's degenerate ends",
+          "[expression_evaluator][filter_cascade]")
+{
+  auto* space = get_default_gpu_space();
+  config_guard guard;
+
+  duckdb::Config::FILTER_CASCADE_MIN_ROWS = 1;
+
+  auto input = make_mixed_table(*space, 1000, /*with_nulls=*/false);
+
+  SECTION("100% cheap pass rate under the default cap combines masks")
+  {
+    duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 0.75;
+    auto expr                                    = make_mixed_and(2000);  // passes every row
+    expect_decision_and_baseline_equality(
+      *space, *expr, input->view(), kInterpret, decision::combined_masks);
+  }
+
+  SECTION("max_pass_rate = 1.0 always gathers, even at a 100% pass rate")
+  {
+    duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 1.0;
+    auto expr                                    = make_mixed_and(2000);
+    expect_decision_and_baseline_equality(
+      *space, *expr, input->view(), kInterpret, decision::cascaded);
+  }
+
+  SECTION("max_pass_rate = 0.0 never gathers")
+  {
+    duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 0.0;
+    auto expr                                    = make_mixed_and(300);  // selective: 30%
+    expect_decision_and_baseline_equality(
+      *space, *expr, input->view(), kInterpret, decision::combined_masks);
+  }
+}
+
+TEST_CASE("Kleene partition invariance: the 3VL matrix selects identical rows on every route",
+          "[expression_evaluator][filter_cascade]")
+{
+  auto* space = get_default_gpu_space();
+  config_guard guard;
+
+  duckdb::Config::FILTER_CASCADE_MIN_ROWS = 1;
+
+  // Nine explicit rows covering all of {TRUE, FALSE, NULL}^2 for the (cheap, expensive) pair:
+  // cheap is col0 = 1 and expensive is col1 = 'AIR', so row i encodes the pair
+  // (T,T),(T,F),(T,N),(F,T),(F,F),(F,N),(N,T),(N,F),(N,N). Only the (T,T) row may survive; a
+  // NULL in the cheap group must drop the row before the residual runs (TRUE AND NULL != TRUE)
+  // and a NULL residual must drop a cheap-TRUE row in the residual stage.
+  auto mr     = get_resource_ref(*space);
+  auto stream = cudf::get_default_stream();
+
+  std::vector<int32_t> const ints{1, 1, 1, 0, 0, 0, 0, 0, 0};
+  std::vector<std::string> const strs{"AIR", "XYZ", "", "AIR", "XYZ", "", "AIR", "XYZ", ""};
+  auto int_col =
+    ::sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(ints, stream, mr);
+  auto str_col =
+    ::sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<test_utils::string_tag>>(
+      strs, stream, mr);
+  set_nulls_at(*int_col, {6, 7, 8}, stream, mr);
+  set_nulls_at(*str_col, {2, 5, 8}, stream, mr);
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(int_col));
+  cols.push_back(std::move(str_col));
+  cudf::table input(std::move(cols));
+
+  std::vector<std::unique_ptr<ast_node>> conjuncts;
+  conjuncts.push_back(
+    make_cmp(sirius::comparison_type::equal,
+             make_ref_typed(0, sirius::logical_type::make(sirius::type_id::INTEGER)),
+             make_int_const(1)));
+  conjuncts.push_back(
+    make_cmp(sirius::comparison_type::equal,
+             make_ref_typed(1, sirius::logical_type::make(sirius::type_id::VARCHAR)),
+             make_str_const("AIR")));
+  auto expr = make_conj(sirius::ast::conjunction::kind::op_and, std::move(conjuncts));
+
+  SECTION("cascaded branch")
+  {
+    // The cheap conjunct passes 3 of 9 rows (rate 0.333) -> gathered.
+    duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 0.75;
+    auto run                                     = expect_decision_and_baseline_equality(
+      *space, *expr, input.view(), kInterpret, decision::cascaded);
+    REQUIRE(run.result->num_rows() == 1);
+  }
+
+  SECTION("combined_masks branch")
+  {
+    duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 0.0;
+    auto run                                     = expect_decision_and_baseline_equality(
+      *space, *expr, input.view(), kInterpret, decision::combined_masks);
+    REQUIRE(run.result->num_rows() == 1);
+  }
+}
+
+TEST_CASE("cascade groups multiple cheap and expensive conjuncts",
+          "[expression_evaluator][filter_cascade]")
+{
+  auto* space = get_default_gpu_space();
+  config_guard guard;
+
+  duckdb::Config::FILTER_CASCADE_MIN_ROWS      = 1;
+  duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE = 0.75;
+
+  auto input = make_mixed_table(*space, 1000, /*with_nulls=*/true);
+
+  // AND[col0 >= 100, col0 < 400, col1 IN ('AIR','MAIL'), col1 <> 'SHIP'] —
+  // two cheap conjuncts and two expensive ones, mirroring q19's part-scan shape
+  // (numeric range + two string groups).
+  auto build = [] {
+    auto varchar = sirius::logical_type::make(sirius::type_id::VARCHAR);
+    std::vector<std::unique_ptr<ast_node>> conjuncts;
+    conjuncts.push_back(make_cmp(sirius::comparison_type::ge, make_ref(0), make_int_const(100)));
+    conjuncts.push_back(make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(400)));
+    std::vector<std::unique_ptr<ast_node>> in_values;
+    in_values.push_back(make_str_const("AIR"));
+    in_values.push_back(make_str_const("MAIL"));
+    conjuncts.push_back(make_in(make_ref_typed(1, varchar), std::move(in_values), false));
+    conjuncts.push_back(make_cmp(
+      sirius::comparison_type::not_equal, make_ref_typed(1, varchar), make_str_const("SHIP")));
+    return make_conj(sirius::ast::conjunction::kind::op_and, std::move(conjuncts));
+  };
+
+  auto expr = build();
+  expect_decision_and_baseline_equality(
+    *space, *expr, input->view(), kInterpret, decision::cascaded);
+}
+
+TEST_CASE("out-of-scope survivor gather refuses the cascade",
+          "[expression_evaluator][filter_cascade]")
+{
+  auto* space = get_default_gpu_space();
+  config_guard guard;
+
+  duckdb::Config::FILTER_CASCADE_CHEAP_CONJUNCTS = true;
+  duckdb::Config::FILTER_CASCADE_MIN_ROWS        = 1;
+  duckdb::Config::FILTER_CASCADE_MAX_PASS_RATE   = 0.75;
+
+  // col2 ("payload-<i>" strings) is neither projected nor referenced by the residual: the
+  // cascaded gather would materialize it pointlessly, and a cascade that may never gather can
+  // only lose to the monolithic kernel, so the guard refuses outright (not combined_masks) even
+  // though the prefilter is selective (30% << 0.75).
+  auto input = make_mixed_table(*space, 1000, /*with_nulls=*/true, extra_column::string_payload);
+  auto expr  = make_mixed_and(300);
+
+  SECTION("projection excludes an unreferenced column -> not_applicable")
+  {
+    std::vector<cudf::size_type> const project_first_two{0, 1};
+    auto refused = expect_decision_and_baseline_equality(
+      *space, *expr, input->view(), kInterpret, decision::not_applicable, project_first_two);
+    REQUIRE(refused.result->num_columns() == 2);
+  }
+
+  SECTION("projection covers every column -> gather stays in scope")
+  {
+    std::vector<cudf::size_type> const project_all{0, 1, 2};
+    expect_decision_and_baseline_equality(
+      *space, *expr, input->view(), kInterpret, decision::cascaded, project_all);
+  }
+
+  SECTION("all-columns select overload is always in scope")
+  {
+    expect_decision_and_baseline_equality(
+      *space, *expr, input->view(), kInterpret, decision::cascaded);
+  }
+
+  SECTION("a column referenced only by the cheap group does not extend the scope")
+  {
+    // col2 is INT32 here and referenced by a cheap conjunct, but it is dead after the prefilter
+    // (neither projected nor residual-referenced), so gathering it would be waste: the needed
+    // set is output_indices union referenced(residual) — deliberately excluding cheap
+    // references — and the guard must refuse.
+    auto cheap_ref_input =
+      make_mixed_table(*space, 1000, /*with_nulls=*/true, extra_column::int_payload);
+    std::vector<std::unique_ptr<ast_node>> conjuncts;
+    conjuncts.push_back(
+      make_cmp(sirius::comparison_type::lt,
+               make_ref_typed(0, sirius::logical_type::make(sirius::type_id::INTEGER)),
+               make_int_const(300)));
+    conjuncts.push_back(
+      make_cmp(sirius::comparison_type::ge,
+               make_ref_typed(2, sirius::logical_type::make(sirius::type_id::INTEGER)),
+               make_int_const(0)));
+    conjuncts.push_back(
+      make_cmp(sirius::comparison_type::equal,
+               make_ref_typed(1, sirius::logical_type::make(sirius::type_id::VARCHAR)),
+               make_str_const("AIR")));
+    auto cheap_ref_expr = make_conj(sirius::ast::conjunction::kind::op_and, std::move(conjuncts));
+
+    std::vector<cudf::size_type> const project_first_two{0, 1};
+    expect_decision_and_baseline_equality(*space,
+                                          *cheap_ref_expr,
+                                          cheap_ref_input->view(),
+                                          kInterpret,
+                                          decision::not_applicable,
+                                          project_first_two);
+  }
+}
+
+TEST_CASE("classifier arms: cheap means an elementwise fixed-width-carried subtree",
+          "[expression_evaluator][filter_cascade]")
+{
+  auto* space = get_default_gpu_space();
+  auto mr     = get_resource_ref(*space);
+  auto stream = cudf::get_default_stream();
+
+  // Column carriers are all that matters to the classifier: col0 INT32, col1 STRING,
+  // col2 BOOL8 (the carrier a decode-time predicate substitution leaves behind).
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT32}, 4, cudf::mask_state::UNALLOCATED, stream, mr));
+  cols.push_back(
+    ::sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<test_utils::string_tag>>(
+      {"a", "b", "c", "d"}, stream, mr));
+  cols.push_back(cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::BOOL8}, 4, cudf::mask_state::UNALLOCATED, stream, mr));
+  cudf::table table(std::move(cols));
+  auto const input = table.view();
+
+  auto integer = sirius::logical_type::make(sirius::type_id::INTEGER);
+  auto varchar = sirius::logical_type::make(sirius::type_id::VARCHAR);
+
+  auto is_cheap = [&](std::unique_ptr<ast_node> const& n) {
+    return sirius::detail::is_cheap_prefilter_conjunct(*n, input);
+  };
+
+  SECTION("references classify by runtime carrier and bounds")
+  {
+    CHECK(is_cheap(make_ref(0)));    // INT32 carrier
+    CHECK(!is_cheap(make_ref(1)));   // STRING carrier
+    CHECK(is_cheap(make_ref(2)));    // BOOL8 carrier — the tier-2 composition guarantee
+    CHECK(!is_cheap(make_ref(99)));  // out-of-bounds column index
+  }
+
+  SECTION("constants classify by payload type")
+  {
+    CHECK(is_cheap(make_int_const(5)));
+    CHECK(!is_cheap(make_str_const("x")));
+  }
+
+  SECTION("elementwise interior nodes are cheap over cheap operands")
+  {
+    CHECK(is_cheap(make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(5))));
+    CHECK(!is_cheap(
+      make_cmp(sirius::comparison_type::equal, make_ref_typed(1, varchar), make_str_const("A"))));
+
+    CHECK(is_cheap(make_between(make_ref(0), make_int_const(1), make_int_const(5), true, true)));
+
+    std::vector<std::unique_ptr<ast_node>> int_values;
+    int_values.push_back(make_int_const(1));
+    int_values.push_back(make_int_const(2));
+    CHECK(is_cheap(make_in(make_ref(0), std::move(int_values), false)));
+
+    std::vector<std::unique_ptr<ast_node>> str_values;
+    str_values.push_back(make_str_const("A"));
+    CHECK(!is_cheap(make_in(make_ref_typed(1, varchar), std::move(str_values), false)));
+  }
+
+  SECTION("nested conjunctions are cheap iff every child is")
+  {
+    auto cheap_or = [&] {
+      std::vector<std::unique_ptr<ast_node>> children;
+      children.push_back(make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(5)));
+      children.push_back(make_cmp(sirius::comparison_type::ge, make_ref(0), make_int_const(7)));
+      return make_conj(sirius::ast::conjunction::kind::op_or, std::move(children));
+    };
+    CHECK(is_cheap(cheap_or()));
+
+    std::vector<std::unique_ptr<ast_node>> and_children;
+    and_children.push_back(make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(5)));
+    and_children.push_back(
+      make_between(make_ref(0), make_int_const(1), make_int_const(3), true, true));
+    CHECK(is_cheap(make_conj(sirius::ast::conjunction::kind::op_and, std::move(and_children))));
+
+    std::vector<std::unique_ptr<ast_node>> mixed_children;
+    mixed_children.push_back(make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(5)));
+    mixed_children.push_back(
+      make_cmp(sirius::comparison_type::equal, make_ref_typed(1, varchar), make_str_const("A")));
+    CHECK(!is_cheap(make_conj(sirius::ast::conjunction::kind::op_or, std::move(mixed_children))));
+  }
+
+  SECTION("unary operators: NOT / IS NULL / IS NOT NULL only, over cheap children")
+  {
+    CHECK(
+      is_cheap(make_unary(sirius::ast::unary_op::kind::op_not,
+                          make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(5)))));
+    CHECK(is_cheap(make_unary(sirius::ast::unary_op::kind::op_is_null, make_ref(0))));
+    CHECK(is_cheap(make_unary(sirius::ast::unary_op::kind::op_is_not_null, make_ref(0))));
+    CHECK(!is_cheap(make_unary(sirius::ast::unary_op::kind::op_is_null, make_ref(1))));
+    CHECK(!is_cheap(make_unary(
+      sirius::ast::unary_op::kind::op_not,
+      make_cmp(sirius::comparison_type::equal, make_ref_typed(1, varchar), make_str_const("A")))));
+    // Any other unary kind is expensive regardless of its child.
+    CHECK(
+      !is_cheap(make_unary(sirius::ast::unary_op::kind::op_try,
+                           make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(5)))));
+  }
+
+  SECTION("AST breakers are unconditionally expensive")
+  {
+    // A fixed-width cast is elementwise-cheap in principle; classifying it expensive is the
+    // documented conservatism (widen only with measured evidence).
+    CHECK(!is_cheap(make_cast(make_ref_typed(0, integer),
+                              sirius::logical_type::make(sirius::type_id::BIGINT),
+                              /*try_cast=*/false)));
+  }
+}

--- a/test/cpp/expression_evaluator/test_filter_cascade.cpp
+++ b/test/cpp/expression_evaluator/test_filter_cascade.cpp
@@ -291,6 +291,10 @@ constexpr auto kInterpret = ::sirius::expression_evaluator_strategy::AST_INTERPR
 
 }  // namespace
 
+// ---------------------------------------------------------------------------
+// Decision branches: each cascade route vs the monolithic baseline
+// ---------------------------------------------------------------------------
+
 TEMPLATE_TEST_CASE("filter cascade selects the same rows as the monolithic path",
                    "[expression_evaluator][filter_cascade]",
                    mat_strategy,
@@ -398,6 +402,10 @@ TEST_CASE("short-circuit under projection synthesizes a typed empty table",
   REQUIRE(run.result->num_columns() == 1);
   REQUIRE(run.result->view().column(0).type().id() == cudf::type_id::INT32);
 }
+
+// ---------------------------------------------------------------------------
+// Refusal guards and knob boundaries (min rows, pass rate, degenerate ends)
+// ---------------------------------------------------------------------------
 
 TEST_CASE("cascade does not engage without a mixed AND or above min rows",
           "[expression_evaluator][filter_cascade]")
@@ -560,6 +568,10 @@ TEST_CASE("all-pass prefilter and the pass-rate knob's degenerate ends",
   }
 }
 
+// ---------------------------------------------------------------------------
+// Correctness: the Kleene 3VL matrix and multi-conjunct grouping
+// ---------------------------------------------------------------------------
+
 TEST_CASE("Kleene partition invariance: the 3VL matrix selects identical rows on every route",
           "[expression_evaluator][filter_cascade]")
 {
@@ -653,6 +665,10 @@ TEST_CASE("cascade groups multiple cheap and expensive conjuncts",
     *space, *expr, input->view(), kInterpret, decision::cascaded);
 }
 
+// ---------------------------------------------------------------------------
+// Gather-scope refusal: needed set = output_indices union referenced(residual)
+// ---------------------------------------------------------------------------
+
 TEST_CASE("out-of-scope survivor gather refuses the cascade",
           "[expression_evaluator][filter_cascade]")
 {
@@ -723,6 +739,10 @@ TEST_CASE("out-of-scope survivor gather refuses the cascade",
                                           project_first_two);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Classifier arms (sirius::detail::is_cheap_prefilter_conjunct)
+// ---------------------------------------------------------------------------
 
 TEST_CASE("classifier arms: cheap means an elementwise fixed-width-carried subtree",
           "[expression_evaluator][filter_cascade]")


### PR DESCRIPTION
<!-- Edit PR title: "<type>[optional scope]: <short description>", see CONTRIBUTING.md for guidance -->

## Description

`expression_evaluator::select()` evaluates a filter's whole conjunction in one pass — for q19's
part-table predicate that is a single 116-register JIT kernel (string OR-groups + an integer
range union) at 25% occupancy, evaluating every conjunct for all 200 M rows.

This PR adds a **filter cascade**: a top-level AND is split into structurally *cheap* conjuncts
(subtrees that are entirely elementwise fixed-width work — comparisons, BETWEEN, integer
IN-lists, NOT; anything else, strings included, is expensive **by default**) and the rest. The
cheap mask runs first; when its pass rate is ≤ `filter_cascade_max_pass_rate`, survivors are
gathered and the expensive conjuncts run on them alone; otherwise the masks are Kleene-ANDed
without a gather (never slower than baseline by more than the cheap pass). Out-of-scope gathers
(columns outside residual-referenced ∪ projected) refuse the cascade outright — no new peak-
memory point. Three-valued (NULL) semantics are preserved by construction and pinned by a 3VL
matrix test.

Cascade logic lives in its own TU (`filter_cascade.cpp` + `filter_cascade_internal.hpp`, per
the `specializations/` precedent) with the classifier directly unit-testable.

## Knobs

| knob | default | semantics |
|---|---|---|
| `filter_cascade_cheap_conjuncts` | `true` | master switch; `false` is operation-identical to pre-change code |
| `filter_cascade_min_rows` | 1048576 | engagement floor (launch-latency amortization) |
| `filter_cascade_max_pass_rate` | 0.75, validated [0,1] | gather-vs-AND break-even (~55 ps/surviving row gather vs ~180 ps/dropped row avoided JIT; s* ≈ 0.77, rounded down — not tuned to q19, whose rate is 0.300) |

## TPC-H SF1000 results (GB300, PR #1371 measurement-kit regime)

q19 is the only query where the cascade engages (measured pass rate 0.300, matching the
analyst estimate; zero activation on the other 21 queries).

- **ABBA 3v3** (A,B,B,A,A,B; full 22-query suite; best-of-3 hot): q19 **357.8 → 347.7 ms
  (−10.1 ms, −2.8%)**, above its 1.9% between-run floor on means; individual pairs
  +0.2/−9.0/−21.7 — q19's documented between-run swing makes single pairs noisy, means don't.
- **Same-build knob isolation** (adjacent runs, only the SET toggled): **350.1 → 327.5 ms
  (−22.6 ms, −6.5%)** — the confounder-free signal.
- Suite neutrality: FoM subset +22.9 ms, inside the ±24 ms floor; no other query beyond its
  floor; GPU pool peak ≤ baseline; JIT kernel cache entry count unchanged (no recompile thrash).
- Correctness: **22/22 byte-identical in every arm and run** (six campaign queries also match
  the SF1000 DuckDB-CPU oracle references); zero fallback markers; activation INFO in q19 only.
- Context for reviewers: a 2×2 evidence matrix (jit/interpret × cascade on/off, all
  byte-identical) confirms the known q19×ast_jit anomaly is real and unresolved by this PR —
  the cascade helps both strategies (−17/−18 ms), while a ~30 ms jit-vs-interpret gap persists
  (candidate future work: per-expression strategy selection).

## Honest caveats

- The pending #1474 (decompression pushdown) will pre-filter rows before this code sees them,
  which shrinks this PR's headline on q19; the mechanism remains valuable for filter shapes
  that survive pushdown (post-scan FILTER operators, non-pushdown-able conjuncts).
- Unit coverage: `[filter_cascade]` 20 cases / 321 assertions incl. classifier arms, boundary
  behavior at `max_pass_rate` (inclusive), Kleene 3VL matrix, empty/all-pass, and knobs-off
  identity. Full-suite failures on the shared measurement box were adjudicated 1:1 as
  pre-existing/environmental (base build reproduces the identical failure set).

## Checklist
- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (docs/super-sirius/configuration.md + expression-executor.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
