### PR TITLE
perf(planner): fuse twin same-table scans behind a shared dynamic filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,7 @@ set(EXTENSION_SOURCES
     src/op/sirius_physical_sort_sample.cpp
     src/op/sirius_physical_table_scan.cpp
     src/op/sirius_physical_top_n.cpp
+    src/op/sirius_physical_twin_scan_split.cpp
     src/op/sirius_physical_ungrouped_aggregate.cpp
     src/parallel/task_executor.cpp
     src/pipeline/gpu_pipeline_executor.cpp
@@ -383,6 +384,7 @@ set(EXTENSION_SOURCES
     src/planner/sirius_plan_projection_utils.cpp
     src/planner/sirius_plan_recursive_cte.cpp
     src/planner/sirius_plan_top_n.cpp
+    src/planner/sirius_plan_twin_scan_fusion.cpp
     src/pin_table.cpp
     src/scan_manager/load_balancing_scan_batch_coalescer.cpp
     src/scan_manager/insert_delta_job.cpp
@@ -751,6 +753,7 @@ set(TEST_SOURCES
     test/cpp/planner/test_join_expression_key.cpp
     test/cpp/planner/test_plan_tree_shape.cpp
     test/cpp/planner/test_projection_fold.cpp
+    test/cpp/planner/test_twin_scan_fusion.cpp
     test/cpp/planner/test_sirius_read_parquet_scan.cpp
     test/cpp/planner/test_query_id.cpp
     test/cpp/planner/test_query_index.cpp

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -558,6 +558,7 @@ SET enable_compressed_materialization = false;
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `fuse_merge_pipelines` | true | Fuse eligible GROUP BY / TOP_N merges into their downstream pipeline instead of cutting a boundary (see [physical-plan-generation.md](physical-plan-generation.md) → Merge fusion) |
+| `fuse_twin_scans` | true | Fuse near-duplicate same-table probe scans into one fan-out twin-scan pipeline: one shared decode + membership probe feeds both consumers, at the price of ~+1%-class extra rows into the narrower consumer's authoritative join and one extra device gather for the first output (see [physical-plan-generation.md](physical-plan-generation.md) → Twin-scan fusion) |
 | `max_sort_partition_bytes` | 0 (auto) | Max sort partition bytes |
 | `max_sort_partition_memory_fraction` | 0.33 | Auto sort-partition fraction when `max_sort_partition_bytes` is 0 |
 | `hash_partition_bytes` | Shared physical/effective GPU batch default | Hash partition target size; must be greater than zero |

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -558,7 +558,7 @@ SET enable_compressed_materialization = false;
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `fuse_merge_pipelines` | true | Fuse eligible GROUP BY / TOP_N merges into their downstream pipeline instead of cutting a boundary (see [physical-plan-generation.md](physical-plan-generation.md) → Merge fusion) |
-| `fuse_twin_scans` | true | Fuse near-duplicate same-table probe scans into one fan-out twin-scan pipeline: one shared decode + membership probe feeds both consumers, at the price of ~+1%-class extra rows into the narrower consumer's authoritative join and one extra device gather for the first output (see [physical-plan-generation.md](physical-plan-generation.md) → Twin-scan fusion) |
+| `fuse_twin_scans` | true | Fuse near-duplicate same-table probe scans into one fan-out twin-scan pipeline: one shared decode + Bloom probe feeds both consumers, at the price of extra rows (measured +1.1% on TPC-H q21) into the narrower consumer's authoritative join and one extra device gather for the first output (see [physical-plan-generation.md](physical-plan-generation.md) → Twin-scan fusion) |
 | `max_sort_partition_bytes` | 0 (auto) | Max sort partition bytes |
 | `max_sort_partition_memory_fraction` | 0.33 | Auto sort-partition fraction when `max_sort_partition_bytes` is 0 |
 | `hash_partition_bytes` | Shared physical/effective GPU batch default | Hash partition target size; must be greater than zero |

--- a/docs/super-sirius/dynamic-filters.md
+++ b/docs/super-sirius/dynamic-filters.md
@@ -111,6 +111,8 @@ Properties:
 
 Consumer access is via `filters_for_column(col_idx)` and `filtered_columns()`. The free helper `merge_ast_dynamic_filters_into_tree(tree, existing_root, set, resolver)` walks the channel, lowers every AST-capable filter, AND-conjoins the per-column and cross-column fragments, and returns `AND(existing_root, dynamic_root)` — or `existing_root` unchanged if no filter contributed.
 
+One plan-time writer can rewire channels after construction: the twin-scan fusion pass (`sirius_plan_twin_scan_fusion.cpp`) may re-point a scan to a sibling scan's channel (after structurally proving the sibling's key set subsumes its own) and `close_for_new_filters()` the orphaned channel — the orphan's producer join then skips filter construction entirely. Channel-lifecycle readers must account for this writer: a channel created with a consumer can enter execution closed and consumerless.
+
 ### Filter router — plan-gen channel map (routing axis)
 
 *Introduced in Phase 1.1.* During plan construction, multiple operators must find each other and agree on a shared channel. The router lives on `sirius_physical_plan_generator` and maps a *route key* to a channel:

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -338,6 +338,16 @@ Merges ungrouped aggregate results from multiple partitions.
 
 Merges local top-N results from multiple partitions.
 
+### `sirius_physical_twin_scan_split` — `TWIN_SCAN_SPLIT`
+**File:** `src/include/op/sirius_physical_twin_scan_split.hpp`
+
+Fan-out sink of a fused twin-scan pipeline (`GPU_SCAN → DYNAMIC_FILTER → TWIN_SCAN_SPLIT`), installed by the twin-scan fusion pass. Per input batch, `execute()` materializes out-A (the first scan's column projection, a fresh owned gather that never aliases the input) and out-B (the second scan's residual filter through an `expression_evaluator`, plus its output projection); `sink()` routes out-A to the tree parent's pipeline and out-B to the `TWIN_SCAN_REF`'s consumer pipeline over the converter's two PARTIAL-barrier edges, throwing on any edge-count mismatch. The declared `types` describe out-A only (`declared_output_schema_is_runtime_schema()` is false because the two halves carry different schemas), and `on_finalize_operator()` logs cumulative `rows_in` / `out_a` / `out_b` for validation against an unfused run.
+
+### `sirius_physical_twin_scan_ref` — `TWIN_SCAN_REF`
+**File:** `src/include/op/sirius_physical_twin_scan_split.hpp`
+
+Routing-only anchor occupying the tree slot of the fused-away second scan so its downstream feeder chain is planned unchanged. Like `DELIM_SCAN` it never lands in any pipeline's `operators[]`: `build_pipelines` appends nothing, and the converter wires the owning `TWIN_SCAN_SPLIT`'s second output edge to this node's tree parent.
+
 ## CTE / Delim Join Operators
 
 ### `sirius_physical_cte` — `CTE`
@@ -403,6 +413,8 @@ After pipeline finalization, `source` and `sink` are just aliases for the first 
 | PARTITION | Pipeline | Hash/range partitioning |
 | CONCAT | Pipeline | Partition reassembly |
 | MERGE_TOP_N | Pipeline | Merge per-partition top-N |
+| TWIN_SCAN_SPLIT | Pipeline | Fan-out sink of a fused twin-scan pipeline: residual filter (out-B) + column gather (out-A) |
+| TWIN_SCAN_REF | Pipeline | Routing-only anchor for the twin split's second consumer (never in `operators[]`) |
 | CTE | CTE | Materialize to ColumnDataCollection |
 | RESULT_COLLECTOR | Result | Final result materialization |
 | EMPTY_RESULT | Result | Empty result set |

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -66,6 +66,20 @@ num_partitions = max(1, ceil(total_bytes / hash_partition_bytes))
 
 **Config:** `fuse_merge_pipelines` (default: true). See [physical-plan-generation.md](physical-plan-generation.md) → Merge fusion for pipeline-shape details.
 
+### Twin-Scan Fusion (PR #NNN)
+
+**Motivation:** DuckDB's delim decomposition of chained `EXISTS` / `NOT EXISTS` (TPC-H q21) leaves two near-duplicate full scans of the same table: nested column sets, one residual predicate, and dynamic membership filters (Blooms) over provably nested key sets. At SF1000 each scan decodes ~6.0B rows and probes a ~70M-key Bloom — near-identical work done twice.
+
+**Mechanism:** A planner pass (`fuse_twin_scans`) runs before `insert_gpu_pipeline_operators`, decomposed into match → prove → rewrite. *Match* checks the pair is mechanically well-formed: same table, the bare scan's columns / output layout / types / physical carriers a strict prefix of the filtered scan's (so no filter-index remapping is ever needed), identical static pushed filters. *Prove* checks that dropping the filtered scan's dynamic-filter channel is safe: B's delim join must directly consume A's delim join and A's join-back must be `RIGHT_SEMI`/`RIGHT_ANTI` — the only join types emitting a row-subset of A's delim input with schema preserved — so with identical distinct group references the delim key sets nest as tuple sets, and both producer joins keying on the same single delim column projects that containment onto the published membership filters. *Rewrite* fuses the pair into one `GPU_SCAN → DYNAMIC_FILTER → TWIN_SCAN_SPLIT` pipeline whose fan-out sink feeds both original consumers; a routing-only `TWIN_SCAN_REF` anchors the second consumer (DELIM_SCAN pattern). Every refused same-table pair is recorded with a typed `twin_scan_rejection_reason` in the generator's `twin_scan_report()`.
+
+**Code path:**
+- `src/planner/sirius_plan_twin_scan_fusion.cpp` (+ header) — the pass: collect / match / prove / rewrite, rejection taxonomy
+- `src/op/sirius_physical_twin_scan_split.cpp` — `TWIN_SCAN_SPLIT` / `TWIN_SCAN_REF` operators
+- `src/pipeline/sirius_pipeline_converter.cpp` — the two-consumer repository wiring
+- `src/planner/sirius_physical_plan_generator.cpp` — invokes the pass under the setting; stores the report
+
+**Config:** `fuse_twin_scans` (default: true; `SET` + `sirius.operator_params.fuse_twin_scans` in YAML). Measured on TPC-H SF1000 (kit regime): q21 802 → ~741-748 ms; the priced costs are ~+1% extra rows into the narrower consumer's authoritative join and one extra 2-column device gather for the first output. See [physical-plan-generation.md](physical-plan-generation.md) → Twin-scan fusion.
+
 ## Operator-Level Optimizations
 
 ### Adaptive Join BUILD_PROBE Mode (PR #423)

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -66,7 +66,7 @@ num_partitions = max(1, ceil(total_bytes / hash_partition_bytes))
 
 **Config:** `fuse_merge_pipelines` (default: true). See [physical-plan-generation.md](physical-plan-generation.md) → Merge fusion for pipeline-shape details.
 
-### Twin-Scan Fusion (PR #NNN)
+### Twin-Scan Fusion (unreleased)
 
 **Motivation:** DuckDB's delim decomposition of chained `EXISTS` / `NOT EXISTS` (TPC-H q21) leaves two near-duplicate full scans of the same table: nested column sets, one residual predicate, and dynamic membership filters (Blooms) over provably nested key sets. At SF1000 each scan decodes ~6.0B rows and probes a ~70M-key Bloom — near-identical work done twice.
 

--- a/docs/super-sirius/physical-plan-generation.md
+++ b/docs/super-sirius/physical-plan-generation.md
@@ -351,6 +351,27 @@ Eligibility is decided at plan time by `mark_fusable_merge_pipelines` (`sirius_p
 
 Total-input structural sinks such as `ORDER_BY`, `TOP_N`, and an outer `GROUP BY` **are** fusable: they already buffer their full input, so folding the merge in does not change when they observe complete data.
 
+### Twin-scan fusion
+
+By default (`fuse_twin_scans = true`) `create_plan` runs `sirius::planner::fuse_twin_scans` (`sirius_plan_twin_scan_fusion.cpp`) after `plan->verify()` and **before** `insert_gpu_pipeline_operators` — the candidate scans must still be `TABLE_SCAN` nodes carrying their `sirius_dynamic_filters` channels, and no pass runs between fusion and pipeline-operator insertion (the split holds a non-owning pointer to its `TWIN_SCAN_REF`, so the pair must reach the converter intact). When a bare probe-side scan and a residual-filtered probe-side scan of the same table pass the pass's match and subsumption checks, the pair is fused into one scan pipeline:
+
+```mermaid
+graph LR
+    F["Fused pipeline<br/>[GPU_SCAN(union columns), DYNAMIC_FILTER(shared channel), TWIN_SCAN_SPLIT]"] -->|"PARTIAL"| A["out-A consumer<br/>[PARTITION ...]"]
+    F -->|"PARTIAL"| B["out-B consumer<br/>[PARTITION ...]"]
+```
+
+The second consumer's tree slot holds the routing-only `TWIN_SCAN_REF`, which (like `DELIM_SCAN`) never lands in any pipeline's `operators[]` and appends nothing in `build_pipelines`; the converter's `compute_repository_wiring` emits the split's two PARTIAL-barrier edges by resolving the split's tree parent (out-A) and the ref's tree parent (out-B). The second consumer's feeder chain (PARTITION/CONCAT wraps, column bindings) is therefore planned completely unchanged.
+
+Two-consumer scheduling is settled, for these reasons:
+
+1. **Acyclicity.** The fused pipeline depends only on A's channel producers — exactly what A's scan depended on at baseline. Both consumers depend on the fused pipeline through buffered repository edges; their other dependencies (delim build partitions) are unchanged from baseline. Fusion strictly removes one dependency (B's scan on B's channel producer) and adds none, so the baseline-acyclic graph stays acyclic.
+2. **Bounded buffering.** The B-side probe PARTITION is a non-driver sibling that waits for its delim build partition to size it; out-B batches buffer in its repository meanwhile. Those batches existed at baseline too (B's own scan produced them) — they are merely held longer (~3.9 GB at SF1000, measured under the suite's pool peak; suite-wide peak delta +1.0 MB). No input-scaled new allocation.
+3. **PARTIAL barriers** on both edges are the engine's standard multi-consumer repository semantics; the split's `sink()` fails loudly on any edge-count mismatch, so wiring drift cannot silently mis-route.
+4. Empirically: GPU runs deadlock-free with one fewer pipeline than baseline; B's consumer starting earlier than baseline exercised no ordering assumption on the NOT-EXISTS side.
+
+See [optimizations.md](optimizations.md) → Twin-Scan Fusion for the match/prove conditions and the measured win, and [operators.md](operators.md) for the two operator contracts.
+
 ### DELIM_JOIN
 
 Decorrelated correlated-subquery join. Both variants hold two internal operators:

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -349,6 +349,13 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   /// so the one-shot publisher sees the whole key set.
   [[nodiscard]] bool publishes_dynamic_filters() const;
 
+  /// The immutable dynamic-filter publish plan (empty when this join publishes nothing).
+  /// Read by the twin-scan fusion pass to identify the producer join of a scan's channel.
+  [[nodiscard]] const dynamic_filter_publish_plan& dynamic_filter_plan() const noexcept
+  {
+    return _dynamic_filter_plan;
+  }
+
   /// The per-GPU hash-table byte budget (also the upstream PARTITION's bound on folding a build
   /// whole for dynamic-filter publication).
   [[nodiscard]] uint64_t max_build_hash_table_bytes() const noexcept

--- a/src/include/op/sirius_physical_operator_type.hpp
+++ b/src/include/op/sirius_physical_operator_type.hpp
@@ -148,7 +148,9 @@ enum class SiriusPhysicalOperatorType : uint8_t {
   GPU_VALUES,
   GPU_SCAN,
   DYNAMIC_FILTER,
-  STREAMING_SOURCE
+  STREAMING_SOURCE,
+  TWIN_SCAN_SPLIT,
+  TWIN_SCAN_REF
 };
 
 std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type);

--- a/src/include/op/sirius_physical_twin_scan_split.hpp
+++ b/src/include/op/sirius_physical_twin_scan_split.hpp
@@ -84,6 +84,8 @@ class sirius_physical_twin_scan_split : public sirius_physical_operator {
   static constexpr const SiriusPhysicalOperatorType TYPE =
     SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT;
 
+  //! @throw internal_exception if @p residual or @p twin_ref is null or @p output_indices_a is
+  //! empty -- the fusion pass only ever constructs a split with all three populated.
   sirius_physical_twin_scan_split(duckdb::vector<sirius::logical_type> types_a,
                                   std::vector<cudf::size_type> output_indices_a,
                                   std::unique_ptr<sirius::ast::node> residual,
@@ -108,6 +110,8 @@ class sirius_physical_twin_scan_split : public sirius_physical_operator {
   //! Route the two halves of the twin output to their consumer pipelines.
   void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
 
+  //! The routing-only anchor of the second output's consumer (non-owning; see `_twin_ref`).
+  //! Read by the pipeline converter to resolve the out-B consumer pipeline.
   [[nodiscard]] sirius_physical_twin_scan_ref* twin_ref() const noexcept { return _twin_ref; }
 
  protected:

--- a/src/include/op/sirius_physical_twin_scan_split.hpp
+++ b/src/include/op/sirius_physical_twin_scan_split.hpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "expression/ast/node.hpp"
+#include "op/sirius_physical_filter.hpp"  // output_mask / passthrough
+#include "op/sirius_physical_operator.hpp"
+
+#include <cudf/types.hpp>
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+namespace sirius {
+namespace op {
+
+/**
+ * @brief Routing-only anchor for the second output of a fused twin scan.
+ *
+ * Occupies the tree slot of the rewritten-away second scan (+ residual FILTER) so the
+ * downstream feeder chain (PARTITION/CONCAT wraps, column bindings) is planned unchanged.
+ * Like DELIM_SCAN it never lands in any pipeline's operators[]: the converter wires the
+ * TWIN_SCAN_SPLIT's second output edge to this node's tree parent's pipeline, and
+ * `build_pipelines` appends nothing.
+ */
+class sirius_physical_twin_scan_ref : public sirius_physical_operator {
+ public:
+  static constexpr const SiriusPhysicalOperatorType TYPE =
+    SiriusPhysicalOperatorType::TWIN_SCAN_REF;
+
+  sirius_physical_twin_scan_ref(duckdb::vector<sirius::logical_type> types,
+                                std::size_t estimated_cardinality)
+    : sirius_physical_operator(
+        SiriusPhysicalOperatorType::TWIN_SCAN_REF, std::move(types), estimated_cardinality)
+  {
+  }
+
+  //! Routing-only: the consumer pipeline's input arrives through the wiring emitted for the
+  //! owning TWIN_SCAN_SPLIT, so this node must not open a pipeline of its own.
+  void build_pipelines(pipeline::sirius_pipeline& current,
+                       pipeline::sirius_meta_pipeline& meta_pipeline) override
+  {
+  }
+};
+
+/**
+ * @brief Fan-out sink of a fused "twin scan" pipeline: one decoded + dynamically-filtered
+ *        stream, two outputs.
+ *
+ * Pipeline shape: [GPU_SCAN(union columns), DYNAMIC_FILTER(shared channel), TWIN_SCAN_SPLIT].
+ * Per input batch, execute() materializes
+ *   - out-A: the first-scan projection (`output_indices_a` into the fused layout), a FRESH
+ *     owned cudf::table gathered on the task stream from the current device resource and
+ *     wrapped via `make_data_batch` into the input batch's memory space;
+ *   - out-B: the second scan's residual filter (`residual` evaluated through an
+ *     `expression_evaluator`, mirroring `sirius_physical_filter`) with the original FILTER's
+ *     output projection (`output_columns_b`).
+ * After execute() returns, neither half aliases the input batch, so the input may be freed or
+ * spilled independently -- the generic streaming-operator memory discipline that lets the
+ * downgrade executor treat this operator like any other with no type-specific handling.
+ * sink() then routes out-A to the tree parent's pipeline and out-B to the twin ref's
+ * consumer pipeline (both edges are emitted by the pipeline converter).
+ *
+ * `types` (and the physical sidecar) describe out-A — the schema the tree parent's feeder
+ * chain was planned against. Out-B's schema is `types_b`, mirrored on the twin ref node.
+ */
+class sirius_physical_twin_scan_split : public sirius_physical_operator {
+ public:
+  static constexpr const SiriusPhysicalOperatorType TYPE =
+    SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT;
+
+  sirius_physical_twin_scan_split(duckdb::vector<sirius::logical_type> types_a,
+                                  std::vector<cudf::size_type> output_indices_a,
+                                  std::unique_ptr<sirius::ast::node> residual,
+                                  output_mask output_columns_b,
+                                  duckdb::vector<sirius::logical_type> types_b,
+                                  std::size_t estimated_cardinality,
+                                  sirius_physical_twin_scan_ref* twin_ref);
+
+  std::string params_to_string() const override;
+
+  //! execute() emits a twin_split_output_data whose two halves carry different schemas
+  //! (out-A == `types`, out-B == `types_b`), so the task-level schema diagnostic must not
+  //! compare them against the declared output.
+  [[nodiscard]] bool declared_output_schema_is_runtime_schema() const noexcept override
+  {
+    return false;
+  }
+
+  std::unique_ptr<operator_data> execute(const operator_data& input_data,
+                                         rmm::cuda_stream_view stream) override;
+
+  //! Route the two halves of the twin output to their consumer pipelines.
+  void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+
+  [[nodiscard]] sirius_physical_twin_scan_ref* twin_ref() const noexcept { return _twin_ref; }
+
+ protected:
+  //! Log the shared-stream / out-A / out-B row counts for validation against an unfused run.
+  void on_finalize_operator() override;
+
+ private:
+  //! Positions of the first scan's output columns within the fused scan's output layout.
+  std::vector<cudf::size_type> _output_indices_a;
+  //! The second scan's residual filter predicate, bound to the fused scan's output layout.
+  std::unique_ptr<sirius::ast::node> _residual;
+  //! The residual FILTER's output projection (see sirius_physical_filter::output_columns).
+  output_mask _output_columns_b;
+  //! Out-B's schema (the rewritten-away FILTER's output schema).
+  duckdb::vector<sirius::logical_type> _types_b;
+  //! Anchor of the second output's consumer pipeline; its tree parent identifies the B edge
+  //! among `next_port_after_sink` at runtime.
+  sirius_physical_twin_scan_ref* _twin_ref;
+
+  //! Cumulative row counts for the fused stream and both outputs (validation telemetry).
+  std::atomic<std::size_t> _rows_in{0};
+  std::atomic<std::size_t> _rows_a{0};
+  std::atomic<std::size_t> _rows_b{0};
+};
+
+}  // namespace op
+}  // namespace sirius

--- a/src/include/planner/sirius_physical_plan_generator.hpp
+++ b/src/include/planner/sirius_physical_plan_generator.hpp
@@ -21,6 +21,7 @@
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "op/sirius_physical_operator.hpp"
+#include "planner/sirius_plan_twin_scan_fusion.hpp"
 
 #include <memory>
 #include <string>
@@ -112,6 +113,15 @@ class sirius_physical_plan_generator {
   /// is null. Same pointer in repeated calls returns the same channel.
   [[nodiscard]] std::shared_ptr<sirius::op::sirius_dynamic_filter_set>
   get_or_create_dynamic_filter_channel(duckdb::DynamicTableFilterSet const* key);
+
+  /// @brief What the twin-scan fusion pass did to the last `create_plan` result: fused pair
+  /// count plus every rejected same-table candidate pair with its typed reason. Diagnostic
+  /// state in the same spirit as `dynamic_filter_channels`; the default report when the
+  /// `fuse_twin_scans` setting is off.
+  [[nodiscard]] const twin_scan_fusion_report& twin_scan_report() const noexcept
+  {
+    return _twin_scan_report;
+  }
 
   //! Creates a plan from the logical operator. This involves resolving column bindings and
   //! generating physical operator nodes.
@@ -247,6 +257,9 @@ class sirius_physical_plan_generator {
  private:
   static void mark_fusable_merge_pipelines(sirius::op::sirius_physical_operator& op,
                                            bool fusion_enabled);
+
+  //! Backing state for `twin_scan_report()`, written by `create_plan`.
+  twin_scan_fusion_report _twin_scan_report;
 
  public:
   //! Walk the plan tree and insert the GPU pipeline operators (PARTITION, CONCAT, sort chain,

--- a/src/include/planner/sirius_plan_twin_scan_fusion.hpp
+++ b/src/include/planner/sirius_plan_twin_scan_fusion.hpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "op/sirius_physical_operator.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace sirius::planner {
+
+/**
+ * @file
+ * @brief Twin-scan fusion: fuse two near-duplicate probe-side scans of the same table into one
+ * fan-out twin-scan pipeline.
+ *
+ * `sirius_physical_plan_generator::create_plan` invokes `fuse_twin_scans` (under the
+ * `fuse_twin_scans` setting, read at the call site) while the scans are still `TABLE_SCAN` nodes,
+ * before `insert_gpu_pipeline_operators` rewrites the fused scan into `GPU_SCAN ->
+ * DYNAMIC_FILTER`. The returned `twin_scan_fusion_report` is stored on the generator and exposed
+ * through `twin_scan_report()` as diagnostic state; the match conditions, the semantic-safety
+ * proof, and the rewrite live in `sirius_plan_twin_scan_fusion.cpp`.
+ */
+
+/// Why a same-table candidate pair was not fused. Values are append-only; the evaluation order
+/// (geometry checks before channel checks before proof checks) is part of the contract -- tests
+/// pin exact reasons. See `sirius_plan_twin_scan_fusion.cpp` for the semantics of each check.
+enum class twin_scan_rejection_reason : uint8_t {
+  // match stage -- scan geometry (I1, I3-static)
+  columns_not_strict_prefix,  // column_ids: size or content
+  output_layout_not_prefix,   // projection_ids / identity layout
+  output_types_not_prefix,    // includes width-consistency internal checks
+  physical_carriers_differ,   // sidecar presence or shared-prefix carriers
+  static_filters_differ,
+  // prove stage -- channels (I4)
+  channel_missing,
+  channel_shared,  // both scans hold the same channel object
+  channel_without_producer,
+  channel_unscoped_producer,
+  channel_multi_target,
+  channel_target_invalid,  // out of range or rowid
+  channel_targets_differ,  // different underlying table columns
+  // prove stage -- delim-chain subsumption (I2)
+  producer_join_not_unique,  // zero, or more than one, publishing hash join
+  producer_joins_identical,
+  build_not_delim_replay,
+  delim_joins_identical,
+  delim_chain_not_direct,    // B's delim join does not directly consume A's
+  join_back_not_row_subset,  // A's join-back is not RIGHT_SEMI / RIGHT_ANTI
+  delim_distinct_missing,
+  delim_key_refs_differ,  // group_idx / types mismatch
+  producer_key_not_single_equality,
+  producer_keys_differ,
+  producer_key_outside_delim_output,
+};
+
+/// The snake_case name of @p reason (matching its enumerator), as it appears in rejection logs.
+[[nodiscard]] std::string_view to_string(twin_scan_rejection_reason reason) noexcept;
+
+/// One rejected same-table pair: the reason plus both sites' one-line geometry summaries (column
+/// ids, projection ids, output width, physical-sidecar presence, channel state).
+struct twin_scan_rejection {
+  twin_scan_rejection_reason reason;
+  std::string site_a;
+  std::string site_b;
+};
+
+/// What the pass did to one plan. `same_table_rejections` records only same-table candidate pairs
+/// (a handful per query at most) -- cross-table pairs are noise and are not recorded.
+struct twin_scan_fusion_report {
+  std::size_t fused_pairs = 0;
+  std::vector<twin_scan_rejection> same_table_rejections;
+};
+
+/// Fuse near-duplicate probe-side scans of the same table into one fan-out twin-scan pipeline.
+/// Must run while scans are still TABLE_SCAN nodes (before `insert_gpu_pipeline_operators`).
+/// Purely structural: reads no settings.
+[[nodiscard]] twin_scan_fusion_report fuse_twin_scans(
+  duckdb::unique_ptr<sirius::op::sirius_physical_operator>& plan);
+
+}  // namespace sirius::planner

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -168,10 +168,10 @@ struct operator_params {
   bool enable_compressed_materialization = true;
 
   /// Fuse near-duplicate probe-side scans of the same table into one fan-out twin-scan pipeline.
-  /// Off: the two scans decode and dynamic-filter the table independently. On: one shared decode
-  /// + membership probe feeds both consumers (one fewer pipeline), at the price of ~+1%-class
-  /// extra rows into the narrower consumer's authoritative join and one extra device gather for
-  /// the first output.
+  /// Off: the two scans each decode the table and probe its dynamic membership (Bloom) filter
+  /// independently. On: one shared decode + Bloom probe feeds both consumers (one fewer
+  /// pipeline), at the price of extra rows into the narrower consumer's authoritative join
+  /// (measured +1.1% on TPC-H q21) and one extra device gather for the first output (out-A).
   bool fuse_twin_scans = true;
 };
 

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -166,6 +166,13 @@ struct operator_params {
   /// metadata; other scans use native carriers. Logical types remain unchanged, and type-sensitive
   /// boundaries restore native carriers.
   bool enable_compressed_materialization = true;
+
+  /// Fuse near-duplicate probe-side scans of the same table into one fan-out twin-scan pipeline.
+  /// Off: the two scans decode and dynamic-filter the table independently. On: one shared decode
+  /// + membership probe feeds both consumers (one fewer pipeline), at the price of ~+1%-class
+  /// extra rows into the narrower consumer's authoritative join and one extra device gather for
+  /// the first output.
+  bool fuse_twin_scans = true;
 };
 
 struct telemetry_config {

--- a/src/op/sirius_physical_operator_type.cpp
+++ b/src/op/sirius_physical_operator_type.cpp
@@ -115,6 +115,8 @@ std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type)
     case SiriusPhysicalOperatorType::GPU_SCAN: return "GPU_SCAN";
     case SiriusPhysicalOperatorType::DYNAMIC_FILTER: return "DYNAMIC_FILTER";
     case SiriusPhysicalOperatorType::STREAMING_SOURCE: return "STREAMING_SOURCE";
+    case SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT: return "TWIN_SCAN_SPLIT";
+    case SiriusPhysicalOperatorType::TWIN_SCAN_REF: return "TWIN_SCAN_REF";
     case SiriusPhysicalOperatorType::INVALID: break;
   }
   return "INVALID";

--- a/src/op/sirius_physical_twin_scan_split.cpp
+++ b/src/op/sirius_physical_twin_scan_split.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_physical_twin_scan_split.hpp"
+
+#include "data/data_batch_utils.hpp"
+#include "expression_evaluator/expression_evaluator.hpp"
+#include "log/logging.hpp"
+#include "sirius/exception.hpp"
+
+#include <cudf/cudf_utils.hpp>
+#include <cudf/table/table.hpp>
+
+#include <nvtx3/nvtx3.hpp>
+
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/data/data_batch.hpp>
+
+#include <format>
+#include <iterator>
+#include <type_traits>
+#include <variant>
+
+namespace sirius {
+namespace op {
+
+namespace {
+
+/**
+ * @brief Twin-scan task output: both fan-out halves in one pipelineable container.
+ *
+ * The base class holds out-A batches followed by out-B batches so the task machinery's
+ * generic accounting (output bytes, telemetry subscription) sees every produced batch;
+ * `split_point` lets sink() route the two halves to their respective consumer pipelines.
+ */
+class twin_split_output_data : public pipelineable_operator_data {
+ public:
+  twin_split_output_data(std::vector<std::shared_ptr<cucascade::data_batch>> batches_a_then_b,
+                         std::size_t split_point)
+    : pipelineable_operator_data(std::move(batches_a_then_b)), _split_point(split_point)
+  {
+  }
+
+  [[nodiscard]] std::size_t split_point() const noexcept { return _split_point; }
+
+ private:
+  std::size_t _split_point;
+};
+
+}  // namespace
+
+sirius_physical_twin_scan_split::sirius_physical_twin_scan_split(
+  duckdb::vector<sirius::logical_type> types_a,
+  std::vector<cudf::size_type> output_indices_a,
+  std::unique_ptr<sirius::ast::node> residual,
+  output_mask output_columns_b,
+  duckdb::vector<sirius::logical_type> types_b,
+  std::size_t estimated_cardinality,
+  sirius_physical_twin_scan_ref* twin_ref)
+  : sirius_physical_operator(
+      SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT, std::move(types_a), estimated_cardinality),
+    _output_indices_a(std::move(output_indices_a)),
+    _residual(std::move(residual)),
+    _output_columns_b(std::move(output_columns_b)),
+    _types_b(std::move(types_b)),
+    _twin_ref(twin_ref)
+{
+  if (_residual == nullptr) {
+    throw internal_exception("twin_scan_split constructed without a residual predicate");
+  }
+  if (_twin_ref == nullptr) {
+    throw internal_exception("twin_scan_split constructed without a twin ref anchor");
+  }
+  if (_output_indices_a.empty()) {
+    throw internal_exception("twin_scan_split constructed with an empty out-A projection");
+  }
+}
+
+std::string sirius_physical_twin_scan_split::params_to_string() const
+{
+  return std::format("out_a_cols={} out_b_cols={}", _output_indices_a.size(), _types_b.size());
+}
+
+std::unique_ptr<operator_data> sirius_physical_twin_scan_split::execute(
+  const operator_data& input_data, rmm::cuda_stream_view stream)
+{
+  nvtx3::scoped_range nvtx_range{"sirius_physical_twin_scan_split::execute"};
+  const auto& input         = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_read_only_batches();
+
+  sirius::expression_evaluator evaluator(
+    *_residual, cudf::get_current_device_resource_ref(), stream);
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> batches_a;
+  std::vector<std::shared_ptr<cucascade::data_batch>> batches_b;
+  batches_a.reserve(input_batches.size());
+  batches_b.reserve(input_batches.size());
+
+  std::size_t rows_in = 0;
+  std::size_t rows_a  = 0;
+  std::size_t rows_b  = 0;
+
+  for (auto const& batch : input_batches) {
+    auto view = batch.get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
+    rows_in += static_cast<std::size_t>(view.num_rows());
+
+    // out-B first: the residual gather reads the shared columns, so it must not observe a
+    // half-moved batch (out-A below is a fresh copy, so ordering is for clarity only).
+    auto filtered_b = std::visit(
+      [&](const auto& indices) {
+        using IndicesType = std::decay_t<decltype(indices)>;
+        if constexpr (std::is_same_v<IndicesType, passthrough>) {
+          return evaluator.select(view);
+        } else {
+          return evaluator.select(view, indices);
+        }
+      },
+      _output_columns_b);
+    rows_b += static_cast<std::size_t>(filtered_b->num_rows());
+    batches_b.push_back(sirius::make_data_batch(
+      std::move(filtered_b), *batch.get_memory_space(), stream, batch_telemetry()));
+
+    // out-A: an unfiltered gather of the first scan's columns from the shared stream.
+    auto table_a = std::make_unique<cudf::table>(
+      view.select(_output_indices_a), stream, cudf::get_current_device_resource_ref());
+    rows_a += static_cast<std::size_t>(table_a->num_rows());
+    batches_a.push_back(sirius::make_data_batch(
+      std::move(table_a), *batch.get_memory_space(), stream, batch_telemetry()));
+  }
+
+  _rows_in.fetch_add(rows_in, std::memory_order_relaxed);
+  _rows_a.fetch_add(rows_a, std::memory_order_relaxed);
+  _rows_b.fetch_add(rows_b, std::memory_order_relaxed);
+
+  const std::size_t split_point = batches_a.size();
+  auto combined                 = std::move(batches_a);
+  combined.insert(combined.end(),
+                  std::make_move_iterator(batches_b.begin()),
+                  std::make_move_iterator(batches_b.end()));
+  return std::make_unique<twin_split_output_data>(std::move(combined), split_point);
+}
+
+void sirius_physical_twin_scan_split::sink(const operator_data& input_data,
+                                           rmm::cuda_stream_view stream)
+{
+  auto const* output = dynamic_cast<const twin_split_output_data*>(&input_data);
+  if (output == nullptr) {
+    throw internal_exception("twin_scan_split::sink expects twin_split_output_data");
+  }
+  auto* consumer_b = _twin_ref->get_parent_op();
+  if (consumer_b == nullptr) {
+    throw internal_exception("twin_scan_split: twin ref has no tree parent to route out-B to");
+  }
+  // Exactly one A edge (the tree parent's pipeline) and one B edge (the twin ref's consumer)
+  // are emitted by the converter; anything else means the wiring pass and this operator
+  // disagree — fail loudly rather than mis-route data.
+  std::size_t b_edges = 0;
+  for (auto const& port_info : next_port_after_sink) {
+    b_edges += port_info.next_operator == consumer_b ? 1 : 0;
+  }
+  if (next_port_after_sink.size() != 2 || b_edges != 1) {
+    throw internal_exception(
+      "twin_scan_split: expected exactly one out-A and one out-B edge, got {} edges ({} to the "
+      "twin consumer)",
+      next_port_after_sink.size(),
+      b_edges);
+  }
+
+  const auto& batches = output->get_data_batches();
+  for (auto const& port_info : next_port_after_sink) {
+    const bool is_b         = port_info.next_operator == consumer_b;
+    const std::size_t begin = is_b ? output->split_point() : 0;
+    const std::size_t end   = is_b ? batches.size() : output->split_point();
+    for (std::size_t i = begin; i < end; ++i) {
+      port_info.next_operator->push_data_batch(port_info.next_operator_port_name, batches[i]);
+    }
+  }
+}
+
+void sirius_physical_twin_scan_split::on_finalize_operator()
+{
+  SIRIUS_LOG_INFO("[twin_scan_split] fused stream rows={} out_a rows={} out_b rows={}",
+                  _rows_in.load(std::memory_order_relaxed),
+                  _rows_a.load(std::memory_order_relaxed),
+                  _rows_b.load(std::memory_order_relaxed));
+}
+
+}  // namespace op
+}  // namespace sirius

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -30,6 +30,7 @@
 #include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_operator_type.hpp"
 #include "op/sirius_physical_partition.hpp"
+#include "op/sirius_physical_twin_scan_split.hpp"
 #include "pipeline/repository_wiring.hpp"
 
 #include <algorithm>
@@ -330,6 +331,24 @@ void sirius_pipeline_converter::compute_repository_wiring(sirius_pipeline_build_
              sink_op,
              pipeline,
              it->second);
+      }
+      continue;
+    }
+
+    // A twin-scan split is a two-output fan-out sink: out-A goes to its tree parent's
+    // pipeline (the consumer the fused pipeline replaced), out-B to the twin ref anchor's
+    // consumer pipeline (the TWIN_SCAN_REF itself is routing-only and never lands in any
+    // pipeline's operators[], like DELIM_SCAN). The split's sink() routes the two halves by
+    // matching each edge's destination operator against the twin ref's tree parent.
+    if (sink_op->type == T::TWIN_SCAN_SPLIT) {
+      auto& split = sink_op->Cast<op::sirius_physical_twin_scan_split>();
+      op::sirius_physical_operator* consumers[] = {sink_op->get_parent_op(),
+                                                   split.twin_ref()->get_parent_op()};
+      for (auto* consumer : consumers) {
+        if (!consumer) { continue; }
+        auto it = dest_for_op.find(consumer);
+        if (it == dest_for_op.end()) { continue; }
+        emit("default", resolve_barrier(*sink_op, *it->second), sink_op, pipeline, it->second);
       }
       continue;
     }

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -1057,7 +1057,9 @@ sirius_physical_plan_generator::create_plan(duckdb::unique_ptr<duckdb::LogicalOp
 
   // Fuse near-duplicate same-table scans into one fan-out twin-scan pipeline. Must run while
   // the scans are still TABLE_SCAN nodes (before the GPU pipeline operator rewrite below).
-  // Policy lives here: the pass itself reads no settings.
+  // Policy lives here: the pass itself reads no settings. With the setting off the pass is
+  // not invoked at all, so the plan is exactly the unfused baseline (knob-off parity) and the
+  // report resets to the default.
   {
     duckdb::Value setting;
     // The fallback is only reachable when the option is unregistered (e.g. SIRIUS_DISABLE);

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -61,6 +61,7 @@
 #include "op/sirius_physical_ungrouped_aggregate_merge.hpp"
 #include "planner/sirius_plan_compressed_schema.hpp"
 #include "planner/sirius_plan_projection_utils.hpp"
+#include "planner/sirius_plan_twin_scan_fusion.hpp"
 #include "sirius_config.hpp"
 #include "sirius_context.hpp"
 
@@ -1053,6 +1054,20 @@ sirius_physical_plan_generator::create_plan(duckdb::unique_ptr<duckdb::LogicalOp
     }
   }
   plan->verify();
+
+  // Fuse near-duplicate same-table scans into one fan-out twin-scan pipeline. Must run while
+  // the scans are still TABLE_SCAN nodes (before the GPU pipeline operator rewrite below).
+  // Policy lives here: the pass itself reads no settings.
+  {
+    duckdb::Value setting;
+    // The fallback is only reachable when the option is unregistered (e.g. SIRIUS_DISABLE);
+    // it matches the registered default, `operator_params.fuse_twin_scans`.
+    bool twin_fusion_enabled = true;
+    if (context.TryGetCurrentSetting("fuse_twin_scans", setting) && !setting.IsNull()) {
+      twin_fusion_enabled = setting.GetValue<bool>();
+    }
+    _twin_scan_report = twin_fusion_enabled ? fuse_twin_scans(plan) : twin_scan_fusion_report{};
+  }
 
   // Rewrite the plan tree to contain the GPU pipeline operators so the converter becomes a
   // pure topology pass over `build_pipelines` virtuals; `set_parent_ops` then derives every

--- a/src/planner/sirius_plan_twin_scan_fusion.cpp
+++ b/src/planner/sirius_plan_twin_scan_fusion.cpp
@@ -80,6 +80,17 @@
 //!    are installed atomically into the same plan tree and destroyed with it. No pass may detach
 //!    one without the other; today none runs between fusion and pipeline insertion, and the
 //!    converter / `sink()` consistency checks fail loudly if the pairing breaks.
+//!  - I7 -- Scheduling acyclicity, by construction. The fused pipeline waits only on A's channel
+//!    producers -- exactly what A's scan waited on at baseline -- and both consumers receive
+//!    their input over the converter's standard buffered PARTIAL-barrier repository edges
+//!    (`compute_repository_wiring`). The rewrite strictly removes one dependency edge (B's scan
+//!    on B's now-closed channel) and adds none, so a baseline-acyclic pipeline graph stays
+//!    acyclic. The full scheduling argument, including the bounded-buffering analysis, lives in
+//!    docs/super-sirius/physical-plan-generation.md ("Twin-scan fusion").
+//!
+//! Knob-off parity: the pass reads no settings; `create_plan` invokes it only when the
+//! `fuse_twin_scans` setting is on, so with the knob off the plan is exactly the unfused
+//! baseline.
 //!
 //! Rewrite: A's slot becomes TWIN_SCAN_SPLIT over B's scan (which keeps its own column set but
 //! now consumes A's dynamic-filter channel); B's slot becomes the routing-only TWIN_SCAN_REF.
@@ -484,8 +495,10 @@ void fuse_pair(twin_site& a, twin_site& b)
   auto& scan_b = fused_scan->Cast<sirius::op::sirius_physical_table_scan>();
   auto chan_b  = scan_b.sirius_dynamic_filters;
   // The fused scan consumes A's channel; A's producer indexes stay valid because A's
-  // column_ids are a prefix of B's (checked by match_scan_geometry). B's channel loses its
-  // only consumer -- close it so its producer join skips filter construction entirely.
+  // column_ids are a prefix of B's (checked by match_scan_geometry, I1). B's channel loses its
+  // only consumer -- close it so its producer join skips filter construction entirely. This
+  // dropped advisory channel is the only thing the pass ever drops (I3), legal because of the
+  // subsumption proof (I2) plus B's authoritative downstream join.
   scan_b.sirius_dynamic_filters = a.scan->sirius_dynamic_filters;
   scan_b.dynamic_filters        = a.scan->dynamic_filters;
   if (chan_b) { chan_b->close_for_new_filters(); }

--- a/src/planner/sirius_plan_twin_scan_fusion.cpp
+++ b/src/planner/sirius_plan_twin_scan_fusion.cpp
@@ -1,0 +1,609 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Twin-scan fusion: fuse two near-duplicate probe-side scans of the same table into ONE
+//! fan-out scan pipeline that decodes and dynamic-filters the shared stream once.
+//!
+//! Motivating shape (TPC-H q21): DuckDB's delim decomposition of chained EXISTS / NOT EXISTS
+//! leaves two full scans of the same table whose column sets nest, whose static filters differ
+//! only by one residual predicate, and whose dynamic membership filters are Blooms over provably
+//! nested key sets. Fusing them halves the decode + Bloom-probe work.
+//!
+//! The pass runs on the physical operator tree after `create_plan` / the compressed-schema
+//! passes and BEFORE `insert_gpu_pipeline_operators` (the scans are still TABLE_SCAN nodes
+//! carrying their `sirius_dynamic_filters` channels; see sirius_physical_plan_generator.cpp).
+//! It is decomposed into `collect_sites` (candidate shapes), `match_scan_geometry` (is fusing
+//! mechanically well-formed), `prove_channel_subsumption` (is dropping B's channel semantically
+//! safe), and `fuse_pair` (the rewrite). Each rejected condition names a
+//! `twin_scan_rejection_reason`.
+//!
+//! Safety invariants (A = the bare scan whose slot becomes the split, B = the residual-filtered
+//! scan that becomes the fused scan):
+//!
+//!  - I1 -- Prefix property (index remapping is structurally impossible). A's `column_ids` must
+//!    be a strict prefix of B's, AND A's effective output layout (projection_ids or identity),
+//!    output types, and physical-carrier sidecar entries must be prefixes of B's. Consequences
+//!    relied on: (a) every producer-side filter-target index of A's channel -- which is in
+//!    column_ids space and remapped to output positions by the fused scan's own ingestible via
+//!    `set_consumer_column_remap` -- is valid on the fused scan unchanged; (b) out-A is the
+//!    identity projection of the first `width_A` fused output columns, so out-A is row-for-row
+//!    A's original output. There is deliberately NO remapping code anywhere; any future
+//!    relaxation of the prefix condition must reject, not remap. Checks:
+//!    `columns_not_strict_prefix`, `output_layout_not_prefix`, `output_types_not_prefix`,
+//!    `physical_carriers_differ`.
+//!  - I2 -- Keyset subsumption, proven structurally over multi-key delim tuples. keys(B) must be
+//!    a subset of keys(A) so A's membership filters never drop a row B's authoritative join
+//!    would keep. Proof obligations: B's delim join's input is DIRECTLY A's delim join
+//!    (`delim_chain_not_direct`); A's join-back is RIGHT_SEMI / RIGHT_ANTI -- the only join
+//!    types emitting a row-subset of A's delim input with schema preserved
+//!    (`join_back_not_row_subset`); both delim distincts have identical group references and
+//!    types (`delim_distinct_missing`, `delim_key_refs_differ`) -- then the delim key sets nest
+//!    as TUPLE sets even for multi-column delim keys, and tuple containment projects to
+//!    containment on any single key column; finally both producer joins must key on the same
+//!    single build-side column position (`producer_key_not_single_equality`,
+//!    `producer_keys_differ`, `producer_key_outside_delim_output`), so the published membership
+//!    filters are over that same projected column.
+//!  - I3 -- Advisory filters only; never a static/correctness filter. The only thing the pass
+//!    ever drops is B's dynamic (advisory) channel -- legal solely because of I2 plus the fact
+//!    that the downstream join is authoritative for extra rows (out-B may carry keys(A) minus
+//!    keys(B) rows; the join drops them). Static pushed table filters are never dropped: they
+//!    must be identical on both scans or the pair is rejected (`static_filters_differ`). B's
+//!    residual predicate is never dropped: it moves into the split and is evaluated per batch.
+//!  - I4 -- The proof must cover every producer of both channels. Each channel must have
+//!    producers (`channel_without_producer`), none unscoped -- an unscoped producer may publish
+//!    on any column and `planned_target_columns()` is documented as meaningless then
+//!    (`channel_unscoped_producer`) -- exactly one planned target column
+//!    (`channel_multi_target`) on the same underlying table column, not rowid, in range
+//!    (`channel_target_invalid`, `channel_targets_differ`), and exactly one hash join whose
+//!    `dynamic_filter_plan().probe_targets()` reference the channel
+//!    (`producer_join_not_unique`). Channels must be distinct objects with distinct producer
+//!    joins (`channel_shared`, `producer_joins_identical`).
+//!  - I5 -- Output equivalence. out-A is A's baseline output row-for-row and byte-for-byte (same
+//!    columns, same static filters, same channel). out-B is a superset of B's baseline output,
+//!    superset only by keys(A) minus keys(B) rows, re-filtered by B's authoritative downstream
+//!    join. The split's finalize log line (`rows_in/out_a/out_b`) exists to validate exactly
+//!    this against an unfused run.
+//!  - I6 -- Tree/lifetime invariant. The split holds a non-owning `TWIN_SCAN_REF*`; both nodes
+//!    are installed atomically into the same plan tree and destroyed with it. No pass may detach
+//!    one without the other; today none runs between fusion and pipeline insertion, and the
+//!    converter / `sink()` consistency checks fail loudly if the pairing breaks.
+//!
+//! Rewrite: A's slot becomes TWIN_SCAN_SPLIT over B's scan (which keeps its own column set but
+//! now consumes A's dynamic-filter channel); B's slot becomes the routing-only TWIN_SCAN_REF.
+//! B's channel is closed so its producer skips filter construction.
+
+#include "planner/sirius_plan_twin_scan_fusion.hpp"
+
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/function/table/table_scan.hpp"
+#include "duckdb/planner/table_filter.hpp"
+#include "log/logging.hpp"
+#include "op/sirius_dynamic_filter.hpp"
+#include "op/sirius_physical_delim_join.hpp"
+#include "op/sirius_physical_filter.hpp"
+#include "op/sirius_physical_grouped_aggregate.hpp"
+#include "op/sirius_physical_hash_join.hpp"
+#include "op/sirius_physical_table_scan.hpp"
+#include "op/sirius_physical_twin_scan_split.hpp"
+#include "planner/sirius_physical_plan_generator.hpp"
+
+#include <format>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace sirius::planner {
+
+namespace {
+
+using sirius::op::SiriusPhysicalOperatorType;
+using op_ptr = duckdb::unique_ptr<sirius::op::sirius_physical_operator>;
+
+//! A fusion candidate: a probe-side slot holding either a bare TABLE_SCAN (A shape) or a
+//! FILTER directly over a TABLE_SCAN (B shape).
+struct twin_site {
+  op_ptr* slot;
+  sirius::op::sirius_physical_table_scan* scan;
+  sirius::op::sirius_physical_filter* residual;  // nullptr for the bare shape
+};
+
+//! Every fusion candidate site in one plan tree plus the full operator census the
+//! subsumption proof searches for producer joins and delim joins.
+struct site_census {
+  std::vector<twin_site> sites;
+  std::vector<sirius::op::sirius_physical_operator*> all;
+};
+
+//! Post-order walk collecting `slot` and its subtree (including delim-join internal subtrees)
+//! into @p census. @p child_idx is `slot`'s index in @p parent's `children[]`, or nullopt for
+//! the delim-internal `join`/`distinct_root` edges, which are never probe edges.
+void collect_sites_recursive(op_ptr& slot,
+                             sirius::op::sirius_physical_operator* parent,
+                             std::optional<std::size_t> child_idx,
+                             site_census& census)
+{
+  if (!slot) { return; }
+  census.all.push_back(slot.get());
+
+  const bool probe_child = parent != nullptr &&
+                           parent->type == SiriusPhysicalOperatorType::HASH_JOIN &&
+                           child_idx == std::size_t{0};
+  if (probe_child) {
+    if (slot->type == SiriusPhysicalOperatorType::TABLE_SCAN && slot->children.empty()) {
+      census.sites.push_back(
+        {&slot, &slot->Cast<sirius::op::sirius_physical_table_scan>(), nullptr});
+    } else if (slot->type == SiriusPhysicalOperatorType::FILTER && slot->children.size() == 1 &&
+               slot->children[0]->type == SiriusPhysicalOperatorType::TABLE_SCAN &&
+               slot->children[0]->children.empty()) {
+      census.sites.push_back({&slot,
+                              &slot->children[0]->Cast<sirius::op::sirius_physical_table_scan>(),
+                              &slot->Cast<sirius::op::sirius_physical_filter>()});
+    }
+  }
+
+  for (std::size_t i = 0; i < slot->children.size(); ++i) {
+    collect_sites_recursive(slot->children[i], slot.get(), i, census);
+  }
+  if (slot->type == SiriusPhysicalOperatorType::LEFT_DELIM_JOIN ||
+      slot->type == SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
+    auto& delim = slot->Cast<sirius::op::sirius_physical_delim_join>();
+    collect_sites_recursive(delim.join, slot.get(), std::nullopt, census);
+    collect_sites_recursive(delim.distinct_root, slot.get(), std::nullopt, census);
+  }
+}
+
+//! Collect every fusion candidate site and the full operator census of @p plan.
+site_census collect_sites(op_ptr& plan)
+{
+  site_census census;
+  collect_sites_recursive(plan, nullptr, std::nullopt, census);
+  return census;
+}
+
+//! One-line scan geometry summary for the detection logs and rejection records: column ids,
+//! projection ids, output width, physical-sidecar presence, and the dynamic-filter channel
+//! state. Planned target columns are shown only when their accessor is meaningful
+//! (producer-backed, no unscoped producer).
+std::string describe_scan_geometry(const sirius::op::sirius_physical_table_scan& scan)
+{
+  std::string cols;
+  for (auto const& ci : scan.column_ids) {
+    cols += (cols.empty() ? "" : ",") +
+            (ci.IsRowIdColumn() ? std::string("rowid") : std::to_string(ci.GetPrimaryIndex()));
+  }
+  std::string projs;
+  for (auto const& p : scan.projection_ids) {
+    projs += (projs.empty() ? "" : ",") + std::to_string(p);
+  }
+  std::string channel_state = "none";
+  std::string planned;
+  if (scan.sirius_dynamic_filters) {
+    auto const& channel = *scan.sirius_dynamic_filters;
+    if (!channel.has_producers()) {
+      channel_state = "no-producers";
+    } else if (channel.has_unscoped_producer()) {
+      channel_state = "unscoped-producer";
+    } else {
+      channel_state = "producer-backed";
+      for (auto const p : channel.planned_target_columns()) {
+        planned += (planned.empty() ? "" : ",") + std::to_string(p);
+      }
+    }
+  }
+  return std::format("col_ids=[{}] proj_ids=[{}] out_width={} phys={} chan={} planned=[{}]",
+                     cols,
+                     projs,
+                     scan.types.size(),
+                     scan.has_physical_overrides(),
+                     channel_state,
+                     planned);
+}
+
+//! Same-relation identity: seq_scan by resolved catalog entry, parquet family by resolved
+//! file path list. Anything unresolvable is not the same table.
+bool same_table_identity(const sirius::op::sirius_physical_table_scan& x,
+                         const sirius::op::sirius_physical_table_scan& y)
+{
+  if (x.function.name != y.function.name) { return false; }
+  if (x.function.name == "seq_scan") {
+    auto const* bx = dynamic_cast<duckdb::TableScanBindData const*>(x.bind_data.get());
+    auto const* by = dynamic_cast<duckdb::TableScanBindData const*>(y.bind_data.get());
+    return bx != nullptr && by != nullptr && &bx->table == &by->table;
+  }
+  if (x.function.name == "parquet_scan" || x.function.name == "read_parquet" ||
+      x.function.name == "sirius_read_parquet") {
+    auto px = resolve_parquet_scan_file_paths(x.function.name, x.bind_data.get(), x.parameters);
+    auto py = resolve_parquet_scan_file_paths(y.function.name, y.bind_data.get(), y.parameters);
+    return !px.empty() && px == py;
+  }
+  return false;
+}
+
+//! Effective output layout of a scan: projection_ids, or the identity over column_ids.
+std::vector<std::size_t> effective_output(const sirius::op::sirius_physical_table_scan& scan)
+{
+  if (!scan.projection_ids.empty()) {
+    return {scan.projection_ids.begin(), scan.projection_ids.end()};
+  }
+  std::vector<std::size_t> identity(scan.column_ids.size());
+  std::iota(identity.begin(), identity.end(), 0);
+  return identity;
+}
+
+//! Whether fusing (a := shared output, b := residual-filtered output) is mechanically
+//! well-formed: the I1 prefix ladder, identical static filters (I3), and agreeing physical
+//! carriers on the shared prefix. Pure scan-vs-scan; no channel or join knowledge. The caller
+//! has already established same-table identity via `same_table_identity` (cross-table pairs
+//! are not candidates and are never recorded). Returns the rejection reason, or nullopt on a
+//! match. @p sa / @p sb are non-const because `TableFilterSet::Equals` is a non-const member.
+std::optional<twin_scan_rejection_reason> match_scan_geometry(
+  sirius::op::sirius_physical_table_scan& sa, sirius::op::sirius_physical_table_scan& sb)
+{
+  // --- Column geometry: A must be a strict prefix of B, in column_ids AND output layout. ---
+  // This is what makes A's channel indexes (column_ids space on the producer side) valid on
+  // the fused scan without remapping.
+  if (sa.column_ids.size() >= sb.column_ids.size()) {
+    return twin_scan_rejection_reason::columns_not_strict_prefix;
+  }
+  for (std::size_t i = 0; i < sa.column_ids.size(); ++i) {
+    if (!(sa.column_ids[i] == sb.column_ids[i])) {
+      return twin_scan_rejection_reason::columns_not_strict_prefix;
+    }
+  }
+  auto eff_a = effective_output(sa);
+  auto eff_b = effective_output(sb);
+  if (eff_a.size() > eff_b.size()) { return twin_scan_rejection_reason::output_layout_not_prefix; }
+  for (std::size_t i = 0; i < eff_a.size(); ++i) {
+    if (eff_a[i] != eff_b[i]) { return twin_scan_rejection_reason::output_layout_not_prefix; }
+  }
+  if (sa.types.size() != eff_a.size() || sa.types.size() >= sb.types.size()) {
+    return twin_scan_rejection_reason::output_types_not_prefix;
+  }
+  for (std::size_t i = 0; i < sa.types.size(); ++i) {
+    if (!(sa.types[i] == sb.types[i])) {
+      return twin_scan_rejection_reason::output_types_not_prefix;
+    }
+  }
+
+  // --- Physical carriers on the shared prefix must agree (downstream ops were planned
+  //     against A's carriers; the fused scan materializes B's). Requiring equal sidecar
+  //     PRESENCE even when only B's residual-only columns are narrowed is deliberate
+  //     over-rejection: it keeps this check independent of how sidecars are derived. ---
+  if (sa.has_physical_overrides() != sb.has_physical_overrides()) {
+    return twin_scan_rejection_reason::physical_carriers_differ;
+  }
+  if (sa.has_physical_overrides()) {
+    auto const& pa = sa.get_physical_types();
+    auto const& pb = sb.get_physical_types();
+    // Sidecar sizes track the column widths already prefix-checked above; the size guard is
+    // defensive so the indexing below can never rely on that invariant silently.
+    if (pa.size() > pb.size()) { return twin_scan_rejection_reason::physical_carriers_differ; }
+    for (std::size_t i = 0; i < pa.size(); ++i) {
+      if (!(pa[i] == pb[i])) { return twin_scan_rejection_reason::physical_carriers_differ; }
+    }
+  }
+
+  // --- Static filters must be identical: the fused scan runs B's, so A's must equal them. ---
+  const bool empty_a = !sa.table_filters || sa.table_filters->filters.empty();
+  const bool empty_b = !sb.table_filters || sb.table_filters->filters.empty();
+  if (empty_a != empty_b) { return twin_scan_rejection_reason::static_filters_differ; }
+  if (!empty_a && !sa.table_filters->Equals(*sb.table_filters)) {
+    return twin_scan_rejection_reason::static_filters_differ;
+  }
+
+  return std::nullopt;
+}
+
+//! The unique hash join publishing into `channel`, or nullptr (none, or more than one).
+sirius::op::sirius_physical_hash_join* unique_producer_join(
+  const std::vector<sirius::op::sirius_physical_operator*>& all,
+  const std::shared_ptr<sirius::op::sirius_dynamic_filter_set>& channel)
+{
+  sirius::op::sirius_physical_hash_join* found = nullptr;
+  for (auto* node : all) {
+    if (node->type != SiriusPhysicalOperatorType::HASH_JOIN) { continue; }
+    auto& join = node->Cast<sirius::op::sirius_physical_hash_join>();
+    for (auto const& target : join.dynamic_filter_plan().probe_targets()) {
+      if (target.filter_set.get() != channel.get()) { continue; }
+      if (found != nullptr && found != &join) { return nullptr; }
+      found = &join;
+    }
+  }
+  return found;
+}
+
+//! The delim join whose duplicate-eliminated keys feed `join`'s build side (children[1]
+//! descends through unary operators to a DELIM_SCAN owned by that delim join), or nullptr.
+sirius::op::sirius_physical_delim_join* delim_feeding_build(
+  const std::vector<sirius::op::sirius_physical_operator*>& all,
+  sirius::op::sirius_physical_hash_join& join)
+{
+  if (join.children.size() < 2) { return nullptr; }
+  auto* node = join.children[1].get();
+  while (node != nullptr && node->type != SiriusPhysicalOperatorType::DELIM_SCAN &&
+         node->children.size() == 1) {
+    node = node->children[0].get();
+  }
+  if (node == nullptr || node->type != SiriusPhysicalOperatorType::DELIM_SCAN) { return nullptr; }
+  for (auto* candidate : all) {
+    if (candidate->type != SiriusPhysicalOperatorType::LEFT_DELIM_JOIN &&
+        candidate->type != SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
+      continue;
+    }
+    auto& delim = candidate->Cast<sirius::op::sirius_physical_delim_join>();
+    for (auto const& scan_ref : delim.delim_scans) {
+      if (&scan_ref.get() == node) { return &delim; }
+    }
+  }
+  return nullptr;
+}
+
+//! The build-side column position of @p join's single equality condition, or nullopt when
+//! the join has more or fewer than one equality, or its build side is not a plain column
+//! reference. The membership filters a join publishes are built from its equality build
+//! keys, so a unique plain-reference key pins down exactly which build column feeds them.
+std::optional<uint32_t> equality_build_key(const sirius::op::sirius_physical_hash_join& join)
+{
+  std::optional<uint32_t> key;
+  for (auto const& cond : join.conditions) {
+    if (cond.comparison != sirius::comparison_type::equal) { continue; }
+    if (key.has_value()) { return std::nullopt; }  // more than one equality
+    if (!cond.right || !cond.right->holds<sirius::ast::reference>()) { return std::nullopt; }
+    key = cond.right->get<sirius::ast::reference>().column_index;
+  }
+  return key;
+}
+
+//! Whether dropping B's dynamic-filter channel in favor of A's is semantically safe: the
+//! channel obligations of I4 followed by the I2 delim-chain proof of keys(B) contained in
+//! keys(A). Returns the rejection reason, or nullopt when the proof holds.
+std::optional<twin_scan_rejection_reason> prove_channel_subsumption(
+  const sirius::op::sirius_physical_table_scan& sa,
+  const sirius::op::sirius_physical_table_scan& sb,
+  const std::vector<sirius::op::sirius_physical_operator*>& all)
+{
+  // --- Dynamic-filter channels: single-column targets on the same table column (I4). ---
+  auto chan_a = sa.sirius_dynamic_filters;
+  auto chan_b = sb.sirius_dynamic_filters;
+  if (!chan_a || !chan_b) { return twin_scan_rejection_reason::channel_missing; }
+  if (chan_a == chan_b) { return twin_scan_rejection_reason::channel_shared; }
+  if (!chan_a->has_producers() || !chan_b->has_producers()) {
+    return twin_scan_rejection_reason::channel_without_producer;
+  }
+  // An unscoped producer may publish filters on any column, and planned_target_columns() is
+  // documented as meaningful only when no producer is unscoped -- the proof below cannot
+  // cover such a producer, so reject.
+  if (chan_a->has_unscoped_producer() || chan_b->has_unscoped_producer()) {
+    return twin_scan_rejection_reason::channel_unscoped_producer;
+  }
+  auto planned_a = chan_a->planned_target_columns();
+  auto planned_b = chan_b->planned_target_columns();
+  if (planned_a.size() != 1 || planned_b.size() != 1) {
+    return twin_scan_rejection_reason::channel_multi_target;
+  }
+  if (planned_a[0] >= sa.column_ids.size() || planned_b[0] >= sb.column_ids.size()) {
+    return twin_scan_rejection_reason::channel_target_invalid;
+  }
+  if (sa.column_ids[planned_a[0]].IsRowIdColumn() || sb.column_ids[planned_b[0]].IsRowIdColumn()) {
+    return twin_scan_rejection_reason::channel_target_invalid;
+  }
+  if (sa.column_ids[planned_a[0]].GetPrimaryIndex() !=
+      sb.column_ids[planned_b[0]].GetPrimaryIndex()) {
+    return twin_scan_rejection_reason::channel_targets_differ;
+  }
+
+  // --- Key-set subsumption keys(B) in keys(A): the delim-chain structural proof (I2). ---
+  auto* join_a = unique_producer_join(all, chan_a);
+  auto* join_b = unique_producer_join(all, chan_b);
+  if (join_a == nullptr || join_b == nullptr) {
+    return twin_scan_rejection_reason::producer_join_not_unique;
+  }
+  if (join_a == join_b) { return twin_scan_rejection_reason::producer_joins_identical; }
+  auto* delim_a = delim_feeding_build(all, *join_a);
+  auto* delim_b = delim_feeding_build(all, *join_b);
+  if (delim_a == nullptr || delim_b == nullptr) {
+    return twin_scan_rejection_reason::build_not_delim_replay;
+  }
+  if (delim_a == delim_b) { return twin_scan_rejection_reason::delim_joins_identical; }
+  if (delim_b->children.empty() || delim_b->children[0].get() != delim_a) {
+    return twin_scan_rejection_reason::delim_chain_not_direct;
+  }
+  if (!delim_a->join || delim_a->join->type != SiriusPhysicalOperatorType::HASH_JOIN) {
+    return twin_scan_rejection_reason::join_back_not_row_subset;
+  }
+  auto const join_back_type =
+    delim_a->join->Cast<sirius::op::sirius_physical_hash_join>().join_type;
+  if (join_back_type != duckdb::JoinType::RIGHT_SEMI &&
+      join_back_type != duckdb::JoinType::RIGHT_ANTI) {
+    // Only these emit a row-subset of A's delim input with the schema preserved, which is
+    // what lets equal distinct group references prove the key containment below.
+    return twin_scan_rejection_reason::join_back_not_row_subset;
+  }
+  auto* distinct_a = delim_a->distinct;
+  auto* distinct_b = delim_b->distinct;
+  if (distinct_a == nullptr || distinct_b == nullptr) {
+    return twin_scan_rejection_reason::delim_distinct_missing;
+  }
+  if (distinct_a->group_idx != distinct_b->group_idx || !(distinct_a->types == distinct_b->types)) {
+    return twin_scan_rejection_reason::delim_key_refs_differ;
+  }
+  // Multi-column delim keys are fine: keys(D_B) is contained in keys(D_A) as TUPLE sets
+  // (row-subset input + identical group refs), and tuple containment projects to containment
+  // on any one key column. What that projection argument needs is that both producer joins
+  // build their membership filter from the SAME delim key column: each join must have exactly
+  // one equality condition, keyed on the same build-side column position.
+  auto build_key   = equality_build_key(*join_a);
+  auto build_key_b = equality_build_key(*join_b);
+  if (!build_key.has_value() || !build_key_b.has_value()) {
+    return twin_scan_rejection_reason::producer_key_not_single_equality;
+  }
+  if (*build_key != *build_key_b) { return twin_scan_rejection_reason::producer_keys_differ; }
+  if (*build_key >= distinct_a->types.size()) {
+    return twin_scan_rejection_reason::producer_key_outside_delim_output;
+  }
+
+  return std::nullopt;
+}
+
+//! Rewrite one matched pair. See the file comment for the resulting shape. The ref is
+//! installed into B's slot first (destroying the residual FILTER whose residual, output mask,
+//! and scan have already been moved out), then the split into A's slot; A is a leaf and the
+//! two slots live in unrelated parents, so neither write invalidates the other (I6).
+void fuse_pair(twin_site& a, twin_site& b)
+{
+  auto& residual_filter = *b.residual;
+
+  auto ref = duckdb::make_uniq<sirius::op::sirius_physical_twin_scan_ref>(
+    residual_filter.types, residual_filter.estimated_cardinality);
+  if (residual_filter.has_physical_overrides()) {
+    ref->set_physical_types(residual_filter.get_physical_types());
+  }
+  auto* ref_ptr = ref.get();
+
+  // Lift the residual out of the FILTER and take B's scan as the fused scan before the
+  // FILTER node is destroyed by the slot replacement below.
+  auto residual_expr = std::move(residual_filter.expression);
+  auto output_mask_b = std::move(residual_filter.output_columns);
+  auto types_b       = residual_filter.types;
+  auto fused_scan    = std::move(residual_filter.children[0]);
+
+  auto& scan_b = fused_scan->Cast<sirius::op::sirius_physical_table_scan>();
+  auto chan_b  = scan_b.sirius_dynamic_filters;
+  // The fused scan consumes A's channel; A's producer indexes stay valid because A's
+  // column_ids are a prefix of B's (checked by match_scan_geometry). B's channel loses its
+  // only consumer -- close it so its producer join skips filter construction entirely.
+  scan_b.sirius_dynamic_filters = a.scan->sirius_dynamic_filters;
+  scan_b.dynamic_filters        = a.scan->dynamic_filters;
+  if (chan_b) { chan_b->close_for_new_filters(); }
+
+  std::vector<cudf::size_type> output_indices_a(a.scan->types.size());
+  std::iota(output_indices_a.begin(), output_indices_a.end(), 0);
+
+  auto split =
+    duckdb::make_uniq<sirius::op::sirius_physical_twin_scan_split>(a.scan->types,
+                                                                   std::move(output_indices_a),
+                                                                   std::move(residual_expr),
+                                                                   std::move(output_mask_b),
+                                                                   std::move(types_b),
+                                                                   a.scan->estimated_cardinality,
+                                                                   ref_ptr);
+  if (a.scan->has_physical_overrides()) { split->set_physical_types(a.scan->get_physical_types()); }
+  split->children.push_back(std::move(fused_scan));
+
+  *b.slot = std::move(ref);    // destroys the residual FILTER node
+  *a.slot = std::move(split);  // destroys A's scan node
+}
+
+}  // namespace
+
+std::string_view to_string(twin_scan_rejection_reason reason) noexcept
+{
+  using enum twin_scan_rejection_reason;
+  switch (reason) {
+    case columns_not_strict_prefix: return "columns_not_strict_prefix";
+    case output_layout_not_prefix: return "output_layout_not_prefix";
+    case output_types_not_prefix: return "output_types_not_prefix";
+    case physical_carriers_differ: return "physical_carriers_differ";
+    case static_filters_differ: return "static_filters_differ";
+    case channel_missing: return "channel_missing";
+    case channel_shared: return "channel_shared";
+    case channel_without_producer: return "channel_without_producer";
+    case channel_unscoped_producer: return "channel_unscoped_producer";
+    case channel_multi_target: return "channel_multi_target";
+    case channel_target_invalid: return "channel_target_invalid";
+    case channel_targets_differ: return "channel_targets_differ";
+    case producer_join_not_unique: return "producer_join_not_unique";
+    case producer_joins_identical: return "producer_joins_identical";
+    case build_not_delim_replay: return "build_not_delim_replay";
+    case delim_joins_identical: return "delim_joins_identical";
+    case delim_chain_not_direct: return "delim_chain_not_direct";
+    case join_back_not_row_subset: return "join_back_not_row_subset";
+    case delim_distinct_missing: return "delim_distinct_missing";
+    case delim_key_refs_differ: return "delim_key_refs_differ";
+    case producer_key_not_single_equality: return "producer_key_not_single_equality";
+    case producer_keys_differ: return "producer_keys_differ";
+    case producer_key_outside_delim_output: return "producer_key_outside_delim_output";
+  }
+  return "unknown_rejection_reason";
+}
+
+twin_scan_fusion_report fuse_twin_scans(
+  duckdb::unique_ptr<sirius::op::sirius_physical_operator>& plan)
+{
+  twin_scan_fusion_report report;
+  bool changed = true;
+  // Re-walk after every rewrite: a fusion invalidates collected slots. O(sites^2) per
+  // iteration is irrelevant at planner scale. A same-table rejection is recorded once per
+  // ordered pair per walk iteration.
+  while (changed) {
+    changed     = false;
+    auto census = collect_sites(plan);
+
+    // Candidate census: one line per collected site so a detection gap is diagnosable from
+    // the log without a debugger (which shape was collected, with what geometry).
+    for (auto const& s : census.sites) {
+      SIRIUS_LOG_DEBUG("[twin_scan_fusion] site fn={} residual={} {}",
+                       s.scan->function.name,
+                       s.residual != nullptr,
+                       describe_scan_geometry(*s.scan));
+    }
+
+    for (auto& a : census.sites) {
+      if (a.residual != nullptr) { continue; }
+      for (auto& b : census.sites) {
+        if (b.residual == nullptr || a.scan == b.scan) { continue; }
+        if (!same_table_identity(*a.scan, *b.scan)) { continue; }
+        auto reject = match_scan_geometry(*a.scan, *b.scan);
+        if (!reject.has_value()) {
+          reject = prove_channel_subsumption(*a.scan, *b.scan, census.all);
+        }
+        if (reject.has_value()) {
+          // A same-table candidate pair that fails a condition is rare (a handful per query
+          // at most) and names an actionable detection gap -- worth INFO and a report record.
+          auto geometry_a = describe_scan_geometry(*a.scan);
+          auto geometry_b = describe_scan_geometry(*b.scan);
+          SIRIUS_LOG_INFO("[twin_scan_fusion] same-table pair rejected: {} | A: {} | B: {}",
+                          to_string(*reject),
+                          geometry_a,
+                          geometry_b);
+          report.same_table_rejections.push_back(
+            {*reject, std::move(geometry_a), std::move(geometry_b)});
+          continue;
+        }
+        std::string table_name = a.scan->function.name;
+        if (auto const* bind =
+              dynamic_cast<duckdb::TableScanBindData const*>(a.scan->bind_data.get())) {
+          table_name = bind->table.name;
+        }
+        SIRIUS_LOG_INFO(
+          "[twin_scan_fusion] fusing twin scans of '{}': shared {} columns + {} residual-only "
+          "columns, shared dynamic-filter channel adopted from the wider key set",
+          table_name,
+          a.scan->types.size(),
+          b.scan->types.size() - a.scan->types.size());
+        fuse_pair(a, b);
+        ++report.fused_pairs;
+        changed = true;
+        break;
+      }
+      if (changed) { break; }
+    }
+  }
+  return report;
+}
+
+}  // namespace sirius::planner

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -279,6 +279,7 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
     "dynamic_filter_keep_threshold", opt.dynamic_filter_keep_threshold, yaml::fraction<double>{});
   r.optional("enable_pinned_zone_map_pruning", opt.enable_pinned_zone_map_pruning);
   r.optional("enable_compressed_materialization", opt.enable_compressed_materialization);
+  r.optional("fuse_twin_scans", opt.fuse_twin_scans);
   r.reject_unknown();
 }
 

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1829,6 +1829,11 @@ static void SetFuseMergePipelines(ClientContext& /*context*/,
   // DuckDB stores this setting in the client context.
 }
 
+static void SetFuseTwinScans(ClientContext& /*context*/, SetScope /*scope*/, Value& /*parameter*/)
+{
+  // DuckDB stores this setting in the client context.
+}
+
 static sirius::operator_params* get_operator_params(ClientContext& context)
 {
   auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
@@ -2270,6 +2275,13 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
                             LogicalType::BOOLEAN,
                             Value::BOOLEAN(true),
                             SetFuseMergePipelines);
+
+  // Default from the YAML-loaded params, so a sirius.yaml value is what connections inherit.
+  config.AddExtensionOption("fuse_twin_scans",
+                            "Fuse near-duplicate same-table scans into one fan-out scan pipeline",
+                            LogicalType::BOOLEAN,
+                            Value::BOOLEAN(operator_defaults.fuse_twin_scans),
+                            SetFuseTwinScans);
 
   // Add in config options for duckdb scan task
   // Default batch size

--- a/test/cpp/config/data/setting_defaults.yaml
+++ b/test/cpp/config/data/setting_defaults.yaml
@@ -30,6 +30,7 @@ sirius:
     dynamic_filter_keep_threshold: 0.7
     enable_pinned_zone_map_pruning: false
     enable_compressed_materialization: false
+    fuse_twin_scans: false
   compression:
     enable_pin_table_compression: true
     min_batch_size_bytes: 8MiB

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -143,11 +143,12 @@ constexpr std::array<setting_assignment, 10> legacy_only_settings{{
   {"modified_pipeline", "true"},
 }};
 
-constexpr std::array<const char*, 5> super_sirius_settings{{
+constexpr std::array<const char*, 6> super_sirius_settings{{
   "expression_evaluator_strategy",
   "enable_regex_jit_impl",
   "enable_duckdb_fallback",
   "fuse_merge_pipelines",
+  "fuse_twin_scans",
   "scan_task_batch_size",
 }};
 }  // namespace
@@ -790,7 +791,8 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
       current_setting('pin_table_input_compression_plan_dir')::VARCHAR,
       current_setting('pin_table_compression_min_batch_size_bytes')::UBIGINT,
       current_setting('pin_table_compression_max_compressed_fraction')::DOUBLE,
-      current_setting('enable_runtime_distinct_build_probe')::BOOLEAN
+      current_setting('enable_runtime_distinct_build_probe')::BOOLEAN,
+      current_setting('fuse_twin_scans')::BOOLEAN
   )");
   REQUIRE(settings != nullptr);
   REQUIRE_FALSE(settings->HasError());
@@ -816,6 +818,7 @@ TEST_CASE("YAML-backed operator and compression settings are DuckDB defaults",
   REQUIRE(settings->GetValue(17, 0).GetValue<uint64_t>() == 8 * mib);
   REQUIRE(settings->GetValue(18, 0).GetValue<double>() == Approx(0.6));
   REQUIRE_FALSE(settings->GetValue(19, 0).GetValue<bool>());
+  REQUIRE_FALSE(settings->GetValue(20, 0).GetValue<bool>());
 
   auto zero_partition = con.Query("SET hash_partition_bytes = 0");
   REQUIRE(zero_partition != nullptr);

--- a/test/cpp/planner/plan_test_harness.hpp
+++ b/test/cpp/planner/plan_test_harness.hpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+/**
+ * @file plan_test_harness.hpp
+ * @brief SQL -> Sirius physical plan harness shared by the planner shape suites
+ *        (test_plan_tree_shape.cpp, test_twin_scan_fusion.cpp): an on-disk temp database
+ *        (the GPU-native seq_scan ingestible refuses non-single-file block managers), plan
+ *        generation via Parser -> Planner -> Optimizer ->
+ *        `sirius_physical_plan_generator::create_plan`, and tree walkers that descend into
+ *        DELIM JOIN internal `join`/`distinct_root` subtrees.
+ */
+
+#include "op/sirius_physical_delim_join.hpp"
+#include "op/sirius_physical_operator.hpp"
+#include "planner/sirius_physical_plan_generator.hpp"
+#include "planner/sirius_plan_twin_scan_fusion.hpp"
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/execution/column_binding_resolver.hpp>
+#include <duckdb/main/config.hpp>
+#include <duckdb/optimizer/optimizer.hpp>
+#include <duckdb/parser/parser.hpp>
+#include <duckdb/planner/planner.hpp>
+#include <unistd.h>
+
+#include <cstdio>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace sirius::test {
+
+/// RAII on-disk DuckDB path: the GPU-native seq_scan ingestible refuses non-single-file
+/// block managers, so plan-shape tests need an on-disk database rather than :memory:.
+class scoped_temp_db_path {
+ public:
+  scoped_temp_db_path()
+  {
+    char tmpl[] = "/tmp/sirius_plan_test_XXXXXX";
+    int fd      = ::mkstemp(tmpl);
+    REQUIRE(fd >= 0);
+    ::close(fd);
+    ::unlink(tmpl);
+    _path = tmpl;
+  }
+
+  ~scoped_temp_db_path()
+  {
+    if (!_path.empty()) {
+      std::remove(_path.c_str());
+      std::remove((_path + ".wal").c_str());
+    }
+  }
+
+  scoped_temp_db_path(const scoped_temp_db_path&)            = delete;
+  scoped_temp_db_path& operator=(const scoped_temp_db_path&) = delete;
+
+  const std::string& path() const { return _path; }
+
+ private:
+  std::string _path;
+};
+
+/// Generate a Sirius physical plan from a SQL query string. Throws on any failure (after
+/// rolling back and restoring the optimizer settings) so a planner regression fails the
+/// test instead of silently skipping it. When @p fusion_report is non-null it receives the
+/// generator's `twin_scan_report()`. The defaulted optimizer mask keeps IN_CLAUSE,
+/// COMPRESSED_MATERIALIZATION, and STATISTICS_PROPAGATION disabled: both suites are
+/// shape-sensitive, and disabling STATISTICS_PROPAGATION lets the deliminator retain the
+/// DELIM_JOINs they assert on.
+inline duckdb::unique_ptr<sirius::op::sirius_physical_operator> generate_sirius_plan(
+  duckdb::Connection& con,
+  const std::string& query,
+  sirius::planner::twin_scan_fusion_report* fusion_report                = nullptr,
+  const duckdb::vector<duckdb::OptimizerType>& extra_disabled_optimizers = {
+    duckdb::OptimizerType::IN_CLAUSE,
+    duckdb::OptimizerType::COMPRESSED_MATERIALIZATION,
+    duckdb::OptimizerType::STATISTICS_PROPAGATION})
+{
+  auto& context = *con.context;
+
+  auto original_disabled = duckdb::DBConfig::GetConfig(context).options.disabled_optimizers;
+  auto& disabled         = duckdb::DBConfig::GetConfig(context).options.disabled_optimizers;
+  for (auto const optimizer : extra_disabled_optimizers) {
+    disabled.insert(optimizer);
+  }
+
+  con.Query("BEGIN TRANSACTION");
+
+  duckdb::unique_ptr<sirius::op::sirius_physical_operator> result;
+  try {
+    duckdb::Parser parser(context.GetParserOptions());
+    parser.ParseQuery(query);
+    REQUIRE(!parser.statements.empty());
+
+    duckdb::Planner planner(context);
+    planner.CreatePlan(std::move(parser.statements[0]));
+    REQUIRE(planner.plan);
+
+    auto plan = std::move(planner.plan);
+
+    if (context.config.enable_optimizer) {
+      duckdb::Optimizer optimizer(*planner.binder, context);
+      plan = optimizer.Optimize(std::move(plan));
+    }
+
+    plan->ResolveOperatorTypes();
+
+    duckdb::ColumnBindingResolver resolver;
+    duckdb::ColumnBindingResolver::Verify(*plan);
+    resolver.VisitOperator(*plan);
+
+    sirius::planner::sirius_physical_plan_generator gen(context);
+    result = gen.create_plan(std::move(plan));
+    if (fusion_report != nullptr) { *fusion_report = gen.twin_scan_report(); }
+  } catch (...) {
+    con.Query("ROLLBACK");
+    duckdb::DBConfig::GetConfig(context).options.disabled_optimizers = original_disabled;
+    throw;
+  }
+
+  con.Query("COMMIT");
+  duckdb::DBConfig::GetConfig(context).options.disabled_optimizers = original_disabled;
+  return result;
+}
+
+/// Visit every operator in the tree, including DELIM JOIN internal `join`/`distinct_root`
+/// subtrees (owned outside `children[]`).
+template <typename Fn>
+void for_each_operator(sirius::op::sirius_physical_operator* root, const Fn& fn)
+{
+  if (!root) { return; }
+  fn(root);
+  for (auto& child : root->children) {
+    for_each_operator(child.get(), fn);
+  }
+  if (root->type == sirius::op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN ||
+      root->type == sirius::op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
+    auto& delim = root->Cast<sirius::op::sirius_physical_delim_join>();
+    for_each_operator(delim.join.get(), fn);
+    for_each_operator(delim.distinct_root.get(), fn);
+  }
+}
+
+inline std::vector<sirius::op::sirius_physical_operator*> collect(
+  sirius::op::sirius_physical_operator* root, sirius::op::SiriusPhysicalOperatorType type)
+{
+  std::vector<sirius::op::sirius_physical_operator*> out;
+  for_each_operator(root, [&](sirius::op::sirius_physical_operator* op) {
+    if (op->type == type) { out.push_back(op); }
+  });
+  return out;
+}
+
+inline sirius::op::sirius_physical_operator* find_first(sirius::op::sirius_physical_operator* root,
+                                                        sirius::op::SiriusPhysicalOperatorType type)
+{
+  auto all = collect(root, type);
+  return all.empty() ? nullptr : all.front();
+}
+
+inline bool contains(sirius::op::sirius_physical_operator* root,
+                     const sirius::op::sirius_physical_operator* target)
+{
+  bool found = false;
+  for_each_operator(root, [&](sirius::op::sirius_physical_operator* op) {
+    if (op == target) { found = true; }
+  });
+  return found;
+}
+
+/// Render the tree (including delim-join internals) for failure diagnostics.
+inline void tree_to_string(sirius::op::sirius_physical_operator* root,
+                           int depth,
+                           std::ostringstream& out)
+{
+  if (!root) { return; }
+  out << std::string(static_cast<size_t>(depth) * 2, ' ')
+      << sirius::op::SiriusPhysicalOperatorToString(root->type) << "\n";
+  for (auto& child : root->children) {
+    tree_to_string(child.get(), depth + 1, out);
+  }
+  if (root->type == sirius::op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN ||
+      root->type == sirius::op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
+    auto& delim = root->Cast<sirius::op::sirius_physical_delim_join>();
+    out << std::string(static_cast<size_t>(depth + 1) * 2, ' ') << "(join)\n";
+    tree_to_string(delim.join.get(), depth + 2, out);
+    out << std::string(static_cast<size_t>(depth + 1) * 2, ' ') << "(distinct_root)\n";
+    tree_to_string(delim.distinct_root.get(), depth + 2, out);
+  }
+}
+
+inline std::string tree_to_string(sirius::op::sirius_physical_operator* root)
+{
+  std::ostringstream out;
+  tree_to_string(root, 0, out);
+  return out.str();
+}
+
+}  // namespace sirius::test

--- a/test/cpp/planner/test_plan_tree_shape.cpp
+++ b/test/cpp/planner/test_plan_tree_shape.cpp
@@ -37,27 +37,20 @@
 #include "op/sirius_physical_nested_loop_join.hpp"
 #include "op/sirius_physical_partition.hpp"
 #include "op/sirius_physical_projection.hpp"
+#include "plan_test_harness.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
 #include <cudf/types.hpp>
 
 #include <catch.hpp>
 #include <duckdb.hpp>
-#include <duckdb/execution/column_binding_resolver.hpp>
-#include <duckdb/main/config.hpp>
-#include <duckdb/optimizer/optimizer.hpp>
-#include <duckdb/parser/parser.hpp>
 #include <duckdb/planner/expression/bound_function_expression.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
 #include <duckdb/planner/filter/expression_filter.hpp>
 #include <duckdb/planner/operator/logical_dummy_scan.hpp>
 #include <duckdb/planner/operator/logical_get.hpp>
-#include <duckdb/planner/planner.hpp>
-#include <unistd.h>
 
-#include <cstdio>
 #include <filesystem>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -65,163 +58,14 @@ using namespace duckdb;
 
 using sirius::op::sirius_physical_operator;
 using sirius::op::SiriusPhysicalOperatorType;
+using sirius::test::collect;
+using sirius::test::contains;
+using sirius::test::find_first;
+using sirius::test::generate_sirius_plan;
+using sirius::test::scoped_temp_db_path;
+using sirius::test::tree_to_string;
 
 namespace {
-
-/// RAII on-disk DuckDB path: the GPU-native seq_scan ingestible refuses non-single-file
-/// block managers, so these tests need an on-disk database rather than :memory:.
-class scoped_temp_db_path {
- public:
-  scoped_temp_db_path()
-  {
-    char tmpl[] = "/tmp/sirius_plan_tree_shape_XXXXXX";
-    int fd      = ::mkstemp(tmpl);
-    REQUIRE(fd >= 0);
-    ::close(fd);
-    ::unlink(tmpl);
-    _path = tmpl;
-  }
-
-  ~scoped_temp_db_path()
-  {
-    if (!_path.empty()) {
-      std::remove(_path.c_str());
-      std::remove((_path + ".wal").c_str());
-    }
-  }
-
-  scoped_temp_db_path(const scoped_temp_db_path&)            = delete;
-  scoped_temp_db_path& operator=(const scoped_temp_db_path&) = delete;
-
-  const std::string& path() const { return _path; }
-
- private:
-  std::string _path;
-};
-
-/// Generate a Sirius physical plan from a SQL query string. Throws on any failure (after
-/// rolling back and restoring the optimizer settings) so a planner regression fails the
-/// test instead of silently skipping it.
-duckdb::unique_ptr<sirius_physical_operator> generate_sirius_plan(Connection& con,
-                                                                  const std::string& query)
-{
-  auto& context = *con.context;
-
-  auto original_disabled = DBConfig::GetConfig(context).options.disabled_optimizers;
-  auto& disabled         = DBConfig::GetConfig(context).options.disabled_optimizers;
-  // Keep STATISTICS_PROPAGATION disabled only for this shape-sensitive suite:
-  // disabling it lets the deliminator retain the DELIM_JOINs asserted below.
-  disabled.insert(OptimizerType::IN_CLAUSE);
-  disabled.insert(OptimizerType::COMPRESSED_MATERIALIZATION);
-  disabled.insert(OptimizerType::STATISTICS_PROPAGATION);
-
-  con.Query("BEGIN TRANSACTION");
-
-  duckdb::unique_ptr<sirius_physical_operator> result;
-  try {
-    Parser parser(context.GetParserOptions());
-    parser.ParseQuery(query);
-    REQUIRE(!parser.statements.empty());
-
-    Planner planner(context);
-    planner.CreatePlan(std::move(parser.statements[0]));
-    REQUIRE(planner.plan);
-
-    auto plan = std::move(planner.plan);
-
-    if (context.config.enable_optimizer) {
-      Optimizer optimizer(*planner.binder, context);
-      plan = optimizer.Optimize(std::move(plan));
-    }
-
-    plan->ResolveOperatorTypes();
-
-    ColumnBindingResolver resolver;
-    ColumnBindingResolver::Verify(*plan);
-    resolver.VisitOperator(*plan);
-
-    sirius::planner::sirius_physical_plan_generator gen(context);
-    result = gen.create_plan(std::move(plan));
-  } catch (...) {
-    con.Query("ROLLBACK");
-    DBConfig::GetConfig(context).options.disabled_optimizers = original_disabled;
-    throw;
-  }
-
-  con.Query("COMMIT");
-  DBConfig::GetConfig(context).options.disabled_optimizers = original_disabled;
-  return result;
-}
-
-/// Visit every operator in the tree, including DELIM JOIN internal `join`/`distinct_root`
-/// subtrees (owned outside `children[]`).
-template <typename Fn>
-void for_each_operator(sirius_physical_operator* root, const Fn& fn)
-{
-  if (!root) { return; }
-  fn(root);
-  for (auto& child : root->children) {
-    for_each_operator(child.get(), fn);
-  }
-  if (root->type == SiriusPhysicalOperatorType::LEFT_DELIM_JOIN ||
-      root->type == SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
-    auto& delim = root->Cast<sirius::op::sirius_physical_delim_join>();
-    for_each_operator(delim.join.get(), fn);
-    for_each_operator(delim.distinct_root.get(), fn);
-  }
-}
-
-std::vector<sirius_physical_operator*> collect(sirius_physical_operator* root,
-                                               SiriusPhysicalOperatorType type)
-{
-  std::vector<sirius_physical_operator*> out;
-  for_each_operator(root, [&](sirius_physical_operator* op) {
-    if (op->type == type) { out.push_back(op); }
-  });
-  return out;
-}
-
-sirius_physical_operator* find_first(sirius_physical_operator* root,
-                                     SiriusPhysicalOperatorType type)
-{
-  auto all = collect(root, type);
-  return all.empty() ? nullptr : all.front();
-}
-
-bool contains(sirius_physical_operator* root, const sirius_physical_operator* target)
-{
-  bool found = false;
-  for_each_operator(root, [&](sirius_physical_operator* op) {
-    if (op == target) { found = true; }
-  });
-  return found;
-}
-
-/// Render the tree (including delim-join internals) for failure diagnostics.
-void tree_to_string(sirius_physical_operator* root, int depth, std::ostringstream& out)
-{
-  if (!root) { return; }
-  out << std::string(static_cast<size_t>(depth) * 2, ' ')
-      << sirius::op::SiriusPhysicalOperatorToString(root->type) << "\n";
-  for (auto& child : root->children) {
-    tree_to_string(child.get(), depth + 1, out);
-  }
-  if (root->type == SiriusPhysicalOperatorType::LEFT_DELIM_JOIN ||
-      root->type == SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
-    auto& delim = root->Cast<sirius::op::sirius_physical_delim_join>();
-    out << std::string(static_cast<size_t>(depth + 1) * 2, ' ') << "(join)\n";
-    tree_to_string(delim.join.get(), depth + 2, out);
-    out << std::string(static_cast<size_t>(depth + 1) * 2, ' ') << "(distinct_root)\n";
-    tree_to_string(delim.distinct_root.get(), depth + 2, out);
-  }
-}
-
-std::string tree_to_string(sirius_physical_operator* root)
-{
-  std::ostringstream out;
-  tree_to_string(root, 0, out);
-  return out.str();
-}
 
 duckdb::unique_ptr<duckdb::Expression> untranslatable_table_filter_expression()
 {

--- a/test/cpp/planner/test_twin_scan_fusion.cpp
+++ b/test/cpp/planner/test_twin_scan_fusion.cpp
@@ -1,0 +1,485 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_twin_scan_fusion.cpp
+ * @brief Contract tests for the twin-scan fusion pass (`fuse_twin_scans`): the multi-key
+ *        positive match, the `fuse_twin_scans` setting toggle, one pinned rejection reason
+ *        per refusal shape from the `twin_scan_fusion_report`, and GPU execution equivalence
+ *        between the fused and unfused plans.
+ *
+ * Every case follows the positive-control discipline: before asserting the fusion outcome it
+ * asserts the precondition shape it claims to exercise, so a DuckDB plan-shape drift fails the
+ * test loudly instead of letting a refusal pass vacuously. The canonical schema mirrors TPC-H
+ * q21's structure without its names: chained EXISTS / NOT EXISTS over one table, correlated on
+ * an equality (k) plus a non-equality (s) -- a multi-column delim key tuple -- with the NOT
+ * EXISTS side carrying the residual predicate d2 > d1.
+ */
+
+#include "op/sirius_physical_delim_join.hpp"
+#include "op/sirius_physical_grouped_aggregate.hpp"
+#include "op/sirius_physical_hash_join.hpp"
+#include "op/sirius_physical_operator.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "plan_test_harness.hpp"
+#include "planner/sirius_plan_twin_scan_fusion.hpp"
+#include "sirius_engine.hpp"
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <utils/gpu_execution_fixture.hpp>
+#include <utils/pipeline_conversion_test_utils.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace duckdb;
+
+using sirius::op::sirius_physical_operator;
+using sirius::op::SiriusPhysicalOperatorType;
+using sirius::planner::twin_scan_fusion_report;
+using sirius::planner::twin_scan_rejection_reason;
+using sirius::test::collect;
+using sirius::test::find_first;
+using sirius::test::generate_sirius_plan;
+using sirius::test::scoped_temp_db_path;
+using sirius::test::tree_to_string;
+
+namespace {
+
+// Column declaration order is load-bearing: the prefix property compares column_ids in table
+// order, so the EXISTS side's columns {k, s} must precede the NOT EXISTS side's residual-only
+// columns {d1, d2}; `pad` exists to break the prefix in the non-prefix refusal case.
+constexpr const char* kCreateTwinTable =
+  "CREATE TABLE t(k BIGINT, s BIGINT, d1 DATE, d2 DATE, pad INTEGER)";
+
+// Deterministic rows (range + modular values) so plans are stable: enough distinct k groups
+// for the delim distinct to matter, s varying within each k group so the <> correlations are
+// selective, and d1/d2 phases making the residual d2 > d1 keep roughly half the rows.
+constexpr const char* kPopulateTwinTable =
+  "INSERT INTO t SELECT range % 50, range % 7, DATE '2024-01-01' + (range % 30)::INTEGER, "
+  "DATE '2024-01-01' + (range % 45)::INTEGER, (range % 11)::INTEGER FROM range(400)";
+
+// The positive query: q21's structure with no TPC-H names. A = the bare EXISTS scan needing
+// {k, s}; B = the NOT EXISTS scan needing {k, s, d1, d2} with the residual d2 > d1. The
+// correlation is the multi-key delim tuple (equality on k, <> on s). The OUTER residual
+// o.d2 > o.d1 (q21's own l1 filter) is load-bearing: without it the deliminator flattens the
+// EXISTS into a plain semi join and no delim chain exists to fuse over.
+constexpr const char* kPositiveQuery =
+  "SELECT count(*) FROM t o "
+  "WHERE o.d2 > o.d1 "
+  "  AND EXISTS     (SELECT 1 FROM t i WHERE i.k = o.k AND i.s <> o.s) "
+  "  AND NOT EXISTS (SELECT 1 FROM t j WHERE j.k = o.k AND j.s <> o.s AND j.d2 > j.d1)";
+
+/// `fuse_twin_scans` is a per-connection DuckDB setting, so the toggle is driven with
+/// `SET`/`RESET` on the connection the plan is generated on.
+class twin_fusion_flag_guard {
+ public:
+  twin_fusion_flag_guard(duckdb::Connection& con, bool enabled) : _con(con)
+  {
+    _con.Query(std::string("SET fuse_twin_scans = ") + (enabled ? "true" : "false") + ";");
+  }
+
+  ~twin_fusion_flag_guard() { _con.Query("RESET fuse_twin_scans;"); }
+
+  twin_fusion_flag_guard(const twin_fusion_flag_guard&)            = delete;
+  twin_fusion_flag_guard& operator=(const twin_fusion_flag_guard&) = delete;
+
+ private:
+  duckdb::Connection& _con;
+};
+
+bool contains_reason(const twin_scan_fusion_report& report, twin_scan_rejection_reason reason)
+{
+  return std::any_of(report.same_table_rejections.begin(),
+                     report.same_table_rejections.end(),
+                     [&](const auto& rejection) { return rejection.reason == reason; });
+}
+
+std::string report_to_string(const twin_scan_fusion_report& report)
+{
+  std::string out = "fused_pairs=" + std::to_string(report.fused_pairs) + " rejections=[";
+  for (const auto& rejection : report.same_table_rejections) {
+    out += std::string(sirius::planner::to_string(rejection.reason)) + " ";
+  }
+  out += "]";
+  return out;
+}
+
+/// Whether any delim join in the plan carries a distinct over at least two group columns --
+/// the positive control that the correlation produced a MULTI-key delim tuple (the shipped
+/// single-key-only draft bug would have made the positive case below pass for the wrong
+/// reason without this).
+bool has_multi_key_delim_distinct(sirius_physical_operator* root)
+{
+  bool found = false;
+  sirius::test::for_each_operator(root, [&](sirius_physical_operator* op) {
+    if (op->type != SiriusPhysicalOperatorType::LEFT_DELIM_JOIN &&
+        op->type != SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
+      return;
+    }
+    auto& delim = op->Cast<sirius::op::sirius_physical_delim_join>();
+    if (delim.distinct != nullptr && delim.distinct->group_idx.size() >= 2) { found = true; }
+  });
+  return found;
+}
+
+struct twin_scan_fusion_fixture {
+  twin_scan_fusion_fixture()
+  {
+    auto cfg = std::filesystem::path(SIRIUS_PROJECT_ROOT) / "test" / "cpp" / "config" / "data" /
+               "minimal.yaml";
+    setenv("SIRIUS_CONFIG_FILE", cfg.string().c_str(), 1);
+    unsetenv("SIRIUS_DISABLE");
+    db = std::make_unique<DuckDB>(_db_path.path());
+    setenv("SIRIUS_DISABLE", "1", 1);
+    con = std::make_unique<Connection>(*db);
+
+    con->Query(kCreateTwinTable);
+    con->Query(kPopulateTwinTable);
+  }
+
+  ~twin_scan_fusion_fixture() { unsetenv("SIRIUS_CONFIG_FILE"); }
+
+  /// Plan @p query on the fixture connection and capture the generator's fusion report.
+  duckdb::unique_ptr<sirius_physical_operator> plan_with_report(const std::string& query,
+                                                                twin_scan_fusion_report& report)
+  {
+    return generate_sirius_plan(*con, query, &report);
+  }
+
+  // Declared before db/con so the backing file outlives the database.
+  scoped_temp_db_path _db_path;
+  std::unique_ptr<DuckDB> db;
+  std::unique_ptr<Connection> con;
+};
+
+}  // namespace
+
+TEST_CASE_METHOD(twin_scan_fusion_fixture,
+                 "twin scan fusion - multi-key tuple pair fuses into split + ref",
+                 "[twin_scan_fusion][isolated_context]")
+{
+  // Knob-off baseline: the twin shape must exist unfused before the knob-on plan may claim a
+  // fusion (positive control against plan-shape drift).
+  std::size_t unfused_scan_count = 0;
+  {
+    twin_fusion_flag_guard guard(*con, /*enabled=*/false);
+    twin_scan_fusion_report report;
+    auto plan = plan_with_report(kPositiveQuery, report);
+    INFO(tree_to_string(plan.get()));
+    REQUIRE(report.fused_pairs == 0);
+    CHECK(collect(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT).empty());
+
+    // Producer-backed channels on at least the two twin scans: each is rewritten into a
+    // GPU_SCAN wrapped by a DYNAMIC_FILTER only when its channel has producers.
+    REQUIRE(collect(plan.get(), SiriusPhysicalOperatorType::DYNAMIC_FILTER).size() >= 2);
+    // The multi-key positive control: the correlation (k equality + s <>) must have produced
+    // a delim distinct over >= 2 group columns.
+    REQUIRE(has_multi_key_delim_distinct(plan.get()));
+
+    unfused_scan_count = collect(plan.get(), SiriusPhysicalOperatorType::GPU_SCAN).size();
+    REQUIRE(unfused_scan_count >= 3);  // o, i, and j all scan t
+  }
+
+  twin_fusion_flag_guard guard(*con, /*enabled=*/true);
+  twin_scan_fusion_report report;
+  auto plan = plan_with_report(kPositiveQuery, report);
+  INFO(tree_to_string(plan.get()));
+  INFO(report_to_string(report));
+
+  REQUIRE(report.fused_pairs == 1);
+  REQUIRE(collect(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT).size() == 1);
+  REQUIRE(collect(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_REF).size() == 1);
+  // The fused plan decodes t one time fewer.
+  CHECK(collect(plan.get(), SiriusPhysicalOperatorType::GPU_SCAN).size() == unfused_scan_count - 1);
+  // The fused pipeline shape: the split consumes the shared GPU_SCAN -> DYNAMIC_FILTER stream.
+  auto* split = find_first(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT);
+  REQUIRE(split != nullptr);
+  CHECK(find_first(split, SiriusPhysicalOperatorType::GPU_SCAN) != nullptr);
+  CHECK(find_first(split, SiriusPhysicalOperatorType::DYNAMIC_FILTER) != nullptr);
+  CHECK(has_multi_key_delim_distinct(plan.get()));
+}
+
+TEST_CASE_METHOD(twin_scan_fusion_fixture,
+                 "twin scan fusion - the fuse_twin_scans setting toggles the pass",
+                 "[twin_scan_fusion][isolated_context]")
+{
+  {
+    twin_fusion_flag_guard guard(*con, /*enabled=*/false);
+    twin_scan_fusion_report report;
+    auto plan = plan_with_report(kPositiveQuery, report);
+    INFO(tree_to_string(plan.get()));
+    // Knob off: the pass never ran, so the report is the default -- no fusions AND no
+    // rejection records.
+    CHECK(report.fused_pairs == 0);
+    CHECK(report.same_table_rejections.empty());
+    CHECK(collect(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT).empty());
+    CHECK(collect(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_REF).empty());
+  }
+  {
+    twin_fusion_flag_guard guard(*con, /*enabled=*/true);
+    twin_scan_fusion_report report;
+    auto plan = plan_with_report(kPositiveQuery, report);
+    INFO(tree_to_string(plan.get()));
+    CHECK(report.fused_pairs == 1);
+    CHECK(collect(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT).size() == 1);
+  }
+}
+
+TEST_CASE_METHOD(twin_scan_fusion_fixture,
+                 "twin scan fusion - refusal: multi-target channel",
+                 "[twin_scan_fusion][isolated_context]")
+{
+  // Two single-key equality joins into the outer scan make o's channel plan filters on two
+  // columns -- q21's own l2 x l1 near-miss shape, where the outer's residual-filtered scan is
+  // itself a candidate B whose channel is fed by two unrelated producer joins. The u1/u2
+  // predicates matter: producers are only wired for filtered (or derived) build sides, since
+  // an unfiltered base-table build covers the whole key domain. They filter on `w` (never a
+  // join key) so no transitive predicate leaks into the t-scans' static filters. The
+  // legitimate (i, j) pair must still fuse; the (i, o) pair must be refused with the pinned
+  // reason.
+  con->Query("CREATE TABLE u1(k BIGINT, w BIGINT)");
+  con->Query("INSERT INTO u1 SELECT range % 50, range FROM range(20)");
+  con->Query("CREATE TABLE u2(s BIGINT, w BIGINT)");
+  con->Query("INSERT INTO u2 SELECT range % 7, range FROM range(20)");
+
+  const std::string query =
+    "SELECT count(*) FROM t o JOIN u1 ON o.k = u1.k JOIN u2 ON o.s = u2.s "
+    "WHERE o.d2 > o.d1 AND u1.w < 100 AND u2.w < 100 "
+    "  AND EXISTS     (SELECT 1 FROM t i WHERE i.k = o.k AND i.s <> o.s) "
+    "  AND NOT EXISTS (SELECT 1 FROM t j WHERE j.k = o.k AND j.s <> o.s AND j.d2 > j.d1)";
+
+  twin_fusion_flag_guard guard(*con, /*enabled=*/true);
+  twin_scan_fusion_report report;
+  auto plan = plan_with_report(query, report);
+  INFO(tree_to_string(plan.get()));
+  INFO(report_to_string(report));
+
+  // Positive control: besides the fused pipeline's shared channel, o's scan carries its own
+  // producer-backed channel (a scan is wrapped by a DYNAMIC_FILTER only then) -- so the
+  // multi-target rejection below judged a real two-producer channel, not a missing one.
+  REQUIRE(collect(plan.get(), SiriusPhysicalOperatorType::DYNAMIC_FILTER).size() >= 2);
+
+  // The rejection reason is pinned: geometry passes (o's {k, s} is a prefix of j's columns),
+  // so the pair fails at the channel checks, on the multi-target condition.
+  CHECK(contains_reason(report, twin_scan_rejection_reason::channel_multi_target));
+  // fused_pairs counts only the legitimate pair.
+  CHECK(report.fused_pairs == 1);
+  CHECK(collect(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT).size() == 1);
+}
+
+TEST_CASE_METHOD(twin_scan_fusion_fixture,
+                 "twin scan fusion - refusal: non-nested key sets",
+                 "[twin_scan_fusion][isolated_context]")
+{
+  // The chain is broken: the subqueries correlate on different keys (equality on k vs
+  // equality on s), so keys(B) within keys(A) is not provable. j references k before s so
+  // both scans keep the declared column order and the pair survives the geometry stage --
+  // this case must fail in the PROOF stage.
+  const std::string query =
+    "SELECT count(*) FROM t o "
+    "WHERE o.d2 > o.d1 "
+    "  AND EXISTS     (SELECT 1 FROM t i WHERE i.k = o.k AND i.s <> o.s) "
+    "  AND NOT EXISTS (SELECT 1 FROM t j WHERE j.k <> o.k AND j.s = o.s AND j.d2 > j.d1)";
+
+  twin_fusion_flag_guard guard(*con, /*enabled=*/true);
+  twin_scan_fusion_report report;
+  auto plan = plan_with_report(query, report);
+  INFO(tree_to_string(plan.get()));
+  INFO(report_to_string(report));
+
+  // Positive control: the twin shape (two producer-backed channels, a residual FILTER) still
+  // exists; only the proof fails.
+  REQUIRE(collect(plan.get(), SiriusPhysicalOperatorType::DYNAMIC_FILTER).size() >= 2);
+  REQUIRE(!collect(plan.get(), SiriusPhysicalOperatorType::FILTER).empty());
+
+  CHECK(report.fused_pairs == 0);
+  CHECK(collect(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT).empty());
+  // Pinned by the check order: the diverging keys surface first at the channel obligations
+  // (i's channel targets k, j's targets s), before the delim-chain walk would also fail.
+  CHECK(contains_reason(report, twin_scan_rejection_reason::channel_targets_differ));
+}
+
+TEST_CASE_METHOD(twin_scan_fusion_fixture,
+                 "twin scan fusion - refusal: multi-equality producer join",
+                 "[twin_scan_fusion][isolated_context]")
+{
+  // The NOT EXISTS side correlates on two equalities (k and s, plus a <> on d1 keeping the
+  // delim chain retained): its channel plans filters for both key columns, which the channel
+  // checks refuse before the single-equality producer check is ever reached.
+  const std::string query =
+    "SELECT count(*) FROM t o "
+    "WHERE o.d2 > o.d1 "
+    "  AND EXISTS     (SELECT 1 FROM t i WHERE i.k = o.k AND i.s <> o.s) "
+    "  AND NOT EXISTS (SELECT 1 FROM t j WHERE j.k = o.k AND j.s = o.s AND j.d1 <> o.d1 "
+    "                  AND j.d2 > j.d1)";
+
+  twin_fusion_flag_guard guard(*con, /*enabled=*/true);
+  twin_scan_fusion_report report;
+  auto plan = plan_with_report(query, report);
+  INFO(tree_to_string(plan.get()));
+  INFO(report_to_string(report));
+
+  REQUIRE(collect(plan.get(), SiriusPhysicalOperatorType::DYNAMIC_FILTER).size() >= 2);
+
+  CHECK(report.fused_pairs == 0);
+  CHECK(collect(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT).empty());
+  // Pinned by the check order: the two-equality correlation surfaces as a two-column channel
+  // before the single-equality producer check could see it.
+  CHECK(contains_reason(report, twin_scan_rejection_reason::channel_multi_target));
+}
+
+TEST_CASE_METHOD(twin_scan_fusion_fixture,
+                 "twin scan fusion - refusal: columns not a strict prefix",
+                 "[twin_scan_fusion][isolated_context]")
+{
+  // The EXISTS side additionally needs `pad` (declared AFTER d1/d2), so A's columns
+  // {k, s, pad} are not a prefix of B's {k, s, d1, d2}.
+  const std::string query =
+    "SELECT count(*) FROM t o "
+    "WHERE o.d2 > o.d1 "
+    "  AND EXISTS     (SELECT 1 FROM t i WHERE i.k = o.k AND i.s <> o.s AND i.pad = o.pad) "
+    "  AND NOT EXISTS (SELECT 1 FROM t j WHERE j.k = o.k AND j.s <> o.s AND j.d2 > j.d1)";
+
+  twin_fusion_flag_guard guard(*con, /*enabled=*/true);
+  twin_scan_fusion_report report;
+  auto plan = plan_with_report(query, report);
+  INFO(tree_to_string(plan.get()));
+  INFO(report_to_string(report));
+
+  REQUIRE(collect(plan.get(), SiriusPhysicalOperatorType::DYNAMIC_FILTER).size() >= 2);
+
+  CHECK(report.fused_pairs == 0);
+  CHECK(collect(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT).empty());
+  CHECK(contains_reason(report, twin_scan_rejection_reason::columns_not_strict_prefix));
+}
+
+TEST_CASE_METHOD(twin_scan_fusion_fixture,
+                 "twin scan fusion - refusal: static pushed filters differ",
+                 "[twin_scan_fusion][isolated_context]")
+{
+  // Positive control first: a constant comparison on this schema is pushed into the scan's
+  // table_filters, not planned as a FILTER node -- so `j.pad > 0` below lands as a static
+  // filter on j's scan only.
+  {
+    auto control = generate_sirius_plan(*con, "SELECT count(*) FROM t WHERE pad > 0");
+    INFO(tree_to_string(control.get()));
+    REQUIRE(collect(control.get(), SiriusPhysicalOperatorType::FILTER).empty());
+  }
+
+  const std::string query =
+    "SELECT count(*) FROM t o "
+    "WHERE o.d2 > o.d1 "
+    "  AND EXISTS     (SELECT 1 FROM t i WHERE i.k = o.k AND i.s <> o.s) "
+    "  AND NOT EXISTS (SELECT 1 FROM t j WHERE j.k = o.k AND j.s <> o.s AND j.d2 > j.d1 "
+    "                  AND j.pad > 0)";
+
+  twin_fusion_flag_guard guard(*con, /*enabled=*/true);
+  twin_scan_fusion_report report;
+  auto plan = plan_with_report(query, report);
+  INFO(tree_to_string(plan.get()));
+  INFO(report_to_string(report));
+
+  CHECK(report.fused_pairs == 0);
+  CHECK(collect(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT).empty());
+  CHECK(contains_reason(report, twin_scan_rejection_reason::static_filters_differ));
+}
+
+TEST_CASE_METHOD(twin_scan_fusion_fixture,
+                 "twin scan fusion - refusal: both scans carry residuals",
+                 "[twin_scan_fusion][isolated_context]")
+{
+  // Both subqueries carry a residual, so neither site matches the bare A shape and the pair
+  // is never collected: no fusion, no crash; an empty rejection list is acceptable because no
+  // bare-plus-filtered candidate pair exists.
+  const std::string query =
+    "SELECT count(*) FROM t o "
+    "WHERE o.d2 > o.d1 "
+    "  AND EXISTS     (SELECT 1 FROM t i WHERE i.k = o.k AND i.s <> o.s AND i.d2 > i.d1) "
+    "  AND NOT EXISTS (SELECT 1 FROM t j WHERE j.k = o.k AND j.s <> o.s AND j.d2 > j.d1)";
+
+  twin_fusion_flag_guard guard(*con, /*enabled=*/true);
+  twin_scan_fusion_report report;
+  auto plan = plan_with_report(query, report);
+  INFO(tree_to_string(plan.get()));
+  INFO(report_to_string(report));
+
+  // Positive control: both residual FILTERs exist over producer-backed scan pipelines.
+  REQUIRE(collect(plan.get(), SiriusPhysicalOperatorType::FILTER).size() >= 2);
+  REQUIRE(collect(plan.get(), SiriusPhysicalOperatorType::DYNAMIC_FILTER).size() >= 2);
+
+  CHECK(report.fused_pairs == 0);
+  CHECK(collect(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT).empty());
+  CHECK(collect(plan.get(), SiriusPhysicalOperatorType::TWIN_SCAN_REF).empty());
+}
+
+TEST_CASE_METHOD(sirius::test::GpuExecutionFixture,
+                 "twin scan fusion - GPU execution equivalence between fused and unfused plans",
+                 "[twin_scan_fusion][integration][gpu_execution]")
+{
+  run_ok(kCreateTwinTable);
+  // The residual d2 > d1 is tied to s so the NOT EXISTS stays satisfiable AND selective: with
+  // residual-passing rows spread across every s value, every k group would contain a
+  // different-s passer and the count would degenerate to zero (guarded below). Here only
+  // s = 0 passes everywhere and s = 1 passes in half the k groups, so the anti join keeps the
+  // s = 0 rows of the other half (358 of 5000) and genuinely drops the rest (715 rows).
+  run_ok(
+    "INSERT INTO t SELECT range % 50, range % 7, DATE '2024-01-01' + 10, DATE '2024-01-01' + "
+    "(CASE WHEN range % 7 = 0 THEN 20 WHEN range % 7 = 1 AND range % 50 < 25 THEN 20 ELSE 5 "
+    "END)::INTEGER, (range % 11)::INTEGER FROM range(5000)");
+  run_ok("CHECKPOINT");
+
+  // Positive control: under this connection's production planning the query actually fuses --
+  // otherwise the off/on comparison below would compare two identical unfused runs and never
+  // exercise the converter wiring, the PARTIAL edges, or sink() routing.
+  {
+    run_ok("SET fuse_twin_scans = true;");
+    sirius::test::with_initialized_engine(*con, kPositiveQuery, [&](sirius::sirius_engine& engine) {
+      bool has_split = false;
+      for (const auto& pipeline : engine.new_scheduled) {
+        for (const auto& op : pipeline->get_operators()) {
+          if (op.get().type == SiriusPhysicalOperatorType::TWIN_SCAN_SPLIT) { has_split = true; }
+        }
+      }
+      REQUIRE(has_split);
+    });
+  }
+
+  auto run_on_gpu = [&](bool fused) {
+    run_ok(std::string("SET fuse_twin_scans = ") + (fused ? "true" : "false") + ";");
+    // Proves the run executed on the GPU with no fallback AND matches DuckDB CPU -- a
+    // plan-time throw would silently fall back and make the off/on comparison vacuous.
+    compare_gpu_vs_cpu(kPositiveQuery);
+    run_ok("SET gpu_execution = true;");
+    auto result = con->Query(kPositiveQuery);
+    REQUIRE(result);
+    REQUIRE_FALSE(result->HasError());
+    return collect_rows(result->Cast<duckdb::MaterializedQueryResult>());
+  };
+
+  auto rows_unfused = run_on_gpu(/*fused=*/false);
+  auto rows_fused   = run_on_gpu(/*fused=*/true);
+  con->Query("RESET fuse_twin_scans;");
+
+  REQUIRE(rows_fused == rows_unfused);
+  // Guard against a degenerate dataset: the count must be a real, non-zero survivor set.
+  REQUIRE(rows_fused.size() == 1);
+  REQUIRE(std::stoll(rows_fused[0][0]) > 0);
+}


### PR DESCRIPTION
<!-- Edit PR title: "<type>[optional scope]: <short description>", see CONTRIBUTING.md for guidance -->

## Description

TPC-H q21 scans lineitem (6 B rows) three times; two of those scans are near-twins — the same
decoded columns (one adds two date columns) and a Bloom probe of nearly the same key set over
all 6 B rows, where one scan's predicate is the other's plus one extra conjunct. The engine
decodes and probes twice to produce two row sets, one a subset of the other.

This PR adds **twin-scan fusion**: a planner pass (`fuse_twin_scans`, own TU, staged as
collect → match → prove → rewrite) that detects such pairs and replaces them with one fused
scan → dynamic filter → a `TWIN_SCAN_SPLIT` fan-out (out-A = column-prefix copy for the wider
consumer; out-B = residual-filter application for the narrower one), with a routing-only
`TWIN_SCAN_REF` at the second plan site.

Safety is structural, stated as six invariants in the pass's header and enforced in code:
- **Prefix property**: fusion is attempted only when A's columns are a prefix of B's — every
  downstream column reference and dynamic-filter channel index stays valid by construction
  (no remapping exists to get wrong).
- **Key-set subsumption** proven from the delim-join chain (multi-key tuples supported;
  containment projected per column), so reusing the wider Bloom for both consumers is
  semantically safe — the downstream join is authoritative; measured cost +1.1% rows into the
  narrower consumer.
- Only **advisory (pruning) filters** may be dropped; static/correctness filters never.
- Producer coverage guarded (`has_unscoped_producer()` precondition), two-consumer wiring
  proven acyclic, and knob-off reproduces the unfused plan exactly (verified: 52-pipeline
  baseline parity).
- Every refusal returns a **typed rejection reason**, logged with plan geometry and exposed via
  a `twin_scan_fusion_report` getter — refusals are a tested contract, not debug noise.

Knob: `fuse_twin_scans` (SET + YAML, default on). Trade documented: one shared decode+Bloom
pipeline vs +1.1% superset rows and an out-A device copy.

## TPC-H SF1000 results (GB300, PR #1371 measurement-kit regime)

- **Detection scope (all 22 queries, plan-logged):** fusion fires **only** on q21's (l2,l3)
  pair (51 vs 52 pipelines); the tempting (l2,l1) pair is refused with the pinned
  `channel_multi_target` reason; all 22 error-free, six campaign queries byte-identical.
- **q21** (best-of-3 hot, ABBA legs vs base `7b69a9cc`): **803.1/826.5 → 739.1/742.7 ms
  (−64.0/−83.8 ms, 4.7–6.2× q21's between-run floor)**; confirmatory re-stamp pair at the
  final commit: 811.9 → 750.2 (−61.7 ms). Other five queries within their floors across legs.
- GPU pool peak ±1 MB; out_a/out_b row counts exact (350,861,503 / 245,930,136).
- Correctness: byte-identical results in every run (references themselves validated against a
  DuckDB-CPU oracle at SF1000); 22/22 GPU-path confirmed; `[twin_scan_fusion]` 9/9 unit cases
  (incl. a GPU execution-equivalence positive control and refusal-reason pinning),
  plan-tree-shape 12/12, config 47/47; full unit suite 2451/2457 with the 5 failures proven
  pre-existing at base (adjudication in the measurement records).

## Notes for reviewers

- The pass is a general same-table pattern (prefix columns + provably nested filter key-sets),
  not a q21 special case — but q21 is the only known TPC-H beneficiary; no speculative
  generalization was added beyond what tests pin.
- Known follow-up (non-blocking review finding): the fusion INFO line names `read_parquet`
  rather than the table on parquet scans; cheapest fix is falling back to the first resolved
  file path.

## Checklist
- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (docs/super-sirius/ rows + optimization notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
