### PR TITLE
feat(starrocks): translate both halves of a two-phase aggregation

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/agg_phase.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/agg_phase.rs
@@ -1,0 +1,80 @@
+//! Phase classification for StarRocks aggregation nodes.
+//!
+//! StarRocks encodes the phase of a (possibly multi-phase) aggregation in two thrift fields:
+//! `TAggregationNode.need_finalize` (does this node produce final values?) and, per measure,
+//! `TAggregateExpr.is_merge_agg` (does this measure consume partial states?). The combinations
+//! map onto the FE's phase names:
+//!
+//! | `need_finalize` | `is_merge_agg` | FE phase          | classification          |
+//! |-----------------|----------------|-------------------|-------------------------|
+//! | true            | none           | one-phase         | [`AggPhase::OneShot`]   |
+//! | false           | none           | update serialize  | [`AggPhase::Partial`]   |
+//! | true            | all            | merge finalize    | [`AggPhase::Merge`]     |
+//! | false           | all            | merge serialize   | error (3/4-phase plan)  |
+//! | —               | mixed          | —                 | error                   |
+//!
+//! Both legacy guards — the node-level `need_finalize` check and the expression-level
+//! `is_merge_agg` rejection — are subsumed here. They must never be relaxed independently: the
+//! node-level tuple-id check alone does not stop a merge node (new-optimizer plans always set
+//! `intermediate_tuple_id == output_tuple_id`), so a classifier that saw only `need_finalize`
+//! would translate a merge node as a one-shot aggregate and double-aggregate silently.
+
+use starrocks_thrift::plan_nodes::{TAggregationNode, TPlanNodeType};
+
+use crate::error::{Result, TranslateError};
+
+/// The role an aggregation node plays in the FE's aggregation plan.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AggPhase {
+    /// One-phase finalized aggregation over raw rows (`new_planner_agg_stage = 1` plans).
+    OneShot,
+    /// First phase of a two-phase plan ("update serialize"): aggregates raw rows and emits
+    /// partial-state columns without finalizing.
+    Partial,
+    /// Final phase of a two-phase plan ("merge finalize"): merges partial states arriving
+    /// from an exchange and finalizes.
+    Merge,
+}
+
+/// Classifies an aggregation node's phase from `need_finalize` and the measures'
+/// `is_merge_agg` flags.
+///
+/// A measure whose root expression carries no `agg_expr` counts as non-merge here; the
+/// expression translator rejects such a measure with its own malformed-aggregate error.
+pub(crate) fn classify(
+    node_id: i32,
+    node_type: TPlanNodeType,
+    agg: &TAggregationNode,
+) -> Result<AggPhase> {
+    let merge_flags = agg.aggregate_functions.iter().map(|expr| {
+        expr.nodes
+            .first()
+            .and_then(|root| root.agg_expr.as_ref())
+            .is_some_and(|agg_expr| agg_expr.is_merge_agg)
+    });
+    let (mut merge, mut update) = (0usize, 0usize);
+    for is_merge in merge_flags {
+        if is_merge {
+            merge += 1;
+        } else {
+            update += 1;
+        }
+    }
+    match (agg.need_finalize, merge, update) {
+        (true, 0, _) => Ok(AggPhase::OneShot),
+        (false, 0, _) => Ok(AggPhase::Partial),
+        (true, _, 0) => Ok(AggPhase::Merge),
+        (false, _, 0) => Err(TranslateError::UnsupportedPlanNode {
+            node_id,
+            node_type,
+            reason: "merge-serialize aggregation (a 3/4-phase DISTINCT plan) is not supported \
+                     (SET new_planner_agg_stage = 1)",
+        }),
+        _ => Err(TranslateError::UnsupportedPlanNode {
+            node_id,
+            node_type,
+            reason: "aggregation node mixes merge and update aggregate functions \
+                     (SET new_planner_agg_stage = 1)",
+        }),
+    }
+}

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
@@ -416,7 +416,7 @@ fn translate_arithmetic(
 }
 
 /// Returns whether a StarRocks type descriptor is any decimal flavour.
-fn is_decimal(type_desc: &starrocks_thrift::types::TTypeDesc) -> Result<bool> {
+pub(crate) fn is_decimal(type_desc: &starrocks_thrift::types::TTypeDesc) -> Result<bool> {
     Ok(matches!(
         type_mapper::scalar_primitive(type_desc)?,
         TPrimitiveType::DECIMAL
@@ -658,7 +658,14 @@ pub(crate) struct AggregateCall {
 
 /// Decomposes a StarRocks aggregate-function expression (the root of a
 /// `TAggregationNode::aggregate_functions` entry) into name, arguments, and distinct-ness.
-pub(crate) fn aggregate_call(expr: &TExpr, ctx: &mut ExprContext<'_>) -> Result<AggregateCall> {
+///
+/// `merge` marks a measure of a merge-phase aggregation, whose arguments are references to
+/// partial-state columns rather than raw rows.
+pub(crate) fn aggregate_call(
+    expr: &TExpr,
+    ctx: &mut ExprContext<'_>,
+    merge: bool,
+) -> Result<AggregateCall> {
     let root = expr
         .nodes
         .first()
@@ -673,18 +680,9 @@ pub(crate) fn aggregate_call(expr: &TExpr, ctx: &mut ExprContext<'_>) -> Result<
             reason: "aggregate function root is not an aggregate expression",
         });
     }
-    // One-phase aggregation only: a merge aggregate consumes partial states this translator
-    // does not model (run with `new_planner_agg_stage = 1`).
-    if root
-        .agg_expr
-        .as_ref()
-        .is_some_and(|agg_expr| agg_expr.is_merge_agg)
-    {
-        return Err(TranslateError::UnsupportedExpression {
-            node_type: root.node_type,
-            reason: "merge-phase aggregate functions are not supported (one-phase only)",
-        });
-    }
+    // No merge check here: the phase decision belongs to the node-level classifier
+    // (`agg_phase::classify`), which sees every measure at once. Rejecting merges in one
+    // place and classifying them in another is how the two guards would drift apart.
     let function = root.fn_.as_ref().ok_or(TranslateError::MissingField {
         context: "aggregate expression",
         field: "fn",
@@ -723,22 +721,18 @@ pub(crate) fn aggregate_call(expr: &TExpr, ctx: &mut ExprContext<'_>) -> Result<
     let mut cursor = ExprNodeCursor::new(&expr.nodes);
     // Consume the root marker; its children are the aggregate arguments.
     cursor.idx = 1;
-    let mut arguments = (0..root.num_children)
+    let raw_arguments = (0..root.num_children)
         .map(|_| cursor.translate_next(ctx))
         .collect::<Result<Vec<_>>>()?;
     cursor.ensure_consumed()?;
-    if decimal_result && matches!(name, "sum" | "avg") {
-        arguments = arguments
-            .into_iter()
-            .map(|input| Expression {
-                rex_type: Some(expression::RexType::Cast(Box::new(expression::Cast {
-                    r#type: Some(type_mapper::fp64_type(true)),
-                    input: Some(Box::new(input)),
-                    failure_behavior: expression::cast::FailureBehavior::ThrowException as i32,
-                }))),
-            })
-            .collect();
-    }
+    // Not on the merge side: a merge measure's argument is already the FP64 partial-state
+    // column; the decimal `ret_type` that drives this condition describes the original input,
+    // not the child the measure actually reads.
+    let arguments = if decimal_result && matches!(name, "sum" | "avg") && !merge {
+        raw_arguments.into_iter().map(cast_to_fp64).collect()
+    } else {
+        raw_arguments
+    };
 
     Ok(AggregateCall {
         name: name.to_string(),
@@ -900,6 +894,26 @@ fn integer_literal_type(
             node_type: Some(starrocks_thrift::types::TTypeNodeType::SCALAR),
             reason: "INT_LITERAL has non-integer scalar type",
         }),
+    }
+}
+
+/// Wraps an expression in the throwing FP64 cast that lowers values Sirius cannot aggregate
+/// or divide in their declared type (decimals, and the inputs of a two-phase avg).
+pub(crate) fn cast_to_fp64(input: Expression) -> Expression {
+    cast_to(input, type_mapper::fp64_type(true))
+}
+
+/// Wraps an expression in a throwing cast to `ty`.
+///
+/// A cast to the type the expression already has is a no-op the consumer's binder elides, so
+/// this is safe to emit wherever the type has to be stated rather than inferred.
+pub(crate) fn cast_to(input: Expression, ty: Type) -> Expression {
+    Expression {
+        rex_type: Some(expression::RexType::Cast(Box::new(expression::Cast {
+            r#type: Some(ty),
+            input: Some(Box::new(input)),
+            failure_behavior: expression::cast::FailureBehavior::ThrowException as i32,
+        }))),
     }
 }
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -31,7 +31,7 @@
 //! | `HDFS_SCAN_NODE`     | `ReadRel` (named table) |
 //! | `SELECT_NODE`        | `FilterRel`        |
 //! | `PROJECT_NODE`       | `ProjectRel` (common slots materialized first as hidden `ProjectRel`s) |
-//! | `AGGREGATION_NODE`   | `AggregateRel` (finalized one-phase only, `new_planner_agg_stage=1`) |
+//! | `AGGREGATION_NODE`   | `AggregateRel` (one-phase, or either half of a two-phase plan) |
 //! | `SORT_NODE`          | `ProjectRel` (sort tuple) + `SortRel` (global row-number top-N only) |
 //! | `HASH_JOIN_NODE`      | `JoinRel` (inner/outer/left-semi; left/right anti as outer join + `is_null` filter, null-aware left anti as mark join + `not`) |
 //! | `NESTLOOP_JOIN_NODE` | `JoinRel` (constant-key inner) + optional `FilterRel`, inner/cross only |
@@ -58,7 +58,8 @@
 //!
 //! Aggregate functions (`sum`, `count`, `min`, `max`, `avg`, and the
 //! `multi_distinct_*` distinct forms) are decomposed by `expr_translator::aggregate_call` for
-//! `AggregateRel` measures; only non-merge (one-phase) aggregates are accepted.
+//! `AggregateRel` measures. A two-phase plan's partial and merge halves are translated per
+//! phase (`agg_phase`), with the partial state each measure ships modeled by `partial_state`.
 //!
 //! Type mapping lives in `type_mapper`. Intentional v1 omissions return
 //! [`TranslateError::UnsupportedType`]: `LARGEINT` (128-bit), `DECIMAL256` and
@@ -99,10 +100,12 @@ use substrait::proto::{Plan, PlanRel, RelRoot, plan_rel};
 // commits to is intentionally small: `PlanTranslator`, `translate_fragment`,
 // `TranslatedPlan`, `TranslateError`, and the extension registry. Widen a module
 // to `pub` only when a real consumer needs it.
+pub(crate) mod agg_phase;
 pub(crate) mod descriptor_table;
 pub mod error;
 mod expr_translator;
 mod node_translator;
+pub(crate) mod partial_state;
 mod scan_paths;
 pub(crate) mod type_mapper;
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -2,7 +2,9 @@ use std::collections::{BTreeMap, HashMap};
 
 use starrocks_thrift::exprs::TExpr;
 use starrocks_thrift::opcodes::TExprOpcode;
-use starrocks_thrift::plan_nodes::{TJoinOp, TPlan, TPlanNode, TPlanNodeType, TSortInfo};
+use starrocks_thrift::plan_nodes::{
+    TAggregationNode, TJoinOp, TPlan, TPlanNode, TPlanNodeType, TSortInfo,
+};
 use starrocks_thrift::types::TSlotId;
 use substrait::proto::read_rel::local_files::FileOrFiles;
 use substrait::proto::read_rel::local_files::file_or_files::{
@@ -10,14 +12,16 @@ use substrait::proto::read_rel::local_files::file_or_files::{
 };
 use substrait::proto::read_rel::{LocalFiles, NamedTable, ReadType};
 use substrait::proto::{
-    AggregateFunction, AggregateRel, Expression, FetchRel, FilterRel, JoinRel, ProjectRel, ReadRel,
-    Rel, RelCommon, SortField, SortRel, aggregate_rel, expression, fetch_rel, function_argument,
-    join_rel, rel, rel_common, sort_field,
+    AggregateFunction, AggregateRel, AggregationPhase, Expression, FetchRel, FilterRel, JoinRel,
+    ProjectRel, ReadRel, Rel, RelCommon, SortField, SortRel, aggregate_rel, expression, fetch_rel,
+    function_argument, join_rel, rel, rel_common, sort_field,
 };
 
+use crate::agg_phase::{self, AggPhase};
 use crate::descriptor_table::DescriptorTable;
 use crate::error::{Result, TranslateError};
 use crate::expr_translator::{self, ExprContext, TranslateExpr};
+use crate::partial_state::{self, WireColumn};
 use crate::scan_paths::ScanFilePaths;
 use crate::type_mapper;
 use crate::{
@@ -61,6 +65,23 @@ struct PlanContext<'a> {
     /// Schema of every exchange lowered to a stream read, in translation order. The caller has to
     /// declare these on the engine before the plan can bind.
     stream_inputs: Vec<StreamInputSchema>,
+    /// Positional wire-column overrides, keyed by exchange node id, for exchanges that feed
+    /// merge aggregations: the FE declares those columns with intermediate slot types that lie
+    /// about what the sender ships (see `partial_state`). Computed by
+    /// [`merge_exchange_overrides`] before translation starts.
+    exchange_state_overrides: HashMap<i32, Vec<StateColumns>>,
+}
+
+/// The wire columns one merge measure's partial state occupies on the exchange row.
+///
+/// `position` indexes the row the *FE* declared (one column per intermediate slot); the extra
+/// types of a wider state are inserted behind it, which is where the partial fragment emitted
+/// them. Every state this layer accepts is one column wide (see [`two_phase_wire_columns`]).
+struct StateColumns {
+    /// Index of the measure's own column in the FE-declared exchange row.
+    position: usize,
+    /// Modeled wire types: the first replaces the FE slot type, the rest are inserted after it.
+    types: Vec<substrait::proto::Type>,
 }
 
 /// One translated fragment: its relation tree plus what the caller has to declare because the
@@ -86,6 +107,7 @@ impl<'a> PlanContext<'a> {
             exchange_inputs,
             registry,
             stream_inputs: Vec::new(),
+            exchange_state_overrides: HashMap::new(),
         }
     }
 
@@ -363,11 +385,61 @@ pub(crate) fn translate_plan(
     registry: &mut ExtensionRegistry,
 ) -> Result<TranslatedFragment> {
     let mut ctx = PlanContext::new(desc, scan_paths, exchange_inputs, registry);
+    ctx.exchange_state_overrides = merge_exchange_overrides(plan)?;
     let root = plan.translate(&mut ctx)?;
     Ok(TranslatedFragment {
         root,
         stream_inputs: std::mem::take(&mut ctx.stream_inputs),
     })
+}
+
+/// Computes the positional wire-column overrides for exchanges that feed merge aggregations.
+///
+/// Runs over the flat preorder node list before translation, because the exchange is
+/// translated before its parent aggregation and must already declare the stream with the
+/// modeled partial-state column types. In preorder a merge aggregation's single child is simply
+/// the next node; anything but an exchange there means the plan reads partial states from a
+/// shape this translator cannot type, so it is refused.
+fn merge_exchange_overrides(plan: &TPlan) -> Result<HashMap<i32, Vec<StateColumns>>> {
+    let mut overrides = HashMap::new();
+    for (index, node) in plan.nodes.iter().enumerate() {
+        if node.node_type != TPlanNodeType::AGGREGATION_NODE {
+            continue;
+        }
+        // A node without agg_node fails in translate_aggregation with its own error.
+        let Some(agg) = node.agg_node.as_ref() else {
+            continue;
+        };
+        if agg_phase::classify(node.node_id, node.node_type, agg)? != AggPhase::Merge {
+            continue;
+        }
+        let child = plan
+            .nodes
+            .get(index + 1)
+            .filter(|child| child.node_type == TPlanNodeType::EXCHANGE_NODE);
+        let Some(child) = child else {
+            return Err(TranslateError::UnsupportedPlanNode {
+                node_id: node.node_id,
+                node_type: node.node_type,
+                reason: "a merge aggregation must read its partial states directly from an \
+                         exchange (SET new_planner_agg_stage = 1)",
+            });
+        };
+        let keys = agg.grouping_exprs.as_deref().unwrap_or_default().len();
+        // The exchange row is the intermediate tuple's materialized slots: grouping keys
+        // first, then one state slot per measure -- the same layout invariant the
+        // aggregation's output tuple uses.
+        let columns = two_phase_wire_columns(node, agg)?
+            .into_iter()
+            .enumerate()
+            .map(|(position, state)| StateColumns {
+                position: keys + position,
+                types: state.into_iter().map(|column| column.ty).collect(),
+            })
+            .collect();
+        overrides.insert(child.node_id, columns);
+    }
+    Ok(overrides)
 }
 
 /// Translates an `EXCHANGE_NODE` into a read of the engine stream its senders' batches arrive on.
@@ -421,6 +493,36 @@ fn translate_exchange(
     let mut schema = ctx
         .desc
         .named_struct_for_tuples(&exchange.input_row_tuples)?;
+    // An exchange feeding a merge aggregation carries partial-state columns; rewrite their
+    // FE-declared slot types to the modeled wire types, and make room for any state the FE
+    // declares in fewer columns than Sirius ships. One `Type`, two consumers: the ReadRel
+    // base_schema below and the engine's stream declaration derive from the same rewritten
+    // entry, so the plan's view of the column and the engine's cannot drift apart.
+    if let Some(state_overrides) = ctx.exchange_state_overrides.get(&node.node_id) {
+        let types = schema
+            .r#struct
+            .as_mut()
+            .map(|structure| &mut structure.types)
+            .ok_or_else(|| TranslateError::malformed("exchange schema has no struct"))?;
+        let width = types.len();
+        // Positions index the FE-declared row, so every insertion shifts the ones after it.
+        let mut inserted = 0usize;
+        for column in state_overrides {
+            let position = column.position + inserted;
+            let slot = types.get_mut(position).ok_or_else(|| {
+                TranslateError::malformed(format!(
+                    "merge aggregation state column {} is outside the exchange row \
+                     ({width} columns)",
+                    column.position
+                ))
+            })?;
+            *slot = column.types[0].clone();
+            for (offset, ty) in column.types.iter().enumerate().skip(1) {
+                types.insert(position + offset, ty.clone());
+            }
+            inserted += column.types.len() - 1;
+        }
+    }
     let output_width = schema
         .r#struct
         .as_ref()
@@ -488,12 +590,17 @@ fn translate_exchange(
     apply_conjuncts(translated, node, ctx)
 }
 
-/// Translates a one-phase `AGGREGATION_NODE` into a Substrait aggregate relation.
+/// Translates an `AGGREGATION_NODE` into a Substrait aggregate relation.
 ///
-/// Only finalized single-phase aggregation is supported (run StarRocks with
-/// `new_planner_agg_stage = 1`); merge/update phases would require modeling partial aggregate
-/// states. The output row layout is the aggregation output tuple, whose materialized slots are
-/// the grouping keys followed by the aggregate results (StarRocks allocates them in that order).
+/// The node's phase (one-shot / partial / merge, see [`agg_phase::classify`]) decides how the
+/// measures are emitted. The output row layout is the aggregation output tuple, whose
+/// materialized slots are the grouping keys followed by the aggregate results (StarRocks
+/// allocates them in that order).
+///
+/// A two-phase measure's partial state is typed by [`partial_state::wire_columns`], the same
+/// model the exchange feeding the merge half declares its stream from, so the two ends of the
+/// hop agree by construction. A state wider than one column (avg) is refused by
+/// [`two_phase_wire_columns`] until the layer that expands it lands.
 fn translate_aggregation(
     node: &TPlanNode,
     children: Vec<TranslatedRel>,
@@ -505,33 +612,32 @@ fn translate_aggregation(
         context: "AGGREGATION_NODE",
         field: "agg_node",
     })?;
-    if !agg.need_finalize || agg.intermediate_tuple_id != agg.output_tuple_id {
+    let phase = agg_phase::classify(node.node_id, node.node_type, agg)?;
+    // Never observed in new-optimizer plans (the FE sets the two ids equal in every phase);
+    // kept as its own loud error so a plan shape that does split them cannot slip through the
+    // slot-layout assumptions below.
+    if agg.intermediate_tuple_id != agg.output_tuple_id {
         return Err(TranslateError::UnsupportedPlanNode {
             node_id: node.node_id,
             node_type: node.node_type,
-            reason: "only finalized one-phase aggregation is supported (new_planner_agg_stage=1)",
+            reason: "aggregation node has distinct intermediate and output tuples \
+                     (SET new_planner_agg_stage = 1)",
         });
     }
     let output_tuple = agg.output_tuple_id;
-
     let grouping_exprs = agg.grouping_exprs.as_deref().unwrap_or_default();
-    let mut grouping_expressions = Vec::with_capacity(grouping_exprs.len());
-    for expr in grouping_exprs {
-        let mut expr_ctx = ctx.expr_context(&child.row_tuples);
-        grouping_expressions.push(expr.translate(&mut expr_ctx)?);
-    }
+    let keys = grouping_exprs.len();
 
     // Aggregate output types come from the output tuple's slots, which carry the grouping keys
     // first and then one slot per aggregate function.
     let output_slots = ctx.desc.materialized_slot_ids(output_tuple)?;
-    let output_width = output_slots.len();
-    if output_width != grouping_expressions.len() + agg.aggregate_functions.len() {
+    if output_slots.len() != keys + agg.aggregate_functions.len() {
         return Err(TranslateError::descriptor(format!(
             "AGGREGATION_NODE {} output tuple {} has {} slots for {} keys + {} aggregates",
             node.node_id,
             output_tuple,
-            output_width,
-            grouping_expressions.len(),
+            output_slots.len(),
+            keys,
             agg.aggregate_functions.len()
         )));
     }
@@ -561,14 +667,44 @@ fn translate_aggregation(
         }
     }
 
+    // A two-phase measure occupies its modeled partial-state columns rather than the single
+    // slot the FE allocated for it; one-shot measures always occupy exactly their own slot,
+    // which is why the model is not consulted for them at all.
+    let wire_columns = match phase {
+        AggPhase::OneShot => Vec::new(),
+        _ => two_phase_wire_columns(node, agg)?,
+    };
+    // A merge measure reads the exchange row, whose layout is the modeled states' rather than
+    // the descriptor's one-slot-per-column view, so every slot's column is resolved explicitly.
+    let merge_slots = match phase {
+        AggPhase::Merge => Some(merge_state_columns(
+            node,
+            &child.row_tuples,
+            keys,
+            &wire_columns,
+            ctx.desc,
+        )?),
+        _ => None,
+    };
+
+    let mut grouping_expressions = Vec::with_capacity(keys);
+    for expr in grouping_exprs {
+        let mut expr_ctx = match &merge_slots {
+            Some(slots) => ctx.expr_context_with_slots(&child.row_tuples, &slots.columns),
+            None => ctx.expr_context(&child.row_tuples),
+        };
+        grouping_expressions.push(expr.translate(&mut expr_ctx)?);
+    }
+
     let mut measures = Vec::with_capacity(agg.aggregate_functions.len());
-    for (expr, slot_id) in agg
-        .aggregate_functions
-        .iter()
-        .zip(&output_slots[grouping_expressions.len()..])
-    {
-        let mut expr_ctx = ctx.expr_context(&child.row_tuples);
-        let call = expr_translator::aggregate_call(expr, &mut expr_ctx)?;
+    for (index, expr) in agg.aggregate_functions.iter().enumerate() {
+        let call = {
+            let mut expr_ctx = match &merge_slots {
+                Some(slots) => ctx.expr_context_with_slots(&child.row_tuples, &slots.columns),
+                None => ctx.expr_context(&child.row_tuples),
+            };
+            expr_translator::aggregate_call(expr, &mut expr_ctx, phase == AggPhase::Merge)?
+        };
         // The GPU ungrouped-aggregate operator rejects every distinct aggregate, so a
         // grouping-free DISTINCT measure would translate fine and then fail at execution.
         if call.distinct && grouping_expressions.is_empty() {
@@ -578,43 +714,59 @@ fn translate_aggregation(
                 reason: "distinct aggregates without grouping keys are not supported",
             });
         }
-        let output_type = ctx
-            .desc
-            .slot(output_tuple, *slot_id)?
-            .substrait_type
-            .clone()
-            .ok_or(TranslateError::MissingField {
-                context: "aggregate output slot",
-                field: "slotType",
-            })?;
-        // `count` lives in the generic aggregate extension; sum/avg/min/max are declared by
-        // the arithmetic extension.
-        let urn = if call.name == "count" {
-            URN_AGGREGATE
+        if phase != AggPhase::OneShot && call.distinct {
+            return Err(TranslateError::UnsupportedPlanNode {
+                node_id: node.node_id,
+                node_type: node.node_type,
+                reason: "DISTINCT aggregates are not supported in two-phase plans \
+                         (SET new_planner_agg_stage = 1)",
+            });
+        }
+        // Merge functions over partial states -- the engine's own internal merge table:
+        // sum->sum, min->min, max->max, and count->SUM. Merging counts must sum the partial
+        // counts; merging them with count would count rows and be silently wrong. This
+        // substitution is the mechanism that makes the plan phase-correct for the engine,
+        // which executes exactly what the function names say.
+        let function_name = if phase == AggPhase::Merge {
+            match call.name.as_str() {
+                "sum" | "min" | "max" => call.name.clone(),
+                "count" => "sum".to_string(),
+                _ => {
+                    return Err(TranslateError::UnsupportedPlanNode {
+                        node_id: node.node_id,
+                        node_type: node.node_type,
+                        reason: "merging this aggregate function is not supported \
+                                 (SET new_planner_agg_stage = 1)",
+                    });
+                }
+            }
         } else {
-            URN_ARITHMETIC
+            call.name.clone()
         };
-        let anchor = ctx.registry.register_function(urn, &call.name);
-        measures.push(aggregate_rel::Measure {
-            measure: Some(AggregateFunction {
-                function_reference: anchor,
-                arguments: call
-                    .arguments
-                    .into_iter()
-                    .map(|expr| substrait::proto::FunctionArgument {
-                        arg_type: Some(function_argument::ArgType::Value(expr)),
-                    })
-                    .collect(),
-                output_type: Some(output_type),
-                invocation: if call.distinct {
-                    substrait::proto::aggregate_function::AggregationInvocation::Distinct as i32
-                } else {
-                    substrait::proto::aggregate_function::AggregationInvocation::All as i32
-                },
-                ..Default::default()
-            }),
-            filter: None,
-        });
+        // A partial measure's output is its partial state, whose wire type is modeled: the
+        // FE's intermediate slot type lies about what Sirius emits (see partial_state). The
+        // engine ignores measure output types either way; carrying the modeled type keeps
+        // dumped plans honest about what is actually on the wire.
+        let output_type = match phase {
+            AggPhase::Partial => wire_columns[index][0].ty.clone(),
+            _ => ctx
+                .desc
+                .slot(output_tuple, output_slots[keys + index])?
+                .substrait_type
+                .clone()
+                .ok_or(TranslateError::MissingField {
+                    context: "aggregate output slot",
+                    field: "slotType",
+                })?,
+        };
+        measures.push(build_measure(
+            &function_name,
+            call.arguments,
+            output_type,
+            call.distinct,
+            phase,
+            ctx,
+        ));
     }
 
     let groupings = if grouping_expressions.is_empty() {
@@ -628,6 +780,7 @@ fn translate_aggregation(
         vec![grouping]
     };
 
+    let output_width = keys + measures.len();
     let aggregated = TranslatedRel {
         rel: Rel {
             rel_type: Some(rel::RelType::Aggregate(Box::new(AggregateRel {
@@ -641,8 +794,201 @@ fn translate_aggregation(
         row_tuples: vec![output_tuple],
         output_width,
     };
+
+    let aggregated = match phase {
+        // Every merge node leaves through the finalizing projection: the engine binds a merged
+        // integer count/sum as HUGEINT (the plan-level downcast relabels the aggregate node, not
+        // a fragment sink above it), so without the projection's throwing casts the fragment's
+        // wire row carries a type its FE-declared slot never announced and the next hop's
+        // schema guard refuses it.
+        AggPhase::Merge => {
+            let measure_types =
+                declared_measure_types(ctx.desc, output_tuple, &output_slots[keys..])?;
+            merge_projection(aggregated, keys, &measure_types)
+        }
+        _ => aggregated,
+    };
     // Node conjuncts evaluate over the aggregation output (HAVING predicates).
     apply_conjuncts(aggregated, node, ctx)
+}
+
+/// Models the partial state of every measure of a two-phase aggregation node.
+///
+/// One entry per FE measure, each the wire columns [`partial_state::wire_columns`] models for
+/// it. This layer emits exactly one measure per FE slot, so a state wider than one column (avg,
+/// whose Sirius state is a sum and a count) is refused here rather than shipped misaligned; the
+/// next translator layer expands it on both sides of the hop.
+fn two_phase_wire_columns(
+    node: &TPlanNode,
+    agg: &TAggregationNode,
+) -> Result<Vec<Vec<WireColumn>>> {
+    let wire_columns = agg
+        .aggregate_functions
+        .iter()
+        .map(|expr| partial_state::wire_columns(measure_function(expr)?))
+        .collect::<Result<Vec<_>>>()?;
+    if wire_columns.iter().any(|columns| columns.len() > 1) {
+        return Err(TranslateError::UnsupportedPlanNode {
+            node_id: node.node_id,
+            node_type: node.node_type,
+            reason: "two-phase avg is not supported yet (lands in the next translator layer); \
+                     SET new_planner_agg_stage = 1",
+        });
+    }
+    Ok(wire_columns)
+}
+
+/// Builds one Substrait measure over already-translated arguments.
+fn build_measure(
+    name: &str,
+    arguments: Vec<Expression>,
+    output_type: substrait::proto::Type,
+    distinct: bool,
+    phase: AggPhase,
+    ctx: &mut PlanContext<'_>,
+) -> aggregate_rel::Measure {
+    // `count` lives in the generic aggregate extension; sum/avg/min/max are declared by the
+    // arithmetic extension. Keyed on the emitted name, so a merged count registers as the
+    // arithmetic `sum` it became.
+    let urn = if name == "count" {
+        URN_AGGREGATE
+    } else {
+        URN_ARITHMETIC
+    };
+    let anchor = ctx.registry.register_function(urn, name);
+    aggregate_rel::Measure {
+        measure: Some(AggregateFunction {
+            function_reference: anchor,
+            arguments: arguments
+                .into_iter()
+                .map(|expr| substrait::proto::FunctionArgument {
+                    arg_type: Some(function_argument::ArgType::Value(expr)),
+                })
+                .collect(),
+            output_type: Some(output_type),
+            invocation: if distinct {
+                substrait::proto::aggregate_function::AggregationInvocation::Distinct as i32
+            } else {
+                substrait::proto::aggregate_function::AggregationInvocation::All as i32
+            },
+            // Advisory only: the engine's Substrait consumer ignores phases and executes
+            // exactly what the function names say, so the plan must be correct for a
+            // phase-ignoring reader first (substitute functions, then label). The label
+            // makes dumped plans self-describing.
+            phase: match phase {
+                AggPhase::OneShot => AggregationPhase::InitialToResult,
+                AggPhase::Partial => AggregationPhase::InitialToIntermediate,
+                AggPhase::Merge => AggregationPhase::IntermediateToResult,
+            } as i32,
+            ..Default::default()
+        }),
+        filter: None,
+    }
+}
+
+/// Physical columns of the intermediate row a merge aggregation reads.
+struct MergeStateColumns {
+    /// Physical column of each `(tuple id, slot id)`, for the expression translator.
+    columns: HashMap<(i32, i32), usize>,
+}
+
+/// Resolves every intermediate-tuple slot a merge aggregation reads to its physical column.
+///
+/// The FE numbers those slots as if every state were one column; a wider state would shift
+/// every slot behind it, so the physical column is stepped by each state's modeled width rather
+/// than read off the descriptor. Grouping keys come first and never shift.
+fn merge_state_columns(
+    node: &TPlanNode,
+    row_tuples: &[i32],
+    keys: usize,
+    wire_columns: &[Vec<WireColumn>],
+    desc: &DescriptorTable,
+) -> Result<MergeStateColumns> {
+    let mut slots = Vec::new();
+    for &tuple_id in row_tuples {
+        for slot_id in desc.materialized_slot_ids(tuple_id)? {
+            slots.push((tuple_id, slot_id));
+        }
+    }
+    if slots.len() != keys + wire_columns.len() {
+        return Err(TranslateError::descriptor(format!(
+            "AGGREGATION_NODE {} merges {} keys + {} aggregates from an intermediate row \
+             {row_tuples:?} of {} slots",
+            node.node_id,
+            keys,
+            wire_columns.len(),
+            slots.len()
+        )));
+    }
+    let mut columns = HashMap::with_capacity(slots.len());
+    let mut position = 0usize;
+    for (index, slot) in slots.into_iter().enumerate() {
+        columns.insert(slot, position);
+        position += match index.checked_sub(keys) {
+            Some(measure) => wire_columns[measure].len(),
+            None => 1,
+        };
+    }
+    Ok(MergeStateColumns { columns })
+}
+
+/// Adds the projection that turns a merge aggregation's emitted columns back into the FE's
+/// output row: the grouping keys, then one column per StarRocks measure.
+///
+/// Every measure column is cast to `measure_types`, the types the FE's output tuple declares,
+/// which is what the next fragment derives its stream schema from. Stating them is not
+/// cosmetic: DuckDB binds `sum(BIGINT)` as HUGEINT, and the engine's HUGEINT-to-BIGINT
+/// downcast happens at the aggregate's own sink, which this projection now sits in front of.
+/// Without the cast a merged count leaves this fragment as a HUGEINT the receiver declared
+/// BIGINT, and the hop refuses it.
+fn merge_projection(
+    input: TranslatedRel,
+    keys: usize,
+    measure_types: &[substrait::proto::Type],
+) -> TranslatedRel {
+    let mut expressions: Vec<Expression> = (0..keys as i32).map(field_selection).collect();
+    for (index, ty) in measure_types.iter().enumerate() {
+        expressions.push(expr_translator::cast_to(
+            field_selection((keys + index) as i32),
+            ty.clone(),
+        ));
+    }
+    let row_tuples = input.row_tuples.clone();
+    project_rel(input, expressions, row_tuples)
+}
+
+/// The types the FE's output tuple declares for an aggregation's measures.
+///
+/// This is the receiver's view of the row (a downstream exchange builds its stream schema
+/// from these very slots), so it is what the emitting fragment has to produce.
+fn declared_measure_types(
+    desc: &DescriptorTable,
+    output_tuple: i32,
+    measure_slots: &[i32],
+) -> Result<Vec<substrait::proto::Type>> {
+    measure_slots
+        .iter()
+        .map(|slot_id| {
+            desc.slot(output_tuple, *slot_id)?
+                .substrait_type
+                .clone()
+                .ok_or(TranslateError::MissingField {
+                    context: "aggregate output slot",
+                    field: "slotType",
+                })
+        })
+        .collect()
+}
+
+/// Returns the FE's serialized function for one aggregate measure.
+fn measure_function(expr: &TExpr) -> Result<&starrocks_thrift::types::TFunction> {
+    expr.nodes
+        .first()
+        .and_then(|root| root.fn_.as_ref())
+        .ok_or(TranslateError::MissingField {
+            context: "aggregate expression",
+            field: "fn",
+        })
 }
 
 /// Translates a `SORT_NODE` into a Substrait sort (plus the fetch added by `apply_fetch` for

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/partial_state.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/partial_state.rs
@@ -1,0 +1,280 @@
+//! The partial-state wire-type model for two-phase aggregation.
+//!
+//! In a two-phase plan the partial fragment ships one column per aggregate to the merge
+//! fragment. The type of that column is decided by what the engine *binds*, not by what the FE
+//! declares: the FE's intermediate slot says `DECIMAL128(38,s)` for a decimal sum (and an
+//! opaque `VARBINARY` for avg), while the plan the translator emits casts decimal sum
+//! arguments to FP64, so the column on the wire is a DOUBLE. Trusting the FE slot type would
+//! declare the receiver's stream with the wrong schema and reinterpret the columns.
+//!
+//! [`wire_columns`] is that binding, modeled as a pure function of thrift fields the FE
+//! serializes identically on the partial and the merge node (the function name and its
+//! `ret_type`). Both fragments derive their side of the exchange from it — the partial
+//! measure's declared output type and the merge fragment's declared stream schema — so the
+//! two ends agree by construction. If this model ever drifts from the engine's real binding,
+//! the engine rejects the batch at the hop (`Fragment::push_packed` / `relay_from` validate
+//! schemas), so a drift is a loud error, not a wrong number.
+//!
+//! The rules mirror the engine's binding:
+//! - decimal `sum` is lowered to FP64 by the argument cast in `expr_translator`;
+//! - integer `sum` binds to DuckDB HUGEINT and the Sirius planner downcasts it to BIGINT;
+//! - `count` is BIGINT;
+//! - `min`/`max` keep their input type (identity), including decimals.
+//!
+//! avg is the one state that is not a single column: StarRocks allocates one opaque VARBINARY
+//! slot for it, while Sirius keeps it as a DOUBLE sum plus a BIGINT count. The model is a
+//! *list* of columns for that reason — the partial fragment emits two measures for the one FE
+//! slot, the exchange row gains the extra column right behind the sum, and the merge fragment
+//! divides them back into an average. avg's sum is FP64 for every supported input because the
+//! partial fragment casts the argument, so the wire type does not depend on the input width.
+
+use starrocks_thrift::types::TFunction;
+use substrait::proto::Type;
+
+use crate::error::{Result, TranslateError};
+use crate::expr_translator::is_decimal;
+use crate::type_mapper;
+
+/// Name suffix of avg's count column, appended to the FE's intermediate slot name.
+///
+/// Deterministic on purpose: the partial fragment names the extra column, the name travels to
+/// the receiver with the rest of the sender's output names, and both ends have to spell it the
+/// same way for the hop to bind.
+pub(crate) const COUNT_SUFFIX: &str = "__count";
+
+/// One column of the partial state a two-phase aggregate ships between fragments.
+#[derive(Debug)]
+pub(crate) struct WireColumn {
+    /// Suffix appended to the FE's intermediate slot name; empty for the measure's own column.
+    // Only avg's second column carries a suffix, and the layer that expands avg is the one that
+    // names the emitted row from it; until then nothing outside the tests reads it.
+    #[allow(dead_code)]
+    pub suffix: &'static str,
+    /// Modeled Substrait type of the column.
+    pub ty: Type,
+}
+
+/// The wire columns of one two-phase aggregate's partial state, in emission order.
+///
+/// `function` is the measure's `TFunction` as serialized by the FE — identical on the partial
+/// and the merge node, which is what guarantees both ends compute the same columns. All but
+/// avg occupy exactly one column, so a longer list is the signal that the emitted row is wider
+/// than the FE's tuple.
+pub(crate) fn wire_columns(function: &TFunction) -> Result<Vec<WireColumn>> {
+    use starrocks_thrift::types::TPrimitiveType;
+
+    let name = function.name.function_name.as_str();
+    match name {
+        "sum" => {
+            if is_decimal(&function.ret_type)? {
+                return Ok(one(type_mapper::fp64_type(true)));
+            }
+            match type_mapper::scalar_primitive(&function.ret_type)? {
+                TPrimitiveType::BIGINT => Ok(one(type_mapper::i64_type(true))),
+                TPrimitiveType::DOUBLE => Ok(one(type_mapper::fp64_type(true))),
+                primitive => Err(TranslateError::malformed(format!(
+                    "two-phase sum returning {primitive:?} has no modeled partial state \
+                     (SET new_planner_agg_stage = 1)"
+                ))),
+            }
+        }
+        "count" => Ok(one(type_mapper::i64_type(true))),
+        "min" | "max" => Ok(one(type_mapper::map_type_desc(&function.ret_type, true)?)),
+        "avg" => Ok(vec![
+            WireColumn {
+                suffix: "",
+                ty: type_mapper::fp64_type(true),
+            },
+            WireColumn {
+                suffix: COUNT_SUFFIX,
+                ty: type_mapper::i64_type(true),
+            },
+        ]),
+        other => Err(TranslateError::malformed(format!(
+            "two-phase aggregation supports only sum/count/min/max/avg; {other:?} has a partial \
+             state this translator does not model (SET new_planner_agg_stage = 1)"
+        ))),
+    }
+}
+
+/// Wraps a single-column partial state, which is every aggregate but avg.
+fn one(ty: Type) -> Vec<WireColumn> {
+    vec![WireColumn { suffix: "", ty }]
+}
+
+#[cfg(test)]
+mod tests {
+    use starrocks_thrift::types::{
+        TFunction, TFunctionBinaryType, TFunctionName, TPrimitiveType, TScalarType, TTypeDesc,
+        TTypeNode, TTypeNodeType,
+    };
+    use substrait::proto::r#type;
+
+    use super::{WireColumn, wire_columns};
+
+    fn scalar_type(
+        primitive: TPrimitiveType,
+        precision: Option<i32>,
+        scale: Option<i32>,
+    ) -> TTypeDesc {
+        TTypeDesc::new(Some(vec![TTypeNode::new(
+            TTypeNodeType::SCALAR,
+            Some(TScalarType::new(primitive, None, precision, scale)),
+            None,
+            None,
+        )]))
+    }
+
+    fn function(name: &str, ret_type: TTypeDesc) -> TFunction {
+        TFunction::new(
+            TFunctionName::new(None, name.to_string()),
+            TFunctionBinaryType::BUILTIN,
+            Vec::new(),
+            ret_type,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
+    fn kind(column: &WireColumn) -> &r#type::Kind {
+        column.ty.kind.as_ref().unwrap()
+    }
+
+    /// Asserts a state occupies exactly one column and returns it.
+    fn sole(columns: Vec<WireColumn>) -> WireColumn {
+        assert_eq!(columns.len(), 1, "expected a single-column state");
+        columns.into_iter().next().unwrap()
+    }
+
+    /// The row that would rot silently if the FE slot type were ever trusted: the FE declares
+    /// a decimal sum's intermediate as DECIMAL128, but the wire column is a DOUBLE.
+    #[test]
+    fn decimal_sum_state_is_fp64_not_decimal() {
+        let column = sole(
+            wire_columns(&function(
+                "sum",
+                scalar_type(TPrimitiveType::DECIMAL128, Some(38), Some(2)),
+            ))
+            .unwrap(),
+        );
+        assert!(matches!(kind(&column), r#type::Kind::Fp64(_)));
+    }
+
+    #[test]
+    fn integer_sum_state_is_i64() {
+        let column = sole(
+            wire_columns(&function(
+                "sum",
+                scalar_type(TPrimitiveType::BIGINT, None, None),
+            ))
+            .unwrap(),
+        );
+        assert!(matches!(kind(&column), r#type::Kind::I64(_)));
+    }
+
+    #[test]
+    fn double_sum_state_is_fp64() {
+        let column = sole(
+            wire_columns(&function(
+                "sum",
+                scalar_type(TPrimitiveType::DOUBLE, None, None),
+            ))
+            .unwrap(),
+        );
+        assert!(matches!(kind(&column), r#type::Kind::Fp64(_)));
+    }
+
+    #[test]
+    fn count_state_is_i64() {
+        let column = sole(
+            wire_columns(&function(
+                "count",
+                scalar_type(TPrimitiveType::BIGINT, None, None),
+            ))
+            .unwrap(),
+        );
+        assert!(matches!(kind(&column), r#type::Kind::I64(_)));
+    }
+
+    /// min/max keep their input type, including decimals.
+    #[test]
+    fn min_max_state_is_the_identity() {
+        for name in ["min", "max"] {
+            let column = sole(
+                wire_columns(&function(
+                    name,
+                    scalar_type(TPrimitiveType::DECIMAL64, Some(15), Some(2)),
+                ))
+                .unwrap(),
+            );
+            let r#type::Kind::Decimal(decimal) = kind(&column) else {
+                panic!("expected decimal, got {:?}", column.ty);
+            };
+            assert_eq!((decimal.precision, decimal.scale), (15, 2));
+
+            let column = sole(
+                wire_columns(&function(
+                    name,
+                    scalar_type(TPrimitiveType::DATE, None, None),
+                ))
+                .unwrap(),
+            );
+            assert!(matches!(kind(&column), r#type::Kind::Date(_)));
+        }
+    }
+
+    /// avg is the state that changes the row's width: one FE slot, two Sirius columns.
+    #[test]
+    fn avg_state_is_two_columns() {
+        // The FE's own declaration for the slot is the opaque VARBINARY the model ignores.
+        let columns = wire_columns(&function(
+            "avg",
+            scalar_type(TPrimitiveType::VARBINARY, None, None),
+        ))
+        .unwrap();
+        assert_eq!(columns.len(), 2);
+        assert!(matches!(kind(&columns[0]), r#type::Kind::Fp64(_)));
+        assert!(matches!(kind(&columns[1]), r#type::Kind::I64(_)));
+        assert_eq!(columns[0].suffix, "");
+        assert_eq!(columns[1].suffix, super::COUNT_SUFFIX);
+    }
+
+    /// A decimal avg ships the same two columns: the partial fragment casts the argument, so
+    /// the sum column is FP64 whatever the FE's declared return type is.
+    #[test]
+    fn decimal_avg_state_is_the_same_two_columns() {
+        let columns = wire_columns(&function(
+            "avg",
+            scalar_type(TPrimitiveType::DECIMAL128, Some(38), Some(2)),
+        ))
+        .unwrap();
+        assert_eq!(columns.len(), 2);
+        assert!(matches!(kind(&columns[0]), r#type::Kind::Fp64(_)));
+        assert!(matches!(kind(&columns[1]), r#type::Kind::I64(_)));
+    }
+
+    #[test]
+    fn unmodeled_functions_are_refused() {
+        let err = wire_columns(&function(
+            "multi_distinct_count",
+            scalar_type(TPrimitiveType::BIGINT, None, None),
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains("sum/count/min/max/avg"), "{err}");
+    }
+}

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/type_mapper.rs
@@ -33,6 +33,17 @@ pub(crate) fn fp64_type(nullable: bool) -> Type {
     }
 }
 
+/// Builds an I64 (BIGINT) type, the width the engine returns for builtins the frontend declares
+/// narrower (year/month/day, length/char_length).
+pub(crate) fn i64_type(nullable: bool) -> Type {
+    Type {
+        kind: Some(r#type::Kind::I64(r#type::I64 {
+            type_variation_reference: 0,
+            nullability: nullability(nullable),
+        })),
+    }
+}
+
 /// Renders a Substrait type as the DuckDB type name the engine parses when a fragment declares
 /// an input stream's schema.
 ///

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -2763,33 +2763,399 @@ fn multi_distinct_count_translates_to_distinct_count() {
     assert!(names.contains(&"count".to_string()), "{names:?}");
 }
 
-/// Verifies a merge-phase aggregate (two-phase aggregation) is rejected.
-#[test]
-fn merge_aggregation_is_rejected() {
-    let mut aggregate = aggregate_expr(
-        "sum",
-        scalar_type(TPrimitiveType::BIGINT),
-        Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
-    );
-    aggregate.nodes[0].agg_expr = Some(TAggregateExpr::new(true));
-    let agg = aggregation_node(1, 1, Vec::new(), vec![aggregate]);
-    // Output tuple 1 has two slots but no grouping keys, so use a dedicated descriptor with a
-    // single aggregate output slot.
-    let desc = desc_table(
+/// Descriptor for the phase-classification tests: scan tuple 0 and an aggregation output
+/// tuple 1 with a single ungrouped aggregate slot.
+fn scalar_agg_desc() -> TDescriptorTable {
+    desc_table(
         vec![(0, Some(100)), (1, None)],
         vec![
             slot(1, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
             slot(2, 0, "name", scalar_type(TPrimitiveType::VARCHAR)),
             slot(1, 1, "total", scalar_type(TPrimitiveType::BIGINT)),
         ],
+    )
+}
+
+/// A scalar `sum(id)` aggregation node with per-measure merge flags and the node's
+/// `need_finalize`, for driving the phase classifier from tests.
+fn phase_aggregation_node(merge_flags: &[bool], need_finalize: bool) -> TPlanNode {
+    let aggregates = merge_flags
+        .iter()
+        .map(|&is_merge| {
+            let mut aggregate = aggregate_expr(
+                "sum",
+                scalar_type(TPrimitiveType::BIGINT),
+                Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+            );
+            aggregate.nodes[0].agg_expr = Some(TAggregateExpr::new(is_merge));
+            aggregate
+        })
+        .collect();
+    let mut node = aggregation_node(1, 1, Vec::new(), aggregates);
+    node.agg_node.as_mut().unwrap().need_finalize = need_finalize;
+    node
+}
+
+fn translate_phase_case(node: TPlanNode) -> Result<TranslatedPlan, TranslateError> {
+    translate_fragment(&params(
+        Some(TPlan::new(vec![node, scan_node(0, 0)])),
+        Some(scalar_agg_desc()),
+        None,
+    ))
+}
+
+/// Verifies a merge aggregation whose child is not an exchange is rejected: its input columns
+/// would carry FE-declared types the wire-type override never corrected.
+#[test]
+fn merge_over_a_scan_is_rejected() {
+    let err = translate_phase_case(phase_aggregation_node(&[true], true)).unwrap_err();
+    assert!(matches!(err, TranslateError::UnsupportedPlanNode { .. }));
+    let message = err.to_string();
+    assert!(message.contains("exchange"), "{message}");
+    assert!(message.contains("new_planner_agg_stage"), "{message}");
+}
+
+/// Builds the merge fragment of a two-phase `sum(decimal), count(*)` query: a merge
+/// aggregation (node 8, output tuple 3) over an exchange (node 7) carrying the intermediate
+/// tuple 2, whose FE-declared slot types are the ones the wire-type model must override.
+fn merge_fragment_params() -> TExecPlanFragmentParams {
+    let exchange = exchange_node_with(7, vec![2], None, None);
+    let mut sum = aggregate_expr(
+        "sum",
+        scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(38), Some(2)),
+        Some(slot_ref(
+            10,
+            2,
+            scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(38), Some(2)),
+        )),
     );
-    let err = translate_fragment(&params(
-        Some(TPlan::new(vec![agg, scan_node(0, 0)])),
+    sum.nodes[0].agg_expr = Some(TAggregateExpr::new(true));
+    let mut count = aggregate_expr(
+        "count",
+        scalar_type(TPrimitiveType::BIGINT),
+        Some(slot_ref(11, 2, scalar_type(TPrimitiveType::BIGINT))),
+    );
+    count.nodes[0].agg_expr = Some(TAggregateExpr::new(true));
+    let aggregate = aggregation_node(8, 3, Vec::new(), vec![sum, count]);
+
+    let desc = desc_table(
+        vec![(2, None), (3, None)],
+        vec![
+            // The FE declares the intermediate sum slot as DECIMAL128, the lie the override
+            // corrects; the wire column is the partial fragment's FP64 output.
+            slot(
+                10,
+                2,
+                "s",
+                scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(38), Some(2)),
+            ),
+            slot(11, 2, "c", scalar_type(TPrimitiveType::BIGINT)),
+            slot(
+                12,
+                3,
+                "revenue",
+                scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(38), Some(2)),
+            ),
+            slot(13, 3, "cnt", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+    params(
+        Some(TPlan::new(vec![aggregate, exchange])),
+        Some(desc),
+        None,
+    )
+}
+
+/// Verifies the merge fragment of a two-phase aggregation translates to a plain aggregate
+/// with the substituted merge functions (count merges as SUM of partial counts) over an
+/// exchange whose declared stream types are the modeled wire types, not the FE's
+/// DECIMAL128 intermediate slot type, and that the fragment leaves through the finalizing
+/// projection that casts every measure to its FE-declared output-slot type. The engine binds
+/// the merged count (a sum over BIGINT) as HUGEINT, so without the cast this fragment's output
+/// feeding a further downstream fragment would be refused by the hop's schema guard.
+#[test]
+fn merge_aggregation_translates_with_substituted_functions() {
+    let translated = PlanTranslator::new()
+        .translate_fragment_with_exchange_inputs(
+            &merge_fragment_params(),
+            &[stream_input(7, &["s", "c"])],
+        )
+        .unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["revenue", "cnt"]);
+    let rel::RelType::Project(project) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected the finalizing project over the merge aggregate");
+    };
+    // One throwing cast per measure, to the FE's output-slot types as the type mapper declares
+    // them: the DECIMAL128(38,2) sum slot lowers to FP64 (precision > 18), the same lowering a
+    // downstream exchange applies when it derives its stream schema from this very slot, and
+    // the count leaves as the BIGINT its slot declares (the engine binds it as HUGEINT).
+    assert_eq!(project.expressions.len(), 2);
+    let (sum_type, sum_input) = cast_parts(&project.expressions[0]);
+    assert!(
+        matches!(sum_type, substrait::proto::r#type::Kind::Fp64(_)),
+        "{sum_type:?}"
+    );
+    assert_eq!(field_index(sum_input), 0);
+    let (count_type, count_input) = cast_parts(&project.expressions[1]);
+    assert!(
+        matches!(count_type, substrait::proto::r#type::Kind::I64(_)),
+        "{count_type:?}"
+    );
+    assert_eq!(field_index(count_input), 1);
+
+    let aggregate = root_aggregate(&translated.plan);
+    assert_eq!(aggregate.measures.len(), 2);
+    for measure in &aggregate.measures {
+        assert_eq!(
+            measure.measure.as_ref().unwrap().phase,
+            substrait::proto::AggregationPhase::IntermediateToResult as i32
+        );
+    }
+    // count merged as count would count rows instead of summing partial counts; the only
+    // registered aggregate must be sum.
+    let names = extension_function_names(&translated.plan);
+    assert!(names.contains(&"sum".to_string()), "{names:?}");
+    assert!(!names.contains(&"count".to_string()), "{names:?}");
+
+    // The engine declaration derives from the overridden types: DOUBLE, not DECIMAL(38,2).
+    assert_eq!(translated.stream_inputs.len(), 1);
+    assert_eq!(
+        translated.stream_inputs[0]
+            .columns
+            .iter()
+            .map(|column| (column.name.as_str(), column.ty.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("s", "DOUBLE"), ("c", "BIGINT")]
+    );
+}
+
+/// Verifies both fragments of one two-phase query derive the same wire types: the partial
+/// fragment's measure output types match the merge fragment's declared stream columns
+/// column-for-column (FP64 <-> DOUBLE, I64 <-> BIGINT).
+#[test]
+fn two_phase_wire_types_agree_end_to_end() {
+    // Partial fragment: sum(decimal) + count(*) over a scan, need_finalize = false.
+    let mut sum = aggregate_expr(
+        "sum",
+        scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(38), Some(2)),
+        Some(slot_ref(
+            1,
+            0,
+            scalar_type_with(TPrimitiveType::DECIMAL64, None, Some(15), Some(2)),
+        )),
+    );
+    sum.nodes[0].agg_expr = Some(TAggregateExpr::new(false));
+    let mut count = aggregate_expr("count", scalar_type(TPrimitiveType::BIGINT), None);
+    count.nodes[0].agg_expr = Some(TAggregateExpr::new(false));
+    let mut node = aggregation_node(1, 1, Vec::new(), vec![sum, count]);
+    node.agg_node.as_mut().unwrap().need_finalize = false;
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None)],
+        vec![
+            slot(
+                1,
+                0,
+                "price",
+                scalar_type_with(TPrimitiveType::DECIMAL64, None, Some(15), Some(2)),
+            ),
+            slot(
+                20,
+                1,
+                "s",
+                scalar_type_with(TPrimitiveType::DECIMAL128, None, Some(38), Some(2)),
+            ),
+            slot(21, 1, "c", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+    let partial = translate_fragment(&params(
+        Some(TPlan::new(vec![node, scan_node(0, 0)])),
         Some(desc),
         None,
     ))
-    .unwrap_err();
-    assert!(matches!(err, TranslateError::UnsupportedExpression { .. }));
+    .unwrap();
+
+    let root = root(&partial.plan);
+    let rel::RelType::Aggregate(aggregate) =
+        root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected aggregate relation");
+    };
+    let partial_kinds: Vec<_> = aggregate
+        .measures
+        .iter()
+        .map(|measure| {
+            match measure
+                .measure
+                .as_ref()
+                .unwrap()
+                .output_type
+                .as_ref()
+                .unwrap()
+                .kind
+                .as_ref()
+                .unwrap()
+            {
+                substrait::proto::r#type::Kind::Fp64(_) => "DOUBLE",
+                substrait::proto::r#type::Kind::I64(_) => "BIGINT",
+                other => panic!("unexpected partial state kind {other:?}"),
+            }
+        })
+        .collect();
+
+    // Merge fragment of the same query (identical FE-serialized functions).
+    let merge = PlanTranslator::new()
+        .translate_fragment_with_exchange_inputs(
+            &merge_fragment_params(),
+            &[stream_input(7, &["s", "c"])],
+        )
+        .unwrap();
+    let merge_types: Vec<_> = merge.stream_inputs[0]
+        .columns
+        .iter()
+        .map(|column| column.ty.as_str())
+        .collect();
+
+    assert_eq!(partial_kinds, merge_types);
+}
+
+/// Verifies a partial-phase ("update serialize") aggregation translates to a plain aggregate
+/// whose measure carries the InitialToIntermediate phase and the modeled partial-state type
+/// (I64 for an integer sum), not the FE's declared slot type.
+#[test]
+fn partial_aggregation_translates_with_the_modeled_state_type() {
+    let translated = translate_phase_case(phase_aggregation_node(&[false], false)).unwrap();
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["total"]);
+    let rel::RelType::Aggregate(aggregate) =
+        root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected aggregate relation");
+    };
+    assert_eq!(aggregate.measures.len(), 1);
+    let measure = aggregate.measures[0].measure.as_ref().unwrap();
+    assert_eq!(
+        measure.phase,
+        substrait::proto::AggregationPhase::InitialToIntermediate as i32
+    );
+    let output_type = measure.output_type.as_ref().unwrap();
+    assert!(
+        matches!(
+            output_type.kind.as_ref().unwrap(),
+            substrait::proto::r#type::Kind::I64(_)
+        ),
+        "{output_type:?}"
+    );
+    let names: Vec<_> = extension_function_names(&translated.plan);
+    assert!(names.contains(&"sum".to_string()), "{names:?}");
+}
+
+/// Extracts the aggregate relation a plan roots at, through an optional finalizing project.
+fn root_aggregate(plan: &substrait::proto::Plan) -> &substrait::proto::AggregateRel {
+    let mut input = root(plan).input.as_ref().unwrap();
+    if let rel::RelType::Project(project) = input.rel_type.as_ref().unwrap() {
+        input = project.input.as_ref().unwrap();
+    }
+    let rel::RelType::Aggregate(aggregate) = input.rel_type.as_ref().unwrap() else {
+        panic!("expected an aggregate relation, got {input:?}");
+    };
+    aggregate
+}
+
+/// Verifies a two-phase avg is refused with an error naming the layer that lands it: its
+/// Sirius state is a sum and a count, two columns for the one slot the FE allocates, and this
+/// layer emits exactly one column per measure.
+#[test]
+fn two_phase_avg_is_refused_until_the_next_layer() {
+    let mut aggregate = aggregate_expr(
+        "avg",
+        scalar_type(TPrimitiveType::DOUBLE),
+        Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+    );
+    aggregate.nodes[0].agg_expr = Some(TAggregateExpr::new(false));
+    let mut node = aggregation_node(1, 1, Vec::new(), vec![aggregate]);
+    node.agg_node.as_mut().unwrap().need_finalize = false;
+    let err = translate_phase_case(node).unwrap_err();
+    assert!(matches!(err, TranslateError::UnsupportedPlanNode { .. }));
+    let message = err.to_string();
+    assert!(message.contains("two-phase avg"), "{message}");
+    assert!(message.contains("next translator layer"), "{message}");
+    assert!(message.contains("new_planner_agg_stage"), "{message}");
+}
+
+/// Verifies grouped two-phase aggregation translates: the partial node keeps its grouping key
+/// and emits the modeled state type for the measure.
+#[test]
+fn grouped_two_phase_translates() {
+    let mut aggregate = aggregate_expr(
+        "sum",
+        scalar_type(TPrimitiveType::BIGINT),
+        Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+    );
+    aggregate.nodes[0].agg_expr = Some(TAggregateExpr::new(false));
+    let mut node = aggregation_node(
+        1,
+        1,
+        vec![slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))],
+        vec![aggregate],
+    );
+    node.agg_node.as_mut().unwrap().need_finalize = false;
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![node, scan_node(0, 0)])),
+        Some(agg_desc()),
+        None,
+    ))
+    .unwrap();
+    let root = root(&translated.plan);
+    let rel::RelType::Aggregate(aggregate) =
+        root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected aggregate relation");
+    };
+    assert_eq!(aggregate.grouping_expressions.len(), 1);
+    assert_eq!(
+        aggregate.measures[0].measure.as_ref().unwrap().phase,
+        substrait::proto::AggregationPhase::InitialToIntermediate as i32
+    );
+}
+
+/// Verifies the one-shot path labels its measures InitialToResult (advisory; the engine
+/// ignores phases, but dumped plans should say what each aggregate is).
+#[test]
+fn one_shot_measures_are_labeled_initial_to_result() {
+    let translated = translate_phase_case(phase_aggregation_node(&[false], true)).unwrap();
+    let root = root(&translated.plan);
+    let rel::RelType::Aggregate(aggregate) =
+        root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected aggregate relation");
+    };
+    assert_eq!(
+        aggregate.measures[0].measure.as_ref().unwrap().phase,
+        substrait::proto::AggregationPhase::InitialToResult as i32
+    );
+}
+
+/// Verifies the "merge serialize" combination (a 3/4-phase DISTINCT plan's middle stage) is
+/// rejected as such.
+#[test]
+fn merge_serialize_aggregation_is_rejected() {
+    let err = translate_phase_case(phase_aggregation_node(&[true], false)).unwrap_err();
+    assert!(matches!(err, TranslateError::UnsupportedPlanNode { .. }));
+    let message = err.to_string();
+    assert!(message.contains("merge-serialize"), "{message}");
+}
+
+/// Verifies a node mixing merge and update measures cannot be phase-classified and is rejected.
+#[test]
+fn mixed_phase_aggregation_is_rejected() {
+    let err = translate_phase_case(phase_aggregation_node(&[true, false], true)).unwrap_err();
+    assert!(matches!(err, TranslateError::UnsupportedPlanNode { .. }));
+    let message = err.to_string();
+    assert!(message.contains("mixes merge and update"), "{message}");
 }
 
 /// Verifies a top-N sort becomes project (sort tuple) + sort + fetch with the node limit.
@@ -3830,6 +4196,26 @@ fn function_calls_use_allowlist() {
     ))
     .unwrap_err();
     assert!(matches!(err, TranslateError::MalformedPlan(_)));
+}
+
+/// Splits a throwing cast into its target-type kind and input expression.
+fn cast_parts(
+    expr: &substrait::proto::Expression,
+) -> (
+    &substrait::proto::r#type::Kind,
+    &substrait::proto::Expression,
+) {
+    let expression::RexType::Cast(cast) = expr.rex_type.as_ref().unwrap() else {
+        panic!("expected cast, got {expr:?}");
+    };
+    assert_eq!(
+        cast.failure_behavior,
+        expression::cast::FailureBehavior::ThrowException as i32
+    );
+    (
+        cast.r#type.as_ref().unwrap().kind.as_ref().unwrap(),
+        cast.input.as_ref().unwrap(),
+    )
 }
 
 /// Verifies CASE WHEN chains become Substrait if-then expressions with a null default.


### PR DESCRIPTION
## Description

StarRocks plans every distributed aggregate in two phases. Each instance runs a partial node ("update serialize") over its own rows, and one merge node ("merge finalize") reads the partial states after the exchange. dev refuses the merge half outright, so a StarRocks-fronted Sirius cluster can only run TPC-H with `SET new_planner_agg_stage = 1`. That setting forces one finalized aggregation instance, which pins the query to one GPU.

This PR translates both halves, without avg.

`agg_phase::classify` reads `need_finalize` and every measure's `is_merge_agg` and returns OneShot, Partial or Merge. It replaces both legacy guards in one commit, the node-level `need_finalize` check in `translate_aggregation` and the blanket `is_merge_agg` rejection in `aggregate_call`. They cannot be relaxed one at a time. New-optimizer plans always set `intermediate_tuple_id == output_tuple_id`, so the node-level check alone does not stop a merge node; a half-landed change would translate it as a one-shot aggregate and double-aggregate without any error.

`partial_state::wire_columns` models what the engine binds for each partial state, not what the FE declares. The FE slot says DECIMAL128 for a decimal sum, but the translator already casts the argument to FP64, so the column on the wire is a DOUBLE. For avg the FE slot is an opaque VARBINARY. Integer sum and count are I64, min and max keep their input type, anything else is refused by name. Both fragments derive their side of the hop from this one pure function of the FE-serialized `TFunction`. The partial measure's declared output type comes from it, and so does the merge fragment's declared stream schema (`merge_exchange_overrides` rewrites the exchange's FE slot types before `translate_exchange` declares the stream). If the model ever drifts from the engine's real binding, the engine refuses the batch at the hop instead of producing a wrong number.

A merge node substitutes sum->sum, min->min, max->max and count->sum. The engine executes exactly the function names it is given, and merging counts with count would count arriving rows. Every merge node leaves through `merge_projection`, one throwing cast per measure back to the FE-declared output type, because DuckDB binds a merged BIGINT sum as HUGEINT and the next hop's schema guard would refuse it.

Q6 translates after this layer.

**How I tested it.** On a GB200 box (aarch64) I ran the CI trio: cargo fmt, clippy with warnings as errors, and the CN test suite without the engine feature. All 200 tests pass, 16 of them new.

Tests: 8 new integration tests in `tests/translate.rs` (127 to 135, with `merge_aggregation_is_rejected` retargeted to `merge_over_a_scan_is_rejected`) and the 8 unit tests of `partial_state.rs` (8 to 16 crate unit tests). `two_phase_wire_types_agree_end_to_end` pins that the partial and merge fragments of one query produce the same wire types column for column.

Not handled here: avg (its state is two columns, so a two-phase avg is refused with an error that names the next layer, which lands it); GROUP BY and ORDER BY key order vs slot order (layer 3); DISTINCT in two-phase plans; 3/4-phase DISTINCT plans ("merge serialize" nodes are refused); opaque VARBINARY states such as ndv, hll and max_by, which `wire_columns` refuses by name.

Layer 2 of the translator stack; base `stacked/translator-exchange-stream-read`.

## Checklist

- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References

Refs #1236 for the decimal-to-FP64 lowering that makes a decimal sum's wire type a DOUBLE. `type_mapper::i64_type`, `expr_translator::cast_to` and the test helper `cast_parts` are copied byte for byte from #1704. When #1704 merges, the first two resolve to identical lines on rebase and the duplicate `cast_parts` definition is deleted once.