### PR TITLE
feat(pipeline): add intra-pipeline fusion matcher (analysis only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,7 @@ set(EXTENSION_SOURCES
     src/pipeline/sirius_pipeline_converter.cpp
     src/pipeline/repository_wiring_materializer.cpp
     src/pipeline/sirius_plan_printer.cpp
+    src/pipeline/fusion_matcher.cpp
     src/pipeline/task_request.cpp
     src/planner/duckdb_join_filter_candidate_adapter.cpp
     src/planner/gpu_admission.cpp
@@ -773,6 +774,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_gpu_pipeline_disk_readback.cpp
     test/cpp/pipeline/test_get_next_ports_after_sink.cpp
     test/cpp/pipeline/test_merge_pipeline_fusion.cpp
+    test/cpp/pipeline/test_fusion_matcher.cpp
     test/cpp/pipeline/test_partition_build_pipelines.cpp
     test/cpp/pipeline/test_pipeline_build_context.cpp
     test/cpp/pipeline/test_pipeline_dynamic_filter_native_shape.cpp

--- a/KERNEL_FUSION_PLAN.md
+++ b/KERNEL_FUSION_PLAN.md
@@ -1,0 +1,90 @@
+# Intra-pipeline kernel fusion: matcher and TPC-H coverage
+
+Question: every `sirius_pipeline` is an ordered operator list executed sequentially by
+`compute_task()`, bounded by pipeline breakers (HASH_JOIN, HASH_GROUP_BY, PARTITION). Adjacent
+operators in that list are separate GPU kernel launches with an intermediate materialization
+between them. Is it worth collapsing straight-line runs of them into a single fused kernel?
+
+`src/pipeline/fusion_matcher.{hpp,cpp}` answers that by measurement rather than design. It is
+static analysis only: it reads the plan and reports which runs of adjacent FILTER/PROJECTION
+operators *could* collapse into one expression evaluation, and logs the report at DEBUG next to
+the plan print in `sirius_engine::initialize_internal`. Nothing executes differently.
+
+**Not to be confused with the existing "pipeline fusion."** `physical-plan-generation.md`'s
+"Merge fusion" (`fuse_merge_pipelines`) folds a MERGE_GROUP_BY/MERGE_TOP_N stage into an adjacent
+pipeline as one more *operator*, saving a task launch and a repository round trip. That is
+task-level fusion. This is about *kernel* launches within a single pipeline's operator list.
+
+## Why the fusability predicate is a separate walk
+
+`cudf_ast_op_count()` looks like the "does this tree lower into a cuDF AST" predicate but cannot
+serve as one: it returns 0 for `reference` and `constant`, which *are* AST-expressible, and it
+counts only the supported prefix of a tree, so a breaker nested under a supported parent is
+invisible in the count. `aggregate::cudf_ast_op_count()` additionally throws. `is_ast_fusable()` /
+`find_ast_breaker()` therefore walk the tree separately, mirroring the AST-mode branch conditions
+in `src/expression_evaluator/specializations/`, and report the first breaker by kind.
+
+## TPC-H coverage
+
+Measured over the 22 canonical TPC-H queries:
+
+| | count |
+|---|---|
+| FILTER + PROJECTION operators in all plans | 17 + 42 = **59** |
+| ...adjacent to another one (i.e. inside a fusable chain) | **12** (6 chains) |
+| ...where the whole chain lowers into one cuDF AST (`ast_clean`) | **4** (2 chains) |
+| queries containing any chain at all | **6 / 22** |
+
+Every chain is exactly length 2, and every one sits at operator index `[1..3)` — directly after
+the source and directly before a pipeline breaker (HASH_GROUP_BY ×3, UNGROUPED_AGGREGATE, TOP_N).
+A chain-level fuser would therefore remove 6 intermediate materializations across the entire
+TPC-H suite, only 2 of which would collapse into a single JIT kernel.
+
+Reproduce with:
+
+```bash
+pixi run build/release/extension/sirius/test/cpp/sirius_unittest "[fusion_matcher]"
+```
+
+## Why the adjacency rate is so low
+
+Roughly 20% of these operators have a fusable neighbour, because the two cases a chain fuser
+would have caught are already handled elsewhere:
+
+- `sirius_physical_filter`'s `output_mask` (`src/include/op/sirius_physical_filter.hpp`) already
+  folds a trailing pure-passthrough projection into the filter's own gather, so the easiest
+  FILTER+PROJECTION pairs never reach the operator list as two operators.
+- Decode-time filter pushdown already fuses scan-side filtering into decompression:
+  `simpatico::decompress_scan_filter(...)` is called from `src/compression/compressed_scan.cpp`,
+  and `DECODE_PUSHDOWN_PLAN.md` records that work.
+
+## Where the leverage actually is
+
+The 4 non-`ast_clean` operators split 2/2 between two breaker kinds:
+
+- `decimal_function` (q1, q19) — DECIMAL-returning arithmetic such as
+  `l_extendedprice * (1 - l_discount)`. `function_call::cudf_ast_op_count()` returns 0 for these
+  pending [rapidsai/cudf#21996](https://github.com/rapidsai/cudf/pull/21996).
+- `unsupported_function` (q7, q8) — a function outside `supported_ast_functions`, which today
+  holds only `{add, sub, mul, div, int_div, mod}`.
+
+Lifting either restriction widens what the *existing* per-operator `AST_JIT` path fuses in every
+query touching such an expression — a far larger surface than the 6 chains a chain-level fuser
+would ever see, and it needs no plan-level machinery.
+
+## Conclusion
+
+A chain-level fuser is not worth building against this workload. The matcher is worth keeping: it
+is the cheap instrument for re-testing that conclusion against a different workload, and its
+breaker histogram is independently useful.
+
+One further finding, for anyone considering a runtime kernel generator here: cuDF already
+maintains a durable on-disk JIT kernel cache at `~/.cudf/<cudf-version>/<sm-arch>/`, with entries
+keyed by `{source digest, sm arch, nvrtc version, nvjitlink version, cache format version}`. Any
+approach built on `cudf::compute_column_jit` inherits cross-process kernel caching for free and
+does not need a separate cache layer such as `simpatico_codegen`'s.
+
+Not measured: the absolute kernel-launch and materialization overhead on TPC-H at realistic scale
+factors. It would size the two levers above, but it is not a gate on the fusion question — however
+large that overhead is, there are only 6 operator pairs in all of TPC-H for a chain fuser to act
+on.

--- a/src/include/pipeline/fusion_matcher.hpp
+++ b/src/include/pipeline/fusion_matcher.hpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "expression/ast/node.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+
+#include <duckdb/common/vector.hpp>
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+/// Intra-pipeline kernel-fusion matcher.
+///
+/// Static analysis only: it reports which runs of adjacent operators inside one
+/// pipeline's operator list *could* be collapsed into a single expression-evaluator
+/// invocation. Nothing here changes the plan or what executes; it measures how much a
+/// fused execution path could win. `KERNEL_FUSION_PLAN.md` records the TPC-H numbers.
+///
+/// Not to be confused with `fuse_merge_pipelines` (task-level merge fusion, see
+/// `docs/super-sirius/physical-plan-generation.md`), which folds a MERGE stage into an
+/// adjacent pipeline as one more operator. This is about *kernel* launches within one
+/// pipeline.
+namespace sirius::pipeline {
+
+/// Why an expression tree cannot be lowered wholly into a cuDF AST. `none` means the
+/// whole tree lowers; every other value names the first breaker found in a pre-order walk.
+enum class ast_breaker {
+  none,
+  case_expr,             ///< CASE/WHEN — always materializes.
+  coalesce,              ///< COALESCE — always materializes (cudf::replace_nulls).
+  unsupported_cast,      ///< CAST to a target outside `supported_ast_cast_types_native`.
+  carrier_cast,          ///< Compressed-materialization restore cast (physical, not semantic).
+  unsupported_function,  ///< Function outside `supported_ast_functions`.
+  decimal_function,      ///< Arithmetic returning DECIMAL — cuDF AST cannot hold the
+                         ///< intermediate (rapidsai/cudf#21996).
+  aggregate,             ///< Aggregate node — never lowers to cuDF AST ops.
+  try_operator,          ///< TRY — no defined lowering.
+  empty_expression       ///< Malformed / no children.
+};
+
+std::string_view to_string(ast_breaker breaker);
+
+/// Why a fusable run stopped growing.
+enum class fusion_stop_reason {
+  end_of_pipeline,  ///< The run reached the sink.
+  operator_kind     ///< The next operator is not a fusable kind (a breaker, join, scan, ...).
+};
+
+/// A maximal run of adjacent fusable operators within one pipeline's operator list.
+struct fusable_chain {
+  std::size_t begin_index      = 0;  ///< First operator index in the run (inclusive).
+  std::size_t end_index        = 0;  ///< One past the last operator index (exclusive).
+  std::size_t filter_count     = 0;
+  std::size_t projection_count = 0;
+  /// True when every expression in every operator of the run lowers wholly into a cuDF AST.
+  /// A run can still be *structurally* fusable when false — the evaluator materializes at
+  /// breakers internally — but only an ast-clean run collapses into one JIT kernel.
+  bool ast_clean                 = true;
+  ast_breaker first_breaker      = ast_breaker::none;
+  fusion_stop_reason stop_reason = fusion_stop_reason::end_of_pipeline;
+  /// Operator type name that terminated the run; empty when `end_of_pipeline`.
+  std::string stop_detail;
+
+  [[nodiscard]] std::size_t length() const noexcept { return end_index - begin_index; }
+};
+
+/// Per-pipeline matcher result.
+struct pipeline_fusion_report {
+  std::size_t pipeline_id    = 0;
+  std::size_t operator_count = 0;
+  /// Maximal fusable runs of length >= 2 only — a run of one is what already happens today.
+  std::vector<fusable_chain> chains;
+};
+
+/// True when `expr` lowers wholly into a cuDF AST (no materialization breaker anywhere in the
+/// tree). Mirrors the AST-mode branch conditions in `src/expression_evaluator/specializations/`.
+[[nodiscard]] bool is_ast_fusable(sirius::ast::node const& expr);
+
+/// The first AST breaker in a pre-order walk of `expr`, or `ast_breaker::none`.
+[[nodiscard]] ast_breaker find_ast_breaker(sirius::ast::node const& expr);
+
+/// Match maximal fusable operator runs in one pipeline.
+[[nodiscard]] pipeline_fusion_report match_fusable_chains(sirius_pipeline const& pipeline);
+
+/// Match every scheduled pipeline. Pipelines with no run of length >= 2 are still reported
+/// (with an empty `chains`) so coverage denominators stay honest.
+[[nodiscard]] std::vector<pipeline_fusion_report> match_fusable_chains(
+  duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> const& pipelines);
+
+/// Human-readable summary of a set of reports, for logging and for the coverage test.
+[[nodiscard]] std::string render_fusion_report(std::vector<pipeline_fusion_report> const& reports);
+
+}  // namespace sirius::pipeline

--- a/src/pipeline/fusion_matcher.cpp
+++ b/src/pipeline/fusion_matcher.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "pipeline/fusion_matcher.hpp"
+
+#include "expression_evaluator/ast_supported_types.hpp"
+#include "op/sirius_physical_filter.hpp"
+#include "op/sirius_physical_operator_type.hpp"
+#include "op/sirius_physical_projection.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <type_traits>
+#include <variant>
+
+namespace sirius::pipeline {
+
+namespace {
+
+using op::SiriusPhysicalOperatorType;
+
+/// Pre-order walk mirroring the AST-mode branch conditions in
+/// `src/expression_evaluator/specializations/`. Returns the first breaker, or `none`.
+ast_breaker walk(sirius::ast::node const& n)
+{
+  auto const first_breaker_of = [](auto const& children) {
+    for (auto const& child : children) {
+      auto const breaker = walk(*child);
+      if (breaker != ast_breaker::none) { return breaker; }
+    }
+    return ast_breaker::none;
+  };
+
+  return std::visit(
+    [&](auto const& alt) -> ast_breaker {
+      using T = std::decay_t<decltype(alt)>;
+
+      if constexpr (std::is_same_v<T, sirius::ast::reference> ||
+                    std::is_same_v<T, sirius::ast::constant>) {
+        return ast_breaker::none;
+      } else if constexpr (std::is_same_v<T, sirius::ast::comparison>) {
+        auto const left = walk(*alt.left);
+        return left != ast_breaker::none ? left : walk(*alt.right);
+      } else if constexpr (std::is_same_v<T, sirius::ast::conjunction>) {
+        if (alt.children.empty()) { return ast_breaker::empty_expression; }
+        return first_breaker_of(alt.children);
+      } else if constexpr (std::is_same_v<T, sirius::ast::between>) {
+        auto breaker = walk(*alt.input);
+        if (breaker != ast_breaker::none) { return breaker; }
+        breaker = walk(*alt.lower);
+        return breaker != ast_breaker::none ? breaker : walk(*alt.upper);
+      } else if constexpr (std::is_same_v<T, sirius::ast::cast>) {
+        // Only semantic casts to a supported target lower into a CAST_TO_* AST op; a
+        // carrier restore is authorized to use the physical-representation tunnel and
+        // must reach the materialized branch.
+        if (alt.kind != sirius::ast::cast_kind::semantic) { return ast_breaker::carrier_cast; }
+        auto const supported =
+          std::find(supported_ast_cast_types_native.begin(),
+                    supported_ast_cast_types_native.end(),
+                    alt.target_type.id()) != supported_ast_cast_types_native.end();
+        if (!supported) { return ast_breaker::unsupported_cast; }
+        return walk(*alt.child);
+      } else if constexpr (std::is_same_v<T, sirius::ast::unary_op>) {
+        if (alt.op == sirius::ast::unary_op::kind::op_try) { return ast_breaker::try_operator; }
+        return walk(*alt.child);
+      } else if constexpr (std::is_same_v<T, sirius::ast::in_list>) {
+        if (alt.values.empty()) { return ast_breaker::empty_expression; }
+        auto const probe = walk(*alt.probe);
+        return probe != ast_breaker::none ? probe : first_breaker_of(alt.values);
+      } else if constexpr (std::is_same_v<T, sirius::ast::function_call>) {
+        // cuDF AST chokes on intermediate DECIMAL results, and only the arithmetic set
+        // lowers at all — mirrors function_call::cudf_ast_op_count().
+        if (alt.return_type().id() == sirius::type_id::DECIMAL) {
+          return ast_breaker::decimal_function;
+        }
+        auto const supported = std::find(supported_ast_functions.begin(),
+                                         supported_ast_functions.end(),
+                                         alt.function()) != supported_ast_functions.end();
+        if (!supported) { return ast_breaker::unsupported_function; }
+        return first_breaker_of(alt.arguments());
+      } else if constexpr (std::is_same_v<T, sirius::ast::case_expr>) {
+        return ast_breaker::case_expr;
+      } else if constexpr (std::is_same_v<T, sirius::ast::coalesce>) {
+        return ast_breaker::coalesce;
+      } else {
+        // sirius::ast::aggregate — never lowers, and its cudf_ast_op_count() throws.
+        return ast_breaker::aggregate;
+      }
+    },
+    n.v);
+}
+
+/// Whether `op` is a kind this matcher knows how to fold into a neighbouring operator's
+/// expression evaluation. Deliberately narrow: FILTER and PROJECTION are the two operators
+/// that do nothing but drive `expression_evaluator` over their input batches.
+bool is_fusable_kind(SiriusPhysicalOperatorType type)
+{
+  return type == SiriusPhysicalOperatorType::FILTER ||
+         type == SiriusPhysicalOperatorType::PROJECTION;
+}
+
+/// The first breaker across every expression the operator evaluates.
+/// The parameter is deliberately not named `op` — that would shadow the `sirius::op`
+/// namespace the qualified type names below resolve through.
+ast_breaker operator_breaker(op::sirius_physical_operator const& oper)
+{
+  if (oper.type == SiriusPhysicalOperatorType::FILTER) {
+    auto const& filter = oper.Cast<op::sirius_physical_filter>();
+    return filter.expression == nullptr ? ast_breaker::empty_expression : walk(*filter.expression);
+  }
+  auto const& projection = oper.Cast<op::sirius_physical_projection>();
+  if (projection.select_list.empty()) { return ast_breaker::empty_expression; }
+  for (auto const& expr : projection.select_list) {
+    auto const breaker = walk(*expr);
+    if (breaker != ast_breaker::none) { return breaker; }
+  }
+  return ast_breaker::none;
+}
+
+}  // namespace
+
+std::string_view to_string(ast_breaker breaker)
+{
+  switch (breaker) {
+    case ast_breaker::none: return "none";
+    case ast_breaker::case_expr: return "case";
+    case ast_breaker::coalesce: return "coalesce";
+    case ast_breaker::unsupported_cast: return "unsupported_cast";
+    case ast_breaker::carrier_cast: return "carrier_cast";
+    case ast_breaker::unsupported_function: return "unsupported_function";
+    case ast_breaker::decimal_function: return "decimal_function";
+    case ast_breaker::aggregate: return "aggregate";
+    case ast_breaker::try_operator: return "try";
+    case ast_breaker::empty_expression: return "empty_expression";
+  }
+  return "unknown";
+}
+
+bool is_ast_fusable(sirius::ast::node const& expr) { return walk(expr) == ast_breaker::none; }
+
+ast_breaker find_ast_breaker(sirius::ast::node const& expr) { return walk(expr); }
+
+pipeline_fusion_report match_fusable_chains(sirius_pipeline const& pipeline)
+{
+  pipeline_fusion_report report;
+  report.pipeline_id = pipeline.get_pipeline_id();
+
+  auto const operators  = pipeline.get_operators();
+  report.operator_count = operators.size();
+
+  for (std::size_t i = 0; i < operators.size();) {
+    if (!is_fusable_kind(operators[i].get().type)) {
+      i++;
+      continue;
+    }
+
+    fusable_chain chain;
+    chain.begin_index = i;
+    std::size_t j     = i;
+    for (; j < operators.size() && is_fusable_kind(operators[j].get().type); j++) {
+      auto const& oper = operators[j].get();
+      if (oper.type == SiriusPhysicalOperatorType::FILTER) {
+        chain.filter_count++;
+      } else {
+        chain.projection_count++;
+      }
+      if (chain.ast_clean) {
+        auto const breaker = operator_breaker(oper);
+        if (breaker != ast_breaker::none) {
+          chain.ast_clean     = false;
+          chain.first_breaker = breaker;
+        }
+      }
+    }
+    chain.end_index = j;
+    if (j < operators.size()) {
+      chain.stop_reason = fusion_stop_reason::operator_kind;
+      chain.stop_detail = op::SiriusPhysicalOperatorToString(operators[j].get().type);
+    } else {
+      chain.stop_reason = fusion_stop_reason::end_of_pipeline;
+    }
+
+    // A run of one is what already executes today — only report real fusion candidates.
+    if (chain.length() >= 2) { report.chains.push_back(std::move(chain)); }
+    i = j;  // j > i: the loop consumed at least the operator at i.
+  }
+
+  return report;
+}
+
+std::vector<pipeline_fusion_report> match_fusable_chains(
+  duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> const& pipelines)
+{
+  std::vector<pipeline_fusion_report> reports;
+  reports.reserve(pipelines.size());
+  for (auto const& pipeline : pipelines) {
+    if (!pipeline) { continue; }
+    reports.push_back(match_fusable_chains(*pipeline));
+  }
+  return reports;
+}
+
+std::string render_fusion_report(std::vector<pipeline_fusion_report> const& reports)
+{
+  std::size_t total_chains     = 0;
+  std::size_t ast_clean_chains = 0;
+  std::size_t fused_operators  = 0;
+
+  std::ostringstream out;
+  for (auto const& report : reports) {
+    for (auto const& chain : report.chains) {
+      total_chains++;
+      fused_operators += chain.length();
+      if (chain.ast_clean) { ast_clean_chains++; }
+      out << "  pipeline " << report.pipeline_id << ": ops [" << chain.begin_index << ".."
+          << chain.end_index << ") len=" << chain.length() << " filters=" << chain.filter_count
+          << " projections=" << chain.projection_count
+          << (chain.ast_clean ? " ast_clean" : " breaker=");
+      if (!chain.ast_clean) { out << to_string(chain.first_breaker); }
+      out << " stopped_by="
+          << (chain.stop_reason == fusion_stop_reason::end_of_pipeline ? "end_of_pipeline"
+                                                                       : chain.stop_detail)
+          << "\n";
+    }
+  }
+
+  std::ostringstream header;
+  header << "fusion matcher: " << total_chains << " candidate chain(s) across " << reports.size()
+         << " pipeline(s); " << ast_clean_chains << " ast-clean; " << fused_operators
+         << " operator(s) inside a chain\n";
+  return header.str() + out.str();
+}
+
+}  // namespace sirius::pipeline

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -29,6 +29,7 @@
 #include "op/sirius_physical_operator_type.hpp"
 #include "op/sirius_physical_partition.hpp"
 #include "op/sirius_physical_result_collector.hpp"
+#include "pipeline/fusion_matcher.hpp"
 #include "pipeline/repository_wiring.hpp"
 #include "pipeline/sirius_pipeline_converter.hpp"
 #include "pipeline/sirius_plan_printer.hpp"
@@ -315,6 +316,11 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
   // Auto-log the enriched query plan
   pipeline::sirius_plan_printer plan_printer(new_scheduled);
   SIRIUS_LOG_INFO("Query Plan:\n{}", plan_printer.render());
+
+  // Static probe: which adjacent FILTER/PROJECTION runs could collapse into a single
+  // expression evaluation. Analysis only — it does not change what executes.
+  SIRIUS_LOG_DEBUG("{}",
+                   pipeline::render_fusion_report(pipeline::match_fusable_chains(new_scheduled)));
 }
 
 }  // namespace sirius

--- a/test/cpp/pipeline/test_fusion_matcher.cpp
+++ b/test/cpp/pipeline/test_fusion_matcher.cpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_fusion_matcher.cpp
+ * @brief Expression-level and pipeline-level tests for the intra-pipeline fusion matcher,
+ *        plus a TPC-H coverage probe that reports how many adjacent FILTER/PROJECTION runs
+ *        the 22 canonical queries actually contain.
+ */
+
+#include "expression/ast/node.hpp"
+#include "op/sirius_physical_operator_type.hpp"
+#include "pipeline/fusion_matcher.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "pipeline/sirius_pipeline_converter.hpp"
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <utils/pipeline_conversion_test_utils.hpp>
+#include <utils/sirius_test_env.hpp>
+
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+using sirius::pipeline::ast_breaker;
+using sirius::pipeline::find_ast_breaker;
+using sirius::pipeline::is_ast_fusable;
+using sirius::pipeline::match_fusable_chains;
+using sirius::pipeline::pipeline_conversion_result;
+
+namespace {
+
+std::unique_ptr<sirius::ast::node> make_node(auto&& alt)
+{
+  return std::make_unique<sirius::ast::node>(std::forward<decltype(alt)>(alt));
+}
+
+std::unique_ptr<sirius::ast::node> col(uint32_t index, sirius::type_id id = sirius::type_id::BIGINT)
+{
+  return make_node(sirius::ast::reference{index, sirius::logical_type::make(id)});
+}
+
+//! `left < right` — the canonical ast-clean predicate shape.
+std::unique_ptr<sirius::ast::node> comparison_of(std::unique_ptr<sirius::ast::node> left,
+                                                 std::unique_ptr<sirius::ast::node> right)
+{
+  sirius::ast::comparison cmp;
+  cmp.op    = sirius::comparison_type::lt;
+  cmp.left  = std::move(left);
+  cmp.right = std::move(right);
+  return make_node(std::move(cmp));
+}
+
+fs::path integration_data_dir()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return fs::path(SIRIUS_PROJECT_ROOT) / "test/cpp/integration/data";
+#else
+  return fs::path(__FILE__).parent_path().parent_path() / "integration/data";
+#endif
+}
+
+}  // namespace
+
+TEST_CASE("fusion matcher: leaves and arithmetic lower wholly into a cuDF AST", "[fusion_matcher]")
+{
+  CHECK(is_ast_fusable(*col(0)));
+  CHECK(is_ast_fusable(*comparison_of(col(0), col(1))));
+
+  sirius::ast::conjunction conj;
+  conj.op = sirius::ast::conjunction::kind::op_and;
+  conj.children.push_back(comparison_of(col(0), col(1)));
+  conj.children.push_back(comparison_of(col(2), col(3)));
+  CHECK(is_ast_fusable(sirius::ast::node{std::move(conj)}));
+
+  sirius::ast::between btw;
+  btw.input = col(0);
+  btw.lower = col(1);
+  btw.upper = col(2);
+  CHECK(is_ast_fusable(sirius::ast::node{std::move(btw)}));
+}
+
+TEST_CASE("fusion matcher: breakers are reported by kind", "[fusion_matcher]")
+{
+  SECTION("CASE never lowers")
+  {
+    sirius::ast::case_expr::when_then branch;
+    branch.when_ = comparison_of(col(0), col(1));
+    branch.then_ = col(2);
+    std::vector<sirius::ast::case_expr::when_then> cases;
+    cases.push_back(std::move(branch));
+    sirius::ast::node n{sirius::ast::case_expr{
+      std::move(cases), col(3), sirius::logical_type::make(sirius::type_id::BIGINT)}};
+    CHECK_FALSE(is_ast_fusable(n));
+    CHECK(find_ast_breaker(n) == ast_breaker::case_expr);
+  }
+
+  SECTION("COALESCE never lowers")
+  {
+    std::vector<std::unique_ptr<sirius::ast::node>> children;
+    children.push_back(col(0));
+    children.push_back(col(1));
+    sirius::ast::node n{sirius::ast::coalesce{std::move(children),
+                                              sirius::logical_type::make(sirius::type_id::BIGINT)}};
+    CHECK_FALSE(is_ast_fusable(n));
+    CHECK(find_ast_breaker(n) == ast_breaker::coalesce);
+  }
+
+  SECTION("CAST to a supported target lowers; VARCHAR does not")
+  {
+    sirius::ast::cast supported;
+    supported.child       = col(0, sirius::type_id::INTEGER);
+    supported.target_type = sirius::logical_type::make(sirius::type_id::DOUBLE);
+    supported.kind        = sirius::ast::cast_kind::semantic;
+    CHECK(is_ast_fusable(sirius::ast::node{std::move(supported)}));
+
+    sirius::ast::cast unsupported;
+    unsupported.child       = col(0, sirius::type_id::INTEGER);
+    unsupported.target_type = sirius::logical_type::make(sirius::type_id::VARCHAR);
+    unsupported.kind        = sirius::ast::cast_kind::semantic;
+    sirius::ast::node n{std::move(unsupported)};
+    CHECK_FALSE(is_ast_fusable(n));
+    CHECK(find_ast_breaker(n) == ast_breaker::unsupported_cast);
+  }
+
+  SECTION("a carrier restore must reach the materialize path")
+  {
+    sirius::ast::cast restore;
+    restore.child       = col(0, sirius::type_id::INTEGER);
+    restore.target_type = sirius::logical_type::make(sirius::type_id::BIGINT);
+    restore.kind        = sirius::ast::cast_kind::carrier_restore;
+    sirius::ast::node n{std::move(restore)};
+    CHECK_FALSE(is_ast_fusable(n));
+    CHECK(find_ast_breaker(n) == ast_breaker::carrier_cast);
+  }
+
+  SECTION("a breaker nested under a fusable parent still breaks the whole tree")
+  {
+    std::vector<std::unique_ptr<sirius::ast::node>> children;
+    children.push_back(col(0));
+    children.push_back(col(1));
+    auto nested = make_node(sirius::ast::coalesce{
+      std::move(children), sirius::logical_type::make(sirius::type_id::BIGINT)});
+    auto n      = comparison_of(std::move(nested), col(2));
+    CHECK_FALSE(is_ast_fusable(*n));
+    CHECK(find_ast_breaker(*n) == ast_breaker::coalesce);
+  }
+}
+
+//! Coverage probe: how many adjacent FILTER/PROJECTION runs do the canonical TPC-H queries
+//! actually produce? Reports rather than gates — the numbers decide whether a fused
+//! execution path is worth building at all.
+TEST_CASE("fusion matcher: TPC-H chain coverage", "[integration][pipeline][fusion_matcher]")
+{
+  REQUIRE(sirius::test::g_integration_env != nullptr);
+  if (!sirius::test::g_integration_env->is_active()) { sirius::test::g_integration_env->resume(); }
+  auto con = sirius::test::g_integration_env->make_connection();
+
+  auto db_path = integration_data_dir() / "duckdb/integration.duckdb";
+  REQUIRE(fs::exists(db_path));
+  auto r = con.Query("ATTACH IF NOT EXISTS '" + db_path.string() + "' AS tpch (READ_ONLY);");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
+  r = con.Query("USE tpch;");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
+
+  std::size_t total_chains       = 0;
+  std::size_t ast_clean_chains   = 0;
+  std::size_t queries_with_chain = 0;
+  // Denominators: without these the chain count is uninterpretable — a low count could mean
+  // "few FILTER/PROJECTION operators exist" or "they exist but are never adjacent".
+  std::size_t total_filters     = 0;
+  std::size_t total_projections = 0;
+
+  for (int q = 1; q <= 22; ++q) {
+    sirius::test::with_conversion_result(
+      con, sirius::test::read_tpch_query_file(q), [&](pipeline_conversion_result& result) {
+        auto const reports      = match_fusable_chains(result.scheduled_pipelines);
+        std::size_t chains_here = 0;
+        for (auto const& pipeline : result.scheduled_pipelines) {
+          for (auto const& oper : pipeline->get_operators()) {
+            if (oper.get().type == sirius::op::SiriusPhysicalOperatorType::FILTER) {
+              total_filters++;
+            } else if (oper.get().type == sirius::op::SiriusPhysicalOperatorType::PROJECTION) {
+              total_projections++;
+            }
+          }
+        }
+        for (auto const& report : reports) {
+          for (auto const& chain : report.chains) {
+            // Structural invariants of every reported chain.
+            INFO("q" << q << " pipeline " << report.pipeline_id);
+            CHECK(chain.length() >= 2);
+            CHECK(chain.end_index <= report.operator_count);
+            CHECK(chain.filter_count + chain.projection_count == chain.length());
+            chains_here++;
+            if (chain.ast_clean) { ast_clean_chains++; }
+          }
+        }
+        total_chains += chains_here;
+        if (chains_here > 0) {
+          queries_with_chain++;
+          std::cout << "[fusion_matcher] q" << q << "\n"
+                    << sirius::pipeline::render_fusion_report(reports);
+        }
+      });
+  }
+
+  std::cout << "[fusion_matcher] TPC-H total: " << total_chains << " candidate chain(s), "
+            << ast_clean_chains << " ast-clean, in " << queries_with_chain << "/22 queries; "
+            << total_filters << " FILTER + " << total_projections
+            << " PROJECTION operator(s) exist in total\n";
+}


### PR DESCRIPTION
Adds a static analysis pass that reports which runs of adjacent FILTER/ PROJECTION operators inside one pipeline could collapse into a single expression evaluation. Nothing executes differently: the matcher only reads the plan and logs a report at DEBUG next to the existing plan print.

- `is_ast_fusable()` / `find_ast_breaker()` walk a `sirius::ast::node`, mirroring the AST-mode branch conditions in the evaluator specializations. `cudf_ast_op_count()` cannot serve as this predicate: it returns 0 for `reference`/`constant` (which are AST-expressible) and counts only a tree's supported prefix, so it cannot distinguish a leaf from a breaker.
- `match_fusable_chains()` collects maximal fusable runs per pipeline.

Measured over the 22 canonical TPC-H queries: 59 FILTER/PROJECTION operators exist, only 12 are adjacent to another (6 chains, all length 2), and only 4 lower wholly into one cuDF AST. The adjacency rate is low because the filter's `output_mask` already folds trailing passthrough projections into its gather, and decode pushdown already fuses scan-side filtering.

The breaker histogram is the useful output: the 4 non-clean operators split 2/2 between DECIMAL-returning arithmetic (blocked on rapidsai/cudf#21996) and functions outside `supported_ast_functions`. Widening either helps the existing per-operator AST_JIT path across every query.

KERNEL_FUSION_PLAN.md records the coverage table and concludes that a chain-level fuser is not worth building against this workload.

<!-- Edit PR title: "<type>[optional scope]: <short description>", see CONTRIBUTING.md for guidance -->

## Description
<!-- Provide a standalone description of changes in this PR -->
<!-- For design docs targeting docs/experimental, note this in the description -->

## Checklist
- [ ] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
<!-- Add open issues with "Closes #issue" to close or "Refs #issue" for reference, and any relevant URLs -->
