### PR TITLE
feat(scan): the parquet ingestible honors a per-file byte range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,7 @@ set(EXTENSION_SOURCES
     src/op/scan/sirius_physical_dynamic_filter.cpp
     src/op/scan/host_keep_mask.cpp
     src/op/scan/owning_table_view.cpp
+    src/op/scan/parquet_byte_range.cpp
     src/op/scan/parquet_schema_mapping.cpp
     src/op/scan/scan_plan.cpp
     src/op/scan/scan_filter_analysis.cpp
@@ -830,6 +831,7 @@ set(TEST_SOURCES
     test/cpp/scan/test_host_keep_mask.cpp
     test/cpp/scan/test_gpu_native_decode.cpp
     test/cpp/scan/test_owning_table_view.cpp
+    test/cpp/scan/test_parquet_byte_range.cpp
     test/cpp/scan/test_parquet_schema_mapping.cpp
     test/cpp/scan/test_parquet_null_count_pruning.cpp
     test/cpp/scan/test_residual_filter.cpp

--- a/src/include/op/scan/parquet_byte_range.hpp
+++ b/src/include/op/scan/parquet_byte_range.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// cudf
+#include <cudf/io/parquet_schema.hpp>
+#include <cudf/types.hpp>
+
+// standard library
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace sirius::op::scan::detail {
+
+/**
+ * @brief Byte offset where row group @p index starts, per the StarRocks reader convention.
+ *
+ * A distributed byte-range scan is correct only if every reader of the same file derives the
+ * same start offset per row group — the FE load-balances splits assuming its readers follow
+ * the StarRocks BE rule (be/src/formats/parquet/utils.cpp): the minimum of the first column
+ * chunk's data/index/dictionary page offsets and the row group's own file_offset, where each
+ * candidate counts only when present. cudf's thrift structs carry no __isset, so a page
+ * offset of 0 is treated as absent (real offsets start after the 4-byte magic).
+ *
+ * @throws sirius::invalid_input_exception if no candidate offset is present — ownership
+ *         would be undefined, and guessing risks reading rows twice or not at all.
+ */
+[[nodiscard]] std::int64_t row_group_start_offset(cudf::io::parquet::FileMetaData const& metadata,
+                                                  std::size_t index);
+
+/**
+ * @brief Row groups owned by the byte range [start, start+length).
+ *
+ * Ownership is start-offset containment: row group i belongs to the range iff
+ * `start <= row_group_start_offset(i) < start + length`. A row group straddling the range end
+ * is still owned in full by this range (the byte range bounds ownership, not I/O), and a range
+ * that contains no start offset owns nothing — the caller must treat that as a valid empty
+ * scan. Together these make any exact tiling of the file read every row group exactly once.
+ *
+ * @return Indices into @p metadata.row_groups, ascending.
+ */
+[[nodiscard]] std::vector<cudf::size_type> row_groups_in_byte_range(
+  cudf::io::parquet::FileMetaData const& metadata, std::uint64_t start, std::uint64_t length);
+
+}  // namespace sirius::op::scan::detail

--- a/src/include/op/scan/parquet_gpu_ingestible.hpp
+++ b/src/include/op/scan/parquet_gpu_ingestible.hpp
@@ -35,6 +35,7 @@
 #include <cudf/io/parquet.hpp>
 
 // standard library
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -42,6 +43,7 @@
 #include <memory>
 #include <span>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace sirius::scan_manager {
@@ -67,6 +69,12 @@ class parquet_ingestible_table_info : public ingestible_table_info {
  public:
   duckdb::vector<sirius::logical_type> returned_types;
   std::vector<std::string> resolved_file_paths;
+  /// Per-file byte range `[start, start+length)`, parallel to @ref resolved_file_paths.
+  /// Empty means every file is read whole; a `(0,0)` entry means that file is read whole.
+  /// A ranged file reads only the row groups whose start offset falls inside the range
+  /// (see parquet_byte_range.hpp) — the mechanism behind distributed byte-range splits,
+  /// where N ranges of one file must read every row exactly once across scan instances.
+  std::vector<std::pair<std::uint64_t, std::uint64_t>> resolved_file_ranges;
   duckdb::vector<duckdb::ColumnIndex> column_ids;
   duckdb::vector<duckdb::idx_t> projection_ids;
   duckdb::vector<std::string> names;
@@ -84,6 +92,14 @@ class parquet_ingestible_table_info : public ingestible_table_info {
   std::size_t scan_output_arity      = 0;
 
   parquet_ingestible_table_info() = default;
+
+  /// True when any file carries a real byte range (a `(0,0)` entry is a whole file).
+  [[nodiscard]] bool has_byte_ranges() const
+  {
+    return std::any_of(resolved_file_ranges.begin(),
+                       resolved_file_ranges.end(),
+                       [](auto const& range) { return range.second != 0 || range.first != 0; });
+  }
 
   [[nodiscard]] std::span<std::string const> column_names() const override { return names; }
 
@@ -317,12 +333,15 @@ class parquet_gpu_ingestible : public gpu_ingestible {
   }
 
  private:
-  /// Read one file's footer, prune its row groups against the filter, and record
-  /// per-row-group byte accounting. Returns a single @c parquet_file_scan_info.
-  /// Runs on a scan-manager dispatcher thread (the task returned by
-  /// @ref next_split_provider).
-  std::unique_ptr<scan_info> build_file_scan_info(std::string const& file_path,
-                                                  std::shared_ptr<io::sirius_ioctx> const& io_ctx);
+  /// Read one file's footer, prune its row groups against the byte range and the filter, and
+  /// record per-row-group byte accounting. Returns a single @c parquet_file_scan_info.
+  /// `byte_range` is `(0,0)` for a whole-file read; otherwise only row groups starting inside
+  /// `[start, start+length)` are read. Runs on a scan-manager dispatcher thread (the task
+  /// returned by @ref next_split_provider).
+  std::unique_ptr<scan_info> build_file_scan_info(
+    std::string const& file_path,
+    std::pair<std::uint64_t, std::uint64_t> byte_range,
+    std::shared_ptr<io::sirius_ioctx> const& io_ctx);
 
   std::unique_ptr<parquet_ingestible_table_info> _info;
 

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -109,7 +109,11 @@ namespace sirius::scan_manager {
 /// owns the match logic that @ref sirius_scan_manager::try_match_cached_entry consults.
 class cache_entry_info {
  public:
-  std::vector<std::string> resolved_file_paths;    ///< parquet identity (file set)
+  std::vector<std::string> resolved_file_paths;  ///< parquet identity (file set)
+  /// True when the parquet scan behind this entry read byte-range subsets of its files. A
+  /// ranged scan holds a fraction of each file's rows, so it neither serves nor is served by
+  /// the cache — matching on the file set alone would silently return extra or missing rows.
+  bool has_byte_ranges = false;
   std::string catalog_name;                        ///< duckdb identity: catalog (attach alias)
   std::string schema_name;                         ///< duckdb identity: schema
   std::string table_name;                          ///< duckdb identity: table

--- a/src/op/scan/parquet_byte_range.cpp
+++ b/src/op/scan/parquet_byte_range.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/scan/parquet_byte_range.hpp"
+
+#include "sirius/exception.hpp"
+
+#include <algorithm>
+#include <limits>
+
+namespace sirius::op::scan::detail {
+
+std::int64_t row_group_start_offset(cudf::io::parquet::FileMetaData const& metadata,
+                                    std::size_t index)
+{
+  auto const& row_group = metadata.row_groups.at(index);
+  auto start            = std::numeric_limits<std::int64_t>::max();
+  if (row_group.file_offset.has_value() && *row_group.file_offset > 0) {
+    start = std::min(start, *row_group.file_offset);
+  }
+  if (!row_group.columns.empty()) {
+    auto const& first_column = row_group.columns.front().meta_data;
+    for (auto const offset : {first_column.data_page_offset,
+                              first_column.index_page_offset,
+                              first_column.dictionary_page_offset}) {
+      if (offset > 0) { start = std::min(start, offset); }
+    }
+  }
+  if (start == std::numeric_limits<std::int64_t>::max()) {
+    throw sirius::invalid_input_exception(
+      "parquet row group {} has no page or file offset; byte-range ownership would be "
+      "undefined",
+      index);
+  }
+  return start;
+}
+
+std::vector<cudf::size_type> row_groups_in_byte_range(
+  cudf::io::parquet::FileMetaData const& metadata, std::uint64_t start, std::uint64_t length)
+{
+  std::vector<cudf::size_type> owned;
+  if (length == 0) { return owned; }
+  auto const end = start + length;
+  for (std::size_t i = 0; i < metadata.row_groups.size(); ++i) {
+    auto const rg_start = static_cast<std::uint64_t>(row_group_start_offset(metadata, i));
+    if (start <= rg_start && rg_start < end) { owned.push_back(static_cast<cudf::size_type>(i)); }
+  }
+  return owned;
+}
+
+}  // namespace sirius::op::scan::detail

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -26,6 +26,7 @@
 #include <log/logging.hpp>
 #include <op/dynamic_filter/sirius_dynamic_filter.hpp>
 #include <op/scan/dynamic_filter_merge.hpp>
+#include <op/scan/parquet_byte_range.hpp>
 #include <op/scan/parquet_gpu_ingestible.hpp>
 #include <op/scan/parquet_metadata.hpp>
 #include <op/scan/parquet_schema_mapping.hpp>
@@ -609,6 +610,14 @@ parquet_gpu_ingestible::parquet_gpu_ingestible(std::unique_ptr<parquet_ingestibl
   }
 
   _file_paths = bind.resolved_file_paths;
+  if (!bind.resolved_file_ranges.empty() &&
+      bind.resolved_file_ranges.size() != bind.resolved_file_paths.size()) {
+    throw sirius::invalid_input_exception(
+      "parquet scan carries {} byte ranges for {} files; a partial pairing would make "
+      "row-group ownership ambiguous",
+      bind.resolved_file_ranges.size(),
+      bind.resolved_file_paths.size());
+  }
 }
 
 parquet_gpu_ingestible::~parquet_gpu_ingestible() = default;
@@ -642,10 +651,13 @@ std::function<std::unique_ptr<op::scan::scan_info>()> parquet_gpu_ingestible::ne
   // per file; row-group chunking and file bundling happen downstream in
   // parquet_batch_coalescer.
   auto const& file_path = _file_paths[idx];
+  auto const byte_range = idx < _info->resolved_file_ranges.size()
+                            ? _info->resolved_file_ranges[idx]
+                            : std::pair<std::uint64_t, std::uint64_t>{0, 0};
   // The resolver returns a valid ioctx or throws if no backend supports the path.
   auto io_ctx = resolve(file_path);
-  return [this, file_path, io_ctx = std::move(io_ctx)]() -> std::unique_ptr<scan_info> {
-    return build_file_scan_info(file_path, io_ctx);
+  return [this, file_path, byte_range, io_ctx = std::move(io_ctx)]() -> std::unique_ptr<scan_info> {
+    return build_file_scan_info(file_path, byte_range, io_ctx);
   };
 }
 
@@ -653,7 +665,9 @@ std::function<std::unique_ptr<op::scan::scan_info>()> parquet_gpu_ingestible::ne
 // build_file_scan_info — per-file footer read + row-group pruning
 //===----------------------------------------------------------------------===//
 std::unique_ptr<scan_info> parquet_gpu_ingestible::build_file_scan_info(
-  std::string const& file_path, std::shared_ptr<io::sirius_ioctx> const& io_ctx)
+  std::string const& file_path,
+  std::pair<std::uint64_t, std::uint64_t> byte_range,
+  std::shared_ptr<io::sirius_ioctx> const& io_ctx)
 {
   auto stream = cudf::get_default_stream();
 
@@ -799,6 +813,18 @@ std::unique_ptr<scan_info> parquet_gpu_ingestible::build_file_scan_info(
   }
 
   auto row_group_indices = reader.all_row_groups(opts);
+  // Distributed byte-range split: keep only the row groups this range owns (start-offset
+  // containment, parquet_byte_range.hpp), BEFORE stats pruning. An empty selection is a valid
+  // empty split and flows through the all-pruned fallback below — never a whole-file read.
+  if (byte_range.second != 0 || byte_range.first != 0) {
+    row_group_indices =
+      detail::row_groups_in_byte_range(metadata, byte_range.first, byte_range.second);
+    SIRIUS_LOG_DEBUG("[parquet_gpu_ingestible] Byte range [{}, +{}) of {} owns {} row group(s)",
+                     byte_range.first,
+                     byte_range.second,
+                     file_path,
+                     row_group_indices.size());
+  }
   if (ast_expression && !disable_filter_pushdown) {
     auto const rgs_before = row_group_indices.size();
     row_group_indices     = reader.filter_row_groups_with_stats(row_group_indices, opts, stream);

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -1085,8 +1085,9 @@ cache_entry_info cache_entry_info::from(const op::scan::ingestible_table_info& i
     // resolved) path.
     ci.resolved_file_paths = p->resolved_file_paths;
     op::scan::canonicalize_scan_file_paths(ci.resolved_file_paths);
-    ci.column_ids = p->column_ids;
-    ci.names      = aligned_column_names(p->names, p->column_ids);
+    ci.has_byte_ranges = p->has_byte_ranges();
+    ci.column_ids      = p->column_ids;
+    ci.names           = aligned_column_names(p->names, p->column_ids);
   } else if (auto const* d =
                dynamic_cast<op::scan::duckdb_native_ingestible_table_info const*>(&info)) {
     ci.catalog_name = d->catalog_name;
@@ -1106,6 +1107,9 @@ std::vector<std::size_t> cache_entry_info::can_serve_with_columns(
   // never serves a scan of the other — the identity check below falls through (a
   // duckdb cache has empty resolved_file_paths; a parquet cache has an empty table_name).
   if (auto const* p = dynamic_cast<op::scan::parquet_ingestible_table_info const*>(&other)) {
+    // A byte-range split scan reads a subset of each file's row groups, so it can neither be
+    // served by a whole-file pin (extra rows) nor produce a pin that serves anyone else.
+    if (has_byte_ranges || p->has_byte_ranges()) { return {}; }
     if (!matches_parquet_files(p->resolved_file_paths)) { return {}; }
     return column_projection_for(p->column_ids);
   }

--- a/test/cpp/scan/test_parquet_byte_range.cpp
+++ b/test/cpp/scan/test_parquet_byte_range.cpp
@@ -18,14 +18,23 @@
 #include <catch.hpp>
 
 // sirius
+#include <io/kvikio/kvikio_context.hpp>
 #include <op/scan/parquet_byte_range.hpp>
+#include <op/scan/parquet_gpu_ingestible.hpp>
 #include <sirius/exception.hpp>
 
 // cudf
+#include <cudf/column/column_factories.hpp>
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/experimental/hybrid_scan.hpp>
+#include <cudf/io/parquet.hpp>
 #include <cudf/io/parquet_io_utils.hpp>
 #include <cudf/io/parquet_schema.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+// rmm
+#include <rmm/device_buffer.hpp>
 
 // standard library
 #include <algorithm>
@@ -225,4 +234,137 @@ TEST_CASE("real footer: rule agrees with cudf's byte-range filter on the test li
     WARN("cudf filter_row_groups_with_byte_range diverges from the StarRocks rule: cudf="
          << cudf_left.size() << " ours=" << left.size());
   }
+}
+
+namespace {
+
+/// Writes a one-column (a BIGINT, values 0..rows-1) parquet with `rows / rows_per_group` row
+/// groups, and returns its path. Deterministic row-group layout for the split-scan tests.
+fs::path write_multi_row_group_parquet(fs::path const& dir,
+                                       std::int64_t rows,
+                                       std::int64_t rows_per_group)
+{
+  auto const path = dir / "byte_range_scan.parquet";
+  auto stream     = cudf::get_default_stream();
+  std::vector<std::int64_t> host(rows);
+  std::iota(host.begin(), host.end(), 0);
+  rmm::device_buffer data(host.data(), rows * sizeof(std::int64_t), stream);
+  auto column = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT64},
+                                               static_cast<cudf::size_type>(rows),
+                                               std::move(data),
+                                               rmm::device_buffer{},
+                                               0);
+  cudf::table_view table({column->view()});
+  cudf::io::table_input_metadata metadata(table);
+  metadata.column_metadata[0].set_name("a");
+  auto options =
+    cudf::io::parquet_writer_options::builder(cudf::io::sink_info(path.string()), table)
+      .metadata(std::move(metadata))
+      .row_group_size_rows(rows_per_group)
+      .build();
+  cudf::io::write_parquet(options);
+  return path;
+}
+
+/// Table info for a byte-range scan of `path` projecting the single BIGINT column.
+std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info> ranged_info(fs::path const& path,
+                                                                             std::uint64_t start,
+                                                                             std::uint64_t length)
+{
+  auto info                  = std::make_unique<sirius::op::scan::parquet_ingestible_table_info>();
+  info->resolved_file_paths  = {path.string()};
+  info->resolved_file_ranges = {{start, length}};
+  info->names                = {"a"};
+  info->returned_types.push_back(sirius::logical_type::make(sirius::type_id::BIGINT));
+  info->column_ids.push_back(duckdb::ColumnIndex(0));
+  info->scan_output_arity      = 1;
+  info->approximate_batch_size = std::size_t{1} << 30;
+  return info;
+}
+
+/// Drives the ingestible for one range and returns the selected row-group indices plus the
+/// number of rows they hold (from the footer metadata — no decode needed).
+std::pair<std::vector<cudf::size_type>, std::int64_t> scan_selection(
+  std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info> info)
+{
+  auto ingestible = sirius::op::scan::make_ingestible(std::move(info));
+  auto ioctx      = std::make_shared<sirius::io::kvikio_context>();
+  auto task       = ingestible->next_split_provider(
+    [ioctx](std::string_view) -> std::shared_ptr<sirius::io::sirius_ioctx> { return ioctx; });
+  REQUIRE(task);
+  auto file = task();
+  REQUIRE(file);
+
+  // Splits materialize downstream of the coalescer, exactly as in production.
+  auto coalescer = ingestible->create_batch_coalescer();
+  auto batches   = coalescer->push(std::move(file));
+  for (auto& batch : coalescer->flush()) {
+    batches.push_back(std::move(batch));
+  }
+
+  std::vector<cudf::size_type> indices;
+  std::int64_t rows = 0;
+  for (auto const& batch : batches) {
+    auto* split = dynamic_cast<sirius::op::scan::parquet_split_info*>(batch.get());
+    REQUIRE(split);
+    for (auto const& slice : split->rg_slices) {
+      for (auto const idx : slice.row_group_indices) {
+        indices.push_back(idx);
+        rows += slice.file_metadata->row_groups.at(idx).num_rows;
+      }
+    }
+  }
+  std::sort(indices.begin(), indices.end());
+  return {indices, rows};
+}
+
+}  // namespace
+
+TEST_CASE("a two-way split scan selects disjoint, complete row groups",
+          "[parquet_byte_range][scan]")
+{
+  auto const dir = fs::temp_directory_path() / "sirius_byte_range_test";
+  fs::create_directories(dir);
+  // cudf clamps row_group_size_rows to a 5000-row floor; 50k rows -> 10 real row groups of
+  // sequential int64s, large enough that both halves of the file hold data pages.
+  constexpr std::int64_t kRows = 50000;
+  auto const path              = write_multi_row_group_parquet(dir, kRows, 5000);
+  auto const file_size         = std::uint64_t(fs::file_size(path));
+  auto const half              = file_size / 2;
+
+  auto [left_rgs, left_rows]   = scan_selection(ranged_info(path, 0, half));
+  auto [right_rgs, right_rows] = scan_selection(ranged_info(path, half, file_size - half));
+
+  INFO("left row groups: " << left_rgs.size() << ", right: " << right_rgs.size());
+  REQUIRE(!left_rgs.empty());
+  REQUIRE(!right_rgs.empty());
+  for (auto const idx : left_rgs) {
+    REQUIRE(std::find(right_rgs.begin(), right_rgs.end(), idx) == right_rgs.end());
+  }
+  REQUIRE(left_rows + right_rows == kRows);
+
+  // A whole-file scan ((0,0) range) is byte-identical to no range at all.
+  auto [all_rgs, all_rows] = scan_selection(ranged_info(path, 0, 0));
+  REQUIRE(all_rows == kRows);
+  REQUIRE(std::int64_t(left_rgs.size() + right_rgs.size()) == std::int64_t(all_rgs.size()));
+
+  // A range inside one row group is a valid empty scan.
+  auto [none_rgs, none_rows] = scan_selection(ranged_info(path, 10, 5));
+  REQUIRE(none_rgs.empty());
+  REQUIRE(none_rows == 0);
+
+  fs::remove_all(dir);
+}
+
+TEST_CASE("mismatched range/path pairing is refused at construction", "[parquet_byte_range][scan]")
+{
+  auto info                  = std::make_unique<sirius::op::scan::parquet_ingestible_table_info>();
+  info->resolved_file_paths  = {"a.parquet", "b.parquet"};
+  info->resolved_file_ranges = {{0, 10}};
+  info->names                = {"a"};
+  info->returned_types.push_back(sirius::logical_type::make(sirius::type_id::BIGINT));
+  info->column_ids.push_back(duckdb::ColumnIndex(0));
+  info->scan_output_arity = 1;
+  REQUIRE_THROWS_AS(sirius::op::scan::make_ingestible(std::move(info)),
+                    sirius::invalid_input_exception);
 }

--- a/test/cpp/scan/test_parquet_byte_range.cpp
+++ b/test/cpp/scan/test_parquet_byte_range.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// test
+#include <catch.hpp>
+
+// sirius
+#include <op/scan/parquet_byte_range.hpp>
+#include <sirius/exception.hpp>
+
+// cudf
+#include <cudf/io/datasource.hpp>
+#include <cudf/io/experimental/hybrid_scan.hpp>
+#include <cudf/io/parquet_io_utils.hpp>
+#include <cudf/io/parquet_schema.hpp>
+
+// standard library
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <numeric>
+#include <set>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+using sirius::op::scan::detail::row_group_start_offset;
+using sirius::op::scan::detail::row_groups_in_byte_range;
+
+namespace {
+
+/// Metadata with one row group per given start offset, encoded the common way
+/// (first column's data_page_offset carries the start; everything else unset).
+cudf::io::parquet::FileMetaData make_metadata(std::vector<std::int64_t> const& rg_starts)
+{
+  cudf::io::parquet::FileMetaData meta;
+  for (auto const start : rg_starts) {
+    cudf::io::parquet::RowGroup rg;
+    cudf::io::parquet::ColumnChunk chunk;
+    chunk.meta_data.data_page_offset = start;
+    rg.columns.push_back(std::move(chunk));
+    meta.row_groups.push_back(std::move(rg));
+  }
+  return meta;
+}
+
+std::vector<cudf::size_type> all_indices(std::size_t n)
+{
+  std::vector<cudf::size_type> all(n);
+  std::iota(all.begin(), all.end(), 0);
+  return all;
+}
+
+fs::path lineitem_parquet_path()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return fs::path(SIRIUS_PROJECT_ROOT) / "test/cpp/integration/data/parquet/lineitem.parquet";
+#else
+  return fs::path(__FILE__).parent_path().parent_path() /
+         "integration/data/parquet/lineitem.parquet";
+#endif
+}
+
+}  // namespace
+
+TEST_CASE("row_group_start_offset follows the StarRocks reader convention", "[parquet_byte_range]")
+{
+  cudf::io::parquet::FileMetaData meta;
+  cudf::io::parquet::RowGroup rg;
+  cudf::io::parquet::ColumnChunk chunk;
+
+  SECTION("data page offset alone")
+  {
+    chunk.meta_data.data_page_offset = 100;
+    rg.columns.push_back(chunk);
+    meta.row_groups.push_back(rg);
+    REQUIRE(row_group_start_offset(meta, 0) == 100);
+  }
+
+  SECTION("dictionary page precedes the data page")
+  {
+    chunk.meta_data.data_page_offset       = 100;
+    chunk.meta_data.dictionary_page_offset = 40;
+    rg.columns.push_back(chunk);
+    meta.row_groups.push_back(rg);
+    REQUIRE(row_group_start_offset(meta, 0) == 40);
+  }
+
+  SECTION("zero offsets count as absent, not as position zero")
+  {
+    chunk.meta_data.data_page_offset       = 100;
+    chunk.meta_data.dictionary_page_offset = 0;
+    chunk.meta_data.index_page_offset      = 0;
+    rg.columns.push_back(chunk);
+    meta.row_groups.push_back(rg);
+    REQUIRE(row_group_start_offset(meta, 0) == 100);
+  }
+
+  SECTION("row group file_offset participates when set")
+  {
+    chunk.meta_data.data_page_offset = 100;
+    rg.columns.push_back(chunk);
+    rg.file_offset = 30;
+    meta.row_groups.push_back(rg);
+    REQUIRE(row_group_start_offset(meta, 0) == 30);
+  }
+
+  SECTION("no candidate offset at all is a loud error, never a guess")
+  {
+    rg.columns.push_back(chunk);  // all offsets zero
+    meta.row_groups.push_back(rg);
+    REQUIRE_THROWS_AS(row_group_start_offset(meta, 0), sirius::invalid_input_exception);
+  }
+}
+
+TEST_CASE("any exact tiling reads every row group exactly once", "[parquet_byte_range]")
+{
+  // Row-group starts chosen so boundaries land before, on, and inside them.
+  auto const starts    = std::vector<std::int64_t>{4, 1000, 1024, 5000, 999999};
+  auto const meta      = make_metadata(starts);
+  auto const file_size = std::uint64_t{1200000};
+
+  // Sweep every tiling of the file into k equal ranges (the FE emits exact tilings).
+  for (std::size_t k : {1, 2, 3, 4, 5, 7, 16}) {
+    std::vector<cudf::size_type> combined;
+    std::set<cudf::size_type> seen;
+    auto const split = file_size / k;
+    for (std::size_t part = 0; part < k; ++part) {
+      auto const start  = part * split;
+      auto const length = (part == k - 1) ? file_size - start : split;
+      auto const owned  = row_groups_in_byte_range(meta, start, length);
+      for (auto const idx : owned) {
+        INFO("tiling k=" << k << " part=" << part);
+        REQUIRE(seen.insert(idx).second);  // pairwise disjoint
+        combined.push_back(idx);
+      }
+    }
+    std::sort(combined.begin(), combined.end());
+    INFO("tiling k=" << k);
+    REQUIRE(combined == all_indices(starts.size()));  // complete
+  }
+}
+
+TEST_CASE("byte-range ownership edge cases", "[parquet_byte_range]")
+{
+  auto const meta = make_metadata({4, 1000, 5000});
+
+  SECTION("whole file owns everything")
+  {
+    REQUIRE(row_groups_in_byte_range(meta, 0, 6000) == all_indices(3));
+  }
+
+  SECTION("a straddling row group belongs to the range holding its start")
+  {
+    // Range ends at 1500, inside row group 1's bytes; rg 1 starts at 1000 -> owned here...
+    REQUIRE(row_groups_in_byte_range(meta, 0, 1500) == std::vector<cudf::size_type>{0, 1});
+    // ...and not by the neighbour that covers its tail.
+    REQUIRE(row_groups_in_byte_range(meta, 1500, 3000) == std::vector<cudf::size_type>{});
+  }
+
+  SECTION("a range inside one row group owns nothing (valid empty split)")
+  {
+    REQUIRE(row_groups_in_byte_range(meta, 1200, 100).empty());
+  }
+
+  SECTION("zero length owns nothing, including the canonical empty split")
+  {
+    REQUIRE(row_groups_in_byte_range(meta, 0, 0).empty());
+    REQUIRE(row_groups_in_byte_range(meta, 6000, 0).empty());
+  }
+
+  SECTION("a boundary exactly on a row-group start assigns it to the right-hand range")
+  {
+    REQUIRE(row_groups_in_byte_range(meta, 4, 996) == std::vector<cudf::size_type>{0});
+    REQUIRE(row_groups_in_byte_range(meta, 1000, 5000) == std::vector<cudf::size_type>{1, 2});
+  }
+}
+
+TEST_CASE("real footer: rule agrees with cudf's byte-range filter on the test lineitem",
+          "[parquet_byte_range]")
+{
+  auto const path = lineitem_parquet_path();
+  REQUIRE(fs::exists(path));
+  auto source = cudf::io::datasource::create(path.string());
+  auto footer = cudf::io::parquet::fetch_footer_to_host(*source);
+  cudf::io::parquet_reader_options options;
+  cudf::io::parquet::experimental::hybrid_scan_reader reader(
+    cudf::host_span<uint8_t const>(footer->data(), footer->size()), options);
+  auto const metadata = reader.parquet_metadata();
+  REQUIRE(!metadata.row_groups.empty());
+  auto const file_size = std::uint64_t(fs::file_size(path));
+
+  // Exactly-once over a two-way tiling of the real file.
+  auto const half = file_size / 2;
+  auto left       = row_groups_in_byte_range(metadata, 0, half);
+  auto right      = row_groups_in_byte_range(metadata, half, file_size - half);
+  std::vector<cudf::size_type> combined = left;
+  combined.insert(combined.end(), right.begin(), right.end());
+  std::sort(combined.begin(), combined.end());
+  REQUIRE(combined == all_indices(metadata.row_groups.size()));
+
+  // Cross-check against cudf's own byte-range pruning. Informational: cudf's definition of a
+  // row group's start is not pinned by its API docs; if this ever diverges, our rule (the
+  // StarRocks reader convention) stays authoritative and this warning says cudf changed.
+  auto all = reader.all_row_groups(options);
+  cudf::io::parquet_reader_options range_options;
+  range_options.set_skip_bytes(0);
+  range_options.set_num_bytes(half);
+  auto cudf_left = reader.filter_row_groups_with_byte_range(
+    cudf::host_span<cudf::size_type const>(all.data(), all.size()), range_options);
+  if (cudf_left != left) {
+    WARN("cudf filter_row_groups_with_byte_range diverges from the StarRocks rule: cudf="
+         << cudf_left.size() << " ours=" << left.size());
+  }
+}


### PR DESCRIPTION
Step 2 of 4 in #1635. **Depends on #1636** — its diff shows that PR's commit too until it merges; this PR's own change is the second commit, `+207/-12` across 5 files.

#1636 added the ownership rule as a pure function that nothing called. This wires it into the scan path, so a byte range now actually reaches the reader.

## What it does

`parquet_ingestible_table_info` gains `resolved_file_ranges`, a per-file `(start, length)` running parallel to `resolved_file_paths`. The split provider pairs each path with its range and hands it to `build_file_scan_info`, which applies `row_groups_in_byte_range` right after `all_row_groups` — **before** stats pruning, so a range and a filter compose rather than fight. The selection flows into `opts.set_row_groups(...)` on the cudf reader.

`(0, 0)` is the whole-file encoding, so every existing plan is byte-identical to before.

## The two cases worth reviewing

**An empty selection is a valid result, not an error.** A range landing inside a single row group owns nothing, and that flows through the existing all-pruned fallback to `set_num_rows(0)` — a schema-correct zero-row split. The failure this avoids is a range that silently degrades to a whole-file read, which across N splits reads every row N times with no error anywhere.

**A range/path count mismatch is refused at construction.** A partial pairing would make ownership ambiguous, and ambiguous ownership is the same silent-duplication bug by another route.

The pinned-table cache learns one fact: a ranged scan holds a fraction of each file's rows, so it neither serves the cache nor is served by it. Matching on the file set alone would return extra or missing rows.

## Tests

Drives the real provider/coalescer path over a generated 10-row-group parquet: two half-file ranges select disjoint row groups whose rows sum to the file total; `(0,0)` equals no range; an inside-one-row-group range is a valid empty scan; the mismatched-pairing refusal.

## Verification

`pixi run make` exit 0 (`[1346/1346] Linking ... sirius_unittest`).
`sirius_unittest "[parquet_byte_range]"` → **All tests passed (84 assertions in 6 test cases)**.
Full suite → **All tests passed (32777505 assertions in 2750 test cases)**.
No compiler diagnostics on `resolved_file_ranges`, `byte_range`, `build_file_scan_info`, or `parquet_byte_range`.

## Not in this PR

Nothing supplies a range yet — the Substrait carriage is step 3. Cherry-picked from `demo-multi-cn` (`a77e52f9`), with one conflict resolved in `parquet_gpu_ingestible.hpp` where `dev` lacks an unrelated helper from that branch.
