### PR TITLE
fix(pipeline): signal query completion from the pipeline finish transition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -807,6 +807,7 @@ set(TEST_SOURCES
     test/cpp/planner/test_query_index.cpp
     test/cpp/planner/test_tier_narrowing_policy.cpp
     test/cpp/pipeline/test_batch_lock_utils.cpp
+    test/cpp/pipeline/test_completion_signal.cpp
     test/cpp/pipeline/test_gpu_pipeline_executor.cpp
     test/cpp/pipeline/test_oom_reschedule.cpp
     test/cpp/pipeline/test_pipeline_memory_history.cpp

--- a/docs/super-sirius/architecture-overview.md
+++ b/docs/super-sirius/architecture-overview.md
@@ -127,13 +127,13 @@ A query through Super Sirius follows these steps:
    - Converts each TABLE_SCAN source into a unified GPU scan source with a per-table `gpu_ingestible`
    - Injects PARTITION, CONCAT, MERGE operators at pipeline boundaries
    - Wires data repositories between pipelines with barrier types
-4. **Query Preparation** — `task_scheduler::prepare_for_query()` drains leftover state and queues initial scan operators; `sirius_scan_manager::prepare_for_query()` builds each scan's split provider, installs its split connector, and matches any pinned-cache entries
-5. **Query Start** — `task_scheduler::start_query()` creates a `completion_handler`, distributes it to all sub-executors, and schedules initial work
+4. **Query Preparation** — `task_scheduler::prepare_for_query()` drains leftover state, creates the `completion_handler`, and installs it on the GPU executors and query-terminal pipelines; `sirius_scan_manager::prepare_for_query()` builds each scan's split provider, installs its split connector, and matches any pinned-cache entries
+5. **Query Start** — `task_scheduler::start_query()` schedules the initial scan operator and returns the completion future
 6. **Scan Phase** — The scan manager drives split providers that pull bytes through the `io_context` (io_uring locally, or REST/kvikio backends) and the prefetching cache; the unified GPU scan source consumes splits and materializes GPU-ready batches into data repositories
 7. **Pipeline Execution** — GPU executor threads pull tasks from the queue, acquire memory reservations, and call `execute()` on every operator in the pipeline (source through sink) on CUDA streams, then call the sink's `sink()` to push results downstream
 8. **Task Creation** — After each task completes, the task creator is notified to schedule downstream consumers based on data availability in ports
 9. **Memory Management** — Downgrade executors monitor GPU memory pressure and spill data to host memory when thresholds are exceeded
-10. **Completion** — When the final `RESULT_COLLECTOR` pipeline finishes, `completion_handler::mark_completed()` signals the future
+10. **Completion** — A query-terminal pipeline signals the completion future when it transitions to finished; the GPU task epilogue may also signal it safely
 11. **Result Extraction** — The main thread extracts the `MaterializedQueryResult` from the result collector and returns it to DuckDB
 
 ## Key Source Files

--- a/docs/super-sirius/execution-flow.md
+++ b/docs/super-sirius/execution-flow.md
@@ -118,14 +118,10 @@ After meta-pipeline construction, `initialize_internal()` applies Sirius-specifi
 
 **File:** `src/sirius_engine.cpp` — `execute()`
 
-1. Creates a `query` object from `new_scheduled` pipelines with a pipeline hashmap
-2. Calls `task_scheduler.start_query(query)` which:
-   - Creates a `completion_handler` with promise/future
-   - Distributes the handler to all sub-executors
-   - Schedules the initial GPU scan tasks
-   - Returns the future
-
-3. The main thread blocks on `future.get()` until the query completes
+1. Calls `SiriusContext::create_query()` with the finalized pipelines
+2. Query preparation creates a `completion_handler` and installs it on the GPU executors and query-terminal pipelines
+3. Calls `task_scheduler::start_query()`, which schedules the initial scan operator and returns the completion future
+4. The main thread blocks on `future.get()` and then drains in-flight work before returning
 
 ## Step 6: Scan Execution
 
@@ -155,6 +151,9 @@ The GPU executor's manager loop:
    - On success: check if query is complete (RESULT_COLLECTOR sink + pipeline finished)
    - If not complete: schedule downstream consumers via `task_creator->schedule()`
    - If complete: `completion_handler->mark_completed()`
+
+The GPU epilogue usually signals completion. A query-terminal pipeline also signals from
+`sirius_pipeline::update_pipeline_status()`, covering finish transitions driven by other threads.
 
 ## Step 8: Task Creation Cycle
 

--- a/docs/super-sirius/pipeline-execution.md
+++ b/docs/super-sirius/pipeline-execution.md
@@ -338,7 +338,7 @@ Concurrency is managed via `exec::bounded_thread_pool`, which uses a two-phase `
 | `_memory_space` | `memory_space*` | GPU memory for making reservations |
 | `_task_request_publisher` | `publisher<task_request>` | Channel to signal pipeline executor |
 | `_task_creator` | `task_creator*` | For scheduling downstream consumer tasks |
-| `_completion_handler` | `completion_handler*` | For signaling query completion |
+| `_completion_handler` | `completion_handler*` | For signaling query completion (the epilogue's copy; query-terminal pipelines hold one too) |
 
 ### Manager Loop
 
@@ -371,6 +371,24 @@ After a task completes:
 
 The completion check happens **before** scheduling downstream tasks to prevent scheduling tasks that reference already-destroyed operators.
 
+This epilogue is the usual signaller, but not the only one — see the completion contract below.
+
+### Completion Contract
+
+`sirius_pipeline::update_pipeline_status()` owns the transition to `pipeline_finished`. A
+query-terminal pipeline signals completion there because task-creator, streaming-source, and
+parent-cascade paths can finish a pipeline without returning through the GPU epilogue.
+
+`task_scheduler::prepare_for_query()` installs the handler on terminal pipelines as a
+`std::weak_ptr`, preventing retired pipelines from retaining or signaling a later query's handler.
+The pipeline obtains a strong reference under `_status_mutex` and calls `mark_completed()` only
+after releasing the lock and finishing all pipeline access.
+
+The GPU epilogue also keeps its completion signal. Duplicate signals are safe because
+`completion_handler` accepts only the first one. After the future resolves,
+`task_scheduler::wait_for_completion()` joins the task creator and in-flight GPU work before
+operators are destroyed.
+
 ### Task Request Flow
 
 GPU executors communicate with the pipeline executor via `exec::channel<task_request>`:
@@ -393,7 +411,8 @@ Thread-safe signaling for query completion using promise/future:
 | `get_awaitable()` | Returns the future for blocking |
 | `is_completed()` / `has_error()` | Atomic status checks |
 
-All methods are idempotent — subsequent calls after the first are no-ops.
+All methods are idempotent: the GPU epilogue and terminal pipeline may signal the same completion,
+and only the first call takes effect.
 
 ## Reschedule Handling (OOM and CUDA launch failures)
 

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -22,12 +22,14 @@
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_operator_type.hpp"
+#include "pipeline/completion_handler.hpp"
 #include "pipeline/pipeline_build_context.hpp"
 #include "pipeline/pipeline_memory_history.hpp"
 #include "telemetry-bridge/gen/uuid.rs.h"
 
 #include <nvtx3/nvtx3.hpp>
 
+#include <memory>
 #include <mutex>
 #include <utility>
 #include <vector>
@@ -201,6 +203,10 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! Set the task_creator pointer so this pipeline can schedule downstream consumers on finish.
   void set_task_creator(sirius::creator::task_creator* tc);
 
+  //! Install a query-terminal pipeline's weak completion reference.
+  //! Weak ownership prevents retired pipelines from keeping a query alive.
+  void set_completion_handler(std::weak_ptr<completion_handler> handler);
+
   //! task_creator for schedule(), or nullptr when unwired. Streaming sources use this to
   //! re-arm a starved head; schedule() only enqueues, so off-thread calls are safe.
   [[nodiscard]] sirius::creator::task_creator* get_task_creator() const noexcept
@@ -278,6 +284,9 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
 
   //! Task creator pointer for scheduling downstream consumers when this pipeline finishes
   sirius::creator::task_creator* _task_creator{nullptr};
+
+  //! Per-query completion reference for terminal pipelines. Guarded by _status_mutex.
+  std::weak_ptr<completion_handler> _completion_handler;
 
   //! The unique ID of this pipeline (assigned based on new_scheduled order)
   size_t pipeline_id = 0;

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -219,7 +219,8 @@ class task_scheduler {
   std::unordered_map<int, std::unique_ptr<gpu_pipeline_executor>> _gpu_executors;
 
   sirius::creator::task_creator* _task_creator{nullptr};
-  std::unique_ptr<completion_handler> _completion_handler;
+  /// Strong owner for the weak completion references held by terminal pipelines.
+  std::shared_ptr<completion_handler> _completion_handler;
   std::shared_ptr<const telemetry::telemetry_context> _telemetry_context;
   std::unique_ptr<telemetry::TaskQueueHandleWrapper> _task_queue_telemetry;
 };

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -347,6 +347,12 @@ bool sirius_pipeline::is_query_terminal() const
 
 void sirius_pipeline::set_task_creator(sirius::creator::task_creator* tc) { _task_creator = tc; }
 
+void sirius_pipeline::set_completion_handler(std::weak_ptr<completion_handler> handler)
+{
+  std::lock_guard<std::mutex> lock(_status_mutex);
+  _completion_handler = std::move(handler);
+}
+
 void sirius_pipeline::notify_downstream_pipelines(bool original_pipeline)
 {
   // Query-terminal: no downstream; early return avoids teardown race after mark_completed().
@@ -378,6 +384,8 @@ std::unique_lock<std::mutex> sirius_pipeline::get_task_creation_lock()
 void sirius_pipeline::update_pipeline_status(bool original_pipeline)
 {
   bool should_notify = false;
+  // Snapshot under the lock; signal only after all pipeline access is complete.
+  std::shared_ptr<completion_handler> completion;
   {
     std::lock_guard<std::mutex> lock(_status_mutex);
 
@@ -426,10 +434,18 @@ void sirius_pipeline::update_pipeline_status(bool original_pipeline)
       }
       if (!pipeline_finished.load()) { end_nvtx_range_if_finished(); }
     }
+
+    // Signal from the transition so non-epilogue finish paths cannot strand execute() (#1486).
+    // Sampling under the lock pairs with set_completion_handler().
+    if (should_notify && is_query_terminal()) { completion = _completion_handler.lock(); }
   }  // _status_mutex released here — notify_downstream_pipelines must run outside the lock
      // to avoid holding the child pipeline mutex while acquiring a parent's
 
   if (should_notify) { notify_downstream_pipelines(original_pipeline); }
+
+  // Keep this last: waking execute() permits teardown. The epilogue may also signal, but
+  // completion_handler makes duplicate calls no-ops.
+  if (completion) { completion->mark_completed(); }
 }
 
 void sirius_pipeline::mark_task_created()

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -224,7 +224,12 @@ std::future<void> task_scheduler::start_query()
 
 void task_scheduler::terminate_query(std::exception_ptr error)
 {
-  _completion_handler->report_error(std::move(error));
+  std::shared_ptr<completion_handler> completion;
+  {
+    std::scoped_lock lock(_query_mutex);
+    completion = _completion_handler;
+  }
+  if (completion) { completion->report_error(std::move(error)); }
   stop();
 }
 

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -189,11 +189,20 @@ void task_scheduler::prepare_for_query(duckdb::shared_ptr<planner::query> query)
   std::lock_guard lock(_query_mutex);
   _query = std::move(query);
 
-  _completion_handler = std::make_unique<completion_handler>();
+  _completion_handler = std::make_shared<completion_handler>();
 
-  // Set completion handler on all executors
+  // Executors keep raw references owned by the scheduler.
   for (auto& [device_id, gpu_exec] : _gpu_executors) {
     gpu_exec->set_completion_handler(_completion_handler.get());
+  }
+
+  // Terminal pipelines keep weak references so replacing the handler retires the previous query.
+  if (_query) {
+    for (auto& pipeline : _query->get_pipelines()) {
+      if (pipeline && pipeline->is_query_terminal()) {
+        pipeline->set_completion_handler(_completion_handler);
+      }
+    }
   }
 }
 

--- a/test/cpp/pipeline/test_completion_signal.cpp
+++ b/test/cpp/pipeline/test_completion_signal.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression tests for #1486: completion driven outside the GPU epilogue must still signal.
+ * Bounded waits turn a lost signal into a test failure instead of a hang.
+ */
+
+#include "helper/logical_type.hpp"
+#include "op/sirius_physical_operator.hpp"
+#include "op/sirius_physical_operator_type.hpp"
+#include "pipeline/completion_handler.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+
+#include <chrono>
+#include <future>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using sirius::op::sirius_physical_operator;
+using sirius::op::SiriusPhysicalOperatorType;
+using sirius::pipeline::completion_handler;
+using sirius::pipeline::sirius_pipeline;
+using sirius::pipeline::sirius_pipeline_build_state;
+using namespace std::chrono_literals;
+
+namespace {
+
+/// Poll until @p done() or fail after @p timeout.
+template <typename Pred>
+void wait_or_fail(Pred done, std::chrono::seconds timeout, const char* what)
+{
+  const auto start = std::chrono::steady_clock::now();
+  while (!done()) {
+    std::this_thread::sleep_for(10ms);
+    if (std::chrono::steady_clock::now() - start > timeout) { FAIL(what); }
+  }
+}
+
+/// Build a zero-task pipeline that can finish without an epilogue fallback.
+duckdb::shared_ptr<sirius_pipeline> make_finishable_pipeline(sirius_physical_operator& sink_op)
+{
+  auto pipeline =
+    duckdb::make_shared_ptr<sirius_pipeline>(sirius::pipeline::pipeline_build_context{nullptr});
+  sirius_pipeline_build_state build_state;
+  build_state.set_pipeline_sink(*pipeline, &sink_op, 0);
+  return pipeline;
+}
+
+sirius_physical_operator make_sink(SiriusPhysicalOperatorType type)
+{
+  return sirius_physical_operator{type, duckdb::vector<sirius::logical_type>{}, 0};
+}
+
+}  // namespace
+
+TEST_CASE("Terminal pipeline finishing off the epilogue still signals completion",
+          "[pipeline][completion][issue-1486]")
+{
+  auto sink     = make_sink(SiriusPhysicalOperatorType::RESULT_COLLECTOR);
+  auto pipeline = make_finishable_pipeline(sink);
+  REQUIRE(pipeline->is_query_terminal());
+
+  auto handler = std::make_shared<completion_handler>();
+  pipeline->set_completion_handler(handler);
+  auto awaitable = handler->get_awaitable();
+
+  // Model task-creator and end-of-stream completion outside the GPU epilogue.
+  std::thread driver([&] { pipeline->update_pipeline_status(false); });
+  driver.join();
+
+  REQUIRE(pipeline->is_pipeline_finished());
+  wait_or_fail([&] { return awaitable.wait_for(0s) == std::future_status::ready; },
+               std::chrono::seconds(10),
+               "terminal pipeline finished without signalling completion (#1486)");
+  REQUIRE(handler->is_completed());
+  REQUIRE_NOTHROW(awaitable.get());
+}
+
+TEST_CASE("A streaming-sink pipeline is query-terminal and signals the same way",
+          "[pipeline][completion][issue-1486]")
+{
+  auto sink     = make_sink(SiriusPhysicalOperatorType::STREAMING_SINK);
+  auto pipeline = make_finishable_pipeline(sink);
+  REQUIRE(pipeline->is_query_terminal());
+
+  auto handler = std::make_shared<completion_handler>();
+  pipeline->set_completion_handler(handler);
+  auto awaitable = handler->get_awaitable();
+
+  std::thread driver([&] { pipeline->update_pipeline_status(false); });
+  driver.join();
+
+  wait_or_fail([&] { return awaitable.wait_for(0s) == std::future_status::ready; },
+               std::chrono::seconds(10),
+               "streaming-sink pipeline finished without signalling completion (#1486)");
+  REQUIRE(handler->is_completed());
+}
+
+TEST_CASE("Re-entering the finish transition re-signals harmlessly",
+          "[pipeline][completion][issue-1486]")
+{
+  auto sink     = make_sink(SiriusPhysicalOperatorType::RESULT_COLLECTOR);
+  auto pipeline = make_finishable_pipeline(sink);
+
+  auto handler = std::make_shared<completion_handler>();
+  pipeline->set_completion_handler(handler);
+  auto awaitable = handler->get_awaitable();
+
+  // Model duplicate transition and epilogue signals, including concurrent re-entry.
+  std::vector<std::thread> drivers;
+  drivers.reserve(4);
+  for (int i = 0; i < 4; ++i) {
+    drivers.emplace_back([&] { pipeline->update_pipeline_status(false); });
+  }
+  for (auto& driver : drivers) {
+    driver.join();
+  }
+  REQUIRE_NOTHROW(handler->mark_completed());
+  REQUIRE_NOTHROW(pipeline->update_pipeline_status(false));
+
+  REQUIRE(awaitable.wait_for(0s) == std::future_status::ready);
+  REQUIRE_NOTHROW(awaitable.get());
+  REQUIRE_FALSE(handler->has_error());
+}
+
+TEST_CASE("A non-terminal pipeline finishing does not signal the query",
+          "[pipeline][completion][issue-1486]")
+{
+  // A hash-join build pipeline is intermediate and must not complete the query.
+  auto sink     = make_sink(SiriusPhysicalOperatorType::HASH_JOIN);
+  auto pipeline = make_finishable_pipeline(sink);
+  REQUIRE_FALSE(pipeline->is_query_terminal());
+
+  auto handler = std::make_shared<completion_handler>();
+  pipeline->set_completion_handler(handler);
+  auto awaitable = handler->get_awaitable();
+
+  pipeline->update_pipeline_status(false);
+
+  REQUIRE(pipeline->is_pipeline_finished());
+  REQUIRE_FALSE(handler->is_completed());
+  REQUIRE(awaitable.wait_for(50ms) == std::future_status::timeout);
+}
+
+TEST_CASE("A pipeline left over from a finished query cannot signal the next one",
+          "[pipeline][completion][issue-1486]")
+{
+  // Dropping the scheduler-owned handler models retirement at the next query.
+  auto sink     = make_sink(SiriusPhysicalOperatorType::RESULT_COLLECTOR);
+  auto pipeline = make_finishable_pipeline(sink);
+
+  auto handler = std::make_shared<completion_handler>();
+  pipeline->set_completion_handler(handler);
+  handler.reset();
+
+  REQUIRE_NOTHROW(pipeline->update_pipeline_status(false));
+  REQUIRE(pipeline->is_pipeline_finished());
+}


### PR DESCRIPTION
## Summary

Move query completion signaling into the terminal pipeline's finish transition so completion no longer depends on the GPU task epilogue observing `pipeline_finished` at the right instant.

Fixes #1486.

## Problem

A query could finish all work but leave `sirius_engine::execute()` blocked forever on its completion future. `pipeline_finished` can be set by GPU workers, task-creator workers, the creator manager, streaming producers, or a parent-pipeline cascade, but only the GPU task epilogue called `completion_handler::mark_completed()`.

If another thread completed the terminal pipeline—or the epilogue sampled the flag just before the transition—the query finished without satisfying the future.

## Fix

- Install the query's completion handler on query-terminal pipelines during `prepare_for_query()`.
- Signal completion directly from `update_pipeline_status()` after releasing `_status_mutex`.
- Hold the handler weakly in pipelines and replace its strong owner per query, preventing retired pipelines from signaling later queries.
- Keep the epilogue signal as a CAS-safe fallback.

## Follow-up: completion quiescence

This change also makes streaming end-of-stream callbacks a possible signaling thread. The existing success path quiesces task-creator and GPU executor work before teardown, but it does not yet establish the same contract for externally driven producer callbacks.

The follow-up branch `fix/completion-quiescence-protocol` will add that quiescence protocol so every completion-capable context is retired before operator and stream state can be destroyed.

## Validation

A controlled test forced the old epilogue gate to miss once on an SF10 grouped aggregation:

| Build | Forced miss | Unmodified |
|---|---|---|
| `dev` | Timed out after 100 s | Passed |
| This PR | Passed in ~2 s | Passed |

Additional coverage:

- Full `sirius_unittest`: 2607 passed, 1 unrelated skip, 0 failed.
- TPC-H transparent path: 49 passed.
- Five new bounded completion tests covering non-epilogue signaling, streaming sinks, non-terminal pipelines, retired handlers, and duplicate/concurrent signals.

The completion contract is documented in `docs/super-sirius/pipeline-execution.md`, with pointers from the execution-flow and architecture overviews.