### PR TITLE
fix: arm64 nightly build fails

### DIFF
--- a/src/include/late_mat/column_origin.hpp
+++ b/src/include/late_mat/column_origin.hpp
@@ -43,6 +43,8 @@
 // range.start + local, at the consumer's edge —
 // codegen/selection/row_id_space.hpp is where they are narrowed back.
 
+#include <rmm/device_buffer.hpp>
+
 #include <atomic>
 #include <cstdint>
 #include <cstdlib>
@@ -50,10 +52,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-
-namespace rmm {
-class device_buffer;
-}
 
 namespace sirius::scan_manager {
 struct pinned_entry;  // scan_manager/sirius_scan_manager.hpp

--- a/test/cpp/integration/test_late_mat_native_filter.cpp
+++ b/test/cpp/integration/test_late_mat_native_filter.cpp
@@ -28,6 +28,7 @@
 #include <late_mat/defer_policy.hpp>
 #include <utils/gpu_execution_fixture.hpp>
 
+#include <cstdint>
 #include <cstdlib>
 #include <string>
 #include <vector>

--- a/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
@@ -49,6 +49,7 @@
 #include <scan_manager/sirius_scan_manager.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <functional>
 #include <memory>


### PR DESCRIPTION
## Description
This fixes a problem introduced in the late materialization work #1524: we need to include rmm/device_buffer.hpp instead of forward-declaring it. Also adds the <cstdint> that two tests rely on transitively for std::int64_t and friends.

## Checklist
- [x] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References