### PR TITLE
feat(starrocks): carry consumed common-expr slots past the project that computes them

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/expr_translator.rs
@@ -13,6 +13,22 @@ use crate::{
     ExtensionRegistry, URN_ARITHMETIC, URN_BOOLEAN, URN_COMPARISON, URN_DATETIME, URN_STRING,
 };
 
+/// A common-expr slot a project physically emits past its descriptor row because an ancestor
+/// node consumes it (see `node_translator::translate_project_node`).
+///
+/// StarRocks' BE outputs a project's common slots when a node above references them even
+/// though no output tuple materializes them; carrying the `(tuple, slot) -> column` binding
+/// upward is how this translator reproduces that.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CarriedSlot {
+    /// Output tuple of the project that carries the slot.
+    pub tuple_id: i32,
+    /// StarRocks slot id (query-global in new-optimizer plans).
+    pub slot_id: i32,
+    /// Physical column of the carried value in the project's output row.
+    pub column: usize,
+}
+
 /// Mutable state needed while translating one StarRocks expression tree.
 pub(crate) struct ExprContext<'a> {
     /// Descriptor lookups for slot references and row layouts.
@@ -23,6 +39,8 @@ pub(crate) struct ExprContext<'a> {
     row_tuples: &'a [i32],
     /// Synthetic StarRocks slots appended while evaluating common project expressions.
     slot_overrides: Option<&'a std::collections::HashMap<(i32, i32), usize>>,
+    /// Common-expr columns the input row carries past its descriptor width.
+    carried: Option<&'a [CarriedSlot]>,
 }
 
 impl<'a> ExprContext<'a> {
@@ -37,6 +55,7 @@ impl<'a> ExprContext<'a> {
             registry,
             row_tuples,
             slot_overrides: None,
+            carried: None,
         }
     }
 
@@ -53,7 +72,16 @@ impl<'a> ExprContext<'a> {
             registry,
             row_tuples,
             slot_overrides: Some(slot_overrides),
+            carried: None,
         }
+    }
+
+    /// Makes the input row's carried common-expr columns visible to slot resolution.
+    pub(crate) fn with_carried(mut self, carried: &'a [CarriedSlot]) -> Self {
+        if !carried.is_empty() {
+            self.carried = Some(carried);
+        }
+        self
     }
 }
 
@@ -156,6 +184,11 @@ fn translate_expr_node(
 }
 
 /// Converts a StarRocks `SLOT_REF` into a Substrait field selection.
+///
+/// Resolution order: exact `(tuple, slot)` synthetic override, exact `(tuple, slot)` carried
+/// column, descriptor row (`slot_global_index`), and only when the descriptor fails a carried
+/// column matched by slot id alone (BE semantics: the tuple id of a ref can be stale, see
+/// `DescriptorTable::slot_global_index`). Every ambiguity is refused, never guessed.
 fn translate_slot_ref(
     node: &TExprNode,
     children: Vec<Expression>,
@@ -166,18 +199,59 @@ fn translate_slot_ref(
         context: "SLOT_REF",
         field: "slot_ref",
     })?;
-    let field = ctx
+    let key = (slot_ref.tuple_id, slot_ref.slot_id);
+    let exact_override = ctx
         .slot_overrides
-        .and_then(|overrides| {
-            overrides
-                .get(&(slot_ref.tuple_id, slot_ref.slot_id))
-                .copied()
-        })
-        .map(Ok)
-        .unwrap_or_else(|| {
-            ctx.desc
+        .and_then(|overrides| overrides.get(&key).copied());
+    let exact_carried = ctx.carried.and_then(|carried| {
+        carried
+            .iter()
+            .find(|slot| (slot.tuple_id, slot.slot_id) == key)
+            .map(|slot| slot.column)
+    });
+    if exact_override.is_some() && exact_carried.is_some() {
+        return Err(TranslateError::descriptor(format!(
+            "slot {} (tuple {}) resolves through both a synthetic slot override and a carried \
+             common column; refusing to guess between the two",
+            key.1, key.0
+        )));
+    }
+    let field = match exact_override.or(exact_carried) {
+        Some(column) => column,
+        None => {
+            match ctx
+                .desc
                 .slot_global_index(slot_ref.tuple_id, slot_ref.slot_id, ctx.row_tuples)
-        })? as i32;
+            {
+                Ok(index) => index,
+                Err(descriptor_error) => {
+                    let candidates = ctx
+                        .carried
+                        .map(|carried| {
+                            carried
+                                .iter()
+                                .filter(|slot| slot.slot_id == key.1)
+                                .map(|slot| slot.column)
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default();
+                    match candidates.as_slice() {
+                        [column] => *column,
+                        [] => return Err(descriptor_error),
+                        _ => {
+                            return Err(TranslateError::descriptor(format!(
+                                "slot {} (tuple {}) matches {} carried common columns by slot id \
+                                 alone; an ambiguous fallback is a guess, not a resolution",
+                                key.1,
+                                key.0,
+                                candidates.len()
+                            )));
+                        }
+                    }
+                }
+            }
+        }
+    } as i32;
     Ok(Expression {
         rex_type: Some(expression::RexType::Selection(Box::new(FieldReference {
             reference_type: Some(field_reference::ReferenceType::DirectReference(
@@ -1000,4 +1074,187 @@ fn encode_decimal(value: &str, scale: i32) -> Result<[u8; 16]> {
         unscaled = -unscaled;
     }
     Ok(unscaled.to_le_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use starrocks_thrift::descriptors::{TDescriptorTable, TSlotDescriptor, TTupleDescriptor};
+    use starrocks_thrift::exprs::TSlotRef;
+    use starrocks_thrift::types::{TScalarType, TTypeDesc, TTypeNode, TTypeNodeType};
+
+    use super::*;
+
+    /// Builds a descriptor with one tuple 0 carrying one BIGINT slot 1.
+    fn one_slot_desc() -> DescriptorTable {
+        let ty = TTypeDesc::new(Some(vec![TTypeNode::new(
+            TTypeNodeType::SCALAR,
+            Some(TScalarType::new(TPrimitiveType::BIGINT, None, None, None)),
+            None,
+            None,
+        )]));
+        let desc_tbl = TDescriptorTable::new(
+            Some(vec![TSlotDescriptor::new(
+                Some(1),
+                Some(0),
+                Some(ty),
+                Some(0),
+                None,
+                None,
+                None,
+                Some("a".to_string()),
+                None,
+                Some(true),
+                Some(true),
+                Some(true),
+                None,
+                None,
+            )]),
+            vec![TTupleDescriptor::new(Some(0), None, None, None, None)],
+            None,
+            None,
+        );
+        DescriptorTable::try_from(&desc_tbl).unwrap()
+    }
+
+    /// Builds a bare slot-reference expression node.
+    fn slot_ref_node(tuple_id: i32, slot_id: i32) -> TExprNode {
+        let ty = TTypeDesc::new(Some(vec![TTypeNode::new(
+            TTypeNodeType::SCALAR,
+            Some(TScalarType::new(TPrimitiveType::BIGINT, None, None, None)),
+            None,
+            None,
+        )]));
+        TExprNode {
+            node_type: TExprNodeType::SLOT_REF,
+            type_: ty,
+            opcode: None,
+            num_children: 0,
+            agg_expr: None,
+            bool_literal: None,
+            case_expr: None,
+            date_literal: None,
+            float_literal: None,
+            int_literal: None,
+            in_predicate: None,
+            is_null_pred: None,
+            like_pred: None,
+            literal_pred: None,
+            slot_ref: Some(TSlotRef::new(slot_id, tuple_id)),
+            string_literal: None,
+            tuple_is_null_pred: None,
+            info_func: None,
+            decimal_literal: None,
+            output_scale: -1,
+            fn_call_expr: None,
+            large_int_literal: None,
+            output_column: None,
+            output_type: None,
+            vector_opcode: None,
+            fn_: None,
+            vararg_start_idx: None,
+            child_type: None,
+            vslot_ref: None,
+            used_subfield_names: None,
+            binary_literal: None,
+            copy_flag: None,
+            check_is_out_of_bounds: None,
+            use_vectorized: None,
+            has_nullable_child: None,
+            is_nullable: None,
+            child_type_desc: None,
+            is_monotonic: None,
+            dict_query_expr: None,
+            dictionary_get_expr: None,
+            is_index_only_filter: None,
+            is_nondeterministic: None,
+            cast_struct_by_name: None,
+        }
+    }
+
+    /// Returns the field index of a direct struct-field selection.
+    fn field_of(expr: &Expression) -> i32 {
+        let expression::RexType::Selection(selection) = expr.rex_type.as_ref().unwrap() else {
+            panic!("expected field selection");
+        };
+        let field_reference::ReferenceType::DirectReference(segment) =
+            selection.reference_type.as_ref().unwrap()
+        else {
+            panic!("expected direct reference");
+        };
+        let reference_segment::ReferenceType::StructField(field) =
+            segment.reference_type.as_ref().unwrap()
+        else {
+            panic!("expected struct field");
+        };
+        field.field
+    }
+
+    /// A stale-tuple ref that misses the descriptor resolves through the single carried column
+    /// matching its slot id: the BE's by-slot-id semantics extended to carried commons.
+    #[test]
+    fn carried_by_slot_id_fallback_resolves_a_single_candidate() {
+        let desc = one_slot_desc();
+        let mut registry = ExtensionRegistry::new();
+        let row = [0];
+        let carried = [CarriedSlot {
+            tuple_id: 7,
+            slot_id: 99,
+            column: 4,
+        }];
+        let mut ctx = ExprContext::new(&desc, &mut registry, &row).with_carried(&carried);
+        let node = slot_ref_node(3, 99);
+        let translated = translate_slot_ref(&node, Vec::new(), &mut ctx).unwrap();
+        assert_eq!(field_of(&translated), 4);
+    }
+
+    /// Two carried columns sharing a slot id make the by-slot-id fallback a guess; refuse it.
+    #[test]
+    fn ambiguous_carried_by_slot_id_fallback_is_refused() {
+        let desc = one_slot_desc();
+        let mut registry = ExtensionRegistry::new();
+        let row = [0];
+        let carried = [
+            CarriedSlot {
+                tuple_id: 7,
+                slot_id: 99,
+                column: 4,
+            },
+            CarriedSlot {
+                tuple_id: 8,
+                slot_id: 99,
+                column: 5,
+            },
+        ];
+        let mut ctx = ExprContext::new(&desc, &mut registry, &row).with_carried(&carried);
+        let node = slot_ref_node(3, 99);
+        let err = translate_slot_ref(&node, Vec::new(), &mut ctx).unwrap_err();
+        assert!(
+            matches!(&err, TranslateError::Descriptor(message) if message.contains("carried")),
+            "{err:?}"
+        );
+    }
+
+    /// A `(tuple, slot)` key present in both the synthetic overrides and the carried columns
+    /// has two competing sources; never guess between them.
+    #[test]
+    fn duplicate_override_and_carried_key_is_refused() {
+        let desc = one_slot_desc();
+        let mut registry = ExtensionRegistry::new();
+        let row = [0];
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert((7, 99), 1usize);
+        let carried = [CarriedSlot {
+            tuple_id: 7,
+            slot_id: 99,
+            column: 4,
+        }];
+        let mut ctx = ExprContext::with_slot_overrides(&desc, &mut registry, &row, &overrides)
+            .with_carried(&carried);
+        let node = slot_ref_node(7, 99);
+        let err = translate_slot_ref(&node, Vec::new(), &mut ctx).unwrap_err();
+        assert!(
+            matches!(&err, TranslateError::Descriptor(message) if message.contains("both")),
+            "{err:?}"
+        );
+    }
 }

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -30,7 +30,7 @@
 //! | `FILE_SCAN_NODE`     | `ReadRel` (local files) |
 //! | `HDFS_SCAN_NODE`     | `ReadRel` (named table) |
 //! | `SELECT_NODE`        | `FilterRel`        |
-//! | `PROJECT_NODE`       | `ProjectRel` (common slots materialized first as hidden `ProjectRel`s) |
+//! | `PROJECT_NODE`       | `ProjectRel` (common slots materialized first as hidden `ProjectRel`s; those an ancestor consumes are carried as trailing columns and confined at the fragment root) |
 //! | `AGGREGATION_NODE`   | `AggregateRel` (one-phase, or either half of a two-phase plan) |
 //! | `SORT_NODE`          | `ProjectRel` (sort tuple) + `SortRel` (global row-number top-N only) |
 //! | `HASH_JOIN_NODE`      | `JoinRel` (inner/outer/left-semi; left/right anti as outer join + `is_null` filter, null-aware left anti as mark join + `not`) |
@@ -295,6 +295,7 @@ impl PlanTranslator {
             partial_expansion,
         } = node_translator::translate_plan(
             plan,
+            fragment.output_exprs.as_deref().unwrap_or_default(),
             &desc,
             &scan_paths,
             &exchange_inputs,
@@ -323,13 +324,22 @@ impl PlanTranslator {
             translated =
                 node_translator::project_exprs(translated, output_exprs, &desc, &mut registry)?;
             names
-        } else if let Some(expansion) = &partial_expansion {
-            // A partial avg ships more columns than the FE's output tuple has slots, so the
-            // descriptor table cannot name the row. These names are what the receiver reads
-            // the stream's columns by.
-            expansion.names.clone()
         } else {
-            desc.output_names_for_tuples(&translated.row_tuples)?
+            // Carried common-expr columns are a fragment-internal mechanism and never leave
+            // the fragment. Narrow back to the descriptor row BEFORE deriving names: a
+            // width-preserving root (a SELECT conjunct above the carrying project, say) would
+            // otherwise ship columns the sender's names and the receiver's declared stream
+            // schema do not describe. (The output_exprs branch above narrows naturally; its
+            // root projection emits only the output expressions.)
+            translated = node_translator::confine_carried(translated);
+            if let Some(expansion) = &partial_expansion {
+                // A partial avg ships more columns than the FE's output tuple has slots, so
+                // the descriptor table cannot name the row. These names are what the receiver
+                // reads the stream's columns by.
+                expansion.names.clone()
+            } else {
+                desc.output_names_for_tuples(&translated.row_tuples)?
+            }
         };
 
         let output_names = unique_names(output_names).collect::<Vec<_>>();

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use starrocks_thrift::exprs::TExpr;
 use starrocks_thrift::opcodes::TExprOpcode;
@@ -18,7 +18,7 @@ use substrait::proto::{
 use crate::agg_phase::{self, AggPhase};
 use crate::descriptor_table::DescriptorTable;
 use crate::error::{Result, TranslateError};
-use crate::expr_translator::{self, ExprContext, TranslateExpr};
+use crate::expr_translator::{self, CarriedSlot, ExprContext, TranslateExpr};
 use crate::partial_state::{self, WireColumn};
 use crate::scan_paths::ScanFilePaths;
 use crate::type_mapper;
@@ -46,6 +46,15 @@ pub(crate) struct TranslatedRel {
     /// that silently produced a wrong offset the moment an unknown relation
     /// appeared mid-tree. Every relation built here MUST set its true width.
     pub output_width: usize,
+    /// Common-expr columns carried past the descriptor row (see [`translate_project_node`]).
+    ///
+    /// Invariant: columns `[0, output_width - carried_slots.len())` are exactly the
+    /// concatenation of `materialized_slot_ids(t)` for `t` in `row_tuples`; the carried
+    /// columns occupy the tail `[output_width - carried_slots.len(), output_width)`.
+    /// Deliberately no `Default` impl: every construction site must decide whether carried
+    /// columns survive it. Width-preserving nodes pass them through, re-materializing nodes
+    /// drop them by construction, joins refuse them, and the fragment root narrows them away.
+    pub carried_slots: Vec<CarriedSlot>,
 }
 
 /// Mutable state shared by plan-node translators.
@@ -71,6 +80,10 @@ struct PlanContext<'a> {
     /// Set when a partial aggregation emitted more columns than its FE output tuple declares.
     /// The fragment's root output names come from here instead of the descriptor table.
     partial_expansion: Option<PartialExpansion>,
+    /// Common-expr slots each project must physically carry because an ancestor consumes them,
+    /// keyed by project node id with slot ids ascending. Computed by
+    /// [`common_slots_consumed_above`] before translation starts.
+    consumed_above: HashMap<i32, Vec<i32>>,
 }
 
 /// The wire columns one merge measure's partial state occupies on the exchange row.
@@ -127,6 +140,7 @@ impl<'a> PlanContext<'a> {
             stream_inputs: Vec::new(),
             exchange_state_overrides: HashMap::new(),
             partial_expansion: None,
+            consumed_above: HashMap::new(),
         }
     }
 
@@ -263,6 +277,7 @@ fn apply_fetch(input: TranslatedRel, node: &TPlanNode) -> TranslatedRel {
         rel,
         row_tuples,
         output_width,
+        carried_slots,
     } = input;
     // For an offset-only fetch, emit an explicit unlimited count: the consumer reads the plain
     // count field without checking the oneof, and an unset count would decode as `LIMIT 0`.
@@ -280,6 +295,8 @@ fn apply_fetch(input: TranslatedRel, node: &TPlanNode) -> TranslatedRel {
         },
         row_tuples,
         output_width,
+        // A fetch keeps the row layout, carried columns included.
+        carried_slots,
     }
 }
 
@@ -337,6 +354,7 @@ fn translate_scan(
         rel: scan_rel(ctx.desc, tuple_id, file_paths)?,
         row_tuples: vec![tuple_id],
         output_width: ctx.desc.materialized_slot_ids(tuple_id)?.len(),
+        carried_slots: Vec::new(),
     };
     apply_conjuncts(input, node, ctx)
 }
@@ -396,8 +414,12 @@ fn translate_project(
 }
 
 /// Translates a flat preorder StarRocks plan into a Substrait relation tree.
+///
+/// `root_output_exprs` are the fragment's output expressions (empty when absent); they count
+/// as consumers sitting above the fragment root for [`common_slots_consumed_above`].
 pub(crate) fn translate_plan(
     plan: &TPlan,
+    root_output_exprs: &[TExpr],
     desc: &DescriptorTable,
     scan_paths: &ScanFilePaths,
     exchange_inputs: &HashMap<i32, &ExchangeInput>,
@@ -405,6 +427,7 @@ pub(crate) fn translate_plan(
 ) -> Result<TranslatedFragment> {
     let mut ctx = PlanContext::new(desc, scan_paths, exchange_inputs, registry);
     ctx.exchange_state_overrides = merge_exchange_overrides(plan)?;
+    ctx.consumed_above = common_slots_consumed_above(plan, root_output_exprs, desc)?;
     let root = plan.translate(&mut ctx)?;
     if let Some(expansion) = &ctx.partial_expansion {
         // Only the fragment root's row leaves this CN by name. Any node above the expanded
@@ -485,6 +508,143 @@ fn merge_exchange_overrides(plan: &TPlan) -> Result<HashMap<i32, Vec<StateColumn
         overrides.insert(child.node_id, columns);
     }
     Ok(overrides)
+}
+
+/// Finds, for every project node, the common-expr slots an ancestor consumes even though no
+/// output tuple materializes them.
+///
+/// StarRocks' BE physically outputs a project's common slots when a node above references
+/// them, and the FE plans against that; this pre-pass reproduces the FE's view so
+/// [`translate_project_node`] can widen the project with the consumed columns. One walk over
+/// the flat preorder node list, keeping the open ancestors on a stack (the same span math
+/// `PlanNodeCursor` uses): when a `PROJECT_NODE` with a non-empty `common_slot_map` is
+/// visited, every expression payload of its strict ancestors, plus `root_output_exprs`,
+/// which sit above the fragment root, is scanned for references to its non-materialized
+/// common slots. Matching is by slot id alone: new-optimizer slot ids are query-global and an
+/// ancestor ref can carry a stale tuple id (see `DescriptorTable::slot_global_index`). A
+/// false positive only widens the row with a column the root confinement drops; a false
+/// negative leaves today's loud zero-candidate descriptor error. Neither is silent.
+fn common_slots_consumed_above(
+    plan: &TPlan,
+    root_output_exprs: &[TExpr],
+    desc: &DescriptorTable,
+) -> Result<HashMap<i32, Vec<i32>>> {
+    let mut consumed = HashMap::new();
+    // Open ancestors of the node being visited: (node index, children not yet completed).
+    let mut stack: Vec<(usize, i32)> = Vec::new();
+    for (index, node) in plan.nodes.iter().enumerate() {
+        if node.node_type == TPlanNodeType::PROJECT_NODE
+            && let Some(common) = node
+                .project_node
+                .as_ref()
+                .and_then(|project| project.common_slot_map.as_ref())
+                .filter(|common| !common.is_empty())
+        {
+            let mut candidates = BTreeSet::new();
+            for &slot_id in common.keys() {
+                let mut materialized = false;
+                for &tuple_id in &node.row_tuples {
+                    if desc.materialized_slot_ids(tuple_id)?.contains(&slot_id) {
+                        materialized = true;
+                        break;
+                    }
+                }
+                if !materialized {
+                    candidates.insert(slot_id);
+                }
+            }
+            if !candidates.is_empty() {
+                let mut hits = BTreeSet::new();
+                for &(ancestor, _) in &stack {
+                    collect_slot_ref_hits(&plan.nodes[ancestor], &candidates, &mut hits);
+                }
+                for expr in root_output_exprs {
+                    collect_expr_slot_ref_hits(expr, &candidates, &mut hits);
+                }
+                if !hits.is_empty() {
+                    consumed.insert(node.node_id, hits.into_iter().collect());
+                }
+            }
+        }
+        if node.num_children > 0 {
+            stack.push((index, node.num_children));
+        } else {
+            // A leaf completes itself, and possibly the subtrees of the ancestors above it.
+            while let Some(top) = stack.last_mut() {
+                top.1 -= 1;
+                if top.1 == 0 {
+                    stack.pop();
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    Ok(consumed)
+}
+
+/// Adds to `hits` every candidate slot id referenced by any expression payload of `node`.
+fn collect_slot_ref_hits(node: &TPlanNode, candidates: &BTreeSet<i32>, hits: &mut BTreeSet<i32>) {
+    let mut exprs: Vec<&TExpr> = Vec::new();
+    exprs.extend(node.conjuncts.as_deref().unwrap_or_default());
+    if let Some(agg) = node.agg_node.as_ref() {
+        exprs.extend(agg.grouping_exprs.as_deref().unwrap_or_default());
+        exprs.extend(&agg.aggregate_functions);
+    }
+    if let Some(sort) = node.sort_node.as_ref() {
+        exprs.extend(&sort.sort_info.ordering_exprs);
+        exprs.extend(
+            sort.sort_info
+                .sort_tuple_slot_exprs
+                .as_deref()
+                .unwrap_or_default(),
+        );
+        // Deprecated node-level duplicate some senders populate instead (see translate_sort).
+        exprs.extend(sort.sort_tuple_slot_exprs.as_deref().unwrap_or_default());
+    }
+    if let Some(join) = node.hash_join_node.as_ref() {
+        for eq in &join.eq_join_conjuncts {
+            exprs.push(&eq.left);
+            exprs.push(&eq.right);
+        }
+        exprs.extend(join.other_join_conjuncts.as_deref().unwrap_or_default());
+    }
+    if let Some(join) = node.nestloop_join_node.as_ref() {
+        exprs.extend(join.join_conjuncts.as_deref().unwrap_or_default());
+    }
+    if let Some(project) = node.project_node.as_ref() {
+        exprs.extend(
+            project
+                .slot_map
+                .as_ref()
+                .into_iter()
+                .flatten()
+                .map(|(_, expr)| expr),
+        );
+        exprs.extend(
+            project
+                .common_slot_map
+                .as_ref()
+                .into_iter()
+                .flatten()
+                .map(|(_, expr)| expr),
+        );
+    }
+    for expr in exprs {
+        collect_expr_slot_ref_hits(expr, candidates, hits);
+    }
+}
+
+/// Adds to `hits` every candidate slot id one flat preorder expression references.
+fn collect_expr_slot_ref_hits(expr: &TExpr, candidates: &BTreeSet<i32>, hits: &mut BTreeSet<i32>) {
+    for node in &expr.nodes {
+        if node.node_type == starrocks_thrift::exprs::TExprNodeType::SLOT_REF
+            && let Some(slot_ref) = node.slot_ref.as_ref()
+            && candidates.contains(&slot_ref.slot_id)
+        {
+            hits.insert(slot_ref.slot_id);
+        }
+    }
 }
 
 /// Translates an `EXCHANGE_NODE` into a read of the engine stream its senders' batches arrive on.
@@ -616,6 +776,9 @@ fn translate_exchange(
         rel: stream_read_rel(schema, &input.stream_view),
         row_tuples: exchange.input_row_tuples.clone(),
         output_width,
+        // Streams never carry: the sender's root narrowed any carried columns away, and the
+        // declared stream schema describes exactly the descriptor row.
+        carried_slots: Vec::new(),
     };
     if let Some(sort_info) = &exchange.sort_info {
         let sorts = sort_fields(sort_info, &translated, ctx)?;
@@ -630,6 +793,7 @@ fn translate_exchange(
             },
             row_tuples,
             output_width,
+            carried_slots: Vec::new(),
         };
     }
     apply_conjuncts(translated, node, ctx)
@@ -759,13 +923,25 @@ fn translate_aggregation(
         )?),
         _ => None,
     };
+    // Unreachable today (a merge child must be an exchange, see merge_exchange_overrides, and
+    // streams never carry); kept as a guard so the two column-remapping mechanisms can never
+    // silently combine.
+    if merge_slots.is_some() && !child.carried_slots.is_empty() {
+        return Err(TranslateError::UnsupportedPlanNode {
+            node_id: node.node_id,
+            node_type: node.node_type,
+            reason: "a merge aggregation cannot read partial states from a child that carries \
+                     common-expr columns",
+        });
+    }
 
     let mut grouping_expressions = Vec::with_capacity(keys);
     for &grouping_index in &key_order {
         let mut expr_ctx = match &merge_slots {
             Some(slots) => ctx.expr_context_with_slots(&child.row_tuples, &slots.columns),
             None => ctx.expr_context(&child.row_tuples),
-        };
+        }
+        .with_carried(&child.carried_slots);
         grouping_expressions.push(grouping_exprs[grouping_index].translate(&mut expr_ctx)?);
     }
 
@@ -778,7 +954,8 @@ fn translate_aggregation(
             let mut expr_ctx = match &merge_slots {
                 Some(slots) => ctx.expr_context_with_slots(&child.row_tuples, &slots.columns),
                 None => ctx.expr_context(&child.row_tuples),
-            };
+            }
+            .with_carried(&child.carried_slots);
             expr_translator::aggregate_call(expr, &mut expr_ctx, phase == AggPhase::Merge)?
         };
         // The GPU ungrouped-aggregate operator rejects every distinct aggregate, so a
@@ -874,6 +1051,9 @@ fn translate_aggregation(
         },
         row_tuples: vec![output_tuple],
         output_width,
+        // The child's carried columns were consumed by the key/measure contexts above; the
+        // aggregate materializes a fresh tuple, so nothing is carried past it.
+        carried_slots: Vec::new(),
     };
 
     let aggregated = match phase {
@@ -1148,7 +1328,7 @@ fn merge_projection(
         ));
     }
     let row_tuples = input.row_tuples.clone();
-    project_rel(input, expressions, row_tuples)
+    project_rel(input, expressions, row_tuples, Vec::new())
 }
 
 /// Divides a merged avg state back into an average, with SQL's empty-input NULL.
@@ -1432,7 +1612,9 @@ fn translate_sort(
         )?;
         let mut translated_by_slot = std::collections::HashMap::with_capacity(slot_exprs.len());
         for (slot_id, expr) in fe_slot_order.iter().zip(slot_exprs) {
-            let mut expr_ctx = ctx.expr_context(&child.row_tuples);
+            let mut expr_ctx = ctx
+                .expr_context(&child.row_tuples)
+                .with_carried(&child.carried_slots);
             translated_by_slot.insert(*slot_id, expr.translate(&mut expr_ctx)?);
         }
         let expressions = materialized
@@ -1445,7 +1627,9 @@ fn translate_sort(
                 })
             })
             .collect::<Result<Vec<_>>>()?;
-        project_rel(child, expressions, vec![sort_tuple])
+        // The sort-tuple projection re-materializes the row; the child's carried columns were
+        // consumed by the expressions above and are dropped here by construction.
+        project_rel(child, expressions, vec![sort_tuple], Vec::new())
     } else {
         child
     };
@@ -1453,6 +1637,8 @@ fn translate_sort(
     let sorts = sort_fields(&sort.sort_info, &input, ctx)?;
     let row_tuples = input.row_tuples.clone();
     let output_width = input.output_width;
+    // A sort keeps the row layout, so any carried columns (the no-sort-tuple path) survive it.
+    let carried_slots = input.carried_slots.clone();
     let sorted = TranslatedRel {
         rel: Rel {
             rel_type: Some(rel::RelType::Sort(Box::new(SortRel {
@@ -1463,6 +1649,7 @@ fn translate_sort(
         },
         row_tuples,
         output_width,
+        carried_slots,
     };
     apply_conjuncts(sorted, node, ctx)
 }
@@ -1544,7 +1731,9 @@ fn sort_fields(
         .iter()
         .zip(sort_info.is_asc_order.iter().zip(&sort_info.nulls_first))
         .map(|(expr, (asc, nulls_first))| {
-            let mut expr_ctx = ctx.expr_context(&input.row_tuples);
+            let mut expr_ctx = ctx
+                .expr_context(&input.row_tuples)
+                .with_carried(&input.carried_slots);
             let expr = expr.translate(&mut expr_ctx)?;
             let direction = match (asc, nulls_first) {
                 (true, true) => sort_field::SortDirection::AscNullsFirst,
@@ -1641,6 +1830,8 @@ fn translate_hash_join(
     let mut children = children.into_iter();
     let left = children.next().unwrap();
     let right = children.next().unwrap();
+    refuse_carried_join_child(node, &left)?;
+    refuse_carried_join_child(node, &right)?;
 
     let combined_tuples = [left.row_tuples.as_slice(), right.row_tuples.as_slice()].concat();
     let mut conditions = Vec::new();
@@ -1700,6 +1891,8 @@ fn translate_hash_join(
         },
         row_tuples,
         output_width,
+        // Both children were refused above if they carried anything.
+        carried_slots: Vec::new(),
     };
     let joined = match output {
         JoinOutput::LeftAnti => {
@@ -1752,6 +1945,30 @@ enum JoinOutput {
     NullAwareLeftAnti,
 }
 
+/// Refuses a join child that physically carries common-expr columns.
+///
+/// Join conjuncts resolve through `slot_global_index` over the concatenated child rows using
+/// DESCRIPTOR materialized widths; a carried (wider-than-descriptor) child would physically
+/// shift every right-side column while the descriptor math would not. That is a wrong column
+/// read, not a type error the engine would catch. Consumers of a common slot across a join are
+/// therefore refused, loudly, at translation.
+fn refuse_carried_join_child(node: &TPlanNode, child: &TranslatedRel) -> Result<()> {
+    if child.carried_slots.is_empty() {
+        return Ok(());
+    }
+    let slots: Vec<i32> = child
+        .carried_slots
+        .iter()
+        .map(|slot| slot.slot_id)
+        .collect();
+    Err(TranslateError::descriptor(format!(
+        "{:?} {} reads a child that carries common-expr columns for slots {slots:?}; carried \
+         columns would shift the join's combined descriptor row, so consumers of a common \
+         slot across a join are not supported",
+        node.node_type, node.node_id
+    )))
+}
+
 /// Translates an inner/cross `NESTLOOP_JOIN_NODE` into an equality join on synthetic constants.
 /// This preserves Cartesian-product semantics without requiring a GPU cross-product operator.
 fn translate_nestloop_join(
@@ -1789,6 +2006,8 @@ fn translate_nestloop_join(
     let mut children = children.into_iter();
     let left = children.next().unwrap();
     let right = children.next().unwrap();
+    refuse_carried_join_child(node, &left)?;
+    refuse_carried_join_child(node, &right)?;
     let left_width = left.output_width;
     let right_width = right.output_width;
     let row_tuples = [left.row_tuples.as_slice(), right.row_tuples.as_slice()].concat();
@@ -1835,6 +2054,7 @@ fn translate_nestloop_join(
                     rel,
                     row_tuples,
                     output_width,
+                    carried_slots,
                 } = cross;
                 TranslatedRel {
                     rel: Rel {
@@ -1846,6 +2066,7 @@ fn translate_nestloop_join(
                     },
                     row_tuples,
                     output_width,
+                    carried_slots,
                 }
             }
             None => cross,
@@ -1966,7 +2187,12 @@ fn translate_project_node(
     let mut common_slots = std::collections::HashMap::new();
     for (&slot_id, expr) in project_node.common_slot_map.as_ref().into_iter().flatten() {
         let expression = {
-            let mut expr_ctx = ctx.expr_context_with_slots(&input.row_tuples, &common_slots);
+            // A project stacked on a carrying project references the lower one's carried
+            // columns; append_project never shifts existing columns, so the child's carried
+            // indices stay valid throughout this loop.
+            let mut expr_ctx = ctx
+                .expr_context_with_slots(&input.row_tuples, &common_slots)
+                .with_carried(&input.carried_slots);
             expr.translate(&mut expr_ctx)?
         };
         let field = input.output_width;
@@ -1983,12 +2209,50 @@ fn translate_project_node(
                     node.node_id, slot_id
                 ))
             })?;
-            let mut expr_ctx = ctx.expr_context_with_slots(&input.row_tuples, &common_slots);
+            let mut expr_ctx = ctx
+                .expr_context_with_slots(&input.row_tuples, &common_slots)
+                .with_carried(&input.carried_slots);
             expressions.push(expr.translate(&mut expr_ctx)?);
         }
     }
 
-    Ok(project_rel(input, expressions, output_tuples))
+    // Physically materialize the common-expr slots an ancestor consumes even though no output
+    // tuple materializes them: StarRocks' BE outputs them and the FE plans against that (it
+    // even emits a slot_map entry for them). They land as extra trailing columns past the
+    // descriptor row, and the returned carried_slots bindings are how ancestor refs find them.
+    let materialized_count = expressions.len();
+    let consumed = ctx
+        .consumed_above
+        .get(&node.node_id)
+        .cloned()
+        .unwrap_or_default();
+    let mut carried = Vec::with_capacity(consumed.len());
+    for (position, &slot_id) in consumed.iter().enumerate() {
+        let expression = if let Some(expr) = slot_map.get(&slot_id) {
+            // The FE's own slot_map entry for the consumed slot (q14: `35 <-> ref 35`); its
+            // ref resolves to the appended common column through the override path.
+            let mut expr_ctx = ctx
+                .expr_context_with_slots(&input.row_tuples, &common_slots)
+                .with_carried(&input.carried_slots);
+            expr.translate(&mut expr_ctx)?
+        } else if let Some(&column) = common_slots.get(&(output_tuple, slot_id)) {
+            field_selection(column as i32)
+        } else {
+            return Err(TranslateError::descriptor(format!(
+                "PROJECT_NODE {} common slot {slot_id} is consumed above but the project has \
+                 no slot_map entry or common binding for it",
+                node.node_id
+            )));
+        };
+        expressions.push(expression);
+        carried.push(CarriedSlot {
+            tuple_id: output_tuple,
+            slot_id,
+            column: materialized_count + position,
+        });
+    }
+
+    Ok(project_rel(input, expressions, output_tuples, carried))
 }
 
 /// Adds a root projection over explicit fragment output expressions.
@@ -2014,12 +2278,15 @@ fn project_exprs_with_context(
 ) -> Result<TranslatedRel> {
     let mut expressions = Vec::with_capacity(exprs.len());
     for expr in exprs {
-        let mut expr_ctx = ctx.expr_context(&input.row_tuples);
+        let mut expr_ctx = ctx
+            .expr_context(&input.row_tuples)
+            .with_carried(&input.carried_slots);
         expressions.push(expr.translate(&mut expr_ctx)?);
     }
-    // A root projection over fragment output expressions keeps the input layout.
+    // A root projection over fragment output expressions keeps the input layout. It emits
+    // only the output expressions, so any carried columns are narrowed away here.
     let row_tuples = input.row_tuples.clone();
-    Ok(project_rel(input, expressions, row_tuples))
+    Ok(project_rel(input, expressions, row_tuples, Vec::new()))
 }
 
 /// Builds a Substrait project that emits exactly `expressions`.
@@ -2027,11 +2294,14 @@ fn project_exprs_with_context(
 /// The emit `output_mapping` selects the projected expressions, which sit after
 /// the input columns, so the base offset is the input's carried `output_width`.
 /// `row_tuples` is the output row layout (the project's own tuples, which may
-/// reorder or differ from the input's).
+/// reorder or differ from the input's). `carried_slots` names the trailing
+/// expressions that carry common-expr columns past the descriptor row; every
+/// caller but [`translate_project_node`] passes none.
 fn project_rel(
     input: TranslatedRel,
     expressions: Vec<Expression>,
     row_tuples: Vec<i32>,
+    carried_slots: Vec<CarriedSlot>,
 ) -> TranslatedRel {
     let base = input.output_width as i32;
     let output_mapping = (base..base + expressions.len() as i32).collect();
@@ -2052,6 +2322,7 @@ fn project_rel(
         },
         row_tuples,
         output_width,
+        carried_slots,
     }
 }
 
@@ -2074,6 +2345,9 @@ fn append_project(input: TranslatedRel, expression: Expression) -> TranslatedRel
         },
         row_tuples: input.row_tuples,
         output_width,
+        // The appended column lands at the END of the row, past any carried columns, so the
+        // carried indices stay valid and pass through unchanged.
+        carried_slots: input.carried_slots,
     }
 }
 
@@ -2095,7 +2369,27 @@ fn emit_columns(input: Rel, output_mapping: Vec<i32>, row_tuples: Vec<i32>) -> T
         },
         row_tuples,
         output_width,
+        // An explicit column list re-materializes the row; carried columns never survive it.
+        carried_slots: Vec::new(),
     }
+}
+
+/// Drops a fragment root's carried common-expr columns, restoring the descriptor row.
+///
+/// Required, not defensive: without it a width-preserving consumer chain above the carrying
+/// project (a SELECT conjunct as the fragment root, say) would ship the carried columns while
+/// the sender's names and the receiver's declared stream schema describe only the descriptor
+/// row, a drift the receiver-side guard would only catch at runtime on the engine.
+pub(crate) fn confine_carried(input: TranslatedRel) -> TranslatedRel {
+    if input.carried_slots.is_empty() {
+        return input;
+    }
+    let descriptor_width = input.output_width - input.carried_slots.len();
+    emit_columns(
+        input.rel,
+        (0..descriptor_width as i32).collect(),
+        input.row_tuples,
+    )
 }
 
 /// Builds a direct field selection against the current relation output.
@@ -2194,6 +2488,8 @@ fn filter_rel(input: TranslatedRel, condition: Expression) -> TranslatedRel {
         },
         row_tuples: input.row_tuples,
         output_width,
+        // A filter keeps the row layout, carried columns included.
+        carried_slots: input.carried_slots,
     }
 }
 
@@ -2245,7 +2541,9 @@ fn apply_conjuncts(
     let conjuncts = node.conjuncts.as_deref().unwrap_or_default();
     let mut conditions = Vec::with_capacity(conjuncts.len());
     for expr in conjuncts {
-        let mut expr_ctx = ctx.expr_context(&input.row_tuples);
+        let mut expr_ctx = ctx
+            .expr_context(&input.row_tuples)
+            .with_carried(&input.carried_slots);
         conditions.push(expr.translate(&mut expr_ctx)?);
     }
     let Some(condition) = and_conditions(conditions, ctx) else {
@@ -2264,6 +2562,8 @@ fn apply_conjuncts(
         },
         row_tuples: input.row_tuples,
         output_width,
+        // A filter keeps the row layout, carried columns included.
+        carried_slots: input.carried_slots,
     })
 }
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -218,11 +218,12 @@ fn bool_literal(value: bool) -> TExpr {
 
 /// Builds an arithmetic expression and appends child nodes in preorder.
 fn arithmetic(opcode: TExprOpcode, left: TExpr, right: TExpr) -> TExpr {
-    let mut node = base_expr_node(
-        TExprNodeType::ARITHMETIC_EXPR,
-        scalar_type(TPrimitiveType::BIGINT),
-        2,
-    );
+    arithmetic_typed(opcode, scalar_type(TPrimitiveType::BIGINT), left, right)
+}
+
+/// Builds a binary arithmetic expression with an explicit result type.
+fn arithmetic_typed(opcode: TExprOpcode, ty: TTypeDesc, left: TExpr, right: TExpr) -> TExpr {
+    let mut node = base_expr_node(TExprNodeType::ARITHMETIC_EXPR, ty, 2);
     node.opcode = Some(opcode);
     let mut nodes = vec![node];
     nodes.extend(left.nodes);
@@ -6490,4 +6491,448 @@ fn bare_cross_join_translates_to_constant_key_join() {
         })
         .collect();
     assert_eq!(operands, vec![2, 4]);
+}
+
+/// Descriptor for the q14 shape: scan tuple 0 (`p_type`, `l_extendedprice`, `l_discount`), the
+/// project's tuple 1 (`p_type`, `disc_price`, plus a non-materialized common slot 35), and the
+/// aggregate's tuple 2 (`promo_revenue`, `total_revenue`).
+fn consumed_common_desc() -> TDescriptorTable {
+    let mut hidden = slot(35, 1, "expr_35", scalar_type(TPrimitiveType::DOUBLE));
+    hidden.is_materialized = Some(false);
+    desc_table(
+        vec![(0, Some(100)), (1, None), (2, None)],
+        vec![
+            slot(21, 0, "p_type", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(
+                22,
+                0,
+                "l_extendedprice",
+                scalar_type(TPrimitiveType::DOUBLE),
+            ),
+            slot(23, 0, "l_discount", scalar_type(TPrimitiveType::DOUBLE)),
+            slot(21, 1, "p_type", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(27, 1, "disc_price", scalar_type(TPrimitiveType::DOUBLE)),
+            hidden,
+            slot(36, 2, "promo_revenue", scalar_type(TPrimitiveType::DOUBLE)),
+            slot(37, 2, "total_revenue", scalar_type(TPrimitiveType::DOUBLE)),
+        ],
+    )
+}
+
+/// Builds the q14-shaped project: common chain `31 <- l_extendedprice`,
+/// `34 <- 1.0 - l_discount`, `35 <- [31] * [34]`; the slot_map materializes 21 (p_type) and
+/// 27 (a read of `[35]`), plus, mirroring the FE, a `35 <-> ref 35` entry for the
+/// non-materialized slot a consumer above reads.
+fn consumed_common_project(node_id: i32, with_consumed_slot_map_entry: bool) -> TPlanNode {
+    let double = || scalar_type(TPrimitiveType::DOUBLE);
+    let mut common_slot_map = BTreeMap::new();
+    common_slot_map.insert(31, slot_ref(22, 0, double()));
+    common_slot_map.insert(
+        34,
+        arithmetic_typed(
+            TExprOpcode::SUBTRACT,
+            double(),
+            float_literal_typed(1.0, TPrimitiveType::DOUBLE),
+            slot_ref(23, 0, double()),
+        ),
+    );
+    common_slot_map.insert(
+        35,
+        arithmetic_typed(
+            TExprOpcode::MULTIPLY,
+            double(),
+            slot_ref(31, 1, double()),
+            slot_ref(34, 1, double()),
+        ),
+    );
+    let mut slot_map = BTreeMap::new();
+    slot_map.insert(21, slot_ref(21, 0, scalar_type(TPrimitiveType::VARCHAR)));
+    slot_map.insert(27, slot_ref(35, 1, double()));
+    if with_consumed_slot_map_entry {
+        slot_map.insert(35, slot_ref(35, 1, double()));
+    }
+    let mut project = base_plan_node(node_id, TPlanNodeType::PROJECT_NODE, 1, vec![1]);
+    project.project_node = Some(TProjectNode::new(Some(slot_map), Some(common_slot_map)));
+    project
+}
+
+/// Builds the q14 promo measure: `sum(if(p_type LIKE 'PROMO%', [35], 0.0))`.
+fn promo_measure() -> TExpr {
+    let double = scalar_type(TPrimitiveType::DOUBLE);
+    let mut sum = base_expr_node(TExprNodeType::AGG_EXPR, double.clone(), 1);
+    sum.agg_expr = Some(TAggregateExpr::new(false));
+    sum.fn_ = Some(builtin_function("sum", double.clone()));
+    let mut if_call = base_expr_node(TExprNodeType::FUNCTION_CALL, double.clone(), 3);
+    if_call.fn_ = Some(builtin_function("if", double.clone()));
+    let mut like_call = base_expr_node(
+        TExprNodeType::FUNCTION_CALL,
+        scalar_type(TPrimitiveType::BOOLEAN),
+        2,
+    );
+    like_call.fn_ = Some(builtin_function(
+        "like",
+        scalar_type(TPrimitiveType::BOOLEAN),
+    ));
+    let mut nodes = vec![sum, if_call, like_call];
+    nodes.extend(slot_ref(21, 1, scalar_type(TPrimitiveType::VARCHAR)).nodes);
+    nodes.extend(string_literal("PROMO%").nodes);
+    nodes.extend(slot_ref(35, 1, double).nodes);
+    nodes.extend(float_literal_typed(0.0, TPrimitiveType::DOUBLE).nodes);
+    TExpr::new(nodes)
+}
+
+/// Builds the q14-shaped aggregation over the project output: the promo measure (which reads
+/// the non-materialized common slot 35) plus `sum(disc_price)`.
+fn consumed_common_agg(node_id: i32) -> TPlanNode {
+    aggregation_node(
+        node_id,
+        2,
+        Vec::new(),
+        vec![
+            promo_measure(),
+            aggregate_expr(
+                "sum",
+                scalar_type(TPrimitiveType::DOUBLE),
+                Some(slot_ref(27, 1, scalar_type(TPrimitiveType::DOUBLE))),
+            ),
+        ],
+    )
+}
+
+/// The q14 shape: a project's non-materialized common slot (the last of a chain of dependent
+/// commons) is consumed by the aggregation above. The project physically carries it as a
+/// trailing column, and the measure's reference resolves to that column.
+#[test]
+fn consumed_common_slot_is_carried_to_the_aggregate() {
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![
+            consumed_common_agg(7),
+            consumed_common_project(6, true),
+            scan_node(0, 0),
+        ])),
+        Some(consumed_common_desc()),
+        None,
+    ))
+    .unwrap();
+
+    let root = root(&translated.plan);
+    // The fragment output (the aggregate row) is unchanged by the carrying.
+    assert_eq!(root.names, vec!["promo_revenue", "total_revenue"]);
+    let rel::RelType::Aggregate(aggregate) =
+        root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected the aggregate over the carrying project");
+    };
+    assert_eq!(aggregate.measures.len(), 2);
+
+    // The project emits its two materialized slots plus the carried slot 35; both the read of
+    // [35] (slot 27) and the carried entry select the appended common column of 35.
+    let project = as_project(aggregate.input.as_ref().unwrap());
+    assert_eq!(project.expressions.len(), 3);
+    assert_eq!(field_index(&project.expressions[1]), 5);
+    assert_eq!(field_index(&project.expressions[2]), 5);
+    assert_eq!(emit_mapping(project.common.as_ref()), vec![6, 7, 8]);
+
+    // The measure argument if(p_type LIKE 'PROMO%', [35], 0.0) reads the carried column 2.
+    let measure = aggregate.measures[0].measure.as_ref().unwrap();
+    let substrait::proto::function_argument::ArgType::Value(argument) =
+        measure.arguments[0].arg_type.as_ref().unwrap()
+    else {
+        panic!("expected a value argument");
+    };
+    let expression::RexType::IfThen(if_then) = argument.rex_type.as_ref().unwrap() else {
+        panic!("expected the if() around the carried slot");
+    };
+    assert_eq!(field_index(if_then.ifs[0].then.as_ref().unwrap()), 2);
+    assert_eq!(
+        field_index(scalar_arg(if_then.ifs[0].r#if.as_ref().unwrap(), 0)),
+        0
+    );
+}
+
+/// Without the FE's slot_map entry for the consumed slot, the project falls back to its own
+/// common binding and still carries the column.
+#[test]
+fn consumed_common_slot_without_slot_map_entry_falls_back_to_the_common_binding() {
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![
+            consumed_common_agg(7),
+            consumed_common_project(6, false),
+            scan_node(0, 0),
+        ])),
+        Some(consumed_common_desc()),
+        None,
+    ))
+    .unwrap();
+
+    let root = root(&translated.plan);
+    let rel::RelType::Aggregate(aggregate) =
+        root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected the aggregate over the carrying project");
+    };
+    let project = as_project(aggregate.input.as_ref().unwrap());
+    assert_eq!(project.expressions.len(), 3);
+    // The carried expression is a direct selection of the appended common column.
+    assert_eq!(field_index(&project.expressions[2]), 5);
+}
+
+/// A common slot consumed only inside the project keeps today's behavior: nothing is carried
+/// and the project emits exactly its materialized slots.
+#[test]
+fn common_slot_consumed_only_inside_the_project_is_not_carried() {
+    let mut select = base_plan_node(7, TPlanNodeType::SELECT_NODE, 1, vec![1]);
+    select.select_node = Some(TSelectNode::new(None));
+    select.conjuncts = Some(vec![binary_pred(
+        TExprOpcode::GT,
+        slot_ref(27, 1, scalar_type(TPrimitiveType::DOUBLE)),
+        float_literal_typed(0.0, TPrimitiveType::DOUBLE),
+    )]);
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![
+            select,
+            consumed_common_project(6, false),
+            scan_node(0, 0),
+        ])),
+        Some(consumed_common_desc()),
+        None,
+    ))
+    .unwrap();
+
+    assert_eq!(translated.output_names, vec!["p_type", "disc_price"]);
+    let root = root(&translated.plan);
+    let rel::RelType::Filter(filter) = root.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected the root filter (no narrowing projection without carried columns)");
+    };
+    let project = as_project(filter.input.as_ref().unwrap());
+    assert_eq!(project.expressions.len(), 2);
+}
+
+/// A carried common slot cannot cross a join: the extra physical column would shift the
+/// join's combined descriptor row, so the join refuses the carrying child loudly.
+#[test]
+fn carried_common_slot_entering_a_join_is_refused() {
+    let mut common_slot_map = BTreeMap::new();
+    common_slot_map.insert(9, slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT)));
+    let mut slot_map = BTreeMap::new();
+    slot_map.insert(3, slot_ref(2, 0, scalar_type(TPrimitiveType::BIGINT)));
+    let mut project = base_plan_node(2, TPlanNodeType::PROJECT_NODE, 1, vec![1]);
+    project.project_node = Some(TProjectNode::new(Some(slot_map), Some(common_slot_map)));
+
+    // The join's non-equality conjunct consumes the project's common slot 9 from above.
+    let mut join = base_plan_node(3, TPlanNodeType::HASH_JOIN_NODE, 2, vec![1, 4]);
+    join.hash_join_node = Some(THashJoinNode::new(
+        TJoinOp::INNER_JOIN,
+        vec![TEqJoinCondition::new(
+            slot_ref(3, 1, scalar_type(TPrimitiveType::BIGINT)),
+            slot_ref(4, 4, scalar_type(TPrimitiveType::BIGINT)),
+            Some(TExprOpcode::EQ),
+        )],
+        Some(vec![binary_pred(
+            TExprOpcode::GT,
+            slot_ref(9, 1, scalar_type(TPrimitiveType::BIGINT)),
+            int_literal(0),
+        )]),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    ));
+
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None), (4, Some(100))],
+        vec![
+            slot(1, 0, "a", scalar_type(TPrimitiveType::BIGINT)),
+            slot(2, 0, "b", scalar_type(TPrimitiveType::BIGINT)),
+            slot(3, 1, "b2", scalar_type(TPrimitiveType::BIGINT)),
+            slot(4, 4, "c", scalar_type(TPrimitiveType::BIGINT)),
+        ],
+    );
+    let err = translate_fragment(&params(
+        Some(TPlan::new(vec![
+            join,
+            project,
+            scan_node(0, 0),
+            scan_node(1, 4),
+        ])),
+        Some(desc),
+        None,
+    ))
+    .unwrap_err();
+    assert!(
+        matches!(&err, TranslateError::Descriptor(message)
+            if message.contains("carries common-expr columns") && message.contains("[9]")),
+        "{err:?}"
+    );
+}
+
+/// A consumer of the common slot beyond the aggregate (which re-materializes the row) still
+/// hits the loud zero-candidate descriptor error, never a silent wrong column.
+#[test]
+fn common_slot_consumed_beyond_the_aggregate_fails_loudly() {
+    // Upper project (tuple 3) references slot 35 above the aggregation.
+    let mut upper_map = BTreeMap::new();
+    upper_map.insert(40, slot_ref(35, 1, scalar_type(TPrimitiveType::DOUBLE)));
+    let mut upper = base_plan_node(8, TPlanNodeType::PROJECT_NODE, 1, vec![3]);
+    upper.project_node = Some(TProjectNode::new(Some(upper_map), None));
+
+    let agg = aggregation_node(
+        7,
+        2,
+        Vec::new(),
+        vec![aggregate_expr(
+            "sum",
+            scalar_type(TPrimitiveType::DOUBLE),
+            Some(slot_ref(27, 1, scalar_type(TPrimitiveType::DOUBLE))),
+        )],
+    );
+
+    let mut hidden = slot(35, 1, "expr_35", scalar_type(TPrimitiveType::DOUBLE));
+    hidden.is_materialized = Some(false);
+    let desc = desc_table(
+        vec![(0, Some(100)), (1, None), (2, None), (3, None)],
+        vec![
+            slot(21, 0, "p_type", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(
+                22,
+                0,
+                "l_extendedprice",
+                scalar_type(TPrimitiveType::DOUBLE),
+            ),
+            slot(23, 0, "l_discount", scalar_type(TPrimitiveType::DOUBLE)),
+            slot(21, 1, "p_type", scalar_type(TPrimitiveType::VARCHAR)),
+            slot(27, 1, "disc_price", scalar_type(TPrimitiveType::DOUBLE)),
+            hidden,
+            slot(36, 2, "total_revenue", scalar_type(TPrimitiveType::DOUBLE)),
+            slot(40, 3, "promo", scalar_type(TPrimitiveType::DOUBLE)),
+        ],
+    );
+    let err = translate_fragment(&params(
+        Some(TPlan::new(vec![
+            upper,
+            agg,
+            consumed_common_project(6, true),
+            scan_node(0, 0),
+        ])),
+        Some(desc),
+        None,
+    ))
+    .unwrap_err();
+    assert!(
+        matches!(&err, TranslateError::Descriptor(message) if message.contains("slot 35")),
+        "{err:?}"
+    );
+}
+
+/// A width-preserving fragment root (a SELECT over the carrying project) is narrowed back to
+/// the descriptor row before names are derived: the carried column never leaves the fragment.
+#[test]
+fn root_filter_over_a_carried_common_slot_is_narrowed_at_the_root() {
+    let mut select = base_plan_node(7, TPlanNodeType::SELECT_NODE, 1, vec![1]);
+    select.select_node = Some(TSelectNode::new(None));
+    select.conjuncts = Some(vec![binary_pred(
+        TExprOpcode::GT,
+        slot_ref(35, 1, scalar_type(TPrimitiveType::DOUBLE)),
+        float_literal_typed(0.0, TPrimitiveType::DOUBLE),
+    )]);
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![
+            select,
+            consumed_common_project(6, true),
+            scan_node(0, 0),
+        ])),
+        Some(consumed_common_desc()),
+        None,
+    ))
+    .unwrap();
+
+    assert_eq!(translated.output_names, vec!["p_type", "disc_price"]);
+    let root = root(&translated.plan);
+    let narrow = as_project(root.input.as_ref().unwrap());
+    assert!(narrow.expressions.is_empty());
+    assert_eq!(emit_mapping(narrow.common.as_ref()), vec![0, 1]);
+    // The filter's condition reads the carried column 2 under the narrowing projection.
+    let rel::RelType::Filter(filter) = narrow.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected the root filter under the narrowing projection");
+    };
+    assert_eq!(
+        field_index(scalar_arg(filter.condition.as_deref().unwrap(), 0)),
+        2
+    );
+}
+
+/// Fragment output expressions count as consumers above the root: a root-project fragment
+/// whose output_exprs read the common slot resolves it through the carried column, and the
+/// output projection narrows naturally.
+#[test]
+fn fragment_output_exprs_consume_a_common_slot() {
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![
+            consumed_common_project(6, true),
+            scan_node(0, 0),
+        ])),
+        Some(consumed_common_desc()),
+        Some(vec![
+            slot_ref(21, 1, scalar_type(TPrimitiveType::VARCHAR)),
+            slot_ref(35, 1, scalar_type(TPrimitiveType::DOUBLE)),
+        ]),
+    ))
+    .unwrap();
+
+    assert_eq!(translated.output_names, vec!["p_type", "expr_35"]);
+    let root = root(&translated.plan);
+    let project = as_project(root.input.as_ref().unwrap());
+    assert_eq!(project.expressions.len(), 2);
+    assert_eq!(field_index(&project.expressions[1]), 2);
+}
+
+/// A sort without a sort tuple keeps the row layout, so its ordering expression resolves the
+/// carried column and the fragment root narrows it away afterwards.
+#[test]
+fn sort_over_a_carried_common_slot_resolves_and_narrows() {
+    let sort_info = TSortInfo::new(
+        vec![slot_ref(35, 1, scalar_type(TPrimitiveType::DOUBLE))],
+        vec![true],
+        vec![false],
+        None,
+    );
+    let mut sort = base_plan_node(7, TPlanNodeType::SORT_NODE, 1, vec![1]);
+    sort.sort_node = Some(TSortNode::new(
+        sort_info, false, None, None, None, None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None, None, None, None,
+    ));
+    let translated = translate_fragment(&params(
+        Some(TPlan::new(vec![
+            sort,
+            consumed_common_project(6, true),
+            scan_node(0, 0),
+        ])),
+        Some(consumed_common_desc()),
+        None,
+    ))
+    .unwrap();
+
+    assert_eq!(translated.output_names, vec!["p_type", "disc_price"]);
+    let root = root(&translated.plan);
+    let narrow = as_project(root.input.as_ref().unwrap());
+    assert_eq!(emit_mapping(narrow.common.as_ref()), vec![0, 1]);
+    let rel::RelType::Sort(sorted) = narrow.input.as_ref().unwrap().rel_type.as_ref().unwrap()
+    else {
+        panic!("expected the sort under the narrowing projection");
+    };
+    assert_eq!(field_index(sorted.sorts[0].expr.as_ref().unwrap()), 2);
 }


### PR DESCRIPTION
## Description

Layer 5 of the translator stack; base `stacked/translator-avg-expansion`.

TPC-H q14 is `100.00 * sum(case when p_type like 'PROMO%' then l_extendedprice * (1 - l_discount) else 0 end) / sum(l_extendedprice * (1 - l_discount))`. The FE computes the revenue expression once as a common slot in the PROJECT_NODE below the aggregate and references that slot from both measures. No output tuple materializes it. On the stack below this layer the fragment is refused with a descriptor error, because #1233 resolves a common slot only inside the project that owns it. Q1 and Q6 do not hit this shape and do not need this layer.

StarRocks' BE outputs a project's common slots whenever a node above references them, and the FE plans against that (it even emits a `slot_map` entry for the consumed slot). This layer reproduces that behavior.

What changed, as one unit:

- `common_slots_consumed_above` is a pre-pass over the flat preorder plan. For every PROJECT_NODE with a non-materialized common slot it scans the expression payloads of the strict ancestors, plus the fragment's `output_exprs`, for references to that slot. Matching is by slot id alone, because an ancestor ref can carry a stale tuple id. `translate_plan` gains a `root_output_exprs` parameter for this; `lib.rs` passes `fragment.output_exprs`.
- `translate_project_node` emits each consumed slot as a trailing column past the descriptor row (preferring the FE's own `slot_map` entry, falling back to the common binding) and records it as a `CarriedSlot { tuple_id, slot_id, column }` on the new `TranslatedRel.carried_slots`.
- Row layout invariant, written on the field: columns `[0, output_width - carried.len())` are the descriptor row, the carried columns occupy the tail. Every construction site now decides what happens to carried columns. Filters, fetches, sorts without a sort tuple and `append_project` pass them through. Aggregates, sort-tuple projections, scans, exchange reads and `emit_columns` start from an empty list because they materialize a fresh row.
- `ExprContext::with_carried` and the extended `translate_slot_ref` ladder: exact synthetic override, exact carried `(tuple, slot)`, descriptor `slot_global_index`, and only when the descriptor fails a carried column matched by slot id alone. A key that matches both an override and a carried column is refused; several by-slot-id candidates are refused. I preferred refusing over guessing everywhere, because a wrong column read is not an error the engine would catch.
- `refuse_carried_join_child`: a carried slot entering a hash or nested-loop join is refused. Join conjuncts resolve over the concatenated child rows using descriptor widths, so a wider left child would shift every right-side column while the descriptor math would not.
- `confine_carried` at the fragment root, called in `lib.rs` before output names are derived. Carried columns are fragment-internal. Without this a width-preserving root (a SELECT conjunct over the carrying project) would ship columns that neither the sender's names nor the receiver's declared stream schema describe.
- A merge aggregation whose child carries columns is refused so the merge-state remapping and the carried remapping can never combine. This is unreachable today (a merge child is always an exchange, and streams never carry) and is kept as a guard.

Tests: 8 new integration tests in `tests/translate.rs`, among them `consumed_common_slot_is_carried_to_the_aggregate`, `carried_common_slot_entering_a_join_is_refused` and `root_filter_over_a_carried_common_slot_is_narrowed_at_the_root`, and 3 unit tests for the resolution ladder in `expr_translator.rs`. The `#1233` tests on dev are unchanged and still pass, including `common_slots_outside_a_project_are_rejected`; `reject_common_slots` is untouched because no shape here needs a non-PROJECT `common_slot_map`.

**How I tested it.** On a GB200 box (aarch64) I ran the CI trio: cargo fmt, clippy with warnings as errors, and the workspace test suite without the engine feature. All 224 tests pass, 11 of them new.

Not handled here: a consumer of a common slot across a join (refused, see above), and a consumer beyond an aggregate (fails with the existing descriptor error, pinned by `common_slot_consumed_beyond_the_aggregate_fails_loudly`). Scan byte ranges and CN-side changes are separate stacks.

## Checklist

- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References

- #1233 (materialize common project slots; this layer extends it to consumers above the project)
- #1711 (layer 4, the base of this PR)