### PR TITLE
feat(pipeline): opt-in stall watchdog (SIRIUS_QUERY_WATCHDOG_SECS)

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -32,6 +32,16 @@ Set `SIRIUS_DISABLE=1` to prevent Super Sirius from initializing. This is **requ
 export SIRIUS_DISABLE=1
 ```
 
+### `SIRIUS_QUERY_WATCHDOG_SECS`
+
+Opt-in query watchdog, **off by default**. Unset or `0` leaves `sirius_engine::execute()` blocking on the query future exactly as before. Set to `N` and the engine thread instead polls the future every 250 ms and fails the query — through the scheduler's completion handler, with a named `sirius query watchdog` error the client sees — once **no pipeline has made any scheduling progress** (no task created or completed, no pipeline finished) for `N` seconds. A wedged query becomes a loud failure in `N` seconds instead of a silent hang; in-flight GPU work is not cancelled, and a query that completes concurrently keeps its real outcome (first call wins).
+
+The watchdog watches scheduling counters, not GPU activity, so a single long-running kernel looks like a stall to it. Pick a value well above the longest single kernel or operator runtime the deployment can see, and below the client-side query timeout so the client receives the engine's error rather than its own. The multi-CN cluster environment uses `60`. The value must be a plain non-negative integer no larger than `86400` (one day); anything else — a sign, whitespace, a non-digit, or a larger number — is rejected when the query starts. The C++ integration tests that run under the watchdog (`watchdog_guard` in `test/cpp/exec/test_streaming_fragment.cpp`) hard-wire a threshold sized for a fast GPU; export `SIRIUS_TEST_WATCHDOG_SECS` to raise it on a slow CI machine.
+
+```bash
+export SIRIUS_QUERY_WATCHDOG_SECS=60
+```
+
 ### Byte Suffixes
 
 Any integer config value that represents bytes supports human-readable suffixes:

--- a/docs/super-sirius/task-creator.md
+++ b/docs/super-sirius/task-creator.md
@@ -215,6 +215,8 @@ while running:
 
 The `mark_task_created()` call before data popping prevents a race condition where the pipeline could appear finished between data check and task creation.
 
+**Zero-task completion.** A pipeline whose input stream closes without ever carrying a batch finishes between `build()` and `run()` — before `prepare_for_query()` installs the query's completion handler — so no task ever runs; step 4's re-status of the scheduled head, together with `update_pipeline_status()` signalling completion for a finished query-terminal pipeline (#1624), still completes the query. `FRAG-11` in `test/cpp/exec/test_streaming_fragment.cpp` pins this.
+
 ### Look-ahead task creation
 
 **Files:** `src/include/creator/config.hpp`, `src/creator/task_creator.cpp`

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -29,6 +29,7 @@
 #include <cucascade/memory/topology_discovery.hpp>
 
 #include <atomic>
+#include <cstdint>
 #include <future>
 #include <memory>
 #include <optional>
@@ -172,6 +173,19 @@ class task_scheduler {
    * @param error The error to report.
    */
   void terminate_query(std::exception_ptr error);
+
+  /**
+   * @brief Fail the running query as stalled.
+   *
+   * Reports an error through the completion handler (first-call-wins: a query that completes
+   * concurrently keeps its real outcome) WITHOUT stopping the scheduler or draining executors —
+   * draining after an error belongs to the engine's execute() catch path, which observes the
+   * failed future. Called from the engine thread by the opt-in query watchdog (see
+   * sirius_engine::execute); never from the task creator's manager thread.
+   *
+   * @param stalled_secs How long the watchdog observed no scheduling progress, for the message.
+   */
+  void fail_stalled_query(uint64_t stalled_secs);
 
   /**
    * @brief Drain all in-flight tasks after a query error.

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -233,6 +233,19 @@ void task_scheduler::terminate_query(std::exception_ptr error)
   stop();
 }
 
+void task_scheduler::fail_stalled_query(uint64_t stalled_secs)
+{
+  std::scoped_lock lock(_query_mutex);
+  if (!_completion_handler) { return; }
+  SIRIUS_LOG_ERROR(
+    "task_scheduler: no scheduling progress for {}s (no task created or completed, no pipeline "
+    "finished); failing the query as stalled",
+    stalled_secs);
+  _completion_handler->report_error("sirius query watchdog: no scheduling progress for " +
+                                    std::to_string(stalled_secs) +
+                                    "s — failing the stalled query instead of wedging the engine");
+}
+
 void task_scheduler::drain_after_error()
 {
   SIRIUS_LOG_INFO("task_scheduler: draining after error");

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -46,6 +46,12 @@
 #include <cucascade/memory/memory_space.hpp>
 
 #include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <stdexcept>
 
@@ -105,6 +111,74 @@ std::shared_ptr<const telemetry::telemetry_context> get_telemetry_context_from_c
   }
 
   return sirius_ctx->get_telemetry_context();
+}
+
+/// Sum of every pipeline's scheduling counters (+1 per finished pipeline): changes whenever any
+/// task is created or completes or a pipeline finishes, so a stalled query — zero tasks anywhere
+/// and nothing finishing — has a constant fingerprint. Counters are atomics; no lock needed.
+std::uint64_t query_progress_fingerprint(duckdb::SiriusContext& sirius_ctx)
+{
+  std::uint64_t fingerprint = 0;
+  if (auto query = sirius_ctx.get_query()) {
+    for (const auto& pipeline : query->get_pipelines()) {
+      if (!pipeline) { continue; }
+      fingerprint += pipeline->get_tasks_created() + pipeline->get_tasks_completed();
+      fingerprint += pipeline->is_pipeline_finished() ? 1 : 0;
+    }
+  }
+  return fingerprint;
+}
+
+/// Wait for the query future. With SIRIUS_QUERY_WATCHDOG_SECS set (> 0) this polls instead of
+/// blocking: when no pipeline makes scheduling progress for that many seconds, the query is
+/// failed loudly through the scheduler's completion handler (first-call-wins; no stop or drain
+/// here — draining belongs to execute()'s catch) and the failed future is rethrown to the
+/// caller. Off by default: an in-flight long-running kernel makes no counter progress, so only
+/// opt in where per-operator runtimes are known to sit far below the threshold (the CN cluster
+/// env sets 60s).
+void wait_for_query_future(std::future<void>& future, duckdb::SiriusContext& sirius_ctx)
+{
+  // One day: far above any kernel and far below where seconds -> steady_clock duration arithmetic
+  // (nanoseconds) would overflow. strtoull alone is not enough — it skips leading whitespace and
+  // accepts a '-' by wrapping, so a "-1" would parse as ULLONG_MAX and fire on the first poll.
+  constexpr std::uint64_t max_watchdog_secs = 86400;
+  std::uint64_t watchdog_secs               = 0;
+  if (const char* env = std::getenv("SIRIUS_QUERY_WATCHDOG_SECS"); env != nullptr && *env != '\0') {
+    auto const digits_only = std::all_of(
+      env, env + std::strlen(env), [](unsigned char c) { return std::isdigit(c) != 0; });
+    char* end         = nullptr;
+    errno             = 0;
+    auto const parsed = std::strtoull(env, &end, 10);
+    if (!digits_only || end == env || *end != '\0' || errno == ERANGE ||
+        parsed > max_watchdog_secs) {
+      throw invalid_input_exception(
+        "SIRIUS_QUERY_WATCHDOG_SECS must be a plain non-negative integer of at most " +
+        std::to_string(max_watchdog_secs) + " seconds, got: '" + std::string(env) + "'");
+    }
+    watchdog_secs = parsed;
+  }
+  if (watchdog_secs == 0) {
+    future.get();
+    return;
+  }
+
+  auto last_fingerprint = query_progress_fingerprint(sirius_ctx);
+  auto last_progress    = std::chrono::steady_clock::now();
+  while (future.wait_for(std::chrono::milliseconds(250)) != std::future_status::ready) {
+    auto const fingerprint = query_progress_fingerprint(sirius_ctx);
+    auto const now         = std::chrono::steady_clock::now();
+    if (fingerprint != last_fingerprint) {
+      last_fingerprint = fingerprint;
+      last_progress    = now;
+      continue;
+    }
+    if (now - last_progress >= std::chrono::seconds(watchdog_secs)) {
+      // Resolves the future with an error unless the query completed concurrently
+      // (first-call-wins); the next wait_for observes it and the loop exits into get().
+      sirius_ctx.get_task_scheduler().fail_stalled_query(watchdog_secs);
+    }
+  }
+  future.get();
 }
 
 }  // namespace
@@ -198,7 +272,7 @@ void sirius_engine::execute()
                            });
   auto future = sirius_ctx->get_task_scheduler().start_query();
   try {
-    future.get();
+    wait_for_query_future(future, *sirius_ctx);
     sirius_ctx->get_task_scheduler().wait_for_completion();
   } catch (const std::exception& e) {
     SIRIUS_LOG_ERROR("Error executing query: {}", e.what());

--- a/test/cpp/exec/test_streaming_fragment.cpp
+++ b/test/cpp/exec/test_streaming_fragment.cpp
@@ -31,8 +31,11 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <memory>
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -501,6 +504,111 @@ TEST_CASE_METHOD(fragment_fixture,
                             << " tasks_completed=" << completed);
 
     REQUIRE(drain_values(receiver, 1) == std::vector<std::int32_t>{1, 2, 3, 4, 5, 6});
+
+    con->Rollback();
+  } catch (...) {
+    con->Rollback();
+    throw;
+  }
+}
+
+// ============================================================================
+// FRAG-11: a fragment over an input stream that closes empty before run().
+// A hash fan-out gives one CN zero keys: its exchange input closes with zero
+// batches before run(), so the pipeline finishes between build() and run() —
+// before the query's completion handler exists — and no task is ever created
+// to carry the completion. run() must still return, with an empty result.
+//
+// This pins behaviour dev already has since #1624: the manager loop re-statuses
+// the scheduled head's pipeline once the query is live, and
+// update_pipeline_status() signals completion for a finished query-terminal
+// pipeline. It is the C++ mirror of the CN suite's
+// fragment_over_an_empty_input_stream_terminates; the watchdog guard turns a
+// regression into a named failure in seconds instead of a hung suite.
+// ============================================================================
+
+namespace {
+
+//! Turns a wedged run() into a loud failure: the engine-side scheduling watchdog
+//! (SIRIUS_QUERY_WATCHDOG_SECS) fails a query with no scheduling progress, and
+//! streaming_fragment::run() rethrows it — so a hang fails in seconds instead of
+//! blocking the suite forever. `secs` is the test's own threshold, sized for a fast
+//! GPU; a non-empty SIRIUS_TEST_WATCHDOG_SECS in the environment overrides it so a
+//! slow CI machine can raise every guarded test at once without editing the tests.
+//! Restores whatever the environment held before.
+struct watchdog_guard {
+  explicit watchdog_guard(const char* secs)
+  {
+    if (const char* previous = std::getenv("SIRIUS_QUERY_WATCHDOG_SECS")) { _previous = previous; }
+    const char* override_secs = std::getenv("SIRIUS_TEST_WATCHDOG_SECS");
+    setenv("SIRIUS_QUERY_WATCHDOG_SECS",
+           (override_secs != nullptr && *override_secs != '\0') ? override_secs : secs,
+           1);
+  }
+  ~watchdog_guard()
+  {
+    if (_previous) {
+      setenv("SIRIUS_QUERY_WATCHDOG_SECS", _previous->c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_QUERY_WATCHDOG_SECS");
+    }
+  }
+  watchdog_guard(const watchdog_guard&)            = delete;
+  watchdog_guard& operator=(const watchdog_guard&) = delete;
+
+ private:
+  std::optional<std::string> _previous;
+};
+
+}  // namespace
+
+TEST_CASE_METHOD(fragment_fixture,
+                 "FRAG-11: a fragment over an input stream that closes empty before run() "
+                 "terminates",
+                 "[integration][streaming_fragment]")
+{
+  auto sirius_ctx = con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+
+  // The query does no GPU work at all, so 20 s of zero scheduling progress is a wedge, not a
+  // slow kernel: a regression fails here in seconds instead of hanging the suite. On a slow CI
+  // GPU, export SIRIUS_TEST_WATCHDOG_SECS to raise the threshold without touching the test.
+  watchdog_guard watchdog("20");
+
+  con->BeginTransaction();
+  try {
+    fragment_spec spec;
+    spec.plan_source = sirius::test::sql_plan_source("SELECT a FROM sirius_stream_source(0)");
+    spec.inputs[0]   = stream_input_spec{
+        {"a"},
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+        {0}};
+    spec.outputs = {1};
+    streaming_fragment receiver(*con->context, std::move(spec));
+
+    query_window window(*sirius_ctx, *con->context, "frag11_receiver");
+    receiver.build(window.query_id());
+
+    // No sender ever parked a batch for this partition; the stream just ends, before run().
+    receiver.session().close_input(0, 0);
+
+    receiver.run();
+    window.finish();
+
+    // The premise, not just the outcome: nothing was scheduled, so no task epilogue could have
+    // carried the completion signal that let run() return.
+    std::size_t created = 0, completed = 0;
+    for (const auto& p : receiver.engine().sirius_pipelines) {
+      created += p->get_tasks_created();
+      completed += p->get_tasks_completed();
+    }
+    INFO("pipelines=" << receiver.engine().sirius_pipelines.size() << " tasks_created=" << created
+                      << " tasks_completed=" << completed);
+    REQUIRE(created == 0);
+    REQUIRE(completed == 0);
+
+    // An empty stream yields no rows — but it must yield.
+    REQUIRE(drain_row_count(receiver, 1) == 0);
 
     con->Rollback();
   } catch (...) {


### PR DESCRIPTION
## Description

**Motivation.** Hang-class regressions in multi-fragment queries should fail in seconds with a named error instead of hanging CI to its timeout. The canonical shape is a hash-partitioned exchange that gives most compute nodes zero keys for a given partition. On TPC-H Q1 the merge fragment's fan-out leaves all but one CN with an input stream that closes with zero batches. That stream closes between `build()` and `run()`. Its end-of-stream hook finishes the pipeline before `prepare_for_query()` has installed the query's completion handler, so no task is ever created to carry the completion. When this class hung, the multi-CN suite sat there for its full 120 s timeout with nothing in the log naming the cause.

**What the investigation found.** The source-of-truth branch (`aocsa/feat/pin-table-cn`) fixed the empty-stream hang with a zero-task completion hunk in `task_creator::manager_loop()`, an exhausted-head re-check that called a new `task_scheduler::complete_query_if_finished()`. On current `dev` that hunk is redundant. #1624 already re-statuses the scheduled head's pipeline in the `visited_pipelines` loop once the query is live, and `update_pipeline_status()` now signals completion from the finish transition for a query-terminal pipeline and re-cascades to parents. I checked this directly on this box. With `src/creator/task_creator.cpp` reverted to `origin/dev` and everything else from the source-of-truth commit kept, FRAG-11 still passes. So this PR does **not** carry the completion hunk or `complete_query_if_finished()`. It keeps the test that pins the behaviour and the watchdog that makes any regression of it loud.

**What changed.** The diff is one reviewable unit, the opt-in stall watchdog plus the regression test it guards.

- In `src/sirius_engine.cpp`, `query_progress_fingerprint()` sums every pipeline's `tasks_created + tasks_completed` and adds 1 per finished pipeline. `wait_for_query_future()` replaces the bare `future.get()` in `execute()`. With `SIRIUS_QUERY_WATCHDOG_SECS` unset or `0` it takes an early `future.get()` return, so the default path is byte-identical to today. When set, it polls the future every 250 ms and fails the query only after **zero** scheduling progress for that many seconds. It parses the value strictly, digits only with no sign or whitespace, `ERANGE` checked, capped at `86400` (one day). The strictness matters because `strtoull` alone accepts `-1` by wrapping it to `ULLONG_MAX`, which would narrow to `seconds(-1)` and fire on the first poll. The error message names exactly what is enforced.
- `fail_stalled_query(uint64_t)` in `src/include/pipeline/task_scheduler.hpp` and `src/pipeline/task_scheduler.cpp` reports a named `sirius query watchdog` error through the completion handler. First call wins, so a query that completes concurrently keeps its real outcome. It does not stop the scheduler or drain executors. That belongs to `execute()`'s catch path, which observes the failed future. Only the engine thread calls it, never the task creator's manager thread.
- `test/cpp/exec/test_streaming_fragment.cpp` gains a `watchdog_guard` RAII helper and **FRAG-11**. The guard sets `SIRIUS_QUERY_WATCHDOG_SECS` and restores the previous value when it goes out of scope. A non-empty `SIRIUS_TEST_WATCHDOG_SECS` in the environment overrides the test's own threshold, so a slow CI GPU can raise every guarded test at once. FRAG-11 builds a fragment reading one declared input stream whose only sender is closed without a batch before `run()`. Under `watchdog_guard("20")` it must return with zero tasks created, zero tasks completed and zero rows. The doc comment calls it what it is. It pins behaviour `dev` already has since #1624, and it is the C++ mirror of the CN suite's `fragment_over_an_empty_input_stream_terminates`.
- `docs/super-sirius/configuration.md` gets a `SIRIUS_QUERY_WATCHDOG_SECS` subsection. Off by default. The value must sit well above any single kernel's runtime, since a long kernel makes no counter progress, and below the client-side query timeout. The CN cluster env uses 60. The accepted range is `0..86400`, digits only, and the `SIRIUS_TEST_WATCHDOG_SECS` test knob is stated. `docs/super-sirius/task-creator.md` gets two sentences where the manager loop is described. An input stream that closes before `run()` still finishes its pipeline through the finish transition (#1624), and FRAG-11 pins it.

**Why a watchdog, and why opt-in.** Every hang-class regression test that follows needs a hung query to fail in seconds with a named error rather than hang CI to its timeout. That means FRAG-6..9 in the hash-join follow-up PR and the CN suite's `under_watchdog` tests. `SIRIUS_QUERY_WATCHDOG_SECS` is the knob that does it. It is opt-in because it watches scheduling counters, not GPU activity. An in-flight long kernel is indistinguishable from a stall, so only deployments that know their per-operator runtimes should enable it. It does not cancel in-flight GPU work. It turns a silent hang into a loud failure.

**How I tested it.** On a GB200 box (aarch64), in a dedicated clone, I did a full build and ran the Catch2 tag `[streaming_fragment]` on a GPU. Six test cases pass, including the new FRAG-11. These tests need a GPU, so CI does not run them; I also ran the markdown linter on the two changed doc files.

**Design overlap with open #1642.** @Jedi18's completion-quiescence work ledger (`fix/completion-quiescence-protocol`) rewrites the same `future.get()` try/catch in `execute()` that this PR replaces with `wait_for_query_future()`. It also rewrites the `task_scheduler` completion region where `fail_stalled_query()` lives. There, it makes `wait_for_completion()` park the creator, close a ledger against new work and wait for a zero count before teardown. `fail_stalled_query()` reports through the completion handler first-call-wins and deliberately does not drain. If the ledger makes draining mandatory before any completion signal, the watchdog's failure path has to be expressed in ledger terms: register the error, let the ledger reach zero, then release. I opened this as **Draft** to settle that with him first.

**Intentionally not handled.** A multi-source fragment where a *non-front* streaming source closes empty before `run()` and is never scheduled. FRAG-11 cannot reach that shape. Its single stream is the scheduled head, so the `visited_pipelines` re-status covers it. Whether the finish-transition signal from #1624 covers a never-scheduled source is an open question for #1642, not something this PR answers with new code. Hash-join slots whose build or probe side can never arrive are the next layer. That work is `never_buildable_slots`, the partition zero-byte strategy and FRAG-6..9. Input-stream cardinality (FRAG-10) is a separate PR. The CN and bench consumers of `SIRIUS_QUERY_WATCHDOG_SECS` ship with the CN slices. Those are the `experimental/starrocks` TUNABLES and the cluster scripts.

This PR is self-contained, no stack. The follow-up gated on it is the hash-join never-buildable / never-probed slot resolution, whose FRAG-6..9 regression tests reuse `watchdog_guard` from this PR.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
- Supersedes the watchdog part of #1644, the draft "Stream fragment execution" (29 commits), which is being closed in favour of the carved PRs.
- Refs #1642 (open), the completion quiescence protocol / work ledger. Same region; the design overlap is noted above.
- Refs #1624 (merged), signal query completion from the pipeline finish transition, which fixes #1486. That transition-time signal already completes the empty-stream case FRAG-11 pins.