### PR TITLE
feat(scan): a deterministic byte-range -> row-group ownership rule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,7 @@ set(EXTENSION_SOURCES
     src/op/scan/sirius_physical_dynamic_filter.cpp
     src/op/scan/host_keep_mask.cpp
     src/op/scan/owning_table_view.cpp
+    src/op/scan/parquet_byte_range.cpp
     src/op/scan/parquet_schema_mapping.cpp
     src/op/scan/scan_plan.cpp
     src/op/scan/scan_filter_analysis.cpp
@@ -830,6 +831,7 @@ set(TEST_SOURCES
     test/cpp/scan/test_host_keep_mask.cpp
     test/cpp/scan/test_gpu_native_decode.cpp
     test/cpp/scan/test_owning_table_view.cpp
+    test/cpp/scan/test_parquet_byte_range.cpp
     test/cpp/scan/test_parquet_schema_mapping.cpp
     test/cpp/scan/test_parquet_null_count_pruning.cpp
     test/cpp/scan/test_residual_filter.cpp

--- a/src/include/op/scan/parquet_byte_range.hpp
+++ b/src/include/op/scan/parquet_byte_range.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// cudf
+#include <cudf/io/parquet_schema.hpp>
+#include <cudf/types.hpp>
+
+// standard library
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace sirius::op::scan::detail {
+
+/**
+ * @brief Byte offset where row group @p index starts, per the StarRocks reader convention.
+ *
+ * A distributed byte-range scan is correct only if every reader of the same file derives the
+ * same start offset per row group — the FE load-balances splits assuming its readers follow
+ * the StarRocks BE rule (be/src/formats/parquet/utils.cpp): the minimum of the first column
+ * chunk's data/index/dictionary page offsets and the row group's own file_offset, where each
+ * candidate counts only when present. cudf's thrift structs carry no __isset, so a page
+ * offset of 0 is treated as absent (real offsets start after the 4-byte magic).
+ *
+ * @throws sirius::invalid_input_exception if no candidate offset is present — ownership
+ *         would be undefined, and guessing risks reading rows twice or not at all.
+ */
+[[nodiscard]] std::int64_t row_group_start_offset(cudf::io::parquet::FileMetaData const& metadata,
+                                                  std::size_t index);
+
+/**
+ * @brief Row groups owned by the byte range [start, start+length).
+ *
+ * Ownership is start-offset containment: row group i belongs to the range iff
+ * `start <= row_group_start_offset(i) < start + length`. A row group straddling the range end
+ * is still owned in full by this range (the byte range bounds ownership, not I/O), and a range
+ * that contains no start offset owns nothing — the caller must treat that as a valid empty
+ * scan. Together these make any exact tiling of the file read every row group exactly once.
+ *
+ * @return Indices into @p metadata.row_groups, ascending.
+ */
+[[nodiscard]] std::vector<cudf::size_type> row_groups_in_byte_range(
+  cudf::io::parquet::FileMetaData const& metadata, std::uint64_t start, std::uint64_t length);
+
+}  // namespace sirius::op::scan::detail

--- a/src/op/scan/parquet_byte_range.cpp
+++ b/src/op/scan/parquet_byte_range.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/scan/parquet_byte_range.hpp"
+
+#include "sirius/exception.hpp"
+
+#include <algorithm>
+#include <limits>
+
+namespace sirius::op::scan::detail {
+
+std::int64_t row_group_start_offset(cudf::io::parquet::FileMetaData const& metadata,
+                                    std::size_t index)
+{
+  auto const& row_group = metadata.row_groups.at(index);
+  auto start            = std::numeric_limits<std::int64_t>::max();
+  if (row_group.file_offset.has_value() && *row_group.file_offset > 0) {
+    start = std::min(start, *row_group.file_offset);
+  }
+  if (!row_group.columns.empty()) {
+    auto const& first_column = row_group.columns.front().meta_data;
+    for (auto const offset : {first_column.data_page_offset,
+                              first_column.index_page_offset,
+                              first_column.dictionary_page_offset}) {
+      if (offset > 0) { start = std::min(start, offset); }
+    }
+  }
+  if (start == std::numeric_limits<std::int64_t>::max()) {
+    throw sirius::invalid_input_exception(
+      "parquet row group {} has no page or file offset; byte-range ownership would be "
+      "undefined",
+      index);
+  }
+  return start;
+}
+
+std::vector<cudf::size_type> row_groups_in_byte_range(
+  cudf::io::parquet::FileMetaData const& metadata, std::uint64_t start, std::uint64_t length)
+{
+  std::vector<cudf::size_type> owned;
+  if (length == 0) { return owned; }
+  auto const end = start + length;
+  for (std::size_t i = 0; i < metadata.row_groups.size(); ++i) {
+    auto const rg_start = static_cast<std::uint64_t>(row_group_start_offset(metadata, i));
+    if (start <= rg_start && rg_start < end) { owned.push_back(static_cast<cudf::size_type>(i)); }
+  }
+  return owned;
+}
+
+}  // namespace sirius::op::scan::detail

--- a/test/cpp/scan/test_parquet_byte_range.cpp
+++ b/test/cpp/scan/test_parquet_byte_range.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// test
+#include <catch.hpp>
+
+// sirius
+#include <op/scan/parquet_byte_range.hpp>
+#include <sirius/exception.hpp>
+
+// cudf
+#include <cudf/io/datasource.hpp>
+#include <cudf/io/experimental/hybrid_scan.hpp>
+#include <cudf/io/parquet_io_utils.hpp>
+#include <cudf/io/parquet_schema.hpp>
+
+// standard library
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <numeric>
+#include <set>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+using sirius::op::scan::detail::row_group_start_offset;
+using sirius::op::scan::detail::row_groups_in_byte_range;
+
+namespace {
+
+/// Metadata with one row group per given start offset, encoded the common way
+/// (first column's data_page_offset carries the start; everything else unset).
+cudf::io::parquet::FileMetaData make_metadata(std::vector<std::int64_t> const& rg_starts)
+{
+  cudf::io::parquet::FileMetaData meta;
+  for (auto const start : rg_starts) {
+    cudf::io::parquet::RowGroup rg;
+    cudf::io::parquet::ColumnChunk chunk;
+    chunk.meta_data.data_page_offset = start;
+    rg.columns.push_back(std::move(chunk));
+    meta.row_groups.push_back(std::move(rg));
+  }
+  return meta;
+}
+
+std::vector<cudf::size_type> all_indices(std::size_t n)
+{
+  std::vector<cudf::size_type> all(n);
+  std::iota(all.begin(), all.end(), 0);
+  return all;
+}
+
+fs::path lineitem_parquet_path()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return fs::path(SIRIUS_PROJECT_ROOT) / "test/cpp/integration/data/parquet/lineitem.parquet";
+#else
+  return fs::path(__FILE__).parent_path().parent_path() /
+         "integration/data/parquet/lineitem.parquet";
+#endif
+}
+
+}  // namespace
+
+TEST_CASE("row_group_start_offset follows the StarRocks reader convention", "[parquet_byte_range]")
+{
+  cudf::io::parquet::FileMetaData meta;
+  cudf::io::parquet::RowGroup rg;
+  cudf::io::parquet::ColumnChunk chunk;
+
+  SECTION("data page offset alone")
+  {
+    chunk.meta_data.data_page_offset = 100;
+    rg.columns.push_back(chunk);
+    meta.row_groups.push_back(rg);
+    REQUIRE(row_group_start_offset(meta, 0) == 100);
+  }
+
+  SECTION("dictionary page precedes the data page")
+  {
+    chunk.meta_data.data_page_offset       = 100;
+    chunk.meta_data.dictionary_page_offset = 40;
+    rg.columns.push_back(chunk);
+    meta.row_groups.push_back(rg);
+    REQUIRE(row_group_start_offset(meta, 0) == 40);
+  }
+
+  SECTION("zero offsets count as absent, not as position zero")
+  {
+    chunk.meta_data.data_page_offset       = 100;
+    chunk.meta_data.dictionary_page_offset = 0;
+    chunk.meta_data.index_page_offset      = 0;
+    rg.columns.push_back(chunk);
+    meta.row_groups.push_back(rg);
+    REQUIRE(row_group_start_offset(meta, 0) == 100);
+  }
+
+  SECTION("row group file_offset participates when set")
+  {
+    chunk.meta_data.data_page_offset = 100;
+    rg.columns.push_back(chunk);
+    rg.file_offset = 30;
+    meta.row_groups.push_back(rg);
+    REQUIRE(row_group_start_offset(meta, 0) == 30);
+  }
+
+  SECTION("no candidate offset at all is a loud error, never a guess")
+  {
+    rg.columns.push_back(chunk);  // all offsets zero
+    meta.row_groups.push_back(rg);
+    REQUIRE_THROWS_AS(row_group_start_offset(meta, 0), sirius::invalid_input_exception);
+  }
+}
+
+TEST_CASE("any exact tiling reads every row group exactly once", "[parquet_byte_range]")
+{
+  // Row-group starts chosen so boundaries land before, on, and inside them.
+  auto const starts    = std::vector<std::int64_t>{4, 1000, 1024, 5000, 999999};
+  auto const meta      = make_metadata(starts);
+  auto const file_size = std::uint64_t{1200000};
+
+  // Sweep every tiling of the file into k equal ranges (the FE emits exact tilings).
+  for (std::size_t k : {1, 2, 3, 4, 5, 7, 16}) {
+    std::vector<cudf::size_type> combined;
+    std::set<cudf::size_type> seen;
+    auto const split = file_size / k;
+    for (std::size_t part = 0; part < k; ++part) {
+      auto const start  = part * split;
+      auto const length = (part == k - 1) ? file_size - start : split;
+      auto const owned  = row_groups_in_byte_range(meta, start, length);
+      for (auto const idx : owned) {
+        INFO("tiling k=" << k << " part=" << part);
+        REQUIRE(seen.insert(idx).second);  // pairwise disjoint
+        combined.push_back(idx);
+      }
+    }
+    std::sort(combined.begin(), combined.end());
+    INFO("tiling k=" << k);
+    REQUIRE(combined == all_indices(starts.size()));  // complete
+  }
+}
+
+TEST_CASE("byte-range ownership edge cases", "[parquet_byte_range]")
+{
+  auto const meta = make_metadata({4, 1000, 5000});
+
+  SECTION("whole file owns everything")
+  {
+    REQUIRE(row_groups_in_byte_range(meta, 0, 6000) == all_indices(3));
+  }
+
+  SECTION("a straddling row group belongs to the range holding its start")
+  {
+    // Range ends at 1500, inside row group 1's bytes; rg 1 starts at 1000 -> owned here...
+    REQUIRE(row_groups_in_byte_range(meta, 0, 1500) == std::vector<cudf::size_type>{0, 1});
+    // ...and not by the neighbour that covers its tail.
+    REQUIRE(row_groups_in_byte_range(meta, 1500, 3000) == std::vector<cudf::size_type>{});
+  }
+
+  SECTION("a range inside one row group owns nothing (valid empty split)")
+  {
+    REQUIRE(row_groups_in_byte_range(meta, 1200, 100).empty());
+  }
+
+  SECTION("zero length owns nothing, including the canonical empty split")
+  {
+    REQUIRE(row_groups_in_byte_range(meta, 0, 0).empty());
+    REQUIRE(row_groups_in_byte_range(meta, 6000, 0).empty());
+  }
+
+  SECTION("a boundary exactly on a row-group start assigns it to the right-hand range")
+  {
+    REQUIRE(row_groups_in_byte_range(meta, 4, 996) == std::vector<cudf::size_type>{0});
+    REQUIRE(row_groups_in_byte_range(meta, 1000, 5000) == std::vector<cudf::size_type>{1, 2});
+  }
+}
+
+TEST_CASE("real footer: rule agrees with cudf's byte-range filter on the test lineitem",
+          "[parquet_byte_range]")
+{
+  auto const path = lineitem_parquet_path();
+  REQUIRE(fs::exists(path));
+  auto source = cudf::io::datasource::create(path.string());
+  auto footer = cudf::io::parquet::fetch_footer_to_host(*source);
+  cudf::io::parquet_reader_options options;
+  cudf::io::parquet::experimental::hybrid_scan_reader reader(
+    cudf::host_span<uint8_t const>(footer->data(), footer->size()), options);
+  auto const metadata = reader.parquet_metadata();
+  REQUIRE(!metadata.row_groups.empty());
+  auto const file_size = std::uint64_t(fs::file_size(path));
+
+  // Exactly-once over a two-way tiling of the real file.
+  auto const half = file_size / 2;
+  auto left       = row_groups_in_byte_range(metadata, 0, half);
+  auto right      = row_groups_in_byte_range(metadata, half, file_size - half);
+  std::vector<cudf::size_type> combined = left;
+  combined.insert(combined.end(), right.begin(), right.end());
+  std::sort(combined.begin(), combined.end());
+  REQUIRE(combined == all_indices(metadata.row_groups.size()));
+
+  // Cross-check against cudf's own byte-range pruning. Informational: cudf's definition of a
+  // row group's start is not pinned by its API docs; if this ever diverges, our rule (the
+  // StarRocks reader convention) stays authoritative and this warning says cudf changed.
+  auto all = reader.all_row_groups(options);
+  cudf::io::parquet_reader_options range_options;
+  range_options.set_skip_bytes(0);
+  range_options.set_num_bytes(half);
+  auto cudf_left = reader.filter_row_groups_with_byte_range(
+    cudf::host_span<cudf::size_type const>(all.data(), all.size()), range_options);
+  if (cudf_left != left) {
+    WARN("cudf filter_row_groups_with_byte_range diverges from the StarRocks rule: cudf="
+         << cudf_left.size() << " ours=" << left.size());
+  }
+}


### PR DESCRIPTION
## Description

Adds a single, self-contained rule: **given a byte range over a parquet file, which row groups does that range own?** Nothing calls it yet — this PR lands the rule and its tests only.

StarRocks' FE does not hand a compute node "read `lineitem.parquet`". It chops each file into byte ranges so several workers read it in parallel. Correctness of such a split scan reduces to one property: **every reader must derive the same owner for every row group**, so that an exact tiling of a file reads every row exactly once.

### The rule

New `src/op/scan/parquet_byte_range.{hpp,cpp}` in `sirius::op::scan::detail`:

- `row_group_start_offset(metadata, i)` — the row group's start offset is the minimum of its `file_offset` and the first column chunk's `data_page_offset` / `index_page_offset` / `dictionary_page_offset`, each candidate counted only when `> 0`. cudf's thrift structs carry no `__isset`, so a zero page offset is treated as *absent* rather than as position zero (real offsets start after the 4-byte magic). A row group with no candidate offset at all throws `invalid_input_exception` — a loud error, never a guess, because a guessed owner silently duplicates or drops rows.
- `row_groups_in_byte_range(metadata, start, length)` — ownership is **start-offset containment**: row group `i` belongs to the range iff `start <= row_group_start_offset(i) < start + length`. A row group straddling the range end is still owned in full by the range holding its start (the byte range bounds ownership, not I/O), and a range that contains no start offset owns nothing — a valid empty split, not an error.

### Why it must match the StarRocks BE convention

This is deliberately the same rule as StarRocks BE's `be/src/formats/parquet/utils.cpp`, and it has to be. The FE load-balances splits *assuming its readers follow that rule*. A reader that used a different definition of "where a row group starts" would disagree with the FE's partitioning at the boundaries: the same row group could be claimed by two splits (rows read twice) or by neither (rows dropped) — with no error anywhere, just wrong results. Pinning the convention here is what makes any exact tiling read every row group exactly once.

## Test coverage

`test/cpp/scan/test_parquet_byte_range.cpp`, tag `[parquet_byte_range]`:

- **Exact-tiling sweep** — the file is tiled into `k` equal ranges for `k ∈ {1, 2, 3, 4, 5, 7, 16}` over row-group starts chosen so boundaries land before, on, and inside row groups; asserts the owned sets are pairwise disjoint and their union is complete for every `k`.
- **Convention corners** — data page offset alone, dictionary page preceding the data page, zero offsets counting as absent, `file_offset` participating, and the no-candidate-offset error.
- **Edge cases** — whole file, a straddling row group belonging to the range holding its start (and *not* to the neighbour covering its tail), a range wholly inside one row group owning nothing, zero length, and a boundary exactly on a row-group start assigning it to the right-hand range.
- **Real footer** — a two-way tiling of the checked-in `lineitem.parquet` reads every row group exactly once, plus an informational cross-check against cudf's `filter_row_groups_with_byte_range` (our rule stays authoritative; a divergence only warns).

## Checklist
- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md) — n/a, no user-facing surface yet

## References

Refs #1635 — this is **step 1 of 4** in that issue's checklist.

Step 1 is self-contained C++ plus unit tests: it touches no translator code and **lands independently of #1232**. Wiring the rule into the parquet ingestible (`build_file_scan_info` / `opts.set_row_groups(...)`) is step 2; carrying byte ranges across the Substrait/DuckDB boundary is step 3; emitting partial splits from the CN is step 4.
