### PR TITLE
fix(build): include variant before cuDF AST headers

### DIFF
--- a/src/include/op/dynamic_filter/sirius_dynamic_filter.hpp
+++ b/src/include/op/dynamic_filter/sirius_dynamic_filter.hpp
@@ -18,8 +18,12 @@
 
 #include "op/dynamic_filter/dynamic_filter_replica_space.hpp"
 
+// libcudf's AST header uses std::variant without including <variant>.
+// clang-format off
+#include <variant>
 #include <cudf/ast/ast_operator.hpp>
 #include <cudf/ast/expressions.hpp>
+// clang-format on
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/scalar/scalar.hpp>

--- a/src/include/op/scan/dynamic_filter_merge.hpp
+++ b/src/include/op/scan/dynamic_filter_merge.hpp
@@ -16,7 +16,11 @@
 
 #pragma once
 
+// libcudf's AST header uses std::variant without including <variant>.
+// clang-format off
+#include <variant>
 #include <cudf/ast/expressions.hpp>
+// clang-format on
 #include <cudf/table/table.hpp>
 
 #include <rmm/cuda_stream_view.hpp>

--- a/src/op/dynamic_filter/sirius_dynamic_filter.cpp
+++ b/src/op/dynamic_filter/sirius_dynamic_filter.cpp
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+// libcudf's AST header uses std::variant without including <variant>.
+// clang-format off
+#include <variant>
 #include <cudf/ast/expressions.hpp>
+// clang-format on
 #include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/search.hpp>
 #include <cudf/utilities/traits.hpp>


### PR DESCRIPTION
## Summary

- Include `<variant>` before `cudf/ast/expressions.hpp`
- Work around libcudf’s missing direct include
- Fix ARM64 GCC 15 nightly builds that cannot resolve `std::variant`