### PR TITLE
feat(starrocks): expand a two-phase avg into sum and count states

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
@@ -652,6 +652,12 @@ pub(crate) struct AggregateCall {
     pub name: String,
     /// Translated argument expressions over the aggregation input row.
     pub arguments: Vec<Expression>,
+    /// The same arguments before the decimal-to-FP64 lowering.
+    ///
+    /// A caller that expands one StarRocks measure into several Sirius measures needs the
+    /// argument without a cast that only fits one of them: a two-phase avg counts the raw
+    /// values and sums the cast ones.
+    pub raw_arguments: Vec<Expression>,
     /// Whether the aggregate applies to distinct inputs.
     pub distinct: bool,
 }
@@ -729,14 +735,15 @@ pub(crate) fn aggregate_call(
     // column; the decimal `ret_type` that drives this condition describes the original input,
     // not the child the measure actually reads.
     let arguments = if decimal_result && matches!(name, "sum" | "avg") && !merge {
-        raw_arguments.into_iter().map(cast_to_fp64).collect()
+        raw_arguments.iter().cloned().map(cast_to_fp64).collect()
     } else {
-        raw_arguments
+        raw_arguments.clone()
     };
 
     Ok(AggregateCall {
         name: name.to_string(),
         arguments,
+        raw_arguments,
         distinct,
     })
 }

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -59,7 +59,9 @@
 //! Aggregate functions (`sum`, `count`, `min`, `max`, `avg`, and the
 //! `multi_distinct_*` distinct forms) are decomposed by `expr_translator::aggregate_call` for
 //! `AggregateRel` measures. A two-phase plan's partial and merge halves are translated per
-//! phase (`agg_phase`), with the partial state each measure ships modeled by `partial_state`.
+//! phase (`agg_phase`), with the partial state each measure ships modeled by `partial_state` —
+//! avg is the one whose state is two columns, so it costs a measure expansion on the partial
+//! side and a finalizing division on the merge side.
 //!
 //! Type mapping lives in `type_mapper`. Intentional v1 omissions return
 //! [`TranslateError::UnsupportedType`]: `LARGEINT` (128-bit), `DECIMAL256` and
@@ -290,6 +292,7 @@ impl PlanTranslator {
         let node_translator::TranslatedFragment {
             root: mut translated,
             stream_inputs,
+            partial_expansion,
         } = node_translator::translate_plan(
             plan,
             &desc,
@@ -303,6 +306,13 @@ impl PlanTranslator {
             .as_ref()
             .filter(|output_exprs| !output_exprs.is_empty())
         {
+            if partial_expansion.is_some() {
+                return Err(TranslateError::malformed(
+                    "a partial aggregation with an avg state cannot be reprojected by fragment \
+                     output expressions, which read the aggregate's columns at the positions \
+                     the state moved (SET new_planner_agg_stage = 1)",
+                ));
+            }
             let names = output_exprs
                 .iter()
                 .enumerate()
@@ -313,6 +323,11 @@ impl PlanTranslator {
             translated =
                 node_translator::project_exprs(translated, output_exprs, &desc, &mut registry)?;
             names
+        } else if let Some(expansion) = &partial_expansion {
+            // A partial avg ships more columns than the FE's output tuple has slots, so the
+            // descriptor table cannot name the row. These names are what the receiver reads
+            // the stream's columns by.
+            expansion.names.clone()
         } else {
             desc.output_names_for_tuples(&translated.row_tuples)?
         };
@@ -370,11 +385,25 @@ impl PlanTranslator {
                              transformed key would silently split equal keys across senders",
                         ));
                     };
-                    columns.push(desc.slot_global_index(
+                    let column = desc.slot_global_index(
                         slot_ref.tuple_id,
                         slot_ref.slot_id,
                         &translated.row_tuples,
-                    )?);
+                    )?;
+                    // Slot indices come from the FE's tuple, where an expanded avg state
+                    // occupies one column and the real row has it occupying two. Grouping
+                    // keys sit ahead of every measure and so keep their index; a partition
+                    // key that is not one would hash the wrong column.
+                    if let Some(expansion) = &partial_expansion
+                        && column >= expansion.keys
+                    {
+                        return Err(TranslateError::malformed(
+                            "a hash-partition key references an aggregate column whose position \
+                             moved when the avg state expanded \
+                             (SET new_planner_agg_stage = 1)",
+                        ));
+                    }
+                    columns.push(column);
                 }
                 Some(columns)
             }

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -2,9 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use starrocks_thrift::exprs::TExpr;
 use starrocks_thrift::opcodes::TExprOpcode;
-use starrocks_thrift::plan_nodes::{
-    TAggregationNode, TJoinOp, TPlan, TPlanNode, TPlanNodeType, TSortInfo,
-};
+use starrocks_thrift::plan_nodes::{TJoinOp, TPlan, TPlanNode, TPlanNodeType, TSortInfo};
 use starrocks_thrift::types::TSlotId;
 use substrait::proto::read_rel::local_files::FileOrFiles;
 use substrait::proto::read_rel::local_files::file_or_files::{
@@ -67,16 +65,19 @@ struct PlanContext<'a> {
     stream_inputs: Vec<StreamInputSchema>,
     /// Positional wire-column overrides, keyed by exchange node id, for exchanges that feed
     /// merge aggregations: the FE declares those columns with intermediate slot types that lie
-    /// about what the sender ships (see `partial_state`). Computed by
-    /// [`merge_exchange_overrides`] before translation starts.
+    /// about what the sender ships, and allocates one slot for a state that can be wider (see
+    /// `partial_state`). Computed by [`merge_exchange_overrides`] before translation starts.
     exchange_state_overrides: HashMap<i32, Vec<StateColumns>>,
+    /// Set when a partial aggregation emitted more columns than its FE output tuple declares.
+    /// The fragment's root output names come from here instead of the descriptor table.
+    partial_expansion: Option<PartialExpansion>,
 }
 
 /// The wire columns one merge measure's partial state occupies on the exchange row.
 ///
 /// `position` indexes the row the *FE* declared (one column per intermediate slot); the extra
 /// types of a wider state are inserted behind it, which is where the partial fragment emitted
-/// them. Every state this layer accepts is one column wide (see [`two_phase_wire_columns`]).
+/// them.
 struct StateColumns {
     /// Index of the measure's own column in the FE-declared exchange row.
     position: usize,
@@ -84,13 +85,30 @@ struct StateColumns {
     types: Vec<substrait::proto::Type>,
 }
 
-/// One translated fragment: its relation tree plus what the caller has to declare because the
-/// FE's descriptor table does not describe it alone.
+/// A partial aggregation that emits more columns than its FE output tuple declares, because an
+/// avg measure expanded into a sum and a count.
+///
+/// Every consumer of the fragment's output row layout has to be told: the FE tuple no longer
+/// describes what the sender ships, so deriving names or column indices from it would mislabel
+/// (or misread) every column at or after the avg.
+pub(crate) struct PartialExpansion {
+    /// The aggregation node that expanded.
+    node_id: i32,
+    /// Grouping-key count. Keys keep their FE column index; measures may not.
+    pub(crate) keys: usize,
+    /// Root output names for the emitted row: the FE's names with the extras inserted.
+    pub(crate) names: Vec<String>,
+}
+
+/// One translated fragment: its relation tree plus everything the caller has to declare or
+/// name because the FE's descriptor table no longer describes it alone.
 pub(crate) struct TranslatedFragment {
     /// Root relation and its row layout.
     pub root: TranslatedRel,
     /// Schema of every exchange lowered to a stream read, in translation order.
     pub stream_inputs: Vec<StreamInputSchema>,
+    /// Set when a partial aggregation widened the output row (see [`PartialExpansion`]).
+    pub partial_expansion: Option<PartialExpansion>,
 }
 
 impl<'a> PlanContext<'a> {
@@ -108,6 +126,7 @@ impl<'a> PlanContext<'a> {
             registry,
             stream_inputs: Vec::new(),
             exchange_state_overrides: HashMap::new(),
+            partial_expansion: None,
         }
     }
 
@@ -387,9 +406,31 @@ pub(crate) fn translate_plan(
     let mut ctx = PlanContext::new(desc, scan_paths, exchange_inputs, registry);
     ctx.exchange_state_overrides = merge_exchange_overrides(plan)?;
     let root = plan.translate(&mut ctx)?;
+    if let Some(expansion) = &ctx.partial_expansion {
+        // Only the fragment root's row leaves this CN by name. Any node above the expanded
+        // aggregation would resolve the aggregation's slots at their FE positions, which the
+        // expansion moved -- a wrong column read, not a type error the engine would catch.
+        if plan.nodes.first().map(|node| node.node_id) != Some(expansion.node_id) {
+            return Err(TranslateError::UnsupportedPlanNode {
+                node_id: expansion.node_id,
+                node_type: TPlanNodeType::AGGREGATION_NODE,
+                reason: "a partial aggregation over avg must be the fragment root; a node above \
+                         it reads the aggregate's columns at the positions the avg state moved \
+                         (SET new_planner_agg_stage = 1)",
+            });
+        }
+        if root.output_width != expansion.names.len() {
+            return Err(TranslateError::malformed(format!(
+                "partial aggregation emits {} columns but named {} of them",
+                root.output_width,
+                expansion.names.len()
+            )));
+        }
+    }
     Ok(TranslatedFragment {
         root,
         stream_inputs: std::mem::take(&mut ctx.stream_inputs),
+        partial_expansion: ctx.partial_expansion,
     })
 }
 
@@ -397,9 +438,10 @@ pub(crate) fn translate_plan(
 ///
 /// Runs over the flat preorder node list before translation, because the exchange is
 /// translated before its parent aggregation and must already declare the stream with the
-/// modeled partial-state column types. In preorder a merge aggregation's single child is simply
-/// the next node; anything but an exchange there means the plan reads partial states from a
-/// shape this translator cannot type, so it is refused.
+/// modeled partial-state columns — their types, and the extra column a wider state (avg)
+/// occupies. In preorder a merge aggregation's single child is simply the next node; anything
+/// but an exchange there means the plan reads partial states from a shape this translator
+/// cannot type, so it is refused.
 fn merge_exchange_overrides(plan: &TPlan) -> Result<HashMap<i32, Vec<StateColumns>>> {
     let mut overrides = HashMap::new();
     for (index, node) in plan.nodes.iter().enumerate() {
@@ -426,17 +468,20 @@ fn merge_exchange_overrides(plan: &TPlan) -> Result<HashMap<i32, Vec<StateColumn
             });
         };
         let keys = agg.grouping_exprs.as_deref().unwrap_or_default().len();
-        // The exchange row is the intermediate tuple's materialized slots: grouping keys
-        // first, then one state slot per measure -- the same layout invariant the
-        // aggregation's output tuple uses.
-        let columns = two_phase_wire_columns(node, agg)?
-            .into_iter()
-            .enumerate()
-            .map(|(position, state)| StateColumns {
+        let mut columns = Vec::with_capacity(agg.aggregate_functions.len());
+        for (position, measure) in agg.aggregate_functions.iter().enumerate() {
+            // The exchange row is the intermediate tuple's materialized slots: grouping keys
+            // first, then one state slot per measure -- the same layout invariant the
+            // aggregation's output tuple uses. A state wider than its slot (avg) claims the
+            // columns behind it, which is where the partial fragment emitted them.
+            columns.push(StateColumns {
                 position: keys + position,
-                types: state.into_iter().map(|column| column.ty).collect(),
-            })
-            .collect();
+                types: partial_state::wire_columns(measure_function(measure)?)?
+                    .into_iter()
+                    .map(|column| column.ty)
+                    .collect(),
+            });
+        }
         overrides.insert(child.node_id, columns);
     }
     Ok(overrides)
@@ -603,10 +648,11 @@ fn translate_exchange(
 /// indices — resolves its columns through the descriptor's order, so the sender reorders to
 /// it, exactly as [`translate_sort`] does for its sort tuple.
 ///
-/// A two-phase measure's partial state is typed by [`partial_state::wire_columns`], the same
-/// model the exchange feeding the merge half declares its stream from, so the two ends of the
-/// hop agree by construction. A state wider than one column (avg) is refused by
-/// [`two_phase_wire_columns`] until the layer that expands it lands.
+/// Two-phase avg is the one aggregate that does not fit that layout one slot at a time: it is
+/// emitted as a sum and a count on the partial side, merged as two sums, and divided back into
+/// an average by a projection on top on the merge side. Both sides take the extra column from
+/// the same [`partial_state::wire_columns`] model that types the exchange, so the two ends of
+/// the hop agree by construction.
 fn translate_aggregation(
     node: &TPlanNode,
     children: Vec<TranslatedRel>,
@@ -693,10 +739,16 @@ fn translate_aggregation(
     // which is why the model is not consulted for them at all.
     let wire_columns = match phase {
         AggPhase::OneShot => Vec::new(),
-        _ => two_phase_wire_columns(node, agg)?,
+        _ => agg
+            .aggregate_functions
+            .iter()
+            .map(|expr| partial_state::wire_columns(measure_function(expr)?))
+            .collect::<Result<Vec<_>>>()?,
     };
-    // A merge measure reads the exchange row, whose layout is the modeled states' rather than
-    // the descriptor's one-slot-per-column view, so every slot's column is resolved explicitly.
+    let expanded = wire_columns.iter().any(|columns| columns.len() > 1);
+    // A merge measure reads the exchange row, which is wider than the FE's intermediate tuple
+    // wherever a state expanded, so every slot's column is resolved explicitly instead of
+    // through the descriptor's one-slot-per-column view.
     let merge_slots = match phase {
         AggPhase::Merge => Some(merge_state_columns(
             node,
@@ -718,7 +770,10 @@ fn translate_aggregation(
     }
 
     let mut measures = Vec::with_capacity(agg.aggregate_functions.len());
+    // Where each StarRocks measure's own state starts among the emitted measures.
+    let mut measure_starts = Vec::with_capacity(agg.aggregate_functions.len());
     for (index, expr) in agg.aggregate_functions.iter().enumerate() {
+        measure_starts.push(measures.len());
         let call = {
             let mut expr_ctx = match &merge_slots {
                 Some(slots) => ctx.expr_context_with_slots(&child.row_tuples, &slots.columns),
@@ -742,6 +797,11 @@ fn translate_aggregation(
                 reason: "DISTINCT aggregates are not supported in two-phase plans \
                          (SET new_planner_agg_stage = 1)",
             });
+        }
+        if let Some(state) = wire_columns.get(index).filter(|columns| columns.len() > 1) {
+            let state_column = merge_slots.as_ref().map(|slots| slots.measures[index]);
+            expand_avg(node, phase, &call, state, state_column, &mut measures, ctx)?;
+            continue;
         }
         // Merge functions over partial states -- the engine's own internal merge table:
         // sum->sum, min->min, max->max, and count->SUM. Merging counts must sum the partial
@@ -817,15 +877,51 @@ fn translate_aggregation(
     };
 
     let aggregated = match phase {
-        // Every merge node leaves through the finalizing projection: the engine binds a merged
-        // integer count/sum as HUGEINT (the plan-level downcast relabels the aggregate node, not
-        // a fragment sink above it), so without the projection's throwing casts the fragment's
-        // wire row carries a type its FE-declared slot never announced and the next hop's
-        // schema guard refuses it.
+        // Every merge node leaves through the finalizing projection, not only the avg-expanded
+        // ones: the engine binds a merged integer count/sum as HUGEINT (the plan-level downcast
+        // relabels the aggregate node, not a fragment sink above it), so without the projection's
+        // throwing casts the fragment's wire row carries a type its FE-declared slot never
+        // announced and the next hop's schema guard refuses it. Where a state expanded, the
+        // projection also folds the extra columns back to one column per FE measure -- everything
+        // above this node sees the row the descriptor describes, types included.
         AggPhase::Merge => {
             let measure_types =
                 declared_measure_types(ctx.desc, output_tuple, &output_slots[keys..])?;
-            merge_projection(aggregated, keys, &measure_types)
+            merge_projection(
+                aggregated,
+                keys,
+                &measure_starts,
+                &wire_columns,
+                &measure_types,
+                ctx,
+            )
+        }
+        // The emitted row is wider than the FE's output tuple, so the fragment's output names
+        // are built here: the descriptor table has no slot to name the extra column from.
+        AggPhase::Partial if expanded => {
+            if has_conjuncts(node) {
+                return Err(TranslateError::UnsupportedPlanNode {
+                    node_id: node.node_id,
+                    node_type: node.node_type,
+                    reason: "conjuncts over a partial aggregation with an avg state would read \
+                             the aggregate's columns at the positions the state moved \
+                             (SET new_planner_agg_stage = 1)",
+                });
+            }
+            if ctx.partial_expansion.is_some() {
+                return Err(TranslateError::malformed(
+                    "two partial aggregations in one fragment expanded an avg state; only the \
+                     fragment root's row is named",
+                ));
+            }
+            let names =
+                expanded_output_names(ctx.desc, output_tuple, &output_slots, keys, &wire_columns)?;
+            ctx.partial_expansion = Some(PartialExpansion {
+                node_id: node.node_id,
+                keys,
+                names,
+            });
+            aggregated
         }
         _ => aggregated,
     };
@@ -833,30 +929,92 @@ fn translate_aggregation(
     apply_conjuncts(aggregated, node, ctx)
 }
 
-/// Models the partial state of every measure of a two-phase aggregation node.
+/// Emits the two Sirius measures one StarRocks avg becomes in a two-phase plan.
 ///
-/// One entry per FE measure, each the wire columns [`partial_state::wire_columns`] models for
-/// it. This layer emits exactly one measure per FE slot, so a state wider than one column (avg,
-/// whose Sirius state is a sum and a count) is refused here rather than shipped misaligned; the
-/// next translator layer expands it on both sides of the hop.
-fn two_phase_wire_columns(
+/// Partial: `sum(cast(arg AS DOUBLE))` and `count(arg)`. Merge: both halves merge with `sum`,
+/// reading the state columns the exchange row already carries side by side, which is what
+/// `state_column` (the physical column the state starts at) points at.
+fn expand_avg(
     node: &TPlanNode,
-    agg: &TAggregationNode,
-) -> Result<Vec<Vec<WireColumn>>> {
-    let wire_columns = agg
-        .aggregate_functions
-        .iter()
-        .map(|expr| partial_state::wire_columns(measure_function(expr)?))
-        .collect::<Result<Vec<_>>>()?;
-    if wire_columns.iter().any(|columns| columns.len() > 1) {
-        return Err(TranslateError::UnsupportedPlanNode {
-            node_id: node.node_id,
-            node_type: node.node_type,
-            reason: "two-phase avg is not supported yet (lands in the next translator layer); \
-                     SET new_planner_agg_stage = 1",
-        });
+    phase: AggPhase,
+    call: &expr_translator::AggregateCall,
+    state: &[WireColumn],
+    state_column: Option<usize>,
+    measures: &mut Vec<aggregate_rel::Measure>,
+    ctx: &mut PlanContext<'_>,
+) -> Result<()> {
+    if call.name != "avg" {
+        return Err(TranslateError::malformed(format!(
+            "aggregate {:?} has a multi-column partial state but no expansion",
+            call.name
+        )));
     }
-    Ok(wire_columns)
+    match phase {
+        AggPhase::Partial => {
+            let argument = sole_argument(node, &call.raw_arguments)?.clone();
+            // The modeled sum column is FP64 for every avg input, so the cast is emitted here
+            // rather than left to the decimal-only lowering in `aggregate_call`: an integer
+            // avg would otherwise ship a BIGINT sum the receiver reads as a DOUBLE.
+            measures.push(build_measure(
+                "sum",
+                vec![expr_translator::cast_to_fp64(argument.clone())],
+                state[0].ty.clone(),
+                false,
+                phase,
+                ctx,
+            ));
+            // Counting the uncast argument keeps the count over the values avg averages: the
+            // cast changes no NULLs, and reading it here would only obscure that.
+            measures.push(build_measure(
+                "count",
+                vec![argument],
+                state[1].ty.clone(),
+                false,
+                phase,
+                ctx,
+            ));
+        }
+        AggPhase::Merge => {
+            let position = state_column.ok_or_else(|| {
+                TranslateError::malformed("merge measure without a resolved state column")
+            })?;
+            // The column behind the sum is this avg's count only if the measure really reads
+            // its own state column; anything else means the FE laid the row out differently
+            // than the expansion assumes, and the count would be some other measure's state.
+            if direct_field(sole_argument(node, &call.arguments)?) != Some(position as i32) {
+                return Err(TranslateError::UnsupportedPlanNode {
+                    node_id: node.node_id,
+                    node_type: node.node_type,
+                    reason: "a merged avg must read its partial state straight from the \
+                             exchange row (SET new_planner_agg_stage = 1)",
+                });
+            }
+            // Both halves merge with sum: the division that finalizes them divides summed
+            // sums by summed counts, where count here would count arriving rows instead.
+            measures.push(build_measure(
+                "sum",
+                vec![field_selection(position as i32)],
+                state[0].ty.clone(),
+                false,
+                phase,
+                ctx,
+            ));
+            measures.push(build_measure(
+                "sum",
+                vec![field_selection(position as i32 + 1)],
+                state[1].ty.clone(),
+                false,
+                phase,
+                ctx,
+            ));
+        }
+        AggPhase::OneShot => {
+            return Err(TranslateError::malformed(
+                "a one-shot aggregate has no partial state to expand",
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Builds one Substrait measure over already-translated arguments.
@@ -911,13 +1069,15 @@ fn build_measure(
 struct MergeStateColumns {
     /// Physical column of each `(tuple id, slot id)`, for the expression translator.
     columns: HashMap<(i32, i32), usize>,
+    /// Physical column where each measure's state starts, in FE measure order.
+    measures: Vec<usize>,
 }
 
 /// Resolves every intermediate-tuple slot a merge aggregation reads to its physical column.
 ///
-/// The FE numbers those slots as if every state were one column; a wider state would shift
-/// every slot behind it, so the physical column is stepped by each state's modeled width rather
-/// than read off the descriptor. Grouping keys come first and never shift.
+/// The FE numbers those slots as if every state were one column; a wider state (avg) shifts
+/// every slot behind it, so the descriptor's index is the wrong column from that point on.
+/// Grouping keys come first and never shift.
 fn merge_state_columns(
     node: &TPlanNode,
     row_tuples: &[i32],
@@ -942,15 +1102,19 @@ fn merge_state_columns(
         )));
     }
     let mut columns = HashMap::with_capacity(slots.len());
+    let mut measures = Vec::with_capacity(wire_columns.len());
     let mut position = 0usize;
     for (index, slot) in slots.into_iter().enumerate() {
         columns.insert(slot, position);
         position += match index.checked_sub(keys) {
-            Some(measure) => wire_columns[measure].len(),
+            Some(measure) => {
+                measures.push(position);
+                wire_columns[measure].len()
+            }
             None => 1,
         };
     }
-    Ok(MergeStateColumns { columns })
+    Ok(MergeStateColumns { columns, measures })
 }
 
 /// Adds the projection that turns a merge aggregation's emitted columns back into the FE's
@@ -965,17 +1129,60 @@ fn merge_state_columns(
 fn merge_projection(
     input: TranslatedRel,
     keys: usize,
+    measure_starts: &[usize],
+    wire_columns: &[Vec<WireColumn>],
     measure_types: &[substrait::proto::Type],
+    ctx: &mut PlanContext<'_>,
 ) -> TranslatedRel {
     let mut expressions: Vec<Expression> = (0..keys as i32).map(field_selection).collect();
-    for (index, ty) in measure_types.iter().enumerate() {
+    for (index, start) in measure_starts.iter().enumerate() {
+        let field = (keys + start) as i32;
+        let value = if wire_columns[index].len() > 1 {
+            avg_from_state(field, field + 1, ctx)
+        } else {
+            field_selection(field)
+        };
         expressions.push(expr_translator::cast_to(
-            field_selection((keys + index) as i32),
-            ty.clone(),
+            value,
+            measure_types[index].clone(),
         ));
     }
     let row_tuples = input.row_tuples.clone();
     project_rel(input, expressions, row_tuples)
+}
+
+/// Divides a merged avg state back into an average, with SQL's empty-input NULL.
+///
+/// A group whose avg argument was NULL in every row arrives with a zero count; dividing by it
+/// is a division by zero where SQL defines NULL, so the zero case is answered explicitly.
+fn avg_from_state(sum: i32, count: i32, ctx: &mut PlanContext<'_>) -> Expression {
+    let equal_anchor = ctx.registry.register_function(URN_COMPARISON, "equal");
+    let no_values = expr_translator::scalar_function(
+        equal_anchor,
+        vec![field_selection(count), i64_literal(0)],
+        type_mapper::bool_type(),
+    );
+    let divide_anchor = ctx.registry.register_function(URN_ARITHMETIC, "divide");
+    // Both operands FP64: the summed sum already is, and dividing it by a BIGINT count would
+    // leave the operand widening to whatever rule the consumer happens to apply.
+    let average = expr_translator::scalar_function(
+        divide_anchor,
+        vec![
+            field_selection(sum),
+            expr_translator::cast_to_fp64(field_selection(count)),
+        ],
+        type_mapper::fp64_type(true),
+    );
+    use substrait::proto::expression::{IfThen, RexType, if_then};
+    Expression {
+        rex_type: Some(RexType::IfThen(Box::new(IfThen {
+            ifs: vec![if_then::IfClause {
+                r#if: Some(no_values),
+                then: Some(null_literal(type_mapper::fp64_type(true))),
+            }],
+            r#else: Some(Box::new(average)),
+        }))),
+    }
 }
 
 /// The types the FE's output tuple declares for an aggregation's measures.
@@ -999,6 +1206,30 @@ fn declared_measure_types(
                 })
         })
         .collect()
+}
+
+/// Names the row a partial aggregation emits: the FE's output-tuple names, plus one suffixed
+/// name per extra state column so the receiver spells the column the same way.
+fn expanded_output_names(
+    desc: &DescriptorTable,
+    output_tuple: i32,
+    output_slots: &[i32],
+    keys: usize,
+    wire_columns: &[Vec<WireColumn>],
+) -> Result<Vec<String>> {
+    let mut names = Vec::with_capacity(output_slots.len());
+    for (index, slot_id) in output_slots.iter().enumerate() {
+        let name = desc.slot(output_tuple, *slot_id)?.output_name();
+        match index.checked_sub(keys) {
+            Some(measure) => names.extend(
+                wire_columns[measure]
+                    .iter()
+                    .map(|column| format!("{name}{}", column.suffix)),
+            ),
+            None => names.push(name),
+        }
+    }
+    Ok(names)
 }
 
 /// The FE allocates one output slot per grouping expression, reusing the expression's own
@@ -1066,6 +1297,19 @@ fn measure_function(expr: &TExpr) -> Result<&starrocks_thrift::types::TFunction>
             context: "aggregate expression",
             field: "fn",
         })
+}
+
+/// Returns the single argument of a measure that expands into several Sirius measures.
+fn sole_argument<'a>(node: &TPlanNode, arguments: &'a [Expression]) -> Result<&'a Expression> {
+    match arguments {
+        [argument] => Ok(argument),
+        _ => Err(TranslateError::UnsupportedPlanNode {
+            node_id: node.node_id,
+            node_type: node.node_type,
+            reason: "a two-phase avg over anything but exactly one argument has no sum/count \
+                     expansion (SET new_planner_agg_stage = 1)",
+        }),
+    }
 }
 
 /// Translates a `SORT_NODE` into a Substrait sort (plus the fetch added by `apply_fetch` for
@@ -1875,6 +2119,51 @@ fn field_selection(field: i32) -> Expression {
                 )),
             },
         ))),
+    }
+}
+
+/// Returns the field index of a direct struct-field reference, if the expression is one.
+fn direct_field(expr: &Expression) -> Option<i32> {
+    use substrait::proto::expression::{RexType, field_reference, reference_segment};
+
+    let RexType::Selection(selection) = expr.rex_type.as_ref()? else {
+        return None;
+    };
+    let field_reference::ReferenceType::DirectReference(segment) =
+        selection.reference_type.as_ref()?
+    else {
+        return None;
+    };
+    let reference_segment::ReferenceType::StructField(field) = segment.reference_type.as_ref()?
+    else {
+        return None;
+    };
+    field.child.is_none().then_some(field.field)
+}
+
+/// Builds a typed Substrait null literal.
+fn null_literal(ty: substrait::proto::Type) -> Expression {
+    Expression {
+        rex_type: Some(substrait::proto::expression::RexType::Literal(
+            substrait::proto::expression::Literal {
+                literal_type: Some(substrait::proto::expression::literal::LiteralType::Null(ty)),
+                ..Default::default()
+            },
+        )),
+    }
+}
+
+/// Builds an i64 literal used to compare against a merged count.
+fn i64_literal(value: i64) -> Expression {
+    Expression {
+        rex_type: Some(substrait::proto::expression::RexType::Literal(
+            substrait::proto::expression::Literal {
+                literal_type: Some(substrait::proto::expression::literal::LiteralType::I64(
+                    value,
+                )),
+                ..Default::default()
+            },
+        )),
     }
 }
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/partial_state.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/partial_state.rs
@@ -46,9 +46,6 @@ pub(crate) const COUNT_SUFFIX: &str = "__count";
 #[derive(Debug)]
 pub(crate) struct WireColumn {
     /// Suffix appended to the FE's intermediate slot name; empty for the measure's own column.
-    // Only avg's second column carries a suffix, and the layer that expands avg is the one that
-    // names the emitted row from it; until then nothing outside the tests reads it.
-    #[allow(dead_code)]
     pub suffix: &'static str,
     /// Modeled Substrait type of the column.
     pub ty: Type,

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -3053,6 +3053,23 @@ fn partial_aggregation_translates_with_the_modeled_state_type() {
     assert!(names.contains(&"sum".to_string()), "{names:?}");
 }
 
+/// Extracts a measure's argument expressions.
+fn measure_arguments(
+    measure: &substrait::proto::aggregate_rel::Measure,
+) -> Vec<&substrait::proto::Expression> {
+    measure
+        .measure
+        .as_ref()
+        .unwrap()
+        .arguments
+        .iter()
+        .map(|argument| match argument.arg_type.as_ref().unwrap() {
+            substrait::proto::function_argument::ArgType::Value(expr) => expr,
+            other => panic!("expected a value argument, got {other:?}"),
+        })
+        .collect()
+}
+
 /// Names a measure's declared output type the way the engine declares a stream column.
 fn measure_output_type(measure: &substrait::proto::aggregate_rel::Measure) -> &'static str {
     match measure
@@ -3085,11 +3102,11 @@ fn root_aggregate(plan: &substrait::proto::Plan) -> &substrait::proto::Aggregate
     aggregate
 }
 
-/// Verifies a two-phase avg is refused with an error naming the layer that lands it: its
-/// Sirius state is a sum and a count, two columns for the one slot the FE allocates, and this
-/// layer emits exactly one column per measure.
+/// Verifies a partial avg expands into the two measures its Sirius state really is: a summed
+/// FP64 and a count, named so the receiver can tell the two columns apart. The FE allocates a
+/// single opaque slot for that state, so the emitted row is one column wider than its tuple.
 #[test]
-fn two_phase_avg_is_refused_until_the_next_layer() {
+fn partial_avg_expands_to_sum_and_count() {
     let mut aggregate = aggregate_expr(
         "avg",
         scalar_type(TPrimitiveType::DOUBLE),
@@ -3098,12 +3115,443 @@ fn two_phase_avg_is_refused_until_the_next_layer() {
     aggregate.nodes[0].agg_expr = Some(TAggregateExpr::new(false));
     let mut node = aggregation_node(1, 1, Vec::new(), vec![aggregate]);
     node.agg_node.as_mut().unwrap().need_finalize = false;
-    let err = translate_phase_case(node).unwrap_err();
-    assert!(matches!(err, TranslateError::UnsupportedPlanNode { .. }));
+    let translated = translate_phase_case(node).unwrap();
+
+    // The FE's output tuple has one slot, "total"; the sender ships two columns.
+    assert_eq!(root(&translated.plan).names, vec!["total", "total__count"]);
+    let aggregate = root_aggregate(&translated.plan);
+    assert_eq!(aggregate.measures.len(), 2);
+    for measure in &aggregate.measures {
+        assert_eq!(
+            measure.measure.as_ref().unwrap().phase,
+            substrait::proto::AggregationPhase::InitialToIntermediate as i32
+        );
+    }
+    assert_eq!(
+        aggregate
+            .measures
+            .iter()
+            .map(measure_output_type)
+            .collect::<Vec<_>>(),
+        vec!["DOUBLE", "BIGINT"]
+    );
+    let names = extension_function_names(&translated.plan);
+    assert!(names.contains(&"sum".to_string()), "{names:?}");
+    assert!(names.contains(&"count".to_string()), "{names:?}");
+
+    // The sum's argument is cast so the modeled DOUBLE wire column holds for an integer avg
+    // too; the count is over the raw values.
+    let sum_argument = measure_arguments(&aggregate.measures[0])[0];
+    assert!(
+        matches!(
+            sum_argument.rex_type.as_ref().unwrap(),
+            expression::RexType::Cast(_)
+        ),
+        "{sum_argument:?}"
+    );
+    let count_argument = measure_arguments(&aggregate.measures[1])[0];
+    assert_eq!(field_index(count_argument), 0);
+}
+
+/// Builds the merge fragment of a two-phase `avg(price), count(id) GROUP BY name` query: a
+/// merge aggregation (node 8, output tuple 3) over an exchange (node 7) whose intermediate
+/// tuple 2 carries the grouping key, the FE's single opaque slot for avg's state, and the
+/// partial count.
+fn merge_avg_fragment_params() -> TExecPlanFragmentParams {
+    let mut exchange = base_plan_node(7, TPlanNodeType::EXCHANGE_NODE, 0, vec![2]);
+    exchange.exchange_node = Some(TExchangeNode::new(
+        vec![2],
+        None,
+        None,
+        Some(TPartitionType::HASH_PARTITIONED),
+        Some(true),
+        None,
+    ));
+    let mut avg = aggregate_expr(
+        "avg",
+        scalar_type(TPrimitiveType::DOUBLE),
+        Some(slot_ref(11, 2, scalar_type(TPrimitiveType::DOUBLE))),
+    );
+    avg.nodes[0].agg_expr = Some(TAggregateExpr::new(true));
+    let mut count = aggregate_expr(
+        "count",
+        scalar_type(TPrimitiveType::BIGINT),
+        Some(slot_ref(12, 2, scalar_type(TPrimitiveType::BIGINT))),
+    );
+    count.nodes[0].agg_expr = Some(TAggregateExpr::new(true));
+    let aggregate = aggregation_node(
+        8,
+        3,
+        vec![slot_ref(10, 2, scalar_type(TPrimitiveType::VARCHAR))],
+        vec![avg, count],
+    );
+
+    let desc = desc_table(
+        vec![(2, None), (3, None)],
+        vec![
+            slot(10, 2, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            // The FE allocates one opaque VARBINARY slot for avg's state; the sender really
+            // shipped the sum and the count side by side.
+            slot(11, 2, "a", scalar_type(TPrimitiveType::VARBINARY)),
+            slot(12, 2, "c", scalar_type(TPrimitiveType::BIGINT)),
+            slot(20, 3, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(21, 3, "avg_price", scalar_type(TPrimitiveType::DOUBLE)),
+            slot(22, 3, "cnt", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+    params(
+        Some(TPlan::new(vec![aggregate, exchange])),
+        Some(desc),
+        None,
+    )
+}
+
+/// The sender's output names for [`merge_avg_fragment_params`], as the partial fragment of the
+/// same query emits them.
+fn merge_avg_exchange_names() -> Vec<String> {
+    ["name", "a", "a__count", "c"]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+}
+
+/// Verifies the merge fragment of a two-phase avg reads both state columns and divides them
+/// back into an average: the exchange declares the extra count column the sender shipped, both
+/// halves merge with sum, and a projection on top restores the FE's output row.
+#[test]
+fn merge_avg_divides_the_summed_state() {
+    let translated = PlanTranslator::new()
+        .translate_fragment_with_exchange_inputs(
+            &merge_avg_fragment_params(),
+            &[ExchangeInput {
+                node_id: 7,
+                stream_view: "sirius_stream_7".to_string(),
+                names: merge_avg_exchange_names(),
+            }],
+        )
+        .unwrap();
+
+    // The declared stream is the sender's row, one column wider than the FE's tuple.
+    assert_eq!(
+        translated.stream_inputs[0]
+            .columns
+            .iter()
+            .map(|column| (column.name.as_str(), column.ty.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("name", "VARCHAR"),
+            ("a", "DOUBLE"),
+            ("a__count", "BIGINT"),
+            ("c", "BIGINT")
+        ]
+    );
+
+    let root = root(&translated.plan);
+    assert_eq!(root.names, vec!["name", "avg_price", "cnt"]);
+    let rel::RelType::Project(project) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected the finalizing project over the aggregate");
+    };
+    // The FE's output row is three columns wide, whatever the aggregate below emitted.
+    let emit = match project.common.as_ref().unwrap().emit_kind.as_ref().unwrap() {
+        substrait::proto::rel_common::EmitKind::Emit(emit) => emit,
+        other => panic!("expected emit, got {other:?}"),
+    };
+    assert_eq!(emit.output_mapping, vec![4, 5, 6]);
+
+    // Three merged measures for two StarRocks ones, all summing: a count here would count
+    // arriving rows instead of summing the partial counts.
+    let aggregate = root_aggregate(&translated.plan);
+    assert_eq!(aggregate.measures.len(), 3);
+    let names = extension_function_names(&translated.plan);
+    assert!(!names.contains(&"count".to_string()), "{names:?}");
+    assert!(!names.contains(&"avg".to_string()), "{names:?}");
+    assert_eq!(
+        aggregate
+            .measures
+            .iter()
+            .map(|measure| field_index(measure_arguments(measure)[0]))
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+
+    // Key passthrough, the divided avg, then the merged count. Every measure leaves through a
+    // throwing cast to its FE-declared output type: the merged count is otherwise DuckDB's
+    // widened sum(BIGINT) = HUGEINT, which the next hop's declared BIGINT stream refuses.
+    assert_eq!(project.expressions.len(), 3);
+    assert_eq!(field_index(&project.expressions[0]), 0);
+    let (count_type, count_input) = cast_parts(&project.expressions[2]);
+    assert!(
+        matches!(count_type, substrait::proto::r#type::Kind::I64(_)),
+        "{count_type:?}"
+    );
+    assert_eq!(field_index(count_input), 3);
+    let (avg_type, avg_input) = cast_parts(&project.expressions[1]);
+    assert!(
+        matches!(avg_type, substrait::proto::r#type::Kind::Fp64(_)),
+        "{avg_type:?}"
+    );
+    let expression::RexType::IfThen(if_then) = avg_input.rex_type.as_ref().unwrap() else {
+        panic!("expected the zero-count guard around the division");
+    };
+    // A group whose values were all NULL arrives with a zero count: SQL's average of no
+    // values is NULL, not a division by zero.
+    let condition = if_then.ifs[0].r#if.as_ref().unwrap();
+    assert_eq!(
+        resolved_function(&translated.plan, scalar_fn(condition).function_reference).1,
+        "equal"
+    );
+    assert_eq!(field_index(scalar_arg(condition, 0)), 2);
+    assert!(matches!(
+        literal_type(scalar_arg(condition, 1)),
+        expression::literal::LiteralType::I64(0)
+    ));
+    assert!(matches!(
+        literal_type(if_then.ifs[0].then.as_ref().unwrap()),
+        expression::literal::LiteralType::Null(_)
+    ));
+    let quotient = if_then.r#else.as_ref().unwrap();
+    assert_eq!(
+        resolved_function(&translated.plan, scalar_fn(quotient).function_reference).1,
+        "divide"
+    );
+    assert_eq!(field_index(scalar_arg(quotient, 0)), 1);
+    assert!(
+        matches!(
+            scalar_arg(quotient, 1).rex_type.as_ref().unwrap(),
+            expression::RexType::Cast(_)
+        ),
+        "the count is divided as a double, not by an integer rule"
+    );
+}
+
+/// Verifies both fragments of a two-phase avg query describe the same wire row: the partial
+/// fragment's output names and measure types match the merge fragment's declared stream
+/// column-for-column, including the count column neither FE tuple has a slot for.
+#[test]
+fn two_phase_avg_columns_agree_end_to_end() {
+    // Partial fragment: avg(price), count(id) GROUP BY name over a scan, need_finalize=false.
+    let mut avg = aggregate_expr(
+        "avg",
+        scalar_type(TPrimitiveType::DOUBLE),
+        Some(slot_ref(1, 0, scalar_type(TPrimitiveType::DOUBLE))),
+    );
+    avg.nodes[0].agg_expr = Some(TAggregateExpr::new(false));
+    let mut count = aggregate_expr(
+        "count",
+        scalar_type(TPrimitiveType::BIGINT),
+        Some(slot_ref(3, 0, scalar_type(TPrimitiveType::BIGINT))),
+    );
+    count.nodes[0].agg_expr = Some(TAggregateExpr::new(false));
+    let mut node = aggregation_node(
+        1,
+        1,
+        vec![slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))],
+        vec![avg, count],
+    );
+    node.agg_node.as_mut().unwrap().need_finalize = false;
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None)],
+        vec![
+            slot(1, 0, "price", scalar_type(TPrimitiveType::DOUBLE)),
+            slot(2, 0, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(3, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(10, 1, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(11, 1, "a", scalar_type(TPrimitiveType::VARBINARY)),
+            slot(12, 1, "c", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+    let partial = translate_fragment(&params(
+        Some(TPlan::new(vec![node, scan_node(0, 0)])),
+        Some(desc),
+        None,
+    ))
+    .unwrap();
+
+    // The sender's row: the grouping key (typed by its slot) then one column per emitted
+    // measure, named the way the partial fragment names them.
+    let partial_columns = std::iter::once("VARCHAR")
+        .chain(
+            root_aggregate(&partial.plan)
+                .measures
+                .iter()
+                .map(measure_output_type),
+        )
+        .zip(&partial.output_names)
+        .map(|(ty, name)| (name.as_str(), ty))
+        .collect::<Vec<_>>();
+
+    let merge = PlanTranslator::new()
+        .translate_fragment_with_exchange_inputs(
+            &merge_avg_fragment_params(),
+            &[ExchangeInput {
+                node_id: 7,
+                stream_view: "sirius_stream_7".to_string(),
+                names: partial.output_names.clone(),
+            }],
+        )
+        .unwrap();
+
+    assert_eq!(
+        partial_columns,
+        merge.stream_inputs[0]
+            .columns
+            .iter()
+            .map(|column| (column.name.as_str(), column.ty.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// A partial `avg(id)` over a scan (need_finalize=false): the shape whose state expands.
+fn partial_avg_node() -> TPlanNode {
+    let mut aggregate = aggregate_expr(
+        "avg",
+        scalar_type(TPrimitiveType::DOUBLE),
+        Some(slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+    );
+    aggregate.nodes[0].agg_expr = Some(TAggregateExpr::new(false));
+    let mut node = aggregation_node(1, 1, Vec::new(), vec![aggregate]);
+    node.agg_node.as_mut().unwrap().need_finalize = false;
+    node
+}
+
+/// Verifies fragment output expressions over an expanded partial are refused: they resolve the
+/// aggregate's slots at their FE positions, which the extra count column moved.
+#[test]
+fn expanded_partial_refuses_fragment_output_exprs() {
+    let err = translate_fragment(&params(
+        Some(TPlan::new(vec![partial_avg_node(), scan_node(0, 0)])),
+        Some(scalar_agg_desc()),
+        Some(vec![slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT))]),
+    ))
+    .unwrap_err();
+    assert!(matches!(err, TranslateError::MalformedPlan(_)), "{err:?}");
     let message = err.to_string();
-    assert!(message.contains("two-phase avg"), "{message}");
-    assert!(message.contains("next translator layer"), "{message}");
+    assert!(message.contains("cannot be reprojected"), "{message}");
     assert!(message.contains("new_planner_agg_stage"), "{message}");
+}
+
+/// Verifies an expanded partial has to be the fragment root: a node above it would read the
+/// aggregate's columns at the positions the state moved, silently.
+#[test]
+fn expanded_partial_must_be_the_fragment_root() {
+    let mut select = base_plan_node(2, TPlanNodeType::SELECT_NODE, 1, vec![1]);
+    select.select_node = Some(TSelectNode::new(None));
+    select.conjuncts = Some(vec![binary_pred(
+        TExprOpcode::GT,
+        slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+        int_literal(10),
+    )]);
+    let err = translate_fragment(&params(
+        Some(TPlan::new(vec![
+            select,
+            partial_avg_node(),
+            scan_node(0, 0),
+        ])),
+        Some(scalar_agg_desc()),
+        None,
+    ))
+    .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            TranslateError::UnsupportedPlanNode {
+                node_id: 1,
+                node_type: TPlanNodeType::AGGREGATION_NODE,
+                ..
+            }
+        ),
+        "{err:?}"
+    );
+    assert!(
+        err.to_string().contains("must be the fragment root"),
+        "{err}"
+    );
+}
+
+/// Verifies HAVING conjuncts on an expanded partial are refused for the same reason: they are
+/// evaluated over the aggregate's row, whose columns sit past the FE positions.
+#[test]
+fn conjuncts_over_an_expanded_partial_are_rejected() {
+    let mut node = partial_avg_node();
+    node.conjuncts = Some(vec![binary_pred(
+        TExprOpcode::GT,
+        slot_ref(1, 1, scalar_type(TPrimitiveType::BIGINT)),
+        int_literal(10),
+    )]);
+    let err = translate_phase_case(node).unwrap_err();
+    assert!(
+        matches!(err, TranslateError::UnsupportedPlanNode { .. }),
+        "{err:?}"
+    );
+    let message = err.to_string();
+    assert!(
+        message.contains("conjuncts over a partial aggregation"),
+        "{message}"
+    );
+}
+
+/// The partial fragment of `avg(price), count(id) GROUP BY name` over a scan, with the FE's
+/// one opaque slot (11) for avg's state, as a plan and its descriptor table.
+fn grouped_partial_avg_plan() -> (TPlan, TDescriptorTable) {
+    let mut avg = aggregate_expr(
+        "avg",
+        scalar_type(TPrimitiveType::DOUBLE),
+        Some(slot_ref(1, 0, scalar_type(TPrimitiveType::DOUBLE))),
+    );
+    avg.nodes[0].agg_expr = Some(TAggregateExpr::new(false));
+    let mut count = aggregate_expr(
+        "count",
+        scalar_type(TPrimitiveType::BIGINT),
+        Some(slot_ref(3, 0, scalar_type(TPrimitiveType::BIGINT))),
+    );
+    count.nodes[0].agg_expr = Some(TAggregateExpr::new(false));
+    let mut node = aggregation_node(
+        1,
+        1,
+        vec![slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))],
+        vec![avg, count],
+    );
+    node.agg_node.as_mut().unwrap().need_finalize = false;
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None)],
+        vec![
+            slot(1, 0, "price", scalar_type(TPrimitiveType::DOUBLE)),
+            slot(2, 0, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(3, 0, "id", scalar_type(TPrimitiveType::BIGINT)),
+            slot(10, 1, "name", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(11, 1, "a", scalar_type(TPrimitiveType::VARBINARY)),
+            slot(12, 1, "c", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+    (TPlan::new(vec![node, scan_node(0, 0)]), desc)
+}
+
+/// Verifies a hash-partitioned sink over an expanded partial keeps a grouping key (it sits
+/// ahead of every measure, so its index holds) and refuses a measure slot, whose FE index
+/// points at the wrong column once the avg state occupies two.
+#[test]
+fn hash_partition_key_on_an_expanded_measure_is_rejected() {
+    let (plan, desc) = grouped_partial_avg_plan();
+    let translated = translate_fragment(&params_with_stream_sink(
+        plan.clone(),
+        desc.clone(),
+        None,
+        hash_partition(vec![slot_ref(10, 1, scalar_type(TPrimitiveType::VARCHAR))]),
+    ))
+    .unwrap();
+    assert_eq!(translated.output_partition_columns, Some(vec![0]));
+    assert_eq!(translated.output_names, vec!["name", "a", "a__count", "c"]);
+
+    let err = translate_fragment(&params_with_stream_sink(
+        plan,
+        desc,
+        None,
+        hash_partition(vec![slot_ref(12, 1, scalar_type(TPrimitiveType::BIGINT))]),
+    ))
+    .unwrap_err();
+    assert!(matches!(err, TranslateError::MalformedPlan(_)), "{err:?}");
+    assert!(err.to_string().contains("position moved"), "{err}");
 }
 
 /// Verifies grouped two-phase aggregation translates: the partial node keeps its grouping key


### PR DESCRIPTION
## Description

TPC-H q01 has three avg measures, and until this layer any two-phase plan with an avg was refused. StarRocks allocates one opaque VARBINARY slot per avg state. Sirius keeps a DOUBLE sum and a BIGINT count. Every other two-phase state is one column wide, so avg is the only measure whose wire row is wider than the FE's tuple.

The partial aggregation now emits two measures for the one FE slot, `sum(cast(arg AS DOUBLE))` and `count(arg)`, and names the extra column `<slot>__count` (`partial_state::COUNT_SUFFIX`) so the receiving fragment spells it the same way. The merge aggregation sums both columns, and the finalizing projection divides them. A summed count of zero yields NULL, as SQL does for the average of no values, instead of a division by zero. `merge_exchange_overrides` and `merge_state_columns` already stepped the exchange row by each state's modeled width; this layer records where each measure's state starts and deletes the temporary refusal in `two_phase_wire_columns`.

The wider row breaks the one-slot-per-column invariant the rest of the translator relies on. I chose to fence where the expansion may appear rather than teach every consumer about it.

- The expanded partial has to be the fragment root. `translate_plan` refuses a node above it.
- No conjuncts on the expanded node. A HAVING would read the aggregate's columns at FE positions.
- No fragment `output_exprs` over an expanded partial.
- A second expanded partial in one fragment is refused.
- Hash-partition keys must be grouping keys. Keys sit ahead of every measure and keep their index.

I want to be plain about what the fences buy. A plan shape that slipped past them would read a wrong column and return wrong rows, not raise. The fences are the review, and one test pins each of them.

`AggregateCall` gains `raw_arguments`, the arguments before the decimal-to-FP64 lowering, because the count has to run over the uncast values while the sum casts them. `WireColumn::suffix` in `partial_state.rs` loses its `#[allow(dead_code)]` and the comment that said nothing reads it yet; `expanded_output_names` is that reader. `TranslatedPlan`'s public fields do not change, so the CN crate is untouched.

**How I tested it.** On a GB200 box (aarch64) I ran the CI trio: cargo fmt, clippy with warnings as errors, and the workspace test suite without the engine feature. All 213 tests pass, 7 of them new. CI runs the same commands, so nothing here is GPU-only.

The translate.rs count goes from 142 to 148. I removed `two_phase_avg_is_refused_until_the_next_layer` and added seven tests, among them `partial_avg_expands_to_sum_and_count`, `two_phase_avg_columns_agree_end_to_end` and `expanded_partial_must_be_the_fragment_root`, with one test per fence. With the base `src/` restored, those seven fail and the other 141 pass.

Not handled here: common-expr slots carried through projects (a later layer) and any relaxation of the fences above. This is the layer q01's aggregation fragments were waiting on.

Layer 4 of the translator stack; base stacked/translator-wire-order.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
Refs #1236 (the FP64 lowering the avg sum column relies on).