### PR TITLE
fix(pipeline): make query completion and teardown wait for all in-flight work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -696,6 +696,7 @@ set(TEST_SOURCES
     test/cpp/exec/test_stream_bind_catalog.cpp
     test/cpp/exec/test_stream_session.cpp
     test/cpp/exec/test_streaming_fragment.cpp
+    test/cpp/exec/test_work_tracker.cpp
     test/cpp/expression/test_ast_aggregate.cpp
     test/cpp/expression/test_ast_clone.cpp
     test/cpp/expression/test_ast_substitute.cpp
@@ -776,6 +777,7 @@ set(TEST_SOURCES
     test/cpp/scan_manager/test_insert_delta_job.cpp
     test/cpp/scan_manager/test_memory_prefetcher_accounting.cpp
     test/cpp/scan_manager/test_mvcc_mask_job.cpp
+    test/cpp/scan_manager/test_split_connector.cpp
     test/cpp/scan_manager/test_pinned_chunk_stats.cpp
     test/cpp/operator/test_physical_grouped_aggregate_merge_mgpu.cpp
     test/cpp/operator/test_physical_hash_join_mgpu.cpp

--- a/docs/super-sirius/architecture-overview.md
+++ b/docs/super-sirius/architecture-overview.md
@@ -127,13 +127,13 @@ A query through Super Sirius follows these steps:
    - Converts each TABLE_SCAN source into a unified GPU scan source with a per-table `gpu_ingestible`
    - Injects PARTITION, CONCAT, MERGE operators at pipeline boundaries
    - Wires data repositories between pipelines with barrier types
-4. **Query Preparation** — `task_scheduler::prepare_for_query()` drains leftover state, creates the `completion_handler`, and installs it on the GPU executors and query-terminal pipelines; `sirius_scan_manager::prepare_for_query()` builds each scan's split provider, installs its split connector, and matches any pinned-cache entries
-5. **Query Start** — `task_scheduler::start_query()` schedules the initial scan operator and returns the completion future
+4. **Query Preparation** — `task_scheduler::prepare_for_query()` drains leftover state, resets scheduler state, and distributes a new `completion_handler` to the executors, task creator, and pipelines. `sirius_scan_manager::prepare_for_query()` builds each scan's split provider, installs its split connector, and matches pinned-cache entries
+5. **Query Start** — `task_scheduler::start_query()` schedules the first scan operator and returns the completion future
 6. **Scan Phase** — The scan manager drives split providers that pull bytes through the `io_context` (io_uring locally, or REST/kvikio backends) and the prefetching cache; the unified GPU scan source consumes splits and materializes GPU-ready batches into data repositories
 7. **Pipeline Execution** — GPU executor threads pull tasks from the queue, acquire memory reservations, and call `execute()` on every operator in the pipeline (source through sink) on CUDA streams, then call the sink's `sink()` to push results downstream
 8. **Task Creation** — After each task completes, the task creator is notified to schedule downstream consumers based on data availability in ports
 9. **Memory Management** — Downgrade executors monitor GPU memory pressure and spill data to host memory when thresholds are exceeded
-10. **Completion** — A query-terminal pipeline signals the completion future when it transitions to finished; the GPU task epilogue may also signal it safely
+10. **Completion** — A terminal pipeline signals from its finish transition; the GPU epilogue may also signal. See the [Completion Contract](pipeline-execution.md#completion-contract)
 11. **Result Extraction** — The main thread extracts the `MaterializedQueryResult` from the result collector and returns it to DuckDB
 
 ## Key Source Files

--- a/docs/super-sirius/execution-flow.md
+++ b/docs/super-sirius/execution-flow.md
@@ -118,10 +118,14 @@ After meta-pipeline construction, `initialize_internal()` applies Sirius-specifi
 
 **File:** `src/sirius_engine.cpp` — `execute()`
 
-1. Calls `SiriusContext::create_query()` with the finalized pipelines
-2. Query preparation creates a `completion_handler` and installs it on the GPU executors and query-terminal pipelines
-3. Calls `task_scheduler::start_query()`, which schedules the initial scan operator and returns the completion future
-4. The main thread blocks on `future.get()` and then drains in-flight work before returning
+1. Creates a `query` object from `new_scheduled` pipelines with a pipeline hashmap
+2. `task_scheduler::prepare_for_query(query)` (from `SiriusContext::create_query`) installs the
+   per-query `completion_handler` on executors, the task creator, and pipelines
+3. Calls `task_scheduler.start_query()`, which schedules the first scan operator and returns the
+   future
+4. The main thread waits on the future, then calls `wait_for_completion()` to drain the work
+   ledger and surface late errors before plan teardown — see
+   [The work ledger](pipeline-execution.md#the-work-ledger)
 
 ## Step 6: Scan Execution
 
@@ -152,8 +156,9 @@ The GPU executor's manager loop:
    - If not complete: schedule downstream consumers via `task_creator->schedule()`
    - If complete: `completion_handler->mark_completed()`
 
-The GPU epilogue usually signals completion. A query-terminal pipeline also signals from
-`sirius_pipeline::update_pipeline_status()`, covering finish transitions driven by other threads.
+The GPU epilogue may signal completion, but terminal pipelines also signal from
+`update_pipeline_status()` — see the
+[Completion Contract](pipeline-execution.md#completion-contract).
 
 ## Step 8: Task Creation Cycle
 
@@ -187,9 +192,9 @@ If any task throws an exception during execution:
 1. The GPU executor catches it and calls `completion_handler->report_error(exception)`
 2. `drain_after_error()` is called on the pipeline executor which:
    - Stops the task creator threads
-   - Drains the task queue
-   - Calls `drain_and_wait()` on the GPU executors
-   - Restarts the task creator for the next query
+   - Stops downgrade workers and drains scheduler and executor queues
+   - Waits for the work ledger to reach zero
+   - Leaves the task creator parked until the next `prepare_for_query()`
 3. The error propagates through the future to the main thread, surfacing as an error-carrying result at `PhysicalSiriusExecution::GetData()`
 
 On the transparent path, that error triggers the runtime CPU fallback described in Step 2 (unless `enable_duckdb_fallback` is false, the error is a user interrupt, or the query reads S3). The fallback runs the stashed DuckDB CPU plan in the same transaction, so a runtime GPU failure completes on CPU rather than failing the query.
@@ -214,9 +219,11 @@ sequenceDiagram
     Iface->>Engine: initialize(result_collector)
     Engine->>Engine: Build pipelines, rewrite scans to GPU scan source, wire repos
     Iface->>Engine: execute()
-    Engine->>PE: start_query(pipelines)
+    Engine->>PE: prepare_for_query(pipelines)
     PE->>CH: create completion_handler
-    PE->>SM: prepare_for_query (split providers + connectors)
+    Engine->>TC: prepare_for_query (global states + lookahead)
+    Engine->>SM: prepare_for_query (split providers + connectors)
+    Engine->>PE: start_query()
     SM->>SM: drive splits through io_context + prefetch cache
     PE->>GPE: schedule initial GPU scan tasks
     GPE->>SM: pull splits via split_connector

--- a/docs/super-sirius/pipeline-execution.md
+++ b/docs/super-sirius/pipeline-execution.md
@@ -371,7 +371,7 @@ After a task completes:
 
 The completion check happens **before** scheduling downstream tasks to prevent scheduling tasks that reference already-destroyed operators.
 
-This epilogue is the usual signaller, but not the only one — see the completion contract below.
+See the [Completion Contract](#completion-contract) for other finish drivers.
 
 ### Completion Contract
 
@@ -384,10 +384,33 @@ parent-cascade paths can finish a pipeline without returning through the GPU epi
 The pipeline obtains a strong reference under `_status_mutex` and calls `mark_completed()` only
 after releasing the lock and finishing all pipeline access.
 
-The GPU epilogue also keeps its completion signal. Duplicate signals are safe because
-`completion_handler` accepts only the first one. After the future resolves,
-`task_scheduler::wait_for_completion()` joins the task creator and in-flight GPU work before
-operators are destroyed.
+| Caller | Thread |
+|---|---|
+| `mark_task_completed()` ← `~gpu_pipeline_task` | GPU pool worker (the epilogue) |
+| `task_creator`'s creation-exit re-evaluation | creator pool worker |
+| `task_creator`'s visited-pipelines re-evaluation | creator manager thread |
+| `sirius_physical_streaming_source`'s end-of-stream hook | producer thread |
+| `notify_downstream_pipelines()`'s `parent->update_pipeline_status(false)` cascade | whichever thread finished the child |
+
+Every one of those but the epilogue ends in `notify_downstream_pipelines()`, which early-returns
+for a query-terminal pipeline: there is no downstream to schedule, and returning early avoids
+racing the teardown that `mark_completed()` unleashes. The epilogue, in turn, re-reads the flag
+only on the transitions it drives itself. Make completion depend on the epilogue observing the
+flag and any other driver leaves the query finished but unsignalled, with `execute()`'s
+`future.get()` waiting forever and nothing in the log (#1486).
+
+So `update_pipeline_status()` signals on its own:
+
+- `task_scheduler::prepare_for_query()` installs the query's `completion_handler` on every
+  query-terminal pipeline via `sirius_pipeline::set_completion_handler()`.
+- The pipeline holds it as a `std::weak_ptr`. Replacing the handler at the next
+  `prepare_for_query()` expires it, so a pipeline left over from a finished query cannot signal
+  the next one.
+- On any call where the pipeline is both query-terminal and finished, the handler is sampled under
+  `_status_mutex` and `mark_completed()` is called **after** the lock is dropped, as the function's
+  last act — nothing may touch pipeline or operator state after the signal.
+
+Post-signal safety is enforced by `wait_for_completion()` and the work ledger described below.
 
 ### Task Request Flow
 
@@ -411,8 +434,29 @@ Thread-safe signaling for query completion using promise/future:
 | `get_awaitable()` | Returns the future for blocking |
 | `is_completed()` / `has_error()` | Atomic status checks |
 
-All methods are idempotent: the GPU epilogue and terminal pipeline may signal the same completion,
-and only the first call takes effect.
+`report_error()` returns whether its error won the completion race. An error that loses is
+preserved for `take_late_error()` instead of being discarded. `terminate_query()` only reports
+the error; engine teardown remains in `drain_after_error()` because `stop()` is terminal.
+
+### The work ledger
+
+The handler owns an `exec::work_tracker` that counts work objects rather than queue entries.
+Pipeline tasks, creation requests, worker epilogues, and producer callbacks hold RAII slots
+through their full lifetimes and hand-offs. A zero count therefore means no query work remains
+in a queue, thread, or destructor.
+
+`wait_for_completion()` lets existing work drain, parks the task creator, closes the ledger, and
+waits once more for acquisitions that raced the close. Producers abort when they cannot acquire
+a slot. `interruptible_mpmc::interrupt()` similarly acts as a producer barrier, ensuring a queue
+stays empty after teardown drains it. A late execution error is then safe to consume.
+
+A non-zero count after the timeout indicates premature completion. Error teardown closes the
+ledger, drains workers and queues, and waits rather than destroying a live plan.
+`prepare_for_query()` re-arms the creator for the next query.
+
+All methods are idempotent — subsequent calls after the first are no-ops. That is load-bearing:
+both the GPU epilogue and the terminal pipeline's finish transition may signal the same completion
+(see the completion contract above), and the loser must be a silent no-op.
 
 ## Reschedule Handling (OOM and CUDA launch failures)
 

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -20,6 +20,7 @@
 #include "memory/topology_index.hpp"
 #include "op/scan/sirius_gpu_scan_operator_data.hpp"
 #include "op/sirius_physical_delim_join.hpp"
+#include "pipeline/completion_handler.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
 #include "pipeline/task_scheduler.hpp"
 #include "planner/query.hpp"
@@ -214,31 +215,23 @@ task_creator::compute_pipeline_priorities(const sirius::planner::query& query) c
   return priorities;
 }
 
-void task_creator::drain_pending_tasks()
+void task_creator::drain_pending_tasks(bool reactivate)
 {
   std::lock_guard<std::mutex> lock(_global_state_mutex);
-  // Drain any queued task creation requests that haven't been picked up yet
+  // Serialize _bounded_pool lifetime across pool start and stop.
+  std::lock_guard<std::mutex> shutdown_lock(_shutdown_mutex);
+  // Discard requests that have not reached the worker pool.
   _task_creation_queue.interrupt();
   _task_creation_queue.drain();
-  // Wait for any in-flight task creation lambdas to finish. When called from
-  // task_scheduler::drain_after_error(), stop_thread_pool() has already joined
-  // the worker pool and reset _bounded_pool to null — in that case the pool's
-  // own destructor already drained in-flight work, so this wait_all is
-  // redundant. Dereferencing the null pointer here throws std::system_error
-  // (EPERM) from the pthread_mutex call on garbage memory, surfacing to the
-  // caller as "Operation not permitted" and breaking otherwise-successful
-  // multi-file SF1000 scans.
+  // The pool is null when stop_thread_pool() has already joined its workers.
   if (_bounded_pool) { _bounded_pool->wait_all(); }
-  // Clear lookahead state so any schedule_lookahead() call from the
-  // management_eventloop that races with QueryEnd (after query_.reset() destroys
-  // operators but before task_creator_->reset() clears the queue) finds an
-  // empty queue and exits cleanly instead of dereferencing dangling pointers.
+  // Lookahead entries are raw pointers into the retiring plan.
   {
     std::lock_guard<std::mutex> lookahead_lock(_lookahead_mutex);
     _lookahead_queue.clear();
     _index_of_next_lookahead = 0;
   }
-  _task_creation_queue.reactivate();
+  if (reactivate) { _task_creation_queue.reactivate(); }
 }
 
 void task_creator::reset()
@@ -286,12 +279,11 @@ void task_creator::stop()
 void task_creator::start_thread_pool()
 {
   std::lock_guard<std::mutex> lock(_global_state_mutex);
+  // Do not recreate the pool while a concurrent shutdown is still joining workers.
+  std::lock_guard<std::mutex> shutdown_lock(_shutdown_mutex);
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
-  // Re-arm the request queue. stop_thread_pool() calls
-  // _task_creation_queue.interrupt() so the manager's pop() unblocks; without
-  // a paired reactivate() here, subsequent schedule() pushes silently no-op
-  // and the next query's manager_loop sees an empty/inactive queue forever.
+  // Reopen the queue parked by stop_thread_pool().
   _task_creation_queue.reactivate();
   _bounded_pool =
     std::make_unique<exec::bounded_thread_pool>(_config.thread_pool.num_threads,
@@ -302,6 +294,8 @@ void task_creator::start_thread_pool()
 
 void task_creator::do_stop_thread_pool()
 {
+  // Serialize joining and resetting the pool.
+  std::lock_guard<std::mutex> shutdown_lock(_shutdown_mutex);
   bool expected = true;
   if (!_running.compare_exchange_strong(expected, false)) { return; }
   _bounded_pool->interrupt();
@@ -310,6 +304,10 @@ void task_creator::do_stop_thread_pool()
   _bounded_pool->wait_all();
   _bounded_pool->stop();
   _bounded_pool.reset();
+  // Lookahead entries are raw operator pointers owned by the retiring plan.
+  std::lock_guard<std::mutex> lookahead_lock(_lookahead_mutex);
+  _lookahead_queue.clear();
+  _index_of_next_lookahead = 0;
 }
 
 void task_creator::stop_thread_pool()
@@ -318,10 +316,27 @@ void task_creator::stop_thread_pool()
   do_stop_thread_pool();
 }
 
+void task_creator::set_completion_handler(std::shared_ptr<pipeline::completion_handler> handler)
+{
+  std::lock_guard<std::mutex> lock(_completion_handler_mutex);
+  _completion_handler = std::move(handler);
+}
+
+std::shared_ptr<pipeline::completion_handler> task_creator::current_completion_handler() const
+{
+  std::lock_guard<std::mutex> lock(_completion_handler_mutex);
+  return _completion_handler;
+}
+
 void task_creator::schedule(op::sirius_physical_operator* node)
 {
   auto request  = std::make_unique<task_creation_request>();
   request->node = node;
+  if (auto handler = current_completion_handler()) {
+    request->work_slot = handler->acquire_work();
+    // A closed ledger means teardown owns the query; untracked work must not enter.
+    if (!request->work_slot) { return; }
+  }
   _task_creation_queue.push(std::move(request));
 }
 
@@ -344,6 +359,10 @@ void task_creator::schedule_lookahead(std::optional<int> device_id_hint)
       auto request  = std::make_unique<task_creation_request>();
       request->node = node;
       request->type = request_type::lookahead;
+      if (auto handler = current_completion_handler()) {
+        request->work_slot = handler->acquire_work();
+        if (!request->work_slot) { return; }
+      }
       _task_creation_queue.push(std::move(request));
       ++_index_of_next_lookahead;
       return;
@@ -361,7 +380,7 @@ void task_creator::manager_loop()
     }
     auto request = _task_creation_queue.pop();
     if (!request) {
-      // This is likely because the task creator was interrupted and the queue was drained
+      // The queue was interrupted while the manager was blocked.
       continue;
     }
 
@@ -374,11 +393,7 @@ void task_creator::manager_loop()
     node = get_operator_for_next_task(node, visited_pipelines);
 
     if (node == nullptr) {
-      // Same re-evaluation the creation path does on exit: get_next_task_hint()
-      // can have drained ports (hash join's discard sweep) in ANY pipeline the
-      // hint walk visited, making it finishable. A visited upstream pipeline
-      // whose tasks all completed earlier gets no later mark_task_completed(),
-      // so this is its only chance to be marked finished.
+      // Hint traversal can drain ports, so re-evaluate every pipeline it visited.
       std::sort(visited_pipelines.begin(), visited_pipelines.end());
       visited_pipelines.erase(std::unique(visited_pipelines.begin(), visited_pipelines.end()),
                               visited_pipelines.end());
@@ -388,209 +403,183 @@ void task_creator::manager_loop()
       continue;
     }
 
-    // Dispatch the task creation work to the pool
-    _bounded_pool->dispatch(std::move(slot), [this, node, request_kind]() mutable {
-      try {
-        // Get what we need to create the task
-        auto pipeline = node->get_pipeline();
-        std::vector<cucascade::shared_data_repository*> destination_data_repositories;
+    // Keep the request's work slot through the queue-to-pool hand-off.
+    auto handler = current_completion_handler();
+    _bounded_pool->dispatch(
+      std::move(slot),
+      [this,
+       node,
+       request_kind,
+       request = std::move(request),
+       handler = std::move(handler)]() mutable {
+        try {
+          // Get what we need to create the task
+          auto pipeline = node->get_pipeline();
+          std::vector<cucascade::shared_data_repository*> destination_data_repositories;
 
-        for (const auto& port_info : pipeline->get_next_ports_after_sink()) {
-          destination_data_repositories.push_back(
-            port_info.next_operator->get_port(port_info.next_operator_port_name)->repo);
-        }
-
-        while (!node->all_ports_empty()) {
-          auto task_lock  = pipeline->get_task_creation_lock();
-          auto input_data = node->get_next_task_input_data();
-          auto* pipelineable_input =
-            dynamic_cast<op::pipelineable_operator_data*>(input_data.get());
-          if (!input_data ||
-              (pipelineable_input && pipelineable_input->get_data_batches().empty())) {
-            // no data to create task for
-            break;
+          for (const auto& port_info : pipeline->get_next_ports_after_sink()) {
+            destination_data_repositories.push_back(
+              port_info.next_operator->get_port(port_info.next_operator_port_name)->repo);
           }
 
-          size_t operator_id                  = node->get_operator_id();
-          auto gpu_pipeline_task_global_state = _gpu_operator_global_state_map.at(operator_id);
-          auto local_state =
-            std::make_unique<pipeline::gpu_pipeline_task_local_state>(std::move(input_data));
+          while (!node->all_ports_empty()) {
+            auto task_lock  = pipeline->get_task_creation_lock();
+            auto input_data = node->get_next_task_input_data();
+            auto* pipelineable_input =
+              dynamic_cast<op::pipelineable_operator_data*>(input_data.get());
+            if (!input_data ||
+                (pipelineable_input && pipelineable_input->get_data_batches().empty())) {
+              // no data to create task for
+              break;
+            }
 
-          // pipelineable_input remains valid here: the cast happened before
-          // the move into local_state, and unique_ptr move transfers
-          // ownership without relocating the object.
-          {
-            std::optional<int> preferred_device_id;
-            // Operating-data preference (highest priority): the scan manager
-            // round-robins fresh-read scan splits across the available GPUs and
-            // stamps the chosen device onto the split's operating data. Honor it
-            // first so each split's task lands on its assigned GPU; the locality
-            // heuristics below only run when no upstream preference was set.
-            if (local_state->_input_data) {
-              preferred_device_id = local_state->_input_data->get_preferred_device_id();
-            }
-            // Partition affinity: if the input is tagged with a partition
-            // index, pin the task to partition_idx % num_gpus.
-            // Partition-based operators (hash_join, grouped_aggregate_merge,
-            // …) use cuco hash tables under the hood, and cuco tables must
-            // live on a single device — a stream bound to GPU A touching a
-            // counter built under GPU B trips cudaErrorInvalidValue at
-            // counter_storage.cuh. Routing on partition_idx keeps every
-            // task of a given partition on one GPU while still spreading
-            // partitions across GPUs.
-            // Partitioned data with no index asks to be placed by affinity instead: its producer
-            // built a single partition, so no other task shares its device requirement.
-            if (auto* partitioned =
-                  dynamic_cast<op::partitioned_operator_data*>(pipelineable_input);
-                !preferred_device_id.has_value() && partitioned && !_active_gpu_ids.empty()) {
-              // Index the active executor set so every task of a partition lands
-              // on the same real GPU (required for cuco tables); the physical
-              // topology would yield phantom pins when num_gpus < physical count.
-              if (auto const partition_idx = partitioned->get_partition_idx()) {
-                auto idx            = *partition_idx % _active_gpu_ids.size();
-                preferred_device_id = _active_gpu_ids[idx];
+            size_t operator_id                  = node->get_operator_id();
+            auto gpu_pipeline_task_global_state = _gpu_operator_global_state_map.at(operator_id);
+            auto local_state =
+              std::make_unique<pipeline::gpu_pipeline_task_local_state>(std::move(input_data));
+
+            // pipelineable_input remains valid after moving input_data.
+            {
+              std::optional<int> preferred_device_id;
+              // Honor an upstream device assignment before applying locality heuristics.
+              if (local_state->_input_data) {
+                preferred_device_id = local_state->_input_data->get_preferred_device_id();
               }
-            }
-            if (!preferred_device_id.has_value() && pipelineable_input &&
-                !pipelineable_input->get_data_batches().empty()) {
-              std::unordered_map<int, size_t> gpu_bytes;
-              std::unordered_map<int, size_t> host_bytes;
-              for (const auto& batch : pipelineable_input->get_data_batches()) {
-                if (!batch) { continue; }
-                auto ro     = batch->to_read_only();
-                auto* space = ro.get_memory_space();
-                if (!space || !ro.get_data()) { continue; }
-                auto size = ro.get_data()->get_size_in_bytes();
-                if (space->get_tier() == cucascade::memory::Tier::GPU) {
-                  gpu_bytes[space->get_device_id()] += size;
-                } else if (space->get_tier() == cucascade::memory::Tier::HOST) {
-                  // Key by the host space's NUMA node verbatim; topology_index
-                  // groups GPUs under that same key (including the -1 "unknown"
-                  // sentinel for non-NUMA / single-NUMA hosts), so gpus_of()
-                  // resolves without any normalization.
-                  host_bytes[space->get_device_id()] += size;
+              // Keep each indexed partition on one GPU because its cuco state is device-local.
+              // Partitioned data with no index asks to be placed by affinity instead: its producer
+              // built a single partition, so no other task shares its device requirement.
+              if (auto* partitioned =
+                    dynamic_cast<op::partitioned_operator_data*>(pipelineable_input);
+                  !preferred_device_id.has_value() && partitioned && !_active_gpu_ids.empty()) {
+                // Index active executors, not physical GPUs, to avoid excluded devices.
+                if (auto const partition_idx = partitioned->get_partition_idx()) {
+                  auto idx            = *partition_idx % _active_gpu_ids.size();
+                  preferred_device_id = _active_gpu_ids[idx];
                 }
               }
-              if (!gpu_bytes.empty()) {
-                // Data-locality: route to GPU with most data by bytes
-                preferred_device_id =
-                  std::max_element(gpu_bytes.begin(),
-                                   gpu_bytes.end(),
-                                   [](const auto& a, const auto& b) { return a.second < b.second; })
-                    ->first;
-              } else if (!host_bytes.empty() && _topology_index) {
-                // NUMA-affinity: no GPU data, route to a GPU on the same
-                // NUMA as the host data. When that NUMA hosts multiple
-                // GPUs, pick round-robin across them — pinning every
-                // host-sourced pipeline task to a single GPU defeats
-                // multi-GPU speedup.
-                auto top_host =
-                  std::max_element(host_bytes.begin(),
-                                   host_bytes.end(),
-                                   [](const auto& a, const auto& b) { return a.second < b.second; })
-                    ->first;
-                auto gpus = _topology_index->gpus_of(top_host);
-                if (!gpus.empty()) {
-                  auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
-                  preferred_device_id = gpus[idx];
-                }
-              }
-              SIRIUS_LOG_DEBUG(
-                "Task Creator: locality score gpu_sources={} host_sources={} preferred_device={}",
-                gpu_bytes.size(),
-                host_bytes.size(),
-                preferred_device_id.value_or(-1));
-            }
-            // Cached-scan locality: a resident scan_operator_input is
-            // NOT a pipelineable_operator_data (see
-            // sirius_gpu_scan_operator_data.hpp), so the data-locality block
-            // above skipped it wholesale. Without this branch, every
-            // pinned-table scan task gets dispatched round-robin by the
-            // scheduler and triggers a peer DMA or host staging when the
-            // consumer GPU differs from the chunk's home GPU. The pinned
-            // chunk's GPU residency is preserved on the batch
-            // (the cached provider pins each chunk_memory_space
-            // into the gpu_table_representation), so we just read it here.
-            if (!preferred_device_id.has_value()) {
-              if (auto* cached =
-                    dynamic_cast<op::scan::scan_operator_input*>(local_state->_input_data.get())) {
-                if (cached->is_resident()) {
-                  auto ro     = cached->get_cached_batch()->to_read_only();
+              if (!preferred_device_id.has_value() && pipelineable_input &&
+                  !pipelineable_input->get_data_batches().empty()) {
+                std::unordered_map<int, size_t> gpu_bytes;
+                std::unordered_map<int, size_t> host_bytes;
+                for (const auto& batch : pipelineable_input->get_data_batches()) {
+                  if (!batch) { continue; }
+                  auto ro     = batch->to_read_only();
                   auto* space = ro.get_memory_space();
-                  if (space) {
-                    if (space->get_tier() == cucascade::memory::Tier::GPU) {
-                      preferred_device_id = space->get_device_id();
-                    } else if (space->get_tier() == cucascade::memory::Tier::HOST &&
-                               _topology_index) {
-                      // tier='host' pinned chunks carry a NUMA-local host
-                      // memory_space; map back through the topology index to
-                      // pick a GPU on the same NUMA. The host space's device id
-                      // is the NUMA key verbatim (-1 = "unknown"), matching the
-                      // pipelineable locality block above.
-                      auto gpus = _topology_index->gpus_of(space->get_device_id());
-                      if (!gpus.empty()) {
-                        auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
-                        preferred_device_id = gpus[idx];
+                  if (!space || !ro.get_data()) { continue; }
+                  auto size = ro.get_data()->get_size_in_bytes();
+                  if (space->get_tier() == cucascade::memory::Tier::GPU) {
+                    gpu_bytes[space->get_device_id()] += size;
+                  } else if (space->get_tier() == cucascade::memory::Tier::HOST) {
+                    // Host device IDs are topology NUMA keys, including -1 for unknown.
+                    host_bytes[space->get_device_id()] += size;
+                  }
+                }
+                if (!gpu_bytes.empty()) {
+                  // Data-locality: route to GPU with most data by bytes
+                  preferred_device_id = std::max_element(gpu_bytes.begin(),
+                                                         gpu_bytes.end(),
+                                                         [](const auto& a, const auto& b) {
+                                                           return a.second < b.second;
+                                                         })
+                                          ->first;
+                } else if (!host_bytes.empty() && _topology_index) {
+                  // With host-only data, spread tasks across GPUs on the closest NUMA node.
+                  auto top_host = std::max_element(host_bytes.begin(),
+                                                   host_bytes.end(),
+                                                   [](const auto& a, const auto& b) {
+                                                     return a.second < b.second;
+                                                   })
+                                    ->first;
+                  auto gpus = _topology_index->gpus_of(top_host);
+                  if (!gpus.empty()) {
+                    auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
+                    preferred_device_id = gpus[idx];
+                  }
+                }
+                SIRIUS_LOG_DEBUG(
+                  "Task Creator: locality score gpu_sources={} host_sources={} preferred_device={}",
+                  gpu_bytes.size(),
+                  host_bytes.size(),
+                  preferred_device_id.value_or(-1));
+              }
+              // Resident scan inputs bypass pipelineable data, so derive locality from the
+              // cached batch to avoid peer copies or host staging.
+              if (!preferred_device_id.has_value()) {
+                if (auto* cached = dynamic_cast<op::scan::scan_operator_input*>(
+                      local_state->_input_data.get())) {
+                  if (cached->is_resident()) {
+                    auto ro     = cached->get_cached_batch()->to_read_only();
+                    auto* space = ro.get_memory_space();
+                    if (space) {
+                      if (space->get_tier() == cucascade::memory::Tier::GPU) {
+                        preferred_device_id = space->get_device_id();
+                      } else if (space->get_tier() == cucascade::memory::Tier::HOST &&
+                                 _topology_index) {
+                        // Host device IDs map directly to topology NUMA keys.
+                        auto gpus = _topology_index->gpus_of(space->get_device_id());
+                        if (!gpus.empty()) {
+                          auto idx            = _numa_affinity_rr.fetch_add(1) % gpus.size();
+                          preferred_device_id = gpus[idx];
+                        }
                       }
+                      SIRIUS_LOG_DEBUG(
+                        "Task Creator: cached-scan locality tier={} device_id={} "
+                        "preferred_device={}",
+                        static_cast<int>(space->get_tier()),
+                        space->get_device_id(),
+                        preferred_device_id.value_or(-1));
                     }
-                    SIRIUS_LOG_DEBUG(
-                      "Task Creator: cached-scan locality tier={} device_id={} "
-                      "preferred_device={}",
-                      static_cast<int>(space->get_tier()),
-                      space->get_device_id(),
-                      preferred_device_id.value_or(-1));
                   }
                 }
               }
-            }
-            // Confine the task to the admitted subset. Every preference above except the
-            // partition pin comes from where data lives rather than from the subset, and the
-            // scheduler treats a preference as binding — so an excluded id would be honoured.
-            // Clamping a residency-derived one costs the locality it encoded, but honouring
-            // it would put the query on a GPU it was not admitted to. An unpreferred task
-            // escapes too: the scheduler gives those to whichever executor asks first. Pin
-            // those as well, but only on a real subset, since a pin costs the scheduler's
-            // freedom to place them wherever frees up first.
-            if (!_active_gpu_ids.empty()) {
-              bool const names_excluded_device =
-                preferred_device_id.has_value() &&
-                std::find(_active_gpu_ids.begin(), _active_gpu_ids.end(), *preferred_device_id) ==
-                  _active_gpu_ids.end();
-              bool const unpinned_on_a_subset =
-                !preferred_device_id.has_value() && _active_gpu_ids.size() < _full_gpu_count;
-              if (names_excluded_device || unpinned_on_a_subset) {
-                auto const idx      = _admission_rr.fetch_add(1) % _active_gpu_ids.size();
-                preferred_device_id = _active_gpu_ids[idx];
+              // Device preferences are binding, so clamp them to the query's admitted subset.
+              // Unpreferred tasks also need a pin when the subset excludes available executors.
+              if (!_active_gpu_ids.empty()) {
+                bool const names_excluded_device =
+                  preferred_device_id.has_value() &&
+                  std::find(_active_gpu_ids.begin(), _active_gpu_ids.end(), *preferred_device_id) ==
+                    _active_gpu_ids.end();
+                bool const unpinned_on_a_subset =
+                  !preferred_device_id.has_value() && _active_gpu_ids.size() < _full_gpu_count;
+                if (names_excluded_device || unpinned_on_a_subset) {
+                  auto const idx      = _admission_rr.fetch_add(1) % _active_gpu_ids.size();
+                  preferred_device_id = _active_gpu_ids[idx];
+                }
+              }
+              if (preferred_device_id.has_value()) {
+                local_state->set_preferred_device_id(preferred_device_id.value());
               }
             }
-            if (preferred_device_id.has_value()) {
-              local_state->set_preferred_device_id(preferred_device_id.value());
+
+            // Acquire before constructing the task: on a closed ledger, abandon here — a
+            // constructed task's destructor would re-enter the pipeline mutex this scope holds.
+            exec::work_tracker::slot task_slot;
+            if (handler) {
+              task_slot = handler->acquire_work();
+              if (!task_slot) { return; }
             }
+            auto task_id = get_next_task_id();
+            auto task =
+              std::make_unique<pipeline::gpu_pipeline_task>(task_id,
+                                                            destination_data_repositories,
+                                                            std::move(local_state),
+                                                            gpu_pipeline_task_global_state);
+            task->set_work_slot(std::move(task_slot));
+            task_lock.unlock();
+            _task_scheduler->schedule(std::move(task));
+
+            if (request_kind == request_type::lookahead) { break; }
           }
-
-          auto task_id = get_next_task_id();
-          auto task    = std::make_unique<pipeline::gpu_pipeline_task>(task_id,
-                                                                    destination_data_repositories,
-                                                                    std::move(local_state),
-                                                                    gpu_pipeline_task_global_state);
-          task_lock.unlock();
-          _task_scheduler->schedule(std::move(task));
-
-          if (request_kind == request_type::lookahead) { break; }
+          // Re-evaluate after source exhaustion; there may be no later task completion.
+          pipeline->update_pipeline_status(false);
+        } catch (const std::exception& e) {
+          SIRIUS_LOG_ERROR("Task Creator: Exception during task creation: {}", e.what());
+          _task_scheduler->terminate_query(std::current_exception());
+          // Do not stop from a pool worker; wake the manager and let engine teardown join it.
+          _task_creation_queue.interrupt();
+          _bounded_pool->interrupt();
         }
-        // Unconditional re-evaluation at every creation exit: with the
-        // source-exhaustion finish guard, "last task completed at T1,
-        // connector closed at T2>T1" has no later mark_task_completed() to
-        // re-check the pipeline — this call, observing the now-exhausted
-        // source, is the paired re-evaluation. Without it, normal fast-GPU
-        // queries would hang.
-        pipeline->update_pipeline_status(false);
-      } catch (const std::exception& e) {
-        SIRIUS_LOG_ERROR("Task Creator: Exception during task creation: {}", e.what());
-        _task_scheduler->terminate_query(std::current_exception());
-        stop();
-      }
-    });
+      });
   }
 }
 

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -79,6 +79,8 @@ void downgrade_executor::start()
   }
 
   _request_queue.reactivate();
+  // A cancelled request must not leave monitoring disabled after restart.
+  _monitor_request_enqueued.store(false, std::memory_order_relaxed);
 
   absl::AnyInvocable<void() noexcept> per_thread_init = nullptr;
   if (_memory_space && _space_id.tier == cucascade::memory::Tier::GPU) {
@@ -471,8 +473,10 @@ void downgrade_executor::monitor_loop()
           };
           _monitor_requests_issued.fetch_add(1, std::memory_order_relaxed);
           _monitor_request_enqueued.store(true, std::memory_order_relaxed);
-          // Fire-and-forget: monitor does not wait for the result
-          _request_queue.push(std::move(req));
+          // A rejected request will not reach either path that normally clears the flag.
+          if (!_request_queue.push(std::move(req))) {
+            _monitor_request_enqueued.store(false, std::memory_order_relaxed);
+          }
         }
       } else if (!backed_off) {
         SIRIUS_LOG_WARN(
@@ -496,6 +500,10 @@ void downgrade_executor::monitor_loop()
 void downgrade_executor::cancel_pending_requests()
 {
   while (auto req = _request_queue.try_pop()) {
+    // Cancelled requests do not reach the processing loop that normally clears this flag.
+    if (req->is_monitor_request) {
+      _monitor_request_enqueued.store(false, std::memory_order_relaxed);
+    }
     try {
       req->result.set_exception(
         std::make_exception_ptr(std::runtime_error("downgrade executor shutting down")));
@@ -523,6 +531,8 @@ std::future<size_t> downgrade_executor::request_free_memory(size_t bytes)
   if (!_request_queue.push(std::move(req))) {
     SIRIUS_LOG_WARN(
       "[downgrade] request_free_memory: queue inactive, dropping request for {} bytes", bytes);
+    // Return the queue error rather than the destroyed promise's broken-promise error.
+    return rejected_request_future();
   }
   return future;
 }
@@ -539,9 +549,17 @@ std::future<size_t> downgrade_executor::request_downgrade(std::function<bool()> 
   auto future    = req->result.get_future();
   if (!_request_queue.push(std::move(req))) {
     SIRIUS_LOG_WARN("[downgrade] request_downgrade: queue inactive, dropping request");
-    return future;
+    return rejected_request_future();
   }
   return future;
+}
+
+std::future<size_t> downgrade_executor::rejected_request_future()
+{
+  std::promise<size_t> rejected;
+  rejected.set_exception(std::make_exception_ptr(
+    std::runtime_error("downgrade executor is not accepting requests (shutting down)")));
+  return rejected.get_future();
 }
 
 }  // namespace parallel

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -22,6 +22,7 @@
 #include "exec/config.hpp"
 #include "exec/interruptible_mpmc.hpp"
 #include "exec/queue_priority.hpp"
+#include "exec/work_tracker.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "op/scan/sirius_gpu_scan_operator.hpp"
 #include "op/sirius_physical_operator.hpp"
@@ -41,6 +42,7 @@
 namespace sirius::pipeline {
 class task_scheduler;
 class sirius_pipeline_task_global_state;
+class completion_handler;
 }  // namespace sirius::pipeline
 
 namespace sirius::planner {
@@ -69,6 +71,8 @@ namespace sirius::creator {
  */
 
 struct task_creation_request {
+  //! Counts the pending request as query work. Declared first so it is released last.
+  exec::work_tracker::slot work_slot;
   op::sirius_physical_operator* node;
   request_type type = request_type::active;
 };
@@ -113,6 +117,9 @@ class task_creator {
   /// \brief sets pipeline executor reference
   void set_task_scheduler(sirius::pipeline::task_scheduler& task_scheduler);
 
+  /// \brief Set the handler used to account for requests and tasks created for this query.
+  void set_completion_handler(std::shared_ptr<pipeline::completion_handler> handler);
+
   /// \brief prepare global states for all pipelines in the query
   void prepare_for_query(const sirius::planner::query& query);
 
@@ -145,8 +152,10 @@ class task_creator {
    *
    * Call this after a query completes (future resolved) but before destroying the engine/operators
    * to ensure no stale operator pointers are accessed by the task creator threads.
+   *
+   * @param reactivate Reopen the request queue after draining. Pass false to leave it parked.
    */
-  void drain_pending_tasks();
+  void drain_pending_tasks(bool reactivate = true);
 
   /**
    * @brief Schedule a task creation info for processing.
@@ -215,6 +224,9 @@ class task_creator {
    */
   void manager_loop();
 
+  /// Return a synchronized snapshot of the current completion handler.
+  [[nodiscard]] std::shared_ptr<pipeline::completion_handler> current_completion_handler() const;
+
   std::atomic<bool> _running;
   task_creator_config _config;
   std::unique_ptr<exec::bounded_thread_pool> _bounded_pool;
@@ -222,6 +234,9 @@ class task_creator {
   ::duckdb::ClientContext* _client_context;
   // Non-owning; SiriusContext stops and joins this creator before destroying the scheduler.
   sirius::pipeline::task_scheduler* _task_scheduler{nullptr};
+  /// Guarded because scheduling may continue from executor epilogues.
+  std::shared_ptr<pipeline::completion_handler> _completion_handler;
+  mutable std::mutex _completion_handler_mutex;
   sirius::memory::sirius_memory_reservation_manager& _mem_res_mgr;
   std::atomic<uint64_t> _task_id{0};
 
@@ -240,6 +255,8 @@ class task_creator {
   std::unique_ptr<duckdb::ThreadContext> _thread_context;
   std::unique_ptr<duckdb::ExecutionContext> _execution_context;
   std::mutex _global_state_mutex;  // Protect concurrent access to the map
+  /// Serializes pool start/stop. Lock order: global state, shutdown, then lookahead.
+  std::mutex _shutdown_mutex;
 
   /// Shared GPU<->NUMA topology index for NUMA-aware GPU routing (may be null).
   /// Scoped to the memory manager's reserved GPU/HOST spaces:

--- a/src/include/data/convertible_gpu_pipeline_task.hpp
+++ b/src/include/data/convertible_gpu_pipeline_task.hpp
@@ -85,7 +85,7 @@ class convertible_gpu_pipeline_task : public convertible_data {
    */
   ~convertible_gpu_pipeline_task() override
   {
-    if (_task) { (void)_queue.push(std::move(_task)); }
+    if (_task) { _queue.push(std::move(_task)); }
   }
 
   /**

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -177,6 +177,13 @@ class downgrade_executor {
   void cancel_pending_requests();
 
   /**
+   * @brief A ready future carrying the queue-inactive error.
+   *
+   * Replaces the broken-promise error produced when a rejected request is destroyed.
+   */
+  static std::future<size_t> rejected_request_future();
+
+  /**
    * @brief Whether a downgrade from this executor's source tier could plausibly free memory.
    *
    * DISK is an effectively unbounded sink, so if it is configured a downgrade can always make

--- a/src/include/exec/interruptible_mpmc.hpp
+++ b/src/include/exec/interruptible_mpmc.hpp
@@ -20,9 +20,11 @@
 
 #include <atomic>
 #include <concepts>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <thread>
 #include <vector>
 
 namespace sirius::exec {
@@ -57,6 +59,9 @@ class interruptible_mpmc {
   // Atomic flag to manage the shutdown state
   std::atomic<bool> _is_active{true};
 
+  // Pushes that passed the active check but have not finished enqueueing.
+  std::atomic<std::size_t> _pending_pushes{0};
+
   // Backstop poll interval (us) for wait_dequeue_timed. interrupt() wakes consumers directly, so
   // this only bounds the (not expected) case of a missed sentinel.
   static constexpr std::int64_t kPollBackstopUs = 10000;
@@ -78,17 +83,22 @@ class interruptible_mpmc {
   template <typename... Args>
   [[nodiscard]] bool emplace(Args&&... args)
   {
-    if (!_is_active.load(std::memory_order_relaxed)) { return false; }
-    queue.enqueue(std::make_unique<value_type>(std::forward<Args>(args)...));
-    return true;
+    return push(std::make_unique<value_type>(std::forward<Args>(args)...));
   }
 
   bool push(pointer_type item)
   {
     assert(item != nullptr);
-    if (!_is_active.load(std::memory_order_relaxed)) { return false; }
-    queue.enqueue(std::move(item));
-    return true;
+    // Register before checking the flag so interrupt() can wait for this enqueue.
+    _pending_pushes.fetch_add(1, std::memory_order_seq_cst);
+    if (!_is_active.load(std::memory_order_seq_cst)) {
+      _pending_pushes.fetch_sub(1, std::memory_order_release);
+      return false;
+    }
+    // Preserve enqueue allocation failures as rejected pushes.
+    const bool enqueued = queue.enqueue(std::move(item));
+    _pending_pushes.fetch_sub(1, std::memory_order_release);
+    return enqueued;
   }
 
   /**
@@ -129,14 +139,19 @@ class interruptible_mpmc {
   /**
    * \brief Clears the active flag AND wakes any blocked consumer immediately.
    *
-   * A consumer blocked in wait_dequeue_timed would otherwise not notice the interrupt until its
-   * poll interval elapsed, a stall paid on the teardown path of every query. Enqueuing null
-   * sentinels wakes the waiter at once; pop() maps a null item to its existing "interrupted"
-   * return. kWakeSentinels covers multiple consumers.
+   * Null sentinels wake blocked consumers immediately; pop() treats them as interruption.
+   *
+   * This is also a producer barrier: all pushes that observed an active queue finish before
+   * return. A subsequent drain therefore remains empty until reactivate().
    */
   void interrupt()
   {
-    _is_active.store(false);
+    _is_active.store(false, std::memory_order_seq_cst);
+    // This load must join the seq_cst order: acquire alone could miss an accepted producer's
+    // increment. Observing its release decrement also makes the enqueue visible to drain().
+    while (_pending_pushes.load(std::memory_order_seq_cst) != 0) {
+      std::this_thread::yield();
+    }
     for (int i = 0; i < kWakeSentinels; ++i) {
       queue.enqueue(pointer_type{});
     }

--- a/src/include/exec/work_tracker.hpp
+++ b/src/include/exec/work_tracker.hpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+namespace sirius::exec {
+
+/**
+ * Tracks in-flight work with move-only RAII slots.
+ *
+ * Slots may outlive the tracker and be acquired while another thread waits. close() rejects new
+ * slots, making the next zero permanent. All operations are thread-safe.
+ */
+
+class work_tracker {
+  struct state {
+    std::mutex m;
+    std::condition_variable cv;
+    std::size_t count{0};
+    bool closed{false};
+  };
+
+ public:
+  /// Move-only handle for one unit of work. Releasing the last slot wakes waiters.
+  class slot {
+   public:
+    slot() = default;
+
+    slot(slot&&) noexcept = default;
+    slot& operator=(slot&& other) noexcept
+    {
+      if (this != &other) {
+        release();
+        _state = std::move(other._state);
+      }
+      return *this;
+    }
+
+    slot(const slot&)            = delete;
+    slot& operator=(const slot&) = delete;
+
+    ~slot() { release(); }
+
+    /// True if this slot holds a live count.
+    explicit operator bool() const noexcept { return _state != nullptr; }
+
+   private:
+    friend class work_tracker;
+    explicit slot(std::shared_ptr<state> s) noexcept : _state(std::move(s)) {}
+
+    void release() noexcept
+    {
+      if (!_state) { return; }
+      bool drained = false;
+      {
+        std::lock_guard<std::mutex> lock(_state->m);
+        drained = (--_state->count == 0);
+      }
+      // The shared state remains alive while notifying outside the lock.
+      if (drained) { _state->cv.notify_all(); }
+      _state.reset();
+    }
+
+    std::shared_ptr<state> _state;
+  };
+
+  work_tracker() : _state(std::make_shared<state>()) {}
+
+  work_tracker(const work_tracker&)            = delete;
+  work_tracker& operator=(const work_tracker&) = delete;
+
+  /// Acquire a slot, or return an empty slot after close().
+  [[nodiscard]] slot acquire()
+  {
+    {
+      std::lock_guard<std::mutex> lock(_state->m);
+      if (_state->closed) { return slot{}; }
+      ++_state->count;
+    }
+    return slot{_state};
+  }
+
+  /// Permanently reject new slots. Trackers are per-query and are never reopened.
+  void close()
+  {
+    std::lock_guard<std::mutex> lock(_state->m);
+    _state->closed = true;
+  }
+
+  /// Return a snapshot of the number of live slots.
+  [[nodiscard]] std::size_t outstanding() const
+  {
+    std::lock_guard<std::mutex> lock(_state->m);
+    return _state->count;
+  }
+
+  /// Wait for the count to reach zero. Returns false on timeout.
+  [[nodiscard]] bool wait_quiescent(std::chrono::milliseconds timeout)
+  {
+    std::unique_lock<std::mutex> lock(_state->m);
+    return _state->cv.wait_for(lock, timeout, [this] { return _state->count == 0; });
+  }
+
+ private:
+  std::shared_ptr<state> _state;
+};
+
+}  // namespace sirius::exec

--- a/src/include/op/scan/sirius_gpu_scan_operator.hpp
+++ b/src/include/op/scan/sirius_gpu_scan_operator.hpp
@@ -101,6 +101,7 @@ class sirius_gpu_scan_operator : public sirius_physical_operator {
   std::optional<task_creation_hint> get_next_task_hint() override;
   [[nodiscard]] bool all_ports_empty() override;
   std::unique_ptr<op::operator_data> get_next_task_input_data() override;
+  void interrupt_source() override;
 
   // -----------------------------
   // Execution

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -777,6 +777,10 @@ class sirius_physical_operator {
   //! Get the input batch
   virtual std::unique_ptr<operator_data> get_next_task_input_data();
 
+  //! Wake any blocked wait inside get_next_task_input_data(); it then returns null. Error
+  //! teardown calls this before joining creator workers, whose producers may already be dead.
+  virtual void interrupt_source() {}
+
   //! Check if all ports are empty
   [[nodiscard]] virtual bool all_ports_empty();
   //! Check if the pipeline is finished

--- a/src/include/parallel/task.hpp
+++ b/src/include/parallel/task.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "exec/work_tracker.hpp"
 #include "helper/helper.hpp"
 
 #include <cudf/utilities/default_stream.hpp>
@@ -26,6 +27,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <utility>
 
 namespace sirius {
 namespace parallel {
@@ -78,6 +80,9 @@ class itask_global_state {
  * Interface for concrete executor tasks.
  */
 class itask {
+  //! Query-work slot. Declared first so it is released after task state and input batches.
+  exec::work_tracker::slot _work_slot;
+
  public:
   itask(uint64_t task_id,
         std::unique_ptr<itask_local_state> local_state,
@@ -120,6 +125,12 @@ class itask {
   itask_local_state* local_state() noexcept { return _local_state.get(); }
   [[nodiscard]] itask_global_state* global_state() noexcept { return _global_state.get(); }
   [[nodiscard]] uint64_t get_task_id() const noexcept { return _task_id; }
+
+  /// Set this task's query-work slot.
+  void set_work_slot(exec::work_tracker::slot slot) noexcept { _work_slot = std::move(slot); }
+
+  /// Move the slot to a continuation of this task.
+  [[nodiscard]] exec::work_tracker::slot take_work_slot() noexcept { return std::move(_work_slot); }
 
  protected:
   uint64_t _task_id;

--- a/src/include/parallel/task_executor.hpp
+++ b/src/include/parallel/task_executor.hpp
@@ -110,19 +110,6 @@ class itask_executor {
    */
   void drain_and_wait();
 
-  /**
-   * @brief Like drain_and_wait(), but VALIDATES the queue is empty instead of
-   * draining it.
-   *
-   * Stops the kiosk and interrupts the queue so the manager exits, waits for all
-   * in-flight thread-pool tasks, then — instead of draining — checks that the
-   * task queue is empty. If it is not, logs an error and throws: a non-empty queue
-   * at query completion means tasks were still scheduled when we declared the query
-   * done. Re-enables the queue/pool and restarts the manager thread either way
-   * (the throw happens after the executor is left in a restartable state).
-   */
-  void wait_and_validate_empty();
-
  protected:
   /**
    * @brief Main dispatch loop — must be implemented by each subclass.

--- a/src/include/pipeline/completion_handler.hpp
+++ b/src/include/pipeline/completion_handler.hpp
@@ -16,18 +16,25 @@
 
 #pragma once
 
+#include "exec/work_tracker.hpp"
+
 #include <atomic>
+#include <chrono>
+#include <cstddef>
 #include <exception>
 #include <future>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
 
 namespace sirius::pipeline {
 
 /**
- * @brief Handles query completion signaling with thread-safe state management.
+ * @brief Thread-safe query completion signaling and work accounting.
  *
- * This class manages a promise/future pair for signaling query completion.
- * It ensures that the completion state is only set once using atomic operations,
- * allowing safe concurrent access from multiple executor threads.
+ * The promise signals a result; the work tracker establishes teardown-safe quiescence.
  */
 class completion_handler {
  public:
@@ -41,14 +48,15 @@ class completion_handler {
   completion_handler& operator=(completion_handler&&)      = delete;
 
   /**
-   * @brief Report an error that occurred during query execution.
+   * @brief Report an exception.
    *
-   * Sets the exception on the promise. Only the first call has effect;
-   * subsequent calls are ignored.
+   * The first completion signal satisfies the promise; a losing error is retained for
+   * take_late_error().
    *
    * @param error The exception pointer to report.
+   * @return True if the future will carry this error, false if it was preserved instead.
    */
-  void report_error(std::exception_ptr error) noexcept
+  bool report_error(std::exception_ptr error) noexcept
   {
     bool expected = false;
     if (_completed.compare_exchange_strong(expected, true)) {
@@ -58,28 +66,29 @@ class completion_handler {
       } catch (...) {
         // Promise already satisfied or other error - ignore
       }
+      return true;
     }
+    keep_late_error(std::move(error));
+    return false;
   }
 
   /**
-   * @brief Report an error that occurred during query execution.
+   * @brief Report an error message with the same completion-race semantics.
    *
-   * Sets the exception on the promise. Only the first call has effect;
-   * subsequent calls are ignored.
-   *
-   * @param error The exception pointer to report.
+   * @param error The message to report.
+   * @return True if the future will carry this error, false if it was preserved instead.
    */
-  void report_error(std::string_view error) noexcept
+  bool report_error(std::string_view error) noexcept
   {
-    bool expected = false;
-    if (_completed.compare_exchange_strong(expected, true)) {
-      try {
-        _has_error.store(true);
-        _promise.set_exception(std::make_exception_ptr(std::runtime_error(error.data())));
-      } catch (...) {
-        // Promise already satisfied or other error - ignore
-      }
+    // Build the exception before racing the CAS: error.data() need not be null-terminated,
+    // and a construction failure after winning would leave the future pending forever.
+    std::exception_ptr exception;
+    try {
+      exception = std::make_exception_ptr(std::runtime_error(std::string(error)));
+    } catch (...) {
+      exception = std::current_exception();
     }
+    return report_error(std::move(exception));
   }
 
   /**
@@ -121,10 +130,73 @@ class completion_handler {
    */
   [[nodiscard]] bool has_error() const noexcept { return _has_error.load(); }
 
+  /**
+   * @brief Take the error that lost the completion race, if any.
+   *
+   * Success and failure share one CAS. Call this only after all potential reporters have
+   * released their work slots or been joined.
+   *
+   * @return The preserved exception, or nullptr. The call clears it, so it is delivered once.
+   */
+  [[nodiscard]] std::exception_ptr take_late_error() noexcept
+  {
+    std::lock_guard<std::mutex> lock(_late_error_mutex);
+    auto error  = std::move(_late_error);
+    _late_error = nullptr;
+    return error;
+  }
+
+  /**
+   * @brief Count one new unit of this query's work.
+   *
+   * The returned slot must cover the full lifetime of the work it counts. Returns an empty slot
+   * after close_work(); self-stamping producers must then abort.
+   */
+  [[nodiscard]] exec::work_tracker::slot acquire_work() { return _work.acquire(); }
+
+  /**
+   * @brief Permanently reject new work slots.
+   */
+  void close_work() { _work.close(); }
+
+  /**
+   * @brief Block until every counted unit of work has been destroyed, or @p timeout elapses.
+   *
+   * @return True if all counted query work has been destroyed.
+   */
+  [[nodiscard]] bool wait_quiescent(std::chrono::milliseconds timeout)
+  {
+    return _work.wait_quiescent(timeout);
+  }
+
+  /**
+   * @brief Return a snapshot of the number of live work slots.
+   */
+  [[nodiscard]] std::size_t outstanding_work() const { return _work.outstanding(); }
+
  private:
+  //! Preserve the first error that loses the completion race.
+  void keep_late_error(std::exception_ptr error) noexcept
+  {
+    if (!error) { return; }
+    try {
+      std::lock_guard<std::mutex> lock(_late_error_mutex);
+      if (!_late_error) { _late_error = std::move(error); }
+    } catch (...) {
+      // Ignore - this reporter is noexcept
+      return;
+    }
+    // Set even though the future carries a value: the reschedule path reads this to stop
+    // retrying work for a query that has already failed.
+    _has_error.store(true);
+  }
+
   std::promise<void> _promise;
   std::atomic<bool> _completed{false};
   std::atomic<bool> _has_error{false};
+  mutable std::mutex _late_error_mutex;
+  std::exception_ptr _late_error;
+  exec::work_tracker _work;
 };
 
 }  // namespace sirius::pipeline

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -203,9 +203,17 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! Set the task_creator pointer so this pipeline can schedule downstream consumers on finish.
   void set_task_creator(sirius::creator::task_creator* tc);
 
-  //! Install a query-terminal pipeline's weak completion reference.
-  //! Weak ownership prevents retired pipelines from keeping a query alive.
+  //! Install the query handler used for completion signals and producer work slots.
+  //! It is weak so a pipeline cannot outlive the query through this reference.
   void set_completion_handler(std::weak_ptr<completion_handler> handler);
+
+  //! Snapshot used by producer callbacks. `installed` distinguishes an ungated standalone
+  //! pipeline from a query pipeline whose handler expired.
+  struct completion_gate {
+    std::shared_ptr<completion_handler> handler;
+    bool installed{false};
+  };
+  [[nodiscard]] completion_gate lock_completion_gate();
 
   //! task_creator for schedule(), or nullptr when unwired. Streaming sources use this to
   //! re-arm a starved head; schedule() only enqueues, so off-thread calls are safe.
@@ -285,8 +293,10 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! Task creator pointer for scheduling downstream consumers when this pipeline finishes
   sirius::creator::task_creator* _task_creator{nullptr};
 
-  //! Per-query completion reference for terminal pipelines. Guarded by _status_mutex.
+  //! Query completion and work accounting, guarded by _status_mutex.
   std::weak_ptr<completion_handler> _completion_handler;
+  //! Distinguishes standalone pipelines from query pipelines with expired handlers.
+  bool _completion_handler_installed{false};
 
   //! The unique ID of this pipeline (assigned based on new_scheduled order)
   size_t pipeline_id = 0;

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -31,7 +31,9 @@
 #include <atomic>
 #include <future>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <stdexcept>
 #include <unordered_map>
 
 namespace sirius::parallel {
@@ -58,6 +60,14 @@ namespace pipeline {
  * task scheduling. It manages a pool of threads dedicated to executing GPU pipeline
  * tasks with specialized GPU resource management.
  */
+/// Thrown by wait_for_completion() when the work ledger fails to drain in time. Typed so the
+/// engine can, after teardown joins every reporter, replace it with the real error a straggler
+/// recorded meanwhile — the generic timeout must never mask a root cause.
+class premature_completion_error : public std::runtime_error {
+ public:
+  using std::runtime_error::runtime_error;
+};
+
 class task_scheduler {
  public:
   /**
@@ -185,16 +195,25 @@ class task_scheduler {
   void drain_after_error();
 
   /**
-   * @brief This function interrupts executors and waits for all in-flight tasks to complete.
-   * If any tasks are still in flight, an error is logged and an exception is thrown.
-   * This is used to ensure that all tasks have completed before the query returns and tears down
-   * the plan.
-   * @throws std::runtime_error if any tasks are still in flight.
+   * @brief Wait for the query's work ledger to drain after the completion future resolves.
+   *
+   * Execution remains active while existing work drains. The creator is then parked and the
+   * ledger closed so no new work can race plan teardown.
+   *
+   * @throws A late execution error, or std::runtime_error if work does not drain in time.
    */
   void wait_for_completion();
 
+  /// The error preserved after losing the completion race, if any; stable once teardown has
+  /// joined every reporter. Delivered once.
+  [[nodiscard]] std::exception_ptr take_preserved_error() noexcept;
+
  private:
   void management_eventloop();
+
+  /// Wake creator workers parked in a scan source's blocking split wait; both completion paths
+  /// call this before joining the creator.
+  void interrupt_query_scan_sources();
 
   std::mutex _query_mutex;
   duckdb::shared_ptr<planner::query> _query;
@@ -217,6 +236,13 @@ class task_scheduler {
 
   /// Device ID to GPU executor.
   std::unordered_map<int, std::unique_ptr<gpu_pipeline_executor>> _gpu_executors;
+
+  /// Lets error teardown flush an in-progress pop-to-schedule pass before draining queues.
+  std::mutex _dispatch_mutex;
+
+  /// Non-owning access used to stop downgrade workers before task queues are drained.
+  const std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>>* _downgrade_executors{
+    nullptr};
 
   sirius::creator::task_creator* _task_creator{nullptr};
   /// Strong owner for the weak completion references held by terminal pipelines.

--- a/src/include/scan_manager/split_connector.hpp
+++ b/src/include/scan_manager/split_connector.hpp
@@ -82,6 +82,12 @@ class split_connector : public std::enable_shared_from_this<split_connector> {
   /// \throws The exception passed to close() (if any) once the queue is drained.
   std::optional<std::unique_ptr<op::operator_data>> get_next_split();
 
+  /// \brief Permanently wake blocked get_next_split() callers; they return nullopt.
+  ///
+  /// For teardown, where the producer may never push or close again. Unlike close(),
+  /// push_split() stays legal afterwards; late splits are simply never consumed.
+  void interrupt();
+
   /// \brief True iff close() has been called and the queue is drained.
   [[nodiscard]] bool is_closed() const;
 
@@ -129,6 +135,7 @@ class split_connector : public std::enable_shared_from_this<split_connector> {
   std::condition_variable _cv;
   std::deque<std::unique_ptr<op::operator_data>> _splits;
   bool _closed{false};
+  bool _interrupted{false};
   std::exception_ptr _exception;
   /// steady_clock ms timestamp of the last get_next_split() pop (0 = never).
   std::atomic<std::int64_t> _last_pop_ms{0};

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -422,6 +422,8 @@ std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::get_next_task_input
   return std::move(*next);
 }
 
+void sirius_gpu_scan_operator::interrupt_source() { _split_connector->interrupt(); }
+
 //===----------------------------------------------------------------------===//
 // scan_manager wiring
 //===----------------------------------------------------------------------===//

--- a/src/op/sirius_physical_streaming_source.cpp
+++ b/src/op/sirius_physical_streaming_source.cpp
@@ -17,6 +17,8 @@
 #include "op/sirius_physical_streaming_source.hpp"
 
 #include "creator/task_creator.hpp"
+#include "exec/work_tracker.hpp"
+#include "pipeline/completion_handler.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 #include "sirius/exception.hpp"
 
@@ -49,19 +51,34 @@ void sirius_physical_streaming_source::set_pipeline(
 {
   sirius_physical_operator::set_pipeline(pipeline);
 
-  // Weak: callbacks run on producer threads.
+  // Work slots gate teardown; the weak pointer avoids extending the plan lifetime.
   duckdb::weak_ptr<pipeline::sirius_pipeline> weak_pipeline = pipeline;
 
-  // Empty/late-closed stream finishes with no task in flight; original_pipeline=false re-arms
-  // downstream consumers.
+  // A stream can end with no task available to update pipeline status.
   _input->set_on_end_of_stream([weak_pipeline] {
-    if (auto p = weak_pipeline.lock()) { p->update_pipeline_status(false); }
+    auto p = weak_pipeline.lock();
+    if (!p) { return; }
+    auto gate = p->lock_completion_gate();
+    exec::work_tracker::slot work;
+    if (gate.installed) {
+      if (!gate.handler) { return; }  // query over: never touch a retired pipeline
+      work = gate.handler->acquire_work();
+      if (!work) { return; }  // ledger closed: teardown owns the plan now
+    }
+    p->update_pipeline_status(false);
   });
 
   // Self-nomination (on_data → schedule(head)); schedule() only enqueues.
   _input->set_on_data([weak_pipeline] {
     auto p = weak_pipeline.lock();
     if (!p) { return; }
+    auto gate = p->lock_completion_gate();
+    exec::work_tracker::slot work;
+    if (gate.installed) {
+      if (!gate.handler) { return; }
+      work = gate.handler->acquire_work();
+      if (!work) { return; }
+    }
     auto* creator = p->get_task_creator();
     auto head     = p->get_source();
     if (creator && head) { creator->schedule(head.get()); }

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -128,36 +128,5 @@ void itask_executor::drain_and_wait()
   _manager_thread = std::thread([this] { manager_loop(); });
 }
 
-void itask_executor::wait_and_validate_empty()
-{
-  // Same quiescing as drain_and_wait(): interrupt the pool + queue so the manager
-  // exits, join it, and wait for all in-flight thread-pool tasks to finish.
-  _bounded_pool->interrupt();
-  _task_queue.interrupt();
-  if (_manager_thread.joinable()) { _manager_thread.join(); }
-  _bounded_pool->wait_all();
-
-  // Instead of draining, VALIDATE the queue is empty. A non-empty queue here means
-  // tasks were still scheduled on this executor when the query was declared complete.
-  const std::size_t remaining = _task_queue.size();
-
-  // Re-enable the pool/queue and restart the manager so the executor is left in a
-  // usable state for the next query, whether or not validation passes.
-  _bounded_pool->resume();
-  _task_queue.reactivate();
-  _manager_thread = std::thread([this] { manager_loop(); });
-
-  if (remaining != 0) {
-    SIRIUS_LOG_ERROR(
-      "itask_executor::wait_and_validate_empty: task queue NOT empty at query completion — "
-      "{} task(s) still queued; tasks were still being scheduled when the query was marked "
-      "complete",
-      remaining);
-    throw std::runtime_error(
-      "task_executor: task queue not empty at query completion (" + std::to_string(remaining) +
-      " task(s) remaining) — premature completion while work was still scheduled");
-  }
-}
-
 }  // namespace parallel
 }  // namespace sirius

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -305,165 +305,197 @@ void gpu_pipeline_executor::manager_loop()
        exc_stream = std::move(exc_stream),
        consumers  = std::move(output_consumers),
        pipeline]() mutable {
+        // Keep the slot through the epilogue, which still uses the pipeline after task.reset().
+        auto work_slot = task->take_work_slot();
+        // A throw inside a handler below bypasses its siblings and the pool would swallow it
+        // after the slot died; report and reset here instead, under the slot.
         try {
-          task->execute(exc_stream);
-          _tasks_executed.fetch_add(1, std::memory_order_relaxed);
-        } catch (task_reschedule_exception& ex) {
-          if (_completion_handler && _completion_handler->has_error()) {
-            // If the completion handler is already in an error state, then we can just return and
-            // not try to reschedule
-            return;
-          }
-          auto* gpu_task = cast_to_gpu_pipeline_task(task.get());
-          if (!gpu_task) {
-            SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to cast task for reschedule");
-            if (_completion_handler) {
-              _completion_handler->report_error(
-                "GPU Pipeline Executor: Failed to cast task for reschedule");
+          try {
+            task->execute(exc_stream);
+            _tasks_executed.fetch_add(1, std::memory_order_relaxed);
+          } catch (task_reschedule_exception& ex) {
+            if (_completion_handler && _completion_handler->has_error()) {
+              // Already erroring: don't retry. Reset under the local slot; the closure
+              // capture would otherwise outlive the ledger's coverage.
+              task.reset();
+              return;
             }
-            return;
-          }
+            auto* gpu_task = cast_to_gpu_pipeline_task(task.get());
+            if (!gpu_task) {
+              SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to cast task for reschedule");
+              if (_completion_handler) {
+                _completion_handler->report_error(
+                  "GPU Pipeline Executor: Failed to cast task for reschedule");
+              }
+              task.reset();
+              return;
+            }
 
-          // Sync the stream to ensure all memory is released before the reschedule.
-          exc_stream->synchronize();
+            // Sync the stream to ensure all memory is released before the reschedule.
+            exc_stream->synchronize();
 
-          // Determine retry count and original task ID for this rescheduled attempt.
-          auto* cur_local = dynamic_cast<gpu_pipeline_task_local_state*>(gpu_task->local_state());
-          uint32_t next_retry_count = 1;
-          uint64_t orig_task_id     = gpu_task->get_task_id();
-          if (cur_local && cur_local->original_task_id.has_value()) {
-            next_retry_count = cur_local->retry_count + 1;
-            orig_task_id     = cur_local->original_task_id.value();
-          }
+            // Determine retry count and original task ID for this rescheduled attempt.
+            auto* cur_local = dynamic_cast<gpu_pipeline_task_local_state*>(gpu_task->local_state());
+            uint32_t next_retry_count = 1;
+            uint64_t orig_task_id     = gpu_task->get_task_id();
+            if (cur_local && cur_local->original_task_id.has_value()) {
+              next_retry_count = cur_local->retry_count + 1;
+              orig_task_id     = cur_local->original_task_id.value();
+            }
 
-          // Bumped from 10 to 100 as part of follow-up #17. SF100 Q11 with
-          // cache=table_gpu + num_gpus=2 exhausted the old 10-retry budget
-          // against cross-GPU BUILD_PROBE batch-lock contention: the batch
-          // was held in `processing` on one GPU while the probe task on the
-          // other GPU needed it. Each convert-release cycle is O(100ms) at
-          // SF100 scale, so 10 retries × 5ms backoff (50 ms total) was far
-          // too short. With 100 retries × 50 ms backoff (~5 s) the probe
-          // tasks get enough patience to clear the contention window while
-          // still bailing out on truly wedged queries.
-          static constexpr uint32_t MAX_RETRIES = 100;
-          if (next_retry_count > MAX_RETRIES) {
-            SIRIUS_LOG_ERROR(
-              "GPU Pipeline Executor: task {} (original task {}) exceeded {} retries at "
-              "operator index {} — terminating query: {}",
+            // Bumped from 10 to 100 as part of follow-up #17. SF100 Q11 with
+            // cache=table_gpu + num_gpus=2 exhausted the old 10-retry budget
+            // against cross-GPU BUILD_PROBE batch-lock contention: the batch
+            // was held in `processing` on one GPU while the probe task on the
+            // other GPU needed it. Each convert-release cycle is O(100ms) at
+            // SF100 scale, so 10 retries × 5ms backoff (50 ms total) was far
+            // too short. With 100 retries × 50 ms backoff (~5 s) the probe
+            // tasks get enough patience to clear the contention window while
+            // still bailing out on truly wedged queries.
+            static constexpr uint32_t MAX_RETRIES = 100;
+            if (next_retry_count > MAX_RETRIES) {
+              SIRIUS_LOG_ERROR(
+                "GPU Pipeline Executor: task {} (original task {}) exceeded {} retries at "
+                "operator index {} — terminating query: {}",
+                gpu_task->get_task_id(),
+                orig_task_id,
+                MAX_RETRIES,
+                ex.get_resume_operator_index(),
+                ex.what());
+              if (_completion_handler) {
+                _completion_handler->report_error(std::make_exception_ptr(std::runtime_error(
+                  "GPU pipeline task exceeded maximum retry limit (" + std::to_string(MAX_RETRIES) +
+                  ") for original task " + std::to_string(orig_task_id) + ": " + ex.what())));
+              }
+              task.reset();
+              return;
+            }
+
+            SIRIUS_LOG_WARN(
+              "GPU Pipeline Executor: reschedule (retry {}/{}) for task {} (original task {}), "
+              "resuming from operator index {}: {}",
+              next_retry_count,
+              MAX_RETRIES,
               gpu_task->get_task_id(),
               orig_task_id,
-              MAX_RETRIES,
               ex.get_resume_operator_index(),
               ex.what());
-            if (_completion_handler) {
-              _completion_handler->report_error(std::make_exception_ptr(std::runtime_error(
-                "GPU pipeline task exceeded maximum retry limit (" + std::to_string(MAX_RETRIES) +
-                ") for original task " + std::to_string(orig_task_id) + ": " + ex.what())));
+
+            auto intermediate_data = ex.release_intermediate_data();
+            if (auto pipelineable_data =
+                  dynamic_cast<op::pipelineable_operator_data*>(intermediate_data.get())) {
+              // We want to release the read-only lock on the data so that when its added back to
+              // the task queue it could be downgraded if needed.
+              pipelineable_data->remove_read_only_lock();
             }
+
+            // Build the rescheduled task via virtual factory (preserves derived type).
+            auto new_local_state = std::make_unique<gpu_pipeline_task_local_state>(
+              std::move(intermediate_data), ex.get_resume_operator_index());
+            new_local_state->retry_count      = next_retry_count;
+            new_local_state->original_task_id = orig_task_id;
+            if (cur_local) { new_local_state->inherit_retry_reservation_floor(*cur_local); }
+
+            // Preserve the per-task device pin across reschedule. Dropping it lets
+            // an OOM'd partition task scatter to the wrong GPU and touch a cuco
+            // table built on another device (cudaErrorInvalidValue). Only the
+            // local_state pin needs copying; a global-state pin already survives.
+            if (cur_local && cur_local->get_preferred_device_id().has_value()) {
+              new_local_state->set_preferred_device_id(
+                cur_local->get_preferred_device_id().value());
+            }
+
+            auto new_task_id =
+              _task_creator ? _task_creator->get_next_task_id() : gpu_task->get_task_id();
+            auto new_task =
+              gpu_task->create_rescheduled_task(new_task_id, std::move(new_local_state));
+
+            if (auto* pipeline_task = dynamic_cast<sirius_pipeline_itask*>(task.get())) {
+              pipeline_task->telemetry_handle().finalizing({
+                .instance_name = "",
+                .success       = false,
+              });
+              pipeline_task->telemetry_handle().exit();
+              pipeline_task->set_telemetry_finalized();
+            }
+
+            // Destroy the original while the slot is still local: its destructor runs
+            // mark_task_completed() against the pipeline, and a completed retry must never be
+            // the last thing keeping the ledger open while this destructor is pending.
+            task.reset();
+            // The retry gets its own slot while this closure keeps its own until schedule()
+            // returns: schedule() owns the retry and a throw inside it would release the
+            // retry's slot before the outer handler reports. Closed ledger: abandon the retry
+            // (its destructor runs under the slot held here).
+            if (_completion_handler) {
+              auto retry_slot = _completion_handler->acquire_work();
+              if (!retry_slot) { return; }
+              new_task->set_work_slot(std::move(retry_slot));
+            }
+
+            // Backoff before rescheduling to allow other tasks to complete and
+            // free memory (true OOM case) or release a contended batch
+            // (cross-GPU processing contention, follow-up #17). 50 ms gives
+            // typical SF100 probe tasks time to finish their current work
+            // without putting the rescheduled task into a tight busy-spin.
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+            // Schedule the rescheduled task. It goes back through manager_loop()
+            // to acquire a fresh reservation before execution.
+            this->schedule(std::move(new_task));
+            return;
+          } catch (const std::exception& e) {
+            SIRIUS_LOG_ERROR("GPU Pipeline Executor: Exception during task execution: {}",
+                             e.what());
+            // Report only: stopping the creator here joins workers only the engine teardown
+            // this report unblocks can wake.
+            if (_completion_handler) {
+              _completion_handler->report_error(std::current_exception());
+            }
+            task.reset();
+            return;
+          } catch (...) {
+            SIRIUS_LOG_ERROR("GPU Pipeline Executor: unknown error during task execution");
+            if (_completion_handler) {
+              _completion_handler->report_error(std::current_exception());
+            }
+            task.reset();
             return;
           }
-
-          SIRIUS_LOG_WARN(
-            "GPU Pipeline Executor: reschedule (retry {}/{}) for task {} (original task {}), "
-            "resuming from operator index {}: {}",
-            next_retry_count,
-            MAX_RETRIES,
-            gpu_task->get_task_id(),
-            orig_task_id,
-            ex.get_resume_operator_index(),
-            ex.what());
-
-          auto intermediate_data = ex.release_intermediate_data();
-          if (auto pipelineable_data =
-                dynamic_cast<op::pipelineable_operator_data*>(intermediate_data.get())) {
-            // We want to release the read-only lock on the data so that when its added back to the
-            // task queue it could be downgraded if needed.
-            pipelineable_data->remove_read_only_lock();
-          }
-
-          // Build the rescheduled task via virtual factory (preserves derived type).
-          auto new_local_state = std::make_unique<gpu_pipeline_task_local_state>(
-            std::move(intermediate_data), ex.get_resume_operator_index());
-          new_local_state->retry_count      = next_retry_count;
-          new_local_state->original_task_id = orig_task_id;
-          if (cur_local) { new_local_state->inherit_retry_reservation_floor(*cur_local); }
-
-          // Preserve the per-task device pin across reschedule. Dropping it lets
-          // an OOM'd partition task scatter to the wrong GPU and touch a cuco
-          // table built on another device (cudaErrorInvalidValue). Only the
-          // local_state pin needs copying; a global-state pin already survives.
-          if (cur_local && cur_local->get_preferred_device_id().has_value()) {
-            new_local_state->set_preferred_device_id(cur_local->get_preferred_device_id().value());
-          }
-
-          auto new_task_id =
-            _task_creator ? _task_creator->get_next_task_id() : gpu_task->get_task_id();
-          auto new_task =
-            gpu_task->create_rescheduled_task(new_task_id, std::move(new_local_state));
-
-          // Backoff before rescheduling to allow other tasks to complete and
-          // free memory (true OOM case) or release a contended batch
-          // (cross-GPU processing contention, follow-up #17). 50 ms gives
-          // typical SF100 probe tasks time to finish their current work
-          // without putting the rescheduled task into a tight busy-spin.
-          std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-          // Schedule the rescheduled task. It goes back through manager_loop()
-          // to acquire a fresh reservation before execution.
           if (auto* pipeline_task = dynamic_cast<sirius_pipeline_itask*>(task.get())) {
             pipeline_task->telemetry_handle().finalizing({
               .instance_name = "",
-              .success       = false,
+              .success       = true,
             });
             pipeline_task->telemetry_handle().exit();
             pipeline_task->set_telemetry_finalized();
           }
-          this->schedule(std::move(new_task));
-          return;
-        } catch (const std::exception& e) {
-          SIRIUS_LOG_ERROR("GPU Pipeline Executor: Exception during task execution: {}", e.what());
-          if (_task_creator) { _task_creator->stop(); }
-          if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
-          return;
-        } catch (...) {
-          SIRIUS_LOG_ERROR("GPU Pipeline Executor: unknown error during task execution");
-          if (_task_creator) { _task_creator->stop(); }
-          if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
-          return;
-        }
-        if (auto* pipeline_task = dynamic_cast<sirius_pipeline_itask*>(task.get())) {
-          pipeline_task->telemetry_handle().finalizing({
-            .instance_name = "",
-            .success       = true,
-          });
-          pipeline_task->telemetry_handle().exit();
-          pipeline_task->set_telemetry_finalized();
-        }
-        task.reset();
+          task.reset();
 
-        // Check if query is complete BEFORE scheduling downstream tasks.
-        // mark_completed() signals the future that engine.execute() is waiting on,
-        // which may destroy the engine and its operators. We must not schedule
-        // tasks that reference those operators after signaling completion.
-        bool query_complete = false;
-        if (_completion_handler && pipeline && pipeline->is_query_terminal()) {
-          query_complete = pipeline->is_pipeline_finished();
-        }
-
-        if (!query_complete && _task_creator) {
-          // Schedule consumers explicitly here to drive the scheduler's
-          // round-robin rotation per-batch. notify_downstream_pipelines() in
-          // the task destructor only fires once the pipeline drains —
-          // mid-pipeline batches need to start rotating before that point so
-          // they reach all GPUs.
-          for (auto* consumer : consumers) {
-            if (consumer) { _task_creator->schedule(consumer); }
+          // Check completion before scheduling work that references plan-owned operators.
+          bool query_complete = false;
+          if (_completion_handler && pipeline && pipeline->is_query_terminal()) {
+            query_complete = pipeline->is_pipeline_finished();
           }
-        }
 
-        if (query_complete && _completion_handler) {
-          _task_creator->drain_pending_tasks();
-          _completion_handler->mark_completed();
+          if (!query_complete && _task_creator) {
+            // Schedule consumers explicitly here to drive the scheduler's
+            // round-robin rotation per-batch. notify_downstream_pipelines() in
+            // the task destructor only fires once the pipeline drains —
+            // mid-pipeline batches need to start rotating before that point so
+            // they reach all GPUs.
+            for (auto* consumer : consumers) {
+              if (consumer) { _task_creator->schedule(consumer); }
+            }
+          }
+
+          if (query_complete && _completion_handler) {
+            _task_creator->drain_pending_tasks();
+            _completion_handler->mark_completed();
+          }
+        } catch (...) {
+          if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
+          task.reset();
         }
       });
   }

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -350,12 +350,19 @@ void sirius_pipeline::set_task_creator(sirius::creator::task_creator* tc) { _tas
 void sirius_pipeline::set_completion_handler(std::weak_ptr<completion_handler> handler)
 {
   std::lock_guard<std::mutex> lock(_status_mutex);
-  _completion_handler = std::move(handler);
+  _completion_handler           = std::move(handler);
+  _completion_handler_installed = true;
+}
+
+sirius_pipeline::completion_gate sirius_pipeline::lock_completion_gate()
+{
+  std::lock_guard<std::mutex> lock(_status_mutex);
+  return {_completion_handler.lock(), _completion_handler_installed};
 }
 
 void sirius_pipeline::notify_downstream_pipelines(bool original_pipeline)
 {
-  // Query-terminal: no downstream; early return avoids teardown race after mark_completed().
+  // Terminal pipelines have no downstream work after completion.
   if (is_query_terminal()) { return; }
 
   // Schedule output consumers via the task_creator so downstream pipelines
@@ -435,16 +442,14 @@ void sirius_pipeline::update_pipeline_status(bool original_pipeline)
       if (!pipeline_finished.load()) { end_nvtx_range_if_finished(); }
     }
 
-    // Signal from the transition so non-epilogue finish paths cannot strand execute() (#1486).
-    // Sampling under the lock pairs with set_completion_handler().
+    // Signal from the finish transition; some finish paths never reach the GPU epilogue.
     if (should_notify && is_query_terminal()) { completion = _completion_handler.lock(); }
-  }  // _status_mutex released here — notify_downstream_pipelines must run outside the lock
-     // to avoid holding the child pipeline mutex while acquiring a parent's
+  }
 
+  // Avoid holding the child status lock while acquiring a parent's.
   if (should_notify) { notify_downstream_pipelines(original_pipeline); }
 
-  // Keep this last: waking execute() permits teardown. The epilogue may also signal, but
-  // completion_handler makes duplicate calls no-ops.
+  // Keep this last: waking execute() permits teardown.
   if (completion) { completion->mark_completed(); }
 }
 

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -35,6 +35,7 @@
 #include <cucascade/memory/memory_space.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <limits>
 #include <mutex>
 #include <stdexcept>
@@ -44,6 +45,11 @@
 
 namespace sirius {
 namespace pipeline {
+
+namespace {
+// Covers normal stragglers, including OOM retry backoff.
+constexpr auto k_ledger_drain_timeout = std::chrono::seconds(60);
+}  // namespace
 
 task_scheduler::task_scheduler(
   const exec::thread_pool_config& gpu_executor_config,
@@ -80,6 +86,7 @@ task_scheduler::task_scheduler(
     }),
     _telemetry_context(std::move(telemetry_context))
 {
+  _downgrade_executors  = downgrade_executors;
   _task_queue_telemetry = std::make_unique<telemetry::TaskQueueHandleWrapper>(
     *_telemetry_context, "task-scheduler-gpu-queue", _telemetry_context->shared_group_id());
 
@@ -196,12 +203,16 @@ void task_scheduler::prepare_for_query(duckdb::shared_ptr<planner::query> query)
     gpu_exec->set_completion_handler(_completion_handler.get());
   }
 
-  // Terminal pipelines keep weak references so replacing the handler retires the previous query.
+  // The creator may still be parked from the previous query.
+  if (_task_creator) {
+    _task_creator->set_completion_handler(_completion_handler);
+    _task_creator->start_thread_pool();
+  }
+
+  // Pipelines hold the handler weakly so they cannot extend the query lifetime.
   if (_query) {
     for (auto& pipeline : _query->get_pipelines()) {
-      if (pipeline && pipeline->is_query_terminal()) {
-        pipeline->set_completion_handler(_completion_handler);
-      }
+      if (pipeline) { pipeline->set_completion_handler(_completion_handler); }
     }
   }
 }
@@ -229,34 +240,53 @@ void task_scheduler::terminate_query(std::exception_ptr error)
     std::scoped_lock lock(_query_mutex);
     completion = _completion_handler;
   }
-  if (completion) { completion->report_error(std::move(error)); }
-  stop();
+  // Teardown belongs to drain_after_error(); stop() is terminal and cannot be restarted.
+  if (completion) { (void)completion->report_error(std::move(error)); }
+}
+
+void task_scheduler::interrupt_query_scan_sources()
+{
+  duckdb::shared_ptr<planner::query> query;
+  {
+    std::lock_guard<std::mutex> query_lock(_query_mutex);
+    query = _query;
+  }
+  if (!query) { return; }
+  for (auto* scan : query->get_scan_operators()) {
+    if (scan) { scan->interrupt_source(); }
+  }
 }
 
 void task_scheduler::drain_after_error()
 {
   SIRIUS_LOG_INFO("task_scheduler: draining after error");
-  // Teardown ordering is load-bearing. The scan/gpu executor drains below run
-  // in-flight tasks to completion, and a completing task schedules its
-  // downstream consumers via task_creator::schedule() (gpu_pipeline_executor and
-  // duckdb_scan_executor both do this). Each such request holds a raw
-  // sirius_physical_operator* owned by the engine, which is destroyed the moment
-  // execute() returns. If the task_creator is live (or restarted) while those
-  // requests are still in flight, its manager_loop dereferences a freed operator
-  // in get_operator_for_next_task() — a use-after-free that crashes intermittently
-  // under multi-partition sort with many in-flight pipeline tasks.
-  //
-  // So: stop the task_creator FIRST and keep its queue interrupted across the
-  // executor drains. With the queue interrupted, schedule() pushes from
-  // completion callbacks return false and the requests (and their dangling
-  // operator pointers) are dropped instead of processed. Only AFTER every
-  // executor has quiesced do we drain the creation queue and restart the
-  // creator for the next query.
+  // Reject new producer work before joining and draining existing work.
+  if (_completion_handler) { _completion_handler->close_work(); }
+
+  // Wake creator workers parked in a scan source's blocking split wait before joining them:
+  // their producers may be dead, and the closes that would wake them only run in query cleanup
+  // after this returns.
+  interrupt_query_scan_sources();
+
+  // Stop the creator before draining executors: completion callbacks may otherwise enqueue
+  // requests containing plan-owned operator pointers. Keep it parked until the next query.
   if (_task_creator) { _task_creator->stop_thread_pool(); }
+
+  // Downgrade workers can return borrowed tasks, so join them before draining queues.
+  if (_downgrade_executors) {
+    for (auto& downgrade_exec : *_downgrade_executors) {
+      if (downgrade_exec) { downgrade_exec->stop(); }
+    }
+  }
 
   // Drain the top-level task queue so management_eventloop doesn't dispatch
   // stale tasks from the failed query.
   _task_queue.drain();
+
+  // Flush any task currently between the scheduler queue and an executor queue.
+  {
+    std::lock_guard<std::mutex> dispatch_lock(_dispatch_mutex);
+  }
 
   // Interrupt each GPU executor's manager loop, wait for in-flight thread-pool
   // tasks to finish, then restart the manager for the next query.
@@ -264,62 +294,93 @@ void task_scheduler::drain_after_error()
     gpu_exec->drain_and_wait();
   }
 
-  // Now that no executor can generate further task_creation_requests, discard
-  // any that accumulated (and release the shared_ptr<data_batch> references they
-  // hold, which would otherwise survive clear_all_repositories at QueryEnd and
-  // show up as inter-iteration "memory leak" warnings). drain_pending_tasks()
-  // reactivates the queue when done.
-  if (_task_creator) { _task_creator->drain_pending_tasks(); }
+  // No executor can now create requests. Discard any queued requests and their data references
+  // while leaving the creator parked.
+  if (_task_creator) { _task_creator->drain_pending_tasks(/*reactivate=*/false); }
 
-  // Belt-and-suspenders: the executor restarts above emit device_ready signals,
-  // and the management loop may have dispatched a leftover task into an executor
-  // queue between the two drains. Clear the top-level queue once more so the
-  // next query starts from empty.
+  // Executor restarts emit readiness signals, so clear anything dispatched between drains.
   _task_queue.drain();
 
-  if (_task_creator) { _task_creator->start_thread_pool(); }
+  // QueryEnd destroys the plan after this returns, so wait indefinitely rather than risk
+  // teardown while a producer callback still holds a slot.
+  if (_completion_handler) {
+    std::size_t waited_s = 0;
+    while (!_completion_handler->wait_quiescent(k_ledger_drain_timeout)) {
+      waited_s += std::chrono::duration_cast<std::chrono::seconds>(k_ledger_drain_timeout).count();
+      SIRIUS_LOG_ERROR(
+        "task_scheduler::drain_after_error: {} unit(s) of work still outstanding after {}s; "
+        "teardown fail-stopped until they drain (only a mid-flight producer callback can hold "
+        "one here, so this indicates a wedged thread)",
+        _completion_handler->outstanding_work(),
+        waited_s);
+    }
+  }
+
+  // Restart downgrade workers only after every borrowed task has been returned and drained.
+  if (_downgrade_executors) {
+    for (auto& downgrade_exec : *_downgrade_executors) {
+      if (downgrade_exec) { downgrade_exec->start(); }
+    }
+  }
   SIRIUS_LOG_INFO("task_scheduler: DONE draining after error");
 }
 
 void task_scheduler::wait_for_completion()
 {
-  // Once the query has signaled completion, NOTHING should still be queued. Rather
-  // than drain (which would hide the bug), validate that every queue is empty and
-  // throw if not — a non-empty queue means tasks were still being scheduled when we
-  // declared the query done.
-  //
-  // Halt the producer (task_creator) first so the checks are not racing new task
-  // creation. The task_creator is always restarted afterwards (even on throw) so the
-  // next query can run.
-  if (_task_creator) { _task_creator->stop_thread_pool(); }
-  try {
-    // The task_scheduler's pipeline task queue must be empty.
-    if (const std::size_t remaining = _task_queue.size(); remaining != 0) {
-      SIRIUS_LOG_ERROR(
-        "task_scheduler::wait_for_completion: pipeline _task_queue NOT empty at query "
-        "completion — {} task(s) still queued; work was still scheduled when the query was "
-        "marked complete",
-        remaining);
-      throw std::runtime_error(
-        "task_scheduler: pipeline task queue not empty at query completion (" +
-        std::to_string(remaining) + " task(s) remaining)");
-    }
+  // Keep execution active while work that outlived the completion signal drains normally.
+  if (!_completion_handler) { return; }
 
-    // Each executor must finish its in-flight tasks and then have an empty queue.
-    for (auto& [device_id, gpu_exec] : _gpu_executors) {
-      gpu_exec->wait_and_validate_empty();
-    }
-  } catch (...) {
-    if (_task_creator) {
-      _task_creator->drain_pending_tasks();
-      _task_creator->start_thread_pool();
-    }
-    throw;
+  // An early-LIMIT finish leaves scan connectors open, and a creator worker can be parked in
+  // one's split wait, holding its request slot. Interrupt sources first: the ledger cannot
+  // drain past a parked worker, and the creator join below would never return. On a normal
+  // finish every connector is already closed, so this is a no-op.
+  interrupt_query_scan_sources();
+
+  const auto deadline  = std::chrono::steady_clock::now() + k_ledger_drain_timeout;
+  const auto time_left = [&deadline]() {
+    return std::max(std::chrono::duration_cast<std::chrono::milliseconds>(
+                      deadline - std::chrono::steady_clock::now()),
+                    std::chrono::milliseconds(0));
+  };
+
+  bool quiescent = _completion_handler->wait_quiescent(time_left());
+
+  // Park the creator so lookahead cannot create work after the first zero.
+  if (_task_creator) { _task_creator->stop_thread_pool(); }
+
+  // Drain requests that raced the first zero and creator shutdown.
+  while (quiescent && _completion_handler->outstanding_work() != 0) {
+    if (_task_creator) { _task_creator->drain_pending_tasks(/*reactivate=*/false); }
+    quiescent = _completion_handler->wait_quiescent(time_left());
   }
-  if (_task_creator) {
-    _task_creator->drain_pending_tasks();
-    _task_creator->start_thread_pool();
+
+  // Closing rejects new slots; the final wait covers acquisitions that won the race.
+  _completion_handler->close_work();
+  if (quiescent) { quiescent = _completion_handler->wait_quiescent(time_left()); }
+
+  // Surface an error that lost the race with the completion signal.
+  if (auto late_error = _completion_handler->take_late_error()) {
+    std::rethrow_exception(late_error);
   }
+  if (!quiescent) {
+    const std::size_t remaining = _completion_handler->outstanding_work();
+    SIRIUS_LOG_ERROR(
+      "task_scheduler::wait_for_completion: {} unit(s) of work still outstanding {}s after the "
+      "query signalled completion; work was still in flight when the query was marked complete",
+      remaining,
+      std::chrono::duration_cast<std::chrono::seconds>(k_ledger_drain_timeout).count());
+    throw premature_completion_error(
+      "task_scheduler: work still outstanding at query completion (" + std::to_string(remaining) +
+      " unit(s) after " +
+      std::to_string(
+        std::chrono::duration_cast<std::chrono::seconds>(k_ledger_drain_timeout).count()) +
+      "s) — the query was marked complete while work was still in flight");
+  }
+}
+
+std::exception_ptr task_scheduler::take_preserved_error() noexcept
+{
+  return _completion_handler ? _completion_handler->take_late_error() : nullptr;
 }
 
 void task_scheduler::management_eventloop()
@@ -346,7 +407,12 @@ void task_scheduler::management_eventloop()
     }
     while (evt) {
       if (evt->kind == task_request_kind::device_ready) {
-        _ready_devices.emplace_back(evt->device_id);
+        // A restarted manager may re-announce while its old credit is still pending.
+        // Deduplication preserves one reserved worker per dispatch credit.
+        if (std::find(_ready_devices.begin(), _ready_devices.end(), evt->device_id) ==
+            _ready_devices.end()) {
+          _ready_devices.emplace_back(evt->device_id);
+        }
       }
       evt = _task_request_channel.try_get();
     }
@@ -372,6 +438,9 @@ void task_scheduler::management_eventloop()
     // is only valid on the preferred device. Step (ii) will introduce an
     // explicit strict-vs-prefer bit; for now, all preferences are treated as
     // binding to guarantee correctness.
+    // Every step in the pass is non-blocking; drain_after_error() cycles this lock to flush
+    // an in-flight pass before it drains the executor queues.
+    std::lock_guard<std::mutex> dispatch_lock(_dispatch_mutex);
     for (auto it = _ready_devices.begin(); it != _ready_devices.end();) {
       const int device_id = *it;
       std::unique_ptr<sirius::parallel::itask> task;

--- a/src/scan_manager/split_connector.cpp
+++ b/src/scan_manager/split_connector.cpp
@@ -61,9 +61,11 @@ void split_connector::close(std::exception_ptr const& exception)
 std::optional<std::unique_ptr<op::operator_data>> split_connector::get_next_split()
 {
   std::unique_lock<std::mutex> lock(_mutex);
-  _cv.wait(lock, [this] { return !_splits.empty() || _closed; });
-  // if there is an exception, propagate it to the consumer instead of returning more splits
+  _cv.wait(lock, [this] { return !_splits.empty() || _closed || _interrupted; });
+  // A recorded producer error outranks a quiet interrupt exit: completion interrupts every
+  // source, and swallowing the error here would let a failed query report success.
   if (_exception) { std::rethrow_exception(_exception); }
+  if (_interrupted) { return std::nullopt; }
   if (!_splits.empty()) {
     auto split = std::move(_splits.front());
     _splits.pop_front();
@@ -74,6 +76,15 @@ std::optional<std::unique_ptr<op::operator_data>> split_connector::get_next_spli
     return std::optional<std::unique_ptr<op::operator_data>>{std::move(split)};
   }
   return std::nullopt;
+}
+
+void split_connector::interrupt()
+{
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _interrupted = true;
+  }
+  _cv.notify_all();
 }
 
 bool split_connector::is_draining(std::size_t quiet_ms) const

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -201,7 +201,17 @@ void sirius_engine::execute()
   auto future = sirius_ctx->get_task_scheduler().start_query();
   try {
     future.get();
+    // Rethrows any error preserved after losing the completion race.
     sirius_ctx->get_task_scheduler().wait_for_completion();
+  } catch (const pipeline::premature_completion_error& e) {
+    SIRIUS_LOG_ERROR("Error executing query: {}", e.what());
+    sirius_ctx->get_task_scheduler().drain_after_error();
+    // Teardown has now joined every reporter; a real error recorded meanwhile explains the
+    // outstanding work and outranks the generic timeout.
+    if (auto real_error = sirius_ctx->get_task_scheduler().take_preserved_error()) {
+      std::rethrow_exception(real_error);
+    }
+    throw;
   } catch (const std::exception& e) {
     SIRIUS_LOG_ERROR("Error executing query: {}", e.what());
     // Drain all in-flight GPU tasks before returning.  QueryEnd() will call

--- a/test/cpp/creator/test_task_creator.cpp
+++ b/test/cpp/creator/test_task_creator.cpp
@@ -20,6 +20,7 @@
 #include "op/sirius_physical_operator.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 #include "pipeline/task_scheduler.hpp"
+#include "scan_manager/split_connector.hpp"
 #include "utils/telemetry_utils.hpp"
 
 #include <cucascade/data/data_repository.hpp>
@@ -986,3 +987,89 @@ TEST_CASE("get_operator_for_next_task for operator with data returns the operato
 
 //   REQUIRE(completed.load() == num_calls);
 // }
+
+namespace {
+
+/// A source whose puller parks in a real split wait, like a scan whose producer has gone idle.
+class blocking_split_source final : public mock_sirius_physical_operator {
+ public:
+  blocking_split_source()
+  {
+    set_custom_hint(task_creation_hint{.hint = TaskCreationHint::READY, .producer = this});
+  }
+
+  bool all_ports_empty() override { return false; }
+
+  std::unique_ptr<op::operator_data> get_next_task_input_data() override
+  {
+    pulling.store(true);
+    auto split = connector.get_next_split();
+    return split.has_value() ? std::move(*split) : nullptr;
+  }
+
+  void interrupt_source() override { connector.interrupt(); }
+
+  scan_manager::split_connector connector;
+  std::atomic<bool> pulling{false};
+};
+
+}  // namespace
+
+// Early-LIMIT teardown shape: the query completes while this source's connector is still open
+// and its producer idle, so a creator worker parks in the split wait and nothing will ever
+// push or close. Joining the creator without interrupt_source() hangs forever; both
+// wait_for_completion() and drain_after_error() interrupt sources before the join.
+TEST_CASE("interrupt_source releases a creator worker parked in the split wait",
+          "[task_creator][completion-race]")
+{
+  test_fixture fixture;
+  // Declared before the creator: its destructor joins workers that still reference these.
+  mock_sirius_physical_operator sink_op;
+  auto pipeline = fixture.create_mock_pipeline();
+  sirius_pipeline_build_state build_state;
+  build_state.set_pipeline_sink(*pipeline, &sink_op, 0);
+  blocking_split_source source;
+  source.set_pipeline(pipeline);
+
+  task_creator creator(
+    creator::task_creator_config{
+      .thread_pool = {.num_threads = 1, .thread_name_prefix = "task_creator"}},
+    *fixture.memory_manager);
+  creator.set_client_context(*fixture.con.context);
+  creator.set_task_scheduler(fixture.pipeline_exec);
+
+  creator.start_thread_pool();
+  creator.schedule(&source);
+
+  const auto deadline   = std::chrono::steady_clock::now() + 15s;
+  const auto wait_until = [&deadline](auto&& done) {
+    while (!done()) {
+      if (std::chrono::steady_clock::now() > deadline) { return false; }
+      std::this_thread::sleep_for(5ms);
+    }
+    return true;
+  };
+
+  if (!wait_until([&] { return source.pulling.load(); })) {
+    // Free any half-parked worker and join before unwinding the stack it references.
+    source.interrupt_source();
+    creator.stop_thread_pool();
+    FAIL("worker never reached the pull");
+  }
+  // Give the worker time to enter the connector wait, not just set the flag.
+  std::this_thread::sleep_for(20ms);
+
+  source.interrupt_source();
+
+  std::atomic<bool> stopped{false};
+  std::thread stopper([&] {
+    creator.stop_thread_pool();
+    stopped.store(true);
+  });
+  const bool join_returned = wait_until([&] { return stopped.load(); });
+  // Never detach past stack references: re-interrupt (idempotent) and block on the join. A
+  // wedged join is the regression under test; the bounded check above already recorded it.
+  source.interrupt_source();
+  stopper.join();
+  if (!join_returned) { FAIL("creator join hung despite interrupt_source()"); }
+}

--- a/test/cpp/exec/test_interruptible_mpmc.cpp
+++ b/test/cpp/exec/test_interruptible_mpmc.cpp
@@ -520,3 +520,39 @@ TEST_CASE("interruptible_mpmc blocking pop receives pushed items", "[interruptib
   consumer.join();
   REQUIRE(received_value.load() == 999);
 }
+
+// Concurrent pushers must not refill the queue after interrupt() returns.
+TEST_CASE("interruptible_mpmc pushes cannot land after interrupt returns",
+          "[interruptible_mpmc][race]")
+{
+  constexpr int rounds    = 200;
+  constexpr int pushers_n = 4;
+
+  for (int round = 0; round < rounds; ++round) {
+    interruptible_mpmc<std::unique_ptr<int>> queue;
+    std::atomic<bool> go{false};
+    std::atomic<bool> stop{false};
+
+    std::vector<std::thread> pushers;
+    pushers.reserve(pushers_n);
+    for (int t = 0; t < pushers_n; ++t) {
+      pushers.emplace_back([&queue, &go, &stop] {
+        while (!go.load(std::memory_order_acquire)) {}
+        while (!stop.load(std::memory_order_acquire)) {
+          (void)queue.push(std::make_unique<int>(1));
+        }
+      });
+    }
+
+    go.store(true, std::memory_order_release);
+    std::this_thread::yield();
+    queue.interrupt();
+    queue.drain();
+    stop.store(true, std::memory_order_release);
+    for (auto& pusher : pushers) {
+      pusher.join();
+    }
+
+    REQUIRE(queue.is_empty());
+  }
+}

--- a/test/cpp/exec/test_work_tracker.cpp
+++ b/test/cpp/exec/test_work_tracker.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/work_tracker.hpp"
+
+#include <catch.hpp>
+
+#include <chrono>
+#include <thread>
+#include <utility>
+#include <vector>
+
+using sirius::exec::work_tracker;
+using namespace std::chrono_literals;
+
+TEST_CASE("work_tracker counts slots from acquire to destruction", "[work_tracker]")
+{
+  work_tracker tracker;
+  REQUIRE(tracker.outstanding() == 0);
+  REQUIRE(tracker.wait_quiescent(0ms));
+
+  {
+    auto a = tracker.acquire();
+    auto b = tracker.acquire();
+    REQUIRE(a);
+    REQUIRE(b);
+    REQUIRE(tracker.outstanding() == 2);
+    REQUIRE_FALSE(tracker.wait_quiescent(0ms));
+  }
+  REQUIRE(tracker.outstanding() == 0);
+  REQUIRE(tracker.wait_quiescent(0ms));
+}
+
+TEST_CASE("work_tracker slots move without double counting", "[work_tracker]")
+{
+  work_tracker tracker;
+  auto a = tracker.acquire();
+  REQUIRE(tracker.outstanding() == 1);
+
+  work_tracker::slot b = std::move(a);
+  REQUIRE(tracker.outstanding() == 1);
+  REQUIRE_FALSE(a);
+  REQUIRE(b);
+
+  auto c = tracker.acquire();
+  REQUIRE(tracker.outstanding() == 2);
+  c = std::move(b);
+  REQUIRE(tracker.outstanding() == 1);
+
+  auto& c_ref = c;
+  c           = std::move(c_ref);
+  REQUIRE(tracker.outstanding() == 1);
+}
+
+TEST_CASE("work_tracker wait_quiescent wakes when the last slot releases from another thread",
+          "[work_tracker]")
+{
+  work_tracker tracker;
+  auto slot = tracker.acquire();
+
+  std::thread releaser([held = std::move(slot)]() mutable { std::this_thread::sleep_for(50ms); });
+
+  REQUIRE(tracker.wait_quiescent(10000ms));
+  releaser.join();
+  REQUIRE(tracker.outstanding() == 0);
+}
+
+TEST_CASE("work_tracker keeps counting work acquired while a waiter is blocked", "[work_tracker]")
+{
+  work_tracker tracker;
+  auto first = tracker.acquire();
+
+  std::thread handoff([&tracker, held = std::move(first)]() mutable {
+    std::this_thread::sleep_for(20ms);
+    auto second = tracker.acquire();  // new work while the waiter blocks
+    held        = work_tracker::slot{};
+    std::this_thread::sleep_for(20ms);
+  });
+
+  REQUIRE(tracker.wait_quiescent(10000ms));
+  REQUIRE(tracker.outstanding() == 0);
+  handoff.join();
+}
+
+TEST_CASE("work_tracker slots may outlive the tracker", "[work_tracker]")
+{
+  work_tracker::slot survivor;
+  {
+    work_tracker tracker;
+    survivor = tracker.acquire();
+  }
+  survivor = work_tracker::slot{};
+  SUCCEED("slot released after tracker destruction without fault");
+}
+
+TEST_CASE("work_tracker close makes zero permanent", "[work_tracker]")
+{
+  work_tracker tracker;
+  auto before_close = tracker.acquire();
+  REQUIRE(before_close);
+
+  tracker.close();
+
+  auto after_close = tracker.acquire();
+  REQUIRE_FALSE(after_close);
+  REQUIRE(tracker.outstanding() == 1);
+  REQUIRE_FALSE(tracker.wait_quiescent(0ms));
+
+  before_close = {};
+  REQUIRE(tracker.wait_quiescent(0ms));
+  REQUIRE(tracker.outstanding() == 0);
+}
+
+TEST_CASE("work_tracker concurrent acquire/release converges to zero", "[work_tracker]")
+{
+  work_tracker tracker;
+  constexpr int threads_n  = 8;
+  constexpr int per_thread = 500;
+
+  std::vector<std::thread> threads;
+  threads.reserve(threads_n);
+  for (int t = 0; t < threads_n; ++t) {
+    threads.emplace_back([&tracker] {
+      for (int i = 0; i < per_thread; ++i) {
+        auto slot                     = tracker.acquire();
+        [[maybe_unused]] auto carrier = std::move(slot);
+      }
+    });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+  REQUIRE(tracker.outstanding() == 0);
+  REQUIRE(tracker.wait_quiescent(0ms));
+}

--- a/test/cpp/pipeline/test_completion_signal.cpp
+++ b/test/cpp/pipeline/test_completion_signal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Sirius Contributors.
+ * Copyright 2026, Sirius Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-/**
- * Regression tests for #1486: completion driven outside the GPU epilogue must still signal.
- * Bounded waits turn a lost signal into a test failure instead of a hang.
- */
+/** Regression tests for #1486: completion outside the GPU epilogue must still signal. */
 
 #include "helper/logical_type.hpp"
 #include "op/sirius_physical_operator.hpp"
@@ -31,6 +28,8 @@
 #include <chrono>
 #include <future>
 #include <memory>
+#include <stdexcept>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -43,7 +42,6 @@ using namespace std::chrono_literals;
 
 namespace {
 
-/// Poll until @p done() or fail after @p timeout.
 template <typename Pred>
 void wait_or_fail(Pred done, std::chrono::seconds timeout, const char* what)
 {
@@ -160,6 +158,113 @@ TEST_CASE("A non-terminal pipeline finishing does not signal the query",
   REQUIRE(awaitable.wait_for(50ms) == std::future_status::timeout);
 }
 
+namespace {
+
+/// Rethrow @p error and return its message, or "" if there is no error.
+std::string message_of(const std::exception_ptr& error)
+{
+  if (!error) { return {}; }
+  try {
+    std::rethrow_exception(error);
+  } catch (const std::exception& e) {
+    return e.what();
+  } catch (...) {
+    return "<non-standard exception>";
+  }
+}
+
+}  // namespace
+
+TEST_CASE("An error losing the completion race is preserved, not discarded",
+          "[pipeline][completion][completion-race]")
+{
+  // Force success to win the completion race before a worker reports an error.
+  completion_handler handler;
+  auto awaitable = handler.get_awaitable();
+
+  handler.mark_completed();
+  handler.report_error(std::make_exception_ptr(std::runtime_error("late failure")));
+
+  REQUIRE(awaitable.wait_for(0s) == std::future_status::ready);
+  REQUIRE_NOTHROW(awaitable.get());
+
+  REQUIRE(handler.has_error());
+  auto late = handler.take_late_error();
+  REQUIRE(late != nullptr);
+  REQUIRE(message_of(late) == "late failure");
+  REQUIRE(handler.take_late_error() == nullptr);
+}
+
+TEST_CASE("An error winning the completion race goes to the future, with nothing left over",
+          "[pipeline][completion][completion-race]")
+{
+  completion_handler handler;
+  auto awaitable = handler.get_awaitable();
+
+  handler.report_error(std::make_exception_ptr(std::runtime_error("first failure")));
+  handler.mark_completed();  // loses; must not convert the failure into a success
+
+  REQUIRE(handler.has_error());
+  REQUIRE(awaitable.wait_for(0s) == std::future_status::ready);
+  bool threw = false;
+  try {
+    awaitable.get();
+  } catch (const std::runtime_error& e) {
+    threw = std::string(e.what()) == "first failure";
+  }
+  REQUIRE(threw);
+  REQUIRE(handler.take_late_error() == nullptr);
+}
+
+TEST_CASE("report_error(string_view) respects the view's bounds",
+          "[pipeline][completion][completion-race]")
+{
+  // A view is not null-terminated; the message must be exactly the viewed bytes.
+  completion_handler handler;
+  auto awaitable = handler.get_awaitable();
+  handler.report_error(std::string_view("abcdef", 3));
+  bool threw = false;
+  try {
+    awaitable.get();
+  } catch (const std::runtime_error& e) {
+    threw = std::string(e.what()) == "abc";
+  }
+  REQUIRE(threw);
+}
+
+TEST_CASE("report_error reports whether it owns the failure",
+          "[pipeline][completion][completion-race]")
+{
+  {
+    completion_handler winner;
+    auto awaitable = winner.get_awaitable();
+    REQUIRE(winner.report_error(std::make_exception_ptr(std::runtime_error("owned"))));
+    REQUIRE_THROWS(awaitable.get());
+  }
+  {
+    completion_handler loser;
+    auto awaitable = loser.get_awaitable();
+    loser.mark_completed();
+    REQUIRE_FALSE(loser.report_error(std::make_exception_ptr(std::runtime_error("not owned"))));
+    REQUIRE_NOTHROW(awaitable.get());
+    REQUIRE(message_of(loser.take_late_error()) == "not owned");
+  }
+}
+
+TEST_CASE("Only the first error to lose the race is preserved",
+          "[pipeline][completion][completion-race]")
+{
+  completion_handler handler;
+  auto awaitable = handler.get_awaitable();
+
+  handler.mark_completed();
+  handler.report_error(std::make_exception_ptr(std::runtime_error("first late")));
+  handler.report_error(std::make_exception_ptr(std::runtime_error("second late")));
+
+  REQUIRE(message_of(handler.take_late_error()) == "first late");
+  REQUIRE_NOTHROW(awaitable.get());
+}
+
 TEST_CASE("A pipeline left over from a finished query cannot signal the next one",
           "[pipeline][completion][issue-1486]")
 {
@@ -173,4 +278,43 @@ TEST_CASE("A pipeline left over from a finished query cannot signal the next one
 
   REQUIRE_NOTHROW(pipeline->update_pipeline_status(false));
   REQUIRE(pipeline->is_pipeline_finished());
+}
+
+TEST_CASE("The completion future and the work ledger are separate conditions",
+          "[pipeline][completion][work-ledger]")
+{
+  // A ready result does not imply that all query work has drained.
+  completion_handler handler;
+  auto awaitable = handler.get_awaitable();
+
+  auto task_slot    = handler.acquire_work();
+  auto request_slot = handler.acquire_work();
+  REQUIRE(handler.outstanding_work() == 2);
+
+  handler.mark_completed();
+  REQUIRE(awaitable.wait_for(0s) == std::future_status::ready);
+  REQUIRE_FALSE(handler.wait_quiescent(0ms));  // signalled, but not yet safe to tear down
+
+  request_slot = {};
+  REQUIRE_FALSE(handler.wait_quiescent(0ms));
+  task_slot = {};
+  REQUIRE(handler.wait_quiescent(0ms));
+  REQUIRE(handler.outstanding_work() == 0);
+}
+
+TEST_CASE("A late error and the ledger drain compose the way wait_for_completion consumes them",
+          "[pipeline][completion][work-ledger]")
+{
+  // Once the straggler's slot is released, its late error is stable to consume.
+  completion_handler handler;
+  handler.mark_completed();
+
+  auto straggler = handler.acquire_work();
+  REQUIRE_FALSE(handler.report_error(std::make_exception_ptr(std::runtime_error("late"))));
+  straggler = {};
+
+  REQUIRE(handler.wait_quiescent(0ms));
+  auto late = handler.take_late_error();
+  REQUIRE(late != nullptr);
+  REQUIRE(message_of(late) == "late");
 }

--- a/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
@@ -17,8 +17,10 @@
 #include "catch.hpp"
 #include "exec/channel.hpp"
 #include "exec/config.hpp"
+#include "pipeline/completion_handler.hpp"
 #include "pipeline/gpu_pipeline_executor.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
+#include "pipeline/oom_reschedule_exception.hpp"
 #include "pipeline/sirius_pipeline_task_states.hpp"
 #include "pipeline/task_request.hpp"
 #include "scan/test_utils.hpp"
@@ -244,5 +246,161 @@ TEST_CASE("GPU pipeline executor schedules GPU tasks directly (push-model)",
     for (auto consumed_bytes : global_state->memory_consumption) {
       REQUIRE(consumed_bytes >= kReservationBytes);
     }
+  }
+}
+
+namespace {
+
+/// Records, at destructor entry, whether the query ledger still tracked this task. The ledger's
+/// lifetime guarantee is that a task's destructor — mark_task_completed() included — runs while
+/// the closure's slot still covers it, on every path out of the worker.
+class ledger_observing_task final : public sirius::pipeline::gpu_pipeline_task {
+ public:
+  enum class failure_mode { throw_error, reschedule_abort, reschedule_secondary_failure };
+
+  ledger_observing_task(uint64_t task_id,
+                        std::unique_ptr<test_gpu_pipeline_task_local_state> local_state,
+                        std::shared_ptr<test_gpu_pipeline_task_global_state> global_state,
+                        sirius::pipeline::completion_handler& handler,
+                        failure_mode mode,
+                        std::atomic<bool>& tracked_at_destruction,
+                        std::atomic<bool>& destroyed)
+    : gpu_pipeline_task(task_id,
+                        std::vector<cucascade::shared_data_repository*>{},
+                        std::move(local_state),
+                        std::move(global_state)),
+      _handler(handler),
+      _mode(mode),
+      _tracked_at_destruction(tracked_at_destruction),
+      _destroyed(destroyed)
+  {
+  }
+
+  ~ledger_observing_task() override
+  {
+    _tracked_at_destruction.store(_handler.outstanding_work() != 0);
+    _destroyed.store(true);
+  }
+
+  void execute(rmm::cuda_stream_view) override
+  {
+    if (_mode != failure_mode::throw_error) {
+      throw sirius::pipeline::task_reschedule_exception(nullptr, 0, "staged reschedule");
+    }
+    throw std::runtime_error("staged task failure");
+  }
+
+  // Secondary failure inside the reschedule handler; only reached when has_error is unset.
+  std::unique_ptr<sirius::pipeline::gpu_pipeline_task> create_rescheduled_task(
+    uint64_t, std::unique_ptr<sirius::pipeline::sirius_pipeline_task_local_state>) override
+  {
+    throw std::runtime_error("staged retry-construction failure");
+  }
+
+  sirius::pipeline::reservation_size_info get_estimated_reservation_size_info(
+    const cucascade::memory::memory_space*) const override
+  {
+    sirius::pipeline::reservation_size_info info;
+    info.reservation_size = kReservationBytes;
+    return info;
+  }
+
+  std::vector<sirius::op::sirius_physical_operator*> get_output_consumers() override { return {}; }
+
+ private:
+  sirius::pipeline::completion_handler& _handler;
+  failure_mode _mode;
+  std::atomic<bool>& _tracked_at_destruction;
+  std::atomic<bool>& _destroyed;
+};
+
+}  // namespace
+
+TEST_CASE("early-return paths destroy the task while the ledger still tracks it",
+          "[gpu_pipeline_executor][completion-race]")
+{
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> manager;
+  try {
+    cucascade::memory::reservation_manager_configurator builder;
+    builder.set_number_of_gpus(1)
+      .set_gpu_usage_limit(256 * 1024 * 1024)
+      .set_reservation_fraction_per_gpu(0.75)
+      .set_per_numa_region_capacity(1 * 1024 * 1024 * 1024)
+      .use_gpu_id_as_host_id()
+      .track_reservation_per_stream(false)
+      .set_reservation_fraction_per_numa_region(0.75);
+    auto space_configs = builder.build();
+    manager =
+      std::make_unique<sirius::memory::sirius_memory_reservation_manager>(std::move(space_configs));
+  } catch (const std::exception& e) {
+    WARN("Skipping test due to insufficient GPUs: " << e.what());
+    return;
+  }
+  auto* mem_space = manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  if (!mem_space) {
+    WARN("Skipping test because no GPU memory space is available.");
+    return;
+  }
+
+  const auto run_mode = [&](ledger_observing_task::failure_mode mode, bool pre_error) {
+    sirius::exec::channel<std::unique_ptr<sirius::pipeline::task_request>> request_channel;
+    sirius::exec::thread_pool_config config;
+    config.num_threads        = 1;
+    config.thread_name_prefix = "gpu-pipeline-test";
+    sirius::pipeline::gpu_pipeline_executor executor(config,
+                                                     mem_space,
+                                                     request_channel.make_publisher(),
+                                                     nullptr,
+                                                     sirius::test::make_test_telemetry_context());
+    sirius::pipeline::completion_handler handler;
+    executor.set_completion_handler(&handler);
+    if (pre_error) {
+      // has_error without a failed future: an error that lost the completion race.
+      handler.mark_completed();
+      handler.report_error(std::string_view("late failure"));
+    }
+
+    std::atomic<bool> tracked_at_destruction{false};
+    std::atomic<bool> destroyed{false};
+    auto local_state = std::make_unique<test_gpu_pipeline_task_local_state>(
+      std::make_unique<sirius::op::pipelineable_operator_data>(
+        std::vector<std::shared_ptr<cucascade::data_batch>>{}));
+    auto task = std::make_unique<ledger_observing_task>(
+      1,
+      std::move(local_state),
+      std::make_shared<test_gpu_pipeline_task_global_state>(),
+      handler,
+      mode,
+      tracked_at_destruction,
+      destroyed);
+    task->set_work_slot(handler.acquire_work());
+
+    executor.start();
+    executor.schedule(std::move(task));
+
+    const auto start = std::chrono::steady_clock::now();
+    while (!destroyed.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      if (std::chrono::steady_clock::now() - start > std::chrono::seconds(20)) {
+        executor.stop();
+        FAIL("staged task was never destroyed");
+      }
+    }
+    executor.stop();
+    REQUIRE(tracked_at_destruction.load());
+    REQUIRE(handler.has_error());
+  };
+
+  SECTION("generic error path")
+  {
+    run_mode(ledger_observing_task::failure_mode::throw_error, false);
+  }
+  SECTION("reschedule abort path (has_error set by a late error)")
+  {
+    run_mode(ledger_observing_task::failure_mode::reschedule_abort, true);
+  }
+  SECTION("secondary failure inside the reschedule handler is reported, not swallowed")
+  {
+    run_mode(ledger_observing_task::failure_mode::reschedule_secondary_failure, false);
   }
 }

--- a/test/cpp/pipeline/test_task_scheduler.cpp
+++ b/test/cpp/pipeline/test_task_scheduler.cpp
@@ -201,6 +201,32 @@ void wait_or_fail(Pred done, std::chrono::seconds timeout, const char* what)
 
 }  // namespace
 
+// Engine shutdown may stop the scheduler before completion cleanup reaches it.
+TEST_CASE("wait_for_completion tolerates executors that were already stopped",
+          "[task_scheduler][completion-race]")
+{
+  auto manager = initialize_memory_manager(1);
+  sirius::exec::thread_pool_config gpu_config{2};
+
+  SECTION("no query was ever prepared: the null-handler guard returns")
+  {
+    task_scheduler sched(gpu_config, *manager, sirius::test::make_test_telemetry_context());
+    sched.start();
+    sched.stop();
+    REQUIRE_NOTHROW(sched.wait_for_completion());
+  }
+
+  SECTION("a prepared query drains and closes its ledger without touching stopped executors")
+  {
+    task_scheduler sched(gpu_config, *manager, sirius::test::make_test_telemetry_context());
+    sched.prepare_for_query(nullptr);
+    sched.start();
+    sched.stop();  // out from under the engine, as engine shutdown would
+    REQUIRE_NOTHROW(sched.wait_for_completion());
+    REQUIRE_NOTHROW(sched.wait_for_completion());  // idempotent on a closed ledger
+  }
+}
+
 // Regression test for the #1467 deadlock: the downgrade executor extracts
 // queued tasks and returns them via convertible_gpu_pipeline_task's RAII
 // destructor — a direct queue push with no task_available event. With every

--- a/test/cpp/scan_manager/test_split_connector.cpp
+++ b/test/cpp/scan_manager/test_split_connector.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "scan_manager/split_connector.hpp"
+
+#include <catch.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <exception>
+#include <stdexcept>
+#include <thread>
+
+using sirius::scan_manager::split_connector;
+using namespace std::chrono_literals;
+
+TEST_CASE("split_connector interrupt wakes a blocked consumer with nullopt", "[split_connector]")
+{
+  split_connector connector;
+  std::atomic<bool> got_nullopt{false};
+  std::thread consumer([&] {
+    if (connector.get_next_split() == std::nullopt) { got_nullopt.store(true); }
+  });
+
+  std::this_thread::sleep_for(20ms);
+  connector.interrupt();
+  consumer.join();
+  REQUIRE(got_nullopt.load());
+}
+
+TEST_CASE("split_connector propagates a recorded producer error past an interrupt",
+          "[split_connector]")
+{
+  // Completion interrupts every scan source. If the producer already failed via
+  // close(exception), the pull must rethrow that error, not exit quietly — swallowing it here
+  // would let a failed query report success.
+  split_connector connector;
+  connector.close(std::make_exception_ptr(std::runtime_error("producer failed")));
+  connector.interrupt();
+
+  bool threw = false;
+  try {
+    (void)connector.get_next_split();
+  } catch (const std::runtime_error& e) {
+    threw = std::string(e.what()) == "producer failed";
+  }
+  REQUIRE(threw);
+}


### PR DESCRIPTION
## Summary

Stacked on #1624, which ensures query completion is always signalled. This PR makes completion safe:

- preserves execution errors that race with a success signal
- waits for all in-flight query work before destroying the plan
- prevents stale work from leaking into the next query

## Why

The completion future means the query is logically finished; it does not mean every worker, callback, or destructor has stopped using query state. Checking queues is insufficient because work may be:

- held by the dispatcher or a worker
- waiting as a task-creation request
- running in a producer callback
- finishing inside a task destructor or GPU epilogue

This PR therefore counts work itself instead of inspecting its containers.

## What changed

### Work ledger

Every query work unit holds an RAII slot from creation through destruction, including task-creation requests, GPU tasks, worker epilogues, OOM retries, and streaming callbacks. A zero count means no tracked query work remains in a queue or thread.

`wait_for_completion()` now:

1. lets existing work drain normally
2. parks the task creator
3. closes the ledger to reject new work
4. waits for the final zero
5. rethrows any error that lost the completion race

`drain_after_error()` applies the same teardown contract before the plan can be destroyed. `prepare_for_query()` re-arms the creator and installs a fresh per-query handler.

### Lifecycle and race fixes

- `terminate_query()` reports the error without terminally stopping the scheduler
- task-creator pool shutdown is serialized and cannot self-join
- error teardown joins downgrade workers and flushes an in-progress dispatch
- `interruptible_mpmc::interrupt()` is a producer barrier, so pushes cannot land after interrupt-and-drain
- restarted GPU managers cannot create duplicate readiness credits
- rejected downgrade requests return their real error and do not disable monitoring permanently

## Validation

- Full unit suite on clean 1-GPU and 2-GPU builds: 2764 cases, including TPC-H SF10
- The only failures were the two known environment-dependent REST subprocess tests, matching `dev`
- H1MISS fault injection completes with correct results; `dev` hangs indefinitely
- Added focused coverage for completion races, work-ledger semantics, slot hand-offs, and push-vs-interrupt ordering

## Checklist

- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests
- [x] No configuration changes
- [x] Update `docs/super-sirius/pipeline-execution.md` and `execution-flow.md`

## References

Refs #1486. Stacked on #1624.