### PR TITLE
docs(reviewability): establish PR reviewability for contributing

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -18,6 +18,11 @@ write permissions are the third, narrower exception.
 "Enqueue stack" or `gh stack merge`, they don't reliably work with this repo's merge queue;
 stacks merge bottom-up instead.
 
+Before marking **any** PR ready for review (self-contained or stacked), check it against
+`CONTRIBUTING.md`'s "PR reviewability" checklist. Open as a Draft until it meets that bar, then
+convert to "Ready for review"; converting too early pings a reviewer before there's anything to
+review, which is the exact problem that checklist exists to prevent.
+
 ## Build & test
 
 Run commands through `pixi run <cmd>` (don't drop into the interactive `pixi shell`) so each

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,11 @@
-<!-- Edit PR title: "<type>[optional scope]: <short description>", see CONTRIBUTING.md for guidance -->
+<!-- NOTE: All PRs should be opened as "Draft" until they meet PR "reviewability" and marked "Ready for review" -->
 
 ## Description
 <!-- Provide a standalone description of changes in this PR -->
 <!-- For design docs targeting docs/experimental, note this in the description -->
 
 ## Checklist
-- [ ] Read CONTRIBUTING.md
+- [ ] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
 - [ ] Cover changes with new or existing tests
 - [ ] Document configuration changes in code and summarize in the description above
 - [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,6 +262,25 @@ not just the stack's author. Steps 5-6 need a local checkout with the stack trac
 Our goal is to automate this process in the future; however, this is the current merge method
 that works with our repo's merge queue settings.
 
+### PR reviewability
+
+PRs sometimes stall for weeks after a reviewer is assigned, simply because the PR wasn't actually
+ready to review the moment CODEOWNERS pinged someone. Before marking a PR ready for review, please
+do the following:
+
+1. **State the motivation, not just the mechanics.** Link the originating issue (`Closes #NNN` /
+   `Refs #NNN`) if one exists; if there isn't one, the description itself should explain *why* the
+   change is needed, not just summarize the diff.
+2. **Scope the PR to one reviewable sitting.** If a reviewer can't get through it start-to-finish
+   without losing context, either split it (see [Stacked PRs](#stacked-prs)) or explicitly justify
+   in the description why it can't be split.
+3. **Make the description self-sufficient.** A reviewer should be able to start reviewing without
+   needing to ask what changed or why — cover what changed, why, how it was verified, and anything
+   non-obvious (e.g. "intentionally doesn't handle X, tracked in #NNN").
+4. **Open as a draft until 1-3 are actually true**, then convert to "Ready for review" — that's
+   the point CODEOWNERS review requests and author auto-assignment (`auto-assign.yml`) trigger, so
+   converting early means a reviewer gets pinged before there's anything reviewable yet.
+
 ### Commit and title convention
 
 Sirius squash-merges PRs, the PR titles become the commit message on merge. Commits and PR titles follow [Conventional Commits](https://www.conventionalcommits.org/) format for readability.


### PR DESCRIPTION
## Description
With the recent changes to the repo, embracing automation of reviews based on `CODEOWNERS` and the growth of contributors to the repo there are some gaps when it comes time for reviewing PRs.

First, reviewers are now automatically assigned the moment a PR is marked 'Ready for review.' For PRs that aren't actually ready, this wastes reviewers' time and causes confusion, leading to delays in getting the PR merged. Second, some PRs that have been marked as 'Ready for review' are incomplete in one of several ways: missing motivation in the description, a PR that has scope that is too large, or a description missing information.

To address these issues, I propose changes to the PR template and the addition of a PR "reviewability" checklist in `CONTRIBUTING.md`. This modifiable checklist is a social contract we have to establish the minimum contents of a PR to ensure that when a reviewer is able to review the PR, they have all the information to do so. 

This proposed checklist is a base-line that we can either update in this PR or over time as the repository grows. I would expect some of these to be still driven by the developer (and potentially their agent), while others we may be able to automate. Until we get there, this is a good place to start.

## Changes
- Seeks to address a common pattern of PRs opened in a non-draft state
  triggering `CODEOWNERS` reviews when the PR is not ready
- Includes "reviewability" checklist as a part of the contributor's
  process in `CONTRIBUTING.md` and the PR template
- Replaces PR title guidance (which is enforced by `validate` CI check)
  in the PR template with instructions to open this PR as a draft first
- Updates `CLAUDE.md` to ensure agents are aware of the "reviewability"
  checklist and when to review it

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
Refs #1367 & #1662 & #1663