### PR TITLE
feat(ffi): Rust bindings for sirius::ffi::Fragment

### DIFF
--- a/rust/crates/sirius-sys/src/lib.rs
+++ b/rust/crates/sirius-sys/src/lib.rs
@@ -5,9 +5,10 @@
 //! wrappers live in the [`sirius`](https://docs.rs/sirius) crate.
 //!
 //! The bridge binds Sirius's **public C++ surface** (`src/include/sirius_ffi.hpp`):
-//! an RAII [`Context`] held via [`cxx::UniquePtr`]. Constructing it brings up an
-//! initialized engine; dropping the `UniquePtr` tears it down. The header is
-//! lightweight, so the bridge compiles without any of Sirius's internal headers
+//! an RAII [`Context`] held via [`cxx::UniquePtr`], plus the [`Fragment`] it
+//! creates — one plan fragment of a multi-fragment query. Constructing a context
+//! brings up an initialized engine; dropping the `UniquePtr` tears it down. The
+//! header is lightweight, so the bridge compiles without any of Sirius's internal headers
 //! (cudf/rmm/duckdb). It is the seed of the public API `libsirius` will expose;
 //! the bindings link whichever Sirius artifact provides these symbols (the DuckDB
 //! extension today, a dedicated `libsirius` later — see `build.rs`).
@@ -55,7 +56,114 @@ mod ffi {
             plan: &CxxString,
             out_stream_addr: usize,
         ) -> Result<()>;
+
+        /// One plan fragment of a multi-fragment query. Either declares output
+        /// streams (an intermediate fragment, whose results park as native GPU
+        /// batches that outlive its own query) or none (a result fragment, which
+        /// produces Arrow).
+        ///
+        /// Usage order: `declare_*` → `build` → `relay_from` every sender → `run`
+        /// → drain via `relay_from` or `result_to_arrow`. Exactly one fragment may
+        /// sit between its own `build` and `run`; the engine serializes queries.
+        type Fragment;
+
+        /// Create a [`Fragment`] on `context`, which must outlive it.
+        fn make_fragment(context: Pin<&mut Context>) -> Result<UniquePtr<Fragment>>;
+
+        /// Name of the view a plan reads to consume input stream `stream_id` — the
+        /// single definition of the convention, so a front end emitting the read
+        /// and the engine creating the view cannot drift apart.
+        fn stream_view_name(stream_id: u64) -> UniquePtr<CxxString>;
+
+        /// Declare one column of an input stream, in plan order. `ty` is a DuckDB
+        /// type name; a stream has no file to probe, so the schema is given, never
+        /// inferred.
+        fn declare_input_column(
+            self: Pin<&mut Fragment>,
+            stream_id: u64,
+            name: &CxxString,
+            ty: &CxxString,
+        ) -> Result<()>;
+
+        /// Declare a sender that must close this input stream before it ends.
+        fn declare_input_sender(
+            self: Pin<&mut Fragment>,
+            stream_id: u64,
+            sender_id: u32,
+        ) -> Result<()>;
+
+        /// Declare an output stream. A fragment with none is a result fragment.
+        fn declare_output(self: Pin<&mut Fragment>, stream_id: u64) -> Result<()>;
+
+        /// Replicate every batch to all declared outputs. Mutually exclusive with
+        /// [`declare_output_hash_key`](Fragment::declare_output_hash_key), and must
+        /// precede `build`; both are the errors raised here. Whether enough
+        /// destinations exist is not known until `build`.
+        fn declare_output_broadcast(self: Pin<&mut Fragment>) -> Result<()>;
+
+        /// Hash-partition across the declared outputs on `column_index` (call once
+        /// per key column, in key order). Same exclusivity and ordering rules as
+        /// broadcast.
+        fn declare_output_hash_key(self: Pin<&mut Fragment>, column_index: u32) -> Result<()>;
+
+        /// Plan `substrait_plan` against the declared streams and open the
+        /// fragment's query lifecycle. Where the declaration-time rules cannot be
+        /// checked, they are checked here:
+        ///
+        /// * a routing mode declared on a fragment with fewer than two outputs is
+        ///   rejected — every row would reach destination 0 regardless, so a
+        ///   silently-dropped spec would look like it worked;
+        /// * a plan that reads the same declared input stream id more than once is
+        ///   rejected — the second read would overwrite the first's registration
+        ///   and strand its pipeline waiting for a push that never comes.
+        fn build(self: Pin<&mut Fragment>, substrait_plan: &CxxString) -> Result<()>;
+
+        /// Move every batch parked on `source`'s output stream into this fragment's
+        /// input stream as native handles — no Arrow, no file, no copy — then close
+        /// `sender_id`. Returns the number of batches moved.
+        ///
+        /// `source` must have finished [`run`](Fragment::run): before that, an empty
+        /// stream and a finished one are indistinguishable, and the input would be
+        /// closed after zero batches. `input_stream_id` must be declared on this
+        /// fragment, and `source` must have output streams (a result fragment is
+        /// rejected).
+        fn relay_from(
+            self: Pin<&mut Fragment>,
+            source: Pin<&mut Fragment>,
+            source_stream_id: u64,
+            input_stream_id: u64,
+            sender_id: u32,
+        ) -> Result<usize>;
+
+        /// Close `sender_id` on input stream `stream_id`. The end-of-stream mirror
+        /// for senders that are not local fragments — `relay_from` closes its own.
+        /// Idempotent per sender.
+        fn close_input(self: Pin<&mut Fragment>, stream_id: u64, sender_id: u32) -> Result<()>;
+
+        /// Execute the fragment and close its query lifecycle. Blocks until its
+        /// pipelines finish.
+        fn run(self: Pin<&mut Fragment>) -> Result<()>;
+
+        /// Write a result fragment's rows into the caller-owned `ArrowArrayStream`
+        /// at `out_stream_addr`.
+        ///
+        /// # Safety
+        /// `out_stream_addr` must be the address of a valid, writable
+        /// `ArrowArrayStream` that outlives this call. The safe
+        /// [`sirius`](https://docs.rs/sirius) wrapper upholds this.
+        unsafe fn result_to_arrow(self: Pin<&mut Fragment>, out_stream_addr: usize) -> Result<()>;
+
+        /// Batches currently parked on an output stream — the evidence that a
+        /// fragment boundary carried native batches rather than nothing.
+        fn output_batch_count(self: &Fragment, stream_id: u64) -> Result<usize>;
+
+        /// DuckDB type names of the fragment's output columns, in plan order.
+        /// Available after `build`; a result fragment has no output streams and is
+        /// rejected.
+        fn output_types(self: &Fragment) -> Result<UniquePtr<CxxVector<CxxString>>>;
     }
 }
 
-pub use ffi::{Context, make_context, make_context_from_config};
+pub use ffi::{
+    Context, Fragment, make_context, make_context_from_config, make_fragment, stream_view_name,
+};

--- a/rust/crates/sirius/src/lib.rs
+++ b/rust/crates/sirius/src/lib.rs
@@ -4,10 +4,16 @@
 //! This crate wraps the low-level [`sirius-sys`] cxx bindings in safe Rust types
 //! — the entry point for driving Sirius from Rust.
 //!
-//! Today it binds just enough to prove the toolchain links against the real
-//! Sirius library: constructing a [`SiriusContext`] from defaults or a YAML
-//! config file. More of the API surface is added in later PRs.
+//! Two entry points:
+//!
+//! * [`SiriusContext`] — an initialized engine, constructed from defaults or a
+//!   YAML config file, able to execute a whole Substrait plan in one call.
+//! * [`Fragment`] — one plan fragment of a multi-fragment query, for driving a
+//!   distributed plan a piece at a time and moving native GPU batches between
+//!   the pieces without going through Arrow.
 
+use std::cell::RefCell;
+use std::marker::PhantomData;
 use std::path::Path;
 
 use arrow_array::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
@@ -27,9 +33,28 @@ use cxx::{Exception, UniquePtr, let_cxx_string};
 /// The engine keeps process-global GPU state, so it currently supports a single
 /// live context per process; constructing or holding more than one concurrently
 /// is not yet supported (enforcement is a follow-up).
+///
+/// Neither `Send` nor `Sync` — drive one context from one thread. `!Send` comes from the cxx
+/// opaque `Context` itself; the `RefCell` adds `!Sync`, and buys
+/// [`fragment`](SiriusContext::fragment) a `&self` receiver so several fragments of one query
+/// can be alive at once.
 pub struct SiriusContext {
     // RAII handle owning the C++ engine context for its lifetime.
-    inner: UniquePtr<sirius_sys::Context>,
+    //
+    // Behind a `RefCell` because every call into C++ needs `Pin<&mut Context>` while a
+    // [`Fragment`] only borrows the context immutably. Several fragments of one query are alive
+    // at once — senders parked, waiting on their receiver — and a `&mut self` factory would allow
+    // exactly one.
+    //
+    // The borrow never outlives the call that takes it, so it cannot be observed by user code and
+    // the runtime check is unreachable without re-entering from a C++ callback. The context is
+    // neither `Send` nor `Sync`, so there is no cross-thread aliasing either.
+    //
+    // What this costs: a `&self` factory gives up compile-time enforcement of "exactly one
+    // fragment sits between its own build() and run()" — two can be mid-lifecycle at once and the
+    // engine rejects that at runtime. The whole-plan path is unaffected: it keeps `&mut self`, so
+    // running a standalone query while any fragment is alive stays a compile error.
+    inner: RefCell<UniquePtr<sirius_sys::Context>>,
 }
 
 /// Fully materialized output of one Substrait execution.
@@ -45,7 +70,7 @@ impl SiriusContext {
     /// built-in defaults.
     pub fn new() -> Result<Self, Exception> {
         Ok(Self {
-            inner: sirius_sys::make_context()?,
+            inner: RefCell::new(sirius_sys::make_context()?),
         })
     }
 
@@ -56,7 +81,20 @@ impl SiriusContext {
         // one from the (lossy) UTF-8 form of the platform path.
         let_cxx_string!(config_path = path.to_string_lossy().as_ref());
         Ok(Self {
-            inner: sirius_sys::make_context_from_config(&config_path)?,
+            inner: RefCell::new(sirius_sys::make_context_from_config(&config_path)?),
+        })
+    }
+
+    /// Create a [`Fragment`] on this context — one plan fragment of a multi-fragment query.
+    ///
+    /// Takes `&self`, not `&mut self`: a distributed plan keeps several fragments alive at once,
+    /// with senders parked until their receiver relays from them, so an exclusive borrow would
+    /// permit exactly one. The returned fragment borrows the context, so it cannot outlive it.
+    pub fn fragment(&self) -> Result<Fragment<'_>, Exception> {
+        let mut context = self.inner.borrow_mut();
+        Ok(Fragment {
+            inner: sirius_sys::make_fragment(context.pin_mut())?,
+            _context: PhantomData,
         })
     }
 
@@ -71,6 +109,10 @@ impl SiriusContext {
     /// Arrow stream converts each batch using this context's client state, so the
     /// stream is drained while the context is alive; the returned batches own
     /// their buffers and are independent of the context's lifetime.
+    ///
+    /// Takes `&mut self` where [`fragment`](SiriusContext::fragment) takes `&self`: the whole-plan
+    /// path has no reason to run while a fragment is alive, so the exclusive borrow turns that
+    /// into a compile error rather than a runtime one.
     pub fn execute_substrait(&mut self, plan: &[u8]) -> Result<Vec<RecordBatch>, SiriusError> {
         Ok(self.execute_substrait_result(plan)?.batches)
     }
@@ -82,28 +124,209 @@ impl SiriusContext {
     ) -> Result<SubstraitResult, SiriusError> {
         // The engine writes a self-owning Arrow C Data Interface stream into
         // `stream`; the FFI takes its address as an integer (a `uintptr_t`).
-        let mut stream = FFI_ArrowArrayStream::empty();
-        let out_stream_addr = std::ptr::addr_of_mut!(stream) as usize;
         let_cxx_string!(plan = plan);
-        // SAFETY: `out_stream_addr` is the address of `stream`, a live, writable
-        // `FFI_ArrowArrayStream` owned by this stack frame for the call's duration.
-        unsafe {
-            self.inner
-                .pin_mut()
-                .execute_substrait(&plan, out_stream_addr)
-                .map_err(SiriusError::Engine)?;
-        }
-        // Drain fully while `self` is alive (conversion dereferences the context).
-        let reader = ArrowArrayStreamReader::try_new(stream).map_err(SiriusError::Arrow)?;
-        let schema = reader.schema();
-        let batches = reader
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(SiriusError::Arrow)?;
-        Ok(SubstraitResult { schema, batches })
+        drain_arrow(|out_stream_addr| {
+            // SAFETY: `drain_arrow` passes the address of a live, writable
+            // `FFI_ArrowArrayStream` it owns for the closure's duration.
+            unsafe {
+                self.inner
+                    .borrow_mut()
+                    .pin_mut()
+                    .execute_substrait(&plan, out_stream_addr)
+            }
+        })
     }
 }
 
-/// Error returned by [`SiriusContext::execute_substrait`].
+/// Name of the DuckDB view a plan reads to consume input stream `stream_id`.
+///
+/// The single definition of the convention: a front end emitting the read and the engine creating
+/// the view resolve the same name, so they cannot drift apart.
+pub fn stream_view_name(stream_id: u64) -> String {
+    sirius_sys::stream_view_name(stream_id)
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// One plan fragment of a multi-fragment query.
+///
+/// A fragment either declares output streams — an *intermediate* fragment, whose results park as
+/// native GPU batches that outlive its own query — or declares none, making it a *result*
+/// fragment that produces Arrow.
+///
+/// The usage order is fixed: declare inputs and outputs, [`build`](Fragment::build) the plan,
+/// [`relay_from`](Fragment::relay_from) every sender, [`run`](Fragment::run), then drain via
+/// `relay_from` (from downstream) or [`result_to_arrow`](Fragment::result_to_arrow). Exactly
+/// one fragment may sit between its own `build` and `run` — the engine serializes queries.
+///
+/// Borrows the [`SiriusContext`] that created it, so a fragment cannot outlive its engine.
+pub struct Fragment<'ctx> {
+    inner: UniquePtr<sirius_sys::Fragment>,
+    /// Ties the fragment's lifetime to the context that made it.
+    _context: PhantomData<&'ctx SiriusContext>,
+}
+
+impl Fragment<'_> {
+    /// Declare one column of input stream `stream_id`, in plan order. `ty` is a DuckDB type name
+    /// (`BIGINT`, `DECIMAL(15,2)`, `DATE`, …) — a stream has no file to probe, so the schema is
+    /// given rather than inferred.
+    pub fn declare_input_column(
+        &mut self,
+        stream_id: u64,
+        name: &str,
+        ty: &str,
+    ) -> Result<(), Exception> {
+        let_cxx_string!(name = name);
+        let_cxx_string!(ty = ty);
+        self.inner
+            .pin_mut()
+            .declare_input_column(stream_id, &name, &ty)
+    }
+
+    /// Declare a sender that must close input stream `stream_id` before it ends. With none
+    /// declared the stream expects the single sender `0`.
+    pub fn declare_input_sender(
+        &mut self,
+        stream_id: u64,
+        sender_id: u32,
+    ) -> Result<(), Exception> {
+        self.inner
+            .pin_mut()
+            .declare_input_sender(stream_id, sender_id)
+    }
+
+    /// Declare an output stream. A fragment with no output stream is a result fragment.
+    pub fn declare_output(&mut self, stream_id: u64) -> Result<(), Exception> {
+        self.inner.pin_mut().declare_output(stream_id)
+    }
+
+    /// Replicate every batch to all declared outputs.
+    ///
+    /// Returns `Err` if a hash key was already declared (the two modes are mutually exclusive) or
+    /// if the fragment is already built. Whether enough destinations exist to route between is not
+    /// known until [`build`](Fragment::build), which is where that is rejected.
+    pub fn declare_output_broadcast(&mut self) -> Result<(), Exception> {
+        self.inner.pin_mut().declare_output_broadcast()
+    }
+
+    /// Hash-partition across the declared outputs on `column_index`. Call once per key column, in
+    /// key order. Same exclusivity and ordering rules as
+    /// [`declare_output_broadcast`](Fragment::declare_output_broadcast).
+    pub fn declare_output_hash_key(&mut self, column_index: u32) -> Result<(), Exception> {
+        self.inner.pin_mut().declare_output_hash_key(column_index)
+    }
+
+    /// Plan `substrait_plan` against the declared streams and open the fragment's query lifecycle.
+    ///
+    /// The declaration-time rules that could not be checked earlier are checked here, so both
+    /// surface as `Err` from this call rather than from the `declare_*` that caused them:
+    ///
+    /// * a routing mode on a fragment with fewer than two outputs — every row would reach
+    ///   destination 0 regardless, so silently dropping the spec would look like it worked;
+    /// * a plan that reads the same declared input stream id more than once (a self-join over one
+    ///   stream, say) — the second read would overwrite the first's registration and strand its
+    ///   pipeline waiting for a push that never arrives.
+    pub fn build(&mut self, substrait_plan: &[u8]) -> Result<(), Exception> {
+        let_cxx_string!(plan = substrait_plan);
+        self.inner.pin_mut().build(&plan)
+    }
+
+    /// Move every batch parked on `source`'s output stream into this fragment's input stream — as
+    /// native GPU batch handles, with no Arrow and no file in between — then close `sender_id`.
+    /// Returns the number of batches moved.
+    ///
+    /// Returns `Err` unless `source` has already finished [`run`](Fragment::run): before that, an
+    /// empty stream is indistinguishable from a finished one, and the input would be closed after
+    /// zero batches, silently truncating the result. Also `Err` if `input_stream_id` was never
+    /// declared here, or if `source` is a result fragment and so has nothing to relay.
+    pub fn relay_from(
+        &mut self,
+        source: &mut Fragment<'_>,
+        source_stream_id: u64,
+        input_stream_id: u64,
+        sender_id: u32,
+    ) -> Result<usize, Exception> {
+        self.inner.pin_mut().relay_from(
+            source.inner.pin_mut(),
+            source_stream_id,
+            input_stream_id,
+            sender_id,
+        )
+    }
+
+    /// Close `sender_id` on input stream `stream_id`.
+    ///
+    /// The end-of-stream mirror for senders that are not local fragments — [`relay_from`] closes
+    /// its own sender. Idempotent per sender.
+    ///
+    /// [`relay_from`]: Fragment::relay_from
+    pub fn close_input(&mut self, stream_id: u64, sender_id: u32) -> Result<(), Exception> {
+        self.inner.pin_mut().close_input(stream_id, sender_id)
+    }
+
+    /// Execute the fragment and close its query lifecycle. Blocks until its pipelines finish.
+    pub fn run(&mut self) -> Result<(), Exception> {
+        self.inner.pin_mut().run()
+    }
+
+    /// Batches currently parked on output stream `stream_id` — the evidence that a fragment
+    /// boundary carried native batches rather than nothing.
+    pub fn output_batch_count(&self, stream_id: u64) -> Result<usize, Exception> {
+        self.inner.output_batch_count(stream_id)
+    }
+
+    /// DuckDB type names of this fragment's output columns, in plan order.
+    ///
+    /// Available after [`build`](Fragment::build). Returns `Err` for a result fragment, which has
+    /// no output streams to describe.
+    pub fn output_types(&self) -> Result<Vec<String>, Exception> {
+        Ok(self
+            .inner
+            .output_types()?
+            .iter()
+            .map(|ty| ty.to_string_lossy().into_owned())
+            .collect())
+    }
+
+    /// Collect a result fragment's rows over the Arrow C Data Interface.
+    ///
+    /// Named for the C++ verb it binds rather than `into_*`, which Rust reserves for by-value
+    /// conversions — this borrows and could in principle be called more than once.
+    ///
+    /// Returns `Err` on a fragment that declared output streams (it parks native batches for a
+    /// peer instead of producing Arrow) or before [`run`](Fragment::run).
+    pub fn result_to_arrow(&mut self) -> Result<SubstraitResult, SiriusError> {
+        drain_arrow(|out_stream_addr| {
+            // SAFETY: `drain_arrow` passes the address of a live, writable
+            // `FFI_ArrowArrayStream` it owns for the closure's duration.
+            unsafe { self.inner.pin_mut().result_to_arrow(out_stream_addr) }
+        })
+    }
+}
+
+/// Run `emit` against a freshly-created Arrow C Data Interface stream, then drain it fully.
+///
+/// Both Arrow-producing entry points — whole-plan execution and a result fragment — hand C++ the
+/// address of a stack-owned `FFI_ArrowArrayStream` and then collect it. Keeping that sequence in
+/// one place keeps the two from drifting: it is the only spot where a raw address crosses the FFI
+/// boundary, and the draining must happen while the producer is still alive, because the
+/// conversion dereferences the engine context.
+fn drain_arrow(
+    emit: impl FnOnce(usize) -> Result<(), Exception>,
+) -> Result<SubstraitResult, SiriusError> {
+    let mut stream = FFI_ArrowArrayStream::empty();
+    let out_stream_addr = std::ptr::addr_of_mut!(stream) as usize;
+    emit(out_stream_addr).map_err(SiriusError::Engine)?;
+    let reader = ArrowArrayStreamReader::try_new(stream).map_err(SiriusError::Arrow)?;
+    let schema = reader.schema();
+    let batches = reader
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(SiriusError::Arrow)?;
+    Ok(SubstraitResult { schema, batches })
+}
+
+/// Error returned by the Arrow-producing entry points: [`SiriusContext::execute_substrait`],
+/// [`SiriusContext::execute_substrait_result`], and [`Fragment::result_to_arrow`].
 #[derive(Debug)]
 pub enum SiriusError {
     /// The engine failed to translate or execute the plan (a C++ exception).
@@ -242,6 +465,75 @@ mod tests {
             let total_rows: usize = result.batches.iter().map(RecordBatch::num_rows).sum();
             assert_eq!(total_rows, 3, "expected 3 rows from the parquet fixture");
         }
+    }
+
+    /// The view-name convention is shared with the engine, so a front end can emit a read for a
+    /// stream it has declared. Pure string formatting — no GPU, no context.
+    #[test]
+    fn stream_view_name_matches_the_engine_convention() {
+        assert_eq!(super::stream_view_name(0), "sirius_stream_0");
+        assert_eq!(super::stream_view_name(42), "sirius_stream_42");
+        assert_eq!(
+            super::stream_view_name(u64::MAX),
+            format!("sirius_stream_{}", u64::MAX)
+        );
+    }
+
+    /// The two routing modes are mutually exclusive, and that *is* enforced at declaration time —
+    /// unlike the "needs at least two destinations" rule, which cannot be known until `build()`
+    /// and is asserted there, not here. Requires a GPU only for context bring-up.
+    #[test]
+    fn routing_modes_are_mutually_exclusive() {
+        let _guard = GPU_CONTEXT_LOCK
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        let ctx = SiriusContext::new().expect("bring up sirius context");
+
+        let mut broadcast_first = ctx.fragment().expect("create fragment");
+        broadcast_first
+            .declare_output_broadcast()
+            .expect("broadcast alone is accepted at declare time");
+        assert!(
+            broadcast_first.declare_output_hash_key(0).is_err(),
+            "a hash key after broadcast must be rejected"
+        );
+
+        let mut hash_first = ctx.fragment().expect("create fragment");
+        hash_first
+            .declare_output_hash_key(0)
+            .expect("a hash key alone is accepted at declare time");
+        assert!(
+            hash_first.declare_output_broadcast().is_err(),
+            "broadcast after a hash key must be rejected"
+        );
+    }
+
+    /// Several fragments are alive at once in a distributed plan — senders parked until their
+    /// receiver relays from them. This is why `fragment()` takes `&self`; with a `&mut self`
+    /// factory the second `ctx.fragment()` below would not borrow-check.
+    #[test]
+    fn context_makes_several_fragments_at_once() {
+        let _guard = GPU_CONTEXT_LOCK
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        let ctx = SiriusContext::new().expect("bring up sirius context");
+
+        let mut sender = ctx.fragment().expect("create sender fragment");
+        let mut receiver = ctx.fragment().expect("create receiver fragment");
+
+        // Both are live here — the point of the test.
+        sender.declare_output(7).expect("declare output");
+        receiver
+            .declare_input_column(7, "id", "BIGINT")
+            .expect("declare input column");
+
+        // Neither has been built, so this trips the build-ordering guard. It does NOT reach the
+        // "source must have run" guard — that one needs two built fragments and a real plan, so
+        // it is covered by the C++ suite rather than pretended at here.
+        assert!(
+            receiver.relay_from(&mut sender, 7, 7, 0).is_err(),
+            "relay_from before build() must be rejected"
+        );
     }
 
     /// A missing config file is rejected before any GPU work (`load_from_file`


### PR DESCRIPTION
Completes the Rust half of #1396 (closed). The C++ half shipped in #1481; this binds it.

> **Purely additive.** No existing signature changes — `SiriusContext` only gains `fragment()`.

**What.** `sirius::ffi::Fragment` — one plan fragment of a multi-fragment query — reachable from
Rust. A fragment declares its input streams (schema and senders) and its output streams, is built
from a Substrait plan, relays native GPU batches to and from its peers, and either parks results
for a downstream fragment or hands them back as Arrow.

**Design: a fragment borrows the context, it does not own it.** That single fact drives the whole
shape. Several fragments of one query are alive simultaneously — senders parked, waiting on their
receiver — so the factory has to be `SiriusContext::fragment(&self)`. A `&mut self` factory would
permit exactly one fragment at a time, which is the one thing a multi-fragment query cannot live
with.

But every call into C++ needs `Pin<&mut Context>`. Reconciling those puts the handle behind a
`RefCell<UniquePtr<Context>>`: the borrow is taken and released inside each call, never held
across one. That adds `!Sync` to the `!Send` the cxx opaque type already carried; both are
documented on the type rather than left to be discovered.

`execute_substrait` and `execute_substrait_result` keep `&mut self`. The `RefCell` does not force
them to give up the exclusive borrow, and holding it earns something: running a whole-plan query
while a fragment is alive stays a *compile* error instead of becoming a runtime rejection. What
the `&self` factory does cost is compile-time enforcement of "exactly one fragment sits between
its own `build()` and `run()`" — two can now be mid-lifecycle at once, and the engine rejects
that at runtime. Both facts are recorded on the type.

One consequence worth flagging for review: an `Arc<SiriusContext>` cannot reach a `&mut self`
method, so the `Arc`-threading sketch in the `StubExecutor` TODO
(`experimental/starrocks/src/fragment_executor.rs`) would have to adopt the shape `SiriusEngine`
already uses: an owned context pinned to its own thread. Nothing depends on that sketch today, and if we do want
`Arc` later, that is the argument for `&self` — worth saying now rather than discovering it then.

`Fragment<'ctx>` carries the context's lifetime, so a fragment cannot outlive the engine it was
built on; that is checked at compile time rather than trusted.

---

**What is bound.** The full surface `sirius_ffi.hpp` exports as of #1481:

| | |
|---|---|
| lifecycle | `make_fragment`, `build`, `run` |
| inputs | `declare_input_column`, `declare_input_sender`, `close_input` |
| outputs | `declare_output`, `declare_output_broadcast`, `declare_output_hash_key` |
| moving data | `relay_from`, `result_to_arrow`, `output_batch_count`, `output_types` |
| helper | `stream_view_name` |

Four of those — `declare_output_broadcast`, `declare_output_hash_key`, `close_input`,
`output_types` — postdate #1396 and are bound here for the first time.

**Preconditions surface as `Err`, not panics.** #1481 made three contracts explicit, and the doc
comments mirror each one rather than leaving a caller to meet a surprising exception:

- a partition mode on a single-output fragment is **rejected**, not silently ignored — every row
  would otherwise go to destination 0 while the call looked like it worked;
- `relay_from` requires the source fragment to have `run()` already, because before that an empty
  stream and a finished one are indistinguishable and the input would close early;
- `relay_from` requires the target input stream to be declared on the receiving fragment, and
  refuses a result fragment as a source;
- a plan that reads the same declared input stream id more than once (e.g. a self-join) is
  **rejected** at `build()` time instead of silently letting the second leaf overwrite the
  first's registration and hang forever with no error.

The usage order — `declare_* → build → relay_from(every sender) → run → drain` — is on the
`Fragment` type, along with the constraint that exactly one fragment may sit between its own
`build()` and `run()`.

---

**Reviewing.** Two files, no C++ changes:

1. `rust/crates/sirius-sys/src/lib.rs` — the `#[cxx::bridge]` declarations. Thin by design; every
   entry documents the C++ contract it binds, and `result_to_arrow` keeps its `# Safety` section
   because it takes a raw `ArrowArrayStream` address.
2. `rust/crates/sirius/src/lib.rs` — the safe wrapper. This is where the `RefCell` and the
   `Fragment<'ctx>` lifetime live, and where `result_to_arrow`'s raw address is made sound by
   reusing the crate's existing `FFI_ArrowArrayStream` path rather than adding a second one.

`build.rs` is unchanged — it already compiles the bridge against `src/include/sirius_ffi.hpp`.

**Tests.** CI runs `cargo test --no-run`, so all of these compile without a GPU:
`routing_modes_are_mutually_exclusive` (a hash key after broadcast and the reverse, both rejected
at declare time) and `context_makes_several_fragments_at_once` (two live fragments — the case
that forces the `&self` factory) both need a device to *run*, because they bring up a context;
`stream_view_name_matches_the_engine_convention` is pure formatting and runs anywhere. That a
`Fragment` cannot outlive its `SiriusContext` is enforced by `Fragment<'ctx>` itself, so there is
no test for it.

---

**Not here.** No `push` / `pull` / `wait` on the Rust surface, and `run()` still blocks — so a
remote peer cannot yet feed a fragment. That is the deferred half of #839, tracked in #1590. This
PR binds what #1481 exports and nothing more.

