### PR TITLE
fix(pipeline): don't abort the process when task completion throws

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,6 +790,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_gpu_pipeline_executor.cpp
     test/cpp/pipeline/test_oom_reschedule.cpp
     test/cpp/pipeline/test_pipeline_memory_history.cpp
+    test/cpp/pipeline/test_gpu_pipeline_task_finalize_throw.cpp
     test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
     test/cpp/pipeline/test_gpu_pipeline_disk_readback.cpp
     test/cpp/pipeline/test_get_next_ports_after_sink.cpp

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -383,7 +383,24 @@ void task_creator::manager_loop()
       visited_pipelines.erase(std::unique(visited_pipelines.begin(), visited_pipelines.end()),
                               visited_pipelines.end());
       for (auto& visited : visited_pipelines) {
-        visited->update_pipeline_status(false);
+        // update_pipeline_status() runs finalize_operator() device work that can throw, and an
+        // exception escaping this thread is std::terminate. Unlike the dispatch-lambda catch
+        // below, stop() must not be called here — it joins this very thread.
+        try {
+          visited->update_pipeline_status(false);
+        } catch (const std::exception& e) {
+          SIRIUS_LOG_ERROR("Task Creator: pipeline {} threw while re-evaluating its status: {}",
+                           visited->get_pipeline_id(),
+                           e.what());
+          _task_scheduler->terminate_query(std::current_exception());
+          break;
+        } catch (...) {
+          SIRIUS_LOG_ERROR(
+            "Task Creator: pipeline {} threw a non-std exception while re-evaluating its status",
+            visited->get_pipeline_id());
+          _task_scheduler->terminate_query(std::current_exception());
+          break;
+        }
       }
       continue;
     }

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -192,13 +192,6 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
   const sirius_pipeline* get_pipeline() const;
 
   /**
-   * @brief Get the GPU pipeline associated with this task, for mutation.
-   *
-   * @return sirius_pipeline* Pointer to the GPU pipeline
-   */
-  sirius_pipeline* get_pipeline();
-
-  /**
    * @brief Compute and return the output data batches for this task.
    *
    * Executes the GPU pipeline on the input batches and returns the computed results.

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -192,6 +192,13 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
   const sirius_pipeline* get_pipeline() const;
 
   /**
+   * @brief Get the GPU pipeline associated with this task, for mutation.
+   *
+   * @return sirius_pipeline* Pointer to the GPU pipeline
+   */
+  sirius_pipeline* get_pipeline();
+
+  /**
    * @brief Compute and return the output data batches for this task.
    *
    * Executes the GPU pipeline on the input batches and returns the computed results.

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -195,11 +195,20 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   void mark_task_completed();
 
   //! Park an exception that escaped mark_task_completed(), for whoever destroyed the task to
-  //! claim. Only the first is kept; later ones are symptoms of it.
+  //! observe. Only the first is kept; later ones are symptoms of it.
   void record_task_completion_error(std::exception_ptr error) noexcept;
 
-  //! Remove and return the parked error, or nullptr if there is none.
-  [[nodiscard]] std::exception_ptr take_task_completion_error() noexcept;
+  //! One locked snapshot of pipeline_finished plus any parked completion error.
+  struct completion_status {
+    bool finished = false;
+    std::exception_ptr error;
+  };
+
+  //! update_pipeline_status() parks a finalize throw in the same _status_mutex critical section
+  //! that flips pipeline_finished, and this reads both under that mutex: an observer can never
+  //! see the pipeline finished without also seeing the error. The error stays parked
+  //! (report_error is first-wins downstream), so every observer sees it.
+  [[nodiscard]] completion_status get_completion_status() const noexcept;
 
   //! Observers for the per-pipeline task counters (testing / diagnostics).
   [[nodiscard]] std::size_t get_tasks_created() const { return tasks_created.load(); }
@@ -283,9 +292,8 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   std::atomic<std::size_t> tasks_created   = 0;
   std::atomic<std::size_t> tasks_completed = 0;
 
-  //! First exception that escaped mark_task_completed(), waiting to be claimed. Not guarded by
-  //! _status_mutex: it is recorded while unwinding out of that lock.
-  std::mutex _task_completion_error_mutex;
+  //! First exception that escaped mark_task_completed(). Guarded by _status_mutex so it is
+  //! recorded atomically with the pipeline_finished flip it may have interrupted.
   std::exception_ptr _task_completion_error;
 
   //! NVTX process-wide range tracking the pipeline's active lifetime

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -27,6 +27,7 @@
 
 #include <nvtx3/nvtx3.hpp>
 
+#include <exception>
 #include <mutex>
 #include <utility>
 #include <vector>
@@ -193,6 +194,13 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   void mark_task_created();
   void mark_task_completed();
 
+  //! Park an exception that escaped mark_task_completed(), for whoever destroyed the task to
+  //! claim. Only the first is kept; later ones are symptoms of it.
+  void record_task_completion_error(std::exception_ptr error) noexcept;
+
+  //! Remove and return the parked error, or nullptr if there is none.
+  [[nodiscard]] std::exception_ptr take_task_completion_error() noexcept;
+
   //! Observers for the per-pipeline task counters (testing / diagnostics).
   [[nodiscard]] std::size_t get_tasks_created() const { return tasks_created.load(); }
   [[nodiscard]] std::size_t get_tasks_completed() const { return tasks_completed.load(); }
@@ -274,6 +282,11 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
 
   std::atomic<std::size_t> tasks_created   = 0;
   std::atomic<std::size_t> tasks_completed = 0;
+
+  //! First exception that escaped mark_task_completed(), waiting to be claimed. Not guarded by
+  //! _status_mutex: it is recorded while unwinding out of that lock.
+  std::mutex _task_completion_error_mutex;
+  std::exception_ptr _task_completion_error;
 
   //! NVTX process-wide range tracking the pipeline's active lifetime
   std::atomic<bool> _nvtx_range_started{false};

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -440,6 +440,22 @@ void gpu_pipeline_executor::manager_loop()
         }
         task.reset();
 
+        // ~gpu_pipeline_task is noexcept, so a throw out of mark_task_completed() above is
+        // parked on the pipeline rather than propagated. Claim it here, the first frame that can
+        // still reach the completion handler: a throw raised before update_pipeline_status()
+        // flips pipeline_finished leaves nobody able to finish the pipeline, so only failing the
+        // query keeps it from waiting forever.
+        if (pipeline) {
+          if (auto completion_error = pipeline->take_task_completion_error()) {
+            SIRIUS_LOG_ERROR(
+              "GPU Pipeline Executor: pipeline {} failed while completing a task; failing the "
+              "query",
+              pipeline->get_pipeline_id());
+            if (_completion_handler) { _completion_handler->report_error(completion_error); }
+            return;
+          }
+        }
+
         // Check if query is complete BEFORE scheduling downstream tasks.
         // mark_completed() signals the future that engine.execute() is waiting on,
         // which may destroy the engine and its operators. We must not schedule

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -235,6 +235,20 @@ void gpu_pipeline_executor::manager_loop()
         SIRIUS_LOG_INFO("GPU Pipeline Executor: downgrade request cancelled for task {}: {}",
                         gpu_task->get_task_id(),
                         e.what());
+        // This break leaves the manager loop, so no epilogue will run for this task: destroy it
+        // now and fail the query if its completion parked an error nobody else would observe.
+        const auto* task_pipeline = gpu_task->get_pipeline();
+        gpu_task                  = nullptr;
+        pipeline_task.reset();
+        if (task_pipeline) {
+          if (auto completion = task_pipeline->get_completion_status(); completion.error) {
+            SIRIUS_LOG_ERROR(
+              "GPU Pipeline Executor: pipeline {} failed while completing a cancelled task; "
+              "failing the query",
+              task_pipeline->get_pipeline_id());
+            if (_completion_handler) { _completion_handler->report_error(completion.error); }
+          }
+        }
         break;
       }
 
@@ -441,19 +455,20 @@ void gpu_pipeline_executor::manager_loop()
         task.reset();
 
         // ~gpu_pipeline_task is noexcept, so a throw out of mark_task_completed() above is
-        // parked on the pipeline rather than propagated. Claim it here, the first frame that can
-        // still reach the completion handler: a throw raised before update_pipeline_status()
-        // flips pipeline_finished leaves nobody able to finish the pipeline, so only failing the
-        // query keeps it from waiting forever.
-        if (pipeline) {
-          if (auto completion_error = pipeline->take_task_completion_error()) {
-            SIRIUS_LOG_ERROR(
-              "GPU Pipeline Executor: pipeline {} failed while completing a task; failing the "
-              "query",
-              pipeline->get_pipeline_id());
-            if (_completion_handler) { _completion_handler->report_error(completion_error); }
-            return;
-          }
+        // parked on the pipeline rather than propagated. Read it here, the first frame that can
+        // still reach the completion handler: a pre-flip throw leaves nobody able to finish the
+        // pipeline, so only failing the query keeps it from waiting forever. The snapshot pairs
+        // pipeline_finished with the parked error, so a sibling task's finalize failure can
+        // never lose to the completion this epilogue would otherwise signal.
+        sirius_pipeline::completion_status completion;
+        if (pipeline) { completion = pipeline->get_completion_status(); }
+        if (completion.error) {
+          SIRIUS_LOG_ERROR(
+            "GPU Pipeline Executor: pipeline {} failed while completing a task; failing the "
+            "query",
+            pipeline->get_pipeline_id());
+          if (_completion_handler) { _completion_handler->report_error(completion.error); }
+          return;
         }
 
         // Check if query is complete BEFORE scheduling downstream tasks.
@@ -462,7 +477,7 @@ void gpu_pipeline_executor::manager_loop()
         // tasks that reference those operators after signaling completion.
         bool query_complete = false;
         if (_completion_handler && pipeline && pipeline->is_query_terminal()) {
-          query_complete = pipeline->is_pipeline_finished();
+          query_complete = completion.finished;
         }
 
         if (!query_complete && _task_creator) {

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -320,14 +320,41 @@ gpu_pipeline_task::~gpu_pipeline_task()
   }
   _subscribed_batches.clear();
 
-  if (_global_state == nullptr ||
-      _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline() == nullptr) {
-    return;
+  if (_global_state == nullptr) { return; }
+  auto* pipeline = _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline();
+  if (pipeline == nullptr) { return; }
+
+  // mark_task_completed() runs finalize_operator() on every operator — device work that throws
+  // (the hash join frees cuco tables there). This destructor is implicitly noexcept, so letting
+  // that escape is std::terminate: the whole process aborts on a failed query. Park it on the
+  // pipeline instead; gpu_pipeline_executor claims it and fails the query through the completion
+  // handler, which a destructor cannot reach.
+  try {
+    pipeline->mark_task_completed();
+  } catch (const std::exception& e) {
+    SIRIUS_LOG_ERROR(
+      "gpu_pipeline_task: pipeline {} threw while completing task {}; failing the query instead "
+      "of aborting the process: {}",
+      pipeline->get_pipeline_id(),
+      get_task_id(),
+      e.what());
+    pipeline->record_task_completion_error(std::current_exception());
+  } catch (...) {
+    SIRIUS_LOG_ERROR(
+      "gpu_pipeline_task: pipeline {} threw a non-std exception while completing task {}; "
+      "failing the query instead of aborting the process",
+      pipeline->get_pipeline_id(),
+      get_task_id());
+    pipeline->record_task_completion_error(std::current_exception());
   }
-  _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline()->mark_task_completed();
 }
 
 const sirius_pipeline* gpu_pipeline_task::get_pipeline() const
+{
+  return _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline();
+}
+
+sirius_pipeline* gpu_pipeline_task::get_pipeline()
 {
   return _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline();
 }

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -354,11 +354,6 @@ const sirius_pipeline* gpu_pipeline_task::get_pipeline() const
   return _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline();
 }
 
-sirius_pipeline* gpu_pipeline_task::get_pipeline()
-{
-  return _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline();
-}
-
 std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_stream_view stream)
 {
   auto pipeline     = _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline();

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -391,40 +391,50 @@ void sirius_pipeline::update_pipeline_status(bool original_pipeline)
     if (pipeline_finished.load()) {
       should_notify = true;
     } else {
-      op::sirius_physical_operator* first_node =
-        operators.size() > 0 ? &operators[0].get() : (sink ? sink.get() : nullptr);
-      if (first_node == nullptr) { throw internal_exception("First node of pipeline is nullptr"); }
-      // Check if any operator has exhausted its limit — this allows the pipeline to finish
-      // early without waiting for the source pipeline to drain all remaining batches.
-      bool limit_exhausted = false;
-      for (auto& op_ref : operators) {
-        if (op_ref.get().is_limit_exhausted()) {
-          limit_exhausted = true;
-          break;
+      try {
+        op::sirius_physical_operator* first_node =
+          operators.size() > 0 ? &operators[0].get() : (sink ? sink.get() : nullptr);
+        if (first_node == nullptr) {
+          throw internal_exception("First node of pipeline is nullptr");
         }
-      }
-      // Source-exhaustion conjunct: the task
-      // counters can be transiently balanced (0==0 before the first split
-      // arrives, or all-done-before-close), so finishing additionally requires
-      // the pipeline's SOURCE MEMBER — get_operators()/first_node excludes it —
-      // to be past the point where it could ever create another task. For a GPU
-      // scan source, all_ports_empty() is split_connector::is_closed() (closed
-      // AND drained); port-less sources are trivially exhausted. limit_exhausted
-      // keeps its early exit: it finishes without draining the source.
-      bool source_exhausted =
-        !source || (source->is_source_pipeline_finished() && source->all_ports_empty());
-      if (limit_exhausted || (source_exhausted && first_node->is_source_pipeline_finished() &&
-                              first_node->all_ports_empty())) {
-        if (tasks_created.load() == tasks_completed.load()) {
-          pipeline_finished.store(true);
-          for (auto& op : get_operators()) {
-            op.get().finalize_operator();
+        // Check if any operator has exhausted its limit — this allows the pipeline to finish
+        // early without waiting for the source pipeline to drain all remaining batches.
+        bool limit_exhausted = false;
+        for (auto& op_ref : operators) {
+          if (op_ref.get().is_limit_exhausted()) {
+            limit_exhausted = true;
+            break;
           }
-          end_nvtx_range_if_finished();
-          should_notify = true;
         }
+        // Source-exhaustion conjunct: the task
+        // counters can be transiently balanced (0==0 before the first split
+        // arrives, or all-done-before-close), so finishing additionally requires
+        // the pipeline's SOURCE MEMBER — get_operators()/first_node excludes it —
+        // to be past the point where it could ever create another task. For a GPU
+        // scan source, all_ports_empty() is split_connector::is_closed() (closed
+        // AND drained); port-less sources are trivially exhausted. limit_exhausted
+        // keeps its early exit: it finishes without draining the source.
+        bool source_exhausted =
+          !source || (source->is_source_pipeline_finished() && source->all_ports_empty());
+        if (limit_exhausted || (source_exhausted && first_node->is_source_pipeline_finished() &&
+                                first_node->all_ports_empty())) {
+          if (tasks_created.load() == tasks_completed.load()) {
+            pipeline_finished.store(true);
+            for (auto& op : get_operators()) {
+              op.get().finalize_operator();
+            }
+            end_nvtx_range_if_finished();
+            should_notify = true;
+          }
+        }
+        if (!pipeline_finished.load()) { end_nvtx_range_if_finished(); }
+      } catch (...) {
+        // Park while still holding _status_mutex, the critical section that may have just
+        // flipped pipeline_finished: a status snapshot that sees the flip then also sees this
+        // error, so no sibling task's epilogue can report the query successful ahead of it.
+        if (!_task_completion_error) { _task_completion_error = std::current_exception(); }
+        throw;
       }
-      if (!pipeline_finished.load()) { end_nvtx_range_if_finished(); }
     }
   }  // _status_mutex released here — notify_downstream_pipelines must run outside the lock
      // to avoid holding the child pipeline mutex while acquiring a parent's
@@ -491,14 +501,14 @@ void sirius_pipeline::mark_task_completed()
 void sirius_pipeline::record_task_completion_error(std::exception_ptr error) noexcept
 {
   if (!error) { return; }
-  std::lock_guard<std::mutex> lock(_task_completion_error_mutex);
+  std::lock_guard<std::mutex> lock(_status_mutex);
   if (!_task_completion_error) { _task_completion_error = std::move(error); }
 }
 
-std::exception_ptr sirius_pipeline::take_task_completion_error() noexcept
+sirius_pipeline::completion_status sirius_pipeline::get_completion_status() const noexcept
 {
-  std::lock_guard<std::mutex> lock(_task_completion_error_mutex);
-  return std::exchange(_task_completion_error, nullptr);
+  std::lock_guard<std::mutex> lock(_status_mutex);
+  return {pipeline_finished.load(), _task_completion_error};
 }
 
 std::vector<op::sirius_physical_operator*> sirius_pipeline::get_output_consumers() const

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -488,6 +488,19 @@ void sirius_pipeline::mark_task_completed()
   update_pipeline_status();
 }
 
+void sirius_pipeline::record_task_completion_error(std::exception_ptr error) noexcept
+{
+  if (!error) { return; }
+  std::lock_guard<std::mutex> lock(_task_completion_error_mutex);
+  if (!_task_completion_error) { _task_completion_error = std::move(error); }
+}
+
+std::exception_ptr sirius_pipeline::take_task_completion_error() noexcept
+{
+  std::lock_guard<std::mutex> lock(_task_completion_error_mutex);
+  return std::exchange(_task_completion_error, nullptr);
+}
+
 std::vector<op::sirius_physical_operator*> sirius_pipeline::get_output_consumers() const
 {
   auto parents = get_parents();

--- a/test/cpp/pipeline/test_gpu_pipeline_task_finalize_throw.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_task_finalize_throw.cpp
@@ -142,11 +142,13 @@ TEST_CASE("a finalize throw in the task destructor does not abort, and completio
   CHECK(pipeline->get_tasks_created() == 1);
   CHECK(pipeline->get_tasks_completed() == 1);
 
-  // The error is parked for whoever destroyed the task, and is handed out exactly once.
-  auto parked = pipeline->take_task_completion_error();
-  REQUIRE(parked != nullptr);
-  CHECK(message_of(parked) == kFinalizeThrowMessage);
-  CHECK(pipeline->take_task_completion_error() == nullptr);
+  // The snapshot pairs the finished flag with the parked error, and the error stays parked so
+  // every observer sees it (report_error downstream is first-wins).
+  auto completion = pipeline->get_completion_status();
+  CHECK(completion.finished);
+  REQUIRE(completion.error != nullptr);
+  CHECK(message_of(completion.error) == kFinalizeThrowMessage);
+  CHECK(pipeline->get_completion_status().error != nullptr);
 }
 
 TEST_CASE("a throw raised before the pipeline_finished flip is still parked for the caller",
@@ -164,11 +166,9 @@ TEST_CASE("a throw raised before the pipeline_finished flip is still parked for 
 
   make_task(global_state).reset();
 
-  CHECK_FALSE(pipeline->is_pipeline_finished());
-
-  auto parked = pipeline->take_task_completion_error();
-  REQUIRE(parked != nullptr);
-  CHECK(message_of(parked).find("First node of pipeline is nullptr") != std::string::npos);
+  auto completion = pipeline->get_completion_status();
+  CHECK_FALSE(completion.finished);
+  REQUIRE(completion.error != nullptr);
 }
 
 TEST_CASE("only the first task-completion error is kept",
@@ -181,10 +181,82 @@ TEST_CASE("only the first task-completion error is kept",
   pipeline->record_task_completion_error(std::make_exception_ptr(std::runtime_error("second")));
   pipeline->record_task_completion_error(nullptr);
 
-  auto parked = pipeline->take_task_completion_error();
-  REQUIRE(parked != nullptr);
-  CHECK(message_of(parked) == "first");
-  CHECK(pipeline->take_task_completion_error() == nullptr);
+  auto completion = pipeline->get_completion_status();
+  REQUIRE(completion.error != nullptr);
+  CHECK(message_of(completion.error) == "first");
+}
+
+namespace {
+
+// Flips pipeline_finished, then blocks in finalize until released — holding
+// update_pipeline_status() mid-throw so a concurrent status snapshot lands in the window
+// between the flip and the park.
+class gated_throwing_finalize_operator : public sirius::op::sirius_physical_operator {
+ public:
+  gated_throwing_finalize_operator()
+    : sirius_physical_operator(
+        SiriusPhysicalOperatorType::FILTER, duckdb::vector<sirius::logical_type>{}, 0)
+  {
+  }
+
+  std::string get_name() const override { return "gated_throwing_finalize_operator"; }
+
+  bool is_limit_exhausted() const override { return true; }
+
+  std::atomic<bool> in_finalize{false};
+  std::atomic<bool> release{false};
+
+ protected:
+  void on_finalize_operator() override
+  {
+    in_finalize.store(true);
+    while (!release.load()) {
+      std::this_thread::yield();
+    }
+    throw std::runtime_error(kFinalizeThrowMessage);
+  }
+};
+
+}  // namespace
+
+TEST_CASE("a status snapshot taken during a finalize throw never sees finished without the error",
+          "[pipeline][gpu_pipeline_task][finalize_throw]")
+{
+  // Regression for the flip-vs-park race: pipeline_finished is stored before the finalize loop,
+  // so a sibling task's epilogue could once observe the flip, find no parked error yet, and
+  // report the query successful. The park now shares the flip's critical section, so the
+  // snapshot below must block until the error is visible.
+  auto pipeline = duckdb::make_shared_ptr<sirius_pipeline>(
+    sirius::pipeline::pipeline_build_context{sirius::test::make_test_telemetry_context()});
+  pipeline->set_pipeline_id(13);
+
+  gated_throwing_finalize_operator op;
+  sirius_pipeline_build_state build_state;
+  build_state.add_pipeline_operator(*pipeline, op);
+
+  auto global_state = std::make_shared<sirius_pipeline_task_global_state>(
+    pipeline, sirius::test::make_test_telemetry_context());
+
+  std::thread destroyer([&] { make_task(global_state).reset(); });
+
+  // The destructor is inside finalize: pipeline_finished is already stored, the throw has not
+  // happened yet — the exact window the race lived in.
+  while (!op.in_finalize.load()) {
+    std::this_thread::yield();
+  }
+
+  sirius_pipeline::completion_status observed;
+  std::thread observer([&] { observed = pipeline->get_completion_status(); });
+
+  // Give the observer time to reach the snapshot lock while finalize still blocks.
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  op.release.store(true);
+  observer.join();
+  destroyer.join();
+
+  CHECK(observed.finished);
+  REQUIRE(observed.error != nullptr);
+  CHECK(message_of(observed.error) == kFinalizeThrowMessage);
 }
 
 namespace {

--- a/test/cpp/pipeline/test_gpu_pipeline_task_finalize_throw.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_task_finalize_throw.cpp
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ~gpu_pipeline_task calls mark_task_completed(), which runs finalize_operator() on every
+// operator — device work that throws. The destructor is implicitly noexcept, so an unguarded
+// throw there is std::terminate.
+//
+// Each case below destroys a task whose pipeline throws out of finalize. Remove the guard and
+// they do not fail: the test binary aborts, which is the signal.
+
+#include "catch.hpp"
+#include "exec/channel.hpp"
+#include "exec/config.hpp"
+#include "helper/logical_type.hpp"
+#include "memory/sirius_memory_reservation_manager.hpp"
+#include "op/sirius_physical_operator.hpp"
+#include "op/sirius_physical_operator_type.hpp"
+#include "pipeline/completion_handler.hpp"
+#include "pipeline/gpu_pipeline_executor.hpp"
+#include "pipeline/gpu_pipeline_task.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+#include "pipeline/sirius_pipeline_task_states.hpp"
+#include "pipeline/task_request.hpp"
+#include "utils/telemetry_utils.hpp"
+
+#include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
+#include <cucascade/memory/reservation_manager_configurator.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <exception>
+#include <future>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr char const* kFinalizeThrowMessage = "test: on_finalize_operator threw";
+constexpr std::size_t kReservationBytes     = 4 * 1024 * 1024;
+
+using sirius::op::SiriusPhysicalOperatorType;
+using sirius::pipeline::gpu_pipeline_task;
+using sirius::pipeline::gpu_pipeline_task_local_state;
+using sirius::pipeline::sirius_pipeline;
+using sirius::pipeline::sirius_pipeline_build_state;
+using sirius::pipeline::sirius_pipeline_task_global_state;
+
+// Reports its limit as exhausted, which is all update_pipeline_status() needs to declare the
+// pipeline finished, then throws out of finalize.
+class throwing_finalize_operator : public sirius::op::sirius_physical_operator {
+ public:
+  throwing_finalize_operator()
+    : sirius_physical_operator(
+        SiriusPhysicalOperatorType::FILTER, duckdb::vector<sirius::logical_type>{}, 0)
+  {
+  }
+
+  std::string get_name() const override { return "throwing_finalize_operator"; }
+
+  bool is_limit_exhausted() const override { return true; }
+
+  std::atomic<int> finalize_calls{0};
+
+ protected:
+  void on_finalize_operator() override
+  {
+    finalize_calls.fetch_add(1, std::memory_order_relaxed);
+    throw std::runtime_error(kFinalizeThrowMessage);
+  }
+};
+
+std::unique_ptr<gpu_pipeline_task_local_state> make_local_state()
+{
+  return std::make_unique<gpu_pipeline_task_local_state>(
+    std::make_unique<sirius::op::pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{}));
+}
+
+std::unique_ptr<gpu_pipeline_task> make_task(
+  const std::shared_ptr<sirius_pipeline_task_global_state>& global_state)
+{
+  return std::make_unique<gpu_pipeline_task>(
+    /*task_id=*/1,
+    std::vector<cucascade::shared_data_repository*>{},
+    make_local_state(),
+    global_state);
+}
+
+std::string message_of(std::exception_ptr error)
+{
+  try {
+    std::rethrow_exception(std::move(error));
+  } catch (const std::exception& e) {
+    return e.what();
+  } catch (...) {
+    return "<non-std exception>";
+  }
+}
+
+}  // namespace
+
+TEST_CASE("a finalize throw in the task destructor does not abort, and completion still stands",
+          "[pipeline][gpu_pipeline_task][finalize_throw]")
+{
+  auto pipeline = duckdb::make_shared_ptr<sirius_pipeline>(
+    sirius::pipeline::pipeline_build_context{sirius::test::make_test_telemetry_context()});
+  pipeline->set_pipeline_id(7);
+
+  throwing_finalize_operator op;
+  sirius_pipeline_build_state build_state;
+  build_state.add_pipeline_operator(*pipeline, op);
+
+  auto global_state = std::make_shared<sirius_pipeline_task_global_state>(
+    pipeline, sirius::test::make_test_telemetry_context());
+
+  // Destroying the task runs mark_task_completed(); the process must survive it.
+  make_task(global_state).reset();
+
+  CHECK(op.finalize_calls.load() == 1);
+
+  // update_pipeline_status() stores pipeline_finished before running the finalize loop, so the
+  // throw lands after the flip and the executor epilogue still sees a finished pipeline.
+  CHECK(pipeline->is_pipeline_finished());
+  CHECK(pipeline->get_tasks_created() == 1);
+  CHECK(pipeline->get_tasks_completed() == 1);
+
+  // The error is parked for whoever destroyed the task, and is handed out exactly once.
+  auto parked = pipeline->take_task_completion_error();
+  REQUIRE(parked != nullptr);
+  CHECK(message_of(parked) == kFinalizeThrowMessage);
+  CHECK(pipeline->take_task_completion_error() == nullptr);
+}
+
+TEST_CASE("a throw raised before the pipeline_finished flip is still parked for the caller",
+          "[pipeline][gpu_pipeline_task][finalize_throw]")
+{
+  // No operators and no sink makes update_pipeline_status() throw "First node of pipeline is
+  // nullptr" — the throw source that fires before pipeline_finished is set. Nothing can finish
+  // the pipeline afterwards, so the parked error is the only way out of a hang.
+  auto pipeline = duckdb::make_shared_ptr<sirius_pipeline>(
+    sirius::pipeline::pipeline_build_context{sirius::test::make_test_telemetry_context()});
+  pipeline->set_pipeline_id(9);
+
+  auto global_state = std::make_shared<sirius_pipeline_task_global_state>(
+    pipeline, sirius::test::make_test_telemetry_context());
+
+  make_task(global_state).reset();
+
+  CHECK_FALSE(pipeline->is_pipeline_finished());
+
+  auto parked = pipeline->take_task_completion_error();
+  REQUIRE(parked != nullptr);
+  CHECK(message_of(parked).find("First node of pipeline is nullptr") != std::string::npos);
+}
+
+TEST_CASE("only the first task-completion error is kept",
+          "[pipeline][gpu_pipeline_task][finalize_throw]")
+{
+  auto pipeline = duckdb::make_shared_ptr<sirius_pipeline>(
+    sirius::pipeline::pipeline_build_context{sirius::test::make_test_telemetry_context()});
+
+  pipeline->record_task_completion_error(std::make_exception_ptr(std::runtime_error("first")));
+  pipeline->record_task_completion_error(std::make_exception_ptr(std::runtime_error("second")));
+  pipeline->record_task_completion_error(nullptr);
+
+  auto parked = pipeline->take_task_completion_error();
+  REQUIRE(parked != nullptr);
+  CHECK(message_of(parked) == "first");
+  CHECK(pipeline->take_task_completion_error() == nullptr);
+}
+
+namespace {
+
+// Executor-driven task. Reservation handling mirrors test_gpu_pipeline_executor.cpp; the work
+// itself is deliberately nothing, since the point of the task is its destructor.
+class finalize_throwing_task : public gpu_pipeline_task {
+ public:
+  finalize_throwing_task(uint64_t task_id,
+                         std::shared_ptr<sirius_pipeline_task_global_state> global_state,
+                         std::atomic<int>& executed)
+    : gpu_pipeline_task(task_id,
+                        std::vector<cucascade::shared_data_repository*>{},
+                        make_local_state(),
+                        std::move(global_state)),
+      _executed(executed)
+  {
+  }
+
+  void execute(rmm::cuda_stream_view stream) override
+  {
+    auto& local      = _local_state->cast<gpu_pipeline_task_local_state>();
+    auto reservation = local.release_reservation();
+    if (reservation) {
+      auto* allocator =
+        reservation
+          ->get_memory_resource_as<cucascade::memory::reservation_aware_resource_adaptor>();
+      if (allocator && allocator->attach_reservation_to_tracker(stream, std::move(reservation))) {
+        allocator->reset_stream_reservation(stream);
+      }
+    }
+    _executed.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  sirius::pipeline::reservation_size_info get_estimated_reservation_size_info(
+    const cucascade::memory::memory_space* /*target_space*/) const override
+  {
+    sirius::pipeline::reservation_size_info info;
+    info.reservation_size = kReservationBytes;
+    return info;
+  }
+
+  std::vector<sirius::op::sirius_physical_operator*> get_output_consumers() override { return {}; }
+
+ private:
+  std::atomic<int>& _executed;
+};
+
+}  // namespace
+
+TEST_CASE("the executor fails the query when the task destructor's completion throws",
+          "[pipeline][gpu_pipeline_task][finalize_throw]")
+{
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> manager;
+  try {
+    cucascade::memory::reservation_manager_configurator builder;
+    builder.set_number_of_gpus(1)
+      .set_gpu_usage_limit(256 * 1024 * 1024)
+      .set_reservation_fraction_per_gpu(0.75)
+      .set_per_numa_region_capacity(1024ULL * 1024 * 1024)
+      .use_gpu_id_as_host_id()
+      .track_reservation_per_stream(false)
+      .set_reservation_fraction_per_numa_region(0.75);
+    manager = std::make_unique<sirius::memory::sirius_memory_reservation_manager>(builder.build());
+  } catch (const std::exception& e) {
+    WARN("Skipping test due to insufficient GPUs: " << e.what());
+    return;
+  }
+
+  auto* mem_space = manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  if (!mem_space) {
+    WARN("Skipping test because no GPU memory space is available.");
+    return;
+  }
+
+  auto pipeline = duckdb::make_shared_ptr<sirius_pipeline>(
+    sirius::pipeline::pipeline_build_context{sirius::test::make_test_telemetry_context()});
+  pipeline->set_pipeline_id(11);
+
+  throwing_finalize_operator op;
+  sirius::op::sirius_physical_operator result_collector(
+    SiriusPhysicalOperatorType::RESULT_COLLECTOR, duckdb::vector<sirius::logical_type>{}, 1);
+  sirius_pipeline_build_state build_state;
+  build_state.add_pipeline_operator(*pipeline, op);
+  build_state.set_pipeline_sink(*pipeline, &result_collector, 0);
+  REQUIRE(pipeline->is_query_terminal());
+
+  sirius::exec::channel<std::unique_ptr<sirius::pipeline::task_request>> request_channel;
+  sirius::exec::thread_pool_config config;
+  config.num_threads        = 1;
+  config.thread_name_prefix = "finalize-throw-test";
+
+  sirius::pipeline::gpu_pipeline_executor executor(config,
+                                                   mem_space,
+                                                   request_channel.make_publisher(),
+                                                   nullptr,
+                                                   sirius::test::make_test_telemetry_context());
+  sirius::pipeline::completion_handler handler;
+  executor.set_completion_handler(&handler);
+  auto awaitable = handler.get_awaitable();
+
+  auto global_state = std::make_shared<sirius_pipeline_task_global_state>(
+    pipeline, sirius::test::make_test_telemetry_context());
+
+  std::atomic<int> executed{0};
+  executor.start();
+  executor.schedule(std::make_unique<finalize_throwing_task>(1, global_state, executed));
+
+  // The query must terminate — not abort, and not hang on a swallowed throw that signals nobody.
+  const auto status = awaitable.wait_for(std::chrono::seconds(30));
+  executor.stop();
+  request_channel.close();
+
+  REQUIRE(status == std::future_status::ready);
+  CHECK(executed.load() == 1);
+  CHECK(handler.has_error());
+  CHECK_THROWS_WITH(awaitable.get(), Catch::Contains(kFinalizeThrowMessage));
+}


### PR DESCRIPTION
## Description

`~gpu_pipeline_task` is implicitly `noexcept` and calls `sirius_pipeline::mark_task_completed()` ([gpu_pipeline_task.cpp:327](https://github.com/sirius-db/sirius/blob/00206457/src/pipeline/gpu_pipeline_task.cpp#L327)), which reaches `update_pipeline_status()`. That throws in two places: `internal_exception` when the pipeline has no first node ([sirius_pipeline.cpp:396](https://github.com/sirius-db/sirius/blob/00206457/src/pipeline/sirius_pipeline.cpp#L396)), and `finalize_operator()` ([:421](https://github.com/sirius-db/sirius/blob/00206457/src/pipeline/sirius_pipeline.cpp#L421)), whose overrides do device work — the hash join frees its cuco tables under `rmm::cuda_set_device_raii` and raises `rmm::cuda_error` on a sticky CUDA error.

Either throw is `std::terminate`: the whole process aborts on a recoverable query error. Adding a `try/catch` further out does not help — a `noexcept` destructor terminates before any enclosing handler runs, so the executor's existing task-exception handlers never fire.

This PR guards the call, matching the `unsubscribe` handler above it.

### How the error is routed

The destructor cannot reach the query's `completion_handler`, so the error is parked on the pipeline and the executor's task epilogue reads it and fails the query through `report_error()`. Two ordering hazards shape the mechanism:

- **Park and flip share a critical section.** `update_pipeline_status()` stores `pipeline_finished` *before* the finalize loop, so a sibling task's epilogue could observe the flip, find no parked error yet, and `mark_completed()` — first-signal-wins would then discard the finalize error and the query would report success. The throw is therefore parked inside `update_pipeline_status()`'s catch while `_status_mutex` is still held, and the epilogue reads the flag and the error in one locked snapshot (`get_completion_status()`): seeing "finished" implies seeing the error.
- **The error is peeked, not taken.** Removing it on read reopens a smaller version of the same window (claimer holds the error while a sibling signals success). `report_error()` is first-wins, so leaving it parked and letting every observer report it is safe.

Routing rather than only logging matters because a throw raised before the `pipeline_finished` flip leaves nobody able to finish the pipeline — log-only would park `future.get()` forever. The reported error wins over the completion the epilogue would otherwise signal: deliberate, since every one of these throws is a process abort today and the realistic trigger is a corrupt device context. `report_error()` is intentionally not paired with `_task_creator->stop()`; failing the query makes `future.get()` throw, which runs `drain_after_error()`, and that already stops the creator first in the documented order.

Two neighboring holes in the same class are closed as well:

- The downgrade-cancel `break` in `manager_loop()` destroys its task with no epilogue to observe a parked error, which would hang the query; the error is now reported at the break.
- `task_creator`'s manager loop calls `update_pipeline_status()` bare on its own thread, so a finalize throw there was still `std::terminate` through a different entry point. It now catches and calls `terminate_query()` (`stop()` would join the thread it runs on).

## Validation

An env-gated throw from `mark_task_completed()` just before `update_pipeline_status()` — the pre-flip case, the harder one — on a single-GPU L4 running a TPC-H `lineitem` group-by:

| | result |
|---|---|
| before | `rc=134` (SIGABRT), `terminate called recursively` ×2, no output |
| after | `rc=0`, `Error in Sirius GPU execution, fallback to DuckDB`, correct results |

The log shows the full path — all four in-flight tasks throwing at once, through `gpu_pipeline_task` → `gpu_pipeline_executor` → `sirius_engine` → transparent fallback.

`test/cpp/pipeline/test_gpu_pipeline_task_finalize_throw.cpp` covers the post-flip case, the pre-flip case, first-error-wins, an executor-driven case asserting the query terminates through `completion_handler` rather than hanging, and a flip-vs-park race regression that holds finalize mid-throw (after the flip, before the park) while a concurrent observer snapshots — the snapshot must block until the error is visible. Remove the guard and the destructor cases do not fail — the binary aborts, which is the signal.

## Checklist

- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above — none
- [x] Update human and agent documentation — none needed, the change is internal to the completion path

## References

Closes #1625
