### PR TITLE
perf(dynamic-filter): carrier-native membership probes + mask-aware filtered decode (rebase of #1557)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -806,6 +806,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_physical_top_n.cpp
     test/cpp/operator/test_physical_ungrouped_aggregate.cpp
     test/cpp/operator/test_sirius_dynamic_filter.cpp
+    test/cpp/operator/test_dynamic_filter_probe.cpp
     test/cpp/operator/test_dynamic_filter_publication_claim.cpp
     test/cpp/operator/test_dynamic_filter_publisher.cpp
     test/cpp/operator/test_dynamic_filter_source_policy.cpp
@@ -856,6 +857,7 @@ set(TEST_SOURCES
     test/cpp/scan/test_duckdb_native_host_backed_decode.cpp
     test/cpp/scan/test_duckdb_native_walker.cpp
     test/cpp/scan/test_dynamic_filter_merge.cpp
+    test/cpp/scan/test_fused_membership_mask.cpp
     test/cpp/scan/test_gpu_decode_alp.cpp
     test/cpp/scan/test_gpu_decode_bitpacking.cpp
     test/cpp/scan/test_gpu_decode_rle.cpp

--- a/docs/super-sirius/dynamic-filters.md
+++ b/docs/super-sirius/dynamic-filters.md
@@ -96,6 +96,12 @@ If no probe-GPU L2 size is available, the hash IN-list is not selected; the publ
 - The domain-coverage gate skips the key before either filter is built when a proven-unique native build key covers at least `dynamic_filter_domain_coverage_threshold` of its known base-table domain.
 - The consumer keep-ratio gate disables ineffective post-decode filtering when a measured batch retains more than `dynamic_filter_keep_threshold` of its rows.
 
+### Probe-side evaluation
+
+`compute_mask` accepts any signed-integer probe carrier (`INT8`..`INT64`) regardless of the build-key width, widening or narrowing each value in-kernel; a probe value the key domain cannot represent is a definite non-member. This matters where the probe column is decoded rather than stored natively: a `BIGINT` join key can decode to a narrow `INT32` carrier, and the consumer probes that carrier directly instead of materializing a full-width cast first. Non-integer probe carriers (decimals, dates, floats) still decline with `nullptr` — a semantic mismatch, not a width mismatch.
+
+`compute_mask` also has an overload taking an optional packed prior keep-mask (1 bit per row, cuDF-bitmask convention): rows the prior already killed skip the set or Bloom lookup entirely. The filtered decode uses it — when a chunk has other mask sources (ranges, dictionary-answered equalities), the membership probes run sequentially on one stream *after* those masks are AND-combined, each consuming the current combined mask as its prior and folding its own result back in, so a selective range removes most of a probe's random lookups and a second probe sees the first probe's survivors. Membership-only chunks keep the concurrent, prior-free submission. The prior is a pruning hint only: ignoring it is always sound, because the caller ANDs the probe's result with that same mask.
+
 Zone maps are off by default because DuckDB static pushdown already handles many known ranges, while scattered runtime keys often span most of the domain. Floating-point keys never receive a zone map: the lowered bounds compare with IEEE semantics under which NaN fails both, while the authoritative join matches NaN keys to each other (DuckDB total order), so a range filter could drop matching rows.
 
 ## Ordering and correctness

--- a/src/compression/compressed_scan.hpp
+++ b/src/compression/compressed_scan.hpp
@@ -74,8 +74,18 @@ struct decode_range {
 /// published device structure (small in-list / hash set / Bloom) over a decoded
 /// key column and returns a BOOL8 keep-mask. The closure co-owns the filter for
 /// the call's duration and must enqueue only on the handed stream.
-using membership_probe_fn = std::function<std::unique_ptr<cudf::column>(
-  cudf::column_view const&, rmm::cuda_stream_view, rmm::device_async_resource_ref)>;
+///
+/// The second argument is an OPTIONAL prior keep-mask over the key column's
+/// rows — packed 1 bit/row (bit `row % 32` of word `row / 32`, 1 = keep), or
+/// null for no restriction. The decoder hands the already-combined mask of the
+/// conjuncts it evaluated first, so the probe skips dead rows' set/Bloom
+/// lookups; the probe may ignore it (its result is ANDed with that same mask
+/// by the caller).
+using membership_probe_fn =
+  std::function<std::unique_ptr<cudf::column>(cudf::column_view const&,
+                                              std::uint32_t const*,
+                                              rmm::cuda_stream_view,
+                                              rmm::device_async_resource_ref)>;
 
 /// One membership test plus the signal used to order it.
 ///

--- a/src/compression/simpatico_codegen/include/codegen/selection/selection.hpp
+++ b/src/compression/simpatico_codegen/include/codegen/selection/selection.hpp
@@ -150,8 +150,16 @@ struct filter_column_directive {
 // the converter must never hand a probe that reads mutable live state.
 struct membership_filter_directive {
   std::size_t column;  // key column, indexes into `selected`
-  std::function<std::unique_ptr<cudf::column>(
-    cudf::column_view keys, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)>
+  // The second argument is an OPTIONAL prior keep-mask over the batch's rows
+  // (packed selection-mask words, 1 = keep, null = no restriction). When other
+  // mask sources exist, the orchestrator runs membership probes AFTER combining
+  // them and hands the combined words here so dead rows skip the membership
+  // lookup; the probe may ignore the hint (its result is ANDed with that same
+  // mask).
+  std::function<std::unique_ptr<cudf::column>(cudf::column_view keys,
+                                              uint32_t const* prior_mask_words,
+                                              rmm::cuda_stream_view stream,
+                                              rmm::device_async_resource_ref mr)>
     probe;
 };
 

--- a/src/compression/simpatico_codegen/src/simpatico_codegen.cpp
+++ b/src/compression/simpatico_codegen/src/simpatico_codegen.cpp
@@ -21,6 +21,7 @@
 #include <nvtx3/nvtx3.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cstdio>
 #include <cstdlib>
 #include <limits>
@@ -619,58 +620,118 @@ std::optional<std::vector<std::unique_ptr<cudf::column>>> try_decompress_fused(
         bool8_full[b] = std::move(flags);
       });
     }
-    for (size_t m = 0; m < k_member; ++m) {
-      submit_mask_source(
-        k_range + k_bool8 + m, [&](std::uint32_t* dst, rmm::cuda_stream_view stream) {
-          auto const& directive = request.membership_filters[m];
-          auto const& col       = table.columns[selected[directive.column]];
-          std::string err;
-          // Full-width key decode (any plan shape), then the type-erased
-          // device probe (in_list / cuco set / Bloom) -> BOOL8, then the
-          // packed-mask adapter. Probe contract: all work on `stream`.
-          auto keys = decompress_column(*col.plan_tree, stream, mr, &err);
-          if (!keys)
-            throw plan_error(err.empty() ? "filtered decode: membership key decode failed" : err);
-          auto keys_typed = apply_stored_dtype(std::move(keys), col.dtype);
-          auto flags      = directive.probe(keys_typed->view(), stream, mr);
-          // A null result is the probe DECLINING this column (the documented
-          // "caller skips it" answer — e.g. the chunk's stored carrier is
-          // narrower than the type the filter was published with). A join
-          // filter is never the whole filter, so dropping one only
-          // under-filters and the authoritative join still runs. Stand the
-          // source down to all-ones, the identity for the AND-combine, rather
-          // than abandoning the batch's whole filtered decode.
-          if (!flags) {
-            if (cudaMemsetAsync(dst,
-                                0xFF,
-                                static_cast<std::size_t>(alloc_words) * sizeof(std::uint32_t),
-                                stream.value()) != cudaSuccess) {
-              throw plan_error("filtered decode: declined-probe mask fill failed");
-            }
-            ++declined_members;
-            return;
+    // Mask-aware membership probes: when any other mask source exists, the
+    // probes are NOT submitted here — they run sequentially on s0 AFTER those
+    // masks are combined, each consuming the current combined words as a prior
+    // mask so dead rows skip the set/Bloom lookup (and each subsequent probe
+    // sees the previous probe's survivors — the capped ordering is ascending
+    // expected keep-rate, so the strongest filter tightens the mask first).
+    // With nothing to prime a prior from, they keep the concurrent round-robin
+    // submission below, prior-free.
+    size_t const k_static            = k_range + k_bool8;
+    bool const sequential_membership = k_member > 0 && k_static > 0;
+    for (size_t m = 0; !sequential_membership && m < k_member; ++m) {
+      submit_mask_source(k_static + m, [&](std::uint32_t* dst, rmm::cuda_stream_view stream) {
+        auto const& directive = request.membership_filters[m];
+        auto const& col       = table.columns[selected[directive.column]];
+        std::string err;
+        // Full-width key decode (any plan shape), then the type-erased
+        // device probe (in_list / cuco set / Bloom) -> BOOL8, then the
+        // packed-mask adapter. Probe contract: all work on `stream`.
+        auto keys = decompress_column(*col.plan_tree, stream, mr, &err);
+        if (!keys)
+          throw plan_error(err.empty() ? "filtered decode: membership key decode failed" : err);
+        auto keys_typed = apply_stored_dtype(std::move(keys), col.dtype);
+        auto flags = directive.probe(keys_typed->view(), /*prior_mask_words=*/nullptr, stream, mr);
+        // A null result is the probe DECLINING this column (the documented
+        // "caller skips it" answer — e.g. the chunk's stored carrier is
+        // narrower than the type the filter was published with). A join
+        // filter is never the whole filter, so dropping one only
+        // under-filters and the authoritative join still runs. Stand the
+        // source down to all-ones, the identity for the AND-combine, rather
+        // than abandoning the batch's whole filtered decode.
+        if (!flags) {
+          if (cudaMemsetAsync(dst,
+                              0xFF,
+                              static_cast<std::size_t>(alloc_words) * sizeof(std::uint32_t),
+                              stream.value()) != cudaSuccess) {
+            throw plan_error("filtered decode: declined-probe mask fill failed");
           }
-          // A wrong type or width is NOT a decline — it breaks the probe
-          // contract, so it stays fatal and names which side broke.
-          if (flags->type().id() != cudf::type_id::BOOL8 || flags->size() != num_rows)
-            throw plan_error("filtered decode: membership probe result shape mismatch (col=" +
-                             std::to_string(selected[directive.column]) + " got=type_id=" +
-                             std::to_string(static_cast<int>(flags->type().id())) +
-                             " size=" + std::to_string(flags->size()) + " want=type_id=" +
-                             std::to_string(static_cast<int>(cudf::type_id::BOOL8)) +
-                             " size=" + std::to_string(num_rows) + ")");
-          if (flags->null_count() != 0)
-            throw plan_error("filtered decode: null-masked membership probe result");
-          sc::mask_from_bool8(flags->view().data<std::uint8_t>(), num_rows, dst, stream);
-          // keys/flags die here: stream-ordered frees behind the adapter
-          // kernel on the same stream.
-        });
+          ++declined_members;
+          return;
+        }
+        // A wrong type or width is NOT a decline — it breaks the probe
+        // contract, so it stays fatal and names which side broke.
+        if (flags->type().id() != cudf::type_id::BOOL8 || flags->size() != num_rows)
+          throw plan_error("filtered decode: membership probe result shape mismatch (col=" +
+                           std::to_string(selected[directive.column]) +
+                           " got=type_id=" + std::to_string(static_cast<int>(flags->type().id())) +
+                           " size=" + std::to_string(flags->size()) + " want=type_id=" +
+                           std::to_string(static_cast<int>(cudf::type_id::BOOL8)) +
+                           " size=" + std::to_string(num_rows) + ")");
+        if (flags->null_count() != 0)
+          throw plan_error("filtered decode: null-masked membership probe result");
+        sc::mask_from_bool8(flags->view().data<std::uint8_t>(), num_rows, dst, stream);
+        // keys/flags die here: stream-ordered frees behind the adapter
+        // kernel on the same stream.
+      });
+    }
+
+    // ── Combine on stream 0: fold every source that wrote a strip into
+    // `combined`. mask_ptrs holds exactly those, so its size is the combine
+    // count on both the concurrent and the sequential-membership path.
+    if (mask_ptrs.size() > 1) {
+      sc::combine_masks_and(
+        combined, mask_ptrs.data(), static_cast<int>(mask_ptrs.size()), alloc_words, s0);
+    }
+
+    // ── Sequential membership cascade (mask-aware): `combined` now holds the
+    // AND of every other source. Each probe consumes it as the prior mask (dead
+    // rows skip the set/Bloom lookup) and its packed result immediately ANDs
+    // back in, so the next probe sees the tightened mask. Everything runs on
+    // s0, ordered behind the combine; one scratch strip serves every probe (its
+    // stream-ordered free is s0-local, so unwinding mid-flight cannot race a
+    // cross-stream reader). A declining probe leaves `combined` untouched —
+    // the AND identity, same stand-down as the concurrent path's all-ones fill.
+    if (sequential_membership) {
+      rmm::device_buffer membership_scratch(
+        static_cast<std::size_t>(alloc_words) * sizeof(std::uint32_t), s0, mr);
+      auto* member_dst = static_cast<std::uint32_t*>(membership_scratch.data());
+      std::array<std::uint32_t const*, 2> and_srcs{combined, member_dst};
+      for (size_t m = 0; m < k_member; ++m) {
+        auto const& directive = request.membership_filters[m];
+        auto const& col       = table.columns[selected[directive.column]];
+        std::string err;
+        auto keys = decompress_column(*col.plan_tree, s0, mr, &err);
+        if (!keys)
+          throw plan_error(err.empty() ? "filtered decode: membership key decode failed" : err);
+        auto keys_typed = apply_stored_dtype(std::move(keys), col.dtype);
+        auto flags      = directive.probe(keys_typed->view(), combined, s0, mr);
+        if (!flags) {
+          ++declined_members;
+          continue;
+        }
+        if (flags->type().id() != cudf::type_id::BOOL8 || flags->size() != num_rows)
+          throw plan_error("filtered decode: membership probe result shape mismatch (col=" +
+                           std::to_string(selected[directive.column]) +
+                           " got=type_id=" + std::to_string(static_cast<int>(flags->type().id())) +
+                           " size=" + std::to_string(flags->size()) + " want=type_id=" +
+                           std::to_string(static_cast<int>(cudf::type_id::BOOL8)) +
+                           " size=" + std::to_string(num_rows) + ")");
+        if (flags->null_count() != 0)
+          throw plan_error("filtered decode: null-masked membership probe result");
+        sc::mask_from_bool8(flags->view().data<std::uint8_t>(), num_rows, member_dst, s0);
+        sc::combine_masks_and(combined, and_srcs.data(), 2, alloc_words, s0);
+        // keys/flags die here: stream-ordered frees behind the combine on s0.
+      }
     }
 
     // An all-ones source is the AND identity only while a real source still
     // zeroes the tail bits past num_rows, which CNT and the gather require. If
     // every source declined there is nothing left to filter by anyway, so take
-    // the plain decode instead of counting a mask that is all ones.
+    // the plain decode instead of counting a mask that is all ones. Only
+    // reachable on the concurrent path: a sequential cascade runs behind at
+    // least one static source, which is never a decline.
     if (declined_members == k_total) {
       throw plan_error("filtered decode: every membership probe declined (" +
                        std::to_string(declined_members) + " of " + std::to_string(k_total) +
@@ -686,12 +747,9 @@ std::optional<std::vector<std::unique_ptr<cudf::column>>> try_decompress_fused(
                    static_cast<long long>(num_rows));
     }
 
-    // ── Combine + CNT on stream 0. run_selection_cnt host-syncs s0 once (the
-    // survivor count gates wave-2 allocations); after it returns, every wave-1
-    // kernel and the combine have completed, so per_filter teardown is safe.
-    if (k_total > 1) {
-      sc::combine_masks_and(combined, mask_ptrs.data(), static_cast<int>(k_total), alloc_words, s0);
-    }
+    // ── CNT on stream 0. run_selection_cnt host-syncs s0 once (the survivor
+    // count gates wave-2 allocations); after it returns, every wave-1 kernel
+    // and the combine have completed, so per_filter teardown is safe.
     sc::selection_mask sel{
       combined, num_rows, -1, static_cast<std::uint32_t*>(result.chunk_offsets.data())};
     sc::run_selection_cnt(sel, s0, mr);

--- a/src/cuda/sirius_dynamic_bloom_filter.cu
+++ b/src/cuda/sirius_dynamic_bloom_filter.cu
@@ -22,9 +22,11 @@
 
 #include <rmm/cuda_device.hpp>
 
+#include <cub/device/device_for.cuh>
 #include <cuco/bloom_filter.cuh>
 #include <cuco/bloom_filter_policies.cuh>
 #include <cuco/hash_functions.cuh>
+#include <cuda/dynamic_filter_probe.cuh>
 #include <cuda/sirius_rmm_cuco_allocator.cuh>
 #include <cuda/std/bit>
 #include <cuda/std/cstddef>
@@ -172,16 +174,32 @@ bloom_owner<Filter> build_bloom(cudf::column_view const& keys,
   return result;
 }
 
-template <class KeyT>
-constexpr cudf::type_id key_type_id() noexcept
-{
-  static_assert(std::is_same_v<KeyT, std::int32_t> || std::is_same_v<KeyT, std::int64_t>);
-  if constexpr (std::is_same_v<KeyT, std::int32_t>) {
-    return cudf::type_id::INT32;
-  } else {
-    return cudf::type_id::INT64;
+/// @brief Per-row Bloom membership probe. Probe values are widened/narrowed into the filter's
+/// key domain per element — an inserted key always fits that domain, so a non-representable
+/// probe value is a definite non-member and conversion preserves the no-false-negative
+/// contract. Rows the optional prior keep-mask killed skip the block fetch entirely.
+template <class ProbeT, class FilterRef>
+struct bloom_contains {
+  using key_type = typename FilterRef::key_type;
+  ProbeT const* __restrict__ probe;
+  bool* __restrict__ out;
+  FilterRef ref;
+  std::uint32_t const* __restrict__ prior_words;  // packed 1 bit/row keep-mask, or nullptr
+
+  __device__ __forceinline__ void operator()(cudf::size_type idx) const noexcept
+  {
+    if (!sirius::op::detail::prior_mask_keeps(prior_words, idx)) {
+      out[idx] = false;
+      return;
+    }
+    key_type key;
+    if (!sirius::op::detail::probe_key_convert(probe[idx], key)) {
+      out[idx] = false;
+      return;
+    }
+    out[idx] = ref.contains(key);
   }
-}
+};
 }  // namespace
 
 struct bloom_replica {
@@ -405,34 +423,39 @@ std::unique_ptr<cudf::column> sirius_dynamic_bloom_filter::compute_mask(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
-  if (!supports(probe.type())) { return nullptr; }
+  return compute_mask(probe, /*prior_mask_words=*/nullptr, device_id, stream, mr);
+}
+
+std::unique_ptr<cudf::column> sirius_dynamic_bloom_filter::compute_mask(
+  cudf::column_view const& probe,
+  std::uint32_t const* prior_mask_words,
+  int device_id,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
   auto const* replica =
     _impl ? _impl->find(detail::resolve_dynamic_filter_device_id(device_id)) : nullptr;
   if (!replica || !replica->has_bloom()) { return nullptr; }
 
-  auto const matching_key_type = std::visit(
-    [&](auto const& bloom) {
-      using owner_type = std::decay_t<decltype(bloom)>;
-      using key_type   = typename owner_type::element_type::key_type;
-      return probe.type().id() == key_type_id<key_type>();
-    },
-    replica->bloom);
-  if (!matching_key_type) { return nullptr; }
-
-  auto const n = probe.size();
-  auto out     = cudf::make_numeric_column(
-    cudf::data_type{cudf::type_id::BOOL8}, n, cudf::mask_state::UNALLOCATED, stream, mr);
-  cuda::stream_ref const s{stream.value()};
-  auto* const outp = out->mutable_view().data<bool>();
-
-  std::visit(
-    [&](auto const& bloom) {
-      using owner_type = std::decay_t<decltype(bloom)>;
-      using key_type   = typename owner_type::element_type::key_type;
-      auto const* d    = probe.data<key_type>();
-      bloom->contains_async(d, d + n, outp, s);
-    },
-    replica->bloom);
+  std::unique_ptr<cudf::column> out;
+  auto const n          = probe.size();
+  auto const dispatched = detail::dispatch_signed_integer_probe(probe.type(), [&](auto probe_tag) {
+    using probe_type = decltype(probe_tag);
+    out              = cudf::make_numeric_column(
+      cudf::data_type{cudf::type_id::BOOL8}, n, cudf::mask_state::UNALLOCATED, stream, mr);
+    auto* const outp = out->mutable_view().data<bool>();
+    auto const* d    = probe.data<probe_type>();
+    std::visit(
+      [&](auto const& bloom) {
+        auto ref = bloom->ref();
+        cub::DeviceFor::Bulk(
+          n,
+          bloom_contains<probe_type, decltype(ref)>{d, outp, ref, prior_mask_words},
+          stream.value());
+      },
+      replica->bloom);
+  });
+  if (!dispatched) { return nullptr; }
 
   if (probe.nullable() && probe.null_count() > 0) {
     out->set_null_mask(cudf::copy_bitmask(probe, stream, mr), probe.null_count());

--- a/src/cuda/sirius_dynamic_in_list_filter.cu
+++ b/src/cuda/sirius_dynamic_in_list_filter.cu
@@ -31,6 +31,7 @@
 #include <cuco/operator.hpp>
 #include <cuco/static_set.cuh>
 #include <cuco/storage.cuh>
+#include <cuda/dynamic_filter_probe.cuh>
 #include <cuda/sirius_rmm_cuco_allocator.cuh>
 #include <cuda/std/functional>
 #include <cuda/std/limits>
@@ -148,15 +149,29 @@ struct equals_sentinel {
   }
 };
 
-template <class KeyT, class SetRef>
+// Probe values arrive at whatever integer carrier the consumer decoded (a decode-time probe
+// commonly sees BIGINT keys stored as a narrow carrier); each value is widened/narrowed into the
+// set's key domain in-kernel, so callers never materialize a cast. A value the key domain cannot
+// represent is a definite non-member. Rows the optional prior keep-mask killed skip the set lookup
+// entirely (out = false; the caller ANDs with that same mask anyway).
+template <class ProbeT, class KeyT, class SetRef>
 struct contains_or_sentinel {
-  KeyT const* probe;
+  ProbeT const* probe;
   bool* out;
   SetRef set;
+  std::uint32_t const* prior_words;  // packed 1 bit/row keep-mask, or null
   __device__ __forceinline__ void operator()(cudf::size_type idx) const noexcept
   {
-    auto const& key = probe[idx];
-    out[idx]        = set.contains(key) || equals_sentinel<KeyT>{}(key);
+    if (!detail::prior_mask_keeps(prior_words, idx)) {
+      out[idx] = false;
+      return;
+    }
+    KeyT key;
+    if (!detail::probe_key_convert(probe[idx], key)) {
+      out[idx] = false;
+      return;
+    }
+    out[idx] = set.contains(key) || equals_sentinel<KeyT>{}(key);
   }
 };
 
@@ -382,26 +397,41 @@ std::unique_ptr<cudf::column> sirius_dynamic_in_list_filter::compute_mask(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
-  if (probe.type() != _key_type) { return nullptr; }
+  return compute_mask(probe, /*prior_mask_words=*/nullptr, device_id, stream, mr);
+}
+
+std::unique_ptr<cudf::column> sirius_dynamic_in_list_filter::compute_mask(
+  cudf::column_view const& probe,
+  std::uint32_t const* prior_mask_words,
+  int device_id,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
   auto const* replica =
     _set ? _set->find(detail::resolve_dynamic_filter_device_id(device_id)) : nullptr;
   if (!replica) { return nullptr; }
 
-  auto const n = probe.size();
-  auto out     = cudf::make_numeric_column(
-    cudf::data_type{cudf::type_id::BOOL8}, n, cudf::mask_state::UNALLOCATED, stream, mr);
-  auto* const outp = out->mutable_view().data<bool>();
-
-  std::visit(
-    [&](auto const& set) {
-      using owner_type = std::decay_t<decltype(set)>;
-      using key_type   = typename owner_type::element_type::key_type;
-      auto const* d    = probe.data<key_type>();
-      auto ref         = set->ref(cuco::contains);
-      cub::DeviceFor::Bulk(
-        n, contains_or_sentinel<key_type, decltype(ref)>{d, outp, ref}, stream.value());
-    },
-    replica->set);
+  std::unique_ptr<cudf::column> out;
+  auto const n          = probe.size();
+  auto const dispatched = detail::dispatch_signed_integer_probe(probe.type(), [&](auto probe_tag) {
+    using probe_type = decltype(probe_tag);
+    out              = cudf::make_numeric_column(
+      cudf::data_type{cudf::type_id::BOOL8}, n, cudf::mask_state::UNALLOCATED, stream, mr);
+    auto* const outp = out->mutable_view().data<bool>();
+    auto const* d    = probe.data<probe_type>();
+    std::visit(
+      [&](auto const& set) {
+        using owner_type = std::decay_t<decltype(set)>;
+        using key_type   = typename owner_type::element_type::key_type;
+        auto ref         = set->ref(cuco::contains);
+        cub::DeviceFor::Bulk(
+          n,
+          contains_or_sentinel<probe_type, key_type, decltype(ref)>{d, outp, ref, prior_mask_words},
+          stream.value());
+      },
+      replica->set);
+  });
+  if (!dispatched) { return nullptr; }
   if (probe.nullable() && probe.null_count() > 0) {
     out->set_null_mask(cudf::copy_bitmask(probe, stream, mr), probe.null_count());
   }

--- a/src/cuda/sirius_dynamic_small_in_list_filter.cu
+++ b/src/cuda/sirius_dynamic_small_in_list_filter.cu
@@ -32,6 +32,7 @@
 
 // cccl
 #include <cub/device/device_for.cuh>
+#include <cuda/dynamic_filter_probe.cuh>
 
 // cucascade
 #include <cucascade/error.hpp>
@@ -60,18 +61,29 @@ namespace {
 
 /// @brief Per-row brute-force membership scan: out[idx] == true iff probe[idx] equals any of the m
 /// needles. For the small m this filter gates on (<= k_max_keys), a compare-all linear scan beats a
-/// hash probe and reserves no sentinel value.
-template <class KeyT>
+/// hash probe and reserves no sentinel value. Probe values are widened/narrowed into the needle
+/// domain per element (a value the domain cannot represent is a definite non-member), and rows the
+/// optional prior keep-mask killed skip the scan.
+template <class ProbeT, class KeyT>
 struct small_in_list_scan {
-  KeyT const* __restrict__ probe;
+  ProbeT const* __restrict__ probe;
   KeyT const* __restrict__ needles;
   int m;
   bool* __restrict__ out;
+  std::uint32_t const* __restrict__ prior_words;  // packed 1 bit/row keep-mask, or nullptr
 
   __device__ __forceinline__ void operator()(cudf::size_type idx) const noexcept
   {
-    auto const x = probe[idx];
-    bool hit     = false;
+    if (!sirius::op::detail::prior_mask_keeps(prior_words, idx)) {
+      out[idx] = false;
+      return;
+    }
+    KeyT x;
+    if (!sirius::op::detail::probe_key_convert(probe[idx], x)) {
+      out[idx] = false;
+      return;
+    }
+    bool hit = false;
     for (int j = 0; j < m; ++j) {
       hit |= (x == needles[j]);
     }
@@ -173,36 +185,50 @@ std::unique_ptr<cudf::column> sirius_dynamic_small_in_list_filter::compute_mask(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
-  if (probe.type() != _key_type) { return nullptr; }
+  return compute_mask(probe, /*prior_mask_words=*/nullptr, device_id, stream, mr);
+}
+
+std::unique_ptr<cudf::column> sirius_dynamic_small_in_list_filter::compute_mask(
+  cudf::column_view const& probe,
+  std::uint32_t const* prior_mask_words,
+  int device_id,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
   auto const* replica =
     _store ? _store->find(detail::resolve_dynamic_filter_device_id(device_id)) : nullptr;
   if (!replica) { return nullptr; }
 
-  auto const n = probe.size();
-  auto out     = cudf::make_numeric_column(
-    cudf::data_type{cudf::type_id::BOOL8}, n, cudf::mask_state::UNALLOCATED, stream, mr);
-  auto* const outp = out->mutable_view().data<bool>();
-  auto const m     = static_cast<int>(_num_keys);
-
-  switch (_key_type.id()) {
-    case cudf::type_id::INT32: {
-      auto const* needles = static_cast<std::int32_t const*>(replica->needles.data());
-      CUCASCADE_CUDA_TRY(cub::DeviceFor::Bulk(
-        n,
-        small_in_list_scan<std::int32_t>{probe.data<std::int32_t>(), needles, m, outp},
-        stream.value()));
-      break;
+  std::unique_ptr<cudf::column> out;
+  auto const n          = probe.size();
+  auto const m          = static_cast<int>(_num_keys);
+  auto const dispatched = detail::dispatch_signed_integer_probe(probe.type(), [&](auto probe_tag) {
+    using probe_type = decltype(probe_tag);
+    out              = cudf::make_numeric_column(
+      cudf::data_type{cudf::type_id::BOOL8}, n, cudf::mask_state::UNALLOCATED, stream, mr);
+    auto* const outp = out->mutable_view().data<bool>();
+    auto const* d    = probe.data<probe_type>();
+    switch (_key_type.id()) {
+      case cudf::type_id::INT32: {
+        auto const* needles = static_cast<std::int32_t const*>(replica->needles.data());
+        CUCASCADE_CUDA_TRY(cub::DeviceFor::Bulk(
+          n,
+          small_in_list_scan<probe_type, std::int32_t>{d, needles, m, outp, prior_mask_words},
+          stream.value()));
+        break;
+      }
+      case cudf::type_id::INT64: {
+        auto const* needles = static_cast<std::int64_t const*>(replica->needles.data());
+        CUCASCADE_CUDA_TRY(cub::DeviceFor::Bulk(
+          n,
+          small_in_list_scan<probe_type, std::int64_t>{d, needles, m, outp, prior_mask_words},
+          stream.value()));
+        break;
+      }
+      default: out.reset(); break;
     }
-    case cudf::type_id::INT64: {
-      auto const* needles = static_cast<std::int64_t const*>(replica->needles.data());
-      CUCASCADE_CUDA_TRY(cub::DeviceFor::Bulk(
-        n,
-        small_in_list_scan<std::int64_t>{probe.data<std::int64_t>(), needles, m, outp},
-        stream.value()));
-      break;
-    }
-    default: return nullptr;
-  }
+  });
+  if (!dispatched || !out) { return nullptr; }
 
   if (probe.nullable() && probe.null_count() > 0) {
     out->set_null_mask(cudf::copy_bitmask(probe, stream, mr), probe.null_count());

--- a/src/include/cuda/dynamic_filter_probe.cuh
+++ b/src/include/cuda/dynamic_filter_probe.cuh
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Shared device/host helpers for the membership dynamic-filter probe kernels
+// (IN-list, small IN-list, Bloom). Two concerns live here so the three .cu
+// implementations stay in lockstep:
+//
+//  1. Heterogeneous probe keys. A consumer may probe with a column whose
+//     integer carrier is narrower or wider than the build-key type — e.g. a
+//     compressed-materialization pin stores BIGINT l_partkey as an INT32
+//     carrier while the set was built from the native INT64 p_partkey.
+//     @ref probe_key_convert widens/narrows per element in-kernel, so no
+//     materialized cast of the probe column is ever needed.
+//
+//  2. Prior keep-masks. A probe may receive the packed keep-mask of the
+//     conjuncts already evaluated (fused scan-filter wave 1); rows the prior
+//     mask killed skip the set/Bloom lookup entirely. @ref prior_mask_keeps
+//     reads the standard packed convention (bit `row % 32` of word
+//     `row / 32`, 1 = keep) shared by cuDF bitmasks and the fused
+//     selection-wave masks.
+
+// cudf
+#include <cudf/types.hpp>
+
+// cccl
+#include <cuda/std/limits>
+
+// standard library
+#include <cstdint>
+
+namespace sirius::op::detail {
+
+/**
+ * @brief Lossless per-element conversion of a probe value into the filter's key domain.
+ *
+ * Widening always succeeds. Narrowing succeeds only when @p value is representable in @c KeyT;
+ * a non-representable value can never equal a stored key, so callers treat a failed conversion
+ * as a definite non-member.
+ *
+ * @return true when @p out holds the converted value, false when @p value is not representable.
+ */
+template <class KeyT, class ProbeT>
+__device__ __forceinline__ bool probe_key_convert(ProbeT value, KeyT& out) noexcept
+{
+  if constexpr (sizeof(ProbeT) <= sizeof(KeyT)) {
+    out = static_cast<KeyT>(value);
+    return true;
+  } else {
+    if (value < static_cast<ProbeT>(cuda::std::numeric_limits<KeyT>::min()) ||
+        value > static_cast<ProbeT>(cuda::std::numeric_limits<KeyT>::max())) {
+      return false;
+    }
+    out = static_cast<KeyT>(value);
+    return true;
+  }
+}
+
+/**
+ * @brief True when @p row survives the optional prior keep-mask.
+ *
+ * @p words is packed 1-bit-per-row (bit `row % 32` of word `row / 32`, 1 = keep) — the shared
+ * cuDF-bitmask / fused-selection-wave convention. A null @p words means no prior restriction.
+ */
+__device__ __forceinline__ bool prior_mask_keeps(std::uint32_t const* words,
+                                                 cudf::size_type row) noexcept
+{
+  return words == nullptr ||
+         ((words[static_cast<std::size_t>(row) >> 5] >> (static_cast<std::uint32_t>(row) & 31U)) &
+          1U) != 0U;
+}
+
+/**
+ * @brief Invoke @p fn with a value-initialized instance of the signed integer type behind @p t.
+ *
+ * Covers the integer carriers compressed materialization can narrow a key column to. Returns
+ * false — without invoking @p fn — for any other type; membership filters answer nullptr there
+ * (a non-integer probe against an integer key set is a semantic mismatch, not a width mismatch).
+ */
+template <class Fn>
+bool dispatch_signed_integer_probe(cudf::data_type t, Fn&& fn)
+{
+  switch (t.id()) {
+    case cudf::type_id::INT8: fn(std::int8_t{}); return true;
+    case cudf::type_id::INT16: fn(std::int16_t{}); return true;
+    case cudf::type_id::INT32: fn(std::int32_t{}); return true;
+    case cudf::type_id::INT64: fn(std::int64_t{}); return true;
+    default: return false;
+  }
+}
+
+}  // namespace sirius::op::detail

--- a/src/include/op/dynamic_filter/sirius_dynamic_filter.hpp
+++ b/src/include/op/dynamic_filter/sirius_dynamic_filter.hpp
@@ -34,6 +34,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -166,12 +167,38 @@ class sirius_mask_applicable {
 
   /**
    * @brief Returns `probe.size()` BOOL8 values (`true` keeps), or null for an incompatible probe
+   *
+   * The membership implementations accept any signed-integer @p probe carrier (INT8..INT64) and
+   * widen/narrow it per element against the build-key type, so a consumer never has to
+   * materialize a cast of the probe column — a decode-time probe commonly sees a BIGINT key
+   * stored as a narrow carrier.
    */
   [[nodiscard]] virtual std::unique_ptr<cudf::column> compute_mask(
     cudf::column_view const& probe,
     int device_id,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const = 0;
+
+  /**
+   * @brief Prior-mask-aware variant: rows the prior keep-mask already killed skip the probe
+   *
+   * @p prior_mask_words is a packed 1-bit-per-row keep-mask over @p probe's rows (bit `row % 32`
+   * of word `row / 32`, 1 = keep — the shared cuDF-bitmask / selection-wave convention), or null
+   * for no restriction. A dead row answers `false` without touching the filter structure, so a
+   * selective prior removes most of the probe's random lookups. The prior is a pruning hint only:
+   * the default implementation ignores it and answers the unmasked form, which is sound because
+   * every caller ANDs the result with that same mask anyway.
+   */
+  [[nodiscard]] virtual std::unique_ptr<cudf::column> compute_mask(
+    cudf::column_view const& probe,
+    std::uint32_t const* prior_mask_words,
+    int device_id,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const
+  {
+    (void)prior_mask_words;
+    return compute_mask(probe, device_id, stream, mr);
+  }
 };
 
 /**
@@ -205,6 +232,13 @@ class sirius_dynamic_in_list_filter final : public sirius_dynamic_filter,
 
   [[nodiscard]] std::unique_ptr<cudf::column> compute_mask(
     cudf::column_view const& probe,
+    int device_id,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const override;
+
+  [[nodiscard]] std::unique_ptr<cudf::column> compute_mask(
+    cudf::column_view const& probe,
+    std::uint32_t const* prior_mask_words,
     int device_id,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const override;
@@ -266,6 +300,13 @@ class sirius_dynamic_small_in_list_filter final : public sirius_dynamic_filter,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const override;
 
+  [[nodiscard]] std::unique_ptr<cudf::column> compute_mask(
+    cudf::column_view const& probe,
+    std::uint32_t const* prior_mask_words,
+    int device_id,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const override;
+
   void replicate_to_devices(std::span<dynamic_filter_replica_space const> spaces) override;
   [[nodiscard]] bool is_available_on_device(int device_id) const noexcept override;
 
@@ -313,6 +354,13 @@ class sirius_dynamic_bloom_filter final : public sirius_dynamic_filter,
 
   [[nodiscard]] std::unique_ptr<cudf::column> compute_mask(
     cudf::column_view const& probe,
+    int device_id,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const override;
+
+  [[nodiscard]] std::unique_ptr<cudf::column> compute_mask(
+    cudf::column_view const& probe,
+    std::uint32_t const* prior_mask_words,
     int device_id,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const override;

--- a/src/op/scan/sirius_gpu_scan_operator_data.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator_data.cpp
@@ -28,6 +28,7 @@
 #include <op/scan/sirius_gpu_scan_operator_data.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <numeric>
 #include <stdexcept>
@@ -100,12 +101,14 @@ membership_snapshot snapshot_membership_probes(sirius::op::sirius_dynamic_filter
       // assigns this split's chunk to a GPU, so the device isn't known yet
       // here; pass -1 so compute_mask resolves it from the CURRENT CUDA
       // device at probe time, which the task scheduler has already set to
-      // the chunk's assigned GPU by then.
+      // the chunk's assigned GPU by then. The prior mask is the decoder's
+      // already-combined conjuncts — dead rows skip the membership lookup.
       snap.probes[i].push_back(
         {[f = std::move(filter), applicable](cudf::column_view const& keys,
+                                             std::uint32_t const* prior_mask_words,
                                              rmm::cuda_stream_view s,
                                              rmm::device_async_resource_ref mr) {
-           return applicable->compute_mask(keys, /*device_id=*/-1, s, mr);
+           return applicable->compute_mask(keys, prior_mask_words, /*device_id=*/-1, s, mr);
          },
          kind_rank,
          num_keys});

--- a/test/cpp/operator/test_dynamic_filter_probe.cpp
+++ b/test/cpp/operator/test_dynamic_filter_probe.cpp
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_dynamic_filter_probe.cpp
+ * @brief Single-GPU probe-kernel semantics of the membership dynamic filters (IN-list,
+ *        small IN-list, Bloom): heterogeneous integer probe carriers (no materialized cast),
+ *        the optional prior keep-mask (dead rows skip the lookup), sentinel conservation, and
+ *        the refusal of non-integer probe types.
+ */
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/device_buffer.hpp>
+
+#include <cuda_runtime.h>
+
+#include <catch.hpp>
+#include <op/dynamic_filter/sirius_dynamic_filter.hpp>
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <vector>
+
+using sirius::op::sirius_dynamic_bloom_filter;
+using sirius::op::sirius_dynamic_in_list_filter;
+using sirius::op::sirius_dynamic_small_in_list_filter;
+
+namespace {
+
+constexpr int kDevice = 0;  // build == probe device: the source replica answers directly
+
+template <typename T>
+std::unique_ptr<cudf::column> make_values(std::vector<T> const& values,
+                                          cudf::data_type type,
+                                          rmm::cuda_stream_view stream)
+{
+  auto col       = cudf::make_numeric_column(type,
+                                       static_cast<cudf::size_type>(values.size()),
+                                       cudf::mask_state::UNALLOCATED,
+                                       stream,
+                                       cudf::get_current_device_resource_ref());
+  auto const err = cudaMemcpyAsync(col->mutable_view().data<T>(),
+                                   values.data(),
+                                   values.size() * sizeof(T),
+                                   cudaMemcpyHostToDevice,
+                                   stream.value());
+  REQUIRE(err == cudaSuccess);
+  stream.synchronize();  // callers pass temporaries; these tests do not benchmark ingestion
+  return col;
+}
+
+std::unique_ptr<cudf::column> make_int32(std::vector<std::int32_t> const& v,
+                                         rmm::cuda_stream_view stream)
+{
+  return make_values(v, cudf::data_type{cudf::type_id::INT32}, stream);
+}
+
+std::unique_ptr<cudf::column> make_int64(std::vector<std::int64_t> const& v,
+                                         rmm::cuda_stream_view stream)
+{
+  return make_values(v, cudf::data_type{cudf::type_id::INT64}, stream);
+}
+
+std::vector<std::uint8_t> mask_to_host(cudf::column_view const& mask, rmm::cuda_stream_view stream)
+{
+  REQUIRE(mask.type().id() == cudf::type_id::BOOL8);
+  std::vector<std::uint8_t> host(static_cast<std::size_t>(mask.size()));
+  auto const err = cudaMemcpyAsync(host.data(),
+                                   mask.data<bool>(),
+                                   host.size() * sizeof(bool),
+                                   cudaMemcpyDeviceToHost,
+                                   stream.value());
+  REQUIRE(err == cudaSuccess);
+  stream.synchronize();
+  return host;
+}
+
+/// Upload a packed 1-bit/row keep-mask (bit row%32 of word row/32, 1 = keep) built from @p keep.
+rmm::device_buffer upload_prior_mask(std::vector<bool> const& keep, rmm::cuda_stream_view stream)
+{
+  std::vector<std::uint32_t> words((keep.size() + 31) / 32, 0U);
+  for (std::size_t row = 0; row < keep.size(); ++row) {
+    if (keep[row]) { words[row / 32] |= (1U << (row % 32)); }
+  }
+  rmm::device_buffer out{words.data(), words.size() * sizeof(std::uint32_t), stream};
+  stream.synchronize();
+  return out;
+}
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// Heterogeneous probe carriers (the killed probe-key cast)
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("IN-list over INT64 keys probes an INT32 carrier without a cast",
+          "[dynamic_filter][probe]")
+{
+  auto const stream = cudf::get_default_stream();
+  auto const mr     = cudf::get_current_device_resource_ref();
+
+  auto keys = make_int64({10, 20, 30, 40}, stream);
+  sirius_dynamic_in_list_filter filter{keys->view(), stream, mr};
+  REQUIRE(filter.has_persistent_set());
+
+  auto probe = make_int32({10, 15, 20, -3, 40}, stream);
+  auto mask  = filter.compute_mask(probe->view(), kDevice, stream, mr);
+  REQUIRE(mask != nullptr);
+  auto const host = mask_to_host(mask->view(), stream);
+  CHECK(host == std::vector<std::uint8_t>{1, 0, 1, 0, 1});
+}
+
+TEST_CASE("IN-list over INT32 keys drops out-of-range INT64 probe values",
+          "[dynamic_filter][probe]")
+{
+  auto const stream = cudf::get_default_stream();
+  auto const mr     = cudf::get_current_device_resource_ref();
+
+  auto keys = make_int32({1, 2, 3}, stream);
+  sirius_dynamic_in_list_filter filter{keys->view(), stream, mr};
+
+  auto probe = make_int64({1, 5'000'000'000LL, 3, -5'000'000'000LL}, stream);
+  auto mask  = filter.compute_mask(probe->view(), kDevice, stream, mr);
+  REQUIRE(mask != nullptr);
+  auto const host = mask_to_host(mask->view(), stream);
+  CHECK(host == std::vector<std::uint8_t>{1, 0, 1, 0});
+}
+
+TEST_CASE("IN-list sentinel semantics under heterogeneous probes", "[dynamic_filter][probe]")
+{
+  auto const stream = cudf::get_default_stream();
+  auto const mr     = cudf::get_current_device_resource_ref();
+
+  SECTION("an INT64 probe equal to the INT32 set's empty sentinel is kept conservatively")
+  {
+    auto keys = make_int32({7}, stream);
+    sirius_dynamic_in_list_filter filter{keys->view(), stream, mr};
+    auto probe = make_int64(
+      {static_cast<std::int64_t>(std::numeric_limits<std::int32_t>::min()), 7, 8}, stream);
+    auto mask = filter.compute_mask(probe->view(), kDevice, stream, mr);
+    REQUIRE(mask != nullptr);
+    auto const host = mask_to_host(mask->view(), stream);
+    CHECK(host == std::vector<std::uint8_t>{1, 1, 0});  // sentinel keep stays conservative
+  }
+
+  SECTION("an INT32 probe against an INT64 set is exact: no widened value hits the sentinel")
+  {
+    auto keys = make_int64({7}, stream);
+    sirius_dynamic_in_list_filter filter{keys->view(), stream, mr};
+    auto probe = make_int32({std::numeric_limits<std::int32_t>::min(), 7}, stream);
+    auto mask  = filter.compute_mask(probe->view(), kDevice, stream, mr);
+    REQUIRE(mask != nullptr);
+    auto const host = mask_to_host(mask->view(), stream);
+    CHECK(host == std::vector<std::uint8_t>{0, 1});  // INT32_MIN widened != INT64 sentinel
+  }
+
+  SECTION("the homogeneous sentinel keep is unchanged")
+  {
+    auto keys = make_int64({5}, stream);
+    sirius_dynamic_in_list_filter filter{keys->view(), stream, mr};
+    auto probe = make_int64({std::numeric_limits<std::int64_t>::min(), 5, 6}, stream);
+    auto mask  = filter.compute_mask(probe->view(), kDevice, stream, mr);
+    REQUIRE(mask != nullptr);
+    auto const host = mask_to_host(mask->view(), stream);
+    CHECK(host == std::vector<std::uint8_t>{1, 1, 0});
+  }
+}
+
+TEST_CASE("small IN-list probes heterogeneous integer carriers", "[dynamic_filter][probe]")
+{
+  auto const stream = cudf::get_default_stream();
+  auto const mr     = cudf::get_current_device_resource_ref();
+
+  SECTION("INT64 needles, INT32 probe")
+  {
+    auto keys = make_int64({7, 1'000'000'000'000LL}, stream);
+    sirius_dynamic_small_in_list_filter filter{keys->view(), stream, mr};
+    auto probe = make_int32({7, -7, 0}, stream);
+    auto mask  = filter.compute_mask(probe->view(), kDevice, stream, mr);
+    REQUIRE(mask != nullptr);
+    auto const host = mask_to_host(mask->view(), stream);
+    CHECK(host == std::vector<std::uint8_t>{1, 0, 0});
+  }
+
+  SECTION("INT32 needles, INT64 probe with out-of-range values")
+  {
+    auto keys = make_int32({5, 6}, stream);
+    sirius_dynamic_small_in_list_filter filter{keys->view(), stream, mr};
+    auto probe = make_int64({5, 6'000'000'000LL, 6}, stream);
+    auto mask  = filter.compute_mask(probe->view(), kDevice, stream, mr);
+    REQUIRE(mask != nullptr);
+    auto const host = mask_to_host(mask->view(), stream);
+    CHECK(host == std::vector<std::uint8_t>{1, 0, 1});
+  }
+}
+
+TEST_CASE("Bloom filter has no false negatives across probe carriers", "[dynamic_filter][probe]")
+{
+  auto const stream = cudf::get_default_stream();
+  auto const mr     = cudf::get_current_device_resource_ref();
+
+  SECTION("INT64 build keys, INT32 probe")
+  {
+    auto keys = make_int64({100, 200, 300, 9'000'000'000LL}, stream);
+    sirius_dynamic_bloom_filter filter{keys->view(), stream, mr};
+    auto probe = make_int32({100, 200, 300}, stream);
+    auto mask  = filter.compute_mask(probe->view(), kDevice, stream, mr);
+    REQUIRE(mask != nullptr);
+    auto const host = mask_to_host(mask->view(), stream);
+    CHECK(host == std::vector<std::uint8_t>{1, 1, 1});  // every inserted key must test positive
+  }
+
+  SECTION("INT32 build keys, INT64 probe")
+  {
+    auto keys = make_int32({100, 200, 300}, stream);
+    sirius_dynamic_bloom_filter filter{keys->view(), stream, mr};
+    auto probe = make_int64({100, 300}, stream);
+    auto mask  = filter.compute_mask(probe->view(), kDevice, stream, mr);
+    REQUIRE(mask != nullptr);
+    auto const host = mask_to_host(mask->view(), stream);
+    CHECK(host == std::vector<std::uint8_t>{1, 1});
+  }
+}
+
+TEST_CASE("membership filters refuse non-integer probe carriers", "[dynamic_filter][probe]")
+{
+  auto const stream = cudf::get_default_stream();
+  auto const mr     = cudf::get_current_device_resource_ref();
+  auto const n      = cudf::size_type{4};
+
+  auto keys = make_int64({1, 2, 3}, stream);
+  sirius_dynamic_in_list_filter in_list{keys->view(), stream, mr};
+  sirius_dynamic_small_in_list_filter small_list{keys->view(), stream, mr};
+  sirius_dynamic_bloom_filter bloom{keys->view(), stream, mr};
+
+  auto const decimal = cudf::make_fixed_point_column(
+    cudf::data_type{cudf::type_id::DECIMAL64, -2}, n, cudf::mask_state::UNALLOCATED, stream, mr);
+  auto const date = cudf::make_timestamp_column(
+    cudf::data_type{cudf::type_id::TIMESTAMP_DAYS}, n, cudf::mask_state::UNALLOCATED, stream, mr);
+  auto const fp = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::FLOAT64}, n, cudf::mask_state::UNALLOCATED, stream, mr);
+
+  for (auto const* probe : {&decimal, &date, &fp}) {
+    CHECK(in_list.compute_mask((*probe)->view(), kDevice, stream, mr) == nullptr);
+    CHECK(small_list.compute_mask((*probe)->view(), kDevice, stream, mr) == nullptr);
+    CHECK(bloom.compute_mask((*probe)->view(), kDevice, stream, mr) == nullptr);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Prior keep-mask (mask-aware probing)
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("prior keep-mask gates the membership probes", "[dynamic_filter][probe]")
+{
+  auto const stream = cudf::get_default_stream();
+  auto const mr     = cudf::get_current_device_resource_ref();
+
+  // > 32 rows so the packed-word indexing crosses word boundaries. Membership = even values;
+  // prior mask keeps rows divisible by 3.
+  constexpr std::size_t n = 70;
+  std::vector<std::int64_t> key_values;
+  std::vector<std::int32_t> probe_values(n);
+  std::vector<bool> keep(n);
+  std::vector<std::uint8_t> expected_unmasked(n);
+  std::vector<std::uint8_t> expected_masked(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    if (i % 2 == 0) { key_values.push_back(static_cast<std::int64_t>(i)); }
+    probe_values[i]      = static_cast<std::int32_t>(i);
+    keep[i]              = (i % 3 == 0);
+    expected_unmasked[i] = (i % 2 == 0) ? 1 : 0;
+    expected_masked[i]   = (i % 2 == 0 && i % 3 == 0) ? 1 : 0;
+  }
+  auto keys               = make_int64(key_values, stream);
+  auto probe              = make_int32(probe_values, stream);
+  auto prior              = upload_prior_mask(keep, stream);
+  auto const* prior_words = static_cast<std::uint32_t const*>(prior.data());
+
+  auto all_dead = upload_prior_mask(std::vector<bool>(n, false), stream);
+  auto all_live = upload_prior_mask(std::vector<bool>(n, true), stream);
+
+  SECTION("IN-list")
+  {
+    sirius_dynamic_in_list_filter filter{keys->view(), stream, mr};
+
+    auto masked = filter.compute_mask(probe->view(), prior_words, kDevice, stream, mr);
+    REQUIRE(masked != nullptr);
+    CHECK(mask_to_host(masked->view(), stream) == expected_masked);
+
+    auto dead = filter.compute_mask(
+      probe->view(), static_cast<std::uint32_t const*>(all_dead.data()), kDevice, stream, mr);
+    REQUIRE(dead != nullptr);
+    CHECK(mask_to_host(dead->view(), stream) == std::vector<std::uint8_t>(n, 0));
+
+    auto live = filter.compute_mask(
+      probe->view(), static_cast<std::uint32_t const*>(all_live.data()), kDevice, stream, mr);
+    REQUIRE(live != nullptr);
+    CHECK(mask_to_host(live->view(), stream) == expected_unmasked);
+
+    auto unmasked = filter.compute_mask(probe->view(), nullptr, kDevice, stream, mr);
+    REQUIRE(unmasked != nullptr);
+    CHECK(mask_to_host(unmasked->view(), stream) == expected_unmasked);
+  }
+
+  SECTION("small IN-list")
+  {
+    // Needles capped at k_max_keys: membership = {0, 6, 12} over the same probe.
+    auto small_keys = make_int64({0, 6, 12}, stream);
+    sirius_dynamic_small_in_list_filter filter{small_keys->view(), stream, mr};
+    std::vector<std::uint8_t> expected(n, 0);
+    for (auto const v : {0, 6, 12}) {
+      expected[static_cast<std::size_t>(v)] = keep[static_cast<std::size_t>(v)] ? 1 : 0;
+    }
+
+    auto masked = filter.compute_mask(probe->view(), prior_words, kDevice, stream, mr);
+    REQUIRE(masked != nullptr);
+    CHECK(mask_to_host(masked->view(), stream) == expected);
+
+    auto dead = filter.compute_mask(
+      probe->view(), static_cast<std::uint32_t const*>(all_dead.data()), kDevice, stream, mr);
+    REQUIRE(dead != nullptr);
+    CHECK(mask_to_host(dead->view(), stream) == std::vector<std::uint8_t>(n, 0));
+  }
+
+  SECTION("Bloom")
+  {
+    sirius_dynamic_bloom_filter filter{keys->view(), stream, mr};
+
+    auto masked = filter.compute_mask(probe->view(), prior_words, kDevice, stream, mr);
+    REQUIRE(masked != nullptr);
+    auto const host = mask_to_host(masked->view(), stream);
+    for (std::size_t i = 0; i < n; ++i) {
+      if (!keep[i]) {
+        CHECK(host[i] == 0);  // dead rows never pass, whatever the filter says
+      } else if (i % 2 == 0) {
+        CHECK(host[i] == 1);  // live in-set rows must pass (no false negatives)
+      }
+    }
+
+    auto dead = filter.compute_mask(
+      probe->view(), static_cast<std::uint32_t const*>(all_dead.data()), kDevice, stream, mr);
+    REQUIRE(dead != nullptr);
+    CHECK(mask_to_host(dead->view(), stream) == std::vector<std::uint8_t>(n, 0));
+  }
+}
+
+TEST_CASE("prior-masked probe still propagates the probe's null mask", "[dynamic_filter][probe]")
+{
+  auto const stream = cudf::get_default_stream();
+  auto const mr     = cudf::get_current_device_resource_ref();
+
+  auto keys = make_int64({1, 2, 3, 4}, stream);
+  sirius_dynamic_in_list_filter filter{keys->view(), stream, mr};
+
+  auto probe     = make_int32({1, 2, 9, 4}, stream);
+  auto null_mask = cudf::create_null_mask(4, cudf::mask_state::ALL_VALID, stream, mr);
+  cudf::set_null_mask(static_cast<cudf::bitmask_type*>(null_mask.data()), 1, 2, false, stream);
+  probe->set_null_mask(std::move(null_mask), 1);
+
+  auto prior = upload_prior_mask({true, true, true, false}, stream);
+  auto mask  = filter.compute_mask(
+    probe->view(), static_cast<std::uint32_t const*>(prior.data()), kDevice, stream, mr);
+  REQUIRE(mask != nullptr);
+  CHECK(mask->null_count() == 1);
+  auto const host = mask_to_host(mask->view(), stream);
+  CHECK(host[0] == 1);  // live, in set
+  CHECK(host[2] == 0);  // live, not in set
+  CHECK(host[3] == 0);  // dead row
+}

--- a/test/cpp/scan/test_fused_membership_mask.cpp
+++ b/test/cpp/scan/test_fused_membership_mask.cpp
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_fused_membership_mask.cpp
+ * @brief Mask-aware membership probing in the filtered-decode wave: with another mask source
+ *        present, the membership probes run AFTER the partial combine and receive it as a prior
+ *        mask; without one they stay concurrent and prior-free. The probe key stays at its narrow
+ *        decoded carrier (INT32) against an INT64-built set — the filtered decode must not require
+ *        a materialized cast.
+ */
+
+#include "api/simpatico_codegen.hpp"
+#include "codegen/selection/selection.hpp"
+#include "codegen/util/stream_pool.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <cuda_runtime.h>
+
+#include <catch.hpp>
+#include <op/dynamic_filter/sirius_dynamic_filter.hpp>
+
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+namespace {
+
+// Both knobs are function-local statistics latched on first use. Arm them at static-init time —
+// before any test can latch them — without overriding an explicit setting (overwrite=0). The
+// filtered path's contract is byte-identical output whatever these say, so suite-wide arming is
+// behavior-neutral for every other test.
+//
+// MAX_MEMBER defaults to 1, which makes the multi-probe cascade unreachable; raise it to 2 so the
+// fold-back (each probe's survivors become the next probe's prior) is actually covered.
+struct fused_gate_armer {
+  fused_gate_armer()
+  {
+    setenv("SIRIUS_EXP_FUSED_SCAN_FILTER", "1", /*overwrite=*/0);
+    setenv("SIRIUS_EXP_FUSED_SCAN_MAX_MEMBER", "2", /*overwrite=*/0);
+  }
+};
+[[maybe_unused]] fused_gate_armer const arm_fused_gate{};
+
+constexpr cudf::size_type kRows = 4096;
+
+// col 0 ("v", range-filtered): i % 100. col 1 ("k", membership key): i % 50.
+std::unique_ptr<cudf::table> make_source_table(rmm::cuda_stream_view stream)
+{
+  std::vector<std::int32_t> v(kRows);
+  std::vector<std::int32_t> k(kRows);
+  for (cudf::size_type i = 0; i < kRows; ++i) {
+    v[static_cast<std::size_t>(i)] = i % 100;
+    k[static_cast<std::size_t>(i)] = i % 50;
+  }
+  auto const mr = cudf::get_current_device_resource_ref();
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  for (auto const* host : {&v, &k}) {
+    auto col = cudf::make_numeric_column(
+      cudf::data_type{cudf::type_id::INT32}, kRows, cudf::mask_state::UNALLOCATED, stream, mr);
+    REQUIRE(cudaMemcpyAsync(col->mutable_view().data<std::int32_t>(),
+                            host->data(),
+                            host->size() * sizeof(std::int32_t),
+                            cudaMemcpyHostToDevice,
+                            stream.value()) == cudaSuccess);
+    cols.push_back(std::move(col));
+  }
+  stream.synchronize();
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
+constexpr char const* kBitpackPlans =
+  "input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed\n"
+  "---\n"
+  "input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed\n";
+
+// INT64-built exact membership set over the multiples of @p step in [0, 50) — the probe column
+// decodes as INT32, so the probe exercises the heterogeneous (cast-free) path.
+std::shared_ptr<sirius::op::sirius_dynamic_in_list_filter> make_key_set(
+  rmm::cuda_stream_view stream, std::int64_t step = 5)
+{
+  std::vector<std::int64_t> keys;
+  for (std::int64_t k = 0; k < 50; k += step) {
+    keys.push_back(k);
+  }
+  auto const mr = cudf::get_current_device_resource_ref();
+  auto col      = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT64},
+                                       static_cast<cudf::size_type>(keys.size()),
+                                       cudf::mask_state::UNALLOCATED,
+                                       stream,
+                                       mr);
+  REQUIRE(cudaMemcpyAsync(col->mutable_view().data<std::int64_t>(),
+                          keys.data(),
+                          keys.size() * sizeof(std::int64_t),
+                          cudaMemcpyHostToDevice,
+                          stream.value()) == cudaSuccess);
+  stream.synchronize();
+  return std::make_shared<sirius::op::sirius_dynamic_in_list_filter>(col->view(), stream, mr);
+}
+
+sirius::codegen::membership_filter_directive make_probe_directive(
+  std::size_t column,
+  std::shared_ptr<sirius::op::sirius_dynamic_in_list_filter> filter,
+  bool* saw_prior)
+{
+  return {column,
+          [filter = std::move(filter), saw_prior](cudf::column_view keys,
+                                                  std::uint32_t const* prior_mask_words,
+                                                  rmm::cuda_stream_view s,
+                                                  rmm::device_async_resource_ref mr) {
+            if (saw_prior != nullptr) { *saw_prior = prior_mask_words != nullptr; }
+            return filter->compute_mask(keys, prior_mask_words, /*device_id=*/0, s, mr);
+          }};
+}
+
+std::vector<std::int32_t> column_to_host(cudf::column_view const& col, rmm::cuda_stream_view stream)
+{
+  REQUIRE(col.type().id() == cudf::type_id::INT32);
+  std::vector<std::int32_t> host(static_cast<std::size_t>(col.size()));
+  if (!host.empty()) {
+    REQUIRE(cudaMemcpyAsync(host.data(),
+                            col.data<std::int32_t>(),
+                            host.size() * sizeof(std::int32_t),
+                            cudaMemcpyDeviceToHost,
+                            stream.value()) == cudaSuccess);
+  }
+  stream.synchronize();
+  return host;
+}
+
+/// True when the filtered attempt was declined because the env gate stayed off (an explicit
+/// SIRIUS_EXP_FUSED_SCAN_FILTER=0, or another TU latched the static before our armer ran).
+bool gate_stayed_off(sirius::codegen::scan_filter_result const& result)
+{
+  return !result.applied && result.status == sirius::codegen::scan_filter_status::refused;
+}
+
+}  // namespace
+
+TEST_CASE("filtered-decode membership probe consumes the static range mask as a prior",
+          "[fused_scan_filter][dynamic_filter]")
+{
+  auto const stream = cudf::get_default_stream();
+  auto const mr     = cudf::get_current_device_resource_ref();
+  auto table        = make_source_table(stream);
+  auto const ct     = simpatico::compress_with_plan(table->view(), kBitpackPlans, stream, mr);
+
+  simpatico::stream_pool pool;
+  REQUIRE(pool.init(4));
+
+  bool saw_prior = false;
+  sirius::codegen::scan_filter_request request;
+  request.filters.push_back({0, {0, 19}});  // v in [0, 19]: 20% static selectivity
+  request.membership_filters.push_back(make_probe_directive(1, make_key_set(stream), &saw_prior));
+  request.routes = {sirius::codegen::decode_route::bitpack_mask,
+                    sirius::codegen::decode_route::bitpack_mask};
+
+  std::vector<std::size_t> const selected{0, 1};
+  sirius::codegen::scan_filter_result result;
+  auto out = simpatico::decompress_scan_filter(ct, selected, request, result, pool, stream, mr);
+  if (gate_stayed_off(result)) {
+    WARN("filtered-decode env gate off in this process; skipping membership coverage");
+    return;
+  }
+
+  REQUIRE(result.applied);
+  CHECK(saw_prior);  // another mask source exists, so the probe must run mask-aware
+
+  // Reference: (i % 100) <= 19 AND (i % 50) % 5 == 0.
+  std::vector<std::int32_t> expect_v;
+  std::vector<std::int32_t> expect_k;
+  for (cudf::size_type i = 0; i < kRows; ++i) {
+    if (i % 100 <= 19 && (i % 50) % 5 == 0) {
+      expect_v.push_back(i % 100);
+      expect_k.push_back(i % 50);
+    }
+  }
+  REQUIRE(result.survivor_count == static_cast<std::int64_t>(expect_v.size()));
+  REQUIRE(out->num_columns() == 2);
+  CHECK(column_to_host(out->view().column(0), stream) == expect_v);
+  CHECK(column_to_host(out->view().column(1), stream) == expect_k);
+}
+
+TEST_CASE("filtered-decode membership probe stays prior-free without another source",
+          "[fused_scan_filter][dynamic_filter]")
+{
+  auto const stream = cudf::get_default_stream();
+  auto const mr     = cudf::get_current_device_resource_ref();
+  auto table        = make_source_table(stream);
+  auto const ct     = simpatico::compress_with_plan(table->view(), kBitpackPlans, stream, mr);
+
+  simpatico::stream_pool pool;
+  REQUIRE(pool.init(4));
+
+  bool saw_prior = true;
+  sirius::codegen::scan_filter_request request;
+  request.membership_filters.push_back(make_probe_directive(1, make_key_set(stream), &saw_prior));
+  request.routes = {sirius::codegen::decode_route::bitpack_mask,
+                    sirius::codegen::decode_route::bitpack_mask};
+
+  std::vector<std::size_t> const selected{0, 1};
+  sirius::codegen::scan_filter_result result;
+  auto out = simpatico::decompress_scan_filter(ct, selected, request, result, pool, stream, mr);
+  if (gate_stayed_off(result)) {
+    WARN("filtered-decode env gate off in this process; skipping membership coverage");
+    return;
+  }
+
+  REQUIRE(result.applied);
+  CHECK_FALSE(saw_prior);  // membership-only requests keep the concurrent, prior-free path
+
+  std::vector<std::int32_t> expect_k;
+  for (cudf::size_type i = 0; i < kRows; ++i) {
+    if ((i % 50) % 5 == 0) { expect_k.push_back(i % 50); }
+  }
+  REQUIRE(result.survivor_count == static_cast<std::int64_t>(expect_k.size()));
+  REQUIRE(out->num_columns() == 2);
+  CHECK(column_to_host(out->view().column(1), stream) == expect_k);
+}
+
+TEST_CASE("a membership cascade folds each probe's survivors into the next probe's prior",
+          "[fused_scan_filter][dynamic_filter]")
+{
+  auto const stream = cudf::get_default_stream();
+  auto const mr     = cudf::get_current_device_resource_ref();
+  auto table        = make_source_table(stream);
+  auto const ct     = simpatico::compress_with_plan(table->view(), kBitpackPlans, stream, mr);
+
+  simpatico::stream_pool pool;
+  REQUIRE(pool.init(4));
+
+  // Two membership sources on the same key column behind one static range. The second probe's
+  // prior must already carry the first probe's result, so the conjunction is {multiples of 10}.
+  bool saw_prior_a = false;
+  bool saw_prior_b = false;
+  sirius::codegen::scan_filter_request request;
+  request.filters.push_back({0, {0, 49}});  // v in [0, 49]: keeps i % 100 < 50
+  request.membership_filters.push_back(
+    make_probe_directive(1, make_key_set(stream, /*step=*/5), &saw_prior_a));
+  request.membership_filters.push_back(
+    make_probe_directive(1, make_key_set(stream, /*step=*/2), &saw_prior_b));
+  request.routes = {sirius::codegen::decode_route::bitpack_mask,
+                    sirius::codegen::decode_route::bitpack_mask};
+
+  std::vector<std::size_t> const selected{0, 1};
+  sirius::codegen::scan_filter_result result;
+  auto out = simpatico::decompress_scan_filter(ct, selected, request, result, pool, stream, mr);
+  if (gate_stayed_off(result)) {
+    WARN("filtered-decode env gate off in this process; skipping membership coverage");
+    return;
+  }
+
+  REQUIRE(result.applied);
+  CHECK(saw_prior_a);
+  CHECK(saw_prior_b);
+
+  // Reference: (i % 100) <= 49 AND (i % 50) % 5 == 0 AND (i % 50) % 2 == 0.
+  std::vector<std::int32_t> expect_k;
+  for (cudf::size_type i = 0; i < kRows; ++i) {
+    if (i % 100 <= 49 && (i % 50) % 5 == 0 && (i % 50) % 2 == 0) { expect_k.push_back(i % 50); }
+  }
+  REQUIRE(result.survivor_count == static_cast<std::int64_t>(expect_k.size()));
+  REQUIRE(out->num_columns() == 2);
+  CHECK(column_to_host(out->view().column(1), stream) == expect_k);
+}
+
+TEST_CASE("filtered-decode membership probe on an all-dead prior stays mask-aware",
+          "[fused_scan_filter][dynamic_filter]")
+{
+  auto const stream = cudf::get_default_stream();
+  auto const mr     = cudf::get_current_device_resource_ref();
+  auto table        = make_source_table(stream);
+  auto const ct     = simpatico::compress_with_plan(table->view(), kBitpackPlans, stream, mr);
+
+  simpatico::stream_pool pool;
+  REQUIRE(pool.init(4));
+
+  bool saw_prior = false;
+  sirius::codegen::scan_filter_request request;
+  request.filters.push_back({0, {1000, 2000}});  // v max is 99: the range kills every row
+  request.membership_filters.push_back(make_probe_directive(1, make_key_set(stream), &saw_prior));
+  request.routes = {sirius::codegen::decode_route::bitpack_mask,
+                    sirius::codegen::decode_route::bitpack_mask};
+
+  std::vector<std::size_t> const selected{0, 1};
+  sirius::codegen::scan_filter_result result;
+  auto out = simpatico::decompress_scan_filter(ct, selected, request, result, pool, stream, mr);
+  if (gate_stayed_off(result)) {
+    WARN("filtered-decode env gate off in this process; skipping membership coverage");
+    return;
+  }
+
+  // The probe must still run mask-aware (it precedes the survivor count), with every row dead in
+  // its prior.
+  CHECK(saw_prior);
+  REQUIRE(out->num_columns() == 2);
+  // Zero-survivor batches may be handled by either the compacted route (0-row columns) or the
+  // full-width fallback, depending on the launcher's empty-batch support; both are correct.
+  if (result.applied) {
+    CHECK(result.survivor_count == 0);
+    CHECK(out->view().column(0).size() == 0);
+  } else {
+    CHECK(out->view().column(0).size() == kRows);
+  }
+}


### PR DESCRIPTION
Rebase of #1557 onto `dev`. Supersedes it — that branch sits on the closed
fused-scan-filter (#1391) + late-mat (#1409) stack, which was reimplemented and
merged as #1474 and #1524. This is a fresh branch off `dev` carrying only the
two probe-side mechanisms, ported onto those merged shapes. **#1557 should be
closed if this lands.**

## What was wrong

Compressed materialization stores a bounded `BIGINT`/`INTEGER` key in the
narrowest fitting signed carrier (`INT8`/`INT16`/`INT32`), and
`apply_stored_dtype` passes a narrow carrier through unchanged — it only re-tags
at equal width:

```cpp
if (!cudf::is_fixed_width(col->type()) || !cudf::is_fixed_width(stored) ||
    cudf::size_of(col->type()) != cudf::size_of(stored)) {
  return col;   // narrow carrier passes straight through
}
```

So a decode-time membership probe legitimately receives an `INT32` column
against an `INT64`-built set, and `compute_mask` answered `nullptr` on the type
mismatch. Since join keys are bounded integer IDs — the best narrowing
candidates in the schema — **the decode-time membership pushdown shipped in
#1474 is inert on exactly the columns it targets.** Depending on scan shape it
either fails the whole filtered decode or silently contributes no filtering at
all.

## The two changes

**1. Carrier-native probes.** All three membership filters (IN-list, small
IN-list, Bloom) now accept any signed-integer probe carrier and widen/narrow per
element in-kernel (new shared header `src/include/cuda/dynamic_filter_probe.cuh`),
so no materialized cast of the probe column is needed. A value the key domain
cannot represent is a definite non-member.

The coverage is *exactly* complete, not merely wider: `supports()` admits only
`INT32`/`INT64` build keys, those narrow only to `INT8`/`INT16`/`INT32`, and the
dispatch handles `INT8`..`INT64`. The width-based decline becomes unreachable.
Sentinel semantics are preserved — narrowing probes keep the set-sentinel
conservative keep, widening probes become exact.

**2. Mask-aware probing.** `sirius_mask_applicable` gains a prior-keep-mask
`compute_mask` overload (packed 1 bit/row); dead rows skip the set/Bloom lookup.
The wave-1 orchestrator runs membership probes sequentially on `s0` after
combining the other mask sources, handing the combined words to each probe as
its prior and folding each result back in. Membership-only chunks keep the
concurrent, prior-free path. The prior is a pruning hint only: ignoring it is
sound because the caller ANDs with that same mask.

## On the original's measured numbers

#1557 claimed SF1000 Power **+7.2%**, q19 **−52%**. Those **do not transfer
wholesale**, because #1524 changed what a declining probe costs — it split
`nullptr` from a contract violation and stands a decline down to the AND
identity. Its own comment names the narrow carrier as the case it absorbs.

| scan shape | today, on `dev` | vs. what the numbers measured |
|---|---|---|
| membership-only (join filter is the only pushdown) | `declined_members == k_total` → throw → full-width fallback | identical |
| mixed (static range/dict equality alongside) | stands down to all-ones; decode compacts on static sources, join filter contributes nothing | smaller loss, and silent |

Which shape dominates decides how much transfers. **Not measured on this stack.**

## Known caveats

- **Item 2 trades concurrency for pruning.** A probe that previously ran
  round-robin on its own pool stream now serializes on `s0` behind the combine,
  and only the set/Bloom lookup is pruned — the full-width key decode is still
  paid. At high static keep-rate that may not pay for the lost overlap.
  Unmeasured. **Item 2 is a reasonable candidate to split out** if you'd rather
  land the defect fix alone.
- **The multi-probe cascade is unreachable in a default build.**
  `SIRIUS_EXP_FUSED_SCAN_MAX_MEMBER` defaults to `1`, so the fold-back never
  executes; the new test arms it to 2. Worth deciding whether that default
  should move.
- All of this sits behind `SIRIUS_EXP_FUSED_SCAN_FILTER`, which is off unless
  set. This makes the experimental path work when enabled; it does not change a
  default build.

## Deliberately not carried over

`dev`'s reimplementation dropped two prior sources the original also primed
from — pair (col-vs-col) filters, and the T9 visibility keep-mask (still open as
#1556). Priors here are ranges and dictionary-answered equalities only. A
declining probe in the sequential cascade leaves the mask untouched, matching
`dev`'s all-ones stand-down rather than the original's throw.

## Related, not fixed here

The build side has the mirror defect with a worse failure mode:
`dynamic_filter_publisher.cpp` compares the runtime build column against the
plan's recorded logical type and **skips the key entirely** on a mismatch
(`keys_skipped_type_mismatch`), so a narrowed build key publishes no filter at
all. Probe-side tolerance cannot help there. Already instrumented via
`dynamic_filter_stats` — worth checking whether that counter fires before
deciding to fix it.

## Tests

- `test/cpp/operator/test_dynamic_filter_probe.cpp` (`[dynamic_filter][probe]`,
  8 cases): heterogeneous carriers, decimal/date/float refusal, sentinel
  conservation, prior-mask all-dead/all-live/patterned, null propagation.
- `test/cpp/scan/test_fused_membership_mask.cpp` (`[fused_scan_filter]`,
  4 cases): prior handed alongside a static range, prior-free membership-only,
  a two-probe cascade proving the fold-back, all-dead prior, INT32 carrier vs
  INT64 set.

Results on this branch: `[probe]` 8/8, `[fused_scan_filter]` 4/4,
`[dynamic_filter]` 239/239. Full suite run twice: **2959/2959 clean** on the
second; the first reported 1 failure whose identity was lost to a truncated
capture and which did not reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)