### PR TITLE
feat: Support late materialization from host-tier batches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,10 +750,12 @@ set(TEST_SOURCES
     test/cpp/late_mat/test_port_materialize.cpp
     test/cpp/integration/test_late_mat_deferred_query.cpp
     test/cpp/integration/test_late_mat_native_filter.cpp
+    test/cpp/integration/test_late_mat_host_query.cpp
     test/cpp/late_mat/test_defer_policy.cpp
     test/cpp/late_mat/test_defer_directive.cpp
     test/cpp/late_mat/test_late_mat_plan_pass.cpp
     test/cpp/late_mat/test_late_mat_resolver.cpp
+    test/cpp/late_mat/test_late_mat_host_pin.cpp
     test/cpp/late_mat/test_pin_handle_lifecycle.cpp
     test/cpp/late_mat/test_pin_uniqueness.cpp
     test/cpp/io/s3/test_sigv4.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,7 @@ set(EXTENSION_SOURCES
     src/planner/late_mat_plan_pass.cpp
     src/scan_manager/late_mat_resolver.cpp
     src/late_mat/multi_source_gather.cu
+    src/late_mat/host_gather_policy.cu
     src/config.cpp
     src/helper/numeric_narrowing.cpp
     src/helper/type_conversions.cpp

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -683,11 +683,11 @@ still an experimental optimization, not a normal session choice.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `SIRIUS_EXP_LATE_MAT` | off | The master gate. Carries a pin-order rowid instead of scanned values for a GPU-tier pinned table, restoring them at the far end. |
+| `SIRIUS_EXP_LATE_MAT` | off | The master gate. Carries a pin-order rowid instead of scanned values for a pinned table (GPU or host tier), restoring them at the far end. |
 | `SIRIUS_EXP_LATE_MAT_PIN_UNIQUE_COLS` | off | Columns the pin-time uniqueness probe observes: `all`, a name list, or `none`. Required for a group-by-rowid ride or a rider to be admissible at all. |
 
-Five further `SIRIUS_EXP_LATE_MAT_*` knobs tune the deferral floors and the count-on-deferred
-path; see [Late Materialization](late-materialization.md#turning-it-on-experimental) for the full
+Six further `SIRIUS_EXP_LATE_MAT_*` knobs tune the deferral floors, the host-tier cost
+correction, and the count-on-deferred path; see [Late Materialization](late-materialization.md#turning-it-on-experimental) for the full
 gate table, the mechanism, and results.
 
 ### Transparent Execution

--- a/docs/super-sirius/late-materialization.md
+++ b/docs/super-sirius/late-materialization.md
@@ -180,7 +180,8 @@ deferral with a single half, admitted only over pinned columns with no nulls. Of
   handful of short strings can clear the floor on the estimate while saving fewer bytes/row than
   the measured value would show). The real fix is measuring the width — the scan already has the
   offsets for it.
-- **A host-tier pin rides only FIXED-WIDTH, uncompressed columns** (see below).
+- **A host-tier pin rides only FIXED-WIDTH, uncompressed columns**; see
+  [Host-tier pins](#host-tier-pins).
 - **A non-pinned scan cannot defer at all.** A fresh parquet or DuckDB-native read consumes its
   decoded batch, so there is nothing for the port to gather from. Deferring against a file would
   mean a rowid addressing a file offset and a re-read per gather — the shape classic disk-based
@@ -211,22 +212,49 @@ representation PER EMITTED BATCH, each carrying every pinned column, where a GPU
 vector per column. The resolver is what bridges the two orientations, and there is no per-column
 merge path on the host side because of it.
 
-**The gather reads the rows where they lie.** The alternative — staging the needed chunk back to
-the device per materialization — was rejected on two counts, one measured and one structural:
+**The gather reads the rows where they lie**, rather than staging the chunk back to the device per
+materialization. Measured on GB300 (Grace-Blackwell, C2C rather than PCIe), a 150M x 8 B pinned
+column stages H2D at 163 GB/s, so a full stage costs 7.4 ms whatever the selection, while a blocked
+zero-copy gather of the same column costs 0.012 ms at 0.01% selectivity, 0.42 ms at 1%, and 5.1 ms
+even when the selection covers every row. Cheaper at every selectivity, and it allocates only its
+output rather than putting the whole column back in device memory, which is what pinning on the
+host was avoiding.
 
-- *Measured.* On GB300 (Grace-Blackwell, C2C rather than PCIe), a 150M x 8 B pinned column stages
-  H2D at 163 GB/s, so a full stage costs 7.4 ms whatever the selection. A blocked zero-copy gather
-  of the same column costs 0.012 ms at 0.01% selectivity, 0.42 ms at 1%, and 5.1 ms even when the
-  selection covers every row — cheaper than staging at EVERY selectivity, and by two to three
-  orders of magnitude for the sparse ones a ride actually produces.
-- *Structural.* Staging puts the whole column in device memory, which is exactly what pinning on
-  the host was avoiding. The in-place gather allocates only its output.
+**The deferred columns are never served.** A pinned scan carrying a deferral withholds them: the
+provider drops their entry positions from what it projects, so a HOST-tier chunk never stages them
+across the link and a GPU-tier chunk never copies them. The batch then arrives NARROWER than the
+scan's arity, which two things downstream absorb — `assemble_scan_output` renumbers the output
+layout past the missing columns (`renumber_output_for_withheld`), and `substitute_deferred_columns`
+INSERTS the rowid and its placeholders at their positions instead of overwriting values that are
+there. Withholding and the older elision are alternatives, never both: elision drops columns the
+batch DID carry, and paid to read them.
+
+Measured, 500k customers x 40 deferred BIGINTs over two joins and two group-by stages, host pin:
+
+| | H2D bytes | of which the pinned scan | GPU kernel time |
+|---|---|---|---|
+| Gate off | 196.231 MB | 55.983 + 22.0 + 4.0 MB | 27.6 ms |
+| Gate on, serving the deferred columns | 196.259 MB | 55.983 + 22.0 + 4.0 MB | 33.0 ms |
+| Gate on, withholding them | **116.259 MB** | **2.0 MB** | 33.5 ms |
+
+The middle row is what the ride cost before withholding existed: per-copy sizes identical to gate
+off, not merely the totals, so the payload crossed in full whether or not it rode. The last row
+lands on the 116.228 MB a control that projects only the key measures, which is what identifies
+the bytes that disappeared as exactly the deferred payload.
+
+**Withholding is refused rather than guessed at.** It requires a parquet plan (the duckdb-native
+reader has no output layout to renumber), no row filter (a post-decode filter evaluates over the
+reader's D-order batch, so a missing column shifts every filter reference past it, and a deferred
+column can itself be a filter column), no partition columns (synthesized rather than read, so
+nothing could have withheld one), and at least one column left over. Where any of those fails the
+scan serves the columns and elides them from the projection, exactly as before.
 
 Against a device gather the same column costs 2.0x, 8.1x, 10.6x, 12.2x, 11.0x and 6.6x at those
 selectivities. That worst case is `SIRIUS_EXP_LATE_MAT_HOST_COST_MULTIPLIER`: the value x crossings
 floor is calibrated against a device gather, and both the floor and the gather scale with the same
 row count, so a host-tier bundle is weighed against `128 x 12` instead of `128`. It bounds one
-operation rather than calibrating a query, which is why it is a knob.
+operation rather than calibrating a query, which is why it is a knob. It does NOT price the
+scan-time staging above, which no floor currently accounts for.
 
 **How a chunk-major host chunk becomes a column-major view.** A host chunk's storage is a list of
 equally sized pinned blocks that are NOT contiguous with one another, so a column's buffer has no

--- a/docs/super-sirius/late-materialization.md
+++ b/docs/super-sirius/late-materialization.md
@@ -7,8 +7,10 @@ what is IN them.
 
 Late materialization replaces those columns at the scan with a pin-order **rowid**, carries that
 instead, and puts the values back at the far end by gathering them out of the pinned table. It
-works only for a **GPU-tier pinned** table — the values have to still exist somewhere
-addressable when the far end asks for them, and that is what the pin guarantees.
+works only for a **pinned** table — the values have to still exist somewhere addressable when the
+far end asks for them, and that is what the pin guarantees. A GPU-tier pin is gathered out of
+device memory; a HOST-tier pin is gathered out of pinned host memory in place, over unified
+virtual addressing, with nothing staged back to the device (see [Host-tier pins](#host-tier-pins)).
 
 ## Turning it on (experimental)
 
@@ -41,6 +43,7 @@ using `all`; without a proof there is no group-by-rowid ride and no riders.
 | `SIRIUS_EXP_LATE_MAT_MIN_VALUE_X_BOUNDARIES` | 128 | Net bytes/row TIMES crossings saved — value and crossings trade off, so this is the floor that matters. |
 | `SIRIUS_EXP_LATE_MAT_COUNT_DEFER` | off | Count-on-deferred (below). |
 | `SIRIUS_EXP_LATE_MAT_MIN_VALUE_COMPRESSED` | = the ordinary floor | Separate floor for compressed origins. Inert until the decode-skip exists to measure. |
+| `SIRIUS_EXP_LATE_MAT_HOST_COST_MULTIPLIER` | 12 | What the value x crossings floor is multiplied by for a HOST-tier pin. |
 
 ## What a deferral is
 
@@ -177,10 +180,7 @@ deferral with a single half, admitted only over pinned columns with no nulls. Of
   handful of short strings can clear the floor on the estimate while saving fewer bytes/row than
   the measured value would show). The real fix is measuring the width — the scan already has the
   offsets for it.
-- **Host-tier pins are refused**, not just unpinned scans: `install_late_materialization`
-  declines on tier, and `resolve_pinned_layout`/`resolve_pinned_column` refuse independently at
-  the far end. Supporting them would mean staging a chunk back to the device per gather, so the
-  ride would have to repay a host round trip rather than a device read.
+- **A host-tier pin rides only FIXED-WIDTH, uncompressed columns** (see below).
 - **A non-pinned scan cannot defer at all.** A fresh parquet or DuckDB-native read consumes its
   decoded batch, so there is nothing for the port to gather from. Deferring against a file would
   mean a rowid addressing a file offset and a re-read per gather — the shape classic disk-based
@@ -204,6 +204,62 @@ deferral with a single half, admitted only over pinned columns with no nulls. Of
   whenever more than one GPU memory space is active, matching the memory prefetcher's own
   single-GPU prototype scope.
 
+## Host-tier pins
+
+A host-tier pin stores its data the other way round from a GPU one: `entry.host_chunks` holds one
+representation PER EMITTED BATCH, each carrying every pinned column, where a GPU pin holds a chunk
+vector per column. The resolver is what bridges the two orientations, and there is no per-column
+merge path on the host side because of it.
+
+**The gather reads the rows where they lie.** The alternative — staging the needed chunk back to
+the device per materialization — was rejected on two counts, one measured and one structural:
+
+- *Measured.* On GB300 (Grace-Blackwell, C2C rather than PCIe), a 150M x 8 B pinned column stages
+  H2D at 163 GB/s, so a full stage costs 7.4 ms whatever the selection. A blocked zero-copy gather
+  of the same column costs 0.012 ms at 0.01% selectivity, 0.42 ms at 1%, and 5.1 ms even when the
+  selection covers every row — cheaper than staging at EVERY selectivity, and by two to three
+  orders of magnitude for the sparse ones a ride actually produces.
+- *Structural.* Staging puts the whole column in device memory, which is exactly what pinning on
+  the host was avoiding. The in-place gather allocates only its output.
+
+Against a device gather the same column costs 2.0x, 8.1x, 10.6x, 12.2x, 11.0x and 6.6x at those
+selectivities. That worst case is `SIRIUS_EXP_LATE_MAT_HOST_COST_MULTIPLIER`: the value x crossings
+floor is calibrated against a device gather, and both the floor and the gather scale with the same
+row count, so a host-tier bundle is weighed against `128 x 12` instead of `128`. It bounds one
+operation rather than calibrating a query, which is why it is a knob.
+
+**How a chunk-major host chunk becomes a column-major view.** A host chunk's storage is a list of
+equally sized pinned blocks that are NOT contiguous with one another, so a column's buffer has no
+single base pointer and cannot be described by a `cudf::column_view` at all. What it does have is a
+byte offset into the logical concatenation of those blocks (`cucascade::memory::column_metadata`),
+and `batch_source::host` carries exactly that: the block pointers, the block size, and the data and
+null-mask offsets. `multi_source_gather_fixed_host` turns a global rowid into a batch, a row, a byte
+offset, a block index and an offset within it — one divide on top of the batch search the GPU-tier
+gather already does. Validity comes along one mask word at a time, in the same coordinates.
+
+The block pointers are used as device addresses directly. That is legitimate only where the device
+reports both `cudaDevAttrUnifiedAddressing` and `cudaDevAttrCanUseHostPointerForRegisteredMem`; the
+resolver asks once and refuses host-tier deferral outright when either is false, rather than
+translating or staging.
+
+**What a host-tier pin refuses**, beyond every refusal the GPU tier makes:
+
+- **A variable-width or nested column.** There is no element width to multiply a row by, and its
+  offsets would have to be rebuilt against buffers that are not contiguous. Refused per COLUMN, not
+  per pin: the fixed-width columns of the same chunks stay eligible.
+- **A compressed host chunk** (`compressed_host_representation`). A Simpatico blob has no
+  addressable per-row layout to read in place, and its per-column nullability is opaque besides —
+  the same reason a compressed GPU chunk is refused.
+- **A translation that does not land on a boundary.** The block size must divide by the element
+  width, the data offset must start on an element, and the mask offset must be word-aligned. A pin
+  that fails any of these is refused rather than read crookedly.
+- **A filtered scan**, which was already refused for host pins and stays refused.
+
+`install_late_materialization` and the rider pass check exactly what `resolve_pinned_column` checks,
+for the same reason the nullability gate does: by the time a port resolves an origin the scan has
+already emitted rowids in place of the values, so a refusal there is a thrown query rather than a
+slower one.
+
 ## Results
 
 GB300, TPC-H SF1000, unpatched libcudf, GPU-pinned, `SIRIUS_EXP_FUSED_SCAN_FILTER=1` held on in
@@ -226,3 +282,4 @@ q10; no other query moves outside noise.
 | Pin-time distinctness proof | `src/late_mat/pin_uniqueness.cpp` |
 | Putting the values back | `src/late_mat/port_materialize.cpp`, `materialize.cpp` |
 | Reading a pinned entry the way the materializer needs it | `src/scan_manager/late_mat_resolver.cpp` |
+| Gathering by global rowid, device and host tiers | `src/late_mat/multi_source_gather.cu` |

--- a/docs/super-sirius/late-materialization.md
+++ b/docs/super-sirius/late-materialization.md
@@ -32,7 +32,10 @@ every refusal says which refusal it was — a deferral that silently did not hap
 like one that did nothing.
 
 The uniqueness probe costs pin-time work, so name the columns a ride actually needs rather than
-using `all`; without a proof there is no group-by-rowid ride and no riders.
+using `all`; without a proof there is no group-by-rowid ride and no riders. On TPC-H SF1000 that
+cost is the ONLY difference `all` makes (see Results): it proves eight more columns distinct and
+not one of them changes an admission, so the choice between `all` and the narrow list is a pin-time
+question, not a query-time one.
 
 | Variable | Default | Effect |
 |---|---|---|
@@ -94,7 +97,9 @@ end a ride early.
 Two things then decide whether the ride is taken:
 
 - **It has to repay.** Value per row and crossings saved TRADE OFF — a thin ride over many
-  crossings can pay where a fat one over few does not — so what is weighed is their product.
+  crossings can pay where a fat one over few does not — so what is weighed is their product. What
+  the ride saves is the values less the CARRIER: the rowid plus a 1-byte placeholder for every
+  column past the first, so an n-column bundle costs `rowid + (n - 1)` bytes per row to carry.
 - **It must not sit above a fan-out.** A join emits one scan row once per match, so a port above
   one gathers a row set larger than the scan produced. The walk tracks whether a join below a
   column multiplied the rows and whether a reduction has undone it, and a port that is still
@@ -298,6 +303,28 @@ q10; no other query moves outside noise.
 |---|---|---|---|
 | Gate off | 7.3911 s | 0.8481 s | 0.4991 s |
 | Gate on | **7.0031 s** | **0.7611 s** | **0.2250 s** |
+
+### `PIN_UNIQUE_COLS`: the narrow list versus `all`
+
+Same machine, ONE build (upstream `dev` at `8c88f2f3`), three arms back to back, best-of-3, 22/22
+results byte-identical across all three:
+
+| `PIN_UNIQUE_COLS` | Suite | q9 | q10 | Pin time, 72 `pin_table` calls |
+|---|---|---|---|---|
+| `none` | 6.6852 s | 0.8523 s | 0.4995 s | 77.6 s |
+| `c_custkey,n_name,n_nationkey` | 6.3065 s | 0.7596 s | 0.2264 s | 77.7 s |
+| `all` | **6.2992 s** | 0.7648 s | 0.2257 s | 91.5 s |
+
+`all` does not regress: no query moves by more than 0.7%, and the per-operator census is
+IDENTICAL between the narrow list and `all` — same installs, same refusals, same byte counts. The
+eight extra columns `all` proves distinct (`c_name`, `c_address`, `p_partkey`, `s_suppkey`,
+`s_name`, `s_address`, `r_name`, `r_regionkey`) do not unlock a single admission, because every
+other candidate is stopped by a floor, the fan-out guard, or the compressed-filtered-scan refusal
+— none of which uniqueness affects. The measured 0.7% spread is the run-to-run noise floor: a
+fourth arm executing an identical plan set moved q9 by the same amount.
+
+What `all` does cost is **+13.8 s of pin time (+17.8%)**, which grouped-mode query timings do not
+include. That is the price of not making the user name columns.
 
 ## Where the code is
 

--- a/src/include/late_mat/defer_policy.hpp
+++ b/src/include/late_mat/defer_policy.hpp
@@ -172,31 +172,6 @@ inline std::int64_t min_value_bytes_compressed(std::int64_t ordinary)
   return value < 0 ? ordinary : value;
 }
 
-/// How much dearer a materialization is when the pin lives on the HOST tier
-/// (SIRIUS_EXP_LATE_MAT_HOST_COST_MULTIPLIER, default 12).
-///
-/// A host-tier ride is gathered out of pinned host blocks over the CPU-GPU link
-/// rather than out of device memory, while the value floor below is calibrated
-/// against a device gather. The floor and the gather scale with the same row
-/// count, so the correction is a plain multiplier on the product floor.
-///
-/// 12 is the worst measured ratio of a blocked host gather to the equivalent
-/// device gather on GB300 (a 150M x 8 B pinned column, random ids, selectivities
-/// from 0.01% to 100%: 2.0x, 8.1x, 10.6x, 12.2x, 11.0x, 6.6x). That bounds ONE
-/// operation rather than calibrating a query, which is why it is a knob.
-inline std::int64_t host_tier_cost_multiplier()
-{
-  static std::int64_t const value = [] {
-    char const* v = std::getenv("SIRIUS_EXP_LATE_MAT_HOST_COST_MULTIPLIER");
-    if (v == nullptr || v[0] == '\0') { return std::int64_t{12}; }
-    std::int64_t parsed = 0;
-    auto const* end     = v + std::strlen(v);
-    auto const rc       = std::from_chars(v, end, parsed);
-    return (rc.ec == std::errc{} && rc.ptr == end && parsed >= 1) ? parsed : std::int64_t{12};
-  }();
-  return value;
-}
-
 /// The thresholds, in one place so a measurement can move them together.
 struct defer_policy {
   /// A ride must save SOMETHING per row after the rowid; whether it repays is

--- a/src/include/late_mat/defer_policy.hpp
+++ b/src/include/late_mat/defer_policy.hpp
@@ -23,8 +23,10 @@
 // far end. That trade is not always good, and the ways it goes bad are
 // measured rather than guessed:
 //
-//  * A NARROW bundle loses. The ride saves (values - rowid) bytes per row per
-//    boundary, but materializing costs a canonicalization on the port side,
+//  * A NARROW bundle loses. The ride saves (values - carrier) bytes per row per
+//    boundary — the carrier being the rowid plus one placeholder for every
+//    column past the first — but materializing costs a canonicalization on the
+//    port side,
 //    which broke even near 60 B/row on the sort path. Dimension columns of
 //    11-25 B were measured COSTING +61 ms on a 800M-row port, while a 154.6 B
 //    bundle and a 50 B pair both won. Hence a floor on deferred value, not a
@@ -73,6 +75,12 @@ enum class defer_refusal : std::uint8_t {
 
 [[nodiscard]] char const* describe(defer_refusal r) noexcept;
 
+/// Per-row width of one placeholder, matching `kPlaceholderType` (INT8) in
+/// `defer_directive.hpp`. A bundle rides as ONE rowid plus one placeholder per
+/// further column, so an n-column bundle costs `rowid_bytes + (n - 1)` per row,
+/// not `rowid_bytes`.
+inline constexpr std::int64_t kPlaceholderBytes = 1;
+
 /// One column a candidate would defer.
 struct defer_column {
   std::uint32_t column_pos = 0;  ///< position within the origin entry
@@ -90,8 +98,12 @@ struct defer_candidate {
   int boundaries = 0;
 
   /// Bytes per row the ride actually saves: the values it stops carrying, less
-  /// the rowid it carries instead.
+  /// what rides in their place.
   [[nodiscard]] std::int64_t net_value_bytes(std::int64_t rowid_bytes) const noexcept;
+
+  /// Bytes per row the substituted columns cost: the rowid at the first
+  /// deferred position plus a placeholder at each of the others.
+  [[nodiscard]] std::int64_t carrier_bytes(std::int64_t rowid_bytes) const noexcept;
 };
 
 /// Port-crossing floor, env-overridable for measurement (default 4). The

--- a/src/include/late_mat/defer_policy.hpp
+++ b/src/include/late_mat/defer_policy.hpp
@@ -160,6 +160,31 @@ inline std::int64_t min_value_bytes_compressed(std::int64_t ordinary)
   return value < 0 ? ordinary : value;
 }
 
+/// How much dearer a materialization is when the pin lives on the HOST tier
+/// (SIRIUS_EXP_LATE_MAT_HOST_COST_MULTIPLIER, default 12).
+///
+/// A host-tier ride is gathered out of pinned host blocks over the CPU-GPU link
+/// rather than out of device memory, while the value floor below is calibrated
+/// against a device gather. The floor and the gather scale with the same row
+/// count, so the correction is a plain multiplier on the product floor.
+///
+/// 12 is the worst measured ratio of a blocked host gather to the equivalent
+/// device gather on GB300 (a 150M x 8 B pinned column, random ids, selectivities
+/// from 0.01% to 100%: 2.0x, 8.1x, 10.6x, 12.2x, 11.0x, 6.6x). That bounds ONE
+/// operation rather than calibrating a query, which is why it is a knob.
+inline std::int64_t host_tier_cost_multiplier()
+{
+  static std::int64_t const value = [] {
+    char const* v = std::getenv("SIRIUS_EXP_LATE_MAT_HOST_COST_MULTIPLIER");
+    if (v == nullptr || v[0] == '\0') { return std::int64_t{12}; }
+    std::int64_t parsed = 0;
+    auto const* end     = v + std::strlen(v);
+    auto const rc       = std::from_chars(v, end, parsed);
+    return (rc.ec == std::errc{} && rc.ptr == end && parsed >= 1) ? parsed : std::int64_t{12};
+  }();
+  return value;
+}
+
 /// The thresholds, in one place so a measurement can move them together.
 struct defer_policy {
   /// A ride must save SOMETHING per row after the rowid; whether it repays is

--- a/src/include/late_mat/host_gather_policy.hpp
+++ b/src/include/late_mat/host_gather_policy.hpp
@@ -75,8 +75,7 @@ struct host_gather_policy {
 /// SIRIUS_EXP_LATE_MAT_HOST_INPLACE_MAX_DENSITY overrides the measured
 /// crossover; setting it to 1 forces in place and 0 forces staging, which is how
 /// a route can be pinned for a measurement or a test.
-[[nodiscard]] bool prefer_inplace_host_gather(std::int64_t selected_rows,
-                                              std::int64_t total_rows);
+[[nodiscard]] bool prefer_inplace_host_gather(std::int64_t selected_rows, std::int64_t total_rows);
 
 /// How many host-tier materializations have taken each route.
 ///

--- a/src/include/late_mat/host_gather_policy.hpp
+++ b/src/include/late_mat/host_gather_policy.hpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Which way to read a HOST-tier pin, decided by measuring this machine's link
+// (env gate: SIRIUS_EXP_LATE_MAT).
+//
+// Two routes produce the same values. IN PLACE reads only the selected rows,
+// scattered, straight out of pinned host memory over unified addressing. STAGING
+// copies the whole chunk to the device in bulk and gathers there. Which one wins
+// depends on how much of the chunk the selection actually wants, and on how badly
+// the link punishes scattered reads relative to a bulk copy:
+//
+//   in-place cost  ~ selected rows,  at the link's SCATTERED bandwidth
+//   staging cost   ~ all rows,       at the link's BULK bandwidth
+//
+// On a coherent CPU-GPU link the two bandwidths are close, so in-place wins at
+// every density and the crossover sits at or above 1.0. On PCIe a scattered read
+// pulls a whole transaction per element, so the crossover falls to a few percent
+// and staging wins for anything denser.
+//
+// THAT RATIO IS NOT INFERABLE FROM THE DEVICE NAME OR FROM BULK BANDWIDTH ALONE.
+// A link can be fast in bulk and still cacheline-granular for scattered reads,
+// which is exactly the combination that makes an in-place gather lose. So both
+// numbers are MEASURED here, once per process, and the crossover is read off the
+// measurements rather than interpolated from other machines.
+
+#include <cstdint>
+#include <optional>
+
+namespace sirius::late_mat {
+
+/// What the probe concluded about this machine's host-to-device link.
+struct host_gather_policy {
+  /// Fraction of a pinned table's rows below which reading in place beats
+  /// staging. 0.0 means staging always wins (also the fail-closed answer when
+  /// the probe could not run); 1.0 means in place always wins.
+  double max_inplace_density = 0.0;
+  /// How much dearer a host materialization is than the equivalent device
+  /// gather, which is what the deferral value floor has to be scaled by since
+  /// that floor was calibrated against a device gather.
+  std::int64_t cost_multiplier = 64;
+  /// False when the probe failed and the conservative defaults above are in use.
+  bool measured = false;
+  /// Bulk host-to-device bandwidth, bytes/s. Diagnostics only.
+  double bulk_bytes_per_second = 0.0;
+  /// Useful scattered-read bandwidth at full density, bytes/s. Diagnostics only.
+  double inplace_bytes_per_second = 0.0;
+};
+
+/// The policy for the current device, measured on first call and shared after.
+///
+/// The probe costs one small pinned allocation and a handful of kernel launches
+/// (tens of milliseconds, once per process). Any CUDA failure inside it is
+/// swallowed and reported as the conservative policy above: a lost optimization,
+/// never a wrong route.
+[[nodiscard]] host_gather_policy const& measured_host_gather_policy();
+
+/// Whether @p selected_rows out of @p total_rows should be read in place.
+///
+/// SIRIUS_EXP_LATE_MAT_HOST_INPLACE_MAX_DENSITY overrides the measured
+/// crossover; setting it to 1 forces in place and 0 forces staging, which is how
+/// a route can be pinned for a measurement or a test.
+[[nodiscard]] bool prefer_inplace_host_gather(std::int64_t selected_rows,
+                                              std::int64_t total_rows);
+
+/// How many host-tier materializations have taken each route.
+///
+/// A correctness assertion passes whichever route ran, so a test that means to
+/// exercise one has to be able to see which one it got. Monotonic for the life
+/// of the process.
+struct host_gather_route_counts {
+  std::uint64_t inplace = 0;
+  std::uint64_t staged  = 0;
+};
+
+[[nodiscard]] host_gather_route_counts host_gather_routes_taken();
+
+/// Record that a materialization took a route. Called by the materializer.
+void note_host_gather_route(bool inplace);
+
+/// Pin the route, or release it back to the measured policy with `std::nullopt`.
+///
+/// The env override is parsed once per process, so it cannot exercise both
+/// routes in one test binary; this can. Affects every subsequent host-tier
+/// materialization on every thread, so a test that sets it must reset it.
+void force_host_gather_route(std::optional<bool> inplace);
+
+/// The value-floor multiplier for a host-tier bundle, measured unless
+/// SIRIUS_EXP_LATE_MAT_HOST_COST_MULTIPLIER overrides it.
+[[nodiscard]] std::int64_t host_tier_cost_multiplier();
+
+}  // namespace sirius::late_mat

--- a/src/include/late_mat/materialize.hpp
+++ b/src/include/late_mat/materialize.hpp
@@ -52,16 +52,42 @@ class compressed_device_representation;
 
 namespace sirius::late_mat {
 
+/// One column's buffers inside one HOST-tier pinned chunk, as a gather has to
+/// address them.
+///
+/// Host-tier storage is a list of equally sized pinned blocks that are NOT
+/// contiguous with one another, so a column's buffer has no single base pointer
+/// and cannot be described by a cudf::column_view at all. What it does have is a
+/// byte offset into the logical concatenation of those blocks, which the gather
+/// translates to (block, offset) per element.
+///
+/// The block pointers are the host addresses. Under unified virtual addressing a
+/// registered pinned host pointer is also a valid device pointer, which is what
+/// lets the gather read the rows it wants where they lie instead of staging the
+/// whole column back to the device; the resolver refuses the pin outright when
+/// the device does not offer that.
+struct host_blocked_buffers {
+  std::vector<void*> blocks;  ///< block bases in allocation order, device-addressable
+  std::size_t block_size       = 0;
+  std::size_t data_offset      = 0;  ///< first data byte, logical offset over `blocks`
+  std::size_t null_mask_offset = 0;  ///< first mask byte, same coordinates; ignored unless
+                                     ///< `has_null_mask`
+  bool has_null_mask = false;
+};
+
 /// One pinned batch of one origin column. Exactly one form is populated, which
 /// mirrors device_pin_chunk: compression is decided per chunk, so a single pin
-/// may interleave the two.
+/// may interleave the two. A host-tier pin populates `host` instead, for every
+/// batch or none — a pinned entry lives in one tier.
 struct batch_source {
   sirius::compressed_device_representation const* compressed = nullptr;
   std::size_t column_index                                   = 0;  ///< within the compressed chunk
-  cudf::column_view uncompressed{};  ///< valid iff compressed == nullptr
+  cudf::column_view uncompressed{};  ///< valid iff compressed == nullptr and host == nullptr
+  std::shared_ptr<host_blocked_buffers const> host;  ///< set iff the pin is host-tier
   std::int64_t num_rows = 0;
 
   [[nodiscard]] bool is_compressed() const noexcept { return compressed != nullptr; }
+  [[nodiscard]] bool is_host() const noexcept { return host != nullptr; }
 };
 
 /// One origin column across the pinned table's batches, positionally consistent
@@ -89,6 +115,13 @@ struct pinned_column_view {
 /// resort. None of these routes writes an output validity buffer, so a decoded
 /// column that turns out to contain nulls is rejected rather than returned
 /// half-formed (require_non_null).
+///
+/// A HOST-tier origin is gathered where it lies, out of the pinned blocks
+/// described by batch_source::host, with no staging pass: fixed-width columns
+/// only, because a variable-width one has no element width to translate and its
+/// offsets would have to be rebuilt against buffers that are not contiguous.
+/// Validity is carried through, one mask word at a time, in the same
+/// coordinates.
 ///
 /// What this materializer can serve and what the INSTALLER admits are two
 /// different questions. Today no compressed origin reaches here: the install

--- a/src/include/late_mat/multi_source_gather.hpp
+++ b/src/include/late_mat/multi_source_gather.hpp
@@ -54,4 +54,42 @@ void multi_source_gather_fixed(void const* const* bases_dev,
                                std::uint32_t* out_mask,
                                rmm::cuda_stream_view stream);
 
+/// The same gather, for batches whose buffers live in HOST-tier pinned blocks.
+///
+/// A host chunk's storage is a list of equally sized blocks that are not
+/// contiguous with one another, so a column has no base pointer to index off.
+/// Each batch instead contributes its blocks to one flattened device array and
+/// gives a byte offset into their logical concatenation; element `local` of
+/// batch `b` is then found by dividing `data_off_dev[b] + local * elem_size` by
+/// the block size. Under unified virtual addressing the block pointers are
+/// device-usable as they are, so the rows are read where they lie rather than
+/// staged to the device first.
+///
+/// `blocks_dev` is a DEVICE array holding every batch's block pointers back to
+/// back; `block_base_dev[b]` is where batch b's run starts in it. `data_off_dev`
+/// and `mask_off_dev` are DEVICE arrays of B byte offsets each; a negative mask
+/// offset means that batch has no null mask (every row valid). Pass
+/// `out_mask == nullptr` to skip validity entirely.
+///
+/// The caller guarantees the translations land on element and word boundaries:
+/// `block_size` and `data_off_dev[b]` must both be multiples of `elem_size`, and
+/// `mask_off_dev[b]` a multiple of 4. A pin that does not satisfy this has no
+/// element-aligned reading and is refused at resolve time rather than read
+/// crookedly here.
+///
+/// Asynchronous on `stream`.
+void multi_source_gather_fixed_host(void const* const* blocks_dev,
+                                    std::int64_t const* block_base_dev,
+                                    std::int64_t const* data_off_dev,
+                                    std::int64_t const* mask_off_dev,
+                                    std::int64_t const* row_start_dev,
+                                    int num_batches,
+                                    std::size_t block_size,
+                                    std::size_t elem_size,
+                                    std::uint64_t const* ids,
+                                    std::int64_t count,
+                                    void* out,
+                                    std::uint32_t* out_mask,
+                                    rmm::cuda_stream_view stream);
+
 }  // namespace sirius::late_mat

--- a/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
+++ b/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
@@ -179,7 +179,8 @@ class duckdb_native_gpu_ingestible : public op::scan::gpu_ingestible {
     bool like_swar_fastpath,
     std::shared_ptr<const sirius::like_multiliteral_cache> like_cache,
     std::unique_ptr<cudf::column>* survivors,
-    std::span<std::size_t const> elided) override;
+    std::span<std::size_t const> elided,
+    std::span<std::size_t const> withheld) override;
 
   [[nodiscard]] const ingestible_table_info& table_info() const noexcept override { return *_info; }
 

--- a/src/include/op/scan/gpu_ingestible.hpp
+++ b/src/include/op/scan/gpu_ingestible.hpp
@@ -179,6 +179,9 @@ class gpu_ingestible : public std::enable_shared_from_this<gpu_ingestible> {
    *        exactly the case a deferral must refuse rather than guess at. An
    *        implementation that ignores it must leave @ref can_report_survivors
    *        false.
+   * @param withheld Output positions the producer never materialized, so the batch arrives
+   *                 without them and the output layout is renumbered past them. Mutually
+   *                 exclusive with @p elided, which drops columns the batch DOES carry.
    * @param elided Output positions the caller is going to overwrite regardless
    *        (a deferral's rowid and placeholders). Dropped from the selection
    *        before it is realized, so the copy never reads them; the caller puts
@@ -193,7 +196,8 @@ class gpu_ingestible : public std::enable_shared_from_this<gpu_ingestible> {
     bool like_swar_fastpath                                           = false,
     std::shared_ptr<const sirius::like_multiliteral_cache> like_cache = nullptr,
     std::unique_ptr<cudf::column>* survivors                          = nullptr,
-    std::span<std::size_t const> elided                               = {}) = 0;
+    std::span<std::size_t const> elided                               = {},
+    std::span<std::size_t const> withheld                             = {}) = 0;
 
   /**
    * @brief Whether this ingestible holds a row-filter expression that

--- a/src/include/op/scan/parquet_gpu_ingestible.hpp
+++ b/src/include/op/scan/parquet_gpu_ingestible.hpp
@@ -305,7 +305,8 @@ class parquet_gpu_ingestible : public gpu_ingestible {
     bool like_swar_fastpath,
     std::shared_ptr<const sirius::like_multiliteral_cache> like_cache,
     std::unique_ptr<cudf::column>* survivors,
-    std::span<std::size_t const> elided) override;
+    std::span<std::size_t const> elided,
+    std::span<std::size_t const> withheld) override;
 
   [[nodiscard]] const ingestible_table_info& table_info() const noexcept override { return *_info; }
 

--- a/src/include/op/scan/scan_plan.hpp
+++ b/src/include/op/scan/scan_plan.hpp
@@ -36,6 +36,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -172,11 +173,34 @@ struct scan_plan {
 ///                          no partition columns.
 /// @param stream            CUDA stream for any GPU work (scalar-backed column
 ///                          construction on the partition path).
+/// @param withheld_data_positions D-space positions the producer did NOT put in
+///                          @p table, ascending and duplicate-free. Their output
+///                          entries are omitted from the result and every
+///                          surviving DATA index is renumbered to its rank among
+///                          the columns that are present, so a narrowed batch is
+///                          assembled by the same layout that describes a full
+///                          one. Empty for every ordinary scan.
 [[nodiscard]] owning_table_view assemble_scan_output(
   scan_plan const& plan,
   owning_table_view&& table,
   std::vector<std::string> const& partition_values,
-  rmm::cuda_stream_view stream);
+  rmm::cuda_stream_view stream,
+  std::span<std::size_t const> withheld_data_positions = {});
+
+/// Renumber @p plan's output layout for a batch that is missing
+/// @p withheld_data_positions (D-space, ascending).
+///
+/// Returns one entry per surviving output column: the position it occupies in
+/// the narrowed batch. `std::nullopt` for a PARTITION entry, which no batch
+/// position describes. Withheld columns' entries are dropped entirely, so the
+/// result is shorter than @c output_layout by exactly the number of withheld
+/// columns that appear in the output.
+///
+/// Throws std::invalid_argument when a withheld position is out of range or the
+/// positions are not ascending and unique: a silent misordering here would
+/// assemble the right number of columns out of the wrong ones.
+[[nodiscard]] std::vector<std::optional<std::size_t>> renumber_output_for_withheld(
+  scan_plan const& plan, std::span<std::size_t const> withheld_data_positions);
 
 /// Batch (D-space) positions of the output DATA columns, in @c output_layout order.
 /// Empty when @c output_layout has no DATA entries (SELECT count(*) or a partition-only output), in

--- a/src/include/op/scan/sirius_gpu_scan_operator.hpp
+++ b/src/include/op/scan/sirius_gpu_scan_operator.hpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <span>
 #include <vector>
 
 namespace sirius::scan_manager {
@@ -153,6 +154,25 @@ class sirius_gpu_scan_operator : public sirius_physical_operator {
    *
    * @return One carrier target per logical output column, in output order
    */
+  //! Output positions whose values the pinned provider does NOT serve, because a deferral is
+  //! going to replace them with a rowid anyway. Empty unless the scan serves from a pin AND a
+  //! deferral installed AND the narrowing was admissible; see
+  //! `sirius_scan_manager`'s install path, which is the only writer.
+  //!
+  //! The batch therefore arrives narrower than `types.size()`, and two things downstream depend
+  //! on that: output assembly renumbers the layout past the missing columns, and
+  //! `substitute_deferred_columns` INSERTS at these positions rather than overwriting. Setting
+  //! this without narrowing what the provider serves, or the reverse, mismatches the batch
+  //! against the layout that describes it.
+  void set_withheld_output_positions(std::vector<std::size_t> positions)
+  {
+    _withheld_output_positions = std::move(positions);
+  }
+  [[nodiscard]] std::span<std::size_t const> withheld_output_positions() const noexcept
+  {
+    return _withheld_output_positions;
+  }
+
   [[nodiscard]] std::vector<cudf::data_type> const& normalization_targets() const noexcept
   {
     return has_physical_overrides() ? get_physical_types() : _native_physical_types;
@@ -171,6 +191,8 @@ class sirius_gpu_scan_operator : public sirius_physical_operator {
   }
 
  private:
+  std::vector<std::size_t> _withheld_output_positions;
+
   std::shared_ptr<gpu_ingestible> _ingestible;
   std::shared_ptr<scan_manager::split_connector> _split_connector;
   /// Latch for "compacting during decode does not pay off", shared with every

--- a/src/include/scan_manager/late_mat_resolver.hpp
+++ b/src/include/scan_manager/late_mat_resolver.hpp
@@ -20,17 +20,19 @@
 // SIRIUS_EXP_LATE_MAT).
 //
 // This is the only code on either side of the seam that knows how a pinned
-// entry stores its chunks — device columns per name for a plain GPU pin, or
+// entry stores its chunks — device columns per name for a plain GPU pin,
 // per-chunk device_pin_chunks that may interleave compressed and uncompressed
-// storage. Everything above it works in layouts and column views, which is
-// what lets the materializer be tested without a scan manager and the scan
-// manager change storage without touching the materializer.
+// storage, or host_chunks in the opposite orientation (one representation per
+// chunk holding every pinned column). Everything above it works in layouts and
+// column views, which is what lets the materializer be tested without a scan
+// manager and the scan manager change storage without touching the
+// materializer.
 //
 // Both entry points return nullopt rather than throwing, because every reason
-// they can fail is a reason to simply not defer: a stale origin, an entry
-// living on the host, a compressed origin, chunks that disagree on their
-// carrier width. A deferral that cannot be resolved must degrade to the
-// ordinary path, not to an error.
+// they can fail is a reason to simply not defer: a stale origin, a compressed
+// origin, a host pin the device cannot address in place, chunks that disagree
+// on their carrier width. A deferral that cannot be resolved must degrade to
+// the ordinary path, not to an error.
 //
 // The views are NON-OWNING and valid for the query's lifetime, which pin/unpin
 // serialization against query execution is what guarantees.
@@ -39,33 +41,61 @@
 #include "late_mat/materialize.hpp"
 #include "late_mat/prepared_selection.hpp"
 
+#include <cstddef>
 #include <optional>
 
 namespace sirius::scan_manager {
 
+struct pinned_entry;  // scan_manager/sirius_scan_manager.hpp
+
 /// The origin table's batch layout, in pin order — how many rows each chunk
 /// holds, which is all a selection needs to be split across them.
 ///
-/// nullopt when the origin is stale (its generation no longer matches) or the
-/// entry is not device-resident: v1 materializes from GPU-tier pins only, since
-/// a host chunk would have to be staged before any of this applies.
+/// nullopt when the origin is stale (its generation no longer matches), when the
+/// entry is on the DISK tier, or when a host-tier entry holds a chunk this path
+/// cannot read (a compressed one).
 [[nodiscard]] std::optional<late_mat::pinned_table_layout> resolve_pinned_layout(
   late_mat::column_origin const& origin);
 
 /// The per-chunk sources of one origin column — a compressed table and column
-/// index, or a device column view, per chunk.
+/// index, a device column view, or a host chunk's block-scattered buffers, per
+/// chunk.
 ///
 /// Positionally consistent with resolve_pinned_layout's batches, which is the
 /// invariant the materializer checks its inputs against: a mismatch there would
 /// read the right number of rows out of the wrong chunks.
 ///
-/// nullopt for a stale or host-resident origin, a column position the entry
-/// does not have, a COMPRESSED origin (the decode routes write values only,
-/// with no output validity buffer), or a column whose chunks were narrowed to
-/// different carrier widths — the view carries one dtype and the gather reads
-/// every batch at it. An uncompressed origin MAY be nullable: every such gather
-/// shape propagates validity.
+/// nullopt for a stale origin, a column position the entry does not have, a
+/// COMPRESSED origin (the decode routes write values only, with no output
+/// validity buffer), or a column whose chunks were narrowed to different carrier
+/// widths — the view carries one dtype and the gather reads every batch at it.
+/// An uncompressed origin MAY be nullable: every such gather shape propagates
+/// validity.
+///
+/// A HOST-tier origin resolves to blocks read in place; it is refused unless
+/// @ref host_pinned_column_is_addressable holds for it.
 [[nodiscard]] std::optional<late_mat::pinned_column_view> resolve_pinned_column(
   late_mat::column_origin const& origin);
+
+/// Whether a HOST-tier entry's column at @p column_position can be gathered
+/// where it lies, without staging it to the device first.
+///
+/// Four things have to hold, and each is a refusal the install gate has to make
+/// for the same reasons the resolver does — a deferral installed over a column
+/// the resolver will later decline throws at the port, with the values already
+/// gone:
+///
+///  * the device must be able to read registered pinned host memory directly
+///    (unified addressing plus cudaDevAttrCanUseHostPointerForRegisteredMem);
+///  * every chunk must be an uncompressed host representation, since a
+///    Simpatico-compressed host blob has no addressable per-row layout;
+///  * the column must be FIXED WIDTH in every chunk, at one carrier width, since
+///    the gather translates a row to a byte offset by multiplying;
+///  * the translation must land on element and mask-word boundaries, which the
+///    block size and the recorded buffer offsets decide.
+///
+/// False for a GPU-tier entry: this asks about host addressability only.
+[[nodiscard]] bool host_pinned_column_is_addressable(pinned_entry const& entry,
+                                                     std::size_t column_position);
 
 }  // namespace sirius::scan_manager

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -257,6 +257,12 @@ struct pinned_entry {
 void validate_pinned_entry_for_serving(pinned_entry const& entry,
                                        std::span<std::size_t const> selected_columns);
 
+/// Actual cuDF carrier of one column of an uncompressed pinned host chunk, rebuilt from the
+/// chunk's host column metadata. Keyed on the DECIMAL type ids, not on a nonzero scale: a
+/// DECIMAL(p,0) column has cuDF scale 0 and must still take the two-argument fixed-point
+/// constructor.
+[[nodiscard]] cudf::data_type host_column_carrier(cucascade::memory::column_metadata const& meta);
+
 /// Validate the shape of @p matrix alone: it must hold @p expected_chunks rows of
 /// @p expected_columns cells each. @p allow_empty admits the empty matrix, which reads as
 /// all-native — @ref validate_pinned_entry_for_serving passes true because a zero-chunk or

--- a/src/late_mat/defer_policy.cpp
+++ b/src/late_mat/defer_policy.cpp
@@ -36,11 +36,18 @@ char const* describe(defer_refusal r) noexcept
 
 std::int64_t defer_candidate::net_value_bytes(std::int64_t rowid_bytes) const noexcept
 {
+  if (columns.empty()) { return -rowid_bytes; }
   std::int64_t total = 0;
   for (auto const& c : columns) {
     total += c.value_bytes;
   }
-  return total - rowid_bytes;
+  return total - carrier_bytes(rowid_bytes);
+}
+
+std::int64_t defer_candidate::carrier_bytes(std::int64_t rowid_bytes) const noexcept
+{
+  if (columns.empty()) { return rowid_bytes; }
+  return rowid_bytes + (static_cast<std::int64_t>(columns.size()) - 1) * kPlaceholderBytes;
 }
 
 std::vector<defer_outcome> choose_deferrals(std::vector<defer_candidate> const& candidates,

--- a/src/late_mat/host_gather_policy.cu
+++ b/src/late_mat/host_gather_policy.cu
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "late_mat/host_gather_policy.hpp"
+
+#include "late_mat/multi_source_gather.hpp"
+#include "log/logging.hpp"
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <charconv>
+#include <cstdlib>
+#include <cstring>
+#include <atomic>
+#include <optional>
+#include <random>
+#include <system_error>
+#include <vector>
+
+namespace sirius::late_mat {
+
+namespace {
+
+constexpr std::size_t kProbeBlockSize = std::size_t{1} << 20;
+constexpr std::size_t kProbeBlocks    = 256;
+constexpr std::size_t kProbeBytes     = kProbeBlockSize * kProbeBlocks;
+constexpr std::size_t kProbeElem      = sizeof(std::uint64_t);
+constexpr std::int64_t kProbeRows     = static_cast<std::int64_t>(kProbeBytes / kProbeElem);
+
+/// Densities the crossover is resolved to. A coherent link crosses at or above
+/// the top rung, PCIe near the bottom ones.
+constexpr double kRungs[] = {0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.0};
+
+/// Where the cost multiplier is read off: a selection a ride would produce.
+constexpr double kMultiplierDensity = 0.08;
+
+/// Every allocation the probe makes, released however it exits.
+struct probe_arena {
+  std::vector<void*> host_blocks;
+  std::vector<void*> device_allocations;
+  cudaEvent_t start = nullptr;
+  cudaEvent_t stop  = nullptr;
+
+  [[nodiscard]] void* device_alloc(std::size_t bytes)
+  {
+    void* ptr = nullptr;
+    if (cudaMalloc(&ptr, bytes) != cudaSuccess) { return nullptr; }
+    device_allocations.push_back(ptr);
+    return ptr;
+  }
+
+  ~probe_arena()
+  {
+    for (auto* block : host_blocks) {
+      if (block != nullptr) { cudaFreeHost(block); }
+    }
+    for (auto* ptr : device_allocations) {
+      cudaFree(ptr);
+    }
+    if (start != nullptr) { cudaEventDestroy(start); }
+    if (stop != nullptr) { cudaEventDestroy(stop); }
+  }
+};
+
+bool cuda_ok(cudaError_t err) { return err == cudaSuccess; }
+
+/// Milliseconds for @p body, best of @p reps after one warm-up.
+template <typename Body>
+bool time_best(probe_arena& arena, int reps, Body&& body, float& best_ms)
+{
+  body();
+  if (!cuda_ok(cudaDeviceSynchronize())) { return false; }
+  best_ms = 0.0F;
+  for (int rep = 0; rep < reps; ++rep) {
+    if (!cuda_ok(cudaEventRecord(arena.start))) { return false; }
+    body();
+    if (!cuda_ok(cudaEventRecord(arena.stop))) { return false; }
+    if (!cuda_ok(cudaEventSynchronize(arena.stop))) { return false; }
+    float ms = 0.0F;
+    if (!cuda_ok(cudaEventElapsedTime(&ms, arena.start, arena.stop))) { return false; }
+    if (rep == 0 || ms < best_ms) { best_ms = ms; }
+  }
+  return true;
+}
+
+host_gather_policy run_probe()
+{
+  host_gather_policy policy;
+  probe_arena arena;
+
+  auto const fail = [&policy](char const* why) {
+    SIRIUS_LOG_WARN(
+      "[late-mat] host gather probe failed ({}); host-tier rides will stage rather than read in "
+      "place, and are costed as expensive",
+      why);
+    return policy;
+  };
+
+  if (!cuda_ok(cudaEventCreate(&arena.start)) || !cuda_ok(cudaEventCreate(&arena.stop))) {
+    return fail("could not create timing events");
+  }
+
+  arena.host_blocks.resize(kProbeBlocks, nullptr);
+  for (std::size_t block = 0; block < kProbeBlocks; ++block) {
+    if (!cuda_ok(cudaHostAlloc(&arena.host_blocks[block], kProbeBlockSize, cudaHostAllocMapped))) {
+      return fail("could not allocate pinned host memory");
+    }
+    std::memset(arena.host_blocks[block], 0, kProbeBlockSize);
+  }
+
+  auto const ids_at = [](double density) {
+    auto const count = static_cast<std::int64_t>(static_cast<double>(kProbeRows) * density);
+    return count < 1 ? std::int64_t{1} : count;
+  };
+  auto const max_ids = ids_at(1.0);
+
+  auto* device_buffer  = arena.device_alloc(kProbeBytes);
+  auto* device_out     = arena.device_alloc(static_cast<std::size_t>(max_ids) * kProbeElem);
+  auto* device_ids     = arena.device_alloc(static_cast<std::size_t>(max_ids) * sizeof(std::uint64_t));
+  auto* device_blocks  = arena.device_alloc(kProbeBlocks * sizeof(void*));
+  auto* device_scalars = arena.device_alloc(4 * sizeof(std::int64_t));
+  auto* device_bases   = arena.device_alloc(sizeof(void*));
+  if (device_buffer == nullptr || device_out == nullptr || device_ids == nullptr ||
+      device_blocks == nullptr || device_scalars == nullptr || device_bases == nullptr) {
+    return fail("could not allocate device memory");
+  }
+
+  // The host pointers double as device addresses; a machine where they do not is
+  // refused by the resolver's addressability check before any of this runs.
+  if (!cuda_ok(cudaMemcpy(device_blocks,
+                          arena.host_blocks.data(),
+                          kProbeBlocks * sizeof(void*),
+                          cudaMemcpyHostToDevice)) ||
+      !cuda_ok(cudaMemcpy(device_bases, &device_buffer, sizeof(void*), cudaMemcpyHostToDevice))) {
+    return fail("could not publish the block tables");
+  }
+
+  std::int64_t const scalars[4] = {0, 0, -1, 0};
+  if (!cuda_ok(cudaMemcpy(device_scalars, scalars, sizeof(scalars), cudaMemcpyHostToDevice))) {
+    return fail("could not publish the batch descriptor");
+  }
+  auto const* block_base = static_cast<std::int64_t const*>(device_scalars);
+  auto const* data_off   = block_base + 1;
+  auto const* mask_off   = block_base + 2;
+  auto const* row_start  = block_base + 3;
+
+  std::vector<std::uint64_t> host_ids(static_cast<std::size_t>(max_ids));
+  std::mt19937_64 rng(1234567);
+  for (auto& id : host_ids) {
+    id = rng() % static_cast<std::uint64_t>(kProbeRows);
+  }
+  // Deliberately NOT sorted. A join hands its ids back in arbitrary order, and
+  // materialize_host_raw gathers them as they came; sorting them here would give
+  // the scattered read a locality production never has, and the probe would then
+  // credit reading in place with a speed it cannot reach on real ids.
+  if (!cuda_ok(cudaMemcpy(device_ids,
+                          host_ids.data(),
+                          host_ids.size() * sizeof(std::uint64_t),
+                          cudaMemcpyHostToDevice))) {
+    return fail("could not publish the probe ids");
+  }
+
+  rmm::cuda_stream_view stream{};
+  auto const* ids_dev = static_cast<std::uint64_t const*>(device_ids);
+
+  float bulk_ms   = 0.0F;
+  auto const bulk = [&] {
+    std::size_t done = 0;
+    for (std::size_t block = 0; block < kProbeBlocks; ++block) {
+      cudaMemcpyAsync(static_cast<char*>(device_buffer) + done,
+                      arena.host_blocks[block],
+                      kProbeBlockSize,
+                      cudaMemcpyHostToDevice,
+                      stream.value());
+      done += kProbeBlockSize;
+    }
+  };
+  if (!time_best(arena, 3, bulk, bulk_ms) || bulk_ms <= 0.0F) {
+    return fail("the bulk copy could not be timed");
+  }
+
+  auto const inplace_at = [&](std::int64_t count, float& ms) {
+    return time_best(
+      arena,
+      3,
+      [&] {
+        multi_source_gather_fixed_host(static_cast<void const* const*>(device_blocks),
+                                       block_base,
+                                       data_off,
+                                       mask_off,
+                                       row_start,
+                                       1,
+                                       kProbeBlockSize,
+                                       kProbeElem,
+                                       ids_dev,
+                                       count,
+                                       device_out,
+                                       nullptr,
+                                       stream);
+      },
+      ms);
+  };
+  auto const device_gather_at = [&](std::int64_t count, float& ms) {
+    return time_best(
+      arena,
+      3,
+      [&] {
+        multi_source_gather_fixed(static_cast<void const* const*>(device_bases),
+                                  row_start,
+                                  1,
+                                  kProbeElem,
+                                  ids_dev,
+                                  count,
+                                  device_out,
+                                  nullptr,
+                                  nullptr,
+                                  stream);
+      },
+      ms);
+  };
+
+  double crossover      = 0.0;
+  float multiplier_host = 0.0F;
+  float multiplier_dev  = 0.0F;
+  for (double rung : kRungs) {
+    auto const count = ids_at(rung);
+    float host_ms    = 0.0F;
+    float dev_ms     = 0.0F;
+    if (!inplace_at(count, host_ms) || !device_gather_at(count, dev_ms)) {
+      return fail("a gather could not be timed");
+    }
+    // Staging pays the bulk copy and then gathers on the device; reading in
+    // place pays neither, only its own scattered reads.
+    if (host_ms < bulk_ms + dev_ms) { crossover = rung; }
+    if (rung >= kMultiplierDensity && multiplier_host == 0.0F) {
+      multiplier_host = host_ms;
+      multiplier_dev  = dev_ms;
+    }
+  }
+
+  policy.measured            = true;
+  policy.max_inplace_density = crossover;
+  policy.bulk_bytes_per_second =
+    static_cast<double>(kProbeBytes) / (static_cast<double>(bulk_ms) / 1e3);
+
+  float full_ms = 0.0F;
+  if (inplace_at(max_ids, full_ms) && full_ms > 0.0F) {
+    policy.inplace_bytes_per_second =
+      static_cast<double>(max_ids) * kProbeElem / (static_cast<double>(full_ms) / 1e3);
+  }
+  if (multiplier_dev > 0.0F && multiplier_host > 0.0F) {
+    auto const ratio = static_cast<double>(multiplier_host) / static_cast<double>(multiplier_dev);
+    policy.cost_multiplier = std::clamp<std::int64_t>(static_cast<std::int64_t>(ratio + 0.5), 1, 64);
+  }
+
+  SIRIUS_LOG_INFO(
+    "[late-mat] host gather probe: bulk {:.1f} GB/s, in-place {:.1f} GB/s, crossover density "
+    "{:.2f}, cost multiplier {}",
+    policy.bulk_bytes_per_second / 1e9,
+    policy.inplace_bytes_per_second / 1e9,
+    policy.max_inplace_density,
+    policy.cost_multiplier);
+  return policy;
+}
+
+std::optional<double> density_override()
+{
+  static std::optional<double> const value = []() -> std::optional<double> {
+    char const* env = std::getenv("SIRIUS_EXP_LATE_MAT_HOST_INPLACE_MAX_DENSITY");
+    if (env == nullptr || env[0] == '\0') { return std::nullopt; }
+    try {
+      std::size_t consumed = 0;
+      double const parsed  = std::stod(env, &consumed);
+      if (consumed != std::strlen(env) || parsed < 0.0 || parsed > 1.0) { return std::nullopt; }
+      return parsed;
+    } catch (std::exception const&) {
+      return std::nullopt;
+    }
+  }();
+  return value;
+}
+
+std::optional<std::int64_t> multiplier_override()
+{
+  static std::optional<std::int64_t> const value = []() -> std::optional<std::int64_t> {
+    char const* env = std::getenv("SIRIUS_EXP_LATE_MAT_HOST_COST_MULTIPLIER");
+    if (env == nullptr || env[0] == '\0') { return std::nullopt; }
+    std::int64_t parsed = 0;
+    auto const* end     = env + std::strlen(env);
+    auto const result   = std::from_chars(env, end, parsed);
+    if (result.ec != std::errc{} || result.ptr != end || parsed < 1) { return std::nullopt; }
+    return parsed;
+  }();
+  return value;
+}
+
+/// Route census, and the test seam that pins a route. Relaxed ordering: these
+/// are counters and a switch, never a happens-before edge.
+std::atomic<std::uint64_t> g_inplace_taken{0};
+std::atomic<std::uint64_t> g_staged_taken{0};
+std::atomic<int> g_forced_route{-1};  // -1 measured policy, 0 staged, 1 in place
+
+}  // namespace
+
+host_gather_route_counts host_gather_routes_taken()
+{
+  return {g_inplace_taken.load(std::memory_order_relaxed),
+          g_staged_taken.load(std::memory_order_relaxed)};
+}
+
+void note_host_gather_route(bool inplace)
+{
+  auto& counter = inplace ? g_inplace_taken : g_staged_taken;
+  counter.fetch_add(1, std::memory_order_relaxed);
+}
+
+void force_host_gather_route(std::optional<bool> inplace)
+{
+  g_forced_route.store(inplace.has_value() ? (*inplace ? 1 : 0) : -1, std::memory_order_relaxed);
+}
+
+host_gather_policy const& measured_host_gather_policy()
+{
+  static host_gather_policy const policy = run_probe();
+  return policy;
+}
+
+bool prefer_inplace_host_gather(std::int64_t selected_rows, std::int64_t total_rows)
+{
+  auto const forced = g_forced_route.load(std::memory_order_relaxed);
+  if (forced >= 0) { return forced == 1; }
+  if (total_rows <= 0) { return false; }
+  auto const threshold =
+    density_override().value_or(measured_host_gather_policy().max_inplace_density);
+  if (threshold >= 1.0) { return true; }
+  if (threshold <= 0.0) { return false; }
+  auto const density = static_cast<double>(selected_rows) / static_cast<double>(total_rows);
+  return density <= threshold;
+}
+
+std::int64_t host_tier_cost_multiplier()
+{
+  return multiplier_override().value_or(measured_host_gather_policy().cost_multiplier);
+}
+
+}  // namespace sirius::late_mat

--- a/src/late_mat/host_gather_policy.cu
+++ b/src/late_mat/host_gather_policy.cu
@@ -15,7 +15,6 @@
  */
 
 #include "late_mat/host_gather_policy.hpp"
-
 #include "late_mat/multi_source_gather.hpp"
 #include "log/logging.hpp"
 
@@ -24,10 +23,10 @@
 #include <cuda_runtime.h>
 
 #include <algorithm>
+#include <atomic>
 #include <charconv>
 #include <cstdlib>
 #include <cstring>
-#include <atomic>
 #include <optional>
 #include <random>
 #include <system_error>
@@ -130,9 +129,9 @@ host_gather_policy run_probe()
   };
   auto const max_ids = ids_at(1.0);
 
-  auto* device_buffer  = arena.device_alloc(kProbeBytes);
-  auto* device_out     = arena.device_alloc(static_cast<std::size_t>(max_ids) * kProbeElem);
-  auto* device_ids     = arena.device_alloc(static_cast<std::size_t>(max_ids) * sizeof(std::uint64_t));
+  auto* device_buffer = arena.device_alloc(kProbeBytes);
+  auto* device_out    = arena.device_alloc(static_cast<std::size_t>(max_ids) * kProbeElem);
+  auto* device_ids = arena.device_alloc(static_cast<std::size_t>(max_ids) * sizeof(std::uint64_t));
   auto* device_blocks  = arena.device_alloc(kProbeBlocks * sizeof(void*));
   auto* device_scalars = arena.device_alloc(4 * sizeof(std::int64_t));
   auto* device_bases   = arena.device_alloc(sizeof(void*));
@@ -266,7 +265,8 @@ host_gather_policy run_probe()
   }
   if (multiplier_dev > 0.0F && multiplier_host > 0.0F) {
     auto const ratio = static_cast<double>(multiplier_host) / static_cast<double>(multiplier_dev);
-    policy.cost_multiplier = std::clamp<std::int64_t>(static_cast<std::int64_t>(ratio + 0.5), 1, 64);
+    policy.cost_multiplier =
+      std::clamp<std::int64_t>(static_cast<std::int64_t>(ratio + 0.5), 1, 64);
   }
 
   SIRIUS_LOG_INFO(

--- a/src/late_mat/materialize.cpp
+++ b/src/late_mat/materialize.cpp
@@ -17,6 +17,7 @@
 #include "late_mat/materialize.hpp"
 
 #include "compression/compressed_representation.hpp"
+#include "late_mat/host_gather_policy.hpp"
 #include "late_mat/multi_source_gather.hpp"
 
 #include <cudf/column/column_factories.hpp>
@@ -99,6 +100,117 @@ rmm::device_buffer to_device(std::vector<T> const& values,
   cudaMemcpyAsync(
     buf.data(), values.data(), values.size() * sizeof(T), cudaMemcpyHostToDevice, stream.value());
   return buf;
+}
+
+/// Copy @p bytes of a host chunk, starting at logical offset @p offset over its
+/// blocks, into @p dest on the device. The blocks are not contiguous with one
+/// another, so the copy splits wherever it crosses one.
+void stage_host_range(host_blocked_buffers const& host,
+                      std::size_t offset,
+                      std::size_t bytes,
+                      void* dest,
+                      rmm::cuda_stream_view stream)
+{
+  std::size_t copied = 0;
+  while (copied < bytes) {
+    auto const at        = offset + copied;
+    auto const block     = at / host.block_size;
+    auto const within    = at % host.block_size;
+    auto const available = host.block_size - within;
+    auto const chunk     = std::min(available, bytes - copied);
+    if (block >= host.blocks.size()) {
+      throw std::runtime_error("late_mat::materialize: a host chunk is shorter than its column");
+    }
+    cudaMemcpyAsync(static_cast<char*>(dest) + copied,
+                    static_cast<char const*>(host.blocks[block]) + within,
+                    chunk,
+                    cudaMemcpyHostToDevice,
+                    stream.value());
+    copied += chunk;
+  }
+}
+
+/// The staging route: copy each host chunk's column to the device in bulk, then
+/// gather there.
+///
+/// Wins once the selection is dense enough that scattered reads over the link
+/// cost more than moving the whole column across it once. Where that crossover
+/// sits is a property of the link and is measured rather than assumed; see
+/// host_gather_policy.hpp. The bytes moved here are the ones the query would
+/// have moved anyway had the column never been deferred.
+std::unique_ptr<cudf::column> materialize_host_staged(pinned_column_view const& column,
+                                                      prepared_selection const& selection,
+                                                      rmm::cuda_stream_view stream,
+                                                      rmm::device_async_resource_ref mr)
+{
+  auto const& ids      = selection.ids();
+  auto const elem_size = cudf::size_of(column.dtype);
+
+  std::vector<rmm::device_buffer> staged_data;
+  std::vector<rmm::device_buffer> staged_masks;
+  std::vector<void const*> bases;
+  std::vector<cudf::bitmask_type const*> masks;
+  std::vector<std::int64_t> starts;
+  staged_data.reserve(column.batches.size());
+  staged_masks.reserve(column.batches.size());
+  bool any_nullable = false;
+
+  for (std::size_t batch = 0; batch < column.batches.size(); ++batch) {
+    auto const* host = column.batches[batch].host.get();
+    if (host == nullptr) {
+      throw std::runtime_error("late_mat::materialize: a host-tier column mixes storage forms");
+    }
+    auto const rows  = static_cast<std::size_t>(column.batches[batch].num_rows);
+    auto const bytes = rows * elem_size;
+    rmm::device_buffer data(bytes, stream, mr);
+    if (bytes > 0) { stage_host_range(*host, host->data_offset, bytes, data.data(), stream); }
+    bases.push_back(data.data());
+    staged_data.push_back(std::move(data));
+
+    if (host->has_null_mask) {
+      any_nullable = true;
+      auto const mask_bytes =
+        cudf::bitmask_allocation_size_bytes(static_cast<cudf::size_type>(rows));
+      rmm::device_buffer mask(mask_bytes, stream, mr);
+      stage_host_range(*host, host->null_mask_offset, mask_bytes, mask.data(), stream);
+      masks.push_back(static_cast<cudf::bitmask_type const*>(mask.data()));
+      staged_masks.push_back(std::move(mask));
+    } else {
+      masks.push_back(nullptr);
+    }
+    starts.push_back(selection.layout().batch_row_start[batch]);
+  }
+
+  auto out = cudf::make_fixed_width_column(
+    column.dtype,
+    static_cast<cudf::size_type>(ids.count),
+    any_nullable ? cudf::mask_state::UNINITIALIZED : cudf::mask_state::UNALLOCATED,
+    stream,
+    mr);
+
+  auto const bases_dev  = to_device(bases, stream, mr);
+  auto const starts_dev = to_device(starts, stream, mr);
+  rmm::device_buffer masks_dev;
+  if (any_nullable) { masks_dev = to_device(masks, stream, mr); }
+
+  multi_source_gather_fixed(
+    static_cast<void const* const*>(bases_dev.data()),
+    static_cast<std::int64_t const*>(starts_dev.data()),
+    static_cast<int>(column.batches.size()),
+    elem_size,
+    ids.ids,
+    ids.count,
+    out->mutable_view().head<void>(),
+    any_nullable ? static_cast<std::uint32_t const* const*>(masks_dev.data()) : nullptr,
+    any_nullable ? reinterpret_cast<std::uint32_t*>(out->mutable_view().null_mask()) : nullptr,
+    stream);
+  if (any_nullable) {
+    out->set_null_count(cudf::null_count(
+      out->view().null_mask(), 0, static_cast<cudf::size_type>(ids.count), stream));
+  }
+  // The staged buffers are freed as this returns, stream-ordered on the same
+  // stream the gather was enqueued on.
+  return out;
 }
 
 /// The host-tier path: gather by global id straight out of the pinned blocks.
@@ -191,7 +303,15 @@ std::unique_ptr<cudf::column> materialize_raw(pinned_column_view const& column,
   auto const& ids = selection.ids();
 
   if (column.batches.front().is_host()) {
-    return materialize_host_raw(column, selection, stream, mr);
+    // Both routes produce the same values; which one is cheaper depends on how
+    // much of the pinned table the selection wants and on how the link handles
+    // scattered reads. The ids may repeat, so this density is an upper bound on
+    // the distinct fraction, which biases the choice towards staging — the
+    // route whose cost does not grow with the count.
+    bool const inplace = prefer_inplace_host_gather(ids.count, selection.layout().total_rows());
+    note_host_gather_route(inplace);
+    return inplace ? materialize_host_raw(column, selection, stream, mr)
+                   : materialize_host_staged(column, selection, stream, mr);
   }
 
   // One batch starts at global row 0, so the ids ARE the batch-local map and

--- a/src/late_mat/materialize.cpp
+++ b/src/late_mat/materialize.cpp
@@ -80,8 +80,106 @@ bool can_gather_raw(pinned_column_view const& column)
   for (auto const& b : column.batches) {
     if (b.is_compressed()) { return false; }
   }
+  // A host batch has no cudf::column_view for the canonical path to gather from
+  // — its buffers are not contiguous — so the blocked gather is its only route,
+  // whatever the batch count.
+  if (column.batches.front().is_host()) { return cudf::is_fixed_width(column.dtype); }
   if (column.batches.size() == 1) { return true; }
   return cudf::is_fixed_width(column.dtype);
+}
+
+/// Copy a host array of trivially-copyable descriptors into a stream-ordered
+/// device buffer.
+template <typename T>
+rmm::device_buffer to_device(std::vector<T> const& values,
+                             rmm::cuda_stream_view stream,
+                             rmm::device_async_resource_ref mr)
+{
+  rmm::device_buffer buf(values.size() * sizeof(T), stream, mr);
+  cudaMemcpyAsync(
+    buf.data(), values.data(), values.size() * sizeof(T), cudaMemcpyHostToDevice, stream.value());
+  return buf;
+}
+
+/// The host-tier path: gather by global id straight out of the pinned blocks.
+///
+/// Each batch contributes its blocks to one flattened array plus a byte offset
+/// into their logical concatenation, which is all the kernel needs to turn a row
+/// into an address. Nothing is staged to the device but the output itself.
+std::unique_ptr<cudf::column> materialize_host_raw(pinned_column_view const& column,
+                                                   prepared_selection const& selection,
+                                                   rmm::cuda_stream_view stream,
+                                                   rmm::device_async_resource_ref mr)
+{
+  auto const& ids        = selection.ids();
+  auto const elem_size   = cudf::size_of(column.dtype);
+  std::size_t block_size = 0;
+
+  std::vector<void const*> blocks;
+  std::vector<std::int64_t> block_base;
+  std::vector<std::int64_t> data_off;
+  std::vector<std::int64_t> mask_off;
+  std::vector<std::int64_t> row_start;
+  block_base.reserve(column.batches.size());
+  data_off.reserve(column.batches.size());
+  mask_off.reserve(column.batches.size());
+  row_start.reserve(column.batches.size());
+  bool any_nullable = false;
+
+  for (std::size_t b = 0; b < column.batches.size(); ++b) {
+    auto const* host = column.batches[b].host.get();
+    if (host == nullptr) {
+      throw std::runtime_error("late_mat::materialize: a host-tier column mixes storage forms");
+    }
+    if (block_size == 0) {
+      block_size = host->block_size;
+    } else if (block_size != host->block_size) {
+      throw std::runtime_error("late_mat::materialize: host chunks disagree on their block size");
+    }
+    block_base.push_back(static_cast<std::int64_t>(blocks.size()));
+    blocks.insert(blocks.end(), host->blocks.begin(), host->blocks.end());
+    data_off.push_back(static_cast<std::int64_t>(host->data_offset));
+    mask_off.push_back(host->has_null_mask ? static_cast<std::int64_t>(host->null_mask_offset)
+                                           : std::int64_t{-1});
+    row_start.push_back(selection.layout().batch_row_start[b]);
+    any_nullable = any_nullable || host->has_null_mask;
+  }
+
+  auto out = cudf::make_fixed_width_column(
+    column.dtype,
+    static_cast<cudf::size_type>(ids.count),
+    any_nullable ? cudf::mask_state::UNINITIALIZED : cudf::mask_state::UNALLOCATED,
+    stream,
+    mr);
+
+  auto const blocks_dev     = to_device(blocks, stream, mr);
+  auto const block_base_dev = to_device(block_base, stream, mr);
+  auto const data_off_dev   = to_device(data_off, stream, mr);
+  auto const mask_off_dev   = to_device(mask_off, stream, mr);
+  auto const row_start_dev  = to_device(row_start, stream, mr);
+
+  multi_source_gather_fixed_host(
+    static_cast<void const* const*>(blocks_dev.data()),
+    static_cast<std::int64_t const*>(block_base_dev.data()),
+    static_cast<std::int64_t const*>(data_off_dev.data()),
+    static_cast<std::int64_t const*>(mask_off_dev.data()),
+    static_cast<std::int64_t const*>(row_start_dev.data()),
+    static_cast<int>(column.batches.size()),
+    block_size,
+    elem_size,
+    ids.ids,
+    ids.count,
+    out->mutable_view().head<void>(),
+    any_nullable ? reinterpret_cast<std::uint32_t*>(out->mutable_view().null_mask()) : nullptr,
+    stream);
+  // The descriptor buffers are freed as this returns; they are stream-ordered on
+  // the same stream the gather was enqueued on, so the deallocation is already
+  // ordered after it.
+  if (any_nullable) {
+    out->set_null_count(cudf::null_count(
+      out->view().null_mask(), 0, static_cast<cudf::size_type>(ids.count), stream));
+  }
+  return out;
 }
 
 /// The raw path: gather by global id, no canonical form, no restoring pass.
@@ -91,6 +189,10 @@ std::unique_ptr<cudf::column> materialize_raw(pinned_column_view const& column,
                                               rmm::device_async_resource_ref mr)
 {
   auto const& ids = selection.ids();
+
+  if (column.batches.front().is_host()) {
+    return materialize_host_raw(column, selection, stream, mr);
+  }
 
   // One batch starts at global row 0, so the ids ARE the batch-local map and
   // cudf gathers straight off the borrowed list. Any dtype, since cudf does the
@@ -293,6 +395,24 @@ std::unique_ptr<cudf::column> materialize(pinned_column_view const& column,
     if (column.batches[b].num_rows != layout.batch_rows[b]) {
       throw std::runtime_error("late_mat::materialize: batch " + std::to_string(b) +
                                " has a different row count than the prepared layout");
+    }
+  }
+
+  // A host-tier column reaches exactly one route, and every batch of it has to
+  // take that route: the canonical path below reads batch_source::uncompressed,
+  // which a host batch does not have. The resolver refuses anything else, so a
+  // column arriving here half host or variable-width is a disagreement between
+  // the two, not a shape to handle.
+  bool const any_host = std::any_of(column.batches.begin(),
+                                    column.batches.end(),
+                                    [](batch_source const& b) { return b.is_host(); });
+  if (any_host) {
+    bool const all_host = std::all_of(column.batches.begin(),
+                                      column.batches.end(),
+                                      [](batch_source const& b) { return b.is_host(); });
+    if (!all_host || !cudf::is_fixed_width(column.dtype)) {
+      throw std::runtime_error(
+        "late_mat::materialize: a host-tier origin must be fixed width in every batch");
     }
   }
 

--- a/src/late_mat/multi_source_gather.cu
+++ b/src/late_mat/multi_source_gather.cu
@@ -103,6 +103,56 @@ __global__ void gather_fixed_kernel(void const* const* __restrict__ bases,
   }
 }
 
+/// The block holding logical byte @p byte of a host chunk's allocation, and the
+/// offset within it. The blocks are equally sized, so this is a divide.
+__device__ inline void const* host_byte(void const* const* __restrict__ blocks,
+                                        std::int64_t block_base,
+                                        std::size_t block_size,
+                                        std::int64_t byte)
+{
+  auto const block = block_base + byte / static_cast<std::int64_t>(block_size);
+  auto const off   = byte % static_cast<std::int64_t>(block_size);
+  return static_cast<char const*>(blocks[block]) + off;
+}
+
+template <typename T>
+__global__ void gather_fixed_host_kernel(void const* const* __restrict__ blocks,
+                                         std::int64_t const* __restrict__ block_base,
+                                         std::int64_t const* __restrict__ data_off,
+                                         std::int64_t const* __restrict__ mask_off,
+                                         std::int64_t const* __restrict__ row_start,
+                                         int num_batches,
+                                         std::size_t block_size,
+                                         std::uint64_t const* __restrict__ ids,
+                                         std::int64_t count,
+                                         T* __restrict__ out,
+                                         cudf::bitmask_type* __restrict__ out_mask)
+{
+  auto const stride = static_cast<std::int64_t>(gridDim.x) * blockDim.x;
+  for (std::int64_t i = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; i < count;
+       i += stride) {
+    auto const id    = static_cast<std::int64_t>(ids[i]);
+    int const b      = find_batch(row_start, num_batches, id);
+    auto const local = id - row_start[b];
+    auto const byte  = data_off[b] + local * static_cast<std::int64_t>(sizeof(T));
+    out[i]           = *static_cast<T const*>(host_byte(blocks, block_base[b], block_size, byte));
+    if (out_mask != nullptr) {
+      bool valid = true;
+      if (mask_off[b] >= 0) {
+        auto const word_byte = mask_off[b] + (local / 32) * 4;
+        auto const word      = *static_cast<cudf::bitmask_type const*>(
+          host_byte(blocks, block_base[b], block_size, word_byte));
+        valid = ((word >> (local % 32)) & 1U) != 0U;
+      }
+      if (valid) {
+        cudf::set_bit(out_mask, static_cast<cudf::size_type>(i));
+      } else {
+        cudf::clear_bit(out_mask, static_cast<cudf::size_type>(i));
+      }
+    }
+  }
+}
+
 }  // namespace
 
 void multi_source_gather_fixed(void const* const* bases_dev,
@@ -191,6 +241,67 @@ void multi_source_gather_fixed(void const* const* bases_dev,
                                " is not one of 1, 2, 4, 8, 16");
   }
   throw_on_cuda(cudaPeekAtLastError(), "gather_fixed launch");
+}
+
+void multi_source_gather_fixed_host(void const* const* blocks_dev,
+                                    std::int64_t const* block_base_dev,
+                                    std::int64_t const* data_off_dev,
+                                    std::int64_t const* mask_off_dev,
+                                    std::int64_t const* row_start_dev,
+                                    int num_batches,
+                                    std::size_t block_size,
+                                    std::size_t elem_size,
+                                    std::uint64_t const* ids,
+                                    std::int64_t count,
+                                    void* out,
+                                    std::uint32_t* out_mask,
+                                    rmm::cuda_stream_view stream)
+{
+  if (count == 0) { return; }
+  if (blocks_dev == nullptr || block_base_dev == nullptr || data_off_dev == nullptr ||
+      mask_off_dev == nullptr || row_start_dev == nullptr || ids == nullptr || out == nullptr ||
+      num_batches <= 0 || block_size == 0) {
+    throw std::runtime_error("multi_source_gather: host gather over unbound buffers");
+  }
+  if (elem_size == 0 || block_size % elem_size != 0) {
+    throw std::runtime_error("multi_source_gather: host block size " + std::to_string(block_size) +
+                             " is not a multiple of the element width " +
+                             std::to_string(elem_size));
+  }
+
+  std::int64_t launch_blocks = (count + kBlock - 1) / kBlock;
+  if (launch_blocks > 4096) { launch_blocks = 4096; }  // grid-stride covers the rest
+  auto const grid = static_cast<unsigned>(launch_blocks);
+
+  auto* out_bits = reinterpret_cast<cudf::bitmask_type*>(out_mask);
+
+  auto const launch = [&](auto tag) {
+    using element_t = decltype(tag);
+    gather_fixed_host_kernel<element_t>
+      <<<grid, kBlock, 0, stream.value()>>>(blocks_dev,
+                                            block_base_dev,
+                                            data_off_dev,
+                                            mask_off_dev,
+                                            row_start_dev,
+                                            num_batches,
+                                            block_size,
+                                            ids,
+                                            count,
+                                            static_cast<element_t*>(out),
+                                            out_bits);
+  };
+
+  switch (elem_size) {
+    case 1: launch(std::uint8_t{}); break;
+    case 2: launch(std::uint16_t{}); break;
+    case 4: launch(std::uint32_t{}); break;
+    case 8: launch(std::uint64_t{}); break;
+    case 16: launch(uint4{}); break;
+    default:
+      throw std::runtime_error("multi_source_gather: element width " + std::to_string(elem_size) +
+                               " is not one of 1, 2, 4, 8, 16");
+  }
+  throw_on_cuda(cudaPeekAtLastError(), "gather_fixed_host launch");
 }
 
 }  // namespace sirius::late_mat

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -349,8 +349,17 @@ std::unique_ptr<cudf::table> duckdb_native_gpu_ingestible::post_filter_and_proje
   bool like_swar_fastpath,
   std::shared_ptr<const like_multiliteral_cache> like_cache,
   std::unique_ptr<cudf::column>* /*survivors*/,
-  std::span<std::size_t const> elided)
+  std::span<std::size_t const> elided,
+  std::span<std::size_t const> withheld)
 {
+  // Column withholding is a pinned-parquet arrangement; this reader's output
+  // assembly has no layout to renumber, so a narrowed batch would be assembled
+  // against positions that no longer describe it.
+  if (!withheld.empty()) {
+    throw internal_exception(
+      "[duckdb_native_gpu_ingestible::post_filter_and_project] this reader cannot assemble a "
+      "batch with withheld columns");
+  }
   auto const output_arity = _info->output_types.size();
   auto const decoded_cols =
     _info->projection_ids.empty() ? _info->column_ids.size() : _info->projection_ids.size();

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -1157,9 +1157,15 @@ std::unique_ptr<cudf::table> parquet_gpu_ingestible::post_filter_and_project(
   bool like_swar_fastpath,
   std::shared_ptr<const like_multiliteral_cache> like_cache,
   std::unique_ptr<cudf::column>* survivors,
-  std::span<std::size_t const> elided)
+  std::span<std::size_t const> elided,
+  std::span<std::size_t const> withheld)
 {
   rmm::device_async_resource_ref mr_ref(mem_space.get_default_allocator());
+  if (!withheld.empty() && !elided.empty()) {
+    throw internal_exception(
+      "[parquet_gpu_ingestible::post_filter_and_project] a batch cannot both withhold and elide "
+      "the same output positions");
+  }
 
   // Apply the row filter post-decode when materialization did not — reader-side
   // pushdown was disabled (FLBA-decimal file) or AST translation failed. A
@@ -1215,8 +1221,25 @@ std::unique_ptr<cudf::table> parquet_gpu_ingestible::post_filter_and_project(
   // (non-owning select_columns, no GPU copy). No partitions reach this path, so
   // partition_values is unused. The release below moves the surviving column
   // buffers out.
-  auto assembled =
-    assemble_scan_output(*_plan, std::move(input.table), /*partition_values=*/{}, stream);
+  // D-space positions of the withheld output columns. Every withheld entry must be
+  // DATA-sourced: a PARTITION column is synthesized rather than read, so nothing
+  // could have withheld it, and treating one as withheld would drop a column the
+  // batch never carried in the first place.
+  std::vector<std::size_t> withheld_data;
+  withheld_data.reserve(withheld.size());
+  for (auto const position : withheld) {
+    if (position >= _plan->output_layout.size() ||
+        _plan->output_layout[position].source != scan_plan::output_entry::DATA) {
+      throw internal_exception(
+        "[parquet_gpu_ingestible::post_filter_and_project] withheld output position " +
+        std::to_string(position) + " is not a data column of this scan");
+    }
+    withheld_data.push_back(_plan->output_layout[position].idx);
+  }
+  std::sort(withheld_data.begin(), withheld_data.end());
+
+  auto assembled = assemble_scan_output(
+    *_plan, std::move(input.table), /*partition_values=*/{}, stream, withheld_data);
   SIRIUS_LOG_DEBUG(
     "[parquet_gpu_ingestible::post_filter_and_project] Assembled scan output to plan layout.");
   if (auto const kept =

--- a/src/op/scan/scan_plan.cpp
+++ b/src/op/scan/scan_plan.cpp
@@ -20,6 +20,10 @@
 #include <op/scan/scan_plan.hpp>
 #include <sirius/exception.hpp>
 
+#include <optional>
+#include <span>
+#include <stdexcept>
+
 // duckdb
 #include <duckdb/common/hive_partitioning.hpp>
 
@@ -115,12 +119,75 @@ std::vector<cudf::size_type> output_data_positions(scan_plan const& plan)
   return positions;
 }
 
+std::vector<std::optional<std::size_t>> renumber_output_for_withheld(
+  scan_plan const& plan, std::span<std::size_t const> withheld_data_positions)
+{
+  auto const width = plan.data_columns.size();
+  for (std::size_t i = 0; i < withheld_data_positions.size(); ++i) {
+    if (withheld_data_positions[i] >= width) {
+      throw std::invalid_argument("[assemble_scan_output] withheld data position " +
+                                  std::to_string(withheld_data_positions[i]) +
+                                  " is outside the plan's " + std::to_string(width) +
+                                  " data column(s)");
+    }
+    if (i > 0 && withheld_data_positions[i] <= withheld_data_positions[i - 1]) {
+      throw std::invalid_argument(
+        "[assemble_scan_output] withheld data positions must be ascending and unique");
+    }
+  }
+
+  // Rank among the columns that ARE present; nullopt for the ones that are not.
+  std::vector<std::optional<std::size_t>> rank(width);
+  std::size_t next = 0;
+  auto withheld_at = withheld_data_positions.begin();
+  for (std::size_t d = 0; d < width; ++d) {
+    if (withheld_at != withheld_data_positions.end() && *withheld_at == d) {
+      ++withheld_at;
+      continue;
+    }
+    rank[d] = next++;
+  }
+
+  std::vector<std::optional<std::size_t>> out;
+  out.reserve(plan.output_layout.size());
+  for (auto const& entry : plan.output_layout) {
+    if (entry.source != scan_plan::output_entry::DATA) {
+      out.push_back(std::nullopt);
+      continue;
+    }
+    if (!rank[entry.idx].has_value()) { continue; }  // withheld: no output entry
+    out.push_back(rank[entry.idx]);
+  }
+  return out;
+}
+
 owning_table_view assemble_scan_output(scan_plan const& plan,
                                        owning_table_view&& table,
                                        std::vector<std::string> const& partition_values,
-                                       rmm::cuda_stream_view stream)
+                                       rmm::cuda_stream_view stream,
+                                       std::span<std::size_t const> withheld_data_positions)
 {
   if (!table) { return std::move(table); }
+
+  // A narrowed batch: the producer left some data columns out, so the layout's
+  // D indices no longer describe it and are renumbered before use. Partition
+  // synthesis is not supported alongside it — the caller refuses that pairing
+  // rather than guessing which injected column a withheld one displaced.
+  if (!withheld_data_positions.empty()) {
+    if (plan.output_layout.empty() || plan.has_partitions()) {
+      throw std::invalid_argument(
+        "[assemble_scan_output] a narrowed batch has no assembly for a partitioned or "
+        "count-only plan");
+    }
+    auto const renumbered = renumber_output_for_withheld(plan, withheld_data_positions);
+    std::vector<std::size_t> positions;
+    positions.reserve(renumbered.size());
+    for (auto const& slot : renumbered) {
+      positions.push_back(slot.value());
+    }
+    table.select_columns(positions);
+    return std::move(table);
+  }
 
   // Nothing to reshape (SELECT count(*) — empty output layout). Emitting a
   // 0-column table would erase the row count downstream aggregations consume.

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -506,13 +506,22 @@ std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::execute(
     if (materialized_table.state != filter_state::ROW_FILTERED_AND_PROJECTED) {
       // Elide the deferred columns from the projection: realizing the batch would
       // copy values this scan is about to replace with a rowid.
-      output_table = _ingestible->post_filter_and_project(std::move(materialized_table),
-                                                          *mem_space,
-                                                          stream,
-                                                          like_swar_fastpath,
-                                                          std::move(like_pattern_cache),
-                                                          wants_survivors ? &survivors : nullptr,
-                                                          deferred_output().output_positions);
+      // Two ways for a deferred column not to reach the output, and they are not
+      // interchangeable. WITHHELD: the pinned provider never served it, so the
+      // batch arrives without it and the layout is renumbered past it — no bytes
+      // were read, staged or copied. ELIDED: the batch carries it and the
+      // projection drops it, which still paid for reading it. Withholding wins
+      // where it is admissible; elision is the fallback everywhere else.
+      auto const withheld = withheld_output_positions();
+      output_table        = _ingestible->post_filter_and_project(
+        std::move(materialized_table),
+        *mem_space,
+        stream,
+        like_swar_fastpath,
+        std::move(like_pattern_cache),
+        wants_survivors ? &survivors : nullptr,
+        withheld.empty() ? deferred_output().output_positions : std::span<std::size_t const>{},
+        withheld);
     } else {
       output_table = materialized_table.table.release(stream, mem_space->get_default_allocator());
     }

--- a/src/scan_manager/late_mat_resolver.cpp
+++ b/src/scan_manager/late_mat_resolver.cpp
@@ -20,8 +20,15 @@
 #include "scan_manager/sirius_scan_manager.hpp"
 
 #include <cudf/column/column.hpp>
+#include <cudf/utilities/traits.hpp>
+
+#include <cuda_runtime.h>
 
 #include <api/simpatico_codegen.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <utility>
 
 namespace sirius::scan_manager {
 
@@ -41,13 +48,155 @@ std::int64_t chunk_rows(sirius::device_pin_chunk const& chunk)
   return chunk.columns.front()->size();
 }
 
+/// Whether this device can dereference a registered pinned host pointer as it
+/// stands. The two attributes together are the documented condition under which
+/// a pinned host allocation's own address is a valid device address; without
+/// them the blocks would have to be translated or staged, and a host-tier
+/// deferral is refused instead.
+///
+/// Asked once per process. Host-tier deferral is admitted only for a single-GPU
+/// pin, so there is no second device whose answer could differ.
+bool host_pins_are_device_addressable()
+{
+  static bool const addressable = [] {
+    int device = 0;
+    if (cudaGetDevice(&device) != cudaSuccess) { return false; }
+    int unified      = 0;
+    int host_pointer = 0;
+    if (cudaDeviceGetAttribute(&unified, cudaDevAttrUnifiedAddressing, device) != cudaSuccess) {
+      return false;
+    }
+    if (cudaDeviceGetAttribute(
+          &host_pointer, cudaDevAttrCanUseHostPointerForRegisteredMem, device) != cudaSuccess) {
+      return false;
+    }
+    return unified != 0 && host_pointer != 0;
+  }();
+  return addressable;
+}
+
+/// The uncompressed host representation of chunk @p index, or nullptr when the
+/// chunk is absent or Simpatico-compressed. compressed_host_representation is a
+/// sibling of host_data_representation rather than a subclass, so the cast
+/// separates the two.
+cucascade::host_data_representation const* plain_host_chunk(pinned_entry const& entry,
+                                                            std::size_t index)
+{
+  if (index >= entry.host_chunks.size() || !entry.host_chunks[index]) { return nullptr; }
+  return dynamic_cast<cucascade::host_data_representation const*>(entry.host_chunks[index].get());
+}
+
+/// One host chunk's column, as the blocked gather addresses it, or nullopt when
+/// it cannot be addressed that way. @p dtype carries the carrier agreed so far
+/// and is filled in from the first chunk.
+std::optional<late_mat::batch_source> host_batch_source(pinned_entry const& entry,
+                                                        std::size_t index,
+                                                        std::size_t column_position,
+                                                        cudf::data_type& dtype)
+{
+  auto const* chunk = plain_host_chunk(entry, index);
+  if (chunk == nullptr) { return std::nullopt; }
+  auto const& allocation = chunk->get_host_table();
+  if (!allocation || !allocation->allocation) { return std::nullopt; }
+  if (column_position >= allocation->columns.size()) { return std::nullopt; }
+  auto const& meta = allocation->columns[column_position];
+
+  // Children mean a nested or variable-width column: there is no element width
+  // to multiply a row by, and its offsets would have to be rebuilt against
+  // buffers that are not contiguous.
+  if (!meta.children.empty()) { return std::nullopt; }
+  auto const carrier = host_column_carrier(meta);
+  if (!cudf::is_fixed_width(carrier)) { return std::nullopt; }
+  if (dtype.id() == cudf::type_id::EMPTY) {
+    dtype = carrier;
+  } else if (dtype != carrier) {
+    return std::nullopt;
+  }
+
+  auto const elem_size  = cudf::size_of(carrier);
+  auto const block_size = allocation->allocation->block_size();
+  if (elem_size == 0 || block_size == 0) { return std::nullopt; }
+
+  auto buffers        = std::make_shared<late_mat::host_blocked_buffers>();
+  buffers->block_size = block_size;
+  buffers->blocks.reserve(allocation->allocation->size());
+  for (std::size_t block = 0; block < allocation->allocation->size(); ++block) {
+    buffers->blocks.push_back(allocation->allocation->at(block).data());
+  }
+  auto const addressable_bytes = buffers->blocks.size() * block_size;
+
+  auto const rows = static_cast<std::int64_t>(meta.num_rows);
+  if (rows > 0) {
+    // A zero-row chunk carries no data buffer at all; anything else must.
+    if (!meta.has_data) { return std::nullopt; }
+    // The gather turns a row into a byte offset by multiplying, then divides
+    // that by the block size. An element straddling a block boundary — or a
+    // buffer not starting on an element — has no address it can compute.
+    if (block_size % elem_size != 0 || meta.data_offset % elem_size != 0) { return std::nullopt; }
+    if (meta.data_offset + (static_cast<std::size_t>(rows) * elem_size) > addressable_bytes) {
+      return std::nullopt;
+    }
+    buffers->data_offset = meta.data_offset;
+  }
+
+  if (meta.has_null_mask) {
+    // Validity is read one mask word at a time, in the same coordinates.
+    constexpr std::size_t kMaskWord = sizeof(cudf::bitmask_type);
+    if (block_size % kMaskWord != 0 || meta.null_mask_offset % kMaskWord != 0) {
+      return std::nullopt;
+    }
+    if (meta.null_mask_offset + meta.null_mask_size > addressable_bytes) { return std::nullopt; }
+    buffers->has_null_mask    = true;
+    buffers->null_mask_offset = meta.null_mask_offset;
+  }
+
+  late_mat::batch_source source;
+  source.num_rows = rows;
+  source.host     = std::move(buffers);
+  return source;
+}
+
+/// Rows in host chunk @p index, read off whichever column the chunk holds first
+/// — every column of a chunk shares its row count.
+std::optional<std::int64_t> host_chunk_rows(pinned_entry const& entry, std::size_t index)
+{
+  auto const* chunk = plain_host_chunk(entry, index);
+  if (chunk == nullptr) { return std::nullopt; }
+  auto const& allocation = chunk->get_host_table();
+  if (!allocation || allocation->columns.empty()) { return std::nullopt; }
+  return static_cast<std::int64_t>(allocation->columns.front().num_rows);
+}
+
 }  // namespace
+
+bool host_pinned_column_is_addressable(pinned_entry const& entry, std::size_t column_position)
+{
+  if (entry.tier != cucascade::memory::Tier::HOST) { return false; }
+  if (entry.host_chunks.empty()) { return false; }
+  if (!host_pins_are_device_addressable()) { return false; }
+  cudf::data_type dtype{cudf::type_id::EMPTY};
+  for (std::size_t index = 0; index < entry.host_chunks.size(); ++index) {
+    if (!host_batch_source(entry, index, column_position, dtype)) { return false; }
+  }
+  return true;
+}
 
 std::optional<late_mat::pinned_table_layout> resolve_pinned_layout(
   late_mat::column_origin const& origin)
 {
   auto const* entry = origin.resolve();
   if (entry == nullptr) { return std::nullopt; }
+  if (entry->tier == cucascade::memory::Tier::HOST) {
+    std::vector<std::int64_t> host_rows;
+    host_rows.reserve(entry->host_chunks.size());
+    for (std::size_t index = 0; index < entry->host_chunks.size(); ++index) {
+      auto const rows_in_chunk = host_chunk_rows(*entry, index);
+      if (!rows_in_chunk) { return std::nullopt; }
+      host_rows.push_back(*rows_in_chunk);
+    }
+    if (host_rows.empty()) { return std::nullopt; }
+    return late_mat::pinned_table_layout::from_batch_rows(std::move(host_rows), origin.generation);
+  }
   if (entry->tier != cucascade::memory::Tier::GPU) { return std::nullopt; }
 
   std::vector<std::int64_t> rows;
@@ -78,13 +227,24 @@ std::optional<late_mat::pinned_column_view> resolve_pinned_column(
 {
   auto const* entry = origin.resolve();
   if (entry == nullptr) { return std::nullopt; }
-  if (entry->tier != cucascade::memory::Tier::GPU) { return std::nullopt; }
 
   auto const& names = entry->cache_info.column_names();
   if (origin.column_pos >= names.size()) { return std::nullopt; }
 
   late_mat::pinned_column_view view;
   view.pin_generation = origin.generation;
+
+  if (entry->tier == cucascade::memory::Tier::HOST) {
+    if (entry->host_chunks.empty() || !host_pins_are_device_addressable()) { return std::nullopt; }
+    for (std::size_t index = 0; index < entry->host_chunks.size(); ++index) {
+      auto source = host_batch_source(*entry, index, origin.column_pos, view.dtype);
+      if (!source) { return std::nullopt; }
+      view.batches.push_back(std::move(*source));
+    }
+    if (view.batches.empty()) { return std::nullopt; }
+    return view;
+  }
+  if (entry->tier != cucascade::memory::Tier::GPU) { return std::nullopt; }
 
   if (uses_device_chunks(*entry)) {
     // Every uncompressed gather shape (single-batch, multi-batch fixed-width, multi-batch

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -828,6 +828,41 @@ struct late_mat_outcome {
   op::sirius_physical_operator const* port = nullptr;
 };
 
+/// Deferred output positions the scan may leave unserved, or empty when it may not.
+///
+/// Withholding is admissible only where the batch that arrives without those
+/// columns can still be assembled by a renumbered layout, and where nothing but
+/// the substitution reads them:
+///
+///  * a deferral must be installed, with at least one position;
+///  * every deferred position must be an ordinary output column of a parquet
+///    plan (the duckdb-native reader has no layout to renumber, and a partition
+///    column is synthesized rather than read);
+///  * the scan must not RESTRICT ROWS. A post-decode filter evaluates over the
+///    reader's D-order batch, so a column missing from it shifts every filter
+///    reference past it — and a deferred column can itself be a filter column.
+///
+/// Ascending and duplicate-free, which the erase below depends on.
+std::vector<std::size_t> admissible_withheld_positions(op::scan::sirius_gpu_scan_operator& scan_op,
+                                                       std::size_t served_width)
+{
+  auto const& deferred = scan_op.deferred_output();
+  if (deferred.output_positions.empty()) { return {}; }
+  if (scan_op.get_ingestible().has_row_filter()) { return {}; }
+  auto const* parquet = dynamic_cast<op::scan::parquet_ingestible_table_info const*>(
+    &scan_op.get_ingestible().table_info());
+  if (parquet == nullptr) { return {}; }
+
+  std::vector<std::size_t> positions(deferred.output_positions.begin(),
+                                     deferred.output_positions.end());
+  std::sort(positions.begin(), positions.end());
+  if (std::adjacent_find(positions.begin(), positions.end()) != positions.end()) { return {}; }
+  // A position outside the served set has no slot to drop, and withholding every
+  // column would leave a batch with no rows to count.
+  if (positions.back() >= served_width || positions.size() >= served_width) { return {}; }
+  return positions;
+}
+
 late_mat_outcome install_late_materialization(op::scan::sirius_gpu_scan_operator& scan_op,
                                               pinned_entry const& entry,
                                               std::span<std::size_t const> selected_columns,
@@ -1693,13 +1728,36 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query,
     } else if (late_mat.port != nullptr) {
       installed_rides.push_back(installed_ride{late_mat.port, assignment.op});
     }
+    // Withhold the deferred columns from what the provider serves, when that is
+    // admissible. The substitution overwrites them with a rowid, so serving them
+    // buys nothing and on a HOST-tier pin costs a bulk transfer across the link.
+    // Refusing leaves the ordinary path, which serves them and elides them from
+    // the projection instead.
+    auto served_columns = assignment.columns;
+    auto served_targets = assignment.op->normalization_targets();
+    auto const withheld = admissible_withheld_positions(*assignment.op, served_columns.size());
+    if (!withheld.empty()) {
+      // Served slot p is output column p for every output column, so dropping the
+      // deferred output positions from both keeps the provider's two parallel
+      // views of a slot — its entry column and its carrier target — in step.
+      for (auto it = withheld.rbegin(); it != withheld.rend(); ++it) {
+        served_columns.erase(served_columns.begin() + static_cast<std::ptrdiff_t>(*it));
+        if (*it < served_targets.size()) {
+          served_targets.erase(served_targets.begin() + static_cast<std::ptrdiff_t>(*it));
+        }
+      }
+      assignment.op->set_withheld_output_positions(withheld);
+      SIRIUS_LOG_INFO("[late-mat] operator {}: withholding {} deferred column(s) from the scan",
+                      assignment.op->get_operator_id(),
+                      withheld.size());
+    }
     auto provider = make_provider_for_pinned_entry(*assignment.entry,
-                                                   assignment.columns,
+                                                   served_columns,
                                                    std::move(assignment.plan),
                                                    assignment.op->batch_telemetry(),
                                                    std::move(masks),
                                                    std::move(delta_splits),
-                                                   assignment.op->normalization_targets(),
+                                                   served_targets,
                                                    assignment.op->has_physical_overrides(),
                                                    std::move(pushdown_req),
                                                    std::move(dynamic_filters));

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -27,6 +27,7 @@
 #include "io/parquet_helpers.hpp"
 #include "io/rest/rest_ioctx.hpp"
 #include "io/sirius_datasource.hpp"
+#include "late_mat/host_gather_policy.hpp"
 #include "late_mat/pin_uniqueness.hpp"
 #include "log/logging.hpp"
 #include "memory/topology_index.hpp"

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -43,6 +43,7 @@
 #include "op/sirius_physical_operator_type.hpp"
 #include "planner/late_mat_plan_pass.hpp"
 #include "planner/query.hpp"
+#include "scan_manager/late_mat_resolver.hpp"
 #include "scan_manager/round_robin_strategy.hpp"
 
 #include <cudf/column/column_view.hpp>
@@ -87,15 +88,6 @@
 
 namespace sirius::scan_manager {
 
-namespace {
-
-using sirius::pinned_column_storage_matrix;
-using sirius::pinned_column_storage_meta;
-
-// Actual cuDF carrier of one column of an uncompressed pinned host chunk, rebuilt from the
-// chunk's host column metadata. Keyed on the DECIMAL type ids, not on a nonzero scale: a
-// DECIMAL(p,0) column has cuDF scale 0 and must still take the two-argument fixed-point
-// constructor.
 cudf::data_type host_column_carrier(cucascade::memory::column_metadata const& meta)
 {
   auto const id         = static_cast<cudf::type_id>(meta.type_id);
@@ -106,9 +98,15 @@ cudf::data_type host_column_carrier(cucascade::memory::column_metadata const& me
 
 namespace {
 
-/// Chunks a GPU-tier entry holds, whichever storage form it uses.
+using sirius::pinned_column_storage_matrix;
+using sirius::pinned_column_storage_meta;
+
+namespace {
+
+/// Chunks an entry holds, whichever storage form it uses.
 std::size_t pinned_chunk_count(pinned_entry const& entry)
 {
+  if (entry.tier == cucascade::memory::Tier::HOST) { return entry.host_chunks.size(); }
   if (!entry.device_chunks.empty()) { return entry.device_chunks.size(); }
   auto const& names = entry.cache_info.column_names();
   if (names.empty()) { return 0; }
@@ -116,10 +114,23 @@ std::size_t pinned_chunk_count(pinned_entry const& entry)
   return it == entry.data_batches_by_column.end() ? 0 : it->second.size();
 }
 
-/// Rows in one chunk of a GPU-tier entry. Every column of a chunk shares its
-/// row count, so any present one answers.
+/// Rows in one chunk of an entry. Every column of a chunk shares its row count,
+/// so any present one answers.
 std::int64_t pinned_chunk_rows(pinned_entry const& entry, std::size_t index)
 {
+  if (entry.tier == cucascade::memory::Tier::HOST) {
+    if (index >= entry.host_chunks.size() || !entry.host_chunks[index]) { return 0; }
+    if (auto const* compressed = dynamic_cast<sirius::compressed_host_representation const*>(
+          entry.host_chunks[index].get())) {
+      return compressed->num_rows();
+    }
+    auto const* host =
+      dynamic_cast<cucascade::host_data_representation const*>(entry.host_chunks[index].get());
+    if (host == nullptr || !host->get_host_table() || host->get_host_table()->columns.empty()) {
+      return 0;
+    }
+    return static_cast<std::int64_t>(host->get_host_table()->columns.front().num_rows);
+  }
   if (!entry.device_chunks.empty()) {
     if (index >= entry.device_chunks.size()) { return 0; }
     auto const& chunk = entry.device_chunks[index];
@@ -189,8 +200,9 @@ struct cached_databatch_provider : public databatch_provider {
     if (!_entry.late_mat_handle) { return decline("the pinned entry has no late-mat handle"); }
     if (has_any_mask(_mvcc_masks)) { return decline("the scan carries MVCC keep-masks"); }
     if (!_delta_splits.empty()) { return decline("the scan carries insert-delta splits"); }
-    if (_entry.tier != cucascade::memory::Tier::GPU) {
-      return decline("the pinned entry is not device-resident");
+    if (_entry.tier != cucascade::memory::Tier::GPU &&
+        _entry.tier != cucascade::memory::Tier::HOST) {
+      return decline("the pinned entry is neither device- nor host-resident");
     }
 
     auto columns = std::make_shared<std::vector<late_mat::column_origin>>();
@@ -626,6 +638,21 @@ std::vector<cudf::data_type> physical_schema_of(op::sirius_physical_operator con
 [[nodiscard]] std::optional<std::size_t> pinned_column_null_count(pinned_entry const& entry,
                                                                   std::size_t column_position)
 {
+  if (entry.tier == cucascade::memory::Tier::HOST) {
+    // A host chunk records its per-column null count at pin time; a compressed
+    // one has no per-column layout to record it against.
+    std::size_t host_nulls = 0;
+    for (auto const& chunk : entry.host_chunks) {
+      auto const* host = dynamic_cast<cucascade::host_data_representation const*>(chunk.get());
+      if (host == nullptr || !host->get_host_table()) { return std::nullopt; }
+      auto const& columns = host->get_host_table()->columns;
+      if (column_position >= columns.size()) { return std::nullopt; }
+      auto const recorded = columns[column_position].null_count;
+      if (recorded < 0) { return std::nullopt; }
+      host_nulls += static_cast<std::size_t>(recorded);
+    }
+    return host_nulls;
+  }
   if (entry.tier != cucascade::memory::Tier::GPU) { return std::nullopt; }
   std::size_t nulls = 0;
   if (!entry.device_chunks.empty()) {
@@ -649,11 +676,14 @@ std::vector<cudf::data_type> physical_schema_of(op::sirius_physical_operator con
 }
 
 /// Whether this column's pin is uncompressed — every such gather shape (single-batch,
-/// multi-batch fixed-width, multi-batch variable-width) propagates validity. Must agree with
-/// resolve_pinned_column's own check.
+/// multi-batch fixed-width, multi-batch variable-width, and the host-tier blocked gather)
+/// propagates validity. Must agree with resolve_pinned_column's own check.
 [[nodiscard]] bool pinned_column_nulls_are_safe(pinned_entry const& entry,
                                                 std::size_t column_position)
 {
+  if (entry.tier == cucascade::memory::Tier::HOST) {
+    return host_pinned_column_is_addressable(entry, column_position);
+  }
   if (entry.tier != cucascade::memory::Tier::GPU) { return false; }
   if (!entry.device_chunks.empty()) {
     return std::all_of(
@@ -813,13 +843,17 @@ late_mat_outcome install_late_materialization(op::scan::sirius_gpu_scan_operator
   };
 
   if (!entry.late_mat_handle) { return decline("the pinned entry has no late-mat handle"); }
-  if (entry.tier != cucascade::memory::Tier::GPU) {
-    return decline("the pinned entry is not device-resident");
+  bool const host_tier = entry.tier == cucascade::memory::Tier::HOST;
+  if (entry.tier != cucascade::memory::Tier::GPU && !host_tier) {
+    return decline("the pinned entry is neither device- nor host-resident");
   }
   if (!single_gpu_pin) {
+    // A device chunk could be dereferenced from the wrong GPU; a host chunk's
+    // blocks are mapped for the context that registered them and need not be
+    // readable from another. Neither is checked at materialize time.
     return decline(
       "more than one GPU space is active; materialization is not yet device-aware and cannot "
-      "safely gather a chunk pinned on a different GPU than the consumer");
+      "safely gather a chunk pinned outside the consumer's GPU");
   }
   if (!serves_whole_chunks) {
     return decline("a served batch is not one pinned chunk's whole row span");
@@ -866,6 +900,11 @@ late_mat_outcome install_late_materialization(op::scan::sirius_gpu_scan_operator
   late_mat::defer_policy policy;
   if (compressed_origin) {
     policy.min_value_bytes = late_mat::min_value_bytes_compressed(policy.min_value_bytes);
+  }
+  if (host_tier) {
+    // Materializing costs more from the host than from the device, so the ride
+    // has to save proportionally more to repay it.
+    policy.min_value_x_boundaries *= late_mat::host_tier_cost_multiplier();
   }
   auto const planned = sirius::planner::plan_deferral(scan_op, policy);
   for (auto const& outcome : planned.census) {
@@ -975,6 +1014,21 @@ late_mat_outcome install_late_materialization(op::scan::sirius_gpu_scan_operator
     return decline(
       "a join on the ride multiplied the rows and nothing collapsed them again, so materializing "
       "at the port would gather the fan-out rather than the scan's rows");
+  }
+
+  // A host-tier column is gathered where it lies, which only some of them can
+  // be. Refusing here rather than at the port matters: by the time the port
+  // resolves the origin the scan has already emitted rowids in place of the
+  // values, so a refusal there is a thrown query, not a slower one.
+  if (host_tier) {
+    for (auto const position : planned.positions) {
+      if (position >= selected_columns.size()) { continue; }  // caught again, and reported, below
+      if (!host_pinned_column_is_addressable(entry, selected_columns[position])) {
+        return decline(
+          "a deferred column's host pin cannot be gathered where it lies — it is compressed, not "
+          "fixed width, or its blocks do not divide on element boundaries");
+      }
+    }
   }
 
   // The pinned SOURCE being nullable is only the pin's to answer, so it's checked here,
@@ -1173,6 +1227,24 @@ void install_rider_deferrals(std::vector<rider_candidate> const& candidates,
       if (!proof.has_value()) {
         decline(
           "neither its own columns nor a join with the ride's scan determines its row in a group");
+        continue;
+      }
+    }
+
+    // Same host-tier gather restriction as the primary bundle's install, above.
+    if (entry.tier == cucascade::memory::Tier::HOST) {
+      bool addressable = true;
+      for (auto const position : planned.positions) {
+        if (position >= candidate.columns.size()) { continue; }  // caught again below
+        if (!host_pinned_column_is_addressable(entry, candidate.columns[position])) {
+          addressable = false;
+          break;
+        }
+      }
+      if (!addressable) {
+        decline(
+          "a deferred column's host pin cannot be gathered where it lies — it is compressed, not "
+          "fixed width, or its blocks do not divide on element boundaries");
         continue;
       }
     }

--- a/test/cpp/integration/test_late_mat_host_query.cpp
+++ b/test/cpp/integration/test_late_mat_host_query.cpp
@@ -57,11 +57,12 @@ constexpr std::int64_t kCustomers = 5'000;
 constexpr std::int64_t kOrders    = 15'000;
 constexpr std::int64_t kLines     = 30'000;
 
-/// Payload width. This shape crosses 6 ports, and the host-tier product floor is
-/// 128 x 12 = 1536, so the bundle has to save at least 256 B/row. 40 BIGINTs save
-/// 40 x 8 - 8 = 312, clearing it with room; 32 would sit just under at 248.
-/// Widening this is the knob if the floor or the shape moves.
-constexpr int kPayloadColumns = 40;
+/// Payload width. The bundle must clear the host-tier product floor, which is
+/// 128 times a multiplier the startup probe measures (13 on a GB300). The ride
+/// carries one rowid plus a placeholder per remaining column, so N BIGINTs save
+/// 8N - (8 + N - 1) per row, and this shape crosses 6 ports. 56 columns save 385
+/// B/row for 2310, clearing a 1664 floor; 40 would sit just under at 1638.
+constexpr int kPayloadColumns = 56;
 
 std::string payload_names(char const* prefix)
 {

--- a/test/cpp/integration/test_late_mat_host_query.cpp
+++ b/test/cpp/integration/test_late_mat_host_query.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The same end-to-end shape as test_late_mat_deferred_query.cpp, over a pin that
+// lives on the HOST tier. GPU required, and SIRIUS_EXP_LATE_MAT must be set in
+// the ENVIRONMENT — the gate is read once per process, so this case skips rather
+// than lying when it is off.
+//
+// What is different from the GPU case, and why the payload looks the way it
+// does:
+//
+//  * The payload columns are FIXED WIDTH. A host chunk stores its columns over
+//    pinned blocks that are not contiguous, so a variable-width column has no
+//    offsets the gather can rebuild and is refused; the GPU case's three wide
+//    strings would install nothing here.
+//  * There are many of them. Materializing from the host costs more than from
+//    the device, so the value floor is multiplied (host_tier_cost_multiplier),
+//    and the bundle has to be correspondingly wider to clear it. The count is
+//    sized to clear the default floor even at the minimum crossing count.
+//
+// THE ASSERTION IS TWO-PART, and the second half is what makes the first mean
+// anything: the answer must match the CPU's, AND a deferral must actually have
+// installed. A query that deferred nothing also returns the right answer.
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <late_mat/column_origin.hpp>
+#include <late_mat/defer_directive.hpp>
+#include <utils/parquet_fixture_utils.hpp>
+#include <utils/sirius_test_env.hpp>
+
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr std::int64_t kCustomers = 5'000;
+constexpr std::int64_t kOrders    = 15'000;
+constexpr std::int64_t kLines     = 30'000;
+
+/// Payload width. This shape crosses 6 ports, and the host-tier product floor is
+/// 128 x 12 = 1536, so the bundle has to save at least 256 B/row. 40 BIGINTs save
+/// 40 x 8 - 8 = 312, clearing it with room; 32 would sit just under at 248.
+/// Widening this is the knob if the floor or the shape moves.
+constexpr int kPayloadColumns = 40;
+
+std::string payload_names(char const* prefix)
+{
+  std::string out;
+  for (int i = 0; i < kPayloadColumns; ++i) {
+    out += std::string(", ") + prefix + "p" + std::to_string(i);
+  }
+  return out;
+}
+
+std::string payload_definitions()
+{
+  std::string out;
+  for (int i = 0; i < kPayloadColumns; ++i) {
+    // Distinct per column and per row, so a gather that read the wrong column or
+    // the wrong row cannot coincide with the right answer.
+    out += ", CAST(range * 100 + " + std::to_string(i) + " AS BIGINT) AS p" + std::to_string(i);
+  }
+  return out;
+}
+
+/// Two INNER joins, then a GROUP BY on the key and the whole payload — the
+/// group-by-rowid shape, materializing one row per group at the far end.
+std::string query_for(fs::path const& customer, fs::path const& orders, fs::path const& lines)
+{
+  return "SELECT c.c_custkey" + payload_names("c.") +
+         ", count(*) AS n "
+         "FROM read_parquet('" +
+         customer.string() +
+         "') c "
+         "JOIN read_parquet('" +
+         orders.string() +
+         "') o ON c.c_custkey = o.o_custkey "
+         "JOIN read_parquet('" +
+         lines.string() +
+         "') l ON o.o_orderkey = l.l_orderkey "
+         "GROUP BY c.c_custkey" +
+         payload_names("c.") + " ORDER BY c.c_custkey";
+}
+
+void generate_parquet(fs::path const& customer, fs::path const& orders, fs::path const& lines)
+{
+  sirius::test::scoped_sirius_disable disable_sirius;
+  duckdb::DuckDB gen_db(nullptr);
+  duckdb::Connection gen(gen_db);
+  auto r = gen.Query("COPY (SELECT range AS c_custkey" + payload_definitions() + " FROM range(" +
+                     std::to_string(kCustomers) + ")) TO " +
+                     sirius::test::sql_literal(customer.string()) + " (FORMAT PARQUET);");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
+
+  r = gen.Query(
+    "COPY (SELECT range AS o_orderkey, "
+    "             range % " +
+    std::to_string(kCustomers) +
+    " AS o_custkey, "
+    "             CAST(range % 3 AS VARCHAR) AS o_status "
+    "      FROM range(" +
+    std::to_string(kOrders) + ")) TO " + sirius::test::sql_literal(orders.string()) +
+    " (FORMAT PARQUET);");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
+
+  r = gen.Query("COPY (SELECT range AS l_linekey, range % " + std::to_string(kOrders) +
+                " AS l_orderkey "
+                "      FROM range(" +
+                std::to_string(kLines) + ")) TO " + sirius::test::sql_literal(lines.string()) +
+                " (FORMAT PARQUET);");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
+}
+
+std::vector<std::string> rows_of(duckdb::MaterializedQueryResult& result)
+{
+  std::vector<std::string> rows;
+  for (duckdb::idx_t i = 0; i < result.RowCount(); ++i) {
+    std::string row;
+    for (duckdb::idx_t c = 0; c < result.ColumnCount(); ++c) {
+      row += result.GetValue(c, i).ToString() + "|";
+    }
+    rows.push_back(std::move(row));
+  }
+  return rows;
+}
+
+/// The ground truth: the same query on DuckDB with Sirius disabled.
+std::vector<std::string> cpu_answer(fs::path const& customer,
+                                    fs::path const& orders,
+                                    fs::path const& lines)
+{
+  sirius::test::scoped_sirius_disable disable_sirius;
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto r = con.Query(query_for(customer, orders, lines));
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
+  return rows_of(*r);
+}
+
+void write_config(fs::path const& yaml_path)
+{
+  std::ofstream f(yaml_path);
+  f << "sirius:\n"
+       "  topology:\n"
+       "    num_gpus: 1\n"
+       "  memory:\n"
+       "    gpu:\n"
+       "      usage_limit_fraction: 0.4\n"
+       "      reservation_limit_fraction: 1.0\n"
+       "    host:\n"
+       "      capacity_bytes: 32000000000\n"
+       "      initial_number_pools: 10\n"
+       "      pool_size: 512\n"
+       "      block_size: 1048576\n"
+       "  executor:\n"
+       "    pipeline:\n"
+       "      num_threads: 4\n"
+       "    task_creator:\n"
+       "      num_threads: 2\n"
+       "    downgrade:\n"
+       "      num_threads: 1\n"
+       "      monitor_period: 10ms\n"
+       "  operator_params:\n"
+       "    scan_task_batch_size: 100000000\n"
+       "    max_sort_partition_bytes: 0\n"
+       "    hash_partition_bytes: 100000000\n"
+       "    concat_batch_bytes: 100000000\n"
+       "    max_build_hash_table_bytes: 90000000\n";
+}
+
+}  // namespace
+
+TEST_CASE("a deferred payload rides a real plan off a host-tier pin",
+          "[late_mat][deferred_query][host_pin]")
+{
+  if (!sirius::late_mat::late_mat_enabled()) {
+    WARN("SIRIUS_EXP_LATE_MAT unset; skipping the end-to-end host-tier deferral case");
+    return;
+  }
+  if (sirius::test::g_shared_env && sirius::test::g_shared_env->is_active()) {
+    sirius::test::g_shared_env->pause();
+  }
+  if (sirius::test::g_integration_env && sirius::test::g_integration_env->is_active()) {
+    sirius::test::g_integration_env->pause();
+  }
+  if (sirius::test::g_integration_env_2gpu && sirius::test::g_integration_env_2gpu->is_active()) {
+    sirius::test::g_integration_env_2gpu->pause();
+  }
+
+  sirius::test::scratch_dir scratch{"late_mat_host_query"};
+  auto const& tmp     = scratch.path();
+  auto const customer = tmp / "customer.parquet";
+  auto const orders   = tmp / "orders.parquet";
+  auto const lines    = tmp / "lineitem.parquet";
+  generate_parquet(customer, orders, lines);
+  auto const expected = cpu_answer(customer, orders, lines);
+  REQUIRE_FALSE(expected.empty());
+
+  auto yaml_path = tmp / "late_mat_host_query.yaml";
+  write_config(yaml_path);
+
+  sirius::test::shared_test_env local_env(yaml_path);
+  auto con = local_env.make_connection();
+  auto fb  = con.Query("SET enable_duckdb_fallback = false;");
+  REQUIRE(fb);
+  REQUIRE_FALSE(fb->HasError());
+
+  // c_custkey rides REAL — it is the join key and a group key — so proving it
+  // distinct over the pin is what admits the ride past the aggregates. The probe
+  // runs on the GPU table each batch is materialized as, before it is copied to
+  // the host, so a host pin proves its columns exactly as a GPU pin does.
+  ::setenv("SIRIUS_EXP_LATE_MAT_PIN_UNIQUE_COLS", "c_custkey", 1);
+
+  auto pin = con.Query("CALL pin_table(" + sirius::test::sql_literal(customer.string()) +
+                       ", tier='host', name='late_mat_host_customer');");
+  REQUIRE(pin);
+  if (pin->HasError()) { UNSCOPED_INFO("pin_table error: " << pin->GetError()); }
+  REQUIRE_FALSE(pin->HasError());
+
+  auto const before = sirius::late_mat::deferrals_installed();
+  auto res          = con.Query(query_for(customer, orders, lines));
+  REQUIRE(res);
+  if (res->HasError()) { UNSCOPED_INFO("query error: " << res->GetError()); }
+  REQUIRE_FALSE(res->HasError());
+  REQUIRE(rows_of(*res) == expected);
+
+  // Without this the case above passes just as well on a query that deferred
+  // nothing, which is the failure mode a correctness test is least able to see.
+  REQUIRE(sirius::late_mat::deferrals_installed() > before);
+
+  ::unsetenv("SIRIUS_EXP_LATE_MAT_PIN_UNIQUE_COLS");
+  auto unpin = con.Query("CALL unpin_table('late_mat_host_customer');");
+  REQUIRE(unpin);
+  REQUIRE_FALSE(unpin->HasError());
+}

--- a/test/cpp/late_mat/test_defer_policy.cpp
+++ b/test/cpp/late_mat/test_defer_policy.cpp
@@ -24,6 +24,7 @@
 #include <catch.hpp>
 #include <late_mat/defer_policy.hpp>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -55,7 +56,26 @@ TEST_CASE("a wide bundle over a long ride installs", "[late_mat][defer]")
   auto const out = choose_deferrals({bundle("agg", {25, 40, 89}, 6)});
   REQUIRE(out.size() == 1);
   REQUIRE(out[0].installed());
-  REQUIRE(out[0].net_value_bytes == 25 + 40 + 89 - 8);
+  // The carrier is the rowid plus a placeholder for each column past the first.
+  REQUIRE(out[0].net_value_bytes == 25 + 40 + 89 - (8 + 2));
+}
+
+TEST_CASE("the carrier costs a placeholder for every column past the first", "[late_mat][defer]")
+{
+  // A ride substitutes ONE rowid and keeps the other positions occupied with
+  // 1-byte placeholders, so a five-column bundle costs 12 B/row to carry. The
+  // placeholders are what a marginal multi-column bundle turns on: they are
+  // small per row and the floor they have to clear is a product.
+  defer_candidate five;
+  five.slot = "agg";
+  for (int i = 0; i < 5; ++i) {
+    five.columns.push_back(defer_column{static_cast<std::uint32_t>(i), 24});
+  }
+  REQUIRE(five.carrier_bytes(8) == 12);
+  REQUIRE(five.net_value_bytes(8) == 5 * 24 - 12);
+
+  // One column carries no placeholder at all.
+  REQUIRE(bundle("agg", {24}, 6).carrier_bytes(8) == 8);
 }
 
 TEST_CASE("a narrow dimension ride over a short one is refused", "[late_mat][defer]")
@@ -81,16 +101,20 @@ TEST_CASE("a wide bundle over a short ride is refused", "[late_mat][defer]")
   REQUIRE(out[0].refusal == defer_refusal::too_short_a_ride);
 }
 
-TEST_CASE("the floor is net of the rowid the ride carries instead", "[late_mat][defer]")
+TEST_CASE("the floor is net of what the ride carries instead", "[late_mat][defer]")
 {
   defer_policy const policy;  // 128 value x crossings, 8 B rowid
   // Over 6 crossings the floor needs 22 B net: 29 B of values is 21 net, and
   // 21 * 6 = 126 — just under.
   REQUIRE(choose_deferrals({bundle("agg", {29}, 6)}, policy)[0].refusal ==
           defer_refusal::below_value_x_boundaries);
-  // 30 B is 22 net and 132 — just over. The rowid is the difference, not a
+  // 30 B is 22 net and 132 — just over. The carrier is the difference, not a
   // rounding.
   REQUIRE(choose_deferrals({bundle("agg", {30}, 6)}, policy)[0].installed());
+  // Split the same 30 B across two columns and the placeholder pushes it back
+  // under: 29 net over 6 is 126.
+  REQUIRE(choose_deferrals({bundle("agg", {15, 15}, 6)}, policy)[0].refusal ==
+          defer_refusal::below_value_x_boundaries);
 }
 
 TEST_CASE("a wider bundle evicts a narrower one holding the same slot", "[late_mat][defer]")

--- a/test/cpp/late_mat/test_late_mat_host_pin.cpp
+++ b/test/cpp/late_mat/test_late_mat_host_pin.cpp
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [late_mat][host_pin] — materializing out of a HOST-tier pin. GPU required.
+//
+// A host chunk stores every pinned column in one representation, over pinned
+// blocks that are not contiguous with one another, which is the opposite
+// orientation from a GPU pin and has no cudf::column_view to gather from. The
+// resolver bridges the two by handing the materializer the blocks plus a byte
+// offset, and the gather reads the rows where they lie.
+//
+// The pin holds row i at value i, so a materialized value IS its own global row
+// id: a resolver that mis-orders the chunks, or a gather that translates an
+// offset wrongly, produces a column that names the rows it actually read.
+//
+// The chunks here are deliberately larger than one 1 MiB block, because the
+// whole point of the blocked addressing is the boundary a column's buffer
+// crosses; a chunk that fits in one block would exercise none of it.
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+#include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/mr/per_device_resource.hpp>
+
+#include <cuda_runtime.h>
+
+#include <catch.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
+#include <cucascade/memory/memory_space.hpp>
+#include <data/sirius_converter_registry.hpp>
+#include <late_mat/materialize.hpp>
+#include <memory/sirius_memory_reservation_manager.hpp>
+#include <scan_manager/late_mat_resolver.hpp>
+#include <scan_manager/sirius_scan_manager.hpp>
+#include <sirius_context.hpp>
+#include <utils/utils.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <vector>
+
+using cucascade::memory::Tier;
+using sirius::late_mat::column_origin;
+using sirius::late_mat::materialize;
+using sirius::late_mat::pin_entry_handle;
+using sirius::late_mat::prepared_selection;
+using sirius::late_mat::row_id_list;
+using sirius::scan_manager::host_pinned_column_is_addressable;
+using sirius::scan_manager::pinned_entry;
+using sirius::scan_manager::resolve_pinned_column;
+using sirius::scan_manager::resolve_pinned_layout;
+
+namespace {
+
+/// Enough rows that a single INT64 column's buffer spans several 1 MiB blocks.
+constexpr std::int64_t kRowsPerChunk = 400'000;
+
+std::filesystem::path test_config_path()
+{
+  return std::filesystem::path(__FILE__).parent_path().parent_path() / "operator" / "result.yaml";
+}
+
+/// Every third row null, so the mask has both states in every word.
+bool row_is_valid(std::int64_t global_row) { return global_row % 3 != 0; }
+
+/// A STRING column of @p values, built by hand so the fixture depends on no
+/// test-utility template.
+std::unique_ptr<cudf::column> make_labels(std::vector<std::string> const& values,
+                                          rmm::cuda_stream_view stream)
+{
+  auto const mr = rmm::mr::get_current_device_resource_ref();
+  std::vector<cudf::size_type> offsets;
+  offsets.reserve(values.size() + 1);
+  std::string chars;
+  cudf::size_type cursor = 0;
+  for (auto const& v : values) {
+    offsets.push_back(cursor);
+    chars += v;
+    cursor += static_cast<cudf::size_type>(v.size());
+  }
+  offsets.push_back(cursor);
+
+  auto offsets_col = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                               static_cast<cudf::size_type>(offsets.size()),
+                                               cudf::mask_state::UNALLOCATED,
+                                               stream,
+                                               mr);
+  cudaMemcpyAsync(offsets_col->mutable_view().data<cudf::size_type>(),
+                  offsets.data(),
+                  offsets.size() * sizeof(cudf::size_type),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  rmm::device_buffer chars_buf(chars.size(), stream, mr);
+  if (!chars.empty()) {
+    cudaMemcpyAsync(
+      chars_buf.data(), chars.data(), chars.size(), cudaMemcpyHostToDevice, stream.value());
+  }
+  cudaStreamSynchronize(stream.value());
+  return cudf::make_strings_column(static_cast<cudf::size_type>(values.size()),
+                                   std::move(offsets_col),
+                                   std::move(chars_buf),
+                                   0,
+                                   rmm::device_buffer{0, stream, mr});
+}
+
+/// One chunk of the pin: an INT64 column holding its own global row id, an
+/// optional nullable twin of it, and a STRING column that the host gather has to
+/// refuse.
+std::unique_ptr<cudf::table> make_chunk(std::int64_t first_row,
+                                        std::int64_t rows,
+                                        rmm::cuda_stream_view stream)
+{
+  std::vector<std::int64_t> ids(static_cast<std::size_t>(rows));
+  std::iota(ids.begin(), ids.end(), first_row);
+
+  auto upload = [&](cudf::mask_state mask) {
+    auto col = cudf::make_numeric_column(
+      cudf::data_type{cudf::type_id::INT64}, static_cast<cudf::size_type>(rows), mask, stream);
+    cudaMemcpyAsync(col->mutable_view().data<std::int64_t>(),
+                    ids.data(),
+                    ids.size() * sizeof(std::int64_t),
+                    cudaMemcpyHostToDevice,
+                    stream.value());
+    return col;
+  };
+
+  auto plain    = upload(cudf::mask_state::UNALLOCATED);
+  auto nullable = upload(cudf::mask_state::UNINITIALIZED);
+
+  std::vector<cudf::bitmask_type> words(
+    static_cast<std::size_t>(cudf::num_bitmask_words(static_cast<cudf::size_type>(rows))), 0);
+  std::size_t nulls = 0;
+  for (std::int64_t i = 0; i < rows; ++i) {
+    if (row_is_valid(first_row + i)) {
+      words[static_cast<std::size_t>(i) / 32] |= (1U << (static_cast<std::size_t>(i) % 32));
+    } else {
+      ++nulls;
+    }
+  }
+  cudaMemcpyAsync(nullable->mutable_view().null_mask(),
+                  words.data(),
+                  words.size() * sizeof(cudf::bitmask_type),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  cudaStreamSynchronize(stream.value());
+  nullable->set_null_count(static_cast<cudf::size_type>(nulls));
+
+  std::vector<std::string> labels;
+  labels.reserve(static_cast<std::size_t>(rows));
+  for (std::int64_t i = 0; i < rows; ++i) {
+    labels.push_back("row-" + std::to_string(first_row + i));
+  }
+  auto text = make_labels(labels, stream);
+
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(std::move(plain));
+  columns.push_back(std::move(nullable));
+  columns.push_back(std::move(text));
+  return std::make_unique<cudf::table>(std::move(columns));
+}
+
+/// A HOST-tier pin of the chunks above, built the way the pin driver builds one:
+/// each chunk materialized on the GPU and converted to a pinned host
+/// representation, with the GPU table released before the next.
+struct host_pin {
+  pinned_entry entry;
+  std::shared_ptr<pin_entry_handle> handle;
+
+  host_pin(std::vector<std::int64_t> const& chunk_rows,
+           cucascade::memory::memory_space& gpu_space,
+           cucascade::memory::memory_space& host_space,
+           rmm::cuda_stream_view stream)
+  {
+    entry.tier         = Tier::HOST;
+    entry.memory_space = &host_space;
+    entry.cache_info.names.assign({"id", "id_nullable", "label"});
+
+    auto& registry     = sirius::converter_registry::get();
+    std::int64_t first = 0;
+    for (auto const rows : chunk_rows) {
+      auto table = make_chunk(first, rows, stream);
+      first += rows;
+      entry.num_rows += static_cast<std::size_t>(rows);
+
+      cucascade::gpu_table_representation gpu(std::move(table), gpu_space, stream);
+      auto host = registry.convert<cucascade::host_data_representation>(gpu, &host_space, stream);
+      REQUIRE(host);
+      entry.host_chunks.push_back(
+        std::shared_ptr<cucascade::idata_representation>(std::move(host)));
+    }
+
+    handle = std::make_shared<pin_entry_handle>("host_pin", 7);
+    handle->set_entry(&entry);
+  }
+
+  [[nodiscard]] column_origin origin(std::uint32_t pos) const
+  {
+    column_origin o;
+    o.handle     = handle;
+    o.column_pos = pos;
+    o.generation = handle->generation();
+    return o;
+  }
+};
+
+rmm::device_buffer upload_ids(std::vector<std::uint64_t> const& host, rmm::cuda_stream_view stream)
+{
+  rmm::device_buffer buf(
+    host.size() * sizeof(std::uint64_t), stream, rmm::mr::get_current_device_resource_ref());
+  cudaMemcpyAsync(buf.data(),
+                  host.data(),
+                  host.size() * sizeof(std::uint64_t),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  cudaStreamSynchronize(stream.value());
+  return buf;
+}
+
+std::vector<std::int64_t> read_values(cudf::column_view const& col)
+{
+  std::vector<std::int64_t> host(static_cast<std::size_t>(col.size()));
+  if (!host.empty()) {
+    cudaMemcpy(host.data(),
+               col.data<std::int64_t>(),
+               host.size() * sizeof(std::int64_t),
+               cudaMemcpyDeviceToHost);
+  }
+  return host;
+}
+
+std::vector<bool> read_validity(cudf::column_view const& col)
+{
+  std::vector<bool> valid(static_cast<std::size_t>(col.size()), true);
+  if (!col.nullable() || col.size() == 0) { return valid; }
+  std::vector<cudf::bitmask_type> words(
+    static_cast<std::size_t>(cudf::num_bitmask_words(col.size())));
+  cudaMemcpy(words.data(),
+             col.null_mask(),
+             words.size() * sizeof(cudf::bitmask_type),
+             cudaMemcpyDeviceToHost);
+  for (cudf::size_type i = 0; i < col.size(); ++i) {
+    valid[static_cast<std::size_t>(i)] =
+      ((words[static_cast<std::size_t>(i) / 32] >> (static_cast<std::size_t>(i) % 32)) & 1U) != 0U;
+  }
+  return valid;
+}
+
+}  // namespace
+
+TEST_CASE("late-mat materializes out of a host-tier pin", "[late_mat][host_pin][shared_context]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto sirius_ctx      = sirius::get_sirius_context(con, test_config_path());
+  auto& manager        = sirius_ctx->get_memory_manager();
+  auto* gpu_space =
+    const_cast<cucascade::memory::memory_space*>(manager.get_memory_space(Tier::GPU, 0));
+  auto* host_space =
+    const_cast<cucascade::memory::memory_space*>(manager.get_memory_space(Tier::HOST, 0));
+  if (host_space == nullptr) {
+    auto const spaces = manager.get_memory_spaces_for_tier(Tier::HOST);
+    REQUIRE_FALSE(spaces.empty());
+    host_space = const_cast<cucascade::memory::memory_space*>(spaces.front());
+  }
+  REQUIRE(gpu_space != nullptr);
+  REQUIRE(host_space != nullptr);
+
+  // A real stream, not the legacy default one: the GPU-to-host converter fires
+  // cudaMemcpyBatchAsync, which rejects the default stream. It outlives the pin
+  // below, whose host chunks were written on it.
+  rmm::cuda_stream owned_stream;
+  auto const stream = owned_stream.view();
+  auto mr           = rmm::mr::get_current_device_resource_ref();
+
+  std::vector<std::int64_t> const chunk_rows{kRowsPerChunk, kRowsPerChunk / 2, kRowsPerChunk};
+  host_pin pin(chunk_rows, *gpu_space, *host_space, stream);
+
+  SECTION("the layout describes the chunks the entry actually holds")
+  {
+    auto const layout = resolve_pinned_layout(pin.origin(0));
+    REQUIRE(layout.has_value());
+    REQUIRE(layout->batch_rows == chunk_rows);
+    REQUIRE(layout->total_rows() == static_cast<std::int64_t>(pin.entry.num_rows));
+  }
+
+  SECTION("a fixed-width column gathers its own row ids back, across block boundaries")
+  {
+    auto const layout = resolve_pinned_layout(pin.origin(0));
+    REQUIRE(layout.has_value());
+    auto const column = resolve_pinned_column(pin.origin(0));
+    REQUIRE(column.has_value());
+    REQUIRE(column->dtype == cudf::data_type{cudf::type_id::INT64});
+    REQUIRE(column->batches.size() == chunk_rows.size());
+    REQUIRE(column->batches.front().is_host());
+
+    // Ids picked to land in every chunk, unordered and with a repeat, since
+    // those are ordinary gather semantics rather than a special case.
+    std::vector<std::uint64_t> ids{0,
+                                   131'071,   // last INT64 of the first 1 MiB block
+                                   131'072,   // first INT64 of the second
+                                   399'999,   // last row of chunk 0
+                                   400'000,   // first row of chunk 1
+                                   599'999,   // last row of chunk 1
+                                   600'000,   // first row of chunk 2
+                                   999'999,   // last row of the pin
+                                   131'072};  // a repeat
+    auto const buf = upload_ids(ids, stream);
+    row_id_list list{
+      static_cast<std::uint64_t const*>(buf.data()), static_cast<std::int64_t>(ids.size()), false};
+    prepared_selection selection(*layout, list);
+
+    auto const produced = materialize(*column, selection, stream, mr);
+    cudaStreamSynchronize(stream.value());
+    REQUIRE(produced->size() == static_cast<cudf::size_type>(ids.size()));
+    REQUIRE(produced->null_count() == 0);
+    auto const values = read_values(produced->view());
+    for (std::size_t i = 0; i < ids.size(); ++i) {
+      REQUIRE(values[i] == static_cast<std::int64_t>(ids[i]));
+    }
+  }
+
+  SECTION("validity rides along with the values")
+  {
+    auto const layout = resolve_pinned_layout(pin.origin(1));
+    REQUIRE(layout.has_value());
+    auto const column = resolve_pinned_column(pin.origin(1));
+    REQUIRE(column.has_value());
+    REQUIRE(column->batches.front().host->has_null_mask);
+
+    std::vector<std::uint64_t> ids;
+    for (std::uint64_t id = 399'990; id < 400'010; ++id) {
+      ids.push_back(id);
+    }
+    auto const buf = upload_ids(ids, stream);
+    row_id_list list{
+      static_cast<std::uint64_t const*>(buf.data()), static_cast<std::int64_t>(ids.size()), true};
+    prepared_selection selection(*layout, list);
+
+    auto const produced = materialize(*column, selection, stream, mr);
+    cudaStreamSynchronize(stream.value());
+    auto const values = read_values(produced->view());
+    auto const valid  = read_validity(produced->view());
+    for (std::size_t i = 0; i < ids.size(); ++i) {
+      auto const id = static_cast<std::int64_t>(ids[i]);
+      REQUIRE(valid[i] == row_is_valid(id));
+      if (valid[i]) { REQUIRE(values[i] == id); }
+    }
+    REQUIRE(produced->null_count() ==
+            static_cast<cudf::size_type>(std::count(valid.begin(), valid.end(), false)));
+  }
+
+  SECTION("a variable-width column is refused rather than read as fixed width")
+  {
+    REQUIRE_FALSE(host_pinned_column_is_addressable(pin.entry, 2));
+    REQUIRE_FALSE(resolve_pinned_column(pin.origin(2)).has_value());
+    // Its fixed-width neighbours in the same chunks stay addressable: the
+    // refusal is per column, not per pin.
+    REQUIRE(host_pinned_column_is_addressable(pin.entry, 0));
+    REQUIRE(host_pinned_column_is_addressable(pin.entry, 1));
+  }
+
+  SECTION("a column position the entry does not have is refused")
+  {
+    REQUIRE_FALSE(host_pinned_column_is_addressable(pin.entry, 7));
+    REQUIRE_FALSE(resolve_pinned_column(pin.origin(7)).has_value());
+  }
+
+  SECTION("a stale origin resolves to nothing, whatever the tier")
+  {
+    auto stale = pin.origin(0);
+    pin.handle->bump_generation(pin.handle->generation() + 1);
+    REQUIRE_FALSE(resolve_pinned_layout(stale).has_value());
+    REQUIRE_FALSE(resolve_pinned_column(stale).has_value());
+  }
+
+  SECTION("a host entry with no chunks is refused rather than resolved empty")
+  {
+    pinned_entry empty;
+    empty.tier = Tier::HOST;
+    empty.cache_info.names.assign({"id"});
+    auto handle = std::make_shared<pin_entry_handle>("empty", 1);
+    handle->set_entry(&empty);
+    column_origin origin;
+    origin.handle     = handle;
+    origin.column_pos = 0;
+    origin.generation = handle->generation();
+
+    REQUIRE_FALSE(host_pinned_column_is_addressable(empty, 0));
+    REQUIRE_FALSE(resolve_pinned_layout(origin).has_value());
+    REQUIRE_FALSE(resolve_pinned_column(origin).has_value());
+  }
+}

--- a/test/cpp/late_mat/test_late_mat_host_pin.cpp
+++ b/test/cpp/late_mat/test_late_mat_host_pin.cpp
@@ -50,6 +50,7 @@
 #include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <data/sirius_converter_registry.hpp>
+#include <late_mat/host_gather_policy.hpp>
 #include <late_mat/materialize.hpp>
 #include <memory/sirius_memory_reservation_manager.hpp>
 #include <scan_manager/late_mat_resolver.hpp>
@@ -271,6 +272,15 @@ std::vector<bool> read_validity(cudf::column_view const& col)
   return valid;
 }
 
+/// Pins a route for the duration of a scope and hands it back afterwards, so a
+/// failed assertion cannot leak the setting into the rest of the binary.
+struct forced_route {
+  explicit forced_route(bool inplace) { sirius::late_mat::force_host_gather_route(inplace); }
+  forced_route(forced_route const&)            = delete;
+  forced_route& operator=(forced_route const&) = delete;
+  ~forced_route() { sirius::late_mat::force_host_gather_route(std::nullopt); }
+};
+
 }  // namespace
 
 TEST_CASE("late-mat materializes out of a host-tier pin", "[late_mat][host_pin][shared_context]")
@@ -398,6 +408,64 @@ TEST_CASE("late-mat materializes out of a host-tier pin", "[late_mat][host_pin][
     REQUIRE_FALSE(resolve_pinned_column(stale).has_value());
   }
 
+  SECTION("the route is chosen, not incidental, and both routes agree")
+  {
+    using sirius::late_mat::host_gather_routes_taken;
+
+    auto const layout = resolve_pinned_layout(pin.origin(1));
+    REQUIRE(layout.has_value());
+    auto const column = resolve_pinned_column(pin.origin(1));
+    REQUIRE(column.has_value());
+
+    // Spread across all three chunks, and nullable, so each route has to carry
+    // validity as well as values.
+    std::vector<std::uint64_t> ids;
+    for (std::uint64_t id = 0; id < 1'000'000; id += 9973) {
+      ids.push_back(id);
+    }
+    auto const buf = upload_ids(ids, stream);
+    row_id_list list{
+      static_cast<std::uint64_t const*>(buf.data()), static_cast<std::int64_t>(ids.size()), true};
+
+    auto run = [&](bool inplace) {
+      forced_route pinned{inplace};
+      auto const before = host_gather_routes_taken();
+      prepared_selection selection(*layout, list);
+      auto produced = materialize(*column, selection, stream, mr);
+      cudaStreamSynchronize(stream.value());
+      auto const after = host_gather_routes_taken();
+      // The branch that ran, asserted directly: a values-only check passes
+      // whichever route was taken and would not notice the choice being ignored.
+      if (inplace) {
+        REQUIRE(after.inplace == before.inplace + 1);
+        REQUIRE(after.staged == before.staged);
+      } else {
+        REQUIRE(after.staged == before.staged + 1);
+        REQUIRE(after.inplace == before.inplace);
+      }
+      return produced;
+    };
+
+    auto const in_place = run(true);
+    auto const staged   = run(false);
+
+    REQUIRE(in_place->size() == static_cast<cudf::size_type>(ids.size()));
+    REQUIRE(staged->size() == in_place->size());
+    REQUIRE(staged->null_count() == in_place->null_count());
+    REQUIRE(read_values(staged->view()) == read_values(in_place->view()));
+    REQUIRE(read_validity(staged->view()) == read_validity(in_place->view()));
+
+    // And the values are the rows that were asked for, not merely two routes
+    // agreeing on the same wrong answer.
+    auto const values = read_values(in_place->view());
+    auto const valid  = read_validity(in_place->view());
+    for (std::size_t i = 0; i < ids.size(); ++i) {
+      auto const id = static_cast<std::int64_t>(ids[i]);
+      REQUIRE(valid[i] == row_is_valid(id));
+      if (valid[i]) { REQUIRE(values[i] == id); }
+    }
+  }
+
   SECTION("a host entry with no chunks is refused rather than resolved empty")
   {
     pinned_entry empty;
@@ -414,4 +482,29 @@ TEST_CASE("late-mat materializes out of a host-tier pin", "[late_mat][host_pin][
     REQUIRE_FALSE(resolve_pinned_layout(origin).has_value());
     REQUIRE_FALSE(resolve_pinned_column(origin).has_value());
   }
+}
+
+TEST_CASE("the host gather probe measures this machine's link", "[late_mat][host_pin][probe]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto sirius_ctx      = sirius::get_sirius_context(con, test_config_path());
+  auto const& policy   = sirius::late_mat::measured_host_gather_policy();
+
+  // Machine-independent invariants only. The crossover is a property of the
+  // link, so pinning a number here would assert this GB300's answer on every
+  // machine that runs the suite; what must hold everywhere is that the probe
+  // either measured something usable or fell back to the conservative policy.
+  REQUIRE(policy.max_inplace_density >= 0.0);
+  REQUIRE(policy.max_inplace_density <= 1.0);
+  REQUIRE(policy.cost_multiplier >= 1);
+  REQUIRE(policy.cost_multiplier <= 64);
+  if (!policy.measured) {
+    REQUIRE(policy.max_inplace_density == 0.0);  // fail closed: stage
+  }
+
+  WARN("host gather probe: measured=" << policy.measured
+                                      << " bulk=" << policy.bulk_bytes_per_second / 1e9
+                                      << " GB/s in-place=" << policy.inplace_bytes_per_second / 1e9
+                                      << " GB/s crossover=" << policy.max_inplace_density
+                                      << " multiplier=" << policy.cost_multiplier);
 }

--- a/test/cpp/late_mat/test_late_mat_plan_pass.cpp
+++ b/test/cpp/late_mat/test_late_mat_plan_pass.cpp
@@ -337,8 +337,9 @@ TEST_CASE("columns that stop at the same operator bundle together", "[late_mat][
   auto const candidates = build_defer_candidates(scan, analyze_column_lifetimes(scan));
   REQUIRE(candidates.size() == 1);  // one reader, one slot
   REQUIRE(candidates[0].columns.size() == 3);
-  // Four-byte integers: three of them, less the eight-byte rowid.
-  REQUIRE(candidates[0].net_value_bytes(8) == 3 * 4 - 8);
+  // Four-byte integers: three of them, less the eight-byte rowid and the two
+  // placeholders riding beside it.
+  REQUIRE(candidates[0].net_value_bytes(8) == 3 * 4 - (8 + 2));
 }
 
 TEST_CASE("a column nothing reads is not a candidate", "[late_mat][lifetime]")
@@ -559,7 +560,7 @@ TEST_CASE("a wide bundle over a long ride plans a deferral at its reader", "[lat
   REQUIRE(planned.restored_types.size() == 5);
   // Leaving the scan and leaving each of the three partitions.
   REQUIRE(planned.boundaries == 4);
-  REQUIRE(planned.net_value_bytes == 5 * 24 - 8);
+  REQUIRE(planned.net_value_bytes == 5 * 24 - (8 + 4));
   REQUIRE(planned.census.size() == 1);
   REQUIRE(planned.census.front().installed());
 }

--- a/test/cpp/late_mat/test_late_mat_resolver.cpp
+++ b/test/cpp/late_mat/test_late_mat_resolver.cpp
@@ -186,13 +186,17 @@ TEST_CASE("a column position the entry does not have resolves to nothing", "[lat
   REQUIRE_FALSE(resolve_pinned_column(pin.origin(7)).has_value());
 }
 
-TEST_CASE("a host-tier entry is not served", "[late_mat][resolver]")
+TEST_CASE("a host-tier entry with no host chunks is not served", "[late_mat][resolver]")
 {
   auto const stream = rmm::cuda_stream_view{};
   fake_entry pin({16}, "c_name", stream);
+  // The tier says HOST while the storage is the GPU per-column map — the shape a
+  // half-built entry has. Not an error, a reason not to defer: the host path
+  // reads host_chunks and there are none, and reading the GPU columns instead,
+  // on the strength of their being there, would gather device memory for an
+  // entry that says it holds none. A host-tier entry that really does hold host
+  // chunks is covered in test_late_mat_host_pin.cpp.
   pin.entry.tier = cucascade::memory::Tier::HOST;
-  // Not an error — a reason not to defer. A host chunk would have to be staged
-  // before any of this applies.
   REQUIRE_FALSE(resolve_pinned_layout(pin.origin()).has_value());
   REQUIRE_FALSE(resolve_pinned_column(pin.origin()).has_value());
 }

--- a/test/cpp/scan/test_scan_schema_normalization.cpp
+++ b/test/cpp/scan/test_scan_schema_normalization.cpp
@@ -160,7 +160,8 @@ class stub_ingestible final : public sirius::op::scan::gpu_ingestible {
     bool,
     std::shared_ptr<const sirius::like_multiliteral_cache>,
     std::unique_ptr<cudf::column>*,
-    std::span<std::size_t const> /*elided*/) override
+    std::span<std::size_t const> /*elided*/,
+    std::span<std::size_t const> /*withheld*/) override
   {
     return _produce();
   }

--- a/test/cpp/scan_manager/test_cached_serving_hardening.cpp
+++ b/test/cpp/scan_manager/test_cached_serving_hardening.cpp
@@ -363,7 +363,8 @@ struct stub_ingestible final : sirius::op::scan::gpu_ingestible {
     bool /*like_swar_fastpath*/,
     std::shared_ptr<const sirius::like_multiliteral_cache> /*like_cache*/,
     std::unique_ptr<cudf::column>* /*survivors*/,
-    std::span<std::size_t const> /*elided*/) override
+    std::span<std::size_t const> /*elided*/,
+    std::span<std::size_t const> /*withheld*/) override
   {
     throw std::logic_error("stub_ingestible::post_filter_and_project is unreachable");
   }


### PR DESCRIPTION
Add support for late materialization of host-pinned data.

This is developed on the GB300 and needs (micro)benchmarking on PCIe devices to find proper policies (whether or not to refuse late-mat, and how to do it (gather from host directly, or stage first).

A host pin stores each chunk as a list of equally sized, non-contiguous blocks, so a column has no base pointer and cannot be expressed as a cudf::column_view at all. That, rather than the tier itself, is what kept late materialization device-only. This first implementation gathers the blocks where they are, because microbenchmarks show that that is typically much faster. cuCascade allocates host memory mapped for device access, so the blocks are already device-addressable; the existing multi-source kernel plus one divide turns a global row into a block index and an offset. Nothing stages a column to the device, which is what pinning it on the host was avoiding, and the gather allocates only its output.

Fixes #1641 

## Description

## Checklist
- [ ] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References