### PR TITLE
docs(contributing): add PR branch strategy and stacked PR instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,64 @@ The component teams can also be mentioned directly in PR comments and issues to 
 
 When you open or update a PR, you will also be automatically assigned as the author. This helps maintainers track ownership and is not a request for you to review your own work.
 
+### PR branching strategy
+
+Sirius uses ***Self-contained*** PRs submitted from contributor forks as our **primary** method of
+contributing to Sirius. There are two approved exceptions, both restricted to [Maintainers](MAINTAINERS.md):
+Stacked PRs as a **secondary** contribution method, and **break-glass** CI & Critical changes.
+
+| PR Type | PR Author | Push To | Reasoning |
+| --- | --- | --- | --- |
+| ***Primary*** - Self-contained | Any Contributor | Personal fork | This allows all contributors to submit PRs from their forks, keeping the main repo focused on development, releases, and Stacked PRs |
+| ***Secondary*** - Stacked PRs (dependent changes)  | Only Maintainers | `sirius-db/sirius` repo  with `stacked/` prefix for branch names | Stacked PRs help developers contribute larger changes to the code base in smaller pieces that are easier to review and have fewer conflicts compared to a single large PR. See [Stacked PRs](#stacked-prs) below for more information |
+| ***Break-glass*** - CI & Critical | Only Maintainers | `sirius-db/sirius` repo | By exception there may be CI and Critical PRs that must be pushed to this repo if there are CI tests or other triggers necessary before merging; examples: `workflow_dispatch` and certain workflows using secrets and tokens not available in forks |
+
+**NOTE:** Branches of PRs pushed to the main repo and personal forks are cleaned up automatically; this
+repo has "Automatically delete head branches" enabled, so merged branches don't need manual deletion.
+
+### Stacked PRs
+
+:warning: Stacked PRs require push permissions to the `sirius-db/sirius` repo in order to work. Currently
+this development option is restricted to [Maintainers](MAINTAINERS.md). If you are interested in becoming a
+maintainer, see [GOVERNANCE.md](GOVERNANCE.md#becoming-a-maintainer) for details.
+
+For a chain of dependent changes, Sirius uses the [`gh-stack`](https://github.com/github/gh-stack)
+`gh` CLI extension — it's the only supported tool for stacked PRs. Don't use Graphite,
+`git-spice`, `ghstack`, or similar; a mix of tools operating on the same branches will conflict.
+
+#### Install it once
+
+If needed, follow these [instructions](https://cli.github.com/) to install GitHub CLI. 
+```bash
+# Install Stacked PRs extension
+gh extension install github/gh-stack
+```
+
+#### Conventions
+
+- Every branch in a stack must be prefixed `stacked/` (e.g. `stacked/docs-contributing-gh-stacks`)
+  so stacked work is identifiable and groupable, separate from regular single-branch PRs.
+- `stacked/`-prefixed branches may be pushed directly to `origin` (this repo)
+  - If you are working on a local copy that is your fork, you will need to ensure `origin` points
+    to this repo and not your fork.
+  - Run the following command replacing `$USER` with your name; otherwise it will use your local username:
+      ```bash
+      # Rename current origin to local user's name and set origin to main Sirius repo
+      git remote rename origin $USER
+      git remote add origin "git@github.com:sirius-db/sirius.git"
+      ```
+
+#### Basic commands
+
+See `gh stack --help` for the full set:
+
+```bash
+gh stack init stacked/<branch1> stacked/<branch2> ...   # create a new stack
+gh stack add stacked/<branch>                           # add a branch on top of the current stack
+gh stack submit                                         # push all branches and create/update PRs
+gh stack sync                                           # rebase and sync the stack with GitHub
+```
+
 ### Commit and title convention
 
 Sirius squash-merges PRs, the PR titles become the commit message on merge. Commits and PR titles follow [Conventional Commits](https://www.conventionalcommits.org/) format for readability.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ For a chain of dependent changes, Sirius uses the [`gh-stack`](https://github.co
 
 #### Install it once
 
-If needed, follow these [instructions](https://cli.github.com/) to install GitHub CLI. 
+If needed, follow these [instructions](https://cli.github.com/) to install GitHub CLI.
 ```bash
 # Install Stacked PRs extension
 gh extension install github/gh-stack


### PR DESCRIPTION
## Description
Sirius has decided to adopt Stacked PRs as an additional method of contributing code to this repo. Stacked PRs are needed for larger feature development where reviewing and keeping very large PRs updated have slowed the team down significantly. The addition of stacked PRs to our traditional fork-based self-contained PRs, will allow Maintainers the flexibility to make a design decision for new features of which method to use.

Stacked PRs allow developers to layer a series of dependent changes in a stack for review and merging into the code base, where each layer is an independent change that can be reviewed and stand on its own. The team decided to use GitHub Stacks due to the native GitHub Web and CLI integration that would allow all reviewers full visibility of a stack. Right now, only Maintainers will be able to make stacked PRs due to the need for pushing stacked branches to this repo.

In addition to detailing ***Stacked PRs***, this PR also defines our PR branching strategy for our primary method of ***Self-contained*** (from fork PRs) and an exception ***Break-glass*** for CI & critical changes. The goal is to make both Stacked PRs available while also defining practices for our primary contribution method in one PR.

In order to meet these goals and to ensure the proposed workflows are without error, I am using this PR along with 2 related PRs as our first Stacked PR to test this process before being fully adopted by the team.

## Changes
- Documented our primary PR branching strategy for contributors of ***Self-contained*** along with approved exceptions for Maintainers of secondary ***Stacked PRs***, and ***Break-glass*** CI & Critical changes
- Added instructions on how to use GitHub Stacks `gh stack` with examples using the conventions of `stacked/` prefix for branch names
- Updated repository settings to enable the use of GitHub Stacked PRs
  - In "Settings / Pull Requests" - enabled `Allow merge commits` and  `Allow rebase merging`
  - In "Branches" and `dev` branch protection - removed `Require linear history`
  
## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
- [GitHub Stacked PRs Announcement](https://github.blog/changelog/2026-07-30-stacked-pull-requests-are-now-in-public-preview/)