### PR TITLE
fix(pin_table): add compression parameter

### DIFF
--- a/docs/super-sirius/compressed-materialization.md
+++ b/docs/super-sirius/compressed-materialization.md
@@ -405,7 +405,7 @@ input with neither a conversion nor a sidecar uses the larger of its stored and 
 
 ## Simpatico interplay
 
-Pin-table compression (Simpatico, `pin_table_compression`) and compressed materialization stack:
+Pin-table compression (Simpatico, `CALL pin_table(..., compression => true)`) and compressed materialization stack:
 a pinned chunk is narrowed first, then compressed, and at serve time decompression reproduces the
 narrow carrier directly from the blob. The two features shrink different things — compression
 shrinks resident bytes and the host-to-GPU transfer (the converter uploads compressed leaves and

--- a/docs/super-sirius/compressed-pinning.md
+++ b/docs/super-sirius/compressed-pinning.md
@@ -35,8 +35,8 @@ when `CALL pin_table(..., compression => true)` requests it, the plan-directory 
 non-empty, and a matching table plan exists. `pin_table` warns and pins uncompressed when
 compression is requested but the plan directory is empty; a missing table plan likewise warns and
 falls back. The batch-size and compressed-fraction settings are inert until a matching plan
-activates compression. The legacy `pin_table_compression` setting remains a default for calls that
-omit the `compression` argument; an explicit argument always wins.
+activates compression. The existing `pin_table_compression` setting remains the default for calls
+that omit the `compression` argument; an explicit argument always wins.
 
 ## Which tier to compress on (GB300, TPC-H SF1000, 22-query hot suite)
 

--- a/docs/super-sirius/compressed-pinning.md
+++ b/docs/super-sirius/compressed-pinning.md
@@ -3,9 +3,12 @@
 `pin_table` can store pinned chunks Simpatico-compressed on either tier:
 
 ```sql
-SET pin_table_compression = true;
 SET pin_table_input_compression_plan_dir = '/path/to/plans';  -- <table>.txt per table
-CALL pin_table('/data/lineitem/*.parquet', tier => 'gpu', name => 'lineitem', cols => [...]);
+CALL pin_table('/data/lineitem/*.parquet',
+               tier => 'gpu',
+               name => 'lineitem',
+               cols => [...],
+               compression => true);
 ```
 
 Tables with no plan file pin uncompressed. Each plan file carries one `---`-separated DSL
@@ -27,11 +30,13 @@ directly. Interfaces: `src/compression/compressed_representation.hpp`
 (`decode_equality_pushdown`), `src/compression/compression_converters.cpp` (predicate
 translation), threaded through `sirius_scan_manager::prepare_for_query`.
 
-The compression settings can be staged in either order before a table is pinned. They become
-active only when `pin_table_compression` is true, the plan-directory setting is non-empty, and a
-matching table plan exists. `pin_table` warns and pins uncompressed when the enable flag is true
-but the plan directory is empty; a missing table plan likewise warns and falls back. The batch-size
-and compressed-fraction settings are inert until a matching plan activates compression.
+The compression settings can be staged before a table is pinned. Compression becomes active only
+when `CALL pin_table(..., compression => true)` requests it, the plan-directory setting is
+non-empty, and a matching table plan exists. `pin_table` warns and pins uncompressed when
+compression is requested but the plan directory is empty; a missing table plan likewise warns and
+falls back. The batch-size and compressed-fraction settings are inert until a matching plan
+activates compression. The legacy `pin_table_compression` setting remains a default for calls that
+omit the `compression` argument; an explicit argument always wins.
 
 ## Which tier to compress on (GB300, TPC-H SF1000, 22-query hot suite)
 

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -162,12 +162,13 @@ Controls the disk spill tier. Data evicted from host memory is written here. Dis
 These settings control optional Simpatico compression when
 `pin_table` caches input tables. Prefer the per-call
 `CALL pin_table(..., compression => true)` argument to request compression for a specific pin.
-Compression also requires a matching plan in `input_plan_dir`; otherwise the table is pinned
-uncompressed.
+The settings below supply the default for calls that omit the argument and configure plan lookup
+and retention gates. Compression also requires a matching plan in `input_plan_dir`; otherwise the
+table is pinned uncompressed.
 
 | Key | DuckDB setting | Type | Default | Description |
 |-----|----------------|------|---------|-------------|
-| `enable_pin_table_compression` | `pin_table_compression` | bool | false | Legacy default for `pin_table` calls that omit the `compression` argument. |
+| `enable_pin_table_compression` | `pin_table_compression` | bool | false | Default for `pin_table` calls that omit the `compression` argument. |
 | `min_batch_size_bytes` | `pin_table_compression_min_batch_size_bytes` | bytes | 1Mi | Skip compression below this uncompressed batch size. `0` disables the size gate. |
 | `max_compressed_fraction` | `pin_table_compression_max_compressed_fraction` | finite double >= 0 | 0.75 | Keep a compressed representation only at or below this fraction of the original batch size. `0` retains none; values above `1` deliberately permit expansion, primarily for testing encodability. |
 | `input_plan_dir` | `pin_table_input_compression_plan_dir` | string | "" | Directory of per-table Simpatico plan files. An empty path leaves compression inactive. |
@@ -676,10 +677,13 @@ test options; it is not part of the normal user surface.
 
 ### Pinned-Table Compression (Simpatico)
 
+Prefer the per-call `pin_table(..., compression => true/false)` argument for a specific pin. The
+variables below supply the default for calls that omit the argument and configure plan lookup and
+retention gates.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `pin_table(..., compression => true/false)` | omitted | Per-call Simpatico compression request. When omitted, `pin_table_compression` supplies the default. |
-| `pin_table_compression` | false | Legacy default for `pin_table` calls that omit the `compression` argument. |
+| `pin_table_compression` | false | Default for `pin_table` calls that omit the `compression` argument. |
 | `pin_table_input_compression_plan_dir` | (empty) | Directory of per-table Simpatico plan files (`<table_name>.<ext>`, multi-column plan DSL). Tables with no matching file are pinned uncompressed. No effect on spill compression. |
 | `pin_table_compression_min_batch_size_bytes` | 1 MiB | Minimum uncompressed batch size below which pin-table compression is skipped. |
 | `pin_table_compression_max_compressed_fraction` | 0.75 | Discard the compressed form and pin uncompressed when the compressed size exceeds this fraction of the original (compression saved too little). |

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -160,13 +160,14 @@ Controls the disk spill tier. Data evicted from host memory is written here. Dis
 ### Input-table compression (`sirius.compression`)
 
 These settings control optional Simpatico compression when
-`pin_table(tier=>'host')` caches input tables. Compression requires both
-`enable_pin_table_compression: true` and a matching plan in `input_plan_dir`;
-otherwise the table is pinned uncompressed.
+`pin_table` caches input tables. Prefer the per-call
+`CALL pin_table(..., compression => true)` argument to request compression for a specific pin.
+Compression also requires a matching plan in `input_plan_dir`; otherwise the table is pinned
+uncompressed.
 
 | Key | DuckDB setting | Type | Default | Description |
 |-----|----------------|------|---------|-------------|
-| `enable_pin_table_compression` | `pin_table_compression` | bool | false | Attempt planned compression while pinning input tables to host memory. |
+| `enable_pin_table_compression` | `pin_table_compression` | bool | false | Legacy default for `pin_table` calls that omit the `compression` argument. |
 | `min_batch_size_bytes` | `pin_table_compression_min_batch_size_bytes` | bytes | 1Mi | Skip compression below this uncompressed batch size. `0` disables the size gate. |
 | `max_compressed_fraction` | `pin_table_compression_max_compressed_fraction` | finite double >= 0 | 0.75 | Keep a compressed representation only at or below this fraction of the original batch size. `0` retains none; values above `1` deliberately permit expansion, primarily for testing encodability. |
 | `input_plan_dir` | `pin_table_input_compression_plan_dir` | string | "" | Directory of per-table Simpatico plan files. An empty path leaves compression inactive. |
@@ -677,7 +678,8 @@ test options; it is not part of the normal user surface.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `pin_table_compression` | false | Enable Simpatico compression for `pin_table(tier=>'host')` chunks. |
+| `pin_table(..., compression => true/false)` | omitted | Per-call Simpatico compression request. When omitted, `pin_table_compression` supplies the default. |
+| `pin_table_compression` | false | Legacy default for `pin_table` calls that omit the `compression` argument. |
 | `pin_table_input_compression_plan_dir` | (empty) | Directory of per-table Simpatico plan files (`<table_name>.<ext>`, multi-column plan DSL). Tables with no matching file are pinned uncompressed. No effect on spill compression. |
 | `pin_table_compression_min_batch_size_bytes` | 1 MiB | Minimum uncompressed batch size below which pin-table compression is skipped. |
 | `pin_table_compression_max_compressed_fraction` | 0.75 | Discard the compressed form and pin uncompressed when the compressed size exceeds this fraction of the original (compression saved too little). |

--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -219,7 +219,7 @@ Pinning drives the source's `gpu_ingestible` to completion (`materialize_all_bat
   whenever either zone-map capture or narrowing needs it; it is cleared only when both features are
   disabled. See [Pin-time narrowing](compressed-materialization.md#pin-time-narrowing) for the full
   narrowing pass and its pin-cache invariants.
-- **Simpatico compression:** with `pin_table_compression`, pinned chunks can additionally be stored compressed on either tier instead of (or after) narrowing — see [Compressed Pinning](compressed-pinning.md) for tier choice, plan selection, and measured results.
+- **Simpatico compression:** with `CALL pin_table(..., compression => true)`, pinned chunks can additionally be stored compressed on either tier instead of (or after) narrowing — see [Compressed Pinning](compressed-pinning.md) for tier choice, plan selection, and measured results.
 - **GPU tier** (`materialize_all_batches`): each resulting batch is stored as a GPU-resident `cudf::table`, round-robining placement across the GPU memory spaces. Placement is deterministic so re-pinning the same source yields identical per-chunk placement (required by the merge path below).
 - **HOST tier** (`materialize_pin_to_host`): each resulting batch is converted on its round-robin GPU to a `host_data_representation` that preserves carrier type and decimal scale on that GPU's NUMA-local host space, then the GPU table is freed before the next batch. Peak GPU residency is therefore ~one batch, so a host pin never needs the whole table to fit in GPU memory.
 

--- a/src/include/pin_table.hpp
+++ b/src/include/pin_table.hpp
@@ -39,6 +39,9 @@ struct PinTableArgs {
   std::string tier;
   std::string name;
   std::optional<std::vector<std::string>> cols;
+  /// Optional per-call request for Simpatico pin compression. When omitted,
+  /// the legacy session/config setting remains the default.
+  std::optional<bool> compression;
   /// Resolved at bind time: "parquet" or "duckdb". Chosen from an explicit
   /// `format` named parameter, else inferred from the path extension
   /// (.parquet -> parquet, .db/.duckdb -> duckdb).

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1176,6 +1176,11 @@ unique_ptr<FunctionData> SiriusExtension::PinTableBind(ClientContext& context,
     result->args.cols = std::move(cols);
   }
 
+  auto compression_it = input.named_parameters.find("compression");
+  if (compression_it != input.named_parameters.end() && !compression_it->second.IsNull()) {
+    result->args.compression = BooleanValue::Get(compression_it->second);
+  }
+
   // Resolve the source format: an explicit 'format' parameter, else inferred from
   // the path extension (.parquet -> parquet, .db/.duckdb -> duckdb).
   auto to_lower = [](std::string s) {
@@ -1364,15 +1369,17 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
   // directory (if configured), then resolve it into a compression_pin_config. Both
   // the host and GPU pin paths compress with this when enabled.
   const auto& comp_cfg = sirius_ctx->get_config().get_compression_config();
-  if (comp_cfg.enable_pin_table_compression && comp_cfg.input_plan_dir.empty()) {
+  bool const compression_requested =
+    data.args.compression.value_or(comp_cfg.enable_pin_table_compression);
+  if (compression_requested && comp_cfg.input_plan_dir.empty()) {
     SIRIUS_LOG_WARN(
-      "[pin_table] '{}': pin_table_compression is enabled but "
+      "[pin_table] '{}': compression was requested but "
       "pin_table_input_compression_plan_dir is empty; pinning uncompressed",
       data.args.name);
   }
-  const bool comp_globally_enabled =
-    comp_cfg.enable_pin_table_compression && !comp_cfg.input_plan_dir.empty();
-  if (comp_globally_enabled) {
+  const bool compression_plan_lookup_enabled =
+    compression_requested && !comp_cfg.input_plan_dir.empty();
+  if (compression_plan_lookup_enabled) {
     namespace fs     = std::filesystem;
     const auto& name = data.args.name;
     if (!sirius::compression::plan_register::global().resolve_table_plan(name).has_value()) {
@@ -1397,7 +1404,7 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
   }
 
   sirius::compression_pin_config pin_comp{};
-  if (comp_globally_enabled) {
+  if (compression_plan_lookup_enabled) {
     if (auto plan_dsl =
           sirius::compression::plan_register::global().resolve_table_plan(data.args.name);
         plan_dsl.has_value()) {
@@ -1428,7 +1435,7 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
       }
     } else {
       SIRIUS_LOG_WARN(
-        "[pin_table] '{}': pin_table_compression is enabled but no plan file was found in '{}'; "
+        "[pin_table] '{}': compression was requested but no plan file was found in '{}'; "
         "pinning uncompressed",
         data.args.name,
         comp_cfg.input_plan_dir);
@@ -2439,6 +2446,7 @@ void SiriusExtension::RegisterGPUFunctions(DatabaseInstance& instance)
     pin_table.named_parameters["tier"]        = LogicalType::VARCHAR;
     pin_table.named_parameters["name"]        = LogicalType::VARCHAR;
     pin_table.named_parameters["cols"]        = LogicalType::LIST(LogicalType::VARCHAR);
+    pin_table.named_parameters["compression"] = LogicalType::BOOLEAN;
     pin_table.named_parameters["format"]      = LogicalType::VARCHAR;
     pin_table.named_parameters["schema_name"] = LogicalType::VARCHAR;
     pin_table_set.AddFunction(std::move(pin_table));
@@ -3300,9 +3308,9 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     SetEnableGpuExecution);
 
   config.AddExtensionOption("pin_table_compression",
-                            "Request Simpatico compression for pin_table chunks. Takes effect only "
-                            "when pin_table_input_compression_plan_dir is non-empty and contains a "
-                            "matching table plan",
+                            "Legacy default for pin_table calls that omit the compression named "
+                            "parameter. Takes effect only when pin_table_input_compression_plan_dir "
+                            "is non-empty and contains a matching table plan",
                             LogicalType::BOOLEAN,
                             Value::BOOLEAN(compression_defaults.enable_pin_table_compression),
                             SetEnablePinTableCompression);
@@ -3311,8 +3319,8 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     "pin_table_input_compression_plan_dir",
     "Directory containing per-table Simpatico plan files for pin_table compression. "
     "Files are named '<table_name>.<ext>'; their contents are the multi-column plan DSL. "
-    "May be set before pin_table_compression is enabled. Tables with no matching file are pinned "
-    "uncompressed. No effect on spill compression.",
+    "May be set before a compression-enabled pin_table call. Tables with no matching file are "
+    "pinned uncompressed. No effect on spill compression.",
     LogicalType::VARCHAR,
     Value(compression_defaults.input_plan_dir),
     SetPinTableInputCompressionPlanDir);

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1178,7 +1178,7 @@ unique_ptr<FunctionData> SiriusExtension::PinTableBind(ClientContext& context,
 
   auto compression_it = input.named_parameters.find("compression");
   if (compression_it != input.named_parameters.end() && !compression_it->second.IsNull()) {
-    result->args.compression = BooleanValue::Get(compression_it->second);
+    result->args.compression = compression_it->second.GetValue<bool>();
   }
 
   // Resolve the source format: an explicit 'format' parameter, else inferred from
@@ -1377,9 +1377,8 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
       "pin_table_input_compression_plan_dir is empty; pinning uncompressed",
       data.args.name);
   }
-  const bool compression_plan_lookup_enabled =
-    compression_requested && !comp_cfg.input_plan_dir.empty();
-  if (compression_plan_lookup_enabled) {
+  const bool compression_active = compression_requested && !comp_cfg.input_plan_dir.empty();
+  if (compression_active) {
     namespace fs     = std::filesystem;
     const auto& name = data.args.name;
     if (!sirius::compression::plan_register::global().resolve_table_plan(name).has_value()) {
@@ -1404,7 +1403,7 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
   }
 
   sirius::compression_pin_config pin_comp{};
-  if (compression_plan_lookup_enabled) {
+  if (compression_active) {
     if (auto plan_dsl =
           sirius::compression::plan_register::global().resolve_table_plan(data.args.name);
         plan_dsl.has_value()) {
@@ -3308,7 +3307,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     SetEnableGpuExecution);
 
   config.AddExtensionOption("pin_table_compression",
-                            "Legacy default for pin_table calls that omit the compression named "
+                            "Default for pin_table calls that omit the compression named "
                             "parameter. Takes effect only when pin_table_input_compression_plan_dir "
                             "is non-empty and contains a matching table plan",
                             LogicalType::BOOLEAN,

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -3306,13 +3306,14 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config, const sirius::sirius_c
     Value::BOOLEAN(true),
     SetEnableGpuExecution);
 
-  config.AddExtensionOption("pin_table_compression",
-                            "Default for pin_table calls that omit the compression named "
-                            "parameter. Takes effect only when pin_table_input_compression_plan_dir "
-                            "is non-empty and contains a matching table plan",
-                            LogicalType::BOOLEAN,
-                            Value::BOOLEAN(compression_defaults.enable_pin_table_compression),
-                            SetEnablePinTableCompression);
+  config.AddExtensionOption(
+    "pin_table_compression",
+    "Default for pin_table calls that omit the compression named "
+    "parameter. Takes effect only when pin_table_input_compression_plan_dir "
+    "is non-empty and contains a matching table plan",
+    LogicalType::BOOLEAN,
+    Value::BOOLEAN(compression_defaults.enable_pin_table_compression),
+    SetEnablePinTableCompression);
 
   config.AddExtensionOption(
     "pin_table_input_compression_plan_dir",

--- a/test/cpp/compression/test_compression.cpp
+++ b/test/cpp/compression/test_compression.cpp
@@ -360,23 +360,51 @@ TEST_CASE("pin_table compression - compression parameter overrides session setti
   run_ok(con, "SET pin_table_compression_min_batch_size_bytes = 0;", "min batch");
   run_ok(con, "SET pin_table_compression_max_compressed_fraction = 1.5;", "fraction");
 
-  run_ok(con, "SET pin_table_compression = false;", "legacy compression off");
-  auto pin_on =
-    con.Query("CALL pin_table('" + glob + "', tier='host', name='t_param_on', compression=true);");
+  run_ok(con, "SET pin_table_compression = false;", "existing compression default off");
+  auto pin_on = con.Query("CALL pin_table('" + glob +
+                          "', tier => 'host', name => 't_param_on', compression => true);");
   require_ok(pin_on, "pin parameter on");
   auto const on = sirius::test::census_entry(con, "t_param_on");
   REQUIRE(on.chunks > 0);
   REQUIRE(on.compressed_chunks == on.chunks);
   run_ok(con, "CALL unpin_table('t_param_on');", "unpin parameter on");
 
-  run_ok(con, "SET pin_table_compression = true;", "legacy compression on");
-  auto pin_off =
-    con.Query("CALL pin_table('" + glob + "', tier='host', name='t_param_off', compression=false);");
+  run_ok(con, "SET pin_table_compression = true;", "existing compression default on");
+  auto pin_off = con.Query("CALL pin_table('" + glob +
+                           "', tier => 'host', name => 't_param_off', compression => false);");
   require_ok(pin_off, "pin parameter off");
   auto const off = sirius::test::census_entry(con, "t_param_off");
   REQUIRE(off.chunks > 0);
   REQUIRE(off.compressed_chunks == 0);
   run_ok(con, "CALL unpin_table('t_param_off');", "unpin parameter off");
+
+  fs::remove_all(tmp);
+}
+
+TEST_CASE("pin_table compression - empty plan dir pins uncompressed",
+          "[compression][pin_table][isolated_context]")
+{
+  if (no_gpu()) { return; }
+
+  auto [tmp, yaml_path] = make_comp_env("emptydir");
+  sirius::test::mgpu::generate_parquet_surface(
+    tmp, "SELECT (range % 1024)::BIGINT AS k FROM range(20000)", /*num_files=*/1);
+
+  sirius::test::mgpu::scoped_mgpu_env env(yaml_path);
+  auto con  = env.make_connection();
+  auto glob = sirius::test::mgpu::parquet_glob(tmp);
+
+  run_ok(con, "SET pin_table_compression_min_batch_size_bytes = 0;", "min batch");
+  run_ok(con, "SET pin_table_compression_max_compressed_fraction = 1.5;", "fraction");
+
+  auto pin = con.Query("CALL pin_table('" + glob +
+                       "', tier => 'host', name => 't_emptydir', compression => true);");
+  require_ok(pin, "pin with empty plan dir");
+  auto const census = sirius::test::census_entry(con, "t_emptydir");
+  REQUIRE(census.chunks > 0);
+  REQUIRE(census.compressed_chunks == 0);
+
+  run_ok(con, "CALL unpin_table('t_emptydir');", "unpin empty plan dir");
 
   fs::remove_all(tmp);
 }

--- a/test/cpp/compression/test_compression.cpp
+++ b/test/cpp/compression/test_compression.cpp
@@ -338,6 +338,49 @@ TEST_CASE("pin_table compression - result equality vs uncompressed pin",
   fs::remove_all(tmp);
 }
 
+TEST_CASE("pin_table compression - compression parameter overrides session setting",
+          "[compression][pin_table][isolated_context]")
+{
+  if (no_gpu()) { return; }
+
+  auto [tmp, yaml_path] = make_comp_env("param");
+  sirius::test::mgpu::generate_parquet_surface(
+    tmp, "SELECT (range % 1024)::BIGINT AS k FROM range(20000)", /*num_files=*/1);
+
+  sirius::test::mgpu::scoped_mgpu_env env(yaml_path);
+  auto con  = env.make_connection();
+  auto glob = sirius::test::mgpu::parquet_glob(tmp);
+
+  auto plan_dir = tmp / "plans";
+  write_plan_file(plan_dir, "t_param_on", bitpack_plan(1));
+  write_plan_file(plan_dir, "t_param_off", bitpack_plan(1));
+
+  run_ok(
+    con, "SET pin_table_input_compression_plan_dir = '" + plan_dir.string() + "';", "plan dir");
+  run_ok(con, "SET pin_table_compression_min_batch_size_bytes = 0;", "min batch");
+  run_ok(con, "SET pin_table_compression_max_compressed_fraction = 1.5;", "fraction");
+
+  run_ok(con, "SET pin_table_compression = false;", "legacy compression off");
+  auto pin_on =
+    con.Query("CALL pin_table('" + glob + "', tier='host', name='t_param_on', compression=true);");
+  require_ok(pin_on, "pin parameter on");
+  auto const on = sirius::test::census_entry(con, "t_param_on");
+  REQUIRE(on.chunks > 0);
+  REQUIRE(on.compressed_chunks == on.chunks);
+  run_ok(con, "CALL unpin_table('t_param_on');", "unpin parameter on");
+
+  run_ok(con, "SET pin_table_compression = true;", "legacy compression on");
+  auto pin_off =
+    con.Query("CALL pin_table('" + glob + "', tier='host', name='t_param_off', compression=false);");
+  require_ok(pin_off, "pin parameter off");
+  auto const off = sirius::test::census_entry(con, "t_param_off");
+  REQUIRE(off.chunks > 0);
+  REQUIRE(off.compressed_chunks == 0);
+  run_ok(con, "CALL unpin_table('t_param_off');", "unpin parameter off");
+
+  fs::remove_all(tmp);
+}
+
 TEST_CASE("pin_table compression - device tier result equality vs uncompressed pin",
           "[compression][pin_table][isolated_context]")
 {


### PR DESCRIPTION
## Summary
- add a per-call `compression` named parameter to `CALL pin_table(...)`
- make explicit `compression=true/false` override the existing `pin_table_compression` setting
- keep `pin_table_compression` as the compatibility default when the argument is omitted
- update Super Sirius docs and add regression coverage for both override directions and the empty-plan-dir fallback

## Configuration/API surface
`CALL pin_table(..., compression => true/false)` is now the preferred way to request or suppress Simpatico compression for a specific pin. Existing `pin_table_compression` YAML/SET behavior remains as the default for calls that omit the new argument.

Backward compatibility is covered by the existing compression tests as well: many existing cases set `pin_table_compression = true` and then call `pin_table` without a `compression` argument. The full `[compression][pin_table]` suite passing below exercises that omitted-argument fallback alongside the new explicit-argument override test.

Closes #1358

## Validation
- `git diff --check`
- Remote GPU validation at `efda095a`, GPU `NVIDIA GeForce RTX 5060 Ti`, driver `595.84`:
  - `CUDAARCHS=120 CMAKE_BUILD_PARALLEL_LEVEL=2 pixi run make` — passed. The initial high-parallel build failed silently during CUDA compilation, and the testcontainers Go bridge needed an existing local Go module cache because external Go module downloads timed out on the node; after lowering parallelism and reusing the cache, the release build and `sirius_unittest` linked successfully.
  - `pixi run build/release/extension/sirius/test/cpp/sirius_unittest "[compression][pin_table]"` — passed, 1224 assertions / 29 test cases. This includes `pin_table compression - compression parameter overrides session setting` and `pin_table compression - empty plan dir pins uncompressed`.
  - `pixi run build/release/extension/sirius/test/cpp/sirius_unittest "[config]"` — passed, 688 assertions / 66 test cases.
- Additional remote GPU checks at `03d26110`, GPU `NVIDIA RTX PRO 4500 Blackwell`, driver `580.159.04`:
  - `CUDAARCHS=120 CMAKE_BUILD_PARALLEL_LEVEL=48 pixi run make` — passed.
  - `pixi run build/release/extension/sirius/test/cpp/sirius_unittest "[compression][plan_register]"` — passed, 16 assertions / 6 test cases.
  - `pixi run build/release/extension/sirius/test/cpp/sirius_unittest "Sirius configuration rejects invalid compression retention fractions"` — passed, 3 assertions / 1 test case.
  - `pixi run build/release/extension/sirius/test/cpp/sirius_unittest "Sirius configuration accepts intentional compression retention fraction boundaries"` — passed, 4 assertions / 1 test case.
  - SQL smoke with a single-GPU `scan_manager.use_sirius_datasource=false` config: created a parquet input and matching Simpatico plan files, then verified `compression=true` overrides `pin_table_compression=false` and `compression=false` overrides `pin_table_compression=true`. The command succeeded and Sirius logs showed compression only for `t_param_on`, not for `t_param_off`.
  - Pod limitation: full C++ `[compression][pin_table]` and broad `[config]` aborted there when test-generated/default YAMLs initialized Sirius' local `io_uring` datasource: `uring_reactor: ring init: Operation not permitted`. The pod reported `kernel.io_uring_disabled = 0`, so this appeared to be a container syscall/capability restriction. The successful remote GPU validation at `efda095a` above covers those previously blocked suites.
- Not run locally: `pixi run ...` build/tests/pre-commit, because this local machine is macOS ARM while the repo declares Linux CUDA pixi platforms.