### PR TITLE
feat(exec): exchange staging arena for cross-node batch transfer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,7 @@ set(EXTENSION_SOURCES
     # Execution primitives (slot-based backpressure / completion tracking)
     src/exec/admission_control.cpp
     src/exec/batch_stream.cpp
+    src/exec/exchange_staging_arena.cpp
     src/exec/stream_session.cpp
     src/exec/stream_bind_catalog.cpp
     src/exec/stream_plan_bindings.cpp
@@ -690,6 +691,7 @@ set(TEST_SOURCES
     test/cpp/downgrade/test_downgrade_lifecycle.cpp
     test/cpp/exec/test_batch_stream.cpp
     test/cpp/exec/test_bounded_thread_pool.cpp
+    test/cpp/exec/test_exchange_staging_arena.cpp
     test/cpp/exec/test_inspectable_mpsc.cpp
     test/cpp/exec/test_interruptible_mpmc.cpp
     test/cpp/exec/test_multi_index_priority_queue.cpp

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -556,6 +556,25 @@ Registered in `src/sirius_extension.cpp`. These can be changed at runtime:
 These can also be set at load via the `SIRIUS_LOG_BACKEND`, `SIRIUS_LOG_DIR`, and
 `SIRIUS_LOG_LEVEL` environment variables.
 
+### Exchange Staging Arena
+
+Environment variables read once at engine bring-up (`exchange_staging_arena::from_env`), not
+`sirius_config`/`SET` knobs. The arena is one device region allocated *outside* the RMM pool that
+a cross-node exchange packs batches into on the send side and lands them in on the receive side,
+so a transport registers exactly one memory region. It is plain `cudaMalloc` by design: UCX's
+`cuda_ipc` path cannot export `cudaMallocAsync` (pool) memory and silently degrades ~220x to
+staged host copies — correct bytes, no error.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SIRIUS_EXCHANGE_STAGING_BYTES` | unset | Arena capacity, with the [byte suffixes](#byte-suffixes) `sirius::yaml::parse_bytes` accepts (`512MiB`, `1Gi`, ...). Unset means **no arena**: every staging call fails loudly with a message naming this variable instead of degrading to a slow path. Capacity bounds *concurrently live* lease bytes, not lifetime totals — leases come from an address-ordered, coalescing free list, so released space is immediately reusable. `0` and unparsable values are rejected at bring-up. |
+| `SIRIUS_EXCHANGE_STAGING_ARENA` | `cudamalloc` | How the region is allocated. `cudamalloc` is correct for every single-host deployment and is the only path the unit tests exercise. `fabric` is opt-in and only needed when peers live on **different hosts**: it allocates through the CUDA driver VMM API with `CU_MEM_HANDLE_TYPE_FABRIC`, the only handle a peer on another host can map (`cudaMalloc`'s IPC handle is node-local, so a cross-host exchange over it falls back to a 0.32-0.43 GB/s host bounce; the fabric path measured 765 GB/s on a two-host GB200 MNNVL pair). Requires a live IMEX domain (`nvidia-imex`) and access to `/dev/nvidia-caps-imex-channels`; `cuMemCreate` fails loudly at bring-up otherwise. Any other value is rejected. |
+
+The arena logs its granted size at construction and its peak live bytes (plus any leaked leases)
+at teardown; those two `INFO` lines are the sizing feedback, since the slab appears in no pool
+accounting. No in-tree component constructs the arena yet; the fragment FFI that packs batches
+into a lease is a follow-up.
+
 ### Expression Evaluation
 
 **File:** `src/include/expression_evaluator/expression_evaluator_strategy.hpp`
@@ -759,6 +778,7 @@ These are compile-time defaults. Runtime configuration via `sirius_config` and D
 | File | Purpose |
 |------|---------|
 | `src/include/sirius_config.hpp` | Config class, operator_params, thread pool configs |
+| `src/include/exec/exchange_staging_arena.hpp` | `SIRIUS_EXCHANGE_STAGING_BYTES` / `SIRIUS_EXCHANGE_STAGING_ARENA` (exchange staging arena) |
 | `src/include/config.hpp` | Legacy config flags |
 | `src/sirius_extension.cpp` | SET variable registration |
 | `src/include/scan_manager/config.hpp` | Scan manager config (thread pool, IO reactors, prefetch cache, object store) |

--- a/src/exec/exchange_staging_arena.cpp
+++ b/src/exec/exchange_staging_arena.cpp
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/exchange_staging_arena.hpp"
+
+#include "log/logging.hpp"
+#include "sirius/exception.hpp"
+#include "yaml_reader.hpp"  // sirius::yaml::parse_bytes
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <iterator>
+
+namespace sirius::exec {
+
+namespace {
+constexpr std::uint64_t align_up(std::uint64_t len)
+{
+  return (len + exchange_staging_arena::kAlignment - 1) & ~(exchange_staging_arena::kAlignment - 1);
+}
+
+//! Driver-API error text, or a bare code when the driver cannot name it.
+std::string driver_error(CUresult status)
+{
+  const char* name = nullptr;
+  cuGetErrorString(status, &name);
+  return name != nullptr ? std::string(name) : ("CUresult " + std::to_string(status));
+}
+
+//! True when the operator asked for the fabric-handle arena.
+bool want_fabric_arena()
+{
+  const char* kind = std::getenv(exchange_staging_arena::kArenaKindEnvVar);
+  if (kind == nullptr) { return false; }
+  if (std::strcmp(kind, "fabric") == 0) { return true; }
+  if (std::strcmp(kind, "cudamalloc") == 0) { return false; }
+  throw sirius::invalid_input_exception(std::string(exchange_staging_arena::kArenaKindEnvVar) +
+                                        ": expected \"fabric\" or \"cudamalloc\", got \"" + kind +
+                                        "\"");
+}
+}  // namespace
+
+exchange_staging_arena::exchange_staging_arena(std::uint64_t capacity_bytes)
+  : capacity_(capacity_bytes)
+{
+  if (capacity_bytes == 0) {
+    throw sirius::invalid_input_exception("exchange staging arena: capacity must be nonzero");
+  }
+
+  if (!want_fabric_arena()) {
+    // Plain cudaMalloc, by contract (see the class comment): pool memory silently loses the
+    // transport's GPU-to-GPU fast path. Correct for a single host; see kArenaKindEnvVar for why
+    // it is not enough across hosts.
+    if (auto err = cudaMalloc(&base_, capacity_bytes); err != cudaSuccess) {
+      throw sirius::internal_exception("exchange staging arena: cudaMalloc of {} bytes failed: {}",
+                                       capacity_bytes,
+                                       cudaGetErrorString(err));
+    }
+    // The size the operator actually got, on the operator's own terms. This slab sits OUTSIDE
+    // the RMM pool, so it appears in no config dump and in no pool accounting -- without this
+    // line the only way to learn it is to read the launcher's environment.
+    SIRIUS_LOG_INFO("exchange staging arena: {} bytes (cudaMalloc)", capacity_);
+    // Seeded at the end of the constructor, after BOTH paths have settled `capacity_`.
+    free_.emplace(0, capacity_);
+    return;
+  }
+
+  // Fabric path (opt-in via SIRIUS_EXCHANGE_STAGING_ARENA=fabric; only needed when peers live on
+  // another host; not exercised by the unit tests): reserve, back and map device memory whose
+  // handle a peer on another host can import. This is the cuMemCreate / cuMemAddressReserve /
+  // cuMemMap / cuMemSetAccess sequence a standalone two-host MNNVL harness validated at 765 GB/s.
+  //
+  // The device ordinal is 0 because a cross-host embedder pins its process to one GPU through
+  // CUDA_VISIBLE_DEVICES before engine bring-up, so the process only ever sees one device, at
+  // ordinal 0. A multi-device process would need the ordinal plumbed through instead.
+  CUmemAllocationProp prop{};
+  prop.type                 = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+  prop.location.type        = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.location.id          = 0;
+
+  std::size_t granularity = 0;
+  if (auto status =
+        cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED);
+      status != CUDA_SUCCESS) {
+    throw sirius::internal_exception(
+      "exchange staging arena: cuMemGetAllocationGranularity failed: {}", driver_error(status));
+  }
+  if (granularity == 0) {
+    throw sirius::internal_exception("exchange staging arena: zero allocation granularity");
+  }
+  // cuMemCreate requires a granularity multiple. Rounding up grows the arena, never shrinks it,
+  // so a lease that fit before still fits.
+  const std::uint64_t size = ((capacity_bytes + granularity - 1) / granularity) * granularity;
+
+  CUmemGenericAllocationHandle handle = 0;
+  if (auto status = cuMemCreate(&handle, size, &prop, 0); status != CUDA_SUCCESS) {
+    throw sirius::internal_exception(
+      "exchange staging arena: cuMemCreate of {} bytes with CU_MEM_HANDLE_TYPE_FABRIC failed: {} "
+      "-- this host cannot export fabric handles (is nvidia-imex running, and are the "
+      "/dev/nvidia-caps-imex-channels devices accessible to this user?)",
+      size,
+      driver_error(status));
+  }
+
+  CUdeviceptr ptr = 0;
+  if (auto status = cuMemAddressReserve(&ptr, size, granularity, 0, 0); status != CUDA_SUCCESS) {
+    cuMemRelease(handle);
+    throw sirius::internal_exception("exchange staging arena: cuMemAddressReserve failed: {}",
+                                     driver_error(status));
+  }
+  if (auto status = cuMemMap(ptr, size, 0, handle, 0); status != CUDA_SUCCESS) {
+    cuMemAddressFree(ptr, size);
+    cuMemRelease(handle);
+    throw sirius::internal_exception("exchange staging arena: cuMemMap failed: {}",
+                                     driver_error(status));
+  }
+
+  CUmemAccessDesc access{};
+  access.location = prop.location;
+  access.flags    = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  if (auto status = cuMemSetAccess(ptr, size, &access, 1); status != CUDA_SUCCESS) {
+    cuMemUnmap(ptr, size);
+    cuMemAddressFree(ptr, size);
+    cuMemRelease(handle);
+    throw sirius::internal_exception("exchange staging arena: cuMemSetAccess failed: {}",
+                                     driver_error(status));
+  }
+
+  base_          = reinterpret_cast<void*>(ptr);
+  capacity_      = size;
+  mapped_bytes_  = size;
+  fabric_handle_ = handle;
+  // Both the requested and the granted size: cuMemCreate rounds up to a granularity multiple, so
+  // these differ, and the granted one is what a lease is actually checked against.
+  SIRIUS_LOG_INFO(
+    "exchange staging arena: {} bytes (fabric handle, requested {})", capacity_, capacity_bytes);
+  // Seeded only now: the fabric path OVERWRITES `capacity_` with the granularity-rounded size
+  // (above), and the free list must describe the region actually mapped, not the one requested.
+  free_.emplace(0, capacity_);
+}
+
+exchange_staging_arena::~exchange_staging_arena()
+{
+  // The one number that says how much arena a workload ACTUALLY needed. Sizing this slab is the
+  // hardest knob to set (it depends on how many exports are in flight at once, not on data
+  // volume) and the arena fails hard rather than degrading, so without this line the only
+  // feedback an operator gets is "exhausted" or silence -- there is no way to learn a passing
+  // run had 90% headroom. Nonzero `outstanding` at teardown means a leaked lease.
+  {
+    std::lock_guard lock(mutex_);
+    SIRIUS_LOG_INFO(
+      "exchange staging arena: peak live {} of {} bytes ({} leases outstanding, {} free blocks, "
+      "largest {})",
+      peak_live_bytes_,
+      capacity_,
+      leases_.size(),
+      free_.size(),
+      largest_free_locked());
+  }
+
+  if (fabric_handle_ != 0) {
+    // Unmap before freeing the reservation, and release the physical handle last -- cudaFree
+    // cannot release a VMM mapping and would leak the entire arena.
+    auto ptr = reinterpret_cast<CUdeviceptr>(base_);
+    cuMemUnmap(ptr, mapped_bytes_);
+    cuMemAddressFree(ptr, mapped_bytes_);
+    cuMemRelease(fabric_handle_);
+    return;
+  }
+  cudaFree(base_);
+}
+
+std::unique_ptr<exchange_staging_arena> exchange_staging_arena::from_env()
+{
+  const char* value = std::getenv(kCapacityEnvVar);
+  if (value == nullptr) { return nullptr; }
+  std::uint64_t bytes = 0;
+  try {
+    bytes = sirius::yaml::parse_bytes(value);
+  } catch (const std::exception& e) {
+    throw sirius::invalid_input_exception(std::string(kCapacityEnvVar) + ": " + e.what());
+  }
+  return std::make_unique<exchange_staging_arena>(bytes);
+}
+
+exchange_staging_arena& exchange_staging_arena::require(exchange_staging_arena* arena)
+{
+  if (arena == nullptr) {
+    throw sirius::invalid_input_exception(
+      "exchange staging arena not configured (set SIRIUS_EXCHANGE_STAGING_BYTES)");
+  }
+  return *arena;
+}
+
+std::uint64_t exchange_staging_arena::lease(std::uint64_t len)
+{
+  if (len == 0) {
+    // A zero-length lease would alias the next lease's offset and break release-by-offset.
+    throw sirius::invalid_input_exception("exchange staging arena: zero-length lease");
+  }
+  std::lock_guard lock(mutex_);
+  const auto aligned = align_up(len);
+  // align_up wraps for len within kAlignment-1 of UINT64_MAX; a wrapped 0 would slip past the
+  // fit scan and register a zero-length lease aliasing a live one. `len` will be wire-supplied
+  // by a peer's lease request once a transport sits on top, so this guard is load-bearing, not
+  // theoretical.
+  if (aligned < len || aligned > capacity_) {
+    throw sirius::invalid_input_exception(
+      "exchange staging arena: lease of {} bytes exceeds the {} byte capacity", len, capacity_);
+  }
+
+  // Address-ordered first fit: keeps low addresses dense and needs no second index. At the tens
+  // of blocks this arena holds, the linear scan is cheaper than maintaining a size index.
+  for (auto it = free_.begin(); it != free_.end(); ++it) {
+    if (it->second < aligned) { continue; }
+    const auto offset    = it->first;
+    const auto block_len = it->second;
+    free_.erase(it);
+    if (block_len > aligned) { free_.emplace(offset + aligned, block_len - aligned); }
+    leases_.emplace(offset, aligned);
+    live_bytes_ += aligned;
+    peak_live_bytes_ = std::max(peak_live_bytes_, live_bytes_);
+    return offset;
+  }
+
+  // Both numbers, because they mean different things: total free short of the request means
+  // raise capacity (or fix retention); total free ample but largest block short means external
+  // fragmentation, which a bigger arena does not necessarily fix.
+  throw sirius::invalid_input_exception(
+    "exchange staging arena exhausted: requested {} bytes ({} aligned), {} free of {} capacity "
+    "in {} blocks (largest {}), {} leases outstanding holding {} bytes "
+    "(raise SIRIUS_EXCHANGE_STAGING_BYTES)",
+    len,
+    aligned,
+    total_free_locked(),
+    capacity_,
+    free_.size(),
+    largest_free_locked(),
+    leases_.size(),
+    live_bytes_);
+}
+
+void exchange_staging_arena::release(std::uint64_t offset)
+{
+  std::lock_guard lock(mutex_);
+  auto it = leases_.find(offset);
+  if (it == leases_.end()) {
+    throw sirius::invalid_input_exception(
+      "exchange staging arena: release of offset {} which is not an outstanding lease "
+      "(double release?)",
+      offset);
+  }
+  const auto len = it->second;
+  leases_.erase(it);
+  live_bytes_ -= len;
+
+  // Insert and coalesce with both neighbours, so the free list never holds two adjacent blocks
+  // and released space is reusable regardless of the order releases arrive in. Merge forward
+  // first (this block absorbs its successor), then backward (the predecessor absorbs the
+  // result) -- doing it in the other order would leave `ins` dangling before the forward merge.
+  auto [ins, ok] = free_.emplace(offset, len);
+  (void)ok;  // offset came out of leases_, so it cannot already be in free_
+
+  auto next = std::next(ins);
+  if (next != free_.end() && ins->first + ins->second == next->first) {
+    ins->second += next->second;
+    free_.erase(next);
+  }
+  if (ins != free_.begin()) {
+    auto prev = std::prev(ins);
+    if (prev->first + prev->second == ins->first) {
+      prev->second += ins->second;
+      free_.erase(ins);
+    }
+  }
+}
+
+std::uint64_t exchange_staging_arena::total_free_locked() const
+{
+  std::uint64_t sum = 0;
+  for (const auto& [offset, len] : free_) {
+    sum += len;
+  }
+  return sum;
+}
+
+std::uint64_t exchange_staging_arena::largest_free_locked() const
+{
+  std::uint64_t best = 0;
+  for (const auto& [offset, len] : free_) {
+    best = std::max(best, len);
+  }
+  return best;
+}
+
+std::size_t exchange_staging_arena::outstanding() const
+{
+  std::lock_guard lock(mutex_);
+  return leases_.size();
+}
+
+std::uint64_t exchange_staging_arena::total_free() const
+{
+  std::lock_guard lock(mutex_);
+  return total_free_locked();
+}
+
+std::uint64_t exchange_staging_arena::largest_free() const
+{
+  std::lock_guard lock(mutex_);
+  return largest_free_locked();
+}
+
+std::uint64_t exchange_staging_arena::live_bytes() const
+{
+  std::lock_guard lock(mutex_);
+  return live_bytes_;
+}
+
+std::uint64_t exchange_staging_arena::peak_live_bytes() const
+{
+  std::lock_guard lock(mutex_);
+  return peak_live_bytes_;
+}
+
+}  // namespace sirius::exec

--- a/src/include/exec/exchange_staging_arena.hpp
+++ b/src/include/exec/exchange_staging_arena.hpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+
+namespace sirius::exec {
+
+/// One device staging region for the cross-node exchange: packed batches are gathered into a
+/// lease on the send side and land in a lease on the receive side, so the transport only ever
+/// registers this one region.
+///
+/// The region is deliberately plain `cudaMalloc`, never pool / stream-ordered memory: UCX's
+/// `cuda_ipc` path cannot export `cudaMallocAsync` allocations and silently degrades ~220x to
+/// staged host copies — correct bytes, no error. Keeping the arena outside every pool is the
+/// reason this class exists.
+///
+/// Leases are allocated from an address-ordered free list under a mutex and freed explicitly
+/// (`lease` / `release` cross an FFI). Each release returns the block and coalesces it with its
+/// free neighbours, so ANY released space is immediately reusable — the allocator has no bump
+/// head and cannot drift: capacity bounds concurrent live bytes, not lifetime totals. A lease
+/// remains one contiguous, `kAlignment`-aligned range, so it is still a valid RDMA target and a
+/// valid `cudf::unpack` source.
+class exchange_staging_arena {
+ public:
+  /// Every lease offset is a multiple of this, so any lease is a valid aligned transfer target.
+  static constexpr std::uint64_t kAlignment = 256;
+
+  /// Environment variable naming the arena capacity. Byte suffixes per
+  /// `sirius::yaml::parse_bytes` ("512MiB", "1Gi", ...). Unset means no arena: every staging
+  /// call fails loudly instead of silently taking a slow path.
+  static constexpr const char* kCapacityEnvVar = "SIRIUS_EXCHANGE_STAGING_BYTES";
+
+  /// Selects how the arena's device memory is allocated. Unset or `cudamalloc` (the default)
+  /// keeps the plain `cudaMalloc` contract described above, which is correct for every
+  /// single-host deployment and is the only path the unit tests exercise. `fabric` is opt-in and
+  /// only needed when peers live on DIFFERENT hosts: it allocates through the CUDA driver's VMM
+  /// API with `CU_MEM_HANDLE_TYPE_FABRIC`, the only allocation a peer on another host can map.
+  /// `cudaMalloc`'s IPC handle is node-local by construction, so a multi-host exchange over it
+  /// degrades to a host bounce (measured 0.32-0.43 GB/s between two GB200 hosts, far below what
+  /// a cross-node exchange can accept); a fabric handle rides the MNNVL fabric instead (a
+  /// standalone two-host harness measured 765 GB/s on the same pair).
+  ///
+  /// Requires a live IMEX domain and access to /dev/nvidia-caps-imex-channels; `cuMemCreate`
+  /// fails loudly here rather than degrading silently later.
+  static constexpr const char* kArenaKindEnvVar = "SIRIUS_EXCHANGE_STAGING_ARENA";
+
+  /// Allocates the region with `cudaMalloc`.
+  /// @throws sirius::invalid_input_exception on a zero capacity.
+  /// @throws sirius::internal_exception when the allocation fails, naming the size and the
+  ///         CUDA error.
+  explicit exchange_staging_arena(std::uint64_t capacity_bytes);
+  ~exchange_staging_arena();
+
+  // The base pointer is handed out for transport registration, so the arena can never move.
+  exchange_staging_arena(const exchange_staging_arena&)            = delete;
+  exchange_staging_arena& operator=(const exchange_staging_arena&) = delete;
+  exchange_staging_arena(exchange_staging_arena&&)                 = delete;
+  exchange_staging_arena& operator=(exchange_staging_arena&&)      = delete;
+
+  /// The arena sized from `kCapacityEnvVar`, or nullptr when the variable is unset.
+  /// @throws sirius::invalid_input_exception on an unparsable value.
+  static std::unique_ptr<exchange_staging_arena> from_env();
+
+  /// `*arena`, or the loud not-configured error. Every call site that may run without an
+  /// arena funnels through here so the operator-facing message has exactly one definition.
+  /// @throws sirius::invalid_input_exception when `arena` is null.
+  static exchange_staging_arena& require(exchange_staging_arena* arena);
+
+  /// Lease `len` bytes; returns the lease's byte offset from `base()`.
+  /// @throws sirius::invalid_input_exception on a zero-length request, or on exhaustion —
+  ///         naming the requested, free, and capacity byte counts.
+  std::uint64_t lease(std::uint64_t len);
+
+  /// Return the lease at `offset`. The block goes back to the free list and coalesces with its
+  /// free neighbours, so the space is immediately reusable regardless of release order.
+  /// @throws sirius::invalid_input_exception when `offset` is not an outstanding lease
+  ///         (double release, or a corrupted offset).
+  void release(std::uint64_t offset);
+
+  /// Device base address, for transport memory registration and for addressing leases.
+  [[nodiscard]] std::uintptr_t base() const noexcept
+  {
+    return reinterpret_cast<std::uintptr_t>(base_);
+  }
+
+  [[nodiscard]] std::uint64_t capacity() const noexcept { return capacity_; }
+
+  /// Leases currently held. Diagnostics: nonzero at quiesce means a leaked lease.
+  [[nodiscard]] std::size_t outstanding() const;
+
+  /// Peak sum of outstanding lease lengths — the working set the workload actually needed.
+  /// With a coalescing free list this is also the peak arena occupancy, because released space
+  /// is immediately reusable; a bump allocator would let the two diverge (that gap is drift).
+  [[nodiscard]] std::uint64_t peak_live_bytes() const;
+
+  /// Current sum of outstanding lease lengths.
+  [[nodiscard]] std::uint64_t live_bytes() const;
+
+  /// Largest single contiguous free block. `total_free() - largest_free()` is the external
+  /// fragmentation; a lease no larger than this is guaranteed to succeed.
+  [[nodiscard]] std::uint64_t largest_free() const;
+
+  /// Sum of all free blocks.
+  [[nodiscard]] std::uint64_t total_free() const;
+
+ private:
+  void* base_             = nullptr;
+  std::uint64_t capacity_ = 0;
+
+  //! VMM bookkeeping, set only on the `fabric` path; `fabric_handle_ == 0` means this arena was
+  //! allocated with cudaMalloc and must be released with cudaFree. The VMM path has to unmap,
+  //! free the reserved address range and release the physical handle -- cudaFree cannot do any
+  //! of that and would silently leak the whole arena.
+  unsigned long long fabric_handle_ = 0;
+  std::uint64_t mapped_bytes_       = 0;
+
+  mutable std::mutex mutex_;
+  //! Free blocks, address-ordered and always coalesced: no two entries are adjacent.
+  //! Seeded with the whole region at construction.
+  std::map<std::uint64_t, std::uint64_t> free_;
+  std::map<std::uint64_t, std::uint64_t> leases_;  // offset -> aligned length
+  std::uint64_t live_bytes_      = 0;
+  std::uint64_t peak_live_bytes_ = 0;
+
+  //! Total free bytes and the largest single contiguous free block. Both are reported on
+  //! exhaustion: the gap between them IS the external fragmentation, and it is the number that
+  //! tells an operator whether to raise capacity or to fix retention.
+  [[nodiscard]] std::uint64_t total_free_locked() const;
+  [[nodiscard]] std::uint64_t largest_free_locked() const;
+};
+
+}  // namespace sirius::exec

--- a/test/cpp/exec/test_exchange_staging_arena.cpp
+++ b/test/cpp/exec/test_exchange_staging_arena.cpp
@@ -1,0 +1,444 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuda_runtime_api.h>
+
+#include <catch.hpp>
+#include <exec/exchange_staging_arena.hpp>
+#include <sirius/exception.hpp>
+
+#include <atomic>
+#include <cstdlib>
+#include <limits>
+#include <thread>
+#include <vector>
+
+using sirius::exec::exchange_staging_arena;
+
+namespace {
+constexpr std::uint64_t kMiB = 1u << 20;
+}
+
+// ============================================================================
+// ARENA-1: leases are aligned, and a released gap is immediately reusable
+// ============================================================================
+
+TEST_CASE("ARENA-1: lease/release bookkeeping and gap reuse", "[staging_arena]")
+{
+  exchange_staging_arena arena(kMiB);
+  REQUIRE(arena.capacity() == kMiB);
+  REQUIRE(arena.outstanding() == 0);
+
+  // On a fresh arena, first fit hands out consecutive blocks: each offset advances by the
+  // previous request rounded up to the alignment.
+  auto a = arena.lease(100);
+  auto b = arena.lease(4000);
+  auto c = arena.lease(1);
+  REQUIRE(a == 0);
+  REQUIRE(b == 256);
+  REQUIRE(c == 256 + 4096);
+  REQUIRE(arena.outstanding() == 3);
+
+  // The gap left by a NON-trailing release is immediately reusable -- this is the whole point
+  // of the free list. A bump allocator would place `d` past everything outstanding and leave
+  // b's 4096 bytes unreachable until every lease had been released.
+  arena.release(b);
+  auto d = arena.lease(1);
+  REQUIRE(d == b);  // reuses b's block, address-ordered first fit
+  REQUIRE(arena.outstanding() == 3);
+
+  // The moment nothing is outstanding, the whole arena is free again from the base and fully
+  // coalesced back into a single block.
+  arena.release(a);
+  arena.release(c);
+  arena.release(d);
+  REQUIRE(arena.outstanding() == 0);
+  REQUIRE(arena.live_bytes() == 0);
+  REQUIRE(arena.largest_free() == arena.capacity());
+  REQUIRE(arena.lease(100) == 0);
+  arena.release(0);
+
+  // Peak concurrency, not lifetime total: three leases of 256 + 4096 + 256 were live at once.
+  REQUIRE(arena.peak_live_bytes() == 256 + 4096 + 256);
+}
+
+// ============================================================================
+// ARENA-2: every offset is aligned, and the region is plain device memory
+// ============================================================================
+
+TEST_CASE("ARENA-2: alignment and allocation type", "[staging_arena]")
+{
+  exchange_staging_arena arena(kMiB);
+
+  REQUIRE(arena.base() != 0);
+  REQUIRE(arena.base() % exchange_staging_arena::kAlignment == 0);
+  for (auto len : {1ULL, 255ULL, 256ULL, 257ULL, 4097ULL}) {
+    REQUIRE(arena.lease(len) % exchange_staging_arena::kAlignment == 0);
+  }
+
+  // The transport fast path hinges on this being an ordinary cudaMalloc device allocation —
+  // pool memory would "work" while silently degrading ~220x over UCX cuda_ipc.
+  cudaPointerAttributes attrs{};
+  REQUIRE(cudaPointerGetAttributes(&attrs, reinterpret_cast<void*>(arena.base())) == cudaSuccess);
+  REQUIRE(attrs.type == cudaMemoryTypeDevice);
+}
+
+// ============================================================================
+// ARENA-3: the two refusal paths are distinct and each names what an operator
+// can act on
+// ============================================================================
+
+TEST_CASE("ARENA-3: oversize and exhaustion are separate, actionable errors", "[staging_arena]")
+{
+  exchange_staging_arena arena(4096);
+  auto a = arena.lease(1024);
+
+  // Path 1 -- larger than the arena will EVER be. No amount of waiting or releasing helps, so
+  // this must not be dressed up as "exhausted"; it is a sizing error, named as one.
+  REQUIRE_THROWS_WITH(arena.lease(8192),
+                      Catch::Contains("exceeds") && Catch::Contains("4096 byte capacity"));
+  REQUIRE_THROWS_AS(arena.lease(8192), sirius::invalid_input_exception);
+
+  // Path 2 -- fits the arena, does not fit what is free right now. This one IS transient, and
+  // the message carries the fragmentation split (blocks / largest) plus the env var to raise.
+  REQUIRE_THROWS_WITH(arena.lease(4000),
+                      Catch::Contains("requested 4000") && Catch::Contains("4096 capacity") &&
+                        Catch::Contains("largest") &&
+                        Catch::Contains("SIRIUS_EXCHANGE_STAGING_BYTES"));
+
+  // A refused lease must consume nothing -- checked against live bytes and the free list, so
+  // the assertion cannot be satisfied vacuously by a later full release resetting state.
+  REQUIRE(arena.outstanding() == 1);
+  REQUIRE(arena.live_bytes() == 1024);
+  REQUIRE(arena.total_free() == 4096 - 1024);
+  arena.release(a);
+  REQUIRE(arena.lease(4096) == 0);
+}
+
+// ============================================================================
+// ARENA-4: misuse of lease/release is a defined error
+// ============================================================================
+
+TEST_CASE("ARENA-4: zero-length, unknown, and double release are rejected", "[staging_arena]")
+{
+  exchange_staging_arena arena(kMiB);
+
+  REQUIRE_THROWS_AS(arena.lease(0), sirius::invalid_input_exception);
+
+  auto a = arena.lease(100);
+  REQUIRE_THROWS_AS(arena.release(a + 256), sirius::invalid_input_exception);
+  arena.release(a);
+  REQUIRE_THROWS_WITH(arena.release(a), Catch::Contains("not an outstanding lease"));
+}
+
+// ============================================================================
+// ARENA-5: the unconfigured arena is a loud, named error
+// ============================================================================
+
+TEST_CASE("ARENA-5: require(nullptr) names the configuration knob", "[staging_arena]")
+{
+  REQUIRE_THROWS_WITH(
+    exchange_staging_arena::require(nullptr),
+    Catch::Contains("exchange staging arena not configured (set SIRIUS_EXCHANGE_STAGING_BYTES)"));
+
+  exchange_staging_arena arena(kMiB);
+  REQUIRE(&exchange_staging_arena::require(&arena) == &arena);
+}
+
+// ============================================================================
+// ARENA-6: construction from the environment
+// ============================================================================
+
+TEST_CASE("ARENA-6: from_env honours the byte-suffix parser", "[staging_arena]")
+{
+  const auto* var = exchange_staging_arena::kCapacityEnvVar;
+
+  // setenv/unsetenv mutate the environment of the whole sirius_unittest process. Catch2 runs
+  // cases serially, and the guard restores the unset state even when an assertion fails
+  // mid-case, so no other case (including engine bring-up) can observe the variable.
+  struct unset_on_exit {
+    const char* name;
+    ~unset_on_exit() { unsetenv(name); }
+  } guard{var};
+
+  unsetenv(var);
+  REQUIRE(exchange_staging_arena::from_env() == nullptr);
+
+  setenv(var, "4MiB", 1);
+  auto arena = exchange_staging_arena::from_env();
+  REQUIRE(arena != nullptr);
+  REQUIRE(arena->capacity() == 4 * kMiB);
+
+  setenv(var, "not-a-size", 1);
+  REQUIRE_THROWS_WITH(exchange_staging_arena::from_env(),
+                      Catch::Contains("SIRIUS_EXCHANGE_STAGING_BYTES"));
+
+  setenv(var, "0", 1);
+  REQUIRE_THROWS_AS(exchange_staging_arena::from_env(), sirius::invalid_input_exception);
+}
+
+// ============================================================================
+// ARENA-7: a stuck lease pins only its own block, not the arena above it
+// ============================================================================
+
+// The failure mode this pins: an allocator that only reclaims at zero outstanding turns into a
+// monotonic bump allocator the moment ONE lease is never released — every later query's
+// staging traffic burns arena permanently (observed while developing this allocator: a 1 GiB
+// arena exhausted within ~20 passing queries). The free list makes reclamation structural
+// rather than a special case: a released block goes straight back and coalesces, so traffic
+// above a stuck lease reuses the same space forever no matter what order the releases arrive
+// in.
+TEST_CASE("ARENA-7: a stuck lease does not pin the space above it", "[staging_arena]")
+{
+  exchange_staging_arena arena(4096);
+  auto stuck = arena.lease(256);
+  REQUIRE(stuck == 0);
+
+  // Steady-state traffic: each lease is released after its transmit. Every cycle must land on
+  // the same offset -- address-ordered first fit always returns the lowest block that fits,
+  // and the released block coalesces straight back into it.
+  for (int i = 0; i < 100; ++i) {
+    auto t = arena.lease(2048);
+    REQUIRE(t == 256);
+    arena.release(t);
+  }
+  REQUIRE(arena.outstanding() == 1);
+
+  // Free bytes are back to baseline: everything above the stuck lease is grantable at once.
+  auto big = arena.lease(4096 - 256);
+  REQUIRE(big == 256);
+  arena.release(big);
+
+  // Out-of-order releases coalesce: z and y merge with the tail into one block starting at y.
+  auto x = arena.lease(256);
+  auto y = arena.lease(256);
+  auto z = arena.lease(256);
+  REQUIRE(z == 256 * 3);
+  arena.release(z);
+  arena.release(y);
+  REQUIRE(arena.lease(256) == y);  // first fit lands at the start of the merged block
+  arena.release(y);
+  arena.release(x);
+
+  arena.release(stuck);
+  REQUIRE(arena.outstanding() == 0);
+  REQUIRE(arena.lease(4096) == 0);
+  arena.release(0);
+}
+
+// ============================================================================
+// ARENA-8: capacity conservation — the invariant that makes drift impossible
+// ============================================================================
+TEST_CASE("ARENA-8: free + live == capacity at every step", "[staging_arena]")
+{
+  exchange_staging_arena arena(kMiB);
+  auto check = [&] { REQUIRE(arena.total_free() + arena.live_bytes() == arena.capacity()); };
+
+  check();
+  std::vector<std::uint64_t> held;
+  for (int i = 0; i < 16; ++i) {
+    held.push_back(arena.lease(1000 + i * 137));
+    check();
+  }
+  // Release in an order chosen to be neither LIFO nor FIFO.
+  for (std::size_t i = 0; i < held.size(); ++i) {
+    arena.release(held[(i * 7) % held.size()]);
+    check();
+  }
+  REQUIRE(arena.outstanding() == 0);
+  REQUIRE(arena.live_bytes() == 0);
+  REQUIRE(arena.total_free() == arena.capacity());
+  // Fully coalesced back to one block.
+  REQUIRE(arena.largest_free() == arena.capacity());
+}
+
+// ============================================================================
+// ARENA-9: adjacent frees coalesce, forward and backward
+// ============================================================================
+TEST_CASE("ARENA-9: neighbouring released blocks merge", "[staging_arena]")
+{
+  exchange_staging_arena arena(4096);
+  auto a = arena.lease(1024);
+  auto b = arena.lease(1024);
+  auto c = arena.lease(1024);
+  REQUIRE(arena.largest_free() == 1024);  // only the tail
+
+  // Releasing the middle block alone cannot yet satisfy a 2048 lease.
+  arena.release(b);
+  REQUIRE(arena.largest_free() == 1024);
+
+  // Releasing its successor merges b + c + tail -- coalescing forward.
+  arena.release(c);
+  REQUIRE(arena.largest_free() == 1024 + 1024 + 1024);
+
+  // And backward, back to a single whole-arena block.
+  arena.release(a);
+  REQUIRE(arena.largest_free() == 4096);
+  REQUIRE(arena.total_free() == 4096);
+  REQUIRE(arena.lease(4096) == 0);
+}
+
+// ============================================================================
+// ARENA-10: out-of-order steady state does not drift
+// ============================================================================
+// The defect this pins: with a bump head, every out-of-order release leaves a gap while every
+// new lease advances the head, so the head tracks LIFETIME TOTALS rather than concurrency. A
+// receiver that grants leases concurrently and releases them out of order therefore drifts
+// toward exhaustion no matter how little is actually live. Here 8 leases of 4 KiB are live at
+// any moment — 32 KiB of a 1 MiB arena — and the loop runs 10,000 cycles. A bump allocator
+// exhausts this arena within the first few hundred cycles (measured while developing the free
+// list); the coalescing free list must never throw.
+TEST_CASE("ARENA-10: out-of-order lease/release never drifts", "[staging_arena]")
+{
+  constexpr std::uint64_t kCapacity  = kMiB;
+  constexpr std::uint64_t kLeaseSize = 4096;
+  constexpr int kConcurrent          = 8;
+  constexpr int kCycles              = 10000;
+
+  exchange_staging_arena arena(kCapacity);
+  std::vector<std::uint64_t> live;
+  for (int i = 0; i < kConcurrent; ++i) {
+    live.push_back(arena.lease(kLeaseSize));
+  }
+
+  // Deterministic pseudo-shuffle: release a rotating non-adjacent slot each cycle and
+  // immediately re-lease, so the live set size is constant but the release order is not.
+  std::uint64_t idx = 0;
+  for (int cycle = 0; cycle < kCycles; ++cycle) {
+    idx = (idx + 5) % kConcurrent;  // 5 is coprime with 8: visits every slot, never in order
+    arena.release(live[idx]);
+    live[idx] = arena.lease(kLeaseSize);  // must not throw
+    REQUIRE(arena.live_bytes() == kConcurrent * kLeaseSize);
+    REQUIRE(arena.total_free() + arena.live_bytes() == kCapacity);
+  }
+
+  REQUIRE(arena.outstanding() == kConcurrent);
+  REQUIRE(arena.peak_live_bytes() == kConcurrent * kLeaseSize);
+  for (auto offset : live) {
+    arena.release(offset);
+  }
+  REQUIRE(arena.largest_free() == kCapacity);
+}
+
+// ============================================================================
+// ARENA-11: live leases never alias, verified through the device memory itself
+// ============================================================================
+TEST_CASE("ARENA-11: concurrent leases address disjoint device memory", "[staging_arena]")
+{
+  exchange_staging_arena arena(kMiB);
+  constexpr std::size_t kLen = 4096;
+  std::vector<std::uint64_t> offsets;
+  for (int i = 0; i < 16; ++i) {
+    offsets.push_back(arena.lease(kLen));
+  }
+
+  // Stamp each lease with its own byte pattern...
+  for (std::size_t i = 0; i < offsets.size(); ++i) {
+    auto* p = reinterpret_cast<void*>(arena.base() + offsets[i]);
+    REQUIRE(cudaMemset(p, static_cast<int>(i + 1), kLen) == cudaSuccess);
+  }
+  REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+
+  // ...and read every one back. Any overlap shows up as a wrong pattern.
+  std::vector<unsigned char> host(kLen);
+  for (std::size_t i = 0; i < offsets.size(); ++i) {
+    const auto* p = reinterpret_cast<const void*>(arena.base() + offsets[i]);
+    REQUIRE(cudaMemcpy(host.data(), p, kLen, cudaMemcpyDeviceToHost) == cudaSuccess);
+    REQUIRE(host.front() == static_cast<unsigned char>(i + 1));
+    REQUIRE(host.back() == static_cast<unsigned char>(i + 1));
+  }
+
+  // Release a subset and re-lease: the reused space must still be disjoint from what is live.
+  for (std::size_t i = 0; i < offsets.size(); i += 2) {
+    arena.release(offsets[i]);
+  }
+  std::vector<std::uint64_t> reused;
+  for (std::size_t i = 0; i < offsets.size() / 2; ++i) {
+    reused.push_back(arena.lease(kLen));
+  }
+  for (auto offset : reused) {
+    auto* p = reinterpret_cast<void*>(arena.base() + offset);
+    REQUIRE(cudaMemset(p, 0xEE, kLen) == cudaSuccess);
+  }
+  REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+  // The odd-indexed leases were never released and must be untouched.
+  for (std::size_t i = 1; i < offsets.size(); i += 2) {
+    const auto* p = reinterpret_cast<const void*>(arena.base() + offsets[i]);
+    REQUIRE(cudaMemcpy(host.data(), p, kLen, cudaMemcpyDeviceToHost) == cudaSuccess);
+    REQUIRE(host.front() == static_cast<unsigned char>(i + 1));
+  }
+}
+
+// ============================================================================
+// ARENA-12: the allocator is safe under concurrent lease/release
+// ============================================================================
+// `lease`/`release` will be called from transport, RPC and engine threads concurrently, so the
+// mutex contract is pinned here rather than discovered in production.
+TEST_CASE("ARENA-12: concurrent lease/release keeps its invariants", "[staging_arena]")
+{
+  exchange_staging_arena arena(8 * kMiB);
+  constexpr int kThreads = 8;
+  constexpr int kIters   = 2000;
+  std::atomic<int> failures{0};
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&arena, &failures] {
+      for (int i = 0; i < kIters; ++i) {
+        try {
+          auto a = arena.lease(1024);
+          auto b = arena.lease(4096);
+          if (a % exchange_staging_arena::kAlignment != 0) { ++failures; }
+          if (a == b) { ++failures; }
+          arena.release(a);
+          arena.release(b);
+        } catch (const std::exception&) {
+          ++failures;  // an 8 MiB arena with 8 threads x 5 KiB must never exhaust
+        }
+      }
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+
+  REQUIRE(failures.load() == 0);
+  REQUIRE(arena.outstanding() == 0);
+  REQUIRE(arena.live_bytes() == 0);
+  REQUIRE(arena.largest_free() == arena.capacity());
+}
+
+// ============================================================================
+// ARENA-13: an oversized request is refused, not wrapped
+// ============================================================================
+TEST_CASE("ARENA-13: align_up overflow cannot alias a live lease", "[staging_arena]")
+{
+  exchange_staging_arena arena(kMiB);
+  auto live = arena.lease(1024);
+
+  // align_up wraps to 0 for these; without the guard the request would slip past the fit scan
+  // and register a zero-length lease that aliases whatever is allocated next.
+  REQUIRE_THROWS_AS(arena.lease(std::numeric_limits<std::uint64_t>::max()),
+                    sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(arena.lease(std::numeric_limits<std::uint64_t>::max() - 100),
+                    sirius::invalid_input_exception);
+  REQUIRE_THROWS_AS(arena.lease(2 * kMiB), sirius::invalid_input_exception);
+
+  REQUIRE(arena.outstanding() == 1);
+  REQUIRE(arena.live_bytes() == 1024);
+  arena.release(live);
+}


### PR DESCRIPTION
## Description

**Motivation.** Sirius can already split a query into fragments and hand batches from one to the
next, but only inside one process (`Fragment::relay_from`, #1481). With one compute node per GPU, a
fragment boundary has to cross a process and a device, so the transport needs a stable device
address to write into and read from. That address cannot live in the RMM pool. UCX's `cuda_ipc`
path cannot export `cudaMallocAsync` stream-ordered pool allocations and silently degrades ~220x
to staged host copies. The bytes stay correct, no error is raised, and nothing but a bandwidth
measurement notices. That failure mode is why I made this a second, dedicated device allocator
outside every RMM/cudf pool instead of a pool tag.

**What changed.** One reviewable unit, a pure allocator and its tests.

- `sirius::exec::exchange_staging_arena`, in `src/include/exec/exchange_staging_arena.hpp` and
  `src/exec/exchange_staging_arena.cpp`. It is one plain `cudaMalloc` device region, and
  `from_env()` sizes it from `SIRIUS_EXCHANGE_STAGING_BYTES`. Unset means no arena, and `require()`
  then turns every staging call into a loud error that names the variable instead of a slow path.
  Leases come from an address-ordered, coalescing free list under a mutex. Because `release` merges
  forward and backward, released space is reusable in any release order, there is no bump head and
  no drift, and capacity bounds concurrently live bytes rather than lifetime totals. Every lease is
  256-byte aligned and contiguous, which makes it a valid RDMA target and a valid `cudf::unpack`
  source. When the arena runs out, the error reports total free and largest free block, whose gap
  is the external fragmentation, and names the env var. A request larger than the whole arena is a
  different mistake than a full one, so it gets its own error rather than being folded into the
  exhaustion path. `lease` also guards `align_up` overflow, because a peer will supply that length
  over the wire once a transport sits on top. The constructor logs the granted size and the
  destructor logs peak live bytes plus any leaked leases. Those two lines are the only sizing
  feedback for a slab that no pool accounting sees.
- Opt-in fabric path. `SIRIUS_EXCHANGE_STAGING_ARENA=fabric` swaps `cudaMalloc` for a CUDA
  driver-API VMM allocation: `cuMemCreate` with `CU_MEM_HANDLE_TYPE_FABRIC`, then
  `cuMemAddressReserve`, `cuMemMap` and `cuMemSetAccess`. This is the first use of the driver API in
  Super Sirius proper. It links through the `CUDA::cuda_driver` dependency `simpatico` already
  exports, so no CMake change. You only need it when peers live on different hosts. `cudaMalloc`'s
  IPC handle is node-local, and a cross-host exchange over it measured 0.32 to 0.43 GB/s as a host
  bounce, against the 765 GB/s a standalone test program measured for a fabric handle over MNNVL on
  a two-host GB200 pair. The fabric path needs a live IMEX domain and
  `/dev/nvidia-caps-imex-channels`; without them `cuMemCreate` fails loudly at bring-up. The tests
  do not exercise this path, since there is no MNNVL/IMEX CI runner. The default `cudamalloc` path
  is the one every single-host deployment uses.
- `CMakeLists.txt` adds the source to `EXTENSION_SOURCES` and the test to `TEST_SOURCES`.
- `docs/super-sirius/configuration.md` gains an "Exchange Staging Arena" subsection that documents
  both environment variables next to the other `SIRIUS_*` env-var docs, plus a Key Files row.

**Configuration changes.** Two new process-environment variables, read once at bring-up.
`SIRIUS_EXCHANGE_STAGING_BYTES` takes the byte suffixes `sirius::yaml::parse_bytes` accepts. Unset
means no arena, and `0` or an unparsable value is rejected. `SIRIUS_EXCHANGE_STAGING_ARENA` is
`cudamalloc` by default, or `fabric`. Neither is a `sirius_config` YAML key or a `SET` variable.

**Tests.** 13 Catch2 cases tagged `[staging_arena]` in `test/cpp/exec/test_exchange_staging_arena.cpp`.
All of them need a GPU, since the constructor calls `cudaMalloc` and the cases use
`cudaPointerGetAttributes`, `cudaMemset` and `cudaMemcpy`. The cases that matter most:

- ARENA-8 asserts `free + live == capacity` after every operation.
- ARENA-10 runs 10,000 out-of-order lease/release cycles with 8 leases live and asserts no drift.
  A bump allocator exhausts the same 1 MiB arena within a few hundred cycles.
- ARENA-7 pins that a never-released lease blocks only its own block.
- ARENA-9 pins forward and backward coalescing.
- ARENA-11 stamps and reads back device bytes to prove live leases are disjoint.
- ARENA-12 runs 8 threads x 2000 iterations.
- ARENA-13 pins the `align_up` overflow guard.
- ARENA-3 pins that oversize and exhausted are two distinct errors, ARENA-4 pins misuse, and
  ARENA-5 pins the unconfigured message.
- ARENA-6 covers `from_env`. It sets and unsets the env var process-wide, and an RAII guard
  restores the unset state even on assertion failure.

**How I tested it.** On a GB200 box (aarch64) I did a full release build with pixi, ran the Catch2
tag `[staging_arena]` on a GPU, where all 13 cases pass, and checked the new configuration doc with
rumdl. Every one of those tests needs a GPU, so CI does not run them, and the fabric path has no test
at all since there is no MNNVL/IMEX runner.

**Intentionally not handled.** There is no in-tree consumer yet. Nothing on `dev` constructs the
arena or takes a lease. Three pieces follow in the `ffi` stack on `stacked/ffi-exchange-staging`,
gated on this PR: the Fragment FFI layer that packs a batch straight into a lease with
`cudf::chunked_pack` and unpacks on arrival, the `StagingArena` handle for embedders, and the Rust
bindings. The transport and compute-node wiring follow that. Two design questions stay open for
the follow-ups: whether the two env vars become YAML keys, and whether the arena's bytes get
exposed to pool accounting. Supersedes the arena portion of the old draft #1644; its remaining
pieces are re-cut as separate PRs.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
Supersedes the exchange-staging-arena part of draft #1644, which is being closed and re-cut.
Refs #1481, the in-process `Fragment::relay_from` hop that this arena lets cross a process boundary.