### PR TITLE
feat(exec): declare stream input cardinality to DuckDB's optimizer

### DIFF
--- a/docs/super-sirius/streaming-fragments.md
+++ b/docs/super-sirius/streaming-fragments.md
@@ -79,6 +79,7 @@ class stream_bind_catalog : public duckdb::ClientContextState {
   void erase(stream_id_t id);                                   // drop one; no-op if absent
 
   const stream_input_binding& get(stream_id_t id) const;        // @throws if undeclared
+  std::optional<std::uint64_t> estimated_rows(stream_id_t id) const;  // nullopt if undeclared
   void set_built(stream_id_t id, op::sirius_physical_streaming_source* built);
 };
 
@@ -119,6 +120,18 @@ otherwise return anything the fragment layer can see) gets back to the session t
   up registered with the session, so the earlier one never receives a push or a close and its
   pipeline waits forever with no error anywhere. Fan-out reads of one declared stream are not
   supported; if a plan genuinely needs that, feed each reader its own stream id instead.
+- **Declaring a stream's row count is optional, and the optimizer only sees it if you do.** A
+  `sirius_stream_source` relation has no rows behind it at bind time, so on its own DuckDB
+  estimates cardinality 1 for every input stream and picks hash-join build sides blind at every
+  fragment boundary. `stream_input_spec::estimated_rows` (forwarded into
+  `stream_input_binding::estimated_rows` by `build()`) lets the caller declare the count; the
+  table function's `cardinality` callback (`stream_source_cardinality`) reads it back through
+  `stream_bind_catalog::estimated_rows(id)` and feeds `LogicalGet::EstimateCardinality`, which is
+  what `create_streaming_source_plan()` already consumes for the `STREAMING_SOURCE` operator's
+  `estimated_cardinality`. Undeclared (`nullopt`) means the callback returns `nullptr` and the
+  optimizer keeps its default (cardinality 1) — exactly the pre-existing behavior. The reader
+  never throws, unlike `get()`, because DuckDB may ask for cardinality outside the window where a
+  fragment's declarations are alive.
 - **The catalog must exist before any bind can succeed.** Both the transparent (normal SQL)
   connection path and the FFI's own embedded connection install a `stream_bind_catalog` when the
   connection opens — `SiriusContextExtensionCallback::OnConnectionOpened` for the former,
@@ -132,6 +145,13 @@ Owns one fragment's complete life cycle: declares inputs into the catalog, plans
 sink, runs, and keeps the output pullable after `run()` returns.
 
 ```cpp
+struct stream_input_spec {
+  std::vector<std::string> names;
+  duckdb::vector<sirius::logical_type> types;
+  std::set<sender_id_t> expected_senders;             // sender-set EOS
+  std::optional<std::uint64_t> estimated_rows;        // optional: declared row count (optimizer)
+};
+
 struct fragment_spec {
   logical_plan_source plan_source;                    // ClientContext& -> LogicalOperator
   std::map<stream_id_t, stream_input_spec> inputs;     // schema + expected senders per input

--- a/src/exec/stream_bind_catalog.cpp
+++ b/src/exec/stream_bind_catalog.cpp
@@ -81,6 +81,14 @@ const stream_input_binding& stream_bind_catalog::get(stream_id_t id) const
   return it->second;
 }
 
+std::optional<std::uint64_t> stream_bind_catalog::estimated_rows(stream_id_t id) const
+{
+  std::lock_guard<std::mutex> guard(_mutex);
+  auto it = _entries.find(id);
+  if (it == _entries.end()) { return std::nullopt; }
+  return it->second.estimated_rows;
+}
+
 void stream_bind_catalog::set_built(stream_id_t id, op::sirius_physical_streaming_source* built)
 {
   std::lock_guard<std::mutex> guard(_mutex);

--- a/src/exec/stream_plan_bindings.cpp
+++ b/src/exec/stream_plan_bindings.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/storage/statistics/node_statistics.hpp"
 #include "helper/type_conversions.hpp"
 #include "sirius/exception.hpp"
 
@@ -64,6 +65,30 @@ void stream_source_function(duckdb::ClientContext&, duckdb::TableFunctionInput&,
     "streaming input and is only valid inside a GPU-executed fragment plan");
 }
 
+/// Reports the caller-declared row count of a stream to DuckDB's optimizer
+/// (LogicalGet::EstimateCardinality consumes it, feeding both the join-order optimizer's base
+/// relation stats and the build/probe-side flip). Without it every stream source estimates
+/// cardinality 1, so a receiver fragment's hash joins pick build sides blind — the q07 2-CN
+/// regression built on a multi-GB lineitem-derived stream instead of a 2-row nation stream.
+///
+/// nullptr (= "no estimate, keep today's behavior") whenever anything is missing: no catalog on
+/// the connection, no bind data, an undeclared stream, or a declaration without a row count.
+/// Never throws — DuckDB may ask for cardinality outside the window where the fragment's
+/// declarations are alive.
+duckdb::unique_ptr<duckdb::NodeStatistics> stream_source_cardinality(
+  duckdb::ClientContext& context, const duckdb::FunctionData* bind_data)
+{
+  if (bind_data == nullptr) { return nullptr; }
+  auto const* bind = dynamic_cast<const stream_source_bind_data*>(bind_data);
+  if (bind == nullptr) { return nullptr; }
+  if (!context.registered_state) { return nullptr; }
+  auto catalog = context.registered_state->Get<stream_bind_catalog>(stream_bind_catalog::kStateKey);
+  if (!catalog) { return nullptr; }
+  auto const rows = catalog->estimated_rows(bind->stream_id);
+  if (!rows.has_value()) { return nullptr; }
+  return duckdb::make_uniq<duckdb::NodeStatistics>(static_cast<duckdb::idx_t>(*rows));
+}
+
 }  // namespace
 
 void register_stream_source_function(duckdb::DatabaseInstance& instance)
@@ -75,6 +100,7 @@ void register_stream_source_function(duckdb::DatabaseInstance& instance)
                                       {duckdb::LogicalType::BIGINT},
                                       stream_source_function,
                                       stream_source_bind);
+  stream_source.cardinality = stream_source_cardinality;
 
   duckdb::CreateTableFunctionInfo info(stream_source);
   // Idempotent: extension callback and explicit callers may both register.

--- a/src/exec/streaming_fragment.cpp
+++ b/src/exec/streaming_fragment.cpp
@@ -136,10 +136,13 @@ void streaming_fragment::build(sirius::query_id_t query_id)
 
   // Declare before planning: bind resolves schema; create_plan reads repo + senders.
   for (const auto& [id, input] : _spec.inputs) {
-    catalog->declare(
-      id,
-      stream_input_binding{
-        input.names, input.types, _input_repos.at(id), input.expected_senders, nullptr});
+    catalog->declare(id,
+                     stream_input_binding{input.names,
+                                          input.types,
+                                          _input_repos.at(id),
+                                          input.expected_senders,
+                                          nullptr,
+                                          input.estimated_rows});
   }
 
   auto logical_plan = _spec.plan_source(_context);

--- a/src/include/exec/stream_bind_catalog.hpp
+++ b/src/include/exec/stream_bind_catalog.hpp
@@ -21,9 +21,11 @@
 #include "exec/stream_session.hpp"
 #include "op/sirius_physical_streaming_source.hpp"
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -39,6 +41,13 @@ struct stream_input_binding {
 
   /// Back-pointer into the engine-owned plan; filled during planning for session registration.
   op::sirius_physical_streaming_source* built = nullptr;
+
+  /// Caller-declared row count for this stream (exact when the sender already parked/staged its
+  /// batches, an estimate otherwise). Reported to DuckDB's optimizer through the stream-source
+  /// TableFunction's cardinality callback so join order / build-side selection can see stream
+  /// sizes. nullopt = undeclared: the optimizer falls back to its default (cardinality 1).
+  /// Kept as the last member so existing positional brace-inits keep compiling unchanged.
+  std::optional<std::uint64_t> estimated_rows;
 };
 
 /// Per-connection declared input streams. ClientContextState so DuckDB bind can resolve schema
@@ -65,6 +74,12 @@ class stream_bind_catalog : public duckdb::ClientContextState {
 
   /// @throws sirius::invalid_input_exception when `id` was never declared.
   [[nodiscard]] const stream_input_binding& get(stream_id_t id) const;
+
+  /// The declared row count of `id`, or nullopt when the stream is undeclared or was declared
+  /// without one. Non-throwing on purpose: this feeds the TableFunction cardinality callback,
+  /// which DuckDB may invoke at any point in a plan's lifetime — a missing declaration there
+  /// must mean "no estimate", never a bind error.
+  [[nodiscard]] std::optional<std::uint64_t> estimated_rows(stream_id_t id) const;
 
   /// @throws sirius::invalid_input_exception when `id` was never declared, or when it already
   ///         has a built operator (the same declared stream read by more than one plan leaf —

--- a/src/include/exec/streaming_fragment.hpp
+++ b/src/include/exec/streaming_fragment.hpp
@@ -24,6 +24,7 @@
 #include <duckdb/main/client_context.hpp>
 #include <duckdb/planner/logical_operator.hpp>
 
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
@@ -43,6 +44,9 @@ struct stream_input_spec {
   duckdb::vector<sirius::logical_type> types;
   /// Sender-set EOS: stream ends only once all have closed.
   std::set<sender_id_t> expected_senders;
+  /// Optional caller-declared row count, forwarded to the bind catalog so DuckDB's optimizer
+  /// can size the stream (see stream_input_binding::estimated_rows). nullopt = undeclared.
+  std::optional<std::uint64_t> estimated_rows;
 };
 
 /// Bound, optimized DuckDB logical plan (Substrait bytes, SQL, …).

--- a/test/cpp/exec/test_stream_bind_catalog.cpp
+++ b/test/cpp/exec/test_stream_bind_catalog.cpp
@@ -22,7 +22,9 @@
 #include <helper/type_conversions.hpp>
 #include <sirius/exception.hpp>
 
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <set>
 #include <vector>
 
@@ -250,4 +252,39 @@ TEST_CASE("stream_bind_catalog CAT-9: no catalog on the connection is an error",
 
   auto prepared = con.Prepare("SELECT * FROM sirius_stream_source(0)");
   REQUIRE(prepared->HasError());
+}
+
+// ============================================================================
+// CAT-10: the optional declared row count round-trips through the catalog
+// ============================================================================
+
+TEST_CASE("stream_bind_catalog CAT-10: estimated_rows is optional and non-throwing",
+          "[stream_bind_catalog]")
+{
+  stream_bind_catalog catalog;
+
+  // Undeclared id: nullopt, not a throw — this feeds the TableFunction cardinality callback,
+  // which DuckDB may invoke after a fragment erased its declarations.
+  REQUIRE_FALSE(catalog.estimated_rows(7).has_value());
+
+  // Declared without a count: still nullopt (today's behavior for callers that never declare).
+  catalog.declare(7, make_binding());
+  REQUIRE_FALSE(catalog.estimated_rows(7).has_value());
+
+  // Declared with a count: the value comes back verbatim.
+  auto binding           = make_binding();
+  binding.estimated_rows = 123456;
+  catalog.declare(7, std::move(binding));
+  REQUIRE(catalog.estimated_rows(7) == std::optional<std::uint64_t>{123456});
+
+  // Redeclaration replaces the whole binding, count included.
+  catalog.declare(7, make_binding());
+  REQUIRE_FALSE(catalog.estimated_rows(7).has_value());
+
+  // erase() drops it with the declaration.
+  binding                = make_binding();
+  binding.estimated_rows = 2;
+  catalog.declare(8, std::move(binding));
+  catalog.erase(8);
+  REQUIRE_FALSE(catalog.estimated_rows(8).has_value());
 }

--- a/test/cpp/exec/test_streaming_fragment.cpp
+++ b/test/cpp/exec/test_streaming_fragment.cpp
@@ -33,6 +33,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -501,6 +502,156 @@ TEST_CASE_METHOD(fragment_fixture,
                             << " tasks_completed=" << completed);
 
     REQUIRE(drain_values(receiver, 1) == std::vector<std::int32_t>{1, 2, 3, 4, 5, 6});
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}
+
+// ============================================================================
+// FRAG-10: declared stream cardinalities steer the hash-join build side.
+// A stream source binds with no backing rows, so without a declared count
+// DuckDB's optimizer sees cardinality 1 on every stream and picks build sides
+// blind — on the 2-CN q07 it built on a multi-GB lineitem-derived stream while
+// the 2-row nation stream probed (14.8s -> 164s at SF500). The receiver's CN
+// already holds every input before build(), so it can declare exact counts;
+// this pins that a declared tiny stream becomes the build side (children[1],
+// DuckDB's convention) in BOTH directions, and that the undeclared path still
+// plans and runs (backward compatibility).
+// ============================================================================
+
+namespace {
+
+sirius::op::sirius_physical_operator* find_first_hash_join(
+  sirius::op::sirius_physical_operator& node)
+{
+  if (node.type == sirius::op::SiriusPhysicalOperatorType::HASH_JOIN) { return &node; }
+  for (auto& child : node.children) {
+    if (auto* join = find_first_hash_join(*child)) { return join; }
+  }
+  return nullptr;
+}
+
+bool subtree_contains(const sirius::op::sirius_physical_operator& node,
+                      const sirius::op::sirius_physical_operator* target)
+{
+  if (&node == target) { return true; }
+  for (const auto& child : node.children) {
+    if (subtree_contains(*child, target)) { return true; }
+  }
+  return false;
+}
+
+}  // namespace
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-10: declared stream cardinalities pick the hash-join build side",
+                 "[integration][streaming_fragment][stream_cardinality]")
+{
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  constexpr const char* kJoinQuery =
+    "SELECT l.a, r.b FROM sirius_stream_source(0) l JOIN sirius_stream_source(1) r ON l.a = r.b";
+
+  // The declared counts alone drive the optimizer; the actual pushed volume (5 rows per side)
+  // never reaches the planner. Both directions are covered so the assertion cannot pass by the
+  // optimizer's accidental default order.
+  std::optional<stream_id_t> small_stream;
+  SECTION("stream 1 declared tiny -> stream 1 builds") { small_stream = 1; }
+  SECTION("stream 0 declared tiny -> stream 0 builds") { small_stream = 0; }
+  SECTION("no declared cardinality still plans and runs") { small_stream = std::nullopt; }
+
+  con->BeginTransaction();
+  try {
+    auto make_sender = [&]() {
+      fragment_spec spec;
+      spec.plan_source = sirius::test::sql_plan_source(kLeafQuery);
+      spec.outputs     = {0};
+      return std::make_unique<streaming_fragment>(*con->context, std::move(spec));
+    };
+
+    auto int_types = [] {
+      return sirius::from_duckdb_vec(
+        duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER});
+    };
+
+    auto left  = make_sender();
+    auto right = make_sender();
+    for (auto* sender : {left.get(), right.get()}) {
+      query_window sender_window(*sirius_ctx, *con->context, "frag10_sender");
+      sender->build(sender_window.query_id());
+      sender->run();
+      sender_window.finish();
+    }
+
+    fragment_spec receiver_spec;
+    receiver_spec.plan_source = sirius::test::sql_plan_source(kJoinQuery);
+    receiver_spec.inputs[0]   = stream_input_spec{{"a"}, int_types(), {0}, std::nullopt};
+    receiver_spec.inputs[1]   = stream_input_spec{{"b"}, int_types(), {0}, std::nullopt};
+    if (small_stream.has_value()) {
+      stream_id_t const big_stream                       = *small_stream == 1 ? 0 : 1;
+      receiver_spec.inputs[*small_stream].estimated_rows = 2;
+      receiver_spec.inputs[big_stream].estimated_rows    = 100'000;
+    }
+    receiver_spec.outputs = {2};
+    streaming_fragment receiver(*con->context, std::move(receiver_spec));
+
+    query_window receiver_window(*sirius_ctx, *con->context, "frag10_receiver");
+    receiver.build(receiver_window.query_id());
+
+    // Plan-shape assertion, straight off the built physical tree: DuckDB's build side is the
+    // join's second child, and it must be the subtree reading the stream declared tiny.
+    auto* root = receiver.engine().sirius_physical_plan.get();
+    REQUIRE(root != nullptr);
+    auto* join = find_first_hash_join(*root);
+    REQUIRE(join != nullptr);
+    REQUIRE(join->children.size() == 2);
+    if (small_stream.has_value()) {
+      stream_id_t const big_stream = *small_stream == 1 ? 0 : 1;
+      // catalog_for, not the fixture's member: the transparent path already registered a catalog
+      // when the connection opened (RegisteredStateManager::Insert never overwrites), so the
+      // fixture's own object is only a fallback and the fragment binds through the live one.
+      auto live_catalog  = catalog_for(*con->context);
+      auto* small_source = live_catalog->get(*small_stream).built;
+      auto* big_source   = live_catalog->get(big_stream).built;
+      REQUIRE(small_source != nullptr);
+      REQUIRE(big_source != nullptr);
+      // The declared counts must have reached the lowered sources verbatim...
+      REQUIRE(small_source->estimated_cardinality == 2);
+      REQUIRE(big_source->estimated_cardinality == 100'000);
+      // ...and flipped the build side onto the tiny stream.
+      REQUIRE(subtree_contains(*join->children[1], small_source));
+      REQUIRE(subtree_contains(*join->children[0], big_source));
+    } else {
+      // The pre-fix blindness this feature exists for, pinned as documentation: with nothing
+      // declared, every stream source estimates cardinality 1 and the optimizer cannot tell a
+      // 2-row nation stream from a multi-GB lineitem stream.
+      auto live_catalog = catalog_for(*con->context);
+      REQUIRE(live_catalog->get(0).built->estimated_cardinality <= 1);
+      REQUIRE(live_catalog->get(1).built->estimated_cardinality <= 1);
+    }
+
+    // The plan is not just well-shaped — it still runs and joins correctly. CN arrival order:
+    // all pushes, then all closes, then run().
+    for (auto [sender, stream] :
+         {std::pair{left.get(), stream_id_t{0}}, std::pair{right.get(), stream_id_t{1}}}) {
+      std::size_t relayed = 0;
+      while (auto batch = sender->session().pull(0)) {
+        REQUIRE(receiver.session().push(stream, *batch));
+        ++relayed;
+      }
+      REQUIRE(relayed > 0);
+      receiver.session().close_input(stream, 0);
+    }
+
+    receiver.run();
+    receiver_window.finish();
+
+    // Both sides carry 1..5, so the equi-join yields exactly the 5 matches whichever side built.
+    REQUIRE(drain_row_count(receiver, 2) == kLeafRows);
 
     con->Rollback();
   } catch (...) {


### PR DESCRIPTION
## Description

**Why.** A `sirius_stream_source` relation has no rows behind it at bind time, so DuckDB's optimizer estimates cardinality 1 for every stream input of a fragment. `create_streaming_source_plan()` already asks `op.EstimateCardinality(context)` for the `STREAMING_SOURCE` operator. It never gets a real answer. So at every fragment boundary the optimizer picks join order and the hash-join build/probe side blind. On the two-CN TPC-H q07 the receiver fragment built its hash table on a multi-GB lineitem-derived stream while a 2-row nation stream probed, 14.8 s -> 164 s at SF500. With one CN per GPU every non-leaf fragment input is an exchange stream, so the blindness grows with GPU count.

**What changed.** One reviewable unit, C++ engine only, no FFI or Rust files.

`stream_input_spec::estimated_rows` and `stream_input_binding::estimated_rows` are both `std::optional<std::uint64_t>`, and `streaming_fragment::build()` forwards the spec's value into the binding. I appended both as the last member so every existing positional brace-init compiles untouched, including the one in `src/sirius_ffi.cpp`.

`stream_bind_catalog::estimated_rows(id)` is a new reader. Unlike `get()` it never throws, and that is deliberate. DuckDB may ask for cardinality outside the window where a fragment's declarations are alive, and a missing declaration there has to mean "no estimate", never a bind error.

`stream_source_cardinality()` in `src/exec/stream_plan_bindings.cpp` becomes `sirius_stream_source`'s `TableFunction::cardinality`. When a count is declared it returns `NodeStatistics(rows)`. In every other case it returns `nullptr`: no bind data, wrong bind type, no registered state, no catalog on the connection, undeclared stream, declaration without a count. The `nullptr` path is bit-for-bit today's behaviour. For the catalog lookup I used `registered_state->Get<>` rather than `catalog_for()`, because `catalog_for()` throws. The wiring is one line, `stream_source.cardinality = stream_source_cardinality;`, the same shape as `sirius_read_parquet.cardinality = SiriusReadParquetCardinality` in `src/sirius_extension.cpp`.

Two tests. `stream_bind_catalog CAT-10` pins the accessor contract: nullopt for an undeclared id and for a declaration without a count, verbatim round-trip, replacement on redeclare, drop on erase.

`FRAG-10`, tagged `[integration][streaming_fragment][stream_cardinality]`, builds a two-stream equi-join fragment. It asserts on the built physical tree that the declared counts, 2 and 100'000, reach the lowered `STREAMING_SOURCE` operators verbatim, and that the tiny stream lands under `join->children[1]`, DuckDB's build side. Two SECTIONs swap which stream is the tiny one, so the test cannot pass on the optimizer's accidental default order. A third SECTION pins that the undeclared path still plans, runs, and estimates `<= 1` on both sources. Every section then pushes, closes, calls `run()` and checks the join's 5 rows. FRAG-10 needs a GPU and `test/cpp/integration/data`, so it does not run in a no-GPU lane. CAT-10 is the only signal there.

Docs in `docs/super-sirius/streaming-fragments.md`: the new method in the `stream_bind_catalog` snippet, a new `stream_input_spec` snippet showing the field, and one Contracts bullet. The struct snippet is new; the doc did not show `stream_input_spec` before this PR. The bullet says undeclared keeps the optimizer's default and declared feeds the count to `LogicalGet::EstimateCardinality`.

This is additive and opt-in. Nothing in this tree declares a count yet, so no plan changes until a caller does.

**How I tested it.** On a GB200 box (aarch64) I did a full release build, then ran the Catch2 tags `[stream_bind_catalog]` and `[streaming_fragment]` on a GPU. All 17 test cases pass, two of them new. FRAG-10 needs a GPU and the integration data, so CI's no-GPU lane only exercises CAT-10. The docs file also passed the rumdl markdown check.

**Intentionally not handled here.** I left out the FFI entry points `Fragment::declare_input_cardinality` and `output_row_count`, the Rust bindings, and the StarRocks CN code that sums local parked plus remote staged rows and declares the count before `build()`. Those land in later PRs of the fragment/CN stack, which build on this one. FRAG-10 also omits the fork version's `SIRIUS_QUERY_WATCHDOG_SECS` hang backstop because the engine-side watchdog it drives is not on `dev`; that PR restores it. This PR stands alone on `dev`. The next layer, the FFI, adds the declaration entry points on `sirius::ffi::Fragment`.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
- Supersedes the C++ engine half of fork commit aocsa/sirius@55e63371 (`feat/pin-table-cn`). No prior upstream draft PR covered this ground. The FFI, Rust, and CN halves follow as stacked PRs.
- Refs #1481, the streaming fragment PR that added the plan builder, blocking runner, and Fragment FFI. It introduced `stream_bind_catalog`, `sirius_stream_source`, and the `create_streaming_source_plan()` `EstimateCardinality` call this PR feeds.