### PR TITLE
fix(join): screen unexecutable join types and fix null-safe MARK semantics

### DIFF
--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -298,13 +298,18 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
                                    pipeline::sirius_meta_pipeline& meta_pipeline,
                                    sirius_physical_operator& op);
 
+  //! Whether the execute dispatch has an arm for @p join_type. SINGLE does not;
+  //! are_conditions_supported() folds this in so the planner never builds one.
+  static bool is_join_type_supported(duckdb::JoinType join_type);
+
   /**
-   * @brief Returns true if the given join conditions can be handled by this operator.
+   * @brief Returns true if the given join type and conditions can be handled by this operator.
    *
-   * Requires at least one equality condition. For mixed joins (equality + inequality), also
-   * requires that no column referenced by an equality condition appears in any inequality
-   * condition on the same side — cuDF's mixed_join API requires disjoint equality and
-   * conditional table columns.
+   * Requires an executable join type (is_join_type_supported) and at least one equality
+   * condition. For mixed joins (equality + inequality), also requires that no column referenced
+   * by an equality condition appears in any inequality condition on the same side — cuDF's
+   * mixed_join API requires disjoint equality and conditional table columns. A MARK join mixing
+   * null-safe and plain keys is rejected; see mark_join_mixes_null_safe_keys.
    *
    * @param join_type Used to exclude MARK joins from null-safe routing.
    */
@@ -434,12 +439,17 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   /// construction (conditions and join_type are fixed thereafter). cuDF applies one
   /// flag to all key columns, so it is EQUAL (null-safe -- NULL matches NULL) only
   /// when EVERY equi-key is IS NOT DISTINCT FROM; a plain `=` key (including mixed
-  /// joins such as delim joins) forces UNEQUAL. MARK joins are also forced to
-  /// UNEQUAL to match their IN/EXISTS three-valued result logic -- a null-safe MARK
-  /// join (e.g. EXISTS with IS NOT DISTINCT FROM) is a known unsupported case, see
-  /// the constructor.
+  /// joins such as delim joins) forces UNEQUAL. A MARK join follows the same rule:
+  /// all-null-safe keys use EQUAL and emit definite marks (see mark_is_null_safe),
+  /// anything containing a plain key uses UNEQUAL and the IN/EXISTS three-valued
+  /// result logic. A MARK join *mixing* the two is rejected at plan time.
   cudf::null_equality compare_nulls() const { return compare_nulls_; }
   cudf::null_equality compare_nulls_ = cudf::null_equality::UNEQUAL;
+
+  /// A MARK join whose every condition is IS NOT DISTINCT FROM: the predicate is never UNKNOWN,
+  /// so every mark is definite and the result carries no null mask.
+  [[nodiscard]] bool mark_is_null_safe() const { return mark_is_null_safe_; }
+  bool mark_is_null_safe_ = false;
 
  public:
   //! Per-key cast info: whether each join key needs a cast before comparison

--- a/src/include/op/sirius_physical_nested_loop_join.hpp
+++ b/src/include/op/sirius_physical_nested_loop_join.hpp
@@ -123,6 +123,11 @@ class sirius_physical_nested_loop_join : public sirius_physical_partition_consum
   static bool is_supported(const duckdb::vector<sirius::join_condition>& conditions,
                            duckdb::JoinType join_type);
 
+  //! Whether `execute` has an arm for @p join_type. DuckDB's PhysicalNestedLoopJoin::IsSupported
+  //! is broader -- RIGHT_SEMI / RIGHT_ANTI / SINGLE pass it -- so the planner screens on this
+  //! too, turning a mid-query throw into a plan-time rejection that falls back to CPU.
+  static bool is_join_type_supported(duckdb::JoinType join_type);
+
  public:
   //! Returns a list of the types of the join conditions
   duckdb::vector<sirius::logical_type> get_join_types() const;

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -33,6 +33,7 @@
 #include "cudf/utilities/memory_resource.hpp"
 #include "cudf/version_config.hpp"
 #include "data/data_batch_utils.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
@@ -101,6 +102,28 @@ static bool wants_null_safe_routing(duckdb::vector<sirius::join_condition> const
     }
   }
   return has_plain_equal && has_null_safe;
+}
+
+// Every condition is null-safe (IS NOT DISTINCT FROM). For a MARK join this is the encodable
+// case: null_equality::EQUAL covers every key, and a null-safe comparison is never UNKNOWN, so
+// every mark is definite.
+static bool all_keys_null_safe(duckdb::vector<sirius::join_condition> const& conditions)
+{
+  return !conditions.empty() &&
+         std::all_of(conditions.begin(), conditions.end(), [](auto const& c) {
+           return c.comparison == sirius::comparison_type::not_distinct_from;
+         });
+}
+
+// A MARK join mixing null-safe keys with anything else (a plain `=`, or an inequality). cuDF takes
+// one null_equality for every key and MARK does not route null-safe keys into the mixed-join
+// predicate, so the null-safe key would silently inherit UNEQUAL. Callers must reject this shape.
+static bool mark_join_mixes_null_safe_keys(duckdb::vector<sirius::join_condition> const& conditions)
+{
+  bool const has_null_safe = std::any_of(conditions.begin(), conditions.end(), [](auto const& c) {
+    return c.comparison == sirius::comparison_type::not_distinct_from;
+  });
+  return has_null_safe && !all_keys_null_safe(conditions);
 }
 
 // Whether a condition belongs in the hash key: a plain `=`, or a null-safe key when it
@@ -176,9 +199,35 @@ static cudf::mark_join make_left_mark_join(cudf::table_view const& left_keys,
   return cudf::mark_join(left_keys, compare_nulls, cudf::join_prefilter::NO, stream);
 }
 
+bool sirius_physical_hash_join::is_join_type_supported(duckdb::JoinType join_type)
+{
+  // Keep in lockstep with the join-type dispatch in execute() and its BUILD_PROBE counterpart.
+  switch (join_type) {
+    case duckdb::JoinType::INNER:
+    case duckdb::JoinType::LEFT:
+    case duckdb::JoinType::RIGHT:
+    case duckdb::JoinType::SEMI:
+    case duckdb::JoinType::ANTI:
+    case duckdb::JoinType::RIGHT_SEMI:
+    case duckdb::JoinType::RIGHT_ANTI:
+    case duckdb::JoinType::MARK:
+    case duckdb::JoinType::OUTER: return true;
+    // SINGLE (at most one build row per probe row, NULL-padded otherwise) has no arm in any
+    // dispatch.
+    default: return false;
+  }
+}
+
 bool sirius_physical_hash_join::are_conditions_supported(
   duckdb::vector<sirius::join_condition>& conditions, duckdb::JoinType join_type)
 {
+  if (!is_join_type_supported(join_type)) { return false; }
+
+  // All-null-safe MARK is fine (EQUAL keys, definite marks); only the mixture is unencodable.
+  if (join_type == duckdb::JoinType::MARK && mark_join_mixes_null_safe_keys(conditions)) {
+    return false;
+  }
+
   // Keep support validation and constructor key classification identical.
   bool const route_null_safe = wants_null_safe_routing(conditions, join_type);
 
@@ -298,6 +347,13 @@ sirius_physical_hash_join::sirius_physical_hash_join(
     delim_types(std::move(delim_types)),
     _dynamic_filter_plan(std::move(dynamic_filter_plan))
 {
+  // Backstop for the planner's screen: throwing here still lands in plan generation, which falls
+  // back to CPU, rather than aborting the query from execute().
+  if (!is_join_type_supported(join_type)) {
+    throw duckdb::NotImplementedException("sirius_physical_hash_join: unsupported join type: " +
+                                          duckdb::JoinTypeToString(join_type));
+  }
+
   _max_build_hash_table_bytes = max_build_hash_table_bytes;
   _hash_partition_bytes       = hash_partition_bytes;
   _max_broadcast_join_size    = max_broadcast_join_size;
@@ -315,11 +371,23 @@ sirius_physical_hash_join::sirius_physical_hash_join(
   }
   reorder_join_conditions(conditions, route_null_safe);
 
+  // Backstop for the planner's screen; reaching here would silently give the null-safe key
+  // NULL != NULL semantics.
+  if (join_type == duckdb::JoinType::MARK && mark_join_mixes_null_safe_keys(conditions)) {
+    throw duckdb::NotImplementedException(
+      "sirius_physical_hash_join: MARK join mixing a null-safe (IS NOT DISTINCT FROM) key with a "
+      "plain key is not supported");
+  }
+
   // Pure null-safe hash keys use EQUAL; any plain hash key requires UNEQUAL. Routed
-  // null-safe keys get their semantics from NULL_EQUAL instead. MARK remains UNEQUAL
-  // for three-valued IN/EXISTS semantics and does not yet support null-safe keys.
+  // null-safe keys get their semantics from NULL_EQUAL instead.
   compare_nulls_ = cudf::null_equality::UNEQUAL;
-  if (join_type != duckdb::JoinType::MARK) {
+  if (join_type == duckdb::JoinType::MARK) {
+    // All-null-safe MARK takes EQUAL and emits definite marks; any other MARK keeps UNEQUAL and
+    // the three-valued IN/EXISTS reconstruction, which assumes a NULL key never matches.
+    mark_is_null_safe_ = all_keys_null_safe(conditions);
+    if (mark_is_null_safe_) { compare_nulls_ = cudf::null_equality::EQUAL; }
+  } else {
     bool saw_null_safe   = false;
     bool saw_plain_equal = false;
     for (auto const& cond : conditions) {
@@ -1503,11 +1571,11 @@ static void set_build_has_null(std::atomic<int>& atomic_flag, bool has_null)
 /// when the build/right side contains a NULL join key.
 ///
 /// The scattered values are already correct (true at matched rows, false elsewhere), so only a null
-/// mask is added. This is the IN/EXISTS three-valued rule and assumes UNEQUAL matching
-/// (compare_nulls() forces UNEQUAL for MARK joins; a null-safe MARK join such as EXISTS
-/// with IS NOT DISTINCT FROM is a known unsupported case). Because a NULL key never
-/// matches under UNEQUAL, a matched row always has a valid probe key, so the desired
-/// validity reduces to two cases:
+/// mask is added. When @p marks_are_definite (an all-null-safe MARK, matched under EQUAL) no mask
+/// is added at all: a null-safe comparison is never UNKNOWN, so an unmatched row is a definite
+/// FALSE. Otherwise this is the IN/EXISTS three-valued rule under UNEQUAL matching. Because a
+/// NULL key never matches under UNEQUAL, a matched row always has a valid probe key, so the
+/// desired validity reduces to two cases:
 ///   - build_has_null == true : every unmatched row is NULL, so valid == matched. The mask is the
 ///                              mark values themselves (cudf::bools_to_mask).
 ///   - build_has_null == false: valid == probe row validity (all probe key columns valid). The mask
@@ -1523,6 +1591,9 @@ static void set_build_has_null(std::atomic<int>& atomic_flag, bool has_null)
 /// @param probe_keys    Probe/left join key columns (post-cast); their per-row validity drives the
 ///                      NULL mark when the build side has no NULL key.
 /// @param build_has_null  Whether the build/right side contains a NULL in any join key column.
+///                        Ignored when @p marks_are_definite.
+/// @param marks_are_definite  Every key is null-safe, so the output column gets no null mask
+///                            (sirius_physical_hash_join::mark_is_null_safe()).
 /// @param left_batch    The original left-side data batch; used to propagate memory space metadata
 ///                      to the returned operator_data.
 /// @param stream        CUDA stream on which all device operations are launched.
@@ -1532,6 +1603,7 @@ static std::unique_ptr<operator_data> resolve_mark_join_result(
   std::vector<cudf::size_type> const& lhs_output_col_idxs,
   cudf::table_view const& probe_keys,
   bool build_has_null,
+  bool marks_are_definite,
   ::cucascade::read_only_data_batch const& left_batch,
   rmm::cuda_stream_view stream,
   const telemetry::batch_telemetry_info& telemetry_info = {})
@@ -1567,6 +1639,16 @@ static std::unique_ptr<operator_data> resolve_mark_join_result(
                                    cudf::table_view({mark_column->view()}),
                                    stream);
     mark_column    = std::move(scattered->release()[0]);
+  }
+
+  // Under EQUAL matching every comparison is definite, so the scattered values are the whole
+  // answer -- no null mask, no three-valued logic.
+  if (marks_are_definite) {
+    mark_out_cols.push_back(std::move(mark_column));
+    auto definite_table = std::make_unique<cudf::table>(std::move(mark_out_cols));
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<::cucascade::data_batch>>{make_data_batch(
+        std::move(definite_table), *left_batch.get_memory_space(), stream, telemetry_info)});
   }
 
   // Apply SQL three-valued logic by attaching a null mask: unmatched rows become NULL when the
@@ -1714,6 +1796,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                         lhs_output_columns.col_idxs,
                                         probe_keys,
                                         _build_has_null.load(std::memory_order_acquire) > 0,
+                                        mark_is_null_safe(),
                                         input_batches[0],
                                         stream,
                                         batch_telemetry());
@@ -1822,6 +1905,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                       lhs_output_columns.col_idxs,
                                       left_eq,
                                       _build_has_null.load(std::memory_order_acquire) > 0,
+                                      mark_is_null_safe(),
                                       input_batches[0],
                                       stream,
                                       batch_telemetry());
@@ -1986,6 +2070,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                         lhs_output_columns.col_idxs,
                                         left_keys,
                                         _build_has_null.load(std::memory_order_acquire) > 0,
+                                        mark_is_null_safe(),
                                         input_batches[0],
                                         stream,
                                         batch_telemetry());
@@ -1998,6 +2083,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                       lhs_output_columns.col_idxs,
                                       left_keys,
                                       _build_has_null.load(std::memory_order_acquire) > 0,
+                                      mark_is_null_safe(),
                                       input_batches[0],
                                       stream,
                                       batch_telemetry());

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -19,6 +19,7 @@
 #include "config.hpp"
 #include "cudf/cudf_utils.hpp"
 #include "data/data_batch_utils.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
@@ -99,6 +100,34 @@ void reorder_conditions(duckdb::vector<sirius::join_condition>& conditions)
   }
 }
 
+bool sirius_physical_nested_loop_join::is_join_type_supported(duckdb::JoinType join_type)
+{
+  // Keep in lockstep with the `switch (join_type)` in execute() and emit_one_side_empty_result().
+  switch (join_type) {
+    case duckdb::JoinType::INNER:
+    case duckdb::JoinType::LEFT:
+    case duckdb::JoinType::RIGHT:
+    case duckdb::JoinType::SEMI:
+    case duckdb::JoinType::ANTI:
+    case duckdb::JoinType::MARK:
+    case duckdb::JoinType::OUTER: return true;
+    // RIGHT_SEMI / RIGHT_ANTI would need the predicate rebuilt with the table references
+    // swapped, SINGLE the matches deduplicated to one right row per left row; neither exists.
+    default: return false;
+  }
+}
+
+// Backstop for a construction site that skipped the planner's screen: throwing here still lands
+// in plan generation, which falls back to CPU, rather than aborting the query from execute().
+static void require_supported_join_type(duckdb::JoinType join_type)
+{
+  if (!sirius_physical_nested_loop_join::is_join_type_supported(join_type)) {
+    throw duckdb::NotImplementedException(
+      "sirius_physical_nested_loop_join: unsupported join type: " +
+      duckdb::JoinTypeToString(join_type));
+  }
+}
+
 sirius_physical_nested_loop_join::sirius_physical_nested_loop_join(
   duckdb::LogicalOperator& op,
   duckdb::unique_ptr<sirius_physical_operator> left,
@@ -112,6 +141,7 @@ sirius_physical_nested_loop_join::sirius_physical_nested_loop_join(
     conditions(std::move(cond)),
     join_type(join_type)
 {
+  require_supported_join_type(join_type);
   reorder_conditions(conditions);
 
   children.push_back(std::move(left));
@@ -143,6 +173,7 @@ sirius_physical_nested_loop_join::sirius_physical_nested_loop_join(
     conditions(std::move(cond)),
     join_type(join_type)
 {
+  require_supported_join_type(join_type);
   reorder_conditions(conditions);
   children.push_back(std::move(left));
   children.push_back(std::move(right));
@@ -171,6 +202,7 @@ sirius_physical_nested_loop_join::sirius_physical_nested_loop_join(
 bool sirius_physical_nested_loop_join::is_supported(
   const duckdb::vector<sirius::join_condition>& conditions, duckdb::JoinType join_type)
 {
+  if (!is_join_type_supported(join_type)) { return false; }
   if (join_type == duckdb::JoinType::MARK) { return true; }
   for (auto& cond : conditions) {
     auto left_expr = sirius::ast::to_duckdb(*cond.left);
@@ -822,6 +854,7 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
         join_result =
           cudf::conditional_full_join(left_effective, right_effective, predicate, stream, mr);
         break;
+      // Unreachable: is_join_type_supported() screens these out at plan time and at construction.
       default:
         throw std::runtime_error("sirius_physical_nested_loop_join: unsupported join type: " +
                                  duckdb::JoinTypeToString(join_type));

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -407,6 +407,28 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
     reject_nested_column_operation(*condition.right, "a join condition");
   }
 
+  // A MARK join mixing null-safe (IS NOT DISTINCT FROM) and plain keys has no correct GPU
+  // encoding (see mark_join_mixes_null_safe_keys in sirius_physical_hash_join.cpp), and the NLJ
+  // is no escape hatch: its MARK arm models the mixture but evaluates each (left batch x right
+  // batch) pair independently, so a left side spread over several right batches emits one partial
+  // mark per pair. Reject here so both routes are closed and DuckDB's CPU mark join answers.
+  if (op.join_type == duckdb::JoinType::MARK) {
+    bool has_null_safe = false;
+    bool all_null_safe = !op.conditions.empty();
+    for (auto const& condition : op.conditions) {
+      if (condition.comparison == duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+        has_null_safe = true;
+      } else {
+        all_null_safe = false;
+      }
+    }
+    if (has_null_safe && !all_null_safe) {
+      throw duckdb::NotImplementedException(
+        "MARK join mixing a null-safe (IS NOT DISTINCT FROM) key with a plain key not supported "
+        "in GPU");
+    }
+  }
+
   std::size_t lhs_cardinality = op.children[0]->EstimateCardinality(context);
   std::size_t rhs_cardinality = op.children[1]->EstimateCardinality(context);
 
@@ -462,8 +484,15 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
 
   // Check DuckDB's NLJ IsSupported here because it needs the raw `op.conditions`; wrapping the
   // conditions below drains them.
-  const bool nlj_is_supported =
+  const bool nlj_conditions_supported =
     duckdb::PhysicalNestedLoopJoin::IsSupported(op.conditions, op.join_type);
+  // DuckDB's check accepts join types the Sirius NLJ execute switch has no arm for
+  // (RIGHT_SEMI / RIGHT_ANTI / SINGLE), which would throw mid-query instead of falling back.
+  // The hash join screens the same way via are_conditions_supported, so SINGLE -- which no GPU
+  // join implements -- is rejected on both routes.
+  const bool nlj_join_type_supported =
+    sirius::op::sirius_physical_nested_loop_join::is_join_type_supported(op.join_type);
+  const bool nlj_is_supported = nlj_conditions_supported && nlj_join_type_supported;
 
   // Wrap once — subsequent checks and ctors consume from the wrapped vector.
   duckdb::vector<sirius::join_condition> conditions =
@@ -764,6 +793,13 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
                                                                       op.left_projection_map,
                                                                       op.right_projection_map);
     return join;
+  }
+
+  // Neither GPU join implements this join type, so say so plainly: the generic "blockwise nested
+  // loop" message below would misattribute the rejection to the conditions.
+  if (!nlj_join_type_supported) {
+    throw duckdb::NotImplementedException("Join type " + duckdb::JoinTypeToString(op.join_type) +
+                                          " not supported in GPU");
   }
 
   throw duckdb::NotImplementedException("Blockwise nested loop join not supported in GPU");

--- a/test/cpp/integration/test_gpu_execution_null_safe_join.cpp
+++ b/test/cpp/integration/test_gpu_execution_null_safe_join.cpp
@@ -278,14 +278,56 @@ TEST_CASE_METHOD(MixedTypeNullSafeJoinFixture,
     "SELECT * FROM mtl LEFT JOIN mtr ON mtl.a = mtr.a AND mtl.b IS NOT DISTINCT FROM mtr.b");
 }
 
-// MARK cannot use MIXED_JOIN, so null-safe keys remain a known [!mayfail] limitation.
-// Replace with a hard comparison or fallback assertion once supported.
+// A correlated IN is the one MARK shape that genuinely mixes key policies: decorrelation makes
+// the correlated predicate null-safe while the IN operand stays a plain `=`, giving conditions
+// `(a IS NOT DISTINCT FROM a)` AND `(b = #0)`. That mixture is rejected at plan time.
 TEST_CASE_METHOD(MixedKeyNullSafeJoinFixture,
-                 "gpu_execution null-safe MARK join (projected EXISTS) is a known limitation",
-                 "[integration][gpu_execution][join][nulls][!mayfail]")
+                 "gpu_execution mixed plain + null-safe MARK join falls back at plan time",
+                 "[integration][gpu_execution][join][nulls]")
 {
+  expect_plan_fallback_matches_cpu(
+    "SELECT mnl.id, mnl.b IN (SELECT mnr.b FROM mnr WHERE mnr.a = mnl.a) AS in_b FROM mnl");
+}
+
+TEST_CASE_METHOD(MixedKeyNullSafeJoinFixture,
+                 "gpu_execution all-null-safe MARK join runs on GPU with definite marks",
+                 "[integration][gpu_execution][join][nulls]")
+{
+  // Every key null-safe => EQUAL matching and definite marks. mnl rows 2, 3 and 5 have a NULL
+  // `b` that must match mnr's NULL `b`.
+  compare_gpu_vs_cpu(
+    "SELECT mnl.id, EXISTS (SELECT 1 FROM mnr "
+    "WHERE mnr.b IS NOT DISTINCT FROM mnl.b) AS has_match "
+    "FROM mnl");
+  // Both correlated predicates decorrelate to null-safe delim keys, so this is all-null-safe
+  // too -- it is the query that was [!mayfail] before.
   compare_gpu_vs_cpu(
     "SELECT mnl.id, EXISTS (SELECT 1 FROM mnr "
     "WHERE mnr.a = mnl.a AND mnr.b IS NOT DISTINCT FROM mnl.b) AS has_match "
     "FROM mnl");
+}
+
+TEST_CASE_METHOD(MixedKeyNullSafeJoinFixture,
+                 "gpu_execution correlated projected EXISTS keeps definite marks on GPU",
+                 "[integration][gpu_execution][join][nulls]")
+{
+  // The common shape this path exists for: DuckDB decorrelates a projected correlated EXISTS
+  // into an all-null-safe MARK over a build side pre-filtered to `a IS NOT NULL`. The null-safe
+  // key is what makes an unmatched row a definite FALSE, so under the old UNEQUAL pin mnl row 6
+  // (a IS NULL, unmatched) came back NULL instead of false.
+  compare_gpu_vs_cpu(
+    "SELECT mnl.id, EXISTS (SELECT 1 FROM mnr WHERE mnr.a = mnl.a) AS has_match FROM mnl");
+  // NOT EXISTS negates the same mark; a stray NULL would surface here as a missing row.
+  compare_gpu_vs_cpu(
+    "SELECT mnl.id, NOT EXISTS (SELECT 1 FROM mnr WHERE mnr.a = mnl.a) AS no_match FROM mnl");
+}
+
+TEST_CASE_METHOD(MixedKeyNullSafeJoinFixture,
+                 "gpu_execution null-safe MARK rejection does not spill onto plain IN/EXISTS",
+                 "[integration][gpu_execution][join][nulls]")
+{
+  // Regression guard on the plan-time screen: an uncorrelated MARK, whose only key is a plain
+  // '=', keeps running on the GPU.
+  compare_gpu_vs_cpu("SELECT mnl.id, mnl.b IN (SELECT mnr.b FROM mnr) AS in_b FROM mnl");
+  compare_gpu_vs_cpu("SELECT mnl.id, mnl.a IN (SELECT mnr.a FROM mnr) AS in_a FROM mnl");
 }

--- a/test/cpp/integration/test_gpu_execution_semantic_cast_fallback.cpp
+++ b/test/cpp/integration/test_gpu_execution_semantic_cast_fallback.cpp
@@ -34,34 +34,6 @@ using SemanticCastFixture = sirius::test::GpuExecutionFixture;
 
 namespace {
 
-/// Run @p query with gpu_execution on and CPU fallback enabled: the query must succeed via a
-/// plan-time fallback (never a GPU execution) and produce exactly the CPU results.
-void expect_plan_fallback_matches_cpu(SemanticCastFixture& fx, std::string const& query)
-{
-  fx.run_ok("SET gpu_execution = true;");
-  auto const before = sirius::test::get_transparent_execution_stats(*fx.con);
-  auto result       = fx.con->Query(query);
-  auto const after  = sirius::test::get_transparent_execution_stats(*fx.con);
-  REQUIRE(result);
-  if (result->HasError()) { UNSCOPED_INFO("query error: " << result->GetError()); }
-  REQUIRE_FALSE(result->HasError());
-  // Plan-time CPU fallback, not a GPU run: the unsupported cast is rejected during plan
-  // generation, so the fallback counter moves and the execution counter does not.
-  REQUIRE(after.fallbacks == before.fallbacks + 1);
-  REQUIRE(after.executions == before.executions);
-
-  fx.run_ok("SET gpu_execution = false;");
-  auto cpu_result = fx.con->Query(query);
-  fx.run_ok("SET gpu_execution = true;");
-  REQUIRE(cpu_result);
-  REQUIRE_FALSE(cpu_result->HasError());
-
-  auto rows = SemanticCastFixture::collect_rows(result->Cast<duckdb::MaterializedQueryResult>());
-  auto cpu_rows =
-    SemanticCastFixture::collect_rows(cpu_result->Cast<duckdb::MaterializedQueryResult>());
-  REQUIRE(rows == cpu_rows);
-}
-
 /// Rejection wording of the projection translation site (sirius_plan_projection.cpp).
 constexpr char kProjectionRejection[] = "Unsupported expression in projection";
 /// Shared prefix of both filter rejection sites: LogicalFilter translation (sirius_plan_filter.cpp,
@@ -120,7 +92,7 @@ TEST_CASE_METHOD(SemanticCastFixture,
 {
   create_cast_table(*this);
   // DuckDB null-cast semantics: every row is NULL -- never the int16 epoch-day value 1.
-  expect_plan_fallback_matches_cpu(*this, "SELECT TRY_CAST(d AS SMALLINT) FROM cast_t;");
+  expect_plan_fallback_matches_cpu("SELECT TRY_CAST(d AS SMALLINT) FROM cast_t;");
 }
 
 TEST_CASE_METHOD(SemanticCastFixture,
@@ -129,7 +101,7 @@ TEST_CASE_METHOD(SemanticCastFixture,
 {
   create_cast_table(*this);
   // Every row NULL -- never DATE '1970-01-02' retagged from s = 1.
-  expect_plan_fallback_matches_cpu(*this, "SELECT TRY_CAST(s AS DATE) FROM cast_t;");
+  expect_plan_fallback_matches_cpu("SELECT TRY_CAST(s AS DATE) FROM cast_t;");
 }
 
 TEST_CASE_METHOD(SemanticCastFixture,
@@ -187,7 +159,7 @@ TEST_CASE_METHOD(SemanticCastFixture,
   // translation declines it from reject_untranslatable_table_filter (sirius_plan_get.cpp) rather
   // than the LogicalFilter site. On the CPU the null-cast makes the predicate true for every row.
   expect_plan_fallback_matches_cpu(
-    *this, "SELECT count(*) FROM cast_t WHERE TRY_CAST(d AS SMALLINT) IS NULL;");
+    "SELECT count(*) FROM cast_t WHERE TRY_CAST(d AS SMALLINT) IS NULL;");
 }
 
 TEST_CASE_METHOD(SemanticCastFixture,

--- a/test/cpp/operator/test_physical_mark_join.cpp
+++ b/test/cpp/operator/test_physical_mark_join.cpp
@@ -21,6 +21,7 @@
 #include <catch.hpp>
 #include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/memory/memory_space.hpp>
+#include <duckdb/common/exception.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
 #include <duckdb/planner/operator/logical_comparison_join.hpp>
 #include <op/sirius_physical_hash_join.hpp>
@@ -69,10 +70,12 @@ struct projected_nlj_result {
 };
 
 /**
- * @brief Create a mark join operator with two INT32 key columns (left col[0] = right col[0]).
+ * @brief Create a mark join operator with two INT32 key columns joined by @p comparison
+ * (left col[0] <comparison> right col[0]).
  * Left child has types {INTEGER, INTEGER} (key + payload), right child has {INTEGER} (key only).
  */
-mark_join_fixture create_mark_join()
+mark_join_fixture create_mark_join(
+  duckdb::ExpressionType comparison = duckdb::ExpressionType::COMPARE_EQUAL)
 {
   mark_join_fixture f;
 
@@ -94,7 +97,7 @@ mark_join_fixture create_mark_join()
   duckdb::JoinCondition cond;
   cond.left       = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
   cond.right      = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
-  cond.comparison = duckdb::ExpressionType::COMPARE_EQUAL;
+  cond.comparison = comparison;
   conditions.push_back(std::move(cond));
 
   f.hash_join = duckdb::make_uniq<sirius_physical_hash_join>(
@@ -885,6 +888,123 @@ TEST_CASE("sirius_physical_nested_loop_join MARK mixed null-safe + null-propagat
     REQUIRE(mark.null_count() == 1);
     REQUIRE(copy_validity_to_host(mark) == std::vector<bool>{false});
   }
+}
+
+// DuckDB's PhysicalNestedLoopJoin::IsSupported admits RIGHT_SEMI, RIGHT_ANTI and SINGLE, which
+// used to survive planning and then hit the execute switch's `default:` throw mid-query.
+TEST_CASE("sirius_physical_nested_loop_join rejects join types it cannot execute",
+          "[physical_nested_loop_join][join_type]")
+{
+  using JT = duckdb::JoinType;
+
+  for (auto join_type : {JT::INNER, JT::LEFT, JT::RIGHT, JT::SEMI, JT::ANTI, JT::MARK, JT::OUTER}) {
+    INFO("join type " << duckdb::JoinTypeToString(join_type));
+    REQUIRE(sirius_physical_nested_loop_join::is_join_type_supported(join_type));
+  }
+
+  for (auto join_type : {JT::RIGHT_SEMI, JT::RIGHT_ANTI, JT::SINGLE}) {
+    INFO("join type " << duckdb::JoinTypeToString(join_type));
+    REQUIRE_FALSE(sirius_physical_nested_loop_join::is_join_type_supported(join_type));
+    // The DuckDB-mirroring condition check must agree, so neither entry point can admit them.
+    REQUIRE_FALSE(sirius_physical_nested_loop_join::is_supported(
+      duckdb::vector<sirius::join_condition>{}, join_type));
+    // Backstop: constructing one anyway throws inside plan generation (which falls back to CPU)
+    // rather than aborting the query from execute().
+    REQUIRE_THROWS_AS(create_projected_nlj(join_type, duckdb::ExpressionType::COMPARE_EQUAL),
+                      duckdb::NotImplementedException);
+  }
+}
+
+// SINGLE reaches neither GPU join: both dispatches fall through to a mid-query throw.
+// are_conditions_supported now folds in the join-type screen so the planner rejects it.
+TEST_CASE("sirius_physical_hash_join rejects join types it cannot execute",
+          "[physical_hash_join][join_type]")
+{
+  using JT = duckdb::JoinType;
+
+  for (auto join_type : {JT::INNER,
+                         JT::LEFT,
+                         JT::RIGHT,
+                         JT::SEMI,
+                         JT::ANTI,
+                         JT::RIGHT_SEMI,
+                         JT::RIGHT_ANTI,
+                         JT::MARK,
+                         JT::OUTER}) {
+    INFO("join type " << duckdb::JoinTypeToString(join_type));
+    REQUIRE(sirius_physical_hash_join::is_join_type_supported(join_type));
+  }
+  REQUIRE_FALSE(sirius_physical_hash_join::is_join_type_supported(JT::SINGLE));
+
+  // A plain equality condition the hash join would otherwise accept.
+  auto make_conditions = [](duckdb::ExpressionType comparison) {
+    duckdb::vector<duckdb::JoinCondition> conditions;
+    duckdb::JoinCondition cond;
+    cond.left       = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
+    cond.right      = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
+    cond.comparison = comparison;
+    conditions.push_back(std::move(cond));
+    return sirius::wrap_join_conditions(std::move(conditions));
+  };
+
+  auto equal_conditions = make_conditions(duckdb::ExpressionType::COMPARE_EQUAL);
+  REQUIRE(sirius_physical_hash_join::are_conditions_supported(equal_conditions, JT::INNER));
+  REQUIRE(sirius_physical_hash_join::are_conditions_supported(equal_conditions, JT::MARK));
+  // Rejected on the join type alone, not the conditions.
+  REQUIRE_FALSE(sirius_physical_hash_join::are_conditions_supported(equal_conditions, JT::SINGLE));
+
+  // An all-null-safe MARK is supported: one EQUAL covers every key and the marks are definite.
+  auto null_safe_conditions = make_conditions(duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM);
+  REQUIRE(sirius_physical_hash_join::are_conditions_supported(null_safe_conditions, JT::INNER));
+  REQUIRE(sirius_physical_hash_join::are_conditions_supported(null_safe_conditions, JT::MARK));
+
+  // Mixing the two is not, since one null_equality cannot express both policies.
+  duckdb::vector<duckdb::JoinCondition> mixed;
+  for (auto comparison :
+       {duckdb::ExpressionType::COMPARE_EQUAL, duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM}) {
+    duckdb::JoinCondition cond;
+    auto const idx = static_cast<duckdb::idx_t>(mixed.size());
+    cond.left      = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, idx);
+    cond.right     = duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType::INTEGER, idx);
+    cond.comparison = comparison;
+    mixed.push_back(std::move(cond));
+  }
+  auto mixed_conditions = sirius::wrap_join_conditions(std::move(mixed));
+  REQUIRE(sirius_physical_hash_join::are_conditions_supported(mixed_conditions, JT::INNER));
+  REQUIRE_FALSE(sirius_physical_hash_join::are_conditions_supported(mixed_conditions, JT::MARK));
+}
+
+// An all-null-safe MARK runs under EQUAL: NULL matches NULL and no comparison is UNKNOWN, so the
+// mark column carries no nulls. Under the previous UNEQUAL pin a NULL probe key produced NULL.
+TEST_CASE("sirius_physical_hash_join MARK with all null-safe keys emits definite marks",
+          "[physical_hash_join][mark][nulls]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+
+  // compare_nulls()/mark_is_null_safe() are internal, so assert the semantics instead: NULL
+  // matching NULL proves EQUAL, a null-free mark column proves definiteness.
+  auto f = create_mark_join(duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM);
+
+  // Left keys {NULL, 5, 7} with payload; right (build) keys {NULL, 5}.
+  auto left_key = make_numeric_batch_with_nulls<int32_t>(
+    *space, {0, 5, 7}, {false, true, true}, cudf::type_id::INT32);
+  auto left_payload = make_numeric_batch<int32_t>(*space, {10, 20, 30}, cudf::type_id::INT32);
+  auto left         = concatenate_batches_horizontal({left_key, left_payload}, *space);
+  auto right =
+    make_numeric_batch_with_nulls<int32_t>(*space, {0, 5}, {false, true}, cudf::type_id::INT32);
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> inputs{left, right};
+  auto outputs =
+    f.hash_join->execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+  auto const& output_data = dynamic_cast<const pipelineable_operator_data&>(*outputs);
+  REQUIRE(output_data.get_data_batches().size() == 1);
+  auto view = sirius::get_cudf_table_view(*output_data.get_data_batches()[0]);
+
+  // NULL matches NULL, 5 matches 5, 7 matches nothing -- and the miss is FALSE, never NULL.
+  auto mark = view.column(view.num_columns() - 1);
+  REQUIRE(mark.null_count() == 0);
+  REQUIRE(copy_column_to_host<bool>(mark) == std::vector<bool>{true, true, false});
 }
 
 TEST_CASE("sirius_physical_nested_loop_join SEMI and ANTI honor the left projection map",

--- a/test/cpp/utils/gpu_execution_fixture.hpp
+++ b/test/cpp/utils/gpu_execution_fixture.hpp
@@ -236,6 +236,38 @@ class GpuExecutionFixture {
     REQUIRE(after.runtime_fallbacks > before.runtime_fallbacks);
   }
 
+  /// Asserts the query is rejected during GPU plan generation and completes via DuckDB's CPU
+  /// plan, returning exactly the CPU results. Distinct from expect_gpu_fallback, which asserts a
+  /// fallback *after* GPU execution started: a plan-time rejection moves `fallbacks` and never
+  /// increments `executions`. Use for shapes Sirius screens out at plan time on purpose.
+  void expect_plan_fallback_matches_cpu(const std::string& query)
+  {
+    run_ok("SET gpu_execution = true;");
+    auto const before = sirius::test::get_transparent_execution_stats(*con);
+    auto gpu_result   = con->Query(query);
+    auto const after  = sirius::test::get_transparent_execution_stats(*con);
+    REQUIRE(gpu_result);
+    if (gpu_result->HasError()) { UNSCOPED_INFO("query error: " << gpu_result->GetError()); }
+    REQUIRE_FALSE(gpu_result->HasError());
+    if (after.fallbacks == before.fallbacks) {
+      UNSCOPED_INFO("expected a plan-time fallback to CPU, but none occurred");
+    }
+    REQUIRE(after.fallbacks == before.fallbacks + 1);
+    REQUIRE(after.executions == before.executions);
+
+    run_ok("SET gpu_execution = false;");
+    auto cpu_result = con->Query(query);
+    run_ok("SET gpu_execution = true;");
+    REQUIRE(cpu_result);
+    REQUIRE_FALSE(cpu_result->HasError());
+
+    REQUIRE(gpu_result->ColumnCount() == cpu_result->ColumnCount());
+    REQUIRE(gpu_result->RowCount() == cpu_result->RowCount());
+    auto gpu_rows = collect_rows(gpu_result->Cast<duckdb::MaterializedQueryResult>(), true);
+    auto cpu_rows = collect_rows(cpu_result->Cast<duckdb::MaterializedQueryResult>(), true);
+    REQUIRE(gpu_rows == cpu_rows);
+  }
+
  private:
   void compare_gpu_vs_cpu_impl(const std::string& query,
                                bool ordered,


### PR DESCRIPTION
## Problem

Two ways a join could abort or lie at runtime instead of falling back to CPU.

**1. Join types that pass planning but have no execute arm.** `RIGHT_SEMI`, `RIGHT_ANTI`
and `SINGLE` pass DuckDB's `PhysicalNestedLoopJoin::IsSupported` and survive plan
generation, but the NLJ execute switch has no arm for them — the query died mid-flight
on a `std::runtime_error` at `sirius_physical_nested_loop_join.cpp:856` instead of
falling back. No test covered either.

`SINGLE` is worse than it looks. With equality conditions it never reaches the NLJ at
all: it routes to the hash join, whose dispatch has no `SINGLE` arm either
(`sirius_physical_hash_join.cpp:2060`). `grep JoinType::SINGLE src/` finds zero
operator-side handling — no GPU join has ever implemented it.

**2. Silently wrong MARK joins.** A MARK join pinned `cudf::null_equality::UNEQUAL`
regardless of its keys, so an `IS NOT DISTINCT FROM` key was matched as a plain one.
This was the one place a join could quietly return wrong answers rather than failing
or falling back; the test for it was tagged `[!mayfail]`.

It is not an exotic shape. DuckDB decorrelates a *projected correlated `EXISTS`* into
exactly this — an all-null-safe MARK over a build side pre-filtered to `IS NOT NULL`:

    COMPARISON_JOIN  Join Type: MARK
    Conditions: (a IS NOT DISTINCT FROM a)
      ├── SEQ_SCAN l
      └── PROJECTION a ← FILTER (a IS NOT NULL) ← SEQ_SCAN r

The NULL-filtered build is why the null-safe key matters: it makes an unmatched row a
*definite FALSE*, not UNKNOWN. Under `UNEQUAL`, `build_has_null` is false, validity
falls back to probe-key validity, and a NULL probe key comes back **NULL where DuckDB
returns `false`**.

## Fix

**Join-type screening.** Both operators expose `is_join_type_supported()`, listing
exactly the arms their dispatch implements. The planner screens on it (the hash join
folds it into `are_conditions_supported`), and each constructor keeps a
`NotImplementedException` backstop — a stray caller still fails inside plan generation,
where the query falls back, rather than dying mid-query.

**Null-safe MARK.** An all-null-safe MARK now uses `EQUAL` and emits definite marks,
skipping the null mask entirely since a null-safe comparison is never UNKNOWN. A MARK
*mixing* null-safe and plain keys has no encoding — cuDF takes one `null_equality` for
every key, and MARK does not route null-safe keys into the mixed-join predicate — so
that shape is rejected at plan time and falls back. A correlated `IN` is what produces
it: `(a IS NOT DISTINCT FROM a) AND (b = #0)`.

## Result

| Shape | Before | After |
|---|---|---|
| NLJ `RIGHT_SEMI` / `RIGHT_ANTI` | runtime throw, query dies | plan-time reject → CPU |
| `SINGLE` (either route) | runtime throw, query dies | plan-time reject → CPU |
| Projected correlated `EXISTS` | NULL where CPU says `false` | correct, on GPU |
| `EXISTS (a = a AND b IS NOT DISTINCT FROM b)` | wrong (`[!mayfail]`) | correct, on GPU |
| Correlated `IN` (mixed keys) | wrong marks | plan-time reject → CPU |
| Plain `IN` / `EXISTS` | correct, on GPU | unchanged |

## Testing

- Full suite: 32,772,613 assertions / 2,581 cases, 0 failures
- `[!mayfail]` removed — that query now runs on GPU and matches CPU
- New unit tests pin both operators' join-type screens and `are_conditions_supported`
  for all-null-safe (supported) vs mixed (rejected) MARK
- New unit test asserts definite marks directly: probe `{NULL, 5, 7}` vs build
  `{NULL, 5}` → `{true, true, false}`, `null_count == 0`
- New integration tests for each row of the table above

## Notes for reviewers

- Adds a shared `expect_plan_fallback_matches_cpu` fixture helper, replacing an
  identical local copy in the semantic-cast test (that file's diff is refactor only).
- The NLJ evaluates each (left batch × right batch) pair independently, so it is not a
  viable escape hatch for left-preserving MARK work at scale. Called out in a comment;
  not addressed here.
