### PR TITLE
fix(starrocks): unwrap CLONE_EXPR and cast FE-narrowed builtins to their declared type

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
@@ -147,6 +147,7 @@ fn translate_expr_node(
         TExprNodeType::ARITHMETIC_EXPR => translate_arithmetic(node, children, ctx),
         TExprNodeType::IN_PRED => translate_in_pred(node, children, ctx),
         TExprNodeType::CASE_EXPR => translate_case(node, children),
+        TExprNodeType::CLONE_EXPR => translate_clone(node, children),
         TExprNodeType::FUNCTION_CALL => translate_function_call(node, children, ctx),
         _ => Err(TranslateError::UnsupportedExpression {
             node_type: node.node_type,
@@ -525,6 +526,20 @@ fn translate_case(node: &TExprNode, children: Vec<Expression>) -> Result<Express
     })
 }
 
+/// Unwraps a StarRocks `CLONE_EXPR`, which carries no value semantics.
+///
+/// The frontend's `CloneDuplicateColRefRule` inserts it when a projection maps two output
+/// slots to the same input column, because the backend has no copy-on-write and would
+/// otherwise write the shared column twice; the backend's `CloneExpr` evaluates its child and
+/// hands back a uniquely-owned copy of the same values. The node's type and nullability are
+/// its child's by construction, so the child is returned as-is — restating the declared type
+/// with a cast would re-narrow a child the arithmetic path deliberately lowered to FP64, and
+/// make a cloned column differ from the uncloned one the frontend says it equals.
+fn translate_clone(node: &TExprNode, children: Vec<Expression>) -> Result<Expression> {
+    expect_child_count(node, &children, 1)?;
+    Ok(children.into_iter().next().unwrap())
+}
+
 /// Converts a StarRocks `FUNCTION_CALL` into a Substrait expression.
 ///
 /// Functions are allowlisted so an unknown StarRocks builtin fails loudly instead of silently
@@ -616,6 +631,18 @@ fn translate_function_call(
         }
     };
     let anchor = ctx.registry.register_function(urn, mapped);
+    // The engine binds these names through DuckDB's catalog, where year/month/day and
+    // octet_length/char_length all return BIGINT, while the FE declares narrower slots
+    // (year SMALLINT, month/day TINYINT, length/char_length INT). A downstream fragment
+    // derives its stream schema from the FE slots, so without a cast back to the declared
+    // type the produced BIGINT column is refused at the next hop's schema guard.
+    if matches!(name, "year" | "month" | "day" | "length" | "char_length") {
+        let produced = type_mapper::i64_type(node.is_nullable.unwrap_or(true));
+        return Ok(cast_to(
+            scalar_function(anchor, children, produced),
+            output_type,
+        ));
+    }
     Ok(scalar_function(anchor, children, output_type))
 }
 
@@ -900,6 +927,20 @@ fn integer_literal_type(
             node_type: Some(starrocks_thrift::types::TTypeNodeType::SCALAR),
             reason: "INT_LITERAL has non-integer scalar type",
         }),
+    }
+}
+
+/// Wraps an expression in a throwing cast to `ty`.
+///
+/// A cast to the type the expression already has is a no-op the consumer's binder elides, so
+/// this is safe to emit wherever the type has to be stated rather than inferred.
+pub(crate) fn cast_to(input: Expression, ty: Type) -> Expression {
+    Expression {
+        rex_type: Some(expression::RexType::Cast(Box::new(expression::Cast {
+            r#type: Some(ty),
+            input: Some(Box::new(input)),
+            failure_behavior: expression::cast::FailureBehavior::ThrowException as i32,
+        }))),
     }
 }
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -53,6 +53,7 @@
 //! | `ARITHMETIC_EXPR` | `add`/`subtract`/`multiply`/`divide`/`modulus` (decimal operands in FP64) |
 //! | `IN_PRED`         | singular-or-list (wrapped in `not` for `NOT IN`) |
 //! | `CASE_EXPR`       | if-then chain (no leading case operand) |
+//! | `CLONE_EXPR`      | its child, unwrapped (the frontend's copy marker has no value semantics) |
 //! | `FUNCTION_CALL`   | allowlisted scalar functions (`like`, `if`, `substring`, `year`, ...) |
 //!
 //! Aggregate functions (`sum`, `count`, `min`, `max`, `avg`, and the

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
@@ -33,6 +33,17 @@ pub(crate) fn fp64_type(nullable: bool) -> Type {
     }
 }
 
+/// Builds an I64 (BIGINT) type, the width the engine returns for builtins the frontend declares
+/// narrower (year/month/day, length/char_length).
+pub(crate) fn i64_type(nullable: bool) -> Type {
+    Type {
+        kind: Some(r#type::Kind::I64(r#type::I64 {
+            type_variation_reference: 0,
+            nullability: nullability(nullable),
+        })),
+    }
+}
+
 /// Maps a StarRocks type descriptor and slot nullability into a Substrait type.
 pub fn map_type_desc(type_desc: &TTypeDesc, nullable: bool) -> Result<Type> {
     let node = scalar_node(type_desc)?;

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
 use starrocks_plan_translator::{
-    ExtensionRegistry, PlanTranslator, TranslateError, URN_BOOLEAN, URN_COMPARISON,
-    translate_fragment,
+    ExtensionRegistry, PlanTranslator, TranslateError, URN_BOOLEAN, URN_COMPARISON, URN_DATETIME,
+    URN_STRING, translate_fragment,
 };
 use starrocks_thrift::descriptors::{
     TDescriptorTable, TSlotDescriptor, TTableDescriptor, TTupleDescriptor,
@@ -2064,6 +2064,15 @@ fn cast_expr(target: TTypeDesc, child: TExpr) -> TExpr {
     TExpr::new(nodes)
 }
 
+/// Builds a `CLONE_EXPR` around `child`, carrying the child's declared type as the frontend
+/// emits it (`CloneExpr.getType()` delegates to its child).
+fn clone_expr(child: TExpr) -> TExpr {
+    let node = base_expr_node(TExprNodeType::CLONE_EXPR, child.nodes[0].type_.clone(), 1);
+    let mut nodes = vec![node];
+    nodes.extend(child.nodes);
+    TExpr::new(nodes)
+}
+
 /// Builds a typed NULL literal expression.
 fn null_literal(primitive: TPrimitiveType) -> TExpr {
     TExpr::new(vec![base_expr_node(
@@ -3371,6 +3380,128 @@ fn function_calls_use_allowlist() {
     assert!(matches!(err, TranslateError::MalformedPlan(_)));
 }
 
+/// Builds a one-argument builtin function call declaring `ret` as the FE return type.
+fn unary_fn_call(name: &str, ret: TPrimitiveType, child: TExpr) -> TExpr {
+    let mut call = base_expr_node(TExprNodeType::FUNCTION_CALL, scalar_type(ret), 1);
+    call.fn_ = Some(builtin_function(name, scalar_type(ret)));
+    let mut nodes = vec![call];
+    nodes.extend(child.nodes);
+    TExpr::new(nodes)
+}
+
+/// Descriptor table with a DATE slot and a VARCHAR slot for scalar-function tests.
+fn date_and_string_desc() -> TDescriptorTable {
+    desc_table(
+        vec![(0, Some(100))],
+        vec![
+            slot(1, 0, "d", scalar_type(TPrimitiveType::DATE)),
+            slot(2, 0, "s", scalar_type(TPrimitiveType::VARCHAR)),
+        ],
+    )
+}
+
+/// Splits a throwing cast into its target-type kind and input expression.
+fn cast_parts(
+    expr: &substrait::proto::Expression,
+) -> (
+    &substrait::proto::r#type::Kind,
+    &substrait::proto::Expression,
+) {
+    let expression::RexType::Cast(cast) = expr.rex_type.as_ref().unwrap() else {
+        panic!("expected cast, got {expr:?}");
+    };
+    assert_eq!(
+        cast.failure_behavior,
+        expression::cast::FailureBehavior::ThrowException as i32
+    );
+    (
+        cast.r#type.as_ref().unwrap().kind.as_ref().unwrap(),
+        cast.input.as_ref().unwrap(),
+    )
+}
+
+/// Verifies FE-narrowed builtins are wrapped in a throwing cast back to the declared return
+/// type: the engine's year/month/day and octet_length/char_length return BIGINT, while the FE
+/// slots the next fragment derives its stream schema from declare SMALLINT/TINYINT/INT.
+#[test]
+fn fe_narrowed_functions_cast_to_declared_return_type() {
+    use substrait::proto::r#type::Kind;
+    let cases = [
+        ("year", TPrimitiveType::SMALLINT, URN_DATETIME, "year"),
+        ("month", TPrimitiveType::TINYINT, URN_DATETIME, "month"),
+        ("day", TPrimitiveType::TINYINT, URN_DATETIME, "day"),
+        ("length", TPrimitiveType::INT, URN_STRING, "octet_length"),
+        (
+            "char_length",
+            TPrimitiveType::INT,
+            URN_STRING,
+            "char_length",
+        ),
+    ];
+    for (name, declared, expected_urn, mapped) in cases {
+        let (child_slot, child_ty) = if expected_urn == URN_STRING {
+            (2, TPrimitiveType::VARCHAR)
+        } else {
+            (1, TPrimitiveType::DATE)
+        };
+        let call = unary_fn_call(
+            name,
+            declared,
+            slot_ref(child_slot, 0, scalar_type(child_ty)),
+        );
+        let translated = translate_fragment(&params(
+            Some(filtered_scan(binary_pred(
+                TExprOpcode::EQ,
+                call,
+                int_literal_typed(1, declared),
+            ))),
+            Some(date_and_string_desc()),
+            None,
+        ))
+        .unwrap();
+        let (kind, input) = cast_parts(scalar_arg(filter_condition(&translated.plan), 0));
+        match declared {
+            TPrimitiveType::SMALLINT => assert!(matches!(kind, Kind::I16(_)), "{name}: {kind:?}"),
+            TPrimitiveType::TINYINT => assert!(matches!(kind, Kind::I8(_)), "{name}: {kind:?}"),
+            _ => assert!(matches!(kind, Kind::I32(_)), "{name}: {kind:?}"),
+        }
+        let inner = scalar_fn(input);
+        assert!(
+            matches!(
+                inner.output_type.as_ref().unwrap().kind.as_ref().unwrap(),
+                Kind::I64(_)
+            ),
+            "{name} should state the BIGINT the engine produces before the cast"
+        );
+        let (urn, resolved) = resolved_function(&translated.plan, inner.function_reference);
+        assert_eq!(resolved, mapped, "{name}");
+        assert_eq!(urn, expected_urn, "{name}");
+    }
+}
+
+/// Pins that a builtin whose engine return type already matches the FE declaration
+/// (BOOLEAN `like`) is not wrapped in a cast.
+#[test]
+fn matching_return_type_function_stays_cast_free() {
+    let mut call = base_expr_node(
+        TExprNodeType::FUNCTION_CALL,
+        scalar_type(TPrimitiveType::BOOLEAN),
+        2,
+    );
+    call.fn_ = Some(builtin_function(
+        "like",
+        scalar_type(TPrimitiveType::BOOLEAN),
+    ));
+    let mut nodes = vec![call];
+    nodes.extend(slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR)).nodes);
+    nodes.extend(string_literal("%x%").nodes);
+    let plan = filter_with_conjunct(TExpr::new(nodes));
+    // `scalar_fn` panics if the conjunct got wrapped in a cast.
+    let scalar = scalar_fn(filter_condition(&plan));
+    let (_, resolved) = resolved_function(&plan, scalar.function_reference);
+    assert_eq!(resolved, "like");
+}
+
 /// Verifies CASE WHEN chains become Substrait if-then expressions with a null default.
 #[test]
 fn case_expression_translates_to_if_then() {
@@ -3683,6 +3814,118 @@ fn unsupported_join_type_is_reported_before_missing_conjuncts() {
         panic!("expected an unsupported plan node, got {err:?}");
     };
     assert_eq!(reason, "hash join type is unsupported");
+}
+
+/// Verifies `CLONE_EXPR` unwraps to its child, so a cloned projection slot translates
+/// identically to the slot it clones.
+#[test]
+fn clone_expr_is_transparent() {
+    let mut common_slot_map = BTreeMap::new();
+    common_slot_map.insert(5, slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)));
+    let mut slot_map = BTreeMap::new();
+    slot_map.insert(3, slot_ref(5, 1, scalar_type(TPrimitiveType::BIGINT)));
+    slot_map.insert(
+        4,
+        clone_expr(slot_ref(5, 1, scalar_type(TPrimitiveType::BIGINT))),
+    );
+
+    let mut project = base_plan_node(1, TPlanNodeType::PROJECT_NODE, 1, vec![1]);
+    project.project_node = Some(TProjectNode::new(Some(slot_map), Some(common_slot_map)));
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None)],
+        vec![
+            slot(1, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(3, 1, "value", scalar_type(TPrimitiveType::BIGINT)),
+            slot(4, 1, "value_clone", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![project, scan_node(0, 0)])),
+        Some(desc),
+        None,
+    ))
+    .unwrap();
+    let rel::RelType::Project(visible) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected visible project");
+    };
+    assert_eq!(visible.expressions.len(), 2);
+    assert_eq!(
+        visible.expressions[0], visible.expressions[1],
+        "a cloned column must translate identically to the column it clones"
+    );
+}
+
+/// Verifies `CLONE_EXPR` returns its child uncast, preserving the FP64 lowering the
+/// arithmetic path applied instead of re-narrowing to the declared decimal type.
+#[test]
+fn clone_expr_keeps_the_child_lowering() {
+    let decimal = scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(31), Some(4));
+    let mut arith = base_expr_node(TExprNodeType::ARITHMETIC_EXPR, decimal.clone(), 2);
+    arith.opcode = Some(TExprOpcode::MULTIPLY);
+    let mut nodes = vec![arith];
+    nodes.extend(slot_ref(1, 0, decimal.clone()).nodes);
+    nodes.extend(slot_ref(1, 0, decimal).nodes);
+
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![scan_node(0, 0)])),
+        Some(base_desc()),
+        Some(vec![clone_expr(TExpr::new(nodes))]),
+    ))
+    .unwrap();
+    let rel::RelType::Project(project) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected output project");
+    };
+    let expression::RexType::ScalarFunction(function) =
+        project.expressions[0].rex_type.as_ref().unwrap()
+    else {
+        panic!("expected the multiply itself, not a cast around it");
+    };
+    assert!(matches!(
+        function
+            .output_type
+            .as_ref()
+            .unwrap()
+            .kind
+            .as_ref()
+            .unwrap(),
+        substrait::proto::r#type::Kind::Fp64(_)
+    ));
+}
+
+/// Verifies a childless `CLONE_EXPR` is reported as a malformed plan.
+#[test]
+fn clone_expr_requires_exactly_one_child() {
+    let mut select = base_plan_node(1, TPlanNodeType::SELECT_NODE, 1, vec![0]);
+    select.select_node = Some(TSelectNode::new(None));
+    select.conjuncts = Some(vec![TExpr::new(vec![base_expr_node(
+        TExprNodeType::CLONE_EXPR,
+        scalar_type(TPrimitiveType::BOOLEAN),
+        0,
+    )])]);
+
+    let err = translate_fragment(&params(
+        Some(TPlan::new(vec![select, scan_node(0, 0)])),
+        Some(base_desc()),
+        None,
+    ))
+    .unwrap_err();
+    assert!(matches!(err, TranslateError::MalformedPlan(_)));
 }
 
 /// Asserts an expression is a throwing cast to FP64, the lowering every decimal operand and


### PR DESCRIPTION
## Description

Two expression-translator fixes the multi-CN branch needed to run TPC-H. Both stand alone from the translator stack.

**CLONE_EXPR.** TPC-H q01's projection reads `l_extendedprice` twice, in two products. The FE's `CloneDuplicateColRefRule` wraps the second use in `CLONE_EXPR` because the BE has no copy-on-write. The translator had no arm for it and refused the whole fragment as an unsupported expression. The node has no value semantics, so the new `translate_clone` returns the child unchanged. I chose not to re-cast it to its declared type. The type is the child's by construction, and a cast would re-narrow a product the arithmetic path already lowered to FP64, so the cloned column would differ from the uncloned one the FE says it equals.

**FE-narrowed builtins.** `year`, `month`, `day`, `length` and `char_length` bind through DuckDB, where they return BIGINT. The FE declares SMALLINT, TINYINT, TINYINT, INT and INT. When the fragment's row crosses an exchange, the receiver declares its stream from the FE slots and the hop's schema guard refuses the BIGINT column. `translate_function_call` now wraps those five calls in a throwing cast back to the declared type through the new `cast_to` helper. The scalar function itself states the BIGINT the engine produces. The binder elides a cast to a type the expression already has, so the cast costs nothing where the two agree.

**How I tested it.** On a GB200 box (aarch64) I ran the CI trio: cargo fmt, clippy with warnings as errors, and the CN test suite without the engine feature. All 176 tests pass, 5 of them new.

Changes sit in `experimental/starrocks/crates/starrocks-plan-translator`, four files. `type_mapper::i64_type` is new. `lib.rs` gains one row in the expression table.

Five new tests in `tests/translate.rs`, among them `clone_expr_is_transparent`, `fe_narrowed_functions_cast_to_declared_return_type` and `matching_return_type_function_stays_cast_free`.

Not handled. Other FE-narrowed builtins are not in the match; add them as they show up. Aggregates and slot resolution are untouched.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
- Refs #1236, the decimal to FP64 lowering. The CLONE_EXPR rule returns the child as is so it cannot undo that lowering.
- Carved from the multi-CN source branch `aocsa/feat/pin-table-cn`; independent of the translator stack (T1 to T4), which can merge in any order relative to this PR.