### PR TITLE
ci(pr-title): skip revalidation in merge queue to unblock stuck PRs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,7 @@ name: Validate
 on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize]
+  merge_group:
 
 jobs:
   semantic-pr:
@@ -11,6 +12,12 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+      - if: github.event_name != 'merge_group'
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # amannn/action-semantic-pull-request requires a `pull_request` payload, which merge_group
+      # events don't have. The title was already validated as a required check before the PR
+      # became mergeable, so there's nothing to re-verify here.
+      - if: github.event_name == 'merge_group'
+        run: exit 0


### PR DESCRIPTION
## Description
Without this change PRs that passed to get into the queue are then stuck in the queue waiting for `pr-title` to pass. `pr-title` is unable to run in merge queues (as it expects a payload that is not available), so it has resulted in 4 PRs that are currently stuck.

We could remove `pr-title` from the required check but that would remove the check to ensure titles follow Conventional Commits. Instead, in a merge queue `pr-title` now returns `exit 0` to move the queue forward. Given only PRs that pass all required checks (including `pr-title` can enter the merge queue this is an adequate workaround.

This is a recent occurrence due to the recent inclusion of `pr-title` in required checks last Friday.

## Checklist
- [x] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
- Impacted PR #1481
