### PR TITLE
feat(pipeline): opt-in stall watchdog (SIRIUS_QUERY_WATCHDOG_SECS)

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -32,6 +32,16 @@ Set `SIRIUS_DISABLE=1` to prevent Super Sirius from initializing. This is **requ
 export SIRIUS_DISABLE=1
 ```
 
+### `SIRIUS_QUERY_WATCHDOG_SECS`
+
+Opt-in query watchdog, **off by default**. Unset or `0` leaves `sirius_engine::execute()` blocking on the query future exactly as before. Set to `N` and the engine thread instead polls the future every 250 ms and fails the query — through the scheduler's completion handler, with a named `sirius query watchdog` error the client sees — once **no pipeline has made any scheduling progress** (no task created or completed, no pipeline finished) for `N` seconds. A wedged query becomes a loud failure in `N` seconds instead of a silent hang; in-flight GPU work is not cancelled, and a query that completes concurrently keeps its real outcome (first call wins).
+
+The watchdog watches scheduling counters, not GPU activity, so a single long-running kernel looks like a stall to it. Pick a value well above the longest single kernel or operator runtime the deployment can see, and below the client-side query timeout so the client receives the engine's error rather than its own. The multi-CN cluster environment uses `60`. The value must be a plain non-negative integer no larger than `86400` (one day); anything else — a sign, whitespace, a non-digit, or a larger number — is rejected when the query starts. The C++ integration tests that run under the watchdog (`watchdog_guard` in `test/cpp/exec/test_streaming_fragment.cpp`) hard-wire a threshold sized for a fast GPU; export `SIRIUS_TEST_WATCHDOG_SECS` to raise it on a slow CI machine.
+
+```bash
+export SIRIUS_QUERY_WATCHDOG_SECS=60
+```
+
 ### Byte Suffixes
 
 Any integer config value that represents bytes supports human-readable suffixes:

--- a/docs/super-sirius/task-creator.md
+++ b/docs/super-sirius/task-creator.md
@@ -215,6 +215,8 @@ while running:
 
 The `mark_task_created()` call before data popping prevents a race condition where the pipeline could appear finished between data check and task creation.
 
+**Zero-task completion.** A pipeline whose input stream closes without ever carrying a batch finishes between `build()` and `run()` — before `prepare_for_query()` installs the query's completion handler — so no task ever runs; step 4's re-status of the scheduled head, together with `update_pipeline_status()` signalling completion for a finished query-terminal pipeline (#1624), still completes the query. `FRAG-11` in `test/cpp/exec/test_streaming_fragment.cpp` pins this.
+
 ### Look-ahead task creation
 
 **Files:** `src/include/creator/config.hpp`, `src/creator/task_creator.cpp`

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -29,6 +29,7 @@
 #include <cucascade/memory/topology_discovery.hpp>
 
 #include <atomic>
+#include <cstdint>
 #include <future>
 #include <memory>
 #include <optional>
@@ -172,6 +173,19 @@ class task_scheduler {
    * @param error The error to report.
    */
   void terminate_query(std::exception_ptr error);
+
+  /**
+   * @brief Fail the running query as stalled.
+   *
+   * Reports an error through the completion handler (first-call-wins: a query that completes
+   * concurrently keeps its real outcome) WITHOUT stopping the scheduler or draining executors —
+   * draining after an error belongs to the engine's execute() catch path, which observes the
+   * failed future. Called from the engine thread by the opt-in query watchdog (see
+   * sirius_engine::execute); never from the task creator's manager thread.
+   *
+   * @param stalled_secs How long the watchdog observed no scheduling progress, for the message.
+   */
+  void fail_stalled_query(uint64_t stalled_secs);
 
   /**
    * @brief Drain all in-flight tasks after a query error.

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -233,6 +233,19 @@ void task_scheduler::terminate_query(std::exception_ptr error)
   stop();
 }
 
+void task_scheduler::fail_stalled_query(uint64_t stalled_secs)
+{
+  std::scoped_lock lock(_query_mutex);
+  if (!_completion_handler) { return; }
+  SIRIUS_LOG_ERROR(
+    "task_scheduler: no scheduling progress for {}s (no task created or completed, no pipeline "
+    "finished); failing the query as stalled",
+    stalled_secs);
+  _completion_handler->report_error("sirius query watchdog: no scheduling progress for " +
+                                    std::to_string(stalled_secs) +
+                                    "s — failing the stalled query instead of wedging the engine");
+}
+
 void task_scheduler::drain_after_error()
 {
   SIRIUS_LOG_INFO("task_scheduler: draining after error");

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -46,6 +46,12 @@
 #include <cucascade/memory/memory_space.hpp>
 
 #include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <stdexcept>
 
@@ -105,6 +111,74 @@ std::shared_ptr<const telemetry::telemetry_context> get_telemetry_context_from_c
   }
 
   return sirius_ctx->get_telemetry_context();
+}
+
+/// Sum of every pipeline's scheduling counters (+1 per finished pipeline): changes whenever any
+/// task is created or completes or a pipeline finishes, so a stalled query — zero tasks anywhere
+/// and nothing finishing — has a constant fingerprint. Counters are atomics; no lock needed.
+std::uint64_t query_progress_fingerprint(duckdb::SiriusContext& sirius_ctx)
+{
+  std::uint64_t fingerprint = 0;
+  if (auto query = sirius_ctx.get_query()) {
+    for (const auto& pipeline : query->get_pipelines()) {
+      if (!pipeline) { continue; }
+      fingerprint += pipeline->get_tasks_created() + pipeline->get_tasks_completed();
+      fingerprint += pipeline->is_pipeline_finished() ? 1 : 0;
+    }
+  }
+  return fingerprint;
+}
+
+/// Wait for the query future. With SIRIUS_QUERY_WATCHDOG_SECS set (> 0) this polls instead of
+/// blocking: when no pipeline makes scheduling progress for that many seconds, the query is
+/// failed loudly through the scheduler's completion handler (first-call-wins; no stop or drain
+/// here — draining belongs to execute()'s catch) and the failed future is rethrown to the
+/// caller. Off by default: an in-flight long-running kernel makes no counter progress, so only
+/// opt in where per-operator runtimes are known to sit far below the threshold (the CN cluster
+/// env sets 60s).
+void wait_for_query_future(std::future<void>& future, duckdb::SiriusContext& sirius_ctx)
+{
+  // One day: far above any kernel and far below where seconds -> steady_clock duration arithmetic
+  // (nanoseconds) would overflow. strtoull alone is not enough — it skips leading whitespace and
+  // accepts a '-' by wrapping, so a "-1" would parse as ULLONG_MAX and fire on the first poll.
+  constexpr std::uint64_t max_watchdog_secs = 86400;
+  std::uint64_t watchdog_secs               = 0;
+  if (const char* env = std::getenv("SIRIUS_QUERY_WATCHDOG_SECS"); env != nullptr && *env != '\0') {
+    auto const digits_only = std::all_of(
+      env, env + std::strlen(env), [](unsigned char c) { return std::isdigit(c) != 0; });
+    char* end         = nullptr;
+    errno             = 0;
+    auto const parsed = std::strtoull(env, &end, 10);
+    if (!digits_only || end == env || *end != '\0' || errno == ERANGE ||
+        parsed > max_watchdog_secs) {
+      throw invalid_input_exception(
+        "SIRIUS_QUERY_WATCHDOG_SECS must be a plain non-negative integer of at most " +
+        std::to_string(max_watchdog_secs) + " seconds, got: '" + std::string(env) + "'");
+    }
+    watchdog_secs = parsed;
+  }
+  if (watchdog_secs == 0) {
+    future.get();
+    return;
+  }
+
+  auto last_fingerprint = query_progress_fingerprint(sirius_ctx);
+  auto last_progress    = std::chrono::steady_clock::now();
+  while (future.wait_for(std::chrono::milliseconds(250)) != std::future_status::ready) {
+    auto const fingerprint = query_progress_fingerprint(sirius_ctx);
+    auto const now         = std::chrono::steady_clock::now();
+    if (fingerprint != last_fingerprint) {
+      last_fingerprint = fingerprint;
+      last_progress    = now;
+      continue;
+    }
+    if (now - last_progress >= std::chrono::seconds(watchdog_secs)) {
+      // Resolves the future with an error unless the query completed concurrently
+      // (first-call-wins); the next wait_for observes it and the loop exits into get().
+      sirius_ctx.get_task_scheduler().fail_stalled_query(watchdog_secs);
+    }
+  }
+  future.get();
 }
 
 }  // namespace
@@ -198,7 +272,7 @@ void sirius_engine::execute()
                            });
   auto future = sirius_ctx->get_task_scheduler().start_query();
   try {
-    future.get();
+    wait_for_query_future(future, *sirius_ctx);
     sirius_ctx->get_task_scheduler().wait_for_completion();
   } catch (const std::exception& e) {
     SIRIUS_LOG_ERROR("Error executing query: {}", e.what());

--- a/test/cpp/exec/test_streaming_fragment.cpp
+++ b/test/cpp/exec/test_streaming_fragment.cpp
@@ -31,8 +31,11 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <memory>
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -501,6 +504,111 @@ TEST_CASE_METHOD(fragment_fixture,
                             << " tasks_completed=" << completed);
 
     REQUIRE(drain_values(receiver, 1) == std::vector<std::int32_t>{1, 2, 3, 4, 5, 6});
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}
+
+// ============================================================================
+// FRAG-11: a fragment over an input stream that closes empty before run().
+// A hash fan-out gives one CN zero keys: its exchange input closes with zero
+// batches before run(), so the pipeline finishes between build() and run() —
+// before the query's completion handler exists — and no task is ever created
+// to carry the completion. run() must still return, with an empty result.
+//
+// This pins behaviour dev already has since #1624: the manager loop re-statuses
+// the scheduled head's pipeline once the query is live, and
+// update_pipeline_status() signals completion for a finished query-terminal
+// pipeline. It is the C++ mirror of the CN suite's
+// fragment_over_an_empty_input_stream_terminates; the watchdog guard turns a
+// regression into a named failure in seconds instead of a hung suite.
+// ============================================================================
+
+namespace {
+
+//! Turns a wedged run() into a loud failure: the engine-side scheduling watchdog
+//! (SIRIUS_QUERY_WATCHDOG_SECS) fails a query with no scheduling progress, and
+//! streaming_fragment::run() rethrows it — so a hang fails in seconds instead of
+//! blocking the suite forever. `secs` is the test's own threshold, sized for a fast
+//! GPU; a non-empty SIRIUS_TEST_WATCHDOG_SECS in the environment overrides it so a
+//! slow CI machine can raise every guarded test at once without editing the tests.
+//! Restores whatever the environment held before.
+struct watchdog_guard {
+  explicit watchdog_guard(const char* secs)
+  {
+    if (const char* previous = std::getenv("SIRIUS_QUERY_WATCHDOG_SECS")) { _previous = previous; }
+    const char* override_secs = std::getenv("SIRIUS_TEST_WATCHDOG_SECS");
+    setenv("SIRIUS_QUERY_WATCHDOG_SECS",
+           (override_secs != nullptr && *override_secs != '\0') ? override_secs : secs,
+           1);
+  }
+  ~watchdog_guard()
+  {
+    if (_previous) {
+      setenv("SIRIUS_QUERY_WATCHDOG_SECS", _previous->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_QUERY_WATCHDOG_SECS");
+    }
+  }
+  watchdog_guard(const watchdog_guard&)            = delete;
+  watchdog_guard& operator=(const watchdog_guard&) = delete;
+
+ private:
+  std::optional<std::string> _previous;
+};
+
+}  // namespace
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-11: a fragment over an input stream that closes empty before run() "
+                 "terminates",
+                 "[integration][streaming_fragment]")
+{
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  // The query does no GPU work at all, so 20 s of zero scheduling progress is a wedge, not a
+  // slow kernel: a regression fails here in seconds instead of hanging the suite. On a slow CI
+  // GPU, export SIRIUS_TEST_WATCHDOG_SECS to raise the threshold without touching the test.
+  watchdog_guard watchdog("20");
+
+  con->BeginTransaction();
+  try {
+    fragment_spec spec;
+    spec.plan_source = sirius::test::sql_plan_source("SELECT a FROM sirius_stream_source(0)");
+    spec.inputs[0]   = stream_input_spec{
+        {"a"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+        {0}};
+    spec.outputs = {1};
+    streaming_fragment receiver(*con->context, std::move(spec));
+
+    query_window window(*sirius_ctx, *con->context, "frag11_receiver");
+    receiver.build(window.query_id());
+
+    // No sender ever parked a batch for this partition; the stream just ends, before run().
+    receiver.session().close_input(0, 0);
+
+    receiver.run();
+    window.finish();
+
+    // The premise, not just the outcome: nothing was scheduled, so no task epilogue could have
+    // carried the completion signal that let run() return.
+    std::size_t created = 0, completed = 0;
+    for (const auto& p : receiver.engine().sirius_pipelines) {
+      created += p->get_tasks_created();
+      completed += p->get_tasks_completed();
+    }
+    INFO("pipelines=" << receiver.engine().sirius_pipelines.size() << " tasks_created=" << created
+                      << " tasks_completed=" << completed);
+    REQUIRE(created == 0);
+    REQUIRE(completed == 0);
+
+    // An empty stream yields no rows — but it must yield.
+    REQUIRE(drain_row_count(receiver, 1) == 0);
 
     con->Rollback();
   } catch (...) {


### PR DESCRIPTION
<!-- NOTE: All PRs should be opened as "Draft" until they meet PR "reviewability" and marked "Ready for review" -->

## Description

**Motivation.** Hang-class regressions in multi-fragment queries need to fail in seconds with a named error, not hang CI to its timeout. The canonical shape: a hash-partitioned exchange gives most compute nodes zero keys for a given partition — on TPC-H Q1 the merge fragment's fan-out leaves all but one CN with an input stream that closes with zero batches. That stream closes between `build()` and `run()`, its end-of-stream hook finishes the pipeline before `prepare_for_query()` has installed the query's completion handler, and no task is ever created to carry the completion. When this class wedged, the multi-CN suite hung for the full 120 s harness timeout with nothing in the log naming the cause.

**What the investigation found.** The source-of-truth branch (`aocsa/feat/pin-table-cn`) fixed the empty-stream hang with a zero-task completion hunk in `task_creator::manager_loop()` (an exhausted-head re-check calling a new `task_scheduler::complete_query_if_finished()`). On current `dev` that hunk is redundant: #1624 already re-statuses the scheduled head's pipeline in the `visited_pipelines` loop once the query is live, and `update_pipeline_status()` now signals completion from the finish transition for a query-terminal pipeline and re-cascades to parents. The experiment on this box was direct — with `src/creator/task_creator.cpp` reverted to `origin/dev` and everything else from the source-of-truth commit kept, FRAG-11 passes (`All tests passed (10 assertions in 1 test case)`). So this PR does **not** carry the completion hunk or `complete_query_if_finished()`; it keeps the test that pins the behaviour and the watchdog that makes any regression of it loud.

**What changed** (one reviewable unit: the opt-in stall watchdog and the regression test it guards):

- `src/sirius_engine.cpp` — `query_progress_fingerprint()` (sum of every pipeline's `tasks_created + tasks_completed`, +1 per finished pipeline) and `wait_for_query_future()`, which replaces the bare `future.get()` in `execute()`. With `SIRIUS_QUERY_WATCHDOG_SECS` unset or `0` it takes an early `future.get()` return — the default path is byte-identical to today. Set, it polls the future every 250 ms and fails the query only after **zero** scheduling progress for that many seconds. The value is parsed strictly — digits only (no sign, no whitespace), `ERANGE` checked, and capped at `86400` (one day) — because `strtoull` alone accepts `-1` by wrapping it to `ULLONG_MAX`, which would narrow to `seconds(-1)` and fire on the first poll; the error message names exactly what is enforced.
- `src/include/pipeline/task_scheduler.hpp`, `src/pipeline/task_scheduler.cpp` — `fail_stalled_query(uint64_t)` reports a named `sirius query watchdog` error through the completion handler (first-call-wins: a query that completes concurrently keeps its real outcome) without stopping or draining — that belongs to `execute()`'s catch path, which observes the failed future. Called from the engine thread only; never from the task creator's manager thread.
- `test/cpp/exec/test_streaming_fragment.cpp` — a `watchdog_guard` RAII helper (sets `SIRIUS_QUERY_WATCHDOG_SECS`, restores the previous value; a non-empty `SIRIUS_TEST_WATCHDOG_SECS` in the environment overrides the test's own threshold so a slow CI GPU can raise every guarded test at once) and **FRAG-11**: a fragment reading one declared input stream whose only sender is closed without a batch before `run()`; under `watchdog_guard("20")` it must return with zero tasks created, zero tasks completed and zero rows. Its doc comment says what it is: a pin on behaviour `dev` already has since #1624, and the C++ mirror of the CN suite's `fragment_over_an_empty_input_stream_terminates`.
- `docs/super-sirius/configuration.md` — a `SIRIUS_QUERY_WATCHDOG_SECS` subsection: off by default; must sit well above any single kernel's runtime (a long kernel makes no counter progress) and below the client-side query timeout; the CN cluster env uses 60; the accepted range (`0..86400`, digits only) and the `SIRIUS_TEST_WATCHDOG_SECS` test knob are stated. `docs/super-sirius/task-creator.md` — two sentences where the manager loop is described: an input stream that closes before `run()` still finishes its pipeline through the finish transition (#1624), and FRAG-11 pins it.

**Why a watchdog, and why opt-in.** Every hang-class regression test in this stack and the next (FRAG-6..9 in the join-wedge layer, the CN suite's `under_watchdog` tests) needs a wedge to fail in seconds with a named error rather than hang CI to its timeout; that is what `SIRIUS_QUERY_WATCHDOG_SECS` provides. It is opt-in because it watches scheduling counters, not GPU activity: an in-flight long kernel is indistinguishable from a stall, so only deployments that know their per-operator runtimes should enable it. It does not cancel in-flight GPU work; it turns a silent hang into a loud failure.

Verified: GB200 aarch64 (CUDA 13.0, driver 580.105.08), d53b44b1 over dev 84ea4ab5, in a dedicated clone: `pixi run make` OK (381 steps, 0 errors); `CUDA_VISIBLE_DEVICES=3 pixi run ./build/release/extension/sirius/test/cpp/sirius_unittest "[streaming_fragment]"` → `All tests passed (85 assertions in 6 test cases)`; `CUDA_VISIBLE_DEVICES=3 pixi run ./build/release/extension/sirius/test/cpp/sirius_unittest "FRAG-11*"` → `All tests passed (10 assertions in 1 test case)`; `pixi run --locked rumdl check docs/super-sirius/configuration.md docs/super-sirius/task-creator.md` → `Success: No issues found in 2 files`; `SKIP=rumdl pre-commit run --files <the six changed files>` all hooks Passed with no rewrites; `git diff origin/dev | grep complete_query_if_finished` empty.

**Design overlap with open #1642.** @Jedi18's completion-quiescence work ledger (`fix/completion-quiescence-protocol`) rewrites the same `future.get()` try/catch in `execute()` this PR replaces with `wait_for_query_future()`, and the same `task_scheduler` completion region `fail_stalled_query()` lives in: it makes `wait_for_completion()` park the creator, close a ledger against new work and wait for a zero count before teardown. `fail_stalled_query()` reports through the completion handler first-call-wins and deliberately does not drain; if the ledger makes draining mandatory before any completion signal, the watchdog's failure path needs to be expressed in ledger terms (register the error, let the ledger reach zero, then release). This PR is opened as **Draft** to settle that with him first.

**Intentionally not handled.** A multi-source fragment where a *non-front* streaming source closes empty before `run()` and is never scheduled: FRAG-11 cannot reach that shape (its single stream is the scheduled head, so the `visited_pipelines` re-status covers it), and whether the finish-transition signal from #1624 covers a never-scheduled source is an open question raised for #1642 rather than answered with new code here. Hash-join slots whose build or probe side can never arrive (`never_buildable_slots`, the partition zero-byte strategy, FRAG-6..9) are the next layer. Input-stream cardinality (FRAG-10) is a separate PR. The CN/bench consumers of `SIRIUS_QUERY_WATCHDOG_SECS` (`experimental/starrocks` TUNABLES, cluster scripts) ship with the CN slices.

Layer 1 of the liveness stack; the next layer resolves hash-join slots that can never be built or probed, and its FRAG-6..9 run under the `watchdog_guard` introduced here.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
- Supersedes the watchdog part of #1644 (draft "Stream fragment execution", 29 commits — being closed in favour of this stack).
- Refs #1642 (open: completion quiescence protocol / work ledger — same region; design overlap noted above).
- Refs #1624 (merged: signal query completion from the pipeline finish transition; fixes #1486) — the transition-time signal that already completes the empty-stream case FRAG-11 pins.
