### PR TITLE
fix(scan): lifetime issue in the prefetcher

### DIFF
--- a/src/include/scan_manager/memory_prefetcher.hpp
+++ b/src/include/scan_manager/memory_prefetcher.hpp
@@ -102,7 +102,7 @@ class memory_prefetcher {
   }
 
  private:
-  void worker_loop();
+  void worker_loop(std::size_t worker_index);
 
   /// Attempt one sweep over all connectors; returns the number of batches converted.
   std::size_t sweep(rmm::cuda_stream_view stream);
@@ -115,6 +115,10 @@ class memory_prefetcher {
   /// short scan-bound queries). Quiet connectors allow full parallelism.
   std::unique_ptr<std::atomic<bool>[]> _drain_claims;
   cucascade::memory::memory_space* _gpu_space;
+
+  /// One stream per worker, borrowed (NOT owned): converted batches are
+  /// dealloc-bound to it and outlive the worker that made them.
+  std::vector<rmm::cuda_stream_view> _worker_streams;
 
   std::atomic<bool> _running{true};
   std::atomic<std::size_t> _batches_prefetched{0};

--- a/src/scan_manager/memory_prefetcher.cpp
+++ b/src/scan_manager/memory_prefetcher.cpp
@@ -21,7 +21,6 @@
 #include "log/logging.hpp"
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream.hpp>
 #include <rmm/error.hpp>
 
 #include <absl/cleanup/cleanup.h>
@@ -48,9 +47,14 @@ memory_prefetcher::memory_prefetcher(memory_prefetcher_config cfg,
   for (std::size_t i = 0; i < _connectors.size(); ++i) {
     _drain_claims[i].store(false, std::memory_order_relaxed);
   }
+  // Acquired before the workers start, so round-robin gives each a distinct stream.
+  _worker_streams.reserve(_config.num_threads);
+  for (std::size_t i = 0; i < _config.num_threads; ++i) {
+    _worker_streams.push_back(_gpu_space->acquire_stream());
+  }
   _workers.reserve(_config.num_threads);
   for (std::size_t i = 0; i < _config.num_threads; ++i) {
-    _workers.emplace_back([this] { worker_loop(); });
+    _workers.emplace_back([this, i] { worker_loop(i); });
   }
   SIRIUS_LOG_INFO(
     "[memory_prefetcher] started: {} threads, {} connectors, min_free_fraction={:.2f}",
@@ -82,17 +86,17 @@ void memory_prefetcher::stop()
   _workers.clear();
 }
 
-void memory_prefetcher::worker_loop()
+void memory_prefetcher::worker_loop(std::size_t worker_index)
 {
   // Bind this worker to the space's device: a fresh thread's current device is
   // 0, and the compression converters allocate from the CURRENT device's
   // resource rather than the target space's.
   rmm::cuda_set_device_raii device_guard{rmm::cuda_device_id{_gpu_space->get_device_id()}};
-  rmm::cuda_stream stream{rmm::cuda_stream::flags::non_blocking};
+  const rmm::cuda_stream_view stream = _worker_streams[worker_index];
   while (_running.load(std::memory_order_relaxed)) {
     std::size_t converted = 0;
     try {
-      converted = sweep(stream.view());
+      converted = sweep(stream);
     } catch (const std::exception& e) {
       SIRIUS_LOG_WARN("[memory_prefetcher] sweep error (backing off): {}", e.what());
     }


### PR DESCRIPTION
## Description
Borrow the prefetch worker's CUDA stream from the GPU space pool

The prefetch worker owned its stream, but the batches it converts are dealloc-bound to the stream the conversion ran on and outlive the worker: the loop exits as soon as every connector closes, while converted batches sit in connector queues until a pipeline task consumes them. Destroying the stream there left live buffers naming it, so the eventual cudaFreeAsync ran against a destroyed stream and segfaulted inside the driver. Borrow from the memory space's pool instead, which outlives every batch.

Some more agentic analysis:
A SIGSEGV inside cuMemFreeAsync when scanning a host-pinned, Simpatico-compressed table. Introduced by #1566 (50ad02fd,
  "fix(scan): await async reads before freeing their source memory").

  That PR replaced the prefetcher's member-owned stream pool with a stream owned by the worker function itself:

  -  std::unique_ptr<cucascade::memory::exclusive_stream_pool> _stream_pool;   // member
  ...
  -  auto stream = _stream_pool->acquire_stream();
  +  rmm::cuda_stream stream{rmm::cuda_stream::flags::non_blocking};           // function-local, OWNS it

  The reasoning is stated in the header comment #1566 added:

  ▎ Each worker's private CUDA stream carries no copy traffic (the converter allocates and copies on a pool stream it 
  ▎ acquires internally); it exists only as a stable per-worker key for attaching the admission reservation to the 
  ▎ allocation tracker.

  That holds for cucascade's uncompressed converter — convert_host_fast_to_gpu calls target_memory_space->acquire_stream()
  and binds the resulting buffers to that pool stream, ignoring the caller's. It does not hold for Sirius's compressed
  converter. decompress_host_to_gpu → reconstruct_and_decompress_to_gpu uses the caller's stream throughout, ending in:

  for (auto& c : cols) c = rebind_column_stream(std::move(c), stream);
  return std::make_unique<cucascade::gpu_table_representation>(std::move(decompressed), *space, stream);

  So with pin_table_compression = true, every decoded column's deallocation stream is the prefetch worker's own stream.

  Those batches outlive the worker. sweep() hands them to connector queues, where they wait for a pipeline task, while the
  worker exits as soon as the connectors close:

  if (all_closed) { break; }     // memory_prefetcher.cpp:111

  Returning from worker_loop() runs ~rmm::cuda_stream → cudaStreamDestroy, leaving queued buffers naming a destroyed
  stream. When a task later drops the batch, device_buffer::deallocate_async() calls cudaFreeAsync(ptr, <destroyed 
  stream>) and the driver dereferences a freed internal object:

  #0  0x72e564 in libcuda.so.1        ldrb w1, [x0, #112]   x0 = 0xffc7408b7503  (unaligned garbage)
  #4  cuMemFreeAsync
  #7  rmm::mr::detail::cuda_async_memory_resource_impl::deallocate
  #10 rmm::device_buffer::~device_buffer()
  #11 cucascade::gpu_table_representation::~gpu_table_representation()
  #13 cucascade::data_batch::~data_batch()
  #16 sirius::op::scan::scan_operator_input::~scan_operator_input()
  #17 sirius::pipeline::gpu_pipeline_task::compute_task(...)

  Why it stayed hidden: memory_prefetcher.enable defaults to false (config.hpp:55), and sweep() skips batches already
  resident (get_current_tier() == Tier::GPU), so GPU-tier pinning never converts anything. Only host-tier + compression +
  prefetcher-on hits it — the combination in bench/sf1000-repro/sirius-sf1000.yaml.

## Checklist
- [x] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
<!-- Add open issues with "Closes #issue" to close or "Refs #issue" for reference, and any relevant URLs -->
