### PR TITLE
perf: eliminate a copy from hash_partition

### DIFF
--- a/src/include/op/sirius_physical_streaming_sink.hpp
+++ b/src/include/op/sirius_physical_streaming_sink.hpp
@@ -99,7 +99,7 @@ class sirius_physical_streaming_sink : public sirius_physical_operator {
   /// N=1: native push. N>1: hash-partition; skip empty slices. Refused push = silent drop.
   void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
 
-  /// 0 if N==1; ~2× when partitioned (hash_partition holds reorder + slices).
+  /// 0 if N==1; one input when hash-partitioned (the reorder buffer the slices view).
   [[nodiscard]] std::size_t no_history_peak_memory_estimate(
     const input_stats& stats) const override;
 

--- a/src/op/partition/gpu_partition_impl.cpp
+++ b/src/op/partition/gpu_partition_impl.cpp
@@ -78,16 +78,13 @@ std::vector<std::shared_ptr<cucascade::data_batch>> gpu_partition_impl::hash_par
                                                stream,
                                                memory_space.get_default_allocator());
 
-  // Build a column-index list for the original (non-cast) columns.
-  std::vector<cudf::size_type> orig_col_indices;
-  orig_col_indices.reserve(orig_num_cols);
-  for (int i = 0; i < orig_num_cols; i++) {
-    orig_col_indices.push_back(i);
-  }
+  // Drop the appended cast columns before slicing. Releasing them here frees their reordered
+  // copies; keeping them in the parent would hold that memory for as long as any output batch
+  // lives, because the outputs are views into this table.
+  auto reordered_columns = partition_result.first->release();
+  reordered_columns.resize(orig_num_cols);
+  auto reordered = std::make_shared<cudf::table>(std::move(reordered_columns));
 
-  // Slice from the reordered table to create separate table partitions.
-  std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
-  output_batches.reserve(num_partitions);
   std::vector<cudf::size_type> slice_indices;
   slice_indices.reserve(num_partitions * 2);
   for (int i = 0; i < num_partitions; ++i) {
@@ -95,15 +92,38 @@ std::vector<std::shared_ptr<cucascade::data_batch>> gpu_partition_impl::hash_par
     slice_indices.push_back(i == num_partitions - 1 ? input_table.num_rows()
                                                     : partition_result.second[i + 1]);
   }
-  auto sliced_partition_views = cudf::slice(partition_result.first->view(), slice_indices, stream);
+  auto sliced_partition_views = cudf::slice(reordered->view(), slice_indices, stream);
+
+  // The reordered rows already sit one partition after another, so each partition is a view into
+  // that table rather than an allocation of its own. A shared_ptr to the reordered table is the
+  // owner: the last surviving partition batch releases it. Memory is therefore reclaimed per
+  // reordered table, not per partition, so a single long-lived partition holds all of it.
+  auto const reordered_bytes = reordered->alloc_size();
+  auto const reordered_rows  = static_cast<std::size_t>(reordered->num_rows());
+  std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
+  output_batches.reserve(num_partitions);
   for (int i = 0; i < num_partitions; ++i) {
-    // Drop any appended cast columns from the output.
-    auto output_partition =
-      std::make_unique<cudf::table>(sliced_partition_views[i].select(orig_col_indices),
-                                    stream,
-                                    memory_space.get_default_allocator());
-    output_batches.push_back(
-      make_data_batch(std::move(output_partition), memory_space, stream, telemetry_info));
+    auto const& partition_view = sliced_partition_views[i];
+    auto const partition_rows  = static_cast<std::size_t>(partition_view.num_rows());
+    if (partition_rows == 0) {
+      // An empty partition owns an empty table instead: it allocates nothing, and a view would
+      // pin the whole reordered table for a batch that carries no rows.
+      output_batches.push_back(make_data_batch(
+        std::make_unique<cudf::table>(partition_view, stream, memory_space.get_default_allocator()),
+        memory_space,
+        stream,
+        telemetry_info));
+      continue;
+    }
+    // Row-proportional share of the reordered table, so the partitions together are charged for
+    // it exactly once. Exact for fixed-width columns, an estimate for variable-width ones.
+    auto const partition_bytes = reordered_bytes * partition_rows / reordered_rows;
+    output_batches.push_back(make_data_batch_from_view(partition_view,
+                                                       std::shared_ptr<cudf::table>(reordered),
+                                                       partition_bytes,
+                                                       memory_space,
+                                                       stream,
+                                                       telemetry_info));
   }
 
   return output_batches;

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -491,7 +491,10 @@ std::size_t sirius_physical_partition::no_history_peak_memory_estimate(
   const op::input_stats& stats) const
 {
   if (_num_partitions.has_value() && *_num_partitions == 1) { return 0; }
-  return stats.bytes * 2;
+  // hash_partition's reorder buffer. The partitions are views into it rather than copies,
+  // so it is the whole cost — but it lives until the last partition referencing it is
+  // released, rather than being freed as each one drains.
+  return stats.bytes;
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_streaming_sink.cpp
+++ b/src/op/sirius_physical_streaming_sink.cpp
@@ -190,8 +190,10 @@ std::size_t sirius_physical_streaming_sink::no_history_peak_memory_estimate(
   // Broadcast holds the original plus one clone per extra destination, and each one stays
   // resident until its own repository drains — so the whole fan-out is live at once, not 2×.
   if (_spec.mode == partition_mode::broadcast) { return stats.bytes * _outputs.size(); }
-  // Hash holds hash_partition's reorder buffer alongside the slices it produces.
-  return stats.bytes * 2;
+  // Hash holds hash_partition's reorder buffer, and the slices are views into it rather
+  // than copies, so the reorder is the whole cost. It stays resident until the last slice
+  // referencing it is released.
+  return stats.bytes;
 }
 
 void sirius_physical_streaming_sink::build_pipelines(pipeline::sirius_pipeline& current,

--- a/test/cpp/operator/test_gpu_partition_impl.cpp
+++ b/test/cpp/operator/test_gpu_partition_impl.cpp
@@ -263,6 +263,98 @@ TEST_CASE("Hash partition with num partitions larger than input size", "[operato
   validate_hash_partition(*input_batch, output_batches, num_partitions);
 }
 
+TEST_CASE("Hash partition drops the appended cast key columns", "[operator][hash_partition]")
+{
+  auto* mem_space                           = get_shared_mem_space();
+  constexpr size_t num_input_rows           = 1000;
+  constexpr size_t num_partitions           = 4;
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
+  std::vector<int> partition_key_idx        = {0, 1};
+  // Key 0 is hashed as INT64; key 1 keeps its own type. The cast column is appended to the
+  // hashed table only, so it must not reach the output.
+  std::vector<cudf::data_type> cast_types = {cudf::data_type{cudf::type_id::INT64},
+                                             cudf::data_type{cudf::type_id::EMPTY}};
+  std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(),
+                                                         std::pair<int, int>{0, 100000});
+
+  auto input_batch =
+    create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
+  std::vector<std::shared_ptr<data_batch>> output_batches;
+  {
+    auto ro        = input_batch->to_read_only();
+    output_batches = gpu_partition_impl::hash_partition(
+      ro, partition_key_idx, cast_types, num_partitions, cudf::get_default_stream(), *mem_space);
+  }
+  // Checks that every output carries exactly the input schema, so a retained cast column shows
+  // up as an extra column rather than as wrong data.
+  validate_hash_partition(*input_batch, output_batches, num_partitions);
+}
+
+TEST_CASE("Hash partition output slices alias one reordered table", "[operator][hash_partition]")
+{
+  auto* mem_space                           = get_shared_mem_space();
+  constexpr size_t num_input_rows           = 4000;
+  constexpr size_t num_partitions           = 4;
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
+  std::vector<int> partition_key_idx        = {0, 1};
+  // Wide key range so every partition receives rows.
+  std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(),
+                                                         std::pair<int, int>{0, 100000});
+
+  auto input_batch =
+    create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
+  std::vector<std::shared_ptr<data_batch>> output_batches;
+  std::size_t input_bytes = 0;
+  {
+    auto ro        = input_batch->to_read_only();
+    input_bytes    = ro.get_data()->get_size_in_bytes();
+    output_batches = gpu_partition_impl::hash_partition(
+      ro, partition_key_idx, num_partitions, cudf::get_default_stream(), *mem_space);
+  }
+  validate_hash_partition(*input_batch, output_batches, num_partitions);
+
+  std::vector<cudf::table_view> views;
+  views.reserve(output_batches.size());
+  for (const auto& output_batch : output_batches) {
+    views.push_back(sirius::get_cudf_table_view(*output_batch));
+  }
+
+  // The partitions must be adjacent windows of a single reordered allocation per column: a
+  // per-partition deep copy would place each one in its own allocation instead.
+  int checked_columns = 0;
+  for (int c = 0; c < views[0].num_columns(); ++c) {
+    const std::byte* base       = nullptr;
+    cudf::size_type next_offset = 0;
+    for (const auto& view : views) {
+      if (view.num_rows() == 0) { continue; }
+      const auto& col = view.column(c);
+      if (base == nullptr) {
+        base        = col.head<std::byte>();
+        next_offset = col.offset();
+      }
+      REQUIRE(col.head<std::byte>() == base);
+      REQUIRE(col.offset() == next_offset);
+      next_offset += view.num_rows();
+    }
+    REQUIRE(base != nullptr);
+    ++checked_columns;
+  }
+  REQUIRE(checked_columns == views[0].num_columns());
+
+  // The reordered table is charged once across the partitions, not once per partition.
+  std::size_t charged = 0;
+  for (const auto& output_batch : output_batches) {
+    charged += output_batch->to_read_only().get_data()->get_size_in_bytes();
+  }
+  REQUIRE(charged <= input_bytes);
+}
+
 namespace {
 
 void validate_evenly_partition(data_batch& input_batch,

--- a/test/cpp/operator/test_no_history_peak_memory_estimate.cpp
+++ b/test/cpp/operator/test_no_history_peak_memory_estimate.cpp
@@ -149,7 +149,7 @@ TEST_CASE("partition no_history_peak_memory_estimate: num_partitions unset retur
     sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
     0,
     f.hash_join.get()};
-  REQUIRE(part.no_history_peak_memory_estimate({1, 1000}) == 2000);
+  REQUIRE(part.no_history_peak_memory_estimate({1, 1000}) == 1000);
 }
 
 TEST_CASE("partition no_history_peak_memory_estimate: 1 partition returns 0",
@@ -173,7 +173,7 @@ TEST_CASE("partition no_history_peak_memory_estimate: 2 partitions returns bytes
     0,
     f.hash_join.get()};
   part.set_num_partitions(2);
-  REQUIRE(part.no_history_peak_memory_estimate({3, 2000}) == 4000);
+  REQUIRE(part.no_history_peak_memory_estimate({3, 2000}) == 2000);
 }
 
 TEST_CASE("partition no_history_peak_memory_estimate: many partitions returns bytes",
@@ -185,7 +185,7 @@ TEST_CASE("partition no_history_peak_memory_estimate: many partitions returns by
     0,
     f.hash_join.get()};
   part.set_num_partitions(8);
-  REQUIRE(part.no_history_peak_memory_estimate({5, 4096}) == 8192);
+  REQUIRE(part.no_history_peak_memory_estimate({5, 4096}) == 4096);
 }
 
 TEST_CASE("GPU scan preserves fresh-read expansion and filter-only accounting",

--- a/test/cpp/operator/test_physical_streaming_sink.cpp
+++ b/test/cpp/operator/test_physical_streaming_sink.cpp
@@ -331,10 +331,10 @@ TEST_CASE("streaming_sink SNK-9: memory estimate follows the routing mode", "[st
     REQUIRE(op->no_history_peak_memory_estimate(stats) == 0);
   }
 
-  SECTION("hash holds the reorder buffer alongside the slices")
+  SECTION("hash holds the reorder buffer, which the slices view rather than copy")
   {
     auto [op, repos] = make_partitioned_sink(4);
-    REQUIRE(op->no_history_peak_memory_estimate(stats) == stats.bytes * 2);
+    REQUIRE(op->no_history_peak_memory_estimate(stats) == stats.bytes);
   }
 
   SECTION("broadcast holds the original plus one clone per extra destination")
@@ -692,7 +692,7 @@ TEST_CASE("streaming_sink PART-6: a single destination bypasses partitioning", "
   REQUIRE(op.no_history_peak_memory_estimate(stats) == 0);
 
   auto [partitioned, repos_2] = make_partitioned_sink(2);
-  REQUIRE(partitioned->no_history_peak_memory_estimate(stats) == stats.bytes * 2);
+  REQUIRE(partitioned->no_history_peak_memory_estimate(stats) == stats.bytes);
 }
 
 // ============================================================================


### PR DESCRIPTION
This eliminates a data copy during hash_partition by using views into a single large table. That reduces the peak memory usage, and the reservation required, but also keeps all data alive until the whole process is complete instead of releasing per partition. So this is mostly to reduce peak memory usage, there isn't a real performance gain measured in our sf1k workload.



## Description

## Checklist
- [ ] Read CONTRIBUTING.md
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References