### PR TITLE
fix(io): adapt datasource overrides to cudf 26.10 cuda::stream_ref

### DIFF
--- a/src/include/io/sirius_datasource.hpp
+++ b/src/include/io/sirius_datasource.hpp
@@ -21,10 +21,23 @@
 
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/text/byte_range_info.hpp>
+#include <cudf/version_config.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cuda/stream_ref>
 
 #include <span>
 
 namespace sirius::io {
+
+// cudf >= 26.10 (rapidsai/cudf#23669) takes cuda::stream_ref in the
+// device_read virtuals; overrides must match the base signature exactly.
+#if CUDF_VERSION_MAJOR > 26 || (CUDF_VERSION_MAJOR == 26 && CUDF_VERSION_MINOR >= 10)
+using cudf_datasource_stream_t = cuda::stream_ref;
+#else
+using cudf_datasource_stream_t = rmm::cuda_stream_view;
+#endif
 
 // ---------------------------------------------------------------------------
 // sirius_datasource
@@ -89,16 +102,16 @@ class sirius_datasource : public cudf::io::datasource {
 
   std::unique_ptr<datasource::buffer> device_read(size_t offset,
                                                   size_t size,
-                                                  rmm::cuda_stream_view stream) override;
+                                                  cudf_datasource_stream_t stream) override;
   size_t device_read(size_t offset,
                      size_t size,
                      uint8_t* dst,
-                     rmm::cuda_stream_view stream) override;
+                     cudf_datasource_stream_t stream) override;
 
   std::future<size_t> device_read_async(size_t offset,
                                         size_t size,
                                         uint8_t* dst,
-                                        rmm::cuda_stream_view stream) override;
+                                        cudf_datasource_stream_t stream) override;
 
   // ---- Advisory IO ---------------------------------------------------------
 

--- a/src/io/sirius_datasource.cpp
+++ b/src/io/sirius_datasource.cpp
@@ -143,8 +143,9 @@ std::future<std::unique_ptr<cudf::io::datasource::buffer>> sirius_datasource::ho
 }
 
 std::unique_ptr<cudf::io::datasource::buffer> sirius_datasource::device_read(
-  size_t offset, size_t size, rmm::cuda_stream_view stream)
+  size_t offset, size_t size, cudf_datasource_stream_t stream_arg)
 {
+  rmm::cuda_stream_view stream{stream_arg};
   rmm::device_buffer buf(size, stream);
   auto n = device_read(offset, size, reinterpret_cast<uint8_t*>(buf.data()), stream);
   n      = std::min(n, size);
@@ -155,8 +156,9 @@ std::unique_ptr<cudf::io::datasource::buffer> sirius_datasource::device_read(
 size_t sirius_datasource::device_read(size_t offset,
                                       size_t size,
                                       uint8_t* dst,
-                                      rmm::cuda_stream_view stream)
+                                      cudf_datasource_stream_t stream_arg)
 {
+  rmm::cuda_stream_view stream{stream_arg};
   auto f = device_read_async(offset, size, dst, stream);
   auto n = f.get();
   stream.synchronize();
@@ -166,8 +168,9 @@ size_t sirius_datasource::device_read(size_t offset,
 std::future<size_t> sirius_datasource::device_read_async(size_t offset,
                                                          size_t size,
                                                          uint8_t* dst,
-                                                         rmm::cuda_stream_view stream)
+                                                         cudf_datasource_stream_t stream_arg)
 {
+  rmm::cuda_stream_view stream{stream_arg};
   exec::semi_future<size_t> semi;
   if (uses_prefetching_cache()) {
     auto* cache = _io_ctx->cache();


### PR DESCRIPTION
## Problem

The nightly CI leg (`build (arm64, gcc, release, default, nightly)`) has been failing on every dev push since 2026-08-17 23:12 UTC ([first failing run](https://github.com/sirius-db/sirius/actions/runs/32079354340/job/95539114504)) with:

```
sirius_datasource.hpp:90:39: error: '... device_read(size_t, size_t, rmm::cuda_stream_view)' marked 'override', but does not override
```

**Root cause:** [rapidsai/cudf#23669](https://github.com/rapidsai/cudf/pull/23669) (merged 2026-08-17 20:24 UTC) changed the stream parameter of `cudf::io::datasource`'s `device_read` / `device_read_async` virtuals from `rmm::cuda_stream_view` to `cuda::stream_ref`. The nightly leg re-solves `rapidsai-nightly` with `libcudf = "*"` every run, so the first run after the new nightly package published broke — independent of the commit it ran on (the same error reproduces on subsequent docs-only and dep-bump commits). It goes unnoticed because the leg is `continue-on-error`.

`sirius::io::sirius_datasource` is the only class in the build deriving from a cudf virtual base, and only the three `device_read*` overrides take a stream, so this is the entire blast radius.

## Fix

- `sirius_datasource.hpp` defines `cudf_datasource_stream_t`, version-gated on `CUDF_VERSION_MAJOR`/`MINOR` (same idiom as the existing gate in `sirius_physical_hash_join.cpp`): `cuda::stream_ref` on cudf ≥ 26.10, `rmm::cuda_stream_view` before. It lives next to the overrides since this class is the alias's only consumer.
- The three overrides use the alias and convert to `rmm::cuda_stream_view` at entry (implicit in both directions per rmm's converting ctor/operator), so the bodies and the whole internal io stack stay rmm-typed. On stable the conversion is a trivial copy.
- Non-virtual call sites that pass streams to cudf APIs need no changes — implicit conversion covers them.

Note: cuCascade's `datasource.cpp` has the identical overrides but is not compiled here (`CUCASCADE_BUILD_IO OFF`); it needs the same fix upstream for IO-enabled builds.

## Verification

- Syntax-checked `sirius_datasource.cpp` with the exact CI compile flags against **stable cudf 26.06** headers: passes.
- Same check against the **nightly signatures** (real `datasource.hpp` from cudf main + `version_config.hpp` reporting 26.10 overlaid over the include path): passes.
- Negative control: the unpatched code under the same nightly overlay reproduces exactly the 3 CI `marked 'override'` errors.
- `pre-commit` hooks pass on the changed files.

The nightly CI leg on this PR is the authoritative end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)