### PR TITLE
build(cn): carry the Sirius exchange RPCs as a checked-in StarRocks proto patch

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -45,6 +45,14 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: git submodule update --init --depth=1 --jobs 2 experimental/starrocks/starrocks experimental/starrocks/brpc
 
+      # The CN's build.rs refuses to build unless internal_service.proto declares the Sirius
+      # exchange RPCs, which are not upstream. `git submodule update` above resets the tree, so
+      # the patch has to be applied here. The script is idempotent (a no-op on a tree that
+      # already carries the patch), and running it rather than an inline `git apply` keeps CI
+      # and developers on the same code path.
+      - name: Patch starrocks proto
+        run: bash scripts/apply-starrocks-patches.sh
+
       - uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
         with:
           cache: false

--- a/.gitmodules
+++ b/.gitmodules
@@ -23,9 +23,12 @@
 [submodule "vcpkg"]
 	path = vcpkg
 	url = https://github.com/Microsoft/vcpkg.git
+# Pinned to an upstream commit; patches/*.patch are applied into the working tree
+# by `pixi run apply-starrocks-patches`, so this submodule is dirty by design.
 [submodule "starrocks/starrocks"]
 	path = experimental/starrocks/starrocks
 	url = https://github.com/starrocks/starrocks
+	ignore = dirty
 [submodule "starrocks/brpc"]
 	path = experimental/starrocks/brpc
 	url = https://github.com/apache/brpc

--- a/experimental/starrocks/build.rs
+++ b/experimental/starrocks/build.rs
@@ -32,6 +32,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed={}", brpc_dir.display());
     println!("cargo:rerun-if-changed={}", proto_dir.display());
 
+    require_exchange_proto_patch(&manifest_dir, &proto_dir)?;
+
     let mut protos = BRPC_PROTOS
         .iter()
         .map(|proto| {
@@ -52,6 +54,60 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     config.compile_protos(&protos, &[brpc_dir.join("src"), proto_dir])?;
 
     Ok(())
+}
+
+/// Fails the build, with the remedy in the message, when the `starrocks` submodule is missing the
+/// Sirius exchange RPCs.
+///
+/// Those RPCs (`PExchangeNixlMd`, `PStagingLeaseRequest`, `PTransmitPackedParams`, ...) are
+/// Sirius-only extensions that live in `patches/nixl-exchange-proto.patch`, and nothing applies
+/// the patch automatically: `git submodule update` resets the working tree to upstream. Without
+/// the patch `prost` generates a `PInternalService` that simply lacks three methods, and the
+/// handlers that implement them (the CN-to-CN exchange transport) fail far from the cause with
+/// `unresolved imports crate::proto::starrocks::PExchangeNixlMd` and `method exchange_nixl_md is
+/// not a member of trait PInternalService`. Those errors name the symptom and give a fresh clone
+/// no way to guess the fix.
+///
+/// The check lives here, not in the pixi task or the CI step, because build.rs is the one place
+/// every build path (plain cargo, pixi, CI) goes through: fail at the earliest point that can
+/// name the fix.
+fn require_exchange_proto_patch(
+    manifest_dir: &std::path::Path,
+    proto_dir: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let internal_service = proto_dir.join("internal_service.proto");
+    // A missing submodule is a different failure with a different fix, so let prost report it.
+    let Ok(contents) = std::fs::read_to_string(&internal_service) else {
+        return Ok(());
+    };
+    // One representative message rather than all of them: the patch is applied whole or not at
+    // all, and matching on a single name keeps this from breaking when the patch grows.
+    if contents.contains("message PExchangeNixlMd") {
+        return Ok(());
+    }
+    let patch = manifest_dir.join("patches/nixl-exchange-proto.patch");
+    let script = manifest_dir.join("scripts/apply-starrocks-patches.sh");
+    let submodule = proto_dir
+        .parent()
+        .and_then(|gensrc| gensrc.parent())
+        .unwrap_or(proto_dir);
+    // The guidance goes to stderr and the returned error stays one line: cargo renders a build
+    // script's error with `Debug`, which would print embedded newlines as literal `\n`.
+    eprintln!(
+        "\n\
+         {} does not define the Sirius exchange RPCs, so the CN cannot be built.\n\
+         Apply the patch to the starrocks submodule:\n\
+         \n    git -C {} apply {}\n\n\
+         or run the idempotent script that applies every patch under patches/:\n\
+         \n    bash {}\n\n\
+         The patch is not applied automatically and is not part of upstream StarRocks. Re-apply\n\
+         it after any `git submodule update` that resets the submodule working tree.\n",
+        internal_service.display(),
+        submodule.display(),
+        patch.display(),
+        script.display(),
+    );
+    Err("the starrocks submodule is missing patches/nixl-exchange-proto.patch (see above)".into())
 }
 
 /// Emits an async BRPC/Tower service facade from StarRocks' protobuf service

--- a/experimental/starrocks/patches/nixl-exchange-proto.patch
+++ b/experimental/starrocks/patches/nixl-exchange-proto.patch
@@ -1,0 +1,64 @@
+diff --git a/gensrc/proto/internal_service.proto b/gensrc/proto/internal_service.proto
+index 1e392043e89..6679b2d8d72 100644
+--- a/gensrc/proto/internal_service.proto
++++ b/gensrc/proto/internal_service.proto
+@@ -786,6 +786,49 @@ message PLookUpResponse {
+     repeated PColumn columns = 2;
+ }
+ 
++// Sirius multi-CN nixl exchange (GPU-to-GPU staging over UCX cuda_ipc).
++// These RPCs are Sirius-only extensions; upstream StarRocks does not define them.
++message PExchangeNixlMd {
++    optional string agent_name = 1;
++    optional bytes agent_metadata = 2;
++}
++
++message PExchangeNixlMdResult {
++    required StatusPB status = 1;
++    optional string agent_name = 2;
++    optional bytes agent_metadata = 3;
++}
++
++message PStagingLeaseRequest {
++    required uint64 length = 1;
++}
++
++message PStagingLeaseResult {
++    required StatusPB status = 1;
++    optional uint64 remote_addr = 2;
++    optional uint64 offset = 3;
++}
++
++message PTransmitPackedParams {
++    optional PUniqueId finst_id = 1;
++    optional int32 node_id = 2;
++    optional int32 sender_id = 3;
++    optional bool eos = 4;
++    optional int64 seq = 5;
++    optional uint64 offset = 6;
++    optional uint64 length = 7;
++    repeated string column_names = 8;
++    optional bool canary = 9;
++    // Exact row count of this batch frame (from export_packed). The receiver sums the counts
++    // per stream into declare_input_cardinality so the optimizer can size the stream; absent
++    // on EOS/canary frames and from senders that predate the field (receiver then declares
++    // nothing and keeps the legacy blind planning).
++    optional uint64 rows = 10;
++}
++
++message PTransmitPackedResult {
++    required StatusPB status = 1;
++}
+ 
+ service PInternalService {
+     rpc transmit_data(PTransmitDataParams) returns (PTransmitDataResult);
+@@ -838,4 +881,9 @@ service PInternalService {
+ 
+     rpc update_transaction_state(PUpdateTransactionStateRequest) returns (PUpdateTransactionStateResponse);
+     rpc lookup(PLookUpRequest) returns (PLookUpResponse);
++
++    // Sirius multi-CN nixl exchange.
++    rpc exchange_nixl_md(PExchangeNixlMd) returns (PExchangeNixlMdResult);
++    rpc request_staging_lease(PStagingLeaseRequest) returns (PStagingLeaseResult);
++    rpc transmit_packed(PTransmitPackedParams) returns (PTransmitPackedResult);
+ };

--- a/experimental/starrocks/pixi.toml
+++ b/experimental/starrocks/pixi.toml
@@ -40,6 +40,11 @@ wait -n "${fe_pid}" "${cn_pid}"
 '
 """,cwd = ".",depends-on = ["fe-build","cn-build"],description = "Run the local StarRocks FE and Rust CN in the foreground with logs"}
 
+# Re-applies Sirius-only StarRocks patches (nixl exchange RPCs) after a clean submodule checkout.
+# The CN's build.rs refuses an unpatched submodule, so every task that builds the CN depends on
+# this one; the script is idempotent.
+apply-starrocks-patches = {cmd = "bash scripts/apply-starrocks-patches.sh",cwd = ".",description = "Apply Sirius patches onto the StarRocks submodule"}
+
 [feature.client.dependencies]
 # Provides the `mysql` CLI that speaks the FE's MySQL wire protocol on query_port.
 mysql-client = "*"
@@ -60,12 +65,12 @@ engine-build = {cmd = "pixi run --manifest-path pixi.toml make",cwd = "../..",de
 
 # Engine-linked CN (default `sirius-engine` feature); needs the engine artifact and
 # the `engine` feature's toolchain/libs (in the default env).
-cn-build = {cmd = "cargo build --release -p sirius-starrocks-cn",depends-on = ["engine-build"],description = "Build the engine-linked StarRocks CN release binary"}
-cn-test = {cmd = "cargo test -p sirius-starrocks-cn",depends-on = ["engine-build"],description = "Run engine-linked StarRocks CN tests"}
-cn-run = {cmd = "cargo run -p sirius-starrocks-cn --",depends-on = ["engine-build"],description = "Run the engine-linked StarRocks CN with local FE defaults"}
+cn-build = {cmd = "cargo build --release -p sirius-starrocks-cn",depends-on = ["engine-build","apply-starrocks-patches"],description = "Build the engine-linked StarRocks CN release binary"}
+cn-test = {cmd = "cargo test -p sirius-starrocks-cn",depends-on = ["engine-build","apply-starrocks-patches"],description = "Run engine-linked StarRocks CN tests"}
+cn-run = {cmd = "cargo run -p sirius-starrocks-cn --",depends-on = ["engine-build","apply-starrocks-patches"],description = "Run the engine-linked StarRocks CN with local FE defaults"}
 
 # Pure-Rust path (no engine, build tree, or GPU). What CI runs.
-cn-test-no-engine = {cmd = "cargo test -p sirius-starrocks-cn --no-default-features",description = "Run Rust StarRocks CN tests without the embedded Sirius engine"}
+cn-test-no-engine = {cmd = "cargo test -p sirius-starrocks-cn --no-default-features",depends-on = ["apply-starrocks-patches"],description = "Run Rust StarRocks CN tests without the embedded Sirius engine"}
 
 # Toolchain + libs to compile and link the engine-linked CN, copied from the
 # repo-root pixi.toml so this env can build/run it. Kept in sync with that file.

--- a/experimental/starrocks/scripts/apply-starrocks-patches.sh
+++ b/experimental/starrocks/scripts/apply-starrocks-patches.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Re-applies Sirius-only patches onto the vendored StarRocks checkout.
+# Safe to re-run: skips a patch that already applies (or is already present).
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+submodule="$root/starrocks"
+patch_dir="$root/patches"
+
+if [[ ! -f "$submodule/gensrc/proto/internal_service.proto" ]]; then
+  echo "StarRocks submodule is not checked out at $submodule" >&2
+  echo "Run: git submodule update --init --recursive experimental/starrocks/starrocks" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+patches=("$patch_dir"/*.patch)
+if ((${#patches[@]} == 0)); then
+  echo "No patches under $patch_dir" >&2
+  exit 1
+fi
+
+cd "$submodule"
+for patch in "${patches[@]}"; do
+  if git apply --check "$patch" >/dev/null 2>&1; then
+    git apply "$patch"
+    echo "applied $(basename "$patch")"
+  elif git apply --reverse --check "$patch" >/dev/null 2>&1; then
+    echo "already applied $(basename "$patch")"
+  else
+    echo "failed to apply $(basename "$patch")" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Description

**Why a submodule patch and not a Sirius-owned proto.** The three RPCs this PR adds
(`exchange_nixl_md`, `request_staging_lease`, `transmit_packed`) are methods of StarRocks'
`PInternalService`. That is the service `build.rs` hands to prost to generate the CN's dispatch
trait and router, and CN-to-CN calls ride the same brpc endpoint the FE already talks to. A
separate `sirius_exchange.proto` would mean a second generated trait and a second dispatch table
for three methods. So I kept them in `internal_service.proto` and carry the edit as
`patches/nixl-exchange-proto.patch`, applied into the submodule working tree. This is what the
multi-CN branch has run with. The cost is a submodule that is dirty by design; `ignore = dirty`
in `.gitmodules` keeps it out of `git status`. If that is not acceptable upstream, vendoring a
Sirius-owned proto is the alternative. It drops the patch and the guard at the cost of a second
service. Reviewers, please answer that question explicitly before the transport PRs stack on this.

**What changed.**
- `experimental/starrocks/patches/nixl-exchange-proto.patch` (64 lines) adds six messages and
  three rpcs to `PInternalService`, commented as Sirius-only extensions.
- `experimental/starrocks/scripts/apply-starrocks-patches.sh` applies every `patches/*.patch`
  with `git apply`. It is idempotent and prints `already applied` when the reverse check passes.
- `experimental/starrocks/build.rs` gains `require_exchange_proto_patch`. When
  `internal_service.proto` lacks `message PExchangeNixlMd` it fails the build with one line that
  names the patch and the `git -C <submodule> apply <patch>` remedy, instead of letting the
  transport handlers fail later with `unresolved imports`.
- `experimental/starrocks/pixi.toml` gains an `apply-starrocks-patches` task, now a dependency of
  `cn-build`, `cn-test`, `cn-run` and `cn-test-no-engine`.
- `.github/workflows/experimental.yml` gains a `Patch starrocks proto` step right after the
  submodule init, running the same script developers run. This step is mandatory. CI checks the
  submodule out unpatched, so from this PR on an unpatched tree fails both the clippy step and
  the test step inside build.rs.

**Behaviour is unchanged.** The three RPCs generate trait methods whose default body returns
"method not implemented", the same answer the CN gives any method it does not implement today.
No `Cargo.toml`, `Cargo.lock` or `src/` change until the transport PRs implement the handlers.

**`rows = 10`.** `PTransmitPackedParams.rows` ships in the patch so the wire shape is final. Its
consumer is the exchange input cardinality work (#1694 on the engine side); nothing here reads it.

**How I tested it.** On a GB200 box (aarch64) I ran the CI trio in the pixi cn env, that is cargo fmt, clippy with warnings as errors, and the workspace test suite without the engine feature, 171 tests green. As the negative check, with the submodule unpatched a cargo check of the CN crate fails inside build.rs with the patch named and the `git apply` remedy printed, and the apply script is idempotent (a second run prints `already applied`).

**Not handled here.** The handlers, the PRPC client and the nixl agent land in the transport
PRs, and the nixl agent tier PR is gated on this one. Fork PR against `dev`, no stack.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [ ] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
- Refs #1694, exchange input cardinality on the engine side, the consumer of `rows = 10`.
- Carved from the `aocsa/feat/pin-table-cn` umbrella (draft #1686, being closed and re-cut).