### PR TITLE
fix(join): disable the runtime distinctness probe by default

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -406,7 +406,7 @@ individually.
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join. A build below this size is replicated to every GPU (instead of hash-partitioned) when it is tiny, or when the DuckDB-estimated probe-to-build row ratio is at least `num_gpus * 1.25`. |
 | `max_sort_partition_memory_fraction` | 0.33 | Fraction of GPU memory per sort partition when `max_sort_partition_bytes` is 0 |
 | `mark_join_build_switch_ratio` | 8.0 | For STANDARD MARK joins, build on the smaller (left) side when `right_rows >= ratio * left_rows` (0 disables) |
-| `enable_runtime_distinct_build_probe` | true | For `BUILD_PROBE` INNER/LEFT equality joins whose build-key uniqueness the planner could not prove, test distinctness at runtime (one `cudf::distinct_count` pass over the cached build, dimension-scale builds only) and take the single-pass `cudf::distinct_hash_join` instead of the general two-pass join when the keys are distinct. |
+| `enable_runtime_distinct_build_probe` | false | For `BUILD_PROBE` INNER/LEFT equality joins whose build-key uniqueness the planner could not prove, test distinctness at runtime (one `cudf::distinct_count` pass over the cached build, dimension-scale builds only) and take the single-pass `cudf::distinct_hash_join` instead of the general two-pass join when the keys are distinct. Temporarily off by default until a cuCollections bug fix ships in libcudf (issue #1600). |
 | `enable_dynamic_filter_pushdown` | true | Master switch for dynamic table-filter pushdown. An eligible `BUILD_PROBE` hash-join build selects a raw exact IN-list for 1–12 supported build rows, otherwise a hash IN-list if it fits the smallest probe-GPU L2 or a Bloom, for post-decode application by the probe scan. |
 | `enable_dynamic_zone_map_filter` | false | Additionally publish build-key min/max bounds. Parquet scans use them for read-time row-group pruning; duckdb-native scans apply them row-wise post-decode. Requires `enable_dynamic_filter_pushdown`; intended for clustered-keyset workloads. |
 | `dynamic_filter_domain_coverage_threshold` | 0.9 | Positive finite threshold for skipping publication when the build covers at least this fraction of the key's domain; ≥ 1.0 effectively disables the gate. |
@@ -591,7 +591,7 @@ SET enable_compressed_materialization = false;
 | `max_build_hash_table_bytes` | 2× batch default | Max build-side hash table bytes |
 | `max_broadcast_join_size` | 256 MiB | Max build-side size eligible for a broadcast join |
 | `mark_join_build_switch_ratio` | 8.0 | STANDARD MARK join build-side switch ratio (0 disables) |
-| `enable_runtime_distinct_build_probe` | true | Runtime distinct-build test for `BUILD_PROBE` joins; promotes to the single-pass `cudf::distinct_hash_join` when the build keys prove distinct |
+| `enable_runtime_distinct_build_probe` | false | Runtime distinct-build test for `BUILD_PROBE` joins; promotes to the single-pass `cudf::distinct_hash_join` when the build keys prove distinct. Temporarily off by default (issue #1600) |
 
 ### GPU Admission
 

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -81,7 +81,10 @@ constexpr double DEFAULT_MARK_JOIN_BUILD_SWITCH_RATIO = 8.0;
 /// probe row count. Sirius already implements both, but the distinct path is gated on a *proof* of
 /// uniqueness, which only a declared PRIMARY KEY on a catalog table can supply. The runtime test is
 /// one cudf::distinct_count pass over the build keys, taken only in BUILD_PROBE mode.
-constexpr bool DEFAULT_ENABLE_RUNTIME_DISTINCT_BUILD_PROBE = true;
+///
+/// Temporarily off by default (issue #1600): cudf::distinct_count can hit a cuCollections bug
+/// (NVIDIA/cuCollections#834) on some key distributions. Re-enable once the fix ships in libcudf.
+constexpr bool DEFAULT_ENABLE_RUNTIME_DISTINCT_BUILD_PROBE = false;
 
 }  // namespace config
 

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -2403,7 +2403,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     "For BUILD_PROBE hash joins whose build-key uniqueness the planner could not prove, test "
     "distinctness at runtime (one cudf::distinct_count pass over the cached build) and take the "
     "single-pass cudf::distinct_hash_join instead of the general two-pass join when the keys are "
-    "distinct (on by default)",
+    "distinct (temporarily off by default pending a cuCollections fix; see issue #1600)",
     LogicalType::BOOLEAN,
     Value::BOOLEAN(operator_defaults.enable_runtime_distinct_build_probe),
     SetEnableRuntimeDistinctBuildProbe);


### PR DESCRIPTION
Temporarily disables the hash-join runtime build-key distinctness probe by default (`DEFAULT_ENABLE_RUNTIME_DISTINCT_BUILD_PROBE` → `false`).

The probe's `cudf::distinct_count` pass can hit a cuCollections bug NVIDIA/cuCollections#834 on some key distributions — observed on the partsupp build in TPC-H q9 at SF=500 on 4 GPUs.

- The `enable_runtime_distinct_build_probe` setting remains, so the probe can still be turned on explicitly.
- The statically-proven-unique `distinct_hash_join` path is unaffected.
- Docs (`configuration.md`) and the setting's description updated to note the temporary default.

Re-enable once the cuCollections fix ships in libcudf.

Partially addresses #1600