### PR TITLE
ci(validate): consolidate checks under a summary job for merge queue

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,9 @@ name: Validate
 on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize]
+  pull_request:
+    paths:
+      - .github/workflows/validate.yml
   merge_group:
 
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,28 +6,31 @@ on:
   merge_group:
 
 jobs:
-  # Checks the PR title to ensure it follows Conventional Commits guidelines
+  # Checks the PR title to ensure it follows Conventional Commits guidelines. Skipped entirely
+  # under merge_group, which has no `pull_request` payload for the action to validate — the
+  # `validate` job below treats a skip here as satisfied, since the title was already required
+  # to pass before the PR became mergeable.
   semantic-pr:
     name: pr-title
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-slim
     permissions:
       pull-requests: read
     steps:
-      - if: github.event_name != 'merge_group'
-        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # amannn/action-semantic-pull-request requires a `pull_request` payload, which merge_group
-      # events don't have. The title was already validated as a required check before the PR
-      # became mergeable, so there's nothing to re-verify here.
-      - if: github.event_name == 'merge_group'
-        run: exit 0
 
-  # Removes HTML comments from our PR template to keep our commits clean; #1609
+  # Removes HTML comments from our PR template to keep our commits clean; #1609. Skipped
+  # entirely under merge_group for the same reason as pr-title above — no `pull_request`
+  # payload to clean, and the body was already cleaned when the PR itself was opened/edited.
   clean-pr-body:
     name: pr-body
+    if: >
+      github.event_name != 'merge_group' &&
+      github.event.action != 'synchronize' &&
+      (github.event.action != 'edited' || github.event.changes.body)
     runs-on: ubuntu-slim
-    if: github.event.action != 'synchronize' && (github.event.action != 'edited' || github.event.changes.body)
     permissions:
       pull-requests: write
     steps:
@@ -44,3 +47,22 @@ jobs:
                 body: stripped,
               });
             }
+
+  # Single required status check for this workflow. Consolidates pr-title and pr-body so branch
+  # protection only needs to list `validate`, not every job here — matching the check/test
+  # workflows' own aggregator pattern. A `skipped` result (both jobs skip under merge_group) is
+  # treated the same as `success`, since skipping there is expected, not a failure.
+  validate:
+    name: validate
+    needs: [semantic-pr, clean-pr-body]
+    if: always()
+    runs-on: ubuntu-slim
+    steps:
+      - if: >
+          (needs['semantic-pr'].result == 'success' || needs['semantic-pr'].result == 'skipped') &&
+          (needs['clean-pr-body'].result == 'success' || needs['clean-pr-body'].result == 'skipped')
+        run: exit 0
+      - if: >
+          !((needs['semantic-pr'].result == 'success' || needs['semantic-pr'].result == 'skipped') &&
+            (needs['clean-pr-body'].result == 'success' || needs['clean-pr-body'].result == 'skipped'))
+        run: exit 1


### PR DESCRIPTION
## Description
- Reworks validate workflow to have a summary job. This summary job handles the issues with the merge_queue checks that do not have the PR payload to do a PR title and body check
- Summary job returns true on skipped jobs in merge_queue

## Checklist
- [x] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## TODO
- [ ] Post-merge update required to `validate` summary job install

## References
Closes #1648