### PR TITLE
test(join): cover a build-side downgrade under memory pressure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -678,6 +678,7 @@ set(TEST_SOURCES
     test/cpp/integration/test_gpu_execution_dynamic_filter_native.cpp
     test/cpp/integration/test_gpu_execution_filter_nulls.cpp
     test/cpp/integration/test_gpu_execution_join_nulls.cpp
+    test/cpp/integration/test_gpu_execution_join_memory_pressure.cpp
     test/cpp/integration/test_gpu_execution_locality.cpp
     test/cpp/integration/test_gpu_execution_multi_format.cpp
     test/cpp/integration/test_gpu_execution_null_safe_join.cpp

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -259,7 +259,8 @@ void downgrade_executor::processing_loop()
              host_end_idx,
              &repo_stats,
              &host_target_stats,
-             &disk_target_stats]() mutable {
+             &disk_target_stats,
+             &cum_repo_bytes = _cumulative_repo_bytes_downgraded]() mutable {
               try {
                 auto result = cand->convert(targets, exc_stream, res_mgr, false);
                 if (result) {
@@ -267,6 +268,16 @@ void downgrade_executor::processing_loop()
                   req_ptr->batches_downgraded.fetch_add(1, std::memory_order_relaxed);
                   repo_stats.batches.fetch_add(1, std::memory_order_relaxed);
                   repo_stats.bytes.fetch_add(candidate_bytes, std::memory_order_relaxed);
+                  // Published here rather than once the request retires: monitor requests are
+                  // fire-and-forget, so a caller that observes them after a query completes would
+                  // otherwise race the request's own aggregation and read stale totals.
+                  cum_repo_bytes.fetch_add(candidate_bytes, std::memory_order_relaxed);
+                  // Per-batch trace: lets a reader follow one batch across tiers, which the
+                  // aggregate counter cannot express.
+                  if (auto const id = cand->data_id(); id.has_value()) {
+                    SIRIUS_LOG_DEBUG(
+                      "[downgrade] batch {} spilled GPU->lower, {} bytes", *id, candidate_bytes);
+                  }
                   for (size_t i = 0; i < result->size(); ++i) {
                     if ((*result)[i] == 0) continue;
                     if (i < host_end_idx) {

--- a/src/include/data/convertible_data.hpp
+++ b/src/include/data/convertible_data.hpp
@@ -19,6 +19,7 @@
 #include <rmm/cuda_stream_view.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -86,6 +87,14 @@ class convertible_data {
    * @return The size in bytes, or 0 if not in that space.
    */
   virtual std::size_t bytes_in_space(cucascade::memory::memory_space* space) const = 0;
+
+  /**
+   * @brief Stable id of the underlying data unit, when it has one.
+   *
+   * Lets a caller trace an individual unit across tiers. Units that do not map to a single batch
+   * (a pipeline task wrapping several) return nullopt.
+   */
+  virtual std::optional<std::uint64_t> data_id() const { return std::nullopt; }
 };
 
 /**

--- a/src/include/data/convertible_data_batch.hpp
+++ b/src/include/data/convertible_data_batch.hpp
@@ -61,6 +61,8 @@ class convertible_data_batch : public convertible_data {
   {
   }
 
+  std::optional<std::uint64_t> data_id() const override { return _batch->get_batch_id(); }
+
   /**
    * @brief Convert this batch to reside in one of the target memory spaces.
    *

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -171,6 +171,24 @@ class downgrade_executor {
     return _monitor_requests_issued.load(std::memory_order_relaxed);
   }
 
+  /**
+   * @brief Cumulative bytes PROCESSED out of this executor's source space from data-repository
+   *        candidates (operator-port batches parked between pipelines), across every request.
+   *
+   * Useful operationally, not just in tests: repository spill that keeps climbing means a working
+   * set that does not fit the tier.
+   *
+   * Bytes processed, not unique bytes moved — a batch spilled, upgraded on demand and spilled again
+   * counts each time, so this can exceed the data the query ever held. Read it as work done.
+   *
+   * Published per conversion rather than when a request retires, so a reader never races the
+   * in-flight aggregation of a fire-and-forget monitor request.
+   */
+  size_t repository_bytes_downgraded() const
+  {
+    return _cumulative_repo_bytes_downgraded.load(std::memory_order_relaxed);
+  }
+
  private:
   void processing_loop();
   void monitor_loop();
@@ -195,6 +213,7 @@ class downgrade_executor {
   std::atomic<bool> _monitor_request_enqueued{false};
   std::atomic<bool> _running{false};
   std::atomic<size_t> _monitor_requests_issued{0};
+  std::atomic<size_t> _cumulative_repo_bytes_downgraded{0};
   std::unique_ptr<cucascade::memory::exclusive_stream_pool> _stream_pool;
 
   std::mutex _monitor_cv_mutex;

--- a/src/include/pipeline/batch_lock_utils.hpp
+++ b/src/include/pipeline/batch_lock_utils.hpp
@@ -143,6 +143,15 @@ inline std::optional<cucascade::read_only_data_batch> lock_or_prepare_batch(
         return clone->to_read_only();
       }
       mut_accessor.convert_to<cucascade::gpu_table_representation>(registry, target_space, stream);
+      // Paired with the downgrade executor's spill trace: together they show a batch's round trip.
+      // The column count travels with it because a batch id alone says nothing about which side of
+      // a join the data came from.
+      SIRIUS_LOG_DEBUG("[upgrade] batch {} restored to GPU for processing, {} columns",
+                       mut_accessor.get_batch_id(),
+                       mut_accessor.get_data()
+                         ->cast<cucascade::gpu_table_representation>()
+                         .get_table_view()
+                         .num_columns());
       telemetry::batch_telemetry_registry::instance().on_tier_change(
         mut_accessor.get_batch_id(),
         target_space->get_tier(),

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -2083,6 +2083,13 @@ void sirius_physical_hash_join::push_data_batch_partitioned(
   std::shared_ptr<::cucascade::data_batch> batch,
   std::size_t partition_idx)
 {
+  // Names the batches that belong to the build side, which nothing downstream can infer: tier
+  // traces carry a batch id but no port.
+  if (port_id == "build" && batch) {
+    SIRIUS_LOG_DEBUG(
+      "[hash_join] id {} build-port batch {}", get_operator_id(), batch->get_batch_id());
+  }
+
   //===----------Dynamic Table Filters----------===//
   // Build-side dynamic-filter publish: the moment the (single, concat-folded) build batch arrives,
   // compute and publish the filter from the build keys.

--- a/test/cpp/integration/test_gpu_execution_join_memory_pressure.cpp
+++ b/test/cpp/integration/test_gpu_execution_join_memory_pressure.cpp
@@ -1,0 +1,436 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// A hash join whose BUILD SIDE is spilled to HOST mid-build and read back, still returning the
+// right answer.
+//
+// A join's build side sits in its build-port repository, GPU-resident and idle, until the join task
+// claims it — the state the downgrade executor picks spill candidates from. Nothing else covers a
+// real operator there: test/cpp/downgrade/* spills synthetic repositories with no operator
+// attached, and test_oom_reschedule.cpp uses stub tasks.
+//
+// Three details are load-bearing:
+//
+//   * The eviction threshold forces the spill, not a tight budget. downgrade_trigger drops to 0.05
+//     of a 2 GiB budget (~102 MiB) so the ~384 MB build side is evicted while still accumulating,
+//     while usage_limit_bytes stays at 2 GiB so the join can upgrade it back.
+//   * The LEFT join pins the build side. Table shape does NOT control it — the planner builds the
+//     side smaller IN BYTES, so an INNER join here builds the NARROW table. An outer join's inner
+//     side cannot be swapped. Every fact key exists in dim, so nothing is NULL-padded and the
+//     result matches the inner join.
+//   * The round trip is asserted per BATCH ID, not in bytes. Spill volume has no operator, port,
+//     batch or direction attribution and counts re-spills repeatedly, so no byte threshold can show
+//     that build-side data specifically made the trip. The engine traces which batches reach the
+//     build port and which cross tiers in each direction; the test intersects those.
+
+#include "config.hpp"
+#include "downgrade/downgrade_executor.hpp"
+#include "log/logging.hpp"
+#include "sirius_context.hpp"
+
+#include <catch.hpp>
+#include <cucascade/memory/common.hpp>
+#include <duckdb.hpp>
+#include <unistd.h>
+#include <utils/parquet_fixture_utils.hpp>
+#include <utils/sirius_test_env.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <regex>
+#include <set>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Build side (pinned there by the LEFT join): 2M rows x 24 int64 -> ~384 MB decoded, well above
+// the eviction threshold below, so the build side alone creates the pressure.
+constexpr std::int64_t kDimRows = 2'000'000;
+constexpr int kDimPayloadCols   = 23;  // plus the key column
+constexpr std::size_t kDimBytes =
+  static_cast<std::size_t>(kDimRows) * (kDimPayloadCols + 1) * sizeof(std::int64_t);
+
+// Probe side: one column, so the entire side is small -- ~24 MB decoded.
+constexpr std::int64_t kFactRows = 3'000'000;
+constexpr std::size_t kFactBytes = static_cast<std::size_t>(kFactRows) * sizeof(std::int64_t);
+
+// GPU budget is generous; only the eviction threshold is tight (see the file header).
+constexpr std::size_t kGpuBudgetBytes = 2048ull << 20;  // 2 GiB
+constexpr double kDowngradeTrigger    = 0.05;           // ~102 MiB
+constexpr double kDowngradeStop       = 0.025;          // ~51 MiB
+constexpr std::size_t kScanBatchBytes = 8ull << 20;  // small batches -> granular spill candidates
+
+/// Ceiling on the probe side's real footprint: kFactBytes is logical row arithmetic, but the engine
+/// sizes that table at 24,375,040. The bounds below compare against MEASURED bytes, so they have to
+/// clear the measured value — a margin thinner than the layout overhead proves nothing.
+constexpr std::size_t kProbeSideCeilingBytes = 32'000'000;
+
+/// The counter sums bytes per conversion, so re-spills count repeatedly. Four probe sides' worth
+/// allows four full re-spill cycles and still cannot be reached without build-side data.
+constexpr std::size_t kBuildSideEvidenceBytes = 4 * kProbeSideCeilingBytes;
+
+/// Half of `dim` is ~8x anything `fact` can measure, so a flipped plan cannot satisfy it.
+constexpr std::size_t kBuildSideFloorBytes = kDimBytes / 2;
+
+/// The DuckDB CPU answer for the join, computed before Sirius is in the picture.
+struct cpu_reference {
+  std::string count_star;
+  std::string sum_dim_payload;
+};
+
+std::string dim_projection()
+{
+  std::string cols = "range AS k";
+  for (int i = 1; i <= kDimPayloadCols; ++i) {
+    cols += ", range * " + std::to_string(i) + " AS c" + std::to_string(i);
+  }
+  return cols;
+}
+
+/// `d.c1 + d.c2 + ... + d.cN` — every payload column, so none can be pruned away.
+std::string dim_payload_sum()
+{
+  std::string expr = "d.c1";
+  for (int i = 2; i <= kDimPayloadCols; ++i) {
+    expr += " + d.c" + std::to_string(i);
+  }
+  return expr;
+}
+
+std::string join_query(fs::path const& dim_path, fs::path const& fact_path)
+{
+  // Summing EVERY payload column is deliberate: reference one and column pruning reads a
+  // two-column build side, so the ~384 MB that creates the pressure never materializes.
+  return "SELECT count(*) AS n, sum(" + dim_payload_sum() +
+         ") AS sc "
+         "FROM read_parquet(" +
+         sirius::test::sql_literal(fact_path.string()) +
+         ") AS f "
+         "LEFT JOIN read_parquet(" +
+         sirius::test::sql_literal(dim_path.string()) + ") AS d ON f.k = d.k;";
+}
+
+/// Sirius is disabled here so the extension callback never builds a SiriusContext on this throwaway
+/// instance — the tight-trigger one comes later.
+cpu_reference generate_inputs_and_reference(fs::path const& dim_path, fs::path const& fact_path)
+{
+  sirius::test::scoped_sirius_disable disable_sirius;
+  duckdb::DuckDB gen_db(nullptr);
+  duckdb::Connection gen(gen_db);
+
+  auto dim =
+    gen.Query("COPY (SELECT " + dim_projection() + " FROM range(" + std::to_string(kDimRows) +
+              ")) TO " + sirius::test::sql_literal(dim_path.string()) + " (FORMAT PARQUET);");
+  REQUIRE(dim);
+  REQUIRE_FALSE(dim->HasError());
+
+  auto fact = gen.Query("COPY (SELECT range % " + std::to_string(kDimRows) + " AS k FROM range(" +
+                        std::to_string(kFactRows) + ")) TO " +
+                        sirius::test::sql_literal(fact_path.string()) + " (FORMAT PARQUET);");
+  REQUIRE(fact);
+  REQUIRE_FALSE(fact->HasError());
+
+  auto ref = gen.Query(join_query(dim_path, fact_path));
+  REQUIRE(ref);
+  if (ref->HasError()) { UNSCOPED_INFO("CPU reference error: " << ref->GetError()); }
+  REQUIRE_FALSE(ref->HasError());
+  REQUIRE(ref->RowCount() == 1);
+
+  return cpu_reference{ref->GetValue(0, 0).ToString(), ref->GetValue(1, 0).ToString()};
+}
+
+/// Mirrors integration.yaml, but with an eviction threshold far below the build side so the
+/// downgrade monitor fires during the build, and small scan batches so it has candidates.
+void write_config(fs::path const& yaml_path)
+{
+  std::ofstream f(yaml_path);
+  f << "sirius:\n"
+       "  topology:\n"
+       "    num_gpus: 1\n"
+       "  memory:\n"
+       "    gpu:\n"
+       "      usage_limit_bytes: "
+    << kGpuBudgetBytes
+    << "\n"
+       "      reservation_limit_fraction: 1.0\n"
+       "      downgrade_trigger_fraction: "
+    << kDowngradeTrigger
+    << "\n"
+       "      downgrade_stop_fraction: "
+    << kDowngradeStop
+    << "\n"
+       "    host:\n"
+       "      capacity_bytes: 32000000000\n"
+       "      initial_number_pools: 10\n"
+       "      pool_size: 512\n"
+       "      block_size: 1048576\n"
+       "  executor:\n"
+       "    pipeline:\n"
+       "      num_threads: 4\n"
+       "    task_creator:\n"
+       "      num_threads: 2\n"
+       "    downgrade:\n"
+       "      num_threads: 1\n"
+       "      monitor_period: 10ms\n"
+       "  operator_params:\n"
+       "    scan_task_batch_size: "
+    << kScanBatchBytes
+    << "\n"
+       "    max_sort_partition_bytes: 0\n"
+       "    hash_partition_bytes: 1000000000\n"
+       "    concat_batch_bytes: 100000000\n"
+       // Above the ~384 MB build side, so the join keeps one hash table rather than splitting into
+       // partitions and the build side parks as one repository's worth of batches.
+       "    max_build_hash_table_bytes: 800000000\n";
+}
+
+/// Points Sirius at @p dir for debug logging, restoring what was set before. The build-side
+/// assertion reads the join's own sizing line, which is DEBUG level.
+class scoped_debug_log_dir {
+ public:
+  explicit scoped_debug_log_dir(fs::path const& dir) : _dir(dir)
+  {
+    fs::create_directories(dir);
+    save_env("SIRIUS_LOG_DIR", _prev_dir, _had_prev_dir);
+    save_env("SIRIUS_LOG_LEVEL", _prev_level, _had_prev_level);
+    // The extension callback overwrites Config::LOG_* only when the env var is set, so restoring
+    // the environment alone would leave this directory and level installed for every later test.
+    _prev_cfg_dir   = duckdb::Config::LOG_DIR;
+    _prev_cfg_level = duckdb::Config::LOG_LEVEL;
+    setenv("SIRIUS_LOG_DIR", dir.c_str(), 1);
+    setenv("SIRIUS_LOG_LEVEL", "debug", 1);
+  }
+
+  /// Restore the environment, the process-global config and the sink, then drop the directory.
+  /// Call once the local SiriusContext is gone; the destructor repeats it if a test throws first.
+  void restore()
+  {
+    if (_restored) { return; }
+    _restored = true;
+    restore_env("SIRIUS_LOG_DIR", _prev_dir, _had_prev_dir);
+    restore_env("SIRIUS_LOG_LEVEL", _prev_level, _had_prev_level);
+    duckdb::Config::LOG_DIR   = _prev_cfg_dir;
+    duckdb::Config::LOG_LEVEL = _prev_cfg_level;
+    duckdb::install_configured_log_sink(nullptr);
+    std::error_code ec;
+    fs::remove_all(_dir, ec);
+  }
+
+  ~scoped_debug_log_dir() { restore(); }
+
+  scoped_debug_log_dir(scoped_debug_log_dir const&)            = delete;
+  scoped_debug_log_dir& operator=(scoped_debug_log_dir const&) = delete;
+
+ private:
+  static void save_env(char const* name, std::string& out, bool& had)
+  {
+    if (char const* prev = std::getenv(name)) {
+      out = prev;
+      had = true;
+    }
+  }
+
+  static void restore_env(char const* name, std::string const& prev, bool had)
+  {
+    if (had) {
+      setenv(name, prev.c_str(), 1);
+    } else {
+      unsetenv(name);
+    }
+  }
+
+  fs::path _dir;
+  std::string _prev_dir;
+  std::string _prev_level;
+  std::string _prev_cfg_dir;
+  std::string _prev_cfg_level;
+  bool _had_prev_dir{false};
+  bool _had_prev_level{false};
+  bool _restored{false};
+};
+
+/// Everything the test reads back out of the debug log.
+struct log_facts {
+  std::size_t build_side_bytes = 0;       ///< largest "build side N bytes" the join reported
+  std::set<std::uint64_t> build_batches;  ///< batches published to the join's build port
+  std::set<std::uint64_t> spilled;        ///< batches the downgrade executor moved off GPU
+  std::map<std::uint64_t, int> upgraded;  ///< batches restored to GPU -> their column count
+};
+
+/// Which side is built is a planner decision and a batch's port is not visible at the tier layer,
+/// so both are read back from the engine's own traces rather than assumed.
+log_facts read_log_facts(fs::path const& log_dir)
+{
+  (void)sirius::log::get_sink()->flush();
+  std::regex const build_side_re(R"(build side ([0-9]+) bytes)");
+  std::regex const build_batch_re(R"(\[hash_join\] id [0-9]+ build-port batch ([0-9]+))");
+  std::regex const spill_re(R"(\[downgrade\] batch ([0-9]+) spilled)");
+  std::regex const upgrade_re(
+    R"(\[upgrade\] batch ([0-9]+) restored to GPU for processing, ([0-9]+) columns)");
+
+  log_facts facts;
+  std::error_code ec;
+  for (auto const& entry : fs::recursive_directory_iterator(log_dir, ec)) {
+    if (!entry.is_regular_file()) { continue; }
+    std::ifstream in(entry.path());
+    std::stringstream ss;
+    ss << in.rdbuf();
+    auto const text = ss.str();
+
+    for (auto it = std::sregex_iterator(text.begin(), text.end(), build_side_re);
+         it != std::sregex_iterator();
+         ++it) {
+      facts.build_side_bytes =
+        std::max(facts.build_side_bytes, static_cast<std::size_t>(std::stoull((*it)[1].str())));
+    }
+    auto collect = [&text](std::regex const& re, std::set<std::uint64_t>& out) {
+      for (auto it = std::sregex_iterator(text.begin(), text.end(), re);
+           it != std::sregex_iterator();
+           ++it) {
+        out.insert(std::stoull((*it)[1].str()));
+      }
+    };
+    collect(build_batch_re, facts.build_batches);
+    collect(spill_re, facts.spilled);
+    for (auto it = std::sregex_iterator(text.begin(), text.end(), upgrade_re);
+         it != std::sregex_iterator();
+         ++it) {
+      facts.upgraded[std::stoull((*it)[1].str())] = std::stoi((*it)[2].str());
+    }
+  }
+  return facts;
+}
+
+/// Build-side batches that went to a lower tier and came back.
+///
+/// Attribution is by SCHEMA, not by port. The join's build port only ever holds one batch — the
+/// concat-folded build side — and that batch is created late and consumed promptly, so it is not
+/// what spills; its inputs are. Those carry dim's full width, and dim is the only relation here
+/// with more than one column, so a round-tripped batch of that width is build-side data.
+std::vector<std::uint64_t> build_side_batches_round_tripped(log_facts const& facts)
+{
+  constexpr int kDimColumns = kDimPayloadCols + 1;
+  std::vector<std::uint64_t> ids;
+  for (auto const& [id, columns] : facts.upgraded) {
+    if (columns == kDimColumns && facts.spilled.count(id) != 0) { ids.push_back(id); }
+  }
+  return ids;
+}
+
+/// Repository-sourced bytes spilled out of every GPU space, summed across downgrade executors.
+std::size_t gpu_repository_bytes_downgraded(duckdb::SiriusContext const& ctx)
+{
+  std::size_t total = 0;
+  for (auto const& executor : ctx.get_downgrade_executors()) {
+    if (executor->get_space_id().tier != cucascade::memory::Tier::GPU) { continue; }
+    total += executor->repository_bytes_downgraded();
+  }
+  return total;
+}
+
+}  // namespace
+
+// NB: no [integration]/[shared_context] tag — those bind a shared env, which would fight this
+// test's own tight-trigger local env. Like the other isolated-context integration tests, this
+// TEST_CASE pauses the shared envs itself.
+TEST_CASE("gpu_execution - hash join build side spills to HOST and is read back mid-build",
+          "[gpu_execution][join][memory_pressure][downgrade]")
+{
+  if (sirius::test::g_shared_env && sirius::test::g_shared_env->is_active()) {
+    sirius::test::g_shared_env->pause();
+  }
+  if (sirius::test::g_integration_env && sirius::test::g_integration_env->is_active()) {
+    sirius::test::g_integration_env->pause();
+  }
+  if (sirius::test::g_integration_env_2gpu && sirius::test::g_integration_env_2gpu->is_active()) {
+    sirius::test::g_integration_env_2gpu->pause();
+  }
+
+  sirius::test::scratch_dir scratch{"join_mem_pressure"};
+  auto const& tmp = scratch.path();
+
+  auto dim_path  = tmp / "dim.parquet";
+  auto fact_path = tmp / "fact.parquet";
+  auto reference = generate_inputs_and_reference(dim_path, fact_path);
+
+  auto yaml_path = tmp / "join_mem_pressure.yaml";
+  write_config(yaml_path);
+  REQUIRE(fs::exists(yaml_path));
+
+  // Outside `scratch`: the guard removes it in restore(), once the sink has been pointed away.
+  auto log_dir = fs::temp_directory_path() /
+                 ("sirius_test_join_mem_pressure_logs_" + std::to_string(::getpid()));
+  std::error_code log_ec;
+  fs::remove_all(log_dir, log_ec);  // clear a previous run's files rather than read them back
+  scoped_debug_log_dir log_guard{log_dir};
+
+  {
+    sirius::test::shared_test_env local_env(yaml_path);
+    auto con = local_env.make_connection();
+
+    // Force GPU execution so a spill-path failure surfaces instead of silently falling back.
+    auto fb = con.Query("SET enable_duckdb_fallback = false;");
+    REQUIRE(fb);
+    REQUIRE_FALSE(fb->HasError());
+
+    auto sirius_ctx = con.context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+    REQUIRE(sirius_ctx);
+
+    auto const before = gpu_repository_bytes_downgraded(*sirius_ctx);
+
+    auto result = con.Query(join_query(dim_path, fact_path));
+    REQUIRE(result);
+    if (result->HasError()) { UNSCOPED_INFO("GPU join error: " << result->GetError()); }
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(result->RowCount() == 1);
+
+    // (1) Correctness: the join survived the spill with the right answer.
+    REQUIRE(result->GetValue(0, 0).ToString() == reference.count_star);
+    REQUIRE(result->GetValue(1, 0).ToString() == reference.sum_dim_payload);
+
+    auto const facts = read_log_facts(log_dir);
+
+    // (2) `dim` really is the build side. A planner change that swaps the sides would otherwise
+    // leave the test green while it exercised the probe side.
+    UNSCOPED_INFO("hash join reported build side = "
+                  << facts.build_side_bytes << " bytes; must exceed " << kBuildSideFloorBytes);
+    REQUIRE(facts.build_side_bytes > kBuildSideFloorBytes);
+
+    // (3) The claim itself: a build-side batch was spilled off GPU and restored before the join
+    // consumed it. Bytes cannot show this — the aggregate counter has no operator, batch or
+    // direction attribution — so it is asserted per batch id, with the side identified by width.
+    auto const round_tripped = build_side_batches_round_tripped(facts);
+    UNSCOPED_INFO("spilled=" << facts.spilled.size() << " upgraded=" << facts.upgraded.size()
+                             << " build-side round-tripped=" << round_tripped.size()
+                             << "; the join's folded build-port batch itself stays resident ("
+                             << facts.build_batches.size() << " such batch(es))");
+    REQUIRE_FALSE(round_tripped.empty());
+
+    // (4) And the spill was substantial, not a single stray batch.
+    auto const spilled = gpu_repository_bytes_downgraded(*sirius_ctx) - before;
+    UNSCOPED_INFO("repository bytes downgraded during the join = " << spilled);
+    REQUIRE(spilled > kBuildSideEvidenceBytes);
+  }
+
+  // The local context is gone; put the global log config and sink back before the directory goes.
+  log_guard.restore();
+}


### PR DESCRIPTION
Join builds are the classic OOM trigger, and nothing in the suite drove one. The two
places you'd expect coverage both stop short:

- `test/cpp/downgrade/*` spills synthetic repositories — batches from `make_gpu_batch`
  dropped into a bare `shared_data_repository`. No operator is attached, so nothing ever
  reads the spilled batch back.
- `test_oom_reschedule.cpp` drives reservation failures with stub tasks whose
  `compute_task` returns `nullptr`. It covers the scheduler's reaction to OOM, not any
  operator's data path.

Neither reaches the state this covers: a join's build side parked in its build-port
repository, GPU-resident and idle, which is exactly what `convertible_data_batch_provider`
picks spill candidates from. That data then has to come back through the `HOST->GPU` arm
of `lock_or_prepare_batch` and still produce the right answer.

## How the spill is forced

Shrinking the GPU budget until something spills is flaky and tests the wrong thing — you
get a starved build racing a real OOM, and the failure mode is a reschedule, not a
downgrade. The two memory knobs are decoupled instead:

- `downgrade_trigger_fraction: 0.05` of a 2 GiB budget (~102 MiB), so the ~384 MB build
  side is evicted while it is still accumulating.
- `usage_limit_bytes` stays at a full 2 GiB, so the join has ample headroom to upgrade its
  inputs back and build the hash table.

The spill is guaranteed by configuration rather than by winning a race.

## Proving it is the build side

Table shape does **not** control which side is built — the planner picks the side smaller
in bytes. An INNER join over these tables builds the *narrow* one:

```
partition strategy: 1 partitions (1 GPUs), build side 24375040 bytes.
Join Type: INNER. build_card_est 3000000 probe_card_est 2000000
```

24 MB of `fact`, not 384 MB of `dim` — the spill would be probe-side and the test would
pass while proving nothing. A `LEFT` join pins it, since an outer join's inner side can't
be swapped without changing semantics. The build side is then `dim` at 390,001,152 bytes.
Every fact key exists in dim, so nothing is NULL-padded and the result matches the inner
join.

The test asserts that premise rather than assuming it, reading the join's own sizing line
back out of a debug log. Verified by negative control: flipping the query to INNER makes
it fail with `build side = 24375040 bytes; must exceed 192000000`.

**Bounds compare measured against measured.** `kFactBytes` is logical row arithmetic
(3M × 8 = 24,000,000), but the engine sizes that same table at 24,375,040. An earlier
revision compared the two — passing by 1.5% and discriminating nothing. The probe-side
ceiling now sits above the measured value, and the spill threshold is 4× it, absorbing
four full re-spill cycles of the entire probe side.

## Production change

`downgrade_executor` exposes one accessor, `repository_bytes_downgraded()`: cumulative
bytes processed out of the source space from repository candidates. Two properties worth
noting:

- **Published per conversion**, not when a request retires. Monitor requests are
  fire-and-forget, so a reader that observes them after a query completes would otherwise
  race the request's own aggregation and see stale totals — or zero, if the only spill
  lived in that request.
- **Bytes processed, not unique bytes.** A batch spilled, upgraded on demand and spilled
  again counts each time, so the number can exceed the data the query ever held. It reads
  as work done, not a footprint — which is why the test's threshold budgets for re-spill
  cycles.

Cost is one relaxed atomic increment per successful spill. It's also useful operationally,
not just here: repository spill that keeps climbing means a working set that doesn't fit
the tier.
