### PR TITLE
feat(starrocks): translate EXCHANGE_NODE as a stream read of the engine's exchange view

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/descriptor_table.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/descriptor_table.rs
@@ -238,23 +238,31 @@ impl DescriptorTable {
 
     /// Builds the Substrait schema for a StarRocks tuple.
     pub fn named_struct(&self, tuple_id: i32) -> Result<NamedStruct> {
-        let (names, types): (Vec<_>, Vec<_>) = self
-            .materialized_slot_ids(tuple_id)?
-            .into_iter()
-            .map(|slot_id| {
+        self.named_struct_for_tuples(&[tuple_id])
+    }
+
+    /// Builds the Substrait schema for a row layout spanning one or more tuples.
+    ///
+    /// Names and types both come from the descriptor table. An exchange read renames the
+    /// columns afterwards: they are the sender's, bound positionally (see
+    /// `node_translator::translate_exchange`).
+    pub(crate) fn named_struct_for_tuples(&self, tuple_ids: &[i32]) -> Result<NamedStruct> {
+        let mut names = Vec::new();
+        let mut types = Vec::new();
+        for &tuple_id in tuple_ids {
+            for slot_id in self.materialized_slot_ids(tuple_id)? {
                 let slot = self.slot(tuple_id, slot_id)?;
-                let substrait_type =
+                names.push(slot.output_name());
+                types.push(
                     slot.substrait_type
                         .clone()
                         .ok_or(TranslateError::MissingField {
                             context: "materialized TSlotDescriptor",
                             field: "slotType",
-                        })?;
-                Ok((slot.output_name(), substrait_type))
-            })
-            .collect::<Result<Vec<_>>>()?
-            .into_iter()
-            .unzip();
+                        })?,
+                );
+            }
+        }
 
         Ok(NamedStruct {
             names,
@@ -269,7 +277,18 @@ impl DescriptorTable {
     /// Resolves a StarRocks `(tuple id, slot id)` to its zero-based field index in `row_tuples`.
     ///
     /// The tuple id comes from the `TSlotRef` and disambiguates slots: ids are unique only within
-    /// a tuple, so the same slot id can name different columns in different tuples.
+    /// a tuple, so the same slot id can name different columns in different tuples. It is NOT
+    /// authoritative, though. StarRocks' BE resolves slot refs by slot id alone (the tuple id is
+    /// only consulted by `is_bound`), and the FE relies on that: `buildAggregateTuple` never
+    /// rebinds `colRefToExpr` for grouping columns, so nodes above a multi-stage aggregation keep
+    /// naming them by the tuple they had below it (the TPC-H q16 shape). New-optimizer slot ids
+    /// are query-wide `ColumnRefOperator` ids, so the same id in another of the row's tuples is
+    /// the same column.
+    ///
+    /// Resolution rule: an exact `(tuple, slot)` match wins; otherwise, if exactly one tuple in
+    /// `row_tuples` carries the slot id, resolve to it (reproducing BE semantics). Zero
+    /// candidates is a descriptor error; more than one is too, since a fallback two tuples could
+    /// satisfy is a guess, not a resolution.
     pub fn slot_global_index(
         &self,
         tuple_id: i32,
@@ -277,21 +296,32 @@ impl DescriptorTable {
         row_tuples: &[i32],
     ) -> Result<usize> {
         let mut offset = 0;
+        let mut by_slot_id = Vec::new();
         for &candidate_tuple in row_tuples {
             let materialized = self.materialized_slot_ids(candidate_tuple)?;
-            if candidate_tuple == tuple_id
-                && let Some(index) = materialized
-                    .iter()
-                    .position(|candidate| *candidate == slot_id)
+            if let Some(index) = materialized
+                .iter()
+                .position(|candidate| *candidate == slot_id)
             {
-                return Ok(offset + index);
+                if candidate_tuple == tuple_id {
+                    return Ok(offset + index);
+                }
+                by_slot_id.push(offset + index);
             }
             offset += materialized.len();
         }
 
-        Err(TranslateError::descriptor(format!(
-            "slot {slot_id} (tuple {tuple_id}) is not part of row_tuples {row_tuples:?}"
-        )))
+        match by_slot_id.as_slice() {
+            [index] => Ok(*index),
+            [] => Err(TranslateError::descriptor(format!(
+                "slot {slot_id} (tuple {tuple_id}) is not part of row_tuples {row_tuples:?}"
+            ))),
+            _ => Err(TranslateError::descriptor(format!(
+                "slot {slot_id} (tuple {tuple_id}) is not part of row_tuples {row_tuples:?}, and {} \
+                 of those tuples carry a slot {slot_id} to fall back on",
+                by_slot_id.len()
+            ))),
+        }
     }
 
     /// Returns the Substrait named-table path for a tuple's backing table.
@@ -398,6 +428,36 @@ mod tests {
         let desc = two_tuple_desc();
         // Slot 3 lives in tuple 1, which is absent from this row layout.
         let err = desc.slot_global_index(1, 3, &[0]).unwrap_err();
+        assert!(matches!(err, TranslateError::Descriptor(_)));
+    }
+
+    /// A slot ref naming a tuple absent from the row still resolves when exactly one row tuple
+    /// carries its slot id: the TPC-H q16 shape, where `buildAggregateTuple` leaves grouping
+    /// columns bound to the tuple below the aggregation.
+    #[test]
+    fn slot_global_index_falls_back_to_the_slot_id_across_tuples() {
+        let desc = two_tuple_desc();
+        // Refs stale-bound to tuple 0 resolve against a row of [1] by slot id alone.
+        assert_eq!(desc.slot_global_index(0, 3, &[1]).unwrap(), 0);
+        assert_eq!(desc.slot_global_index(0, 4, &[1]).unwrap(), 1);
+    }
+
+    /// A fallback two tuples could satisfy is a guess, not a resolution. It must fail loudly.
+    #[test]
+    fn slot_global_index_refuses_an_ambiguous_slot_id_fallback() {
+        // Tuples 0 and 1 both carry a slot 1.
+        let desc_tbl = TDescriptorTable::new(
+            Some(vec![slot(1, 0, 0, "a"), slot(1, 1, 0, "x")]),
+            vec![
+                TTupleDescriptor::new(Some(0), None, None, None, None),
+                TTupleDescriptor::new(Some(1), None, None, None, None),
+            ],
+            None,
+            None,
+        );
+        let desc = DescriptorTable::try_from(&desc_tbl).unwrap();
+
+        let err = desc.slot_global_index(2, 1, &[0, 1]).unwrap_err();
         assert!(matches!(err, TranslateError::Descriptor(_)));
     }
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -6,9 +6,9 @@
 //! invariants over breadth: it translates one fragment at a time, and everything
 //! outside the supported surface returns a structured [`TranslateError`] that
 //! names the offending node/type — so the next contributor knows exactly what to
-//! implement next. In particular `EXCHANGE_NODE` is rejected: a fragment is
-//! translated in isolation, and multi-fragment plans (every exchange is a
-//! fragment boundary) are a later milestone.
+//! implement next. An `EXCHANGE_NODE` is a fragment boundary; it translates only
+//! when the compute node supplies, per exchange node, the engine stream view its
+//! senders' batches arrive on (see [`ExchangeInput`]).
 //!
 //! # Wire format: flat preorder
 //!
@@ -35,11 +35,12 @@
 //! | `SORT_NODE`          | `ProjectRel` (sort tuple) + `SortRel` (global row-number top-N only) |
 //! | `HASH_JOIN_NODE`      | `JoinRel` (inner/outer/left-semi; left/right anti as outer join + `is_null` filter, null-aware left anti as mark join + `not`) |
 //! | `NESTLOOP_JOIN_NODE` | `JoinRel` (constant-key inner) + optional `FilterRel`, inner/cross only |
+//! | `EXCHANGE_NODE`      | `ReadRel` (named table = the engine's `sirius_stream_<node_id>` view); a merging exchange adds a `SortRel` |
 //!
 //! Node-level `conjuncts` (scan/filter predicates, HAVING, post-join filters) become a
 //! `FilterRel` over the node's output on every supported node.
 //!
-//! Any node's non-negative `limit` (plus a sort offset) becomes a `FetchRel` on top of its
+//! Any node's non-negative `limit` (plus a sort or exchange offset) becomes a `FetchRel` on top of its
 //! relation.
 //!
 //! | Expression node   | Substrait expression |
@@ -89,6 +90,7 @@ use std::fmt;
 use prost::Message;
 use starrocks_thrift::exprs::{TExpr, TExprNodeType};
 use starrocks_thrift::internal_service::TExecPlanFragmentParams;
+use starrocks_thrift::partitions::TPartitionType;
 use substrait::proto::extensions::simple_extension_declaration;
 use substrait::proto::extensions::{SimpleExtensionDeclaration, SimpleExtensionUrn};
 use substrait::proto::{Plan, PlanRel, RelRoot, plan_rel};
@@ -128,6 +130,47 @@ pub struct TranslatedPlan {
     pub plan: Plan,
     /// Root output names as emitted in the Substrait plan.
     pub output_names: Vec<String>,
+    /// For a fragment whose data-stream sink is HASH_PARTITIONED: the output column index of
+    /// each partition key, in the sink's partition-expression order. Every sender instance of
+    /// one exchange derives the same indices from the same FE thrift, which is one leg of the
+    /// cross-sender hash-parity contract (the others are one hash function and one destination
+    /// count). `None` for UNPARTITIONED / result sinks.
+    pub output_partition_columns: Option<Vec<usize>>,
+    /// One entry per exchange node lowered to a stream read. The caller declares these on the
+    /// engine before handing it the plan: a stream has no file to infer a schema from.
+    pub stream_inputs: Vec<StreamInputSchema>,
+}
+
+/// The input stream bound to one StarRocks exchange node.
+#[derive(Clone, Debug)]
+pub struct ExchangeInput {
+    /// Receiver `EXCHANGE_NODE` id.
+    pub node_id: i32,
+    /// Name of the engine view this exchange's input stream is read through.
+    pub stream_view: String,
+    /// Sender output names, which become the stream's column names. Bound by position: one per
+    /// column of the exchange's `input_row_tuples`, in row order.
+    pub names: Vec<String>,
+}
+
+/// The schema one exchange's input stream must be declared with, as the plan reads it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StreamInputSchema {
+    /// Receiver `EXCHANGE_NODE` id, which is also the engine-side stream id.
+    pub node_id: i32,
+    /// Name of the engine view the plan reads this stream through.
+    pub stream_view: String,
+    /// Columns in plan order.
+    pub columns: Vec<StreamInputColumn>,
+}
+
+/// One column of a declared input stream.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StreamInputColumn {
+    /// Column name, matching the read's base schema.
+    pub name: String,
+    /// DuckDB type name the engine parses when declaring the stream.
+    pub ty: String,
 }
 
 impl TranslatedPlan {
@@ -147,6 +190,8 @@ impl fmt::Debug for TranslatedPlan {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TranslatedPlan")
             .field("output_names", &self.output_names)
+            .field("output_partition_columns", &self.output_partition_columns)
+            .field("stream_inputs", &self.stream_inputs)
             .field("plan", &self.explain())
             .finish()
     }
@@ -200,7 +245,19 @@ impl PlanTranslator {
     }
 
     /// Translates a StarRocks execution fragment into a Substrait plan.
+    ///
+    /// Equivalent to [`Self::translate_fragment_with_exchange_inputs`] with no bound streams, so
+    /// a fragment containing an `EXCHANGE_NODE` is refused.
     pub fn translate_fragment(&self, params: &TExecPlanFragmentParams) -> Result<TranslatedPlan> {
+        self.translate_fragment_with_exchange_inputs(params, &[])
+    }
+
+    /// Translates a fragment whose exchange nodes read the given input streams.
+    pub fn translate_fragment_with_exchange_inputs(
+        &self,
+        params: &TExecPlanFragmentParams,
+        exchange_inputs: &[ExchangeInput],
+    ) -> Result<TranslatedPlan> {
         let fragment = params
             .fragment
             .as_ref()
@@ -222,9 +279,21 @@ impl PlanTranslator {
 
         let desc = DescriptorTable::try_from(desc_tbl)?;
         let scan_paths = ScanFilePaths::from_fragment(params, &desc)?;
+        let exchange_inputs = exchange_inputs
+            .iter()
+            .map(|input| (input.node_id, input))
+            .collect::<HashMap<_, _>>();
         let mut registry = ExtensionRegistry::new();
-        let mut translated =
-            node_translator::translate_plan(plan, &desc, &scan_paths, &mut registry)?;
+        let node_translator::TranslatedFragment {
+            root: mut translated,
+            stream_inputs,
+        } = node_translator::translate_plan(
+            plan,
+            &desc,
+            &scan_paths,
+            &exchange_inputs,
+            &mut registry,
+        )?;
 
         let output_names = if let Some(output_exprs) = fragment
             .output_exprs
@@ -246,6 +315,69 @@ impl PlanTranslator {
         };
 
         let output_names = unique_names(output_names).collect::<Vec<_>>();
+
+        // One loud guard against any width/name drift at the root: the names are what the
+        // receiver (or the client) reads the row by, so a mismatch is a wrong column read
+        // waiting to happen. Never ship it.
+        if output_names.len() != translated.output_width {
+            return Err(TranslateError::malformed(format!(
+                "fragment root emits {} columns but derived {} output names",
+                translated.output_width,
+                output_names.len()
+            )));
+        }
+
+        // Resolve a hash-partitioned sink's keys to output column indices while the row layout
+        // is still in hand. Bare SLOT_REFs only: any transform would make this sender hash a
+        // value its peers do not, silently splitting equal keys across destinations.
+        let output_partition_columns = match fragment
+            .output_sink
+            .as_ref()
+            .and_then(|sink| sink.stream_sink.as_ref())
+            .map(|stream_sink| &stream_sink.output_partition)
+        {
+            Some(partition) if partition.type_ == TPartitionType::HASH_PARTITIONED => {
+                if fragment
+                    .output_exprs
+                    .as_ref()
+                    .is_some_and(|exprs| !exprs.is_empty())
+                {
+                    return Err(TranslateError::malformed(
+                        "a hash-partitioned stream sink with output_exprs cannot map its \
+                         partition keys onto the sink row (never emitted by the FE)",
+                    ));
+                }
+                let exprs = partition.partition_exprs.as_deref().unwrap_or_default();
+                if exprs.is_empty() {
+                    return Err(TranslateError::malformed(
+                        "a hash-partitioned stream sink carries no partition expressions",
+                    ));
+                }
+                let mut columns = Vec::with_capacity(exprs.len());
+                for expr in exprs {
+                    let slot_ref = match expr.nodes.as_slice() {
+                        [node] if node.node_type == TExprNodeType::SLOT_REF => {
+                            node.slot_ref.as_ref()
+                        }
+                        _ => None,
+                    };
+                    let Some(slot_ref) = slot_ref else {
+                        return Err(TranslateError::malformed(
+                            "a hash-partition key is not a bare slot reference; hashing a \
+                             transformed key would silently split equal keys across senders",
+                        ));
+                    };
+                    columns.push(desc.slot_global_index(
+                        slot_ref.tuple_id,
+                        slot_ref.slot_id,
+                        &translated.row_tuples,
+                    )?);
+                }
+                Some(columns)
+            }
+            _ => None,
+        };
+
         let (extension_urns, extensions) = registry.into_extensions();
         let substrait_plan = Plan {
             // Source the spec version from the `substrait` crate so it tracks the
@@ -268,6 +400,8 @@ impl PlanTranslator {
         Ok(TranslatedPlan {
             plan: substrait_plan,
             output_names,
+            output_partition_columns,
+            stream_inputs,
         })
     }
 }

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use starrocks_thrift::exprs::TExpr;
 use starrocks_thrift::opcodes::TExprOpcode;
@@ -20,7 +20,10 @@ use crate::error::{Result, TranslateError};
 use crate::expr_translator::{self, ExprContext, TranslateExpr};
 use crate::scan_paths::ScanFilePaths;
 use crate::type_mapper;
-use crate::{ExtensionRegistry, URN_AGGREGATE, URN_ARITHMETIC, URN_BOOLEAN, URN_COMPARISON};
+use crate::{
+    ExchangeInput, ExtensionRegistry, StreamInputColumn, StreamInputSchema, URN_AGGREGATE,
+    URN_ARITHMETIC, URN_BOOLEAN, URN_COMPARISON,
+};
 
 /// Partially translated relation plus the StarRocks row layout it emits.
 pub(crate) struct TranslatedRel {
@@ -51,8 +54,22 @@ struct PlanContext<'a> {
     /// scan ranges. Scans with paths emit a `local_files` read; path-less scans
     /// fall back to a named-table read.
     scan_paths: &'a ScanFilePaths,
+    /// Input streams keyed by receiver exchange node id.
+    exchange_inputs: &'a HashMap<i32, &'a ExchangeInput>,
     /// Substrait extension registry shared across the whole plan.
     registry: &'a mut ExtensionRegistry,
+    /// Schema of every exchange lowered to a stream read, in translation order. The caller has to
+    /// declare these on the engine before the plan can bind.
+    stream_inputs: Vec<StreamInputSchema>,
+}
+
+/// One translated fragment: its relation tree plus what the caller has to declare because the
+/// FE's descriptor table does not describe it alone.
+pub(crate) struct TranslatedFragment {
+    /// Root relation and its row layout.
+    pub root: TranslatedRel,
+    /// Schema of every exchange lowered to a stream read, in translation order.
+    pub stream_inputs: Vec<StreamInputSchema>,
 }
 
 impl<'a> PlanContext<'a> {
@@ -60,12 +77,15 @@ impl<'a> PlanContext<'a> {
     fn new(
         desc: &'a DescriptorTable,
         scan_paths: &'a ScanFilePaths,
+        exchange_inputs: &'a HashMap<i32, &'a ExchangeInput>,
         registry: &'a mut ExtensionRegistry,
     ) -> Self {
         Self {
             desc,
             scan_paths,
+            exchange_inputs,
             registry,
+            stream_inputs: Vec::new(),
         }
     }
 
@@ -167,6 +187,7 @@ fn translate_plan_node(
         TPlanNodeType::SORT_NODE => translate_sort(node, children, ctx),
         TPlanNodeType::HASH_JOIN_NODE => translate_hash_join(node, children, ctx),
         TPlanNodeType::NESTLOOP_JOIN_NODE => translate_nestloop_join(node, children, ctx),
+        TPlanNodeType::EXCHANGE_NODE => translate_exchange(node, children, ctx),
         _ => Err(TranslateError::UnsupportedPlanNode {
             node_id: node.node_id,
             node_type: node.node_type,
@@ -188,6 +209,11 @@ fn apply_fetch(input: TranslatedRel, node: &TPlanNode) -> TranslatedRel {
         .sort_node
         .as_ref()
         .and_then(|sort| sort.offset)
+        .or_else(|| {
+            node.exchange_node
+                .as_ref()
+                .and_then(|exchange| exchange.offset)
+        })
         .unwrap_or(0);
     if node.limit < 0 && offset == 0 {
         return input;
@@ -333,10 +359,133 @@ pub(crate) fn translate_plan(
     plan: &TPlan,
     desc: &DescriptorTable,
     scan_paths: &ScanFilePaths,
+    exchange_inputs: &HashMap<i32, &ExchangeInput>,
     registry: &mut ExtensionRegistry,
+) -> Result<TranslatedFragment> {
+    let mut ctx = PlanContext::new(desc, scan_paths, exchange_inputs, registry);
+    let root = plan.translate(&mut ctx)?;
+    Ok(TranslatedFragment {
+        root,
+        stream_inputs: std::mem::take(&mut ctx.stream_inputs),
+    })
+}
+
+/// Translates an `EXCHANGE_NODE` into a read of the engine stream its senders' batches arrive on.
+///
+/// An exchange is a fragment boundary: the receiver has nothing of its own to read, so the
+/// compute node binds one [`ExchangeInput`] per exchange node, naming the engine view
+/// (`sirius_stream_<node_id>`) the input stream is read through. The read's schema comes from
+/// the FE's `input_row_tuples`; its column names are the sender's, bound positionally, because
+/// the receiver's tuple can spell them differently from what the sender ships. The same schema
+/// is recorded on the context as the declaration the engine needs before the plan can bind.
+///
+/// A merging exchange (`sort_info` present) merges its senders' sorted runs; here it becomes a
+/// `SortRel` over the stream read, which yields the same rows in the same order.
+fn translate_exchange(
+    node: &TPlanNode,
+    children: Vec<TranslatedRel>,
+    ctx: &mut PlanContext<'_>,
 ) -> Result<TranslatedRel> {
-    let mut ctx = PlanContext::new(desc, scan_paths, registry);
-    plan.translate(&mut ctx)
+    expect_children(node, &children, 0)?;
+    let exchange = node
+        .exchange_node
+        .as_ref()
+        .ok_or(TranslateError::MissingField {
+            context: "EXCHANGE_NODE",
+            field: "exchange_node",
+        })?;
+    if exchange.input_row_tuples.is_empty() {
+        return Err(TranslateError::MissingField {
+            context: "TExchangeNode",
+            field: "input_row_tuples",
+        });
+    }
+    let input =
+        ctx.exchange_inputs
+            .get(&node.node_id)
+            .ok_or(TranslateError::UnsupportedPlanNode {
+                node_id: node.node_id,
+                node_type: node.node_type,
+                reason: "exchange node has no bound input stream; the compute node binds one per \
+                         receiver exchange",
+            })?;
+    // The view name is the only thing tying this read to the stream the engine fills. An empty
+    // one would emit a read of a table named "" and fail at bind time with no mention of the
+    // exchange.
+    if input.stream_view.is_empty() {
+        return Err(TranslateError::malformed(format!(
+            "exchange node {} is bound to an input stream with an empty view name",
+            node.node_id
+        )));
+    }
+    let mut schema = ctx
+        .desc
+        .named_struct_for_tuples(&exchange.input_row_tuples)?;
+    let output_width = schema
+        .r#struct
+        .as_ref()
+        .map(|structure| structure.types.len())
+        .unwrap_or(0);
+    // The stream's columns are the sender's, named by the sender and bound by position: one
+    // name per column of the declared row layout, or a column would be read under the wrong
+    // name.
+    if input.names.len() != output_width {
+        return Err(TranslateError::descriptor(format!(
+            "row layout {:?} has {} fields but exchange input has {} names",
+            exchange.input_row_tuples,
+            output_width,
+            input.names.len()
+        )));
+    }
+    schema.names = input.names.clone();
+
+    // The declaration the engine needs, derived from the very types the read carries so the
+    // plan's view of a column and the engine's cannot drift apart.
+    let columns = schema
+        .names
+        .iter()
+        .cloned()
+        .zip(
+            schema
+                .r#struct
+                .as_ref()
+                .map(|structure| structure.types.as_slice())
+                .unwrap_or_default(),
+        )
+        .map(|(name, ty)| {
+            Ok(StreamInputColumn {
+                name,
+                ty: type_mapper::duckdb_type_name(ty)?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    ctx.stream_inputs.push(StreamInputSchema {
+        node_id: node.node_id,
+        stream_view: input.stream_view.clone(),
+        columns,
+    });
+
+    let mut translated = TranslatedRel {
+        rel: stream_read_rel(schema, &input.stream_view),
+        row_tuples: exchange.input_row_tuples.clone(),
+        output_width,
+    };
+    if let Some(sort_info) = &exchange.sort_info {
+        let sorts = sort_fields(sort_info, &translated, ctx)?;
+        let row_tuples = translated.row_tuples.clone();
+        translated = TranslatedRel {
+            rel: Rel {
+                rel_type: Some(rel::RelType::Sort(Box::new(SortRel {
+                    input: Some(Box::new(translated.rel)),
+                    sorts,
+                    ..Default::default()
+                }))),
+            },
+            row_tuples,
+            output_width,
+        };
+    }
+    apply_conjuncts(translated, node, ctx)
 }
 
 /// Translates a one-phase `AGGREGATION_NODE` into a Substrait aggregate relation.
@@ -1012,6 +1161,23 @@ fn scan_rel(desc: &DescriptorTable, tuple_id: i32, file_paths: &[String]) -> Res
     })
 }
 
+/// Builds a read of an engine stream view with an explicit schema.
+///
+/// The view is a named table as far as Substrait is concerned; the engine defines it as a read of
+/// the corresponding input stream, so the plan never names a file.
+fn stream_read_rel(schema: substrait::proto::NamedStruct, stream_view: &str) -> Rel {
+    Rel {
+        rel_type: Some(rel::RelType::Read(Box::new(ReadRel {
+            base_schema: Some(schema),
+            read_type: Some(ReadType::NamedTable(NamedTable {
+                names: vec![stream_view.to_string()],
+                ..Default::default()
+            })),
+            ..Default::default()
+        }))),
+    }
+}
+
 /// Translates a StarRocks project node while preserving descriptor output order.
 fn translate_project_node(
     child: TranslatedRel,
@@ -1080,9 +1246,10 @@ pub(crate) fn project_exprs(
     registry: &mut ExtensionRegistry,
 ) -> Result<TranslatedRel> {
     // Root projections evaluate over already-translated inputs, so there are no
-    // scan nodes to resolve file paths for.
+    // scan nodes to resolve file paths for and no exchange nodes to bind streams to.
     let scan_paths = ScanFilePaths::default();
-    let mut ctx = PlanContext::new(desc, &scan_paths, registry);
+    let exchange_inputs = HashMap::new();
+    let mut ctx = PlanContext::new(desc, &scan_paths, &exchange_inputs, registry);
     project_exprs_with_context(input, exprs, &mut ctx)
 }
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
@@ -33,6 +33,45 @@ pub(crate) fn fp64_type(nullable: bool) -> Type {
     }
 }
 
+/// Renders a Substrait type as the DuckDB type name the engine parses when a fragment declares
+/// an input stream's schema.
+///
+/// A stream has no file to probe, so the engine cannot infer the schema; it is declared. Deriving
+/// the declaration from the very `Type` the plan's read carries is what keeps the two from
+/// drifting. The alternative, a second StarRocks-to-DuckDB mapping, would be a silent
+/// wrong-results bug the first time the two disagreed.
+pub fn duckdb_type_name(ty: &Type) -> Result<String> {
+    let kind = ty
+        .kind
+        .as_ref()
+        .ok_or_else(|| TranslateError::malformed("stream input column has no type"))?;
+    let name = match kind {
+        r#type::Kind::Bool(_) => "BOOLEAN".to_string(),
+        r#type::Kind::I8(_) => "TINYINT".to_string(),
+        r#type::Kind::I16(_) => "SMALLINT".to_string(),
+        r#type::Kind::I32(_) => "INTEGER".to_string(),
+        r#type::Kind::I64(_) => "BIGINT".to_string(),
+        r#type::Kind::Fp32(_) => "FLOAT".to_string(),
+        r#type::Kind::Fp64(_) => "DOUBLE".to_string(),
+        // DuckDB's CHAR is an alias of VARCHAR, so the declared length carries no information.
+        r#type::Kind::FixedChar(_) | r#type::Kind::Varchar(_) | r#type::Kind::String(_) => {
+            "VARCHAR".to_string()
+        }
+        r#type::Kind::Binary(_) | r#type::Kind::FixedBinary(_) => "BLOB".to_string(),
+        r#type::Kind::Date(_) => "DATE".to_string(),
+        r#type::Kind::PrecisionTimestamp(_) => "TIMESTAMP".to_string(),
+        r#type::Kind::Decimal(decimal) => {
+            format!("DECIMAL({},{})", decimal.precision, decimal.scale)
+        }
+        _ => {
+            return Err(TranslateError::malformed(
+                "stream input column type has no DuckDB name",
+            ));
+        }
+    };
+    Ok(name)
+}
+
 /// Maps a StarRocks type descriptor and slot nullability into a Substrait type.
 pub fn map_type_desc(type_desc: &TTypeDesc, nullable: bool) -> Result<Type> {
     let node = scalar_node(type_desc)?;

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -1,9 +1,10 @@
 use std::collections::BTreeMap;
 
 use starrocks_plan_translator::{
-    ExtensionRegistry, PlanTranslator, TranslateError, URN_BOOLEAN, URN_COMPARISON,
-    translate_fragment,
+    ExchangeInput, ExtensionRegistry, PlanTranslator, TranslateError, TranslatedPlan, URN_BOOLEAN,
+    URN_COMPARISON, translate_fragment,
 };
+use starrocks_thrift::data_sinks::{TDataSink, TDataSinkType, TDataStreamSink};
 use starrocks_thrift::descriptors::{
     TDescriptorTable, TSlotDescriptor, TTableDescriptor, TTupleDescriptor,
 };
@@ -19,8 +20,9 @@ use starrocks_thrift::opcodes::TExprOpcode;
 use starrocks_thrift::partitions::{TDataPartition, TPartitionType};
 use starrocks_thrift::plan_nodes::{
     TAggregationNode, TBrokerRangeDesc, TBrokerScanRange, TBrokerScanRangeParams, TEqJoinCondition,
-    TFileFormatType, TFileScanNode, TFileScanType, THashJoinNode, TJoinOp, TNestLoopJoinNode,
-    TPlan, TPlanNode, TPlanNodeType, TProjectNode, TScanRange, TSelectNode, TSortInfo, TSortNode,
+    TExchangeNode, TFileFormatType, TFileScanNode, TFileScanType, THashJoinNode, TJoinOp,
+    TNestLoopJoinNode, TPlan, TPlanNode, TPlanNodeType, TProjectNode, TScanRange, TSelectNode,
+    TSortInfo, TSortNode,
 };
 use starrocks_thrift::planner::TPlanFragment;
 use starrocks_thrift::types::{
@@ -3202,24 +3204,483 @@ fn nestloop_join_without_a_liftable_comparison_still_translates() {
     }
 }
 
-/// Verifies an exchange node is still rejected: fragments are translated in isolation and
-/// multi-fragment plans are a later milestone.
+/// Builds an EXCHANGE_NODE `node_id` over `input_row_tuples`, optionally merging (`sort_info`)
+/// and skipping `offset` rows.
+fn exchange_node_with(
+    node_id: i32,
+    input_row_tuples: Vec<i32>,
+    sort_info: Option<TSortInfo>,
+    offset: Option<i64>,
+) -> TPlanNode {
+    let mut exchange = base_plan_node(
+        node_id,
+        TPlanNodeType::EXCHANGE_NODE,
+        0,
+        input_row_tuples.clone(),
+    );
+    exchange.exchange_node = Some(TExchangeNode::new(
+        input_row_tuples,
+        sort_info,
+        offset,
+        Some(TPartitionType::UNPARTITIONED),
+        Some(true),
+        None,
+    ));
+    exchange
+}
+
+/// Binds exchange node `node_id` to the engine view `sirius_stream_<node_id>` with the given
+/// sender names.
+fn stream_input(node_id: i32, names: &[&str]) -> ExchangeInput {
+    ExchangeInput {
+        node_id,
+        stream_view: format!("sirius_stream_{node_id}"),
+        names: names.iter().map(|name| name.to_string()).collect(),
+    }
+}
+
+/// Translates `plan` over `desc` with the given input streams bound.
+fn translate_with_streams(
+    plan: TPlan,
+    desc: TDescriptorTable,
+    inputs: &[ExchangeInput],
+) -> Result<TranslatedPlan, TranslateError> {
+    PlanTranslator::new()
+        .translate_fragment_with_exchange_inputs(&params(Some(plan), Some(desc), None), inputs)
+}
+
+/// Verifies an exchange node without a bound input stream is rejected, naming the node: a
+/// fragment translated in isolation has nothing to read the exchange from.
 #[test]
 fn exchange_node_is_rejected() {
-    let exchange = base_plan_node(1, TPlanNodeType::EXCHANGE_NODE, 0, vec![0]);
     let err = translate_fragment(&params(
-        Some(TPlan::new(vec![exchange])),
+        Some(TPlan::new(vec![exchange_node_with(1, vec![0], None, None)])),
         Some(base_desc()),
         None,
     ))
     .unwrap_err();
-    assert!(matches!(
-        err,
-        TranslateError::UnsupportedPlanNode {
-            node_type: TPlanNodeType::EXCHANGE_NODE,
-            ..
-        }
+    assert!(
+        matches!(
+            err,
+            TranslateError::UnsupportedPlanNode {
+                node_id: 1,
+                node_type: TPlanNodeType::EXCHANGE_NODE,
+                ..
+            }
+        ),
+        "{err:?}"
+    );
+}
+
+/// Verifies a bound exchange becomes a stream read below the receiver aggregate, and that no
+/// file appears anywhere in the plan: the boundary is a stream, not a parquet round-trip.
+#[test]
+fn bound_exchange_feeds_aggregate_from_a_stream() {
+    let aggregate = aggregation_node(
+        8,
+        1,
+        vec![slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))],
+        vec![aggregate_expr(
+            "sum",
+            scalar_type(TPrimitiveType::BIGINT),
+            Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+        )],
+    );
+    let translated = translate_with_streams(
+        TPlan::new(vec![aggregate, exchange_node_with(7, vec![0], None, None)]),
+        agg_desc(),
+        &[stream_input(7, &["id", "name"])],
+    )
+    .unwrap();
+
+    let root = root(&translated.plan);
+    let rel::RelType::Aggregate(aggregate) =
+        root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected aggregate receiver");
+    };
+    let rel::RelType::Read(read) = aggregate.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected exchange read");
+    };
+    let Some(read_rel::ReadType::NamedTable(table)) = read.read_type.as_ref() else {
+        panic!("expected a stream read for the exchange input");
+    };
+    assert_eq!(table.names, vec!["sirius_stream_7"]);
+    assert_eq!(read.base_schema.as_ref().unwrap().names, vec!["id", "name"]);
+    assert!(translated.output_partition_columns.is_none());
+
+    // The declaration the engine needs, derived from the same schema the read carries.
+    assert_eq!(translated.stream_inputs.len(), 1);
+    let stream = &translated.stream_inputs[0];
+    assert_eq!(stream.node_id, 7);
+    assert_eq!(stream.stream_view, "sirius_stream_7");
+    assert_eq!(
+        stream
+            .columns
+            .iter()
+            .map(|column| (column.name.as_str(), column.ty.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("id", "BIGINT"), ("name", "VARCHAR")]
+    );
+}
+
+/// The sender's names win over the receiver's descriptor names: the stream's columns are bound
+/// positionally and the fragment's root is named by its own tuple, so a rename at the boundary
+/// changes the read's schema and nothing else.
+#[test]
+fn exchange_columns_take_the_senders_names_positionally() {
+    let translated = translate_with_streams(
+        TPlan::new(vec![exchange_node_with(7, vec![0], None, None)]),
+        base_desc(),
+        &[stream_input(7, &["sender_id", "sender_name"])],
+    )
+    .unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["id", "name"]);
+    let rel::RelType::Read(read) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected the exchange read at the root");
+    };
+    assert_eq!(
+        read.base_schema.as_ref().unwrap().names,
+        vec!["sender_id", "sender_name"]
+    );
+    assert_eq!(
+        translated.stream_inputs[0]
+            .columns
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["sender_id", "sender_name"]
+    );
+}
+
+/// A multi-stage DISTINCT reallocates its columns into a fresh tuple at every stage, but the
+/// FE's `buildAggregateTuple` never rebinds `colRefToExpr` for grouping columns, so every ref
+/// above the first aggregation keeps naming the tuple from below it (TPC-H q16's
+/// `count(distinct ps_suppkey)` reaches its final stage still naming the scan-side tuple). The
+/// BE resolves slot refs by slot id alone, so those stale refs must resolve the same way here.
+#[test]
+fn stale_tuple_ids_from_a_multi_stage_distinct_resolve_by_slot_id() {
+    // Four tuples reallocating the same two columns: suppkey keeps slot 2 and brand slot 9
+    // through tuple 0 (below the aggregation), tuple 1 (the exchange input), and tuple 2 (the
+    // dedup output); tuple 3 is the counting output (brand key, count slot 23).
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None), (2, None), (3, None)],
+        vec![
+            slot(2, 0, "ps_suppkey", scalar_type(TPrimitiveType::BIGINT)),
+            slot(9, 0, "p_brand", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(2, 1, "ps_suppkey", scalar_type(TPrimitiveType::BIGINT)),
+            slot(9, 1, "p_brand", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(2, 2, "ps_suppkey", scalar_type(TPrimitiveType::BIGINT)),
+            slot(9, 2, "p_brand", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(9, 3, "p_brand", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(23, 3, "supplier_cnt", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+
+    let exchange = exchange_node_with(4, vec![1], None, None);
+    // The dedup stage: grouping-only, its refs stale-bound to tuple 0.
+    let dedup = aggregation_node(
+        5,
+        2,
+        vec![
+            slot_ref(2, 0, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(9, 0, scalar_type(TPrimitiveType::VARCHAR)),
+        ],
+        Vec::new(),
+    );
+    // The counting stage: its count argument names tuple 0 too.
+    let count = aggregation_node(
+        6,
+        3,
+        vec![slot_ref(9, 0, scalar_type(TPrimitiveType::VARCHAR))],
+        vec![aggregate_expr(
+            "count",
+            scalar_type(TPrimitiveType::BIGINT),
+            Some(slot_ref(2, 0, scalar_type(TPrimitiveType::BIGINT))),
+        )],
+    );
+    let translated = translate_with_streams(
+        TPlan::new(vec![count, dedup, exchange]),
+        desc,
+        &[stream_input(4, &["ps_suppkey", "p_brand"])],
+    )
+    .unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["p_brand", "supplier_cnt"]);
+    let rel::RelType::Aggregate(counting) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected counting aggregate");
+    };
+    // The deduped row is [ps_suppkey, p_brand]: the count groups on brand and counts suppkey.
+    assert_eq!(counting.grouping_expressions.len(), 1);
+    assert_eq!(field_index(&counting.grouping_expressions[0]), 1);
+    assert_eq!(counting.measures.len(), 1);
+    let measure = counting.measures[0].measure.as_ref().unwrap();
+    assert_eq!(measure.arguments.len(), 1);
+    let substrait::proto::function_argument::ArgType::Value(argument) =
+        measure.arguments[0].arg_type.as_ref().unwrap()
+    else {
+        panic!("expected value argument");
+    };
+    assert_eq!(field_index(argument), 0);
+
+    let rel::RelType::Aggregate(dedup) =
+        counting.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected dedup aggregate under the count");
+    };
+    let keys: Vec<_> = dedup.grouping_expressions.iter().map(field_index).collect();
+    assert_eq!(keys, vec![0, 1]);
+    assert!(dedup.measures.is_empty());
+}
+
+/// Verifies a merging exchange globally sorts the stream it reads: the senders' runs arrive in
+/// no particular interleaving, and a plain read would drop the cross-fragment ORDER BY.
+#[test]
+fn merging_exchange_becomes_sort_over_stream_read() {
+    let sort_info = TSortInfo::new(
+        vec![slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))],
+        vec![false],
+        vec![false],
+        None,
+    );
+    let translated = translate_with_streams(
+        TPlan::new(vec![exchange_node_with(
+            7,
+            vec![0],
+            Some(sort_info),
+            Some(0),
+        )]),
+        base_desc(),
+        &[stream_input(7, &["id", "name"])],
+    )
+    .unwrap();
+
+    let root = root(&translated.plan);
+    let rel::RelType::Sort(sort) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected merging exchange sort");
+    };
+    let rel::RelType::Read(read) = sort.input.as_ref().unwrap().rel_type.as_ref().unwrap() else {
+        panic!("expected an exchange read under the sort");
+    };
+    assert!(
+        matches!(
+            read.read_type.as_ref(),
+            Some(read_rel::ReadType::NamedTable(_))
+        ),
+        "a merging exchange must stream its input too, not re-scan a file"
+    );
+    assert_eq!(sort.sorts.len(), 1);
+    assert_eq!(field_index(sort.sorts[0].expr.as_ref().unwrap()), 0);
+    assert_eq!(
+        sort.sorts[0].sort_kind,
+        Some(substrait::proto::sort_field::SortKind::Direction(
+            substrait::proto::sort_field::SortDirection::DescNullsLast as i32
+        ))
+    );
+}
+
+/// Without `input_row_tuples` there is no row layout to type the stream with.
+#[test]
+fn exchange_without_input_row_tuples_is_rejected() {
+    let err = translate_with_streams(
+        TPlan::new(vec![exchange_node_with(7, Vec::new(), None, None)]),
+        base_desc(),
+        &[stream_input(7, &["id", "name"])],
+    )
+    .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            TranslateError::MissingField {
+                context: "TExchangeNode",
+                field: "input_row_tuples"
+            }
+        ),
+        "{err:?}"
+    );
+}
+
+/// The view name is what ties the read to the stream the engine fills. An empty one would bind
+/// a table named "" and fail far from the exchange that caused it.
+#[test]
+fn exchange_bound_to_an_empty_stream_view_is_rejected() {
+    let err = translate_with_streams(
+        TPlan::new(vec![exchange_node_with(7, vec![0], None, None)]),
+        base_desc(),
+        &[ExchangeInput {
+            node_id: 7,
+            stream_view: String::new(),
+            names: vec!["id".to_string(), "name".to_string()],
+        }],
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, TranslateError::MalformedPlan { .. }),
+        "{err:?}"
+    );
+}
+
+/// The sender's name list must have one entry per column of the declared row layout; a mismatch
+/// would otherwise bind columns positionally under the wrong names.
+#[test]
+fn exchange_names_must_match_the_row_layout_arity() {
+    let err = translate_with_streams(
+        TPlan::new(vec![exchange_node_with(7, vec![0], None, None)]),
+        base_desc(),
+        &[stream_input(7, &["only_one"])],
+    )
+    .unwrap_err();
+    assert!(matches!(err, TranslateError::Descriptor(_)), "{err:?}");
+}
+
+/// An exchange node carries its own skip offset, not just a sort. It must reach the fetch with an
+/// explicit unlimited count, or the consumer decodes the unset count as `LIMIT 0`.
+#[test]
+#[allow(deprecated)]
+fn exchange_offset_becomes_a_fetch() {
+    let translated = translate_with_streams(
+        TPlan::new(vec![exchange_node_with(7, vec![0], None, Some(5))]),
+        base_desc(),
+        &[stream_input(7, &["id", "name"])],
+    )
+    .unwrap();
+    let rel::RelType::Fetch(fetch) = root(&translated.plan)
+        .input
+        .as_ref()
+        .unwrap()
+        .rel_type
+        .as_ref()
+        .unwrap()
+    else {
+        panic!("expected the exchange offset to become a fetch");
+    };
+    assert_eq!(
+        fetch.count_mode,
+        Some(substrait::proto::fetch_rel::CountMode::Count(-1))
+    );
+    assert_eq!(
+        fetch.offset_mode,
+        Some(substrait::proto::fetch_rel::OffsetMode::Offset(5))
+    );
+}
+
+/// Builds fragment params whose output sink is a data-stream sink with `partition`.
+fn params_with_stream_sink(
+    plan: TPlan,
+    desc: TDescriptorTable,
+    output_exprs: Option<Vec<TExpr>>,
+    partition: TDataPartition,
+) -> TExecPlanFragmentParams {
+    let mut params = params(Some(plan), Some(desc), output_exprs);
+    params.fragment.as_mut().unwrap().output_sink = Some(TDataSink::new(
+        TDataSinkType::DATA_STREAM_SINK,
+        Some(TDataStreamSink::new(
+            9, partition, None, None, None, None, None,
+        )),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
     ));
+    params
+}
+
+/// Builds a hash partition over the given key expressions.
+fn hash_partition(keys: Vec<TExpr>) -> TDataPartition {
+    TDataPartition::new(TPartitionType::HASH_PARTITIONED, Some(keys), None, None)
+}
+
+/// A hash-partitioned sink's keys resolve to output column indices in partition-expression
+/// order, and an unpartitioned sink resolves to none: the sender hashes exactly the columns the
+/// FE named, in the order it named them.
+#[test]
+fn hash_partitioned_sink_resolves_partition_keys_to_output_columns() {
+    let translated = translate_fragment(&params_with_stream_sink(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        None,
+        hash_partition(vec![
+            slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR)),
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+        ]),
+    ))
+    .unwrap();
+    assert_eq!(translated.output_partition_columns, Some(vec![1, 0]));
+
+    let unpartitioned = translate_fragment(&params_with_stream_sink(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        None,
+        TDataPartition::new(TPartitionType::UNPARTITIONED, None, None, None),
+    ))
+    .unwrap();
+    assert!(unpartitioned.output_partition_columns.is_none());
+}
+
+/// A transformed partition key is refused: this sender would hash a value its peers do not,
+/// silently splitting equal keys across destinations.
+#[test]
+fn hash_partitioned_sink_with_a_transformed_key_is_rejected() {
+    let err = translate_fragment(&params_with_stream_sink(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        None,
+        hash_partition(vec![arithmetic(
+            TExprOpcode::ADD,
+            slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)),
+            int_literal(1),
+        )]),
+    ))
+    .unwrap_err();
+    assert!(
+        matches!(err, TranslateError::MalformedPlan { .. }),
+        "{err:?}"
+    );
+}
+
+/// A hash-partitioned sink with no partition expressions has nothing to hash, and one with
+/// fragment output expressions has a sink row the FE's slot refs no longer describe. Both are
+/// refused rather than guessed at.
+#[test]
+fn hash_partitioned_sink_without_resolvable_keys_is_rejected() {
+    let no_keys = translate_fragment(&params_with_stream_sink(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        None,
+        hash_partition(Vec::new()),
+    ))
+    .unwrap_err();
+    assert!(
+        matches!(no_keys, TranslateError::MalformedPlan { .. }),
+        "{no_keys:?}"
+    );
+
+    let reprojected = translate_fragment(&params_with_stream_sink(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        Some(vec![slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))]),
+        hash_partition(vec![slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))]),
+    ))
+    .unwrap_err();
+    assert!(
+        matches!(reprojected, TranslateError::MalformedPlan { .. }),
+        "{reprojected:?}"
+    );
 }
 
 /// Returns every extension function name declared by the plan.

--- a/experimental/starrocks/src/engine.rs
+++ b/experimental/starrocks/src/engine.rs
@@ -204,6 +204,8 @@ mod tests {
         TranslatedPlan {
             plan,
             output_names: names,
+            output_partition_columns: None,
+            stream_inputs: Vec::new(),
         }
     }
 
@@ -272,6 +274,8 @@ mod tests {
         TranslatedPlan {
             plan,
             output_names: names,
+            output_partition_columns: None,
+            stream_inputs: Vec::new(),
         }
     }
 

--- a/experimental/starrocks/src/fragment_executor.rs
+++ b/experimental/starrocks/src/fragment_executor.rs
@@ -86,6 +86,8 @@ mod tests {
         TranslatedPlan {
             plan: Default::default(),
             output_names: names.iter().map(|name| name.to_string()).collect(),
+            output_partition_columns: None,
+            stream_inputs: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Description

Layer 1 of the translator stack; base `dev`.

An `EXCHANGE_NODE` is a fragment boundary. `dev` refuses it, so every multi-fragment plan fails to translate: every two-phase aggregate, every distributed join. TPC-H runs today only with `SET new_planner_agg_stage = 1` on one GPU.

This layer lowers the receiver's exchange to a `ReadRel` over the engine's `sirius_stream_<node_id>` view. That name is the one the CN and the engine already share (`sirius::ffi::stream_view_name`, Rust binding in #1702). The compute node supplies, per exchange node, an `ExchangeInput { node_id, stream_view, names }` through the new `PlanTranslator::translate_fragment_with_exchange_inputs`; `translate_fragment` delegates with no inputs and keeps refusing exchanges. A stream has no file to infer a schema from, so the translator records each exchange's schema (name plus DuckDB type name per column, derived from the same `Type` the read carries) on `TranslatedPlan.stream_inputs` for the CN to declare.

Rows never leave the GPU (`relay_from` on one node, packed bytes across nodes). That is why I did not take the materialize-to-parquet route of #1242; it added a GPU to file to GPU round trip per hop and could not name a remote sender.

What the exchange becomes:

- The read's schema comes from `input_row_tuples` (`named_struct_for_tuples`, which spans several tuples). Its column names are the sender's, bound by position: one name per column of the row layout, or the translation fails with a descriptor error. The receiver's own tuple still names the fragment root.
- A merging exchange (`sort_info` present) becomes a `SortRel` over the stream read, built with the existing sort helpers. The senders' runs arrive in no fixed interleaving, so a plain read would drop the cross-fragment ORDER BY.
- An exchange's own `offset` reaches `apply_fetch`, so `OFFSET n` on an exchange emits a `FetchRel` with an explicit unlimited count instead of being ignored.
- Guards: an unbound exchange is refused naming the node, as are empty `input_row_tuples`, an empty `stream_view`, and a names/width mismatch.

Two pieces the read needs ride along. `slot_global_index` falls back to the slot id when exactly one row tuple carries it (the FE leaves grouping refs bound to the tuple below a multi-stage aggregation, the TPC-H q16 shape); two candidates is still an error. And `TranslatedPlan.output_partition_columns` resolves a HASH_PARTITIONED stream sink's keys to output column indices, bare `SLOT_REF`s only. A transformed key would make one sender hash a value its peers do not, so it is refused, as are a hash sink with no partition expressions and one combined with `output_exprs`. A root-level guard now rejects any width/name drift between the emitted row and its names.

The CN crate changes are mechanical: three test literals gain the two new `TranslatedPlan` fields.

**How I tested it.** On a GB200 box (aarch64) I ran the CI trio: cargo fmt, clippy with warnings as errors, and the CN workspace tests without the engine feature. All 184 tests pass; the translator integration suite goes from 116 on dev to 127, and the 11 new ones (among them `merging_exchange_becomes_sort_over_stream_read`, `exchange_offset_becomes_a_fetch` and `hash_partitioned_sink_with_a_transformed_key_is_rejected`) plus 2 new descriptor_table unit tests all pass.

Not here: aggregation phases (partial/merge translation is the next layer; this one still accepts one-phase aggregates only) and the CN wiring that declares the streams and routes batches (the `cn` stack).

## Checklist

- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References

- Supersedes #1242 (closed): its `translate_fragment_with_exchange_inputs` / `ExchangeInput` API and three guard tests survive here, rewritten for streams.
- Refs #1481, #1702.