### PR TITLE
docs: add stack management and merging guides

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -42,13 +42,13 @@ in a clone that's been set up this way, `origin` no longer points at your fork. 
 remote -v` before pushing rather than assuming `origin` = your fork; a self-contained PR from
 such a clone needs to push to the renamed fork remote instead.
 
-**Merging a stack** happens all at once, not PR by PR: either the web UI's "Enqueue stack" button
-on the top-most PR, or `gh stack merge`. Both respect this repo's merge queue. Don't merge stack
-PRs individually with `gh pr merge` even if asked, and don't pass `--yes` to `gh stack merge`
-without asking first, since it merges multiple PRs at once and both humans and agents should
-confirm before that happens. If a layer ends up merged out of order anyway, run `gh stack sync
---prune` to fix it. See `CONTRIBUTING.md`'s "Merging a stack" section for the full verification
-steps.
+**Merging a stack**: never use "Enqueue stack" (Web UI) or `gh stack merge` (CLI). Tested against
+this repo's actual merge queue settings and confirmed neither reliably walks a whole stack
+through; the bottom PR merges, then the rest stalls with a stale base and nothing continues
+automatically. Always merge bottom-up instead: `gh stack bottom` to find the bottom PR, confirm
+it's approved and passing, `gh pr merge <number> --auto` to merge just that one PR (ask before
+running this, since it's a real merge), then `gh stack sync --prune` once it lands, then repeat
+for the next layer. See `CONTRIBUTING.md`'s "Merging a stack" section for the full steps.
 
 ## Build & test
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,42 +13,10 @@ of the three approved paths applies — most work is **Self-contained** (push to
 not `origin`); dependent changes use **Stacked PRs**; CI/critical changes that need same-repo
 write permissions are the third, narrower exception.
 
-### Choosing self-contained vs. Stacked
-
-Decide this before starting work, not partway through — it's possible to split already-started
-work into a stack later, but retrofitting costs more than planning it upfront. Default to
-self-contained. Choose a stack only when reviewability is genuinely better served by splitting
-into ordered layers: each layer should stand on its own as something a reviewer can fully
-understand and approve without reading ahead, even though later layers depend on earlier ones
-merging first. Size alone isn't a reason to stack — a large self-contained PR is still
-self-contained if it can be reviewed as one coherent unit. If unsure, ask the user before deciding
-to stack: the setup has real, sticky side effects (see "Remote gotcha" below) and requires
-maintainer push access (check `MAINTAINERS.md`), so it isn't something to default into
-unilaterally. If a stack is chosen, aim for every layer to be reviewable on its own merits, not
-just the stack as a whole. If a stack turns out to be the wrong call after starting, `gh stack
-unstack` converts the PRs back to self-contained targeting `dev`; see `CONTRIBUTING.md`'s
-"Managing a stack" section.
-
-### Stacked PR tips
-
-Use `stacked/`-prefixed branches with the `gh-stack` CLI extension (`gh stack add`,
-`gh stack submit`) instead of a single branch off `dev`, and push `stacked/` branches to `origin`
-— see `CONTRIBUTING.md`'s "Stacked PRs" section for the full convention (requires push access to
-`sirius-db/sirius`).
-
-**Remote gotcha**: setting up for Stacked PRs (per `CONTRIBUTING.md`) involves renaming a fork
-clone's `origin` remote to the main `sirius-db/sirius` repo — that change is local and sticky, so
-in a clone that's been set up this way, `origin` no longer points at your fork. Always run `git
-remote -v` before pushing rather than assuming `origin` = your fork; a self-contained PR from
-such a clone needs to push to the renamed fork remote instead.
-
-**Merging a stack**: never use "Enqueue stack" (Web UI) or `gh stack merge` (CLI). Tested against
-this repo's actual merge queue settings and confirmed neither reliably walks a whole stack
-through; the bottom PR merges, then the rest stalls with a stale base and nothing continues
-automatically. Always merge bottom-up instead: `gh stack bottom` to find the bottom PR, confirm
-it's approved and passing, `gh pr merge <number> --auto` to merge just that one PR (ask before
-running this, since it's a real merge), then `gh stack sync --prune` once it lands, then repeat
-for the next layer. See `CONTRIBUTING.md`'s "Merging a stack" section for the full steps.
+**Doing a chain of dependent changes (Stacked PRs)?** Read `CONTRIBUTING.md`'s "Stacked PRs" and
+"Merging a stack" sections first. One thing worth knowing without opening that doc: never use
+"Enqueue stack" or `gh stack merge`, they don't reliably work with this repo's merge queue;
+stacks merge bottom-up instead.
 
 ## Build & test
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,7 +5,40 @@ operations to the GPU (via cuDF/RMM/cuCascade) and falling back to DuckDB's CPU 
 otherwise. Once the extension is loaded it **transparently intercepts** normal SQL and runs it
 on the GPU — no special syntax needed.
 
+## Contributions & PRs
+
 **The default/main branch is `dev`** (not `main`/`master`) — branch and open PRs against it.
+Before opening a PR, read `CONTRIBUTING.md`'s "PR branching strategy" section to determine which
+of the three approved paths applies — most work is **Self-contained** (push to a personal fork,
+not `origin`); dependent changes use **Stacked PRs**; CI/critical changes that need same-repo
+write permissions are the third, narrower exception.
+
+### Choosing self-contained vs. Stacked
+
+Decide this before starting work, not partway through — it's possible to split already-started
+work into a stack later, but retrofitting costs more than planning it upfront. Default to
+self-contained. Choose a stack only when reviewability is genuinely better served by splitting
+into ordered layers: each layer should stand on its own as something a reviewer can fully
+understand and approve without reading ahead, even though later layers depend on earlier ones
+merging first. Size alone isn't a reason to stack — a large self-contained PR is still
+self-contained if it can be reviewed as one coherent unit. If unsure, ask the user before deciding
+to stack: the setup has real, sticky side effects (see "Remote gotcha" below) and requires
+maintainer push access (check `MAINTAINERS.md`), so it isn't something to default into
+unilaterally. If a stack is chosen, aim for every layer to be reviewable on its own merits, not
+just the stack as a whole.
+
+### Stacked PR tips
+
+Use `stacked/`-prefixed branches with the `gh-stack` CLI extension (`gh stack add`,
+`gh stack submit`) instead of a single branch off `dev`, and push `stacked/` branches to `origin`
+— see `CONTRIBUTING.md`'s "Stacked PRs" section for the full convention (requires push access to
+`sirius-db/sirius`).
+
+**Remote gotcha**: setting up for Stacked PRs (per `CONTRIBUTING.md`) involves renaming a fork
+clone's `origin` remote to the main `sirius-db/sirius` repo — that change is local and sticky, so
+in a clone that's been set up this way, `origin` no longer points at your fork. Always run `git
+remote -v` before pushing rather than assuming `origin` = your fork; a self-contained PR from
+such a clone needs to push to the renamed fork remote instead.
 
 ## Build & test
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -25,7 +25,9 @@ self-contained if it can be reviewed as one coherent unit. If unsure, ask the us
 to stack: the setup has real, sticky side effects (see "Remote gotcha" below) and requires
 maintainer push access (check `MAINTAINERS.md`), so it isn't something to default into
 unilaterally. If a stack is chosen, aim for every layer to be reviewable on its own merits, not
-just the stack as a whole.
+just the stack as a whole. If a stack turns out to be the wrong call after starting, `gh stack
+unstack` converts the PRs back to self-contained targeting `dev`; see `CONTRIBUTING.md`'s
+"Managing a stack" section.
 
 ### Stacked PR tips
 
@@ -39,6 +41,14 @@ clone's `origin` remote to the main `sirius-db/sirius` repo — that change is l
 in a clone that's been set up this way, `origin` no longer points at your fork. Always run `git
 remote -v` before pushing rather than assuming `origin` = your fork; a self-contained PR from
 such a clone needs to push to the renamed fork remote instead.
+
+**Merging a stack** happens all at once, not PR by PR: either the web UI's "Enqueue stack" button
+on the top-most PR, or `gh stack merge`. Both respect this repo's merge queue. Don't merge stack
+PRs individually with `gh pr merge` even if asked, and don't pass `--yes` to `gh stack merge`
+without asking first, since it merges multiple PRs at once and both humans and agents should
+confirm before that happens. If a layer ends up merged out of order anyway, run `gh stack sync
+--prune` to fix it. See `CONTRIBUTING.md`'s "Merging a stack" section for the full verification
+steps.
 
 ## Build & test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,31 +200,41 @@ self-contained PRs targeting `dev`.
 
 #### Merging a stack
 
-**Merging as a stack (recommended)**
+**Note:** each PR's page always shows "wants to merge into `<branch>`" pointing at the layer
+directly below it; that's just its git base for diffing, not the actual merge order. Merges
+always land bottom-up regardless of what that header displays.
 
-By design stacked PRs are merged as a stack, once every PR passes required checks and has
-reviewer approval. You can merge the whole stack at once with either method:
-- **Web UI**: the top-most PR's page shows an **"Enqueue stack"** button with a count of the PRs
-  still open in the stack. It stays disabled (showing "Unable to merge as a stack") until every
-  open PR in the stack passes required checks and has reviewer approval.
-- **CLI**: `gh stack merge` only checks that each PR is open and not a draft locally; branch
-  protection and repository rules are still evaluated by GitHub when the merge runs.
+:warning: **Do not use "Enqueue stack" (Web UI) or `gh stack merge` (CLI).** We tested both
+against this repo's actual merge queue settings (1 PR built and merged at a time) and confirmed
+they do not reliably merge the whole stack through. This is a tested limitation of GitHub's
+support for merge queues using squash commits. Until this is fixed, we can use the following
+bottom-up merging method in this repo.
 
-Both methods respect this repo's merge queue: the stack is added to the queue and merges once
-it's processed, rather than merging directly.
+**Merging bottom-up**
 
-**Merging from the bottom**
+Steps 1-4 and 7 only need GitHub, so any maintainer with merge permission can do them, not just
+the stack's author. Steps 5-6 need the stack's actual local checkout (where `gh-stack` tracks the
+stack), so only whoever has that clone, normally the author, can do them. If you're merging
+someone else's stack, do steps 1-4, then ping the author to run steps 5-6 before you continue.
 
-Sometimes, it may be necessary to merge the bottom layer(s) of a stack instead of the entire
-stack at once. While this is not the recommended flow, there is support for this. Starting with
-the bottom PR, merge the PR using the "Enqueue pull request" button. Once the PR has cleared the
-merge queue and is merged, run `gh stack sync --prune` to rebase the remaining branches onto the
-updated `dev` and clean up local branches for the merged PR. Confirm it worked via `gh stack view`:
-the merged layer should show a ✓ under a `╌╌╌ merged ╌╌╌` marker, and the remaining branches
-shouldn't show a `⚠` warning icon. If they still do, repeat the sync.
+1. Open the bottom-most unmerged PR of the stack (the stack
+   panel on any PR in it, click the `N/M` badge next to the PR title, shows the whole stack in
+   order).
+2. Confirm it's approved and its required checks have passed.
+3. Click **"Enqueue pull request"** on that PR's own page to
+   merge just that one PR. Do not click "Enqueue stack" (this is only on the top-most layer of
+   the stack) and don't use `gh stack merge`.
+4. Wait for it to clear the merge queue and merge to `dev`.
+5. **(Stack author)** Run `gh stack sync --prune` to rebase the
+   remaining branches onto the updated `dev` and clean up local branches for the merged PR.
+6. **(Stack author)** Confirm it worked via `gh stack view`: the
+   merged layer should show a ✓ under a `╌╌╌ merged ╌╌╌` marker, and the remaining branches
+   shouldn't show a `⚠` warning icon. If they still do, repeat step 5.
+7. Back in the web UI, open the new bottom-most unmerged PR
+   and repeat from step 2, until the whole stack is merged.
 
-Once the sync has taken effect, the new bottom of the stack will target `dev` while the top of
-the stack will be able to merge as a whole stack minus the merged PR.
+Our goal is to automate this process in the future; however, this is the current merge method
+that works with our repo's merge queue settings.
 
 ### Commit and title convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,10 @@ gh extension install github/gh-stack
 - `stacked/`-prefixed branches may be pushed directly to `origin` (this repo)
   - If you are working on a local copy that is your fork, you will need to ensure `origin` points
     to this repo and not your fork.
+  - This is a workaround for [gh-stack#381](https://github.com/github/gh-stack/issues/381), where
+    `gh stack`'s `--remote` flag doesn't actually control which repo it operates against, only
+    `origin` does. Once that's fixed upstream, this remote-renaming step should no longer be
+    necessary.
   - Run the following command replacing `$USER` with your name; otherwise it will use your local username:
       ```bash
       # Rename current origin to local user's name and set origin to main Sirius repo
@@ -158,6 +162,69 @@ gh stack add stacked/<branch>                           # add a branch on top of
 gh stack submit                                         # push all branches and create/update PRs
 gh stack sync                                           # rebase and sync the stack with GitHub
 ```
+
+#### Navigating a stack
+
+Move between layers without typing branch names:
+
+```bash
+gh stack top       # check out the top branch (furthest from dev)
+gh stack bottom    # check out the bottom branch (closest to dev)
+gh stack up        # check out one branch up (further from dev)
+gh stack down      # check out one branch down (closer to dev)
+gh stack trunk     # check out dev
+gh stack switch    # interactively pick a branch in the stack
+```
+
+`gh stack checkout <stack-number|PR-number|PR-URL|branch>` resumes a stack you don't currently
+have checked out, for example one someone else started or one you left a while ago.
+
+`gh stack modify` opens an interactive editor to reorder, insert, drop, or fold branches in a
+stack, useful if a stack's layering needs to change after the fact.
+
+#### Managing a stack
+
+**Adding layers to a stack**
+
+`gh stack` CLI can manage the stack, adding layers as needed with `gh stack add stacked/<branch>`.
+This can also be done in the Web UI by clicking on the stack icon (next to the PR status button,
+in the top left of the PR page). There you can see the full stack of PRs, and an option to add
+to the stack.
+
+**Unstacking PRs**
+
+Sometimes it may be necessary to unstack PRs. This can be done in the CLI with
+`gh stack unstack` or in the Web UI clicking on the stack icon and selecting the stack icon with
+an "x" labeled "Unstack pull requests." Both methods remove the stack and convert the PRs to
+self-contained PRs targeting `dev`.
+
+#### Merging a stack
+
+**Merging as a stack (recommended)**
+
+By design stacked PRs are merged as a stack, once every PR passes required checks and has
+reviewer approval. You can merge the whole stack at once with either method:
+- **Web UI**: the top-most PR's page shows an **"Enqueue stack"** button with a count of the PRs
+  still open in the stack. It stays disabled (showing "Unable to merge as a stack") until every
+  open PR in the stack passes required checks and has reviewer approval.
+- **CLI**: `gh stack merge` only checks that each PR is open and not a draft locally; branch
+  protection and repository rules are still evaluated by GitHub when the merge runs.
+
+Both methods respect this repo's merge queue: the stack is added to the queue and merges once
+it's processed, rather than merging directly.
+
+**Merging from the bottom**
+
+Sometimes, it may be necessary to merge the bottom layer(s) of a stack instead of the entire
+stack at once. While this is not the recommended flow, there is support for this. Starting with
+the bottom PR, merge the PR using the "Enqueue pull request" button. Once the PR has cleared the
+merge queue and is merged, run `gh stack sync --prune` to rebase the remaining branches onto the
+updated `dev` and clean up local branches for the merged PR. Confirm it worked via `gh stack view`:
+the merged layer should show a ✓ under a `╌╌╌ merged ╌╌╌` marker, and the remaining branches
+shouldn't show a `⚠` warning icon. If they still do, repeat the sync.
+
+Once the sync has taken effect, the new bottom of the stack will target `dev` while the top of
+the stack will be able to merge as a whole stack minus the merged PR.
 
 ### Commit and title convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,6 +191,30 @@ This can also be done in the Web UI by clicking on the stack icon (next to the P
 in the top left of the PR page). There you can see the full stack of PRs, and an option to add
 to the stack.
 
+**Collaborating with existing stacks**
+
+Any Maintainer can use `gh stack checkout <PR-number>` to check out an existing stack to contribute
+code or to manage the stack during the "bottom-up" merge process.
+
+**Managing conflicts**
+
+During active development of the stack, always use `gh stack rebase` to manage conflicts with `dev`
+or between your stacked layers. If you have submitted your stack, run `gh stack submit` to push
+these changes to the repo and open PRs.
+
+Conflicts can also occur while merging "bottom-up" as described below. The two-step process above
+can be shortened to `gh stack sync --prune` during merging to handle the merge conflicts between
+the stack layers as they are merged.
+
+**Rebase stack notifications**
+
+GitHub's support for stacked PRs includes a "Rebase stack" option in the Web UI when the target base
+(usually `dev`) has moved forward; it is not recommended to use this method.
+
+**NOTE:** CI and the merge queue both test the combined merge commit of the PR and the latest
+`dev` before merging. Rebasing is not necessary unless there is a conflict. If you have a conflict,
+follow the instructions in **Managing conflicts**.
+
 **Unstacking PRs**
 
 Sometimes it may be necessary to unstack PRs. This can be done in the CLI with
@@ -212,26 +236,28 @@ bottom-up merging method in this repo.
 
 **Merging bottom-up**
 
-Steps 1-4 and 7 only need GitHub, so any maintainer with merge permission can do them, not just
-the stack's author. Steps 5-6 need the stack's actual local checkout (where `gh-stack` tracks the
-stack), so only whoever has that clone, normally the author, can do them. If you're merging
-someone else's stack, do steps 1-4, then ping the author to run steps 5-6 before you continue.
+Steps 1-4 and 7 only need GitHub Web UI, so any maintainer with merge permission can do them,
+not just the stack's author. Steps 5-6 need a local checkout with the stack tracked to manage
+(see **Managing a stack** above).
 
-1. Open the bottom-most unmerged PR of the stack (the stack
-   panel on any PR in it, click the `N/M` badge next to the PR title, shows the whole stack in
-   order).
-2. Confirm it's approved and its required checks have passed.
-3. Click **"Enqueue pull request"** on that PR's own page to
+1. ***Web UI*** - Open the bottom-most unmerged PR of the stack (the stack panel on any PR in it,
+   click the `N/M` badge next to the PR title, shows the whole stack in order).
+2. ***Web UI*** - Confirm it's approved and its required checks have passed.
+3. ***Web UI*** - Click **"Enqueue pull request"** on that PR's own page to
    merge just that one PR. Do not click "Enqueue stack" (this is only on the top-most layer of
    the stack) and don't use `gh stack merge`.
-4. Wait for it to clear the merge queue and merge to `dev`.
-5. **(Stack author)** Run `gh stack sync --prune` to rebase the
-   remaining branches onto the updated `dev` and clean up local branches for the merged PR.
-6. **(Stack author)** Confirm it worked via `gh stack view`: the
-   merged layer should show a ✓ under a `╌╌╌ merged ╌╌╌` marker, and the remaining branches
-   shouldn't show a `⚠` warning icon. If they still do, repeat step 5.
-7. Back in the web UI, open the new bottom-most unmerged PR
-   and repeat from step 2, until the whole stack is merged.
+4. ***Web UI*** - Wait for it to clear the merge queue and merge to `dev`. GitHub automatically
+   retargets the next layer's base to `dev` once the branch it was targeting is deleted; no
+   manual action is needed for the retargeting.
+5. ***GH CLI*** - If the next layer's PR now shows "This branch has conflicts that must be
+   resolved" / "Unable to merge", run `gh stack sync --prune` to rebase the remaining branches
+   onto the updated `dev` and clean up local branches for the merged PR. Always resolve stack
+   conflicts via the CLI.
+6. ***GH CLI*** - Confirm it worked via `gh stack view`: the merged layer should show a `✓` under
+   a `╌╌╌ merged ╌╌╌` marker, and the remaining branches shouldn't show a `⚠` warning icon. If
+   they still do, repeat **step 5**.
+7. ***Web UI*** - Open the new bottom-most unmerged PR and repeat from **step 2**, until the whole
+   stack is merged.
 
 Our goal is to automate this process in the future; however, this is the current merge method
 that works with our repo's merge queue settings.


### PR DESCRIPTION
## Description
With Stacked PRs from #1662, we need to also update the `CLAUDE.md` so agents have a reference for the contribution methods for this repo, the requirements (Maintainer for Stacked) and a decision guide to assist agents during feature discussion. This also highlights a potential gotcha for the agent to navigate with `origin` potentially referring to the fork rather than the upstream repo.

Purposefully merging #1662 out of order allowed me to create guidelines for both managing and merging stacked PRs for this repository. In addition, testing in another repo configured with the same merge queue settings and squash commits showed a limitation: "Enqueue stack" and `gh stack merge` don't reliably merge an entire stack under this repo's actual settings. However, there is a manual workaround of merging from the bottom-up that I have documented to allow us to use stacked PRs in this repo now, with an ultimate goal to automate the manual work in the future. Changes in both `CONTRIBUTING.md` and `CLAUDE.md` cover these scenarios.

## Changes
**For agents (`CLAUDE.md`)**
- Added decision guide for Stacked PRs and tips for remote gotchas with renaming `origin`
- Summarized the branching strategy for agents
- Added guidance on merging a stack via CLI, including when to ask before merging multiple PRs
- Documented that "Enqueue stack" / `gh stack merge` don't reliably work under this repo's merge queue settings (tested directly), and added a required bottom-up merge procedure instead

**For contributors (`CONTRIBUTING.md`)**
- Added guides for managing (adding/navigating/unstacking) and merging stacked PRs, by CLI and Web UI
- Documented the `origin`-rename step as a workaround for gh-stack#381, with a link, rather than an unexplained requirement
- Documented that "Enqueue stack" / `gh stack merge` don't reliably work under this repo's merge queue settings (tested directly), and added a required, step-by-step bottom-up merge procedure instead

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
Refs #1662