### PR TITLE
fix(ffi): own a transaction while lowering a fragment's Substrait plan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -942,7 +942,13 @@ target_include_directories(
     # landed.
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/compression/simpatico_codegen/include>
     $<$<BOOL:${SIRIUS_LEGACY_INCLUDE_DIR}>:$<BUILD_INTERFACE:${SIRIUS_LEGACY_INCLUDE_DIR}>>
-)
+    # test/cpp/exec/test_sirius_ffi_fragment.cpp builds the Substrait plan it
+    # hands to Fragment::build() with the bundled protobuf (substrait/*.pb.h):
+    # the same two header roots from_substrait.hpp needs on the extension
+    # targets above. The generated code itself is already linked in through
+    # sirius_extension.
+    ${SIRIUS_SUBSTRAIT_DIR}/third_party
+    ${SIRIUS_SUBSTRAIT_DIR}/third_party/substrait)
 
 target_link_libraries(sirius_unittest sirius_extension duckdb_static ZLIB::ZLIB)
 link_extension_libraries(sirius_unittest "")

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -20,6 +20,7 @@
 
 #include "sirius_ffi.hpp"
 
+#include "config.hpp"                                      // duckdb::Config (LOG_* knobs)
 #include "core_functions_extension.hpp"                    // duckdb::CoreFunctionsExtension
 #include "data/sirius_converter_registry.hpp"              // sirius::converter_registry
 #include "duckdb/common/arrow/result_arrow_wrapper.hpp"    // duckdb::ResultArrowArrayStreamWrapper
@@ -46,6 +47,7 @@
 #include "sirius_context.hpp"                          // duckdb::SiriusContext
 #include "sirius_interface.hpp"  // sirius::sirius_interface, sirius::sirius_prepared_statement_data
 
+#include <cstdlib>  // std::getenv
 #include <map>
 #include <set>
 
@@ -70,29 +72,50 @@ lowered_plan lower_substrait(duckdb::Connection& conn, const std::string& substr
 {
   auto& client = *conn.context;
 
-  duckdb::SubstraitToDuckDB transformer(conn.context, substrait_plan, /*json=*/false);
-  auto relation = transformer.TransformPlan();
+  // Substrait transformation and planning both bind against the catalog, and every catalog lookup
+  // goes through TransactionContext::ActiveTransaction(). DuckDB 1.5.5 throws there when no
+  // transaction is open ("TransactionContext::ActiveTransaction called without active
+  // transaction"); 1.5.4 tolerated it. Fragment::build() commits its view-creation transaction
+  // before opening the StandaloneQueryScope, so by the time we are called there is usually none.
+  //
+  // Own one only if the caller has not already opened it — the single-shot path in
+  // execute_substrait() begins its own and expects to still own it on return.
+  //
+  // ClientContext::transaction, NOT Connection::BeginTransaction(): the latter runs
+  // Query("BEGIN TRANSACTION"), an ordinary statement that would take the lifecycle mutex the
+  // enclosing StandaloneQueryScope already holds.
+  const bool owned_transaction = !client.transaction.HasActiveTransaction();
+  if (owned_transaction) { client.transaction.BeginTransaction(); }
 
-  duckdb::Planner planner(client);
-  planner.CreatePlan(duckdb::make_uniq<duckdb::RelationStatement>(relation));
+  try {
+    duckdb::SubstraitToDuckDB transformer(conn.context, substrait_plan, /*json=*/false);
+    auto relation = transformer.TransformPlan();
 
-  auto prepared =
-    duckdb::make_shared_ptr<duckdb::PreparedStatementData>(duckdb::StatementType::SELECT_STATEMENT);
-  prepared->names     = planner.names;
-  prepared->types     = planner.types;
-  prepared->value_map = std::move(planner.value_map);
+    duckdb::Planner planner(client);
+    planner.CreatePlan(duckdb::make_uniq<duckdb::RelationStatement>(relation));
 
-  auto logical_plan = std::move(planner.plan);
-  if (client.config.enable_optimizer) {
-    duckdb::Optimizer optimizer(*planner.binder, client);
-    logical_plan = optimizer.Optimize(std::move(logical_plan));
+    auto prepared = duckdb::make_shared_ptr<duckdb::PreparedStatementData>(
+      duckdb::StatementType::SELECT_STATEMENT);
+    prepared->names     = planner.names;
+    prepared->types     = planner.types;
+    prepared->value_map = std::move(planner.value_map);
+
+    auto logical_plan = std::move(planner.plan);
+    if (client.config.enable_optimizer) {
+      duckdb::Optimizer optimizer(*planner.binder, client);
+      logical_plan = optimizer.Optimize(std::move(logical_plan));
+    }
+    logical_plan->ResolveOperatorTypes();
+    duckdb::ColumnBindingResolver resolver;
+    duckdb::ColumnBindingResolver::Verify(*logical_plan);
+    resolver.VisitOperator(*logical_plan);
+
+    if (owned_transaction) { client.transaction.Commit(); }
+    return {std::move(prepared), std::move(logical_plan)};
+  } catch (...) {
+    if (owned_transaction) { client.transaction.Rollback(nullptr); }
+    throw;
   }
-  logical_plan->ResolveOperatorTypes();
-  duckdb::ColumnBindingResolver resolver;
-  duckdb::ColumnBindingResolver::Verify(*logical_plan);
-  resolver.VisitOperator(*logical_plan);
-
-  return {std::move(prepared), std::move(logical_plan)};
 }
 
 }  // namespace
@@ -108,6 +131,21 @@ struct Context::Impl {
 
   void bring_up(sirius::sirius_config& config)
   {
+    // The extension path installs the engine log sink from SiriusContextExtensionCallback's
+    // ctor, which this FFI path never constructs — leaving SIRIUS_LOG_* dead and every
+    // engine-side stall invisible on a compute node. Honor the env here, but only when
+    // explicitly configured, so embedders without SIRIUS_LOG_* keep today's behavior (no
+    // surprise ./log directory).
+    const char* log_backend = std::getenv("SIRIUS_LOG_BACKEND");
+    const char* log_dir     = std::getenv("SIRIUS_LOG_DIR");
+    const char* log_level   = std::getenv("SIRIUS_LOG_LEVEL");
+    if (log_backend != nullptr || log_dir != nullptr || log_level != nullptr) {
+      if (log_backend != nullptr) { duckdb::Config::LOG_BACKEND = log_backend; }
+      if (log_dir != nullptr) { duckdb::Config::LOG_DIR = log_dir; }
+      if (log_level != nullptr) { duckdb::Config::LOG_LEVEL = log_level; }
+      duckdb::install_configured_log_sink(nullptr);
+    }
+
     context = duckdb::make_shared_ptr<duckdb::SiriusContext>();
     context->initialize(config);
     // Register the builtin + parquet representation converters the GPU scan/result

--- a/test/cpp/exec/test_sirius_ffi_fragment.cpp
+++ b/test/cpp/exec/test_sirius_ffi_fragment.cpp
@@ -14,21 +14,28 @@
  * limitations under the License.
  */
 
-// Regression coverage for Fragment::Impl::end_lifecycle() (src/sirius_ffi.cpp): a build()
-// failure while the transaction is still open must roll it back, not commit it (a7bb47e2).
+// Regression coverage for the transaction handling in src/sirius_ffi.cpp:
+//
+// 1. Fragment::Impl::end_lifecycle(): a build() failure while the transaction is still open must
+//    roll it back, not commit it (a7bb47e2).
+// 2. lower_substrait(): Fragment::build() commits its view-creation transaction before it lowers
+//    the plan, and DuckDB 1.5.5 throws "TransactionContext::ActiveTransaction called without
+//    active transaction" from every catalog lookup made without one — so lowering must own a
+//    transaction of its own.
 //
 // The public FFI surface links only DuckDB's substrait consumer (no substrait-plan-from-SQL
-// helper, no raw-SQL passthrough), so no test here can construct a valid Fragment or inspect
-// catalog state after a failed build(). Instead these tests use a declared column type name
-// that TransformStringToLogicalType() can never resolve, which fails build() inside
-// resolve_inputs() before `substrait_plan` is ever parsed — and check the one thing observable
-// through the public API: that end_lifecycle() leaves the connection able to start and fail a
-// second, independent Fragment cleanly.
+// helper, no raw-SQL passthrough), so a valid plan has to be built here by hand with the bundled
+// protobuf, and catalog state after a failed build() cannot be inspected. The end_lifecycle()
+// tests therefore use a declared column type name that TransformStringToLogicalType() can never
+// resolve, which fails build() inside resolve_inputs() before `substrait_plan` is ever parsed —
+// and check the one thing observable through the public API: that end_lifecycle() leaves the
+// connection able to start and fail a second, independent Fragment cleanly.
 
 #include "sirius_ffi.hpp"
 
 #include <catch.hpp>
 #include <duckdb/common/exception/transaction_exception.hpp>
+#include <substrait/plan.pb.h>
 
 #include <cstdint>
 #include <filesystem>
@@ -49,6 +56,27 @@ fs::path isolated_memory_config_path()
 void declare_unresolvable_column(sirius::ffi::Fragment& fragment, const std::string& type_name)
 {
   fragment.declare_input_column(0, "a", type_name);
+}
+
+// A plan whose only read is the engine's stream view for input stream `stream_id`, projecting a
+// single nullable INTEGER column `a` — the shape a front end emits where it would otherwise emit
+// a file scan. Mirrors what Fragment::build() creates: `CREATE VIEW sirius_stream_<id> AS
+// SELECT * FROM sirius_stream_source(<id>)`.
+std::string stream_read_plan(std::uint64_t stream_id)
+{
+  substrait::Plan plan;
+  auto* root = plan.add_relations()->mutable_root();
+  root->add_names("a");
+
+  auto* read   = root->mutable_input()->mutable_read();
+  auto* schema = read->mutable_base_schema();
+  schema->add_names("a");
+  auto* row_type = schema->mutable_struct_();
+  row_type->set_nullability(substrait::Type::NULLABILITY_REQUIRED);
+  row_type->add_types()->mutable_i32()->set_nullability(substrait::Type::NULLABILITY_NULLABLE);
+  read->mutable_named_table()->add_names(*sirius::ffi::stream_view_name(stream_id));
+
+  return plan.SerializeAsString();
 }
 
 // Both TransactionContext::Commit() and ::Rollback() clear current_transaction before doing any
@@ -104,4 +132,29 @@ TEST_CASE("Fragment destroyed between a failed build() and reuse also closes the
   auto second = sirius::ffi::make_fragment(*context);
   declare_unresolvable_column(*second, "also_not_a_real_type_xyz");
   require_build_fails_without_transaction_exception(*second);
+}
+
+// Exercises the success path the two cases above never reach: a well-formed plan over a declared
+// input stream. Fragment::build() commits its own transaction (type resolution + CREATE VIEW)
+// before opening the query lifecycle and only then calls lower_substrait(), so the Substrait
+// consumer's view lookup and the planner's binding run with no ambient transaction. Without
+// lower_substrait() owning one, DuckDB 1.5.5 fails this build() with
+// "TransactionContext::ActiveTransaction called without active transaction".
+TEST_CASE("Fragment::build() lowers its Substrait plan without an ambient transaction",
+          "[isolated_context][sirius_ffi]")
+{
+  auto context = sirius::ffi::make_context_from_config(isolated_memory_config_path().string());
+
+  {
+    auto first = sirius::ffi::make_fragment(*context);
+    first->declare_input_column(0, "a", "INTEGER");
+    REQUIRE_NOTHROW(first->build(stream_read_plan(0)));
+  }
+
+  // The transaction lower_substrait() opened must be closed again on return: the next build()
+  // begins its own on the same connection and would throw "cannot start a transaction within a
+  // transaction" if the first one were still open.
+  auto second = sirius::ffi::make_fragment(*context);
+  second->declare_input_column(1, "a", "INTEGER");
+  REQUIRE_NOTHROW(second->build(stream_read_plan(1)));
 }


### PR DESCRIPTION
## Description

**Motivation.** #1481 merged the C++ `sirius::ffi::Fragment`, and #1328 moved the DuckDB submodule to 1.5.5. Since then, on `dev`, every well-formed `Fragment::build()` throws `TransactionContext::ActiveTransaction called without active transaction`. The cause is ordering. `build()` commits the transaction it uses for type resolution and `CREATE VIEW sirius_stream_<id>`, then opens the `StandaloneQueryScope` query lifecycle, and only then lowers the Substrait plan. So the Substrait consumer's catalog lookup and the planner's binding run with no transaction open. DuckDB 1.5.4 tolerated that. 1.5.5 throws. CI never saw it because the only two C++ Fragment cases exercise `build()` failure paths, and the Rust crate has no Fragment binding yet.

**What changed.** This is one reviewable unit. It changes the transaction scope of Substrait lowering on the FFI path, and adds the test that pins it.

- In `src/sirius_ffi.cpp`, `lower_substrait()` now opens a transaction on `ClientContext::transaction` when none is active. It commits on success, and on failure it rolls back and rethrows. I used `client.transaction` rather than `Connection::BeginTransaction()` on purpose. The latter runs `BEGIN TRANSACTION` as an ordinary statement, which would take the lifecycle mutex the enclosing `StandaloneQueryScope` already holds. `Context::execute_substrait` already opens its own transaction before calling `lower_substrait`, so `owned_transaction` is false there and that path is unchanged.
- Also in `src/sirius_ffi.cpp`, `Context::Impl::bring_up` now honors `SIRIUS_LOG_BACKEND`, `SIRIUS_LOG_DIR` and `SIRIUS_LOG_LEVEL`, the env vars `docs/super-sirius/configuration.md` already documents for the extension. The extension installs the engine log sink from the `SiriusContextExtensionCallback` constructor, which the FFI path never constructs. So those variables were dead for every embedder, and engine-side stalls were invisible on a compute node. I gated the new code on at least one of the three being set. Embedders that set none keep today's behavior and get no surprise `./log` directory. This adds no new setting.
- `test/cpp/exec/test_sirius_ffi_fragment.cpp` gets a new `[isolated_context][sirius_ffi]` case. It declares an input stream and hand-builds a Substrait `ReadRel` of `sirius_stream_<id>` with the bundled protobuf, because the FFI library links no plan-from-SQL helper. It requires `build()` not to throw, then builds a second fragment on the same connection to prove the owned transaction was closed again. A still-open one would fail the next `BeginTransaction()` with "cannot start a transaction within a transaction". On unfixed `dev` the first `REQUIRE_NOTHROW` fails with the `ActiveTransaction` message.
- `CMakeLists.txt` adds the two protobuf header roots, `substrait/third_party` and `substrait/third_party/substrait`, to `sirius_unittest` so the test can include `substrait/plan.pb.h`. The generated code is already linked in through `sirius_extension`.

What I want eyes on is the `owned_transaction` gate and the commit/rollback pairing around the try block. Everything else in that hunk is the existing lowering code reindented into the try block, plus a comment explaining why the transaction has to be owned here.

**How I tested it.** On a GB200 box (aarch64) I did a full release build, then ran the Catch2 tags `[sirius_ffi]` and `[streaming_fragment]` on a GPU. All 8 test cases pass, one of them the new one, which fails on unfixed `dev` with the `ActiveTransaction` message.

**Intentionally not handled.** Everything else `feat/pin-table-cn` changes in `src/sirius_ffi.cpp` lands in later layers of this stack. That covers the exchange staging arena and `export_packed` / `push_packed`, `pin_table`, `declare_input_cardinality` / `estimated_rows`, and the byte-range extraction that sits in the same `lower_substrait` try block. `src/include/sirius_ffi.hpp` is untouched here. This is layer 1 of the ffi stack. The next layer adds the Rust bindings for `sirius::ffi::Fragment`.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
- Refs #1481, already merged. It added the C++ `sirius::ffi::Fragment` API this fix makes buildable.
- Refs #1328, already merged. It bumped DuckDB to 1.5.5, which turned the missing transaction into a throw.
- Supersedes #1644, an old draft that carried this fix. It is split out here.