### PR TITLE
feat(op): Add native UNION ALL operator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,7 @@ set(EXTENSION_SOURCES
     src/op/sirius_physical_order.cpp
     src/op/sirius_physical_partition.cpp
     src/op/sirius_physical_partition_consumer_operator.cpp
+    src/op/sirius_physical_passthrough_sink.cpp
     src/op/sirius_physical_projection.cpp
     src/op/sirius_physical_result_collector.cpp
     src/op/sirius_physical_sort_partition.cpp
@@ -378,6 +379,7 @@ set(EXTENSION_SOURCES
     src/op/sirius_physical_table_scan.cpp
     src/op/sirius_physical_top_n.cpp
     src/op/sirius_physical_ungrouped_aggregate.cpp
+    src/op/sirius_physical_union.cpp
     src/parallel/task_executor.cpp
     src/pipeline/gpu_pipeline_executor.cpp
     src/pipeline/gpu_pipeline_task.cpp
@@ -416,6 +418,7 @@ set(EXTENSION_SOURCES
     src/planner/sirius_plan_projection.cpp
     src/planner/sirius_plan_projection_utils.cpp
     src/planner/sirius_plan_recursive_cte.cpp
+    src/planner/sirius_plan_set_operation.cpp
     src/planner/sirius_plan_top_n.cpp
     src/pin_table.cpp
     src/scan_manager/load_balancing_scan_batch_coalescer.cpp
@@ -739,6 +742,7 @@ set(TEST_SOURCES
     test/cpp/integration/test_gpu_execution_tpch.cpp
     test/cpp/integration/test_gpu_execution_tpch_mgpu_audit.cpp
     test/cpp/integration/test_gpu_execution_unique_join.cpp
+    test/cpp/integration/test_gpu_execution_union_all.cpp
     test/cpp/integration/test_gpu_execution_vector_search.cpp
     test/cpp/integration/test_pin_table_host_streaming.cpp
     test/cpp/integration/test_pin_table_merge_columns.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -789,6 +789,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_physical_hash_join_mgpu.cpp
     test/cpp/operator/test_physical_order_mgpu.cpp
     test/cpp/operator/test_task_scheduler_routing.cpp
+    test/cpp/operator/test_physical_union_mgpu.cpp
     test/cpp/operator/test_partition_memspace_mgpu.cpp
     test/cpp/memory/test_multiple_blocks_allocation_accessor.cpp
     test/cpp/memory/test_topology_index.cpp

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -312,32 +312,24 @@ Conditional MARK joins produce the same three-valued mark as the hash join, via 
 ### `sirius_physical_union` — `UNION`
 **File:** `src/include/op/sirius_physical_union.hpp`
 
-`UNION ALL` only — bag (multiset) concatenation, so the operator computes nothing and `execute` is
-the identity. Distinct `UNION`, `EXCEPT` and `INTERSECT` are rejected by the plan builder
-(`src/planner/sirius_plan_set_operation.cpp`) and fall back to the CPU, as is `UNION ALL` with
-`allow_out_of_order = false`.
+`UNION ALL` only — bag concatenation, so the operator computes nothing and `execute` is the
+identity. N-ary: `a UNION ALL b UNION ALL c` binds to one `LogicalSetOperation`, so every path loops
+over `children`. Distinct `UNION`, `EXCEPT` and `INTERSECT` are rejected by the plan builder
+(`src/planner/sirius_plan_set_operation.cpp`), as is `allow_out_of_order = false`.
 
-- **N-ary.** DuckDB binds `a UNION ALL b UNION ALL c` to one `LogicalSetOperation` with three
-  children, so every path loops over `children` rather than indexing 0 and 1.
-- **One port per arm.** Each arm is wrapped `child -> PASSTHROUGH_SINK` by `wrap_union`, feeding a
-  distinct `"union_{i}"` port. Distinct names are required, not cosmetic: `add_port` is
-  last-writer-wins, the repository manager keys by `(operator_id, port_id)`, and the pipeline-finish
-  gate reads `is_source_pipeline_finished()` / `all_ports_empty()` across the `ports` map — a shared
-  name would orphan an arm's repository and finish the pipeline while that arm still had rows.
-- **`PASSTHROUGH_SINK -> UNION` is `PARTIAL`.** The base's default is `FULL`, which
-  would hold every arm's entire output in repositories until all of them finished. A stateless bag
-  union never needs a complete side.
-- **Overrides both task-driver methods.** The base is lockstep — ready only when *every* port has
-  data, then one batch popped from every port — which strands the long arm once a short one drains.
-  `UNION` reports ready when *any* arm has a batch and pops one batch from one arm. One arm per task
-  also preserves device placement: a task runs on one GPU, so bundling arms would reintroduce the
-  migration the passthrough sink removes.
+- **One port per arm.** `wrap_union` wraps each arm `child -> PASSTHROUGH_SINK`, feeding a distinct
+  `"union_{i}"` port. The distinct names are required: `add_port` is last-writer-wins and the
+  repository manager keys by `(operator_id, port_id)`, so a shared name would orphan an arm's
+  repository and finish the pipeline while that arm still had rows.
+- **`PASSTHROUGH_SINK -> UNION` is `PARTIAL`**, not the base's `FULL` default, which
+  would hold every arm's output in repositories until all arms finished.
+- **Overrides both task-driver methods.** Ready when *any* arm has a batch, popping one batch from
+  one arm; the base is lockstep and strands the long arm once a short one drains. One arm per task
+  also keeps each batch on the GPU that produced it.
 - **`source_order()` is `NO_ORDER`.** `order_preservation_recursive` stops at the first `is_source()`
-  operator, so this answer decides the whole plan's; `INSERTION_ORDER` would claim an ordering a bag
-  union does not provide.
-- **Carriers.** The compressed-schema pass treats `UNION` as a native boundary (its `default` arm
-  restores every child), which is also what prevents two arms presenting different physical carriers
-  for the same logical column.
+  operator, so this answer decides the whole plan's.
+- **Carriers.** The compressed-schema pass treats `UNION` as a native boundary, which prevents two
+  arms presenting different physical carriers for the same logical column.
 
 ### `sirius_physical_order` — `ORDER_BY`
 **File:** `src/include/op/sirius_physical_order.hpp`
@@ -421,21 +413,19 @@ Reassembles partitioned data back into a linear stream. Behavior depends on join
 ### `sirius_physical_passthrough_sink` — `PASSTHROUGH_SINK`
 **File:** `src/include/op/sirius_physical_passthrough_sink.hpp`
 
-Terminates one arm of a `UNION`. Where a join arm is wrapped `PARTITION -> CONCAT`, a bag union
-needs neither a shuffle nor a coalesce, so a single operator does the job: forward every batch
-unchanged into the downstream `UNION`'s `"union_{i}"` port.
+Terminates one arm of a `UNION`, forwarding every batch unchanged into the downstream `UNION`'s
+`"union_{i}"` port. It replaces the join arm's `PARTITION -> CONCAT` chain, which a bag union needs
+neither half of.
 
-- **Emits `pipelineable_operator_data`, not `partitioned_operator_data`.** With no `partition_idx`,
-  the task creator's device selection falls through to data locality instead of
-  `partition_idx % num_gpus`, so each batch is consumed on the GPU its scan produced it on. A
-  single-partition `CONCAT` would pin every UNION task to GPU 0.
-- **Pushes through the base `sink()`**, not `push_data_batch_partitioned`, so the receiving `UNION`
-  need not be a `partition_consumer_operator`.
+- **Emits `pipelineable_operator_data`, not `partitioned_operator_data`.** With no `partition_idx`
+  the task creator selects a device by data locality instead of `partition_idx % num_gpus`, so each
+  batch is consumed on the GPU its scan produced it on. A single-partition `CONCAT` would pin every
+  UNION task to GPU 0.
 - **Owns its port name.** `sirius_physical_union::input_port_for` returns a `string_view` into
-  `_union_port_label`, and
-  both the wiring descriptor and `next_port_info` retain that view for the life of the query.
-- Inherits the base task-driver methods: it is single-input, so the fan-in hazards that force
-  `UNION` to override them cannot arise.
+  `_union_port_label`, which the wiring descriptor and `next_port_info` retain for the life of the
+  query.
+- Inherits the base task-driver methods: it is single-input, so `UNION`'s fan-in hazards cannot
+  arise.
 
 ### `sirius_physical_sort_sample` — `SORT_SAMPLE`
 **File:** `src/include/op/sirius_physical_sort_sample.hpp`

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -323,9 +323,12 @@ over `children`. Distinct `UNION`, `EXCEPT` and `INTERSECT` are rejected by the 
   repository and finish the pipeline while that arm still had rows.
 - **`PASSTHROUGH_SINK -> UNION` is `PARTIAL`**, not the base's `FULL` default, which
   would hold every arm's output in repositories until all arms finished.
-- **Overrides both task-driver methods.** Ready when *any* arm has a batch, popping one batch from
-  one arm; the base is lockstep and strands the long arm once a short one drains. One arm per task
-  also keeps each batch on the GPU that produced it.
+- **Overrides both task-driver methods.** Ready when every *live* arm has a batch, popping one batch
+  from one arm; the base is lockstep and strands the long arm once a short one drains, so a finished
+  arm is excused while arms still producing rendezvous. A starved arm — live producer, empty port —
+  outranks a ready one, since `task_scheduler::start_query` starts one scan for the whole query and
+  an arm is named in this hint or never runs. One arm per task also keeps each batch on the GPU that
+  produced it.
 - **`source_order()` is `NO_ORDER`.** `order_preservation_recursive` stops at the first `is_source()`
   operator, so this answer decides the whole plan's.
 - **Arm ports are cached.** Both task-driver methods run on every task-creation walk that reaches

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -328,6 +328,9 @@ over `children`. Distinct `UNION`, `EXCEPT` and `INTERSECT` are rejected by the 
   also keeps each batch on the GPU that produced it.
 - **`source_order()` is `NO_ORDER`.** `order_preservation_recursive` stops at the first `is_source()`
   operator, so this answer decides the whole plan's.
+- **Arm ports are cached.** Both task-driver methods run on every task-creation walk that reaches
+  the operator, and resolving a `"union_{i}"` name costs two `std::string` allocations, so the
+  names are resolved to `port*` once on first use.
 - **Carriers.** The compressed-schema pass treats `UNION` as a native boundary, which prevents two
   arms presenting different physical carriers for the same logical column.
 

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -309,6 +309,36 @@ Fallback for joins not supported by cuDF hash join (pure inequality conditions).
 
 Conditional MARK joins produce the same three-valued mark as the hash join, via a two-semi-join scheme in its own `resolve_mark_join_result`: one `conditional_left_semi_join` on the predicate itself yields the *matched* set, and a second on `predicate IS NOT FALSE` — each comparison rewritten as `cᵢ OR IS_NULL(left) OR IS_NULL(right)` with Kleene `NULL_LOGICAL_OR` — yields the *maybe* set. A row's mark is true if matched, NULL if in the maybe set but not matched, false otherwise. Null-safe (`IS [NOT] DISTINCT FROM`) conjuncts skip the `IS_NULL` tainting since they are never NULL-valued; `distinct_from` is lowered as `NOT(NULL_EQUAL(l, r))`.
 
+### `sirius_physical_union` — `UNION`
+**File:** `src/include/op/sirius_physical_union.hpp`
+
+`UNION ALL` only — bag (multiset) concatenation, so the operator computes nothing and `execute` is
+the identity. Distinct `UNION`, `EXCEPT` and `INTERSECT` are rejected by the plan builder
+(`src/planner/sirius_plan_set_operation.cpp`) and fall back to the CPU, as is `UNION ALL` with
+`allow_out_of_order = false`.
+
+- **N-ary.** DuckDB binds `a UNION ALL b UNION ALL c` to one `LogicalSetOperation` with three
+  children, so every path loops over `children` rather than indexing 0 and 1.
+- **One port per arm.** Each arm is wrapped `child -> PASSTHROUGH_SINK` by `wrap_union`, feeding a
+  distinct `"union_{i}"` port. Distinct names are required, not cosmetic: `add_port` is
+  last-writer-wins, the repository manager keys by `(operator_id, port_id)`, and the pipeline-finish
+  gate reads `is_source_pipeline_finished()` / `all_ports_empty()` across the `ports` map — a shared
+  name would orphan an arm's repository and finish the pipeline while that arm still had rows.
+- **`PASSTHROUGH_SINK -> UNION` is `PARTIAL`.** The base's default is `FULL`, which
+  would hold every arm's entire output in repositories until all of them finished. A stateless bag
+  union never needs a complete side.
+- **Overrides both task-driver methods.** The base is lockstep — ready only when *every* port has
+  data, then one batch popped from every port — which strands the long arm once a short one drains.
+  `UNION` reports ready when *any* arm has a batch and pops one batch from one arm. One arm per task
+  also preserves device placement: a task runs on one GPU, so bundling arms would reintroduce the
+  migration the passthrough sink removes.
+- **`source_order()` is `NO_ORDER`.** `order_preservation_recursive` stops at the first `is_source()`
+  operator, so this answer decides the whole plan's; `INSERTION_ORDER` would claim an ordering a bag
+  union does not provide.
+- **Carriers.** The compressed-schema pass treats `UNION` as a native boundary (its `default` arm
+  restores every child), which is also what prevents two arms presenting different physical carriers
+  for the same logical column.
+
 ### `sirius_physical_order` — `ORDER_BY`
 **File:** `src/include/op/sirius_physical_order.hpp`
 
@@ -387,6 +417,25 @@ Reassembles partitioned data back into a linear stream. Behavior depends on join
 
 - `_concat_all = true` (LEFT/ANTI/OUTER joins): waits for all data before emitting
 - `_concat_all = false` (INNER joins): emits tasks when byte threshold (`_concat_batch_bytes`) is met
+
+### `sirius_physical_passthrough_sink` — `PASSTHROUGH_SINK`
+**File:** `src/include/op/sirius_physical_passthrough_sink.hpp`
+
+Terminates one arm of a `UNION`. Where a join arm is wrapped `PARTITION -> CONCAT`, a bag union
+needs neither a shuffle nor a coalesce, so a single operator does the job: forward every batch
+unchanged into the downstream `UNION`'s `"union_{i}"` port.
+
+- **Emits `pipelineable_operator_data`, not `partitioned_operator_data`.** With no `partition_idx`,
+  the task creator's device selection falls through to data locality instead of
+  `partition_idx % num_gpus`, so each batch is consumed on the GPU its scan produced it on. A
+  single-partition `CONCAT` would pin every UNION task to GPU 0.
+- **Pushes through the base `sink()`**, not `push_data_batch_partitioned`, so the receiving `UNION`
+  need not be a `partition_consumer_operator`.
+- **Owns its port name.** `sirius_physical_union::input_port_for` returns a `string_view` into
+  `_union_port_label`, and
+  both the wiring descriptor and `next_port_info` retain that view for the life of the query.
+- Inherits the base task-driver methods: it is single-input, so the fan-in hazards that force
+  `UNION` to override them cannot arise.
 
 ### `sirius_physical_sort_sample` — `SORT_SAMPLE`
 **File:** `src/include/op/sirius_physical_sort_sample.hpp`
@@ -490,8 +539,10 @@ After pipeline finalization, `source` and `sink` are just aliases for the first 
 | NESTED_LOOP_JOIN | Join | Fallback nested loops |
 | LEFT_DELIM_JOIN | Join | Correlated subquery wrapper |
 | RIGHT_DELIM_JOIN | Join | Correlated subquery wrapper |
+| UNION | Set op | `UNION ALL` only; N-ary identity fan-in, no data touched |
 | PARTITION | Pipeline | Hash/range partitioning |
 | CONCAT | Pipeline | Partition reassembly |
+| PASSTHROUGH_SINK | Pipeline | UNION arm terminator; forwards batches unpartitioned |
 | MERGE_TOP_N | Pipeline | Merge per-partition top-N |
 | CTE | CTE | Materialize to ColumnDataCollection |
 | RESULT_COLLECTOR | Result | Final result materialization |

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -332,8 +332,7 @@ over `children`. Distinct `UNION`, `EXCEPT` and `INTERSECT` are rejected by the 
 - **`source_order()` is `NO_ORDER`.** `order_preservation_recursive` stops at the first `is_source()`
   operator, so this answer decides the whole plan's.
 - **Arm ports are cached.** Both task-driver methods run on every task-creation walk that reaches
-  the operator, and resolving a `"union_{i}"` name costs two `std::string` allocations, so the
-  names are resolved to `port*` once on first use.
+  the operator, so the `"union_{i}"` names are resolved to `port*` once on first use.
 - **Carriers.** The compressed-schema pass treats `UNION` as a native boundary, which prevents two
   arms presenting different physical carriers for the same logical column.
 
@@ -425,8 +424,7 @@ neither half of.
 
 - **Emits `pipelineable_operator_data`, not `partitioned_operator_data`.** With no `partition_idx`
   the task creator selects a device by data locality instead of `partition_idx % num_gpus`, so each
-  batch is consumed on the GPU its scan produced it on. A single-partition `CONCAT` would pin every
-  UNION task to GPU 0.
+  batch is consumed on the GPU its scan produced it on.
 - **Owns its port name.** `sirius_physical_union::input_port_for` returns a `string_view` into
   `_union_port_label`, which the wiring descriptor and `next_port_info` retain for the life of the
   query.

--- a/src/include/op/sirius_physical_operator_type.hpp
+++ b/src/include/op/sirius_physical_operator_type.hpp
@@ -139,6 +139,8 @@ enum class SiriusPhysicalOperatorType : uint8_t {
   // -----------------------------
   PARTITION,
   CONCAT,
+  //! Non-partitioning arm terminator for UNION: forwards batches unchanged and unpartitioned.
+  PASSTHROUGH_SINK,
   MERGE_SORT,
   MERGE_GROUP_BY,
   MERGE_TOP_N,

--- a/src/include/op/sirius_physical_operator_type.hpp
+++ b/src/include/op/sirius_physical_operator_type.hpp
@@ -139,7 +139,6 @@ enum class SiriusPhysicalOperatorType : uint8_t {
   // -----------------------------
   PARTITION,
   CONCAT,
-  //! Non-partitioning arm terminator for UNION: forwards batches unchanged and unpartitioned.
   PASSTHROUGH_SINK,
   MERGE_SORT,
   MERGE_GROUP_BY,

--- a/src/include/op/sirius_physical_passthrough_sink.hpp
+++ b/src/include/op/sirius_physical_passthrough_sink.hpp
@@ -27,15 +27,24 @@ namespace op {
 //! unchanged into the downstream UNION's per-arm input port. It replaces the join's
 //! `PARTITION -> CONCAT` feeder chain, which a bag union needs neither half of.
 //!
-//! It emits plain `pipelineable_operator_data`, so the batch carries no `partition_idx` and
+//! Two properties are load-bearing, and both come from *not* being a CONCAT. It emits plain
+//! `pipelineable_operator_data`, so the batch carries no `partition_idx` and
 //! `task_creator::create_task` selects a device by data locality rather than
 //! `partition_idx % num_gpus` — each batch is consumed on the GPU its scan produced it on. A
-//! single-partition CONCAT would instead pin every UNION task to GPU 0.
+//! single-partition CONCAT would instead pin every UNION task to GPU 0. And it pushes through the
+//! base `sink()` rather than `push_data_batch_partitioned`, so the receiving UNION need not be a
+//! `sirius_physical_partition_consumer_operator`.
 //!
 //! Each arm's sink owns the `"union_{i}"` port name it feeds: the consuming UNION's
 //! `input_port_for` hands back a `string_view` into that member which the wiring descriptor and
 //! `next_port_info` retain for the life of the query, so the storage has to live on a plan-tree
 //! node.
+//!
+//! Deliberately *not* overridden, in both cases because the base is already right. `sink()` pushes
+//! every batch of a `pipelineable_operator_data` to each `next_port_after_sink` via
+//! `push_data_batch`, which is this operator's whole contract; CONCAT overrides it only to thread a
+//! `partition_idx`. `get_next_task_hint` / `get_next_task_input_data` degenerate at arity 1 to the
+//! right behavior, so the fan-in hazards that force UNION to override them cannot arise here.
 class sirius_physical_passthrough_sink : public sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE =
@@ -43,9 +52,9 @@ class sirius_physical_passthrough_sink : public sirius_physical_operator {
 
   //! @param types       Output schema; identical to the arm's own schema.
   //! @param port_label  The downstream port this arm feeds, `sirius_physical_union::port_label(i)`.
-  sirius_physical_passthrough_sink(duckdb::vector<sirius::logical_type> types,
-                                   std::size_t estimated_cardinality,
-                                   std::string port_label);
+  explicit sirius_physical_passthrough_sink(duckdb::vector<sirius::logical_type> types,
+                                            std::size_t estimated_cardinality,
+                                            std::string port_label);
 
   std::string get_name() const override;
 
@@ -59,6 +68,7 @@ class sirius_physical_passthrough_sink : public sirius_physical_operator {
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
 
+  //! The `"union_{i}"` label this arm feeds; read by `sirius_physical_union::input_port_for`.
   [[nodiscard]] const std::string& union_port_label() const noexcept { return _union_port_label; }
 
   //! Pure forwarder: no device allocation beyond the batches already resident.

--- a/src/include/op/sirius_physical_passthrough_sink.hpp
+++ b/src/include/op/sirius_physical_passthrough_sink.hpp
@@ -32,7 +32,8 @@ namespace op {
 //!   - It emits plain `pipelineable_operator_data`, so the batch carries no `partition_idx`. Task
 //!     device selection therefore falls through to data locality instead of
 //!     `partition_idx % num_gpus`, and each batch is consumed on the GPU its scan produced it on
-//!     (`task_creator::create_task`). A single-partition CONCAT would pin every UNION task to GPU 0.
+//!     (`task_creator::create_task`). A single-partition CONCAT would pin every UNION task to GPU
+//!     0.
 //!   - It pushes through the base `sink()`, not `push_data_batch_partitioned`, so the receiving
 //!     UNION need not be a `sirius_physical_partition_consumer_operator`.
 //!

--- a/src/include/op/sirius_physical_passthrough_sink.hpp
+++ b/src/include/op/sirius_physical_passthrough_sink.hpp
@@ -24,29 +24,24 @@ namespace sirius {
 namespace op {
 
 //! Terminates one arm of a UNION: a non-partitioning pipeline sink that forwards every batch
-//! unchanged into the downstream UNION's per-arm input port. It is the UNION counterpart of the
-//! join's `PARTITION -> CONCAT` feeder chain, collapsed to a single operator because a bag union
-//! needs neither a shuffle nor a coalesce.
+//! unchanged into the downstream UNION's per-arm input port. It replaces the join's
+//! `PARTITION -> CONCAT` feeder chain, which a bag union needs neither half of.
 //!
-//! Two properties are load-bearing, and both come from *not* being a CONCAT:
-//!   - It emits plain `pipelineable_operator_data`, so the batch carries no `partition_idx`. Task
-//!     device selection therefore falls through to data locality instead of
-//!     `partition_idx % num_gpus`, and each batch is consumed on the GPU its scan produced it on
-//!     (`task_creator::create_task`). A single-partition CONCAT would pin every UNION task to GPU
-//!     0.
-//!   - It pushes through the base `sink()`, not `push_data_batch_partitioned`, so the receiving
-//!     UNION need not be a `sirius_physical_partition_consumer_operator`.
+//! It emits plain `pipelineable_operator_data`, so the batch carries no `partition_idx` and
+//! `task_creator::create_task` selects a device by data locality rather than
+//! `partition_idx % num_gpus` — each batch is consumed on the GPU its scan produced it on. A
+//! single-partition CONCAT would instead pin every UNION task to GPU 0.
 //!
-//! Each arm's sink owns the `"union_{i}"` port name it feeds. The consuming UNION's
-//! `input_port_for` hands back a
-//! `string_view` into that member and both the wiring descriptor and `next_port_info` retain the
-//! view for the life of the query, so the storage has to live on a plan-tree node.
+//! Each arm's sink owns the `"union_{i}"` port name it feeds: the consuming UNION's
+//! `input_port_for` hands back a `string_view` into that member which the wiring descriptor and
+//! `next_port_info` retain for the life of the query, so the storage has to live on a plan-tree
+//! node.
 class sirius_physical_passthrough_sink : public sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE =
     SiriusPhysicalOperatorType::PASSTHROUGH_SINK;
 
-  //! @param types       Output schema; identical to the arm's own schema (nothing is reshaped).
+  //! @param types       Output schema; identical to the arm's own schema.
   //! @param port_label  The downstream port this arm feeds, `sirius_physical_union::port_label(i)`.
   sirius_physical_passthrough_sink(duckdb::vector<sirius::logical_type> types,
                                    std::size_t estimated_cardinality,
@@ -54,28 +49,16 @@ class sirius_physical_passthrough_sink : public sirius_physical_operator {
 
   std::string get_name() const override;
 
-  //! Mirrors CONCAT's dual role: it both produces its arm's tasks and terminates the arm pipeline.
-  //! `is_source()` also satisfies `sirius_pipeline::reset_source` for the arm shapes where this
-  //! sink ends up alone in its pipeline (an arm whose root is itself an unconditional sink, e.g.
-  //! an aggregate); in the common scan-rooted arm it is the last operator of the scan's pipeline.
+  //! Both, as CONCAT is: this operator produces its arm's tasks and terminates the arm pipeline.
+  //! `is_source()` also satisfies `sirius_pipeline::reset_source` for an arm whose root is itself
+  //! an unconditional sink, where this operator ends up alone in its pipeline.
   bool is_source() const override;
   bool is_sink() const override;
 
-  //! Identity forward. The only reason to override `execute` at all is that the base returns an
-  //! empty batch vector.
+  //! Identity forward, overridden only because the base returns an empty batch vector.
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
 
-  //! No `sink()` override: the base already pushes every batch of a `pipelineable_operator_data`
-  //! to each `next_port_after_sink` via `push_data_batch`, which is exactly this operator's
-  //! contract. Contrast CONCAT, which overrides it only to thread a `partition_idx`.
-
-  //! No `get_next_task_hint` / `get_next_task_input_data` overrides either. This sink is
-  //! single-input, so the base's all-ports readiness test and one-batch-per-port pop both
-  //! degenerate to the correct behavior; the fan-in hazards that force UNION to override them
-  //! cannot arise at arity 1.
-
-  //! The `"union_{i}"` label this arm feeds; read by `sirius_physical_union::input_port_for`.
   [[nodiscard]] const std::string& union_port_label() const noexcept { return _union_port_label; }
 
   //! Pure forwarder: no device allocation beyond the batches already resident.

--- a/src/include/op/sirius_physical_passthrough_sink.hpp
+++ b/src/include/op/sirius_physical_passthrough_sink.hpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "op/sirius_physical_operator.hpp"
+
+#include <string>
+
+namespace sirius {
+namespace op {
+
+//! Terminates one arm of a UNION: a non-partitioning pipeline sink that forwards every batch
+//! unchanged into the downstream UNION's per-arm input port. It is the UNION counterpart of the
+//! join's `PARTITION -> CONCAT` feeder chain, collapsed to a single operator because a bag union
+//! needs neither a shuffle nor a coalesce.
+//!
+//! Two properties are load-bearing, and both come from *not* being a CONCAT:
+//!   - It emits plain `pipelineable_operator_data`, so the batch carries no `partition_idx`. Task
+//!     device selection therefore falls through to data locality instead of
+//!     `partition_idx % num_gpus`, and each batch is consumed on the GPU its scan produced it on
+//!     (`task_creator::create_task`). A single-partition CONCAT would pin every UNION task to GPU 0.
+//!   - It pushes through the base `sink()`, not `push_data_batch_partitioned`, so the receiving
+//!     UNION need not be a `sirius_physical_partition_consumer_operator`.
+//!
+//! Each arm's sink owns the `"union_{i}"` port name it feeds. The consuming UNION's
+//! `input_port_for` hands back a
+//! `string_view` into that member and both the wiring descriptor and `next_port_info` retain the
+//! view for the life of the query, so the storage has to live on a plan-tree node.
+class sirius_physical_passthrough_sink : public sirius_physical_operator {
+ public:
+  static constexpr const SiriusPhysicalOperatorType TYPE =
+    SiriusPhysicalOperatorType::PASSTHROUGH_SINK;
+
+  //! @param types       Output schema; identical to the arm's own schema (nothing is reshaped).
+  //! @param port_label  The downstream port this arm feeds, `sirius_physical_union::port_label(i)`.
+  sirius_physical_passthrough_sink(duckdb::vector<sirius::logical_type> types,
+                                   std::size_t estimated_cardinality,
+                                   std::string port_label);
+
+  std::string get_name() const override;
+
+  //! Mirrors CONCAT's dual role: it both produces its arm's tasks and terminates the arm pipeline.
+  //! `is_source()` also satisfies `sirius_pipeline::reset_source` for the arm shapes where this
+  //! sink ends up alone in its pipeline (an arm whose root is itself an unconditional sink, e.g.
+  //! an aggregate); in the common scan-rooted arm it is the last operator of the scan's pipeline.
+  bool is_source() const override;
+  bool is_sink() const override;
+
+  //! Identity forward. The only reason to override `execute` at all is that the base returns an
+  //! empty batch vector.
+  std::unique_ptr<operator_data> execute(const operator_data& input_data,
+                                         rmm::cuda_stream_view stream) override;
+
+  //! No `sink()` override: the base already pushes every batch of a `pipelineable_operator_data`
+  //! to each `next_port_after_sink` via `push_data_batch`, which is exactly this operator's
+  //! contract. Contrast CONCAT, which overrides it only to thread a `partition_idx`.
+
+  //! No `get_next_task_hint` / `get_next_task_input_data` overrides either. This sink is
+  //! single-input, so the base's all-ports readiness test and one-batch-per-port pop both
+  //! degenerate to the correct behavior; the fan-in hazards that force UNION to override them
+  //! cannot arise at arity 1.
+
+  //! The `"union_{i}"` label this arm feeds; read by `sirius_physical_union::input_port_for`.
+  [[nodiscard]] const std::string& union_port_label() const noexcept { return _union_port_label; }
+
+  //! Pure forwarder: no device allocation beyond the batches already resident.
+  [[nodiscard]] std::size_t no_history_peak_memory_estimate(
+    const op::input_stats& /*stats*/) const override
+  {
+    return 0;
+  }
+
+ private:
+  //! Owns the storage behind the `string_view` in the wiring descriptor and in the upstream
+  //! operator's `next_port_info`, both of which outlive plan conversion.
+  std::string _union_port_label;
+};
+
+}  // namespace op
+}  // namespace sirius

--- a/src/include/op/sirius_physical_passthrough_sink.hpp
+++ b/src/include/op/sirius_physical_passthrough_sink.hpp
@@ -27,24 +27,11 @@ namespace op {
 //! unchanged into the downstream UNION's per-arm input port. It replaces the join's
 //! `PARTITION -> CONCAT` feeder chain, which a bag union needs neither half of.
 //!
-//! Two properties are load-bearing, and both come from *not* being a CONCAT. It emits plain
-//! `pipelineable_operator_data`, so the batch carries no `partition_idx` and
+//! Emitting plain `pipelineable_operator_data` is the load-bearing part: with no `partition_idx`,
 //! `task_creator::create_task` selects a device by data locality rather than
-//! `partition_idx % num_gpus` — each batch is consumed on the GPU its scan produced it on. A
-//! single-partition CONCAT would instead pin every UNION task to GPU 0. And it pushes through the
-//! base `sink()` rather than `push_data_batch_partitioned`, so the receiving UNION need not be a
+//! `partition_idx % num_gpus`, so each batch is consumed on the GPU its scan produced it on.
+//! Pushing through the base `sink()` also means the receiving UNION need not be a
 //! `sirius_physical_partition_consumer_operator`.
-//!
-//! Each arm's sink owns the `"union_{i}"` port name it feeds: the consuming UNION's
-//! `input_port_for` hands back a `string_view` into that member which the wiring descriptor and
-//! `next_port_info` retain for the life of the query, so the storage has to live on a plan-tree
-//! node.
-//!
-//! Deliberately *not* overridden, in both cases because the base is already right. `sink()` pushes
-//! every batch of a `pipelineable_operator_data` to each `next_port_after_sink` via
-//! `push_data_batch`, which is this operator's whole contract; CONCAT overrides it only to thread a
-//! `partition_idx`. `get_next_task_hint` / `get_next_task_input_data` degenerate at arity 1 to the
-//! right behavior, so the fan-in hazards that force UNION to override them cannot arise here.
 class sirius_physical_passthrough_sink : public sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE =
@@ -58,9 +45,8 @@ class sirius_physical_passthrough_sink : public sirius_physical_operator {
 
   std::string get_name() const override;
 
-  //! Both, as CONCAT is: this operator produces its arm's tasks and terminates the arm pipeline.
-  //! `is_source()` also satisfies `sirius_pipeline::reset_source` for an arm whose root is itself
-  //! an unconditional sink, where this operator ends up alone in its pipeline.
+  //! Both, as CONCAT is. `is_source()` also satisfies `sirius_pipeline::reset_source` for an arm
+  //! whose root is itself an unconditional sink, leaving this operator alone in its pipeline.
   bool is_source() const override;
   bool is_sink() const override;
 
@@ -68,7 +54,7 @@ class sirius_physical_passthrough_sink : public sirius_physical_operator {
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
 
-  //! The `"union_{i}"` label this arm feeds; read by `sirius_physical_union::input_port_for`.
+  //! Read by `sirius_physical_union::input_port_for`.
   [[nodiscard]] const std::string& union_port_label() const noexcept { return _union_port_label; }
 
   //! Pure forwarder: no device allocation beyond the batches already resident.

--- a/src/include/op/sirius_physical_passthrough_sink.hpp
+++ b/src/include/op/sirius_physical_passthrough_sink.hpp
@@ -37,7 +37,8 @@ class sirius_physical_passthrough_sink : public sirius_physical_operator {
   static constexpr const SiriusPhysicalOperatorType TYPE =
     SiriusPhysicalOperatorType::PASSTHROUGH_SINK;
 
-  //! @param types       Output schema; identical to the arm's own schema.
+  //! @param types       Output schema: the union's, since a materialized CTE arm declares its
+  //!                    materialization side rather than what it emits.
   //! @param port_label  The downstream port this arm feeds, `sirius_physical_union::port_label(i)`.
   explicit sirius_physical_passthrough_sink(duckdb::vector<sirius::logical_type> types,
                                             std::size_t estimated_cardinality,

--- a/src/include/op/sirius_physical_union.hpp
+++ b/src/include/op/sirius_physical_union.hpp
@@ -95,10 +95,12 @@ class sirius_physical_union : public sirius_physical_operator {
   [[nodiscard]] MemoryBarrierType input_barrier_for(
     sirius_physical_operator const& producer) const override;
 
-  //! READY when *any* arm has a batch, popping one batch from one arm. The base is lockstep —
-  //! READY only when every port has data, then one batch from every port — which strands a long
-  //! arm's remaining batches once a short arm drains and its pipeline finishes. One arm per task
-  //! also keeps each batch on the GPU that produced it, since a task runs on one device.
+  //! READY when every *live* arm has a batch, popping one batch from one arm. The base is lockstep
+  //! — READY only when every port has data, then one batch from every port — which strands a long
+  //! arm's remaining batches once a short arm drains and its pipeline finishes. Excusing a finished
+  //! arm is the whole difference; arms still producing rendezvous. A starved arm (live producer,
+  //! empty port) outranks a ready one, because nothing else will start it. One arm per task also
+  //! keeps each batch on the GPU that produced it, since a task runs on one device.
   std::optional<task_creation_hint> get_next_task_hint() override;
   std::unique_ptr<operator_data> get_next_task_input_data() override;
 

--- a/src/include/op/sirius_physical_union.hpp
+++ b/src/include/op/sirius_physical_union.hpp
@@ -24,40 +24,30 @@
 namespace sirius {
 namespace op {
 
-//! Physical `UNION ALL`: an N-ary, non-materializing fan-in. Bag (multiset) union computes
-//! nothing — no de-duplication, no key, no comparison, no ordering guarantee — so this operator
-//! only routes batches from all of its arms into one downstream stream. `execute` is the identity.
+//! Physical `UNION ALL`: an N-ary, non-materializing fan-in. Bag union computes nothing, so this
+//! operator only routes batches from every arm into one downstream stream and `execute` is the
+//! identity. Distinct `UNION`, `EXCEPT` and `INTERSECT` never reach it: the plan builder accepts
+//! only `setop_all == true`.
 //!
-//! Each arm is wrapped `child -> PASSTHROUGH_SINK` by `wrap_union`, and each sink feeds a
-//! *distinct* input port, `port_label(i)` for `children[i]`. Distinct ports are mandatory rather
-//! than tidy: `add_port` is last-writer-wins on the name, the repository manager keys by
-//! `(operator_id, port_id)`, and the pipeline-finish gate reads `is_source_pipeline_finished()` /
-//! `all_ports_empty()` across the `ports` map — so a shared name would orphan an arm's repository
-//! and let the UNION pipeline finish while that arm still had rows.
-//!
-//! N-ary, not binary: DuckDB binds `a UNION ALL b UNION ALL c` to one `LogicalSetOperation` with
-//! three children, and `UNION BY NAME` / macro expansion can produce N-ary nodes regardless. A
-//! "handle exactly 2" cut would silently fall back to the CPU on the common 3-way chain.
-//!
-//! Distinct `UNION`, `EXCEPT` and `INTERSECT` never reach this operator: the plan builder accepts
-//! only `setop_all == true`, so those still fall back to the CPU.
+//! `wrap_union` wraps each arm `child -> PASSTHROUGH_SINK`, and each sink feeds a *distinct* input
+//! port, `port_label(i)` for `children[i]`. The distinct names are a correctness requirement:
+//! `add_port` is last-writer-wins and the repository manager keys by `(operator_id, port_id)`, so a
+//! shared name would orphan an arm's repository and let the pipeline finish while that arm still
+//! had rows.
 class sirius_physical_union : public sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::UNION;
 
-  //! @param types  Output schema. The binder has already cast every arm to the per-column common
-  //!               super-type and guaranteed matching arity and order, so this is carried through
-  //!               unchanged and Sirius does no type reconciliation of its own.
+  //! @param types  Output schema, carried through unchanged. The binder has already cast every
+  //!               arm to the common super-type, so Sirius does no type reconciliation itself.
   explicit sirius_physical_union(duckdb::vector<sirius::logical_type> types,
                                  std::size_t estimated_cardinality);
 
-  //! The input port name for arm `i` — the single definition of the `"union_{i}"` convention,
-  //! shared by `wrap_union` (which labels each arm's sink) and the task-driver methods below.
+  //! The input port name for arm `i`; the single definition of the `"union_{i}"` convention.
   //!
-  //! Returns by value. Safe to feed straight to `get_port`, which copies into a `std::string` to
-  //! index `ports`. NOT safe as the return of `input_port_for`, which hands back a `string_view`
-  //! that both the wiring descriptor and `next_port_info` retain — that view must point at the
-  //! passthrough sink's own `_union_port_label`, which this helper initialises.
+  //! Returns by value, so it is safe for `get_port` (which copies) but NOT as the return of
+  //! `input_port_for`, whose `string_view` is retained by the wiring descriptor and
+  //! `next_port_info`. That view must point at the sink's own `_union_port_label` instead.
   [[nodiscard]] static std::string port_label(std::size_t arm_index)
   {
     return "union_" + std::to_string(arm_index);
@@ -65,26 +55,19 @@ class sirius_physical_union : public sirius_physical_operator {
 
   std::string get_name() const override;
 
-  //! Always a source: UNION drains its arms' port repositories and re-emits each batch.
   bool is_source() const override;
 
-  //! `is_sink()` is deliberately not overridden. The base rule — sink iff the tree parent is a
-  //! PARTITION or RIGHT_DELIM_JOIN — is already right: UNION is a sink exactly when it feeds a
-  //! downstream shuffle (a UNION under a GROUP BY or a join) and a plain source otherwise.
-
-  //! `NO_ORDER`, not `INSERTION_ORDER`. `order_preservation_recursive` stops at the first
-  //! `is_source()` operator, so UNION's answer decides the whole plan's, and `INSERTION_ORDER`
-  //! would have the plan claim an ordering a bag union explicitly does not provide. Same answer,
-  //! same reason, as GROUPED_AGGREGATE and DELIM_JOIN.
+  //! `NO_ORDER`: `order_preservation_recursive` stops at the first `is_source()` operator, so this
+  //! answer decides the whole plan's, and a bag union provides no ordering.
   sirius::OrderPreservationType source_order() const override;
 
-  //! The base throws for a non-sink operator with more than one child, so every multi-input
-  //! operator supplies its own. This is the hash join's shape looped over N arms.
+  //! The base throws for a non-sink operator with more than one child, so a multi-input operator
+  //! must supply its own.
   void build_pipelines(pipeline::sirius_pipeline& current,
                        pipeline::sirius_meta_pipeline& meta_pipeline) override;
 
-  //! The base recurses into `children[0]` and throws when there is more than one child. Collect
-  //! every arm's sources instead, so the debug plan verification pass accepts an N-ary node.
+  //! The base recurses into `children[0]` and throws when there is more than one child; collect
+  //! every arm's sources instead.
   duckdb::vector<duckdb::const_reference<sirius_physical_operator>> get_sources() const override;
 
   //! Identity: forward the batch that `get_next_task_input_data` popped, unchanged.
@@ -100,26 +83,15 @@ class sirius_physical_union : public sirius_physical_operator {
     sirius_physical_operator const& producer) const override;
 
   //! A UNION arm streams: bag union keeps no cross-batch state and makes no ordering guarantee, so
-  //! it never needs a complete side. Under the base's FULL default, `get_next_task_hint` would
-  //! refuse a task until *every* arm's pipeline finished, holding all arms' output in repositories
-  //! — maximum peak memory and no producer/consumer overlap for an operator that only forwards.
-  //! The UNION operator overrides the hint and does not read `port::type`, so this is the operator
-  //! declaring the same contract it already implements rather than a behavior change.
+  //! it never needs a complete side. The base's default is FULL, which would hold every arm's
+  //! output in repositories until all arms finished.
   [[nodiscard]] MemoryBarrierType input_barrier_for(
     sirius_physical_operator const& producer) const override;
 
-  //! Both task-driver methods must be overridden, for reasons independent of the port barrier.
-  //!
-  //! The base becomes READY only when *every* port has data and then pops one batch from *every*
-  //! port into a single task. That is the right contract for a join, which consumes one input per
-  //! side, and wrong for a fan-in whose arms are independent and rarely the same length: once the
-  //! short arm drains and its pipeline finishes, the readiness test can never hold again and the
-  //! long arm's remaining batches are stranded.
-  //!
-  //! UNION instead reports READY when *any* arm has a batch and pops one batch from one arm. The
-  //! one-arm-per-task rule is also what keeps Phase-2 device placement: a task runs on one GPU, so
-  //! bundling batches from several arms would force the cross-device migration this design exists
-  //! to avoid.
+  //! READY when *any* arm has a batch, popping one batch from one arm. The base is lockstep —
+  //! READY only when every port has data, then one batch from every port — which strands a long
+  //! arm's remaining batches once a short arm drains and its pipeline finishes. One arm per task
+  //! also keeps each batch on the GPU that produced it, since a task runs on one device.
   std::optional<task_creation_hint> get_next_task_hint() override;
   std::unique_ptr<operator_data> get_next_task_input_data() override;
 
@@ -131,20 +103,15 @@ class sirius_physical_union : public sirius_physical_operator {
   }
 
  private:
-  //! Arm ports in arm order, resolved once on first use. `get_port` allocates a `std::string` per
-  //! lookup and `port_label` allocates another, and both task-driver methods run on every
-  //! task-creation walk that reaches this operator, so the names are resolved to `port*` once and
-  //! reused. Callers must hold `lock`.
+  //! Arm ports in arm order, resolved once on first use. Callers must hold `lock`.
   const std::vector<port*>& arm_ports();
 
-  //! Arm to start the next pop at. Draining strictly from arm 0 would empty the first arm before
-  //! touching the rest, which works against the executor's per-batch rotation across GPUs.
-  //! Guarded by `lock`.
+  //! Arm to start the next pop at, so draining rotates across arms rather than emptying arm 0
+  //! first. Guarded by `lock`.
   std::size_t _arm_cursor = 0;
 
-  //! Arm to start the next producer nomination at, so successive `WAITING_FOR_INPUT_DATA` hints do
-  //! not keep naming the same arm. Kept separate from `_arm_cursor` so pop fairness and wait
-  //! fairness do not perturb each other. Guarded by `lock`.
+  //! Arm to start the next producer nomination at, so successive `WAITING_FOR_INPUT_DATA` hints
+  //! do not keep naming the same arm. Separate from `_arm_cursor`. Guarded by `lock`.
   std::size_t _wait_cursor = 0;
 
   //! Cache behind `arm_ports()`; empty until the wiring has been materialised.

--- a/src/include/op/sirius_physical_union.hpp
+++ b/src/include/op/sirius_physical_union.hpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "op/sirius_physical_operator.hpp"
+
+#include <string>
+#include <vector>
+
+namespace sirius {
+namespace op {
+
+//! Physical `UNION ALL`: an N-ary, non-materializing fan-in. Bag (multiset) union computes
+//! nothing — no de-duplication, no key, no comparison, no ordering guarantee — so this operator
+//! only routes batches from all of its arms into one downstream stream. `execute` is the identity.
+//!
+//! Each arm is wrapped `child -> PASSTHROUGH_SINK` by `wrap_union`, and each sink feeds a
+//! *distinct* input port, `port_label(i)` for `children[i]`. Distinct ports are mandatory rather
+//! than tidy: `add_port` is last-writer-wins on the name, the repository manager keys by
+//! `(operator_id, port_id)`, and the pipeline-finish gate reads `is_source_pipeline_finished()` /
+//! `all_ports_empty()` across the `ports` map — so a shared name would orphan an arm's repository
+//! and let the UNION pipeline finish while that arm still had rows.
+//!
+//! N-ary, not binary: DuckDB binds `a UNION ALL b UNION ALL c` to one `LogicalSetOperation` with
+//! three children, and `UNION BY NAME` / macro expansion can produce N-ary nodes regardless. A
+//! "handle exactly 2" cut would silently fall back to the CPU on the common 3-way chain.
+//!
+//! Distinct `UNION`, `EXCEPT` and `INTERSECT` never reach this operator: the plan builder accepts
+//! only `setop_all == true`, so those still fall back to the CPU.
+class sirius_physical_union : public sirius_physical_operator {
+ public:
+  static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::UNION;
+
+  //! @param types  Output schema. The binder has already cast every arm to the per-column common
+  //!               super-type and guaranteed matching arity and order, so this is carried through
+  //!               unchanged and Sirius does no type reconciliation of its own.
+  explicit sirius_physical_union(duckdb::vector<sirius::logical_type> types,
+                                 std::size_t estimated_cardinality);
+
+  //! The input port name for arm `i` — the single definition of the `"union_{i}"` convention,
+  //! shared by `wrap_union` (which labels each arm's sink) and the task-driver methods below.
+  //!
+  //! Returns by value. Safe to feed straight to `get_port`, which copies into a `std::string` to
+  //! index `ports`. NOT safe as the return of `input_port_for`, which hands back a `string_view`
+  //! that both the wiring descriptor and `next_port_info` retain — that view must point at the
+  //! passthrough sink's own `_union_port_label`, which this helper initialises.
+  [[nodiscard]] static std::string port_label(std::size_t arm_index)
+  {
+    return "union_" + std::to_string(arm_index);
+  }
+
+  std::string get_name() const override;
+
+  //! Always a source: UNION drains its arms' port repositories and re-emits each batch.
+  bool is_source() const override;
+
+  //! `is_sink()` is deliberately not overridden. The base rule — sink iff the tree parent is a
+  //! PARTITION or RIGHT_DELIM_JOIN — is already right: UNION is a sink exactly when it feeds a
+  //! downstream shuffle (a UNION under a GROUP BY or a join) and a plain source otherwise.
+
+  //! `NO_ORDER`, not `INSERTION_ORDER`. `order_preservation_recursive` stops at the first
+  //! `is_source()` operator, so UNION's answer decides the whole plan's, and `INSERTION_ORDER`
+  //! would have the plan claim an ordering a bag union explicitly does not provide. Same answer,
+  //! same reason, as GROUPED_AGGREGATE and DELIM_JOIN.
+  sirius::OrderPreservationType source_order() const override;
+
+  //! The base throws for a non-sink operator with more than one child, so every multi-input
+  //! operator supplies its own. This is the hash join's shape looped over N arms.
+  void build_pipelines(pipeline::sirius_pipeline& current,
+                       pipeline::sirius_meta_pipeline& meta_pipeline) override;
+
+  //! The base recurses into `children[0]` and throws when there is more than one child. Collect
+  //! every arm's sources instead, so the debug plan verification pass accepts an N-ary node.
+  duckdb::vector<duckdb::const_reference<sirius_physical_operator>> get_sources() const override;
+
+  //! Identity: forward the batch that `get_next_task_input_data` popped, unchanged.
+  std::unique_ptr<operator_data> execute(const operator_data& input_data,
+                                         rmm::cuda_stream_view stream) override;
+
+  //! Each arm feeds its own `"union_{i}"` port, labelled on that arm's PASSTHROUGH_SINK by
+  //! `wrap_union`. Distinct names are required, not cosmetic: `add_port` is last-writer-wins and
+  //! the repository manager keys by (operator_id, port_id), so a shared name would orphan an arm's
+  //! repository. The returned view is backed by the producer's own member, which outlives every
+  //! consumer of it.
+  [[nodiscard]] std::string_view input_port_for(
+    sirius_physical_operator const& producer) const override;
+
+  //! A UNION arm streams: bag union keeps no cross-batch state and makes no ordering guarantee, so
+  //! it never needs a complete side. Under the base's FULL default, `get_next_task_hint` would
+  //! refuse a task until *every* arm's pipeline finished, holding all arms' output in repositories
+  //! — maximum peak memory and no producer/consumer overlap for an operator that only forwards.
+  //! The UNION operator overrides the hint and does not read `port::type`, so this is the operator
+  //! declaring the same contract it already implements rather than a behavior change.
+  [[nodiscard]] MemoryBarrierType input_barrier_for(
+    sirius_physical_operator const& producer) const override;
+
+  //! Both task-driver methods must be overridden, for reasons independent of the port barrier.
+  //!
+  //! The base becomes READY only when *every* port has data and then pops one batch from *every*
+  //! port into a single task. That is the right contract for a join, which consumes one input per
+  //! side, and wrong for a fan-in whose arms are independent and rarely the same length: once the
+  //! short arm drains and its pipeline finishes, the readiness test can never hold again and the
+  //! long arm's remaining batches are stranded.
+  //!
+  //! UNION instead reports READY when *any* arm has a batch and pops one batch from one arm. The
+  //! one-arm-per-task rule is also what keeps Phase-2 device placement: a task runs on one GPU, so
+  //! bundling batches from several arms would force the cross-device migration this design exists
+  //! to avoid.
+  std::optional<task_creation_hint> get_next_task_hint() override;
+  std::unique_ptr<operator_data> get_next_task_input_data() override;
+
+  //! Pure forwarder: no device allocation beyond the batches already resident.
+  [[nodiscard]] std::size_t no_history_peak_memory_estimate(
+    const op::input_stats& /*stats*/) const override
+  {
+    return 0;
+  }
+
+ private:
+  //! Arm ports in arm order, resolved once on first use. `get_port` allocates a `std::string` per
+  //! lookup and `port_label` allocates another, and both task-driver methods run on every
+  //! task-creation walk that reaches this operator, so the names are resolved to `port*` once and
+  //! reused. Callers must hold `lock`.
+  const std::vector<port*>& arm_ports();
+
+  //! Arm to start the next pop at. Draining strictly from arm 0 would empty the first arm before
+  //! touching the rest, which works against the executor's per-batch rotation across GPUs.
+  //! Guarded by `lock`.
+  std::size_t _arm_cursor = 0;
+
+  //! Arm to start the next producer nomination at, so successive `WAITING_FOR_INPUT_DATA` hints do
+  //! not keep naming the same arm. Kept separate from `_arm_cursor` so pop fairness and wait
+  //! fairness do not perturb each other. Guarded by `lock`.
+  std::size_t _wait_cursor = 0;
+
+  //! Cache behind `arm_ports()`; empty until the wiring has been materialised.
+  std::vector<port*> _arm_ports;
+};
+
+}  // namespace op
+}  // namespace sirius

--- a/src/include/op/sirius_physical_union.hpp
+++ b/src/include/op/sirius_physical_union.hpp
@@ -31,9 +31,11 @@ namespace op {
 //!
 //! `wrap_union` wraps each arm `child -> PASSTHROUGH_SINK`, and each sink feeds a *distinct* input
 //! port, `port_label(i)` for `children[i]`. The distinct names are a correctness requirement:
-//! `add_port` is last-writer-wins and the repository manager keys by `(operator_id, port_id)`, so a
-//! shared name would orphan an arm's repository and let the pipeline finish while that arm still
-//! had rows.
+//! `add_port` is last-writer-wins on the name, the repository manager keys by
+//! `(operator_id, port_id)`, and the pipeline-finish gate reads `is_source_pipeline_finished()` /
+//! `all_ports_empty()` across the same `ports` map. A shared name would therefore orphan an arm's
+//! repository, and because the orphan is no longer in that map, let the pipeline finish while that
+//! arm still had rows.
 class sirius_physical_union : public sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::UNION;
@@ -83,8 +85,13 @@ class sirius_physical_union : public sirius_physical_operator {
     sirius_physical_operator const& producer) const override;
 
   //! A UNION arm streams: bag union keeps no cross-batch state and makes no ordering guarantee, so
-  //! it never needs a complete side. The base's default is FULL, which would hold every arm's
-  //! output in repositories until all arms finished.
+  //! it never needs a complete side. Same answer as the join's inbound edges, so a fan-in consumer
+  //! absorbed into its producers' branches is the established shape rather than a novelty. UNION
+  //! overrides its own hint and never reads `port::type`, but the value still matters:
+  //! `query_index` cuts a branch only on a FULL edge, so PARTIAL lets each arm's branch walk absorb
+  //! the UNION's pipeline rather than give it one of its own, which feeds scheduling priorities. It
+  //! is also what would keep the base hint from buffering every arm to completion, the day someone
+  //! simplifies UNION back onto it.
   [[nodiscard]] MemoryBarrierType input_barrier_for(
     sirius_physical_operator const& producer) const override;
 

--- a/src/include/op/sirius_physical_union.hpp
+++ b/src/include/op/sirius_physical_union.hpp
@@ -25,31 +25,22 @@ namespace sirius {
 namespace op {
 
 //! Physical `UNION ALL`: an N-ary, non-materializing fan-in. Bag union computes nothing, so this
-//! operator only routes batches from every arm into one downstream stream and `execute` is the
-//! identity. Distinct `UNION`, `EXCEPT` and `INTERSECT` never reach it: the plan builder accepts
-//! only `setop_all == true`.
+//! operator only routes batches and `execute` is the identity. Distinct `UNION`, `EXCEPT` and
+//! `INTERSECT` never reach it: the plan builder accepts only `setop_all == true`.
 //!
-//! `wrap_union` wraps each arm `child -> PASSTHROUGH_SINK`, and each sink feeds a *distinct* input
-//! port, `port_label(i)` for `children[i]`. The distinct names are a correctness requirement:
-//! `add_port` is last-writer-wins on the name, the repository manager keys by
-//! `(operator_id, port_id)`, and the pipeline-finish gate reads `is_source_pipeline_finished()` /
-//! `all_ports_empty()` across the same `ports` map. A shared name would therefore orphan an arm's
-//! repository, and because the orphan is no longer in that map, let the pipeline finish while that
-//! arm still had rows.
+//! `wrap_union` wraps each arm `child -> PASSTHROUGH_SINK`, and each sink feeds a distinct
+//! `port_label(i)` port.
 class sirius_physical_union : public sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::UNION;
 
-  //! @param types  Output schema, carried through unchanged. The binder has already cast every
-  //!               arm to the common super-type, so Sirius does no type reconciliation itself.
+  //! @param types  Output schema. The binder has already cast every arm to the common super-type,
+  //!               so Sirius does no type reconciliation itself.
   explicit sirius_physical_union(duckdb::vector<sirius::logical_type> types,
                                  std::size_t estimated_cardinality);
 
-  //! The input port name for arm `i`; the single definition of the `"union_{i}"` convention.
-  //!
-  //! Returns by value, so it is safe for `get_port` (which copies) but NOT as the return of
-  //! `input_port_for`, whose `string_view` is retained by the wiring descriptor and
-  //! `next_port_info`. That view must point at the sink's own `_union_port_label` instead.
+  //! Port name for arm `i`. Returns by value, so it cannot back `input_port_for`'s `string_view`,
+  //! which is retained by the wiring descriptor — that view points at the sink's own member.
   [[nodiscard]] static std::string port_label(std::size_t arm_index)
   {
     return "union_" + std::to_string(arm_index);
@@ -59,48 +50,32 @@ class sirius_physical_union : public sirius_physical_operator {
 
   bool is_source() const override;
 
-  //! `NO_ORDER`: `order_preservation_recursive` stops at the first `is_source()` operator, so this
-  //! answer decides the whole plan's, and a bag union provides no ordering.
+  //! `order_preservation_recursive` stops at the first `is_source()` operator, so this answer
+  //! decides the whole plan's.
   sirius::OrderPreservationType source_order() const override;
 
-  //! The base throws for a non-sink operator with more than one child, so a multi-input operator
-  //! must supply its own.
+  //! The base throws for a non-sink operator with more than one child.
   void build_pipelines(pipeline::sirius_pipeline& current,
                        pipeline::sirius_meta_pipeline& meta_pipeline) override;
 
-  //! The base recurses into `children[0]` and throws when there is more than one child; collect
-  //! every arm's sources instead.
+  //! The base recurses into `children[0]` only; collect every arm's sources instead.
   duckdb::vector<duckdb::const_reference<sirius_physical_operator>> get_sources() const override;
 
-  //! Identity: forward the batch that `get_next_task_input_data` popped, unchanged.
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
 
-  //! Each arm feeds its own `"union_{i}"` port, labelled on that arm's PASSTHROUGH_SINK by
-  //! `wrap_union`. Distinct names are required, not cosmetic: `add_port` is last-writer-wins and
-  //! the repository manager keys by (operator_id, port_id), so a shared name would orphan an arm's
-  //! repository. The returned view is backed by the producer's own member, which outlives every
-  //! consumer of it.
+  //! Distinct per arm, not cosmetic: `add_port` is last-writer-wins and repositories key by
+  //! `(operator_id, port_id)`, so a shared name orphans an arm's repository. The returned view is
+  //! backed by the producer's own member.
   [[nodiscard]] std::string_view input_port_for(
     sirius_physical_operator const& producer) const override;
 
-  //! A UNION arm streams: bag union keeps no cross-batch state and makes no ordering guarantee, so
-  //! it never needs a complete side. Same answer as the join's inbound edges, so a fan-in consumer
-  //! absorbed into its producers' branches is the established shape rather than a novelty. UNION
-  //! overrides its own hint and never reads `port::type`, but the value still matters:
-  //! `query_index` cuts a branch only on a FULL edge, so PARTIAL lets each arm's branch walk absorb
-  //! the UNION's pipeline rather than give it one of its own, which feeds scheduling priorities. It
-  //! is also what would keep the base hint from buffering every arm to completion, the day someone
-  //! simplifies UNION back onto it.
+  //! `PARTIAL`: a UNION arm streams, so it never needs a complete side. The base default `FULL`
+  //! would buffer every arm before emitting.
   [[nodiscard]] MemoryBarrierType input_barrier_for(
     sirius_physical_operator const& producer) const override;
 
-  //! READY when every *live* arm has a batch, popping one batch from one arm. The base is lockstep
-  //! — READY only when every port has data, then one batch from every port — which strands a long
-  //! arm's remaining batches once a short arm drains and its pipeline finishes. Excusing a finished
-  //! arm is the whole difference; arms still producing rendezvous. A starved arm (live producer,
-  //! empty port) outranks a ready one, because nothing else will start it. One arm per task also
-  //! keeps each batch on the GPU that produced it, since a task runs on one device.
+  //! Relaxes the lockstep base: a finished arm is excused, and a starved arm outranks a ready one.
   std::optional<task_creation_hint> get_next_task_hint() override;
   std::unique_ptr<operator_data> get_next_task_input_data() override;
 
@@ -123,7 +98,6 @@ class sirius_physical_union : public sirius_physical_operator {
   //! do not keep naming the same arm. Separate from `_arm_cursor`. Guarded by `lock`.
   std::size_t _wait_cursor = 0;
 
-  //! Cache behind `arm_ports()`; empty until the wiring has been materialised.
   std::vector<port*> _arm_ports;
 };
 

--- a/src/include/planner/sirius_physical_plan_generator.hpp
+++ b/src/include/planner/sirius_physical_plan_generator.hpp
@@ -53,6 +53,7 @@ class LogicalLimit;
 class LogicalOrder;
 class LogicalTopN;
 class LogicalProjection;
+class LogicalSetOperation;
 class LogicalMaterializedCTE;
 class LogicalCTERef;
 }  // namespace duckdb
@@ -166,8 +167,11 @@ class sirius_physical_plan_generator {
   // &op); duckdb::unique_ptr<sirius::op::sirius_physical_operator>
   // create_plan(duckdb::LogicalCopyToFile &op);
   // duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(duckdb::LogicalExplain
-  // &op); duckdb::unique_ptr<sirius::op::sirius_physical_operator>
-  // create_plan(duckdb::LogicalSetOperation &op);
+  // &op);
+  //! `UNION ALL` only; the builder rejects distinct UNION. EXCEPT / INTERSECT share the same
+  //! DuckDB node but keep their own throwing case in the dispatch switch, so they never arrive.
+  duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(
+    duckdb::LogicalSetOperation& op);
   // duckdb::unique_ptr<sirius::op::sirius_physical_operator> create_plan(duckdb::LogicalUpdate
   // &op); duckdb::unique_ptr<sirius::op::sirius_physical_operator>
   // create_plan(duckdb::LogicalPrepare &expr);

--- a/src/op/sirius_physical_operator_type.cpp
+++ b/src/op/sirius_physical_operator_type.cpp
@@ -105,6 +105,7 @@ std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type)
     case SiriusPhysicalOperatorType::UPDATE_EXTENSIONS: return "UPDATE_EXTENSIONS";
     case SiriusPhysicalOperatorType::PARTITION: return "PARTITION";
     case SiriusPhysicalOperatorType::CONCAT: return "CONCAT";
+    case SiriusPhysicalOperatorType::PASSTHROUGH_SINK: return "PASSTHROUGH_SINK";
     case SiriusPhysicalOperatorType::MERGE_SORT: return "MERGE_SORT";
     case SiriusPhysicalOperatorType::MERGE_GROUP_BY: return "MERGE_GROUP_BY";
     case SiriusPhysicalOperatorType::MERGE_TOP_N: return "MERGE_TOP_N";

--- a/src/op/sirius_physical_passthrough_sink.cpp
+++ b/src/op/sirius_physical_passthrough_sink.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_physical_passthrough_sink.hpp"
+
+#include "sirius/exception.hpp"
+
+#include <nvtx3/nvtx3.hpp>
+
+namespace sirius {
+namespace op {
+
+sirius_physical_passthrough_sink::sirius_physical_passthrough_sink(
+  duckdb::vector<sirius::logical_type> types,
+  std::size_t estimated_cardinality,
+  std::string port_label)
+  : sirius_physical_operator(SiriusPhysicalOperatorType::PASSTHROUGH_SINK,
+                             std::move(types),
+                             estimated_cardinality),
+    _union_port_label(std::move(port_label))
+{
+}
+
+std::string sirius_physical_passthrough_sink::get_name() const { return "PASSTHROUGH_SINK"; }
+
+bool sirius_physical_passthrough_sink::is_source() const { return true; }
+
+bool sirius_physical_passthrough_sink::is_sink() const { return true; }
+
+std::unique_ptr<operator_data> sirius_physical_passthrough_sink::execute(
+  const operator_data& input_data, rmm::cuda_stream_view /*stream*/)
+{
+  nvtx3::scoped_range nvtx_range{"sirius_physical_passthrough_sink::execute"};
+  // Re-wrap the same batches, deliberately as the base `pipelineable_operator_data` rather than a
+  // `partitioned_operator_data`: the absence of a partition index is what lets the task creator
+  // route the downstream UNION task by data locality. Forwarding the read-only accessors keeps the
+  // shared read lock held across the handoff, matching the other pass-through forwarders (CTE,
+  // DELIM_JOIN, COLUMN_DATA_SCAN).
+  const auto* pipelineable = dynamic_cast<const pipelineable_operator_data*>(&input_data);
+  if (pipelineable == nullptr) {
+    throw internal_exception(
+      "sirius_physical_passthrough_sink::execute: expected pipelineable_operator_data");
+  }
+  return std::make_unique<pipelineable_operator_data>(pipelineable->get_read_only_batches(false));
+}
+
+}  // namespace op
+}  // namespace sirius

--- a/src/op/sirius_physical_passthrough_sink.cpp
+++ b/src/op/sirius_physical_passthrough_sink.cpp
@@ -27,9 +27,8 @@ sirius_physical_passthrough_sink::sirius_physical_passthrough_sink(
   duckdb::vector<sirius::logical_type> types,
   std::size_t estimated_cardinality,
   std::string port_label)
-  : sirius_physical_operator(SiriusPhysicalOperatorType::PASSTHROUGH_SINK,
-                             std::move(types),
-                             estimated_cardinality),
+  : sirius_physical_operator(
+      SiriusPhysicalOperatorType::PASSTHROUGH_SINK, std::move(types), estimated_cardinality),
     _union_port_label(std::move(port_label))
 {
 }

--- a/src/op/sirius_physical_passthrough_sink.cpp
+++ b/src/op/sirius_physical_passthrough_sink.cpp
@@ -43,11 +43,10 @@ std::unique_ptr<operator_data> sirius_physical_passthrough_sink::execute(
   const operator_data& input_data, rmm::cuda_stream_view /*stream*/)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_passthrough_sink::execute"};
-  // Re-wrap the same batches, deliberately as the base `pipelineable_operator_data` rather than a
-  // `partitioned_operator_data`: the absence of a partition index is what lets the task creator
-  // route the downstream UNION task by data locality. Forwarding the read-only accessors keeps the
-  // shared read lock held across the handoff, matching the other pass-through forwarders (CTE,
-  // DELIM_JOIN, COLUMN_DATA_SCAN).
+  // Re-wrap as the base `pipelineable_operator_data`, not a `partitioned_operator_data`: the
+  // absence of a partition index is what lets the task creator route the downstream UNION task by
+  // data locality. Forwarding the read-only accessors keeps the shared read lock held across the
+  // handoff.
   const auto* pipelineable = dynamic_cast<const pipelineable_operator_data*>(&input_data);
   if (pipelineable == nullptr) {
     throw internal_exception(

--- a/src/op/sirius_physical_union.cpp
+++ b/src/op/sirius_physical_union.cpp
@@ -146,32 +146,36 @@ std::optional<task_creation_hint> sirius_physical_union::get_next_task_hint()
   const auto num_arms      = ports_by_arm.size();
   if (num_arms == 0) { return std::nullopt; }
 
-  sirius_physical_operator* live_producer = nullptr;
-  std::size_t live_arm                    = 0;
+  bool any_ready                             = false;
+  sirius_physical_operator* starved_producer = nullptr;
+  std::size_t starved_arm                    = 0;
   for (std::size_t offset = 0; offset < num_arms; offset++) {
-    const auto arm = (_wait_cursor + offset) % num_arms;
-    auto* p        = ports_by_arm[arm];
-    // Readiness is ANY, not ALL: one arm with a queued batch is enough to fire a task.
-    if (p->repo && p->repo->total_size() > 0) {
-      return task_creation_hint{TaskCreationHint::READY, this};
-    }
-    // Carry a still-producing arm rather than returning here: a later arm may have data, and
-    // READY outranks WAITING.
-    if (live_producer == nullptr && p->src_pipeline && !p->src_pipeline->is_pipeline_finished()) {
-      live_producer = &(p->src_pipeline->get_operators()[0].get());
-      live_arm      = arm;
+    const auto arm      = (_wait_cursor + offset) % num_arms;
+    auto* p             = ports_by_arm[arm];
+    const bool has_data = p->repo && p->repo->total_size() > 0;
+    const bool live     = p->src_pipeline && !p->src_pipeline->is_pipeline_finished();
+    any_ready           = any_ready || has_data;
+    if (!has_data && live && starved_producer == nullptr) {
+      starved_producer = &(p->src_pipeline->get_operators()[0].get());
+      starved_arm      = arm;
     }
   }
 
-  // `task_creator::get_operator_for_next_task` selects the next operator to run *only* by walking
-  // `hint.producer`, so a null producer here would leave the still-producing arm with nothing to
-  // run it. The walk is also all-or-nothing: when it yields no operator, `task_creator` abandons
-  // the whole task-creation request, so repeatedly nominating one stalled arm concentrates that
-  // loss on it. Advancing past the arm just nominated spreads it across the arms instead.
-  if (live_producer != nullptr) {
-    _wait_cursor = (live_arm + 1) % num_arms;
-    return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, live_producer};
+  // A starved arm outranks a ready one, because nothing else will start it.
+  // `task_creator::get_operator_for_next_task` reaches an operator *only* by walking
+  // `hint.producer`, and `task_scheduler::start_query` schedules `scans.front()` alone — so an arm
+  // is named here or never runs, and answering READY first spends that request on draining. The
+  // producer is likewise never null, or the still-producing arm has nothing to run it. The walk is
+  // all-or-nothing too: when it yields no operator `task_creator` abandons the whole request, so
+  // advancing past the arm just nominated spreads that loss instead of concentrating it on one.
+  if (starved_producer != nullptr) {
+    _wait_cursor = (starved_arm + 1) % num_arms;
+    return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, starved_producer};
   }
+
+  // Readiness is ANY, not ALL: one arm with a queued batch is enough to fire a task. An arm that
+  // finished without producing is not starved, which is what lets an empty arm through.
+  if (any_ready) { return task_creation_hint{TaskCreationHint::READY, this}; }
 
   return std::nullopt;
 }

--- a/src/op/sirius_physical_union.cpp
+++ b/src/op/sirius_physical_union.cpp
@@ -31,7 +31,6 @@ sirius_physical_union::sirius_physical_union(duckdb::vector<sirius::logical_type
   : sirius_physical_operator(
       SiriusPhysicalOperatorType::UNION, std::move(types), estimated_cardinality)
 {
-  // Nothing to configure: no keys, no join type, no dedup.
 }
 
 std::string sirius_physical_union::get_name() const { return "UNION"; }
@@ -92,10 +91,8 @@ std::unique_ptr<operator_data> sirius_physical_union::execute(const operator_dat
                                                               rmm::cuda_stream_view /*stream*/)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_union::execute"};
-  // Identity: no device work, no concat. get_next_task_input_data already popped the batch from
-  // one arm's repository; re-wrap the same batches. Forwarding the read-only accessors keeps the
-  // shared read lock held across the handoff, matching the other pass-through forwarders (CTE,
-  // DELIM_JOIN, COLUMN_DATA_SCAN).
+  // get_next_task_input_data already popped the batch; re-wrap it. Forwarding the read-only
+  // accessors keeps the shared read lock held across the handoff.
   const auto* pipelineable = dynamic_cast<const pipelineable_operator_data*>(&input_data);
   if (pipelineable == nullptr) {
     throw internal_exception("sirius_physical_union::execute: expected pipelineable_operator_data");
@@ -109,9 +106,8 @@ const std::vector<sirius_physical_operator::port*>& sirius_physical_union::arm_p
   _arm_ports.clear();
   _arm_ports.reserve(children.size());
   for (std::size_t i = 0; i < children.size(); i++) {
-    // get_port throws (listing the ports that do exist) when an arm has no port, which means the
-    // wiring dropped that arm. Failing loudly is the point: the alternative is silently returning
-    // a short row count.
+    // get_port throws when an arm has no port, meaning the wiring dropped that arm. Failing
+    // loudly is the point: the alternative is silently returning a short row count.
     _arm_ports.push_back(get_port(port_label(i)));
   }
   return _arm_ports;
@@ -138,9 +134,8 @@ std::optional<task_creation_hint> sirius_physical_union::get_next_task_hint()
 {
   std::lock_guard<std::mutex> lg(lock);
 
-  // One pass over the arms doing two jobs. The base splits this into three scans because it must
-  // distinguish FULL from PARTIAL ports; a UNION arm carries no cross-batch state, so the inbound
-  // edge is declared PARTIAL (`input_barrier_for`) and `port::type` is deliberately not consulted.
+  // `port::type` is deliberately not consulted: a UNION arm carries no cross-batch state, so its
+  // inbound edge is declared PARTIAL by this operator's `input_barrier_for`.
   const auto& ports_by_arm = arm_ports();
   const auto num_arms      = ports_by_arm.size();
   if (num_arms == 0) { return std::nullopt; }
@@ -150,34 +145,26 @@ std::optional<task_creation_hint> sirius_physical_union::get_next_task_hint()
   for (std::size_t offset = 0; offset < num_arms; offset++) {
     const auto arm = (_wait_cursor + offset) % num_arms;
     auto* p        = ports_by_arm[arm];
-    // Readiness is ANY, not ALL: one arm with a queued batch is enough to fire a task. The scan
-    // order does not affect this answer, only which arm is nominated below.
+    // Readiness is ANY, not ALL: one arm with a queued batch is enough to fire a task.
     if (p->repo && p->repo->total_size() > 0) {
       return task_creation_hint{TaskCreationHint::READY, this};
     }
-    // Otherwise remember one arm that is still producing. Unlike the base we cannot return here —
-    // a later arm may have data, and READY outranks WAITING — so the candidate is carried.
+    // Carry a still-producing arm rather than returning here: a later arm may have data, and
+    // READY outranks WAITING.
     if (live_producer == nullptr && p->src_pipeline && !p->src_pipeline->is_pipeline_finished()) {
       live_producer = &(p->src_pipeline->get_operators()[0].get());
       live_arm      = arm;
     }
   }
 
-  // No arm has data, but one is still producing: wait, and name that arm's producer.
   // `task_creator::get_operator_for_next_task` selects the next operator to run *only* by walking
   // `hint.producer`, so a null producer here means the still-producing arm never runs — a hang,
-  // not a wrong answer. Drained and finished arms are skipped: waiting on one would be pointless.
-  //
-  // Nominating strictly by arm index would keep naming the same producer, and a producer that
-  // cannot progress costs the whole task-creation request (task_creator drops the walk when it
-  // yields no operator). Advancing past the arm just nominated spreads that cost over the arms
-  // instead of concentrating it on the lowest-numbered stalled one.
+  // not a wrong answer. Advance the cursor so successive waits do not keep naming the same arm.
   if (live_producer != nullptr) {
     _wait_cursor = (live_arm + 1) % num_arms;
     return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, live_producer};
   }
 
-  // Every arm empty and every producer finished: exhausted.
   return std::nullopt;
 }
 
@@ -185,12 +172,9 @@ std::unique_ptr<operator_data> sirius_physical_union::get_next_task_input_data()
 {
   std::lock_guard<std::mutex> lg(lock);
 
-  // One batch from one arm, rather than the base's one-from-every-port bundle. Beyond the
-  // unequal-arm problem the bundle would also mix batches produced on different GPUs into a single
-  // task, which runs on one device — reintroducing the migration the passthrough sink removes.
-  //
-  // task_creator loops `while (!node->all_ports_empty())` around this call, so one batch per call
-  // still drains every arm within a scheduling round; the cursor only decides the order within it.
+  // One batch from one arm, not the base's one-from-every-port bundle, which would mix batches
+  // produced on different GPUs into a task that runs on one device. task_creator loops
+  // `while (!node->all_ports_empty())` around this call, so every arm still drains in a round.
   const auto& ports_by_arm = arm_ports();
   const auto num_arms      = ports_by_arm.size();
   if (num_arms == 0) { return nullptr; }
@@ -203,8 +187,8 @@ std::unique_ptr<operator_data> sirius_physical_union::get_next_task_input_data()
     _arm_cursor = (arm + 1) % num_arms;
     std::vector<std::shared_ptr<::cucascade::data_batch>> popped;
     popped.push_back(std::move(batch));
-    // pipelineable, not partitioned: no partition_idx, so the task creator routes this task by
-    // data locality and the batch is processed on the GPU that produced it.
+    // pipelineable, not partitioned: with no partition_idx the task creator routes by data
+    // locality, so the batch is processed on the GPU that produced it.
     return std::make_unique<pipelineable_operator_data>(std::move(popped));
   }
   return nullptr;

--- a/src/op/sirius_physical_union.cpp
+++ b/src/op/sirius_physical_union.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_physical_union.hpp"
+
+#include "op/sirius_physical_passthrough_sink.hpp"
+#include "pipeline/sirius_meta_pipeline.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "sirius/exception.hpp"
+
+#include <nvtx3/nvtx3.hpp>
+
+namespace sirius {
+namespace op {
+
+sirius_physical_union::sirius_physical_union(duckdb::vector<sirius::logical_type> types,
+                                             std::size_t estimated_cardinality)
+  : sirius_physical_operator(
+      SiriusPhysicalOperatorType::UNION, std::move(types), estimated_cardinality)
+{
+  // Nothing to configure: no keys, no join type, no dedup.
+}
+
+std::string sirius_physical_union::get_name() const { return "UNION"; }
+
+bool sirius_physical_union::is_source() const { return true; }
+
+sirius::OrderPreservationType sirius_physical_union::source_order() const
+{
+  return sirius::OrderPreservationType::NO_ORDER;
+}
+
+void sirius_physical_union::build_pipelines(pipeline::sirius_pipeline& current,
+                                            pipeline::sirius_meta_pipeline& meta_pipeline)
+{
+  // Mirrors sirius_physical_hash_join::build_pipelines, generalized from two sides to N arms.
+  pipeline::sirius_meta_pipeline* host_meta;
+  pipeline::sirius_pipeline* host_current;
+  if (is_sink()) {
+    auto& sink_meta = meta_pipeline.create_child_meta_pipeline(current, *this);
+    host_meta       = &sink_meta;
+    host_current    = sink_meta.get_base_pipeline().get();
+  } else {
+    meta_pipeline.get_state().add_pipeline_operator(current, *this);
+    host_meta    = &meta_pipeline;
+    host_current = &current;
+  }
+
+  // Every arm reaches UNION through a plan-gen PASSTHROUGH_SINK wrap. Create a child meta per arm
+  // terminating in that sink, then recurse *past* it so it does not redundantly create its own.
+  D_ASSERT(children.size() >= 2);
+  for (auto& child_slot : children) {
+    auto& child = *child_slot;
+    D_ASSERT(child.is_sink());
+    D_ASSERT(!child.children.empty());
+    auto& child_meta = host_meta->create_child_meta_pipeline(*host_current, child);
+    child_meta.build(*child.children[0]);
+  }
+}
+
+duckdb::vector<duckdb::const_reference<sirius_physical_operator>>
+sirius_physical_union::get_sources() const
+{
+  duckdb::vector<duckdb::const_reference<sirius_physical_operator>> result;
+  if (is_sink()) {
+    result.push_back(*this);
+    return result;
+  }
+  for (const auto& child : children) {
+    auto child_sources = child->get_sources();
+    for (const auto& source : child_sources) {
+      result.push_back(source);
+    }
+  }
+  return result;
+}
+
+std::unique_ptr<operator_data> sirius_physical_union::execute(const operator_data& input_data,
+                                                              rmm::cuda_stream_view /*stream*/)
+{
+  nvtx3::scoped_range nvtx_range{"sirius_physical_union::execute"};
+  // Identity: no device work, no concat. get_next_task_input_data already popped the batch from
+  // one arm's repository; re-wrap the same batches. Forwarding the read-only accessors keeps the
+  // shared read lock held across the handoff, matching the other pass-through forwarders (CTE,
+  // DELIM_JOIN, COLUMN_DATA_SCAN).
+  const auto* pipelineable = dynamic_cast<const pipelineable_operator_data*>(&input_data);
+  if (pipelineable == nullptr) {
+    throw internal_exception("sirius_physical_union::execute: expected pipelineable_operator_data");
+  }
+  return std::make_unique<pipelineable_operator_data>(pipelineable->get_read_only_batches(false));
+}
+
+const std::vector<sirius_physical_operator::port*>& sirius_physical_union::arm_ports()
+{
+  if (_arm_ports.size() == children.size()) { return _arm_ports; }
+  _arm_ports.clear();
+  _arm_ports.reserve(children.size());
+  for (std::size_t i = 0; i < children.size(); i++) {
+    // get_port throws (listing the ports that do exist) when an arm has no port, which means the
+    // wiring dropped that arm. Failing loudly is the point: the alternative is silently returning
+    // a short row count.
+    _arm_ports.push_back(get_port(port_label(i)));
+  }
+  return _arm_ports;
+}
+
+std::string_view sirius_physical_union::input_port_for(
+  sirius_physical_operator const& producer) const
+{
+  if (producer.type == SiriusPhysicalOperatorType::PASSTHROUGH_SINK) {
+    return producer.Cast<sirius_physical_passthrough_sink>().union_port_label();
+  }
+  return sirius_physical_operator::input_port_for(producer);
+}
+
+MemoryBarrierType sirius_physical_union::input_barrier_for(
+  sirius_physical_operator const& producer) const
+{
+  return producer.type == SiriusPhysicalOperatorType::PASSTHROUGH_SINK
+           ? MemoryBarrierType::PARTIAL
+           : sirius_physical_operator::input_barrier_for(producer);
+}
+
+std::optional<task_creation_hint> sirius_physical_union::get_next_task_hint()
+{
+  std::lock_guard<std::mutex> lg(lock);
+
+  // One pass over the arms doing two jobs. The base splits this into three scans because it must
+  // distinguish FULL from PARTIAL ports; a UNION arm carries no cross-batch state, so the inbound
+  // edge is declared PARTIAL (`input_barrier_for`) and `port::type` is deliberately not consulted.
+  const auto& ports_by_arm = arm_ports();
+  const auto num_arms      = ports_by_arm.size();
+  if (num_arms == 0) { return std::nullopt; }
+
+  sirius_physical_operator* live_producer = nullptr;
+  std::size_t live_arm                    = 0;
+  for (std::size_t offset = 0; offset < num_arms; offset++) {
+    const auto arm = (_wait_cursor + offset) % num_arms;
+    auto* p        = ports_by_arm[arm];
+    // Readiness is ANY, not ALL: one arm with a queued batch is enough to fire a task. The scan
+    // order does not affect this answer, only which arm is nominated below.
+    if (p->repo && p->repo->total_size() > 0) {
+      return task_creation_hint{TaskCreationHint::READY, this};
+    }
+    // Otherwise remember one arm that is still producing. Unlike the base we cannot return here —
+    // a later arm may have data, and READY outranks WAITING — so the candidate is carried.
+    if (live_producer == nullptr && p->src_pipeline && !p->src_pipeline->is_pipeline_finished()) {
+      live_producer = &(p->src_pipeline->get_operators()[0].get());
+      live_arm      = arm;
+    }
+  }
+
+  // No arm has data, but one is still producing: wait, and name that arm's producer.
+  // `task_creator::get_operator_for_next_task` selects the next operator to run *only* by walking
+  // `hint.producer`, so a null producer here means the still-producing arm never runs — a hang,
+  // not a wrong answer. Drained and finished arms are skipped: waiting on one would be pointless.
+  //
+  // Nominating strictly by arm index would keep naming the same producer, and a producer that
+  // cannot progress costs the whole task-creation request (task_creator drops the walk when it
+  // yields no operator). Advancing past the arm just nominated spreads that cost over the arms
+  // instead of concentrating it on the lowest-numbered stalled one.
+  if (live_producer != nullptr) {
+    _wait_cursor = (live_arm + 1) % num_arms;
+    return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, live_producer};
+  }
+
+  // Every arm empty and every producer finished: exhausted.
+  return std::nullopt;
+}
+
+std::unique_ptr<operator_data> sirius_physical_union::get_next_task_input_data()
+{
+  std::lock_guard<std::mutex> lg(lock);
+
+  // One batch from one arm, rather than the base's one-from-every-port bundle. Beyond the
+  // unequal-arm problem the bundle would also mix batches produced on different GPUs into a single
+  // task, which runs on one device — reintroducing the migration the passthrough sink removes.
+  //
+  // task_creator loops `while (!node->all_ports_empty())` around this call, so one batch per call
+  // still drains every arm within a scheduling round; the cursor only decides the order within it.
+  const auto& ports_by_arm = arm_ports();
+  const auto num_arms      = ports_by_arm.size();
+  if (num_arms == 0) { return nullptr; }
+  for (std::size_t offset = 0; offset < num_arms; offset++) {
+    const auto arm = (_arm_cursor + offset) % num_arms;
+    auto* p        = ports_by_arm[arm];
+    if (p->repo == nullptr) { continue; }
+    auto batch = p->repo->pop_next_data_batch();
+    if (!batch) { continue; }
+    _arm_cursor = (arm + 1) % num_arms;
+    std::vector<std::shared_ptr<::cucascade::data_batch>> popped;
+    popped.push_back(std::move(batch));
+    // pipelineable, not partitioned: no partition_idx, so the task creator routes this task by
+    // data locality and the batch is processed on the GPU that produced it.
+    return std::make_unique<pipelineable_operator_data>(std::move(popped));
+  }
+  return nullptr;
+}
+
+}  // namespace op
+}  // namespace sirius

--- a/src/op/sirius_physical_union.cpp
+++ b/src/op/sirius_physical_union.cpp
@@ -173,8 +173,11 @@ std::optional<task_creation_hint> sirius_physical_union::get_next_task_hint()
     return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, starved_producer};
   }
 
-  // Readiness is ANY, not ALL: one arm with a queued batch is enough to fire a task. An arm that
-  // finished without producing is not starved, which is what lets an empty arm through.
+  // Reached only when nothing is starved, so the aggregate rule is: READY iff every *live* arm has
+  // a queued batch and at least one port is poppable. That is the base's ALL weakened by exactly
+  // one clause -- a finished arm is excused instead of blocking forever -- which is what lets an
+  // empty arm through and what stops a drained short arm from stranding a long one. Arms still
+  // producing rendezvous; `any_ready` alone decides only once every arm has finished.
   if (any_ready) { return task_creation_hint{TaskCreationHint::READY, this}; }
 
   return std::nullopt;

--- a/src/op/sirius_physical_union.cpp
+++ b/src/op/sirius_physical_union.cpp
@@ -60,11 +60,17 @@ void sirius_physical_union::build_pipelines(pipeline::sirius_pipeline& current,
 
   // Every arm reaches UNION through a plan-gen PASSTHROUGH_SINK wrap. Create a child meta per arm
   // terminating in that sink, then recurse *past* it so it does not redundantly create its own.
-  D_ASSERT(children.size() >= 2);
+  // A throw rather than a D_ASSERT, because a release build would otherwise index an empty
+  // `children` and read past the end silently. The other two preconditions already fail loudly
+  // elsewhere: arity in the plan builder (`sirius_plan_set_operation.cpp`), and a non-sink
+  // pipeline sink in `sirius_pipeline::reset_sink`.
   for (auto& child_slot : children) {
     auto& child = *child_slot;
-    D_ASSERT(child.is_sink());
-    D_ASSERT(!child.children.empty());
+    if (child.children.empty()) {
+      throw internal_exception(
+        "sirius_physical_union::build_pipelines: arm reached pipeline building without its "
+        "PASSTHROUGH_SINK wrap");
+    }
     auto& child_meta = host_meta->create_child_meta_pipeline(*host_current, child);
     child_meta.build(*child.children[0]);
   }
@@ -158,8 +164,10 @@ std::optional<task_creation_hint> sirius_physical_union::get_next_task_hint()
   }
 
   // `task_creator::get_operator_for_next_task` selects the next operator to run *only* by walking
-  // `hint.producer`, so a null producer here means the still-producing arm never runs — a hang,
-  // not a wrong answer. Advance the cursor so successive waits do not keep naming the same arm.
+  // `hint.producer`, so a null producer here would leave the still-producing arm with nothing to
+  // run it. The walk is also all-or-nothing: when it yields no operator, `task_creator` abandons
+  // the whole task-creation request, so repeatedly nominating one stalled arm concentrates that
+  // loss on it. Advancing past the arm just nominated spreads it across the arms instead.
   if (live_producer != nullptr) {
     _wait_cursor = (live_arm + 1) % num_arms;
     return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, live_producer};

--- a/src/op/sirius_physical_union.cpp
+++ b/src/op/sirius_physical_union.cpp
@@ -163,11 +163,15 @@ std::optional<task_creation_hint> sirius_physical_union::get_next_task_hint()
 
   // A starved arm outranks a ready one, because nothing else will start it.
   // `task_creator::get_operator_for_next_task` reaches an operator *only* by walking
-  // `hint.producer`, and `task_scheduler::start_query` schedules `scans.front()` alone — so an arm
-  // is named here or never runs, and answering READY first spends that request on draining. The
-  // producer is likewise never null, or the still-producing arm has nothing to run it. The walk is
-  // all-or-nothing too: when it yields no operator `task_creator` abandons the whole request, so
-  // advancing past the arm just nominated spreads that loss instead of concentrating it on one.
+  // `hint.producer`, and `task_scheduler::start_query` schedules `scans.front()` alone. Nothing
+  // schedules a scan again after that: both recurring paths schedule a pipeline's output consumers,
+  // never its own source. So this branch is not only how an arm starts, it is how every arm's scan
+  // resumes each time its splits run dry — answering READY first spends that request on draining.
+  // The producer is likewise never null, or the still-producing arm has nothing to run it. The walk
+  // is all-or-nothing too: when it yields no operator `task_creator` abandons the whole request,
+  // and an arm whose connector closed while its last tasks run is starved but yields nothing — so a
+  // fixed start would burn every request for that arm's tail, which is what `_wait_cursor` advances
+  // past.
   if (starved_producer != nullptr) {
     _wait_cursor = (starved_arm + 1) % num_arms;
     return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, starved_producer};

--- a/src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp
+++ b/src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp
@@ -241,11 +241,13 @@ std::vector<descent_step> descent_steps(sirius::op::sirius_physical_operator con
     case SiriusPhysicalOperatorType::VERIFY_VECTOR:
     case SiriusPhysicalOperatorType::UPDATE_EXTENSIONS:
     case SiriusPhysicalOperatorType::CREATE_SECRET:
-    // Join feeders are added after discovery as CONCAT -> PARTITION -> existing child in
-    // `insert_gpu_pipeline_operators()`. Targets therefore end up below both even though either
-    // wrapper is terminal if encountered here.
+    // Feeders are added after discovery in `insert_gpu_pipeline_operators()`: the join child's
+    // CONCAT -> PARTITION -> existing child, and the UNION arm's PASSTHROUGH_SINK -> existing
+    // child. Targets therefore end up below the wrappers either way, even though each wrapper is
+    // terminal if encountered here.
     case SiriusPhysicalOperatorType::PARTITION:
     case SiriusPhysicalOperatorType::CONCAT:
+    case SiriusPhysicalOperatorType::PASSTHROUGH_SINK:
     case SiriusPhysicalOperatorType::MERGE_SORT:
     case SiriusPhysicalOperatorType::MERGE_GROUP_BY:
     case SiriusPhysicalOperatorType::MERGE_TOP_N:

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -50,6 +50,7 @@
 #include "op/sirius_physical_merge_sort.hpp"
 #include "op/sirius_physical_order.hpp"
 #include "op/sirius_physical_partition.hpp"
+#include "op/sirius_physical_passthrough_sink.hpp"
 #include "op/sirius_physical_projection.hpp"
 #include "op/sirius_physical_result_collector.hpp"
 #include "op/sirius_physical_sort_partition.hpp"
@@ -59,6 +60,7 @@
 #include "op/sirius_physical_top_n_merge.hpp"
 #include "op/sirius_physical_ungrouped_aggregate.hpp"
 #include "op/sirius_physical_ungrouped_aggregate_merge.hpp"
+#include "op/sirius_physical_union.hpp"
 #include "planner/sirius_plan_compressed_schema.hpp"
 #include "planner/sirius_plan_projection_utils.hpp"
 #include "sirius_config.hpp"
@@ -634,6 +636,46 @@ void wrap_join(sirius::op::sirius_physical_operator& join_op,
   }
 }
 
+//! Terminate one UNION arm with a `PASSTHROUGH_SINK`. Where a join arm needs `PARTITION -> CONCAT`
+//! (a shuffle plus a coalesce), a bag union needs neither, so one operator does the whole job: it
+//! forwards each batch unchanged and unpartitioned into UNION's `"union_{child_idx}"` port, which
+//! keeps every batch on the GPU its scan produced it on. The sink owns that port name — the wiring
+//! descriptor and the upstream `next_port_info` both retain a `string_view` into it.
+void wrap_union_child(sirius::op::sirius_physical_operator& union_op, std::size_t child_idx)
+{
+  D_ASSERT(union_op.type == sirius::op::SiriusPhysicalOperatorType::UNION);
+  wrap_child(
+    union_op, child_idx, [&](duckdb::unique_ptr<sirius::op::sirius_physical_operator> child_orig) {
+      // Capture types/cardinality before the child is moved into the sink.
+      auto child_types    = child_orig->types;
+      auto est_card       = child_orig->estimated_cardinality;
+      auto child_physical = child_orig->has_physical_overrides() ? child_orig->get_physical_types()
+                                                                 : std::vector<cudf::data_type>{};
+
+      auto sink = duckdb::make_uniq<sirius::op::sirius_physical_passthrough_sink>(
+        std::move(child_types),
+        est_card,
+        sirius::op::sirius_physical_union::port_label(child_idx));
+      // Expected to be empty: the compressed-schema pass treats UNION as a native boundary and
+      // restores every arm before this runs. Carried anyway so the sink never silently declares a
+      // different carrier than the batches flowing through it, mirroring wrap_join_child.
+      if (!child_physical.empty()) { sink->set_physical_types(std::move(child_physical)); }
+      sink->children.push_back(std::move(child_orig));
+      return sink;
+    });
+}
+
+//! Wrap every UNION arm. `wrap_child` replaces the slot in place rather than resizing `children`,
+//! so indexing over the original size is safe.
+void wrap_union(sirius::op::sirius_physical_operator& union_op)
+{
+  D_ASSERT(union_op.children.size() >= 2);
+  const auto num_children = union_op.children.size();
+  for (std::size_t i = 0; i < num_children; i++) {
+    wrap_union_child(union_op, i);
+  }
+}
+
 // Forward declaration: wrap_delim_join recurses into a DELIM JOIN's internal `join`/`distinct`
 // subtrees, which live outside `children[]`.
 void insert_gpu_pipeline_operators_recursive(
@@ -778,6 +820,7 @@ void insert_gpu_pipeline_operators_recursive(
     case sirius::op::SiriusPhysicalOperatorType::DENSE_COUNT_JOIN:
       wrap_dense_count_join(*slot, compressed_materialization_observer);
       break;
+    case sirius::op::SiriusPhysicalOperatorType::UNION: wrap_union(*slot); break;
     case sirius::op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN:
     case sirius::op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN:
       wrap_delim_join(slot, op_params, context, compressed_materialization_observer);
@@ -1156,10 +1199,12 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalOperator& op)
       // plan = create_plan(op.Cast<duckdb::LogicalPositionalJoin>());
       break;
     case duckdb::LogicalOperatorType::LOGICAL_UNION:
+      // UNION ALL only; the builder rejects distinct UNION and ordered arms.
+      plan = create_plan(op.Cast<duckdb::LogicalSetOperation>());
+      break;
     case duckdb::LogicalOperatorType::LOGICAL_EXCEPT:
     case duckdb::LogicalOperatorType::LOGICAL_INTERSECT:
-      throw duckdb::NotImplementedException("Set operation not supported");
-      // plan = create_plan(op.Cast<duckdb::LogicalSetOperation>());
+      throw duckdb::NotImplementedException("Set operation (EXCEPT/INTERSECT) not supported");
       break;
     case duckdb::LogicalOperatorType::LOGICAL_INSERT:
       throw duckdb::NotImplementedException("Insert not supported");

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -653,9 +653,7 @@ void wrap_union_child(sirius::op::sirius_physical_operator& union_op, std::size_
                                                                  : std::vector<cudf::data_type>{};
 
       auto sink = duckdb::make_uniq<sirius::op::sirius_physical_passthrough_sink>(
-        std::move(child_types),
-        est_card,
-        sirius::op::sirius_physical_union::port_label(child_idx));
+        std::move(child_types), est_card, sirius::op::sirius_physical_union::port_label(child_idx));
       // Expected to be empty: the compressed-schema pass treats UNION as a native boundary and
       // restores every arm before this runs. Carried anyway so the sink never silently declares a
       // different carrier than the batches flowing through it, mirroring wrap_join_child.

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -646,14 +646,15 @@ void wrap_union_child(sirius::op::sirius_physical_operator& union_op, std::size_
   D_ASSERT(union_op.type == sirius::op::SiriusPhysicalOperatorType::UNION);
   wrap_child(
     union_op, child_idx, [&](duckdb::unique_ptr<sirius::op::sirius_physical_operator> child_orig) {
-      // Capture types/cardinality before the child is moved into the sink.
-      auto child_types    = child_orig->types;
+      // Capture cardinality before the child is moved into the sink.
       auto est_card       = child_orig->estimated_cardinality;
       auto child_physical = child_orig->has_physical_overrides() ? child_orig->get_physical_types()
                                                                  : std::vector<cudf::data_type>{};
 
+      // The union's schema, not the arm's: the binder has already cast every arm to it, and a
+      // materialized CTE's own `types` are its materialization side rather than what it emits.
       auto sink = duckdb::make_uniq<sirius::op::sirius_physical_passthrough_sink>(
-        std::move(child_types), est_card, sirius::op::sirius_physical_union::port_label(child_idx));
+        union_op.types, est_card, sirius::op::sirius_physical_union::port_label(child_idx));
       // Expected to be empty: the compressed-schema pass treats UNION as a native boundary and
       // restores every arm before this runs. Carried anyway so the sink never silently declares a
       // different carrier than the batches flowing through it, mirroring wrap_join_child.

--- a/src/planner/sirius_plan_compressed_schema.cpp
+++ b/src/planner/sirius_plan_compressed_schema.cpp
@@ -482,11 +482,12 @@ void propagate_compressed_schema(duckdb::unique_ptr<sirius::op::sirius_physical_
     default: break;
   }
 
-  // Pipeline wrapper operators (PARTITION, CONCAT, MERGE_*, SORT_PARTITION, SORT_SAMPLE,
-  // GPU_SCAN) are inserted by insert_gpu_pipeline_operators after these passes run; their
-  // carrier contracts are established at wrap time from the finished sidecars.
+  // Pipeline wrapper operators (PARTITION, CONCAT, PASSTHROUGH_SINK, MERGE_*, SORT_PARTITION,
+  // SORT_SAMPLE, GPU_SCAN) are inserted by insert_gpu_pipeline_operators after these passes
+  // run; their carrier contracts are established at wrap time from the finished sidecars.
   D_ASSERT(slot->type != sirius::op::SiriusPhysicalOperatorType::PARTITION &&
            slot->type != sirius::op::SiriusPhysicalOperatorType::CONCAT &&
+           slot->type != sirius::op::SiriusPhysicalOperatorType::PASSTHROUGH_SINK &&
            slot->type != sirius::op::SiriusPhysicalOperatorType::MERGE_SORT &&
            slot->type != sirius::op::SiriusPhysicalOperatorType::MERGE_GROUP_BY &&
            slot->type != sirius::op::SiriusPhysicalOperatorType::MERGE_TOP_N &&

--- a/src/planner/sirius_plan_compressed_schema.cpp
+++ b/src/planner/sirius_plan_compressed_schema.cpp
@@ -482,12 +482,11 @@ void propagate_compressed_schema(duckdb::unique_ptr<sirius::op::sirius_physical_
     default: break;
   }
 
-  // Pipeline wrapper operators (PARTITION, CONCAT, PASSTHROUGH_SINK, MERGE_*, SORT_PARTITION,
-  // SORT_SAMPLE, GPU_SCAN) are inserted by insert_gpu_pipeline_operators after these passes
-  // run; their carrier contracts are established at wrap time from the finished sidecars.
+  // Pipeline wrapper operators (PARTITION, CONCAT, MERGE_*, SORT_PARTITION, SORT_SAMPLE,
+  // GPU_SCAN) are inserted by insert_gpu_pipeline_operators after these passes run; their
+  // carrier contracts are established at wrap time from the finished sidecars.
   D_ASSERT(slot->type != sirius::op::SiriusPhysicalOperatorType::PARTITION &&
            slot->type != sirius::op::SiriusPhysicalOperatorType::CONCAT &&
-           slot->type != sirius::op::SiriusPhysicalOperatorType::PASSTHROUGH_SINK &&
            slot->type != sirius::op::SiriusPhysicalOperatorType::MERGE_SORT &&
            slot->type != sirius::op::SiriusPhysicalOperatorType::MERGE_GROUP_BY &&
            slot->type != sirius::op::SiriusPhysicalOperatorType::MERGE_TOP_N &&

--- a/src/planner/sirius_plan_set_operation.cpp
+++ b/src/planner/sirius_plan_set_operation.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "duckdb/planner/operator/logical_set_operation.hpp"
+#include "helper/type_conversions.hpp"
+#include "op/sirius_physical_union.hpp"
+#include "planner/sirius_physical_plan_generator.hpp"
+
+namespace sirius::planner {
+
+//! `LogicalSetOperation` is DuckDB's single node for the whole set-operation family; the inherited
+//! `LogicalOperatorType` tag picks the operation and `setop_all` picks ALL vs distinct. The
+//! generator switch routes only `LOGICAL_UNION` here — `EXCEPT` / `INTERSECT` keep their own
+//! throwing case — so the only discrimination left to do is on `setop_all`.
+duckdb::unique_ptr<sirius::op::sirius_physical_operator>
+sirius_physical_plan_generator::create_plan(duckdb::LogicalSetOperation& op)
+{
+  // Distinct UNION is `DISTINCT(UNION ALL)`: the binder rewrites "not ALL" into a modifier that
+  // lowers to a separate LOGICAL_DISTINCT above this node. That node has no builder yet, so a
+  // distinct UNION would fall back one node later anyway; rejecting here keeps the message
+  // specific. Delete this throw once the DISTINCT builder lands.
+  if (!op.setop_all) {
+    throw duckdb::NotImplementedException(
+      "UNION (distinct) not supported yet; only UNION ALL is on the GPU path");
+  }
+
+  // `allow_out_of_order == false` asks for the arms to be evaluated strictly left to right —
+  // DuckDB's own PhysicalUnion adds pipeline dependencies to enforce it. This operator is built on
+  // N independent arms drained in whatever order they produce, so it cannot honor that and must
+  // decline the node. The main binder path always passes the `true` default; EXPORT DATABASE and
+  // deserialized plans are the shapes that can carry `false`, and they carry `setop_all == true`,
+  // so the guard above does not catch them. What this prevents is a silently mis-ordered result
+  // rather than an exception, which is why it is a guard and not a reachability argument.
+  if (!op.allow_out_of_order) {
+    throw duckdb::NotImplementedException(
+      "UNION ALL with ordered arms (allow_out_of_order = false) not supported on the GPU path");
+  }
+
+  // No Sirius-side schema reconciliation: the binder has already cast every arm to the per-column
+  // common super-type and guaranteed `op.column_count` columns in matching order. Any cast that
+  // was needed is already a LOGICAL_PROJECTION inside the arm's subtree.
+  //
+  // N-ary: `a UNION ALL b UNION ALL c` binds to one node with three children, and `UNION BY NAME`
+  // and macro expansion can produce N-ary nodes too, so this loops rather than indexing 0 and 1.
+  D_ASSERT(op.children.size() >= 2);
+  if (op.children.size() < 2) {
+    throw duckdb::NotImplementedException("UNION ALL with fewer than two inputs not supported");
+  }
+
+  auto union_op = duckdb::make_uniq<sirius::op::sirius_physical_union>(
+    sirius::from_duckdb_vec(op.types), op.estimated_cardinality);
+
+  for (auto& child : op.children) {
+    auto child_plan = create_plan(*child);
+    // The arity guarantee above is a binder invariant, not something re-derived here. Check it
+    // anyway: a mismatch means the invariant was misread, and falling back to the CPU is better
+    // than emitting a differently-shaped batch on one arm.
+    if (child_plan->types.size() != op.types.size()) {
+      throw duckdb::NotImplementedException(
+        "UNION ALL: input column count does not match the set operation output");
+    }
+    union_op->children.push_back(std::move(child_plan));
+  }
+
+  return union_op;
+}
+
+}  // namespace sirius::planner

--- a/src/planner/sirius_plan_set_operation.cpp
+++ b/src/planner/sirius_plan_set_operation.cpp
@@ -27,9 +27,17 @@ namespace sirius::planner {
 duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalSetOperation& op)
 {
-  // Distinct UNION lowers to a separate LOGICAL_DISTINCT above this node, which has no builder
-  // yet, so it would fall back one node later anyway; rejecting here keeps the message specific.
-  // Delete this throw once the DISTINCT builder lands.
+  // A distinct UNION usually lowers to a LOGICAL_DISTINCT above this node, so declining here
+  // rather than one node later only sharpens the message. Usually, not always: a WITH RECURSIVE
+  // body with no self-reference degrades to a plain LogicalSetOperation carrying the CTE's
+  // `union_all`, and nothing inserts a DistinctModifier on that path (duckdb
+  // `bind_recursive_cte_node.cpp:124`-`:127`). For that shape this throw is the only thing between
+  // a distinct UNION and duplicate rows.
+  //
+  // So lifting this once the DISTINCT builder lands is not a deletion: `create_plan` dispatches on
+  // node type with no parent context, so this builder cannot tell whether a LOGICAL_DISTINCT sits
+  // above it. The pair has to be recognised from the DISTINCT side and planned as one dedup over a
+  // bag union, leaving this throw for the bare case.
   if (!op.setop_all) {
     throw duckdb::NotImplementedException(
       "UNION (distinct) not supported yet; only UNION ALL is on the GPU path");

--- a/src/planner/sirius_plan_set_operation.cpp
+++ b/src/planner/sirius_plan_set_operation.cpp
@@ -21,40 +21,32 @@
 
 namespace sirius::planner {
 
-//! `LogicalSetOperation` is DuckDB's single node for the whole set-operation family; the inherited
-//! `LogicalOperatorType` tag picks the operation and `setop_all` picks ALL vs distinct. The
-//! generator switch routes only `LOGICAL_UNION` here — `EXCEPT` / `INTERSECT` keep their own
-//! throwing case — so the only discrimination left to do is on `setop_all`.
+//! `LogicalSetOperation` is DuckDB's single node for the whole set-operation family. The generator
+//! switch routes only `LOGICAL_UNION` here — `EXCEPT` / `INTERSECT` keep their own throwing case —
+//! so the only discrimination left is on `setop_all`.
 duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalSetOperation& op)
 {
-  // Distinct UNION is `DISTINCT(UNION ALL)`: the binder rewrites "not ALL" into a modifier that
-  // lowers to a separate LOGICAL_DISTINCT above this node. That node has no builder yet, so a
-  // distinct UNION would fall back one node later anyway; rejecting here keeps the message
-  // specific. Delete this throw once the DISTINCT builder lands.
+  // Distinct UNION lowers to a separate LOGICAL_DISTINCT above this node, which has no builder
+  // yet, so it would fall back one node later anyway; rejecting here keeps the message specific.
+  // Delete this throw once the DISTINCT builder lands.
   if (!op.setop_all) {
     throw duckdb::NotImplementedException(
       "UNION (distinct) not supported yet; only UNION ALL is on the GPU path");
   }
 
-  // `allow_out_of_order == false` asks for the arms to be evaluated strictly left to right —
-  // DuckDB's own PhysicalUnion adds pipeline dependencies to enforce it. This operator is built on
-  // N independent arms drained in whatever order they produce, so it cannot honor that and must
-  // decline the node. The main binder path always passes the `true` default; EXPORT DATABASE and
-  // deserialized plans are the shapes that can carry `false`, and they carry `setop_all == true`,
-  // so the guard above does not catch them. What this prevents is a silently mis-ordered result
-  // rather than an exception, which is why it is a guard and not a reachability argument.
+  // `allow_out_of_order == false` asks for the arms to be evaluated strictly left to right, which
+  // N independently drained arms cannot honor. EXPORT DATABASE and deserialized plans are the
+  // shapes that carry `false`, and they carry `setop_all == true`, so the guard above does not
+  // catch them. Without this the result is silently mis-ordered rather than an error.
   if (!op.allow_out_of_order) {
     throw duckdb::NotImplementedException(
       "UNION ALL with ordered arms (allow_out_of_order = false) not supported on the GPU path");
   }
 
-  // No Sirius-side schema reconciliation: the binder has already cast every arm to the per-column
-  // common super-type and guaranteed `op.column_count` columns in matching order. Any cast that
-  // was needed is already a LOGICAL_PROJECTION inside the arm's subtree.
-  //
-  // N-ary: `a UNION ALL b UNION ALL c` binds to one node with three children, and `UNION BY NAME`
-  // and macro expansion can produce N-ary nodes too, so this loops rather than indexing 0 and 1.
+  // No Sirius-side schema reconciliation: the binder has already cast every arm to the common
+  // super-type, and any cast needed is a LOGICAL_PROJECTION inside the arm's subtree. N-ary:
+  // `a UNION ALL b UNION ALL c` binds to one node with three children, so this loops.
   D_ASSERT(op.children.size() >= 2);
   if (op.children.size() < 2) {
     throw duckdb::NotImplementedException("UNION ALL with fewer than two inputs not supported");
@@ -65,9 +57,8 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalSetOperation& op)
 
   for (auto& child : op.children) {
     auto child_plan = create_plan(*child);
-    // The arity guarantee above is a binder invariant, not something re-derived here. Check it
-    // anyway: a mismatch means the invariant was misread, and falling back to the CPU is better
-    // than emitting a differently-shaped batch on one arm.
+    // Re-check the binder's arity invariant: a mismatch means it was misread, and falling back to
+    // the CPU beats emitting a differently-shaped batch on one arm.
     if (child_plan->types.size() != op.types.size()) {
       throw duckdb::NotImplementedException(
         "UNION ALL: input column count does not match the set operation output");

--- a/src/planner/sirius_plan_set_operation.cpp
+++ b/src/planner/sirius_plan_set_operation.cpp
@@ -55,14 +55,15 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalSetOperation& op)
     sirius::from_duckdb_vec(op.types), op.estimated_cardinality);
 
   for (auto& child : op.children) {
-    auto child_plan = create_plan(*child);
-    // Re-check the binder's arity invariant: a mismatch means it was misread, and falling back to
-    // the CPU beats emitting a differently-shaped batch on one arm.
-    if (child_plan->types.size() != op.types.size()) {
+    // Re-check the binder's arity invariant on the *logical* arm, not on `create_plan`'s result:
+    // a physical root's types are not always its output schema. `sirius_physical_cte` declares its
+    // materialization side (`sirius_plan_cte.cpp`), so reading the physical plan declines a valid
+    // query whose arm is a materialized CTE.
+    if (child->types.size() != op.types.size()) {
       throw duckdb::NotImplementedException(
         "UNION ALL: input column count does not match the set operation output");
     }
-    union_op->children.push_back(std::move(child_plan));
+    union_op->children.push_back(create_plan(*child));
   }
 
   return union_op;

--- a/src/planner/sirius_plan_set_operation.cpp
+++ b/src/planner/sirius_plan_set_operation.cpp
@@ -21,40 +21,31 @@
 
 namespace sirius::planner {
 
-//! `LogicalSetOperation` is DuckDB's single node for the whole set-operation family. The generator
-//! switch routes only `LOGICAL_UNION` here — `EXCEPT` / `INTERSECT` keep their own throwing case —
-//! so the only discrimination left is on `setop_all`.
+// The generator switch routes only `LOGICAL_UNION` to this builder — `EXCEPT` / `INTERSECT` keep
+// their own throwing case — so the only discrimination left here is on `setop_all`.
 duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalSetOperation& op)
 {
-  // A distinct UNION usually lowers to a LOGICAL_DISTINCT above this node, so declining here
-  // rather than one node later only sharpens the message. Usually, not always: a WITH RECURSIVE
-  // body with no self-reference degrades to a plain LogicalSetOperation carrying the CTE's
-  // `union_all`, and nothing inserts a DistinctModifier on that path (duckdb
+  // A distinct UNION usually lowers to a LOGICAL_DISTINCT above this node, but not always: a
+  // WITH RECURSIVE body with no self-reference degrades to a plain LogicalSetOperation carrying
+  // the CTE's `union_all`, and nothing inserts a DistinctModifier on that path (duckdb
   // `bind_recursive_cte_node.cpp:124`-`:127`). For that shape this throw is the only thing between
   // a distinct UNION and duplicate rows.
-  //
-  // So lifting this once the DISTINCT builder lands is not a deletion: `create_plan` dispatches on
-  // node type with no parent context, so this builder cannot tell whether a LOGICAL_DISTINCT sits
-  // above it. The pair has to be recognised from the DISTINCT side and planned as one dedup over a
-  // bag union, leaving this throw for the bare case.
   if (!op.setop_all) {
     throw duckdb::NotImplementedException(
       "UNION (distinct) not supported yet; only UNION ALL is on the GPU path");
   }
 
-  // `allow_out_of_order == false` asks for the arms to be evaluated strictly left to right, which
-  // N independently drained arms cannot honor. EXPORT DATABASE and deserialized plans are the
-  // shapes that carry `false`, and they carry `setop_all == true`, so the guard above does not
-  // catch them. Without this the result is silently mis-ordered rather than an error.
+  // `allow_out_of_order == false` asks for strict left-to-right evaluation, which N independently
+  // drained arms cannot honor. EXPORT DATABASE and deserialized plans carry it alongside
+  // `setop_all == true`, so the guard above does not catch them, and the result would be silently
+  // mis-ordered rather than an error.
   if (!op.allow_out_of_order) {
     throw duckdb::NotImplementedException(
       "UNION ALL with ordered arms (allow_out_of_order = false) not supported on the GPU path");
   }
 
-  // No Sirius-side schema reconciliation: the binder has already cast every arm to the common
-  // super-type, and any cast needed is a LOGICAL_PROJECTION inside the arm's subtree. N-ary:
-  // `a UNION ALL b UNION ALL c` binds to one node with three children, so this loops.
+  // N-ary: `a UNION ALL b UNION ALL c` binds to one node with three children.
   D_ASSERT(op.children.size() >= 2);
   if (op.children.size() < 2) {
     throw duckdb::NotImplementedException("UNION ALL with fewer than two inputs not supported");

--- a/test/cpp/integration/test_gpu_execution_union_all.cpp
+++ b/test/cpp/integration/test_gpu_execution_union_all.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// GPU-vs-CPU correctness for `UNION ALL` (sirius_physical_union +
+// sirius_physical_passthrough_sink).
+//
+// Every query goes through the shared GpuExecutionFixture, which runs it once
+// transparently on the GPU -- asserting exactly one GPU execution and ZERO
+// fallbacks -- and once on DuckDB CPU, then compares. That zero-fallback
+// assertion is what makes these tests meaningful: a UNION ALL that silently
+// CPU-fell-back would still produce the right answer, so a plain result check
+// would pass whether or not the operator existed.
+//
+// The rest of the set-operation family is asserted the other way round, with
+// expect_gpu_fallback: those must still leave the GPU path cleanly.
+//
+// NOT covered here (needs a fixture with a small scan_task_batch_size; the
+// shared integration config uses 100 MB, so these fixtures are one batch per
+// arm): multi-batch streaming, unequal-length arms across many batches, and
+// multi-GPU device placement.
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <utils/gpu_execution_fixture.hpp>
+
+#include <string>
+
+namespace {
+
+// Overlapping keys between a and b (k = 3) so multiset semantics are
+// observable, a disjoint third table for N-ary chains, an empty table, and a
+// BIGINT-keyed table so the binder has a super-type to reconcile to.
+class UnionAllFixture : public sirius::test::GpuExecutionFixture {
+ public:
+  UnionAllFixture()
+  {
+    run_ok("CREATE TABLE ua (k INTEGER, v VARCHAR);");
+    run_ok("CREATE TABLE ub (k INTEGER, v VARCHAR);");
+    run_ok("CREATE TABLE uc (k INTEGER, v VARCHAR);");
+    run_ok("CREATE TABLE uempty (k INTEGER, v VARCHAR);");
+    run_ok("CREATE TABLE uwide (k BIGINT, v VARCHAR);");
+
+    run_ok("INSERT INTO ua VALUES (1, 'a'), (2, 'b'), (3, 'c'), (NULL, 'n');");
+    run_ok("INSERT INTO ub VALUES (3, 'c'), (4, 'd');");
+    run_ok("INSERT INTO uc VALUES (5, 'e');");
+    run_ok("INSERT INTO uwide VALUES (100, 'w'), (200, 'x');");
+    run_ok("CHECKPOINT;");
+  }
+};
+
+}  // namespace
+
+TEST_CASE_METHOD(UnionAllFixture,
+                 "gpu_execution UNION ALL two arms",
+                 "[integration][gpu_execution][union_all]")
+{
+  compare_gpu_vs_cpu("SELECT k, v FROM ua UNION ALL SELECT k, v FROM ub");
+  compare_gpu_vs_cpu("SELECT k FROM ua UNION ALL SELECT k FROM ub");
+  // Arm order reversed: the operator must not depend on which arm is children[0].
+  compare_gpu_vs_cpu("SELECT k, v FROM ub UNION ALL SELECT k, v FROM ua");
+}
+
+TEST_CASE_METHOD(UnionAllFixture,
+                 "gpu_execution UNION ALL is a multiset, not a set",
+                 "[integration][gpu_execution][union_all]")
+{
+  // (3, 'c') is in both inputs and must survive twice. The count comparison is
+  // the assertion that no de-duplication happened.
+  compare_gpu_vs_cpu("SELECT count(*) FROM (SELECT k, v FROM ua UNION ALL SELECT k, v FROM ub) t");
+  compare_gpu_vs_cpu(
+    "SELECT count(*) FROM (SELECT k, v FROM ua UNION ALL SELECT k, v FROM ub) t WHERE k = 3");
+  // A table unioned with itself: every row appears exactly twice.
+  compare_gpu_vs_cpu("SELECT k, v FROM ua UNION ALL SELECT k, v FROM ua");
+}
+
+TEST_CASE_METHOD(UnionAllFixture,
+                 "gpu_execution UNION ALL with an empty arm",
+                 "[integration][gpu_execution][union_all]")
+{
+  // An empty arm's pipeline finishes without ever pushing a batch, so the
+  // operator must fall through it to the other arm rather than reporting
+  // exhausted.
+  compare_gpu_vs_cpu("SELECT k, v FROM ua UNION ALL SELECT k, v FROM uempty");
+  compare_gpu_vs_cpu("SELECT k, v FROM uempty UNION ALL SELECT k, v FROM ua");
+  compare_gpu_vs_cpu("SELECT k FROM uempty UNION ALL SELECT k FROM uempty");
+}
+
+TEST_CASE_METHOD(UnionAllFixture,
+                 "gpu_execution UNION ALL is N-ary",
+                 "[integration][gpu_execution][union_all]")
+{
+  // At the pinned DuckDB a chain binds to ONE set-operation node with N
+  // children rather than a left-deep tree of binary nodes, which is why the
+  // operator loops over children instead of indexing 0 and 1.
+  compare_gpu_vs_cpu("SELECT k, v FROM ua UNION ALL SELECT k, v FROM ub UNION ALL SELECT k, v FROM uc");
+  compare_gpu_vs_cpu(
+    "SELECT count(*) FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub UNION ALL SELECT k FROM uc "
+    "UNION ALL SELECT k FROM uempty) t");
+  // Five arms, with the empty one in the middle rather than at the end.
+  compare_gpu_vs_cpu(
+    "SELECT k FROM ua UNION ALL SELECT k FROM ub UNION ALL SELECT k FROM uempty UNION ALL "
+    "SELECT k FROM uc UNION ALL SELECT k FROM ua");
+}
+
+TEST_CASE_METHOD(UnionAllFixture,
+                 "gpu_execution UNION ALL arms of unequal length",
+                 "[integration][gpu_execution][union_all]")
+{
+  // A short arm drains first. The base task-driver contract would strand the
+  // longer arm's remaining rows once the short one finished; the row counts
+  // here are what catches that.
+  compare_gpu_vs_cpu("SELECT count(*) FROM (SELECT k FROM uc UNION ALL SELECT k FROM ua) t");
+  compare_gpu_vs_cpu("SELECT count(*) FROM (SELECT k FROM ua UNION ALL SELECT k FROM uc) t");
+  compare_gpu_vs_cpu("SELECT k FROM uc UNION ALL SELECT k FROM ua");
+}
+
+TEST_CASE_METHOD(UnionAllFixture,
+                 "gpu_execution UNION ALL reconciles types in the binder",
+                 "[integration][gpu_execution][union_all]")
+{
+  // INTEGER + BIGINT reconcile to BIGINT. Sirius does no type work: the cast is
+  // already a projection inside the INTEGER arm's subtree.
+  compare_gpu_vs_cpu("SELECT k FROM ua UNION ALL SELECT k FROM uwide");
+  compare_gpu_vs_cpu("SELECT k, v FROM uwide UNION ALL SELECT k, v FROM ua");
+  // A literal arm forces a second reconciliation shape.
+  compare_gpu_vs_cpu("SELECT k FROM ua UNION ALL SELECT 999");
+}
+
+TEST_CASE_METHOD(UnionAllFixture,
+                 "gpu_execution UNION ALL preserves NULLs",
+                 "[integration][gpu_execution][union_all]")
+{
+  // Bag union has no key and no comparison, so a NULL is just another value —
+  // it must be forwarded, never dropped or coalesced.
+  compare_gpu_vs_cpu("SELECT k, v FROM ua UNION ALL SELECT k, v FROM ub");
+  compare_gpu_vs_cpu(
+    "SELECT count(*) FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) t WHERE k IS NULL");
+}
+
+TEST_CASE_METHOD(UnionAllFixture,
+                 "gpu_execution UNION ALL composes with downstream operators",
+                 "[integration][gpu_execution][union_all]")
+{
+  // Aggregate downstream: UNION becomes a pipeline sink under the group-by's
+  // hash PARTITION, which is the is_sink() == true shape.
+  compare_gpu_vs_cpu(
+    "SELECT k, count(*) FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) t GROUP BY k");
+  compare_gpu_vs_cpu("SELECT sum(k) FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) t");
+
+  // Ordering downstream, where UNION's NO_ORDER source_order() decides the
+  // plan's order preservation.
+  compare_gpu_vs_cpu_ordered(
+    "SELECT k FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) t ORDER BY k NULLS LAST");
+  compare_gpu_vs_cpu_ordered(
+    "SELECT k FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) t ORDER BY k DESC NULLS LAST "
+    "LIMIT 3");
+
+  // Filter and projection downstream.
+  compare_gpu_vs_cpu("SELECT k * 2 FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) t WHERE k > 2");
+
+  // Probe side of a join.
+  compare_gpu_vs_cpu(
+    "SELECT t.k, b.v FROM (SELECT k FROM ua UNION ALL SELECT k FROM uc) t JOIN ub b ON t.k = b.k");
+  // Build side of a join.
+  compare_gpu_vs_cpu(
+    "SELECT a.k, a.v FROM ua a JOIN (SELECT k FROM ub UNION ALL SELECT k FROM uc) t ON a.k = t.k");
+}
+
+TEST_CASE_METHOD(UnionAllFixture,
+                 "gpu_execution UNION ALL nested inside another UNION ALL arm",
+                 "[integration][gpu_execution][union_all]")
+{
+  // An arm whose own subtree is a UNION: the inner UNION's passthrough sinks
+  // and the outer one's must not collide, since port names are per-operator.
+  compare_gpu_vs_cpu(
+    "SELECT count(*) FROM (SELECT k FROM ua UNION ALL "
+    "SELECT k FROM (SELECT k FROM ub UNION ALL SELECT k FROM uc) inner_t) t");
+  compare_gpu_vs_cpu(
+    "SELECT k FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) l UNION ALL "
+    "SELECT k FROM (SELECT k FROM uc UNION ALL SELECT k FROM uempty) r");
+  // An arm that is itself an aggregate: that arm's root is an unconditional
+  // sink, so the passthrough sink ends up alone in its pipeline with an input
+  // port, rather than inline at the end of a scan's pipeline.
+  compare_gpu_vs_cpu(
+    "SELECT k FROM (SELECT k FROM ua GROUP BY k) g UNION ALL SELECT k FROM ub");
+}
+
+TEST_CASE_METHOD(UnionAllFixture,
+                 "gpu_execution UNION ALL over a narrowed scan",
+                 "[integration][gpu_execution][union_all]")
+{
+  // The compressed-schema pass treats UNION as a native carrier boundary and
+  // restores every arm before the wrap pass runs, which is what stops two arms
+  // presenting different physical carriers for the same logical column. This
+  // exercises that path: uwide.k is BIGINT with small values (a narrowing
+  // candidate) unioned against an INTEGER arm.
+  compare_gpu_vs_cpu("SELECT k FROM uwide UNION ALL SELECT k FROM ua");
+  compare_gpu_vs_cpu(
+    "SELECT k, count(*) FROM (SELECT k FROM uwide UNION ALL SELECT k FROM ua) t GROUP BY k");
+}
+
+TEST_CASE_METHOD(UnionAllFixture,
+                 "gpu_execution declines the rest of the set-operation family",
+                 "[integration][gpu_execution][union_all]")
+{
+  // Distinct UNION, EXCEPT and INTERSECT are still unsupported. They must leave
+  // the GPU path cleanly via a fallback -- not error, and not silently produce a
+  // bag union.
+  expect_gpu_fallback("SELECT k FROM ua UNION SELECT k FROM ub");
+  expect_gpu_fallback("SELECT k FROM ua EXCEPT SELECT k FROM ub");
+  expect_gpu_fallback("SELECT k FROM ua INTERSECT SELECT k FROM ub");
+
+  // And the results are still right on the CPU.
+  auto distinct_result = con->Query(
+    "SELECT count(*) FROM (SELECT k FROM ua UNION SELECT k FROM ub) t WHERE k IS NOT NULL");
+  REQUIRE(distinct_result);
+  REQUIRE_FALSE(distinct_result->HasError());
+  REQUIRE(distinct_result->GetValue(0, 0).ToString() == "4");
+}

--- a/test/cpp/integration/test_gpu_execution_union_all.cpp
+++ b/test/cpp/integration/test_gpu_execution_union_all.cpp
@@ -105,7 +105,8 @@ TEST_CASE_METHOD(UnionAllFixture,
   // At the pinned DuckDB a chain binds to ONE set-operation node with N
   // children rather than a left-deep tree of binary nodes, which is why the
   // operator loops over children instead of indexing 0 and 1.
-  compare_gpu_vs_cpu("SELECT k, v FROM ua UNION ALL SELECT k, v FROM ub UNION ALL SELECT k, v FROM uc");
+  compare_gpu_vs_cpu(
+    "SELECT k, v FROM ua UNION ALL SELECT k, v FROM ub UNION ALL SELECT k, v FROM uc");
   compare_gpu_vs_cpu(
     "SELECT count(*) FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub UNION ALL SELECT k FROM uc "
     "UNION ALL SELECT k FROM uempty) t");
@@ -169,7 +170,8 @@ TEST_CASE_METHOD(UnionAllFixture,
     "LIMIT 3");
 
   // Filter and projection downstream.
-  compare_gpu_vs_cpu("SELECT k * 2 FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) t WHERE k > 2");
+  compare_gpu_vs_cpu(
+    "SELECT k * 2 FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) t WHERE k > 2");
 
   // Probe side of a join.
   compare_gpu_vs_cpu(
@@ -194,8 +196,7 @@ TEST_CASE_METHOD(UnionAllFixture,
   // An arm that is itself an aggregate: that arm's root is an unconditional
   // sink, so the passthrough sink ends up alone in its pipeline with an input
   // port, rather than inline at the end of a scan's pipeline.
-  compare_gpu_vs_cpu(
-    "SELECT k FROM (SELECT k FROM ua GROUP BY k) g UNION ALL SELECT k FROM ub");
+  compare_gpu_vs_cpu("SELECT k FROM (SELECT k FROM ua GROUP BY k) g UNION ALL SELECT k FROM ub");
 }
 
 TEST_CASE_METHOD(UnionAllFixture,

--- a/test/cpp/integration/test_gpu_execution_union_all.cpp
+++ b/test/cpp/integration/test_gpu_execution_union_all.cpp
@@ -30,7 +30,9 @@
 
 #include <catch.hpp>
 #include <duckdb.hpp>
+#include <utils/dynamic_filter_test_utils.hpp>
 #include <utils/gpu_execution_fixture.hpp>
+#include <utils/transparent_execution_test_utils.hpp>
 
 #include <string>
 
@@ -148,6 +150,18 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL composes with downstream operators",
                  "[integration][gpu_execution][union_all]")
 {
+  // DuckDB's COMPRESSED_MATERIALIZATION rewrites these narrow keys into
+  // __internal_compress_integral_* inside a projection, which the expression translator declines,
+  // so the query runs on the CPU and the fixture's GPU-execution assertion fails. It keys on
+  // statistics earlier tests warm, so this passes alone and fails in a full run. Guarded so the
+  // case asserts UNION's shape, not that.
+  //
+  // This guard appends to the live mask rather than replacing it. Sirius publishes in_clause,
+  // compressed_materialization and late_materialization at extension load
+  // (publish_transparent_optimizer_mask, sirius_extension.cpp:3438), so a plain
+  // `SET disabled_optimizers = '...'` would drop the other two for the duration of this case.
+  sirius::test::disabled_optimizers_guard no_cm{*con, "compressed_materialization"};
+
   // Aggregate downstream: UNION becomes a pipeline sink under the group-by's hash PARTITION,
   // which is the is_sink() == true shape.
   compare_gpu_vs_cpu(
@@ -177,6 +191,9 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL nested inside another UNION ALL arm",
                  "[integration][gpu_execution][union_all]")
 {
+  // Same COMPRESSED_MATERIALIZATION guard as the case above.
+  sirius::test::disabled_optimizers_guard no_cm{*con, "compressed_materialization"};
+
   // An arm whose own subtree is a UNION: the inner and outer passthrough sinks must not collide,
   // since port names are per-operator.
   compare_gpu_vs_cpu(
@@ -197,9 +214,28 @@ TEST_CASE_METHOD(UnionAllFixture,
   // The compressed-schema pass treats UNION as a native carrier boundary and restores every arm
   // before the wrap pass, stopping two arms presenting different carriers for one logical column.
   // uwide.k is BIGINT with small values (a narrowing candidate) unioned against an INTEGER arm.
+  // uwide must be pinned for any of that to happen -- a sidecar is installed only for a resident
+  // table (sirius_plan_get.cpp:633) -- and without it this case narrowed nothing and proved none
+  // of the above.
+  // Same COMPRESSED_MATERIALIZATION guard as the case above.
+  sirius::test::disabled_optimizers_guard no_cm{*con, "compressed_materialization"};
+  auto pin = con->Query("CALL pin_table(format='duckdb', name='uwide', tier='gpu');");
+  REQUIRE(pin);
+  REQUIRE_FALSE(pin->HasError());
+
+  auto const before = sirius::test::get_compressed_materialization_stats(*con);
+
   compare_gpu_vs_cpu("SELECT k FROM uwide UNION ALL SELECT k FROM ua");
   compare_gpu_vs_cpu(
     "SELECT k, count(*) FROM (SELECT k FROM uwide UNION ALL SELECT k FROM ua) t GROUP BY k");
+
+  auto const after = sirius::test::get_compressed_materialization_stats(*con);
+  // Both halves of the claim: the arm scans narrow, the boundary restores. scan_columns_narrowed
+  // stays 0 by design -- nothing survives narrow past the boundary.
+  REQUIRE(after.scan_sidecars_installed > before.scan_sidecars_installed);
+  REQUIRE(after.scan_columns_restored > before.scan_columns_restored);
+
+  REQUIRE_FALSE(con->Query("CALL unpin_table('uwide');")->HasError());
 }
 
 TEST_CASE_METHOD(UnionAllFixture,

--- a/test/cpp/integration/test_gpu_execution_union_all.cpp
+++ b/test/cpp/integration/test_gpu_execution_union_all.cpp
@@ -14,23 +14,17 @@
  * limitations under the License.
  */
 
-// GPU-vs-CPU correctness for `UNION ALL` (sirius_physical_union +
-// sirius_physical_passthrough_sink).
+// GPU-vs-CPU correctness for `UNION ALL`: sirius_physical_union + sirius_physical_passthrough_sink.
 //
-// Every query goes through the shared GpuExecutionFixture, which runs it once
-// transparently on the GPU -- asserting exactly one GPU execution and ZERO
-// fallbacks -- and once on DuckDB CPU, then compares. That zero-fallback
-// assertion is what makes these tests meaningful: a UNION ALL that silently
-// CPU-fell-back would still produce the right answer, so a plain result check
-// would pass whether or not the operator existed.
+// GpuExecutionFixture runs each query on the GPU -- asserting one GPU execution and ZERO fallbacks
+// -- and again on DuckDB CPU, then compares. The zero-fallback assertion is what makes these tests
+// meaningful: a silent CPU fallback would still produce the right answer, so a plain result check
+// would pass whether or not the operator existed. The rest of the set-operation family is asserted
+// the other way round, with expect_gpu_fallback.
 //
-// The rest of the set-operation family is asserted the other way round, with
-// expect_gpu_fallback: those must still leave the GPU path cleanly.
-//
-// NOT covered here (needs a fixture with a small scan_task_batch_size; the
-// shared integration config uses 100 MB, so these fixtures are one batch per
-// arm): multi-batch streaming, unequal-length arms across many batches, and
-// multi-GPU device placement.
+// NOT covered here (needs a fixture with a small scan_task_batch_size; the shared integration
+// config uses 100 MB, so these fixtures are one batch per arm): multi-batch streaming,
+// unequal-length arms across many batches, and multi-GPU device placement.
 
 #include <catch.hpp>
 #include <duckdb.hpp>
@@ -40,9 +34,8 @@
 
 namespace {
 
-// Overlapping keys between a and b (k = 3) so multiset semantics are
-// observable, a disjoint third table for N-ary chains, an empty table, and a
-// BIGINT-keyed table so the binder has a super-type to reconcile to.
+// Overlapping keys between a and b (k = 3) so multiset semantics are observable, a disjoint third
+// table for N-ary chains, an empty table, and a BIGINT-keyed table for super-type reconciliation.
 class UnionAllFixture : public sirius::test::GpuExecutionFixture {
  public:
   UnionAllFixture()
@@ -77,8 +70,7 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL is a multiset, not a set",
                  "[integration][gpu_execution][union_all]")
 {
-  // (3, 'c') is in both inputs and must survive twice. The count comparison is
-  // the assertion that no de-duplication happened.
+  // (3, 'c') is in both inputs and must survive twice: the count is what catches de-duplication.
   compare_gpu_vs_cpu("SELECT count(*) FROM (SELECT k, v FROM ua UNION ALL SELECT k, v FROM ub) t");
   compare_gpu_vs_cpu(
     "SELECT count(*) FROM (SELECT k, v FROM ua UNION ALL SELECT k, v FROM ub) t WHERE k = 3");
@@ -90,9 +82,8 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL with an empty arm",
                  "[integration][gpu_execution][union_all]")
 {
-  // An empty arm's pipeline finishes without ever pushing a batch, so the
-  // operator must fall through it to the other arm rather than reporting
-  // exhausted.
+  // An empty arm's pipeline finishes without pushing a batch, so the operator must fall through
+  // to the other arm rather than reporting exhausted.
   compare_gpu_vs_cpu("SELECT k, v FROM ua UNION ALL SELECT k, v FROM uempty");
   compare_gpu_vs_cpu("SELECT k, v FROM uempty UNION ALL SELECT k, v FROM ua");
   compare_gpu_vs_cpu("SELECT k FROM uempty UNION ALL SELECT k FROM uempty");
@@ -102,9 +93,8 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL is N-ary",
                  "[integration][gpu_execution][union_all]")
 {
-  // At the pinned DuckDB a chain binds to ONE set-operation node with N
-  // children rather than a left-deep tree of binary nodes, which is why the
-  // operator loops over children instead of indexing 0 and 1.
+  // At the pinned DuckDB a chain binds to ONE set-operation node with N children rather than a
+  // left-deep tree of binary nodes, which is why the operator loops over children.
   compare_gpu_vs_cpu(
     "SELECT k, v FROM ua UNION ALL SELECT k, v FROM ub UNION ALL SELECT k, v FROM uc");
   compare_gpu_vs_cpu(
@@ -120,9 +110,8 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL arms of unequal length",
                  "[integration][gpu_execution][union_all]")
 {
-  // A short arm drains first. The base task-driver contract would strand the
-  // longer arm's remaining rows once the short one finished; the row counts
-  // here are what catches that.
+  // A short arm drains first. The base task-driver contract would strand the longer arm's
+  // remaining rows once the short one finished; the row counts here are what catches that.
   compare_gpu_vs_cpu("SELECT count(*) FROM (SELECT k FROM uc UNION ALL SELECT k FROM ua) t");
   compare_gpu_vs_cpu("SELECT count(*) FROM (SELECT k FROM ua UNION ALL SELECT k FROM uc) t");
   compare_gpu_vs_cpu("SELECT k FROM uc UNION ALL SELECT k FROM ua");
@@ -132,8 +121,7 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL reconciles types in the binder",
                  "[integration][gpu_execution][union_all]")
 {
-  // INTEGER + BIGINT reconcile to BIGINT. Sirius does no type work: the cast is
-  // already a projection inside the INTEGER arm's subtree.
+  // INTEGER + BIGINT reconcile to BIGINT; the cast is already a projection inside the INTEGER arm.
   compare_gpu_vs_cpu("SELECT k FROM ua UNION ALL SELECT k FROM uwide");
   compare_gpu_vs_cpu("SELECT k, v FROM uwide UNION ALL SELECT k, v FROM ua");
   // A literal arm forces a second reconciliation shape.
@@ -144,8 +132,7 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL preserves NULLs",
                  "[integration][gpu_execution][union_all]")
 {
-  // Bag union has no key and no comparison, so a NULL is just another value —
-  // it must be forwarded, never dropped or coalesced.
+  // Bag union has no key and no comparison, so a NULL must be forwarded, not dropped or coalesced.
   compare_gpu_vs_cpu("SELECT k, v FROM ua UNION ALL SELECT k, v FROM ub");
   compare_gpu_vs_cpu(
     "SELECT count(*) FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) t WHERE k IS NULL");
@@ -155,14 +142,13 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL composes with downstream operators",
                  "[integration][gpu_execution][union_all]")
 {
-  // Aggregate downstream: UNION becomes a pipeline sink under the group-by's
-  // hash PARTITION, which is the is_sink() == true shape.
+  // Aggregate downstream: UNION becomes a pipeline sink under the group-by's hash PARTITION,
+  // which is the is_sink() == true shape.
   compare_gpu_vs_cpu(
     "SELECT k, count(*) FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) t GROUP BY k");
   compare_gpu_vs_cpu("SELECT sum(k) FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) t");
 
-  // Ordering downstream, where UNION's NO_ORDER source_order() decides the
-  // plan's order preservation.
+  // Ordering downstream, where UNION's NO_ORDER source_order() decides the plan's preservation.
   compare_gpu_vs_cpu_ordered(
     "SELECT k FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) t ORDER BY k NULLS LAST");
   compare_gpu_vs_cpu_ordered(
@@ -185,17 +171,16 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL nested inside another UNION ALL arm",
                  "[integration][gpu_execution][union_all]")
 {
-  // An arm whose own subtree is a UNION: the inner UNION's passthrough sinks
-  // and the outer one's must not collide, since port names are per-operator.
+  // An arm whose own subtree is a UNION: the inner and outer passthrough sinks must not collide,
+  // since port names are per-operator.
   compare_gpu_vs_cpu(
     "SELECT count(*) FROM (SELECT k FROM ua UNION ALL "
     "SELECT k FROM (SELECT k FROM ub UNION ALL SELECT k FROM uc) inner_t) t");
   compare_gpu_vs_cpu(
     "SELECT k FROM (SELECT k FROM ua UNION ALL SELECT k FROM ub) l UNION ALL "
     "SELECT k FROM (SELECT k FROM uc UNION ALL SELECT k FROM uempty) r");
-  // An arm that is itself an aggregate: that arm's root is an unconditional
-  // sink, so the passthrough sink ends up alone in its pipeline with an input
-  // port, rather than inline at the end of a scan's pipeline.
+  // An arm that is itself an aggregate: its root is an unconditional sink, so the passthrough
+  // sink ends up alone in its pipeline with an input port rather than inline in a scan's.
   compare_gpu_vs_cpu("SELECT k FROM (SELECT k FROM ua GROUP BY k) g UNION ALL SELECT k FROM ub");
 }
 
@@ -203,11 +188,9 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL over a narrowed scan",
                  "[integration][gpu_execution][union_all]")
 {
-  // The compressed-schema pass treats UNION as a native carrier boundary and
-  // restores every arm before the wrap pass runs, which is what stops two arms
-  // presenting different physical carriers for the same logical column. This
-  // exercises that path: uwide.k is BIGINT with small values (a narrowing
-  // candidate) unioned against an INTEGER arm.
+  // The compressed-schema pass treats UNION as a native carrier boundary and restores every arm
+  // before the wrap pass, stopping two arms presenting different carriers for one logical column.
+  // uwide.k is BIGINT with small values (a narrowing candidate) unioned against an INTEGER arm.
   compare_gpu_vs_cpu("SELECT k FROM uwide UNION ALL SELECT k FROM ua");
   compare_gpu_vs_cpu(
     "SELECT k, count(*) FROM (SELECT k FROM uwide UNION ALL SELECT k FROM ua) t GROUP BY k");
@@ -217,9 +200,8 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution declines the rest of the set-operation family",
                  "[integration][gpu_execution][union_all]")
 {
-  // Distinct UNION, EXCEPT and INTERSECT are still unsupported. They must leave
-  // the GPU path cleanly via a fallback -- not error, and not silently produce a
-  // bag union.
+  // Distinct UNION, EXCEPT and INTERSECT must leave the GPU path cleanly via a fallback -- not
+  // error, and not silently produce a bag union.
   expect_gpu_fallback("SELECT k FROM ua UNION SELECT k FROM ub");
   expect_gpu_fallback("SELECT k FROM ua EXCEPT SELECT k FROM ub");
   expect_gpu_fallback("SELECT k FROM ua INTERSECT SELECT k FROM ub");

--- a/test/cpp/integration/test_gpu_execution_union_all.cpp
+++ b/test/cpp/integration/test_gpu_execution_union_all.cpp
@@ -85,7 +85,9 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "[integration][gpu_execution][union_all]")
 {
   // An empty arm's pipeline finishes without pushing a batch, so the operator must fall through
-  // to the other arm rather than reporting exhausted.
+  // to the other arm rather than reporting exhausted. The base's all-ports readiness test can
+  // never hold here, which makes these the only cases in the file that would fail if UNION's
+  // ANY-readiness override were reverted.
   compare_gpu_vs_cpu("SELECT k, v FROM ua UNION ALL SELECT k, v FROM uempty");
   compare_gpu_vs_cpu("SELECT k, v FROM uempty UNION ALL SELECT k, v FROM ua");
   compare_gpu_vs_cpu("SELECT k FROM uempty UNION ALL SELECT k FROM uempty");
@@ -112,8 +114,9 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL arms of unequal length",
                  "[integration][gpu_execution][union_all]")
 {
-  // A short arm drains first. The base task-driver contract would strand the longer arm's
-  // remaining rows once the short one finished; the row counts here are what catches that.
+  // A row-count check on asymmetric inputs, and no more than that. Arm stranding needs an arm
+  // with a second batch to strand, which the shared 100 MB scan_task_batch_size cannot produce:
+  // at one batch per arm the base task-driver contract answers these correctly too.
   compare_gpu_vs_cpu("SELECT count(*) FROM (SELECT k FROM uc UNION ALL SELECT k FROM ua) t");
   compare_gpu_vs_cpu("SELECT count(*) FROM (SELECT k FROM ua UNION ALL SELECT k FROM uc) t");
   compare_gpu_vs_cpu("SELECT k FROM uc UNION ALL SELECT k FROM ua");

--- a/test/cpp/integration/test_gpu_execution_union_all.cpp
+++ b/test/cpp/integration/test_gpu_execution_union_all.cpp
@@ -87,7 +87,8 @@ TEST_CASE_METHOD(UnionAllFixture,
   // An empty arm's pipeline finishes without pushing a batch, so the operator must fall through
   // to the other arm rather than reporting exhausted. The base's all-ports readiness test can
   // never hold here, which makes these the only cases in the file that would fail if UNION's
-  // ANY-readiness override were reverted.
+  // readiness override -- excusing a finished arm rather than waiting on every port -- were
+  // reverted.
   compare_gpu_vs_cpu("SELECT k, v FROM ua UNION ALL SELECT k, v FROM uempty");
   compare_gpu_vs_cpu("SELECT k, v FROM uempty UNION ALL SELECT k, v FROM ua");
   compare_gpu_vs_cpu("SELECT k FROM uempty UNION ALL SELECT k FROM uempty");

--- a/test/cpp/integration/test_gpu_execution_union_all.cpp
+++ b/test/cpp/integration/test_gpu_execution_union_all.cpp
@@ -20,7 +20,9 @@
 // -- and again on DuckDB CPU, then compares. The zero-fallback assertion is what makes these tests
 // meaningful: a silent CPU fallback would still produce the right answer, so a plain result check
 // would pass whether or not the operator existed. The rest of the set-operation family is asserted
-// the other way round, with expect_gpu_fallback.
+// the other way round, with expect_plan_fallback_matches_cpu -- those shapes are refused during
+// plan generation, which moves `fallbacks` and leaves `executions` flat, so expect_gpu_fallback
+// (which requires the *runtime* counter to move) would never hold for them.
 //
 // NOT covered here (needs a fixture with a small scan_task_batch_size; the shared integration
 // config uses 100 MB, so these fixtures are one batch per arm): multi-batch streaming,
@@ -201,15 +203,11 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "[integration][gpu_execution][union_all]")
 {
   // Distinct UNION, EXCEPT and INTERSECT must leave the GPU path cleanly via a fallback -- not
-  // error, and not silently produce a bag union.
-  expect_gpu_fallback("SELECT k FROM ua UNION SELECT k FROM ub");
-  expect_gpu_fallback("SELECT k FROM ua EXCEPT SELECT k FROM ub");
-  expect_gpu_fallback("SELECT k FROM ua INTERSECT SELECT k FROM ub");
-
-  // And the results are still right on the CPU.
-  auto distinct_result = con->Query(
-    "SELECT count(*) FROM (SELECT k FROM ua UNION SELECT k FROM ub) t WHERE k IS NOT NULL");
-  REQUIRE(distinct_result);
-  REQUIRE_FALSE(distinct_result->HasError());
-  REQUIRE(distinct_result->GetValue(0, 0).ToString() == "4");
+  // error, and not silently produce a bag union. All three are refused during plan generation
+  // (sirius_plan_set_operation.cpp for distinct UNION, the generator switch for the other two),
+  // so this asserts a plan-time fallback. The helper also compares against the CPU result, which
+  // is what pins "still the right answer" without a hand-rolled second check.
+  expect_plan_fallback_matches_cpu("SELECT k FROM ua UNION SELECT k FROM ub");
+  expect_plan_fallback_matches_cpu("SELECT k FROM ua EXCEPT SELECT k FROM ub");
+  expect_plan_fallback_matches_cpu("SELECT k FROM ua INTERSECT SELECT k FROM ub");
 }

--- a/test/cpp/integration/test_gpu_execution_union_all.cpp
+++ b/test/cpp/integration/test_gpu_execution_union_all.cpp
@@ -88,9 +88,7 @@ TEST_CASE_METHOD(UnionAllFixture,
 {
   // An empty arm's pipeline finishes without pushing a batch, so the operator must fall through
   // to the other arm rather than reporting exhausted. The base's all-ports readiness test can
-  // never hold here, which makes these the only cases in the file that would fail if UNION's
-  // readiness override -- excusing a finished arm rather than waiting on every port -- were
-  // reverted.
+  // never hold here, so these cases are the regression test for excusing a finished arm.
   compare_gpu_vs_cpu("SELECT k, v FROM ua UNION ALL SELECT k, v FROM uempty");
   compare_gpu_vs_cpu("SELECT k, v FROM uempty UNION ALL SELECT k, v FROM ua");
   compare_gpu_vs_cpu("SELECT k FROM uempty UNION ALL SELECT k FROM uempty");
@@ -150,16 +148,11 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL composes with downstream operators",
                  "[integration][gpu_execution][union_all]")
 {
-  // DuckDB's COMPRESSED_MATERIALIZATION rewrites these narrow keys into
-  // __internal_compress_integral_* inside a projection, which the expression translator declines,
-  // so the query runs on the CPU and the fixture's GPU-execution assertion fails. It keys on
-  // statistics earlier tests warm, so this passes alone and fails in a full run. Guarded so the
-  // case asserts UNION's shape, not that.
-  //
-  // This guard appends to the live mask rather than replacing it. Sirius publishes in_clause,
-  // compressed_materialization and late_materialization at extension load
-  // (publish_transparent_optimizer_mask, sirius_extension.cpp:3438), so a plain
-  // `SET disabled_optimizers = '...'` would drop the other two for the duration of this case.
+  // COMPRESSED_MATERIALIZATION rewrites these narrow keys into __internal_compress_integral_*
+  // inside a projection, which the expression translator declines, so the query runs on the CPU
+  // and the fixture's GPU-execution assertion fails. Sirius masks that optimizer at load, but
+  // ~UniqueJoinFixture (test_gpu_execution_unique_join.cpp:68) resets the mask to '', so it is
+  // live again for anything running after it. The guard appends, restoring the mask it found.
   sirius::test::disabled_optimizers_guard no_cm{*con, "compressed_materialization"};
 
   // Aggregate downstream: UNION becomes a pipeline sink under the group-by's hash PARTITION,
@@ -211,12 +204,10 @@ TEST_CASE_METHOD(UnionAllFixture,
                  "gpu_execution UNION ALL over a narrowed scan",
                  "[integration][gpu_execution][union_all]")
 {
-  // The compressed-schema pass treats UNION as a native carrier boundary and restores every arm
-  // before the wrap pass, stopping two arms presenting different carriers for one logical column.
-  // uwide.k is BIGINT with small values (a narrowing candidate) unioned against an INTEGER arm.
-  // uwide must be pinned for any of that to happen -- a sidecar is installed only for a resident
-  // table (sirius_plan_get.cpp:633) -- and without it this case narrowed nothing and proved none
-  // of the above.
+  // The compressed-schema pass treats UNION as a native carrier boundary and restores every arm,
+  // so two arms never present different carriers for one logical column. uwide.k is BIGINT with
+  // small values (a narrowing candidate) against an INTEGER arm, and must be pinned for a sidecar
+  // to be installed at all (sirius_plan_get.cpp:633).
   // Same COMPRESSED_MATERIALIZATION guard as the case above.
   sirius::test::disabled_optimizers_guard no_cm{*con, "compressed_materialization"};
   auto pin = con->Query("CALL pin_table(format='duckdb', name='uwide', tier='gpu');");

--- a/test/cpp/integration/test_gpu_execution_union_all.cpp
+++ b/test/cpp/integration/test_gpu_execution_union_all.cpp
@@ -242,3 +242,51 @@ TEST_CASE_METHOD(UnionAllFixture,
   expect_plan_fallback_matches_cpu("SELECT k FROM ua EXCEPT SELECT k FROM ub");
   expect_plan_fallback_matches_cpu("SELECT k FROM ua INTERSECT SELECT k FROM ub");
 }
+
+TEST_CASE_METHOD(UnionAllFixture,
+                 "gpu_execution UNION ALL over a materialized CTE arm",
+                 "[integration][gpu_execution][union_all]")
+{
+  // Regression for the arity guard in sirius_plan_set_operation.cpp, which used to read the arm's
+  // *physical* width. A materialized CTE declares its materialization side, so an arm whose
+  // definition and body differ in width was declined to the CPU.
+  //
+  // Two traps when reshaping these. The CTE must stay MATERIALIZED, or a single-reference one is
+  // inlined away and no CTE node reaches the planner. And the definition's width must be forced
+  // apart from the body's: DuckDB's unused-column optimizer prunes the materialization down to
+  // what the body reads, so a body that merely projects a subset leaves the two equal and tests
+  // nothing.
+
+  // Definition wider, 2 against 1. The self-join on v is what keeps v from being pruned.
+  compare_gpu_vs_cpu(
+    "SELECT k FROM ua "
+    "UNION ALL "
+    "(WITH m AS MATERIALIZED (SELECT k, v FROM ub) "
+    " SELECT m1.k FROM m m1 JOIN m m2 ON m1.v = m2.v)");
+
+  // Definition narrower, 1 against 2; the body widens with arithmetic. Direction does not matter.
+  compare_gpu_vs_cpu(
+    "SELECT k, k * 2 FROM ua "
+    "UNION ALL "
+    "(WITH m AS MATERIALIZED (SELECT k FROM ub) SELECT k, k * 2 FROM m)");
+
+  // Widths coincide at 2, so this passed before the fix too. Kept so the guard cannot regress into
+  // rejecting it.
+  compare_gpu_vs_cpu(
+    "SELECT k, v FROM ua "
+    "UNION ALL "
+    "(WITH m AS MATERIALIZED (SELECT k, v FROM ub) SELECT k, v FROM m)");
+
+  // The CTE as arm 0, mirroring the "arm order reversed" case above: arm position must not matter.
+  compare_gpu_vs_cpu(
+    "(WITH m AS MATERIALIZED (SELECT k FROM ub) SELECT k, k * 2 FROM m) "
+    "UNION ALL "
+    "SELECT k, k * 2 FROM ua");
+
+  // Control: written above the union, the CTE is its parent and never reaches the guard.
+  compare_gpu_vs_cpu(
+    "WITH m AS MATERIALIZED (SELECT k, v FROM ub) "
+    "SELECT k FROM ua "
+    "UNION ALL "
+    "SELECT k FROM m");
+}

--- a/test/cpp/operator/test_physical_union_mgpu.cpp
+++ b/test/cpp/operator/test_physical_union_mgpu.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Per-operator MGPU integration test for UNION ALL (physical_union).
+//
+// UNION ALL is the one wrapper-fed operator that is deliberately NOT
+// partition-based. Its arms are joined by PASSTHROUGH_SINK, which forwards a
+// batch unpartitioned: the `pipelineable_operator_data` it hands on carries no
+// `partition_idx`, so the `partition_idx % num_gpus` pin every other MGPU
+// operator relies on never fires. Placement instead falls to the locality
+// block in task_creator.cpp:450-475, which reads the memory space of the
+// inbound batch and picks the GPU already holding the most bytes.
+//
+// That makes `hash_partition_bytes` — the lever test_physical_order_mgpu.cpp
+// and test_physical_grouped_aggregate_merge_mgpu.cpp pull to force
+// multi-partition execution — the wrong knob here. The lever is
+// `scan_task_batch_size`: small enough that a wide arm produces many batches
+// while a narrow one produces few, which is the unequal-arm shape the
+// starved-arm task hint exists to serve.
+//
+// The shared integration configs cannot express that shape. Both
+// integration.yaml:22 and integration-2gpu.yaml pin scan_task_batch_size at
+// 100 MB, so every fixture table is one batch per arm and no suite run has
+// ever driven an arm past a single round. These TEST_CASEs generate their own
+// yaml via write_mgpu_yaml instead, which is why they change no config file.
+//
+//   1. Unequal arms drain across many batches — SINGLE GPU. The wide arm
+//      produces many scan batches, the narrow one a single batch. Correctness
+//      against a CPU oracle. This is the first fixture that exercises the
+//      starved-arm hint across more than one round per arm.
+//   2. Three arms of descending width — SINGLE GPU. Drives `_arm_cursor` /
+//      `_wait_cursor` past arm 0, which the 100 MB fixtures cannot.
+//   3. Balanced arms distribute across two GPUs — needs 2 GPUs.
+//   4. Unequal arms do not strand work on one GPU — needs 2 GPUs. The
+//      stranding failure the hint exists to prevent.
+//
+// TEST_CASEs 1 and 2 carry [single-gpu] and no [mgpu] tag, so they run on a
+// single-GPU host; 3 and 4 carry [mgpu] and gate on require_two_gpus().
+//
+// NOT asserted here: zero cross-device migration — that a UNION task ran on
+// the GPU that produced its input batch. `tasks_executed` per executor proves
+// distribution, not locality, and the suite has no mechanism for the stronger
+// property. Demonstrating it needs either an nsys run or a negative control
+// that forces `partition_idx == 0` onto the sink, and the latter would mean a
+// behaviour hook in production code. See the union-all note set's
+// gpu-handoff.md §2.
+
+#include "mgpu_test_utils.hpp"
+
+#include <cuda_runtime.h>
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+using namespace sirius::test::mgpu;
+
+namespace {
+
+// 1 MB is below the per-file size of every surface here, so the coalescer
+// gives each file its own batch: 8 batches for the wide arm, 2 for the middle
+// one, 1 for the narrow one. That is the asymmetry the starved-arm hint exists
+// to serve, at a row count that keeps the CPU-oracle comparison cheap enough
+// for CI. Mirrors test/cpp/scan_manager/test_pin_table_multi_gpu.cpp:139.
+// hash_partition_bytes is left at its default: UNION ALL does not partition,
+// so shrinking it would only add noise from the scan side.
+constexpr uint64_t kSmallScanBatchBytes = 1'000'000;
+
+mgpu_env_params make_params(int num_gpus)
+{
+  mgpu_env_params p;
+  p.cache                    = "none";
+  p.num_gpus                 = num_gpus;
+  p.scan_task_batch_size     = kSmallScanBatchBytes;
+  p.pipeline_num_threads     = 4;
+  p.task_creator_num_threads = 4;
+  return p;
+}
+
+fs::path make_tmp_dir(std::string const& tag)
+{
+  auto tmp =
+    fs::temp_directory_path() / ("sirius-mgpu-union-" + std::to_string(::getpid()) + "-" + tag);
+  std::error_code ec;
+  fs::remove_all(tmp, ec);
+  fs::create_directories(tmp);
+  return tmp;
+}
+
+// 8 files x 100k rows x 16 B ~ 12.8 MB, so each ~1.6 MB file is its own batch
+// at kSmallScanBatchBytes and the arm needs eight rounds to drain.
+void generate_wide_arm(fs::path const& dir)
+{
+  generate_parquet_surface(dir, "SELECT range AS k, range * 2 AS v FROM range(100000)", 8);
+}
+
+// One file, 1k rows — a single batch however the coalescer is configured.
+void generate_narrow_arm(fs::path const& dir)
+{
+  generate_parquet_surface(dir, "SELECT range AS k, range * 3 AS v FROM range(1000)", 1);
+}
+
+// A middle arm, wide enough for a handful of batches but well short of the
+// wide arm, so a three-arm union has three distinct drain lengths.
+void generate_middle_arm(fs::path const& dir)
+{
+  generate_parquet_surface(dir, "SELECT range AS k, range * 5 AS v FROM range(200000)", 2);
+}
+
+std::string union_of(std::vector<fs::path> const& dirs)
+{
+  std::string sql;
+  for (size_t i = 0; i < dirs.size(); ++i) {
+    if (i != 0) sql += " UNION ALL ";
+    sql += "SELECT k, v FROM read_parquet('" + parquet_glob(dirs[i]) + "')";
+  }
+  return sql;
+}
+
+// Run `query` under a generated env and return tasks_executed per device.
+std::map<int, size_t> run_and_collect(fs::path const& yaml, std::string const& query)
+{
+  std::map<int, size_t> tasks_per_gpu;
+  scoped_mgpu_env env(yaml);
+  auto con = std::make_unique<duckdb::Connection>(env.make_connection());
+  require_gpu_matches_cpu(*con, query, /*force_cpu_reference=*/true);
+  auto& scheduler = env.get_task_scheduler(*con);
+  con.reset();  // flush sinks before reading metrics
+
+  scheduler.visit_executors(
+    [&](int device_id, sirius::pipeline::gpu_pipeline_executor const& exec) {
+      tasks_per_gpu[device_id] = exec.get_metrics().tasks_executed;
+    });
+  return tasks_per_gpu;
+}
+
+}  // namespace
+
+TEST_CASE("physical_union - unequal arms drain across many batches",
+          "[single-gpu][operator-mgpu][union_all][gpu_execution]")
+{
+  auto tmp  = make_tmp_dir("unequal-1gpu");
+  auto yaml = tmp / "mgpu.yaml";
+  write_mgpu_yaml(yaml, make_params(/*num_gpus=*/1));
+  REQUIRE(fs::exists(yaml));
+
+  auto wide   = tmp / "wide";
+  auto narrow = tmp / "narrow";
+  generate_wide_arm(wide);
+  generate_narrow_arm(narrow);
+
+  // 8 x 100k + 1 x 1k. The arms are bag-unioned, so every row of both survives.
+  constexpr size_t kExpectedRows = 8 * 100000 + 1000;
+
+  auto query = union_of({wide, narrow});
+  {
+    scoped_mgpu_env env(yaml);
+    auto con = env.make_connection();
+    require_gpu_matches_cpu(con, query, /*force_cpu_reference=*/true);
+
+    auto rows = con.Query("SELECT count(*) FROM (" + query + ") t;");
+    REQUIRE(rows);
+    REQUIRE_FALSE(rows->HasError());
+    REQUIRE(rows->GetValue(0, 0).GetValue<int64_t>() == static_cast<int64_t>(kExpectedRows));
+  }
+
+  std::error_code ec;
+  fs::remove_all(tmp, ec);
+}
+
+TEST_CASE("physical_union - three arms of descending width",
+          "[single-gpu][operator-mgpu][union_all][gpu_execution]")
+{
+  auto tmp  = make_tmp_dir("three-arm-1gpu");
+  auto yaml = tmp / "mgpu.yaml";
+  write_mgpu_yaml(yaml, make_params(/*num_gpus=*/1));
+  REQUIRE(fs::exists(yaml));
+
+  auto wide   = tmp / "wide";
+  auto middle = tmp / "middle";
+  auto narrow = tmp / "narrow";
+  generate_wide_arm(wide);
+  generate_middle_arm(middle);
+  generate_narrow_arm(narrow);
+
+  constexpr size_t kExpectedRows = 8 * 100000 + 2 * 200000 + 1000;
+
+  auto query = union_of({wide, middle, narrow});
+  {
+    scoped_mgpu_env env(yaml);
+    auto con = env.make_connection();
+    require_gpu_matches_cpu(con, query, /*force_cpu_reference=*/true);
+
+    auto rows = con.Query("SELECT count(*) FROM (" + query + ") t;");
+    REQUIRE(rows);
+    REQUIRE_FALSE(rows->HasError());
+    REQUIRE(rows->GetValue(0, 0).GetValue<int64_t>() == static_cast<int64_t>(kExpectedRows));
+  }
+
+  std::error_code ec;
+  fs::remove_all(tmp, ec);
+}
+
+TEST_CASE("physical_union - balanced arms distribute across two GPUs",
+          "[mgpu][operator-mgpu][union_all][gpu_execution]")
+{
+  if (!require_two_gpus()) return;
+
+  auto tmp  = make_tmp_dir("balanced-2gpu");
+  auto yaml = tmp / "mgpu.yaml";
+  write_mgpu_yaml(yaml, make_params(/*num_gpus=*/2));
+  REQUIRE(fs::exists(yaml));
+
+  auto left  = tmp / "left";
+  auto right = tmp / "right";
+  generate_wide_arm(left);
+  generate_wide_arm(right);
+
+  auto tasks_per_gpu = run_and_collect(yaml, union_of({left, right}));
+
+  INFO("gpu0 tasks=" << tasks_per_gpu[0] << " gpu1 tasks=" << tasks_per_gpu[1]);
+  REQUIRE(tasks_per_gpu.count(0));
+  REQUIRE(tasks_per_gpu.count(1));
+  REQUIRE(tasks_per_gpu.at(0) >= 1);
+  REQUIRE(tasks_per_gpu.at(1) >= 1);
+
+  std::error_code ec;
+  fs::remove_all(tmp, ec);
+}
+
+TEST_CASE("physical_union - unequal arms do not strand work on one GPU",
+          "[mgpu][operator-mgpu][union_all][gpu_execution]")
+{
+  if (!require_two_gpus()) return;
+
+  auto tmp  = make_tmp_dir("unequal-2gpu");
+  auto yaml = tmp / "mgpu.yaml";
+  write_mgpu_yaml(yaml, make_params(/*num_gpus=*/2));
+  REQUIRE(fs::exists(yaml));
+
+  // The asymmetry is the point: the narrow arm finishes in one round while the
+  // wide arm is still draining. If the starved-arm hint stopped nominating the
+  // wide arm, its remaining batches would strand on whichever GPU took the
+  // first one.
+  auto wide   = tmp / "wide";
+  auto narrow = tmp / "narrow";
+  generate_wide_arm(wide);
+  generate_narrow_arm(narrow);
+
+  auto tasks_per_gpu = run_and_collect(yaml, union_of({wide, narrow}));
+
+  INFO("gpu0 tasks=" << tasks_per_gpu[0] << " gpu1 tasks=" << tasks_per_gpu[1]);
+  REQUIRE(tasks_per_gpu.count(0));
+  REQUIRE(tasks_per_gpu.count(1));
+  REQUIRE(tasks_per_gpu.at(0) >= 1);
+  REQUIRE(tasks_per_gpu.at(1) >= 1);
+
+  std::error_code ec;
+  fs::remove_all(tmp, ec);
+}

--- a/test/cpp/planner/test_dynamic_filter_discovery_parity.cpp
+++ b/test/cpp/planner/test_dynamic_filter_discovery_parity.cpp
@@ -605,6 +605,38 @@ TEST_CASE_METHOD(discovery_parity_fixture,
 }
 
 TEST_CASE_METHOD(discovery_parity_fixture,
+                 "discovery parity - a UNION ALL probe fans into every arm",
+                 "[dynamic_filter][parity][isolated_context]")
+{
+  // Both walks descend a union positionally into every child, so one scan binds per arm. Every
+  // other case in this file follows a single spine.
+  dynamic_filter_on_guard filter_on(*con);
+  auto c = plan_parity_case(*con,
+                            "SELECT * FROM (SELECT id FROM big_left UNION ALL "
+                            "SELECT ckey FROM small_c) t "
+                            "JOIN small_right r ON t.id = r.rid WHERE r.other > 0");
+
+  auto joins = comparison_joins_of(*c.oracle_plan);
+  REQUIRE(joins.size() == 1);
+  auto const oracle = oracle_targets_for_join(*joins[0]);
+  REQUIRE(oracle.size() == 2);
+  REQUIRE(oracle[0].condition_index == 0);
+  REQUIRE(oracle[1].condition_index == 0);
+  REQUIRE(oracle[0].table_name == "big_left");
+  REQUIRE(oracle[1].table_name == "small_c");
+
+  auto physical_joins = hash_joins_of(c.physical.get());
+  REQUIRE(physical_joins.size() == 1);
+  REQUIRE(scan_bindings_of(*physical_joins[0], c.physical.get()) ==
+          std::vector<sirius_scan_binding>{{.condition_index = 0,
+                                            .table_name      = oracle[0].table_name,
+                                            .push_ordinal    = oracle[0].output_ordinal},
+                                           {.condition_index = 0,
+                                            .table_name      = oracle[1].table_name,
+                                            .push_ordinal    = oracle[1].output_ordinal}});
+}
+
+TEST_CASE_METHOD(discovery_parity_fixture,
                  "discovery parity - a cast projection: DuckDB crosses it, Sirius refuses",
                  "[dynamic_filter][parity][isolated_context]")
 {

--- a/test/cpp/planner/test_plan_tree_shape.cpp
+++ b/test/cpp/planner/test_plan_tree_shape.cpp
@@ -1494,3 +1494,50 @@ TEST_CASE_METHOD(plan_tree_shape_fixture,
   sirius::planner::collect_gpu_scans(*plan, found);
   CHECK(found.size() == expected.size());
 }
+
+TEST_CASE_METHOD(plan_tree_shape_fixture,
+                 "plan tree shape - UNION arm sinks declare the union's schema, not the arm's",
+                 "[plan_tree_shape][union_all][isolated_context]")
+{
+  // Each arm's sink must declare the union's schema. A materialized CTE declares its
+  // materialization side instead, so copying the arm's `types` misdeclares the sink's width --
+  // which `validate_operator_output_types` only warns about, so no end-to-end test can see it.
+  auto require_sinks_match_union = [&](const std::string& query) {
+    auto plan = generate_sirius_plan(*con, query);
+    INFO(tree_to_string(plan.get()));
+
+    auto* union_op = find_first(plan.get(), SiriusPhysicalOperatorType::UNION);
+    REQUIRE(union_op != nullptr);
+    REQUIRE(union_op->children.size() == 2);
+
+    // The premise, pinned: the arm is really a CTE node and its width really differs from the
+    // union's, or the sink would be right by accident. DuckDB's unused-column optimizer prunes the
+    // materialization down to what the body reads and can collapse these queries silently. If this
+    // fires, reshape so the definition is unprunable or the body widens; do not relax it.
+    auto* cte = find_first(plan.get(), SiriusPhysicalOperatorType::CTE);
+    REQUIRE(cte != nullptr);
+    INFO("cte width=" << cte->types.size() << " union width=" << union_op->types.size());
+    REQUIRE(cte->types.size() != union_op->types.size());
+
+    for (auto& child : union_op->children) {
+      REQUIRE(child->type == SiriusPhysicalOperatorType::PASSTHROUGH_SINK);
+      CHECK(child->types == union_op->types);
+    }
+  };
+
+  // Definition wider than the arity: the self-join on `other` keeps it from being pruned to `rid`.
+  require_sinks_match_union(
+    "SELECT id FROM big_left UNION ALL "
+    "(WITH m AS MATERIALIZED (SELECT rid, other FROM small_right) "
+    " SELECT m1.rid FROM m m1 JOIN m m2 ON m1.other = m2.other)");
+
+  // Definition narrower: the body widens with a computed column the materialization never held.
+  require_sinks_match_union(
+    "SELECT id, id * 2 FROM big_left UNION ALL "
+    "(WITH m AS MATERIALIZED (SELECT rid FROM small_right) SELECT rid, rid * 2 FROM m)");
+
+  // The CTE as arm 0, so `op.types` is routed through the CTE's own body resolution.
+  require_sinks_match_union(
+    "(WITH m AS MATERIALIZED (SELECT rid FROM small_right) SELECT rid, rid * 2 FROM m) "
+    "UNION ALL SELECT id, id * 2 FROM big_left");
+}


### PR DESCRIPTION
## Description

Lowers DuckDB's `LOGICAL_UNION` (`setop_all == true`) onto a new N-ary physical UNION operator, so a query containing `UNION ALL` no longer forfeits the whole plan to the CPU. Distinct `UNION`, `EXCEPT` and `INTERSECT` continue to fall back, guarded.

Bag union computes nothing, so the operator only routes batches. UNION's `execute` is the identity. Each arm is terminated by a new `PASSTHROUGH_SINK` rather than the join's

distinct UNION is out of scope but becomes available once LOGICAL_DISTINCT is lowered. `src/planner/sirius_get_operator::create_plan` currently gates on `!op.setop_all`.

Four wiring decisions worth review:

- **A distinct `union_{i}` port per arm.** `add_port` is last-writer-wins and the repository manager keys by `(operator_id, port_id)`, so a shared name would orphan an arm's repository and let the pipeline finish with rows still pending.
- **`PASSTHROUGH_SINK -> UNION` is `PARTIAL`.** `FULL` waits for every batch from every arm before UNION emits anything. Here `PARTIAL` waits for *one batch from each live arm*.
- **`UNION`** overrides both task-driver methods and the ranking inside the hint matters. A starved arm is one whose port is empty but whose source pipeline has not finished, so rows are still coming. `sirius_physical_union::get_next_task_hint()` names a starved arm first, returning `task_creation_hint(TaskCreationHint::WAITING_FOR_INPUT_DATA, starved_producer)` and falls through to READY only when nothing is starved and at least one port holds a batch. A finished arm is not starved so it is excused rather than blocking forever. Ranking `READY` first would strand a starved arm outright, since `task_creator::get_operator_for_next_task` reaches an operator only by walking `hint.producer`. A `READY` hint puts `task_creator` in a `while (!node->all_ports_empty())` loop over `get_next_task_input_data`, which pops one batch from one arm per call and rotates across arms. One batch per task, rather than the base's one-from-every-port bundle, keeps each batch on the GPU that produced it, since a task runs on one device. The hint is re-evaluated per request and every completed arm task schedules one, so these rounds are short and interleave with the arms still producing rather than running as two phases. The query ends when every arm's pipeline has finished and its port is drained.
- **`source_order()` is `NO_ORDER`.** `order_preservation_recursive` stops at the first `is_source()` operator, so UNION's answer decides the plan's, and `INSERTION_ORDER` would claim an ordering a bag union does not provide.

**Tests**. Eleven integration cases compare GPU against CPU, asserting one GPU execution and zero fallbacks, plus a plan-time fallback check for the three declined set operations. `test_physical_union_mgpu.cpp` adds four more, driven by `scan_task_batch_size` rather than hash_partition_bytes, UNION is deliberately not partition-based so the usual lever does nothing. Two run at num_gpus = 1 and are the regression test for the starvation hang; two need two GPUs. All green on a single T4. [gpu_execution] is 781/797, and the 16 failures are identical by name to a clean dev build, this branch adds none.

**Caveats**. Data locality, as in the UNION task being executed on the GPU which produced it, has not been tested and there is no mechanism to enforce it. The current implementation of UNION only assumes locality because there is no producer stamp and no partition_idx so device placement falls to the third rung, being locality.

## Checklist
- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and su above - n/a no configuration changes.
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
Refs #1599