### PR TITLE
fix(test): avoid environment mutation after fork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -889,6 +889,7 @@ set(TEST_SOURCES
     test/cpp/unittest.cpp
     test/cpp/utils/pipeline_conversion_test_utils.cpp
     test/cpp/utils/sirius_test_env.cpp
+    test/cpp/utils/test_child_process_environment.cpp
     test/cpp/utils/test_gpu_execution_comparator.cpp
     test/cpp/utils/utils.cpp)
 # cmake-format: on

--- a/test/cpp/integration/test_gpu_execution_multi_format.cpp
+++ b/test/cpp/integration/test_gpu_execution_multi_format.cpp
@@ -28,8 +28,10 @@
 #include <catch.hpp>
 #include <duckdb.hpp>
 #include <signal.h>
+#include <spawn.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <utils/child_process_environment.hpp>
 #include <utils/parquet_fixture_utils.hpp>
 #include <utils/sirius_test_env.hpp>
 #include <utils/transparent_execution_test_utils.hpp>
@@ -620,19 +622,26 @@ class HivePartitionDataset {
     static std::atomic<std::uint64_t> next_child_id{0};
     auto const output_path =
       hive_dir / ("watchdog_result_" + std::to_string(next_child_id.fetch_add(1)) + ".txt");
-    auto const pid = ::fork();
-    REQUIRE(pid >= 0);
-    if (pid == 0) {
-      ::setenv("SIRIUS_HIVE_WATCHDOG_QUERY", query.c_str(), 1);
-      ::setenv("SIRIUS_HIVE_WATCHDOG_OUTPUT", output_path.string().c_str(), 1);
-      ::setenv("SIRIUS_HIVE_WATCHDOG_CONFIG", config_path.string().c_str(), 1);
-      ::setenv("SIRIUS_CONFIG_FILE", config_path.string().c_str(), 1);
-      ::execl("/proc/self/exe",
-              "sirius_unittest",
-              "gpu_execution hive partition watchdog child runner",
-              static_cast<char*>(nullptr));
-      ::_exit(127);
+    std::vector<std::string> child_arguments{"sirius_unittest",
+                                             "gpu_execution hive partition watchdog child runner"};
+    std::vector<char*> child_argv;
+    child_argv.reserve(child_arguments.size() + 1);
+    for (auto& argument : child_arguments) {
+      child_argv.push_back(argument.data());
     }
+    child_argv.push_back(nullptr);
+
+    sirius::test::child_process_environment child_environment{
+      {{"SIRIUS_HIVE_WATCHDOG_QUERY", query},
+       {"SIRIUS_HIVE_WATCHDOG_OUTPUT", output_path.string()},
+       {"SIRIUS_HIVE_WATCHDOG_CONFIG", config_path.string()},
+       {"SIRIUS_CONFIG_FILE", config_path.string()}},
+      {"SIRIUS_DISABLE"}};
+
+    pid_t pid{};
+    auto const spawn_result = ::posix_spawn(
+      &pid, "/proc/self/exe", nullptr, nullptr, child_argv.data(), child_environment.data());
+    REQUIRE(spawn_result == 0);
 
     int status      = 0;
     auto const stop = std::chrono::steady_clock::now() + timeout;
@@ -732,12 +741,9 @@ TEST_CASE("gpu_execution hive partition watchdog child runner",
     auto const* config_raw = std::getenv("SIRIUS_HIVE_WATCHDOG_CONFIG");
     if (config_raw == nullptr) { out.error = "watchdog child missing config path"; }
 
-    std::unique_ptr<sirius_config_env_guard> config_guard;
     std::unique_ptr<duckdb::DuckDB> db;
     std::unique_ptr<duckdb::Connection> con;
     if (out.error.empty()) {
-      config_guard = std::make_unique<sirius_config_env_guard>(config_raw);
-      unsetenv("SIRIUS_DISABLE");
       db  = std::make_unique<duckdb::DuckDB>(nullptr);
       con = std::make_unique<duckdb::Connection>(*db);
     }

--- a/test/cpp/integration/test_gpu_execution_multi_format.cpp
+++ b/test/cpp/integration/test_gpu_execution_multi_format.cpp
@@ -741,9 +741,12 @@ TEST_CASE("gpu_execution hive partition watchdog child runner",
     auto const* config_raw = std::getenv("SIRIUS_HIVE_WATCHDOG_CONFIG");
     if (config_raw == nullptr) { out.error = "watchdog child missing config path"; }
 
+    std::unique_ptr<sirius_config_env_guard> config_guard;
     std::unique_ptr<duckdb::DuckDB> db;
     std::unique_ptr<duckdb::Connection> con;
     if (out.error.empty()) {
+      config_guard = std::make_unique<sirius_config_env_guard>(config_raw);
+      unsetenv("SIRIUS_DISABLE");
       db  = std::make_unique<duckdb::DuckDB>(nullptr);
       con = std::make_unique<duckdb::Connection>(*db);
     }

--- a/test/cpp/integration/test_gpu_execution_multi_format.cpp
+++ b/test/cpp/integration/test_gpu_execution_multi_format.cpp
@@ -635,8 +635,7 @@ class HivePartitionDataset {
       {{"SIRIUS_HIVE_WATCHDOG_QUERY", query},
        {"SIRIUS_HIVE_WATCHDOG_OUTPUT", output_path.string()},
        {"SIRIUS_HIVE_WATCHDOG_CONFIG", config_path.string()},
-       {"SIRIUS_CONFIG_FILE", config_path.string()}},
-      {"SIRIUS_DISABLE"}};
+       {"SIRIUS_CONFIG_FILE", config_path.string()}}};
 
     pid_t pid{};
     auto const spawn_result = ::posix_spawn(
@@ -745,8 +744,10 @@ TEST_CASE("gpu_execution hive partition watchdog child runner",
     std::unique_ptr<duckdb::DuckDB> db;
     std::unique_ptr<duckdb::Connection> con;
     if (out.error.empty()) {
+      // Shared test-environment startup resets these values after exec, so restore the
+      // watchdog's isolated-context environment before opening its database.
       config_guard = std::make_unique<sirius_config_env_guard>(config_raw);
-      unsetenv("SIRIUS_DISABLE");
+      ::unsetenv("SIRIUS_DISABLE");
       db  = std::make_unique<duckdb::DuckDB>(nullptr);
       con = std::make_unique<duckdb::Connection>(*db);
     }

--- a/test/cpp/integration/test_query_lifecycle_slot.cpp
+++ b/test/cpp/integration/test_query_lifecycle_slot.cpp
@@ -2109,6 +2109,8 @@ TEST_CASE(kChildRunnerCase, "[.][query_lifecycle][watchdog_child]")
   if (config_raw == nullptr) {
     out.error = "watchdog child missing config path";
   } else {
+    setenv("SIRIUS_CONFIG_FILE", config_raw, 1);
+    unsetenv("SIRIUS_DISABLE");
     auto const output_path = fs::path(output_raw);
     auto const database_path =
       output_path.parent_path() / ("scenario_" + std::string(variant_raw) + ".duckdb");

--- a/test/cpp/integration/test_query_lifecycle_slot.cpp
+++ b/test/cpp/integration/test_query_lifecycle_slot.cpp
@@ -2109,8 +2109,10 @@ TEST_CASE(kChildRunnerCase, "[.][query_lifecycle][watchdog_child]")
   if (config_raw == nullptr) {
     out.error = "watchdog child missing config path";
   } else {
-    setenv("SIRIUS_CONFIG_FILE", config_raw, 1);
-    unsetenv("SIRIUS_DISABLE");
+    // Shared test-environment startup resets these values after exec, so restore the
+    // watchdog's isolated-context environment before running the scenario.
+    ::setenv("SIRIUS_CONFIG_FILE", config_raw, 1);
+    ::unsetenv("SIRIUS_DISABLE");
     auto const output_path = fs::path(output_raw);
     auto const database_path =
       output_path.parent_path() / ("scenario_" + std::string(variant_raw) + ".duckdb");
@@ -2157,15 +2159,13 @@ class QueryLifecycleSlotFixture {
     std::vector<sirius::test::child_process_environment::override> environment_overrides{
       {kEnvVariant, variant},
       {kEnvOutput, output_path.string()},
-      {kEnvConfig, config_path.string()},
-      {"SIRIUS_CONFIG_FILE", config_path.string()}};
+      {kEnvConfig, config_path.string()}};
     if (variant_requires_file_log(variant)) {
       environment_overrides.emplace_back("SIRIUS_LOG_BACKEND", "spdlog");
       environment_overrides.emplace_back("SIRIUS_LOG_DIR", log_dir.string());
       environment_overrides.emplace_back("SIRIUS_LOG_LEVEL", "debug");
     }
-    sirius::test::child_process_environment child_environment{std::move(environment_overrides),
-                                                              {"SIRIUS_DISABLE"}};
+    sirius::test::child_process_environment child_environment{std::move(environment_overrides)};
 
     // Re-exec before running an engine query so no live CUDA context is inherited.
     pid_t pid{};

--- a/test/cpp/integration/test_query_lifecycle_slot.cpp
+++ b/test/cpp/integration/test_query_lifecycle_slot.cpp
@@ -39,8 +39,10 @@
 #include <duckdb/main/client_data.hpp>
 #include <duckdb/main/pending_query_result.hpp>
 #include <signal.h>
+#include <spawn.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <utils/child_process_environment.hpp>
 #include <utils/transparent_execution_test_utils.hpp>
 
 #include <algorithm>
@@ -2094,7 +2096,7 @@ slot_watchdog_result run_scenario(std::string const& variant,
 
 }  // namespace
 
-// Hidden child-runner: re-entered via execl by the watchdog below. Not part of any
+// Hidden child-runner: re-entered by the watchdog below. Not part of any
 // standard gate; runs only when selected by its exact name.
 TEST_CASE(kChildRunnerCase, "[.][query_lifecycle][watchdog_child]")
 {
@@ -2107,8 +2109,6 @@ TEST_CASE(kChildRunnerCase, "[.][query_lifecycle][watchdog_child]")
   if (config_raw == nullptr) {
     out.error = "watchdog child missing config path";
   } else {
-    ::setenv("SIRIUS_CONFIG_FILE", config_raw, 1);
-    ::unsetenv("SIRIUS_DISABLE");
     auto const output_path = fs::path(output_raw);
     auto const database_path =
       output_path.parent_path() / ("scenario_" + std::string(variant_raw) + ".duckdb");
@@ -2144,22 +2144,32 @@ class QueryLifecycleSlotFixture {
     auto const log_dir = variant_log_dir(output_path);
     if (variant_requires_file_log(variant)) { fs::create_directories(log_dir); }
 
-    auto const pid = ::fork();
-    REQUIRE(pid >= 0);
-    if (pid == 0) {
-      ::setenv(kEnvVariant, variant.c_str(), 1);
-      ::setenv(kEnvOutput, output_path.string().c_str(), 1);
-      ::setenv(kEnvConfig, config_path.string().c_str(), 1);
-      if (variant_requires_file_log(variant)) {
-        ::setenv("SIRIUS_LOG_BACKEND", "spdlog", 1);
-        ::setenv("SIRIUS_LOG_DIR", log_dir.string().c_str(), 1);
-        ::setenv("SIRIUS_LOG_LEVEL", "debug", 1);
-      }
-      // A child that inherited a live CUDA context must re-exec before running an
-      // engine query, so re-invoke the unit-test binary for the child-runner case.
-      ::execl("/proc/self/exe", "sirius_unittest", kChildRunnerCase, static_cast<char*>(nullptr));
-      ::_exit(127);
+    std::vector<std::string> child_arguments{"sirius_unittest", kChildRunnerCase};
+    std::vector<char*> child_argv;
+    child_argv.reserve(child_arguments.size() + 1);
+    for (auto& argument : child_arguments) {
+      child_argv.push_back(argument.data());
     }
+    child_argv.push_back(nullptr);
+
+    std::vector<sirius::test::child_process_environment::override> environment_overrides{
+      {kEnvVariant, variant},
+      {kEnvOutput, output_path.string()},
+      {kEnvConfig, config_path.string()},
+      {"SIRIUS_CONFIG_FILE", config_path.string()}};
+    if (variant_requires_file_log(variant)) {
+      environment_overrides.emplace_back("SIRIUS_LOG_BACKEND", "spdlog");
+      environment_overrides.emplace_back("SIRIUS_LOG_DIR", log_dir.string());
+      environment_overrides.emplace_back("SIRIUS_LOG_LEVEL", "debug");
+    }
+    sirius::test::child_process_environment child_environment{std::move(environment_overrides),
+                                                              {"SIRIUS_DISABLE"}};
+
+    // Re-exec before running an engine query so no live CUDA context is inherited.
+    pid_t pid{};
+    auto const spawn_result = ::posix_spawn(
+      &pid, "/proc/self/exe", nullptr, nullptr, child_argv.data(), child_environment.data());
+    REQUIRE(spawn_result == 0);
 
     int status      = 0;
     auto const stop = std::chrono::steady_clock::now() + deadline;

--- a/test/cpp/utils/child_process_environment.hpp
+++ b/test/cpp/utils/child_process_environment.hpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#if defined(__APPLE__)
+#include <crt_externs.h>
+#else
+extern char** environ;
+#endif
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace sirius::test {
+
+/** An inherited environment with child-only overrides, suitable for execve/posix_spawn. */
+class child_process_environment {
+ public:
+  using override = std::pair<std::string, std::string>;
+
+  explicit child_process_environment(std::vector<override> overrides,
+                                     std::vector<std::string> removals = {})
+  {
+#if defined(__APPLE__)
+    auto const current_environment = *_NSGetEnviron();
+#else
+    auto const current_environment = environ;
+#endif
+
+    auto const is_replaced_or_removed = [&](std::string_view name) {
+      auto const is_override = std::any_of(
+        overrides.begin(), overrides.end(), [&](auto const& item) { return item.first == name; });
+      auto const is_removal = std::any_of(
+        removals.begin(), removals.end(), [&](auto const& item) { return item == name; });
+      return is_override || is_removal;
+    };
+
+    for (auto entry = current_environment; entry != nullptr && *entry != nullptr; ++entry) {
+      std::string_view const value{*entry};
+      auto const separator = value.find('=');
+      auto const name      = value.substr(0, separator);
+      if (!is_replaced_or_removed(name)) { entries_.emplace_back(value); }
+    }
+
+    for (auto& [name, value] : overrides) {
+      entries_.push_back(std::move(name) + "=" + std::move(value));
+    }
+
+    envp_.reserve(entries_.size() + 1);
+    for (auto& entry : entries_) {
+      envp_.push_back(entry.data());
+    }
+    envp_.push_back(nullptr);
+  }
+
+  child_process_environment(child_process_environment const&)            = delete;
+  child_process_environment& operator=(child_process_environment const&) = delete;
+  child_process_environment(child_process_environment&&)                 = delete;
+  child_process_environment& operator=(child_process_environment&&)      = delete;
+
+  [[nodiscard]] char* const* data() noexcept { return envp_.data(); }
+
+ private:
+  std::vector<std::string> entries_;
+  std::vector<char*> envp_;
+};
+
+}  // namespace sirius::test

--- a/test/cpp/utils/test_child_process_environment.cpp
+++ b/test/cpp/utils/test_child_process_environment.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch.hpp>
+#include <utils/child_process_environment.hpp>
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace {
+
+std::optional<std::string> environment_value(char const* name)
+{
+  auto const* value = std::getenv(name);
+  return value == nullptr ? std::nullopt : std::optional<std::string>{value};
+}
+
+std::optional<std::string_view> child_environment_value(char* const* environment,
+                                                        std::string_view name)
+{
+  for (auto entry = environment; entry != nullptr && *entry != nullptr; ++entry) {
+    std::string_view const value{*entry};
+    auto const separator = value.find('=');
+    if (separator != std::string_view::npos && value.substr(0, separator) == name) {
+      return value.substr(separator + 1);
+    }
+  }
+  return std::nullopt;
+}
+
+}  // namespace
+
+TEST_CASE("child process environment applies changes without mutating the parent",
+          "[utils][child_process_environment]")
+{
+  constexpr char const* override_name = "SIRIUS_CHILD_ENV_TEST_OVERRIDE";
+  constexpr char const* removal_name  = "SIRIUS_DISABLE";
+  auto const parent_override          = environment_value(override_name);
+  auto const parent_removal           = environment_value(removal_name);
+  auto const parent_path              = environment_value("PATH");
+
+  sirius::test::child_process_environment child_environment{
+    {{override_name, "child-only"}, {"PATH", "child-path"}}, {removal_name}};
+
+  CHECK(child_environment_value(child_environment.data(), override_name) == "child-only");
+  CHECK(child_environment_value(child_environment.data(), "PATH") == "child-path");
+  CHECK_FALSE(child_environment_value(child_environment.data(), removal_name).has_value());
+
+  CHECK(environment_value(override_name) == parent_override);
+  CHECK(environment_value(removal_name) == parent_removal);
+  CHECK(environment_value("PATH") == parent_path);
+}

--- a/test/cpp/utils/test_child_process_environment.cpp
+++ b/test/cpp/utils/test_child_process_environment.cpp
@@ -53,6 +53,7 @@ TEST_CASE("child process environment applies changes without mutating the parent
   auto const parent_override          = environment_value(override_name);
   auto const parent_removal           = environment_value(removal_name);
   auto const parent_path              = environment_value("PATH");
+  auto const parent_home              = environment_value("HOME");
 
   sirius::test::child_process_environment child_environment{
     {{override_name, "child-only"}, {"PATH", "child-path"}}, {removal_name}};
@@ -60,6 +61,7 @@ TEST_CASE("child process environment applies changes without mutating the parent
   CHECK(child_environment_value(child_environment.data(), override_name) == "child-only");
   CHECK(child_environment_value(child_environment.data(), "PATH") == "child-path");
   CHECK_FALSE(child_environment_value(child_environment.data(), removal_name).has_value());
+  CHECK(child_environment_value(child_environment.data(), "HOME") == parent_home);
 
   CHECK(environment_value(override_name) == parent_override);
   CHECK(environment_value(removal_name) == parent_removal);


### PR DESCRIPTION
## Description

Replace the two watchdog runners' `fork()` + environment mutation + `exec()` sequences with `posix_spawn()` using an environment prepared entirely in the parent process.

Add a reusable child-process environment helper that snapshots the inherited environment, applies child-only overrides and removals, and leaves the parent unchanged. This generalizes the existing envp-construction pattern in `test_operator_sweep.cpp` and `test_fused_operator_sweep.cpp` so both watchdogs share it.

The spawn environments preserve the original pre-exec behavior, including inheriting `SIRIUS_DISABLE`. After re-exec, the hidden runners reapply `SIRIUS_CONFIG_FILE` and clear `SIRIUS_DISABLE` because shared test-environment startup resets those process-wide values before the selected test runs.

A tree-wide process-launch audit found no other post-fork environment mutation. Other fork/exec sites either prepare `envp` in the parent or perform only descriptor and exec operations in the child, so they are intentionally outside this change.

## Validation

Validated on Ubuntu 24.04 with an NVIDIA GeForce RTX 5060 Ti (compute capability 12.0), CUDA 13.2, and `io_uring` enabled:

- `CUDAARCHS=120 CMAKE_BUILD_PARALLEL_LEVEL=8 pixi run make`
- `pixi run pre-commit run -a`
- Child-process environment regression: 7 assertions in 1 test case
- Query-lifecycle watchdog: 78 assertions in 11 test cases
- Hive-partition CUDA watchdog: 28 assertions in 1 test case
- `pixi run make s3-test`: 31,433 assertions in 92 test cases using testcontainers-managed MinIO over HTTP and TLS
- Native macOS C++17 spawn/environment smoke test passed

## Checklist

- [x] Read CONTRIBUTING.md
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above (N/A: no configuration changes)
- [x] Update human and agent documentation (N/A: internal test infrastructure only)

## References

Closes #1440