### PR TITLE
feat(starrocks): the CN emits byte-range splits instead of refusing them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,6 +385,7 @@ set(EXTENSION_SOURCES
     src/planner/query_index.cpp
     src/planner/sirius_physical_plan_generator.cpp
     src/planner/sirius_plan_aggregate.cpp
+    src/planner/substrait_scan_ranges.cpp
     src/planner/sirius_plan_column_data_get.cpp
     src/planner/sirius_plan_comparison_join.cpp
     src/planner/sirius_plan_compressed_schema.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,7 @@ set(EXTENSION_SOURCES
     src/op/scan/sirius_physical_dynamic_filter.cpp
     src/op/scan/host_keep_mask.cpp
     src/op/scan/owning_table_view.cpp
+    src/op/scan/parquet_byte_range.cpp
     src/op/scan/parquet_schema_mapping.cpp
     src/op/scan/scan_plan.cpp
     src/op/scan/scan_filter_analysis.cpp
@@ -830,6 +831,7 @@ set(TEST_SOURCES
     test/cpp/scan/test_host_keep_mask.cpp
     test/cpp/scan/test_gpu_native_decode.cpp
     test/cpp/scan/test_owning_table_view.cpp
+    test/cpp/scan/test_parquet_byte_range.cpp
     test/cpp/scan/test_parquet_schema_mapping.cpp
     test/cpp/scan/test_parquet_null_count_pruning.cpp
     test/cpp/scan/test_residual_filter.cpp

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -855,24 +855,18 @@ fn and_conditions(
 /// `parquet_scan(<paths>)`. v1 assumes parquet files whose column order matches
 /// the scan tuple's slot order, which holds for `FILES()` `SELECT *`. Without
 /// paths (e.g. HDFS scans) it falls back to a named-table read.
-fn scan_rel(desc: &DescriptorTable, tuple_id: i32, file_paths: &[String]) -> Result<Rel> {
-    let read_type = if file_paths.is_empty() {
+fn scan_rel(
+    desc: &DescriptorTable,
+    tuple_id: i32,
+    files: &[crate::scan_paths::ScanFile],
+) -> Result<Rel> {
+    let read_type = if files.is_empty() {
         ReadType::NamedTable(NamedTable {
             names: desc.table_names_for_tuple(tuple_id)?,
             ..Default::default()
         })
     } else {
-        ReadType::LocalFiles(LocalFiles {
-            items: file_paths
-                .iter()
-                .map(|path| FileOrFiles {
-                    path_type: Some(PathType::UriFile(path.clone())),
-                    file_format: Some(FileFormat::Parquet(ParquetReadOptions {})),
-                    ..Default::default()
-                })
-                .collect(),
-            ..Default::default()
-        })
+        return Ok(local_files_rel(desc.named_struct(tuple_id)?, files));
     };
     Ok(Rel {
         rel_type: Some(rel::RelType::Read(Box::new(ReadRel {
@@ -881,6 +875,37 @@ fn scan_rel(desc: &DescriptorTable, tuple_id: i32, file_paths: &[String]) -> Res
             ..Default::default()
         }))),
     })
+}
+
+/// Builds a local parquet read with an explicit schema, one item per file or byte-range
+/// split. A split's `start`/`length` ride the Substrait item; `(0, 0)` — the proto default —
+/// is the whole-file encoding, which is why a real range is never emitted as `(0, 0)`.
+fn local_files_rel(
+    schema: substrait::proto::NamedStruct,
+    files: &[crate::scan_paths::ScanFile],
+) -> Rel {
+    Rel {
+        rel_type: Some(rel::RelType::Read(Box::new(ReadRel {
+            base_schema: Some(schema),
+            read_type: Some(ReadType::LocalFiles(LocalFiles {
+                items: files
+                    .iter()
+                    .map(|file| {
+                        let (start, length) = file.range.unwrap_or((0, 0));
+                        FileOrFiles {
+                            path_type: Some(PathType::UriFile(file.path.clone())),
+                            file_format: Some(FileFormat::Parquet(ParquetReadOptions {})),
+                            start,
+                            length,
+                            ..Default::default()
+                        }
+                    })
+                    .collect(),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }))),
+    }
 }
 
 /// Translates a StarRocks project node while preserving descriptor output order.

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
@@ -12,26 +12,49 @@ use starrocks_thrift::types::TFileType;
 use crate::descriptor_table::DescriptorTable;
 use crate::error::{Result, TranslateError};
 
-/// Parquet file paths for each scan node in a fragment, keyed by plan node id.
+/// Parquet files (whole or byte-range slices) for each scan node in a fragment, keyed by plan
+/// node id.
 ///
-/// Built from the fragment's broker scan ranges so `FILE_SCAN` nodes emit
-/// Substrait `local_files` reads DuckDB resolves as `parquet_scan(<paths>)`.
-/// Nodes without broker ranges have no entry and fall back to a named-table read.
+/// Built from the fragment's broker scan ranges so `FILE_SCAN` nodes emit Substrait
+/// `local_files` reads DuckDB resolves as `parquet_scan(<paths>)`. Nodes without broker ranges
+/// have no entry and fall back to a named-table read.
 ///
-/// Collection fails closed: only the slice that maps faithfully onto a
-/// `parquet_scan` over local files is accepted — a `FILES()` query (not a load),
-/// reading whole local parquet files whose columns are direct passthroughs to the
-/// scan tuple. Anything else (loads, byte-range splits, remote schemes, casts or
-/// other column transforms, path-derived or flexibly-mapped columns) is rejected
-/// with [`TranslateError::UnsupportedScanRange`] rather than silently producing
-/// wrong results.
+/// Collection fails closed: only the slice that maps faithfully onto a `parquet_scan` over
+/// local files is accepted — a `FILES()` query (not a load), reading local parquet files whose
+/// columns are direct passthroughs to the scan tuple. Byte ranges assigned to this instance are
+/// normalized per file: overlaps are refused (they would read rows twice), adjacent ranges
+/// coalesce, an exact tiling of the whole file collapses to a whole-file read, and anything
+/// else is emitted as explicit `[start, start+length)` splits — the engine reads exactly the
+/// row groups whose start offset falls inside each split, so the instances of a distributed
+/// scan together read every row exactly once. Anything outside that slice (loads, remote
+/// schemes, casts or other column transforms, path-derived or flexibly-mapped columns,
+/// incremental `has_more` delivery) is rejected with [`TranslateError::UnsupportedScanRange`]
+/// rather than silently producing wrong results.
 #[derive(Debug, Default)]
 pub(crate) struct ScanFilePaths {
     by_node: HashMap<i32, Vec<String>>,
+    byte_ranges: HashMap<i32, HashMap<String, Vec<ByteRange>>>,
+    resolved: HashMap<i32, Vec<ScanFile>>,
+}
+
+/// One file — or one byte-range slice of a file — a scan node reads.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ScanFile {
+    pub path: String,
+    /// `Some((start, length))` for a byte-range split; `None` reads the whole file. `(0, 0)`
+    /// is never emitted as a range — it is the whole-file encoding on the wire.
+    pub range: Option<(u64, u64)>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ByteRange {
+    start: i64,
+    size: i64,
+    file_size: Option<i64>,
 }
 
 impl ScanFilePaths {
-    /// Collects whole-file parquet paths from `params`' broker scan ranges.
+    /// Collects complete parquet paths from `params`' broker scan ranges.
     ///
     /// Ranges arrive either per node (`per_node_scan_ranges`) or, for pipeline
     /// fragments, per driver sequence (`node_to_per_driver_seq_scan_ranges`);
@@ -65,19 +88,20 @@ impl ScanFilePaths {
                 }
             }
         }
+        paths.resolve_ranges()?;
         Ok(paths)
     }
 
-    /// Returns the parquet file paths collected for `node_id`, empty when the node
-    /// has no broker scan ranges (it then falls back to a named-table read).
-    pub(crate) fn for_node(&self, node_id: i32) -> &[String] {
-        self.by_node
+    /// Returns the parquet files (whole or ranged) collected for `node_id`, empty when the
+    /// node has no broker scan ranges (it then falls back to a named-table read).
+    pub(crate) fn for_node(&self, node_id: i32) -> &[ScanFile] {
+        self.resolved
             .get(&node_id)
             .map(Vec::as_slice)
             .unwrap_or_default()
     }
 
-    /// Validates and appends the whole-file parquet paths in `ranges` to `node_id`.
+    /// Validates and appends parquet paths and byte ranges in `ranges` to `node_id`.
     fn add_ranges(
         &mut self,
         node_id: i32,
@@ -85,17 +109,149 @@ impl ScanFilePaths {
         desc: &DescriptorTable,
     ) -> Result<()> {
         for range in ranges {
+            // Incremental delivery: more ranges follow through deliver_scan_ranges, which this
+            // CN does not implement — accepting the prefix would silently read a subset.
+            if range.has_more == Some(true) {
+                return Err(Self::unsupported(
+                    node_id,
+                    "incremental scan-range delivery (has_more) is not supported",
+                ));
+            }
+            // An explicitly empty placeholder range carries no file.
+            if range.empty == Some(true) {
+                continue;
+            }
             let Some(broker) = range.scan_range.broker_scan_range.as_ref() else {
                 continue;
             };
             Self::check_params(node_id, &broker.params, desc)?;
             for range_desc in &broker.ranges {
                 Self::check_range(node_id, range_desc)?;
-                self.by_node
+                let node_paths = self.by_node.entry(node_id).or_default();
+                if !node_paths.contains(&range_desc.path) {
+                    node_paths.push(range_desc.path.clone());
+                }
+                self.byte_ranges
                     .entry(node_id)
                     .or_default()
-                    .push(range_desc.path.clone());
+                    .entry(range_desc.path.clone())
+                    .or_default()
+                    .push(ByteRange {
+                        start: range_desc.start_offset,
+                        size: range_desc.size,
+                        file_size: range_desc.file_size,
+                    });
             }
+        }
+        Ok(())
+    }
+
+    /// Normalizes each file's byte ranges into the [`ScanFile`]s this instance reads.
+    ///
+    /// Overlaps are refused — under start-offset row-group ownership two overlapping ranges
+    /// would read the same row groups twice, silently. Adjacent ranges coalesce; an exact
+    /// tiling of the whole file collapses to a whole-file read (so single-instance plans stay
+    /// byte-identical to before splits existed); everything else becomes explicit ranges. The
+    /// rest of the file belongs to other instances of the same distributed scan.
+    fn resolve_ranges(&mut self) -> Result<()> {
+        for (&node_id, node_paths) in &self.by_node {
+            let files = self.byte_ranges.get(&node_id);
+            let mut scan_files = Vec::new();
+            for path in node_paths {
+                let ranges = files
+                    .and_then(|files| files.get(path))
+                    .map(Vec::as_slice)
+                    .unwrap_or_default();
+                let Some(file_size) = ranges.first().and_then(|range| range.file_size) else {
+                    return Err(Self::unsupported(
+                        node_id,
+                        "scan range is missing the parquet file size",
+                    ));
+                };
+                if file_size <= 0
+                    || ranges
+                        .iter()
+                        .any(|range| range.file_size != Some(file_size))
+                {
+                    return Err(Self::unsupported(
+                        node_id,
+                        "scan ranges disagree on the parquet file size",
+                    ));
+                }
+                let file_size = file_size as u64;
+
+                let mut intervals = Vec::with_capacity(ranges.len());
+                for range in ranges {
+                    if range.start < 0 {
+                        return Err(Self::unsupported(
+                            node_id,
+                            "scan range has a negative start offset",
+                        ));
+                    }
+                    let start = range.start as u64;
+                    let end = match range.size {
+                        -1 => file_size, // "to end of file"
+                        size if size >= 0 => start.saturating_add(size as u64),
+                        _ => {
+                            return Err(Self::unsupported(
+                                node_id,
+                                "scan range has a negative size",
+                            ));
+                        }
+                    };
+                    if end > file_size {
+                        return Err(Self::unsupported(
+                            node_id,
+                            "byte range extends past the end of the parquet file",
+                        ));
+                    }
+                    // Empty ranges (size 0, or -1 starting at EOF) own nothing.
+                    if start >= end {
+                        continue;
+                    }
+                    intervals.push((start, end));
+                }
+                intervals.sort_unstable();
+
+                let mut coalesced: Vec<(u64, u64)> = Vec::new();
+                for (start, end) in intervals {
+                    if let Some(last) = coalesced.last_mut() {
+                        if start < last.1 {
+                            return Err(Self::unsupported(
+                                node_id,
+                                "overlapping byte ranges would read the same rows twice",
+                            ));
+                        }
+                        if start == last.1 {
+                            last.1 = end;
+                            continue;
+                        }
+                    }
+                    coalesced.push((start, end));
+                }
+
+                if coalesced == [(0, file_size)] {
+                    scan_files.push(ScanFile {
+                        path: path.clone(),
+                        range: None,
+                    });
+                } else {
+                    for (start, end) in coalesced {
+                        scan_files.push(ScanFile {
+                            path: path.clone(),
+                            range: Some((start, end - start)),
+                        });
+                    }
+                }
+            }
+            // Zero owned bytes must not fall back to a named-table read of something else.
+            if scan_files.is_empty() {
+                return Err(Self::unsupported(
+                    node_id,
+                    "scan instance owns only empty byte ranges",
+                ));
+            }
+            self.resolved.insert(node_id, scan_files);
         }
         Ok(())
     }
@@ -169,7 +325,7 @@ impl ScanFilePaths {
         Ok(())
     }
 
-    /// Rejects a single broker range outside the supported whole-file local-parquet slice.
+    /// Rejects a broker range outside the supported local-parquet slice.
     fn check_range(node_id: i32, desc: &TBrokerRangeDesc) -> Result<()> {
         if desc.format_type != TFileFormatType::FORMAT_PARQUET {
             return Err(Self::unsupported(
@@ -185,24 +341,6 @@ impl ScanFilePaths {
                 "only broker-descriptor file scan ranges are supported",
             ));
         }
-        // Whole-file only: DuckDB's `local_files` reader ignores per-file byte
-        // offsets, so accept a range only when it provably covers the whole,
-        // non-empty file. A FILES() query stats each file, so require a known
-        // positive `file_size` reached by reading to EOF (`size == -1`) or by a
-        // bounded size at least that large. Unknown size, an empty file, or a
-        // bounded size short of the file are rejected rather than silently reading
-        // the wrong bytes.
-        let whole_file = desc.start_offset == 0
-            && match desc.file_size {
-                Some(file_size) => file_size > 0 && (desc.size == -1 || desc.size >= file_size),
-                None => false,
-            };
-        if !whole_file {
-            return Err(Self::unsupported(
-                node_id,
-                "byte-range split scan ranges are not supported",
-            ));
-        }
         // StarRocks appends path-derived columns after the physical parquet
         // columns; `parquet_scan` over the path alone would not produce them, so
         // the descriptor slot order would no longer match.
@@ -214,6 +352,18 @@ impl ScanFilePaths {
             return Err(Self::unsupported(
                 node_id,
                 "path-derived columns (columns_from_path) are not supported",
+            ));
+        }
+        // Parquet compression is per-page inside the file; an outer compression_type on the
+        // range describes a compressed *container* the reader would have to unwrap first.
+        // The FE leaves it unset (or NO_COMPRESSION) for plain parquet files.
+        if desc.compression_type.is_some_and(|compression| {
+            compression != starrocks_thrift::types::TCompressionType::NO_COMPRESSION
+                && compression != starrocks_thrift::types::TCompressionType::UNKNOWN_COMPRESSION
+        }) {
+            return Err(Self::unsupported(
+                node_id,
+                "an outer compression_type on a parquet scan range is not supported",
             ));
         }
         Self::check_local_path(node_id, &desc.path)

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use starrocks_plan_translator::{
-    ExtensionRegistry, PlanTranslator, TranslateError, URN_BOOLEAN, URN_COMPARISON,
+    ExtensionRegistry, PlanTranslator, TranslateError, TranslatedPlan, URN_BOOLEAN, URN_COMPARISON,
     translate_fragment,
 };
 use starrocks_thrift::descriptors::{
@@ -636,36 +636,198 @@ fn non_parquet_broker_range_is_unsupported() {
 /// Verifies a byte-range split broker scan range is rejected as unsupported,
 /// both for a non-zero start offset and for a first split (offset 0, partial size).
 #[test]
-fn split_broker_range_is_unsupported() {
-    for range in [
-        broker_scan_range(
-            "file:///data/users.parquet",
-            TFileFormatType::FORMAT_PARQUET,
-            1024,
-            -1,
+fn split_broker_range_without_a_file_size_is_unsupported() {
+    // Without the total file size a range cannot be validated against EOF or collapsed when
+    // it tiles the whole file.
+    let err = PlanTranslator::new()
+        .translate_fragment(&params_with_scan_range(
+            TPlan::new(vec![scan_node(0, 0)]),
+            base_desc(),
+            0,
+            broker_scan_range(
+                "file:///data/users.parquet",
+                TFileFormatType::FORMAT_PARQUET,
+                1024,
+                -1,
+                None,
+            ),
+        ))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        TranslateError::UnsupportedScanRange { node_id: 0, .. }
+    ));
+}
+
+/// Extracts the LocalFiles items of the plan's root read.
+fn local_files_items(
+    translated: &TranslatedPlan,
+) -> &[substrait::proto::read_rel::local_files::FileOrFiles] {
+    let rel::RelType::Read(read) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected local read");
+    };
+    let Some(read_rel::ReadType::LocalFiles(files)) = read.read_type.as_ref() else {
+        panic!("expected local files");
+    };
+    &files.items
+}
+
+/// Verifies a byte-range split translates to a local-files item carrying the range — the
+/// exact shape a live 2-CN FE emits (162140518-byte lineitem split at 81070259).
+#[test]
+fn split_broker_range_emits_a_ranged_local_file() {
+    let path = "file:///data/lineitem.parquet";
+    let translated = PlanTranslator::new()
+        .translate_fragment(&params_with_scan_range(
+            TPlan::new(vec![scan_node(0, 0)]),
+            base_desc(),
+            0,
+            broker_scan_range(
+                path,
+                TFileFormatType::FORMAT_PARQUET,
+                81070259,
+                81070259,
+                Some(162140518),
+            ),
+        ))
+        .unwrap();
+    let items = local_files_items(&translated);
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].start, 81070259);
+    assert_eq!(items[0].length, 81070259);
+}
+
+/// Verifies `size == -1` reads from the start offset to the end of the file.
+#[test]
+fn open_ended_split_reads_to_the_end_of_the_file() {
+    let translated = PlanTranslator::new()
+        .translate_fragment(&params_with_scan_range(
+            TPlan::new(vec![scan_node(0, 0)]),
+            base_desc(),
+            0,
+            broker_scan_range(
+                "file:///data/users.parquet",
+                TFileFormatType::FORMAT_PARQUET,
+                1024,
+                -1,
+                Some(4096),
+            ),
+        ))
+        .unwrap();
+    let items = local_files_items(&translated);
+    assert_eq!(items.len(), 1);
+    assert_eq!((items[0].start, items[0].length), (1024, 3072));
+}
+
+/// Verifies overlapping ranges are refused: under start-offset row-group ownership they would
+/// read the same rows twice, silently.
+#[test]
+fn overlapping_split_ranges_are_refused() {
+    let path = "file:///data/users.parquet";
+    let mut fragment = params_with_scan_range(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        0,
+        broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, 600, Some(1024)),
+    );
+    fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap()
+        .push(TScanRangeParams::new(
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 512, 512, Some(1024)),
             None,
-        ),
+            None,
+            None,
+        ));
+    let err = PlanTranslator::new()
+        .translate_fragment(&fragment)
+        .unwrap_err();
+    assert!(err.to_string().contains("overlapping"), "{err}");
+}
+
+/// Verifies a range extending past the end of the file is refused.
+#[test]
+fn split_past_the_end_of_the_file_is_refused() {
+    let err = PlanTranslator::new()
+        .translate_fragment(&params_with_scan_range(
+            TPlan::new(vec![scan_node(0, 0)]),
+            base_desc(),
+            0,
+            broker_scan_range(
+                "file:///data/users.parquet",
+                TFileFormatType::FORMAT_PARQUET,
+                512,
+                1024,
+                Some(1024),
+            ),
+        ))
+        .unwrap_err();
+    assert!(err.to_string().contains("past the end"), "{err}");
+}
+
+/// Verifies an outer compression_type on a parquet range is refused — it describes a
+/// compressed container the reader would have to unwrap, not parquet's per-page compression.
+#[test]
+fn compressed_container_scan_range_is_refused() {
+    let mut range = broker_scan_range(
+        "file:///data/users.parquet",
+        TFileFormatType::FORMAT_PARQUET,
+        0,
+        -1,
+        Some(1024),
+    );
+    range.broker_scan_range.as_mut().unwrap().ranges[0].compression_type =
+        Some(starrocks_thrift::types::TCompressionType::GZIP);
+    let err = PlanTranslator::new()
+        .translate_fragment(&params_with_scan_range(
+            TPlan::new(vec![scan_node(0, 0)]),
+            base_desc(),
+            0,
+            range,
+        ))
+        .unwrap_err();
+    assert!(err.to_string().contains("compression"), "{err}");
+}
+
+/// Verifies incremental scan-range delivery is refused: this CN never receives the rest, so
+/// accepting the prefix would silently read a subset of the data.
+#[test]
+fn has_more_scan_ranges_are_refused() {
+    let mut fragment = params_with_scan_range(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        0,
         broker_scan_range(
             "file:///data/users.parquet",
             TFileFormatType::FORMAT_PARQUET,
             0,
-            512,
+            -1,
             Some(1024),
         ),
-    ] {
-        let err = PlanTranslator::new()
-            .translate_fragment(&params_with_scan_range(
-                TPlan::new(vec![scan_node(0, 0)]),
-                base_desc(),
-                0,
-                range,
-            ))
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            TranslateError::UnsupportedScanRange { node_id: 0, .. }
-        ));
-    }
+    );
+    fragment
+        .params
+        .as_mut()
+        .unwrap()
+        .per_node_scan_ranges
+        .get_mut(&0)
+        .unwrap()[0]
+        .has_more = Some(true);
+    let err = PlanTranslator::new()
+        .translate_fragment(&fragment)
+        .unwrap_err();
+    assert!(err.to_string().contains("has_more"), "{err}");
 }
 
 /// Verifies a scan range delivered via the pipeline per-driver-sequence map is

--- a/rust/crates/sirius/src/lib.rs
+++ b/rust/crates/sirius/src/lib.rs
@@ -157,10 +157,11 @@ mod tests {
         let _ctx = SiriusContext::new().expect("bring up default Sirius context");
     }
 
-    /// Encodes a single-file `local_files` parquet read plan with `names` as the
-    /// root output names — the shape DuckDB's Substrait reader resolves to
-    /// `parquet_scan(<path>)`.
-    fn local_files_plan(path: &str, names: Vec<String>) -> Vec<u8> {
+    /// Encodes a `local_files` parquet read plan with `names` as the root output names and one
+    /// item per `(path, start, length)` — `(0, 0)` meaning the whole file. The shape DuckDB's
+    /// Substrait reader resolves to `parquet_scan(<path>)`; a non-zero range is what a compute
+    /// node emits for one byte-range split of a distributed scan.
+    fn local_files_plan_ranged(items: &[(&str, u64, u64)], names: Vec<String>) -> Vec<u8> {
         use substrait::proto::read_rel::local_files::FileOrFiles;
         use substrait::proto::read_rel::local_files::file_or_files::{
             FileFormat, ParquetReadOptions, PathType,
@@ -171,11 +172,16 @@ mod tests {
         let read = Rel {
             rel_type: Some(rel::RelType::Read(Box::new(ReadRel {
                 read_type: Some(ReadType::LocalFiles(LocalFiles {
-                    items: vec![FileOrFiles {
-                        path_type: Some(PathType::UriFile(path.to_string())),
-                        file_format: Some(FileFormat::Parquet(ParquetReadOptions {})),
-                        ..Default::default()
-                    }],
+                    items: items
+                        .iter()
+                        .map(|(path, start, length)| FileOrFiles {
+                            path_type: Some(PathType::UriFile(path.to_string())),
+                            file_format: Some(FileFormat::Parquet(ParquetReadOptions {})),
+                            start: *start,
+                            length: *length,
+                            ..Default::default()
+                        })
+                        .collect(),
                     ..Default::default()
                 })),
                 ..Default::default()
@@ -191,6 +197,33 @@ mod tests {
             ..Default::default()
         }
         .encode_to_vec()
+    }
+
+    /// Encodes a single-file whole-file `local_files` parquet read plan.
+    fn local_files_plan(path: &str, names: Vec<String>) -> Vec<u8> {
+        local_files_plan_ranged(&[(path, 0, 0)], names)
+    }
+
+    /// Writes a `(id BIGINT, name VARCHAR)` parquet with `rows` rows split into row groups of
+    /// `rows_per_group`, so a byte range of the file holds a real subset of its row groups.
+    fn write_multi_row_group_parquet(path: &Path, rows: i64, rows_per_group: usize) {
+        use parquet::file::properties::WriterProperties;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let ids: ArrayRef = Arc::new(Int64Array::from((0..rows).collect::<Vec<_>>()));
+        let names: ArrayRef = Arc::new(StringArray::from(
+            (0..rows).map(|i| format!("n{i}")).collect::<Vec<_>>(),
+        ));
+        let batch = RecordBatch::try_new(schema.clone(), vec![ids, names]).unwrap();
+        let props = WriterProperties::builder()
+            .set_max_row_group_row_count(Some(rows_per_group))
+            .build();
+        let file = std::fs::File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
     }
 
     /// End-to-end: execute a `local_files` parquet plan on the GPU and read the
@@ -242,6 +275,93 @@ mod tests {
             let total_rows: usize = result.batches.iter().map(RecordBatch::num_rows).sum();
             assert_eq!(total_rows, 3, "expected 3 rows from the parquet fixture");
         }
+    }
+
+    /// Flattens a result's batches into sorted `(id, name)` rows, so two scans can be
+    /// compared as sets regardless of how the engine chunked them into batches.
+    fn rows(result: &super::SubstraitResult) -> Vec<(i64, String)> {
+        let mut rows = Vec::new();
+        for batch in &result.batches {
+            let ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("id column");
+            let names = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("name column");
+            for i in 0..batch.num_rows() {
+                rows.push((ids.value(i), names.value(i).to_string()));
+            }
+        }
+        rows.sort();
+        rows
+    }
+
+    /// Byte-range splits of one parquet file must read every row exactly once: each split
+    /// yields a disjoint subset, their union is the whole file, and one plan carrying both
+    /// splits as separate LocalFiles items equals the whole-file plan. Requires a GPU.
+    #[test]
+    fn byte_range_splits_read_every_row_exactly_once() {
+        let _guard = GPU_CONTEXT_LOCK
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("many.parquet");
+        // 30k rows in ~6 row groups: big enough that both halves hold data pages.
+        write_multi_row_group_parquet(&path, 30000, 5000);
+        let file_size = std::fs::metadata(&path).unwrap().len();
+        let half = file_size / 2;
+        let p = path.to_str().unwrap();
+        let names = || vec!["id".to_string(), "name".to_string()];
+
+        let mut ctx = SiriusContext::new().expect("bring up sirius context");
+        let whole = ctx
+            .execute_substrait_result(&local_files_plan(p, names()))
+            .expect("whole-file plan");
+        let left = ctx
+            .execute_substrait_result(&local_files_plan_ranged(&[(p, 0, half)], names()))
+            .expect("left split plan");
+        let right = ctx
+            .execute_substrait_result(&local_files_plan_ranged(
+                &[(p, half, file_size - half)],
+                names(),
+            ))
+            .expect("right split plan");
+
+        let whole_rows = rows(&whole);
+        let left_rows = rows(&left);
+        let right_rows = rows(&right);
+        assert_eq!(whole_rows.len(), 30000);
+        assert!(!left_rows.is_empty(), "left split must own row groups");
+        assert!(!right_rows.is_empty(), "right split must own row groups");
+        let mut union = left_rows.clone();
+        union.extend(right_rows.iter().cloned());
+        union.sort();
+        assert_eq!(
+            union, whole_rows,
+            "splits must partition the file: no duplication, no loss"
+        );
+
+        // Both splits in ONE plan (two LocalFiles items for the same path) also equal the
+        // whole file — the multi-range-per-instance shape a CN emits when the FE co-locates
+        // two splits of one file.
+        let both = ctx
+            .execute_substrait_result(&local_files_plan_ranged(
+                &[(p, 0, half), (p, half, file_size - half)],
+                names(),
+            ))
+            .expect("two-splits-one-plan");
+        assert_eq!(rows(&both), whole_rows);
+
+        // An empty split (range inside one row group) is a valid empty result, not an error.
+        let empty = ctx
+            .execute_substrait_result(&local_files_plan_ranged(&[(p, 10, 5)], names()))
+            .expect("empty split plan");
+        assert_eq!(rows(&empty).len(), 0);
     }
 
     /// A missing config file is rejected before any GPU work (`load_from_file`

--- a/src/include/op/scan/parquet_byte_range.hpp
+++ b/src/include/op/scan/parquet_byte_range.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// cudf
+#include <cudf/io/parquet_schema.hpp>
+#include <cudf/types.hpp>
+
+// standard library
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace sirius::op::scan::detail {
+
+/**
+ * @brief Byte offset where row group @p index starts, per the StarRocks reader convention.
+ *
+ * A distributed byte-range scan is correct only if every reader of the same file derives the
+ * same start offset per row group — the FE load-balances splits assuming its readers follow
+ * the StarRocks BE rule (be/src/formats/parquet/utils.cpp): the minimum of the first column
+ * chunk's data/index/dictionary page offsets and the row group's own file_offset, where each
+ * candidate counts only when present. cudf's thrift structs carry no __isset, so a page
+ * offset of 0 is treated as absent (real offsets start after the 4-byte magic).
+ *
+ * @throws sirius::invalid_input_exception if no candidate offset is present — ownership
+ *         would be undefined, and guessing risks reading rows twice or not at all.
+ */
+[[nodiscard]] std::int64_t row_group_start_offset(cudf::io::parquet::FileMetaData const& metadata,
+                                                  std::size_t index);
+
+/**
+ * @brief Row groups owned by the byte range [start, start+length).
+ *
+ * Ownership is start-offset containment: row group i belongs to the range iff
+ * `start <= row_group_start_offset(i) < start + length`. A row group straddling the range end
+ * is still owned in full by this range (the byte range bounds ownership, not I/O), and a range
+ * that contains no start offset owns nothing — the caller must treat that as a valid empty
+ * scan. Together these make any exact tiling of the file read every row group exactly once.
+ *
+ * @return Indices into @p metadata.row_groups, ascending.
+ */
+[[nodiscard]] std::vector<cudf::size_type> row_groups_in_byte_range(
+  cudf::io::parquet::FileMetaData const& metadata, std::uint64_t start, std::uint64_t length);
+
+}  // namespace sirius::op::scan::detail

--- a/src/include/op/scan/parquet_gpu_ingestible.hpp
+++ b/src/include/op/scan/parquet_gpu_ingestible.hpp
@@ -35,6 +35,7 @@
 #include <cudf/io/parquet.hpp>
 
 // standard library
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -42,6 +43,7 @@
 #include <memory>
 #include <span>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace sirius::scan_manager {
@@ -67,6 +69,12 @@ class parquet_ingestible_table_info : public ingestible_table_info {
  public:
   duckdb::vector<sirius::logical_type> returned_types;
   std::vector<std::string> resolved_file_paths;
+  /// Per-file byte range `[start, start+length)`, parallel to @ref resolved_file_paths.
+  /// Empty means every file is read whole; a `(0,0)` entry means that file is read whole.
+  /// A ranged file reads only the row groups whose start offset falls inside the range
+  /// (see parquet_byte_range.hpp) — the mechanism behind distributed byte-range splits,
+  /// where N ranges of one file must read every row exactly once across scan instances.
+  std::vector<std::pair<std::uint64_t, std::uint64_t>> resolved_file_ranges;
   duckdb::vector<duckdb::ColumnIndex> column_ids;
   duckdb::vector<duckdb::idx_t> projection_ids;
   duckdb::vector<std::string> names;
@@ -84,6 +92,14 @@ class parquet_ingestible_table_info : public ingestible_table_info {
   std::size_t scan_output_arity      = 0;
 
   parquet_ingestible_table_info() = default;
+
+  /// True when any file carries a real byte range (a `(0,0)` entry is a whole file).
+  [[nodiscard]] bool has_byte_ranges() const
+  {
+    return std::any_of(resolved_file_ranges.begin(),
+                       resolved_file_ranges.end(),
+                       [](auto const& range) { return range.second != 0 || range.first != 0; });
+  }
 
   [[nodiscard]] std::span<std::string const> column_names() const override { return names; }
 
@@ -317,12 +333,15 @@ class parquet_gpu_ingestible : public gpu_ingestible {
   }
 
  private:
-  /// Read one file's footer, prune its row groups against the filter, and record
-  /// per-row-group byte accounting. Returns a single @c parquet_file_scan_info.
-  /// Runs on a scan-manager dispatcher thread (the task returned by
-  /// @ref next_split_provider).
-  std::unique_ptr<scan_info> build_file_scan_info(std::string const& file_path,
-                                                  std::shared_ptr<io::sirius_ioctx> const& io_ctx);
+  /// Read one file's footer, prune its row groups against the byte range and the filter, and
+  /// record per-row-group byte accounting. Returns a single @c parquet_file_scan_info.
+  /// `byte_range` is `(0,0)` for a whole-file read; otherwise only row groups starting inside
+  /// `[start, start+length)` are read. Runs on a scan-manager dispatcher thread (the task
+  /// returned by @ref next_split_provider).
+  std::unique_ptr<scan_info> build_file_scan_info(
+    std::string const& file_path,
+    std::pair<std::uint64_t, std::uint64_t> byte_range,
+    std::shared_ptr<io::sirius_ioctx> const& io_ctx);
 
   std::unique_ptr<parquet_ingestible_table_info> _info;
 

--- a/src/include/planner/substrait_scan_ranges.hpp
+++ b/src/include/planner/substrait_scan_ranges.hpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <duckdb/main/client_context_state.hpp>
+
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace sirius::planner {
+
+using scan_byte_range = std::pair<std::uint64_t, std::uint64_t>;
+
+/**
+ * @brief Per-plan parquet byte ranges, carried out-of-band from the Substrait plan.
+ *
+ * A distributed split scan encodes each split as `FileOrFiles.start/length` in the plan's
+ * LocalFiles read. DuckDB's Substrait consumer and its `parquet_scan` binding have no byte-range
+ * parameter, so the range cannot ride the relation tree: `lower_substrait` extracts every range
+ * from the plan bytes into this state, and `build_parquet_table_info` claims them when it lifts
+ * the scan's bind data into the GPU ingestible.
+ *
+ * The failure mode this state's discipline prevents is silent: a range that is emitted but not
+ * applied degrades to a whole-file read, and N splits of one file then read every row N times.
+ * Hence claims are per-file and single-shot (a second claim throws — two scans sharing a ranged
+ * file would double-read), and `assert_all_consumed` runs after plan generation so an unclaimed
+ * range is a loud error. `lower_substrait` replaces the state on every plan, so a stale registry
+ * can never leak ranges into the next statement.
+ */
+class scan_byte_ranges_state : public duckdb::ClientContextState {
+ public:
+  static constexpr const char* kStateKey = "sirius_scan_byte_ranges";
+
+  explicit scan_byte_ranges_state(std::map<std::string, std::vector<scan_byte_range>> ranges)
+    : _ranges(std::move(ranges))
+  {
+  }
+
+  [[nodiscard]] bool has(const std::string& path) const;
+
+  /// Claims every range registered for `path`. Single-shot per file.
+  /// @throws sirius::invalid_input_exception on a second claim of the same file.
+  [[nodiscard]] std::vector<scan_byte_range> claim(const std::string& path);
+
+  /// @throws sirius::invalid_input_exception naming any file whose ranges were never claimed —
+  /// the scan that should honor them would otherwise silently read whole files.
+  void assert_all_consumed() const;
+
+ private:
+  std::map<std::string, std::vector<scan_byte_range>> _ranges;
+  std::set<std::string> _claimed;
+};
+
+/**
+ * @brief Extracts `path -> byte ranges` from every LocalFiles read in a Substrait plan.
+ *
+ * Only items carrying a real range (`start`/`length` not both zero) are returned; a whole-file
+ * item contributes nothing. The relation walk is exhaustive over the rel types this engine can
+ * receive and THROWS on an unknown one: skipping it could hide a ranged read, and a hidden
+ * ranged read silently duplicates rows.
+ */
+[[nodiscard]] std::map<std::string, std::vector<scan_byte_range>> extract_scan_byte_ranges(
+  const std::string& plan_bytes);
+
+}  // namespace sirius::planner

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -109,7 +109,11 @@ namespace sirius::scan_manager {
 /// owns the match logic that @ref sirius_scan_manager::try_match_cached_entry consults.
 class cache_entry_info {
  public:
-  std::vector<std::string> resolved_file_paths;    ///< parquet identity (file set)
+  std::vector<std::string> resolved_file_paths;  ///< parquet identity (file set)
+  /// True when the parquet scan behind this entry read byte-range subsets of its files. A
+  /// ranged scan holds a fraction of each file's rows, so it neither serves nor is served by
+  /// the cache — matching on the file set alone would silently return extra or missing rows.
+  bool has_byte_ranges = false;
   std::string catalog_name;                        ///< duckdb identity: catalog (attach alias)
   std::string schema_name;                         ///< duckdb identity: schema
   std::string table_name;                          ///< duckdb identity: table

--- a/src/op/scan/parquet_byte_range.cpp
+++ b/src/op/scan/parquet_byte_range.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/scan/parquet_byte_range.hpp"
+
+#include "sirius/exception.hpp"
+
+#include <algorithm>
+#include <limits>
+
+namespace sirius::op::scan::detail {
+
+std::int64_t row_group_start_offset(cudf::io::parquet::FileMetaData const& metadata,
+                                    std::size_t index)
+{
+  auto const& row_group = metadata.row_groups.at(index);
+  auto start            = std::numeric_limits<std::int64_t>::max();
+  if (row_group.file_offset.has_value() && *row_group.file_offset > 0) {
+    start = std::min(start, *row_group.file_offset);
+  }
+  if (!row_group.columns.empty()) {
+    auto const& first_column = row_group.columns.front().meta_data;
+    for (auto const offset : {first_column.data_page_offset,
+                              first_column.index_page_offset,
+                              first_column.dictionary_page_offset}) {
+      if (offset > 0) { start = std::min(start, offset); }
+    }
+  }
+  if (start == std::numeric_limits<std::int64_t>::max()) {
+    throw sirius::invalid_input_exception(
+      "parquet row group {} has no page or file offset; byte-range ownership would be "
+      "undefined",
+      index);
+  }
+  return start;
+}
+
+std::vector<cudf::size_type> row_groups_in_byte_range(
+  cudf::io::parquet::FileMetaData const& metadata, std::uint64_t start, std::uint64_t length)
+{
+  std::vector<cudf::size_type> owned;
+  if (length == 0) { return owned; }
+  auto const end = start + length;
+  for (std::size_t i = 0; i < metadata.row_groups.size(); ++i) {
+    auto const rg_start = static_cast<std::uint64_t>(row_group_start_offset(metadata, i));
+    if (start <= rg_start && rg_start < end) { owned.push_back(static_cast<cudf::size_type>(i)); }
+  }
+  return owned;
+}
+
+}  // namespace sirius::op::scan::detail

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -26,6 +26,7 @@
 #include <log/logging.hpp>
 #include <op/dynamic_filter/sirius_dynamic_filter.hpp>
 #include <op/scan/dynamic_filter_merge.hpp>
+#include <op/scan/parquet_byte_range.hpp>
 #include <op/scan/parquet_gpu_ingestible.hpp>
 #include <op/scan/parquet_metadata.hpp>
 #include <op/scan/parquet_schema_mapping.hpp>
@@ -609,6 +610,14 @@ parquet_gpu_ingestible::parquet_gpu_ingestible(std::unique_ptr<parquet_ingestibl
   }
 
   _file_paths = bind.resolved_file_paths;
+  if (!bind.resolved_file_ranges.empty() &&
+      bind.resolved_file_ranges.size() != bind.resolved_file_paths.size()) {
+    throw sirius::invalid_input_exception(
+      "parquet scan carries {} byte ranges for {} files; a partial pairing would make "
+      "row-group ownership ambiguous",
+      bind.resolved_file_ranges.size(),
+      bind.resolved_file_paths.size());
+  }
 }
 
 parquet_gpu_ingestible::~parquet_gpu_ingestible() = default;
@@ -642,10 +651,13 @@ std::function<std::unique_ptr<op::scan::scan_info>()> parquet_gpu_ingestible::ne
   // per file; row-group chunking and file bundling happen downstream in
   // parquet_batch_coalescer.
   auto const& file_path = _file_paths[idx];
+  auto const byte_range = idx < _info->resolved_file_ranges.size()
+                            ? _info->resolved_file_ranges[idx]
+                            : std::pair<std::uint64_t, std::uint64_t>{0, 0};
   // The resolver returns a valid ioctx or throws if no backend supports the path.
   auto io_ctx = resolve(file_path);
-  return [this, file_path, io_ctx = std::move(io_ctx)]() -> std::unique_ptr<scan_info> {
-    return build_file_scan_info(file_path, io_ctx);
+  return [this, file_path, byte_range, io_ctx = std::move(io_ctx)]() -> std::unique_ptr<scan_info> {
+    return build_file_scan_info(file_path, byte_range, io_ctx);
   };
 }
 
@@ -653,7 +665,9 @@ std::function<std::unique_ptr<op::scan::scan_info>()> parquet_gpu_ingestible::ne
 // build_file_scan_info — per-file footer read + row-group pruning
 //===----------------------------------------------------------------------===//
 std::unique_ptr<scan_info> parquet_gpu_ingestible::build_file_scan_info(
-  std::string const& file_path, std::shared_ptr<io::sirius_ioctx> const& io_ctx)
+  std::string const& file_path,
+  std::pair<std::uint64_t, std::uint64_t> byte_range,
+  std::shared_ptr<io::sirius_ioctx> const& io_ctx)
 {
   auto stream = cudf::get_default_stream();
 
@@ -799,6 +813,18 @@ std::unique_ptr<scan_info> parquet_gpu_ingestible::build_file_scan_info(
   }
 
   auto row_group_indices = reader.all_row_groups(opts);
+  // Distributed byte-range split: keep only the row groups this range owns (start-offset
+  // containment, parquet_byte_range.hpp), BEFORE stats pruning. An empty selection is a valid
+  // empty split and flows through the all-pruned fallback below — never a whole-file read.
+  if (byte_range.second != 0 || byte_range.first != 0) {
+    row_group_indices =
+      detail::row_groups_in_byte_range(metadata, byte_range.first, byte_range.second);
+    SIRIUS_LOG_DEBUG("[parquet_gpu_ingestible] Byte range [{}, +{}) of {} owns {} row group(s)",
+                     byte_range.first,
+                     byte_range.second,
+                     file_path,
+                     row_group_indices.size());
+  }
   if (ast_expression && !disable_filter_pushdown) {
     auto const rgs_before = row_group_indices.size();
     row_group_indices     = reader.filter_row_groups_with_stats(row_group_indices, opts, stream);

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -61,12 +61,15 @@
 #include "op/sirius_physical_ungrouped_aggregate_merge.hpp"
 #include "planner/sirius_plan_compressed_schema.hpp"
 #include "planner/sirius_plan_projection_utils.hpp"
+#include "planner/substrait_scan_ranges.hpp"
+#include "sirius/exception.hpp"
 #include "sirius_config.hpp"
 #include "sirius_context.hpp"
 
 #include <cudf/cudf_utils.hpp>
 
 #include <numeric>
+#include <set>
 #include <utility>
 
 namespace sirius::planner {
@@ -130,10 +133,39 @@ void wrap_above(duckdb::unique_ptr<sirius::op::sirius_physical_operator>& slot,
   slot          = std::forward<WrapperFactory>(factory)(std::move(original));
 }
 
+//! Attach the plan-carried byte ranges to the scan's files. Consumes (claims) each file's
+//! ranges from the per-plan registry; a file with N ranges expands to N entries whether the
+//! bind deduplicated the repeated path or kept every occurrence — the ranges are disjoint, so
+//! only their union per file matters, not which occurrence carries which range.
+void attach_byte_ranges(sirius::op::scan::parquet_ingestible_table_info& info,
+                        sirius::planner::scan_byte_ranges_state& ranges)
+{
+  std::vector<std::string> paths;
+  std::vector<std::pair<std::uint64_t, std::uint64_t>> file_ranges;
+  std::set<std::string> expanded;
+  for (auto const& path : info.resolved_file_paths) {
+    if (!ranges.has(path)) {
+      paths.push_back(path);
+      file_ranges.emplace_back(0, 0);
+      continue;
+    }
+    // Repeated occurrences of a ranged path collapse into the one expansion below.
+    if (!expanded.insert(path).second) { continue; }
+    for (auto const& range : ranges.claim(path)) {
+      paths.push_back(path);
+      file_ranges.push_back(range);
+    }
+  }
+  info.resolved_file_paths  = std::move(paths);
+  info.resolved_file_ranges = std::move(file_ranges);
+}
+
 //! Build a `parquet_ingestible_table_info` from a TABLE_SCAN. Destructive: `table_filters`
 //! is moved out of the scan.
 std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info> build_parquet_table_info(
-  sirius::op::sirius_physical_table_scan& scan_op, const sirius::operator_params& op_params)
+  sirius::op::sirius_physical_table_scan& scan_op,
+  const sirius::operator_params& op_params,
+  duckdb::ClientContext& context)
 {
   auto info                = std::make_unique<sirius::op::scan::parquet_ingestible_table_info>();
   info->returned_types     = scan_op.returned_types;
@@ -143,6 +175,8 @@ std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info> build_parquet_t
   info->table_filters      = std::move(scan_op.table_filters);
   auto resolved_file_paths = resolve_parquet_scan_file_paths(
     scan_op.function.name, scan_op.bind_data.get(), scan_op.parameters);
+  auto byte_ranges = context.registered_state->Get<sirius::planner::scan_byte_ranges_state>(
+    sirius::planner::scan_byte_ranges_state::kStateKey);
   if (scan_op.function.name == "sirius_read_parquet") {
     if (resolved_file_paths.empty()) {
       throw std::runtime_error(
@@ -150,6 +184,12 @@ std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info> build_parquet_t
         "has no URI parameter");
     }
     info->resolved_file_paths = std::move(resolved_file_paths);
+    // The S3 read path has its own footer/prefetch lifecycle that byte ranges were never
+    // tested against; refuse rather than risk a quiet whole-file read.
+    if (byte_ranges && byte_ranges->has(info->resolved_file_paths.front())) {
+      throw sirius::invalid_input_exception(
+        "byte-range splits are not supported on the sirius_read_parquet (S3) path");
+    }
   } else {
     if (resolved_file_paths.empty()) {
       throw std::runtime_error(
@@ -158,6 +198,7 @@ std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info> build_parquet_t
     info->resolved_file_paths = std::move(resolved_file_paths);
     auto const& bind_data     = scan_op.bind_data->Cast<duckdb::MultiFileBindData>();
     info->partition_indices   = bind_data.reader_bind.hive_partitioning_indexes;
+    if (byte_ranges) { attach_byte_ranges(*info, *byte_ranges); }
   }
   // `scan_output_arity` drives the provider's expected column count — without it the runtime
   // task skips the hive-partition columns it should inject post-read, mis-sizing the output.
@@ -333,7 +374,7 @@ void wrap_table_scan_source(
     replace_slot = true;
   } else if (fn == "parquet_scan" || fn == "read_parquet" || fn == "sirius_read_parquet") {
     // Parquet applies AST filters in the reader; post-decode uses membership only.
-    leaf         = make_gpu_scan_leaf(build_parquet_table_info(scan, op_params),
+    leaf         = make_gpu_scan_leaf(build_parquet_table_info(scan, op_params, context),
                               scan,
                               op_params,
                               sirius::op::scan::dynamic_filter_apply_mode::membership_masks_only,
@@ -1020,6 +1061,13 @@ sirius_physical_plan_generator::create_plan(duckdb::unique_ptr<duckdb::LogicalOp
   // `_parent_op` from the final tree for the tree-parent-lookup wiring.
   insert_gpu_pipeline_operators(plan);
   set_parent_ops(*plan, /*parent=*/nullptr);
+
+  // A plan-carried byte range that no scan consumed would degrade to a whole-file read and
+  // duplicate rows across splits — fail here, before anything executes.
+  if (auto byte_ranges = context.registered_state->Get<sirius::planner::scan_byte_ranges_state>(
+        sirius::planner::scan_byte_ranges_state::kStateKey)) {
+    byte_ranges->assert_all_consumed();
+  }
 
   return plan;
 }

--- a/src/planner/substrait_scan_ranges.cpp
+++ b/src/planner/substrait_scan_ranges.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "planner/substrait_scan_ranges.hpp"
+
+#include "sirius/exception.hpp"
+#include "substrait/plan.pb.h"
+
+namespace sirius::planner {
+
+namespace {
+
+/// `file:` scheme variants (`file:/p`, `file:///p`, `file://localhost/p`) all name the local
+/// filesystem; the plan may carry one form (the FE's) while DuckDB's bind reports another (or
+/// the plain path). One canonical form — the plain path — keyed at insert AND lookup is what
+/// keeps a registered range from being silently unclaimed over a spelling difference.
+std::string canonical_scan_path(const std::string& path)
+{
+  constexpr std::string_view kScheme = "file:";
+  if (path.rfind(kScheme, 0) != 0) { return path; }
+  auto rest = path.substr(kScheme.size());
+  if (rest.rfind("//", 0) == 0) {
+    // Drop the authority (empty or localhost — anything else never reaches this planner).
+    auto const slash = rest.find('/', 2);
+    if (slash == std::string::npos) { return path; }
+    rest = rest.substr(slash);
+  }
+  return rest;
+}
+
+}  // namespace
+
+bool scan_byte_ranges_state::has(const std::string& path) const
+{
+  return _ranges.count(canonical_scan_path(path)) > 0;
+}
+
+std::vector<scan_byte_range> scan_byte_ranges_state::claim(const std::string& path)
+{
+  auto it = _ranges.find(canonical_scan_path(path));
+  if (it == _ranges.end()) { return {}; }
+  if (!_claimed.insert(it->first).second) {
+    throw sirius::invalid_input_exception(
+      "two scans in one plan read byte ranges of '{}'; the ranges cannot be attributed to "
+      "either without double-reading",
+      path);
+  }
+  return it->second;
+}
+
+void scan_byte_ranges_state::assert_all_consumed() const
+{
+  for (const auto& [path, ranges] : _ranges) {
+    if (_claimed.count(path) == 0) {
+      throw sirius::invalid_input_exception(
+        "the plan carries {} byte range(s) for '{}' that no scan consumed; executing anyway "
+        "would read whole files and duplicate rows across splits",
+        ranges.size(),
+        path);
+    }
+  }
+}
+
+namespace {
+
+void collect_from_rel(const substrait::Rel& rel,
+                      std::map<std::string, std::vector<scan_byte_range>>& out);
+
+void collect_from_read(const substrait::ReadRel& read,
+                       std::map<std::string, std::vector<scan_byte_range>>& out)
+{
+  if (!read.has_local_files()) { return; }
+  for (const auto& item : read.local_files().items()) {
+    if (item.start() == 0 && item.length() == 0) { continue; }  // whole file
+    if (!item.has_uri_file()) {
+      throw sirius::invalid_input_exception(
+        "a byte-ranged LocalFiles item uses a path type other than uri_file; its range "
+        "cannot be attributed to a file");
+    }
+    out[canonical_scan_path(item.uri_file())].emplace_back(item.start(), item.length());
+  }
+}
+
+void collect_from_rel(const substrait::Rel& rel,
+                      std::map<std::string, std::vector<scan_byte_range>>& out)
+{
+  switch (rel.rel_type_case()) {
+    case substrait::Rel::kRead: collect_from_read(rel.read(), out); return;
+    case substrait::Rel::kFilter: collect_from_rel(rel.filter().input(), out); return;
+    case substrait::Rel::kFetch: collect_from_rel(rel.fetch().input(), out); return;
+    case substrait::Rel::kAggregate: collect_from_rel(rel.aggregate().input(), out); return;
+    case substrait::Rel::kSort: collect_from_rel(rel.sort().input(), out); return;
+    case substrait::Rel::kProject: collect_from_rel(rel.project().input(), out); return;
+    case substrait::Rel::kJoin:
+      collect_from_rel(rel.join().left(), out);
+      collect_from_rel(rel.join().right(), out);
+      return;
+    case substrait::Rel::kCross:
+      collect_from_rel(rel.cross().left(), out);
+      collect_from_rel(rel.cross().right(), out);
+      return;
+    case substrait::Rel::kSet:
+      for (const auto& input : rel.set().inputs()) {
+        collect_from_rel(input, out);
+      }
+      return;
+    case substrait::Rel::REL_TYPE_NOT_SET: return;
+    default:
+      // Skipping an unknown rel could hide a ranged read inside it, and a hidden ranged
+      // read degrades to a whole-file scan that duplicates rows across splits.
+      throw sirius::invalid_input_exception(
+        "byte-range extraction does not know Substrait rel type {}; refusing to guess "
+        "whether it hides a ranged read",
+        static_cast<int>(rel.rel_type_case()));
+  }
+}
+
+}  // namespace
+
+std::map<std::string, std::vector<scan_byte_range>> extract_scan_byte_ranges(
+  const std::string& plan_bytes)
+{
+  substrait::Plan plan;
+  if (!plan.ParseFromString(plan_bytes)) {
+    throw sirius::invalid_input_exception(
+      "failed to parse the Substrait plan while extracting scan byte ranges");
+  }
+  std::map<std::string, std::vector<scan_byte_range>> out;
+  for (const auto& plan_rel : plan.relations()) {
+    if (plan_rel.has_root() && plan_rel.root().has_input()) {
+      collect_from_rel(plan_rel.root().input(), out);
+    } else if (plan_rel.has_rel()) {
+      collect_from_rel(plan_rel.rel(), out);
+    }
+  }
+  return out;
+}
+
+}  // namespace sirius::planner

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -1085,8 +1085,9 @@ cache_entry_info cache_entry_info::from(const op::scan::ingestible_table_info& i
     // resolved) path.
     ci.resolved_file_paths = p->resolved_file_paths;
     op::scan::canonicalize_scan_file_paths(ci.resolved_file_paths);
-    ci.column_ids = p->column_ids;
-    ci.names      = aligned_column_names(p->names, p->column_ids);
+    ci.has_byte_ranges = p->has_byte_ranges();
+    ci.column_ids      = p->column_ids;
+    ci.names           = aligned_column_names(p->names, p->column_ids);
   } else if (auto const* d =
                dynamic_cast<op::scan::duckdb_native_ingestible_table_info const*>(&info)) {
     ci.catalog_name = d->catalog_name;
@@ -1106,6 +1107,9 @@ std::vector<std::size_t> cache_entry_info::can_serve_with_columns(
   // never serves a scan of the other — the identity check below falls through (a
   // duckdb cache has empty resolved_file_paths; a parquet cache has an empty table_name).
   if (auto const* p = dynamic_cast<op::scan::parquet_ingestible_table_info const*>(&other)) {
+    // A byte-range split scan reads a subset of each file's row groups, so it can neither be
+    // served by a whole-file pin (extra rows) nor produce a pin that serves anyone else.
+    if (has_byte_ranges || p->has_byte_ranges()) { return {}; }
     if (!matches_parquet_files(p->resolved_file_paths)) { return {}; }
     return column_projection_for(p->column_ids);
   }

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -38,6 +38,7 @@
 #include "from_substrait.hpp"     // duckdb::SubstraitToDuckDB (compiled into libsirius)
 #include "parquet_extension.hpp"  // duckdb::ParquetExtension
 #include "planner/sirius_physical_plan_generator.hpp"  // sirius::planner::sirius_physical_plan_generator
+#include "planner/substrait_scan_ranges.hpp"           // sirius::planner::scan_byte_ranges_state
 #include "sirius_config.hpp"                           // sirius::sirius_config
 #include "sirius_context.hpp"                          // duckdb::SiriusContext
 #include "sirius_interface.hpp"  // sirius::sirius_interface, sirius::sirius_prepared_statement_data
@@ -125,6 +126,18 @@ void Context::execute_substrait(const std::string& plan, std::uintptr_t out_stre
   impl_->conn->BeginTransaction();
   duckdb::unique_ptr<duckdb::QueryResult> result;
   try {
+    // 0. Byte-ranged parquet splits ride the plan's LocalFiles items, but DuckDB's Substrait
+    //    consumer drops FileOrFiles.start/.length and parquet_scan has no byte-range
+    //    parameter — extract them into a per-plan state the physical plan generator consumes.
+    //    Always replaced (and removed when this plan carries none), so a stale registry can
+    //    never leak a previous plan's ranges into this one.
+    client.registered_state->Remove(sirius::planner::scan_byte_ranges_state::kStateKey);
+    if (auto ranges = sirius::planner::extract_scan_byte_ranges(plan); !ranges.empty()) {
+      client.registered_state->Insert(
+        sirius::planner::scan_byte_ranges_state::kStateKey,
+        duckdb::make_shared_ptr<sirius::planner::scan_byte_ranges_state>(std::move(ranges)));
+    }
+
     // 1. Substrait bytes -> DuckDB Relation. DuckDB is used only for this lowering.
     duckdb::SubstraitToDuckDB transformer(impl_->conn->context, plan, /*json=*/false);
     auto relation = transformer.TransformPlan();

--- a/test/cpp/scan/test_parquet_byte_range.cpp
+++ b/test/cpp/scan/test_parquet_byte_range.cpp
@@ -18,14 +18,23 @@
 #include <catch.hpp>
 
 // sirius
+#include <io/kvikio/kvikio_context.hpp>
 #include <op/scan/parquet_byte_range.hpp>
+#include <op/scan/parquet_gpu_ingestible.hpp>
 #include <sirius/exception.hpp>
 
 // cudf
+#include <cudf/column/column_factories.hpp>
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/experimental/hybrid_scan.hpp>
+#include <cudf/io/parquet.hpp>
 #include <cudf/io/parquet_io_utils.hpp>
 #include <cudf/io/parquet_schema.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+// rmm
+#include <rmm/device_buffer.hpp>
 
 // standard library
 #include <algorithm>
@@ -225,4 +234,137 @@ TEST_CASE("real footer: rule agrees with cudf's byte-range filter on the test li
     WARN("cudf filter_row_groups_with_byte_range diverges from the StarRocks rule: cudf="
          << cudf_left.size() << " ours=" << left.size());
   }
+}
+
+namespace {
+
+/// Writes a one-column (a BIGINT, values 0..rows-1) parquet with `rows / rows_per_group` row
+/// groups, and returns its path. Deterministic row-group layout for the split-scan tests.
+fs::path write_multi_row_group_parquet(fs::path const& dir,
+                                       std::int64_t rows,
+                                       std::int64_t rows_per_group)
+{
+  auto const path = dir / "byte_range_scan.parquet";
+  auto stream     = cudf::get_default_stream();
+  std::vector<std::int64_t> host(rows);
+  std::iota(host.begin(), host.end(), 0);
+  rmm::device_buffer data(host.data(), rows * sizeof(std::int64_t), stream);
+  auto column = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT64},
+                                               static_cast<cudf::size_type>(rows),
+                                               std::move(data),
+                                               rmm::device_buffer{},
+                                               0);
+  cudf::table_view table({column->view()});
+  cudf::io::table_input_metadata metadata(table);
+  metadata.column_metadata[0].set_name("a");
+  auto options =
+    cudf::io::parquet_writer_options::builder(cudf::io::sink_info(path.string()), table)
+      .metadata(std::move(metadata))
+      .row_group_size_rows(rows_per_group)
+      .build();
+  cudf::io::write_parquet(options);
+  return path;
+}
+
+/// Table info for a byte-range scan of `path` projecting the single BIGINT column.
+std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info> ranged_info(fs::path const& path,
+                                                                             std::uint64_t start,
+                                                                             std::uint64_t length)
+{
+  auto info                  = std::make_unique<sirius::op::scan::parquet_ingestible_table_info>();
+  info->resolved_file_paths  = {path.string()};
+  info->resolved_file_ranges = {{start, length}};
+  info->names                = {"a"};
+  info->returned_types.push_back(sirius::logical_type::make(sirius::type_id::BIGINT));
+  info->column_ids.push_back(duckdb::ColumnIndex(0));
+  info->scan_output_arity      = 1;
+  info->approximate_batch_size = std::size_t{1} << 30;
+  return info;
+}
+
+/// Drives the ingestible for one range and returns the selected row-group indices plus the
+/// number of rows they hold (from the footer metadata — no decode needed).
+std::pair<std::vector<cudf::size_type>, std::int64_t> scan_selection(
+  std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info> info)
+{
+  auto ingestible = sirius::op::scan::make_ingestible(std::move(info));
+  auto ioctx      = std::make_shared<sirius::io::kvikio_context>();
+  auto task       = ingestible->next_split_provider(
+    [ioctx](std::string_view) -> std::shared_ptr<sirius::io::sirius_ioctx> { return ioctx; });
+  REQUIRE(task);
+  auto file = task();
+  REQUIRE(file);
+
+  // Splits materialize downstream of the coalescer, exactly as in production.
+  auto coalescer = ingestible->create_batch_coalescer();
+  auto batches   = coalescer->push(std::move(file));
+  for (auto& batch : coalescer->flush()) {
+    batches.push_back(std::move(batch));
+  }
+
+  std::vector<cudf::size_type> indices;
+  std::int64_t rows = 0;
+  for (auto const& batch : batches) {
+    auto* split = dynamic_cast<sirius::op::scan::parquet_split_info*>(batch.get());
+    REQUIRE(split);
+    for (auto const& slice : split->rg_slices) {
+      for (auto const idx : slice.row_group_indices) {
+        indices.push_back(idx);
+        rows += slice.file_metadata->row_groups.at(idx).num_rows;
+      }
+    }
+  }
+  std::sort(indices.begin(), indices.end());
+  return {indices, rows};
+}
+
+}  // namespace
+
+TEST_CASE("a two-way split scan selects disjoint, complete row groups",
+          "[parquet_byte_range][scan]")
+{
+  auto const dir = fs::temp_directory_path() / "sirius_byte_range_test";
+  fs::create_directories(dir);
+  // cudf clamps row_group_size_rows to a 5000-row floor; 50k rows -> 10 real row groups of
+  // sequential int64s, large enough that both halves of the file hold data pages.
+  constexpr std::int64_t kRows = 50000;
+  auto const path              = write_multi_row_group_parquet(dir, kRows, 5000);
+  auto const file_size         = std::uint64_t(fs::file_size(path));
+  auto const half              = file_size / 2;
+
+  auto [left_rgs, left_rows]   = scan_selection(ranged_info(path, 0, half));
+  auto [right_rgs, right_rows] = scan_selection(ranged_info(path, half, file_size - half));
+
+  INFO("left row groups: " << left_rgs.size() << ", right: " << right_rgs.size());
+  REQUIRE(!left_rgs.empty());
+  REQUIRE(!right_rgs.empty());
+  for (auto const idx : left_rgs) {
+    REQUIRE(std::find(right_rgs.begin(), right_rgs.end(), idx) == right_rgs.end());
+  }
+  REQUIRE(left_rows + right_rows == kRows);
+
+  // A whole-file scan ((0,0) range) is byte-identical to no range at all.
+  auto [all_rgs, all_rows] = scan_selection(ranged_info(path, 0, 0));
+  REQUIRE(all_rows == kRows);
+  REQUIRE(std::int64_t(left_rgs.size() + right_rgs.size()) == std::int64_t(all_rgs.size()));
+
+  // A range inside one row group is a valid empty scan.
+  auto [none_rgs, none_rows] = scan_selection(ranged_info(path, 10, 5));
+  REQUIRE(none_rgs.empty());
+  REQUIRE(none_rows == 0);
+
+  fs::remove_all(dir);
+}
+
+TEST_CASE("mismatched range/path pairing is refused at construction", "[parquet_byte_range][scan]")
+{
+  auto info                  = std::make_unique<sirius::op::scan::parquet_ingestible_table_info>();
+  info->resolved_file_paths  = {"a.parquet", "b.parquet"};
+  info->resolved_file_ranges = {{0, 10}};
+  info->names                = {"a"};
+  info->returned_types.push_back(sirius::logical_type::make(sirius::type_id::BIGINT));
+  info->column_ids.push_back(duckdb::ColumnIndex(0));
+  info->scan_output_arity = 1;
+  REQUIRE_THROWS_AS(sirius::op::scan::make_ingestible(std::move(info)),
+                    sirius::invalid_input_exception);
 }

--- a/test/cpp/scan/test_parquet_byte_range.cpp
+++ b/test/cpp/scan/test_parquet_byte_range.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// test
+#include <catch.hpp>
+
+// sirius
+#include <op/scan/parquet_byte_range.hpp>
+#include <sirius/exception.hpp>
+
+// cudf
+#include <cudf/io/datasource.hpp>
+#include <cudf/io/experimental/hybrid_scan.hpp>
+#include <cudf/io/parquet_io_utils.hpp>
+#include <cudf/io/parquet_schema.hpp>
+
+// standard library
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <numeric>
+#include <set>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+using sirius::op::scan::detail::row_group_start_offset;
+using sirius::op::scan::detail::row_groups_in_byte_range;
+
+namespace {
+
+/// Metadata with one row group per given start offset, encoded the common way
+/// (first column's data_page_offset carries the start; everything else unset).
+cudf::io::parquet::FileMetaData make_metadata(std::vector<std::int64_t> const& rg_starts)
+{
+  cudf::io::parquet::FileMetaData meta;
+  for (auto const start : rg_starts) {
+    cudf::io::parquet::RowGroup rg;
+    cudf::io::parquet::ColumnChunk chunk;
+    chunk.meta_data.data_page_offset = start;
+    rg.columns.push_back(std::move(chunk));
+    meta.row_groups.push_back(std::move(rg));
+  }
+  return meta;
+}
+
+std::vector<cudf::size_type> all_indices(std::size_t n)
+{
+  std::vector<cudf::size_type> all(n);
+  std::iota(all.begin(), all.end(), 0);
+  return all;
+}
+
+fs::path lineitem_parquet_path()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return fs::path(SIRIUS_PROJECT_ROOT) / "test/cpp/integration/data/parquet/lineitem.parquet";
+#else
+  return fs::path(__FILE__).parent_path().parent_path() /
+         "integration/data/parquet/lineitem.parquet";
+#endif
+}
+
+}  // namespace
+
+TEST_CASE("row_group_start_offset follows the StarRocks reader convention", "[parquet_byte_range]")
+{
+  cudf::io::parquet::FileMetaData meta;
+  cudf::io::parquet::RowGroup rg;
+  cudf::io::parquet::ColumnChunk chunk;
+
+  SECTION("data page offset alone")
+  {
+    chunk.meta_data.data_page_offset = 100;
+    rg.columns.push_back(chunk);
+    meta.row_groups.push_back(rg);
+    REQUIRE(row_group_start_offset(meta, 0) == 100);
+  }
+
+  SECTION("dictionary page precedes the data page")
+  {
+    chunk.meta_data.data_page_offset       = 100;
+    chunk.meta_data.dictionary_page_offset = 40;
+    rg.columns.push_back(chunk);
+    meta.row_groups.push_back(rg);
+    REQUIRE(row_group_start_offset(meta, 0) == 40);
+  }
+
+  SECTION("zero offsets count as absent, not as position zero")
+  {
+    chunk.meta_data.data_page_offset       = 100;
+    chunk.meta_data.dictionary_page_offset = 0;
+    chunk.meta_data.index_page_offset      = 0;
+    rg.columns.push_back(chunk);
+    meta.row_groups.push_back(rg);
+    REQUIRE(row_group_start_offset(meta, 0) == 100);
+  }
+
+  SECTION("row group file_offset participates when set")
+  {
+    chunk.meta_data.data_page_offset = 100;
+    rg.columns.push_back(chunk);
+    rg.file_offset = 30;
+    meta.row_groups.push_back(rg);
+    REQUIRE(row_group_start_offset(meta, 0) == 30);
+  }
+
+  SECTION("no candidate offset at all is a loud error, never a guess")
+  {
+    rg.columns.push_back(chunk);  // all offsets zero
+    meta.row_groups.push_back(rg);
+    REQUIRE_THROWS_AS(row_group_start_offset(meta, 0), sirius::invalid_input_exception);
+  }
+}
+
+TEST_CASE("any exact tiling reads every row group exactly once", "[parquet_byte_range]")
+{
+  // Row-group starts chosen so boundaries land before, on, and inside them.
+  auto const starts    = std::vector<std::int64_t>{4, 1000, 1024, 5000, 999999};
+  auto const meta      = make_metadata(starts);
+  auto const file_size = std::uint64_t{1200000};
+
+  // Sweep every tiling of the file into k equal ranges (the FE emits exact tilings).
+  for (std::size_t k : {1, 2, 3, 4, 5, 7, 16}) {
+    std::vector<cudf::size_type> combined;
+    std::set<cudf::size_type> seen;
+    auto const split = file_size / k;
+    for (std::size_t part = 0; part < k; ++part) {
+      auto const start  = part * split;
+      auto const length = (part == k - 1) ? file_size - start : split;
+      auto const owned  = row_groups_in_byte_range(meta, start, length);
+      for (auto const idx : owned) {
+        INFO("tiling k=" << k << " part=" << part);
+        REQUIRE(seen.insert(idx).second);  // pairwise disjoint
+        combined.push_back(idx);
+      }
+    }
+    std::sort(combined.begin(), combined.end());
+    INFO("tiling k=" << k);
+    REQUIRE(combined == all_indices(starts.size()));  // complete
+  }
+}
+
+TEST_CASE("byte-range ownership edge cases", "[parquet_byte_range]")
+{
+  auto const meta = make_metadata({4, 1000, 5000});
+
+  SECTION("whole file owns everything")
+  {
+    REQUIRE(row_groups_in_byte_range(meta, 0, 6000) == all_indices(3));
+  }
+
+  SECTION("a straddling row group belongs to the range holding its start")
+  {
+    // Range ends at 1500, inside row group 1's bytes; rg 1 starts at 1000 -> owned here...
+    REQUIRE(row_groups_in_byte_range(meta, 0, 1500) == std::vector<cudf::size_type>{0, 1});
+    // ...and not by the neighbour that covers its tail.
+    REQUIRE(row_groups_in_byte_range(meta, 1500, 3000) == std::vector<cudf::size_type>{});
+  }
+
+  SECTION("a range inside one row group owns nothing (valid empty split)")
+  {
+    REQUIRE(row_groups_in_byte_range(meta, 1200, 100).empty());
+  }
+
+  SECTION("zero length owns nothing, including the canonical empty split")
+  {
+    REQUIRE(row_groups_in_byte_range(meta, 0, 0).empty());
+    REQUIRE(row_groups_in_byte_range(meta, 6000, 0).empty());
+  }
+
+  SECTION("a boundary exactly on a row-group start assigns it to the right-hand range")
+  {
+    REQUIRE(row_groups_in_byte_range(meta, 4, 996) == std::vector<cudf::size_type>{0});
+    REQUIRE(row_groups_in_byte_range(meta, 1000, 5000) == std::vector<cudf::size_type>{1, 2});
+  }
+}
+
+TEST_CASE("real footer: rule agrees with cudf's byte-range filter on the test lineitem",
+          "[parquet_byte_range]")
+{
+  auto const path = lineitem_parquet_path();
+  REQUIRE(fs::exists(path));
+  auto source = cudf::io::datasource::create(path.string());
+  auto footer = cudf::io::parquet::fetch_footer_to_host(*source);
+  cudf::io::parquet_reader_options options;
+  cudf::io::parquet::experimental::hybrid_scan_reader reader(
+    cudf::host_span<uint8_t const>(footer->data(), footer->size()), options);
+  auto const metadata = reader.parquet_metadata();
+  REQUIRE(!metadata.row_groups.empty());
+  auto const file_size = std::uint64_t(fs::file_size(path));
+
+  // Exactly-once over a two-way tiling of the real file.
+  auto const half = file_size / 2;
+  auto left       = row_groups_in_byte_range(metadata, 0, half);
+  auto right      = row_groups_in_byte_range(metadata, half, file_size - half);
+  std::vector<cudf::size_type> combined = left;
+  combined.insert(combined.end(), right.begin(), right.end());
+  std::sort(combined.begin(), combined.end());
+  REQUIRE(combined == all_indices(metadata.row_groups.size()));
+
+  // Cross-check against cudf's own byte-range pruning. Informational: cudf's definition of a
+  // row group's start is not pinned by its API docs; if this ever diverges, our rule (the
+  // StarRocks reader convention) stays authoritative and this warning says cudf changed.
+  auto all = reader.all_row_groups(options);
+  cudf::io::parquet_reader_options range_options;
+  range_options.set_skip_bytes(0);
+  range_options.set_num_bytes(half);
+  auto cudf_left = reader.filter_row_groups_with_byte_range(
+    cudf::host_span<cudf::size_type const>(all.data(), all.size()), range_options);
+  if (cudf_left != left) {
+    WARN("cudf filter_row_groups_with_byte_range diverges from the StarRocks rule: cudf="
+         << cudf_left.size() << " ours=" << left.size());
+  }
+}


### PR DESCRIPTION
Step 4 of 4 in #1635 — the one that makes the capability real. **Depends on #1638** (and transitively #1637, #1636); its diff shows those commits until they merge. This PR's own change is the fourth commit, `+434/-63` across 3 files, all Rust.

**Supersedes the approach in #1232.** See the last section.

## The problem

The frontend does not hand a worker "read `lineitem.parquet`". It stats each file and chops it into `TBrokerRangeDesc` splits so several workers read in parallel: bytes 0–512MB to one instance, 512MB–1GB to the next. Until now `check_range` refused any range that was not provably the whole file — *"byte-range split scan ranges are not supported"* — because DuckDB's `local_files` reader could not carry an offset.

The three PRs below this one changed that. A range now rides the plan into the reader, which selects exactly the row groups whose start offset falls inside it. So the translator can stop refusing.

## What it does

`resolve_ranges` normalizes each file's ranges into the `ScanFile`s this instance reads:

- `size == -1` resolves to EOF;
- empty intervals drop;
- intervals **sort**, because the FE promises no ordering;
- **overlaps are refused, not merged** — under start-offset ownership two overlapping ranges read the same row groups twice, and `count(*)` disagrees with no error;
- adjacent ranges coalesce;
- an exact whole-file tiling **collapses to a whole-file read**, so every plan that worked before splits existed still translates byte-identically;
- everything else becomes explicit `[start, start+length)` splits.

Two delivery shapes are now handled rather than mis-read: `has_more` is refused (more ranges follow through `deliver_scan_ranges`, which this CN does not implement, so accepting the prefix would silently read a subset), and an explicitly empty placeholder range carries no file. An instance owning only empty ranges is refused rather than falling back to a named-table read of something else entirely.

Also folds in the compressed-container guard (`397dd878`): parquet compression is per-page inside the file, so an outer `compression_type` on the range describes a container the reader would have to unwrap first. The FE leaves it unset for plain parquet. It guards the same `check_range` predicate this PR rewrites, which is why it belongs in the same change rather than trailing it.

## Tests

`split_broker_range_emits_a_ranged_local_file`, `overlapping_split_ranges_are_refused`, `open_ended_split_reads_to_the_end_of_the_file`, `split_past_the_end_of_the_file_is_refused`, `split_broker_range_without_a_file_size_is_unsupported`, `bounded_split_with_unknown_file_size_is_unsupported`, `has_more_scan_ranges_are_refused`, `compressed_container_scan_range_is_refused`, `empty_file_scan_range_is_unsupported`.

## Verification

`cargo test -p starrocks-plan-translator` → **105 passed, 0 failed** (100 integration + 5 unit).
`cargo clippy -p starrocks-plan-translator --all-targets` clean. `cargo fmt` clean.
Rust-only change; no C++ touched.

## Relationship to #1232

#1232 accepts splits **only when the ranges assigned to one fragment tile the whole file**, then collapses them to a single whole-file read. That is the special case where a fragment happens to own everything — and it is a real improvement over the old refusal, which killed even that.

This handles the general case, where a fragment owns a **subset**, which is what the FE actually produces once a file is split across CNs. It replaces `validate_complete_files` with `resolve_ranges`; the exact-tiling case still collapses to a whole-file read, so #1232's behavior is preserved as a subset of this one.

If #1232 lands first, this PR replaces that function and I will rebase. If the reviewers prefer, #1232 can also merge as-is and this becomes the follow-up that generalizes it — the outcomes are identical either way.

## End-to-end evidence

With all four steps applied, `count(*)` over a single 155 MB `lineitem.parquet` byte-split across 2 CNs returns `6001215`, and Q6 returns `61567694.9502`. A duplicated or lost split moves both.
