### PR TITLE
feat: support late materialization from nullable and compressed batches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -747,6 +747,7 @@ set(TEST_SOURCES
     test/cpp/late_mat/test_column_origin.cpp
     test/cpp/late_mat/test_prepared_selection.cpp
     test/cpp/late_mat/test_materialize.cpp
+    test/cpp/late_mat/test_materialize_compressed.cpp
     test/cpp/late_mat/test_port_materialize.cpp
     test/cpp/integration/test_late_mat_deferred_query.cpp
     test/cpp/integration/test_late_mat_native_filter.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,6 +751,7 @@ set(TEST_SOURCES
     test/cpp/late_mat/test_port_materialize.cpp
     test/cpp/integration/test_late_mat_deferred_query.cpp
     test/cpp/integration/test_late_mat_native_filter.cpp
+    test/cpp/integration/test_late_mat_compressed_filter.cpp
     test/cpp/late_mat/test_defer_policy.cpp
     test/cpp/late_mat/test_defer_directive.cpp
     test/cpp/late_mat/test_late_mat_plan_pass.cpp

--- a/docs/super-sirius/compressed-pinning.md
+++ b/docs/super-sirius/compressed-pinning.md
@@ -122,6 +122,21 @@ than decoding when enough rows are dropped:
 One batch measured unselective predicts the rest of that scan, so the scan stops attempting it
 rather than paying per batch.
 
+### Reporting the rows the decode kept
+
+A decode that compacts can hand back the positions it kept, as an ascending INT32 index list over
+the pre-filter batch (`pushdown_outcome::survivor_rows`). It is produced only when the request
+asks (`pushdown_request::report_survivors`, set through
+`decompression_pushdown_scan::with_survivor_reporting()`), which only a scan carrying a
+late-materialization deferral does — that rowid addresses the pinned chunk by position, and a
+compacted batch no longer holds the chunk's rows in order.
+
+The answer is not re-derived: the tier-B route already materialized the index list to gather by,
+and every other route left the counted mask it balloted, so this either copies a buffer that
+exists or expands one (`mask_to_row_indices`). `pushdown_outcome::compacted` reports that rows
+were dropped at all — separately from `row_filtered`, which additionally claims the whole filter
+was carried — so a consumer can tell "no positions asked for" apart from "no rows dropped".
+
 Two operational caveats. These are environment variables, not `SET` options: they are
 process-wide, read once and cached, so they cannot be changed per session and do not appear in
 `duckdb_settings()`. And the trace is the only way to see what happened — the plan per column (route,

--- a/docs/super-sirius/late-materialization.md
+++ b/docs/super-sirius/late-materialization.md
@@ -74,9 +74,7 @@ hoping schemas differ: `install_rider` (`late_mat_plan_pass.cpp`) requires the m
 `expected_schema` to match the existing one at every position except the new rider's own, and
 `port_materialize_directive::valid()` re-checks self-consistency and position collisions before
 the merge is accepted. Two scans converging at one port get ONE directive with each side's rowid
-at its own fixed position — disambiguated structurally, not by a runtime schema coincidence. No
-code change identified as necessary; recorded here because the reasoning isn't obvious from the
-"schema equality is the entire identity check" statement alone.
+at its own fixed position — disambiguated structurally, not by a runtime schema coincidence.
 
 ## Which columns, and how far
 
@@ -159,15 +157,16 @@ deferral with a single half, admitted only over pinned columns with no nulls. Of
 
 - A column an outer join could null is withheld: a null rowid must materialize a null, which the
   materializer does not do yet.
-- A nullable PINNED SOURCE column is admitted for any uncompressed origin (single-batch,
-  multi-batch fixed-width, or multi-batch variable-width — every such gather path propagates
-  validity). A compressed origin is refused UNCONDITIONALLY, whether or not it actually has any
-  nulls: per-column nullability inside a Simpatico-compressed blob is opaque (see
-  [Compressed Materialization](compressed-materialization.md)), so nothing upstream of the
-  install-time gate can tell "no nulls" apart from "unknown," and the gate treats both as unsafe.
-  `materialize_compressed`'s decode routes in `materialize.cpp` do write values only, with no
-  output validity buffer — but that is a secondary reason and moot in practice, since a compressed
-  origin never reaches them today.
+- A nullable PINNED SOURCE column is admitted for any origin whose gather path propagates
+  validity, which is now every one of them. The uncompressed shapes (single-batch, multi-batch
+  fixed-width, multi-batch variable-width) do it natively. A COMPRESSED origin does it through
+  the validity sidecar compression stores beside each column's plan tree: the count is readable
+  from the `.hpln` header without decoding (`simpatico::column_null_count`), so the install gate
+  can tell "no nulls" apart from "unknown", and the decode routes reattach the mask
+  (`materialize.cpp`'s `attach_selected_validity`). The two COMPACTING routes gather the stored
+  bitmask by the same rows they selected the values by — the mask describes the whole chunk while
+  a compacted output holds only the selection, so copying it verbatim would pair each value with
+  another row's validity. A chunk carrying no blob still answers nothing and is refused.
 - A compressed origin cannot skip its decode — the scan substitutes on the FINISHED output, so a
   deferred column from a compressed pin is decompressed and then discarded.
 - Filtered scans of compressed pins are refused (above).

--- a/docs/super-sirius/late-materialization.md
+++ b/docs/super-sirius/late-materialization.md
@@ -146,9 +146,27 @@ NAME, since a re-pin that merges columns would make a positional attach mark the
 ## Filtered scans, and count-on-deferred
 
 A filtered batch is no longer the chunk's rows in order, so the rowid comes from the surviving
-row positions, taken from the same mask the scan filters with. It is refused where the survivors
-are decided somewhere this path cannot see them — a compressed pin filters inside the fused
-decode (see [Compressed Pinning](compressed-pinning.md)).
+row positions, taken from the same mask the scan filters with.
+
+**A batch off a compressed pin can be restricted twice.** The fused decode drops rows while
+decoding (see [Compressed Pinning](compressed-pinning.md)), and whatever conjuncts it could not
+carry are evaluated again on what it kept. Each stage reports positions in ITS OWN input, so the
+second stage's positions index the first stage's output rather than the chunk, and the pin-order
+rowid is only right once the two are composed — `compose_survivors`
+(`sirius_gpu_scan_operator.cpp`) gathers the decode's list by the residual's.
+
+The decode reports its half because it is asked to: a split carrying a deferral sets
+`late_mat_wants_survivors`, which `prepare_for_processing` turns into
+`decompression_pushdown_scan::with_survivor_reporting()`, and the decode then expands the
+selection mask it already balloted into an ascending INT32 index list
+(`pushdown_outcome::survivor_rows`). Off a deferring scan the decode does neither, so the cost is
+one index-list expansion plus 4 bytes per surviving row, paid only where a ride uses it.
+
+Both directions fail closed. A decode that compacted without accounting for its survivors throws
+rather than emit a rowid, at `prepare_for_processing` and again at substitution; a survivor list
+whose length does not match the rows handed on throws too. A scan whose INGESTIBLE cannot report
+survivors (the duckdb-native one filters with a plain select) is still refused at install, since
+the residual half would have nothing to say.
 
 A column every reader only COUNTs needs no far end at all: `install_count_deferral` is the one
 deferral with a single half, admitted only over pinned columns with no nulls. Off by default.
@@ -169,7 +187,6 @@ deferral with a single half, admitted only over pinned columns with no nulls. Of
   another row's validity. A chunk carrying no blob still answers nothing and is refused.
 - A compressed origin cannot skip its decode — the scan substitutes on the FINISHED output, so a
   deferred column from a compressed pin is decompressed and then discarded.
-- Filtered scans of compressed pins are refused (above).
 - Deferred-value widths are ESTIMATED for variable-width columns, not measured, and the error runs
   both ways: underestimating a wide column can refuse a bundle that would have qualified, but
   overestimating a short one can just as easily admit a bundle that does not actually repay (a

--- a/docs/super-sirius/late-materialization.md
+++ b/docs/super-sirius/late-materialization.md
@@ -162,6 +162,14 @@ selection mask it already balloted into an ascending INT32 index list
 (`pushdown_outcome::survivor_rows`). Off a deferring scan the decode does neither, so the cost is
 one index-list expansion plus 4 bytes per surviving row, paid only where a ride uses it.
 
+Admitting the shape is not the same as it paying. On TPC-H SF1000 with
+`PIN_UNIQUE_COLS=all` it turns 39 structural refusals into ordinary policy decisions and installs
+no additional deferral: the newly reachable candidates are `lineitem` and `orders` filtered scans,
+and they are withheld because a partition hashes them or refused on the value-times-crossings
+floor. Suite time is unchanged (6.312 s before, 6.304 s / 6.326 s after, same build and machine),
+which is what a change that only removes a refusal should look like where the refusal was not the
+binding constraint on value.
+
 Both directions fail closed. A decode that compacted without accounting for its survivors throws
 rather than emit a rowid, at `prepare_for_processing` and again at substitution; a survivor list
 whose length does not match the rows handed on throws too. A scan whose INGESTIBLE cannot report

--- a/src/compression/compressed_scan.cpp
+++ b/src/compression/compressed_scan.cpp
@@ -19,7 +19,9 @@
 #include "decompression_pushdown_policy.hpp"
 
 #include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/utilities/error.hpp>
 
 #include <api/simpatico_codegen.hpp>
 #include <codegen/selection/selection.hpp>
@@ -328,6 +330,39 @@ struct selection_source {
 /// is structurally impossible and the round-trip is skipped.
 constexpr std::size_t kMaxSelectionSources = 8;
 
+/// The rows a filtered decode kept, as ascending chunk-local INT32 positions.
+///
+/// The selection wave already holds the answer: the tier-B route materialized
+/// the index list to gather by, and every other route left the counted mask it
+/// balloted. So this either wraps a buffer that exists or expands one, never
+/// re-derives the selection.
+///
+/// Returns null when the result cannot account for its survivors exactly — an
+/// uncounted mask, or a count the buffers do not cover. A caller that asked for
+/// the positions must treat that as a refusal rather than as "no rows dropped".
+[[nodiscard]] std::unique_ptr<cudf::column> survivor_positions(
+  sirius::codegen::scan_filter_result& result,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  if (result.survivor_count < 0) { return nullptr; }
+  auto const count = static_cast<cudf::size_type>(result.survivor_count);
+  auto column      = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT32}, count, cudf::mask_state::UNALLOCATED, stream, mr);
+  if (count == 0) { return column; }
+  auto* out       = column->mutable_view().data<std::int32_t>();
+  auto const need = static_cast<std::size_t>(count) * sizeof(std::int32_t);
+  if (result.row_indices.size() >= need) {
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+      out, result.row_indices.data(), need, cudaMemcpyDeviceToDevice, stream.value()));
+    return column;
+  }
+  if (result.mask_words.size() == 0 || result.chunk_offsets.size() == 0) { return nullptr; }
+  auto mask = result.view();
+  sirius::codegen::mask_to_row_indices(mask, out, stream);
+  return column;
+}
+
 /// Decompress @p selected columns of @p chunk with @p request applied during
 /// the decode. Returns a null table when the attempt is declined here
 /// (nothing to configure, shape checks) or when the assembly refuses — the
@@ -437,6 +472,15 @@ std::unique_ptr<cudf::table> decompress_with_pushdown(simpatico::compressed_tabl
   } else if (result.applied && config.covers_whole_filter) {
     outcome.row_filtered = true;
   }
+  // Rows were dropped whenever the filtered decode applied, whether or not it
+  // carried the whole filter. A consumer that addresses the chunk by position
+  // needs that fact separately from row_filtered, and it must be reported even
+  // when the positions themselves were not asked for — otherwise "not asked"
+  // and "nothing dropped" look the same.
+  outcome.compacted = result.applied;
+  if (result.applied && request.report_survivors) {
+    outcome.survivor_rows = survivor_positions(result, stream, mr);
+  }
   // Every equality the request carried was ANDed into the batch mask before
   // wave 2 ran, so on an applied decode the surviving rows already satisfy
   // them. On any other outcome the equality answers come from the plain
@@ -477,7 +521,16 @@ decompression_pushdown_scan::without_row_selection() const
   }
   if (narrowed.empty()) { return nullptr; }
   narrowed.row_selection_disabled = true;
+  narrowed.report_survivors       = _request.report_survivors;
   return std::make_shared<const decompression_pushdown_scan>(std::move(narrowed));
+}
+
+std::shared_ptr<const decompression_pushdown_scan>
+decompression_pushdown_scan::with_survivor_reporting() const
+{
+  auto refreshed             = _request;
+  refreshed.report_survivors = true;
+  return std::make_shared<const decompression_pushdown_scan>(std::move(refreshed));
 }
 
 std::shared_ptr<const decompression_pushdown_scan>

--- a/src/compression/compressed_scan.hpp
+++ b/src/compression/compressed_scan.hpp
@@ -146,6 +146,16 @@ struct pushdown_request {
   /// copy it along with everything else.
   bool row_selection_disabled = false;
 
+  /// Ask the decode to hand back the positions of the rows it kept, as
+  /// ascending chunk-local indices (@ref pushdown_outcome::survivor_rows).
+  ///
+  /// Set only by a scan carrying a late-materialization deferral: its rowid
+  /// addresses the pinned chunk, and a compacted batch no longer holds that
+  /// chunk's rows in order. Costs one index-list expansion of the selection
+  /// mask the decode already built, plus 4 bytes per surviving row; off, the
+  /// decode does neither.
+  bool report_survivors = false;
+
   [[nodiscard]] bool empty() const noexcept;
   /// True iff any entry asks for rows to be DROPPED (as opposed to a column
   /// being answered in place, which changes no row count).
@@ -199,9 +209,25 @@ struct pushdown_outcome {
   /// dropped for them, so the scan must still evaluate them.
   bool predicates_enforced = false;
 
+  /// The decode DROPPED rows: the columns are compacted to the survivors, so
+  /// the batch no longer holds the chunk's rows in order.
+  ///
+  /// Distinct from @ref row_filtered, which additionally claims the whole
+  /// filter was carried. A partially applied request compacts without setting
+  /// that, and a consumer addressing the pinned chunk by position has to know.
+  bool compacted = false;
+
+  /// Chunk-local positions of the rows @ref compacted kept, ascending, INT32,
+  /// one entry per output row. Populated only when the request asked
+  /// (@ref pushdown_request::report_survivors); null otherwise.
+  ///
+  /// Shared rather than owned so the outcome stays copyable, which is what lets
+  /// it ride on the representation as a value.
+  std::shared_ptr<cudf::column const> survivor_rows;
+
   [[nodiscard]] bool any() const noexcept
   {
-    return row_filtered || selection_unprofitable || !predicate_columns.empty();
+    return row_filtered || selection_unprofitable || compacted || !predicate_columns.empty();
   }
 };
 
@@ -231,6 +257,11 @@ class decompression_pushdown_scan {
   /// working; only the attempt to compact is given up. Null if nothing is left
   /// to ask for.
   [[nodiscard]] std::shared_ptr<const decompression_pushdown_scan> without_row_selection() const;
+
+  /// This scan with @c pushdown_request::report_survivors set — what a split
+  /// carrying a late-materialization deferral attaches before its decode.
+  /// Never null: it only adds an obligation to a request that already exists.
+  [[nodiscard]] std::shared_ptr<const decompression_pushdown_scan> with_survivor_reporting() const;
 
   /// This scan with its join filters replaced by a fresher snapshot. @p probes
   /// is parallel to the selected column list.

--- a/src/compression/simpatico_codegen/CMakeLists.txt
+++ b/src/compression/simpatico_codegen/CMakeLists.txt
@@ -156,6 +156,7 @@ add_library(
   src/plan/operator_registry.cpp
   src/plan/representation_factory.cpp
   src/plan/bitjoin_layout.cpp
+  src/plan/validity.cpp
   src/plan/compress.cpp
   src/plan/decompress.cpp
   src/util/stream_pool.cpp

--- a/src/compression/simpatico_codegen/include/api/compressed_table_io.hpp
+++ b/src/compression/simpatico_codegen/include/api/compressed_table_io.hpp
@@ -16,6 +16,9 @@
 //       name_len (uint16 LE) + name bytes   [0 = no name]
 //       dtype_tag (uint8)                   [decoded column type]
 //       num_rows (int64 LE)
+//       validity_kind (uint8)               [0=all_valid 1=all_null 2=mask]
+//         if kind != all_valid: null_count (int64 LE)
+//         if kind == mask:      mask_size_bytes (uint64 LE) + payload_offset (uint64 LE)
 //       num_nodes (uint16 LE)
 //       per node:
 //         op_len (uint16 LE) + op bytes

--- a/src/compression/simpatico_codegen/include/api/simpatico_codegen.hpp
+++ b/src/compression/simpatico_codegen/include/api/simpatico_codegen.hpp
@@ -272,30 +272,58 @@ std::unique_ptr<cudf::table> decompress(
 // dtype. That is not cosmetic: a DECIMAL64 returned as its INT64 storage silently drops
 // its scale, which is a wrong-results bug rather than a type complaint.
 
+/// The validity one column of @p table carries, or nullptr when the column has
+/// no plan tree.
+///
+/// Compression strips a column's nulls into this sidecar before the walk and
+/// reattaches them after the decode, so the record is readable straight from a
+/// loaded header — no decode, no device work.
+[[nodiscard]] validity_sidecar const* column_validity(const compressed_table& table,
+                                                      std::size_t column_index);
+
+/// How many of one column's rows are null, or nullopt when the blob cannot say.
+///
+/// Fails closed: a column with no plan tree, an index past the table's width and
+/// a negative recorded count all read as unknown rather than as "no nulls". A
+/// blob written before the validity record existed does not reach here at all —
+/// the reader rejects any header version it does not know.
+[[nodiscard]] std::optional<std::int64_t> column_null_count(const compressed_table& table,
+                                                            std::size_t column_index);
+
 /// One column decoded for a chunk-bucketed row set — the sparse walk, one block
 /// per touched chunk. Refuses any plan without random access (dictionary,
 /// str_split, delta roots). Re-tags the decode's storage type to the column's
 /// stored dtype (see the per-column decode note above).
+///
+/// A compacted output holds only the selected rows, while the stored bitmask
+/// describes every row of the chunk, so a nullable column is refused unless the
+/// caller opts in by passing @p stripped_validity. Doing so returns the values
+/// alone and points @p stripped_validity at the chunk's full-width sidecar,
+/// which the caller must compact against the very selection it passed here.
 std::unique_ptr<cudf::column> decompress_column_rows(
   const compressed_table& table,
   std::size_t column_index,
   sirius::codegen::chunk_row_set const& rows,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref(),
-  std::string* error_out            = nullptr);
+  rmm::cuda_stream_view stream               = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr          = rmm::mr::get_current_device_resource_ref(),
+  std::string* error_out                     = nullptr,
+  validity_sidecar const** stripped_validity = nullptr);
 
 /// One column decoded compacted against a mask the caller already holds — the
 /// shipped mask route, reached as the capability fallback when the sparse walk
 /// refuses. The mask must have been counted (chunk_offsets present). Re-tags
 /// the decode's storage type to the column's stored dtype (see the per-column
 /// decode note above).
+///
+/// Carries validity on the same opt-in terms as decompress_column_rows.
 std::unique_ptr<cudf::column> decompress_column_compacted(
   const compressed_table& table,
   std::size_t column_index,
   sirius::codegen::selection_mask const& mask,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref(),
-  std::string* error_out            = nullptr);
+  rmm::cuda_stream_view stream               = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr          = rmm::mr::get_current_device_resource_ref(),
+  std::string* error_out                     = nullptr,
+  validity_sidecar const** stripped_validity = nullptr);
 
 /// One column decoded full width — the end of every cascade, so it refuses only
 /// on a genuine decode failure. Re-tags the decode's storage type to the

--- a/src/compression/simpatico_codegen/include/codegen/plan/plan_interpreter.hpp
+++ b/src/compression/simpatico_codegen/include/codegen/plan/plan_interpreter.hpp
@@ -125,6 +125,12 @@ struct decode_selection {
   /// the survivor index list (@c full), and are refused rather than silently
   /// decoded full width — the same footing the index walk was introduced on.
   sirius::codegen::chunk_row_set const* rows = nullptr;
+  /// The caller compacts the column's stripped validity itself, against this
+  /// same selection. Off by default, which refuses a nullable column outright:
+  /// the stored bitmask spans the whole chunk and a compacted output does not,
+  /// so anything that returns one against the other silently misaligns validity
+  /// with values.
+  bool caller_reattaches_validity = false;
 
   [[nodiscard]] bool active() const noexcept
   {

--- a/src/compression/simpatico_codegen/include/codegen/plan/plan_tree.hpp
+++ b/src/compression/simpatico_codegen/include/codegen/plan/plan_tree.hpp
@@ -6,6 +6,7 @@
 #include "codegen/plan/operator_registry.hpp"  // ChannelId
 #include "codegen/plan/plan_dsl.hpp"
 #include "codegen/plan/representation.hpp"
+#include "codegen/plan/validity.hpp"
 
 #include <cudf/types.hpp>
 
@@ -113,6 +114,13 @@ struct PlanNode {
 
 struct PlanTree {
   std::vector<PlanNode> nodes;
+
+  // The column's validity, detached from the dataflow the nodes describe.
+  // compress_column strips it off the input before the walk and decompress_column
+  // reattaches it after, so no node -- and no plan DSL -- ever refers to it.
+  // Default-constructed (all_valid) for a column with no nulls, which costs
+  // nothing to carry.
+  validity_sidecar validity;
 };
 
 std::optional<PlanTree> plan_tree_from_dsl(std::string_view dsl, std::string* error_out = nullptr);

--- a/src/compression/simpatico_codegen/include/codegen/plan/representation.hpp
+++ b/src/compression/simpatico_codegen/include/codegen/plan/representation.hpp
@@ -7,7 +7,6 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
-#include <cudf/null_mask.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -121,21 +120,16 @@ struct compressed_representation {
 
   /// Canonical channel enumeration: this rep's named output channels, in manifest/wire order.
   /// Generic implementation: driven by channels_ + op_info(kind()).channels from the registry.
-  /// Subclasses with variable-arity or lazy synthesis (dictionary, bitextract) override this.
+  /// Subclasses with lazy synthesis (dictionary, bitextract) override this.
   virtual std::vector<compressible_output> named_channels(rmm::cuda_stream_view) const
   {
     auto const& names = op_info(kind()).channels;
     std::vector<compressible_output> out;
     out.reserve(channels_.size());
     for (size_t i = 0; i < channels_.size() && i < names.size(); ++i)
-      if (channels_[i]) out.push_back({names[i], channels_[i]->view()});
+      out.push_back({names[i], channels_[i]->view()});
     return out;
   }
-
-  /// Channels that MUST be routed by the plan, else the driver errors -- preventing silent data
-  /// loss. Default: none. str_split returns {"null_mask"} for a nullable input so a plan can never
-  /// silently drop validity.
-  virtual std::vector<std::string> required_channels() const { return {}; }
 
   /// SAFETY invariant: a representation owns everything it exposes — all
   /// compressors create new data during compression, and the original user
@@ -224,7 +218,7 @@ struct identity_compressor : compressor {
 /// Dictionary format: stores the encoded dictionary column and a copy of keys chars.
 /// In modern cuDF, chars are not accessible as a column_view, so we copy them into a UINT8 column.
 struct dictionary_compressed_representation : standalone_compressed_representation {
-  // Accepts the (keys_offsets, keys_chars, indices[, null_mask]) form.
+  // Accepts the (keys_offsets, keys_chars, indices) form.
   static std::unique_ptr<compressed_representation> from_outputs(
     std::vector<std::string> const& output_names,
     std::vector<std::unique_ptr<cudf::column>> outputs,
@@ -240,11 +234,6 @@ struct dictionary_compressed_representation : standalone_compressed_representati
   // an all-null column yields zero keys). See named_channels().
   mutable std::unique_ptr<cudf::column> keys_offsets_synth;
   mutable std::unique_ptr<cudf::column> indices_synth;
-  // Lazily copied validity bitmask bytes (UINT8), exposed as the optional
-  // "null_mask" channel (and marked required) so a nullable column's validity
-  // survives every channel-based path: .hpln IO and decomposed plans rebuild
-  // via from_outputs, which cannot see the mask carried on the stored columns.
-  mutable std::unique_ptr<cudf::column> null_mask_copy;
 
   // Constant key byte-width, measured lazily at first decompress (0 = variable, -1 = unmeasured).
   mutable std::int64_t constant_key_width = -1;
@@ -278,8 +267,9 @@ struct dictionary_compressed_representation : standalone_compressed_representati
   {
     std::vector<compressible_output> outputs;
 
-    // Expose keys_offsets, keys_chars, indices and — for a nullable column —
-    // null_mask.
+    // Expose keys_offsets, keys_chars and indices. Validity is never among them:
+    // compress_column strips it into the plan tree's sidecar, so the column this
+    // rep was built from is null-free by construction.
     auto dict_view            = dict_column->view();
     bool const childless_dict = dict_column->num_children() == 0;  // zero-row compress
     bool const childless_keys =  // encode of an all-null column: zero keys, no offsets child
@@ -343,35 +333,10 @@ struct dictionary_compressed_representation : standalone_compressed_representati
         {"indices", get_dictionary_child_view(dict_view, dictionary_view_kind::Indices)});
     }
 
-    if (dict_column->null_count() > 0) {
-      ensure_null_mask_copy(dict_view, stream);
-      outputs.push_back({"null_mask", null_mask_copy->view()});
-    }
     return outputs;
   }
 
-  std::vector<std::string> required_channels() const override
-  {
-    if (dict_column && dict_column->null_count() > 0) return {"null_mask"};
-    return {};
-  }
-
   OpId kind() const override { return OpId::Dictionary; }
-
- private:
-  // Copy `source`'s validity bitmask into the owned UINT8 null_mask_copy
-  // column (no-op if already built).
-  void ensure_null_mask_copy(cudf::column_view const& source, rmm::cuda_stream_view stream) const
-  {
-    if (null_mask_copy) return;
-    auto mr                 = rmm::mr::get_current_device_resource_ref();
-    rmm::device_buffer bits = cudf::copy_bitmask(source, stream, mr);
-    auto const mask_bytes =
-      static_cast<cudf::size_type>(cudf::bitmask_allocation_size_bytes(source.size()));
-    null_mask_copy = std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT8}, mask_bytes, std::move(bits), rmm::device_buffer{}, 0);
-    cudaStreamSynchronize(stream.value());
-  }
 };
 
 /// Dictionary compressor: STRING column only. Encodes via cudf dictionary encode; stores the
@@ -383,16 +348,14 @@ struct dictionary_compressor : compressor {
 };
 
 // -----------------------------------------------------------------------------
-// str_split: decompose a STRING column into {offsets, chars, null_mask} channels.
+// str_split: decompose a STRING column into {offsets, chars} channels.
 // Structural (non-codegen) operator -- byte compression is delegated to the
 // channel codecs (offsets -> delta -> bitpack; chars -> lz4). Modeled on the
 // ALP rep (dedicated struct + from_outputs); decode reassembles via
-// cudf::make_strings_column. Conditional arity: a non-null column exposes
-// {offsets, chars}; a nullable column also exposes null_mask, which is marked
-// required() so the driver errors if the plan fails to route it.
+// cudf::make_strings_column. Validity is not among the channels: it is stripped
+// into the plan tree's sidecar before the walk, so the input is always null-free.
 // -----------------------------------------------------------------------------
-// channels_[0] = offsets (INT32 or INT64), channels_[1] = chars (UINT8/UINT32/UINT64),
-// channels_[2] = null_mask (UINT8 bitmask bytes, only present when nullable).
+// channels_[0] = offsets (INT32 or INT64), channels_[1] = chars (UINT8/UINT32/UINT64).
 // decompress() copies channels into make_strings_column; channels_ is left intact.
 struct str_split_compressed_representation : standalone_compressed_representation {
   static std::unique_ptr<compressed_representation> from_outputs(
@@ -404,23 +367,15 @@ struct str_split_compressed_representation : standalone_compressed_representatio
 
   str_split_compressed_representation(cudf::size_type n_rows,
                                       std::unique_ptr<cudf::column> offsets,
-                                      std::unique_ptr<cudf::column> chars,
-                                      std::unique_ptr<cudf::column> null_mask)
+                                      std::unique_ptr<cudf::column> chars)
     : standalone_compressed_representation(cudf::data_type{cudf::type_id::STRING}, n_rows)
   {
     channels_.push_back(std::move(offsets));
     channels_.push_back(std::move(chars));
-    if (null_mask) channels_.push_back(std::move(null_mask));
   }
 
   std::unique_ptr<cudf::column> decompress(rmm::cuda_stream_view stream,
                                            rmm::device_async_resource_ref mr) const override;
-
-  std::vector<std::string> required_channels() const override
-  {
-    if (channels_.size() > 2 && channels_[2]) return {"null_mask"};
-    return {};
-  }
 
   OpId kind() const override { return OpId::StrSplit; }
 };

--- a/src/compression/simpatico_codegen/include/codegen/plan/validity.hpp
+++ b/src/compression/simpatico_codegen/include/codegen/plan/validity.hpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Transparent validity handling.
+//
+// Nulls are stripped off a column before the compress walk and reattached after
+// the decode walk, so the plan DSL never mentions validity and no operator ever
+// sees a nullable input. The stripped bitmask rides along as a sidecar on the
+// column's PlanTree (see plan_tree.hpp) rather than as a routed channel.
+//
+// Two shapes cost nothing to carry and are special-cased:
+//   * no nulls  -- no sidecar, no allocation, no copy; the input view is passed
+//                  through untouched, so an all-valid column is byte-for-byte
+//                  the same work it was before validity was supported at all.
+//   * all nulls -- the bitmask is a constant, so only the kind is recorded; it
+//                  is regenerated on decode and occupies no payload bytes.
+
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cstdint>
+
+namespace simpatico {
+
+/// How a column's validity is carried alongside its compression plan.
+/// Serialized as a uint8 in the .hpln header -- do not renumber.
+enum class validity_kind : std::uint8_t {
+  all_valid = 0,  ///< No nulls. Nothing stored.
+  all_null  = 1,  ///< Every row null. Nothing stored; the mask is regenerated on decode.
+  mask      = 2,  ///< Mixed. `mask` holds the bitmask bytes for rows [0, size).
+};
+
+/// A column's validity, detached from its data.
+struct validity_sidecar {
+  validity_kind kind      = validity_kind::all_valid;
+  std::int64_t null_count = 0;
+  /// Bitmask bytes, populated iff kind == mask. Always rebased so bit i
+  /// describes row i of the logical column, whatever the source view's offset.
+  rmm::device_buffer mask;
+
+  /// True when there is nothing to reattach (the common, all-valid case).
+  bool empty() const { return kind == validity_kind::all_valid; }
+};
+
+/// Detach @p input's validity into @p out and return the same column with its
+/// null mask dropped.
+///
+/// The returned view keeps @p input's offset and children, so it is exactly what
+/// the walk would have received had the column never been nullable -- no
+/// operator behaviour changes. It borrows @p input's data, so @p input must
+/// outlive it.
+cudf::column_view strip_validity(cudf::column_view input,
+                                 validity_sidecar& out,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::device_async_resource_ref mr);
+
+/// Reattach @p v to a freshly decoded column. A no-op when @p v is all_valid.
+/// @p v is not consumed: a PlanTree can be decoded more than once, so the mask
+/// is copied rather than moved.
+void attach_validity(cudf::column& col,
+                     validity_sidecar const& v,
+                     rmm::cuda_stream_view stream,
+                     rmm::device_async_resource_ref mr);
+
+}  // namespace simpatico

--- a/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
+++ b/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
@@ -323,7 +323,62 @@ static std::unique_ptr<compressed_representation> rep_from_leaf_desc(
 // 11: a Bitpack "packed" buffer counts its decode gather guard words in num_rows, so the
 //     stored word count is what the reader allocates and the guard needs no read-side
 //     reconstruction (see compact_bitpack_packed).
-static constexpr std::uint8_t kVersion = 11;
+//
+// 12: a per-column validity sidecar record sits beside each column's plan tree (see
+//     push_validity), so a nullable column compresses instead of falling back.
+static constexpr std::uint8_t kVersion = 12;
+
+// Per-column validity record, written right after num_rows:
+//
+//   kind (uint8)                        [validity_kind]
+//   if kind != all_valid: null_count (int64 LE)
+//   if kind == mask:      size_bytes (uint64 LE) + payload_offset (uint64 LE)
+//
+// An all-valid column costs exactly one byte, and an all-null one costs nine
+// with no payload at all -- only a genuinely mixed column pays for a bitmask.
+// The mask is appended to the payload region like any leaf buffer, so callers
+// that stage the payload themselves need no special case for it.
+static void push_validity(std::vector<std::uint8_t>& hdr,
+                          validity_sidecar const& v,
+                          std::vector<payload_buffer_ref>& out_buffers,
+                          std::uint64_t& payload_offset)
+{
+  push_le(hdr, static_cast<std::uint8_t>(v.kind));
+  if (v.kind == validity_kind::all_valid) return;
+
+  push_le(hdr, v.null_count);
+  if (v.kind != validity_kind::mask) return;
+
+  auto const size_bytes = static_cast<std::uint64_t>(v.mask.size());
+  push_le(hdr, size_bytes);
+  push_le(hdr, payload_offset);
+  out_buffers.push_back(payload_buffer_ref{payload_offset, v.mask.data(), size_bytes, size_bytes});
+  payload_offset += size_bytes;
+}
+
+// Parsed form of the record above; the mask bytes are pulled from the payload
+// later (reconstruct_from_records), like every leaf buffer.
+struct ValidityRecord {
+  validity_kind kind           = validity_kind::all_valid;
+  std::int64_t null_count      = 0;
+  std::uint64_t size_bytes     = 0;
+  std::uint64_t payload_offset = 0;
+};
+
+// Inverse of push_validity. Returns false on a truncated or unknown record.
+static bool read_validity(Reader& r, ValidityRecord& v)
+{
+  std::uint8_t k;
+  if (!r.read_le(k)) return false;
+  if (k > static_cast<std::uint8_t>(validity_kind::mask)) return false;
+  v.kind = static_cast<validity_kind>(k);
+  if (v.kind == validity_kind::all_valid) return true;
+
+  if (!r.read_le(v.null_count)) return false;
+  if (v.kind != validity_kind::mask) return true;
+
+  return r.read_le(v.size_bytes) && r.read_le(v.payload_offset);
+}
 
 // Serialize one node's structure (op, bitjoin params, edges, output names).
 // Other ops carry their params in the op name, so only bitjoin needs attrs.
@@ -413,6 +468,7 @@ struct ColRecord {
   std::uint8_t dtype_tag = 0;
   std::int32_t scale     = 0;  // fixed-point scale for the column dtype (0 otherwise)
   std::int64_t num_rows  = 0;
+  ValidityRecord validity;
   PlanTree tree;
   std::vector<leaf_desc> leaf_descs;
   std::vector<std::vector<std::uint64_t>> buf_offsets;  // [leaf][buffer] -> payload offset
@@ -450,6 +506,7 @@ static bool parse_hpln_header(Reader& r, std::vector<ColRecord>& out, std::strin
     if (!r.read_le(cr.dtype_tag)) return bad("truncated col dtype");
     if (!r.read_le(cr.scale)) return bad("truncated col scale");
     if (!r.read_le(cr.num_rows)) return bad("truncated col num_rows");
+    if (!read_validity(r, cr.validity)) return bad("truncated/unknown col validity");
 
     std::uint16_t nn;
     if (!r.read_le(nn)) return bad("truncated num_nodes");
@@ -533,6 +590,17 @@ static compressed_table reconstruct_from_records(std::vector<ColRecord>& recs,
     auto plan_tree = std::make_unique<PlanTree>();
     *plan_tree     = std::move(cr.tree);
     auto& nodes    = plan_tree->nodes;
+
+    // Rebuild the validity sidecar. all_valid and all_null carry no payload, so
+    // only a mixed column costs a fetch here.
+    auto& validity      = plan_tree->validity;
+    validity.kind       = cr.validity.kind;
+    validity.null_count = cr.validity.null_count;
+    if (validity.kind == validity_kind::mask) {
+      auto const sz = static_cast<std::size_t>(cr.validity.size_bytes);
+      validity.mask = rmm::device_buffer(sz, stream, mr);
+      if (sz > 0) fetch(cr.validity.payload_offset, sz, validity.mask.data(), stream);
+    }
 
     for (std::size_t li = 0; li < cr.leaf_descs.size(); ++li) {
       auto const& ld    = cr.leaf_descs[li];
@@ -635,17 +703,22 @@ compressed_table read_compressed_table(std::string const& path,
 
   // Bounds-check every buffer up front so a truncated file is reported here
   // rather than faulting mid-copy, then copy each buffer straight to device.
+  auto in_payload = [&](std::uint64_t off, std::size_t sz) {
+    // Subtraction form: `off + sz` could overflow for a corrupt/hostile file's
+    // huge declared offset and wrap below payload_total, passing the check and
+    // then faulting in fetch(). Compare against the remaining space instead so
+    // it can never overflow.
+    return sz == 0 || (off <= payload_total && sz <= payload_total - off);
+  };
   for (auto const& cr : col_records) {
+    if (cr.validity.kind == validity_kind::mask &&
+        !in_payload(cr.validity.payload_offset, static_cast<std::size_t>(cr.validity.size_bytes)))
+      return fail("payload out of bounds");
     for (std::size_t li = 0; li < cr.leaf_descs.size(); ++li) {
       for (std::size_t bi = 0; bi < cr.leaf_descs[li].buffers.size(); ++bi) {
         std::size_t sz = static_cast<std::size_t>(cr.leaf_descs[li].buffers[bi].size_bytes);
         std::uint64_t const off = cr.buf_offsets[li][bi];
-        // Subtraction form: `off + sz` could overflow for a corrupt/hostile
-        // file's huge declared offset and wrap below payload_total, passing the
-        // check and then faulting in fetch(). Compare against the remaining space
-        // instead so it can never overflow.
-        if (sz > 0 && (off > payload_total || sz > payload_total - off))
-          return fail("payload out of bounds");
+        if (!in_payload(off, sz)) return fail("payload out of bounds");
       }
     }
   }
@@ -772,6 +845,10 @@ std::string build_compressed_table_header(compressed_table const& table,
     // Structural plan tree (identical layout to the file header, so the same
     // parser reconstructs it): the node array is the source of truth on read.
     PlanTree const& tree = col.plan_tree ? *col.plan_tree : kEmptyTree;
+
+    // Validity rides beside the tree, not inside it: it is not a leaf and has no
+    // node, so it is written here rather than through describe().
+    push_validity(hdr, tree.validity, out_buffers, payload_offset);
     push_le(hdr, static_cast<std::uint16_t>(tree.nodes.size()));
     for (auto const& node : tree.nodes)
       push_node(hdr, node);

--- a/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
+++ b/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
@@ -440,7 +440,7 @@ const char* dtype_to_cxx(const char* dtype)
   // the original float type_id so cudf reinterprets the bits correctly.
   if (s == "float32") return "int32_t";
   if (s == "float64") return "int64_t";
-  // Byte types (string sub-channels: chars, null_mask, keys_chars) map to the
+  // Byte types (string sub-channels: chars, keys_chars) map to the
   // SIGNED int8_t: zigzag's shift = elem_size*8-1 relies on sign-extension.
   // The output column retains the original UINT8 type_id.
   if (s == "uint8" || s == "uint8_t" || s == "int8" || s == "int8_t") return "int8_t";

--- a/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
+++ b/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
@@ -13,6 +13,7 @@
 #include "codegen/plan/operator_registry.hpp"  // is_terminal_compressor
 #include "codegen/plan/plan_interpreter.hpp"
 #include "codegen/plan/representation.hpp"
+#include "codegen/plan/validity.hpp"
 
 #include <cudf/copying.hpp>
 #include <cudf/strings/strings_column_view.hpp>
@@ -462,6 +463,14 @@ exploration_result explore_column_compression(cudf::column_view input,
                                               rmm::cuda_stream_view stream,
                                               rmm::device_async_resource_ref mr)
 {
+  // Explore the column as compress_column will actually see it. The BFS calls
+  // compress_single_op directly, bypassing the plan walk's strip, so without
+  // this a nullable column would be scored on data the real compress pass never
+  // feeds its operators. The sidecar is discarded — exploration only ranks how
+  // the values compress.
+  validity_sidecar explored_validity;
+  input = strip_validity(input, explored_validity, stream, mr);
+
   size_t const full_size = column_size_bytes_ex(input, stream);
 
   // Head-prefix of `input` (rows). Strings are materialized — a zero-copy slice

--- a/src/compression/simpatico_codegen/src/operators/str_split_compressor.cu
+++ b/src/compression/simpatico_codegen/src/operators/str_split_compressor.cu
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// str_split: decompose STRING into {offsets, chars, null_mask}; reassemble via
-// make_strings_column on decode. Structural operator.
+// str_split: decompose STRING into {offsets, chars}; reassemble via
+// make_strings_column on decode. Structural operator. Validity never reaches
+// here: compress_column strips it into the plan tree's sidecar beforehand.
 
 #include "codegen/plan/bitjoin_layout.hpp"  // copy_column_view
 #include "codegen/plan/representation.hpp"
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/null_mask.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
 
@@ -22,9 +22,8 @@ namespace simpatico {
 std::unique_ptr<cudf::column> str_split_compressed_representation::decompress(
   rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const
 {
-  auto& offsets   = channels_[0];
-  auto& chars     = channels_[1];
-  auto* null_mask = channels_.size() > 2 ? channels_[2].get() : nullptr;
+  auto& offsets = channels_[0];
+  auto& chars   = channels_[1];
   if (num_rows == 0 || !offsets) {
     return cudf::make_empty_column(cudf::data_type(cudf::type_id::STRING));
   }
@@ -33,20 +32,12 @@ std::unique_ptr<cudf::column> str_split_compressed_representation::decompress(
                            static_cast<std::size_t>(cudf::size_of(chars->type()));
   rmm::device_buffer chars_buf(chars->view().head<void>(), chars_bytes, stream, mr);
 
-  cudf::size_type nc = 0;
-  rmm::device_buffer mask_buf(0, stream, mr);
-  if (null_mask) {
-    auto const* bits =
-      reinterpret_cast<cudf::bitmask_type const*>(null_mask->view().data<std::uint8_t>());
-    nc = cudf::null_count(bits, 0, num_rows, stream);
-    if (nc > 0) {
-      mask_buf = rmm::device_buffer(
-        null_mask->view().head<void>(), static_cast<std::size_t>(null_mask->size()), stream, mr);
-    }
-  }
   auto offsets_copy = std::make_unique<cudf::column>(*offsets, stream, mr);
-  return cudf::make_strings_column(
-    num_rows, std::move(offsets_copy), std::move(chars_buf), nc, std::move(mask_buf));
+  return cudf::make_strings_column(num_rows,
+                                   std::move(offsets_copy),
+                                   std::move(chars_buf),
+                                   /*null_count=*/0,
+                                   rmm::device_buffer(0, stream, mr));
 }
 
 std::unique_ptr<compressed_representation> str_split_compressor::compress(
@@ -70,7 +61,7 @@ std::unique_ptr<compressed_representation> str_split_compressor::compress(
       cudf::data_type{cudf::type_id::UINT8}, 0, cudf::mask_state::UNALLOCATED, stream, mr);
     cudaStreamSynchronize(stream.value());
     return std::make_unique<str_split_compressed_representation>(
-      0, std::move(offsets), std::move(chars), nullptr);
+      0, std::move(offsets), std::move(chars));
   }
 
   std::unique_ptr<cudf::column>
@@ -78,8 +69,8 @@ std::unique_ptr<compressed_representation> str_split_compressor::compress(
   cudf::column_view src = column_to_compress;
   // Normalize any sliced view to an owned compact copy: a non-zero offset
   // needs rebasing, and a head-slice (offset 0, size < parent) still views the
-  // parent's full offsets child, so the emitted channels would be mutually
-  // inconsistent (offsets/chars parent-sized, null_mask slice-sized).
+  // parent's full offsets child, so the emitted channels would be sized off the
+  // parent rather than the slice.
   if (column_to_compress.offset() != 0 ||
       cudf::strings_column_view(column_to_compress).offsets().size() !=
         column_to_compress.size() + 1) {
@@ -123,19 +114,10 @@ std::unique_ptr<compressed_representation> str_split_compressor::compress(
     }
   }
 
-  // null_mask: owned UINT8 bitmask bytes, copied only if the column has nulls.
-  // A non-null column gets NO mask channel (2-channel str_split).
-  std::unique_ptr<cudf::column> null_mask;
-  if (src.null_count() > 0) {
-    rmm::device_buffer mbuf = cudf::copy_bitmask(src, stream, mr);
-    auto const mbytes       = static_cast<cudf::size_type>(cudf::bitmask_allocation_size_bytes(n));
-    null_mask               = std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT8}, mbytes, std::move(mbuf), rmm::device_buffer{}, 0);
-  }
   cudaStreamSynchronize(stream.value());
 
   return std::make_unique<str_split_compressed_representation>(
-    n, std::move(offsets), std::move(chars), std::move(null_mask));
+    n, std::move(offsets), std::move(chars));
 }
 
 }  // namespace simpatico

--- a/src/compression/simpatico_codegen/src/plan/compress.cpp
+++ b/src/compression/simpatico_codegen/src/plan/compress.cpp
@@ -19,6 +19,7 @@
 #include "codegen/plan/plan_interpreter.hpp"
 #include "codegen/plan/plan_tree.hpp"
 #include "codegen/plan/representation.hpp"
+#include "codegen/plan/validity.hpp"
 
 #include <cudf/column/column_factories.hpp>
 
@@ -106,14 +107,6 @@ bool is_keys_chars_path(std::string const& path)
 {
   return path.find("keys_chars") != std::string::npos;
 }
-
-// Ops that carry a nullable input's validity through to decode (via a null_mask
-// channel their representation marks required(), see representation.hpp). Every
-// other compressor operates on the packed data buffer only and would silently
-// drop the validity bitmask, surfacing garbage under the null slots on decode.
-// The walk fails closed for those (see emit_path) until numeric ops learn to
-// route validity themselves.
-bool op_handles_nulls(std::string const& op) { return op == "str_split" || op == "dictionary"; }
 
 std::unique_ptr<cudf::column> copy_identity_leaf(cudf::column_view const& view,
                                                  std::string const& path,
@@ -238,20 +231,18 @@ void CompressWalk::emit_path(ValueId v)
   }
   visited[n] = true;
 
-  // Fail closed on nullable input to an op that can't carry validity, rather
-  // than silently dropping the null mask. Intermediate channels are null-free by
-  // construction, so checking each op's input view is sufficient; only the root
-  // leaf column can legitimately carry nulls.
-  if (!op_handles_nulls(node.op)) {
-    for (auto const& src : node.input_sources) {
-      auto const src_it = columns.find(src);
-      if (src_it != columns.end() && src_it->second.null_count() > 0) {
-        set_error("compressor '" + node.op +
-                  "' does not support nullable input (validity would be dropped); "
-                  "route the column through a null-aware op (str_split/dictionary) "
-                  "or drop nulls upstream");
-        return;
-      }
+  // Backstop: no op can see a nullable input, because compress_column strips the
+  // column's validity into the tree's sidecar before the walk and intermediate
+  // channels are null-free by construction. No compressor carries a validity
+  // bitmask, so fail closed rather than silently drop one if that invariant is
+  // ever broken.
+  for (auto const& src : node.input_sources) {
+    auto const src_it = columns.find(src);
+    if (src_it != columns.end() && src_it->second.null_count() > 0) {
+      set_error("compressor '" + node.op +
+                "' received a nullable input (validity would be dropped); validity "
+                "should have been stripped into the plan tree's sidecar before the walk");
+      return;
     }
   }
 
@@ -522,25 +513,6 @@ void CompressWalk::emit_generic_node(NodeId n, cudf::column_view col)
   for (auto const& output : outputs)
     output_by_name.emplace(output.name, output.view);
 
-  // Guard: every channel the rep marks required must be routed by the plan, or
-  // data (e.g. a nullable column's validity via str_split's null_mask) would be
-  // silently dropped. Runs only when some outputs are declared (a bare terminal
-  // `input -> str_split` stored the whole rep above and is safe).
-  for (auto const& req : repr->required_channels()) {
-    bool declared = false;
-    for (auto const& out_name : node.output_names) {
-      if (req == out_name) {
-        declared = true;
-        break;
-      }
-    }
-    if (!declared) {
-      set_error("compressor '" + node.op + "' requires output '" + req +
-                "' to be routed by the plan (nullable input)");
-      return;
-    }
-  }
-
   size_t pending = 0;
   std::vector<ValueId> to_recurse;
   // The rep's owner key is this node's own representative output value {n,0} —
@@ -614,6 +586,12 @@ std::unique_ptr<PlanTree> compress_column(cudf::column_view input,
   }
   PlanTree& tree = *plan_tree;
 
+  // Detach validity before anything else looks at the column. Everything below
+  // this line -- the walk, every operator, the JIT-fused subtrees -- sees a
+  // null-free column, which is why no plan has to route a mask and no compressor
+  // has to know what one is. An all-valid input passes through untouched.
+  cudf::column_view values = strip_validity(input, tree.validity, stream, mr);
+
   // consumer_by_input[V] = the node that consumes the value produced at V,
   // derived structurally from each node's input_sources (the (node, port) each
   // input comes from). First-consumer-wins, matching parse_plan_dsl. Every value
@@ -634,7 +612,7 @@ std::unique_ptr<PlanTree> compress_column(cudf::column_view input,
   // case (a raw-passthrough or boundary channel with a downstream consumer)
   // uniformly — so there is no separate fast path to maintain here.
   ValueColumnMap columns;
-  columns.emplace(ValueId{0, 0}, input);  // the column input is value (node 0, port 0)
+  columns.emplace(ValueId{0, 0}, values);  // the column input is value (node 0, port 0)
   std::unordered_map<ValueId, std::unique_ptr<compressed_representation>, ValueIdHash>
     reprs_by_input;
   std::vector<bool> visited(tree.nodes.size(), false);

--- a/src/compression/simpatico_codegen/src/plan/decompress.cpp
+++ b/src/compression/simpatico_codegen/src/plan/decompress.cpp
@@ -4,6 +4,7 @@
 #include "codegen/decode/masked_launch.hpp"
 #include "codegen/plan/bitjoin_layout.hpp"
 #include "codegen/plan/plan_interpreter.hpp"
+#include "codegen/plan/validity.hpp"
 
 #include <cudf/aggregation.hpp>
 #include <cudf/binaryop.hpp>
@@ -1299,6 +1300,16 @@ std::unique_ptr<cudf::column> decompress_column(PlanTree const& tree,
 
   bool const selecting    = sel != nullptr && sel->active();
   bool const substituting = pred != nullptr && pred->active();
+  // A selection compacts the value rows, while the stored bitmask describes
+  // every row of the chunk. Returning it verbatim would misalign validity with
+  // values, so a nullable column is refused here; a caller that wants both
+  // reattaches the mask itself against the same selection it passed in.
+  if (selecting && !tree.validity.empty()) {
+    if (error_out) {
+      *error_out = "decompress: selection on a null-masked column is not supported";
+    }
+    return nullptr;
+  }
   // The requested route must be the one this plan actually supports: a
   // mismatch would silently decode full width where the caller sized the
   // output from the survivor count.
@@ -1432,6 +1443,10 @@ std::unique_ptr<cudf::column> decompress_column(PlanTree const& tree,
     // soon as we return, so the gather must have completed.
     cudaStreamSynchronize(stream.value());
   }
+  // Reattach the validity the compress side detached. The walk decodes a
+  // null-free column, so this is the only place the mask re-enters the picture;
+  // a selecting decode was refused above and reaches here only when all-valid.
+  if (col) { attach_validity(*col, tree.validity, stream, mr); }
   return col;
 }
 

--- a/src/compression/simpatico_codegen/src/plan/decompress.cpp
+++ b/src/compression/simpatico_codegen/src/plan/decompress.cpp
@@ -1304,7 +1304,7 @@ std::unique_ptr<cudf::column> decompress_column(PlanTree const& tree,
   // every row of the chunk. Returning it verbatim would misalign validity with
   // values, so a nullable column is refused here; a caller that wants both
   // reattaches the mask itself against the same selection it passed in.
-  if (selecting && !tree.validity.empty()) {
+  if (selecting && !tree.validity.empty() && !sel->caller_reattaches_validity) {
     if (error_out) {
       *error_out = "decompress: selection on a null-masked column is not supported";
     }
@@ -1444,9 +1444,10 @@ std::unique_ptr<cudf::column> decompress_column(PlanTree const& tree,
     cudaStreamSynchronize(stream.value());
   }
   // Reattach the validity the compress side detached. The walk decodes a
-  // null-free column, so this is the only place the mask re-enters the picture;
-  // a selecting decode was refused above and reaches here only when all-valid.
-  if (col) { attach_validity(*col, tree.validity, stream, mr); }
+  // null-free column, so this is the only place the mask re-enters the picture.
+  // A selecting decode is either all-valid or served an opting-in caller, which
+  // compacts the sidecar itself against the selection it supplied.
+  if (col && !selecting) { attach_validity(*col, tree.validity, stream, mr); }
   return col;
 }
 

--- a/src/compression/simpatico_codegen/src/plan/operator_registry.cpp
+++ b/src/compression/simpatico_codegen/src/plan/operator_registry.cpp
@@ -56,9 +56,7 @@ std::vector<OperatorInfo> const& operator_registry()
     {OpId::Bitextract,     "bitextract",      {},                                                                     true,  false, true,  false},
     {OpId::Identity,       "identity",        {"data"},                                                               false, false, false, false},
     {OpId::NvcompCascaded, "nvcomp_cascaded", {"output"},                                                             false, false, false, false},
-    // 2 or 3 channels: offsets, chars[, null_mask]. null_mask is optional (present only when
-    // nullable); the generic named_channels() skips nullptr slots so arity is correct at runtime.
-    {OpId::StrSplit,       "str_split",       {"offsets", "chars", "null_mask"},                                     true,  false, true,  false},
+    {OpId::StrSplit,       "str_split",       {"offsets", "chars"},                                                   true,  false, true,  false},
   };
   // clang-format on
   return kTable;

--- a/src/compression/simpatico_codegen/src/plan/representation_factory.cpp
+++ b/src/compression/simpatico_codegen/src/plan/representation_factory.cpp
@@ -17,7 +17,6 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/dictionary/dictionary_factories.hpp>
-#include <cudf/null_mask.hpp>
 
 #include <rmm/device_buffer.hpp>
 #include <rmm/resource_ref.hpp>
@@ -127,36 +126,6 @@ std::unique_ptr<compressed_representation> identity_compressed_representation::f
   return std::make_unique<identity_compressed_representation>(std::move(outputs[0]));
 }
 
-namespace {
-
-// Reads a "null_mask" channel column (UINT8 bitmask bytes, as emitted by
-// dictionary/str_split named_channels) into a device_buffer + null count over
-// `num_rows` rows. Returns false and sets *error_out on a malformed channel.
-bool take_null_mask_channel(std::unique_ptr<cudf::column> mask_col,
-                            cudf::size_type num_rows,
-                            rmm::device_buffer* mask_out,
-                            cudf::size_type* null_count_out,
-                            rmm::cuda_stream_view stream,
-                            std::string* error_out)
-{
-  if (mask_col->type().id() != cudf::type_id::UINT8) {
-    if (error_out) *error_out = "dictionary null_mask must be UINT8";
-    return false;
-  }
-  if (static_cast<std::size_t>(mask_col->size()) < cudf::bitmask_allocation_size_bytes(num_rows)) {
-    if (error_out) *error_out = "dictionary null_mask is shorter than the row count requires";
-    return false;
-  }
-  auto const* bits =
-    reinterpret_cast<cudf::bitmask_type const*>(mask_col->view().data<std::uint8_t>());
-  *null_count_out = num_rows > 0 ? cudf::null_count(bits, 0, num_rows, stream) : 0;
-  auto contents   = mask_col->release();
-  *mask_out       = std::move(*contents.data);
-  return true;
-}
-
-}  // namespace
-
 std::unique_ptr<compressed_representation> dictionary_compressed_representation::from_outputs(
   std::vector<std::string> const& output_names,
   std::vector<std::unique_ptr<cudf::column>> outputs,
@@ -168,17 +137,10 @@ std::unique_ptr<compressed_representation> dictionary_compressed_representation:
     if (error_out) *error_out = "dictionary: output_names / outputs size mismatch";
     return nullptr;
   }
-  // Accepts a trailing optional "null_mask" channel (UINT8 bitmask bytes of the
-  // decoded column) — reattached below so validity survives channel-based
-  // round-trips (.hpln IO and decomposed plans).
-  bool const has_mask = !output_names.empty() && output_names.back() == "null_mask";
-
-  // keys_offsets, keys_chars, indices (+ null_mask).
-  if (outputs.size() != (has_mask ? 4u : 3u) || output_names[0] != "keys_offsets" ||
+  if (outputs.size() != 3u || output_names[0] != "keys_offsets" ||
       output_names[1] != "keys_chars" || output_names[2] != "indices") {
     if (error_out) {
-      *error_out =
-        "dictionary outputs must be named 'keys_offsets, keys_chars, indices[, null_mask]'";
+      *error_out = "dictionary outputs must be named 'keys_offsets, keys_chars, indices'";
     }
     return nullptr;
   }
@@ -190,14 +152,6 @@ std::unique_ptr<compressed_representation> dictionary_compressed_representation:
   cudf::size_type num_keys    = num_offsets > 0 ? static_cast<cudf::size_type>(num_offsets - 1) : 0;
   if (keys_chars->type().id() != cudf::type_id::UINT8) {
     if (error_out) *error_out = "dictionary keys_chars must be UINT8";
-    return nullptr;
-  }
-
-  rmm::device_buffer mask(0, stream, mr);
-  cudf::size_type null_count = 0;
-  if (has_mask &&
-      !take_null_mask_channel(
-        std::move(outputs[3]), indices->size(), &mask, &null_count, stream, error_out)) {
     return nullptr;
   }
 
@@ -214,10 +168,7 @@ std::unique_ptr<compressed_representation> dictionary_compressed_representation:
                                                 rmm::device_buffer(0, stream, mr));
 
   auto dict_col =
-    null_count > 0
-      ? cudf::make_dictionary_column(
-          std::move(keys_strings), std::move(indices), std::move(mask), null_count)
-      : cudf::make_dictionary_column(std::move(keys_strings), std::move(indices), stream, mr);
+    cudf::make_dictionary_column(std::move(keys_strings), std::move(indices), stream, mr);
   // Indices, keys, and chars are then obtained as views from this column via
   // get_dictionary_child_view(dict_col->view(), ...) / dictionary_column_view.
   return std::make_unique<dictionary_compressed_representation>(std::move(dict_col));
@@ -380,20 +331,16 @@ std::unique_ptr<compressed_representation> str_split_compressed_representation::
   rmm::device_async_resource_ref,
   std::string* error_out)
 {
-  // Variable arity: {offsets, chars} or {offsets, chars, null_mask}.
-  bool const has_mask = outputs.size() == 3;
-  if (outputs.size() != 2 && outputs.size() != 3) {
-    if (error_out) *error_out = "str_split expects 2 (offsets, chars) or 3 (+ null_mask) outputs";
+  if (outputs.size() != 2) {
+    if (error_out) *error_out = "str_split expects 2 outputs (offsets, chars)";
     return nullptr;
   }
-  if (output_names[0] != "offsets" || output_names[1] != "chars" ||
-      (has_mask && output_names[2] != "null_mask")) {
-    if (error_out) *error_out = "str_split outputs must be 'offsets, chars[, null_mask]'";
+  if (output_names[0] != "offsets" || output_names[1] != "chars") {
+    if (error_out) *error_out = "str_split outputs must be 'offsets, chars'";
     return nullptr;
   }
   auto offsets       = std::move(outputs[0]);
   auto chars         = std::move(outputs[1]);
-  auto null_mask     = has_mask ? std::move(outputs[2]) : nullptr;
   auto const off_tid = offsets->type().id();
   if (off_tid != cudf::type_id::INT32 && off_tid != cudf::type_id::INT64) {
     if (error_out) *error_out = "str_split offsets must be INT32 or INT64";
@@ -404,13 +351,13 @@ std::unique_ptr<compressed_representation> str_split_compressed_representation::
   auto const chars_tid = chars->type().id();
   bool const chars_ok  = chars_tid == cudf::type_id::UINT8 || chars_tid == cudf::type_id::UINT32 ||
                         chars_tid == cudf::type_id::UINT64;
-  if (!chars_ok || (null_mask && null_mask->type().id() != cudf::type_id::UINT8)) {
-    if (error_out) *error_out = "str_split chars must be UINT8/UINT32/UINT64, null_mask UINT8";
+  if (!chars_ok) {
+    if (error_out) *error_out = "str_split chars must be UINT8/UINT32/UINT64";
     return nullptr;
   }
   cudf::size_type const n = offsets->size() > 0 ? offsets->size() - 1 : 0;
   return std::make_unique<str_split_compressed_representation>(
-    n, std::move(offsets), std::move(chars), std::move(null_mask));
+    n, std::move(offsets), std::move(chars));
 }
 
 std::unique_ptr<compressed_representation> bitextract_compressed_representation::from_outputs(

--- a/src/compression/simpatico_codegen/src/plan/validity.cpp
+++ b/src/compression/simpatico_codegen/src/plan/validity.cpp
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// strip_validity / attach_validity: the two ends of the transparent null path.
+// See validity.hpp for the contract.
+
+#include "codegen/plan/validity.hpp"
+
+#include <cudf/null_mask.hpp>
+
+#include <vector>
+
+namespace simpatico {
+
+cudf::column_view strip_validity(cudf::column_view input,
+                                 validity_sidecar& out,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::device_async_resource_ref mr)
+{
+  auto const n     = input.size();
+  auto const nulls = input.null_count();
+
+  // Fast path: nothing to carry. No allocation, no copy, no kernel -- the view
+  // reaches the walk exactly as it arrived. An all-valid column pays nothing for
+  // nullability support, including in the .hpln header (see push_validity).
+  if (nulls == 0 || n == 0) {
+    out = validity_sidecar{};
+    return input;
+  }
+
+  if (nulls == n) {
+    // Fast path: every row is null, so the bitmask is a constant. Record the
+    // kind alone -- nothing is copied here and nothing is serialized later;
+    // attach_validity regenerates the mask from the row count.
+    out.kind       = validity_kind::all_null;
+    out.null_count = n;
+    out.mask       = rmm::device_buffer{};
+  } else {
+    // copy_bitmask rebases a sliced view's mask to start at row 0, so the
+    // sidecar always describes rows [0, size) of the logical column regardless
+    // of input.offset().
+    out.kind       = validity_kind::mask;
+    out.null_count = nulls;
+    out.mask       = cudf::copy_bitmask(input, stream, mr);
+  }
+
+  // The same column with its validity buffer dropped. Offset and children are
+  // preserved, so stripping is behaviourally neutral: every operator sees what
+  // it would have seen had the column arrived all-valid.
+  std::vector<cudf::column_view> children;
+  children.reserve(static_cast<std::size_t>(input.num_children()));
+  for (cudf::size_type i = 0; i < input.num_children(); ++i) {
+    children.push_back(input.child(i));
+  }
+  return cudf::column_view(input.type(),
+                           n,
+                           input.head<void>(),
+                           /*null_mask=*/nullptr,
+                           /*null_count=*/0,
+                           input.offset(),
+                           children);
+}
+
+void attach_validity(cudf::column& col,
+                     validity_sidecar const& v,
+                     rmm::cuda_stream_view stream,
+                     rmm::device_async_resource_ref mr)
+{
+  switch (v.kind) {
+    case validity_kind::all_valid: return;
+
+    case validity_kind::all_null:
+      col.set_null_mask(cudf::create_null_mask(col.size(), cudf::mask_state::ALL_NULL, stream, mr),
+                        col.size());
+      return;
+
+    case validity_kind::mask:
+      // Copied, not moved: decompress_column takes the tree by const reference
+      // and the same tree may be decoded repeatedly (e.g. a pinned chunk served
+      // to several queries).
+      col.set_null_mask(rmm::device_buffer(v.mask.data(), v.mask.size(), stream, mr),
+                        static_cast<cudf::size_type>(v.null_count));
+      return;
+  }
+}
+
+}  // namespace simpatico

--- a/src/compression/simpatico_codegen/src/simpatico_codegen.cpp
+++ b/src/compression/simpatico_codegen/src/simpatico_codegen.cpp
@@ -445,6 +445,11 @@ std::optional<std::vector<std::unique_ptr<cudf::column>>> try_decompress_fused(
     auto const& col = table.columns[idx];
     if (!col.plan_tree || col.num_rows != num_rows)
       return refuse("selected column missing plan_tree or row-count mismatch");
+    // A compacted decode returns the surviving rows while the stored bitmask
+    // still spans the whole chunk, and nothing on this path compacts one against
+    // the other. Refused here, before any device work, rather than as a
+    // per-column failure that unwinds the whole batch mid-flight.
+    if (!col.plan_tree->validity.empty()) return refuse("selected column is nullable");
   }
   for (auto const& f : request.filters) {
     if (f.column >= selected.size()) return refuse("filter directive column out of range");

--- a/src/compression/simpatico_codegen/src/simpatico_codegen.cpp
+++ b/src/compression/simpatico_codegen/src/simpatico_codegen.cpp
@@ -1032,12 +1032,36 @@ PlanTree const* column_plan(const compressed_table& table,
 
 }  // namespace
 
+validity_sidecar const* column_validity(const compressed_table& table, std::size_t column_index)
+{
+  auto const* tree = column_plan(table, column_index, nullptr, "column_validity");
+  return tree == nullptr ? nullptr : &tree->validity;
+}
+
+std::optional<std::int64_t> column_null_count(const compressed_table& table,
+                                              std::size_t column_index)
+{
+  auto const* v = column_validity(table, column_index);
+  if (v == nullptr) { return std::nullopt; }
+  switch (v->kind) {
+    case validity_kind::all_valid: return std::int64_t{0};
+    case validity_kind::all_null:
+    case validity_kind::mask:
+      // A negative count is a record the writer never produces; reading it as
+      // "no nulls" would admit a column on a corrupted header.
+      if (v->null_count < 0) { return std::nullopt; }
+      return v->null_count;
+  }
+  return std::nullopt;
+}
+
 std::unique_ptr<cudf::column> decompress_column_rows(const compressed_table& table,
                                                      std::size_t column_index,
                                                      sirius::codegen::chunk_row_set const& rows,
                                                      rmm::cuda_stream_view stream,
                                                      rmm::device_async_resource_ref mr,
-                                                     std::string* error_out)
+                                                     std::string* error_out,
+                                                     validity_sidecar const** stripped_validity)
 {
   auto const* tree = column_plan(table, column_index, error_out, "decompress_column_rows");
   if (tree == nullptr) { return nullptr; }
@@ -1055,12 +1079,14 @@ std::unique_ptr<cudf::column> decompress_column_rows(const compressed_table& tab
   }
 
   decode_selection sel;
-  sel.rows           = &rows;
-  sel.survivor_count = rows.num_survivors;
-  sel.route          = sirius::codegen::decode_route::bitpack_mask;
+  sel.rows                       = &rows;
+  sel.survivor_count             = rows.num_survivors;
+  sel.route                      = sirius::codegen::decode_route::bitpack_mask;
+  sel.caller_reattaches_validity = stripped_validity != nullptr;
 
   auto col = decompress_column(*tree, stream, mr, error_out, nullptr, &sel);
   if (!col) { return nullptr; }
+  if (stripped_validity != nullptr) { *stripped_validity = &tree->validity; }
   return apply_stored_dtype(std::move(col), table.columns[column_index].dtype);
 }
 
@@ -1070,7 +1096,8 @@ std::unique_ptr<cudf::column> decompress_column_compacted(
   sirius::codegen::selection_mask const& mask,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr,
-  std::string* error_out)
+  std::string* error_out,
+  validity_sidecar const** stripped_validity)
 {
   auto const* tree = column_plan(table, column_index, error_out, "decompress_column_compacted");
   if (tree == nullptr) { return nullptr; }
@@ -1087,12 +1114,14 @@ std::unique_ptr<cudf::column> decompress_column_compacted(
   }
 
   decode_selection sel;
-  sel.mask           = &mask;
-  sel.survivor_count = mask.survivor_count;
-  sel.route          = route;
+  sel.mask                       = &mask;
+  sel.survivor_count             = mask.survivor_count;
+  sel.route                      = route;
+  sel.caller_reattaches_validity = stripped_validity != nullptr;
 
   auto col = decompress_column(*tree, stream, mr, error_out, nullptr, &sel);
   if (!col) { return nullptr; }
+  if (stripped_validity != nullptr) { *stripped_validity = &tree->validity; }
   return apply_stored_dtype(std::move(col), table.columns[column_index].dtype);
 }
 

--- a/src/compression/simpatico_codegen/tests/test_compress_with_plan_roundtrip.cpp
+++ b/src/compression/simpatico_codegen/tests/test_compress_with_plan_roundtrip.cpp
@@ -797,10 +797,11 @@ int main()
     }
 
     {
-      // str_split: decompose STRING into offsets/chars[/null_mask], compress each
-      // channel independently (offsets -> delta -> bitpack fused; chars -> lz4),
-      // reassemble via make_strings_column. Conditional arity: a non-null column
-      // uses a 2-channel plan; a nullable column MUST route null_mask (guarded).
+      // str_split: decompose STRING into offsets/chars, compress each channel
+      // independently (offsets -> delta -> bitpack fused; chars -> lz4),
+      // reassemble via make_strings_column. Validity never reaches str_split --
+      // compress_column strips it into the tree's sidecar -- so ONE 2-channel
+      // plan serves nullable and non-nullable columns alike.
       // NOTE the nested path str_split.offsets.differences (offsets is non-root).
       auto stream                   = cudf::get_default_stream();
       std::vector<std::string> vals = {
@@ -815,28 +816,32 @@ int main()
       roundtrip_once(t->view(), dsl2, 1, "str_split");
       roundtrip_once(t->view(), dsl2, 2, "str_split_mt");
 
-      // Nullable: 3-channel plan carries the mask (null_mask declared on line 1).
-      std::string const dsl3 =
-        "input -> str_split -> offsets, chars, null_mask\n"
-        "str_split.offsets -> delta -> differences\n"
-        "str_split.offsets.differences -> bitpack\n"
-        "str_split.chars -> lz4\n"
-        "str_split.null_mask -> identity\n";
+      // The SAME plan on a nullable column: the mask rides the tree's sidecar, so
+      // the plan needs no null_mask leg and the walk is identical to the
+      // non-nullable case above.
       std::vector<bool> valid = {true, false, true, true, false, true, true, false};  // 3 nulls
       auto tn                 = make_strings_table(vals, valid, stream);
-      auto ct                 = roundtrip_once(tn->view(), dsl3, 1, "str_split_nulls");
+      auto ct                 = roundtrip_once(tn->view(), dsl2, 1, "str_split_nulls");
       // strings_equal ignores validity, so assert null preservation explicitly.
       auto decoded = decompress(ct, stream, rmm::mr::get_current_device_resource_ref());
       expect(decoded->view().column(0).null_count() == 3, "str_split_nulls: null_count preserved");
+      expect(validity_equal(tn->view().column(0), decoded->view().column(0)),
+             "str_split_nulls: null positions preserved");
+      expect(ct.columns[0].plan_tree->validity.kind == simpatico::validity_kind::mask,
+             "str_split_nulls: sidecar carries a mask");
 
-      // Guard: nullable column + 2-channel plan must ERROR, not drop nulls silently.
-      bool threw = false;
+      // A plan that still declares null_mask must ERROR: str_split no longer
+      // produces that channel, and silently ignoring a declared output would
+      // hide plan typos.
+      std::string const dsl_mask = dsl2 + "str_split.null_mask -> identity\n";
+      bool threw                 = false;
       try {
-        compress_with_plan(tn->view(), dsl2, stream, rmm::mr::get_current_device_resource_ref());
+        compress_with_plan(
+          tn->view(), dsl_mask, stream, rmm::mr::get_current_device_resource_ref());
       } catch (std::runtime_error const&) {
         threw = true;
       }
-      expect(threw, "str_split: nullable input without null_mask must throw");
+      expect(threw, "str_split: a plan routing null_mask must throw");
     }
 
     {
@@ -890,9 +895,9 @@ int main()
     }
 
     {
-      // Nullable STRING through the byte codecs must be REJECTED (the payload
-      // carries no mask), and a decomposed dictionary plan that fails to
-      // route null_mask must error rather than silently drop validity.
+      // STRING through the raw byte codecs is still rejected -- but on dtype
+      // grounds ("only fixed-width columns supported; use str_split"), which has
+      // nothing to do with validity and applies equally to a non-null column.
       auto stream = cudf::get_default_stream();
       auto mr     = rmm::mr::get_current_device_resource_ref();
       auto tn     = make_strings_table({"a", "b"}, {true, false}, stream);
@@ -903,24 +908,21 @@ int main()
         } catch (std::exception const&) {
           threw = true;
         }
-        expect(threw, "nullable STRING through ans/bitcomp must throw");
+        expect(threw, "STRING through ans/bitcomp must throw (not fixed-width)");
       }
-      bool threw = false;
-      try {
-        compress_with_plan(
-          tn->view(), "input -> dictionary -> keys_offsets, keys_chars, indices\n", stream, mr);
-      } catch (std::exception const&) {
-        threw = true;
-      }
-      expect(threw, "nullable decomposed dictionary without null_mask must throw");
+      // A decomposed dictionary plan no longer has to route null_mask.
+      auto ctd = compress_with_plan(
+        tn->view(), "input -> dictionary -> keys_offsets, keys_chars, indices\n", stream, mr);
+      auto decd = decompress(ctd, stream, mr);
+      expect(validity_equal(tn->view().column(0), decd->view().column(0)),
+             "nullable decomposed dictionary preserves validity");
     }
 
     {
-      // Nullable NUMERIC input through a non-null-aware op must be REJECTED,
-      // not silently stripped of validity. No numeric op carries a null_mask
-      // channel, so both the fused codegen path (delta -> bitpack) and the
-      // generic byte codecs (ans) must fail closed rather than decode garbage
-      // under the null slots.
+      // Nullable NUMERIC input. No numeric op carries a null_mask channel, so
+      // every one of these used to fail closed; with validity stripped into the
+      // sidecar they all round-trip, through both the fused codegen path
+      // (delta / bitpack) and the generic byte codecs (ans).
       auto stream = cudf::get_default_stream();
       auto mr     = rmm::mr::get_current_device_resource_ref();
       // Build a nullable INT32 column (offset 0, one null at row 5) directly so
@@ -934,43 +936,72 @@ int main()
                      host.data(),
                      host.size() * sizeof(std::int32_t),
                      cudaMemcpyHostToDevice) != cudaSuccess)
-        throw std::runtime_error("nullable numeric guard: cudaMemcpy failed");
+        throw std::runtime_error("nullable numeric: cudaMemcpy failed");
       cudf::set_null_mask(col->mutable_view().null_mask(), 5, 6, /*valid=*/false, stream);
       col->set_null_count(1);
       cudf::table_view nullable_tbl({col->view()});
-      expect(col->null_count() == 1, "nullable numeric guard: input has one null");
+      expect(col->null_count() == 1, "nullable numeric: input has one null");
       for (char const* plan :
            {"input -> delta -> differences\n", "input -> ans\n", "input -> bitpack\n"}) {
-        bool threw = false;
-        try {
-          compress_with_plan(nullable_tbl, plan, stream, mr);
-        } catch (std::exception const&) {
-          threw = true;
-        }
-        expect(threw, "nullable numeric input through a non-null-aware op must throw");
+        auto ct = compress_with_plan(nullable_tbl, plan, stream, mr);
+        expect(ct.columns[0].plan_tree->validity.kind == simpatico::validity_kind::mask,
+               "nullable numeric: sidecar carries a mask");
+        auto dec = decompress(ct, stream, mr);
+        // columns_equal compares the payload bytes AND validity, so a roundtrip
+        // that moved or lost the null fails here.
+        expect(columns_equal(nullable_tbl.column(0), dec->view().column(0)),
+               "nullable numeric roundtrip preserves data and validity");
       }
     }
 
     {
-      // Nullable decomposed dictionary WITH the null_mask channel routed:
-      // validity must survive the from_outputs rebuild.
+      // Validity fast paths. An all-valid column must carry no sidecar at all
+      // (byte-identical to the pre-sidecar behaviour), and an all-null column
+      // must record only the kind -- no bitmask is copied or serialized.
+      auto stream = cudf::get_default_stream();
+      auto mr     = rmm::mr::get_current_device_resource_ref();
+
+      auto plain = make_int32_table(1, 256, 7);
+      auto ctv   = compress_with_plan(plain->view(), "input -> delta -> differences\n", stream, mr);
+      expect(ctv.columns[0].plan_tree->validity.kind == simpatico::validity_kind::all_valid,
+             "all-valid column carries no sidecar");
+      expect(ctv.columns[0].plan_tree->validity.mask.size() == 0,
+             "all-valid column allocates no mask");
+
+      auto all_null = cudf::make_numeric_column(
+        cudf::data_type{cudf::type_id::INT32}, 32, cudf::mask_state::ALL_NULL, stream, mr);
+      all_null->set_null_count(32);
+      cudf::table_view an_tbl({all_null->view()});
+      auto cta = compress_with_plan(an_tbl, "input -> delta -> differences\n", stream, mr);
+      expect(cta.columns[0].plan_tree->validity.kind == simpatico::validity_kind::all_null,
+             "all-null column takes the all_null fast path");
+      expect(cta.columns[0].plan_tree->validity.mask.size() == 0,
+             "all-null column stores no bitmask");
+      auto deca = decompress(cta, stream, mr);
+      expect(deca->view().column(0).null_count() == 32, "all-null column decodes back to all-null");
+    }
+
+    {
+      // Nullable decomposed dictionary: validity must survive the from_outputs
+      // rebuild, carried by the sidecar rather than a routed channel.
       auto stream             = cudf::get_default_stream();
       std::vector<bool> valid = {true, false, true, true};
       auto tn                 = make_strings_table({"apple", "", "cherry", "apple"}, valid, stream);
       auto ct                 = roundtrip_once(tn->view(),
-                               "input -> dictionary -> keys_offsets, keys_chars, indices, "
-                                               "null_mask\n"
-                                               "dictionary.indices -> bitpack\n"
-                                               "dictionary.null_mask -> identity\n",
+                               "input -> dictionary -> keys_offsets, keys_chars, indices\n"
+                                               "dictionary.indices -> bitpack\n",
                                1,
                                "dictionary_decomposed_nulls");
       auto decoded            = decompress(ct, stream, rmm::mr::get_current_device_resource_ref());
       expect(decoded->view().column(0).null_count() == 1, "dictionary_decomposed_nulls: count");
+      expect(validity_equal(tn->view().column(0), decoded->view().column(0)),
+             "dictionary_decomposed_nulls: positions");
     }
 
     {
-      // u8 codegen on string sub-channels: RLE on the (mostly 0xFF) null_mask
-      // bytes and a fused delta->bitpack cascade on the chars bytes.
+      // u8 codegen on string sub-channels: a fused delta->bitpack cascade on the
+      // offsets and lz4 on the chars bytes, with a sparse null pattern riding the
+      // sidecar alongside.
       auto stream = cudf::get_default_stream();
       std::vector<std::string> v64;
       std::vector<bool> b64;
@@ -980,15 +1011,16 @@ int main()
       }
       auto tn      = make_strings_table(v64, b64, stream);
       auto ct      = roundtrip_once(tn->view(),
-                               "input -> str_split -> offsets, chars, null_mask\n"
+                               "input -> str_split -> offsets, chars\n"
                                     "str_split.offsets -> delta -> differences\n"
                                     "str_split.offsets.differences -> bitpack\n"
-                                    "str_split.chars -> lz4\n"
-                                    "str_split.null_mask -> rle -> runs, values\n",
+                                    "str_split.chars -> lz4\n",
                                1,
-                               "str_split_null_mask_rle_u8");
+                               "str_split_sparse_nulls_u8");
       auto decoded = decompress(ct, stream, rmm::mr::get_current_device_resource_ref());
-      expect(decoded->view().column(0).null_count() == 2, "str_split_null_mask_rle_u8: count");
+      expect(decoded->view().column(0).null_count() == 2, "str_split_sparse_nulls_u8: count");
+      expect(validity_equal(tn->view().column(0), decoded->view().column(0)),
+             "str_split_sparse_nulls_u8: positions");
 
       std::vector<std::string> vals8 = {"aa", "bb", "cc", "aa", "dd", "bb", "ee", "aa"};
       auto t8                        = make_strings_table(vals8, {}, stream);

--- a/src/compression/simpatico_codegen/tests/test_compressed_table_io.cpp
+++ b/src/compression/simpatico_codegen/tests/test_compressed_table_io.cpp
@@ -639,6 +639,49 @@ void test_str_split_plan_shapes_roundtrip()
   memory_roundtrip("str_split_bare_terminal_mem", addr_tbl->view(), bare_dsl);
 }
 
+// Validity survives both serialization paths. The sidecar is not a leaf, so it
+// travels in its own per-column header record rather than through describe() --
+// this covers the file path, the pinned in-memory path, and the two fast paths
+// that write no payload bytes at all.
+void test_validity_sidecar_roundtrip()
+{
+  auto stream = cudf::get_default_stream();
+  auto mr     = rmm::mr::get_current_device_resource_ref();
+
+  // Mixed validity: a real bitmask is written to the payload region.
+  auto mixed = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT32}, 128, cudf::mask_state::ALL_VALID, stream, mr);
+  std::vector<std::int32_t> host(128);
+  for (int r = 0; r < 128; ++r)
+    host[static_cast<std::size_t>(r)] = static_cast<std::int32_t>((r * 31 + 7) % 5000);
+  if (cudaMemcpy(mixed->mutable_view().head<std::int32_t>(),
+                 host.data(),
+                 host.size() * sizeof(std::int32_t),
+                 cudaMemcpyHostToDevice) != cudaSuccess)
+    throw std::runtime_error("validity_sidecar: cudaMemcpy failed");
+  cudf::set_null_mask(mixed->mutable_view().null_mask(), 3, 4, /*valid=*/false, stream);
+  cudf::set_null_mask(mixed->mutable_view().null_mask(), 70, 96, /*valid=*/false, stream);
+  mixed->set_null_count(27);
+  cudf::table_view mixed_tbl({mixed->view()});
+  io_roundtrip("validity_mixed", mixed_tbl, "input -> delta -> differences\n");
+  memory_roundtrip("validity_mixed_mem", mixed_tbl, "input -> delta -> differences\n");
+
+  // All null: nothing is written to the payload, so this also checks that the
+  // reader rebuilds the mask from the kind alone.
+  auto all_null = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT32}, 64, cudf::mask_state::ALL_NULL, stream, mr);
+  all_null->set_null_count(64);
+  cudf::table_view an_tbl({all_null->view()});
+  io_roundtrip("validity_all_null", an_tbl, "input -> delta -> differences\n");
+  memory_roundtrip("validity_all_null_mem", an_tbl, "input -> delta -> differences\n");
+
+  // Nullable STRING through str_split, where validity used to be a routed channel.
+  std::vector<bool> valid = {true, false, true, true, false, true};
+  auto strs = make_strings_table({"alpha", "", "gamma", "delta", "x", "zeta"}, valid, stream);
+  io_roundtrip("validity_strings", strs->view(), "input -> str_split\n");
+  memory_roundtrip("validity_strings_mem", strs->view(), "input -> str_split\n");
+}
+
 }  // namespace
 
 int main()
@@ -674,6 +717,7 @@ int main()
     {"error_bad_version", test_error_bad_version},
     {"identity_string_roundtrip", test_identity_string_roundtrip},
     {"str_split_plan_shapes", test_str_split_plan_shapes_roundtrip},
+    {"validity_sidecar", test_validity_sidecar_roundtrip},
   };
 
   int failures = 0;

--- a/src/include/late_mat/materialize.hpp
+++ b/src/include/late_mat/materialize.hpp
@@ -81,22 +81,18 @@ struct pinned_column_view {
 /// prepared against, since a positional mismatch would read the right number of
 /// rows from the wrong batches.
 ///
-/// A COMPRESSED origin IS served here, by materialize_compressed: a dense batch
-/// takes an ordinary full decode, and a selective one tries the sparse walk
+/// A compressed origin is handled by materialize_compressed: a dense batch takes
+/// an ordinary full decode, and a selective one tries the sparse walk
 /// (simpatico::decompress_column_rows over the CSR each batch already carries),
 /// falling back to the mask route for the shapes with no random access
-/// (dictionary, str_split, render rejections) and to a full decode as the last
-/// resort. None of these routes writes an output validity buffer, so a decoded
-/// column that turns out to contain nulls is rejected rather than returned
-/// half-formed (require_non_null).
+/// (dictionary, str_split, render rejections) and to a full decode otherwise.
 ///
-/// What this materializer can serve and what the INSTALLER admits are two
-/// different questions. Today no compressed origin reaches here: the install
-/// gate refuses one outright, because pinned_column_null_count cannot read a
-/// compressed chunk's null count without decoding it and so reports "unknown",
-/// which the nullability check treats as unsafe. These routes are therefore
-/// exercised by their own tests rather than by a query, and they are what a
-/// future relaxation of that gate would rest on.
+/// Every route carries validity. Compression strips a column's nulls into a
+/// sidecar beside its plan tree, so a full decode reattaches them itself, and
+/// the two compacting routes gather the stored bitmask by the same rows they
+/// selected the values by: that mask describes the whole chunk, and returning it
+/// verbatim beside a compacted column would pair each value with another row's
+/// validity.
 std::unique_ptr<cudf::column> materialize(pinned_column_view const& column,
                                           prepared_selection const& selection,
                                           rmm::cuda_stream_view stream,

--- a/src/include/late_mat/multi_source_gather.hpp
+++ b/src/include/late_mat/multi_source_gather.hpp
@@ -54,4 +54,23 @@ void multi_source_gather_fixed(void const* const* bases_dev,
                                std::uint32_t* out_mask,
                                rmm::cuda_stream_view stream);
 
+/// Gather validity bits: bit `i` of `out_mask` is bit `map[i]` of `source_mask`.
+///
+/// A compacted decode returns only the selected rows of a chunk while the
+/// chunk's stored bitmask still describes all of them, so the mask has to be
+/// gathered by the same row list the values were selected by. `map` is the
+/// batch-local, ascending index list the selection already carries; `count` is
+/// its length, which must equal the decoded column's row count.
+///
+/// `out_mask` must be sized for `count` bits and may be uninitialized — every
+/// bit below `count` is written. Indices are not bounds-checked, matching the
+/// gather above.
+///
+/// Asynchronous on `stream`.
+void gather_validity_bits(std::uint32_t const* source_mask,
+                          std::int32_t const* map,
+                          std::int64_t count,
+                          std::uint32_t* out_mask,
+                          rmm::cuda_stream_view stream);
+
 }  // namespace sirius::late_mat

--- a/src/include/op/scan/sirius_gpu_scan_operator_data.hpp
+++ b/src/include/op/scan/sirius_gpu_scan_operator_data.hpp
@@ -242,6 +242,23 @@ class scan_operator_input : public op::operator_data {
   /// again. False whenever the answers came from the plain predicated decode,
   /// which drops no rows.
   bool pushdown_predicates_enforced{false};
+  /// True when the decode DROPPED rows (pushdown_outcome::compacted), whether
+  /// or not it carried the whole filter. A deferral's rowid addresses the
+  /// pinned chunk by position, so a compacted batch is only addressable
+  /// together with @ref pushdown_survivors.
+  bool pushdown_compacted{false};
+  /// Chunk-local positions of the rows the decode kept, ascending INT32, one
+  /// per row of the decoded batch (pushdown_outcome::survivor_rows). Requested
+  /// only by a split carrying a deferral (@ref late_mat_wants_survivors) and
+  /// only produced when the decode compacted; null otherwise. Composed with the
+  /// post-decode residual filter's own survivors in
+  /// sirius_gpu_scan_operator::execute.
+  std::shared_ptr<cudf::column const> pushdown_survivors;
+  /// Whether this split's scan carries a late-materialization deferral, so the
+  /// decode must be asked to report which rows it kept. Stamped by
+  /// sirius_gpu_scan_operator::get_next_task_input_data, which is the only
+  /// place that knows. False leaves the decode exactly as it was.
+  bool late_mat_wants_survivors{false};
   /// The operator's dynamic-filter channel (may be null), stamped by
   /// sirius_gpu_scan_operator::get_next_task_input_data. prepare_for_processing
   /// snapshots it at DECODE time — the scan-manager drain runs at query

--- a/src/late_mat/materialize.cpp
+++ b/src/late_mat/materialize.cpp
@@ -177,14 +177,54 @@ std::unique_ptr<cudf::column> materialize_raw(pinned_column_view const& column,
 /// microbench.
 constexpr double kMaskRouteMaxDensity = 0.35;
 
-std::unique_ptr<cudf::column> require_non_null(std::unique_ptr<cudf::column> col)
+/// Reattach a compressed chunk's stripped validity to a decoded column that
+/// holds only the rows @p selection selected.
+///
+/// The sidecar's bitmask spans every row of the chunk while the decode returned
+/// the selected ones alone, so bit i of the result is bit `local_indices[i]` of
+/// the stored mask. Copying it verbatim would pair each value with some other
+/// row's validity. The all-valid and all-null shapes carry no bitmask and need
+/// no gather.
+void attach_selected_validity(cudf::column& col,
+                              simpatico::validity_sidecar const& validity,
+                              batch_selection const& selection,
+                              std::int64_t source_rows,
+                              rmm::cuda_stream_view stream,
+                              rmm::device_async_resource_ref mr)
 {
-  // None of these routes gathers a validity mask alongside the values, so a
-  // nullable column would come back with someone else's nulls.
-  if (col && col->null_count() != 0) {
-    throw std::runtime_error("late_mat::materialize: nullable origin columns are not supported");
+  if (validity.kind == simpatico::validity_kind::all_valid) { return; }
+
+  auto const count = col.size();
+  if (static_cast<std::int64_t>(count) != selection.survivors) {
+    throw std::runtime_error(
+      "late_mat::materialize: a compacted decode returned a row count the selection did not ask "
+      "for, so its validity cannot be aligned");
   }
-  return col;
+  if (validity.kind == simpatico::validity_kind::all_null) {
+    col.set_null_mask(cudf::create_null_mask(count, cudf::mask_state::ALL_NULL, stream, mr), count);
+    return;
+  }
+
+  auto const needed =
+    cudf::bitmask_allocation_size_bytes(static_cast<cudf::size_type>(source_rows));
+  if (validity.mask.size() < needed) {
+    throw std::runtime_error(
+      "late_mat::materialize: the stored validity mask is too small for the chunk's rows");
+  }
+  if (selection.local_indices.size() < static_cast<std::size_t>(count) * sizeof(std::int32_t)) {
+    throw std::runtime_error(
+      "late_mat::materialize: the selection carries no row list to gather validity by");
+  }
+
+  auto out = cudf::create_null_mask(count, cudf::mask_state::UNINITIALIZED, stream, mr);
+  gather_validity_bits(static_cast<std::uint32_t const*>(validity.mask.data()),
+                       static_cast<std::int32_t const*>(selection.local_indices.data()),
+                       static_cast<std::int64_t>(count),
+                       static_cast<std::uint32_t*>(out.data()),
+                       stream);
+  auto const nulls =
+    cudf::null_count(static_cast<cudf::bitmask_type const*>(out.data()), 0, count, stream);
+  col.set_null_mask(std::move(out), nulls);
 }
 
 /// One compressed batch, by the cheapest route its plan can take.
@@ -201,12 +241,13 @@ std::unique_ptr<cudf::column> materialize_compressed(batch_source const& source,
   auto const& table = source.compressed->table();
   auto const idx    = source.column_index;
 
-  // Whole batch live: no selection to express, so this is an ordinary decode.
+  // Whole batch live: no selection to express, so this is an ordinary decode,
+  // which reattaches the column's validity itself.
   if (selection.dense) {
     std::string err;
     auto full = simpatico::decompress_column_full(table, idx, stream, mr, &err);
     if (!full) { throw std::runtime_error("late_mat::materialize: full decode failed: " + err); }
-    return require_non_null(std::move(full));
+    return full;
   }
 
   auto const rows = selection.rows.view();
@@ -216,8 +257,12 @@ std::unique_ptr<cudf::column> materialize_compressed(batch_source const& source,
   // measured — it is the capability fallback below, not the faster one.
   {
     std::string err;
-    auto sparse = simpatico::decompress_column_rows(table, idx, rows, stream, mr, &err);
-    if (sparse) { return require_non_null(std::move(sparse)); }
+    simpatico::validity_sidecar const* validity = nullptr;
+    auto sparse = simpatico::decompress_column_rows(table, idx, rows, stream, mr, &err, &validity);
+    if (sparse) {
+      attach_selected_validity(*sparse, *validity, selection, source.num_rows, stream, mr);
+      return sparse;
+    }
   }
 
   // (b) Mask route: the shipped kernels, for the shapes with no random access
@@ -243,17 +288,22 @@ std::unique_ptr<cudf::column> materialize_compressed(batch_source const& source,
                                          rows.num_survivors,
                                          static_cast<std::uint32_t*>(chunk_offsets.data())};
     std::string err;
-    auto compacted = simpatico::decompress_column_compacted(table, idx, mask, stream, mr, &err);
-    if (compacted) { return require_non_null(std::move(compacted)); }
+    simpatico::validity_sidecar const* validity = nullptr;
+    auto compacted =
+      simpatico::decompress_column_compacted(table, idx, mask, stream, mr, &err, &validity);
+    if (compacted) {
+      attach_selected_validity(*compacted, *validity, selection, source.num_rows, stream, mr);
+      return compacted;
+    }
   }
 
-  // (c) The route that always works: decode everything, gather once.
+  // (c) The route that always works: decode everything, gather once. The full
+  // decode carries the column's validity and the gather propagates it.
   std::string err;
   auto full = simpatico::decompress_column_full(table, idx, stream, mr, &err);
   if (!full) { throw std::runtime_error("late_mat::materialize: full decode failed: " + err); }
-  auto checked = require_non_null(std::move(full));
   return gather_one(
-    checked->view(), int32_map(selection.local_indices, selection.survivors), stream, mr);
+    full->view(), int32_map(selection.local_indices, selection.survivors), stream, mr);
 }
 
 /// A batch's surviving rows, as a column of its own.

--- a/src/late_mat/multi_source_gather.cu
+++ b/src/late_mat/multi_source_gather.cu
@@ -103,7 +103,45 @@ __global__ void gather_fixed_kernel(void const* const* __restrict__ bases,
   }
 }
 
+__global__ void gather_validity_kernel(cudf::bitmask_type const* __restrict__ source_mask,
+                                       std::int32_t const* __restrict__ map,
+                                       std::int64_t count,
+                                       cudf::bitmask_type* __restrict__ out_mask)
+{
+  auto const stride = static_cast<std::int64_t>(gridDim.x) * blockDim.x;
+  for (std::int64_t i = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; i < count;
+       i += stride) {
+    if (cudf::bit_is_set(source_mask, static_cast<cudf::size_type>(map[i]))) {
+      cudf::set_bit(out_mask, static_cast<cudf::size_type>(i));
+    } else {
+      cudf::clear_bit(out_mask, static_cast<cudf::size_type>(i));
+    }
+  }
+}
+
 }  // namespace
+
+void gather_validity_bits(std::uint32_t const* source_mask,
+                          std::int32_t const* map,
+                          std::int64_t count,
+                          std::uint32_t* out_mask,
+                          rmm::cuda_stream_view stream)
+{
+  if (count == 0) { return; }
+  if (source_mask == nullptr || map == nullptr || out_mask == nullptr) {
+    throw std::runtime_error("multi_source_gather: validity gather over unbound buffers");
+  }
+
+  std::int64_t blocks = (count + kBlock - 1) / kBlock;
+  if (blocks > 4096) { blocks = 4096; }  // grid-stride covers the rest
+
+  gather_validity_kernel<<<static_cast<unsigned>(blocks), kBlock, 0, stream.value()>>>(
+    reinterpret_cast<cudf::bitmask_type const*>(source_mask),
+    map,
+    count,
+    reinterpret_cast<cudf::bitmask_type*>(out_mask));
+  throw_on_cuda(cudaPeekAtLastError(), "gather_validity launch");
+}
 
 void multi_source_gather_fixed(void const* const* bases_dev,
                                std::int64_t const* row_start_dev,

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -35,6 +35,7 @@
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_stream.hpp>
+#include <cudf/copying.hpp>
 #include <cudf/cudf_utils.hpp>
 #include <cudf/filling.hpp>
 #include <cudf/scalar/scalar.hpp>
@@ -60,6 +61,52 @@
 namespace sirius::op::scan {
 namespace {
 constexpr std::size_t kMaxNumericCarrierExpansion = 8;
+
+/// One filtered scan's surviving row positions, however many stages produced
+/// them.
+///
+/// A batch off a compressed pin can be restricted twice: the fused decode drops
+/// rows while decoding, and whatever conjuncts it could not carry are evaluated
+/// again afterwards. Each stage reports positions in ITS OWN input, so the
+/// second stage's positions index the first stage's output, not the chunk. The
+/// composition that turns them back into chunk positions is a gather of the
+/// decode's list by the residual's.
+struct composed_survivors {
+  /// Non-null when this call built the composition.
+  std::unique_ptr<cudf::column> column;
+  /// A view of a list that already existed, used when nothing had to be built.
+  std::optional<cudf::column_view> borrowed;
+};
+
+/// @param decoded Positions the decode kept, chunk-local; null when it kept all.
+/// @param residual Positions the post-decode filter kept, indexing the decoded
+///        batch; null when no filter ran there.
+/// @param decode_compacted Whether the decode dropped rows at all. A compaction
+///        with no positions to account for it cannot be composed, and emitting
+///        the residual's positions alone would address the wrong rows.
+composed_survivors compose_survivors(cudf::column const* decoded,
+                                     cudf::column const* residual,
+                                     bool decode_compacted,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::device_async_resource_ref mr)
+{
+  if (decode_compacted && decoded == nullptr) {
+    throw std::runtime_error(
+      "[sirius_gpu_scan_operator] the decode compacted this batch without reporting which rows "
+      "it kept; a pin-order rowid cannot be rebuilt from it");
+  }
+  if (decoded == nullptr) {
+    return {nullptr, residual ? std::optional<cudf::column_view>{residual->view()} : std::nullopt};
+  }
+  if (residual == nullptr) { return {nullptr, std::optional<cudf::column_view>{decoded->view()}}; }
+  auto gathered = cudf::gather(cudf::table_view{{decoded->view()}},
+                               residual->view(),
+                               cudf::out_of_bounds_policy::DONT_CHECK,
+                               stream,
+                               mr);
+  auto columns  = gathered->release();
+  return {std::move(columns.front()), std::nullopt};
+}
 
 /// Emit the deferred positions as a rowid and placeholders instead of values.
 ///
@@ -427,6 +474,9 @@ std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::get_next_task_input
     // Membership channel for the decode-time snapshot (join builds publish
     // during execution — only a snapshot taken at prepare/decode can see them).
     scan_input->dynamic_filters = _dynamic_filters_channel;
+    // Only this side knows a deferral is installed, and only a decode told
+    // before it runs can report which rows it kept.
+    scan_input->late_mat_wants_survivors = !deferred_output().empty();
     scan_input->prefetch(io::cache::prefetching_stage::immediate);
   }
   return std::move(*next);
@@ -503,6 +553,15 @@ std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::execute(
     auto like_pattern_cache       = like_cache();
     auto materialized_table =
       _ingestible->materialize_table(*scan_input, stream, like_swar_fastpath, like_pattern_cache);
+    // The decode's survivor list must describe exactly the rows the residual
+    // filter is about to index, or composing the two addresses the wrong rows.
+    if (wants_survivors && scan_input->pushdown_survivors &&
+        scan_input->pushdown_survivors->size() != materialized_table.table.view().num_rows()) {
+      throw std::runtime_error("[sirius_gpu_scan_operator::execute] the decode reported " +
+                               std::to_string(scan_input->pushdown_survivors->size()) +
+                               " surviving rows but handed on " +
+                               std::to_string(materialized_table.table.view().num_rows()));
+    }
     if (materialized_table.state != filter_state::ROW_FILTERED_AND_PROJECTED) {
       // Elide the deferred columns from the projection: realizing the batch would
       // copy values this scan is about to replace with a rowid.
@@ -528,8 +587,14 @@ std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::execute(
           "[sirius_gpu_scan_operator::execute] a deferral is installed but this split carries no "
           "origin; the scan cannot say where its rows came from");
       }
+      auto const composed = compose_survivors(scan_input->pushdown_survivors.get(),
+                                              survivors.get(),
+                                              scan_input->pushdown_compacted,
+                                              stream,
+                                              mem_space->get_default_allocator());
       std::optional<cudf::column_view> const survivor_view =
-        survivors ? std::optional<cudf::column_view>{survivors->view()} : std::nullopt;
+        composed.column ? std::optional<cudf::column_view>{composed.column->view()}
+                        : composed.borrowed;
       output_table = substitute_deferred_columns(std::move(output_table),
                                                  deferred_output(),
                                                  *scan_input->origin,

--- a/src/op/scan/sirius_gpu_scan_operator_data.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator_data.cpp
@@ -200,6 +200,23 @@ void scan_operator_input::prepare_for_processing(
           snapshot_onto(host_rep);
         }
       }
+      // A deferral on this scan makes the rowid positional in the pinned chunk,
+      // so a decode that compacts has to say which rows it kept. Only added
+      // where a request already exists: with none the decode drops no rows.
+      if (late_mat_wants_survivors) {
+        auto ask_for_survivors = [](auto* rep) {
+          if (rep->pushdown_scan()) {
+            rep->set_pushdown_scan(rep->pushdown_scan()->with_survivor_reporting());
+          }
+        };
+        if (auto* device_rep =
+              dynamic_cast<::sirius::compressed_device_representation*>(mut.get_data())) {
+          ask_for_survivors(device_rep);
+        } else if (auto* host_rep =
+                     dynamic_cast<::sirius::compressed_host_representation*>(mut.get_data())) {
+          ask_for_survivors(host_rep);
+        }
+      }
       mut.convert_to<::cucascade::gpu_table_representation>(
         registry, requested_memory_space, stream);
       // The converter reports what the decode did as a value on the
@@ -224,9 +241,17 @@ void scan_operator_input::prepare_for_processing(
         pushdown_row_filtered        = outcome.row_filtered;
         pushdown_predicate_columns   = outcome.predicate_columns;
         pushdown_predicates_enforced = outcome.predicates_enforced;
+        pushdown_compacted           = outcome.compacted;
+        pushdown_survivors           = outcome.survivor_rows;
         if (pushdown_selection_unprofitable && outcome.selection_unprofitable) {
           pushdown_selection_unprofitable->store(true, std::memory_order_relaxed);
         }
+      }
+      if (late_mat_wants_survivors && pushdown_compacted && !pushdown_survivors) {
+        throw std::runtime_error(
+          "[scan_operator_input::prepare_for_processing] the decode compacted this split but "
+          "could not report which rows it kept, and a deferral needs those positions to build "
+          "its pin-order rowid");
       }
       if (pushdown_row_filtered && mvcc_keep_mask.has_mask()) {
         // The keep-mask is positional over the chunk's full row range; a

--- a/src/scan_manager/late_mat_resolver.cpp
+++ b/src/scan_manager/late_mat_resolver.cpp
@@ -87,9 +87,10 @@ std::optional<late_mat::pinned_column_view> resolve_pinned_column(
   view.pin_generation = origin.generation;
 
   if (uses_device_chunks(*entry)) {
-    // Every uncompressed gather shape (single-batch, multi-batch fixed-width, multi-batch
-    // variable-width) propagates validity; only a compressed origin cannot (materialize.cpp's
-    // require_non_null, at decode time).
+    // Every gather shape propagates validity: the uncompressed ones (single-batch, multi-batch
+    // fixed-width, multi-batch variable-width) natively, and a compressed one through the decode
+    // routes (materialize.cpp's attach_selected_validity). A chunk with no blob is refused below,
+    // since its validity sidecar is unreadable along with everything else about it.
     for (auto const& chunk : entry->device_chunks) {
       late_mat::batch_source source;
       source.num_rows = chunk_rows(chunk);

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -857,20 +857,14 @@ late_mat_outcome install_late_materialization(op::scan::sirius_gpu_scan_operator
   }
   if (scan_op.get_ingestible().has_row_filter()) {
     // A filtered batch is no longer the chunk's rows in order, so the rowid has
-    // to come from the survivor positions the filter produced. That only works
-    // where the filter runs where we can see it — post-serve, over a whole
-    // served chunk. A COMPRESSED chunk is filtered inside the fused decode
-    // instead, and those survivors never reach the scan's output path, so a
-    // pin with any compressed chunk is refused rather than guessed at.
-    bool const compressed_chunks =
-      std::any_of(entry.device_chunks.begin(), entry.device_chunks.end(), [](auto const& chunk) {
-        return chunk.compressed != nullptr;
-      });
-    if (compressed_chunks) {
-      return decline(
-        "the scan restricts rows and its pin is compressed, so the surviving rows are decided "
-        "inside the decode");
-    }
+    // to come from the survivor positions the filter produced. A COMPRESSED
+    // chunk may be restricted twice — inside the fused decode and again by
+    // whatever conjuncts the decode could not carry — and both stages report
+    // their survivors: the decode through pushdown_outcome::survivor_rows,
+    // requested per split by late_mat_wants_survivors, and the residual through
+    // post_filter_and_project. The scan composes them
+    // (sirius_gpu_scan_operator's compose_survivors) and throws rather than
+    // guess if a compaction arrives unaccounted for.
     if (!entry.host_chunks.empty()) {
       return decline("the scan restricts rows and its pin is host-tier");
     }

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -621,6 +621,22 @@ std::vector<cudf::data_type> physical_schema_of(op::sirius_physical_operator con
            : late_mat::kRowidType;
 }
 
+/// Nulls one compressed chunk records for a column, or nullopt when the chunk
+/// cannot say.
+///
+/// Compression strips a column's validity into a sidecar the .hpln header
+/// carries, so the count is a header read and no decode happens here. A chunk
+/// carrying no blob at all is a legitimate shape (serving paths that need only
+/// a row count never load one), and it answers nothing.
+[[nodiscard]] std::optional<std::size_t> compressed_chunk_null_count(
+  sirius::compressed_device_representation const& compressed, std::size_t column_position)
+{
+  if (!compressed.has_table()) { return std::nullopt; }
+  auto const count = simpatico::column_null_count(compressed.table(), column_position);
+  if (!count.has_value()) { return std::nullopt; }
+  return static_cast<std::size_t>(*count);
+}
+
 /// Nulls in one pinned column across every chunk, or nullopt when the storage
 /// cannot say without decompressing — which reads as "assume the worst".
 [[nodiscard]] std::optional<std::size_t> pinned_column_null_count(pinned_entry const& entry,
@@ -630,8 +646,14 @@ std::vector<cudf::data_type> physical_schema_of(op::sirius_physical_operator con
   std::size_t nulls = 0;
   if (!entry.device_chunks.empty()) {
     for (auto const& chunk : entry.device_chunks) {
-      if (chunk.compressed || column_position >= chunk.columns.size() ||
-          !chunk.columns[column_position]) {
+      if (chunk.compressed) {
+        auto const compressed_nulls =
+          compressed_chunk_null_count(*chunk.compressed, column_position);
+        if (!compressed_nulls.has_value()) { return std::nullopt; }
+        nulls += *compressed_nulls;
+        continue;
+      }
+      if (column_position >= chunk.columns.size() || !chunk.columns[column_position]) {
         return std::nullopt;
       }
       nulls += static_cast<std::size_t>(chunk.columns[column_position]->null_count());
@@ -648,9 +670,16 @@ std::vector<cudf::data_type> physical_schema_of(op::sirius_physical_operator con
   return nulls;
 }
 
-/// Whether this column's pin is uncompressed — every such gather shape (single-batch,
-/// multi-batch fixed-width, multi-batch variable-width) propagates validity. Must agree with
-/// resolve_pinned_column's own check.
+/// Whether materialization can carry this column's validity through.
+///
+/// Every uncompressed gather shape (single-batch, multi-batch fixed-width,
+/// multi-batch variable-width) propagates validity. A compressed chunk does too,
+/// provided its blob is loaded and records the column's validity sidecar: a full
+/// decode reattaches the mask, and the two compacting routes gather it by the
+/// same rows they selected the values by (materialize.cpp's
+/// attach_selected_validity). A chunk carrying no blob answers nothing and is
+/// unsafe, which is also where resolve_pinned_column refuses — the two checks
+/// must agree.
 [[nodiscard]] bool pinned_column_nulls_are_safe(pinned_entry const& entry,
                                                 std::size_t column_position)
 {
@@ -658,8 +687,10 @@ std::vector<cudf::data_type> physical_schema_of(op::sirius_physical_operator con
   if (!entry.device_chunks.empty()) {
     return std::all_of(
       entry.device_chunks.begin(), entry.device_chunks.end(), [&](auto const& chunk) {
-        return !chunk.compressed && column_position < chunk.columns.size() &&
-               chunk.columns[column_position] != nullptr;
+        if (chunk.compressed) {
+          return compressed_chunk_null_count(*chunk.compressed, column_position).has_value();
+        }
+        return column_position < chunk.columns.size() && chunk.columns[column_position] != nullptr;
       });
   }
   if (column_position >= entry.cache_info.names.size()) { return false; }

--- a/test/cpp/compression/test_compression.cpp
+++ b/test/cpp/compression/test_compression.cpp
@@ -24,6 +24,7 @@
 //    * fallback when no plan / chunk below threshold
 
 #include <catch.hpp>
+#include <compression/compressed_scan.hpp>
 #include <compression/plan_register.hpp>
 #include <utils/log_test_utils.hpp>
 
@@ -1883,4 +1884,51 @@ TEST_CASE("pin_table compression - device tier driver returns uniqueness verdict
 
   run_ok(con, "CALL unpin_table('t_uniqcompressed');", "unpin");
   fs::remove_all(tmp);
+}
+
+// ─── Survivor reporting (no GPU required) ────────────────────────────────────
+
+TEST_CASE("with_survivor_reporting sets the obligation and survives per-batch narrowing",
+          "[compression][pushdown_survivors]")
+{
+  sirius::pushdown_request request;
+  request.columns.resize(2);
+  request.columns[0].range          = sirius::decode_range{0, 10};
+  request.columns[1].equals_any     = {"a"};
+  request.ranges_cover_whole_filter = true;
+
+  auto const base = std::make_shared<const sirius::decompression_pushdown_scan>(request);
+  REQUIRE_FALSE(base->request().report_survivors);
+
+  auto const asked = base->with_survivor_reporting();
+  REQUIRE(asked);
+  REQUIRE(asked->request().report_survivors);
+  // The obligation is added to a copy; other batches keep reading the original.
+  REQUIRE_FALSE(base->request().report_survivors);
+  // Nothing else about the request changes.
+  REQUIRE(asked->request().columns.size() == 2);
+  REQUIRE(asked->request().ranges_cover_whole_filter);
+
+  // A batch that stops compacting still reports for whatever it does drop, and
+  // a fresher join-filter snapshot must not silently clear the obligation.
+  auto const narrowed = asked->without_row_selection();
+  REQUIRE(narrowed);
+  REQUIRE(narrowed->request().report_survivors);
+  auto const refreshed = asked->with_membership_probes({}, /*generation=*/7);
+  REQUIRE(refreshed);
+  REQUIRE(refreshed->request().report_survivors);
+}
+
+TEST_CASE("a decode that dropped rows is reported apart from one that carried the whole filter",
+          "[compression][pushdown_survivors]")
+{
+  sirius::pushdown_outcome outcome;
+  REQUIRE_FALSE(outcome.any());
+
+  // Compaction alone is worth reporting: a consumer addressing the chunk by
+  // position needs it even when the residual filter still has to run.
+  outcome.compacted = true;
+  REQUIRE(outcome.any());
+  REQUIRE_FALSE(outcome.row_filtered);
+  REQUIRE_FALSE(outcome.survivor_rows);
 }

--- a/test/cpp/integration/test_late_mat_compressed_filter.cpp
+++ b/test/cpp/integration/test_late_mat_compressed_filter.cpp
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// A deferral over a filtered scan of a COMPRESSED pin. Rows can be dropped in
+// two places: inside the fused decode, and again by the conjuncts the decode
+// could not carry. The pin-order rowid is only correct when both stages are
+// composed.
+//
+// Which stages run depends on SIRIUS_EXP_FUSED_SCAN_FILTER, whose value caches
+// on first read and so cannot be varied within one binary. The case holds under
+// either setting; with the gate on it also covers the decode-compacted stage.
+//
+// Requires SIRIUS_EXP_LATE_MAT=1 in the ENVIRONMENT: the gate is read per process.
+
+#include <catch.hpp>
+#include <compression/decompression_pushdown_policy.hpp>
+#include <duckdb.hpp>
+#include <late_mat/column_origin.hpp>
+#include <late_mat/defer_directive.hpp>
+#include <utils/parquet_fixture_utils.hpp>
+#include <utils/pinned_entry_census.hpp>
+#include <utils/sirius_test_env.hpp>
+
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr std::int64_t kCustomers = 20'000;
+constexpr std::int64_t kOrders    = 60'000;
+constexpr std::int64_t kLines     = 120'000;
+
+/// Three wide strings read only by the aggregate at the far end, two joins to
+/// clear the crossing floor, and a range predicate on the pinned table so the
+/// scan restricts rows. The predicate is a bare range on the key, which a
+/// bitpack-rooted plan can answer inside the decode.
+constexpr char const* kQuery =
+  "SELECT c.c_custkey, c.c_name, c.c_address, c.c_comment, count(*) AS n "
+  "FROM read_parquet('{C}') c "
+  "JOIN read_parquet('{O}') o ON c.c_custkey = o.o_custkey "
+  "JOIN read_parquet('{L}') l ON o.o_orderkey = l.l_orderkey "
+  "WHERE c.c_custkey < 4000 {X}"
+  "GROUP BY c.c_custkey, c.c_name, c.c_address, c.c_comment "
+  "ORDER BY c.c_custkey";
+
+/// A conjunct on an identity-planned string column, which no decode route can
+/// answer. It leaves the range pushed down but the request no longer covering
+/// the whole filter, so the decode compacts and the residual filter then runs
+/// over what it kept — the two stages whose positions have to be composed.
+constexpr char const* kResidualConjunct = "AND c.c_name LIKE '%7' ";
+
+std::string query_for(fs::path const& customer,
+                      fs::path const& orders,
+                      fs::path const& lines,
+                      bool residual = false)
+{
+  std::string sql = kQuery;
+  sql.replace(sql.find("{X}"), 3, residual ? kResidualConjunct : "");
+  sql.replace(sql.find("{C}"), 3, customer.string());
+  sql.replace(sql.find("{O}"), 3, orders.string());
+  sql.replace(sql.find("{L}"), 3, lines.string());
+  return sql;
+}
+
+std::vector<std::string> rows_of(duckdb::MaterializedQueryResult& result)
+{
+  std::vector<std::string> rows;
+  for (duckdb::idx_t i = 0; i < result.RowCount(); ++i) {
+    std::string row;
+    for (duckdb::idx_t c = 0; c < result.ColumnCount(); ++c) {
+      row += result.GetValue(c, i).ToString() + "|";
+    }
+    rows.push_back(std::move(row));
+  }
+  return rows;
+}
+
+void generate_parquet(fs::path const& customer, fs::path const& orders, fs::path const& lines)
+{
+  sirius::test::scoped_sirius_disable disable_sirius;
+  duckdb::DuckDB gen_db(nullptr);
+  duckdb::Connection gen(gen_db);
+  auto r = gen.Query(
+    "COPY (SELECT range AS c_custkey, "
+    "             'Customer#' || lpad(CAST(range AS VARCHAR), 12, '0') AS c_name, "
+    "             'address-' || repeat(CAST(range % 97 AS VARCHAR), 6) AS c_address, "
+    "             'comment for customer ' || CAST(range AS VARCHAR) AS c_comment "
+    "      FROM range(" +
+    std::to_string(kCustomers) + ")) TO " + sirius::test::sql_literal(customer.string()) +
+    " (FORMAT PARQUET);");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
+
+  r = gen.Query(
+    "COPY (SELECT range AS o_orderkey, "
+    "             range % " +
+    std::to_string(kCustomers) +
+    " AS o_custkey "
+    "      FROM range(" +
+    std::to_string(kOrders) + ")) TO " + sirius::test::sql_literal(orders.string()) +
+    " (FORMAT PARQUET);");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
+
+  r = gen.Query("COPY (SELECT range AS l_linekey, range % " + std::to_string(kOrders) +
+                " AS l_orderkey "
+                "      FROM range(" +
+                std::to_string(kLines) + ")) TO " + sirius::test::sql_literal(lines.string()) +
+                " (FORMAT PARQUET);");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
+}
+
+/// The same query on DuckDB with Sirius disabled.
+std::vector<std::string> cpu_answer(fs::path const& customer,
+                                    fs::path const& orders,
+                                    fs::path const& lines,
+                                    bool residual)
+{
+  sirius::test::scoped_sirius_disable disable_sirius;
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto r = con.Query(query_for(customer, orders, lines, residual));
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
+  return rows_of(*r);
+}
+
+/// A bitpack block for the key, so its decode produces a range-answering mask —
+/// the plan shape that lets the decode drop rows at all. The string payloads sit
+/// on identity and take the full-decode route, compacted by the survivor gather.
+void write_plan_file(fs::path const& plan_dir, std::string const& table)
+{
+  fs::create_directories(plan_dir);
+  std::ofstream f(plan_dir / (table + ".txt"));
+  f << "input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed\n"
+       "---\n"
+       "input -> identity\n"
+       "---\n"
+       "input -> identity\n"
+       "---\n"
+       "input -> identity\n";
+}
+
+void write_config(fs::path const& yaml_path)
+{
+  std::ofstream f(yaml_path);
+  f << "sirius:\n"
+       "  topology:\n"
+       "    num_gpus: 1\n"
+       "  memory:\n"
+       "    gpu:\n"
+       "      usage_limit_fraction: 0.4\n"
+       "      reservation_limit_fraction: 1.0\n"
+       "    host:\n"
+       "      capacity_bytes: 32000000000\n"
+       "      initial_number_pools: 10\n"
+       "      pool_size: 512\n"
+       "      block_size: 1048576\n"
+       "  executor:\n"
+       "    pipeline:\n"
+       "      num_threads: 4\n"
+       "    task_creator:\n"
+       "      num_threads: 2\n"
+       "    downgrade:\n"
+       "      num_threads: 1\n"
+       "      monitor_period: 10ms\n"
+       "  operator_params:\n"
+       "    scan_task_batch_size: 100000000\n"
+       "    max_sort_partition_bytes: 0\n"
+       "    hash_partition_bytes: 100000000\n"
+       "    concat_batch_bytes: 100000000\n"
+       "    max_build_hash_table_bytes: 90000000\n";
+}
+
+}  // namespace
+
+TEST_CASE("a deferral over a filtered compressed pin rebuilds its rowid from both filter stages",
+          "[late_mat][compression][compressed_filter]")
+{
+  if (!sirius::late_mat::late_mat_enabled()) {
+    WARN("SIRIUS_EXP_LATE_MAT unset; skipping the filtered compressed-pin case");
+    return;
+  }
+  if (sirius::test::g_shared_env && sirius::test::g_shared_env->is_active()) {
+    sirius::test::g_shared_env->pause();
+  }
+  if (sirius::test::g_integration_env && sirius::test::g_integration_env->is_active()) {
+    sirius::test::g_integration_env->pause();
+  }
+  if (sirius::test::g_integration_env_2gpu && sirius::test::g_integration_env_2gpu->is_active()) {
+    sirius::test::g_integration_env_2gpu->pause();
+  }
+
+  sirius::test::scratch_dir scratch{"late_mat_compressed_filter"};
+  auto const& tmp     = scratch.path();
+  auto const customer = tmp / "lm_comp_customer.parquet";
+  auto const orders   = tmp / "orders.parquet";
+  auto const lines    = tmp / "lineitem.parquet";
+  generate_parquet(customer, orders, lines);
+  auto const expected          = cpu_answer(customer, orders, lines, /*residual=*/false);
+  auto const expected_composed = cpu_answer(customer, orders, lines, /*residual=*/true);
+  REQUIRE_FALSE(expected.empty());
+  REQUIRE_FALSE(expected_composed.empty());
+
+  auto yaml_path = tmp / "late_mat_compressed_filter.yaml";
+  write_config(yaml_path);
+
+  sirius::test::shared_test_env local_env(yaml_path);
+  auto con = local_env.make_connection();
+  auto fb  = con.Query("SET enable_duckdb_fallback = false;");
+  REQUIRE(fb);
+  REQUIRE_FALSE(fb->HasError());
+
+  auto const plan_dir = tmp / "plans";
+  write_plan_file(plan_dir, "lm_comp_customer");
+  for (auto const& setting :
+       {std::string{"SET pin_table_compression = true;"},
+        std::string{"SET pin_table_compression_min_batch_size_bytes = 0;"},
+        std::string{"SET pin_table_compression_max_compressed_fraction = 1.5;"},
+        "SET pin_table_input_compression_plan_dir = '" + plan_dir.string() + "';"}) {
+    auto r = con.Query(setting);
+    REQUIRE(r);
+    if (r->HasError()) { UNSCOPED_INFO(setting << " error: " << r->GetError()); }
+    REQUIRE_FALSE(r->HasError());
+  }
+
+  ::setenv("SIRIUS_EXP_LATE_MAT_PIN_UNIQUE_COLS", "c_custkey", 1);
+
+  auto pin = con.Query("CALL pin_table(" + sirius::test::sql_literal(customer.string()) +
+                       ", tier='gpu', name='lm_comp_customer');");
+  REQUIRE(pin);
+  if (pin->HasError()) { UNSCOPED_INFO("pin_table error: " << pin->GetError()); }
+  REQUIRE_FALSE(pin->HasError());
+
+  // Identity blocks on the payloads barely shrink the chunk, so the savings
+  // gate is what decides whether it stays compressed at all.
+  REQUIRE(sirius::test::census_entry(con, "lm_comp_customer").compressed_chunks > 0);
+
+  // Whole filter in the decode: the batch arrives compacted and nothing filters
+  // it again, so the rowid comes from the decode's positions alone.
+  auto before = sirius::late_mat::deferrals_installed();
+  auto res    = con.Query(query_for(customer, orders, lines, /*residual=*/false));
+  REQUIRE(res);
+  if (res->HasError()) { UNSCOPED_INFO("query error: " << res->GetError()); }
+  REQUIRE_FALSE(res->HasError());
+  REQUIRE(rows_of(*res) == expected);
+  // A query that deferred nothing returns the same answer, so the count is what
+  // makes the comparison above mean anything.
+  REQUIRE(sirius::late_mat::deferrals_installed() > before);
+
+  // Part of the filter in the decode and the rest after it: the two stages
+  // report positions in different coordinate systems and must be composed.
+  before = sirius::late_mat::deferrals_installed();
+  res    = con.Query(query_for(customer, orders, lines, /*residual=*/true));
+  REQUIRE(res);
+  if (res->HasError()) { UNSCOPED_INFO("composed query error: " << res->GetError()); }
+  REQUIRE_FALSE(res->HasError());
+  REQUIRE(rows_of(*res) == expected_composed);
+  REQUIRE(sirius::late_mat::deferrals_installed() > before);
+
+  if (!sirius::codegen::decompression_pushdown_enabled()) {
+    WARN("SIRIUS_EXP_FUSED_SCAN_FILTER unset; the decode-compacted stage was not exercised");
+  }
+
+  ::unsetenv("SIRIUS_EXP_LATE_MAT_PIN_UNIQUE_COLS");
+  auto unpin = con.Query("CALL unpin_table('lm_comp_customer');");
+  REQUIRE(unpin);
+  REQUIRE_FALSE(unpin->HasError());
+}

--- a/test/cpp/late_mat/test_late_mat_resolver.cpp
+++ b/test/cpp/late_mat/test_late_mat_resolver.cpp
@@ -39,8 +39,10 @@
 
 #include <cuda_runtime.h>
 
+#include <api/simpatico_codegen.hpp>
 #include <catch.hpp>
 #include <compression/compressed_representation.hpp>
+#include <compression/device_compressed_blob.hpp>
 #include <late_mat/materialize.hpp>
 #include <scan_manager/late_mat_resolver.hpp>
 #include <scan_manager/sirius_scan_manager.hpp>
@@ -464,4 +466,127 @@ TEST_CASE("a multi-batch column carries nulls through the multi-source gather ke
   auto const values = read_back(out->view());
   REQUIRE(values[1] == 40);
   REQUIRE(values[4] == 20);
+}
+
+namespace {
+
+/// A GPU pin whose chunks are Simpatico-compressed and carry nulls, addressed
+/// the way the scan manager stores a compressed pin: through device_chunks
+/// rather than data_batches_by_column.
+struct fake_compressed_entry {
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> manager;
+  pinned_entry entry;
+  std::shared_ptr<pin_entry_handle> handle;
+
+  fake_compressed_entry(std::vector<std::int64_t> const& batch_rows,
+                        std::vector<std::int64_t> const& null_rows,
+                        std::string const& name,
+                        rmm::cuda_stream_view stream)
+  {
+    auto const mr   = rmm::mr::get_current_device_resource_ref();
+    manager         = sirius::test::operator_utils::initialize_memory_manager();
+    auto* gpu_space = manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+
+    entry.tier = cucascade::memory::Tier::GPU;
+    entry.cache_info.names.push_back(name);
+
+    std::int64_t next = 0;
+    for (auto const rows : batch_rows) {
+      std::vector<std::int32_t> host(static_cast<std::size_t>(rows));
+      std::iota(host.begin(), host.end(), static_cast<std::int32_t>(next));
+
+      auto col = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                           static_cast<cudf::size_type>(rows),
+                                           cudf::mask_state::ALL_VALID,
+                                           stream);
+      cudaMemcpyAsync(col->mutable_view().data<std::int32_t>(),
+                      host.data(),
+                      host.size() * sizeof(std::int32_t),
+                      cudaMemcpyHostToDevice,
+                      stream.value());
+      cudf::size_type null_count = 0;
+      for (auto const global_row : null_rows) {
+        if (global_row < next || global_row >= next + rows) { continue; }
+        auto const local = static_cast<cudf::size_type>(global_row - next);
+        cudf::set_null_mask(col->mutable_view().null_mask(), local, local + 1, false, stream);
+        ++null_count;
+      }
+      col->set_null_count(null_count);
+      cudaStreamSynchronize(stream.value());
+      next += rows;
+
+      auto blob   = std::make_shared<sirius::compressed_device_blob>();
+      blob->table = simpatico::compress_with_plan(
+        cudf::table_view{{col->view()}}, "input -> bitpack -> packed\n", stream, mr);
+      cudaStreamSynchronize(stream.value());
+
+      sirius::device_pin_chunk chunk;
+      chunk.memory_space = gpu_space;
+      chunk.compressed   = std::make_shared<sirius::compressed_device_representation>(
+        *gpu_space,
+        blob,
+        std::vector<std::string>{name},
+        /*compressed_bytes=*/64,
+        /*uncompressed_bytes=*/static_cast<std::size_t>(rows) * sizeof(std::int32_t),
+        rows);
+      entry.device_chunks.push_back(std::move(chunk));
+      entry.num_rows += static_cast<std::size_t>(rows);
+    }
+
+    handle = std::make_shared<pin_entry_handle>(name, 5);
+    handle->set_entry(&entry);
+  }
+
+  [[nodiscard]] column_origin origin(std::uint32_t pos = 0) const
+  {
+    column_origin o;
+    o.handle     = handle;
+    o.column_pos = pos;
+    o.generation = handle->generation();
+    return o;
+  }
+};
+
+}  // namespace
+
+TEST_CASE("a nullable compressed pin resolves and materializes with its nulls",
+          "[late_mat][resolver]")
+{
+  auto const stream = rmm::cuda_stream_view{};
+  auto const mr     = rmm::mr::get_current_device_resource_ref();
+  // Rows 5 and 60 are null, and 60 falls in the third chunk, so the selection
+  // below crosses chunk boundaries with nulls on either side of one.
+  fake_compressed_entry pin({32, 16, 24}, /*null_rows=*/{5, 60}, "c_mktsegment", stream);
+
+  auto const column = resolve_pinned_column(pin.origin());
+  REQUIRE(column.has_value());
+  REQUIRE(column->batches.size() == 3);
+  REQUIRE(column->batches[0].is_compressed());
+
+  auto const layout = resolve_pinned_layout(pin.origin());
+  REQUIRE(layout.has_value());
+
+  // Out of order and with a repeat, touching both null rows.
+  std::vector<std::uint64_t> const ids{5, 40, 60, 5, 20};
+  auto d_ids = upload_ids(ids, stream);
+  prepared_selection const prepared(*layout,
+                                    row_id_list{static_cast<std::uint64_t const*>(d_ids.data()),
+                                                static_cast<std::int64_t>(ids.size()),
+                                                false});
+  auto const out = materialize(*column, prepared, stream, mr);
+  cudaStreamSynchronize(stream.value());
+
+  REQUIRE(out->view().nullable());
+  auto const host_mask = read_back_mask(out->view());
+  auto const* mask     = host_mask.data();
+  REQUIRE_FALSE(cudf::bit_is_set(mask, 0));
+  REQUIRE(cudf::bit_is_set(mask, 1));
+  REQUIRE_FALSE(cudf::bit_is_set(mask, 2));
+  REQUIRE_FALSE(cudf::bit_is_set(mask, 3));
+  REQUIRE(cudf::bit_is_set(mask, 4));
+
+  // The values are the row ids themselves, so a decode that read other rows
+  // shows up here rather than only in the mask.
+  auto const values = read_back(out->view());
+  REQUIRE(values == std::vector<std::int32_t>{5, 40, 60, 5, 20});
 }

--- a/test/cpp/late_mat/test_materialize_compressed.cpp
+++ b/test/cpp/late_mat/test_materialize_compressed.cpp
@@ -101,8 +101,8 @@ std::unique_ptr<cudf::column> make_batch(std::int64_t first_row,
                   stream.value());
 
   if (nullable) {
-    auto const words = static_cast<std::size_t>(cudf::bitmask_allocation_size_bytes(
-                         static_cast<cudf::size_type>(rows))) /
+    auto const words = static_cast<std::size_t>(
+                         cudf::bitmask_allocation_size_bytes(static_cast<cudf::size_type>(rows))) /
                        sizeof(cudf::bitmask_type);
     std::vector<cudf::bitmask_type> host_mask(words, 0);
     cudf::size_type nulls = 0;
@@ -149,7 +149,7 @@ struct fake_compressed_pin {
       auto source = make_batch(next, rows, nullable, stream);
       next += rows;
 
-      auto blob   = std::make_shared<sirius::compressed_device_blob>();
+      auto blob = std::make_shared<sirius::compressed_device_blob>();
       blob->table =
         simpatico::compress_with_plan(cudf::table_view{{source->view()}}, dsl, stream, mr);
       cudaStreamSynchronize(stream.value());
@@ -196,15 +196,13 @@ std::vector<bool> read_validity(cudf::column_view const& col)
 {
   std::vector<bool> valid(static_cast<std::size_t>(col.size()), true);
   if (col.null_mask() == nullptr) { return valid; }
-  auto const words =
-    static_cast<std::size_t>(cudf::bitmask_allocation_size_bytes(col.size())) /
-    sizeof(cudf::bitmask_type);
+  auto const words = static_cast<std::size_t>(cudf::bitmask_allocation_size_bytes(col.size())) /
+                     sizeof(cudf::bitmask_type);
   std::vector<cudf::bitmask_type> host(words, 0);
   cudaMemcpy(
     host.data(), col.null_mask(), host.size() * sizeof(cudf::bitmask_type), cudaMemcpyDeviceToHost);
   for (cudf::size_type i = 0; i < col.size(); ++i) {
-    valid[static_cast<std::size_t>(i)] =
-      (host[static_cast<std::size_t>(i) / 32] >> (i % 32)) & 1u;
+    valid[static_cast<std::size_t>(i)] = (host[static_cast<std::size_t>(i) / 32] >> (i % 32)) & 1u;
   }
   return valid;
 }
@@ -340,7 +338,7 @@ constexpr char const* kBitpackPlan = "input -> bitpack -> packed\n";
 constexpr char const* kDeltaPlan =
   "input -> delta -> differences\n"
   "delta.differences -> bitpack\n";
-constexpr char const* kFullPlan    = "input -> ans\n";
+constexpr char const* kFullPlan = "input -> ans\n";
 
 }  // namespace
 
@@ -548,7 +546,7 @@ TEST_CASE("an all-null compressed column materializes as all null",
                                           stream);
   cudaStreamSynchronize(stream.value());
 
-  auto blob   = std::make_shared<sirius::compressed_device_blob>();
+  auto blob = std::make_shared<sirius::compressed_device_blob>();
   blob->table =
     simpatico::compress_with_plan(cudf::table_view{{source->view()}}, kBitpackPlan, stream, mr);
   cudaStreamSynchronize(stream.value());

--- a/test/cpp/late_mat/test_materialize_compressed.cpp
+++ b/test/cpp/late_mat/test_materialize_compressed.cpp
@@ -1,0 +1,588 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [late_mat][materialize_compressed] — deferring a column out of a compressed
+// pin, including a nullable one. GPU required.
+//
+// The pinned column holds row i at value i and is null on a fixed, irregular
+// set of rows, so both halves of a materialized row name the row it was read
+// from: the value IS the global id, and the validity is a function of that id.
+// A route that decodes the right values but pairs them with another row's
+// validity produces a column that is right in one half and wrong in the other,
+// which is the failure this file exists to catch — the stored bitmask describes
+// every row of a chunk, while a compacted decode returns only the selected ones.
+//
+// materialize_compressed picks between four routes and cannot be asked which one
+// it took, so each case pins the choice from below: it calls the simpatico decode
+// the route rests on and asserts it serves (or refuses) for that plan, then goes
+// through materialize() for the values and validity. The plans are chosen to
+// classify differently — a bitpack root takes the sparse walk, a delta root has
+// no random access and falls to the mask route, and an ANS root has no compacted
+// route at all and falls to the full decode.
+
+#include "operator/operator_test_utils.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/utilities/bit.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/mr/per_device_resource.hpp>
+
+#include <cuda_runtime.h>
+
+#include <api/simpatico_codegen.hpp>
+#include <catch.hpp>
+#include <codegen/selection/chunk_row_set.hpp>
+#include <codegen/selection/selection.hpp>
+#include <compression/compressed_representation.hpp>
+#include <compression/device_compressed_blob.hpp>
+#include <late_mat/materialize.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <vector>
+
+using sirius::late_mat::batch_source;
+using sirius::late_mat::materialize;
+using sirius::late_mat::pinned_column_view;
+using sirius::late_mat::pinned_table_layout;
+using sirius::late_mat::prepared_selection;
+using sirius::late_mat::row_id_list;
+
+namespace {
+
+constexpr std::int64_t kChunk = 1024;
+
+/// Which rows of the fixture are null: an irregular pattern, so a validity
+/// gather that is off by one row, or that reads the selection's position
+/// instead of the row it selected, cannot coincide with the right answer.
+bool row_is_null(std::int64_t global_id) { return global_id % 7 == 3 || global_id % 11 == 0; }
+
+/// One batch of the fixture as a plain cuDF column: row i holds i, null per
+/// row_is_null. The values under a null row are still written, so a decode that
+/// drops validity is caught by the validity check alone rather than by the
+/// values changing too.
+std::unique_ptr<cudf::column> make_batch(std::int64_t first_row,
+                                         std::int64_t rows,
+                                         bool nullable,
+                                         rmm::cuda_stream_view stream)
+{
+  std::vector<std::int32_t> values(static_cast<std::size_t>(rows));
+  std::iota(values.begin(), values.end(), static_cast<std::int32_t>(first_row));
+
+  auto col = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT32},
+    static_cast<cudf::size_type>(rows),
+    nullable ? cudf::mask_state::UNINITIALIZED : cudf::mask_state::UNALLOCATED,
+    stream);
+  cudaMemcpyAsync(col->mutable_view().data<std::int32_t>(),
+                  values.data(),
+                  values.size() * sizeof(std::int32_t),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+
+  if (nullable) {
+    auto const words = static_cast<std::size_t>(cudf::bitmask_allocation_size_bytes(
+                         static_cast<cudf::size_type>(rows))) /
+                       sizeof(cudf::bitmask_type);
+    std::vector<cudf::bitmask_type> host_mask(words, 0);
+    cudf::size_type nulls = 0;
+    for (std::int64_t r = 0; r < rows; ++r) {
+      if (row_is_null(first_row + r)) {
+        ++nulls;
+      } else {
+        host_mask[static_cast<std::size_t>(r) / 32] |= (1u << (r % 32));
+      }
+    }
+    cudaMemcpyAsync(col->mutable_view().null_mask(),
+                    host_mask.data(),
+                    host_mask.size() * sizeof(cudf::bitmask_type),
+                    cudaMemcpyHostToDevice,
+                    stream.value());
+    cudaStreamSynchronize(stream.value());
+    col->set_null_count(nulls);
+  }
+  cudaStreamSynchronize(stream.value());
+  return col;
+}
+
+/// A pinned column whose batches are Simpatico-compressed under one plan.
+///
+/// The blob carries only the compressed_table: its leaves are owned by the
+/// plan's own representations rather than sliced out of a staged payload, which
+/// is all a decode needs and all this fixture builds.
+struct fake_compressed_pin {
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> manager;
+  std::vector<std::shared_ptr<sirius::compressed_device_representation>> chunks;
+  pinned_column_view view;
+
+  fake_compressed_pin(std::vector<std::int64_t> const& batch_rows,
+                      std::string const& dsl,
+                      bool nullable,
+                      rmm::cuda_stream_view stream)
+  {
+    auto const mr   = rmm::mr::get_current_device_resource_ref();
+    manager         = sirius::test::operator_utils::initialize_memory_manager();
+    auto* gpu_space = manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+
+    std::int64_t next = 0;
+    for (auto const rows : batch_rows) {
+      auto source = make_batch(next, rows, nullable, stream);
+      next += rows;
+
+      auto blob   = std::make_shared<sirius::compressed_device_blob>();
+      blob->table =
+        simpatico::compress_with_plan(cudf::table_view{{source->view()}}, dsl, stream, mr);
+      cudaStreamSynchronize(stream.value());
+
+      auto rep = std::make_shared<sirius::compressed_device_representation>(
+        *gpu_space,
+        blob,
+        std::vector<std::string>{"value"},
+        /*compressed_bytes=*/64,
+        /*uncompressed_bytes=*/static_cast<std::size_t>(rows) * sizeof(std::int32_t),
+        rows);
+
+      batch_source src;
+      src.compressed   = rep.get();
+      src.column_index = 0;
+      src.num_rows     = rows;
+      view.batches.push_back(src);
+      chunks.push_back(std::move(rep));
+    }
+    view.dtype = cudf::data_type{cudf::type_id::INT32};
+  }
+
+  [[nodiscard]] simpatico::compressed_table const& table(std::size_t batch = 0) const
+  {
+    return chunks[batch]->table();
+  }
+};
+
+std::vector<std::int32_t> read_back(cudf::column_view const& col)
+{
+  std::vector<std::int32_t> host(static_cast<std::size_t>(col.size()));
+  if (!host.empty()) {
+    cudaMemcpy(host.data(),
+               col.data<std::int32_t>(),
+               host.size() * sizeof(std::int32_t),
+               cudaMemcpyDeviceToHost);
+  }
+  return host;
+}
+
+/// The column's per-row validity, as a plain vector. An unallocated mask reads
+/// as all-valid, which is what cuDF means by it.
+std::vector<bool> read_validity(cudf::column_view const& col)
+{
+  std::vector<bool> valid(static_cast<std::size_t>(col.size()), true);
+  if (col.null_mask() == nullptr) { return valid; }
+  auto const words =
+    static_cast<std::size_t>(cudf::bitmask_allocation_size_bytes(col.size())) /
+    sizeof(cudf::bitmask_type);
+  std::vector<cudf::bitmask_type> host(words, 0);
+  cudaMemcpy(
+    host.data(), col.null_mask(), host.size() * sizeof(cudf::bitmask_type), cudaMemcpyDeviceToHost);
+  for (cudf::size_type i = 0; i < col.size(); ++i) {
+    valid[static_cast<std::size_t>(i)] =
+      (host[static_cast<std::size_t>(i) / 32] >> (i % 32)) & 1u;
+  }
+  return valid;
+}
+
+rmm::device_buffer upload_ids(std::vector<std::uint64_t> const& host, rmm::cuda_stream_view stream)
+{
+  rmm::device_buffer buf(
+    host.size() * sizeof(std::uint64_t), stream, rmm::mr::get_current_device_resource_ref());
+  if (!host.empty()) {
+    cudaMemcpyAsync(buf.data(),
+                    host.data(),
+                    host.size() * sizeof(std::uint64_t),
+                    cudaMemcpyHostToDevice,
+                    stream.value());
+    cudaStreamSynchronize(stream.value());
+  }
+  return buf;
+}
+
+/// Materialize `ids` out of `pin` and check both halves against the fixture's
+/// own rule: value i is i, and row i is null exactly when row_is_null says so.
+void check_against_ids(pinned_column_view const& view,
+                       std::vector<std::int64_t> const& batch_rows,
+                       std::vector<std::uint64_t> const& ids,
+                       bool nullable,
+                       bool sorted_unique,
+                       rmm::cuda_stream_view stream)
+{
+  auto const mr     = rmm::mr::get_current_device_resource_ref();
+  auto const layout = pinned_table_layout::from_batch_rows(batch_rows);
+  auto d_ids        = upload_ids(ids, stream);
+
+  prepared_selection const prepared(layout,
+                                    row_id_list{static_cast<std::uint64_t const*>(d_ids.data()),
+                                                static_cast<std::int64_t>(ids.size()),
+                                                sorted_unique});
+  auto const column = materialize(view, prepared, stream, mr);
+  cudaStreamSynchronize(stream.value());
+
+  REQUIRE(column->size() == static_cast<cudf::size_type>(ids.size()));
+
+  std::vector<std::int32_t> expect_values;
+  std::vector<bool> expect_valid;
+  for (auto const id : ids) {
+    expect_values.push_back(static_cast<std::int32_t>(id));
+    expect_valid.push_back(!nullable || !row_is_null(static_cast<std::int64_t>(id)));
+  }
+  REQUIRE(read_back(column->view()) == expect_values);
+  REQUIRE(read_validity(column->view()) == expect_valid);
+}
+
+/// A chunk-CSR over `rows`, batch-local and ascending — the shape the sparse
+/// walk indexes by.
+struct device_row_set {
+  rmm::device_buffer chunk_ids, block_offsets, in_chunk_rows;
+  sirius::codegen::chunk_row_set view{};
+
+  device_row_set(std::vector<std::int64_t> const& rows,
+                 std::int64_t num_rows,
+                 rmm::cuda_stream_view stream)
+  {
+    std::vector<std::uint32_t> chunks, offsets{0};
+    std::vector<std::uint16_t> positions;
+    for (auto const r : rows) {
+      auto const c = static_cast<std::uint32_t>(r / kChunk);
+      if (chunks.empty() || chunks.back() != c) {
+        if (!chunks.empty()) { offsets.push_back(static_cast<std::uint32_t>(positions.size())); }
+        chunks.push_back(c);
+      }
+      positions.push_back(static_cast<std::uint16_t>(r % kChunk));
+    }
+    offsets.push_back(static_cast<std::uint32_t>(positions.size()));
+
+    auto const mr = rmm::mr::get_current_device_resource_ref();
+    auto upload   = [&](void const* src, std::size_t bytes) {
+      rmm::device_buffer buf(bytes, stream, mr);
+      if (bytes != 0) {
+        cudaMemcpyAsync(buf.data(), src, bytes, cudaMemcpyHostToDevice, stream.value());
+      }
+      return buf;
+    };
+    chunk_ids     = upload(chunks.data(), chunks.size() * sizeof(std::uint32_t));
+    block_offsets = upload(offsets.data(), offsets.size() * sizeof(std::uint32_t));
+    in_chunk_rows = upload(positions.data(), positions.size() * sizeof(std::uint16_t));
+    cudaStreamSynchronize(stream.value());
+
+    view.chunk_ids     = static_cast<std::uint32_t const*>(chunk_ids.data());
+    view.block_offsets = static_cast<std::uint32_t const*>(block_offsets.data());
+    view.in_chunk_rows = static_cast<std::uint16_t const*>(in_chunk_rows.data());
+    view.num_touched   = static_cast<std::int64_t>(chunks.size());
+    view.num_survivors = static_cast<std::int64_t>(positions.size());
+    view.num_rows      = num_rows;
+  }
+};
+
+/// The counted selection mask the mask route reads, derived from a row set the
+/// same way materialize_compressed derives it.
+struct device_mask {
+  rmm::device_buffer words, chunk_offsets;
+  sirius::codegen::selection_mask view{};
+};
+
+device_mask mask_over(device_row_set const& set,
+                      std::int64_t num_rows,
+                      rmm::cuda_stream_view stream,
+                      rmm::device_async_resource_ref mr)
+{
+  device_mask out;
+  auto const chunks = sirius::codegen::selection_mask::ChunksFor(num_rows);
+  out.words         = rmm::device_buffer(
+    static_cast<std::size_t>(sirius::codegen::selection_mask::WordsFor(num_rows)) *
+      sizeof(std::uint32_t),
+    stream,
+    mr);
+  out.chunk_offsets =
+    rmm::device_buffer((static_cast<std::size_t>(chunks) + 1) * sizeof(std::uint32_t), stream, mr);
+  sirius::codegen::row_set_to_mask(set.view,
+                                   static_cast<std::uint32_t*>(out.words.data()),
+                                   static_cast<std::uint32_t*>(out.chunk_offsets.data()),
+                                   stream,
+                                   mr);
+  out.view = sirius::codegen::selection_mask{static_cast<std::uint32_t*>(out.words.data()),
+                                             num_rows,
+                                             set.view.num_survivors,
+                                             static_cast<std::uint32_t*>(out.chunk_offsets.data())};
+  return out;
+}
+
+// Plans that classify onto the three selective routes. A bitpack root has random
+// access; a delta root does not, so it takes the mask kernels; an ANS root has no
+// compacted route at all.
+constexpr char const* kBitpackPlan = "input -> bitpack -> packed\n";
+constexpr char const* kDeltaPlan =
+  "input -> delta -> differences\n"
+  "delta.differences -> bitpack\n";
+constexpr char const* kFullPlan    = "input -> ans\n";
+
+}  // namespace
+
+TEST_CASE("a compressed chunk reports its null count without decoding",
+          "[late_mat][materialize_compressed]")
+{
+  auto const stream = rmm::cuda_stream_view{};
+
+  fake_compressed_pin nullable({4 * kChunk}, kBitpackPlan, /*nullable=*/true, stream);
+  fake_compressed_pin plain({4 * kChunk}, kBitpackPlan, /*nullable=*/false, stream);
+
+  std::int64_t expected = 0;
+  for (std::int64_t r = 0; r < 4 * kChunk; ++r) {
+    if (row_is_null(r)) { ++expected; }
+  }
+  REQUIRE(expected > 0);
+
+  auto const counted = simpatico::column_null_count(nullable.table(), 0);
+  REQUIRE(counted.has_value());
+  REQUIRE(*counted == expected);
+
+  auto const none = simpatico::column_null_count(plain.table(), 0);
+  REQUIRE(none.has_value());
+  REQUIRE(*none == 0);
+
+  // A column the table does not have answers nothing, rather than answering
+  // zero — the whole point of the count is that the gate can trust it.
+  REQUIRE_FALSE(simpatico::column_null_count(nullable.table(), 9).has_value());
+  REQUIRE(simpatico::column_validity(nullable.table(), 9) == nullptr);
+}
+
+TEST_CASE("the dense route decodes a whole nullable batch", "[late_mat][materialize_compressed]")
+{
+  auto const stream = rmm::cuda_stream_view{};
+  std::vector<std::int64_t> const batch_rows{2 * kChunk};
+  fake_compressed_pin pin(batch_rows, kBitpackPlan, /*nullable=*/true, stream);
+
+  // Every row of the batch survives, so the selection is dense and the route is
+  // an ordinary full decode, which reattaches validity itself.
+  std::vector<std::uint64_t> ids(static_cast<std::size_t>(2 * kChunk));
+  std::iota(ids.begin(), ids.end(), std::uint64_t{0});
+  check_against_ids(pin.view, batch_rows, ids, /*nullable=*/true, /*sorted_unique=*/true, stream);
+}
+
+TEST_CASE("the sparse route carries validity for the rows it selected",
+          "[late_mat][materialize_compressed]")
+{
+  auto const stream = rmm::cuda_stream_view{};
+  auto const mr     = rmm::mr::get_current_device_resource_ref();
+  std::vector<std::int64_t> const batch_rows{4 * kChunk};
+  fake_compressed_pin pin(batch_rows, kBitpackPlan, /*nullable=*/true, stream);
+
+  std::vector<std::int64_t> const rows{5, 1023, 1024, 2050, 3000, 4095};
+  device_row_set const set(rows, 4 * kChunk, stream);
+
+  // The route this case is about: a bitpack root serves the sparse walk, and
+  // it declines the nullable column unless the caller takes the sidecar.
+  {
+    std::string err;
+    auto refused = simpatico::decompress_column_rows(pin.table(), 0, set.view, stream, mr, &err);
+    REQUIRE(refused == nullptr);
+    REQUIRE(err.find("null-masked") != std::string::npos);
+  }
+  {
+    std::string err;
+    simpatico::validity_sidecar const* validity = nullptr;
+    auto served =
+      simpatico::decompress_column_rows(pin.table(), 0, set.view, stream, mr, &err, &validity);
+    REQUIRE(served != nullptr);
+    REQUIRE(validity != nullptr);
+    REQUIRE(validity->kind == simpatico::validity_kind::mask);
+    // Values only: the sidecar is the caller's to compact.
+    REQUIRE(served->null_count() == 0);
+  }
+
+  std::vector<std::uint64_t> ids;
+  for (auto const r : rows) {
+    ids.push_back(static_cast<std::uint64_t>(r));
+  }
+  check_against_ids(pin.view, batch_rows, ids, /*nullable=*/true, /*sorted_unique=*/true, stream);
+}
+
+TEST_CASE("the mask route carries validity where the sparse walk cannot serve",
+          "[late_mat][materialize_compressed]")
+{
+  auto const stream = rmm::cuda_stream_view{};
+  auto const mr     = rmm::mr::get_current_device_resource_ref();
+  std::vector<std::int64_t> const batch_rows{4 * kChunk};
+  fake_compressed_pin pin(batch_rows, kDeltaPlan, /*nullable=*/true, stream);
+
+  std::vector<std::int64_t> const rows{2, 900, 1500, 2600, 4000};
+  device_row_set const set(rows, 4 * kChunk, stream);
+
+  // A delta root has no random access, so the sparse walk refuses for a reason
+  // that is not nullability, and the mask kernels are what serve this plan.
+  std::string err;
+  simpatico::validity_sidecar const* validity = nullptr;
+  auto declined =
+    simpatico::decompress_column_rows(pin.table(), 0, set.view, stream, mr, &err, &validity);
+  REQUIRE(declined == nullptr);
+  REQUIRE(err.find("random-access") != std::string::npos);
+
+  // Well under the density at which materialize_compressed stops trying the
+  // mask route, so this is the route the selection below actually takes.
+  REQUIRE(static_cast<double>(rows.size()) / static_cast<double>(4 * kChunk) < 0.35);
+
+  // And the mask kernels really do serve this plan — otherwise the cascade
+  // would fall through to the full decode and this case would be testing that
+  // route a second time.
+  auto const mask = mask_over(set, 4 * kChunk, stream, mr);
+  {
+    std::string err2;
+    simpatico::validity_sidecar const* mask_validity = nullptr;
+    auto served                                      = simpatico::decompress_column_compacted(
+      pin.table(), 0, mask.view, stream, mr, &err2, &mask_validity);
+    REQUIRE(served != nullptr);
+    REQUIRE(served->size() == static_cast<cudf::size_type>(rows.size()));
+    REQUIRE(mask_validity != nullptr);
+    REQUIRE(mask_validity->kind == simpatico::validity_kind::mask);
+    REQUIRE(served->null_count() == 0);
+  }
+
+  std::vector<std::uint64_t> ids;
+  for (auto const r : rows) {
+    ids.push_back(static_cast<std::uint64_t>(r));
+  }
+  check_against_ids(pin.view, batch_rows, ids, /*nullable=*/true, /*sorted_unique=*/true, stream);
+}
+
+TEST_CASE("the full-decode fallback carries validity through its gather",
+          "[late_mat][materialize_compressed]")
+{
+  auto const stream = rmm::cuda_stream_view{};
+  auto const mr     = rmm::mr::get_current_device_resource_ref();
+  std::vector<std::int64_t> const batch_rows{2 * kChunk};
+  fake_compressed_pin pin(batch_rows, kFullPlan, /*nullable=*/true, stream);
+
+  std::vector<std::int64_t> const rows{1, 40, 700, 1100, 2047};
+  device_row_set const set(rows, 2 * kChunk, stream);
+
+  // Neither compacting route classifies this plan, so the cascade ends at the
+  // full decode and one gather.
+  {
+    std::string err;
+    simpatico::validity_sidecar const* validity = nullptr;
+    REQUIRE(simpatico::decompress_column_rows(
+              pin.table(), 0, set.view, stream, mr, &err, &validity) == nullptr);
+  }
+  {
+    std::string err;
+    auto full = simpatico::decompress_column_full(pin.table(), 0, stream, mr, &err);
+    REQUIRE(full != nullptr);
+    // The full decode is the one route that reattaches validity on its own.
+    REQUIRE(full->null_count() > 0);
+  }
+
+  std::vector<std::uint64_t> ids;
+  for (auto const r : rows) {
+    ids.push_back(static_cast<std::uint64_t>(r));
+  }
+  check_against_ids(pin.view, batch_rows, ids, /*nullable=*/true, /*sorted_unique=*/true, stream);
+}
+
+TEST_CASE("validity stays with its value under a repeated, unsorted selection",
+          "[late_mat][materialize_compressed]")
+{
+  auto const stream = rmm::cuda_stream_view{};
+  std::vector<std::int64_t> const batch_rows{3 * kChunk, 2 * kChunk};
+  fake_compressed_pin pin(batch_rows, kBitpackPlan, /*nullable=*/true, stream);
+
+  // What a join hands back: out of order, with repeats, spanning both batches.
+  // The canonical form sorts and deduplicates it, materializes in table order
+  // and gathers back — three places for validity to part company with its value
+  // while the row count stays right.
+  std::vector<std::uint64_t> const ids{
+    4000, 3, 4000, 3072, 3, 12, 4999, 3072, 0, 4999, 4999, 2050, 1023, 1024, 4999, 7};
+  check_against_ids(pin.view, batch_rows, ids, /*nullable=*/true, /*sorted_unique=*/false, stream);
+}
+
+TEST_CASE("a compressed origin with no nulls materializes unchanged",
+          "[late_mat][materialize_compressed]")
+{
+  auto const stream = rmm::cuda_stream_view{};
+  std::vector<std::int64_t> const batch_rows{3 * kChunk, 2 * kChunk};
+  fake_compressed_pin pin(batch_rows, kBitpackPlan, /*nullable=*/false, stream);
+
+  std::vector<std::uint64_t> const ids{4000, 3, 4000, 3072, 12, 4999, 0, 2050, 1023, 1024};
+  check_against_ids(pin.view, batch_rows, ids, /*nullable=*/false, /*sorted_unique=*/false, stream);
+}
+
+TEST_CASE("an all-null compressed column materializes as all null",
+          "[late_mat][materialize_compressed]")
+{
+  auto const stream = rmm::cuda_stream_view{};
+  auto const mr     = rmm::mr::get_current_device_resource_ref();
+  auto manager      = sirius::test::operator_utils::initialize_memory_manager();
+  auto* gpu_space   = manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+
+  // The all-null shape stores no bitmask at all — only the kind and the count —
+  // so it is the one case where nothing is gathered and the mask is regenerated.
+  constexpr std::int64_t kRows = 2 * kChunk;
+  auto source                  = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                          static_cast<cudf::size_type>(kRows),
+                                          cudf::mask_state::ALL_NULL,
+                                          stream);
+  cudaStreamSynchronize(stream.value());
+
+  auto blob   = std::make_shared<sirius::compressed_device_blob>();
+  blob->table =
+    simpatico::compress_with_plan(cudf::table_view{{source->view()}}, kBitpackPlan, stream, mr);
+  cudaStreamSynchronize(stream.value());
+
+  auto const counted = simpatico::column_null_count(blob->table, 0);
+  REQUIRE(counted.has_value());
+  REQUIRE(*counted == kRows);
+
+  auto rep = std::make_shared<sirius::compressed_device_representation>(
+    *gpu_space,
+    blob,
+    std::vector<std::string>{"value"},
+    /*compressed_bytes=*/64,
+    /*uncompressed_bytes=*/static_cast<std::size_t>(kRows) * sizeof(std::int32_t),
+    kRows);
+
+  pinned_column_view view;
+  view.dtype = cudf::data_type{cudf::type_id::INT32};
+  batch_source src;
+  src.compressed   = rep.get();
+  src.column_index = 0;
+  src.num_rows     = kRows;
+  view.batches.push_back(src);
+
+  std::vector<std::uint64_t> const ids{5, 900, 900, 2047, 0};
+  auto const layout = pinned_table_layout::from_batch_rows({kRows});
+  auto d_ids        = upload_ids(ids, stream);
+  prepared_selection const prepared(layout,
+                                    row_id_list{static_cast<std::uint64_t const*>(d_ids.data()),
+                                                static_cast<std::int64_t>(ids.size()),
+                                                false});
+  auto const column = materialize(view, prepared, stream, mr);
+  cudaStreamSynchronize(stream.value());
+
+  REQUIRE(column->size() == static_cast<cudf::size_type>(ids.size()));
+  REQUIRE(column->null_count() == static_cast<cudf::size_type>(ids.size()));
+}


### PR DESCRIPTION
## Description
This builds on top of https://github.com/sirius-db/sirius/pull/1368, which we still may decide not to be the way to go for adding null support in Simpatico. But if it is, this completes the implementation for no longer refusing late materializations from nullable and/or compressed data.

This does not help the current TPCH workload in the configuration we mostly use for our benchmarks, but may enable benefits in other cases (for example on smaller devices where more tables are compressed to make it fit in device memory).

Fixes #1640 

## Checklist
- [ ] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References