### PR TITLE
fix(io): qualify CUDA stream_ref in datasource alias

### DIFF
--- a/src/include/io/sirius_datasource.hpp
+++ b/src/include/io/sirius_datasource.hpp
@@ -34,7 +34,7 @@ namespace sirius::io {
 // cudf >= 26.10 (rapidsai/cudf#23669) takes cuda::stream_ref in the
 // device_read virtuals; overrides must match the base signature exactly.
 #if CUDF_VERSION_MAJOR > 26 || (CUDF_VERSION_MAJOR == 26 && CUDF_VERSION_MINOR >= 10)
-using cudf_datasource_stream_t = cuda::stream_ref;
+using cudf_datasource_stream_t = ::cuda::stream_ref;
 #else
 using cudf_datasource_stream_t = rmm::cuda_stream_view;
 #endif


### PR DESCRIPTION
## Description
Qualify cuda::stream_ref with the global namespace to prevent it resolving as sirius::cuda::stream_ref when Sirius CUDA headers are included first. This fixes the cuDF 26.10 nightly ARM64 build failure.
